### PR TITLE
decisions: ADRs 0004-0006 for load-bearing G2 calls

### DIFF
--- a/decisions/0004-postgres-day-one.md
+++ b/decisions/0004-postgres-day-one.md
@@ -1,0 +1,39 @@
+# 0004 — Postgres from day one (drop the SQLite path)
+
+**Status:** Accepted — 2026-05-09.
+
+## Context
+
+The Phase 2 engineering plan (`plan/phase-2-build-plan/engineering-plan.md`) raised OQ-1b: SQLite + WAL on a Render persistent disk for launch, or Postgres? The plan's working assumption was SQLite, justified by aod-ex's existing use of it and by the modest scale of the 100-WAU success metric. Postgres was framed as a later cutover.
+
+Two facts pushed the decision the other way at G2:
+
+1. **The cutover has a real cost and risk profile.** A SQLite→Postgres migration mid-product means coordinating a downtime window, validating data parity, and reworking infra (replace persistent disk, add managed Postgres, swap `DATABASE_URL`, retest backups). Done well it's a sprint; done badly it's an incident. Doing it once, at G2, while the schema is still ink-on-paper, removes that risk entirely.
+2. **The SQLite path required Litestream for any meaningful PITR.** OQ-9b would have added Litestream + S3 to the launch infrastructure list. Managed Postgres backups are a single line of `render.yaml` configuration and a known commodity for the operator. Strictly less infrastructure to learn.
+
+aod-ex's reference value (ADR 0002) is in the schema and the contexts, not the storage adapter. Ecto abstracts both backends; the migration files differ only in field types where Postgres-specific features (`jsonb`, `uuid`, `bytea`) are clearly preferable.
+
+## Decision
+
+Fountain ships with **managed Postgres** as its only relational store from launch. The SQLite + Litestream path described in earlier drafts of the engineering plan is removed.
+
+Concretely:
+- `render.yaml` declares a managed Postgres database, exposes `DATABASE_URL` to the web service, and removes the persistent disk that SQLite required.
+- Ecto repo configured for `Ecto.Adapters.Postgres`.
+- Schema definitions use `jsonb` for `metadata` columns (`usage_events`, `admin_audit_events`), `binary_id` (UUID) for primary keys, and `bigint` for the append-only event PKs.
+- All new tables use UUID v7 (separate decision, OQ-1c) — the time-ordering benefit is realized on Postgres B-tree indexes specifically.
+- Backups: rely on Render's managed Postgres daily backups + PITR. No Litestream needed; OQ-9b is N/A.
+
+## Consequences
+
+- One less pending migration on the roadmap. Sprint 1 onward writes Postgres-native schemas directly; no abstraction layer needed to keep the SQLite option open.
+- Operational floor rises slightly: a managed Postgres line item on Render replaces the cost of a small persistent disk. Within tolerance for the launch budget.
+- Schema and query review can use Postgres-specific features without restraint — `jsonb` operators, partial indexes, `GENERATED ALWAYS AS IDENTITY`, etc. — when they pay for themselves.
+- If a future product line truly needs an embedded single-tenant deployment (a Fountain Lite distributed as a single binary), that's a separate product with its own storage decision; this ADR does not constrain that.
+- Reversal cost: low at G2 (no production data exists). Once production data exists, reversing this is a Postgres→SQLite migration, which is materially worse than the cutover this ADR avoids. Treat as effectively irreversible after launch.
+
+## Alternatives considered
+
+- **SQLite + Litestream at launch, Postgres cutover later.** The original engineering-plan default. Rejected: pushes a known migration into a future sprint, requires Litestream tuning the operator hasn't done before, and saves only the cost of a managed Postgres line item — not enough to justify the future-toil debt.
+- **SQLite at launch, no Litestream, accept the backup gap.** Rejected: Render persistent disks are not cross-AZ replicated; a disk failure would lose data between snapshots. Unacceptable for a paid product (G2 chose a hard billing gate, ADR 0006).
+- **Postgres-compatible managed serverless (Neon, Supabase) instead of Render-managed Postgres.** Rejected for launch: adds a vendor relationship and egress considerations that aren't justified before there's evidence Render's managed Postgres is the bottleneck. Easy to revisit if it becomes one.

--- a/decisions/0005-platform-shared-sprites-token.md
+++ b/decisions/0005-platform-shared-sprites-token.md
@@ -1,0 +1,45 @@
+# 0005 — Platform-shared `SPRITES_TOKEN` is the trust model for sandbox provisioning
+
+**Status:** Accepted — 2026-05-09.
+
+## Context
+
+Fountain provisions sandboxes for tenants via Sprites. The Phase 2 engineering plan raised OQ-4a: how does Sprites authenticate? Three models were considered:
+
+- **Platform-shared.** Fountain holds one `SPRITES_TOKEN`, uses it for every tenant's sandboxes. (aod-ex's model.)
+- **Per-tenant delegation.** If Sprites supports issuing scoped sub-tokens, use one per tenant for stronger isolation while Fountain still pays.
+- **BYO-token per tenant.** Each tenant signs up for Sprites separately and pastes their own token in onboarding. Fountain pays nothing for sandbox usage; isolation is account-level at Sprites.
+
+The G2 conversation initially landed on BYO-token. The operator then surfaced a load-bearing constraint that flipped the call: **Sprites is an implementation detail Fountain should hide from end users**. That is the whole shape of the Option B direction (ADR 0003) — self-serve users should not know what Sprites is, should not have to hold an account there, should not paste tokens. Asking them to do so undoes the onboarding wizard.
+
+This ADR pins the chosen model and, more importantly, captures the trust assumptions that make it safe — so future specialists touching the sandbox path don't quietly violate them.
+
+## Decision
+
+Fountain uses a **single platform-level `SPRITES_TOKEN`** for all tenants' sandbox provisioning. Tenants never see, hold, or rotate Sprites credentials. The token lives only as a Render env var (never persisted to the database, never surfaced in admin UI, never logged) and is loaded at runtime via `Application.fetch_env!(:fountain, :sprites_token)` inside `ConversationServer`.
+
+Tenant isolation is enforced at two layers:
+
+1. **Application layer (Fountain's responsibility).** Every context function scopes by `user_id`; no cross-tenant read is possible through the normal context API. See `plan/phase-2-build-plan/engineering-plan.md` §3 for the enumerated context-function changes.
+2. **Sandbox layer (Sprites's responsibility, trusted).** Each conversation gets its own sandbox (`fountain-conv-<short-id>`). Sandboxes within the same Sprites account are isolated from each other — separate process/container/VM, no shared filesystem, no implicit network reachability. The Sprites API does not let one sandbox enumerate or read another's metadata or logs.
+
+To bound noisy-neighbor risk on the shared Sprites account, **every tenant gets a Fountain-side concurrency cap** (`users.max_concurrent_sandboxes`, default 5, admin-adjustable per user). This is the load-bearing safety mechanism — without it, one tenant could exhaust Sprites' account-level rate limits and starve everyone else.
+
+## Consequences
+
+- Onboarding has no "connect Sprites" step. The wizard goes straight from email verification to first Environment, matching the Option B UX goal.
+- Fountain pays for all sandbox usage on its Sprites bill. Tier pricing (set by growth/marketing pre-launch) must cover Sprites costs plus margin. Per-tenant usage is reconstructed from `usage_events` for cost attribution and metered billing.
+- The `SPRITES_TOKEN` becomes a high-blast-radius secret. Mitigations that must be in place at launch:
+  - Env var only — never in the database, never in logs, never displayed in admin UI.
+  - Alerting on Sprites API anomalies (unusual sandbox count, unusual regions, sudden volume spikes) so a leaked token is detected by behavior, not by audit.
+  - Documented rotation runbook (Render env-var update + restart; in-flight conversations finish on the old token if Sprites supports lazy invalidation, otherwise they crash and users retry).
+- The per-tenant concurrency cap is no longer optional — it is the only thing standing between one tenant and all the others. Sprint 1 must implement it; admins must be able to adjust it; abuse response runbooks reference it.
+- This ADR depends on Sprites' isolation guarantees. If those are weaker than assumed (e.g., sandboxes in the same account can reach each other on a shared internal network), this trust model breaks and the platform-shared approach becomes unsafe. **Action item before launch:** confirm Sprites' per-sandbox isolation properties in writing (docs or direct from the Sprites team).
+- BYO-token can return as an *optional* power-user feature post-launch if a tenant explicitly wants their own Sprites account (e.g., for cost attribution or compliance reasons). It must not become the default.
+- Per-tenant delegated sub-tokens (if Sprites adds this capability) would be a strict isolation upgrade with no UX cost. Worth revisiting at the next architectural review.
+
+## Alternatives considered
+
+- **BYO-token per tenant.** Initially chosen at G2; reversed once the operator clarified that Sprites must be hidden from users. Adds a hard onboarding step that breaks Option B's self-serve flow. Better isolation, but the operator priced isolation against onboarding friction and chose onboarding.
+- **Per-tenant delegated sub-tokens via Sprites.** Rejected only because Sprites' current API support for delegation is unverified. If/when it lands, this is the upgrade path — same UX, stronger isolation, no change to the tenant-facing flow.
+- **Run a separate Sprites account per tenant, managed by Fountain.** Rejected — the operational overhead (account creation, billing reconciliation across N accounts, support escalations) scales linearly with tenants. Defeats the purpose of a hosted product.

--- a/decisions/0006-hard-stripe-billing-gate-at-launch.md
+++ b/decisions/0006-hard-stripe-billing-gate-at-launch.md
@@ -1,0 +1,45 @@
+# 0006 — Hard Stripe billing gate at launch with a 14-day trial
+
+**Status:** Accepted — 2026-05-09.
+
+## Context
+
+The Phase 2 engineering plan raised OQ-5b: ship a hard billing gate at launch (block users without an active subscription from creating sandboxes), or ship a usage-tracking stub and add the gate later? OQ-5a asked which payment provider; OQ-5c asked the usage period.
+
+The case for a stub at launch was reduced sprint scope: skip Stripe integration, leave `BILLING_WEBHOOK_URL` empty, ship the rest. The case for a hard gate was that Fountain pays for tenants' sandbox usage on a shared Sprites account (ADR 0005), so every free user is a direct cost line on the Sprites bill. Without a gate, scaling users without scaling revenue is the default behavior of the system.
+
+Two related calls fall out of "hard gate": choice of provider (Stripe — best Elixir tooling via `stripity_stripe`, fastest path to ship a Checkout flow) and how to avoid locking users out the moment a payment fails (a `past_due` window with read-only access).
+
+## Decision
+
+Fountain ships with a **hard Stripe billing gate** at launch, integrated via `stripity_stripe`. New users get a **14-day trial** that begins at registration; a Stripe Customer is created at email verification, and `users.subscription_status` is synced from Stripe webhooks (`trialing`, `active`, `past_due`, `canceled`).
+
+Gate enforcement, via `Fountain.Billing.assert_active!(user)`:
+
+- **Allowed when** `subscription_status in [:trialing, :active]`.
+- **Allowed read-only when** `subscription_status == :past_due` — the user can view past conversations, list resources, update payment method, but cannot start new conversations or provision sandboxes. This window exists so a temporary card decline doesn't lock users out of their own data while they fix payment.
+- **Blocked when** `subscription_status in [:canceled, nil]` — POST to write endpoints returns 402 Payment Required pointing at the upgrade URL; LiveViews flash + redirect to `/account/billing`.
+
+Plan management uses Stripe Checkout (new subscriptions) and Stripe Customer Portal (existing subscriptions, payment method updates, cancellation). Webhook endpoint `POST /api/stripe/webhook` is signature-verified via `Stripe.Webhook.construct_event/3`.
+
+Usage period (OQ-5c): **calendar month in the user's selected timezone** (default UTC). `BillingLive` aggregates `usage_events` for the current calendar month.
+
+Pricing tier shape (Free / Pro / etc.) is **not** decided here — that's growth/marketing's call before launch. This ADR commits to the gate mechanism, not the price points.
+
+## Consequences
+
+- Sprint scope grows by the Stripe integration: customer creation flow, webhook endpoint, Checkout + Portal links, `assert_active!` enforcement at three call sites (`ConversationServer.init/1`, `POST /api/conversations`, `:require_active_subscription` LiveView hook). Recommend treating it as its own sprint or a clearly-scoped track within the auth/billing sprint.
+- Revenue exists from day 14 of the first paying user. Without the gate, revenue would be zero until a future sprint added it; the runway implication of that gap was the dispositive argument.
+- Users who registered, did the wizard, and never paid silently consume Sprites resources during the 14-day trial. Mitigation: trial users are still bound by the per-tenant concurrency cap (default 5, ADR 0005). If trial-period costs surprise on the Sprites bill, drop the trial cap separately from the paid cap.
+- Pricing decisions become unblocking: growth/marketing must propose tier prices before launch, even if "Free tier = blocked after trial" is the simplest opening position. The ADR does not require multiple tiers; one paid tier + the trial is enough to ship.
+- `past_due` UX must be tested explicitly — it's the most common churn-inducing state and the easiest to get wrong (false lockouts on transient declines, or true lockouts when the read-only window is too short).
+- Stripe is now a launch-blocking dependency. If Stripe is down, no new subscriptions complete and webhooks queue. `stripity_stripe` and Stripe's own retry behavior on webhook delivery are the mitigations; document the behavior when webhooks are delayed (subscription state lags reality by minutes — acceptable).
+- Provider lock-in is Stripe-shaped: switching providers later means re-implementing Customer Portal flows and remapping subscription states. Within the cost of doing business; the alternative (provider-neutral abstraction at launch) costs more than it saves.
+- Reversal cost: low for the gate itself (changing `assert_active!` to always return `:ok` is one line). High for the Stripe integration if it has to be ripped out — but no realistic post-launch path requires that.
+
+## Alternatives considered
+
+- **Usage-tracking stub at launch, gate added in growth sprint.** Rejected: every free user is a direct Sprites cost. Adding the gate later means migrating users who never expected to pay, which is worse UX than charging from launch.
+- **Soft warn at launch (track usage, surface warnings, no enforcement).** Rejected: same cost problem as the stub, plus a worse story for "we never said this was free." A hard gate with a generous trial is more honest.
+- **Paddle or Lemon Squeezy as merchant-of-record (handles tax/VAT globally).** Rejected for launch: Stripe has materially better Elixir tooling and a faster path to a working Checkout flow. International tax compliance is a real concern but addressable post-launch (Stripe Tax, or a provider switch if Stripe Tax proves inadequate). Don't trade ship velocity for problems that don't exist yet.
+- **Lifetime / one-time payment instead of subscription.** Rejected: incompatible with a per-conversation cost model where Fountain pays Sprites continuously. Subscription matches the cost shape.


### PR DESCRIPTION
## Summary

Captures the three G2 decisions from PR #4 that constrain future sprints across multiple domains.

- **0004 — Postgres from day one.** Drops the SQLite + Litestream path entirely; managed Postgres is the only relational store from launch. Removes a known migration from the future roadmap; trades a tiny line-item cost for materially less infra to learn.
- **0005 — Platform-shared `SPRITES_TOKEN`.** Pins the trust model: one platform credential, hidden from users, with per-tenant concurrency cap (default 5, admin-adjustable) as the load-bearing noisy-neighbor mitigation. Documents the Sprites isolation properties Fountain depends on (action item before launch: confirm in writing).
- **0006 — Hard Stripe billing gate at launch with a 14-day trial.** `stripity_stripe`, Stripe Checkout + Customer Portal, webhook-synced `users.subscription_status`, read-only access during `past_due`. Pricing tiers are growth/marketing's call pre-launch; this ADR commits to the gate mechanism, not the price points.

These are the three G2 decisions flagged in PR #4's body as worth promoting to ADRs. The other 23 OQ resolutions remain captured in `plan/phase-2-build-plan/engineering-plan.md` only — they are scope calls that don't constrain future work the same way.

## Test plan

- [ ] Each ADR follows `decisions/0001-template.md` shape (Status, Context, Decision, Consequences, Alternatives considered)
- [ ] References to prior ADRs (0002 reference, 0003 direction) are accurate
- [ ] References to engineering plan sections (`§3`, `§4`, `§9.1`) match what landed in PR #4
- [ ] No code or schema changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)