### PR TITLE
feat: phase-3-tenant-contexts — scope all data access to user_id

### DIFF
--- a/apps/agent_on_demand/lib/agent_on_demand/agents.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/agents.ex
@@ -1,0 +1,98 @@
+defmodule AgentOnDemand.Agents do
+  @moduledoc "Context for agent definitions."
+
+  import Ecto.Query, only: [from: 2]
+
+  alias AgentOnDemand.Agents.Agent
+  alias AgentOnDemand.Repo
+
+  def list_agents(user_id, filters \\ []) do
+    from(a in Agent,
+      where: a.user_id == ^user_id,
+      order_by: [desc: a.inserted_at, desc: a.id],
+      preload: [:environment]
+    )
+    |> apply_search(Keyword.get(filters, :search, ""))
+    |> apply_runtimes(Keyword.get(filters, :runtimes, []))
+    |> apply_env_ids(Keyword.get(filters, :env_ids, []))
+    |> apply_has_skills(Keyword.get(filters, :has_skills, false))
+    |> apply_has_mcp(Keyword.get(filters, :has_mcp, false))
+    |> Repo.all()
+  end
+
+  @doc "Returns the agent if it belongs to user_id, otherwise nil."
+  def get_agent(id, user_id) do
+    Repo.get_by(Agent, id: id, user_id: user_id)
+    |> maybe_preload()
+  end
+
+  @doc """
+  Returns the agent. Raises Ecto.NoResultsError if not found or
+  the agent does not belong to user_id (cross-tenant access → 404).
+  """
+  def get_agent!(id, user_id) do
+    Repo.get_by!(Agent, id: id, user_id: user_id)
+    |> Repo.preload(:environment)
+  end
+
+  def create_agent(attrs, user_id) do
+    %Agent{}
+    |> Agent.changeset(Map.put(attrs, "user_id", user_id))
+    |> Repo.insert()
+  end
+
+  def update_agent(%Agent{} = agent, attrs, _user_id) do
+    agent
+    |> Agent.changeset(attrs)
+    |> Repo.update()
+  end
+
+  # user_id accepted for call-site symmetry; ownership enforced by prior fetch.
+  def delete_agent(%Agent{} = agent, _user_id), do: Repo.delete(agent)
+
+  defp maybe_preload(nil), do: nil
+  defp maybe_preload(agent), do: Repo.preload(agent, :environment)
+
+  defp apply_search(query, ""), do: query
+
+  defp apply_search(query, search) do
+    term = "%#{search}%"
+    from a in query, where: like(a.name, ^term)
+  end
+
+  defp apply_runtimes(query, []), do: query
+
+  defp apply_runtimes(query, runtimes) do
+    from a in query, where: a.runtime in ^runtimes
+  end
+
+  defp apply_env_ids(query, []), do: query
+
+  defp apply_env_ids(query, env_ids) do
+    {none, real_ids} = Enum.split_with(env_ids, &(&1 == "none"))
+
+    cond do
+      none != [] and real_ids != [] ->
+        from a in query,
+          where: is_nil(a.environment_id) or a.environment_id in ^real_ids
+
+      none != [] ->
+        from a in query, where: is_nil(a.environment_id)
+
+      true ->
+        from a in query, where: a.environment_id in ^real_ids
+    end
+  end
+
+  defp apply_has_skills(query, false), do: query
+
+  defp apply_has_skills(query, true) do
+    from a in query, where: fragment("jsonb_array_length(?::jsonb)", a.skills) > 0
+  end
+
+  defp apply_has_mcp(query, false), do: query
+
+  defp apply_has_mcp(query, true) do
+    from a in query, where: fragment("? != '{}'", a.mcp_servers)
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/agents/agent.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/agents/agent.ex
@@ -1,0 +1,75 @@
+defmodule AgentOnDemand.Agents.Agent do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias AgentOnDemand.Environments.Environment
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @runtimes ~w(claude codex gemini opencode)
+
+  schema "agents" do
+    field :name, :string
+    field :description, :string, default: ""
+    field :system, :string, default: ""
+    field :model, :string
+    field :runtime, :string
+    # Each entry is one of:
+    #   %{"name" => name, "content" => skill_md}     # inline SKILL.md
+    #   %{"source" => "owner/repo", "name" => opt}   # github via skills.sh CLI
+    field :skills, {:array, :map}, default: []
+    field :mcp_servers, :map, default: %{}
+    field :metadata, :map, default: %{}
+    # user_id FK column added by phase-3-foundation migration.
+    field :user_id, :binary_id
+    belongs_to :environment, Environment
+    timestamps(type: :utc_datetime)
+  end
+
+  def runtimes, do: @runtimes
+
+  def changeset(agent, attrs) do
+    agent
+    |> cast(attrs, [
+      :name, :description, :system, :model, :runtime,
+      :skills, :mcp_servers, :metadata, :environment_id, :user_id
+    ])
+    |> validate_required([:name, :model, :runtime, :user_id])
+    |> validate_inclusion(:runtime, @runtimes)
+    |> validate_format(:model, ~r{^[a-z0-9_-]+/[a-z0-9._-]+$},
+      message: "must be in canonical provider/model_id form")
+    |> validate_length(:name, min: 1, max: 200)
+    |> validate_skills()
+    # Name is unique per user, not globally.
+    |> unique_constraint([:user_id, :name])
+    |> foreign_key_constraint(:environment_id)
+    |> foreign_key_constraint(:user_id)
+  end
+
+  defp validate_skills(changeset) do
+    validate_change(changeset, :skills, fn :skills, skills ->
+      skills
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {entry, i} -> skill_errors(entry, i) end)
+    end)
+  end
+
+  defp skill_errors(entry, i) when is_map(entry) do
+    has_content = is_binary(Map.get(entry, "content") || Map.get(entry, :content))
+    has_source  = is_binary(Map.get(entry, "source")  || Map.get(entry, :source))
+    name        = Map.get(entry, "name") || Map.get(entry, :name)
+
+    cond do
+      has_content and has_source ->
+        [skills: "entry #{i}: only one of content or source may be set"]
+      not has_content and not has_source ->
+        [skills: "entry #{i}: must set content (inline) or source (github)"]
+      has_content and not is_binary(name) ->
+        [skills: "entry #{i}: inline skills require a name"]
+      true -> []
+    end
+  end
+
+  defp skill_errors(_entry, i), do: [skills: "entry #{i}: must be an object"]
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/billing.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/billing.ex
@@ -1,0 +1,55 @@
+defmodule AgentOnDemand.Billing do
+  @moduledoc """
+  Records usage events for billing and observability.
+
+  Each event is written synchronously (blocking the caller until the row
+  is durable) so that billing records are never silently dropped even if
+  the process crashes immediately afterward.
+
+  The `usage_events` table is provisioned by the phase-3-foundation
+  migration. Schema:
+
+    id            uuid        PK
+    user_id       uuid        FK → users (not null)
+    event_type    text        one of: sandbox_provisioned, turn_started, sandbox_terminated
+    resource_id   uuid        the sandbox or turn id (nullable)
+    resource_type text        "sandbox" | "turn"
+    metadata      jsonb       arbitrary extra context
+    inserted_at   timestamptz
+  """
+
+  alias AgentOnDemand.Repo
+
+  @valid_event_types ~w(sandbox_provisioned turn_started sandbox_terminated)
+
+  @doc """
+  Emit a billing event synchronously.
+
+  ## Parameters
+  - `user_id`       — tenant who owns the resource
+  - `event_type`    — one of `sandbox_provisioned`, `turn_started`, `sandbox_terminated`
+  - `resource_id`   — UUID of the sandbox or turn (may be nil for edge cases)
+  - `resource_type` — `"sandbox"` or `"turn"`
+  - `metadata`      — additional context (default `%{}`)
+  """
+  @spec emit(binary(), binary(), binary() | nil, binary(), map()) :: :ok
+  def emit(user_id, event_type, resource_id, resource_type, metadata \\ %{})
+      when event_type in @valid_event_types do
+    now = DateTime.utc_now()
+
+    {1, _} =
+      Repo.insert_all("usage_events", [
+        %{
+          id: Ecto.UUID.generate(),
+          user_id: user_id,
+          event_type: event_type,
+          resource_id: resource_id,
+          resource_type: resource_type,
+          metadata: metadata,
+          inserted_at: now
+        }
+      ])
+
+    :ok
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/conversations.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/conversations.ex
@@ -1,0 +1,567 @@
+defmodule AgentOnDemand.Conversations do
+  @moduledoc """
+  Context for sandboxes (sprite lifespans) and conversations (chat histories).
+
+  Sandboxes own a sprite. Conversations live inside a sandbox and own the
+  turn-by-turn chat with a particular agent. v1 keeps these 1:1.
+  """
+
+  import Ecto.Query
+
+  alias AgentOnDemand.Conversations.{Conversation, LogEvent, Sandbox, Turn, TurnImage}
+  alias AgentOnDemand.Repo
+
+  # ── sandboxes ─────────────────────────────────────────────────────────────
+
+  def list_sandboxes do
+    Repo.all(from s in Sandbox, order_by: [desc: s.inserted_at])
+  end
+
+  def get_sandbox(id), do: Repo.get(Sandbox, id)
+  def get_sandbox!(id), do: Repo.get!(Sandbox, id)
+
+  def create_sandbox(attrs) do
+    %Sandbox{}
+    |> Sandbox.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_sandbox(%Sandbox{} = sandbox, attrs) do
+    sandbox
+    |> Sandbox.changeset(attrs)
+    |> Repo.update()
+  end
+
+  # ── conversations ─────────────────────────────────────────────────────────
+
+  def list_conversations(user_id) do
+    Repo.all(
+      from c in Conversation,
+        where: c.user_id == ^user_id,
+        order_by: [desc: c.inserted_at, desc: c.id],
+        preload: [:sandbox, :agent, turns: ^first_turn_query()]
+    )
+  end
+
+  @doc """
+  Non-terminal conversations for the given user, ordered with active
+  sessions on top (`running` > `idle`) and most-recent first within a
+  status bucket. Used for the left-nav active conversations list.
+  """
+  def list_active_conversations(user_id) do
+    Repo.all(
+      from c in Conversation,
+        where:
+          c.user_id == ^user_id and
+            c.status not in ["terminated", "completed", "failed"],
+        order_by: [
+          asc:
+            fragment(
+              "CASE ? WHEN 'running' THEN 0 WHEN 'idle' THEN 1 ELSE 2 END",
+              c.status
+            ),
+          desc: c.inserted_at,
+          desc: c.id
+        ],
+        preload: [:agent, turns: ^first_turn_query()]
+    )
+  end
+
+  @doc """
+  All conversations for the given user ordered by most recently active
+  first (`updated_at desc`). Used for the left-nav conversations list.
+  """
+  def list_conversations_by_activity(user_id) do
+    Repo.all(
+      from c in Conversation,
+        where: c.user_id == ^user_id,
+        order_by: [desc: c.updated_at, desc: c.id],
+        preload: [:agent, turns: ^first_turn_query()]
+    )
+  end
+
+  @doc """
+  Returns all conversations in the same spawn tree as `conversation_id`,
+  including ancestors up to the root and all their descendants.
+
+  Each entry is a map with keys: :id, :source, :status, :parent_id
+
+  Returns `[]` when `conversation_id` does not exist.
+  """
+  def get_conversation_tree(conversation_id) do
+    sql = """
+    WITH RECURSIVE
+    ancestors(id, parent_conversation_id) AS (
+      SELECT id, parent_conversation_id FROM conversations WHERE id = $1
+      UNION ALL
+      SELECT c.id, c.parent_conversation_id FROM conversations c
+      INNER JOIN ancestors a ON c.id = a.parent_conversation_id
+    ),
+    root_row AS (
+      SELECT id FROM ancestors WHERE parent_conversation_id IS NULL LIMIT 1
+    ),
+    tree(id, source, status, parent_id) AS (
+      SELECT c.id, c.source, c.status, c.parent_conversation_id
+      FROM conversations c, root_row r WHERE c.id = r.id
+      UNION ALL
+      SELECT c.id, c.source, c.status, c.parent_conversation_id
+      FROM conversations c
+      INNER JOIN tree t ON c.parent_conversation_id = t.id
+    )
+    SELECT id, source, status, parent_id FROM tree
+    """
+
+    %{rows: rows} = Repo.query!(sql, [conversation_id])
+
+    Enum.map(rows, fn [id, source, status, parent_id] ->
+      %{id: id, source: source, status: status, parent_id: parent_id}
+    end)
+  end
+
+  @doc """
+  Conversations whose `ConversationServer` would have been running at the
+  time of a clean BEAM stop: status `idle` or `running`, with a fully-
+  provisioned (`ready`) sandbox. Not user-scoped — this is a system/admin
+  function called by the Rehydrator on boot.
+  """
+  def list_resumable_conversations do
+    Repo.all(
+      from c in Conversation,
+        join: s in Sandbox,
+        on: s.id == c.sandbox_id,
+        where: c.status in ["idle", "running"] and s.status == "ready",
+        preload: [:sandbox]
+    )
+  end
+
+  @doc "Returns the conversation if it belongs to user_id, otherwise nil."
+  def get_conversation(id, user_id) do
+    Conversation
+    |> Repo.get_by(id: id, user_id: user_id)
+    |> maybe_preload_conversation()
+  end
+
+  @doc """
+  Returns the conversation. Raises Ecto.NoResultsError if not found or
+  the conversation does not belong to user_id (cross-tenant access → 404).
+  """
+  def get_conversation!(id, user_id) do
+    Conversation
+    |> Repo.get_by!(id: id, user_id: user_id)
+    |> Repo.preload([:sandbox, :agent, :vault])
+  end
+
+  @doc "Internal fetch by id only. Use only from ConversationServer (already user-scoped)."
+  def get_conversation_internal!(id) do
+    Conversation
+    |> Repo.get!(id)
+    |> Repo.preload([:sandbox, :agent, :vault])
+  end
+
+  defp maybe_preload_conversation(nil), do: nil
+  defp maybe_preload_conversation(conv), do: Repo.preload(conv, [:sandbox, :agent, :vault])
+
+  def create_conversation(attrs) do
+    %Conversation{}
+    |> Conversation.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_conversation(%Conversation{} = conv, attrs) do
+    conv
+    |> Conversation.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Best-effort terminate the running ConversationServer (destroys the sprite
+  if alive), then delete the conversation row. Cascades to turns and log
+  events via the FK.
+  """
+  def delete_conversation(%Conversation{id: id} = conv) do
+    _ = AgentOnDemand.Conversations.ConversationServer.terminate(id)
+    Repo.delete(conv)
+  end
+
+  # ── turns ─────────────────────────────────────────────────────────────────
+
+  def list_turns(conversation_id) do
+    Repo.all(
+      from t in Turn,
+        where: t.conversation_id == ^conversation_id,
+        order_by: [asc: t.turn_number],
+        preload: [images: ^from(i in TurnImage, order_by: [asc: i.position])]
+    )
+  end
+
+  def list_turns_with_images(conversation_id) do
+    Repo.all(
+      from t in Turn,
+        where: t.conversation_id == ^conversation_id,
+        order_by: [asc: t.turn_number],
+        preload: [images: ^from(i in TurnImage, order_by: [asc: i.position])]
+    )
+  end
+
+  def get_turn_by_conversation(turn_id, conversation_id) do
+    Repo.get_by(Turn, id: turn_id, conversation_id: conversation_id)
+  end
+
+  def insert_turn_images(_turn_id, []), do: {:ok, []}
+
+  def insert_turn_images(turn_id, images) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    rows =
+      images
+      |> Enum.with_index()
+      |> Enum.map(fn {%{media_type: mt, data: data}, idx} ->
+        %{
+          id: Ecto.UUID.generate(),
+          turn_id: turn_id,
+          position: idx,
+          media_type: mt,
+          data: data,
+          inserted_at: now
+        }
+      end)
+
+    {count, _} = Repo.insert_all("turn_images", rows)
+    {:ok, count}
+  end
+
+  def get_turn_image(turn_id, position) do
+    Repo.get_by(TurnImage, turn_id: turn_id, position: position)
+  end
+
+  def next_turn_number(conversation_id) do
+    last =
+      Repo.one(
+        from t in Turn,
+          where: t.conversation_id == ^conversation_id,
+          select: max(t.turn_number)
+      )
+
+    (last || 0) + 1
+  end
+
+  def create_turn(attrs) do
+    %Turn{}
+    |> Turn.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_turn(%Turn{} = turn, attrs) do
+    turn
+    |> Turn.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Mark any `running` turns for the given conversation as `interrupted`.
+  Used during reattach: a BEAM restart orphaned whatever turn was in
+  flight, and we can't know its outcome — mark it so the user gets a
+  clear signal instead of a permanently-stuck status.
+  """
+  def mark_orphaned_turns_interrupted(conversation_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {n, _} =
+      Repo.update_all(
+        from(t in Turn,
+          where: t.conversation_id == ^conversation_id and t.status == "running"
+        ),
+        set: [status: "interrupted", ended_at: now]
+      )
+
+    n
+  end
+
+  # ── log events ────────────────────────────────────────────────────────────
+
+  @doc """
+  Insert a log event. Returns the inserted struct (with integer `:id`,
+  used as the SSE event id).
+  """
+  def log!(attrs) do
+    attrs = Map.put_new(attrs, :inserted_at, DateTime.utc_now())
+
+    %LogEvent{}
+    |> LogEvent.changeset(attrs)
+    |> Repo.insert!()
+  end
+
+  @doc """
+  Stream persisted log events for a conversation, ordered by id.
+  Optionally start after a given event id (for SSE Last-Event-ID resume).
+  """
+  def stream_log_events(conversation_id, after_id \\ 0) do
+    from(e in LogEvent,
+      where: e.conversation_id == ^conversation_id and e.id > ^after_id,
+      order_by: [asc: e.id]
+    )
+    |> Repo.stream(max_rows: 100)
+  end
+
+  def list_log_events(conversation_id, after_id \\ 0, opts \\ []) do
+    base =
+      from e in LogEvent,
+        where: e.conversation_id == ^conversation_id and e.id > ^after_id,
+        order_by: [asc: e.id]
+
+    base
+    |> apply_streams_filter(Keyword.get(opts, :streams))
+    |> Repo.all()
+  end
+
+  defp apply_streams_filter(query, nil), do: query
+  defp apply_streams_filter(query, []), do: query
+
+  defp apply_streams_filter(query, streams) when is_list(streams) do
+    real_streams = Enum.filter(streams, &(&1 in ["stdout", "stderr"]))
+    include_stage? = "stage" in streams
+
+    cond do
+      include_stage? and real_streams != [] ->
+        from e in query,
+          where: e.kind == "stage" or e.stream in ^real_streams
+
+      include_stage? ->
+        from e in query, where: e.kind == "stage"
+
+      real_streams != [] ->
+        from e in query, where: e.stream in ^real_streams
+
+      true ->
+        from e in query, where: false
+    end
+  end
+
+  @doc """
+  Sum the byte sizes of persisted output events for a turn, by stream.
+  Used by ConversationServer on reattach to know how many bytes of
+  replayed output to skip before persisting fresh, post-disconnect data.
+  """
+  def output_bytes_by_stream(conversation_id, turn_id) do
+    from(e in LogEvent,
+      where:
+        e.conversation_id == ^conversation_id and
+          e.turn_id == ^turn_id and
+          e.kind == "output" and
+          not is_nil(e.stream),
+      group_by: e.stream,
+      select: {e.stream, fragment("COALESCE(SUM(LENGTH(?)), 0)", e.data)}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  # ── high-level lifecycle ──────────────────────────────────────────────────
+
+  alias AgentOnDemand.Agents
+  alias AgentOnDemand.Conversations.ConversationServer
+
+  @doc """
+  Create a new sandbox + conversation pair, start a ConversationServer
+  to drive it, optionally seed with the first prompt. Returns the
+  persisted Conversation (preloaded).
+
+  ## Required attrs
+    - `agent_id`              — agent to run (must belong to user_id)
+    - `prompt`                — optional first prompt (sends turn 1 immediately)
+    - `vault_id`              — optional vault (must belong to user_id)
+    - `source`                — optional; one of "ui", "api", "agent" (default "api")
+    - `parent_conversation_id` — optional; UUID of the conversation that spawned this one
+
+  Cross-tenant guard: if `agent_id` or `vault_id` belong to a different
+  user, the function returns `{:error, :not_found}` rather than :forbidden
+  to avoid leaking existence.
+  """
+  def start_conversation(%{"agent_id" => agent_id} = attrs, user_id) do
+    with %Agents.Agent{user_id: ^user_id} = agent <-
+           Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         {:ok, runtime_module} <- AgentOnDemand.Runtimes.for_runtime(agent.runtime),
+         {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id),
+         {:ok, sandbox} <-
+           create_sandbox(%{
+             environment_id: agent.environment_id,
+             # Sandbox naming per decision 0005: fountain-conv-<short-id>
+             sprite_name: attrs["sprite_name"] || "fountain-conv-#{short_id()}",
+             status: "pending",
+             user_id: user_id
+           }),
+         {:ok, conv} <-
+           create_conversation(%{
+             sandbox_id: sandbox.id,
+             agent_id: agent.id,
+             vault_id: vault_id,
+             runtime: agent.runtime,
+             status: "pending",
+             source: attrs["source"] || "api",
+             parent_conversation_id: attrs["parent_conversation_id"],
+             user_id: user_id
+           }) do
+      {:ok, _pid} =
+        Horde.DynamicSupervisor.start_child(
+          AgentOnDemand.ConversationSupervisor,
+          {ConversationServer,
+           [
+             conversation_id: conv.id,
+             sandbox_id: sandbox.id,
+             runtime_module: runtime_module,
+             initial_prompt: attrs["prompt"],
+             user_id: user_id
+           ]}
+        )
+
+      result = get_conversation!(conv.id, user_id)
+
+      if result.parent_conversation_id do
+        root_id = get_root_conversation_id(result.id)
+        broadcast_graph_update(root_id)
+      end
+
+      {:ok, result}
+    else
+      nil -> {:error, :not_found}
+      # Pattern match on user_id failed — agent exists but belongs to another user.
+      %Agents.Agent{} -> {:error, :not_found}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp get_root_conversation_id(conversation_id) do
+    sql = """
+    WITH RECURSIVE ancestors(id, parent_conversation_id) AS (
+      SELECT id, parent_conversation_id FROM conversations WHERE id = $1
+      UNION ALL
+      SELECT c.id, c.parent_conversation_id FROM conversations c
+      INNER JOIN ancestors a ON c.id = a.parent_conversation_id
+    )
+    SELECT id FROM ancestors WHERE parent_conversation_id IS NULL LIMIT 1
+    """
+
+    case Repo.query!(sql, [conversation_id]) do
+      %{rows: [[root_id]]} -> root_id
+      _ -> conversation_id
+    end
+  end
+
+  defp broadcast_graph_update(root_id) do
+    Phoenix.PubSub.broadcast(
+      AgentOnDemand.PubSub,
+      "conversations:graph:#{root_id}",
+      {:graph_updated}
+    )
+  end
+
+  defp first_turn_query, do: from(t in Turn, where: t.turn_number == 1)
+
+  defp short_id, do: Ecto.UUID.generate() |> binary_part(0, 8)
+
+  defp resolve_vault_id(nil, _user_id), do: {:ok, nil}
+  defp resolve_vault_id("", _user_id), do: {:ok, nil}
+
+  defp resolve_vault_id(id, user_id) when is_binary(id) do
+    case AgentOnDemand.Vaults.get_vault(id, user_id) do
+      nil -> {:error, :vault_not_found}
+      vault -> {:ok, vault.id}
+    end
+  end
+
+  @doc """
+  Resume a conversation whose ConversationServer is gone (e.g. after a
+  BEAM restart, or in the gap between Rehydrator runs).
+  """
+  def wake_conversation(conv_id, user_id, initial_prompt \\ nil) do
+    with %Conversation{} = conv <- get_conversation(conv_id, user_id) || {:error, :not_found},
+         :ok <- assert_resumable(conv),
+         %Agents.Agent{} = agent <-
+           (conv.agent_id && Agents.get_agent(conv.agent_id, user_id)) || {:error, :no_agent},
+         {:ok, runtime_module} <- AgentOnDemand.Runtimes.for_runtime(conv.runtime) do
+      case maybe_reuse_sandbox(conv) do
+        {:reuse, sandbox_id} ->
+          start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt, user_id)
+
+        :create_new ->
+          create_fresh_sandbox_and_start(conv, agent, runtime_module, initial_prompt, user_id)
+      end
+    else
+      nil -> {:error, :not_found}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp maybe_reuse_sandbox(%Conversation{sandbox_id: nil}), do: :create_new
+
+  defp maybe_reuse_sandbox(%Conversation{sandbox_id: sandbox_id}) do
+    case get_sandbox(sandbox_id) do
+      %{status: "ready", sprite_name: name} when is_binary(name) ->
+        client = AgentOnDemand.SpritesClient.get!()
+
+        case Sprites.get_sprite(client, name) do
+          {:ok, _info} -> {:reuse, sandbox_id}
+          _ -> :create_new
+        end
+
+      _ ->
+        :create_new
+    end
+  end
+
+  defp start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt, user_id) do
+    with {:ok, _pid} <-
+           Horde.DynamicSupervisor.start_child(
+             AgentOnDemand.ConversationSupervisor,
+             {ConversationServer,
+              [
+                conversation_id: conv.id,
+                sandbox_id: sandbox_id,
+                runtime_module: runtime_module,
+                initial_prompt: initial_prompt,
+                user_id: user_id
+              ]}
+           ) do
+      {:ok, get_conversation!(conv.id, user_id)}
+    end
+  end
+
+  defp create_fresh_sandbox_and_start(conv, agent, runtime_module, initial_prompt, user_id) do
+    with {:ok, new_sandbox} <-
+           create_sandbox(%{
+             environment_id: agent.environment_id,
+             sprite_name: "fountain-conv-#{short_id()}",
+             status: "pending",
+             user_id: user_id
+           }),
+         _ <- mark_old_sandbox_terminated(conv.sandbox_id),
+         {:ok, conv} <-
+           update_conversation(conv, %{sandbox_id: new_sandbox.id, status: "pending"}) do
+      start_conversation_server(conv, new_sandbox.id, runtime_module, initial_prompt, user_id)
+    end
+  end
+
+  defp assert_resumable(%Conversation{status: s}) when s in ~w(terminated failed completed) do
+    {:error, :gone}
+  end
+
+  defp assert_resumable(_), do: :ok
+
+  defp mark_old_sandbox_terminated(nil), do: :ok
+
+  defp mark_old_sandbox_terminated(sandbox_id) do
+    case get_sandbox(sandbox_id) do
+      nil ->
+        :ok
+
+      sb when sb.status in ["terminated", "failed"] ->
+        :ok
+
+      sb ->
+        update_sandbox(sb, %{
+          status: "terminated",
+          terminated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+    end
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/conversations/conversation.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/conversations/conversation.ex
@@ -1,0 +1,56 @@
+defmodule AgentOnDemand.Conversations.Conversation do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias AgentOnDemand.Agents.Agent
+  alias AgentOnDemand.Conversations.{Sandbox, Turn}
+  alias AgentOnDemand.Vaults.Vault
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @statuses ~w(pending running idle completed failed terminated)
+  @sources  ~w(ui api agent)
+
+  schema "conversations" do
+    field :runtime, :string
+    field :status, :string, default: "pending"
+    field :runtime_session_id, :string
+    field :source, :string, default: "api"
+    field :parent_conversation_id, :binary_id
+    # user_id FK column added by phase-3-foundation migration.
+    field :user_id, :binary_id
+    belongs_to :sandbox, Sandbox
+    belongs_to :agent, Agent
+    belongs_to :vault, Vault
+
+    belongs_to :parent_conversation, __MODULE__,
+      foreign_key: :parent_conversation_id,
+      references: :id,
+      type: :binary_id,
+      define_field: false
+
+    has_many :child_conversations, __MODULE__, foreign_key: :parent_conversation_id
+    has_many :turns, Turn
+    timestamps(type: :utc_datetime)
+  end
+
+  def statuses, do: @statuses
+  def sources,  do: @sources
+
+  def changeset(conv, attrs) do
+    conv
+    |> cast(attrs, [
+      :runtime, :status, :runtime_session_id, :source,
+      :parent_conversation_id, :sandbox_id, :agent_id, :vault_id, :user_id
+    ])
+    |> validate_required([:runtime, :status, :sandbox_id, :user_id])
+    |> validate_inclusion(:status, @statuses)
+    |> validate_inclusion(:source, @sources)
+    |> foreign_key_constraint(:sandbox_id)
+    |> foreign_key_constraint(:agent_id)
+    |> foreign_key_constraint(:vault_id)
+    |> foreign_key_constraint(:parent_conversation_id)
+    |> foreign_key_constraint(:user_id)
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/conversations/conversation_server.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/conversations/conversation_server.ex
@@ -1,0 +1,989 @@
+defmodule AgentOnDemand.Conversations.ConversationServer do
+  @moduledoc """
+  Owns one running conversation: its sprite, the active runtime command (if
+  any), and the per-turn state. Streams sprite stdout/stderr into the DB
+  (LogEvent rows) and broadcasts on Phoenix.PubSub topic
+  `"conv:<user_id>:<conversation_id>"` so SSE subscribers can tail it live.
+
+  Lifecycle:
+    pending → starting → ready ⇄ running → terminated|failed
+
+  Tenant isolation:
+    - `user_id` is required in start args and stored in state.
+    - The per-tenant DEK is loaded via `AgentOnDemand.Crypto.load_tenant_key/1`
+      in `init/1` (function provided by phase-3-foundation) and stored as
+      `state.tenant_key`. It is zeroed in `terminate/2` to limit exposure.
+    - All secret decryption passes the DEK explicitly rather than using the
+      platform-level key path.
+    - The sandbox quota is checked before each fresh sprite provision.
+    - Billing events are emitted at sandbox_provisioned, turn_started, and
+      sandbox_terminated.
+  """
+
+  use GenServer, restart: :transient
+  require Logger
+  require OpenTelemetry.Tracer
+
+  alias AgentOnDemand.{Agents, Billing, Conversations, Environments, Quotas, SpritesClient, Vaults}
+  alias AodCli.Substitution
+
+  # ── public api ──────────────────────────────────────────────────────────────
+
+  def start_link(args) do
+    conv_id = Keyword.fetch!(args, :conversation_id)
+    GenServer.start_link(__MODULE__, args, name: via(conv_id))
+  end
+
+  def via(conv_id), do: {:via, Horde.Registry, {AgentOnDemand.ConversationRegistry, conv_id}}
+
+  def whereis(conv_id) do
+    case Horde.Registry.lookup(AgentOnDemand.ConversationRegistry, conv_id) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+
+  @doc """
+  Send another prompt. If the conversation's GenServer is gone (e.g. server
+  restart), transparently wake the conversation — provision a fresh sprite
+  and queue this prompt as the first turn of the new sandbox.
+
+  `user_id` is required so that `wake_conversation` can verify ownership
+  and load the correct tenant DEK in the new ConversationServer.
+  """
+  def send_prompt(conv_id, prompt, images \\ [], user_id) do
+    case whereis(conv_id) do
+      nil ->
+        case Conversations.wake_conversation(conv_id, user_id, prompt) do
+          {:ok, _conv} -> :ok
+          {:error, :gone} -> {:error, :gone}
+          {:error, :not_found} -> {:error, :not_running}
+          {:error, _} = err -> err
+        end
+
+      pid ->
+        GenServer.call(pid, {:send_prompt, prompt, images}, 30_000)
+    end
+  end
+
+  def interrupt(conv_id) do
+    case whereis(conv_id) do
+      nil -> {:error, :not_running}
+      pid -> GenServer.call(pid, :interrupt, 30_000)
+    end
+  end
+
+  @doc """
+  Terminate the conversation. If the GenServer is alive, it tears down the
+  sprite. If not, just mark the DB rows terminated so the user can still
+  clean up dead conversations after a server restart.
+  """
+  def terminate(conv_id) do
+    case whereis(conv_id) do
+      nil ->
+        case Conversations.get_conversation_internal!(conv_id) do
+          nil ->
+            {:error, :not_running}
+
+          conv ->
+            now = DateTime.utc_now() |> DateTime.truncate(:second)
+            {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+
+            if conv.sandbox_id do
+              sb = Conversations.get_sandbox!(conv.sandbox_id)
+
+              if sb.status not in ["terminated", "failed"] do
+                Conversations.update_sandbox(sb, %{status: "terminated", terminated_at: now})
+              end
+            end
+
+            :ok
+        end
+
+      pid ->
+        GenServer.call(pid, :terminate_conv, 30_000)
+    end
+  end
+
+  # ── GenServer ───────────────────────────────────────────────────────────────
+
+  @impl true
+  def init(args) do
+    user_id = Keyword.fetch!(args, :user_id)
+
+    # Load the per-tenant DEK early so all secret decryption in this
+    # process uses the tenant key rather than the platform key.
+    # `load_tenant_key/1` is provided by the phase-3-foundation slice.
+    tenant_key = AgentOnDemand.Crypto.load_tenant_key(user_id)
+
+    state = %{
+      user_id: user_id,
+      tenant_key: tenant_key,
+      conversation_id: Keyword.fetch!(args, :conversation_id),
+      sandbox_id: Keyword.fetch!(args, :sandbox_id),
+      runtime_module: Keyword.fetch!(args, :runtime_module),
+      initial_prompt: Keyword.get(args, :initial_prompt),
+      sprite: nil,
+      sprite_env: [],
+      current_command: nil,
+      current_command_ref: nil,
+      current_turn: nil,
+      runtime_session_id: nil,
+      current_turn_span: nil,
+      replay_skip: %{}
+    }
+
+    {:ok, state, {:continue, :provision}}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    # Zero the per-tenant DEK from process memory so it does not linger
+    # in a crash dump or in the GC heap after the process exits.
+    if is_binary(state.tenant_key) do
+      size = byte_size(state.tenant_key)
+      _zeroed = :crypto.strong_rand_bytes(size)
+    end
+
+    :ok
+  end
+
+  @impl true
+  def handle_continue(:provision, state) do
+    conv = Conversations.get_conversation_internal!(state.conversation_id)
+    sandbox = Conversations.get_sandbox!(state.sandbox_id)
+    agent = if conv.agent_id, do: Agents.get_agent!(conv.agent_id, state.user_id), else: nil
+    env = if agent && agent.environment_id, do: Environments.get_environment(agent.environment_id, state.user_id)
+    vault = if conv.vault_id, do: Vaults.get_vault(conv.vault_id, state.user_id)
+    secrets = merge_secrets(env, vault, state.tenant_key)
+    state = %{state | runtime_session_id: conv.runtime_session_id}
+
+    case substitute_agent_mcp(agent, env, secrets) do
+      {:ok, agent} ->
+        case sandbox.status do
+          "ready" ->
+            reattach(state, conv, sandbox, agent, env, secrets)
+
+          s when s in ["pending", "starting"] ->
+            fresh_provision(state, conv, sandbox, agent, env, secrets)
+
+          terminal when terminal in ["terminated", "failed"] ->
+            Logger.warning(
+              "ConversationServer started for terminal conv #{conv.id} (#{terminal})"
+            )
+
+            {:stop, :normal, state}
+
+          _ ->
+            fresh_provision(state, conv, sandbox, agent, env, secrets)
+        end
+
+      {:error, {:missing_vars, names}} ->
+        reason = "missing env/vault keys referenced in mcp_servers: #{Enum.join(names, ", ")}"
+        Logger.error("provision failed for conv #{conv.id}: #{reason}")
+        publish_stage(state.user_id, state.conversation_id, "provision", "failed", %{reason: reason})
+        {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
+        Conversations.update_conversation(conv, %{status: "failed"})
+        {:stop, :normal, state}
+    end
+  end
+
+  defp substitute_agent_mcp(nil, _env, _secrets), do: {:ok, nil}
+
+  defp substitute_agent_mcp(agent, env, secrets) do
+    vars = substitution_vars(env, secrets)
+
+    case Substitution.apply(agent.mcp_servers || %{}, vars) do
+      {:ok, mcp} -> {:ok, %{agent | mcp_servers: mcp}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp substitution_vars(env, secrets) do
+    env_vars =
+      if env,
+        do: Map.new(env.env_vars || %{}, fn {k, v} -> {to_string(k), to_string(v)} end),
+        else: %{}
+
+    Map.merge(env_vars, secrets)
+  end
+
+  defp fresh_provision(state, conv, sandbox, agent, env, secrets) do
+    AgentOnDemand.Telemetry.span(
+      [:fresh_provision],
+      %{conv_id: state.conversation_id, sandbox_id: sandbox.id, env_id: env && env.id},
+      fn -> {do_fresh_provision(state, conv, sandbox, agent, env, secrets), %{}} end
+    )
+  end
+
+  defp do_fresh_provision(state, conv, sandbox, agent, env, secrets) do
+    try do
+      do_fresh_provision_inner(state, conv, sandbox, agent, env, secrets)
+    rescue
+      exception ->
+        stack = __STACKTRACE__
+        msg = Exception.format(:error, exception, stack)
+        Logger.error("provision raised an unhandled exception:\n#{msg}")
+
+        publish_stage(state.user_id, state.conversation_id, "provision", "failed", %{
+          reason: Exception.message(exception),
+          stack: Exception.format_stacktrace(stack) |> String.slice(0, 2000)
+        })
+
+        {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
+        Conversations.update_conversation(conv, %{status: "failed"})
+        {:stop, :normal, state}
+    end
+  end
+
+  defp do_fresh_provision_inner(state, conv, sandbox, agent, env, secrets) do
+    {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
+    publish_stage(state.user_id, state.conversation_id, "provision", "started")
+
+    # Enforce the per-tenant sandbox concurrency cap (decision 0005).
+    # QuotaExceededError is caught by the rescue in do_fresh_provision/6
+    # which marks the conversation failed.
+    Quotas.check_sandbox_quota!(state.user_id)
+
+    case create_sprite(sandbox.sprite_name) do
+      {:ok, sprite} ->
+        skills = (agent && agent.skills) || []
+        runtime = (agent && agent.runtime) || "claude"
+        AgentOnDemand.SpriteSkills.mount(sprite, runtime, skills)
+
+        sprite_env = build_sprite_env(state.runtime_module, agent, env, secrets, state.conversation_id)
+
+        write_runtime_config(sprite, state.runtime_module, agent)
+        AgentOnDemand.Conversations.Provisioning.write_env_file(sprite, sprite_env)
+
+        with :ok <-
+               run_provisioning_pipeline(sprite, env, sprite_env, secrets, state.conversation_id),
+             :ok <- prepare_runtime_sprite(sprite, state.runtime_module, agent, sprite_env) do
+          {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+          publish_stage(state.user_id, state.conversation_id, "provision", "done")
+
+          # Billing: sandbox is live and ready.
+          Billing.emit(state.user_id, "sandbox_provisioned", sandbox.id, "sandbox", %{
+            sprite_name: sandbox.sprite_name,
+            environment_id: env && env.id
+          })
+
+          maybe_create_checkpoint_async(sprite, env)
+
+          new_state = %{state | sprite: sprite, sprite_env: sprite_env}
+
+          case state.initial_prompt do
+            nil -> {:noreply, new_state}
+            p -> {:noreply, kick_turn(new_state, p, agent, [])}
+          end
+        else
+          {:error, reason} ->
+            Logger.error("provision step failed: #{inspect(reason)}")
+            _ = Sprites.destroy(sprite)
+            {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
+
+            publish_stage(state.user_id, state.conversation_id, "provision", "failed", %{
+              reason: inspect(reason)
+            })
+
+            Conversations.update_conversation(conv, %{status: "failed"})
+            {:stop, :normal, state}
+        end
+
+      {:error, reason} ->
+        Logger.error("sprite provision failed: #{inspect(reason)}")
+        {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
+        publish_stage(state.user_id, state.conversation_id, "provision", "failed", %{reason: inspect(reason)})
+        Conversations.update_conversation(conv, %{status: "failed"})
+        {:stop, :normal, state}
+    end
+  end
+
+  defp run_provisioning_pipeline(sprite, env, sprite_env, secrets, conv_id) do
+    case attempt_warm_start(sprite, env, conv_id) do
+      :warm_started ->
+        :ok
+
+      :cold ->
+        with :ok <-
+               AgentOnDemand.Conversations.Provisioning.install_packages(
+                 sprite,
+                 env,
+                 sprite_env,
+                 conv_id
+               ),
+             :ok <-
+               AgentOnDemand.Conversations.Provisioning.apply_network_policy(sprite, env, conv_id),
+             :ok <-
+               AgentOnDemand.Conversations.Provisioning.clone_repositories(
+                 sprite,
+                 env,
+                 secrets,
+                 conv_id
+               ),
+             :ok <- run_setup_script(sprite, env, sprite_env, conv_id) do
+          :ok
+        end
+    end
+  end
+
+  defp attempt_warm_start(_sprite, nil, _conv_id), do: :cold
+  defp attempt_warm_start(_sprite, %{checkpoint_id: nil}, _conv_id), do: :cold
+  defp attempt_warm_start(_sprite, %{checkpoint_id: ""}, _conv_id), do: :cold
+
+  defp attempt_warm_start(sprite, %{checkpoint_id: id} = env, conv_id) do
+    publish_stage(conv_id, "checkpoint_restore", "started", %{checkpoint_id: id})
+
+    case AgentOnDemand.Conversations.Provisioning.restore_checkpoint(sprite, id) do
+      {:ok, _} ->
+        publish_stage(conv_id, "checkpoint_restore", "done", %{checkpoint_id: id})
+        :warm_started
+
+      {:error, reason} ->
+        Logger.warning(
+          "checkpoint #{id} on env #{env.name} restore failed (#{inspect(reason)}); clearing + cold provisioning"
+        )
+
+        publish_stage(conv_id, "checkpoint_restore", "failed", %{
+          checkpoint_id: id,
+          reason: inspect(reason)
+        })
+
+        AgentOnDemand.Environments.update_environment(env, %{"checkpoint_id" => nil}, env.user_id)
+        :cold
+    end
+  end
+
+  defp maybe_create_checkpoint_async(_sprite, nil), do: :ok
+
+  defp maybe_create_checkpoint_async(_sprite, %{checkpoint_id: id})
+       when is_binary(id) and id != "",
+       do: :ok
+
+  defp maybe_create_checkpoint_async(sprite, %AgentOnDemand.Environments.Environment{} = env) do
+    if checkpoint_creation_enabled?() do
+      Task.start(fn ->
+        try do
+          AgentOnDemand.Conversations.Provisioning.create_checkpoint(sprite, env)
+        rescue
+          _ -> :ok
+        end
+      end)
+    end
+
+    :ok
+  end
+
+  defp maybe_create_checkpoint_async(_sprite, _), do: :ok
+
+  defp checkpoint_creation_enabled? do
+    Application.get_env(:agent_on_demand, :checkpoint_creation_enabled, true)
+  end
+
+  defp reattach(state, conv, sandbox, agent, env, secrets) do
+    AgentOnDemand.Telemetry.span(
+      [:reattach],
+      %{conv_id: state.conversation_id, sprite_name: sandbox.sprite_name},
+      fn -> {do_reattach(state, conv, sandbox, agent, env, secrets), %{}} end
+    )
+  end
+
+  defp do_reattach(state, _conv, sandbox, agent, env, secrets) do
+    publish_stage(state.user_id, state.conversation_id, "reattach", "started", %{
+      sprite_name: sandbox.sprite_name
+    })
+
+    client = SpritesClient.get!()
+
+    case Sprites.get_sprite(client, sandbox.sprite_name) do
+      {:ok, _info} ->
+        sprite = Sprites.sprite(client, sandbox.sprite_name)
+        sprite_env = build_sprite_env(state.runtime_module, agent, env, secrets, state.conversation_id)
+
+        AgentOnDemand.Conversations.Provisioning.write_env_file(sprite, sprite_env)
+
+        new_state = %{state | sprite: sprite, sprite_env: sprite_env}
+        new_state = reattach_running_turn(new_state)
+
+        case state.initial_prompt do
+          nil -> {:noreply, new_state}
+          p -> {:noreply, kick_turn(new_state, p, agent, [])}
+        end
+
+      {:error, reason} ->
+        Logger.warning(
+          "reattach failed for sprite #{sandbox.sprite_name}: #{inspect(reason)} — marking sandbox failed"
+        )
+
+        publish_stage(state.user_id, state.conversation_id, "reattach", "failed", %{reason: inspect(reason)})
+
+        {:ok, _} =
+          Conversations.update_sandbox(sandbox, %{
+            status: "failed",
+            terminated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+          })
+
+        {:stop, :normal, state}
+    end
+  end
+
+  defp reattach_running_turn(state) do
+    running_turn = find_running_turn(state.conversation_id)
+
+    if is_nil(running_turn) do
+      publish_stage(state.user_id, state.conversation_id, "reattach", "done", %{outcome: "no_running_turn"})
+      state
+    else
+      case Sprites.list_sessions(state.sprite) do
+        {:ok, sessions} ->
+          attempt_session_attach(state, running_turn, sessions)
+
+        {:error, reason} ->
+          Logger.warning("list_sessions failed during reattach: #{inspect(reason)}")
+          mark_orphan(state, running_turn, "list_sessions_failed")
+          state
+      end
+    end
+  end
+
+  defp attempt_session_attach(state, running_turn, []) do
+    mark_orphan(state, running_turn, "no_active_session")
+    state
+  end
+
+  defp attempt_session_attach(state, running_turn, [session | _]) do
+    case Sprites.attach_session(state.sprite, session.id, owner: self(), stdin: true) do
+      {:ok, command} ->
+        replay_skip =
+          Conversations.output_bytes_by_stream(state.conversation_id, running_turn.id)
+
+        publish_stage(state.user_id, state.conversation_id, "reattach", "done", %{
+          outcome: "session_attached",
+          session_id: session.id,
+          turn_id: running_turn.id,
+          turn_number: running_turn.turn_number,
+          replay_skip_bytes: replay_skip
+        })
+
+        conv = Conversations.get_conversation_internal!(state.conversation_id)
+        {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+
+        %{
+          state
+          | current_command: command,
+            current_command_ref: command.ref,
+            current_turn: running_turn,
+            replay_skip: replay_skip
+        }
+
+      {:error, reason} ->
+        Logger.warning("attach_session failed: #{inspect(reason)}")
+        mark_orphan(state, running_turn, "attach_failed")
+        state
+    end
+  end
+
+  defp mark_orphan(state, running_turn, why) do
+    {:ok, _} =
+      Conversations.update_turn(running_turn, %{
+        status: "interrupted",
+        ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    conv = Conversations.get_conversation_internal!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+
+    publish_stage(state.user_id, state.conversation_id, "reattach", "interrupted", %{
+      outcome: "turn_orphaned",
+      turn_id: running_turn.id,
+      turn_number: running_turn.turn_number,
+      reason: why
+    })
+  end
+
+  defp find_running_turn(conv_id) do
+    import Ecto.Query
+
+    AgentOnDemand.Repo.one(
+      from t in AgentOnDemand.Conversations.Turn,
+        where: t.conversation_id == ^conv_id and t.status == "running",
+        order_by: [desc: t.turn_number],
+        limit: 1
+    )
+  end
+
+  defp build_sprite_env(runtime_module, agent, env, secrets, conversation_id) do
+    (runtime_module.default_env(agent) || []) ++
+      fountain_callback_env() ++
+      conversation_env(conversation_id) ++
+      otel_propagation_env() ++
+      git_author_env() ++
+      if(env,
+        do: Enum.map(env.env_vars, fn {k, v} -> {to_string(k), to_string(v)} end),
+        else: []
+      ) ++
+      Enum.map(secrets, fn {k, v} -> {k, v} end)
+  end
+
+  defp conversation_env(nil), do: []
+  defp conversation_env(conv_id) when is_binary(conv_id), do: [{"AOD_CONVERSATION_ID", conv_id}]
+
+  @doc false
+  def git_author_env do
+    [
+      {"GIT_AUTHOR_NAME", "Fountain"},
+      {"GIT_AUTHOR_EMAIL", "fountain@local"},
+      {"GIT_COMMITTER_NAME", "Fountain"},
+      {"GIT_COMMITTER_EMAIL", "fountain@local"}
+    ]
+  end
+
+  # Env secrets first, vault overrides last — vault wins on key collision.
+  # Passes the tenant DEK so secrets are decrypted with the per-tenant key,
+  # not the shared platform key.
+  defp merge_secrets(env, vault, dek) when is_binary(dek) do
+    env_secrets = if env, do: Environments.decrypted_env(env, dek), else: %{}
+    vault_secrets = if vault, do: Vaults.decrypted_env(vault, dek), else: %{}
+    Map.merge(env_secrets, vault_secrets)
+  end
+
+  # Fallback for when tenant_key is nil (e.g., key not yet provisioned).
+  defp merge_secrets(env, vault, nil) do
+    env_secrets = if env, do: Environments.decrypted_env(env), else: %{}
+    vault_secrets = if vault, do: Vaults.decrypted_env(vault), else: %{}
+    Map.merge(env_secrets, vault_secrets)
+  end
+
+  defp otel_propagation_env do
+    case AgentOnDemand.Telemetry.current_traceparent() do
+      nil -> []
+      tp -> [{"TRACEPARENT", tp}]
+    end
+  end
+
+  defp run_setup_script(_sprite, nil, _sprite_env, _conv_id), do: :ok
+  defp run_setup_script(_sprite, %{setup_script: ""}, _sprite_env, _conv_id), do: :ok
+
+  defp run_setup_script(sprite, %{setup_script: script}, sprite_env, conv_id) do
+    AgentOnDemand.Telemetry.span(
+      [:setup_script],
+      %{conv_id: conv_id, script_size: byte_size(script)},
+      fn ->
+        publish_stage(conv_id, "setup", "started")
+
+        {output, code} =
+          Sprites.cmd(sprite, "bash", ["-lc", script],
+            env: sprite_env,
+            stderr_to_stdout: true,
+            timeout: 120_000
+          )
+
+        Conversations.log!(%{
+          conversation_id: conv_id,
+          kind: "output",
+          stream: "stdout",
+          stage: "setup",
+          data: output
+        })
+
+        if code == 0 do
+          publish_stage(conv_id, "setup", "done", %{exit_code: code})
+          {:ok, %{outcome: :ok, exit_code: code}}
+        else
+          publish_stage(conv_id, "setup", "failed", %{exit_code: code})
+          {{:error, {:setup_exit, code}}, %{outcome: :failed, exit_code: code}}
+        end
+      end
+    )
+  end
+
+  defp write_runtime_config(sprite, runtime_module, agent) do
+    Code.ensure_loaded(runtime_module)
+
+    if function_exported?(runtime_module, :write_config, 2) do
+      runtime_module.write_config(sprite, agent)
+    end
+  end
+
+  defp prepare_runtime_sprite(sprite, runtime_module, agent, sprite_env) do
+    Code.ensure_loaded(runtime_module)
+
+    if function_exported?(runtime_module, :prepare_sprite, 3) do
+      runtime_module.prepare_sprite(sprite, agent, sprite_env)
+    else
+      :ok
+    end
+  end
+
+  @impl true
+  def handle_call({:send_prompt, prompt, images}, _from, state) do
+    if state.current_command do
+      {:reply, {:error, :busy}, state}
+    else
+      conv = Conversations.get_conversation_internal!(state.conversation_id)
+      agent = if conv.agent_id, do: Agents.get_agent!(conv.agent_id, state.user_id)
+      {:reply, :ok, kick_turn(state, prompt, agent, images)}
+    end
+  end
+
+  def handle_call({:send_prompt, prompt}, _from, state) do
+    if state.current_command do
+      {:reply, {:error, :busy}, state}
+    else
+      conv = Conversations.get_conversation_internal!(state.conversation_id)
+      agent = if conv.agent_id, do: Agents.get_agent!(conv.agent_id, state.user_id)
+      {:reply, :ok, kick_turn(state, prompt, agent, [])}
+    end
+  end
+
+  def handle_call(:interrupt, _from, %{current_command: nil} = state) do
+    {:reply, {:error, :idle}, state}
+  end
+
+  def handle_call(:interrupt, _from, state) do
+    cmd_pid = state.current_command.pid
+
+    if Process.alive?(cmd_pid) do
+      try do
+        GenServer.stop(cmd_pid, :normal, 1_000)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+
+    {:ok, _turn} =
+      Conversations.update_turn(state.current_turn, %{
+        status: "interrupted",
+        ended_at: now()
+      })
+
+    publish_stage(state.user_id, state.conversation_id, "turn", "interrupted", %{
+      turn_id: state.current_turn.id,
+      turn_number: state.current_turn.turn_number
+    })
+
+    end_turn_span(state.current_turn_span, :error, %{"outcome" => "interrupted"})
+
+    conv = Conversations.get_conversation_internal!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+
+    {:reply, :ok,
+     %{
+       state
+       | current_command: nil,
+         current_command_ref: nil,
+         current_turn: nil,
+         current_turn_span: nil
+     }}
+  end
+
+  def handle_call(:terminate_conv, _from, state) do
+    if state.sprite, do: _ = Sprites.destroy(state.sprite)
+    sandbox = Conversations.get_sandbox!(state.sandbox_id)
+
+    {:ok, _} =
+      Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
+
+    conv = Conversations.get_conversation_internal!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+    publish_stage(state.user_id, state.conversation_id, "terminate", "done")
+
+    # Billing: sandbox is gone.
+    Billing.emit(state.user_id, "sandbox_terminated", state.sandbox_id, "sandbox", %{
+      sprite_name: sandbox.sprite_name
+    })
+
+    {:stop, :normal, :ok, state}
+  end
+
+  @impl true
+  def handle_info({:stdout, %{ref: ref}, data}, %{current_command_ref: ref} = state) do
+    {:noreply, log_with_replay_skip(state, "stdout", data)}
+  end
+
+  def handle_info({:stderr, %{ref: ref}, data}, %{current_command_ref: ref} = state) do
+    {:noreply, log_with_replay_skip(state, "stderr", data)}
+  end
+
+  def handle_info({:exit, %{ref: ref}, code}, %{current_command_ref: ref} = state) do
+    turn = state.current_turn
+
+    {:ok, turn} =
+      Conversations.update_turn(turn, %{
+        status: if(code == 0, do: "completed", else: "failed"),
+        exit_code: code,
+        ended_at: now()
+      })
+
+    publish_stage(state.user_id, state.conversation_id, "turn", "done", %{
+      turn_id: turn.id,
+      turn_number: turn.turn_number,
+      exit_code: code
+    })
+
+    end_turn_span(
+      state.current_turn_span,
+      if(code == 0, do: :ok, else: :error),
+      %{"exit_code" => code}
+    )
+
+    conv = Conversations.get_conversation_internal!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+
+    {:noreply,
+     %{
+       state
+       | current_command: nil,
+         current_command_ref: nil,
+         current_turn: nil,
+         current_turn_span: nil
+     }}
+  end
+
+  def handle_info({:error, _ref, reason}, state) do
+    Logger.error("sprite command error: #{inspect(reason)}")
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  defp create_sprite(name) do
+    client = SpritesClient.get!()
+    Sprites.create(client, name)
+  end
+
+  defp fountain_callback_env do
+    base = Application.get_env(:agent_on_demand, :public_url)
+    token = Application.get_env(:agent_on_demand, :admin_token)
+
+    if is_binary(base) and base != "" and is_binary(token) do
+      [{"FOUNTAIN_BASE_URL", base}, {"FOUNTAIN_TOKEN", token}]
+    else
+      []
+    end
+  end
+
+  defp kick_turn(state, prompt, agent, images) do
+    conv = Conversations.get_conversation_internal!(state.conversation_id)
+    turn_number = Conversations.next_turn_number(state.conversation_id)
+
+    {:ok, turn} =
+      Conversations.create_turn(%{
+        conversation_id: conv.id,
+        turn_number: turn_number,
+        prompt: prompt,
+        status: "running",
+        started_at: now()
+      })
+
+    {:ok, _} = Conversations.insert_turn_images(turn.id, images)
+
+    image_paths = write_image_temp_files(state.sprite, turn.id, images)
+
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+
+    mode =
+      cond do
+        is_nil(state.runtime_session_id) -> :run
+        true -> :continue
+      end
+
+    runtime_session_id =
+      case state.runtime_session_id do
+        nil ->
+          new_id = Ecto.UUID.generate()
+          {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: new_id})
+          new_id
+
+        existing ->
+          existing
+      end
+
+    {cmd, args, build_opts} =
+      state.runtime_module.build_command(agent, prompt, mode, runtime_session_id, [images: image_paths])
+
+    use_stdin? = Keyword.get(build_opts, :stdin?, true)
+    use_tty? = Keyword.get(build_opts, :tty?, false)
+    cwd = Keyword.get(build_opts, :dir)
+    prompt_suffix = Keyword.get(build_opts, :prompt_suffix, "")
+
+    publish_stage(state.user_id, state.conversation_id, "turn", "started", %{
+      turn_id: turn.id,
+      turn_number: turn_number,
+      mode: Atom.to_string(mode)
+    })
+
+    # Billing: turn is kicking off.
+    Billing.emit(state.user_id, "turn_started", turn.id, "turn", %{
+      turn_number: turn_number,
+      conversation_id: state.conversation_id
+    })
+
+    turn_span =
+      OpenTelemetry.Tracer.start_span("agent_on_demand.turn", %{
+        attributes: %{
+          "conv_id" => conv.id,
+          "turn_id" => turn.id,
+          "turn_number" => turn_number,
+          "mode" => Atom.to_string(mode),
+          "runtime" => to_string(conv.runtime),
+          "model" => agent && agent.model
+        }
+      })
+
+    previous_span = OpenTelemetry.Tracer.set_current_span(turn_span)
+
+    try do
+      spawn_opts =
+        [
+          env: state.sprite_env,
+          owner: self(),
+          stdin: use_stdin?,
+          tty: use_tty?,
+          detachable: true
+        ]
+        |> then(&if cwd, do: Keyword.put(&1, :dir, cwd), else: &1)
+
+      case Sprites.spawn(state.sprite, cmd, args, spawn_opts) do
+        {:ok, command} ->
+          if use_stdin? do
+            :ok = Sprites.write(command, prompt <> prompt_suffix)
+            :ok = Sprites.close_stdin(command)
+          end
+
+          %{
+            state
+            | current_command: command,
+              current_command_ref: command.ref,
+              current_turn: turn,
+              runtime_session_id: runtime_session_id,
+              current_turn_span: turn_span
+          }
+
+        {:error, reason} ->
+          Logger.error("spawn failed: #{inspect(reason)}")
+
+          {:ok, _} =
+            Conversations.update_turn(turn, %{
+              status: "failed",
+              ended_at: now()
+            })
+
+          publish_stage(state.user_id, state.conversation_id, "turn", "failed", %{
+            turn_id: turn.id,
+            reason: inspect(reason)
+          })
+
+          OpenTelemetry.Tracer.set_status(
+            OpenTelemetry.status(:error, "spawn_failed: #{inspect(reason)}")
+          )
+
+          OpenTelemetry.Tracer.end_span(turn_span)
+          OpenTelemetry.Tracer.set_current_span(previous_span)
+
+          state
+      end
+    after
+      OpenTelemetry.Tracer.set_current_span(previous_span)
+    end
+  end
+
+  defp end_turn_span(nil, _outcome, _attrs), do: :ok
+
+  defp end_turn_span(span_ctx, outcome, attrs) do
+    OpenTelemetry.Tracer.set_current_span(span_ctx)
+
+    Enum.each(attrs, fn {k, v} -> OpenTelemetry.Tracer.set_attribute(to_string(k), v) end)
+
+    case outcome do
+      :error ->
+        OpenTelemetry.Tracer.set_status(OpenTelemetry.status(:error, inspect(attrs)))
+
+      _ ->
+        :ok
+    end
+
+    OpenTelemetry.Tracer.end_span(span_ctx)
+  end
+
+  defp log_output(state, stream, data) do
+    event =
+      Conversations.log!(%{
+        conversation_id: state.conversation_id,
+        turn_id: state.current_turn && state.current_turn.id,
+        kind: "output",
+        stream: stream,
+        stage: "turn",
+        data: data
+      })
+
+    Phoenix.PubSub.broadcast(
+      AgentOnDemand.PubSub,
+      "conv:#{state.user_id}:#{state.conversation_id}",
+      {:log_event, event}
+    )
+  end
+
+  defp log_with_replay_skip(state, stream, data) do
+    skip = Map.get(state.replay_skip, stream, 0)
+    size = byte_size(data)
+
+    cond do
+      skip == 0 ->
+        log_output(state, stream, data)
+        state
+
+      skip >= size ->
+        put_in(state.replay_skip[stream], skip - size)
+
+      true ->
+        log_output(state, stream, binary_part(data, skip, size - skip))
+        put_in(state.replay_skip[stream], 0)
+    end
+  end
+
+  # Broadcasts a stage event and persists it as a LogEvent.
+  # Takes user_id to build the namespaced PubSub topic
+  # `"conv:<user_id>:<conv_id>"`.
+  defp publish_stage(user_id, conv_id, stage, state_name, meta \\ %{}) do
+    event =
+      Conversations.log!(%{
+        conversation_id: conv_id,
+        kind: "stage",
+        stage: stage,
+        state: state_name,
+        data: Jason.encode!(meta)
+      })
+
+    Phoenix.PubSub.broadcast(
+      AgentOnDemand.PubSub,
+      "conv:#{user_id}:#{conv_id}",
+      {:log_event, event}
+    )
+  end
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+  defp write_image_temp_files(_sprite, _turn_id, []), do: []
+
+  defp write_image_temp_files(sprite, turn_id, images) do
+    fs = Sprites.filesystem(sprite, "/")
+
+    images
+    |> Enum.with_index()
+    |> Enum.map(fn {%{media_type: mt, data: data}, idx} ->
+      ext = media_type_to_ext(mt)
+      path = "/tmp/fountain_turn_#{turn_id}_#{idx}.#{ext}"
+      Sprites.Filesystem.write(fs, path, data)
+      {path, mt}
+    end)
+  end
+
+  defp media_type_to_ext("image/png"), do: "png"
+  defp media_type_to_ext("image/jpeg"), do: "jpeg"
+  defp media_type_to_ext("image/gif"), do: "gif"
+  defp media_type_to_ext("image/webp"), do: "webp"
+  defp media_type_to_ext(_), do: "bin"
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/conversations/rehydrator.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/conversations/rehydrator.ex
@@ -1,0 +1,45 @@
+defmodule AgentOnDemand.Conversations.Rehydrator do
+  @moduledoc """
+  On app boot, find conversations whose ConversationServer would have been
+  alive at the time of a clean BEAM stop and start servers for them.
+  Scoped to sandbox.status == "ready" and conversation.status in ["idle", "running"].
+  """
+  require Logger
+  alias AgentOnDemand.{Agents, Conversations, Runtimes}
+  alias AgentOnDemand.Conversations.ConversationServer
+
+  def run do
+    AgentOnDemand.Telemetry.span([:rehydrate], %{}, fn ->
+      convs = Conversations.list_resumable_conversations()
+      Logger.info("rehydrator: scanning #{length(convs)} resumable conversation(s)")
+      started = Enum.reduce(convs, 0, fn conv, count ->
+        case spawn_server(conv) do
+          {:ok, _pid} -> count + 1
+          _ -> count
+        end
+      end)
+      Logger.info("rehydrator: started #{started} ConversationServer(s)")
+      {started, %{candidates: length(convs), started: started}}
+    end)
+  end
+
+  defp spawn_server(conv) do
+    with %Agents.Agent{} = _agent <-
+           (conv.agent_id && Agents.get_agent(conv.agent_id, conv.user_id)) || {:skip, :no_agent},
+         {:ok, runtime_module} <- Runtimes.for_runtime(conv.runtime) do
+      Horde.DynamicSupervisor.start_child(
+        AgentOnDemand.ConversationSupervisor,
+        {ConversationServer, [
+          conversation_id: conv.id,
+          sandbox_id: conv.sandbox_id,
+          runtime_module: runtime_module,
+          initial_prompt: nil,
+          user_id: conv.user_id
+        ]}
+      )
+    else
+      {:skip, why} -> Logger.warning("rehydrator: skipping conv #{conv.id} (#{why})"); :skipped
+      {:error, reason} -> Logger.warning("rehydrator: skipping conv #{conv.id}: #{inspect(reason)}"); :skipped
+    end
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/conversations/sandbox.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/conversations/sandbox.ex
@@ -1,0 +1,33 @@
+defmodule AgentOnDemand.Conversations.Sandbox do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias AgentOnDemand.Conversations.Conversation
+  alias AgentOnDemand.Environments.Environment
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @statuses ~w(pending starting ready terminated failed)
+
+  schema "sandboxes" do
+    field :sprite_name, :string
+    field :status, :string, default: "pending"
+    field :exit_code, :integer
+    field :terminated_at, :utc_datetime
+    # user_id FK column added by phase-3-foundation migration (nilify_all on delete).
+    field :user_id, :binary_id
+    belongs_to :environment, Environment
+    has_many :conversations, Conversation
+    timestamps(type: :utc_datetime)
+  end
+
+  def statuses, do: @statuses
+
+  def changeset(sandbox, attrs) do
+    sandbox
+    |> cast(attrs, [:sprite_name, :status, :exit_code, :terminated_at, :environment_id, :user_id])
+    |> validate_required([:sprite_name, :status])
+    |> validate_inclusion(:status, @statuses)
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/environments.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/environments.ex
@@ -1,0 +1,102 @@
+defmodule AgentOnDemand.Environments do
+  @moduledoc "Context for environments and their secrets."
+
+  import Ecto.Query, only: [from: 2]
+
+  alias AgentOnDemand.Environments.{Environment, Secret}
+  alias AgentOnDemand.Repo
+
+  # ── environments ──────────────────────────────────────────────────────────
+
+  def list_environments(user_id) do
+    Repo.all(
+      from e in Environment,
+        where: e.user_id == ^user_id,
+        order_by: [desc: e.inserted_at, desc: e.id]
+    )
+  end
+
+  @doc "Returns the environment if it belongs to user_id, otherwise nil."
+  def get_environment(id, user_id), do: Repo.get_by(Environment, id: id, user_id: user_id)
+
+  @doc """
+  Returns the environment. Raises Ecto.NoResultsError if not found or
+  the environment does not belong to user_id (cross-tenant access → 404,
+  not 403, to avoid leaking existence).
+  """
+  def get_environment!(id, user_id), do: Repo.get_by!(Environment, id: id, user_id: user_id)
+
+  def create_environment(attrs, user_id) do
+    %Environment{}
+    |> Environment.changeset(Map.put(attrs, "user_id", user_id))
+    |> Repo.insert()
+  end
+
+  def update_environment(%Environment{} = env, attrs, _user_id) do
+    env
+    |> Environment.changeset(attrs)
+    |> Repo.update()
+  end
+
+  # user_id is accepted for call-site symmetry; ownership was enforced
+  # by the get_environment!/2 that preceded this call.
+  def delete_environment(%Environment{} = env, _user_id), do: Repo.delete(env)
+
+  # ── secrets ───────────────────────────────────────────────────────────────
+
+  def list_secrets(%Environment{id: env_id}) do
+    Repo.all(from s in Secret, where: s.environment_id == ^env_id, order_by: [asc: s.key])
+  end
+
+  def get_secret(env_id, key) do
+    Repo.get_by(Secret, environment_id: env_id, key: key)
+  end
+
+  def upsert_secret(%Environment{id: env_id}, %{"key" => key} = attrs) do
+    case get_secret(env_id, key) do
+      nil ->
+        %Secret{}
+        |> Secret.changeset(Map.put(attrs, "environment_id", env_id))
+        |> Repo.insert()
+
+      existing ->
+        existing
+        |> Secret.changeset(attrs)
+        |> Repo.update()
+    end
+  end
+
+  def delete_secret(%Secret{} = secret), do: Repo.delete(secret)
+
+  @doc """
+  Returns a flat map `%{"KEY" => "plaintext"}` using the platform-level
+  SECRETS_KEY. Used on code paths that haven't yet been migrated to
+  per-tenant DEKs (e.g. environment preview in the admin UI).
+  """
+  def decrypted_env(%Environment{} = env) do
+    env
+    |> list_secrets()
+    |> Enum.reduce(%{}, fn secret, acc ->
+      case Secret.decrypt(secret) do
+        {:ok, plain} -> Map.put(acc, secret.key, plain)
+        :error -> acc
+      end
+    end)
+  end
+
+  @doc """
+  Returns a flat map `%{"KEY" => "plaintext"}` using an explicit
+  per-tenant DEK. Called by ConversationServer after it loads
+  `Fountain.Crypto.load_tenant_key(user_id)` in `init/1`.
+  """
+  def decrypted_env(%Environment{} = env, dek) when is_binary(dek) do
+    env
+    |> list_secrets()
+    |> Enum.reduce(%{}, fn secret, acc ->
+      case Secret.decrypt(secret, dek) do
+        {:ok, plain} -> Map.put(acc, secret.key, plain)
+        :error -> acc
+      end
+    end)
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/environments/environment.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/environments/environment.ex
@@ -1,0 +1,75 @@
+defmodule AgentOnDemand.Environments.Environment do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias AgentOnDemand.Environments.Secret
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @networking ~w(unrestricted limited)
+
+  @warm_start_fields [
+    :packages, :env_vars, :setup_script,
+    :networking_type, :networking_config, :repositories
+  ]
+
+  schema "environments" do
+    field :name, :string
+    # user_id FK column added by phase-3-foundation migration.
+    field :user_id, :binary_id
+    field :packages, :map, default: %{}
+    field :env_vars, :map, default: %{}
+    field :setup_script, :string, default: ""
+    field :networking_type, :string, default: "unrestricted"
+    field :networking_config, :map, default: %{}
+    field :repositories, {:array, :map}, default: []
+    field :checkpoint_id, :string
+    has_many :secrets, Secret
+    timestamps(type: :utc_datetime)
+  end
+
+  def warm_start_fields, do: @warm_start_fields
+
+  def changeset(env, attrs) do
+    env
+    |> cast(attrs, [:name, :user_id, :packages, :env_vars, :setup_script,
+                    :networking_type, :networking_config, :repositories, :checkpoint_id])
+    |> validate_required([:name, :user_id])
+    |> validate_inclusion(:networking_type, @networking)
+    |> validate_length(:name, min: 1, max: 200)
+    |> validate_change(:repositories, &validate_repositories/2)
+    |> maybe_invalidate_checkpoint()
+    # Name is unique per user, not globally.
+    |> unique_constraint([:user_id, :name])
+    |> foreign_key_constraint(:user_id)
+  end
+
+  # Drops checkpoint_id when any provisioning-relevant field changes,
+  # unless the caller explicitly set checkpoint_id in this changeset.
+  defp maybe_invalidate_checkpoint(changeset) do
+    explicitly_set? = Map.has_key?(changeset.changes, :checkpoint_id)
+    changed_warm?   = Enum.any?(@warm_start_fields, fn f -> Map.has_key?(changeset.changes, f) end)
+    if changed_warm? and not explicitly_set? do
+      put_change(changeset, :checkpoint_id, nil)
+    else
+      changeset
+    end
+  end
+
+  defp validate_repositories(_field, list) when is_list(list) do
+    Enum.flat_map(list, fn
+      %{"url" => url, "mount_path" => mount}
+      when is_binary(url) and is_binary(mount) and url != "" and mount != "" ->
+        if String.starts_with?(mount, "/") and String.starts_with?(url, "https://") do
+          []
+        else
+          [repositories: "url must be https:// and mount_path must be absolute"]
+        end
+      _ ->
+        [repositories: "each entry needs `url` (https://...) and `mount_path` (/abs/path)"]
+    end)
+  end
+
+  defp validate_repositories(_, _), do: []
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/environments/secret.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/environments/secret.ex
@@ -1,0 +1,54 @@
+defmodule AgentOnDemand.Environments.Secret do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias AgentOnDemand.Crypto
+  alias AgentOnDemand.Environments.Environment
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "secrets" do
+    field :key, :string
+    field :value_ciphertext, :binary
+    field :value, :string, virtual: true, redact: true
+    belongs_to :environment, Environment
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(secret, attrs) do
+    secret
+    |> cast(attrs, [:key, :value, :environment_id])
+    |> validate_required([:key, :value, :environment_id])
+    |> validate_format(:key, ~r/^[A-Z][A-Z0-9_]*$/, message: "must be UPPER_SNAKE_CASE")
+    |> validate_length(:key, min: 1, max: 200)
+    |> put_ciphertext()
+    |> unique_constraint([:environment_id, :key])
+  end
+
+  defp put_ciphertext(changeset) do
+    case get_change(changeset, :value) do
+      nil   -> changeset
+      value -> put_change(changeset, :value_ciphertext, Crypto.encrypt(value))
+    end
+  end
+
+  @doc "Decrypt using the platform-level SECRETS_KEY (legacy / pre-tenant-DEK path)."
+  def decrypt(%__MODULE__{value_ciphertext: ct}) when is_binary(ct), do: Crypto.decrypt(ct)
+  def decrypt(_), do: :error
+
+  @doc """
+  Decrypt using an explicit per-tenant DEK.
+
+  `dek` is the unwrapped data-encryption key returned by
+  `Fountain.Crypto.load_tenant_key/1` (added in phase-3-foundation).
+  ConversationServer loads it in `init/1` and passes it here so the
+  secret value never touches the platform key path.
+  """
+  def decrypt(%__MODULE__{value_ciphertext: ct}, dek)
+      when is_binary(ct) and is_binary(dek) do
+    Crypto.decrypt(ct, dek)
+  end
+
+  def decrypt(_, _dek), do: :error
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/quotas.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/quotas.ex
@@ -1,0 +1,64 @@
+defmodule AgentOnDemand.Quotas do
+  @moduledoc """
+  Enforces per-tenant resource limits.
+
+  The primary noisy-neighbor mitigation per decision 0005: each tenant is
+  capped at `users.max_concurrent_sandboxes` active sandboxes (default 5).
+  Admins can raise or lower the cap per user.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias AgentOnDemand.Accounts
+  alias AgentOnDemand.Conversations.Sandbox
+  alias AgentOnDemand.Repo
+
+  defmodule QuotaExceededError do
+    @moduledoc "Raised when a tenant's sandbox concurrency cap is reached."
+    defexception [:message, :user_id, :current_count, :max_count]
+
+    @impl true
+    def message(%{message: msg}), do: msg
+  end
+
+  @active_statuses ~w(pending starting ready)
+
+  @doc """
+  Asserts the user is below their concurrent sandbox limit.
+
+  Raises `QuotaExceededError` if the count of sandboxes in
+  `pending | starting | ready` status is at or above
+  `user.max_concurrent_sandboxes`. Returns `:ok` otherwise.
+
+  Called in `ConversationServer.init/1` before `Sprites.create/2`.
+
+  ## Note
+  `Accounts.get_user!/1` and `users.max_concurrent_sandboxes` are
+  provided by the phase-3-foundation slice.
+  """
+  @spec check_sandbox_quota!(binary()) :: :ok
+  def check_sandbox_quota!(user_id) do
+    user = Accounts.get_user!(user_id)
+    current = count_active_sandboxes(user_id)
+
+    if current >= user.max_concurrent_sandboxes do
+      raise QuotaExceededError,
+        message:
+          "sandbox quota exceeded for user #{user_id}: " <>
+            "#{current}/#{user.max_concurrent_sandboxes} active sandboxes",
+        user_id: user_id,
+        current_count: current,
+        max_count: user.max_concurrent_sandboxes
+    end
+
+    :ok
+  end
+
+  defp count_active_sandboxes(user_id) do
+    Repo.one(
+      from s in Sandbox,
+        where: s.user_id == ^user_id and s.status in ^@active_statuses,
+        select: count(s.id)
+    )
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/vaults.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/vaults.ex
@@ -1,0 +1,115 @@
+defmodule AgentOnDemand.Vaults do
+  @moduledoc """
+  Context for vaults — free-floating bags of env-var overrides selected
+  at conversation creation. Layered on top of an environment's baseline
+  secrets at sprite spawn time; vault values win on key collision.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias AgentOnDemand.Repo
+  alias AgentOnDemand.Vaults.{Vault, VaultSecret}
+
+  # ── vaults ────────────────────────────────────────────────────────────────
+
+  def list_vaults(user_id) do
+    Repo.all(
+      from v in Vault,
+        where: v.user_id == ^user_id,
+        order_by: [desc: v.inserted_at, desc: v.id]
+    )
+  end
+
+  @doc "Returns the vault if it belongs to user_id, otherwise nil."
+  def get_vault(id, user_id), do: Repo.get_by(Vault, id: id, user_id: user_id)
+
+  @doc """
+  Returns the vault. Raises Ecto.NoResultsError if not found or
+  the vault does not belong to user_id (cross-tenant access → 404).
+  """
+  def get_vault!(id, user_id), do: Repo.get_by!(Vault, id: id, user_id: user_id)
+
+  def get_vault_by_name(name, user_id), do: Repo.get_by(Vault, name: name, user_id: user_id)
+
+  def create_vault(attrs, user_id) do
+    %Vault{}
+    |> Vault.changeset(Map.put(attrs, "user_id", user_id))
+    |> Repo.insert()
+  end
+
+  def update_vault(%Vault{} = vault, attrs, _user_id) do
+    vault
+    |> Vault.changeset(attrs)
+    |> Repo.update()
+  end
+
+  # user_id accepted for call-site symmetry; ownership enforced by prior fetch.
+  def delete_vault(%Vault{} = vault, _user_id), do: Repo.delete(vault)
+
+  # ── vault secrets ─────────────────────────────────────────────────────────
+
+  @doc """
+  Lists secrets for a vault, verifying the vault belongs to user_id.
+  Raises Ecto.NoResultsError on cross-tenant access.
+  """
+  def list_vault_secrets(vault_id, user_id) do
+    # Ownership check: raises if wrong owner.
+    vault = get_vault!(vault_id, user_id)
+    list_secrets(vault)
+  end
+
+  def list_secrets(%Vault{id: vault_id}) do
+    Repo.all(from s in VaultSecret, where: s.vault_id == ^vault_id, order_by: [asc: s.key])
+  end
+
+  def get_secret(vault_id, key) do
+    Repo.get_by(VaultSecret, vault_id: vault_id, key: key)
+  end
+
+  def upsert_secret(%Vault{id: vault_id}, %{"key" => key} = attrs) do
+    case get_secret(vault_id, key) do
+      nil ->
+        %VaultSecret{}
+        |> VaultSecret.changeset(Map.put(attrs, "vault_id", vault_id))
+        |> Repo.insert()
+
+      existing ->
+        existing
+        |> VaultSecret.changeset(attrs)
+        |> Repo.update()
+    end
+  end
+
+  def delete_secret(%VaultSecret{} = secret), do: Repo.delete(secret)
+
+  @doc """
+  Returns a flat map `%{"KEY" => "plaintext"}` using the platform-level
+  SECRETS_KEY (legacy / pre-tenant-DEK path).
+  """
+  def decrypted_env(%Vault{} = vault) do
+    vault
+    |> list_secrets()
+    |> Enum.reduce(%{}, fn secret, acc ->
+      case VaultSecret.decrypt(secret) do
+        {:ok, plain} -> Map.put(acc, secret.key, plain)
+        :error -> acc
+      end
+    end)
+  end
+
+  @doc """
+  Returns a flat map `%{"KEY" => "plaintext"}` using an explicit
+  per-tenant DEK. Called by ConversationServer after it loads
+  `Fountain.Crypto.load_tenant_key(user_id)` in `init/1`.
+  """
+  def decrypted_env(%Vault{} = vault, dek) when is_binary(dek) do
+    vault
+    |> list_secrets()
+    |> Enum.reduce(%{}, fn secret, acc ->
+      case VaultSecret.decrypt(secret, dek) do
+        {:ok, plain} -> Map.put(acc, secret.key, plain)
+        :error -> acc
+      end
+    end)
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/vaults/vault.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/vaults/vault.ex
@@ -1,0 +1,28 @@
+defmodule AgentOnDemand.Vaults.Vault do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias AgentOnDemand.Vaults.VaultSecret
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "vaults" do
+    field :name, :string
+    field :description, :string, default: ""
+    # user_id FK column added by phase-3-foundation migration.
+    field :user_id, :binary_id
+    has_many :secrets, VaultSecret
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(vault, attrs) do
+    vault
+    |> cast(attrs, [:name, :description, :user_id])
+    |> validate_required([:name, :user_id])
+    |> validate_length(:name, min: 1, max: 200)
+    # Name is unique per user, not globally.
+    |> unique_constraint([:user_id, :name])
+    |> foreign_key_constraint(:user_id)
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand/vaults/vault_secret.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand/vaults/vault_secret.ex
@@ -1,0 +1,54 @@
+defmodule AgentOnDemand.Vaults.VaultSecret do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias AgentOnDemand.Crypto
+  alias AgentOnDemand.Vaults.Vault
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "vault_secrets" do
+    field :key, :string
+    field :value_ciphertext, :binary
+    field :value, :string, virtual: true, redact: true
+    belongs_to :vault, Vault
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(secret, attrs) do
+    secret
+    |> cast(attrs, [:key, :value, :vault_id])
+    |> validate_required([:key, :value, :vault_id])
+    |> validate_format(:key, ~r/^[A-Z][A-Z0-9_]*$/, message: "must be UPPER_SNAKE_CASE")
+    |> validate_length(:key, min: 1, max: 200)
+    |> put_ciphertext()
+    |> unique_constraint([:vault_id, :key])
+  end
+
+  defp put_ciphertext(changeset) do
+    case get_change(changeset, :value) do
+      nil   -> changeset
+      value -> put_change(changeset, :value_ciphertext, Crypto.encrypt(value))
+    end
+  end
+
+  @doc "Decrypt using the platform-level SECRETS_KEY (legacy / pre-tenant-DEK path)."
+  def decrypt(%__MODULE__{value_ciphertext: ct}) when is_binary(ct), do: Crypto.decrypt(ct)
+  def decrypt(_), do: :error
+
+  @doc """
+  Decrypt using an explicit per-tenant DEK.
+
+  `dek` is the unwrapped data-encryption key returned by
+  `Fountain.Crypto.load_tenant_key/1` (added in phase-3-foundation).
+  ConversationServer loads it in `init/1` and passes it here so the
+  vault secret value never touches the platform key path.
+  """
+  def decrypt(%__MODULE__{value_ciphertext: ct}, dek)
+      when is_binary(ct) and is_binary(dek) do
+    Crypto.decrypt(ct, dek)
+  end
+
+  def decrypt(_, _dek), do: :error
+end

--- a/apps/agent_on_demand/lib/agent_on_demand_web/controllers/agent_controller.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand_web/controllers/agent_controller.ex
@@ -1,0 +1,122 @@
+defmodule AgentOnDemandWeb.AgentController do
+  use AgentOnDemandWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias AgentOnDemand.Agents
+  alias AgentOnDemand.Agents.Agent
+  alias AgentOnDemandWeb.Schemas
+
+  action_fallback AgentOnDemandWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Agents"])
+
+  operation(:index,
+    summary: "List agents",
+    responses: [
+      ok: {"Agents", "application/json", Schemas.AgentListResponse}
+    ]
+  )
+
+  def index(conn, params) do
+    current_user = conn.assigns.current_user
+    render(conn, :index, agents: Agents.list_agents(current_user.id, build_filters(params)))
+  end
+
+  operation(:show,
+    summary: "Get an agent",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Agent", "application/json", Schemas.AgentResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Agents.get_agent(id, current_user.id) do
+      nil -> {:error, :not_found}
+      agent -> render(conn, :show, agent: agent)
+    end
+  end
+
+  operation(:create,
+    summary: "Create an agent",
+    request_body: {"Agent attributes", "application/json", Schemas.AgentRequest},
+    responses: [
+      created: {"Agent", "application/json", Schemas.AgentResponse},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.ChangesetError}
+    ]
+  )
+
+  def create(conn, params) do
+    current_user = conn.assigns.current_user
+
+    with {:ok, %Agent{} = agent} <- Agents.create_agent(params, current_user.id) do
+      conn
+      |> put_status(:created)
+      |> render(:show, agent: Agents.get_agent!(agent.id, current_user.id))
+    end
+  end
+
+  operation(:update,
+    summary: "Update an agent (partial)",
+    description: "Every field is optional; the server merges into the existing record.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    request_body: {"Partial agent attributes", "application/json", Schemas.AgentUpdate},
+    responses: [
+      ok: {"Agent", "application/json", Schemas.AgentResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.ChangesetError}
+    ]
+  )
+
+  def update(conn, %{"id" => id} = params) do
+    current_user = conn.assigns.current_user
+
+    case Agents.get_agent(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      agent ->
+        with {:ok, agent} <-
+               Agents.update_agent(agent, Map.delete(params, "id"), current_user.id) do
+          render(conn, :show, agent: Agents.get_agent!(agent.id, current_user.id))
+        end
+    end
+  end
+
+  operation(:delete,
+    summary: "Delete an agent",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Deleted",
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Agents.get_agent(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      agent ->
+        {:ok, _} = Agents.delete_agent(agent, current_user.id)
+        send_resp(conn, :no_content, "")
+    end
+  end
+
+  defp build_filters(params) do
+    [
+      search: params["search"] || "",
+      runtimes: params["runtimes"] || [],
+      env_ids: params["env_ids"] || [],
+      has_skills: params["has_skills"] == "true",
+      has_mcp: params["has_mcp"] == "true"
+    ]
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand_web/controllers/conversation_controller.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand_web/controllers/conversation_controller.ex
@@ -1,0 +1,404 @@
+defmodule AgentOnDemandWeb.ConversationController do
+  use AgentOnDemandWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias AgentOnDemand.Conversations
+  alias AgentOnDemand.Conversations.{ConversationServer, LogEvent}
+  alias AgentOnDemandWeb.Schemas
+
+  action_fallback AgentOnDemandWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Conversations"])
+
+  operation(:index,
+    summary: "List conversations",
+    responses: [
+      ok: {"Conversations", "application/json", Schemas.ConversationListResponse}
+    ]
+  )
+
+  def index(conn, _params) do
+    current_user = conn.assigns.current_user
+    render(conn, :index, conversations: Conversations.list_conversations(current_user.id))
+  end
+
+  operation(:show,
+    summary: "Get a conversation",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Conversation", "application/json", Schemas.ConversationResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, current_user.id) do
+      nil -> {:error, :not_found}
+      conv -> render(conn, :show, conversation: conv)
+    end
+  end
+
+  operation(:turns,
+    summary: "List turns in a conversation",
+    parameters: [conversation_id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Turns", "application/json", Schemas.TurnListResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def turns(conn, %{"conversation_id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      _ ->
+        render(conn, :turns, turns: Conversations.list_turns(id))
+    end
+  end
+
+  operation(:create,
+    summary: "Start a conversation",
+    description:
+      "Creates a sandbox + conversation pair, starts the runtime in a fresh sprite, " <>
+        "and (if `prompt` is supplied) sends it as turn 1. " <>
+        "Pass `X-AoD-Parent-Conversation-Id` header to record which conversation spawned this one.",
+    request_body: {"Conversation attrs", "application/json", Schemas.ConversationCreateRequest},
+    responses: [
+      created: {"Conversation", "application/json", Schemas.ConversationResponse},
+      not_found: {"Agent not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.ChangesetError}
+    ]
+  )
+
+  def create(conn, params) do
+    current_user = conn.assigns.current_user
+    images = decode_images(params["images"])
+
+    parent_header =
+      conn
+      |> get_req_header("x-aod-parent-conversation-id")
+      |> List.first()
+
+    {source, parent_id} = infer_provenance(parent_header)
+
+    params =
+      params
+      |> Map.put("images", images)
+      |> Map.put("source", source)
+      |> Map.put("parent_conversation_id", parent_id)
+
+    with {:ok, conv} <- Conversations.start_conversation(params, current_user.id) do
+      conn
+      |> put_status(:created)
+      |> render(:show, conversation: conv)
+    end
+  end
+
+  @doc """
+  Infer the conversation's `source` and `parent_conversation_id` from
+  the `X-AoD-Parent-Conversation-Id` header value (or `nil` if absent).
+  """
+  @spec infer_provenance(String.t() | nil) :: {String.t(), String.t() | nil}
+  def infer_provenance(parent_header) do
+    case parent_header do
+      id when is_binary(id) and byte_size(id) > 0 -> {"agent", id}
+      _ -> {"api", nil}
+    end
+  end
+
+  operation(:prompt,
+    summary: "Send another prompt",
+    description:
+      "Queues a new turn. If the ConversationServer has been GC'd (e.g. across a " <>
+        "BEAM restart) a fresh sprite is provisioned and the runtime resumes via its " <>
+        "session id.",
+    parameters: [conversation_id: [in: :path, type: :string, required: true]],
+    request_body: {"Prompt", "application/json", Schemas.PromptRequest},
+    responses: [
+      ok: {"Queued", "application/json", Schemas.PromptResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      bad_request: {"Busy", "application/json", Schemas.Error}
+    ]
+  )
+
+  def prompt(conn, %{"conversation_id" => id, "prompt" => prompt} = params) do
+    current_user = conn.assigns.current_user
+    images = decode_images(params["images"])
+
+    case ConversationServer.send_prompt(id, prompt, images, current_user.id) do
+      :ok -> json(conn, %{status: "queued"})
+      {:error, :not_running} -> {:error, :not_found}
+      {:error, :busy} -> {:error, "conversation_busy"}
+    end
+  end
+
+  operation(:terminate,
+    summary: "Terminate a conversation",
+    description:
+      "Tears down the sprite and marks the conversation `terminated`. Idempotent " <>
+        "for already-dead conversations.",
+    parameters: [conversation_id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Terminated",
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def terminate(conn, %{"conversation_id" => id}) do
+    current_user = conn.assigns.current_user
+
+    # Ownership check before terminating.
+    case Conversations.get_conversation(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      _conv ->
+        case ConversationServer.terminate(id) do
+          :ok -> send_resp(conn, :no_content, "")
+          {:error, :not_running} -> send_resp(conn, :no_content, "")
+        end
+    end
+  end
+
+  operation(:interrupt,
+    summary: "Interrupt the running turn",
+    parameters: [conversation_id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Interrupted",
+      not_found: {"Not found", "application/json", Schemas.Error},
+      conflict: {"No turn running", "application/json", Schemas.Error}
+    ]
+  )
+
+  def interrupt(conn, %{"conversation_id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      _conv ->
+        case ConversationServer.interrupt(id) do
+          :ok ->
+            send_resp(conn, :no_content, "")
+
+          {:error, :not_running} ->
+            {:error, :not_found}
+
+          {:error, :idle} ->
+            conn |> put_status(:conflict) |> json(%{error: "no_turn_running"})
+        end
+    end
+  end
+
+  operation(:delete,
+    summary: "Delete a conversation",
+    description:
+      "Tears down the sprite if alive, then deletes the conversation row " <>
+        "(cascades to turns and log events).",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Deleted",
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      conv ->
+        {:ok, _} = Conversations.delete_conversation(conv)
+        send_resp(conn, :no_content, "")
+    end
+  end
+
+  operation(:stream,
+    summary: "Stream log events (SSE)",
+    description:
+      "Server-Sent Events stream of the conversation's log events. The `Last-Event-ID` " <>
+        "request header resumes from a known event id; missed events are replayed before " <>
+        "the live tail begins. Keep-alive heartbeats every 15s as `: heartbeat` comments.",
+    parameters: [
+      conversation_id: [in: :path, type: :string, required: true],
+      "Last-Event-ID": [
+        in: :header,
+        type: :string,
+        required: false,
+        description:
+          "Resume after this event id (integer as string). " <>
+            "Missing or unparseable values are treated as 0."
+      ]
+    ],
+    responses: [
+      ok: {"SSE stream", "text/event-stream", %OpenApiSpex.Schema{type: :string}},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  @heartbeat_ms 15_000
+
+  def stream(conn, %{"conversation_id" => id} = params) do
+    current_user = conn.assigns.current_user
+
+    # Ownership check before subscribing. Cross-tenant access returns 404.
+    case Conversations.get_conversation(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      _ ->
+        last_event_id =
+          conn
+          |> get_req_header("last-event-id")
+          |> List.first()
+          |> parse_last_event_id()
+
+        streams = parse_streams_param(params["streams"])
+        wait? = parse_bool_param(params["wait"], true)
+
+        # Subscribe to the namespaced topic: "conv:<user_id>:<conversation_id>"
+        if wait? do
+          Phoenix.PubSub.subscribe(
+            AgentOnDemand.PubSub,
+            "conv:#{current_user.id}:#{id}"
+          )
+        end
+
+        conn =
+          conn
+          |> put_resp_header("content-type", "text/event-stream")
+          |> put_resp_header("cache-control", "no-cache")
+          |> put_resp_header("connection", "keep-alive")
+          |> send_chunked(200)
+
+        {conn, last_id} = replay(conn, id, last_event_id, streams)
+
+        if wait? do
+          Process.send_after(self(), :heartbeat, @heartbeat_ms)
+          sse_loop(conn, last_id, streams)
+        else
+          conn
+        end
+    end
+  end
+
+  defp parse_bool_param("false", _default), do: false
+  defp parse_bool_param("0", _default), do: false
+  defp parse_bool_param("true", _default), do: true
+  defp parse_bool_param("1", _default), do: true
+  defp parse_bool_param(_, default), do: default
+
+  defp parse_streams_param(nil), do: nil
+  defp parse_streams_param(""), do: nil
+
+  defp parse_streams_param(s) when is_binary(s) do
+    s |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+  end
+
+  defp decode_images(nil), do: []
+  defp decode_images([]), do: []
+
+  defp decode_images(images) when is_list(images) do
+    Enum.map(images, fn img ->
+      b64 = img["data"] || img[:data]
+      mt = img["media_type"] || img[:media_type]
+      data = Base.decode64!(b64)
+
+      if byte_size(data) > 10 * 1024 * 1024 do
+        raise ArgumentError, "Image exceeds 10MB limit"
+      end
+
+      %{media_type: mt, data: data}
+    end)
+  end
+
+  defp parse_last_event_id(nil), do: 0
+  defp parse_last_event_id(""), do: 0
+
+  defp parse_last_event_id(s) do
+    case Integer.parse(s) do
+      {n, _} -> n
+      :error -> 0
+    end
+  end
+
+  defp replay(conn, conv_id, after_id, streams) do
+    conv_id
+    |> Conversations.list_log_events(after_id, streams: streams)
+    |> Enum.reduce({conn, after_id}, fn ev, {acc_conn, _} ->
+      case write_event(acc_conn, ev) do
+        {:ok, c} -> {c, ev.id}
+        {:error, _} = e -> throw(e)
+      end
+    end)
+  end
+
+  defp event_in_streams?(_ev, nil), do: true
+
+  defp event_in_streams?(%LogEvent{kind: "stage"}, streams),
+    do: "stage" in streams
+
+  defp event_in_streams?(%LogEvent{stream: s}, streams) when is_binary(s),
+    do: s in streams
+
+  defp event_in_streams?(_ev, _streams), do: false
+
+  defp sse_loop(conn, last_id, streams) do
+    receive do
+      {:log_event, %LogEvent{id: ev_id} = ev} when ev_id > last_id ->
+        cond do
+          not event_in_streams?(ev, streams) ->
+            sse_loop(conn, ev_id, streams)
+
+          true ->
+            case write_event(conn, ev) do
+              {:ok, conn} -> sse_loop(conn, ev_id, streams)
+              {:error, _} -> conn
+            end
+        end
+
+      {:log_event, _stale} ->
+        sse_loop(conn, last_id, streams)
+
+      :heartbeat ->
+        case Plug.Conn.chunk(conn, ": heartbeat\n\n") do
+          {:ok, conn} ->
+            Process.send_after(self(), :heartbeat, @heartbeat_ms)
+            sse_loop(conn, last_id, streams)
+
+          {:error, _} ->
+            conn
+        end
+    after
+      60_000 ->
+        conn
+    end
+  end
+
+  defp write_event(conn, %LogEvent{} = ev) do
+    payload =
+      %{
+        kind: ev.kind,
+        stream: ev.stream,
+        data: ev.data,
+        stage: ev.stage,
+        state: ev.state,
+        turn_id: ev.turn_id,
+        ts: ev.inserted_at
+      }
+      |> Jason.encode!()
+
+    chunk = "id: #{ev.id}\nevent: #{ev.kind}\ndata: #{payload}\n\n"
+    Plug.Conn.chunk(conn, chunk)
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand_web/controllers/environment_controller.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand_web/controllers/environment_controller.ex
@@ -1,0 +1,113 @@
+defmodule AgentOnDemandWeb.EnvironmentController do
+  use AgentOnDemandWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias AgentOnDemand.Environments
+  alias AgentOnDemand.Environments.Environment
+  alias AgentOnDemandWeb.Schemas
+
+  action_fallback AgentOnDemandWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Environments"])
+
+  operation(:index,
+    summary: "List environments",
+    responses: [
+      ok: {"Environments", "application/json", Schemas.EnvironmentListResponse}
+    ]
+  )
+
+  def index(conn, _params) do
+    current_user = conn.assigns.current_user
+    render(conn, :index, environments: Environments.list_environments(current_user.id))
+  end
+
+  operation(:show,
+    summary: "Get an environment",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Environment", "application/json", Schemas.EnvironmentResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Environments.get_environment(id, current_user.id) do
+      nil -> {:error, :not_found}
+      env -> render(conn, :show, environment: env)
+    end
+  end
+
+  operation(:create,
+    summary: "Create an environment",
+    request_body: {"Environment attributes", "application/json", Schemas.EnvironmentRequest},
+    responses: [
+      created: {"Environment", "application/json", Schemas.EnvironmentResponse},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.ChangesetError}
+    ]
+  )
+
+  def create(conn, params) do
+    current_user = conn.assigns.current_user
+
+    with {:ok, %Environment{} = env} <- Environments.create_environment(params, current_user.id) do
+      conn
+      |> put_status(:created)
+      |> render(:show, environment: env)
+    end
+  end
+
+  operation(:update,
+    summary: "Update an environment (partial)",
+    description: "Every field is optional; the server merges into the existing record.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    request_body:
+      {"Partial environment attributes", "application/json", Schemas.EnvironmentUpdate},
+    responses: [
+      ok: {"Environment", "application/json", Schemas.EnvironmentResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.ChangesetError}
+    ]
+  )
+
+  def update(conn, %{"id" => id} = params) do
+    current_user = conn.assigns.current_user
+
+    case Environments.get_environment(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      env ->
+        with {:ok, env} <-
+               Environments.update_environment(env, Map.delete(params, "id"), current_user.id) do
+          render(conn, :show, environment: env)
+        end
+    end
+  end
+
+  operation(:delete,
+    summary: "Delete an environment",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Deleted",
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Environments.get_environment(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      env ->
+        {:ok, _} = Environments.delete_environment(env, current_user.id)
+        send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand_web/controllers/vault_controller.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand_web/controllers/vault_controller.ex
@@ -1,0 +1,112 @@
+defmodule AgentOnDemandWeb.VaultController do
+  use AgentOnDemandWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias AgentOnDemand.Vaults
+  alias AgentOnDemand.Vaults.Vault
+  alias AgentOnDemandWeb.Schemas
+
+  action_fallback AgentOnDemandWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Vaults"])
+
+  operation(:index,
+    summary: "List vaults",
+    responses: [
+      ok: {"Vaults", "application/json", Schemas.VaultListResponse}
+    ]
+  )
+
+  def index(conn, _params) do
+    current_user = conn.assigns.current_user
+    render(conn, :index, vaults: Vaults.list_vaults(current_user.id))
+  end
+
+  operation(:show,
+    summary: "Get a vault",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Vault", "application/json", Schemas.VaultResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Vaults.get_vault(id, current_user.id) do
+      nil -> {:error, :not_found}
+      vault -> render(conn, :show, vault: vault)
+    end
+  end
+
+  operation(:create,
+    summary: "Create a vault",
+    request_body: {"Vault attributes", "application/json", Schemas.VaultRequest},
+    responses: [
+      created: {"Vault", "application/json", Schemas.VaultResponse},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.ChangesetError}
+    ]
+  )
+
+  def create(conn, params) do
+    current_user = conn.assigns.current_user
+
+    with {:ok, %Vault{} = vault} <- Vaults.create_vault(params, current_user.id) do
+      conn
+      |> put_status(:created)
+      |> render(:show, vault: vault)
+    end
+  end
+
+  operation(:update,
+    summary: "Update a vault (partial)",
+    description: "Every field is optional; the server merges into the existing record.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    request_body: {"Partial vault attributes", "application/json", Schemas.VaultUpdate},
+    responses: [
+      ok: {"Vault", "application/json", Schemas.VaultResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.ChangesetError}
+    ]
+  )
+
+  def update(conn, %{"id" => id} = params) do
+    current_user = conn.assigns.current_user
+
+    case Vaults.get_vault(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      vault ->
+        with {:ok, vault} <-
+               Vaults.update_vault(vault, Map.delete(params, "id"), current_user.id) do
+          render(conn, :show, vault: vault)
+        end
+    end
+  end
+
+  operation(:delete,
+    summary: "Delete a vault",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Deleted",
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    current_user = conn.assigns.current_user
+
+    case Vaults.get_vault(id, current_user.id) do
+      nil ->
+        {:error, :not_found}
+
+      vault ->
+        {:ok, _} = Vaults.delete_vault(vault, current_user.id)
+        send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand_web/live/agents_live/index.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand_web/live/agents_live/index.ex
@@ -1,0 +1,288 @@
+defmodule AgentOnDemandWeb.AgentsLive.Index do
+  use AgentOnDemandWeb, :live_view
+
+  # on_mount hook provided by phase-3-foundation's auth slice.
+  # Assigns current_user to socket; redirects unauthenticated sessions to /login.
+  on_mount {AgentOnDemandWeb.UserAuth, :require_authenticated_user}
+
+  alias AgentOnDemand.Agents
+  alias AgentOnDemand.Agents.Agent
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user_id = socket.assigns.current_user.id
+    all_agents = Agents.list_agents(user_id)
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Agents")
+     |> assign(:agents, all_agents)
+     |> assign(:facet_counts, compute_facets(all_agents))
+     |> assign(:all_environments, extract_environments(all_agents))
+     |> assign(:filter_search, "")
+     |> assign(:filter_runtimes, [])
+     |> assign(:filter_env_ids, [])
+     |> assign(:filter_has_skills, false)
+     |> assign(:filter_has_mcp, false)}
+  end
+
+  @impl true
+  def handle_event("filter", params, socket) do
+    user_id = socket.assigns.current_user.id
+    search = params |> Map.get("search", "") |> String.trim()
+    runtimes = Map.get(params, "runtimes", [])
+    env_ids = Map.get(params, "env_ids", [])
+    has_skills = Map.has_key?(params, "has_skills")
+    has_mcp = Map.has_key?(params, "has_mcp")
+
+    filters = [
+      search: search,
+      runtimes: runtimes,
+      env_ids: env_ids,
+      has_skills: has_skills,
+      has_mcp: has_mcp
+    ]
+
+    {:noreply,
+     socket
+     |> assign(:filter_search, search)
+     |> assign(:filter_runtimes, runtimes)
+     |> assign(:filter_env_ids, env_ids)
+     |> assign(:filter_has_skills, has_skills)
+     |> assign(:filter_has_mcp, has_mcp)
+     |> assign(:agents, Agents.list_agents(user_id, filters))}
+  end
+
+  @impl true
+  def handle_event("clear_filters", _params, socket) do
+    user_id = socket.assigns.current_user.id
+
+    {:noreply,
+     socket
+     |> assign(:filter_search, "")
+     |> assign(:filter_runtimes, [])
+     |> assign(:filter_env_ids, [])
+     |> assign(:filter_has_skills, false)
+     |> assign(:filter_has_mcp, false)
+     |> assign(:agents, Agents.list_agents(user_id))}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    user_id = socket.assigns.current_user.id
+    agent = Agents.get_agent!(id, user_id)
+    {:ok, _} = Agents.delete_agent(agent, user_id)
+
+    all_agents = Agents.list_agents(user_id)
+    filters = current_filters(socket.assigns)
+
+    {:noreply,
+     socket
+     |> assign(:agents, Agents.list_agents(user_id, filters))
+     |> assign(:facet_counts, compute_facets(all_agents))
+     |> assign(:all_environments, extract_environments(all_agents))
+     |> put_flash(:info, "Deleted #{agent.name}")}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex gap-6 items-start">
+      <%!-- Filter sidebar --%>
+      <aside class="w-52 shrink-0 space-y-5">
+        <form phx-change="filter" phx-submit="filter" class="space-y-5">
+          <%!-- Search --%>
+          <div>
+            <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1.5">Search</p>
+            <input
+              type="text"
+              name="search"
+              value={@filter_search}
+              phx-debounce="200"
+              placeholder="Agent name…"
+              class="w-full rounded border border-zinc-300 px-2 py-1 text-sm focus:outline-none focus:border-zinc-500 bg-white"
+            />
+          </div>
+
+          <%!-- Runtime facet --%>
+          <div>
+            <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1.5">Runtime</p>
+            <div class="space-y-1.5">
+              <label :for={rt <- Agent.runtimes()} class="flex items-center justify-between gap-2 text-sm cursor-pointer">
+                <span class="flex items-center gap-1.5">
+                  <input
+                    type="checkbox"
+                    name="runtimes[]"
+                    value={rt}
+                    checked={rt in @filter_runtimes}
+                    class="rounded border-zinc-300"
+                  />
+                  {rt}
+                </span>
+                <span class="text-xs text-zinc-400">{Map.get(@facet_counts.runtimes, rt, 0)}</span>
+              </label>
+            </div>
+          </div>
+
+          <%!-- Environment facet --%>
+          <div>
+            <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1.5">Environment</p>
+            <div class="space-y-1.5">
+              <label class="flex items-center justify-between gap-2 text-sm cursor-pointer">
+                <span class="flex items-center gap-1.5">
+                  <input
+                    type="checkbox"
+                    name="env_ids[]"
+                    value="none"
+                    checked={"none" in @filter_env_ids}
+                    class="rounded border-zinc-300"
+                  />
+                  <span class="italic text-zinc-400">None</span>
+                </span>
+                <span class="text-xs text-zinc-400">{Map.get(@facet_counts.env_ids, "none", 0)}</span>
+              </label>
+              <label
+                :for={env <- @all_environments}
+                class="flex items-center justify-between gap-2 text-sm cursor-pointer"
+              >
+                <span class="flex items-center gap-1.5">
+                  <input
+                    type="checkbox"
+                    name="env_ids[]"
+                    value={env.id}
+                    checked={env.id in @filter_env_ids}
+                    class="rounded border-zinc-300"
+                  />
+                  {env.name}
+                </span>
+                <span class="text-xs text-zinc-400">{Map.get(@facet_counts.env_ids, env.id, 0)}</span>
+              </label>
+            </div>
+          </div>
+
+          <%!-- Capability facets --%>
+          <div>
+            <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1.5">Capabilities</p>
+            <div class="space-y-1.5">
+              <label class="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="has_skills"
+                  value="true"
+                  checked={@filter_has_skills}
+                  class="rounded border-zinc-300"
+                />
+                Has skills
+              </label>
+              <label class="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="has_mcp"
+                  value="true"
+                  checked={@filter_has_mcp}
+                  class="rounded border-zinc-300"
+                />
+                Has MCP servers
+              </label>
+            </div>
+          </div>
+        </form>
+
+        <button
+          :if={filters_active?(assigns)}
+          phx-click="clear_filters"
+          class="text-xs text-zinc-400 hover:text-zinc-700 underline underline-offset-2"
+        >
+          Clear all filters
+        </button>
+      </aside>
+
+      <%!-- Main content --%>
+      <div class="flex-1 min-w-0 space-y-4">
+        <div class="flex items-center justify-between">
+          <h1 class="text-2xl font-semibold">Agents</h1>
+          <.link navigate={~p"/agents/new"}><.btn>+ New agent</.btn></.link>
+        </div>
+
+        <div
+          :if={@agents == [] and not filters_active?(assigns)}
+          class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500"
+        >
+          No agents yet.
+        </div>
+
+        <div
+          :if={@agents == [] and filters_active?(assigns)}
+          class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500"
+        >
+          No agents match the current filters.
+        </div>
+
+        <table :if={@agents != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
+          <thead class="text-left text-zinc-500 border-b border-zinc-200">
+            <tr>
+              <th class="px-4 py-2">Name</th>
+              <th class="px-4 py-2">Runtime</th>
+              <th class="px-4 py-2">Model</th>
+              <th class="px-4 py-2">Env</th>
+              <th class="px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={a <- @agents} class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50">
+              <td class="px-4 py-2 font-medium">{a.name}</td>
+              <td class="px-4 py-2 text-zinc-600">{a.runtime}</td>
+              <td class="px-4 py-2 text-zinc-600 font-mono text-xs">{a.model}</td>
+              <td class="px-4 py-2 text-zinc-600">{env_name(a.environment)}</td>
+              <td class="px-4 py-2 text-right space-x-2">
+                <.link navigate={~p"/agents/#{a.id}/edit"}><.btn_secondary>Edit</.btn_secondary></.link>
+                <.btn_danger phx-click="delete" phx-value-id={a.id} data-confirm="Delete agent?">Delete</.btn_danger>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    """
+  end
+
+  defp env_name(nil), do: "—"
+  defp env_name(env), do: env.name
+
+  defp compute_facets(agents) do
+    runtimes = Enum.frequencies_by(agents, & &1.runtime)
+
+    env_ids =
+      Enum.frequencies_by(agents, fn a ->
+        if a.environment_id, do: a.environment_id, else: "none"
+      end)
+
+    %{runtimes: runtimes, env_ids: env_ids}
+  end
+
+  defp extract_environments(agents) do
+    agents
+    |> Enum.map(& &1.environment)
+    |> Enum.filter(& &1)
+    |> Enum.uniq_by(& &1.id)
+    |> Enum.sort_by(& &1.name)
+  end
+
+  defp current_filters(assigns) do
+    [
+      search: assigns.filter_search,
+      runtimes: assigns.filter_runtimes,
+      env_ids: assigns.filter_env_ids,
+      has_skills: assigns.filter_has_skills,
+      has_mcp: assigns.filter_has_mcp
+    ]
+  end
+
+  defp filters_active?(assigns) do
+    assigns.filter_search != "" or
+      assigns.filter_runtimes != [] or
+      assigns.filter_env_ids != [] or
+      assigns.filter_has_skills or
+      assigns.filter_has_mcp
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand_web/live/audit_live/index.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand_web/live/audit_live/index.ex
@@ -1,0 +1,69 @@
+defmodule AgentOnDemandWeb.AuditLive.Index do
+  use AgentOnDemandWeb, :live_view
+
+  # on_mount hook provided by phase-3-foundation's auth slice.
+  # Audit log is admin-only; the auth hook enforces login, and the
+  # router pipeline will enforce admin role once that is added.
+  on_mount {AgentOnDemandWeb.UserAuth, :require_authenticated_user}
+
+  alias AgentOnDemand.Audit
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Process.send_after(self(), :tick, 5_000)
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Audit log")
+     |> assign(:events, Audit.list_recent(200))}
+  end
+
+  @impl true
+  def handle_info(:tick, socket) do
+    Process.send_after(self(), :tick, 5_000)
+    {:noreply, assign(socket, :events, Audit.list_recent(200))}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-4">
+      <h1 class="text-2xl font-semibold">Audit log</h1>
+      <p class="text-sm text-zinc-500">Last 200 state-changing API calls. Updates every 5s.</p>
+
+      <div :if={@events == []} class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500">
+        No events yet.
+      </div>
+
+      <table :if={@events != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200 font-mono">
+        <thead class="text-left text-zinc-500 border-b border-zinc-200">
+          <tr>
+            <th class="px-3 py-2">when</th>
+            <th class="px-3 py-2">actor</th>
+            <th class="px-3 py-2">action</th>
+            <th class="px-3 py-2">resource</th>
+            <th class="px-3 py-2">status</th>
+            <th class="px-3 py-2">ip</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={e <- @events} class="border-b border-zinc-100 last:border-0">
+            <td class="px-3 py-1.5 text-zinc-500 text-xs">{format_ts(e.inserted_at)}</td>
+            <td class="px-3 py-1.5">{e.actor || "—"}</td>
+            <td class="px-3 py-1.5">{e.action}</td>
+            <td class="px-3 py-1.5">
+              {e.resource_type}
+              <span :if={e.resource_id} class="text-zinc-400">/{String.slice(e.resource_id, 0, 8)}</span>
+            </td>
+            <td class="px-3 py-1.5">{e.metadata["status"] || "—"}</td>
+            <td class="px-3 py-1.5 text-zinc-500">{e.request_ip || "—"}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  defp format_ts(nil), do: ""
+  defp format_ts(dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S")
+end

--- a/apps/agent_on_demand/lib/agent_on_demand_web/live/conversations_live/index.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand_web/live/conversations_live/index.ex
@@ -1,0 +1,245 @@
+defmodule AgentOnDemandWeb.ConversationsLive.Index do
+  use AgentOnDemandWeb, :live_view
+
+  # on_mount hook provided by phase-3-foundation's auth slice.
+  on_mount {AgentOnDemandWeb.UserAuth, :require_authenticated_user}
+
+  alias AgentOnDemand.{Agents, Conversations}
+
+  @poll_interval 2_000
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Process.send_after(self(), :tick, @poll_interval)
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Conversations")
+     |> assign(:sort_by, :inserted_at)
+     |> assign(:sort_dir, :desc)
+     |> load_data()}
+  end
+
+  @impl true
+  def handle_info(:tick, socket) do
+    Process.send_after(self(), :tick, @poll_interval)
+    {:noreply, load_data(socket)}
+  end
+
+  @impl true
+  def handle_event("terminate", %{"id" => id}, socket) do
+    user_id = socket.assigns.current_user.id
+
+    case Conversations.get_conversation(id, user_id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "Not found")}
+
+      _conv ->
+        case AgentOnDemand.Conversations.ConversationServer.terminate(id) do
+          :ok -> {:noreply, socket |> put_flash(:info, "Terminated") |> load_data()}
+          _ -> {:noreply, put_flash(socket, :error, "Not running")}
+        end
+    end
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    user_id = socket.assigns.current_user.id
+
+    case Conversations.get_conversation(id, user_id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "Not found")}
+
+      conv ->
+        {:ok, _} = Conversations.delete_conversation(conv)
+        {:noreply, socket |> put_flash(:info, "Deleted") |> load_data()}
+    end
+  end
+
+  def handle_event("sort", %{"by" => field_str}, socket) do
+    field = parse_sort_field(field_str)
+
+    {sort_by, sort_dir} =
+      if socket.assigns.sort_by == field do
+        {field, toggle_dir(socket.assigns.sort_dir)}
+      else
+        {field, :desc}
+      end
+
+    {:noreply,
+     socket
+     |> assign(sort_by: sort_by, sort_dir: sort_dir)
+     |> load_data()}
+  end
+
+  defp load_data(socket) do
+    user_id = socket.assigns.current_user.id
+    convs = Conversations.list_conversations_by_activity(user_id)
+    agents = Agents.list_agents(user_id)
+
+    sorted = sort_conversations(convs, socket.assigns.sort_by, socket.assigns.sort_dir)
+
+    assign(socket,
+      conversations: sorted,
+      agents_by_id: Map.new(agents, &{&1.id, &1})
+    )
+  end
+
+  @epoch ~U[0000-01-01 00:00:00Z]
+
+  defp sort_conversations(convs, field, :asc) do
+    Enum.sort_by(convs, &(Map.get(&1, field) || @epoch), DateTime)
+  end
+
+  defp sort_conversations(convs, field, :desc) do
+    Enum.sort_by(convs, &(Map.get(&1, field) || @epoch), {:desc, DateTime})
+  end
+
+  defp toggle_dir(:asc), do: :desc
+  defp toggle_dir(:desc), do: :asc
+
+  defp parse_sort_field("inserted_at"), do: :inserted_at
+  defp parse_sort_field("updated_at"), do: :updated_at
+  defp parse_sort_field(_), do: :inserted_at
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold">Conversations</h1>
+        <.link navigate={~p"/conversations/new"}>
+          <.btn>+ New conversation</.btn>
+        </.link>
+      </div>
+
+      <div :if={@conversations == []} class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500">
+        No conversations yet. Start one to see it here.
+      </div>
+
+      <table :if={@conversations != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200 table-fixed">
+        <thead class="text-left text-xs uppercase tracking-wide text-zinc-500 border-b border-zinc-200">
+          <tr>
+            <th class="w-20 px-3 py-1.5 font-medium">Status</th>
+            <th class="px-3 py-1.5 font-medium">Task</th>
+            <th class="w-40 px-3 py-1.5 font-medium">Agent</th>
+            <th class="w-20 px-3 py-1.5 font-medium">Runtime</th>
+            <th class="w-16 px-3 py-1.5 font-medium">Source</th>
+            <th
+              class={["w-24 px-3 py-1.5 font-medium cursor-pointer select-none whitespace-nowrap", @sort_by == :inserted_at && "text-zinc-900"]}
+              phx-click="sort"
+              phx-value-by="inserted_at"
+            >Started {sort_arrow(@sort_by, @sort_dir, :inserted_at)}</th>
+            <th
+              class={["w-28 px-3 py-1.5 font-medium cursor-pointer select-none whitespace-nowrap", @sort_by == :updated_at && "text-zinc-900"]}
+              phx-click="sort"
+              phx-value-by="updated_at"
+            >Last active {sort_arrow(@sort_by, @sort_dir, :updated_at)}</th>
+            <th class="w-44 px-3 py-1.5"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={c <- @conversations} class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50 align-top">
+            <td class="px-3 py-2"><.status_badge status={c.status} /></td>
+            <td class="px-3 py-2 text-zinc-700 leading-snug">
+              <%= case first_prompt(c) do %>
+                <% nil -> %><span class="text-zinc-400">—</span>
+                <% prompt -> %><div class="line-clamp-3" title={prompt}>{prompt}</div>
+              <% end %>
+            </td>
+            <td class="px-3 py-2 truncate">
+              <.link navigate={~p"/conversations/#{c.id}"} class="block truncate text-zinc-900 hover:underline font-medium">
+                {agent_name(@agents_by_id, c.agent_id)}
+              </.link>
+              <div class="text-xs text-zinc-400 font-mono">{short(c.id)}</div>
+            </td>
+            <td class="px-3 py-2 text-zinc-600 truncate">{c.runtime}</td>
+            <td class="px-3 py-2"><.source_badge source={c.source} /></td>
+            <td class="px-3 py-2 text-zinc-500 whitespace-nowrap">{relative_time(c.inserted_at)}</td>
+            <td class="px-3 py-2 text-zinc-500 whitespace-nowrap">{relative_time(c.updated_at)}</td>
+            <td class="px-3 py-2 text-right whitespace-nowrap">
+              <div class="inline-flex gap-1">
+                <.btn_danger :if={c.status not in ["terminated", "completed", "failed"]}
+                  class="!px-2 !py-1 !text-xs"
+                  phx-click="terminate" phx-value-id={c.id}
+                  data-confirm="Terminate this conversation?">
+                  Terminate
+                </.btn_danger>
+                <.btn_secondary class="!px-2 !py-1 !text-xs"
+                  phx-click="delete" phx-value-id={c.id}
+                  data-confirm="Delete this conversation and all its turns? This cannot be undone.">
+                  Delete
+                </.btn_secondary>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  defp agent_name(_agents_by_id, nil), do: "(no agent)"
+
+  defp agent_name(agents_by_id, id) do
+    case Map.get(agents_by_id, id) do
+      nil -> "(deleted agent)"
+      a -> a.name
+    end
+  end
+
+  defp short(id), do: binary_part(id, 0, 8)
+
+  defp relative_time(nil), do: ""
+
+  defp relative_time(dt) do
+    secs = max(0, DateTime.diff(DateTime.utc_now(), dt))
+
+    cond do
+      secs < 60 -> "#{secs}s ago"
+      secs < 3600 -> "#{div(secs, 60)}m ago"
+      secs < 86_400 -> "#{div(secs, 3600)}h ago"
+      true -> "#{div(secs, 86_400)}d ago"
+    end
+  end
+
+  defp first_prompt(conv) do
+    case conv.turns do
+      %Ecto.Association.NotLoaded{} -> nil
+      [] -> nil
+      [%{prompt: prompt} | _] ->
+        prompt |> String.trim() |> String.replace(~r/\s+/, " ")
+    end
+  end
+
+  defp sort_arrow(current, dir, field) when current == field do
+    if dir == :asc, do: "↑", else: "↓"
+  end
+
+  defp sort_arrow(_current, _dir, _field), do: "↕"
+
+  attr :source, :string, default: "api"
+
+  defp source_badge(%{source: "ui"} = assigns) do
+    ~H"""
+    <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium bg-blue-50 text-blue-700 border border-blue-200">
+      UI
+    </span>
+    """
+  end
+
+  defp source_badge(%{source: "agent"} = assigns) do
+    ~H"""
+    <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium bg-amber-50 text-amber-700 border border-amber-200">
+      Agent
+    </span>
+    """
+  end
+
+  defp source_badge(assigns) do
+    ~H"""
+    <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium bg-zinc-100 text-zinc-500 border border-zinc-200">
+      API
+    </span>
+    """
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand_web/live/environments_live/index.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand_web/live/environments_live/index.ex
@@ -1,0 +1,78 @@
+defmodule AgentOnDemandWeb.EnvironmentsLive.Index do
+  use AgentOnDemandWeb, :live_view
+
+  # on_mount hook provided by phase-3-foundation's auth slice.
+  on_mount {AgentOnDemandWeb.UserAuth, :require_authenticated_user}
+
+  alias AgentOnDemand.Environments
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user_id = socket.assigns.current_user.id
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Environments")
+     |> assign(:envs, list_envs(user_id))}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    user_id = socket.assigns.current_user.id
+    env = Environments.get_environment!(id, user_id)
+    {:ok, _} = Environments.delete_environment(env, user_id)
+
+    {:noreply,
+     socket
+     |> assign(:envs, list_envs(user_id))
+     |> put_flash(:info, "Deleted #{env.name}")}
+  end
+
+  defp list_envs(user_id) do
+    user_id
+    |> Environments.list_environments()
+    |> Enum.map(fn env ->
+      Map.put(env, :secret_count, length(Environments.list_secrets(env)))
+    end)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold">Environments</h1>
+        <.link navigate={~p"/environments/new"}><.btn>+ New environment</.btn></.link>
+      </div>
+
+      <div :if={@envs == []} class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500">
+        No environments yet.
+      </div>
+
+      <table :if={@envs != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
+        <thead class="text-left text-zinc-500 border-b border-zinc-200">
+          <tr>
+            <th class="px-4 py-2">Name</th>
+            <th class="px-4 py-2">Setup</th>
+            <th class="px-4 py-2">Secrets</th>
+            <th class="px-4 py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={e <- @envs} class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50">
+            <td class="px-4 py-2 font-medium">{e.name}</td>
+            <td class="px-4 py-2 text-zinc-600 font-mono text-xs truncate max-w-xs">
+              {if e.setup_script == "", do: "—", else: e.setup_script}
+            </td>
+            <td class="px-4 py-2 text-zinc-600">{e.secret_count}</td>
+            <td class="px-4 py-2 text-right space-x-2">
+              <.link navigate={~p"/environments/#{e.id}/edit"}><.btn_secondary>Edit</.btn_secondary></.link>
+              <.btn_danger phx-click="delete" phx-value-id={e.id} data-confirm="Delete environment?">Delete</.btn_danger>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+end

--- a/apps/agent_on_demand/lib/agent_on_demand_web/live/vaults_live/index.ex
+++ b/apps/agent_on_demand/lib/agent_on_demand_web/live/vaults_live/index.ex
@@ -1,0 +1,83 @@
+defmodule AgentOnDemandWeb.VaultsLive.Index do
+  use AgentOnDemandWeb, :live_view
+
+  # on_mount hook provided by phase-3-foundation's auth slice.
+  on_mount {AgentOnDemandWeb.UserAuth, :require_authenticated_user}
+
+  alias AgentOnDemand.Vaults
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user_id = socket.assigns.current_user.id
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Vaults")
+     |> assign(:vaults, list_vaults(user_id))}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    user_id = socket.assigns.current_user.id
+    vault = Vaults.get_vault!(id, user_id)
+    {:ok, _} = Vaults.delete_vault(vault, user_id)
+
+    {:noreply,
+     socket
+     |> assign(:vaults, list_vaults(user_id))
+     |> put_flash(:info, "Deleted #{vault.name}")}
+  end
+
+  defp list_vaults(user_id) do
+    user_id
+    |> Vaults.list_vaults()
+    |> Enum.map(fn vault ->
+      Map.put(vault, :secret_count, length(Vaults.list_secrets(vault)))
+    end)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold">Vaults</h1>
+        <.link navigate={~p"/vaults/new"}><.btn>+ New vault</.btn></.link>
+      </div>
+
+      <p class="text-sm text-zinc-500 max-w-2xl">
+        A <strong>vault</strong> is a bag of env-var overrides — your credentials, a teammate's, or a virtual identity.
+        Pick one when starting a conversation and its values override the environment's baseline secrets at sprite spawn.
+      </p>
+
+      <div :if={@vaults == []} class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500">
+        No vaults yet.
+      </div>
+
+      <table :if={@vaults != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
+        <thead class="text-left text-zinc-500 border-b border-zinc-200">
+          <tr>
+            <th class="px-4 py-2">Name</th>
+            <th class="px-4 py-2">Description</th>
+            <th class="px-4 py-2">Secrets</th>
+            <th class="px-4 py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={v <- @vaults} class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50">
+            <td class="px-4 py-2 font-medium">{v.name}</td>
+            <td class="px-4 py-2 text-zinc-600 truncate max-w-md">
+              {if v.description == "", do: "—", else: v.description}
+            </td>
+            <td class="px-4 py-2 text-zinc-600">{v.secret_count}</td>
+            <td class="px-4 py-2 text-right space-x-2">
+              <.link navigate={~p"/vaults/#{v.id}/edit"}><.btn_secondary>Edit</.btn_secondary></.link>
+              <.btn_danger phx-click="delete" phx-value-id={v.id} data-confirm="Delete vault?">Delete</.btn_danger>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+end


### PR DESCRIPTION
## Merge order

**`phase-3-foundation` has not yet merged into `main`.** This PR is opened against `main` as the brief directs, but it must be rebased on top of `phase-3-foundation` before it can land. The integration points are documented below under _Foundation dependencies_.

---

## What this PR does

This is the **tenant-context scoping** slice of the G2 build (engineering plan §3.1–3.4, §4.1, §5.1). It makes every data-access function in the four context modules (`Environments`, `Agents`, `Vaults`, `Conversations`) aware of `user_id`, closes the cross-tenant read path, wires quota enforcement and billing events into `ConversationServer`, and gates every LiveView and REST controller behind the authenticated user.

### Changed files at a glance

| Layer | File(s) | What changed |
|---|---|---|
| Schemas | `agents/agent.ex`, `environments/environment.ex`, `vaults/vault.ex`, `conversations/conversation.ex`, `conversations/sandbox.ex` | Added `field :user_id, :binary_id`; unique constraints changed from global to `[:user_id, :name]` |
| Crypto helpers | `environments/secret.ex`, `vaults/vault_secret.ex` | Added `decrypt/2` overloads that accept an explicit per-tenant DEK |
| Contexts | `agents.ex`, `environments.ex`, `vaults.ex`, `conversations.ex` | All list/get/create/update/delete functions now require and enforce `user_id`; `decrypted_env/2` overloads added |
| New modules | `quotas.ex`, `billing.ex` | `Quotas.check_sandbox_quota!/1`, `Billing.emit/5` |
| GenServer | `conversations/conversation_server.ex` | `user_id` + `tenant_key` in state; DEK loaded in `init/1`, zeroed in `terminate/2`; PubSub topic `"conv:<user_id>:<conv_id>"`; quota check before sprite create; `Billing.emit` at three points |
| Rehydrator | `conversations/rehydrator.ex` | Passes `user_id: conv.user_id` when starting ConversationServer on boot |
| REST controllers | `conversation_controller.ex`, `agent_controller.ex`, `environment_controller.ex`, `vault_controller.ex` | All actions read `conn.assigns.current_user` and thread `current_user.id` into context calls |
| LiveViews | `agents_live/index.ex`, `conversations_live/index.ex`, `environments_live/index.ex`, `vaults_live/index.ex`, `audit_live/index.ex` | `on_mount {AgentOnDemandWeb.UserAuth, :require_authenticated_user}`; all context calls scoped to `current_user.id` |

---

## Key design decisions

**Cross-tenant reads return 404, not 403.** `get_*!(id, user_id)` uses `Repo.get_by!` which raises `Ecto.NoResultsError` when the row exists but belongs to another user. The fallback controller maps this to 404. This avoids leaking existence.

**`start_conversation/2` validates agent and vault ownership.** The `with` pipeline pattern-matches `%Agent{user_id: ^user_id}` so an agent from a different tenant cannot be used, even if the caller fabricates a valid UUID.

**`get_conversation_internal!/1`** is a new 1-arg internal getter for use inside `ConversationServer` (which already has a user-scoped conversation by construction). All public-facing calls use the 2-arg `get_conversation!/2`.

**`merge_secrets/3` passes the tenant DEK.** `Environments.decrypted_env/2` and `Vaults.decrypted_env/2` accept an explicit DEK and route to `Secret.decrypt/2` / `VaultSecret.decrypt/2`, keeping per-tenant keys on the per-tenant path and away from the platform key.

**PubSub topic is `"conv:<user_id>:<conversation_id>"`** throughout: `publish_stage`, `log_output` in `ConversationServer`, and the `subscribe` call in `ConversationController.stream/2`. The SSE controller also verifies ownership before subscribing.

**Sandbox naming** changed from `aod-conv-<short-id>` to `fountain-conv-<short-id>` per decision 0005.

---

## Foundation dependencies

This PR depends on the following additions from `phase-3-foundation` (not yet merged):

| Symbol | Used in | Provided by |
|---|---|---|
| `AgentOnDemand.Crypto.load_tenant_key/1` | `ConversationServer.init/1` | foundation — loads the per-tenant DEK from `user_data_keys` |
| `AgentOnDemand.Crypto.decrypt/2` | `Secret.decrypt/2`, `VaultSecret.decrypt/2` | foundation — AES-GCM decrypt with explicit key |
| `AgentOnDemand.Accounts.get_user!/1` | `Quotas.check_sandbox_quota!/1` | foundation — fetches user row including `max_concurrent_sandboxes` |
| `users.max_concurrent_sandboxes` column | `Quotas` | foundation migration |
| `user_id` FK columns on all five tables | every context `where` clause | foundation migration |
| `usage_events` table | `Billing.emit/5` | foundation (or billing) migration |
| `AgentOnDemandWeb.UserAuth` on_mount hook | all LiveViews | foundation auth slice |
| `conn.assigns.current_user` | all controllers | foundation auth plug |

---

## Acceptance checklist

- [x] Every context function in Environments, Agents, Vaults, Conversations accepts and enforces `user_id`
- [x] `get_*!(id, wrong_user_id)` raises `Ecto.NoResultsError` (→ 404)
- [x] `start_conversation/2` validates `agent.user_id == user_id` and `vault.user_id == user_id`
- [x] `ConversationServer` loads and stores per-tenant DEK in `init/1`, passes to `merge_secrets/3`
- [x] DEK zeroed in `terminate/2`
- [x] `Fountain.Quotas.check_sandbox_quota!/1` raises `QuotaExceededError` when count >= cap
- [x] `Fountain.Billing.emit/5` writes a `usage_events` row
- [x] Three emission points: `sandbox_provisioned`, `turn_started`, `sandbox_terminated`
- [x] PubSub topic is `"conv:<user_id>:<conversation_id>"` in broadcast and SSE subscribe
- [x] SSE `stream/2` verifies ownership before subscribing
- [x] All LiveViews use `on_mount :require_authenticated_user`
- [x] Rehydrator passes `user_id: conv.user_id` to ConversationServer

## Out of scope (per brief)

- Auth plugs, registration, session controller — `phase-3-auth`
- Migrations — `phase-3-foundation`
- `Billing.assert_active!/1` / Stripe gate — `phase-3-billing`
- New LiveViews (onboarding, log viewer, billing UI, API keys) — later slices