### PR TITLE
fix(render): migrate Postgres plan from legacy 'starter' to 'basic-256mb'

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -66,7 +66,7 @@ services:
 
 databases:
   - name: fountain-db
-    plan: starter
+    plan: basic-256mb
     region: oregon
     databaseName: fountain
     user: fountain


### PR DESCRIPTION
## Summary

Render no longer accepts the legacy \`starter\` Postgres plan for new databases ([Render docs](https://render.com/docs/postgresql-legacy-instance-types)). Deploy was failing with: *Legacy Postgres plans, including 'starter', are no longer supported for new databases.*

\`basic-256mb\` is the closest current equivalent — same 256 MB RAM tier as legacy \`starter\`, smallest paid tier. Sufficient for the 100-WAU launch target per ADR 0004; upgrade to \`basic-1gb\` or a \`pro-*\` tier when growth warrants it.

## Test plan

- [ ] Render Blueprint validates the YAML
- [ ] First deploy provisions the database without the legacy-plan error

🤖 Generated with [Claude Code](https://claude.com/claude-code)