### PR TITLE
fix(S1/S4): correct onboarding redirect path from step/1 to step_1

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
@@ -45,7 +45,7 @@ defmodule FountainWeb.EmailVerificationController do
 
                 conn
                 |> log_in_user(verified_user)
-                |> redirect(to: "/onboarding/step/1")
+                |> redirect(to: ~p"/onboarding/step_1")
 
               {:error, _changeset} ->
                 conn
@@ -79,7 +79,7 @@ defmodule FountainWeb.EmailVerificationController do
     if user.onboarding_completed_at do
       ~p"/"
     else
-      "/onboarding/step/1"
+      ~p"/onboarding/step_1"
     end
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/session_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/session_controller.ex
@@ -82,7 +82,7 @@ defmodule FountainWeb.SessionController do
     if user.onboarding_completed_at do
       ~p"/"
     else
-      "/onboarding/step/1"
+      ~p"/onboarding/step_1"
     end
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
@@ -57,7 +57,7 @@ defmodule FountainWeb.UeberauthController do
           |> configure_session(renew: true)
           |> put_session(:user_id, user.id)
           |> put_session(:session_version, user.session_version)
-          |> redirect(to: "/onboarding/step/1")
+          |> redirect(to: ~p"/onboarding/step_1")
 
         {:ok, user, :existing} ->
           conn


### PR DESCRIPTION
## Summary

Critical bug fix found during phase-3 release validation (S1, S3, S4).

The router registers `/onboarding/:step` where valid step values are `step_1`, `step_2`, `step_3` (underscore-separated, 2-segment paths). Three controllers were redirecting new users to the string literal `\"/onboarding/step/1\"` — a 3-segment path that produces a 404.

**Impact:** Every new user (email/password registration and GitHub OAuth) receives a 404 page after completing email verification or OAuth login, instead of landing on the onboarding wizard. No new user could complete onboarding without manually navigating to `/onboarding/step_1`.

## Changes

Three files — minimal, surgical:

| File | Change |
|------|--------|
| `session_controller.ex` | `after_login_path/1`: `\"/onboarding/step/1\"` → `~p\"/onboarding/step_1\"` |
| `email_verification_controller.ex` | `confirm/2` and `destination/1`: same fix (2 occurrences) |
| `ueberauth_controller.ex` | `callback/2` for new OAuth users: same fix |

All other redirect paths in these files already use verified `~p\"...\"` sigils — only the onboarding path was using an unverified bare string.

## Test plan

- [ ] `mix test apps/fountain` — existing controller tests should pass; the corrected path is what `onboarding_live_test.exs` already uses (`~p\"/onboarding/step_1\"`)
- [ ] Manual: register a new account, verify email, confirm landing on `/onboarding/step_1`
- [ ] Manual: GitHub OAuth new user, confirm landing on `/onboarding/step_1`
- [ ] Manual: email/password login for a user with incomplete onboarding, confirm landing on `/onboarding/step_1`

Ref: phase-3-release-validation report, BUG-2.