### PR TITLE
chore(render): attach fountain-prod-core env group to web service

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -19,6 +19,10 @@ projects:
             healthCheckPath: /health
 
             envVars:
+              # Shared secrets + config from the dashboard-managed env group.
+              # Service-local envVars below override any same-named keys in the group.
+              - fromGroup: fountain-prod-core
+
               - key: PHX_SERVER
                 value: "true"
               - key: FOUNTAIN_DOMAIN


### PR DESCRIPTION
## Summary

Adds \`- fromGroup: fountain-prod-core\` to the web service's \`envVars\` in \`render.yaml\` so it inherits variables from the dashboard-managed env group of that name.

The group is referenced (not redefined). It must already exist in the Render workspace — which it does, per the request.

## Behavior on key collisions

Per Render's docs, **service-local \`envVars\` override same-named keys from a \`fromGroup\`**. This means the existing \`sync: false\` placeholders below (\`MASTER_SECRETS_KEY\`, \`SPRITES_TOKEN\`, \`STRIPE_*\`, \`SMTP_*\`, etc.) keep their dashboard-managed values; the env group only fills in keys the service doesn't already declare.

If \`fountain-prod-core\` already holds the same secrets that are listed as service-local \`sync: false\` placeholders, those placeholders become redundant and could be removed in a follow-up to avoid two sources of truth. I left them in for now since I don't know what's in the group — happy to clean them up in a follow-up PR if you confirm what overlaps.

## Test plan

- [ ] Render Blueprint sync accepts the new \`fromGroup\` reference
- [ ] Web service shows the env group as linked in the dashboard after sync
- [ ] No service env vars regress (collision behavior matches expectation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)