### PR TITLE
fix: add POST /api/auth/token endpoint for CLI login

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
@@ -1,0 +1,41 @@
+defmodule FountainWeb.AuthTokenController do
+  @moduledoc """
+  POST /api/auth/token
+
+  Exchanges email + password for a fresh API key. Used by `fountain auth login`.
+  Rate-limited to 10 attempts per IP per hour.
+  """
+
+  use FountainWeb, :controller
+
+  alias Fountain.Accounts
+
+  plug FountainWeb.Plugs.RateLimit,
+       [bucket: "auth_token", max: 10, window_ms: 3_600_000]
+       when action in [:create]
+
+  def create(conn, %{"email" => email, "password" => password})
+      when is_binary(email) and is_binary(password) do
+    case Accounts.authenticate_user(email, password) do
+      {:ok, user} ->
+        name = "CLI login \u2014 #{DateTime.utc_now() |> DateTime.to_date()}"
+
+        {:ok, {api_key, raw_key}} = Accounts.create_api_key(user.id, name)
+
+        conn
+        |> put_status(:created)
+        |> json(%{api_key: raw_key, key_id: api_key.id, prefix: api_key.key_prefix})
+
+      {:error, _} ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "Invalid email or password"})
+    end
+  end
+
+  def create(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "email and password are required"})
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -100,6 +100,7 @@ defmodule FountainWeb.Router do
   scope "/api/auth", FountainWeb do
     pipe_through :api_public
 
+    post "/token", AuthTokenController, :create
     post "/register", RegistrationController, :api_create
     post "/forgot", PasswordResetController, :api_forgot
   end

--- a/apps/fountain/test/fountain_web/controllers/auth_token_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_token_controller_test.exs
@@ -1,0 +1,64 @@
+defmodule FountainWeb.AuthTokenControllerTest do
+  # async: false because the rate-limit ETS table is global state
+  use FountainWeb.ConnCase, async: false
+
+  describe "POST /api/auth/token" do
+    test "returns 201 with api_key on valid credentials", %{conn: conn} do
+      user = insert_verified_user(%{"email" => "login#{System.unique_integer()}@example.com", "password" => "password123"})
+
+      conn = post_json(conn, "/api/auth/token", %{email: user.email, password: "password123"})
+
+      assert %{"api_key" => key, "key_id" => _id, "prefix" => prefix} = json_response(conn, 201)
+      assert is_binary(key)
+      assert String.starts_with?(key, "ftn_")
+      assert String.starts_with?(prefix, "ftn_")
+    end
+
+    test "returns 401 on wrong password", %{conn: conn} do
+      user = insert_verified_user(%{"email" => "login#{System.unique_integer()}@example.com", "password" => "password123"})
+
+      conn = post_json(conn, "/api/auth/token", %{email: user.email, password: "wrongpassword"})
+
+      assert %{"error" => "Invalid email or password"} = json_response(conn, 401)
+    end
+
+    test "returns 401 on unknown email", %{conn: conn} do
+      conn = post_json(conn, "/api/auth/token", %{email: "nobody@example.com", password: "password123"})
+
+      assert %{"error" => "Invalid email or password"} = json_response(conn, 401)
+    end
+
+    test "api_key from response can authenticate GET /api/auth/me", %{conn: conn} do
+      user = insert_verified_user(%{"email" => "login#{System.unique_integer()}@example.com", "password" => "password123"})
+
+      %{"api_key" => raw_key} =
+        conn
+        |> post_json("/api/auth/token", %{email: user.email, password: "password123"})
+        |> json_response(201)
+
+      me_conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/auth/me")
+
+      assert %{"email" => email} = json_response(me_conn, 200)
+      assert email == user.email
+    end
+
+    test "returns 422 when email or password missing", %{conn: conn} do
+      conn = post_json(conn, "/api/auth/token", %{email: "only@example.com"})
+      assert json_response(conn, 422)
+    end
+  end
+
+  describe "rate limiting" do
+    test "blocks 11th attempt from same IP within the hour", %{conn: conn} do
+      for _ <- 1..10 do
+        post_json(conn, "/api/auth/token", %{email: "x@example.com", password: "wrong"})
+      end
+
+      conn11 = post_json(conn, "/api/auth/token", %{email: "x@example.com", password: "wrong"})
+      assert conn11.status == 429
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`fountain auth login` calls `POST /api/auth/token` but the route didn't exist — every CLI login attempt returned 404, breaking `fountain auth whoami`, `fountain run`, and all credential-dependent commands.

## Changes

**3 files, minimal surface:**

- `router.ex` — adds `post "/token", AuthTokenController, :create` to the existing `api_public` scope at `/api/auth` (same scope as `/api/auth/register` and `/api/auth/forgot`)
- `auth_token_controller.ex` — new controller: accepts `{email, password}` JSON, delegates to the already-present `Accounts.authenticate_user/2` and `Accounts.create_api_key/2`, rate-limited to 10 attempts/IP/hour via the existing `RateLimit` plug
- `auth_token_controller_test.exs` — tests: valid creds → 201 + `api_key`; wrong password → 401; unknown email → 401; returned key authenticates `GET /api/auth/me` → 200; 11th attempt → 429

## Response shape

```json
{ "api_key": "ftn_...", "key_id": "<uuid>", "prefix": "ftn_xxxx" }
```

The CLI's `handle_login_response/4` already handles the top-level `"api_key"` key.

## Notes

- `Accounts.authenticate_user/2` already existed with timing-safe `Bcrypt.no_user_verify()` guard — no changes needed to the Accounts context
- `async: false` on the test module because the rate-limit ETS table is global state