### PR TITLE
chore(render): point FOUNTAIN_DOMAIN at fountain.inevitable.fyi

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -26,7 +26,7 @@ projects:
               - key: PHX_SERVER
                 value: "true"
               - key: FOUNTAIN_DOMAIN
-                value: fountain.onrender.com
+                value: fountain.inevitable.fyi
               - key: PORT
                 value: "10000"
 


### PR DESCRIPTION
## Summary

Updates \`FOUNTAIN_DOMAIN\` from \`fountain.onrender.com\` to \`fountain.inevitable.fyi\` in \`render.yaml\`.

## Follow-ups worth considering (not in this PR)

- **Custom domain in Render.** The YAML env var sets the host the app uses to generate URLs (LiveView host, callback URLs, OAuth redirects), but Render also needs the custom domain attached to the service from the dashboard, plus a CNAME from \`fountain.inevitable.fyi\` to the Render-provided target.
- **\`EMAIL_FROM\` still defaults to \`noreply@fountain.dev\`** (from PR #19). If you'd rather send from \`noreply@inevitable.fyi\` (or another address on a domain you control), update \`render.yaml\`'s \`EMAIL_FROM\` and verify that domain in Resend with SPF/DKIM/DMARC.
- **GitHub OAuth callback URL** registered with GitHub may still point at the old hostname — needs an update in the GitHub OAuth app settings.
- **Stripe webhook endpoint** registered with Stripe may also need its URL updated.

## Test plan

- [ ] Deploy succeeds with the new value
- [ ] LiveView assets load from \`fountain.inevitable.fyi\` after DNS + Render custom-domain attach

🤖 Generated with [Claude Code](https://claude.com/claude-code)