### PR TITLE
chore(render): set EMAIL_FROM to noreply@updates.inevitable.fyi

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -56,7 +56,7 @@ projects:
               - key: RESEND_API_KEY
                 sync: false
               - key: EMAIL_FROM
-                value: noreply@fountain.dev
+                value: noreply@updates.inevitable.fyi
 
               - key: ELIXIR_VERSION
                 value: "1.18.4"


### PR DESCRIPTION
## Summary

Sets the prod \`EMAIL_FROM\` to \`noreply@updates.inevitable.fyi\` so verification and password-reset emails come from a domain you control.

## Resend setup that needs to match

\`updates.inevitable.fyi\` (a subdomain) must be verified in Resend with SPF/DKIM/DMARC records. Resend supports subdomain sender identities — the typical setup is to verify \`updates.inevitable.fyi\` specifically (not the apex), which keeps marketing/transactional sender reputation isolated from any other use of the apex domain. Resend's UI generates the exact records when you add the domain.

## Followups not in this PR (flagging for visibility)

- \`config/runtime.exs:111\` and \`apps/fountain/lib/fountain/emails/user_emails.ex:59\` still default to \`noreply@fountain.dev\` if \`EMAIL_FROM\` is unset. Prod always sets it via this YAML, so the default only matters in dev/test/edge cases. Worth updating to \`noreply@updates.inevitable.fyi\` (or \`noreply@example.com\`) for consistency — happy to do that as a follow-up.
- \`.env.example\` still shows \`EMAIL_FROM=noreply@fountain.dev\`. Same call.

## Test plan

- [ ] Render redeploys with the new value
- [ ] After Resend domain verification: registration → email arrives from \`noreply@updates.inevitable.fyi\` and lands in inbox (not spam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)