### PR TITLE
chore(email): align EMAIL_FROM defaults with updates.inevitable.fyi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,10 @@ STRIPE_PUBLISHABLE_KEY=
 STRIPE_WEBHOOK_SECRET=
 
 # Resend for transactional email (Swoosh.Adapters.Resend).
-# Domain (fountain.dev) must be verified in Resend with SPF/DKIM/DMARC
+# Domain (updates.inevitable.fyi) must be verified in Resend with SPF/DKIM/DMARC
 # DNS records before EMAIL_FROM can deliver to arbitrary inboxes.
 RESEND_API_KEY=
-EMAIL_FROM=noreply@fountain.dev
+EMAIL_FROM=noreply@updates.inevitable.fyi
 
 # Claude auth — set EITHER one. CLAUDE_CODE_OAUTH_TOKEN takes precedence
 # and bills against a Claude.ai Pro/Team subscription (cheaper for

--- a/apps/fountain/lib/fountain/emails/user_emails.ex
+++ b/apps/fountain/lib/fountain/emails/user_emails.ex
@@ -56,7 +56,7 @@ defmodule Fountain.Emails.UserEmails do
   ## Private helpers
 
   defp from_address do
-    addr = Application.get_env(:fountain, :email_from, "noreply@fountain.dev")
+    addr = Application.get_env(:fountain, :email_from, "noreply@updates.inevitable.fyi")
     {addr, addr}
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -106,10 +106,10 @@ config :stripity_stripe,
   webhook_secret: System.get_env("STRIPE_WEBHOOK_SECRET")
 
 # Swoosh Resend adapter for prod; overridden to Local/Test in dev/test via env configs.
-# Domain (fountain.dev) must be verified in Resend with SPF/DKIM/DMARC DNS records
-# before the configured EMAIL_FROM address can deliver.
+# Domain (updates.inevitable.fyi) must be verified in Resend with SPF/DKIM/DMARC DNS
+# records before the configured EMAIL_FROM address can deliver.
 if config_env() == :prod do
-  config :fountain, :email_from, System.get_env("EMAIL_FROM", "noreply@fountain.dev")
+  config :fountain, :email_from, System.get_env("EMAIL_FROM", "noreply@updates.inevitable.fyi")
 
   if api_key = System.get_env("RESEND_API_KEY") do
     config :fountain, Fountain.Mailer,


### PR DESCRIPTION
## Summary

Follow-up to PR #21. Updates the dev/test/edge-case fallback values and explanatory comments so they no longer reference the retired \`fountain.dev\` domain:

- \`config/runtime.exs:112\` — default for \`:email_from\` config when \`EMAIL_FROM\` is unset.
- \`config/runtime.exs:109\` — comment naming the domain to verify in Resend.
- \`apps/fountain/lib/fountain/emails/user_emails.ex:59\` — final fallback if \`Application.get_env\` returns nothing.
- \`.env.example:21,24\` — comment + sample value for new contributors.

**Prod behavior is unchanged.** \`render.yaml\` always sets \`EMAIL_FROM=noreply@updates.inevitable.fyi\`, which takes precedence over every default touched here. This is purely consistency cleanup.

## Related but not in this PR

\`config/runtime.exs:135\` still has \`host = System.get_env(\"FOUNTAIN_DOMAIN\") || \"fountain.dev\"\` as the URL host fallback. Same shape (stale fallback for a domain we've moved off of), but it's a different concern (URL host vs email sender) and the prod env var also covers it. Worth a separate one-line PR if you want full consistency — let me know.

## Test plan

- [ ] \`grep noreply@fountain.dev\` returns nothing across config/, apps/, .env.example, render.yaml (verified locally)
- [ ] \`mix test\` still passes (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)