### PR TITLE
chore(config): replace 'fountain.dev' default for FOUNTAIN_DOMAIN

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -132,7 +132,7 @@ if config_env() == :prod and server? do
     System.get_env("SECRET_KEY_BASE") ||
       raise "environment variable SECRET_KEY_BASE is missing."
 
-  host = System.get_env("FOUNTAIN_DOMAIN") || "fountain.dev"
+  host = System.get_env("FOUNTAIN_DOMAIN") || "localhost"
 
   config :fountain, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 


### PR DESCRIPTION
## Summary

\`config/runtime.exs:135\` had \`host = System.get_env(\"FOUNTAIN_DOMAIN\") || \"fountain.dev\"\`. Flips the default to \`\"localhost\"\`.

## Why localhost (not the prod hostname or raise)

The fallback only fires inside \`if config_env() == :prod and server? do\` when \`FOUNTAIN_DOMAIN\` is unset — i.e., a misconfigured prod deploy. Three options were on the table:

| Option | Behavior on missing env var | Trade-off |
|---|---|---|
| \`\"fountain.inevitable.fyi\"\` | Silently uses prod hostname | Hides the misconfig; URLs may look right but session cookies, OAuth callbacks, etc. assume a host you intended to override |
| \`raise\` (matches \`DATABASE_URL\` and \`SECRET_KEY_BASE\` 3 lines above) | Crashes on startup | Most strict; matches the surrounding pattern; impossible to deploy half-configured |
| \`\"localhost\"\` (chosen) | Generates localhost URLs in prod | Fails visibly without crashing — health check still passes, but external requests, OAuth callbacks, and email links will obviously not work |

\`localhost\` is the \"dev appropriate\" fallback the user requested. If you'd rather match the surrounding fail-fast pattern (\`raise\` like \`DATABASE_URL\`), happy to swap in a one-line follow-up.

## Test plan

- [ ] \`grep fountain.dev config/ apps/ render.yaml .env.example\` returns nothing (verified locally)
- [ ] Prod deploys with \`FOUNTAIN_DOMAIN\` set behave identically (env var still wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)