### PR TITLE
feat(billing): wire STRIPE_PRICE_ID env var through to Checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ GITHUB_OAUTH_CLIENT_SECRET=
 STRIPE_SECRET_KEY=
 STRIPE_PUBLISHABLE_KEY=
 STRIPE_WEBHOOK_SECRET=
+# Price ID for the subscription tier (price_xxx). Use the test-mode
+# price in dev (created in Stripe Dashboard > Test mode > Products).
+STRIPE_PRICE_ID=
 
 # Resend for transactional email (Swoosh.Adapters.Resend).
 # Domain (updates.inevitable.fyi) must be verified in Resend with SPF/DKIM/DMARC

--- a/apps/fountain/lib/fountain_web/live/billing_live.ex
+++ b/apps/fountain/lib/fountain_web/live/billing_live.ex
@@ -159,9 +159,7 @@ defmodule FountainWeb.Live.BillingLive do
         error -> error
       end
     else
-      price_id =
-        Application.get_env(:fountain, :stripe_price_id) ||
-          System.get_env("STRIPE_PRICE_ID", "")
+      price_id = Application.get_env(:fountain, :stripe_price_id, "")
 
       base_params = %{
         mode: "subscription",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -105,6 +105,10 @@ config :stripity_stripe,
   api_key: System.get_env("STRIPE_SECRET_KEY"),
   webhook_secret: System.get_env("STRIPE_WEBHOOK_SECRET")
 
+# Stripe Price ID for the subscription tier surfaced by Checkout.
+# Set per environment (test-mode price in dev, live-mode price in prod).
+config :fountain, :stripe_price_id, System.get_env("STRIPE_PRICE_ID")
+
 # Swoosh Resend adapter for prod; overridden to Local/Test in dev/test via env configs.
 # Domain (updates.inevitable.fyi) must be verified in Resend with SPF/DKIM/DMARC DNS
 # records before the configured EMAIL_FROM address can deliver.

--- a/render.yaml
+++ b/render.yaml
@@ -51,6 +51,8 @@ projects:
                 sync: false
               - key: STRIPE_WEBHOOK_SECRET
                 sync: false
+              - key: STRIPE_PRICE_ID
+                sync: false
 
               # Resend transactional email
               - key: RESEND_API_KEY


### PR DESCRIPTION
## Summary

\`billing_live.ex\` already read \`:fountain, :stripe_price_id\` from Application config, but nothing actually seeded it from an env var. Result: Checkout sessions were created with \`price: \"\"\` and Stripe rejected them.

This PR closes the loop:
- \`config/runtime.exs\` sets \`:fountain, :stripe_price_id\` from \`STRIPE_PRICE_ID\` (loaded in all environments — Stripe price IDs are environment-specific test vs live, so this needs to vary per env).
- \`billing_live.ex\` reads from one source: \`Application.get_env(:fountain, :stripe_price_id, \"\")\`. Removed the redundant inline \`System.get_env\` fallback.
- \`render.yaml\` adds \`STRIPE_PRICE_ID\` (\`sync: false\`, alongside the other Stripe entries).
- \`.env.example\` adds the variable with a comment pointing to Stripe Dashboard test-mode for dev.

## Why only price (and not product)

Stripe Checkout's \`line_items\` takes a \`price\` (\`price_xxx\`), not a product (\`prod_xxx\`). The Product is the abstract thing being sold; the Price is the recurring billing setup attached to it. Only the Price ID is needed at the API boundary. If you later want the product name displayed in the UI, you can fetch it via \`Stripe.Product.retrieve/1\` and cache — let me know and I'll wire that up separately.

## Two manual setup steps

1. **Create a Product + Price in Stripe Dashboard** (test mode for dev, live mode for prod). Pick the recurring interval (monthly / yearly) and amount per ADR 0006's not-yet-decided pricing call.
2. **Set \`STRIPE_PRICE_ID\` in Render dashboard** (or in the \`fountain-prod-core\` env group). Same for your local \`.env\` for dev.

## Test plan

- [ ] After setting \`STRIPE_PRICE_ID\` to a valid test-mode price, hitting the Upgrade button in \`/account/billing\` produces a working Stripe Checkout session
- [ ] Existing tests still pass (no behavioral change when env var is unset; price was already empty before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)