### PR TITLE
fix(config): add config/prod.exs to unblock prod compile

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :logger, level: :info
+
+config :phoenix, :logger, false


### PR DESCRIPTION
## Summary
- Render's `MIX_ENV=prod mix compile` fails because `config/config.exs` ends with `import_config "#{config_env()}.exs"` and `config/prod.exs` doesn't exist.
- Add a minimal compile-time prod config (logger level + disable phoenix logger). Runtime config continues to live in `config/runtime.exs`.

## Test plan
- [ ] Re-run the Render deploy and confirm the build clears the compile step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)