### PR TITLE
fix(render): name fountain_server release in build command

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,7 +13,7 @@ projects:
               mix local.rebar --force
               mix deps.get --only prod
               MIX_ENV=prod mix compile
-              MIX_ENV=prod mix release
+              MIX_ENV=prod mix release fountain_server
             startCommand: _build/prod/rel/fountain_server/bin/server
             preDeployCommand: _build/prod/rel/fountain_server/bin/migrate
             healthCheckPath: /health


### PR DESCRIPTION
## Summary
- Build was failing with `(Mix) "mix release" was invoked without a name but there are multiple releases`. The umbrella `mix.exs` defines two releases (`fountain`, `fountain_server`), so the unnamed invocation in `render.yaml` is ambiguous.
- `startCommand` and `preDeployCommand` already reference `_build/prod/rel/fountain_server/...`, so naming `fountain_server` in the build step matches existing intent.

## Test plan
- [ ] Render deploy reaches the assemble/wrap step without the multi-release error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)