### PR TITLE
fix(secrets): wire per-tenant DEK through vault + environment encryption

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -131,10 +131,11 @@ defmodule Fountain.Conversations.ConversationServer do
     agent = if conv.agent_id, do: Agents.get_agent!(conv.agent_id), else: nil
     env = if agent && agent.environment_id, do: Environments.get_environment(agent.environment_id)
     vault = if conv.vault_id, do: Vaults.get_vault(conv.vault_id)
-    secrets = merge_secrets(env, vault)
 
     case load_tenant_state(conv.user_id) do
       {:ok, dek, inference_creds} ->
+        secrets = merge_secrets(env, vault, dek)
+
         state =
           %{state | runtime_session_id: conv.runtime_session_id, tenant_key: dek, inference_credentials: inference_creds}
 
@@ -577,9 +578,9 @@ defmodule Fountain.Conversations.ConversationServer do
 
   # Env secrets first, vault overrides last — vault wins on key collision.
   # Same merged map feeds repositories[].secret_key resolution.
-  defp merge_secrets(env, vault) do
-    env_secrets = if env, do: Environments.decrypted_env(env), else: %{}
-    vault_secrets = if vault, do: Vaults.decrypted_env(vault), else: %{}
+  defp merge_secrets(env, vault, dek) do
+    env_secrets = if env, do: Environments.decrypted_env(env, dek), else: %{}
+    vault_secrets = if vault, do: Vaults.decrypted_env(vault, dek), else: %{}
     Map.merge(env_secrets, vault_secrets)
   end
 

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -53,16 +53,21 @@ defmodule Fountain.Environments do
     Repo.get_by(Secret, environment_id: env_id, key: key)
   end
 
-  def upsert_secret(%Environment{id: env_id}, %{"key" => key} = attrs) do
+  @doc """
+  Insert or update an environment secret. The plaintext `attrs["value"]` is
+  encrypted with the supplied per-tenant `dek` before persisting.
+  """
+  def upsert_secret(%Environment{id: env_id}, %{"key" => key} = attrs, dek)
+      when is_binary(dek) do
     case get_secret(env_id, key) do
       nil ->
         %Secret{}
-        |> Secret.changeset(Map.put(attrs, "environment_id", env_id))
+        |> Secret.changeset(Map.put(attrs, "environment_id", env_id), dek)
         |> Repo.insert()
 
       existing ->
         existing
-        |> Secret.changeset(attrs)
+        |> Secret.changeset(attrs, dek)
         |> Repo.update()
     end
   end
@@ -71,14 +76,14 @@ defmodule Fountain.Environments do
 
   @doc """
   Returns a flat map `%{"KEY" => "plaintext"}` of all decrypted secrets
-  attached to the given environment. Used when materializing env vars
-  into a Sprite.
+  attached to the given environment. Caller must supply the per-tenant `dek`
+  (load via `Fountain.Crypto.load_tenant_key/1`).
   """
-  def decrypted_env(%Environment{} = env) do
+  def decrypted_env(%Environment{} = env, dek) when is_binary(dek) do
     env
     |> list_secrets()
     |> Enum.reduce(%{}, fn secret, acc ->
-      case Secret.decrypt(secret) do
+      case Secret.decrypt(secret, dek) do
         {:ok, plain} -> Map.put(acc, secret.key, plain)
         :error -> acc
       end

--- a/apps/fountain/lib/fountain/environments/secret.ex
+++ b/apps/fountain/lib/fountain/environments/secret.ex
@@ -16,24 +16,33 @@ defmodule Fountain.Environments.Secret do
     timestamps(type: :utc_datetime)
   end
 
-  def changeset(secret, attrs) do
+  @doc """
+  Build a changeset that encrypts `attrs["value"]` with the supplied
+  per-tenant `dek` before persisting. The plaintext is never stored.
+  """
+  def changeset(secret, attrs, dek) when is_binary(dek) do
     secret
     |> cast(attrs, [:key, :value, :environment_id])
     |> validate_required([:key, :value, :environment_id])
     |> validate_format(:key, ~r/^[A-Z][A-Z0-9_]*$/, message: "must be UPPER_SNAKE_CASE")
     |> validate_length(:key, min: 1, max: 200)
-    |> put_ciphertext()
+    |> put_ciphertext(dek)
     |> unique_constraint([:environment_id, :key])
   end
 
-  defp put_ciphertext(changeset) do
+  defp put_ciphertext(changeset, dek) do
     case get_change(changeset, :value) do
       nil -> changeset
-      value -> put_change(changeset, :value_ciphertext, Crypto.encrypt(value))
+      value -> put_change(changeset, :value_ciphertext, Crypto.encrypt(value, dek))
     end
   end
 
-  @doc "Decrypt the value. Returns `{:ok, plaintext}` or `:error`."
-  def decrypt(%__MODULE__{value_ciphertext: ct}) when is_binary(ct), do: Crypto.decrypt(ct)
-  def decrypt(_), do: :error
+  @doc """
+  Decrypt the value with the supplied per-tenant `dek`.
+  Returns `{:ok, plaintext}` or `:error`.
+  """
+  def decrypt(%__MODULE__{value_ciphertext: ct}, dek) when is_binary(ct) and is_binary(dek),
+    do: Crypto.decrypt(ct, dek)
+
+  def decrypt(_, _), do: :error
 end

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -54,16 +54,20 @@ defmodule Fountain.Vaults do
     Repo.get_by(VaultSecret, vault_id: vault_id, key: key)
   end
 
-  def upsert_secret(%Vault{id: vault_id}, %{"key" => key} = attrs) do
+  @doc """
+  Insert or update a vault secret. The plaintext `attrs["value"]` is encrypted
+  with the supplied per-tenant `dek` before persisting.
+  """
+  def upsert_secret(%Vault{id: vault_id}, %{"key" => key} = attrs, dek) when is_binary(dek) do
     case get_secret(vault_id, key) do
       nil ->
         %VaultSecret{}
-        |> VaultSecret.changeset(Map.put(attrs, "vault_id", vault_id))
+        |> VaultSecret.changeset(Map.put(attrs, "vault_id", vault_id), dek)
         |> Repo.insert()
 
       existing ->
         existing
-        |> VaultSecret.changeset(attrs)
+        |> VaultSecret.changeset(attrs, dek)
         |> Repo.update()
     end
   end
@@ -73,12 +77,13 @@ defmodule Fountain.Vaults do
   @doc """
   Returns a flat map `%{"KEY" => "plaintext"}` of all decrypted secrets
   in the given vault. Used when materializing env vars into a Sprite.
+  Caller must supply the per-tenant `dek` (load via `Fountain.Crypto.load_tenant_key/1`).
   """
-  def decrypted_env(%Vault{} = vault) do
+  def decrypted_env(%Vault{} = vault, dek) when is_binary(dek) do
     vault
     |> list_secrets()
     |> Enum.reduce(%{}, fn secret, acc ->
-      case VaultSecret.decrypt(secret) do
+      case VaultSecret.decrypt(secret, dek) do
         {:ok, plain} -> Map.put(acc, secret.key, plain)
         :error -> acc
       end

--- a/apps/fountain/lib/fountain/vaults/vault_secret.ex
+++ b/apps/fountain/lib/fountain/vaults/vault_secret.ex
@@ -16,24 +16,33 @@ defmodule Fountain.Vaults.VaultSecret do
     timestamps(type: :utc_datetime)
   end
 
-  def changeset(secret, attrs) do
+  @doc """
+  Build a changeset that encrypts `attrs["value"]` with the supplied
+  per-tenant `dek` before persisting. The plaintext is never stored.
+  """
+  def changeset(secret, attrs, dek) when is_binary(dek) do
     secret
     |> cast(attrs, [:key, :value, :vault_id])
     |> validate_required([:key, :value, :vault_id])
     |> validate_format(:key, ~r/^[A-Z][A-Z0-9_]*$/, message: "must be UPPER_SNAKE_CASE")
     |> validate_length(:key, min: 1, max: 200)
-    |> put_ciphertext()
+    |> put_ciphertext(dek)
     |> unique_constraint([:vault_id, :key])
   end
 
-  defp put_ciphertext(changeset) do
+  defp put_ciphertext(changeset, dek) do
     case get_change(changeset, :value) do
       nil -> changeset
-      value -> put_change(changeset, :value_ciphertext, Crypto.encrypt(value))
+      value -> put_change(changeset, :value_ciphertext, Crypto.encrypt(value, dek))
     end
   end
 
-  @doc "Decrypt the value. Returns `{:ok, plaintext}` or `:error`."
-  def decrypt(%__MODULE__{value_ciphertext: ct}) when is_binary(ct), do: Crypto.decrypt(ct)
-  def decrypt(_), do: :error
+  @doc """
+  Decrypt the value with the supplied per-tenant `dek`.
+  Returns `{:ok, plaintext}` or `:error`.
+  """
+  def decrypt(%__MODULE__{value_ciphertext: ct}, dek) when is_binary(ct) and is_binary(dek),
+    do: Crypto.decrypt(ct, dek)
+
+  def decrypt(_, _), do: :error
 end

--- a/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
@@ -2,7 +2,7 @@ defmodule FountainWeb.SecretController do
   use FountainWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
-  alias Fountain.Environments
+  alias Fountain.{Crypto, Environments}
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
@@ -48,8 +48,9 @@ defmodule FountainWeb.SecretController do
 
       env ->
         attrs = Map.take(params, ["key", "value"])
+        {:ok, dek} = Crypto.load_tenant_key(conn.assigns.current_user.id)
 
-        with {:ok, secret} <- Environments.upsert_secret(env, attrs) do
+        with {:ok, secret} <- Environments.upsert_secret(env, attrs, dek) do
           conn
           |> put_status(:created)
           |> render(:show, secret: secret)

--- a/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
@@ -2,7 +2,7 @@ defmodule FountainWeb.VaultSecretController do
   use FountainWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
-  alias Fountain.Vaults
+  alias Fountain.{Crypto, Vaults}
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
@@ -48,8 +48,9 @@ defmodule FountainWeb.VaultSecretController do
 
       vault ->
         attrs = Map.take(params, ["key", "value"])
+        {:ok, dek} = Crypto.load_tenant_key(conn.assigns.current_user.id)
 
-        with {:ok, secret} <- Vaults.upsert_secret(vault, attrs) do
+        with {:ok, secret} <- Vaults.upsert_secret(vault, attrs, dek) do
           conn
           |> put_status(:created)
           |> render(:show, secret: secret)

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -1,18 +1,20 @@
 defmodule FountainWeb.EnvironmentsLive.Form do
   use FountainWeb, :live_view
 
-  alias Fountain.Environments
+  alias Fountain.{Crypto, Environments}
   alias Fountain.Environments.Environment
 
   @impl true
   def mount(params, _session, socket) do
     user_id = socket.assigns.current_user.id
     {env, action} = load(params, user_id)
+    {:ok, dek} = Crypto.load_tenant_key(user_id)
 
     {:ok,
      socket
      |> assign(:page_title, page_title(action))
      |> assign(:user_id, user_id)
+     |> assign(:tenant_key, dek)
      |> assign(:action, action)
      |> assign(:env, env)
      |> assign(:form, env_to_form(env))
@@ -79,7 +81,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
 
   def handle_event("add_secret", %{"secret" => %{"key" => k, "value" => v}}, socket)
       when k != "" and v != "" do
-    case Environments.upsert_secret(socket.assigns.env, %{"key" => k, "value" => v}) do
+    case Environments.upsert_secret(socket.assigns.env, %{"key" => k, "value" => v}, socket.assigns.tenant_key) do
       {:ok, _} ->
         {:noreply,
          socket

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -1,18 +1,20 @@
 defmodule FountainWeb.VaultsLive.Form do
   use FountainWeb, :live_view
 
-  alias Fountain.Vaults
+  alias Fountain.{Crypto, Vaults}
   alias Fountain.Vaults.Vault
 
   @impl true
   def mount(params, _session, socket) do
     user_id = socket.assigns.current_user.id
     {vault, action} = load(params, user_id)
+    {:ok, dek} = Crypto.load_tenant_key(user_id)
 
     {:ok,
      socket
      |> assign(:page_title, page_title(action))
      |> assign(:user_id, user_id)
+     |> assign(:tenant_key, dek)
      |> assign(:action, action)
      |> assign(:vault, vault)
      |> assign(:form, vault_to_form(vault))
@@ -52,7 +54,7 @@ defmodule FountainWeb.VaultsLive.Form do
 
   def handle_event("add_secret", %{"secret" => %{"key" => k, "value" => v}}, socket)
       when k != "" and v != "" do
-    case Vaults.upsert_secret(socket.assigns.vault, %{"key" => k, "value" => v}) do
+    case Vaults.upsert_secret(socket.assigns.vault, %{"key" => k, "value" => v}, socket.assigns.tenant_key) do
       {:ok, _} ->
         {:noreply,
          socket

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -66,7 +66,8 @@ defmodule Fountain.Factory do
       %{"key" => "TEST_KEY_#{uniq()}", "value" => "test-value-#{uniq()}"}
       |> Map.merge(to_string_map(overrides))
 
-    {:ok, secret} = Fountain.Environments.upsert_secret(env, attrs)
+    {:ok, dek} = Fountain.Crypto.load_tenant_key(env.user_id)
+    {:ok, secret} = Fountain.Environments.upsert_secret(env, attrs, dek)
     secret
   end
 
@@ -89,7 +90,8 @@ defmodule Fountain.Factory do
       %{"key" => "TEST_KEY_#{uniq()}", "value" => "test-value-#{uniq()}"}
       |> Map.merge(to_string_map(overrides))
 
-    {:ok, secret} = Fountain.Vaults.upsert_secret(vault, attrs)
+    {:ok, dek} = Fountain.Crypto.load_tenant_key(vault.user_id)
+    {:ok, secret} = Fountain.Vaults.upsert_secret(vault, attrs, dek)
     secret
   end
 


### PR DESCRIPTION
## Summary

Vault and environment secret encryption was silently broken: \`Secret.changeset\` and \`VaultSecret.changeset\` called \`Crypto.encrypt(value)\` with one arg, and the decrypt fns called \`Crypto.decrypt(ct)\` with one arg, but \`Fountain.Crypto\` requires the per-tenant DEK as a second arg. The compile warnings flagged it (\`Fountain.Crypto.encrypt/1 is undefined\`); runtime would have crashed on the first vault or environment secret write.

This PR plumbs the per-tenant DEK through the whole secrets path.

## What changed

| Layer | Change |
|---|---|
| Schema | \`Secret.changeset/2\` → \`/3\` (takes \`dek\`); \`Secret.decrypt/1\` → \`/2\`. Same shape for \`VaultSecret\`. |
| Context | \`Environments.upsert_secret/2\` → \`/3\`; \`Environments.decrypted_env/1\` → \`/2\`. Same for \`Vaults\`. |
| ConversationServer | Loads tenant state (DEK + inference credentials) **before** calling \`merge_secrets/3\` so the DEK is available. \`merge_secrets/2\` → \`/3\`. |
| LiveViews | \`VaultsLive.Form\` and \`EnvironmentsLive.Form\` load DEK at mount via \`Crypto.load_tenant_key(current_user.id)\`, stash in socket assigns, pass to upsert. |
| Controllers | \`VaultSecretController.create\` and \`SecretController.create\` load DEK per request, pass to upsert. |
| Test factory | \`insert_secret\` and \`insert_vault_secret\` load DEK from \`env.user_id\` / \`vault.user_id\`. |

## Why each callsite acquires the DEK independently

A `Fountain.TenantContext.with_dek/2`-style helper would deduplicate the four call sites, but at the cost of an extra abstraction for what's currently 1 call per LiveView mount + 1 call per controller request. The pattern matches the existing inference-credentials wiring (ADR 0008), which also loads the DEK at the boundary. If the call-site count grows past ~6, time to extract a helper.

## What this does NOT fix (separate PR territory)

- The Vaults / Environments **read** path (LiveView listing decrypted secret values, if anywhere) — I did not audit every place secrets are decrypted outside of \`decrypted_env\`. Spot-grepping found no other callers of \`Secret.decrypt\` / \`VaultSecret.decrypt\`, so I believe this is complete, but worth a code review eye.
- Tests for the new arity. The existing tests will exercise the changed signatures via the factory; if any currently-passing test passed against the old broken code, it will now actually exercise encryption end-to-end and probably need user_id supplied in fixtures.

## Test plan

- [ ] \`mix compile\` — no \`Crypto.encrypt/1\` / \`Crypto.decrypt/1\` warnings (verified locally; pre-existing OpenTelemetry-only-in-prod warnings remain)
- [ ] \`mix test apps/fountain/test/fountain/vaults_test.exs\` and \`environments_test.exs\` pass against the new arity
- [ ] Manual: via the LiveView, create a vault → add a secret → start a conversation that uses that vault → confirm the secret value reaches the sandbox env

🤖 Generated with [Claude Code](https://claude.com/claude-code)