### PR TITLE
fix(render): drop Burrito wrap from fountain_server release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,9 +34,7 @@ defmodule Fountain.Umbrella.MixProject do
           )
       ],
       fountain_server: [
-        applications: [fountain_cli: :permanent, fountain: :permanent],
-        steps: [:assemble, &Burrito.wrap/1],
-        burrito: burrito_targets_with_musl_fix()
+        applications: [fountain_cli: :permanent, fountain: :permanent]
       ]
     ]
   end
@@ -73,12 +71,6 @@ defmodule Fountain.Umbrella.MixProject do
       end
 
     [targets: selected, debug: Mix.env() != :prod]
-  end
-
-  defp burrito_targets_with_musl_fix do
-    Keyword.merge(burrito_targets(),
-      extra_steps: [fetch: [pre: [Fountain.Burrito.InjectMuslPath]]]
-    )
   end
 
   defp aliases do


### PR DESCRIPTION
## Summary
- Render's Elixir buildpack lacks `zig` and `xz`, so `Burrito.wrap/1` fails with `You MUST have zig and xz installed` during `mix release fountain_server`.
- The server release runs as a standard mix release on Render (overlay scripts already point at `_build/prod/rel/fountain_server/bin/fountain_server`); only the `fountain` CLI distribution needs Burrito.
- Drops the `Burrito.wrap/1` step + `burrito:` config from the `fountain_server` release and removes the now-unused `burrito_targets_with_musl_fix/0` helper.

## Test plan
- [x] `MIX_ENV=prod mix release fountain_server --overwrite` succeeds locally without invoking Burrito
- [ ] Render build for `fountain` web service completes successfully
- [ ] Service boots via `_build/prod/rel/fountain_server/bin/server` and `/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)