### PR TITLE
chore: clean up compile warnings

### DIFF
--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -90,6 +90,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
       <form phx-submit="create_key" class="flex gap-2 items-end">
         <div class="flex-1">
           <.form_field
+            id="label"
             label="Key label"
             name="label"
             type="text"

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -106,9 +106,9 @@ defmodule FountainWeb.ConversationsLive.Index do
         sorted_by={Atom.to_string(@sort_by)}
         sorted_dir={@sort_dir}
       >
-        <:empty>
+        <:empty_state>
           No conversations yet. Start one to see it here.
-        </:empty>
+        </:empty_state>
         <:col :let={c} label="Status"><.badge status={c.status} /></:col>
         <:col :let={c} label="Task">
           <%= case first_prompt(c) do %>

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -43,7 +43,7 @@ defmodule FountainWeb.DashboardLive.Index do
       </div>
 
       <div class="grid grid-cols-3 gap-4">
-        <.link navigate={~p"/conversations"}
+        <.link navigate={~p"/"}
           class="rounded border border-zinc-200 bg-white shadow p-4 hover:bg-zinc-50 block">
           <p class="text-xs text-zinc-500 uppercase tracking-wide">Recent conversations</p>
           <p class="text-2xl font-semibold mt-1">{length(@recent_conversations)}</p>

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -28,7 +28,7 @@ defmodule FountainWeb.Live.Hooks do
   """
 
   import Phoenix.LiveView
-  import Phoenix.Component, only: [assign: 2, assign_new: 3]
+  import Phoenix.Component, only: [assign_new: 3]
 
   use FountainWeb, :verified_routes
 

--- a/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
@@ -33,7 +33,7 @@ defmodule FountainWeb.LogViewerLive.Show do
       {:ok,
        socket
        |> put_flash(:error, "Conversation not found")
-       |> push_navigate(to: ~p"/conversations")}
+       |> push_navigate(to: ~p"/")}
     end
   end
 

--- a/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
+++ b/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
@@ -1,9 +1,7 @@
 defmodule FountainWeb.OnboardingLive.Wizard do
   use FountainWeb, :live_view
 
-  alias Fountain.{Accounts, Agents, Conversations, Crypto, Environments, InferenceCredentials}
-  alias Fountain.Environments.Environment
-  alias Fountain.Agents.Agent
+  alias Fountain.{Accounts, Agents, Crypto, Environments, InferenceCredentials}
   alias Fountain.InferenceCredentials.Validator
 
   # ADR 0008 inserted "inference" as the new first step. Old step_1/2/3

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Fountain.Umbrella.MixProject do
     ]
   end
 
-  defp burrito_targets(opts \\ []) do
+  defp burrito_targets(opts) do
     skip_nifs = Keyword.get(opts, :skip_nifs, false)
 
     all_targets = [


### PR DESCRIPTION
## Summary
Resolves the warnings surfaced by the prior Render build:

- `hooks.ex` — drop unused `assign/2` import (only `assign_new/3` is used)
- `onboarding/wizard.ex` — drop unused `Conversations`, `Environment`, `Agent` aliases
- `dashboard_live/index.ex` + `log_viewer_live/show.ex` — `~p"/conversations"` doesn't exist in the router; the conversations index is mounted at `/`
- `conversations_live/index.ex` — `<:empty>` → `<:empty_state>` to match the slot name on `CoreComponents.table/1`
- `api_keys_live/index.ex` — `form_field` requires `id`; pass `id="label"`
- `mix.exs` — drop unused `\\ []` default arg from `burrito_targets/1` (after #30 there's only one call site, which always passes `skip_nifs: true`)

The four `Crypto.encrypt/decrypt/1` warnings in the build log were already fixed in `327454d` ("fix(secrets): wire per-tenant DEK through vault + environment encryption") and will disappear on the next deploy.

## Test plan
- [x] `MIX_ENV=prod mix compile --force --warnings-as-errors` passes locally
- [ ] Render build log no longer reports any of the above warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)