### PR TITLE
fix(render): bump Erlang to 28.0.2 and disable Postgres TLS verify

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -128,7 +128,8 @@ if config_env() == :prod and server? do
   config :fountain, Fountain.Repo,
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    ssl: true
+    ssl: true,
+    ssl_opts: [verify: :verify_none]
 
   secret_key_base =
     System.get_env("SECRET_KEY_BASE") ||

--- a/render.yaml
+++ b/render.yaml
@@ -65,7 +65,7 @@ projects:
               - key: ELIXIR_VERSION
                 value: "1.18.4"
               - key: ERLANG_VERSION
-                value: "27.0"
+                value: "28.0.2"
 
               - key: DATABASE_URL
                 fromDatabase:


### PR DESCRIPTION
## Summary
Pre-deploy failed on two issues:

1. **Erlang too old.** `ERLANG_VERSION=27.0` was incompatible with Elixir 1.18.4's prebuilt `.beam` files (\"Failed to load module 'elixir' because it requires a more recent Erlang/OTP version\"). Render's current default pairing for Elixir 1.18.4 is OTP **28.0.2** — pin explicitly.

2. **Postgres TLS bad certificate.** Postgrex failed with `Bad Certificate` on every connect. OTP 27+ defaults `ssl: true` to `verify: :verify_peer` using the system CA bundle, which doesn't include Render's internal Postgres CA. Added `ssl_opts: [verify: :verify_none]` in `config/runtime.exs`.

   Trade-off: the connection stays TLS-encrypted, but cert validation is skipped. Acceptable here because `DATABASE_URL` injected via `fromDatabase` resolves to Render's private internal hostname (not the public internet) — no MITM surface. If we want strict verification later, we'd need to ship Render's CA cert and switch to `verify: :verify_peer` with `cacertfile:`.

## Test plan
- [ ] Render redeploy: build succeeds (already does)
- [ ] Pre-deploy `migrate` runs without the OTP version error
- [ ] Pre-deploy `migrate` connects to Postgres without TLS errors and runs migrations
- [ ] Service starts and `/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)