### PR TITLE
fix(render): bump Elixir to 1.19.2 to pair with OTP 28.0.2

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -63,7 +63,7 @@ projects:
                 value: noreply@updates.inevitable.fyi
 
               - key: ELIXIR_VERSION
-                value: "1.18.4"
+                value: "1.19.2"
               - key: ERLANG_VERSION
                 value: "28.0.2"
 


### PR DESCRIPTION
## Summary
Last deploy failed with \`find: '/opt/render/project/elixirs/*': No such file or directory\` — Elixir 1.18.4 doesn't ship an OTP-28 prebuild in Render's cache, so requesting that pair leaves no Elixir for Render to use.

Bump \`ELIXIR_VERSION\` to \`1.19.2\` (which Hex does ship against OTP 28.x) to pair with the \`28.0.2\` runtime. Also aligns with \`.tool-versions\` (\`elixir 1.19.2-otp-28\`).

Umbrella \`mix.exs\` constraints are \`elixir: \"~> 1.18\"\`, which permits 1.19.x.

Note: local development currently uses Elixir 1.18.4 even though \`.tool-versions\` requests 1.19.2 — after this lands, dev should switch toolchains to match.

## Test plan
- [ ] Render build pulls Elixir 1.19.2 + OTP 28.0.2 successfully (no \`find\` error)
- [ ] \`mix release fountain_server\` assembles
- [ ] Pre-deploy \`migrate\` runs against Postgres
- [ ] Service starts and \`/health\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)