### PR TITLE
fix(render): SECRET_KEY_BASE must be ≥64 bytes (sync: false, not generateValue)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -30,11 +30,12 @@ projects:
               - key: PORT
                 value: "10000"
 
-              # Auto-generated secrets
+              # Set via dashboard (sync: false hides from yaml).
+              # SECRET_KEY_BASE must be ≥64 bytes for Phoenix's cookie session
+              # store; Render's `generateValue: true` produces a value that's
+              # too short. Generate locally with `mix phx.gen.secret` and paste.
               - key: SECRET_KEY_BASE
-                generateValue: true
-
-              # Set via dashboard (sync: false hides from yaml)
+                sync: false
               - key: MASTER_SECRETS_KEY
                 sync: false
               - key: SPRITES_TOKEN


### PR DESCRIPTION
## Summary

Render's \`generateValue: true\` generates a value too short for Phoenix's cookie session store, which requires \`byte_size(secret_key_base) >= 64\`. The app crashes at first request with:

\`\`\`
** (ArgumentError) cookie store expects conn.secret_key_base to be at least 64 bytes
\`\`\`

Switch to \`sync: false\` so the operator generates the value with \`mix phx.gen.secret\` (Phoenix helper, 64-char/64-byte default) and pastes it in the Render dashboard. Adds an inline comment documenting the requirement so future operators don't repeat it.

## Operator action after this merges

\`\`\`
mix phx.gen.secret
\`\`\`

Paste output into Render dashboard as the value for \`SECRET_KEY_BASE\`. Once set, redeploy.

## Test plan

- [ ] Render Blueprint sync accepts the change
- [ ] After setting \`SECRET_KEY_BASE\` to a 64+ byte value, the cookie-store error goes away

🤖 Generated with [Claude Code](https://claude.com/claude-code)