### PR TITLE
chore(render): bump fountain-db to basic-1gb

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -75,7 +75,7 @@ projects:
 
         databases:
           - name: fountain-db
-            plan: basic-256mb
+            plan: basic-1gb
             region: oregon
             databaseName: fountain
             user: fountain


### PR DESCRIPTION
## Summary
Bumps the Postgres plan for \`fountain-db\` from \`basic-256mb\` to \`basic-1gb\` in the Render blueprint.

## Heads up
Applying this blueprint will trigger a plan upgrade on the existing managed Postgres instance. Render typically does this in place, but verify in the Render dashboard before merging — and confirm there's no required maintenance window for your traffic level.

Billing impact is on you to confirm; basic-1gb is roughly 4× the basic-256mb monthly cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)