### PR TITLE
fix(live): set @current_path in the authenticated on_mount hook

### DIFF
--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -28,7 +28,7 @@ defmodule FountainWeb.Live.Hooks do
   """
 
   import Phoenix.LiveView
-  import Phoenix.Component, only: [assign_new: 3]
+  import Phoenix.Component, only: [assign: 3, assign_new: 3]
 
   use FountainWeb, :verified_routes
 
@@ -50,7 +50,7 @@ defmodule FountainWeb.Live.Hooks do
          |> redirect(to: ~p"/auth/login")}
 
       true ->
-        {:cont, socket}
+        {:cont, track_current_path(socket)}
     end
   end
 
@@ -98,6 +98,17 @@ defmodule FountainWeb.Live.Hooks do
       else
         _ -> nil
       end
+    end)
+  end
+
+  # The shared layout reads @current_path to highlight the active nav item.
+  # Seed it with "/" for the initial render and update it from the URI on
+  # every handle_params (LiveView navigation).
+  defp track_current_path(socket) do
+    socket
+    |> assign_new(:current_path, fn -> "/" end)
+    |> Phoenix.LiveView.attach_hook(:current_path, :handle_params, fn _params, uri, socket ->
+      {:cont, assign(socket, :current_path, URI.parse(uri).path)}
     end)
   end
 end


### PR DESCRIPTION
## Summary
Logging in and landing on \`/onboarding/step_1\` (or any authenticated LiveView) crashed with:

\`\`\`
** (KeyError) key :current_path not found in: %{ ... }
    (fountain 0.1.0) lib/fountain_web/components/layouts.ex:98: anonymous fn/2 in FountainWeb.Layouts.app/1
\`\`\`

Root cause: \`FountainWeb.Layouts.app/1\` reads \`@current_path\` to highlight the active sidebar nav item, but no \`on_mount\` hook attached to the live_sessions in the router was assigning it. The legacy \`Plugs.SessionAuth.on_mount(:require_admin)\` did set it, but that hook isn't wired into any live_session — the actual auth path goes through \`FountainWeb.Live.Hooks.:require_authenticated_user\`.

Move the path tracking into \`:require_authenticated_user\`:
- seed \`@current_path\` to \`"/"\` on mount via \`assign_new\`
- attach a \`:handle_params\` hook to keep it in sync as the user navigates

This covers every live_session that runs through the auth hook (\`:authenticated\`, \`:active_subscription\`, \`:admin\`).

## Test plan
- [x] \`mix compile --force --warnings-as-errors\` clean
- [ ] Log in → land on \`/onboarding/step_1\` without KeyError
- [ ] Sidebar highlights the right nav item as you navigate (e.g. \`/agents\`, \`/environments\`)

## Out of scope (follow-up)
The deploy logs also show OTel exporter noise — \`opentelemetry_exporter\` is trying to push OTLP to \`localhost:4318\` and there's no collector. Either set \`OTEL_EXPORTER_OTLP_ENDPOINT\` to a real endpoint or set \`OTEL_TRACES_EXPORTER=none\` in render.yaml. Not blocking, but worth a separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)