### PR TITLE
fix(onboarding): wizard agent submit + dark-mode contrast

### DIFF
--- a/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
+++ b/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
@@ -139,7 +139,15 @@ defmodule FountainWeb.OnboardingLive.Wizard do
   end
 
   def handle_event("create_agent", %{"agent" => params}, socket) do
-    attrs = Map.put(params, "user_id", socket.assigns.user_id)
+    # The wizard form only collects name + system prompt; supply runtime/model
+    # defaults and map system_prompt -> system so the changeset can pass.
+    attrs =
+      params
+      |> Map.put("user_id", socket.assigns.user_id)
+      |> Map.put_new("runtime", "claude")
+      |> Map.put_new("model", "anthropic/claude-sonnet-4-6")
+      |> Map.put("system", Map.get(params, "system_prompt", ""))
+      |> Map.delete("system_prompt")
 
     case Agents.create_agent(attrs) do
       {:ok, _agent} -> advance(socket, "step_4")
@@ -192,7 +200,7 @@ defmodule FountainWeb.OnboardingLive.Wizard do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="min-h-screen bg-zinc-50 flex flex-col items-center justify-center py-12 px-4">
+    <div class="min-h-screen bg-zinc-50 text-zinc-900 flex flex-col items-center justify-center py-12 px-4">
       <div class="w-full max-w-lg space-y-8">
         <div class="text-center">
           <h1 class="text-2xl font-bold text-zinc-900">Welcome to Fountain</h1>


### PR DESCRIPTION
## Summary

Two bugs on the agent step of the onboarding wizard.

### 1. "Create agent & continue" appeared to do nothing

The wizard form only collects \`name\` and \`system_prompt\`, but \`Agent.changeset\` requires \`:name\`, \`:model\`, **and** \`:runtime\`. The submit *did* reach the server over the LiveView WebSocket — the changeset failed validation, and the handler stored errors only for the \`"name"\` key. The form template only renders errors for \`"name"\`, so the page re-rendered with no visible change. Looked exactly like a no-op.

Fix: in the wizard \`create_agent\` handler, supply sensible defaults (\`runtime: "claude"\`, \`model: "anthropic/claude-sonnet-4-6"\` — already the canonical default elsewhere in the app) and map the form's \`system_prompt\` field onto the schema's \`system\` field.

### 2. Headings and inputs rendered white-on-white in dark mode

The wizard root uses hardcoded light-theme classes (\`bg-zinc-50\`, \`bg-white\`), but the root layout's \`<body>\` sets \`text-[var(--color-text-primary)]\` — which resolves to a *light* color in dark mode. So the wizard's hardcoded-white panel inherited light text → invisible.

Fix: add \`text-zinc-900\` to the wizard's outermost div so all child text inherits a dark color regardless of theme.

## Test plan

- [x] \`mix compile --force --warnings-as-errors\` clean
- [ ] Log in fresh user → step 3 → type name → "Create agent & continue" advances to step 4
- [ ] Step 3 in dark mode (OS dark or \`localStorage.fountain-theme = "dark"\`) renders all text legibly

## Follow-ups (not in this PR)

- The \`validate_agent\` handler stores form params but never runs the changeset, so users get no real-time validation feedback. Worth a separate small change.
- The form template only displays errors keyed by \`"name"\` — any other validation failure is invisible. Adding a fallback \`for\`-loop over remaining errors would prevent another silent-failure bug.
- The wizard's hardcoded-light theme is a deliberate choice but worth documenting (or making theme-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)