### PR TITLE
fix(oauth): install plug Ueberauth + set base_path to match router prefix

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
@@ -11,10 +11,15 @@ defmodule FountainWeb.UeberauthController do
 
   use FountainWeb, :controller
 
-  # Ueberauth calls `request/2` via its plug before this action runs; by the
-  # time Phoenix dispatches here the plug has already redirected to the
-  # provider. This action only fires if Ueberauth passes through (e.g. unknown
-  # provider), so we just redirect home.
+  # Ueberauth's plug handles the request phase (redirect to the provider)
+  # and the callback phase (parse the response into assigns). It MUST be
+  # in the controller's plug pipeline — otherwise `request/2` is hit
+  # directly and falls through to the "Unknown OAuth provider" branch.
+  # The `base_path` in config/config.exs must match the route prefix
+  # (`/auth/oauth`) for the plug to recognize the path.
+  plug Ueberauth
+
+  # Only fires if Ueberauth passes through (unknown / unconfigured provider).
   def request(conn, _params) do
     conn
     |> put_flash(:error, "Unknown OAuth provider.")

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,8 +23,12 @@ config :phoenix, :json_library, Jason
 # Swoosh mailer
 config :fountain, Fountain.Mailer, adapter: Swoosh.Adapters.Local
 
-# Ueberauth — GitHub OAuth strategy
+# Ueberauth — GitHub OAuth strategy.
+# `base_path` matches the router prefix in router.ex (`/auth/oauth/:provider`);
+# without it the plug ignores the requests and the controller's :request
+# action runs directly, redirecting users back to /auth/login.
 config :ueberauth, Ueberauth,
+  base_path: "/auth/oauth",
   providers: [
     github: {Ueberauth.Strategy.Github, [default_scope: "user:email"]}
   ]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -89,7 +89,9 @@ cluster_topologies =
 config :libcluster, topologies: cluster_topologies
 
 # GitHub OAuth (§2.4)
+# base_path must match the router prefix in router.ex (/auth/oauth/:provider).
 config :ueberauth, Ueberauth,
+  base_path: "/auth/oauth",
   providers: [
     github: {Ueberauth.Strategy.Github, [default_scope: "user:email"]}
   ]


### PR DESCRIPTION
## Summary

OAuth is silently bouncing users back to \`/auth/login\` instead of redirecting to GitHub. Network trace: 302 → \`/auth/oauth/github\` → 200 at \`/auth/login\`, never reaching \`github.com/login/oauth/authorize\`.

Two missing pieces:

### 1. \`UeberauthController\` had no \`plug Ueberauth\`

Without the plug, Ueberauth's request_phase never fires. The controller's \`:request\` action runs directly and falls through to the "Unknown OAuth provider" branch — which redirects to \`/auth/login\`. Exactly the symptom observed.

The controller's docstring even claims "Ueberauth calls request/2 via its plug before this action runs" — the plug line was just missing.

### 2. Ueberauth \`base_path\` defaults to \`/auth\`

The router exposes \`/auth/oauth/:provider\` (namespaced), but Ueberauth's plug only intercepts paths matching its configured \`base_path\` (default \`/auth\`). With the default, the plug ignored \`/auth/oauth/github\` entirely.

Set \`base_path: "/auth/oauth"\` in both \`config/config.exs\` and \`config/runtime.exs\` to match the router prefix.

## After this merges

OAuth flow should work end-to-end. To verify:

1. Click "Continue with GitHub"
2. Browser redirects to \`github.com/login/oauth/authorize?client_id=…\`
3. Approve → callback at \`/auth/oauth/github/callback\` → onboarding (new user) or dashboard (returning)

If anything still fails, the \`UeberauthController.callback/2\` failure clause now displays the actual \`failure.errors[].message\` as a flash, so the next error message will be specific.

## Test plan

- [ ] After deploy: clicking GitHub button redirects to \`github.com\` (not back to \`/auth/login\`)
- [ ] Callback completes; new user lands at \`/onboarding/step_1\`; returning user at \`/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)