### PR TITLE
feat(billing): allow promotion codes on Stripe Checkout

### DIFF
--- a/apps/fountain/lib/fountain_web/live/billing_live.ex
+++ b/apps/fountain/lib/fountain_web/live/billing_live.ex
@@ -165,7 +165,11 @@ defmodule FountainWeb.Live.BillingLive do
         mode: "subscription",
         line_items: [%{price: price_id, quantity: 1}],
         success_url: return_url <> "?checkout=success",
-        cancel_url: return_url
+        cancel_url: return_url,
+        # Show "Add promotion code" link on the Checkout page. Promotion codes
+        # are user-facing redeemable strings tied to coupons created in the
+        # Stripe dashboard. Without this flag, the field is hidden by default.
+        allow_promotion_codes: true
       }
 
       params =


### PR DESCRIPTION
## Summary

Stripe Checkout hides the promo-code field by default. Adding \`allow_promotion_codes: true\` to the session params surfaces an "Add promotion code" link on the Checkout page that expands into a redemption input.

## Setup needed (Stripe dashboard, not code)

Promotion codes are user-facing redeemable strings tied to coupons. To create one:

1. **Stripe Dashboard → Products → Coupons** — create a coupon (e.g., 50% off, $10 off, 30 days free trial extension)
2. **In the coupon → "Promotion codes" tab** — generate a redeemable code like \`LAUNCH50\`
3. Users can now enter that code at Checkout

## Scope

- ✅ First-time Checkout (covered by this PR)
- ❌ **Not** the Billing Portal (existing customers changing their plan) — that's controlled separately via Stripe dashboard Customer Portal settings, no code change needed

## Test plan

- [ ] After deploy + creating a test promo code in Stripe dashboard: hitting Upgrade in \`/account/billing\` shows the "Add promotion code" link
- [ ] Code redeems correctly and reflects discount in the Checkout summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)