### PR TITLE
fix(admin): render sandbox->conversations as a list, not a single id

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -27,7 +27,7 @@ defmodule Fountain.Conversations do
         order_by: [desc: s.inserted_at],
         left_join: u in User,
         on: u.id == s.user_id,
-        preload: [user: u]
+        preload: [user: u, conversations: []]
     )
   end
 

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -105,7 +105,7 @@ defmodule FountainWeb.AdminLive.Index do
             <tr>
               <th class="px-4 py-2">ID</th>
               <th class="px-4 py-2">Status</th>
-              <th class="px-4 py-2">Conversation</th>
+              <th class="px-4 py-2">Conversations</th>
               <th class="px-4 py-2">Started</th>
             </tr>
           </thead>
@@ -121,9 +121,14 @@ defmodule FountainWeb.AdminLive.Index do
                 </span>
               </td>
               <td class="px-4 py-2 text-xs text-zinc-500">
-                <.link navigate={~p"/conversations/#{s.conversation_id}"} class="hover:underline">
-                  {String.slice(s.conversation_id, 0, 8)}
-                </.link>
+                <span :if={s.conversations == []}>—</span>
+                <span :if={s.conversations != []} class="space-x-2">
+                  <.link
+                    :for={c <- s.conversations}
+                    navigate={~p"/conversations/#{c.id}"}
+                    class="hover:underline"
+                  >{String.slice(c.id, 0, 8)}</.link>
+                </span>
               </td>
               <td class="px-4 py-2 text-xs text-zinc-500">{format_ts(s.inserted_at)}</td>
             </tr>


### PR DESCRIPTION
## Summary

\`/admin\` 500'd with:

\`\`\`
** (KeyError) key :conversation_id not found in: %Fountain.Conversations.Sandbox{ ... conversations: #Ecto.Association.NotLoaded ... }
    (fountain 0.1.0) lib/fountain_web/live/admin_live/index.ex:124
\`\`\`

The view assumed a 1:1 sandbox→conversation relationship, but the schema is \`Sandbox has_many :conversations\` — there's no \`:conversation_id\` field on Sandbox at all. The admin view was never updated when the schema moved to 1:many.

## Changes
- \`Conversations.list_sandboxes_admin/0\`: also preload \`:conversations\`.
- \`AdminLive.Index\`: rename the column to "Conversations" and render each preloaded conversation id as a link, with "—" for sandboxes that have none.

## Test plan
- [x] \`mix compile --force --warnings-as-errors\` clean
- [ ] \`/admin\` loads without KeyError
- [ ] Sandboxes with multiple conversations render multiple links; empty sandboxes render "—"

🤖 Generated with [Claude Code](https://claude.com/claude-code)