### PR TITLE
fix(security): scope all Conversation reads/writes to current_user

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -91,6 +91,16 @@ defmodule Fountain.Conversations do
     )
   end
 
+  @doc "List conversations for `user_id`, ordered by most recently active."
+  def list_conversations_by_activity(user_id) when is_binary(user_id) do
+    Repo.all(
+      from c in Conversation,
+        where: c.user_id == ^user_id,
+        order_by: [desc: c.updated_at, desc: c.id],
+        preload: [:agent, turns: ^first_turn_query()]
+    )
+  end
+
   @doc """
   Returns all conversations in the same spawn tree as `conversation_id`,
   including ancestors up to the root and all their descendants.
@@ -154,6 +164,14 @@ defmodule Fountain.Conversations do
     Conversation
     |> Repo.get!(id)
     |> Repo.preload([:sandbox, :agent, :vault])
+  end
+
+  @doc "Get conversation scoped to user. Returns nil on wrong owner or missing id."
+  def get_conversation(id, user_id) when is_binary(user_id) do
+    case Repo.get_by(Conversation, id: id, user_id: user_id) do
+      nil -> nil
+      conv -> Repo.preload(conv, [:sandbox, :agent, :vault])
+    end
   end
 
   @doc "Get conversation scoped to user. Raises Ecto.NoResultsError on wrong owner."

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -7,10 +7,16 @@ defmodule FountainWeb.Layouts do
 
   def app(assigns) do
     convs =
-      try do
-        Conversations.list_conversations_by_activity()
-      rescue
-        _ -> []
+      case assigns[:current_user] do
+        %{id: user_id} ->
+          try do
+            Conversations.list_conversations_by_activity(user_id)
+          rescue
+            _ -> []
+          end
+
+        _ ->
+          []
       end
 
     assigns = assign(assigns, :nav_conversations, convs)

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -21,7 +21,8 @@ defmodule FountainWeb.ConversationController do
   )
 
   def index(conn, _params) do
-    render(conn, :index, conversations: Conversations.list_conversations())
+    user = conn.assigns.current_user
+    render(conn, :index, conversations: Conversations.list_conversations(user.id))
   end
 
   operation(:show,
@@ -34,7 +35,9 @@ defmodule FountainWeb.ConversationController do
   )
 
   def show(conn, %{"id" => id}) do
-    case Conversations.get_conversation(id) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
       nil -> {:error, :not_found}
       conv -> render(conn, :show, conversation: conv)
     end
@@ -50,7 +53,9 @@ defmodule FountainWeb.ConversationController do
   )
 
   def turns(conn, %{"conversation_id" => id}) do
-    case Conversations.get_conversation(id) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
       nil ->
         {:error, :not_found}
 
@@ -146,12 +151,19 @@ defmodule FountainWeb.ConversationController do
   )
 
   def prompt(conn, %{"conversation_id" => id, "prompt" => prompt} = params) do
+    user = conn.assigns.current_user
     images = decode_images(params["images"])
 
-    case ConversationServer.send_prompt(id, prompt, images) do
-      :ok -> json(conn, %{status: "queued"})
-      {:error, :not_running} -> {:error, :not_found}
-      {:error, :busy} -> {:error, "conversation_busy"}
+    case Conversations.get_conversation(id, user.id) do
+      nil ->
+        {:error, :not_found}
+
+      _ ->
+        case ConversationServer.send_prompt(id, prompt, images) do
+          :ok -> json(conn, %{status: "queued"})
+          {:error, :not_running} -> {:error, :not_found}
+          {:error, :busy} -> {:error, "conversation_busy"}
+        end
     end
   end
 
@@ -168,9 +180,17 @@ defmodule FountainWeb.ConversationController do
   )
 
   def terminate(conn, %{"conversation_id" => id}) do
-    case ConversationServer.terminate(id) do
-      :ok -> send_resp(conn, :no_content, "")
-      {:error, :not_running} -> {:error, :not_found}
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
+      nil ->
+        {:error, :not_found}
+
+      _ ->
+        case ConversationServer.terminate(id) do
+          :ok -> send_resp(conn, :no_content, "")
+          {:error, :not_running} -> {:error, :not_found}
+        end
     end
   end
 
@@ -185,15 +205,23 @@ defmodule FountainWeb.ConversationController do
   )
 
   def interrupt(conn, %{"conversation_id" => id}) do
-    case ConversationServer.interrupt(id) do
-      :ok ->
-        send_resp(conn, :no_content, "")
+    user = conn.assigns.current_user
 
-      {:error, :not_running} ->
+    case Conversations.get_conversation(id, user.id) do
+      nil ->
         {:error, :not_found}
 
-      {:error, :idle} ->
-        conn |> put_status(:conflict) |> json(%{error: "no_turn_running"})
+      _ ->
+        case ConversationServer.interrupt(id) do
+          :ok ->
+            send_resp(conn, :no_content, "")
+
+          {:error, :not_running} ->
+            {:error, :not_found}
+
+          {:error, :idle} ->
+            conn |> put_status(:conflict) |> json(%{error: "no_turn_running"})
+        end
     end
   end
 
@@ -210,7 +238,9 @@ defmodule FountainWeb.ConversationController do
   )
 
   def delete(conn, %{"id" => id}) do
-    case Conversations.get_conversation(id) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
       nil ->
         {:error, :not_found}
 
@@ -246,7 +276,9 @@ defmodule FountainWeb.ConversationController do
   @heartbeat_ms 15_000
 
   def stream(conn, %{"conversation_id" => id} = params) do
-    case Conversations.get_conversation(id) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
       nil ->
         {:error, :not_found}
 

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -25,14 +25,24 @@ defmodule FountainWeb.ConversationsLive.Index do
 
   @impl true
   def handle_event("terminate", %{"id" => id}, socket) do
-    case Fountain.Conversations.ConversationServer.terminate(id) do
-      :ok -> {:noreply, socket |> put_flash(:info, "Terminated") |> load_data()}
-      _ -> {:noreply, put_flash(socket, :error, "Not running")}
+    user = socket.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "Not found")}
+
+      _ ->
+        case Fountain.Conversations.ConversationServer.terminate(id) do
+          :ok -> {:noreply, socket |> put_flash(:info, "Terminated") |> load_data()}
+          _ -> {:noreply, put_flash(socket, :error, "Not running")}
+        end
     end
   end
 
   def handle_event("delete", %{"id" => id}, socket) do
-    case Conversations.get_conversation(id) do
+    user = socket.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
       nil ->
         {:noreply, put_flash(socket, :error, "Not found")}
 


### PR DESCRIPTION
## Summary

**Multi-tenant data leak.** Conversations were not scoped to the requesting user across multiple surfaces. Reported when user A's conversation appeared in user B's dashboard sidebar.

### Affected surfaces

| Surface | Issue | Severity |
| --- | --- | --- |
| Layout sidebar (\`layouts.ex\`) | \`list_conversations_by_activity/0\` returned every user's conversations; rendered on every authenticated page | **Critical** — visible leak, no auth bypass needed |
| \`GET /api/conversations\` | \`list_conversations/0\` (no scoping) | **Critical** — list-all leak |
| \`GET /api/conversations/:id\` (+ \`/turns\`, \`/stream\`) | \`get_conversation/1\` lookup by id alone | **High** — IDOR read |
| \`DELETE /api/conversations/:id\` | Same IDOR | **High** — IDOR write |
| \`POST /api/conversations/:id/prompts\` (+ \`/interrupt\`, \`/terminate\`) | No conversation-ownership check | **High** — IDOR write |
| \`ConversationsLive.Index\` \`delete\` + \`terminate\` events | Acted on any id pushed over the LV WebSocket | **High** — IDOR write |

### Fix

Two new scoped helpers in \`Fountain.Conversations\`:

- \`get_conversation(id, user_id) :: Conversation.t() \| nil\`
- \`list_conversations_by_activity(user_id) :: [Conversation.t()]\`

Every user-facing call site (layout, API controller, LiveView event handlers) now passes \`current_user.id\` and treats wrong-owner as 404 / "Not found". Internal callers (\`ConversationServer.terminate/1\`) are unchanged — auth is enforced at the call sites above them.

The unscoped functions remain in the context (used by the internal server-state lookup) but no longer appear at any user-driven boundary.

## Test plan

- [x] \`mix compile --force --warnings-as-errors\` clean
- [ ] User A's sidebar only shows User A's conversations
- [ ] \`GET /api/conversations\` (auth as User A) returns only User A's conversations
- [ ] \`GET /api/conversations/:id\` for a different user's conversation returns 404
- [ ] \`DELETE\` / \`POST .../prompts\` / etc. for someone else's conversation returns 404 and does not mutate
- [ ] \`ConversationsLive.Index\` "delete"/"terminate" against a forged id (e.g. via JS console pushEvent) returns "Not found" flash, not actual mutation

## Follow-ups

- Audit \`Agents\`, \`Environments\`, \`Vaults\` contexts for the same pattern (likely have similar issues).
- Add a context-level enforcement helper or Ecto query module so future endpoints can't accidentally skip the user filter.
- Add a regression test for cross-tenant access on each scoped endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)