### PR TITLE
fix(release): repair CLI release workflow before first tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,19 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release as (e.g. v0.1.0). Must already exist on a commit."
+        required: true
+
+env:
+  ELIXIR_VERSION: "1.19.5"
+  # OTP_VERSION is also encoded in the macOS custom_erts URL in mix.exs
+  # (vendor-erts-otp-28.4). Bytecode built here runs against that ERTS,
+  # so the major version MUST match.
+  OTP_VERSION: "28.4"
+  ZIG_VERSION: "0.13.0"
 
 jobs:
   build:
@@ -26,13 +39,13 @@ jobs:
       - name: Install Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.18"
-          otp-version: "27"
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
 
       - name: Install Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: "0.13.0"
+          version: ${{ env.ZIG_VERSION }}
 
       - name: Cache deps
         uses: actions/cache@v4
@@ -47,7 +60,7 @@ jobs:
         env:
           MIX_ENV: prod
           BURRITO_TARGETS: ${{ matrix.target }}
-        run: mix release fountain
+        run: mix release fountain --overwrite
 
       - name: Stage artifact
         run: |
@@ -71,6 +84,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -79,6 +101,8 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
           files: |
             artifacts/fountain-linux-x86_64/fountain-linux-x86_64
             artifacts/fountain-macos-aarch64/fountain-macos-aarch64

--- a/mix.exs
+++ b/mix.exs
@@ -28,10 +28,7 @@ defmodule Fountain.Umbrella.MixProject do
       fountain: [
         applications: [fountain_cli: :permanent, runtime_tools: :permanent],
         steps: [:assemble, &Burrito.wrap/1],
-        burrito:
-          Keyword.merge(burrito_targets(skip_nifs: true),
-            extra_steps: [fetch: [pre: [Fountain.Burrito.InjectMuslPath]]]
-          )
+        burrito: burrito_targets(skip_nifs: true)
       ],
       fountain_server: [
         applications: [fountain_cli: :permanent, fountain: :permanent]


### PR DESCRIPTION
## Summary

Audit + fix of the existing `Release` workflow before cutting our first CLI tag. Two bugs would have crashed any tag push; both fixed here.

### Bugs found

1. **`Fountain.Burrito.InjectMuslPath` was referenced but never defined** (`mix.exs:33`). Burrito's builder iterates `extra_steps` and calls `mod.execute/1` on each one, so `mix release fountain` would crash with `UndefinedFunctionError`. The module was copy-pasted from sibling `jhgaylor/aod-ex` but never ported.

   The hack is only needed when `custom_erts:` is a URL (which causes Burrito's stock `FetchMusl` to skip). Our linux target uses the host's precompiled ERTS, so stock `FetchMusl` runs and the hack isn't needed at all. Dropped the `extra_steps` wrapper.

2. **OTP version mismatch on macOS.** Workflow installed OTP 27, but the macOS `custom_erts:` URL in `mix.exs` pins **OTP 28.4** (`vendor-erts-otp-28.4`). Burrito swaps in `custom_erts` at the end of the build, so bytecode compiled against OTP 27 would end up running on ERTS 28.4 — a major-version mismatch. Bumped CI to Elixir 1.19.5 + OTP 28.4 to match the vendor ERTS.

### Workflow improvements

- Promoted `ELIXIR_VERSION` / `OTP_VERSION` / `ZIG_VERSION` to top-level `env` so they live in one place.
- Added `workflow_dispatch` trigger with a `tag` input, so a failed release can be retried without cutting a fresh tag.
- Passed `tag_name` / `name` explicitly to `action-gh-release` (otherwise `workflow_dispatch` falls back to `GITHUB_REF`, which would be a branch ref).
- Passed `--overwrite` to `mix release` so reruns are idempotent.

### Out of scope (noted, not done)

- CLI has no `--version` flag.
- `mix.exs` version is hardcoded (`0.1.0`) — needs manual bump per release.
- No checksums / signatures.
- No Homebrew tap or install script.

## Test plan

- [ ] Merge this PR into `main`.
- [ ] Push `v0.1.0` tag from `main` (or use `workflow_dispatch` with `tag: v0.1.0`).
- [ ] Verify both `fountain-linux-x86_64` and `fountain-macos-aarch64` build.
- [ ] Verify the GitHub Release is created with both binaries attached.
- [ ] Smoke-test the macOS binary on a clean machine: `./fountain-macos-aarch64 --help` should print the help banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)