### PR TITLE
fix(release): bump Zig to 0.15.2 to match Burrito requirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,10 @@ env:
   # (vendor-erts-otp-28.4). Bytecode built here runs against that ERTS,
   # so the major version MUST match.
   OTP_VERSION: "28.4"
-  ZIG_VERSION: "0.13.0"
+  # Burrito 1.5.0 requires zig 0.15.2 (checked at build time in
+  # `Burrito.check_zig_version/0`). Bumping below that range will
+  # fail with "Your Zig version does not match the one Burrito requires".
+  ZIG_VERSION: "0.15.2"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Follow-up to #45. The v0.1.0 release run failed at \`Burrito.wrap/1\`:

\`\`\`
> Your Zig version does not match the one Burrito requires!
> We need \`0.15.2\`, you have: \`0.13.0\`
\`\`\`

Burrito 1.5.0 hard-checks the Zig version. The 0.13.0 pin was leftover from before the bump.

## Recovery plan

After this merges, re-run the release via \`workflow_dispatch\` with \`tag: v0.1.0\` — exactly the retry path #45 added. The existing v0.1.0 git tag does not need to be rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)