### PR TITLE
fix(security): propagate user_id through start_conversation + backfill orphans

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -19,6 +19,14 @@ defmodule Fountain.Agents do
   def get_agent(id), do: Repo.get(Agent, id) |> Repo.preload(:environment)
   def get_agent!(id), do: Repo.get!(Agent, id) |> Repo.preload(:environment)
 
+  @doc "Get agent scoped to user. Returns nil on wrong owner or missing id."
+  def get_agent(id, user_id) when is_binary(user_id) do
+    case Repo.get_by(Agent, id: id, user_id: user_id) do
+      nil -> nil
+      agent -> Repo.preload(agent, :environment)
+    end
+  end
+
   @doc "Get agent scoped to user. Raises Ecto.NoResultsError if wrong owner."
   def get_agent!(id, user_id) when is_binary(user_id) do
     Repo.get_by!(Agent, id: id, user_id: user_id) |> Repo.preload(:environment)

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -412,21 +412,24 @@ defmodule Fountain.Conversations do
     - `source`                — optional; one of "ui", "api", "agent" (default "api")
     - `parent_conversation_id` — optional; UUID of the conversation that spawned this one
   """
-  def start_conversation(%{"agent_id" => agent_id} = attrs) do
-    with %Agents.Agent{} = agent <- Agents.get_agent(agent_id) || {:error, :not_found},
+  def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs)
+      when is_binary(user_id) do
+    with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
-         {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"]),
+         {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id),
          {:ok, sandbox} <-
            create_sandbox(%{
              environment_id: agent.environment_id,
              sprite_name: attrs["sprite_name"] || "aod-conv-#{short_id()}",
-             status: "pending"
+             status: "pending",
+             user_id: user_id
            }),
          {:ok, conv} <-
            create_conversation(%{
              sandbox_id: sandbox.id,
              agent_id: agent.id,
              vault_id: vault_id,
+             user_id: user_id,
              runtime: agent.runtime,
              status: "pending",
              source: attrs["source"] || "api",
@@ -487,11 +490,11 @@ defmodule Fountain.Conversations do
 
   defp short_id, do: Ecto.UUID.generate() |> binary_part(0, 8)
 
-  defp resolve_vault_id(nil), do: {:ok, nil}
-  defp resolve_vault_id(""), do: {:ok, nil}
+  defp resolve_vault_id(nil, _user_id), do: {:ok, nil}
+  defp resolve_vault_id("", _user_id), do: {:ok, nil}
 
-  defp resolve_vault_id(id) when is_binary(id) do
-    case Fountain.Vaults.get_vault(id) do
+  defp resolve_vault_id(id, user_id) when is_binary(id) and is_binary(user_id) do
+    case Fountain.Vaults.get_vault(id, user_id) do
       nil -> {:error, :vault_not_found}
       vault -> {:ok, vault.id}
     end
@@ -574,7 +577,8 @@ defmodule Fountain.Conversations do
            create_sandbox(%{
              environment_id: agent.environment_id,
              sprite_name: "aod-conv-#{short_id()}",
-             status: "pending"
+             status: "pending",
+             user_id: conv.user_id
            }),
          _ <- mark_old_sandbox_terminated(conv.sandbox_id),
          {:ok, conv} <-

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -51,7 +51,7 @@ defmodule Fountain.Conversations.Conversation do
       :agent_id,
       :vault_id
     ])
-    |> validate_required([:runtime, :status, :sandbox_id])
+    |> validate_required([:runtime, :status, :sandbox_id, :user_id])
     |> validate_inclusion(:status, @statuses)
     |> validate_inclusion(:source, @sources)
     |> foreign_key_constraint(:sandbox_id)

--- a/apps/fountain/lib/fountain/conversations/sandbox.ex
+++ b/apps/fountain/lib/fountain/conversations/sandbox.ex
@@ -27,7 +27,7 @@ defmodule Fountain.Conversations.Sandbox do
   def changeset(sandbox, attrs) do
     sandbox
     |> cast(attrs, [:sprite_name, :status, :exit_code, :terminated_at, :environment_id, :user_id])
-    |> validate_required([:sprite_name, :status])
+    |> validate_required([:sprite_name, :status, :user_id])
     |> validate_inclusion(:status, @statuses)
   end
 end

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -25,6 +25,11 @@ defmodule Fountain.Vaults do
     Repo.all(from v in Vault, where: v.user_id == ^user_id, order_by: [desc: v.inserted_at, desc: v.id])
   end
 
+  @doc "Get vault scoped to user. Returns nil on wrong owner or missing id."
+  def get_vault(id, user_id) when is_binary(user_id) do
+    Repo.get_by(Vault, id: id, user_id: user_id)
+  end
+
   @doc "Get vault scoped to user. Raises Ecto.NoResultsError on wrong owner."
   def get_vault!(id, user_id) when is_binary(user_id) do
     Repo.get_by!(Vault, id: id, user_id: user_id)

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -88,6 +88,7 @@ defmodule FountainWeb.ConversationController do
   )
 
   def create(conn, params) do
+    user = conn.assigns.current_user
     images = decode_images(params["images"])
 
     parent_header =
@@ -102,8 +103,9 @@ defmodule FountainWeb.ConversationController do
       |> Map.put("images", images)
       |> Map.put("source", source)
       |> Map.put("parent_conversation_id", parent_id)
+      |> Map.put("user_id", user.id)
 
-    with :ok <- gate_subscription(conn.assigns.current_user),
+    with :ok <- gate_subscription(user),
          {:ok, conv} <- Conversations.start_conversation(params) do
       conn
       |> put_status(:created)

--- a/apps/fountain/priv/repo/migrations/20260510220000_backfill_conversation_and_sandbox_user_ids.exs
+++ b/apps/fountain/priv/repo/migrations/20260510220000_backfill_conversation_and_sandbox_user_ids.exs
@@ -1,0 +1,35 @@
+defmodule Fountain.Repo.Migrations.BackfillConversationAndSandboxUserIds do
+  use Ecto.Migration
+
+  def up do
+    # Conversations were created without user_id propagation; agent.user_id
+    # is the source of truth for who owns the conversation.
+    execute("""
+    UPDATE conversations c
+       SET user_id = a.user_id
+      FROM agents a
+     WHERE c.agent_id = a.id
+       AND c.user_id IS NULL
+       AND a.user_id IS NOT NULL
+    """)
+
+    # Sandboxes have the same gap. Derive ownership from the conversations
+    # attached to them; pick any (they should all share an owner once the
+    # conversation backfill above runs).
+    execute("""
+    UPDATE sandboxes s
+       SET user_id = c.user_id
+      FROM conversations c
+     WHERE c.sandbox_id = s.id
+       AND s.user_id IS NULL
+       AND c.user_id IS NOT NULL
+    """)
+
+    # Anything still NULL has no agent or no conversations — orphan rows.
+    # Delete them rather than carry around unreachable data.
+    execute("DELETE FROM conversations WHERE user_id IS NULL")
+    execute("DELETE FROM sandboxes WHERE user_id IS NULL")
+  end
+
+  def down, do: :ok
+end


### PR DESCRIPTION
## Summary

Root cause behind the cross-tenant leak fixed at the symptom level in #44: \`Conversations.start_conversation/1\` built a new attrs map for \`create_conversation\` (and \`create_sandbox\`) that **did not include user_id**, so every conversation and sandbox row was inserted with \`user_id: NULL\`.

- \`list_conversations(user_id)\` returned nothing for any real user (NULL ≠ uuid).
- \`list_conversations_by_activity/0\` (no filter) returned all rows, including the NULL-owner rows — that's what users saw in each other's sidebar.

#44 patched the symptom (added scoped variants and routed user-driven calls through them). This PR fixes the source so new conversations are correctly attributed and existing orphans are repaired.

## Changes

- \`start_conversation/1\` now requires \`"user_id"\` in attrs and propagates it into both \`create_sandbox\` and \`create_conversation\`.
- Agent ownership: switched the agent lookup to \`Agents.get_agent/2\` (new arity-2 returning nil on wrong owner). User B can no longer start a conversation against user A's agent.
- Vault ownership: \`resolve_vault_id/2\` now takes \`user_id\` and uses \`Vaults.get_vault/2\` (new). User B can no longer attach user A's vault to a new conversation.
- \`Conversation.changeset\` and \`Sandbox.changeset\` \`validate_required(:user_id)\` so future inserts can't silently skip it.
- \`ConversationController.create\` passes \`current_user.id\` into attrs.
- \`create_fresh_sandbox_and_start\` (resume path after GenServer GC) reads \`user_id\` off the existing conversation.

## Migration (\`20260510220000\`)

\`\`\`sql
UPDATE conversations c SET user_id = a.user_id
  FROM agents a
 WHERE c.agent_id = a.id AND c.user_id IS NULL AND a.user_id IS NOT NULL;

UPDATE sandboxes s SET user_id = c.user_id
  FROM conversations c
 WHERE c.sandbox_id = s.id AND s.user_id IS NULL AND c.user_id IS NOT NULL;

DELETE FROM conversations WHERE user_id IS NULL;
DELETE FROM sandboxes     WHERE user_id IS NULL;
\`\`\`

Anything still NULL after backfill is an orphan (no owning agent or no conversations) and gets deleted. There may be a small number of these in prod from the broken-state period; their loss is expected and acceptable.

## Test plan

- [x] \`mix compile --force --warnings-as-errors\` clean
- [x] \`mix ecto.migrate\` runs cleanly on dev DB
- [ ] After deploy: prod migration runs cleanly, dashboard shows the expected per-user conversations
- [ ] Starting a new conversation as user A → row has \`user_id = A\`
- [ ] User B trying \`POST /api/conversations\` with user A's \`agent_id\` → 404
- [ ] User B trying with user A's \`vault_id\` → \`vault_not_found\`

## Follow-ups

This is part 1 of a 4-PR series following the multi-tenant audit:
- [ ] PR 2: \`AgentController\` REST endpoints (4 IDOR surfaces from the audit)
- [ ] PR 3: \`VaultController\` + \`VaultSecretController\` (12 leaks, including upserting secrets into someone else's vault)
- [ ] PR 4: \`EnvironmentController\` + \`SecretController\` (5 leaks)
- [ ] Then: rename surviving unscoped fns to \`_unsafe_*\` + add cross-tenant regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)