### PR TITLE
fix(security): scope AgentController endpoints to current_user

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
@@ -20,7 +20,8 @@ defmodule FountainWeb.AgentController do
   )
 
   def index(conn, _params) do
-    render(conn, :index, agents: Agents.list_agents())
+    user = conn.assigns.current_user
+    render(conn, :index, agents: Agents.list_agents(user.id, []))
   end
 
   operation(:show,
@@ -33,7 +34,9 @@ defmodule FountainWeb.AgentController do
   )
 
   def show(conn, %{"id" => id}) do
-    case Agents.get_agent(id) do
+    user = conn.assigns.current_user
+
+    case Agents.get_agent(id, user.id) do
       nil -> {:error, :not_found}
       agent -> render(conn, :show, agent: agent)
     end
@@ -49,10 +52,15 @@ defmodule FountainWeb.AgentController do
   )
 
   def create(conn, params) do
-    with {:ok, %Agent{} = agent} <- Agents.create_agent(params) do
+    user = conn.assigns.current_user
+    # Force the new agent's user_id to the authenticated user; ignore any
+    # client-supplied user_id to prevent owner spoofing.
+    attrs = Map.put(params, "user_id", user.id)
+
+    with {:ok, %Agent{} = agent} <- Agents.create_agent(attrs) do
       conn
       |> put_status(:created)
-      |> render(:show, agent: Agents.get_agent!(agent.id))
+      |> render(:show, agent: Agents.get_agent!(agent.id, user.id))
     end
   end
 
@@ -69,13 +77,17 @@ defmodule FountainWeb.AgentController do
   )
 
   def update(conn, %{"id" => id} = params) do
-    case Agents.get_agent(id) do
+    user = conn.assigns.current_user
+    # Strip user_id from update attrs so the owner can't be reassigned.
+    attrs = params |> Map.delete("id") |> Map.delete("user_id")
+
+    case Agents.get_agent(id, user.id) do
       nil ->
         {:error, :not_found}
 
       agent ->
-        with {:ok, agent} <- Agents.update_agent(agent, Map.delete(params, "id")) do
-          render(conn, :show, agent: Agents.get_agent!(agent.id))
+        with {:ok, agent} <- Agents.update_agent(agent, attrs) do
+          render(conn, :show, agent: Agents.get_agent!(agent.id, user.id))
         end
     end
   end
@@ -90,7 +102,9 @@ defmodule FountainWeb.AgentController do
   )
 
   def delete(conn, %{"id" => id}) do
-    case Agents.get_agent(id) do
+    user = conn.assigns.current_user
+
+    case Agents.get_agent(id, user.id) do
       nil ->
         {:error, :not_found}
 


### PR DESCRIPTION
## Summary

Audit follow-up to #44/#48. \`AgentController\` had IDOR on every endpoint:

| Endpoint | Bug | Now |
| --- | --- | --- |
| \`GET /api/agents\` | returned all agents (\`list_agents/0\`) | \`list_agents(current_user.id, [])\` |
| \`GET /api/agents/:id\` | \`get_agent/1\` (any id) | \`get_agent/2\` → 404 on wrong owner |
| \`POST /api/agents\` | didn't pin \`user_id\` — client could spoof owner via body | force \`user_id\` from \`current_user\` |
| \`PATCH /api/agents/:id\` | didn't scope lookup AND didn't strip \`user_id\` from attrs (owner reassignment) | scoped lookup + strip \`user_id\` from update attrs |
| \`DELETE /api/agents/:id\` | unscoped delete | scoped lookup |

Context already had scoped variants (\`Agents.get_agent/2\`, \`Agents.list_agents/2\`); this just routes the controller through them.

## Test plan

- [x] \`mix compile --force --warnings-as-errors\` clean
- [ ] \`GET /api/agents\` (auth as A) returns only A's agents
- [ ] \`GET /api/agents/:id\` for B's agent → 404
- [ ] \`POST /api/agents\` with body \`{"user_id": "<some other id>", ...}\` ignores the spoofed user_id
- [ ] \`PATCH /api/agents/:id\` for B's agent → 404; for own agent with body \`{"user_id": "<other>"}\` → user_id unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)