### PR TITLE
fix(release): install Zig 0.15.2 from ziglang.org directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,21 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
 
+      # mlugg/setup-zig@v1's index doesn't have 0.15.2; install
+      # straight from ziglang.org. macos-latest runners are aarch64.
       - name: Install Zig
-        uses: mlugg/setup-zig@v1
-        with:
-          version: ${{ env.ZIG_VERSION }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          case "${{ runner.os }}" in
+            Linux) tarball="zig-x86_64-linux-${ZIG_VERSION}.tar.xz" ;;
+            macOS) tarball="zig-aarch64-macos-${ZIG_VERSION}.tar.xz" ;;
+            *) echo "unsupported runner.os: ${{ runner.os }}"; exit 1 ;;
+          esac
+          dir="${tarball%.tar.xz}"
+          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/${tarball}" | tar -xJ
+          echo "$PWD/${dir}" >> "$GITHUB_PATH"
+          "$PWD/${dir}/zig" version
 
       - name: Cache deps
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

Follow-up to #47. The retried v0.1.0 release run failed at the Install Zig step:

\`\`\`
Unexpected HTTP response: 404
\`\`\`

\`mlugg/setup-zig@v1\` queries its own index for the requested version, and **0.15.2 isn't in it** (the action's index lags ziglang.org). ziglang.org itself hosts 0.15.2 fine — just curl it directly, matching the pattern in sibling \`jhgaylor/aod-ex\`. macos-latest runners are aarch64, so the OS switch picks the right tarball.

## Recovery plan

After merge, re-dispatch the Release workflow with \`tag: v0.1.0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)