### PR TITLE
fix(security): scope VaultController + VaultSecretController to current_user

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
@@ -20,7 +20,8 @@ defmodule FountainWeb.VaultController do
   )
 
   def index(conn, _params) do
-    render(conn, :index, vaults: Vaults.list_vaults())
+    user = conn.assigns.current_user
+    render(conn, :index, vaults: Vaults.list_vaults(user.id))
   end
 
   operation(:show,
@@ -33,7 +34,9 @@ defmodule FountainWeb.VaultController do
   )
 
   def show(conn, %{"id" => id}) do
-    case Vaults.get_vault(id) do
+    user = conn.assigns.current_user
+
+    case Vaults.get_vault(id, user.id) do
       nil -> {:error, :not_found}
       vault -> render(conn, :show, vault: vault)
     end
@@ -49,7 +52,10 @@ defmodule FountainWeb.VaultController do
   )
 
   def create(conn, params) do
-    with {:ok, %Vault{} = vault} <- Vaults.create_vault(params) do
+    user = conn.assigns.current_user
+    attrs = Map.put(params, "user_id", user.id)
+
+    with {:ok, %Vault{} = vault} <- Vaults.create_vault(attrs) do
       conn
       |> put_status(:created)
       |> render(:show, vault: vault)
@@ -69,12 +75,15 @@ defmodule FountainWeb.VaultController do
   )
 
   def update(conn, %{"id" => id} = params) do
-    case Vaults.get_vault(id) do
+    user = conn.assigns.current_user
+    attrs = params |> Map.delete("id") |> Map.delete("user_id")
+
+    case Vaults.get_vault(id, user.id) do
       nil ->
         {:error, :not_found}
 
       vault ->
-        with {:ok, vault} <- Vaults.update_vault(vault, Map.delete(params, "id")) do
+        with {:ok, vault} <- Vaults.update_vault(vault, attrs) do
           render(conn, :show, vault: vault)
         end
     end
@@ -90,7 +99,9 @@ defmodule FountainWeb.VaultController do
   )
 
   def delete(conn, %{"id" => id}) do
-    case Vaults.get_vault(id) do
+    user = conn.assigns.current_user
+
+    case Vaults.get_vault(id, user.id) do
       nil ->
         {:error, :not_found}
 

--- a/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
@@ -21,7 +21,9 @@ defmodule FountainWeb.VaultSecretController do
   )
 
   def index(conn, %{"vault_id" => vault_id}) do
-    case Vaults.get_vault(vault_id) do
+    user = conn.assigns.current_user
+
+    case Vaults.get_vault(vault_id, user.id) do
       nil -> {:error, :not_found}
       vault -> render(conn, :index, secrets: Vaults.list_secrets(vault))
     end
@@ -42,13 +44,15 @@ defmodule FountainWeb.VaultSecretController do
   )
 
   def create(conn, %{"vault_id" => vault_id} = params) do
-    case Vaults.get_vault(vault_id) do
+    user = conn.assigns.current_user
+
+    case Vaults.get_vault(vault_id, user.id) do
       nil ->
         {:error, :not_found}
 
       vault ->
         attrs = Map.take(params, ["key", "value"])
-        {:ok, dek} = Crypto.load_tenant_key(conn.assigns.current_user.id)
+        {:ok, dek} = Crypto.load_tenant_key(user.id)
 
         with {:ok, secret} <- Vaults.upsert_secret(vault, attrs, dek) do
           conn
@@ -71,13 +75,14 @@ defmodule FountainWeb.VaultSecretController do
   )
 
   def delete(conn, %{"vault_id" => vault_id, "id" => key}) do
-    case Vaults.get_secret(vault_id, key) do
-      nil ->
-        {:error, :not_found}
+    user = conn.assigns.current_user
 
-      secret ->
-        {:ok, _} = Vaults.delete_secret(secret)
-        send_resp(conn, :no_content, "")
+    with %_{} <- Vaults.get_vault(vault_id, user.id),
+         %_{} = secret <- Vaults.get_secret(vault_id, key) do
+      {:ok, _} = Vaults.delete_secret(secret)
+      send_resp(conn, :no_content, "")
+    else
+      _ -> {:error, :not_found}
     end
   end
 end


### PR DESCRIPTION
## Summary

Audit follow-up. The biggest single chunk of the multi-tenant audit (12 leaks). Vaults hold encrypted secret material, so the upsert + read endpoints were the worst leaks in the codebase.

### VaultController

| Endpoint | Bug | Fix |
| --- | --- | --- |
| \`GET /api/vaults\` | returned all vaults | \`list_vaults(user.id)\` |
| \`GET /api/vaults/:id\` | \`get_vault/1\` | \`get_vault/2\` |
| \`POST /api/vaults\` | client could spoof \`user_id\` | force \`user_id\` from \`current_user\` |
| \`PATCH /api/vaults/:id\` | unscoped lookup + owner reassignment via attrs | scoped lookup + strip \`user_id\` |
| \`DELETE /api/vaults/:id\` | unscoped delete | scoped lookup |

### VaultSecretController

| Endpoint | Bug | Fix |
| --- | --- | --- |
| \`GET /api/vaults/:vault_id/secrets\` | read other users' secret metadata via vault_id | scoped vault lookup |
| \`POST /api/vaults/:vault_id/secrets\` | **user B could write secrets INTO user A's vault** (DEK loaded from B, ciphertext bound to A's vault) | scoped vault lookup |
| \`DELETE /api/vaults/:vault_id/secrets/:id\` | resolved secret by \`(vault_id, key)\` without verifying vault ownership | scoped vault lookup *first*, then secret lookup |

All endpoints route through \`Vaults.get_vault/2\` (the new arity-2 added in #48).

## Test plan

- [x] \`mix compile --force --warnings-as-errors\` clean
- [ ] \`GET /api/vaults\` (auth as A) returns only A's vaults
- [ ] \`POST /api/vaults\` body \`{"user_id": "<other>", ...}\` → vault stored with auth user, not body user
- [ ] \`PATCH /api/vaults/:id\` for own vault with \`{"user_id": "<other>"}\` → user_id unchanged
- [ ] \`POST /api/vaults/<B's vault id>/secrets\` (auth as A) → 404, B's vault not modified
- [ ] \`DELETE /api/vaults/<B's vault id>/secrets/SOME_KEY\` (auth as A) → 404, B's secret intact
- [ ] Conversation-creation path: \`POST /api/conversations\` with B's \`vault_id\` → \`vault_not_found\` (already covered by #48 but worth re-verifying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)