### PR TITLE
fix(security): scope EnvironmentController + SecretController to current_user

### DIFF
--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -24,6 +24,11 @@ defmodule Fountain.Environments do
     )
   end
 
+  @doc "Get environment scoped to user. Returns nil on wrong owner or missing id."
+  def get_environment(id, user_id) when is_binary(user_id) do
+    Repo.get_by(Environment, id: id, user_id: user_id)
+  end
+
   @doc "Get environment scoped to user. Raises Ecto.NoResultsError on wrong owner."
   def get_environment!(id, user_id) when is_binary(user_id) do
     Repo.get_by!(Environment, id: id, user_id: user_id)

--- a/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
@@ -20,7 +20,8 @@ defmodule FountainWeb.EnvironmentController do
   )
 
   def index(conn, _params) do
-    render(conn, :index, environments: Environments.list_environments())
+    user = conn.assigns.current_user
+    render(conn, :index, environments: Environments.list_environments(user.id))
   end
 
   operation(:show,
@@ -33,7 +34,9 @@ defmodule FountainWeb.EnvironmentController do
   )
 
   def show(conn, %{"id" => id}) do
-    case Environments.get_environment(id) do
+    user = conn.assigns.current_user
+
+    case Environments.get_environment(id, user.id) do
       nil -> {:error, :not_found}
       env -> render(conn, :show, environment: env)
     end
@@ -49,7 +52,10 @@ defmodule FountainWeb.EnvironmentController do
   )
 
   def create(conn, params) do
-    with {:ok, %Environment{} = env} <- Environments.create_environment(params) do
+    user = conn.assigns.current_user
+    attrs = Map.put(params, "user_id", user.id)
+
+    with {:ok, %Environment{} = env} <- Environments.create_environment(attrs) do
       conn
       |> put_status(:created)
       |> render(:show, environment: env)
@@ -70,12 +76,15 @@ defmodule FountainWeb.EnvironmentController do
   )
 
   def update(conn, %{"id" => id} = params) do
-    case Environments.get_environment(id) do
+    user = conn.assigns.current_user
+    attrs = params |> Map.delete("id") |> Map.delete("user_id")
+
+    case Environments.get_environment(id, user.id) do
       nil ->
         {:error, :not_found}
 
       env ->
-        with {:ok, env} <- Environments.update_environment(env, Map.delete(params, "id")) do
+        with {:ok, env} <- Environments.update_environment(env, attrs) do
           render(conn, :show, environment: env)
         end
     end
@@ -91,7 +100,9 @@ defmodule FountainWeb.EnvironmentController do
   )
 
   def delete(conn, %{"id" => id}) do
-    case Environments.get_environment(id) do
+    user = conn.assigns.current_user
+
+    case Environments.get_environment(id, user.id) do
       nil ->
         {:error, :not_found}
 

--- a/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
@@ -21,7 +21,7 @@ defmodule FountainWeb.SecretController do
   )
 
   def index(conn, %{"environment_id" => env_id}) do
-    case Environments.get_environment(env_id) do
+    case Environments.get_environment(env_id, conn.assigns.current_user.id) do
       nil -> {:error, :not_found}
       env -> render(conn, :index, secrets: Environments.list_secrets(env))
     end
@@ -42,7 +42,7 @@ defmodule FountainWeb.SecretController do
   )
 
   def create(conn, %{"environment_id" => env_id} = params) do
-    case Environments.get_environment(env_id) do
+    case Environments.get_environment(env_id, conn.assigns.current_user.id) do
       nil ->
         {:error, :not_found}
 
@@ -71,13 +71,14 @@ defmodule FountainWeb.SecretController do
   )
 
   def delete(conn, %{"environment_id" => env_id, "id" => key}) do
-    case Environments.get_secret(env_id, key) do
-      nil ->
-        {:error, :not_found}
+    user = conn.assigns.current_user
 
-      secret ->
-        {:ok, _} = Environments.delete_secret(secret)
-        send_resp(conn, :no_content, "")
+    with %_{} <- Environments.get_environment(env_id, user.id),
+         %_{} = secret <- Environments.get_secret(env_id, key) do
+      {:ok, _} = Environments.delete_secret(secret)
+      send_resp(conn, :no_content, "")
+    else
+      _ -> {:error, :not_found}
     end
   end
 end


### PR DESCRIPTION
## Summary

Audit follow-up. Same IDOR pattern as #49/#51:

### EnvironmentController (5 leaks)

| Endpoint | Bug | Fix |
| --- | --- | --- |
| \`GET /api/environments\` | returned all envs | \`list_environments(user.id)\` |
| \`GET /api/environments/:id\` | \`get_environment/1\` | \`get_environment/2\` (new) |
| \`POST /api/environments\` | client could spoof \`user_id\` | force \`user_id\` |
| \`PATCH /api/environments/:id\` | unscoped + owner reassignment | scoped + strip \`user_id\` |
| \`DELETE /api/environments/:id\` | unscoped delete | scoped lookup |

### SecretController (env secrets, 2 leaks)

| Endpoint | Bug | Fix |
| --- | --- | --- |
| \`GET /api/environments/:env_id/secrets\` | unscoped parent lookup | scoped \`get_environment/2\` |
| \`POST /api/environments/:env_id/secrets\` | user B could write secrets into A's env | scoped parent lookup |
| \`DELETE /api/environments/:env_id/secrets/:id\` | resolved secret by \`(env_id, key)\` without verifying env owner | parent-env scoped lookup, *then* secret lookup |

Added \`Environments.get_environment/2\` (returning nil); the \`!\`-raising variant already existed.

## Test plan

- [x] \`mix compile --force --warnings-as-errors\` clean
- [ ] \`GET /api/environments\` (auth A) returns only A's envs
- [ ] \`POST /api/environments\` body with spoofed \`user_id\` → ignored
- [ ] \`PATCH /api/environments/:id\` body with \`user_id\` → ignored
- [ ] \`POST /api/environments/<B's env id>/secrets\` (auth A) → 404
- [ ] \`DELETE\` against B's secret (auth A) → 404, B's data intact

That closes the audit's controller surface. Next up: cross-tenant regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)