### PR TITLE
feat: public marketing landing page at /

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -52,7 +52,7 @@ defmodule FountainWeb.Layouts do
         >
           <%!-- Sidebar header --%>
           <div class="flex items-center justify-between p-4 border-b border-[var(--color-border)] shrink-0">
-            <.link navigate={~p"/"} class="flex items-center gap-2">
+            <.link navigate={~p"/conversations"} class="flex items-center gap-2">
               <div class="size-7 rounded-md bg-[var(--color-brand)] flex items-center justify-center">
                 <svg
                   class="size-4 text-white"
@@ -84,7 +84,7 @@ defmodule FountainWeb.Layouts do
             class="px-2 pt-3 pb-1 text-sm space-y-0.5 shrink-0"
             aria-label="Primary navigation"
           >
-            <.nav_link href={~p"/"} label="Conversations" current={@current_path} />
+            <.nav_link href={~p"/conversations"} label="Conversations" current={@current_path} />
             <.nav_link href={~p"/agents"} label="Agents" current={@current_path} />
             <.nav_link href={~p"/environments"} label="Environments" current={@current_path} />
             <.nav_link href={~p"/vaults"} label="Vaults" current={@current_path} />

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -1,0 +1,52 @@
+<div class="min-h-screen flex flex-col bg-[var(--color-bg-0)] text-[var(--color-text-primary)]">
+  <%!-- Top nav --%>
+  <header class="border-b border-[var(--color-border)] bg-[var(--color-bg-0)]">
+    <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="/" class="flex items-center gap-2">
+        <div class="size-7 rounded-md bg-[var(--color-brand)] flex items-center justify-center">
+          <svg
+            class="size-4 text-white"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            aria-hidden="true"
+          >
+            <path d="M3 12h18M3 6l9-3 9 3M3 18l9 3 9-3" />
+          </svg>
+        </div>
+        <span class="font-semibold text-sm text-[var(--color-text-primary)]">Fountain</span>
+      </a>
+      <nav class="flex items-center gap-3">
+        <a
+          href={~p"/auth/login"}
+          class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors px-3 py-1.5 rounded-md hover:bg-[var(--color-bg-2)]"
+        >
+          Sign in
+        </a>
+        <a
+          href={~p"/auth/register"}
+          class="text-sm font-medium bg-[var(--color-brand)] text-white px-4 py-1.5 rounded-md hover:bg-[var(--color-brand-hover)] transition-colors"
+        >
+          Get started
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <%!-- Page content --%>
+  <main class="flex-1">
+    {@inner_content}
+  </main>
+
+  <%!-- Footer --%>
+  <footer class="border-t border-[var(--color-border)] bg-[var(--color-bg-1)]">
+    <div class="max-w-5xl mx-auto px-6 py-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-[var(--color-text-muted)]">
+      <span>© 2026 Fountain. Managed agent infrastructure for teams who'd rather build than configure.</span>
+      <div class="flex items-center gap-4">
+        <a href={~p"/auth/login"} class="hover:text-[var(--color-text-secondary)] transition-colors">Sign in</a>
+        <a href={~p"/auth/register"} class="hover:text-[var(--color-text-secondary)] transition-colors">Register</a>
+      </div>
+    </div>
+  </footer>
+</div>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -1,0 +1,11 @@
+defmodule FountainWeb.MarketingController do
+  use FountainWeb, :controller
+
+  def home(conn, _params) do
+    if conn.assigns[:current_user] do
+      redirect(conn, to: ~p"/dashboard")
+    else
+      render(conn, :home, layout: {FountainWeb.Layouts, :marketing})
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1,0 +1,5 @@
+defmodule FountainWeb.MarketingHTML do
+  use FountainWeb, :html
+
+  embed_templates "marketing_html/*"
+end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -1,0 +1,123 @@
+<%!-- Hero --%>
+<section class="max-w-5xl mx-auto px-6 py-20 text-center">
+  <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
+    Stop wiring up Claude instances by hand.
+  </h1>
+  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
+    Fountain gives teams a single place to define agent environments, swap credentials, and run sandboxed conversations — with real-time log visibility and nothing to configure locally.
+  </p>
+  <div class="flex flex-col sm:flex-row gap-3 justify-center">
+    <a
+      href={~p"/auth/register"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+    >
+      Get started free
+    </a>
+    <a
+      href={~p"/auth/login"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+    >
+      Sign in
+    </a>
+  </div>
+</section>
+
+<%!-- Problem --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-6 text-center">
+      Manual configuration doesn't scale.
+    </h2>
+    <p class="text-[var(--color-text-secondary)] max-w-2xl mx-auto text-center leading-relaxed">
+      A developer using Claude Code solo can manage configuration by hand — environment variables in <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">.env</code>, credentials in shell profiles, skills copy-pasted from shared docs. At team scale, it breaks: new teammates spend afternoons reverse-engineering setup, API keys expire mid-sprint with no single source of truth, and parallel tasks with different credentials require maintaining separate local checkouts. Every new agent multiplies the configuration surface, and every parallel conversation multiplies the credential management problem — the productivity promise of AI-assisted coding erodes under the weight of keeping the plumbing consistent.
+    </p>
+  </div>
+</section>
+
+<%!-- Feature cards --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
+    Everything you need, nothing you don't.
+  </h2>
+  <div class="grid sm:grid-cols-2 gap-6">
+    <%!-- Self-serve onboarding --%>
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+      <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
+        <svg class="size-5 text-[var(--color-brand)]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M10 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm-7 9a7 7 0 1 1 14 0H3Z" clip-rule="evenodd" />
+        </svg>
+      </div>
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">Self-serve onboarding</h3>
+      <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        A new user arrives at a URL, registers, configures a first agent, and starts a conversation without reading documentation or filing a ticket. The onboarding wizard steps through environment setup, agent configuration, and first run in a single guided flow.
+      </p>
+    </div>
+
+    <%!-- Vaults --%>
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+      <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
+        <svg class="size-5 text-[var(--color-brand)]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z" clip-rule="evenodd" />
+        </svg>
+      </div>
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">Vaults for credential swapping</h3>
+      <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        A Vault is a scoped set of encrypted env-var overrides applied per conversation. Teams use Vaults to run the same agent under different GitHub identities or API keys without redefining the underlying environment. Vault values win over Environment secrets on collision.
+      </p>
+    </div>
+
+    <%!-- Log viewer --%>
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+      <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
+        <svg class="size-5 text-[var(--color-brand)]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M2 4.25A2.25 2.25 0 0 1 4.25 2h11.5A2.25 2.25 0 0 1 18 4.25v8.5A2.25 2.25 0 0 1 15.75 15h-3.105a3.501 3.501 0 0 0 1.1 1.677A.75.75 0 0 1 13.26 18H6.74a.75.75 0 0 1-.484-1.323A3.501 3.501 0 0 0 7.355 15H4.25A2.25 2.25 0 0 1 2 12.75v-8.5Zm1.5 0a.75.75 0 0 1 .75-.75h11.5a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-.75.75H4.25a.75.75 0 0 1-.75-.75v-7.5Z" clip-rule="evenodd" />
+        </svg>
+      </div>
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">In-browser log viewer</h3>
+      <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        Every conversation's stdout, stderr, and lifecycle events stream in real time directly in the dashboard. No <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">curl -N</code> to a raw SSE endpoint, no log aggregation setup. Debugging a stuck sandbox takes seconds.
+      </p>
+    </div>
+
+    <%!-- Three surfaces --%>
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+      <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
+        <svg class="size-5 text-[var(--color-brand)]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M3.25 4A2.25 2.25 0 0 0 1 6.25v7.5A2.25 2.25 0 0 0 3.25 16h7.5A2.25 2.25 0 0 0 13 13.75v-7.5A2.25 2.25 0 0 0 10.75 4h-7.5ZM19 4.75a.75.75 0 0 0-1.28-.53l-3 3a.75.75 0 0 0-.22.53v4.5c0 .199.079.39.22.53l3 3a.75.75 0 0 0 1.28-.53V4.75Z" />
+        </svg>
+      </div>
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">Three surfaces, one data model</h3>
+      <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        Fountain exposes a REST API for automation, a Phoenix LiveView dashboard for interactive use, and an <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">aod</code> CLI preconfigured to point at the hosted service. Developers script against the API; teammates use the dashboard; CI pipelines call the CLI.
+      </p>
+    </div>
+  </div>
+</section>
+
+<%!-- Customer quote --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-3xl mx-auto px-6 py-16 text-center">
+    <blockquote class="text-lg text-[var(--color-text-primary)] leading-relaxed mb-6">
+      "We were maintaining three separate <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">.env</code> files and a shared Notion doc to keep our agent configs in sync. Every time someone's API key rotated, we'd spend an hour tracking down which conversation had stale credentials. Fountain replaced all of it. We define the environment once, swap credentials with a Vault when we need to, and every team member starts from the same baseline. Onboarding the last two engineers took ten minutes each."
+    </blockquote>
+    <p class="text-sm text-[var(--color-text-muted)] font-medium">
+      — Engineering lead, early access customer
+    </p>
+  </div>
+</section>
+
+<%!-- Footer CTA --%>
+<section class="max-w-5xl mx-auto px-6 py-20 text-center">
+  <h2 class="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] mb-4">
+    Start your free 14-day trial.
+  </h2>
+  <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
+    Spin up your first sandboxed agent conversation in under ten minutes. No credit card required.
+  </p>
+  <a
+    href={~p"/auth/register"}
+    class="inline-flex items-center justify-center px-8 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors"
+  >
+    Get started free
+  </a>
+</section>

--- a/apps/fountain/lib/fountain_web/controllers/session_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/session_controller.ex
@@ -62,7 +62,7 @@ defmodule FountainWeb.SessionController do
       conn
       |> configure_session(renew: true)
       |> put_session(:admin, true)
-      |> redirect(to: ~p"/")
+      |> redirect(to: ~p"/conversations")
     else
       conn
       |> put_status(:unauthorized)

--- a/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
@@ -69,7 +69,7 @@ defmodule FountainWeb.UeberauthController do
           |> configure_session(renew: true)
           |> put_session(:user_id, user.id)
           |> put_session(:session_version, user.session_version)
-          |> redirect(to: ~p"/")
+          |> redirect(to: ~p"/conversations")
 
         {:error, _changeset} ->
           conn

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -17,7 +17,7 @@ defmodule FountainWeb.ConversationsLive.Show do
 
     case conv do
       nil ->
-        {:ok, socket |> put_flash(:error, "Conversation not found") |> push_navigate(to: ~p"/")}
+        {:ok, socket |> put_flash(:error, "Conversation not found") |> push_navigate(to: ~p"/conversations")}
 
       conv ->
         graph = Conversations.get_conversation_tree(id)
@@ -188,7 +188,7 @@ defmodule FountainWeb.ConversationsLive.Show do
     {:noreply,
      socket
      |> put_flash(:info, "Conversation deleted")
-     |> push_navigate(to: ~p"/")}
+     |> push_navigate(to: ~p"/conversations")}
   end
 
   def handle_event("update_prompt", %{"prompt" => p}, socket) do

--- a/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
@@ -33,7 +33,7 @@ defmodule FountainWeb.LogViewerLive.Show do
       {:ok,
        socket
        |> put_flash(:error, "Conversation not found")
-       |> push_navigate(to: ~p"/")}
+       |> push_navigate(to: ~p"/conversations")}
     end
   end
 

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -53,6 +53,12 @@ defmodule FountainWeb.Router do
 
   ## ─── Public browser routes ──────────────────────────────────────────────────
 
+  # Marketing landing page — public, no auth required
+  scope "/", FountainWeb do
+    pipe_through :browser
+    get "/", MarketingController, :home
+  end
+
   # Legacy single-tenant admin login (kept for ops runbook compat)
   scope "/", FountainWeb do
     pipe_through :browser
@@ -159,7 +165,7 @@ defmodule FountainWeb.Router do
         {FountainWeb.Live.Hooks, :require_authenticated_user},
         {FountainWeb.Live.Hooks, :require_active_subscription}
       ] do
-      live "/", ConversationsLive.Index, :index
+      live "/conversations", ConversationsLive.Index, :index
       live "/conversations/new", ConversationsLive.New, :new
       live "/conversations/:id", ConversationsLive.Show, :show
     end


### PR DESCRIPTION
## Summary

- Adds a public marketing landing page at `GET /` with no auth required. Authenticated users are redirected to `/dashboard`.
- Moves `ConversationsLive` from `/` to `/conversations` (inside the `:active_subscription` live_session).
- New `MarketingController` + `MarketingHTML` view + `marketing.html.heex` layout (minimal nav + footer, no sidebar).
- `home.html.heex` template built from the phase-1 press release: hero, problem section, 4 feature cards, customer quote, footer CTA.
- All internal links that used `~p"/"` as the conversations list updated to `~p"/conversations"` (layouts sidebar, session/ueberauth post-login redirects, LiveView push_navigates).

## Acceptance checklist

- [x] `mix compile` passes (no warnings or errors)
- [x] `GET /` with no session → renders marketing page (200, no redirect)
- [x] `GET /` with valid session → redirects to `/dashboard`
- [x] `GET /conversations` with valid session → renders conversations list
- [x] `GET /conversations` without session → redirects to login (TenantSessionAuth)
- [x] "Conversations" nav link in sidebar → `/conversations`
- [x] No other functional behaviour changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)