### PR TITLE
chore(security): rename unscoped context fns to _unsafe_* (enforcement convention)

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -6,7 +6,11 @@ defmodule Fountain.Agents do
   alias Fountain.Agents.Agent
   alias Fountain.Repo
 
-  def list_agents(filters \\ []) do
+  @doc """
+  WARNING: returns agents across all tenants. Admin/internal use only.
+  User-facing code must use the arity-2 variant that takes user_id.
+  """
+  def _unsafe_list_agents(filters \\ []) do
     from(a in Agent, order_by: [desc: a.inserted_at, desc: a.id], preload: [:environment])
     |> apply_search(Keyword.get(filters, :search, ""))
     |> apply_runtimes(Keyword.get(filters, :runtimes, []))
@@ -16,8 +20,11 @@ defmodule Fountain.Agents do
     |> Repo.all()
   end
 
-  def get_agent(id), do: Repo.get(Agent, id) |> Repo.preload(:environment)
-  def get_agent!(id), do: Repo.get!(Agent, id) |> Repo.preload(:environment)
+  @doc "WARNING: lookup by id without owner check. Admin/internal use only."
+  def _unsafe_get_agent(id), do: Repo.get(Agent, id) |> Repo.preload(:environment)
+
+  @doc "WARNING: lookup by id without owner check. Admin/internal use only."
+  def _unsafe_get_agent!(id), do: Repo.get!(Agent, id) |> Repo.preload(:environment)
 
   @doc "Get agent scoped to user. Returns nil on wrong owner or missing id."
   def get_agent(id, user_id) when is_binary(user_id) do

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -48,7 +48,12 @@ defmodule Fountain.Conversations do
 
   # ── conversations ─────────────────────────────────────────────────────────
 
-  def list_conversations do
+  @doc """
+  WARNING: returns conversations across all tenants. Only call from
+  admin-restricted paths or internal state lookups where ownership has
+  already been verified upstream.
+  """
+  def _unsafe_list_conversations do
     Repo.all(
       from c in Conversation,
         order_by: [desc: c.inserted_at, desc: c.id],
@@ -80,10 +85,11 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
-  All conversations ordered by most recently active first (`updated_at desc`).
-  Used for the left-nav conversations list.
+  WARNING: returns conversations across all tenants ordered by activity.
+  Admin/internal use only. User-facing code must use the arity-1 variant
+  that takes user_id.
   """
-  def list_conversations_by_activity do
+  def _unsafe_list_conversations_by_activity do
     Repo.all(
       from c in Conversation,
         order_by: [desc: c.updated_at, desc: c.id],
@@ -154,13 +160,20 @@ defmodule Fountain.Conversations do
     )
   end
 
-  def get_conversation(id) do
+  @doc """
+  WARNING: lookup by id without owner check. Admin/internal use only —
+  user-facing endpoints must use the arity-2 variant that takes user_id.
+  """
+  def _unsafe_get_conversation(id) do
     Conversation
     |> Repo.get(id)
     |> Repo.preload([:sandbox, :agent, :vault])
   end
 
-  def get_conversation!(id) do
+  @doc """
+  WARNING: lookup by id without owner check. Admin/internal use only.
+  """
+  def _unsafe_get_conversation!(id) do
     Conversation
     |> Repo.get!(id)
     |> Repo.preload([:sandbox, :agent, :vault])
@@ -447,7 +460,7 @@ defmodule Fountain.Conversations do
            ]}
         )
 
-      result = get_conversation!(conv.id)
+      result = _unsafe_get_conversation!(conv.id)
 
       if result.parent_conversation_id do
         root_id = get_root_conversation_id(result.id)
@@ -518,10 +531,10 @@ defmodule Fountain.Conversations do
   (`terminated`, `failed`, `completed`) — those don't auto-resume.
   """
   def wake_conversation(conv_id, initial_prompt \\ nil) do
-    with %Conversation{} = conv <- get_conversation(conv_id) || {:error, :not_found},
+    with %Conversation{} = conv <- _unsafe_get_conversation(conv_id) || {:error, :not_found},
          :ok <- assert_resumable(conv),
          %Agents.Agent{} = agent <-
-           (conv.agent_id && Agents.get_agent(conv.agent_id)) || {:error, :no_agent},
+           (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:error, :no_agent},
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(conv.runtime) do
       case maybe_reuse_sandbox(conv) do
         {:reuse, sandbox_id} ->
@@ -568,7 +581,7 @@ defmodule Fountain.Conversations do
                 initial_prompt: initial_prompt
               ]}
            ) do
-      {:ok, get_conversation!(conv.id)}
+      {:ok, _unsafe_get_conversation!(conv.id)}
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -68,7 +68,7 @@ defmodule Fountain.Conversations.ConversationServer do
   def terminate(conv_id) do
     case whereis(conv_id) do
       nil ->
-        case Conversations.get_conversation(conv_id) do
+        case Conversations._unsafe_get_conversation(conv_id) do
           nil ->
             {:error, :not_running}
 
@@ -126,11 +126,11 @@ defmodule Fountain.Conversations.ConversationServer do
 
   @impl true
   def handle_continue(:provision, state) do
-    conv = Conversations.get_conversation!(state.conversation_id)
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     sandbox = Conversations.get_sandbox!(state.sandbox_id)
-    agent = if conv.agent_id, do: Agents.get_agent!(conv.agent_id), else: nil
-    env = if agent && agent.environment_id, do: Environments.get_environment(agent.environment_id)
-    vault = if conv.vault_id, do: Vaults.get_vault(conv.vault_id)
+    agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id), else: nil
+    env = if agent && agent.environment_id, do: Environments._unsafe_get_environment(agent.environment_id)
+    vault = if conv.vault_id, do: Vaults._unsafe_get_vault(conv.vault_id)
 
     case load_tenant_state(conv.user_id) do
       {:ok, dek, inference_creds} ->
@@ -498,7 +498,7 @@ defmodule Fountain.Conversations.ConversationServer do
           replay_skip_bytes: replay_skip
         })
 
-        conv = Conversations.get_conversation!(state.conversation_id)
+        conv = Conversations._unsafe_get_conversation!(state.conversation_id)
         {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
 
         %{
@@ -526,7 +526,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # The orphaned turn was the only thing keeping the conversation in
     # `running`. Flip it back to `idle` so the UI accurately reflects
     # state and the user can prompt without going through wake.
-    conv = Conversations.get_conversation!(state.conversation_id)
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
 
     publish_stage(state.conversation_id, "reattach", "interrupted", %{
@@ -654,8 +654,8 @@ defmodule Fountain.Conversations.ConversationServer do
     if state.current_command do
       {:reply, {:error, :busy}, state}
     else
-      conv = Conversations.get_conversation!(state.conversation_id)
-      agent = if conv.agent_id, do: Agents.get_agent!(conv.agent_id)
+      conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+      agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
       {:reply, :ok, kick_turn(state, prompt, agent, images)}
     end
   end
@@ -664,8 +664,8 @@ defmodule Fountain.Conversations.ConversationServer do
     if state.current_command do
       {:reply, {:error, :busy}, state}
     else
-      conv = Conversations.get_conversation!(state.conversation_id)
-      agent = if conv.agent_id, do: Agents.get_agent!(conv.agent_id)
+      conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+      agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
       {:reply, :ok, kick_turn(state, prompt, agent, [])}
     end
   end
@@ -698,7 +698,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
     end_turn_span(state.current_turn_span, :error, %{"outcome" => "interrupted"})
 
-    conv = Conversations.get_conversation!(state.conversation_id)
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
 
     {:reply, :ok,
@@ -718,7 +718,7 @@ defmodule Fountain.Conversations.ConversationServer do
     {:ok, _} =
       Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
 
-    conv = Conversations.get_conversation!(state.conversation_id)
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
     publish_stage(state.conversation_id, "terminate", "done")
     {:stop, :normal, :ok, state}
@@ -756,7 +756,7 @@ defmodule Fountain.Conversations.ConversationServer do
       %{"exit_code" => code}
     )
 
-    conv = Conversations.get_conversation!(state.conversation_id)
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
 
     {:noreply,
@@ -795,7 +795,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp kick_turn(state, prompt, agent, images) do
-    conv = Conversations.get_conversation!(state.conversation_id)
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     turn_number = Conversations.next_turn_number(state.conversation_id)
 
     {:ok, turn} =

--- a/apps/fountain/lib/fountain/conversations/rehydrator.ex
+++ b/apps/fountain/lib/fountain/conversations/rehydrator.ex
@@ -37,7 +37,7 @@ defmodule Fountain.Conversations.Rehydrator do
 
   defp spawn_server(conv) do
     with %Agents.Agent{} = _agent <-
-           (conv.agent_id && Agents.get_agent(conv.agent_id)) || {:skip, :no_agent},
+           (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:skip, :no_agent},
          {:ok, runtime_module} <- Runtimes.for_runtime(conv.runtime) do
       Horde.DynamicSupervisor.start_child(
         Fountain.ConversationSupervisor,

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -8,12 +8,19 @@ defmodule Fountain.Environments do
 
   # ── environments ──────────────────────────────────────────────────────────
 
-  def list_environments do
+  @doc """
+  WARNING: returns environments across all tenants. Admin/internal use only.
+  User-facing code must use the arity-1 variant that takes user_id.
+  """
+  def _unsafe_list_environments do
     Repo.all(from e in Environment, order_by: [desc: e.inserted_at, desc: e.id])
   end
 
-  def get_environment(id), do: Repo.get(Environment, id)
-  def get_environment!(id), do: Repo.get!(Environment, id)
+  @doc "WARNING: lookup by id without owner check. Admin/internal use only."
+  def _unsafe_get_environment(id), do: Repo.get(Environment, id)
+
+  @doc "WARNING: lookup by id without owner check. Admin/internal use only."
+  def _unsafe_get_environment!(id), do: Repo.get!(Environment, id)
 
   @doc "List environments scoped to user."
   def list_environments(user_id) when is_binary(user_id) do

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -12,13 +12,22 @@ defmodule Fountain.Vaults do
 
   # ── vaults ────────────────────────────────────────────────────────────────
 
-  def list_vaults do
+  @doc """
+  WARNING: returns vaults across all tenants. Admin/internal use only.
+  User-facing code must use the arity-1 variant that takes user_id.
+  """
+  def _unsafe_list_vaults do
     Repo.all(from v in Vault, order_by: [desc: v.inserted_at, desc: v.id])
   end
 
-  def get_vault(id), do: Repo.get(Vault, id)
-  def get_vault!(id), do: Repo.get!(Vault, id)
-  def get_vault_by_name(name), do: Repo.get_by(Vault, name: name)
+  @doc "WARNING: lookup by id without owner check. Admin/internal use only."
+  def _unsafe_get_vault(id), do: Repo.get(Vault, id)
+
+  @doc "WARNING: lookup by id without owner check. Admin/internal use only."
+  def _unsafe_get_vault!(id), do: Repo.get!(Vault, id)
+
+  @doc "WARNING: lookup by name without owner check. Admin/internal use only."
+  def _unsafe_get_vault_by_name(name), do: Repo.get_by(Vault, name: name)
 
   @doc "List vaults scoped to user."
   def list_vaults(user_id) when is_binary(user_id) do

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -129,7 +129,7 @@ defmodule FountainWeb.ConversationsLive.Show do
     case ConversationServer.send_prompt(socket.assigns.conv.id, p, decoded_images) do
       :ok ->
         # Refetch the conversation — wake-from-cold flips sandbox + status.
-        conv = Conversations.get_conversation!(socket.assigns.conv.id)
+        conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
 
         {:noreply,
          socket
@@ -160,7 +160,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   def handle_event("terminate", _, socket) do
     case ConversationServer.terminate(socket.assigns.conv.id) do
       :ok ->
-        conv = Conversations.get_conversation!(socket.assigns.conv.id)
+        conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
         {:noreply, socket |> assign(:conv, conv) |> put_flash(:info, "Terminated")}
 
       _ ->
@@ -171,7 +171,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   def handle_event("interrupt", _, socket) do
     case ConversationServer.interrupt(socket.assigns.conv.id) do
       :ok ->
-        conv = Conversations.get_conversation!(socket.assigns.conv.id)
+        conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
         {:noreply, socket |> assign(:conv, conv) |> put_flash(:info, "Interrupted")}
 
       {:error, :idle} ->


### PR DESCRIPTION
## Summary

Adds a per-context enforcement layer for the multi-tenant work in #44/#48–#52. Every context function that looks up by id without a user filter is now prefixed \`_unsafe_\` and carries a \`@doc\` warning. **Intent:** future code review can spot a leak just by reading function names.

## Renamed

| Context | Renamed |
| --- | --- |
| Conversations | \`_unsafe_get_conversation/1\`, \`_unsafe_get_conversation!/1\`, \`_unsafe_list_conversations/0\`, \`_unsafe_list_conversations_by_activity/0\` |
| Agents | \`_unsafe_get_agent/1\`, \`_unsafe_get_agent!/1\`, \`_unsafe_list_agents/1\` |
| Vaults | \`_unsafe_get_vault/1\`, \`_unsafe_get_vault!/1\`, \`_unsafe_get_vault_by_name/1\`, \`_unsafe_list_vaults/0\` |
| Environments | \`_unsafe_get_environment/1\`, \`_unsafe_get_environment!/1\`, \`_unsafe_list_environments/0\` |

## Internal callers updated

- \`Fountain.Conversations.wake_conversation/2\` (resume from cold)
- \`Fountain.Conversations.ConversationServer\` (state refresh during provision and on every command)
- \`Fountain.Conversations.Rehydrator\` (BEAM-startup spawn loop)
- \`FountainWeb.ConversationsLive.Show\` (post-mutation refresh) — switched to the **scoped** \`get_conversation!/2\` instead, since \`current_user.id\` is already in assigns

## Net effect

After this PR, the only code calling \`_unsafe_*\` is genuinely internal or admin. Anyone introducing a new controller can't accidentally call a leaky variant without it standing out in review.

## Test plan

- [x] \`mix compile --force --warnings-as-errors\` clean
- [x] \`grep -rE 'Conversations\\.(get_conversation\|list_conversations\|list_conversations_by_activity)\\b'\` outside the context module returns only \`user_id\`-bearing calls
- [x] Same for Agents/Vaults/Environments

## Follow-up

Cross-tenant regression tests still to come (audit task #7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)