### PR TITLE
chore(render): silence OTLP exporter — set OTEL_TRACES_EXPORTER=none

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -30,6 +30,14 @@ projects:
               - key: PORT
                 value: "10000"
 
+              # Disable OTLP trace export — no collector is wired up yet.
+              # Without this, opentelemetry_exporter retries localhost:4318
+              # for every span and floods the logs with :econnrefused.
+              # When we set up Honeycomb/Grafana/etc, swap to the real
+              # OTEL_EXPORTER_OTLP_ENDPOINT and remove this line.
+              - key: OTEL_TRACES_EXPORTER
+                value: none
+
               # Set via dashboard (sync: false hides from yaml).
               # SECRET_KEY_BASE must be ≥64 bytes for Phoenix's cookie session
               # store; Render's `generateValue: true` produces a value that's


### PR DESCRIPTION
## Summary

\`opentelemetry_exporter\` defaults to OTLP HTTP at \`localhost:4318\`. No collector is wired up yet, so every span emission retries the connect and logs \`:econnrefused\` — visible in deploy logs as \`client error exporting {:failed_connect, ...}\` on every request.

Set \`OTEL_TRACES_EXPORTER=none\` per the SDK convention to make the exporter a no-op.

When we wire up a real collector (Honeycomb / Grafana Tempo / etc) we'll swap this for \`OTEL_EXPORTER_OTLP_ENDPOINT\` and drop the line.

## Test plan
- [ ] Render redeploy, confirm log noise is gone
- [ ] App still serves traffic normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)