### PR TITLE
feat(cli): port Fountain CLI from Elixir/Burrito to Go

### DIFF
--- a/.github/workflows/cli-release-go.yml
+++ b/.github/workflows/cli-release-go.yml
@@ -1,0 +1,108 @@
+name: CLI Release (Go)
+
+# Builds the Go-port CLI under cli/. Runs alongside the Burrito-based
+# Elixir release workflow during the migration; once the Elixir CLI is
+# removed, the existing release.yml goes away and this becomes the
+# canonical CLI release pipeline.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release as (must already exist on a commit)."
+        required: true
+
+env:
+  GO_VERSION: "1.25.0"
+
+jobs:
+  build:
+    name: Build ${{ matrix.artifact }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            artifact: fountain-linux-amd64
+          - goos: linux
+            goarch: arm64
+            artifact: fountain-linux-arm64
+          - goos: darwin
+            goarch: amd64
+            artifact: fountain-darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            artifact: fountain-darwin-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: cli/go.sum
+
+      - name: Build
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        working-directory: cli
+        run: |
+          set -euxo pipefail
+          mkdir -p ../dist
+          go build -trimpath -ldflags "-s -w" -o "../dist/${{ matrix.artifact }}" ./cmd/fountain
+          file "../dist/${{ matrix.artifact }}"
+          du -h "../dist/${{ matrix.artifact }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}
+
+  release:
+    name: Attach Go CLI to GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      # The release.yml workflow (Burrito) creates the GitHub Release; we
+      # only attach additional files. softprops/action-gh-release with
+      # `append_body: false` and the same tag will upsert assets without
+      # clobbering the body.
+      - name: Attach Go binaries
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          files: |
+            artifacts/fountain-linux-amd64/fountain-linux-amd64
+            artifacts/fountain-linux-arm64/fountain-linux-arm64
+            artifacts/fountain-darwin-amd64/fountain-darwin-amd64
+            artifacts/fountain-darwin-arm64/fountain-darwin-arm64
+          fail_on_unmatched_files: true

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,82 @@
+# Fountain CLI (Go)
+
+Single-binary port of the Fountain CLI from Elixir/Burrito to Go. Same
+command surface, same API contract, same `~/.fountain/credentials` file.
+
+## Why a port
+
+The CLI is an HTTP/JSON client with subprocess shellouts (1Password,
+Bitwarden Secrets Manager, Infisical) and an SSE stream consumer. None
+of that needs the BEAM. Burrito wraps Elixir releases in a Zig-built
+launcher so the BEAM ships inside the binary; that pipeline has been
+fragile (Zig version pinning, slow startup, large binaries) and the
+runtime concurrency model adds nothing for a CLI.
+
+The Go binary is ~10 MB, statically linked, starts in <50 ms, and
+cross-compiles cleanly with stdlib tooling.
+
+## Build
+
+Requires Go 1.25+.
+
+```sh
+cd cli
+go build -o fountain ./cmd/fountain
+./fountain --help
+```
+
+Cross-compile:
+
+```sh
+GOOS=linux  GOARCH=amd64 CGO_ENABLED=0 go build -o fountain-linux-amd64  ./cmd/fountain
+GOOS=linux  GOARCH=arm64 CGO_ENABLED=0 go build -o fountain-linux-arm64  ./cmd/fountain
+GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o fountain-darwin-amd64 ./cmd/fountain
+GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o fountain-darwin-arm64 ./cmd/fountain
+```
+
+The `cli-release-go.yml` workflow builds and attaches all four to the
+GitHub release on tag push.
+
+## Layout
+
+```
+cli/
+  cmd/fountain/         entry point
+  internal/
+    api/                HTTP client (Bearer auth, JSON, error envelope)
+    cmd/                Cobra command tree (auth, keys, env, agent, vault, conv, run, apply)
+    config/             API key + base URL precedence resolver
+    credentials/        ~/.fountain/credentials reader/writer (TOML-ish)
+    manifest/           YAML doc reader for `apply`
+    output/             table + JSON rendering helpers
+    secrets/            external secret resolvers (op, bws, infisical)
+    sse/                RFC 6202 Server-Sent Events parser
+    substitution/       ${VAR} expansion (with $${VAR} escape)
+```
+
+## Test
+
+```sh
+go test ./...
+```
+
+Coverage focuses on the pure logic — credentials parser, substitution,
+SSE framing, manifest loading. Command handlers (which only assemble
+HTTP requests) are validated by smoke runs against a real server.
+
+## Parity with the Elixir CLI
+
+Every command and flag from `apps/fountain_cli/` is supported, with one
+explicit omission: the `up` / `down` self-deploy commands were removed
+from the Elixir CLI in [phase-3-cli](../plan/phase-3-cli/engineer-brief.md)
+and are not reintroduced here.
+
+## Migration plan
+
+1. **This PR** — Go CLI lives in `cli/`, Elixir CLI continues to ship
+   alongside it. Both release workflows run on tag push.
+2. **Validation** — Cut a tag, smoke-test the Go binary against the
+   production API for a few days.
+3. **Follow-up PR** — Delete `apps/fountain_cli/`, drop Burrito and
+   `release.yml`, rename `cli-release-go.yml` → `release.yml`, update
+   docs that point at the Burrito artifacts.

--- a/cli/cmd/fountain/main.go
+++ b/cli/cmd/fountain/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/BinaryBourbon/fountain/cli/internal/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,0 +1,15 @@
+module github.com/BinaryBourbon/fountain/cli
+
+go 1.25.0
+
+require (
+	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.43.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.44.0 // indirect
+)

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,0 +1,17 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/internal/api/api.go
+++ b/cli/internal/api/api.go
@@ -1,0 +1,150 @@
+// Package api is a thin HTTP client for the Fountain API.
+//
+// All requests are prefixed with /api and carry a Bearer token resolved
+// from FountainCli config (env vars, then ~/.fountain/credentials).
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/config"
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+)
+
+// HTTPError carries the status code and decoded body for non-2xx responses.
+type HTTPError struct {
+	Status int
+	Body   any // map/array/string depending on parse
+}
+
+func (e *HTTPError) Error() string {
+	if e.Body == nil {
+		return fmt.Sprintf("http %d", e.Status)
+	}
+	return fmt.Sprintf("http %d: %v", e.Status, e.Body)
+}
+
+// Client wraps the HTTP client and credential resolution.
+type Client struct {
+	HTTP *http.Client
+	Opts credentials.Opts
+}
+
+// New returns a Client bound to the active profile.
+func New(opts credentials.Opts) *Client {
+	return &Client{
+		HTTP: &http.Client{Timeout: 60 * time.Second},
+		Opts: opts,
+	}
+}
+
+// BaseURL returns the resolved base URL (no trailing slash).
+func (c *Client) BaseURL() string { return config.BaseURL(c.Opts) }
+
+// Token returns the API token, or an error if unconfigured.
+func (c *Client) Token() (string, error) { return config.APIKey(c.Opts) }
+
+// Get performs GET /api<path> and decodes JSON into out (may be nil to discard).
+func (c *Client) Get(path string, out any) error {
+	return c.do(http.MethodGet, path, nil, out)
+}
+
+// Post performs POST /api<path> with a JSON body.
+func (c *Client) Post(path string, body, out any) error {
+	return c.do(http.MethodPost, path, body, out)
+}
+
+// Put performs PUT /api<path> with a JSON body.
+func (c *Client) Put(path string, body, out any) error {
+	return c.do(http.MethodPut, path, body, out)
+}
+
+// Delete performs DELETE /api<path>.
+func (c *Client) Delete(path string, out any) error {
+	return c.do(http.MethodDelete, path, nil, out)
+}
+
+func (c *Client) do(method, path string, body, out any) error {
+	token, err := c.Token()
+	if err != nil {
+		return err
+	}
+	url := c.BaseURL() + "/api" + path
+
+	var rdr io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		rdr = bytes.NewReader(buf)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, url, rdr)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var decoded any
+		if len(respBody) > 0 {
+			if json.Unmarshal(respBody, &decoded) != nil {
+				decoded = string(respBody)
+			}
+		}
+		return &HTTPError{Status: resp.StatusCode, Body: decoded}
+	}
+
+	if out == nil || len(respBody) == 0 {
+		return nil
+	}
+	return json.Unmarshal(respBody, out)
+}
+
+// NewStreamRequest returns an *http.Request for an SSE endpoint.
+// The caller is responsible for executing it and parsing the body.
+func (c *Client) NewStreamRequest(ctx context.Context, path, lastEventID string) (*http.Request, error) {
+	token, err := c.Token()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL()+"/api"+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "text/event-stream")
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+	return req, nil
+}
+
+// StatusCode extracts the status code from an error if it is an HTTPError.
+func StatusCode(err error) int {
+	if he, ok := err.(*HTTPError); ok {
+		return he.Status
+	}
+	return 0
+}

--- a/cli/internal/cmd/agent.go
+++ b/cli/internal/cmd/agent.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	agentCmd := &cobra.Command{Use: "agent", Short: "Manage agents"}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List agents",
+		RunE:  func(cmd *cobra.Command, args []string) error { return agentList(cmd) },
+	}
+	listCmd.Flags().Bool("json", false, "output JSON")
+
+	agentCmd.AddCommand(
+		listCmd,
+		&cobra.Command{
+			Use:   "show <id>",
+			Short: "Show an agent",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return agentShow(args[0]) },
+		},
+	)
+	rootCmd.AddCommand(agentCmd)
+}
+
+func agentList(cmd *cobra.Command) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/agents", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	if jsonOut {
+		return output.PrintJSON(resp.Data)
+	}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, a := range resp.Data {
+		envID := output.ToString(a["environment_id"])
+		if envID == "" {
+			envID = "(none)"
+		} else {
+			envID = output.ShortID(envID)
+		}
+		rows = append(rows, []string{
+			output.ToString(a["name"]),
+			output.ToString(a["runtime"]),
+			output.ToString(a["model"]),
+			envID,
+		})
+	}
+	output.Table([]string{"name", "runtime", "model", "env"}, rows)
+	return nil
+}
+
+func agentShow(id string) error {
+	c := activeClient()
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := c.Get("/agents/"+id, &resp); err != nil {
+		Fatal(err.Error())
+	}
+	return output.PrintJSON(resp.Data)
+}
+
+// resolveAgentID accepts a UUID or a name; for names it queries /agents
+// and finds by exact match. Used by `run` for --agent name resolution.
+func resolveAgentID(target string) string {
+	if isUUID(target) {
+		return target
+	}
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/agents", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	for _, a := range resp.Data {
+		if output.ToString(a["name"]) == target {
+			return output.ToString(a["id"])
+		}
+	}
+	Fatalf("no agent named %q", target)
+	return ""
+}

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -1,0 +1,450 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/api"
+	"github.com/BinaryBourbon/fountain/cli/internal/manifest"
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/BinaryBourbon/fountain/cli/internal/secrets"
+	"github.com/BinaryBourbon/fountain/cli/internal/substitution"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	applyCmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply resource definitions from a YAML file or directory",
+		RunE:  runApply,
+	}
+	applyCmd.Flags().StringP("file", "f", "", "path to YAML file or directory")
+	applyCmd.Flags().StringSlice("var", nil, "extra variable for ${VAR} substitution (KEY=VAL, repeatable)")
+	rootCmd.AddCommand(applyCmd)
+}
+
+func runApply(cmd *cobra.Command, args []string) error {
+	path, _ := cmd.Flags().GetString("file")
+	if path == "" && len(args) > 0 {
+		path = args[0]
+	}
+	if path == "" {
+		Fatal("usage: fountain apply -f <path-to-yaml> [--var KEY=VAL ...]")
+	}
+
+	varFlags, _ := cmd.Flags().GetStringSlice("var")
+	applyVars := buildApplyVars(varFlags)
+
+	docs, err := manifest.Read(path)
+	if err != nil {
+		Fatal(err.Error())
+	}
+
+	envs, vaults, agents, unknown := groupDocs(docs)
+	if len(unknown) > 0 {
+		names := make([]string, len(unknown))
+		for i, d := range unknown {
+			names[i] = d.Kind
+		}
+		Fatalf("unsupported kinds in %s: %s", path, strings.Join(names, ", "))
+	}
+
+	envs, vaults = expandApplySecrets(envs, vaults, applyVars)
+
+	c := activeClient()
+	envIDByName := map[string]string{}
+	anyFailed := false
+
+	for _, d := range envs {
+		if envID, ok := applyEnvironment(c, d); ok {
+			envIDByName[d.Name()] = envID
+		} else {
+			anyFailed = true
+		}
+	}
+
+	for _, d := range vaults {
+		if !applyVault(c, d) {
+			anyFailed = true
+		}
+	}
+
+	for _, d := range agents {
+		if !applyAgent(c, d, envIDByName) {
+			anyFailed = true
+		}
+	}
+
+	if anyFailed {
+		os.Exit(1)
+	}
+	return nil
+}
+
+// ── grouping ───────────────────────────────────────────────────────────
+
+func groupDocs(docs []*manifest.Doc) (envs, vaults, agents, unknown []*manifest.Doc) {
+	for _, d := range docs {
+		switch d.Kind {
+		case "Environment":
+			envs = append(envs, d)
+		case "Vault":
+			vaults = append(vaults, d)
+		case "Agent":
+			agents = append(agents, d)
+		default:
+			unknown = append(unknown, d)
+		}
+	}
+	return
+}
+
+// ── apply-time secret resolution ───────────────────────────────────────
+
+func buildApplyVars(varFlags []string) map[string]string {
+	out := map[string]string{}
+	for _, kv := range os.Environ() {
+		if eq := strings.IndexByte(kv, '='); eq > 0 {
+			out[kv[:eq]] = kv[eq+1:]
+		}
+	}
+	for _, kv := range varFlags {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			Fatalf("--var must be KEY=VALUE, got: %q", kv)
+		}
+		out[kv[:eq]] = kv[eq+1:]
+	}
+	return out
+}
+
+// expandApplySecrets runs the two-phase resolution (substitution then
+// external refs) across both env and vault doc lists, collecting all
+// failures across both before exiting. Returns the same docs with
+// `spec.secrets` rewritten in place.
+func expandApplySecrets(envs, vaults []*manifest.Doc, vars map[string]string) ([]*manifest.Doc, []*manifest.Doc) {
+	all := append([]*manifest.Doc{}, envs...)
+	all = append(all, vaults...)
+
+	substErrors := map[string][]string{}
+	for _, d := range all {
+		if err := substituteDocSecrets(d, vars); err != nil {
+			if me, ok := err.(*substitution.MissingVarsError); ok {
+				substErrors[d.Name()] = me.Missing
+			}
+		}
+	}
+	if len(substErrors) > 0 {
+		Fatal(formatMissingVars(substErrors))
+	}
+
+	resolverErrors := map[string][]resolverFailure{}
+	for _, d := range all {
+		if fails := resolveDocExternalRefs(d, secrets.Default); len(fails) > 0 {
+			resolverErrors[d.Name()] = fails
+		}
+	}
+	if len(resolverErrors) > 0 {
+		Fatal(formatResolverFailures(resolverErrors))
+	}
+
+	return envs, vaults
+}
+
+func substituteDocSecrets(d *manifest.Doc, vars map[string]string) error {
+	if d.Spec == nil {
+		return nil
+	}
+	raw, ok := d.Spec["secrets"]
+	if !ok {
+		return nil
+	}
+	subbed, err := substitution.Apply(raw, vars)
+	if err != nil {
+		return err
+	}
+	d.Spec["secrets"] = subbed
+	return nil
+}
+
+type resolverFailure struct {
+	Key   string
+	Ref   string
+	Mod   secrets.Resolver
+	Err   error
+	Empty bool
+}
+
+func resolveDocExternalRefs(d *manifest.Doc, resolvers []secrets.Resolver) []resolverFailure {
+	if d.Spec == nil {
+		return nil
+	}
+	raw, ok := d.Spec["secrets"]
+	if !ok {
+		return nil
+	}
+	secMap, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	var fails []resolverFailure
+	resolved := make(map[string]any, len(secMap))
+
+	keys := sortedKeys(secMap)
+	for _, k := range keys {
+		v := secMap[k]
+		s, isStr := v.(string)
+		if !isStr {
+			resolved[k] = v
+			continue
+		}
+		mod := secrets.ForValue(s, resolvers)
+		if mod == nil {
+			resolved[k] = v
+			continue
+		}
+		plaintext, err := mod.Read(s)
+		if err != nil {
+			fails = append(fails, resolverFailure{Key: k, Ref: s, Mod: mod, Err: err})
+			continue
+		}
+		if plaintext == "" {
+			// An empty value back from an external CLI nearly always means
+			// "secret not found" — surface as a failure rather than silently
+			// writing "" and letting the API 422 us later.
+			fails = append(fails, resolverFailure{Key: k, Ref: s, Mod: mod, Empty: true})
+			continue
+		}
+		resolved[k] = plaintext
+	}
+	d.Spec["secrets"] = resolved
+	return fails
+}
+
+func formatMissingVars(perDoc map[string][]string) string {
+	var b strings.Builder
+	b.WriteString("apply-time substitution failed — set these in the env or pass --var KEY=VAL:\n")
+	for _, name := range sortedStringKeys(perDoc) {
+		fmt.Fprintf(&b, "  %s: %s\n", name, strings.Join(perDoc[name], ", "))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func formatResolverFailures(perDoc map[string][]resolverFailure) string {
+	var b strings.Builder
+	b.WriteString("apply-time secret resolution failed:\n")
+	for _, name := range sortedStringKeys(perDoc) {
+		fmt.Fprintf(&b, "  %s:\n", name)
+		for _, f := range perDoc[name] {
+			msg := ""
+			if f.Empty {
+				msg = "resolver returned an empty value (secret missing or wrong env/path?)"
+			} else {
+				msg = f.Mod.FormatError(f.Err)
+			}
+			fmt.Fprintf(&b, "    %s (%s): %s\n", f.Key, f.Ref, msg)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func sortedStringKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ── reconciliation ─────────────────────────────────────────────────────
+
+func applyEnvironment(c *api.Client, d *manifest.Doc) (string, bool) {
+	name := requireName(d)
+	body, secretsMap := buildBody(d, name)
+
+	existing := fetchByName(c, "/environments", name)
+	var env map[string]any
+	if existing != nil {
+		id := output.ToString(existing["id"])
+		var resp struct {
+			Data map[string]any `json:"data"`
+		}
+		if err := c.Put("/environments/"+id, body, &resp); err != nil {
+			warnf("env  !  %s (update failed): %v", name, err)
+			return "", false
+		}
+		fmt.Printf("env  ~  %s\n", name)
+		env = resp.Data
+	} else {
+		var resp struct {
+			Data map[string]any `json:"data"`
+		}
+		if err := c.Post("/environments", body, &resp); err != nil {
+			warnf("env  !  %s (create failed): %v", name, err)
+			return "", false
+		}
+		fmt.Printf("env  +  %s\n", name)
+		env = resp.Data
+	}
+
+	envID := output.ToString(env["id"])
+	if envID == "" {
+		warnf("env  !  %s: missing id in response", name)
+		return "", false
+	}
+	upsertSecrets(c, "/environments/"+envID+"/secrets", name, secretsMap)
+	return envID, true
+}
+
+func applyVault(c *api.Client, d *manifest.Doc) bool {
+	name := requireName(d)
+	body, secretsMap := buildBody(d, name)
+
+	existing := fetchByName(c, "/vaults", name)
+	var v map[string]any
+	if existing != nil {
+		id := output.ToString(existing["id"])
+		var resp struct {
+			Data map[string]any `json:"data"`
+		}
+		if err := c.Put("/vaults/"+id, body, &resp); err != nil {
+			warnf("vault  !  %s (update failed): %v", name, err)
+			return false
+		}
+		fmt.Printf("vault  ~  %s\n", name)
+		v = resp.Data
+	} else {
+		var resp struct {
+			Data map[string]any `json:"data"`
+		}
+		if err := c.Post("/vaults", body, &resp); err != nil {
+			warnf("vault  !  %s (create failed): %v", name, err)
+			return false
+		}
+		fmt.Printf("vault  +  %s\n", name)
+		v = resp.Data
+	}
+
+	vaultID := output.ToString(v["id"])
+	if vaultID == "" {
+		warnf("vault  !  %s: missing id in response", name)
+		return false
+	}
+	upsertSecrets(c, "/vaults/"+vaultID+"/secrets", name, secretsMap)
+	return true
+}
+
+func applyAgent(c *api.Client, d *manifest.Doc, envIDByName map[string]string) bool {
+	name := requireName(d)
+	spec := cloneMap(d.Spec)
+
+	if envName, ok := spec["environment"].(string); ok && envName != "" {
+		if id, ok := envIDByName[envName]; ok {
+			delete(spec, "environment")
+			spec["environment_id"] = id
+		} else {
+			warnf("agent  ?  %s: environment '%s' not in this manifest, skipping reference", name, envName)
+			delete(spec, "environment")
+		}
+	} else {
+		delete(spec, "environment")
+	}
+
+	body := spec
+	body["name"] = name
+
+	existing := fetchByName(c, "/agents", name)
+	if existing != nil {
+		id := output.ToString(existing["id"])
+		if err := c.Put("/agents/"+id, body, nil); err != nil {
+			warnf("agent  !  %s (update failed): %v", name, err)
+			return false
+		}
+		fmt.Printf("agent  ~  %s\n", name)
+	} else {
+		if err := c.Post("/agents", body, nil); err != nil {
+			warnf("agent  !  %s (create failed): %v", name, err)
+			return false
+		}
+		fmt.Printf("agent  +  %s\n", name)
+	}
+	return true
+}
+
+// buildBody returns the request body for a resource (spec minus
+// `secrets`, with `name` set) and a separate map of secrets to upsert.
+func buildBody(d *manifest.Doc, name string) (map[string]any, map[string]any) {
+	body := cloneMap(d.Spec)
+	secretsMap, _ := body["secrets"].(map[string]any)
+	delete(body, "secrets")
+	body["name"] = name
+	return body, secretsMap
+}
+
+func upsertSecrets(c *api.Client, path, resourceName string, m map[string]any) {
+	if len(m) == 0 {
+		return
+	}
+	for _, k := range sortedKeys(m) {
+		v := m[k]
+		body := map[string]string{
+			"key":   k,
+			"value": output.ToString(v),
+		}
+		if err := c.Post(path, body, nil); err != nil {
+			warnf("  secret  !  %s/%s: %v", resourceName, k, err)
+			continue
+		}
+		fmt.Printf("  secret  ~  %s/%s\n", resourceName, k)
+	}
+}
+
+func fetchByName(c *api.Client, collection, name string) map[string]any {
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get(collection, &resp); err != nil {
+		Fatalf("GET %s failed: %v", collection, err)
+	}
+	for _, row := range resp.Data {
+		if output.ToString(row["name"]) == name {
+			return row
+		}
+	}
+	return nil
+}
+
+func requireName(d *manifest.Doc) string {
+	n := d.Name()
+	if n == "" {
+		Fatalf("resource missing required `metadata.name`: %s/%s", d.APIVersion, d.Kind)
+	}
+	return n
+}
+
+func cloneMap(m map[string]any) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func warnf(format string, a ...any) {
+	fmt.Fprintln(os.Stderr, fmt.Sprintf(format, a...))
+}

--- a/cli/internal/cmd/auth.go
+++ b/cli/internal/cmd/auth.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/api"
+	"github.com/BinaryBourbon/fountain/cli/internal/config"
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+func init() {
+	authCmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Authenticate against the Fountain API",
+	}
+	authCmd.AddCommand(
+		&cobra.Command{
+			Use:   "login",
+			Short: "Authenticate and save credentials",
+			RunE:  func(cmd *cobra.Command, args []string) error { return authLogin() },
+		},
+		&cobra.Command{
+			Use:   "logout",
+			Short: "Remove saved credentials",
+			RunE:  func(cmd *cobra.Command, args []string) error { return authLogout() },
+		},
+		&cobra.Command{
+			Use:   "whoami",
+			Short: "Print current user info",
+			RunE:  func(cmd *cobra.Command, args []string) error { return authWhoami() },
+		},
+	)
+	rootCmd.AddCommand(authCmd)
+}
+
+func authLogin() error {
+	opts := activeOpts()
+	profile := credentials.ProfileName(opts)
+
+	email, err := promptLine("Email: ")
+	if err != nil {
+		return err
+	}
+	password, err := promptPassword("Password: ")
+	if err != nil {
+		return err
+	}
+
+	base := config.BaseURL(opts)
+	body, err := json.Marshal(map[string]string{"email": email, "password": password})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, base+"/api/auth/token", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		Fatalf("login failed (HTTP %d): %s", resp.StatusCode, respBody)
+	}
+
+	key := extractAPIKey(respBody)
+	if key == "" {
+		Fatalf("unexpected login response: %s", respBody)
+	}
+
+	if err := credentials.WriteProfile(profile, map[string]string{
+		"api_key":  key,
+		"base_url": base,
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("Logged in as %s. Credentials written to ~/.fountain/credentials (profile: %s).\n", email, profile)
+	return nil
+}
+
+// extractAPIKey accepts any of the four shapes the server has returned:
+// {data:{api_key}}, {data:{token}}, {api_key}, {token}.
+func extractAPIKey(body []byte) string {
+	var top struct {
+		Data struct {
+			APIKey string `json:"api_key"`
+			Token  string `json:"token"`
+		} `json:"data"`
+		APIKey string `json:"api_key"`
+		Token  string `json:"token"`
+	}
+	if json.Unmarshal(body, &top) != nil {
+		return ""
+	}
+	switch {
+	case top.Data.APIKey != "":
+		return top.Data.APIKey
+	case top.Data.Token != "":
+		return top.Data.Token
+	case top.APIKey != "":
+		return top.APIKey
+	case top.Token != "":
+		return top.Token
+	}
+	return ""
+}
+
+func authLogout() error {
+	profile := credentials.ProfileName(activeOpts())
+	if err := credentials.DeleteProfile(profile); err != nil {
+		return err
+	}
+	fmt.Printf("Profile '%s' removed from ~/.fountain/credentials.\n", profile)
+	return nil
+}
+
+func authWhoami() error {
+	c := activeClient()
+	profile := credentials.ProfileName(activeOpts())
+
+	var out struct {
+		Data struct {
+			Email string `json:"email"`
+			Role  string `json:"role"`
+		} `json:"data"`
+	}
+	if err := c.Get("/auth/me", &out); err != nil {
+		if api.StatusCode(err) == 401 {
+			Fatalf("not authenticated for profile '%s'. Run `fountain auth login --profile %s`.", profile, profile)
+		}
+		Fatal(err.Error())
+	}
+	fmt.Printf("email: %s\n", out.Data.Email)
+	fmt.Printf("role:  %s\n", out.Data.Role)
+	return nil
+}
+
+func promptLine(label string) (string, error) {
+	fmt.Print(label)
+	r := bufio.NewReader(os.Stdin)
+	line, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+func promptPassword(label string) (string, error) {
+	fmt.Print(label)
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		buf, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Println()
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimRight(string(buf), "\r\n"), nil
+	}
+	// Non-TTY: fall back to plain read so piped tests work.
+	return promptLine("")
+}

--- a/cli/internal/cmd/clientopts.go
+++ b/cli/internal/cmd/clientopts.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/BinaryBourbon/fountain/cli/internal/api"
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+)
+
+// activeOpts builds credentials.Opts from the parsed --profile flag.
+func activeOpts() credentials.Opts {
+	return credentials.Opts{Profile: profileFlag}
+}
+
+// activeClient builds a Client bound to the active profile.
+func activeClient() *api.Client {
+	return api.New(activeOpts())
+}

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -1,0 +1,441 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/api"
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/BinaryBourbon/fountain/cli/internal/sse"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	convCmd := &cobra.Command{Use: "conv", Short: "Manage conversations"}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List conversations",
+		RunE:  func(cmd *cobra.Command, args []string) error { return convList(cmd) },
+	}
+	listCmd.Flags().Bool("json", false, "output JSON")
+
+	promptCmd := &cobra.Command{
+		Use:   "prompt <id>",
+		Short: "Send a prompt to a conversation and stream the result",
+		Args:  cobra.ExactArgs(1),
+		RunE:  func(cmd *cobra.Command, args []string) error { return convPrompt(cmd, args[0]) },
+	}
+	promptCmd.Flags().StringP("prompt", "p", "", "prompt text (required)")
+	promptCmd.Flags().StringSliceP("image", "i", nil, "image file path (repeatable)")
+
+	convCmd.AddCommand(
+		listCmd,
+		&cobra.Command{
+			Use:   "show <id>",
+			Short: "Show a conversation",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return convShow(args[0]) },
+		},
+		&cobra.Command{
+			Use:   "stream <id>",
+			Short: "Stream conversation events",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return convStream(args[0]) },
+		},
+		promptCmd,
+		&cobra.Command{
+			Use:   "interrupt <id>",
+			Short: "Interrupt the running turn",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return convInterrupt(args[0]) },
+		},
+		&cobra.Command{
+			Use:   "terminate <id>",
+			Short: "Terminate a conversation",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return convTerminate(args[0]) },
+		},
+		&cobra.Command{
+			Use:   "delete <id>",
+			Short: "Delete a conversation",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return convDelete(args[0]) },
+		},
+	)
+	rootCmd.AddCommand(convCmd)
+
+	// `run` is a top-level shortcut: create + stream until done.
+	runCmd := &cobra.Command{
+		Use:   "run <agent-name-or-id>",
+		Short: "Run an agent (create conversation + stream until done)",
+		Args:  cobra.ExactArgs(1),
+		RunE:  func(cmd *cobra.Command, args []string) error { return runAgent(cmd, args[0]) },
+	}
+	runCmd.Flags().StringP("prompt", "p", "", "prompt text (required)")
+	runCmd.Flags().String("vault", "", "vault name or id")
+	rootCmd.AddCommand(runCmd)
+}
+
+// ── list / show ────────────────────────────────────────────────────────
+
+func convList(cmd *cobra.Command) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/conversations", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	if jsonOut {
+		return output.PrintJSON(resp.Data)
+	}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, v := range resp.Data {
+		rows = append(rows, []string{
+			output.ToString(v["status"]),
+			output.ShortID(output.ToString(v["id"])),
+			output.ShortID(output.ToString(v["agent_id"])),
+			output.ToString(v["runtime"]),
+			output.ToString(v["inserted_at"]),
+		})
+	}
+	output.Table([]string{"status", "id", "agent_id", "runtime", "started"}, rows)
+	return nil
+}
+
+func convShow(id string) error {
+	c := activeClient()
+	var convResp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := c.Get("/conversations/"+id, &convResp); err != nil {
+		Fatal(err.Error())
+	}
+	var turnResp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/conversations/"+id+"/turns", &turnResp); err != nil {
+		Fatal(err.Error())
+	}
+
+	conv := convResp.Data
+	fmt.Printf("conversation %s\n", output.ToString(conv["id"]))
+	fmt.Printf("  status:    %s\n", output.ToString(conv["status"]))
+	fmt.Printf("  agent:     %s\n", output.ToString(conv["agent_id"]))
+	fmt.Printf("  sandbox:   %s\n", output.ToString(conv["sandbox_id"]))
+	fmt.Printf("  sprite:    %s\n", spriteLabel(conv["sandbox"]))
+	fmt.Printf("  runtime:   %s\n", output.ToString(conv["runtime"]))
+	fmt.Printf("  inserted:  %s\n", output.ToString(conv["inserted_at"]))
+	fmt.Printf("\nturns (%d):\n", len(turnResp.Data))
+	for _, t := range turnResp.Data {
+		fmt.Printf("  #%s %s exit=%s  %s\n",
+			output.ToString(t["turn_number"]),
+			output.ToString(t["status"]),
+			output.ToString(t["exit_code"]),
+			output.Truncate(output.ToString(t["prompt"]), 80),
+		)
+	}
+	return nil
+}
+
+func spriteLabel(v any) string {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return "—"
+	}
+	name, _ := m["sprite_name"].(string)
+	status, _ := m["status"].(string)
+	if name == "" {
+		return "—"
+	}
+	return fmt.Sprintf("%s (%s)", name, status)
+}
+
+// ── streaming ──────────────────────────────────────────────────────────
+
+func convStream(id string) error {
+	return followUntilIdle(id)
+}
+
+func convPrompt(cmd *cobra.Command, id string) error {
+	prompt, _ := cmd.Flags().GetString("prompt")
+	if prompt == "" {
+		Fatal("missing -p <prompt>")
+	}
+	imagePaths, _ := cmd.Flags().GetStringSlice("image")
+	images := make([]map[string]string, 0, len(imagePaths))
+	for _, p := range imagePaths {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			Fatalf("read %s: %v", p, err)
+		}
+		images = append(images, map[string]string{
+			"data":       base64.StdEncoding.EncodeToString(raw),
+			"media_type": guessMediaType(p),
+		})
+	}
+	c := activeClient()
+	body := map[string]any{"prompt": prompt, "images": images}
+	if err := c.Post("/conversations/"+id+"/prompts", body, nil); err != nil {
+		Fatal(err.Error())
+	}
+	return followUntilIdle(id)
+}
+
+func guessMediaType(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	default:
+		return "image/png"
+	}
+}
+
+func convInterrupt(id string) error {
+	c := activeClient()
+	if err := c.Post("/conversations/"+id+"/interrupt", map[string]any{}, nil); err != nil {
+		if api.StatusCode(err) == 409 {
+			Fatal("no turn running")
+		}
+		Fatal(err.Error())
+	}
+	fmt.Printf("interrupted %s\n", id)
+	return nil
+}
+
+func convTerminate(id string) error {
+	c := activeClient()
+	if err := c.Post("/conversations/"+id+"/terminate", map[string]any{}, nil); err != nil {
+		Fatal(err.Error())
+	}
+	fmt.Printf("terminated %s\n", id)
+	return nil
+}
+
+func convDelete(id string) error {
+	c := activeClient()
+	if err := c.Delete("/conversations/"+id, nil); err != nil {
+		if api.StatusCode(err) == 404 {
+			Fatal("not found")
+		}
+		Fatal(err.Error())
+	}
+	fmt.Printf("deleted %s\n", id)
+	return nil
+}
+
+// ── run shortcut ────────────────────────────────────────────────────────
+
+func runAgent(cmd *cobra.Command, target string) error {
+	prompt, _ := cmd.Flags().GetString("prompt")
+	if prompt == "" {
+		Fatal("missing -p <prompt>")
+	}
+	vault, _ := cmd.Flags().GetString("vault")
+
+	agentID := resolveAgentID(target)
+	body := map[string]any{"agent_id": agentID, "prompt": prompt}
+	if vault != "" {
+		body["vault_id"] = resolveVaultID(vault)
+	}
+
+	c := activeClient()
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := c.Post("/conversations", body, &resp); err != nil {
+		Fatal(err.Error())
+	}
+	convID := output.ToString(resp.Data["id"])
+	fmt.Fprintf(os.Stderr, "▸ conversation %s\n", convID)
+	return followUntilIdle(convID)
+}
+
+// ── stream loop ─────────────────────────────────────────────────────────
+
+// followUntilIdle opens the SSE stream for conv `id` and prints output
+// until a `stage=turn state=done` event arrives or the server closes.
+func followUntilIdle(convID string) error {
+	c := activeClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	req, err := c.NewStreamRequest(ctx, "/conversations/"+convID+"/stream", "")
+	if err != nil {
+		return err
+	}
+	httpClient := &http.Client{} // no global timeout — streams are long-lived
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		Fatalf("stream request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		Fatalf("stream HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	buf := make([]byte, 8192)
+	var pending bytes.Buffer
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			pending.Write(buf[:n])
+			events, leftover := sse.Feed(pending.String())
+			pending.Reset()
+			pending.WriteString(leftover)
+			for _, ev := range events {
+				if handleEvent(ev) {
+					return nil
+				}
+			}
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				Fatal("stream timeout")
+			}
+			Fatalf("stream read: %v", err)
+		}
+	}
+}
+
+// handleEvent prints output and returns true when the turn is done.
+func handleEvent(ev sse.Event) bool {
+	switch ev.Event {
+	case "stage":
+		data, ok := ev.Data.(map[string]any)
+		if !ok {
+			return false
+		}
+		stage, _ := data["stage"].(string)
+		state, _ := data["state"].(string)
+		if stage == "turn" && state == "done" {
+			exit := exitCodeFromStageDone(data)
+			fmt.Fprintf(os.Stderr, "▸ turn done (exit_code=%s)\n", exit)
+			return true
+		}
+		fmt.Fprintf(os.Stderr, "▸ %s: %s\n", stage, state)
+	case "output":
+		data, ok := ev.Data.(map[string]any)
+		if !ok {
+			return false
+		}
+		text := formatOutput(data)
+		if text != "" {
+			fmt.Print(text)
+		}
+	}
+	return false
+}
+
+// exitCodeFromStageDone digs `data.data.exit_code` out of a turn-done event.
+// The Elixir code looked up the same path; the inner `data` was JSON-encoded,
+// so we accept either a nested map or a JSON string.
+func exitCodeFromStageDone(data map[string]any) string {
+	inner := data["data"]
+	if s, ok := inner.(string); ok {
+		var m map[string]any
+		if json.Unmarshal([]byte(s), &m) == nil {
+			return output.ToString(m["exit_code"])
+		}
+	}
+	if m, ok := inner.(map[string]any); ok {
+		return output.ToString(m["exit_code"])
+	}
+	return ""
+}
+
+func formatOutput(data map[string]any) string {
+	stream, _ := data["stream"].(string)
+	raw, _ := data["data"].(string)
+	if stream == "stderr" {
+		return "\x1b[31m" + raw + "\x1b[0m"
+	}
+	if raw == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(raw, "\n") {
+		if line == "" {
+			continue
+		}
+		b.WriteString(formatStreamJSONLine(line))
+	}
+	return b.String()
+}
+
+// formatStreamJSONLine renders a single line from the assistant/user/result
+// JSON Lines stream. Mirrors conv.ex's format_stream_json_line/1.
+func formatStreamJSONLine(line string) string {
+	var msg map[string]any
+	if json.Unmarshal([]byte(line), &msg) != nil {
+		return ""
+	}
+	t, _ := msg["type"].(string)
+	switch t {
+	case "assistant":
+		message, _ := msg["message"].(map[string]any)
+		content, _ := message["content"].([]any)
+		var b strings.Builder
+		for _, item := range content {
+			c, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			ct, _ := c["type"].(string)
+			switch ct {
+			case "text":
+				if text, ok := c["text"].(string); ok {
+					b.WriteString(text)
+				}
+			case "tool_use":
+				name, _ := c["name"].(string)
+				input := c["input"]
+				inputJSON, _ := json.Marshal(input)
+				b.WriteString("\n\x1b[36m[")
+				b.WriteString(name)
+				b.WriteString("]\x1b[0m ")
+				b.Write(inputJSON)
+				b.WriteString("\n")
+			}
+		}
+		return b.String()
+
+	case "user":
+		message, _ := msg["message"].(map[string]any)
+		contentArr, _ := message["content"].([]any)
+		if len(contentArr) > 0 {
+			c, ok := contentArr[0].(map[string]any)
+			if ok {
+				if text, ok := c["content"].(string); ok {
+					return "\n\x1b[2m→ " + output.Truncate(text, 200) + "\x1b[0m\n"
+				}
+			}
+		}
+	case "result":
+		if r, ok := msg["result"].(string); ok {
+			return "\n\x1b[32m✓ " + r + "\x1b[0m\n"
+		}
+	}
+	return ""
+}

--- a/cli/internal/cmd/env.go
+++ b/cli/internal/cmd/env.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	envCmd := &cobra.Command{Use: "env", Short: "Manage environments"}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List environments",
+		RunE:  func(cmd *cobra.Command, args []string) error { return envList(cmd) },
+	}
+	listCmd.Flags().Bool("json", false, "output JSON")
+
+	envCmd.AddCommand(
+		listCmd,
+		&cobra.Command{
+			Use:   "show <id>",
+			Short: "Show an environment",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return envShow(args[0]) },
+		},
+	)
+	rootCmd.AddCommand(envCmd)
+}
+
+func envList(cmd *cobra.Command) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/environments", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	if jsonOut {
+		return output.PrintJSON(resp.Data)
+	}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, e := range resp.Data {
+		rows = append(rows, []string{
+			output.ToString(e["name"]),
+			output.ToString(e["networking_type"]),
+			output.Truncate(output.ToString(e["setup_script"]), 60),
+		})
+	}
+	output.Table([]string{"name", "networking", "setup_script"}, rows)
+	return nil
+}
+
+func envShow(id string) error {
+	c := activeClient()
+	var envResp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := c.Get("/environments/"+id, &envResp); err != nil {
+		Fatal(err.Error())
+	}
+	var secResp struct {
+		Data any `json:"data"`
+	}
+	if err := c.Get("/environments/"+id+"/secrets", &secResp); err != nil {
+		Fatal(err.Error())
+	}
+	envResp.Data["secrets"] = secResp.Data
+	return output.PrintJSON(envResp.Data)
+}

--- a/cli/internal/cmd/keys.go
+++ b/cli/internal/cmd/keys.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/api"
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	keysCmd := &cobra.Command{Use: "keys", Short: "Manage Fountain API keys"}
+	keysCmd.AddCommand(
+		&cobra.Command{
+			Use:   "list",
+			Short: "List API keys",
+			RunE:  func(cmd *cobra.Command, args []string) error { return keysList() },
+		},
+		&cobra.Command{
+			Use:   "create <name>",
+			Short: "Create a new API key",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return keysCreate(args[0]) },
+		},
+		&cobra.Command{
+			Use:   "revoke <id>",
+			Short: "Revoke an API key",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return keysRevoke(args[0]) },
+		},
+	)
+	rootCmd.AddCommand(keysCmd)
+}
+
+func keysList() error {
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/auth/api-keys", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, k := range resp.Data {
+		lastUsed := output.ToString(k["last_used_at"])
+		if lastUsed == "" {
+			lastUsed = "never"
+		}
+		rows = append(rows, []string{
+			output.ToString(k["key_prefix"]),
+			output.ToString(k["name"]),
+			lastUsed,
+		})
+	}
+	output.Table([]string{"prefix", "name", "last_used"}, rows)
+	return nil
+}
+
+func keysCreate(name string) error {
+	c := activeClient()
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := c.Post("/auth/api-keys", map[string]string{"name": name}, &resp); err != nil {
+		Fatal(err.Error())
+	}
+	key := output.ToString(resp.Data["key"])
+	if key == "" {
+		Fatalf("unexpected response: %v", resp.Data)
+	}
+	fmt.Println()
+	fmt.Println("╭────────────────────────────────────────────────────────────────╮")
+	fmt.Println("│  Save this key — it will not be shown again.                  │")
+	fmt.Println("╰────────────────────────────────────────────────────────────────╯")
+	fmt.Println()
+	fmt.Println(key)
+	fmt.Println()
+	fmt.Printf("Name:   %s\n", output.ToString(resp.Data["name"]))
+	fmt.Printf("Prefix: %s\n", output.ToString(resp.Data["key_prefix"]))
+	fmt.Println()
+	return nil
+}
+
+func keysRevoke(id string) error {
+	fmt.Printf("Revoke API key %s? This cannot be undone. [y/N] ", id)
+	r := bufio.NewReader(os.Stdin)
+	answer, _ := r.ReadString('\n')
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer != "y" && answer != "yes" {
+		fmt.Println("Aborted.")
+		return nil
+	}
+	c := activeClient()
+	if err := c.Delete("/auth/api-keys/"+id, nil); err != nil {
+		if api.StatusCode(err) == 404 {
+			Fatalf("key not found: %s", id)
+		}
+		Fatal(err.Error())
+	}
+	fmt.Printf("Revoked %s.\n", id)
+	return nil
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var profileFlag string
+
+var rootCmd = &cobra.Command{
+	Use:   "fountain",
+	Short: "Fountain CLI",
+	Long: `Fountain CLI.
+
+Credentials are read from FOUNTAIN_API_KEY env var or ~/.fountain/credentials.
+Use FOUNTAIN_PROFILE or --profile to select a non-default profile.`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		Fatal(err.Error())
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&profileFlag, "profile", "", "credentials profile name")
+}
+
+// Fatal prints "fountain: <msg>" to stderr and exits 1.
+func Fatal(msg string) {
+	fmt.Fprintln(os.Stderr, "fountain: "+msg)
+	os.Exit(1)
+}
+
+// Fatalf is Fatal with format args.
+func Fatalf(format string, a ...any) {
+	Fatal(fmt.Sprintf(format, a...))
+}

--- a/cli/internal/cmd/vault.go
+++ b/cli/internal/cmd/vault.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/api"
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var uuidRE = regexp.MustCompile(`^[0-9a-fA-F-]{36}$`)
+
+func isUUID(s string) bool { return uuidRE.MatchString(s) }
+
+func init() {
+	vaultCmd := &cobra.Command{Use: "vault", Short: "Manage vaults"}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List vaults",
+		RunE:  func(cmd *cobra.Command, args []string) error { return vaultList(cmd) },
+	}
+	listCmd.Flags().Bool("json", false, "output JSON")
+
+	createCmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a vault",
+		Args:  cobra.ExactArgs(1),
+		RunE:  func(cmd *cobra.Command, args []string) error { return vaultCreate(cmd, args[0]) },
+	}
+	createCmd.Flags().String("description", "", "vault description")
+
+	vaultCmd.AddCommand(
+		listCmd,
+		createCmd,
+		&cobra.Command{
+			Use:   "show <id-or-name>",
+			Short: "Show a vault",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return vaultShow(args[0]) },
+		},
+		&cobra.Command{
+			Use:   "delete <id-or-name>",
+			Short: "Delete a vault",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return vaultDelete(args[0]) },
+		},
+		&cobra.Command{
+			Use:   "set-secret <id-or-name> <key> <value>",
+			Short: "Set a vault secret",
+			Args:  cobra.ExactArgs(3),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return vaultSetSecret(args[0], args[1], args[2])
+			},
+		},
+		&cobra.Command{
+			Use:   "delete-secret <id-or-name> <key>",
+			Short: "Delete a vault secret",
+			Args:  cobra.ExactArgs(2),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return vaultDeleteSecret(args[0], args[1])
+			},
+		},
+	)
+	rootCmd.AddCommand(vaultCmd)
+}
+
+func vaultList(cmd *cobra.Command) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/vaults", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	if jsonOut {
+		return output.PrintJSON(resp.Data)
+	}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, v := range resp.Data {
+		rows = append(rows, []string{
+			output.ToString(v["name"]),
+			output.ShortID(output.ToString(v["id"])),
+			output.Truncate(output.ToString(v["description"]), 60),
+		})
+	}
+	output.Table([]string{"name", "id", "description"}, rows)
+	return nil
+}
+
+func vaultShow(target string) error {
+	c := activeClient()
+	id := resolveVaultID(target)
+	var vresp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := c.Get("/vaults/"+id, &vresp); err != nil {
+		Fatal(err.Error())
+	}
+	var sresp struct {
+		Data any `json:"data"`
+	}
+	if err := c.Get("/vaults/"+id+"/secrets", &sresp); err != nil {
+		Fatal(err.Error())
+	}
+	vresp.Data["secrets"] = sresp.Data
+	return output.PrintJSON(vresp.Data)
+}
+
+func vaultCreate(cmd *cobra.Command, name string) error {
+	desc, _ := cmd.Flags().GetString("description")
+	c := activeClient()
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	body := map[string]string{"name": name, "description": desc}
+	if err := c.Post("/vaults", body, &resp); err != nil {
+		Fatal(err.Error())
+	}
+	fmt.Printf("vault  +  %s (%s)\n", output.ToString(resp.Data["name"]), output.ToString(resp.Data["id"]))
+	return nil
+}
+
+func vaultDelete(target string) error {
+	c := activeClient()
+	id := resolveVaultID(target)
+	if err := c.Delete("/vaults/"+id, nil); err != nil {
+		if api.StatusCode(err) == 404 {
+			Fatal("not found")
+		}
+		Fatal(err.Error())
+	}
+	fmt.Printf("deleted %s\n", id)
+	return nil
+}
+
+func vaultSetSecret(target, key, value string) error {
+	c := activeClient()
+	id := resolveVaultID(target)
+	if err := c.Post("/vaults/"+id+"/secrets", map[string]string{"key": key, "value": value}, nil); err != nil {
+		Fatal(err.Error())
+	}
+	fmt.Printf("secret  +  %s\n", key)
+	return nil
+}
+
+func vaultDeleteSecret(target, key string) error {
+	c := activeClient()
+	id := resolveVaultID(target)
+	if err := c.Delete("/vaults/"+id+"/secrets/"+key, nil); err != nil {
+		if api.StatusCode(err) == 404 {
+			Fatal("not found")
+		}
+		Fatal(err.Error())
+	}
+	fmt.Printf("deleted secret %s\n", key)
+	return nil
+}
+
+// resolveVaultID accepts a UUID or vault name; for names it queries
+// /vaults and matches by exact name.
+func resolveVaultID(target string) string {
+	if isUUID(target) {
+		return target
+	}
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/vaults", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	for _, v := range resp.Data {
+		if output.ToString(v["name"]) == target {
+			return output.ToString(v["id"])
+		}
+	}
+	Fatalf("no vault named %q", target)
+	return ""
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -1,0 +1,54 @@
+// Package config resolves the API key and base URL for the active profile.
+//
+// API key precedence:
+//  1. FOUNTAIN_API_KEY env var
+//  2. api_key from ~/.fountain/credentials (active profile)
+//
+// Base URL precedence:
+//  1. FOUNTAIN_BASE_URL env var
+//  2. base_url from ~/.fountain/credentials (active profile)
+//  3. compile-time default (https://fountain.dev)
+package config
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+)
+
+const DefaultBaseURL = "https://fountain.dev"
+
+// ErrNoAPIKey signals that no API key is configured.
+var ErrNoAPIKey = errors.New("FOUNTAIN_API_KEY is not set. Run `fountain auth login` or export the FOUNTAIN_API_KEY environment variable.")
+
+// APIKey resolves the API key for opts. Returns ErrNoAPIKey if none.
+func APIKey(opts credentials.Opts) (string, error) {
+	if k := os.Getenv("FOUNTAIN_API_KEY"); k != "" {
+		return k, nil
+	}
+	profile := credentials.ProfileName(opts)
+	attrs, err := credentials.ReadProfile(profile)
+	if err != nil {
+		return "", err
+	}
+	if k := attrs["api_key"]; k != "" {
+		return k, nil
+	}
+	return "", ErrNoAPIKey
+}
+
+// BaseURL resolves the base URL for opts (trailing slash stripped).
+func BaseURL(opts credentials.Opts) string {
+	if u := os.Getenv("FOUNTAIN_BASE_URL"); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	profile := credentials.ProfileName(opts)
+	if attrs, err := credentials.ReadProfile(profile); err == nil {
+		if u := attrs["base_url"]; u != "" {
+			return strings.TrimRight(u, "/")
+		}
+	}
+	return strings.TrimRight(DefaultBaseURL, "/")
+}

--- a/cli/internal/credentials/credentials.go
+++ b/cli/internal/credentials/credentials.go
@@ -1,0 +1,201 @@
+// Package credentials reads and writes ~/.fountain/credentials as an
+// AWS-CLI-style multi-profile TOML file.
+//
+//	[default]
+//	api_key = "ftn_..."
+//	base_url = "https://fountain.dev"
+//
+//	[staging]
+//	api_key = "ftn_..."
+//	base_url = "https://staging.fountain.dev"
+//
+// The format is intentionally lenient — values may be unquoted, and
+// comment lines (starting with `#`) and blank lines are ignored.
+package credentials
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// pathOverride lets tests redirect the credentials file location.
+// Production code never sets this.
+var pathOverride string
+
+// SetPathOverride redirects the credentials file path. Pass "" to clear.
+func SetPathOverride(p string) { pathOverride = p }
+
+// Path returns the resolved credentials file path.
+func Path() string {
+	if pathOverride != "" {
+		return pathOverride
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// No HOME — fall back to relative; the eventual write will fail visibly.
+		return ".fountain/credentials"
+	}
+	return filepath.Join(home, ".fountain", "credentials")
+}
+
+// Opts carries the resolved profile flag from the command layer.
+type Opts struct {
+	Profile string
+}
+
+// ProfileName returns the active profile name.
+// Precedence: opts.Profile > FOUNTAIN_PROFILE env var > "default".
+func ProfileName(opts Opts) string {
+	if opts.Profile != "" {
+		return opts.Profile
+	}
+	if env := os.Getenv("FOUNTAIN_PROFILE"); env != "" {
+		return env
+	}
+	return "default"
+}
+
+// ReadProfile returns the named profile's attributes.
+// Returns an empty map when the file or profile is missing.
+func ReadProfile(profile string) (map[string]string, error) {
+	content, err := os.ReadFile(Path())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("cannot read %s: %w", Path(), err)
+	}
+	all := ParseAll(string(content))
+	if attrs, ok := all[profile]; ok {
+		return attrs, nil
+	}
+	return map[string]string{}, nil
+}
+
+// WriteProfile upserts a profile section, preserving other profiles.
+func WriteProfile(profile string, attrs map[string]string) error {
+	path := Path()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	all := map[string]map[string]string{}
+	if content, err := os.ReadFile(path); err == nil {
+		all = ParseAll(string(content))
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("cannot read %s: %w", path, err)
+	}
+
+	all[profile] = attrs
+	return os.WriteFile(path, []byte(serialize(all)), 0o600)
+}
+
+// DeleteProfile removes a profile from the credentials file.
+// No-op if the file or profile does not exist.
+func DeleteProfile(profile string) error {
+	path := Path()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("cannot read %s: %w", path, err)
+	}
+	all := ParseAll(string(content))
+	delete(all, profile)
+	return os.WriteFile(path, []byte(serialize(all)), 0o600)
+}
+
+var sectionRE = regexp.MustCompile(`^\[([^\]]+)\]$`)
+
+// ParseAll parses the credentials file content into a profile→attrs map.
+// Exposed for tests; the parser is lenient (matches the Elixir original).
+func ParseAll(content string) map[string]map[string]string {
+	out := map[string]map[string]string{}
+	var section string
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if m := sectionRE.FindStringSubmatch(line); m != nil {
+			section = m[1]
+			continue
+		}
+		if section == "" || !strings.Contains(line, "=") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		key := strings.TrimSpace(line[:eq])
+		val := stripQuotes(strings.TrimSpace(line[eq+1:]))
+		if _, ok := out[section]; !ok {
+			out[section] = map[string]string{}
+		}
+		out[section][key] = val
+	}
+	return out
+}
+
+func stripQuotes(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	if len(s) >= 1 && s[0] == '"' {
+		return s[1:]
+	}
+	return s
+}
+
+// serialize writes profiles back as the same TOML-ish shape, with
+// "default" first and other profiles in sorted order.
+func serialize(all map[string]map[string]string) string {
+	if len(all) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(all))
+	for n := range all {
+		names = append(names, n)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		ki := names[i]
+		kj := names[j]
+		if ki == "default" {
+			ki = ""
+		}
+		if kj == "default" {
+			kj = ""
+		}
+		return ki < kj
+	})
+
+	var sections []string
+	for _, name := range names {
+		attrs := all[name]
+		keys := make([]string, 0, len(attrs))
+		for k := range attrs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		b.WriteString("[")
+		b.WriteString(name)
+		b.WriteString("]\n")
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(k)
+			b.WriteString(` = "`)
+			b.WriteString(attrs[k])
+			b.WriteString(`"`)
+		}
+		sections = append(sections, b.String())
+	}
+	return strings.Join(sections, "\n\n") + "\n"
+}

--- a/cli/internal/credentials/credentials_test.go
+++ b/cli/internal/credentials/credentials_test.go
@@ -1,0 +1,235 @@
+package credentials
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setup(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "credentials")
+	SetPathOverride(path)
+	t.Cleanup(func() { SetPathOverride("") })
+	return path
+}
+
+// ── ParseAll ────────────────────────────────────────────────────────────
+
+func TestParseAll_SingleProfile(t *testing.T) {
+	toml := `[default]
+api_key = "ftn_abc123"
+base_url = "https://fountain.dev"
+`
+	got := ParseAll(toml)
+	if got["default"]["api_key"] != "ftn_abc123" {
+		t.Fatalf("api_key: %q", got["default"]["api_key"])
+	}
+	if got["default"]["base_url"] != "https://fountain.dev" {
+		t.Fatalf("base_url: %q", got["default"]["base_url"])
+	}
+}
+
+func TestParseAll_MultipleProfiles(t *testing.T) {
+	toml := `[default]
+api_key = "ftn_def456"
+base_url = "https://fountain.dev"
+
+[staging]
+api_key = "ftn_abc123"
+base_url = "https://staging.fountain.dev"
+`
+	got := ParseAll(toml)
+	if got["default"]["api_key"] != "ftn_def456" {
+		t.Fatalf("default.api_key")
+	}
+	if got["staging"]["api_key"] != "ftn_abc123" {
+		t.Fatalf("staging.api_key")
+	}
+	if got["staging"]["base_url"] != "https://staging.fountain.dev" {
+		t.Fatalf("staging.base_url")
+	}
+}
+
+func TestParseAll_Empty(t *testing.T) {
+	if got := ParseAll(""); len(got) != 0 {
+		t.Fatalf("expected empty, got %v", got)
+	}
+}
+
+func TestParseAll_IgnoresBlanksAndComments(t *testing.T) {
+	toml := `# This is a comment
+[default]
+# Another comment
+api_key = "ftn_abc"
+`
+	got := ParseAll(toml)
+	if got["default"]["api_key"] != "ftn_abc" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestParseAll_UnquotedValue(t *testing.T) {
+	toml := `[default]
+api_key = ftn_noquotes
+`
+	got := ParseAll(toml)
+	if got["default"]["api_key"] != "ftn_noquotes" {
+		t.Fatalf("got %q", got["default"]["api_key"])
+	}
+}
+
+// ── ReadProfile ─────────────────────────────────────────────────────────
+
+func TestReadProfile_NoFile(t *testing.T) {
+	setup(t)
+	got, err := ReadProfile("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %v", got)
+	}
+}
+
+func TestReadProfile_MissingProfile(t *testing.T) {
+	setup(t)
+	if err := WriteProfile("default", map[string]string{"api_key": "ftn_x"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadProfile("nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %v", got)
+	}
+}
+
+func TestReadProfile_RoundTrip(t *testing.T) {
+	setup(t)
+	in := map[string]string{"api_key": "ftn_abc", "base_url": "https://fountain.dev"}
+	if err := WriteProfile("default", in); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadProfile("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["api_key"] != "ftn_abc" || got["base_url"] != "https://fountain.dev" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+// ── WriteProfile ────────────────────────────────────────────────────────
+
+func TestWriteProfile_CreatesParentDirs(t *testing.T) {
+	path := setup(t)
+	if err := WriteProfile("default", map[string]string{"api_key": "ftn_x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s: %v", path, err)
+	}
+}
+
+func TestWriteProfile_StagingDoesNotAlterDefault(t *testing.T) {
+	setup(t)
+	_ = WriteProfile("default", map[string]string{"api_key": "ftn_default"})
+	_ = WriteProfile("staging", map[string]string{"api_key": "ftn_staging", "base_url": "https://staging.fountain.dev"})
+
+	def, _ := ReadProfile("default")
+	if def["api_key"] != "ftn_default" || len(def) != 1 {
+		t.Fatalf("default mutated: %v", def)
+	}
+	stg, _ := ReadProfile("staging")
+	if stg["api_key"] != "ftn_staging" || stg["base_url"] != "https://staging.fountain.dev" {
+		t.Fatalf("staging: %v", stg)
+	}
+}
+
+func TestWriteProfile_UpsertDoesNotAlterDefault(t *testing.T) {
+	setup(t)
+	_ = WriteProfile("default", map[string]string{"api_key": "ftn_default"})
+	_ = WriteProfile("staging", map[string]string{"api_key": "ftn_staging_v1"})
+	_ = WriteProfile("staging", map[string]string{"api_key": "ftn_staging_v2"})
+
+	def, _ := ReadProfile("default")
+	if def["api_key"] != "ftn_default" {
+		t.Fatalf("default mutated: %v", def)
+	}
+	stg, _ := ReadProfile("staging")
+	if stg["api_key"] != "ftn_staging_v2" {
+		t.Fatalf("staging not upserted: %v", stg)
+	}
+}
+
+// ── DeleteProfile ───────────────────────────────────────────────────────
+
+func TestDeleteProfile_NoFile(t *testing.T) {
+	setup(t)
+	if err := DeleteProfile("default"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeleteProfile_RemovesNamedSection(t *testing.T) {
+	setup(t)
+	_ = WriteProfile("default", map[string]string{"api_key": "ftn_default"})
+	_ = WriteProfile("staging", map[string]string{"api_key": "ftn_staging"})
+
+	if err := DeleteProfile("staging"); err != nil {
+		t.Fatal(err)
+	}
+	def, _ := ReadProfile("default")
+	if def["api_key"] != "ftn_default" {
+		t.Fatalf("default mutated: %v", def)
+	}
+	stg, _ := ReadProfile("staging")
+	if len(stg) != 0 {
+		t.Fatalf("staging not removed: %v", stg)
+	}
+}
+
+func TestDeleteProfile_NoOpOnUnknown(t *testing.T) {
+	setup(t)
+	_ = WriteProfile("default", map[string]string{"api_key": "ftn_default"})
+	if err := DeleteProfile("nonexistent"); err != nil {
+		t.Fatal(err)
+	}
+	def, _ := ReadProfile("default")
+	if def["api_key"] != "ftn_default" {
+		t.Fatalf("default mutated: %v", def)
+	}
+}
+
+// ── ProfileName ─────────────────────────────────────────────────────────
+
+func TestProfileName_FromOpts(t *testing.T) {
+	t.Setenv("FOUNTAIN_PROFILE", "")
+	if got := ProfileName(Opts{Profile: "staging"}); got != "staging" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestProfileName_FromEnv(t *testing.T) {
+	t.Setenv("FOUNTAIN_PROFILE", "env_profile")
+	if got := ProfileName(Opts{}); got != "env_profile" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestProfileName_DefaultFallback(t *testing.T) {
+	t.Setenv("FOUNTAIN_PROFILE", "")
+	if got := ProfileName(Opts{}); got != "default" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestProfileName_OptsBeatsEnv(t *testing.T) {
+	t.Setenv("FOUNTAIN_PROFILE", "env_profile")
+	if got := ProfileName(Opts{Profile: "opt_profile"}); got != "opt_profile" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/cli/internal/manifest/manifest.go
+++ b/cli/internal/manifest/manifest.go
@@ -1,0 +1,175 @@
+// Package manifest reads YAML resource definitions for `fountain apply`.
+package manifest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Doc is one parsed resource document.
+//
+// `Spec` is intentionally a `map[string]any` so callers can keep arbitrary
+// fields and roundtrip them to the API as JSON. Only `apiVersion`, `kind`,
+// and `metadata.name` are part of the contract here.
+type Doc struct {
+	APIVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	Metadata   map[string]any `yaml:"metadata"`
+	Spec       map[string]any `yaml:"spec"`
+	// Raw is the full doc as a generic map (preserves anything we don't model).
+	Raw map[string]any `yaml:"-"`
+}
+
+// Name returns metadata.name or "" if missing.
+func (d *Doc) Name() string {
+	if d.Metadata == nil {
+		return ""
+	}
+	n, _ := d.Metadata["name"].(string)
+	return n
+}
+
+// IsResource reports whether the doc carries both apiVersion and kind.
+// Files in a specs tree may include unrelated YAML (CI config, etc.); we
+// only treat docs with both fields as something to reconcile.
+func (d *Doc) IsResource() bool {
+	return d.APIVersion != "" && d.Kind != ""
+}
+
+// Read parses path. If path is a directory, all *.yml and *.yaml files
+// are walked recursively (sorted alphabetically) and concatenated. Docs
+// without both apiVersion and kind are silently skipped.
+func Read(path string) ([]*Doc, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		files, err := listYAMLFiles(path)
+		if err != nil {
+			return nil, err
+		}
+		if len(files) == 0 {
+			return nil, fmt.Errorf("no .yml/.yaml files found under %s", path)
+		}
+		var all []*Doc
+		for _, f := range files {
+			docs, err := readFile(f)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, docs...)
+		}
+		return filterResources(all), nil
+	}
+	docs, err := readFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return filterResources(docs), nil
+}
+
+func listYAMLFiles(dir string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(p))
+		if ext == ".yml" || ext == ".yaml" {
+			out = append(out, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func readFile(path string) ([]*Doc, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var docs []*Doc
+	dec := yaml.NewDecoder(strings.NewReader(string(raw)))
+	for {
+		var node map[string]any
+		if err := dec.Decode(&node); err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return nil, fmt.Errorf("yaml parse error in %s: %w", path, err)
+		}
+		if len(node) == 0 {
+			continue
+		}
+		// Re-encode then decode into Doc to populate the typed fields,
+		// while keeping the raw map for downstream serialization.
+		buf, err := yaml.Marshal(node)
+		if err != nil {
+			return nil, err
+		}
+		var d Doc
+		if err := yaml.Unmarshal(buf, &d); err != nil {
+			return nil, err
+		}
+		d.Raw = normalizeMap(node)
+		docs = append(docs, &d)
+	}
+	return docs, nil
+}
+
+func filterResources(docs []*Doc) []*Doc {
+	out := make([]*Doc, 0, len(docs))
+	for _, d := range docs {
+		if d.IsResource() {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// normalizeMap converts yaml's map[interface{}]interface{} subtrees to
+// map[string]any, recursively. yaml.v3 already produces map[string]any
+// for top-level keys but nested maps under MapSlice or unusual shapes
+// can still come back keyed by interface{}; this guard keeps downstream
+// JSON encoding safe.
+func normalizeMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = normalize(v)
+	}
+	return out
+}
+
+func normalize(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		return normalizeMap(x)
+	case map[any]any:
+		out := make(map[string]any, len(x))
+		for k, val := range x {
+			out[fmt.Sprintf("%v", k)] = normalize(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, item := range x {
+			out[i] = normalize(item)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/cli/internal/manifest/manifest_test.go
+++ b/cli/internal/manifest/manifest_test.go
@@ -1,0 +1,88 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRead_SingleFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spec.yml")
+	yaml := `apiVersion: aod/v1
+kind: Environment
+metadata:
+  name: prod
+spec:
+  setup_script: "echo hi"
+  secrets:
+    GH: ${GH_PAT}
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	docs, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("docs: %d", len(docs))
+	}
+	d := docs[0]
+	if d.Kind != "Environment" || d.Name() != "prod" {
+		t.Fatalf("kind=%q name=%q", d.Kind, d.Name())
+	}
+	if d.Spec["setup_script"] != "echo hi" {
+		t.Fatalf("spec: %v", d.Spec)
+	}
+	secrets := d.Spec["secrets"].(map[string]any)
+	if secrets["GH"] != "${GH_PAT}" {
+		t.Fatalf("secrets: %v", secrets)
+	}
+}
+
+func TestRead_MultiDoc(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "all.yaml")
+	yaml := `---
+apiVersion: aod/v1
+kind: Environment
+metadata:
+  name: a
+spec: {}
+---
+apiVersion: aod/v1
+kind: Vault
+metadata:
+  name: b
+spec: {}
+`
+	_ = os.WriteFile(path, []byte(yaml), 0o600)
+	docs, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("docs: %d", len(docs))
+	}
+}
+
+func TestRead_DirectoryFiltersNonResource(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "a.yml"), []byte(`apiVersion: aod/v1
+kind: Vault
+metadata:
+  name: a
+spec: {}
+`), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "ci.yml"), []byte(`name: build
+on: push
+`), 0o600)
+	docs, err := Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docs) != 1 || docs[0].Name() != "a" {
+		t.Fatalf("docs: %v", docs)
+	}
+}

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -1,0 +1,111 @@
+// Package output: shared CLI rendering helpers (tables, JSON, truncation).
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// PrintJSON pretty-prints v as JSON to stdout.
+func PrintJSON(v any) error {
+	buf, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(buf))
+	return nil
+}
+
+// Table prints a column-aligned table. Columns are separated by two
+// spaces; a separator row of dashes follows the header.
+func Table(headers []string, rows [][]string) {
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = utf8.RuneCountInString(h)
+	}
+	for _, r := range rows {
+		for i, c := range r {
+			if i >= len(widths) {
+				continue
+			}
+			if w := utf8.RuneCountInString(c); w > widths[i] {
+				widths[i] = w
+			}
+		}
+	}
+
+	cells := make([]string, len(headers))
+	for i, h := range headers {
+		cells[i] = padRight(h, widths[i])
+	}
+	fmt.Println(strings.Join(cells, "  "))
+
+	dashes := make([]string, len(widths))
+	for i, w := range widths {
+		dashes[i] = strings.Repeat("-", w)
+	}
+	fmt.Println(strings.Join(dashes, "  "))
+
+	for _, r := range rows {
+		row := make([]string, len(widths))
+		for i := range widths {
+			v := ""
+			if i < len(r) {
+				v = r[i]
+			}
+			row[i] = padRight(v, widths[i])
+		}
+		fmt.Println(strings.Join(row, "  "))
+	}
+}
+
+func padRight(s string, n int) string {
+	pad := n - utf8.RuneCountInString(s)
+	if pad <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", pad)
+}
+
+// Truncate returns s truncated to n runes with an ellipsis if needed.
+func Truncate(s string, n int) string {
+	if utf8.RuneCountInString(s) <= n {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:n]) + "…"
+}
+
+// ShortID returns the first 8 chars of an id (for compact tables).
+func ShortID(s string) string {
+	if len(s) >= 8 {
+		return s[:8]
+	}
+	return s
+}
+
+// ToString renders any JSON-decoded value as a printable string.
+func ToString(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case float64:
+		// json.Unmarshal yields float64 for numbers; render integers cleanly.
+		if x == float64(int64(x)) {
+			return fmt.Sprintf("%d", int64(x))
+		}
+		return fmt.Sprintf("%g", x)
+	default:
+		return fmt.Sprintf("%v", x)
+	}
+}

--- a/cli/internal/secrets/bws.go
+++ b/cli/internal/secrets/bws.go
@@ -1,0 +1,79 @@
+package secrets
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Bitwarden wraps the `bws` (Bitwarden Secrets Manager) CLI for
+// bws://<secret-uuid> refs.
+type Bitwarden struct{}
+
+func (*Bitwarden) Prefix() string { return "bws://" }
+
+var (
+	errBwsNotInstalled = errors.New("bws_not_installed")
+	errBwsEmptyRef     = errors.New("bws_empty_ref")
+	errBwsInvalidRef   = errors.New("bws_invalid_ref")
+)
+
+type bwsFailed struct{ Output string }
+
+func (e *bwsFailed) Error() string { return "bws_failed: " + e.Output }
+
+type bwsUnexpected struct{ Reason string }
+
+func (e *bwsUnexpected) Error() string { return "bws_unexpected_output: " + e.Reason }
+
+func (*Bitwarden) Read(ref string) (string, error) {
+	if !strings.HasPrefix(ref, "bws://") {
+		return "", errBwsInvalidRef
+	}
+	uuid := strings.TrimPrefix(ref, "bws://")
+	if uuid == "" {
+		return "", errBwsEmptyRef
+	}
+	if _, err := exec.LookPath("bws"); err != nil {
+		return "", errBwsNotInstalled
+	}
+	out, err := combinedOutput("bws", "secret", "get", uuid)
+	if err != nil {
+		return "", &bwsFailed{Output: strings.TrimSpace(out)}
+	}
+	var parsed struct {
+		Value *string `json:"value"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		return "", &bwsUnexpected{Reason: "could not parse `bws` output as JSON"}
+	}
+	if parsed.Value == nil {
+		return "", &bwsUnexpected{Reason: "JSON had no string `value` field"}
+	}
+	return *parsed.Value, nil
+}
+
+func (*Bitwarden) FormatError(err error) string {
+	switch {
+	case errors.Is(err, errBwsNotInstalled):
+		return "Bitwarden Secrets Manager CLI (`bws`) not on PATH — install from https://bitwarden.com/help/secrets-manager-cli/"
+	case errors.Is(err, errBwsEmptyRef):
+		return "bws://<uuid> reference is missing the UUID"
+	case errors.Is(err, errBwsInvalidRef):
+		return "invalid bws:// reference"
+	}
+	var f *bwsFailed
+	if errors.As(err, &f) {
+		if f.Output == "" {
+			return "bws exited non-zero with no output"
+		}
+		return f.Output
+	}
+	var u *bwsUnexpected
+	if errors.As(err, &u) {
+		return "unexpected bws output: " + u.Reason
+	}
+	return fmt.Sprintf("%v", err)
+}

--- a/cli/internal/secrets/exec.go
+++ b/cli/internal/secrets/exec.go
@@ -1,0 +1,10 @@
+package secrets
+
+import "os/exec"
+
+// combinedOutput runs cmd with args and returns combined stdout+stderr.
+// On non-zero exit the output is still returned alongside the error.
+func combinedOutput(cmd string, args ...string) (string, error) {
+	out, err := exec.Command(cmd, args...).CombinedOutput()
+	return string(out), err
+}

--- a/cli/internal/secrets/infisical.go
+++ b/cli/internal/secrets/infisical.go
@@ -1,0 +1,112 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Infisical wraps the `infisical` CLI for
+// infisical://<project?>/<env>/<path?>/<name> refs.
+type Infisical struct{}
+
+func (*Infisical) Prefix() string { return "infisical://" }
+
+var errInfisicalNotInstalled = errors.New("infisical_not_installed")
+
+type infisicalInvalidRef struct{ Reason string }
+
+func (e *infisicalInvalidRef) Error() string { return "invalid_ref: " + e.Reason }
+
+type infisicalFailed struct{ Output string }
+
+func (e *infisicalFailed) Error() string { return "infisical_failed: " + e.Output }
+
+type infisicalParts struct {
+	Project string // empty → fall through to .infisical.json / INFISICAL_PROJECT_ID
+	Env     string
+	Path    string
+	Name    string
+}
+
+func (*Infisical) Read(ref string) (string, error) {
+	if !strings.HasPrefix(ref, "infisical://") {
+		return "", &infisicalInvalidRef{Reason: "missing infisical:// prefix"}
+	}
+	rest := strings.TrimPrefix(ref, "infisical://")
+	parts, err := parseInfisical(rest)
+	if err != nil {
+		return "", err
+	}
+	if _, err := exec.LookPath("infisical"); err != nil {
+		return "", errInfisicalNotInstalled
+	}
+	args := []string{"secrets", "get", parts.Name, "--env=" + parts.Env, "--path=" + parts.Path, "--plain"}
+	if parts.Project != "" {
+		args = append(args, "--projectId="+parts.Project)
+	}
+	out, err := combinedOutput("infisical", args...)
+	if err != nil {
+		return "", &infisicalFailed{Output: strings.TrimSpace(out)}
+	}
+	return strings.TrimRight(out, "\n"), nil
+}
+
+// parseInfisical splits the URI tail into its positional segments.
+//
+//	<project>/<env>/<name>                    → path = "/"
+//	<project>/<env>/<seg>/<seg>/.../<name>    → path = "/" + joined middle segments
+//
+// The project segment may be empty (the CLI then falls through to its own
+// project resolution).
+func parseInfisical(rest string) (infisicalParts, error) {
+	segments := strings.Split(rest, "/")
+	switch {
+	case len(segments) == 3 && segments[1] != "" && segments[2] != "":
+		return infisicalParts{
+			Project: segments[0],
+			Env:     segments[1],
+			Path:    "/",
+			Name:    segments[2],
+		}, nil
+	case len(segments) >= 4 && segments[1] != "":
+		name := segments[len(segments)-1]
+		mid := segments[2 : len(segments)-1]
+		if name == "" {
+			return infisicalParts{}, &infisicalInvalidRef{Reason: "missing secret name (last segment)"}
+		}
+		for _, s := range mid {
+			if s == "" {
+				return infisicalParts{}, &infisicalInvalidRef{Reason: "empty path segment"}
+			}
+		}
+		return infisicalParts{
+			Project: segments[0],
+			Env:     segments[1],
+			Path:    "/" + strings.Join(mid, "/"),
+			Name:    name,
+		}, nil
+	}
+	return infisicalParts{}, &infisicalInvalidRef{
+		Reason: "expected infisical://<project?>/<env>/<path?>/<name> with at least env and name",
+	}
+}
+
+func (*Infisical) FormatError(err error) string {
+	if errors.Is(err, errInfisicalNotInstalled) {
+		return "Infisical CLI (`infisical`) not on PATH — install from https://infisical.com/docs/cli/overview"
+	}
+	var ir *infisicalInvalidRef
+	if errors.As(err, &ir) {
+		return "invalid infisical:// reference: " + ir.Reason
+	}
+	var f *infisicalFailed
+	if errors.As(err, &f) {
+		if f.Output == "" {
+			return "infisical exited non-zero with no output"
+		}
+		return f.Output
+	}
+	return fmt.Sprintf("%v", err)
+}

--- a/cli/internal/secrets/op.go
+++ b/cli/internal/secrets/op.go
@@ -1,0 +1,47 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// OnePassword wraps the `op` CLI for op://<vault>/<item>/<field> refs.
+type OnePassword struct{}
+
+func (*OnePassword) Prefix() string { return "op://" }
+
+// Sentinel errors so FormatError can produce the right message.
+var (
+	errOpNotInstalled = errors.New("op_not_installed")
+)
+
+type opFailed struct{ Output string }
+
+func (e *opFailed) Error() string { return "op_failed: " + e.Output }
+
+func (*OnePassword) Read(ref string) (string, error) {
+	if _, err := exec.LookPath("op"); err != nil {
+		return "", errOpNotInstalled
+	}
+	out, err := combinedOutput("op", "read", "--no-newline", ref)
+	if err != nil {
+		return "", &opFailed{Output: strings.TrimSpace(out)}
+	}
+	return out, nil
+}
+
+func (*OnePassword) FormatError(err error) string {
+	if errors.Is(err, errOpNotInstalled) {
+		return "1Password CLI (`op`) not on PATH — install from https://developer.1password.com/docs/cli/get-started"
+	}
+	var f *opFailed
+	if errors.As(err, &f) {
+		if f.Output == "" {
+			return "op exited non-zero with no output"
+		}
+		return f.Output
+	}
+	return fmt.Sprintf("%v", err)
+}

--- a/cli/internal/secrets/resolver.go
+++ b/cli/internal/secrets/resolver.go
@@ -1,0 +1,37 @@
+// Package secrets resolves external secret references at apply time.
+//
+// Each Resolver is bound to a URI prefix (op://, bws://, infisical://).
+// Apply walks `spec.secrets` values, finds the resolver whose prefix
+// matches, and replaces the value with whatever the resolver returns.
+package secrets
+
+import "strings"
+
+// Resolver is the contract for an external secret backend.
+type Resolver interface {
+	// Prefix is the URI scheme this resolver claims, e.g. "op://".
+	Prefix() string
+	// Read returns the plaintext for ref, or an error.
+	Read(ref string) (string, error)
+	// FormatError converts a Read error into a human-readable message
+	// for the apply CLI's failure dump.
+	FormatError(err error) string
+}
+
+// Default is the registry used by Apply when no override is supplied.
+var Default = []Resolver{
+	&OnePassword{},
+	&Bitwarden{},
+	&Infisical{},
+}
+
+// ForValue returns the first Resolver in `list` whose prefix matches s.
+// Returns nil for non-string values or when no scheme matches.
+func ForValue(s string, list []Resolver) Resolver {
+	for _, r := range list {
+		if strings.HasPrefix(s, r.Prefix()) {
+			return r
+		}
+	}
+	return nil
+}

--- a/cli/internal/sse/sse.go
+++ b/cli/internal/sse/sse.go
@@ -1,0 +1,91 @@
+// Package sse is a minimal RFC 6202 Server-Sent Events parser.
+package sse
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// Event is one SSE message. Data is JSON-decoded if it parses, or the raw
+// concatenated string otherwise.
+type Event struct {
+	ID    int
+	Event string
+	Data  any
+	// rawData is preserved for callers that need the original string form.
+	rawData string
+}
+
+// RawData returns the concatenated raw string form of the event's data field.
+func (e *Event) RawData() string { return e.rawData }
+
+// Feed parses complete events out of buffer. Returns events and any
+// trailing partial event left in the buffer (the caller must prepend it
+// to the next read before calling Feed again).
+func Feed(buffer string) (events []Event, leftover string) {
+	parts := strings.Split(buffer, "\n\n")
+	if len(parts) == 0 {
+		return nil, ""
+	}
+	leftover = parts[len(parts)-1]
+	for _, block := range parts[:len(parts)-1] {
+		if ev, ok := parse(block); ok {
+			events = append(events, ev)
+		}
+	}
+	return events, leftover
+}
+
+func parse(block string) (Event, bool) {
+	if block == "" || strings.HasPrefix(block, ":") {
+		return Event{}, false
+	}
+	var ev Event
+	var dataLines []string
+	for _, line := range strings.Split(block, "\n") {
+		if line == "" {
+			continue
+		}
+		key, val, ok := splitField(line)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "id":
+			n, _ := strconv.Atoi(val)
+			ev.ID = n
+		case "event":
+			ev.Event = val
+		case "data":
+			dataLines = append(dataLines, val)
+		}
+	}
+	if ev.Event == "" && len(dataLines) == 0 && ev.ID == 0 {
+		return Event{}, false
+	}
+	if len(dataLines) > 0 {
+		raw := strings.Join(dataLines, "\n")
+		ev.rawData = raw
+		var decoded any
+		if json.Unmarshal([]byte(raw), &decoded) == nil {
+			ev.Data = decoded
+		} else {
+			ev.Data = raw
+		}
+	}
+	return ev, true
+}
+
+// splitField parses an SSE field line. The Elixir parser used `": "` as
+// separator (value-with-leading-space form); the spec also allows `:`
+// alone. We accept either.
+func splitField(line string) (key, val string, ok bool) {
+	idx := strings.Index(line, ":")
+	if idx < 0 {
+		return "", "", false
+	}
+	key = line[:idx]
+	val = strings.TrimPrefix(line[idx+1:], " ")
+	return key, val, true
+}

--- a/cli/internal/sse/sse_test.go
+++ b/cli/internal/sse/sse_test.go
@@ -1,0 +1,61 @@
+package sse
+
+import "testing"
+
+func TestFeed_LeavesPartialEvent(t *testing.T) {
+	events, leftover := Feed("event: stage\ndata: \"hi\"\n\nevent: ou")
+	if len(events) != 1 {
+		t.Fatalf("events: %d", len(events))
+	}
+	if events[0].Event != "stage" {
+		t.Fatalf("event: %q", events[0].Event)
+	}
+	if leftover != "event: ou" {
+		t.Fatalf("leftover: %q", leftover)
+	}
+}
+
+func TestFeed_DecodesJSONData(t *testing.T) {
+	events, _ := Feed(`event: stage
+data: {"stage":"turn","state":"done"}
+
+`)
+	if len(events) != 1 {
+		t.Fatalf("events: %d", len(events))
+	}
+	m, ok := events[0].Data.(map[string]any)
+	if !ok {
+		t.Fatalf("data not map: %T", events[0].Data)
+	}
+	if m["stage"] != "turn" || m["state"] != "done" {
+		t.Fatalf("data: %v", m)
+	}
+}
+
+func TestFeed_FallsBackToRawString(t *testing.T) {
+	events, _ := Feed("data: not json\n\n")
+	if len(events) != 1 {
+		t.Fatalf("events: %d", len(events))
+	}
+	s, ok := events[0].Data.(string)
+	if !ok || s != "not json" {
+		t.Fatalf("data: %v", events[0].Data)
+	}
+}
+
+func TestFeed_IgnoresHeartbeat(t *testing.T) {
+	events, _ := Feed(": keep-alive\n\n")
+	if len(events) != 0 {
+		t.Fatalf("events: %d", len(events))
+	}
+}
+
+func TestFeed_ParsesIDAsInt(t *testing.T) {
+	events, _ := Feed("id: 42\nevent: x\ndata: ok\n\n")
+	if len(events) != 1 {
+		t.Fatalf("events: %d", len(events))
+	}
+	if events[0].ID != 42 {
+		t.Fatalf("id: %d", events[0].ID)
+	}
+}

--- a/cli/internal/substitution/substitution.go
+++ b/cli/internal/substitution/substitution.go
@@ -1,0 +1,114 @@
+// Package substitution implements ${VAR} expansion for manifest secrets.
+//
+//	${VAR}    eager — substituted from the supplied vars map
+//	$${VAR}   escape — written through as literal `${VAR}`
+//	$$        literal `$`
+//
+// Identifiers must match [A-Z_][A-Z0-9_]* (UPPER_SNAKE_CASE).
+//
+// Walks recursively through maps and lists; only string leaves are
+// rewritten. Missing keys are accumulated across the entire input so
+// the caller can surface every typo at once.
+package substitution
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+var refRE = regexp.MustCompile(`\$\$|\$\{([A-Z_][A-Z0-9_]*)\}`)
+
+// MissingVarsError lists variable names that were referenced but not provided.
+type MissingVarsError struct{ Missing []string }
+
+func (e *MissingVarsError) Error() string {
+	return fmt.Sprintf("missing vars: %v", e.Missing)
+}
+
+// Apply walks value recursively and substitutes ${VAR} references.
+// Returns a fresh value tree on success; on missing vars, returns the
+// input unchanged plus a MissingVarsError listing every missing key.
+func Apply(value any, vars map[string]string) (any, error) {
+	missing := map[string]struct{}{}
+	result := walk(value, vars, missing)
+	if len(missing) == 0 {
+		return result, nil
+	}
+	list := make([]string, 0, len(missing))
+	for k := range missing {
+		list = append(list, k)
+	}
+	sort.Strings(list)
+	return value, &MissingVarsError{Missing: list}
+}
+
+func walk(value any, vars map[string]string, missing map[string]struct{}) any {
+	switch v := value.(type) {
+	case string:
+		// Find missing first so we know whether to substitute.
+		need := requiredVars(v)
+		complete := true
+		for _, name := range need {
+			if _, ok := vars[name]; !ok {
+				missing[name] = struct{}{}
+				complete = false
+			}
+		}
+		if !complete {
+			return v
+		}
+		return substitute(v, vars)
+
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, child := range v {
+			out[k] = walk(child, vars, missing)
+		}
+		return out
+
+	case map[string]string:
+		out := make(map[string]string, len(v))
+		for k, child := range v {
+			r := walk(child, vars, missing)
+			if s, ok := r.(string); ok {
+				out[k] = s
+			} else {
+				out[k] = fmt.Sprintf("%v", r)
+			}
+		}
+		return out
+
+	case []any:
+		out := make([]any, len(v))
+		for i, child := range v {
+			out[i] = walk(child, vars, missing)
+		}
+		return out
+
+	default:
+		return v
+	}
+}
+
+func requiredVars(s string) []string {
+	var out []string
+	for _, m := range refRE.FindAllStringSubmatch(s, -1) {
+		if m[0] == "$$" {
+			continue
+		}
+		out = append(out, m[1])
+	}
+	return out
+}
+
+func substitute(s string, vars map[string]string) string {
+	return refRE.ReplaceAllStringFunc(s, func(match string) string {
+		if match == "$$" {
+			return "$"
+		}
+		// match is ${NAME}
+		name := match[2 : len(match)-1]
+		return vars[name]
+	})
+}

--- a/cli/internal/substitution/substitution_test.go
+++ b/cli/internal/substitution/substitution_test.go
@@ -1,0 +1,87 @@
+package substitution
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestApply_SimpleString(t *testing.T) {
+	got, err := Apply("hello ${NAME}", map[string]string{"NAME": "world"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello world" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestApply_EscapeDollarBrace(t *testing.T) {
+	got, err := Apply("$${PATH}/x", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "${PATH}/x" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestApply_MissingVarErrors(t *testing.T) {
+	_, err := Apply(map[string]any{
+		"a": "hello ${NAME}",
+		"b": "${OTHER}",
+	}, map[string]string{})
+	var me *MissingVarsError
+	if !errors.As(err, &me) {
+		t.Fatalf("expected MissingVarsError, got %v", err)
+	}
+	want := []string{"NAME", "OTHER"}
+	if !reflect.DeepEqual(me.Missing, want) {
+		t.Fatalf("got missing %v, want %v", me.Missing, want)
+	}
+}
+
+func TestApply_MissingDoesNotPartiallySubstitute(t *testing.T) {
+	got, err := Apply("${SET}/${UNSET}", map[string]string{"SET": "x"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	// On error the original string is returned unchanged.
+	if got != "${SET}/${UNSET}" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestApply_NestedMapList(t *testing.T) {
+	in := map[string]any{
+		"k": "v-${A}",
+		"list": []any{
+			"${B}",
+			map[string]any{"deep": "x-${A}-y"},
+		},
+	}
+	got, err := Apply(in, map[string]string{"A": "1", "B": "2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"k": "v-1",
+		"list": []any{
+			"2",
+			map[string]any{"deep": "x-1-y"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestApply_DollarDollarEscape(t *testing.T) {
+	got, err := Apply("$$5.00", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "$5.00" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Port `apps/fountain_cli/` (~2.3k lines Elixir) to Go at `cli/` (~3.5k lines).
- Drops the BEAM runtime and Burrito's Zig-version-pinning release pipeline (last pain point: #47, the 0.15.2 bump). The CLI is an HTTP/JSON client with three subprocess shellouts (`op` / `bws` / `infisical`) and one SSE consumer — none of that needs the actor model.
- Resulting binary: ~10 MB, statically linked, <50 ms cold start, cross-compiles via `GOOS`/`GOARCH` with no toolchain other than `go`.

## Parity

Every command from the Elixir CLI is supported, with the same flags, the same `~/.fountain/credentials` TOML, the same `/api/*` endpoints, and the same `op://` / `bws://` / `infisical://` secret reference syntax.

| Command | Status |
|---|---|
| `auth login` / `logout` / `whoami` | ✅ (password prompt via `golang.org/x/term`) |
| `keys list` / `create` / `revoke` | ✅ |
| `env list` / `show` | ✅ |
| `agent list` / `show` | ✅ |
| `vault list` / `show` / `create` / `delete` / `set-secret` / `delete-secret` | ✅ (id-or-name resolution) |
| `conv list` / `show` / `stream` / `prompt` / `interrupt` / `terminate` / `delete` | ✅ (stdlib net/http for SSE — no `curl` subprocess) |
| `run <agent> -p <prompt>` | ✅ |
| `apply -f <path>` | ✅ (two-phase secret resolution, idempotent reconcile) |
| ~~`up` / `down`~~ | Out of scope — removed from the Elixir CLI in `plan/phase-3-cli`, not reintroduced. |

## What's NOT in this PR

Per discussion, this is the side-by-side ship. Follow-up PR will:
- Delete `apps/fountain_cli/`
- Remove `mix.exs` Burrito config and `release.yml`
- Rename `cli-release-go.yml` → `release.yml`
- Update any docs that point at the Burrito artifact names (`fountain-linux-x86_64`, `fountain-macos-aarch64`)

This keeps a fallback in place during validation.

## Layout

```
cli/
  cmd/fountain/         entry point
  internal/
    api/                HTTP client (Bearer auth, JSON envelope handling)
    cmd/                Cobra command tree
    config/             API key + base URL precedence resolver
    credentials/        ~/.fountain/credentials reader/writer
    manifest/           YAML doc reader for `apply`
    output/             table + JSON rendering
    secrets/            op / bws / infisical resolvers
    sse/                RFC 6202 SSE parser
    substitution/       ${VAR} expansion (with $${VAR} escape)
```

Deps: `cobra`, `gopkg.in/yaml.v3`, `golang.org/x/term`. HTTP, TOML-ish parsing, and SSE framing are stdlib.

## Test plan

Unit tests cover the pure logic (run with `cd cli && go test ./...`):
- [x] Credentials parser/writer — mirrors the Elixir ExUnit suite
- [x] `${VAR}` substitution — escape handling, missing-var collection across nested maps/lists
- [x] SSE framing — partial events, JSON-decoded data, heartbeat skipping
- [x] Manifest loading — single file, multi-doc, directory walk with non-resource filtering

Smoke validation needed against a real server:
- [ ] `fountain auth login` writes credentials, `whoami` reads them
- [ ] `fountain conv stream <id>` matches the Elixir output formatting (ANSI colors, `▸` stage markers, turn-done halt)
- [ ] `fountain apply -f <manifest>` reconciles env+vault+agent with secrets pulled from `op://` / `bws://` / `infisical://`
- [ ] Cross-compile workflow succeeds end-to-end (tag a `v0.x.y-go` release candidate)

## Build

```sh
cd cli
go build -o fountain ./cmd/fountain
./fountain --help
```

CI workflow `cli-release-go.yml` cross-compiles to linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 on tag push and attaches all four to the GitHub Release alongside the existing Burrito artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)