### PR TITLE
fix(cli): strip ownership fields in apply before POST/PUT

### DIFF
--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -385,10 +385,17 @@ func applyAgent(c *api.Client, d *manifest.Doc, envIDByName map[string]string) b
 
 // buildBody returns the request body for a resource (spec minus
 // `secrets`, with `name` set) and a separate map of secrets to upsert.
+//
+// Strips ownership fields (user_id, created_by) so a malicious or
+// careless manifest can't try to attribute resources to another tenant.
+// The server enforces this on its own, but defense-in-depth: don't
+// transmit fields the server is just going to drop.
 func buildBody(d *manifest.Doc, name string) (map[string]any, map[string]any) {
 	body := cloneMap(d.Spec)
 	secretsMap, _ := body["secrets"].(map[string]any)
 	delete(body, "secrets")
+	delete(body, "user_id")
+	delete(body, "created_by")
 	body["name"] = name
 	return body, secretsMap
 }


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to the multi-tenant audit (PRs #44–#55).

\`buildBody\` in \`cli/internal/cmd/apply.go\` previously passed the entire manifest \`spec\` map straight through to POST/PUT. The server now strips \`user_id\` (and ignores \`created_by\`) on create/update — but the CLI was still transmitting them, which is a code smell the audit flagged.

Drop \`user_id\` and \`created_by\` from the body before sending. The server's enforcement still wins; this just stops the CLI from speaking words it knows the server will ignore.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` passes
- [ ] After release: manifest with \`user_id: "..."\` field applies without sending the spoofed value (verifiable by capturing the request body or by server-side audit log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)