### PR TITLE
fix: dashboard "Recent conversations" card links to /conversations

### DIFF
--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -43,7 +43,7 @@ defmodule FountainWeb.DashboardLive.Index do
       </div>
 
       <div class="grid grid-cols-3 gap-4">
-        <.link navigate={~p"/"}
+        <.link navigate={~p"/conversations"}
           class="rounded border border-zinc-200 bg-white shadow p-4 hover:bg-zinc-50 block">
           <p class="text-xs text-zinc-500 uppercase tracking-wide">Recent conversations</p>
           <p class="text-2xl font-semibold mt-1">{length(@recent_conversations)}</p>


### PR DESCRIPTION
## Summary

The "Recent conversations" stat card on the dashboard was navigating to `~p"/"` (the public marketing page) instead of `~p"/conversations"`.

**File changed:** `apps/fountain/lib/fountain_web/live/dashboard_live/index.ex`

```diff
- <.link navigate={~p"/"}
+ <.link navigate={~p"/conversations"}
```