### PR TITLE
fix(cli): default base URL to fountain.inevitable.fyi

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -7,7 +7,7 @@
 // Base URL precedence:
 //  1. FOUNTAIN_BASE_URL env var
 //  2. base_url from ~/.fountain/credentials (active profile)
-//  3. compile-time default (https://fountain.dev)
+//  3. compile-time default (https://fountain.inevitable.fyi)
 package config
 
 import (
@@ -18,7 +18,7 @@ import (
 	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
 )
 
-const DefaultBaseURL = "https://fountain.dev"
+const DefaultBaseURL = "https://fountain.inevitable.fyi"
 
 // ErrNoAPIKey signals that no API key is configured.
 var ErrNoAPIKey = errors.New("FOUNTAIN_API_KEY is not set. Run `fountain auth login` or export the FOUNTAIN_API_KEY environment variable.")


### PR DESCRIPTION
## Summary

The Elixir CLI defaulted to `https://fountain.dev` — a domain we don't own — and the Go port faithfully carried that over. First-time users running `fountain auth login` without setting `FOUNTAIN_BASE_URL` hit DNS failures.

Reported during v0.2.0 install:
\`\`\`
fountain: request failed: Post "https://fountain.dev/api/auth/token": dial tcp: lookup fountain.dev: no such host
\`\`\`

Fix is one-line: change the compile-time default to `https://fountain.inevitable.fyi` (matches `render.yaml`'s `FOUNTAIN_DOMAIN`).

## Test plan

- [x] `go test ./...` clean
- [x] Local build hits real host (`/api/auth/me` returns 401 → "not authenticated", confirming the request reached the server)
- [ ] Tag v0.2.1 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)