### PR TITLE
ci: trigger Render deploy on push to main via deploy hook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy
+
+# Triggers a Render deploy on every push to main.
+#
+# Render's GitHub auto-deploy isn't available here: jhgaylor owns the
+# Render workspace, but the repo lives under the BinaryBourbon org and
+# the Render GitHub app isn't installed there. The standard workaround
+# is a per-service deploy hook (https://render.com/docs/deploy-hooks):
+# Render gives us a unique URL, we POST to it, Render fetches the
+# latest commit from the (public) repo and redeploys.
+#
+# Secret: RENDER_DEPLOY_HOOK_URL (repo secret, set via gh or the UI).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: render-deploy
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    name: Trigger Render deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST to Render deploy hook
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_HOOK_URL}" ]; then
+            echo "RENDER_DEPLOY_HOOK_URL secret is not set" >&2
+            exit 1
+          fi
+          curl --fail-with-body --show-error --silent \
+            -X POST "${DEPLOY_HOOK_URL}"
+          echo


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml`: on every push to `main` (and `workflow_dispatch`), POSTs to a Render deploy hook URL stored as the repo secret `RENDER_DEPLOY_HOOK_URL`.
- Render's standard GitHub auto-deploy can't be used here: jhgaylor owns the Render workspace, but this repo lives under the `BinaryBourbon` org and the Render GitHub app isn't installed there. [Deploy hooks](https://render.com/docs/deploy-hooks) are the documented workaround — Render gives us a unique URL, we POST to it, Render fetches the latest commit and redeploys (the repo is public, so Render can pull without an install).
- `concurrency: render-deploy` serializes triggers so back-to-back merges don't race; `--fail-with-body` on curl makes hook errors surface in the workflow log.

## Required before merge
Set the repo secret so the very first run after merge actually deploys:

```
gh secret set RENDER_DEPLOY_HOOK_URL --repo BinaryBourbon/fountain
# paste the deploy hook URL from the Render dashboard
# (Service → Settings → Deploy Hook)
```

If the secret is missing, the workflow exits 1 with a clear message rather than silently no-op'ing.

## Test plan
- [ ] Add the `RENDER_DEPLOY_HOOK_URL` secret to the repo before merging.
- [ ] Merge this PR and confirm the `Deploy` workflow runs and turns green.
- [ ] Confirm a new deploy appears in the Render dashboard for the `fountain` service shortly after.
- [ ] (Optional) Run the workflow manually via `gh workflow run Deploy` and verify the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)