### PR TITLE
fix(db): change agents.skills from text[] to jsonb[]

### DIFF
--- a/apps/fountain/priv/repo/migrations/20260511000000_change_agents_skills_to_jsonb_array.exs
+++ b/apps/fountain/priv/repo/migrations/20260511000000_change_agents_skills_to_jsonb_array.exs
@@ -1,0 +1,78 @@
+defmodule Fountain.Repo.Migrations.ChangeAgentsSkillsToJsonbArray do
+  @moduledoc """
+  `agents.skills` was created as `text[]` in the initial schema, but the
+  Ecto field declaration is `{:array, :map}` (each element is a SkillSpec
+  map: `%{"source" => owner_repo}` or `%{"name" => n, "content" => md}`).
+  On Postgres, `{:array, :map}` maps to `jsonb[]`, not `text[]`.
+
+  The mismatch was masked on SQLite (both shapes are stored as TEXT JSON).
+  On Postgres it surfaces as `Postgrex.Extensions.Array.encode/4` errors
+  any time agent create/update tries to send a SkillSpec map — which is
+  what `fountain apply` does for every agent doc.
+
+  Existing rows hold `[]` (the post-rehydrate default; the rehydrate
+  migration's legacy_skills branch can't have run on Postgres without
+  hitting the same encode error). The USING clause defensively casts
+  each text element through `::jsonb` so any hand-written valid-JSON
+  data is preserved; non-JSON text would error loudly here rather than
+  silently corrupt.
+
+  Postgres disallows subqueries directly in `ALTER COLUMN ... USING`,
+  so the cast goes through a temporary function that's dropped at the
+  end of the migration.
+  """
+  use Ecto.Migration
+
+  def up do
+    # The initial migration set `default ARRAY[]::text[]` on the column;
+    # the type change can't auto-cast the default, so drop it for the
+    # ALTER and re-add it as `'{}'::jsonb[]` after.
+    execute "ALTER TABLE agents ALTER COLUMN skills DROP DEFAULT"
+
+    execute """
+    CREATE FUNCTION fountain_text_to_jsonb_array(text[]) RETURNS jsonb[]
+      LANGUAGE SQL IMMUTABLE AS $$
+      SELECT COALESCE(
+        array_agg(elem::jsonb),
+        ARRAY[]::jsonb[]
+      )
+      FROM unnest($1) AS elem
+    $$
+    """
+
+    execute """
+    ALTER TABLE agents
+      ALTER COLUMN skills TYPE jsonb[]
+      USING fountain_text_to_jsonb_array(skills)
+    """
+
+    execute "DROP FUNCTION fountain_text_to_jsonb_array(text[])"
+
+    execute "ALTER TABLE agents ALTER COLUMN skills SET DEFAULT ARRAY[]::jsonb[]"
+  end
+
+  def down do
+    execute "ALTER TABLE agents ALTER COLUMN skills DROP DEFAULT"
+
+    execute """
+    CREATE FUNCTION fountain_jsonb_to_text_array(jsonb[]) RETURNS text[]
+      LANGUAGE SQL IMMUTABLE AS $$
+      SELECT COALESCE(
+        array_agg(elem::text),
+        ARRAY[]::text[]
+      )
+      FROM unnest($1) AS elem
+    $$
+    """
+
+    execute """
+    ALTER TABLE agents
+      ALTER COLUMN skills TYPE text[]
+      USING fountain_jsonb_to_text_array(skills)
+    """
+
+    execute "DROP FUNCTION fountain_jsonb_to_text_array(jsonb[])"
+
+    execute "ALTER TABLE agents ALTER COLUMN skills SET DEFAULT ARRAY[]::text[]"
+  end
+end


### PR DESCRIPTION
## Summary

Schema/DB type mismatch on the \`agents.skills\` column has been silently breaking every agent insert/update on Postgres since the SkillSpec migration. \`fountain apply\` can't create any agent with a skills entry.

Reported via this morning's apply log:
\`\`\`
agent  !  designer (create failed): http 500: map[errors:map[detail:Internal Server Error]]
…
** (DBConnection.EncodeError) Postgrex expected a binary, got %{"source" => "obra/superpowers"}
    (postgrex 0.22.1) lib/postgrex/extensions/array.ex:88: Postgrex.Extensions.Array.encode/4
\`\`\`

## Root cause

- **Schema** (\`apps/fountain/lib/fountain/agents/agent.ex:22\`): \`field :skills, {:array, :map}\`. On Postgres, \`{:array, :map}\` → \`jsonb[]\`.
- **DB column** (\`20260501000000_create_initial_schema.exs\`): created as \`{:array, :string}\` → \`text[]\`.
- **Rehydrate migration** (\`20260504000000_rehydrate_agent_skills.exs\`) only updated values; assumed SQLite (which doesn't care). Never altered the column type.

Result: Ecto tries to insert SkillSpec maps into a \`text[]\`, Postgrex fails to encode, server returns 500. Sqlite tests pass because both shapes are stored as TEXT JSON there.

## Fix

\`ALTER COLUMN skills TYPE jsonb[] USING …\` via a temporary cast function (Postgres disallows subqueries directly in \`USING\`). Drops the column default, alters the type, resets the default to \`ARRAY[]::jsonb[]\`. The down migration is the symmetric inverse.

## Verification

Local Postgres dev DB:

- [x] \`mix ecto.migrate\` runs clean
- [x] \`mix ecto.rollback\` returns column to \`text[]\` cleanly
- [x] Re-applying the migration is idempotent
- [x] Inserting an agent with \`skills: [%{"source" => "obra/superpowers"}, %{"name" => "inline-test", "content" => "# hi"}]\` succeeds (it 500'd before)

## Deploy

Render runs \`_build/prod/rel/fountain_server/bin/migrate\` as preDeployCommand on every deploy, so this lands automatically when the merge commit deploys to prod. After that, retry \`fountain apply .\` — the failing agents should reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)