### PR TITLE
docs(help): refresh in-app help to match the Fountain CLI/API

### DIFF
--- a/apps/fountain/priv/help/agents.md
+++ b/apps/fountain/priv/help/agents.md
@@ -9,13 +9,13 @@ An **Agent** is a named configuration for a single coding-agent CLI. It bundles 
 - optional **skills** — names of bundled skills to mount into the sprite
 - optional **mcp_servers** — MCP servers the agent should connect to
 
-When you start a conversation against an agent, AoD provisions a fresh sprite based on the environment, mounts the agent's skills, writes runtime-specific config (e.g. claude's `~/.claude.json`), and runs the runtime CLI inside.
+When you start a conversation against an agent, Fountain provisions a fresh sprite based on the environment, mounts the agent's skills, writes runtime-specific config (e.g. claude's `~/.claude.json`), and runs the runtime CLI inside.
 
 ## Create one via the API
 
 ```bash
-curl -s -X POST "$AOD_BASE_URL/api/agents" \
-  -H "Authorization: Bearer $AOD_TOKEN" -H "Content-Type: application/json" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/agents" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" -H "Content-Type: application/json" \
   -d '{
     "name": "researcher",
     "runtime": "claude",
@@ -39,11 +39,11 @@ The `model` field always uses the `provider/model` shape — even though codex/g
 
 ## Bulk-managing via manifest
 
-If you've got more than two or three agents, use **`aod apply -f aod.yml`**. See **Manifest** for the YAML format.
+If you've got more than two or three agents, use **`fountain apply -f fountain.yml`**. See **Manifest** for the YAML format.
 
 ## `${VAR}` substitution in `mcp_servers`
 
-Most MCP clients don't expand env vars in their config — they read literal strings. So when AoD writes the runtime's MCP config (claude's `~/.claude.json`, codex's `~/.codex/config.toml`, etc.), it substitutes `${VAR}` references **eagerly**, at provision time, against the merged `env_vars` + environment secrets + vault secrets map. Vault wins on key collision.
+Most MCP clients don't expand env vars in their config — they read literal strings. So when Fountain writes the runtime's MCP config (claude's `~/.claude.json`, codex's `~/.codex/config.toml`, etc.), it substitutes `${VAR}` references **eagerly**, at provision time, against the merged `env_vars` + environment secrets + vault secrets map. Vault wins on key collision.
 
 ```yaml
 mcp_servers:
@@ -77,7 +77,7 @@ Use `$${VAR}` only when the MCP server (or some downstream process the runtime s
 | gemini | `gemini` | `google/gemini-2.5-pro` | `GEMINI_API_KEY` |
 | opencode | `opencode` | `provider/model` (anthropic / openai / google) | per provider |
 
-Each has its own quirks — codex needs a one-shot login, opencode auto-installs from `bun install -g`, gemini needs `--allowed-mcp-server-names` for MCP, etc. The runtime modules in `lib/agent_on_demand/runtimes/*.ex` handle these transparently.
+Each has its own quirks — codex needs a one-shot login, opencode auto-installs from `bun install -g`, gemini needs `--allowed-mcp-server-names` for MCP, etc. The runtime modules in `apps/fountain/lib/fountain/runtimes/*.ex` handle these transparently.
 
 ## Skills
 
@@ -87,4 +87,4 @@ Skills are reusable instructional/context files that get mounted into a sprite a
 - For **codex**: concatenated into `~/.codex/AGENTS.md`.
 - For **gemini**: concatenated into `~/.gemini/GEMINI.md`.
 
-Bundled skills live under `priv/sprite_skills/`. Reference them by directory name in the agent's `skills` array. The bundled `aod` skill is **always** mounted regardless — it's how a sprite-internal agent calls back to spawn more conversations.
+Bundled skills live under `apps/fountain/priv/sprite_skills/`. Reference them by directory name in the agent's `skills` array. The bundled `aod` skill is **always** mounted regardless — it's how a sprite-internal agent calls back to spawn more conversations.

--- a/apps/fountain/priv/help/api.md
+++ b/apps/fountain/priv/help/api.md
@@ -5,7 +5,7 @@ The full API spec lives at:
 - **[/api/openapi.json](/api/openapi.json)** — OpenAPI 3 spec, generated from controller decls
 - **[/api/docs](/api/docs)** — Swagger UI; click "Authorize" to set your bearer token and try calls inline
 
-Everything under `/api/*` requires `Authorization: Bearer <ADMIN_TOKEN>`.
+Everything under `/api/*` requires `Authorization: Bearer <FOUNTAIN_API_KEY>`. Mint one with `fountain auth login` (writes to `~/.fountain/credentials`) or `fountain keys create` (prints a raw key for scripting).
 
 ## Endpoint summary
 

--- a/apps/fountain/priv/help/environments.md
+++ b/apps/fountain/priv/help/environments.md
@@ -10,13 +10,13 @@ Fields:
 - **`networking_config`** — for `limited`, an `allowed_hosts` list
 - **`repositories`** — git repos to clone into the sprite at provision time, optionally authenticated via a secret
 - **`setup_script`** — shell run after packages/clones, before the runtime CLI
-- **`checkpoint_id`** — last successful provision's sprite checkpoint (managed by AoD; lets new conversations on the same env warm-start)
+- **`checkpoint_id`** — last successful provision's sprite checkpoint (managed by Fountain; lets new conversations on the same env warm-start)
 
 ## Create one
 
 ```bash
-curl -s -X POST "$AOD_BASE_URL/api/environments" \
-  -H "Authorization: Bearer $AOD_TOKEN" -H "Content-Type: application/json" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/environments" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" -H "Content-Type: application/json" \
   -d '{
     "name": "my-project",
     "packages": {"apt": ["jq", "ripgrep"]},
@@ -38,12 +38,12 @@ curl -s -X POST "$AOD_BASE_URL/api/environments" \
 
 ## Secrets
 
-`repositories[].secret_key` references a **Secret** stored under the environment. Secrets are AES-256-GCM encrypted at rest with the key from `SECRETS_KEY`. Add one:
+`repositories[].secret_key` references a **Secret** stored under the environment. Secrets are AES-256-GCM encrypted at rest with a per-tenant data encryption key derived from the server's `MASTER_SECRETS_KEY`. Add one:
 
 ```bash
 ENV_ID=...
-curl -s -X POST "$AOD_BASE_URL/api/environments/$ENV_ID/secrets" \
-  -H "Authorization: Bearer $AOD_TOKEN" -H "Content-Type: application/json" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/environments/$ENV_ID/secrets" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" -H "Content-Type: application/json" \
   -d '{"key":"GITHUB_TOKEN","value":"ghp_..."}'
 ```
 

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -1,13 +1,13 @@
-# Declarative manifest (`aod apply`)
+# Declarative manifest (`fountain apply`)
 
 For more than a handful of agents/environments, manage them as YAML and reconcile via the CLI.
 
 ## Format
 
-A `aod.yml` is a multi-document YAML file. Each doc is one resource with three top-level fields:
+A `fountain.yml` is a multi-document YAML file. Each doc is one resource with three top-level fields:
 
 ```yaml
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Environment | Vault | Agent
 metadata:
   name: <unique-on-operator-side>
@@ -19,13 +19,13 @@ The `metadata.name` is the upsert key. If a resource with that name exists, it's
 
 ## Order is irrelevant inside the file
 
-`aod apply` reconciles **environments first, vaults second, agents last** — so an agent doc can reference an environment by name (`spec.environment: my-env`) even if that environment is defined later in the file. Vaults aren't referenced from agents (they're picked per-conversation), so the order between envs and vaults doesn't matter functionally; the predictable ordering just makes the apply output easier to skim.
+`fountain apply` reconciles **environments first, vaults second, agents last** — so an agent doc can reference an environment by name (`spec.environment: my-env`) even if that environment is defined later in the file. Vaults aren't referenced from agents (they're picked per-conversation), so the order between envs and vaults doesn't matter functionally; the predictable ordering just makes the apply output easier to skim.
 
 ## Example
 
 ```yaml
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Environment
 metadata:
   name: my-project
@@ -35,7 +35,7 @@ spec:
   setup_script: cd /workspace && uv sync
 
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Vault
 metadata:
   name: alice
@@ -46,7 +46,7 @@ spec:
     NPM_TOKEN: npm_alice_...
 
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Agent
 metadata:
   name: researcher
@@ -65,12 +65,11 @@ spec:
 ## Apply
 
 ```bash
-./aod apply -f aod.yml          # single file
-./aod apply -f ./aod-specs/     # directory: walks **/*.{yml,yaml}
-./aod apply ./aod-specs/        # positional form, equivalent
+fountain apply -f fountain.yml          # single file
+fountain apply -f ./fountain-specs/     # directory: walks **/*.{yml,yaml}
 ```
 
-Directory mode walks recursively. Any YAML document carrying both `apiVersion` and `kind` is treated as a resource; anything else (a doc without front-matter, an unrelated `.yaml` config) is silently ignored. So `aod-specs/agents/*.yml`, `aod-specs/environments/*.yml`, plus an unrelated `.github/workflows/ci.yml` in the same tree all coexist cleanly. Files are processed in alphabetical order; if you want strict ordering for any reason, prefix names like `10-envs.yml` / `20-agents.yml` (though reconciliation order is fixed internally — envs first, then vaults, then agents — regardless).
+Directory mode walks recursively. Any YAML document carrying both `apiVersion` and `kind` is treated as a resource; anything else (a doc without front-matter, an unrelated `.yaml` config) is silently ignored. So `fountain-specs/agents/*.yml`, `fountain-specs/environments/*.yml`, plus an unrelated `.github/workflows/ci.yml` in the same tree all coexist cleanly. Files are processed in alphabetical order; if you want strict ordering for any reason, prefix names like `10-envs.yml` / `20-agents.yml` (though reconciliation order is fixed internally — envs first, then vaults, then agents — regardless).
 
 Output uses `+` for create, `~` for update, one line per resource:
 
@@ -86,22 +85,20 @@ Errors per-resource go to stderr but don't stop the run; other resources still a
 
 ## Idempotency
 
-Re-applying the same file is a no-op (every resource shows `~` because we always PUT, but the spec doesn't change). Useful for CI: keep `aod.yml` in source control, run `aod apply -f aod.yml` from your deploy pipeline.
+Re-applying the same file is a no-op (every resource shows `~` because we always PUT, but the spec doesn't change). Useful for CI: keep `fountain.yml` in source control, run `fountain apply -f fountain.yml` from your deploy pipeline.
 
-## Apply-time secret resolution (so you can commit `aod.yml`)
+## Apply-time secret resolution (so you can commit `fountain.yml`)
 
-Secret values in `spec.secrets` accept two kinds of references that get resolved at **apply time** before any DB write:
+Secret values in `spec.secrets` accept references that get resolved at **apply time** before any DB write:
 
 - `${VAR}` — substituted from your local environment, or from `--var KEY=VAL` flags.
 - `op://<vault>/<item>/<field>` — resolved via the [1Password CLI](https://developer.1password.com/docs/cli/get-started). Auth (biometric unlock, session) handled by `op`.
 - `bws://<secret-uuid>` — resolved via the [Bitwarden Secrets Manager CLI](https://bitwarden.com/help/secrets-manager-cli/). Auth via `BWS_ACCESS_TOKEN` (consumed by `bws`).
 - `infisical://<project?>/<env>/<path?>/<name>` — resolved via the [Infisical CLI](https://infisical.com/docs/cli/overview). Empty project segment (`infisical:///<env>/<name>`) falls through to `.infisical.json` / `INFISICAL_PROJECT_ID`. Last URI segment is always the secret name; segments between env and name form the folder path.
 
-Add another provider (Vault, AWS Secrets Manager, Doppler, ...) by implementing `AodCli.SecretResolver` and registering the module — ~30 lines per provider.
-
 ```yaml
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Environment
 metadata:
   name: my-project
@@ -114,7 +111,7 @@ spec:
     REDIS_URL: infisical:///prod/REDIS_URL                   # ← Infisical (workspace project)
     ANTHROPIC_API_KEY: op://${OP_VAULT}/Anthropic/key        # ← composes: ${VAR} first, then op
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Vault
 metadata:
   name: alice
@@ -127,10 +124,10 @@ Run with:
 
 ```bash
 GH_PAT=ghp_... POSTHOG=phc_... ALICE_GH_PAT=ghp_alice... \
-  ./aod apply -f aod.yml
+  fountain apply -f fountain.yml
 
 # or pass values inline:
-./aod apply -f aod.yml --var GH_PAT=ghp_... --var POSTHOG=phc_...
+fountain apply -f fountain.yml --var GH_PAT=ghp_... --var POSTHOG=phc_...
 ```
 
 Flags win over env vars when both are set. Use `$${VAR}` to write through a literal `${VAR}` (rare).

--- a/apps/fountain/priv/help/quickstart.md
+++ b/apps/fountain/priv/help/quickstart.md
@@ -1,12 +1,27 @@
 # Quickstart
 
-Five minutes to your first conversation. Assumes the server is running and you have an admin token.
+Five minutes to your first conversation. Assumes the server is running and you have a Fountain account.
 
-## 1. Set your token
+## 1. Install the CLI and log in
+
+Pre-built binaries are attached to each [GitHub release](https://github.com/BinaryBourbon/fountain/releases). One-shot install for macOS arm64:
 
 ```bash
-export AOD_TOKEN=...           # the admin token from your .env
-export AOD_BASE_URL=http://localhost:4000
+curl -L -o fountain https://github.com/BinaryBourbon/fountain/releases/latest/download/fountain-darwin-arm64
+chmod +x fountain && sudo mv fountain /usr/local/bin/
+```
+
+Then log in — this writes an API key to `~/.fountain/credentials`:
+
+```bash
+fountain auth login
+```
+
+For one-off scripting you can skip the credentials file and export the key directly:
+
+```bash
+export FOUNTAIN_API_KEY=...                        # an API key from `fountain keys create`
+export FOUNTAIN_BASE_URL=http://localhost:4000     # only if not pointing at fountain.inevitable.fyi
 ```
 
 ## 2. Create an environment
@@ -14,8 +29,8 @@ export AOD_BASE_URL=http://localhost:4000
 The simplest possible — no packages, no clones, default networking.
 
 ```bash
-curl -s -X POST "$AOD_BASE_URL/api/environments" \
-  -H "Authorization: Bearer $AOD_TOKEN" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/environments" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name":"plain"}'
 ```
@@ -23,8 +38,8 @@ curl -s -X POST "$AOD_BASE_URL/api/environments" \
 ## 3. Create an agent
 
 ```bash
-curl -s -X POST "$AOD_BASE_URL/api/agents" \
-  -H "Authorization: Bearer $AOD_TOKEN" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/agents" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "name":"hello",
@@ -37,12 +52,20 @@ The runtime decides which CLI gets executed inside the sprite. See **Runtimes** 
 
 ## 4. Start a conversation
 
+The CLI handles the create-and-stream flow in one shot:
+
 ```bash
-AGENT_ID=$(curl -s "$AOD_BASE_URL/api/agents" -H "Authorization: Bearer $AOD_TOKEN" \
+fountain run hello -p "Say hi."
+```
+
+If you'd rather drive the API yourself:
+
+```bash
+AGENT_ID=$(curl -s "$FOUNTAIN_BASE_URL/api/agents" -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
   | jq -r '.data[] | select(.name=="hello") | .id')
 
-curl -s -X POST "$AOD_BASE_URL/api/conversations" \
-  -H "Authorization: Bearer $AOD_TOKEN" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/conversations" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"agent_id\":\"$AGENT_ID\",\"prompt\":\"Say hi.\"}"
 ```
@@ -55,14 +78,14 @@ This provisions a fresh sprite, mounts the bundled skills, runs your `setup_scri
 CONV=...
 
 while :; do
-  s=$(curl -s "$AOD_BASE_URL/api/conversations/$CONV" \
-    -H "Authorization: Bearer $AOD_TOKEN" | jq -r .data.status)
+  s=$(curl -s "$FOUNTAIN_BASE_URL/api/conversations/$CONV" \
+    -H "Authorization: Bearer $FOUNTAIN_API_KEY" | jq -r .data.status)
   case "$s" in running|pending) sleep 2 ;; *) break ;; esac
 done
 
 curl -sN --max-time 5 \
-  "$AOD_BASE_URL/api/conversations/$CONV/stream?streams=stdout&wait=false" \
-  -H "Authorization: Bearer $AOD_TOKEN" \
+  "$FOUNTAIN_BASE_URL/api/conversations/$CONV/stream?streams=stdout&wait=false" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
 | awk '/^data: /{sub(/^data: /,""); print}' \
 | jq -r '.data | fromjson? | select(.type=="result") | .result' \
 | tail -n1
@@ -73,6 +96,6 @@ curl -sN --max-time 5 \
 ## What's next
 
 - **Vaults** — pick a bag of credential overrides at conversation creation (e.g. run as a different GitHub user).
-- **Manifest** — declare agents, environments, and vaults in YAML and `aod apply` them.
+- **Manifest** — declare agents, environments, and vaults in YAML and `fountain apply` them.
 - **Spawning sub-agents** — agents inside sprites can call back to spawn more agents.
 - **API reference** — full OpenAPI at [/api/docs](/api/docs).

--- a/apps/fountain/priv/help/runbook.md
+++ b/apps/fountain/priv/help/runbook.md
@@ -1,81 +1,84 @@
 # Operator runbook
 
-What to do when something's wrong with a running AoD instance. Single-tenant assumption throughout — if you're the operator, you're also the only user.
+What to do when something's wrong with a running Fountain instance.
 
 ## Emergency switches
 
-### Rotate the admin token
+### Revoke or rotate a user's API keys
+
+API keys are minted per-user and SHA-256-hashed at rest. Either revoke a single leaked key, or revoke them all and have the user re-issue.
 
 ```bash
-# Render dashboard → service env vars → ADMIN_TOKEN → set to new value → save
-# Render redeploys automatically. While the deploy is in flight, both
-# old and new instances are live; in-flight CLI/API sessions on the old
-# token will 401 on next request.
+# Single key
+fountain keys list                  # find the id
+fountain keys revoke <id>
+
+# Or via the API as the affected user
+curl -s -X DELETE "$FOUNTAIN_BASE_URL/api/auth/api-keys/<id>" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY"
 ```
 
-The CLI picks up the new token on next run via `AOD_TOKEN`. UI sessions use a cookie keyed off the old token — you'll need to log in again.
+CLI sessions pick up the change on next request (401 on the revoked key). UI sessions are cookie-backed and continue until logout/timeout.
 
-### Rotate `SECRETS_KEY`
+### Rotate `MASTER_SECRETS_KEY`
 
-`SECRETS_KEY` is the AES-256 key encrypting `secrets.value_ciphertext` at rest. **Rotating it without re-encrypting** breaks every existing secret (decryption fails silently — `decrypted_env/1` skips them).
+`MASTER_SECRETS_KEY` wraps each tenant's data encryption key (DEK), stored in `user_data_keys.wrapped_key`. The DEKs themselves never change on rotation — only the wrap does. **Updating the env var without re-wrapping** breaks every login (`load_tenant_key/1` returns `{:error, :unwrap_failed}` on every conversation start).
 
-Re-encryption procedure (manual, no Mix task yet):
+Re-wrapping procedure (manual — bin/server remote on the running node):
 
 ```elixir
-# iex -S mix phx.server (or `bin/agent_on_demand remote`)
-old_key = "<old SECRETS_KEY base64>" |> Base.url_decode64!(padding: false)
-new_key = "<new SECRETS_KEY base64>" |> Base.url_decode64!(padding: false)
+old_master = "<old MASTER_SECRETS_KEY base64>" |> Base.url_decode64!(padding: false)
+new_master = "<new MASTER_SECRETS_KEY base64>" |> Base.url_decode64!(padding: false)
 
-# Restore the old key, decrypt all secrets, hold them in memory
-Application.put_env(:agent_on_demand, :secrets_key, old_key)
+# Restore the old master, unwrap every tenant DEK in memory
+Application.put_env(:fountain, :master_secrets_key, old_master)
 
-plain =
-  AgentOnDemand.Repo.all(AgentOnDemand.Environments.Secret)
-  |> Enum.map(fn s ->
-    {:ok, v} = AgentOnDemand.Environments.Secret.decrypt(s)
-    {s.id, v}
+deks =
+  Fountain.Repo.all(Fountain.Accounts.UserDataKey)
+  |> Enum.map(fn udk ->
+    {:ok, dek} = Fountain.Crypto.load_tenant_key(udk.user_id)
+    {udk.id, dek}
   end)
 
-# Switch to the new key, re-encrypt + update
-Application.put_env(:agent_on_demand, :secrets_key, new_key)
+# Switch to the new master, re-wrap and persist
+Application.put_env(:fountain, :master_secrets_key, new_master)
 
-for {id, v} <- plain do
-  s = AgentOnDemand.Repo.get!(AgentOnDemand.Environments.Secret, id)
-  {:ok, _} = AgentOnDemand.Environments.upsert_secret(
-    %AgentOnDemand.Environments.Environment{id: s.environment_id},
-    %{"key" => s.key, "value" => v}
-  )
+for {id, dek} <- deks do
+  udk = Fountain.Repo.get!(Fountain.Accounts.UserDataKey, id)
+  udk
+  |> Ecto.Changeset.change(wrapped_key: Fountain.Crypto.wrap_dek(dek))
+  |> Fountain.Repo.update!()
 end
 ```
 
-Then update the `SECRETS_KEY` env var in your deploy and restart. Existing decrypted-in-memory secrets in running ConversationServers stay valid for the rest of those conversations.
+Then update the `MASTER_SECRETS_KEY` env var in your deploy and restart. DEKs already loaded into running ConversationServers stay valid for the rest of those conversations — they're held in GenServer state, not re-fetched per request.
 
 ## Stuck conversation
 
 Symptoms: conversation status shows `running` but no SSE events arrive.
 
 ```bash
-# 1. From the CLI:
-./aod conv show <conv-id>          # see turn status, sandbox name
-./aod conv interrupt <conv-id>     # stop the in-flight turn (sandbox lives)
-./aod conv terminate <conv-id>     # destroy the sprite + mark conv terminated
+fountain conv show <conv-id>          # see turn status, sandbox name
+fountain conv interrupt <conv-id>     # stop the in-flight turn (sandbox lives)
+fountain conv terminate <conv-id>     # destroy the sprite + mark conv terminated
 ```
 
-If `interrupt` returns `no_turn_running`, the GenServer thinks no turn is in flight — most likely the sprite-side process exited and we missed the `:exit` message. Send a fresh prompt; `auto-wake` will spin up a new sandbox keeping the conversation history (claude `--resume` via persisted `runtime_session_id`).
+If `interrupt` returns `no_turn_running`, the GenServer thinks no turn is in flight — most likely the sprite-side process exited and we missed the `:exit` message. Send a fresh prompt; `wake_conversation` will spin up a new sandbox, keeping the conversation history (claude `--resume` via persisted `runtime_session_id`).
 
 ## Orphaned sprites
 
-Symptoms: sprites.dev billing shows sprites we don't recognize. AoD's `sandboxes` table doesn't have a row for them.
+Symptoms: sprites.dev billing shows sprites we don't recognize. Fountain's `sandboxes` table doesn't have a row for them.
 
-This shouldn't happen after a clean stop — `Rehydrator` reattaches on boot. It can happen after a hard kill (BEAM crash) on a sandbox that hadn't reached `ready` yet (those don't get rehydrated):
+This shouldn't happen after a clean stop — `Fountain.Conversations.Rehydrator` reattaches on boot. It can happen after a hard kill (BEAM crash) on a sandbox that hadn't reached `ready` yet (those don't get rehydrated):
 
 ```bash
 # List all sprites in your account
 curl -sS https://api.sprites.dev/v1/sprites \
   -H "Authorization: Bearer $SPRITES_TOKEN" | jq -r '.[].name'
 
-# Cross-reference with your AoD sandbox table
-sqlite3 /data/agent_on_demand.db \
+# Cross-reference with your Fountain sandbox table (run on Render via the
+# Postgres dashboard, or psql against DATABASE_URL)
+psql "$DATABASE_URL" -c \
   "SELECT sprite_name FROM sandboxes WHERE status NOT IN ('terminated','failed')"
 
 # Anything in the first list not in the second is an orphan. Destroy:
@@ -91,50 +94,49 @@ The default bucket is 600 req/min per IP. If a script is hot-looping, the respon
 
 ```elixir
 # router.ex
-plug AgentOnDemandWeb.Plugs.RateLimit, bucket: "api", max: 1200
+plug FountainWeb.Plugs.RateLimit, bucket: "api", max: 1200
 ```
 
 To clear the counter manually (e.g., in dev):
 
 ```elixir
-# iex
-:ets.delete_all_objects(AgentOnDemandWeb.Plugs.RateLimit.table())
+# bin/server remote
+:ets.delete_all_objects(FountainWeb.Plugs.RateLimit.table())
 ```
 
 ## Audit log overgrows
 
-The `audit_events` table is append-only. SQLite won't compact on its own.
+The `audit_events` table is append-only.
 
 ```bash
 # How big?
-sqlite3 /data/agent_on_demand.db "SELECT count(*) FROM audit_events"
+psql "$DATABASE_URL" -c "SELECT count(*) FROM audit_events"
 
 # Trim to last 30 days
-sqlite3 /data/agent_on_demand.db \
-  "DELETE FROM audit_events WHERE inserted_at < datetime('now', '-30 days')"
+psql "$DATABASE_URL" -c \
+  "DELETE FROM audit_events WHERE inserted_at < NOW() - INTERVAL '30 days'"
 
-# Reclaim space
-sqlite3 /data/agent_on_demand.db "VACUUM"
+# Reclaim space (Postgres handles this with autovacuum normally; force if needed)
+psql "$DATABASE_URL" -c "VACUUM ANALYZE audit_events"
 ```
 
-## SQLite backup + restore
+## Postgres backup + restore
+
+On Render, daily backups are managed by the Postgres add-on dashboard — there's nothing to wire up. Manual snapshots:
 
 ```bash
-# Backup (consistent — uses SQLite's backup API)
-sqlite3 /data/agent_on_demand.db ".backup /data/agent_on_demand.bak"
+# Backup
+pg_dump "$DATABASE_URL" > fountain.sql
 
-# Restore (with the app stopped)
-cp /data/agent_on_demand.bak /data/agent_on_demand.db
-# Restart the service
+# Restore (with the app stopped, against a fresh database)
+psql "$NEW_DATABASE_URL" < fountain.sql
 ```
-
-For Render specifically: the disk at `/data` survives redeploys, so daily backups via a cron job is the simplest durability story.
 
 ## BEAM crash recovery
 
 Symptoms: server is up but conversations show as `running`/`idle` from before the crash.
 
-`Rehydrator` runs on every successful boot (see `application.ex` after `Supervisor.start_link`). It scans conversations whose status is non-terminal AND whose sandbox status was `ready` at the time of the stop, and starts a `ConversationServer` for each. The server enters reattach mode:
+`Fountain.Conversations.Rehydrator` runs on every successful boot (see `apps/fountain/lib/fountain/application.ex` after `Supervisor.start_link`). It scans conversations whose status is non-terminal AND whose sandbox status was `ready` at the time of the stop, and starts a `ConversationServer` for each. The server enters reattach mode:
 
 - If the sprite is still alive at sprites.dev → attach via `Sprites.list_sessions` + `attach_session`. Any in-flight detachable runtime command keeps streaming where it left off.
 - If the sprite is gone → mark sandbox `failed`. The user's next prompt triggers `wake_conversation` to spin a fresh sandbox.
@@ -145,7 +147,7 @@ Conversations whose sandbox was `pending` or `starting` at the crash (mid-provis
 
 Symptoms: API call returns `422` with `{"errors":[{"message":"Missing field: <name>"}]}` for what looks like a valid payload.
 
-Our request schemas are reused for POST and PUT today, so PUT requires the full Create shape. This is tracked under task #45. Workaround: include all the required fields on PUT, or use the LiveView UI which talks to the context functions directly (no OpenAPI gate).
+Our request schemas are reused for POST and PUT today, so PUT requires the full Create shape. Workaround: include all the required fields on PUT, or use the LiveView UI which talks to the context functions directly (no OpenAPI gate).
 
 ## "I just deployed and the rate limiter keeps blocking me"
 
@@ -153,4 +155,4 @@ ETS table state survives redeploys-without-restart on Render's infrastructure bu
 
 ## Adding a new node (clustering)
 
-Not yet supported. `Registry`, `DynamicSupervisor`, and `Phoenix.PubSub` are local. Tracking under task #37 (libcluster + Horde).
+`libcluster` with the `Cluster.Strategy.DNSPoll` topology is wired up via `CLUSTER_DNS_QUERY` (see `config/runtime.exs`). On Render, set it to the internal DNS name of the service for multi-instance deployments. `Registry`, `DynamicSupervisor`, and `Phoenix.PubSub` are still local — cross-node ConversationServer routing isn't implemented yet.

--- a/apps/fountain/priv/help/secrets-managers.md
+++ b/apps/fountain/priv/help/secrets-managers.md
@@ -1,8 +1,8 @@
 # Secrets managers
 
-`aod apply` resolves secret values at apply time — before writing anything to the database — so you can commit `aod.yml` without embedding credentials.
+`fountain apply` resolves secret values at apply time — before writing anything to the database — so you can commit `fountain.yml` without embedding credentials.
 
-Any value under `spec.secrets` can be a URI reference. The resolver for each scheme runs on the operator's machine using its own CLI and credentials. AoD never sees your vault password or access token.
+Any value under `spec.secrets` can be a URI reference. The resolver for each scheme runs on the operator's machine using its own CLI and credentials. Fountain never sees your vault password or access token.
 
 ## URI schemes
 
@@ -28,7 +28,7 @@ Use `$${VAR}` to write a literal `${VAR}` (escapes the substitution).
 
 ```yaml
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Environment
 metadata:
   name: my-project
@@ -40,7 +40,7 @@ spec:
     DATABASE_URL: infisical://abc123/prod/api/DATABASE_URL  # Infisical (explicit project)
     REDIS_URL: infisical:///prod/REDIS_URL                  # Infisical (workspace project)
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Vault
 metadata:
   name: alice
@@ -52,8 +52,8 @@ spec:
 Run:
 
 ```bash
-GH_PAT=ghp_... ./aod apply -f aod.yml
-# or: ./aod apply -f aod.yml --var GH_PAT=ghp_...
+GH_PAT=ghp_... ./fountain apply -f fountain.yml
+# or: ./fountain apply -f fountain.yml --var GH_PAT=ghp_...
 ```
 
 ## Failure output

--- a/apps/fountain/priv/help/secrets/1password.md
+++ b/apps/fountain/priv/help/secrets/1password.md
@@ -1,6 +1,6 @@
 # 1Password (`op://`)
 
-Use the 1Password CLI to resolve secret references at `aod apply` time. AoD calls `op read` on your machine — it never sees your 1Password credentials or master password.
+Use the 1Password CLI to resolve secret references at `fountain apply` time. Fountain calls `op read` on your machine — it never sees your 1Password credentials or master password.
 
 ## Prerequisites
 
@@ -18,9 +18,9 @@ unzip -o op.zip && sudo mv op /usr/local/bin/
 
 ## Auth
 
-`op` manages its own authentication. AoD doesn't see your password, session token, or service account key.
+`op` manages its own authentication. Fountain doesn't see your password, session token, or service account key.
 
-**Interactive (local dev):** Sign in with biometric or password once before running `aod apply`:
+**Interactive (local dev):** Sign in with biometric or password once before running `fountain apply`:
 
 ```bash
 op signin
@@ -38,7 +38,7 @@ Run `op signin` again and re-apply.
 
 ```bash
 export OP_SERVICE_ACCOUNT_TOKEN=ops_...
-./aod apply -f aod.yml
+fountain apply -f fountain.yml
 ```
 
 ## URI format
@@ -65,7 +65,7 @@ op item get PostHog --vault Work      # show item fields
 
 ```yaml
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Environment
 metadata:
   name: ravi-hq
@@ -78,7 +78,7 @@ spec:
     GITHUB_TOKEN: op://Work/GitHub/token
 
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Vault
 metadata:
   name: alice
@@ -93,7 +93,7 @@ Apply:
 
 ```bash
 op signin    # once per session
-./aod apply -f aod.yml
+fountain apply -f fountain.yml
 ```
 
 Output:
@@ -118,7 +118,7 @@ secrets:
 ```
 
 ```bash
-OP_VAULT=Work ./aod apply -f aod.yml
+OP_VAULT=Work fountain apply -f fountain.yml
 ```
 
 ## Troubleshooting

--- a/apps/fountain/priv/help/secrets/bws.md
+++ b/apps/fountain/priv/help/secrets/bws.md
@@ -1,6 +1,6 @@
 # Bitwarden Secrets Manager (`bws://`)
 
-Use the Bitwarden Secrets Manager CLI to resolve `bws://<uuid>` references at `aod apply` time. AoD calls `bws secret get` on your machine — it never sees your Bitwarden master password.
+Use the Bitwarden Secrets Manager CLI to resolve `bws://<uuid>` references at `fountain apply` time. Fountain calls `bws secret get` on your machine — it never sees your Bitwarden master password.
 
 > **Note:** This is the **Secrets Manager** CLI (`bws`), not the personal vault CLI (`bw`). Secrets Manager is designed for IaC / CI flows and uses access tokens + UUID addressing.
 
@@ -20,7 +20,7 @@ brew install bitwarden/brew/bws
 
 ## Auth
 
-`bws` authenticates with a machine access token. AoD reads `BWS_ACCESS_TOKEN` from your environment and passes it to `bws` — it's never written to the database.
+`bws` authenticates with a machine access token. Fountain reads `BWS_ACCESS_TOKEN` from your environment and passes it to `bws` — it's never written to the database.
 
 **Generate a token in the Bitwarden dashboard:**
 
@@ -29,17 +29,17 @@ brew install bitwarden/brew/bws
 3. Grant it read access to the secrets you need.
 4. Copy the access token — it's only shown once.
 
-**Set it before running `aod apply`:**
+**Set it before running `fountain apply`:**
 
 ```bash
 export BWS_ACCESS_TOKEN=0.your-token-here...
-./aod apply -f aod.yml
+fountain apply -f fountain.yml
 ```
 
 Or inline:
 
 ```bash
-BWS_ACCESS_TOKEN=0.your-token-here... ./aod apply -f aod.yml
+BWS_ACCESS_TOKEN=0.your-token-here... fountain apply -f fountain.yml
 ```
 
 ## URI format
@@ -75,7 +75,7 @@ Use the `id` field as the UUID in your manifest.
 
 ```yaml
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Environment
 metadata:
   name: ravi-hq
@@ -88,7 +88,7 @@ spec:
     NPM_TOKEN: bws://33333333-3333-3333-3333-333333333333
 
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Vault
 metadata:
   name: alice
@@ -101,7 +101,7 @@ spec:
 Apply:
 
 ```bash
-BWS_ACCESS_TOKEN=0.your-token... ./aod apply -f aod.yml
+BWS_ACCESS_TOKEN=0.your-token... fountain apply -f fountain.yml
 ```
 
 Output:

--- a/apps/fountain/priv/help/secrets/infisical.md
+++ b/apps/fountain/priv/help/secrets/infisical.md
@@ -1,6 +1,6 @@
 # Infisical (`infisical://`)
 
-Use the Infisical CLI to resolve `infisical://` references at `aod apply` time. AoD calls `infisical secrets get` on your machine — it never sees your Infisical credentials.
+Use the Infisical CLI to resolve `infisical://` references at `fountain apply` time. Fountain calls `infisical secrets get` on your machine — it never sees your Infisical credentials.
 
 ## Prerequisites
 
@@ -29,15 +29,15 @@ infisical login                        # opens browser or prompts credentials
 infisical init                         # creates .infisical.json with your project ID
 ```
 
-After `infisical init`, references using the empty-project form (`infisical:///<env>/<name>`) pick up the project automatically from `.infisical.json`. Run `aod apply` from the same directory.
+After `infisical init`, references using the empty-project form (`infisical:///<env>/<name>`) pick up the project automatically from `.infisical.json`. Run `fountain apply` from the same directory.
 
 ### Token-based (CI / headless)
 
-Generate a service token or machine identity token in the Infisical dashboard, then set it before running `aod apply`:
+Generate a service token or machine identity token in the Infisical dashboard, then set it before running `fountain apply`:
 
 ```bash
 export INFISICAL_TOKEN=st.your-token-here...
-./aod apply -f aod.yml
+fountain apply -f fountain.yml
 ```
 
 Service tokens are scoped to a project + environment, so the project can be omitted from the URI. Machine identity tokens are project-agnostic — include the project ID in the URI.
@@ -74,7 +74,7 @@ infisical projects list
 
 ```yaml
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Environment
 metadata:
   name: ravi-hq
@@ -91,7 +91,7 @@ spec:
     NPM_TOKEN: infisical:///prod/npm/NPM_TOKEN
 
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Vault
 metadata:
   name: alice
@@ -104,14 +104,14 @@ spec:
 
 ```bash
 infisical login
-infisical init    # run once in the directory where you'll run aod apply
-./aod apply -f aod.yml
+infisical init    # run once in the directory where you'll run fountain apply
+fountain apply -f fountain.yml
 ```
 
 ### CI (token auth)
 
 ```bash
-INFISICAL_TOKEN=st.your-token... ./aod apply -f aod.yml
+INFISICAL_TOKEN=st.your-token... fountain apply -f fountain.yml
 ```
 
 Output:

--- a/apps/fountain/priv/help/spawning.md
+++ b/apps/fountain/priv/help/spawning.md
@@ -2,10 +2,12 @@
 
 Every conversation gets two env vars in its sprite:
 
-- `AOD_BASE_URL` — your AoD's public URL (e.g. `https://aod.example.com`)
-- `AOD_TOKEN` — the same admin token you'd use as an operator
+- `AOD_BASE_URL` — your Fountain server's public URL (e.g. `https://fountain.inevitable.fyi`)
+- `AOD_TOKEN` — an API key the conversation can use to call back
 
 Plus the bundled **`aod` skill** mounted under `~/.claude/skills/aod/` (or the runtime equivalent). With those three pieces, any agent inside a sprite can call back to the API and spawn more conversations.
+
+> The env-var names (`AOD_*`) and the bundled skill name are leftovers from the project's previous name. They're stable contracts the bundled skill keys off of — renaming them would break every sprite-internal script. Treat them as opaque identifiers that mean "the Fountain callback URL/key".
 
 ## Patterns the agent will use
 
@@ -74,7 +76,7 @@ The SSE endpoint normally holds open for ~60s waiting for new events. When the c
 
 ## Security model — what to know
 
-The sprite-side `AOD_TOKEN` is the **same** admin token operators use. Anything inside a sprite can do anything an operator can — create/delete other agents, list other conversations, etc. There's no scoping today. Treat prompt-injection on a sprite-bound agent as a full privilege escalation. Per-conversation scoped tokens are on the roadmap.
+The sprite-side `AOD_TOKEN` is a regular Fountain API key — it carries the same blast radius the owning user has. Anything inside a sprite can create/delete agents, list conversations, etc. on behalf of that user. There's no per-conversation scoping today. Treat prompt-injection on a sprite-bound agent as a full account takeover for that user. Per-conversation scoped tokens are on the roadmap.
 
 ## Tunneling
 

--- a/apps/fountain/priv/help/vaults.md
+++ b/apps/fountain/priv/help/vaults.md
@@ -13,15 +13,15 @@ Vaults are not bound to a user, team, or environment — they're loose bags. v1 
 ## Create one
 
 ```bash
-curl -s -X POST "$AOD_BASE_URL/api/vaults" \
-  -H "Authorization: Bearer $AOD_TOKEN" -H "Content-Type: application/json" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/vaults" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" -H "Content-Type: application/json" \
   -d '{"name":"alice","description":"Alice'"'"'s GitHub + npm credentials"}'
 ```
 
 Or via CLI:
 
 ```bash
-aod vault create alice --description "Alice's GitHub + npm credentials"
+fountain vault create alice --description "Alice's GitHub + npm credentials"
 ```
 
 ## Add secrets
@@ -29,29 +29,29 @@ aod vault create alice --description "Alice's GitHub + npm credentials"
 Vault secrets are AES-256-GCM encrypted at rest. Values are write-only — the API never returns them.
 
 ```bash
-aod vault set-secret alice GITHUB_TOKEN ghp_alice_...
-aod vault set-secret alice NPM_TOKEN    npm_alice_...
+fountain vault set-secret alice GITHUB_TOKEN ghp_alice_...
+fountain vault set-secret alice NPM_TOKEN    npm_alice_...
 ```
 
 Equivalently:
 
 ```bash
-curl -s -X POST "$AOD_BASE_URL/api/vaults/<vault_id>/secrets" \
-  -H "Authorization: Bearer $AOD_TOKEN" -H "Content-Type: application/json" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/vaults/<vault_id>/secrets" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" -H "Content-Type: application/json" \
   -d '{"key":"GITHUB_TOKEN","value":"ghp_alice_..."}'
 ```
 
 ## Use one when starting a conversation
 
 ```bash
-aod run AODDocsWriter -p "Open a docs PR." --vault alice
+fountain run docs-writer -p "Open a docs PR." --vault alice
 ```
 
 Or via the API:
 
 ```bash
-curl -s -X POST "$AOD_BASE_URL/api/conversations" \
-  -H "Authorization: Bearer $AOD_TOKEN" -H "Content-Type: application/json" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/conversations" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" -H "Content-Type: application/json" \
   -d '{"agent_id":"<id>","vault_id":"<vault_id>","prompt":"..."}'
 ```
 
@@ -74,11 +74,11 @@ Repository clones that reference `secret_key: GITHUB_TOKEN` see the vault's valu
 
 ## Manifest
 
-Vaults are first-class in `aod apply`:
+Vaults are first-class in `fountain apply`:
 
 ```yaml
 ---
-apiVersion: aod/v1
+apiVersion: fountain/v1
 kind: Vault
 metadata:
   name: alice
@@ -89,4 +89,4 @@ spec:
     NPM_TOKEN: npm_alice_...
 ```
 
-Inline secrets here are convenient for boostrapping but mean the manifest holds plaintext — keep `aod.yml` out of version control or use a per-environment overlay.
+Inline secrets here are convenient for bootstrapping but mean the manifest holds plaintext — keep `fountain.yml` out of version control or use a per-environment overlay.


### PR DESCRIPTION
## Summary

The `/help` content hosted at https://fountain.inevitable.fyi/help was largely written for the AoD-era `./aod` CLI and `ADMIN_TOKEN` single-tenant auth model. This brings it in line with what actually ships today.

- **CLI examples** use `fountain` (not `aod`) and `FOUNTAIN_API_KEY` / `FOUNTAIN_BASE_URL` (not `AOD_TOKEN` / `AOD_BASE_URL`).
- **Manifest examples** use `apiVersion: fountain/v1` and `fountain.yml`.
- **Quickstart** leads with `fountain auth login` instead of asking the reader to export an admin token.
- **Runbook** rewritten for Postgres (was SQLite), per-user API keys (was `ADMIN_TOKEN`), and `MASTER_SECRETS_KEY` envelope encryption with per-tenant DEKs in `user_data_keys` (was a single `SECRETS_KEY` symmetric key). Module names and bin paths updated to current reality.

The **spawning** page intentionally keeps `AOD_BASE_URL` / `AOD_TOKEN` and the bundled `aod` skill name — those are the live wire-format contracts the bundled skill keys off of (see `apps/fountain/lib/fountain/conversations/conversation_server.ex:790` and `apps/fountain/priv/sprite_skills/aod/`). Annotated with a callout so readers don't think it's just stale text.

## Test plan

- [ ] `mix phx.server`, visit `/help`, click each topic in the sidebar — markdown renders without errors
- [ ] `/help/quickstart` reads end-to-end with the current `fountain` CLI installed
- [ ] `/help/manifest` example pasted into a `fountain.yml` and `fountain apply -f fountain.yml` succeeds
- [ ] `/help/runbook` runbook commands resolve against the current modules (e.g. `Fountain.Accounts.UserDataKey`, `FountainWeb.Plugs.RateLimit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)