### PR TITLE
fix(security): scope audit_events to current_user

### DIFF
--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -1,11 +1,10 @@
 defmodule Fountain.Audit do
   @moduledoc """
-  Append-only audit log for admin actions.
+  Append-only audit log for state-changing actions.
 
-  Single-tenant, so this is more of a "what just happened" feed than an
-  authorization trail. Useful when something gets deleted unexpectedly,
-  or when you want to know which surface (api/ui/cli) triggered a
-  conversation.
+  Each event is attributed to a tenant via `user_id`. Pre-tenancy rows
+  and system-originated events have `user_id = nil` and are only
+  surfaced through admin views.
 
   Logging is best-effort: a log failure must never break the operation
   it's recording. Use `record!/1` only when you can tolerate raising;
@@ -23,7 +22,8 @@ defmodule Fountain.Audit do
           optional(:resource_id) => String.t() | nil,
           optional(:actor) => String.t() | nil,
           optional(:request_ip) => String.t() | nil,
-          optional(:metadata) => map()
+          optional(:metadata) => map(),
+          optional(:user_id) => Ecto.UUID.t() | nil
         }
 
   @spec record(attrs()) :: {:ok, Event.t()} | {:error, term()}
@@ -51,16 +51,44 @@ defmodule Fountain.Audit do
     event
   end
 
-  @doc "List the most recent N events, newest first."
-  def list_recent(limit \\ 200) do
+  @doc """
+  List the most recent N events for one tenant, newest first.
+
+  System events (`user_id = nil`) are excluded — those belong to admin
+  views via `_unsafe_list_recent/1`.
+  """
+  @spec list_recent_for_user(Ecto.UUID.t(), pos_integer()) :: [Event.t()]
+  def list_recent_for_user(user_id, limit \\ 200) when is_binary(user_id) do
+    Repo.all(
+      from e in Event,
+        where: e.user_id == ^user_id,
+        order_by: [desc: e.inserted_at, desc: e.id],
+        limit: ^limit
+    )
+  end
+
+  @doc """
+  Unscoped: every event in the system, regardless of tenant.
+
+  Reserved for admin/system surfaces. Anything user-facing must use
+  `list_recent_for_user/2` instead.
+  """
+  @spec _unsafe_list_recent(pos_integer()) :: [Event.t()]
+  def _unsafe_list_recent(limit \\ 200) do
     Repo.all(from e in Event, order_by: [desc: e.inserted_at, desc: e.id], limit: ^limit)
   end
 
-  @doc "List events for one resource."
-  def list_for(resource_type, resource_id, limit \\ 50) do
+  @doc """
+  List events for one resource, scoped to a tenant.
+  """
+  @spec list_for(String.t(), String.t(), Ecto.UUID.t(), pos_integer()) :: [Event.t()]
+  def list_for(resource_type, resource_id, user_id, limit \\ 50)
+      when is_binary(user_id) do
     Repo.all(
       from e in Event,
-        where: e.resource_type == ^resource_type and e.resource_id == ^resource_id,
+        where:
+          e.resource_type == ^resource_type and e.resource_id == ^resource_id and
+            e.user_id == ^user_id,
         order_by: [desc: e.inserted_at, desc: e.id],
         limit: ^limit
     )

--- a/apps/fountain/lib/fountain/audit/event.ex
+++ b/apps/fountain/lib/fountain/audit/event.ex
@@ -2,12 +2,17 @@ defmodule Fountain.Audit.Event do
   @moduledoc """
   An audit log entry. Append-only — there is no update / delete path.
 
-  Single-tenant, so `actor` is just a label (`"api"`, `"ui"`,
-  `"cli"`, `"system"`) rather than a user reference. `metadata` is a
-  free-form bag.
+  `user_id` attributes the event to a tenant; nullable for system events
+  and pre-tenancy backfill rows. `actor` is a coarse surface label
+  (`"api"`, `"ui"`, `"cli"`, `"system"`) kept for grouping. `metadata`
+  is a free-form bag.
   """
   use Ecto.Schema
   import Ecto.Changeset
+
+  alias Fountain.Accounts.User
+
+  @foreign_key_type :binary_id
 
   schema "audit_events" do
     field :action, :string
@@ -17,6 +22,7 @@ defmodule Fountain.Audit.Event do
     field :request_ip, :string
     field :metadata, :map, default: %{}
     field :inserted_at, :utc_datetime
+    belongs_to :user, User
   end
 
   def changeset(event, attrs) do
@@ -28,7 +34,8 @@ defmodule Fountain.Audit.Event do
       :actor,
       :request_ip,
       :metadata,
-      :inserted_at
+      :inserted_at,
+      :user_id
     ])
     |> validate_required([:action, :resource_type, :inserted_at])
   end

--- a/apps/fountain/lib/fountain_web/live/audit_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/audit_live/index.ex
@@ -24,11 +24,8 @@ defmodule FountainWeb.AuditLive.Index do
     {:noreply, assign(socket, :events, events)}
   end
 
-  # Admins see all recent events; regular users see the last 200 events
-  # scoped to resource IDs they own. Full per-tenant scoping of audit events
-  # requires adding user_id to the audit_events table (planned for a future sprint).
-  defp load_events(%{role: "admin"}), do: Audit.list_recent(200)
-  defp load_events(_user), do: Audit.list_recent(200)
+  defp load_events(%{role: "admin"}), do: Audit._unsafe_list_recent(200)
+  defp load_events(%{id: id}), do: Audit.list_recent_for_user(id, 200)
 
   @impl true
   def render(assigns) do

--- a/apps/fountain/lib/fountain_web/plugs/audit.ex
+++ b/apps/fountain/lib/fountain_web/plugs/audit.ex
@@ -46,10 +46,18 @@ defmodule FountainWeb.Plugs.Audit do
       resource_id: resource_id,
       actor: "api",
       request_ip: format_ip(conn.remote_ip),
-      metadata: %{"status" => conn.status}
+      metadata: %{"status" => conn.status},
+      user_id: current_user_id(conn)
     })
 
     conn
+  end
+
+  defp current_user_id(conn) do
+    case conn.assigns[:current_user] do
+      %{id: id} -> id
+      _ -> nil
+    end
   end
 
   defp derive_resource(conn) do

--- a/apps/fountain/priv/repo/migrations/20260511000001_add_user_id_to_audit_events.exs
+++ b/apps/fountain/priv/repo/migrations/20260511000001_add_user_id_to_audit_events.exs
@@ -1,0 +1,14 @@
+defmodule Fountain.Repo.Migrations.AddUserIdToAuditEvents do
+  use Ecto.Migration
+
+  def change do
+    # nilify_all — audit events outlive the user they're attributed to.
+    # Existing rows (written before per-tenant audit scoping landed) get
+    # NULL and are only visible to admins.
+    alter table(:audit_events) do
+      add :user_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+    end
+
+    create index(:audit_events, [:user_id, :inserted_at])
+  end
+end

--- a/apps/fountain/test/fountain_web/live/audit_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/audit_live_test.exs
@@ -1,0 +1,106 @@
+defmodule FountainWeb.AuditLiveTest do
+  @moduledoc """
+  Regression tests for per-tenant scoping on /audit. Pre-fix, every
+  authenticated user saw every event in the system.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Audit
+
+  describe "AuditLive.Index — tenant scoping" do
+    test "regular user only sees their own events", %{conn: conn} do
+      user_a = insert_verified_user()
+      user_b = insert_verified_user()
+
+      # The template renders String.slice(resource_id, 0, 8). Distinct
+      # 8-char prefixes keep the assertion sharp.
+      Audit.record!(%{
+        action: "POST /api/agents",
+        resource_type: "agent",
+        resource_id: "aaaaaaaa-belongs-to-a",
+        actor: "api",
+        user_id: user_a.id,
+        metadata: %{"status" => 201}
+      })
+
+      Audit.record!(%{
+        action: "POST /api/agents",
+        resource_type: "agent",
+        resource_id: "bbbbbbbb-belongs-to-b",
+        actor: "api",
+        user_id: user_b.id,
+        metadata: %{"status" => 201}
+      })
+
+      conn = login_user(conn, user_b)
+      {:ok, _lv, html} = live(conn, ~p"/audit")
+
+      assert html =~ "bbbbbbbb"
+      refute html =~ "aaaaaaaa"
+    end
+
+    test "regular user does not see system events (user_id nil)", %{conn: conn} do
+      user = insert_verified_user()
+
+      Audit.record!(%{
+        action: "POST /api/agents",
+        resource_type: "agent",
+        resource_id: "system-event",
+        actor: "system",
+        user_id: nil,
+        metadata: %{"status" => 200}
+      })
+
+      conn = login_user(conn, user)
+      {:ok, _lv, html} = live(conn, ~p"/audit")
+
+      refute html =~ "system-e"
+    end
+
+    test "admin sees every tenant's events", %{conn: conn} do
+      admin = insert_verified_user(%{"role" => "admin"})
+      other = insert_verified_user()
+
+      Audit.record!(%{
+        action: "POST /api/agents",
+        resource_type: "agent",
+        resource_id: "other-tenant",
+        actor: "api",
+        user_id: other.id,
+        metadata: %{"status" => 201}
+      })
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/audit")
+
+      assert html =~ "other-te"
+    end
+
+    test "unauthenticated user redirected to login", %{conn: conn} do
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/audit")
+      assert path =~ "/auth/login"
+    end
+  end
+
+  describe "Plugs.Audit — user_id capture" do
+    test "API requests record the authenticated user's id", %{conn: conn} do
+      user = insert_verified_user()
+      {_, key} = insert_api_key(user)
+
+      conn
+      |> authed_with_key(key)
+      |> post("/api/agents", %{
+        "name" => "audit-capture-#{System.unique_integer([:positive])}",
+        "runtime" => "claude",
+        "model" => "anthropic/claude-sonnet-4-6"
+      })
+
+      events = Audit.list_recent_for_user(user.id, 10)
+      assert length(events) >= 1
+      assert Enum.all?(events, &(&1.user_id == user.id))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`/audit` was leaking events across tenants — every authenticated user saw every event in the system, regardless of role. Three layers were user-blind:

1. **Schema** — `audit_events` had no `user_id` column.
2. **Writer** — `FountainWeb.Plugs.Audit` recorded `actor: \"api\"` with no user attribution.
3. **Reader** — `Fountain.Audit.list_recent/1` had no tenant filter, and the LiveView's two-clause `load_events/1` called the same unscoped function from both branches. The inline comment admitted it: *\"planned for a future sprint\"*.

This PR finishes the work, following the `_unsafe_*` convention from #49–#54.

### Changes

- **Migration** (`20260511000001_add_user_id_to_audit_events.exs`) adds nullable `user_id` (binary_id, `on_delete: :nilify_all`) plus a `(user_id, inserted_at)` index. Existing rows get NULL → visible to admins only.
- **`Fountain.Audit.Event`** schema picks up `belongs_to :user`; `@foreign_key_type :binary_id` because the table's primary key is the default integer.
- **`Fountain.Audit`** splits into `list_recent_for_user/2` (tenant-scoped — default user path) and `_unsafe_list_recent/1` (admin / system).
- **`FountainWeb.Plugs.Audit`** reads `conn.assigns.current_user.id` (set by `TenantAPIAuth`, which runs first in the `:api` pipeline) and threads it through `Audit.record/1`.
- **`FountainWeb.AuditLive.Index`** dispatches: admins → `_unsafe_list_recent`, regular users → `list_recent_for_user(user.id, 200)`.

### Backfill

Pre-fix rows have `user_id = NULL` and won't surface in non-admin views. We don't know whose actions they were and shouldn't guess. If a forensic need comes up, admins can see them.

## Test plan

- [x] `mix test apps/fountain/test/fountain_web/live/audit_live_test.exs` — 5 new regressions pass
- [x] `mix test apps/fountain/test/fountain_web/cross_tenant_isolation_test.exs` — sibling suite still green
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format` — applied
- [ ] Manual: sign in as user A, perform a write, sign in as user B → user B sees only their events at `/audit`. Sign in as admin → sees both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)