### PR TITLE
refactor(sprites): name sandboxes fountain-<tenant>-<id>

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -434,7 +434,7 @@ defmodule Fountain.Conversations do
   ## Required attrs
     - `agent_id`              — agent to run
     - `prompt`                — optional first prompt (sends turn 1 immediately)
-    - `sprite_name`           — optional override; defaults to "aod-conv-<short-id>"
+    - `sprite_name`           — optional override; defaults to "fountain-<short-user-id>-<short-id>"
     - `vault_id`              — optional vault whose secrets override the env's
     - `source`                — optional; one of "ui", "api", "agent" (default "api")
     - `parent_conversation_id` — optional; UUID of the conversation that spawned this one
@@ -447,7 +447,7 @@ defmodule Fountain.Conversations do
          {:ok, sandbox} <-
            create_sandbox(%{
              environment_id: agent.environment_id,
-             sprite_name: attrs["sprite_name"] || "aod-conv-#{short_id()}",
+             sprite_name: attrs["sprite_name"] || "fountain-#{tenant_prefix(user_id)}-#{short_id()}",
              status: "pending",
              user_id: user_id
            }),
@@ -522,6 +522,8 @@ defmodule Fountain.Conversations do
   defp first_turn_query, do: from(t in Turn, where: t.turn_number == 1)
 
   defp short_id, do: Ecto.UUID.generate() |> binary_part(0, 8)
+
+  defp tenant_prefix(user_id) when is_binary(user_id), do: binary_part(user_id, 0, 8)
 
   defp resolve_vault_id(nil, _user_id), do: {:ok, nil}
   defp resolve_vault_id("", _user_id), do: {:ok, nil}
@@ -609,7 +611,7 @@ defmodule Fountain.Conversations do
     with {:ok, new_sandbox} <-
            create_sandbox(%{
              environment_id: agent.environment_id,
-             sprite_name: "aod-conv-#{short_id()}",
+             sprite_name: "fountain-#{tenant_prefix(conv.user_id)}-#{short_id()}",
              status: "pending",
              user_id: conv.user_id
            }),

--- a/decisions/0005-platform-shared-sprites-token.md
+++ b/decisions/0005-platform-shared-sprites-token.md
@@ -14,7 +14,7 @@ Fountain holds a single **platform-level `SPRITES_TOKEN`** that is used to provi
 
 - `SPRITES_TOKEN` is an env-var-only secret on Render. It is never stored in the DB, never surfaced in the admin UI, and never visible to tenants.
 - Each `ConversationServer` reads it from `Application.fetch_env!(:fountain, :sprites_token)` at provisioning time.
-- Sprites sandbox naming: `fountain-conv-<short-id>` (replacing `aod-conv-<short-id>` from aod-ex).
+- Sprites sandbox naming: `fountain-<tenant-prefix>-<short-id>` (replacing `aod-conv-<short-id>` from aod-ex). `<tenant-prefix>` is the first 8 chars of the owning user's UUID; `<short-id>` is the first 8 chars of a fresh UUID.
 - **Per-tenant concurrency cap** (`users.max_concurrent_sandboxes`, default `5`) is the primary noisy-neighbor mitigation. The cap is enforced in `Fountain.Quotas.check_sandbox_quota!/1` before `Sprites.create/2` is called.
 - The cap is admin-adjustable per user (raise for trusted tenants, lower during abuse).
 - Fountain pays the Sprites bill and prices its own tiers to recover the cost.

--- a/plan/phase-2-build-plan/engineering-plan.md
+++ b/plan/phase-2-build-plan/engineering-plan.md
@@ -365,7 +365,7 @@ The cap is the primary defense against a single tenant exhausting Sprites accoun
 - Document a token rotation runbook; rotation is a Render env-var update + restart.
 - Engage Sprites to raise account-level rate limits proactively as WAU grows.
 
-The `aod-conv-<short-id>` sprite naming prefix from aod-ex becomes `fountain-conv-<short-id>` to distinguish from any legacy aod-ex sprites on the same Sprites account.
+The `aod-conv-<short-id>` sprite naming prefix from aod-ex becomes `fountain-<tenant-prefix>-<short-id>` (8-char user UUID prefix + 8-char short id) to distinguish from any legacy aod-ex sprites on the same Sprites account and to make tenant ownership greppable in Sprites listings.
 
 ### 4.3 Inference credentials — BYO per tenant (ADR 0008, post-G2)
 
@@ -650,7 +650,7 @@ The `aod` skill in `priv/sprite_skills/aod/SKILL.md` must be updated to use `FOU
 
 `aod up` / `aod down` (deploying aod-ex itself to a Sprite as the host) are removed from Fountain's CLI. Fountain is deployed to Render (or a comparable platform), not Sprites. The `aod-host-<unix-ts>` sprite naming convention is retired.
 
-Per-conversation sprites continue with the prefix pattern, changed from `aod-conv-<id>` to `fountain-conv-<id>` to distinguish from any legacy aod-ex sprites on the same Sprites account.
+Per-conversation sprites continue with the prefix pattern, changed from `aod-conv-<id>` to `fountain-<tenant-prefix>-<short-id>` (8-char user UUID prefix + 8-char short id) to distinguish from any legacy aod-ex sprites on the same Sprites account and to make tenant ownership greppable in Sprites listings.
 
 `render.yaml` `preDeployCommand` remains `_build/prod/rel/fountain/bin/migrate` — Ecto migrations run before each deploy.
 


### PR DESCRIPTION
## Summary
- Replaces legacy `aod-conv-<short-id>` sprite naming with `fountain-<tenant-prefix>-<short-id>`, where `<tenant-prefix>` is the first 8 chars of the owning user's UUID.
- Updates both `start_conversation/1` and `create_fresh_sandbox_and_start/4` call sites in `Fountain.Conversations`, plus ADR 0005 and the phase-2 engineering plan to match.
- Existing sandboxes are unaffected (sprite_name is persisted per-row); only newly-provisioned sandboxes use the new format.

Rationale: makes tenant ownership greppable in Sprites listings without exposing the full user_id, and finishes retiring the aod-ex carryover.

## Test plan
- [ ] `mix compile --warnings-as-errors` is clean (verified locally).
- [ ] Start a new conversation; confirm the resulting Sprite name is `fountain-<8-char-user-prefix>-<8-char-id>`.
- [ ] Trigger `create_fresh_sandbox_and_start` (resume a conversation whose old sandbox is gone) and confirm the new sandbox name uses the same format.
- [ ] Existing in-flight sandboxes provisioned with `aod-conv-…` continue to function (no DB rename, no orphaning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)