### PR TITLE
fix(runtimes/claude): use `claude mcp add-json` for MCP servers

### DIFF
--- a/apps/fountain/lib/fountain/runtimes/claude.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude.ex
@@ -70,14 +70,41 @@ defmodule Fountain.Runtimes.Claude do
     end
   end
 
+  # Claude Code 2.x dropped support for top-level `mcpServers` in
+  # `~/.claude.json` and rewrites that file aggressively on first
+  # launch, clobbering anything we drop in there. Use the supported
+  # `claude mcp add-json --scope user` path instead — it goes through
+  # Claude's own state machine and survives further schema changes.
   @impl true
-  def write_config(_sprite, nil), do: :ok
-  def write_config(_sprite, %{mcp_servers: m}) when m == %{} or is_nil(m), do: :ok
+  def prepare_sprite(_sprite, nil, _sprite_env), do: :ok
 
-  def write_config(sprite, %{mcp_servers: mcp_servers}) do
-    fs = Sprites.filesystem(sprite, "/")
-    payload = Jason.encode!(%{"mcpServers" => mcp_servers}, pretty: true)
-    Sprites.Filesystem.write(fs, "/home/sprite/.claude.json", payload)
-    :ok
+  def prepare_sprite(_sprite, %{mcp_servers: m}, _sprite_env)
+      when m == %{} or is_nil(m),
+      do: :ok
+
+  def prepare_sprite(sprite, %{mcp_servers: mcp_servers}, sprite_env)
+      when is_map(mcp_servers) do
+    Enum.reduce_while(mcp_servers, :ok, fn {name, entry}, :ok ->
+      args = [
+        "mcp",
+        "add-json",
+        "--scope",
+        "user",
+        to_string(name),
+        Jason.encode!(entry)
+      ]
+
+      case Sprites.cmd(sprite, "claude", args,
+             env: sprite_env,
+             stderr_to_stdout: true,
+             timeout: 30_000
+           ) do
+        {_out, 0} ->
+          {:cont, :ok}
+
+        {out, code} ->
+          {:halt, {:error, {:claude_mcp_add_failed, name, code, out}}}
+      end
+    end)
   end
 end


### PR DESCRIPTION
## Summary

- Claude Code 2.x rewrites `~/.claude.json` on first launch and no longer reads top-level `mcpServers`. Our provision-time write at `/home/sprite/.claude.json` was getting clobbered before the first turn — `claude mcp list` came back empty even though we wrote a valid `{"mcpServers": …}` payload.
- Replaces `Fountain.Runtimes.Claude.write_config/2` with `prepare_sprite/3` that shells out to `claude mcp add-json --scope user <name> '<json>'` once per entry on `agent.mcp_servers`. The CLI owns its config schema, so this survives further Claude Code releases.
- No behavior change for the other runtimes (codex/gemini/opencode keep their existing `write_config` paths — they don't suffer from this).

## Test plan

- [x] Manual repro inside an `aod-conv-*` sprite: `claude mcp add-json --scope user context7 '{...}'` followed by `claude mcp list` shows the server. (Confirmed before the change.)
- [ ] Spawn a fresh conversation with an agent that has `mcp_servers: {"context7": {...}}` and confirm the agent reports MCP availability on its first turn.
- [ ] Confirm `prepare_sprite` no-ops cleanly when `mcp_servers` is empty / nil / agent is nil (matches the other runtimes' shape).

## Notes / follow-ups

- Stale-config drift on reattach is a separate, pre-existing issue: `do_reattach` doesn't re-run `prepare_sprite` (or the old `write_config`), so editing `mcp_servers` on an agent won't propagate to a sandbox that's already `ready`. New conversations always get a fresh sandbox so they pick it up. Not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)