### PR TITLE
fix(sprites): rebrand bundled aod skill as fountain

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -549,7 +549,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp build_sprite_env(runtime_module, agent, env, secrets, conversation_id, inference_credentials) do
     (runtime_module.default_env(agent, inference_credentials) || []) ++
-      aod_callback_env() ++
+      fountain_callback_env() ++
       conversation_env(conversation_id) ++
       otel_propagation_env() ++
       git_author_env() ++
@@ -560,10 +560,10 @@ defmodule Fountain.Conversations.ConversationServer do
       Enum.map(secrets, fn {k, v} -> {k, v} end)
   end
 
-  # Inject the current conversation ID so the bundled aod skill can
-  # propagate it as X-AoD-Parent-Conversation-Id when spawning children.
+  # Inject the current conversation ID so the bundled fountain skill can
+  # propagate it as X-Fountain-Parent-Conversation-Id when spawning children.
   defp conversation_env(nil), do: []
-  defp conversation_env(conv_id) when is_binary(conv_id), do: [{"AOD_CONVERSATION_ID", conv_id}]
+  defp conversation_env(conv_id) when is_binary(conv_id), do: [{"FOUNTAIN_CONVERSATION_ID", conv_id}]
 
   @doc false
   def git_author_env do
@@ -782,12 +782,12 @@ defmodule Fountain.Conversations.ConversationServer do
     Sprites.create(client, name)
   end
 
-  defp aod_callback_env do
+  defp fountain_callback_env do
     base = Application.get_env(:fountain, :public_url)
     token = Application.get_env(:fountain, :admin_token)
 
     if is_binary(base) and base != "" and is_binary(token) do
-      [{"AOD_BASE_URL", base}, {"AOD_TOKEN", token}]
+      [{"FOUNTAIN_BASE_URL", base}, {"FOUNTAIN_TOKEN", token}]
     else
       []
     end

--- a/apps/fountain/lib/fountain/sprite_skills.ex
+++ b/apps/fountain/lib/fountain/sprite_skills.ex
@@ -12,8 +12,8 @@ defmodule Fountain.SpriteSkills do
       --yes [--skill <name>]`. Each runtime declares its own
       `skills_sh_agent` so the CLI writes to the right on-disk layout.
 
-  The bundled `aod` skill at `priv/sprite_skills/aod/SKILL.md` is always
-  prepended as an inline skill — it's how the per-conversation callback
+  The bundled `fountain` skill at `priv/sprite_skills/fountain/SKILL.md` is
+  always prepended as an inline skill — it's how the per-conversation callback
   API gets discovered inside the sprite.
 
   This must run before the network policy locks the sprite down: github
@@ -26,11 +26,11 @@ defmodule Fountain.SpriteSkills do
   alias Sprites.Filesystem
 
   @bundle_root "sprite_skills"
-  @aod_skill_name "aod"
+  @fountain_skill_name "fountain"
 
   @doc """
   Mount `skills` (a list of inline/github maps) on `sprite` for the
-  named runtime. The bundled `aod` skill is always prepended.
+  named runtime. The bundled `fountain` skill is always prepended.
   """
   def mount(sprite, runtime, skills) when is_binary(runtime) do
     case Runtimes.for_runtime(runtime) do
@@ -43,7 +43,7 @@ defmodule Fountain.SpriteSkills do
     skills_root = runtime_module.skills_root()
     sh_agent = runtime_module.skills_sh_agent()
 
-    all = [aod_inline_skill() | normalize(skills || [])]
+    all = [fountain_inline_skill() | normalize(skills || [])]
 
     {inline, github} =
       Enum.split_with(all, fn s -> is_binary(s["content"]) end)
@@ -64,10 +64,10 @@ defmodule Fountain.SpriteSkills do
     end)
   end
 
-  defp aod_inline_skill do
+  defp fountain_inline_skill do
     %{
-      "name" => @aod_skill_name,
-      "content" => File.read!(Path.join([priv_dir(), @aod_skill_name, "SKILL.md"]))
+      "name" => @fountain_skill_name,
+      "content" => File.read!(Path.join([priv_dir(), @fountain_skill_name, "SKILL.md"]))
     }
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -69,7 +69,8 @@ defmodule FountainWeb.ConversationController do
     description:
       "Creates a sandbox + conversation pair, starts the runtime in a fresh sprite, " <>
         "and (if `prompt` is supplied) sends it as turn 1. " <>
-        "Pass `X-AoD-Parent-Conversation-Id` header to record which conversation spawned this one.",
+        "Pass `X-Fountain-Parent-Conversation-Id` header to record which conversation spawned this one. " <>
+          "Legacy `X-AoD-Parent-Conversation-Id` is still accepted for sprites provisioned before the rename.",
     request_body: {"Conversation attrs", "application/json", Schemas.ConversationCreateRequest},
     responses: [
       created: {"Conversation", "application/json", Schemas.ConversationResponse},
@@ -92,9 +93,8 @@ defmodule FountainWeb.ConversationController do
     images = decode_images(params["images"])
 
     parent_header =
-      conn
-      |> get_req_header("x-aod-parent-conversation-id")
-      |> List.first()
+      List.first(get_req_header(conn, "x-fountain-parent-conversation-id")) ||
+        List.first(get_req_header(conn, "x-aod-parent-conversation-id"))
 
     {source, parent_id} = infer_provenance(parent_header)
 
@@ -123,7 +123,8 @@ defmodule FountainWeb.ConversationController do
 
   @doc """
   Infer the conversation's `source` and `parent_conversation_id` from
-  the `X-AoD-Parent-Conversation-Id` header value (or `nil` if absent).
+  the `X-Fountain-Parent-Conversation-Id` (or legacy `X-AoD-Parent-Conversation-Id`)
+  header value (or `nil` if absent).
 
   Pure function so the inference logic can be unit-tested without
   going through the full `Conversations.start_conversation/1` pipeline

--- a/apps/fountain/priv/help/agents.md
+++ b/apps/fountain/priv/help/agents.md
@@ -21,7 +21,7 @@ curl -s -X POST "$FOUNTAIN_BASE_URL/api/agents" \
     "runtime": "claude",
     "model": "anthropic/claude-sonnet-4-6",
     "system": "You are a research assistant. Cite primary sources.",
-    "skills": ["aod"],
+    "skills": ["fountain"],
     "mcp_servers": {
       "everything": {
         "command": "npx",
@@ -87,4 +87,4 @@ Skills are reusable instructional/context files that get mounted into a sprite a
 - For **codex**: concatenated into `~/.codex/AGENTS.md`.
 - For **gemini**: concatenated into `~/.gemini/GEMINI.md`.
 
-Bundled skills live under `apps/fountain/priv/sprite_skills/`. Reference them by directory name in the agent's `skills` array. The bundled `aod` skill is **always** mounted regardless — it's how a sprite-internal agent calls back to spawn more conversations.
+Bundled skills live under `apps/fountain/priv/sprite_skills/`. Reference them by directory name in the agent's `skills` array. The bundled `fountain` skill is **always** mounted regardless — it's how a sprite-internal agent calls back to spawn more conversations.

--- a/apps/fountain/priv/help/spawning.md
+++ b/apps/fountain/priv/help/spawning.md
@@ -1,13 +1,14 @@
 # Spawning sub-agents from inside a sprite
 
-Every conversation gets two env vars in its sprite:
+Every conversation gets three env vars in its sprite:
 
-- `AOD_BASE_URL` — your Fountain server's public URL (e.g. `https://fountain.inevitable.fyi`)
-- `AOD_TOKEN` — an API key the conversation can use to call back
+- `FOUNTAIN_BASE_URL` — your Fountain server's public URL (e.g. `https://fountain.inevitable.fyi`)
+- `FOUNTAIN_TOKEN` — an API key the conversation can use to call back
+- `FOUNTAIN_CONVERSATION_ID` — the spawning conversation's UUID, used to record provenance via `X-Fountain-Parent-Conversation-Id`
 
-Plus the bundled **`aod` skill** mounted under `~/.claude/skills/aod/` (or the runtime equivalent). With those three pieces, any agent inside a sprite can call back to the API and spawn more conversations.
+Plus the bundled **`fountain` skill** mounted under `~/.claude/skills/fountain/` (or the runtime equivalent). With those pieces, any agent inside a sprite can call back to the API and spawn more conversations.
 
-> The env-var names (`AOD_*`) and the bundled skill name are leftovers from the project's previous name. They're stable contracts the bundled skill keys off of — renaming them would break every sprite-internal script. Treat them as opaque identifiers that mean "the Fountain callback URL/key".
+> Legacy `AOD_*` env vars and `X-AoD-Parent-Conversation-Id` are no longer injected. The Fountain API still accepts the legacy header on `POST /api/conversations` so sprites provisioned before the rename keep working until they terminate.
 
 ## Patterns the agent will use
 
@@ -22,7 +23,7 @@ ids=$(printf '%s\n' "First task" "Second task" "Third task" \
       -H "Content-Type: application/json" \
       -d "$(jq -n --arg a "$3" --arg p "$4" "{agent_id:\$a, prompt:\$p}")" \
     | jq -r .data.id
-  ' _ "$AOD_BASE_URL" "$AOD_TOKEN" "$AGENT_ID" {})
+  ' _ "$FOUNTAIN_BASE_URL" "$FOUNTAIN_TOKEN" "$AGENT_ID" {})
 
 # Wait for all in parallel
 echo "$ids" | xargs -n1 -P10 -I{} sh -c '
@@ -30,13 +31,13 @@ echo "$ids" | xargs -n1 -P10 -I{} sh -c '
     s=$(curl -s "$1/api/conversations/$3" -H "Authorization: Bearer $2" | jq -r .data.status)
     case "$s" in running|pending) sleep 2 ;; *) break ;; esac
   done
-' _ "$AOD_BASE_URL" "$AOD_TOKEN" {}
+' _ "$FOUNTAIN_BASE_URL" "$FOUNTAIN_TOKEN" {}
 
 # Gather final answers
 while IFS= read -r conv; do
   curl -sN --max-time 5 \
-    "$AOD_BASE_URL/api/conversations/$conv/stream?streams=stdout&wait=false" \
-    -H "Authorization: Bearer $AOD_TOKEN" \
+    "$FOUNTAIN_BASE_URL/api/conversations/$conv/stream?streams=stdout&wait=false" \
+    -H "Authorization: Bearer $FOUNTAIN_TOKEN" \
   | awk '/^data: /{sub(/^data: /,""); print}' \
   | jq -r '.data | fromjson? | select(.type=="result") | .result' \
   | tail -n1
@@ -45,7 +46,7 @@ done <<<"$ids"
 
 ### Block-and-return-result
 
-Same shape but for one conversation at a time. The full bash function is in the bundled skill — `cat ~/.claude/skills/aod/SKILL.md` from inside any sprite.
+Same shape but for one conversation at a time. The full bash function is in the bundled skill — `cat ~/.claude/skills/fountain/SKILL.md` from inside any sprite.
 
 ## SSE wire format
 
@@ -76,8 +77,8 @@ The SSE endpoint normally holds open for ~60s waiting for new events. When the c
 
 ## Security model — what to know
 
-The sprite-side `AOD_TOKEN` is a regular Fountain API key — it carries the same blast radius the owning user has. Anything inside a sprite can create/delete agents, list conversations, etc. on behalf of that user. There's no per-conversation scoping today. Treat prompt-injection on a sprite-bound agent as a full account takeover for that user. Per-conversation scoped tokens are on the roadmap.
+The sprite-side `FOUNTAIN_TOKEN` is a regular Fountain API key — it carries the same blast radius the owning user has. Anything inside a sprite can create/delete agents, list conversations, etc. on behalf of that user. There's no per-conversation scoping today. Treat prompt-injection on a sprite-bound agent as a full account takeover for that user. Per-conversation scoped tokens are on the roadmap.
 
 ## Tunneling
 
-For a sprite to call back, `AOD_BASE_URL` must be reachable from inside the sprite — `localhost` won't do. Local-dev cleanest option: [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/install-and-setup/tunnel-guide/local/) or [ngrok](https://ngrok.com). In production: whatever your hosted URL is.
+For a sprite to call back, `FOUNTAIN_BASE_URL` must be reachable from inside the sprite — `localhost` won't do. Local-dev cleanest option: [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/install-and-setup/tunnel-guide/local/) or [ngrok](https://ngrok.com). In production: whatever your hosted URL is.

--- a/apps/fountain/priv/sprite_skills/fountain/SKILL.md
+++ b/apps/fountain/priv/sprite_skills/fountain/SKILL.md
@@ -1,17 +1,18 @@
 ---
-name: aod
-description: Spawn and stream Agent on Demand (AoD) conversations — for when this agent needs to fan out work to other coding agents. Use when the user asks you to "delegate to another agent", "spawn an agent", "fan out", or when a task is large enough to warrant parallel agents working in parallel sandboxes. AoD provisions an isolated Sprite, runs a configured agent in it, and streams output back over SSE. Reads `AOD_BASE_URL` and `AOD_TOKEN` from the environment.
+name: fountain
+description: Spawn and stream Fountain conversations from inside a sprite — use whenever the user asks you to "spin up an agent on Fountain", "delegate to another agent", "fan out", or any task large enough to parallelise across coding agents. Fountain provisions an isolated Sprite per conversation, runs the configured runtime in it, and streams output back over SSE. Reads `FOUNTAIN_BASE_URL`, `FOUNTAIN_TOKEN`, and `FOUNTAIN_CONVERSATION_ID` from the environment.
 ---
 
-# Agent on Demand (AoD) — From Inside a Sprite
+# Fountain — spawning conversations from inside a sprite
 
-You are running inside a Sprite that AoD provisioned. AoD itself is reachable
-at `$AOD_BASE_URL` (the API lives under **`/api`**) with bearer `$AOD_TOKEN`.
-From here you can spawn *more* AoD conversations — each one runs in its own
-fresh Sprite.
+You are running inside a Sprite that Fountain provisioned. The Fountain API is
+reachable at `$FOUNTAIN_BASE_URL` (under **`/api`**) with bearer
+`$FOUNTAIN_TOKEN`. From here you can spawn *more* Fountain conversations —
+each runs in its own fresh Sprite.
 
-> **Common mistake**: hitting `$AOD_BASE_URL/conversations` returns 302 (the
-> bare path is the LiveView UI). The right URL is `$AOD_BASE_URL/api/conversations`.
+> **Common mistake**: hitting `$FOUNTAIN_BASE_URL/conversations` returns 302
+> (the bare path is the LiveView UI). The right URL is
+> `$FOUNTAIN_BASE_URL/api/conversations`.
 
 ## The two patterns you'll use
 
@@ -19,8 +20,8 @@ fresh Sprite.
 
 ```bash
 # 1. Pick the agent (by name).
-AGENT_ID=$(curl -s "$AOD_BASE_URL/api/agents" \
-  -H "Authorization: Bearer $AOD_TOKEN" \
+AGENT_ID=$(curl -s "$FOUNTAIN_BASE_URL/api/agents" \
+  -H "Authorization: Bearer $FOUNTAIN_TOKEN" \
   | jq -r '.data[] | select(.name == "echo-bot") | .id')
 
 # 2. Spawn N conversations IN PARALLEL with xargs. Output is conv ids on stdout.
@@ -29,10 +30,10 @@ ids=$(printf '%s\n' "${prompts[@]}" | xargs -n1 -P8 -I{} sh -c '
   curl -s -X POST "$1/api/conversations" \
     -H "Authorization: Bearer $2" \
     -H "Content-Type: application/json" \
-    -H "X-AoD-Parent-Conversation-Id: $AOD_CONVERSATION_ID" \
+    -H "X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID" \
     -d "$(jq -n --arg a "$3" --arg p "$4" "{agent_id:\$a, prompt:\$p}")" \
   | jq -r .data.id
-' _ "$AOD_BASE_URL" "$AOD_TOKEN" "$AGENT_ID" {})
+' _ "$FOUNTAIN_BASE_URL" "$FOUNTAIN_TOKEN" "$AGENT_ID" {})
 
 echo "$ids"   # one conv id per line
 
@@ -42,14 +43,14 @@ echo "$ids" | xargs -n1 -P10 -I{} sh -c '
     s=$(curl -s "$1/api/conversations/$3" -H "Authorization: Bearer $2" | jq -r .data.status)
     case "$s" in running|pending) sleep 2 ;; *) break ;; esac
   done
-' _ "$AOD_BASE_URL" "$AOD_TOKEN" {}
+' _ "$FOUNTAIN_BASE_URL" "$FOUNTAIN_TOKEN" {}
 
 # 4. Gather the final text from each (claude runtime).
 while IFS= read -r conv; do
   echo "=== $conv ==="
   curl -sN --max-time 5 \
-    "$AOD_BASE_URL/api/conversations/$conv/stream?streams=stdout&wait=false" \
-    -H "Authorization: Bearer $AOD_TOKEN" \
+    "$FOUNTAIN_BASE_URL/api/conversations/$conv/stream?streams=stdout&wait=false" \
+    -H "Authorization: Bearer $FOUNTAIN_TOKEN" \
   | awk '/^data: /{sub(/^data: /,""); print}' \
   | jq -r '.data | fromjson? | select(.type=="result") | .result' \
   | tail -n1
@@ -62,22 +63,22 @@ done <<<"$ids"
 AGENT_ID=...
 PROMPT=...
 
-CONV=$(curl -s -X POST "$AOD_BASE_URL/api/conversations" \
-  -H "Authorization: Bearer $AOD_TOKEN" \
+CONV=$(curl -s -X POST "$FOUNTAIN_BASE_URL/api/conversations" \
+  -H "Authorization: Bearer $FOUNTAIN_TOKEN" \
   -H "Content-Type: application/json" \
-  -H "X-AoD-Parent-Conversation-Id: $AOD_CONVERSATION_ID" \
+  -H "X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID" \
   -d "$(jq -n --arg a "$AGENT_ID" --arg p "$PROMPT" '{agent_id:$a, prompt:$p}')" \
   | jq -r .data.id)
 
 while :; do
-  s=$(curl -s "$AOD_BASE_URL/api/conversations/$CONV" \
-    -H "Authorization: Bearer $AOD_TOKEN" | jq -r .data.status)
+  s=$(curl -s "$FOUNTAIN_BASE_URL/api/conversations/$CONV" \
+    -H "Authorization: Bearer $FOUNTAIN_TOKEN" | jq -r .data.status)
   case "$s" in running|pending) sleep 2 ;; *) break ;; esac
 done
 
 curl -sN --max-time 5 \
-  "$AOD_BASE_URL/api/conversations/$CONV/stream?streams=stdout&wait=false" \
-  -H "Authorization: Bearer $AOD_TOKEN" \
+  "$FOUNTAIN_BASE_URL/api/conversations/$CONV/stream?streams=stdout&wait=false" \
+  -H "Authorization: Bearer $FOUNTAIN_TOKEN" \
 | awk '/^data: /{sub(/^data: /,""); print}' \
 | jq -r '.data | fromjson? | select(.type=="result") | .result' \
 | tail -n1
@@ -119,8 +120,8 @@ controls the shape of the inner JSON. Pull the runtime once, then pick the
 right filter:
 
 ```bash
-RT=$(curl -s "$AOD_BASE_URL/api/conversations/$CONV" \
-  -H "Authorization: Bearer $AOD_TOKEN" | jq -r .data.runtime)
+RT=$(curl -s "$FOUNTAIN_BASE_URL/api/conversations/$CONV" \
+  -H "Authorization: Bearer $FOUNTAIN_TOKEN" | jq -r .data.runtime)
 ```
 
 | runtime  | filter (the part **after** `.data \| fromjson?`)                       | text path        |
@@ -137,13 +138,13 @@ agent's environment provides (e.g. contribute to GitHub as a specific user), pas
 an optional `vault_id` when creating it. List vaults to find the one you want:
 
 ```bash
-curl -s "$AOD_BASE_URL/api/vaults" -H "Authorization: Bearer $AOD_TOKEN" \
+curl -s "$FOUNTAIN_BASE_URL/api/vaults" -H "Authorization: Bearer $FOUNTAIN_TOKEN" \
   | jq -r '.data[] | "\(.name)\t\(.id)"'
 
 # Spawn with a specific vault layered on top of the env's secrets:
-curl -s -X POST "$AOD_BASE_URL/api/conversations" \
-  -H "Authorization: Bearer $AOD_TOKEN" -H "Content-Type: application/json" \
-  -H "X-AoD-Parent-Conversation-Id: $AOD_CONVERSATION_ID" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/conversations" \
+  -H "Authorization: Bearer $FOUNTAIN_TOKEN" -H "Content-Type: application/json" \
+  -H "X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID" \
   -d "$(jq -n --arg a "$AGENT_ID" --arg v "$VAULT_ID" --arg p "$PROMPT" \
         '{agent_id:$a, vault_id:$v, prompt:$p}')"
 ```
@@ -157,8 +158,8 @@ credentials per spawned conversation.
 Send a follow-up prompt to an existing conversation:
 
 ```bash
-curl -s -X POST "$AOD_BASE_URL/api/conversations/$CONV/prompts" \
-  -H "Authorization: Bearer $AOD_TOKEN" -H "Content-Type: application/json" \
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/conversations/$CONV/prompts" \
+  -H "Authorization: Bearer $FOUNTAIN_TOKEN" -H "Content-Type: application/json" \
   -d '{"prompt":"Now compare that to the worker service."}'
 ```
 
@@ -168,8 +169,8 @@ resumes — the agent remembers turn 1.
 ## Tear down when you're done
 
 ```bash
-curl -s -X POST "$AOD_BASE_URL/api/conversations/$CONV/terminate" \
-  -H "Authorization: Bearer $AOD_TOKEN"
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/conversations/$CONV/terminate" \
+  -H "Authorization: Bearer $FOUNTAIN_TOKEN"
 ```
 
 ## Important
@@ -178,6 +179,6 @@ curl -s -X POST "$AOD_BASE_URL/api/conversations/$CONV/terminate" \
 - **Parallelize spawn / poll / gather** with `xargs -P` — one provisioning takes ~5–15s, and there's no reason to do them sequentially.
 - **Don't recurse forever.** Spawned agents have the same skill. Cap depth with a `MAX_DEPTH` you check before spawning.
 - **Costs add up.** Every conversation provisions a real sandbox.
-- **Same `$AOD_TOKEN`.** All spawned agents share the single-tenant admin token. Don't leak it outside the sprite.
+- **Same `$FOUNTAIN_TOKEN`.** All spawned agents share the single-tenant admin token. Don't leak it outside the sprite.
 - **API path is `/api/...`.** The bare `/conversations` redirects (302 → /login) for non-browser requests.
-- **Provenance is automatic.** `AOD_CONVERSATION_ID` is always present in your sprite's environment. Every `POST /api/conversations` call that includes `X-AoD-Parent-Conversation-Id: $AOD_CONVERSATION_ID` records this conversation as the parent, letting the operator reconstruct the full spawn chain.
+- **Provenance is automatic.** `FOUNTAIN_CONVERSATION_ID` is always present in your sprite's environment. Every `POST /api/conversations` call that includes `X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID` records this conversation as the parent, letting the operator reconstruct the full spawn chain.


### PR DESCRIPTION
## Summary
- The bundled self-spawn skill was still named `aod` with an "Agent on Demand" description. When an agent received "spin up any agent on fountain", Claude didn't match the AoD wording and reached for unrelated skills (e.g. `claude-api`), silently breaking fan-out.
- Renames the bundled skill end-to-end: directory `priv/sprite_skills/aod/` → `priv/sprite_skills/fountain/`, frontmatter `name:`/`description:` rewritten in terms of Fountain, helper `aod_inline_skill` → `fountain_inline_skill`, module attribute `@aod_skill_name` → `@fountain_skill_name`.
- Renames the sprite env vars: `AOD_BASE_URL` → `FOUNTAIN_BASE_URL`, `AOD_TOKEN` → `FOUNTAIN_TOKEN`, `AOD_CONVERSATION_ID` → `FOUNTAIN_CONVERSATION_ID`. Skill content now uses these throughout.
- New provenance header: `X-Fountain-Parent-Conversation-Id`. The `POST /api/conversations` controller also still accepts the legacy `X-AoD-Parent-Conversation-Id` so sprites provisioned before this change keep linking their children until they terminate. Once those drain, the legacy header path can be removed in a follow-up.
- Help docs (`agents.md`, `spawning.md`) updated; the stale "leftovers from previous name" note is removed.

Aligns with `plan/phase-2-build-plan/engineering-plan.md` §9.2, which already calls out this rename.

**Out of scope:** the per-conversation signed callback token from §9.2 (separate security rework), the `GIT_AUTHOR_NAME=AoD` identity, and the `/tmp/aod_ssh_*` markers in `provisioning.ex`.

## Test plan
- [ ] `mix compile --warnings-as-errors` is clean (verified locally).
- [ ] Start a fresh conversation; from inside the sprite, confirm `env | grep FOUNTAIN_` shows `FOUNTAIN_BASE_URL`, `FOUNTAIN_TOKEN`, and `FOUNTAIN_CONVERSATION_ID`, and `~/.claude/skills/fountain/SKILL.md` exists.
- [ ] Prompt that conversation's agent with "spin up any agent on fountain, have it say hi and report back" — confirm Claude picks up the `fountain` skill (no longer falling back to `claude-api`) and successfully creates a child conversation.
- [ ] Confirm the child conversation's `parent_conversation_id` is set (sent via `X-Fountain-Parent-Conversation-Id`) and shows up in the conversation graph.
- [ ] Hit `POST /api/conversations` with the legacy `X-AoD-Parent-Conversation-Id` header — verify it still records provenance (backward-compat path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)