### PR TITLE
fix(sprite-skills): land bundled SKILL.md by waiting on sprite ready

### DIFF
--- a/apps/fountain/lib/fountain/sprite_skills.ex
+++ b/apps/fountain/lib/fountain/sprite_skills.ex
@@ -17,7 +17,10 @@ defmodule Fountain.SpriteSkills do
   API gets discovered inside the sprite.
 
   This must run before the network policy locks the sprite down: github
-  installs hit npm + GitHub.
+  installs hit npm + GitHub. Inside `mount/3` the github installs run
+  before the inline writes — `Sprites.cmd` blocks until the sprite is
+  fully ready, which is the readiness gate the HTTP `/fs/*` endpoints
+  silently need too.
   """
 
   require Logger
@@ -48,9 +51,16 @@ defmodule Fountain.SpriteSkills do
     {inline, github} =
       Enum.split_with(all, fn s -> is_binary(s["content"]) end)
 
+    # Run github installs first. `Sprites.cmd` opens a WebSocket session
+    # that blocks until the sprite is fully running, so by the time it
+    # returns the sprite's HTTP `/fs/*` endpoints are also up. The inline
+    # write previously ran immediately after `Sprites.create` and lost a
+    # race with the filesystem service coming online — `Sprites.Filesystem.write/4`
+    # returned `{:error, _}` and `Enum.each` swallowed it, so the bundled
+    # `fountain` SKILL.md silently never landed.
+    install_github_skills(sprite, sh_agent, github)
     fs = Sprites.filesystem(sprite, "/")
     write_inline_skills(fs, skills_root, inline)
-    install_github_skills(sprite, sh_agent, github)
     :ok
   end
 
@@ -74,12 +84,20 @@ defmodule Fountain.SpriteSkills do
   defp write_inline_skills(_fs, _root, []), do: :ok
 
   defp write_inline_skills(fs, root, inline) do
-    Filesystem.mkdir_p(fs, root)
-
     Enum.each(inline, fn %{"name" => name, "content" => content} ->
-      dir = Path.join(root, name)
-      Filesystem.mkdir_p(fs, dir)
-      Filesystem.write(fs, Path.join(dir, "SKILL.md"), content)
+      # `mkdirParents: true` inside `Filesystem.write/4` creates the
+      # `<root>/<name>` directory atomically with the file write, so we
+      # don't need a separate `mkdir_p` round-trip (each one was another
+      # opportunity for the same readiness race).
+      path = Path.join([root, name, "SKILL.md"])
+
+      case Filesystem.write(fs, path, content) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("inline skill write failed for #{name} at #{path}: #{inspect(reason)}")
+      end
     end)
   end
 


### PR DESCRIPTION
## Summary
The bundled `fountain` skill never reached `/home/sprite/.claude/skills/` even after the rename in #72. Inside a fresh conversation on the live deploy, `ls ~/.claude/skills/` shows every github-installed skill (`brainstorming`, `using-superpowers`, etc.) but no `fountain/` directory. Result: agents in the sprite don't know how to call back to Fountain.

**Root cause.** `mount/3` called `Sprites.Filesystem.write/4` immediately after `Sprites.create/2` returned. `POST /v1/sprites` returns once the sprite record exists, but the HTTP `/fs/*` proxy isn't accepting writes yet, so `Filesystem.write` returned `{:error, _}` and `Enum.each` silently swallowed it. The github-source install path used `Sprites.cmd`, which opens a WebSocket and blocks until the sprite is fully running — those installs landed normally, which is why the failure looked like "only the inline write is broken."

**Fix.** Three small changes in `apps/fountain/lib/fountain/sprite_skills.ex`:
- Reorder `mount/3`: install github skills first. By the time `Sprites.cmd` returns, the sprite is ready and the subsequent `Filesystem.write` calls succeed. Network policy is still applied later in `run_provisioning_pipeline`, so the npm/GitHub fetch the install needs is unaffected.
- Drop the redundant `Filesystem.mkdir_p` round-trips. `Filesystem.write` already passes `mkdirParents: true`, so the directory is created atomically with the file. Each removed call was another spot the same race could bite.
- Surface `{:error, _}` from `Filesystem.write` via `Logger.warning` so a future regression shows up in logs instead of disappearing.

**Out of scope.** `config/runtime.exs` never sets `:fountain, :admin_token`, so `FOUNTAIN_BASE_URL` / `FOUNTAIN_TOKEN` are still not injected into the sprite (`fountain_callback_env/0` returns `[]`). That's a separate token-model decision — per-user API key vs. the signed per-conversation token from engineering-plan §9.2 — and the skill landing on disk is a prerequisite for either approach.

## Test plan
- [x] `mix compile --warnings-as-errors` is clean.
- [ ] After deploy: spawn a fresh conversation and confirm `~/.claude/skills/fountain/SKILL.md` exists on the sprite.
- [ ] Confirm the sprite's `claude` runtime reports `fountain` in its init-event `skills` list.
- [ ] Once `FOUNTAIN_BASE_URL` / `FOUNTAIN_TOKEN` are wired up in a follow-up, prompt the agent with "spin up an agent on Fountain and have it say hi" — verify it now picks up the `fountain` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)