### PR TITLE
feat(conversations): per-conversation FOUNTAIN_TOKEN scoped to owner

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -19,6 +19,7 @@ defmodule Fountain.Conversations.Conversation do
     field :runtime_session_id, :string
     field :source, :string, default: "api"
     field :parent_conversation_id, :binary_id
+    field :callback_api_key_id, :binary_id
     belongs_to :user, User
     belongs_to :sandbox, Sandbox
     belongs_to :agent, Agent
@@ -46,6 +47,7 @@ defmodule Fountain.Conversations.Conversation do
       :runtime_session_id,
       :source,
       :parent_conversation_id,
+      :callback_api_key_id,
       :user_id,
       :sandbox_id,
       :agent_id,

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -13,7 +13,8 @@ defmodule Fountain.Conversations.ConversationServer do
   require Logger
   require OpenTelemetry.Tracer
 
-  alias Fountain.{Agents, Conversations, Crypto, Environments, InferenceCredentials, SpritesClient, Substitution, Vaults}
+  alias Fountain.{Accounts, Agents, Conversations, Crypto, Environments, InferenceCredentials, SpritesClient, Substitution, Vaults}
+  alias Fountain.Conversations.Conversation
 
   # ── public api ────────────────────────────────────────────────────────────
 
@@ -117,7 +118,13 @@ defmodule Fountain.Conversations.ConversationServer do
       # owning user_id; held for the conversation lifetime; dropped on
       # terminate. See ADR 0008 (BYO inference credentials).
       tenant_key: nil,
-      inference_credentials: %{}
+      inference_credentials: %{},
+      # Plaintext of the per-conversation API key that's injected into the
+      # sprite as FOUNTAIN_TOKEN. The hash and a row in `api_keys` is the
+      # durable record; we keep the raw value in memory only while this
+      # GenServer is alive. Rotated on every fresh provision/reattach;
+      # revoked in terminate/2.
+      callback_token: nil
     }
 
     {:ok, state, {:continue, :provision}}
@@ -261,7 +268,9 @@ defmodule Fountain.Conversations.ConversationServer do
         runtime = (agent && agent.runtime) || "claude"
         Fountain.SpriteSkills.mount(sprite, runtime, skills)
 
-        sprite_env = build_sprite_env(state.runtime_module, agent, env, secrets, state.conversation_id, state.inference_credentials)
+        {state, conv} = rotate_callback_api_key(state, conv)
+
+        sprite_env = build_sprite_env(state, agent, env, secrets)
 
         write_runtime_config(sprite, state.runtime_module, agent)
         Fountain.Conversations.Provisioning.write_env_file(sprite, sprite_env)
@@ -403,7 +412,7 @@ defmodule Fountain.Conversations.ConversationServer do
     )
   end
 
-  defp do_reattach(state, _conv, sandbox, agent, env, secrets) do
+  defp do_reattach(state, conv, sandbox, agent, env, secrets) do
     publish_stage(state.conversation_id, "reattach", "started", %{
       sprite_name: sandbox.sprite_name
     })
@@ -413,7 +422,8 @@ defmodule Fountain.Conversations.ConversationServer do
     case Sprites.get_sprite(client, sandbox.sprite_name) do
       {:ok, _info} ->
         sprite = Sprites.sprite(client, sandbox.sprite_name)
-        sprite_env = build_sprite_env(state.runtime_module, agent, env, secrets, state.conversation_id, state.inference_credentials)
+        {state, _conv} = rotate_callback_api_key(state, conv)
+        sprite_env = build_sprite_env(state, agent, env, secrets)
 
         # Refresh the .env file in case secrets/env_vars were edited
         # between the original provision and this reattach.
@@ -547,10 +557,10 @@ defmodule Fountain.Conversations.ConversationServer do
     )
   end
 
-  defp build_sprite_env(runtime_module, agent, env, secrets, conversation_id, inference_credentials) do
-    (runtime_module.default_env(agent, inference_credentials) || []) ++
-      fountain_callback_env() ++
-      conversation_env(conversation_id) ++
+  defp build_sprite_env(state, agent, env, secrets) do
+    (state.runtime_module.default_env(agent, state.inference_credentials) || []) ++
+      fountain_callback_env(state.callback_token) ++
+      conversation_env(state.conversation_id) ++
       otel_propagation_env() ++
       git_author_env() ++
       if(env,
@@ -775,6 +785,27 @@ defmodule Fountain.Conversations.ConversationServer do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
+  # Best-effort revoke of the per-conversation API key when this server
+  # exits — covers both clean termination (`:terminate_conv`) and crash
+  # paths that hit `{:stop, :normal, state}` after a provision failure.
+  # If the BEAM crashes hard, the row in `api_keys` is orphaned and lives
+  # until an admin/janitor sweeps it; that's a known gap, not a regression.
+  @impl true
+  def terminate(_reason, state) do
+    if state.conversation_id do
+      case Conversations._unsafe_get_conversation(state.conversation_id) do
+        %Conversation{user_id: user_id, callback_api_key_id: id}
+        when is_binary(user_id) and is_binary(id) ->
+          _ = Accounts.revoke_api_key(user_id, id)
+
+        _ ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+
   # ── helpers ───────────────────────────────────────────────────────────────
 
   defp create_sprite(name) do
@@ -782,14 +813,37 @@ defmodule Fountain.Conversations.ConversationServer do
     Sprites.create(client, name)
   end
 
-  defp fountain_callback_env do
+  defp fountain_callback_env(token) do
     base = Application.get_env(:fountain, :public_url)
-    token = Application.get_env(:fountain, :admin_token)
 
-    if is_binary(base) and base != "" and is_binary(token) do
+    if is_binary(base) and base != "" and is_binary(token) and token != "" do
       [{"FOUNTAIN_BASE_URL", base}, {"FOUNTAIN_TOKEN", token}]
     else
       []
+    end
+  end
+
+  # Issue a fresh per-conversation API key scoped to the conversation
+  # owner, revoking any prior one. The plaintext is only kept in
+  # `state.callback_token` — the durable record is a hash in `api_keys`,
+  # which we can't reverse, so we rotate on every fresh provision /
+  # reattach instead of trying to recover the old plaintext.
+  defp rotate_callback_api_key(state, %Conversation{} = conv) do
+    if id = conv.callback_api_key_id do
+      _ = Accounts.revoke_api_key(conv.user_id, id)
+    end
+
+    case Accounts.create_api_key(conv.user_id, "sprite:#{String.slice(conv.id, 0, 8)}") do
+      {:ok, {%Accounts.ApiKey{id: key_id}, raw}} ->
+        {:ok, conv} = Conversations.update_conversation(conv, %{callback_api_key_id: key_id})
+        {%{state | callback_token: raw}, conv}
+
+      {:error, cs} ->
+        Logger.warning(
+          "could not issue callback api key for conv #{conv.id}: #{inspect(cs.errors)}"
+        )
+
+        {%{state | callback_token: nil}, conv}
     end
   end
 

--- a/apps/fountain/priv/help/spawning.md
+++ b/apps/fountain/priv/help/spawning.md
@@ -77,7 +77,9 @@ The SSE endpoint normally holds open for ~60s waiting for new events. When the c
 
 ## Security model — what to know
 
-The sprite-side `FOUNTAIN_TOKEN` is a regular Fountain API key — it carries the same blast radius the owning user has. Anything inside a sprite can create/delete agents, list conversations, etc. on behalf of that user. There's no per-conversation scoping today. Treat prompt-injection on a sprite-bound agent as a full account takeover for that user. Per-conversation scoped tokens are on the roadmap.
+`FOUNTAIN_TOKEN` is a Fountain API key issued **per conversation**, scoped to the conversation's owning user. Fountain mints it at provision time, names the `api_keys` row `sprite:<short-conv-id>`, and stores its ID on the `conversations` row. The token rotates on every fresh provision or reattach (plaintext can't be recovered after a BEAM restart) and is revoked when the conversation terminates — kill the conversation, kill the key.
+
+The token still carries the **same Fountain blast radius the owning user has** — anything inside the sprite can create/delete agents, list conversations, list keys, etc. on behalf of that user. Treat prompt injection on a sprite-bound agent as a full account takeover for that user; the per-conversation scoping bounds *how long* a leaked token stays live, not *what it can do* while it's live.
 
 ## Tunneling
 

--- a/apps/fountain/priv/repo/migrations/20260511000002_add_callback_api_key_to_conversations.exs
+++ b/apps/fountain/priv/repo/migrations/20260511000002_add_callback_api_key_to_conversations.exs
@@ -1,0 +1,13 @@
+defmodule Fountain.Repo.Migrations.AddCallbackApiKeyToConversations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:conversations) do
+      add :callback_api_key_id,
+          references(:api_keys, type: :binary_id, on_delete: :nilify_all),
+          null: true
+    end
+
+    create index(:conversations, [:callback_api_key_id])
+  end
+end


### PR DESCRIPTION
## Summary
`FOUNTAIN_BASE_URL` and `FOUNTAIN_TOKEN` weren't reaching sprites in production — the verification probe after #74 confirms `~/.claude/skills/fountain/SKILL.md` lands correctly now, but `env | grep ^FOUNTAIN_` inside the sprite only shows `FOUNTAIN_CONVERSATION_ID`. Root cause: `fountain_callback_env/0` read `Application.get_env(:fountain, :admin_token)`, which `config/runtime.exs` never sets, so the function silently returned `[]`. The bundled `fountain` skill had no API to call back to.

Replace the global admin-token model with a **per-conversation API key scoped to the conversation's owner**.

## Changes

**Schema**
- `apps/fountain/priv/repo/migrations/20260511000002_add_callback_api_key_to_conversations.exs` — adds `conversations.callback_api_key_id` (`binary_id`, nullable, `references(:api_keys)` with `on_delete: :nilify_all`).
- `Fountain.Conversations.Conversation` — adds the field + casts it through the changeset.

**ConversationServer (`apps/fountain/lib/fountain/conversations/conversation_server.ex`)**
- New `rotate_callback_api_key/2`: revokes any previously-issued key (we can't recover its plaintext across BEAM restarts) and mints a fresh one via `Fountain.Accounts.create_api_key/2`, named `sprite:<short-conv-id>`. Plaintext is held in `state.callback_token` for the GenServer lifetime only; the durable record is the hash in `api_keys`.
- Called from both `do_fresh_provision_inner/6` and `do_reattach/6` before `build_sprite_env/4`, so every provisioning of a sprite gets a fresh valid token.
- `build_sprite_env/4` now takes `state` (was a 6-tuple of plain args) and reads `state.callback_token`. `fountain_callback_env/1` takes the token explicitly instead of consulting Application config.
- New `terminate/2` GenServer callback revokes the active key when the ConversationServer stops — covers both clean `:terminate_conv` and `{:stop, :normal, state}` failure paths.

**Docs**
- `apps/fountain/priv/help/spawning.md` security section rewritten to reflect the new model.

## Security model
- Token still carries the **same Fountain blast radius the owning user has** — anything in the sprite can `create/delete/list` agents, keys, conversations, etc. on behalf of that user. The per-conversation scoping bounds *how long* a leaked token stays live, not *what it can do* while it's live.
- Token rotates on every fresh provision or reattach (since plaintext can't be recovered after a BEAM restart).
- Revoked at conversation termination (via `terminate/2`).

## Known gap
If the BEAM hard-crashes before `terminate/2` fires, the `api_keys` row is orphaned (still owned by the user, still revocable from the keys UI). A janitor that sweeps `sprite:*` keys for conversations in terminal status is a separate ticket.

## Test plan
- [x] `mix compile --warnings-as-errors` is clean.
- [ ] After deploy: spawn a fresh conversation, confirm `env | grep ^FOUNTAIN_` inside the sprite shows `FOUNTAIN_BASE_URL`, `FOUNTAIN_TOKEN`, and `FOUNTAIN_CONVERSATION_ID`.
- [ ] From inside the sprite, confirm `curl -sS "$FOUNTAIN_BASE_URL/api/agents" -H "Authorization: Bearer $FOUNTAIN_TOKEN" | jq '.data | length'` returns the owning user's agent count.
- [ ] Inspect `api_keys` for the user — confirm a `sprite:<short-id>` row exists while the conversation is live and gets `revoked_at` set after `POST /api/conversations/:id/terminate`.
- [ ] Prompt the agent "spin up another fountain agent and have it say hi" — verify the `fountain` skill executes the spawn end-to-end with provenance recorded via `X-Fountain-Parent-Conversation-Id`.
- [ ] Force a `ConversationServer` re-provision (e.g., kill the sprite from outside) and confirm a fresh `sprite:*` row appears while the old one is revoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)