### PR TITLE
docs(readme): add CLI quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,29 @@ A multi-tenant API and UI for managing agents, repos, secrets, and conversations
 
 This repo is the bus for the [`captain-picard`](https://github.com/jhgaylor/aod-specs) Agent on Demand orchestrator. See `OPERATING_MODEL.md` for how the team operates and `ROADMAP.md` for what's open.
 
+## Get started with the CLI
+
+Install the `fountain` binary from the [Homebrew tap](https://github.com/BinaryBourbon/homebrew-tap):
+
+```sh
+brew install BinaryBourbon/tap/fountain
+```
+
+Log in against your Fountain instance — prompts for email + password, writes `~/.fountain/credentials`:
+
+```sh
+fountain auth login
+```
+
+Apply a manifest. [`jhgaylor/agent-specs`](https://github.com/jhgaylor/agent-specs) is a public example tree of agents, environments, and vaults:
+
+```sh
+git clone https://github.com/jhgaylor/agent-specs
+fountain apply -f agent-specs
+```
+
+`fountain apply` walks the directory and applies every `*.yml` / `*.yaml` doc that declares both `apiVersion` and `kind`. See [`cli/README.md`](cli/README.md) for the rest of the command surface.
+
 ## Bootstrap a workstation
 
 See [`SETUP.md`](SETUP.md) for the full local bootstrap (mise + Postgres + deps). The toolchain version is pinned in `.tool-versions` and mirrored in `render.yaml`, so a fresh laptop or ephemeral VM gets the same Erlang/Elixir as production.


### PR DESCRIPTION
## Summary
- Adds a "Get started with the CLI" section at the top of the README: `brew install BinaryBourbon/tap/fountain`, `fountain auth login`, then clone `jhgaylor/agent-specs` and `fountain apply -f agent-specs`.
- Cross-links to `cli/README.md` for the rest of the command surface; leaves the existing "Bootstrap a workstation" section beneath it.

## Test plan
- [ ] README renders cleanly on GitHub (headings, code fences, links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)