### PR TITLE
fix(auth): distinguish revoked vs unknown API keys; correct in-sprite token guidance

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -276,24 +276,30 @@ defmodule Fountain.Accounts do
   @doc """
   Authenticate a raw API key string.
 
-  Hashes the raw key with SHA-256, queries `api_keys` for an active (non-revoked) match,
-  and returns the associated user.
+  Hashes the raw key with SHA-256, queries `api_keys` for a matching row, and
+  returns the associated user when the key is active.
 
-  Returns `{:ok, user}` or `{:error, :invalid}`. Revoked keys always return `:invalid`.
+  Returns `{:ok, user}` for an active match, `{:error, :revoked}` when the hash
+  matches a row whose `revoked_at` is set, and `{:error, :not_found}` when no
+  row matches. Callers (e.g. the auth plug) can distinguish these to give
+  legitimate clients holding a stale token a more useful error than a generic
+  401.
   """
-  @spec get_user_by_api_key(String.t()) :: {:ok, User.t()} | {:error, :invalid}
+  @spec get_user_by_api_key(String.t()) ::
+          {:ok, User.t()} | {:error, :revoked | :not_found}
   def get_user_by_api_key(raw_key) when is_binary(raw_key) do
     key_hash = hash_key(raw_key)
 
     query =
       from k in ApiKey,
-        where: k.key_hash == ^key_hash and is_nil(k.revoked_at),
+        where: k.key_hash == ^key_hash,
         join: u in assoc(k, :user),
         preload: [user: u]
 
     case Repo.one(query) do
-      nil -> {:error, :invalid}
-      key -> {:ok, key.user}
+      nil -> {:error, :not_found}
+      %ApiKey{revoked_at: nil} = key -> {:ok, key.user}
+      %ApiKey{} -> {:error, :revoked}
     end
   end
 
@@ -339,7 +345,11 @@ defmodule Fountain.Accounts do
 
   defp insert_oauth_identity(user_id, provider, provider_uid) do
     %OauthIdentity{}
-    |> OauthIdentity.changeset(%{user_id: user_id, provider: provider, provider_uid: provider_uid})
+    |> OauthIdentity.changeset(%{
+      user_id: user_id,
+      provider: provider,
+      provider_uid: provider_uid
+    })
     |> Repo.insert(on_conflict: :nothing, conflict_target: [:provider, :provider_uid])
   end
 

--- a/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
+++ b/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
@@ -1,13 +1,18 @@
 defmodule FountainWeb.Plugs.TenantAPIAuth do
   @moduledoc """
   API pipeline auth: extracts `Authorization: Bearer <key>`, SHA-256 hashes it,
-  looks up the active API key, loads the owning user, and sets
+  looks up the API key, loads the owning user, and sets
   `conn.assigns.current_user`.
 
   Updates `last_used_at` asynchronously via `Task.async` so it never blocks
   the request.
 
-  Returns 401 JSON on failure.
+  Returns 401 JSON on failure. The response body includes a machine-readable
+  `reason` so clients (especially in-sprite agents holding a rotated
+  `$FOUNTAIN_TOKEN`) can tell a revoked key apart from one that never existed:
+
+      {"error": "API key has been revoked", "reason": "api_key_revoked"}
+      {"error": "Invalid or missing API key", "reason": "api_key_invalid"}
   """
 
   import Plug.Conn
@@ -24,11 +29,18 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
       Task.async(fn -> Accounts.touch_api_key(raw_key) end)
       assign(conn, :current_user, user)
     else
+      {:error, :revoked} ->
+        unauthorized(conn, "API key has been revoked", "api_key_revoked")
+
       _ ->
-        conn
-        |> put_status(:unauthorized)
-        |> json(%{error: "Invalid or missing API key"})
-        |> halt()
+        unauthorized(conn, "Invalid or missing API key", "api_key_invalid")
     end
+  end
+
+  defp unauthorized(conn, message, reason) do
+    conn
+    |> put_status(:unauthorized)
+    |> json(%{error: message, reason: reason})
+    |> halt()
   end
 end

--- a/apps/fountain/priv/sprite_skills/fountain/SKILL.md
+++ b/apps/fountain/priv/sprite_skills/fountain/SKILL.md
@@ -179,6 +179,6 @@ curl -s -X POST "$FOUNTAIN_BASE_URL/api/conversations/$CONV/terminate" \
 - **Parallelize spawn / poll / gather** with `xargs -P` — one provisioning takes ~5–15s, and there's no reason to do them sequentially.
 - **Don't recurse forever.** Spawned agents have the same skill. Cap depth with a `MAX_DEPTH` you check before spawning.
 - **Costs add up.** Every conversation provisions a real sandbox.
-- **Same `$FOUNTAIN_TOKEN`.** All spawned agents share the single-tenant admin token. Don't leak it outside the sprite.
+- **Re-read `$FOUNTAIN_TOKEN` from env on each call.** It's a per-conversation key scoped to this conversation's owner, not a long-lived admin token. Fountain rotates it on every fresh provision and every reattach (e.g. after a deploy or BEAM restart), revoking the previous value. If a request returns 401 with `"reason": "api_key_revoked"`, your cached copy is stale — re-source `$FOUNTAIN_TOKEN` from the environment before retrying. Don't leak it outside the sprite.
 - **API path is `/api/...`.** The bare `/conversations` redirects (302 → /login) for non-browser requests.
 - **Provenance is automatic.** `FOUNTAIN_CONVERSATION_ID` is always present in your sprite's environment. Every `POST /api/conversations` call that includes `X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID` records this conversation as the parent, letting the operator reconstruct the full spawn chain.

--- a/apps/fountain/test/fountain/accounts_additional_test.exs
+++ b/apps/fountain/test/fountain/accounts_additional_test.exs
@@ -165,17 +165,17 @@ defmodule Fountain.AccountsAdditionalTest do
       assert returned_user.id == user.id
     end
 
-    test "returns {:error, :invalid} for an unknown key" do
+    test "returns {:error, :not_found} for an unknown key" do
       fake_raw = "ftn_" <> String.duplicate("a", 64)
-      assert {:error, :invalid} = Accounts.get_user_by_api_key(fake_raw)
+      assert {:error, :not_found} = Accounts.get_user_by_api_key(fake_raw)
     end
 
-    test "returns {:error, :invalid} for a revoked key" do
+    test "returns {:error, :revoked} for a revoked key" do
       user = insert_verified_user()
       {:ok, {key, raw_key}} = Accounts.create_api_key(user.id, "revokeme")
       {:ok, _} = Accounts.revoke_api_key(user.id, key.id)
 
-      assert {:error, :invalid} = Accounts.get_user_by_api_key(raw_key)
+      assert {:error, :revoked} = Accounts.get_user_by_api_key(raw_key)
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
@@ -71,7 +71,7 @@ defmodule FountainWeb.ApiKeyControllerTest do
       assert conn.status == 204
 
       # Key is now revoked — authentication with the revoked key fails
-      assert {:error, :invalid} = Accounts.get_user_by_api_key(target_raw)
+      assert {:error, :revoked} = Accounts.get_user_by_api_key(target_raw)
     end
 
     test "returns 404 when key does not belong to user", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/plugs/tenant_api_auth_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/tenant_api_auth_test.exs
@@ -22,7 +22,9 @@ defmodule FountainWeb.Plugs.TenantAPIAuthTest do
 
       assert conn.halted
       assert conn.status == 401
-      assert Jason.decode!(conn.resp_body)["error"] =~ "missing"
+      body = Jason.decode!(conn.resp_body)
+      assert body["error"] =~ "missing"
+      assert body["reason"] == "api_key_invalid"
     end
 
     test "returns 401 for malformed Authorization header", %{conn: conn} do
@@ -33,9 +35,10 @@ defmodule FountainWeb.Plugs.TenantAPIAuthTest do
 
       assert conn.halted
       assert conn.status == 401
+      assert Jason.decode!(conn.resp_body)["reason"] == "api_key_invalid"
     end
 
-    test "returns 401 for wrong key", %{conn: conn} do
+    test "returns 401 with api_key_invalid for unknown key", %{conn: conn} do
       conn =
         conn
         |> authed_with_key("ftn_" <> String.duplicate("0", 64))
@@ -43,9 +46,10 @@ defmodule FountainWeb.Plugs.TenantAPIAuthTest do
 
       assert conn.halted
       assert conn.status == 401
+      assert Jason.decode!(conn.resp_body)["reason"] == "api_key_invalid"
     end
 
-    test "returns 401 for revoked key", %{conn: conn} do
+    test "returns 401 with api_key_revoked for revoked key", %{conn: conn} do
       user = insert_verified_user()
       {record, raw_key} = insert_api_key(user)
       {:ok, _} = Fountain.Accounts.revoke_api_key(user.id, record.id)
@@ -57,6 +61,9 @@ defmodule FountainWeb.Plugs.TenantAPIAuthTest do
 
       assert conn.halted
       assert conn.status == 401
+      body = Jason.decode!(conn.resp_body)
+      assert body["error"] =~ "revoked"
+      assert body["reason"] == "api_key_revoked"
     end
 
     test "cross-tenant key does not authenticate another user", %{conn: conn} do


### PR DESCRIPTION
## Summary

- Diagnosed from a real incident on conv `82096cfe-d982-4bcf-9689-10b89a2ed462`: an in-sprite agent hit a 401 trying to spawn a child conversation and confabulated *"The Fountain token isn't valid against this deployment. Falling back to parallel Claude subagents."* Root cause was a stale cached `$FOUNTAIN_TOKEN` (rotated by #75's per-conversation tokens on reattach) hitting a now-revoked `api_keys` row, plus a SKILL.md line that still described the old "shared admin token" model.
- `Accounts.get_user_by_api_key/1` now returns `{:error, :revoked}` distinct from `{:error, :not_found}`. The auth plug surfaces this as a machine-readable `reason` field in the 401 body (`api_key_revoked` vs `api_key_invalid`). HTTP status unchanged. Tests updated.
- `priv/sprite_skills/fountain/SKILL.md` no longer claims `$FOUNTAIN_TOKEN` is a "single-tenant admin token"; instead it tells the agent the token rotates on reattach, to re-read it from env on each call, and to look for `reason: "api_key_revoked"` to know its cached copy is stale.

## Design note

Distinguishing revoked from unknown does technically leak "this hash was once a key in this DB." The threat model: an attacker needs to already possess a revoked raw key to learn anything new from the distinction — and if they have a revoked raw key, they already saw it valid at some point. The diagnostic win for legit clients (especially long-running sprites) is worth the trade. Happy to revisit if security disagrees.

## Test plan

- [ ] CI green (compile/format/credo/test)
- [ ] Locally: `mix test apps/fountain/test/fountain_web/plugs/tenant_api_auth_test.exs` (requires Postgres; couldn't run on my box — Docker wasn't up)
- [ ] Manual against staging: revoke a key, hit `/api/agents`, confirm body contains `"reason":"api_key_revoked"`; hit with garbage Bearer, confirm `"reason":"api_key_invalid"`
- [ ] After deploy: re-run the original failing fan-out from conv `82096cfe…` and confirm the agent either succeeds (token still good) or sees a useful `api_key_revoked` instead of inventing a deployment-mismatch story

🤖 Generated with [Claude Code](https://claude.com/claude-code)