### PR TITLE
Live sidebar: push conversation updates via PubSub

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -228,6 +228,10 @@ defmodule Fountain.Conversations do
     conv
     |> Conversation.changeset(attrs)
     |> Repo.update()
+    |> tap(fn
+      {:ok, updated} -> broadcast_sidebar_update(updated.user_id)
+      _ -> :ok
+    end)
   end
 
   @doc """
@@ -235,9 +239,11 @@ defmodule Fountain.Conversations do
   if alive), then delete the conversation row. Cascades to turns and log
   events via the FK.
   """
-  def delete_conversation(%Conversation{id: id} = conv) do
+  def delete_conversation(%Conversation{id: id, user_id: user_id} = conv) do
     _ = Fountain.Conversations.ConversationServer.terminate(id)
-    Repo.delete(conv)
+    result = Repo.delete(conv)
+    if match?({:ok, _}, result), do: broadcast_sidebar_update(user_id)
+    result
   end
 
   # ── turns ─────────────────────────────────────────────────────────────────
@@ -481,6 +487,7 @@ defmodule Fountain.Conversations do
         broadcast_graph_update(root_id)
       end
 
+      broadcast_sidebar_update(user_id)
       {:ok, result}
     else
       nil -> {:error, :not_found}
@@ -516,6 +523,14 @@ defmodule Fountain.Conversations do
       Fountain.PubSub,
       "conversations:graph:#{root_id}",
       {:graph_updated}
+    )
+  end
+
+  defp broadcast_sidebar_update(user_id) when is_binary(user_id) do
+    Phoenix.PubSub.broadcast(
+      Fountain.PubSub,
+      "sidebar:#{user_id}",
+      {:sidebar_update, user_id}
     )
   end
 

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -7,17 +7,26 @@ defmodule FountainWeb.Layouts do
   alias Fountain.Conversations
 
   def app(assigns) do
+    # nav_conversations is pre-loaded into socket assigns by the live sidebar
+    # hook (mount_live_sidebar) for all authenticated LiveView pages. Fall back
+    # to a fresh DB fetch for any non-LiveView rendering context.
     convs =
-      case assigns[:current_user] do
-        %{id: user_id} ->
-          try do
-            Conversations.list_conversations_by_activity(user_id)
-          rescue
-            _ -> []
-          end
+      case assigns[:nav_conversations] do
+        convs when is_list(convs) ->
+          convs
 
         _ ->
-          []
+          case assigns[:current_user] do
+            %{id: user_id} ->
+              try do
+                Conversations.list_conversations_by_activity(user_id)
+              rescue
+                _ -> []
+              end
+
+            _ ->
+              []
+          end
       end
 
     assigns = assign(assigns, :nav_conversations, convs)

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -36,6 +36,7 @@ defmodule FountainWeb.Live.Hooks do
 
   alias Fountain.Accounts
   alias Fountain.Billing
+  alias Fountain.Conversations
 
   def on_mount(:require_authenticated_user, _params, session, socket) do
     socket = mount_current_user(session, socket)
@@ -52,7 +53,7 @@ defmodule FountainWeb.Live.Hooks do
          |> redirect(to: ~p"/auth/login")}
 
       true ->
-        {:cont, track_current_path(socket)}
+        {:cont, socket |> track_current_path() |> mount_live_sidebar()}
     end
   end
 
@@ -117,5 +118,35 @@ defmodule FountainWeb.Live.Hooks do
     |> Phoenix.LiveView.attach_hook(:current_path, :handle_params, fn _params, uri, socket ->
       {:cont, assign(socket, :current_path, URI.parse(uri).path)}
     end)
+  end
+
+  # Subscribe to the user's sidebar PubSub topic and load the initial
+  # conversation list into socket assigns. A handle_info hook intercepts
+  # {:sidebar_update, user_id} messages and refreshes nav_conversations
+  # in-place, so the sidebar re-renders without any per-LiveView code.
+  defp mount_live_sidebar(socket) do
+    user_id = socket.assigns.current_user.id
+
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Fountain.PubSub, "sidebar:#{user_id}")
+    end
+
+    socket
+    |> assign(:nav_conversations, load_sidebar_conversations(user_id))
+    |> attach_hook(:sidebar_nav, :handle_info, fn
+      {:sidebar_update, ^user_id}, socket ->
+        {:halt, assign(socket, :nav_conversations, load_sidebar_conversations(user_id))}
+
+      _, socket ->
+        {:cont, socket}
+    end)
+  end
+
+  defp load_sidebar_conversations(user_id) do
+    try do
+      Conversations.list_conversations_by_activity(user_id)
+    rescue
+      _ -> []
+    end
   end
 end


### PR DESCRIPTION
## Problem

The sidebar's "Recent" conversation list was a static snapshot fetched once at page load. Starting a new conversation, status changes (`pending` → `running` → `idle`), and deletions were invisible until the user navigated to another page.

## Solution

Three-file change, no new files, no per-LiveView boilerplate:

### `conversations.ex`
- Added `broadcast_sidebar_update/1` (private) — broadcasts `{:sidebar_update, user_id}` to `"sidebar:#{user_id}"` via Phoenix.PubSub
- Wired it into `update_conversation/2` (catches all status transitions from ConversationServer), `start_conversation/1` (new conversation appears immediately), and `delete_conversation/1` (gone immediately)

### `hooks.ex`
- `require_authenticated_user` now calls `mount_live_sidebar/1` on the happy path
- `mount_live_sidebar/1` subscribes to `"sidebar:#{user_id}"` when connected, does the initial DB load into `socket.assigns.nav_conversations`, and attaches a `handle_info` hook via `attach_hook/4` that refreshes the list on every `{:sidebar_update, user_id}` message — all transparent to individual LiveViews

### `layouts.ex`
- `app/1` now checks `assigns[:nav_conversations]` first; uses it when present (LiveView path, updated live) and falls back to a fresh fetch otherwise (non-LiveView rendering contexts)

## Result

The sidebar updates in real time for every open browser tab whenever a conversation is created, changes state, or is deleted. No polling, no per-LiveView `handle_info` implementations needed.