### PR TITLE
Sidebar: show turn count per conversation

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -98,13 +98,25 @@ defmodule Fountain.Conversations do
   end
 
   @doc "List conversations for `user_id`, ordered by most recently active."
+  @doc """
+  Populates the `turn_count` virtual field on each conversation by LEFT
+  JOINing a subquery that counts turns per conversation. This avoids an
+  N+1 and keeps the result a plain list of `%Conversation{}` structs.
+  """
   def list_conversations_by_activity(user_id) when is_binary(user_id) do
+    turn_counts =
+      from t in Turn,
+        group_by: t.conversation_id,
+        select: %{conversation_id: t.conversation_id, count: count(t.id)}
+
     Repo.all(
       from c in Conversation,
         where: c.user_id == ^user_id,
+        left_join: tc in subquery(turn_counts), on: tc.conversation_id == c.id,
         order_by: [desc: c.updated_at, desc: c.id],
-        preload: [:agent, turns: ^first_turn_query()]
+        select: %{c | turn_count: fragment("COALESCE(?, 0)", tc.count)}
     )
+    |> Repo.preload([:agent, turns: first_turn_query()])
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -20,6 +20,10 @@ defmodule Fountain.Conversations.Conversation do
     field :source, :string, default: "api"
     field :parent_conversation_id, :binary_id
     field :callback_api_key_id, :binary_id
+
+    # Populated by list_conversations_by_activity/1 — not persisted.
+    field :turn_count, :integer, virtual: true, default: 0
+
     belongs_to :user, User
     belongs_to :sandbox, Sandbox
     belongs_to :agent, Agent

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -315,8 +315,17 @@ defmodule FountainWeb.Layouts do
     task_label = if first_turn, do: truncate(first_turn.prompt, 55), else: nil
     agent_name = assigns.conv.agent && assigns.conv.agent.name
 
+    turn_count = Map.get(assigns.conv, :turn_count, 0) || 0
+
+    turns_label =
+      case turn_count do
+        0 -> nil
+        1 -> "1 turn"
+        n -> "#{n} turns"
+      end
+
     meta =
-      [agent_name, sidebar_relative_time(assigns.conv.updated_at)]
+      [agent_name, turns_label, sidebar_relative_time(assigns.conv.updated_at)]
       |> Enum.reject(&is_nil/1)
       |> Enum.join(" · ")
 


### PR DESCRIPTION
## What

Each sidebar conversation entry now shows how many turns it has in the meta line:

```
● Fix the auth bug
  Claude · 3 turns · 5m ago
```

Conversations with 0 turns (just created, no prompt yet) omit the turn label entirely.

## How

**`conversation.ex`** — adds `field :turn_count, :integer, virtual: true, default: 0`. Virtual fields aren't persisted; this is just a container for the query result.

**`conversations.ex`** — `list_conversations_by_activity/1` now LEFT JOINs a subquery that counts turns grouped by `conversation_id`, then uses `select: %{c | turn_count: fragment("COALESCE(?, 0)", tc.count)}` to populate the virtual field. No N+1 — it's one SQL query + the existing preload calls.

**`layouts.ex`** — `conv_nav_link/1` reads `turn_count`, formats it as `"N turn(s)"`, and inserts it between agent name and relative time in the meta string.