### PR TITLE
Sidebar quick filters: roots-only toggle + agent select

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -26,19 +26,43 @@ defmodule FountainWeb.Layouts do
           end
       end
 
+    roots_only = Map.get(assigns, :sidebar_roots_only, false)
+    agent_filter = Map.get(assigns, :sidebar_agent_filter, nil)
+
+    unique_agents =
+      convs
+      |> Enum.map(& &1.agent)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq_by(& &1.id)
+      |> Enum.sort_by(& &1.name)
+
+    # child_counts always uses the full unfiltered list so badges stay correct
+    # regardless of which filters are active.
     child_counts =
       convs
       |> Enum.map(& &1.parent_conversation_id)
       |> Enum.reject(&is_nil/1)
       |> Enum.frequencies()
 
-    groups = group_conversations_by_date(convs)
+    filtered_convs =
+      convs
+      |> then(fn cs ->
+        if roots_only, do: Enum.filter(cs, &is_nil(&1.parent_conversation_id)), else: cs
+      end)
+      |> then(fn cs ->
+        if agent_filter, do: Enum.filter(cs, &(&1.agent_id == agent_filter)), else: cs
+      end)
+
+    groups = group_conversations_by_date(filtered_convs)
 
     assigns =
       assign(assigns,
         nav_conversations: convs,
         nav_conversation_groups: groups,
-        child_counts: child_counts
+        child_counts: child_counts,
+        sidebar_roots_only: roots_only,
+        sidebar_agent_filter: agent_filter,
+        sidebar_unique_agents: unique_agents
       )
 
     ~H"""
@@ -94,6 +118,52 @@ defmodule FountainWeb.Layouts do
             <.nav_link href={~p"/environments"} label="Environments" current={@current_path} />
             <.nav_link href={~p"/vaults"} label="Vaults" current={@current_path} />
           </nav>
+
+          <%!-- Conversation filters --%>
+          <div class="px-2 pt-0.5 pb-1 flex items-center gap-1.5 shrink-0">
+            <button
+              type="button"
+              phx-click="sidebar_toggle_roots_only"
+              title={if @sidebar_roots_only, do: "Showing roots only — click to show all", else: "Show root conversations only"}
+              class={[
+                "shrink-0 inline-flex items-center gap-1 rounded px-2 py-1",
+                "text-[11px] font-medium leading-none transition-colors border",
+                if(@sidebar_roots_only,
+                  do:
+                    "bg-[var(--color-bg-2)] text-[var(--color-text-primary)] border-[var(--color-text-muted)]/40",
+                  else:
+                    "bg-transparent text-[var(--color-text-muted)] border-[var(--color-border)] hover:text-[var(--color-text-secondary)]"
+                )
+              ]}
+            >
+              <svg class="size-3 shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm0 2.122a2.25 2.25 0 1 0-1.5 0v.878A2.25 2.25 0 0 0 5.75 8.5h1.5v2.128a2.251 2.251 0 1 0 1.5 0V8.5h1.5a2.25 2.25 0 0 0 2.25-2.25v-.878a2.25 2.25 0 1 0-1.5 0v.878a.75.75 0 0 1-.75.75h-4.5A.75.75 0 0 1 5 6.25v-.878zm3.75 7.378a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm3-8.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0z" />
+              </svg>
+              Roots
+            </button>
+
+            <form
+              :if={length(@sidebar_unique_agents) > 1}
+              phx-change="sidebar_set_agent_filter"
+              class="flex-1 min-w-0"
+            >
+              <select
+                name="agent_id"
+                class="w-full rounded px-1.5 py-1 text-[11px] leading-none
+                       bg-[var(--color-bg-0)] border border-[var(--color-border)]
+                       text-[var(--color-text-muted)] focus:outline-none cursor-pointer"
+              >
+                <option value="">All agents</option>
+                <option
+                  :for={agent <- @sidebar_unique_agents}
+                  value={agent.id}
+                  selected={@sidebar_agent_filter == agent.id}
+                >
+                  {agent.name}
+                </option>
+              </select>
+            </form>
+          </div>
 
           <%!-- Recent conversations (scrollable, grouped by date) --%>
           <div class="flex-1 min-h-0 overflow-y-auto px-2 py-0.5">
@@ -367,7 +437,7 @@ defmodule FountainWeb.Layouts do
 
         <span
           :if={@meta != ""}
-          class="block text-[11px] text-[var(--color-text-muted)] truncate mt-0.5"
+          class="block text-[11px] text-[var(--color-text-muted)] truncate"
         >
           {@meta}
         </span>

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -124,6 +124,10 @@ defmodule FountainWeb.Live.Hooks do
   # conversation list into socket assigns. A handle_info hook intercepts
   # {:sidebar_update, user_id} messages and refreshes nav_conversations
   # in-place, so the sidebar re-renders without any per-LiveView code.
+  #
+  # A handle_event hook intercepts the two sidebar filter events
+  # (sidebar_toggle_roots_only, sidebar_set_agent_filter) so they never
+  # reach — and confuse — the current LiveView's own handle_event.
   defp mount_live_sidebar(socket) do
     user_id = socket.assigns.current_user.id
 
@@ -133,11 +137,24 @@ defmodule FountainWeb.Live.Hooks do
 
     socket
     |> assign(:nav_conversations, load_sidebar_conversations(user_id))
+    |> assign(:sidebar_roots_only, false)
+    |> assign(:sidebar_agent_filter, nil)
     |> attach_hook(:sidebar_nav, :handle_info, fn
       {:sidebar_update, ^user_id}, socket ->
         {:halt, assign(socket, :nav_conversations, load_sidebar_conversations(user_id))}
 
       _, socket ->
+        {:cont, socket}
+    end)
+    |> attach_hook(:sidebar_filters, :handle_event, fn
+      "sidebar_toggle_roots_only", _params, socket ->
+        {:halt, assign(socket, :sidebar_roots_only, !socket.assigns.sidebar_roots_only)}
+
+      "sidebar_set_agent_filter", %{"agent_id" => agent_id}, socket ->
+        filter = if agent_id == "", do: nil, else: agent_id
+        {:halt, assign(socket, :sidebar_agent_filter, filter)}
+
+      _event, _params, socket ->
         {:cont, socket}
     end)
   end


### PR DESCRIPTION
Adds two quick filters to the conversation list and tightens the per-item spacing.

**Filters bar** (between primary nav and conversation groups):
- **Roots toggle** — `phx-click` pill that hides child/branch conversations, showing only root ones. Uses a `handle_event` hook in `hooks.ex` so no per-LiveView boilerplate is needed.
- **Agent select** — compact `<select>` that filters to a single agent. Only rendered when there are 2+ distinct agents. Also driven by the same hook.

Both filters reset to defaults on page reload (state lives in socket assigns, not localStorage).

**Spacing**: removed `mt-0.5` from the meta (agent · time) line inside each conversation row to close the gap between the task label and the meta line.

**Implementation notes**:
- `attach_hook(:sidebar_filters, :handle_event, ...)` intercepts the two filter events before they reach the LiveView, so nothing leaks.
- `child_counts` is computed from the full unfiltered list so branch badges stay correct when roots-only is active.
- Agent select is built from unique agents in the already-loaded conversation list — no extra queries.