### PR TITLE
Reorganize sidebar: move tools below conversations, add New Conversation button

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -246,6 +246,9 @@ defmodule FountainWeb.Layouts do
 
           <%!-- Tools section --%>
           <div class="border-t border-[var(--color-border)] px-2 py-1.5 space-y-0.5 shrink-0">
+            <p class="px-3 pt-1 pb-0.5 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] font-medium">
+              Tools
+            </p>
             <.nav_link href={~p"/agents"} label="Agents" current={@current_path} />
             <.nav_link href={~p"/environments"} label="Environments" current={@current_path} />
             <.nav_link href={~p"/vaults"} label="Vaults" current={@current_path} />

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -138,10 +138,18 @@ defmodule FountainWeb.Layouts do
             aria-label="Primary navigation"
           >
             <.nav_link href={~p"/conversations"} label="Conversations" current={@current_path} />
-            <.nav_link href={~p"/agents"} label="Agents" current={@current_path} />
-            <.nav_link href={~p"/environments"} label="Environments" current={@current_path} />
-            <.nav_link href={~p"/vaults"} label="Vaults" current={@current_path} />
           </nav>
+
+          <%!-- New conversation --%>
+          <div class="px-2 pb-1 shrink-0">
+            <.link
+              navigate={~p"/conversations/new"}
+              class="block w-full rounded-md px-3 py-1.5 text-sm font-medium text-center
+                     bg-indigo-600 text-white hover:bg-indigo-500 transition-colors"
+            >
+              + New Conversation
+            </.link>
+          </div>
 
           <%!-- Conversation filters --%>
           <div class="px-2 pt-0.5 pb-1 flex items-center gap-1.5 shrink-0">
@@ -234,6 +242,13 @@ defmodule FountainWeb.Layouts do
                 child_count={Map.get(@child_counts, conv.id, 0)}
               />
             </details>
+          </div>
+
+          <%!-- Tools section --%>
+          <div class="border-t border-[var(--color-border)] px-2 py-1.5 space-y-0.5 shrink-0">
+            <.nav_link href={~p"/agents"} label="Agents" current={@current_path} />
+            <.nav_link href={~p"/environments"} label="Environments" current={@current_path} />
+            <.nav_link href={~p"/vaults"} label="Vaults" current={@current_path} />
           </div>
 
           <%!-- Settings section --%>


### PR DESCRIPTION
## Summary

- Moves Agents, Environments, and Vaults from the top primary nav to a new **Tools** section below the conversation list (directly above Settings)
- Adds a full-width **+ New Conversation** button in the sidebar, between the Conversations nav link and the conversation filters
- Tools section uses the same `border-t` separator and section label pattern as the Settings section

## Changes

Single file: `apps/fountain/lib/fountain_web/components/layouts.ex`

## Test plan

- [ ] Sidebar primary nav shows only "Conversations"
- [ ] "+ New Conversation" button appears below the Conversations link, navigates to `/conversations/new`
- [ ] Conversation filters (Roots toggle, agent dropdown) appear below the button, unchanged
- [ ] Recent conversations list is unchanged
- [ ] "Tools" label and Agents/Environments/Vaults links appear below the conversation list, above Settings
- [ ] Active-highlight on Agents/Environments/Vaults links still works when on those pages
- [ ] Settings section is unchanged
- [ ] Mobile sidebar toggle works correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)