### PR TITLE
feat: persist sidebar roots-only filter in localStorage

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -154,6 +154,8 @@ defmodule FountainWeb.Layouts do
           <%!-- Conversation filters --%>
           <div class="px-2 pt-0.5 pb-1 flex items-center gap-1.5 shrink-0">
             <button
+              id="roots-filter-persist"
+              phx-hook="RootsFilterPersist"
               type="button"
               phx-click="sidebar_toggle_roots_only"
               title={if @sidebar_roots_only, do: "Showing roots only — click to show all", else: "Show root conversations only"}

--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -268,6 +268,22 @@
               document.addEventListener("keydown", this.trap);
             },
             destroyed() { document.removeEventListener("keydown", this.trap); }
+          },
+          // ── Roots filter persistence (localStorage) ─────────────────────────
+          RootsFilterPersist: {
+            mounted() {
+              const saved = localStorage.getItem("fountain-sidebar-roots-only");
+              if (saved === "true") {
+                this.pushEvent("restore_roots_only", {});
+              }
+              this._handleRootsOnly = ({ value }) => {
+                localStorage.setItem("fountain-sidebar-roots-only", value);
+              };
+              this.handleEvent("roots_only_changed", this._handleRootsOnly);
+            },
+            destroyed() {
+              this._handleRootsOnly = null;
+            }
           }
         };
 

--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -276,13 +276,12 @@
               if (saved === "true") {
                 this.pushEvent("restore_roots_only", {});
               }
-              this._handleRootsOnly = ({ value }) => {
+              this._removeRootsOnly = this.handleEvent("roots_only_changed", ({ value }) => {
                 localStorage.setItem("fountain-sidebar-roots-only", value);
-              };
-              this.handleEvent("roots_only_changed", this._handleRootsOnly);
+              });
             },
             destroyed() {
-              this._handleRootsOnly = null;
+              if (this._removeRootsOnly) this._removeRootsOnly();
             }
           }
         };

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -147,6 +147,9 @@ defmodule FountainWeb.Live.Hooks do
         {:cont, socket}
     end)
     |> attach_hook(:sidebar_filters, :handle_event, fn
+      "restore_roots_only", _params, socket ->
+        {:halt, assign(socket, :sidebar_roots_only, true)}
+
       "sidebar_toggle_roots_only", _params, socket ->
         {:halt, assign(socket, :sidebar_roots_only, !socket.assigns.sidebar_roots_only)}
 

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -151,7 +151,11 @@ defmodule FountainWeb.Live.Hooks do
         {:halt, assign(socket, :sidebar_roots_only, true)}
 
       "sidebar_toggle_roots_only", _params, socket ->
-        {:halt, assign(socket, :sidebar_roots_only, !socket.assigns.sidebar_roots_only)}
+        next = !socket.assigns.sidebar_roots_only
+        {:halt,
+         socket
+         |> assign(:sidebar_roots_only, next)
+         |> push_event("roots_only_changed", %{value: to_string(next)})}
 
       "sidebar_set_agent_filter", %{"agent_id" => agent_id}, socket ->
         filter = if agent_id == "", do: nil, else: agent_id

--- a/apps/fountain/test/fountain_web/live/hooks_test.exs
+++ b/apps/fountain/test/fountain_web/live/hooks_test.exs
@@ -138,6 +138,39 @@ defmodule FountainWeb.Live.HooksTest do
     end
   end
 
+  # ── sidebar roots filter persistence ────────────────────────────────────────
+
+  describe "sidebar roots filter persistence" do
+    setup do
+      user = insert_verified_user()
+      %{user: user}
+    end
+
+    @tag :restore_roots_only
+    test "restore_roots_only sets sidebar_roots_only to true", %{conn: conn, user: user} do
+      conn = login_user(conn, user)
+      {:ok, view, html} = live(conn, ~p"/conversations")
+
+      # default is false — button shows "Show root conversations only"
+      assert html =~ "Show root conversations only"
+
+      render_hook(view, "restore_roots_only", %{})
+
+      assert render(view) =~ "Showing roots only"
+    end
+
+    @tag :restore_roots_only
+    test "restore_roots_only is idempotent when already true", %{conn: conn, user: user} do
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations")
+
+      render_hook(view, "restore_roots_only", %{})
+      render_hook(view, "restore_roots_only", %{})
+
+      assert render(view) =~ "Showing roots only"
+    end
+  end
+
   # ── Direct on_mount unit tests ───────────────────────────────────────────────
   # The :browser_authenticated plug redirects unauthenticated requests before
   # reaching LiveView, so the is_nil(user) branches are never triggered through

--- a/apps/fountain/test/fountain_web/live/hooks_test.exs
+++ b/apps/fountain/test/fountain_web/live/hooks_test.exs
@@ -169,6 +169,27 @@ defmodule FountainWeb.Live.HooksTest do
 
       assert render(view) =~ "Showing roots only"
     end
+
+    @tag :push_roots_only_changed
+    test "sidebar_toggle_roots_only pushes roots_only_changed with value true", %{conn: conn, user: user} do
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations")
+
+      view |> element("[phx-click='sidebar_toggle_roots_only']") |> render_click()
+      assert_push_event(view, "roots_only_changed", %{value: "true"})
+    end
+
+    @tag :push_roots_only_changed
+    test "sidebar_toggle_roots_only pushes roots_only_changed with value false when toggled twice", %{conn: conn, user: user} do
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations")
+
+      view |> element("[phx-click='sidebar_toggle_roots_only']") |> render_click()
+      assert_push_event(view, "roots_only_changed", %{value: "true"})
+
+      view |> element("[phx-click='sidebar_toggle_roots_only']") |> render_click()
+      assert_push_event(view, "roots_only_changed", %{value: "false"})
+    end
   end
 
   # ── Direct on_mount unit tests ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `RootsFilterPersist` JS hook that reads `localStorage["fountain-sidebar-roots-only"]` on mount and restores the filter state without a page flash
- Adds `restore_roots_only` event handler in `hooks.ex` to set `sidebar_roots_only: true` from the client
- Updates `sidebar_toggle_roots_only` to push a `roots_only_changed` event back to the hook so it can persist the new value
- Wires the hook to the roots filter button via `id="roots-filter-persist"` + `phx-hook="RootsFilterPersist"` in `layouts.ex`

Mirrors the `ViewModePersist` pattern from #89.

## Test Plan

- [ ] 4 new tests in `hooks_test.exs` covering: restore sets true, restore is idempotent, toggle pushes `"true"`, double-toggle pushes `"false"`
- [ ] Manual: click Roots, reload — sidebar stays in roots-only mode
- [ ] Manual: click Roots to deactivate, navigate — sidebar shows all conversations
- [ ] Manual: DevTools → LocalStorage → verify `fountain-sidebar-roots-only` is `"true"` or `"false"`
- [ ] Manual: delete key from DevTools, reload — defaults to showing all conversations