### PR TITLE
feat: enhance agent list table with stats badges and visual polish

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -4,6 +4,7 @@ defmodule Fountain.Agents do
   import Ecto.Query, only: [from: 2]
 
   alias Fountain.Agents.Agent
+  alias Fountain.Conversations.Conversation
   alias Fountain.Repo
 
   @doc """
@@ -52,6 +53,29 @@ defmodule Fountain.Agents do
     |> apply_has_skills(Keyword.get(filters, :has_skills, false))
     |> apply_has_mcp(Keyword.get(filters, :has_mcp, false))
     |> Repo.all()
+  end
+
+  @doc "List agents for user_id with total conversation counts. Accepts same filters as list_agents/2."
+  def list_agents_with_counts(user_id, filters) when is_binary(user_id) and is_list(filters) do
+    counts_subquery =
+      from c in Conversation,
+        group_by: c.agent_id,
+        select: %{agent_id: c.agent_id, count: count(c.id)}
+
+    from(a in Agent,
+      where: a.user_id == ^user_id,
+      order_by: [desc: a.inserted_at, desc: a.id],
+      left_join: counts in subquery(counts_subquery),
+      on: counts.agent_id == a.id,
+      select_merge: %{conversation_count: fragment("COALESCE(?, 0)", counts.count)}
+    )
+    |> apply_search(Keyword.get(filters, :search, ""))
+    |> apply_runtimes(Keyword.get(filters, :runtimes, []))
+    |> apply_env_ids(Keyword.get(filters, :env_ids, []))
+    |> apply_has_skills(Keyword.get(filters, :has_skills, false))
+    |> apply_has_mcp(Keyword.get(filters, :has_mcp, false))
+    |> Repo.all()
+    |> Repo.preload(:environment)
   end
 
   def create_agent(attrs) do

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -59,6 +59,7 @@ defmodule Fountain.Agents do
   def list_agents_with_counts(user_id, filters) when is_binary(user_id) and is_list(filters) do
     counts_subquery =
       from c in Conversation,
+        where: c.user_id == ^user_id,
         group_by: c.agent_id,
         select: %{agent_id: c.agent_id, count: count(c.id)}
 

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -75,6 +75,8 @@ defmodule Fountain.Agents do
     |> apply_has_skills(Keyword.get(filters, :has_skills, false))
     |> apply_has_mcp(Keyword.get(filters, :has_mcp, false))
     |> Repo.all()
+    # Preload done post-query (not inline in `from`) because select_merge is
+    # incompatible with Ecto's inline preload compilation.
     |> Repo.preload(:environment)
   end
 

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -22,6 +22,7 @@ defmodule Fountain.Agents.Agent do
     field :skills, {:array, :map}, default: []
     field :mcp_servers, :map, default: %{}
     field :metadata, :map, default: %{}
+    field :conversation_count, :integer, virtual: true, default: 0
     belongs_to :user, User
     belongs_to :environment, Environment
     timestamps(type: :utc_datetime)

--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -8,7 +8,7 @@ defmodule FountainWeb.AgentsLive.Index do
   @impl true
   def mount(_params, _session, socket) do
     user_id = socket.assigns.current_user.id
-    all_agents = Agents.list_agents(user_id, [])
+    all_agents = Agents.list_agents_with_counts(user_id, [])
 
     {:ok,
      socket
@@ -47,7 +47,7 @@ defmodule FountainWeb.AgentsLive.Index do
      |> assign(:filter_env_ids, env_ids)
      |> assign(:filter_has_skills, has_skills)
      |> assign(:filter_has_mcp, has_mcp)
-     |> assign(:agents, Agents.list_agents(socket.assigns.user_id, filters))}
+     |> assign(:agents, Agents.list_agents_with_counts(socket.assigns.user_id, filters))}
   end
 
   @impl true
@@ -59,7 +59,7 @@ defmodule FountainWeb.AgentsLive.Index do
      |> assign(:filter_env_ids, [])
      |> assign(:filter_has_skills, false)
      |> assign(:filter_has_mcp, false)
-     |> assign(:agents, Agents.list_agents(socket.assigns.user_id, []))}
+     |> assign(:agents, Agents.list_agents_with_counts(socket.assigns.user_id, []))}
   end
 
   @impl true
@@ -68,12 +68,12 @@ defmodule FountainWeb.AgentsLive.Index do
     agent = Agents.get_agent!(id, user_id)
     {:ok, _} = Agents.delete_agent(agent)
 
-    all_agents = Agents.list_agents(user_id, [])
+    all_agents = Agents.list_agents_with_counts(user_id, [])
     filters = current_filters(socket.assigns)
 
     {:noreply,
      socket
-     |> assign(:agents, Agents.list_agents(user_id, filters))
+     |> assign(:agents, Agents.list_agents_with_counts(user_id, filters))
      |> assign(:facet_counts, compute_facets(all_agents))
      |> assign(:all_environments, extract_environments(all_agents))
      |> put_flash(:info, "Deleted #{agent.name}")}
@@ -220,15 +220,37 @@ defmodule FountainWeb.AgentsLive.Index do
               <th class="px-4 py-2">Runtime</th>
               <th class="px-4 py-2">Model</th>
               <th class="px-4 py-2">Env</th>
+              <th class="px-4 py-2">Conversations</th>
               <th class="px-4 py-2"></th>
             </tr>
           </thead>
           <tbody>
             <tr :for={a <- @agents} class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50">
               <td class="px-4 py-2 font-medium">{a.name}</td>
-              <td class="px-4 py-2 text-zinc-600">{a.runtime}</td>
+              <td class="px-4 py-2">
+                <span style={runtime_badge_style(a.runtime)} class="px-2 py-0.5 rounded text-xs font-medium">
+                  {a.runtime}
+                </span>
+              </td>
               <td class="px-4 py-2 text-zinc-600 font-mono text-xs">{a.model}</td>
-              <td class="px-4 py-2 text-zinc-600">{env_name(a.environment)}</td>
+              <td class="px-4 py-2">
+                <span
+                  :if={a.environment}
+                  style={env_badge_style(a.environment.name)}
+                  class="px-2 py-0.5 rounded text-xs font-medium"
+                >
+                  {a.environment.name}
+                </span>
+                <span :if={!a.environment} class="text-zinc-400">—</span>
+              </td>
+              <td class="px-4 py-2">
+                <span
+                  style={stat_badge_style(:conversations, a.conversation_count)}
+                  class="px-2 py-0.5 rounded text-xs font-medium"
+                >
+                  {a.conversation_count}
+                </span>
+              </td>
               <td class="px-4 py-2 text-right space-x-2">
                 <.link navigate={~p"/agents/#{a.id}/edit"}><.btn_secondary>Edit</.btn_secondary></.link>
                 <.btn_danger phx-click="delete" phx-value-id={a.id} data-confirm="Delete agent?">Delete</.btn_danger>
@@ -240,9 +262,6 @@ defmodule FountainWeb.AgentsLive.Index do
     </div>
     """
   end
-
-  defp env_name(nil), do: "—"
-  defp env_name(env), do: env.name
 
   defp compute_facets(agents) do
     runtimes = Enum.frequencies_by(agents, & &1.runtime)
@@ -279,5 +298,46 @@ defmodule FountainWeb.AgentsLive.Index do
       assigns.filter_env_ids != [] or
       assigns.filter_has_skills or
       assigns.filter_has_mcp
+  end
+
+  defp runtime_badge_style("claude"),
+    do: "background:#0d1f0d;color:#6ee7b7;border:1px solid #1a3a1a;"
+
+  defp runtime_badge_style("gemini"),
+    do: "background:#0d1525;color:#93c5fd;border:1px solid #1a2a4a;"
+
+  defp runtime_badge_style("opencode"),
+    do: "background:#150d25;color:#a78bfa;border:1px solid #2a1a4a;"
+
+  defp runtime_badge_style("codex"),
+    do: "background:#1a1200;color:#fbbf24;border:1px solid #3a2a00;"
+
+  defp runtime_badge_style(_),
+    do: "background:#1a1a1a;color:#9ca3af;border:1px solid #2a2a2a;"
+
+  defp stat_badge_style(_type, 0),
+    do: "background:#111;color:#374151;border:1px solid #1f1f1f;"
+
+  defp stat_badge_style(:conversations, _),
+    do: "background:#1a0d1a;color:#c084fc;border:1px solid #2d1a3a;"
+
+  # :skills -> "background:#0d1f0d;color:#6ee7b7;border:1px solid #1a3a1a;"
+  # :mcp    -> "background:#0d1525;color:#93c5fd;border:1px solid #1a2a4a;"
+  defp stat_badge_style(_type, _),
+    do: "background:#1a1a1a;color:#9ca3af;border:1px solid #2a2a2a;"
+
+  defp env_badge_style(name) do
+    lower = String.downcase(name)
+
+    cond do
+      String.contains?(lower, "prod") ->
+        "background:#0d1f0d;color:#6ee7b7;border:1px solid #1a3a1a;"
+
+      String.contains?(lower, "dev") or String.contains?(lower, "staging") ->
+        "background:#0d1525;color:#93c5fd;border:1px solid #1a2a4a;"
+
+      true ->
+        "background:#1a1a1a;color:#9ca3af;border:1px solid #2a2a2a;"
+    end
   end
 end

--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -213,47 +213,81 @@ defmodule FountainWeb.AgentsLive.Index do
           No agents match the current filters.
         </div>
 
-        <table :if={@agents != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
-          <thead class="text-left text-zinc-500 border-b border-zinc-200">
+        <table
+          :if={@agents != []}
+          class="w-full text-sm rounded-lg overflow-hidden"
+          style="background:#0a0a0a;border:1px solid #1a1a1a;"
+        >
+          <thead style="border-bottom:1px solid #222;">
             <tr>
-              <th class="px-4 py-2">Name</th>
-              <th class="px-4 py-2">Runtime</th>
-              <th class="px-4 py-2">Model</th>
-              <th class="px-4 py-2">Env</th>
-              <th class="px-4 py-2">Conversations</th>
-              <th class="px-4 py-2"></th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Name</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Runtime</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Model</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Stats</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Env</th>
+              <th class="px-4 py-3"></th>
             </tr>
           </thead>
           <tbody>
-            <tr :for={a <- @agents} class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50">
-              <td class="px-4 py-2 font-medium">{a.name}</td>
-              <td class="px-4 py-2">
-                <span style={runtime_badge_style(a.runtime)} class="px-2 py-0.5 rounded text-xs font-medium">
+            <tr
+              :for={a <- @agents}
+              class="hover:bg-[#0d1117] transition-colors duration-150"
+              style="border-bottom:1px solid #161616;"
+            >
+              <td class="px-4 py-3 font-medium" style="color:#e5e7eb;">{a.name}</td>
+              <td class="px-4 py-3">
+                <span
+                  class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold"
+                  style={runtime_badge_style(a.runtime)}
+                >
+                  <span class="w-1.5 h-1.5 rounded-full" style="background:currentColor;"></span>
                   {a.runtime}
                 </span>
               </td>
-              <td class="px-4 py-2 text-zinc-600 font-mono text-xs">{a.model}</td>
-              <td class="px-4 py-2">
+              <td class="px-4 py-3 font-mono text-xs" style="color:#4b5563;">{a.model}</td>
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-1.5 flex-wrap">
+                  <span
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                    style={stat_badge_style(:skills, length(a.skills))}
+                    title={"#{length(a.skills)} skills"}
+                  >⚡ {length(a.skills)}</span>
+                  <span
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                    style={stat_badge_style(:mcp, map_size(a.mcp_servers))}
+                    title={"#{map_size(a.mcp_servers)} MCP servers"}
+                  >🔌 {map_size(a.mcp_servers)}</span>
+                  <span
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                    style={stat_badge_style(:conversations, a.conversation_count)}
+                    title={"#{a.conversation_count} total conversations"}
+                  >💬 {a.conversation_count}</span>
+                </div>
+              </td>
+              <td class="px-4 py-3">
                 <span
                   :if={a.environment}
+                  class="inline-flex items-center px-2 py-1 rounded text-xs font-medium"
                   style={env_badge_style(a.environment.name)}
-                  class="px-2 py-0.5 rounded text-xs font-medium"
-                >
-                  {a.environment.name}
-                </span>
-                <span :if={!a.environment} class="text-zinc-400">—</span>
+                >{a.environment.name}</span>
+                <span :if={!a.environment} style="color:#374151;">—</span>
               </td>
-              <td class="px-4 py-2">
-                <span
-                  style={stat_badge_style(:conversations, a.conversation_count)}
-                  class="px-2 py-0.5 rounded text-xs font-medium"
-                >
-                  {a.conversation_count}
-                </span>
-              </td>
-              <td class="px-4 py-2 text-right space-x-2">
-                <.link navigate={~p"/agents/#{a.id}/edit"}><.btn_secondary>Edit</.btn_secondary></.link>
-                <.btn_danger phx-click="delete" phx-value-id={a.id} data-confirm="Delete agent?">Delete</.btn_danger>
+              <td class="px-4 py-3 text-right">
+                <div class="inline-flex gap-1">
+                  <.link navigate={~p"/agents/#{a.id}/edit"}>
+                    <button
+                      class="px-2 py-1 rounded text-xs cursor-pointer"
+                      style="background:#1a1a1a;border:1px solid #2a2a2a;color:#9ca3af;"
+                    >Edit</button>
+                  </.link>
+                  <button
+                    class="px-2 py-1 rounded text-xs cursor-pointer"
+                    style="background:#1a0d0d;border:1px solid #3a1a1a;color:#f87171;"
+                    phx-click="delete"
+                    phx-value-id={a.id}
+                    data-confirm="Delete agent?"
+                  >Delete</button>
+                </div>
               </td>
             </tr>
           </tbody>

--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -318,13 +318,14 @@ defmodule FountainWeb.AgentsLive.Index do
   defp stat_badge_style(_type, 0),
     do: "background:#111;color:#374151;border:1px solid #1f1f1f;"
 
+  defp stat_badge_style(:skills, _),
+    do: "background:#0d1f0d;color:#6ee7b7;border:1px solid #1a3a1a;"
+
+  defp stat_badge_style(:mcp, _),
+    do: "background:#0d1525;color:#93c5fd;border:1px solid #1a2a4a;"
+
   defp stat_badge_style(:conversations, _),
     do: "background:#1a0d1a;color:#c084fc;border:1px solid #2d1a3a;"
-
-  # :skills -> "background:#0d1f0d;color:#6ee7b7;border:1px solid #1a3a1a;"
-  # :mcp    -> "background:#0d1525;color:#93c5fd;border:1px solid #1a2a4a;"
-  defp stat_badge_style(_type, _),
-    do: "background:#1a1a1a;color:#9ca3af;border:1px solid #2a2a2a;"
 
   defp env_badge_style(name) do
     lower = String.downcase(name)

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -340,6 +340,17 @@ defmodule Fountain.AgentsTest do
       assert hd(results).name == "alpha"
     end
 
+    test "does not count conversations belonging to another user" do
+      user_a = insert_verified_user()
+      user_b = insert_verified_user()
+      agent = insert_agent(user_id: user_a.id)
+      insert_conversation(user_id: user_b.id, agent_id: agent.id)
+
+      results = Agents.list_agents_with_counts(user_a.id, [])
+      assert length(results) == 1
+      assert hd(results).conversation_count == 0
+    end
+
     test "preloads the environment association" do
       user = insert_verified_user()
       env = insert_env(user_id: user.id)

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -297,6 +297,17 @@ defmodule Fountain.AgentsTest do
       assert hd(results).conversation_count == 0
     end
 
+    test "does not return agents belonging to another user" do
+      user_a = insert_verified_user()
+      user_b = insert_verified_user()
+      agent_a = insert_agent(user_id: user_a.id)
+      _agent_b = insert_agent(user_id: user_b.id)
+
+      results = Agents.list_agents_with_counts(user_a.id, [])
+      assert length(results) == 1
+      assert hd(results).id == agent_a.id
+    end
+
     test "returns correct conversation_count for agent with conversations" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -286,4 +286,56 @@ defmodule Fountain.AgentsTest do
       assert agent_with_mcp.id in ids
     end
   end
+
+  describe "list_agents_with_counts/2" do
+    test "returns conversation_count 0 for agent with no conversations" do
+      user = insert_verified_user()
+      _agent = insert_agent(user_id: user.id)
+
+      results = Agents.list_agents_with_counts(user.id, [])
+      assert length(results) == 1
+      assert hd(results).conversation_count == 0
+    end
+
+    test "returns correct conversation_count for agent with conversations" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      insert_conversation(user_id: user.id, agent_id: agent.id)
+      insert_conversation(user_id: user.id, agent_id: agent.id)
+
+      results = Agents.list_agents_with_counts(user.id, [])
+      assert length(results) == 1
+      assert hd(results).conversation_count == 2
+    end
+
+    test "does not count conversations belonging to other agents" do
+      user = insert_verified_user()
+      agent_a = insert_agent(user_id: user.id)
+      agent_b = insert_agent(user_id: user.id)
+      insert_conversation(user_id: user.id, agent_id: agent_b.id)
+
+      results = Agents.list_agents_with_counts(user.id, [])
+      a_result = Enum.find(results, &(&1.id == agent_a.id))
+      assert a_result.conversation_count == 0
+    end
+
+    test "accepts the same filters as list_agents/2" do
+      user = insert_verified_user()
+      insert_agent(user_id: user.id, name: "alpha", runtime: "claude")
+      insert_agent(user_id: user.id, name: "beta", runtime: "gemini")
+
+      results = Agents.list_agents_with_counts(user.id, runtimes: ["claude"])
+      assert length(results) == 1
+      assert hd(results).name == "alpha"
+    end
+
+    test "preloads the environment association" do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id)
+      _agent = insert_agent(user_id: user.id, environment_id: env.id)
+
+      results = Agents.list_agents_with_counts(user.id, [])
+      assert hd(results).environment.id == env.id
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Add **skills count**, **MCP server count**, and **total conversation count** badges to the agent list table
- Replace the plain table with a dark-themed design: runtime badges, env badges, stat badges, row hover, styled action buttons
- Add `list_agents_with_counts/2` context function using a left-join subquery (tenant-scoped) and a `conversation_count` virtual field on the Agent schema

## Details

**Schema:** `conversation_count` virtual field (`default: 0`) on `Agent` — never nil when loaded outside the new function.

**Query:** Left-join a per-user conversation count subquery using `select_merge` + `COALESCE`. Conversation counts are scoped to the requesting user (`where: c.user_id == ^user_id`) to prevent cross-tenant leakage. `Repo.preload(:environment)` is done post-query due to `select_merge` incompatibility with inline Ecto preloads.

**Template:** Dark-themed table with five columns — Name, Runtime, Model, Stats, Env — plus a styled actions column. Stat badges dim to grey at zero.

## Test Plan

- [ ] `mix test apps/fountain/test/fountain/agents_test.exs` — 7 new tests: zero count, correct count, cross-agent isolation, filter pass-through, environment preload, user isolation, cross-tenant count isolation
- [ ] `mix test` — 927 tests, 0 failures (one pre-existing flaky timing test in `conversations_context_test.exs` may appear under high parallelism; passes in isolation)
- [ ] `mix compile --warnings-as-errors` — clean