### PR TITLE
feat: improve environments and vaults list views with dark theme and richer info

### DIFF
--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -3,6 +3,7 @@ defmodule Fountain.Environments do
 
   import Ecto.Query, only: [from: 2]
 
+  alias Fountain.Agents.Agent
   alias Fountain.Environments.{Environment, Secret}
   alias Fountain.Repo
 
@@ -29,6 +30,50 @@ defmodule Fountain.Environments do
         where: e.user_id == ^user_id,
         order_by: [desc: e.inserted_at, desc: e.id]
     )
+  end
+
+  @doc """
+  List environments scoped to user, with `:secret_count` and `:agent_count`
+  attached as virtual fields via two lightweight aggregation queries.
+  """
+  def list_environments_with_counts(user_id) when is_binary(user_id) do
+    secret_counts_query =
+      from s in Secret,
+        join: e in Environment,
+        on: s.environment_id == e.id,
+        where: e.user_id == ^user_id,
+        group_by: s.environment_id,
+        select: %{environment_id: s.environment_id, count: count(s.id)}
+
+    agent_counts_query =
+      from a in Agent,
+        where: a.user_id == ^user_id,
+        where: not is_nil(a.environment_id),
+        group_by: a.environment_id,
+        select: %{environment_id: a.environment_id, count: count(a.id)}
+
+    envs =
+      Repo.all(
+        from e in Environment,
+          where: e.user_id == ^user_id,
+          order_by: [desc: e.inserted_at, desc: e.id]
+      )
+
+    secret_map =
+      secret_counts_query
+      |> Repo.all()
+      |> Map.new(&{&1.environment_id, &1.count})
+
+    agent_map =
+      agent_counts_query
+      |> Repo.all()
+      |> Map.new(&{&1.environment_id, &1.count})
+
+    Enum.map(envs, fn env ->
+      env
+      |> Map.put(:secret_count, Map.get(secret_map, env.id, 0))
+      |> Map.put(:agent_count, Map.get(agent_map, env.id, 0))
+    end)
   end
 
   @doc "Get environment scoped to user. Returns nil on wrong owner or missing id."

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -31,7 +31,41 @@ defmodule Fountain.Vaults do
 
   @doc "List vaults scoped to user."
   def list_vaults(user_id) when is_binary(user_id) do
-    Repo.all(from v in Vault, where: v.user_id == ^user_id, order_by: [desc: v.inserted_at, desc: v.id])
+    Repo.all(
+      from v in Vault,
+        where: v.user_id == ^user_id,
+        order_by: [desc: v.inserted_at, desc: v.id]
+    )
+  end
+
+  @doc """
+  List vaults scoped to user, with `:secret_count` attached as a virtual
+  field via a lightweight aggregation query.
+  """
+  def list_vaults_with_counts(user_id) when is_binary(user_id) do
+    secret_counts_query =
+      from s in VaultSecret,
+        join: v in Vault,
+        on: s.vault_id == v.id,
+        where: v.user_id == ^user_id,
+        group_by: s.vault_id,
+        select: %{vault_id: s.vault_id, count: count(s.id)}
+
+    vaults =
+      Repo.all(
+        from v in Vault,
+          where: v.user_id == ^user_id,
+          order_by: [desc: v.inserted_at, desc: v.id]
+      )
+
+    secret_map =
+      secret_counts_query
+      |> Repo.all()
+      |> Map.new(&{&1.vault_id, &1.count})
+
+    Enum.map(vaults, fn vault ->
+      Map.put(vault, :secret_count, Map.get(secret_map, vault.id, 0))
+    end)
   end
 
   @doc "Get vault scoped to user. Returns nil on wrong owner or missing id."
@@ -61,7 +95,9 @@ defmodule Fountain.Vaults do
   # ── secrets ───────────────────────────────────────────────────────────────
 
   def list_secrets(%Vault{id: vault_id}) do
-    Repo.all(from s in VaultSecret, where: s.vault_id == ^vault_id, order_by: [asc: s.key])
+    Repo.all(
+      from s in VaultSecret, where: s.vault_id == ^vault_id, order_by: [asc: s.key]
+    )
   end
 
   def get_secret(vault_id, key) do

--- a/apps/fountain/lib/fountain_web/live/environments_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/index.ex
@@ -7,11 +7,23 @@ defmodule FountainWeb.EnvironmentsLive.Index do
   @impl true
   def mount(_params, _session, socket) do
     user_id = socket.assigns.current_user.id
+
     {:ok,
      socket
      |> assign(:page_title, "Environments")
      |> assign(:user_id, user_id)
-     |> assign(:envs, list_envs(user_id))}
+     |> assign(:filter_search, "")
+     |> assign(:envs, load_envs(user_id, ""))}
+  end
+
+  @impl true
+  def handle_event("search", %{"search" => search}, socket) do
+    search = String.trim(search)
+
+    {:noreply,
+     socket
+     |> assign(:filter_search, search)
+     |> assign(:envs, load_envs(socket.assigns.user_id, search))}
   end
 
   @impl true
@@ -21,15 +33,19 @@ defmodule FountainWeb.EnvironmentsLive.Index do
 
     {:noreply,
      socket
-     |> assign(:envs, list_envs(socket.assigns.user_id))
+     |> assign(:envs, load_envs(socket.assigns.user_id, socket.assigns.filter_search))
      |> put_flash(:info, "Deleted #{env.name}")}
   end
 
-  defp list_envs(user_id) do
-    Environments.list_environments(user_id)
-    |> Enum.map(fn env ->
-      Map.put(env, :secret_count, length(Environments.list_secrets(env)))
-    end)
+  defp load_envs(user_id, search) do
+    envs = Environments.list_environments_with_counts(user_id)
+
+    if search == "" do
+      envs
+    else
+      term = String.downcase(search)
+      Enum.filter(envs, fn e -> String.contains?(String.downcase(e.name), term) end)
+    end
   end
 
   @impl true
@@ -41,29 +57,120 @@ defmodule FountainWeb.EnvironmentsLive.Index do
         <.link navigate={~p"/environments/new"}><.btn>+ New environment</.btn></.link>
       </div>
 
-      <div :if={@envs == []} class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500">
-        No environments yet.
+      <%!-- Search bar --%>
+      <form phx-change="search" phx-submit="search">
+        <input
+          type="text"
+          name="search"
+          value={@filter_search}
+          phx-debounce="200"
+          placeholder="Search environments…"
+          class="w-64 rounded border px-3 py-1.5 text-sm focus:outline-none"
+          style="background:#111;border-color:#2a2a2a;color:#e5e7eb;"
+        />
+      </form>
+
+      <%!-- Empty state — no envs at all --%>
+      <div
+        :if={@envs == [] and @filter_search == ""}
+        class="rounded-lg p-10 text-center"
+        style="background:#0a0a0a;border:1px dashed #2a2a2a;"
+      >
+        <p class="text-sm" style="color:#6b7280;">No environments yet.</p>
+        <p class="text-xs mt-1" style="color:#374151;">Create one to configure packages, secrets, and a setup script for your agents.</p>
       </div>
 
-      <table :if={@envs != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
-        <thead class="text-left text-zinc-500 border-b border-zinc-200">
+      <%!-- Empty state — search returned nothing --%>
+      <div
+        :if={@envs == [] and @filter_search != ""}
+        class="rounded-lg p-8 text-center"
+        style="background:#0a0a0a;border:1px dashed #2a2a2a;"
+      >
+        <p class="text-sm" style="color:#6b7280;">No environments match <span class="font-mono" style="color:#9ca3af;">"{@filter_search}"</span>.</p>
+      </div>
+
+      <%!-- Table --%>
+      <table
+        :if={@envs != []}
+        class="w-full text-sm rounded-lg overflow-hidden"
+        style="background:#0a0a0a;border:1px solid #1a1a1a;"
+      >
+        <thead style="border-bottom:1px solid #222;">
           <tr>
-            <th class="px-4 py-2">Name</th>
-            <th class="px-4 py-2">Setup</th>
-            <th class="px-4 py-2">Secrets</th>
-            <th class="px-4 py-2"></th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Name</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Network</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Setup</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Stats</th>
+            <th class="px-4 py-3"></th>
           </tr>
         </thead>
         <tbody>
-          <tr :for={e <- @envs} class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50">
-            <td class="px-4 py-2 font-medium">{e.name}</td>
-            <td class="px-4 py-2 text-zinc-600 font-mono text-xs truncate max-w-xs">
-              {if e.setup_script == "", do: "—", else: e.setup_script}
+          <tr
+            :for={e <- @envs}
+            class="hover:bg-[#0d1117] transition-colors duration-150"
+            style="border-bottom:1px solid #161616;"
+          >
+            <td class="px-4 py-3 font-medium" style="color:#e5e7eb;">{e.name}</td>
+            <td class="px-4 py-3">
+              <span
+                class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold"
+                style={networking_badge_style(e.networking_type)}
+              >
+                <span class="w-1.5 h-1.5 rounded-full" style="background:currentColor;"></span>
+                {e.networking_type}
+              </span>
             </td>
-            <td class="px-4 py-2 text-zinc-600">{e.secret_count}</td>
-            <td class="px-4 py-2 text-right space-x-2">
-              <.link navigate={~p"/environments/#{e.id}/edit"}><.btn_secondary>Edit</.btn_secondary></.link>
-              <.btn_danger phx-click="delete" phx-value-id={e.id} data-confirm="Delete environment?">Delete</.btn_danger>
+            <td class="px-4 py-3">
+              <span
+                :if={e.setup_script != ""}
+                class="font-mono text-xs block truncate max-w-xs"
+                style="color:#4b5563;"
+                title={e.setup_script}
+              >{truncate(e.setup_script, 48)}</span>
+              <span :if={e.setup_script == ""} style="color:#374151;">—</span>
+            </td>
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-1.5 flex-wrap">
+                <span
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                  style={stat_badge_style(:secrets, e.secret_count)}
+                  title={"#{e.secret_count} secrets"}
+                >🔑 {e.secret_count}</span>
+                <span
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                  style={stat_badge_style(:agents, e.agent_count)}
+                  title={"#{e.agent_count} agents"}
+                >⚡ {e.agent_count}</span>
+                <span
+                  :if={map_size(e.packages) > 0}
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                  style="background:#150d25;color:#a78bfa;border:1px solid #2a1a4a;"
+                  title={"#{map_size(e.packages)} packages"}
+                >📦 {map_size(e.packages)}</span>
+                <span
+                  :if={length(e.repositories) > 0}
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                  style="background:#0d1525;color:#93c5fd;border:1px solid #1a2a4a;"
+                  title={"#{length(e.repositories)} repos"}
+                >⑂ {length(e.repositories)}</span>
+              </div>
+            </td>
+            <td class="px-4 py-3 text-right">
+              <div class="inline-flex gap-1">
+                <.link navigate={~p"/environments/#{e.id}/edit"}>
+                  <button
+                    class="px-2 py-1 rounded text-xs cursor-pointer"
+                    style="background:#1a1a1a;border:1px solid #2a2a2a;color:#9ca3af;"
+                  >Edit</button>
+                </.link>
+                <button
+                  class="px-2 py-1 rounded text-xs cursor-pointer"
+                  style="background:#1a0d0d;border:1px solid #3a1a1a;color:#f87171;"
+                  phx-click="delete"
+                  phx-value-id={e.id}
+                  data-confirm="Delete environment?"
+                >Delete</button>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -71,4 +178,25 @@ defmodule FountainWeb.EnvironmentsLive.Index do
     </div>
     """
   end
+
+  defp truncate(str, max) when byte_size(str) <= max, do: str
+  defp truncate(str, max), do: binary_part(str, 0, max) <> "…"
+
+  defp networking_badge_style("unrestricted"),
+    do: "background:#0d1f0d;color:#6ee7b7;border:1px solid #1a3a1a;"
+
+  defp networking_badge_style("limited"),
+    do: "background:#1a1200;color:#fbbf24;border:1px solid #3a2a00;"
+
+  defp networking_badge_style(_),
+    do: "background:#1a1a1a;color:#9ca3af;border:1px solid #2a2a2a;"
+
+  defp stat_badge_style(_type, 0),
+    do: "background:#111;color:#374151;border:1px solid #1f1f1f;"
+
+  defp stat_badge_style(:secrets, _),
+    do: "background:#1a1200;color:#fbbf24;border:1px solid #3a2a00;"
+
+  defp stat_badge_style(:agents, _),
+    do: "background:#0d1f0d;color:#6ee7b7;border:1px solid #1a3a1a;"
 end

--- a/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
@@ -7,11 +7,23 @@ defmodule FountainWeb.VaultsLive.Index do
   @impl true
   def mount(_params, _session, socket) do
     user_id = socket.assigns.current_user.id
+
     {:ok,
      socket
      |> assign(:page_title, "Vaults")
      |> assign(:user_id, user_id)
-     |> assign(:vaults, list_vaults(user_id))}
+     |> assign(:filter_search, "")
+     |> assign(:vaults, load_vaults(user_id, ""))}
+  end
+
+  @impl true
+  def handle_event("search", %{"search" => search}, socket) do
+    search = String.trim(search)
+
+    {:noreply,
+     socket
+     |> assign(:filter_search, search)
+     |> assign(:vaults, load_vaults(socket.assigns.user_id, search))}
   end
 
   @impl true
@@ -21,15 +33,19 @@ defmodule FountainWeb.VaultsLive.Index do
 
     {:noreply,
      socket
-     |> assign(:vaults, list_vaults(socket.assigns.user_id))
+     |> assign(:vaults, load_vaults(socket.assigns.user_id, socket.assigns.filter_search))
      |> put_flash(:info, "Deleted #{vault.name}")}
   end
 
-  defp list_vaults(user_id) do
-    Vaults.list_vaults(user_id)
-    |> Enum.map(fn vault ->
-      Map.put(vault, :secret_count, length(Vaults.list_secrets(vault)))
-    end)
+  defp load_vaults(user_id, search) do
+    vaults = Vaults.list_vaults_with_counts(user_id)
+
+    if search == "" do
+      vaults
+    else
+      term = String.downcase(search)
+      Enum.filter(vaults, fn v -> String.contains?(String.downcase(v.name), term) end)
+    end
   end
 
   @impl true
@@ -41,34 +57,96 @@ defmodule FountainWeb.VaultsLive.Index do
         <.link navigate={~p"/vaults/new"}><.btn>+ New vault</.btn></.link>
       </div>
 
-      <p class="text-sm text-zinc-500 max-w-2xl">
-        A <strong>vault</strong> is a bag of env-var overrides — your credentials, a teammate's, or a virtual identity.
+      <p class="text-sm max-w-2xl" style="color:#6b7280;">
+        A <strong style="color:#9ca3af;">vault</strong> is a bag of env-var overrides — your credentials, a teammate's, or a virtual identity.
         Pick one when starting a conversation and its values override the environment's baseline secrets at sprite spawn.
       </p>
 
-      <div :if={@vaults == []} class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500">
-        No vaults yet.
+      <%!-- Search bar --%>
+      <form phx-change="search" phx-submit="search">
+        <input
+          type="text"
+          name="search"
+          value={@filter_search}
+          phx-debounce="200"
+          placeholder="Search vaults…"
+          class="w-64 rounded border px-3 py-1.5 text-sm focus:outline-none"
+          style="background:#111;border-color:#2a2a2a;color:#e5e7eb;"
+        />
+      </form>
+
+      <%!-- Empty state — no vaults at all --%>
+      <div
+        :if={@vaults == [] and @filter_search == ""}
+        class="rounded-lg p-10 text-center"
+        style="background:#0a0a0a;border:1px dashed #2a2a2a;"
+      >
+        <p class="text-sm" style="color:#6b7280;">No vaults yet.</p>
+        <p class="text-xs mt-1" style="color:#374151;">Create a vault to store a set of credential overrides you can apply per conversation.</p>
       </div>
 
-      <table :if={@vaults != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
-        <thead class="text-left text-zinc-500 border-b border-zinc-200">
+      <%!-- Empty state — search returned nothing --%>
+      <div
+        :if={@vaults == [] and @filter_search != ""}
+        class="rounded-lg p-8 text-center"
+        style="background:#0a0a0a;border:1px dashed #2a2a2a;"
+      >
+        <p class="text-sm" style="color:#6b7280;">No vaults match <span class="font-mono" style="color:#9ca3af;">"{@filter_search}"</span>.</p>
+      </div>
+
+      <%!-- Table --%>
+      <table
+        :if={@vaults != []}
+        class="w-full text-sm rounded-lg overflow-hidden"
+        style="background:#0a0a0a;border:1px solid #1a1a1a;"
+      >
+        <thead style="border-bottom:1px solid #222;">
           <tr>
-            <th class="px-4 py-2">Name</th>
-            <th class="px-4 py-2">Description</th>
-            <th class="px-4 py-2">Secrets</th>
-            <th class="px-4 py-2"></th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Name</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Description</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Secrets</th>
+            <th class="px-4 py-3"></th>
           </tr>
         </thead>
         <tbody>
-          <tr :for={v <- @vaults} class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50">
-            <td class="px-4 py-2 font-medium">{v.name}</td>
-            <td class="px-4 py-2 text-zinc-600 truncate max-w-md">
-              {if v.description == "", do: "—", else: v.description}
+          <tr
+            :for={v <- @vaults}
+            class="hover:bg-[#0d1117] transition-colors duration-150"
+            style="border-bottom:1px solid #161616;"
+          >
+            <td class="px-4 py-3 font-medium" style="color:#e5e7eb;">{v.name}</td>
+            <td class="px-4 py-3 max-w-md">
+              <span
+                :if={v.description != ""}
+                class="text-xs block truncate"
+                style="color:#4b5563;"
+                title={v.description}
+              >{v.description}</span>
+              <span :if={v.description == ""} style="color:#374151;">—</span>
             </td>
-            <td class="px-4 py-2 text-zinc-600">{v.secret_count}</td>
-            <td class="px-4 py-2 text-right space-x-2">
-              <.link navigate={~p"/vaults/#{v.id}/edit"}><.btn_secondary>Edit</.btn_secondary></.link>
-              <.btn_danger phx-click="delete" phx-value-id={v.id} data-confirm="Delete vault?">Delete</.btn_danger>
+            <td class="px-4 py-3">
+              <span
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                style={secrets_badge_style(v.secret_count)}
+                title={"#{v.secret_count} secrets"}
+              >🔑 {v.secret_count}</span>
+            </td>
+            <td class="px-4 py-3 text-right">
+              <div class="inline-flex gap-1">
+                <.link navigate={~p"/vaults/#{v.id}/edit"}>
+                  <button
+                    class="px-2 py-1 rounded text-xs cursor-pointer"
+                    style="background:#1a1a1a;border:1px solid #2a2a2a;color:#9ca3af;"
+                  >Edit</button>
+                </.link>
+                <button
+                  class="px-2 py-1 rounded text-xs cursor-pointer"
+                  style="background:#1a0d0d;border:1px solid #3a1a1a;color:#f87171;"
+                  phx-click="delete"
+                  phx-value-id={v.id}
+                  data-confirm="Delete vault?"
+                >Delete</button>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -76,4 +154,10 @@ defmodule FountainWeb.VaultsLive.Index do
     </div>
     """
   end
+
+  defp secrets_badge_style(0),
+    do: "background:#111;color:#374151;border:1px solid #1f1f1f;"
+
+  defp secrets_badge_style(_),
+    do: "background:#1a1200;color:#fbbf24;border:1px solid #3a2a00;"
 end


### PR DESCRIPTION
## Summary

Brings the Environments and Vaults list views in line with the polished dark aesthetic already used by the Agents list view.

### Before
- Plain white `bg-white` table with zinc borders
- No search/filter
- Secrets displayed as a raw integer with no visual treatment
- No agent count, no package count, no repo count
- Generic empty state text, no helpful sub-copy
- Delete button used the `<.btn_danger>` component (light red background)

### After

**Both views:**
- Dark card table: `#0a0a0a` background, `#1a1a1a` border, `#161616` row separators — exact same tokens as `agents_live/index.ex`
- `hover:bg-[#0d1117]` row highlight on hover
- Column headers in `#4b5563` uppercase tracking
- Edit/Delete inline buttons styled with the same dark button tokens (`#1a1a1a` / `#1a0d0d`)
- Name column in `#e5e7eb` (bright)
- Name-search input with `phx-change="search"` / `phx-debounce="200"` — filters in-memory after the DB load
- Two empty states: "nothing at all" (with helpful sub-copy) vs "no search results" (echoes the search term)

**Environments view specifically:**
- **Network badge** — `unrestricted` → green (`#6ee7b7`), `limited` → amber (`#fbbf24`), unknown → grey; dot indicator matches `agents_live` runtime badge pattern
- **Setup column** — truncated monospace preview of `setup_script` (48 chars + `…`), full value in `title` tooltip; shows `—` when blank
- **Stats badges:**
  - 🔑 secret count (amber when > 0, dim when 0)
  - ⚡ agent count (green when > 0, dim when 0)  — powered by new `list_environments_with_counts/1`
  - 📦 package count (purple) — only shown when > 0
  - ⑂ repo count (blue) — only shown when > 0

**Vaults view specifically:**
- **Description column** — truncated at `max-w-md`, full value in `title` tooltip; shows `—` when blank
- **Secrets badge** — 🔑 amber when > 0, dim when 0 — powered by new `list_vaults_with_counts/1`

### Context changes

**`Fountain.Environments.list_environments_with_counts/1`** (new)  
Runs two extra aggregation queries (secret counts, agent counts), then merges the results onto the environment structs as `:secret_count` and `:agent_count` virtual fields. Agent FK `environment_id` is already on the `Agent` schema so no migration needed.

**`Fountain.Vaults.list_vaults_with_counts/1`** (new)  
Runs one aggregation query (vault-secret counts), merges `:secret_count` onto each vault struct. Replaces the previous `Enum.map` + `length(Vaults.list_secrets(vault))` N+1 pattern.

Both follow the same pattern as `Agents.list_agents_with_counts/2`.
