### PR TITLE
docs: skills help page + agent form context for injected skill

### DIFF
--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -157,11 +157,31 @@ defmodule FountainWeb.AgentsLive.Form do
           value={@form["skills_json"]}
           placeholder={~s([{"source": "anthropics/skills", "name": "frontend-design"}])}/>
         <.error_msg field="skills_json" errors={@errors}/>
-        <p class="text-xs text-zinc-500 -mt-2">
-          Each entry is either inline (<code>{~s({"name": "...", "content": "<SKILL.md body>"})}</code>)
-          or github via <a href="https://skills.sh" class="underline">skills.sh</a>
-          (<code>{~s({"source": "owner/repo", "name": "<optional>"})}</code>).
-        </p>
+        <div class="text-xs text-zinc-500 -mt-2 space-y-2">
+          <p>
+            Each entry is either inline
+            (<code>{~s({"name": "...", "content": "<SKILL.md body>"})}</code>)
+            or a GitHub skill via
+            <a href="https://skills.sh" target="_blank" class="underline">skills.sh</a>
+            (<code>{~s({"source": "owner/repo", "name": "<optional>"})}</code>).
+            <.link navigate={~p"/help/skills"} class="underline">Skills help →</.link>
+          </p>
+          <div class="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-blue-900 leading-relaxed">
+            <strong>Always included:</strong>
+            the built-in <code>fountain</code> skill is automatically mounted in every
+            conversation — no need to declare it. It gives the agent
+            <code>$FOUNTAIN_TOKEN</code>, <code>$FOUNTAIN_BASE_URL</code>, and
+            <code>$FOUNTAIN_CONVERSATION_ID</code> so it can spawn and coordinate sub-agents.
+          </div>
+          <p>
+            Common GitHub skills:
+            <code>{~s({"source": "anthropics/skills", "name": "brainstorming"})}</code>
+            ·
+            <code>{~s({"source": "anthropics/skills", "name": "test-driven-development"})}</code>
+            ·
+            <code>{~s({"source": "anthropics/skills", "name": "systematic-debugging"})}</code>
+          </p>
+        </div>
 
         <.input id="mcp_servers_json" name="agent[mcp_servers_json]" type="textarea" rows="6"
           label="MCP servers (JSON object)" value={@form["mcp_servers_json"]}/>

--- a/apps/fountain/lib/fountain_web/live/help_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/help_live/show.ex
@@ -14,6 +14,7 @@ defmodule FountainWeb.HelpLive.Show do
   @topics [
     {"quickstart", "Quickstart"},
     {"agents", "Agents"},
+    {"skills", "Skills"},
     {"environments", "Environments"},
     {"vaults", "Vaults"},
     {"manifest", "Manifest"},

--- a/apps/fountain/priv/help/skills.md
+++ b/apps/fountain/priv/help/skills.md
@@ -1,0 +1,150 @@
+# Skills
+
+Skills are Markdown files that Fountain mounts into every sprite at provision time, making them available to the runtime as persistent instructional context. They are the primary mechanism for giving agents durable knowledge: how to spawn sub-agents, which tools to reach for, how to follow project conventions.
+
+## The built-in `fountain` skill
+
+Every conversation gets the bundled `fountain` skill automatically — you do not need to declare it, and you cannot remove it. It is always the first skill mounted regardless of what else is in the agent's `skills` list.
+
+The skill gives the agent inside the sprite everything it needs to call back to Fountain's API:
+
+- `FOUNTAIN_BASE_URL` — the public URL of your Fountain server
+- `FOUNTAIN_TOKEN` — a per-conversation API key scoped to the owning user, rotated on every fresh provision
+- `FOUNTAIN_CONVERSATION_ID` — this conversation's UUID, passed as `X-Fountain-Parent-Conversation-Id` when spawning children so the full spawn chain is recorded
+
+With those three env vars and the skill's instructions, any agent can spawn new conversations, fan out work across multiple agents, poll for results, stream output, and tear down conversations when done. See **Spawning sub-agents** for the full patterns.
+
+`FOUNTAIN_TOKEN` carries the same Fountain blast radius as the owning user — treat prompt injection on a sprite-bound agent as a potential account takeover for that user. The per-conversation scoping limits *how long* a leaked token stays live, not what it can do while it is live.
+
+To inspect the exact skill text your server is running, read it from inside any sprite:
+
+```bash
+# claude / opencode
+cat ~/.claude/skills/fountain/SKILL.md
+
+# codex (concatenated into AGENTS.md)
+cat ~/.codex/AGENTS.md | head -60
+
+# gemini
+cat ~/.gemini/GEMINI.md | head -60
+```
+
+## Per-runtime mounting
+
+Where a skill lands depends on the runtime:
+
+| Runtime | Location | How used |
+| --- | --- | --- |
+| `claude` | `~/.claude/skills/<name>/SKILL.md` | Auto-discovered by Claude Code at session start |
+| `opencode` | `~/.claude/skills/<name>/SKILL.md` | Same discovery path as claude |
+| `codex` | concatenated into `~/.codex/AGENTS.md` | Read as global agent instructions |
+| `gemini` | concatenated into `~/.gemini/GEMINI.md` | Read as global instructions |
+
+For claude and opencode, each skill lives in its own named directory and is discovered independently — the runtime's skill-loading mechanism finds them all. For codex and gemini, all skills are concatenated in declaration order into a single flat file. The `fountain` skill is always first in that concatenated output.
+
+## Adding skills to an agent
+
+The `skills` field is a JSON array on the agent. Each entry is one of two shapes.
+
+### GitHub skill
+
+Installed from a `owner/repo` source via the [skills.sh](https://skills.sh) CLI at provision time:
+
+```json
+[
+  {"source": "anthropics/skills", "name": "frontend-design"},
+  {"source": "BinaryBourbon/skills"}
+]
+```
+
+`name` is optional — when omitted the skill's declared name from the repository is used. Installs run via `npx -y skills@latest add <source> --global` on the sprite **before** the network policy locks the sprite down, so they can reach npm and GitHub.
+
+### Inline skill
+
+Content written directly from the agent definition, no network required:
+
+```json
+[
+  {
+    "name": "project-conventions",
+    "content": "# Conventions\n\n- All DB migrations must be reversible.\n- Never commit `.env` files."
+  }
+]
+```
+
+`content` is the full Markdown body written to `<skills_root>/<name>/SKILL.md`. Inline skills are written after all GitHub installs have completed.
+
+## Injection order
+
+1. **Bundled `fountain` skill** — always first, injected by Fountain itself
+2. **GitHub skills** — installed in declaration order (concurrent), before network lockdown
+3. **Inline skills** — written in declaration order, after GitHub installs finish
+
+Runtime config files (`~/.claude.json`, `~/.codex/config.toml`, etc.) are written after all skills are mounted.
+
+## Known good patterns
+
+### General-purpose agent that can spawn sub-agents
+
+The `fountain` skill is automatic — you don't need to add it. A blank `skills` array is sufficient for an agent that just needs to spawn. For one that should also be a capable coder, layer workflow skills on top:
+
+```json
+[
+  {"source": "anthropics/skills", "name": "brainstorming"},
+  {"source": "anthropics/skills", "name": "writing-plans"},
+  {"source": "anthropics/skills", "name": "test-driven-development"}
+]
+```
+
+### Code-review / quality gate agent
+
+```json
+[
+  {"source": "anthropics/skills", "name": "receiving-code-review"},
+  {"source": "anthropics/skills", "name": "requesting-code-review"},
+  {"source": "anthropics/skills", "name": "verification-before-completion"}
+]
+```
+
+### Project-specific conventions mixed with GitHub skills
+
+Combine a shared skill bundle with an inline skill for your project's quirks — the inline skill wins on specificity because the agent reads it alongside the shared ones:
+
+```json
+[
+  {"source": "anthropics/skills", "name": "test-driven-development"},
+  {
+    "name": "repo-conventions",
+    "content": "# Repo conventions\n\n- Use `snake_case` for Elixir, `camelCase` for TypeScript.\n- All Ecto migrations must be reversible (`down/0` required).\n- `mix format` before every commit."
+  }
+]
+```
+
+### Specialised leaf-node worker
+
+Leaf agents that are only ever spawned by orchestrators and never spawn themselves still get the `fountain` skill — it's harmless. Keep the skills list focused on the task:
+
+```json
+[
+  {"source": "anthropics/skills", "name": "systematic-debugging"}
+]
+```
+
+### Orchestrator with per-runtime awareness
+
+If the orchestrator needs to spawn agents across different runtimes and interpret their output, include the spawning context from the `fountain` skill (already there) and add a skill with any runtime-specific interpretation notes inline:
+
+```json
+[
+  {
+    "name": "runtime-output-notes",
+    "content": "# Runtime output shapes\n\nWhen gathering results from codex agents use `.item.text`; from gemini agents use the last `.content` message. See `$FOUNTAIN_BASE_URL/help/skills` for the full table."
+  }
+]
+```
+
+## Security and validation
+
+Skill `name` and `source` values are validated against `[A-Za-z0-9._/-]` before being interpolated into shell commands on the sprite. Any value that doesn't match that allow-list causes provisioning to fail with a clear error — no silent partial substitution.
+
+GitHub skills are installed via `npx` before the network policy engages. After that point, the sprite's egress is governed by the attached environment's policy. Inline skills bypass the network entirely — they're written via the sprite's internal filesystem HTTP API.

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -226,12 +226,13 @@ defmodule Fountain.ConversationsContextTest do
       c1 = insert_conversation(user_id: user.id)
       c2 = insert_conversation(user_id: user.id)
 
-      # Backdate c2 so c1 is guaranteed to sort first regardless of wall-clock
-      # precision (utc_datetime has second granularity).
+      # Backdate c2 so c1 is guaranteed to sort first. list_conversations_by_activity
+      # orders by GREATEST(last_log_at, last_turn_at, inserted_at) — no turns or log
+      # events here, so the tiebreaker is inserted_at, not updated_at.
       past = DateTime.add(DateTime.utc_now(), -3600, :second) |> DateTime.truncate(:second)
       Fountain.Repo.update_all(
         Ecto.Query.from(c in Conversation, where: c.id == ^c2.id),
-        set: [updated_at: past]
+        set: [inserted_at: past]
       )
 
       [first | _] = Conversations.list_conversations_by_activity(user.id)
@@ -1758,7 +1759,7 @@ defmodule Fountain.ConversationsContextTest do
 
   describe "factory to_atom_map — safe_to_existing_atom fallback" do
     test "to_atom_map with an unknown string key does not crash and returns the string as fallback" do
-      # "xyzquuxfoo_novel_key_never_an_atom" is not an existing Elixir atom,
+      # \"xyzquuxfoo_novel_key_never_an_atom\" is not an existing Elixir atom,
       # so safe_to_existing_atom triggers its rescue clause and returns the string key.
       result = Fountain.Factory.to_atom_map(%{
         "sprite_name" => "test-sprite",


### PR DESCRIPTION
## What

The `fountain` skill is injected into every agent automatically, but this was invisible to users — no help content existed for it, and the agent create form gave almost no guidance on skills in general.

This PR surfaces that behavior and adds actionable context where users actually need it.

## Changes

**New: `priv/help/skills.md`**
Full help page covering:
- The always-injected `fountain` skill: what it is, what env vars it provides (`FOUNTAIN_TOKEN`, `FOUNTAIN_BASE_URL`, `FOUNTAIN_CONVERSATION_ID`), security implications, and how to inspect the exact text running on your server
- Per-runtime mounting locations (claude/opencode → `~/.claude/skills/`, codex → `AGENTS.md`, gemini → `GEMINI.md`)
- Inline vs GitHub skill formats with examples
- Injection order (fountain → GitHub installs before network lockdown → inline)
- Known good patterns: general orchestrators, reviewer agents, project-conventions combos, leaf-node workers

**Updated: `help_live/show.ex`**
Adds `{"skills", "Skills"}` to `@topics` between Agents and Environments, so the new page shows up in the nav.

**Updated: `agents_live/form.ex`**
Expands the terse one-liner below the skills textarea into three sections:
- Format reminder + link to `/help/skills`
- Blue callout explaining that `fountain` is always auto-mounted, with the three env vars named explicitly
- Quick-reference list of common `anthropics/skills` entries

## Why now

The form had room and context was missing. Users arriving at the agent create page had no way to know the skill injection was happening, what it enabled, or what good patterns looked like.

## CI

All changes are Elixir source and Markdown. The `~p"/help/skills"` verified route is valid (matched by the existing `/help/:topic` route). No new dependencies.