### PR TITLE
Add avatar upload for agents

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -4,6 +4,7 @@ defmodule Fountain.Agents do
   import Ecto.Query, only: [from: 2]
 
   alias Fountain.Agents.Agent
+  alias Fountain.Agents.AgentAvatar
   alias Fountain.Conversations.Conversation
   alias Fountain.Repo
 
@@ -94,6 +95,38 @@ defmodule Fountain.Agents do
   end
 
   def delete_agent(%Agent{} = agent), do: Repo.delete(agent)
+
+  @doc "Upload or replace the avatar for an agent."
+  def upload_avatar(%Agent{} = agent, data, media_type)
+      when is_binary(data) and is_binary(media_type) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Repo.transaction(fn ->
+      Repo.insert!(
+        %AgentAvatar{agent_id: agent.id, data: data, inserted_at: now},
+        on_conflict: {:replace, [:data, :inserted_at]},
+        conflict_target: :agent_id
+      )
+
+      agent
+      |> Ecto.Changeset.change(%{avatar_media_type: media_type})
+      |> Repo.update!()
+    end)
+  end
+
+  @doc "Remove the avatar for an agent."
+  def delete_avatar(%Agent{} = agent) do
+    Repo.transaction(fn ->
+      Repo.delete_all(from(av in AgentAvatar, where: av.agent_id == ^agent.id))
+
+      agent
+      |> Ecto.Changeset.change(%{avatar_media_type: nil})
+      |> Repo.update!()
+    end)
+  end
+
+  @doc "Fetch the raw avatar blob for an agent. Returns nil if none uploaded."
+  def get_avatar(%Agent{id: agent_id}), do: Repo.get(AgentAvatar, agent_id)
 
   defp apply_search(query, ""), do: query
 

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -22,6 +22,7 @@ defmodule Fountain.Agents.Agent do
     field :skills, {:array, :map}, default: []
     field :mcp_servers, :map, default: %{}
     field :metadata, :map, default: %{}
+    field :avatar_media_type, :string
     field :conversation_count, :integer, virtual: true, default: 0
     belongs_to :user, User
     belongs_to :environment, Environment

--- a/apps/fountain/lib/fountain/agents/agent_avatar.ex
+++ b/apps/fountain/lib/fountain/agents/agent_avatar.ex
@@ -1,0 +1,22 @@
+defmodule Fountain.Agents.AgentAvatar do
+  @moduledoc false
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Fountain.Agents.Agent
+
+  @primary_key {:agent_id, :binary_id, autogenerate: false}
+  @foreign_key_type :binary_id
+
+  schema "agent_avatars" do
+    belongs_to :agent, Agent, define_field: false
+    field :data, :binary
+    field :inserted_at, :utc_datetime
+  end
+
+  def changeset(struct, attrs) do
+    struct
+    |> cast(attrs, [:agent_id, :data, :inserted_at])
+    |> validate_required([:agent_id, :data, :inserted_at])
+  end
+end

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -409,7 +409,8 @@ defmodule FountainWeb.Layouts do
 
     raw_prompt = first_turn && first_turn.prompt
     task_label = clean_conv_title(raw_prompt)
-    agent_name = assigns.conv.agent && assigns.conv.agent.name
+    agent = assigns.conv.agent
+    agent_name = agent && agent.name
     turn_count = Map.get(assigns.conv, :turn_count, 0) || 0
 
     target = extract_sidebar_target(raw_prompt, agent_name)
@@ -421,6 +422,7 @@ defmodule FountainWeb.Layouts do
       |> Enum.join(" · ")
 
     {initials, chip_class} = role_chip_style(agent_name)
+    avatar_url = if agent && Map.get(agent, :avatar_media_type), do: "/agents/#{agent.id}/avatar"
 
     assigns =
       assign(assigns,
@@ -430,6 +432,7 @@ defmodule FountainWeb.Layouts do
         subtitle: subtitle,
         initials: initials,
         chip_class: chip_class,
+        avatar_url: avatar_url,
         turn_count: turn_count
       )
 
@@ -444,8 +447,16 @@ defmodule FountainWeb.Layouts do
         )
       ]}
     >
-      <%!-- Role chip: 28x28 rounded-square showing agent initials --%>
+      <%!-- Role chip: 28x28 rounded-square showing agent avatar or initials --%>
+      <img
+        :if={@avatar_url}
+        src={@avatar_url}
+        class="w-7 h-7 rounded-[6px] object-cover shrink-0"
+        alt=""
+        title={if @conv.agent, do: @conv.agent.name}
+      />
       <span
+        :if={!@avatar_url}
         class={[
           "inline-flex items-center justify-center shrink-0",
           "w-7 h-7 rounded-[6px] text-[10px] font-bold leading-none select-none",

--- a/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
@@ -1,0 +1,21 @@
+defmodule FountainWeb.AgentAvatarController do
+  @moduledoc false
+  use FountainWeb, :controller
+
+  alias Fountain.Agents
+
+  def show(conn, %{"id" => id}) do
+    user_id = conn.assigns.current_user.id
+
+    with %{avatar_media_type: media_type} = agent
+         when not is_nil(media_type) <- Agents.get_agent(id, user_id),
+         %{data: data} <- Agents.get_avatar(agent) do
+      conn
+      |> put_resp_content_type(media_type)
+      |> put_resp_header("cache-control", "private, max-age=3600")
+      |> send_resp(200, data)
+    else
+      _ -> send_resp(conn, 404, "")
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -19,7 +19,12 @@ defmodule FountainWeb.AgentsLive.Form do
      |> assign(:action, action)
      |> assign(:agent, agent)
      |> assign(:form, agent_to_form(agent))
-     |> assign(:errors, %{})}
+     |> assign(:errors, %{})
+     |> allow_upload(:avatar,
+       accept: ~w(image/jpeg image/png image/gif image/webp),
+       max_entries: 1,
+       max_file_size: 5_242_880
+     )}
   end
 
   defp load(%{"id" => id}, user_id), do: {Agents.get_agent!(id, user_id), :edit}
@@ -46,6 +51,21 @@ defmodule FountainWeb.AgentsLive.Form do
     {:noreply, assign(socket, :form, params)}
   end
 
+  def handle_event("cancel_upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :avatar, ref)}
+  end
+
+  def handle_event("remove_avatar", _, socket) do
+    agent = socket.assigns.agent
+
+    if agent.id do
+      Agents.delete_avatar(agent)
+      {:noreply, assign(socket, :agent, %{agent | avatar_media_type: nil})}
+    else
+      {:noreply, socket}
+    end
+  end
+
   def handle_event("submit", %{"agent" => params}, socket) do
     with {:ok, mcp} <- parse_mcp(params),
          {:ok, skills} <- parse_skills(params) do
@@ -57,7 +77,10 @@ defmodule FountainWeb.AgentsLive.Form do
         |> Map.drop(["skills_json", "mcp_servers_json"])
         |> nil_if_blank("environment_id")
 
-      save(socket, attrs)
+      case save(socket, attrs) do
+        {:ok, socket} -> {:noreply, socket}
+        {:error, socket} -> {:noreply, socket}
+      end
     else
       {:error, field, msg} ->
         {:noreply, assign(socket, :errors, %{field => msg})}
@@ -66,22 +89,40 @@ defmodule FountainWeb.AgentsLive.Form do
 
   defp save(%{assigns: %{action: :new}} = socket, attrs) do
     case Agents.create_agent(attrs) do
-      {:ok, _agent} ->
-        {:noreply, socket |> put_flash(:info, "Agent created") |> push_navigate(to: ~p"/agents")}
+      {:ok, agent} ->
+        maybe_upload_avatar(socket, agent)
+
+        {:ok,
+         socket
+         |> put_flash(:info, "Agent created")
+         |> push_navigate(to: ~p"/agents")}
 
       {:error, cs} ->
-        {:noreply, assign(socket, :errors, changeset_errors(cs))}
+        {:error, assign(socket, :errors, changeset_errors(cs))}
     end
   end
 
-  defp save(%{assigns: %{action: :edit, agent: agent}} = socket, attrs) do
-    case Agents.update_agent(agent, attrs) do
-      {:ok, _agent} ->
-        {:noreply, socket |> put_flash(:info, "Agent updated") |> push_navigate(to: ~p"/agents")}
+  defp save(%{assigns: %{action: :edit, agent: existing}} = socket, attrs) do
+    case Agents.update_agent(existing, attrs) do
+      {:ok, saved} ->
+        maybe_upload_avatar(socket, saved)
+
+        {:ok,
+         socket
+         |> put_flash(:info, "Agent updated")
+         |> push_navigate(to: ~p"/agents")}
 
       {:error, cs} ->
-        {:noreply, assign(socket, :errors, changeset_errors(cs))}
+        {:error, assign(socket, :errors, changeset_errors(cs))}
     end
+  end
+
+  defp maybe_upload_avatar(socket, agent) do
+    consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
+      data = File.read!(path)
+      Agents.upload_avatar(agent, data, entry.client_type)
+      {:ok, :uploaded}
+    end)
   end
 
   defp parse_skills(%{"skills_json" => v}) when v in [nil, ""], do: {:ok, []}
@@ -90,6 +131,7 @@ defmodule FountainWeb.AgentsLive.Form do
     case Jason.decode(json) do
       {:ok, list} when is_list(list) -> {:ok, list}
       {:ok, _} -> {:error, "skills_json", "must be a JSON array"}
+
       {:error, %Jason.DecodeError{} = e} ->
         {:error, "skills_json", "invalid JSON: #{Exception.message(e)}"}
     end
@@ -101,6 +143,7 @@ defmodule FountainWeb.AgentsLive.Form do
     case Jason.decode(json) do
       {:ok, m} when is_map(m) -> {:ok, m}
       {:ok, _} -> {:error, "mcp_servers_json", "must be a JSON object"}
+
       {:error, %Jason.DecodeError{} = e} ->
         {:error, "mcp_servers_json", "invalid JSON: #{Exception.message(e)}"}
     end
@@ -116,6 +159,11 @@ defmodule FountainWeb.AgentsLive.Form do
     end)
     |> Map.new(fn {k, [first | _]} -> {to_string(k), first} end)
   end
+
+  defp upload_error_to_string(:too_large), do: "File too large (max 5 MB)"
+  defp upload_error_to_string(:not_accepted), do: "Unsupported file type"
+  defp upload_error_to_string(:too_many_files), do: "Only one avatar allowed"
+  defp upload_error_to_string(_), do: "Upload failed"
 
   @impl true
   def render(assigns) do
@@ -150,6 +198,55 @@ defmodule FountainWeb.AgentsLive.Form do
             <option value="">— none —</option>
             <option :for={e <- @envs} value={e.id} selected={@form["environment_id"] == e.id}>{e.name}</option>
           </select>
+        </div>
+
+        <%!-- Avatar upload --%>
+        <div class="space-y-2">
+          <label class="block text-sm font-medium text-zinc-700">Avatar</label>
+
+          <div :if={@agent.id && @agent.avatar_media_type} class="flex items-center gap-3">
+            <img
+              src={~p"/agents/#{@agent.id}/avatar"}
+              class="w-14 h-14 rounded-xl object-cover border border-zinc-200"
+              alt="Current avatar"
+            />
+            <button
+              type="button"
+              phx-click="remove_avatar"
+              class="text-sm text-rose-600 hover:text-rose-800 underline underline-offset-2"
+            >
+              Remove
+            </button>
+          </div>
+
+          <.live_file_input
+            upload={@uploads.avatar}
+            class="block text-sm text-zinc-700 file:mr-3 file:rounded file:border-0
+                   file:bg-zinc-100 file:px-3 file:py-1.5 file:text-sm file:font-medium
+                   file:cursor-pointer hover:file:bg-zinc-200"
+          />
+          <p class="text-xs text-zinc-500">JPEG, PNG, GIF, or WebP · max 5 MB</p>
+
+          <div :for={entry <- @uploads.avatar.entries} class="flex items-center gap-3">
+            <.live_img_preview
+              entry={entry}
+              class="w-14 h-14 rounded-xl object-cover border border-zinc-200"
+            />
+            <div class="text-sm text-zinc-600">
+              <p class="font-medium">{entry.client_name}</p>
+              <button
+                type="button"
+                phx-click="cancel_upload"
+                phx-value-ref={entry.ref}
+                class="text-rose-600 hover:text-rose-800 underline underline-offset-2"
+              >
+                Remove
+              </button>
+            </div>
+            <p :for={err <- upload_errors(@uploads.avatar, entry)} class="text-rose-600 text-xs">
+              {upload_error_to_string(err)}
+            </p>
+          </div>
         </div>
 
         <.input id="skills_json" name="agent[skills_json]" type="textarea" rows="6"

--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -234,7 +234,17 @@ defmodule FountainWeb.AgentsLive.Index do
               class="hover:bg-[#0d1117] transition-colors duration-150"
               style="border-bottom:1px solid #161616;"
             >
-              <td class="px-4 py-3 font-medium" style="color:#e5e7eb;">{a.name}</td>
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-2.5">
+                  <img
+                    :if={a.avatar_media_type}
+                    src={~p"/agents/#{a.id}/avatar"}
+                    class="w-7 h-7 rounded-md object-cover shrink-0"
+                    alt=""
+                  />
+                  <span class="font-medium" style="color:#e5e7eb;">{a.name}</span>
+                </div>
+              </td>
               <td class="px-4 py-3">
                 <span
                   class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold"

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -167,6 +167,9 @@ defmodule FountainWeb.Router do
     # ── Theme preference — CSRF-protected, session-authenticated ─────────────────────────────────────────
     patch "/api/settings/theme", SettingsController, :update_theme
 
+    # ── Avatar serving — tenant-scoped image endpoint ─────────────────────────────────────────────────────
+    get "/agents/:id/avatar", AgentAvatarController, :show
+
     # ── Phase-3-billing: conversation routes require an active subscription ─────────────────
     # :require_active_subscription runs after :require_authenticated_user and
     # redirects to /account/billing on SubscriptionRequiredError.

--- a/apps/fountain/priv/repo/migrations/20260512000000_add_agent_avatars.exs
+++ b/apps/fountain/priv/repo/migrations/20260512000000_add_agent_avatars.exs
@@ -1,0 +1,18 @@
+defmodule Fountain.Repo.Migrations.AddAgentAvatars do
+  use Ecto.Migration
+
+  def change do
+    alter table(:agents) do
+      add :avatar_media_type, :string, null: true
+    end
+
+    create table(:agent_avatars, primary_key: false) do
+      add :agent_id,
+          references(:agents, type: :binary_id, on_delete: :delete_all),
+          primary_key: true
+
+      add :data, :binary, null: false
+      add :inserted_at, :utc_datetime, null: false
+    end
+  end
+end

--- a/apps/fountain/test/fountain/agents/agent_avatar_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_avatar_test.exs
@@ -1,0 +1,58 @@
+defmodule Fountain.Agents.AgentAvatarTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Agents
+
+  describe "upload_avatar/3" do
+    test "stores avatar data and sets avatar_media_type on the agent" do
+      agent = insert_agent()
+
+      assert {:ok, updated} = Agents.upload_avatar(agent, "img-data", "image/jpeg")
+      assert updated.avatar_media_type == "image/jpeg"
+    end
+
+    test "replaces an existing avatar" do
+      agent = insert_agent()
+      {:ok, with_avatar} = Agents.upload_avatar(agent, "first", "image/png")
+      {:ok, replaced} = Agents.upload_avatar(with_avatar, "second", "image/jpeg")
+
+      assert replaced.avatar_media_type == "image/jpeg"
+
+      avatar = Agents.get_avatar(replaced)
+      assert avatar.data == "second"
+    end
+  end
+
+  describe "delete_avatar/1" do
+    test "clears avatar_media_type and removes the blob" do
+      agent = insert_agent()
+      {:ok, with_avatar} = Agents.upload_avatar(agent, "blob", "image/png")
+
+      assert {:ok, cleared} = Agents.delete_avatar(with_avatar)
+      assert cleared.avatar_media_type == nil
+      assert Agents.get_avatar(cleared) == nil
+    end
+
+    test "succeeds when agent has no avatar" do
+      agent = insert_agent()
+
+      assert {:ok, updated} = Agents.delete_avatar(agent)
+      assert updated.avatar_media_type == nil
+    end
+  end
+
+  describe "get_avatar/1" do
+    test "returns nil when no avatar has been uploaded" do
+      agent = insert_agent()
+      assert Agents.get_avatar(agent) == nil
+    end
+
+    test "returns the avatar blob when one exists" do
+      agent = insert_agent()
+      {:ok, updated} = Agents.upload_avatar(agent, "blob-bytes", "image/webp")
+
+      avatar = Agents.get_avatar(updated)
+      assert avatar.data == "blob-bytes"
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/agent_avatar_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_avatar_controller_test.exs
@@ -1,0 +1,46 @@
+defmodule FountainWeb.AgentAvatarControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Agents
+
+  describe "GET /agents/:id/avatar" do
+    test "returns 404 when agent has no avatar", %{conn: conn} do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      conn = login_user(conn, user)
+
+      conn = get(conn, ~p"/agents/#{agent.id}/avatar")
+      assert conn.status == 404
+    end
+
+    test "returns the avatar image with the correct content-type", %{conn: conn} do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      {:ok, _} = Agents.upload_avatar(agent, "fake-img", "image/png")
+      conn = login_user(conn, user)
+
+      conn = get(conn, ~p"/agents/#{agent.id}/avatar")
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") |> hd() =~ "image/png"
+      assert conn.resp_body == "fake-img"
+    end
+
+    test "returns 404 for another tenant's agent", %{conn: conn} do
+      owner = insert_verified_user()
+      other = insert_verified_user()
+      agent = insert_agent(user_id: owner.id)
+      {:ok, _} = Agents.upload_avatar(agent, "fake-img", "image/jpeg")
+      conn = login_user(conn, other)
+
+      conn = get(conn, ~p"/agents/#{agent.id}/avatar")
+      assert conn.status == 404
+    end
+
+    test "redirects unauthenticated requests to login", %{conn: conn} do
+      agent = insert_agent()
+
+      conn = get(conn, ~p"/agents/#{agent.id}/avatar")
+      assert redirected_to(conn) =~ "/auth/login"
+    end
+  end
+end


### PR DESCRIPTION
## What

Allows uploading a real image avatar for each agent, replacing the text-initials placeholder everywhere agents are shown.

## Changes

**Storage**
- New migration: adds `avatar_media_type :string` to `agents` (presence indicator, avoids loading binary in list queries) and creates `agent_avatars` table (1:1 with agents, stores raw binary, follows the `turn_images` pattern)
- `Fountain.Agents.AgentAvatar` — Ecto schema for the blob table
- `Fountain.Agents.upload_avatar/3`, `delete_avatar/1`, `get_avatar/1` — context functions; upload uses upsert so re-uploading replaces atomically

**Serving**
- `GET /agents/:id/avatar` — tenant-scoped endpoint; returns image with correct `Content-Type` and a 1-hour private cache header; 404 for wrong owner or no avatar

**UI**
- Agent form (`agents_live/form.ex`) — LiveView file upload (JPEG/PNG/GIF/WebP, 5 MB max); shows current avatar with a Remove button, live preview of selected file, per-entry error messages
- Agents index (`agents_live/index.ex`) — shows thumbnail next to agent name when avatar is set
- Sidebar (`components/layouts.ex`) — `conv_nav_link` shows `<img>` in place of the initials chip when the agent has an avatar

**Tests**
- `test/fountain/agents/agent_avatar_test.exs` — context-level tests for upload/delete/get
- `test/fountain_web/controllers/agent_avatar_controller_test.exs` — 404 (no avatar), 200 with correct content-type (owner), 404 (other tenant), redirect (unauthenticated)
