### PR TITLE
Move sidebar settings into collapsible user menu

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -79,6 +79,12 @@ defmodule FountainWeb.Layouts do
 
     groups = group_conversations_by_date(filtered_convs)
 
+    footer_open =
+      Enum.any?(
+        ["/api-keys", "/account/billing", "/audit", "/help", "/admin"],
+        &String.starts_with?(assigns[:current_path] || "", &1)
+      )
+
     assigns =
       assign(assigns,
         nav_conversations: convs,
@@ -86,7 +92,8 @@ defmodule FountainWeb.Layouts do
         child_counts: child_counts,
         sidebar_roots_only: roots_only,
         sidebar_agent_filter: agent_filter,
-        sidebar_unique_agents: unique_agents
+        sidebar_unique_agents: unique_agents,
+        footer_open: footer_open
       )
 
     ~H"""
@@ -256,56 +263,68 @@ defmodule FountainWeb.Layouts do
             <.nav_link href={~p"/vaults"} label="Vaults" current={@current_path} />
           </div>
 
-          <%!-- Settings section --%>
-          <div class="border-t border-[var(--color-border)] px-2 py-1.5 space-y-0.5 shrink-0">
-            <p class="px-3 pt-1 pb-0.5 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] font-medium">
-              Settings
-            </p>
-            <.nav_link href={~p"/api-keys"} label="API Keys" current={@current_path} />
-            <.nav_link href={~p"/account/billing"} label="Billing" current={@current_path} />
-            <.nav_link href={~p"/audit"} label="Audit log" current={@current_path} />
-            <.nav_link href={~p"/help"} label="Help" current={@current_path} />
-            <.nav_link
-              :if={assigns[:current_user] && assigns.current_user.role == "admin"}
-              href={~p"/admin"}
-              label="Admin"
-              current={@current_path}
-            />
-          </div>
-
-          <%!-- Sidebar footer --%>
-          <div class="border-t border-[var(--color-border)] px-3 py-2.5 shrink-0">
-            <div class="flex items-center justify-between gap-2">
-              <div class="min-w-0 flex-1">
-                <p
+          <%!-- Sidebar footer: click username to reveal settings --%>
+          <div class="border-t border-[var(--color-border)] shrink-0 flex items-start">
+            <details class="flex-1 min-w-0 group" open={@footer_open}>
+              <summary class="
+                flex items-center gap-2 px-3 py-2.5
+                cursor-pointer select-none
+                list-none [&::-webkit-details-marker]:hidden
+                hover:bg-[var(--color-bg-2)] transition-colors
+              ">
+                <span
                   :if={assigns[:current_user]}
-                  class="text-xs font-medium text-[var(--color-text-primary)] truncate"
+                  class="flex-1 min-w-0 text-xs font-medium text-[var(--color-text-primary)] truncate"
                 >
                   {assigns.current_user.email}
-                </p>
+                </span>
+                <svg
+                  class="size-3.5 shrink-0 text-[var(--color-text-muted)] -rotate-90 group-open:rotate-0 transition-transform duration-150"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+                    clip-rule="evenodd"
+                  />
+                </svg>
+              </summary>
+              <div class="px-2 pt-0.5 pb-2 space-y-0.5 border-t border-[var(--color-border)]">
+                <.nav_link href={~p"/api-keys"} label="API Keys" current={@current_path} />
+                <.nav_link href={~p"/account/billing"} label="Billing" current={@current_path} />
+                <.nav_link href={~p"/audit"} label="Audit log" current={@current_path} />
+                <.nav_link href={~p"/help"} label="Help" current={@current_path} />
+                <.nav_link
+                  :if={assigns[:current_user] && assigns.current_user.role == "admin"}
+                  href={~p"/admin"}
+                  label="Admin"
+                  current={@current_path}
+                />
                 <a
                   href={~p"/auth/logout"}
                   data-method="post"
-                  class="text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+                  class="block rounded-md px-3 py-1 text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)] transition-colors"
                 >
                   Sign out
                 </a>
               </div>
-              <button
-                id="theme-toggle"
-                phx-hook="ThemeToggle"
-                type="button"
-                aria-label="Toggle dark mode"
-                class="shrink-0 rounded-md p-1.5 text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-              >
-                <svg id="theme-icon-moon" class="size-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path d="M17.293 13.293A8 8 0 0 1 6.707 2.707a8.001 8.001 0 1 0 10.586 10.586z" />
-                </svg>
-                <svg id="theme-icon-sun" class="size-4 hidden" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M10 2a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1Zm4 8a4 4 0 1 1-8 0 4 4 0 0 1 8 0Zm-.464 4.95.707.707a1 1 0 0 0 1.414-1.414l-.707-.707a1 1 0 0 0-1.414 1.414Zm2.12-10.607a1 1 0 0 1 0 1.414l-.706.707a1 1 0 1 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 0ZM17 11a1 1 0 1 0 0-2h-1a1 1 0 1 0 0 2h1Zm-7 4a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1ZM5.05 6.464A1 1 0 1 0 6.465 5.05l-.708-.707a1 1 0 0 0-1.414 1.414l.707.707Zm1.414 8.486-.707.707a1 1 0 0 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 1.414ZM4 11a1 1 0 1 0 0-2H3a1 1 0 0 0 0 2h1Z" clip-rule="evenodd" />
-                </svg>
-              </button>
-            </div>
+            </details>
+            <button
+              id="theme-toggle"
+              phx-hook="ThemeToggle"
+              type="button"
+              aria-label="Toggle dark mode"
+              class="shrink-0 mt-1 mr-1.5 rounded-md p-1.5 text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+            >
+              <svg id="theme-icon-moon" class="size-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path d="M17.293 13.293A8 8 0 0 1 6.707 2.707a8.001 8.001 0 1 0 10.586 10.586z" />
+              </svg>
+              <svg id="theme-icon-sun" class="size-4 hidden" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M10 2a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1Zm4 8a4 4 0 1 1-8 0 4 4 0 0 1 8 0Zm-.464 4.95.707.707a1 1 0 0 0 1.414-1.414l-.707-.707a1 1 0 0 0-1.414 1.414Zm2.12-10.607a1 1 0 0 1 0 1.414l-.706.707a1 1 0 1 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 0ZM17 11a1 1 0 1 0 0-2h-1a1 1 0 1 0 0 2h1Zm-7 4a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1ZM5.05 6.464A1 1 0 1 0 6.465 5.05l-.708-.707a1 1 0 0 0-1.414 1.414l.707.707Zm1.414 8.486-.707.707a1 1 0 0 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 1.414ZM4 11a1 1 0 1 0 0-2H3a1 1 0 0 0 0 2h1Z" clip-rule="evenodd" />
+              </svg>
+            </button>
           </div>
         </aside>
 

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -221,17 +221,18 @@ defmodule Fountain.ConversationsContextTest do
       assert Conversations.list_conversations_by_activity(user.id) == []
     end
 
-    test "orders by updated_at descending" do
+    test "orders by most recent activity descending" do
       user = insert_verified_user()
       c1 = insert_conversation(user_id: user.id)
       c2 = insert_conversation(user_id: user.id)
 
-      # Backdate c2 so c1 is guaranteed to sort first regardless of wall-clock
-      # precision (utc_datetime has second granularity).
+      # Backdate c2's inserted_at so c1 sorts first. The activity expression
+      # falls back to inserted_at when there are no turns or log events, so
+      # this is the field that controls ordering for brand-new conversations.
       past = DateTime.add(DateTime.utc_now(), -3600, :second) |> DateTime.truncate(:second)
       Fountain.Repo.update_all(
         Ecto.Query.from(c in Conversation, where: c.id == ^c2.id),
-        set: [updated_at: past]
+        set: [inserted_at: past]
       )
 
       [first | _] = Conversations.list_conversations_by_activity(user.id)
@@ -1758,7 +1759,7 @@ defmodule Fountain.ConversationsContextTest do
 
   describe "factory to_atom_map — safe_to_existing_atom fallback" do
     test "to_atom_map with an unknown string key does not crash and returns the string as fallback" do
-      # "xyzquuxfoo_novel_key_never_an_atom" is not an existing Elixir atom,
+      # \"xyzquuxfoo_novel_key_never_an_atom\" is not an existing Elixir atom,
       # so safe_to_existing_atom triggers its rescue clause and returns the string key.
       result = Fountain.Factory.to_atom_map(%{
         "sprite_name" => "test-sprite",

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1759,7 +1759,7 @@ defmodule Fountain.ConversationsContextTest do
 
   describe "factory to_atom_map — safe_to_existing_atom fallback" do
     test "to_atom_map with an unknown string key does not crash and returns the string as fallback" do
-      # \"xyzquuxfoo_novel_key_never_an_atom\" is not an existing Elixir atom,
+      # "xyzquuxfoo_novel_key_never_an_atom" is not an existing Elixir atom,
       # so safe_to_existing_atom triggers its rescue clause and returns the string key.
       result = Fountain.Factory.to_atom_map(%{
         "sprite_name" => "test-sprite",


### PR DESCRIPTION
## What

The Settings section (API Keys, Billing, Audit log, Help, Admin) and the Sign out link are now hidden behind a collapsible triggered by clicking the username in the sidebar footer. The Tools section (Agents, Environments, Vaults) stays visible since those are operational nav, not settings.

## How it works

- Uses a `<details>`/`<summary>` element, consistent with the existing conversation-group collapsibles
- Clicking the username/email row toggles the menu open/closed with an animated chevron
- The menu auto-opens when the current path is a settings route (`/api-keys`, `/account/billing`, `/audit`, `/help`, `/admin`) so active-page highlighting still works
- The theme toggle is a sibling of `<details>` (not inside `<summary>`) so clicking it doesn't accidentally toggle the menu
- Sign out moved inside the collapsible since it's account-related

## Before / After

**Before:** separate "Settings" section with 5 links always visible in the sidebar, plus user email + sign out at the bottom

**After:** sidebar footer shows username + chevron + theme toggle; clicking username reveals API Keys, Billing, Audit log, Help, Admin, Sign out