### PR TITLE
fix: light mode theming for environments and vaults tables

### DIFF
--- a/apps/fountain/lib/fountain_web/live/environments_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/index.ex
@@ -65,57 +65,51 @@ defmodule FountainWeb.EnvironmentsLive.Index do
           value={@filter_search}
           phx-debounce="200"
           placeholder="Search environments…"
-          class="w-64 rounded border px-3 py-1.5 text-sm focus:outline-none"
-          style="background:#111;border-color:#2a2a2a;color:#e5e7eb;"
+          class="w-64 rounded border border-[var(--color-border)] px-3 py-1.5 text-sm focus:outline-none bg-[var(--color-bg-1)] text-[var(--color-text-primary)]"
         />
       </form>
 
       <%!-- Empty state — no envs at all --%>
       <div
         :if={@envs == [] and @filter_search == ""}
-        class="rounded-lg p-10 text-center"
-        style="background:#0a0a0a;border:1px dashed #2a2a2a;"
+        class="rounded-lg p-10 text-center bg-[var(--color-bg-1)] border border-dashed border-[var(--color-border)]"
       >
-        <p class="text-sm" style="color:#6b7280;">No environments yet.</p>
-        <p class="text-xs mt-1" style="color:#374151;">Create one to configure packages, secrets, and a setup script for your agents.</p>
+        <p class="text-sm text-[var(--color-text-muted)]">No environments yet.</p>
+        <p class="text-xs mt-1 text-[var(--color-text-secondary)]">Create one to configure packages, secrets, and a setup script for your agents.</p>
       </div>
 
       <%!-- Empty state — search returned nothing --%>
       <div
         :if={@envs == [] and @filter_search != ""}
-        class="rounded-lg p-8 text-center"
-        style="background:#0a0a0a;border:1px dashed #2a2a2a;"
+        class="rounded-lg p-8 text-center bg-[var(--color-bg-1)] border border-dashed border-[var(--color-border)]"
       >
-        <p class="text-sm" style="color:#6b7280;">No environments match <span class="font-mono" style="color:#9ca3af;">"{@filter_search}"</span>.</p>
+        <p class="text-sm text-[var(--color-text-muted)]">
+          No environments match <span class="font-mono text-[var(--color-text-secondary)]">&#34;{@filter_search}&#34;</span>.
+        </p>
       </div>
 
       <%!-- Table --%>
       <table
         :if={@envs != []}
-        class="w-full text-sm rounded-lg overflow-hidden"
-        style="background:#0a0a0a;border:1px solid #1a1a1a;"
+        class="w-full text-sm rounded-lg overflow-hidden bg-[var(--color-bg-1)] border border-[var(--color-border)]"
       >
-        <thead style="border-bottom:1px solid #222;">
+        <thead class="border-b border-[var(--color-border)]">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Name</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Network</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Setup</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Stats</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Name</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Network</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Setup</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Stats</th>
             <th class="px-4 py-3"></th>
           </tr>
         </thead>
         <tbody>
           <tr
             :for={e <- @envs}
-            class="hover:bg-[#0d1117] transition-colors duration-150"
-            style="border-bottom:1px solid #161616;"
+            class="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-bg-2)] transition-colors duration-150"
           >
-            <td class="px-4 py-3 font-medium" style="color:#e5e7eb;">{e.name}</td>
+            <td class="px-4 py-3 font-medium text-[var(--color-text-primary)]">{e.name}</td>
             <td class="px-4 py-3">
-              <span
-                class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold"
-                style={networking_badge_style(e.networking_type)}
-              >
+              <span class={["inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold", networking_badge_class(e.networking_type)]}>
                 <span class="w-1.5 h-1.5 rounded-full" style="background:currentColor;"></span>
                 {e.networking_type}
               </span>
@@ -123,49 +117,40 @@ defmodule FountainWeb.EnvironmentsLive.Index do
             <td class="px-4 py-3">
               <span
                 :if={e.setup_script != ""}
-                class="font-mono text-xs block truncate max-w-xs"
-                style="color:#4b5563;"
+                class="font-mono text-xs block truncate max-w-xs text-[var(--color-text-muted)]"
                 title={e.setup_script}
               >{truncate(e.setup_script, 48)}</span>
-              <span :if={e.setup_script == ""} style="color:#374151;">—</span>
+              <span :if={e.setup_script == ""} class="text-[var(--color-text-muted)]">&#8212;</span>
             </td>
             <td class="px-4 py-3">
               <div class="flex items-center gap-1.5 flex-wrap">
                 <span
-                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                  style={stat_badge_style(:secrets, e.secret_count)}
+                  class={["inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium", stat_badge_class(:secrets, e.secret_count)]}
                   title={"#{e.secret_count} secrets"}
-                >🔑 {e.secret_count}</span>
+                >&#128273; {e.secret_count}</span>
                 <span
-                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                  style={stat_badge_style(:agents, e.agent_count)}
+                  class={["inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium", stat_badge_class(:agents, e.agent_count)]}
                   title={"#{e.agent_count} agents"}
-                >⚡ {e.agent_count}</span>
+                >&#9889; {e.agent_count}</span>
                 <span
                   :if={map_size(e.packages) > 0}
-                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                  style="background:#150d25;color:#a78bfa;border:1px solid #2a1a4a;"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-[var(--color-bg-2)] text-[var(--color-brand)] border border-[var(--color-brand)]"
                   title={"#{map_size(e.packages)} packages"}
-                >📦 {map_size(e.packages)}</span>
+                >&#128230; {map_size(e.packages)}</span>
                 <span
                   :if={length(e.repositories) > 0}
-                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                  style="background:#0d1525;color:#93c5fd;border:1px solid #1a2a4a;"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-[var(--color-info-bg)] text-[var(--color-info-text)] border border-[var(--color-info)]"
                   title={"#{length(e.repositories)} repos"}
-                >⑂ {length(e.repositories)}</span>
+                >&#9322; {length(e.repositories)}</span>
               </div>
             </td>
             <td class="px-4 py-3 text-right">
               <div class="inline-flex gap-1">
                 <.link navigate={~p"/environments/#{e.id}/edit"}>
-                  <button
-                    class="px-2 py-1 rounded text-xs cursor-pointer"
-                    style="background:#1a1a1a;border:1px solid #2a2a2a;color:#9ca3af;"
-                  >Edit</button>
+                  <.btn_secondary>Edit</.btn_secondary>
                 </.link>
                 <button
-                  class="px-2 py-1 rounded text-xs cursor-pointer"
-                  style="background:#1a0d0d;border:1px solid #3a1a1a;color:#f87171;"
+                  class="px-2 py-1 rounded text-xs cursor-pointer bg-[var(--color-error-bg)] border border-[var(--color-error)] text-[var(--color-error-text)] hover:bg-[var(--color-error)] hover:text-white transition-colors"
                   phx-click="delete"
                   phx-value-id={e.id}
                   data-confirm="Delete environment?"
@@ -182,21 +167,26 @@ defmodule FountainWeb.EnvironmentsLive.Index do
   defp truncate(str, max) when byte_size(str) <= max, do: str
   defp truncate(str, max), do: binary_part(str, 0, max) <> "…"
 
-  defp networking_badge_style("unrestricted"),
-    do: "background:#0d1f0d;color:#6ee7b7;border:1px solid #1a3a1a;"
+  defp networking_badge_class("unrestricted"),
+    do:
+      "bg-[var(--color-success-bg)] text-[var(--color-success-text)] border border-[var(--color-success)]"
 
-  defp networking_badge_style("limited"),
-    do: "background:#1a1200;color:#fbbf24;border:1px solid #3a2a00;"
+  defp networking_badge_class("limited"),
+    do:
+      "bg-[var(--color-warning-bg)] text-[var(--color-warning-text)] border border-[var(--color-warning)]"
 
-  defp networking_badge_style(_),
-    do: "background:#1a1a1a;color:#9ca3af;border:1px solid #2a2a2a;"
+  defp networking_badge_class(_),
+    do:
+      "bg-[var(--color-bg-2)] text-[var(--color-text-secondary)] border border-[var(--color-border)]"
 
-  defp stat_badge_style(_type, 0),
-    do: "background:#111;color:#374151;border:1px solid #1f1f1f;"
+  defp stat_badge_class(_type, 0),
+    do: "bg-[var(--color-bg-2)] text-[var(--color-text-muted)] border border-[var(--color-border)]"
 
-  defp stat_badge_style(:secrets, _),
-    do: "background:#1a1200;color:#fbbf24;border:1px solid #3a2a00;"
+  defp stat_badge_class(:secrets, _),
+    do:
+      "bg-[var(--color-warning-bg)] text-[var(--color-warning-text)] border border-[var(--color-warning)]"
 
-  defp stat_badge_style(:agents, _),
-    do: "background:#0d1f0d;color:#6ee7b7;border:1px solid #1a3a1a;"
+  defp stat_badge_class(:agents, _),
+    do:
+      "bg-[var(--color-success-bg)] text-[var(--color-success-text)] border border-[var(--color-success)]"
 end

--- a/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
@@ -57,9 +57,9 @@ defmodule FountainWeb.VaultsLive.Index do
         <.link navigate={~p"/vaults/new"}><.btn>+ New vault</.btn></.link>
       </div>
 
-      <p class="text-sm max-w-2xl" style="color:#6b7280;">
-        A <strong style="color:#9ca3af;">vault</strong> is a bag of env-var overrides — your credentials, a teammate's, or a virtual identity.
-        Pick one when starting a conversation and its values override the environment's baseline secrets at sprite spawn.
+      <p class="text-sm max-w-2xl text-[var(--color-text-muted)]">
+        A <strong class="text-[var(--color-text-secondary)]">vault</strong> is a bag of env-var overrides — your credentials, a teammate&#39;s, or a virtual identity.
+        Pick one when starting a conversation and its values override the environment&#39;s baseline secrets at sprite spawn.
       </p>
 
       <%!-- Search bar --%>
@@ -70,78 +70,69 @@ defmodule FountainWeb.VaultsLive.Index do
           value={@filter_search}
           phx-debounce="200"
           placeholder="Search vaults…"
-          class="w-64 rounded border px-3 py-1.5 text-sm focus:outline-none"
-          style="background:#111;border-color:#2a2a2a;color:#e5e7eb;"
+          class="w-64 rounded border border-[var(--color-border)] px-3 py-1.5 text-sm focus:outline-none bg-[var(--color-bg-1)] text-[var(--color-text-primary)]"
         />
       </form>
 
       <%!-- Empty state — no vaults at all --%>
       <div
         :if={@vaults == [] and @filter_search == ""}
-        class="rounded-lg p-10 text-center"
-        style="background:#0a0a0a;border:1px dashed #2a2a2a;"
+        class="rounded-lg p-10 text-center bg-[var(--color-bg-1)] border border-dashed border-[var(--color-border)]"
       >
-        <p class="text-sm" style="color:#6b7280;">No vaults yet.</p>
-        <p class="text-xs mt-1" style="color:#374151;">Create a vault to store a set of credential overrides you can apply per conversation.</p>
+        <p class="text-sm text-[var(--color-text-muted)]">No vaults yet.</p>
+        <p class="text-xs mt-1 text-[var(--color-text-secondary)]">Create a vault to store a set of credential overrides you can apply per conversation.</p>
       </div>
 
       <%!-- Empty state — search returned nothing --%>
       <div
         :if={@vaults == [] and @filter_search != ""}
-        class="rounded-lg p-8 text-center"
-        style="background:#0a0a0a;border:1px dashed #2a2a2a;"
+        class="rounded-lg p-8 text-center bg-[var(--color-bg-1)] border border-dashed border-[var(--color-border)]"
       >
-        <p class="text-sm" style="color:#6b7280;">No vaults match <span class="font-mono" style="color:#9ca3af;">"{@filter_search}"</span>.</p>
+        <p class="text-sm text-[var(--color-text-muted)]">
+          No vaults match <span class="font-mono text-[var(--color-text-secondary)]">&#34;{@filter_search}&#34;</span>.
+        </p>
       </div>
 
       <%!-- Table --%>
       <table
         :if={@vaults != []}
-        class="w-full text-sm rounded-lg overflow-hidden"
-        style="background:#0a0a0a;border:1px solid #1a1a1a;"
+        class="w-full text-sm rounded-lg overflow-hidden bg-[var(--color-bg-1)] border border-[var(--color-border)]"
       >
-        <thead style="border-bottom:1px solid #222;">
+        <thead class="border-b border-[var(--color-border)]">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Name</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Description</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide" style="color:#4b5563;">Secrets</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Name</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Description</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Secrets</th>
             <th class="px-4 py-3"></th>
           </tr>
         </thead>
         <tbody>
           <tr
             :for={v <- @vaults}
-            class="hover:bg-[#0d1117] transition-colors duration-150"
-            style="border-bottom:1px solid #161616;"
+            class="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-bg-2)] transition-colors duration-150"
           >
-            <td class="px-4 py-3 font-medium" style="color:#e5e7eb;">{v.name}</td>
+            <td class="px-4 py-3 font-medium text-[var(--color-text-primary)]">{v.name}</td>
             <td class="px-4 py-3 max-w-md">
               <span
                 :if={v.description != ""}
-                class="text-xs block truncate"
-                style="color:#4b5563;"
+                class="text-xs block truncate text-[var(--color-text-muted)]"
                 title={v.description}
               >{v.description}</span>
-              <span :if={v.description == ""} style="color:#374151;">—</span>
+              <span :if={v.description == ""} class="text-[var(--color-text-muted)]">&#8212;</span>
             </td>
             <td class="px-4 py-3">
               <span
-                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                style={secrets_badge_style(v.secret_count)}
+                class={["inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium", secrets_badge_class(v.secret_count)]}
                 title={"#{v.secret_count} secrets"}
-              >🔑 {v.secret_count}</span>
+              >&#128273; {v.secret_count}</span>
             </td>
             <td class="px-4 py-3 text-right">
               <div class="inline-flex gap-1">
                 <.link navigate={~p"/vaults/#{v.id}/edit"}>
-                  <button
-                    class="px-2 py-1 rounded text-xs cursor-pointer"
-                    style="background:#1a1a1a;border:1px solid #2a2a2a;color:#9ca3af;"
-                  >Edit</button>
+                  <.btn_secondary>Edit</.btn_secondary>
                 </.link>
                 <button
-                  class="px-2 py-1 rounded text-xs cursor-pointer"
-                  style="background:#1a0d0d;border:1px solid #3a1a1a;color:#f87171;"
+                  class="px-2 py-1 rounded text-xs cursor-pointer bg-[var(--color-error-bg)] border border-[var(--color-error)] text-[var(--color-error-text)] hover:bg-[var(--color-error)] hover:text-white transition-colors"
                   phx-click="delete"
                   phx-value-id={v.id}
                   data-confirm="Delete vault?"
@@ -155,9 +146,10 @@ defmodule FountainWeb.VaultsLive.Index do
     """
   end
 
-  defp secrets_badge_style(0),
-    do: "background:#111;color:#374151;border:1px solid #1f1f1f;"
+  defp secrets_badge_class(0),
+    do: "bg-[var(--color-bg-2)] text-[var(--color-text-muted)] border border-[var(--color-border)]"
 
-  defp secrets_badge_style(_),
-    do: "background:#1a1200;color:#fbbf24;border:1px solid #3a2a00;"
+  defp secrets_badge_class(_),
+    do:
+      "bg-[var(--color-warning-bg)] text-[var(--color-warning-text)] border border-[var(--color-warning)]"
 end


### PR DESCRIPTION
## Summary

- Environments and vaults list pages had hardcoded dark-mode hex colors in inline `style=` attributes throughout — tables, badges, empty states, inputs, and buttons were all invisible/broken in light mode
- Applied the same CSS variable pattern already used on the agents page (`var(--color-bg-1)`, `var(--color-border)`, `var(--color-text-muted)`, etc.) to both pages
- Renamed private `*_badge_style` helpers → `*_badge_class`; they now return Tailwind class strings instead of inline style strings, and call sites updated to use `class=` accordingly
- Edit buttons changed from raw `<button style="...">` to `<.btn_secondary>` (consistent with agents page)
- Delete buttons changed from hardcoded dark red to `var(--color-error-*)` CSS variables
- Packages badge (was hardcoded purple) → `brand` CSS variable; repos badge (was hardcoded blue) → `info` CSS variables

## Test plan

- [ ] Light mode: table rows, headers, badges, empty states, inputs all readable
- [ ] Dark mode: no regression — CSS variables resolve to the same dark palette
- [ ] CI green: format, compile, credo, tests