### PR TITLE
fix: agents new/edit buttons don't navigate

### DIFF
--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -196,7 +196,7 @@ defmodule FountainWeb.AgentsLive.Index do
       <div class="flex-1 min-w-0 space-y-4">
         <div class="flex items-center justify-between">
           <h1 class="text-2xl font-semibold">Agents</h1>
-          <.link navigate={~p"/agents/new"}><.btn>+ New agent</.btn></.link>
+          <.link href={~p"/agents/new"}><.btn>+ New agent</.btn></.link>
         </div>
 
         <div
@@ -275,7 +275,7 @@ defmodule FountainWeb.AgentsLive.Index do
               </td>
               <td class="px-4 py-3 text-right">
                 <div class="inline-flex gap-1">
-                  <.link navigate={~p"/agents/#{a.id}/edit"}>
+                  <.link href={~p"/agents/#{a.id}/edit"}>
                     <.btn_secondary>Edit</.btn_secondary>
                   </.link>
                   <button

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -1,0 +1,95 @@
+defmodule FountainWeb.AgentsLive.IndexTest do
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  describe "index" do
+    test "renders agent list for authenticated user", %{conn: conn} do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/agents")
+
+      assert html =~ agent.name
+      assert html =~ "+ New agent"
+      assert html =~ "Edit"
+    end
+
+    test "renders empty state when user has no agents", %{conn: conn} do
+      user = insert_verified_user()
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/agents")
+
+      assert html =~ "No agents yet"
+    end
+
+    test "new agent button uses plain href (not LiveView navigate)", %{conn: conn} do
+      user = insert_verified_user()
+      conn = login_user(conn, user)
+
+      {:ok, view, _html} = live(conn, ~p"/agents")
+
+      # Must be a plain href so the browser always performs a real navigation.
+      # Regression: navigate= was a no-op in some LiveSocket states (e.g. after
+      # visiting a conversation page where JS hooks had been mounted).
+      assert has_element?(view, ~s(a[href="/agents/new"]))
+      refute has_element?(view, ~s(a[data-phx-link][href="/agents/new"]))
+    end
+
+    test "edit button uses plain href (not LiveView navigate)", %{conn: conn} do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      conn = login_user(conn, user)
+
+      {:ok, view, _html} = live(conn, ~p"/agents")
+
+      assert has_element?(view, ~s(a[href="/agents/#{agent.id}/edit"]))
+      refute has_element?(view, ~s(a[data-phx-link][href="/agents/#{agent.id}/edit"]))
+    end
+
+    test "redirects unauthenticated user to login", %{conn: conn} do
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/agents")
+      assert path =~ "/auth/login"
+    end
+  end
+
+  describe "new" do
+    test "renders new agent form for authenticated user", %{conn: conn} do
+      user = insert_verified_user()
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/agents/new")
+
+      assert html =~ "New agent"
+      assert html =~ "phx-submit"
+    end
+
+    test "redirects unauthenticated user to login", %{conn: conn} do
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/agents/new")
+      assert path =~ "/auth/login"
+    end
+  end
+
+  describe "edit" do
+    test "renders edit form for existing agent", %{conn: conn} do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+
+      assert html =~ "Edit agent"
+      assert html =~ agent.name
+    end
+
+    test "redirects unauthenticated user to login", %{conn: conn} do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/agents/#{agent.id}/edit")
+      assert path =~ "/auth/login"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Clicking **+ New agent** on the agents list page does nothing. Clicking **Edit** on an agent row also does nothing.

Both buttons used `<.link navigate={...}>` wrapping a `<.btn>` / `<.btn_secondary>` component. In some LiveSocket states — notably after visiting a conversation detail page where JS hooks were previously mounted — `navigate=` is a no-op and the page doesn't change.

## Fix

Changed both links to `<.link href={...}>` so the browser always performs a real HTTP navigation, regardless of LiveSocket state. This is the same fix applied to the "+ New Conversation" sidebar button in #98, and matches the pattern used throughout the sidebar nav.

```diff
- <.link navigate={~p"/agents/new"}><.btn>+ New agent</.btn></.link>
+ <.link href={~p"/agents/new"}><.btn>+ New agent</.btn></.link>

- <.link navigate={~p"/agents/#{a.id}/edit"}>
+ <.link href={~p"/agents/#{a.id}/edit"}>
```

## Tests

Added `agents_live_test.exs` covering:
- Index mounts with and without agents
- New agent button renders as plain `href` (regression assertion: no `data-phx-link` attribute)
- Edit button renders as plain `href` (same regression assertion)
- `/agents/new` mounts the form correctly
- `/agents/:id/edit` mounts the edit form correctly
- Unauthenticated users are redirected for all three routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)