### PR TITLE
feat: persist roots filter and visible streams preferences in DB

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -155,6 +155,21 @@ defmodule Fountain.Accounts do
   end
 
   @doc """
+  Update conversation filter preferences for the user.
+
+  Accepts a subset of: `conversations_roots_only` (boolean) and
+  `conversation_visible_streams` (list of "stdout", "stderr", "stage").
+
+  Returns `{:ok, user}` or `{:error, changeset}`.
+  """
+  @spec update_preferences(User.t(), map()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  def update_preferences(%User{} = user, attrs) do
+    user
+    |> User.preferences_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
   Find or create a user from an OAuth provider callback.
 
   Looks up by `(provider, provider_uid)` first; falls back to email lookup

--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -8,6 +8,7 @@ defmodule Fountain.Accounts.User do
   @roles ~w(user admin)
   @subscription_statuses ~w(trialing active past_due canceled)
   @theme_values ~w(light dark system)
+  @visible_stream_values ~w(stdout stderr stage)
 
   schema "users" do
     field :email, :string
@@ -23,6 +24,8 @@ defmodule Fountain.Accounts.User do
     field :trial_ends_at, :utc_datetime
     field :session_version, :integer, default: 0
     field :theme_preference, :string, default: "system"
+    field :conversations_roots_only, :boolean, default: false
+    field :conversation_visible_streams, {:array, :string}, default: ["stdout", "stderr", "stage"]
 
     has_many :api_keys, Fountain.Accounts.ApiKey
     has_one :data_key, Fountain.Accounts.UserDataKey
@@ -71,6 +74,13 @@ defmodule Fountain.Accounts.User do
     user
     |> cast(attrs, [:theme_preference])
     |> validate_inclusion(:theme_preference, @theme_values)
+  end
+
+  @doc "Changeset for updating conversation filter preferences."
+  def preferences_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:conversations_roots_only, :conversation_visible_streams])
+    |> validate_subset(:conversation_visible_streams, @visible_stream_values)
   end
 
   @doc "Changeset for resetting a password (validates + hashes new password)."

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -255,14 +255,30 @@ defmodule Fountain.Conversations do
     |> Repo.preload([:sandbox, :agent, :vault])
   end
 
-  @doc "List conversations for user, ordered by most recently active."
-  def list_conversations(user_id) when is_binary(user_id) do
-    Repo.all(
+  @doc """
+  List conversations for user, ordered by most recently updated.
+
+  Pass `roots_only: true` to exclude child conversations (those with a
+  `parent_conversation_id`). Useful for hiding agent-spawned sub-conversations
+  from the index when the user only wants to see top-level sessions.
+  """
+  def list_conversations(user_id, opts \\ []) when is_binary(user_id) do
+    roots_only = Keyword.get(opts, :roots_only, false)
+
+    base =
       from c in Conversation,
         where: c.user_id == ^user_id,
         order_by: [desc: c.updated_at, desc: c.id],
         preload: [:agent, turns: ^first_turn_query()]
-    )
+
+    query =
+      if roots_only do
+        from c in base, where: is_nil(c.parent_conversation_id)
+      else
+        base
+      end
+
+    Repo.all(query)
   end
 
   def create_conversation(attrs) do

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -2,7 +2,7 @@ defmodule FountainWeb.ConversationsLive.Index do
   @moduledoc false
   use FountainWeb, :live_view
 
-  alias Fountain.{Agents, Conversations}
+  alias Fountain.{Accounts, Agents, Conversations}
 
   @poll_interval 2_000
 
@@ -10,11 +10,14 @@ defmodule FountainWeb.ConversationsLive.Index do
   def mount(_params, _session, socket) do
     if connected?(socket), do: Process.send_after(self(), :tick, @poll_interval)
 
+    user = socket.assigns.current_user
+
     {:ok,
      socket
      |> assign(:page_title, "Conversations")
      |> assign(:sort_by, :inserted_at)
      |> assign(:sort_dir, :desc)
+     |> assign(:roots_only, user.conversations_roots_only)
      |> load_data()}
   end
 
@@ -69,9 +72,26 @@ defmodule FountainWeb.ConversationsLive.Index do
      |> load_data()}
   end
 
+  def handle_event("toggle_roots_only", _, socket) do
+    user = socket.assigns.current_user
+    roots_only = !socket.assigns.roots_only
+
+    case Accounts.update_preferences(user, %{conversations_roots_only: roots_only}) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> assign(:roots_only, roots_only)
+         |> load_data()}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Could not save preference")}
+    end
+  end
+
   defp load_data(socket) do
     user_id = socket.assigns.current_user.id
-    convs = Conversations.list_conversations(user_id)
+    roots_only = socket.assigns.roots_only
+    convs = Conversations.list_conversations(user_id, roots_only: roots_only)
     agents = Agents.list_agents(user_id, [])
 
     sorted = sort_conversations(convs, socket.assigns.sort_by, socket.assigns.sort_dir)
@@ -105,9 +125,24 @@ defmodule FountainWeb.ConversationsLive.Index do
     <div class="space-y-4">
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Conversations</h1>
-        <.link navigate={~p"/conversations/new"}>
-          <.button>+ New conversation</.button>
-        </.link>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            phx-click="toggle_roots_only"
+            class={[
+              "px-3 py-1 rounded text-sm font-mono border",
+              if(@roots_only,
+                do: "bg-[var(--color-bg-2)] text-[var(--color-text-primary)] border-[var(--color-border)]",
+                else: "text-[var(--color-text-muted)] border-[var(--color-border)] hover:text-[var(--color-text-secondary)]"
+              )
+            ]}
+          >
+            {if @roots_only, do: "roots only", else: "all"}
+          </button>
+          <.link navigate={~p"/conversations/new"}>
+            <.button>+ New conversation</.button>
+          </.link>
+        </div>
       </div>
 
       <.table

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -2,6 +2,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   @moduledoc false
   use FountainWeb, :live_view
 
+  alias Fountain.Accounts
   alias Fountain.Conversations
   alias Fountain.Conversations.{ConversationServer, LogEvent}
 
@@ -38,7 +39,7 @@ defmodule FountainWeb.ConversationsLive.Show do
          |> assign(:conv, conv)
          |> assign(:events, events)
          |> assign(:turns_by_id, load_turns(id))
-         |> assign(:visible_streams, MapSet.new(["stdout", "stderr", "stage"]))
+         |> assign(:visible_streams, MapSet.new(initial_visible_streams(socket.assigns.current_user)))
          |> assign(:view_mode, :pretty)
          |> assign(:prompt, "")
          |> assign(:pending_images, [])
@@ -54,6 +55,13 @@ defmodule FountainWeb.ConversationsLive.Show do
       Map.put(t, :image_count, image_count)
     end)
     |> Map.new(&{&1.id, &1})
+  end
+
+  defp initial_visible_streams(user) do
+    case user.conversation_visible_streams do
+      streams when is_list(streams) -> streams
+      _ -> ["stdout", "stderr", "stage"]
+    end
   end
 
   # Pair `started`/`done` stage events by name (most recent open
@@ -197,10 +205,11 @@ defmodule FountainWeb.ConversationsLive.Show do
     {:noreply, assign(socket, :prompt, p)}
   end
 
-  # Toggle a stream filter pill on/off. Defaults to all three on.
-  # Note: we name the assign `:visible_streams` rather than `:streams`
-  # because Phoenix LiveView reserves `:streams` for its built-in
-  # streams collection API and refuses to let us shadow it.
+  # Toggle a stream filter pill on/off. Persists the new preference to the
+  # database so it survives page reloads. Note: we name the assign
+  # `:visible_streams` rather than `:streams` because Phoenix LiveView
+  # reserves `:streams` for its built-in streams collection API and
+  # refuses to let us shadow it.
   def handle_event("toggle_stream", %{"stream" => name}, socket) do
     visible =
       if MapSet.member?(socket.assigns.visible_streams, name) do
@@ -208,6 +217,11 @@ defmodule FountainWeb.ConversationsLive.Show do
       else
         MapSet.put(socket.assigns.visible_streams, name)
       end
+
+    Accounts.update_preferences(
+      socket.assigns.current_user,
+      %{conversation_visible_streams: MapSet.to_list(visible)}
+    )
 
     {:noreply, assign(socket, :visible_streams, visible)}
   end
@@ -675,7 +689,7 @@ defmodule FountainWeb.ConversationsLive.Show do
     """
   end
 
-  # ── grouping events into stage sections ─────────────────────────────────────────────
+  # ── grouping events into stage sections ───────────────────────────────────────────────
 
   # Walk the events list and produce a flat list of "tree nodes" where
   # each `started`-stage event opens a `:section` node that contains all
@@ -786,7 +800,7 @@ defmodule FountainWeb.ConversationsLive.Show do
     }
   end
 
-  # ── tree node renderer ─────────────────────────────────────────────
+  # ── tree node renderer ───────────────────────────────────────────────────
 
   attr :node, :map, required: true
   attr :runtime, :string, required: true
@@ -977,7 +991,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   attr :block, :map, required: true
   attr :stream, :string, default: nil
 
-  # ── per-block renderers ──────────────────────────────────────────────
+  # ── per-block renderers ────────────────────────────────────────────────────
 
   defp block_row(%{block: %{kind: :init}} = assigns) do
     ~H"""
@@ -1069,7 +1083,7 @@ defmodule FountainWeb.ConversationsLive.Show do
     """
   end
 
-  # ── event → blocks ────────────────────────────────────────────
+  # ── event → blocks ──────────────────────────────────────────────
 
   # Splits an event's `data` (which may be a stream-json chunk with N
   # lines) into a flat list of structured blocks. Each block is a map
@@ -1142,7 +1156,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   defp short_kind(%{"type" => t}), do: to_string(t)
   defp short_kind(_), do: "raw"
 
-  # ── claude (stream-json) ─────────────────────────────────────────────────
+  # ── claude (stream-json) ────────────────────────────────────────────────────────────
   defp event_blocks("claude", %{"type" => "system", "subtype" => "init"} = ev) do
     model = ev["model"]
 
@@ -1222,7 +1236,7 @@ defmodule FountainWeb.ConversationsLive.Show do
 
   defp event_blocks("claude", %{"type" => "rate_limit_event"}), do: []
 
-  # ── codex (`codex exec --json`) ───────────────────────────────────────────────────
+  # ── codex (`codex exec --json`) ────────────────────────────────────────────────────────
   defp event_blocks("codex", %{"type" => "thread.started", "thread_id" => id}),
     do: [%{kind: :init, summary: "thread: #{id}"}]
 
@@ -1306,7 +1320,7 @@ defmodule FountainWeb.ConversationsLive.Show do
     [%{kind: :result, body: bits, raw: Jason.encode!(ev, pretty: true)}]
   end
 
-  # ── opencode (`opencode run --format json`) ───────────────────────────────
+  # ── opencode (`opencode run --format json`) ───────────────────────────────────
   defp event_blocks("opencode", %{"type" => "step_start"}), do: []
 
   defp event_blocks("opencode", %{"type" => "text", "part" => %{"text" => t}})
@@ -1356,7 +1370,7 @@ defmodule FountainWeb.ConversationsLive.Show do
 
   defp truncate(s, _), do: s
 
-  # ── stage row helpers ──────────────────────────────────────────────────
+  # ── stage row helpers ───────────────────────────────────────────────────────
 
   defp stage_icon("provision"), do: "&#10024;"
   defp stage_icon("checkpoint_restore"), do: "&#128230;"

--- a/apps/fountain/priv/repo/migrations/20260513000000_add_user_filter_preferences.exs
+++ b/apps/fountain/priv/repo/migrations/20260513000000_add_user_filter_preferences.exs
@@ -1,0 +1,10 @@
+defmodule Fountain.Repo.Migrations.AddUserFilterPreferences do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :conversations_roots_only, :boolean, null: false, default: false
+      add :conversation_visible_streams, {:array, :string}, null: false, default: ["stdout", "stderr", "stage"]
+    end
+  end
+end

--- a/apps/fountain/test/fountain/accounts_preferences_test.exs
+++ b/apps/fountain/test/fountain/accounts_preferences_test.exs
@@ -1,0 +1,76 @@
+defmodule Fountain.AccountsPreferencesTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts
+  alias Fountain.Accounts.User
+
+  describe "User.preferences_changeset/2" do
+    test "accepts valid conversations_roots_only values" do
+      for val <- [true, false] do
+        cs = User.preferences_changeset(%User{}, %{conversations_roots_only: val})
+        assert cs.valid?, "expected #{inspect(val)} to be valid"
+      end
+    end
+
+    test "accepts valid conversation_visible_streams subsets" do
+      for streams <- [[], ["stdout"], ["stderr"], ["stage"], ["stdout", "stderr"], ["stdout", "stderr", "stage"]] do
+        cs = User.preferences_changeset(%User{}, %{conversation_visible_streams: streams})
+        assert cs.valid?, "expected #{inspect(streams)} to be valid"
+      end
+    end
+
+    test "rejects invalid stream values" do
+      cs = User.preferences_changeset(%User{}, %{conversation_visible_streams: ["stdout", "invalid"]})
+      refute cs.valid?
+      assert cs.errors[:conversation_visible_streams] != nil
+    end
+
+    test "accepts partial updates (only roots_only)" do
+      cs = User.preferences_changeset(%User{}, %{conversations_roots_only: true})
+      assert cs.valid?
+    end
+
+    test "accepts partial updates (only visible_streams)" do
+      cs = User.preferences_changeset(%User{}, %{conversation_visible_streams: ["stdout"]})
+      assert cs.valid?
+    end
+  end
+
+  describe "Accounts.update_preferences/2" do
+    setup do
+      {:ok, user: insert_verified_user()}
+    end
+
+    test "persists conversations_roots_only", %{user: user} do
+      assert {:ok, updated} = Accounts.update_preferences(user, %{conversations_roots_only: true})
+      assert updated.conversations_roots_only == true
+
+      reloaded = Accounts.get_user!(user.id)
+      assert reloaded.conversations_roots_only == true
+    end
+
+    test "persists conversation_visible_streams", %{user: user} do
+      streams = ["stdout", "stage"]
+      assert {:ok, updated} = Accounts.update_preferences(user, %{conversation_visible_streams: streams})
+      assert updated.conversation_visible_streams == streams
+
+      reloaded = Accounts.get_user!(user.id)
+      assert reloaded.conversation_visible_streams == streams
+    end
+
+    test "persists empty visible_streams list", %{user: user} do
+      assert {:ok, updated} = Accounts.update_preferences(user, %{conversation_visible_streams: []})
+      assert updated.conversation_visible_streams == []
+    end
+
+    test "returns error changeset for invalid streams", %{user: user} do
+      assert {:error, changeset} = Accounts.update_preferences(user, %{conversation_visible_streams: ["bad"]})
+      assert changeset.errors[:conversation_visible_streams] != nil
+    end
+
+    test "new users default to roots_only false and all streams", %{user: user} do
+      assert user.conversations_roots_only == false
+      assert user.conversation_visible_streams == ["stdout", "stderr", "stage"]
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations_roots_filter_test.exs
+++ b/apps/fountain/test/fountain/conversations_roots_filter_test.exs
@@ -1,0 +1,49 @@
+defmodule Fountain.ConversationsRootsFilterTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+
+  describe "list_conversations/2 with roots_only" do
+    setup do
+      user = insert_verified_user()
+      root = insert_conversation(user_id: user.id)
+      child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
+      %{user: user, root: root, child: child}
+    end
+
+    test "default (no opts) returns all conversations", %{user: user, root: root, child: child} do
+      ids = Conversations.list_conversations(user.id) |> Enum.map(& &1.id)
+      assert root.id in ids
+      assert child.id in ids
+    end
+
+    test "roots_only: false returns all conversations", %{user: user, root: root, child: child} do
+      ids = Conversations.list_conversations(user.id, roots_only: false) |> Enum.map(& &1.id)
+      assert root.id in ids
+      assert child.id in ids
+    end
+
+    test "roots_only: true excludes child conversations", %{user: user, root: root, child: child} do
+      ids = Conversations.list_conversations(user.id, roots_only: true) |> Enum.map(& &1.id)
+      assert root.id in ids
+      refute child.id in ids
+    end
+
+    test "roots_only: true includes conversations without a parent", %{user: user} do
+      standalone = insert_conversation(user_id: user.id)
+      ids = Conversations.list_conversations(user.id, roots_only: true) |> Enum.map(& &1.id)
+      assert standalone.id in ids
+    end
+
+    test "scoping is not affected: does not return other users' roots" do
+      other_user = insert_verified_user()
+      other_root = insert_conversation(user_id: other_user.id)
+
+      user = insert_verified_user()
+      _my_root = insert_conversation(user_id: user.id)
+
+      ids = Conversations.list_conversations(user.id, roots_only: true) |> Enum.map(& &1.id)
+      refute other_root.id in ids
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/conversations_live/index_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/index_test.exs
@@ -1,0 +1,75 @@
+defmodule FountainWeb.ConversationsLive.IndexTest do
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  describe "roots filter" do
+    setup do
+      user = insert_verified_user()
+      root = insert_conversation(user_id: user.id)
+      child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
+      %{user: user, root: root, child: child}
+    end
+
+    test "shows all conversations by default", %{conn: conn, user: user, root: root, child: child} do
+      conn = login_user(conn, user)
+      {:ok, _view, html} = live(conn, ~p"/conversations")
+
+      assert html =~ short(root.id)
+      assert html =~ short(child.id)
+    end
+
+    test "shows only roots when preference is already true", %{conn: conn, user: user, root: root, child: child} do
+      {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversations_roots_only: true})
+      # Reload user from DB so session has current preference
+      user = Fountain.Accounts.get_user!(user.id)
+
+      conn = login_user(conn, user)
+      {:ok, _view, html} = live(conn, ~p"/conversations")
+
+      assert html =~ short(root.id)
+      refute html =~ short(child.id)
+    end
+
+    test "toggle_roots_only hides child conversations and persists preference",
+         %{conn: conn, user: user, root: root, child: child} do
+      conn = login_user(conn, user)
+      {:ok, view, html} = live(conn, ~p"/conversations")
+
+      # Both visible initially
+      assert html =~ short(root.id)
+      assert html =~ short(child.id)
+
+      # Toggle to roots only
+      render_click(view, "toggle_roots_only")
+      html = render(view)
+
+      assert html =~ short(root.id)
+      refute html =~ short(child.id)
+
+      # Preference was persisted
+      reloaded = Fountain.Accounts.get_user!(user.id)
+      assert reloaded.conversations_roots_only == true
+    end
+
+    test "toggle_roots_only back to all shows child again",
+         %{conn: conn, user: user, root: root, child: child} do
+      {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversations_roots_only: true})
+      user = Fountain.Accounts.get_user!(user.id)
+
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations")
+
+      render_click(view, "toggle_roots_only")
+      html = render(view)
+
+      assert html =~ short(root.id)
+      assert html =~ short(child.id)
+
+      reloaded = Fountain.Accounts.get_user!(user.id)
+      assert reloaded.conversations_roots_only == false
+    end
+  end
+
+  defp short(id), do: binary_part(id, 0, 8)
+end

--- a/apps/fountain/test/fountain_web/live/conversations_live/index_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/index_test.exs
@@ -13,39 +13,39 @@ defmodule FountainWeb.ConversationsLive.IndexTest do
 
     test "shows all conversations by default", %{conn: conn, user: user, root: root, child: child} do
       conn = login_user(conn, user)
-      {:ok, _view, html} = live(conn, ~p"/conversations")
+      {:ok, view, _html} = live(conn, ~p"/conversations")
 
-      assert html =~ short(root.id)
-      assert html =~ short(child.id)
+      assert has_element?(view, "[phx-value-id='#{root.id}']")
+      assert has_element?(view, "[phx-value-id='#{child.id}']")
     end
 
-    test "shows only roots when preference is already true", %{conn: conn, user: user, root: root, child: child} do
+    test "shows only roots when preference is already true",
+         %{conn: conn, user: user, root: root, child: child} do
       {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversations_roots_only: true})
       # Reload user from DB so session has current preference
       user = Fountain.Accounts.get_user!(user.id)
 
       conn = login_user(conn, user)
-      {:ok, _view, html} = live(conn, ~p"/conversations")
+      {:ok, view, _html} = live(conn, ~p"/conversations")
 
-      assert html =~ short(root.id)
-      refute html =~ short(child.id)
+      assert has_element?(view, "[phx-value-id='#{root.id}']")
+      refute has_element?(view, "[phx-value-id='#{child.id}']")
     end
 
     test "toggle_roots_only hides child conversations and persists preference",
          %{conn: conn, user: user, root: root, child: child} do
       conn = login_user(conn, user)
-      {:ok, view, html} = live(conn, ~p"/conversations")
+      {:ok, view, _html} = live(conn, ~p"/conversations")
 
       # Both visible initially
-      assert html =~ short(root.id)
-      assert html =~ short(child.id)
+      assert has_element?(view, "[phx-value-id='#{root.id}']")
+      assert has_element?(view, "[phx-value-id='#{child.id}']")
 
       # Toggle to roots only
       render_click(view, "toggle_roots_only")
-      html = render(view)
 
-      assert html =~ short(root.id)
-      refute html =~ short(child.id)
+      assert has_element?(view, "[phx-value-id='#{root.id}']")
+      refute has_element?(view, "[phx-value-id='#{child.id}']")
 
       # Preference was persisted
       reloaded = Fountain.Accounts.get_user!(user.id)
@@ -61,15 +61,12 @@ defmodule FountainWeb.ConversationsLive.IndexTest do
       {:ok, view, _html} = live(conn, ~p"/conversations")
 
       render_click(view, "toggle_roots_only")
-      html = render(view)
 
-      assert html =~ short(root.id)
-      assert html =~ short(child.id)
+      assert has_element?(view, "[phx-value-id='#{root.id}']")
+      assert has_element?(view, "[phx-value-id='#{child.id}']")
 
       reloaded = Fountain.Accounts.get_user!(user.id)
       assert reloaded.conversations_roots_only == false
     end
   end
-
-  defp short(id), do: binary_part(id, 0, 8)
 end

--- a/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
@@ -60,4 +60,48 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
       assert_push_event(view, "view_mode_changed", %{mode: "chat"})
     end
   end
+
+  describe "toggle_stream persists visible_streams" do
+    setup do
+      user = insert_verified_user()
+      conversation = insert_conversation(user_id: user.id)
+      %{user: user, conversation: conversation}
+    end
+
+    test "toggling stdout off persists the preference", %{conn: conn, user: user, conversation: conversation} do
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      view |> element("[phx-click='toggle_stream'][phx-value-stream='stdout']") |> render_click()
+
+      reloaded = Fountain.Accounts.get_user!(user.id)
+      assert "stdout" not in reloaded.conversation_visible_streams
+      assert "stderr" in reloaded.conversation_visible_streams
+      assert "stage" in reloaded.conversation_visible_streams
+    end
+
+    test "toggling stdout back on persists the preference", %{conn: conn, user: user, conversation: conversation} do
+      {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversation_visible_streams: ["stderr", "stage"]})
+      user = Fountain.Accounts.get_user!(user.id)
+
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      view |> element("[phx-click='toggle_stream'][phx-value-stream='stdout']") |> render_click()
+
+      reloaded = Fountain.Accounts.get_user!(user.id)
+      assert "stdout" in reloaded.conversation_visible_streams
+    end
+
+    test "mounts with saved visible_streams preference", %{conn: conn, user: user, conversation: conversation} do
+      {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversation_visible_streams: ["stdout"]})
+      user = Fountain.Accounts.get_user!(user.id)
+
+      conn = login_user(conn, user)
+      {:ok, _view, html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      # stdout pill should be active (not struck through), stderr and stage struck through
+      assert html =~ "toggle_stream"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Stores user filter preferences in the database so they load correctly on mount, eliminating the extra round trips that caused a poor UX.

**Two preferences added:**
- `conversations_roots_only` (boolean) — conversation index toggle to show only root conversations (no parent)
- `conversation_visible_streams` (string array) — which log streams (stdout/stderr/stage) are visible in conversation show view

## Changes

- **Migration**: Adds `conversations_roots_only` and `conversation_visible_streams` columns to `users` table with sensible defaults
- **`User`**: New schema fields + `preferences_changeset/2` with `validate_subset` on stream values
- **`Accounts`**: New `update_preferences/2` context function following the `theme_preference` pattern
- **`Conversations`**: `list_conversations/2` gains optional `roots_only:` keyword arg that filters `parent_conversation_id IS NULL`
- **`conversations_live/index.ex`**: Reads `user.conversations_roots_only` at mount; `toggle_roots_only` event persists + reloads data
- **`conversations_live/show.ex`**: Reads `user.conversation_visible_streams` at mount; `toggle_stream` event persists to DB

## Test plan

- [ ] Unit tests for `preferences_changeset/2` (valid/invalid stream values)
- [ ] Unit tests for `Accounts.update_preferences/2` (persistence, defaults, error cases)
- [ ] Unit tests for `list_conversations/2` with `roots_only:` option
- [ ] LiveView tests for roots filter toggle (mount with saved preference, toggle persists, toggle back)
- [ ] LiveView tests for visible streams toggle (mount with saved preference, toggle persists)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)