### PR TITLE
fix: redirect and show feedback after starting a conversation

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -515,7 +515,7 @@ defmodule Fountain.Conversations do
              source: attrs["source"] || "api",
              parent_conversation_id: attrs["parent_conversation_id"]
            }) do
-      {:ok, _pid} =
+      start_result =
         Horde.DynamicSupervisor.start_child(
           Fountain.ConversationSupervisor,
           {ConversationServer,
@@ -527,15 +527,21 @@ defmodule Fountain.Conversations do
            ]}
         )
 
-      result = _unsafe_get_conversation!(conv.id)
+      case start_result do
+        {:ok, _pid} ->
+          result = _unsafe_get_conversation!(conv.id)
 
-      if result.parent_conversation_id do
-        root_id = get_root_conversation_id(result.id)
-        broadcast_graph_update(root_id)
+          if result.parent_conversation_id do
+            root_id = get_root_conversation_id(result.id)
+            broadcast_graph_update(root_id)
+          end
+
+          broadcast_sidebar_update(user_id)
+          {:ok, result}
+
+        {:error, reason} ->
+          {:error, {:server_start_failed, reason}}
       end
-
-      broadcast_sidebar_update(user_id)
-      {:ok, result}
     else
       nil -> {:error, :not_found}
       {:error, _} = err -> err

--- a/apps/fountain/test/fountain_web/live/conversations_live/new_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/new_test.exs
@@ -63,3 +63,66 @@ defmodule FountainWeb.ConversationsLive.NewTest do
     end
   end
 end
+
+# Submit tests require Mimic global mode (stubs visible to the LiveView
+# process), which is incompatible with async: true — isolated in a
+# separate non-async module.
+defmodule FountainWeb.ConversationsLive.NewSubmitTest do
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  setup :set_mimic_global
+
+  describe "submit" do
+    setup %{conn: conn} do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      conn = login_user(conn, user)
+      {:ok, lv, _html} = live(conn, ~p"/conversations/new")
+      %{lv: lv, agent: agent}
+    end
+
+    test "redirects to the new conversation on success", %{lv: lv, agent: agent} do
+      stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
+        {:ok, :test_pid}
+      end)
+
+      params = %{"agent_id" => agent.id, "prompt" => "hello", "vault_id" => ""}
+
+      assert {:error, {:live_redirect, %{to: path}}} =
+               lv
+               |> element("form[phx-submit='submit']")
+               |> render_submit(%{"conv" => params})
+
+      assert String.starts_with?(path, "/conversations/")
+    end
+
+    test "shows agent-not-found flash when agent_id is unknown", %{lv: lv} do
+      params = %{"agent_id" => Ecto.UUID.generate(), "prompt" => "hello", "vault_id" => ""}
+
+      html =
+        lv
+        |> element("form[phx-submit='submit']")
+        |> render_submit(%{"conv" => params})
+
+      assert html =~ "Agent not found"
+    end
+
+    test "shows error flash when conversation server fails to start", %{lv: lv, agent: agent} do
+      stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
+        {:error, :test_failure}
+      end)
+
+      params = %{"agent_id" => agent.id, "prompt" => "hello", "vault_id" => ""}
+
+      html =
+        lv
+        |> element("form[phx-submit='submit']")
+        |> render_submit(%{"conv" => params})
+
+      assert html =~ "Failed:"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Clicking "Start" on `/conversations/new` left the user on the page with no feedback, even though the conversation was created in the database.

**Root cause:** `start_conversation/1` contained a bare pattern match:

```elixir
{:ok, _pid} = Horde.DynamicSupervisor.start_child(...)
```

When `start_child` returns `{:error, reason}` (e.g. supervisor error, already-started), Elixir raises a `MatchError`. This exception escapes `handle_event("submit", ...)`, crashing the LiveView process. Phoenix reconnects/remounts — the user ends up back on the form with no flash and no redirect. The conversation row was already written to the DB before the crash, so it appeared created but unreachable from the UI.

## Fix

Replace the bare match with a `case` expression so `{:error, reason}` bubbles up as `{:error, {:server_start_failed, reason}}` and is caught by `handle_event`'s existing catch-all clause, showing the user an error flash.

`handle_event` already had correct success/error handling — `push_navigate` on `{:ok, conv}` and `put_flash(:error, ...)` on errors. The bug was entirely in `conversations.ex`.

## Tests

Added `FountainWeb.ConversationsLive.NewSubmitTest` (non-async, Mimic global mode) with three cases:
- Success → redirects to `/conversations/:id`
- Unknown agent → "Agent not found" flash  
- `start_child` returns error → "Failed:" flash

`Horde.DynamicSupervisor` is already `Mimic.copy`'d in `test_helper.exs`.