### PR TITLE
Fix sidebar roots filter resetting on navigation

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -284,13 +284,12 @@
               if (this._removeViewMode) this._removeViewMode();
             }
           },
-          // ── Roots filter persistence (localStorage) ─────────────────────────
+          // ── Roots filter — DB is now the source of truth for the initial render.
+          // This hook only keeps localStorage in sync for informational purposes;
+          // it no longer pushes restore_roots_only on mount since the server reads
+          // the preference from user.conversations_roots_only at mount time.
           RootsFilterPersist: {
             mounted() {
-              const saved = localStorage.getItem("fountain-sidebar-roots-only");
-              if (saved === "true") {
-                this.pushEvent("restore_roots_only", {});
-              }
               this._removeRootsOnly = this.handleEvent("roots_only_changed", ({ value }) => {
                 localStorage.setItem("fountain-sidebar-roots-only", value);
               });

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -128,8 +128,13 @@ defmodule FountainWeb.Live.Hooks do
   # A handle_event hook intercepts the two sidebar filter events
   # (sidebar_toggle_roots_only, sidebar_set_agent_filter) so they never
   # reach — and confuse — the current LiveView's own handle_event.
+  #
+  # sidebar_roots_only is initialised from user.conversations_roots_only (DB)
+  # so the sidebar renders the correct filter state on the very first paint,
+  # with no localStorage round-trip. The toggle also persists back to DB.
   defp mount_live_sidebar(socket) do
-    user_id = socket.assigns.current_user.id
+    user = socket.assigns.current_user
+    user_id = user.id
 
     if connected?(socket) do
       Phoenix.PubSub.subscribe(Fountain.PubSub, "sidebar:#{user_id}")
@@ -137,7 +142,7 @@ defmodule FountainWeb.Live.Hooks do
 
     socket
     |> assign(:nav_conversations, load_sidebar_conversations(user_id))
-    |> assign(:sidebar_roots_only, false)
+    |> assign(:sidebar_roots_only, user.conversations_roots_only)
     |> assign(:sidebar_agent_filter, nil)
     |> attach_hook(:sidebar_nav, :handle_info, fn
       {:sidebar_update, ^user_id}, socket ->
@@ -152,6 +157,8 @@ defmodule FountainWeb.Live.Hooks do
 
       "sidebar_toggle_roots_only", _params, socket ->
         next = !socket.assigns.sidebar_roots_only
+        Accounts.update_preferences(socket.assigns.current_user, %{conversations_roots_only: next})
+
         {:halt,
          socket
          |> assign(:sidebar_roots_only, next)


### PR DESCRIPTION
## Problem

The roots filter was resetting every time the user navigated between conversations. Two bugs caused this:

1. `mount_live_sidebar` hardcoded `sidebar_roots_only: false` on every mount, relying on a JS `restore_roots_only` event from localStorage to fix it up — which always caused a re-render flash and a round trip.
2. The sidebar toggle (`sidebar_toggle_roots_only`) never wrote to the database, so the preference wasn't actually persisted across page loads.

## Fix

- **`hooks.ex`**: `mount_live_sidebar` now reads `sidebar_roots_only` directly from `user.conversations_roots_only` (the DB column added in #101). The `sidebar_toggle_roots_only` event handler now calls `Accounts.update_preferences/2` to persist the change.
- **`root.html.heex`**: Removed the `restore_roots_only` push from `RootsFilterPersist.mounted()` — the server now initialises from DB with no JS round-trip needed. The `roots_only_changed` handler is kept to mirror state to localStorage.

## Result

Filter state is now read from DB at mount (zero extra round trips) and written to DB on every toggle. Navigating between conversations no longer resets the filter.