### PR TITLE
feat: LLM-generated conversation titles in sidebar

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -20,6 +20,7 @@ defmodule Fountain.Conversations.Conversation do
     field :source, :string, default: "api"
     field :parent_conversation_id, :binary_id
     field :callback_api_key_id, :binary_id
+    field :title, :string
 
     # Populated by list_conversations_by_activity/1 — not persisted.
     field :turn_count, :integer, virtual: true, default: 0
@@ -53,6 +54,7 @@ defmodule Fountain.Conversations.Conversation do
       :source,
       :parent_conversation_id,
       :callback_api_key_id,
+      :title,
       :user_id,
       :sandbox_id,
       :agent_id,

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -862,6 +862,23 @@ defmodule Fountain.Conversations.ConversationServer do
     # Store images in DB
     {:ok, _} = Conversations.insert_turn_images(turn.id, images)
 
+    # On the first turn, asynchronously generate a short title for the sidebar.
+    if turn.turn_number == 1 do
+      conv_id = state.conversation_id
+      creds = state.inference_credentials
+
+      Task.start(fn ->
+        case Fountain.Conversations.TitleGenerator.generate(prompt, creds) do
+          {:ok, title} ->
+            fresh = Conversations._unsafe_get_conversation!(conv_id)
+            Conversations.update_conversation(fresh, %{title: title})
+
+          {:error, reason} ->
+            Logger.warning("Title generation failed for conv #{conv_id}: #{inspect(reason)}")
+        end
+      end)
+    end
+
     # Write image temp files to sprite
     image_paths = write_image_temp_files(state.sprite, turn.id, images)
 

--- a/apps/fountain/lib/fountain/conversations/title_generator.ex
+++ b/apps/fountain/lib/fountain/conversations/title_generator.ex
@@ -1,0 +1,147 @@
+defmodule Fountain.Conversations.TitleGenerator do
+  @moduledoc """
+  Generates a short title (≤50 chars) for a conversation's first prompt by
+  calling an LLM API. Credential priority:
+  claude_code_oauth_token → anthropic_api_key → openai_api_key → gemini_api_key
+  """
+
+  require Logger
+
+  @max_chars 50
+
+  @doc """
+  Generate a short title for the given prompt using available credentials.
+  Returns `{:ok, title}` or `{:error, reason}`.
+  """
+  @spec generate(String.t(), map()) :: {:ok, String.t()} | {:error, term()}
+  def generate(prompt, credentials) when is_binary(prompt) and is_map(credentials) do
+    cond do
+      token = Map.get(credentials, :claude_code_oauth_token) ->
+        call_anthropic(prompt, token, :oauth)
+
+      key = Map.get(credentials, :anthropic_api_key) ->
+        call_anthropic(prompt, key, :api_key)
+
+      key = Map.get(credentials, :openai_api_key) ->
+        call_openai(prompt, key)
+
+      key = Map.get(credentials, :gemini_api_key) ->
+        call_gemini(prompt, key)
+
+      true ->
+        {:error, :no_credentials}
+    end
+  end
+
+  # ── providers ─────────────────────────────────────────────────────────────
+
+  defp call_anthropic(prompt, credential, type) do
+    auth_header =
+      case type do
+        :api_key -> {"x-api-key", credential}
+        :oauth -> {"Authorization", "Bearer #{credential}"}
+      end
+
+    body = %{
+      model: "claude-haiku-4-5",
+      max_tokens: 30,
+      system: system_prompt(),
+      messages: [%{role: "user", content: String.slice(prompt, 0, 500)}]
+    }
+
+    case Req.post("https://api.anthropic.com/v1/messages",
+           headers: [auth_header, {"anthropic-version", "2023-06-01"}],
+           json: body,
+           receive_timeout: 10_000
+         ) do
+      {:ok, %{status: 200, body: %{"content" => [%{"text" => text} | _]}}} ->
+        {:ok, sanitize(text)}
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.warning("TitleGenerator: Anthropic returned #{status}: #{inspect(body)}")
+        {:error, {:api_error, status}}
+
+      {:error, reason} ->
+        {:error, {:request_failed, reason}}
+    end
+  end
+
+  defp call_openai(prompt, api_key) do
+    body = %{
+      model: "gpt-4o-mini",
+      max_tokens: 30,
+      messages: [
+        %{role: "system", content: system_prompt()},
+        %{role: "user", content: String.slice(prompt, 0, 500)}
+      ]
+    }
+
+    case Req.post("https://api.openai.com/v1/chat/completions",
+           headers: [{"Authorization", "Bearer #{api_key}"}],
+           json: body,
+           receive_timeout: 10_000
+         ) do
+      {:ok, %{status: 200, body: %{"choices" => [%{"message" => %{"content" => text}} | _]}}} ->
+        {:ok, sanitize(text)}
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.warning("TitleGenerator: OpenAI returned #{status}: #{inspect(body)}")
+        {:error, {:api_error, status}}
+
+      {:error, reason} ->
+        {:error, {:request_failed, reason}}
+    end
+  end
+
+  defp call_gemini(prompt, api_key) do
+    url =
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=#{api_key}"
+
+    body = %{
+      contents: [
+        %{
+          role: "user",
+          parts: [%{text: "#{system_prompt()}\n\n#{String.slice(prompt, 0, 500)}"}]
+        }
+      ],
+      generationConfig: %{maxOutputTokens: 30}
+    }
+
+    case Req.post(url, json: body, receive_timeout: 10_000) do
+      {:ok,
+       %{
+         status: 200,
+         body: %{
+           "candidates" => [
+             %{"content" => %{"parts" => [%{"text" => text} | _]}} | _
+           ]
+         }
+       }} ->
+        {:ok, sanitize(text)}
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.warning("TitleGenerator: Gemini returned #{status}: #{inspect(body)}")
+        {:error, {:api_error, status}}
+
+      {:error, reason} ->
+        {:error, {:request_failed, reason}}
+    end
+  end
+
+  # ── helpers ───────────────────────────────────────────────────────────────
+
+  defp system_prompt do
+    "Generate a title of 3-7 words for the following task or prompt. " <>
+      "Return ONLY the title, no quotes, no punctuation at the end."
+  end
+
+  defp sanitize(text) do
+    text
+    |> String.trim()
+    |> String.replace(~r/\A["']|["']\z/, "")
+    |> String.split("\n")
+    |> List.first("")
+    |> String.trim()
+    |> String.slice(0, @max_chars)
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -157,9 +157,13 @@ defmodule FountainWeb.ConversationsLive.Index do
         </:empty_state>
         <:col :let={c} label="Status"><.badge status={c.status} /></:col>
         <:col :let={c} label="Task">
-          <%= case first_prompt(c) do %>
-            <% nil -> %><span class="text-[var(--color-text-muted)]">—</span>
-            <% prompt -> %><div class="line-clamp-3" title={prompt}>{prompt}</div>
+          <%= if c.title do %>
+            <div class="font-medium truncate" title={first_prompt(c) || c.title}>{c.title}</div>
+          <% else %>
+            <%= case first_prompt(c) do %>
+              <% nil -> %><span class="text-[var(--color-text-muted)]">—</span>
+              <% prompt -> %><div class="line-clamp-3 text-[var(--color-text-muted)]" title={prompt}>{prompt}</div>
+            <% end %>
           <% end %>
         </:col>
         <:col :let={c} label="Agent">

--- a/apps/fountain/priv/repo/migrations/20260513100000_add_title_to_conversations.exs
+++ b/apps/fountain/priv/repo/migrations/20260513100000_add_title_to_conversations.exs
@@ -1,0 +1,9 @@
+defmodule Fountain.Repo.Migrations.AddTitleToConversations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:conversations) do
+      add :title, :string, null: true
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/title_generator_test.exs
+++ b/apps/fountain/test/fountain/conversations/title_generator_test.exs
@@ -1,0 +1,135 @@
+defmodule Fountain.Conversations.TitleGeneratorTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Fountain.Conversations.TitleGenerator
+
+  describe "generate/2 with no credentials" do
+    test "returns error when credentials map is empty" do
+      assert {:error, :no_credentials} = TitleGenerator.generate("Fix login", %{})
+    end
+  end
+
+  describe "generate/2 with anthropic_api_key" do
+    test "calls Anthropic API and returns title" do
+      Req
+      |> expect(:post, fn "https://api.anthropic.com/v1/messages", opts ->
+        assert Keyword.get(opts, :json)[:model] == "claude-haiku-4-5"
+        assert {"x-api-key", "sk-test"} in Keyword.get(opts, :headers, [])
+        {:ok, %{status: 200, body: %{"content" => [%{"text" => "Fix the Login Bug"}]}}}
+      end)
+
+      assert {:ok, "Fix the Login Bug"} =
+               TitleGenerator.generate("Fix login bug in auth", %{anthropic_api_key: "sk-test"})
+    end
+
+    test "strips surrounding quotes from title" do
+      Req
+      |> stub(:post, fn _url, _opts ->
+        {:ok, %{status: 200, body: %{"content" => [%{"text" => "\"Debug Memory Leak\""}]}}}
+      end)
+
+      assert {:ok, "Debug Memory Leak"} =
+               TitleGenerator.generate("debug memory leak", %{anthropic_api_key: "sk-test"})
+    end
+
+    test "takes only the first line" do
+      Req
+      |> stub(:post, fn _url, _opts ->
+        {:ok, %{status: 200, body: %{"content" => [%{"text" => "Fix Auth Bug\nExtra text"}]}}}
+      end)
+
+      assert {:ok, "Fix Auth Bug"} =
+               TitleGenerator.generate("fix auth", %{anthropic_api_key: "sk-test"})
+    end
+
+    test "truncates to 50 characters" do
+      long = String.duplicate("A", 60)
+
+      Req
+      |> stub(:post, fn _url, _opts ->
+        {:ok, %{status: 200, body: %{"content" => [%{"text" => long}]}}}
+      end)
+
+      {:ok, title} = TitleGenerator.generate("some prompt", %{anthropic_api_key: "sk-test"})
+      assert String.length(title) == 50
+    end
+
+    test "returns error on non-200 response" do
+      Req
+      |> stub(:post, fn _url, _opts ->
+        {:ok, %{status: 401, body: %{"error" => "unauthorized"}}}
+      end)
+
+      assert {:error, {:api_error, 401}} =
+               TitleGenerator.generate("prompt", %{anthropic_api_key: "bad-key"})
+    end
+
+    test "returns error on request failure" do
+      Req
+      |> stub(:post, fn _url, _opts -> {:error, :timeout} end)
+
+      assert {:error, {:request_failed, _}} =
+               TitleGenerator.generate("prompt", %{anthropic_api_key: "sk-test"})
+    end
+  end
+
+  describe "generate/2 credential priority" do
+    test "prefers claude_code_oauth_token over anthropic_api_key" do
+      Req
+      |> expect(:post, fn _url, opts ->
+        headers = Keyword.get(opts, :headers, [])
+        assert Enum.any?(headers, fn {k, _} -> k == "Authorization" end)
+        refute Enum.any?(headers, fn {k, _} -> k == "x-api-key" end)
+        {:ok, %{status: 200, body: %{"content" => [%{"text" => "Some Title"}]}}}
+      end)
+
+      assert {:ok, _} =
+               TitleGenerator.generate("prompt", %{
+                 claude_code_oauth_token: "oauth-token",
+                 anthropic_api_key: "sk-test"
+               })
+    end
+  end
+
+  describe "generate/2 with openai_api_key" do
+    test "calls OpenAI chat completions" do
+      Req
+      |> expect(:post, fn "https://api.openai.com/v1/chat/completions", opts ->
+        assert Keyword.get(opts, :json)[:model] == "gpt-4o-mini"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{"choices" => [%{"message" => %{"content" => "Fix Auth Issue"}}]}
+         }}
+      end)
+
+      assert {:ok, "Fix Auth Issue"} =
+               TitleGenerator.generate("fix auth", %{openai_api_key: "sk-openai"})
+    end
+  end
+
+  describe "generate/2 with gemini_api_key" do
+    test "calls Gemini generateContent" do
+      Req
+      |> expect(:post, fn url, _opts ->
+        assert String.starts_with?(url, "https://generativelanguage.googleapis.com")
+        assert String.contains?(url, "gemini-key")
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "candidates" => [
+               %{"content" => %{"parts" => [%{"text" => "Deploy New Feature"}]}}
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, "Deploy New Feature"} =
+               TitleGenerator.generate("deploy feature", %{gemini_api_key: "gemini-key"})
+    end
+  end
+end

--- a/docs/superpowers/plans/2026-05-13-conversation-titles.md
+++ b/docs/superpowers/plans/2026-05-13-conversation-titles.md
@@ -1,0 +1,28 @@
+# Plan: LLM-Generated Conversation Titles
+
+**Date:** 2026-05-13
+
+## What was done
+
+Added LLM-generated short titles (≤50 chars) to conversations so the sidebar displays a meaningful label instead of truncating the raw first prompt.
+
+## Files changed
+
+1. **`apps/fountain/priv/repo/migrations/20260513100000_add_title_to_conversations.exs`** — New migration adding a nullable `:title` string column to the `conversations` table.
+
+2. **`apps/fountain/lib/fountain/conversations/conversation.ex`** — Added `field :title, :string` to the schema and `:title` to the `cast/2` list in `changeset/2`.
+
+3. **`apps/fountain/lib/fountain/conversations/title_generator.ex`** — New module that calls an LLM API to produce a 3–7 word title from the first turn's prompt. Credential priority: `claude_code_oauth_token` → `anthropic_api_key` → `openai_api_key` → `gemini_api_key`. Uses `Req.post/2` with a 10 s timeout; returns `{:ok, title}` or `{:error, reason}`.
+
+4. **`apps/fountain/test/fountain/conversations/title_generator_test.exs`** — ExUnit tests covering all three providers, credential priority, sanitisation (quote stripping, first-line extraction, 50-char truncation), error paths (non-200, request failure), and the no-credentials case. Uses `Mimic` to stub `Req.post/2`.
+
+5. **`apps/fountain/lib/fountain/conversations/conversation_server.ex`** — In `kick_turn/4`, after images are stored, a `Task.start/1` fires on `turn_number == 1` to call `TitleGenerator.generate/2` asynchronously. On success it re-fetches the conversation struct and calls `Conversations.update_conversation/2` (which already broadcasts the sidebar update via PubSub). Failures are logged as warnings.
+
+6. **`apps/fountain/lib/fountain_web/live/conversations_live/index.ex`** — The "Task" column in the conversations table now renders `c.title` (bold, truncated, with the raw prompt as a hover tooltip) when a title is available, falling back to the previous raw-prompt display (muted styling) for untitled conversations.
+
+## Design decisions
+
+- **Async / best-effort:** title generation is fire-and-forget; a failure never blocks or crashes a turn.
+- **First turn only:** title is generated once; subsequent turns do not overwrite it.
+- **Credential priority mirrors the inference stack:** existing `state.inference_credentials` map is reused directly — no new credential storage.
+- **50-char hard cap** enforced in `sanitize/1`; leading/trailing quotes and multi-line responses are cleaned up before slicing.


### PR DESCRIPTION
## Summary

- Adds a nullable `title` column to `conversations` via a new Ecto migration
- Introduces `Fountain.Conversations.TitleGenerator` which calls Anthropic (claude-haiku-4-5), OpenAI (gpt-4o-mini), or Gemini (gemini-2.0-flash) to produce a ≤50-char title from the first turn's prompt, using the user's stored inference credentials in priority order (`claude_code_oauth_token` → `anthropic_api_key` → `openai_api_key` → `gemini_api_key`)
- Fires title generation as a `Task.start/1` on turn 1 inside `ConversationServer.kick_turn/4` — entirely async and best-effort, never blocks the turn
- Updates the conversations index LiveView to display the generated title (bold, truncated) with the raw prompt as a hover tooltip, falling back to the previous muted raw-prompt display for untitled conversations

## Files changed

| File | Change |
|------|--------|
| `priv/repo/migrations/20260513100000_add_title_to_conversations.exs` | New migration |
| `lib/fountain/conversations/conversation.ex` | Add `:title` field + cast |
| `lib/fountain/conversations/title_generator.ex` | New module — multi-provider LLM title generation |
| `test/fountain/conversations/title_generator_test.exs` | Full unit test coverage via Mimic |
| `lib/fountain/conversations/conversation_server.ex` | Async Task on turn 1 in `kick_turn/4` |
| `lib/fountain_web/live/conversations_live/index.ex` | Render title in Task column |
| `docs/superpowers/plans/2026-05-13-conversation-titles.md` | Plan document |

## Test plan

- [ ] Run `mix test apps/fountain/test/fountain/conversations/title_generator_test.exs` — all cases should pass (no-credentials, Anthropic API key, OAuth token, OpenAI, Gemini, quote stripping, first-line, truncation, non-200, request failure)
- [ ] Run `mix ecto.migrate` and confirm the `title` column is added to `conversations`
- [ ] Start a new conversation via the UI, confirm a title appears in the sidebar after the first turn completes
- [ ] Verify conversations created before the migration render the fallback (raw prompt, muted) correctly
- [ ] Confirm a title-generation failure (e.g. no credentials) logs a warning and does not affect the turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)