### PR TITLE
Persist conversation view mode preference to database

### DIFF
--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -9,6 +9,7 @@ defmodule Fountain.Accounts.User do
   @subscription_statuses ~w(trialing active past_due canceled)
   @theme_values ~w(light dark system)
   @visible_stream_values ~w(stdout stderr stage)
+  @view_mode_values ~w(chat pretty raw)
 
   schema "users" do
     field :email, :string
@@ -26,6 +27,7 @@ defmodule Fountain.Accounts.User do
     field :theme_preference, :string, default: "system"
     field :conversations_roots_only, :boolean, default: false
     field :conversation_visible_streams, {:array, :string}, default: ["stdout", "stderr", "stage"]
+    field :conversation_view_mode, :string, default: "pretty"
 
     has_many :api_keys, Fountain.Accounts.ApiKey
     has_one :data_key, Fountain.Accounts.UserDataKey
@@ -79,8 +81,9 @@ defmodule Fountain.Accounts.User do
   @doc "Changeset for updating conversation filter preferences."
   def preferences_changeset(user, attrs) do
     user
-    |> cast(attrs, [:conversations_roots_only, :conversation_visible_streams])
+    |> cast(attrs, [:conversations_roots_only, :conversation_visible_streams, :conversation_view_mode])
     |> validate_subset(:conversation_visible_streams, @visible_stream_values)
+    |> validate_inclusion(:conversation_view_mode, @view_mode_values)
   end
 
   @doc "Changeset for resetting a password (validates + hashes new password)."

--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -269,13 +269,13 @@
             },
             destroyed() { document.removeEventListener("keydown", this.trap); }
           },
-          // ── View mode persistence (localStorage) ────────────────────────────
+          // ── View mode persistence — DB is now the source of truth for the
+          // initial render. This hook only keeps localStorage in sync for
+          // informational purposes; it no longer pushes restore_view_mode on
+          // mount since the server reads the preference from
+          // user.conversation_view_mode at mount time.
           ViewModePersist: {
             mounted() {
-              const saved = localStorage.getItem("fountain-view-mode");
-              if (saved) {
-                this.pushEvent("restore_view_mode", { mode: saved });
-              }
               this._removeViewMode = this.handleEvent("view_mode_changed", ({ mode }) => {
                 localStorage.setItem("fountain-view-mode", mode);
               });

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -40,7 +40,7 @@ defmodule FountainWeb.ConversationsLive.Show do
          |> assign(:events, events)
          |> assign(:turns_by_id, load_turns(id))
          |> assign(:visible_streams, MapSet.new(initial_visible_streams(socket.assigns.current_user)))
-         |> assign(:view_mode, :pretty)
+         |> assign(:view_mode, initial_view_mode(socket.assigns.current_user))
          |> assign(:prompt, "")
          |> assign(:pending_images, [])
          |> assign(:graph, graph)
@@ -61,6 +61,13 @@ defmodule FountainWeb.ConversationsLive.Show do
     case user.conversation_visible_streams do
       streams when is_list(streams) -> streams
       _ -> ["stdout", "stderr", "stage"]
+    end
+  end
+
+  defp initial_view_mode(user) do
+    case user.conversation_view_mode do
+      mode when mode in ["chat", "pretty", "raw"] -> String.to_existing_atom(mode)
+      _ -> :pretty
     end
   end
 
@@ -229,14 +236,10 @@ defmodule FountainWeb.ConversationsLive.Show do
   def handle_event("set_view_mode", %{"mode" => mode}, socket) do
     next = parse_view_mode(mode, socket.assigns.view_mode)
 
-    {:noreply,
-     socket
-     |> assign(:view_mode, next)
-     |> push_event("view_mode_changed", %{mode: Atom.to_string(next)})}
-  end
-
-  def handle_event("restore_view_mode", %{"mode" => mode}, socket) do
-    next = parse_view_mode(mode, socket.assigns.view_mode)
+    Accounts.update_preferences(
+      socket.assigns.current_user,
+      %{conversation_view_mode: Atom.to_string(next)}
+    )
 
     {:noreply,
      socket

--- a/apps/fountain/priv/repo/migrations/20260513000001_add_view_mode_preference_to_users.exs
+++ b/apps/fountain/priv/repo/migrations/20260513000001_add_view_mode_preference_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Fountain.Repo.Migrations.AddViewModePreferenceToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :conversation_view_mode, :string, null: false, default: "pretty"
+    end
+  end
+end

--- a/apps/fountain/test/fountain/accounts_preferences_test.exs
+++ b/apps/fountain/test/fountain/accounts_preferences_test.exs
@@ -73,4 +73,47 @@ defmodule Fountain.AccountsPreferencesTest do
       assert user.conversation_visible_streams == ["stdout", "stderr", "stage"]
     end
   end
+
+  describe "User.preferences_changeset/2 for conversation_view_mode" do
+    test "accepts valid view modes" do
+      for mode <- ["chat", "pretty", "raw"] do
+        cs = User.preferences_changeset(%User{}, %{conversation_view_mode: mode})
+        assert cs.valid?, "expected #{inspect(mode)} to be valid"
+      end
+    end
+
+    test "rejects invalid view mode" do
+      cs = User.preferences_changeset(%User{}, %{conversation_view_mode: "tree"})
+      refute cs.valid?
+      assert cs.errors[:conversation_view_mode] != nil
+    end
+
+    test "accepts partial update without view mode" do
+      cs = User.preferences_changeset(%User{}, %{conversations_roots_only: true})
+      assert cs.valid?
+    end
+  end
+
+  describe "Accounts.update_preferences/2 for conversation_view_mode" do
+    setup do
+      {:ok, user: insert_verified_user()}
+    end
+
+    test "persists conversation_view_mode to database", %{user: user} do
+      assert {:ok, updated} = Accounts.update_preferences(user, %{conversation_view_mode: "chat"})
+      assert updated.conversation_view_mode == "chat"
+
+      reloaded = Accounts.get_user!(user.id)
+      assert reloaded.conversation_view_mode == "chat"
+    end
+
+    test "new users default to pretty view mode", %{user: user} do
+      assert user.conversation_view_mode == "pretty"
+    end
+
+    test "returns error changeset for invalid view mode", %{user: user} do
+      assert {:error, changeset} = Accounts.update_preferences(user, %{conversation_view_mode: "invalid"})
+      assert changeset.errors[:conversation_view_mode] != nil
+    end
+  end
 end

--- a/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
@@ -3,44 +3,38 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
 
   import Phoenix.LiveViewTest
 
-  describe "restore_view_mode" do
+  describe "view_mode loaded from database" do
     setup do
       user = insert_verified_user()
       conversation = insert_conversation(user_id: user.id)
       %{user: user, conversation: conversation}
     end
 
-    @tag :restore_view_mode
-    test "restores chat mode from client", %{conn: conn, user: user, conversation: conversation} do
+    test "mounts with default pretty mode when no preference saved", %{conn: conn, user: user, conversation: conversation} do
       conn = login_user(conn, user)
       {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
-      # default is :pretty
-      assert view |> element("[data-view-mode]") |> render() =~ "pretty"
 
-      view |> render_hook("restore_view_mode", %{"mode" => "chat"})
+      assert view |> element("[data-view-mode]") |> render() =~ "pretty"
+    end
+
+    test "mounts with chat mode when preference is saved as chat", %{conn: conn, user: user, conversation: conversation} do
+      {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversation_view_mode: "chat"})
+      user = Fountain.Accounts.get_user!(user.id)
+
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
 
       assert view |> element("[data-view-mode]") |> render() =~ "chat"
     end
 
-    @tag :restore_view_mode
-    test "restores raw mode from client", %{conn: conn, user: user, conversation: conversation} do
+    test "mounts with raw mode when preference is saved as raw", %{conn: conn, user: user, conversation: conversation} do
+      {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversation_view_mode: "raw"})
+      user = Fountain.Accounts.get_user!(user.id)
+
       conn = login_user(conn, user)
       {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
-
-      view |> render_hook("restore_view_mode", %{"mode" => "raw"})
 
       assert view |> element("[data-view-mode]") |> render() =~ "raw"
-    end
-
-    @tag :restore_view_mode
-    test "ignores unrecognised mode value", %{conn: conn, user: user, conversation: conversation} do
-      conn = login_user(conn, user)
-      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
-
-      view |> render_hook("restore_view_mode", %{"mode" => "garbage"})
-
-      # should stay on default :pretty
-      assert view |> element("[data-view-mode]") |> render() =~ "pretty"
     end
   end
 
@@ -58,6 +52,16 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
 
       view |> element("[phx-click='set_view_mode'][phx-value-mode='chat']") |> render_click()
       assert_push_event(view, "view_mode_changed", %{mode: "chat"})
+    end
+
+    test "persists view mode to database when changed", %{conn: conn, user: user, conversation: conversation} do
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      view |> element("[phx-click='set_view_mode'][phx-value-mode='raw']") |> render_click()
+
+      reloaded = Fountain.Accounts.get_user!(user.id)
+      assert reloaded.conversation_view_mode == "raw"
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds `conversation_view_mode` column (string, default `"pretty"`) to the `users` table via migration
- Extends `User.preferences_changeset/2` to accept and validate the new field (`chat | pretty | raw`)
- `ConversationsLive.Show` now reads the saved preference from the user at mount time (`initial_view_mode/1`), eliminating the localStorage round-trip that caused the flash of wrong state
- `set_view_mode` handler persists the new mode via `Accounts.update_preferences/2` on every change
- `ViewModePersist` JS hook simplified to match `RootsFilterPersist`: still writes localStorage for informational sync, but no longer pushes `restore_view_mode` on mount since the server is now the source of truth

## Test plan

- [ ] `Fountain.AccountsPreferencesTest` — changeset validation (valid modes, rejects invalid, partial updates) and DB persistence for `conversation_view_mode`
- [ ] `FountainWeb.ConversationsLive.ShowTest` — replaced `restore_view_mode` tests with DB-backed mount tests (default pretty, saved chat, saved raw); added persistence test for `set_view_mode`; existing `toggle_stream` and `push_view_mode_changed` tests unchanged
- [ ] Full suite: 991 tests, 0 failures locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)