### PR TITLE
Fix sidebar date bucketing: use elapsed hours instead of UTC calendar dates

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -354,36 +354,36 @@ defmodule FountainWeb.Layouts do
 
   defp group_conversations_by_date(convs) do
     now = DateTime.utc_now()
-    today = DateTime.to_date(now)
-    yesterday = Date.add(today, -1)
-    week_start = Date.add(today, -7)
 
     {running, rest} = Enum.split_with(convs, &(&1.status == "running"))
 
     [
       {"Active", running},
-      {"Today", Enum.filter(rest, &(conv_date(&1) == today))},
-      {"Yesterday", Enum.filter(rest, &(conv_date(&1) == yesterday))},
+      {"Today", Enum.filter(rest, &(hours_ago(conv_dt(&1), now) < 24))},
+      {"Yesterday",
+       Enum.filter(rest, fn c ->
+         h = hours_ago(conv_dt(c), now)
+         h >= 24 && h < 48
+       end)},
       {"Past 7 days",
        Enum.filter(rest, fn c ->
-         d = conv_date(c)
-         d && Date.compare(d, week_start) != :lt && Date.compare(d, yesterday) == :lt
+         h = hours_ago(conv_dt(c), now)
+         h >= 48 && h < 168
        end)},
-      {"Older",
-       Enum.filter(rest, fn c ->
-         d = conv_date(c)
-         d && Date.compare(d, week_start) == :lt
-       end)}
+      {"Older", Enum.filter(rest, &(hours_ago(conv_dt(&1), now) >= 168))}
     ]
     |> Enum.reject(fn {_, items} -> items == [] end)
   end
 
-  defp conv_date(%{last_active_at: dt}) when not is_nil(dt), do: to_date(dt)
-  defp conv_date(%{inserted_at: dt}) when not is_nil(dt), do: to_date(dt)
-  defp conv_date(_), do: nil
+  defp conv_dt(%{last_active_at: dt}) when not is_nil(dt), do: to_utc(dt)
+  defp conv_dt(%{inserted_at: dt}) when not is_nil(dt), do: to_utc(dt)
+  defp conv_dt(_), do: nil
 
-  defp to_date(%DateTime{} = dt), do: DateTime.to_date(dt)
-  defp to_date(%NaiveDateTime{} = dt), do: NaiveDateTime.to_date(dt)
+  defp to_utc(%DateTime{} = dt), do: dt
+  defp to_utc(%NaiveDateTime{} = dt), do: DateTime.from_naive!(dt, "Etc/UTC")
+
+  defp hours_ago(nil, _now), do: 999_999
+  defp hours_ago(dt, now), do: max(0, div(DateTime.diff(now, dt), 3600))
 
   attr :href, :string, required: true
   attr :label, :string, required: true


### PR DESCRIPTION
## Problem

Conversations near the UTC midnight boundary would appear in "Yesterday" while showing a small "Xm ago" label — e.g. a conversation active 8 minutes ago showing under "Yesterday". This happened because the buckets were computed by comparing UTC calendar dates:

```elixir
today = DateTime.to_date(DateTime.utc_now())
yesterday = Date.add(today, -1)
# ...
{"Yesterday", Enum.filter(rest, &(conv_date(&1) == yesterday))}
```

A conversation last active at 23:56 UTC has a UTC date of "yesterday", but `sidebar_relative_time` (also UTC-based) correctly reports it as "8m ago". For users in UTC-1 through UTC-12, this window is their active evening hours — so it happened constantly.

## Fix

Replace calendar-date comparison with elapsed-hours bucketing:

- **Today** → < 24 hours ago
- **Yesterday** → 24–48 hours ago  
- **Past 7 days** → 48–168 hours ago
- **Older** → 168+ hours ago

This keeps the bucket label and the "Xm/Xh ago" timestamp consistent: anything showing "Xm ago" or a small "Xh ago" will always be in "Today".