### PR TITLE
fix: remove response_format param unsupported by gpt-image-1

### DIFF
--- a/apps/fountain/lib/fountain/avatar_generator.ex
+++ b/apps/fountain/lib/fountain/avatar_generator.ex
@@ -73,8 +73,7 @@ defmodule Fountain.AvatarGenerator do
       model: "gpt-image-1",
       prompt: prompt,
       n: 1,
-      size: "1024x1024",
-      response_format: "b64_json"
+      size: "1024x1024"
     }
 
     case Req.post(@openai_url,


### PR DESCRIPTION
## Root cause

`response_format` was a `dall-e-2` / `dall-e-3` parameter. `gpt-image-1` rejects it with _"Unknown parameter: 'response_format'."_

`gpt-image-1` returns base64 image data in `data[0].b64_json` by default — no flag required. The response parsing is unchanged.

## Change

```diff
  body = %{
    model: "gpt-image-1",
    prompt: prompt,
    n: 1,
-   size: "1024x1024",
-   response_format: "b64_json"
+   size: "1024x1024"
  }
```

No test changes needed — `Req.post` is stubbed in the unit tests and the stub already returns `b64_json` in the response body, which still matches the parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)