### PR TITLE
refactor: use Phoenix-idiomatic <.link> for sidebar navigation

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -85,6 +85,18 @@ defmodule FountainWeb.Layouts do
         &String.starts_with?(assigns[:current_path] || "", &1)
       )
 
+    current_path = assigns[:current_path] || ""
+
+    logo_link_attrs =
+      if session_for(current_path) == :active_subscription,
+        do: [navigate: ~p"/conversations"],
+        else: [href: ~p"/conversations"]
+
+    new_conv_link_attrs =
+      if session_for(current_path) == :active_subscription,
+        do: [navigate: ~p"/conversations/new"],
+        else: [href: ~p"/conversations/new"]
+
     assigns =
       assign(assigns,
         nav_conversations: convs,
@@ -93,7 +105,9 @@ defmodule FountainWeb.Layouts do
         sidebar_roots_only: roots_only,
         sidebar_agent_filter: agent_filter,
         sidebar_unique_agents: unique_agents,
-        footer_open: footer_open
+        footer_open: footer_open,
+        logo_link_attrs: logo_link_attrs,
+        new_conv_link_attrs: new_conv_link_attrs
       )
 
     ~H"""
@@ -124,10 +138,10 @@ defmodule FountainWeb.Layouts do
         >
           <%!-- Sidebar header --%>
           <div class="flex items-center justify-between p-4 border-b border-[var(--color-border)] shrink-0">
-            <a href={~p"/conversations"} class="flex items-center gap-2">
+            <.link {@logo_link_attrs} class="flex items-center gap-2">
               <img src="/images/app-icon.png" alt="" class="size-7 rounded-md" />
               <span class="font-semibold text-sm text-[var(--color-text-primary)]">Fountain</span>
-            </a>
+            </.link>
             <label
               for="sidebar-toggle"
               class="md:hidden cursor-pointer rounded-md p-1 text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)]"
@@ -149,13 +163,13 @@ defmodule FountainWeb.Layouts do
 
           <%!-- New conversation --%>
           <div class="px-2 pb-1 shrink-0">
-            <a
-              href={~p"/conversations/new"}
+            <.link
+              {@new_conv_link_attrs}
               class="block w-full rounded-md px-3 py-1.5 text-sm font-medium text-center
                      bg-indigo-600 text-white hover:bg-indigo-500 transition-colors"
             >
               + New Conversation
-            </a>
+            </.link>
           </div>
 
           <%!-- Conversation filters --%>
@@ -393,11 +407,16 @@ defmodule FountainWeb.Layouts do
       (String.starts_with?(assigns.current || "", assigns.href) and assigns.href != "/") or
         assigns.current == assigns.href
 
-    assigns = assign(assigns, :active, active)
+    link_attrs =
+      if session_for(assigns.current) == session_for(assigns.href),
+        do: [navigate: assigns.href],
+        else: [href: assigns.href]
+
+    assigns = assign(assigns, active: active, link_attrs: link_attrs)
 
     ~H"""
-    <a
-      href={@href}
+    <.link
+      {@link_attrs}
       class={[
         "block rounded-md px-3 py-1 text-sm transition-colors",
         if(@active,
@@ -407,9 +426,23 @@ defmodule FountainWeb.Layouts do
       ]}
     >
       {@label}
-    </a>
+    </.link>
     """
   end
+
+  # Map a path to its live_session.
+  # /conversations/:id/logs is in :authenticated (log viewer live_session),
+  # not :active_subscription, despite sharing the /conversations prefix.
+  defp session_for(path) when is_binary(path) do
+    cond do
+      String.match?(path, ~r{^/conversations/[^/]+/logs}) -> :authenticated
+      String.starts_with?(path, "/conversations") -> :active_subscription
+      String.starts_with?(path, "/admin") -> :admin
+      true -> :authenticated
+    end
+  end
+
+  defp session_for(_), do: :authenticated
 
   attr :conv, :map, required: true
   attr :current, :string, default: ""
@@ -442,6 +475,11 @@ defmodule FountainWeb.Layouts do
     {initials, chip_class} = role_chip_style(agent_name)
     avatar_url = if agent && Map.get(agent, :avatar_media_type), do: "/agents/#{agent.id}/avatar"
 
+    link_attrs =
+      if session_for(assigns.current) == :active_subscription,
+        do: [navigate: href],
+        else: [href: href]
+
     assigns =
       assign(assigns,
         href: href,
@@ -451,12 +489,13 @@ defmodule FountainWeb.Layouts do
         initials: initials,
         chip_class: chip_class,
         avatar_url: avatar_url,
-        turn_count: turn_count
+        turn_count: turn_count,
+        link_attrs: link_attrs
       )
 
     ~H"""
-    <a
-      href={@href}
+    <.link
+      {@link_attrs}
       class={[
         "flex items-center gap-2.5 rounded-md px-3 py-1.5 text-sm transition-colors",
         if(@active,
@@ -535,7 +574,7 @@ defmodule FountainWeb.Layouts do
           class="block text-[11px] text-[var(--color-text-muted)] truncate"
         >{@subtitle}</span>
       </span>
-    </a>
+    </.link>
     """
   end
 

--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -98,32 +98,6 @@
           }
         });
 
-        // ── Sidebar navigation ───────────────────────────────────────────────
-        // LiveView registers a document-level bubble-phase click handler that
-        // intercepts <a href> clicks on internal routes and routes them via the
-        // WebSocket. Cross-session navigation (e.g. conversations → agents) then
-        // fails silently: LiveView's redirect can't cross live_session boundaries,
-        // but it already called preventDefault() so the browser doesn't navigate
-        // either.
-        //
-        // Fix: attach a bubble-phase listener to #app-sidebar. It fires before
-        // LiveView's document handler (closer elements bubble first) and calls
-        // stopPropagation(), so LiveView's handler never runs. The browser then
-        // follows the href normally via a full-page navigation, which works
-        // reliably across all live_session boundaries.
-        //
-        // Modified clicks (Cmd/Ctrl/Shift/Alt) are left through so cmd+click
-        // still opens links in a new tab.
-        const sidebar = document.getElementById("app-sidebar");
-        if (sidebar) {
-          sidebar.addEventListener("click", (e) => {
-            const link = e.target.closest("a[href]");
-            if (!link) return;
-            if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-            e.stopPropagation();
-          });
-        }
-
         // ── LiveView hooks ───────────────────────────────────────────────────
         const Hooks = {
           ScrollBottom: {


### PR DESCRIPTION
## Summary

- Replaces the JavaScript `stopPropagation` hack on `#app-sidebar` with proper Phoenix LiveView link components
- Adds `session_for/1` to classify any path into its `live_session` (`:active_subscription`, `:authenticated`, `:admin`)
- All sidebar links now use `<.link navigate>` when the target is in the same session (client-side, no page reload) and `<.link href>` when crossing session boundaries (full-page navigation)
- Removes ~20 lines of workaround JS from `root.html.heex`

## Why

The router splits routes across two `live_session` groups. `<.link navigate>` (socket-based redirect) cannot cross session boundaries — it fails silently because `preventDefault()` is already called before the failure. Previously we worked around this with a `stopPropagation()` listener that prevented LiveView from intercepting plain `<a href>` clicks. That works, but the fix lived in a JS block far from the templates it was compensating for.

Phoenix provides `<.link href>` exactly for this case: it renders `data-phx-link="href"` which LiveView handles via full-page navigation instead of a socket redirect. And `<.link navigate>` works correctly for same-session links.

## Navigation behaviour

| From \ To | Conversations | Agents / Envs / Vaults |
|-----------|--------------|------------------------|
| Conversations | `navigate` (client-side) | `href` (full reload) |
| Agents / Envs / Vaults | `href` (full reload) | `navigate` (client-side) |

## Files changed

- `apps/fountain/lib/fountain_web/components/layouts.ex` — adds `session_for/1`, updates `nav_link/1`, `conv_nav_link/1`, logo link, and New Conversation button
- `apps/fountain/lib/fountain_web/components/layouts/root.html.heex` — removes sidebar `stopPropagation` handler

## Test plan

- [ ] From a conversation, click Agents → full-page navigation to `/agents`
- [ ] From agents, click a conversation in the sidebar → full-page navigation to the conversation
- [ ] From a conversation, click another conversation → client-side navigation (URL changes, no full reload, no flash)
- [ ] From agents, click Environments → client-side navigation
- [ ] Cmd+click any sidebar link → opens in new tab
- [ ] Fountain logo navigates to `/conversations` from all pages
- [ ] New Conversation button works from all pages