### PR TITLE
Show full conversation title on sidebar hover

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -496,6 +496,7 @@ defmodule FountainWeb.Layouts do
             <span
               :if={@task_label}
               class="block truncate text-[13px] text-[var(--color-text-primary)]"
+              title={@task_label}
             >{@task_label}</span>
             <span
               :if={!@task_label}


### PR DESCRIPTION
Sidebar conversation titles are truncated, making it impossible to read long ones without opening the conversation. This adds a native `title=` tooltip to the title span so hovering reveals the full text.

Consistent with how turn count and branch badges already expose their values — same pattern, one line.