### PR TITLE
feat: unread message indicators for conversations

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -266,24 +266,41 @@ defmodule Fountain.Conversations do
   Pass `roots_only: true` to exclude child conversations (those with a
   `parent_conversation_id`). Useful for hiding agent-spawned sub-conversations
   from the index when the user only wants to see top-level sessions.
+
+  Populates the `last_active_at` virtual field using `kind: "output"` log
+  events only — stage events (reconnects, lifecycle) are excluded so
+  reconnects don't produce false unread indicators.
   """
   def list_conversations(user_id, opts \\ []) when is_binary(user_id) do
     roots_only = Keyword.get(opts, :roots_only, false)
 
+    last_log_at =
+      from le in LogEvent,
+        where: le.kind == "output",
+        group_by: le.conversation_id,
+        select: %{conversation_id: le.conversation_id, last_at: max(le.inserted_at)}
+
     base =
       from c in Conversation,
+        as: :conv,
         where: c.user_id == ^user_id,
+        left_join: ll in subquery(last_log_at), on: ll.conversation_id == c.id,
         order_by: [desc: c.updated_at, desc: c.id],
-        preload: [:agent, turns: ^first_turn_query()]
+        select: %{
+          c
+          | last_active_at:
+              fragment("COALESCE(?, ?)", ll.last_at, c.inserted_at)
+        }
 
     query =
       if roots_only do
-        from c in base, where: is_nil(c.parent_conversation_id)
+        where(base, [conv: c], is_nil(c.parent_conversation_id))
       else
         base
       end
 
     Repo.all(query)
+    |> Repo.preload([:agent, turns: first_turn_query()])
   end
 
   def create_conversation(attrs) do
@@ -312,6 +329,30 @@ defmodule Fountain.Conversations do
     result = Repo.delete(conv)
     if match?({:ok, _}, result), do: broadcast_sidebar_update(user_id)
     result
+  end
+
+  @doc """
+  Record that `user_id` has read `conversation_id` as of now.
+
+  Scoped to owner — silently no-ops for a wrong user_id. Broadcasts a
+  sidebar update so the unread dot clears in the nav without waiting for
+  the next natural PubSub event.
+  """
+  def mark_read(conversation_id, user_id)
+      when is_binary(conversation_id) and is_binary(user_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    case Repo.update_all(
+           from(c in Conversation,
+             where: c.id == ^conversation_id and c.user_id == ^user_id
+           ),
+           set: [last_read_at: now]
+         ) do
+      {0, _} -> :ok
+      {_, _} ->
+        broadcast_sidebar_update(user_id)
+        :ok
+    end
   end
 
   # ── turns ─────────────────────────────────────────────────────────────────────────────

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -134,7 +134,7 @@ defmodule Fountain.Conversations do
         order_by: [
           desc:
             fragment(
-              "GREATEST(COALESCE(?, ?), COALESCE(?, ?), ?)",
+              "GREATEST(COALESCE(?, ?::timestamptz), COALESCE(?, ?::timestamptz), ?::timestamptz)",
               ll.last_at,
               c.inserted_at,
               lt.last_at,
@@ -147,7 +147,7 @@ defmodule Fountain.Conversations do
           | turn_count: fragment("COALESCE(?, 0)", tc.count),
             last_active_at:
               fragment(
-                "GREATEST(COALESCE(?, ?), COALESCE(?, ?), ?)",
+                "GREATEST(COALESCE(?, ?::timestamptz), COALESCE(?, ?::timestamptz), ?::timestamptz)",
                 ll.last_at,
                 c.inserted_at,
                 lt.last_at,
@@ -289,7 +289,7 @@ defmodule Fountain.Conversations do
         select: %{
           c
           | last_active_at:
-              fragment("COALESCE(?, ?)", ll.last_at, c.inserted_at)
+              fragment("COALESCE(?, ?::timestamptz)", ll.last_at, c.inserted_at)
         }
 
     query =

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -21,6 +21,7 @@ defmodule Fountain.Conversations.Conversation do
     field :parent_conversation_id, :binary_id
     field :callback_api_key_id, :binary_id
     field :title, :string
+    field :last_read_at, :utc_datetime_usec
 
     # Populated by list_conversations_by_activity/1 — not persisted.
     field :turn_count, :integer, virtual: true, default: 0

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -432,6 +432,7 @@ defmodule FountainWeb.Layouts do
     agent = assigns.conv.agent
     agent_name = agent && agent.name
     turn_count = Map.get(assigns.conv, :turn_count, 0) || 0
+    unread? = not active and unread_conv?(assigns.conv)
 
     target = extract_sidebar_target(raw_prompt, agent_name)
     time_str = sidebar_relative_time(assigns.conv.last_active_at || assigns.conv.inserted_at)
@@ -454,6 +455,7 @@ defmodule FountainWeb.Layouts do
         chip_class: chip_class,
         avatar_url: avatar_url,
         turn_count: turn_count,
+        unread?: unread?,
         link_attrs: [href: href]
       )
 
@@ -469,24 +471,31 @@ defmodule FountainWeb.Layouts do
       ]}
     >
       <%!-- Role chip: 28x28 rounded-square showing agent avatar or initials --%>
-      <img
-        :if={@avatar_url}
-        src={@avatar_url}
-        class="w-7 h-7 rounded-[6px] object-cover shrink-0"
-        alt=""
-        title={if @conv.agent, do: @conv.agent.name}
-      />
-      <span
-        :if={!@avatar_url}
-        class={[
-          "inline-flex items-center justify-center shrink-0",
-          "w-7 h-7 rounded-[6px] text-[10px] font-bold leading-none select-none",
-          @chip_class
-        ]}
-        title={if @conv.agent, do: @conv.agent.name}
-      >
-        {@initials}
-      </span>
+      <div class="relative shrink-0">
+        <img
+          :if={@avatar_url}
+          src={@avatar_url}
+          class="w-7 h-7 rounded-[6px] object-cover"
+          alt=""
+          title={if @conv.agent, do: @conv.agent.name}
+        />
+        <span
+          :if={!@avatar_url}
+          class={[
+            "inline-flex items-center justify-center",
+            "w-7 h-7 rounded-[6px] text-[10px] font-bold leading-none select-none",
+            @chip_class
+          ]}
+          title={if @conv.agent, do: @conv.agent.name}
+        >
+          {@initials}
+        </span>
+        <span
+          :if={@unread?}
+          class="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-indigo-500 border-2 border-[var(--color-bg-1)]"
+          aria-label="unread activity"
+        />
+      </div>
 
       <%!-- Text block --%>
       <span class="flex-1 min-w-0">
@@ -541,6 +550,17 @@ defmodule FountainWeb.Layouts do
     </.link>
     """
   end
+
+  # True when the conversation has output activity that post-dates the last
+  # time the user viewed it. Stage events (reconnects, lifecycle) are already
+  # excluded from last_active_at by the query layer, so this comparison is
+  # reconnect-safe.
+  defp unread_conv?(%{last_read_at: nil, last_active_at: _}), do: true
+  defp unread_conv?(%{last_read_at: _, last_active_at: nil}), do: false
+  defp unread_conv?(%{last_read_at: read_at, last_active_at: active_at}) do
+    DateTime.compare(active_at, read_at) == :gt
+  end
+  defp unread_conv?(_), do: false
 
   # Returns {initials, tailwind_classes} for a role chip.
   # Known roles use the curated @role_styles map.

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -248,7 +248,7 @@ defmodule FountainWeb.ConversationsLive.Index do
     end
   end
 
-  defp unread?(%{last_read_at: nil}), do: true
+  defp unread?(%{last_read_at: nil, last_active_at: _}), do: true
   defp unread?(%{last_read_at: _, last_active_at: nil}), do: false
   defp unread?(%{last_read_at: read_at, last_active_at: active_at}) do
     DateTime.compare(active_at, read_at) == :gt

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -157,14 +157,23 @@ defmodule FountainWeb.ConversationsLive.Index do
         </:empty_state>
         <:col :let={c} label="Status"><.badge status={c.status} /></:col>
         <:col :let={c} label="Task">
-          <%= if c.title do %>
-            <div class="font-medium truncate" title={first_prompt(c) || c.title}>{c.title}</div>
-          <% else %>
-            <%= case first_prompt(c) do %>
-              <% nil -> %><span class="text-[var(--color-text-muted)]">—</span>
-              <% prompt -> %><div class="line-clamp-3 text-[var(--color-text-muted)]" title={prompt}>{prompt}</div>
-            <% end %>
-          <% end %>
+          <div class="flex items-start gap-1.5">
+            <span
+              :if={unread?(c)}
+              class="mt-1.5 size-1.5 shrink-0 rounded-full bg-indigo-500"
+              aria-label="unread activity"
+            />
+            <div class="min-w-0">
+              <%= if c.title do %>
+                <div class="font-medium truncate" title={first_prompt(c) || c.title}>{c.title}</div>
+              <% else %>
+                <%= case first_prompt(c) do %>
+                  <% nil -> %><span class="text-[var(--color-text-muted)]">—</span>
+                  <% prompt -> %><div class="line-clamp-3 text-[var(--color-text-muted)]" title={prompt}>{prompt}</div>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
         </:col>
         <:col :let={c} label="Agent">
           <.link navigate={~p"/conversations/#{c.id}"} class="block truncate text-[var(--color-text-primary)] hover:underline font-medium">
@@ -238,6 +247,13 @@ defmodule FountainWeb.ConversationsLive.Index do
         prompt |> String.trim() |> String.replace(~r/\s+/, " ")
     end
   end
+
+  defp unread?(%{last_read_at: nil}), do: true
+  defp unread?(%{last_read_at: _, last_active_at: nil}), do: false
+  defp unread?(%{last_read_at: read_at, last_active_at: active_at}) do
+    DateTime.compare(active_at, read_at) == :gt
+  end
+  defp unread?(_), do: false
 
   attr :source, :string, default: "api"
 

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -29,6 +29,7 @@ defmodule FountainWeb.ConversationsLive.Show do
           root_node = Enum.find(graph, fn n -> is_nil(n.parent_id) end)
           root_id = if root_node, do: root_node.id, else: id
           Phoenix.PubSub.subscribe(Fountain.PubSub, "conversations:graph:#{root_id}")
+          Conversations.mark_read(id, user_id)
         end
 
         events = Conversations.list_log_events(id) |> annotate_durations()

--- a/apps/fountain/priv/repo/migrations/20260513200000_add_last_read_at_to_conversations.exs
+++ b/apps/fountain/priv/repo/migrations/20260513200000_add_last_read_at_to_conversations.exs
@@ -1,0 +1,9 @@
+defmodule Fountain.Repo.Migrations.AddLastReadAtToConversations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:conversations) do
+      add :last_read_at, :utc_datetime_usec
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1771,4 +1771,106 @@ defmodule Fountain.ConversationsContextTest do
       assert Map.get(result, "xyzquuxfoo_novel_key_never_an_atom") == "ignored_value"
     end
   end
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # mark_read/2
+  # ────────────────────────────────────────────────────────────────────────────
+
+  describe "mark_read/2" do
+    test "sets last_read_at to approximately now" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      assert is_nil(conv.last_read_at)
+
+      before = DateTime.utc_now()
+      :ok = Conversations.mark_read(conv.id, user.id)
+      after_time = DateTime.utc_now()
+
+      reloaded = Conversations.get_conversation(conv.id, user.id)
+      refute is_nil(reloaded.last_read_at)
+      assert DateTime.compare(reloaded.last_read_at, before) in [:gt, :eq]
+      assert DateTime.compare(reloaded.last_read_at, after_time) in [:lt, :eq]
+    end
+
+    test "is scoped to owner — does not update another user's conversation" do
+      user1 = insert_verified_user()
+      user2 = insert_verified_user()
+      conv = insert_conversation(user_id: user1.id)
+
+      :ok = Conversations.mark_read(conv.id, user2.id)
+
+      reloaded = Conversations.get_conversation(conv.id, user1.id)
+      assert is_nil(reloaded.last_read_at)
+    end
+
+    test "calling twice updates last_read_at to a more recent time" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+
+      :ok = Conversations.mark_read(conv.id, user.id)
+      first_read = Conversations.get_conversation(conv.id, user.id).last_read_at
+
+      Process.sleep(2)
+
+      :ok = Conversations.mark_read(conv.id, user.id)
+      second_read = Conversations.get_conversation(conv.id, user.id).last_read_at
+
+      assert DateTime.compare(second_read, first_read) in [:gt, :eq]
+    end
+  end
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # list_conversations/2 — last_active_at and unread safety
+  # ────────────────────────────────────────────────────────────────────────────
+
+  describe "list_conversations/2 last_active_at" do
+    test "defaults to inserted_at when there are no log events" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+
+      [result] = Conversations.list_conversations(user.id)
+      assert result.last_active_at == result.inserted_at
+    end
+
+    test "advances past inserted_at when output log events exist" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+
+      later = DateTime.utc_now() |> DateTime.add(60, :second) |> DateTime.truncate(:microsecond)
+      insert_log_event(conv, kind: "output", stream: "stdout", inserted_at: later)
+
+      [result] = Conversations.list_conversations(user.id)
+      assert DateTime.compare(result.last_active_at, conv.inserted_at) == :gt
+    end
+
+    test "stage events (reconnects) do NOT advance last_active_at" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+
+      baseline_at = List.first(Conversations.list_conversations(user.id)).last_active_at
+
+      later = DateTime.utc_now() |> DateTime.add(300, :second) |> DateTime.truncate(:microsecond)
+      insert_log_event(conv, kind: "stage", data: "reattach", stream: "", inserted_at: later)
+
+      [result] = Conversations.list_conversations(user.id)
+      assert DateTime.compare(result.last_active_at, baseline_at) == :eq
+    end
+
+    test "last_read_at is nil by default" do
+      user = insert_verified_user()
+      insert_conversation(user_id: user.id)
+
+      [result] = Conversations.list_conversations(user.id)
+      assert is_nil(result.last_read_at)
+    end
+
+    test "last_read_at is populated after mark_read" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      Conversations.mark_read(conv.id, user.id)
+
+      [result] = Conversations.list_conversations(user.id)
+      refute is_nil(result.last_read_at)
+    end
+  end
 end

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1829,7 +1829,10 @@ defmodule Fountain.ConversationsContextTest do
       conv = insert_conversation(user_id: user.id)
 
       [result] = Conversations.list_conversations(user.id)
-      assert result.last_active_at == result.inserted_at
+      assert DateTime.compare(
+               result.last_active_at,
+               DateTime.from_naive!(result.inserted_at, "Etc/UTC")
+             ) == :eq
     end
 
     test "advances past inserted_at when output log events exist" do

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1843,7 +1843,7 @@ defmodule Fountain.ConversationsContextTest do
       insert_log_event(conv, kind: "output", stream: "stdout", inserted_at: later)
 
       [result] = Conversations.list_conversations(user.id)
-      assert DateTime.compare(result.last_active_at, conv.inserted_at) == :gt
+      assert DateTime.compare(result.last_active_at, DateTime.from_naive!(conv.inserted_at, "Etc/UTC")) == :gt
     end
 
     test "stage events (reconnects) do NOT advance last_active_at" do


### PR DESCRIPTION
## Summary

- Adds `last_read_at :utc_datetime_usec` column to conversations — stamped when a user opens a conversation via `Show.mount`
- Shows an indigo dot in the sidebar and conversations index whenever `last_active_at > last_read_at` (i.e. the AI has responded since the user last looked)
- **Reconnect-safe:** `last_active_at` is computed from `kind: "output"` log events only — stage/lifecycle events (reattaches, sandbox reconnects) are explicitly excluded at the query layer

## How it works

1. User opens a conversation → `Show.mount` calls `mark_read/2` → stamps `last_read_at = now()`, broadcasts sidebar refresh
2. AI produces output → new `kind: "output"` log event → `last_active_at` advances past `last_read_at` → dot appears on next sidebar refresh
3. Dot is suppressed while the user is actively on that conversation's page (`not active` guard), so it disappears immediately on navigation without waiting for the DB round-trip

## Test Plan
- [ ] `mix ecto.migrate` applies cleanly
- [ ] `mix test test/fountain/conversations_context_test.exs` — 8 new tests pass (mark_read scoping, timestamp correctness, stage-event exclusion)
- [ ] Open a conversation → sidebar dot disappears
- [ ] Simulate AI response (insert an output log event) → dot reappears after sidebar refresh
- [ ] Reconnect a conversation → confirm no spurious dot

🤖 Generated with [Claude Code](https://claude.ai/claude-code)