### PR TITLE
Live unread dots: broadcast sidebar update on AI output

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -101,6 +101,7 @@ defmodule Fountain.Conversations.ConversationServer do
       sandbox_id: Keyword.fetch!(args, :sandbox_id),
       runtime_module: Keyword.fetch!(args, :runtime_module),
       initial_prompt: Keyword.get(args, :initial_prompt),
+      user_id: nil,
       sprite: nil,
       sprite_env: [],
       current_command: nil,
@@ -143,7 +144,7 @@ defmodule Fountain.Conversations.ConversationServer do
         secrets = merge_secrets(env, vault, dek)
 
         state =
-          %{state | runtime_session_id: conv.runtime_session_id, tenant_key: dek, inference_credentials: inference_creds}
+          %{state | user_id: conv.user_id, runtime_session_id: conv.runtime_session_id, tenant_key: dek, inference_credentials: inference_creds}
 
         dispatch_provision(state, conv, sandbox, agent, env, vault, secrets)
 
@@ -1053,6 +1054,14 @@ defmodule Fountain.Conversations.ConversationServer do
       "conv:#{state.conversation_id}",
       {:log_event, event}
     )
+
+    if state.user_id do
+      Phoenix.PubSub.broadcast(
+        Fountain.PubSub,
+        "sidebar:#{state.user_id}",
+        {:sidebar_update, state.user_id}
+      )
+    end
   end
 
   # Drop replayed bytes before persisting. After reattach, sprites replays


### PR DESCRIPTION
## Summary

- Store `user_id` in `ConversationServer` state (populated from the conversation row during `handle_continue(:provision)`)
- After each `kind: "output"` log event is persisted and broadcast on `conv:*`, also broadcast `{:sidebar_update, user_id}` on `sidebar:#{user_id}`
- The existing sidebar hook in `hooks.ex` already subscribes to that topic and reloads `nav_conversations` in-place — so unread dots now appear across all open tabs without a page refresh

The `if state.user_id` guard makes the broadcast a safe no-op during the brief startup window before provision completes. Stage events (reconnects) go through `publish_stage`, not `log_output`, so the reconnect-safe invariant from #115 is preserved.

## Test plan

- [ ] Open two browser tabs: conversation list in one, a different conversation in another
- [ ] Trigger an AI response in the background conversation
- [ ] Confirm the unread dot appears in the sidebar of the active tab without refreshing
- [ ] Confirm no dot appears when viewing the conversation that received the response (the \`not active\` guard)
- [ ] Confirm reconnecting/reattaching does not trigger a false unread dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)