### PR TITLE
fix: chat view avatar glyphs and broken image thumbnails

### DIFF
--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -405,7 +405,7 @@ defmodule FountainWeb.ConversationsLive.Show do
           <label class="cursor-pointer flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-700">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
             <span>{if @pending_images == [], do: "Attach images", else: "#{length(@pending_images)} image(s)"}</span>
             <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" multiple class="hidden"
@@ -526,14 +526,14 @@ defmodule FountainWeb.ConversationsLive.Show do
       <.chat_message
         role={:user}
         name="you"
-        avatar="&#128100;"
+        avatar="👤"
         glyph_class="bg-blue-600 text-white"
         timestamp={@turn.started_at}
       >
         <div :if={@image_count > 0} class="flex flex-wrap gap-2 mb-2">
           <%= for pos <- 0..(@image_count - 1) do %>
-            <a href={"/api/conversations/#{@conv.id}/turns/#{@turn.id}/images/#{pos}"} target="_blank">
-              <img src={"/api/conversations/#{@conv.id}/turns/#{@turn.id}/images/#{pos}"}
+            <a href={"/conversations/#{@conv.id}/turns/#{@turn.id}/images/#{pos}"} target="_blank">
+              <img src={"/conversations/#{@conv.id}/turns/#{@turn.id}/images/#{pos}"}
                 class="max-w-[300px] max-h-[200px] object-contain rounded border border-blue-400/30" />
             </a>
           <% end %>
@@ -648,11 +648,11 @@ defmodule FountainWeb.ConversationsLive.Show do
 
   defp format_chat_time(_), do: ""
 
-  defp agent_glyph("claude"), do: "&#10022;"
-  defp agent_glyph("codex"), do: "&#9671;"
-  defp agent_glyph("gemini"), do: "&#9672;"
-  defp agent_glyph("opencode"), do: "&#9673;"
-  defp agent_glyph(_), do: "&#129302;"
+  defp agent_glyph("claude"), do: "✦"
+  defp agent_glyph("codex"), do: "◇"
+  defp agent_glyph("gemini"), do: "◈"
+  defp agent_glyph("opencode"), do: "◉"
+  defp agent_glyph(_), do: "🤖"
 
   # Walk this turn's events and pull out every `:text` block from each
   # runtime's stream-json. Joined so multi-message turns (claude can

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -175,6 +175,9 @@ defmodule FountainWeb.Router do
     # ── Avatar serving — tenant-scoped image endpoint ─────────────────────────────────────────────────────
     get "/agents/:id/avatar", AgentAvatarController, :show
 
+    # ── Turn image serving — session-authenticated so <img> tags can load without a bearer token ──────────
+    get "/conversations/:conversation_id/turns/:turn_id/images/:position", TurnImageController, :show
+
     # ── Phase-3-billing: conversation routes require an active subscription ─────────────────
     # :require_active_subscription runs after :require_authenticated_user and
     # redirects to /account/billing on SubscriptionRequiredError.


### PR DESCRIPTION
## Problem

Two rendering bugs in the chat view:

1. **Avatar shows `&#10022;` as literal text** — `agent_glyph/1` returned HTML entity strings (e.g. `"&#10022;"`), but HEEX's `{}` interpolation auto-escapes content, so the entity was never decoded by the browser. Same issue for the hardcoded user avatar `"&#128100;"`.

2. **Image thumbnails show as broken** — The `<img src>` pointed at `/api/conversations/.../turns/.../images/:pos`, which goes through the `:api` pipeline requiring a bearer token (`TenantAPIAuth`). Browser-initiated `<img>` requests only carry session cookies, so the request returned 401 and the image failed to load.

## Fix

- Replace HTML entity strings in `agent_glyph/1` and the user avatar attribute with the actual Unicode characters (`✦`, `◇`, `◈`, `◉`, `🤖`, `👤`) so HEEX interpolation passes them through cleanly.
- Add a browser-authenticated route for turn images (`GET /conversations/:conversation_id/turns/:turn_id/images/:position`) alongside the existing agent avatar route, using the same session-cookie auth the LiveView already uses.
- Update the chat view `<img>` src/href to use the new browser route.