### PR TITLE
Align sidebar conv avatar with subtitle line

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -463,7 +463,7 @@ defmodule FountainWeb.Layouts do
     <.link
       {@link_attrs}
       class={[
-        "flex items-center gap-2.5 rounded-md px-3 py-1.5 text-sm transition-colors",
+        "flex items-end gap-2.5 rounded-md px-3 py-1.5 text-sm transition-colors",
         if(@active,
           do: "bg-[var(--color-bg-2)] text-[var(--color-text-primary)]",
           else: "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)]"


### PR DESCRIPTION
Changes `items-center` to `items-end` on the conv nav link flex container, so the avatar sits flush with line 2 (the subtitle row) rather than being vertically centred across both lines.

**Before:** avatar centred across title + subtitle
**After:** avatar bottom-aligned with the subtitle row