### PR TITLE
Replace repositories JSON textarea with structured form UI

### DIFF
--- a/.claude/skills/fountain/SKILL.md
+++ b/.claude/skills/fountain/SKILL.md
@@ -14,6 +14,26 @@ each runs in its own fresh Sprite.
 > (the bare path is the LiveView UI). The right URL is
 > `$FOUNTAIN_BASE_URL/api/conversations`.
 
+## Finding cloned repositories
+
+If the environment was configured with repositories, they are cloned into the
+sprite **before** the setup script runs. **Look for cloned repos under
+`/workspace/`** — for example, a repo cloned with `mount_path:
+"/workspace/my-repo"` will be at `/workspace/my-repo` inside the sprite.
+
+```bash
+# List all cloned repos:
+ls /workspace/
+
+# Navigate to a specific repo:
+cd /workspace/my-repo
+```
+
+When writing prompts for spawned agents that need to work with source code,
+tell them to look in `/workspace/<repo-name>` — that is the conventional
+location. If you are unsure of the repo name, `ls /workspace/` will show
+what is available.
+
 ## The two patterns you'll use
 
 ### A. Fan out N agents and collect their answers
@@ -225,3 +245,4 @@ spawned_ids+=("$CONV")
 - **Re-read `$FOUNTAIN_TOKEN` from env on each call.** It's a per-conversation key scoped to this conversation's owner, not a long-lived admin token. Fountain rotates it on every fresh provision and every reattach (e.g. after a deploy or BEAM restart), revoking the previous value. If a request returns 401 with `"reason": "api_key_revoked"`, your cached copy is stale — re-source `$FOUNTAIN_TOKEN` from the environment before retrying. Don't leak it outside the sprite.
 - **API path is `/api/...`.** The bare `/conversations` redirects (302 → /login) for non-browser requests.
 - **Provenance is automatic.** `FOUNTAIN_CONVERSATION_ID` is always present in your sprite's environment. Every `POST /api/conversations` call that includes `X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID` records this conversation as the parent, letting the operator reconstruct the full spawn chain.
+- **Cloned repos are under `/workspace/`.** When an environment is configured with repositories, they are cloned to their configured `mount_path` (e.g. `/workspace/my-repo`) before the setup script runs. Always look in `/workspace/` first when you need to find source code.

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -21,7 +21,8 @@ defmodule FountainWeb.EnvironmentsLive.Form do
      |> assign(:form, env_to_form(env))
      |> assign(:errors, %{})
      |> assign(:secrets, secrets_for(env))
-     |> assign(:new_secret, %{"key" => "", "value" => ""})}
+     |> assign(:new_secret, %{"key" => "", "value" => ""})
+     |> assign(:repositories, env.repositories || [])}
   end
 
   defp load(%{"id" => id}, user_id), do: {Environments.get_environment!(id, user_id), :edit}
@@ -37,8 +38,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
       "env_vars_json" => Jason.encode!(e.env_vars || %{}, pretty: true),
       "packages_json" => Jason.encode!(e.packages || %{}, pretty: true),
       "networking_type" => e.networking_type || "unrestricted",
-      "networking_config_json" => Jason.encode!(e.networking_config || %{}, pretty: true),
-      "repositories_json" => Jason.encode!(e.repositories || [], pretty: true)
+      "networking_config_json" => Jason.encode!(e.networking_config || %{}, pretty: true)
     }
   end
 
@@ -47,27 +47,39 @@ defmodule FountainWeb.EnvironmentsLive.Form do
 
   @impl true
   def handle_event("validate", %{"env" => params}, socket) do
-    {:noreply, assign(socket, :form, params)}
+    repos = extract_repos_from_params(params)
+    {:noreply, socket |> assign(:form, params) |> assign(:repositories, repos)}
+  end
+
+  def handle_event("add_repo", _, socket) do
+    repos =
+      socket.assigns.repositories ++
+        [%{"url" => "", "mount_path" => "/workspace/", "secret_key" => "", "ref" => ""}]
+
+    {:noreply, assign(socket, :repositories, repos)}
+  end
+
+  def handle_event("remove_repo", %{"index" => index_str}, socket) do
+    index = String.to_integer(index_str)
+    repos = List.delete_at(socket.assigns.repositories, index)
+    {:noreply, assign(socket, :repositories, repos)}
   end
 
   def handle_event("submit", %{"env" => params}, socket) do
+    repos = extract_repos_from_params(params)
+
     with {:ok, env_vars} <- parse_json_object(params["env_vars_json"], "env_vars_json"),
          {:ok, packages} <- parse_json_object(params["packages_json"], "packages_json"),
          {:ok, networking} <-
            parse_json_object(params["networking_config_json"], "networking_config_json"),
-         {:ok, repos} <- parse_repos(params["repositories_json"]) do
+         :ok <- validate_repos(repos) do
       attrs =
         params
         |> Map.put("env_vars", env_vars)
         |> Map.put("packages", packages)
         |> Map.put("networking_config", networking)
         |> Map.put("repositories", repos)
-        |> Map.drop([
-          "env_vars_json",
-          "packages_json",
-          "networking_config_json",
-          "repositories_json"
-        ])
+        |> Map.drop(["env_vars_json", "packages_json", "networking_config_json"])
 
       save(socket, attrs)
     else
@@ -147,14 +159,45 @@ defmodule FountainWeb.EnvironmentsLive.Form do
     end
   end
 
-  defp parse_repos(nil), do: {:ok, []}
-  defp parse_repos(""), do: {:ok, []}
+  defp extract_repos_from_params(params) do
+    case params["repositories"] do
+      nil ->
+        []
 
-  defp parse_repos(json) do
-    case Jason.decode(json) do
-      {:ok, list} when is_list(list) -> {:ok, list}
-      _ -> {:error, "repositories_json", "must be a JSON array of repo specs"}
+      repos_map when is_map(repos_map) ->
+        repos_map
+        |> Enum.sort_by(fn {k, _} -> String.to_integer(k) end)
+        |> Enum.map(fn {_, r} -> r end)
+
+      _ ->
+        []
     end
+  end
+
+  defp validate_repos([]), do: :ok
+
+  defp validate_repos(repos) do
+    Enum.reduce_while(repos, :ok, fn repo, _acc ->
+      url = repo["url"] || ""
+      mount = repo["mount_path"] || ""
+
+      cond do
+        url == "" ->
+          {:halt, {:error, "repositories", "each repo must have a url"}}
+
+        not String.starts_with?(url, "https://") ->
+          {:halt, {:error, "repositories", "each repo url must start with https://"}}
+
+        mount == "" ->
+          {:halt, {:error, "repositories", "each repo must have a mount_path"}}
+
+        not String.starts_with?(mount, "/") ->
+          {:halt, {:error, "repositories", "each repo mount_path must be an absolute path"}}
+
+        true ->
+          {:cont, :ok}
+      end
+    end)
   end
 
   defp changeset_errors(cs) do
@@ -196,15 +239,77 @@ defmodule FountainWeb.EnvironmentsLive.Form do
           placeholder='{"PROJECT_ROOT": "/workspace/repo"}'/>
         <.error_msg field="env_vars_json" errors={@errors}/>
 
-        <.input id="repositories_json" name="env[repositories_json]" type="textarea" rows="6"
-          label="Repositories (JSON array)" value={@form["repositories_json"]}
-          placeholder={~s|[\n  {\n    "url": "https://github.com/ravi-hq/agent-on-demand",\n    "mount_path": "/workspace/agent-on-demand",\n    "secret_key": "GITHUB_TOKEN"\n  }\n]|}/>
-        <.error_msg field="repositories_json" errors={@errors}/>
-        <p class="text-xs text-zinc-500">
-          Each repo: <code>url</code> (https://...), <code>mount_path</code> (absolute), optional
-          <code>secret_key</code> (name of an env secret holding a token; used as
-          <code>x-access-token</code> for the clone), optional <code>ref</code> (branch/tag).
-        </p>
+        <div class="space-y-2">
+          <label class="block text-sm font-medium text-zinc-700">Repositories</label>
+
+          <div :if={@repositories == []} class="text-sm text-zinc-400 italic py-1">
+            No repositories configured.
+          </div>
+
+          <div
+            :for={{repo, i} <- Enum.with_index(@repositories)}
+            class="border border-zinc-200 rounded-md p-3 space-y-2 bg-zinc-50"
+          >
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Repo {i + 1}</span>
+              <button
+                type="button"
+                phx-click="remove_repo"
+                phx-value-index={i}
+                class="text-xs text-rose-500 hover:text-rose-700 font-medium"
+              >
+                Remove
+              </button>
+            </div>
+            <.input
+              id={"repo_#{i}_url"}
+              name={"env[repositories][#{i}][url]"}
+              label="URL"
+              value={repo["url"] || ""}
+              placeholder="https://github.com/owner/repo"
+            />
+            <.input
+              id={"repo_#{i}_mount_path"}
+              name={"env[repositories][#{i}][mount_path]"}
+              label="Mount path"
+              value={repo["mount_path"] || ""}
+              placeholder="/workspace/repo"
+            />
+            <div class="grid grid-cols-2 gap-2">
+              <.input
+                id={"repo_#{i}_secret_key"}
+                name={"env[repositories][#{i}][secret_key]"}
+                label="Secret key (optional)"
+                value={repo["secret_key"] || ""}
+                placeholder="GITHUB_TOKEN"
+              />
+              <.input
+                id={"repo_#{i}_ref"}
+                name={"env[repositories][#{i}][ref]"}
+                label="Ref / branch (optional)"
+                value={repo["ref"] || ""}
+                placeholder="main"
+              />
+            </div>
+          </div>
+
+          <button
+            type="button"
+            phx-click="add_repo"
+            class="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+          >
+            + Add repository
+          </button>
+          <.error_msg field="repositories" errors={@errors} />
+          <p class="text-xs text-zinc-500 mt-1">
+            Repos are cloned into the sprite before your setup script runs.
+            Set <code>mount_path</code> to where the repo should appear — use
+            <code>/workspace/repo-name</code> as the convention (cloned repos live under
+            <code>/workspace/</code> in the sprite). Use <code>secret_key</code> to name
+            an env secret whose value is passed as <code>x-access-token</code> for
+            cloning private repos.
+          </p>
+        </div>
 
         <div class="grid grid-cols-2 gap-3">
           <div class="space-y-1">
@@ -220,7 +325,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
         <.error_msg field="networking_config_json" errors={@errors}/>
 
         <div class="flex gap-2">
-          <.btn type="submit" phx-disable-with="Saving…">Save</.btn>
+          <.btn type="submit" phx-disable-with="Saving\u2026">Save</.btn>
           <.link navigate={~p"/environments"}><.btn_secondary>Cancel</.btn_secondary></.link>
         </div>
       </form>
@@ -238,7 +343,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
           <tbody>
             <tr :for={s <- @secrets} class="border-b border-zinc-100 last:border-0">
               <td class="py-2 font-mono">{s.key}</td>
-              <td class="py-2 text-zinc-400 font-mono text-xs">•••••••</td>
+              <td class="py-2 text-zinc-400 font-mono text-xs">&bull;&bull;&bull;&bull;&bull;&bull;&bull;</td>
               <td class="py-2 text-right">
                 <.btn_danger phx-click="delete_secret" phx-value-id={s.id} data-confirm="Delete?">Delete</.btn_danger>
               </td>


### PR DESCRIPTION
## Summary

- **Repositories field**: replaces the raw JSON textarea with a dynamic form UI — add/remove repos via buttons, with individual fields for `url`, `mount_path`, `secret_key` (optional), and `ref` (optional)
- **LiveView events**: `add_repo` appends a blank entry; `remove_repo` deletes by index; `validate` syncs form state including the repo list; `submit` collects and validates the structured data
- **Mount path guidance**: help text and placeholder direct users to the `/workspace/repo-name` convention
- **Fountain skill** (`SKILL.md`): adds a "Finding cloned repositories" section explaining that cloned repos live under `/workspace/` and showing how to list them

## Details

### Environment form (`form.ex`)

The `repositories_json` textarea is gone. Instead, the form renders a card per repo with four inputs. The socket carries a `@repositories` list (list of string-keyed maps); `validate` events extract it from nested params (`env[repositories][0][url]` etc.) and keep it in sync. `add_repo`/`remove_repo` mutate the list server-side.

Validation checks that every repo has a `url` starting with `https://` and a `mount_path` starting with `/`.

### Fountain skill

New section added near the top (right after the common-mistake callout) explaining:
- Cloned repos appear under `/workspace/` at the configured `mount_path`
- `ls /workspace/` to discover what's available
- Tell spawned agents to look in `/workspace/<repo-name>` for source code
- Added a bullet to the Important list at the bottom as a quick reminder

## Test plan

- [ ] Create a new environment, click "Add repository", fill in url + mount_path, save — verify it round-trips correctly
- [ ] Add multiple repos, remove one, verify remaining repos save correctly
- [ ] Leave url blank, submit — verify error message appears
- [ ] Use a non-https url — verify error message
- [ ] Edit an existing environment with repos — verify fields are pre-populated
- [ ] Verify networking and other fields still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)