### PR TITLE
Replace skills and MCP servers JSON textareas with structured form UI

### DIFF
--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -20,6 +20,8 @@ defmodule FountainWeb.AgentsLive.Form do
      |> assign(:agent, agent)
      |> assign(:form, agent_to_form(agent))
      |> assign(:errors, %{})
+     |> assign(:skills, agent_to_skill_list(agent.skills || []))
+     |> assign(:mcp_servers, agent_to_mcp_server_list(agent.mcp_servers || %{}))
      |> assign(:avatar_tab, :upload)
      |> assign(:avatar_base, "robot")
      |> assign(:avatar_mood, "serious")
@@ -47,15 +49,98 @@ defmodule FountainWeb.AgentsLive.Form do
       "system" => a.system || "",
       "model" => a.model || "anthropic/claude-sonnet-4-6",
       "runtime" => a.runtime || "claude",
-      "environment_id" => a.environment_id || "",
-      "skills_json" => Jason.encode!(a.skills || [], pretty: true),
-      "mcp_servers_json" => Jason.encode!(a.mcp_servers || %{}, pretty: true)
+      "environment_id" => a.environment_id || ""
     }
+  end
+
+  defp agent_to_skill_list(skills) do
+    Enum.map(skills, fn skill ->
+      if Map.has_key?(skill, "content") or Map.has_key?(skill, :content) do
+        %{
+          "type" => "inline",
+          "name" => skill["name"] || skill[:name] || "",
+          "content" => skill["content"] || skill[:content] || "",
+          "source" => ""
+        }
+      else
+        %{
+          "type" => "github",
+          "source" => skill["source"] || skill[:source] || "",
+          "name" => skill["name"] || skill[:name] || "",
+          "content" => ""
+        }
+      end
+    end)
+  end
+
+  defp agent_to_mcp_server_list(mcp_servers) do
+    Enum.map(mcp_servers, fn {name, config} ->
+      args_str = (config["args"] || []) |> Enum.join("\n")
+      env_vars = (config["env"] || %{}) |> Enum.map(fn {k, v} -> %{"key" => k, "value" => v} end)
+      %{"name" => name, "command" => config["command"] || "", "args" => args_str, "env_vars" => env_vars}
+    end)
   end
 
   @impl true
   def handle_event("validate", %{"agent" => params}, socket) do
-    {:noreply, assign(socket, :form, params)}
+    skills = extract_skills_from_params(params, socket.assigns.skills)
+    mcp_servers = extract_mcp_servers_from_params(params, socket.assigns.mcp_servers)
+    {:noreply, socket |> assign(:form, params) |> assign(:skills, skills) |> assign(:mcp_servers, mcp_servers)}
+  end
+
+  def handle_event("add_skill", _, socket) do
+    skills = socket.assigns.skills ++ [%{"type" => "github", "source" => "", "name" => "", "content" => ""}]
+    {:noreply, assign(socket, :skills, skills)}
+  end
+
+  def handle_event("remove_skill", %{"index" => index_str}, socket) do
+    index = String.to_integer(index_str)
+    {:noreply, assign(socket, :skills, List.delete_at(socket.assigns.skills, index))}
+  end
+
+  def handle_event("set_skill_type", %{"index" => index_str, "type" => type}, socket)
+      when type in ["github", "inline"] do
+    index = String.to_integer(index_str)
+    skills = List.update_at(socket.assigns.skills, index, &Map.put(&1, "type", type))
+    {:noreply, assign(socket, :skills, skills)}
+  end
+
+  def handle_event("add_mcp_server", _, socket) do
+    servers =
+      socket.assigns.mcp_servers ++
+        [%{"name" => "", "command" => "", "args" => "", "env_vars" => []}]
+
+    {:noreply, assign(socket, :mcp_servers, servers)}
+  end
+
+  def handle_event("remove_mcp_server", %{"index" => index_str}, socket) do
+    index = String.to_integer(index_str)
+    {:noreply, assign(socket, :mcp_servers, List.delete_at(socket.assigns.mcp_servers, index))}
+  end
+
+  def handle_event("add_mcp_env_var", %{"server" => server_idx_str}, socket) do
+    server_idx = String.to_integer(server_idx_str)
+
+    servers =
+      List.update_at(socket.assigns.mcp_servers, server_idx, fn s ->
+        Map.update(s, "env_vars", [%{"key" => "", "value" => ""}], fn evs ->
+          evs ++ [%{"key" => "", "value" => ""}]
+        end)
+      end)
+
+    {:noreply, assign(socket, :mcp_servers, servers)}
+  end
+
+  def handle_event("remove_mcp_env_var", %{"server" => server_idx_str, "index" => idx_str}, socket) do
+    server_idx = String.to_integer(server_idx_str)
+    idx = String.to_integer(idx_str)
+
+    servers =
+      List.update_at(socket.assigns.mcp_servers, server_idx, fn s ->
+        Map.update(s, "env_vars", [], &List.delete_at(&1, idx))
+      end)
+
+    {:noreply, assign(socket, :mcp_servers, servers)}
   end
 
   def handle_event("cancel_upload", %{"ref" => ref}, socket) do
@@ -114,14 +199,53 @@ defmodule FountainWeb.AgentsLive.Form do
   end
 
   def handle_event("submit", %{"agent" => params}, socket) do
-    with {:ok, mcp} <- parse_mcp(params),
-         {:ok, skills} <- parse_skills(params) do
+    skills_list = extract_skills_from_params(params, socket.assigns.skills)
+    mcp_servers_list = extract_mcp_servers_from_params(params, socket.assigns.mcp_servers)
+
+    with :ok <- validate_skills_list(skills_list),
+         :ok <- validate_mcp_servers(mcp_servers_list) do
+      skills =
+        Enum.map(skills_list, fn s ->
+          case s["type"] do
+            "github" ->
+              m = %{"source" => s["source"] || ""}
+              if (s["name"] || "") != "", do: Map.put(m, "name", s["name"]), else: m
+
+            "inline" ->
+              %{"name" => s["name"] || "", "content" => s["content"] || ""}
+
+            _ ->
+              nil
+          end
+        end)
+        |> Enum.reject(&is_nil/1)
+
+      mcp_map =
+        Map.new(mcp_servers_list, fn s ->
+          args =
+            (s["args"] || "")
+            |> String.split("\n")
+            |> Enum.map(&String.trim/1)
+            |> Enum.reject(&(&1 == ""))
+
+          env_map =
+            (s["env_vars"] || [])
+            |> Map.new(fn %{"key" => k, "value" => v} -> {k, v} end)
+            |> Map.reject(fn {k, _} -> k == "" end)
+
+          config = %{"command" => s["command"] || ""}
+          config = if args != [], do: Map.put(config, "args", args), else: config
+          config = if map_size(env_map) > 0, do: Map.put(config, "env", env_map), else: config
+
+          {s["name"] || "", config}
+        end)
+        |> Map.reject(fn {k, _} -> k == "" end)
+
       attrs =
         params
         |> Map.put("skills", skills)
-        |> Map.put("mcp_servers", mcp)
+        |> Map.put("mcp_servers", mcp_map)
         |> Map.put("user_id", socket.assigns.user_id)
-        |> Map.drop(["skills_json", "mcp_servers_json"])
         |> nil_if_blank("environment_id")
 
       case save(socket, attrs) do
@@ -150,7 +274,7 @@ defmodule FountainWeb.AgentsLive.Form do
     {:noreply,
      socket
      |> assign(:generating_avatar, false)
-     |> assign(:avatar_error, "No OpenAI API key found. Add one in Settings → Credentials.")}
+     |> assign(:avatar_error, "No OpenAI API key found. Add one in Settings \u2192 Credentials.")}
   end
 
   def handle_async(:generate_avatar, {:ok, {:error, reason}}, socket)
@@ -205,7 +329,6 @@ defmodule FountainWeb.AgentsLive.Form do
     end
   end
 
-  # File uploads take priority; fall back to generated avatar data if present.
   defp maybe_set_avatar(socket, agent) do
     uploaded =
       consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
@@ -222,27 +345,83 @@ defmodule FountainWeb.AgentsLive.Form do
     end
   end
 
-  defp parse_skills(%{"skills_json" => v}) when v in [nil, ""], do: {:ok, []}
-
-  defp parse_skills(%{"skills_json" => json}) do
-    case Jason.decode(json) do
-      {:ok, list} when is_list(list) -> {:ok, list}
-      {:ok, _} -> {:error, "skills_json", "must be a JSON array"}
-
-      {:error, %Jason.DecodeError{} = e} ->
-        {:error, "skills_json", "invalid JSON: #{Exception.message(e)}"}
+  defp extract_skills_from_params(params, current_skills) do
+    case params["skills"] do
+      nil -> current_skills
+      skills_map when is_map(skills_map) ->
+        skills_map
+        |> Enum.sort_by(fn {k, _} -> String.to_integer(k) end)
+        |> Enum.map(fn {_, s} -> s end)
+      _ -> current_skills
     end
   end
 
-  defp parse_mcp(%{"mcp_servers_json" => v}) when v in [nil, ""], do: {:ok, %{}}
+  defp extract_mcp_servers_from_params(params, current_servers) do
+    case params["mcp_servers"] do
+      nil -> current_servers
+      servers_map when is_map(servers_map) ->
+        servers_map
+        |> Enum.sort_by(fn {k, _} -> String.to_integer(k) end)
+        |> Enum.map(fn {_, s} ->
+          env_vars =
+            case s["env_vars"] do
+              nil -> []
+              evs when is_map(evs) ->
+                evs
+                |> Enum.sort_by(fn {k, _} -> String.to_integer(k) end)
+                |> Enum.map(fn {_, r} -> r end)
+              _ -> []
+            end
+          Map.put(s, "env_vars", env_vars)
+        end)
+      _ -> current_servers
+    end
+  end
 
-  defp parse_mcp(%{"mcp_servers_json" => json}) do
-    case Jason.decode(json) do
-      {:ok, m} when is_map(m) -> {:ok, m}
-      {:ok, _} -> {:error, "mcp_servers_json", "must be a JSON object"}
+  defp validate_skills_list([]), do: :ok
 
-      {:error, %Jason.DecodeError{} = e} ->
-        {:error, "mcp_servers_json", "invalid JSON: #{Exception.message(e)}"}
+  defp validate_skills_list(skills) do
+    Enum.reduce_while(skills, :ok, fn skill, _acc ->
+      case skill["type"] do
+        "github" ->
+          if (skill["source"] || "") == "" do
+            {:halt, {:error, "skills_json", "each GitHub skill must have a source (owner/repo)"}}
+          else
+            {:cont, :ok}
+          end
+
+        "inline" ->
+          cond do
+            (skill["name"] || "") == "" ->
+              {:halt, {:error, "skills_json", "each inline skill must have a name"}}
+
+            (skill["content"] || "") == "" ->
+              {:halt, {:error, "skills_json", "each inline skill must have content"}}
+
+            true ->
+              {:cont, :ok}
+          end
+
+        _ ->
+          {:cont, :ok}
+      end
+    end)
+  end
+
+  defp validate_mcp_servers([]), do: :ok
+
+  defp validate_mcp_servers(servers) do
+    names = Enum.map(servers, &(&1["name"] || ""))
+
+    cond do
+      Enum.any?(names, &(&1 == "")) ->
+        {:error, "mcp_servers_json", "each server must have a name"}
+
+      length(names) != length(Enum.uniq(names)) ->
+        {:error, "mcp_servers_json", "server names must be unique"}
+
+      true ->
+        :ok
     end
   end
 
@@ -292,7 +471,7 @@ defmodule FountainWeb.AgentsLive.Form do
         <div class="space-y-1">
           <label class="block text-sm font-medium text-zinc-700">Environment</label>
           <select name="agent[environment_id]" class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm">
-            <option value="">— none —</option>
+            <option value="">\u2014 none \u2014</option>
             <option :for={e <- @envs} value={e.id} selected={@form["environment_id"] == e.id}>{e.name}</option>
           </select>
         </div>
@@ -301,7 +480,6 @@ defmodule FountainWeb.AgentsLive.Form do
         <div class="space-y-3">
           <label class="block text-sm font-medium text-zinc-700">Avatar</label>
 
-          <%!-- Current DB avatar (hidden when a generated preview is pending) --%>
           <div :if={@agent.id && @agent.avatar_media_type && !@generated_avatar_preview}
                class="flex items-center gap-3">
             <img
@@ -318,7 +496,6 @@ defmodule FountainWeb.AgentsLive.Form do
             </button>
           </div>
 
-          <%!-- Generated avatar preview --%>
           <div :if={@generated_avatar_preview} class="flex items-center gap-3">
             <img
               src={@generated_avatar_preview}
@@ -337,7 +514,6 @@ defmodule FountainWeb.AgentsLive.Form do
             </div>
           </div>
 
-          <%!-- Tab switcher --%>
           <div class="flex gap-0.5 rounded-lg border border-zinc-200 bg-zinc-50 p-0.5 w-fit text-sm">
             <button
               type="button"
@@ -365,7 +541,6 @@ defmodule FountainWeb.AgentsLive.Form do
             </button>
           </div>
 
-          <%!-- Upload tab --%>
           <div :if={@avatar_tab == :upload} class="space-y-2">
             <.live_file_input
               upload={@uploads.avatar}
@@ -373,7 +548,7 @@ defmodule FountainWeb.AgentsLive.Form do
                      file:bg-zinc-100 file:px-3 file:py-1.5 file:text-sm file:font-medium
                      file:cursor-pointer hover:file:bg-zinc-200"
             />
-            <p class="text-xs text-zinc-500">JPEG, PNG, GIF, or WebP · max 5 MB</p>
+            <p class="text-xs text-zinc-500">JPEG, PNG, GIF, or WebP \u00b7 max 5 MB</p>
 
             <div :for={entry <- @uploads.avatar.entries} class="flex items-center gap-3">
               <.live_img_preview
@@ -397,9 +572,7 @@ defmodule FountainWeb.AgentsLive.Form do
             </div>
           </div>
 
-          <%!-- Generate tab --%>
           <div :if={@avatar_tab == :generate} class="space-y-3">
-            <%!-- Base picker --%>
             <div class="space-y-1.5">
               <p class="text-xs font-medium text-zinc-600">Base</p>
               <div class="flex gap-1.5">
@@ -419,7 +592,6 @@ defmodule FountainWeb.AgentsLive.Form do
               </div>
             </div>
 
-            <%!-- Mood picker --%>
             <div class="space-y-1.5">
               <p class="text-xs font-medium text-zinc-600">Mood</p>
               <div class="flex gap-1.5">
@@ -451,7 +623,7 @@ defmodule FountainWeb.AgentsLive.Form do
                   <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                   <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
-                Generating…
+                Generating\u2026
               <% else %>
                 Generate
               <% end %>
@@ -461,43 +633,227 @@ defmodule FountainWeb.AgentsLive.Form do
           </div>
         </div>
 
-        <.input id="skills_json" name="agent[skills_json]" type="textarea" rows="6"
-          label="Skills (JSON array)"
-          value={@form["skills_json"]}
-          placeholder={~s([{"source": "anthropics/skills", "name": "frontend-design"}])}/>
-        <.error_msg field="skills_json" errors={@errors}/>
-        <div class="text-xs text-zinc-500 -mt-2 space-y-2">
-          <p>
-            Each entry is either inline
-            (<code>{~s({"name": "...", "content": "<SKILL.md body>"})}</code>)
-            or a GitHub skill via
-            <a href="https://skills.sh" target="_blank" class="underline">skills.sh</a>
-            (<code>{~s({"source": "owner/repo", "name": "<optional>"})}</code>).
-            <.link navigate={~p"/help/skills"} class="underline">Skills help →</.link>
-          </p>
-          <div class="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-blue-900 leading-relaxed">
-            <strong>Always included:</strong>
-            the built-in <code>fountain</code> skill is automatically mounted in every
-            conversation — no need to declare it. It gives the agent
-            <code>$FOUNTAIN_TOKEN</code>, <code>$FOUNTAIN_BASE_URL</code>, and
-            <code>$FOUNTAIN_CONVERSATION_ID</code> so it can spawn and coordinate sub-agents.
+        <%!-- Skills --%>
+        <div class="space-y-2">
+          <label class="block text-sm font-medium text-zinc-700">Skills</label>
+
+          <div :if={@skills == []} class="text-sm text-zinc-400 italic py-1">No skills configured.</div>
+
+          <div
+            :for={{skill, i} <- Enum.with_index(@skills)}
+            class="border border-zinc-200 rounded-md p-3 bg-zinc-50 space-y-2"
+          >
+            <div class="flex items-center justify-between">
+              <div class="flex gap-0.5 rounded border border-zinc-200 bg-white p-0.5 text-xs">
+                <button
+                  type="button"
+                  phx-click="set_skill_type"
+                  phx-value-index={i}
+                  phx-value-type="github"
+                  class={[
+                    "px-2 py-0.5 rounded-sm transition-colors",
+                    skill["type"] == "github" && "bg-zinc-900 text-white",
+                    skill["type"] != "github" && "text-zinc-500 hover:text-zinc-700"
+                  ]}
+                >
+                  GitHub
+                </button>
+                <button
+                  type="button"
+                  phx-click="set_skill_type"
+                  phx-value-index={i}
+                  phx-value-type="inline"
+                  class={[
+                    "px-2 py-0.5 rounded-sm transition-colors",
+                    skill["type"] == "inline" && "bg-zinc-900 text-white",
+                    skill["type"] != "inline" && "text-zinc-500 hover:text-zinc-700"
+                  ]}
+                >
+                  Inline
+                </button>
+              </div>
+              <button
+                type="button"
+                phx-click="remove_skill"
+                phx-value-index={i}
+                class="text-xs text-rose-500 hover:text-rose-700 font-medium"
+              >
+                Remove
+              </button>
+            </div>
+
+            <input type="hidden" name={"agent[skills][#{i}][type]"} value={skill["type"]} />
+
+            <div :if={skill["type"] == "github"} class="grid grid-cols-2 gap-2">
+              <.input
+                id={"skill_#{i}_source"}
+                name={"agent[skills][#{i}][source]"}
+                label="Source (owner/repo)"
+                value={skill["source"] || ""}
+                placeholder="anthropics/skills"
+              />
+              <.input
+                id={"skill_#{i}_name"}
+                name={"agent[skills][#{i}][name]"}
+                label="Name (optional)"
+                value={skill["name"] || ""}
+                placeholder="brainstorming"
+              />
+            </div>
+
+            <div :if={skill["type"] == "inline"} class="space-y-2">
+              <.input
+                id={"skill_#{i}_inline_name"}
+                name={"agent[skills][#{i}][name]"}
+                label="Name"
+                value={skill["name"] || ""}
+                placeholder="my-skill"
+              />
+              <.input
+                id={"skill_#{i}_content"}
+                name={"agent[skills][#{i}][content]"}
+                type="textarea"
+                rows="8"
+                label="Content (SKILL.md body)"
+                value={skill["content"] || ""}
+                placeholder="# My Skill&#10;&#10;..."
+              />
+            </div>
           </div>
-          <p>
-            Common GitHub skills:
-            <code>{~s({"source": "anthropics/skills", "name": "brainstorming"})}</code>
-            ·
-            <code>{~s({"source": "anthropics/skills", "name": "test-driven-development"})}</code>
-            ·
-            <code>{~s({"source": "anthropics/skills", "name": "systematic-debugging"})}</code>
-          </p>
+
+          <button
+            type="button"
+            phx-click="add_skill"
+            class="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+          >
+            + Add skill
+          </button>
+          <.error_msg field="skills_json" errors={@errors} />
+
+          <div class="text-xs text-zinc-500 space-y-2 mt-1">
+            <p>
+              GitHub skills are fetched via
+              <a href="https://skills.sh" target="_blank" class="underline">skills.sh</a>
+              using the <code>source</code> (owner/repo) and optional skill <code>name</code>.
+              Inline skills embed a full SKILL.md body directly.
+              <.link navigate={~p"/help/skills"} class="underline">Skills help \u2192</.link>
+            </p>
+            <div class="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-blue-900 leading-relaxed">
+              <strong>Always included:</strong>
+              the built-in <code>fountain</code> skill is automatically mounted in every
+              conversation \u2014 no need to declare it. It gives the agent
+              <code>$FOUNTAIN_TOKEN</code>, <code>$FOUNTAIN_BASE_URL</code>, and
+              <code>$FOUNTAIN_CONVERSATION_ID</code> so it can spawn and coordinate sub-agents.
+            </div>
+          </div>
         </div>
 
-        <.input id="mcp_servers_json" name="agent[mcp_servers_json]" type="textarea" rows="6"
-          label="MCP servers (JSON object)" value={@form["mcp_servers_json"]}/>
-        <.error_msg field="mcp_servers_json" errors={@errors}/>
+        <%!-- MCP servers --%>
+        <div class="space-y-2">
+          <label class="block text-sm font-medium text-zinc-700">MCP servers</label>
+
+          <div :if={@mcp_servers == []} class="text-sm text-zinc-400 italic py-1">
+            No MCP servers configured.
+          </div>
+
+          <div
+            :for={{server, i} <- Enum.with_index(@mcp_servers)}
+            class="border border-zinc-200 rounded-md p-3 bg-zinc-50 space-y-2"
+          >
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Server {i + 1}</span>
+              <button
+                type="button"
+                phx-click="remove_mcp_server"
+                phx-value-index={i}
+                class="text-xs text-rose-500 hover:text-rose-700 font-medium"
+              >
+                Remove
+              </button>
+            </div>
+
+            <.input
+              id={"mcp_#{i}_name"}
+              name={"agent[mcp_servers][#{i}][name]"}
+              label="Server name"
+              value={server["name"] || ""}
+              placeholder="github"
+            />
+            <.input
+              id={"mcp_#{i}_command"}
+              name={"agent[mcp_servers][#{i}][command]"}
+              label="Command"
+              value={server["command"] || ""}
+              placeholder="npx"
+            />
+            <.input
+              id={"mcp_#{i}_args"}
+              name={"agent[mcp_servers][#{i}][args]"}
+              type="textarea"
+              rows="2"
+              label="Args (one per line)"
+              value={server["args"] || ""}
+              placeholder="-y&#10;@modelcontextprotocol/server-github"
+            />
+
+            <div class="space-y-1.5">
+              <label class="block text-xs font-medium text-zinc-600">Env vars (optional)</label>
+
+              <div class="space-y-1">
+                <div
+                  :for={{ev, j} <- Enum.with_index(server["env_vars"] || [])}
+                  class="flex gap-2 items-center"
+                >
+                  <input
+                    type="text"
+                    name={"agent[mcp_servers][#{i}][env_vars][#{j}][key]"}
+                    value={ev["key"] || ""}
+                    placeholder="KEY"
+                    class="w-32 rounded border border-zinc-300 px-2 py-1 text-xs font-mono"
+                  />
+                  <span class="text-zinc-400 text-xs select-none">=</span>
+                  <input
+                    type="text"
+                    name={"agent[mcp_servers][#{i}][env_vars][#{j}][value]"}
+                    value={ev["value"] || ""}
+                    placeholder="value"
+                    class="flex-1 rounded border border-zinc-300 px-2 py-1 text-xs"
+                  />
+                  <button
+                    type="button"
+                    phx-click="remove_mcp_env_var"
+                    phx-value-server={i}
+                    phx-value-index={j}
+                    class="text-xs text-rose-400 hover:text-rose-600 font-medium shrink-0"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                phx-click="add_mcp_env_var"
+                phx-value-server={i}
+                class="text-xs font-medium text-indigo-600 hover:text-indigo-800"
+              >
+                + Add env var
+              </button>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            phx-click="add_mcp_server"
+            class="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+          >
+            + Add server
+          </button>
+          <.error_msg field="mcp_servers_json" errors={@errors} />
+        </div>
 
         <div class="flex gap-2">
-          <.btn type="submit" phx-disable-with="Saving…">Save</.btn>
+          <.btn type="submit" phx-disable-with="Saving\u2026">Save</.btn>
           <.link navigate={~p"/agents"}><.btn_secondary>Cancel</.btn_secondary></.link>
         </div>
       </form>


### PR DESCRIPTION
## Summary

- **Skills**: unified card list with a GitHub/Inline toggle per card. GitHub mode shows `source` (owner/repo) + optional `name`. Inline mode shows `name` + a `content` textarea for the full SKILL.md body.
- **MCP servers**: server cards with `name`, `command`, `args` (one per line), and nested env var key=value rows with add/remove per server.
- Both follow the same LiveView patterns established in #122 and #123.

## Details

### Skills

Socket carries `@skills` — a list of maps each with a `type` field (`"github"` or `"inline"`) used only for UI rendering. `set_skill_type` toggles the type per card. On submit, the `type` field is used to build the correct backend shape (`%{"source" => ...}` vs `%{"name" => ..., "content" => ...}`), then dropped.

Hidden `<input type="hidden" name="agent[skills][N][type]">` ensures the type survives every `validate` round-trip.

### MCP servers

Socket carries `@mcp_servers` — a list of maps with `name`, `command`, `args` (newline string), `env_vars` (list of key/value maps). On load, existing server maps are converted from `%{"server" => %{"command" => ..., "args" => [...], "env" => %{...}}}` to this flat list form. On submit, the reverse conversion builds the final map.

`add_mcp_env_var` / `remove_mcp_env_var` both take a `server` index and a row `index`, operating on the nested env_vars list inside the specific server.

## Test plan

- [ ] Add a GitHub skill (source + name), save — verify round-trip
- [ ] Add a GitHub skill with only source (no name), save — verify name is omitted in stored data
- [ ] Add an inline skill, fill name + content, save — verify stored correctly
- [ ] Toggle a skill between GitHub and Inline — verify fields switch
- [ ] Submit with a GitHub skill missing source — verify error
- [ ] Submit with an inline skill missing content — verify error
- [ ] Add an MCP server with command, args, env vars — verify stored as `%{"command" => ..., "args" => [...], "env" => {...}}`
- [ ] Load existing agent with skills and MCP servers — verify fields pre-populate
- [ ] Verify avatar upload/generate still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)