### PR TITLE
feat: deep OTel instrumentation for conversation lifecycle and turns

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -16,7 +16,7 @@ defmodule Fountain.Conversations.ConversationServer do
   alias Fountain.{Accounts, Agents, Conversations, Crypto, Environments, InferenceCredentials, SpritesClient, Substitution, Vaults}
   alias Fountain.Conversations.Conversation
 
-  # ── public api ────────────────────────────────────────────────────────────
+  # ── public api ───────────────────────────────────────────────────────────────────────────────
 
   def start_link(args) do
     conv_id = Keyword.fetch!(args, :conversation_id)
@@ -92,7 +92,7 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
-  # ── GenServer ─────────────────────────────────────────────────────────────
+  # ── GenServer ─────────────────────────────────────────────────────────────────────────────
 
   @impl true
   def init(args) do
@@ -111,6 +111,9 @@ defmodule Fountain.Conversations.ConversationServer do
       # OTel span context for the in-flight turn (started in kick_turn,
       # ended in the :exit / :interrupt handlers).
       current_turn_span: nil,
+      # Stream tracer for parsing Claude's stream-json stdout into OTel
+      # child spans and events. nil for non-Claude runtimes.
+      stream_tracer: nil,
       # Bytes of replayed output to drop on reattach, keyed by stream.
       # Empty map outside a reattach window. See attempt_session_attach.
       replay_skip: %{},
@@ -705,6 +708,9 @@ defmodule Fountain.Conversations.ConversationServer do
       turn_number: state.current_turn.turn_number
     })
 
+    # Finalize stream tracer: close any tool spans still open (abandoned calls).
+    Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
+
     end_turn_span(state.current_turn_span, :error, %{"outcome" => "interrupted"})
 
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
@@ -716,7 +722,8 @@ defmodule Fountain.Conversations.ConversationServer do
        | current_command: nil,
          current_command_ref: nil,
          current_turn: nil,
-         current_turn_span: nil
+         current_turn_span: nil,
+         stream_tracer: nil
      }}
   end
 
@@ -735,7 +742,36 @@ defmodule Fountain.Conversations.ConversationServer do
 
   @impl true
   def handle_info({:stdout, %{ref: ref}, data}, %{current_command_ref: ref} = state) do
-    {:noreply, log_with_replay_skip(state, "stdout", data)}
+    new_state = log_with_replay_skip(state, "stdout", data)
+
+    # Feed non-replayed bytes into the stream tracer (Claude only).
+    # Replayed bytes were already processed in a prior BEAM lifetime; skip them
+    # to avoid duplicate spans. The replay window shrinks as we consume bytes,
+    # so we compute how much of this chunk is genuinely new.
+    skip = Map.get(state.replay_skip, "stdout", 0)
+    size = byte_size(data)
+
+    new_tracer =
+      cond do
+        is_nil(state.stream_tracer) ->
+          nil
+
+        skip == 0 ->
+          Fountain.Runtimes.Claude.StreamTracer.handle_chunk(state.stream_tracer, data)
+
+        skip >= size ->
+          # Entire chunk is replayed — discard.
+          state.stream_tracer
+
+        true ->
+          # Partial replay: only forward the fresh suffix.
+          Fountain.Runtimes.Claude.StreamTracer.handle_chunk(
+            state.stream_tracer,
+            binary_part(data, skip, size - skip)
+          )
+      end
+
+    {:noreply, %{new_state | stream_tracer: new_tracer}}
   end
 
   def handle_info({:stderr, %{ref: ref}, data}, %{current_command_ref: ref} = state) do
@@ -758,6 +794,9 @@ defmodule Fountain.Conversations.ConversationServer do
       exit_code: code
     })
 
+    # Finalize stream tracer: close any tool spans still open (abandoned calls).
+    Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
+
     # Close the OTel turn span we opened in kick_turn.
     end_turn_span(
       state.current_turn_span,
@@ -774,7 +813,8 @@ defmodule Fountain.Conversations.ConversationServer do
        | current_command: nil,
          current_command_ref: nil,
          current_turn: nil,
-         current_turn_span: nil
+         current_turn_span: nil,
+         stream_tracer: nil
      }}
   end
 
@@ -806,7 +846,7 @@ defmodule Fountain.Conversations.ConversationServer do
     :ok
   end
 
-  # ── helpers ───────────────────────────────────────────────────────────────
+  # ── helpers ──────────────────────────────────────────────────────────────────────────────
 
   defp create_sprite(name) do
     client = SpritesClient.get!()
@@ -945,7 +985,11 @@ defmodule Fountain.Conversations.ConversationServer do
           "turn_number" => turn_number,
           "mode" => Atom.to_string(mode),
           "runtime" => to_string(conv.runtime),
-          "model" => agent && agent.model
+          "model" => agent && agent.model,
+          "agent_id" => agent && agent.id,
+          "user_id" => state.user_id,
+          "prompt_length" => byte_size(prompt),
+          "image_count" => length(images)
         }
       })
 
@@ -971,13 +1015,21 @@ defmodule Fountain.Conversations.ConversationServer do
             :ok = Sprites.close_stdin(command)
           end
 
+          # Start a stream tracer for Claude (stream-json → OTel child spans).
+          # Other runtimes produce unstructured output; tracer stays nil.
+          stream_tracer =
+            if state.runtime_module == Fountain.Runtimes.Claude do
+              Fountain.Runtimes.Claude.StreamTracer.new(turn_span)
+            end
+
           %{
             state
             | current_command: command,
               current_command_ref: command.ref,
               current_turn: turn,
               runtime_session_id: runtime_session_id,
-              current_turn_span: turn_span
+              current_turn_span: turn_span,
+              stream_tracer: stream_tracer
           }
 
         {:error, reason} ->

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -16,7 +16,7 @@ defmodule Fountain.Conversations.ConversationServer do
   alias Fountain.{Accounts, Agents, Conversations, Crypto, Environments, InferenceCredentials, SpritesClient, Substitution, Vaults}
   alias Fountain.Conversations.Conversation
 
-  # ── public api ───────────────────────────────────────────────────────────────────────────────
+  # ── public api ────────────────────────────────────────────────────────────
 
   def start_link(args) do
     conv_id = Keyword.fetch!(args, :conversation_id)
@@ -92,7 +92,7 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
-  # ── GenServer ─────────────────────────────────────────────────────────────────────────────
+  # ── GenServer ─────────────────────────────────────────────────────────────
 
   @impl true
   def init(args) do
@@ -846,7 +846,7 @@ defmodule Fountain.Conversations.ConversationServer do
     :ok
   end
 
-  # ── helpers ──────────────────────────────────────────────────────────────────────────────
+  # ── helpers ───────────────────────────────────────────────────────────────
 
   defp create_sprite(name) do
     client = SpritesClient.get!()

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -62,13 +62,13 @@ defmodule Fountain.Conversations.Provisioning do
     # Quote values containing whitespace, quotes, or shell metacharacters.
     # Escape inner double quotes.
     if String.match?(v, ~r/[\s"'\\$`]/) do
-      ~s|"|  <> String.replace(v, ~s|"|, ~s|\\"|) <> ~s|"|   
+      ~s|"| <> String.replace(v, ~s|"|, ~s|\\"|) <> ~s|"|
     else
       v
     end
   end
 
-  # ── checkpoint create / restore ────────────────────────────────────────────────────────────
+  # ── checkpoint create / restore ───────────────────────────────────────────
 
   @doc """
   Create a sprites.dev checkpoint of the fully-provisioned sprite. The
@@ -148,7 +148,7 @@ defmodule Fountain.Conversations.Provisioning do
     )
   end
 
-  # ── packages ──────────────────────────────────────────────────────────────────────────────
+  # ── packages ──────────────────────────────────────────────────────────────
 
   @doc """
   Install OS / language packages declared on the env. Recognized keys:
@@ -236,7 +236,7 @@ defmodule Fountain.Conversations.Provisioning do
     if quoted == "", do: [], else: ["npm install -g --no-progress --silent #{quoted}"]
   end
 
-  # ── network policy ─────────────────────────────────────────────────────────────────────────
+  # ── network policy ────────────────────────────────────────────────────────
 
   @doc """
   Apply the env's networking config to the sprite. `unrestricted` is a
@@ -273,7 +273,7 @@ defmodule Fountain.Conversations.Provisioning do
 
   def apply_network_policy(_sprite, _env, _conv_id), do: :ok
 
-  # ── git clone ──────────────────────────────────────────────────────────────────────────────
+  # ── git clone ─────────────────────────────────────────────────────────────
 
   @doc """
   Clone every repository declared on the env into the sprite at its
@@ -448,7 +448,7 @@ defmodule Fountain.Conversations.Provisioning do
 
   def scrub_token(s), do: s
 
-  # ── helpers ────────────────────────────────────────────────────────────────────────────
+  # ── helpers ───────────────────────────────────────────────────────────────
 
   @doc false
   def shell_quote(s), do: "'" <> String.replace(s, "'", "'\\''" ) <> "'"

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -62,13 +62,13 @@ defmodule Fountain.Conversations.Provisioning do
     # Quote values containing whitespace, quotes, or shell metacharacters.
     # Escape inner double quotes.
     if String.match?(v, ~r/[\s"'\\$`]/) do
-      ~s|"| <> String.replace(v, ~s|"|, ~s|\\"|) <> ~s|"|
+      ~s|"|  <> String.replace(v, ~s|"|, ~s|\\"|) <> ~s|"|   
     else
       v
     end
   end
 
-  # ── checkpoint create / restore ───────────────────────────────────────────
+  # ── checkpoint create / restore ────────────────────────────────────────────────────────────
 
   @doc """
   Create a sprites.dev checkpoint of the fully-provisioned sprite. The
@@ -148,7 +148,7 @@ defmodule Fountain.Conversations.Provisioning do
     )
   end
 
-  # ── packages ──────────────────────────────────────────────────────────────
+  # ── packages ──────────────────────────────────────────────────────────────────────────────
 
   @doc """
   Install OS / language packages declared on the env. Recognized keys:
@@ -170,33 +170,39 @@ defmodule Fountain.Conversations.Provisioning do
         :ok
 
       cmds ->
-        publish_stage(conv_id, "packages", "started", %{commands: length(cmds)})
+        Fountain.Telemetry.span(
+          [:packages],
+          %{conv_id: conv_id, commands: length(cmds)},
+          fn ->
+            publish_stage(conv_id, "packages", "started", %{commands: length(cmds)})
 
-        result =
-          Enum.reduce_while(cmds, :ok, fn cmd, _ ->
-            {output, code} =
-              Sprites.cmd(sprite, "bash", ["-lc", cmd],
-                env: sprite_env,
-                stderr_to_stdout: true,
-                timeout: 300_000
-              )
+            result =
+              Enum.reduce_while(cmds, :ok, fn cmd, _ ->
+                {output, code} =
+                  Sprites.cmd(sprite, "bash", ["-lc", cmd],
+                    env: sprite_env,
+                    stderr_to_stdout: true,
+                    timeout: 300_000
+                  )
 
-            log_output(conv_id, "packages", output)
+                log_output(conv_id, "packages", output)
 
-            if code == 0,
-              do: {:cont, :ok},
-              else: {:halt, {:error, {:packages, code, output}}}
-          end)
+                if code == 0,
+                  do: {:cont, :ok},
+                  else: {:halt, {:error, {:packages, code, output}}}
+              end)
 
-        case result do
-          :ok ->
-            publish_stage(conv_id, "packages", "done")
-            :ok
+            case result do
+              :ok ->
+                publish_stage(conv_id, "packages", "done")
+                {:ok, %{outcome: :ok}}
 
-          {:error, {:packages, code, _}} = err ->
-            publish_stage(conv_id, "packages", "failed", %{exit_code: code})
-            err
-        end
+              {:error, {:packages, code, _}} = err ->
+                publish_stage(conv_id, "packages", "failed", %{exit_code: code})
+                {err, %{outcome: :failed, exit_code: code}}
+            end
+          end
+        )
     end
   end
 
@@ -230,7 +236,7 @@ defmodule Fountain.Conversations.Provisioning do
     if quoted == "", do: [], else: ["npm install -g --no-progress --silent #{quoted}"]
   end
 
-  # ── network policy ────────────────────────────────────────────────────────
+  # ── network policy ─────────────────────────────────────────────────────────────────────────
 
   @doc """
   Apply the env's networking config to the sprite. `unrestricted` is a
@@ -267,7 +273,7 @@ defmodule Fountain.Conversations.Provisioning do
 
   def apply_network_policy(_sprite, _env, _conv_id), do: :ok
 
-  # ── git clone ─────────────────────────────────────────────────────────────
+  # ── git clone ──────────────────────────────────────────────────────────────────────────────
 
   @doc """
   Clone every repository declared on the env into the sprite at its
@@ -442,10 +448,10 @@ defmodule Fountain.Conversations.Provisioning do
 
   def scrub_token(s), do: s
 
-  # ── helpers ───────────────────────────────────────────────────────────────
+  # ── helpers ────────────────────────────────────────────────────────────────────────────
 
   @doc false
-  def shell_quote(s), do: "'" <> String.replace(s, "'", "'\\''") <> "'"
+  def shell_quote(s), do: "'" <> String.replace(s, "'", "'\\''" ) <> "'"
 
   defp publish_stage(conv_id, stage, state, meta \\ %{}) do
     Conversations.log!(%{

--- a/apps/fountain/lib/fountain/runtimes/claude/stream_tracer.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude/stream_tracer.ex
@@ -87,7 +87,7 @@ defmodule Fountain.Runtimes.Claude.StreamTracer do
     :ok
   end
 
-  # ── private ───────────────────────────────────────────────────────────────
+  # ── private ─────────────────────────────────────────────────────────────────────────
 
   # Split at newlines; last element is the (possibly empty) incomplete tail.
   defp split_lines(s) do
@@ -106,7 +106,7 @@ defmodule Fountain.Runtimes.Claude.StreamTracer do
     end
   end
 
-  # ── event handlers ────────────────────────────────────────────────────────
+  # ── event handlers ────────────────────────────────────────────────────────────────────
 
   # System init: record model + tool count.
   defp process_event(tracer, %{"type" => "system", "subtype" => "init"} = event) do
@@ -178,7 +178,7 @@ defmodule Fountain.Runtimes.Claude.StreamTracer do
 
   defp process_event(tracer, _event), do: tracer
 
-  # ── content block handlers ────────────────────────────────────────────────
+  # ── content block handlers ───────────────────────────────────────────────────────────────────
 
   # Tool use block: open a child span for the tool call.
   defp process_content_block(tracer, %{"type" => "tool_use", "id" => id, "name" => name}) do
@@ -211,7 +211,7 @@ defmodule Fountain.Runtimes.Claude.StreamTracer do
 
   defp process_content_block(tracer, _block), do: tracer
 
-  # ── helpers ───────────────────────────────────────────────────────────────
+  # ── helpers ─────────────────────────────────────────────────────────────────────────
 
   defp set_if_present(map, key, attr) do
     case Map.get(map, key) do

--- a/apps/fountain/lib/fountain/runtimes/claude/stream_tracer.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude/stream_tracer.ex
@@ -1,0 +1,222 @@
+defmodule Fountain.Runtimes.Claude.StreamTracer do
+  @moduledoc """
+  Bridges Claude's `--output-format stream-json` stdout into the active OTel
+  turn span.
+
+  Claude emits one newline-delimited JSON object per event. This module buffers
+  incomplete lines across chunk boundaries, then for each complete line:
+
+  - **`system` / `init`**: adds a span event with model + tool count; sets
+    `fountain.claude_model` on the turn span.
+  - **`assistant`** with `tool_use` content: opens a child `fountain.tool_use`
+    span, keyed by `tool_use_id`.
+  - **`assistant`** with `text` / `thinking` content: adds a span event
+    recording the byte length (content itself is not stored in traces).
+  - **`tool_result`**: closes the matching `fountain.tool_use` child span;
+    marks it as an error if `is_error: true`.
+  - **`result`**: sets duration, cost, and token-usage attributes on the turn
+    span; adds a `claude.result` span event.
+
+  Non-JSON lines (e.g. debug output written to stdout) are silently skipped.
+
+  ## Usage
+
+      tracer = StreamTracer.new(turn_span_ctx)
+      tracer = StreamTracer.handle_chunk(tracer, chunk)
+      StreamTracer.finalize(tracer)   # call on turn end / interrupt
+
+  All functions are no-ops when passed `nil`, so the caller can keep a `nil`
+  tracer for non-Claude runtimes without branching.
+  """
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  @type t :: %{
+          line_buffer: binary(),
+          turn_span_ctx: term(),
+          open_tool_spans: %{binary() => term()}
+        }
+
+  @doc "Create a new stream tracer attached to `turn_span_ctx`."
+  @spec new(term()) :: t()
+  def new(turn_span_ctx) do
+    %{
+      line_buffer: "",
+      turn_span_ctx: turn_span_ctx,
+      open_tool_spans: %{}
+    }
+  end
+
+  @doc """
+  Feed a raw stdout chunk into the tracer. Returns updated tracer state.
+  Pass `nil` to no-op (useful for non-Claude runtimes).
+  """
+  @spec handle_chunk(t() | nil, binary()) :: t() | nil
+  def handle_chunk(nil, _data), do: nil
+
+  def handle_chunk(%{line_buffer: buf} = tracer, data) when is_binary(data) do
+    full = buf <> data
+    {complete_lines, remaining} = split_lines(full)
+    Enum.reduce(complete_lines, %{tracer | line_buffer: remaining}, &handle_line(&2, &1))
+  end
+
+  @doc """
+  Close any tool spans that are still open (runtime exited mid-turn or was
+  interrupted before emitting matching `tool_result` events).
+  Pass `nil` to no-op.
+  """
+  @spec finalize(t() | nil) :: :ok
+  def finalize(nil), do: :ok
+
+  def finalize(%{open_tool_spans: spans, turn_span_ctx: turn_ctx}) when map_size(spans) == 0 do
+    Tracer.set_current_span(turn_ctx)
+    :ok
+  end
+
+  def finalize(%{open_tool_spans: spans, turn_span_ctx: turn_ctx}) do
+    Tracer.set_current_span(turn_ctx)
+
+    Enum.each(spans, fn {_id, span_ctx} ->
+      Tracer.set_current_span(span_ctx)
+      Tracer.set_attribute("fountain.tool_status", "abandoned")
+      Tracer.set_status(OpenTelemetry.status(:error, "turn ended with open tool call"))
+      Tracer.end_span(span_ctx)
+    end)
+
+    Tracer.set_current_span(turn_ctx)
+    :ok
+  end
+
+  # ── private ───────────────────────────────────────────────────────────────
+
+  # Split at newlines; last element is the (possibly empty) incomplete tail.
+  defp split_lines(s) do
+    parts = String.split(s, "\n")
+    {complete, [tail]} = Enum.split(parts, -1)
+    {complete, tail}
+  end
+
+  defp handle_line(tracer, ""), do: tracer
+
+  defp handle_line(tracer, line) do
+    case Jason.decode(line) do
+      {:ok, event} -> process_event(tracer, event)
+      # Non-JSON lines (e.g. debug/warning output) — silently ignore.
+      {:error, _} -> tracer
+    end
+  end
+
+  # ── event handlers ────────────────────────────────────────────────────────
+
+  # System init: record model + tool count.
+  defp process_event(tracer, %{"type" => "system", "subtype" => "init"} = event) do
+    Tracer.set_current_span(tracer.turn_span_ctx)
+    model = Map.get(event, "model", "")
+    tools = length(Map.get(event, "tools", []))
+
+    Tracer.set_attribute("fountain.claude_model", model)
+
+    Tracer.add_event("claude.init", %{
+      "model" => model,
+      "tools_count" => tools
+    })
+
+    tracer
+  end
+
+  # Assistant message: process each content block.
+  defp process_event(tracer, %{"type" => "assistant", "message" => message}) do
+    Tracer.set_current_span(tracer.turn_span_ctx)
+    content = Map.get(message, "content", [])
+    Enum.reduce(content, tracer, &process_content_block(&2, &1))
+  end
+
+  # Tool result: close the matching child span.
+  defp process_event(tracer, %{"type" => "tool_result", "tool_use_id" => tool_id} = event) do
+    case Map.pop(tracer.open_tool_spans, tool_id) do
+      {nil, _} ->
+        tracer
+
+      {span_ctx, remaining} ->
+        Tracer.set_current_span(span_ctx)
+        is_error = Map.get(event, "is_error", false)
+        Tracer.set_attribute("fountain.tool_is_error", is_error)
+
+        if is_error do
+          Tracer.set_status(OpenTelemetry.status(:error, "tool returned error"))
+        end
+
+        Tracer.end_span(span_ctx)
+        Tracer.set_current_span(tracer.turn_span_ctx)
+        %{tracer | open_tool_spans: remaining}
+    end
+  end
+
+  # Final result: set cost/duration/token attributes on the turn span.
+  defp process_event(tracer, %{"type" => "result"} = event) do
+    Tracer.set_current_span(tracer.turn_span_ctx)
+
+    set_if_present(event, "duration_ms", "fountain.duration_ms")
+    set_if_present(event, "duration_api_ms", "fountain.duration_api_ms")
+    set_if_present(event, "num_turns", "fountain.num_turns")
+    set_if_present(event, "total_cost_usd", "fountain.total_cost_usd")
+
+    if usage = Map.get(event, "usage") do
+      set_if_present(usage, "input_tokens", "fountain.input_tokens")
+      set_if_present(usage, "output_tokens", "fountain.output_tokens")
+      set_if_present(usage, "cache_read_input_tokens", "fountain.cache_read_tokens")
+      set_if_present(usage, "cache_creation_input_tokens", "fountain.cache_write_tokens")
+    end
+
+    Tracer.add_event("claude.result", %{
+      "subtype" => Map.get(event, "subtype", ""),
+      "is_error" => Map.get(event, "is_error", false)
+    })
+
+    tracer
+  end
+
+  defp process_event(tracer, _event), do: tracer
+
+  # ── content block handlers ────────────────────────────────────────────────
+
+  # Tool use block: open a child span for the tool call.
+  defp process_content_block(tracer, %{"type" => "tool_use", "id" => id, "name" => name}) do
+    Tracer.set_current_span(tracer.turn_span_ctx)
+
+    span_ctx =
+      Tracer.start_span("fountain.tool_use", %{
+        attributes: %{
+          "fountain.tool_name" => name,
+          "fountain.tool_id" => id
+        }
+      })
+
+    %{tracer | open_tool_spans: Map.put(tracer.open_tool_spans, id, span_ctx)}
+  end
+
+  # Text output: add a span event with byte length (not the content itself).
+  defp process_content_block(tracer, %{"type" => "text", "text" => text}) do
+    Tracer.set_current_span(tracer.turn_span_ctx)
+    Tracer.add_event("claude.text", %{"length" => byte_size(text)})
+    tracer
+  end
+
+  # Extended thinking block.
+  defp process_content_block(tracer, %{"type" => "thinking", "thinking" => thinking}) do
+    Tracer.set_current_span(tracer.turn_span_ctx)
+    Tracer.add_event("claude.thinking", %{"length" => byte_size(thinking)})
+    tracer
+  end
+
+  defp process_content_block(tracer, _block), do: tracer
+
+  # ── helpers ───────────────────────────────────────────────────────────────
+
+  defp set_if_present(map, key, attr) do
+    case Map.get(map, key) do
+      nil -> :ok
+      v -> Tracer.set_attribute(attr, v)
+    end
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -145,4 +145,54 @@ if config_env() == :prod and server? do
     url: [host: host, port: 443, scheme: "https"],
     http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}],
     secret_key_base: secret_key_base
+
+  # ── OpenTelemetry ─────────────────────────────────────────────────────────────────────────
+  #
+  # Export traces via OTLP (HTTP/protobuf). Reads standard OTEL env vars:
+  #   OTEL_SERVICE_NAME          — defaults to "fountain"
+  #   OTEL_EXPORTER_OTLP_ENDPOINT — e.g. "https://api.honeycomb.io"
+  #   OTEL_EXPORTER_OTLP_HEADERS  — e.g. "x-honeycomb-team=<key>"
+  #
+  # For Honeycomb specifically you can also set HONEYCOMB_API_KEY and the
+  # exporter config below will wire it up automatically.
+  otel_endpoint =
+    System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT") ||
+      System.get_env("HONEYCOMB_ENDPOINT", "https://api.honeycomb.io")
+
+  # Parse "key=val,key2=val2" header strings produced by OTEL_EXPORTER_OTLP_HEADERS,
+  # then layer on Honeycomb-specific headers if HONEYCOMB_API_KEY is set.
+  otel_headers =
+    case System.get_env("OTEL_EXPORTER_OTLP_HEADERS") do
+      nil ->
+        []
+
+      raw ->
+        raw
+        |> String.split(",")
+        |> Enum.flat_map(fn pair ->
+          case String.split(pair, "=", parts: 2) do
+            [k, v] -> [{String.trim(k), String.trim(v)}]
+            _ -> []
+          end
+        end)
+    end
+
+  otel_headers =
+    case System.get_env("HONEYCOMB_API_KEY") do
+      nil -> otel_headers
+      key -> [{"x-honeycomb-team", key} | otel_headers]
+    end
+
+  config :opentelemetry,
+    span_processor: :batch,
+    traces_exporter: :otlp,
+    resource: [
+      {"service.name", System.get_env("OTEL_SERVICE_NAME", "fountain")},
+      {"deployment.environment", System.get_env("FLY_APP_NAME", "prod")}
+    ]
+
+  config :opentelemetry_exporter,
+    otlp_protocol: :http_protobuf,
+    otlp_endpoint: otel_endpoint,
+    otlp_headers: otel_headers
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -146,7 +146,7 @@ if config_env() == :prod and server? do
     http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}],
     secret_key_base: secret_key_base
 
-  # ── OpenTelemetry ─────────────────────────────────────────────────────────────────────────
+  # ── OpenTelemetry ─────────────────────────────────────────────────────────
   #
   # Export traces via OTLP (HTTP/protobuf). Reads standard OTEL env vars:
   #   OTEL_SERVICE_NAME          — defaults to "fountain"


### PR DESCRIPTION
## Summary

Adds comprehensive OpenTelemetry instrumentation across the conversation hot path, with particular depth on Claude's turn lifecycle.

### New: `Fountain.Runtimes.Claude.StreamTracer`

Claude runs with `--output-format stream-json`, emitting one newline-delimited JSON object per event. The new `StreamTracer` module buffers stdout chunks, parses each line, and bridges events into the active OTel turn span:

| Claude event | OTel action |
|---|---|
| `system / init` | Set `fountain.claude_model` attribute; add `claude.init` event with model + tool count |
| `assistant` → `tool_use` block | Open child span `fountain.tool_use` with `fountain.tool_name` / `fountain.tool_id` |
| `assistant` → `text` block | Add `claude.text` event with `length` (content not stored in traces) |
| `assistant` → `thinking` block | Add `claude.thinking` event with `length` |
| `tool_result` | Close matching `fountain.tool_use` child span; mark error if `is_error: true` |
| `result` | Set `fountain.duration_ms`, `fountain.duration_api_ms`, `fountain.num_turns`, `fountain.total_cost_usd`, `fountain.input_tokens`, `fountain.output_tokens`, `fountain.cache_read_tokens`, `fountain.cache_write_tokens`; add `claude.result` event |

On turn exit or interrupt, `finalize/1` closes any tool spans that were abandoned mid-call (e.g. runtime killed) with `fountain.tool_status = "abandoned"`.

Replayed bytes (from session reattach after BEAM restart) are skipped so spans aren't duplicated across restarts.

### `ConversationServer` changes

- `stream_tracer` added to GenServer state (nil for non-Claude runtimes)
- `fountain.turn` span gets four new attributes: `agent_id`, `user_id`, `prompt_length`, `image_count`
- `handle_info({:stdout, ...})` feeds non-replayed data to the stream tracer
- `:exit` and `:interrupt` handlers call `StreamTracer.finalize/1` before closing the turn span

### `Provisioning` changes

- `install_packages/4` now wrapped in `Fountain.Telemetry.span([:packages], ...)` — the only provisioning step that previously had no OTel coverage. Span carries `conv_id` and `commands` count; outcome attribute set on success/failure.

### OTLP exporter config (`config/runtime.exs`, prod only)

```
OTEL_SERVICE_NAME           — service.name resource attribute (default: "fountain")
OTEL_EXPORTER_OTLP_ENDPOINT — OTLP endpoint (default: https://api.honeycomb.io)
OTEL_EXPORTER_OTLP_HEADERS  — comma-separated "key=val" header pairs
HONEYCOMB_API_KEY           — shortcut: sets x-honeycomb-team header automatically
```

## Span inventory after this PR

| Span name | What it covers |
|---|---|
| `fountain.fresh_provision` | Full fresh sprite provision |
| `fountain.reattach` | BEAM-restart sprite reattach |
| `fountain.packages` | apt/npm package install **[new]** |
| `fountain.network_policy` | Sprite network allowlist apply |
| `fountain.clone_repositories` | Git clone of all repos |
| `fountain.setup_script` | User setup script execution |
| `fountain.checkpoint.create` | Checkpoint upload |
| `fountain.checkpoint.restore` | Checkpoint warm-start |
| `fountain.turn` | Full turn (prompt → exit) — now with 4 more attributes **[enriched]** |
| `fountain.tool_use` | Per-tool-call child span (Claude only) **[new]** |
| HTTP spans | Auto via `opentelemetry_phoenix` |
| DB query spans | Auto via `opentelemetry_ecto` |

## Test plan

- [ ] Run a Claude conversation and verify `fountain.turn` appears in your trace backend with `fountain.claude_model`, cost/token attributes set by the `result` event
- [ ] Verify `fountain.tool_use` child spans appear for tool calls, with correct `fountain.tool_name`
- [ ] Run a conversation with packages configured and verify `fountain.packages` span appears
- [ ] Interrupt a running turn and verify abandoned `fountain.tool_use` spans are closed with `fountain.tool_status = "abandoned"`
- [ ] Set `HONEYCOMB_API_KEY` in prod env and verify traces arrive in Honeycomb

🤖 Generated with [Claude Code](https://claude.ai/claude-code)