### PR TITLE
Add fly.toml for Fly.io deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,59 @@
+# fly.toml — Fly.io deployment configuration
+#
+# Setup steps:
+#   1. fly launch --no-deploy        # creates the app and imports this config
+#   2. fly postgres create           # provision a Postgres cluster
+#   3. fly postgres attach <pg-app>  # sets DATABASE_URL secret automatically
+#   4. fly secrets set \
+#        SECRET_KEY_BASE=$(mix phx.gen.secret) \
+#        MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=') \
+#        GITHUB_OAUTH_CLIENT_ID=... \
+#        GITHUB_OAUTH_CLIENT_SECRET=... \
+#        STRIPE_SECRET_KEY=... \
+#        STRIPE_PUBLISHABLE_KEY=... \
+#        STRIPE_WEBHOOK_SECRET=... \
+#        STRIPE_PRICE_ID=... \
+#        RESEND_API_KEY=... \
+#        SPRITES_TOKEN=...
+#   5. fly deploy
+
+app = 'fountain'
+primary_region = 'sea'
+
+[build]
+
+[deploy]
+  release_command = '/app/bin/fountain_server eval "Fountain.Release.migrate()"'
+
+[env]
+  PHX_SERVER = 'true'
+  PORT = '8080'
+  FOUNTAIN_DOMAIN = 'fountain.fly.dev'
+  EMAIL_FROM = 'noreply@updates.inevitable.fyi'
+  OTEL_TRACES_EXPORTER = 'none'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+  [http_service.concurrency]
+    type = 'connections'
+    hard_limit = 1000
+    soft_limit = 800
+
+  [[http_service.checks]]
+    grace_period = '10s'
+    interval = '30s'
+    method = 'GET'
+    path = '/health'
+    protocol = 'http'
+    timeout = '5s'
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1


### PR DESCRIPTION
## Summary

- Adds `fly.toml` to support deploying on Fly.io as an alternative to Render
- Mirrors existing Render config: `sea` region (closest to Render's `oregon`), `/health` check, `Fountain.Release.migrate()` release command
- Sets `PORT=8080` (Fly convention) via env — no app code changes needed

## Notes

A `Dockerfile` will be needed before `fly deploy` — run `fly launch --no-deploy` and it will generate one automatically, or write a custom multi-stage build using `hexpm/elixir`.

Secrets to configure via `fly secrets set` are documented in the comments at the top of `fly.toml`.

## Test plan

- [ ] `fly launch --no-deploy` imports config without errors
- [ ] `fly postgres create && fly postgres attach` sets `DATABASE_URL`
- [ ] `fly secrets set` all required secrets
- [ ] `fly deploy` completes — migration release command runs, health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)