### PR TITLE
fix: restore collapsed pretty-view sections when new content arrives

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -130,6 +130,19 @@
             mounted() { this.el.scrollTop = this.el.scrollHeight; },
             updated() { this.el.scrollTop = this.el.scrollHeight; }
           },
+          // Prevents a collapsed <details> section from staying closed when
+          // LiveView adds new content to it. Because `open?` is always `true`
+          // for turn/recursive sections, LiveView's diff never re-sends the
+          // `open` attribute — so a user-collapsed section won't reopen on its
+          // own. This hook restores `open` whenever the element's content is
+          // updated and `data-force-open` says it should stay open.
+          KeepOpen: {
+            updated() {
+              if (this.el.dataset.forceOpen === "true" && !this.el.open) {
+                this.el.open = true;
+              }
+            }
+          },
           SubmitOnCmdEnter: {
             mounted() {
               this.handler = (e) => {

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -875,7 +875,13 @@ defmodule FountainWeb.ConversationsLive.Show do
       )
 
     ~H"""
-    <details open={@open?} class="group">
+    <details
+      id={"section-#{@node.started.id}"}
+      open={@open?}
+      data-force-open={to_string(@open?)}
+      phx-hook="KeepOpen"
+      class="group"
+    >
       <summary class={[
         "cursor-pointer flex items-center gap-3 text-xs",
         not @has_kids? && "list-none cursor-default"


### PR DESCRIPTION
## Problem

In the pretty conversation view, manually collapsing a `<details>` section causes new messages inside it to become invisible. The user has to switch to chat view to see recent output.

**Root cause:** Phoenix LiveView's efficient diffing never re-sends the `open` attribute for turn/recursive sections because `open?` is computed as a constant `true` (never changes between renders). When a user collapses a section, the browser removes `open` from the DOM. On the next render, LiveView's patch only contains new child content — it never mentions `open` — so the section stays collapsed and hides new messages.

## Fix

Added a `KeepOpen` LiveView JS hook that fires on `updated()` (i.e., whenever LiveView patches the element or its descendants). It reads `data-force-open` from the element — an attribute set at initial render time that the browser never touches — and restores `open` if the section should stay open but was collapsed by the user.

Changes:
- `show.ex`: Added `id`, `data-force-open`, and `phx-hook="KeepOpen"` to the `<details>` element in `tree_node`. The `id` is required by LiveView for hooks and improves morphdom's element matching.
- `root.html.heex`: Added the `KeepOpen` hook definition.