### PR TITLE
security: address blacklight audit findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ env:
   # name is stable enough that the indirection isn't worth it.
   IMAGE: ghcr.io/binarybourbon/fountain
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,23 +28,23 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build and Test
@@ -19,7 +22,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:287eced1f33b59ed265ed13a60d3680dd7646d70c4dc0e785f59a470ebc03eeb
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -36,17 +39,17 @@ jobs:
       MIX_ENV: test
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Elixir
         id: beam
-        uses: erlef/setup-beam@v1.24.0
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           elixir-version: "1.19.2"
           otp-version: "28.3"
 
       - name: Restore deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -54,7 +57,7 @@ jobs:
             ${{ runner.os }}-mix-
 
       - name: Restore build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: _build
           key: ${{ runner.os }}-build-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,9 @@ concurrency:
   group: render-deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   trigger:
     name: Trigger Render deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -22,16 +20,20 @@ jobs:
   build-and-deploy:
     name: Build and deploy docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -41,9 +43,9 @@ jobs:
       - name: Build site
         run: mkdocs build --strict
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
 
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         id: deployment

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -20,6 +20,9 @@ concurrency:
   group: mutation-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   muzak:
     name: Muzak Mutation Testing
@@ -30,7 +33,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:287eced1f33b59ed265ed13a60d3680dd7646d70c4dc0e785f59a470ebc03eeb
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -47,17 +50,17 @@ jobs:
       MIX_ENV: test
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Elixir
         id: beam
-        uses: erlef/setup-beam@v1.24.0
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           elixir-version: "1.19.2"
           otp-version: "28.3"
 
       - name: Restore deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: deps
           key: ${{ runner.os }}-mutation-mix-${{ hashFiles('**/mix.lock') }}
@@ -66,7 +69,7 @@ jobs:
             ${{ runner.os }}-mix-
 
       - name: Restore build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: _build
           key: ${{ runner.os }}-mutation-build-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -20,6 +20,9 @@ on:
           - minor
           - major
 
+permissions:
+  contents: read
+
 jobs:
   bump:
     name: Bump version, commit, tag, push
@@ -34,7 +37,7 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Full history so git tag sees existing tags and push back
           # to main isn't rejected as a shallow-clone.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ on:
 env:
   GO_VERSION: "1.25.0"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{ matrix.artifact }}
@@ -39,10 +42,12 @@ jobs:
             artifact: fountain-darwin-arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: cli/go.sum
@@ -61,7 +66,7 @@ jobs:
           du -h "../dist/${{ matrix.artifact }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.artifact }}
           path: dist/${{ matrix.artifact }}
@@ -74,7 +79,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Resolve tag
         id: tag
@@ -86,12 +93,12 @@ jobs:
           fi
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
@@ -121,7 +128,7 @@ jobs:
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
@@ -136,7 +143,7 @@ jobs:
           done
 
       - name: Checkout tap repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: BinaryBourbon/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     name: Detect secrets
@@ -14,11 +17,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,13 +59,17 @@ ENV LANG=C.UTF-8 \
 RUN apt-get update -y \
  && apt-get install -y --no-install-recommends \
       libstdc++6 openssl libncurses6 locales ca-certificates tini \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd --system --gid 1001 fountain \
+ && useradd --system --uid 1001 --gid fountain --no-create-home fountain
 
 WORKDIR /app
 
-COPY --from=build /app/_build/prod/rel/fountain_server ./
+COPY --chown=fountain:fountain --from=build /app/_build/prod/rel/fountain_server ./
 
 EXPOSE 4000
+
+USER fountain
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 # Migrations run on every boot. Idempotent (Ecto.Migrator skips

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -80,6 +80,12 @@ spec:
             # environment value in the DB unreadable.
             - secretRef:
                 name: fountain-secrets
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Addresses the blacklight security audit report. 35 of 58 findings fixed (all security-tier items); 23 report-only hygiene items deferred.

## Quick wins (25 findings)

**GHA017 — workflow-level permissions block missing**
Added `permissions: contents: read` at workflow level to: `build.yml`, `ci.yml`, `deploy.yml`, `mutation-test.yml`, `release-bump.yml`, `release.yml`, `secrets-scan.yml`

**GHA021 — unpinned `actions/checkout`**
Pinned to full commit SHA in: `ci.yml`, `docs.yml`, `mutation-test.yml`, `release-bump.yml`, `release.yml` (×3 jobs), `secrets-scan.yml`

**GHA029 — unpinned third-party actions**
Pinned to full commit SHA (with `# vN` tag comment): all docker actions in `build.yml`, pages actions in `docs.yml`, Go/artifact/release actions in `release.yml`, gitleaks in `secrets-scan.yml`

**GHA030 — mutable service container image**
`postgres:16` → `postgres:16@sha256:287eced...` in `ci.yml` and `mutation-test.yml`

## Needs review (8 findings addressed)

**GHA034 — write scopes granted workflow-wide (`docs.yml`)**
Moved `pages: write` and `id-token: write` down to the `build-and-deploy` job; workflow default is now read-only.

**GHA049 — persisted checkout credentials with artifact upload (`release.yml`)**
Added `persist-credentials: false` to the `build` and `release` job checkouts. The uploaded artifact is the compiled binary only, not the source tree, but belt-and-suspenders.

**DKRD012 — container runs as root (`Dockerfile`)**
Created system user `fountain` (uid/gid 1001) in the runtime stage, `--chown`'d the release copy, and added `USER fountain` before `ENTRYPOINT`.

**WK8203/8204/8205 — missing Kubernetes security context (`k8s/deployment.yaml`)**
Added `securityContext` to the container spec:
```yaml
securityContext:
  runAsNonRoot: true
  runAsUser: 1001
  readOnlyRootFilesystem: true
  capabilities:
    drop: ["ALL"]
```
⚠️ `readOnlyRootFilesystem: true` means the BEAM crash dump dir (`/tmp`) is read-only. Watch for `erl_crash.dump` write errors at runtime; if they surface, add an `emptyDir` volume mounted at `/tmp`.

## Deferred

- **WK8006** (`:latest` k8s image) — intentional per existing code comment; will migrate to `sha-*` tags once releases are stable
- **Report-only (23)** — GHA022/026, WK8102/8104/8201/8302 — hygiene/HA items with no security impact