### PR TITLE
infra(k8s): scale fountain to 2 replicas with Erlang clustering

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -11,10 +11,16 @@ metadata:
     # effect. The Phoenix release reads env at boot, not per-request.
     secrets.infisical.com/auto-reload: "true"
 spec:
-  replicas: 1
-  # Single replica: SECRET_KEY_BASE is one value across pods, so this is
-  # safe to scale later — left at 1 for now to keep CNPG single-writer
-  # behavior obvious and to match the current Render footprint.
+  replicas: 2
+  # Two replicas for HA. This is only safe because the pods form a real
+  # Erlang cluster: libcluster (DNSPoll against the fountain-headless
+  # Service) connects the BEAM nodes, which lets Horde route per-conversation
+  # ConversationServers cluster-wide and Phoenix.PubSub fan `conv:<id>`
+  # events across pods. Without that wiring (RELEASE_DISTRIBUTION/RELEASE_NODE/
+  # RELEASE_COOKIE/CLUSTER_DNS_QUERY below + the headless Service) two pods
+  # run as isolated islands and conversation streaming silently breaks for
+  # whichever pod didn't spawn the conversation. CNPG remains the single
+  # writer — the app tier is the stateless part being scaled here.
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -37,7 +43,49 @@ spec:
           ports:
             - name: http
               containerPort: 4000
+            # Erlang distribution: epmd + the pinned dist port (see
+            # ERL_AFLAGS). Informational here, but lets a future
+            # NetworkPolicy reference them by name.
+            - name: epmd
+              containerPort: 4369
+            - name: erldist
+              containerPort: 9100
           env:
+            # --- Erlang clustering (required for >1 replica) ---
+            # Pod IP via the downward API; RELEASE_NODE interpolates it
+            # below. Must be declared before any env that references
+            # $(POD_IP) — k8s only substitutes vars defined earlier.
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: RELEASE_DISTRIBUTION
+              value: name
+            # Node name MUST use the release name `fountain_server` as its
+            # basename: libcluster's DNSPoll derives the peer node name from
+            # RELEASE_NAME (= fountain_server in the release), so a mismatched
+            # basename here means peers are discovered but never connect.
+            - name: RELEASE_NODE
+              value: fountain_server@$(POD_IP)
+            # Shared Erlang cookie so the nodes accept each other's
+            # connections. Reuses SECRET_KEY_BASE — already identical across
+            # all pods and present in fountain-secrets — to avoid a separate
+            # Infisical key that, if missing, would let each pod generate a
+            # random cookie and silently fail to cluster. Swap to a dedicated
+            # RELEASE_COOKIE key here if you'd rather not reuse it.
+            - name: RELEASE_COOKIE
+              valueFrom:
+                secretKeyRef:
+                  name: fountain-secrets
+                  key: SECRET_KEY_BASE
+            # Pin the distribution listener to a single port so it's
+            # firewall/NetworkPolicy-friendly (epmd otherwise hands out a
+            # random high port per boot).
+            - name: ERL_AFLAGS
+              value: "-kernel inet_dist_listen_min 9100 inet_dist_listen_max 9100"
+            # Headless Service FQDN libcluster polls to discover peer pods.
+            - name: CLUSTER_DNS_QUERY
+              value: fountain-headless.fountain.svc.cluster.local
             # CNPG-generated `fountain-pg-app` Secret. `uri` is the
             # postgres://user:pass@host:port/db URL Ecto consumes
             # directly via DATABASE_URL.

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -13,3 +13,32 @@ spec:
     - name: http
       port: 80
       targetPort: 4000
+---
+# Headless service (clusterIP: None) — DNS returns one A record per pod IP
+# instead of a single VIP. libcluster's DNSPoll strategy queries this name
+# (CLUSTER_DNS_QUERY in the Deployment) to discover peer pods and form the
+# Erlang cluster that backs Horde + Phoenix.PubSub. Distribution traffic
+# itself flows pod-IP → pod-IP on epmd (4369) + the pinned dist port (9100),
+# not through this service. publishNotReadyAddresses lets pods find each
+# other during a rollout before they pass readiness, so the cluster forms
+# promptly instead of waiting out the readiness gate.
+apiVersion: v1
+kind: Service
+metadata:
+  name: fountain-headless
+  namespace: fountain
+  labels:
+    app: fountain
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: fountain
+  ports:
+    - name: epmd
+      port: 4369
+      targetPort: 4369
+    - name: erldist
+      port: 9100
+      targetPort: 9100


### PR DESCRIPTION
## What

Bumps the `fountain` Deployment from **1 → 2 replicas** for HA, and adds the clustering wiring that makes that actually safe.

## Why it wasn't a one-line change

The app is already built for multi-node — `Horde.Registry`/`Horde.DynamicSupervisor` host per-conversation `ConversationServer` GenServers addressed cluster-wide, and `Phoenix.PubSub` fans `conv:<id>` log events across nodes. But none of that works unless the BEAM nodes actually connect, and the manifest set **none** of the required env (`CLUSTER_DNS_QUERY` was unset → libcluster topologies `[]`; no node name / cookie → releases default to a loopback `sname`).

Flipping `replicas: 2` on the old manifest would have produced **two isolated islands**:
- A conversation's server lives on the pod that spawned it; the other pod can't route to it (Horde needs the cluster) and won't receive its PubSub events → **streaming silently breaks for ~half of requests**.
- The boot `Rehydrator` runs on every pod → un-clustered, both rehydrate the same conversations → duplicate sprite servers.

## Changes

- **Headless Service** `fountain-headless` (`clusterIP: None`, `publishNotReadyAddresses: true`) so libcluster DNSPoll resolves per-pod IPs.
- **Deployment env:** `RELEASE_DISTRIBUTION=name`, `RELEASE_NODE=fountain_server@$(POD_IP)`, `POD_IP` (downward API), `RELEASE_COOKIE` (sourced from the already-shared `SECRET_KEY_BASE`), `ERL_AFLAGS` pinning the dist port to 9100, `CLUSTER_DNS_QUERY` → the headless Service.
- `epmd`/`erldist` containerPorts.
- Fixes the stale "safe to scale later" comment.

> ⚠️ Node basename: `RELEASE_NODE` uses `fountain_server` because that's the release name (`mix.exs`), which is what libcluster's DNSPoll derives the peer node name from. A `fountain@` basename would discover peers but never connect.

## Verification

- `kubectl kustomize k8s` builds clean; rendered env has `POD_IP` ordered before `RELEASE_NODE` (required for `$(POD_IP)` substitution).
- Post-deploy, confirm `Node.list()` shows the peer and that a conversation started on pod A streams to a LiveView pinned to pod B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)