### PR TITLE
fix(rehydrator): elect a single leader to avoid duplicate-server storm on clustered boot

### DIFF
--- a/apps/fountain/lib/fountain/conversations/rehydrator.ex
+++ b/apps/fountain/lib/fountain/conversations/rehydrator.ex
@@ -10,6 +10,24 @@ defmodule Fountain.Conversations.Rehydrator do
   and conversation.status in ["idle", "running"]). Pending/starting
   sandboxes from a crashed mid-provision are left as-is — the user's next
   action lazily resolves them via `wake_conversation`.
+
+  ## Clustered boot
+
+  `run/1` fires on every node as it boots, but libcluster needs a few
+  seconds (DNSPoll interval + connect) before the nodes form a cluster.
+  If every node swept immediately, each would `start_child` all resumable
+  conversations into its own not-yet-synced Horde registry; when the CRDT
+  registries later merge they'd find duplicate names and mass-terminate the
+  losers — a brief window of duplicate sprite servers and a noisy log storm.
+
+  To avoid that we wait for cluster membership to stabilize, then let only
+  the **rehydration leader** (the lowest node name in the connected set)
+  run the sweep. `Horde.UniformDistribution` still spreads the started
+  children across all nodes, so a single sweeper does not concentrate load.
+  When clustering is disabled (single-node / no `CLUSTER_DNS_QUERY`) the
+  wait and election short-circuit and the node sweeps immediately, exactly
+  as before. `start_child` returning `{:already_started, _}` is treated as
+  success so any residual cross-node overlap is a no-op rather than an error.
   """
 
   require Logger
@@ -17,7 +35,79 @@ defmodule Fountain.Conversations.Rehydrator do
   alias Fountain.{Agents, Conversations, Runtimes}
   alias Fountain.Conversations.ConversationServer
 
-  def run do
+  def run(opts \\ []) do
+    if clustering_enabled?() do
+      peers = await_stable_cluster(opts)
+
+      if leader?(Node.self(), peers) do
+        Logger.info("rehydrator: #{Node.self()} elected rehydration leader; sweeping")
+        sweep()
+      else
+        Logger.info(
+          "rehydrator: #{Node.self()} not leader (leader=#{leader_node(Node.self(), peers)}); skipping sweep"
+        )
+
+        {:skipped, %{leader: false, peers: peers}}
+      end
+    else
+      sweep()
+    end
+  end
+
+  # ── leader election (pure) ────────────────────────────────────────────────
+
+  @doc "True if `self_node` is the rehydration leader for the connected set."
+  def leader?(self_node, peers), do: self_node == leader_node(self_node, peers)
+
+  @doc "The elected leader node: the lowest name across self + connected peers."
+  def leader_node(self_node, peers), do: Enum.min([self_node | peers])
+
+  # ── cluster stabilization ─────────────────────────────────────────────────
+
+  # Poll `Node.list/0` until the connected set has been unchanged for
+  # `stabilize_ms`, or `cluster_wait_ms` elapses — whichever comes first.
+  # Returns the peer list to elect a leader against. A genuinely single
+  # node simply observes an empty, stable set and returns after the quiet
+  # period.
+  defp await_stable_cluster(opts) do
+    max_wait = Keyword.get(opts, :cluster_wait_ms, cfg(:rehydrate_cluster_wait_ms, 30_000))
+    stabilize = Keyword.get(opts, :stabilize_ms, cfg(:rehydrate_stabilize_ms, 5_000))
+    poll = Keyword.get(opts, :poll_ms, cfg(:rehydrate_poll_ms, 1_000))
+
+    now = System.monotonic_time(:millisecond)
+    loop_until_stable(MapSet.new(Node.list()), now, now + max_wait, stabilize, poll)
+  end
+
+  defp loop_until_stable(members, stable_since, deadline, stabilize, poll) do
+    now = System.monotonic_time(:millisecond)
+    current = MapSet.new(Node.list())
+    unchanged? = MapSet.equal?(current, members)
+
+    cond do
+      now >= deadline ->
+        MapSet.to_list(current)
+
+      unchanged? and now - stable_since >= stabilize ->
+        MapSet.to_list(current)
+
+      unchanged? ->
+        Process.sleep(poll)
+        loop_until_stable(members, stable_since, deadline, stabilize, poll)
+
+      true ->
+        # Membership changed — restart the quiet window from now.
+        Process.sleep(poll)
+        loop_until_stable(current, now, deadline, stabilize, poll)
+    end
+  end
+
+  defp clustering_enabled?, do: Application.get_env(:libcluster, :topologies, []) != []
+
+  defp cfg(key, default), do: Application.get_env(:fountain, key, default)
+
+  # ── sweep ─────────────────────────────────────────────────────────────────
+
+  defp sweep do
     Fountain.Telemetry.span([:rehydrate], %{}, fn ->
       convs = Conversations.list_resumable_conversations()
       Logger.info("rehydrator: scanning #{length(convs)} resumable conversation(s)")
@@ -30,7 +120,7 @@ defmodule Fountain.Conversations.Rehydrator do
           end
         end)
 
-      Logger.info("rehydrator: started #{started} ConversationServer(s)")
+      Logger.info("rehydrator: ensured #{started} ConversationServer(s)")
       {started, %{candidates: length(convs), started: started}}
     end)
   end
@@ -39,8 +129,8 @@ defmodule Fountain.Conversations.Rehydrator do
     with %Agents.Agent{} = _agent <-
            (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:skip, :no_agent},
          {:ok, runtime_module} <- Runtimes.for_runtime(conv.runtime) do
-      Horde.DynamicSupervisor.start_child(
-        Fountain.ConversationSupervisor,
+      Fountain.ConversationSupervisor
+      |> Horde.DynamicSupervisor.start_child(
         {ConversationServer,
          [
            conversation_id: conv.id,
@@ -49,6 +139,18 @@ defmodule Fountain.Conversations.Rehydrator do
            initial_prompt: nil
          ]}
       )
+      |> case do
+        {:ok, pid} ->
+          {:ok, pid}
+
+        # Another node already started this server (cluster synced between
+        # our list read and the start). Treat as success — it's running.
+        {:error, {:already_started, pid}} ->
+          {:ok, pid}
+
+        other ->
+          other
+      end
     else
       {:skip, why} ->
         Logger.warning("rehydrator: skipping conv #{conv.id} (#{why})")

--- a/apps/fountain/test/fountain/conversations/rehydrator_test.exs
+++ b/apps/fountain/test/fountain/conversations/rehydrator_test.exs
@@ -1,0 +1,43 @@
+defmodule Fountain.Conversations.RehydratorTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Conversations.Rehydrator
+
+  describe "leader election" do
+    test "a lone node (no peers) is always the leader" do
+      assert Rehydrator.leader?(:"fountain_server@10.0.0.1", [])
+
+      assert Rehydrator.leader_node(:"fountain_server@10.0.0.1", []) ==
+               :"fountain_server@10.0.0.1"
+    end
+
+    test "the lowest node name wins, regardless of discovery order" do
+      self_node = :"fountain_server@10.0.0.1"
+      peers = [:"fountain_server@10.0.0.2", :"fountain_server@10.0.0.3"]
+
+      assert Rehydrator.leader?(self_node, peers)
+      assert Rehydrator.leader_node(self_node, peers) == self_node
+    end
+
+    test "a non-lowest node defers to the leader" do
+      self_node = :"fountain_server@10.0.0.3"
+      peers = [:"fountain_server@10.0.0.1", :"fountain_server@10.0.0.2"]
+
+      refute Rehydrator.leader?(self_node, peers)
+      assert Rehydrator.leader_node(self_node, peers) == :"fountain_server@10.0.0.1"
+    end
+
+    test "election is consistent across the cluster: exactly one leader" do
+      a = :"fountain_server@10.0.0.1"
+      b = :"fountain_server@10.0.0.2"
+      c = :"fountain_server@10.0.0.3"
+      cluster = [a, b, c]
+
+      # Each node evaluates against itself + its peers; all must agree.
+      leaders =
+        for node <- cluster, Rehydrator.leader?(node, cluster -- [node]), do: node
+
+      assert leaders == [a]
+    end
+  end
+end


### PR DESCRIPTION
## Background

Follow-up to #132 (2-replica HA). After that landed, every deploy logged a burst of:

```
[error] GenServer Fountain.ConversationSupervisor terminating
```

## Root cause

`application.ex` starts the rehydrator the instant each node's supervisor boots:

```elixir
Task.start(fn -> Fountain.Conversations.Rehydrator.run() end)
```

But libcluster's DNSPoll takes ~15s to connect the peers (confirmed in pod logs: rehydrator ran at `19:58:50`, cluster connected `19:59:05`). So **both** nodes independently swept `list_resumable_conversations/0` and `start_child`'d all ~51 servers into their own not-yet-synced Horde registries. When the CRDT registries merged, Horde found the duplicate names and mass-terminated the losers — a sub-second window of duplicate sprite servers plus the log storm, on every deploy/restart.

## Fix

Before sweeping, wait for cluster membership to **stabilize**, then let only the **rehydration leader** (lowest connected node name) run the sweep:

- `Horde.UniformDistribution` already spreads started children across all nodes regardless of which node calls `start_child`, so a single sweeper doesn't concentrate load.
- **Clustering disabled / single node** (no `CLUSTER_DNS_QUERY`) short-circuits the wait + election and sweeps immediately — identical to today's behavior.
- `start_child` returning `{:already_started, _}` is now treated as success, so any residual cross-node overlap is a no-op instead of a counted failure.

Leader election is a pure function (`leader?/2`, `leader_node/2`) with unit tests proving exactly one node elects itself across a cluster. Cluster-wait timings are configurable via `:rehydrate_cluster_wait_ms` / `:rehydrate_stabilize_ms` / `:rehydrate_poll_ms` (code defaults 30s / 5s / 1s).

## Test

```
4 tests, 0 failures   # rehydrator_test.exs (pure leader-election)
mix compile --warnings-as-errors   # clean
mix credo (changed file)           # no issues
mix format --check-formatted       # clean
```

## Verify after deploy

On the next rollout, the `ConversationSupervisor terminating` lines should be gone, and logs should show `rehydrator: <node> elected rehydration leader; sweeping` on one pod and `not leader; skipping sweep` on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)