### PR TITLE
chore(deploy): pin image to sha-e53d0b7

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: fountain
           # Pinned to the sha tag produced by the build workflow for the
           # last commit that ran it. Update this alongside any deploy.
-          image: ghcr.io/binarybourbon/fountain:sha-0e76cd7b287e6af13a1251cbff663985aafc87d3
+          image: ghcr.io/binarybourbon/fountain:sha-e53d0b7c06449442699619f7c74879164b158948
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Image pin bump for the rehydrator cluster-race fix (#133).

**Image:** `ghcr.io/binarybourbon/fountain:sha-e53d0b7c06449442699619f7c74879164b158948`

The `pin-image` workflow built this branch + commit automatically but couldn't open the PR itself — the org has "Allow GitHub Actions to create and approve pull requests" disabled, so it fails at the final `gh pr create` step (every prior run failed the same way). Opening manually.

Merging deploys `sha-e53d0b7` to k8s via Flux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)