### PR TITLE
API keys: list endpoint

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
@@ -1,7 +1,8 @@
 defmodule FountainWeb.ApiKeyController do
   @moduledoc """
-  API key issuance and revocation for the authenticated user.
+  API key issuance, listing, and revocation for the authenticated user.
 
+  GET    /api/auth/api-keys      — list active keys (never returns key material)
   POST   /api/auth/api-keys      — create a new key (returns plaintext once)
   DELETE /api/auth/api-keys/:id  — revoke a key
   """
@@ -9,6 +10,11 @@ defmodule FountainWeb.ApiKeyController do
   use FountainWeb, :controller
 
   alias Fountain.Accounts
+
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    render(conn, :index, keys: Accounts.list_api_keys(user.id))
+  end
 
   def create(conn, %{"name" => name}) when is_binary(name) and name != "" do
     user = conn.assigns.current_user

--- a/apps/fountain/lib/fountain_web/controllers/api_key_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/api_key_json.ex
@@ -13,4 +13,17 @@ defmodule FountainWeb.ApiKeyJSON do
       created_at: key.inserted_at
     }
   end
+
+  @doc "Key listing — metadata only, never the key or its hash."
+  def index(%{keys: keys}), do: %{data: Enum.map(keys, &summary/1)}
+
+  defp summary(%ApiKey{} = key) do
+    %{
+      id: key.id,
+      name: key.name,
+      prefix: key.key_prefix,
+      created_at: key.inserted_at,
+      last_used_at: key.last_used_at
+    }
+  end
 end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -137,6 +137,7 @@ defmodule FountainWeb.Router do
     pipe_through :api
 
     get "/me", AuthMeController, :show
+    get "/api-keys", ApiKeyController, :index
     post "/api-keys", ApiKeyController, :create
     delete "/api-keys/:id", ApiKeyController, :delete
   end

--- a/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
@@ -113,6 +113,73 @@ defmodule FountainWeb.ApiKeyControllerTest do
     end
   end
 
+  describe "GET /api/auth/api-keys" do
+    test "lists active keys newest-first with metadata only", %{conn: conn} do
+      user = insert_verified_user()
+      {first, raw_key} = insert_api_key(user, "first-key")
+      {second, _} = insert_api_key(user, "second-key")
+
+      # inserted_at is second-granular; backdate the first key so the
+      # newest-first ordering assertion can't tie.
+      first =
+        first
+        |> Ecto.Changeset.change(inserted_at: DateTime.add(first.inserted_at, -60, :second))
+        |> Fountain.Repo.update!()
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/auth/api-keys")
+
+      %{"data" => keys} = json_response(conn, 200)
+      assert Enum.map(keys, & &1["id"]) == [second.id, first.id]
+
+      for key <- keys do
+        assert key["name"]
+        assert key["prefix"]
+        assert key["created_at"]
+        assert Map.has_key?(key, "last_used_at")
+        refute Map.has_key?(key, "key")
+        refute Map.has_key?(key, "key_hash")
+      end
+    end
+
+    test "excludes revoked keys", %{conn: conn} do
+      user = insert_verified_user()
+      {_auth, raw_key} = insert_api_key(user, "auth-key")
+      {revoked, _} = insert_api_key(user, "revoked-key")
+      {:ok, _} = Accounts.revoke_api_key(user.id, revoked.id)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/auth/api-keys")
+
+      %{"data" => keys} = json_response(conn, 200)
+      refute Enum.any?(keys, &(&1["id"] == revoked.id))
+    end
+
+    test "only returns the authenticated user's keys", %{conn: conn} do
+      user_a = insert_verified_user()
+      user_b = insert_verified_user()
+      {_key_b, _} = insert_api_key(user_b, "other-tenant")
+      {key_a, raw_a} = insert_api_key(user_a, "mine")
+
+      conn =
+        conn
+        |> authed_with_key(raw_a)
+        |> get("/api/auth/api-keys")
+
+      %{"data" => keys} = json_response(conn, 200)
+      assert Enum.map(keys, & &1["id"]) == [key_a.id]
+    end
+
+    test "returns 401 without valid API key", %{conn: conn} do
+      conn = get(conn, "/api/auth/api-keys")
+      assert json_response(conn, 401)
+    end
+  end
+
   describe "GET /api/auth/me" do
     test "returns user identity for authenticated request", %{conn: conn} do
       user = insert_verified_user()


### PR DESCRIPTION
Closes #141

## Summary

Adds `GET /api/auth/api-keys`, letting a tenant enumerate their own API keys. Reuses the existing `Accounts.list_api_keys/1` context function (active/non-revoked keys, newest first). Response fields are `id`, `name`, `prefix`, `created_at`, `last_used_at` — never key material or hashes, matching the posture used for environment/vault secrets.

## Implementation notes

Ported as-is from lex00's fork commit, no code changes needed — cherry-picked cleanly onto current `main` with no conflicts.

Before pushing, I specifically verified the two things called out as worth extra scrutiny for an auth-adjacent endpoint:

- **No key material leakage**: `Accounts.ApiKey` stores `key_hash` (never the raw key); `ApiKeyJSON.summary/1` only maps `id`, `name`, `key_prefix` → `prefix`, `created_at`, `last_used_at` — it does not touch `key_hash`. The ported tests assert this directly (`refute Map.has_key?(key, "key")` / `refute Map.has_key?(key, "key_hash")`), not just a 200 status.
- **Tenant scoping**: `Accounts.list_api_keys(user_id)` filters `where: k.user_id == ^user_id`, and the controller passes `conn.assigns.current_user.id` — no `_unsafe_*` bypass involved. A dedicated test (`"only returns the authenticated user's keys"`) creates keys for two different users and asserts one tenant only sees their own.

Ran the 4 ported tests (ordering w/ tie-broken timestamps, revoked-key exclusion, tenant scoping, 401-when-unauthenticated) plus the full suite: `mix test` → 1028 tests, 0 failures.

Nothing jumped out that needed fixing — shipping as-is per the "take as-is unless something jumps out" guidance.

## Attribution

Original implementation by lex00: [`issue-141-api-key-list`](https://github.com/lex00/fountain/tree/issue-141-api-key-list), commit [`49ce9e2`](https://github.com/lex00/fountain/commit/49ce9e2e03ae6c7347b274d45360864942b96511).