### PR TITLE
Agent: vault allowlist — conversation-time vault_id can override reviewed agent config

### DIFF
--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -22,6 +22,11 @@ defmodule Fountain.Agents.Agent do
     field :skills, {:array, :map}, default: []
     field :mcp_servers, :map, default: %{}
     field :metadata, :map, default: %{}
+    # Vaults a conversation may attach to this agent. nil = any tenant
+    # vault (legacy), [] = none, non-empty = allowlist. Vault values win
+    # on env-var collision, so an attached vault can override reviewed
+    # agent config — this is the lever that scopes who can do that.
+    field :allowed_vault_ids, {:array, :binary_id}
     field :avatar_media_type, :string
     field :conversation_count, :integer, virtual: true, default: 0
     belongs_to :user, User
@@ -42,6 +47,7 @@ defmodule Fountain.Agents.Agent do
       :skills,
       :mcp_servers,
       :metadata,
+      :allowed_vault_ids,
       :user_id,
       :environment_id
     ])

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -560,7 +560,7 @@ defmodule Fountain.Conversations do
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
-         {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id),
+         {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, sandbox} <-
            create_sandbox(%{
              environment_id: agent.environment_id,
@@ -666,14 +666,26 @@ defmodule Fountain.Conversations do
 
   defp tenant_prefix(user_id) when is_binary(user_id), do: binary_part(user_id, 0, 8)
 
-  defp resolve_vault_id(nil, _user_id), do: {:ok, nil}
-  defp resolve_vault_id("", _user_id), do: {:ok, nil}
+  defp resolve_vault_id(nil, _user_id, _agent), do: {:ok, nil}
+  defp resolve_vault_id("", _user_id, _agent), do: {:ok, nil}
 
-  defp resolve_vault_id(id, user_id) when is_binary(id) and is_binary(user_id) do
-    case Fountain.Vaults.get_vault(id, user_id) do
-      nil -> {:error, :vault_not_found}
-      vault -> {:ok, vault.id}
+  defp resolve_vault_id(id, user_id, agent) when is_binary(id) and is_binary(user_id) do
+    with :ok <- check_vault_allowed(id, agent) do
+      case Fountain.Vaults.get_vault(id, user_id) do
+        nil -> {:error, :vault_not_found}
+        vault -> {:ok, vault.id}
+      end
     end
+  end
+
+  # Vault values win on env-var collision, so an attached vault overrides
+  # the agent's reviewed environment. agent.allowed_vault_ids scopes who
+  # may do that: nil keeps the legacy any-tenant-vault behavior, [] forbids
+  # attaching any vault, a non-empty list is an allowlist.
+  defp check_vault_allowed(_vault_id, %Agents.Agent{allowed_vault_ids: nil}), do: :ok
+
+  defp check_vault_allowed(vault_id, %Agents.Agent{allowed_vault_ids: allowed}) do
+    if vault_id in allowed, do: :ok, else: {:error, :vault_not_allowed}
   end
 
   @doc """

--- a/apps/fountain/lib/fountain_web/controllers/agent_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_json.ex
@@ -17,6 +17,7 @@ defmodule FountainWeb.AgentJSON do
       skills: a.skills,
       mcp_servers: a.mcp_servers,
       metadata: a.metadata,
+      allowed_vault_ids: a.allowed_vault_ids,
       inserted_at: a.inserted_at,
       updated_at: a.updated_at
     }

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -24,6 +24,15 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "vault_not_found"})
   end
 
+  # The agent's allowed_vault_ids forbids attaching this (existing, same-
+  # tenant) vault. Unlike :vault_not_found this is a policy denial, so a
+  # distinct status + message tells the caller which knob to look at.
+  def call(conn, {:error, :vault_not_allowed}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "vault_not_allowed", message: "vault is not in the agent's allowed_vault_ids"})
+  end
+
   def call(conn, {:error, reason}) when is_binary(reason) do
     conn
     |> put_status(:bad_request)

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -117,7 +117,8 @@ defmodule FountainWeb.Schemas do
           format: :uuid,
           nullable: true,
           description:
-            "Optional vault whose secrets override the environment's baseline at sprite spawn."
+            "Optional vault whose secrets override the environment's baseline at sprite spawn. " <>
+              "Must satisfy the agent's allowed_vault_ids when that allowlist is set."
         },
         prompt: %Schema{type: :string, description: "Optional first turn prompt."},
         images: %Schema{
@@ -246,6 +247,16 @@ defmodule FountainWeb.Schemas do
         },
         mcp_servers: %Schema{type: :object, additionalProperties: true},
         metadata: %Schema{type: :object, additionalProperties: true},
+        allowed_vault_ids: %Schema{
+          type: :array,
+          items: %Schema{type: :string, format: :uuid},
+          nullable: true,
+          description:
+            "Vaults a conversation may attach to this agent. null (default) allows " <>
+              "any vault the tenant owns; an empty list forbids attaching any vault; " <>
+              "a non-empty list is an allowlist. Vault values override the agent's " <>
+              "environment on key collision, so this scopes who can override reviewed config."
+        },
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
@@ -314,7 +325,16 @@ defmodule FountainWeb.Schemas do
           }
         },
         mcp_servers: %Schema{type: :object, additionalProperties: true},
-        metadata: %Schema{type: :object, additionalProperties: true}
+        metadata: %Schema{type: :object, additionalProperties: true},
+        allowed_vault_ids: %Schema{
+          type: :array,
+          items: %Schema{type: :string, format: :uuid},
+          nullable: true,
+          description:
+            "Vaults a conversation may attach to this agent. null (default) allows " <>
+              "any vault the tenant owns; an empty list forbids attaching any vault; " <>
+              "a non-empty list is an allowlist."
+        }
       },
       required: [:name, :model, :runtime]
     })
@@ -357,7 +377,16 @@ defmodule FountainWeb.Schemas do
           }
         },
         mcp_servers: %Schema{type: :object, additionalProperties: true},
-        metadata: %Schema{type: :object, additionalProperties: true}
+        metadata: %Schema{type: :object, additionalProperties: true},
+        allowed_vault_ids: %Schema{
+          type: :array,
+          items: %Schema{type: :string, format: :uuid},
+          nullable: true,
+          description:
+            "Vaults a conversation may attach to this agent. null (default) allows " <>
+              "any vault the tenant owns; an empty list forbids attaching any vault; " <>
+              "a non-empty list is an allowlist."
+        }
       }
     })
   end

--- a/apps/fountain/priv/repo/migrations/20260729000001_add_allowed_vault_ids_to_agents.exs
+++ b/apps/fountain/priv/repo/migrations/20260729000001_add_allowed_vault_ids_to_agents.exs
@@ -1,0 +1,13 @@
+defmodule Fountain.Repo.Migrations.AddAllowedVaultIdsToAgents do
+  use Ecto.Migration
+
+  # nil (default) preserves legacy behavior: any tenant vault may be attached
+  # at conversation create. [] means no vault may be attached; a non-empty
+  # list is an allowlist. Nullable on purpose — nil and [] mean different
+  # things.
+  def change do
+    alter table(:agents) do
+      add :allowed_vault_ids, {:array, :binary_id}, null: true
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1623,6 +1623,48 @@ defmodule Fountain.ConversationsContextTest do
       assert {:ok, conv} = Conversations.start_conversation(attrs)
       assert conv.vault_id == vault.id
     end
+
+    test "allows a vault on the agent's allowed_vault_ids list", %{} do
+      user = insert_verified_user()
+      vault = insert_vault(user_id: user.id)
+      agent = insert_agent(user_id: user.id, allowed_vault_ids: [vault.id])
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+      attrs = %{"agent_id" => agent.id, "user_id" => user.id, "vault_id" => vault.id}
+      assert {:ok, conv} = Conversations.start_conversation(attrs)
+      assert conv.vault_id == vault.id
+    end
+
+    test "returns {:error, :vault_not_allowed} for a vault outside the allowlist", %{} do
+      user = insert_verified_user()
+      allowed = insert_vault(user_id: user.id)
+      other = insert_vault(user_id: user.id)
+      agent = insert_agent(user_id: user.id, allowed_vault_ids: [allowed.id])
+
+      attrs = %{"agent_id" => agent.id, "user_id" => user.id, "vault_id" => other.id}
+      assert {:error, :vault_not_allowed} = Conversations.start_conversation(attrs)
+    end
+
+    test "returns {:error, :vault_not_allowed} for any vault when the allowlist is empty", %{} do
+      user = insert_verified_user()
+      vault = insert_vault(user_id: user.id)
+      agent = insert_agent(user_id: user.id, allowed_vault_ids: [])
+
+      attrs = %{"agent_id" => agent.id, "user_id" => user.id, "vault_id" => vault.id}
+      assert {:error, :vault_not_allowed} = Conversations.start_conversation(attrs)
+    end
+
+    test "empty allowlist still permits starting with no vault at all", %{} do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id, allowed_vault_ids: [])
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+      attrs = %{"agent_id" => agent.id, "user_id" => user.id}
+      assert {:ok, conv} = Conversations.start_conversation(attrs)
+      assert is_nil(conv.vault_id)
+    end
   end
 
   # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #136

## Summary

`vault_id` was caller-chosen at conversation create time with no agent-side constraint, and vault values win on env-var collision at sprite spawn — so anyone who could open a conversation against an agent could override that agent's reviewed environment by attaching an arbitrary tenant vault.

This adds a nullable `allowed_vault_ids` field on `Agent`:
- `nil` (default) — legacy behavior, any tenant vault may be attached. Existing agents are unaffected.
- `[]` — no vault may be attached to a conversation against this agent.
- non-empty list — allowlist of vault ids; only those may be attached.

The check runs in `start_conversation`, inside `resolve_vault_id/3`, before the tenant-scoped vault lookup (`Fountain.Vaults.get_vault/2`) — so a policy denial never leaks whether a disallowed vault id even exists for the tenant. Denial surfaces as a distinct `422 Unprocessable Entity` with error code `vault_not_allowed`, separate from the existing `404 vault_not_found`, so callers can tell "policy denied" from "vault not found".

## Implementation notes

This is a straight port of lex00's commit — no redesign. Main had not diverged from the commit's parent at all (`531988c^` was already an ancestor of `main`), so the cherry-pick applied with zero conflicts and zero adjustments to code or tests.

What I did:
- Cherry-picked commit `531988c` onto a fresh branch off current `main`.
- Verified the test factory (`insert_agent/1`) already threads arbitrary overrides through `Agents.create_agent/1`, so `allowed_vault_ids: [...]` works in tests without factory changes.
- Ran the ported context tests (allow / deny outside allowlist / deny via empty list / empty-list-but-no-vault / legacy-nil-vs-vault-not-found from existing tests) — all pass.
- Ran the full suite (`mix test`): 1028 tests, 0 failures.
- Ran `mix format --check-formatted`, `mix compile --warnings-as-errors`, and `mix credo`: all clean (credo `--strict` flags 3 pre-existing, unrelated readability nits — not introduced by this change).

No deviations from the fork's implementation shape — field semantics, enforcement point, error code, and test coverage all match what was specified.

## Attribution

Original implementation by lex00: [`issue-136-vault-allowlist`](https://github.com/lex00/fountain/tree/issue-136-vault-allowlist), commit [`531988c`](https://github.com/lex00/fountain/commit/531988c7dd26d18c9f9e31e9cced8463c31f79b3).