### PR TITLE
Environment: type and document networking_config semantics

### DIFF
--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -241,7 +241,11 @@ defmodule Fountain.Conversations.Provisioning do
   @doc """
   Apply the env's networking config to the sprite. `unrestricted` is a
   no-op (sprites are open by default). `limited` builds an allowlist from
-  `networking_config.allowed_hosts: [...]`.
+  `networking_config.allowed_hosts: [...]`. Sprites treats a policy with no
+  rules as "no enforcement" (allow-all), so an empty/absent allowlist is
+  translated into an explicit deny-all rule rather than a bare `rules: []`
+  — otherwise `limited` with nothing allowed would silently open full
+  egress instead of denying it.
   """
   def apply_network_policy(_sprite, nil, _conv_id), do: :ok
 
@@ -255,7 +259,7 @@ defmodule Fountain.Conversations.Provisioning do
       [:network_policy],
       %{conv_id: conv_id, hosts: length(hosts)},
       fn ->
-        rules = Enum.map(hosts, &%Sprites.Policy.Rule{domain: &1, action: "allow"})
+        rules = network_policy_rules(hosts)
         publish_stage(conv_id, "network", "started", %{type: "limited", hosts: length(hosts)})
 
         case Sprites.update_network_policy(sprite, %Sprites.Policy{rules: rules}) do
@@ -272,6 +276,16 @@ defmodule Fountain.Conversations.Provisioning do
   end
 
   def apply_network_policy(_sprite, _env, _conv_id), do: :ok
+
+  # An empty allowlist must still deny by default. Sending Sprites a bare
+  # `rules: []` is interpreted as "no enforcement" (allow-all) on their
+  # side, so `limited` with nothing allowed would otherwise fail open.
+  # The deny rule stands alone — no `include: "defaults"` — since pulling
+  # in Sprites' own default allowances would defeat the deny-all.
+  defp network_policy_rules([]), do: [%Sprites.Policy.Rule{domain: "*", action: "deny"}]
+
+  defp network_policy_rules(hosts),
+    do: Enum.map(hosts, &%Sprites.Policy.Rule{domain: &1, action: "allow"})
 
   # ── git clone ─────────────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain/environments/environment.ex
+++ b/apps/fountain/lib/fountain/environments/environment.ex
@@ -53,6 +53,7 @@ defmodule Fountain.Environments.Environment do
     |> validate_required([:name])
     |> validate_inclusion(:networking_type, @networking)
     |> validate_length(:name, min: 1, max: 200)
+    |> validate_change(:networking_config, &validate_networking_config/2)
     |> validate_change(:repositories, &validate_repositories/2)
     |> maybe_invalidate_checkpoint()
     |> unique_constraint(:name)
@@ -91,4 +92,28 @@ defmodule Fountain.Environments.Environment do
   end
 
   defp validate_repositories(_, _), do: []
+
+  # networking_config's only honored key is "allowed_hosts" (see
+  # Provisioning.apply_network_policy/3 — under `limited` it becomes the
+  # sprite's domain allowlist). Unknown keys stay allowed for forward
+  # compat, but a malformed allowed_hosts fails here instead of silently
+  # producing a policy the author didn't intend.
+  defp validate_networking_config(_field, %{} = config) do
+    case Map.get(config, "allowed_hosts") || Map.get(config, :allowed_hosts) do
+      nil ->
+        []
+
+      hosts when is_list(hosts) ->
+        if Enum.all?(hosts, fn h -> is_binary(h) and h != "" end) do
+          []
+        else
+          [networking_config: "allowed_hosts entries must be non-empty strings"]
+        end
+
+      _ ->
+        [networking_config: "allowed_hosts must be a list of hostnames"]
+    end
+  end
+
+  defp validate_networking_config(_, _), do: []
 end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -397,8 +397,9 @@ defmodule FountainWeb.Schemas do
           description:
             "Refines networking_type: limited. allowed_hosts is the only key " <>
               "honored today; unknown keys are ignored. Under limited, egress is " <>
-              "restricted to the allowlisted domains — with no allowed_hosts, " <>
-              "nothing is allowlisted.",
+              "restricted to the allowlisted domains. With no allowed_hosts (or an " <>
+              "empty list), the sandbox denies all egress by default — this is a " <>
+              "deny-all, not an allow-all.",
           properties: %{
             allowed_hosts: %Schema{
               type: :array,
@@ -458,8 +459,9 @@ defmodule FountainWeb.Schemas do
           description:
             "Refines networking_type: limited. allowed_hosts is the only key " <>
               "honored today; unknown keys are ignored. Under limited, egress is " <>
-              "restricted to the allowlisted domains — with no allowed_hosts, " <>
-              "nothing is allowlisted.",
+              "restricted to the allowlisted domains. With no allowed_hosts (or an " <>
+              "empty list), the sandbox denies all egress by default — this is a " <>
+              "deny-all, not an allow-all.",
           properties: %{
             allowed_hosts: %Schema{
               type: :array,
@@ -497,8 +499,9 @@ defmodule FountainWeb.Schemas do
           description:
             "Refines networking_type: limited. allowed_hosts is the only key " <>
               "honored today; unknown keys are ignored. Under limited, egress is " <>
-              "restricted to the allowlisted domains — with no allowed_hosts, " <>
-              "nothing is allowlisted.",
+              "restricted to the allowlisted domains. With no allowed_hosts (or an " <>
+              "empty list), the sandbox denies all egress by default — this is a " <>
+              "deny-all, not an allow-all.",
           properties: %{
             allowed_hosts: %Schema{
               type: :array,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -392,7 +392,22 @@ defmodule FountainWeb.Schemas do
         env_vars: %Schema{type: :object, additionalProperties: %Schema{type: :string}},
         setup_script: %Schema{type: :string},
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
-        networking_config: %Schema{type: :object, additionalProperties: true},
+        networking_config: %Schema{
+          type: :object,
+          description:
+            "Refines networking_type: limited. allowed_hosts is the only key " <>
+              "honored today; unknown keys are ignored. Under limited, egress is " <>
+              "restricted to the allowlisted domains — with no allowed_hosts, " <>
+              "nothing is allowlisted.",
+          properties: %{
+            allowed_hosts: %Schema{
+              type: :array,
+              items: %Schema{type: :string},
+              description: "Domains the sandbox may reach when networking_type is limited."
+            }
+          },
+          additionalProperties: true
+        },
         repositories: %Schema{type: :array, items: Repository},
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
@@ -438,7 +453,22 @@ defmodule FountainWeb.Schemas do
         env_vars: %Schema{type: :object, additionalProperties: %Schema{type: :string}},
         setup_script: %Schema{type: :string},
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
-        networking_config: %Schema{type: :object, additionalProperties: true},
+        networking_config: %Schema{
+          type: :object,
+          description:
+            "Refines networking_type: limited. allowed_hosts is the only key " <>
+              "honored today; unknown keys are ignored. Under limited, egress is " <>
+              "restricted to the allowlisted domains — with no allowed_hosts, " <>
+              "nothing is allowlisted.",
+          properties: %{
+            allowed_hosts: %Schema{
+              type: :array,
+              items: %Schema{type: :string},
+              description: "Domains the sandbox may reach when networking_type is limited."
+            }
+          },
+          additionalProperties: true
+        },
         repositories: %Schema{type: :array, items: Repository}
       },
       required: [:name]
@@ -462,7 +492,22 @@ defmodule FountainWeb.Schemas do
         env_vars: %Schema{type: :object, additionalProperties: %Schema{type: :string}},
         setup_script: %Schema{type: :string},
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
-        networking_config: %Schema{type: :object, additionalProperties: true},
+        networking_config: %Schema{
+          type: :object,
+          description:
+            "Refines networking_type: limited. allowed_hosts is the only key " <>
+              "honored today; unknown keys are ignored. Under limited, egress is " <>
+              "restricted to the allowlisted domains — with no allowed_hosts, " <>
+              "nothing is allowlisted.",
+          properties: %{
+            allowed_hosts: %Schema{
+              type: :array,
+              items: %Schema{type: :string},
+              description: "Domains the sandbox may reach when networking_type is limited."
+            }
+          },
+          additionalProperties: true
+        },
         repositories: %Schema{type: :array, items: Repository}
       }
     })

--- a/apps/fountain/test/fountain/conversations/provisioning_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_test.exs
@@ -1,0 +1,63 @@
+defmodule Fountain.Conversations.ProvisioningTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations.Provisioning
+
+  describe "apply_network_policy/3 — limited networking" do
+    test "empty allowed_hosts denies by default instead of sending an empty rule list" do
+      env = insert_env(%{"networking_type" => "limited", "networking_config" => %{}})
+      conv = insert_conversation()
+
+      expect(Sprites, :update_network_policy, fn _sprite, policy ->
+        refute policy.rules == [],
+               "an empty rules list is Sprites' documented allow-all — limited " <>
+                 "with no allowed_hosts must not send that"
+
+        assert %Sprites.Policy{rules: [%Sprites.Policy.Rule{domain: "*", action: "deny"}]} =
+                 policy
+
+        :ok
+      end)
+
+      assert :ok = Provisioning.apply_network_policy(%{name: "test-sprite"}, env, conv.id)
+    end
+
+    test "absent allowed_hosts (no networking_config at all) also denies by default" do
+      env = insert_env(%{"networking_type" => "limited"})
+      conv = insert_conversation()
+
+      expect(Sprites, :update_network_policy, fn _sprite, policy ->
+        assert %Sprites.Policy{rules: [%Sprites.Policy.Rule{domain: "*", action: "deny"}]} =
+                 policy
+
+        :ok
+      end)
+
+      assert :ok = Provisioning.apply_network_policy(%{name: "test-sprite"}, env, conv.id)
+    end
+
+    test "non-empty allowed_hosts still builds an allowlist" do
+      env =
+        insert_env(%{
+          "networking_type" => "limited",
+          "networking_config" => %{"allowed_hosts" => ["github.com", "registry.npmjs.org"]}
+        })
+
+      conv = insert_conversation()
+
+      expect(Sprites, :update_network_policy, fn _sprite, policy ->
+        assert %Sprites.Policy{
+                 rules: [
+                   %Sprites.Policy.Rule{domain: "github.com", action: "allow"},
+                   %Sprites.Policy.Rule{domain: "registry.npmjs.org", action: "allow"}
+                 ]
+               } = policy
+
+        :ok
+      end)
+
+      assert :ok = Provisioning.apply_network_policy(%{name: "test-sprite"}, env, conv.id)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/environments/environment_test.exs
+++ b/apps/fountain/test/fountain/environments/environment_test.exs
@@ -92,6 +92,51 @@ defmodule Fountain.Environments.EnvironmentTest do
   end
 
   # ---------------------------------------------------------------------------
+  # validate_networking_config
+  # ---------------------------------------------------------------------------
+
+  describe "validate_networking_config" do
+    test "allowed_hosts as a list of hostnames passes" do
+      cs =
+        changeset(%{
+          "networking_type" => "limited",
+          "networking_config" => %{"allowed_hosts" => ["registry.npmjs.org", "github.com"]}
+        })
+
+      assert cs.valid?
+    end
+
+    test "config without allowed_hosts passes (unknown keys are ignored)" do
+      cs = changeset(%{"networking_config" => %{"future_knob" => true}})
+      assert cs.valid?
+    end
+
+    test "allowed_hosts as a bare string fails" do
+      errors =
+        changeset(%{"networking_config" => %{"allowed_hosts" => "github.com"}})
+        |> errors_on()
+
+      assert "allowed_hosts must be a list of hostnames" in errors.networking_config
+    end
+
+    test "allowed_hosts containing an empty string fails" do
+      errors =
+        changeset(%{"networking_config" => %{"allowed_hosts" => ["github.com", ""]}})
+        |> errors_on()
+
+      assert "allowed_hosts entries must be non-empty strings" in errors.networking_config
+    end
+
+    test "allowed_hosts containing a non-string fails" do
+      errors =
+        changeset(%{"networking_config" => %{"allowed_hosts" => [42]}})
+        |> errors_on()
+
+      assert "allowed_hosts entries must be non-empty strings" in errors.networking_config
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # validate_repositories
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #139

## Summary

`networking_config` was an untyped, undocumented map. This PR:

- Types `networking_config` in the OpenAPI schema, documenting the one key `Provisioning.apply_network_policy/3` honors (`allowed_hosts`) and its actual semantics: under `networking_type: limited` it becomes the sandbox's domain allowlist; `unrestricted` is a no-op; unknown keys are accepted for forward compat.
- Adds an `Environment` changeset validation that rejects a malformed `allowed_hosts` (non-list, non-string entries, empty strings) at write time instead of silently producing a policy the author didn't intend.
- **Fixes a deny-all gap**: `apply_network_policy/3` translated `limited` + empty/absent `allowed_hosts` into a bare `%Sprites.Policy{rules: []}`. Sprites documents an empty rules list as "no enforcement" (allow-all) — so a config an operator wrote expecting lockdown was silently opening full egress instead. This directly undermines issue #139's own motivating use case (a lint requiring `limited` + pinned/empty config for untrusted agents).

## Implementation notes

Part 1 (typing + validation) is cherry-picked as-is from lex00's fork branch `issue-139-networking-config-typing` (commit `1215fb0`) — applied cleanly with no conflicts against current `main`.

Part 2 (the deny-all fix) is new work on top of that commit, done in this PR:

- Investigated the open question lex00 left in the fork (does `limited` + empty allowlist behave as deny-all on the Sprites side?) by reading the vendored `sprites-ex` client (`Sprites.Policy.to_map/1`): an empty `rules` list serializes to a bare `{"rules": []}` JSON body, which is Sprites' documented signal for "no enforcement." Confirmed this is exactly what `apply_network_policy/3` sent for `limited` + no `allowed_hosts` on current `main` — the gap is real, not hypothetical.
- Fixed `apply_network_policy/3` (`apps/fountain/lib/fountain/conversations/provisioning.ex`) so empty/absent `allowed_hosts` under `limited` sends an explicit `%Sprites.Policy.Rule{domain: "*", action: "deny"}` instead of an empty rules array. Deliberately did **not** add an `include: "defaults"` rule alongside it, since that would reintroduce Sprites' own default allowances and defeat the deny-all. Non-empty `allowed_hosts` is unchanged (same allow-rule building as before).
- Added `apps/fountain/test/fountain/conversations/provisioning_test.exs` (new file — no prior test coverage existed for `apply_network_policy/3`) pinning: empty `allowed_hosts` → single deny-all rule (not `rules: []`), absent `networking_config` → same, non-empty `allowed_hosts` → unchanged allowlist behavior.
- Updated the OpenAPI `networking_config` description (ported from part 1) to state the deny-all behavior explicitly, since documenting exactly this kind of claim is what issue #139 asked for.

Docs paragraph for this behavior is intentionally left to issue #142, per the issue's own scope split.

## Attribution

Original implementation (typing + changeset validation) by lex00: [`issue-139-networking-config-typing`](https://github.com/lex00/fountain/tree/issue-139-networking-config-typing), commit [`1215fb0`](https://github.com/lex00/fountain/commit/1215fb09b361365e6e67cc2668357bc842064907). The deny-all fix (Part 2 above) is new work added in this PR.