### PR TITLE
Release: export openapi.json as a versioned artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,11 +72,80 @@ jobs:
           name: ${{ matrix.artifact }}
           path: dist/${{ matrix.artifact }}
 
+  openapi:
+    name: Export OpenAPI spec
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    # Same service + env shape as ci.yml's test job: the spec renders from
+    # the compiled app, and app start is verified against this exact setup.
+    services:
+      postgres:
+        image: postgres:16@sha256:287eced1f33b59ed265ed13a60d3680dd7646d70c4dc0e785f59a470ebc03eeb
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: fountain_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      MIX_ENV: test
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Elixir
+        id: beam
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        with:
+          elixir-version: "1.19.2"
+          otp-version: "28.3"
+
+      - name: Restore deps cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Restore build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+            ${{ runner.os }}-build-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Export spec
+        working-directory: apps/fountain
+        run: mix openapi.export
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: openapi.json
+          path: dist/openapi.json
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, openapi]
     permissions:
       contents: write
 
@@ -110,6 +179,7 @@ jobs:
             artifacts/fountain-linux-arm64/fountain-linux-arm64
             artifacts/fountain-darwin-amd64/fountain-darwin-amd64
             artifacts/fountain-darwin-arm64/fountain-darwin-arm64
+            artifacts/openapi.json/openapi.json
           fail_on_unmatched_files: true
 
   bump-tap:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
 
+# Local build outputs (CLI binaries in CI, `mix openapi.export` locally).
+/dist/
+
 # The directory Mix downloads your dependencies sources to.
 /deps/
 

--- a/apps/fountain/mix.exs
+++ b/apps/fountain/mix.exs
@@ -87,8 +87,12 @@ defmodule Fountain.MixProject do
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["test"],
       # Render the served OpenAPI spec to a file (same content as
-      # /api/openapi.json). The release workflow attaches it per tag.
-      "openapi.export": ["openapi.spec.json --spec FountainWeb.ApiSpec ../../dist/openapi.json"]
+      # /api/openapi.json — RenderSpec doesn't include open_api_spex's
+      # vendor extensions, so this must match with --vendor-extensions=false.
+      # The release workflow attaches it per tag.
+      "openapi.export": [
+        "openapi.spec.json --spec FountainWeb.ApiSpec --vendor-extensions=false ../../dist/openapi.json"
+      ]
     ]
   end
 end

--- a/apps/fountain/mix.exs
+++ b/apps/fountain/mix.exs
@@ -85,7 +85,10 @@ defmodule Fountain.MixProject do
       setup: ["deps.get", "ecto.setup"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["test"]
+      test: ["test"],
+      # Render the served OpenAPI spec to a file (same content as
+      # /api/openapi.json). The release workflow attaches it per tag.
+      "openapi.export": ["openapi.spec.json --spec FountainWeb.ApiSpec ../../dist/openapi.json"]
     ]
   end
 end


### PR DESCRIPTION
Closes #140

## Summary

Adds a `mix openapi.export` alias that renders the served OpenApiSpex spec to `dist/openapi.json`, and a release workflow job that exports and attaches this file to each tagged release alongside the CLI binaries. This lets downstream tooling pin against a specific released API spec version rather than only being able to track the spec via live deploys.

## Implementation notes

Ported as-is from lex00's fork with one fix:

- The ported `mix.exs` alias called `openapi.spec.json --spec FountainWeb.ApiSpec` without `--vendor-extensions=false`. `open_api_spex`'s mix task defaults `--vendor-extensions` to `true`, which adds `x-struct`/`x-validate` fields to every schema object. The served `/api/openapi.json` endpoint (`OpenApiSpex.Plug.RenderSpec`) does not include these — it just `Jason.encode!`s the raw spec struct. Without the flag, the exported artifact was NOT byte-identical to the served spec, which contradicts the alias's own comment ("same content as /api/openapi.json") and the issue's intent. Added `--vendor-extensions=false` to the alias and verified the two outputs are now byte-for-byte identical (confirmed by starting the app locally, curling `/api/openapi.json`, and diffing against a fresh `mix openapi.export` run).
- No other changes — the release workflow job's Postgres image, Elixir/OTP versions, and cache config are copied verbatim from `ci.yml`'s test job and match it exactly. Its `actions/checkout` pin matches the convention already used by the rest of `release.yml` (a slightly older SHA than `ci.yml` uses — pre-existing drift between the two workflow files, not introduced by this change).

## Verification

- `mix openapi.export` produces `dist/openapi.json`: 18 paths, `version: "0.1.0"` (matches `mix.exs`).
- Started the app locally (`mix phx.server`), curled `/api/openapi.json`, and diffed it against a fresh `mix openapi.export` run — byte-for-byte identical after the vendor-extensions fix.
- `mix precommit` (format, compile --warnings-as-errors, credo, ecto.create/migrate, mix test) — all green, 1024 tests / 0 failures.
- `.github/workflows/release.yml` validated as syntactically correct YAML.

## Attribution

Original implementation by [lex00](https://github.com/lex00) on branch [`issue-140-openapi-artifact`](https://github.com/lex00/fountain/tree/issue-140-openapi-artifact), commit [80bd9a8](https://github.com/lex00/fountain/commit/80bd9a8ca97173fb334b14349d587a8e2ee88d39).