### PR TITLE
Agent skills: GitHub-sourced entries need a ref/sha pin

### DIFF
--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -91,11 +91,11 @@ defmodule Fountain.Agents.Agent do
     end
   end
 
+  defp skill_errors(_entry, i), do: [skills: "entry #{i}: must be an object"]
+
   # Mirrors SpriteSkills.safe_token!/1 — the ref is interpolated into the
   # sprite-side install command, so reject anything outside the allow-list
   # at write time instead of failing the spawn later.
   defp valid_ref?(ref) when is_binary(ref), do: Regex.match?(~r{\A[A-Za-z0-9._/-]+\z}, ref)
   defp valid_ref?(_), do: false
-
-  defp skill_errors(_entry, i), do: [skills: "entry #{i}: must be an object"]
 end

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -68,6 +68,7 @@ defmodule Fountain.Agents.Agent do
     has_content = is_binary(Map.get(entry, "content") || Map.get(entry, :content))
     has_source = is_binary(Map.get(entry, "source") || Map.get(entry, :source))
     name = Map.get(entry, "name") || Map.get(entry, :name)
+    ref = Map.get(entry, "ref") || Map.get(entry, :ref)
 
     cond do
       has_content and has_source ->
@@ -79,10 +80,22 @@ defmodule Fountain.Agents.Agent do
       has_content and not is_binary(name) ->
         [skills: "entry #{i}: inline skills require a name"]
 
+      has_content and not is_nil(ref) ->
+        [skills: "entry #{i}: ref only applies to github-sourced skills"]
+
+      not is_nil(ref) and not valid_ref?(ref) ->
+        [skills: "entry #{i}: ref must match [A-Za-z0-9._/-]+ (tag, branch, or sha)"]
+
       true ->
         []
     end
   end
+
+  # Mirrors SpriteSkills.safe_token!/1 — the ref is interpolated into the
+  # sprite-side install command, so reject anything outside the allow-list
+  # at write time instead of failing the spawn later.
+  defp valid_ref?(ref) when is_binary(ref), do: Regex.match?(~r{\A[A-Za-z0-9._/-]+\z}, ref)
+  defp valid_ref?(_), do: false
 
   defp skill_errors(_entry, i), do: [skills: "entry #{i}: must be an object"]
 end

--- a/apps/fountain/lib/fountain/sprite_skills.ex
+++ b/apps/fountain/lib/fountain/sprite_skills.ex
@@ -6,11 +6,13 @@ defmodule Fountain.SpriteSkills do
 
     * `%{"name" => name, "content" => skill_md}` — inline. Written
       directly to `<runtime.skills_root>/<name>/SKILL.md`.
-    * `%{"source" => "owner/repo", "name" => optional}` — github.
-      Installed via the [skills.sh](https://skills.sh) CLI on the sprite:
-      `npx -y skills@latest add <source> --global --agent <runtime-agent>
-      --yes [--skill <name>]`. Each runtime declares its own
-      `skills_sh_agent` so the CLI writes to the right on-disk layout.
+    * `%{"source" => "owner/repo", "ref" => optional, "name" => optional}` —
+      github. Installed via the [skills.sh](https://skills.sh) CLI on the
+      sprite: `npx -y skills@latest add <source>[@<ref>] --global --agent
+      <runtime-agent> --yes [--skill <name>]`. A `ref` (tag, branch, or sha)
+      pins the install; without one the repo's default branch is used at
+      spawn time. Each runtime declares its own `skills_sh_agent` so the
+      CLI writes to the right on-disk layout.
 
   The bundled `fountain` skill at `priv/sprite_skills/fountain/SKILL.md` is
   always prepended as an inline skill — it's how the per-conversation callback
@@ -104,15 +106,7 @@ defmodule Fountain.SpriteSkills do
     safe_agent = safe_token!(agent_id)
 
     Enum.each(github, fn entry ->
-      source = safe_token!(entry["source"])
-
-      cmd =
-        "npx -y skills@latest add #{source} --global --agent #{safe_agent} --yes" <>
-          case entry["name"] do
-            nil -> ""
-            "" -> ""
-            name -> " --skill #{safe_token!(name)}"
-          end
+      cmd = github_install_cmd(entry, safe_agent)
 
       {output, code} =
         Sprites.cmd(sprite, "bash", ["-lc", cmd],
@@ -126,6 +120,29 @@ defmodule Fountain.SpriteSkills do
         )
       end
     end)
+  end
+
+  # Build the skills.sh install command for one github entry. `@ref` pins
+  # the fetch to a tag/branch/sha (skills.sh resolves `owner/repo@ref`).
+  # Every interpolated value passes the safe_token! allow-list separately —
+  # `@` itself is never accepted inside a token.
+  @doc false
+  def github_install_cmd(entry, safe_agent) do
+    source = safe_token!(entry["source"])
+
+    pinned =
+      case entry["ref"] do
+        nil -> source
+        "" -> source
+        ref -> source <> "@" <> safe_token!(ref)
+      end
+
+    "npx -y skills@latest add #{pinned} --global --agent #{safe_agent} --yes" <>
+      case entry["name"] do
+        nil -> ""
+        "" -> ""
+        name -> " --skill #{safe_token!(name)}"
+      end
   end
 
   # Allow-list quoting guard for values interpolated into `bash -lc`.

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -229,7 +229,8 @@ defmodule FountainWeb.Schemas do
           type: :array,
           description:
             "Each entry is either inline (`{name, content}` — full SKILL.md text written to the sprite) " <>
-              "or github (`{source, name?}` — installed on the sprite via the skills.sh CLI). " <>
+              "or github (`{source, ref?, name?}` — installed on the sprite via the skills.sh CLI, " <>
+              "optionally pinned to a tag/branch/sha via `ref`). " <>
               "Exactly one of `content` or `source` must be set on each entry.",
           items: %Schema{
             type: :object,
@@ -239,6 +240,14 @@ defmodule FountainWeb.Schemas do
               source: %Schema{
                 type: :string,
                 description: "GitHub `owner/repo` for skills.sh-sourced entries.",
+                pattern: "^[A-Za-z0-9._/-]+$"
+              },
+              ref: %Schema{
+                type: :string,
+                description:
+                  "Optional tag, branch, or sha pinning a github-sourced skill " <>
+                    "(installed as `owner/repo@ref`). Without it the default branch " <>
+                    "is fetched at spawn time.",
                 pattern: "^[A-Za-z0-9._/-]+$"
               }
             }
@@ -298,7 +307,8 @@ defmodule FountainWeb.Schemas do
           type: :array,
           description:
             "Each entry is either inline (`{name, content}` — full SKILL.md text written to the sprite) " <>
-              "or github (`{source, name?}` — installed on the sprite via the skills.sh CLI). " <>
+              "or github (`{source, ref?, name?}` — installed on the sprite via the skills.sh CLI, " <>
+              "optionally pinned to a tag/branch/sha via `ref`). " <>
               "Exactly one of `content` or `source` must be set on each entry.",
           items: %Schema{
             type: :object,
@@ -308,6 +318,14 @@ defmodule FountainWeb.Schemas do
               source: %Schema{
                 type: :string,
                 description: "GitHub `owner/repo` for skills.sh-sourced entries.",
+                pattern: "^[A-Za-z0-9._/-]+$"
+              },
+              ref: %Schema{
+                type: :string,
+                description:
+                  "Optional tag, branch, or sha pinning a github-sourced skill " <>
+                    "(installed as `owner/repo@ref`). Without it the default branch " <>
+                    "is fetched at spawn time.",
                 pattern: "^[A-Za-z0-9._/-]+$"
               }
             }
@@ -341,7 +359,8 @@ defmodule FountainWeb.Schemas do
           type: :array,
           description:
             "Each entry is either inline (`{name, content}` — full SKILL.md text written to the sprite) " <>
-              "or github (`{source, name?}` — installed on the sprite via the skills.sh CLI). " <>
+              "or github (`{source, ref?, name?}` — installed on the sprite via the skills.sh CLI, " <>
+              "optionally pinned to a tag/branch/sha via `ref`). " <>
               "Exactly one of `content` or `source` must be set on each entry.",
           items: %Schema{
             type: :object,
@@ -351,6 +370,14 @@ defmodule FountainWeb.Schemas do
               source: %Schema{
                 type: :string,
                 description: "GitHub `owner/repo` for skills.sh-sourced entries.",
+                pattern: "^[A-Za-z0-9._/-]+$"
+              },
+              ref: %Schema{
+                type: :string,
+                description:
+                  "Optional tag, branch, or sha pinning a github-sourced skill " <>
+                    "(installed as `owner/repo@ref`). Without it the default branch " <>
+                    "is fetched at spawn time.",
                 pattern: "^[A-Za-z0-9._/-]+$"
               }
             }

--- a/apps/fountain/test/fountain/agents/agent_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_test.exs
@@ -123,6 +123,37 @@ defmodule Fountain.Agents.AgentTest do
       assert Enum.any?(errors_on(changeset).skills, &String.contains?(&1, "only one of"))
     end
 
+    test "github skill pinned with a ref passes" do
+      skills = [%{"source" => "owner/repo", "ref" => "v1.2.0"}]
+      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :skills, skills))
+      assert changeset.valid?
+    end
+
+    test "ref on an inline skill fails" do
+      skills = [%{"name" => "foo", "content" => "x", "ref" => "main"}]
+      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :skills, skills))
+      refute changeset.valid?
+
+      assert Enum.any?(
+               errors_on(changeset).skills,
+               &String.contains?(&1, "ref only applies to github-sourced")
+             )
+    end
+
+    test "ref with shell-unsafe characters fails" do
+      skills = [%{"source" => "owner/repo", "ref" => "main; rm -rf /"}]
+      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :skills, skills))
+      refute changeset.valid?
+      assert Enum.any?(errors_on(changeset).skills, &String.contains?(&1, "ref must match"))
+    end
+
+    test "non-string ref fails" do
+      skills = [%{"source" => "owner/repo", "ref" => 42}]
+      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :skills, skills))
+      refute changeset.valid?
+      assert Enum.any?(errors_on(changeset).skills, &String.contains?(&1, "ref must match"))
+    end
+
     test "skill with neither content nor source fails" do
       skills = [%{}]
       changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :skills, skills))

--- a/apps/fountain/test/fountain/sprite_skills_test.exs
+++ b/apps/fountain/test/fountain/sprite_skills_test.exs
@@ -1,0 +1,55 @@
+defmodule Fountain.SpriteSkillsTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.SpriteSkills
+
+  describe "github_install_cmd/2" do
+    test "unpinned source installs from the default branch" do
+      cmd = SpriteSkills.github_install_cmd(%{"source" => "owner/repo"}, "claude")
+
+      assert cmd == "npx -y skills@latest add owner/repo --global --agent claude --yes"
+    end
+
+    test "ref pins the source as owner/repo@ref" do
+      cmd =
+        SpriteSkills.github_install_cmd(
+          %{"source" => "owner/repo", "ref" => "v1.2.0"},
+          "claude"
+        )
+
+      assert cmd == "npx -y skills@latest add owner/repo@v1.2.0 --global --agent claude --yes"
+    end
+
+    test "empty ref is treated as unpinned" do
+      cmd = SpriteSkills.github_install_cmd(%{"source" => "owner/repo", "ref" => ""}, "claude")
+
+      assert cmd == "npx -y skills@latest add owner/repo --global --agent claude --yes"
+    end
+
+    test "name adds the --skill flag alongside a ref" do
+      cmd =
+        SpriteSkills.github_install_cmd(
+          %{"source" => "owner/repo", "ref" => "abc123", "name" => "my-skill"},
+          "claude"
+        )
+
+      assert cmd ==
+               "npx -y skills@latest add owner/repo@abc123 --global --agent claude --yes --skill my-skill"
+    end
+
+    test "shell-unsafe ref raises instead of reaching the command" do
+      assert_raise ArgumentError, fn ->
+        SpriteSkills.github_install_cmd(
+          %{"source" => "owner/repo", "ref" => "main; rm -rf /"},
+          "claude"
+        )
+      end
+    end
+
+    test "shell-unsafe source raises" do
+      assert_raise ArgumentError, fn ->
+        SpriteSkills.github_install_cmd(%{"source" => "owner/repo$(whoami)"}, "claude")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #138

## Summary

A skills entry's `source` previously always resolved to whatever the repo's default branch held at spawn time — non-reproducible between conversations and open to upstream drift. This adds an optional `ref` field (tag, branch, or sha) that pins github-sourced skill installs.

- Optional `ref` field on github-sourced `skills` entries (schema, changeset validation).
- `ref` is validated at write time against the **same** shell allow-list regex already used for `source` (`[A-Za-z0-9._/-]+`) — no separate/looser validator. This intentionally rejects exotic ref names containing `~`, `^`, `@{`, spaces, etc.
- The install command becomes `add <source>@<ref>` when `ref` is present; unset/empty `ref` falls back to the previous unpinned `add <source>` form.
- The command builder is extracted into `SpriteSkills.github_install_cmd/2` and unit-tested, including injection-guard cases (`;`, `$(...)`) that exercise the shell-metacharacter rejection — since the guard is a strict allow-list (not a blacklist), these representative cases cover the full class of rejected metacharacters (backticks, `&&`, spaces, etc. all fall outside `[A-Za-z0-9._/-]+` the same way).

## Implementation notes

- Cherry-picked cleanly from lex00's branch onto current `main` — `main` HEAD was exactly the commit's parent (no drift), so no conflict resolution was needed.
- One deviation from the original commit: the ported diff placed the new private `valid_ref?/1` helper between the two `skill_errors/2` function clauses in `agent.ex`, which trips the compiler's "clauses with the same name/arity should be grouped together" warning. This repo's CI runs `mix compile --warnings-as-errors`, so left as-is this would have broken the build. Fixed by moving `valid_ref?/1` after both `skill_errors/2` clauses — pure reordering, no behavior change, added as a separate commit on top of the cherry-pick.
- Verified `skills@latest` (the exact npm dist-tag this code invokes — there is no locally vendored/pinned version of the CLI in this repo) genuinely honors `owner/repo@ref`: ran `npx -y skills@latest add vercel-labs/agent-skills --list` (9 skills, default branch) vs `npx -y skills@latest add vercel-labs/agent-skills@deploy-to-vercel --list` (1 skill, matching that branch's content) against the real published package. Confirms the `@ref` resolution this change relies on is real behavior, not just the fork author's manual claim.
- Tests: scoped run (`agent_test.exs` + `sprite_skills_test.exs`) — 34 tests, 0 failures. Full suite — 1034 tests (3 properties), 0 failures.

## Attribution

Original implementation by lex00: [`issue-138-skills-ref`](https://github.com/lex00/fountain/tree/issue-138-skills-ref), commit [`6c30c95`](https://github.com/lex00/fountain/commit/6c30c959f8354d207c3741346f718b2f71fc1e56).