### PR TITLE
feat(api): bulk manifest apply endpoint + single-request CLI apply

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -82,6 +82,11 @@ defmodule Fountain.Agents do
     |> Repo.preload(:environment)
   end
 
+  @doc "Get agent by name scoped to user. Returns nil when missing."
+  def get_agent_by_name(name, user_id) when is_binary(name) and is_binary(user_id) do
+    Repo.get_by(Agent, name: name, user_id: user_id)
+  end
+
   def create_agent(attrs) do
     %Agent{}
     |> Agent.changeset(attrs)

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -58,7 +58,7 @@ defmodule Fountain.Agents.Agent do
     )
     |> validate_length(:name, min: 1, max: 200)
     |> validate_skills()
-    |> unique_constraint(:name)
+    |> unique_constraint(:name, name: :agents_user_id_name_index)
     |> foreign_key_constraint(:environment_id)
   end
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -136,7 +136,7 @@ defmodule Fountain.Conversations do
         order_by: [
           desc:
             fragment(
-              "GREATEST(COALESCE(?, ?::timestamptz), COALESCE(?, ?::timestamptz), ?::timestamptz)",
+              "GREATEST(COALESCE(? AT TIME ZONE 'UTC', ? AT TIME ZONE 'UTC'), COALESCE(? AT TIME ZONE 'UTC', ? AT TIME ZONE 'UTC'), ? AT TIME ZONE 'UTC')",
               ll.last_at,
               c.inserted_at,
               lt.last_at,
@@ -149,7 +149,7 @@ defmodule Fountain.Conversations do
           | turn_count: fragment("COALESCE(?, 0)", tc.count),
             last_active_at:
               fragment(
-                "GREATEST(COALESCE(?, ?::timestamptz), COALESCE(?, ?::timestamptz), ?::timestamptz)",
+                "GREATEST(COALESCE(? AT TIME ZONE 'UTC', ? AT TIME ZONE 'UTC'), COALESCE(? AT TIME ZONE 'UTC', ? AT TIME ZONE 'UTC'), ? AT TIME ZONE 'UTC')",
                 ll.last_at,
                 c.inserted_at,
                 lt.last_at,
@@ -291,7 +291,11 @@ defmodule Fountain.Conversations do
         select: %{
           c
           | last_active_at:
-              fragment("COALESCE(?, ?::timestamptz)", ll.last_at, c.inserted_at)
+              fragment(
+                "COALESCE(? AT TIME ZONE 'UTC', ? AT TIME ZONE 'UTC')",
+                ll.last_at,
+                c.inserted_at
+              )
         }
 
     query =

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -86,6 +86,11 @@ defmodule Fountain.Environments do
     Repo.get_by!(Environment, id: id, user_id: user_id)
   end
 
+  @doc "Get environment by name scoped to user. Returns nil when missing."
+  def get_environment_by_name(name, user_id) when is_binary(name) and is_binary(user_id) do
+    Repo.get_by(Environment, name: name, user_id: user_id)
+  end
+
   def create_environment(attrs) do
     %Environment{}
     |> Environment.changeset(attrs)

--- a/apps/fountain/lib/fountain/environments/environment.ex
+++ b/apps/fountain/lib/fountain/environments/environment.ex
@@ -60,7 +60,7 @@ defmodule Fountain.Environments.Environment do
     |> validate_change(:networking_config, &validate_networking_config/2)
     |> validate_change(:repositories, &validate_repositories/2)
     |> maybe_invalidate_checkpoint()
-    |> unique_constraint(:name)
+    |> unique_constraint(:name, name: :environments_user_id_name_index)
   end
 
   # If any provisioning-relevant field changed AND the caller didn't

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -1,0 +1,232 @@
+defmodule Fountain.Manifest do
+  @moduledoc """
+  Bulk apply for compiled IaC manifests (`fountain apply`).
+
+  Takes the full list of resources the CLI compiled from a `fountain.yml`
+  and reconciles them against the tenant's records in one pass:
+  environments first, then vaults, then agents — the same fixed ordering
+  `fountain apply` has always used, so an Agent doc can reference an
+  Environment by name regardless of document order. Agent `environment`
+  references resolve against environments in this manifest first, then
+  against the tenant's existing environments.
+
+  Application is best-effort per resource, mirroring the CLI's previous
+  one-call-per-resource behavior: a resource that fails validation is
+  reported in its result entry and does not stop the rest of the manifest.
+  """
+
+  alias Fountain.{Agents, Crypto, Environments, Vaults}
+
+  @kinds ~w(Environment Vault Agent)
+
+  # Ownership/identity fields are never taken from a manifest spec; secrets
+  # are split out and written through the envelope-encryption path instead.
+  @stripped_keys ~w(id user_id created_by secrets)
+
+  @doc """
+  Apply `resources` (maps with `"kind"`, `"name"`, and `"spec"`) for `user_id`.
+
+  Returns `{:ok, results}` with one result map per resource in apply order
+  (environments, vaults, agents, then any malformed entries). Each result
+  holds `:kind`, `:name`, an `:action` of `:created` / `:updated` / `:error`,
+  changeset-style `:errors` when the action is `:error`, and a `:secrets`
+  list with the per-key upsert outcome. Secret values are never echoed back.
+  """
+  def apply_manifest(user_id, resources) when is_binary(user_id) and is_list(resources) do
+    {valid, invalid} = Enum.split_with(resources, &valid_resource?/1)
+    groups = Enum.group_by(valid, & &1["kind"])
+    envs = Map.get(groups, "Environment", [])
+    vaults = Map.get(groups, "Vault", [])
+    agents = Map.get(groups, "Agent", [])
+
+    dek = if Enum.any?(envs ++ vaults, &has_secrets?/1), do: load_dek!(user_id)
+
+    {env_results, env_id_by_name} =
+      Enum.map_reduce(envs, %{}, fn res, acc ->
+        case apply_environment(user_id, res, dek) do
+          {result, nil} -> {result, acc}
+          {result, env} -> {result, Map.put(acc, env.name, env.id)}
+        end
+      end)
+
+    results =
+      env_results ++
+        Enum.map(vaults, &apply_vault(user_id, &1, dek)) ++
+        Enum.map(agents, &apply_agent(user_id, &1, env_id_by_name)) ++
+        Enum.map(invalid, &invalid_result/1)
+
+    {:ok, results}
+  end
+
+  # ── per-kind reconciliation ───────────────────────────────────────────────
+
+  defp apply_environment(user_id, %{"name" => name} = res, dek) do
+    {attrs, secrets} = split_spec(res, name)
+
+    outcome =
+      case Environments.get_environment_by_name(name, user_id) do
+        nil -> {:created, Environments.create_environment(Map.put(attrs, "user_id", user_id))}
+        env -> {:updated, Environments.update_environment(env, attrs)}
+      end
+
+    case outcome do
+      {action, {:ok, env}} ->
+        secret_results = upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek))
+        {result("Environment", name, action, nil, secret_results), env}
+
+      {_action, {:error, changeset}} ->
+        {result("Environment", name, :error, changeset_errors(changeset), []), nil}
+    end
+  end
+
+  defp apply_vault(user_id, %{"name" => name} = res, dek) do
+    {attrs, secrets} = split_spec(res, name)
+
+    outcome =
+      case Vaults.get_vault_by_name(name, user_id) do
+        nil -> {:created, Vaults.create_vault(Map.put(attrs, "user_id", user_id))}
+        vault -> {:updated, Vaults.update_vault(vault, attrs)}
+      end
+
+    case outcome do
+      {action, {:ok, vault}} ->
+        secret_results = upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek))
+        result("Vault", name, action, nil, secret_results)
+
+      {_action, {:error, changeset}} ->
+        result("Vault", name, :error, changeset_errors(changeset), [])
+    end
+  end
+
+  defp apply_agent(user_id, %{"name" => name} = res, env_id_by_name) do
+    {attrs, _secrets} = split_spec(res, name)
+    {env_ref, attrs} = Map.pop(attrs, "environment")
+
+    case resolve_environment_ref(user_id, env_ref, env_id_by_name) do
+      {:ok, env_attrs} ->
+        attrs = Map.merge(attrs, env_attrs)
+
+        outcome =
+          case Agents.get_agent_by_name(name, user_id) do
+            nil -> {:created, Agents.create_agent(Map.put(attrs, "user_id", user_id))}
+            agent -> {:updated, Agents.update_agent(agent, attrs)}
+          end
+
+        case outcome do
+          {action, {:ok, _agent}} -> result("Agent", name, action, nil, [])
+          {_action, {:error, cs}} -> result("Agent", name, :error, changeset_errors(cs), [])
+        end
+
+      {:error, ref} ->
+        errors = %{"environment" => ["environment not found: #{ref}"]}
+        result("Agent", name, :error, errors, [])
+    end
+  end
+
+  # Resolve an agent's `environment: <name>` reference: environments applied
+  # earlier in this manifest win, then the tenant's existing environments.
+  defp resolve_environment_ref(_user_id, ref, _env_id_by_name) when ref in [nil, ""],
+    do: {:ok, %{}}
+
+  defp resolve_environment_ref(user_id, ref, env_id_by_name) when is_binary(ref) do
+    case env_id_by_name[ref] || existing_env_id(user_id, ref) do
+      nil -> {:error, ref}
+      id -> {:ok, %{"environment_id" => id}}
+    end
+  end
+
+  defp resolve_environment_ref(_user_id, ref, _env_id_by_name), do: {:error, inspect(ref)}
+
+  defp existing_env_id(user_id, name) do
+    case Environments.get_environment_by_name(name, user_id) do
+      nil -> nil
+      env -> env.id
+    end
+  end
+
+  # ── secrets ───────────────────────────────────────────────────────────────
+
+  defp upsert_secrets(secrets, upsert_fun) do
+    secrets
+    |> Enum.sort_by(fn {key, _value} -> key end)
+    |> Enum.map(fn {key, value} ->
+      case normalize_secret_value(value) do
+        {:ok, plain} ->
+          case upsert_fun.(%{"key" => key, "value" => plain}) do
+            {:ok, _secret} -> %{key: key, action: :upserted, errors: nil}
+            {:error, cs} -> %{key: key, action: :error, errors: changeset_errors(cs)}
+          end
+
+        :error ->
+          %{key: key, action: :error, errors: %{"value" => ["must be a string"]}}
+      end
+    end)
+  end
+
+  defp normalize_secret_value(value) when is_binary(value), do: {:ok, value}
+
+  defp normalize_secret_value(value) when is_number(value) or is_boolean(value),
+    do: {:ok, to_string(value)}
+
+  defp normalize_secret_value(_value), do: :error
+
+  defp has_secrets?(%{"spec" => %{"secrets" => secrets}}) when is_map(secrets),
+    do: map_size(secrets) > 0
+
+  defp has_secrets?(_res), do: false
+
+  defp load_dek!(user_id) do
+    {:ok, dek} = Crypto.load_tenant_key(user_id)
+    dek
+  end
+
+  # ── helpers ───────────────────────────────────────────────────────────────
+
+  defp valid_resource?(%{"kind" => kind, "name" => name} = res)
+       when kind in @kinds and is_binary(name) and name != "" do
+    case Map.get(res, "spec") do
+      nil -> true
+      spec when is_map(spec) -> true
+      _other -> false
+    end
+  end
+
+  defp valid_resource?(_res), do: false
+
+  # The top-level resource name is authoritative — it is the upsert key, so
+  # it overrides any `name` a spec happens to carry.
+  defp split_spec(%{"spec" => spec}, name) when is_map(spec) do
+    secrets =
+      case Map.get(spec, "secrets") do
+        m when is_map(m) -> m
+        _other -> %{}
+      end
+
+    {spec |> Map.drop(@stripped_keys) |> Map.put("name", name), secrets}
+  end
+
+  defp split_spec(_res, name), do: {%{"name" => name}, %{}}
+
+  defp result(kind, name, action, errors, secrets) do
+    %{kind: kind, name: name, action: action, errors: errors, secrets: secrets}
+  end
+
+  defp invalid_result(res) do
+    errors = %{
+      "resource" => ["must have kind (Environment | Vault | Agent), name, and a map spec"]
+    }
+
+    result(str(res["kind"]), str(res["name"]), :error, errors, [])
+  end
+
+  defp str(value) when is_binary(value), do: value
+  defp str(_value), do: ""
+
+  defp changeset_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -78,6 +78,11 @@ defmodule Fountain.Vaults do
     Repo.get_by!(Vault, id: id, user_id: user_id)
   end
 
+  @doc "Get vault by name scoped to user. Returns nil when missing."
+  def get_vault_by_name(name, user_id) when is_binary(name) and is_binary(user_id) do
+    Repo.get_by(Vault, name: name, user_id: user_id)
+  end
+
   def create_vault(attrs) do
     %Vault{}
     |> Vault.changeset(attrs)

--- a/apps/fountain/lib/fountain/vaults/vault.ex
+++ b/apps/fountain/lib/fountain/vaults/vault.ex
@@ -22,6 +22,6 @@ defmodule Fountain.Vaults.Vault do
     |> cast(attrs, [:name, :description, :metadata, :user_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 200)
-    |> unique_constraint(:name)
+    |> unique_constraint(:name, name: :vaults_user_id_name_index)
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -1,0 +1,38 @@
+defmodule FountainWeb.ApplyController do
+  @moduledoc false
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Manifest
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Apply"])
+
+  operation(:create,
+    summary: "Apply a compiled manifest (bulk upsert)",
+    description:
+      "Applies all resources from a compiled fountain.yml manifest in one request. " <>
+        "Resources are reconciled by name — environments first, then vaults, then " <>
+        "agents — so agent specs may reference an environment by name via " <>
+        "`spec.environment`. Application is best-effort per resource: the response " <>
+        "is 200 even when individual resources fail, with per-resource errors in " <>
+        "the result entries.",
+    request_body: {"Compiled manifest", "application/json", Schemas.ApplyRequest},
+    responses: [
+      ok: {"Per-resource results", "application/json", Schemas.ApplyResponse},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.ChangesetError}
+    ]
+  )
+
+  def create(conn, %{"resources" => resources}) do
+    user = conn.assigns.current_user
+
+    with {:ok, results} <- Manifest.apply_manifest(user.id, resources) do
+      render(conn, :create, results: results)
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/apply_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_json.ex
@@ -1,0 +1,17 @@
+defmodule FountainWeb.ApplyJSON do
+  @moduledoc false
+
+  def create(%{results: results}) do
+    %{data: %{results: Enum.map(results, &result_json/1)}}
+  end
+
+  defp result_json(result) do
+    %{
+      kind: result.kind,
+      name: result.name,
+      action: result.action,
+      errors: result.errors,
+      secrets: Enum.map(result.secrets, &Map.take(&1, [:key, :action, :errors]))
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -155,6 +155,9 @@ defmodule FountainWeb.Router do
 
     resources "/agents", AgentController, except: [:new, :edit]
 
+    # Bulk apply for compiled fountain.yml manifests (`fountain apply`).
+    post "/apply", ApplyController, :create
+
     resources "/conversations", ConversationController, only: [:index, :show, :create, :delete] do
       post "/prompts", ConversationController, :prompt, as: :prompt
       post "/interrupt", ConversationController, :interrupt, as: :interrupt

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -796,6 +796,94 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule ManifestResource do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ManifestResource",
+      description:
+        "One compiled document from a fountain.yml manifest. `spec` matches the " <>
+          "create/update schema for the kind, plus an inline `secrets` map " <>
+          "(Environment and Vault). Agent specs may reference an environment by " <>
+          "name via `environment`; the server resolves it to `environment_id`.",
+      type: :object,
+      properties: %{
+        kind: %Schema{type: :string, enum: ["Environment", "Vault", "Agent"]},
+        name: %Schema{type: :string, minLength: 1, maxLength: 200},
+        spec: %Schema{type: :object, additionalProperties: true}
+      },
+      required: [:kind, :name]
+    })
+  end
+
+  defmodule ApplyRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ApplyRequest",
+      type: :object,
+      properties: %{
+        resources: %Schema{type: :array, items: ManifestResource}
+      },
+      required: [:resources]
+    })
+  end
+
+  defmodule ApplySecretResult do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ApplySecretResult",
+      description: "Outcome for one secret key. Values are never echoed back.",
+      type: :object,
+      properties: %{
+        key: %Schema{type: :string},
+        action: %Schema{type: :string, enum: ["upserted", "error"]},
+        errors: %Schema{type: :object, additionalProperties: true, nullable: true}
+      },
+      required: [:key, :action]
+    })
+  end
+
+  defmodule ApplyResult do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ApplyResult",
+      type: :object,
+      properties: %{
+        kind: %Schema{type: :string},
+        name: %Schema{type: :string},
+        action: %Schema{type: :string, enum: ["created", "updated", "error"]},
+        errors: %Schema{type: :object, additionalProperties: true, nullable: true},
+        secrets: %Schema{type: :array, items: ApplySecretResult}
+      },
+      required: [:kind, :name, :action]
+    })
+  end
+
+  defmodule ApplyResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ApplyResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{results: %Schema{type: :array, items: ApplyResult}},
+          required: [:results]
+        }
+      },
+      required: [:data]
+    })
+  end
+
   defmodule ChangesetError do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -15,11 +15,11 @@ spec:
   # ... fields matching the API schema for the kind ...
 ```
 
-The `metadata.name` is the upsert key. If a resource with that name exists, it's PUT; if not, it's POSTed.
+The `metadata.name` is the upsert key. If a resource with that name exists, it's updated; if not, it's created.
 
 ## Order is irrelevant inside the file
 
-`fountain apply` reconciles **environments first, vaults second, agents last** — so an agent doc can reference an environment by name (`spec.environment: my-env`) even if that environment is defined later in the file. Vaults aren't referenced from agents (they're picked per-conversation), so the order between envs and vaults doesn't matter functionally; the predictable ordering just makes the apply output easier to skim.
+`fountain apply` reconciles **environments first, vaults second, agents last** — so an agent doc can reference an environment by name (`spec.environment: my-env`) even if that environment is defined later in the file. The reference also resolves against environments that **already exist** server-side, so a manifest can attach an agent to an environment managed elsewhere; a name that matches neither the manifest nor an existing environment fails that agent doc. Vaults aren't referenced from agents (they're picked per-conversation), so the order between envs and vaults doesn't matter functionally; the predictable ordering just makes the apply output easier to skim.
 
 ## Example
 
@@ -83,9 +83,11 @@ agent  ~  researcher
 
 Errors per-resource go to stderr but don't stop the run; other resources still apply.
 
+Under the hood the CLI compiles the whole manifest into one document and sends it to `POST /api/apply` in a single request — the server reconciles everything and returns per-resource results. (Against older servers without that endpoint, the CLI falls back to one call per resource.)
+
 ## Idempotency
 
-Re-applying the same file is a no-op (every resource shows `~` because we always PUT, but the spec doesn't change). Useful for CI: keep `fountain.yml` in source control, run `fountain apply -f fountain.yml` from your deploy pipeline.
+Re-applying the same file is a no-op (every resource shows `~` because existing resources are always re-written, but the spec doesn't change). Useful for CI: keep `fountain.yml` in source control, run `fountain apply -f fountain.yml` from your deploy pipeline.
 
 ## Apply-time secret resolution (so you can commit `fountain.yml`)
 

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -1,0 +1,196 @@
+defmodule Fountain.ManifestTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.{Agents, Crypto, Environments, Manifest, Vaults}
+
+  setup do
+    %{user: insert_verified_user()}
+  end
+
+  defp env_resource(name, spec \\ %{}) do
+    %{"kind" => "Environment", "name" => name, "spec" => spec}
+  end
+
+  defp vault_resource(name, spec \\ %{}) do
+    %{"kind" => "Vault", "name" => name, "spec" => spec}
+  end
+
+  defp agent_resource(name, spec \\ %{}) do
+    spec =
+      Map.merge(%{"model" => "anthropic/claude-sonnet-4-6", "runtime" => "claude"}, spec)
+
+    %{"kind" => "Agent", "name" => name, "spec" => spec}
+  end
+
+  describe "apply_manifest/2 creation" do
+    test "creates environments, vaults, and agents with secrets", %{user: user} do
+      resources = [
+        agent_resource("researcher", %{"environment" => "proj"}),
+        vault_resource("alice", %{"secrets" => %{"GH" => "ghp_x", "NPM" => "npm_y"}}),
+        env_resource("proj", %{
+          "setup_script" => "echo hi",
+          "secrets" => %{"TOKEN" => "t0"}
+        })
+      ]
+
+      {:ok, results} = Manifest.apply_manifest(user.id, resources)
+
+      # Reconciliation order is envs, vaults, agents regardless of input order.
+      assert [
+               %{kind: "Environment", name: "proj", action: :created, secrets: [env_secret]},
+               %{kind: "Vault", name: "alice", action: :created, secrets: vault_secrets},
+               %{kind: "Agent", name: "researcher", action: :created}
+             ] = results
+
+      assert env_secret == %{key: "TOKEN", action: :upserted, errors: nil}
+      assert Enum.map(vault_secrets, & &1.key) == ["GH", "NPM"]
+
+      env = Environments.get_environment_by_name("proj", user.id)
+      assert env.setup_script == "echo hi"
+
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      assert Environments.decrypted_env(env, dek) == %{"TOKEN" => "t0"}
+
+      vault = Vaults.get_vault_by_name("alice", user.id)
+      assert Vaults.decrypted_env(vault, dek) == %{"GH" => "ghp_x", "NPM" => "npm_y"}
+
+      agent = Agents.get_agent_by_name("researcher", user.id)
+      assert agent.environment_id == env.id
+    end
+
+    test "coerces numeric and boolean secret values to strings", %{user: user} do
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          vault_resource("v", %{"secrets" => %{"PORT" => 5432, "DEBUG" => true}})
+        ])
+
+      assert [%{action: :created, secrets: secrets}] = results
+      assert Enum.all?(secrets, &(&1.action == :upserted))
+
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      vault = Vaults.get_vault_by_name("v", user.id)
+      assert Vaults.decrypted_env(vault, dek) == %{"PORT" => "5432", "DEBUG" => "true"}
+    end
+  end
+
+  describe "apply_manifest/2 updates" do
+    test "re-applying the same manifest is an idempotent update", %{user: user} do
+      resources = [
+        env_resource("proj", %{"secrets" => %{"TOKEN" => "t0"}}),
+        agent_resource("researcher", %{"environment" => "proj"})
+      ]
+
+      {:ok, _} = Manifest.apply_manifest(user.id, resources)
+      {:ok, results} = Manifest.apply_manifest(user.id, resources)
+
+      assert [
+               %{kind: "Environment", action: :updated, secrets: [%{action: :upserted}]},
+               %{kind: "Agent", action: :updated}
+             ] = results
+
+      assert length(Environments.list_environments(user.id)) == 1
+      assert length(Agents.list_agents(user.id, [])) == 1
+    end
+
+    test "agent can reference a pre-existing environment not in the manifest", %{user: user} do
+      env = insert_env(user_id: user.id, name: "existing-env")
+
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          agent_resource("a", %{"environment" => "existing-env"})
+        ])
+
+      assert [%{kind: "Agent", action: :created, errors: nil}] = results
+      assert Agents.get_agent_by_name("a", user.id).environment_id == env.id
+    end
+  end
+
+  describe "apply_manifest/2 errors" do
+    test "unknown environment reference fails that agent only", %{user: user} do
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          vault_resource("v"),
+          agent_resource("a", %{"environment" => "nope"})
+        ])
+
+      assert [
+               %{kind: "Vault", action: :created},
+               %{kind: "Agent", name: "a", action: :error, errors: errors}
+             ] = results
+
+      assert errors == %{"environment" => ["environment not found: nope"]}
+      assert Agents.get_agent_by_name("a", user.id) == nil
+    end
+
+    test "a failing resource does not stop the rest of the manifest", %{user: user} do
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          %{"kind" => "Agent", "name" => "broken", "spec" => %{"runtime" => "claude"}},
+          agent_resource("ok-agent")
+        ])
+
+      assert [
+               %{name: "broken", action: :error, errors: %{model: _}},
+               %{name: "ok-agent", action: :created}
+             ] = results
+    end
+
+    test "malformed resources are reported, not applied", %{user: user} do
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          %{"kind" => "Cluster", "name" => "x"},
+          %{"kind" => "Vault", "name" => ""},
+          vault_resource("good")
+        ])
+
+      assert [
+               %{kind: "Vault", name: "good", action: :created},
+               %{kind: "Cluster", name: "x", action: :error},
+               %{kind: "Vault", name: "", action: :error}
+             ] = results
+
+      assert Vaults.list_vaults(user.id) |> length() == 1
+    end
+
+    test "manifest specs cannot reassign ownership", %{user: user} do
+      other = insert_verified_user()
+
+      {:ok, [%{action: :created}]} =
+        Manifest.apply_manifest(user.id, [
+          vault_resource("mine", %{"user_id" => other.id, "id" => Ecto.UUID.generate()})
+        ])
+
+      assert [vault] = Vaults.list_vaults(user.id)
+      assert vault.user_id == user.id
+      assert Vaults.list_vaults(other.id) == []
+    end
+  end
+
+  describe "apply_manifest/2 tenant isolation" do
+    test "same-named resources of another tenant are not touched", %{user: user} do
+      other = insert_verified_user()
+      other_env = insert_env(user_id: other.id, name: "shared-name", setup_script: "original")
+
+      {:ok, [%{kind: "Environment", action: :created}]} =
+        Manifest.apply_manifest(user.id, [
+          env_resource("shared-name", %{"setup_script" => "mine"})
+        ])
+
+      assert Environments.get_environment_by_name("shared-name", user.id).setup_script == "mine"
+      assert Environments.get_environment!(other_env.id, other.id).setup_script == "original"
+    end
+
+    test "agent environment references cannot resolve to another tenant's environment",
+         %{user: user} do
+      other = insert_verified_user()
+      insert_env(user_id: other.id, name: "their-env")
+
+      {:ok, [%{kind: "Agent", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [
+          agent_resource("a", %{"environment" => "their-env"})
+        ])
+
+      assert errors == %{"environment" => ["environment not found: their-env"]}
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
@@ -1,0 +1,128 @@
+defmodule FountainWeb.ApplyControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.{Agents, Crypto, Environments, Vaults}
+
+  setup do
+    user = insert_verified_user()
+    {_key_record, raw_key} = insert_api_key(user)
+    {:ok, user: user, raw_key: raw_key}
+  end
+
+  describe "POST /api/apply" do
+    test "applies a full manifest in one request", %{conn: conn, user: user, raw_key: raw_key} do
+      payload = %{
+        "resources" => [
+          %{
+            "kind" => "Environment",
+            "name" => "proj",
+            "spec" => %{"setup_script" => "echo hi", "secrets" => %{"TOKEN" => "t0"}}
+          },
+          %{
+            "kind" => "Vault",
+            "name" => "alice",
+            "spec" => %{"secrets" => %{"GH" => "ghp_x"}}
+          },
+          %{
+            "kind" => "Agent",
+            "name" => "researcher",
+            "spec" => %{
+              "model" => "anthropic/claude-sonnet-4-6",
+              "runtime" => "claude",
+              "environment" => "proj"
+            }
+          }
+        ]
+      }
+
+      conn = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+
+      assert %{"data" => %{"results" => results}} = json_response(conn, 200)
+
+      assert [
+               %{
+                 "kind" => "Environment",
+                 "name" => "proj",
+                 "action" => "created",
+                 "errors" => nil,
+                 "secrets" => [%{"key" => "TOKEN", "action" => "upserted"}]
+               },
+               %{"kind" => "Vault", "name" => "alice", "action" => "created"},
+               %{"kind" => "Agent", "name" => "researcher", "action" => "created"}
+             ] = results
+
+      env = Environments.get_environment_by_name("proj", user.id)
+      assert env.setup_script == "echo hi"
+      assert Agents.get_agent_by_name("researcher", user.id).environment_id == env.id
+
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      assert Environments.decrypted_env(env, dek) == %{"TOKEN" => "t0"}
+      assert Vaults.decrypted_env(Vaults.get_vault_by_name("alice", user.id), dek) == %{"GH" => "ghp_x"}
+    end
+
+    test "never echoes secret values back", %{conn: conn, raw_key: raw_key} do
+      payload = %{
+        "resources" => [
+          %{"kind" => "Vault", "name" => "v", "spec" => %{"secrets" => %{"GH" => "sekrit-value"}}}
+        ]
+      }
+
+      conn = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+
+      assert json_response(conn, 200)
+      refute conn.resp_body =~ "sekrit-value"
+    end
+
+    test "re-apply reports updated actions", %{conn: conn, raw_key: raw_key} do
+      payload = %{
+        "resources" => [%{"kind" => "Vault", "name" => "v", "spec" => %{}}]
+      }
+
+      auth = fn conn -> authed_with_key(conn, raw_key) end
+      assert %{"data" => %{"results" => [%{"action" => "created"}]}} =
+               conn |> auth.() |> post_json(~p"/api/apply", payload) |> json_response(200)
+
+      assert %{"data" => %{"results" => [%{"action" => "updated"}]}} =
+               build_conn() |> auth.() |> post_json(~p"/api/apply", payload) |> json_response(200)
+    end
+
+    test "returns 200 with per-resource errors on partial failure", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      payload = %{
+        "resources" => [
+          %{"kind" => "Vault", "name" => "ok", "spec" => %{}},
+          %{"kind" => "Agent", "name" => "broken", "spec" => %{"runtime" => "claude"}}
+        ]
+      }
+
+      conn = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+
+      assert %{"data" => %{"results" => [vault_result, agent_result]}} = json_response(conn, 200)
+      assert vault_result["action"] == "created"
+      assert agent_result["action"] == "error"
+      assert %{"model" => _} = agent_result["errors"]
+      assert Vaults.get_vault_by_name("ok", user.id)
+      refute Agents.get_agent_by_name("broken", user.id)
+    end
+
+    test "rejects an invalid kind with 422", %{conn: conn, raw_key: raw_key} do
+      payload = %{"resources" => [%{"kind" => "Cluster", "name" => "x", "spec" => %{}}]}
+
+      conn = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+      assert conn.status == 422
+    end
+
+    test "rejects a payload without resources with 422", %{conn: conn, raw_key: raw_key} do
+      conn = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", %{})
+      assert conn.status == 422
+    end
+
+    test "requires authentication", %{conn: conn} do
+      conn = post_json(conn, ~p"/api/apply", %{"resources" => []})
+      assert conn.status == 401
+    end
+  end
+end

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -54,6 +54,130 @@ func runApply(cmd *cobra.Command, args []string) error {
 	envs, vaults = expandApplySecrets(envs, vaults, applyVars)
 
 	c := activeClient()
+
+	results, err := postApply(c, buildApplyPayload(envs, vaults, agents))
+	if err != nil {
+		if api.StatusCode(err) == 404 {
+			// Server predates POST /api/apply — reconcile resource-by-resource.
+			legacyApply(c, envs, vaults, agents)
+			return nil
+		}
+		Fatalf("apply failed: %v", err)
+	}
+
+	if renderApplyResults(results) {
+		os.Exit(1)
+	}
+	return nil
+}
+
+// ── bulk apply ─────────────────────────────────────────────────────────
+
+// applyResource is one compiled manifest document. The whole manifest is
+// sent to POST /api/apply in a single request; the server reconciles by
+// name (environments first, then vaults, then agents) and resolves agent
+// `spec.environment` references server-side — including environments that
+// already exist but aren't part of this manifest.
+type applyResource struct {
+	Kind string         `json:"kind"`
+	Name string         `json:"name"`
+	Spec map[string]any `json:"spec"`
+}
+
+type applySecretResult struct {
+	Key    string         `json:"key"`
+	Action string         `json:"action"`
+	Errors map[string]any `json:"errors"`
+}
+
+type applyResult struct {
+	Kind    string              `json:"kind"`
+	Name    string              `json:"name"`
+	Action  string              `json:"action"`
+	Errors  map[string]any      `json:"errors"`
+	Secrets []applySecretResult `json:"secrets"`
+}
+
+func buildApplyPayload(envs, vaults, agents []*manifest.Doc) []applyResource {
+	var out []applyResource
+	for _, group := range [][]*manifest.Doc{envs, vaults, agents} {
+		for _, d := range group {
+			name := requireName(d)
+			spec := cloneMap(d.Spec)
+			// Ownership fields are server-assigned; don't transmit fields the
+			// server is just going to drop.
+			delete(spec, "id")
+			delete(spec, "user_id")
+			delete(spec, "created_by")
+			out = append(out, applyResource{Kind: d.Kind, Name: name, Spec: spec})
+		}
+	}
+	return out
+}
+
+func postApply(c *api.Client, resources []applyResource) ([]applyResult, error) {
+	var resp struct {
+		Data struct {
+			Results []applyResult `json:"results"`
+		} `json:"data"`
+	}
+	body := map[string]any{"resources": resources}
+	if err := c.Post("/apply", body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data.Results, nil
+}
+
+var applyKindLabels = map[string]string{
+	"Environment": "env",
+	"Vault":       "vault",
+	"Agent":       "agent",
+}
+
+// renderApplyResults prints one line per resource in the same format the
+// per-resource loop used (`+` create, `~` update, `!` error to stderr) and
+// reports whether any resource or secret failed.
+func renderApplyResults(results []applyResult) (anyFailed bool) {
+	for _, r := range results {
+		label := applyKindLabels[r.Kind]
+		if label == "" {
+			label = strings.ToLower(r.Kind)
+		}
+		switch r.Action {
+		case "created":
+			fmt.Printf("%s  +  %s\n", label, r.Name)
+		case "updated":
+			fmt.Printf("%s  ~  %s\n", label, r.Name)
+		default:
+			anyFailed = true
+			warnf("%s  !  %s: %s", label, r.Name, formatResultErrors(r.Errors))
+		}
+		for _, s := range r.Secrets {
+			if s.Action == "upserted" {
+				fmt.Printf("  secret  ~  %s/%s\n", r.Name, s.Key)
+			} else {
+				anyFailed = true
+				warnf("  secret  !  %s/%s: %s", r.Name, s.Key, formatResultErrors(s.Errors))
+			}
+		}
+	}
+	return anyFailed
+}
+
+func formatResultErrors(errs map[string]any) string {
+	if len(errs) == 0 {
+		return "apply failed"
+	}
+	parts := make([]string, 0, len(errs))
+	for _, k := range sortedKeys(errs) {
+		parts = append(parts, fmt.Sprintf("%s: %v", k, errs[k]))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// legacyApply is the pre-bulk reconciliation path: one GET+write per
+// resource and one POST per secret. Kept for servers without /api/apply.
+func legacyApply(c *api.Client, envs, vaults, agents []*manifest.Doc) {
 	envIDByName := map[string]string{}
 	anyFailed := false
 
@@ -80,7 +204,6 @@ func runApply(cmd *cobra.Command, args []string) error {
 	if anyFailed {
 		os.Exit(1)
 	}
-	return nil
 }
 
 // ── grouping ───────────────────────────────────────────────────────────

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/manifest"
+)
+
+func doc(kind, name string, spec map[string]any) *manifest.Doc {
+	return &manifest.Doc{
+		APIVersion: "fountain/v1",
+		Kind:       kind,
+		Metadata:   map[string]any{"name": name},
+		Spec:       spec,
+	}
+}
+
+func TestBuildApplyPayloadOrdersAndStrips(t *testing.T) {
+	envs := []*manifest.Doc{doc("Environment", "proj", map[string]any{
+		"setup_script": "echo hi",
+		"secrets":      map[string]any{"TOKEN": "t0"},
+		"user_id":      "someone-else",
+		"created_by":   "mallory",
+		"id":           "forced-id",
+	})}
+	vaults := []*manifest.Doc{doc("Vault", "alice", nil)}
+	agents := []*manifest.Doc{doc("Agent", "researcher", map[string]any{
+		"runtime":     "claude",
+		"environment": "proj",
+	})}
+
+	// Payload order is envs, vaults, agents regardless of manifest order.
+	got := buildApplyPayload(envs, vaults, agents)
+
+	if len(got) != 3 {
+		t.Fatalf("want 3 resources, got %d", len(got))
+	}
+	if got[0].Kind != "Environment" || got[1].Kind != "Vault" || got[2].Kind != "Agent" {
+		t.Fatalf("wrong kind order: %v, %v, %v", got[0].Kind, got[1].Kind, got[2].Kind)
+	}
+
+	env := got[0]
+	if env.Name != "proj" {
+		t.Fatalf("want name proj, got %q", env.Name)
+	}
+	for _, k := range []string{"id", "user_id", "created_by"} {
+		if _, ok := env.Spec[k]; ok {
+			t.Errorf("ownership field %q must be stripped from spec", k)
+		}
+	}
+	// Secrets stay inline — the server splits them out and encrypts.
+	wantSecrets := map[string]any{"TOKEN": "t0"}
+	if !reflect.DeepEqual(env.Spec["secrets"], wantSecrets) {
+		t.Errorf("want inline secrets %v, got %v", wantSecrets, env.Spec["secrets"])
+	}
+
+	// The environment name reference is passed through for server-side resolution.
+	if got[2].Spec["environment"] != "proj" {
+		t.Errorf("agent environment reference must be preserved, got %v", got[2].Spec["environment"])
+	}
+
+	// A nil spec still yields a non-nil map so the JSON encodes as {}.
+	if got[1].Spec == nil {
+		t.Errorf("nil spec must be sent as an empty object")
+	}
+}
+
+func TestRenderApplyResultsFailureDetection(t *testing.T) {
+	cases := []struct {
+		name    string
+		results []applyResult
+		want    bool
+	}{
+		{"all ok", []applyResult{
+			{Kind: "Environment", Name: "e", Action: "created"},
+			{Kind: "Agent", Name: "a", Action: "updated"},
+		}, false},
+		{"resource error", []applyResult{
+			{Kind: "Agent", Name: "a", Action: "error", Errors: map[string]any{"model": []any{"can't be blank"}}},
+		}, true},
+		{"secret error", []applyResult{
+			{Kind: "Vault", Name: "v", Action: "created", Secrets: []applySecretResult{
+				{Key: "GH", Action: "error"},
+			}},
+		}, true},
+	}
+	for _, tc := range cases {
+		if got := renderApplyResults(tc.results); got != tc.want {
+			t.Errorf("%s: anyFailed = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestFormatResultErrors(t *testing.T) {
+	got := formatResultErrors(map[string]any{
+		"model":   []any{"can't be blank"},
+		"runtime": []any{"is invalid"},
+	})
+	want := "model: [can't be blank]; runtime: [is invalid]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if formatResultErrors(nil) != "apply failed" {
+		t.Errorf("nil errors should fall back to generic message")
+	}
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,6 +73,26 @@ DELETE /api/vaults/:id/secrets/:key
 
 The same write-only rule applies to vault secret values.
 
+## Bulk apply
+
+```
+POST   /api/apply                # apply a compiled manifest in one request
+```
+
+Takes the compiled form of a `fountain.yml` manifest — this is what `fountain apply` sends:
+
+```json
+{
+  "resources": [
+    {"kind": "Environment", "name": "proj", "spec": {"setup_script": "...", "secrets": {"TOKEN": "..."}}},
+    {"kind": "Vault", "name": "alice", "spec": {"secrets": {"GH": "..."}}},
+    {"kind": "Agent", "name": "researcher", "spec": {"model": "...", "runtime": "claude", "environment": "proj"}}
+  ]
+}
+```
+
+Resources are upserted by name in a fixed order (environments, then vaults, then agents), so an agent's `spec.environment` name reference resolves against environments in the same manifest **or** environments that already exist. Application is best-effort per resource: the response is always `200` with a per-resource result — `action` of `created`, `updated`, or `error` (with changeset-style `errors`), plus per-key secret outcomes. Secret values are never echoed back.
+
 ## Conversations
 
 Conversations are multi-turn: create one with an initial prompt, then keep prompting it.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,8 @@ fountain apply -f path/to/directory/    # walks all *.yml / *.yaml files
 
 Apply is idempotent - create if new, update if changed. Supported kinds: `Environment`, `Vault`, `Agent`.
 
+The CLI compiles every document into a single manifest and sends it to `POST /api/apply` in one request; the server reconciles environments, then vaults, then agents, and resolves agent `environment:` name references — including environments that already exist on the server. Against older servers without `/api/apply`, the CLI falls back to per-resource calls.
+
 ## Read resources
 
 ```bash


### PR DESCRIPTION
## Why

`fountain apply` reconciled a manifest with a fan-out of HTTP calls: one list-GET + one PUT/POST per resource, plus one POST per secret key. For a typical manifest that's dozens of round-trips, non-atomic name resolution done client-side, and agents that could only reference environments defined in the same manifest.

## What

**Server — `POST /api/apply`** (new, in the authenticated `:api` scope)

- Accepts the compiled manifest: `{"resources": [{"kind", "name", "spec"}, ...]}` (OpenAPI schemas included; request validated by CastAndValidate).
- `Fountain.Manifest.apply_manifest/2` reconciles by name in the fixed order **environments → vaults → agents** (same contract `fountain apply` documented), upserting each resource tenant-scoped and writing `spec.secrets` through the existing envelope-encryption path — DEK loaded once per request instead of per secret.
- Application is **best-effort per resource** (unchanged semantics from the per-call CLI flow): the response is always 200 with per-resource results — `created` / `updated` / `error` with changeset-style errors, plus per-key secret outcomes. Secret values are never echoed back.
- Agent `spec.environment` name references now resolve server-side, **including pre-existing environments not in the manifest**. Behavior change: a name that matches nothing now fails that agent doc; previously the CLI warned and silently dropped the reference.
- New tenant-scoped `get_agent_by_name/2`, `get_environment_by_name/2`, `get_vault_by_name/2`.

**CLI**

- `fountain apply` compiles all docs into one payload and makes a single `POST /api/apply`, rendering the same `+` / `~` / `!` output from the results; exits 1 if anything failed. Client-side `${VAR}` / `op://` / `bws://` / `infisical://` secret resolution is unchanged and still happens before the request.
- Falls back to the legacy per-resource loop when the server 404s the endpoint (older servers), so a new CLI works against a not-yet-deployed server.

**Drive-by fix**

- `unique_constraint(:name)` in the Agent/Environment/Vault schemas pointed at the single-column indexes that were dropped by the multi-tenant migration (`20260510100006`), so a duplicate-name race raised `Ecto.ConstraintError` (500) instead of a 422. Now pinned to `{table}_user_id_name_index`.

## Tests

- `Fountain.ManifestTest` (10 tests): create/update/idempotency, secret encryption round-trip, env-by-name resolution (manifest + pre-existing), per-resource error isolation, malformed resources, ownership stripping, cross-tenant isolation.
- `FountainWeb.ApplyControllerTest` (7 tests): full-manifest happy path, secret values never echoed, re-apply, partial failure, 422s, 401.
- `cli/internal/cmd/apply_test.go`: payload compilation (ordering, ownership stripping, inline secrets), result rendering failure detection, error formatting.

`mix precommit` fully green (1070 tests); `gofmt` / `go vet` / `go test ./...` all clean.

Also includes a second drive-by fix: the `last_active_at` query fragments cast naive UTC timestamps with `::timestamptz`, which resolves in the Postgres *session* timezone — deterministically wrong (and failing `conversations_context_test.exs:1880`) on any non-UTC Postgres, masked by CI's UTC server. Replaced with `AT TIME ZONE 'UTC'` on every naive operand.

Docs updated: `docs/api.md`, `docs/cli.md`, `priv/help/manifest.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
