### PR TITLE
test(manifest): pin that spec.metadata survives bulk apply

### DIFF
--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -71,6 +71,25 @@ defmodule Fountain.ManifestTest do
       vault = Vaults.get_vault_by_name("v", user.id)
       assert Vaults.decrypted_env(vault, dek) == %{"PORT" => "5432", "DEBUG" => "true"}
     end
+
+    # chant's fountain lexicon marks resources it manages with
+    # metadata."managed-by" and prunes by reading that marker back from the
+    # list endpoints — bulk apply must persist spec.metadata verbatim.
+    test "spec.metadata (e.g. chant's managed-by marker) survives apply", %{user: user} do
+      marker = %{"managed-by" => "chant"}
+
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          env_resource("e", %{"metadata" => marker}),
+          vault_resource("v", %{"metadata" => marker}),
+          agent_resource("a", %{"metadata" => marker})
+        ])
+
+      assert Enum.all?(results, &(&1.action == :created))
+      assert Environments.get_environment_by_name("e", user.id).metadata == marker
+      assert Vaults.get_vault_by_name("v", user.id).metadata == marker
+      assert Agents.get_agent_by_name("a", user.id).metadata == marker
+    end
   end
 
   describe "apply_manifest/2 updates" do


### PR DESCRIPTION
Adds one regression test to the bulk-apply suite: `spec.metadata` must pass through `apply_manifest/2` verbatim for all three kinds.

The apply path strips `id` / `user_id` / `created_by` / `secrets` from specs before they reach the changesets, and `metadata` is one careless edit away from joining that list. External tooling depends on the pass-through — chant's fountain lexicon (INTENTIUS/chant#1260) tags resources it manages with `metadata."managed-by": chant` and reads the marker back from the list endpoints to gate pruning. Nothing covered it until now.

Originally this PR also carried infra/docs changes for the chant integration (legacy `founta.inevitable.fyi` host alias + hostname cleanup); those were dropped — that work belongs elsewhere — leaving just the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)