### PR TITLE
config: split PUBLIC_URL from PHX_HOST so generated links are absolute

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,20 @@ MASTER_SECRETS_KEY=
 # Sprites platform token (never expose to tenants)
 SPRITES_TOKEN=
 
+# Externally-visible base URL, absolute and scheme-ful. Used to build links
+# that leave the app (verification and reset emails, llms.txt) and passed to
+# every sprite as FOUNTAIN_BASE_URL, so it must be resolvable from outside.
+# Defaults to http://localhost:4000.
+PUBLIC_URL=http://localhost:4000
+
+# Bare host for the endpoint URL and the LiveView check_origin allowlist.
+# Derived from PUBLIC_URL when unset, so most setups can leave it blank.
+# PHX_HOST=
+
+# Deprecated: FOUNTAIN_DOMAIN set both of the above and was used verbatim as
+# the base URL, which produced schemeless links when set to a bare host. Still
+# honoured as a fallback for both; prefer PUBLIC_URL / PHX_HOST.
+
 # GitHub OAuth (register at https://github.com/settings/developers)
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -854,7 +854,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp fountain_callback_env(token) do
-    base = Application.get_env(:fountain, :public_url)
+    base = Fountain.PublicUrl.base()
 
     if is_binary(base) and base != "" and is_binary(token) and token != "" do
       [{"FOUNTAIN_BASE_URL", base}, {"FOUNTAIN_TOKEN", token}]

--- a/apps/fountain/lib/fountain/emails/user_emails.ex
+++ b/apps/fountain/lib/fountain/emails/user_emails.ex
@@ -21,7 +21,7 @@ defmodule Fountain.Emails.UserEmails do
   @spec deliver_verification_email(User.t(), String.t()) ::
           {:ok, term()} | {:error, term()}
   def deliver_verification_email(%User{} = user, token) do
-    base_url = Application.get_env(:fountain, :public_url, "http://localhost:4000")
+    base_url = Fountain.PublicUrl.base()
     verify_url = "#{base_url}/users/confirm/#{token}"
 
     new()
@@ -41,7 +41,7 @@ defmodule Fountain.Emails.UserEmails do
   @spec deliver_password_reset_email(User.t(), String.t()) ::
           {:ok, term()} | {:error, term()}
   def deliver_password_reset_email(%User{} = user, token) do
-    base_url = Application.get_env(:fountain, :public_url, "http://localhost:4000")
+    base_url = Fountain.PublicUrl.base()
     reset_url = "#{base_url}/auth/reset/#{token}"
 
     new()

--- a/apps/fountain/lib/fountain/public_url.ex
+++ b/apps/fountain/lib/fountain/public_url.ex
@@ -1,0 +1,84 @@
+defmodule Fountain.PublicUrl do
+  @moduledoc """
+  Normalisation for the app's externally-visible base URL.
+
+  Two shapes are needed and they are not interchangeable:
+
+    * an absolute, scheme-ful URL for links that leave the app (verification
+      and reset emails, `llms.txt`) and for `FOUNTAIN_BASE_URL` inside sprites
+    * a bare host for the endpoint `:url` and `check_origin`
+
+  `FOUNTAIN_DOMAIN` historically supplied both, and every shipped example sets
+  it bare, so the absolute form came out schemeless. `PUBLIC_URL` / `PHX_HOST`
+  are the explicit replacements; the functions here accept either spelling so
+  existing deployments keep working.
+
+  Called from `config/runtime.exs`, so everything in here must be pure and must
+  not depend on any application having been started.
+  """
+
+  @default "http://localhost:4000"
+
+  @doc """
+  Build an absolute base URL from a configured value.
+
+  Accepts a bare host (`"example.com"`) or an already-absolute URL, and returns
+  an absolute URL with no trailing slash. `scheme` is the scheme to assume when
+  the input has none.
+
+      iex> Fountain.PublicUrl.absolute("example.com", "https")
+      "https://example.com"
+
+      iex> Fountain.PublicUrl.absolute("https://example.com/", "https")
+      "https://example.com"
+
+      iex> Fountain.PublicUrl.absolute(nil, "https")
+      "http://localhost:4000"
+  """
+  @spec absolute(String.t() | nil, String.t()) :: String.t()
+  def absolute(value, scheme \\ "https")
+
+  def absolute(blank, _scheme) when blank in [nil, ""], do: @default
+
+  def absolute(value, scheme) when is_binary(value) do
+    trimmed = value |> String.trim() |> String.trim_trailing("/")
+
+    cond do
+      trimmed == "" -> @default
+      String.starts_with?(trimmed, ["http://", "https://"]) -> trimmed
+      true -> scheme <> "://" <> trimmed
+    end
+  end
+
+  @doc """
+  Extract the bare host from a base URL, for the endpoint and `check_origin`.
+
+      iex> Fountain.PublicUrl.host("https://example.com")
+      "example.com"
+
+      iex> Fountain.PublicUrl.host("example.com")
+      "example.com"
+  """
+  @spec host(String.t() | nil) :: String.t()
+  def host(blank) when blank in [nil, ""], do: "localhost"
+
+  def host(value) when is_binary(value) do
+    value
+    |> absolute()
+    |> URI.parse()
+    |> Map.get(:host)
+    |> case do
+      nil -> "localhost"
+      "" -> "localhost"
+      host -> host
+    end
+  end
+
+  @doc "The configured absolute base URL. Safe to call at runtime."
+  @spec base() :: String.t()
+  def base do
+    :fountain
+    |> Application.get_env(:public_url, @default)
+    |> absolute()
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
@@ -152,10 +152,7 @@ defmodule FountainWeb.LlmsController do
 
   ## ─── Helpers ──────────────────────────────────────────────────────────────
 
-  defp base_url do
-    Application.get_env(:fountain, :public_url, "https://founta.inevitable.fyi")
-    |> String.trim_trailing("/")
-  end
+  defp base_url, do: Fountain.PublicUrl.base()
 
   defp send_text(conn, body) do
     conn

--- a/apps/fountain/test/fountain/emails/user_emails_test.exs
+++ b/apps/fountain/test/fountain/emails/user_emails_test.exs
@@ -40,6 +40,53 @@ defmodule Fountain.Emails.UserEmailsTest do
     end
   end
 
+  describe "link absoluteness" do
+    # These assert on the scheme, not just the path. The original tests only
+    # checked "/users/confirm/<token>", which passed happily while production
+    # was emitting "fountain.inevitable.fyi/users/confirm/<token>" — a string
+    # no mail client will render as a link.
+    setup do
+      original = Application.get_env(:fountain, :public_url)
+      on_exit(fn -> Application.put_env(:fountain, :public_url, original) end)
+      :ok
+    end
+
+    test "verification link is absolute even if :public_url is set to a bare host" do
+      Application.put_env(:fountain, :public_url, "fountain.example.com")
+      user = insert_verified_user()
+
+      assert {:ok, _} = UserEmails.deliver_verification_email(user, "tok")
+
+      assert_email_sent(fn email ->
+        assert email.html_body =~ "https://fountain.example.com/users/confirm/tok"
+        assert email.text_body =~ "https://fountain.example.com/users/confirm/tok"
+      end)
+    end
+
+    test "reset link is absolute even if :public_url is set to a bare host" do
+      Application.put_env(:fountain, :public_url, "fountain.example.com")
+      user = insert_verified_user()
+
+      assert {:ok, _} = UserEmails.deliver_password_reset_email(user, "tok")
+
+      assert_email_sent(fn email ->
+        assert email.html_body =~ "https://fountain.example.com/auth/reset/tok"
+        assert email.text_body =~ "https://fountain.example.com/auth/reset/tok"
+      end)
+    end
+
+    test "an absolute :public_url is preserved verbatim" do
+      Application.put_env(:fountain, :public_url, "https://custom.example.org")
+      user = insert_verified_user()
+
+      assert {:ok, _} = UserEmails.deliver_verification_email(user, "tok")
+
+      assert_email_sent(fn email ->
+        assert email.html_body =~ "https://custom.example.org/users/confirm/tok"
+      end)
+    end
+  end
+
   describe "deliver_password_reset_email/2" do
     test "delivers an email with the correct subject to the user" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain/public_url_test.exs
+++ b/apps/fountain/test/fountain/public_url_test.exs
@@ -1,0 +1,74 @@
+defmodule Fountain.PublicUrlTest do
+  @moduledoc """
+  Regression cover for the FOUNTAIN_DOMAIN defect: the variable was used both
+  as a bare host (endpoint) and as an absolute base URL (email links,
+  FOUNTAIN_BASE_URL in sprites), and every shipped example sets it bare — so
+  every generated link came out schemeless.
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Fountain.PublicUrl
+
+  alias Fountain.PublicUrl
+
+  describe "absolute/2" do
+    test "adds the scheme to a bare host — the shape every deploy example uses" do
+      assert PublicUrl.absolute("fountain.inevitable.fyi", "https") ==
+               "https://fountain.inevitable.fyi"
+    end
+
+    test "leaves an already-absolute URL alone" do
+      assert PublicUrl.absolute("https://example.com", "https") == "https://example.com"
+      assert PublicUrl.absolute("http://localhost:4000", "https") == "http://localhost:4000"
+    end
+
+    test "honours the requested scheme for bare hosts" do
+      assert PublicUrl.absolute("example.com", "http") == "http://example.com"
+    end
+
+    test "strips a trailing slash so callers can concatenate paths" do
+      assert PublicUrl.absolute("https://example.com/", "https") == "https://example.com"
+      assert PublicUrl.absolute("example.com/", "https") == "https://example.com"
+    end
+
+    test "falls back to the dev default when unset or blank" do
+      assert PublicUrl.absolute(nil, "https") == "http://localhost:4000"
+      assert PublicUrl.absolute("", "https") == "http://localhost:4000"
+      assert PublicUrl.absolute("   ", "https") == "http://localhost:4000"
+    end
+
+    test "keeps a port" do
+      assert PublicUrl.absolute("example.com:8080", "https") == "https://example.com:8080"
+    end
+  end
+
+  describe "host/1" do
+    test "extracts the bare host from an absolute URL" do
+      assert PublicUrl.host("https://fountain.inevitable.fyi") == "fountain.inevitable.fyi"
+    end
+
+    test "passes a bare host straight through" do
+      assert PublicUrl.host("fountain.inevitable.fyi") == "fountain.inevitable.fyi"
+    end
+
+    test "drops the port, which check_origin and endpoint :url set separately" do
+      assert PublicUrl.host("https://example.com:8080") == "example.com"
+    end
+
+    test "falls back to localhost when unset" do
+      assert PublicUrl.host(nil) == "localhost"
+      assert PublicUrl.host("") == "localhost"
+    end
+  end
+
+  describe "base/0" do
+    test "normalises whatever is in app env, even if set bare" do
+      original = Application.get_env(:fountain, :public_url)
+      on_exit(fn -> Application.put_env(:fountain, :public_url, original) end)
+
+      Application.put_env(:fountain, :public_url, "fountain.example.com")
+      assert PublicUrl.base() == "https://fountain.example.com"
+    end
+  end
+end

--- a/apps/fountain/test/fountain/runtime_config_test.exs
+++ b/apps/fountain/test/fountain/runtime_config_test.exs
@@ -1,0 +1,100 @@
+defmodule Fountain.RuntimeConfigTest do
+  @moduledoc """
+  Evaluates `config/runtime.exs` the way the release config provider does.
+
+  The FOUNTAIN_DOMAIN defect lived entirely in this file, so no unit test of
+  application code could have caught it: `:public_url` was set to a bare host
+  and every consumer faithfully produced schemeless links. These cases pin the
+  derivation itself, including the legacy spelling that production still uses.
+  """
+
+  # Mutates process env, so it must not run alongside anything else.
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+
+  @required %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db"
+  }
+
+  setup do
+    # A valid 32-byte key, or runtime.exs raises before reaching the URL logic.
+    key = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+    previous = System.get_env()
+
+    on_exit(fn ->
+      System.put_env(previous)
+
+      for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN),
+          not Map.has_key?(previous, k),
+          do: System.delete_env(k)
+    end)
+
+    {:ok, base: Map.put(@required, "MASTER_SECRETS_KEY", key)}
+  end
+
+  defp read_prod_config(env) do
+    for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN), do: System.delete_env(k)
+    System.put_env(env)
+    Config.Reader.read!(@runtime_exs, env: :prod)[:fountain]
+  end
+
+  test "a bare FOUNTAIN_DOMAIN still yields an absolute :public_url", %{base: base} do
+    # This is exactly what production sets today (k8s/deployment.yaml), and it
+    # is the case that was producing "fountain.inevitable.fyi/users/confirm/...".
+    cfg = read_prod_config(Map.put(base, "FOUNTAIN_DOMAIN", "fountain.example.com"))
+
+    assert cfg[:public_url] == "https://fountain.example.com"
+    assert cfg[:phx_host] == "fountain.example.com"
+  end
+
+  test "PUBLIC_URL and PHX_HOST are used when set", %{base: base} do
+    cfg =
+      base
+      |> Map.merge(%{
+        "PUBLIC_URL" => "https://app.example.com",
+        "PHX_HOST" => "internal.example.com"
+      })
+      |> read_prod_config()
+
+    assert cfg[:public_url] == "https://app.example.com"
+    assert cfg[:phx_host] == "internal.example.com"
+  end
+
+  test "PUBLIC_URL takes precedence over the legacy FOUNTAIN_DOMAIN", %{base: base} do
+    cfg =
+      base
+      |> Map.merge(%{
+        "PUBLIC_URL" => "https://new.example.com",
+        "FOUNTAIN_DOMAIN" => "old.example.com"
+      })
+      |> read_prod_config()
+
+    assert cfg[:public_url] == "https://new.example.com"
+  end
+
+  test "endpoint scheme and port follow PUBLIC_URL for plain-HTTP self-hosts", %{base: base} do
+    cfg = read_prod_config(Map.put(base, "PUBLIC_URL", "http://fountain.internal:4000"))
+
+    url = cfg[FountainWeb.Endpoint][:url]
+    assert url[:scheme] == "http"
+    assert url[:port] == 4000
+    assert url[:host] == "fountain.internal"
+  end
+
+  test "https keeps 443 so the hosted deployment is unchanged", %{base: base} do
+    cfg = read_prod_config(Map.put(base, "PUBLIC_URL", "https://fountain.example.com"))
+
+    url = cfg[FountainWeb.Endpoint][:url]
+    assert url[:scheme] == "https"
+    assert url[:port] == 443
+  end
+
+  test "check_origin lists the bare host", %{base: base} do
+    cfg = read_prod_config(Map.put(base, "PUBLIC_URL", "https://fountain.example.com"))
+
+    assert "//fountain.example.com" in cfg[FountainWeb.Endpoint][:check_origin]
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -61,7 +61,38 @@ master_secrets_key =
 
 config :fountain, :master_secrets_key, master_secrets_key
 config :fountain, :sprites_token, System.get_env("SPRITES_TOKEN")
-config :fountain, :public_url, System.get_env("FOUNTAIN_DOMAIN", "http://localhost:4000")
+
+# Two different shapes are needed and they are not interchangeable:
+#
+#   :public_url — absolute, scheme-ful. Used to build links that leave the app
+#                 (verification/reset emails, llms.txt) and as FOUNTAIN_BASE_URL
+#                 inside every sprite.
+#   :phx_host   — bare host. Used for the endpoint url and check_origin.
+#
+# `FOUNTAIN_DOMAIN` was used verbatim for both, and every shipped example sets
+# it bare (render.yaml, fly.toml, k8s/deployment.yaml), so :public_url came out
+# schemeless — "fountain.example.com/users/confirm/<token>" is not a link, and
+# a schemeless FOUNTAIN_BASE_URL is not resolvable by the in-sprite client.
+#
+# PUBLIC_URL and PHX_HOST are the explicit replacements. FOUNTAIN_DOMAIN still
+# works and is normalised into whichever shape is being asked for, so existing
+# deployments keep booting and get correct links without an env change.
+default_scheme = if env == :prod, do: "https", else: "http"
+
+public_url =
+  Fountain.PublicUrl.absolute(
+    System.get_env("PUBLIC_URL") || System.get_env("FOUNTAIN_DOMAIN"),
+    default_scheme
+  )
+
+phx_host =
+  case System.get_env("PHX_HOST") do
+    blank when blank in [nil, ""] -> Fountain.PublicUrl.host(public_url)
+    host -> host
+  end
+
+config :fountain, :public_url, public_url
+config :fountain, :phx_host, phx_host
 # Inference credentials are per-user (BYO, ADR 0008) and live in the
 # inference_credentials table — no platform-level env vars for them.
 
@@ -137,12 +168,18 @@ if config_env() == :prod and server? do
     System.get_env("SECRET_KEY_BASE") ||
       raise "environment variable SECRET_KEY_BASE is missing."
 
-  host = System.get_env("FOUNTAIN_DOMAIN") || "localhost"
+  host = phx_host
 
   config :fountain, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
+  # Scheme and port come from PUBLIC_URL rather than being pinned to https/443,
+  # so a self-hoster terminating on plain HTTP or a non-standard port generates
+  # correct URLs. For the hosted deployment PUBLIC_URL is https, and URI.parse
+  # fills in 443, so this is byte-identical to the previous hardcoding.
+  public_uri = URI.parse(public_url)
+
   config :fountain, FountainWeb.Endpoint,
-    url: [host: host, port: 443, scheme: "https"],
+    url: [host: host, port: public_uri.port || 443, scheme: public_uri.scheme || "https"],
     http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}],
     # check_origin guards the LiveView websocket/longpoll handshake. Setting an
     # explicit list replaces the default (the endpoint's own host), so we must

--- a/fly.toml
+++ b/fly.toml
@@ -28,7 +28,10 @@ primary_region = 'sea'
 [env]
   PHX_SERVER = 'true'
   PORT = '8080'
-  FOUNTAIN_DOMAIN = 'fountain.fly.dev'
+  # PUBLIC_URL: absolute base for outbound links + sprite FOUNTAIN_BASE_URL.
+  # PHX_HOST: bare host for the endpoint and check_origin.
+  PUBLIC_URL = 'https://fountain.fly.dev'
+  PHX_HOST = 'fountain.fly.dev'
   EMAIL_FROM = 'noreply@updates.inevitable.fyi'
   OTEL_TRACES_EXPORTER = 'none'
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -102,6 +102,17 @@ spec:
             # in the same commit as the Cloudflare record swap. The
             # Certificate (certificate.yaml) and IngressRoute
             # (ingressroute.yaml) must move together.
+            # PUBLIC_URL is the absolute base for outbound links (verification
+            # and reset emails, llms.txt) and for FOUNTAIN_BASE_URL inside every
+            # sprite. PHX_HOST is the bare host for the endpoint and
+            # check_origin. FOUNTAIN_DOMAIN used to serve both, which produced
+            # schemeless links; it is kept here only so a rollback to an image
+            # predating the split still boots with the right host, and can be
+            # dropped once the current image is settled.
+            - name: PUBLIC_URL
+              value: https://fountain.inevitable.fyi
+            - name: PHX_HOST
+              value: fountain.inevitable.fyi
             - name: FOUNTAIN_DOMAIN
               value: fountain.inevitable.fyi
             - name: EMAIL_FROM

--- a/render.yaml
+++ b/render.yaml
@@ -25,7 +25,11 @@ projects:
 
               - key: PHX_SERVER
                 value: "true"
-              - key: FOUNTAIN_DOMAIN
+              # PUBLIC_URL: absolute base for outbound links + sprite
+              # FOUNTAIN_BASE_URL. PHX_HOST: bare host for the endpoint.
+              - key: PUBLIC_URL
+                value: https://fountain.inevitable.fyi
+              - key: PHX_HOST
                 value: fountain.inevitable.fyi
               - key: PORT
                 value: "10000"


### PR DESCRIPTION
Closes #186.

## The defect

`FOUNTAIN_DOMAIN` fed two settings that need incompatible shapes:

- `config/runtime.exs:64` → `:public_url`, used **raw** to build links, so it must be scheme-ful
- `config/runtime.exs:140` → the endpoint host, which must be **bare**

Every shipped example sets it bare (`k8s/deployment.yaml:106`, `render.yaml:29`, `fly.toml:31`), so `:public_url` was a bare host.

**This is live in production.** With `FOUNTAIN_DOMAIN=fountain.inevitable.fyi`:

- `user_emails.ex:24` produces `fountain.inevitable.fyi/users/confirm/<token>` — no scheme, which no mail client renders as a link. Verification and password-reset emails are both affected, and unverified users cannot log in (`hooks.ex:49-53`), so this plausibly blocks password signups outright.
- `conversation_server.ex:857` passes the same value to **every sprite** as `FOUNTAIN_BASE_URL`. A schemeless base is not resolvable by the in-sprite client, so agent callbacks are affected too. This is the part I'd check first — it's a broader blast radius than the emails.

Worth confirming against a real signup and a real conversation before/after merge.

## The fix

New `Fountain.PublicUrl` normalises both shapes in one place, and `runtime.exs` now reads `PUBLIC_URL` (absolute) and `PHX_HOST` (bare).

`FOUNTAIN_DOMAIN` is still accepted and normalised into whichever shape is being asked for. That is deliberate: **merging fixes production with no deploy-time env change**, and self-hosters pinned to an older image keep booting. The manifests now set the new variables explicitly *and* retain `FOUNTAIN_DOMAIN`, so a rollback to a pre-split image still finds the host it expects; it can be dropped once the current image settles.

Also derives endpoint scheme/port from `PUBLIC_URL` rather than pinning `https`/`443`, so a self-hoster terminating on plain HTTP generates correct URLs (#184 territory). For the hosted deployment `URI.parse` fills in 443 and the output is byte-identical.

## Verification

Evaluated `runtime.exs` through `Config.Reader` exactly as the release config provider does, using production's **current** variables:

| Input | `:public_url` | `:phx_host` | endpoint `:url` |
|---|---|---|---|
| `FOUNTAIN_DOMAIN=fountain.example.com` (prod today) | `https://fountain.example.com` | `fountain.example.com` | https/443 |
| `PUBLIC_URL` + `PHX_HOST` set | `https://app.example.com` | `internal.example.com` | https/443 |
| `PUBLIC_URL=http://fountain.internal:4000` | unchanged | `fountain.internal` | **http/4000** |

Those cases are now a committed test (`runtime_config_test.exs`) rather than a one-off script. That matters here: this bug lived entirely in `runtime.exs`, where no unit test of application code could reach it — `:public_url` was simply wrong and every consumer faithfully propagated it.

The existing email tests asserted only `"/users/confirm/#{token}"`, which passed happily throughout. They now assert the scheme, and there is a case pinning that a bare `:public_url` still yields an absolute link.

Full suite: **1091 tests + 5 doctests, 0 failures** (baseline 1071). Format, `--warnings-as-errors`, and credo all clean.

## Not addressed here

`llms_controller.ex` previously defaulted to `https://founta.inevitable.fyi` while the CLI defaults to `https://fountain.inevitable.fyi` (`cli/internal/config/config.go:20`). That dead default is gone, but the underlying question of which hostname is canonical is left to #195 rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)