### PR TITLE
security: scope sprite callback tokens and add API key expiry

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -246,9 +246,9 @@ defmodule Fountain.Accounts do
 
   Returns `{:ok, {%ApiKey{}, raw_key_string}}` or `{:error, changeset}`.
   """
-  @spec create_api_key(binary(), String.t()) ::
+  @spec create_api_key(binary(), String.t(), keyword()) ::
           {:ok, {ApiKey.t(), String.t()}} | {:error, Ecto.Changeset.t()}
-  def create_api_key(user_id, name) when is_binary(user_id) and is_binary(name) do
+  def create_api_key(user_id, name, opts \\ []) when is_binary(user_id) and is_binary(name) do
     raw = "ftn_" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower)
     key_hash = hash_key(raw)
     key_prefix = String.slice(raw, 0, 8)
@@ -258,7 +258,9 @@ defmodule Fountain.Accounts do
       user_id: user_id,
       name: name,
       key_hash: key_hash,
-      key_prefix: key_prefix
+      key_prefix: key_prefix,
+      scopes: Keyword.get(opts, :scopes, ["full"]),
+      expires_at: Keyword.get(opts, :expires_at)
     })
     |> Repo.insert()
     |> case do
@@ -301,8 +303,26 @@ defmodule Fountain.Accounts do
   401.
   """
   @spec get_user_by_api_key(String.t()) ::
-          {:ok, User.t()} | {:error, :revoked | :not_found}
+          {:ok, User.t()} | {:error, :revoked | :expired | :not_found}
   def get_user_by_api_key(raw_key) when is_binary(raw_key) do
+    case authenticate_api_key(raw_key) do
+      {:ok, user, _key} -> {:ok, user}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
+  Authenticate a raw API key and return the key record alongside the user.
+
+  The auth plug needs the record, not just the user: scope is carried on the key,
+  so a caller holding a sandbox token is otherwise indistinguishable from the
+  human who owns the tenant.
+
+  Returns `{:ok, user, api_key}`, or `{:error, :revoked | :expired | :not_found}`.
+  """
+  @spec authenticate_api_key(String.t()) ::
+          {:ok, User.t(), ApiKey.t()} | {:error, :revoked | :expired | :not_found}
+  def authenticate_api_key(raw_key) when is_binary(raw_key) do
     key_hash = hash_key(raw_key)
 
     query =
@@ -312,9 +332,14 @@ defmodule Fountain.Accounts do
         preload: [user: u]
 
     case Repo.one(query) do
-      nil -> {:error, :not_found}
-      %ApiKey{revoked_at: nil} = key -> {:ok, key.user}
-      %ApiKey{} -> {:error, :revoked}
+      nil ->
+        {:error, :not_found}
+
+      %ApiKey{revoked_at: revoked} when not is_nil(revoked) ->
+        {:error, :revoked}
+
+      %ApiKey{} = key ->
+        if ApiKey.expired?(key), do: {:error, :expired}, else: {:ok, key.user, key}
     end
   end
 

--- a/apps/fountain/lib/fountain/accounts/api_key.ex
+++ b/apps/fountain/lib/fountain/accounts/api_key.ex
@@ -5,16 +5,52 @@ defmodule Fountain.Accounts.ApiKey do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
+  @moduledoc """
+  A tenant API key.
+
+  ## Scopes
+
+    * `"full"`   — everything, including issuing and revoking API keys. What a
+      human gets from the UI or `fountain keys create`.
+    * `"sprite"` — the per-conversation token handed to a sandbox. Deliberately
+      permits the normal resource surface, because spawning sub-agents from
+      inside a sprite is a supported workflow, but **not** API key management:
+      without that exclusion, code running in a sandbox can mint a permanent
+      key that survives the conversation-scoped revoke at teardown, turning a
+      one-conversation credential into standing tenant access.
+  """
+
+  @scopes ~w(full sprite)
+
+  # Scopes permitted to issue, list, or revoke API keys.
+  @key_management_scopes ~w(full)
+
   schema "api_keys" do
     field :name, :string
     field :key_hash, :string
     field :key_prefix, :string
     field :last_used_at, :utc_datetime
     field :revoked_at, :utc_datetime
+    field :expires_at, :utc_datetime
+    field :scopes, {:array, :string}, default: ["full"]
 
     belongs_to :user, Fountain.Accounts.User
 
     timestamps(type: :utc_datetime)
+  end
+
+  def scopes, do: @scopes
+
+  @doc "Whether `key` may issue, list, or revoke API keys."
+  def may_manage_keys?(%__MODULE__{scopes: scopes}) do
+    Enum.any?(scopes, &(&1 in @key_management_scopes))
+  end
+
+  @doc "Whether `key` is past its expiry. Keys without one never expire."
+  def expired?(%__MODULE__{expires_at: nil}), do: false
+
+  def expired?(%__MODULE__{expires_at: at}) do
+    DateTime.compare(DateTime.utc_now(), at) == :gt
   end
 
   @doc """
@@ -25,9 +61,11 @@ defmodule Fountain.Accounts.ApiKey do
   """
   def changeset(api_key, attrs) do
     api_key
-    |> cast(attrs, [:name, :key_hash, :key_prefix, :user_id])
-    |> validate_required([:name, :key_hash, :key_prefix, :user_id])
+    |> cast(attrs, [:name, :key_hash, :key_prefix, :user_id, :scopes, :expires_at])
+    |> validate_required([:name, :key_hash, :key_prefix, :user_id, :scopes])
     |> validate_length(:name, min: 1, max: 200)
+    |> validate_length(:scopes, min: 1)
+    |> validate_subset(:scopes, @scopes)
     |> unique_constraint(:key_hash)
     |> foreign_key_constraint(:user_id)
   end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -13,7 +13,18 @@ defmodule Fountain.Conversations.ConversationServer do
   require Logger
   require OpenTelemetry.Tracer
 
-  alias Fountain.{Accounts, Agents, Conversations, Crypto, Environments, InferenceCredentials, SpritesClient, Substitution, Vaults}
+  alias Fountain.{
+    Accounts,
+    Agents,
+    Conversations,
+    Crypto,
+    Environments,
+    InferenceCredentials,
+    SpritesClient,
+    Substitution,
+    Vaults
+  }
+
   alias Fountain.Conversations.Conversation
 
   # ── public api ────────────────────────────────────────────────────────────
@@ -139,7 +150,11 @@ defmodule Fountain.Conversations.ConversationServer do
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     sandbox = Conversations.get_sandbox!(state.sandbox_id)
     agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id), else: nil
-    env = if agent && agent.environment_id, do: Environments._unsafe_get_environment(agent.environment_id)
+
+    env =
+      if agent && agent.environment_id,
+        do: Environments._unsafe_get_environment(agent.environment_id)
+
     vault = if conv.vault_id, do: Vaults._unsafe_get_vault(conv.vault_id)
 
     case load_tenant_state(conv.user_id) do
@@ -147,7 +162,13 @@ defmodule Fountain.Conversations.ConversationServer do
         secrets = merge_secrets(env, vault, dek)
 
         state =
-          %{state | user_id: conv.user_id, runtime_session_id: conv.runtime_session_id, tenant_key: dek, inference_credentials: inference_creds}
+          %{
+            state
+            | user_id: conv.user_id,
+              runtime_session_id: conv.runtime_session_id,
+              tenant_key: dek,
+              inference_credentials: inference_creds
+          }
 
         dispatch_provision(state, conv, sandbox, agent, env, vault, secrets)
 
@@ -576,7 +597,9 @@ defmodule Fountain.Conversations.ConversationServer do
   # Inject the current conversation ID so the bundled fountain skill can
   # propagate it as X-Fountain-Parent-Conversation-Id when spawning children.
   defp conversation_env(nil), do: []
-  defp conversation_env(conv_id) when is_binary(conv_id), do: [{"FOUNTAIN_CONVERSATION_ID", conv_id}]
+
+  defp conversation_env(conv_id) when is_binary(conv_id),
+    do: [{"FOUNTAIN_CONVERSATION_ID", conv_id}]
 
   @doc false
   def git_author_env do
@@ -863,6 +886,46 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
+  # How long a sprite's callback key stays valid.
+  #
+  # This is a backstop, not the primary control: the key is revoked at
+  # terminate/2 and rotated on every provision and reattach, so under normal
+  # operation it is replaced long before expiry. It exists for the hard-crash
+  # case, where the row is orphaned and would otherwise be valid forever.
+  #
+  # The default is deliberately generous. The token is only rotated on provision
+  # and reattach, so a TTL shorter than the longest continuously-running
+  # conversation would expire a token mid-flight and break the agent's callbacks
+  # — a worse failure than a long-lived orphan. Lower it if conversations in your
+  # deployment are short.
+  @default_callback_key_ttl_seconds 30 * 24 * 60 * 60
+
+  defp callback_key_ttl_seconds do
+    Application.get_env(:fountain, :callback_key_ttl_seconds, @default_callback_key_ttl_seconds)
+  end
+
+  @doc """
+  Options used when minting a sprite's callback key.
+
+  `"sprite"` scope, not full: the sandbox can stream, prompt and spawn
+  sub-agents, but cannot mint a key that would survive the revoke at teardown.
+  The expiry is a backstop for the orphan case — if the BEAM dies hard the row
+  is never revoked, and without it the key stays valid forever.
+
+  Public so the scope and expiry can be asserted directly: this module has no
+  test coverage of its own (#192), and an unscoped callback token is the
+  privilege-escalation path the scoping exists to close.
+  """
+  def callback_api_key_opts do
+    [
+      scopes: ["sprite"],
+      expires_at:
+        DateTime.utc_now()
+        |> DateTime.add(callback_key_ttl_seconds(), :second)
+        |> DateTime.truncate(:second)
+    ]
+  end
+
   # Issue a fresh per-conversation API key scoped to the conversation
   # owner, revoking any prior one. The plaintext is only kept in
   # `state.callback_token` — the durable record is a hash in `api_keys`,
@@ -873,7 +936,11 @@ defmodule Fountain.Conversations.ConversationServer do
       _ = Accounts.revoke_api_key(conv.user_id, id)
     end
 
-    case Accounts.create_api_key(conv.user_id, "sprite:#{String.slice(conv.id, 0, 8)}") do
+    case Accounts.create_api_key(
+           conv.user_id,
+           "sprite:#{String.slice(conv.id, 0, 8)}",
+           callback_api_key_opts()
+         ) do
       {:ok, {%Accounts.ApiKey{id: key_id}, raw}} ->
         {:ok, conv} = Conversations.update_conversation(conv, %{callback_api_key_id: key_id})
         {%{state | callback_token: raw}, conv}
@@ -946,7 +1013,9 @@ defmodule Fountain.Conversations.ConversationServer do
       end
 
     {cmd, args, build_opts} =
-      state.runtime_module.build_command(agent, prompt, mode, runtime_session_id, [images: image_paths])
+      state.runtime_module.build_command(agent, prompt, mode, runtime_session_id,
+        images: image_paths
+      )
 
     # If a runtime embeds the prompt in argv (codex), it returns
     # `stdin?: false` and we skip the Sprites.write/close_stdin pipeline.

--- a/apps/fountain/lib/fountain_web/controllers/api_key_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/api_key_json.ex
@@ -23,7 +23,12 @@ defmodule FountainWeb.ApiKeyJSON do
       name: key.name,
       prefix: key.key_prefix,
       created_at: key.inserted_at,
-      last_used_at: key.last_used_at
+      last_used_at: key.last_used_at,
+      # A tenant's list is mostly auto-issued `sprite:*` conversation tokens.
+      # Surfacing scope and expiry is what makes those distinguishable from a
+      # key the user created and is responsible for.
+      scopes: key.scopes,
+      expires_at: key.expires_at
     }
   end
 end

--- a/apps/fountain/lib/fountain_web/plugs/require_key_management.ex
+++ b/apps/fountain/lib/fountain_web/plugs/require_key_management.ex
@@ -1,0 +1,49 @@
+defmodule FountainWeb.Plugs.RequireKeyManagement do
+  @moduledoc """
+  Restricts API key issuance, listing and revocation to keys scoped for it.
+
+  Every conversation hands its sprite a tenant API key so the agent can stream,
+  prompt, and spawn sub-agents. Before scoping existed those tokens were
+  unrestricted, so code running in a sandbox could call
+  `POST /api/auth/api-keys` and mint a second key — one that the
+  conversation-scoped revoke at teardown knows nothing about, and which
+  therefore outlives the conversation as standing tenant access.
+
+  Sandboxes run untrusted code by design, so that path has to be closed at the
+  boundary rather than trusted not to be walked.
+
+  Session-authenticated browser routes never reach this plug; it guards the
+  bearer-token API pipeline only.
+  """
+
+  import Plug.Conn
+  import Phoenix.Controller, only: [json: 2]
+
+  alias Fountain.Accounts.ApiKey
+
+  def init(opts), do: opts
+
+  def call(%{assigns: %{current_api_key: %ApiKey{} = key}} = conn, _opts) do
+    if ApiKey.may_manage_keys?(key) do
+      conn
+    else
+      conn
+      |> put_status(:forbidden)
+      |> json(%{
+        error: "This API key is not permitted to manage API keys",
+        reason: "insufficient_scope",
+        required_scope: "full"
+      })
+      |> halt()
+    end
+  end
+
+  # No key on the connection means this ran outside the bearer-token pipeline.
+  # Fail closed rather than assume the caller is privileged.
+  def call(conn, _opts) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{error: "API key scope could not be determined", reason: "insufficient_scope"})
+    |> halt()
+  end
+end

--- a/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
+++ b/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
@@ -25,12 +25,20 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
   def call(conn, _opts) do
     with [auth_header] <- get_req_header(conn, "authorization"),
          "Bearer " <> raw_key <- auth_header,
-         {:ok, user} <- Accounts.get_user_by_api_key(raw_key) do
+         {:ok, user, api_key} <- Accounts.authenticate_api_key(raw_key) do
       Task.async(fn -> Accounts.touch_api_key(raw_key) end)
-      assign(conn, :current_user, user)
+
+      conn
+      |> assign(:current_user, user)
+      # Scope lives on the key, so downstream guards need the record — a sandbox
+      # token is otherwise indistinguishable from the tenant's own key.
+      |> assign(:current_api_key, api_key)
     else
       {:error, :revoked} ->
         unauthorized(conn, "API key has been revoked", "api_key_revoked")
+
+      {:error, :expired} ->
+        unauthorized(conn, "API key has expired", "api_key_expired")
 
       _ ->
         unauthorized(conn, "Invalid or missing API key", "api_key_invalid")

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -44,6 +44,11 @@ defmodule FountainWeb.Router do
     plug FountainWeb.Plugs.OptionalSessionAuth
   end
 
+  # Layered on top of :api for routes that manage API keys themselves.
+  pipeline :require_key_management do
+    plug FountainWeb.Plugs.RequireKeyManagement
+  end
+
   ## ─── Public routes ────────────────────────────────────────────────────────────────────
 
   scope "/", FountainWeb do
@@ -137,6 +142,13 @@ defmodule FountainWeb.Router do
     pipe_through :api
 
     get "/me", AuthMeController, :show
+  end
+
+  # Key management is scope-gated: the per-conversation token a sprite holds
+  # must not be able to mint a second key that survives conversation teardown.
+  scope "/api/auth", FountainWeb do
+    pipe_through [:api, :require_key_management]
+
     get "/api-keys", ApiKeyController, :index
     post "/api-keys", ApiKeyController, :create
     delete "/api-keys/:id", ApiKeyController, :delete

--- a/apps/fountain/priv/repo/migrations/20260801000000_add_scopes_and_expiry_to_api_keys.exs
+++ b/apps/fountain/priv/repo/migrations/20260801000000_add_scopes_and_expiry_to_api_keys.exs
@@ -1,0 +1,28 @@
+defmodule Fountain.Repo.Migrations.AddScopesAndExpiryToApiKeys do
+  use Ecto.Migration
+
+  # Every key was previously unrestricted, including the per-conversation token
+  # handed to each sprite — which meant code running in a sandbox could mint
+  # itself a second, permanent key that outlived the conversation.
+  #
+  # Existing rows backfill to ["full"] so behaviour is unchanged on deploy;
+  # only newly issued sprite tokens get the narrower scope.
+  def up do
+    alter table(:api_keys) do
+      add :scopes, {:array, :string}, null: false, default: ["full"]
+      add :expires_at, :utc_datetime
+    end
+
+    # Auth looks up by hash and then filters on expiry.
+    create index(:api_keys, [:expires_at])
+  end
+
+  def down do
+    drop index(:api_keys, [:expires_at])
+
+    alter table(:api_keys) do
+      remove :scopes
+      remove :expires_at
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/api_key_scope_test.exs
+++ b/apps/fountain/test/fountain_web/api_key_scope_test.exs
@@ -1,0 +1,243 @@
+defmodule FountainWeb.ApiKeyScopeTest do
+  @moduledoc """
+  Privilege-escalation cover for the sandbox callback token.
+
+  Every conversation hands its sprite a tenant API key. Before scoping, that key
+  was unrestricted, so code running in a sandbox could mint a second key — one
+  the conversation-scoped revoke at teardown knows nothing about — and hold
+  standing tenant access long after the conversation ended.
+  """
+
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.Accounts
+  alias Fountain.Accounts.ApiKey
+
+  describe "sprite-scoped keys cannot manage API keys" do
+    setup do
+      user = insert_verified_user()
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+      {:ok, user: user, sprite_key: sprite_key}
+    end
+
+    test "POST /api/auth/api-keys is forbidden — the escalation path", %{
+      conn: conn,
+      sprite_key: key
+    } do
+      conn =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/auth/api-keys", %{"name" => "escalated"})
+
+      body = json_response(conn, 403)
+      assert body["reason"] == "insufficient_scope"
+    end
+
+    test "no key is created when the attempt is refused", %{
+      conn: conn,
+      user: user,
+      sprite_key: key
+    } do
+      before = length(Accounts.list_api_keys(user.id))
+
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/auth/api-keys", %{"name" => "escalated"})
+      |> json_response(403)
+
+      assert length(Accounts.list_api_keys(user.id)) == before
+    end
+
+    test "GET /api/auth/api-keys is forbidden", %{conn: conn, sprite_key: key} do
+      conn = conn |> authed_with_key(key) |> get("/api/auth/api-keys")
+      assert json_response(conn, 403)["reason"] == "insufficient_scope"
+    end
+
+    test "DELETE /api/auth/api-keys/:id is forbidden", %{conn: conn, user: user, sprite_key: key} do
+      {victim, _raw} = insert_api_key(user, "victim")
+
+      conn = conn |> authed_with_key(key) |> delete("/api/auth/api-keys/#{victim.id}")
+      assert json_response(conn, 403)["reason"] == "insufficient_scope"
+
+      # And it is genuinely still usable, not merely un-listed.
+      assert {:ok, _user, _key} =
+               Accounts.authenticate_api_key(elem(insert_api_key(user, "probe"), 1))
+
+      refute Accounts.list_api_keys(user.id) |> Enum.find(&(&1.id == victim.id)) |> is_nil()
+    end
+  end
+
+  describe "sprite-scoped keys keep the access they legitimately need" do
+    # Spawning sub-agents from inside a sprite is a supported workflow
+    # (/help/spawning), so scoping must not reduce these tokens to read-only.
+    setup do
+      user = insert_verified_user()
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+      {:ok, user: user, sprite_key: sprite_key}
+    end
+
+    test "can read /api/auth/me", %{conn: conn, sprite_key: key} do
+      conn = conn |> authed_with_key(key) |> get("/api/auth/me")
+      assert json_response(conn, 200)
+    end
+
+    test "can list and create resources", %{conn: conn, sprite_key: key} do
+      assert conn |> authed_with_key(key) |> get("/api/agents") |> json_response(200)
+
+      created =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/environments", %{"name" => "from-sprite"})
+        |> json_response(201)
+
+      assert created["data"]["name"] == "from-sprite"
+    end
+
+    test "can spawn a sub-agent conversation", %{conn: conn, user: user, sprite_key: key} do
+      agent = insert_agent(user_id: user.id)
+      stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+      conn =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/conversations", %{"agent_id" => agent.id})
+
+      assert json_response(conn, 201)
+    end
+  end
+
+  describe "full-scoped keys are unaffected" do
+    test "can still create, list and revoke", %{conn: conn} do
+      user = insert_verified_user()
+      {_rec, key} = insert_api_key(user)
+
+      created =
+        conn |> authed_with_key(key) |> post_json("/api/auth/api-keys", %{"name" => "ci"})
+
+      assert json_response(created, 201)
+      assert conn |> authed_with_key(key) |> get("/api/auth/api-keys") |> json_response(200)
+    end
+
+    test "keys default to full scope so existing keys keep working" do
+      user = insert_verified_user()
+      {record, _raw} = insert_api_key(user)
+
+      assert record.scopes == ["full"]
+      assert ApiKey.may_manage_keys?(record)
+    end
+  end
+
+  describe "expiry" do
+    test "an expired key is rejected with a distinguishable reason", %{conn: conn} do
+      user = insert_verified_user()
+
+      {_rec, key} =
+        insert_api_key(user, "stale",
+          expires_at:
+            DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.truncate(:second)
+        )
+
+      conn = conn |> authed_with_key(key) |> get("/api/agents")
+
+      body = json_response(conn, 401)
+      assert body["reason"] == "api_key_expired"
+    end
+
+    test "a key expiring in the future still works", %{conn: conn} do
+      user = insert_verified_user()
+
+      {_rec, key} =
+        insert_api_key(user, "fresh",
+          expires_at:
+            DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+        )
+
+      assert conn |> authed_with_key(key) |> get("/api/agents") |> json_response(200)
+    end
+
+    test "a key with no expiry never expires" do
+      user = insert_verified_user()
+      {record, _raw} = insert_api_key(user)
+
+      assert record.expires_at == nil
+      refute ApiKey.expired?(record)
+    end
+
+    test "revocation still takes precedence over expiry", %{conn: conn} do
+      user = insert_verified_user()
+      {record, key} = insert_api_key(user, "revoked")
+      {:ok, _} = Accounts.revoke_api_key(user.id, record.id)
+
+      conn = conn |> authed_with_key(key) |> get("/api/agents")
+      assert json_response(conn, 401)["reason"] == "api_key_revoked"
+    end
+  end
+
+  describe "sprite callback tokens as actually minted" do
+    alias Fountain.Conversations.ConversationServer
+
+    test "carry the sprite scope, not full" do
+      assert Keyword.fetch!(ConversationServer.callback_api_key_opts(), :scopes) == ["sprite"]
+    end
+
+    test "carry an expiry so a token orphaned by a hard crash does not live forever" do
+      expires_at = Keyword.fetch!(ConversationServer.callback_api_key_opts(), :expires_at)
+
+      assert DateTime.compare(expires_at, DateTime.utc_now()) == :gt
+    end
+
+    test "a key minted with those options cannot manage keys", %{conn: conn} do
+      user = insert_verified_user()
+
+      {:ok, {_rec, raw}} =
+        Accounts.create_api_key(user.id, "sprite:test", ConversationServer.callback_api_key_opts())
+
+      conn =
+        conn
+        |> authed_with_key(raw)
+        |> post_json("/api/auth/api-keys", %{"name" => "escalated"})
+
+      assert json_response(conn, 403)["reason"] == "insufficient_scope"
+    end
+
+    test "the TTL is configurable" do
+      original = Application.get_env(:fountain, :callback_key_ttl_seconds)
+
+      on_exit(fn ->
+        # put_env(nil) would leave the key present-but-nil, so the default in
+        # callback_key_ttl_seconds/0 would stop applying and DateTime.add would
+        # be handed nil.
+        case original do
+          nil -> Application.delete_env(:fountain, :callback_key_ttl_seconds)
+          value -> Application.put_env(:fountain, :callback_key_ttl_seconds, value)
+        end
+      end)
+
+      Application.put_env(:fountain, :callback_key_ttl_seconds, 60)
+      expires_at = Keyword.fetch!(ConversationServer.callback_api_key_opts(), :expires_at)
+
+      assert DateTime.diff(expires_at, DateTime.utc_now()) <= 61
+    end
+  end
+
+  describe "ApiKey predicates" do
+    test "may_manage_keys?/1" do
+      assert ApiKey.may_manage_keys?(%ApiKey{scopes: ["full"]})
+      refute ApiKey.may_manage_keys?(%ApiKey{scopes: ["sprite"]})
+    end
+
+    test "expired?/1 compares against now" do
+      refute ApiKey.expired?(%ApiKey{expires_at: nil})
+      refute ApiKey.expired?(%ApiKey{expires_at: DateTime.add(DateTime.utc_now(), 60)})
+      assert ApiKey.expired?(%ApiKey{expires_at: DateTime.add(DateTime.utc_now(), -60)})
+    end
+
+    test "an unknown scope is rejected at the changeset" do
+      user = insert_verified_user()
+
+      assert {:error, cs} = Accounts.create_api_key(user.id, "bad", scopes: ["root"])
+      assert Keyword.has_key?(cs.errors, :scopes)
+    end
+  end
+end

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -33,10 +33,18 @@ defmodule Fountain.Factory do
     verified
   end
 
-  def insert_api_key(user, name \\ nil) do
+  def insert_api_key(user, name \\ nil, opts \\ []) do
     name = name || "key-#{uniq()}"
-    {:ok, {key_record, raw_key}} = Fountain.Accounts.create_api_key(user.id, name)
+    {:ok, {key_record, raw_key}} = Fountain.Accounts.create_api_key(user.id, name, opts)
     {key_record, raw_key}
+  end
+
+  @doc """
+  A key with the narrow scope handed to sandboxes — the credential an agent
+  running inside a sprite actually holds.
+  """
+  def insert_sprite_api_key(user, opts \\ []) do
+    insert_api_key(user, "sprite:#{uniq()}", Keyword.put_new(opts, :scopes, ["sprite"]))
   end
 
   # ── environments ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #171.

## The escalation

Every conversation mints a tenant API key and hands it to its sprite as `FOUNTAIN_TOKEN` (`conversation_server.ex`), so the agent can stream, prompt, and spawn sub-agents. That key was **unrestricted**, and `POST /api/auth/api-keys` sits inside the same bearer-token pipeline (`router.ex:141`).

So code running in a sandbox could mint itself a second key. The conversation-scoped revoke in `terminate/2` only knows about the token it issued, so the minted one **survives conversation teardown as standing tenant access** — read every environment and vault secret, start conversations, indefinitely.

Sandboxes run untrusted code by design (that is the product), so this is the wrong thing to leave to convention.

## Scoping

New `scopes` column, backfilled to `["full"]`, so **every existing key behaves exactly as before**.

| Scope | Gets |
|---|---|
| `full` | everything, including key management — what a human gets from the UI or `fountain keys create` |
| `sprite` | the full resource surface **except** API key management |

`sprite` is deliberately not read-only. Spawning sub-agents from inside a sprite is a supported, documented workflow (`/help/spawning`), so locking these tokens down further would break the product. The narrow, correct cut is key *minting* — that is what converts a scoped credential into an unscoped one.

Enforced with a router pipeline on the three key-management routes rather than a check inside the controller, so a future route added to that scope block inherits the guard. The plug fails closed if no key is on the connection.

## Expiry

`terminate/2` already carries a comment admitting that a hard BEAM crash orphans the `api_keys` row with no janitor to sweep it (#166). With no `expires_at`, that orphan was valid **forever**. Callback tokens now carry one.

The default TTL is 30 days and configurable — deliberately generous, and I want to flag the tradeoff rather than bury it. Tokens rotate only on provision and reattach, so a TTL shorter than the longest continuously-running conversation would expire a token mid-flight and break the agent's callbacks. That is a worse, more confusing failure than a long-lived orphan. Lower `:callback_key_ttl_seconds` if conversations in a given deployment are short.

Expired keys get their own 401 reason (`api_key_expired`), matching the existing revoked/invalid split, so an in-sprite client can tell why it was rejected.

## Verification

**20 new tests**, and the four escalation cases were confirmed to **fail against the unguarded router** — removing the pipeline produces exactly 4 failures, so they are not vacuous.

Deliberate coverage of what must *not* break:

- a sprite-scoped key can still read `/api/auth/me`, list agents, create environments, and **spawn a sub-agent conversation**
- full-scoped keys are unaffected; keys default to `["full"]`
- revocation still takes precedence over expiry
- an unknown scope is rejected at the changeset

`ConversationServer` has no test coverage of its own (#192), so the minting options are exposed as a public function and asserted directly — verifying that callback tokens are *actually* issued narrow, rather than only that narrow tokens would be restricted if issued.

Migration verified `up`, `down`, and `up` again. Full suite: **1151 tests + 5 doctests, 0 failures** (baseline 1131). Format, `--warnings-as-errors`, credo clean.

## Notes for review

- Adding a column with a default is metadata-only on modern Postgres, so the migration is not a table rewrite.
- `Accounts.get_user_by_api_key/1` is kept and now delegates to `authenticate_api_key/1`, which returns the key record too — the plug needs it, since scope lives on the key and a sandbox token is otherwise indistinguishable from the tenant's own.
- The key listing now returns `scopes` and `expires_at`. A tenant's list is mostly auto-issued `sprite:*` tokens, and this is what makes them distinguishable from keys the user created.
- **Not covered:** #203 (ingest-side media validation) and the broader scope surface — this closes the escalation path, but does not, say, prevent a sprite token from deleting environments. Worth a follow-up conversation about whether `sprite` should be narrower still, which is really a question about what sub-agent workflows are meant to be able to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)