### PR TITLE
ops: provision Garage bucket + credentials for Postgres backups (1/2)

### DIFF
--- a/k8s/backup-bucket-bootstrap.yaml
+++ b/k8s/backup-bucket-bootstrap.yaml
@@ -1,0 +1,100 @@
+# One-shot (idempotent) setup for the private `fountain-backups` bucket on the
+# home-cloud Garage cluster, plus the credentials CNPG uses to write into it.
+#
+# Deliberately a separate step from enabling backups on the Cluster: if the
+# barmanObjectStore config went live before this Secret existed, Postgres would
+# start archiving WAL to a destination it cannot reach. A failing archive_command
+# makes Postgres *retain* WAL on the data volume rather than drop it, so a broken
+# destination is a slow disk-fill, not a no-op. Land this, confirm the Secret
+# exists, then enable backups.
+#
+# NOT website-enabled and not quota-shared with `share` — this bucket holds base
+# backups and WAL for the production database.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fountain-backup-bucket-bootstrap
+  namespace: fountain
+  annotations:
+    # Re-create the Job when the script changes so an edited bootstrap re-runs
+    # without a manual `kubectl delete job` first.
+    kustomize.toolkit.fluxcd.io/force: "true"
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      serviceAccountName: fountain-backup-bootstrap
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: alpine/k8s:1.30.0
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              NS=fountain
+              SECRET=fountain-backup-s3-credentials
+              GARAGE_NS=garage
+              GARAGE_POD=garage-0
+              BUCKET=fountain-backups
+              KEY=fountain-backup-key
+
+              echo "Waiting for $GARAGE_POD to be Ready..."
+              kubectl wait pod "$GARAGE_POD" -n "$GARAGE_NS" \
+                --for=condition=Ready --timeout=120s
+
+              GAR="kubectl exec $GARAGE_POD -n $GARAGE_NS -- /garage"
+
+              echo "Ensuring bucket $BUCKET exists..."
+              $GAR bucket create "$BUCKET" 2>/dev/null || echo "  (bucket already exists)"
+
+              # Garage replication_factor is 2, so N bytes stored costs 2N across
+              # the cluster. The database is ~155MB, so 5GiB is roughly 30x
+              # headroom for 14 days of base backups plus WAL, while bounding a
+              # runaway WAL stream so it cannot starve the loki/share buckets.
+              echo "Capping $BUCKET at 5GiB..."
+              $GAR bucket set-quotas "$BUCKET" --max-size 5GiB
+
+              echo "Ensuring key $KEY exists..."
+              if ! $GAR key info "$KEY" >/dev/null 2>&1; then
+                $GAR key create "$KEY"
+              else
+                echo "  (key already exists)"
+              fi
+
+              echo "Granting $KEY read+write on $BUCKET..."
+              $GAR bucket allow --read --write "$BUCKET" --key "$KEY"
+
+              # Bucket/quota/key-grant above are idempotent and re-run every
+              # time. Only the Secret write is skipped when it already exists:
+              # Garage will re-show the secret for an existing key, but
+              # rewriting it would churn the value CNPG has already loaded.
+              if kubectl get secret "$SECRET" -n "$NS" >/dev/null 2>&1; then
+                echo "Secret $NS/$SECRET already exists; done."
+                exit 0
+              fi
+
+              echo "Fetching key info..."
+              INFO=$($GAR key info --show-secret "$KEY")
+              ACCESS_KEY=$(echo "$INFO" | awk '/^Key ID:/ {print $3}')
+              SECRET_KEY=$(echo "$INFO" | awk '/^Secret key:/ {print $3}')
+
+              if [ -z "$ACCESS_KEY" ] || [ -z "$SECRET_KEY" ]; then
+                echo "FAIL: could not parse Key ID / Secret key from garage output:"
+                echo "$INFO"
+                exit 1
+              fi
+
+              echo "Creating Secret $NS/$SECRET..."
+              kubectl create secret generic "$SECRET" -n "$NS" \
+                --from-literal=AWS_ACCESS_KEY_ID="$ACCESS_KEY" \
+                --from-literal=AWS_SECRET_ACCESS_KEY="$SECRET_KEY"
+
+              echo "Done."
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/k8s/backup-bucket-rbac.yaml
+++ b/k8s/backup-bucket-rbac.yaml
@@ -1,0 +1,75 @@
+# RBAC for the backup-bucket bootstrap Job.
+#
+# Mirrors the loki/share bootstrap pattern in the home-cloud repo: the Job
+# needs to exec `/garage` inside a Garage pod to create the bucket and key,
+# then write the resulting credentials as a Secret in this namespace.
+#
+# The Role in the `garage` namespace is deliberately cross-namespace. Fountain's
+# Flux Kustomization reconciles with the kustomize-controller service account,
+# so it can create it; keeping it here rather than in home-cloud keeps "Fountain
+# has backups" self-contained in the repo that owns Fountain.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fountain-backup-bootstrap
+  namespace: fountain
+---
+# Exec into garage pods to run the /garage CLI.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fountain-backup-bootstrap-garage-exec
+  namespace: garage
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fountain-backup-bootstrap-garage-exec
+  namespace: garage
+subjects:
+  - kind: ServiceAccount
+    name: fountain-backup-bootstrap
+    namespace: fountain
+roleRef:
+  kind: Role
+  name: fountain-backup-bootstrap-garage-exec
+  apiGroup: rbac.authorization.k8s.io
+---
+# Write the credential Secret in the fountain namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fountain-backup-bootstrap-secret-writer
+  namespace: fountain
+rules:
+  # K8s RBAC ignores resourceNames on `create` (authorization happens before
+  # the resource name is known), so create is namespace-scoped.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create"]
+  # Updates/patches are pinned to the specific Secret.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["update", "patch"]
+    resourceNames: ["fountain-backup-s3-credentials"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fountain-backup-bootstrap-secret-writer
+  namespace: fountain
+subjects:
+  - kind: ServiceAccount
+    name: fountain-backup-bootstrap
+    namespace: fountain
+roleRef:
+  kind: Role
+  name: fountain-backup-bootstrap-secret-writer
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - serviceaccount.yaml
+  # Bucket + credentials for Postgres backups. Ordered before postgres.yaml so
+  # the Secret exists before the Cluster starts archiving WAL into it.
+  - backup-bucket-rbac.yaml
+  - backup-bucket-bootstrap.yaml
   - postgres.yaml
   - infisicalsecret.yaml
   - deployment.yaml


### PR DESCRIPTION
First half of #161. **Merging this applies to the live cluster** — Flux reconciles `k8s/` from `main` on a 5-minute interval.

## Context worth knowing before reviewing

The audit filed this as "Fountain has no backups." Investigating the cluster, it's broader than that: **no CNPG cluster in the home cloud has backups configured.** `infisical`, `mem0`, `mealie`, `calcom` and `grafana-postgres` all run without a `backup:` stanza, and the only `ScheduledBackup` reference anywhere is the CRD shipped in the operator's HelmRelease. So there was no house pattern to follow — this establishes one, closely mirroring the existing `loki` and `share` bucket bootstraps in the home-cloud repo.

Current exposure for Fountain specifically: a single CNPG instance on a Longhorn volume. Longhorn replication covers a disk or node failure. It does not cover a bad migration, an accidental `DROP`, or an application bug — and `MASTER_SECRETS_KEY` wrapping every tenant DEK means the database and that key together are the whole product.

## What this does

Creates a private `fountain-backups` bucket on the home-cloud Garage cluster, a key scoped to it, and materializes the credentials as Secret `fountain-backup-s3-credentials` in the `fountain` namespace.

**It does not enable backups.** That is deliberate and is the main thing to check in review.

A failing `archive_command` makes Postgres *retain* WAL on the data volume rather than discard it. So enabling `barmanObjectStore` against a destination whose credentials do not exist yet is not a harmless no-op — it is a slow fill of the 10Gi data volume. Landing the bucket first, confirming the Secret, and only then turning archiving on removes that window entirely. PR 2/2 does the second half.

## Sizing, measured rather than guessed

| Fact | Value |
|---|---|
| `fountain` database | **155 MB** |
| Data volume used | 740 MB of 9.8 GB |
| Garage free per node | 16.7 / 35.1 / 19.6 GiB |
| Garage `replication_factor` | **2** — N bytes stored costs 2N cluster-wide |

Quota is **5 GiB**, roughly 30x headroom for the planned retention, and bounded so a runaway WAL stream cannot starve the `loki` or `share` buckets on the node that currently has 16.7 GiB free.

## Verification

- `kubectl kustomize k8s/` builds cleanly (16 resources).
- All six new resources pass `kubectl apply --dry-run=server` against the live cluster.
- The bootstrap Job is idempotent: bucket/quota/key-grant re-run every reconcile; only the Secret write is skipped when it already exists, so the value CNPG has loaded is never churned underneath it.

## Honest limitation

**Garage runs in the same cluster as the database this backs up.** This protects against the failure modes that actually kill products — bad migration, accidental deletion, application bug — and against the storage layer losing the volume. It does **not** protect against loss of the cluster or the site. Off-site is a separate, larger decision (an external S3 provider, credentials, egress) and I have not assumed an answer; I'll file it as a follow-up rather than silently leave the impression that "backups are done" means "off-site backups are done."

## Note on RBAC

The `Role`/`RoleBinding` granting exec into Garage pods live in the `garage` namespace but are managed from this repo. Fountain's Flux Kustomization reconciles with the kustomize-controller service account so it has the permission; keeping them here makes "Fountain has backups" self-contained in the repo that owns Fountain, rather than splitting the change across two repos. Say the word if you'd rather the Garage-side pieces lived in home-cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)