### PR TITLE
ops: nightly Postgres backup to Garage, with a verified restore (2/2)

### DIFF
--- a/apps/fountain/priv/help/runbook.md
+++ b/apps/fountain/priv/help/runbook.md
@@ -122,15 +122,71 @@ psql "$DATABASE_URL" -c "VACUUM ANALYZE audit_events"
 
 ## Postgres backup + restore
 
-On Render, daily backups are managed by the Postgres add-on dashboard — there's nothing to wire up. Manual snapshots:
+A `fountain-pg-backup` CronJob (`k8s/backup-cronjob.yaml`) takes a compressed
+`pg_dump` every night at 03:17 UTC and uploads it to the private
+`fountain-backups` bucket on the home-cloud Garage cluster, under `pg_dump/`.
+Dumps older than 14 days are pruned after each successful upload.
+
+The job verifies the uploaded object's size against the local file and fails if
+they differ — a silently truncated upload is the failure mode that would
+otherwise stay hidden until you needed it.
+
+**Recovery granularity is 24 hours.** This is a nightly logical dump, not
+continuous archiving; there is no point-in-time recovery. CNPG's own
+`barmanObjectStore` would give PITR but is not usable here: as of CNPG 1.26 the
+barman-cloud tooling moved out of the operand images into a separate plugin, and
+neither the plugin nor its `ObjectStore` CRD is installed on this cluster.
+Configuring `spec.backup` without it yields a Cluster that reports healthy and
+archives nothing.
+
+**Garage is in the same cluster as the database.** This covers a bad migration,
+an accidental `DROP`, or an application bug. It does not cover loss of the
+cluster or the site.
+
+### Check backups are actually running
 
 ```bash
-# Backup
-pg_dump "$DATABASE_URL" > fountain.sql
-
-# Restore (with the app stopped, against a fresh database)
-psql "$NEW_DATABASE_URL" < fountain.sql
+kubectl get cronjob fountain-pg-backup -n fountain
+kubectl get jobs -n fountain -l app=fountain --sort-by=.metadata.creationTimestamp | tail -5
+kubectl exec -n garage garage-0 -- /garage bucket info fountain-backups
 ```
+
+### Restore
+
+Note the Garage quirk: `aws s3 cp` issues a `HeadObject` first and Garage
+answers that with `400`, so **use `s3api get-object` to download**. Uploads via
+`s3 cp` are fine.
+
+```bash
+# Credentials for the backup bucket (never printed)
+eval "$(kubectl get secret fountain-backup-s3-credentials -n fountain \
+  -o go-template='export AWS_ACCESS_KEY_ID={{index .data "AWS_ACCESS_KEY_ID" | base64decode}}{{"\n"}}export AWS_SECRET_ACCESS_KEY={{index .data "AWS_SECRET_ACCESS_KEY" | base64decode}}{{"\n"}}')"
+export AWS_DEFAULT_REGION=garage
+EP=http://garage-s3:3900        # over the tailnet; in-cluster use http://s3.garage.svc.cluster.local:3900
+
+# Newest dump
+LATEST=$(aws --endpoint-url $EP s3api list-objects-v2 --bucket fountain-backups \
+  --prefix pg_dump/ --query 'sort_by(Contents,&LastModified)[-1].Key' --output text)
+aws --endpoint-url $EP s3api get-object --bucket fountain-backups --key "$LATEST" restore.dump
+
+# Restore into a scratch database first and compare, before touching the live one.
+# `postgres` is superuser but only over the pod's local socket — the app role is
+# deliberately NOCREATEDB, so grant it for the duration and revoke afterwards.
+kubectl exec -n fountain fountain-pg-1 -c postgres -- psql -U postgres -c "CREATE DATABASE restore_verify;"
+kubectl exec -n fountain -i fountain-pg-1 -c postgres -- \
+  pg_restore -U postgres -d restore_verify --no-owner --no-privileges < restore.dump
+kubectl exec -n fountain fountain-pg-1 -c postgres -- \
+  psql -U postgres -d restore_verify -c "SELECT count(*) FROM users;"
+```
+
+`pg_restore` reports one ignored error, `must be owner of extension vector`, on
+a `COMMENT ON EXTENSION` statement. It is cosmetic — the extension comes from
+the cluster's `postInitTemplateSQL` and the data restores fully.
+
+This procedure was exercised end to end on 2026-08-01 against a real nightly
+artifact: every table matched the live database (users 191, agents 45,
+conversations 255, environments 22, vaults 5). Re-run it periodically — a
+backup nobody has restored is a hypothesis, not a backup.
 
 ## BEAM crash recovery
 

--- a/k8s/backup-cronjob.yaml
+++ b/k8s/backup-cronjob.yaml
@@ -1,0 +1,188 @@
+# Nightly logical backup of the Fountain database to the private
+# `fountain-backups` Garage bucket.
+#
+# WHY THIS RATHER THAN CNPG'S OWN BACKUPS
+#
+# CNPG's in-tree `spec.backup.barmanObjectStore` is the obvious answer and is
+# NOT usable on this cluster today. The operator is 1.29.1, and as of 1.26 the
+# barman-cloud tooling was moved out of the operand images into a separate
+# CNPG-I plugin. Verified directly: `ghcr.io/cloudnative-pg/postgresql:18.4-
+# standard-trixie` contains no `barman-cloud-*` binaries and no Python at all,
+# and no barman-cloud plugin or ObjectStore CRD is installed in the cluster.
+# Configuring barmanObjectStore in that state produces a Cluster that looks
+# backed up and archives nothing.
+#
+# So this is a deliberate interim: a plain `pg_dump` on a schedule, entirely
+# self-contained in this repo, giving a real restorable artifact today. The
+# database is ~155MB, so a nightly full dump is cheap.
+#
+# WHAT IT DOES NOT GIVE YOU
+#
+# No point-in-time recovery — recovery granularity is 24 hours, back to the
+# last nightly dump. PITR needs continuous WAL archiving, which needs the
+# barman-cloud plugin installed cluster-wide (a home-cloud repo change, since
+# it affects every CNPG cluster there). Tracked separately.
+#
+# RESTORE
+#
+#   kubectl exec -n fountain -i fountain-pg-1 -c postgres -- \
+#     pg_restore -U postgres -d fountain --clean --if-exists < fountain-<ts>.dump
+#
+# Restore is exercised in the runbook; a backup nobody has restored is a
+# hypothesis, not a backup.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fountain-pg-backup
+  namespace: fountain
+  labels:
+    app: fountain
+spec:
+  # 03:17 UTC — off the hour so it doesn't pile onto every other cron in the
+  # cluster, and well clear of the nightly image builds.
+  schedule: "17 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  # If a node is down at 03:17, still run when the cluster recovers, but don't
+  # fire a stampede of missed runs.
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 26
+            fsGroup: 26
+          volumes:
+            - name: work
+              emptyDir:
+                # Dump is compressed; the database is ~155MB. 2Gi is generous
+                # and bounded so a runaway dump cannot fill the node.
+                sizeLimit: 2Gi
+          # pg_dump runs first, to completion, into the shared volume. The
+          # upload container only starts once it has succeeded, so a failed
+          # dump can never be uploaded as a valid-looking empty object.
+          initContainers:
+            - name: dump
+              image: ghcr.io/cloudnative-pg/postgresql:18.4-standard-trixie
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+                  TS="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+                  OUT="/work/fountain-${TS}.dump"
+
+                  echo "Dumping ${PGDATABASE} from ${PGHOST}..."
+                  # -Fc: custom format, compressed, restorable with pg_restore
+                  # and selective about what it replays.
+                  pg_dump -Fc -Z6 --no-owner --no-privileges -f "$OUT"
+
+                  ls -lh "$OUT"
+                  # Refuse to hand a suspiciously small file to the uploader —
+                  # a truncated dump that uploads cleanly is worse than a
+                  # failed job, because it looks like a backup.
+                  SIZE=$(stat -c %s "$OUT")
+                  if [ "$SIZE" -lt 10240 ]; then
+                    echo "FAIL: dump is only ${SIZE} bytes, refusing to upload"
+                    exit 1
+                  fi
+                  echo "$OUT" > /work/latest
+              env:
+                - name: PGHOST
+                  value: fountain-pg-rw
+                - name: PGPORT
+                  value: "5432"
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef: { name: fountain-pg-app, key: dbname }
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef: { name: fountain-pg-app, key: username }
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef: { name: fountain-pg-app, key: password }
+              volumeMounts:
+                - { name: work, mountPath: /work }
+              resources:
+                requests: { cpu: 50m, memory: 128Mi }
+                limits: { memory: 512Mi }
+          containers:
+            - name: upload
+              image: amazon/aws-cli:2.31.19
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  # Garage serves path-style only — the bucket is not resolvable
+                  # as a DNS subdomain of the in-cluster service name. There is
+                  # no environment variable for this, so write a config file.
+                  # AWS_CONFIG_FILE points at the shared volume because the
+                  # container runs as a non-root uid with no writable home.
+                  printf '[default]\ns3 =\n    addressing_style = path\n' > /work/aws-config
+
+                  FILE="$(cat /work/latest)"
+                  BASE="$(basename "$FILE")"
+                  DEST="s3://${BUCKET}/pg_dump/${BASE}"
+
+                  echo "Uploading ${BASE}..."
+                  # --no-progress: the per-chunk progress lines are hundreds of
+                  # KB of log per run, which is pure noise in an aggregator.
+                  aws --endpoint-url "$S3_ENDPOINT" s3 cp --no-progress "$FILE" "$DEST"
+
+                  # Read back the object size and compare against the local
+                  # file. A silently truncated upload is the failure mode that
+                  # would otherwise go unnoticed until a restore.
+                  #
+                  # list-objects-v2 rather than head-object: Garage answers
+                  # HeadObject with 400 here, and a verification step that
+                  # always fails is worse than none — it would mask a real
+                  # mismatch behind an expected error.
+                  LOCAL=$(stat -c %s "$FILE")
+                  REMOTE=$(aws --endpoint-url "$S3_ENDPOINT" s3api list-objects-v2 \
+                    --bucket "$BUCKET" --prefix "pg_dump/${BASE}" \
+                    --query "Contents[?Key=='pg_dump/${BASE}'].Size | [0]" --output text)
+                  echo "local=${LOCAL} remote=${REMOTE}"
+                  if [ "$LOCAL" != "$REMOTE" ]; then
+                    echo "FAIL: size mismatch after upload"
+                    exit 1
+                  fi
+
+                  # Prune anything older than the retention window. Done after
+                  # a verified upload so a run that failed to produce a new
+                  # backup never deletes an old one.
+                  CUTOFF=$(date -u -d "-${RETENTION_DAYS} days" +%Y-%m-%d)
+                  echo "Pruning dumps older than ${CUTOFF}..."
+                  aws --endpoint-url "$S3_ENDPOINT" s3api list-objects-v2 \
+                    --bucket "$BUCKET" --prefix "pg_dump/" \
+                    --query "Contents[?LastModified<'${CUTOFF}'].Key" --output text \
+                    | tr '\t' '\n' | grep -v '^$' | grep -v '^None$' | while read -r KEY; do
+                        echo "  deleting ${KEY}"
+                        aws --endpoint-url "$S3_ENDPOINT" s3api delete-object \
+                          --bucket "$BUCKET" --key "$KEY"
+                      done || true
+
+                  echo "Backup complete: ${DEST}"
+              env:
+                - name: S3_ENDPOINT
+                  value: http://s3.garage.svc.cluster.local:3900
+                - name: BUCKET
+                  value: fountain-backups
+                - name: RETENTION_DAYS
+                  value: "14"
+                # Garage needs a region set even though it ignores the value.
+                - name: AWS_DEFAULT_REGION
+                  value: garage
+                - name: AWS_CONFIG_FILE
+                  value: /work/aws-config
+              envFrom:
+                - secretRef:
+                    name: fountain-backup-s3-credentials
+              volumeMounts:
+                - { name: work, mountPath: /work }
+              resources:
+                requests: { cpu: 50m, memory: 128Mi }
+                limits: { memory: 512Mi }

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   # the Secret exists before the Cluster starts archiving WAL into it.
   - backup-bucket-rbac.yaml
   - backup-bucket-bootstrap.yaml
+  - backup-cronjob.yaml
   - postgres.yaml
   - infisicalsecret.yaml
   - deployment.yaml


### PR DESCRIPTION
Closes #161. Follows #207, which provisioned the bucket and credentials.

## This is not the fix the issue described, and that matters

The issue (and my own audit note) assumed the answer was CNPG's `spec.backup.barmanObjectStore`. **It would have silently backed up nothing.**

CNPG here is **1.29.1**, and as of 1.26 the barman-cloud tooling was moved out of the operand images into a separate CNPG-I plugin. Verified directly rather than inferred:

- `ghcr.io/cloudnative-pg/postgresql:18.4-standard-trixie` contains **no `barman-cloud-*` binaries and no Python at all**
- no barman-cloud plugin, and no `ObjectStore` CRD, is installed on this cluster

Configuring `spec.backup` in that state yields a Cluster that reports healthy and archives nothing — strictly worse than no backups, because it looks like backups. Had I written the "obvious" manifest and merged it, #161 would have been closed with the problem intact.

## What this does instead

A nightly `pg_dump` at 03:17 UTC to the private `fountain-backups` bucket, entirely self-contained in this repo.

Failure modes handled deliberately:

- **`pg_dump` runs as an initContainer.** The upload container only starts if the dump succeeded, so a failed dump can never be uploaded as a valid-looking object. The dump step also refuses to hand over a file under 10KB.
- **The upload reads the object size back** and fails on mismatch. A silently truncated upload is the failure that stays hidden until the day you need it.
- **Pruning runs only after a verified upload**, so a run that failed to produce a new backup never deletes an old one.

## Verified, not assumed

I pulled a real artifact out of the bucket and restored it into a scratch database:

| Table | Restored | Live |
|---|---|---|
| users | 191 | 191 |
| agents | 45 | 45 |
| conversations | 255 | 255 |
| environments | 22 | 22 |
| vaults | 5 | 5 |

Two things surfaced only by actually running it, both now handled in the manifest and documented in the runbook:

1. **Garage answers `HeadObject` with `400`.** `aws s3 cp` issues one before downloading, so it cannot fetch — `s3api get-object` works. My first size-check used `head-object` and failed 100% of the time; a verification step that always fails is worse than none, because it masks real mismatches behind an expected error.
2. **Default `aws s3 cp` progress output is hundreds of KB of log per run** — meaningful given `log_events` growth is already an open issue (#164). Now `--no-progress`.

The restore needed `CREATEDB`, which the app role deliberately lacks (`postgres` is superuser but only over the pod's local socket). I granted it for the duration and **revoked it afterwards — confirmed `rolcreatedb = f`**, scratch database dropped, test Jobs and the local dump copy deleted.

## Limits, stated plainly

- **Recovery granularity is 24 hours.** No PITR. That needs continuous WAL archiving, which needs the barman-cloud plugin installed cluster-wide — a home-cloud repo change affecting all six CNPG clusters there, so not something I'd fold into a Fountain PR. Filed separately.
- **Garage shares a cluster with the database it backs up.** Covers a bad migration, an accidental `DROP`, an application bug. Does not cover losing the cluster or the site.
- **Nothing alerts if the job stops running.** A CronJob that quietly stops is the classic way backups rot, and there is no error tracking or alerting at all yet (#162). Until that lands, the runbook has the manual check.

## Incidental findings worth your attention

While verifying, the restored row counts exposed two things:

- **`api_keys` has 24,115 rows** for 255 conversations — sprite callback tokens accumulating, since they rotate on every provision and reattach and are only revoked at clean teardown. The expiry added in #206 bounds new ones; the backlog is #166's reaper.
- **`log_events` has 97,015 rows**, the unbounded-growth table from #164, on a 10Gi volume.

Also replaces the runbook's backup section, which still told operators "On Render, daily backups are managed by the Postgres add-on dashboard" — untrue since the k3s cutover, and the kind of stale instruction that costs you an outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)