### PR TITLE
billing: gate every provisioning path, and stop orphaning paid checkouts

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -8,9 +8,13 @@ defmodule Fountain.Billing do
       Fountain.Billing.assert_active!(current_user)
 
   Call sites:
-  - `ConversationServer.init/1` — blocks new conversations at the GenServer level
-  - `POST /api/conversations` controller — returns HTTP 402 on failure
-  - `on_mount :require_active_subscription` LiveView hook — redirects to billing page
+  - `Conversations.start_conversation/1` and the wake path — the backstop. Every
+    route to a sprite passes through one of these, so a new surface cannot
+    silently skip the gate the way `POST /api/conversations/:id/prompts` did.
+  - `POST /api/conversations` controller — fast 402 before doing any work
+  - `on_mount :require_active_subscription` LiveView hook — redirects to billing.
+    Mount-time only, so it does not cover a session that is cancelled mid-flight;
+    the context-level check does.
 
   ## Webhook sync
 
@@ -53,6 +57,23 @@ defmodule Fountain.Billing do
 
   def assert_active!(%User{}), do: raise(SubscriptionRequiredError)
 
+  @doc """
+  Non-raising gate, for `with` pipelines in contexts.
+
+  Accepts a user or a user id. An unknown id fails closed: a caller that cannot
+  identify the user must not be able to provision on someone's behalf.
+  """
+  @spec check_active(User.t() | binary()) :: :ok | {:error, :subscription_required}
+  def check_active(%User{subscription_status: status}) when status in @active_statuses, do: :ok
+  def check_active(%User{}), do: {:error, :subscription_required}
+
+  def check_active(user_id) when is_binary(user_id) do
+    case Repo.get(User, user_id) do
+      nil -> {:error, :subscription_required}
+      user -> check_active(user)
+    end
+  end
+
   # ─── Stripe customer ────────────────────────────────────────────────────────
 
   @doc """
@@ -81,6 +102,37 @@ defmodule Fountain.Billing do
     end
   end
 
+  @doc """
+  Returns the user with a `stripe_customer_id`, creating the Stripe Customer if
+  it is missing.
+
+  Checkout must never be opened without one. Passing `customer_email` instead
+  makes Stripe mint its own Customer whose id we never learn, so the resulting
+  `customer.subscription.created` webhook matches no user and the payment is
+  taken without ever activating the account.
+  """
+  @spec ensure_stripe_customer(User.t()) :: {:ok, User.t()} | {:error, term()}
+  def ensure_stripe_customer(%User{stripe_customer_id: id} = user)
+      when is_binary(id) and id != "",
+      do: {:ok, user}
+
+  def ensure_stripe_customer(%User{} = user), do: create_stripe_customer(user)
+
+  @doc """
+  Attach a Stripe customer id to a user that has none.
+
+  Used to repair the accounts created before Checkout guaranteed a customer:
+  `checkout.session.completed` carries both the customer id and our
+  `client_reference_id`, which is the only way back to the user for a Customer
+  Stripe minted on its own.
+  """
+  @spec attach_stripe_customer(User.t(), binary()) :: {:ok, User.t()} | {:error, term()}
+  def attach_stripe_customer(%User{} = user, customer_id) when is_binary(customer_id) do
+    user
+    |> User.billing_changeset(%{stripe_customer_id: customer_id})
+    |> Repo.update()
+  end
+
   # ─── Webhook sync ───────────────────────────────────────────────────────────
 
   @doc """
@@ -91,6 +143,32 @@ defmodule Fountain.Billing do
   All other event types return `{:ok, :ignored}` without touching the DB.
   """
   @spec sync_subscription(Stripe.Event.t()) :: {:ok, User.t() | :ignored} | {:error, term()}
+  def sync_subscription(%Stripe.Event{
+        type: "checkout.session.completed",
+        data: %{object: session}
+      }) do
+    customer_id = extract_customer_id(Map.get(session, :customer))
+    user_id = Map.get(session, :client_reference_id)
+
+    cond do
+      is_nil(customer_id) ->
+        {:ok, :ignored}
+
+      # Already linked — the subscription events will carry the same customer.
+      not is_nil(get_user_by_stripe_customer_id(customer_id)) ->
+        {:ok, :ignored}
+
+      is_binary(user_id) ->
+        case Repo.get(User, user_id) do
+          nil -> {:error, :user_not_found}
+          user -> attach_stripe_customer(user, customer_id)
+        end
+
+      true ->
+        {:error, :user_not_found}
+    end
+  end
+
   def sync_subscription(%Stripe.Event{type: type, data: %{object: sub}})
       when type in [
              "customer.subscription.created",

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -589,6 +589,7 @@ defmodule Fountain.Conversations do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
+         :ok <- Fountain.Billing.check_active(user_id),
          :ok <- Fountain.Quotas.check_sandbox_quota(user_id),
          {:ok, sandbox} <-
            create_sandbox(%{
@@ -792,7 +793,11 @@ defmodule Fountain.Conversations do
   defp create_fresh_sandbox_and_start(conv, agent, runtime_module, initial_prompt) do
     # The sandbox being replaced is excluded: it is retired immediately below,
     # so counting it would block a wake that leaves concurrency unchanged.
-    with :ok <-
+    # Waking a dormant conversation provisions a fresh sprite, so it is subject
+    # to the same gate as creating one. Without this, prompting an existing
+    # conversation was an unmetered way past billing entirely.
+    with :ok <- Fountain.Billing.check_active(conv.user_id),
+         :ok <-
            Fountain.Quotas.check_sandbox_quota(conv.user_id, exclude: conv.sandbox_id),
          {:ok, new_sandbox} <-
            create_sandbox(%{

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -174,9 +174,13 @@ defmodule FountainWeb.ConversationController do
             {:error, "conversation_busy"}
 
           # Waking a dormant conversation provisions a fresh sprite, so it is
-          # subject to the concurrency cap. Pass the tuple through to the
-          # fallback controller rather than letting it blow the case clause.
+          # subject to both the concurrency cap and the subscription gate. Pass
+          # these through to the fallback controller rather than letting them
+          # blow the case clause — an unmatched tuple here is a 500, not a 402.
           {:error, {:sandbox_quota_exceeded, _}} = err ->
+            err
+
+          {:error, :subscription_required} = err ->
             err
         end
     end

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -33,6 +33,14 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "vault_not_allowed", message: "vault is not in the agent's allowed_vault_ids"})
   end
 
+  # Subscription gate (ADR 0006). Raised from the context so every provisioning
+  # path renders the same response, rather than each controller inventing one.
+  def call(conn, {:error, :subscription_required}) do
+    conn
+    |> put_status(:payment_required)
+    |> json(%{error: "subscription_required", upgrade_url: "/account/billing"})
+  end
+
   # Per-tenant sandbox concurrency cap (ADR 0005). 429 rather than 402: this is
   # a rate/concurrency condition the caller can clear by terminating a
   # conversation, not a billing state they have to resolve by paying.

--- a/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
@@ -11,6 +11,8 @@ defmodule FountainWeb.UeberauthController do
 
   use FountainWeb, :controller
 
+  alias Fountain.Billing
+
   # Ueberauth's plug handles the request phase (redirect to the provider)
   # and the callback phase (parse the response into assigns). It MUST be
   # in the controller's plug pipeline — otherwise `request/2` is hit
@@ -64,6 +66,11 @@ defmodule FountainWeb.UeberauthController do
 
       case Fountain.Accounts.upsert_oauth_user(provider, provider_uid, attrs) do
         {:ok, user, :new} ->
+          # The email+password path does this after verification. OAuth skips
+          # verification entirely (the provider asserts the address), so without
+          # this every GitHub signup had no Stripe customer and no trial_ends_at.
+          Task.async(fn -> Billing.create_stripe_customer(user) end)
+
           conn
           |> configure_session(renew: true)
           |> put_session(:user_id, user.id)

--- a/apps/fountain/lib/fountain_web/live/billing_live.ex
+++ b/apps/fountain/lib/fountain_web/live/billing_live.ex
@@ -161,25 +161,30 @@ defmodule FountainWeb.Live.BillingLive do
     else
       price_id = Application.get_env(:fountain, :stripe_price_id, "")
 
-      base_params = %{
-        mode: "subscription",
-        line_items: [%{price: price_id, quantity: 1}],
-        success_url: return_url <> "?checkout=success",
-        cancel_url: return_url,
-        # Show "Add promotion code" link on the Checkout page. Promotion codes
-        # are user-facing redeemable strings tied to coupons created in the
-        # Stripe dashboard. Without this flag, the field is hidden by default.
-        allow_promotion_codes: true
-      }
+      # Never fall back to `customer_email`. That makes Stripe mint its own
+      # Customer whose id we never learn, so the subscription webhook matches no
+      # user: the card is charged and the account is never activated. Creating
+      # the Customer first means the id is always ours.
+      with {:ok, user} <- Billing.ensure_stripe_customer(user) do
+        params = %{
+          mode: "subscription",
+          line_items: [%{price: price_id, quantity: 1}],
+          success_url: return_url <> "?checkout=success",
+          cancel_url: return_url,
+          customer: user.stripe_customer_id,
+          # Second route back to the user if the customer link is ever lost —
+          # checkout.session.completed carries this through.
+          client_reference_id: user.id,
+          # Show "Add promotion code" link on the Checkout page. Promotion codes
+          # are user-facing redeemable strings tied to coupons created in the
+          # Stripe dashboard. Without this flag, the field is hidden by default.
+          allow_promotion_codes: true
+        }
 
-      params =
-        if user.stripe_customer_id,
-          do: Map.put(base_params, :customer, user.stripe_customer_id),
-          else: Map.put(base_params, :customer_email, user.email)
-
-      case Stripe.Checkout.Session.create(params) do
-        {:ok, session} -> {:ok, session.url}
-        error -> error
+        case Stripe.Checkout.Session.create(params) do
+          {:ok, session} -> {:ok, session.url}
+          error -> error
+        end
       end
     end
   end

--- a/apps/fountain/lib/fountain_web/live/conversations_live/new.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/new.ex
@@ -46,6 +46,15 @@ defmodule FountainWeb.ConversationsLive.New do
       {:error, :vault_not_found} ->
         {:noreply, put_flash(socket, :error, "Vault not found")}
 
+      # The on_mount hook gates at mount only, so a socket that connected while
+      # the subscription was active survives a mid-session cancellation. The
+      # context check catches that; send them where they can fix it.
+      {:error, :subscription_required} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "An active subscription is required to start a conversation.")
+         |> push_navigate(to: ~p"/account/billing")}
+
       {:error, {:sandbox_quota_exceeded, %{count: count, limit: limit}}} ->
         {:noreply,
          put_flash(

--- a/apps/fountain/test/fountain/billing_gate_test.exs
+++ b/apps/fountain/test/fountain/billing_gate_test.exs
@@ -1,0 +1,121 @@
+defmodule Fountain.BillingGateTest do
+  @moduledoc """
+  The subscription gate, checked where sprites are actually provisioned.
+
+  ADR 0006 claimed this backstop existed in `ConversationServer.init/1`. It did
+  not, and the gap was not theoretical: `POST /api/conversations/:id/prompts`
+  wakes a dormant conversation, which provisions a brand-new sprite, and it
+  never went near a billing check. Anyone with one existing conversation could
+  keep spending indefinitely after cancelling.
+  """
+
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Billing, Conversations}
+
+  defp user_with_status(status) do
+    user = insert_verified_user()
+
+    {:ok, user} =
+      user
+      |> Fountain.Accounts.User.billing_changeset(%{subscription_status: status})
+      |> Fountain.Repo.update()
+
+    user
+  end
+
+  describe "check_active/1" do
+    test "allows trialing and active" do
+      assert :ok = Billing.check_active(user_with_status("trialing"))
+      assert :ok = Billing.check_active(user_with_status("active"))
+    end
+
+    test "refuses past_due and canceled" do
+      assert {:error, :subscription_required} = Billing.check_active(user_with_status("past_due"))
+      assert {:error, :subscription_required} = Billing.check_active(user_with_status("canceled"))
+    end
+
+    test "accepts a user id as well as a struct" do
+      assert :ok = Billing.check_active(user_with_status("active").id)
+
+      assert {:error, :subscription_required} =
+               Billing.check_active(user_with_status("canceled").id)
+    end
+
+    test "fails closed on an unknown user id" do
+      assert {:error, :subscription_required} = Billing.check_active(Ecto.UUID.generate())
+    end
+  end
+
+  describe "start_conversation/1" do
+    test "is refused for a canceled subscription" do
+      user = user_with_status("canceled")
+      agent = insert_agent(user_id: user.id)
+
+      assert {:error, :subscription_required} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+    end
+
+    test "allocates no sandbox when refused" do
+      user = user_with_status("past_due")
+      agent = insert_agent(user_id: user.id)
+
+      assert {:error, :subscription_required} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+
+      assert Fountain.Quotas.active_sandbox_count(user.id) == 0
+    end
+
+    test "still works while trialing" do
+      user = user_with_status("trialing")
+      agent = insert_agent(user_id: user.id)
+      stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+      assert {:ok, _} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+    end
+  end
+
+  describe "wake_conversation/2 — the path that was ungated" do
+    test "is refused for a canceled subscription" do
+      user = user_with_status("canceled")
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
+
+      assert {:error, :subscription_required} = Conversations.wake_conversation(conv.id, "hi")
+    end
+
+    test "provisions no replacement sandbox when refused" do
+      user = user_with_status("canceled")
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
+      before = Fountain.Quotas.active_sandbox_count(user.id)
+
+      assert {:error, :subscription_required} = Conversations.wake_conversation(conv.id, "hi")
+      assert Fountain.Quotas.active_sandbox_count(user.id) == before
+    end
+
+    test "an active subscription still wakes" do
+      user = user_with_status("active")
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
+      stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+      assert {:ok, _} = Conversations.wake_conversation(conv.id, "hi")
+    end
+  end
+
+  describe "gate ordering" do
+    test "billing is reported before quota" do
+      # A cancelled tenant sitting at their sandbox cap should be told to fix
+      # their subscription, not to terminate conversations that would not help.
+      user = user_with_status("canceled")
+      agent = insert_agent(user_id: user.id)
+      for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+
+      assert {:error, :subscription_required} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+    end
+  end
+end

--- a/apps/fountain/test/fountain/billing_payment_path_test.exs
+++ b/apps/fountain/test/fountain/billing_payment_path_test.exs
@@ -1,0 +1,132 @@
+defmodule Fountain.BillingPaymentPathTest do
+  @moduledoc """
+  The path from "user clicks Upgrade" to "account is active".
+
+  It had a hole big enough to take money through. When a user had no
+  `stripe_customer_id`, Checkout was opened with `customer_email`, so Stripe
+  minted its own Customer whose id we never learned. The resulting
+  `customer.subscription.created` webhook then matched no user, the controller
+  logged it and answered 200, and the card was charged against an account that
+  stayed unactivated. Roughly 80% of accounts had no customer id, so this was
+  the common case rather than an edge.
+  """
+
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Accounts, Billing, Repo}
+  alias Fountain.Accounts.User
+
+  describe "ensure_stripe_customer/1" do
+    test "creates a customer when the user has none" do
+      user = insert_verified_user()
+      refute user.stripe_customer_id
+
+      expect(Stripe.Customer, :create, fn %{email: email} ->
+        assert email == user.email
+        {:ok, %Stripe.Customer{id: "cus_new123"}}
+      end)
+
+      assert {:ok, updated} = Billing.ensure_stripe_customer(user)
+      assert updated.stripe_customer_id == "cus_new123"
+      assert Repo.get(User, user.id).stripe_customer_id == "cus_new123"
+    end
+
+    test "reuses an existing customer without calling Stripe" do
+      user = insert_verified_user()
+      {:ok, user} = Billing.attach_stripe_customer(user, "cus_existing")
+
+      # No expect/3 on Stripe.Customer — a call would fail the test.
+      assert {:ok, same} = Billing.ensure_stripe_customer(user)
+      assert same.stripe_customer_id == "cus_existing"
+    end
+
+    test "sets a trial end date alongside the customer" do
+      user = insert_verified_user()
+      stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_t"}} end)
+
+      assert {:ok, updated} = Billing.ensure_stripe_customer(user)
+      assert updated.trial_ends_at
+      assert DateTime.compare(updated.trial_ends_at, DateTime.utc_now()) == :gt
+    end
+
+    test "propagates a Stripe failure rather than returning a customerless user" do
+      user = insert_verified_user()
+
+      stub(Stripe.Customer, :create, fn _ ->
+        {:error, %Stripe.Error{source: :stripe, code: :api_error, message: "nope"}}
+      end)
+
+      assert {:error, _} = Billing.ensure_stripe_customer(user)
+      refute Repo.get(User, user.id).stripe_customer_id
+    end
+  end
+
+  describe "checkout.session.completed" do
+    defp checkout_event(customer, client_reference_id) do
+      %Stripe.Event{
+        type: "checkout.session.completed",
+        data: %{object: %{customer: customer, client_reference_id: client_reference_id}}
+      }
+    end
+
+    test "backfills the customer id via client_reference_id" do
+      user = insert_verified_user()
+      refute user.stripe_customer_id
+
+      assert {:ok, updated} = Billing.sync_subscription(checkout_event("cus_orphan", user.id))
+      assert updated.stripe_customer_id == "cus_orphan"
+    end
+
+    test "is a no-op when the customer is already linked" do
+      user = insert_verified_user()
+      {:ok, _} = Billing.attach_stripe_customer(user, "cus_known")
+
+      assert {:ok, :ignored} = Billing.sync_subscription(checkout_event("cus_known", user.id))
+    end
+
+    test "reports an unknown client_reference_id rather than silently passing" do
+      assert {:error, :user_not_found} =
+               Billing.sync_subscription(checkout_event("cus_x", Ecto.UUID.generate()))
+    end
+
+    test "ignores a session with no customer" do
+      assert {:ok, :ignored} = Billing.sync_subscription(checkout_event(nil, nil))
+    end
+
+    test "after backfill, the subscription webhook can find the user" do
+      # The end-to-end point: this is what turns a charged-but-inactive account
+      # into an active one.
+      user = insert_verified_user()
+      {:ok, _} = Billing.sync_subscription(checkout_event("cus_flow", user.id))
+
+      event = %Stripe.Event{
+        type: "customer.subscription.created",
+        data: %{object: %{customer: "cus_flow", status: "active", trial_end: nil}}
+      }
+
+      assert {:ok, updated} = Billing.sync_subscription(event)
+      assert updated.id == user.id
+      assert updated.subscription_status == "active"
+    end
+  end
+
+  describe "OAuth signups" do
+    test "get a Stripe customer and a trial end date" do
+      # The email+password path creates the customer after verification. OAuth
+      # skips verification, so it used to create neither — every GitHub user
+      # then walked into the orphaned-checkout bug above.
+      stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_oauth"}} end)
+
+      {:ok, user, :new} =
+        Accounts.upsert_oauth_user("github", "gh-#{System.unique_integer([:positive])}", %{
+          "email" => "oauth-#{System.unique_integer([:positive])}@example.com"
+        })
+
+      {:ok, updated} = Billing.create_stripe_customer(user)
+
+      assert updated.stripe_customer_id == "cus_oauth"
+      assert updated.trial_ends_at
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -23,7 +23,10 @@ defmodule FountainWeb.ConversationControllerTest do
       assert conv.id in ids
     end
 
-    test "does not include conversations belonging to other users", %{conn: conn, raw_key: raw_key} do
+    test "does not include conversations belonging to other users", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       other_user = insert_verified_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
@@ -41,7 +44,11 @@ defmodule FountainWeb.ConversationControllerTest do
   end
 
   describe "GET /api/conversations/:id" do
-    test "returns 200 with the conversation for the authenticated user", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 with the conversation for the authenticated user", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
 
       conn = conn |> authed_with_key(raw_key) |> get("/api/conversations/#{conv.id}")
@@ -50,7 +57,10 @@ defmodule FountainWeb.ConversationControllerTest do
       assert body["data"]["id"] == conv.id
     end
 
-    test "returns 404 when the conversation belongs to a different user", %{conn: conn, raw_key: raw_key} do
+    test "returns 404 when the conversation belongs to a different user", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       other_user = insert_verified_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
@@ -67,7 +77,11 @@ defmodule FountainWeb.ConversationControllerTest do
   end
 
   describe "GET /api/conversations/:conversation_id/turns" do
-    test "returns 200 with turns list for the authenticated user", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 with turns list for the authenticated user", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
       turn = insert_turn(conv, [])
 
@@ -79,7 +93,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert turn.id in ids
     end
 
-    test "returns 200 with an empty list when there are no turns", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 with an empty list when there are no turns", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
 
       conn = conn |> authed_with_key(raw_key) |> get("/api/conversations/#{conv.id}/turns")
@@ -88,7 +106,10 @@ defmodule FountainWeb.ConversationControllerTest do
       assert body["data"] == []
     end
 
-    test "returns 404 when the conversation belongs to a different user", %{conn: conn, raw_key: raw_key} do
+    test "returns 404 when the conversation belongs to a different user", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       other_user = insert_verified_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
@@ -98,8 +119,57 @@ defmodule FountainWeb.ConversationControllerTest do
     end
   end
 
+  describe "subscription gate" do
+    test "POST /api/conversations/:id/prompts returns 402 when cancelled", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      # Prompting wakes a dormant conversation, which provisions a fresh sprite.
+      # It was the one provisioning path with no billing check at all.
+      conv = insert_conversation(user_id: user.id)
+
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images ->
+        {:error, :subscription_required}
+      end)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations/#{conv.id}/prompts", %{"prompt" => "hi"})
+
+      body = json_response(conn, 402)
+      assert body["error"] == "subscription_required"
+      assert body["upgrade_url"] == "/account/billing"
+    end
+
+    test "POST /api/conversations returns 402 when cancelled", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+
+      {:ok, _} =
+        user
+        |> Fountain.Accounts.User.billing_changeset(%{subscription_status: "canceled"})
+        |> Fountain.Repo.update()
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations", %{"agent_id" => agent.id})
+
+      assert json_response(conn, 402)["error"] == "subscription_required"
+    end
+  end
+
   describe "sandbox concurrency cap" do
-    test "POST /api/conversations returns 429 at the cap", %{conn: conn, user: user, raw_key: raw_key} do
+    test "POST /api/conversations returns 429 at the cap", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       agent = insert_agent(user_id: user.id)
 
       for _ <- 1..Fountain.Quotas.default_limit(),
@@ -116,7 +186,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert body["limit"] == 5
     end
 
-    test "POST /api/conversations succeeds below the cap", %{conn: conn, user: user, raw_key: raw_key} do
+    test "POST /api/conversations succeeds below the cap", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       agent = insert_agent(user_id: user.id)
       insert_sandbox(user_id: user.id, status: "ready")
 
@@ -130,7 +204,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert json_response(conn, 201)
     end
 
-    test "prompting a dormant conversation is capped too", %{conn: conn, user: user, raw_key: raw_key} do
+    test "prompting a dormant conversation is capped too", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       # send_prompt on a dead GenServer wakes the conversation, which provisions
       # a fresh sprite — so it has to be subject to the same cap, or the cap is
       # trivially bypassed by prompting instead of creating.
@@ -159,7 +237,10 @@ defmodule FountainWeb.ConversationControllerTest do
       assert conn.status == 204
     end
 
-    test "returns 404 when the conversation belongs to a different user", %{conn: conn, raw_key: raw_key} do
+    test "returns 404 when the conversation belongs to a different user", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       other_user = insert_verified_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
@@ -185,12 +266,17 @@ defmodule FountainWeb.ConversationControllerTest do
     end
 
     test "returns {\"agent\", id} when header contains a conversation id" do
-      assert ConversationController.infer_provenance("some-conv-uuid") == {"agent", "some-conv-uuid"}
+      assert ConversationController.infer_provenance("some-conv-uuid") ==
+               {"agent", "some-conv-uuid"}
     end
   end
 
   describe "POST /api/conversations" do
-    test "returns 402 when user has a canceled subscription", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 402 when user has a canceled subscription", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       Fountain.Repo.update!(Ecto.Changeset.change(user, subscription_status: "canceled"))
       agent = insert_agent(user_id: user.id)
 
@@ -210,7 +296,10 @@ defmodule FountainWeb.ConversationControllerTest do
         conn
         |> authed_with_key(raw_key)
         |> put_req_header("content-type", "application/json")
-        |> post("/api/conversations", Jason.encode!(%{"agent_id" => unknown_agent_id, "prompt" => "hello"}))
+        |> post(
+          "/api/conversations",
+          Jason.encode!(%{"agent_id" => unknown_agent_id, "prompt" => "hello"})
+        )
 
       assert json_response(conn, 404)
     end
@@ -223,7 +312,10 @@ defmodule FountainWeb.ConversationControllerTest do
         conn
         |> authed_with_key(raw_key)
         |> put_req_header("content-type", "application/json")
-        |> post("/api/conversations", Jason.encode!(%{"agent_id" => other_agent.id, "prompt" => "hello"}))
+        |> post(
+          "/api/conversations",
+          Jason.encode!(%{"agent_id" => other_agent.id, "prompt" => "hello"})
+        )
 
       assert json_response(conn, 404)
     end
@@ -242,9 +334,16 @@ defmodule FountainWeb.ConversationControllerTest do
       assert json_response(conn, 200)["status"] == "queued"
     end
 
-    test "returns 404 when ConversationServer is not running", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 404 when ConversationServer is not running", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images -> {:error, :not_running} end)
+
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images ->
+        {:error, :not_running}
+      end)
 
       conn =
         conn
@@ -277,7 +376,10 @@ defmodule FountainWeb.ConversationControllerTest do
       assert json_response(conn, 404)
     end
 
-    test "returns 404 when conversation belongs to a different user", %{conn: conn, raw_key: raw_key} do
+    test "returns 404 when conversation belongs to a different user", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       other_user = insert_verified_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
@@ -303,7 +405,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert conn.status == 204
     end
 
-    test "returns 404 when ConversationServer is not running", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 404 when ConversationServer is not running", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
       stub(ConversationServer, :terminate, fn _id -> {:error, :not_running} end)
 
@@ -340,7 +446,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert conn.status == 204
     end
 
-    test "returns 404 when ConversationServer is not running", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 404 when ConversationServer is not running", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
       stub(ConversationServer, :interrupt, fn _id -> {:error, :not_running} end)
 
@@ -352,7 +462,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert json_response(conn, 404)
     end
 
-    test "returns 409 conflict when conversation is idle", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 409 conflict when conversation is idle", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
       stub(ConversationServer, :interrupt, fn _id -> {:error, :idle} end)
 
@@ -388,7 +502,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert json_response(conn, 404)
     end
 
-    test "returns 200 with text/event-stream content-type when wait=false", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 with text/event-stream content-type when wait=false", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
 
       conn =
@@ -406,7 +524,11 @@ defmodule FountainWeb.ConversationControllerTest do
     # exercised whenever the default (true) is used in production.
     # Instead we verify that explicitly passing wait=false (parse_bool_param
     # "false" → false) closes the stream immediately with 200.
-    test "returns 200 when wait=false is explicit (parse_bool_param \"false\" branch)", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 when wait=false is explicit (parse_bool_param \"false\" branch)", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
 
       conn =
@@ -418,7 +540,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert get_resp_header(conn, "content-type") == ["text/event-stream"]
     end
 
-    test "returns 200 when streams param is provided (parse_streams_param branch)", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 when streams param is provided (parse_streams_param branch)", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
 
       conn =
@@ -430,7 +556,8 @@ defmodule FountainWeb.ConversationControllerTest do
       assert get_resp_header(conn, "content-type") == ["text/event-stream"]
     end
 
-    test "returns 200 when Last-Event-ID is non-integer (parse_last_event_id :error branch defaults to 0)", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 when Last-Event-ID is non-integer (parse_last_event_id :error branch defaults to 0)",
+         %{conn: conn, user: user, raw_key: raw_key} do
       conv = insert_conversation(user_id: user.id)
 
       conn =
@@ -443,7 +570,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert get_resp_header(conn, "content-type") == ["text/event-stream"]
     end
 
-    test "returns 200 when wait=0 (parse_bool_param \"0\" → false, non-blocking)", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 when wait=0 (parse_bool_param \"0\" → false, non-blocking)", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
 
       conn =
@@ -455,7 +586,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert get_resp_header(conn, "content-type") == ["text/event-stream"]
     end
 
-    test "returns 200 when streams= is empty string (parse_streams_param \"\" → nil)", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 when streams= is empty string (parse_streams_param \"\" → nil)", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
 
       conn =
@@ -467,7 +602,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert get_resp_header(conn, "content-type") == ["text/event-stream"]
     end
 
-    test "returns 200 when Last-Event-ID is empty string (parse_last_event_id \"\" → 0)", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 when Last-Event-ID is empty string (parse_last_event_id \"\" → 0)", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
 
       conn =
@@ -482,7 +621,11 @@ defmodule FountainWeb.ConversationControllerTest do
   end
 
   describe "GET /api/conversations/:conversation_id/stream with log events (replay path)" do
-    test "replays existing log events when wait=false and conversation has events", %{conn: conn, user: user, raw_key: raw_key} do
+    test "replays existing log events when wait=false and conversation has events", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
       insert_log_event(conv, %{kind: "output", stream: "stdout", data: "hello"})
 
@@ -498,7 +641,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert body =~ "hello"
     end
 
-    test "replays only matching stream events when streams filter is set", %{conn: conn, user: user, raw_key: raw_key} do
+    test "replays only matching stream events when streams filter is set", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
       insert_log_event(conv, %{kind: "output", stream: "stdout", data: "stdout-data"})
       insert_log_event(conv, %{kind: "output", stream: "stderr", data: "stderr-data"})
@@ -514,7 +661,11 @@ defmodule FountainWeb.ConversationControllerTest do
       refute body =~ "stderr-data"
     end
 
-    test "replays events after last_event_id when Last-Event-ID header is set", %{conn: conn, user: user, raw_key: raw_key} do
+    test "replays events after last_event_id when Last-Event-ID header is set", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       conv = insert_conversation(user_id: user.id)
       ev1 = insert_log_event(conv, %{kind: "output", stream: "stdout", data: "first"})
       insert_log_event(conv, %{kind: "output", stream: "stdout", data: "second"})
@@ -533,7 +684,11 @@ defmodule FountainWeb.ConversationControllerTest do
   end
 
   describe "POST /api/conversations — parent conversation header" do
-    test "returns 201 when x-fountain-parent-conversation-id header is set", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 201 when x-fountain-parent-conversation-id header is set", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       agent = insert_agent(user_id: user.id)
       parent_conv = insert_conversation(user_id: user.id)
 
@@ -552,7 +707,8 @@ defmodule FountainWeb.ConversationControllerTest do
   end
 
   describe "POST /api/conversations with images" do
-    test "returns 201 with conversation when images array is provided (decode_images non-empty branch)", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 201 with conversation when images array is provided (decode_images non-empty branch)",
+         %{conn: conn, user: user, raw_key: raw_key} do
       agent = insert_agent(user_id: user.id)
 
       stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
@@ -572,7 +728,11 @@ defmodule FountainWeb.ConversationControllerTest do
       assert json_response(conn, 201)
     end
 
-    test "returns 201 with conversation when no images provided (decode_images [] branch)", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 201 with conversation when no images provided (decode_images [] branch)", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       agent = insert_agent(user_id: user.id)
 
       stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->

--- a/apps/fountain/test/fountain_web/live/billing_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/billing_live_test.exs
@@ -1,0 +1,139 @@
+defmodule FountainWeb.BillingLiveTest do
+  @moduledoc """
+  Cover for the Checkout call itself, which is where money is actually taken.
+
+  The bug this pins: when a user had no `stripe_customer_id`, Checkout was
+  opened with `customer_email`. Stripe then minted its own Customer whose id we
+  never learned, so the subscription webhook matched no user and the account was
+  charged without ever activating.
+
+  Also closes NC-5 from the release-validation report, which flagged BillingLive
+  as untested.
+  """
+
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Billing
+
+  setup do
+    original = Application.get_env(:fountain, :stripe_price_id)
+    Application.put_env(:fountain, :stripe_price_id, "price_test123")
+
+    on_exit(fn ->
+      case original do
+        nil -> Application.delete_env(:fountain, :stripe_price_id)
+        v -> Application.put_env(:fountain, :stripe_price_id, v)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "upgrade with no existing Stripe customer" do
+    test "creates the customer first and never passes customer_email", %{conn: conn} do
+      user = insert_verified_user()
+      refute user.stripe_customer_id
+
+      stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_created"}} end)
+
+      test_pid = self()
+
+      stub(Stripe.Checkout.Session, :create, fn params ->
+        send(test_pid, {:checkout_params, params})
+        {:ok, %{url: "https://checkout.stripe.test/session"}}
+      end)
+
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      render_click(lv, "manage_subscription", %{})
+
+      assert_receive {:checkout_params, params}
+
+      # The whole point: an id we control, and never an email fallback.
+      assert params.customer == "cus_created"
+      refute Map.has_key?(params, :customer_email)
+
+      # Second route home if the customer link is ever lost.
+      assert params.client_reference_id == user.id
+      assert params.mode == "subscription"
+    end
+
+    test "the created customer is persisted, so a retry reuses it", %{conn: conn} do
+      user = insert_verified_user()
+      stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_persist"}} end)
+      stub(Stripe.Checkout.Session, :create, fn _ -> {:ok, %{url: "https://checkout.test"}} end)
+
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      render_click(lv, "manage_subscription", %{})
+
+      assert Fountain.Repo.get(Fountain.Accounts.User, user.id).stripe_customer_id ==
+               "cus_persist"
+    end
+  end
+
+  describe "upgrade with an existing Stripe customer" do
+    test "reuses it without minting another", %{conn: conn} do
+      user = insert_verified_user()
+      {:ok, user} = Billing.attach_stripe_customer(user, "cus_already")
+
+      test_pid = self()
+
+      stub(Stripe.Checkout.Session, :create, fn params ->
+        send(test_pid, {:checkout_params, params})
+        {:ok, %{url: "https://checkout.test"}}
+      end)
+
+      # No stub on Stripe.Customer.create — calling it would fail the test.
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      render_click(lv, "manage_subscription", %{})
+
+      assert_receive {:checkout_params, params}
+      assert params.customer == "cus_already"
+    end
+  end
+
+  describe "active subscribers" do
+    test "are sent to the billing portal rather than Checkout", %{conn: conn} do
+      user = insert_verified_user()
+      {:ok, user} = Billing.attach_stripe_customer(user, "cus_active")
+
+      {:ok, user} =
+        user
+        |> Fountain.Accounts.User.billing_changeset(%{subscription_status: "active"})
+        |> Fountain.Repo.update()
+
+      test_pid = self()
+
+      stub(Stripe.BillingPortal.Session, :create, fn params ->
+        send(test_pid, {:portal_params, params})
+        {:ok, %{url: "https://portal.test"}}
+      end)
+
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      render_click(lv, "manage_subscription", %{})
+
+      assert_receive {:portal_params, params}
+      assert params.customer == "cus_active"
+    end
+  end
+
+  describe "when Stripe customer creation fails" do
+    test "no Checkout session is opened", %{conn: conn} do
+      user = insert_verified_user()
+
+      stub(Stripe.Customer, :create, fn _ ->
+        {:error, %Stripe.Error{source: :stripe, code: :api_error, message: "down"}}
+      end)
+
+      # No stub on Checkout.Session.create: opening one without a customer is
+      # exactly the bug, so a call here must fail the test.
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      html = render_click(lv, "manage_subscription", %{})
+
+      assert html =~ "billing" or html =~ "error" or html =~ "Billing"
+      refute Fountain.Repo.get(Fountain.Accounts.User, user.id).stripe_customer_id
+    end
+  end
+end


### PR DESCRIPTION
Closes #154, #155, #156, #157. Items 1 and 2 of the revenue sequencing.

## 1. The gate had a hole you could drive a sprite through

The subscription gate had exactly two call sites: the LiveView mount hook and `POST /api/conversations`. Both `billing.ex:11` and `decisions/0006` claim a third in `ConversationServer.init/1` — never written.

That gap was load-bearing. `POST /api/conversations/:id/prompts` wakes a dormant conversation, and waking **provisions a brand-new sprite**. It never went near a billing check. One existing conversation was enough to keep spending on the platform-paid Sprites token indefinitely after cancelling.

The mount hook has the same shape of gap in the UI: it runs once, so a socket connected while the subscription was active survives a mid-session cancellation.

The check now sits **beside the quota check**, in `start_conversation/1` and the wake path — where sprites are actually provisioned — so a new surface can't skip it. Billing is evaluated *before* quota: a cancelled tenant sitting at their cap should be told to fix billing, not to terminate conversations that wouldn't help.

## 2. Checkout was orphaning paid subscriptions

When a user had no `stripe_customer_id`, Checkout was opened with `customer_email`. Stripe minted **its own** Customer whose id we never learned, so `customer.subscription.created` matched no user, the controller logged the miss and answered **200**, and the card was charged against an account that stayed unactivated.

This was not an edge case. In production **153 of 190 accounts have no `stripe_customer_id`** — and every OAuth signup was guaranteed to be one, because `create_stripe_customer/1` was only ever called from the email-verification path, which OAuth skips entirely.

Three changes:

- **Checkout creates the Customer first** and never falls back to an email. If Stripe is down, it errors instead of opening a session that can't be reconciled.
- **`client_reference_id`** on every session, as a second route back to the user.
- **`checkout.session.completed`** backfills the link — which repairs anyone already in the orphaned state, not just new sessions.

Plus OAuth signups now get a customer and a trial date like verified signups do.

## Verified against the real failure, not just green

Both fixes were checked by reverting them and confirming the tests fail:

- **gate** — 5 failures without the context check, including both wake-path cases
- **checkout** — 3 failures with the old `customer_email` behaviour, including the one asserting `customer_email` is never sent

**Writing the HTTP test found a bug I'd otherwise have shipped:** `prompt/2` had no `case` clause for the new error tuple, so a cancelled user would have received a **500 instead of a 402**. Exactly the defect the quota tuple had in #205 — worth noting the pattern, since `prompt/2` is now the third error shape that has had to be threaded through that `case` by hand.

There's also a new `billing_live_test.exs`, which closes **NC-5** from the release-validation report (BillingLive flagged as untested since launch).

Suite: **1187 tests + 5 doctests, 0 failures** (baseline 1159). Format, `--warnings-as-errors`, credo clean.

## What this does not do

- **Trials still never expire (#153).** Nothing here changes that, so the practical revenue effect is still zero until it lands. It needs the pricing decision first.
- **No webhook idempotency (#158).** Replays and out-of-order events still corrupt state in both directions. Not urgent at current volume; is before real traffic.
- **No metering (#159).** `Billing.emit/5` still has no call sites.
- **The 153 orphaned accounts are repaired lazily** — on their next Checkout or `checkout.session.completed`, not by a backfill. Given 2 of 190 accounts have ever started a conversation, a migration seemed like more risk than it's worth. Say the word if you'd rather have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)