### PR TITLE
billing: actually emit usage events

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -25,6 +25,8 @@ defmodule Fountain.Billing do
 
   import Ecto.Query
 
+  require Logger
+
   alias Fountain.Accounts.User
   alias Fountain.Billing.UsageEvent
   alias Fountain.Repo
@@ -243,10 +245,42 @@ defmodule Fountain.Billing do
   # ─── Usage emission ─────────────────────────────────────────────────────────
 
   @doc """
+  Best-effort `emit/5`.
+
+  Metering is bookkeeping: it must never be able to fail a conversation. A bad
+  changeset, a dropped connection or an unexpected raise is logged and swallowed,
+  the same contract `Fountain.Audit.record/1` uses. The cost is that a silent
+  metering outage looks like zero usage — worth an alert once there is anything
+  to bill.
+  """
+  @spec record_usage(binary(), String.t(), binary() | nil, String.t() | nil, map()) ::
+          {:ok, UsageEvent.t()} | {:error, term()}
+  def record_usage(user_id, event_type, resource_id, resource_type, metadata \\ %{}) do
+    case emit(user_id, event_type, resource_id, resource_type, metadata) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        Logger.warning("usage: #{event_type} rejected: #{inspect(cs.errors)}")
+        {:error, :invalid}
+    end
+  rescue
+    e ->
+      Logger.warning("usage: #{event_type} failed: #{Exception.message(e)}")
+      {:error, :exception}
+  end
+
+  @doc """
   Writes a usage event synchronously to `usage_events`.
 
-  Called from `ConversationServer` at sandbox provisioning, turn start,
-  and sandbox termination points.
+  Raises nothing itself but returns `{:error, changeset}` on rejection. Callers
+  on a conversation's critical path should use `record_usage/5`, which cannot
+  fail the operation it is measuring.
+
+  Emitted from `Conversations.update_sandbox/2` and `Conversations.create_turn/1`
+  rather than from `ConversationServer`, so every path that provisions, runs or
+  tears down a sandbox is counted — including the wake path and the
+  terminate-when-the-server-is-already-dead path.
   """
   @spec emit(binary(), String.t(), binary() | nil, String.t() | nil, map()) ::
           {:ok, UsageEvent.t()} | {:error, Ecto.Changeset.t()}

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -42,10 +42,62 @@ defmodule Fountain.Conversations do
     |> Repo.insert()
   end
 
+  @doc """
+  Update a sandbox, emitting usage events on billable transitions.
+
+  Every sandbox status change in the system goes through here — fresh
+  provisioning, the wake path, and the terminate-when-the-server-is-already-dead
+  path in `ConversationServer.terminate/1`. Metering at this choke point means a
+  new caller cannot forget to record usage, which is how `Billing.emit/5` ended
+  up with no call sites at all despite being documented, schema'd and tested.
+  """
   def update_sandbox(%Sandbox{} = sandbox, attrs) do
-    sandbox
-    |> Sandbox.changeset(attrs)
-    |> Repo.update()
+    was = sandbox.status
+
+    with {:ok, updated} <- sandbox |> Sandbox.changeset(attrs) |> Repo.update() do
+      record_sandbox_usage(was, updated)
+      {:ok, updated}
+    end
+  end
+
+  @billable_terminal ~w(terminated failed)
+
+  # Transitions only: update_sandbox/2 is called repeatedly with the same status
+  # in places, and double-counting a sandbox would overstate a bill.
+  defp record_sandbox_usage(was, %Sandbox{status: "ready"} = sandbox) when was != "ready" do
+    Fountain.Billing.record_usage(
+      sandbox.user_id,
+      "sandbox_provisioned",
+      sandbox.id,
+      "sandbox",
+      %{"sprite_name" => sandbox.sprite_name}
+    )
+  end
+
+  defp record_sandbox_usage(was, %Sandbox{status: status} = sandbox)
+       when status in @billable_terminal and was not in @billable_terminal do
+    # `failed` counts too: a sprite that died mid-provision still ran, and was
+    # still billed by Sprites. Recording only clean terminations would
+    # understate cost precisely when something is going wrong.
+    Fountain.Billing.record_usage(
+      sandbox.user_id,
+      "sandbox_terminated",
+      sandbox.id,
+      "sandbox",
+      %{
+        "duration_ms" => sandbox_duration_ms(sandbox),
+        "final_status" => status
+      }
+    )
+  end
+
+  defp record_sandbox_usage(_was, _sandbox), do: :ok
+
+  defp sandbox_duration_ms(%Sandbox{inserted_at: nil}), do: 0
+
+  defp sandbox_duration_ms(%Sandbox{inserted_at: started} = sandbox) do
+    ended = sandbox.terminated_at || DateTime.utc_now()
+    ended |> DateTime.diff(started, :millisecond) |> max(0)
   end
 
   # ── conversations ─────────────────────────────────────────────────────────────────────
@@ -448,9 +500,26 @@ defmodule Fountain.Conversations do
   end
 
   def create_turn(attrs) do
-    %Turn{}
-    |> Turn.changeset(attrs)
-    |> Repo.insert()
+    with {:ok, turn} <- %Turn{} |> Turn.changeset(attrs) |> Repo.insert() do
+      record_turn_usage(turn)
+      {:ok, turn}
+    end
+  end
+
+  # Turns carry no user_id of their own, so resolve it through the conversation.
+  # One narrow select per turn, and turns are prompt-frequency rather than
+  # request-frequency, so this is not a hot path.
+  defp record_turn_usage(%Turn{} = turn) do
+    case Repo.one(from c in Conversation, where: c.id == ^turn.conversation_id, select: c.user_id) do
+      nil ->
+        :ok
+
+      user_id ->
+        Fountain.Billing.record_usage(user_id, "turn_started", turn.id, "turn", %{
+          "conversation_id" => turn.conversation_id,
+          "turn_number" => turn.turn_number
+        })
+    end
   end
 
   def update_turn(%Turn{} = turn, attrs) do

--- a/apps/fountain/test/fountain/usage_metering_test.exs
+++ b/apps/fountain/test/fountain/usage_metering_test.exs
@@ -1,0 +1,205 @@
+defmodule Fountain.UsageMeteringTest do
+  @moduledoc """
+  Usage events, emitted where sandboxes and turns actually change state.
+
+  `Billing.emit/5` was defined, documented as being called from
+  `ConversationServer`, schema'd, and unit-tested — with **no call sites**. So
+  `usage_events` was permanently empty and `/account/billing` rendered zeros to
+  every user. The lesson those tests didn't catch is the one pinned here:
+  emission has to be verified from the operations that cause it, not from the
+  emit function in isolation.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.{Billing, Conversations}
+  alias Fountain.Billing.UsageEvent
+  alias Fountain.Repo
+
+  defp events_for(user_id, type) do
+    Repo.all(from e in UsageEvent, where: e.user_id == ^user_id and e.event_type == ^type)
+  end
+
+  describe "sandbox_provisioned" do
+    test "is emitted when a sandbox becomes ready" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+
+      assert [event] = events_for(user.id, "sandbox_provisioned")
+      assert event.resource_id == sandbox.id
+      assert event.resource_type == "sandbox"
+    end
+
+    test "is not emitted for intermediate transitions" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
+
+      assert events_for(user.id, "sandbox_provisioned") == []
+    end
+
+    test "is emitted once even if ready is written repeatedly" do
+      # Reattach and rehydration both re-assert `ready`. Counting each write
+      # would inflate the bill for a conversation that was merely resumed.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      {:ok, ready} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      {:ok, ready} = Conversations.update_sandbox(ready, %{status: "ready"})
+      {:ok, _} = Conversations.update_sandbox(ready, %{status: "ready"})
+
+      assert length(events_for(user.id, "sandbox_provisioned")) == 1
+    end
+  end
+
+  describe "sandbox_terminated" do
+    test "is emitted with a duration when a sandbox is terminated" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      {:ok, _} =
+        Conversations.update_sandbox(sandbox, %{
+          status: "terminated",
+          terminated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      assert [event] = events_for(user.id, "sandbox_terminated")
+      assert is_integer(event.metadata["duration_ms"])
+      assert event.metadata["duration_ms"] >= 0
+      assert event.metadata["final_status"] == "terminated"
+    end
+
+    test "a failed sandbox counts too — it still ran and was still billed" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "starting")
+
+      {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
+
+      assert [event] = events_for(user.id, "sandbox_terminated")
+      assert event.metadata["final_status"] == "failed"
+    end
+
+    test "is emitted once even if termination is written twice" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      {:ok, term} = Conversations.update_sandbox(sandbox, %{status: "terminated"})
+      {:ok, _} = Conversations.update_sandbox(term, %{status: "terminated"})
+
+      assert length(events_for(user.id, "sandbox_terminated")) == 1
+    end
+  end
+
+  describe "turn_started" do
+    test "is emitted when a turn is created" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+
+      {:ok, turn} =
+        Conversations.create_turn(%{
+          conversation_id: conv.id,
+          turn_number: 1,
+          prompt: "hello",
+          status: "running"
+        })
+
+      assert [event] = events_for(user.id, "turn_started")
+      assert event.resource_id == turn.id
+      assert event.metadata["conversation_id"] == conv.id
+    end
+
+    test "is attributed to the conversation's owner" do
+      owner = insert_verified_user()
+      other = insert_verified_user()
+      conv = insert_conversation(user_id: owner.id)
+
+      {:ok, _} =
+        Conversations.create_turn(%{
+          conversation_id: conv.id,
+          turn_number: 1,
+          prompt: "x",
+          status: "running"
+        })
+
+      assert length(events_for(owner.id, "turn_started")) == 1
+      assert events_for(other.id, "turn_started") == []
+    end
+  end
+
+  describe "usage_summary/3 against real emissions" do
+    test "reports what actually happened" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      {:ok, ready} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+
+      for n <- 1..3 do
+        {:ok, _} =
+          Conversations.create_turn(%{
+            conversation_id: conv.id,
+            turn_number: n,
+            prompt: "p#{n}",
+            status: "running"
+          })
+      end
+
+      {:ok, _} =
+        Conversations.update_sandbox(ready, %{
+          status: "terminated",
+          terminated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      summary =
+        Billing.usage_summary(
+          user.id,
+          DateTime.utc_now() |> DateTime.add(-3600, :second),
+          DateTime.utc_now() |> DateTime.add(3600, :second)
+        )
+
+      # This is the assertion that would have caught the missing call sites:
+      # before, every one of these was zero no matter what the user did.
+      assert summary.conversations == 1
+      assert summary.turns == 3
+      assert summary.sandbox_minutes >= 0.0
+    end
+
+    test "one tenant's usage is not another's" do
+      a = insert_verified_user()
+      b = insert_verified_user()
+
+      insert_sandbox(user_id: a.id, status: "pending")
+      |> Conversations.update_sandbox(%{status: "ready"})
+
+      window = {
+        DateTime.utc_now() |> DateTime.add(-3600, :second),
+        DateTime.utc_now() |> DateTime.add(3600, :second)
+      }
+
+      {from, to} = window
+      assert Billing.usage_summary(a.id, from, to).conversations == 1
+      assert Billing.usage_summary(b.id, from, to).conversations == 0
+    end
+  end
+
+  describe "record_usage/5 is best effort" do
+    test "an invalid event type is logged, not raised" do
+      user = insert_verified_user()
+
+      assert {:error, :invalid} =
+               Billing.record_usage(user.id, "not_a_real_event", nil, nil, %{})
+    end
+
+    test "a metering failure does not fail the operation being measured" do
+      # The contract that matters: bookkeeping must never break a conversation.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      assert {:ok, updated} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      assert updated.status == "ready"
+    end
+  end
+end


### PR DESCRIPTION
Closes #159. Item 3 of the revenue sequencing.

## The gap

`Billing.emit/5` was defined, documented as being called *"from `ConversationServer` at sandbox provisioning, turn start, and sandbox termination points"*, given a schema, a migration, and unit tests — and had **no call sites anywhere in the codebase**.

So `usage_events` was permanently empty, `usage_summary/3` always returned zeros, and `/account/billing` rendered those zeros to every user, including the one paying account. Every artifact of a working feature existed except the feature.

## Where emission goes, and why not where the docs said

Not `ConversationServer`. In `Conversations.update_sandbox/2` and `create_turn/1`.

Every sandbox status change in the system passes through `update_sandbox/2` — fresh provisioning, the wake path, and the terminate-when-the-server-is-already-dead branch of `ConversationServer.terminate/1`. Metering at that choke point can't be forgotten by a new caller, which is precisely how this ended up unwired. It's the same reasoning as the quota check in #205 and the billing gate in #212: put the cross-cutting check where the state actually changes, not at each call site.

Two decisions worth reviewing:

**Only transitions count.** `update_sandbox/2` is called repeatedly with the same status in places — reattach and rehydration both re-assert `ready`. Counting each write would overstate a bill for a conversation that was merely resumed.

**Failed sandboxes emit `sandbox_terminated`.** A sprite that died mid-provision still ran and was still billed by Sprites. Recording only clean terminations would understate cost exactly when something is going wrong. The `final_status` metadata keeps the two distinguishable.

`record_usage/5` wraps `emit/5` so bookkeeping can never fail the operation it measures — the same contract `Audit.record/1` uses. The tradeoff is real and worth naming: a silent metering outage now looks identical to zero usage. Worth an alert once there's anything to bill.

## Testing the thing that was actually broken

The existing tests covered `emit/5` in isolation and **passed happily throughout**, which is why this shipped. So the new tests assert from the operations that cause emission rather than from the emit function:

- **9 of the 12 fail if the call sites are removed again** — verified by reverting.
- double-emission is pinned in both directions (repeated `ready`, repeated `terminated`)
- `usage_summary/3` is asserted against real emissions rather than hand-inserted rows — that assertion is the one that would have caught the original bug, since every field was zero no matter what the user did
- cross-tenant attribution, and that a turn is billed to the conversation's owner

Suite: **1199 tests + 5 doctests, 0 failures** (baseline 1187). Format, `--warnings-as-errors`, credo clean.

## What this unblocks

You now get real data on conversations, turns and sandbox-minutes per tenant — which is the input the pricing decision needs. Right now nobody knows what a user actually costs, so any per-seat or usage-based tier would be a guess.

Worth being clear about scope: **this meters, it does not enforce or charge.** No per-plan quotas, no usage-based billing, no reporting beyond the existing `/account/billing` panel (which will now show real numbers instead of zeros).

## Still open in the cluster

- **#153 — trials never expire.** Still the one that makes revenue actually zero, and still blocked on the pricing question.
- **#158 — webhook idempotency.** Replays and out-of-order events still corrupt subscription state in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)