### PR TITLE
billing: make Stripe webhooks idempotent and order-aware

### DIFF
--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -23,6 +23,9 @@ defmodule Fountain.Accounts.User do
     field :stripe_customer_id, :string
     field :subscription_status, :string, default: "trialing"
     field :trial_ends_at, :utc_datetime
+    # Stripe `created` of the last subscription event applied — the ordering
+    # guard's watermark. See Billing.sync_subscription/1.
+    field :subscription_synced_at, :utc_datetime
     field :session_version, :integer, default: 0
     field :theme_preference, :string, default: "system"
     field :conversations_roots_only, :boolean, default: false
@@ -80,7 +83,12 @@ defmodule Fountain.Accounts.User do
   @doc "Changeset for billing field updates (driven by Stripe webhooks)."
   def billing_changeset(user, attrs) do
     user
-    |> cast(attrs, [:stripe_customer_id, :subscription_status, :trial_ends_at])
+    |> cast(attrs, [
+      :stripe_customer_id,
+      :subscription_status,
+      :trial_ends_at,
+      :subscription_synced_at
+    ])
     |> validate_inclusion(:subscription_status, @subscription_statuses)
   end
 
@@ -94,7 +102,11 @@ defmodule Fountain.Accounts.User do
   @doc "Changeset for updating conversation filter preferences."
   def preferences_changeset(user, attrs) do
     user
-    |> cast(attrs, [:conversations_roots_only, :conversation_visible_streams, :conversation_view_mode])
+    |> cast(attrs, [
+      :conversations_roots_only,
+      :conversation_visible_streams,
+      :conversation_view_mode
+    ])
     |> validate_subset(:conversation_visible_streams, @visible_stream_values)
     |> validate_inclusion(:conversation_view_mode, @view_mode_values)
   end

--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -138,6 +138,49 @@ defmodule Fountain.Billing do
   # ─── Webhook sync ───────────────────────────────────────────────────────────
 
   @doc """
+  Entry point for a verified Stripe webhook event.
+
+  Claims the event id first, so a redelivery is a no-op rather than a second
+  application. Stripe retries a failed delivery for up to three days and makes
+  no ordering promise, so without this a replayed
+  `customer.subscription.updated{active}` arriving after `.deleted` silently
+  reactivates a cancelled account.
+
+  Returns `{:ok, :duplicate}` for an event already seen.
+  """
+  @spec handle_event(Stripe.Event.t()) ::
+          {:ok, User.t() | :ignored | :duplicate | :stale} | {:error, term()}
+  def handle_event(%Stripe.Event{id: id, type: type} = event) when is_binary(id) do
+    if claim_event(id, type) == :claimed do
+      sync_subscription(event)
+    else
+      {:ok, :duplicate}
+    end
+  end
+
+  # No id (hand-built events in tests) — nothing to dedupe against.
+  def handle_event(%Stripe.Event{} = event), do: sync_subscription(event)
+
+  # Atomic claim: the unique primary key is what makes concurrent deliveries of
+  # the same event resolve to exactly one winner.
+  defp claim_event(id, type) do
+    {count, _} =
+      Repo.insert_all(
+        "stripe_events",
+        [
+          %{
+            id: id,
+            type: type,
+            inserted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+          }
+        ],
+        on_conflict: :nothing
+      )
+
+    if count == 1, do: :claimed, else: :duplicate
+  end
+
+  @doc """
   Syncs `users.subscription_status` (and `trial_ends_at`) from a verified
   Stripe webhook event.
 
@@ -171,7 +214,7 @@ defmodule Fountain.Billing do
     end
   end
 
-  def sync_subscription(%Stripe.Event{type: type, data: %{object: sub}})
+  def sync_subscription(%Stripe.Event{type: type, data: %{object: sub}} = event)
       when type in [
              "customer.subscription.created",
              "customer.subscription.updated",
@@ -186,21 +229,42 @@ defmodule Fountain.Billing do
         ts when is_integer(ts) -> DateTime.from_unix!(ts) |> DateTime.truncate(:second)
       end
 
+    event_created = event_created_at(event)
+
     case get_user_by_stripe_customer_id(customer_id) do
       nil ->
         {:error, :user_not_found}
 
       user ->
-        user
-        |> User.billing_changeset(%{
-          subscription_status: status,
-          trial_ends_at: trial_ends_at
-        })
-        |> Repo.update()
+        if stale?(user.subscription_synced_at, event_created) do
+          # An older event arriving after a newer one. Applying it would move the
+          # account backwards — reactivating a cancellation, or re-locking an
+          # account that has already recovered.
+          {:ok, :stale}
+        else
+          user
+          |> User.billing_changeset(%{
+            subscription_status: status,
+            trial_ends_at: trial_ends_at,
+            subscription_synced_at: event_created || user.subscription_synced_at
+          })
+          |> Repo.update()
+        end
     end
   end
 
   def sync_subscription(_event), do: {:ok, :ignored}
+
+  defp event_created_at(%Stripe.Event{created: ts}) when is_integer(ts),
+    do: DateTime.from_unix!(ts) |> DateTime.truncate(:second)
+
+  defp event_created_at(_), do: nil
+
+  # Unknown timestamps are treated as fresh: refusing to apply an event we
+  # cannot order would be worse than applying it.
+  defp stale?(nil, _incoming), do: false
+  defp stale?(_synced, nil), do: false
+  defp stale?(synced, incoming), do: DateTime.compare(incoming, synced) == :lt
 
   # ─── Usage summary ──────────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain_web/controllers/stripe_webhook_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/stripe_webhook_controller.ex
@@ -27,8 +27,16 @@ defmodule FountainWeb.StripeWebhookController do
 
     case Stripe.Webhook.construct_event(raw_body, sig_header, secret) do
       {:ok, event} ->
-        process_event(event)
-        send_resp(conn, 200, "")
+        case process_event(event) do
+          :ok ->
+            send_resp(conn, 200, "")
+
+          :retry ->
+            # 500 so Stripe redelivers. Previously every outcome answered 200,
+            # which threw away the only recovery mechanism there is for a
+            # transient failure — the event was logged and then gone forever.
+            send_resp(conn, 500, "")
+        end
 
       {:error, reason} ->
         Logger.warning("[stripe_webhook] Signature verification failed: #{inspect(reason)}")
@@ -37,13 +45,32 @@ defmodule FountainWeb.StripeWebhookController do
   end
 
   defp process_event(event) do
-    case Billing.sync_subscription(event) do
+    case Billing.handle_event(event) do
+      {:ok, :duplicate} ->
+        Logger.info("[stripe_webhook] Ignoring duplicate delivery of #{event.id}")
+        :ok
+
+      {:ok, :stale} ->
+        Logger.info("[stripe_webhook] Ignoring out-of-order event #{event.id}")
+        :ok
+
       {:ok, _} ->
+        :ok
+
+      # Retrying cannot fix an event whose customer we do not recognise, so
+      # acknowledge it rather than making Stripe redeliver for three days.
+      {:error, :user_not_found} ->
+        Logger.error("[stripe_webhook] No user for event #{event.id} (#{event.type})")
         :ok
 
       {:error, reason} ->
         Logger.error("[stripe_webhook] Event processing error: #{inspect(reason)}")
+        :retry
     end
+  rescue
+    e ->
+      Logger.error("[stripe_webhook] Unhandled error: #{Exception.message(e)}")
+      :retry
   end
 
   defp webhook_secret do

--- a/apps/fountain/priv/repo/migrations/20260801120000_create_stripe_events.exs
+++ b/apps/fountain/priv/repo/migrations/20260801120000_create_stripe_events.exs
@@ -1,0 +1,24 @@
+defmodule Fountain.Repo.Migrations.CreateStripeEvents do
+  use Ecto.Migration
+
+  # Stripe retries a failed delivery for up to three days, and does not promise
+  # ordering. Without a record of what has already been applied, a redelivered
+  # `customer.subscription.updated{active}` arriving after `.deleted` silently
+  # reactivates a cancelled account — and the reverse locks out a paying one.
+  def change do
+    create table(:stripe_events, primary_key: false) do
+      # Stripe's own event id (evt_...) is the natural key; the unique index is
+      # what makes claiming an event atomic under concurrent deliveries.
+      add :id, :string, primary_key: true
+      add :type, :string, null: false
+      add :inserted_at, :utc_datetime, null: false
+    end
+
+    # Watermark for the ordering guard: the `created` timestamp of the most
+    # recent subscription event actually applied to this user. Anything older
+    # is stale and ignored.
+    alter table(:users) do
+      add :subscription_synced_at, :utc_datetime
+    end
+  end
+end

--- a/apps/fountain/test/fountain/stripe_webhook_idempotency_test.exs
+++ b/apps/fountain/test/fountain/stripe_webhook_idempotency_test.exs
@@ -1,0 +1,219 @@
+defmodule Fountain.StripeWebhookIdempotencyTest do
+  @moduledoc """
+  Replay and ordering protection for Stripe webhooks.
+
+  Stripe retries a failed delivery for up to three days and makes no ordering
+  promise. Without a record of what has been applied, both directions corrupt
+  state: a replayed `updated{active}` landing after `.deleted` reactivates a
+  cancelled account, and a stale `past_due` landing after recovery locks out a
+  paying one.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Billing
+  alias Fountain.Repo
+
+  defp user_with_customer(customer_id) do
+    user = insert_verified_user()
+    {:ok, user} = Billing.attach_stripe_customer(user, customer_id)
+    user
+  end
+
+  defp sub_event(id, type, customer, status, created) do
+    %Stripe.Event{
+      id: id,
+      type: type,
+      created: created,
+      data: %{object: %{customer: customer, status: status, trial_end: nil}}
+    }
+  end
+
+  defp now_unix, do: DateTime.utc_now() |> DateTime.to_unix()
+
+  describe "replay protection" do
+    test "the same event id is applied once" do
+      user = user_with_customer("cus_replay")
+
+      event =
+        sub_event("evt_1", "customer.subscription.created", "cus_replay", "active", now_unix())
+
+      assert {:ok, updated} = Billing.handle_event(event)
+      assert updated.subscription_status == "active"
+
+      assert {:ok, :duplicate} = Billing.handle_event(event)
+      assert Repo.reload(user).subscription_status == "active"
+    end
+
+    test "a redelivered activation cannot resurrect a cancelled account" do
+      # The scenario that motivates this: Stripe retries an older event after a
+      # newer one has already been applied.
+      user = user_with_customer("cus_zombie")
+      t0 = now_unix()
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event("evt_active", "customer.subscription.updated", "cus_zombie", "active", t0)
+        )
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event(
+            "evt_gone",
+            "customer.subscription.deleted",
+            "cus_zombie",
+            "canceled",
+            t0 + 10
+          )
+        )
+
+      assert Repo.reload(user).subscription_status == "canceled"
+
+      # Stripe redelivers the activation.
+      assert {:ok, :duplicate} =
+               Billing.handle_event(
+                 sub_event(
+                   "evt_active",
+                   "customer.subscription.updated",
+                   "cus_zombie",
+                   "active",
+                   t0
+                 )
+               )
+
+      assert Repo.reload(user).subscription_status == "canceled"
+    end
+
+    test "distinct event ids are each applied" do
+      user = user_with_customer("cus_two")
+      t0 = now_unix()
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event("evt_a", "customer.subscription.updated", "cus_two", "active", t0)
+        )
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event("evt_b", "customer.subscription.updated", "cus_two", "past_due", t0 + 5)
+        )
+
+      assert Repo.reload(user).subscription_status == "past_due"
+    end
+  end
+
+  describe "ordering guard" do
+    test "an out-of-order older event is ignored" do
+      # Same account, different event ids, delivered newest-first.
+      user = user_with_customer("cus_order")
+      t0 = now_unix()
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event("evt_new", "customer.subscription.deleted", "cus_order", "canceled", t0 + 60)
+        )
+
+      assert {:ok, :stale} =
+               Billing.handle_event(
+                 sub_event("evt_old", "customer.subscription.updated", "cus_order", "active", t0)
+               )
+
+      assert Repo.reload(user).subscription_status == "canceled"
+    end
+
+    test "a stale past_due cannot re-lock a recovered account" do
+      user = user_with_customer("cus_recover")
+      t0 = now_unix()
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event(
+            "evt_recovered",
+            "customer.subscription.updated",
+            "cus_recover",
+            "active",
+            t0 + 60
+          )
+        )
+
+      assert {:ok, :stale} =
+               Billing.handle_event(
+                 sub_event(
+                   "evt_late",
+                   "customer.subscription.updated",
+                   "cus_recover",
+                   "past_due",
+                   t0
+                 )
+               )
+
+      assert Repo.reload(user).subscription_status == "active"
+    end
+
+    test "a newer event still applies" do
+      user = user_with_customer("cus_fwd")
+      t0 = now_unix()
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event("evt_first", "customer.subscription.updated", "cus_fwd", "active", t0)
+        )
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event("evt_second", "customer.subscription.deleted", "cus_fwd", "canceled", t0 + 30)
+        )
+
+      assert Repo.reload(user).subscription_status == "canceled"
+    end
+
+    test "an event with no timestamp is treated as fresh rather than dropped" do
+      user = user_with_customer("cus_nots")
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event("evt_ts", "customer.subscription.updated", "cus_nots", "active", now_unix())
+        )
+
+      assert {:ok, updated} =
+               Billing.handle_event(
+                 sub_event(
+                   "evt_nots",
+                   "customer.subscription.updated",
+                   "cus_nots",
+                   "past_due",
+                   nil
+                 )
+               )
+
+      assert updated.subscription_status == "past_due"
+      assert Repo.reload(user).subscription_status == "past_due"
+    end
+  end
+
+  describe "unrelated events" do
+    test "an unhandled type is claimed but ignored" do
+      event = %Stripe.Event{
+        id: "evt_other",
+        type: "invoice.paid",
+        created: now_unix(),
+        data: %{object: %{}}
+      }
+
+      assert {:ok, :ignored} = Billing.handle_event(event)
+      assert {:ok, :duplicate} = Billing.handle_event(event)
+    end
+
+    test "an event without an id still works, for hand-built events" do
+      user = user_with_customer("cus_noid")
+
+      event = %Stripe.Event{
+        type: "customer.subscription.updated",
+        data: %{object: %{customer: "cus_noid", status: "active", trial_end: nil}}
+      }
+
+      assert {:ok, updated} = Billing.handle_event(event)
+      assert updated.id == user.id
+    end
+  end
+end


### PR DESCRIPTION
Closes #158. Item 4 of the revenue sequencing.

## The problem

`sync_subscription/1` applied whatever status arrived, with no record of what had already been handled. Stripe retries a failed delivery for up to three days and makes no ordering promise, so **both directions corrupted state**:

- a redelivered `customer.subscription.updated{active}` landing after `.deleted` **silently reactivates a cancelled account**
- a stale `past_due` landing after recovery **locks out a paying customer**

## Two separate mechanisms, because they solve different problems

**Replay** is handled by claiming the event id against a new `stripe_events` table before applying it. The unique primary key is what makes the claim atomic — concurrent deliveries of the same event resolve to exactly one winner rather than racing.

**Ordering** needs its own guard, because distinct event ids can still arrive out of order and dedup won't catch that. `users.subscription_synced_at` records the Stripe `created` timestamp of the last subscription event actually applied; anything older is ignored.

Events with no timestamp are treated as **fresh**, not stale. Refusing to apply an event we can't order would be a worse failure than applying it — the conservative-looking choice here is the dangerous one.

## The controller was discarding Stripe's retries

Every outcome answered `200`, including failures. So the only recovery path for a transient error — a dropped DB connection mid-sync — was a log line, and the event was gone forever.

Now transient failures return `500` so Stripe redelivers, while `:user_not_found` still returns `200`, since no amount of retrying will conjure a customer we don't recognise. There's also a `rescue` so an unexpected raise becomes a retry rather than a 500 with no signal.

## Verified against the real corruption

Both mechanisms were checked by disabling them: **5 of 9 tests fail** without the claim and the ordering guard, including the two headline scenarios:

- *"a redelivered activation cannot resurrect a cancelled account"*
- *"a stale past_due cannot re-lock a recovered account"*

Those are written as the actual sequences Stripe would deliver, not as unit tests of the guard functions — the same lesson as #213, where `emit/5` had passing tests and no call sites.

Migration verified `up`/`down`/`up`. Suite: **1208 tests + 5 doctests, 0 failures** (baseline 1199). Format, `--warnings-as-errors`, credo clean.

## Notes

- `stripe_events` grows one row per event received and nothing prunes it. At current volume that's negligible, but it belongs on the retention list in #164 rather than being forgotten.
- The ordering guard is per-user, keyed on the last applied subscription event. That's correct for one subscription per customer, which is what the current model assumes. If a customer ever has two subscriptions, this needs to key on the subscription id instead — worth remembering if the pricing decision introduces multiple products.

## Revenue cluster status

With this, everything actionable is done: #154, #155, #156, #157, #158, #159 all closed. **#153 (trials never expire) is the only one left**, and it's still blocked on the pricing question — what the product actually is, given the marketing page advertises "$29/mo per team" and there's no team entity in the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)