### PR TITLE
security: scope the conversation spawn graph to its tenant

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -182,9 +182,12 @@ defmodule Fountain.Conversations do
     Repo.all(
       from c in Conversation,
         where: c.user_id == ^user_id and c.status != "terminated",
-        left_join: tc in subquery(turn_counts), on: tc.conversation_id == c.id,
-        left_join: lt in subquery(last_turn_at), on: lt.conversation_id == c.id,
-        left_join: ll in subquery(last_log_at), on: ll.conversation_id == c.id,
+        left_join: tc in subquery(turn_counts),
+        on: tc.conversation_id == c.id,
+        left_join: lt in subquery(last_turn_at),
+        on: lt.conversation_id == c.id,
+        left_join: ll in subquery(last_log_at),
+        on: ll.conversation_id == c.id,
         order_by: [
           desc:
             fragment(
@@ -215,13 +218,75 @@ defmodule Fountain.Conversations do
 
   @doc """
   Returns all conversations in the same spawn tree as `conversation_id`,
-  including ancestors up to the root and all their descendants.
+  scoped to `user_id`.
 
   Each entry is a map with keys: :id, :source, :status, :parent_id
 
-  Returns `[]` when `conversation_id` does not exist.
+  Returns `[]` when the conversation does not exist or belongs to someone else.
+
+  Every reference to `conversations` carries the tenant predicate. Without it
+  the recursion walks straight across tenant boundaries, which leaked
+  conversation ids, sources and statuses in both directions: a conversation
+  parented onto another tenant's conversation pulled their whole tree into this
+  view, and put this one into theirs.
+
+  The root is the furthest *reachable* ancestor rather than the one with a NULL
+  parent. For clean data those are the same node. They differ only where a
+  foreign parent link already exists in the data, and picking the boundary node
+  degrades to "show the part of the tree you own" instead of returning nothing.
   """
-  def get_conversation_tree(conversation_id) do
+  def get_conversation_tree(conversation_id, user_id) when is_binary(user_id) do
+    sql = """
+    WITH RECURSIVE
+    ancestors(id, parent_conversation_id, depth) AS (
+      SELECT id, parent_conversation_id, 0
+      FROM conversations WHERE id = $1 AND user_id = $2
+      UNION ALL
+      SELECT c.id, c.parent_conversation_id, a.depth + 1
+      FROM conversations c
+      INNER JOIN ancestors a ON c.id = a.parent_conversation_id
+      -- depth bound: parent links are client-supplied, and a cycle would
+      -- otherwise spin this CTE forever.
+      WHERE c.user_id = $2 AND a.depth < 100
+    ),
+    root_row AS (
+      SELECT id FROM ancestors ORDER BY depth DESC LIMIT 1
+    ),
+    tree(id, source, status, parent_id, depth) AS (
+      SELECT c.id, c.source, c.status, c.parent_conversation_id, 0
+      FROM conversations c, root_row r
+      WHERE c.id = r.id AND c.user_id = $2
+      UNION ALL
+      SELECT c.id, c.source, c.status, c.parent_conversation_id, t.depth + 1
+      FROM conversations c
+      INNER JOIN tree t ON c.parent_conversation_id = t.id
+      WHERE c.user_id = $2 AND t.depth < 100
+    )
+    SELECT id, source, status, parent_id FROM tree
+    """
+
+    with {:ok, conv_uuid} <- Ecto.UUID.dump(conversation_id),
+         {:ok, user_uuid} <- Ecto.UUID.dump(user_id) do
+      %{rows: rows} = Repo.query!(sql, [conv_uuid, user_uuid])
+
+      Enum.map(rows, fn [id, source, status, parent_id] ->
+        %{
+          id: load_uuid!(id),
+          source: source,
+          status: status,
+          parent_id: load_uuid(parent_id)
+        }
+      end)
+    else
+      _ -> []
+    end
+  end
+
+  @doc """
+  WARNING: walks the spawn tree across all tenants. Admin/internal use only —
+  user-facing callers must use `get_conversation_tree/2`.
+  """
+  def _unsafe_get_conversation_tree(conversation_id) do
     sql = """
     WITH RECURSIVE
     ancestors(id, parent_conversation_id) AS (
@@ -338,7 +403,8 @@ defmodule Fountain.Conversations do
       from c in Conversation,
         as: :conv,
         where: c.user_id == ^user_id,
-        left_join: ll in subquery(last_log_at), on: ll.conversation_id == c.id,
+        left_join: ll in subquery(last_log_at),
+        on: ll.conversation_id == c.id,
         order_by: [desc: c.updated_at, desc: c.id],
         select: %{
           c
@@ -406,7 +472,9 @@ defmodule Fountain.Conversations do
            ),
            set: [last_read_at: now]
          ) do
-      {0, _} -> :ok
+      {0, _} ->
+        :ok
+
       {_, _} ->
         broadcast_sidebar_update(user_id)
         :ok
@@ -658,12 +726,14 @@ defmodule Fountain.Conversations do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
+         {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Billing.check_active(user_id),
          :ok <- Fountain.Quotas.check_sandbox_quota(user_id),
          {:ok, sandbox} <-
            create_sandbox(%{
              environment_id: agent.environment_id,
-             sprite_name: attrs["sprite_name"] || "fountain-#{tenant_prefix(user_id)}-#{short_id()}",
+             sprite_name:
+               attrs["sprite_name"] || "fountain-#{tenant_prefix(user_id)}-#{short_id()}",
              status: "pending",
              user_id: user_id
            }),
@@ -676,7 +746,7 @@ defmodule Fountain.Conversations do
              runtime: agent.runtime,
              status: "pending",
              source: attrs["source"] || "api",
-             parent_conversation_id: attrs["parent_conversation_id"]
+             parent_conversation_id: parent_id
            }) do
       start_result =
         Horde.DynamicSupervisor.start_child(
@@ -707,7 +777,10 @@ defmodule Fountain.Conversations do
           # sandbox failed so the status is visible on the conversation page,
           # then return it so callers (UI + API) navigate there rather than
           # leaving the user stuck on the new-conversation form.
-          Logger.error("ConversationServer failed to start for conv #{conv.id}: #{inspect(reason)}")
+          Logger.error(
+            "ConversationServer failed to start for conv #{conv.id}: #{inspect(reason)}"
+          )
+
           update_conversation(conv, %{status: "failed"})
           update_sandbox(sandbox, %{status: "failed"})
           result = _unsafe_get_conversation!(conv.id)
@@ -764,6 +837,23 @@ defmodule Fountain.Conversations do
   defp short_id, do: Ecto.UUID.generate() |> binary_part(0, 8)
 
   defp tenant_prefix(user_id) when is_binary(user_id), do: binary_part(user_id, 0, 8)
+
+  # `parent_conversation_id` arrives from a client-supplied header
+  # (X-Fountain-Parent-Conversation-Id). The changeset only enforced an FK, so
+  # any conversation id in the system was accepted — including another tenant's,
+  # which grafted this conversation onto their spawn tree and theirs onto ours.
+  #
+  # A legitimate spawn comes from inside a sprite holding that tenant's own
+  # token, so ownership always matches; a mismatch is a bug or an attack.
+  defp resolve_parent_id(nil, _user_id), do: {:ok, nil}
+  defp resolve_parent_id("", _user_id), do: {:ok, nil}
+
+  defp resolve_parent_id(id, user_id) when is_binary(id) and is_binary(user_id) do
+    case get_conversation(id, user_id) do
+      nil -> {:error, :parent_not_found}
+      conv -> {:ok, conv.id}
+    end
+  end
 
   defp resolve_vault_id(nil, _user_id, _agent), do: {:ok, nil}
   defp resolve_vault_id("", _user_id, _agent), do: {:ok, nil}

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -33,6 +33,14 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "vault_not_allowed", message: "vault is not in the agent's allowed_vault_ids"})
   end
 
+  # An unknown or cross-tenant parent conversation. 404 rather than 403 so the
+  # caller cannot use the response to probe which conversation ids exist.
+  def call(conn, {:error, :parent_not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> json(%{error: "parent_conversation_not_found"})
+  end
+
   # Subscription gate (ADR 0006). Raised from the context so every provisioning
   # path renders the same response, rather than each controller inventing one.
   def call(conn, {:error, :subscription_required}) do

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -22,7 +22,7 @@ defmodule FountainWeb.ConversationsLive.Show do
         {:ok, socket |> put_flash(:error, "Conversation not found") |> push_navigate(to: ~p"/conversations")}
 
       conv ->
-        graph = Conversations.get_conversation_tree(id)
+        graph = Conversations.get_conversation_tree(id, socket.assigns.current_user.id)
 
         if connected?(socket) do
           Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{id}")
@@ -122,7 +122,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   @impl true
   def handle_info({:graph_updated}, socket) do
     id = socket.assigns.conv.id
-    {:noreply, assign(socket, :graph, Conversations.get_conversation_tree(id))}
+    {:noreply, assign(socket, :graph, Conversations.get_conversation_tree(id, socket.assigns.current_user.id))}
   end
 
   @impl true

--- a/apps/fountain/test/fountain/conversation_tree_scoping_test.exs
+++ b/apps/fountain/test/fountain/conversation_tree_scoping_test.exs
@@ -1,0 +1,155 @@
+defmodule Fountain.ConversationTreeScopingTest do
+  @moduledoc """
+  Tenant scoping for the conversation spawn graph.
+
+  Two defects, one feeding the other. `parent_conversation_id` came straight
+  from a client header and the changeset only enforced a foreign key, so any
+  conversation id in the system was accepted — including another tenant's. And
+  `get_conversation_tree/1` was raw recursive SQL with no `user_id` predicate,
+  so it happily walked across that link. The result leaked conversation ids,
+  sources and statuses in *both* directions: the attacker's view pulled in the
+  victim's tree, and the victim's view showed the attacker's node.
+  """
+
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+
+  setup do
+    stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+    :ok
+  end
+
+  describe "parent_conversation_id validation" do
+    test "another tenant's conversation is rejected" do
+      victim = insert_verified_user()
+      attacker = insert_verified_user()
+      victim_conv = insert_conversation(user_id: victim.id)
+      agent = insert_agent(user_id: attacker.id)
+
+      assert {:error, :parent_not_found} =
+               Conversations.start_conversation(%{
+                 "agent_id" => agent.id,
+                 "user_id" => attacker.id,
+                 "parent_conversation_id" => victim_conv.id
+               })
+    end
+
+    test "a nonexistent conversation is rejected" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      assert {:error, :parent_not_found} =
+               Conversations.start_conversation(%{
+                 "agent_id" => agent.id,
+                 "user_id" => user.id,
+                 "parent_conversation_id" => Ecto.UUID.generate()
+               })
+    end
+
+    test "the caller's own conversation is accepted" do
+      user = insert_verified_user()
+      parent = insert_conversation(user_id: user.id)
+      agent = insert_agent(user_id: user.id)
+
+      assert {:ok, conv} =
+               Conversations.start_conversation(%{
+                 "agent_id" => agent.id,
+                 "user_id" => user.id,
+                 "parent_conversation_id" => parent.id
+               })
+
+      assert conv.parent_conversation_id == parent.id
+    end
+
+    test "no parent is still fine" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      assert {:ok, conv} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+
+      assert conv.parent_conversation_id == nil
+    end
+  end
+
+  describe "get_conversation_tree/2" do
+    test "returns the caller's own tree" do
+      user = insert_verified_user()
+      root = insert_conversation(user_id: user.id)
+      child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
+
+      ids = Conversations.get_conversation_tree(root.id, user.id) |> Enum.map(& &1.id)
+
+      assert root.id in ids
+      assert child.id in ids
+    end
+
+    test "returns nothing for another tenant's conversation" do
+      owner = insert_verified_user()
+      other = insert_verified_user()
+      conv = insert_conversation(user_id: owner.id)
+
+      assert Conversations.get_conversation_tree(conv.id, other.id) == []
+    end
+
+    test "does not walk across a foreign parent link left in the data" do
+      # Pre-existing rows can still carry a cross-tenant parent, written before
+      # validation existed. The query must not follow it even so.
+      victim = insert_verified_user()
+      attacker = insert_verified_user()
+
+      victim_root = insert_conversation(user_id: victim.id)
+
+      victim_child =
+        insert_conversation(user_id: victim.id, parent_conversation_id: victim_root.id)
+
+      # Bypass the context to simulate legacy data.
+      attacker_conv =
+        insert_conversation(user_id: attacker.id, parent_conversation_id: victim_root.id)
+
+      ids =
+        Conversations.get_conversation_tree(attacker_conv.id, attacker.id) |> Enum.map(& &1.id)
+
+      assert attacker_conv.id in ids
+      refute victim_root.id in ids
+      refute victim_child.id in ids
+    end
+
+    test "the victim's view does not show the attacker's grafted node" do
+      victim = insert_verified_user()
+      attacker = insert_verified_user()
+      victim_root = insert_conversation(user_id: victim.id)
+
+      attacker_conv =
+        insert_conversation(user_id: attacker.id, parent_conversation_id: victim_root.id)
+
+      ids = Conversations.get_conversation_tree(victim_root.id, victim.id) |> Enum.map(& &1.id)
+
+      assert victim_root.id in ids
+      refute attacker_conv.id in ids
+    end
+
+    test "a malformed id returns empty rather than raising" do
+      user = insert_verified_user()
+      assert Conversations.get_conversation_tree("not-a-uuid", user.id) == []
+    end
+
+    test "a deep chain terminates rather than running away" do
+      # Parent links are client-supplied; the depth bound is what stops a cycle
+      # from spinning the recursive CTE forever.
+      user = insert_verified_user()
+
+      root = insert_conversation(user_id: user.id)
+
+      leaf =
+        Enum.reduce(1..12, root, fn _, parent ->
+          insert_conversation(user_id: user.id, parent_conversation_id: parent.id)
+        end)
+
+      tree = Conversations.get_conversation_tree(leaf.id, user.id)
+      assert length(tree) == 13
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_tree_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_tree_test.exs
@@ -4,19 +4,19 @@ defmodule Fountain.Conversations.ConversationTreeTest do
   alias Fountain.Conversations
 
   # ---------------------------------------------------------------------------
-  # get_conversation_tree/1
+  # _unsafe_get_conversation_tree/1
   # ---------------------------------------------------------------------------
 
-  describe "get_conversation_tree/1" do
+  describe "_unsafe_get_conversation_tree/1" do
     test "returns empty list for a non-existent conversation_id" do
-      assert Conversations.get_conversation_tree(Ecto.UUID.generate()) == []
+      assert Conversations._unsafe_get_conversation_tree(Ecto.UUID.generate()) == []
     end
 
     test "returns a single-item list for a standalone conversation (no parent, no children)" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      tree = Conversations.get_conversation_tree(conv.id)
+      tree = Conversations._unsafe_get_conversation_tree(conv.id)
 
       assert length(tree) == 1
       assert hd(tree).id == conv.id
@@ -28,7 +28,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
       grandchild = insert_conversation(user_id: user.id, parent_conversation_id: child.id)
 
-      tree = Conversations.get_conversation_tree(grandchild.id)
+      tree = Conversations._unsafe_get_conversation_tree(grandchild.id)
       ids = Enum.map(tree, & &1.id) |> Enum.sort()
 
       assert ids == Enum.sort([root.id, child.id, grandchild.id])
@@ -40,7 +40,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
       grandchild = insert_conversation(user_id: user.id, parent_conversation_id: child.id)
 
-      tree = Conversations.get_conversation_tree(root.id)
+      tree = Conversations._unsafe_get_conversation_tree(root.id)
       ids = Enum.map(tree, & &1.id) |> Enum.sort()
 
       assert ids == Enum.sort([root.id, child.id, grandchild.id])
@@ -52,7 +52,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
       grandchild = insert_conversation(user_id: user.id, parent_conversation_id: child.id)
 
-      tree = Conversations.get_conversation_tree(child.id)
+      tree = Conversations._unsafe_get_conversation_tree(child.id)
       ids = Enum.map(tree, & &1.id) |> Enum.sort()
 
       assert ids == Enum.sort([root.id, child.id, grandchild.id])
@@ -64,7 +64,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
       _unrelated = insert_conversation(user_id: user.id)
 
-      tree = Conversations.get_conversation_tree(child.id)
+      tree = Conversations._unsafe_get_conversation_tree(child.id)
       ids = Enum.map(tree, & &1.id)
 
       assert length(ids) == 2
@@ -76,7 +76,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      [entry] = Conversations.get_conversation_tree(conv.id)
+      [entry] = Conversations._unsafe_get_conversation_tree(conv.id)
 
       assert Map.has_key?(entry, :id)
       assert Map.has_key?(entry, :source)
@@ -89,7 +89,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       root = insert_conversation(user_id: user.id)
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
 
-      tree = Conversations.get_conversation_tree(root.id)
+      tree = Conversations._unsafe_get_conversation_tree(root.id)
 
       root_entry = Enum.find(tree, fn e -> e.id == root.id end)
       child_entry = Enum.find(tree, fn e -> e.id == child.id end)

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1260,19 +1260,19 @@ defmodule Fountain.ConversationsContextTest do
   end
 
   # ────────────────────────────────────────────────────────────────────────────
-  # get_conversation_tree/1
+  # _unsafe_get_conversation_tree/1
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "get_conversation_tree/1" do
+  describe "_unsafe_get_conversation_tree/1" do
     test "returns empty list when conversation id does not exist" do
-      assert Conversations.get_conversation_tree(Ecto.UUID.generate()) == []
+      assert Conversations._unsafe_get_conversation_tree(Ecto.UUID.generate()) == []
     end
 
     test "returns single-element tree for a root conversation with no children" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      tree = Conversations.get_conversation_tree(conv.id)
+      tree = Conversations._unsafe_get_conversation_tree(conv.id)
       assert length(tree) == 1
       [node] = tree
       assert node.id == conv.id
@@ -1283,7 +1283,7 @@ defmodule Fountain.ConversationsContextTest do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      [node] = Conversations.get_conversation_tree(conv.id)
+      [node] = Conversations._unsafe_get_conversation_tree(conv.id)
       assert Map.has_key?(node, :id)
       assert Map.has_key?(node, :source)
       assert Map.has_key?(node, :status)
@@ -1295,7 +1295,7 @@ defmodule Fountain.ConversationsContextTest do
       parent = insert_conversation(user_id: user.id)
       child = insert_conversation(user_id: user.id, parent_conversation_id: parent.id)
 
-      tree = Conversations.get_conversation_tree(child.id)
+      tree = Conversations._unsafe_get_conversation_tree(child.id)
       ids = Enum.map(tree, & &1.id)
       assert parent.id in ids
       assert child.id in ids
@@ -1306,7 +1306,7 @@ defmodule Fountain.ConversationsContextTest do
       parent = insert_conversation(user_id: user.id)
       child = insert_conversation(user_id: user.id, parent_conversation_id: parent.id)
 
-      tree = Conversations.get_conversation_tree(child.id)
+      tree = Conversations._unsafe_get_conversation_tree(child.id)
       child_node = Enum.find(tree, &(&1.id == child.id))
       assert child_node.parent_id == parent.id
     end
@@ -1316,7 +1316,7 @@ defmodule Fountain.ConversationsContextTest do
       parent = insert_conversation(user_id: user.id)
       child = insert_conversation(user_id: user.id, parent_conversation_id: parent.id)
 
-      tree = Conversations.get_conversation_tree(parent.id)
+      tree = Conversations._unsafe_get_conversation_tree(parent.id)
       ids = Enum.map(tree, & &1.id)
       assert parent.id in ids
       assert child.id in ids


### PR DESCRIPTION
Closes #174. The last open cross-tenant isolation defect from the audit.

## Two defects, one feeding the other

`parent_conversation_id` arrived from a client-supplied header (`X-Fountain-Parent-Conversation-Id`) and the changeset enforced only a foreign key — so **any** conversation id in the system was accepted, including another tenant's. Then `get_conversation_tree/1` was raw recursive SQL with **no `user_id` predicate**, so it walked straight across that link.

The leak ran in both directions: a conversation parented onto a victim's conversation pulled the victim's whole tree into the attacker's graph view, and put the attacker's node into the victim's.

## Fixes

**Ownership resolved in `start_conversation/1`**, beside the vault check, so every caller is covered rather than just the controller. A foreign or unknown parent returns **404** — matching how an unknown vault is handled, so the response can't be used to probe which conversation ids exist. This costs nothing legitimate: a real spawn comes from inside a sprite holding that tenant's own token, so ownership always matches.

**Every `conversations` reference in the tree query carries the tenant predicate.**

One subtlety worth reviewing: the root is now the **furthest reachable ancestor** rather than the one with a `NULL` parent. For clean data those are the same node. They differ only where a foreign link already exists in the data — and there, picking the boundary node degrades to "show the part of the tree you own" rather than returning nothing at all, which is what a naive `parent IS NULL` filter would do once the chain is cut at the tenant boundary.

The unscoped query is retained as `_unsafe_get_conversation_tree/1` per the codebase convention (#182), with the existing tree tests pointed at it so their coverage isn't lost.

## Found while rewriting

**The recursion had no depth bound.** Parent links are client-supplied, so a cycle — `A → B → A` — would have spun the recursive CTE indefinitely against the database. Both recursive terms are now bounded at depth 100. That's a latent DoS that existed independently of the tenancy bug, and I only noticed it because the query had to be rewritten anyway.

## Verification

**7 of 10 tests fail against the unscoped version** — confirmed by reverting both the validation and the predicates. The cases are written as the actual attack: a conversation grafted onto another tenant's, asserted from both sides.

There's also a case for **legacy data** — rows that already carry a cross-tenant parent, written before validation existed. The query must not follow those links even though validation now prevents new ones, and it doesn't.

Suite: **1218 tests + 5 doctests, 0 failures** (baseline 1208). Format, `--warnings-as-errors`, credo clean.

## Note on existing data

I did not audit production for rows that already have a cross-tenant `parent_conversation_id`. The query now refuses to traverse them, so the leak is closed either way, but if you want to know whether it was ever exercised, that's a `SELECT` joining `conversations` to itself on differing `user_id`. Happy to run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)