### PR TITLE
test: cover ConversationServer, and put it back under the coverage gate

### DIFF
--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -1,0 +1,326 @@
+defmodule Fountain.Conversations.ConversationServerTest do
+  @moduledoc """
+  First tests for `ConversationServer`.
+
+  1,183 lines that provision sandboxes, hold decrypted tenant secrets, mint API
+  keys and spend money on sprites — with no test file at all since launch, and
+  excluded from the coverage gate on top of that. Every caller `Mimic.copy`'d it
+  away, so the module was verified only by running the product.
+
+  These cover the lifecycle: provisioning succeeds and the sandbox reaches
+  `ready`; each way provisioning can fail leaves the sandbox and conversation
+  marked `failed` rather than stuck; teardown revokes the sprite's callback key;
+  and a terminate against a dead server still cleans up the rows.
+  """
+
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Accounts
+  alias Fountain.Repo
+
+  setup do
+    user = insert_verified_user()
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, environment_id: env.id)
+    sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        sandbox_id: sandbox.id,
+        status: "pending"
+      )
+
+    {:ok, user: user, env: env, agent: agent, sandbox: sandbox, conv: conv}
+  end
+
+  describe "provisioning — happy path" do
+    test "drives the sandbox to ready", %{conv: conv, sandbox: sandbox} do
+      stub_happy_sprite()
+
+      {pid, _ref, :alive} = start_server(conv)
+
+      assert Conversations.get_sandbox!(sandbox.id).status == "ready"
+      GenServer.stop(pid)
+    end
+
+    test "asks the runtime to write its config and prepare the sprite", %{conv: conv} do
+      stub_happy_sprite()
+
+      {pid, _ref, :alive} = start_server(conv)
+
+      assert_received :write_config
+      assert_received :prepare_sprite
+      GenServer.stop(pid)
+    end
+
+    test "mints a sprite-scoped callback key and records it on the conversation", %{conv: conv} do
+      stub_happy_sprite()
+
+      {pid, _ref, :alive} = start_server(conv)
+
+      reloaded = Conversations._unsafe_get_conversation!(conv.id)
+      assert reloaded.callback_api_key_id
+
+      key = Repo.get(Accounts.ApiKey, reloaded.callback_api_key_id)
+      assert key.scopes == ["sprite"]
+      assert key.expires_at
+      refute key.revoked_at
+
+      GenServer.stop(pid)
+    end
+
+    test "runs the first turn when a prompt is supplied", %{conv: conv} do
+      stub_happy_sprite()
+      # The server reads command.ref, so the spawn result must be a command struct
+      # rather than a bare pid.
+      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
+        {:ok, %{ref: make_ref(), pid: self()}}
+      end)
+
+      Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
+      Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+
+      {pid, _ref, :alive} = start_server(conv, initial_prompt: "hello there")
+
+      assert_received {:build_command, "hello there", _mode, _session, _opts}
+      assert [turn] = Conversations.list_turns(conv.id)
+      assert turn.prompt == "hello there"
+
+      GenServer.stop(pid)
+    end
+
+    test "does not start a turn without a prompt", %{conv: conv} do
+      stub_happy_sprite()
+
+      {pid, _ref, :alive} = start_server(conv)
+
+      assert Conversations.list_turns(conv.id) == []
+      GenServer.stop(pid)
+    end
+  end
+
+  describe "provisioning — failure paths" do
+    test "a sprite that cannot be created marks both rows failed", %{conv: conv, sandbox: sandbox} do
+      stub_happy_sprite()
+      Mimic.stub(Sprites, :create, fn _client, _name -> {:error, :quota_exceeded} end)
+
+      {_pid, ref, _} = start_server(conv)
+      assert_stopped(ref)
+
+      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
+    end
+
+    test "a failing provisioning step destroys the sprite rather than leaking it", %{conv: conv} do
+      stub_happy_sprite()
+      test_pid = self()
+
+      Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->
+        {:error, :apt_failed}
+      end)
+
+      Mimic.stub(Sprites, :destroy, fn sprite ->
+        send(test_pid, {:destroyed, sprite.name})
+        :ok
+      end)
+
+      {_pid, ref, _} = start_server(conv)
+      assert_stopped(ref)
+
+      # The sprite is billed until it is destroyed, so a failed provision that
+      # leaves it running costs money indefinitely.
+      assert_received {:destroyed, "test-sprite"}
+    end
+
+    test "a runtime that fails to prepare marks the sandbox failed", %{
+      conv: conv,
+      sandbox: sandbox
+    } do
+      stub_happy_sprite()
+
+      {_pid, ref, _} = start_server(conv, runtime: Fountain.Test.FailingRuntime)
+      assert_stopped(ref)
+
+      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+    end
+
+    test "an unexpected exception is caught and does not leave the sandbox pending", %{
+      conv: conv,
+      sandbox: sandbox
+    } do
+      # The provision path wraps itself in a rescue precisely so a bug in any
+      # step cannot strand a conversation in `pending` forever.
+      stub_happy_sprite()
+
+      Mimic.stub(Fountain.SpriteSkills, :mount, fn _s, _r, _sk ->
+        raise "boom"
+      end)
+
+      {_pid, ref, _} = start_server(conv)
+      assert_stopped(ref)
+
+      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
+    end
+
+    test "unreadable tenant credentials fail the conversation rather than provisioning blind", %{
+      conv: conv,
+      sandbox: sandbox
+    } do
+      stub_happy_sprite()
+      Mimic.stub(Fountain.Crypto, :load_tenant_key, fn _ -> {:error, :unwrap_failed} end)
+
+      {_pid, ref, _} = start_server(conv)
+      assert_stopped(ref)
+
+      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+    end
+  end
+
+  describe "turn lifecycle on a running server" do
+    defp start_with_turn(conv) do
+      stub_happy_sprite()
+      ref = make_ref()
+
+      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
+        {:ok, %{ref: ref, pid: self()}}
+      end)
+
+      Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
+      Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "first")
+      {pid, ref}
+    end
+
+    test "a completed command closes the turn and returns the conversation to idle", %{conv: conv} do
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:exit, %{ref: ref}, 0})
+      _ = :sys.get_state(pid)
+
+      assert [turn] = Conversations.list_turns(conv.id)
+      assert turn.status == "completed"
+      assert turn.exit_code == 0
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      GenServer.stop(pid)
+    end
+
+    test "a non-zero exit marks the turn failed but keeps the conversation usable", %{conv: conv} do
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:exit, %{ref: ref}, 1})
+      _ = :sys.get_state(pid)
+
+      assert [turn] = Conversations.list_turns(conv.id)
+      assert turn.status == "failed"
+      assert turn.exit_code == 1
+
+      # A failed turn is not a failed conversation — the user can prompt again.
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      GenServer.stop(pid)
+    end
+
+    test "stdout is persisted as log events", %{conv: conv} do
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:stdout, %{ref: ref}, "hello from the sprite"})
+      _ = :sys.get_state(pid)
+
+      events = Conversations.list_log_events(conv.id)
+      assert Enum.any?(events, &(&1.data =~ "hello from the sprite"))
+
+      GenServer.stop(pid)
+    end
+
+    test "prompting while a turn is running is refused rather than queued", %{conv: conv} do
+      {pid, _ref} = start_with_turn(conv)
+
+      # There is no queue, so a second prompt mid-turn must be rejected rather
+      # than silently dropped or interleaved.
+      assert {:error, :busy} = GenServer.call(pid, {:send_prompt, "second", []})
+
+      GenServer.stop(pid)
+    end
+
+    test "a prompt after the turn finishes starts a new turn", %{conv: conv} do
+      {pid, ref} = start_with_turn(conv)
+      send(pid, {:exit, %{ref: ref}, 0})
+      _ = :sys.get_state(pid)
+
+      assert :ok = GenServer.call(pid, {:send_prompt, "second", []})
+      assert length(Conversations.list_turns(conv.id)) == 2
+
+      GenServer.stop(pid)
+    end
+
+    test "interrupt with nothing running reports idle rather than pretending to act", %{
+      conv: conv
+    } do
+      stub_happy_sprite()
+      {pid, _mon, :alive} = start_server(conv)
+
+      assert {:error, :idle} = GenServer.call(pid, :interrupt)
+      GenServer.stop(pid)
+    end
+  end
+
+  describe "teardown" do
+    test "revokes the sprite's callback key when the server stops", %{conv: conv} do
+      stub_happy_sprite()
+
+      {pid, ref, :alive} = start_server(conv)
+      key_id = Conversations._unsafe_get_conversation!(conv.id).callback_api_key_id
+      refute Repo.get(Accounts.ApiKey, key_id).revoked_at
+
+      GenServer.stop(pid)
+      assert_stopped(ref)
+
+      # Otherwise the sandbox's credential outlives the sandbox.
+      assert Repo.get(Accounts.ApiKey, key_id).revoked_at
+    end
+  end
+
+  describe "terminate/1 with no running server" do
+    test "still marks the conversation and sandbox terminated", %{conv: conv, sandbox: sandbox} do
+      # After a BEAM restart the GenServer is gone but the rows remain, and a
+      # user still needs to be able to clean up.
+      assert :ok = ConversationServer.terminate(conv.id)
+
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "terminated"
+      assert Conversations.get_sandbox!(sandbox.id).status == "terminated"
+    end
+
+    test "reports not_running for an unknown conversation" do
+      assert {:error, :not_running} = ConversationServer.terminate(Ecto.UUID.generate())
+    end
+
+    test "does not resurrect an already-failed sandbox", %{conv: conv, sandbox: sandbox} do
+      {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
+
+      assert :ok = ConversationServer.terminate(conv.id)
+      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+    end
+  end
+
+  describe "interrupt/1 and send_prompt/3 with no running server" do
+    test "interrupt reports not_running", %{conv: conv} do
+      assert {:error, :not_running} = ConversationServer.interrupt(conv.id)
+    end
+
+    test "send_prompt for an unknown conversation reports not_running" do
+      assert {:error, :not_running} =
+               ConversationServer.send_prompt(Ecto.UUID.generate(), "hi", [])
+    end
+
+    test "send_prompt to a terminated conversation reports gone", %{conv: conv} do
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+
+      assert {:error, :gone} = ConversationServer.send_prompt(conv.id, "hi", [])
+    end
+  end
+end

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -1,0 +1,133 @@
+defmodule Fountain.ConversationServerCase do
+  @moduledoc """
+  Harness for driving a real `ConversationServer` in tests.
+
+  The module has had no tests of its own since launch — 1,183 lines covering
+  provisioning, reattach, turn handling and teardown, holding tenant secrets and
+  spending money, excluded from the coverage gate and `Mimic.copy`'d out of
+  every caller's tests. The reason it stayed untested is that starting one
+  reaches for the Sprites API, the filesystem inside a sprite, a runtime CLI and
+  OpenTelemetry.
+
+  This stubs that boundary once, permissively, so an individual test only has to
+  express the thing it cares about. `stub/3` is used rather than `expect/3` so
+  unstated calls are allowed; tests that care about a specific interaction
+  override it.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      use Fountain.DataCase, async: false
+      use Mimic
+
+      import Fountain.ConversationServerCase
+
+      alias Fountain.Conversations
+      alias Fountain.Conversations.ConversationServer
+
+      # The server runs in its own process, so per-process stubs set from the
+      # test would not apply to it. Global mode is safe here because these
+      # modules are async: false, and ExUnit runs those one at a time after the
+      # async ones have finished.
+      setup :set_mimic_global
+
+      # The server also needs to reach the sandbox from its own process.
+      setup do
+        Ecto.Adapters.SQL.Sandbox.mode(Fountain.Repo, {:shared, self()})
+        :ok
+      end
+    end
+  end
+
+  @doc """
+  Stub every external boundary a provision touches, on the happy path.
+
+  Returns the sprite the stubbed `Sprites.create/2` will hand back.
+  """
+  def stub_happy_sprite(name \\ "test-sprite") do
+    sprite = %{name: name, id: "sprite_" <> name}
+
+    Mimic.stub(Fountain.SpritesClient, :get!, fn -> %{token: "test"} end)
+    Mimic.stub(Sprites, :create, fn _client, _name -> {:ok, sprite} end)
+    Mimic.stub(Sprites, :destroy, fn _sprite -> :ok end)
+    Mimic.stub(Sprites, :cmd, fn _sprite, _cmd, _opts -> {:ok, %{exit_code: 0, stdout: ""}} end)
+    Mimic.stub(Sprites, :list_sessions, fn _sprite -> {:ok, []} end)
+    Mimic.stub(Sprites, :update_network_policy, fn _sprite, _policy -> :ok end)
+    Mimic.stub(Sprites.Filesystem, :write, fn _sprite, _path, _contents -> :ok end)
+
+    Mimic.stub(Fountain.SpriteSkills, :mount, fn _sprite, _runtime, _skills -> :ok end)
+
+    Mimic.stub(Fountain.Conversations.Provisioning, :write_env_file, fn _s, _e -> :ok end)
+
+    Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->
+      :ok
+    end)
+
+    Mimic.stub(Fountain.Conversations.Provisioning, :apply_network_policy, fn _s, _e, _c ->
+      :ok
+    end)
+
+    Mimic.stub(Fountain.Conversations.Provisioning, :clone_repositories, fn _s, _e, _sec, _c ->
+      :ok
+    end)
+
+    Mimic.stub(Fountain.Conversations.Provisioning, :create_checkpoint, fn _s, _e ->
+      {:error, :no_env}
+    end)
+
+    Mimic.stub(Fountain.Conversations.Provisioning, :restore_checkpoint, fn _s, _c ->
+      {:error, :no_checkpoint}
+    end)
+
+    # Per-tenant crypto is exercised in its own tests; here it only needs to
+    # succeed so provisioning can proceed.
+    Mimic.stub(Fountain.Crypto, :load_tenant_key, fn _user_id -> {:ok, <<0::256>>} end)
+    Mimic.stub(Fountain.InferenceCredentials, :decrypted_for_user, fn _u, _k -> {:ok, %{}} end)
+
+    sprite
+  end
+
+  @doc """
+  Start a real ConversationServer for `conv` and wait for it to settle.
+
+  Started outside Horde and unlinked, so a server that legitimately stops —
+  which the failure paths do — doesn't take the test process with it.
+  """
+  def start_server(conv, opts \\ []) do
+    runtime = Keyword.get(opts, :runtime, Fountain.Test.FakeRuntime)
+    Application.put_env(:fountain, :test_observer, self())
+
+    args = [
+      conversation_id: conv.id,
+      sandbox_id: conv.sandbox_id,
+      runtime_module: runtime,
+      initial_prompt: Keyword.get(opts, :initial_prompt)
+    ]
+
+    {:ok, pid} = GenServer.start(Fountain.Conversations.ConversationServer, args)
+    ref = Process.monitor(pid)
+
+    # handle_continue(:provision) runs before any call is answered, so a
+    # synchronous call is enough to know provisioning has finished.
+    settled =
+      try do
+        _ = :sys.get_state(pid)
+        :alive
+      catch
+        :exit, _ -> :stopped
+      end
+
+    {pid, ref, settled}
+  end
+
+  @doc "Wait for a monitored server to stop, or fail the test."
+  def assert_stopped(ref, timeout \\ 2_000) do
+    receive do
+      {:DOWN, ^ref, :process, _pid, reason} -> reason
+    after
+      timeout -> raise "expected the ConversationServer to stop, but it is still running"
+    end
+  end
+end

--- a/apps/fountain/test/support/fake_runtime.ex
+++ b/apps/fountain/test/support/fake_runtime.ex
@@ -1,0 +1,73 @@
+defmodule Fountain.Test.FakeRuntime do
+  @moduledoc """
+  A `Fountain.Runtimes` implementation for tests.
+
+  `ConversationServer` takes its runtime module as a start argument, which is
+  the one dependency-injection seam the module already has. Using it avoids
+  stubbing four real runtime modules to test behaviour that has nothing to do
+  with which CLI is being driven.
+
+  Every callback records itself in the calling process so a test can assert what
+  the server asked the runtime to do.
+  """
+
+  @behaviour Fountain.Runtimes
+
+  @doc "Where callbacks report to. Set by the test harness."
+  def observer, do: Application.get_env(:fountain, :test_observer)
+
+  defp report(msg) do
+    # The server runs in its own process, so self() here is the GenServer, not
+    # the test. Report to the pid the harness registered instead.
+    if pid = observer(), do: send(pid, msg)
+    :ok
+  end
+
+  @impl true
+  def build_command(_agent, prompt, mode, session_id, opts) do
+    report({:build_command, prompt, mode, session_id, opts})
+    {"echo", [prompt], stdin?: true}
+  end
+
+  @impl true
+  def default_env(_agent, _credentials), do: [{"FAKE_RUNTIME", "1"}]
+
+  @impl true
+  def write_config(_sprite, _agent), do: report(:write_config)
+
+  @impl true
+  def prepare_sprite(_sprite, _agent, _sprite_env), do: report(:prepare_sprite)
+
+  @impl true
+  def skills_root, do: "/home/sprite/.fake/skills"
+
+  @impl true
+  def skills_sh_agent, do: "fake"
+end
+
+defmodule Fountain.Test.FailingRuntime do
+  @moduledoc """
+  A runtime whose `prepare_sprite/3` fails, for exercising the provisioning
+  failure path without having to make a Sprites call fail.
+  """
+
+  @behaviour Fountain.Runtimes
+
+  @impl true
+  def build_command(_agent, prompt, _mode, _session_id, _opts), do: {"echo", [prompt], []}
+
+  @impl true
+  def default_env(_agent, _credentials), do: []
+
+  @impl true
+  def write_config(_sprite, _agent), do: :ok
+
+  @impl true
+  def prepare_sprite(_sprite, _agent, _sprite_env), do: {:error, :prepare_failed}
+
+  @impl true
+  def skills_root, do: "/home/sprite/.fake/skills"
+
+  @impl true
+  def skills_sh_agent, do: "fake"
+end

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -21,6 +21,8 @@ Mimic.copy(Stripe.BillingPortal.Session)
 Mimic.copy(Stripe.Checkout.Session)
 
 Mimic.copy(Fountain.Conversations.ConversationServer)
+Mimic.copy(Fountain.Conversations.Provisioning)
+Mimic.copy(Fountain.SpriteSkills)
 Mimic.copy(Fountain.Accounts)
 Mimic.copy(Fountain.Audit)
 Mimic.copy(Fountain.Crypto)

--- a/coveralls.json
+++ b/coveralls.json
@@ -10,7 +10,6 @@
     "lib/fountain/telemetry.ex",
     "lib/fountain/sprite_skills.ex",
     "lib/fountain/sprites_client.ex",
-    "lib/fountain/conversations/conversation_server.ex",
     "lib/fountain/conversations/provisioning.ex",
     "lib/fountain/conversations/rehydrator.ex",
     "lib/fountain/runtimes/",


### PR DESCRIPTION
Closes #192.

## Why this was the riskiest gap

1,183 lines that provision sandboxes, hold decrypted tenant secrets, mint API keys and spend money on sprites — **no test file at all since launch**, and excluded from the coverage gate on top of that, so the reported number never reflected its absence. Every caller `Mimic.copy`'d it away, which meant the module was only ever verified by running the product.

It also kept blocking other work: I declined to move sprite checkpointing onto Oban in #217 specifically because changing this module without tests wasn't worth the risk.

## Why it stayed untested, and the way in

Starting a `ConversationServer` reaches for the Sprites API, a sprite filesystem, a runtime CLI and OpenTelemetry. `ConversationServerCase` stubs that boundary once, permissively (`stub/3`, not `expect/3`), so an individual test only states the thing it cares about.

The runtime module is already injected as a start argument — the one DI seam the module has — so `Fountain.Test.FakeRuntime` covers that side rather than stubbing four real runtime modules.

Two harness details that are easy to get wrong and cost me a cycle each:

- **Mimic has to be global.** The server runs in its own process, so per-process stubs set from the test don't apply to it. Safe here because these are `async: false`, which ExUnit runs one at a time after the async modules finish.
- **The SQL sandbox has to be shared**, for the same reason.

## What's covered

Provisioning reaching `ready`; each way it can fail (sprite creation, a pipeline step, runtime prepare, an unexpected raise, unreadable tenant credentials) leaving **both** rows marked `failed` rather than stuck in `pending`; **the sprite being destroyed when a step fails**, since a failed provision that leaves it running bills indefinitely; the callback key being minted `sprite`-scoped with an expiry and revoked at teardown; turn completion and failure; stdout persisting as log events; and prompting mid-turn being refused rather than silently dropped.

## Back under the gate

`conversation_server.ex` is removed from `skip_files`. It sits at **57.7%**, and total coverage is **87.7%** against the 85% gate — a 2.7% margin, so this file is now protected by the same check as everything else instead of being invisible to it.

That number is worth stating plainly: **42% of the module is still uncovered.** The untested remainder is mostly reattach/rehydration, the stream-tracing path, and interrupt against a live command. Those are the next things worth writing, and now that the harness exists they're incremental rather than a project.

## Two assumptions the tests corrected

- `interrupt` with nothing running returns `{:error, :idle}`, not `:ok` — I asserted the latter and was wrong.
- A **failed** turn deliberately leaves the conversation `idle`, not `failed`, so the user can prompt again. That's correct behaviour and now pinned, since it would be easy to "fix" into a bug.

Suite: **1266 tests + 5 doctests, 0 failures** (baseline 1243). Format, `--warnings-as-errors`, credo clean.

## Note

`provisioning.ex` and `runtimes/` are still skipped. `provisioning.ex` has a 63-line test file against 500 lines and would be the natural next target — the same harness applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)