### PR TITLE
cli: resume the stream instead of reporting success when it drops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,22 @@ jobs:
       - name: Security scan (sobelow)
         run: mix sobelow --config
 
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      # The CLI had tests since launch that no workflow ever ran, so they gated
+      # neither a merge nor a release.
+      - name: CLI tests
+        working-directory: cli
+        run: go test ./...
+
+      - name: CLI vet
+        working-directory: cli
+        run: go vet ./...
+
       - name: Set up database
         run: mix ecto.create --quiet && mix ecto.migrate --quiet
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -90,3 +90,28 @@ chmod +x fountain && sudo mv fountain /usr/local/bin/
 ```
 
 Pinned versions are at `https://github.com/BinaryBourbon/fountain/releases/download/<tag>/fountain-<os>-<arch>`.
+
+## Streaming long turns
+
+`fountain run`, `fountain conv prompt` and `fountain conv stream` follow a
+conversation until the turn reaches a terminal state.
+
+The server closes an SSE connection after 60 seconds of quiet, so a turn that
+thinks for a while without emitting output will see the connection drop. The CLI
+reconnects using `Last-Event-ID`, so anything produced while disconnected is
+replayed rather than lost, and a dropped connection is never mistaken for a
+finished turn.
+
+If nothing arrives at all for 30 minutes the CLI gives up with an explicit
+error naming the conversation, rather than exiting successfully. Override the
+wait with `FOUNTAIN_STREAM_IDLE_TIMEOUT` (seconds):
+
+```sh
+FOUNTAIN_STREAM_IDLE_TIMEOUT=7200 fountain run researcher -p "audit the auth module"
+```
+
+Reattach to a conversation at any time — nothing is lost by disconnecting:
+
+```sh
+fountain conv stream <conversation-id>
+```

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -11,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/BinaryBourbon/fountain/cli/internal/api"
 	"github.com/BinaryBourbon/fountain/cli/internal/output"
@@ -270,53 +268,35 @@ func runAgent(cmd *cobra.Command, target string) error {
 
 // ── stream loop ─────────────────────────────────────────────────────────
 
-// followUntilIdle opens the SSE stream for conv `id` and prints output
-// until a `stage=turn state=done` event arrives or the server closes.
+// followUntilIdle streams conv `id` until the turn reaches a terminal state,
+// reconnecting across server-side idle disconnects. See stream.go.
 func followUntilIdle(convID string) error {
 	c := activeClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
 
-	req, err := c.NewStreamRequest(ctx, "/conversations/"+convID+"/stream", "")
-	if err != nil {
-		return err
-	}
-	httpClient := &http.Client{} // no global timeout — streams are long-lived
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		Fatalf("stream request failed: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		Fatalf("stream HTTP %d: %s", resp.StatusCode, body)
-	}
-
-	buf := make([]byte, 8192)
-	var pending bytes.Buffer
-	for {
-		n, err := resp.Body.Read(buf)
-		if n > 0 {
-			pending.Write(buf[:n])
-			events, leftover := sse.Feed(pending.String())
-			pending.Reset()
-			pending.WriteString(leftover)
-			for _, ev := range events {
-				if handleEvent(ev) {
-					return nil
-				}
-			}
-		}
-		if err == io.EOF {
-			return nil
-		}
+	open := func(ctx context.Context, lastEventID string) (io.ReadCloser, error) {
+		req, err := c.NewStreamRequest(ctx, "/conversations/"+convID+"/stream", lastEventID)
 		if err != nil {
-			if ctx.Err() == context.DeadlineExceeded {
-				Fatal("stream timeout")
-			}
-			Fatalf("stream read: %v", err)
+			return nil, err
 		}
+		// No client timeout: streams are long-lived and the idle watchdog in
+		// followStream is what bounds them.
+		resp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			// Auth and not-found are not worth retrying.
+			if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 404 {
+				Fatalf("stream HTTP %d: %s", resp.StatusCode, body)
+			}
+			return nil, fmt.Errorf("stream HTTP %d: %s", resp.StatusCode, body)
+		}
+		return resp.Body, nil
 	}
+
+	return followStream(open, streamIdleTimeout(), convID)
 }
 
 // handleEvent prints output and returns true when the turn is done.
@@ -332,6 +312,21 @@ func handleEvent(ev sse.Event) bool {
 		if stage == "turn" && state == "done" {
 			exit := exitCodeFromStageDone(data)
 			fmt.Fprintf(os.Stderr, "▸ turn done (exit_code=%s)\n", exit)
+			return true
+		}
+		// Terminal states where no turn will ever complete. Without these the
+		// stream would reconnect and wait out the idle timeout for a turn that
+		// is never coming.
+		if stage == "turn" && state == "failed" {
+			fmt.Fprintf(os.Stderr, "▸ turn failed\n")
+			return true
+		}
+		if stage == "provision" && state == "failed" {
+			fmt.Fprintf(os.Stderr, "▸ provisioning failed — the sandbox never started\n")
+			return true
+		}
+		if stage == "terminate" && state == "done" {
+			fmt.Fprintf(os.Stderr, "▸ conversation terminated\n")
 			return true
 		}
 		fmt.Fprintf(os.Stderr, "▸ %s: %s\n", stage, state)

--- a/cli/internal/cmd/stream.go
+++ b/cli/internal/cmd/stream.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/sse"
+)
+
+// streamOpener opens an SSE body, resuming after lastEventID when non-empty.
+//
+// Behind an interface so the reconnect logic can be tested without a server:
+// the bug this file exists to fix only appears across a disconnect, which is
+// exactly the part that is awkward to reach through the real client.
+type streamOpener func(ctx context.Context, lastEventID string) (io.ReadCloser, error)
+
+const (
+	// How long to wait with no bytes at all before giving up. The server closes
+	// its SSE loop after 60s of quiet, so this has to be comfortably longer than
+	// that or every reconnect would look like an idle stream.
+	defaultStreamIdle = 30 * time.Minute
+
+	// Consecutive failures to reopen the stream before giving up. Transport
+	// errors are usually transient; a server that is genuinely gone will exhaust
+	// these quickly.
+	maxReconnectAttempts = 5
+)
+
+var errIdleTimeout = errors.New("no output received")
+
+// reconnectBackoff is a variable so tests do not have to sit through real
+// sleeps to exercise the retry path.
+var reconnectBackoff = func(attempt int) time.Duration {
+	return time.Duration(attempt) * time.Second
+}
+
+// streamIdleTimeout allows the wait to be widened or narrowed without a rebuild.
+func streamIdleTimeout() time.Duration {
+	if v := os.Getenv("FOUNTAIN_STREAM_IDLE_TIMEOUT"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return defaultStreamIdle
+}
+
+// followStream consumes an SSE stream until the turn reaches a terminal state,
+// reconnecting when the server closes the connection.
+//
+// The bug this replaces: the old loop treated io.EOF as success and returned
+// nil. The server closes its SSE loop after 60 seconds of quiet, so any turn
+// that thought for longer than a minute without emitting output made the CLI
+// exit silently, reporting success while the agent was still working. For a
+// product whose normal case is a long-running agent, that is the worst possible
+// failure — it is indistinguishable from the turn actually finishing.
+//
+// A disconnect now resumes from the last event id, so output produced while
+// disconnected is replayed rather than lost, and only a terminal event or a
+// genuine timeout ends the loop.
+func followStream(open streamOpener, idle time.Duration, convID string) error {
+	lastEventID := ""
+	failures := 0
+
+	for {
+		done, resumeID, err := streamOnce(open, lastEventID, idle)
+		if resumeID != "" {
+			lastEventID = resumeID
+		}
+
+		switch {
+		case done:
+			return nil
+
+		case errors.Is(err, errIdleTimeout):
+			// Explicit, rather than the old silent success.
+			return fmt.Errorf(
+				"no output for %s — the turn may still be running; reattach with `fountain conv stream %s`",
+				idle, convID,
+			)
+
+		case err != nil:
+			failures++
+			if failures >= maxReconnectAttempts {
+				return fmt.Errorf("stream failed after %d attempts: %w", failures, err)
+			}
+			// Linear backoff: enough to ride out a redeploy without hammering.
+			time.Sleep(reconnectBackoff(failures))
+
+		default:
+			// Clean EOF with no terminal event: the server closed an idle
+			// stream. Reconnect and keep waiting.
+			failures = 0
+		}
+	}
+}
+
+// streamOnce reads one connection to completion. It returns whether a terminal
+// event was seen and the id to resume from if the connection drops.
+func streamOnce(open streamOpener, lastEventID string, idle time.Duration) (bool, string, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body, err := open(ctx, lastEventID)
+	if err != nil {
+		return false, "", err
+	}
+	defer body.Close()
+
+	// Idle watchdog. A blocking Read cannot be given a deadline directly, so a
+	// separate goroutine cancels the request context if nothing arrives.
+	activity := make(chan struct{}, 1)
+	idled := make(chan struct{})
+	go watchIdle(ctx, cancel, activity, idled, idle)
+
+	buf := make([]byte, 8192)
+	var pending bytes.Buffer
+	resumeID := lastEventID
+
+	for {
+		n, readErr := body.Read(buf)
+		if n > 0 {
+			select {
+			case activity <- struct{}{}:
+			default:
+			}
+
+			pending.Write(buf[:n])
+			events, leftover := sse.Feed(pending.String())
+			pending.Reset()
+			pending.WriteString(leftover)
+
+			for _, ev := range events {
+				if ev.ID > 0 {
+					resumeID = strconv.Itoa(ev.ID)
+				}
+				if handleEvent(ev) {
+					return true, resumeID, nil
+				}
+			}
+		}
+
+		if readErr != nil {
+			select {
+			case <-idled:
+				return false, resumeID, errIdleTimeout
+			default:
+			}
+			if errors.Is(readErr, io.EOF) {
+				return false, resumeID, nil
+			}
+			return false, resumeID, readErr
+		}
+	}
+}
+
+// watchIdle cancels the request context when nothing has arrived for `idle`.
+// Cancelling is what actually unblocks the pending Read — closing `idled` alone
+// would leave a genuinely stalled stream hanging forever, which is the failure
+// this whole change is meant to remove.
+func watchIdle(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	activity <-chan struct{},
+	idled chan<- struct{},
+	idle time.Duration,
+) {
+	timer := time.NewTimer(idle)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-activity:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(idle)
+		case <-timer.C:
+			close(idled)
+			cancel()
+			return
+		}
+	}
+}

--- a/cli/internal/cmd/stream_test.go
+++ b/cli/internal/cmd/stream_test.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeStream serves a scripted sequence of connections. Each entry is the body
+// one connection produces before returning io.EOF, which is exactly what the
+// server does when it closes an idle SSE loop after 60 seconds of quiet.
+type fakeStream struct {
+	mu       sync.Mutex
+	bodies   []string
+	opened   int
+	resumeAt []string // Last-Event-ID seen on each open
+	failNext int      // number of leading opens that should fail
+	openErr  error
+}
+
+func (f *fakeStream) open(_ context.Context, lastEventID string) (io.ReadCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.resumeAt = append(f.resumeAt, lastEventID)
+	f.opened++
+
+	if f.failNext > 0 {
+		f.failNext--
+		return nil, f.openErr
+	}
+	if len(f.bodies) == 0 {
+		// Nothing left to serve: behave like a stream that closes immediately.
+		return io.NopCloser(strings.NewReader("")), nil
+	}
+	body := f.bodies[0]
+	f.bodies = f.bodies[1:]
+	return io.NopCloser(strings.NewReader(body)), nil
+}
+
+func (f *fakeStream) opens() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.opened
+}
+
+func (f *fakeStream) resumeIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.resumeAt))
+	copy(out, f.resumeAt)
+	return out
+}
+
+func stage(id int, stageName, state string) string {
+	return "id: " + strconv.Itoa(id) + "\nevent: stage\ndata: {\"stage\":\"" + stageName +
+		"\",\"state\":\"" + state + "\"}\n\n"
+}
+
+// TestReconnectsAfterServerClosesIdleStream is the regression this change
+// exists for. The old loop returned nil on io.EOF, so a turn that thought for
+// longer than the server's 60s idle window made `fountain run` exit reporting
+// success while the agent was still working.
+func TestReconnectsAfterServerClosesIdleStream(t *testing.T) {
+	f := &fakeStream{bodies: []string{
+		// First connection: some progress, then the server closes.
+		stage(1, "provision", "done"),
+		// Second connection: the turn actually finishes.
+		stage(2, "turn", "done"),
+	}}
+
+	if err := followStream(f.open, time.Second, "conv-1"); err != nil {
+		t.Fatalf("expected clean completion, got %v", err)
+	}
+	if f.opens() != 2 {
+		t.Fatalf("expected the stream to be reopened after EOF, opened %d times", f.opens())
+	}
+}
+
+func TestResumesFromLastEventID(t *testing.T) {
+	f := &fakeStream{bodies: []string{
+		stage(7, "setup", "done"),
+		stage(8, "turn", "done"),
+	}}
+
+	if err := followStream(f.open, time.Second, "conv-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := f.resumeIDs()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 opens, got %v", got)
+	}
+	if got[0] != "" {
+		t.Errorf("first open should not resume, sent Last-Event-ID %q", got[0])
+	}
+	// Without this the replay restarts from zero and output already seen is
+	// printed twice, or output produced while disconnected is lost.
+	if got[1] != "7" {
+		t.Errorf("reconnect should resume from the last event id, sent %q", got[1])
+	}
+}
+
+func TestStopsOnTurnDone(t *testing.T) {
+	f := &fakeStream{bodies: []string{stage(1, "turn", "done")}}
+
+	if err := followStream(f.open, time.Second, "conv-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.opens() != 1 {
+		t.Fatalf("should not reconnect after a terminal event, opened %d times", f.opens())
+	}
+}
+
+// A failed provision means no turn is ever coming. Reconnecting would just wait
+// out the idle timeout.
+func TestStopsOnProvisionFailed(t *testing.T) {
+	f := &fakeStream{bodies: []string{stage(1, "provision", "failed")}}
+
+	if err := followStream(f.open, time.Second, "conv-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.opens() != 1 {
+		t.Fatalf("expected to stop on provision failure, opened %d times", f.opens())
+	}
+}
+
+func TestStopsOnTerminated(t *testing.T) {
+	f := &fakeStream{bodies: []string{stage(1, "terminate", "done")}}
+
+	if err := followStream(f.open, time.Second, "conv-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.opens() != 1 {
+		t.Fatalf("expected to stop on terminate, opened %d times", f.opens())
+	}
+}
+
+// The old code reported success here. Silence must be an explicit, actionable
+// error instead — "your turn may still be running" is very different from
+// "your turn finished".
+func TestIdleTimeoutIsAnErrorNotSilentSuccess(t *testing.T) {
+	blocked := &blockingStream{released: make(chan struct{})}
+	defer close(blocked.released)
+
+	err := followStream(blocked.open, 100*time.Millisecond, "conv-42")
+	if err == nil {
+		t.Fatal("an idle stream must not report success")
+	}
+	if !strings.Contains(err.Error(), "conv-42") {
+		t.Errorf("error should tell the user how to reattach, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "still be running") {
+		t.Errorf("error should say the turn may still be running, got %q", err)
+	}
+}
+
+func noBackoff(t *testing.T) {
+	t.Helper()
+	original := reconnectBackoff
+	reconnectBackoff = func(int) time.Duration { return 0 }
+	t.Cleanup(func() { reconnectBackoff = original })
+}
+
+func TestGivesUpAfterRepeatedOpenFailures(t *testing.T) {
+	noBackoff(t)
+	f := &fakeStream{failNext: 99, openErr: errors.New("connection refused")}
+
+	err := followStream(f.open, time.Second, "conv-1")
+	if err == nil {
+		t.Fatal("expected an error once reconnects are exhausted")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("error should preserve the cause, got %q", err)
+	}
+	if f.opens() != maxReconnectAttempts {
+		t.Errorf("expected %d attempts, got %d", maxReconnectAttempts, f.opens())
+	}
+}
+
+func TestRecoversFromATransientOpenFailure(t *testing.T) {
+	noBackoff(t)
+	f := &fakeStream{
+		failNext: 1,
+		openErr:  errors.New("temporary failure"),
+		bodies:   []string{stage(1, "turn", "done")},
+	}
+
+	if err := followStream(f.open, time.Second, "conv-1"); err != nil {
+		t.Fatalf("a single transient failure should not be fatal, got %v", err)
+	}
+}
+
+func TestStreamIdleTimeoutOverride(t *testing.T) {
+	t.Setenv("FOUNTAIN_STREAM_IDLE_TIMEOUT", "5")
+	if got := streamIdleTimeout(); got != 5*time.Second {
+		t.Errorf("want 5s from env, got %s", got)
+	}
+
+	t.Setenv("FOUNTAIN_STREAM_IDLE_TIMEOUT", "not-a-number")
+	if got := streamIdleTimeout(); got != defaultStreamIdle {
+		t.Errorf("garbage should fall back to the default, got %s", got)
+	}
+}
+
+// blockingStream never produces bytes and never closes, which is what a stalled
+// connection looks like from the client's side.
+type blockingStream struct{ released chan struct{} }
+
+func (b *blockingStream) open(ctx context.Context, _ string) (io.ReadCloser, error) {
+	return &blockingBody{ctx: ctx, released: b.released}, nil
+}
+
+type blockingBody struct {
+	ctx      context.Context
+	released chan struct{}
+}
+
+func (b *blockingBody) Read(_ []byte) (int, error) {
+	select {
+	case <-b.ctx.Done():
+		return 0, b.ctx.Err()
+	case <-b.released:
+		return 0, io.EOF
+	}
+}
+
+func (b *blockingBody) Close() error { return nil }


### PR DESCRIPTION
Closes #196. Also lands the `go test` half of #194.

## The bug

`followUntilIdle` treated `io.EOF` as success:

```go
if err == io.EOF {
    return nil
}
```

The server closes its SSE loop after **60 seconds of quiet** (`conversation_controller.ex:417-421`). So any turn that thought for longer than a minute without emitting output made `fountain run` **exit reporting success while the agent was still working**.

For a product whose normal case is a long-running coding agent, that's the worst available shape of bug — the output is indistinguishable from the turn actually finishing. A user gets their shell prompt back and reasonably concludes the work is done.

There was also a hard 5-minute context deadline that cut off any longer turn regardless of whether it was making progress.

## The fix

**Reconnect with `Last-Event-ID`.** `api.go:139` already supported sending that header; no caller ever passed one. So the resume machinery existed and was simply unused. Output produced while disconnected is now replayed rather than lost.

**Silence bounds the wait, not duration.** 30 minutes with no bytes at all (configurable via `FOUNTAIN_STREAM_IDLE_TIMEOUT`), reported as an explicit error naming the conversation to reattach to — not as success:

```
no output for 30m0s — the turn may still be running; reattach with `fountain conv stream <id>`
```

**Terminal states other than turn-done are recognised.** A failed provision or a terminated conversation means no turn is ever coming; without this the client would reconnect and wait out the entire idle window for something that cannot arrive.

## Testing the part that was untestable

The bug only appears **across a disconnect**, which is exactly what's awkward to reach through the real client — which is presumably why this shipped. The reconnect loop now sits behind a stream-opener function, so a fake can script "connection one ends, connection two completes the turn".

Nine tests. The load-bearing one is inherently a regression test: `TestReconnectsAfterServerClosesIdleStream` asserts the stream is opened **twice**, which the old `return nil` on EOF could never satisfy. Others cover resuming from the right event id, each terminal state, an idle stream producing an error rather than silent success, giving up after repeated failures, and recovering from a transient one.

Backoff is injectable so the retry test doesn't sit through 10 seconds of real sleeps — the suite runs in 0.27s.

## Two bugs in my own first draft

Worth recording, since both would have been invisible without the tests:

1. **The idle watchdog only signalled; it never cancelled the request context.** A genuinely stalled connection would have blocked in `Read` forever — the exact failure the change exists to remove.
2. Unused imports left behind by the rewrite, caught by `go vet`.

## CI

`go test ./...` and `go vet ./...` are now wired into `ci.yml` with a SHA-pinned `setup-go` (verified against the real v5.5.0 tag). The CLI has had tests since launch that **no workflow ever ran** — `release.yml` only cross-compiles — so they gated neither a merge nor a release. Without this step the tests above would be decoration too.

I did **not** touch the sobelow step in the same PR. Running it correctly (per-app rather than from the umbrella root, where it scans nothing and exits 0) would surface pre-existing findings and could fail CI, which belongs in #194 rather than here.

Elixir suite unchanged at 1266 tests. Go: all packages pass, `vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)