### PR TITLE
docs: rewrite the CLI reference from the actual binary, and fix a dead hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,32 +45,32 @@ fountain apply -f agent-specs
 
 ```sh
 # Get a session token (email + password)
-TOKEN=$(curl -sX POST https://founta.inevitable.fyi/api/auth/token \
+TOKEN=$(curl -sX POST https://fountain.inevitable.fyi/api/auth/token \
   -H 'Content-Type: application/json' \
   -d '{"email":"you@example.com","password":"..."}'  | jq -r .token)
 
 # Or create a long-lived API key in the UI: Account → API Keys
 # Then use it directly:
-TOKEN=ft_your_api_key
+TOKEN=ftn_your_api_key
 ```
 
 ### Manage resources
 
 ```sh
 # Create an environment
-curl -sX POST https://founta.inevitable.fyi/api/environments \
+curl -sX POST https://fountain.inevitable.fyi/api/environments \
   -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"name":"python-data","networking_type":"unrestricted"}'
 
 # Upsert a secret
-curl -sX POST https://founta.inevitable.fyi/api/environments/$ENV_ID/secrets \
+curl -sX POST https://fountain.inevitable.fyi/api/environments/$ENV_ID/secrets \
   -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"key":"OPENAI_API_KEY","value":"sk-..."}'
 
 # Create an agent
-curl -sX POST https://founta.inevitable.fyi/api/agents \
+curl -sX POST https://fountain.inevitable.fyi/api/agents \
   -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"name":"researcher","model":"anthropic/claude-sonnet-4-6","runtime":"claude","environment_id":"$ENV_ID"}'
@@ -80,7 +80,7 @@ curl -sX POST https://founta.inevitable.fyi/api/agents \
 
 ```sh
 # Start a conversation
-CONV=$(curl -sX POST https://founta.inevitable.fyi/api/conversations \
+CONV=$(curl -sX POST https://fountain.inevitable.fyi/api/conversations \
   -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d "{\"agent_id\":\"$AGENT_ID\",\"prompt\":\"Audit the auth module for security issues\"}")
@@ -88,7 +88,7 @@ CONV=$(curl -sX POST https://founta.inevitable.fyi/api/conversations \
 CONV_ID=$(echo $CONV | jq -r .id)
 
 # Stream log events (SSE)
-curl -sN https://founta.inevitable.fyi/api/conversations/$CONV_ID/stream \
+curl -sN https://fountain.inevitable.fyi/api/conversations/$CONV_ID/stream \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -96,17 +96,17 @@ Each SSE event is a JSON object: `{"kind":"output","stream":"stdout","data":"...
 
 ### Explore the full API
 
-Interactive Swagger UI: `https://founta.inevitable.fyi/api/docs`
+Interactive Swagger UI: `https://fountain.inevitable.fyi/api/docs`
 
-OpenAPI spec: `https://founta.inevitable.fyi/api/openapi.json`
+OpenAPI spec: `https://fountain.inevitable.fyi/api/openapi.json`
 
 ## Point an LLM at Fountain
 
-Every Fountain instance serves a plain-text [`/llms.txt`](https://founta.inevitable.fyi/llms.txt), a bundled [`/llms-full.txt`](https://founta.inevitable.fyi/llms-full.txt), and a drop-in [`/skill`](https://founta.inevitable.fyi/skill) so any agentic IDE (Claude Code, Cursor, Continue, Aider, ...) can learn the API from one fetch:
+Every Fountain instance serves a plain-text [`/llms.txt`](https://fountain.inevitable.fyi/llms.txt), a bundled [`/llms-full.txt`](https://fountain.inevitable.fyi/llms-full.txt), and a drop-in [`/skill`](https://fountain.inevitable.fyi/skill) so any agentic IDE (Claude Code, Cursor, Continue, Aider, ...) can learn the API from one fetch:
 
 ```sh
 mkdir -p ~/.claude/skills/fountain
-curl -fsSL https://founta.inevitable.fyi/skill > ~/.claude/skills/fountain/SKILL.md
+curl -fsSL https://fountain.inevitable.fyi/skill > ~/.claude/skills/fountain/SKILL.md
 ```
 
 After that, telling Claude “spin up a researcher agent on Fountain and have it audit the auth module” Just Works — the skill describes the four primitives (Environment / Vault / Agent / Conversation), the CLI commands, the API endpoints, the SSE format, and the per-runtime result filters.

--- a/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
@@ -59,7 +59,7 @@ defmodule FountainWeb.LlmsController do
     - **Agent** — named runtime config (runtime + model + system prompt + skills + MCP servers + an environment)
     - **Conversation** — one running instance of an agent inside a freshly provisioned sprite, streamable over SSE
 
-    Public instance: <https://founta.inevitable.fyi>. Source: <https://github.com/BinaryBourbon/fountain>.
+    Public instance: <https://fountain.inevitable.fyi>. Source: <https://github.com/BinaryBourbon/fountain>.
 
     ## Get started
 

--- a/apps/fountain/priv/external_skills/fountain/SKILL.md
+++ b/apps/fountain/priv/external_skills/fountain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fountain
-description: Operate Fountain (https://founta.inevitable.fyi) — a multi-tenant service that runs sandboxed coding agents (claude/codex/gemini/opencode) inside per-conversation sprites. Use this skill whenever the user asks you to spin up an agent on Fountain, delegate work to another agent, fan out a task across N agents, manage Fountain agents/environments/vaults declaratively, or drive the `fountain` CLI. Reads `FOUNTAIN_API_KEY` (required) and `FOUNTAIN_BASE_URL` (defaults to https://founta.inevitable.fyi).
+description: Operate Fountain (https://fountain.inevitable.fyi) — a multi-tenant service that runs sandboxed coding agents (claude/codex/gemini/opencode) inside per-conversation sprites. Use this skill whenever the user asks you to spin up an agent on Fountain, delegate work to another agent, fan out a task across N agents, manage Fountain agents/environments/vaults declaratively, or drive the `fountain` CLI. Reads `FOUNTAIN_API_KEY` (required) and `FOUNTAIN_BASE_URL` (defaults to https://fountain.inevitable.fyi).
 ---
 
 # Fountain — driving the API, CLI, and manifest from outside a sprite
@@ -33,7 +33,7 @@ stream for the final answer.
 Everything under `/api/*` requires `Authorization: Bearer <FOUNTAIN_API_KEY>`.
 
 ```bash
-export FOUNTAIN_BASE_URL=https://founta.inevitable.fyi
+export FOUNTAIN_BASE_URL=https://fountain.inevitable.fyi
 export FOUNTAIN_API_KEY=<key>
 ```
 

--- a/apps/fountain/priv/help/for-llms.md
+++ b/apps/fountain/priv/help/for-llms.md
@@ -14,7 +14,7 @@ Point your agent at Fountain in one command:
 
 ```sh
 mkdir -p ~/.claude/skills/fountain
-curl -fsSL https://founta.inevitable.fyi/skill > ~/.claude/skills/fountain/SKILL.md
+curl -fsSL https://fountain.inevitable.fyi/skill > ~/.claude/skills/fountain/SKILL.md
 ```
 
 Self-hosted instance? Substitute your base URL. The skill text itself reads `$FOUNTAIN_BASE_URL` and `$FOUNTAIN_API_KEY` from the agent's environment, so it's not pinned to one host.

--- a/cli/internal/cmd/docs_test.go
+++ b/cli/internal/cmd/docs_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// docs/cli.md described a kubectl-style CLI that never existed: `get`,
+// `describe`, a top-level `delete`, `-o json|yaml|table`, `auth status`,
+// `auth login --endpoint`, and a credentials file in the wrong format. None of
+// it was caught, because nothing compared the page to the binary.
+//
+// This walks the real command tree and fails if a command is undocumented, so
+// the page cannot drift again without someone noticing.
+func TestEveryCommandIsDocumented(t *testing.T) {
+	doc := readCLIDoc(t)
+
+	var missing []string
+	walkCommands(rootCmd, nil, func(path []string) {
+		full := "fountain " + strings.Join(path, " ")
+		if !strings.Contains(doc, full) {
+			missing = append(missing, full)
+		}
+	})
+
+	if len(missing) > 0 {
+		t.Errorf("docs/cli.md does not mention:\n  %s", strings.Join(missing, "\n  "))
+	}
+}
+
+// The reverse direction: a documented command that does not exist is worse than
+// an undocumented one, because someone will type it.
+func TestNoDocumentedCommandIsInvented(t *testing.T) {
+	doc := readCLIDoc(t)
+
+	real := map[string]bool{}
+	walkCommands(rootCmd, nil, func(path []string) {
+		real["fountain "+strings.Join(path, " ")] = true
+	})
+	// Group commands are legitimate to mention on their own.
+	for _, g := range []string{"agent", "auth", "conv", "env", "keys", "vault"} {
+		real["fountain "+g] = true
+	}
+
+	seen := map[string]bool{}
+	inFence := false
+
+	for _, line := range strings.Split(doc, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		// Only example commands count. Prose mentions `fountain <command>` and
+		// markdown links contain punctuation that is not part of any command.
+		if strings.HasPrefix(trimmed, "```") {
+			inFence = !inFence
+			continue
+		}
+		if !inFence {
+			continue
+		}
+
+		idx := strings.Index(trimmed, "fountain ")
+		if idx == -1 || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		fields := strings.Fields(trimmed[idx:])
+		if len(fields) < 2 {
+			continue
+		}
+
+		// Longest match first: `fountain vault set-secret` before `fountain vault`.
+		var candidates []string
+		if len(fields) >= 3 && isCommandWord(fields[2]) {
+			candidates = append(candidates, strings.Join(fields[:3], " "))
+		}
+		candidates = append(candidates, strings.Join(fields[:2], " "))
+
+		matched := false
+		for _, c := range candidates {
+			if real[c] {
+				matched = true
+				break
+			}
+		}
+		if !matched && !seen[candidates[len(candidates)-1]] {
+			seen[candidates[len(candidates)-1]] = true
+			t.Errorf("docs/cli.md documents a command that does not exist: %q (line: %s)",
+				candidates[len(candidates)-1], trimmed)
+		}
+	}
+}
+
+// isCommandWord filters out placeholders and flags so `fountain conv show <id>`
+// does not look like a three-word command.
+func isCommandWord(s string) bool {
+	if s == "" || strings.HasPrefix(s, "-") || strings.HasPrefix(s, "<") || strings.HasPrefix(s, "[") {
+		return false
+	}
+	for _, r := range s {
+		if !(r == '-' || (r >= 'a' && r <= 'z')) {
+			return false
+		}
+	}
+	return true
+}
+
+func walkCommands(c *cobra.Command, path []string, fn func([]string)) {
+	for _, sub := range c.Commands() {
+		if sub.Name() == "help" || sub.Name() == "completion" || sub.Hidden {
+			continue
+		}
+		next := append(append([]string{}, path...), sub.Name())
+		if len(sub.Commands()) == 0 {
+			fn(next)
+		} else {
+			walkCommands(sub, next, fn)
+		}
+	}
+}
+
+func readCLIDoc(t *testing.T) string {
+	t.Helper()
+	// cli/internal/cmd -> repo root
+	path := filepath.Join("..", "..", "..", "docs", "cli.md")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("docs/cli.md not readable from here (%v); skipping", err)
+	}
+	return string(b)
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,7 @@ Create a key under Account -> API Keys (or exchange credentials via `POST /api/a
 
 ```bash
 curl -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
-     https://founta.inevitable.fyi/api/agents
+     https://fountain.inevitable.fyi/api/agents
 ```
 
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,11 @@
 # CLI reference
 
 The `fountain` binary manages Fountain resources from the terminal or CI scripts.
+It is a convenience wrapper over the REST API — everything here can be done with
+`curl`.
+
+This page tracks the real command tree. If a command is not listed here it does
+not exist; `fountain <command> --help` is authoritative.
 
 ## Install
 
@@ -13,82 +18,165 @@ Or grab a release binary from the [GitHub Releases](https://github.com/BinaryBou
 ## Authentication
 
 ```bash
-fountain auth login        # prompts for email + password
-fountain auth logout
-fountain auth status
+fountain auth login     # prompts for email + password, saves an API key
+fountain auth whoami    # print the current user
+fountain auth logout    # remove saved credentials
 ```
 
-Target a non-default instance:
+`auth login` has no `--endpoint` flag. Point the CLI at a different instance with
+`FOUNTAIN_BASE_URL`, which `auth login` then records in the saved profile:
 
 ```bash
-fountain auth login --endpoint https://your-fountain.example.com
+FOUNTAIN_BASE_URL=https://your-fountain.example.com fountain auth login
+```
+
+### Profiles
+
+Use `--profile` (or `FOUNTAIN_PROFILE`) to keep several instances side by side:
+
+```bash
+FOUNTAIN_BASE_URL=https://staging.example.com fountain auth login --profile staging
+fountain conv list --profile staging
+```
+
+## Agents
+
+```bash
+fountain agent list [--json]
+fountain agent show <id>
+```
+
+Agents are **read-only** from the CLI. Create and update them with
+[`fountain apply`](#apply-manifests) or the REST API.
+
+## Environments
+
+```bash
+fountain env list [--json]
+fountain env show <id>
+```
+
+Also read-only. Environment secrets are set through `apply` or the API.
+
+## Vaults
+
+Vaults are the one resource with a full CLI surface, because they hold the
+per-conversation credentials you most often want to change without editing a
+manifest.
+
+```bash
+fountain vault list [--json]
+fountain vault show <id-or-name>
+fountain vault create <name> [--description "..."]
+fountain vault delete <id-or-name>
+
+fountain vault set-secret <id-or-name> <key> <value>
+fountain vault delete-secret <id-or-name> <key>
+```
+
+## Conversations
+
+```bash
+fountain conv list [--json]
+fountain conv show <id>
+fountain conv stream <id>
+fountain conv prompt <id> -p "next instruction" [-i screenshot.png]
+fountain conv interrupt <id>
+fountain conv terminate <id>
+fountain conv delete <id>
+```
+
+`-i/--image` is repeatable and takes local file paths.
+
+## Run an agent
+
+```bash
+fountain run <agent-name-or-id> -p "Audit the auth module"
+fountain run <agent-name-or-id> -p "Run the test suite" --vault staging-creds
+```
+
+`run` creates a conversation and streams until the turn reaches a terminal state.
+
+### Long-running turns
+
+The server closes an idle SSE connection after 60 seconds, so a turn that thinks
+for a while without printing will see the connection drop. The CLI reconnects
+using `Last-Event-ID`, so output produced while disconnected is replayed and a
+dropped connection is never mistaken for a finished turn.
+
+If nothing arrives at all for 30 minutes the CLI exits with an error naming the
+conversation, rather than reporting success. Widen the wait with
+`FOUNTAIN_STREAM_IDLE_TIMEOUT` (seconds):
+
+```bash
+FOUNTAIN_STREAM_IDLE_TIMEOUT=7200 fountain run researcher -p "large refactor"
+```
+
+Disconnecting loses nothing — reattach at any time:
+
+```bash
+fountain conv stream <conversation-id>
 ```
 
 ## Apply manifests
 
 ```bash
 fountain apply -f path/to/manifest.yml
-fountain apply -f path/to/directory/    # walks all *.yml / *.yaml files
+fountain apply -f path/to/directory/          # walks all *.yml / *.yaml files
+fountain apply -f dir/ --var REGION=eu-west-1 # ${VAR} substitution, repeatable
 ```
 
-Apply is idempotent - create if new, update if changed. Supported kinds: `Environment`, `Vault`, `Agent`.
+Apply is idempotent — create if new, update if changed. Supported kinds:
+`Environment`, `Vault`, `Agent`.
 
-The CLI compiles every document into a single manifest and sends it to `POST /api/apply` in one request; the server reconciles environments, then vaults, then agents, and resolves agent `environment:` name references — including environments that already exist on the server. Against older servers without `/api/apply`, the CLI falls back to per-resource calls.
+The CLI compiles every document into a single manifest and sends it to
+`POST /api/apply` in one request; the server reconciles environments, then
+vaults, then agents, and resolves agent `environment:` name references —
+including environments that already exist on the server. Against older servers
+without `/api/apply`, the CLI falls back to per-resource calls.
 
-## Read resources
+## API keys
 
 ```bash
-fountain get agents
-fountain get environments
-fountain get vaults
-fountain get conversations
-
-fountain get agent my-agent-name
+fountain keys list
+fountain keys create <name>     # prints the key once; it is not recoverable
+fountain keys revoke <id>
 ```
 
-## Inspect a resource
+## Output
+
+List commands accept `--json`. There is no `-o` flag and no YAML output:
 
 ```bash
-fountain describe agent my-agent-name
-fountain describe conversation <id>
+fountain agent list --json | jq '.[].name'
 ```
 
-## Delete
+## Configuration
+
+`~/.fountain/credentials` is an INI-style file written by `fountain auth login`,
+with one section per profile:
+
+```ini
+[default]
+api_key = ftn_...
+base_url = https://fountain.inevitable.fyi
+```
+
+The file is written `0600` and the directory `0700`.
+
+### Environment variables
+
+| Variable | Effect |
+|---|---|
+| `FOUNTAIN_API_KEY` | API key; takes precedence over the credentials file |
+| `FOUNTAIN_BASE_URL` | Instance URL; takes precedence over the credentials file |
+| `FOUNTAIN_PROFILE` | Profile to use, equivalent to `--profile` |
+| `FOUNTAIN_STREAM_IDLE_TIMEOUT` | Seconds of silence before a stream gives up (default 1800) |
 
 ```bash
-fountain delete agent my-agent-name
-fountain delete environment python-data-env
+FOUNTAIN_API_KEY=ftn_... FOUNTAIN_BASE_URL=https://other.example.com fountain agent list
 ```
 
-## Start a conversation
-
-```bash
-fountain run agent my-agent-name --prompt "Audit the auth module"
-fountain run agent my-agent-name --vault staging-creds --prompt "Run the test suite"
-```
-
-`run` streams log output until the conversation completes, then prints the final result.
-
-## Output formats
-
-```bash
-fountain get agents -o json
-fountain get agents -o yaml
-fountain get agents -o table   # default
-```
-
-## Configuration file
-
-`~/.fountain/credentials` is written by `fountain auth login`:
-
-```yaml
-endpoint: https://founta.inevitable.fyi
-token: ft_...
-```
-
-Per-invocation overrides:
-
-```bash
-FOUNTAIN_TOKEN=ft_... fountain get agents
-FOUNTAIN_ENDPOINT=https://other.example.com fountain get agents
-```
+Resolution order for both the key and the URL is: environment variable, then the
+active profile in the credentials file, then — for the URL only — the built-in
+default `https://fountain.inevitable.fyi`.

--- a/docs/llm-integration.md
+++ b/docs/llm-integration.md
@@ -6,7 +6,7 @@ Fountain is built to be consumed by AI coding tools. Every instance exposes mach
 
 ```bash
 mkdir -p ~/.claude/skills/fountain
-curl -fsSL https://founta.inevitable.fyi/skill > ~/.claude/skills/fountain/SKILL.md
+curl -fsSL https://fountain.inevitable.fyi/skill > ~/.claude/skills/fountain/SKILL.md
 ```
 
 After that, telling Claude "spin up a researcher agent on Fountain and have it audit the auth module" Just Works.
@@ -20,8 +20,8 @@ After that, telling Claude "spin up a researcher agent on Fountain and have it a
 | `/skill` | Claude Code / Cursor skill file | IDE skills |
 
 ```bash
-curl https://founta.inevitable.fyi/llms.txt
-curl https://founta.inevitable.fyi/llms-full.txt
+curl https://fountain.inevitable.fyi/llms.txt
+curl https://fountain.inevitable.fyi/llms-full.txt
 ```
 
 ## Self-hosted instances
@@ -41,8 +41,8 @@ Fountain will ship a first-party MCP server exposing all four primitives as tool
       "command": "npx",
       "args": ["-y", "@fountain/mcp-server"],
       "env": {
-        "FOUNTAIN_TOKEN": "ft_your_api_key",
-        "FOUNTAIN_ENDPOINT": "https://founta.inevitable.fyi"
+        "FOUNTAIN_API_KEY": "ftn_your_api_key",
+        "FOUNTAIN_BASE_URL": "https://fountain.inevitable.fyi"
       }
     }
   }


### PR DESCRIPTION
Closes #195.

## The page described a CLI that never existed

`docs/cli.md` documented a kubectl-style interface: `fountain get agents`, `fountain describe agent`, a top-level `fountain delete`, `-o json|yaml|table`, `auth status`, `auth login --endpoint`, `FOUNTAIN_ENDPOINT`, and a YAML credentials file with `endpoint:`/`token:` keys.

**None of that is real.** The actual surface is `agent`/`env` (read-only), `vault` (full CRUD), `conv`, `run`, `apply`, `auth`, `keys`, with a boolean `--json` on list commands and an INI-style credentials file keyed `api_key`/`base_url`.

The page is now derived from the command tree — every command, flag and variable read off `--help` rather than from memory. It also documents the streaming behaviour changed in #219, which the old page predated.

## A dead hostname in 22 places

While checking the documented base URL I found `founta.inevitable.fyi` across the README, docs, the bundled `SKILL.md`, the in-app help and `llms.txt`.

That host **resolves** — both names share an A record — which is why it looks like a harmless typo. It isn't:

```
fountain.inevitable.fyi      HTTP 200  body={"status":"ok"}
founta.inevitable.fyi        HTTP 000  body=
```

Only the full name has a certificate and an IngressRoute `Host` match. So every one of those copy-pasteable `curl` commands — including the one in the README that installs the agent skill — failed outright. All 22 now point at the working host.

Also corrects the documented API key prefix from `ft_` to `ftn_`, which is what `create_api_key/3` actually issues, and aligns the (still unbuilt, still marked "coming soon") MCP config block with the CLI's real variable names.

## A guard, because this is drift and drift recurs

Fixing the page once doesn't stop it happening again — nothing compared it to the binary, which is the actual defect. Two Go tests now walk the cobra command tree and check the page in both directions:

- **every real command is documented**
- **every documented command exists** — the more important direction, since someone will type an invented one

Against the previous version of the page they fail on exactly `get`, `describe` and `delete`. Verified by checking out the old doc and running them.

The second test only scans fenced code blocks; my first version flagged prose (`fountain <command> --help`) and a markdown link as invented commands.

These run in CI now that #219 wired up `go test`.

## Verification

- Every documented command executed against the built binary — all 26 resolve.
- `mkdocs build --strict` passes.
- Go: 5 packages pass, `vet` clean. Elixir: 1266 tests, unchanged (only `llms_controller.ex` was touched, for the hostname).

## Note

`site/` is mkdocs build output and is **not** in `.gitignore` — running `mkdocs build` locally leaves an untracked directory. I removed mine rather than commit it, but it's worth adding to `.gitignore` so nobody does it accidentally. Not folded into this PR since it's unrelated to the docs content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)