### PR TITLE
audit: cover the browser surface, auth events and admin actions

### DIFF
--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -13,6 +13,7 @@ defmodule Fountain.Audit do
 
   import Ecto.Query
 
+  alias Fountain.Audit.AdminEvent
   alias Fountain.Audit.Event
   alias Fountain.Repo
 
@@ -49,6 +50,34 @@ defmodule Fountain.Audit do
   def record!(attrs) do
     {:ok, event} = record(attrs)
     event
+  end
+
+  @doc """
+  Record an administrative action taken against another user.
+
+  Separate from `record/1` because these need both an actor and a target, which
+  `audit_events` cannot express. Best-effort on the same terms.
+  """
+  @spec record_admin(map()) :: {:ok, AdminEvent.t()} | {:error, term()}
+  def record_admin(attrs) do
+    attrs =
+      attrs
+      |> Map.new()
+      |> Map.put_new(:metadata, %{})
+      |> Map.put_new(:inserted_at, DateTime.utc_now() |> DateTime.truncate(:second))
+
+    %AdminEvent{} |> AdminEvent.changeset(attrs) |> Repo.insert()
+  rescue
+    e ->
+      require Logger
+      Logger.warning("audit: admin record failed: #{inspect(e)}")
+      {:error, :exception}
+  end
+
+  @doc "Most recent administrative actions, newest first. Admin surfaces only."
+  @spec list_recent_admin(pos_integer()) :: [AdminEvent.t()]
+  def list_recent_admin(limit \\ 100) do
+    Repo.all(from e in AdminEvent, order_by: [desc: e.inserted_at, desc: e.id], limit: ^limit)
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/audit/admin_event.ex
+++ b/apps/fountain/lib/fountain/audit/admin_event.ex
@@ -1,0 +1,45 @@
+defmodule Fountain.Audit.AdminEvent do
+  @moduledoc """
+  An administrative action taken by one user against another.
+
+  The `admin_audit_events` table was created at launch and then never used —
+  no schema module, no writer, no reader. So granting or revoking the admin
+  role, the single most privilege-sensitive action in the product, left no
+  record anywhere.
+
+  It is a separate table from `audit_events` because it needs a shape that one
+  cannot express: an actor *and* a target. `audit_events.user_id` is the tenant
+  an event belongs to, which is ambiguous when an admin acts on someone else's
+  account — the row would either lose the actor or lose the subject.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :id, autogenerate: true}
+
+  schema "admin_audit_events" do
+    # nil for system-originated actions
+    field :actor_user_id, :binary_id
+    field :target_user_id, :binary_id
+    field :event_type, :string
+    field :metadata, :map, default: %{}
+    # Write-once; there is deliberately no updated_at.
+    field :inserted_at, :utc_datetime
+  end
+
+  @event_types ~w(
+    admin.role.granted
+    admin.role.revoked
+    admin.sandbox_limit.changed
+  )
+
+  def event_types, do: @event_types
+
+  def changeset(event, attrs) do
+    event
+    |> cast(attrs, [:actor_user_id, :target_user_id, :event_type, :metadata, :inserted_at])
+    |> validate_required([:event_type, :inserted_at])
+    |> validate_inclusion(:event_type, @event_types)
+  end
+end

--- a/apps/fountain/lib/fountain_web/audited.ex
+++ b/apps/fountain/lib/fountain_web/audited.ex
@@ -1,0 +1,141 @@
+defmodule FountainWeb.Audited do
+  @moduledoc """
+  Records audit events from controllers and LiveViews.
+
+  Auditing used to live entirely in a plug on the `:api` pipeline, so the whole
+  browser surface was invisible: creating, changing or deleting a **secret**
+  through the UI produced no record at all, while the same secret written
+  through the API produced one. For a product whose job is holding tenant
+  secrets, that is the wrong way round.
+
+  ## Actor
+
+  `actor` was hardcoded to `"api"`, which made a human, a CI job and an agent
+  running inside a sandbox indistinguishable in the trail. It is now derived:
+
+    * `"sprite"` — a per-conversation callback token (see the scopes added for
+      the sandbox privilege-escalation fix). Worth separating: "the agent did
+      this" and "the account owner did this" are very different claims.
+    * `"api"` — any other bearer token
+    * `"ui"` — a browser session
+    * `"system"` — no identifiable actor
+
+  Recording is best-effort throughout: `Fountain.Audit.record/1` rescues, so a
+  logging failure can never break the operation being logged.
+  """
+
+  alias Fountain.Accounts.ApiKey
+  alias Fountain.Audit
+
+  @doc """
+  Record an event originating from a `Plug.Conn`.
+
+      Audited.from_conn(conn, "auth.login", "session", metadata: %{"result" => "ok"})
+
+  Pass `:actor` explicitly where the connection cannot reveal it — at login the
+  session does not exist yet, so derivation would report `"system"` for what is
+  plainly a browser sign-in.
+  """
+  def from_conn(conn, action, resource_type, opts \\ []) do
+    Audit.record(%{
+      action: action,
+      resource_type: resource_type,
+      resource_id: Keyword.get(opts, :resource_id),
+      actor: Keyword.get(opts, :actor) || conn_actor(conn),
+      request_ip: format_ip(conn.remote_ip),
+      metadata: Keyword.get(opts, :metadata, %{}),
+      user_id: Keyword.get(opts, :user_id) || conn_user_id(conn)
+    })
+  end
+
+  @doc """
+  Record an event originating from a LiveView socket.
+
+      Audited.from_socket(socket, "vault.secret.write", "vault_secret", resource_id: key)
+  """
+  def from_socket(socket, action, resource_type, opts \\ []) do
+    Audit.record(%{
+      action: action,
+      resource_type: resource_type,
+      resource_id: Keyword.get(opts, :resource_id),
+      actor: "ui",
+      request_ip: socket.assigns[:client_ip],
+      metadata: Keyword.get(opts, :metadata, %{}),
+      user_id: Keyword.get(opts, :user_id) || socket_user_id(socket)
+    })
+  end
+
+  @doc """
+  Resolve the client address for a LiveView socket at mount.
+
+  `get_connect_info/2` is only callable during mount, so the result is stashed
+  in assigns for later events. Forwarded headers are honoured only when the peer
+  is a configured proxy — the same rule the HTTP path uses, and for the same
+  reason: trusting a header from a direct client lets it write whatever address
+  it likes into the audit trail.
+  """
+  def put_client_ip(socket) do
+    Phoenix.Component.assign(socket, :client_ip, resolve_client_ip(socket))
+  end
+
+  defp resolve_client_ip(socket) do
+    peer = Phoenix.LiveView.get_connect_info(socket, :peer_data)
+    headers = Phoenix.LiveView.get_connect_info(socket, :x_headers) || []
+
+    case peer do
+      %{address: address} ->
+        if FountainWeb.Plugs.ClientIp.from_trusted_proxy?(address) do
+          forwarded_ip(headers) || format_ip(address)
+        else
+          format_ip(address)
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp forwarded_ip(headers) do
+    headers
+    |> Enum.find(fn {name, _} -> String.downcase(name) == "x-forwarded-for" end)
+    |> case do
+      {_, value} ->
+        value
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> Enum.reject(&(&1 == ""))
+        |> List.first()
+
+      _ ->
+        nil
+    end
+  end
+
+  defp conn_actor(conn) do
+    case conn.assigns[:current_api_key] do
+      %ApiKey{scopes: scopes} ->
+        if "sprite" in scopes, do: "sprite", else: "api"
+
+      _ ->
+        if conn.assigns[:current_user], do: "ui", else: "system"
+    end
+  end
+
+  defp conn_user_id(conn) do
+    case conn.assigns[:current_user] do
+      %{id: id} -> id
+      _ -> nil
+    end
+  end
+
+  defp socket_user_id(socket) do
+    case socket.assigns[:current_user] do
+      %{id: id} -> id
+      _ -> socket.assigns[:user_id]
+    end
+  end
+
+  defp format_ip(nil), do: nil
+  defp format_ip(tuple) when is_tuple(tuple), do: tuple |> :inet.ntoa() |> to_string()
+  defp format_ip(other), do: to_string(other)
+end

--- a/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
@@ -37,6 +37,11 @@ defmodule FountainWeb.EmailVerificationController do
           user ->
             case Accounts.verify_email(user) do
               {:ok, verified_user} ->
+                FountainWeb.Audited.from_conn(conn, "auth.email.verified", "user",
+                  user_id: verified_user.id,
+                  resource_id: verified_user.id
+                )
+
                 # Durable job rather than a linked Task: this used to be a bare
                 # Task.async with no await, so it could be killed when the
                 # request process finished and a Stripe error vanished silently,

--- a/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
@@ -88,6 +88,13 @@ defmodule FountainWeb.PasswordResetController do
           user ->
             case Accounts.reset_password(user, password) do
               {:ok, _user} ->
+                # Also invalidates every existing session, so this is a
+                # security-relevant event even when the user initiated it.
+                FountainWeb.Audited.from_conn(conn, "auth.password.reset", "user",
+                  user_id: user.id,
+                  resource_id: user.id
+                )
+
                 conn
                 |> configure_session(drop: true)
                 |> put_flash(:info, "Password updated. Please sign in with your new password.")

--- a/apps/fountain/lib/fountain_web/controllers/session_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/session_controller.ex
@@ -38,13 +38,26 @@ defmodule FountainWeb.SessionController do
   def create(conn, %{"email" => email, "password" => password}) do
     case Accounts.authenticate_user(email, password) do
       {:ok, user} ->
+        FountainWeb.Audited.from_conn(conn, "auth.login", "session",
+          user_id: user.id,
+          actor: "ui",
+          metadata: %{"result" => "ok"}
+        )
+
         conn
         |> configure_session(renew: true)
         |> put_session(:user_id, user.id)
         |> put_session(:session_version, user.session_version)
         |> redirect(to: after_login_path(user))
 
-      {:error, _reason} ->
+      {:error, reason} ->
+        # Failures matter more than successes here: a run of them against one
+        # account is the signal you want, and there was no record of any.
+        FountainWeb.Audited.from_conn(conn, "auth.login.failed", "session",
+          actor: "ui",
+          metadata: %{"email" => email, "reason" => to_string(reason)}
+        )
+
         conn
         |> put_status(:unauthorized)
         |> render(:new, error: "Invalid email or password.", layout: false)

--- a/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
@@ -65,6 +65,11 @@ defmodule FountainWeb.UeberauthController do
 
       case Fountain.Accounts.upsert_oauth_user(provider, provider_uid, attrs) do
         {:ok, user, :new} ->
+          FountainWeb.Audited.from_conn(conn, "auth.oauth.signup", "user",
+            user_id: user.id,
+            metadata: %{"provider" => provider}
+          )
+
           # The email+password path does this after verification. OAuth skips
           # verification entirely (the provider asserts the address), so without
           # this every GitHub signup had no Stripe customer and no trial_ends_at.
@@ -77,6 +82,11 @@ defmodule FountainWeb.UeberauthController do
           |> redirect(to: ~p"/onboarding/step_1")
 
         {:ok, user, :existing} ->
+          FountainWeb.Audited.from_conn(conn, "auth.oauth.login", "user",
+            user_id: user.id,
+            metadata: %{"provider" => provider}
+          )
+
           conn
           |> configure_session(renew: true)
           |> put_session(:user_id, user.id)

--- a/apps/fountain/lib/fountain_web/endpoint.ex
+++ b/apps/fountain/lib/fountain_web/endpoint.ex
@@ -28,9 +28,14 @@ defmodule FountainWeb.Endpoint do
     same_site: "Lax"
   ]
 
+  # peer_data + x_headers so LiveView can resolve a client address for audit
+  # events. Without them every UI-originated audit row has a nil request_ip,
+  # which is most of the value of auditing the UI in the first place.
+  @connect_info [session: @session_options, peer_data: true, x_headers: true]
+
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: @session_options]],
-    longpoll: [connect_info: [session: @session_options]]
+    websocket: [connect_info: @connect_info],
+    longpoll: [connect_info: @connect_info]
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -12,7 +12,8 @@ defmodule FountainWeb.AdminLive.Index do
      socket
      |> assign(:page_title, "Admin")
      |> assign_users()
-     |> assign(:sandboxes, Conversations.list_sandboxes_admin())}
+     |> assign(:sandboxes, Conversations.list_sandboxes_admin())
+     |> assign(:admin_events, Fountain.Audit.list_recent_admin(25))}
   end
 
   @impl true
@@ -22,7 +23,8 @@ defmodule FountainWeb.AdminLive.Index do
     {:noreply,
      socket
      |> assign_users()
-     |> assign(:sandboxes, Conversations.list_sandboxes_admin())}
+     |> assign(:sandboxes, Conversations.list_sandboxes_admin())
+     |> assign(:admin_events, Fountain.Audit.list_recent_admin(25))}
   end
 
   @impl true
@@ -32,6 +34,13 @@ defmodule FountainWeb.AdminLive.Index do
 
     case Accounts.update_user_role(user, new_role) do
       {:ok, _} ->
+        Fountain.Audit.record_admin(%{
+          actor_user_id: socket.assigns.current_user.id,
+          target_user_id: user.id,
+          event_type: if(new_role == "admin", do: "admin.role.granted", else: "admin.role.revoked"),
+          metadata: %{"email" => user.email, "from" => user.role, "to" => new_role}
+        })
+
         {:noreply, socket |> assign_users() |> put_flash(:info, "Role updated")}
 
       {:error, _} ->
@@ -47,6 +56,17 @@ defmodule FountainWeb.AdminLive.Index do
     with {limit, ""} <- Integer.parse(String.trim(raw)),
          user = Accounts.get_user!(id),
          {:ok, _} <- Accounts.update_sandbox_limit(user, limit) do
+      Fountain.Audit.record_admin(%{
+        actor_user_id: socket.assigns.current_user.id,
+        target_user_id: user.id,
+        event_type: "admin.sandbox_limit.changed",
+        metadata: %{
+          "email" => user.email,
+          "from" => user.max_concurrent_sandboxes,
+          "to" => limit
+        }
+      })
+
       {:noreply, socket |> assign_users() |> put_flash(:info, "Sandbox limit updated")}
     else
       _ -> {:noreply, put_flash(socket, :error, "Limit must be a whole number of 0 or more")}
@@ -173,6 +193,38 @@ defmodule FountainWeb.AdminLive.Index do
                 </span>
               </td>
               <td class="px-4 py-2 text-xs text-zinc-500">{format_ts(s.inserted_at)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Recent admin actions</h2>
+        <p class="text-sm text-zinc-500">
+          Role grants and quota changes. Previously unrecorded — the
+          <code>admin_audit_events</code> table existed with no writer.
+        </p>
+
+        <div :if={@admin_events == []} class="text-sm text-zinc-500">Nothing yet.</div>
+
+        <table :if={@admin_events != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
+          <thead class="text-left text-zinc-500 border-b border-zinc-200">
+            <tr>
+              <th class="px-4 py-2">When</th>
+              <th class="px-4 py-2">Action</th>
+              <th class="px-4 py-2">Target</th>
+              <th class="px-4 py-2">Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={e <- @admin_events} class="border-b border-zinc-100 last:border-0">
+              <td class="px-4 py-2 text-xs text-zinc-500">{format_ts(e.inserted_at)}</td>
+              <td class="px-4 py-2 font-mono text-xs">{e.event_type}</td>
+              <td class="px-4 py-2 font-mono text-xs">{e.metadata["email"]}</td>
+              <td class="px-4 py-2 text-xs text-zinc-500">
+                <span :if={e.metadata["from"] != nil}>
+                  {e.metadata["from"]} &rarr; {e.metadata["to"]}
+                </span>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -21,6 +21,11 @@ defmodule FountainWeb.ApiKeysLive.Index do
   def handle_event("create_key", %{"label" => label}, socket) do
     case Accounts.create_api_key(socket.assigns.user_id, label) do
       {:ok, {key, raw_token}} ->
+        FountainWeb.Audited.from_socket(socket, "api_key.created", "api_key",
+          resource_id: key.id,
+          metadata: %{"name" => key.name, "scopes" => key.scopes}
+        )
+
         {:noreply,
          socket
          |> assign(:keys, Accounts.list_api_keys(socket.assigns.user_id))
@@ -37,7 +42,12 @@ defmodule FountainWeb.ApiKeysLive.Index do
 
   def handle_event("revoke", %{"id" => id}, socket) do
     case Accounts.revoke_api_key(socket.assigns.user_id, id) do
-      {:ok, _} ->
+      {:ok, revoked} ->
+        FountainWeb.Audited.from_socket(socket, "api_key.revoked", "api_key",
+          resource_id: id,
+          metadata: %{"name" => revoked.name}
+        )
+
         {:noreply,
          socket
          |> assign(:keys, Accounts.list_api_keys(socket.assigns.user_id))

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -168,6 +168,11 @@ defmodule FountainWeb.EnvironmentsLive.Form do
            socket.assigns.tenant_key
          ) do
       {:ok, _} ->
+        FountainWeb.Audited.from_socket(socket, "environment.secret.write", "secret",
+          resource_id: socket.assigns.env.id,
+          metadata: %{"key" => k}
+        )
+
         {:noreply,
          socket
          |> assign(:secrets, secrets_for(socket.assigns.env))
@@ -186,6 +191,11 @@ defmodule FountainWeb.EnvironmentsLive.Form do
 
     if secret do
       Environments.delete_secret(secret)
+
+      FountainWeb.Audited.from_socket(socket, "environment.secret.delete", "secret",
+        resource_id: socket.assigns.env.id,
+        metadata: %{"key" => secret.key}
+      )
 
       {:noreply,
        socket

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -53,7 +53,11 @@ defmodule FountainWeb.Live.Hooks do
          |> redirect(to: ~p"/auth/login")}
 
       true ->
-        {:cont, socket |> track_current_path() |> mount_live_sidebar()}
+        {:cont,
+         socket
+         |> FountainWeb.Audited.put_client_ip()
+         |> track_current_path()
+         |> mount_live_sidebar()}
     end
   end
 

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -57,6 +57,11 @@ defmodule FountainWeb.VaultsLive.Form do
       when k != "" and v != "" do
     case Vaults.upsert_secret(socket.assigns.vault, %{"key" => k, "value" => v}, socket.assigns.tenant_key) do
       {:ok, _} ->
+        FountainWeb.Audited.from_socket(socket, "vault.secret.write", "vault_secret",
+          resource_id: socket.assigns.vault.id,
+          metadata: %{"key" => k}
+        )
+
         {:noreply,
          socket
          |> assign(:secrets, secrets_for(socket.assigns.vault))
@@ -75,6 +80,11 @@ defmodule FountainWeb.VaultsLive.Form do
 
     if secret do
       Vaults.delete_secret(secret)
+
+      FountainWeb.Audited.from_socket(socket, "vault.secret.delete", "vault_secret",
+        resource_id: socket.assigns.vault.id,
+        metadata: %{"key" => secret.key}
+      )
 
       {:noreply,
        socket

--- a/apps/fountain/lib/fountain_web/plugs/audit.ex
+++ b/apps/fountain/lib/fountain_web/plugs/audit.ex
@@ -7,7 +7,10 @@ defmodule FountainWeb.Plugs.Audit do
       `POST conversations`, `DELETE environments/:id/secrets/:id`).
     * `resource_type`, `resource_id`: derived from the matched route's
       action + params.
-    * `actor`: `"api"` for now; could be made request-driven later.
+    * `actor`: derived from the credential — `"sprite"` for a per-conversation
+      callback token, `"api"` otherwise. Previously hardcoded to `"api"`, which
+      made a human, a CI job and an agent running inside a sandbox
+      indistinguishable in the trail.
     * `request_ip`: from `conn.remote_ip`.
     * `metadata`: response status code.
 
@@ -44,13 +47,26 @@ defmodule FountainWeb.Plugs.Audit do
       action: "#{conn.method} #{conn.request_path}",
       resource_type: resource_type,
       resource_id: resource_id,
-      actor: "api",
+      actor: actor(conn),
       request_ip: format_ip(conn.remote_ip),
       metadata: %{"status" => conn.status},
       user_id: current_user_id(conn)
     })
 
     conn
+  end
+
+  # A sandbox acting on the tenant's behalf is a materially different claim from
+  # the tenant acting directly, and the scopes added for the sandbox
+  # privilege-escalation fix make the two distinguishable.
+  defp actor(conn) do
+    case conn.assigns[:current_api_key] do
+      %Fountain.Accounts.ApiKey{scopes: scopes} ->
+        if "sprite" in scopes, do: "sprite", else: "api"
+
+      _ ->
+        "api"
+    end
   end
 
   defp current_user_id(conn) do

--- a/apps/fountain/test/fountain_web/audit_coverage_test.exs
+++ b/apps/fountain/test/fountain_web/audit_coverage_test.exs
@@ -1,0 +1,221 @@
+defmodule FountainWeb.AuditCoverageTest do
+  @moduledoc """
+  Audit coverage across the surfaces that had none.
+
+  There was exactly one `Audit.record` call site in the codebase — a plug on the
+  `:api` pipeline. So writing a secret through the API produced a record and
+  writing the identical secret through the UI produced nothing, which is the
+  wrong way round for a product whose job is holding tenant secrets. Login,
+  logout, password reset and admin role changes were likewise invisible, and
+  `actor` was hardcoded to `"api"`, making a human, a CI job and an agent inside
+  a sandbox indistinguishable.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Audit
+  alias Fountain.Audit.AdminEvent
+  alias Fountain.Repo
+
+  defp events_for(user_id) do
+    Audit.list_recent_for_user(user_id, 100)
+  end
+
+  defp find_action(user_id, action) do
+    Enum.find(events_for(user_id), &(&1.action == action))
+  end
+
+  describe "secret writes through the UI" do
+    test "a vault secret write is recorded", %{conn: conn} do
+      user = insert_verified_user()
+      vault = insert_vault(user_id: user.id)
+
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/vaults/#{vault.id}/edit")
+
+      lv
+      |> element("form[phx-submit='add_secret']")
+      |> render_submit(%{"secret" => %{"key" => "API_TOKEN", "value" => "s3cret"}})
+
+      event = find_action(user.id, "vault.secret.write")
+      assert event, "writing a vault secret through the UI must be audited"
+      assert event.actor == "ui"
+      assert event.resource_id == vault.id
+      assert event.metadata["key"] == "API_TOKEN"
+    end
+
+    test "the secret value is never written to the audit log", %{conn: conn} do
+      # The key is the useful part; the value is the thing that must not leak
+      # into a second table.
+      user = insert_verified_user()
+      vault = insert_vault(user_id: user.id)
+
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/vaults/#{vault.id}/edit")
+
+      lv
+      |> element("form[phx-submit='add_secret']")
+      |> render_submit(%{"secret" => %{"key" => "K", "value" => "super-secret-value"}})
+
+      for event <- events_for(user.id) do
+        refute inspect(event.metadata) =~ "super-secret-value"
+      end
+    end
+
+    test "an environment secret write is recorded", %{conn: conn} do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id)
+
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/environments/#{env.id}/edit")
+
+      lv
+      |> element("form[phx-submit='add_secret']")
+      |> render_submit(%{"secret" => %{"key" => "DB_URL", "value" => "postgres://x"}})
+
+      event = find_action(user.id, "environment.secret.write")
+      assert event
+      assert event.metadata["key"] == "DB_URL"
+    end
+  end
+
+  describe "authentication events" do
+    test "a successful login is recorded", %{conn: conn} do
+      user = insert_verified_user(%{"password" => "password12345"})
+
+      post(conn, ~p"/auth/login", %{"email" => user.email, "password" => "password12345"})
+
+      event = find_action(user.id, "auth.login")
+      assert event
+      assert event.actor == "ui"
+      assert event.metadata["result"] == "ok"
+    end
+
+    test "a failed login is recorded, which is the one that matters", %{conn: conn} do
+      user = insert_verified_user(%{"password" => "password12345"})
+
+      post(conn, ~p"/auth/login", %{"email" => user.email, "password" => "wrong-password"})
+
+      # Attributed to no tenant, since the attempt failed — visible in the
+      # admin view rather than the user's own trail.
+      event = Enum.find(Audit._unsafe_list_recent(50), &(&1.action == "auth.login.failed"))
+      assert event, "failed logins must leave a record — a run of them is the signal"
+      assert event.metadata["email"] == user.email
+      refute event.metadata["password"]
+    end
+
+    test "a password reset is recorded" do
+      user = insert_verified_user()
+      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", user.id)
+
+      build_conn()
+      |> post(~p"/auth/reset", %{"token" => token, "password" => "new-password-123"})
+
+      assert find_action(user.id, "auth.password.reset")
+    end
+  end
+
+  describe "admin actions" do
+    setup do
+      admin = insert_verified_user()
+      {:ok, admin} = Fountain.Accounts.update_user_role(admin, "admin")
+      {:ok, admin: admin}
+    end
+
+    test "granting the admin role is recorded with actor and target", %{conn: conn, admin: admin} do
+      target = insert_verified_user()
+
+      {:ok, lv, _html} = live(login_user(conn, admin), ~p"/admin")
+      render_click(lv, "toggle_admin", %{"id" => target.id})
+
+      assert [event] = Repo.all(AdminEvent)
+      assert event.event_type == "admin.role.granted"
+      assert event.actor_user_id == admin.id
+      assert event.target_user_id == target.id
+      assert event.metadata["to"] == "admin"
+    end
+
+    test "revoking the admin role is recorded distinctly", %{conn: conn, admin: admin} do
+      target = insert_verified_user()
+      {:ok, target} = Fountain.Accounts.update_user_role(target, "admin")
+
+      {:ok, lv, _html} = live(login_user(conn, admin), ~p"/admin")
+      render_click(lv, "toggle_admin", %{"id" => target.id})
+
+      assert [event] = Repo.all(AdminEvent)
+      assert event.event_type == "admin.role.revoked"
+    end
+
+    test "a quota change is recorded", %{conn: conn, admin: admin} do
+      target = insert_verified_user()
+
+      {:ok, lv, _html} = live(login_user(conn, admin), ~p"/admin")
+
+      lv
+      |> element("#sandbox-limit-#{target.id}")
+      |> render_submit(%{"user_id" => target.id, "limit" => "42"})
+
+      assert [event] = Repo.all(AdminEvent)
+      assert event.event_type == "admin.sandbox_limit.changed"
+      assert event.metadata["to"] == 42
+    end
+
+    test "the admin view surfaces the trail", %{conn: conn, admin: admin} do
+      target = insert_verified_user()
+
+      {:ok, lv, _html} = live(login_user(conn, admin), ~p"/admin")
+      render_click(lv, "toggle_admin", %{"id" => target.id})
+
+      {:ok, _lv2, html} = live(login_user(conn, admin), ~p"/admin")
+      assert html =~ "admin.role.granted"
+      assert html =~ target.email
+    end
+  end
+
+  describe "actor attribution" do
+    test "a sprite callback token is distinguished from a human's key", %{conn: conn} do
+      # "the agent did this" and "the account owner did this" are very different
+      # claims, and were indistinguishable when actor was hardcoded.
+      user = insert_verified_user()
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+
+      conn
+      |> authed_with_key(sprite_key)
+      |> post_json("/api/environments", %{"name" => "from-a-sandbox"})
+      |> json_response(201)
+
+      event = Enum.find(events_for(user.id), &(&1.actor == "sprite"))
+      assert event, "a sandbox-originated write must be attributable to the sandbox"
+    end
+
+    test "an ordinary API key is recorded as api", %{conn: conn} do
+      user = insert_verified_user()
+      {_rec, key} = insert_api_key(user)
+
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/environments", %{"name" => "from-cli"})
+      |> json_response(201)
+
+      assert Enum.any?(events_for(user.id), &(&1.actor == "api"))
+      refute Enum.any?(events_for(user.id), &(&1.actor == "sprite"))
+    end
+  end
+
+  describe "API key lifecycle through the UI" do
+    test "creation and revocation are both recorded", %{conn: conn} do
+      user = insert_verified_user()
+
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/api-keys")
+      render_submit(lv, "create_key", %{"label" => "ci-deploy"})
+
+      created = find_action(user.id, "api_key.created")
+      assert created
+      assert created.metadata["name"] == "ci-deploy"
+
+      key_id = created.resource_id
+      render_click(lv, "revoke", %{"id" => key_id})
+
+      assert find_action(user.id, "api_key.revoked")
+    end
+  end
+end


### PR DESCRIPTION
Closes #177.

## The gap

There was exactly **one** `Audit.record` call site in the codebase — a plug on the `:api` pipeline. So a secret written through the API produced a record, and **the identical secret written through the UI produced nothing**. For a product whose job is holding tenant secrets, that is the wrong way round.

Login, logout, password reset and admin role changes were likewise invisible.

## Now recorded

Vault and environment secret writes and deletes, API key creation and revocation through the UI, login success **and failure**, password reset, email verification, and OAuth signup/login.

Failed logins are worth calling out separately: a run of them against one account is the signal you actually want out of an audit log, and there was no record of any.

## Admin actions, and the table that was never wired up

`admin_audit_events` was created at launch and then never used — no schema module, no writer, no reader. So **granting or revoking the admin role, the most privilege-sensitive action in the product, left no trace anywhere.**

It stays a separate table rather than being folded into `audit_events`, because it needs an **actor and a target**, which `audit_events.user_id` cannot express — that column is the tenant an event belongs to, so a single row would either lose the admin who acted or lose the account acted upon.

The admin view renders the trail, since a record nobody can read is only half a fix.

## Actor attribution

`actor` was hardcoded to `"api"`, making a human, a CI job and an agent running inside a sandbox indistinguishable. It is now derived from the credential — and the scopes added in #206 make **`"sprite"` distinguishable from `"api"`**, which is a materially different claim about who did something. "The agent did this" and "the account owner did this" should not look the same in an audit log.

## A gap I hit while building it

LiveView sockets only received `:session` in `connect_info`, so **every UI-originated event would have carried a nil address** — most of the value of auditing the UI. `peer_data` and `x_headers` are now passed and resolved once at mount.

Forwarded headers are honoured only when the peer is a configured proxy, reusing the trusted-proxy check from #216 and for the same reason: trusting that header from a direct client lets it write whatever address it likes into the audit trail. Getting this wrong would make the audit log actively misleading rather than merely incomplete.

## Secret values

Keys are recorded; values are not. There's a test asserting a written secret's value appears in no audit row — worth pinning explicitly, since the natural way to write this code leaks the value into metadata.

## Verification

13 new tests across all five surfaces. One found a real bug in my first version: at login there is no `current_user` on the conn yet, so derivation reported `"system"` for what is plainly a browser sign-in — `:actor` can now be passed explicitly where the connection cannot reveal it.

Suite: **1279 tests + 5 doctests, 0 failures** (baseline 1266). Coverage 87.5% against the 85% gate. Format, `--warnings-as-errors`, credo clean.

## Not covered

- **Sandbox lifecycle events** (provision, network policy, terminate) still only emit PubSub stage events, not audit rows. They're arguably operational telemetry rather than audit, and #213 now meters them; worth a separate decision rather than assuming.
- **Agent / environment / vault CRUD through the UI** (as opposed to their *secrets*) is still unaudited. Secrets were the severity case; the rest is mechanical follow-up.
- `audit_events` retention is 365 days from #217, and `admin_audit_events` is not yet in the pruner — it is low-volume, but it should be added before it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)