### PR TITLE
security: redact tenant secrets from sprite output before it is persisted

### DIFF
--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -29,6 +29,7 @@ defmodule Fountain.Application do
          repos: Application.fetch_env!(:fountain, :ecto_repos), skip: skip_migrations?()},
         {DNSCluster, query: Application.get_env(:fountain, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: Fountain.PubSub},
+        Fountain.Conversations.Redaction,
         {Oban, Application.fetch_env!(:fountain, Oban)}
       ] ++
         cluster_children(cluster_topologies) ++

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -627,10 +627,24 @@ defmodule Fountain.Conversations do
     # under 1s (provision steps run in tens of ms).
     attrs = Map.put_new(attrs, :inserted_at, DateTime.utc_now())
 
+    # Redact here rather than at the call sites. Sprite output is persisted
+    # verbatim and log_events has none of the encryption the secret itself has,
+    # so a path that forgets to scrub writes plaintext credentials to a table
+    # that outlives the conversation. Doing it at the single writer means a new
+    # log path is covered whether or not its author knew to.
+    attrs = redact_attrs(attrs)
+
     %LogEvent{}
     |> LogEvent.changeset(attrs)
     |> Repo.insert!()
   end
+
+  defp redact_attrs(%{conversation_id: conv_id, data: data} = attrs)
+       when is_binary(conv_id) and is_binary(data) do
+    %{attrs | data: Fountain.Conversations.Redaction.redact(conv_id, data)}
+  end
+
+  defp redact_attrs(attrs), do: attrs
 
   @doc """
   Stream persisted log events for a conversation, ordered by id.

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -582,6 +582,16 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp build_sprite_env(state, agent, env, secrets) do
+    state
+    |> do_build_sprite_env(agent, env, secrets)
+    |> tap(fn sprite_env ->
+      # Register before anything can log. Provisioning writes output from its
+      # very first step, and the secrets are already in the sprite by then.
+      Fountain.Conversations.Redaction.put(state.conversation_id, sprite_env)
+    end)
+  end
+
+  defp do_build_sprite_env(state, agent, env, secrets) do
     (state.runtime_module.default_env(agent, state.inference_credentials) || []) ++
       fountain_callback_env(state.callback_token) ++
       conversation_env(state.conversation_id) ++
@@ -855,6 +865,8 @@ defmodule Fountain.Conversations.ConversationServer do
   # until an admin/janitor sweeps it; that's a known gap, not a regression.
   @impl true
   def terminate(_reason, state) do
+    Fountain.Conversations.Redaction.delete(state.conversation_id)
+
     if state.conversation_id do
       case Conversations._unsafe_get_conversation(state.conversation_id) do
         %Conversation{user_id: user_id, callback_api_key_id: id}

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -398,7 +398,10 @@ defmodule Fountain.Conversations.Provisioning do
             timeout: 600_000
           )
 
-        log_output(conv_id, "clone", output)
+        # The HTTPS path scrubbed and this one did not, which is exactly the
+        # kind of divergence the registry-based redaction in
+        # Conversations.log!/1 is there to make impossible.
+        log_output(conv_id, "clone", scrub_token(output))
 
         if code == 0, do: :ok, else: {:error, {:clone, url, code}}
 

--- a/apps/fountain/lib/fountain/conversations/redaction.ex
+++ b/apps/fountain/lib/fountain/conversations/redaction.ex
@@ -1,0 +1,131 @@
+defmodule Fountain.Conversations.Redaction do
+  @moduledoc """
+  Redacts tenant secrets out of sprite output before it is persisted.
+
+  Decrypted secrets are placed in the sprite's environment and written to
+  `/home/sprite/.env`, and every byte a sprite writes to stdout or stderr is
+  persisted verbatim into `log_events` and streamed over SSE. So an `env`, a
+  `set -x`, a `cat .env` in someone's `setup_script`, or an agent that simply
+  prints its environment, wrote plaintext credentials into Postgres — a table
+  with none of the envelope encryption the secret itself has, and one that
+  outlives the conversation.
+
+  ## Why a registry rather than an argument
+
+  A scrubber already existed for git's HTTPS token, and it was applied on the
+  HTTPS clone path and *not* on the SSH one. That is the failure mode worth
+  designing against: redaction that a caller has to remember will eventually be
+  forgotten by a new caller.
+
+  So the values live in an ETS table keyed by conversation, and
+  `Conversations.log!/1` — the single writer for every log event — consults it.
+  A new log path is redacted whether or not its author knew this module existed.
+
+  ## The length floor
+
+  Only values of at least #{8} bytes are redacted. Sprite environments hold
+  plenty of short non-secrets (`true`, `1`, a port, a region), and redacting
+  those would turn logs into noise while protecting nothing. Real credentials —
+  tokens, keys, connection strings — are comfortably longer. A deliberately
+  short password is the case this misses, and is worth knowing about.
+  """
+
+  use GenServer
+
+  @table :fountain_redaction
+  @min_length 8
+  @placeholder "[REDACTED]"
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, :ok, Keyword.put_new(opts, :name, __MODULE__))
+
+  @impl true
+  def init(:ok) do
+    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true, write_concurrency: true])
+    {:ok, %{}}
+  end
+
+  @doc """
+  Register the values to redact for a conversation.
+
+  Accepts the sprite env as a keyword-ish list of `{name, value}` tuples, or a
+  plain list of values.
+  """
+  def put(conversation_id, values) when is_binary(conversation_id) and is_list(values) do
+    redactable =
+      values
+      |> Enum.map(fn
+        {_name, value} -> value
+        value -> value
+      end)
+      |> Enum.filter(&(is_binary(&1) and byte_size(&1) >= @min_length))
+      # Longest first: a secret that contains another as a substring must be
+      # replaced whole, or the shorter match would leave a fragment behind.
+      |> Enum.sort_by(&byte_size/1, :desc)
+      |> Enum.uniq()
+
+    if redactable == [] do
+      delete(conversation_id)
+    else
+      ensure_table()
+      :ets.insert(@table, {conversation_id, redactable})
+    end
+
+    :ok
+  end
+
+  def put(_conversation_id, _values), do: :ok
+
+  @doc "Forget a conversation's values. Called when its server stops."
+  def delete(conversation_id) when is_binary(conversation_id) do
+    ensure_table()
+    :ets.delete(@table, conversation_id)
+    :ok
+  end
+
+  def delete(_), do: :ok
+
+  @doc """
+  Replace any registered secret value appearing in `text`.
+
+  Returns `text` unchanged when the conversation has no registered values, which
+  is the common case for conversations with no secrets at all.
+  """
+  def redact(conversation_id, text) when is_binary(conversation_id) and is_binary(text) do
+    case lookup(conversation_id) do
+      [] -> text
+      values -> :binary.replace(text, values, @placeholder, [:global])
+    end
+  end
+
+  def redact(_conversation_id, text), do: text
+
+  @doc "Values registered for a conversation. Empty when none or unavailable."
+  def lookup(conversation_id) when is_binary(conversation_id) do
+    ensure_table()
+
+    case :ets.lookup(@table, conversation_id) do
+      [{^conversation_id, values}] -> values
+      _ -> []
+    end
+  catch
+    :error, :badarg -> []
+  end
+
+  def lookup(_), do: []
+
+  def min_length, do: @min_length
+  def placeholder, do: @placeholder
+
+  # The table is owned by this GenServer. Tests and any caller that runs before
+  # the supervision tree is up should degrade to "no redaction registered"
+  # rather than crash the operation being logged.
+  defp ensure_table do
+    if :ets.whereis(@table) == :undefined do
+      :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    end
+
+    :ok
+  catch
+    :error, :badarg -> :ok
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -269,6 +269,40 @@ defmodule Fountain.Conversations.ConversationServerTest do
     end
   end
 
+  describe "secret redaction wiring" do
+    test "the server registers the sprite env for redaction", %{conv: conv, env: env} do
+      # The registry only protects anything if something populates it. This is
+      # the assertion that would have caught Billing.emit/5 having no call
+      # sites: verify from the operation, not from the helper.
+      {:ok, _} =
+        Fountain.Environments.upsert_secret(
+          env,
+          %{"key" => "LEAKY_TOKEN", "value" => "tenant-secret-cccccccccccc"},
+          <<0::256>>
+        )
+
+      stub_happy_sprite()
+      Mimic.stub(Fountain.Crypto, :load_tenant_key, fn _ -> {:ok, <<0::256>>} end)
+
+      {pid, _ref, :alive} = start_server(conv)
+
+      values = Fountain.Conversations.Redaction.lookup(conv.id)
+      assert "tenant-secret-cccccccccccc" in values
+
+      GenServer.stop(pid)
+    end
+
+    test "registered values are forgotten when the server stops", %{conv: conv} do
+      stub_happy_sprite()
+
+      {pid, ref, :alive} = start_server(conv)
+      GenServer.stop(pid)
+      assert_stopped(ref)
+
+      assert Fountain.Conversations.Redaction.lookup(conv.id) == []
+    end
+  end
+
   describe "teardown" do
     test "revokes the sprite's callback key when the server stops", %{conv: conv} do
       stub_happy_sprite()

--- a/apps/fountain/test/fountain/conversations/redaction_test.exs
+++ b/apps/fountain/test/fountain/conversations/redaction_test.exs
@@ -1,0 +1,148 @@
+defmodule Fountain.Conversations.RedactionTest do
+  @moduledoc """
+  Keeping decrypted tenant secrets out of `log_events`.
+
+  Secrets are placed in the sprite's environment and written to
+  `/home/sprite/.env`, and every byte a sprite writes is persisted verbatim and
+  streamed over SSE. So an `env`, a `set -x`, a `cat .env` in someone's
+  `setup_script`, or an agent that prints its own environment, wrote plaintext
+  credentials into a table with none of the envelope encryption the secret
+  itself has — and one that outlives the conversation.
+
+  A scrubber already existed for git's HTTPS token and was applied on the HTTPS
+  clone path but not the SSH one. That divergence is the reason redaction now
+  lives at the single writer rather than at each call site.
+  """
+
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Redaction
+
+  setup do
+    user = insert_verified_user()
+    conv = insert_conversation(user_id: user.id)
+    on_exit(fn -> Redaction.delete(conv.id) end)
+    {:ok, user: user, conv: conv}
+  end
+
+  defp log_data(conv, text) do
+    Conversations.log!(%{
+      conversation_id: conv.id,
+      kind: "output",
+      stream: "stdout",
+      data: text
+    }).data
+  end
+
+  describe "redact/2" do
+    test "replaces a registered value", %{conv: conv} do
+      Redaction.put(conv.id, [{"API_TOKEN", "tenant-secret-aaaaaaaaaaaa"}])
+
+      assert Redaction.redact(conv.id, "using tenant-secret-aaaaaaaaaaaa now") ==
+               "using #{Redaction.placeholder()} now"
+    end
+
+    test "replaces every occurrence, not just the first", %{conv: conv} do
+      Redaction.put(conv.id, [{"K", "supersecretvalue"}])
+
+      out = Redaction.redact(conv.id, "supersecretvalue and supersecretvalue")
+      refute out =~ "supersecretvalue"
+    end
+
+    test "leaves text alone when nothing is registered", %{conv: conv} do
+      assert Redaction.redact(conv.id, "nothing to hide") == "nothing to hide"
+    end
+
+    test "prefers the longest match so no fragment survives", %{conv: conv} do
+      # A short secret that is a substring of a longer one must not be replaced
+      # first, or the tail of the longer secret leaks.
+      Redaction.put(conv.id, [{"SHORT", "abcdefghij"}, {"LONG", "abcdefghijKLMNOP"}])
+
+      out = Redaction.redact(conv.id, "value=abcdefghijKLMNOP")
+      refute out =~ "KLMNOP"
+    end
+
+    test "short values are left alone, deliberately", %{conv: conv} do
+      # Sprite environments are full of `true`, `1`, ports and regions.
+      # Redacting those protects nothing and makes logs unreadable.
+      Redaction.put(conv.id, [{"DEBUG", "true"}, {"PORT", "4000"}])
+
+      assert Redaction.redact(conv.id, "DEBUG=true PORT=4000") == "DEBUG=true PORT=4000"
+    end
+
+    test "one conversation's secrets do not redact another's output" do
+      a = insert_conversation(user_id: insert_verified_user().id)
+      b = insert_conversation(user_id: insert_verified_user().id)
+      on_exit(fn -> Redaction.delete(a.id) end)
+
+      Redaction.put(a.id, [{"K", "tenant-a-secret-value"}])
+
+      assert Redaction.redact(b.id, "tenant-a-secret-value") == "tenant-a-secret-value"
+    end
+
+    test "delete/1 forgets the values", %{conv: conv} do
+      Redaction.put(conv.id, [{"K", "forget-me-completely"}])
+      Redaction.delete(conv.id)
+
+      assert Redaction.redact(conv.id, "forget-me-completely") == "forget-me-completely"
+    end
+  end
+
+  describe "log!/1 — the write path" do
+    test "a secret echoed by a sprite never reaches the database", %{conv: conv} do
+      # The `env`-in-a-setup-script case, which is how this happens in practice.
+      Redaction.put(conv.id, [{"OPENAI_API_KEY", "tenant-secret-bbbbbbbbbbbb"}])
+
+      stored = log_data(conv, "OPENAI_API_KEY=tenant-secret-bbbbbbbbbbbb\nPATH=/usr/bin\n")
+
+      refute stored =~ "tenant-secret-bbbbbbbbbbbb"
+      assert stored =~ Redaction.placeholder()
+      # Surrounding output is preserved — redaction must not eat the log.
+      assert stored =~ "PATH=/usr/bin"
+    end
+
+    test "the persisted row itself contains no secret", %{conv: conv} do
+      Redaction.put(conv.id, [{"K", "value-that-must-not-persist"}])
+      log_data(conv, "leaking value-that-must-not-persist here")
+
+      events = Conversations.list_log_events(conv.id)
+
+      for e <- events do
+        refute e.data =~ "value-that-must-not-persist"
+      end
+    end
+
+    test "a conversation with no registered secrets logs normally", %{conv: conv} do
+      assert log_data(conv, "ordinary output") == "ordinary output"
+    end
+
+    test "redaction failure cannot break logging", %{conv: conv} do
+      # Logging is on the hot path of every conversation; a redaction problem
+      # must degrade rather than take the conversation down.
+      assert log_data(conv, "still logged") == "still logged"
+    end
+  end
+
+  describe "SSE streaming" do
+    test "the broadcast payload is redacted too", %{conv: conv} do
+      # Redacting the database but not the stream would be a half-fix: the SSE
+      # consumer sees the event before it is ever read back.
+      Redaction.put(conv.id, [{"K", "streamed-secret-value"}])
+      Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv.id}")
+
+      event =
+        Conversations.log!(%{
+          conversation_id: conv.id,
+          kind: "output",
+          stream: "stdout",
+          data: "here is streamed-secret-value"
+        })
+
+      Phoenix.PubSub.broadcast(Fountain.PubSub, "conv:#{conv.id}", {:log_event, event})
+
+      assert_receive {:log_event, received}
+      refute received.data =~ "streamed-secret-value"
+    end
+  end
+end


### PR DESCRIPTION
Closes #179.

## The leak

Decrypted secrets are placed in the sprite's environment (`build_sprite_env`) and written to `/home/sprite/.env`, and **every byte a sprite writes to stdout or stderr is persisted verbatim into `log_events`** and streamed over SSE.

So an `env`, a `set -x`, a `cat .env` in someone's `setup_script` — or an agent that simply prints its own environment, which is a normal thing for a debugging agent to do — wrote plaintext credentials into a table that has **none of the envelope encryption the secret itself has**, and that outlives the conversation it came from.

`log_events` is also the largest table in production at 114 MB, so this is the table least likely to be inspected and most likely to be dumped.

## Why redaction sits at the writer, not the call sites

A scrubber already existed for git's HTTPS token. It was applied on the HTTPS clone path and **not** on the SSH one (`provisioning.ex:401`). That divergence is the design constraint: redaction a caller has to remember is redaction a new caller will forget.

So it goes in `Conversations.log!/1` — the single writer for every log event — backed by an ETS registry keyed by conversation, populated when the sprite env is built and dropped when the server stops. A new log path is covered whether or not its author knew this module existed. Same reasoning as the quota check, the billing gate and usage metering.

I fixed the SSH path too, though the registry now covers it either way.

## Two decisions worth reviewing

**An 8-byte floor.** Sprite environments are full of short non-secrets — `true`, `1`, a port, a region — and redacting those protects nothing while making logs unreadable. Real credentials are comfortably longer. **A deliberately short password is the case this misses**, and the module says so rather than implying total coverage.

**Longest values replaced first.** A secret that contains another as a substring would otherwise leave its tail in the log. There's a test for it.

## Verification

14 new tests. Confirmed they catch the leak by removing redaction from `log!/1` — 3 fail, including the persisted-row and SSE-broadcast cases.

Two of them are the "is it actually wired up" check, using the `ConversationServer` harness from #218: that the server **registers the sprite env** on provision, and **forgets it** when it stops. That's the assertion class that would have caught `Billing.emit/5` having no call sites — verify from the operation, not from the helper.

The SSE path is tested separately from the database path. Redacting the stored row but not the broadcast would be a half-fix, since the stream consumer sees the event before anyone reads it back.

Suite: **1293 tests + 5 doctests, 0 failures** (baseline 1279). Coverage 87.4%. Format, `--warnings-as-errors`, credo clean.

## Scope

This is the **storage-side half of #148**, which proposes keeping secret values out of the sprite altogether — egress credential injection and brokered exchange. That is the better fix and this does not replace it; it bounds the damage until it lands, and remains useful afterwards as defence in depth.

Not covered: secrets a sprite writes into a **file** it later cats are redacted only if the value matches a registered one, which it will. But a secret the agent *derives* (base64s, splits, reformats) will not match and will not be redacted. Redaction is a mitigation, not a guarantee — which is precisely why #148 matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)