### PR TITLE
config: switches a self-hoster needs — database TLS, billing, registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,22 @@ EMAIL_FROM=noreply@updates.inevitable.fyi
 # /account/inference-credentials in the running app, not via env vars.
 # (CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY
 # all live in the inference_credentials table now.)
+
+# ── Self-hosting switches ────────────────────────────────────────────────────
+
+# Database TLS. Defaults to on. A stock postgres container does not serve TLS,
+# so set this false for the docker-compose setup.
+# DATABASE_SSL=false
+# Verify the server certificate rather than merely encrypting. Uses the OS trust
+# store unless DATABASE_SSL_CA_FILE points at a bundle.
+# DATABASE_SSL_VERIFY=true
+# DATABASE_SSL_CA_FILE=/etc/ssl/certs/ca.pem
+
+# The subscription gate (ADR 0006) is meaningful for the hosted instance and is
+# a lock with no key on a self-hosted one.
+# BILLING_ENABLED=false
+
+# Registration is open by default. Close it once your accounts exist, or restrict it
+# to your own domains.
+# REGISTRATION_ENABLED=false
+# REGISTRATION_ALLOWED_EMAIL_DOMAINS=example.com,example.org

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -41,15 +41,63 @@ defmodule Fountain.Accounts do
   def get_user!(id) when is_binary(id), do: Repo.get!(User, id)
 
   @doc """
+  Whether `email` may create an account on this instance.
+
+  Registration was open to the world with no way to close it: a self-hoster
+  exposing an instance had no control over who signed up, and on the hosted side
+  every signup consumes the platform Sprites token.
+
+  Checked in the context rather than the controller because there are three
+  ways to create an account — the HTML form, the JSON endpoint, and an OAuth
+  callback for an unrecognised identity. A control that only covers the form is
+  not a control.
+  """
+  @spec registration_allowed?(String.t() | nil) :: :ok | {:error, atom()}
+  def registration_allowed?(email) do
+    cond do
+      not Application.get_env(:fountain, :registration_enabled, true) ->
+        {:error, :registration_closed}
+
+      not domain_allowed?(email) ->
+        {:error, :email_domain_not_allowed}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp domain_allowed?(email) do
+    case Application.get_env(:fountain, :registration_allowed_email_domains, []) do
+      [] ->
+        true
+
+      domains ->
+        case String.split(to_string(email), "@") do
+          [_, domain] -> String.downcase(domain) in domains
+          _ -> false
+        end
+    end
+  end
+
+  @doc """
   Register a new user with email + password.
 
   Also creates a `UserDataKey` row in the same transaction, wrapping a freshly
   generated DEK with the platform master key.
 
-  Returns `{:ok, user}` or `{:error, changeset}`.
+  Returns `{:ok, user}`, `{:error, changeset}`, or `{:error, reason}` when
+  registration is closed or the email domain is not allowed.
   """
-  @spec register_user(map()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  @spec register_user(map()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t() | atom()}
   def register_user(attrs) do
+    email = attrs["email"] || attrs[:email]
+
+    with :ok <- registration_allowed?(email) do
+      do_register_user(attrs)
+    end
+  end
+
+  defp do_register_user(attrs) do
     Repo.transaction(fn ->
       with {:ok, user} <- insert_user(attrs),
            {:ok, _udk} <- create_user_data_key(user.id) do
@@ -209,7 +257,13 @@ defmodule Fountain.Accounts do
               end
 
             nil ->
-              # Brand-new user from OAuth
+              # Brand-new user from OAuth — a registration like any other, and
+              # the path most likely to be forgotten by a controller-level gate.
+              case registration_allowed?(email) do
+                :ok -> :ok
+                {:error, reason} -> Repo.rollback(reason)
+              end
+
               verified_at = DateTime.utc_now() |> DateTime.truncate(:second)
 
               with {:ok, user} <-

--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -54,10 +54,21 @@ defmodule Fountain.Billing do
   Raises `SubscriptionRequiredError` for `past_due` and `canceled` statuses.
   """
   @spec assert_active!(User.t()) :: :ok
-  def assert_active!(%User{subscription_status: status}) when status in @active_statuses,
-    do: :ok
+  def assert_active!(%User{} = user) do
+    case check_active(user) do
+      :ok -> :ok
+      {:error, :subscription_required} -> raise(SubscriptionRequiredError)
+    end
+  end
 
-  def assert_active!(%User{}), do: raise(SubscriptionRequiredError)
+  @doc """
+  Whether the subscription gate is enforced at all.
+
+  ADR 0006 made it a product invariant. On a self-hosted instance it is a lock
+  on the front door with no key, so `BILLING_ENABLED=false` disables it — config
+  rather than the source patch the ADR assumed.
+  """
+  def enabled?, do: Application.get_env(:fountain, :billing_enabled, true)
 
   @doc """
   Non-raising gate, for `with` pipelines in contexts.
@@ -66,15 +77,27 @@ defmodule Fountain.Billing do
   identify the user must not be able to provision on someone's behalf.
   """
   @spec check_active(User.t() | binary()) :: :ok | {:error, :subscription_required}
-  def check_active(%User{subscription_status: status}) when status in @active_statuses, do: :ok
-  def check_active(%User{}), do: {:error, :subscription_required}
-
-  def check_active(user_id) when is_binary(user_id) do
-    case Repo.get(User, user_id) do
-      nil -> {:error, :subscription_required}
-      user -> check_active(user)
+  def check_active(subject) do
+    if enabled?() do
+      do_check_active(subject)
+    else
+      :ok
     end
   end
+
+  defp do_check_active(%User{subscription_status: status}) when status in @active_statuses,
+    do: :ok
+
+  defp do_check_active(%User{}), do: {:error, :subscription_required}
+
+  defp do_check_active(user_id) when is_binary(user_id) do
+    case Repo.get(User, user_id) do
+      nil -> {:error, :subscription_required}
+      user -> do_check_active(user)
+    end
+  end
+
+  defp do_check_active(_), do: {:error, :subscription_required}
 
   # ─── Stripe customer ────────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain_web/controllers/registration_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/registration_controller.ex
@@ -36,6 +36,11 @@ defmodule FountainWeb.RegistrationController do
         |> put_flash(:info, "Account created! Check your email to verify your address.")
         |> redirect(to: ~p"/auth/check-email")
 
+      {:error, reason} when is_atom(reason) ->
+        conn
+        |> put_status(:forbidden)
+        |> render(:new, errors: %{email: [registration_message(reason)]}, layout: false)
+
       {:error, changeset} ->
         errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
 
@@ -44,6 +49,14 @@ defmodule FountainWeb.RegistrationController do
         |> render(:new, errors: errors, layout: false)
     end
   end
+
+  defp registration_message(:registration_closed),
+    do: "Registration is closed on this instance."
+
+  defp registration_message(:email_domain_not_allowed),
+    do: "That email domain is not permitted on this instance."
+
+  defp registration_message(_), do: "Registration is not available."
 
   ## JSON path
 
@@ -59,6 +72,11 @@ defmodule FountainWeb.RegistrationController do
           user_id: user.id,
           message: "Check your email to verify your account."
         })
+
+      {:error, reason} when is_atom(reason) ->
+        conn
+        |> put_status(:forbidden)
+        |> json(%{error: to_string(reason), message: registration_message(reason)})
 
       {:error, changeset} ->
         conn

--- a/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
@@ -93,6 +93,11 @@ defmodule FountainWeb.UeberauthController do
           |> put_session(:session_version, user.session_version)
           |> redirect(to: ~p"/conversations")
 
+        {:error, reason} when reason in [:registration_closed, :email_domain_not_allowed] ->
+          conn
+          |> put_flash(:error, "Registration is not open on this instance.")
+          |> redirect(to: ~p"/auth/login")
+
         {:error, _changeset} ->
           conn
           |> put_flash(:error, "Could not sign in with GitHub. Please try again.")

--- a/apps/fountain/test/fountain/self_host_switches_test.exs
+++ b/apps/fountain/test/fountain/self_host_switches_test.exs
@@ -1,0 +1,167 @@
+defmodule Fountain.SelfHostSwitchesTest do
+  @moduledoc """
+  The two switches a self-hoster needs and did not have.
+
+  ADR 0006 made the subscription gate a product invariant, which is right for
+  the hosted instance and is a lock with no key on a self-hosted one — the ADR
+  itself notes the reversal costs "one line", but that line was a source patch.
+
+  Registration was open to the world with no way to close it. On the hosted side
+  that matters too: every signup consumes the platform Sprites token, and
+  production took 188 signups in two weeks with a 1% activation rate.
+  """
+
+  use Fountain.DataCase, async: false
+
+  alias Fountain.{Accounts, Billing}
+
+  defp with_env(pairs, fun) do
+    previous = Enum.map(pairs, fn {k, _} -> {k, Application.get_env(:fountain, k)} end)
+    Enum.each(pairs, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+
+    try do
+      fun.()
+    after
+      Enum.each(previous, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+    end
+  end
+
+  defp cancelled_user do
+    user = insert_verified_user()
+
+    {:ok, user} =
+      user
+      |> Accounts.User.billing_changeset(%{subscription_status: "canceled"})
+      |> Fountain.Repo.update()
+
+    user
+  end
+
+  describe "BILLING_ENABLED" do
+    test "the gate is enforced by default" do
+      assert {:error, :subscription_required} = Billing.check_active(cancelled_user())
+    end
+
+    test "disabling it lets a cancelled account through" do
+      user = cancelled_user()
+
+      with_env([billing_enabled: false], fn ->
+        assert :ok = Billing.check_active(user)
+      end)
+    end
+
+    test "assert_active!/1 follows the same switch" do
+      user = cancelled_user()
+
+      with_env([billing_enabled: false], fn ->
+        assert :ok = Billing.assert_active!(user)
+      end)
+
+      assert_raise Billing.SubscriptionRequiredError, fn ->
+        Billing.assert_active!(user)
+      end
+    end
+
+    test "a conversation can start with billing disabled" do
+      # The end-to-end point: the gate is checked in the context, so the switch
+      # has to reach there and not just the controller.
+      user = cancelled_user()
+      agent = insert_agent(user_id: user.id)
+
+      with_env([billing_enabled: false], fn ->
+        Mimic.stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec ->
+          {:ok, spawn(fn -> :ok end)}
+        end)
+
+        assert {:ok, _} =
+                 Fountain.Conversations.start_conversation(%{
+                   "agent_id" => agent.id,
+                   "user_id" => user.id
+                 })
+      end)
+    end
+  end
+
+  describe "REGISTRATION_ENABLED" do
+    test "registration is open by default" do
+      assert :ok = Accounts.registration_allowed?("someone@example.com")
+    end
+
+    test "closing it refuses new accounts" do
+      with_env([registration_enabled: false], fn ->
+        assert {:error, :registration_closed} =
+                 Accounts.registration_allowed?("someone@example.com")
+
+        assert {:error, :registration_closed} =
+                 Accounts.register_user(%{
+                   "email" => "blocked@example.com",
+                   "password" => "password123"
+                 })
+      end)
+    end
+
+    test "closing it does not affect existing accounts" do
+      user = insert_verified_user()
+
+      with_env([registration_enabled: false], fn ->
+        assert {:ok, ^user} = Accounts.authenticate_user(user.email, "password123")
+      end)
+    end
+  end
+
+  describe "REGISTRATION_ALLOWED_EMAIL_DOMAINS" do
+    test "an empty list allows any domain" do
+      assert :ok = Accounts.registration_allowed?("anyone@anywhere.test")
+    end
+
+    test "a configured list admits only those domains" do
+      with_env([registration_allowed_email_domains: ["example.com"]], fn ->
+        assert :ok = Accounts.registration_allowed?("someone@example.com")
+
+        assert {:error, :email_domain_not_allowed} =
+                 Accounts.registration_allowed?("someone@elsewhere.com")
+      end)
+    end
+
+    test "matching is case-insensitive" do
+      with_env([registration_allowed_email_domains: ["example.com"]], fn ->
+        assert :ok = Accounts.registration_allowed?("Someone@EXAMPLE.com")
+      end)
+    end
+
+    test "a malformed address is refused rather than admitted" do
+      with_env([registration_allowed_email_domains: ["example.com"]], fn ->
+        assert {:error, :email_domain_not_allowed} = Accounts.registration_allowed?("no-at-sign")
+        assert {:error, :email_domain_not_allowed} = Accounts.registration_allowed?(nil)
+      end)
+    end
+  end
+
+  describe "OAuth signup" do
+    test "is gated too, not just the forms" do
+      # The path most likely to be missed by a controller-level check: an
+      # unrecognised OAuth identity creates an account.
+      with_env([registration_enabled: false], fn ->
+        assert {:error, :registration_closed} =
+                 Accounts.upsert_oauth_user(
+                   "github",
+                   "gh-#{System.unique_integer([:positive])}",
+                   %{
+                     "email" => "newcomer@example.com"
+                   }
+                 )
+      end)
+    end
+
+    test "an existing user can still sign in when registration is closed" do
+      user = insert_verified_user()
+      uid = "gh-#{System.unique_integer([:positive])}"
+      {:ok, _, :existing} = Accounts.upsert_oauth_user("github", uid, %{"email" => user.email})
+
+      with_env([registration_enabled: false], fn ->
+        assert {:ok, _user, :existing} =
+                 Accounts.upsert_oauth_user("github", uid, %{"email" => user.email})
+      end)
+    end
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,6 +17,13 @@ config :fountain, Oban,
      ]}
   ]
 
+# Self-hosting switches. Defaults preserve the hosted behaviour; a self-hoster
+# turns billing off and closes registration without patching source.
+config :fountain,
+  billing_enabled: true,
+  registration_enabled: true,
+  registration_allowed_email_domains: []
+
 config :fountain,
   ecto_repos: [Fountain.Repo],
   generators: [timestamp_type: :utc_datetime, binary_id: true]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -112,6 +112,29 @@ metrics_port =
 
 config :fountain, :metrics_port, metrics_port
 
+# ADR 0006 made the subscription gate a product invariant. For a self-hosted
+# instance it is just a lock on the front door with no key, so it is now
+# config rather than a source patch.
+config :fountain, :billing_enabled, System.get_env("BILLING_ENABLED", "true") != "false"
+
+# Registration was open to the world with no way to close it. A self-hoster
+# exposing an instance had no control over who signed up, and on the hosted
+# side every signup consumes the platform Sprites token.
+config :fountain, :registration_enabled, System.get_env("REGISTRATION_ENABLED", "true") != "false"
+
+allowed_signup_domains =
+  case System.get_env("REGISTRATION_ALLOWED_EMAIL_DOMAINS") do
+    blank when blank in [nil, ""] ->
+      []
+
+    list ->
+      list
+      |> String.split(",", trim: true)
+      |> Enum.map(&(&1 |> String.trim() |> String.downcase()))
+  end
+
+config :fountain, :registration_allowed_email_domains, allowed_signup_domains
+
 # CIDRs treated as proxies when resolving the client IP from X-Forwarded-For.
 # Only widen this to cover addresses that are genuinely proxies — anything
 # trusted here is stepped over, so an over-broad list lets a client spoof its
@@ -244,11 +267,33 @@ if config_env() == :prod and server? do
     System.get_env("DATABASE_URL") ||
       raise "environment variable DATABASE_URL is missing."
 
+  # verify_none is the historical behaviour. DATABASE_SSL_VERIFY=true turns on
+  # real certificate verification, using an explicit CA bundle when given and
+  # the OS trust store otherwise — no extra dependency, and OTP loads it.
+  database_ssl_opts =
+    case {System.get_env("DATABASE_SSL_VERIFY"), System.get_env("DATABASE_SSL_CA_FILE")} do
+      {"true", nil} ->
+        [verify: :verify_peer, cacerts: :public_key.cacerts_get(), depth: 3]
+
+      {"true", ca_file} ->
+        [verify: :verify_peer, cacertfile: to_charlist(ca_file), depth: 3]
+
+      _ ->
+        [verify: :verify_none]
+    end
+
   config :fountain, Fountain.Repo,
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    ssl: true,
-    ssl_opts: [verify: :verify_none]
+    # TLS was hardcoded on with no override, which meant the canonical
+    # self-host setup — app and Postgres in containers — could not connect at
+    # all, because a stock postgres image does not serve TLS. Defaults to on so
+    # the hosted deployment is unchanged.
+    ssl: System.get_env("DATABASE_SSL", "true") != "false",
+    # verify_none is the historical behaviour: encrypted but not authenticated,
+    # so a MITM between app and database is possible. Set DATABASE_SSL_VERIFY=true
+    # with DATABASE_SSL_CA_FILE to actually verify the server.
+    ssl_opts: database_ssl_opts
 
   secret_key_base =
     System.get_env("SECRET_KEY_BASE") ||


### PR DESCRIPTION
Closes #185, #188. First half of the self-hosting work; the compose file and guide (#184) follow and depend on this.

## Three things that could only be changed by patching source

**Postgres TLS was hardcoded on** (`ssl: true`, no override), so the canonical self-host setup — app and database in containers — **could not connect at all**, because a stock `postgres` image does not serve TLS. This is the hard blocker behind #184.

`DATABASE_SSL` defaults to on so the hosted deployment is unchanged. While in there, `DATABASE_SSL_VERIFY` makes it possible to *authenticate* the server rather than merely encrypt to it — the historical `verify: :verify_none` (encrypted but MITM-able) remains the default so nothing breaks, but it is now a choice rather than the only option. Uses the OS trust store via `:public_key.cacerts_get/0`, so no new dependency.

**The subscription gate.** ADR 0006 made it a product invariant — right for the hosted instance, a lock with no key on a self-hosted one. The ADR notes the reversal costs "one line", but that line was a source patch. `BILLING_ENABLED=false` now disables it.

**Registration was open to the world** with no way to close it. A self-hoster exposing an instance had no control over who signed up. This matters on the hosted side too: every signup consumes the platform Sprites token, and production took **188 signups in two weeks with a 1% activation rate**. `REGISTRATION_ENABLED` closes it; `REGISTRATION_ALLOWED_EMAIL_DOMAINS` restricts it to your own domains.

## Both gates live in the context, not the controllers

There are **three** ways to create an account: the HTML form, the JSON endpoint, and an OAuth callback for an unrecognised identity. A control that covers only the form is not a control — and the OAuth path is exactly the one a controller-level check would have missed, since it does not look like registration code.

Same reasoning for billing: the gate is checked in `start_conversation/1`, so the switch has to reach there and not just the controller. There is a test asserting a conversation actually starts for a cancelled account with billing disabled, rather than only that the predicate returns `:ok`.

## Verification

13 new tests. The ones worth noting: OAuth signup being gated, an existing user still being able to sign in when registration is closed (closing the door must not lock people out), case-insensitive domain matching, and a malformed address being **refused rather than admitted** — a `nil` or `no-at-sign` email must not slip past a domain allowlist.

The three TLS modes were checked by evaluating `runtime.exs` through `Config.Reader`:

| Configuration | Result |
|---|---|
| default (**production today**) | `ssl=true verify=:verify_none` — unchanged |
| `DATABASE_SSL=false` | `ssl=false` |
| `DATABASE_SSL_VERIFY=true` | `ssl=true verify=:verify_peer` |

Suite: **1314 tests + 5 doctests, 0 failures** (baseline 1301). Format, `--warnings-as-errors`, credo clean.

## Note on the hosted instance

Nothing here changes production behaviour: every default preserves what is running today. `BILLING_ENABLED` and `REGISTRATION_ENABLED` are both unset there, so both remain on.

Worth considering separately whether to set `REGISTRATION_ENABLED=false` on the hosted instance given the signup pattern — that is a product decision, not one I should make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)