### PR TITLE
docs: a compose file that runs the app, and a self-hosting guide

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -1,0 +1,58 @@
+# Copy to `.env` beside docker-compose.yml, then fill in the two generated keys.
+#
+#   cp .env.compose.example .env
+#
+# Generate both:
+#
+#   echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')" >> .env
+#   echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" >> .env
+
+# Phoenix session/cookie signing. Any long random string.
+SECRET_KEY_BASE=
+
+# Wraps every tenant's data encryption key. 32 bytes, url-safe base64, no
+# padding.
+#
+# BACK THIS UP, AND DO NOT CHANGE IT. Every encrypted environment and vault
+# value in the database is unreadable without it — losing it is equivalent to
+# losing the secrets themselves, and rotating it has the same effect.
+MASTER_SECRETS_KEY=
+
+# Required to run conversations. Fountain provisions sandboxes through
+# sprites.dev; the app starts without a token but every conversation fails.
+SPRITES_TOKEN=
+
+# ── Optional ─────────────────────────────────────────────────────────────────
+
+# Where this instance is reached. Must be absolute and include the scheme —
+# it builds verification links and is passed to every sandbox.
+# PUBLIC_URL=https://fountain.example.com
+
+# Host port to publish. The container always listens on 4000.
+# PORT=4000
+
+# POSTGRES_PASSWORD=postgres
+
+# Pin the image rather than tracking latest.
+# FOUNTAIN_IMAGE_TAG=latest
+
+# Mail. The default (EMAIL_DELIVERY=none) sends nothing, so verify accounts
+# with:
+#   docker compose exec app bin/fountain_server eval \
+#     'Fountain.Release.verify_email("you@example.com")'
+#
+# For real mail, set one of these and remove EMAIL_DELIVERY.
+# RESEND_API_KEY=
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# EMAIL_FROM=fountain@example.com
+
+# The subscription gate. Off by default in compose — it exists for the hosted
+# service and is a lock with no key on your own instance.
+# BILLING_ENABLED=false
+
+# Close registration once your own account exists.
+# REGISTRATION_ENABLED=false
+# REGISTRATION_ALLOWED_EMAIL_DOMAINS=example.com

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ aod.yml
 # Burrito output.
 /burrito_out/
 
+
+# mkdocs build output
+site/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ A multi-tenant API and UI for managing agents, repos, secrets, and conversations
 
 This repo is the bus for the [`captain-picard`](https://github.com/jhgaylor/aod-specs) Agent on Demand orchestrator. See `OPERATING_MODEL.md` for how the team operates and `ROADMAP.md` for what's open.
 
+## Self-hosting
+
+Run your own instance: [docs/self-hosting.md](docs/self-hosting.md).
+
+```sh
+cp .env.compose.example .env   # then fill in the generated keys
+docker compose up -d
+```
+
 ## Three surfaces
 
 Every public feature lives on all three:

--- a/SETUP.md
+++ b/SETUP.md
@@ -63,7 +63,7 @@ Pick **one** path:
 docker compose up -d postgres
 ```
 
-Brings up Postgres 16 on `localhost:5432` with role `postgres`/`postgres` and database `fountain_dev`. Stop with `docker compose down`; data persists in the `postgres_data` volume.
+Brings up Postgres 16 on `localhost:5432` with role `postgres`/`postgres`. `mix setup` creates `fountain_dev` itself. (`docker compose up` with no service name also starts Fountain — see [self-hosting](docs/self-hosting.md).) Stop with `docker compose down`; data persists in the `postgres_data` volume.
 
 ### Option B — Native Postgres
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,87 @@
-version: "3.9"
+# Fountain, self-hosted.
+#
+#   cp .env.compose.example .env    # then fill in the generated keys
+#   docker compose up -d
+#   open http://localhost:4000
+#
+# For local development you only want the database, and `docker compose up -d
+# postgres` still does exactly that — `mix setup` creates fountain_dev itself.
+# See SETUP.md.
 services:
   postgres:
     image: postgres:16
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: fountain_dev
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: fountain
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      # The app runs migrations at boot, so it must not start against a
+      # database that is still initialising.
+      test: ["CMD-SHELL", "pg_isready -U postgres -d fountain"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    image: ghcr.io/binarybourbon/fountain:${FOUNTAIN_IMAGE_TAG:-latest}
+    # To run your own build instead of the published image, comment the line
+    # above and uncomment this:
+    #   build: .
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${PORT:-4000}:4000"
+    environment:
+      PHX_SERVER: "true"
+      PORT: "4000"
+
+      DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/fountain
+      # A stock postgres image does not serve TLS, and this was hardcoded on —
+      # which is why a compose setup could not have worked before.
+      DATABASE_SSL: "false"
+
+      # Absolute and scheme-ful: it builds the links in verification emails and
+      # is handed to every sprite as FOUNTAIN_BASE_URL. Change it if you reach
+      # this instance by anything other than localhost.
+      PUBLIC_URL: ${PUBLIC_URL:-http://localhost:4000}
+
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:?set SECRET_KEY_BASE in .env — see .env.compose.example}
+      MASTER_SECRETS_KEY: ${MASTER_SECRETS_KEY:?set MASTER_SECRETS_KEY in .env — see .env.compose.example}
+
+      # Conversations need a Sprites token. The app boots without one; every
+      # attempt to start a conversation then fails.
+      SPRITES_TOKEN: ${SPRITES_TOKEN:-}
+
+      # Off by default here: the subscription gate is meaningful for the hosted
+      # service and is a lock with no key on a self-hosted instance.
+      BILLING_ENABLED: ${BILLING_ENABLED:-false}
+
+      # No mail by default, so a first run needs nothing external. Verify your
+      # account with:
+      #   docker compose exec app bin/fountain_server eval \
+      #     'Fountain.Release.verify_email("you@example.com")'
+      # Set RESEND_API_KEY or SMTP_HOST to send real mail instead.
+      EMAIL_DELIVERY: ${EMAIL_DELIVERY:-none}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      EMAIL_FROM: ${EMAIL_FROM:-noreply@localhost}
+
+      # Open by default so the first account can be created. Close it once
+      # yours exists.
+      REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
+
+      # There is no OTLP collector in a default compose setup, and without this
+      # the exporter retries per span and floods the logs.
+      OTEL_TRACES_EXPORTER: "none"
+    restart: unless-stopped
 
 volumes:
   postgres_data:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,163 @@
+# Self-hosting
+
+Running your own Fountain instance.
+
+For a development environment on your own machine, see [Setup](setup.md) — that
+is a different thing, and this page assumes you want an instance that stays up.
+
+## What you need
+
+| | |
+|---|---|
+| **Postgres 16+** | The compose file below runs one for you |
+| **A Sprites token** | Fountain provisions sandboxes through [sprites.dev](https://sprites.dev). The app boots without one, but every conversation fails |
+| **A mail provider** | Resend or any SMTP server. Optional — see [Email](#email) |
+
+Sprites is currently the only sandbox backend, and it is a hosted service, so a
+Fountain instance is not fully self-contained. `SPRITES_BASE_URL` is not yet
+configurable ([#189](https://github.com/BinaryBourbon/fountain/issues/189)).
+
+## Quick start
+
+```bash
+git clone https://github.com/BinaryBourbon/fountain
+cd fountain
+
+cp .env.compose.example .env
+echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')" >> .env
+echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" >> .env
+# add your SPRITES_TOKEN to .env
+
+docker compose up -d
+```
+
+Then open <http://localhost:4000> and register. With the default
+`EMAIL_DELIVERY=none` nothing is sent, so verify your own account:
+
+```bash
+docker compose exec app bin/fountain_server eval \
+  'Fountain.Release.verify_email("you@example.com")'
+```
+
+Sign in, and close registration so nobody else can join:
+
+```bash
+echo "REGISTRATION_ENABLED=false" >> .env
+docker compose up -d
+```
+
+To make yourself an admin, set the role directly — there is no bootstrap flow
+for the first admin yet:
+
+```bash
+docker compose exec postgres psql -U postgres -d fountain \
+  -c "UPDATE users SET role = 'admin' WHERE email = 'you@example.com';"
+```
+
+## Back up `MASTER_SECRETS_KEY`
+
+Every environment and vault secret is encrypted with a per-tenant key that is
+itself wrapped with `MASTER_SECRETS_KEY`. **Lose it and every stored secret is
+unrecoverable; change it and the same is true.** It is not stored in the
+database, by design — so a database backup alone does not protect you.
+
+Keep it somewhere separate from your database backups, and treat rotating it as
+a migration rather than a config change.
+
+## Database
+
+The app runs its migrations at boot, so upgrading is `docker compose pull &&
+docker compose up -d`.
+
+`DATABASE_SSL` defaults to on and the compose file sets it to `false`, because a
+stock `postgres` image does not serve TLS. If you point Fountain at a managed
+database, remove that line. To verify the server certificate rather than merely
+encrypt to it:
+
+```bash
+DATABASE_SSL_VERIFY=true
+# optional, otherwise the OS trust store is used
+DATABASE_SSL_CA_FILE=/etc/ssl/certs/rds-ca.pem
+```
+
+### Backups
+
+Nothing here backs up your database. Fountain's own deployment uses a nightly
+`pg_dump` to object storage; the mechanism is described in the
+[operator runbook](https://github.com/BinaryBourbon/fountain/blob/main/apps/fountain/priv/help/runbook.md).
+At minimum:
+
+```bash
+docker compose exec postgres pg_dump -U postgres -Fc fountain > fountain-$(date +%F).dump
+```
+
+Restore into a scratch database and check the row counts before you need it in
+anger. A backup nobody has restored is a hypothesis.
+
+## Email
+
+Fountain refuses to start in production without a mail setting, because a
+silently discarded verification email dead-ends signup with no visible error.
+Pick one:
+
+| Setting | Effect |
+|---|---|
+| `RESEND_API_KEY` | Delivery via Resend |
+| `SMTP_HOST` (+ `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`) | Any SMTP server. Port defaults to 587 with STARTTLS; omit the username for an unauthenticated relay |
+| `EMAIL_DELIVERY=none` | No email. Verify accounts with `Fountain.Release.verify_email/1` |
+
+Password reset also needs working mail. With `EMAIL_DELIVERY=none` the only
+route back into a locked-out account is the database.
+
+## Billing
+
+The compose file sets `BILLING_ENABLED=false`. The subscription gate exists for
+the hosted service; on your own instance it is a lock with no key. Leave it off
+unless you are running Fountain commercially and have configured Stripe.
+
+## Putting it on the internet
+
+The compose file publishes port 4000 with no TLS. Terminate TLS in front of it
+with Caddy, nginx, or a tunnel, and then:
+
+- set `PUBLIC_URL` to the external URL, scheme included — it builds verification
+  links and is passed to every sandbox
+- set `TRUSTED_PROXIES` to your proxy's address range, or per-IP rate limits will
+  all collapse into one bucket keyed on the proxy
+- close registration, or set `REGISTRATION_ALLOWED_EMAIL_DOMAINS`
+
+Registration is open by default. An instance on the public internet with
+registration open will be found.
+
+## Observability
+
+The app serves Prometheus metrics on port 9568, which the compose file does not
+publish. Add a port mapping if you are scraping it, and keep it off the public
+internet — it enumerates routes, request rates and database timings.
+
+Logs go to stdout: `docker compose logs -f app`.
+
+## Kubernetes
+
+`k8s/` in this repository is the maintainer's own cluster, not a template: it
+assumes CNPG, Traefik, cert-manager, Infisical, Flux and Longhorn, and hardcodes
+personal hostnames. It is worth reading for reference and is not worth applying.
+A generic chart is
+[#191](https://github.com/BinaryBourbon/fountain/issues/191).
+
+## Known gaps
+
+Being straight about what self-hosting does not yet include:
+
+- **No licence.** The repository has no `LICENSE` file
+  ([#183](https://github.com/BinaryBourbon/fountain/issues/183)), so strictly
+  speaking nobody has been granted permission to run it. That is being resolved;
+  until it is, treat this page as documentation rather than a grant.
+- **Sprites is a hosted dependency** and the endpoint is not configurable
+  ([#189](https://github.com/BinaryBourbon/fountain/issues/189)).
+- **No published version tags for the server image** — only `latest` and
+  per-commit SHAs ([#190](https://github.com/BinaryBourbon/fountain/issues/190)),
+  so pinning means pinning a SHA.
+- **No first-admin bootstrap**; the role is set in SQL.
+- **No account deletion**
+  ([#170](https://github.com/BinaryBourbon/fountain/issues/170)).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Setup: setup.md
+  - Self-hosting: self-hosting.md
   - The four primitives: primitives.md
   - CLI reference: cli.md
   - API reference: api.md


### PR DESCRIPTION
Closes #184. Depends on #224 (merged), which made database TLS configurable — without that this could not work at all.

## What was there

`docker-compose.yml` started **only Postgres**. It was a dev database helper, exactly as `SETUP.md` describes it, and there was no one-command path to a running instance.

There was also no self-hosting documentation of any kind: `SETUP.md` and `docs/setup.md` are workstation bootstrap, and `PREREQUISITES.md` documents the captain-picard agent-orchestration workflow rather than Fountain.

## The compose file

Brings up the app against its database, gated on a health check so migrations do not race Postgres initialising, and sets `DATABASE_SSL=false` — a stock `postgres` image does not serve TLS, and that setting being hardcoded is the reason a compose setup could not have worked before.

Defaults are chosen so a **first run needs nothing external**: billing off, email off, registration open. Each is a variable with a comment saying what to change and when.

`SECRET_KEY_BASE` and `MASTER_SECRETS_KEY` use compose's `:?` syntax, so a missing key fails immediately with a message naming the file to look in, rather than booting into a confusing state.

`docker compose up -d postgres` still does what `SETUP.md` documents for development, so the dev workflow is unaffected. The compose database is now named `fountain`; `mix setup` creates `fountain_dev` itself, and I corrected the sentence in `SETUP.md` that said otherwise.

## The guide

`docs/self-hosting.md` covers the first-account flow, which needs explaining because there is no bootstrap: register, verify via the release command (no mail is configured by default), close registration, then set the admin role in SQL.

It also states plainly:

- **`MASTER_SECRETS_KEY` is not in the database**, so a database backup alone does not protect you, and rotating it has the same effect as losing it.
- **Nothing backs up your database** unless you set it up, with a `pg_dump` starting point and the advice to actually restore it once.
- **Put it behind TLS and set `TRUSTED_PROXIES`**, or per-IP rate limits collapse into a single bucket keyed on the proxy.
- **`k8s/` is the maintainer's own cluster, not a template** — worth reading, not worth applying.

And a "known gaps" section, because a self-hosting guide that oversells is worse than none: no licence (#183), Sprites is a hosted dependency with a non-configurable endpoint (#189), no version-tagged images (#190), no first-admin bootstrap, no account deletion (#170).

## What I verified, and what I could not

**Could not:** there is no container runtime on this machine — no docker, podman, nerdctl, colima or lima. **I have not run `docker compose up`.** Given how much of this work has turned on actually executing things, I want that stated rather than implied.

**Did:**

- the compose YAML parses, and `depends_on` gates on `service_healthy`
- every `${VAR}` the app service references is documented in `.env.compose.example` (checked programmatically — it caught two I had missed, `BILLING_ENABLED` and `SMTP_PORT`)
- **the application config resolves correctly under exactly the environment the compose file sets**, evaluated through `Config.Reader`:

| | |
|---|---|
| boots | yes |
| database ssl | `false` |
| public_url | `"http://localhost:4000"` |
| billing_enabled | `false` |
| registration | `true` |
| mailer adapter | none — `EMAIL_DELIVERY=none` honoured |

That last check is the one that matters most, because every historical failure in this area was a config resolution bug rather than a compose syntax bug: TLS hardcoded on, `PUBLIC_URL` schemeless, mail silently discarded. A `docker compose up` on your machine is still the real test.

`mkdocs build --strict` passes with the new page in the nav.

## Also

Added `site/` to `.gitignore` — mkdocs build output, which I flagged on #220 as easy to commit accidentally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)