### PR TITLE
docs: add the MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jake Gaylor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -127,3 +127,11 @@ See [`SETUP.md`](SETUP.md) for the full local bootstrap (mise + Postgres + deps)
 ## Contributing
 
 See [`CLAUDE.md`](CLAUDE.md) for architecture, test patterns, tenant isolation contract, and things to avoid. See [`OPERATING_MODEL.md`](OPERATING_MODEL.md) for how the team operates.
+
+## Licence
+
+Fountain is [MIT licensed](LICENSE). Use it, run it, modify it, host it.
+
+If a directory named `ee/` appears in this repository later, the code in it is
+**not** covered by that licence and will carry its own — the MIT grant above
+applies to everything outside `ee/`. Nothing lives there today.

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jake Gaylor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -145,14 +145,15 @@ personal hostnames. It is worth reading for reference and is not worth applying.
 A generic chart is
 [#191](https://github.com/BinaryBourbon/fountain/issues/191).
 
+## Licence
+
+Fountain is MIT licensed — running your own instance is explicitly fine,
+including commercially.
+
 ## Known gaps
 
 Being straight about what self-hosting does not yet include:
 
-- **No licence.** The repository has no `LICENSE` file
-  ([#183](https://github.com/BinaryBourbon/fountain/issues/183)), so strictly
-  speaking nobody has been granted permission to run it. That is being resolved;
-  until it is, treat this page as documentation rather than a grant.
 - **Sprites is a hosted dependency** and the endpoint is not configurable
   ([#189](https://github.com/BinaryBourbon/fountain/issues/189)).
 - **No published version tags for the server image** — only `latest` and


### PR DESCRIPTION
Closes #183.

## What this does

Adds `LICENSE` (MIT, © 2026 Jake Gaylor) at the repository root, and a copy in `cli/` because that is a separate Go module and pkg.go.dev looks for a licence at the module root.

The generated Homebrew formula has been asserting `license "MIT"` to everyone who installed the CLI while nothing in the repository backed it. That claim is now true.

The file is the **unmodified** MIT text so GitHub's licence detection recognises it. The open-core intent is stated in the README instead, carving out a future `ee/` directory in advance:

> If a directory named `ee/` appears in this repository later, the code in it is **not** covered by that licence and will carry its own — the MIT grant above applies to everything outside `ee/`. Nothing lives there today.

Saying that now rather than when `ee/` arrives removes any argument that the root grant already covered it. Keeping it out of `LICENSE` itself keeps the licence standard.

Also removes the "no licence" entry from the self-hosting guide's known-gaps section, which was the last blocker listed there.

---

## Before merging: one consequence worth being explicit about

**Merging this is irreversible for every commit it covers.** You can relicense future versions at any time; you cannot un-MIT what has already been published. Anyone who takes a copy keeps those rights permanently.

Concretely, against what you said earlier — *"no one but me should be able to sell fountain"* — **MIT does not achieve that for the current codebase.** Under MIT, anyone may take today's Fountain and sell a hosted competitor, with no obligation to contribute back or even say they used it.

The `ee/` model protects **future** features you deliberately build there. It does not protect what exists now, which is essentially the whole product: the four primitives, sandbox provisioning, the billing integration, the CLI, the API. GitLab and Sentry both work this way, and in both cases the open core is genuinely, permanently free for anyone to host.

That is a completely defensible trade — adoption is worth more than protection when you have one paying account, and MIT is the lowest-friction thing for the self-hosting goal you have been prioritising. I am not arguing against it. But it is the one decision in this whole audit that cannot be walked back, so I would rather you make it deliberately than notice the implication later.

If you would rather keep the option open, the alternative is to ship a source-available non-compete licence now (FSL converts to Apache 2.0 after two years, so it is open-source-with-a-delay rather than closed) and relax to MIT whenever you choose — that direction is easy, and this one is not.

**I have not merged this.** Say the word and I will, or swap the licence if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)