### PR TITLE
fix(provisioning): quote .env values inertly, verify ssh host keys

### DIFF
--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -58,15 +58,17 @@ defmodule Fountain.Conversations.Provisioning do
     |> Kernel.<>("\n")
   end
 
-  defp shell_escape_value(v) do
-    # Quote values containing whitespace, quotes, or shell metacharacters.
-    # Escape inner double quotes.
-    if String.match?(v, ~r/[\s"'\\$`]/) do
-      ~s|"| <> String.replace(v, ~s|"|, ~s|\\"|) <> ~s|"|
-    else
-      v
-    end
-  end
+  # Always single-quote, escaping inner single quotes as '\''.
+  #
+  # This previously detected `$`, backtick and backslash and then wrapped the
+  # value in *double* quotes, where all three remain active. The file is
+  # explicitly meant to be `source`d by a user's setup_script, so a secret whose
+  # value contained $(...) or `...` executed on source. A value containing a
+  # newline also silently corrupted the file, since nothing quoted it.
+  #
+  # Single quotes are inert in shell: the only character needing treatment is
+  # the single quote itself, and newlines survive intact.
+  defp shell_escape_value(v), do: shell_quote(v)
 
   # ── checkpoint create / restore ───────────────────────────────────────────
 
@@ -367,47 +369,90 @@ defmodule Fountain.Conversations.Provisioning do
     "export XDG_CONFIG_HOME=/tmp; "
   end
 
-  # SSH clone via key-from-secret. The private key is written to a
-  # short-lived path inside the sprite, GIT_SSH_COMMAND uses it for this
-  # clone, and the file is removed on exit. StrictHostKeyChecking=no
-  # because we don't have known_hosts management; this is the
-  # convenience tradeoff for SSH on a sprite.
+  # Host keys for the common forges, so an SSH clone verifies who it is talking
+  # to. Every one of these was checked against the provider's own published
+  # fingerprints fetched over TLS — ssh-keyscan alone is the very channel this
+  # is meant to protect against, so scanning and pinning the result would be
+  # circular.
+  #
+  # Providers do rotate these (GitHub replaced its RSA key in 2023). A rotation
+  # makes clones from that host fail closed rather than silently succeed against
+  # an unknown key, which is the intended direction.
+  @known_hosts [
+                 "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl",
+                 "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=",
+                 "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=",
+                 "gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf",
+                 "gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9",
+                 "bitbucket.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIazEu89wgQZ4bqs3d63QSMzYVa0MuJ2e2gKTKqu+UUO",
+                 "bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDQeJzhupRu0u0cdegZIa8e86EG2qOCsIsD1Xw0xSeiPDlCr7kq97NLmMbpKTX6Esc30NuoqEEHCuc7yWtwp8dI76EEEB1VqY9QJq6vk+aySyboD5QF61I/1WeTwu+deCbgKMGbUijeXhtfbxSxm6JwGrXrhBdofTsbKRUsrN1WoNgUa8uqN1Vx6WAJw1JHPhglEGGHea6QICwJOAr/6mrui/oB7pkaWKHj3z7d1IC4KWLtY47elvjbaTlkN04Kc/5LFEirorGYVbt15kAUlqGM65pk6ZBxtaO3+30LVlORZkxOh+LKL/BvbZ/iRNhItLqNyieoQj/uh/7Iv4uyH/cV/0b4WDSd3DptigWq84lJubb9t/DnZlrJazxyDCulTmKdOR7vs9gMTo+uoIrPSb8ScTtvw65+odKAlBj59dhnVp9zd7QUojOpXlL62Aw56U4oO+FALuevvMjiWeavKhJqlR7i5n9srYcrNV7ttmDw7kf/97P5zauIhxcjX+xHv4M="
+               ]
+               |> Enum.join("\n")
+               |> Kernel.<>("\n")
+
+  # SSH clone via key-from-secret. The private key is written to a short-lived
+  # path inside the sprite, GIT_SSH_COMMAND uses it for this clone, and the file
+  # is removed on exit.
   defp clone_ssh(sprite, %{"url" => url, "mount_path" => mount} = repo, secrets, conv_id) do
     case fetch_secret(repo["ssh_key_secret"], secrets) do
       {:ok, key} ->
-        key_path = "/tmp/aod_ssh_#{:erlang.unique_integer([:positive])}"
+        unique = :erlang.unique_integer([:positive])
+        key_path = "/tmp/aod_ssh_#{unique}"
+        hosts_path = "/tmp/aod_known_hosts_#{unique}"
 
-        cmd =
-          ~s|set -e; |
-          |> Kernel.<>(git_env_prefix())
-          |> Kernel.<>(~s|umask 077; |)
-          |> Kernel.<>(~s|cat > #{shell_quote(key_path)} << 'AOD_KEY_EOF'\n#{key}\nAOD_KEY_EOF\n|)
-          |> Kernel.<>(~s|chmod 600 #{shell_quote(key_path)}; |)
-          |> Kernel.<>(~s|mkdir -p #{shell_quote(Path.dirname(mount))}; |)
-          |> Kernel.<>(
-            ~s|GIT_SSH_COMMAND='ssh -i #{key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' |
-          )
-          |> Kernel.<>(
-            ~s|git clone --depth 50 #{branch_arg(repo)}#{shell_quote(url)} #{shell_quote(mount)}; |
-          )
-          |> Kernel.<>(~s|rc=$?; rm -f #{shell_quote(key_path)}; exit $rc|)
+        # Written as files rather than heredoc'd into the command. The heredoc
+        # used a fixed sentinel, so a key containing a line equal to it
+        # terminated the heredoc early and the remainder of the key ran as
+        # shell — an arbitrary-write primitive into the provisioning command.
+        fs = Sprites.filesystem(sprite, "/")
 
-        {output, code} =
-          Sprites.cmd(sprite, "bash", ["-lc", cmd],
-            stderr_to_stdout: true,
-            timeout: 600_000
-          )
+        with :ok <- Sprites.Filesystem.write(fs, key_path, key),
+             :ok <- Sprites.Filesystem.write(fs, hosts_path, @known_hosts) do
+          # Cleanup via trap rather than `rc=$?; rm ...`: with `set -e` a failed
+          # clone exits the shell immediately, so the trailing rm never ran and
+          # the private key stayed on the sprite for the rest of its life.
+          cmd =
+            ~s|set -e; |
+            |> Kernel.<>(
+              ~s|trap 'rm -f #{shell_quote(key_path)} #{shell_quote(hosts_path)}' EXIT; |
+            )
+            |> Kernel.<>(git_env_prefix())
+            |> Kernel.<>(~s|chmod 600 #{shell_quote(key_path)}; |)
+            |> Kernel.<>(~s|mkdir -p #{shell_quote(Path.dirname(mount))}; |)
+            # accept-new rather than no: a pinned host is verified and a
+            # mismatch fails, while an unrecognised host (someone's self-hosted
+            # git server) is still usable. `no` disabled the check entirely,
+            # including for a host whose key had changed under us.
+            |> Kernel.<>(
+              ~s|GIT_SSH_COMMAND='ssh -i #{key_path} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=#{hosts_path}' |
+            )
+            |> Kernel.<>(
+              ~s|git clone --depth 50 #{branch_arg(repo)}#{shell_quote(url)} #{shell_quote(mount)}|
+            )
 
-        # The HTTPS path scrubbed and this one did not, which is exactly the
-        # kind of divergence the registry-based redaction in
-        # Conversations.log!/1 is there to make impossible.
-        log_output(conv_id, "clone", scrub_token(output))
-
-        if code == 0, do: :ok, else: {:error, {:clone, url, code}}
+          run_ssh_clone(sprite, cmd, url, conv_id)
+        else
+          {:error, reason} -> {:error, {:clone_ssh_write, reason}}
+        end
 
       {:error, reason} ->
         {:error, {:clone_ssh_secret, reason}}
     end
+  end
+
+  defp run_ssh_clone(sprite, cmd, url, conv_id) do
+    {output, code} =
+      Sprites.cmd(sprite, "bash", ["-lc", cmd],
+        stderr_to_stdout: true,
+        timeout: 600_000
+      )
+
+    # The HTTPS path scrubbed and this one did not, which is exactly the kind of
+    # divergence the registry-based redaction in Conversations.log!/1 is there
+    # to make impossible.
+    log_output(conv_id, "clone", scrub_token(output))
+
+    if code == 0, do: :ok, else: {:error, {:clone, url, code}}
   end
 
   @doc false
@@ -468,7 +513,7 @@ defmodule Fountain.Conversations.Provisioning do
   # ── helpers ───────────────────────────────────────────────────────────────
 
   @doc false
-  def shell_quote(s), do: "'" <> String.replace(s, "'", "'\\''" ) <> "'"
+  def shell_quote(s), do: "'" <> String.replace(s, "'", "'\\''") <> "'"
 
   defp publish_stage(conv_id, stage, state, meta \\ %{}) do
     Conversations.log!(%{

--- a/apps/fountain/test/fountain/conversations/provisioning_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_test.exs
@@ -60,4 +60,200 @@ defmodule Fountain.Conversations.ProvisioningTest do
       assert :ok = Provisioning.apply_network_policy(%{name: "test-sprite"}, env, conv.id)
     end
   end
+
+  # ── .env quoting ───────────────────────────────────────────────────────────
+
+  # The file exists to be `source`d by the user's setup_script, so the only
+  # assertion worth making is what a real shell sees when it reads it back.
+  # Values used to be wrapped in *double* quotes with only `"` escaped, so
+  # $(...), backticks and backslashes stayed live, and a newline split the value
+  # across lines.
+  defp sourced_value(value) do
+    body = Provisioning.render_env_file(%{"SECRET" => value})
+    dir = Path.join(System.tmp_dir!(), "envq-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    file = Path.join(dir, ".env")
+    File.write!(file, body)
+
+    try do
+      {out, 0} =
+        System.cmd("bash", ["-c", "set -a; source #{file}; printf %s \"$SECRET\""],
+          stderr_to_stdout: true
+        )
+
+      out
+    after
+      File.rm_rf!(dir)
+    end
+  end
+
+  describe "render_env_file/1" do
+    test "a command substitution is not executed" do
+      assert sourced_value("pw-$(id -u)-end") == "pw-$(id -u)-end"
+      assert sourced_value("pw-`id -u`-end") == "pw-`id -u`-end"
+    end
+
+    test "a variable reference is not expanded" do
+      assert sourced_value("literal-$HOME") == "literal-$HOME"
+      assert sourced_value("literal-${HOME}") == "literal-${HOME}"
+    end
+
+    test "backslashes survive" do
+      # Windows-style paths and anything base64/PEM-adjacent hit this.
+      assert sourced_value("C:\\Users\\me") == "C:\\Users\\me"
+      assert sourced_value("a\\nb") == "a\\nb"
+    end
+
+    test "a multi-line value survives instead of splitting the file" do
+      pem = "-----BEGIN KEY-----\nabc\ndef\n-----END KEY-----"
+      assert sourced_value(pem) == pem
+    end
+
+    test "quotes of both kinds survive" do
+      assert sourced_value(~s|it's a "quote"|) == ~s|it's a "quote"|
+      assert sourced_value("'") == "'"
+    end
+
+    test "a value cannot introduce a second assignment" do
+      assert sourced_value("x\nINJECTED=1") == "x\nINJECTED=1"
+
+      body = Provisioning.render_env_file(%{"SECRET" => "x\nINJECTED=1"})
+      script = "set -a; source /dev/stdin <<'EOF'\n#{body}EOF\necho \"[${INJECTED-}]\""
+      {out, 0} = System.cmd("bash", ["-c", script], stderr_to_stdout: true)
+
+      assert String.trim(out) == "[]"
+    end
+
+    test "ordinary values still round-trip" do
+      assert sourced_value("plain") == "plain"
+      assert sourced_value("") == ""
+    end
+  end
+
+  # ── ssh clone ──────────────────────────────────────────────────────────────
+
+  # Built as a struct rather than through the factory on purpose: the
+  # Environment changeset has rejected any url that is not https:// since the
+  # schema was written, so no environment reachable through the UI, the API or
+  # the manifest apply can carry an ssh repo — production has 9 repositories,
+  # all https, none with an ssh_key_secret. clone_ssh/4 is unreachable today.
+  # That is why these bugs were never hit, not a reason to leave them in: the
+  # branch is live code that a one-line validation change would switch on.
+  defp ssh_repo_env do
+    %Fountain.Environments.Environment{
+      id: Ecto.UUID.generate(),
+      name: "ssh-env",
+      repositories: [
+        %{
+          "url" => "git@github.com:acme/widgets.git",
+          "mount_path" => "/home/sprite/widgets",
+          "ssh_key_secret" => "DEPLOY_KEY"
+        }
+      ]
+    }
+  end
+
+  # Runs a clone and returns the shell command plus every file written into the
+  # sprite, keyed by path.
+  defp run_ssh_clone(env, conv, key) do
+    test = self()
+
+    stub(Sprites, :filesystem, fn _sprite, _dir -> :fs end)
+
+    stub(Sprites.Filesystem, :write, fn :fs, path, contents ->
+      send(test, {:wrote, path, contents})
+      :ok
+    end)
+
+    stub(Sprites, :cmd, fn _sprite, "bash", ["-lc", cmd], _opts ->
+      send(test, {:cmd, cmd})
+      {"", 0}
+    end)
+
+    assert :ok =
+             Provisioning.clone_repositories(
+               %{name: "test-sprite"},
+               env,
+               %{"DEPLOY_KEY" => key},
+               conv.id
+             )
+
+    assert_received {:cmd, cmd}
+    {cmd, collect_writes(%{})}
+  end
+
+  defp collect_writes(acc) do
+    receive do
+      {:wrote, path, contents} -> collect_writes(Map.put(acc, path, contents))
+    after
+      0 -> acc
+    end
+  end
+
+  describe "clone_repositories/4 over ssh" do
+    test "the private key is written as a file, never embedded in the command" do
+      # It used to be heredoc'd in with the fixed sentinel AOD_KEY_EOF, so a key
+      # containing that line closed the heredoc early and the remainder ran as
+      # shell — command injection into provisioning for anyone who can set a
+      # secret, which is every user on their own sandbox and anyone they share
+      # a vault with.
+      key = "-----BEGIN OPENSSH PRIVATE KEY-----\nAOD_KEY_EOF\ntouch /tmp/pwned\n"
+      {cmd, writes} = run_ssh_clone(ssh_repo_env(), insert_conversation(), key)
+
+      refute cmd =~ "AOD_KEY_EOF"
+      refute cmd =~ "touch /tmp/pwned"
+      refute cmd =~ "BEGIN OPENSSH PRIVATE KEY"
+
+      {key_path, ^key} = Enum.find(writes, fn {path, _} -> path =~ "aod_ssh_" end)
+      assert key_path =~ ~r|^/tmp/aod_ssh_\d+$|
+      assert cmd =~ "chmod 600 '#{key_path}'"
+      assert cmd =~ "ssh -i #{key_path} "
+    end
+
+    test "host keys are pinned and checking stays on" do
+      {cmd, writes} = run_ssh_clone(ssh_repo_env(), insert_conversation(), "key")
+
+      # StrictHostKeyChecking=no accepted whatever answered the connection, so
+      # anything on the network path could serve its own repository contents
+      # and have an agent execute them inside the sandbox.
+      refute cmd =~ "StrictHostKeyChecking=no"
+      refute cmd =~ "UserKnownHostsFile=/dev/null"
+      assert cmd =~ "StrictHostKeyChecking=accept-new"
+
+      {hosts_path, hosts} = Enum.find(writes, fn {path, _} -> path =~ "aod_known_hosts_" end)
+      assert cmd =~ "UserKnownHostsFile=#{hosts_path}"
+
+      for host <- ~w(github.com gitlab.com bitbucket.org) do
+        assert hosts =~ "#{host} ssh-ed25519 AAAA"
+      end
+
+      # accept-new alone would be nearly worthless here: every sprite is fresh,
+      # so with an empty known_hosts every host is trusted on first sight. The
+      # pinned entries are what actually closes the window.
+      assert String.trim(hosts) != ""
+    end
+
+    test "both temp files are removed even when the clone fails" do
+      # `set -e` meant a failing clone exited the shell before the trailing rm,
+      # leaving the private key on the sprite for the rest of its life.
+      {cmd, _writes} = run_ssh_clone(ssh_repo_env(), insert_conversation(), "key")
+
+      assert String.starts_with?(cmd, "set -e; trap 'rm -f ")
+      assert cmd =~ ~r/trap 'rm -f \S*aod_ssh\S* \S*aod_known_hosts\S*' EXIT/
+    end
+
+    test "a failed write is reported rather than clone running without the key" do
+      stub(Sprites, :filesystem, fn _sprite, _dir -> :fs end)
+      stub(Sprites.Filesystem, :write, fn :fs, _path, _contents -> {:error, :enospc} end)
+      reject(&Sprites.cmd/4)
+
+      assert {:error, {:clone_ssh_write, :enospc}} =
+               Provisioning.clone_repositories(
+                 %{name: "test-sprite"},
+                 ssh_repo_env(),
+                 %{"DEPLOY_KEY" => "key"},
+                 insert_conversation().id
+               )
+    end
+  end
 end


### PR DESCRIPTION
Closes #178.

Three problems in `Fountain.Conversations.Provisioning`, the module that builds a sprite's filesystem before an agent starts.

## `.env` values were interpolated by the shell

`shell_escape_value/1` decided whether to quote by looking for `$`, backtick, whitespace, quotes and backslash — and then wrapped the value in **double** quotes with only `"` escaped. All of `$`, backtick and backslash remain active inside double quotes.

The file is explicitly written to be `source`d by the user's `setup_script`, so:

- a secret containing `$(...)` or `` `...` `` executed on source
- `$HOME` and friends silently expanded, so the variable the agent read was not the value the user stored
- a multi-line value (a PEM body, an SSH key) split across lines, and its tail was interpreted as further assignments

Now every value is single-quoted with `'\''` escaping. Single quotes are inert, and newlines survive intact.

This one was live — every conversation writes this file.

## The SSH key was heredoc'd into the command

The private key went into the provisioning command inside a heredoc with the fixed sentinel `AOD_KEY_EOF`. A key containing that line closed the heredoc early and the remainder ran as shell.

It is now written with `Sprites.Filesystem.write/3` — the same way `write_env_file/2` already did it — so the key never appears in the command string at all.

## The SSH clone did not verify who it was talking to

`StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null` accepted whatever answered the connection. The consequence is not key disclosure, it is that anything on the network path could serve its own repository contents into a sandbox that an agent then executes.

Now a `known_hosts` pinned to github.com, gitlab.com and bitbucket.org is written into the sprite, with `StrictHostKeyChecking=accept-new`.

`accept-new` on its own would be close to worthless here: every sprite is fresh, so with an empty `known_hosts` every host is trusted on first sight. The pinned entries are what actually closes the window.

Each key was verified against the provider's own published fingerprints, fetched over TLS — `ssh-keyscan` is precisely the channel this is meant to defend against, so scanning and pinning the result would be circular. Providers do rotate these; a rotation makes clones fail closed rather than silently succeed against an unknown key, which is the direction we want.

Cleanup also moved from `rc=$?; rm -f ...` to a `trap ... EXIT`, because `set -e` meant a failed clone exited the shell before the `rm` and left the private key on the sprite for the rest of its life.

## Scope note: the SSH path is unreachable today

`clone_ssh/4` cannot currently be reached. The `Environment` changeset has rejected any `url` that is not `https://` since the schema was written, and every write path (UI, API, manifest apply) goes through it. Production has 9 repositories: all https, none with an `ssh_key_secret`. So none of the SSH bugs were exploitable — but the branch is live code that a one-line validation change would switch on, which is why it is fixed rather than left.

`priv/help/environments.md` documents SSH clones as a working feature. That mismatch is filed separately as #228.

## Tests

`.env` quoting is asserted through a real `bash source` round-trip rather than on the shape of the rendered string — what a shell actually sees is the only thing that matters. Reverting the source change fails 6 of the 14 tests in the file.

Full suite: 1325 tests, 0 failures. `mix format --check-formatted`, `mix compile --warnings-as-errors` and `mix credo --strict` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
