### PR TITLE
fix(api): stop the SSE stream endpoint 406ing every real client

### DIFF
--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -10,13 +10,24 @@ defmodule FountainWeb.Router do
     plug FountainWeb.Plugs.PutApiSpec, module: FountainWeb.ApiSpec
   end
 
-  # Authenticated JSON — TenantAPIAuth gate for all resource endpoints
+  # Authenticated API — TenantAPIAuth gate for all resource endpoints.
+  #
+  # Content negotiation is deliberately NOT part of this pipeline. Every
+  # authenticated route pipes through `:accepts_json` as well, except the SSE
+  # stream, which cannot: a real EventSource client sends
+  # `Accept: text/event-stream`, and `plug :accepts, ["json"]` refuses that with
+  # 406 before the action ever runs. Keeping the auth chain in one pipeline
+  # means the stream route cannot drift out of it — a second copy of these
+  # plugs would be one forgotten line away from an unauthenticated endpoint.
   pipeline :api do
-    plug :accepts, ["json"]
     plug FountainWeb.Plugs.PutApiSpec, module: FountainWeb.ApiSpec
     plug FountainWeb.Plugs.TenantAPIAuth
     plug FountainWeb.Plugs.RateLimit, bucket: "api", max: 600
     plug FountainWeb.Plugs.Audit
+  end
+
+  pipeline :accepts_json do
+    plug :accepts, ["json"]
   end
 
   # Base browser pipeline — session, flash, CSRF, secure headers
@@ -139,7 +150,7 @@ defmodule FountainWeb.Router do
   ## ─── Authenticated JSON resource endpoints ──────────────────────────────────────────────────────────────
 
   scope "/api/auth", FountainWeb do
-    pipe_through :api
+    pipe_through [:accepts_json, :api]
 
     get "/me", AuthMeController, :show
   end
@@ -147,7 +158,7 @@ defmodule FountainWeb.Router do
   # Key management is scope-gated: the per-conversation token a sprite holds
   # must not be able to mint a second key that survives conversation teardown.
   scope "/api/auth", FountainWeb do
-    pipe_through [:api, :require_key_management]
+    pipe_through [:accepts_json, :api, :require_key_management]
 
     get "/api-keys", ApiKeyController, :index
     post "/api-keys", ApiKeyController, :create
@@ -155,7 +166,7 @@ defmodule FountainWeb.Router do
   end
 
   scope "/api", FountainWeb do
-    pipe_through :api
+    pipe_through [:accepts_json, :api]
 
     resources "/environments", EnvironmentController, except: [:new, :edit] do
       resources "/secrets", SecretController, only: [:index, :create, :delete]
@@ -174,10 +185,21 @@ defmodule FountainWeb.Router do
       post "/prompts", ConversationController, :prompt, as: :prompt
       post "/interrupt", ConversationController, :interrupt, as: :interrupt
       post "/terminate", ConversationController, :terminate, as: :terminate
-      get "/stream", ConversationController, :stream, as: :stream
       get "/turns", ConversationController, :turns, as: :turns
       get "/turns/:turn_id/images/:position", TurnImageController, :show, as: :turn_image
     end
+  end
+
+  # Server-sent events. Same auth chain as the rest of /api, minus content
+  # negotiation — see the `:api` pipeline. The action sets its own
+  # `text/event-stream` content-type and its error paths go through
+  # FallbackController's `json/2`, which does not consult the negotiated
+  # format, so there is nothing here for `:accepts` to decide.
+  scope "/api", FountainWeb do
+    pipe_through :api
+
+    get "/conversations/:conversation_id/stream", ConversationController, :stream,
+      as: :conversation_stream
   end
 
   ## ─── Authenticated browser / LiveView routes ──────────────────────────────────────────────────────────────────
@@ -192,7 +214,9 @@ defmodule FountainWeb.Router do
     get "/agents/:id/avatar", AgentAvatarController, :show
 
     # ── Turn image serving — session-authenticated so <img> tags can load without a bearer token ──────────
-    get "/conversations/:conversation_id/turns/:turn_id/images/:position", TurnImageController, :show
+    get "/conversations/:conversation_id/turns/:turn_id/images/:position",
+        TurnImageController,
+        :show
 
     # ── Phase-3-billing: conversation routes require an active subscription ─────────────────
     # :require_active_subscription runs after :require_authenticated_user and

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -620,6 +620,99 @@ defmodule FountainWeb.ConversationControllerTest do
     end
   end
 
+  # Every test above passed while the endpoint 406'd for every real client,
+  # because Phoenix.ConnTest sends no Accept header and `plug :accepts` then
+  # falls through to the default format. A real SSE client — the Go CLI, the
+  # browser's EventSource, curl -H — sends `Accept: text/event-stream`, which
+  # `plug :accepts, ["json"]` refuses before the action runs. So these tests
+  # send the header on purpose.
+  describe "GET /api/conversations/:conversation_id/stream — content negotiation" do
+    test "accepts the Accept header a real SSE client sends", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("accept", "text/event-stream")
+        |> get("/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["text/event-stream"]
+    end
+
+    test "still replays buffered events with that header set", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "hello"})
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("accept", "text/event-stream")
+        |> get("/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "event: output"
+      assert conn.resp_body =~ "hello"
+    end
+
+    test "an unknown conversation still renders a JSON 404", %{conn: conn, raw_key: raw_key} do
+      # The route negotiates no format at all now, so the fallback path has to
+      # keep working without one.
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("accept", "text/event-stream")
+        |> get("/api/conversations/#{Ecto.UUID.generate()}/stream")
+
+      assert json_response(conn, 404)
+    end
+
+    test "authentication is still enforced on the stream route", %{conn: conn, user: user} do
+      # The stream lives in its own scope now. It shares the `:api` pipeline
+      # rather than a copy of it, and this is what holds that true.
+      conv = insert_conversation(user_id: user.id)
+
+      conn =
+        conn
+        |> put_req_header("accept", "text/event-stream")
+        |> get("/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert json_response(conn, 401)
+    end
+
+    test "another tenant's conversation is still a 404", %{conn: conn, raw_key: raw_key} do
+      other = insert_conversation(user_id: insert_verified_user().id)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("accept", "text/event-stream")
+        |> get("/api/conversations/#{other.id}/stream?wait=false")
+
+      assert json_response(conn, 404)
+    end
+
+    test "JSON endpoints still refuse text/event-stream", %{conn: conn, raw_key: raw_key} do
+      # The fix is scoped to the stream route: negotiation was not loosened
+      # across /api, so asking a JSON endpoint for an event stream is still a
+      # 406 rather than a 500 from a missing template.
+      assert_raise Phoenix.NotAcceptableError, fn ->
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("accept", "text/event-stream")
+        |> get("/api/conversations")
+      end
+    end
+  end
+
   describe "GET /api/conversations/:conversation_id/stream with log events (replay path)" do
     test "replays existing log events when wait=false and conversation has events", %{
       conn: conn,


### PR DESCRIPTION
Closes #201.

## What was wrong

The `:api` pipeline runs `plug :accepts, ["json"]`. Every SSE client sends `Accept: text/event-stream`. Phoenix refuses that with 406 before the action runs, so every streaming command failed:

```
fountain: stream HTTP 406: {"errors":{"detail":"Not Acceptable"}}
```

Turns still executed — there was just no way to read what an agent said, since the stream is the only surface carrying turn output.

## It is not a recent regression

`plug :accepts, ["json"]` and the `/stream` route have both been present since the first Phoenix commit. The pre-port Elixir CLI sent only an `Authorization` header and no `Accept`, so negotiation fell through to the default format and streaming worked. The Go port (`03ed28b`, 2026-05-10) added `Accept: text/event-stream` in `NewStreamRequest`, and the endpoint has been unreachable since. Roughly twelve weeks.

## The fix

Content negotiation moves out of the `:api` pipeline into a separate `:accepts_json` pipeline that every authenticated route pipes through — except the stream, which gets its own scope.

Splitting it this way rather than copying the plug list into a second pipeline is deliberate: the auth chain (`TenantAPIAuth`, `RateLimit`, `Audit`) stays defined exactly once. A duplicated chain would be one forgotten line away from an unauthenticated endpoint, which is a much worse failure than the one being fixed.

The stream action sets its own `text/event-stream` content-type, and its error paths render through `FallbackController`'s `json/2`, which does not consult the negotiated format. So there is genuinely nothing for `:accepts` to decide on that route.

Negotiation is **not** loosened anywhere else — asking a JSON endpoint for an event stream is still a 406, not a 500 from a missing `.sse` template. There's a test pinning that.

The route path is unchanged, so the OpenAPI spec (derived from the router via `Paths.from_router`) is unchanged.

## Why nine passing tests didn't catch it

The endpoint has had test coverage this whole time. Those tests pass because `Phoenix.ConnTest` sends no `Accept` header, so `plug :accepts` falls through to the default format — they exercised a request no real client makes.

The new tests set the header on purpose, and also cover the fallback 404, the cross-tenant 404, and that auth still applies to the relocated route. Five of the six fail without the router change; the sixth is the guard against loosening negotiation, so it passes both before and after by design.

This is the concrete case #193 was about.

## End-to-end verification

Against a dev server over real HTTP, not `ConnTest`:

- `curl -H 'Accept: text/event-stream' .../stream?wait=false` → `200`, replays buffered events
- the same header on `/api/conversations` → `406` (unchanged)
- a freshly built `fountain conv stream <id>` connects and reports conversation state — no 406

Full suite: 1331 tests, 0 failures.

## Not addressed here

#201 also notes that `/turns` carries no response text and that `/messages`, `/events` and `/turns/:id/output` 404. Those endpoints don't exist — the stream is the intended read surface, and with `?wait=false` it replays the full history from `log_events`. Inventing new endpoints is out of scope for this fix. #196 (stream dies silently on quiet turns) is a separate defect on the same path and is already fixed on the CLI side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)