### PR TITLE
ops: reap leaked sprites and release sandbox rows stuck mid-provision

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -861,8 +861,12 @@ defmodule Fountain.Conversations.ConversationServer do
   # Best-effort revoke of the per-conversation API key when this server
   # exits — covers both clean termination (`:terminate_conv`) and crash
   # paths that hit `{:stop, :normal, state}` after a provision failure.
-  # If the BEAM crashes hard, the row in `api_keys` is orphaned and lives
-  # until an admin/janitor sweeps it; that's a known gap, not a regression.
+  # If the BEAM crashes hard the row in `api_keys` is left behind, but it is no
+  # longer dangerous: `callback_api_key_opts/0` sets an `expires_at`, so an
+  # un-revoked key stops authenticating on its own, and RetentionPruner deletes
+  # the row later. It used to live forever, which is what made a sweeper
+  # necessary — see SandboxReaper for the sprite half, which does not
+  # self-heal.
   @impl true
   def terminate(_reason, state) do
     Fountain.Conversations.Redaction.delete(state.conversation_id)

--- a/apps/fountain/lib/fountain/sprites_client.ex
+++ b/apps/fountain/lib/fountain/sprites_client.ex
@@ -4,6 +4,12 @@ defmodule Fountain.SpritesClient do
   application env (set in runtime.exs).
   """
 
+  require Logger
+
+  # The list endpoint returns 50 per page. A reconciliation that stops at the
+  # first page is worse than no reconciliation, because it looks complete.
+  @max_pages 40
+
   @doc "Returns a Sprites client, or raises if SPRITES_TOKEN is not set."
   def get! do
     token =
@@ -12,5 +18,51 @@ defmodule Fountain.SpritesClient do
 
     base_url = Application.get_env(:fountain, :sprites_base_url, "https://api.sprites.dev")
     Sprites.new(token, base_url: base_url)
+  end
+
+  @doc """
+  Every sprite name on the account, as a MapSet.
+
+  `Sprites.list/2` cannot be used for this. It pattern-matches the `"sprites"`
+  key out of the response and discards `has_more` and
+  `next_continuation_token`, so it returns the first page and gives no
+  indication there is more — against production that was 50 names out of 114.
+  Anything comparing that list to the database would silently treat two thirds
+  of the account as non-existent.
+
+  Returns `{:error, :truncated}` rather than a short list if the account somehow
+  exceeds `#{@max_pages}` pages, because a caller deciding what to delete must
+  never be handed a partial view that looks whole.
+  """
+  @spec list_all_sprite_names() :: {:ok, MapSet.t(String.t())} | {:error, term()}
+  def list_all_sprite_names do
+    collect(get!(), nil, MapSet.new(), 0)
+  end
+
+  defp collect(_client, _token, _acc, page) when page >= @max_pages do
+    Logger.error("sprites: list exceeded #{@max_pages} pages — refusing to return a partial view")
+    {:error, :truncated}
+  end
+
+  defp collect(client, token, acc, page) do
+    params = if token, do: [continuation_token: token], else: []
+
+    case Req.get(client.req, url: "/v1/sprites", params: params) do
+      {:ok, %{status: status, body: %{"sprites" => sprites} = body}} when status in 200..299 ->
+        acc = Enum.reduce(sprites, acc, fn s, set -> MapSet.put(set, s["name"]) end)
+        next = body["next_continuation_token"]
+
+        if body["has_more"] && is_binary(next) && next != "" do
+          collect(client, next, acc, page + 1)
+        else
+          {:ok, acc}
+        end
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {:api_error, status, body}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 end

--- a/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
@@ -1,0 +1,203 @@
+defmodule Fountain.Workers.SandboxReaper do
+  @moduledoc """
+  Reconciles the `sandboxes` table against what actually exists at sprites.dev.
+
+  ## What leaks, and how
+
+  Both destroy call sites in `ConversationServer` discard the result —
+  `_ = Sprites.destroy(sprite)` — and then mark the row `terminated` or
+  `failed` regardless. So any destroy that fails for a transient reason leaves a
+  sprite alive with a database row that says it is gone, and nothing ever looks
+  again. This does not need a hard BEAM crash; the ordinary path is enough.
+
+  Measured against production when this was written: 114 sprites existed at
+  sprites.dev, 7 of them with a terminal sandbox row. The rest of the drift is
+  historical (102 sprites with no row at all, from the pre-rename `aod-*` era)
+  and 443 rows whose sprite is already gone.
+
+  The other half is quota. `Fountain.Quotas` counts `pending`, `starting` and
+  `ready` toward a tenant's concurrent-sandbox cap, deliberately — a sprite
+  bills from the moment provisioning starts. A row stuck in `pending` because
+  the BEAM died mid-provision therefore consumes cap forever, and a
+  default-limit tenant with a few of those cannot start a conversation at all,
+  with no self-serve way out.
+
+  ## Three passes, in descending order of confidence
+
+  1. **Release stuck rows.** `pending`/`starting` past the grace period with no
+     live `ConversationServer` become `failed`. This frees quota and is safe:
+     the row already cannot be used for anything.
+
+  2. **Destroy sprites we know are dead.** A sandbox row in a terminal state
+     whose sprite still exists at sprites.dev. Unambiguously ours,
+     unambiguously finished.
+
+  3. **Count sprites we do not recognise, and touch nothing.** Reported as a
+     log line and a telemetry measurement.
+
+  Pass 3 is deliberately inert. A sprite with no row is not proof of a leak: the
+  same `SPRITES_TOKEN` may be in a developer's shell or a staging instance, and
+  a sprite created seconds ago may simply not have committed its row yet.
+  Production currently holds a `jake-*` sprite that is exactly this case.
+  Destroying by absence-of-evidence would eventually delete someone's live work,
+  and unlike a missed sprite that mistake cannot be undone. Cleaning up the
+  legacy `aod-*` sprites is a one-off an operator can do by hand, having looked
+  at the list.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{ConversationServer, Sandbox}
+  alias Fountain.Repo
+
+  # Long enough to clear the slowest legitimate provision: package installs get
+  # 300s per command and a clone gets 600s, and several can run in sequence.
+  # Being late to release a stuck row costs a little quota; being early kills a
+  # sandbox that was still starting.
+  @stuck_after_minutes 60
+
+  # A cap per run, so a large backlog drains over several hours instead of
+  # firing hundreds of destroy calls at sprites.dev in one burst.
+  @destroy_limit 25
+
+  @terminal_statuses ~w(terminated failed)
+  @active_statuses ~w(pending starting)
+
+  @impl Oban.Worker
+  def perform(_job) do
+    released = release_stuck_sandboxes()
+
+    result =
+      case list_sprites() do
+        {:ok, live_names} ->
+          destroyed = destroy_dead_sprites(live_names)
+          untracked = report_untracked(live_names)
+
+          Logger.info(
+            "reaper: released=#{released} destroyed=#{destroyed} " <>
+              "untracked=#{untracked} live=#{MapSet.size(live_names)}"
+          )
+
+          :ok
+
+        {:error, reason} ->
+          # The stuck-row pass already ran and does not need sprites.dev, so its
+          # work stands. Returning an error lets Oban retry the rest.
+          Logger.warning("reaper: could not list sprites: #{inspect(reason)}")
+          {:error, reason}
+      end
+
+    :telemetry.execute([:fountain, :reaper, :run], %{released: released}, %{})
+
+    result
+  end
+
+  # ── pass 1: rows stuck mid-provision ──────────────────────────────────────
+
+  @doc false
+  def release_stuck_sandboxes do
+    cutoff = DateTime.utc_now() |> DateTime.add(-@stuck_after_minutes * 60, :second)
+
+    Sandbox
+    |> where([s], s.status in ^@active_statuses and s.updated_at < ^cutoff)
+    |> Repo.all()
+    |> Repo.preload(:conversations)
+    |> Enum.reject(&server_alive?/1)
+    |> Enum.map(fn sandbox ->
+      {:ok, _} =
+        Conversations.update_sandbox(sandbox, %{
+          status: "failed",
+          terminated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      Logger.info(
+        "reaper: released stuck sandbox #{sandbox.id} (#{sandbox.sprite_name}) " <>
+          "after #{@stuck_after_minutes}m in #{sandbox.status}"
+      )
+
+      sandbox
+    end)
+    |> length()
+  end
+
+  # A live ConversationServer means provisioning is still in flight somewhere in
+  # the cluster, however long it has taken. Horde's registry is cluster-wide, so
+  # this is not just a local check.
+  defp server_alive?(%Sandbox{conversations: conversations}) do
+    Enum.any?(conversations, fn conv -> ConversationServer.whereis(conv.id) != nil end)
+  end
+
+  # ── pass 2: terminal rows whose sprite is still there ─────────────────────
+
+  defp destroy_dead_sprites(live_names) do
+    client = Fountain.SpritesClient.get!()
+
+    Sandbox
+    |> where([s], s.status in ^@terminal_statuses)
+    |> select([s], {s.id, s.sprite_name})
+    |> Repo.all()
+    |> Enum.filter(fn {_id, name} -> MapSet.member?(live_names, name) end)
+    |> Enum.take(@destroy_limit)
+    |> Enum.count(fn {id, name} -> destroy(client, id, name) end)
+  end
+
+  defp destroy(client, sandbox_id, sprite_name) do
+    # `Sprites.sprite/2` builds the handle; `get_sprite/2` only returns a map
+    # and cannot be passed to destroy. We already know it exists — it came out
+    # of the listing — so there is nothing to look up first.
+    case Sprites.destroy(Sprites.sprite(client, sprite_name)) do
+      :ok ->
+        Logger.info("reaper: destroyed leaked sprite #{sprite_name} (sandbox #{sandbox_id})")
+        true
+
+      {:error, reason} ->
+        # Left for the next run rather than retried here; the row stays terminal
+        # either way, so nothing is lost by being slow about it.
+        Logger.warning("reaper: destroy failed for #{sprite_name}: #{inspect(reason)}")
+        false
+    end
+  end
+
+  # ── pass 3: sprites with no row — counted, never touched ──────────────────
+
+  @doc false
+  def report_untracked(live_names) do
+    known =
+      Sandbox
+      |> select([s], s.sprite_name)
+      |> Repo.all()
+      |> MapSet.new()
+
+    untracked = MapSet.difference(live_names, known)
+    count = MapSet.size(untracked)
+
+    if count > 0 do
+      sample = untracked |> Enum.sort() |> Enum.take(10) |> Enum.join(", ")
+
+      Logger.info(
+        "reaper: #{count} sprite(s) at sprites.dev have no sandbox row and were " <>
+          "left alone (sample: #{sample})"
+      )
+    end
+
+    :telemetry.execute([:fountain, :reaper, :untracked], %{count: count}, %{})
+    count
+  end
+
+  # ── sprites.dev ───────────────────────────────────────────────────────────
+
+  # Paginated deliberately — see Fountain.SpritesClient.list_all_sprite_names/0.
+  # A single `Sprites.list/2` call returns the first 50 and looks complete,
+  # which for a function that decides what to delete is the worst possible
+  # shape of wrong.
+  defp list_sprites do
+    Fountain.SpritesClient.list_all_sprite_names()
+  rescue
+    e -> {:error, e}
+  end
+end

--- a/apps/fountain/priv/help/runbook.md
+++ b/apps/fountain/priv/help/runbook.md
@@ -67,24 +67,45 @@ If `interrupt` returns `no_turn_running`, the GenServer thinks no turn is in fli
 
 ## Orphaned sprites
 
-Symptoms: sprites.dev billing shows sprites we don't recognize. Fountain's `sandboxes` table doesn't have a row for them.
+`Fountain.Workers.SandboxReaper` runs hourly and handles this. Each run:
 
-This shouldn't happen after a clean stop — `Fountain.Conversations.Rehydrator` reattaches on boot. It can happen after a hard kill (BEAM crash) on a sandbox that hadn't reached `ready` yet (those don't get rehydrated):
+1. marks `pending`/`starting` sandboxes older than 60 minutes as `failed` when no `ConversationServer` is alive for them — this is what frees a tenant's concurrent-sandbox quota after a crash mid-provision;
+2. destroys sprites whose sandbox row is already `terminated` or `failed`, up to 25 per run;
+3. counts sprites with no sandbox row at all, and **touches none of them**.
+
+Step 3 is deliberate. The same `SPRITES_TOKEN` may be in a developer's shell or another instance, and a sprite created seconds ago may not have committed its row yet — absence of a row is not evidence of a leak, and that is the one mistake here that cannot be undone.
+
+Check what it is seeing:
 
 ```bash
-# List all sprites in your account
-curl -sS https://api.sprites.dev/v1/sprites \
-  -H "Authorization: Bearer $SPRITES_TOKEN" | jq -r '.[].name'
-
-# Cross-reference with your Fountain sandbox table (run on Render via the
-# Postgres dashboard, or psql against DATABASE_URL)
-psql "$DATABASE_URL" -c \
-  "SELECT sprite_name FROM sandboxes WHERE status NOT IN ('terminated','failed')"
-
-# Anything in the first list not in the second is an orphan. Destroy:
-curl -sS -X DELETE https://api.sprites.dev/v1/sprites/<name> \
-  -H "Authorization: Bearer $SPRITES_TOKEN"
+kubectl logs -n fountain -l app=fountain --since=2h | grep 'reaper:'
+# reaper: released=0 destroyed=2 untracked=102 live=114
 ```
+
+A steady non-zero `destroyed` means sprite deletion is failing on the normal path — both `Sprites.destroy` call sites in `ConversationServer` discard their result, so the reaper is the only thing that notices.
+
+### Cleaning up untracked sprites by hand
+
+The reaper will never do this. Look at the list before deleting anything.
+
+```bash
+TOKEN=$(kubectl get secret fountain-secrets -n fountain \
+  -o jsonpath='{.data.SPRITES_TOKEN}' | base64 -d)
+
+# The response is an object, not an array, and it pages at 50 with
+# has_more/next_continuation_token — a single unpaginated call sees a fraction
+# of the account.
+curl -sS https://api.sprites.dev/v1/sprites \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.sprites[].name'
+
+kubectl exec -n fountain fountain-pg-1 -- \
+  psql -U postgres -d fountain -At -c "SELECT sprite_name FROM sandboxes"
+
+curl -sS -X DELETE https://api.sprites.dev/v1/sprites/<name> \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+As of 2026-08-01 the untracked set is 102 sprites named `aod-*`, all `cold`, created before the rename to `fountain-*`. They are safe to remove; nothing in the current schema references them.
 
 ## Rate limit overflow
 

--- a/apps/fountain/test/fountain/sprites_client_test.exs
+++ b/apps/fountain/test/fountain/sprites_client_test.exs
@@ -1,0 +1,102 @@
+defmodule Fountain.SpritesClientTest do
+  @moduledoc """
+  Listing every sprite on the account.
+
+  `Sprites.list/2` pattern-matches the `"sprites"` key out of the response and
+  drops `has_more` and `next_continuation_token`, so it returns the first page
+  of 50 and gives the caller no way to tell there is more. Against production
+  that is 50 names out of 114. Anything that compares that list to the database
+  to decide what has leaked would conclude that two thirds of the account does
+  not exist — so these tests are mostly about pagination being real.
+  """
+
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Fountain.SpritesClient
+
+  setup :set_mimic_global
+
+  setup do
+    previous = Application.get_env(:fountain, :sprites_token)
+    Application.put_env(:fountain, :sprites_token, "test-token")
+    on_exit(fn -> Application.put_env(:fountain, :sprites_token, previous) end)
+    :ok
+  end
+
+  defp page(names, next \\ nil) do
+    %{
+      "sprites" => Enum.map(names, &%{"name" => &1}),
+      "has_more" => next != nil,
+      "next_continuation_token" => next
+    }
+  end
+
+  defp stub_pages(pages) do
+    # Keyed by the continuation token the request carries, so the test asserts
+    # the token is actually threaded through rather than just counting calls.
+    stub(Req, :get, fn _req, opts ->
+      token = opts |> Keyword.get(:params, []) |> Keyword.get(:continuation_token)
+      {:ok, %{status: 200, body: Map.fetch!(pages, token)}}
+    end)
+  end
+
+  test "a single page returns every name" do
+    stub_pages(%{nil => page(~w(a b c))})
+
+    assert {:ok, names} = SpritesClient.list_all_sprite_names()
+    assert names == MapSet.new(~w(a b c))
+  end
+
+  test "follows the continuation token across pages" do
+    # The regression this file exists for.
+    stub_pages(%{
+      nil => page(~w(a b), "tok-1"),
+      "tok-1" => page(~w(c d), "tok-2"),
+      "tok-2" => page(~w(e))
+    })
+
+    assert {:ok, names} = SpritesClient.list_all_sprite_names()
+    assert names == MapSet.new(~w(a b c d e))
+  end
+
+  test "stops when has_more is true but no token comes back" do
+    # Rather than looping forever on a server that contradicts itself.
+    stub_pages(%{nil => %{"sprites" => [%{"name" => "a"}], "has_more" => true}})
+
+    assert {:ok, names} = SpritesClient.list_all_sprite_names()
+    assert names == MapSet.new(["a"])
+  end
+
+  test "refuses to return a partial view rather than a short list" do
+    # A caller deciding what to delete must never be handed a truncated set that
+    # looks complete — every unlisted sprite would look already destroyed.
+    stub(Req, :get, fn _req, opts ->
+      token = opts |> Keyword.get(:params, []) |> Keyword.get(:continuation_token)
+      next = "tok-#{token}"
+      {:ok, %{status: 200, body: page(["sprite-#{token}"], next)}}
+    end)
+
+    assert {:error, :truncated} = SpritesClient.list_all_sprite_names()
+  end
+
+  test "surfaces an API error" do
+    stub(Req, :get, fn _req, _opts -> {:ok, %{status: 500, body: "boom"}} end)
+
+    assert {:error, {:api_error, 500, "boom"}} = SpritesClient.list_all_sprite_names()
+  end
+
+  test "surfaces a transport error" do
+    stub(Req, :get, fn _req, _opts -> {:error, :nxdomain} end)
+
+    assert {:error, :nxdomain} = SpritesClient.list_all_sprite_names()
+  end
+
+  test "raises when no token is configured" do
+    Application.put_env(:fountain, :sprites_token, nil)
+
+    assert_raise RuntimeError, ~r/SPRITES_TOKEN is not set/, fn ->
+      SpritesClient.list_all_sprite_names()
+    end
+  end
+end

--- a/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
+++ b/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
@@ -1,0 +1,244 @@
+defmodule Fountain.Workers.SandboxReaperTest do
+  @moduledoc """
+  Reconciliation between the `sandboxes` table and sprites.dev.
+
+  The risk here is asymmetric and points in one direction: failing to reap a
+  sprite costs money and quota, while reaping the wrong one destroys someone's
+  running work and cannot be undone. So most of these tests are about what the
+  reaper refuses to touch.
+  """
+
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  import ExUnit.CaptureLog
+
+  alias Fountain.Conversations.Sandbox
+  alias Fountain.Repo
+  alias Fountain.Workers.SandboxReaper
+
+  setup :set_mimic_global
+
+  defp minutes_ago(n),
+    do: DateTime.utc_now() |> DateTime.add(-n * 60, :second) |> DateTime.truncate(:second)
+
+  # updated_at is managed by Ecto, so age has to be forced with a raw update.
+  defp age_sandbox(sandbox, minutes) do
+    ts = minutes_ago(minutes)
+    Repo.update_all(from(s in Sandbox, where: s.id == ^sandbox.id), set: [updated_at: ts])
+    %{sandbox | updated_at: ts}
+  end
+
+  defp stub_sprites(names) do
+    stub(Fountain.SpritesClient, :list_all_sprite_names, fn -> {:ok, MapSet.new(names)} end)
+    stub(Fountain.SpritesClient, :get!, fn -> :client end)
+  end
+
+  defp capture_destroys do
+    test = self()
+
+    stub(Sprites, :sprite, fn :client, name -> {:handle, name} end)
+
+    stub(Sprites, :destroy, fn {:handle, name} ->
+      send(test, {:destroyed, name})
+      :ok
+    end)
+  end
+
+  defp destroyed_names do
+    receive do
+      {:destroyed, name} -> [name | destroyed_names()]
+    after
+      0 -> []
+    end
+  end
+
+  describe "stuck sandboxes" do
+    test "a row stuck in pending past the grace period is released" do
+      # This is the quota half: Quotas counts pending/starting toward the
+      # concurrent cap, so a row left behind by a BEAM that died mid-provision
+      # consumes a tenant's allowance forever, with no self-serve way out.
+      sandbox = insert_sandbox(status: "pending") |> age_sandbox(120)
+
+      capture_log(fn -> assert 1 = SandboxReaper.release_stuck_sandboxes() end)
+
+      assert %{status: "failed", terminated_at: %DateTime{}} = Repo.reload(sandbox)
+    end
+
+    test "starting is released too" do
+      sandbox = insert_sandbox(status: "starting") |> age_sandbox(120)
+
+      capture_log(fn -> assert 1 = SandboxReaper.release_stuck_sandboxes() end)
+
+      assert Repo.reload(sandbox).status == "failed"
+    end
+
+    test "a recent row is left alone" do
+      # A slow provision is not a stuck one. Package installs get 300s per
+      # command and a clone gets 600s, and they run in sequence.
+      sandbox = insert_sandbox(status: "pending") |> age_sandbox(5)
+
+      assert 0 = SandboxReaper.release_stuck_sandboxes()
+      assert Repo.reload(sandbox).status == "pending"
+    end
+
+    test "a ready sandbox is never released, however old" do
+      # An idle sandbox is a lifetime question (#167), not a stuck one. Marking
+      # it failed here would kill live conversations.
+      sandbox = insert_sandbox(status: "ready") |> age_sandbox(60 * 24 * 90)
+
+      assert 0 = SandboxReaper.release_stuck_sandboxes()
+      assert Repo.reload(sandbox).status == "ready"
+    end
+
+    test "a row with a live ConversationServer is left alone" do
+      # Whatever the clock says, a running server means provisioning is still
+      # in flight somewhere in the cluster.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "pending") |> age_sandbox(600)
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox)
+
+      stub(Fountain.Conversations.ConversationServer, :whereis, fn id ->
+        if id == conv.id, do: self(), else: nil
+      end)
+
+      assert 0 = SandboxReaper.release_stuck_sandboxes()
+      assert Repo.reload(sandbox).status == "pending"
+    end
+  end
+
+  describe "leaked sprites" do
+    test "destroys a sprite whose sandbox row is terminal" do
+      # The ordinary leak: both destroy call sites in ConversationServer discard
+      # the result and mark the row terminal regardless, so a transient failure
+      # at sprites.dev strands the sprite permanently.
+      sandbox = insert_sandbox(status: "terminated")
+      stub_sprites([sandbox.sprite_name])
+      capture_destroys()
+
+      capture_log(fn -> assert :ok = perform_job(SandboxReaper, %{}) end)
+
+      assert destroyed_names() == [sandbox.sprite_name]
+    end
+
+    test "destroys for failed sandboxes as well as terminated" do
+      sandbox = insert_sandbox(status: "failed")
+      stub_sprites([sandbox.sprite_name])
+      capture_destroys()
+
+      capture_log(fn -> assert :ok = perform_job(SandboxReaper, %{}) end)
+
+      assert destroyed_names() == [sandbox.sprite_name]
+    end
+
+    test "never destroys a sprite whose sandbox is still live" do
+      ready = insert_sandbox(status: "ready")
+      pending = insert_sandbox(status: "pending")
+      stub_sprites([ready.sprite_name, pending.sprite_name])
+      capture_destroys()
+
+      capture_log(fn -> assert :ok = perform_job(SandboxReaper, %{}) end)
+
+      assert destroyed_names() == []
+    end
+
+    test "never destroys a sprite with no sandbox row" do
+      # The rule that keeps this safe. The same SPRITES_TOKEN can be in a
+      # developer's shell or a staging instance, and a sprite created seconds
+      # ago may not have committed its row yet — production holds a `jake-*`
+      # sprite that is exactly this case. Absence of a row is not evidence of a
+      # leak, and this mistake is the one that cannot be undone.
+      stub_sprites(["someone-elses-sprite", "aod-conv-legacy"])
+      capture_destroys()
+
+      capture_log(fn -> assert :ok = perform_job(SandboxReaper, %{}) end)
+
+      assert destroyed_names() == []
+    end
+
+    test "untracked sprites are counted so the drift is visible" do
+      # Inert is not the same as ignored — an operator still has to be able to
+      # see that 102 sprites have no row, which is what production looked like.
+      insert_sandbox(status: "ready", sprite_name: "known-1")
+
+      test = self()
+
+      :telemetry.attach(
+        "reaper-untracked-#{System.unique_integer([:positive])}",
+        [:fountain, :reaper, :untracked],
+        fn _e, measurements, _meta, _cfg -> send(test, {:untracked, measurements.count}) end,
+        nil
+      )
+
+      capture_log(fn ->
+        assert 2 =
+                 SandboxReaper.report_untracked(
+                   MapSet.new(["known-1", "stranger-a", "stranger-b"])
+                 )
+      end)
+
+      assert_received {:untracked, 2}
+    end
+
+    test "a row whose sprite is already gone needs no work" do
+      insert_sandbox(status: "terminated")
+      stub_sprites([])
+      capture_destroys()
+
+      capture_log(fn -> assert :ok = perform_job(SandboxReaper, %{}) end)
+
+      assert destroyed_names() == []
+    end
+
+    test "one destroy failure does not stop the rest" do
+      doomed = insert_sandbox(status: "terminated")
+      other = insert_sandbox(status: "terminated")
+      stub_sprites([doomed.sprite_name, other.sprite_name])
+
+      test = self()
+      stub(Sprites, :sprite, fn :client, name -> {:handle, name} end)
+
+      stub(Sprites, :destroy, fn {:handle, name} ->
+        if name == doomed.sprite_name do
+          {:error, :boom}
+        else
+          send(test, {:destroyed, name})
+          :ok
+        end
+      end)
+
+      capture_log(fn -> assert :ok = perform_job(SandboxReaper, %{}) end)
+
+      assert destroyed_names() == [other.sprite_name]
+    end
+  end
+
+  describe "when sprites.dev is unreachable" do
+    test "stuck rows are still released and the job retries" do
+      # The quota fix needs no network, so it must not be held hostage to the
+      # API being up. Returning an error lets Oban retry the rest.
+      sandbox = insert_sandbox(status: "pending") |> age_sandbox(120)
+      stub(Fountain.SpritesClient, :list_all_sprite_names, fn -> {:error, :nxdomain} end)
+
+      capture_log(fn ->
+        assert {:error, :nxdomain} = perform_job(SandboxReaper, %{})
+      end)
+
+      assert Repo.reload(sandbox).status == "failed"
+    end
+
+    test "a truncated listing destroys nothing" do
+      # SpritesClient refuses to return a partial page set. Treating a partial
+      # view as complete would make every unlisted sprite look like it had
+      # already been destroyed.
+      sandbox = insert_sandbox(status: "terminated")
+      stub(Fountain.SpritesClient, :list_all_sprite_names, fn -> {:error, :truncated} end)
+      capture_destroys()
+
+      capture_log(fn -> assert {:error, :truncated} = perform_job(SandboxReaper, %{}) end)
+
+      assert destroyed_names() == []
+      assert Repo.reload(sandbox).status == "terminated"
+    end
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,12 @@ config :fountain, Oban,
      crontab: [
        # 04:23 UTC — after the 03:17 database backup, so pruning never races
        # the dump and a backup always captures the pre-prune state.
-       {"23 4 * * *", Fountain.Workers.RetentionPruner}
+       {"23 4 * * *", Fountain.Workers.RetentionPruner},
+       # Hourly: a leaked sprite costs money and a stuck sandbox row holds
+       # tenant quota, so the gap between the leak and its cleanup is what
+       # matters. Each run is one paginated list plus at most a handful of
+       # deletes.
+       {"7 * * * *", Fountain.Workers.SandboxReaper}
      ]}
   ]
 


### PR DESCRIPTION
Closes #166.

Adds `Fountain.Workers.SandboxReaper`, hourly on the maintenance queue.

## The leak is not the one the issue describes

#166 attributes orphaned sprites to a hard BEAM crash. That is one route, but the ordinary path is enough: both `Sprites.destroy` call sites in `ConversationServer` discard the result — `_ = Sprites.destroy(sprite)` — and then mark the row `terminated`/`failed` regardless. Any destroy that fails for a transient reason leaves a sprite alive with a row saying it is gone, and nothing ever looks again.

Measured against production while writing this:

| | count |
|---|---|
| sprites at sprites.dev | 114 (all `cold`, 0 running, 0 warm) |
| …with a terminal sandbox row — **the ongoing leak** | 7 |
| …with no sandbox row at all (pre-rename `aod-*`, Apr–May) | 102 |
| sandbox rows whose sprite is already gone | 443 |

## Three passes, in descending order of confidence

1. **Release stuck rows.** `pending`/`starting` past a 60-minute grace period with no live `ConversationServer` become `failed`.
2. **Destroy sprites we know are dead.** Terminal row + sprite still present. Capped at 25 per run so a backlog drains over hours instead of firing hundreds of deletes at sprites.dev at once.
3. **Count sprites with no row, and touch none of them.**

Pass 1 is the part that matters most to users, and it is the quota half rather than the cost half. `Fountain.Quotas` counts `pending`/`starting` toward the concurrent-sandbox cap deliberately — a sprite bills from the moment provisioning starts, so counting only `ready` would let a burst of starts slip past. That means a row stranded mid-provision consumes a tenant's allowance forever, and a default-limit tenant with a few of them cannot start a conversation at all, with no self-serve remedy. This is the escalation you flagged in the #166 comment after #205 landed.

Pass 3 is inert on purpose, and I want to be explicit about why, because "clean up sprites with no database row" is the obvious implementation and it is wrong. The same `SPRITES_TOKEN` may be in a developer's shell or another instance, and a sprite created seconds ago may not have committed its row yet — production currently holds a `jake-*` sprite that is exactly this case. Absence of a row is not evidence of a leak, and unlike a missed sprite, deleting someone's live work cannot be undone. The count is logged and emitted as telemetry so the drift stays visible, and the runbook now explains how to clear the legacy `aod-*` set by hand after looking at it.

## `Sprites.list/2` could not be used

It pattern-matches `"sprites"` out of the response and discards `has_more` and `next_continuation_token`, so it returns the first page of 50 and gives the caller no indication there is more. Against production that is 50 names out of 114 — a reaper built on it would have concluded that two thirds of the account does not exist, which for a function deciding what to delete is the worst available shape of wrong.

`SpritesClient.list_all_sprite_names/0` paginates properly, and returns `{:error, :truncated}` rather than a short list if it ever runs past the page ceiling. The reaper destroys nothing on that error.

## The API-key half is already closed

#166 also asks for a sweeper for orphaned conversation tokens. That no longer needs one: `callback_api_key_opts/0` sets an `expires_at`, so an un-revoked key stops authenticating on its own and `RetentionPruner` deletes the row later. Production agrees — 0 live conversation keys without an expiry, 0 whose conversation is already dead. The comment in `conversation_server.ex` still claiming an orphaned key "lives forever" is corrected rather than acted on.

## Runbook

The manual procedure there was wrong twice over: it `jq`'d `.[].name` against an object that has a `sprites` key, and it did not paginate. Replaced with what the reaper does, how to read its log line, and a correct manual procedure for the untracked residue.

## Tests

Weighted toward what the reaper refuses to touch, since that is the asymmetric risk: a `ready` sandbox however old, a row with a live server, a recent row mid-provision, a sprite with no row, and anything at all when the listing is truncated or the API is down. Stuck-row release is verified to still run when sprites.dev is unreachable, because the quota fix needs no network and must not be held hostage to the API being up.

The pagination test was checked against a non-paginating implementation: it fails, as does the truncation guard.

Full suite: 1362 tests, 0 failures. `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` clean.

## Note on deploying

This touches no Kubernetes manifest, so #231's ordering hazard does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)