### PR TITLE
ops: bound sandbox lifetime with an idle timeout and a maximum age

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -53,6 +53,12 @@ SPRITES_TOKEN=
 # service and is a lock with no key on your own instance.
 # BILLING_ENABLED=false
 
+# Sandbox lifetime bounds. A sandbox is reclaimed after this long without turn
+# activity, or on reaching the absolute ceiling. The conversation survives
+# either way and resumes on the next prompt. 0 disables a bound.
+# SANDBOX_IDLE_TIMEOUT_MINUTES=60
+# SANDBOX_MAX_LIFETIME_HOURS=24
+
 # Close registration once your own account exists.
 # REGISTRATION_ENABLED=false
 # REGISTRATION_ALLOWED_EMAIL_DOMAINS=example.com

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -25,7 +25,12 @@ defmodule Fountain.Conversations.ConversationServer do
     Vaults
   }
 
-  alias Fountain.Conversations.Conversation
+  alias Fountain.Conversations.{Conversation, Lifecycle}
+
+  # How often the sandbox lifetime bounds are evaluated. A minute is far finer
+  # than the bounds themselves (an hour, a day), so the cost of the tick is
+  # irrelevant and the overshoot is bounded by it.
+  @lifecycle_check_ms :timer.minutes(1)
 
   # ── public api ────────────────────────────────────────────────────────────
 
@@ -139,9 +144,16 @@ defmodule Fountain.Conversations.ConversationServer do
       # durable record; we keep the raw value in memory only while this
       # GenServer is alive. Rotated on every fresh provision/reattach;
       # revoked in terminate/2.
-      callback_token: nil
+      callback_token: nil,
+      # Sandbox lifetime bookkeeping. `started_at` is set once the sprite
+      # exists; `last_activity_at` moves on every turn start and end. See
+      # Fountain.Conversations.Lifecycle for what the bounds are and why
+      # reclaiming a sandbox does not end the conversation.
+      sandbox_started_at: nil,
+      last_activity_at: DateTime.utc_now()
     }
 
+    schedule_lifecycle_check()
     {:ok, state, {:continue, :provision}}
   end
 
@@ -311,7 +323,14 @@ defmodule Fountain.Conversations.ConversationServer do
           # doesn't block the user's first turn.
           maybe_create_checkpoint_async(sprite, env)
 
-          new_state = %{state | sprite: sprite, sprite_env: sprite_env}
+          # Dated from the sandbox row, not from now, so the absolute lifetime
+          # ceiling survives a restart and a reattach rather than resetting.
+          new_state = %{
+            state
+            | sprite: sprite,
+              sprite_env: sprite_env,
+              sandbox_started_at: sandbox.inserted_at
+          }
 
           case state.initial_prompt do
             nil -> {:noreply, new_state}
@@ -453,7 +472,13 @@ defmodule Fountain.Conversations.ConversationServer do
         # between the original provision and this reattach.
         Fountain.Conversations.Provisioning.write_env_file(sprite, sprite_env)
 
-        new_state = %{state | sprite: sprite, sprite_env: sprite_env}
+        new_state = %{
+          state
+          | sprite: sprite,
+            sprite_env: sprite_env,
+            sandbox_started_at: sandbox.inserted_at
+        }
+
         new_state = reattach_running_turn(new_state)
 
         case state.initial_prompt do
@@ -842,7 +867,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
     {:noreply,
      %{
-       state
+       touch_activity(state)
        | current_command: nil,
          current_command_ref: nil,
          current_turn: nil,
@@ -856,7 +881,76 @@ defmodule Fountain.Conversations.ConversationServer do
     {:noreply, state}
   end
 
+  # ── sandbox lifetime ──────────────────────────────────────────────────────
+
+  def handle_info(:lifecycle_check, state) do
+    schedule_lifecycle_check()
+
+    started_at = state.sandbox_started_at
+
+    cond do
+      # No sprite yet: provisioning is still in flight and there is nothing to
+      # reclaim. The reaper handles a provision that never finishes.
+      is_nil(started_at) ->
+        {:noreply, state}
+
+      true ->
+        case Lifecycle.check(started_at, state.last_activity_at, state.current_command != nil) do
+          {:expired, reason} -> reclaim_sandbox(state, reason)
+          :ok -> {:noreply, state}
+        end
+    end
+  end
+
   def handle_info(_msg, state), do: {:noreply, state}
+
+  defp schedule_lifecycle_check do
+    Process.send_after(self(), :lifecycle_check, @lifecycle_check_ms)
+  end
+
+  defp touch_activity(state), do: %{state | last_activity_at: DateTime.utc_now()}
+
+  # Tear down the sprite and stop, leaving the conversation `idle` so the next
+  # prompt wakes it with a fresh sandbox. Setting the conversation `terminated`
+  # here would make it permanently unresumable — a cost control turning into
+  # data loss. See Fountain.Conversations.Lifecycle.
+  defp reclaim_sandbox(state, reason) do
+    Logger.info(
+      "reclaiming sandbox for conv #{state.conversation_id}: #{reason} " <>
+        "(sprite #{inspect(state.sprite && state.sprite.name)})"
+    )
+
+    if state.sprite, do: _ = Sprites.destroy(state.sprite)
+
+    if state.sandbox_id do
+      sandbox = Conversations.get_sandbox!(state.sandbox_id)
+
+      if sandbox.status not in ["terminated", "failed"] do
+        {:ok, _} =
+          Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
+      end
+    end
+
+    # The conversation stays idle and resumable; only the sandbox is gone.
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
+
+    # `state` is a stage-lifecycle vocabulary — LogEvent allows only
+    # started/done/failed/interrupted, and both the CLI and the LiveView switch
+    # on it. A reclaimed sandbox is a stage that reached its end, so "done" is
+    # accurate and needs no client to learn a new word; the `reason` and
+    # `message` fields carry what actually happened. The new part clients key on
+    # is the "sandbox" stage itself.
+    publish_stage(state.conversation_id, "sandbox", "done", %{
+      event: "reclaimed",
+      reason: to_string(reason),
+      message: Lifecycle.explain(reason)
+    })
+
+    :telemetry.execute([:fountain, :sandbox, :reclaimed], %{count: 1}, %{reason: reason})
+
+    {:stop, :normal, %{state | sprite: nil}}
+  end
 
   # Best-effort revoke of the per-conversation API key when this server
   # exits — covers both clean termination (`:terminate_conv`) and crash
@@ -971,6 +1065,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp kick_turn(state, prompt, agent, images) do
+    state = touch_activity(state)
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     turn_number = Conversations.next_turn_number(state.conversation_id)
 

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -1,0 +1,122 @@
+defmodule Fountain.Conversations.Lifecycle do
+  @moduledoc """
+  How long a sandbox is allowed to exist.
+
+  Nothing bounded this before. A sandbox lived until something explicitly
+  terminated it, and `docs/primitives.md` told users "the sandbox exits when the
+  conversation terminates **or a timeout hits**" — describing a safeguard that
+  was never built. Production had a `ready` sandbox continuously alive since
+  2026-05-10, 83 days idle, billing and holding a slot against its owner's
+  concurrent-sandbox cap the whole time.
+
+  Two bounds, both off by setting the value to `nil` or `0`:
+
+  * **Idle timeout** — no turn activity for this long and the sandbox is
+    reclaimed. This is the one that recovers abandoned conversations, which is
+    the common case: someone starts a run, reads the answer, closes the tab.
+
+  * **Max lifetime** — an absolute ceiling from sandbox creation, regardless of
+    activity. Catches the case an idle timeout cannot: a conversation that keeps
+    itself busy forever.
+
+  ## Why reclaiming is safe
+
+  Only the *sandbox* is torn down. The conversation row stays `idle`, which
+  keeps it resumable — `assert_resumable/1` only refuses `terminated`, `failed`
+  and `completed`. The next prompt goes through `wake_conversation/2`, which
+  sees a sandbox that is no longer `ready`, provisions a fresh one, and passes
+  the persisted `runtime_session_id` so the runtime resumes the same chat.
+
+  So the cost of reclaiming early is a re-provision on the next prompt, not lost
+  work. That asymmetry is why the defaults can be fairly aggressive: being wrong
+  in the reclaiming direction is recoverable and being wrong in the other
+  direction bills indefinitely.
+
+  Setting the conversation itself to `terminated` here would *not* be safe — it
+  would make the conversation permanently unresumable, turning a cost control
+  into data loss.
+  """
+
+  @default_idle_minutes 60
+  @default_max_lifetime_hours 24
+
+  @doc "Idle timeout in seconds, or `nil` when disabled."
+  @spec idle_timeout_seconds() :: pos_integer() | nil
+  def idle_timeout_seconds do
+    to_seconds(
+      Application.get_env(:fountain, :sandbox_idle_timeout_minutes, @default_idle_minutes),
+      60
+    )
+  end
+
+  @doc "Absolute sandbox lifetime in seconds, or `nil` when disabled."
+  @spec max_lifetime_seconds() :: pos_integer() | nil
+  def max_lifetime_seconds do
+    to_seconds(
+      Application.get_env(:fountain, :sandbox_max_lifetime_hours, @default_max_lifetime_hours),
+      3600
+    )
+  end
+
+  defp to_seconds(nil, _unit), do: nil
+  defp to_seconds(0, _unit), do: nil
+  defp to_seconds(n, unit) when is_integer(n) and n > 0, do: n * unit
+
+  defp to_seconds(n, unit) when is_binary(n) do
+    case Integer.parse(n) do
+      {i, _} -> to_seconds(i, unit)
+      :error -> nil
+    end
+  end
+
+  defp to_seconds(_, _), do: nil
+
+  @doc """
+  Which bound, if any, a sandbox has crossed.
+
+  Returns `{:expired, :idle | :max_lifetime}` or `:ok`. `busy?` suppresses only
+  the idle verdict: a turn in flight is activity by definition, while the
+  absolute ceiling exists precisely for the conversation that never stops being
+  busy.
+  """
+  @spec check(DateTime.t(), DateTime.t(), boolean(), DateTime.t()) ::
+          {:expired, :idle | :max_lifetime} | :ok
+  def check(started_at, last_activity_at, busy?, now \\ DateTime.utc_now()) do
+    max_lifetime = max_lifetime_seconds()
+    idle = idle_timeout_seconds()
+
+    cond do
+      max_lifetime && DateTime.diff(now, started_at) >= max_lifetime ->
+        {:expired, :max_lifetime}
+
+      not busy? && idle && DateTime.diff(now, last_activity_at) >= idle ->
+        {:expired, :idle}
+
+      true ->
+        :ok
+    end
+  end
+
+  @doc """
+  Human-readable reason, for the stage event a client sees on the stream.
+
+  Worth spending words on: from the user's side the sandbox simply went away,
+  and "your sandbox was idle for 60 minutes and was reclaimed; send another
+  prompt to continue" is the difference between a bug report and a shrug.
+  """
+  @spec explain(:idle | :max_lifetime) :: String.t()
+  def explain(:idle) do
+    "Sandbox reclaimed after #{minutes(idle_timeout_seconds())} minutes idle. " <>
+      "Send another prompt to continue the conversation — history is preserved."
+  end
+
+  def explain(:max_lifetime) do
+    "Sandbox reclaimed after reaching the #{hours(max_lifetime_seconds())} hour maximum " <>
+      "lifetime. Send another prompt to continue the conversation — history is preserved."
+  end
+
+  defp minutes(nil), do: "?"
+  defp minutes(seconds), do: div(seconds, 60)
+  defp hours(nil), do: "?"
+  defp hours(seconds), do: div(seconds, 3600)
+end

--- a/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
@@ -52,7 +52,7 @@ defmodule Fountain.Workers.SandboxReaper do
   require Logger
 
   alias Fountain.Conversations
-  alias Fountain.Conversations.{ConversationServer, Sandbox}
+  alias Fountain.Conversations.{ConversationServer, Lifecycle, Sandbox, Turn}
   alias Fountain.Repo
 
   # Long enough to clear the slowest legitimate provision: package installs get
@@ -71,6 +71,7 @@ defmodule Fountain.Workers.SandboxReaper do
   @impl Oban.Worker
   def perform(_job) do
     released = release_stuck_sandboxes()
+    expired = expire_abandoned_sandboxes()
 
     result =
       case list_sprites() do
@@ -79,7 +80,7 @@ defmodule Fountain.Workers.SandboxReaper do
           untracked = report_untracked(live_names)
 
           Logger.info(
-            "reaper: released=#{released} destroyed=#{destroyed} " <>
+            "reaper: released=#{released} expired=#{expired} destroyed=#{destroyed} " <>
               "untracked=#{untracked} live=#{MapSet.size(live_names)}"
           )
 
@@ -92,7 +93,7 @@ defmodule Fountain.Workers.SandboxReaper do
           {:error, reason}
       end
 
-    :telemetry.execute([:fountain, :reaper, :run], %{released: released}, %{})
+    :telemetry.execute([:fountain, :reaper, :run], %{released: released, expired: expired}, %{})
 
     result
   end
@@ -130,6 +131,85 @@ defmodule Fountain.Workers.SandboxReaper do
   # this is not just a local check.
   defp server_alive?(%Sandbox{conversations: conversations}) do
     Enum.any?(conversations, fn conv -> ConversationServer.whereis(conv.id) != nil end)
+  end
+
+  # ── pass 1b: ready sandboxes nobody is holding ────────────────────────────
+
+  @doc """
+  Marks `ready` sandboxes past their lifetime bound as terminated.
+
+  This is the half of #167 that the ConversationServer cannot do. The server
+  enforces its own idle timeout while it is alive, but a sandbox whose server
+  died — a crash, a node that left the cluster, a deploy that happened to land
+  between the rehydrator's scan and a reattach — has nothing watching it. The
+  83-day-old sandbox in production was exactly that: `ready`, no server, alive
+  since 2026-05-10.
+
+  Activity is read from the conversation's most recent turn rather than from
+  `sandboxes.updated_at` or `conversations.updated_at`, both of which get
+  touched by bookkeeping the user had nothing to do with — the rehydrator moves
+  `conversations.updated_at` on every boot, which would make an abandoned
+  conversation look freshly active after each deploy.
+  """
+  def expire_abandoned_sandboxes do
+    idle = Lifecycle.idle_timeout_seconds()
+    max_lifetime = Lifecycle.max_lifetime_seconds()
+
+    if is_nil(idle) and is_nil(max_lifetime) do
+      0
+    else
+      now = DateTime.utc_now()
+
+      Sandbox
+      |> where([s], s.status == "ready")
+      |> Repo.all()
+      |> Repo.preload(:conversations)
+      |> Enum.reject(&server_alive?/1)
+      |> Enum.filter(&expired?(&1, now))
+      |> Enum.map(&expire/1)
+      |> length()
+    end
+  end
+
+  defp expired?(sandbox, now) do
+    Lifecycle.check(sandbox.inserted_at, last_activity_at(sandbox), false, now) != :ok
+  end
+
+  # Newest turn across the sandbox's conversations, falling back to when the
+  # sandbox itself was created for one that never took a turn.
+  defp last_activity_at(%Sandbox{inserted_at: inserted_at, conversations: convs}) do
+    conv_ids = Enum.map(convs, & &1.id)
+
+    latest =
+      if conv_ids == [] do
+        nil
+      else
+        Turn
+        |> where([t], t.conversation_id in ^conv_ids)
+        |> select([t], max(t.inserted_at))
+        |> Repo.one()
+      end
+
+    latest || inserted_at
+  end
+
+  defp expire(sandbox) do
+    {:ok, _} =
+      Conversations.update_sandbox(sandbox, %{
+        status: "terminated",
+        terminated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    Logger.info(
+      "reaper: expired abandoned sandbox #{sandbox.id} (#{sandbox.sprite_name}) — " <>
+        "ready with no live server past its lifetime bound"
+    )
+
+    # The conversation is deliberately left alone. It stays resumable, and the
+    # next prompt provisions a fresh sandbox with the same runtime session.
+    # The sprite itself is destroyed by pass 2 on this same run, now that the
+    # row is terminal.
+    sandbox
   end
 
   # ── pass 2: terminal rows whose sprite is still there ─────────────────────

--- a/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
@@ -1,0 +1,203 @@
+defmodule Fountain.Conversations.ConversationServerLifetimeTest do
+  @moduledoc """
+  A live ConversationServer reclaiming its own sandbox.
+
+  The bound is checked on a one-minute timer, so these send `:lifecycle_check`
+  directly rather than waiting for it — the timer's only job is to call the
+  same code path.
+  """
+
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Conversations.Lifecycle
+
+  defp with_bounds(pairs, fun) do
+    previous = Enum.map(pairs, fn {k, _} -> {k, Application.get_env(:fountain, k)} end)
+    Enum.each(pairs, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+
+    try do
+      fun.()
+    after
+      Enum.each(previous, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+    end
+  end
+
+  # These start from a `ready` sandbox, which routes the server down the
+  # reattach path rather than a fresh provision. The shared harness only covers
+  # provisioning, so the two reattach-specific calls are stubbed here.
+  defp stub_reattach do
+    sprite = stub_happy_sprite()
+    stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{}} end)
+    stub(Sprites, :sprite, fn _client, _name -> sprite end)
+    sprite
+  end
+
+  defp aged_conversation(minutes) do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+    ts = DateTime.utc_now() |> DateTime.add(-minutes * 60, :second) |> DateTime.truncate(:second)
+
+    Fountain.Repo.update_all(
+      from(s in Fountain.Conversations.Sandbox, where: s.id == ^sandbox.id),
+      set: [inserted_at: ts]
+    )
+
+    conv =
+      insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+    {conv, Fountain.Repo.reload(sandbox)}
+  end
+
+  describe "idle timeout" do
+    test "an idle server tears down its sandbox and stops" do
+      {conv, sandbox} = aged_conversation(180)
+      stub_reattach()
+
+      test = self()
+      stub(Sprites, :destroy, fn _sprite -> send(test, :destroyed) && :ok end)
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        {pid, ref, :alive} = start_server(conv)
+
+        # last_activity_at is set at init, so age it to look abandoned.
+        :sys.replace_state(pid, fn state ->
+          %{state | last_activity_at: DateTime.add(DateTime.utc_now(), -7200, :second)}
+        end)
+
+        send(pid, :lifecycle_check)
+        assert :normal = assert_stopped(ref)
+      end)
+
+      assert_received :destroyed
+      assert Fountain.Repo.reload(sandbox).status == "terminated"
+    end
+
+    test "the conversation stays resumable" do
+      # The whole design rests on this. assert_resumable/1 refuses terminated,
+      # so if reclaiming marked the conversation the user would lose access to
+      # their own history permanently — a cost control turned into data loss.
+      {conv, _sandbox} = aged_conversation(180)
+      stub_reattach()
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        {pid, ref, :alive} = start_server(conv)
+
+        :sys.replace_state(pid, fn state ->
+          %{state | last_activity_at: DateTime.add(DateTime.utc_now(), -7200, :second)}
+        end)
+
+        send(pid, :lifecycle_check)
+        assert_stopped(ref)
+      end)
+
+      assert Fountain.Repo.reload(conv).status == "idle"
+    end
+
+    test "a recently active server is left running" do
+      {conv, sandbox} = aged_conversation(180)
+      stub_reattach()
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 999], fn ->
+        {pid, _ref, :alive} = start_server(conv)
+
+        send(pid, :lifecycle_check)
+        # A synchronous call after the cast proves it processed the message and
+        # is still alive.
+        assert is_map(:sys.get_state(pid))
+
+        GenServer.stop(pid)
+      end)
+
+      assert Fountain.Repo.reload(sandbox).status == "ready"
+    end
+
+    test "bounds disabled means the server never reclaims" do
+      {conv, sandbox} = aged_conversation(60 * 24 * 83)
+      stub_reattach()
+
+      with_bounds([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 0], fn ->
+        {pid, _ref, :alive} = start_server(conv)
+
+        :sys.replace_state(pid, fn state ->
+          %{state | last_activity_at: DateTime.add(DateTime.utc_now(), -99_999_999, :second)}
+        end)
+
+        send(pid, :lifecycle_check)
+        assert is_map(:sys.get_state(pid))
+
+        GenServer.stop(pid)
+      end)
+
+      assert Fountain.Repo.reload(sandbox).status == "ready"
+    end
+  end
+
+  describe "max lifetime" do
+    test "an old sandbox is reclaimed even with recent activity" do
+      {conv, sandbox} = aged_conversation(60 * 48)
+      stub_reattach()
+
+      with_bounds([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 24], fn ->
+        {pid, ref, :alive} = start_server(conv)
+
+        send(pid, :lifecycle_check)
+        assert :normal = assert_stopped(ref)
+      end)
+
+      assert Fountain.Repo.reload(sandbox).status == "terminated"
+    end
+
+    test "the ceiling is dated from the sandbox row, not from server start" do
+      # Otherwise every restart, reattach and deploy would reset the ceiling and
+      # a long-lived sandbox would never reach it.
+      {conv, sandbox} = aged_conversation(60 * 48)
+      stub_reattach()
+
+      with_bounds([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 24], fn ->
+        {pid, ref, :alive} = start_server(conv)
+
+        assert %{sandbox_started_at: started} = :sys.get_state(pid)
+        assert DateTime.compare(started, sandbox.inserted_at) == :eq
+
+        send(pid, :lifecycle_check)
+        assert_stopped(ref)
+      end)
+    end
+  end
+
+  describe "before a sprite exists" do
+    test "nothing is reclaimed while provisioning is still in flight" do
+      # sandbox_started_at is nil until the sprite is up. Reclaiming here would
+      # fight the provisioner; the reaper's stuck-row pass owns this case.
+      {conv, _sandbox} = aged_conversation(60 * 24)
+      stub_reattach()
+      stub(Sprites, :get_sprite, fn _client, _name -> {:error, :not_found} end)
+
+      with_bounds([sandbox_idle_timeout_minutes: 1, sandbox_max_lifetime_hours: 1], fn ->
+        {pid, ref, settled} = start_server(conv)
+
+        if settled == :alive do
+          assert %{sandbox_started_at: nil} = :sys.get_state(pid)
+          send(pid, :lifecycle_check)
+          assert is_map(:sys.get_state(pid))
+          GenServer.stop(pid)
+        else
+          # A provision failure stops the server on its own, which is fine —
+          # the point is that the lifecycle check did not do it.
+          assert_stopped(ref)
+        end
+      end)
+    end
+  end
+
+  describe "the reclaim message" do
+    test "explains itself in terms the user can act on" do
+      with_bounds([sandbox_idle_timeout_minutes: 90, sandbox_max_lifetime_hours: 6], fn ->
+        assert Lifecycle.explain(:idle) =~ "90 minutes idle"
+        assert Lifecycle.explain(:max_lifetime) =~ "6 hour"
+      end)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/lifecycle_test.exs
+++ b/apps/fountain/test/fountain/conversations/lifecycle_test.exs
@@ -1,0 +1,126 @@
+defmodule Fountain.Conversations.LifecycleTest do
+  @moduledoc """
+  Sandbox lifetime bounds.
+
+  The bias throughout is that reclaiming too eagerly costs a re-provision on the
+  next prompt while reclaiming too late bills indefinitely — but only because
+  the conversation survives. These tests pin both halves: when a bound fires,
+  and that the answer is a bound on the *sandbox*.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Fountain.Conversations.Lifecycle
+
+  defp with_config(pairs, fun) do
+    previous = Enum.map(pairs, fn {k, _} -> {k, Application.get_env(:fountain, k)} end)
+    Enum.each(pairs, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+
+    try do
+      fun.()
+    after
+      Enum.each(previous, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+    end
+  end
+
+  defp ago(seconds), do: DateTime.add(DateTime.utc_now(), -seconds, :second)
+
+  describe "configuration" do
+    test "defaults are an hour idle and a day absolute" do
+      with_config([sandbox_idle_timeout_minutes: nil, sandbox_max_lifetime_hours: nil], fn ->
+        Application.delete_env(:fountain, :sandbox_idle_timeout_minutes)
+        Application.delete_env(:fountain, :sandbox_max_lifetime_hours)
+
+        assert Lifecycle.idle_timeout_seconds() == 3600
+        assert Lifecycle.max_lifetime_seconds() == 86_400
+      end)
+    end
+
+    test "0 disables a bound" do
+      # The escape hatch for a self-hoster who wants the pre-#167 behaviour.
+      with_config([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 0], fn ->
+        assert Lifecycle.idle_timeout_seconds() == nil
+        assert Lifecycle.max_lifetime_seconds() == nil
+      end)
+    end
+
+    test "a string value is accepted" do
+      # runtime.exs parses these, but application env can be set by hand too.
+      with_config([sandbox_idle_timeout_minutes: "15"], fn ->
+        assert Lifecycle.idle_timeout_seconds() == 900
+      end)
+    end
+
+    test "nonsense disables rather than crashes the check" do
+      # A bad env var must not take out every ConversationServer on its timer.
+      with_config([sandbox_idle_timeout_minutes: "banana"], fn ->
+        assert Lifecycle.idle_timeout_seconds() == nil
+      end)
+    end
+  end
+
+  describe "check/4" do
+    test "a fresh, active sandbox is fine" do
+      with_config([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        assert :ok = Lifecycle.check(ago(60), ago(10), false)
+      end)
+    end
+
+    test "idle past the timeout expires" do
+      with_config([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        assert {:expired, :idle} = Lifecycle.check(ago(7200), ago(3601), false)
+      end)
+    end
+
+    test "a running turn is activity, so idle does not fire" do
+      # Otherwise a single long turn — the thing sandboxes exist for — would be
+      # killed underneath the user at the hour mark.
+      with_config([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        assert :ok = Lifecycle.check(ago(7200), ago(7200), true)
+      end)
+    end
+
+    test "max lifetime fires even mid-turn" do
+      # The bound an idle timeout cannot enforce: a conversation that keeps
+      # itself permanently busy. A day is far past any legitimate turn.
+      with_config([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        assert {:expired, :max_lifetime} = Lifecycle.check(ago(90_000), DateTime.utc_now(), true)
+      end)
+    end
+
+    test "max lifetime is reported in preference to idle" do
+      with_config([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        assert {:expired, :max_lifetime} = Lifecycle.check(ago(90_000), ago(90_000), false)
+      end)
+    end
+
+    test "disabled bounds never expire, however old" do
+      with_config([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 0], fn ->
+        # The 83-day production sandbox, under an operator who opted out.
+        assert :ok = Lifecycle.check(ago(83 * 86_400), ago(83 * 86_400), false)
+      end)
+    end
+
+    test "one bound disabled does not disable the other" do
+      with_config([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 24], fn ->
+        assert :ok = Lifecycle.check(ago(3600), ago(3600), false)
+        assert {:expired, :max_lifetime} = Lifecycle.check(ago(90_000), ago(90_000), false)
+      end)
+    end
+  end
+
+  describe "explain/1" do
+    test "tells the user what happened and that nothing was lost" do
+      # From the user's side the sandbox simply vanished. This message is the
+      # difference between a bug report and a shrug.
+      with_config([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        idle = Lifecycle.explain(:idle)
+        assert idle =~ "60 minutes idle"
+        assert idle =~ "Send another prompt"
+        assert idle =~ "history is preserved"
+
+        assert Lifecycle.explain(:max_lifetime) =~ "24 hour"
+      end)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/sandbox_bounds_config_test.exs
+++ b/apps/fountain/test/fountain/sandbox_bounds_config_test.exs
@@ -1,0 +1,87 @@
+defmodule Fountain.SandboxBoundsConfigTest do
+  @moduledoc """
+  Boot-time parsing of the sandbox lifetime bounds.
+
+  A typo in one of these would otherwise disable the bound silently, and an
+  operator who set a limit should learn it did not take effect from a boot
+  failure rather than from a bill.
+  """
+
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+
+  @base %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "EMAIL_DELIVERY" => "none"
+  }
+
+  @vars ~w(SANDBOX_IDLE_TIMEOUT_MINUTES SANDBOX_MAX_LIFETIME_HOURS)
+
+  setup do
+    previous = System.get_env()
+
+    on_exit(fn ->
+      System.put_env(previous)
+
+      for k <- @vars ++ ["MASTER_SECRETS_KEY"],
+          not Map.has_key?(previous, k),
+          do: System.delete_env(k)
+    end)
+
+    key = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+    {:ok, base: Map.put(@base, "MASTER_SECRETS_KEY", key)}
+  end
+
+  defp read_prod(env) do
+    for k <- @vars, do: System.delete_env(k)
+    System.put_env(env)
+    Config.Reader.read!(@runtime_exs, env: :prod)[:fountain]
+  end
+
+  test "defaults are an hour idle and a day absolute", %{base: base} do
+    config = read_prod(base)
+
+    assert config[:sandbox_idle_timeout_minutes] == 60
+    assert config[:sandbox_max_lifetime_hours] == 24
+  end
+
+  test "values are read from the environment", %{base: base} do
+    config =
+      base
+      |> Map.merge(%{"SANDBOX_IDLE_TIMEOUT_MINUTES" => "15", "SANDBOX_MAX_LIFETIME_HOURS" => "6"})
+      |> read_prod()
+
+    assert config[:sandbox_idle_timeout_minutes] == 15
+    assert config[:sandbox_max_lifetime_hours] == 6
+  end
+
+  test "0 is accepted as the opt-out", %{base: base} do
+    config =
+      base
+      |> Map.merge(%{"SANDBOX_IDLE_TIMEOUT_MINUTES" => "0", "SANDBOX_MAX_LIFETIME_HOURS" => "0"})
+      |> read_prod()
+
+    assert config[:sandbox_idle_timeout_minutes] == 0
+    assert config[:sandbox_max_lifetime_hours] == 0
+  end
+
+  test "a malformed value refuses to boot", %{base: base} do
+    error =
+      assert_raise RuntimeError, fn ->
+        base |> Map.put("SANDBOX_IDLE_TIMEOUT_MINUTES", "60m") |> read_prod()
+      end
+
+    assert error.message =~ "SANDBOX_IDLE_TIMEOUT_MINUTES"
+    assert error.message =~ "non-negative integer"
+    assert error.message =~ "Set it to 0 to disable"
+  end
+
+  test "a negative value refuses to boot", %{base: base} do
+    assert_raise RuntimeError, ~r/SANDBOX_MAX_LIFETIME_HOURS/, fn ->
+      base |> Map.put("SANDBOX_MAX_LIFETIME_HOURS", "-1") |> read_prod()
+    end
+  end
+end

--- a/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
+++ b/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
@@ -107,6 +107,128 @@ defmodule Fountain.Workers.SandboxReaperTest do
     end
   end
 
+  describe "abandoned ready sandboxes" do
+    defp with_bounds(pairs, fun) do
+      previous = Enum.map(pairs, fn {k, _} -> {k, Application.get_env(:fountain, k)} end)
+      Enum.each(pairs, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+
+      try do
+        fun.()
+      after
+        Enum.each(previous, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+      end
+    end
+
+    defp age_rows(sandbox, conv, minutes) do
+      ts = minutes_ago(minutes)
+      Repo.update_all(from(s in Sandbox, where: s.id == ^sandbox.id), set: [inserted_at: ts])
+
+      if conv do
+        Repo.update_all(
+          from(t in Fountain.Conversations.Turn, where: t.conversation_id == ^conv.id),
+          set: [inserted_at: ts]
+        )
+      end
+
+      Repo.reload(sandbox)
+    end
+
+    test "a ready sandbox with no server and no recent turn is expired" do
+      # The 83-day production sandbox. Its ConversationServer is long gone, so
+      # nothing was watching it — the server-side idle timeout cannot help.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+      insert_turn(conv, %{status: "completed"})
+      sandbox = age_rows(sandbox, conv, 60 * 24 * 83)
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        capture_log(fn -> assert 1 = SandboxReaper.expire_abandoned_sandboxes() end)
+      end)
+
+      assert Repo.reload(sandbox).status == "terminated"
+
+      # The conversation must survive — reclaiming is a cost control, not a
+      # delete. assert_resumable/1 refuses terminated/failed/completed, so
+      # marking it here would lock the user out of their own history forever.
+      assert Repo.reload(conv).status == "idle"
+      refute Repo.reload(conv).status in ~w(terminated failed completed)
+    end
+
+    test "recent turn activity keeps a sandbox alive" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox)
+      insert_turn(conv, %{status: "completed"})
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        assert 0 = SandboxReaper.expire_abandoned_sandboxes()
+      end)
+
+      assert Repo.reload(sandbox).status == "ready"
+    end
+
+    test "a live ConversationServer is left to enforce its own timeout" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox)
+      age_rows(sandbox, conv, 60 * 24 * 83)
+
+      stub(Fountain.Conversations.ConversationServer, :whereis, fn id ->
+        if id == conv.id, do: self(), else: nil
+      end)
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        assert 0 = SandboxReaper.expire_abandoned_sandboxes()
+      end)
+
+      assert Repo.reload(sandbox).status == "ready"
+    end
+
+    test "with both bounds disabled nothing is expired" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox)
+      age_rows(sandbox, conv, 60 * 24 * 83)
+
+      with_bounds([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 0], fn ->
+        assert 0 = SandboxReaper.expire_abandoned_sandboxes()
+      end)
+
+      assert Repo.reload(sandbox).status == "ready"
+    end
+
+    test "a sandbox that never took a turn is dated from its own creation" do
+      # Otherwise a sandbox with no turns has no activity timestamp at all and
+      # would either never expire or expire immediately.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox)
+      sandbox = age_rows(sandbox, conv, 60 * 5)
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        capture_log(fn -> assert 1 = SandboxReaper.expire_abandoned_sandboxes() end)
+      end)
+
+      assert Repo.reload(sandbox).status == "terminated"
+    end
+
+    test "expiring a sandbox makes its sprite eligible for destruction the same run" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox)
+      age_rows(sandbox, conv, 60 * 24 * 83)
+      stub_sprites([sandbox.sprite_name])
+      capture_destroys()
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        capture_log(fn -> assert :ok = perform_job(SandboxReaper, %{}) end)
+      end)
+
+      assert destroyed_names() == [sandbox.sprite_name]
+    end
+  end
+
   describe "leaked sprites" do
     test "destroys a sprite whose sandbox row is terminal" do
       # The ordinary leak: both destroy call sites in ConversationServer discard

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,6 +29,15 @@ config :fountain,
   registration_enabled: true,
   registration_allowed_email_domains: []
 
+# Sandbox lifetime bounds. A sandbox used to live until something explicitly
+# terminated it; production had one idle for 83 days. Reclaiming only tears down
+# the sandbox — the conversation stays resumable and the next prompt provisions
+# a fresh one — so the cost of being wrong here is a re-provision, not lost
+# work. Set either to 0 to disable. See Fountain.Conversations.Lifecycle.
+config :fountain,
+  sandbox_idle_timeout_minutes: 60,
+  sandbox_max_lifetime_hours: 24
+
 config :fountain,
   ecto_repos: [Fountain.Repo],
   generators: [timestamp_type: :utc_datetime, binary_id: true]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -135,6 +135,32 @@ allowed_signup_domains =
 
 config :fountain, :registration_allowed_email_domains, allowed_signup_domains
 
+# Sandbox lifetime bounds. Either set to 0 disables that bound; an operator who
+# wants sandboxes to live until explicitly terminated sets both to 0 and gets
+# the pre-#167 behaviour back. Reclaiming a sandbox does not end its
+# conversation — see Fountain.Conversations.Lifecycle.
+#
+# Refused at boot rather than ignored: a typo here would otherwise silently
+# disable the bound, and an operator who set a limit deserves to find out that
+# it did not take effect now rather than from a bill.
+parse_bound = fn var, default ->
+  case System.get_env(var, default) |> Integer.parse() do
+    {n, ""} when n >= 0 ->
+      n
+
+    _ ->
+      raise """
+      #{var} must be a non-negative integer (got: #{inspect(System.get_env(var))}).
+
+      Set it to 0 to disable this bound entirely.
+      """
+  end
+end
+
+config :fountain,
+  sandbox_idle_timeout_minutes: parse_bound.("SANDBOX_IDLE_TIMEOUT_MINUTES", "60"),
+  sandbox_max_lifetime_hours: parse_bound.("SANDBOX_MAX_LIFETIME_HOURS", "24")
+
 # CIDRs treated as proxies when resolving the client IP from X-Forwarded-For.
 # Only widen this to cover addresses that are genuinely proxies — anything
 # trusted here is stepped over, so an over-broad list lets a client spoof its

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -95,7 +95,9 @@ A **Conversation** is a running session of an Agent inside a sandboxed VM. It st
 2. Fountain resolves the full env-var set and spawns a Sprites sandbox
 3. The agent runs; log events stream in real time over SSE (`GET /api/conversations/:id/stream`)
 4. Follow-up prompts go to `POST /api/conversations/:id/prompts`; a running turn can be interrupted (`POST .../interrupt`) and the whole conversation ended early (`POST .../terminate`)
-5. The sandbox exits when the conversation terminates or a timeout hits
+5. The sandbox exits when the conversation terminates, or when it is reclaimed for being idle (default 60 minutes with no turn activity) or for reaching its maximum lifetime (default 24 hours)
+
+Reclaiming ends the **sandbox**, not the conversation. The conversation stays resumable: the next prompt provisions a fresh sandbox and the runtime resumes the same session, so history is preserved and the only cost is the provisioning wait. Self-hosters can widen or disable both bounds with `SANDBOX_IDLE_TIMEOUT_MINUTES` and `SANDBOX_MAX_LIFETIME_HOURS` (`0` disables).
 
 ### Status lifecycle
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -109,6 +109,24 @@ Pick one:
 Password reset also needs working mail. With `EMAIL_DELIVERY=none` the only
 route back into a locked-out account is the database.
 
+## Sandbox lifetime
+
+Sandboxes are reclaimed when they go idle or reach a maximum age, so an
+abandoned conversation stops costing you:
+
+| Setting | Default | |
+|---|---|---|
+| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | No turn activity for this long and the sandbox is torn down |
+| `SANDBOX_MAX_LIFETIME_HOURS` | `24` | Absolute ceiling from creation, regardless of activity |
+
+Set either to `0` to disable it. A value that is not a non-negative integer
+refuses to boot rather than quietly disabling the bound.
+
+Reclaiming ends the **sandbox**, not the conversation. The conversation stays
+resumable — the next prompt provisions a fresh sandbox and the runtime resumes
+the same session — so the cost of a bound being too aggressive is a
+re-provisioning wait, not lost work.
+
 ## Billing
 
 The compose file sets `BILLING_ENABLED=false`. The subscription gate exists for


### PR DESCRIPTION
Closes #167.

A sandbox lived until something explicitly terminated it. Production had one continuously `ready` since **2026-05-10 — 83 days idle**, billing and holding a slot against its owner's concurrent-sandbox cap the entire time. `docs/primitives.md:98` told users "the sandbox exits when the conversation terminates **or a timeout hits**", describing a safeguard that was never built. It is now true.

## The bounds

| | default | |
|---|---|---|
| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | no turn activity for this long → reclaimed |
| `SANDBOX_MAX_LIFETIME_HOURS` | `24` | absolute ceiling from creation, regardless of activity |

Either set to `0` disables that bound, restoring the previous behaviour for an operator who wants it. A value that is not a non-negative integer **refuses to boot** rather than quietly disabling the bound — a typo should surface now rather than in a bill.

## Why the defaults can be this tight

Reclaiming is non-destructive, and the whole design rests on that. Only the *sandbox* is torn down. The conversation row stays `idle`, and `assert_resumable/1` only refuses `terminated`/`failed`/`completed`, so the next prompt goes through `wake_conversation/2`, provisions a fresh sandbox, and passes the persisted `runtime_session_id` so the runtime resumes the same session.

So the cost of a bound being too aggressive is a re-provisioning wait, not lost work, while the cost of being too lax is an unbounded bill. Marking the *conversation* terminated here would invert that — a cost control becoming permanent data loss — and there are tests on both the server path and the reaper path pinning that it does not happen.

## Enforced in two places

Neither covers the other:

**`ConversationServer`** checks its own bounds on a one-minute timer. A running turn counts as activity for the idle bound but *not* for the absolute one, which exists precisely for a conversation that never stops being busy. The ceiling is dated from `sandboxes.inserted_at`, not from server start, so a restart, reattach or deploy does not reset it.

**`SandboxReaper`** gains a pass for `ready` sandboxes with no live `ConversationServer` — a crash, a node leaving the cluster, a deploy landing between the rehydrator's scan and a reattach. Nothing is watching those, and that is exactly what the 83-day sandbox was: `ready`, serverless, alive for months.

One detail worth calling out there: activity is read from the conversation's newest **turn**, not from `sandboxes.updated_at` or `conversations.updated_at`. The rehydrator touches the latter on every boot — I saw all five production `ready` sandboxes with an `updated_at` of minutes ago purely because the pods had just restarted — so using it would make an abandoned conversation look freshly active after every deploy and the bound would never fire.

Expiring a sandbox runs before the destroy pass in the same run, so the sprite goes on the same tick.

## The stage event

The reclaim publishes a `sandbox` stage event whose message says what happened and that history is preserved — from the user's side the sandbox simply vanished, and that message is the difference between a bug report and a shrug.

It uses state `"done"` rather than a new `"reclaimed"`. `LogEvent` allows only `started/done/failed/interrupted`, and both the Go CLI and the LiveView switch on that vocabulary; a new value would require every client to learn a word in order to say something the `reason` and `message` fields already carry. The genuinely new thing clients can key on is the `sandbox` stage itself.

## Tests

The lifetime tests drive a real `ConversationServer` through the existing harness and send `:lifecycle_check` directly rather than waiting a minute for the timer. They cover: idle reclaim tears down and stops; the conversation survives; recent activity is left alone; disabled bounds never fire however old; max lifetime fires despite activity; the ceiling comes from the sandbox row; and nothing is reclaimed before a sprite exists.

Config parsing is tested through `Config.Reader.read!` on the real `runtime.exs`, including that `60m` and `-1` refuse to boot.

Full suite: 1393 tests, 0 failures. `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` clean.

## Deploying

No Kubernetes manifest changes, so #231's ordering hazard does not apply. Once this ships, the four remaining long-lived production sandboxes will be reclaimed on the first reaper run after the deploy — including the 83-day one. Their conversations stay resumable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)