### PR TITLE
fix(conversations): validate turn images at ingest, not only on serve

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -529,27 +529,41 @@ defmodule Fountain.Conversations do
     )
   end
 
-  def insert_turn_images(_turn_id, []), do: {:ok, []}
+  def insert_turn_images(_turn_id, []), do: {:ok, 0}
 
+  @doc """
+  Store a turn's images.
+
+  Goes through `TurnImage.changeset/2` rather than `Repo.insert_all` against a
+  raw table name. The old path skipped the schema entirely, so the media-type
+  allowlist, the required fields and the `(turn_id, position)` unique constraint
+  never ran — the schema described validation that nothing performed, and a
+  client could store an arbitrary media type. Volume here is a handful of rows
+  per turn, so there was never a bulk-insert win to protect.
+
+  Returns `{:ok, count}` or `{:error, changeset}`. Both are handled by the
+  caller; a rejected image must not take a turn down with it.
+  """
   def insert_turn_images(turn_id, images) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    rows =
-      images
-      |> Enum.with_index()
-      |> Enum.map(fn {%{media_type: mt, data: data}, idx} ->
-        %{
-          id: Ecto.UUID.dump!(Ecto.UUID.generate()),
-          turn_id: Ecto.UUID.dump!(turn_id),
+    images
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, 0}, fn {%{media_type: mt, data: data}, idx}, {:ok, count} ->
+      changeset =
+        TurnImage.changeset(%TurnImage{}, %{
+          turn_id: turn_id,
           position: idx,
           media_type: mt,
           data: data,
           inserted_at: now
-        }
-      end)
+        })
 
-    {count, _} = Repo.insert_all("turn_images", rows)
-    {:ok, count}
+      case Repo.insert(changeset) do
+        {:ok, _} -> {:cont, {:ok, count + 1}}
+        {:error, cs} -> {:halt, {:error, cs}}
+      end
+    end)
   end
 
   def get_turn_image(turn_id, position) do

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1078,8 +1078,23 @@ defmodule Fountain.Conversations.ConversationServer do
         started_at: now()
       })
 
-    # Store images in DB
-    {:ok, _} = Conversations.insert_turn_images(turn.id, images)
+    # Store images. A rejected image must not take the turn down with it: this
+    # used to hard-match {:ok, _}, which is why validation could not be added to
+    # the insert path without crashing the server mid-turn.
+    case Conversations.insert_turn_images(turn.id, images) do
+      {:ok, _count} ->
+        :ok
+
+      {:error, changeset} ->
+        # Log only. A `turn`/`started` stage event is what the LiveView uses to
+        # create a turn row, so publishing one here would invent a second turn.
+        Logger.warning(
+          "turn #{turn.id}: image rejected, continuing without it: " <>
+            inspect(changeset.errors)
+        )
+
+        :ok
+    end
 
     # On the first turn, asynchronously generate a short title for the sidebar.
     if turn.turn_number == 1 do

--- a/apps/fountain/lib/fountain/conversations/turn_image.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_image.ex
@@ -28,9 +28,14 @@ defmodule Fountain.Conversations.TurnImage do
 
   def changeset(image, attrs) do
     image
-    |> cast(attrs, [:position, :media_type, :data, :turn_id])
+    |> cast(attrs, [:position, :media_type, :data, :turn_id, :inserted_at])
     |> validate_required([:position, :media_type, :data, :turn_id])
     |> validate_inclusion(:media_type, @valid_media_types)
+    |> validate_number(:position, greater_than_or_equal_to: 0)
     |> unique_constraint([:turn_id, :position])
+    # Without this a missing turn raises Ecto.ConstraintError instead of
+    # returning a changeset, which would crash the ConversationServer — the
+    # exact failure mode that kept validation out of this path.
+    |> foreign_key_constraint(:turn_id)
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -71,7 +71,7 @@ defmodule FountainWeb.ConversationController do
       "Creates a sandbox + conversation pair, starts the runtime in a fresh sprite, " <>
         "and (if `prompt` is supplied) sends it as turn 1. " <>
         "Pass `X-Fountain-Parent-Conversation-Id` header to record which conversation spawned this one. " <>
-          "Legacy `X-AoD-Parent-Conversation-Id` is still accepted for sprites provisioned before the rename.",
+        "Legacy `X-AoD-Parent-Conversation-Id` is still accepted for sprites provisioned before the rename.",
     request_body: {"Conversation attrs", "application/json", Schemas.ConversationCreateRequest},
     responses: [
       created: {"Conversation", "application/json", Schemas.ConversationResponse},
@@ -91,8 +91,13 @@ defmodule FountainWeb.ConversationController do
 
   def create(conn, params) do
     user = conn.assigns.current_user
-    images = decode_images(params["images"])
 
+    with {:ok, images} <- decode_images(params["images"]) do
+      create_with_images(conn, params, user, images)
+    end
+  end
+
+  defp create_with_images(conn, params, user, images) do
     parent_header =
       List.first(get_req_header(conn, "x-fountain-parent-conversation-id")) ||
         List.first(get_req_header(conn, "x-aod-parent-conversation-id"))
@@ -156,8 +161,13 @@ defmodule FountainWeb.ConversationController do
 
   def prompt(conn, %{"conversation_id" => id, "prompt" => prompt} = params) do
     user = conn.assigns.current_user
-    images = decode_images(params["images"])
 
+    with {:ok, images} <- decode_images(params["images"]) do
+      do_prompt(conn, id, prompt, user, images)
+    end
+  end
+
+  defp do_prompt(conn, id, prompt, user, images) do
     case Conversations.get_conversation(id, user.id) do
       nil ->
         {:error, :not_found}
@@ -353,21 +363,69 @@ defmodule FountainWeb.ConversationController do
     s |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
   end
 
-  defp decode_images(nil), do: []
-  defp decode_images([]), do: []
+  @max_image_bytes 10 * 1024 * 1024
+
+  @doc false
+  # Exposed for tests: a body large enough to exercise the size guard through
+  # HTTP is rejected by the body parser first, so the guard itself would
+  # otherwise be untestable.
+  def decode_images_for_test(images), do: decode_images(images)
+
+  # Validates before anything is stored, and returns an error the caller can
+  # turn into a 400. Previously this decoded with `Base.decode64!` and raised a
+  # bare ArgumentError past the size limit — both surfaced as a 500, telling a
+  # client with a malformed request that the server was broken. The media type
+  # was not checked at all, so a client could store an arbitrary one.
+  defp decode_images(nil), do: {:ok, []}
+  defp decode_images([]), do: {:ok, []}
 
   defp decode_images(images) when is_list(images) do
-    Enum.map(images, fn img ->
-      b64 = img["data"] || img[:data]
-      mt = img["media_type"] || img[:media_type]
-      data = Base.decode64!(b64)
-
-      if byte_size(data) > 10 * 1024 * 1024 do
-        raise ArgumentError, "Image exceeds 10MB limit"
+    Enum.reduce_while(images, {:ok, []}, fn img, {:ok, acc} ->
+      case decode_image(img) do
+        {:ok, decoded} -> {:cont, {:ok, acc ++ [decoded]}}
+        {:error, _} = err -> {:halt, err}
       end
-
-      %{media_type: mt, data: data}
     end)
+  end
+
+  defp decode_images(_), do: {:error, "images must be a list"}
+
+  defp decode_image(img) when is_map(img) do
+    b64 = img["data"] || img[:data]
+    mt = img["media_type"] || img[:media_type]
+
+    with :ok <- validate_media_type(mt),
+         {:ok, data} <- decode_base64(b64),
+         :ok <- validate_size(data) do
+      {:ok, %{media_type: mt, data: data}}
+    end
+  end
+
+  defp decode_image(_), do: {:error, "each image must be an object"}
+
+  defp validate_media_type(mt) do
+    if mt in Fountain.Conversations.TurnImage.valid_media_types() do
+      :ok
+    else
+      {:error,
+       "unsupported image media_type #{inspect(mt)} — must be one of " <>
+         Enum.join(Fountain.Conversations.TurnImage.valid_media_types(), ", ")}
+    end
+  end
+
+  defp decode_base64(b64) when is_binary(b64) do
+    case Base.decode64(b64) do
+      {:ok, data} -> {:ok, data}
+      :error -> {:error, "image data must be base64-encoded"}
+    end
+  end
+
+  defp decode_base64(_), do: {:error, "image data is required"}
+
+  defp validate_size(data) do
+    if byte_size(data) > @max_image_bytes,
+      do: {:error, "image exceeds the 10MB limit"},
+      else: :ok
   end
 
   defp parse_last_event_id(nil), do: 0

--- a/apps/fountain/lib/fountain_web/plugs/caching_body_reader.ex
+++ b/apps/fountain/lib/fountain_web/plugs/caching_body_reader.ex
@@ -20,8 +20,23 @@ defmodule FountainWeb.CachingBodyReader do
           | {:more, binary(), Plug.Conn.t()}
           | {:error, term()}
   def read_body(conn, opts) do
-    {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
-    conn = put_in(conn.assigns[:raw_body], body)
-    {:ok, body, conn}
+    # Every branch has to be passed through. This used to hard-match
+    # `{:ok, body, conn}`, so a request larger than the parser's read length —
+    # where `Plug.Conn.read_body/2` returns `{:more, ...}` — raised a MatchError
+    # and surfaced as a 500 on every endpoint, instead of the 413 that
+    # `Plug.Parsers` produces when it is told the body did not fit. An
+    # oversized upload is a client error and should read as one.
+    case Plug.Conn.read_body(conn, opts) do
+      {:ok, body, conn} ->
+        {:ok, body, put_in(conn.assigns[:raw_body], body)}
+
+      {:more, partial, conn} ->
+        # Deliberately not cached: a partial body would let the Stripe webhook
+        # verifier compute a signature over something that was never sent.
+        {:more, partial, conn}
+
+      {:error, _} = err ->
+        err
+    end
   end
 end

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -230,6 +230,7 @@ defmodule Fountain.ConversationsContextTest do
       # falls back to inserted_at when there are no turns or log events, so
       # this is the field that controls ordering for brand-new conversations.
       past = DateTime.add(DateTime.utc_now(), -3600, :second) |> DateTime.truncate(:second)
+
       Fountain.Repo.update_all(
         Ecto.Query.from(c in Conversation, where: c.id == ^c2.id),
         set: [inserted_at: past]
@@ -671,7 +672,8 @@ defmodule Fountain.ConversationsContextTest do
       assert count == 0
 
       # conv2's running turn should be untouched
-      assert Conversations.get_turn_by_conversation(running_in_conv2.id, conv2.id).status == "running"
+      assert Conversations.get_turn_by_conversation(running_in_conv2.id, conv2.id).status ==
+               "running"
     end
 
     test "updates running turns to interrupted status in db" do
@@ -1240,6 +1242,7 @@ defmodule Fountain.ConversationsContextTest do
 
       # Backdate c2 so c1 sorts first
       past = DateTime.add(DateTime.utc_now(), -3600, :second) |> DateTime.truncate(:second)
+
       Fountain.Repo.update_all(
         Ecto.Query.from(c in Conversation, where: c.id == ^c2.id),
         set: [updated_at: past]
@@ -1327,8 +1330,8 @@ defmodule Fountain.ConversationsContextTest do
   # insert_turn_images/2 and get_turn_image/2
   # ────────────────────────────────────────────────────────────────────────────
 
-  # Helper to insert a TurnImage via changeset (avoids the UUID-encoding issue in
-  # insert_turn_images/2 which uses Repo.insert_all with a raw table name string).
+  # Helper to insert a TurnImage via changeset directly, for tests that need a
+  # row without exercising insert_turn_images/2.
   defp insert_turn_image!(turn_id, position, media_type, data) do
     %Fountain.Conversations.TurnImage{}
     |> Fountain.Conversations.TurnImage.changeset(%{
@@ -1342,9 +1345,8 @@ defmodule Fountain.ConversationsContextTest do
   end
 
   describe "insert_turn_images/2" do
-    # The empty-list fast-path returns {:ok, []} without touching the DB, so no UUID issue.
-    test "returns {:ok, []} immediately when images list is empty" do
-      assert {:ok, []} = Conversations.insert_turn_images(Ecto.UUID.generate(), [])
+    test "returns {:ok, 0} immediately when images list is empty" do
+      assert {:ok, 0} = Conversations.insert_turn_images(Ecto.UUID.generate(), [])
     end
 
     test "inserts images and returns count" do
@@ -1353,6 +1355,47 @@ defmodule Fountain.ConversationsContextTest do
       turn = insert_turn(conv)
       images = [%{media_type: "image/png", data: <<1, 2, 3>>}]
       assert {:ok, 1} = Conversations.insert_turn_images(turn.id, images)
+    end
+
+    test "positions are assigned in order" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv)
+
+      assert {:ok, 2} =
+               Conversations.insert_turn_images(turn.id, [
+                 %{media_type: "image/png", data: <<1>>},
+                 %{media_type: "image/jpeg", data: <<2>>}
+               ])
+
+      assert Conversations.get_turn_image(turn.id, 0).media_type == "image/png"
+      assert Conversations.get_turn_image(turn.id, 1).media_type == "image/jpeg"
+    end
+
+    test "a disallowed media type is refused instead of stored" do
+      # This used to go through Repo.insert_all against a raw table name, so the
+      # schema's allowlist never ran and the schema described validation that
+      # nothing performed.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv)
+
+      assert {:error, changeset} =
+               Conversations.insert_turn_images(turn.id, [
+                 %{media_type: "text/html", data: "<script>alert(1)</script>"}
+               ])
+
+      assert {"is invalid", _} = changeset.errors[:media_type]
+      assert Conversations.get_turn_image(turn.id, 0) == nil
+    end
+
+    test "an unknown turn is refused rather than orphaning a row" do
+      assert {:error, changeset} =
+               Conversations.insert_turn_images(Ecto.UUID.generate(), [
+                 %{media_type: "image/png", data: <<1>>}
+               ])
+
+      refute changeset.valid? and changeset.errors == []
     end
   end
 
@@ -1475,6 +1518,7 @@ defmodule Fountain.ConversationsContextTest do
     test "returns {:ok, conv} creating fresh sandbox when sandbox is pending (not ready)" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)
+
       # sandbox remains "pending" (not "ready"), so maybe_reuse_sandbox hits the _ -> :create_new branch
       sandbox = insert_sandbox(user_id: user.id)
       conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
@@ -1565,7 +1609,9 @@ defmodule Fountain.ConversationsContextTest do
     test "is refused once the tenant is at its concurrent-sandbox cap" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)
-      for _ <- 1..Fountain.Quotas.default_limit(), do: insert_sandbox(user_id: user.id, status: "ready")
+
+      for _ <- 1..Fountain.Quotas.default_limit(),
+          do: insert_sandbox(user_id: user.id, status: "ready")
 
       assert {:error, {:sandbox_quota_exceeded, %{count: 5, limit: 5}}} =
                Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
@@ -1577,7 +1623,9 @@ defmodule Fountain.ConversationsContextTest do
       for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
 
       before = Fountain.Quotas.active_sandbox_count(user.id)
-      assert {:error, _} = Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+
+      assert {:error, _} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
 
       # A denial that still allocated would let a caller ratchet past the cap
       # by retrying, which is the failure mode the cap exists to prevent.
@@ -1654,7 +1702,9 @@ defmodule Fountain.ConversationsContextTest do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)
 
-      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec -> {:ok, spawn(fn -> :ok end)} end)
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
 
       attrs = %{"agent_id" => agent.id, "user_id" => user.id, "vault_id" => ""}
       assert {:ok, conv} = Conversations.start_conversation(attrs)
@@ -1666,7 +1716,9 @@ defmodule Fountain.ConversationsContextTest do
       agent = insert_agent(user_id: user.id)
       vault = insert_vault(user_id: user.id)
 
-      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec -> {:ok, spawn(fn -> :ok end)} end)
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
 
       attrs = %{"agent_id" => agent.id, "user_id" => user.id, "vault_id" => vault.id}
       assert {:ok, conv} = Conversations.start_conversation(attrs)
@@ -1678,7 +1730,9 @@ defmodule Fountain.ConversationsContextTest do
       vault = insert_vault(user_id: user.id)
       agent = insert_agent(user_id: user.id, allowed_vault_ids: [vault.id])
 
-      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec -> {:ok, spawn(fn -> :ok end)} end)
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
 
       attrs = %{"agent_id" => agent.id, "user_id" => user.id, "vault_id" => vault.id}
       assert {:ok, conv} = Conversations.start_conversation(attrs)
@@ -1708,7 +1762,9 @@ defmodule Fountain.ConversationsContextTest do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id, allowed_vault_ids: [])
 
-      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec -> {:ok, spawn(fn -> :ok end)} end)
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
 
       attrs = %{"agent_id" => agent.id, "user_id" => user.id}
       assert {:ok, conv} = Conversations.start_conversation(attrs)
@@ -1816,7 +1872,12 @@ defmodule Fountain.ConversationsContextTest do
       turn = insert_turn(conv)
 
       now = DateTime.utc_now() |> DateTime.truncate(:second)
-      for {mt, data, pos} <- [{"image/png", <<10>>, 0}, {"image/jpeg", <<20>>, 1}, {"image/gif", <<30>>, 2}] do
+
+      for {mt, data, pos} <- [
+            {"image/png", <<10>>, 0},
+            {"image/jpeg", <<20>>, 1},
+            {"image/gif", <<30>>, 2}
+          ] do
         %Fountain.Conversations.TurnImage{}
         |> Fountain.Conversations.TurnImage.changeset(%{
           turn_id: turn.id,
@@ -1863,10 +1924,11 @@ defmodule Fountain.ConversationsContextTest do
     test "to_atom_map with an unknown string key does not crash and returns the string as fallback" do
       # \"xyzquuxfoo_novel_key_never_an_atom\" is not an existing Elixir atom,
       # so safe_to_existing_atom triggers its rescue clause and returns the string key.
-      result = Fountain.Factory.to_atom_map(%{
-        "sprite_name" => "test-sprite",
-        "xyzquuxfoo_novel_key_never_an_atom" => "ignored_value"
-      })
+      result =
+        Fountain.Factory.to_atom_map(%{
+          "sprite_name" => "test-sprite",
+          "xyzquuxfoo_novel_key_never_an_atom" => "ignored_value"
+        })
 
       assert Map.get(result, :sprite_name) == "test-sprite"
       # The unknown key is preserved as a string (fallback)
@@ -1931,6 +1993,7 @@ defmodule Fountain.ConversationsContextTest do
       conv = insert_conversation(user_id: user.id)
 
       [result] = Conversations.list_conversations(user.id)
+
       assert DateTime.compare(
                result.last_active_at,
                DateTime.from_naive!(result.inserted_at, "Etc/UTC")
@@ -1945,7 +2008,11 @@ defmodule Fountain.ConversationsContextTest do
       insert_log_event(conv, kind: "output", stream: "stdout", inserted_at: later)
 
       [result] = Conversations.list_conversations(user.id)
-      assert DateTime.compare(result.last_active_at, DateTime.from_naive!(conv.inserted_at, "Etc/UTC")) == :gt
+
+      assert DateTime.compare(
+               result.last_active_at,
+               DateTime.from_naive!(conv.inserted_at, "Etc/UTC")
+             ) == :gt
     end
 
     test "stage events (reconnects) do NOT advance last_active_at" do

--- a/apps/fountain/test/fountain_web/controllers/turn_image_ingest_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/turn_image_ingest_test.exs
@@ -1,0 +1,168 @@
+defmodule FountainWeb.TurnImageIngestTest do
+  @moduledoc """
+  What the API accepts as a turn image.
+
+  #202 stopped hostile rows being *served*. This is the other half: they should
+  not be storable either, and a malformed request should say so rather than
+  looking like a server fault.
+
+  Two layers answer here, and it is worth knowing which. `OpenApiSpex`
+  `CastAndValidate` already enforces the `ImageInput` schema — including the
+  `media_type` enum — and rejects those with 422 before the controller runs. It
+  does not decode base64 and does not know about the size limit, so those
+  reached `decode_images/1`, which called `Base.decode64!` and `raise`d an
+  unrescued `ArgumentError`: both surfaced as a 500, telling a client with a
+  malformed request that the server was broken.
+
+  So the assertions below accept either 4xx where the spec layer gets there
+  first, and pin 400 exactly where the controller is the only thing checking.
+  The context-level guard that makes all of this defence in depth rather than a
+  single boundary is in `Conversations.insert_turn_images/2`.
+  """
+
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    agent = insert_agent(user_id: user.id)
+    {:ok, user: user, raw_key: raw_key, agent: agent}
+  end
+
+  defp png, do: Base.encode64(<<0x89, 0x50, 0x4E, 0x47>>)
+
+  defp post_create(conn, raw_key, agent, images) do
+    conn
+    |> authed_with_key(raw_key)
+    |> post_json("/api/conversations", %{"agent_id" => agent.id, "images" => images})
+  end
+
+  describe "media type" do
+    test "a disallowed type is a 400, not a 500 and not a stored row", %{
+      conn: conn,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      conn =
+        post_create(conn, raw_key, agent, [%{"media_type" => "text/html", "data" => png()}])
+
+      assert conn.status in [400, 422]
+      assert conn.resp_body =~ "media_type" or conn.resp_body =~ "Invalid value"
+    end
+
+    test "a missing type is refused", %{conn: conn, raw_key: raw_key, agent: agent} do
+      conn = post_create(conn, raw_key, agent, [%{"data" => png()}])
+      assert conn.status in [400, 422]
+    end
+
+    test "every allowed type is accepted", %{raw_key: raw_key, agent: agent} do
+      stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
+
+      for type <- Conversations.TurnImage.valid_media_types() do
+        conn =
+          build_conn()
+          |> post_create(raw_key, agent, [%{"media_type" => type, "data" => png()}])
+
+        assert conn.status in [200, 201], "#{type} was rejected with #{conn.status}"
+      end
+    end
+  end
+
+  describe "payload" do
+    test "data that is not base64 is a 400 rather than a 500", %{
+      conn: conn,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      conn =
+        post_create(conn, raw_key, agent, [
+          %{"media_type" => "image/png", "data" => "not base64 !!!"}
+        ])
+
+      assert json_response(conn, 400)["error"] =~ "base64"
+    end
+
+    test "missing data is a 400", %{conn: conn, raw_key: raw_key, agent: agent} do
+      conn = post_create(conn, raw_key, agent, [%{"media_type" => "image/png"}])
+      assert conn.status in [400, 422]
+    end
+
+    test "an oversized image is a client error, not a 500" do
+      # A body this large never reaches the controller: it exceeds the parser's
+      # read length, so Plug.Parsers rejects it. That path used to raise a
+      # MatchError inside CachingBodyReader and surface as a 500 for every
+      # endpoint — fixed here, so it is now the 413 it should always have been.
+      oversized = Base.encode64(:binary.copy(<<0>>, 10 * 1024 * 1024 + 1))
+      user = insert_verified_user()
+      {_key, raw_key} = insert_api_key(user)
+      agent = insert_agent(user_id: user.id)
+
+      assert_raise Plug.Parsers.RequestTooLargeError, fn ->
+        post_create(build_conn(), raw_key, agent, [
+          %{"media_type" => "image/png", "data" => oversized}
+        ])
+      end
+    end
+
+    test "the controller still guards the size itself" do
+      # Defence in depth: the parser limit is configuration and could be raised,
+      # and this is the check that keeps a 10MB ceiling meaningful if it is.
+      big = :binary.copy(<<0>>, 10 * 1024 * 1024 + 1)
+
+      assert {:error, msg} =
+               FountainWeb.ConversationController.decode_images_for_test([
+                 %{"media_type" => "image/png", "data" => Base.encode64(big)}
+               ])
+
+      assert msg =~ "10MB"
+    end
+
+    test "a non-object entry is refused", %{conn: conn, raw_key: raw_key, agent: agent} do
+      conn = post_create(conn, raw_key, agent, ["just a string"])
+      assert conn.status in [400, 422]
+    end
+  end
+
+  describe "the prompt endpoint validates the same way" do
+    test "a disallowed type is refused there too", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      # Two entry points take images; validating only one of them would leave
+      # the other as the way in.
+      conv = insert_conversation(user_id: user.id, agent: agent)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations/#{conv.id}/prompts", %{
+          "prompt" => "hi",
+          "images" => [%{"media_type" => "application/octet-stream", "data" => png()}]
+        })
+
+      assert conn.status in [400, 422]
+    end
+  end
+
+  describe "no images" do
+    test "an absent images key is fine", %{conn: conn, raw_key: raw_key, agent: agent} do
+      stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations", %{"agent_id" => agent.id})
+
+      assert conn.status in [200, 201]
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/cross_tenant_isolation_test.exs
+++ b/apps/fountain/test/fountain_web/cross_tenant_isolation_test.exs
@@ -130,19 +130,16 @@ defmodule FountainWeb.CrossTenantIsolationTest do
     end
 
     test "an image stored with a non-image media type is not served", %{conn: conn} do
-      # insert_turn_images/2 goes through Repo.insert_all against a raw table
-      # name, so TurnImage.changeset/2 (and its allowlist) never runs — a
-      # hostile media_type can reach the table. Refuse it at serve time so it
-      # can never come back as active content on the app's origin.
+      # #203 closed the ingest path, so this row can no longer be written through
+      # insert_turn_images/2 — it is inserted raw here on purpose. Rows written
+      # before that fix still exist, and defence at serve time is what keeps
+      # them from coming back as active content on the app's origin.
       {user_a, _user_b, key_a, _key_b} = two_users()
       agent = insert_agent(user_id: user_a.id)
       conv = insert_conversation(user_id: user_a.id, agent: agent)
       turn = insert_turn(conv)
 
-      {:ok, _} =
-        Fountain.Conversations.insert_turn_images(turn.id, [
-          %{media_type: "text/html", data: "<script>alert(1)</script>"}
-        ])
+      insert_raw_turn_image(turn.id, "text/html", "<script>alert(1)</script>")
 
       conn =
         conn
@@ -385,5 +382,20 @@ defmodule FountainWeb.CrossTenantIsolationTest do
       |> post_json("/api/conversations", %{"agent_id" => agent_a.id})
       |> json_response(404)
     end
+  end
+
+  # Bypasses TurnImage.changeset/2 deliberately, to reproduce a row written
+  # before ingest validation existed. Nothing in lib/ writes this way any more.
+  defp insert_raw_turn_image(turn_id, media_type, data) do
+    Fountain.Repo.insert_all("turn_images", [
+      %{
+        id: Ecto.UUID.dump!(Ecto.UUID.generate()),
+        turn_id: Ecto.UUID.dump!(turn_id),
+        position: 0,
+        media_type: media_type,
+        data: data,
+        inserted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      }
+    ])
   end
 end


### PR DESCRIPTION
Closes #203.

`TurnImage.changeset/2` and its media-type allowlist were never called. Every row reached `turn_images` through `Conversations.insert_turn_images/2`, which built raw maps and called `Repo.insert_all` against a raw table-name string — so the allowlist, `validate_required` and the `(turn_id, position)` unique constraint never ran. The schema described validation that nothing performed.

## What changed

**Inserts go through the changeset.** Volume is a handful of rows per turn, so there was no bulk-insert win to protect.

The changeset also gains `foreign_key_constraint(:turn_id)`. Without it a missing turn raises `Ecto.ConstraintError` instead of returning a changeset — and that raise is precisely why validation could not be added here before: the caller hard-matched `{:ok, _}` and would have crashed the `ConversationServer` mid-turn. The caller now logs and continues, because a rejected image must not take a turn down with it. (It deliberately does *not* publish a `turn`/`started` stage event to report this — that event is what the LiveView uses to create a turn row, so it would invent a second turn.)

**`decode_images/1` returns `{:ok, images} | {:error, reason}`** instead of raising. It called `Base.decode64!` and `raise`d an unrescued `ArgumentError` past the size limit; both surfaced as a 500, telling a client with a malformed request that the server was broken.

## A correction to the issue's premise

Writing the tests turned up that `OpenApiSpex` `CastAndValidate` already enforces the `ImageInput` schema — including the `media_type` enum — on both entry points, rejecting a hostile type with 422 before the controller runs. So the "a client can store an arbitrary media_type" claim doesn't hold through the public API as it stands today.

What genuinely wasn't covered is everything below that boundary: the context-level insert (any internal caller, and any future route that doesn't declare the schema), plus base64 validity and the size limit, which the spec layer doesn't check at all. The fix is worth having as defence in depth and to make the schema honest, but I didn't want the PR implying it closed a live hole that the spec layer was already covering.

## A real bug found on the way

`FountainWeb.CachingBodyReader.read_body/2` hard-matched `{:ok, body, conn}` from `Plug.Conn.read_body/2`. Any request larger than the parser's read length — where `read_body` returns `{:more, ...}` — raised a `MatchError` and surfaced as a **500 on every endpoint**, instead of the 413 `Plug.Parsers` produces when told the body didn't fit. That's how I found it: the oversized-image test 500'd for the wrong reason.

Now all three branches are passed through. The partial body is deliberately not cached — the Stripe webhook verifier would otherwise compute a signature over something that was never sent.

## Tests

The #202 serve-side test that stored a `text/html` row now inserts it raw on purpose, with a comment saying why: the ingest path refuses it, but rows written before this fix still exist and serve-time refusal is what keeps them inert.

The size guard is tested directly rather than over HTTP, since a body big enough to trip it is rejected by the parser first — and that fact is now itself a test.

Full suite: 1429 tests, 0 failures. Format, warnings-as-errors and credo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)