### PR TITLE
test(api): cover the SSE loop — replay, filter, live tail, heartbeats, idle

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -302,7 +302,17 @@ defmodule FountainWeb.ConversationController do
     ]
   )
 
-  @heartbeat_ms 15_000
+  # Both read from application env so the loop can be driven at test speed.
+  # Waiting 15s for a heartbeat and 60s for the idle exit is why none of this
+  # had tests: the timings are the behaviour, and the behaviour was unreachable.
+  @default_heartbeat_ms 15_000
+  @default_idle_timeout_ms 60_000
+
+  defp heartbeat_ms,
+    do: Application.get_env(:fountain, :sse_heartbeat_ms, @default_heartbeat_ms)
+
+  defp idle_timeout_ms,
+    do: Application.get_env(:fountain, :sse_idle_timeout_ms, @default_idle_timeout_ms)
 
   def stream(conn, %{"conversation_id" => id} = params) do
     user = conn.assigns.current_user
@@ -336,7 +346,7 @@ defmodule FountainWeb.ConversationController do
         {conn, last_id} = replay(conn, id, last_event_id, streams)
 
         if wait? do
-          Process.send_after(self(), :heartbeat, @heartbeat_ms)
+          Process.send_after(self(), :heartbeat, heartbeat_ms())
           sse_loop(conn, last_id, streams)
         else
           # `?wait=false` → close immediately after replay. Useful when
@@ -481,14 +491,14 @@ defmodule FountainWeb.ConversationController do
       :heartbeat ->
         case Plug.Conn.chunk(conn, ": heartbeat\n\n") do
           {:ok, conn} ->
-            Process.send_after(self(), :heartbeat, @heartbeat_ms)
+            Process.send_after(self(), :heartbeat, heartbeat_ms())
             sse_loop(conn, last_id, streams)
 
           {:error, _} ->
             conn
         end
     after
-      60_000 ->
+      idle_timeout_ms() ->
         # Long quiet — exit cleanly so the client reconnects.
         conn
     end

--- a/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
@@ -1,0 +1,246 @@
+defmodule FountainWeb.SseStreamTest do
+  @moduledoc """
+  The SSE loop itself: replay from `Last-Event-ID`, the live PubSub tail, the
+  `?streams=` filter, heartbeats, and the idle exit.
+
+  None of it was tested. The endpoint had coverage for "does it return 200",
+  which is how a blanket 406 shipped (#201) and how #196's silent mid-turn exit
+  went unnoticed — the loop is the part that carries every CLI user's output and
+  the dashboard log viewer.
+
+  The timings are the behaviour here, and waiting 15s for a heartbeat and 60s
+  for the idle exit is why this was never covered. Both are now read from
+  application env, so these drive the real loop at milliseconds.
+  """
+
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.ConnTest, only: [build_conn: 0]
+
+  @endpoint FountainWeb.Endpoint
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    conv = insert_conversation(user_id: user.id)
+
+    previous = {
+      Application.get_env(:fountain, :sse_heartbeat_ms),
+      Application.get_env(:fountain, :sse_idle_timeout_ms)
+    }
+
+    on_exit(fn ->
+      {hb, idle} = previous
+
+      if hb,
+        do: Application.put_env(:fountain, :sse_heartbeat_ms, hb),
+        else: Application.delete_env(:fountain, :sse_heartbeat_ms)
+
+      if idle,
+        do: Application.put_env(:fountain, :sse_idle_timeout_ms, idle),
+        else: Application.delete_env(:fountain, :sse_idle_timeout_ms)
+    end)
+
+    Ecto.Adapters.SQL.Sandbox.mode(Fountain.Repo, {:shared, self()})
+
+    {:ok, user: user, raw_key: raw_key, conv: conv}
+  end
+
+  defp fast_loop(heartbeat_ms, idle_ms) do
+    Application.put_env(:fountain, :sse_heartbeat_ms, heartbeat_ms)
+    Application.put_env(:fountain, :sse_idle_timeout_ms, idle_ms)
+  end
+
+  # Writes the row and puts it on the topic, which is what ConversationServer
+  # and Provisioning do — Conversations.log!/1 only persists, so a test using it
+  # alone would silently exercise nothing.
+  defp publish(conv, attrs) do
+    ev = insert_log_event(conv, attrs)
+    Phoenix.PubSub.broadcast(Fountain.PubSub, "conv:#{conv.id}", {:log_event, ev})
+    ev
+  end
+
+  defp stream(raw_key, path, headers \\ []) do
+    conn =
+      Enum.reduce(headers, authed_with_key(build_conn(), raw_key), fn {k, v}, c ->
+        Plug.Conn.put_req_header(c, k, v)
+      end)
+
+    Phoenix.ConnTest.dispatch(conn, @endpoint, :get, path)
+  end
+
+  describe "replay" do
+    test "drains buffered events and closes with wait=false", %{raw_key: key, conv: conv} do
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "first"})
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "second"})
+
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "first"
+      assert conn.resp_body =~ "second"
+    end
+
+    test "Last-Event-ID replays only what came after it", %{raw_key: key, conv: conv} do
+      first = insert_log_event(conv, %{kind: "output", stream: "stdout", data: "already-seen"})
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "missed-this"})
+
+      conn =
+        stream(key, "/api/conversations/#{conv.id}/stream?wait=false", [
+          {"last-event-id", to_string(first.id)}
+        ])
+
+      # The point of the header: a client that reconnects must not be handed
+      # output it already printed.
+      refute conn.resp_body =~ "already-seen"
+      assert conn.resp_body =~ "missed-this"
+    end
+
+    test "events carry an id, so a client can resume from them", %{raw_key: key, conv: conv} do
+      ev = insert_log_event(conv, %{kind: "output", stream: "stdout", data: "x"})
+
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert conn.resp_body =~ "id: #{ev.id}"
+    end
+
+    test "a garbage Last-Event-ID replays everything rather than nothing", %{
+      raw_key: key,
+      conv: conv
+    } do
+      # Falling back to "send nothing" would lose output silently, which is the
+      # worse direction to be wrong in.
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "keep-me"})
+
+      conn =
+        stream(key, "/api/conversations/#{conv.id}/stream?wait=false", [
+          {"last-event-id", "not-a-number"}
+        ])
+
+      assert conn.resp_body =~ "keep-me"
+    end
+  end
+
+  describe "the streams filter" do
+    setup %{conv: conv} do
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "on-stdout"})
+      insert_log_event(conv, %{kind: "output", stream: "stderr", data: "on-stderr"})
+      insert_log_event(conv, %{kind: "stage", stream: "", stage: "provision", state: "done"})
+      :ok
+    end
+
+    test "no filter sends everything", %{raw_key: key, conv: conv} do
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert conn.resp_body =~ "on-stdout"
+      assert conn.resp_body =~ "on-stderr"
+      assert conn.resp_body =~ "event: stage"
+    end
+
+    test "a single stream excludes the others", %{raw_key: key, conv: conv} do
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false&streams=stdout")
+
+      assert conn.resp_body =~ "on-stdout"
+      refute conn.resp_body =~ "on-stderr"
+      refute conn.resp_body =~ "event: stage"
+    end
+
+    test "several streams can be combined", %{raw_key: key, conv: conv} do
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false&streams=stderr,stage")
+
+      refute conn.resp_body =~ "on-stdout"
+      assert conn.resp_body =~ "on-stderr"
+      assert conn.resp_body =~ "event: stage"
+    end
+  end
+
+  describe "the live tail" do
+    test "an event published while connected is streamed", %{raw_key: key, conv: conv} do
+      # The request has to run in its own process: the loop blocks on `receive`,
+      # so the broadcast has to come from somewhere else.
+      fast_loop(60_000, 600)
+
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+          stream(key, "/api/conversations/#{conv.id}/stream")
+        end)
+
+      # Give the loop time to subscribe before publishing.
+      Process.sleep(300)
+
+      publish(conv, %{kind: "output", stream: "stdout", data: "live-event"})
+
+      conn = Task.await(task, 5_000)
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "live-event"
+    end
+
+    test "a filtered-out live event is not streamed", %{raw_key: key, conv: conv} do
+      fast_loop(60_000, 600)
+
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+          stream(key, "/api/conversations/#{conv.id}/stream?streams=stdout")
+        end)
+
+      Process.sleep(300)
+
+      publish(conv, %{kind: "output", stream: "stderr", data: "filtered-out"})
+      publish(conv, %{kind: "output", stream: "stdout", data: "wanted"})
+
+      conn = Task.await(task, 5_000)
+
+      assert conn.resp_body =~ "wanted"
+      refute conn.resp_body =~ "filtered-out"
+    end
+  end
+
+  describe "heartbeats and the idle exit" do
+    test "a quiet stream closes so the client can reconnect", %{raw_key: key, conv: conv} do
+      # Heartbeat set beyond the test's life so none arrives: this exercises the
+      # `after` clause on its own.
+      fast_loop(60_000, 250)
+
+      started = System.monotonic_time(:millisecond)
+      conn = stream(key, "/api/conversations/#{conv.id}/stream")
+      elapsed = System.monotonic_time(:millisecond) - started
+
+      assert conn.status == 200
+      refute conn.resp_body =~ "heartbeat"
+      assert elapsed < 3_000, "the idle timeout did not fire (took #{elapsed}ms)"
+    end
+
+    test "heartbeats hold the connection open past the idle timeout", %{
+      raw_key: key,
+      conv: conv
+    } do
+      # Worth being explicit about, because it is not what the constants
+      # suggest: every `:heartbeat` is a message, and a message restarts the
+      # `receive ... after` timer. With the production values — 15s heartbeat,
+      # 60s idle — the idle branch can therefore never fire while the client is
+      # still attached. The stream ends when `Plug.Conn.chunk/2` fails because
+      # the client went away, not on a timer.
+      #
+      # That matters for reading #196: the CLI's silent mid-turn exit was not
+      # the server hanging up after 60s of quiet, because the server does not
+      # do that.
+      fast_loop(50, 200)
+
+      task = Task.async(fn -> stream(key, "/api/conversations/#{conv.id}/stream") end)
+
+      # Well past the 200ms idle window. Still running means the heartbeats are
+      # being delivered, chunked and rescheduled.
+      Process.sleep(700)
+      assert Process.alive?(task.pid), "the loop exited despite heartbeats"
+
+      Task.shutdown(task, :brutal_kill)
+    end
+  end
+end


### PR DESCRIPTION
Closes #193.

The stream endpoint had tests for "does it return 200" and nothing for the loop that carries every CLI user's output and the dashboard log viewer. That gap is how a blanket 406 shipped (#201).

The timings *are* the behaviour here, and waiting 15s for a heartbeat and 60s for the idle exit is why this was never covered. `@heartbeat_ms` and the idle timeout now read from application env — production values unchanged as defaults — so the tests drive the real loop at milliseconds instead of mocking it.

Covered: replay with and without `Last-Event-ID`, that a garbage `Last-Event-ID` replays everything rather than nothing (losing output silently is the worse direction to be wrong in), that events carry an `id` so a client can resume, the `?streams=` filter over both replayed and live events, the live PubSub tail, heartbeat emission, and the idle exit.

## Two things surfaced while writing them

**`Conversations.log!/1` doesn't broadcast.** It only persists — the broadcast lives in `ConversationServer` and `Provisioning`. A live-tail test built on `log!` alone writes a row, publishes nothing, and passes while exercising none of the loop. My first draft did exactly that and "passed" with an empty response body. The helper now does both, which is what production does.

**The 60s idle exit cannot fire while a client is attached.** Every `:heartbeat` is a message, and a message restarts the `receive ... after` timer — so a 15s heartbeat against a 60s idle window resets the timer four times over before it could expire. The stream ends when `Plug.Conn.chunk/2` fails because the client went away, not on a timer.

That's worth knowing when reading #196, which attributes the CLI's silent mid-turn exit to "the server closes the SSE loop after 60 seconds of quiet". The server doesn't do that. The CLI-side fix (reconnect with `Last-Event-ID` instead of treating EOF as success) was right regardless, but the stated mechanism wasn't the server hanging up.

I've left the behaviour alone rather than "fixing" it in a test PR — a stream that lives until the client disconnects is reasonable for SSE, and `chunk/2` failing is what reclaims it. Two tests pin both halves so the next person doesn't have to re-derive it: the idle branch works when heartbeats are disabled, and heartbeats hold the connection open past the window when they aren't.

Full suite: 1440 tests, 0 failures. Format, warnings-as-errors and strict credo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)