### PR TITLE
fix: wire up the API filters and help topics the docs already promised

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -136,8 +136,10 @@ defmodule Fountain.Agents do
   defp apply_search(query, ""), do: query
 
   defp apply_search(query, search) do
+    # ilike, not like: a case-sensitive search box is a broken one, and this
+    # backs both the agents list in the UI and the documented ?search= param.
     term = "%#{search}%"
-    from a in query, where: like(a.name, ^term)
+    from a in query, where: ilike(a.name, ^term)
   end
 
   defp apply_runtimes(query, []), do: query

--- a/apps/fountain/lib/fountain/help.ex
+++ b/apps/fountain/lib/fountain/help.ex
@@ -1,0 +1,56 @@
+defmodule Fountain.Help do
+  @moduledoc """
+  The canonical list of in-app help topics.
+
+  There used to be two hand-maintained copies — one in `HelpLive.Show`, one in
+  `LlmsController` — with a comment on the second saying "keep them in sync".
+  They were not in sync: the LiveView was missing `secrets-managers` and the
+  controller was missing `skills`, so `/llms.txt` advertised a URL that flashed
+  "No such help topic" and redirected, while the in-app nav hid a page that
+  `/llms-full.txt` served in full.
+
+  One list, and a test that checks it against `priv/help/` in both directions,
+  so a new topic file with no entry (or an entry with no file) fails rather than
+  drifting.
+  """
+
+  @topics [
+    {"quickstart", "Quickstart"},
+    {"agents", "Agents"},
+    {"skills", "Skills"},
+    {"environments", "Environments"},
+    {"vaults", "Vaults"},
+    {"manifest", "Manifest"},
+    {"spawning", "Spawning sub-agents"},
+    {"api", "API reference"},
+    {"secrets-managers", "Secrets managers"},
+    {"for-llms", "For LLMs"},
+    {"runbook", "Operating"}
+  ]
+
+  @doc "`{slug, title}` pairs, in nav order."
+  @spec topics() :: [{String.t(), String.t()}]
+  def topics, do: @topics
+
+  @doc "Just the slugs."
+  @spec slugs() :: [String.t()]
+  def slugs, do: Enum.map(@topics, &elem(&1, 0))
+
+  @doc "Whether a slug is a real topic."
+  @spec topic?(String.t()) :: boolean()
+  def topic?(slug), do: slug in slugs()
+
+  @doc "Absolute path to the directory holding the topic markdown."
+  @spec dir() :: String.t()
+  def dir, do: Path.join(:code.priv_dir(:fountain) |> to_string(), "help")
+
+  @doc "Markdown files present on disk, as slugs. The other half of the check."
+  @spec files() :: [String.t()]
+  def files do
+    dir()
+    |> File.ls!()
+    |> Enum.filter(&String.ends_with?(&1, ".md"))
+    |> Enum.map(&Path.rootname/1)
+    |> Enum.sort()
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
@@ -15,15 +15,73 @@ defmodule FountainWeb.AgentController do
 
   operation(:index,
     summary: "List agents",
+    parameters: [
+      search: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Case-insensitive substring match on the agent name."
+      ],
+      runtime: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Comma-separated runtimes, e.g. `claude,codex`."
+      ],
+      environment_id: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Comma-separated environment ids."
+      ],
+      has_skills: [
+        in: :query,
+        type: :boolean,
+        required: false,
+        description: "Only agents with at least one skill."
+      ],
+      has_mcp: [
+        in: :query,
+        type: :boolean,
+        required: false,
+        description: "Only agents with at least one MCP server."
+      ]
+    ],
     responses: [
       ok: {"Agents", "application/json", Schemas.AgentListResponse}
     ]
   )
 
-  def index(conn, _params) do
+  # docs/api.md has documented ?search= and ?runtime= since launch, and the
+  # filters have been implemented in Agents.list_agents/2 the whole time — but
+  # this action passed `[]` and ignored every param, so the documented
+  # behaviour only ever worked in the LiveView.
+  def index(conn, params) do
     user = conn.assigns.current_user
-    render(conn, :index, agents: Agents.list_agents(user.id, []))
+    render(conn, :index, agents: Agents.list_agents(user.id, agent_filters(params)))
   end
+
+  defp agent_filters(params) do
+    [
+      search: params["search"] || "",
+      runtimes: csv(params["runtime"]),
+      env_ids: csv(params["environment_id"]),
+      has_skills: truthy(params["has_skills"]),
+      has_mcp: truthy(params["has_mcp"])
+    ]
+  end
+
+  defp csv(nil), do: []
+  defp csv(""), do: []
+
+  defp csv(value) when is_binary(value),
+    do: value |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+
+  defp csv(value) when is_list(value), do: value
+  defp csv(_), do: []
+
+  defp truthy(v) when v in [true, "true", "1"], do: true
+  defp truthy(_), do: false
 
   operation(:show,
     summary: "Get an agent",

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -294,6 +294,25 @@ defmodule FountainWeb.ConversationController do
         description:
           "Resume after this event id (integer as string). " <>
             "Missing or unparseable values are treated as 0."
+      ],
+      # Both load-bearing in the bundled SKILL.md files and undocumented here
+      # until now.
+      streams: [
+        in: :query,
+        type: :string,
+        required: false,
+        description:
+          "Comma-separated subset of `stdout`, `stderr`, `stage`. " <>
+            "Omitted or empty means all three."
+      ],
+      wait: [
+        in: :query,
+        type: :string,
+        required: false,
+        description:
+          "`false`/`0` drains the buffered events and closes immediately, " <>
+            "rather than holding the connection open for the live tail. " <>
+            "Defaults to true."
       ]
     ],
     responses: [

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -302,7 +302,17 @@ defmodule FountainWeb.ConversationController do
     ]
   )
 
-  @heartbeat_ms 15_000
+  # Both read from application env so the loop can be driven at test speed.
+  # Waiting 15s for a heartbeat and 60s for the idle exit is why none of this
+  # had tests: the timings are the behaviour, and the behaviour was unreachable.
+  @default_heartbeat_ms 15_000
+  @default_idle_timeout_ms 60_000
+
+  defp heartbeat_ms,
+    do: Application.get_env(:fountain, :sse_heartbeat_ms, @default_heartbeat_ms)
+
+  defp idle_timeout_ms,
+    do: Application.get_env(:fountain, :sse_idle_timeout_ms, @default_idle_timeout_ms)
 
   def stream(conn, %{"conversation_id" => id} = params) do
     user = conn.assigns.current_user
@@ -336,7 +346,7 @@ defmodule FountainWeb.ConversationController do
         {conn, last_id} = replay(conn, id, last_event_id, streams)
 
         if wait? do
-          Process.send_after(self(), :heartbeat, @heartbeat_ms)
+          Process.send_after(self(), :heartbeat, heartbeat_ms())
           sse_loop(conn, last_id, streams)
         else
           # `?wait=false` → close immediately after replay. Useful when
@@ -481,14 +491,14 @@ defmodule FountainWeb.ConversationController do
       :heartbeat ->
         case Plug.Conn.chunk(conn, ": heartbeat\n\n") do
           {:ok, conn} ->
-            Process.send_after(self(), :heartbeat, @heartbeat_ms)
+            Process.send_after(self(), :heartbeat, heartbeat_ms())
             sse_loop(conn, last_id, streams)
 
           {:error, _} ->
             conn
         end
     after
-      60_000 ->
+      idle_timeout_ms() ->
         # Long quiet — exit cleanly so the client reconnects.
         conn
     end

--- a/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
@@ -17,21 +17,6 @@ defmodule FountainWeb.LlmsController do
 
   use FountainWeb, :controller
 
-  # Topic order mirrors FountainWeb.HelpLive.Show — keep them in sync so the
-  # bundled doc reads the same as the in-app nav.
-  @help_topics [
-    {"quickstart", "Quickstart"},
-    {"agents", "Agents"},
-    {"environments", "Environments"},
-    {"vaults", "Vaults"},
-    {"manifest", "Manifest"},
-    {"spawning", "Spawning sub-agents"},
-    {"api", "API reference"},
-    {"secrets-managers", "Secrets managers"},
-    {"for-llms", "For LLMs"},
-    {"runbook", "Operating"}
-  ]
-
   def index(conn, _params) do
     send_text(conn, render_index(base_url()))
   end
@@ -119,7 +104,7 @@ defmodule FountainWeb.LlmsController do
   end
 
   defp bundled_help_sections do
-    Enum.map(@help_topics, fn {slug, title} ->
+    Enum.map(Fountain.Help.topics(), fn {slug, title} ->
       body = read_help(slug)
       ["\n\n## ", title, " (`/help/", slug, "`)\n\n", body, "\n"]
     end)

--- a/apps/fountain/lib/fountain_web/live/help_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/help_live/show.ex
@@ -11,28 +11,15 @@ defmodule FountainWeb.HelpLive.Show do
 
   use FountainWeb, :live_view
 
-  @topics [
-    {"quickstart", "Quickstart"},
-    {"agents", "Agents"},
-    {"skills", "Skills"},
-    {"environments", "Environments"},
-    {"vaults", "Vaults"},
-    {"manifest", "Manifest"},
-    {"spawning", "Spawning sub-agents"},
-    {"api", "API reference"},
-    {"for-llms", "For LLMs"},
-    {"runbook", "Operating"}
-  ]
-
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :topics, @topics)}
+    {:ok, assign(socket, :topics, Fountain.Help.topics())}
   end
 
   @impl true
   def handle_params(params, _uri, socket) do
     slug = params["topic"] || "quickstart"
-    topic = Enum.find(@topics, fn {s, _} -> s == slug end)
+    topic = Enum.find(Fountain.Help.topics(), fn {s, _} -> s == slug end)
 
     case topic do
       nil ->

--- a/apps/fountain/test/fountain/help_test.exs
+++ b/apps/fountain/test/fountain/help_test.exs
@@ -1,0 +1,40 @@
+defmodule Fountain.HelpTest do
+  @moduledoc """
+  The help topic list against what is actually on disk.
+
+  There used to be two hand-maintained copies of this list — one in
+  `HelpLive.Show`, one in `LlmsController`, with a comment on the second saying
+  "keep them in sync". They were not: `/llms.txt` advertised
+  `/help/secrets-managers`, which the in-app list did not know, so following the
+  link flashed "No such help topic" and redirected. The reverse hole existed
+  too — `skills` was in the nav and missing from the bundle.
+
+  One list now, and these check it in both directions so the next drift is a
+  test failure rather than a dead link.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Fountain.Help
+
+  test "every topic has a markdown file" do
+    missing = Help.slugs() -- Help.files()
+    assert missing == [], "topics with no file in priv/help: #{inspect(missing)}"
+  end
+
+  test "every markdown file is a listed topic" do
+    # The direction that produced the original bug: a file exists and is served
+    # in /llms-full.txt while the nav hides it.
+    unlisted = Help.files() -- Help.slugs()
+    assert unlisted == [], "files in priv/help with no topic entry: #{inspect(unlisted)}"
+  end
+
+  test "slugs are unique" do
+    assert Enum.uniq(Help.slugs()) == Help.slugs()
+  end
+
+  test "the topic that started this is present" do
+    assert Help.topic?("secrets-managers")
+    assert Help.topic?("skills")
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/agent_filter_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_filter_test.exs
@@ -1,0 +1,80 @@
+defmodule FountainWeb.AgentFilterTest do
+  @moduledoc """
+  `GET /api/agents` filters.
+
+  `docs/api.md` has documented `?search=` and `?runtime=` since launch, and
+  `Agents.list_agents/2` has implemented search, runtimes, environments, skills
+  and MCP the whole time — but the controller passed `[]` and ignored every
+  param, so the documented behaviour only ever worked in the LiveView.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    env = insert_env(user_id: user.id)
+
+    claude =
+      insert_agent(
+        user_id: user.id,
+        name: "billing-reconciler",
+        runtime: "claude",
+        environment_id: env.id,
+        skills: [%{"name" => "s", "content" => "# s"}]
+      )
+
+    codex = insert_agent(user_id: user.id, name: "docs-writer", runtime: "codex")
+
+    {:ok, raw_key: raw_key, env: env, claude: claude, codex: codex}
+  end
+
+  defp names(conn), do: conn |> json_response(200) |> Map.fetch!("data") |> Enum.map(& &1["name"])
+
+  defp list(conn, key, query \\ "") do
+    conn |> authed_with_key(key) |> get("/api/agents" <> query)
+  end
+
+  test "no filters lists everything", %{conn: conn, raw_key: key} do
+    assert length(names(list(conn, key))) == 2
+  end
+
+  test "search matches on name", %{conn: conn, raw_key: key} do
+    assert names(list(conn, key, "?search=billing")) == ["billing-reconciler"]
+  end
+
+  test "search is case-insensitive", %{conn: conn, raw_key: key} do
+    assert names(list(conn, key, "?search=BILLING")) == ["billing-reconciler"]
+  end
+
+  test "runtime filters", %{conn: conn, raw_key: key} do
+    assert names(list(conn, key, "?runtime=codex")) == ["docs-writer"]
+  end
+
+  test "runtime accepts a comma-separated list", %{conn: conn, raw_key: key} do
+    assert length(names(list(conn, key, "?runtime=claude,codex"))) == 2
+  end
+
+  test "environment_id filters", %{conn: conn, raw_key: key, env: env} do
+    assert names(list(conn, key, "?environment_id=#{env.id}")) == ["billing-reconciler"]
+  end
+
+  test "has_skills filters", %{conn: conn, raw_key: key} do
+    assert names(list(conn, key, "?has_skills=true")) == ["billing-reconciler"]
+  end
+
+  test "an empty filter value is ignored rather than matching nothing", %{
+    conn: conn,
+    raw_key: key
+  } do
+    # A client building a query string from optional fields sends these.
+    assert length(names(list(conn, key, "?search=&runtime="))) == 2
+  end
+
+  test "filters still respect tenancy", %{conn: conn, raw_key: key} do
+    other = insert_verified_user()
+    insert_agent(user_id: other.id, name: "billing-someone-elses", runtime: "claude")
+
+    assert names(list(conn, key, "?search=billing")) == ["billing-reconciler"]
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
@@ -1,0 +1,246 @@
+defmodule FountainWeb.SseStreamTest do
+  @moduledoc """
+  The SSE loop itself: replay from `Last-Event-ID`, the live PubSub tail, the
+  `?streams=` filter, heartbeats, and the idle exit.
+
+  None of it was tested. The endpoint had coverage for "does it return 200",
+  which is how a blanket 406 shipped (#201) and how #196's silent mid-turn exit
+  went unnoticed — the loop is the part that carries every CLI user's output and
+  the dashboard log viewer.
+
+  The timings are the behaviour here, and waiting 15s for a heartbeat and 60s
+  for the idle exit is why this was never covered. Both are now read from
+  application env, so these drive the real loop at milliseconds.
+  """
+
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.ConnTest, only: [build_conn: 0]
+
+  @endpoint FountainWeb.Endpoint
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    conv = insert_conversation(user_id: user.id)
+
+    previous = {
+      Application.get_env(:fountain, :sse_heartbeat_ms),
+      Application.get_env(:fountain, :sse_idle_timeout_ms)
+    }
+
+    on_exit(fn ->
+      {hb, idle} = previous
+
+      if hb,
+        do: Application.put_env(:fountain, :sse_heartbeat_ms, hb),
+        else: Application.delete_env(:fountain, :sse_heartbeat_ms)
+
+      if idle,
+        do: Application.put_env(:fountain, :sse_idle_timeout_ms, idle),
+        else: Application.delete_env(:fountain, :sse_idle_timeout_ms)
+    end)
+
+    Ecto.Adapters.SQL.Sandbox.mode(Fountain.Repo, {:shared, self()})
+
+    {:ok, user: user, raw_key: raw_key, conv: conv}
+  end
+
+  defp fast_loop(heartbeat_ms, idle_ms) do
+    Application.put_env(:fountain, :sse_heartbeat_ms, heartbeat_ms)
+    Application.put_env(:fountain, :sse_idle_timeout_ms, idle_ms)
+  end
+
+  # Writes the row and puts it on the topic, which is what ConversationServer
+  # and Provisioning do — Conversations.log!/1 only persists, so a test using it
+  # alone would silently exercise nothing.
+  defp publish(conv, attrs) do
+    ev = insert_log_event(conv, attrs)
+    Phoenix.PubSub.broadcast(Fountain.PubSub, "conv:#{conv.id}", {:log_event, ev})
+    ev
+  end
+
+  defp stream(raw_key, path, headers \\ []) do
+    conn =
+      Enum.reduce(headers, authed_with_key(build_conn(), raw_key), fn {k, v}, c ->
+        Plug.Conn.put_req_header(c, k, v)
+      end)
+
+    Phoenix.ConnTest.dispatch(conn, @endpoint, :get, path)
+  end
+
+  describe "replay" do
+    test "drains buffered events and closes with wait=false", %{raw_key: key, conv: conv} do
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "first"})
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "second"})
+
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "first"
+      assert conn.resp_body =~ "second"
+    end
+
+    test "Last-Event-ID replays only what came after it", %{raw_key: key, conv: conv} do
+      first = insert_log_event(conv, %{kind: "output", stream: "stdout", data: "already-seen"})
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "missed-this"})
+
+      conn =
+        stream(key, "/api/conversations/#{conv.id}/stream?wait=false", [
+          {"last-event-id", to_string(first.id)}
+        ])
+
+      # The point of the header: a client that reconnects must not be handed
+      # output it already printed.
+      refute conn.resp_body =~ "already-seen"
+      assert conn.resp_body =~ "missed-this"
+    end
+
+    test "events carry an id, so a client can resume from them", %{raw_key: key, conv: conv} do
+      ev = insert_log_event(conv, %{kind: "output", stream: "stdout", data: "x"})
+
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert conn.resp_body =~ "id: #{ev.id}"
+    end
+
+    test "a garbage Last-Event-ID replays everything rather than nothing", %{
+      raw_key: key,
+      conv: conv
+    } do
+      # Falling back to "send nothing" would lose output silently, which is the
+      # worse direction to be wrong in.
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "keep-me"})
+
+      conn =
+        stream(key, "/api/conversations/#{conv.id}/stream?wait=false", [
+          {"last-event-id", "not-a-number"}
+        ])
+
+      assert conn.resp_body =~ "keep-me"
+    end
+  end
+
+  describe "the streams filter" do
+    setup %{conv: conv} do
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "on-stdout"})
+      insert_log_event(conv, %{kind: "output", stream: "stderr", data: "on-stderr"})
+      insert_log_event(conv, %{kind: "stage", stream: "", stage: "provision", state: "done"})
+      :ok
+    end
+
+    test "no filter sends everything", %{raw_key: key, conv: conv} do
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert conn.resp_body =~ "on-stdout"
+      assert conn.resp_body =~ "on-stderr"
+      assert conn.resp_body =~ "event: stage"
+    end
+
+    test "a single stream excludes the others", %{raw_key: key, conv: conv} do
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false&streams=stdout")
+
+      assert conn.resp_body =~ "on-stdout"
+      refute conn.resp_body =~ "on-stderr"
+      refute conn.resp_body =~ "event: stage"
+    end
+
+    test "several streams can be combined", %{raw_key: key, conv: conv} do
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false&streams=stderr,stage")
+
+      refute conn.resp_body =~ "on-stdout"
+      assert conn.resp_body =~ "on-stderr"
+      assert conn.resp_body =~ "event: stage"
+    end
+  end
+
+  describe "the live tail" do
+    test "an event published while connected is streamed", %{raw_key: key, conv: conv} do
+      # The request has to run in its own process: the loop blocks on `receive`,
+      # so the broadcast has to come from somewhere else.
+      fast_loop(60_000, 600)
+
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+          stream(key, "/api/conversations/#{conv.id}/stream")
+        end)
+
+      # Give the loop time to subscribe before publishing.
+      Process.sleep(300)
+
+      publish(conv, %{kind: "output", stream: "stdout", data: "live-event"})
+
+      conn = Task.await(task, 5_000)
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "live-event"
+    end
+
+    test "a filtered-out live event is not streamed", %{raw_key: key, conv: conv} do
+      fast_loop(60_000, 600)
+
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+          stream(key, "/api/conversations/#{conv.id}/stream?streams=stdout")
+        end)
+
+      Process.sleep(300)
+
+      publish(conv, %{kind: "output", stream: "stderr", data: "filtered-out"})
+      publish(conv, %{kind: "output", stream: "stdout", data: "wanted"})
+
+      conn = Task.await(task, 5_000)
+
+      assert conn.resp_body =~ "wanted"
+      refute conn.resp_body =~ "filtered-out"
+    end
+  end
+
+  describe "heartbeats and the idle exit" do
+    test "a quiet stream closes so the client can reconnect", %{raw_key: key, conv: conv} do
+      # Heartbeat set beyond the test's life so none arrives: this exercises the
+      # `after` clause on its own.
+      fast_loop(60_000, 250)
+
+      started = System.monotonic_time(:millisecond)
+      conn = stream(key, "/api/conversations/#{conv.id}/stream")
+      elapsed = System.monotonic_time(:millisecond) - started
+
+      assert conn.status == 200
+      refute conn.resp_body =~ "heartbeat"
+      assert elapsed < 3_000, "the idle timeout did not fire (took #{elapsed}ms)"
+    end
+
+    test "heartbeats hold the connection open past the idle timeout", %{
+      raw_key: key,
+      conv: conv
+    } do
+      # Worth being explicit about, because it is not what the constants
+      # suggest: every `:heartbeat` is a message, and a message restarts the
+      # `receive ... after` timer. With the production values — 15s heartbeat,
+      # 60s idle — the idle branch can therefore never fire while the client is
+      # still attached. The stream ends when `Plug.Conn.chunk/2` fails because
+      # the client went away, not on a timer.
+      #
+      # That matters for reading #196: the CLI's silent mid-turn exit was not
+      # the server hanging up after 60s of quiet, because the server does not
+      # do that.
+      fast_loop(50, 200)
+
+      task = Task.async(fn -> stream(key, "/api/conversations/#{conv.id}/stream") end)
+
+      # Well past the 200ms idle window. Still running means the heartbeats are
+      # being delivered, chunked and rescheduled.
+      Process.sleep(700)
+      assert Process.alive?(task.pid), "the loop exited despite heartbeats"
+
+      Task.shutdown(task, :brutal_kill)
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,7 +36,7 @@ Requests are rate-limited per API key (or IP for unauthenticated requests). On l
 ## Agents
 
 ```
-GET    /api/agents              # list (supports ?search=, ?runtime=)
+GET    /api/agents              # list (?search=, ?runtime=, ?environment_id=, ?has_skills=, ?has_mcp=)
 POST   /api/agents              # create
 GET    /api/agents/:id
 PUT    /api/agents/:id
@@ -106,7 +106,7 @@ POST   /api/conversations/:id/prompts      # follow-up turn
 POST   /api/conversations/:id/interrupt    # stop the running turn
 POST   /api/conversations/:id/terminate    # end the conversation and sandbox
 GET    /api/conversations/:id/turns
-GET    /api/conversations/:id/stream       # SSE log stream
+GET    /api/conversations/:id/stream       # SSE log stream (?streams=stdout,stderr,stage  ?wait=false)
 ```
 
 ## Error responses


### PR DESCRIPTION
Closes #198. Closes #199.

Two cases of documentation describing behaviour the code didn't have.

## `GET /api/agents` ignored every filter param

`docs/api.md` has listed `?search=` and `?runtime=` since launch, and `Agents.list_agents/2` has implemented search, runtimes, environments, skills and MCP the whole time — but the controller passed `[]`. The filters only ever worked in the LiveView.

They're now passed through, declared in the OpenAPI operation, and the doc line lists all five rather than two.

`apply_search/2` also moves from `like` to `ilike`. A case-sensitive search box is a broken one, and this query backs both the agents list in the UI and the documented param. Caught by a test asserting `?search=BILLING` finds `billing-reconciler`.

## The help topic list had two copies, and they'd drifted

`HelpLive.Show` was missing `secrets-managers`; `LlmsController` was missing `skills` — despite the comment on the second saying "keep them in sync". The visible symptom was the one in the issue: `/llms.txt` advertised `/help/secrets-managers`, which flashed "No such help topic" and redirected. The reverse hole was there too, quieter — `skills` was in the nav and absent from the bundle.

Both now read `Fountain.Help.topics/0`, and a test checks that list against `priv/help/` **in both directions**: a topic with no file fails, and a file with no topic fails. That second direction is the one that produced the original bug, so it's the one worth having.

## Also

The OpenAPI hole on the streaming endpoint: `?streams=` and `?wait=` are load-bearing in both bundled SKILL.md files and were undocumented in the spec, so any client generated from it couldn't use them.

## Not in scope

The issues mention further `docs/api.md` gaps (missing register/forgot/webhook/image routes) and mkdocs nav drift. Those are real but they're documentation-completeness work rather than code that lies about itself, and folding them in would have made this PR hard to review. Happy to do them as a follow-up.

Full suite: 1453 tests, 0 failures. Format, warnings-as-errors and strict credo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)