### PR TITLE
fix(auth): require a provider-verified email before linking an OAuth identity

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
@@ -49,59 +49,66 @@ defmodule FountainWeb.UeberauthController do
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
     provider = to_string(auth.provider)
     provider_uid = to_string(auth.uid)
-    email = get_in(auth.info, [Access.key(:email)])
+    # Not `auth.info.email`: that address can be a GitHub primary that has never
+    # been confirmed, and upsert_oauth_user/3 links any matching address to an
+    # existing account. See FountainWeb.OauthEmail.
+    case FountainWeb.OauthEmail.verified_email(auth) do
+      {:error, reason} ->
+        FountainWeb.Audited.from_conn(conn, "auth.oauth.rejected", "user",
+          metadata: %{"provider" => provider, "reason" => to_string(reason)}
+        )
 
-    if is_nil(email) or email == "" do
-      conn
-      |> put_flash(
-        :error,
-        "GitHub did not return a verified email address. " <>
-          "Please add a public email to your GitHub account and try again."
-      )
-      |> redirect(to: ~p"/auth/login")
-    else
-      attrs = %{"email" => email}
+        conn
+        |> put_flash(:error, FountainWeb.OauthEmail.explain(reason))
+        |> redirect(to: ~p"/auth/login")
 
-      case Fountain.Accounts.upsert_oauth_user(provider, provider_uid, attrs) do
-        {:ok, user, :new} ->
-          FountainWeb.Audited.from_conn(conn, "auth.oauth.signup", "user",
-            user_id: user.id,
-            metadata: %{"provider" => provider}
-          )
+      {:ok, email} ->
+        do_callback(conn, provider, provider_uid, email)
+    end
+  end
 
-          # The email+password path does this after verification. OAuth skips
-          # verification entirely (the provider asserts the address), so without
-          # this every GitHub signup had no Stripe customer and no trial_ends_at.
-          Fountain.Workers.StripeCustomerSync.enqueue(user)
+  defp do_callback(conn, provider, provider_uid, email) do
+    attrs = %{"email" => email}
 
-          conn
-          |> configure_session(renew: true)
-          |> put_session(:user_id, user.id)
-          |> put_session(:session_version, user.session_version)
-          |> redirect(to: ~p"/onboarding/step_1")
+    case Fountain.Accounts.upsert_oauth_user(provider, provider_uid, attrs) do
+      {:ok, user, :new} ->
+        FountainWeb.Audited.from_conn(conn, "auth.oauth.signup", "user",
+          user_id: user.id,
+          metadata: %{"provider" => provider}
+        )
 
-        {:ok, user, :existing} ->
-          FountainWeb.Audited.from_conn(conn, "auth.oauth.login", "user",
-            user_id: user.id,
-            metadata: %{"provider" => provider}
-          )
+        # The email+password path does this after verification. OAuth skips
+        # verification entirely (the provider asserts the address), so without
+        # this every GitHub signup had no Stripe customer and no trial_ends_at.
+        Fountain.Workers.StripeCustomerSync.enqueue(user)
 
-          conn
-          |> configure_session(renew: true)
-          |> put_session(:user_id, user.id)
-          |> put_session(:session_version, user.session_version)
-          |> redirect(to: ~p"/conversations")
+        conn
+        |> configure_session(renew: true)
+        |> put_session(:user_id, user.id)
+        |> put_session(:session_version, user.session_version)
+        |> redirect(to: ~p"/onboarding/step_1")
 
-        {:error, reason} when reason in [:registration_closed, :email_domain_not_allowed] ->
-          conn
-          |> put_flash(:error, "Registration is not open on this instance.")
-          |> redirect(to: ~p"/auth/login")
+      {:ok, user, :existing} ->
+        FountainWeb.Audited.from_conn(conn, "auth.oauth.login", "user",
+          user_id: user.id,
+          metadata: %{"provider" => provider}
+        )
 
-        {:error, _changeset} ->
-          conn
-          |> put_flash(:error, "Could not sign in with GitHub. Please try again.")
-          |> redirect(to: ~p"/auth/login")
-      end
+        conn
+        |> configure_session(renew: true)
+        |> put_session(:user_id, user.id)
+        |> put_session(:session_version, user.session_version)
+        |> redirect(to: ~p"/conversations")
+
+      {:error, reason} when reason in [:registration_closed, :email_domain_not_allowed] ->
+        conn
+        |> put_flash(:error, "Registration is not open on this instance.")
+        |> redirect(to: ~p"/auth/login")
+
+      {:error, _changeset} ->
+        conn
+        |> put_flash(:error, "Could not sign in with GitHub. Please try again.")
+        |> redirect(to: ~p"/auth/login")
     end
   end
 end

--- a/apps/fountain/lib/fountain_web/oauth_email.ex
+++ b/apps/fountain/lib/fountain_web/oauth_email.ex
@@ -1,0 +1,72 @@
+defmodule FountainWeb.OauthEmail do
+  @moduledoc """
+  Extracts a provider-verified email address from an Ueberauth result.
+
+  `Accounts.upsert_oauth_user/3` links a new OAuth identity to any existing
+  account with a matching email. That is the convenient behaviour and it is only
+  safe if the provider actually asserts the address belongs to the person
+  signing in.
+
+  It did not. `ueberauth_github`'s `maybe_get_primary_email/1` picks the address
+  flagged `primary` out of `/user/emails` and never looks at the `verified`
+  field beside it, so a GitHub account whose primary address is added but not
+  yet confirmed still produced an `auth.info.email`. The controller checked only
+  that the string was non-empty. Set an unconfirmed primary address to a
+  victim's, sign in with GitHub, and the identity attaches to their existing
+  password account.
+
+  So the verified flag is read here from the raw provider payload rather than
+  trusting `auth.info.email`, and an address the provider will not vouch for is
+  refused outright.
+  """
+
+  @doc """
+  Returns `{:ok, email}` when the provider asserts the address is verified.
+
+  `{:error, :no_email}` when there is no address at all, and
+  `{:error, :unverified}` when there is one the provider has not confirmed.
+  """
+  @spec verified_email(map()) :: {:ok, String.t()} | {:error, :no_email | :unverified}
+  def verified_email(auth) do
+    case email_from(auth) do
+      nil -> {:error, :no_email}
+      "" -> {:error, :no_email}
+      email -> if verified?(auth, email), do: {:ok, email}, else: {:error, :unverified}
+    end
+  end
+
+  defp email_from(auth), do: get_in(auth, [Access.key(:info), Access.key(:email)])
+
+  # GitHub's /user/emails entries carry both `primary` and `verified`. Match on
+  # the address we were handed rather than on `primary`, since they can differ.
+  defp verified?(auth, email) do
+    auth
+    |> raw_emails()
+    |> Enum.any?(fn entry ->
+      String.downcase(to_string(entry["email"] || "")) == String.downcase(email) and
+        entry["verified"] == true
+    end)
+  end
+
+  defp raw_emails(auth) do
+    case get_in(auth, [Access.key(:extra), Access.key(:raw_info)]) do
+      %{user: %{"emails" => emails}} when is_list(emails) -> emails
+      %{"user" => %{"emails" => emails}} when is_list(emails) -> emails
+      _ -> []
+    end
+  end
+
+  @doc """
+  Message shown to someone we refused, phrased so they can fix it themselves.
+  """
+  @spec explain(:no_email | :unverified) :: String.t()
+  def explain(:no_email) do
+    "GitHub did not return an email address. Grant the `user:email` scope, or " <>
+      "add a public email to your GitHub account, and try again."
+  end
+
+  def explain(:unverified) do
+    "GitHub has not verified that email address. Confirm it in your GitHub " <>
+      "email settings and try signing in again."
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/oauth_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/oauth_controller_test.exs
@@ -11,16 +11,28 @@ defmodule FountainWeb.UeberauthControllerTest do
 
   alias Fountain.Accounts
 
-  # Simulate a successful Ueberauth auth struct from GitHub
-  defp github_auth(email, uid \\ nil) do
+  # Simulate a successful Ueberauth auth struct from GitHub.
+  #
+  # `raw_info` carries the /user/emails payload, and the callback reads the
+  # `verified` flag out of it rather than trusting `info.email` — see
+  # FountainWeb.OauthEmail. Pass `verified: false` to model the address a
+  # GitHub account can hold as primary without ever confirming it.
+  defp github_auth(email, uid \\ nil, opts \\ []) do
     uid = uid || "gh_#{System.unique_integer([:positive])}"
+    verified = Keyword.get(opts, :verified, true)
 
     %Ueberauth.Auth{
       provider: :github,
       uid: uid,
       info: %Ueberauth.Auth.Info{email: email},
       credentials: %Ueberauth.Auth.Credentials{},
-      extra: %Ueberauth.Auth.Extra{}
+      extra: %Ueberauth.Auth.Extra{
+        raw_info: %{
+          user: %{
+            "emails" => [%{"email" => email, "primary" => true, "verified" => verified}]
+          }
+        }
+      }
     }
   end
 
@@ -139,12 +151,14 @@ defmodule FountainWeb.UeberauthControllerTest do
       assert redirected_to(conn) == ~p"/auth/login"
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
-               "GitHub did not return a verified email address."
+               "did not return an email address"
     end
   end
 
   describe "callback/2 — upsert_oauth_user error" do
-    test "redirects to login with error flash when upsert_oauth_user returns an error", %{conn: conn} do
+    test "redirects to login with error flash when upsert_oauth_user returns an error", %{
+      conn: conn
+    } do
       email = "github_error_#{System.unique_integer()}@example.com"
       auth = github_auth(email)
 
@@ -153,6 +167,7 @@ defmodule FountainWeb.UeberauthControllerTest do
           %Fountain.Accounts.User{}
           |> Ecto.Changeset.change()
           |> Ecto.Changeset.add_error(:email, "simulated failure")
+
         {:error, changeset}
       end)
 
@@ -177,6 +192,75 @@ defmodule FountainWeb.UeberauthControllerTest do
         |> get(~p"/auth/oauth/github")
 
       assert redirected_to(conn) == ~p"/auth/login"
+    end
+  end
+
+  describe "an email the provider has not verified" do
+    test "is refused rather than linked to an existing account", %{conn: conn} do
+      # The takeover path. ueberauth_github picks the address flagged `primary`
+      # out of /user/emails and never looks at `verified` beside it, so a
+      # GitHub account can present an unconfirmed address. If it matches an
+      # existing Fountain account, upsert_oauth_user/3 would attach the
+      # identity to it.
+      victim = insert_verified_user()
+
+      conn =
+        conn
+        |> assign_auth(github_auth(victim.email, "gh_attacker", verified: false))
+        |> get(~p"/auth/oauth/github/callback")
+
+      assert redirected_to(conn) == ~p"/auth/login"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "has not verified"
+      refute get_session(conn, :user_id)
+
+      # And no identity was attached.
+      refute Fountain.Repo.get_by(Fountain.Accounts.OauthIdentity, provider_uid: "gh_attacker")
+    end
+
+    test "is refused for a brand-new signup too", %{conn: conn} do
+      # Creating an account on an unverified address is a smaller problem than
+      # takeover, but the account would be marked email_verified_at on the
+      # strength of an assertion the provider did not make.
+      email = "unverified_#{System.unique_integer([:positive])}@example.com"
+
+      conn =
+        conn
+        |> assign_auth(github_auth(email, nil, verified: false))
+        |> get(~p"/auth/oauth/github/callback")
+
+      assert redirected_to(conn) == ~p"/auth/login"
+      refute Accounts.get_user_by_email(email)
+    end
+
+    test "a verified address still signs in normally", %{conn: conn} do
+      user = insert_verified_user()
+
+      conn =
+        conn
+        |> assign_auth(github_auth(user.email, "gh_ok", verified: true))
+        |> get(~p"/auth/oauth/github/callback")
+
+      assert redirected_to(conn) == ~p"/conversations"
+      assert get_session(conn, :user_id) == user.id
+    end
+
+    test "a payload with no emails list at all is refused", %{conn: conn} do
+      # Older strategy versions, or a provider that returns nothing usable.
+      # Failing closed is the only safe default when the assertion is absent.
+      user = insert_verified_user()
+
+      auth = %Ueberauth.Auth{
+        provider: :github,
+        uid: "gh_noraw",
+        info: %Ueberauth.Auth.Info{email: user.email},
+        credentials: %Ueberauth.Auth.Credentials{},
+        extra: %Ueberauth.Auth.Extra{}
+      }
+
+      conn = conn |> assign_auth(auth) |> get(~p"/auth/oauth/github/callback")
+
+      assert redirected_to(conn) == ~p"/auth/login"
+      refute get_session(conn, :user_id)
     end
   end
 end


### PR DESCRIPTION
Closes #181.

`upsert_oauth_user/3` links a new OAuth identity to any existing account with a matching email, and the callback checked only that the address string was non-empty.

That's only safe if the provider actually asserts the address belongs to whoever is signing in. It doesn't.

## The mechanism

`ueberauth_github`'s `maybe_get_primary_email/1`:

```elixir
Enum.find(user["emails"], & &1["primary"])["email"]
```

It picks the entry flagged `primary` out of `/user/emails` and never reads the `verified` field sitting right beside it in the same map. GitHub will report `verified: false` for an address that's been added and set primary but not confirmed — so `auth.info.email` can be an address the account holder has not proven they control.

Set that to a victim's address, sign in with GitHub, and `upsert_oauth_user/3` attaches your identity to their existing password account.

## The fix

`FountainWeb.OauthEmail` reads the verified flag out of the raw provider payload and matches it against the address we were handed — rather than trusting `auth.info.email`. It matches on the address rather than on `primary`, since those can differ. Anything the provider won't vouch for is refused, and the refusal is audited as `auth.oauth.rejected`.

**It fails closed.** A payload with no emails list at all — an older strategy version, a provider that returns nothing usable — is refused rather than assumed verified. When the assertion is simply absent, that's the only safe default, and there's a test for it.

**New signups are refused on the same rule**, not just links to existing accounts. Creating an account on an unverified address is a smaller problem than takeover, but the OAuth path sets `email_verified_at` on the strength of the provider's assertion, and it shouldn't do that on an assertion the provider never made.

## Tests

The existing fixtures had a bare `%Ueberauth.Auth.Extra{}`, so they all started failing once the check landed — which is itself the evidence that nothing was looking at verification before. They now carry a realistic `/user/emails` payload and take a `verified:` flag.

New tests cover the takeover path directly (unverified address matching an existing user → refused, no identity row created), the new-signup case, the missing-payload case, and that a verified address still signs in normally.

Full suite: 1433 tests, 0 failures.

## One thing worth deciding separately

This closes the hole by refusing. The alternative the issue raises — an explicit confirmation step before attaching an identity to an existing account — is friendlier, and would also cover a provider that lies about verification. It needs a confirm-by-email flow that doesn't exist yet, so I've left it. Refusing is strictly safer in the meantime; the cost is that someone with an unconfirmed GitHub primary address gets a message telling them to confirm it, which is a reasonable thing to ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)