### PR TITLE
security: HSTS, secure cookie and a scoped check_origin, derived from PUBLIC_URL

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -53,6 +53,13 @@ SPRITES_TOKEN=
 # service and is a lock with no key on your own instance.
 # BILLING_ENABLED=false
 
+# Point at a different Sprites endpoint. Defaults to the hosted service.
+# SPRITES_BASE_URL=https://api.sprites.dev
+
+# Extra origins allowed to open a LiveView websocket, comma-separated. Your own
+# PUBLIC_URL host is always allowed.
+# CHECK_ORIGIN_EXTRA=//*.preview.example.com
+
 # Sandbox lifetime bounds. A sandbox is reclaimed after this long without turn
 # activity, or on reaching the absolute ceiling. The conversation survives
 # either way and resumes on the next prompt. 0 disables a bound.

--- a/apps/fountain/lib/fountain_web/endpoint.ex
+++ b/apps/fountain/lib/fountain_web/endpoint.ex
@@ -2,9 +2,6 @@ defmodule FountainWeb.Endpoint do
   @moduledoc false
   use Phoenix.Endpoint, otp_app: :fountain
 
-  # The session will be stored in the cookie and signed,
-  # this means its contents can be read but not tampered with.
-  # Set :encryption_salt if you would also like to encrypt it.
   @doc """
   CIDRs treated as proxies when walking X-Forwarded-For.
 
@@ -21,6 +18,16 @@ defmodule FountainWeb.Endpoint do
     ])
   end
 
+  # `secure` is set from config rather than hardcoded: a self-hosted instance on
+  # plain http (the compose default) would never receive a cookie marked secure,
+  # so it cannot simply be true. runtime.exs turns it on whenever PUBLIC_URL is
+  # https, which is every deployment that can actually honour it.
+  #
+  # Signed, not encrypted. The contents are readable but not forgeable, and today
+  # that is a user id and a session version counter. Adding an encryption_salt
+  # would log every existing session out to hide two values that are already
+  # tamper-proof — worth doing alongside the first change that puts anything
+  # else in here, not on its own.
   @session_options [
     store: :cookie,
     key: "_fountain_key",
@@ -83,6 +90,21 @@ defmodule FountainWeb.Endpoint do
 
   plug Plug.MethodOverride
   plug Plug.Head
-  plug Plug.Session, @session_options
+  # Not `plug Plug.Session, @session_options`: the `secure` flag has to be
+  # decided at runtime. A release is one artifact, and the same artifact runs
+  # the hosted instance behind TLS and a self-hoster's compose stack on plain
+  # http — where a cookie marked secure is simply never sent back, so login
+  # silently fails.
+  plug :session
+
+  defp session(conn, _opts) do
+    Plug.Session.call(conn, Plug.Session.init(session_options()))
+  end
+
+  @doc false
+  def session_options do
+    Keyword.put(@session_options, :secure, Application.get_env(:fountain, :secure_cookie, false))
+  end
+
   plug FountainWeb.Router
 end

--- a/apps/fountain/test/fountain/transport_security_config_test.exs
+++ b/apps/fountain/test/fountain/transport_security_config_test.exs
@@ -1,0 +1,134 @@
+defmodule Fountain.TransportSecurityConfigTest do
+  @moduledoc """
+  Transport hardening that is derived from PUBLIC_URL rather than set by hand.
+
+  The reason it is derived: a release is one artifact, and the same artifact
+  runs the hosted instance behind TLS and a self-hoster's compose stack on plain
+  http. Anything switched on unconditionally — a secure cookie, an https
+  redirect — turns the second into a silent login failure.
+  """
+
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+
+  @base %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "EMAIL_DELIVERY" => "none"
+  }
+
+  @vars ~w(PUBLIC_URL CHECK_ORIGIN_EXTRA SPRITES_BASE_URL)
+
+  setup do
+    previous = System.get_env()
+
+    on_exit(fn ->
+      System.put_env(previous)
+
+      for k <- @vars ++ ["MASTER_SECRETS_KEY"],
+          not Map.has_key?(previous, k),
+          do: System.delete_env(k)
+    end)
+
+    key = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+    {:ok, base: Map.put(@base, "MASTER_SECRETS_KEY", key)}
+  end
+
+  defp read_prod(env) do
+    for k <- @vars, do: System.delete_env(k)
+    System.put_env(env)
+    Config.Reader.read!(@runtime_exs, env: :prod)[:fountain]
+  end
+
+  describe "over https" do
+    setup %{base: base} do
+      {:ok, config: read_prod(Map.put(base, "PUBLIC_URL", "https://fountain.example.com"))}
+    end
+
+    test "the session cookie is marked secure", %{config: config} do
+      assert config[:secure_cookie] == true
+    end
+
+    test "force_ssl is on with HSTS", %{config: config} do
+      force_ssl = config[FountainWeb.Endpoint][:force_ssl]
+
+      assert force_ssl[:hsts] == true
+      assert force_ssl[:expires] == 31_536_000
+      assert force_ssl[:subdomains] == true
+    end
+
+    test "force_ssl rewrites on forwarded headers", %{config: config} do
+      # Without this every request looks like http behind a terminating proxy
+      # and the redirect loops.
+      assert :x_forwarded_proto in config[FountainWeb.Endpoint][:force_ssl][:rewrite_on]
+    end
+
+    test "HSTS is not preloaded", %{config: config} do
+      # Deliberate: the preload list is a one-way door measured in months.
+      refute config[FountainWeb.Endpoint][:force_ssl][:preload]
+    end
+  end
+
+  describe "over plain http" do
+    setup %{base: base} do
+      {:ok, config: read_prod(Map.put(base, "PUBLIC_URL", "http://localhost:4000"))}
+    end
+
+    test "the session cookie is not marked secure", %{config: config} do
+      # It would never be sent back, which reads as login silently failing.
+      assert config[:secure_cookie] == false
+    end
+
+    test "force_ssl is off", %{config: config} do
+      # Otherwise the compose quick-start redirects to a port serving nothing.
+      refute config[FountainWeb.Endpoint][:force_ssl]
+    end
+  end
+
+  describe "check_origin" do
+    test "is just the deployment's own host by default", %{base: base} do
+      config = read_prod(Map.put(base, "PUBLIC_URL", "https://fountain.example.com"))
+
+      # `//*.replit.dev` used to be here unconditionally, which let a LiveView
+      # websocket be opened from any Replit subdomain.
+      assert config[FountainWeb.Endpoint][:check_origin] == ["//fountain.example.com"]
+    end
+
+    test "extra origins are opt-in", %{base: base} do
+      config =
+        base
+        |> Map.merge(%{
+          "PUBLIC_URL" => "https://fountain.example.com",
+          "CHECK_ORIGIN_EXTRA" => "//*.preview.example.com, //staging.example.com"
+        })
+        |> read_prod()
+
+      assert config[FountainWeb.Endpoint][:check_origin] == [
+               "//fountain.example.com",
+               "//*.preview.example.com",
+               "//staging.example.com"
+             ]
+    end
+  end
+
+  describe "SPRITES_BASE_URL" do
+    test "defaults to the hosted endpoint", %{base: base} do
+      config = read_prod(Map.put(base, "PUBLIC_URL", "https://f.example.com"))
+      assert config[:sprites_base_url] == "https://api.sprites.dev"
+    end
+
+    test "can be repointed", %{base: base} do
+      config =
+        base
+        |> Map.merge(%{
+          "PUBLIC_URL" => "https://f.example.com",
+          "SPRITES_BASE_URL" => "http://sprites.internal:8080"
+        })
+        |> read_prod()
+
+      assert config[:sprites_base_url] == "http://sprites.internal:8080"
+    end
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -67,6 +67,15 @@ master_secrets_key =
 config :fountain, :master_secrets_key, master_secrets_key
 config :fountain, :sprites_token, System.get_env("SPRITES_TOKEN")
 
+# SpritesClient has read :sprites_base_url from application env since it was
+# written, but nothing ever set it — so the default was the only value, and
+# pointing an instance at a different sandbox backend meant editing config and
+# rebuilding. Wiring it does not make Sprites self-hostable (see #189), it just
+# stops the endpoint being baked into the release.
+config :fountain,
+       :sprites_base_url,
+       System.get_env("SPRITES_BASE_URL", "https://api.sprites.dev")
+
 # Two different shapes are needed and they are not interchangeable:
 #
 #   :public_url — absolute, scheme-ful. Used to build links that leave the app
@@ -335,16 +344,51 @@ if config_env() == :prod and server? do
   # fills in 443, so this is byte-identical to the previous hardcoding.
   public_uri = URI.parse(public_url)
 
+  extra_origins =
+    case System.get_env("CHECK_ORIGIN_EXTRA") do
+      blank when blank in [nil, ""] -> []
+      list -> list |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+    end
+
+  # Everything below only makes sense over TLS, so it is derived from the scheme
+  # of PUBLIC_URL rather than set independently. A self-hoster on plain http
+  # gets none of it and keeps working; anyone on https gets all of it without
+  # having to know it exists.
+  https? = public_uri.scheme == "https"
+
+  # A cookie marked secure is never sent back over http, so this must not be on
+  # for an http deployment — it would look like login silently failing.
+  config :fountain, :secure_cookie, https?
+
+  # force_ssl also emits HSTS. rewrite_on is required behind a terminating
+  # proxy: without it every request looks like http to the app and redirects
+  # into a loop.
+  if https? do
+    config :fountain, FountainWeb.Endpoint,
+      force_ssl: [
+        rewrite_on: [:x_forwarded_proto, :x_forwarded_host, :x_forwarded_port],
+        hsts: true,
+        # One year, and subdomains, which is what preload lists require. No
+        # `preload` directive: that is a one-way door — getting off the preload
+        # list takes months — and it is not this change's call to make.
+        expires: 31_536_000,
+        subdomains: true
+      ]
+  end
+
   config :fountain, FountainWeb.Endpoint,
     url: [host: host, port: public_uri.port || 443, scheme: public_uri.scheme || "https"],
     http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}],
     # check_origin guards the LiveView websocket/longpoll handshake. Setting an
     # explicit list replaces the default (the endpoint's own host), so we must
     # re-list it here. `//*.replit.dev` allows Replit preview/dev subdomains.
-    check_origin: [
-      "//#{host}",
-      "//*.replit.dev"
-    ],
+    # An explicit list replaces the default (the endpoint's own host), so the
+    # host has to be re-listed here. `//*.replit.dev` used to be in this list,
+    # which let a LiveView websocket be opened from any Replit subdomain — dev
+    # convenience that leaked into the production branch. Extra origins are now
+    # opt-in via CHECK_ORIGIN_EXTRA, so a preview environment can add its own
+    # without every deployment inheriting it.
+    check_origin: ["//#{host}" | extra_origins],
     secret_key_base: secret_key_base
 
   # ── OpenTelemetry ─────────────────────────────────────────────────────────

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -144,6 +144,19 @@ with Caddy, nginx, or a tunnel, and then:
   all collapse into one bucket keyed on the proxy
 - close registration, or set `REGISTRATION_ALLOWED_EMAIL_DOMAINS`
 
+An `https://` `PUBLIC_URL` also switches on HTTPS redirection, HSTS (one year,
+including subdomains — not preloaded) and the `secure` flag on the session
+cookie. All three are derived from the scheme rather than set separately,
+because none of them can be on for an `http://` instance: a cookie marked
+secure is never sent back, and the redirect would point at a port serving
+nothing. If you terminate TLS in front of Fountain, make sure your proxy sets
+`X-Forwarded-Proto` — the redirect uses it, and without it every request looks
+like plain http and loops.
+
+`CHECK_ORIGIN_EXTRA` adds origins allowed to open a LiveView websocket, as a
+comma-separated list. Your own host is always included; add to this only for
+something like a preview environment on a different domain.
+
 Registration is open by default. An instance on the public internet with
 registration open will be found.
 


### PR DESCRIPTION
Closes #180. Closes #189.

Four transport gaps, plus the `SPRITES_BASE_URL` wiring from #189 since it lands in the same file and is one line.

- **No HSTS and no `force_ssl`.** Now on, one-year max-age including subdomains. **Not preloaded** — the preload list is a one-way door measured in months, and that's not this change's call to make. `rewrite_on` covers the forwarded headers, without which every request looks like http behind a terminating proxy and the redirect loops.
- **The session cookie wasn't marked `secure`.** Now is.
- **`check_origin` allowed `//*.replit.dev` in production**, letting a LiveView websocket be opened from any Replit subdomain. Removed. Extra origins are opt-in via `CHECK_ORIGIN_EXTRA`, so a preview environment can add its own without every deployment inheriting it.

## Why they're derived rather than set

All three come from the scheme of `PUBLIC_URL`. A release is one artifact — the same build runs the hosted instance behind TLS and a self-hoster's compose stack on plain http. A cookie marked `secure` is never sent back over http, and an https redirect on an http instance points at a port serving nothing. Both read to the operator as *login silently fails*.

Deriving means an https deployment gets all of it without having to know it exists, and an http one gets none of it and keeps working. There are tests for both directions.

This did require moving off `plug Plug.Session, @session_options` — the flag has to be decided at runtime rather than baked in at compile time, which `Application.compile_env` in an endpoint attribute can't do.

## The cookie stays signed, not encrypted

The issue also asks for an `encryption_salt`. I've left it, deliberately.

The contents are already tamper-proof, and today they are a user id and a session version counter. Adding encryption would log **every existing session out** — 191 accounts — to hide two values nobody can forge. That's a bad trade on its own. It's worth doing alongside the first change that puts anything else in the session, and the reasoning is now a comment next to `@session_options` so whoever makes that change finds it.

## Already covered

`DATABASE_SSL_VERIFY` landed earlier in this audit, so the DB-TLS item is done. `dev_routes` is only set in `config/dev.exs`, so the unauthenticated LiveDashboard route is absent from a prod release — confirmed, not assumed.

## Verification

Tests read the real `config/runtime.exs` through `Config.Reader` for both an https and an http `PUBLIC_URL`, and assert the resulting config rather than the intent: secure cookie on/off, `force_ssl` present/absent, `rewrite_on` includes `x_forwarded_proto`, no `preload`, `check_origin` is exactly the deployment's own host, and `CHECK_ORIGIN_EXTRA` appends.

Full suite: 1467 tests, 0 failures. Format and strict credo clean.

## Deploying

`PUBLIC_URL` on the hosted instance is `https://fountain.inevitable.fyi`, so this turns on HSTS and the https redirect there on the next deploy. Traefik already sets `X-Forwarded-Proto`. Worth being aware that HSTS is sticky in browsers for a year — if you ever need to serve that host over plain http again, clients that have seen the header will refuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)