### PR TITLE
fix(config): apply force_ssl as a runtime plug — it cannot be set in runtime.exs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,5 +117,27 @@ jobs:
       - name: Run tests with coverage
         run: mix coveralls
 
+      # Builds a release and runs its config providers. Config.Reader tests
+      # validate config *values*; only a real boot catches a key that may not be
+      # set at runtime at all. A `force_ssl` moved into runtime.exs passed every
+      # test and then CrashLoopBackOff'd every pod with:
+      #   ERROR! the application :fountain has a different value set for path
+      #   [:force_ssl] inside key FountainWeb.Endpoint during runtime compared
+      #   to compile time.
+      - name: Release boots with production config
+        env:
+          MIX_ENV: prod
+          PHX_SERVER: "true"
+          SECRET_KEY_BASE: ci-only-not-a-secret-0000000000000000000000000000000000000000000000000000
+          MASTER_SECRETS_KEY: ci-only-not-a-secret-AAAAAAAAAAAAAAAAAAAAA
+          DATABASE_URL: postgres://postgres:postgres@localhost/fountain_test
+          PUBLIC_URL: https://ci.example.com
+          EMAIL_DELIVERY: none
+        run: |
+          set -euo pipefail
+          mix deps.get --only prod
+          mix release fountain_server --overwrite
+          _build/prod/rel/fountain_server/bin/fountain_server eval 'IO.puts("release boots")'
+
       - name: Validate OpenAPI spec
         run: mix openapi.spec.json --spec FountainWeb.ApiSpec --output /tmp/openapi.json && jq empty /tmp/openapi.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,9 @@ jobs:
         env:
           MIX_ENV: prod
           PHX_SERVER: "true"
-          SECRET_KEY_BASE: ci-only-not-a-secret-0000000000000000000000000000000000000000000000000000
-          MASTER_SECRETS_KEY: ci-only-not-a-secret-AAAAAAAAAAAAAAAAAAAAA
+          SECRET_KEY_BASE: ci-only-not-a-secret-000000000000000000000000000000000000000000000000
+          # 43 chars of base64url = 32 zero bytes. Valid format, obviously not a key.
+          MASTER_SECRETS_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           DATABASE_URL: postgres://postgres:postgres@localhost/fountain_test
           PUBLIC_URL: https://ci.example.com
           EMAIL_DELIVERY: none

--- a/apps/fountain/lib/fountain_web/endpoint.ex
+++ b/apps/fountain/lib/fountain_web/endpoint.ex
@@ -2,6 +2,22 @@ defmodule FountainWeb.Endpoint do
   @moduledoc false
   use Phoenix.Endpoint, otp_app: :fountain
 
+  # First in the pipeline, and applied by hand rather than through the endpoint's
+  # `force_ssl:` option: Phoenix reads that option with Application.compile_env,
+  # so setting it from runtime.exs aborts boot with a validate_compile_env
+  # error. Runtime is the only place it can be decided — the same release runs
+  # an https deployment and a self-hoster's http compose stack, and redirecting
+  # the latter to a port serving nothing reads as the app being broken.
+  plug :force_ssl
+
+  defp force_ssl(conn, _opts) do
+    case Application.get_env(:fountain, :force_ssl) do
+      nil -> conn
+      [] -> conn
+      opts -> Plug.SSL.call(conn, Plug.SSL.init(opts))
+    end
+  end
+
   @doc """
   CIDRs treated as proxies when walking X-Forwarded-For.
 

--- a/apps/fountain/test/fountain/transport_security_config_test.exs
+++ b/apps/fountain/test/fountain/transport_security_config_test.exs
@@ -52,7 +52,7 @@ defmodule Fountain.TransportSecurityConfigTest do
     end
 
     test "force_ssl is on with HSTS", %{config: config} do
-      force_ssl = config[FountainWeb.Endpoint][:force_ssl]
+      force_ssl = config[:force_ssl]
 
       assert force_ssl[:hsts] == true
       assert force_ssl[:expires] == 31_536_000
@@ -62,12 +62,28 @@ defmodule Fountain.TransportSecurityConfigTest do
     test "force_ssl rewrites on forwarded headers", %{config: config} do
       # Without this every request looks like http behind a terminating proxy
       # and the redirect loops.
-      assert :x_forwarded_proto in config[FountainWeb.Endpoint][:force_ssl][:rewrite_on]
+      assert :x_forwarded_proto in config[:force_ssl][:rewrite_on]
     end
 
     test "HSTS is not preloaded", %{config: config} do
       # Deliberate: the preload list is a one-way door measured in months.
-      refute config[FountainWeb.Endpoint][:force_ssl][:preload]
+      refute config[:force_ssl][:preload]
+    end
+
+    test "force_ssl is not set under the Endpoint key", %{config: config} do
+      # This is the bug that reached production. Phoenix reads
+      # FountainWeb.Endpoint's :force_ssl with Application.compile_env, so
+      # setting it from runtime.exs fails the release's validate_compile_env
+      # check and the node aborts during boot:
+      #
+      #   ERROR! the application :fountain has a different value set for path
+      #   [:force_ssl] inside key FountainWeb.Endpoint during runtime compared
+      #   to compile time.
+      #
+      # Config.Reader validates values, not whether they may be set at runtime,
+      # so the original tests passed while every pod CrashLoopBackOff'd. The
+      # endpoint applies Plug.SSL from :fountain, :force_ssl instead.
+      refute config[FountainWeb.Endpoint][:force_ssl]
     end
   end
 
@@ -83,6 +99,7 @@ defmodule Fountain.TransportSecurityConfigTest do
 
     test "force_ssl is off", %{config: config} do
       # Otherwise the compose quick-start redirects to a port serving nothing.
+      refute config[:force_ssl]
       refute config[FountainWeb.Endpoint][:force_ssl]
     end
   end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -360,20 +360,29 @@ if config_env() == :prod and server? do
   # for an http deployment — it would look like login silently failing.
   config :fountain, :secure_cookie, https?
 
-  # force_ssl also emits HSTS. rewrite_on is required behind a terminating
-  # proxy: without it every request looks like http to the app and redirects
-  # into a loop.
+  # Deliberately NOT `config :fountain, FountainWeb.Endpoint, force_ssl: ...`.
+  # Phoenix reads that key with Application.compile_env, so setting it here
+  # fails the release's validate_compile_env check and aborts boot:
+  #
+  #   ERROR! the application :fountain has a different value set for path
+  #   [:force_ssl] inside key FountainWeb.Endpoint during runtime compared to
+  #   compile time.
+  #
+  # The endpoint applies Plug.SSL itself from this key instead, which is what
+  # `force_ssl:` does internally anyway — and it has to be a runtime decision,
+  # since one release artifact serves both an https deployment and a
+  # self-hoster's http compose stack.
+  #
+  # rewrite_on is required behind a terminating proxy: without it every request
+  # looks like http to the app and the redirect loops.
   if https? do
-    config :fountain, FountainWeb.Endpoint,
-      force_ssl: [
-        rewrite_on: [:x_forwarded_proto, :x_forwarded_host, :x_forwarded_port],
-        hsts: true,
-        # One year, and subdomains, which is what preload lists require. No
-        # `preload` directive: that is a one-way door — getting off the preload
-        # list takes months — and it is not this change's call to make.
-        expires: 31_536_000,
-        subdomains: true
-      ]
+    config :fountain, :force_ssl,
+      rewrite_on: [:x_forwarded_proto, :x_forwarded_host, :x_forwarded_port],
+      hsts: true,
+      # One year, including subdomains. No `preload`: that is a one-way door —
+      # getting off the preload list takes months — and not this change's call.
+      expires: 31_536_000,
+      subdomains: true
   end
 
   config :fountain, FountainWeb.Endpoint,


### PR DESCRIPTION
Fixes a production break I shipped in #241.

## What happened

#241 set `config :fountain, FountainWeb.Endpoint, force_ssl: [...]` from `runtime.exs`. Phoenix reads that key with `Application.compile_env`, so the release's `validate_compile_env` check aborted boot:

```
ERROR! the application :fountain has a different value set for path [:force_ssl]
inside key FountainWeb.Endpoint during runtime compared to compile time.
  * Compile time value was not set
  * Runtime value was set to: [rewrite_on: [...], hsts: true, ...]
Runtime terminating during boot
```

Every new pod went `CrashLoopBackOff`. **No outage** — the old replicas stayed Ready and served throughout, and the rollout wedged rather than proceeding — but the deploy was stuck and Flux reported the kustomization failed.

## The fix

The endpoint applies `Plug.SSL` itself from a `:fountain, :force_ssl` key, which is what `force_ssl:` does internally anyway. The decision stays at runtime, which it has to be: one release artifact serves both the https deployment and a self-hoster's http compose stack, and redirecting the latter to a port serving nothing reads as the app being broken.

This is the same shape as the secure-cookie flag from the same PR — that one was already a runtime plug for exactly this reason, and it was fine. I applied the pattern to one of the two settings and not the other.

## Why the tests didn't catch it, and what now does

The #241 tests read the real `runtime.exs` through `Config.Reader` and assert the resulting values. That validates *what the config says* — nothing in it knows a key may not be settable at runtime at all. They passed while every pod crashed.

So CI now builds a release and runs its config providers with production-shaped env:

```
mix release fountain_server --overwrite
_build/prod/rel/fountain_server/bin/fountain_server eval 'IO.puts("release boots")'
```

I verified this detector both ways against a real release, not in theory: with the old config shape it fails with the error above, with the new one it prints `release boots`. That catches the whole class — any compile-env violation, any config provider that raises — not just this instance.

There's also a cheap test pinning the specific mistake (`:force_ssl` must not appear under the Endpoint key) so the next person moving config around gets the fast failure before the slow one.

## State of production

Currently serving on the previous image with two Ready pods. Merging this unwedges the rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)