### PR TITLE
fix(endpoint): exempt health probes from the https redirect

### DIFF
--- a/apps/fountain/lib/fountain_web/endpoint.ex
+++ b/apps/fountain/lib/fountain_web/endpoint.ex
@@ -10,6 +10,20 @@ defmodule FountainWeb.Endpoint do
   # the latter to a port serving nothing reads as the app being broken.
   plug :force_ssl
 
+  # kubelet hits these directly on the pod IP, over plain http and with no
+  # X-Forwarded-Proto, because there is no proxy on that path. Plug.SSL sees
+  # http and answers 301, the probe scores a redirect as a failure, and the pod
+  # never becomes ready — the deployment then stalls on its progress deadline
+  # with an app that is running perfectly.
+  #
+  # Exempting them costs nothing: both are public, unauthenticated, and carry no
+  # secrets. Every other response still redirects and still carries HSTS.
+  @no_ssl_redirect ["/health", "/health/ready"]
+
+  defp force_ssl(%Plug.Conn{request_path: path} = conn, _opts)
+       when path in @no_ssl_redirect,
+       do: conn
+
   defp force_ssl(conn, _opts) do
     case Application.get_env(:fountain, :force_ssl) do
       nil -> conn

--- a/apps/fountain/test/fountain_web/force_ssl_probe_test.exs
+++ b/apps/fountain/test/fountain_web/force_ssl_probe_test.exs
@@ -1,0 +1,75 @@
+defmodule FountainWeb.ForceSslProbeTest do
+  @moduledoc """
+  The https redirect must not apply to the health probes.
+
+  kubelet hits them directly on the pod IP, over plain http and with no
+  X-Forwarded-Proto, because there is no proxy on that path. Plug.SSL saw http
+  and answered 301; the probe scored a redirect as a failure; the pod never
+  became ready; the deployment stalled on its progress deadline with an app that
+  was running perfectly. Nothing in the logs said "broken" — the only clue was
+
+      Plug.SSL is redirecting GET /health to https://10.42.3.221 with status 301
+  """
+
+  use FountainWeb.ConnCase, async: false
+
+  setup do
+    previous = Application.get_env(:fountain, :force_ssl)
+
+    Application.put_env(:fountain, :force_ssl,
+      rewrite_on: [:x_forwarded_proto],
+      hsts: true
+    )
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:fountain, :force_ssl)
+        v -> Application.put_env(:fountain, :force_ssl, v)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "with force_ssl on, over plain http" do
+    test "liveness answers 200 rather than redirecting", %{conn: conn} do
+      conn = get(conn, "/health")
+
+      assert conn.status == 200
+      assert json_response(conn, 200)["status"] == "ok"
+    end
+
+    test "readiness answers rather than redirecting", %{conn: conn} do
+      # A 301 here is scored as a probe failure, which drains the pod.
+      conn = get(conn, "/health/ready")
+
+      assert conn.status in [200, 503]
+      refute conn.status == 301
+    end
+
+    test "everything else still redirects to https", %{conn: conn} do
+      # The exemption must be exactly the probe paths and nothing more.
+      conn = get(conn, "/auth/login")
+
+      assert conn.status == 301
+      assert [location] = Plug.Conn.get_resp_header(conn, "location")
+      assert String.starts_with?(location, "https://")
+    end
+
+    test "a path merely starting with /health is not exempt", %{conn: conn} do
+      # Guards against a prefix match quietly exempting more than intended.
+      conn = get(conn, "/healthcheck")
+
+      assert conn.status == 301
+    end
+  end
+
+  describe "with force_ssl off" do
+    test "nothing redirects", %{conn: conn} do
+      Application.delete_env(:fountain, :force_ssl)
+
+      assert get(conn, "/health").status == 200
+      refute get(conn, "/auth/login").status == 301
+    end
+  end
+end


### PR DESCRIPTION
Second defect in the #241 transport change, found the same way as the first — by watching the deploy.

## What happened

After #243 fixed the boot crash, the new pod started cleanly and then **never became ready**. kubelet hits `/health` and `/health/ready` directly on the pod IP, over plain http and with no `X-Forwarded-Proto`, because there is no proxy on that path. `Plug.SSL` saw http and answered 301, the probe scored a redirect as a failure, and the deployment stalled on its progress deadline — with an application that was running perfectly.

The single line in the logs that gave it away:

```
Plug.SSL is redirecting GET /health to https://10.42.3.221 with status 301
```

No outage. The two old pods stayed Ready and served throughout, and the rollout wedged rather than proceeding. That's now three times today the deployment strategy has been the thing between a mistake and a user-visible failure.

## The fix

Exempt the two probe paths. It costs nothing: both are public, unauthenticated and carry no secrets, and every other response still redirects and still carries HSTS.

Matched **exactly**, not by prefix — there's a test asserting `/healthcheck` still redirects, because a sloppy `String.starts_with?` here would silently exempt more than intended.

## On the checks

This is the second thing wrong with the same change, and neither was catchable by what existed.

The release-boot gate I added in #243 proves the node *starts*. It cannot tell that a started node fails its probes — which is a distinct failure mode with an identical symptom from the outside (pods not becoming ready, rollout stalled).

What would have caught both: a smoke test that boots the release and curls `/health` and `/health/ready` over plain http, asserting 200. That's a natural extension of the existing gate and I'd like to add it — filed separately rather than bolted on here, so this fix can go out and unwedge the deploy.

Full suite: 1486 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)