### PR TITLE
fix(conversations): stop replaying the last prompt on every deploy

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -776,6 +776,7 @@ defmodule Fountain.Conversations do
              source: attrs["source"] || "api",
              parent_conversation_id: parent_id
            }) do
+      # No prompt in the child spec — see start_conversation_server/4.
       start_result =
         Horde.DynamicSupervisor.start_child(
           Fountain.ConversationSupervisor,
@@ -783,13 +784,20 @@ defmodule Fountain.Conversations do
            [
              conversation_id: conv.id,
              sandbox_id: sandbox.id,
-             runtime_module: runtime_module,
-             initial_prompt: attrs["prompt"]
+             runtime_module: runtime_module
            ]}
         )
 
       case start_result do
         {:ok, _pid} ->
+          if is_binary(attrs["prompt"]) and attrs["prompt"] != "" do
+            ConversationServer.queue_initial_prompt(
+              conv.id,
+              attrs["prompt"],
+              attrs["images"] || []
+            )
+          end
+
           result = _unsafe_get_conversation!(conv.id)
 
           if result.parent_conversation_id do
@@ -961,6 +969,20 @@ defmodule Fountain.Conversations do
     end
   end
 
+  # The child spec deliberately carries no prompt.
+  #
+  # Horde redistributes children when cluster membership changes — which every
+  # deploy does — and restarts each one from its *stored child spec*. A prompt
+  # baked into that spec is therefore replayed on every rebalance, silently
+  # re-running the user's last message against the agent. Production
+  # accumulated 38 turns from 2 distinct prompts on one conversation this way,
+  # one duplicate per rollout, and the agent on the other end spent several
+  # turns pointing out it was being asked the same thing repeatedly.
+  #
+  # So the prompt is delivered out of band, after the server exists. A cast is
+  # queued behind handle_continue(:provision), so it is processed once
+  # provisioning finishes; if provisioning fails the server stops and the cast
+  # dies with it, which is the right outcome — no turn on a failed provision.
   defp start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt) do
     with {:ok, _pid} <-
            Horde.DynamicSupervisor.start_child(
@@ -969,10 +991,13 @@ defmodule Fountain.Conversations do
               [
                 conversation_id: conv.id,
                 sandbox_id: sandbox_id,
-                runtime_module: runtime_module,
-                initial_prompt: initial_prompt
+                runtime_module: runtime_module
               ]}
            ) do
+      if is_binary(initial_prompt) and initial_prompt != "" do
+        ConversationServer.queue_initial_prompt(conv.id, initial_prompt)
+      end
+
       {:ok, _unsafe_get_conversation!(conv.id)}
     end
   end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -69,6 +69,21 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
+  @doc """
+  Deliver the prompt a conversation was started for, after the server exists.
+
+  Deliberately not a `start_link` argument. Horde restarts a redistributed
+  child from its *stored child spec*, so anything in there is replayed on every
+  cluster membership change — which every deploy causes. A prompt in the spec
+  therefore re-ran the user's last message on each rollout.
+
+  A cast rather than a call: it queues behind `handle_continue(:provision)`,
+  which can take minutes, and no caller is waiting on the turn to finish.
+  """
+  def queue_initial_prompt(conv_id, prompt, images \\ []) do
+    GenServer.cast(via(conv_id), {:initial_prompt, prompt, images})
+  end
+
   def interrupt(conv_id) do
     case whereis(conv_id) do
       nil -> {:error, :not_running}
@@ -116,7 +131,6 @@ defmodule Fountain.Conversations.ConversationServer do
       conversation_id: Keyword.fetch!(args, :conversation_id),
       sandbox_id: Keyword.fetch!(args, :sandbox_id),
       runtime_module: Keyword.fetch!(args, :runtime_module),
-      initial_prompt: Keyword.get(args, :initial_prompt),
       user_id: nil,
       sprite: nil,
       sprite_env: [],
@@ -332,10 +346,10 @@ defmodule Fountain.Conversations.ConversationServer do
               sandbox_started_at: sandbox.inserted_at
           }
 
-          case state.initial_prompt do
-            nil -> {:noreply, new_state}
-            p -> {:noreply, kick_turn(new_state, p, agent, [])}
-          end
+          # Any prompt this conversation was started for arrives as a cast,
+          # already queued behind this handle_continue. See
+          # queue_initial_prompt/3.
+          {:noreply, new_state}
         else
           {:error, reason} ->
             Logger.error("provision step failed: #{inspect(reason)}")
@@ -481,10 +495,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
         new_state = reattach_running_turn(new_state)
 
-        case state.initial_prompt do
-          nil -> {:noreply, new_state}
-          p -> {:noreply, kick_turn(new_state, p, agent, [])}
-        end
+        {:noreply, new_state}
 
       {:error, reason} ->
         Logger.warning(
@@ -796,6 +807,24 @@ defmodule Fountain.Conversations.ConversationServer do
     {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
     publish_stage(state.conversation_id, "terminate", "done")
     {:stop, :normal, :ok, state}
+  end
+
+  # The prompt a conversation was started for. Ignored if a turn is somehow
+  # already running — the cast is queued behind provisioning, so that should not
+  # happen, and re-running is the failure this whole mechanism exists to avoid.
+  @impl true
+  def handle_cast({:initial_prompt, prompt, images}, state) do
+    if state.current_command do
+      Logger.warning(
+        "conv #{state.conversation_id}: initial prompt arrived while a turn was running; dropping it"
+      )
+
+      {:noreply, state}
+    else
+      conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+      agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
+      {:noreply, kick_turn(state, prompt, agent, images)}
+    end
   end
 
   @impl true

--- a/apps/fountain/test/fountain/conversations/prompt_replay_test.exs
+++ b/apps/fountain/test/fountain/conversations/prompt_replay_test.exs
@@ -1,0 +1,119 @@
+defmodule Fountain.Conversations.PromptReplayTest do
+  @moduledoc """
+  A prompt must never reach the Horde child spec.
+
+  `Horde.DynamicSupervisor` redistributes children when cluster membership
+  changes — which every deploy does, as pods join and leave — and restarts each
+  one from its **stored child spec**. `wake_conversation/2` used to bake the
+  user's prompt into that spec as `initial_prompt`, so every rebalance replayed
+  it against the agent.
+
+  Production accumulated 38 turns from 2 distinct prompts on one conversation
+  this way, one duplicate per rollout across four conversations, until the agent
+  on the other end started replying "this is the sixth identical message" and
+  refused to keep working.
+
+  The test that matters is therefore about the **spec**, captured from the real
+  code path, because the spec is the thing Horde stores and replays. An earlier
+  version of this file restarted a server with hand-written args instead, which
+  passed against the buggy code — the replay was never exercised, because the
+  args under test were not the args Horde would have kept.
+  """
+
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Fountain.Conversations
+
+  setup :set_mimic_global
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+    stub(Fountain.SpritesClient, :get!, fn -> :client end)
+    stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{}} end)
+
+    test = self()
+
+    # Capture what would be handed to Horde, and do not actually start anything.
+    stub(Horde.DynamicSupervisor, :start_child, fn _sup, spec ->
+      send(test, {:child_spec, spec})
+      {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+    end)
+
+    stub(Conversations.ConversationServer, :queue_initial_prompt, fn id, prompt, images ->
+      send(test, {:queued_prompt, id, prompt, images})
+      :ok
+    end)
+
+    stub(Conversations.ConversationServer, :queue_initial_prompt, fn id, prompt ->
+      send(test, {:queued_prompt, id, prompt, []})
+      :ok
+    end)
+
+    {:ok, conv: conv, agent: agent, user: user}
+  end
+
+  defp spec_args do
+    assert_received {:child_spec, {_module, args}}
+    args
+  end
+
+  describe "waking a conversation with a prompt" do
+    test "puts no prompt in the child spec", %{conv: conv} do
+      # The bug, in one assertion. Anything in here is replayed by Horde on
+      # every redistribution, so a one-shot side effect must not be in it.
+      {:ok, _} = Conversations.wake_conversation(conv.id, "run the migration")
+
+      args = spec_args()
+
+      refute Keyword.has_key?(args, :initial_prompt),
+             "the prompt is in the child spec and will be replayed on every deploy"
+
+      refute args |> Keyword.values() |> Enum.any?(&(&1 == "run the migration"))
+    end
+
+    test "delivers the prompt out of band instead", %{conv: conv} do
+      # It must still arrive — the fix is about how, not whether.
+      {:ok, _} = Conversations.wake_conversation(conv.id, "run the migration")
+
+      assert_received {:queued_prompt, conv_id, "run the migration", _}
+      assert conv_id == conv.id
+    end
+
+    test "waking without a prompt queues nothing", %{conv: conv} do
+      # The rehydrator path. A boot must not send anything to the agent.
+      {:ok, _} = Conversations.wake_conversation(conv.id)
+
+      refute_received {:queued_prompt, _, _, _}
+    end
+
+    test "the spec carries only what a restart legitimately needs", %{conv: conv} do
+      {:ok, _} = Conversations.wake_conversation(conv.id, "hello")
+
+      assert Enum.sort(Keyword.keys(spec_args())) ==
+               [:conversation_id, :runtime_module, :sandbox_id]
+    end
+  end
+
+  describe "creating a conversation with an opening prompt" do
+    test "puts no prompt in the child spec either", %{user: user, agent: agent} do
+      # The other entry point. Fixing only the wake path would leave every
+      # conversation created with an opening prompt still replaying it.
+      {:ok, _conv} =
+        Conversations.start_conversation(%{
+          "agent_id" => agent.id,
+          "user_id" => user.id,
+          "prompt" => "kick things off"
+        })
+
+      args = spec_args()
+
+      refute Keyword.has_key?(args, :initial_prompt)
+      assert_received {:queued_prompt, _id, "kick things off", _}
+    end
+  end
+end

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -102,12 +102,21 @@ defmodule Fountain.ConversationServerCase do
     args = [
       conversation_id: conv.id,
       sandbox_id: conv.sandbox_id,
-      runtime_module: runtime,
-      initial_prompt: Keyword.get(opts, :initial_prompt)
+      runtime_module: runtime
     ]
 
     {:ok, pid} = GenServer.start(Fountain.Conversations.ConversationServer, args)
     ref = Process.monitor(pid)
+
+    # The prompt is delivered out of band, exactly as production does it: it is
+    # not a start_link argument, because Horde replays a stored child spec on
+    # every redistribution and would re-run the prompt on each deploy. Cast to
+    # the pid rather than through the registry, since this harness starts the
+    # server outside Horde.
+    case Keyword.get(opts, :initial_prompt) do
+      nil -> :ok
+      prompt -> GenServer.cast(pid, {:initial_prompt, prompt, Keyword.get(opts, :images, [])})
+    end
 
     # handle_continue(:provision) runs before any call is answered, so a
     # synchronous call is enough to know provisioning has finished.


### PR DESCRIPTION
## The bug

`Horde.DynamicSupervisor` redistributes children when cluster membership changes — which **every deploy does**, as pods join and leave — and restarts each one from its **stored child spec**. Both `wake_conversation/2` and `start_conversation/1` baked the user's prompt into that spec as `initial_prompt`, and `handle_continue(:provision)` ran it.

So every rollout re-sent the user's last message to their agent.

## Evidence

Four conversations in production accumulated 34–43 turns from **one or two distinct prompts**:

| conversation | turns | distinct prompts |
|---|---|---|
| `7c302e45` | 43 | 2 |
| `31dab5cc` | 38 | 2 |
| `d883316b` | 37 | **1** |
| `b614eb6a` | 34 | **1** |

The turn bursts line up exactly with ReplicaSet creation times — one turn per affected conversation per rollout:

```
RS 20:13:58 → 4 turns at 20:14
RS 20:42:50 → turns at 20:42–20:43
RS 20:57:39 → 4 turns at 20:57
RS 21:09:02 → turn at 21:09
```

What pinned the mechanism rather than a client-side retry loop: the affected set is **precisely** the conversations whose servers were started by a prompt. The fifth long-lived conversation — alive since 2026-05-10, only ever started by the rehydrator, which passes `initial_prompt: nil` — has no duplicates at all. And a pod that logged `rehydrator: not leader; skipping sweep` still started a reattach for one of these conversations a fraction of a second earlier, so the server was placed there by Horde, not by that node's own sweep.

The agent on the other end had worked it out too, and was refusing to act:

> This is the sixth identical message with no reply to my last two questions. I won't open another duplicate PR… that's almost certainly a stuck retry loop on your end.

It was right that something was looping. It was ours.

## The fix

The prompt is delivered by cast after the server exists, so there is nothing in the spec to replay. The cast queues behind `handle_continue(:provision)`, so it lands once provisioning finishes; if provisioning fails, the server stops and the cast dies with it — no turn on a failed provision, which is correct.

The spec now carries only `conversation_id`, `sandbox_id` and `runtime_module`: things a restart legitimately needs, none of them a one-shot side effect.

## On the tests, because the first version was worthless

My first attempt restarted a server with hand-written args and asserted no extra turn appeared. It **passed against the buggy code** — because the args under test were not the args Horde had stored. I only caught that by reverting the fix and seeing the tests stay green, which is why that check is worth running every time.

The bug is about the *stored spec*, so the tests now capture what the real code path hands to `Horde.DynamicSupervisor.start_child` and assert the prompt is not in it. Reverting either call site fails them — verified separately for the wake path (3 failures) and the create path (1 failure), since fixing only one would have left the other replaying.

Full suite: 1491 tests, 0 failures.

## Cleanup worth doing separately

The four affected conversations carry dozens of junk turns and their log events. I have not touched production data — say the word and I will work out which turns were replays and what, if anything, is safe to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)