### PR TITLE
fix(ci): fully qualify the deploy branch refspec

### DIFF
--- a/.github/workflows/pin-image.yml
+++ b/.github/workflows/pin-image.yml
@@ -96,8 +96,13 @@ jobs:
           git add k8s/deployment.yaml
           git commit -m "deploy: sha-${SHORT}" -m "Deployed-From: ${SHA}"
 
+          # Fully qualified on purpose. `HEAD:deploy` cannot create the branch
+          # on the first run — git refuses to guess a destination that does not
+          # exist yet ("You must fully qualify the ref"), which is exactly how
+          # this failed the first time it ran.
+          #
           # Force, because deploy is derived: it is rebuilt from each built
           # commit rather than accumulating history of its own.
-          git push --force origin HEAD:deploy
+          git push --force origin HEAD:refs/heads/deploy
 
           echo "deploy now at $(git rev-parse --short HEAD) (from ${SHORT}, image ${IMAGE})"


### PR DESCRIPTION
The first run of the new pin workflow (#250) failed at the last step.

`git push --force origin HEAD:deploy` cannot **create** a branch that doesn't exist yet — git won't guess a destination it can't resolve on the remote:

```
error: The destination you provided is not a full refname (i.e., starting with "refs/").
hint: Did you mean to create a new branch by pushing to
hint: 'HEAD:refs/heads/deploy'?
```

Everything before the push worked — it checked out the built sha, applied the pin, and committed `deploy: sha-f855ff5` with the `Deployed-From:` trailer. Only the push failed, so no branch was created.

**Nothing is broken in the meantime.** Flux still tracks `main`, which still carries a valid pin, and home-cloud#35 has deliberately not been merged — the sequencing in #250 was specifically so that a problem at this stage would be inert. It was.

Once this merges, the next build publishes `deploy` and I'll run the four verification checks before merging the home-cloud side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)