### PR TITLE
chore: remove unreachable state, and mark every unscoped helper _unsafe_

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,10 +58,16 @@ Agents.list_agents(user_id, filters)
 
 # WRONG — unsafe, admin-only, prefixed accordingly
 Agents._unsafe_get_agent(id)
-Agents._unsafe_list_agents()
+Conversations._unsafe_get_sandbox(id)
 ```
 
 Functions prefixed `_unsafe_` bypass tenant scoping. **Never call them from user-facing code.** They exist for admin views and internal tooling only.
+
+The prefix goes on *every* unscoped function, including ones whose callers
+happen to check ownership first — the reader of a call site should not have to
+go and find out. A legitimate caller is an admin surface behind `require_admin`,
+a system-level sweep like the rehydrator or `SandboxReaper`, or a GenServer that
+has already established ownership.
 
 ## Envelope encryption
 

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -8,20 +8,6 @@ defmodule Fountain.Agents do
   alias Fountain.Conversations.Conversation
   alias Fountain.Repo
 
-  @doc """
-  WARNING: returns agents across all tenants. Admin/internal use only.
-  User-facing code must use the arity-2 variant that takes user_id.
-  """
-  def _unsafe_list_agents(filters \\ []) do
-    from(a in Agent, order_by: [desc: a.inserted_at, desc: a.id], preload: [:environment])
-    |> apply_search(Keyword.get(filters, :search, ""))
-    |> apply_runtimes(Keyword.get(filters, :runtimes, []))
-    |> apply_env_ids(Keyword.get(filters, :env_ids, []))
-    |> apply_has_skills(Keyword.get(filters, :has_skills, false))
-    |> apply_has_mcp(Keyword.get(filters, :has_mcp, false))
-    |> Repo.all()
-  end
-
   @doc "WARNING: lookup by id without owner check. Admin/internal use only."
   def _unsafe_get_agent(id), do: Repo.get(Agent, id) |> Repo.preload(:environment)
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -13,9 +13,26 @@ defmodule Fountain.Conversations do
   alias Fountain.Conversations.{Conversation, LogEvent, Sandbox, Turn, TurnImage}
   alias Fountain.Repo
 
+  # ── on the _unsafe_ prefix ────────────────────────────────────────────────
+  #
+  # Every function here that does not scope by `user_id` carries the prefix,
+  # including the ones whose callers happen to check ownership first. That is
+  # the point of a convention: the reader of a call site should not have to go
+  # and find out.
+  #
+  # Several of these were unprefixed until #182 — `get_sandbox/1`,
+  # `list_turns/1`, `list_log_events/3` and friends. No call site was wrong, but
+  # nothing marked them either, so the audit that makes `_unsafe_` useful had a
+  # hole exactly where it mattered least visibly.
+  #
+  # A legitimate caller is one of: admin surfaces behind `require_admin`,
+  # system-level sweeps like the rehydrator and the reaper, or a GenServer that
+  # has already established ownership. Anything user-facing wants the scoped
+  # variant.
+
   # ── sandboxes ──────────────────────────────────────────────────────────────────────────
 
-  def list_sandboxes do
+  def _unsafe_list_sandboxes do
     Repo.all(from s in Sandbox, order_by: [desc: s.inserted_at])
   end
 
@@ -33,8 +50,8 @@ defmodule Fountain.Conversations do
     )
   end
 
-  def get_sandbox(id), do: Repo.get(Sandbox, id)
-  def get_sandbox!(id), do: Repo.get!(Sandbox, id)
+  def _unsafe_get_sandbox(id), do: Repo.get(Sandbox, id)
+  def _unsafe_get_sandbox!(id), do: Repo.get!(Sandbox, id)
 
   def create_sandbox(attrs) do
     %Sandbox{}
@@ -103,28 +120,15 @@ defmodule Fountain.Conversations do
   # ── conversations ─────────────────────────────────────────────────────────────────────
 
   @doc """
-  WARNING: returns conversations across all tenants. Only call from
-  admin-restricted paths or internal state lookups where ownership has
-  already been verified upstream.
-  """
-  def _unsafe_list_conversations do
-    Repo.all(
-      from c in Conversation,
-        order_by: [desc: c.inserted_at, desc: c.id],
-        preload: [:sandbox, :agent, turns: ^first_turn_query()]
-    )
-  end
-
-  @doc """
   Conversations the operator might still want to interact with: anything
   not in a terminal state. Ordered with active sessions on top
   (`running` > `idle`) and most-recent first within a status bucket.
   Used for the left-nav "active conversations" list.
   """
-  def list_active_conversations do
+  def _unsafe_list_active_conversations do
     Repo.all(
       from c in Conversation,
-        where: c.status not in ["terminated", "completed", "failed"],
+        where: c.status not in ["terminated", "failed"],
         order_by: [
           asc:
             fragment(
@@ -134,19 +138,6 @@ defmodule Fountain.Conversations do
           desc: c.inserted_at,
           desc: c.id
         ],
-        preload: [:agent, turns: ^first_turn_query()]
-    )
-  end
-
-  @doc """
-  WARNING: returns conversations across all tenants ordered by activity.
-  Admin/internal use only. User-facing code must use the arity-1 variant
-  that takes user_id.
-  """
-  def _unsafe_list_conversations_by_activity do
-    Repo.all(
-      from c in Conversation,
-        order_by: [desc: c.updated_at, desc: c.id],
         preload: [:agent, turns: ^first_turn_query()]
     )
   end
@@ -335,7 +326,7 @@ defmodule Fountain.Conversations do
   time of a clean BEAM stop: status `idle` or `running`, with a fully-
   provisioned (`ready`) sandbox.
   """
-  def list_resumable_conversations do
+  def _unsafe_list_resumable_conversations do
     Repo.all(
       from c in Conversation,
         join: s in Sandbox,
@@ -483,7 +474,7 @@ defmodule Fountain.Conversations do
 
   # ── turns ─────────────────────────────────────────────────────────────────────────────
 
-  def list_turns(conversation_id) do
+  def _unsafe_list_turns(conversation_id) do
     Repo.all(
       from t in Turn,
         where: t.conversation_id == ^conversation_id,
@@ -672,7 +663,7 @@ defmodule Fountain.Conversations do
     |> Repo.stream(max_rows: 100)
   end
 
-  def list_log_events(conversation_id, after_id \\ 0, opts \\ []) do
+  def _unsafe_list_log_events(conversation_id, after_id \\ 0, opts \\ []) do
     base =
       from e in LogEvent,
         where: e.conversation_id == ^conversation_id and e.id > ^after_id,
@@ -955,7 +946,7 @@ defmodule Fountain.Conversations do
   defp maybe_reuse_sandbox(%Conversation{sandbox_id: nil}), do: :create_new
 
   defp maybe_reuse_sandbox(%Conversation{sandbox_id: sandbox_id}) do
-    case get_sandbox(sandbox_id) do
+    case _unsafe_get_sandbox(sandbox_id) do
       %{status: "ready", sprite_name: name} when is_binary(name) ->
         client = Fountain.SpritesClient.get!()
 
@@ -1025,7 +1016,7 @@ defmodule Fountain.Conversations do
     end
   end
 
-  defp assert_resumable(%Conversation{status: s}) when s in ~w(terminated failed completed) do
+  defp assert_resumable(%Conversation{status: s}) when s in ~w(terminated failed) do
     {:error, :gone}
   end
 
@@ -1034,7 +1025,7 @@ defmodule Fountain.Conversations do
   defp mark_old_sandbox_terminated(nil), do: :ok
 
   defp mark_old_sandbox_terminated(sandbox_id) do
-    case get_sandbox(sandbox_id) do
+    case _unsafe_get_sandbox(sandbox_id) do
       nil ->
         :ok
 

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -10,7 +10,16 @@ defmodule Fountain.Conversations.Conversation do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
-  @statuses ~w(pending running idle completed failed terminated)
+  # No `completed`. It was in this list, three query sites filtered on it, and
+  # nothing ever wrote it — production has 247 terminated, 5 idle, 3 failed and
+  # zero completed, so every filter keyed on it was silently always empty.
+  #
+  # There is also no state it could describe. A conversation is either usable
+  # (pending/running/idle) or finished with (failed/terminated), and #167
+  # settled the ambiguous case: reclaiming an idle sandbox leaves the
+  # conversation `idle` and resumable rather than closing it. "Done" is the
+  # user's decision, and that is `terminated`.
+  @statuses ~w(pending running idle failed terminated)
   @sources ~w(ui api agent)
 
   schema "conversations" do

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -108,7 +108,7 @@ defmodule Fountain.Conversations.ConversationServer do
             {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
 
             if conv.sandbox_id do
-              sb = Conversations.get_sandbox!(conv.sandbox_id)
+              sb = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
 
               if sb.status not in ["terminated", "failed"] do
                 Conversations.update_sandbox(sb, %{status: "terminated", terminated_at: now})
@@ -174,7 +174,7 @@ defmodule Fountain.Conversations.ConversationServer do
   @impl true
   def handle_continue(:provision, state) do
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    sandbox = Conversations.get_sandbox!(state.sandbox_id)
+    sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
     agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id), else: nil
 
     env =
@@ -741,16 +741,6 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
-  def handle_call({:send_prompt, prompt}, _from, state) do
-    if state.current_command do
-      {:reply, {:error, :busy}, state}
-    else
-      conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-      agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
-      {:reply, :ok, kick_turn(state, prompt, agent, [])}
-    end
-  end
-
   def handle_call(:interrupt, _from, %{current_command: nil} = state) do
     {:reply, {:error, :idle}, state}
   end
@@ -798,7 +788,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   def handle_call(:terminate_conv, _from, state) do
     if state.sprite, do: _ = Sprites.destroy(state.sprite)
-    sandbox = Conversations.get_sandbox!(state.sandbox_id)
+    sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
 
     {:ok, _} =
       Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
@@ -952,7 +942,7 @@ defmodule Fountain.Conversations.ConversationServer do
     if state.sprite, do: _ = Sprites.destroy(state.sprite)
 
     if state.sandbox_id do
-      sandbox = Conversations.get_sandbox!(state.sandbox_id)
+      sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
 
       if sandbox.status not in ["terminated", "failed"] do
         {:ok, _} =

--- a/apps/fountain/lib/fountain/conversations/rehydrator.ex
+++ b/apps/fountain/lib/fountain/conversations/rehydrator.ex
@@ -109,7 +109,7 @@ defmodule Fountain.Conversations.Rehydrator do
 
   defp sweep do
     Fountain.Telemetry.span([:rehydrate], %{}, fn ->
-      convs = Conversations.list_resumable_conversations()
+      convs = Conversations._unsafe_list_resumable_conversations()
       Logger.info("rehydrator: scanning #{length(convs)} resumable conversation(s)")
 
       started =

--- a/apps/fountain/lib/fountain/conversations/sandbox.ex
+++ b/apps/fountain/lib/fountain/conversations/sandbox.ex
@@ -14,7 +14,6 @@ defmodule Fountain.Conversations.Sandbox do
   schema "sandboxes" do
     field :sprite_name, :string
     field :status, :string, default: "pending"
-    field :exit_code, :integer
     field :terminated_at, :utc_datetime
     belongs_to :environment, Environment
     belongs_to :user, User
@@ -26,7 +25,7 @@ defmodule Fountain.Conversations.Sandbox do
 
   def changeset(sandbox, attrs) do
     sandbox
-    |> cast(attrs, [:sprite_name, :status, :exit_code, :terminated_at, :environment_id, :user_id])
+    |> cast(attrs, [:sprite_name, :status, :terminated_at, :environment_id, :user_id])
     |> validate_required([:sprite_name, :status, :user_id])
     |> validate_inclusion(:status, @statuses)
   end

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -9,14 +9,6 @@ defmodule Fountain.Environments do
 
   # ── environments ──────────────────────────────────────────────────────────
 
-  @doc """
-  WARNING: returns environments across all tenants. Admin/internal use only.
-  User-facing code must use the arity-1 variant that takes user_id.
-  """
-  def _unsafe_list_environments do
-    Repo.all(from e in Environment, order_by: [desc: e.inserted_at, desc: e.id])
-  end
-
   @doc "WARNING: lookup by id without owner check. Admin/internal use only."
   def _unsafe_get_environment(id), do: Repo.get(Environment, id)
 

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -12,14 +12,6 @@ defmodule Fountain.Vaults do
 
   # ── vaults ────────────────────────────────────────────────────────────────
 
-  @doc """
-  WARNING: returns vaults across all tenants. Admin/internal use only.
-  User-facing code must use the arity-1 variant that takes user_id.
-  """
-  def _unsafe_list_vaults do
-    Repo.all(from v in Vault, order_by: [desc: v.inserted_at, desc: v.id])
-  end
-
   @doc "WARNING: lookup by id without owner check. Admin/internal use only."
   def _unsafe_get_vault(id), do: Repo.get(Vault, id)
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -61,7 +61,7 @@ defmodule FountainWeb.ConversationController do
         {:error, :not_found}
 
       _ ->
-        render(conn, :turns, turns: Conversations.list_turns(id))
+        render(conn, :turns, turns: Conversations._unsafe_list_turns(id))
     end
   end
 
@@ -469,7 +469,7 @@ defmodule FountainWeb.ConversationController do
 
   defp replay(conn, conv_id, after_id, streams) do
     conv_id
-    |> Conversations.list_log_events(after_id, streams: streams)
+    |> Conversations._unsafe_list_log_events(after_id, streams: streams)
     |> Enum.reduce({conn, after_id}, fn ev, {acc_conn, _} ->
       case write_event(acc_conn, ev) do
         {:ok, c} -> {c, ev.id}

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -194,7 +194,7 @@ defmodule FountainWeb.ConversationsLive.Index do
         <:col :let={c} label="">
           <div class="inline-flex gap-1 justify-end w-full">
             <.button
-              :if={c.status not in ["terminated", "completed", "failed"]}
+              :if={c.status not in ["terminated", "failed"]}
               variant="danger"
               phx-click="terminate"
               phx-value-id={c.id}

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -32,7 +32,7 @@ defmodule FountainWeb.ConversationsLive.Show do
           Conversations.mark_read(id, user_id)
         end
 
-        events = Conversations.list_log_events(id) |> annotate_durations()
+        events = Conversations._unsafe_list_log_events(id) |> annotate_durations()
 
         {:ok,
          socket
@@ -50,7 +50,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   end
 
   defp load_turns(conv_id) do
-    Conversations.list_turns(conv_id)
+    Conversations._unsafe_list_turns(conv_id)
     |> Enum.map(fn t ->
       image_count = length(t.images || [])
       Map.put(t, :image_count, image_count)
@@ -318,7 +318,7 @@ defmodule FountainWeb.ConversationsLive.Show do
             phx-click="interrupt" data-confirm="Stop the running turn?">
             Interrupt
           </.btn_secondary>
-          <.btn_danger :if={@conv.status not in ["terminated", "completed", "failed"]}
+          <.btn_danger :if={@conv.status not in ["terminated", "failed"]}
             phx-click="terminate" data-confirm="Terminate this conversation?">
             Terminate
           </.btn_danger>

--- a/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
@@ -23,7 +23,7 @@ defmodule FountainWeb.LogViewerLive.Show do
         )
       end
 
-      logs = Conversations.list_log_events(conversation.id)
+      logs = Conversations._unsafe_list_log_events(conversation.id)
 
       {:ok,
        socket

--- a/apps/fountain/priv/repo/migrations/20260802020000_drop_sandbox_exit_code.exs
+++ b/apps/fountain/priv/repo/migrations/20260802020000_drop_sandbox_exit_code.exs
@@ -1,0 +1,27 @@
+defmodule Fountain.Repo.Migrations.DropSandboxExitCode do
+  use Ecto.Migration
+
+  # `sandboxes.exit_code` has existed since the table was created, with a
+  # changeset cast and no writer anywhere. All 455 production rows are null.
+  #
+  # It is not a missing feature, it is the wrong home for the data. An exit code
+  # belongs to a *command*, and a sandbox runs many over its life — that is
+  # `turns.exit_code`, which is written and used. A single code on the sandbox
+  # could only ever mean "the last one", which is both ambiguous and already
+  # available by looking at the last turn.
+  #
+  # Dropping it rather than finding something to put in it: a column that is
+  # cast, never written and never read invites someone to start writing it,
+  # and then to reason about a value that means nothing in particular.
+  def up do
+    alter table(:sandboxes) do
+      remove :exit_code
+    end
+  end
+
+  def down do
+    alter table(:sandboxes) do
+      add :exit_code, :integer
+    end
+  end
+end

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -127,7 +127,6 @@ defmodule Fountain.AgentsTest do
     end
   end
 
-
   describe "_unsafe_get_agent/1 and _unsafe_get_agent!/1" do
     test "_unsafe_get_agent returns the agent by id" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -127,38 +127,6 @@ defmodule Fountain.AgentsTest do
     end
   end
 
-  describe "_unsafe_list_agents/1" do
-    test "returns agents across all users (no user_id filter)" do
-      user_a = insert_verified_user()
-      user_b = insert_verified_user()
-      agent_a = insert_agent(user_id: user_a.id)
-      agent_b = insert_agent(user_id: user_b.id)
-
-      ids = Agents._unsafe_list_agents() |> Enum.map(& &1.id)
-      assert agent_a.id in ids
-      assert agent_b.id in ids
-    end
-
-    test "search filter matches agent name" do
-      user = insert_verified_user()
-      insert_agent(user_id: user.id, name: "unsafe-alpha")
-      insert_agent(user_id: user.id, name: "unsafe-beta")
-
-      results = Agents._unsafe_list_agents(search: "unsafe-alpha")
-      assert length(results) == 1
-      assert hd(results).name == "unsafe-alpha"
-    end
-
-    test "runtimes filter returns only matching agents" do
-      user = insert_verified_user()
-      insert_agent(user_id: user.id, runtime: "gemini")
-      insert_agent(user_id: user.id, runtime: "claude")
-
-      results = Agents._unsafe_list_agents(runtimes: ["gemini"])
-      assert Enum.all?(results, &(&1.runtime == "gemini"))
-      assert Enum.any?(results, &(&1.runtime == "gemini"))
-    end
-  end
 
   describe "_unsafe_get_agent/1 and _unsafe_get_agent!/1" do
     test "_unsafe_get_agent returns the agent by id" do

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -41,7 +41,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
 
       {pid, _ref, :alive} = start_server(conv)
 
-      assert Conversations.get_sandbox!(sandbox.id).status == "ready"
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
       GenServer.stop(pid)
     end
 
@@ -85,7 +85,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       {pid, _ref, :alive} = start_server(conv, initial_prompt: "hello there")
 
       assert_received {:build_command, "hello there", _mode, _session, _opts}
-      assert [turn] = Conversations.list_turns(conv.id)
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
       assert turn.prompt == "hello there"
 
       GenServer.stop(pid)
@@ -96,7 +96,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
 
       {pid, _ref, :alive} = start_server(conv)
 
-      assert Conversations.list_turns(conv.id) == []
+      assert Conversations._unsafe_list_turns(conv.id) == []
       GenServer.stop(pid)
     end
   end
@@ -109,7 +109,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       {_pid, ref, _} = start_server(conv)
       assert_stopped(ref)
 
-      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "failed"
       assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
     end
 
@@ -143,7 +143,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       {_pid, ref, _} = start_server(conv, runtime: Fountain.Test.FailingRuntime)
       assert_stopped(ref)
 
-      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "failed"
     end
 
     test "an unexpected exception is caught and does not leave the sandbox pending", %{
@@ -161,7 +161,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       {_pid, ref, _} = start_server(conv)
       assert_stopped(ref)
 
-      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "failed"
       assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
     end
 
@@ -175,7 +175,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       {_pid, ref, _} = start_server(conv)
       assert_stopped(ref)
 
-      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "failed"
     end
   end
 
@@ -201,7 +201,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       send(pid, {:exit, %{ref: ref}, 0})
       _ = :sys.get_state(pid)
 
-      assert [turn] = Conversations.list_turns(conv.id)
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
       assert turn.status == "completed"
       assert turn.exit_code == 0
       assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
@@ -215,7 +215,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       send(pid, {:exit, %{ref: ref}, 1})
       _ = :sys.get_state(pid)
 
-      assert [turn] = Conversations.list_turns(conv.id)
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
       assert turn.status == "failed"
       assert turn.exit_code == 1
 
@@ -231,7 +231,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       send(pid, {:stdout, %{ref: ref}, "hello from the sprite"})
       _ = :sys.get_state(pid)
 
-      events = Conversations.list_log_events(conv.id)
+      events = Conversations._unsafe_list_log_events(conv.id)
       assert Enum.any?(events, &(&1.data =~ "hello from the sprite"))
 
       GenServer.stop(pid)
@@ -253,7 +253,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       _ = :sys.get_state(pid)
 
       assert :ok = GenServer.call(pid, {:send_prompt, "second", []})
-      assert length(Conversations.list_turns(conv.id)) == 2
+      assert length(Conversations._unsafe_list_turns(conv.id)) == 2
 
       GenServer.stop(pid)
     end
@@ -326,7 +326,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       assert :ok = ConversationServer.terminate(conv.id)
 
       assert Conversations._unsafe_get_conversation!(conv.id).status == "terminated"
-      assert Conversations.get_sandbox!(sandbox.id).status == "terminated"
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "terminated"
     end
 
     test "reports not_running for an unknown conversation" do
@@ -337,7 +337,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
 
       assert :ok = ConversationServer.terminate(conv.id)
-      assert Conversations.get_sandbox!(sandbox.id).status == "failed"
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "failed"
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_test.exs
@@ -37,9 +37,16 @@ defmodule Fountain.Conversations.ConversationTest do
   # ---------------------------------------------------------------------------
 
   describe "statuses/0" do
-    test "returns all six valid statuses" do
-      assert Conversation.statuses() ==
-               ~w(pending running idle completed failed terminated)
+    test "returns the five valid statuses" do
+      assert Conversation.statuses() == ~w(pending running idle failed terminated)
+    end
+
+    test "completed is not one of them" do
+      # It was, three query sites filtered on it, and nothing ever wrote it —
+      # production had 247 terminated, 5 idle, 3 failed and zero completed. A
+      # status nothing can produce makes every filter keyed on it silently
+      # empty, which is worse than not having it.
+      refute "completed" in Conversation.statuses()
     end
   end
 
@@ -107,7 +114,7 @@ defmodule Fountain.Conversations.ConversationTest do
   # ---------------------------------------------------------------------------
 
   describe "changeset/2 status inclusion" do
-    for status <- ~w(pending running idle completed failed terminated) do
+    for status <- ~w(pending running idle failed terminated) do
       test "accepts status '#{status}'" do
         assert changeset(%{status: unquote(status)}).valid?
       end
@@ -142,12 +149,13 @@ defmodule Fountain.Conversations.ConversationTest do
 
   describe "changeset/2 status transition" do
     test "casts a status change from 'pending' to 'running'" do
-      cs = Conversation.changeset(%Conversation{status: "pending"}, %{
-        runtime: "claude",
-        status: "running",
-        sandbox_id: Ecto.UUID.generate(),
-        user_id: Ecto.UUID.generate()
-      })
+      cs =
+        Conversation.changeset(%Conversation{status: "pending"}, %{
+          runtime: "claude",
+          status: "running",
+          sandbox_id: Ecto.UUID.generate(),
+          user_id: Ecto.UUID.generate()
+        })
 
       assert cs.valid?
       assert Ecto.Changeset.get_change(cs, :status) == "running"

--- a/apps/fountain/test/fountain/conversations/redaction_test.exs
+++ b/apps/fountain/test/fountain/conversations/redaction_test.exs
@@ -106,7 +106,7 @@ defmodule Fountain.Conversations.RedactionTest do
       Redaction.put(conv.id, [{"K", "value-that-must-not-persist"}])
       log_data(conv, "leaking value-that-must-not-persist here")
 
-      events = Conversations.list_log_events(conv.id)
+      events = Conversations._unsafe_list_log_events(conv.id)
 
       for e <- events do
         refute e.data =~ "value-that-must-not-persist"

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -9,9 +9,9 @@ defmodule Fountain.ConversationsContextTest do
   # Sandboxes
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "list_sandboxes/0" do
+  describe "_unsafe_list_sandboxes/0" do
     test "returns an empty list when no sandboxes exist" do
-      assert Conversations.list_sandboxes() == []
+      assert Conversations._unsafe_list_sandboxes() == []
     end
 
     test "returns all sandboxes" do
@@ -19,7 +19,7 @@ defmodule Fountain.ConversationsContextTest do
       s1 = insert_sandbox(user_id: user.id)
       s2 = insert_sandbox(user_id: user.id)
 
-      ids = Conversations.list_sandboxes() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_sandboxes() |> Enum.map(& &1.id)
       assert s1.id in ids
       assert s2.id in ids
     end
@@ -29,7 +29,7 @@ defmodule Fountain.ConversationsContextTest do
       s1 = insert_sandbox(user_id: user.id)
       s2 = insert_sandbox(user_id: user.id)
 
-      [first | _] = Conversations.list_sandboxes()
+      [first | _] = Conversations._unsafe_list_sandboxes()
       # Most recently inserted is first
       assert first.id == s2.id || first.inserted_at >= s1.inserted_at
     end
@@ -40,39 +40,39 @@ defmodule Fountain.ConversationsContextTest do
       s1 = insert_sandbox(user_id: user1.id)
       s2 = insert_sandbox(user_id: user2.id)
 
-      ids = Conversations.list_sandboxes() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_sandboxes() |> Enum.map(& &1.id)
       assert s1.id in ids
       assert s2.id in ids
     end
   end
 
-  describe "get_sandbox/1" do
+  describe "_unsafe_get_sandbox/1" do
     test "returns the sandbox when it exists" do
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id)
 
-      result = Conversations.get_sandbox(sandbox.id)
+      result = Conversations._unsafe_get_sandbox(sandbox.id)
       assert result.id == sandbox.id
       assert result.sprite_name == sandbox.sprite_name
     end
 
     test "returns nil when sandbox does not exist" do
-      assert Conversations.get_sandbox(Ecto.UUID.generate()) == nil
+      assert Conversations._unsafe_get_sandbox(Ecto.UUID.generate()) == nil
     end
   end
 
-  describe "get_sandbox!/1" do
+  describe "_unsafe_get_sandbox!/1" do
     test "returns the sandbox when it exists" do
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id)
 
-      result = Conversations.get_sandbox!(sandbox.id)
+      result = Conversations._unsafe_get_sandbox!(sandbox.id)
       assert result.id == sandbox.id
     end
 
     test "raises Ecto.NoResultsError when sandbox does not exist" do
       assert_raise Ecto.NoResultsError, fn ->
-        Conversations.get_sandbox!(Ecto.UUID.generate())
+        Conversations._unsafe_get_sandbox!(Ecto.UUID.generate())
       end
     end
   end
@@ -136,35 +136,10 @@ defmodule Fountain.ConversationsContextTest do
   # Conversations
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "_unsafe_list_conversations/0" do
-    test "returns an empty list when no conversations exist" do
-      assert Conversations._unsafe_list_conversations() == []
-    end
 
-    test "returns conversations across multiple users" do
-      user1 = insert_verified_user()
-      user2 = insert_verified_user()
-      c1 = insert_conversation(user_id: user1.id)
-      c2 = insert_conversation(user_id: user2.id)
-
-      ids = Conversations._unsafe_list_conversations() |> Enum.map(& &1.id)
-      assert c1.id in ids
-      assert c2.id in ids
-    end
-
-    test "preloads sandbox and agent" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-
-      [result | _] = Conversations._unsafe_list_conversations()
-      assert result.id == conv.id
-      assert %Sandbox{} = result.sandbox
-    end
-  end
-
-  describe "list_active_conversations/0" do
+  describe "_unsafe_list_active_conversations/0" do
     test "returns empty list when no conversations exist" do
-      assert Conversations.list_active_conversations() == []
+      assert Conversations._unsafe_list_active_conversations() == []
     end
 
     test "returns conversations with non-terminal statuses" do
@@ -173,21 +148,20 @@ defmodule Fountain.ConversationsContextTest do
       idle = insert_conversation(user_id: user.id, status: "idle")
       running = insert_conversation(user_id: user.id, status: "running")
 
-      ids = Conversations.list_active_conversations() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_active_conversations() |> Enum.map(& &1.id)
       assert pending.id in ids
       assert idle.id in ids
       assert running.id in ids
     end
 
-    test "excludes terminated, completed, and failed conversations" do
+    test "excludes terminated and failed conversations" do
       user = insert_verified_user()
       terminated = insert_conversation(user_id: user.id, status: "terminated")
-      completed = insert_conversation(user_id: user.id, status: "completed")
+
       failed = insert_conversation(user_id: user.id, status: "failed")
 
-      ids = Conversations.list_active_conversations() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_active_conversations() |> Enum.map(& &1.id)
       refute terminated.id in ids
-      refute completed.id in ids
       refute failed.id in ids
     end
 
@@ -197,7 +171,7 @@ defmodule Fountain.ConversationsContextTest do
       c1 = insert_conversation(user_id: user1.id, status: "pending")
       c2 = insert_conversation(user_id: user2.id, status: "idle")
 
-      ids = Conversations.list_active_conversations() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_active_conversations() |> Enum.map(& &1.id)
       assert c1.id in ids
       assert c2.id in ids
     end
@@ -464,12 +438,12 @@ defmodule Fountain.ConversationsContextTest do
   # Turns
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "list_turns/1" do
+  describe "_unsafe_list_turns/1" do
     test "returns empty list when conversation has no turns" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      assert Conversations.list_turns(conv.id) == []
+      assert Conversations._unsafe_list_turns(conv.id) == []
     end
 
     test "returns all turns for the conversation" do
@@ -478,7 +452,7 @@ defmodule Fountain.ConversationsContextTest do
       t1 = insert_turn(conv)
       t2 = insert_turn(conv)
 
-      ids = Conversations.list_turns(conv.id) |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_turns(conv.id) |> Enum.map(& &1.id)
       assert t1.id in ids
       assert t2.id in ids
     end
@@ -489,7 +463,7 @@ defmodule Fountain.ConversationsContextTest do
       t1 = insert_turn(conv)
       t2 = insert_turn(conv)
 
-      [first, second] = Conversations.list_turns(conv.id)
+      [first, second] = Conversations._unsafe_list_turns(conv.id)
       assert first.turn_number < second.turn_number
       assert first.id == t1.id
       assert second.id == t2.id
@@ -502,7 +476,7 @@ defmodule Fountain.ConversationsContextTest do
       t1 = insert_turn(conv1)
       _t2 = insert_turn(conv2)
 
-      results = Conversations.list_turns(conv1.id)
+      results = Conversations._unsafe_list_turns(conv1.id)
       assert length(results) == 1
       assert hd(results).id == t1.id
     end
@@ -749,7 +723,7 @@ defmodule Fountain.ConversationsContextTest do
     end
   end
 
-  describe "list_log_events/3" do
+  describe "_unsafe_list_log_events/3" do
     setup do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
@@ -761,7 +735,7 @@ defmodule Fountain.ConversationsContextTest do
       e2 = insert_log_event(conv, kind: "output", stream: "stderr", data: "b")
       e3 = insert_log_event(conv, kind: "stage", stream: "", stage: "provision")
 
-      ids = Conversations.list_log_events(conv.id) |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_log_events(conv.id) |> Enum.map(& &1.id)
       assert e1.id in ids
       assert e2.id in ids
       assert e3.id in ids
@@ -771,7 +745,7 @@ defmodule Fountain.ConversationsContextTest do
       e1 = insert_log_event(conv, kind: "output", stream: "stdout")
       e2 = insert_log_event(conv, kind: "stage", stream: "", stage: "provision")
 
-      ids = Conversations.list_log_events(conv.id, 0, streams: []) |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_log_events(conv.id, 0, streams: []) |> Enum.map(& &1.id)
       assert e1.id in ids
       assert e2.id in ids
     end
@@ -781,7 +755,7 @@ defmodule Fountain.ConversationsContextTest do
       stderr = insert_log_event(conv, kind: "output", stream: "stderr", data: "err")
       stage = insert_log_event(conv, kind: "stage", stream: "", stage: "provision")
 
-      results = Conversations.list_log_events(conv.id, 0, streams: ["stdout"])
+      results = Conversations._unsafe_list_log_events(conv.id, 0, streams: ["stdout"])
       ids = Enum.map(results, & &1.id)
       assert stdout.id in ids
       refute stderr.id in ids
@@ -793,7 +767,7 @@ defmodule Fountain.ConversationsContextTest do
       stderr = insert_log_event(conv, kind: "output", stream: "stderr")
       stage = insert_log_event(conv, kind: "stage", stream: "", stage: "provision")
 
-      results = Conversations.list_log_events(conv.id, 0, streams: ["stderr"])
+      results = Conversations._unsafe_list_log_events(conv.id, 0, streams: ["stderr"])
       ids = Enum.map(results, & &1.id)
       refute stdout.id in ids
       assert stderr.id in ids
@@ -805,7 +779,7 @@ defmodule Fountain.ConversationsContextTest do
       stderr = insert_log_event(conv, kind: "output", stream: "stderr")
       stage = insert_log_event(conv, kind: "stage", stream: "", stage: "provision")
 
-      results = Conversations.list_log_events(conv.id, 0, streams: ["stage"])
+      results = Conversations._unsafe_list_log_events(conv.id, 0, streams: ["stage"])
       ids = Enum.map(results, & &1.id)
       refute stdout.id in ids
       refute stderr.id in ids
@@ -817,7 +791,7 @@ defmodule Fountain.ConversationsContextTest do
       stderr = insert_log_event(conv, kind: "output", stream: "stderr")
       stage = insert_log_event(conv, kind: "stage", stream: "", stage: "provision")
 
-      results = Conversations.list_log_events(conv.id, 0, streams: ["stdout", "stage"])
+      results = Conversations._unsafe_list_log_events(conv.id, 0, streams: ["stdout", "stage"])
       ids = Enum.map(results, & &1.id)
       assert stdout.id in ids
       refute stderr.id in ids
@@ -827,7 +801,7 @@ defmodule Fountain.ConversationsContextTest do
     test "streams: [\"unknown\"] returns empty list (unknown stream filter)", %{conv: conv} do
       _e = insert_log_event(conv, kind: "output", stream: "stdout")
 
-      assert Conversations.list_log_events(conv.id, 0, streams: ["unknown"]) == []
+      assert Conversations._unsafe_list_log_events(conv.id, 0, streams: ["unknown"]) == []
     end
 
     test "after_id filters events with id greater than after_id", %{conv: conv} do
@@ -835,7 +809,7 @@ defmodule Fountain.ConversationsContextTest do
       e2 = insert_log_event(conv, kind: "output", stream: "stdout")
       e3 = insert_log_event(conv, kind: "output", stream: "stdout")
 
-      ids = Conversations.list_log_events(conv.id, e1.id) |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_log_events(conv.id, e1.id) |> Enum.map(& &1.id)
       refute e1.id in ids
       assert e2.id in ids
       assert e3.id in ids
@@ -846,7 +820,7 @@ defmodule Fountain.ConversationsContextTest do
       e2 = insert_log_event(conv, kind: "output", stream: "stdout")
       e3 = insert_log_event(conv, kind: "output", stream: "stdout")
 
-      ids = Conversations.list_log_events(conv.id) |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_log_events(conv.id) |> Enum.map(& &1.id)
       assert ids == Enum.sort(ids)
       assert hd(ids) == e1.id
       assert List.last(ids) == e3.id
@@ -858,7 +832,7 @@ defmodule Fountain.ConversationsContextTest do
       _other = insert_log_event(other_conv, kind: "output", stream: "stdout")
       mine = insert_log_event(conv, kind: "output", stream: "stdout")
 
-      results = Conversations.list_log_events(conv.id)
+      results = Conversations._unsafe_list_log_events(conv.id)
       ids = Enum.map(results, & &1.id)
       assert ids == [mine.id]
     end
@@ -945,17 +919,17 @@ defmodule Fountain.ConversationsContextTest do
   end
 
   # ────────────────────────────────────────────────────────────────────────────
-  # list_resumable_conversations/0
+  # _unsafe_list_resumable_conversations/0
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "list_resumable_conversations/0" do
+  describe "_unsafe_list_resumable_conversations/0" do
     test "returns idle conversation whose sandbox is ready" do
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id)
       {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
       conv = insert_conversation(user_id: user.id, status: "idle", sandbox_id: sandbox.id)
 
-      ids = Conversations.list_resumable_conversations() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_resumable_conversations() |> Enum.map(& &1.id)
       assert conv.id in ids
     end
 
@@ -965,7 +939,7 @@ defmodule Fountain.ConversationsContextTest do
       {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
       conv = insert_conversation(user_id: user.id, status: "running", sandbox_id: sandbox.id)
 
-      ids = Conversations.list_resumable_conversations() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_resumable_conversations() |> Enum.map(& &1.id)
       assert conv.id in ids
     end
 
@@ -975,7 +949,7 @@ defmodule Fountain.ConversationsContextTest do
       # sandbox remains "pending"
       conv = insert_conversation(user_id: user.id, status: "idle", sandbox_id: sandbox.id)
 
-      ids = Conversations.list_resumable_conversations() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_resumable_conversations() |> Enum.map(& &1.id)
       refute conv.id in ids
     end
 
@@ -985,17 +959,20 @@ defmodule Fountain.ConversationsContextTest do
       {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
       conv = insert_conversation(user_id: user.id, status: "terminated", sandbox_id: sandbox.id)
 
-      ids = Conversations.list_resumable_conversations() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_resumable_conversations() |> Enum.map(& &1.id)
       refute conv.id in ids
     end
 
-    test "excludes completed conversation even when sandbox is ready" do
+    test "excludes a terminated conversation even when sandbox is ready" do
+      # The sandbox being usable is not enough; the conversation has to be one
+      # someone can still talk to. This used to be asserted with "completed",
+      # a status nothing could produce, so it proved nothing.
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id)
       {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
-      conv = insert_conversation(user_id: user.id, status: "completed", sandbox_id: sandbox.id)
+      conv = insert_conversation(user_id: user.id, status: "terminated", sandbox_id: sandbox.id)
 
-      ids = Conversations.list_resumable_conversations() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_resumable_conversations() |> Enum.map(& &1.id)
       refute conv.id in ids
     end
 
@@ -1005,14 +982,14 @@ defmodule Fountain.ConversationsContextTest do
       {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
       conv = insert_conversation(user_id: user.id, status: "idle", sandbox_id: sandbox.id)
 
-      results = Conversations.list_resumable_conversations()
+      results = Conversations._unsafe_list_resumable_conversations()
       result = Enum.find(results, &(&1.id == conv.id))
       assert %Sandbox{} = result.sandbox
       assert result.sandbox.id == sandbox.id
     end
 
     test "returns empty list when no resumable conversations exist" do
-      assert Conversations.list_resumable_conversations() == []
+      assert Conversations._unsafe_list_resumable_conversations() == []
     end
   end
 
@@ -1219,48 +1196,6 @@ defmodule Fountain.ConversationsContextTest do
   # _unsafe_list_conversations_by_activity/0
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "_unsafe_list_conversations_by_activity/0" do
-    test "returns empty list when no conversations exist" do
-      assert Conversations._unsafe_list_conversations_by_activity() == []
-    end
-
-    test "returns conversations across all users" do
-      user1 = insert_verified_user()
-      user2 = insert_verified_user()
-      c1 = insert_conversation(user_id: user1.id)
-      c2 = insert_conversation(user_id: user2.id)
-
-      ids = Conversations._unsafe_list_conversations_by_activity() |> Enum.map(& &1.id)
-      assert c1.id in ids
-      assert c2.id in ids
-    end
-
-    test "orders conversations by updated_at descending" do
-      user = insert_verified_user()
-      c1 = insert_conversation(user_id: user.id)
-      c2 = insert_conversation(user_id: user.id)
-
-      # Backdate c2 so c1 sorts first
-      past = DateTime.add(DateTime.utc_now(), -3600, :second) |> DateTime.truncate(:second)
-
-      Fountain.Repo.update_all(
-        Ecto.Query.from(c in Conversation, where: c.id == ^c2.id),
-        set: [updated_at: past]
-      )
-
-      [first | _] = Conversations._unsafe_list_conversations_by_activity()
-      assert first.id == c1.id
-    end
-
-    test "preloads agent association" do
-      user = insert_verified_user()
-      _conv = insert_conversation(user_id: user.id)
-
-      [result | _] = Conversations._unsafe_list_conversations_by_activity()
-      # agent may be nil but the key must be present and not an Ecto.Association
-      assert Map.has_key?(result, :agent)
-    end
-  end
 
   # ────────────────────────────────────────────────────────────────────────────
   # _unsafe_get_conversation_tree/1
@@ -1462,11 +1397,16 @@ defmodule Fountain.ConversationsContextTest do
       assert {:error, :gone} = Conversations.wake_conversation(conv.id)
     end
 
-    test "returns {:error, :gone} when conversation status is completed" do
+    test "an idle conversation whose sandbox was reclaimed is still resumable" do
+      # The case #167 created and the reason `completed` was never needed:
+      # reclaiming an idle sandbox leaves the conversation resumable rather
+      # than closing it, so waking it must not be refused as :gone.
       user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id, status: "completed")
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, status: "terminated")
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
 
-      assert {:error, :gone} = Conversations.wake_conversation(conv.id)
+      refute match?({:error, :gone}, Conversations.wake_conversation(conv.id))
     end
 
     test "returns {:error, :no_agent} when conversation has no agent_id" do
@@ -1773,16 +1713,16 @@ defmodule Fountain.ConversationsContextTest do
   end
 
   # ────────────────────────────────────────────────────────────────────────────
-  # list_active_conversations/0 — ordering
+  # _unsafe_list_active_conversations/0 — ordering
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "list_active_conversations/0 ordering" do
+  describe "_unsafe_list_active_conversations/0 ordering" do
     test "running conversations appear before idle conversations" do
       user = insert_verified_user()
       idle = insert_conversation(user_id: user.id, status: "idle")
       running = insert_conversation(user_id: user.id, status: "running")
 
-      results = Conversations.list_active_conversations()
+      results = Conversations._unsafe_list_active_conversations()
       active_ids = results |> Enum.map(& &1.id) |> Enum.filter(&(&1 in [idle.id, running.id]))
       assert hd(active_ids) == running.id
     end

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -136,7 +136,6 @@ defmodule Fountain.ConversationsContextTest do
   # Conversations
   # ────────────────────────────────────────────────────────────────────────────
 
-
   describe "_unsafe_list_active_conversations/0" do
     test "returns empty list when no conversations exist" do
       assert Conversations._unsafe_list_active_conversations() == []
@@ -1195,7 +1194,6 @@ defmodule Fountain.ConversationsContextTest do
   # ────────────────────────────────────────────────────────────────────────────
   # _unsafe_list_conversations_by_activity/0
   # ────────────────────────────────────────────────────────────────────────────
-
 
   # ────────────────────────────────────────────────────────────────────────────
   # _unsafe_get_conversation_tree/1

--- a/apps/fountain/test/fountain/environments_test.exs
+++ b/apps/fountain/test/fountain/environments_test.exs
@@ -181,18 +181,6 @@ defmodule Fountain.EnvironmentsTest do
     end
   end
 
-  describe "_unsafe_list_environments/0" do
-    test "returns all environments regardless of user" do
-      u1 = insert_verified_user()
-      u2 = insert_verified_user()
-      e1 = insert_env(user_id: u1.id)
-      e2 = insert_env(user_id: u2.id)
-
-      ids = Environments._unsafe_list_environments() |> Enum.map(& &1.id)
-      assert e1.id in ids
-      assert e2.id in ids
-    end
-  end
 
   describe "_unsafe_get_environment/1" do
     test "returns the environment by id" do

--- a/apps/fountain/test/fountain/environments_test.exs
+++ b/apps/fountain/test/fountain/environments_test.exs
@@ -181,7 +181,6 @@ defmodule Fountain.EnvironmentsTest do
     end
   end
 
-
   describe "_unsafe_get_environment/1" do
     test "returns the environment by id" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain/vaults_test.exs
+++ b/apps/fountain/test/fountain/vaults_test.exs
@@ -192,31 +192,6 @@ defmodule Fountain.VaultsTest do
     end
   end
 
-  describe "_unsafe_list_vaults/0" do
-    test "returns an empty list when no vaults exist" do
-      assert Vaults._unsafe_list_vaults() == []
-    end
-
-    test "returns vaults across all users" do
-      user_a = insert_verified_user()
-      user_b = insert_verified_user()
-      vault_a = insert_vault(user_id: user_a.id)
-      vault_b = insert_vault(user_id: user_b.id)
-
-      ids = Vaults._unsafe_list_vaults() |> Enum.map(& &1.id)
-      assert vault_a.id in ids
-      assert vault_b.id in ids
-    end
-
-    test "orders by inserted_at descending" do
-      user = insert_verified_user()
-      v1 = insert_vault(user_id: user.id)
-      v2 = insert_vault(user_id: user.id)
-
-      [first | _] = Vaults._unsafe_list_vaults()
-      assert first.id == v2.id || first.inserted_at >= v1.inserted_at
-    end
-  end
 
   describe "_unsafe_get_vault/1" do
     test "returns the vault when it exists" do

--- a/apps/fountain/test/fountain/vaults_test.exs
+++ b/apps/fountain/test/fountain/vaults_test.exs
@@ -192,7 +192,6 @@ defmodule Fountain.VaultsTest do
     end
   end
 
-
   describe "_unsafe_get_vault/1" do
     test "returns the vault when it exists" do
       user = insert_verified_user()


### PR DESCRIPTION
Closes #197. Closes #182.

Two pieces of hygiene that were each half a footgun.

## #197 — state nothing could produce

**`completed` was in the conversation status enum** and three query sites filtered on it, but nothing ever wrote it. Production:

| status | count |
|---|---|
| terminated | 247 |
| idle | 5 |
| failed | 3 |
| **completed** | **0** |

So every filter keyed on it was silently always empty — the worst kind of dead code, because it reads as working.

There's also no state it *could* describe. A conversation is either usable (`pending`/`running`/`idle`) or finished with (`failed`/`terminated`), and #167 settled the ambiguous case: reclaiming an idle sandbox leaves the conversation resumable rather than closing it. "Done" is the user's decision, and that's `terminated`.

**`sandboxes.exit_code`** had a column, a changeset cast, no writer, and 455 null rows. It's not a missing feature — it's the wrong home for the data. An exit code belongs to a *command*, and a sandbox runs many over its life; that's `turns.exit_code`, which is written and read. A single code on the sandbox could only mean "the last one", which is ambiguous and already available from the last turn.

Dropped rather than filled in, because a column that's cast and never written invites someone to start writing it and then to reason about a value that means nothing in particular. The migration's `down` restores it; no data is lost since every row is null.

Also removes the dead arity-2 `handle_call({:send_prompt, prompt}, ...)` clause — unreachable since `send_prompt/3` defaults `images`.

## #182 — the convention had a hole where it mattered least visibly

`get_sandbox/1`, `get_sandbox!/1`, `list_sandboxes/0`, `list_active_conversations/0`, `list_resumable_conversations/0`, `list_turns/1` and `list_log_events/3` are all unscoped and none carried the prefix.

No call site was wrong — each checks ownership first, and the audit in #182 confirmed that. But nothing *said* so, and the point of the convention is that a reader of a call site shouldn't have to go and find out. All renamed.

Five `_unsafe_list_*` functions had no callers outside their own tests. Deleted, with the tests — a footgun that exists only to be tested is still a footgun.

`CLAUDE.md` and the context module now state the rule and what counts as a legitimate caller (admin surfaces behind `require_admin`, system-level sweeps like the rehydrator and `SandboxReaper`, or a GenServer that already established ownership), since the prefix only works if people know when it's required rather than optional.

## A note on how this was done

My first pass at deleting the dead functions used a broad regex that also swallowed `update_sandbox/2` and the sandbox usage-recording functions next to it — i.e. billing code. It surfaced immediately as a compile error, and I reverted that file and redid the edits with exact, bounded matches rather than patching the damage back. Worth mentioning because the diff touches 20 files and "it compiles and the tests pass" is doing a lot of work; I also diffed removed `def` lines against HEAD to confirm only the intended functions went.

Full suite: 1489 tests, 0 failures. Format and strict credo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)