### PR TITLE
release: version-tag the server image, restore the changelog (#190)

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -33,8 +33,10 @@ SPRITES_TOKEN=
 
 # POSTGRES_PASSWORD=postgres
 
-# Pin the image rather than tracking latest.
-# FOUNTAIN_IMAGE_TAG=latest
+# Pin the image rather than tracking latest. Releases publish vX.Y.Z
+# (immutable) and vX.Y (newest patch in the line) tags:
+# https://binarybourbon.github.io/fountain/self-hosting/#versioning-and-upgrades
+# FOUNTAIN_IMAGE_TAG=v0.3.0
 
 # Mail. The default (EMAIL_DELIVERY=none) sends nothing, so verify accounts
 # with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      # docs/changelog.md includes this via pymdownx.snippets, so editing it
+      # must rebuild the site.
+      - 'CHANGELOG.md'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
-# Builds the Go CLI under cli/ and attaches binaries to a GitHub
-# Release. Triggered by pushing a v*.*.* tag, or manually via
-# workflow_dispatch with an existing tag.
+# Builds the Go CLI under cli/, publishes the version-tagged server
+# image, and attaches binaries to a GitHub Release. Triggered by
+# pushing a v*.*.* tag, or manually via workflow_dispatch with an
+# existing tag.
 
 on:
   push:
@@ -148,11 +149,90 @@ jobs:
           name: openapi.json
           path: dist/openapi.json
 
+  image:
+    # The server image is built fresh from the tag's tree rather than
+    # re-tagging the sha- image build.yml already pushed, for two reasons:
+    # the tag points at release-bump's version commit, which build.yml never
+    # built ([skip ci] + GITHUB_TOKEN suppression), and the mix.exs version
+    # baked into the image is surfaced in-app — it must match the tag.
+    #
+    # Tags: vX.Y.Z is immutable; vX.Y moves to the newest patch in its line.
+    # :latest continues to track main via build.yml and is not touched here.
+    name: Publish versioned server image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ github.event.inputs.tag }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          if ! echo "${tag}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "'${tag}' is not a vX.Y.Z tag" >&2
+            exit 1
+          fi
+          {
+            echo "tag=${tag}"
+            echo "minor=${tag%.*}"
+            echo "version=${tag#v}"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # The tag's commit, explicitly — a workflow_dispatch runs on the
+          # ref it was dispatched from, which need not be the tag.
+          ref: refs/tags/${{ steps.tag.outputs.tag }}
+          persist-credentials: false
+
+      - name: Resolve build sha
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BUILD_SHA=${{ steps.sha.outputs.sha }}
+          tags: |
+            ghcr.io/binarybourbon/fountain:${{ steps.tag.outputs.tag }}
+            ghcr.io/binarybourbon/fountain:${{ steps.tag.outputs.minor }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.sha.outputs.sha }}
+            org.opencontainers.image.version=${{ steps.tag.outputs.version }}
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, openapi]
+    # image is a needs so a release is never published without its image —
+    # the release page is what tells a self-hoster the tag exists to pin.
+    needs: [build, openapi, image]
     permissions:
       contents: write
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,143 @@
 # Changelog
 
-All notable changes to Fountain are documented here. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+All notable changes to Fountain are documented here. Format:
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
+[SemVer](https://semver.org/).
 
-Versions track the public API and notable behavioural changes. Internal refactors, test additions, and doc updates are noted but don't bump the version on their own.
+Pre-1.0, a minor bump (`0.x` → `0.y`) may include breaking changes; when one
+does, the release carries an **Upgrade notes** section. Patch releases are
+always safe to take. Every release publishes the server image to
+`ghcr.io/binarybourbon/fountain` as `vX.Y.Z` (immutable) and `vX.Y` (moving,
+newest patch in the line). The full policy, including how migrations run on
+upgrade, is in
+[Versioning and upgrades](https://binarybourbon.github.io/fountain/self-hosting/#versioning-and-upgrades).
 
 ---
 
 ## [Unreleased]
 
+### Upgrade notes
+
+- Set `PUBLIC_URL` to your external URL, scheme included. It is now separate
+  from `PHX_HOST` and is what generated links, OAuth callbacks, and sandbox
+  callbacks are built from (#204). An `https://` `PUBLIC_URL` also switches on
+  the HTTPS redirect, HSTS, and secure session cookies (#241) — if you
+  terminate TLS in front of Fountain, your proxy must set `X-Forwarded-Proto`.
+- Production now refuses to boot without a mail setting. Configure
+  `RESEND_API_KEY`, `SMTP_HOST`, or explicitly opt out with
+  `EMAIL_DELIVERY=none` (#223).
+- Migrations continue to run automatically at boot; no manual steps.
+
 ### Added
-- Context-level ExUnit tests for `Agents`, `Environments`, `Vaults`, `Audit`, and `Substitution` (all `async: true`, using `DataCase` + factory helpers)
-- StreamData property-based tests for `Fountain.Substitution`
-- GitHub Actions CI pipeline (`.github/workflows/ci.yml`): format check, compile with warnings-as-errors, Credo, DB migrate, full test suite
-- `CLAUDE.md` contributor guide covering architecture, test patterns, tenant isolation contract, and things to avoid
+
+- Bulk manifest apply — a whole manifest in one request, and the CLI's
+  `fountain apply` uses it (#151)
+- Agent-scoped vault allowlists: an agent can be restricted to a named set of
+  vaults (#144)
+- `networking_config` on Environment, typed and documented (#146)
+- `metadata` field on Environment and Vault for external tooling (#145)
+- `GET /api/auth/api-keys` — list active keys, metadata only (#143)
+- GitHub-sourced agent skills require a ref/SHA pin (#149)
+- Account deletion, self-serve and admin (#234)
+- Billing that holds: real Stripe trial subscriptions with end dates (#244), a
+  warning email three days before a trial ends (#251), usage events (#213),
+  idempotent order-aware webhooks (#214), and billing gates on every
+  provisioning path (#212)
+- Sandbox lifecycle bounds: per-tenant concurrent-sandbox cap (#205), idle
+  timeout and maximum age (#233), and a reaper for leaked sprites and rows
+  stuck mid-provision (#232)
+- Durable job queue (#217)
+- Self-hosting support: compose file and guide (#225), configurable
+  `SPRITES_BASE_URL` (#189), database TLS / billing / registration switches
+  (#224), SMTP delivery (#223), split liveness and readiness probes (#230),
+  and an explicit MIT licence (#226)
+- LLM-generated conversation titles, agent avatars, unread indicators, and a
+  live-updating sidebar
+- Public documentation site (MkDocs); OTel instrumentation for the
+  conversation lifecycle (#125); Prometheus/Loki/Alertmanager wiring for the
+  hosted instance (#210)
+- Context-level and property-based test suites, with coverage held above a CI
+  floor
 
 ### Changed
-- Test DB `pool_size` raised from 5 → 20 to support concurrent async test modules without connection timeouts
-- `require_admin` LiveView hook now uses `push_navigate` (live redirect) for authenticated non-admin users instead of a hard HTTP redirect, making the hook testable with `{:live_redirect, _}` assertions
-- `advance_onboarding/2` guard extended to include `"step_4"` (wizard has four steps)
+
+- Agent, environment, and vault editors use structured form UI instead of raw
+  JSON textareas (#122–#124)
+- Sandboxes are named `fountain-<tenant>-<id>` (#70)
+- The hosted instance runs two clustered replicas (#132), with a single
+  elected leader for conversation rehydration (#133)
+- CI actually gates: strict Credo, coverage floor, sobelow, secret scanning,
+  CLI tests on release (#237), and a smoke test that boots the built image
+  against its own health probes (#249)
+- Deploys pin the exact built image on a dedicated `deploy` branch so manifest
+  and image can never diverge (#250)
 
 ### Fixed
-- `PasswordResetController` now returns `422 Unprocessable Entity` (was `200 OK`) on validation failure
-- Rate limiter keyed by calling process PID in test mode so async tests don't share ETS counters
-- `UeberAuthController` skips `plug Ueberauth` in test mode to prevent OAuth plug from overwriting manually-set `conn.assigns`
 
----
+- Conversations no longer replay their last prompt on every deploy (#248)
+- The SSE stream endpoint no longer 406s real clients (#229), and the CLI
+  resumes a dropped stream instead of reporting success (#219)
+- `force_ssl` is applied as a runtime plug (#243), with health probes exempt
+  from the HTTPS redirect (#245)
+- Paid checkouts are never orphaned (#212)
+- Turn images are validated at ingest, not only on serve (#235)
+- `agents.skills` migrated from `text[]` to `jsonb[]` (#65)
+- `PasswordResetController` returns `422 Unprocessable Entity` (was `200 OK`)
+  on validation failure
+
+### Security
+
+- HSTS, secure cookies, and a scoped `check_origin`, all derived from
+  `PUBLIC_URL` (#241)
+- OAuth identities require a provider-verified email before linking (#240)
+- Tenant secrets are redacted from sprite output before it is persisted (#222)
+- Real client IP resolution behind proxies, and rate-limited login forms
+  (#216)
+- Tenant scoping tightened across the conversation spawn graph (#215), turn
+  images (#202), sprite callback tokens — now with key expiry (#206), audit
+  events (#68), and per-conversation `FOUNTAIN_TOKEN`s scoped to their owner
+  (#75)
+- Provisioning hardening: `.env` values quoted inertly, SSH host keys
+  verified (#227)
+- Audit coverage extended to the browser surface, auth events, and admin
+  actions (#221); external audit findings addressed (#129, #130)
+
+## [0.2.1] — 2026-05-10
+
+### Fixed
+
+- CLI defaults its base URL to `fountain.inevitable.fyi` (#62)
+- Dashboard "Recent conversations" card links to `/conversations`
+
+## [0.2.0] — 2026-05-10
+
+### Added
+
+- Public marketing landing page at `/`
+- Cross-tenant security regression suite (#55)
+
+### Changed
+
+- CLI ported from Elixir/Burrito to Go; the Elixir CLI and its release
+  pipeline are removed (#60, #47, #50)
+- Unscoped context functions renamed `_unsafe_*` as an enforcement convention
+  (#54)
+
+### Fixed
+
+- Postgres `$N` placeholders in recursive CTE queries (#58)
+- `fountain apply` strips ownership fields before POST/PUT (#59)
+
+### Security
+
+- Agent, Environment, Secret, and Vault controllers scoped to the
+  authenticated user (#49, #51, #52); `user_id` propagated through
+  `start_conversation` and orphaned rows backfilled (#48)
 
 ## [0.1.0] — 2026-04-01
 
 ### Added
+
 - Multi-tenant API and UI for managing Agents, Environments, Vaults, and Conversations
 - GitHub OAuth login via Ueberauth
 - Stripe billing integration with subscription enforcement
@@ -40,3 +149,8 @@ Versions track the public API and notable behavioural changes. Internal refactor
 - `llms.txt` / `llms-full.txt` / `/skill` endpoints for LLM-native API discovery
 - Audit log for state-changing actions (append-only, best-effort)
 - Substitution engine for `${VAR}` / `$$` interpolation in agent configs
+
+[Unreleased]: https://github.com/BinaryBourbon/fountain/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/BinaryBourbon/fountain/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/BinaryBourbon/fountain/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/BinaryBourbon/fountain/releases/tag/v0.1.0

--- a/apps/fountain/mix.exs
+++ b/apps/fountain/mix.exs
@@ -4,7 +4,7 @@ defmodule Fountain.MixProject do
   def project do
     [
       app: :fountain,
-      version: "0.1.0",
+      version: "0.2.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,36 +1,5 @@
-# Changelog
+<!-- The changelog lives in the repo root (CHANGELOG.md). This page pulls
+     it in verbatim via pymdownx.snippets so the two can never drift.
+     Edit CHANGELOG.md, not this file. -->
 
-This page mirrors [`CHANGELOG.md`](https://github.com/BinaryBourbon/fountain/blob/main/CHANGELOG.md) in the repo root.
-
----
-
-## [Unreleased]
-
-### Added
-- Context-level ExUnit tests for `Agents`, `Environments`, `Vaults`, `Audit`, and `Substitution`
-- StreamData property-based tests for `Fountain.Substitution`
-- GitHub Actions CI pipeline: format check, compile warnings-as-errors, Credo, DB migrate, full suite
-- `CLAUDE.md` contributor guide
-- This public documentation site
-
-### Changed
-- Test DB pool size raised from 5 to 20 to support concurrent async test modules
-- `require_admin` LiveView hook now uses `push_navigate` for authenticated non-admin users
-
-### Fixed
-- `PasswordResetController` returns `422` on validation failure (was `200`)
-- Rate limiter uses PID-based isolation in test mode
-- `UeberAuthController` skips `plug Ueberauth` in test mode
-
----
-
-## [0.1.0] - 2026-04-01
-
-### Added
-- Multi-tenant API and UI for Agents, Environments, Vaults, and Conversations
-- GitHub OAuth, Stripe billing, per-tenant envelope encryption
-- Sprites sandbox integration with streaming log events
-- LiveView UI, REST API with API-key auth, per-tenant rate limiting
-- `fountain` CLI with `auth`, `apply`, `get`, `describe`, `delete`, `run`
-- `/llms.txt`, `/llms-full.txt`, `/skill` for LLM-native API discovery
-- Audit log, substitution engine
+--8<-- "CHANGELOG.md"

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -14,8 +14,8 @@ is a different thing, and this page assumes you want an instance that stays up.
 | **A mail provider** | Resend or any SMTP server. Optional — see [Email](#email) |
 
 Sprites is currently the only sandbox backend, and it is a hosted service, so a
-Fountain instance is not fully self-contained. `SPRITES_BASE_URL` is not yet
-configurable ([#189](https://github.com/BinaryBourbon/fountain/issues/189)).
+Fountain instance is not fully self-contained. `SPRITES_BASE_URL` repoints the
+API endpoint if you have a compatible one; there is no bundled alternative.
 
 ## Quick start
 
@@ -53,6 +53,43 @@ for the first admin yet:
 docker compose exec postgres psql -U postgres -d fountain \
   -c "UPDATE users SET role = 'admin' WHERE email = 'you@example.com';"
 ```
+
+## Versioning and upgrades
+
+Fountain follows [SemVer](https://semver.org/), pre-1.0: a patch release
+(`v0.3.0` → `v0.3.1`) is always safe to take; a minor release (`v0.3` → `v0.4`)
+may include breaking changes, and calls them out under **Upgrade notes** in the
+[changelog](changelog.md).
+
+Each release publishes the server image to `ghcr.io/binarybourbon/fountain`
+under two tags, alongside the tags that track development:
+
+| Tag | Moves? | Use it for |
+|---|---|---|
+| `vX.Y.Z` | Never | Pinning a known version — the recommended default |
+| `vX.Y` | To the newest patch in the line | Taking patches automatically without risking a breaking minor |
+| `latest` | On every merge to `main` | Nothing you keep running — it moves under you |
+| `sha-<commit>` | Never | Reproducing exactly what a given commit built |
+
+Releases v0.2.1 and earlier predate image tagging and exist only as `sha-`
+tags.
+
+The compose file reads `FOUNTAIN_IMAGE_TAG` from `.env`, so pinning is one
+line:
+
+```bash
+echo "FOUNTAIN_IMAGE_TAG=v0.3.0" >> .env
+```
+
+Upgrading is editing that value, then `docker compose pull && docker compose
+up -d`. Migrations run automatically at boot — idempotently, under an advisory
+lock — so rolling replicas do not race each other, and there are no manual
+migration steps unless a release's upgrade notes say otherwise. Downgrading is
+not supported once a newer version's migrations have run; restore from a
+backup instead.
+
+The CLI and the server are cut from the same tag, so matching versions are the
+tested pairing.
 
 ## Back up `MASTER_SECRETS_KEY`
 
@@ -208,9 +245,6 @@ including commercially.
 
 Being straight about what self-hosting does not yet include:
 
-- **Sprites is a hosted dependency** and the endpoint is not configurable
-  ([#189](https://github.com/BinaryBourbon/fountain/issues/189)).
-- **No published version tags for the server image** — only `latest` and
-  per-commit SHAs ([#190](https://github.com/BinaryBourbon/fountain/issues/190)),
-  so pinning means pinning a SHA.
+- **Sprites is a hosted dependency** — `SPRITES_BASE_URL` can repoint it, but
+  there is no self-hostable sandbox backend to point it at.
 - **No first-admin bootstrap**; the role is set in SQL.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,9 @@ defmodule Fountain.Umbrella.MixProject do
   def project do
     [
       apps_path: "apps",
-      version: "0.1.0",
+      # Kept in lockstep with the newest v* git tag — release-bump.yml
+      # computes the next tag from this value.
+      version: "0.2.1",
       deps: deps(),
       releases: releases(),
       aliases: aliases(),

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,11 @@ plugins:
 markdown_extensions:
   - admonition
   - pymdownx.details
+  # Lets docs/changelog.md include the repo-root CHANGELOG.md. base_path is
+  # relative to the directory mkdocs runs from, i.e. the repo root — both
+  # docs.yml and a local `mkdocs serve` invoke it there.
+  - pymdownx.snippets:
+      check_paths: true
   - pymdownx.superfences
   - pymdownx.highlight:
       anchor_linenums: true


### PR DESCRIPTION
Closes #190.

## What a self-hoster gets

A release now publishes the server image as:

| Tag | Mutability |
|---|---|
| `ghcr.io/binarybourbon/fountain:vX.Y.Z` | immutable |
| `ghcr.io/binarybourbon/fountain:vX.Y` | moves to the newest patch in the line |

`latest` (tracks main) and `sha-<commit>` are unchanged. The GitHub Release is only created if the image push succeeded, so a visible release always has a pinnable image.

## Why build from the tag instead of re-tagging the `sha-` image

The tag points at release-bump's version commit, which build.yml never built (`[skip ci]` + GITHUB_TOKEN suppression) — and the mix.exs version baked into the image is surfaced in-app, so it must match the tag.

## The latent release-bump bug

`mix.exs` still said `0.1.0` even though v0.2.1 is tagged (v0.2.x were cut by hand). release-bump computes the next tag from mix.exs, so the next patch release would have been **v0.1.1**, sorting before existing tags. Both mix.exs files now say `0.2.1`.

## Changelog + policy

- `CHANGELOG.md`: 0.2.0 and 0.2.1 reconstructed from git history; everything notable since v0.2.1 recorded under Unreleased, including **Upgrade notes** (`PUBLIC_URL`, mandatory mail config); version policy stated up top.
- `docs/changelog.md` now includes the root file via `pymdownx.snippets` instead of duplicating it (they had already drifted). docs.yml rebuilds the site when `CHANGELOG.md` changes.
- `docs/self-hosting.md`: new **Versioning and upgrades** section (tag table, pinning via `FOUNTAIN_IMAGE_TAG`, migrations-on-boot semantics, no-downgrade rule); removed two stale known-gaps bullets (#189 closed, #190 is this PR).

## Verified

- `mkdocs build --strict` passes; the rendered changelog page contains the included content and the `#versioning-and-upgrades` anchor exists.
- `mix format --check-formatted` + `mix compile --warnings-as-errors` pass after the version bump.
- Tag-derivation shell logic checked by hand (`v0.3.0` → `v0.3`/`0.3.0`, double-digit segments too).
- The first release after this merges will exercise the new `image` job end to end — worth watching that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)