### PR TITLE
fix(release): migrate the database before exporting the OpenAPI spec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,11 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
 
+      # openapi.export boots the app, and since Oban arrived (#217) boot
+      # requires the oban_jobs table — an unmigrated database aborts startup.
+      - name: Set up database
+        run: mix ecto.create --quiet && mix ecto.migrate --quiet
+
       - name: Export spec
         working-directory: apps/fountain
         run: mix openapi.export


### PR DESCRIPTION
The `openapi` job in release.yml boots the app via `mix openapi.export`, and since Oban landed (#217) app boot verifies the `oban_jobs` table exists — but the job never ran `ecto.create`/`ecto.migrate`. It was added in #147, after v0.2.1, and no release has been cut since, so the v0.3.0 cut was its first real run and it failed exactly the way the 2026-08-01 first-run workflow bugs did.

Fix is the same database setup step ci.yml already uses.

After merge, v0.3.0 will be re-dispatched as `gh workflow run release.yml --ref main -f tag=v0.3.0` — the dispatch path exists for exactly this, and the tag itself doesn't move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)