### PR TITLE
feat(admin): billing visibility and support levers (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ upgrade, is in
 
 ### Added
 
+- Admin support tooling: subscription status, trial end and a Stripe dashboard
+  link per user, trial extension (Stripe-aware), a `comped` status for
+  operator-granted free access, per-user 30-day usage, and a sandbox reap
+  action (#169). Admin account deletions are now actually audit-recorded —
+  the event type was missing from the audit allowlist and failed validation
+  silently
 - Bulk manifest apply — a whole manifest in one request, and the CLI's
   `fountain apply` uses it (#151)
 - Agent-scoped vault allowlists: an agent can be restricted to a named set of

--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -6,7 +6,11 @@ defmodule Fountain.Accounts.User do
   @foreign_key_type :binary_id
 
   @roles ~w(user admin)
-  @subscription_statuses ~w(trialing active past_due canceled)
+  # "comped" is operator-granted free access, set only from the admin panel.
+  # It is deliberately distinct from a nil trial_ends_at (the legacy accident
+  # expire_legacy_trials cleans up) so a comp can never be swept by a backfill,
+  # and Billing.sync_subscription refuses to overwrite it from webhooks.
+  @subscription_statuses ~w(trialing active past_due canceled comped)
   @theme_values ~w(light dark system)
   @visible_stream_values ~w(stdout stderr stage)
   @view_mode_values ~w(chat pretty raw)

--- a/apps/fountain/lib/fountain/audit/admin_event.ex
+++ b/apps/fountain/lib/fountain/audit/admin_event.ex
@@ -28,10 +28,20 @@ defmodule Fountain.Audit.AdminEvent do
     field :inserted_at, :utc_datetime
   end
 
+  # Closed allowlist: an unknown type fails validation and record_admin/1
+  # swallows the error, so an event type missing from this list is silently
+  # never recorded. That already happened once — admin.account.deleted shipped
+  # in the deletion work without being added here, and admin deletions left no
+  # audit row until the admin billing work tripped over the same behaviour.
   @event_types ~w(
     admin.role.granted
     admin.role.revoked
     admin.sandbox_limit.changed
+    admin.account.deleted
+    admin.trial.extended
+    admin.comp.granted
+    admin.comp.revoked
+    admin.sandbox.reaped
   )
 
   def event_types, do: @event_types

--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -47,7 +47,7 @@ defmodule Fountain.Billing do
 
   # ─── Gate ──────────────────────────────────────────────────────────────────
 
-  @active_statuses ~w(trialing active)
+  @active_statuses ~w(trialing active comped)
 
   @doc """
   Returns `:ok` when the user's subscription allows new conversation creation.
@@ -92,10 +92,11 @@ defmodule Fountain.Billing do
   # undelivered webhook, a Stripe outage or a misconfigured endpoint delays
   # revenue rather than forfeiting it.
   #
-  # A nil `trial_ends_at` is treated as no expiry. 159 production accounts are
-  # in that state, from before a trial end was recorded at all; deciding their
-  # cutoff is a business call, not something a boolean should do silently. See
-  # Fountain.Release.expire_legacy_trials/1.
+  # A nil `trial_ends_at` is treated as no expiry. 159 production accounts were
+  # in that state, from before a trial end was recorded at all; they were given
+  # an expiry on 2026-08-02 via Fountain.Release.expire_legacy_trials/1, which
+  # exists for any that reappear. A *deliberate* free account is "comped", not
+  # this.
   defp do_check_active(%User{subscription_status: "trialing", trial_ends_at: nil}), do: :ok
 
   defp do_check_active(%User{subscription_status: "trialing", trial_ends_at: ends_at}) do
@@ -232,6 +233,104 @@ defmodule Fountain.Billing do
     do: DateTime.from_unix!(ts) |> DateTime.truncate(:second)
 
   defp unix_to_datetime(_), do: trial_end_from_now()
+
+  @doc """
+  Extends a user's trial by `days`, counted from whichever is later — now or
+  the current trial end — so an extension can never shorten a trial.
+
+  Stripe owns `trial_ends_at` for an account with a subscription still in its
+  trial (`sync_subscription/1` overwrites the local value on every subscription
+  event), so for those the extension goes through `Stripe.Subscription.update/2`
+  first and the local write is the optimistic copy the webhook will confirm.
+  An account with no live trial subscription — no Stripe customer at all, or a
+  subscription already ended — gets a plain local update, which also moves a
+  `canceled` or `past_due` account back to `trialing`: the support lever for
+  "give this person another look".
+
+  Refused for `active` (they are paying; there is no trial) and `comped`
+  (already free; extending would demote them to a trial that ends).
+  """
+  @spec extend_trial(User.t(), pos_integer()) :: {:ok, User.t()} | {:error, term()}
+  def extend_trial(%User{subscription_status: "active"}, _days),
+    do: {:error, :active_subscription}
+
+  def extend_trial(%User{subscription_status: "comped"}, _days), do: {:error, :comped}
+
+  def extend_trial(%User{} = user, days) when is_integer(days) and days > 0 do
+    now = DateTime.utc_now()
+
+    base =
+      case user.trial_ends_at do
+        %DateTime{} = ends_at -> if DateTime.compare(ends_at, now) == :gt, do: ends_at, else: now
+        nil -> now
+      end
+
+    new_end = base |> DateTime.add(days * 24 * 60 * 60, :second) |> DateTime.truncate(:second)
+
+    with :ok <- push_stripe_trial_end(user, new_end) do
+      user
+      |> User.billing_changeset(%{subscription_status: "trialing", trial_ends_at: new_end})
+      |> Repo.update()
+    end
+  end
+
+  # Stripe first, so a Stripe refusal leaves nothing half-applied. Only a
+  # subscription still trialing can have its trial moved; any other state means
+  # there is no live trial subscription and the local write stands alone.
+  defp push_stripe_trial_end(%User{stripe_customer_id: id}, _new_end) when id in [nil, ""],
+    do: :ok
+
+  defp push_stripe_trial_end(%User{stripe_customer_id: customer_id}, new_end) do
+    case Stripe.Subscription.list(%{customer: customer_id, status: "trialing", limit: 1}) do
+      {:ok, %{data: [sub | _]}} ->
+        case Stripe.Subscription.update(sub.id, %{
+               trial_end: DateTime.to_unix(new_end),
+               proration_behavior: "none"
+             }) do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Marks an account comped: free access granted by an operator, indefinitely.
+
+  Any live Stripe subscription is cancelled first — a comped account must not
+  keep charging, and a surviving subscription's webhooks would fight the comp.
+  The cancellation webhook that follows is ignored by `sync_subscription/1`
+  (comped accounts are excluded from webhook sync), so the comp sticks until
+  `revoke_comp/1`.
+  """
+  @spec comp_account(User.t()) :: {:ok, User.t()} | {:error, term()}
+  def comp_account(%User{subscription_status: "comped"} = user), do: {:ok, user}
+
+  def comp_account(%User{} = user) do
+    with {:ok, _cancelled} <- cancel_subscriptions(user) do
+      user
+      |> User.billing_changeset(%{subscription_status: "comped"})
+      |> Repo.update()
+    end
+  end
+
+  @doc """
+  Ends a comp. The account becomes `canceled` — gated, with self-serve checkout
+  as the way back in — rather than guessing at whatever state preceded the comp.
+  """
+  @spec revoke_comp(User.t()) :: {:ok, User.t()} | {:error, :not_comped}
+  def revoke_comp(%User{subscription_status: "comped"} = user) do
+    user
+    |> User.billing_changeset(%{subscription_status: "canceled"})
+    |> Repo.update()
+  end
+
+  def revoke_comp(%User{}), do: {:error, :not_comped}
 
   @doc """
   Cancels every subscription attached to the user's Stripe customer.
@@ -448,6 +547,13 @@ defmodule Fountain.Billing do
       nil ->
         {:error, :user_not_found}
 
+      # A comp is an operator decision; Stripe events do not override it. In
+      # particular, comp_account/1 cancels the user's subscriptions, and the
+      # cancellation webhook that follows must not flip the account it just
+      # comped to "canceled". revoke_comp/1 is the only way out of comped.
+      %User{subscription_status: "comped"} ->
+        {:ok, :comped_ignored}
+
       user ->
         if stale?(user.subscription_synced_at, event_created) do
           # An older event arriving after a newer one. Applying it would move the
@@ -518,6 +624,44 @@ defmodule Fountain.Billing do
 
     %{conversations: conversations, turns: turns, sandbox_minutes: sandbox_minutes}
   end
+
+  @doc """
+  `usage_summary/3` for every user at once, in one query — for the admin view,
+  which refreshes on a timer and must not run a query per user.
+
+  Returns `%{user_id => %{conversations: n, turns: n, sandbox_minutes: f}}`;
+  users with no events in the period are absent.
+  """
+  @spec usage_summaries(DateTime.t(), DateTime.t()) :: %{optional(binary()) => map()}
+  def usage_summaries(%DateTime{} = period_start, %DateTime{} = period_end) do
+    empty = %{conversations: 0, turns: 0, sandbox_minutes: 0.0}
+
+    from(e in UsageEvent,
+      where: e.inserted_at >= ^period_start and e.inserted_at < ^period_end,
+      group_by: [e.user_id, e.event_type],
+      select:
+        {e.user_id, e.event_type, count(e.id),
+         sum(coalesce(fragment("(? ->> 'duration_ms')::numeric", e.metadata), 0))}
+    )
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn {user_id, type, count, duration_ms}, acc ->
+      summary = Map.get(acc, user_id, empty)
+
+      summary =
+        case type do
+          "sandbox_provisioned" -> %{summary | conversations: count}
+          "turn_started" -> %{summary | turns: count}
+          "sandbox_terminated" -> %{summary | sandbox_minutes: to_minutes(duration_ms)}
+          _ -> summary
+        end
+
+      Map.put(acc, user_id, summary)
+    end)
+  end
+
+  defp to_minutes(nil), do: 0.0
+  defp to_minutes(%Decimal{} = ms), do: Decimal.to_float(ms) / 60_000.0
+  defp to_minutes(ms) when is_number(ms), do: ms / 60_000.0
 
   # ─── Usage emission ─────────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -53,6 +53,41 @@ defmodule Fountain.Conversations do
   def _unsafe_get_sandbox(id), do: Repo.get(Sandbox, id)
   def _unsafe_get_sandbox!(id), do: Repo.get!(Sandbox, id)
 
+  @doc """
+  Support teardown of any tenant's sandbox, from the admin panel.
+
+  A conversation with a live `ConversationServer` is terminated through the
+  server, which destroys the sprite and ends the conversation — that is what
+  stopping a runaway agent means. A sandbox with no live server just has its
+  row marked terminated: the conversation stays resumable (next prompt gets a
+  fresh sandbox, same session) and the reaper destroys the sprite on its next
+  pass, the same split `SandboxReaper.expire_abandoned_sandboxes/0` uses.
+  """
+  def _unsafe_reap_sandbox(sandbox_id) do
+    alias Fountain.Conversations.ConversationServer
+
+    case _unsafe_get_sandbox(sandbox_id) do
+      nil ->
+        {:error, :not_found}
+
+      %Sandbox{status: s} when s in ["terminated", "failed"] ->
+        {:ok, :already_terminal}
+
+      sandbox ->
+        sandbox = Repo.preload(sandbox, :conversations)
+        live = Enum.filter(sandbox.conversations, &ConversationServer.whereis(&1.id))
+
+        if live == [] do
+          now = DateTime.utc_now() |> DateTime.truncate(:second)
+          {:ok, _} = update_sandbox(sandbox, %{status: "terminated", terminated_at: now})
+          {:ok, :released}
+        else
+          Enum.each(live, &ConversationServer.terminate(&1.id))
+          {:ok, :terminated}
+        end
+    end
+  end
+
   def create_sandbox(attrs) do
     %Sandbox{}
     |> Sandbox.changeset(attrs)

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -2,8 +2,10 @@ defmodule FountainWeb.AdminLive.Index do
   @moduledoc false
   use FountainWeb, :live_view
 
-  alias Fountain.{Accounts, Conversations, Quotas}
+  alias Fountain.{Accounts, Billing, Conversations, Quotas}
   alias Fountain.Accounts.Deletion
+
+  @usage_window_days 30
 
   @impl true
   def mount(_params, _session, socket) do
@@ -76,6 +78,101 @@ defmodule FountainWeb.AdminLive.Index do
     end
   end
 
+  @impl true
+  def handle_event("extend_trial", %{"user_id" => id, "days" => raw}, socket) do
+    with {days, ""} when days > 0 <- Integer.parse(String.trim(raw)),
+         user = Accounts.get_user!(id),
+         {:ok, updated} <- Billing.extend_trial(user, days) do
+      Fountain.Audit.record_admin(%{
+        actor_user_id: socket.assigns.current_user.id,
+        target_user_id: user.id,
+        event_type: "admin.trial.extended",
+        metadata: %{
+          "email" => user.email,
+          "from" => user.trial_ends_at && DateTime.to_iso8601(user.trial_ends_at),
+          "to" => DateTime.to_iso8601(updated.trial_ends_at)
+        }
+      })
+
+      {:noreply,
+       socket
+       |> assign_users()
+       |> put_flash(:info, "Trial extended to #{format_date(updated.trial_ends_at)}")}
+    else
+      {:error, :active_subscription} ->
+        {:noreply, put_flash(socket, :error, "Account has an active paid subscription")}
+
+      {:error, :comped} ->
+        {:noreply, put_flash(socket, :error, "Account is comped — nothing to extend")}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Could not extend trial — Stripe refused")}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "Days must be a whole number of 1 or more")}
+    end
+  end
+
+  @impl true
+  def handle_event("toggle_comp", %{"id" => id}, socket) do
+    user = Accounts.get_user!(id)
+
+    result =
+      if user.subscription_status == "comped",
+        do: {Billing.revoke_comp(user), "admin.comp.revoked"},
+        else: {Billing.comp_account(user), "admin.comp.granted"}
+
+    case result do
+      {{:ok, updated}, event_type} ->
+        Fountain.Audit.record_admin(%{
+          actor_user_id: socket.assigns.current_user.id,
+          target_user_id: user.id,
+          event_type: event_type,
+          metadata: %{
+            "email" => user.email,
+            "from" => user.subscription_status,
+            "to" => updated.subscription_status
+          }
+        })
+
+        {:noreply,
+         socket |> assign_users() |> put_flash(:info, "Now #{updated.subscription_status}")}
+
+      {{:error, _}, _} ->
+        {:noreply,
+         put_flash(socket, :error, "Could not change comp — Stripe cancellation failed")}
+    end
+  end
+
+  @impl true
+  def handle_event("reap_sandbox", %{"id" => id}, socket) do
+    case Conversations._unsafe_reap_sandbox(id) do
+      {:ok, outcome} ->
+        Fountain.Audit.record_admin(%{
+          actor_user_id: socket.assigns.current_user.id,
+          target_user_id: nil,
+          event_type: "admin.sandbox.reaped",
+          metadata: %{"sandbox_id" => id, "outcome" => to_string(outcome)}
+        })
+
+        msg =
+          case outcome do
+            :terminated -> "Sandbox and its live conversations terminated"
+            :released -> "Sandbox released — conversations stay resumable"
+            :already_terminal -> "Sandbox was already terminated"
+          end
+
+        {:noreply,
+         socket
+         |> assign(:sandboxes, Conversations.list_sandboxes_admin())
+         |> assign_users()
+         |> put_flash(:info, msg)}
+
+      {:error, :not_found} ->
+        {:noreply, put_flash(socket, :error, "Sandbox not found")}
+    end
+  end
+
   # The support path for a deletion request that cannot go through the account
   # page — a locked-out user, or one who asked by email. Same teardown as
   # self-serve; only the actor recorded differs.
@@ -124,9 +221,23 @@ defmodule FountainWeb.AdminLive.Index do
   end
 
   defp assign_users(socket) do
+    now = DateTime.utc_now()
+
+    # Upper bound one second ahead: the column is second-precision, so a bound
+    # of `now` loses its sub-second part in the cast and excludes events
+    # recorded within the current second.
+    usage =
+      Billing.usage_summaries(
+        DateTime.add(now, -@usage_window_days, :day),
+        DateTime.add(now, 1, :second)
+      )
+    no_usage = %{conversations: 0, turns: 0, sandbox_minutes: 0.0}
+
     users =
       Enum.map(Accounts.list_users(), fn u ->
-        Map.put(u, :active_sandboxes, Quotas.active_sandbox_count(u.id))
+        u
+        |> Map.put(:active_sandboxes, Quotas.active_sandbox_count(u.id))
+        |> Map.put(:usage, Map.get(usage, u.id, no_usage))
       end)
 
     assign(socket, :users, users)
@@ -148,6 +259,10 @@ defmodule FountainWeb.AdminLive.Index do
             <tr>
               <th class="px-4 py-2">Email</th>
               <th class="px-4 py-2">Role</th>
+              <th class="px-4 py-2">Billing</th>
+              <th class="px-4 py-2" title="Last 30 days: conversations / turns / sandbox minutes">
+                Usage 30d
+              </th>
               <th class="px-4 py-2">Sandboxes</th>
               <th class="px-4 py-2">Onboarding</th>
               <th class="px-4 py-2">Joined</th>
@@ -167,6 +282,66 @@ defmodule FountainWeb.AdminLive.Index do
                 ]}>
                   {u.role}
                 </span>
+              </td>
+              <td class="px-4 py-2">
+                <div class="space-y-1">
+                  <div class="flex items-center gap-2">
+                    <span class={[
+                      "inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium border",
+                      subscription_status_color(u.subscription_status)
+                    ]}>
+                      {u.subscription_status}
+                    </span>
+                    <span :if={u.subscription_status == "trialing" and u.trial_ends_at} class="text-xs text-zinc-500">
+                      ends {format_date(u.trial_ends_at)}
+                    </span>
+                    <a
+                      :if={u.stripe_customer_id not in [nil, ""]}
+                      href={"https://dashboard.stripe.com/customers/#{u.stripe_customer_id}"}
+                      target="_blank"
+                      rel="noopener"
+                      class="text-xs text-zinc-400 hover:text-zinc-700 underline"
+                    >
+                      stripe ↗
+                    </a>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <form
+                      :if={u.subscription_status not in ["active", "comped"]}
+                      phx-submit="extend_trial"
+                      id={"extend-trial-#{u.id}"}
+                      class="flex items-center gap-1"
+                    >
+                      <input type="hidden" name="user_id" value={u.id} />
+                      <input
+                        type="number"
+                        name="days"
+                        min="1"
+                        value="14"
+                        class="w-12 rounded border border-zinc-200 px-1 py-0.5 text-xs"
+                      />
+                      <button class="text-xs text-zinc-500 hover:text-zinc-900 underline">
+                        extend trial
+                      </button>
+                    </form>
+                    <button
+                      phx-click="toggle_comp"
+                      phx-value-id={u.id}
+                      data-confirm={
+                        if u.subscription_status == "comped",
+                          do: "Revoke #{u.email}'s comp? They become canceled and must subscribe.",
+                          else:
+                            "Comp #{u.email}? Free access until revoked. Any Stripe subscription is cancelled."
+                      }
+                      class="text-xs text-zinc-500 hover:text-zinc-900 underline"
+                    >
+                      {if u.subscription_status == "comped", do: "revoke comp", else: "comp"}
+                    </button>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-2 text-xs text-zinc-500 tabular-nums whitespace-nowrap">
+                {u.usage.conversations}c · {u.usage.turns}t · {round(u.usage.sandbox_minutes)}m
               </td>
               <td class="px-4 py-2">
                 <form phx-submit="set_sandbox_limit" id={"sandbox-limit-#{u.id}"} class="flex items-center gap-1">
@@ -227,6 +402,7 @@ defmodule FountainWeb.AdminLive.Index do
               <th class="px-4 py-2">Status</th>
               <th class="px-4 py-2">Conversations</th>
               <th class="px-4 py-2">Started</th>
+              <th class="px-4 py-2"></th>
             </tr>
           </thead>
           <tbody>
@@ -251,6 +427,16 @@ defmodule FountainWeb.AdminLive.Index do
                 </span>
               </td>
               <td class="px-4 py-2 text-xs text-zinc-500">{format_ts(s.inserted_at)}</td>
+              <td class="px-4 py-2 text-right">
+                <button
+                  phx-click="reap_sandbox"
+                  phx-value-id={s.id}
+                  data-confirm={"Reap sandbox #{String.slice(s.id, 0, 8)}? Live conversations are terminated; idle ones stay resumable on a fresh sandbox."}
+                  class="text-xs text-red-600 hover:text-red-800 underline"
+                >
+                  Reap
+                </button>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -290,6 +476,12 @@ defmodule FountainWeb.AdminLive.Index do
     </div>
     """
   end
+
+  defp subscription_status_color("active"), do: "bg-green-100 text-green-800 border-green-200"
+  defp subscription_status_color("trialing"), do: "bg-blue-100 text-blue-800 border-blue-200"
+  defp subscription_status_color("comped"), do: "bg-purple-100 text-purple-800 border-purple-200"
+  defp subscription_status_color("past_due"), do: "bg-amber-100 text-amber-800 border-amber-200"
+  defp subscription_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
 
   defp sandbox_status_color("running"), do: "bg-blue-100 text-blue-800 border-blue-200"
   defp sandbox_status_color("ready"), do: "bg-green-100 text-green-800 border-green-200"

--- a/apps/fountain/test/fountain/billing_test.exs
+++ b/apps/fountain/test/fountain/billing_test.exs
@@ -72,8 +72,13 @@ defmodule Fountain.BillingTest do
 
     test "sums duration_ms from sandbox_terminated events into sandbox_minutes", %{user: user} do
       # 60_000 ms = 1 min, 120_000 ms = 2 min -> total 3.0 minutes
-      insert_event(user, "sandbox_terminated", ~U[2026-05-10 12:00:00Z], %{"duration_ms" => 60_000})
-      insert_event(user, "sandbox_terminated", ~U[2026-05-10 12:30:00Z], %{"duration_ms" => 120_000})
+      insert_event(user, "sandbox_terminated", ~U[2026-05-10 12:00:00Z], %{
+        "duration_ms" => 60_000
+      })
+
+      insert_event(user, "sandbox_terminated", ~U[2026-05-10 12:30:00Z], %{
+        "duration_ms" => 120_000
+      })
 
       summary = Billing.usage_summary(user.id, @period_start, @period_end)
 
@@ -388,7 +393,9 @@ defmodule Fountain.BillingTest do
     test "unknown stripe status is coerced to past_due", %{user: _user} do
       event = %Stripe.Event{
         type: "customer.subscription.updated",
-        data: %{object: %{customer: "cus_coerce_catchall", status: "some_future_status", trial_end: nil}}
+        data: %{
+          object: %{customer: "cus_coerce_catchall", status: "some_future_status", trial_end: nil}
+        }
       }
 
       assert {:ok, updated_user} = Billing.sync_subscription(event)
@@ -412,5 +419,186 @@ defmodule Fountain.BillingTest do
       metadata: metadata
     })
     |> Repo.insert!()
+  end
+
+  describe "extend_trial/2" do
+    defp billing_state(user, attrs) do
+      Repo.update!(Ecto.Changeset.change(user, attrs))
+    end
+
+    test "no Stripe customer: sets trialing and an end ~days from now" do
+      user =
+        billing_state(insert_verified_user(), subscription_status: "canceled", trial_ends_at: nil)
+
+      assert {:ok, updated} = Billing.extend_trial(user, 7)
+      assert updated.subscription_status == "trialing"
+
+      expected = DateTime.add(DateTime.utc_now(), 7 * 24 * 60 * 60, :second)
+      assert abs(DateTime.diff(updated.trial_ends_at, expected, :second)) < 60
+    end
+
+    test "extends from the current end when it is in the future — never shortens" do
+      future =
+        DateTime.utc_now()
+        |> DateTime.add(10 * 24 * 60 * 60, :second)
+        |> DateTime.truncate(:second)
+
+      user =
+        billing_state(insert_verified_user(),
+          subscription_status: "trialing",
+          trial_ends_at: future
+        )
+
+      assert {:ok, updated} = Billing.extend_trial(user, 7)
+
+      expected = DateTime.add(future, 7 * 24 * 60 * 60, :second)
+      assert abs(DateTime.diff(updated.trial_ends_at, expected, :second)) < 60
+    end
+
+    test "with a trialing Stripe subscription: pushes the new end to Stripe first" do
+      user =
+        billing_state(insert_verified_user(),
+          subscription_status: "trialing",
+          stripe_customer_id: "cus_ext1",
+          trial_ends_at: nil
+        )
+
+      stub(Stripe.Subscription, :list, fn %{customer: "cus_ext1", status: "trialing"} ->
+        {:ok, %{data: [%Stripe.Subscription{id: "sub_ext1", status: "trialing"}]}}
+      end)
+
+      test_pid = self()
+
+      stub(Stripe.Subscription, :update, fn "sub_ext1", params ->
+        send(test_pid, {:stripe_update, params})
+        {:ok, %Stripe.Subscription{id: "sub_ext1", status: "trialing"}}
+      end)
+
+      assert {:ok, updated} = Billing.extend_trial(user, 14)
+      assert_receive {:stripe_update, %{trial_end: unix, proration_behavior: "none"}}
+      assert unix == DateTime.to_unix(updated.trial_ends_at)
+    end
+
+    test "a Stripe refusal leaves the user unchanged" do
+      user =
+        billing_state(insert_verified_user(),
+          subscription_status: "trialing",
+          stripe_customer_id: "cus_ext2",
+          trial_ends_at: nil
+        )
+
+      stub(Stripe.Subscription, :list, fn _ ->
+        {:ok, %{data: [%Stripe.Subscription{id: "sub_ext2", status: "trialing"}]}}
+      end)
+
+      stub(Stripe.Subscription, :update, fn _, _ -> {:error, :stripe_down} end)
+
+      assert {:error, :stripe_down} = Billing.extend_trial(user, 14)
+      assert Repo.reload!(user).trial_ends_at == nil
+    end
+
+    test "refused for active and comped accounts" do
+      active = billing_state(insert_verified_user(), subscription_status: "active")
+      comped = billing_state(insert_verified_user(), subscription_status: "comped")
+
+      assert {:error, :active_subscription} = Billing.extend_trial(active, 7)
+      assert {:error, :comped} = Billing.extend_trial(comped, 7)
+    end
+  end
+
+  describe "comp_account/1 and revoke_comp/1" do
+    test "comps an account with no Stripe customer" do
+      user = insert_verified_user()
+
+      assert {:ok, updated} = Billing.comp_account(user)
+      assert updated.subscription_status == "comped"
+      assert Billing.check_active(updated) == :ok
+    end
+
+    test "cancels live Stripe subscriptions before comping" do
+      user =
+        Repo.update!(
+          Ecto.Changeset.change(insert_verified_user(), stripe_customer_id: "cus_comp1")
+        )
+
+      stub(Stripe.Subscription, :list, fn %{customer: "cus_comp1"} ->
+        {:ok,
+         %{data: [%Stripe.Subscription{id: "sub_comp1", status: "trialing"}], has_more: false}}
+      end)
+
+      test_pid = self()
+
+      stub(Stripe.Subscription, :cancel, fn id ->
+        send(test_pid, {:cancelled, id})
+        {:ok, %Stripe.Subscription{id: id, status: "canceled"}}
+      end)
+
+      assert {:ok, updated} = Billing.comp_account(user)
+      assert updated.subscription_status == "comped"
+      assert_receive {:cancelled, "sub_comp1"}
+    end
+
+    test "a failed Stripe cancellation leaves the account un-comped" do
+      user =
+        Repo.update!(
+          Ecto.Changeset.change(insert_verified_user(), stripe_customer_id: "cus_comp2")
+        )
+
+      stub(Stripe.Subscription, :list, fn _ -> {:error, :stripe_down} end)
+
+      assert {:error, :stripe_down} = Billing.comp_account(user)
+      refute Repo.reload!(user).subscription_status == "comped"
+    end
+
+    test "webhook sync does not override a comp" do
+      user =
+        Repo.update!(
+          Ecto.Changeset.change(insert_verified_user(),
+            stripe_customer_id: "cus_comp3",
+            subscription_status: "comped"
+          )
+        )
+
+      event = %Stripe.Event{
+        type: "customer.subscription.deleted",
+        data: %{object: %{customer: "cus_comp3", status: "canceled", trial_end: nil}}
+      }
+
+      assert {:ok, :comped_ignored} = Billing.sync_subscription(event)
+      assert Repo.reload!(user).subscription_status == "comped"
+    end
+
+    test "revoke_comp moves a comped account to canceled, and refuses others" do
+      user =
+        Repo.update!(Ecto.Changeset.change(insert_verified_user(), subscription_status: "comped"))
+
+      assert {:ok, updated} = Billing.revoke_comp(user)
+      assert updated.subscription_status == "canceled"
+      assert {:error, :not_comped} = Billing.revoke_comp(updated)
+    end
+  end
+
+  describe "usage_summaries/2" do
+    test "aggregates per user in the window, absent users omitted" do
+      a = insert_verified_user()
+      b = insert_verified_user()
+      quiet = insert_verified_user()
+
+      {:ok, _} = Billing.record_usage(a.id, "sandbox_provisioned", nil, nil)
+      {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil)
+      {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil)
+
+      {:ok, _} =
+        Billing.record_usage(a.id, "sandbox_terminated", nil, nil, %{"duration_ms" => 120_000})
+
+      {:ok, _} = Billing.record_usage(b.id, "turn_started", nil, nil)
+
+      now = DateTime.utc_now()
+      summaries = Billing.usage_summaries(DateTime.add(now, -1, :day), DateTime.add(now, 1, :day))
+
+      assert summaries[a.id] == %{conversations: 1, turns: 2, sandbox_minutes: 2.0}
+      assert summaries[b.id] == %{conversations: 0, turns: 1, sandbox_minutes: 0.0}
+      refute Map.has_key?(summaries, quiet.id)
+    end
   end
 end

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1983,4 +1983,27 @@ defmodule Fountain.ConversationsContextTest do
       refute is_nil(result.last_read_at)
     end
   end
+
+  describe "_unsafe_reap_sandbox/1" do
+    test "marks a ready sandbox with no live server terminated; conversations untouched" do
+      sandbox = insert_sandbox(status: "ready")
+      conv = insert_conversation(sandbox: sandbox, user_id: sandbox.user_id)
+
+      assert {:ok, :released} = Conversations._unsafe_reap_sandbox(sandbox.id)
+
+      reloaded = Conversations._unsafe_get_sandbox!(sandbox.id)
+      assert reloaded.status == "terminated"
+      assert reloaded.terminated_at
+      refute Conversations._unsafe_get_conversation(conv.id).status == "terminated"
+    end
+
+    test "is a no-op on an already-terminal sandbox" do
+      sandbox = insert_sandbox(status: "terminated")
+      assert {:ok, :already_terminal} = Conversations._unsafe_reap_sandbox(sandbox.id)
+    end
+
+    test "returns not_found for an unknown id" do
+      assert {:error, :not_found} = Conversations._unsafe_reap_sandbox(Ecto.UUID.generate())
+    end
+  end
 end

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -325,6 +325,139 @@ defmodule FountainWeb.AdminLiveTest do
       assert render(lv) =~ "whole number"
     end
   end
+
+  describe "AdminLive.Index — billing column" do
+    test "shows subscription status, trial end and a Stripe link", %{conn: conn} do
+      admin = insert_admin()
+
+      user = insert_verified_user()
+
+      user =
+        Fountain.Repo.update!(
+          Ecto.Changeset.change(user,
+            subscription_status: "trialing",
+            trial_ends_at: ~U[2027-03-01 00:00:00Z],
+            stripe_customer_id: "cus_admin_test"
+          )
+        )
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "trialing"
+      assert html =~ "ends 2027-03-01"
+      assert html =~ "https://dashboard.stripe.com/customers/#{user.stripe_customer_id}"
+    end
+  end
+
+  describe "AdminLive.Index — extend_trial" do
+    test "extends the trial and records an admin audit event", %{conn: conn} do
+      admin = insert_admin()
+
+      user =
+        Fountain.Repo.update!(
+          Ecto.Changeset.change(insert_verified_user(),
+            subscription_status: "canceled",
+            trial_ends_at: nil
+          )
+        )
+
+      conn = login_user(conn, admin)
+      {:ok, lv, _html} = live(conn, ~p"/admin")
+
+      lv
+      |> form("#extend-trial-#{user.id}", %{"days" => "7"})
+      |> render_submit()
+
+      updated = Fountain.Repo.reload!(user)
+      assert updated.subscription_status == "trialing"
+      expected = DateTime.add(DateTime.utc_now(), 7 * 24 * 60 * 60, :second)
+      assert abs(DateTime.diff(updated.trial_ends_at, expected, :second)) < 60
+
+      assert Enum.any?(
+               Fountain.Audit.list_recent_admin(10),
+               &(&1.event_type == "admin.trial.extended" and &1.target_user_id == user.id)
+             )
+    end
+
+    test "rejects a non-numeric day count", %{conn: conn} do
+      admin = insert_admin()
+      user = insert_verified_user()
+      conn = login_user(conn, admin)
+      {:ok, lv, _html} = live(conn, ~p"/admin")
+
+      html =
+        lv
+        |> form("#extend-trial-#{user.id}", %{"days" => "nope"})
+        |> render_submit()
+
+      assert html =~ "whole number"
+    end
+  end
+
+  describe "AdminLive.Index — toggle_comp" do
+    test "comps and un-comps an account, with audit events", %{conn: conn} do
+      admin = insert_admin()
+      user = insert_verified_user()
+      conn = login_user(conn, admin)
+      {:ok, lv, _html} = live(conn, ~p"/admin")
+
+      lv
+      |> element("button[phx-value-id='#{user.id}'][phx-click='toggle_comp']")
+      |> render_click()
+
+      assert Fountain.Repo.reload!(user).subscription_status == "comped"
+
+      lv
+      |> element("button[phx-value-id='#{user.id}'][phx-click='toggle_comp']")
+      |> render_click()
+
+      assert Fountain.Repo.reload!(user).subscription_status == "canceled"
+
+      events = Fountain.Audit.list_recent_admin(10)
+      assert Enum.any?(events, &(&1.event_type == "admin.comp.granted"))
+      assert Enum.any?(events, &(&1.event_type == "admin.comp.revoked"))
+    end
+  end
+
+  describe "AdminLive.Index — reap_sandbox" do
+    test "reaps a ready sandbox with no live server and audits it", %{conn: conn} do
+      admin = insert_admin()
+      sandbox = insert_sandbox(status: "ready")
+      conn = login_user(conn, admin)
+      {:ok, lv, _html} = live(conn, ~p"/admin")
+
+      html =
+        lv
+        |> element("button[phx-value-id='#{sandbox.id}'][phx-click='reap_sandbox']")
+        |> render_click()
+
+      assert html =~ "released"
+      reloaded = Fountain.Conversations._unsafe_get_sandbox!(sandbox.id)
+      assert reloaded.status == "terminated"
+      assert reloaded.terminated_at
+
+      assert Enum.any?(
+               Fountain.Audit.list_recent_admin(10),
+               &(&1.event_type == "admin.sandbox.reaped" and
+                   &1.metadata["sandbox_id"] == sandbox.id)
+             )
+    end
+  end
+
+  describe "AdminLive.Index — usage column" do
+    test "shows 30-day usage per user", %{conn: conn} do
+      admin = insert_admin()
+      user = insert_verified_user()
+      {:ok, _} = Fountain.Billing.record_usage(user.id, "turn_started", nil, nil)
+      {:ok, _} = Fountain.Billing.record_usage(user.id, "sandbox_provisioned", nil, nil)
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "1c · 1t · 0m"
+    end
+  end
 end
 
 defmodule FountainWeb.AdminLiveErrorTest do


### PR DESCRIPTION
Closes #169. Everything on the issue's list that was still missing (quota editing and deletion landed earlier via #205/#234):

## Billing column
Status badge, trial end date, and a deep link to the Stripe customer. Support can answer "did this customer pay?" without leaving the page.

## Trial extension
`Billing.extend_trial(user, days)` — extends from `max(now, current end)` so it can never shorten. For an account with a subscription still trialing, the new end goes to **Stripe first** (`Subscription.update`, `proration_behavior: none`) because `sync_subscription/1` overwrites `trial_ends_at` on every subscription webhook — a local-only write would silently revert. No-Stripe accounts get a local write, which also moves `canceled`/`past_due` back to `trialing` (the "give them another look" lever). Refused for `active` and `comped`.

## Comped status
A new `"comped"` subscription status: operator-granted free access. Deliberately **not** `trialing`+nil `trial_ends_at` — after the 2026-08-02 backfill that state means "legacy accident", and a comp must never be sweepable by `expire_legacy_trials`. `comp_account/1` cancels live Stripe subscriptions first, and webhook sync explicitly ignores comped users — otherwise the cancellation webhook the comp itself triggers would flip the account to `canceled`. `revoke_comp/1` → `canceled` (self-serve checkout is the way back).

## Usage 30d
`Billing.usage_summaries/2` — one grouped query for all users (the page refreshes every 10s; a query per user was not an option). Includes a subtle fix: the window's upper bound is `now + 1s` because the column is second-precision and a bound of `now` loses its sub-second part in the cast, excluding the current second.

## Sandbox reap
`Conversations._unsafe_reap_sandbox/1` (unscoped ⇒ `_unsafe_`, admin-only caller): conversations with a live `ConversationServer` are terminated through the server (sprite destroyed, conversation ended); a sandbox with no live server has its row released — conversation stays resumable, reaper pass 2 destroys the sprite. Same split `expire_abandoned_sandboxes` uses.

## Pre-existing bug found: admin deletions were never audited
`AdminEvent` validates `event_type` against a closed allowlist and `record_admin/1` swallows failures. `admin.account.deleted` (#234) was never added to the list, so **admin deletions have never produced an audit row**. All event types are now listed and the allowlist documents the silent-drop failure mode.

## Verification
- 20 new tests (billing context, conversations context, admin LiveView), full suite 1513 green.
- Revert-verified the allowlist fix: without it, the three audit assertions fail; with it, green.
- All admin actions record `admin.*` audit events, asserted in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)