### PR TITLE
self-host: a portable Kubernetes baseline under deploy/k8s (#191)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ on:
     # manifest would, hence the explicit ignore.)
     paths-ignore:
       - "k8s/**"
+      # The portable self-hosting manifests — never part of the image.
+      - "deploy/**"
       - "docs/**"
       - "decisions/**"
       - "**/*.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ upgrade, is in
 
 ### Added
 
+- A portable Kubernetes baseline under `deploy/k8s/` — plain manifests,
+  `kubectl apply -k`, no operators assumed; bring a Postgres and an ingress
+  (#191)
 - Dialyzer now gates CI and `mix precommit` (#236). Triage of its 77 findings
   fixed real bugs: OTel spans were ended by passing the span where a
   timestamp belongs (silently corrupting recorded spans), Stripe API params

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,75 @@
+# Fountain on Kubernetes — portable baseline
+
+Plain manifests, applied with `kubectl apply -k`. No operators, no CRDs, no
+assumptions beyond a cluster and an ingress controller. This is the generic
+counterpart to `k8s/` in the repo root, which is the maintainer's own cluster
+(CNPG, Traefik, Infisical, Flux) and is worth reading but not worth applying.
+
+The [compose path](https://binarybourbon.github.io/fountain/self-hosting/) is
+simpler if you don't already live on Kubernetes — start there.
+
+## What this does not include
+
+- **A database.** Bring a Postgres 16+ and hand its URL to the app. If it
+  doesn't serve TLS, set `DATABASE_SSL: "false"` in the ConfigMap.
+- **TLS / ingress specifics.** `ingress.yaml` is a standard Ingress with the
+  contract documented inline; wire it to your controller and certificates.
+- **Secret management.** The manifests reference a `fountain-secrets` Secret;
+  creating it is on you (plain Secret below, or your ESO/Vault/sealed-secrets
+  machinery pointed at the same name).
+
+## Quick start
+
+```bash
+# 1. The secrets. MASTER_SECRETS_KEY encrypts every stored secret — lose it
+#    and they are unrecoverable, so back it up somewhere that is not the
+#    cluster. See "Back up MASTER_SECRETS_KEY" in the self-hosting guide.
+kubectl create namespace fountain
+kubectl create secret generic fountain-secrets -n fountain \
+  --from-literal=SECRET_KEY_BASE="$(openssl rand -base64 48 | tr -d '\n')" \
+  --from-literal=MASTER_SECRETS_KEY="$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" \
+  --from-literal=DATABASE_URL="postgres://user:pass@your-postgres:5432/fountain" \
+  --from-literal=SPRITES_TOKEN="your-sprites-token"
+
+# 2. Edit configmap.yaml (PUBLIC_URL at minimum) and the image pin in
+#    kustomization.yaml, then:
+kubectl apply -k deploy/k8s
+
+# 3. Watch it come up. Migrations run at boot under an advisory lock.
+kubectl rollout status deployment/fountain -n fountain
+
+# 4. Register, then verify your account (EMAIL_DELIVERY defaults to none):
+kubectl exec -n fountain deploy/fountain -- \
+  sh -c "PHX_SERVER=false bin/fountain_server eval 'Fountain.Release.verify_email(\"you@example.com\")'"
+```
+
+Then close registration (`REGISTRATION_ENABLED: "false"` + re-apply) and, to
+make yourself admin, set the role in SQL — there is no first-admin bootstrap
+yet:
+
+```bash
+psql "$DATABASE_URL" -c "UPDATE users SET role = 'admin' WHERE email = 'you@example.com';"
+```
+
+## Upgrades
+
+Edit the tag in `kustomization.yaml`'s `images:` block and re-apply. `vX.Y.Z`
+tags are immutable; `vX.Y` follows patches. Patch releases are always safe;
+pre-1.0 minor bumps may carry **Upgrade notes** in the
+[changelog](https://binarybourbon.github.io/fountain/changelog/). Migrations
+run at boot, idempotently, under an advisory lock. Downgrades are not
+supported once a newer version's migrations have run — restore from a backup.
+
+## Operational notes
+
+- **Probes**: liveness checks only the process (a Postgres blip must not
+  restart the app tier); readiness checks the database and gates traffic; the
+  startup probe allows 150s for boot-time migrations. Reasons are inline in
+  `deployment.yaml`.
+- **Metrics**: Prometheus format on port 9568 (`metrics`). Scrape in-cluster;
+  never expose it.
+- **Scaling**: one replica by default, and going higher is not just a number —
+  see the comment atop `deployment.yaml`.
+- **Backups**: nothing here backs up your database, and `MASTER_SECRETS_KEY`
+  must be backed up separately from it — a database backup alone cannot
+  decrypt itself.

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,35 @@
+# Non-secret configuration. Secrets (SECRET_KEY_BASE, MASTER_SECRETS_KEY,
+# DATABASE_URL, SPRITES_TOKEN, mail credentials) belong in the
+# `fountain-secrets` Secret — see README.md for the create command.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fountain-config
+data:
+  # The externally-visible URL, scheme included. Builds verification and
+  # password-reset links and is handed to every sandbox as FOUNTAIN_BASE_URL,
+  # so it must resolve from outside the cluster. An https:// value also turns
+  # on the HTTPS redirect, HSTS and secure cookies — your ingress must then
+  # set X-Forwarded-Proto or every request looks like http and redirect-loops.
+  PUBLIC_URL: "https://fountain.example.com"
+
+  # The subscription gate is a lock with no key on a self-hosted instance
+  # unless you configure Stripe. Leave it off.
+  BILLING_ENABLED: "false"
+
+  # An instance on the public internet with registration open will be found.
+  # Open it just long enough to register yourself, or scope it:
+  # REGISTRATION_ALLOWED_EMAIL_DOMAINS: "example.com"
+  REGISTRATION_ENABLED: "true"
+
+  # "none" sends nothing: verify your first account with
+  #   kubectl exec -n fountain deploy/fountain -- \
+  #     sh -c "PHX_SERVER=false bin/fountain_server eval 'Fountain.Release.verify_email(\"you@example.com\")'"
+  # For real delivery set RESEND_API_KEY or SMTP_* in fountain-secrets and
+  # delete this key.
+  EMAIL_DELIVERY: "none"
+
+  # On by default; set to "false" only if your Postgres does not serve TLS.
+  # DATABASE_SSL_VERIFY / DATABASE_SSL_CA_FILE upgrade encryption to actual
+  # verification — see the self-hosting guide.
+  DATABASE_SSL: "true"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,101 @@
+# The portable baseline. The probe layout, security posture and resource
+# shape mirror what the hosted instance learned the hard way (k8s/ at the
+# repo root); the personal infrastructure — CNPG, Infisical, Traefik,
+# Erlang clustering — does not follow it here.
+#
+# One replica on purpose. Running more requires a real Erlang cluster
+# (RELEASE_DISTRIBUTION/RELEASE_NODE/RELEASE_COOKIE, CLUSTER_DNS_QUERY
+# against a headless Service, and an open dist port) or the pods run as
+# isolated islands and conversation streaming silently breaks for whichever
+# pod didn't spawn the conversation. k8s/deployment.yaml in the repo root
+# shows the full wiring if you need HA.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fountain
+  labels:
+    app: fountain
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: fountain
+  template:
+    metadata:
+      labels:
+        app: fountain
+    spec:
+      containers:
+        - name: fountain
+          # Retagged by kustomization.yaml's images: block — edit the pin
+          # there, not here.
+          image: ghcr.io/binarybourbon/fountain:v0.3.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 4000
+            # Prometheus scrape endpoint, on its own listener so it never
+            # rides the public Service. Scrape it in-cluster; do not expose
+            # it — it enumerates routes, request rates and DB timings.
+            - name: metrics
+              containerPort: 9568
+          env:
+            - name: PHX_SERVER
+              value: "true"
+            - name: PORT
+              value: "4000"
+          envFrom:
+            - configMapRef:
+                name: fountain-config
+            # SECRET_KEY_BASE, MASTER_SECRETS_KEY, DATABASE_URL,
+            # SPRITES_TOKEN (+ mail/OAuth/Stripe if used). See README.md.
+            - secretRef:
+                name: fountain-secrets
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          # Migrations run at boot, before the endpoint listens. The startup
+          # probe holds the other probes off for up to 150s so a slow
+          # migration is not mistaken for a dead pod and restart-looped.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
+          # Readiness checks Postgres and gates traffic: a pod that cannot
+          # serve is pulled from the Service without being killed, and
+          # recovery needs no restart. Generous timeout because answering
+          # 503 with a dead database takes ~3s, and a recorded 503 is more
+          # legible than a probe timeout.
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 4
+            failureThreshold: 6
+          # Liveness restarts the pod, so it checks nothing but the process:
+          # pointing it at the database would restart every pod at once
+          # during a Postgres blip, which does nothing to fix Postgres.
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+            failureThreshold: 3

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -1,0 +1,32 @@
+# A standard networking.k8s.io/v1 Ingress. Edit the host, then uncomment
+# this file in kustomization.yaml.
+#
+# The contract your ingress must satisfy, whatever controller you run:
+#   - terminate TLS (or run PUBLIC_URL as http:// and accept what that means)
+#   - set X-Forwarded-Proto — with an https:// PUBLIC_URL the app redirects
+#     anything that looks like plain http, and without the header everything
+#     does, in a loop
+#   - allow WebSocket upgrades (LiveView)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fountain
+  annotations:
+    # Controller-specific annotations go here, e.g. for cert-manager:
+    # cert-manager.io/cluster-issuer: your-issuer
+spec:
+  # ingressClassName: nginx
+  rules:
+    - host: fountain.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fountain
+                port:
+                  name: http
+  # tls:
+  #   - hosts: [fountain.example.com]
+  #     secretName: fountain-tls

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: fountain
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  # Uncomment after editing the host in ingress.yaml. Left out of the base
+  # because ingress controllers and TLS setups vary too much to guess at —
+  # see README.md for the contract yours must satisfy.
+  # - ingress.yaml
+
+images:
+  # Pin a release, not `latest` — `latest` moves on every merge to main.
+  # Released tags: vX.Y.Z (immutable) and vX.Y (newest patch in the line).
+  # https://binarybourbon.github.io/fountain/self-hosting/#versioning-and-upgrades
+  - name: ghcr.io/binarybourbon/fountain
+    newTag: v0.3.0

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fountain

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fountain
+  labels:
+    app: fountain
+spec:
+  selector:
+    app: fountain
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -230,11 +230,17 @@ lower.
 
 ## Kubernetes
 
-`k8s/` in this repository is the maintainer's own cluster, not a template: it
-assumes CNPG, Traefik, cert-manager, Infisical, Flux and Longhorn, and hardcodes
-personal hostnames. It is worth reading for reference and is not worth applying.
-A generic chart is
-[#191](https://github.com/BinaryBourbon/fountain/issues/191).
+A portable baseline lives in
+[`deploy/k8s/`](https://github.com/BinaryBourbon/fountain/tree/main/deploy/k8s)
+— plain manifests applied with `kubectl apply -k`, no operators or CRDs
+assumed. You bring a Postgres, an ingress controller, and the
+`fountain-secrets` Secret; its README walks through the rest, and the probe
+and scaling reasoning is commented inline in the manifests.
+
+`k8s/` in this repository is a different thing: the maintainer's own cluster
+(CNPG, Traefik, cert-manager, Infisical, Flux, Longhorn, personal hostnames).
+It is worth reading — it shows the full Erlang-clustering wiring for running
+more than one replica — and is not worth applying.
 
 ## Licence
 


### PR DESCRIPTION
Closes #191.

## Shape

`deploy/k8s/` — a self-contained kustomize base (`kubectl apply -k`), deliberately **not** a restructuring of `k8s/`:

- `pin-image.yml` rewrites `k8s/deployment.yaml` by sed and Flux consumes that path from the `deploy` branch. Moving those files means touching the exact plumbing behind #231/#241, for zero self-hoster benefit. `k8s/` stays byte-identical, documented as the maintainer's cluster and referenced as the worked example of HA clustering wiring.
- `deploy/**` joins build.yml's `paths-ignore` — manifest edits never trigger a multi-arch image build.

## Contents

| File | Notes |
|---|---|
| `kustomization.yaml` | `images:` block pins `v0.3.0` (pinnable since #190); edit there, not in the Deployment |
| `configmap.yaml` | the non-secret env contract, each key documented (PUBLIC_URL semantics, registration warning, EMAIL_DELIVERY=none verify flow) |
| `deployment.yaml` | 1 replica with the isolated-islands caveat explained; prod's probe philosophy (startup window for boot migrations, DB-checking readiness, dependency-free liveness) and non-root/read-only securityContext carried over |
| `service.yaml`, `namespace.yaml` | plain |
| `ingress.yaml` | opt-in (commented out of resources); generic `networking.k8s.io/v1` with the contract any controller must satisfy: TLS, X-Forwarded-Proto, WebSocket upgrade |
| `README.md` | quick start incl. secret creation, upgrade flow, what's deliberately excluded (database, TLS, secret management) |

Docs: self-hosting guide's Kubernetes section now leads with the baseline; changelog entry added.

## Verification

- `kubectl kustomize deploy/k8s` renders; the image retag applies.
- All manifests (ingress included) pass `kubectl apply --dry-run=client` schema validation — dry-run only, nothing applied anywhere.
- `mkdocs build --strict` clean with the docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)