### PR TITLE
accounts: prune never-verified registrations after 30 days (#258)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,12 @@ SPRITES_TOKEN=
 # SENTRY_DSN=
 # SENTRY_ENVIRONMENT=production
 
+# Accounts that never verify their email are deleted after this many days
+# (0 disables). UNVERIFIED_PRUNE_EXEMPT: comma-separated email substrings
+# never pruned (operator/test accounts that deliberately stay unverified).
+# UNVERIFIED_PRUNE_AFTER_DAYS=30
+# UNVERIFIED_PRUNE_EXEMPT=
+
 # Externally-visible base URL, absolute and scheme-ful. Used to build links
 # that leave the app (verification and reset emails, llms.txt) and passed to
 # every sprite as FOUNTAIN_BASE_URL, so it must be resolvable from outside.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ upgrade, is in
 
 ### Added
 
+- Accounts that register and never verify their email are deleted after 30
+  days (#258) — they cannot log in, and 158 of them were briefly mistaken for
+  a legacy trial cohort. Same teardown as self-serve deletion, Stripe
+  cancellation included; `UNVERIFIED_PRUNE_AFTER_DAYS=0` disables,
+  `UNVERIFIED_PRUNE_EXEMPT` protects deliberate unverified accounts
+
 - Optional error tracking via Sentry (or any Sentry-API-compatible endpoint):
   crashes from every process — not just web requests — are reported with
   release correlation, rate-limited, with PII off. Fully inert unless

--- a/apps/fountain/lib/fountain/workers/unverified_account_pruner.ex
+++ b/apps/fountain/lib/fountain/workers/unverified_account_pruner.ex
@@ -1,0 +1,100 @@
+defmodule Fountain.Workers.UnverifiedAccountPruner do
+  @moduledoc """
+  Deletes accounts that registered and never verified their email (#258).
+
+  Unverified accounts cannot log in — `require_authenticated_user` halts them —
+  so after the grace period they are rows, not users. They are not free rows
+  either: each carries a wrapped DEK, they distort every metric that counts
+  `users`, and 158 of them were briefly mistaken for a 159-person legacy trial
+  cohort (see `Fountain.Release.expire_legacy_trials/1`). The steady inflow is
+  drive-by/bot registration (#259).
+
+  Deletion goes through `Accounts.Deletion.delete_user/2` — the same teardown
+  as self-serve and admin deletion (Stripe cancellation first, sprites, audit
+  row) — never a bare `DELETE`. A registration-time Stripe trial subscription
+  (#244) is therefore cancelled rather than left to fire trial-ending emails
+  at an address that never asked for them.
+
+  Config:
+
+    * `:unverified_prune_after_days` — grace period, default 30. An account
+      that verifies at any point is never touched; the window only has to be
+      longer than "signed up, verified a while later". `0` disables the sweep.
+    * `:unverified_prune_exempt` — substrings; an email containing any of
+      them is never pruned, case-insensitively. For operator/test accounts
+      that deliberately stay unverified.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 1
+
+  import Ecto.Query
+
+  alias Fountain.Accounts.{Deletion, User}
+  alias Fountain.Repo
+
+  require Logger
+
+  # Bounds one run; the sweep is daily, so a backlog larger than this drains
+  # over a few days rather than making one giant run.
+  @batch 100
+
+  @impl Oban.Worker
+  def perform(_job) do
+    case prune_after_days() do
+      0 ->
+        :ok
+
+      days ->
+        {deleted, skipped} = sweep(days)
+
+        if deleted > 0 or skipped > 0 do
+          Logger.info(
+            "unverified-account pruner: deleted #{deleted}, skipped #{skipped} " <>
+              "(exempt or deletion failed)"
+          )
+        end
+
+        :ok
+    end
+  end
+
+  defp sweep(days) do
+    cutoff = DateTime.utc_now() |> DateTime.add(-days, :day)
+    exempt = exempt_substrings()
+
+    User
+    |> where([u], is_nil(u.email_verified_at) and u.inserted_at < ^cutoff)
+    |> order_by([u], asc: u.inserted_at)
+    |> limit(@batch)
+    |> Repo.all()
+    |> Enum.reduce({0, 0}, fn user, {deleted, skipped} ->
+      cond do
+        exempt?(user.email, exempt) ->
+          {deleted, skipped + 1}
+
+        match?({:ok, _}, Deletion.delete_user(user, actor: "system:unverified_pruner")) ->
+          {deleted + 1, skipped}
+
+        true ->
+          # delete_user logged the reason; a Stripe refusal aborts before any
+          # destruction, so leaving it for the next run is safe.
+          {deleted, skipped + 1}
+      end
+    end)
+  end
+
+  defp exempt?(_email, []), do: false
+
+  defp exempt?(email, substrings) do
+    downcased = String.downcase(email)
+    Enum.any?(substrings, &String.contains?(downcased, String.downcase(&1)))
+  end
+
+  defp prune_after_days do
+    Application.get_env(:fountain, :unverified_prune_after_days, 30)
+  end
+
+  defp exempt_substrings do
+    Application.get_env(:fountain, :unverified_prune_exempt, [])
+  end
+end

--- a/apps/fountain/test/fountain/workers/unverified_account_pruner_test.exs
+++ b/apps/fountain/test/fountain/workers/unverified_account_pruner_test.exs
@@ -1,0 +1,71 @@
+defmodule Fountain.Workers.UnverifiedAccountPrunerTest do
+  # async: false — the exemption list lives in application env, which is
+  # global; a concurrent test would see this one's config.
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Accounts.User
+  alias Fountain.Workers.UnverifiedAccountPruner
+
+  defp backdate(user, days_ago) do
+    inserted =
+      DateTime.utc_now() |> DateTime.add(-days_ago, :day) |> DateTime.truncate(:second)
+
+    user |> Ecto.Changeset.change(inserted_at: inserted) |> Repo.update!()
+  end
+
+  setup do
+    previous_days = Application.get_env(:fountain, :unverified_prune_after_days, 30)
+    previous_exempt = Application.get_env(:fountain, :unverified_prune_exempt, [])
+
+    on_exit(fn ->
+      Application.put_env(:fountain, :unverified_prune_after_days, previous_days)
+      Application.put_env(:fountain, :unverified_prune_exempt, previous_exempt)
+    end)
+
+    :ok
+  end
+
+  test "deletes only unverified accounts past the grace period" do
+    stale = backdate(insert_user(), 45)
+    fresh = insert_user()
+    verified_stale = backdate(insert_verified_user(), 45)
+
+    assert :ok = UnverifiedAccountPruner.perform(%Oban.Job{})
+
+    refute Repo.get(User, stale.id)
+    assert Repo.get(User, fresh.id)
+    assert Repo.get(User, verified_stale.id)
+  end
+
+  test "an exempt substring protects an account, case-insensitively" do
+    Application.put_env(:fountain, :unverified_prune_exempt, ["jhgaylor"])
+
+    exempt = backdate(insert_user(%{"email" => "JHGaylor+bot-test-#{System.unique_integer([:positive])}@example.com"}), 45)
+    doomed = backdate(insert_user(), 45)
+
+    assert :ok = UnverifiedAccountPruner.perform(%Oban.Job{})
+
+    assert Repo.get(User, exempt.id)
+    refute Repo.get(User, doomed.id)
+  end
+
+  test "0 days disables the sweep entirely" do
+    Application.put_env(:fountain, :unverified_prune_after_days, 0)
+    stale = backdate(insert_user(), 400)
+
+    assert :ok = UnverifiedAccountPruner.perform(%Oban.Job{})
+    assert Repo.get(User, stale.id)
+  end
+
+  test "deletion leaves the audit trail delete_user writes" do
+    stale = backdate(insert_user(), 45)
+    assert :ok = UnverifiedAccountPruner.perform(%Oban.Job{})
+
+    assert Enum.any?(
+             Fountain.Audit._unsafe_list_recent(50),
+             &(&1.action == "account.deleted" and
+                 &1.metadata["user_id"] == stale.id and
+                 &1.actor == "system:unverified_pruner")
+           )
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,7 +18,10 @@ config :fountain, Oban,
        # tenant quota, so the gap between the leak and its cleanup is what
        # matters. Each run is one paginated list plus at most a handful of
        # deletes.
-       {"7 * * * *", Fountain.Workers.SandboxReaper}
+       {"7 * * * *", Fountain.Workers.SandboxReaper},
+       # 05:41 UTC — after the 03:17 backup and the 04:23 retention prune, so
+       # a backup always captures the accounts before the sweep removes them.
+       {"41 5 * * *", Fountain.Workers.UnverifiedAccountPruner}
      ]}
   ]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -205,6 +205,21 @@ config :fountain,
   sandbox_idle_timeout_minutes: parse_bound.("SANDBOX_IDLE_TIMEOUT_MINUTES", "60"),
   sandbox_max_lifetime_hours: parse_bound.("SANDBOX_MAX_LIFETIME_HOURS", "24")
 
+# Accounts that registered and never verified are deleted after this many
+# days (#258) — they cannot log in, so they are rows, not users. 0 disables
+# the sweep. UNVERIFIED_PRUNE_EXEMPT is a comma-separated list of email
+# substrings that are never pruned (operator/test accounts that deliberately
+# stay unverified).
+unverified_prune_exempt =
+  case System.get_env("UNVERIFIED_PRUNE_EXEMPT") do
+    blank when blank in [nil, ""] -> []
+    list -> list |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+  end
+
+config :fountain,
+  unverified_prune_after_days: parse_bound.("UNVERIFIED_PRUNE_AFTER_DAYS", "30"),
+  unverified_prune_exempt: unverified_prune_exempt
+
 # CIDRs treated as proxies when resolving the client IP from X-Forwarded-For.
 # Only widen this to cover addresses that are genuinely proxies — anything
 # trusted here is stepped over, so an over-broad list lets a client spoof its


### PR DESCRIPTION
Closes #258, per the decision (with the jhgaylor exemption).

- **Daily Oban cron** (05:41 UTC — after the 03:17 backup and 04:23 retention prune, so backups always capture pre-sweep state), batch-limited to 100/run so a backlog drains over days rather than one giant run. The existing 158 are the first run's work.
- **Deletes through `Accounts.Deletion.delete_user/2`**, never a bare `DELETE` — Stripe cancellation first (a registration-time trial subscription stops sending trial emails to a harvested address), sprites, audit row with `actor: "system:unverified_pruner"`.
- **Exemption**: `UNVERIFIED_PRUNE_EXEMPT` comma-separated email substrings, case-insensitive. The hosted instance sets `jhgaylor` (env added on the #268 overlay branch). `UNVERIFIED_PRUNE_AFTER_DAYS=0` disables the sweep for self-hosters who want the old behavior.
- 4 tests: grace-period boundary (stale unverified deleted; fresh and verified-stale untouched), exemption case-insensitivity, the 0-disable, and the audit trail.

Full precommit green, 1528 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)