### PR TITLE
ops: point-in-time recovery via the barman-cloud plugin (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ upgrade, is in
 
 ### Added
 
+- Point-in-time recovery for the hosted database (#209): continuous WAL
+  archiving plus nightly base backups via the CNPG barman-cloud plugin into
+  the existing Garage bucket, retention 14 days, RPO ~5 minutes with the
+  nightly `pg_dump` kept as the operator-independent fallback. The dump job
+  now sends a Sentry Crons check-in, so a backup that quietly stops running
+  pages instead of rotting
+
 - Accounts that register and never verify their email are deleted after 30
   days (#258) — they cannot log in, and 158 of them were briefly mistaken for
   a legacy trial cohort. Same teardown as self-serve deletion, Stripe

--- a/k8s/backup-cronjob.yaml
+++ b/k8s/backup-cronjob.yaml
@@ -166,7 +166,31 @@ spec:
                       done || true
 
                   echo "Backup complete: ${DEST}"
+
+                  # Sentry Crons check-in (#209): a backup job that quietly
+                  # stops running is the classic way backups rot, and Sentry
+                  # (#211) alerts on a missed schedule. Best-effort — a Sentry
+                  # outage must never fail a backup that succeeded. The
+                  # monitor is auto-created on first check-in; set its
+                  # schedule (daily, 03:17 UTC, grace ~60min) in the Sentry UI
+                  # to arm missed-run alerting.
+                  if [ -n "${SENTRY_DSN:-}" ]; then
+                    K="${SENTRY_DSN#https://}"; K="${K%%@*}"
+                    HP="${SENTRY_DSN#*@}"; H="${HP%%/*}"; P="${HP##*/}"
+                    curl -fsS -m 10 \
+                      "https://${H}/api/${P}/cron/fountain-pg-dump/${K}/?status=ok" \
+                      >/dev/null && echo "Sentry check-in sent." \
+                      || echo "Sentry check-in failed (ignored)."
+                  fi
               env:
+                # Optional: enables the cron check-in above; absent, the job
+                # still runs and simply doesn't report.
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: fountain-secrets
+                      key: SENTRY_DSN
+                      optional: true
                 - name: S3_ENDPOINT
                   value: http://s3.garage.svc.cluster.local:3900
                 - name: BUCKET

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -19,6 +19,11 @@ resources:
   - backup-bucket-rbac.yaml
   - backup-bucket-bootstrap.yaml
   - backup-cronjob.yaml
+  # WAL archiving + base backups (#209): the ObjectStore the plugin archives
+  # into, and the nightly base backup PITR replays from. Ordered before
+  # postgres.yaml, whose plugins: block references the ObjectStore by name.
+  - objectstore.yaml
+  - scheduledbackup.yaml
   - postgres.yaml
   - infisicalsecret.yaml
   - service-headless.yaml

--- a/k8s/objectstore.yaml
+++ b/k8s/objectstore.yaml
@@ -1,0 +1,38 @@
+# Barman object store for continuous WAL archiving + base backups (#209),
+# served by the barman-cloud CNPG-I plugin (installed cluster-wide from
+# home-cloud). Reuses the same Garage bucket and credentials as the nightly
+# pg_dump — deliberately: the dump stays as the mechanism-diverse fallback,
+# and its value is being restorable without the operator, not surviving a
+# Garage outage the WAL stream wouldn't.
+#
+# Everything lands under s3://fountain-backups/barman/, beside the dumps in
+# pg_dump/. The bucket carries a 5GiB Garage quota (backup-bucket-bootstrap),
+# which bounds a runaway WAL stream; retention keeps steady-state well under.
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: fountain-backups
+  namespace: fountain
+  labels:
+    app: fountain
+spec:
+  # Base backups + WAL older than this are pruned by the plugin after each
+  # base backup. Two weeks of PITR is far past any realistic "when did the
+  # bad write happen" window for a single-operator product.
+  retentionPolicy: "14d"
+  configuration:
+    destinationPath: s3://fountain-backups/barman
+    # Garage, in-cluster, path-style (the bucket is not DNS-resolvable as a
+    # subdomain of the service name).
+    endpointURL: http://s3.garage.svc.cluster.local:3900
+    s3Credentials:
+      accessKeyId:
+        name: fountain-backup-s3-credentials
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: fountain-backup-s3-credentials
+        key: AWS_SECRET_ACCESS_KEY
+    wal:
+      compression: gzip
+    data:
+      compression: gzip

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -28,6 +28,19 @@ metadata:
 spec:
   instances: 1
 
+  # Continuous WAL archiving via the barman-cloud CNPG-I plugin (#209) into
+  # the ObjectStore defined in objectstore.yaml. Adding this injects the
+  # plugin sidecar, which ROLLS THE POSTGRES POD — with instances: 1 that is
+  # a brief database outage; the app's readiness probe drains and recovers
+  # without restarts by design. Recovery objective once live: RPO <= ~5min
+  # (WAL granularity), with the 03:17 pg_dump as the operator-independent
+  # 24h fallback.
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: fountain-backups
+
   imageName: ghcr.io/cloudnative-pg/postgresql:18.4-standard-trixie
 
   bootstrap:

--- a/k8s/scheduledbackup.yaml
+++ b/k8s/scheduledbackup.yaml
@@ -1,0 +1,23 @@
+# Nightly base backup through the barman-cloud plugin. PITR needs both: the
+# WAL stream (continuous, from the Cluster's plugin config) and a base backup
+# to replay it against — recovery time grows with WAL replayed since the last
+# base.
+#
+# 02:47 UTC: before the 03:17 pg_dump so the two backup mechanisms never
+# contend, and both precede the 04:23/05:41 pruners. Note CNPG schedules are
+# SIX fields (leading seconds), unlike vanilla cron.
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: fountain-pg-base
+  namespace: fountain
+  labels:
+    app: fountain
+spec:
+  schedule: "0 47 2 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: fountain-pg
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io


### PR DESCRIPTION
Closes #209, per the accepted recommendation (Garage bucket, RPO ≤ 5min / 24h dump fallback). The cluster-wide prerequisite is already live: home-cloud#36 installed plugin-barman-cloud v0.14.0, verified Running in `cnpg-system` with the ObjectStore CRD present.

## What this adds

- **`ObjectStore/fountain-backups`** — barman config pointing at the existing Garage bucket (`s3://fountain-backups/barman/`, beside the dumps), same credentials Secret, gzip WAL+data, `retentionPolicy: 14d`. The bucket's 5GiB Garage quota bounds a runaway WAL stream.
- **`Cluster/fountain-pg`** gains the `plugins:` block (`isWALArchiver: true`) — the *plugin* route, not the in-tree `spec.backup.barmanObjectStore` that silently archives nothing on operator ≥1.26 (the trap this issue documented).
- **`ScheduledBackup/fountain-pg-base`** — nightly base backup at 02:47 UTC (CNPG's six-field cron), before the dump, both before the pruners.
- **Sentry Crons check-in** on the existing dump CronJob (best-effort, optional `SENTRY_DSN`, never fails a successful backup): monitor `fountain-pg-dump` auto-creates on first check-in; set its schedule + grace in the Sentry UI to arm missed-run alerting.
- The dump stays, deliberately — different mechanism, different failure mode, restorable without the operator.

## Rollout caution

Adding `plugins:` injects a sidecar and **rolls the single-instance Postgres pod** — a brief DB outage the app absorbs (readiness drains, liveness deliberately doesn't restart). Sequence: merge after the current app rollout settles, dispatch `build.yml` (k8s-only changes don't trigger builds), watch Flux apply + the pod roll, then verify `ContinuousArchiving` on the Cluster, take an on-demand `Backup` to prove the base-backup path, and check objects appear under `barman/` in Garage.

## Verified pre-merge

- `kubectl kustomize` renders; all 21 resources pass client dry-run.
- Plugin parameter names (`barmanObjectName`, `isWALArchiver`) confirmed against plugin v0.14.0 docs; secret key names confirmed against the live Secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)