### PR TITLE
docs: ADRs and docstrings must not describe unbuilt behavior as existing (#271)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,3 +207,5 @@ See `.env.example` for the full list. Key ones for local dev:
 ## Decisions
 
 Architecturally significant choices live in `decisions/NNNN-<title>.md`. When a decision is contentious or needs to constrain future work, write an ADR. Use `decisions/0001-template.md` as the template.
+
+**ADRs and docstrings must not describe unbuilt behavior as existing.** The 2026-07 audit found three mechanisms asserted as implemented (a quota check, metering call sites, a gate backstop) that did not exist — anyone reading the ADRs concluded the system was metered, capped and gated when it was none of those. If a document describes behavior that is not yet in code, say so explicitly (`**Status:** Proposed`, "not yet built"), and remove the caveat in the PR that builds it.

--- a/decisions/0001-template.md
+++ b/decisions/0001-template.md
@@ -2,6 +2,14 @@
 
 **Status:** Template — not a real decision. Copy this file as `decisions/NNNN-<short-title>.md` and fill it in.
 
+Real ADRs carry a status too: `Proposed` (decision not yet made), `Accepted`
+(decided; may describe behavior that is not all built yet — if so, name what
+is unbuilt), or `Superseded by NNNN`. Never describe unbuilt behavior as
+existing: the 2026-07 audit (#200) found three mechanisms asserted as
+implemented that did not exist, and every reader of those ADRs was misled
+until code was checked (#271). The PR that builds a described mechanism
+removes its "not yet built" caveat in the same change.
+
 ## Context
 
 What's the situation forcing a choice? What constraints make this non-obvious? Link to relevant briefs, prior ADRs, or external docs.


### PR DESCRIPTION
Closes #271. Two small writing changes plus the sweep:

- **CLAUDE.md** (Decisions section): the convention, with the audit's finding as the rationale — three mechanisms asserted as implemented that didn't exist, misleading every ADR reader until code was checked.
- **decisions/0001-template.md**: real ADRs carry `Proposed` / `Accepted` / `Superseded by NNNN`; unbuilt behavior must be named as unbuilt; the PR that builds it removes the caveat.
- **Sweep (0002–0009 + the flagged docstrings), verified against code**: every previously-phantom claim is now true — `Quotas.check_sandbox_quota!/1` exists and gates provisioning at `conversations.ex:785`/`1039`, the metering docstring names its actual emit sites, ADR 0008's `Crypto.load_tenant_key/1` dependency is real, ADR 0009 is `Proposed` and says so. No caveats needed today; the convention keeps it that way.

Docs-only; no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)