### PR TITLE
config: every runtime env var documented, enforced by a test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+# Every variable the server reads is documented in docs/configuration.md
+# (published on the docs site as "Configuration reference"), enforced by a
+# test. This file is the local-dev subset plus the self-hosting switches.
+
+# ── Core ─────────────────────────────────────────────────────────────────────
+
 # Database — use docker-compose for local dev: docker compose up -d
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/fountain_dev
 
@@ -5,28 +11,15 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/fountain_dev
 # Generate: openssl rand 32 | base64 | tr '+/' '-_' | tr -d '='
 MASTER_SECRETS_KEY=
 
-# Sprites platform token (never expose to tenants)
-SPRITES_TOKEN=
-
-# HTTP timeout for Sprites API calls, in milliseconds. Long-running commands
-# (package installs, clones) set their own per-call timeouts.
-# SPRITES_TIMEOUT_MS=30000
-
-# Error tracking. Unset = fully disabled, nothing is sent anywhere. Accepts a
-# sentry.io DSN or any Sentry-API-compatible endpoint (e.g. GlitchTip).
-# SENTRY_DSN=
-# SENTRY_ENVIRONMENT=production
-
-# Accounts that never verify their email are deleted after this many days
-# (0 disables). UNVERIFIED_PRUNE_EXEMPT: comma-separated email substrings
-# never pruned (operator/test accounts that deliberately stay unverified).
-# UNVERIFIED_PRUNE_AFTER_DAYS=30
-# UNVERIFIED_PRUNE_EXEMPT=
+# Required in production when serving. Signs and encrypts session cookies.
+# Generate: openssl rand -base64 48
+# SECRET_KEY_BASE=
 
 # Externally-visible base URL, absolute and scheme-ful. Used to build links
 # that leave the app (verification and reset emails, llms.txt) and passed to
 # every sprite as FOUNTAIN_BASE_URL, so it must be resolvable from outside.
-# Defaults to http://localhost:4000.
+# An https:// value also switches on HTTPS redirection, HSTS and the secure
+# cookie flag. Defaults to http://localhost:4000.
 PUBLIC_URL=http://localhost:4000
 
 # Bare host for the endpoint URL and the LiveView check_origin allowlist.
@@ -37,17 +30,42 @@ PUBLIC_URL=http://localhost:4000
 # the base URL, which produced schemeless links when set to a bare host. Still
 # honoured as a fallback for both; prefer PUBLIC_URL / PHX_HOST.
 
-# GitHub OAuth (register at https://github.com/settings/developers)
-GITHUB_OAUTH_CLIENT_ID=
-GITHUB_OAUTH_CLIENT_SECRET=
+# PHX_SERVER=true starts the web listener (the shipped image sets it; release
+# tasks run with PHX_SERVER=false). PORT is the listen port.
+# PHX_SERVER=true
+# PORT=4000
 
-# Stripe billing
-STRIPE_SECRET_KEY=
-STRIPE_PUBLISHABLE_KEY=
-STRIPE_WEBHOOK_SECRET=
-# Price ID for the subscription tier (price_xxx). Use the test-mode
-# price in dev (created in Stripe Dashboard > Test mode > Products).
-STRIPE_PRICE_ID=
+# ── Sandboxes ────────────────────────────────────────────────────────────────
+
+# Sprites platform token (never expose to tenants — it pays for every sandbox)
+SPRITES_TOKEN=
+
+# Sandbox API endpoint. Anything else must implement the same contract.
+# SPRITES_BASE_URL=https://api.sprites.dev
+
+# HTTP timeout for Sprites API calls, in milliseconds. Long-running commands
+# (package installs, clones) set their own per-call timeouts.
+# SPRITES_TIMEOUT_MS=30000
+
+# Sandbox lifetime bounds: reclaim after this long idle, and an absolute age
+# ceiling. 0 disables a bound; the conversation always stays resumable.
+# SANDBOX_IDLE_TIMEOUT_MINUTES=60
+# SANDBOX_MAX_LIFETIME_HOURS=24
+
+# ── Registration and accounts ────────────────────────────────────────────────
+
+# Registration is open by default. Close it once your accounts exist, or
+# restrict it to your own domains.
+# REGISTRATION_ENABLED=false
+# REGISTRATION_ALLOWED_EMAIL_DOMAINS=example.com,example.org
+
+# Accounts that never verify their email are deleted after this many days
+# (0 disables). UNVERIFIED_PRUNE_EXEMPT: comma-separated email substrings
+# never pruned (operator/test accounts that deliberately stay unverified).
+# UNVERIFIED_PRUNE_AFTER_DAYS=30
+# UNVERIFIED_PRUNE_EXEMPT=
+
+# ── Email ────────────────────────────────────────────────────────────────────
 
 # Mail delivery. Production refuses to boot unless one of these is set —
 # an unconfigured instance used to discard verification emails silently, which
@@ -74,12 +92,32 @@ RESEND_API_KEY=
 
 EMAIL_FROM=noreply@updates.inevitable.fyi
 
+# ── Authentication ───────────────────────────────────────────────────────────
+
+# GitHub OAuth (register at https://github.com/settings/developers). Optional:
+# unset, email + password auth still works.
+GITHUB_OAUTH_CLIENT_ID=
+GITHUB_OAUTH_CLIENT_SECRET=
+
 # Inference credentials are per-user (BYO, ADR 0008). Set them via
 # /account/inference-credentials in the running app, not via env vars.
 # (CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY
 # all live in the inference_credentials table now.)
 
-# ── Self-hosting switches ────────────────────────────────────────────────────
+# ── Billing ──────────────────────────────────────────────────────────────────
+
+# The subscription gate (ADR 0006) is meaningful for the hosted instance and is
+# a lock with no key on a self-hosted one.
+# BILLING_ENABLED=false
+
+# Stripe billing (only with BILLING_ENABLED=true)
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+# Price ID for the subscription tier (price_xxx). Use the test-mode
+# price in dev (created in Stripe Dashboard > Test mode > Products).
+STRIPE_PRICE_ID=
+
+# ── Database TLS and pool ────────────────────────────────────────────────────
 
 # Database TLS. Defaults to on. A stock postgres container does not serve TLS,
 # so set this false for the docker-compose setup.
@@ -88,12 +126,46 @@ EMAIL_FROM=noreply@updates.inevitable.fyi
 # store unless DATABASE_SSL_CA_FILE points at a bundle.
 # DATABASE_SSL_VERIFY=true
 # DATABASE_SSL_CA_FILE=/etc/ssl/certs/ca.pem
+# POOL_SIZE=10
 
-# The subscription gate (ADR 0006) is meaningful for the hosted instance and is
-# a lock with no key on a self-hosted one.
-# BILLING_ENABLED=false
+# ── Proxies and origins ──────────────────────────────────────────────────────
 
-# Registration is open by default. Close it once your accounts exist, or restrict it
-# to your own domains.
-# REGISTRATION_ENABLED=false
-# REGISTRATION_ALLOWED_EMAIL_DOMAINS=example.com,example.org
+# CIDRs treated as proxies when resolving the client IP from X-Forwarded-For.
+# Required behind a terminating proxy, or per-IP rate limits collapse into one
+# bucket keyed on the proxy. Only list genuine proxies.
+# TRUSTED_PROXIES=10.0.0.0/8
+
+# Extra origins allowed to open a LiveView websocket (comma-separated). Your
+# own host is always included.
+# CHECK_ORIGIN_EXTRA=
+
+# ── Clustering (multi-replica only) ──────────────────────────────────────────
+
+# DNS name polled for Erlang peer discovery — a headless service in k8s.
+# Unset, clustering is off, which is correct for a single replica.
+# RELEASE_NAME (the node basename) is set by the release tooling; DNS_CLUSTER_QUERY
+# is a separate discovery mechanism — leave it unset when using CLUSTER_DNS_QUERY.
+# CLUSTER_DNS_QUERY=
+
+# ── Observability ────────────────────────────────────────────────────────────
+
+# Prometheus listener (/metrics, /health) on its own private port. Defaults to
+# 9568 in prod and off elsewhere; "" or 0 disables.
+# METRICS_PORT=9568
+
+# Error tracking. Unset = fully disabled, nothing is sent anywhere. Accepts a
+# sentry.io DSN or any Sentry-API-compatible endpoint (e.g. GlitchTip).
+# SENTRY_DSN=
+# SENTRY_ENVIRONMENT=production
+
+# Set by the image build; correlates errors and traces with deploys.
+# FOUNTAIN_BUILD_SHA=
+
+# OpenTelemetry trace export (OTLP over HTTP/protobuf), prod + serving only.
+# HONEYCOMB_ENDPOINT / HONEYCOMB_API_KEY are Honeycomb shortcuts for the
+# endpoint and the x-honeycomb-team header.
+# OTEL_SERVICE_NAME=fountain
+# OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io
+# OTEL_EXPORTER_OTLP_HEADERS=
+# HONEYCOMB_ENDPOINT=https://api.honeycomb.io
+# HONEYCOMB_API_KEY=

--- a/apps/fountain/test/fountain/config_reference_test.exs
+++ b/apps/fountain/test/fountain/config_reference_test.exs
@@ -1,0 +1,61 @@
+defmodule Fountain.ConfigReferenceTest do
+  use ExUnit.Case, async: true
+
+  # Guards docs/configuration.md against drifting from config/runtime.exs
+  # (#280): every environment variable the runtime config reads must have a
+  # row in the reference. Reading a new var without documenting it is a red
+  # build, not an archaeology project.
+
+  @repo_root Path.expand("../../../..", __DIR__)
+
+  # Injected by the platform or release tooling rather than set by an
+  # operator; not part of the operator-facing reference.
+  @platform_injected ~w(FLY_APP_NAME)
+
+  test "every env var read in config/runtime.exs is documented in docs/configuration.md" do
+    source = File.read!(Path.join(@repo_root, "config/runtime.exs"))
+    doc = File.read!(Path.join(@repo_root, "docs/configuration.md"))
+
+    # Two extraction passes: direct System.get_env/fetch_env calls, plus any
+    # quoted UNDERSCORED_ALL_CAPS literal — the latter catches vars passed
+    # through helpers like parse_bound.("SANDBOX_IDLE_TIMEOUT_MINUTES", ...),
+    # which the direct pattern misses.
+    direct =
+      Regex.scan(
+        ~r/System\.(?:get_env|fetch_env!?)\(\s*"([A-Z][A-Z0-9_]*)"/,
+        source,
+        capture: :all_but_first
+      )
+
+    underscored_literals =
+      Regex.scan(~r/"([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)"/, source, capture: :all_but_first)
+
+    vars =
+      (direct ++ underscored_literals)
+      |> List.flatten()
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    # If extraction ever stops matching (a refactor of runtime.exs, a regex
+    # rot), this guard fails loudly instead of the main assertion passing
+    # vacuously over an empty list.
+    assert length(vars) > 30,
+           "extracted only #{length(vars)} env vars from config/runtime.exs — " <>
+             "the extraction patterns no longer match how the file reads env vars"
+
+    undocumented =
+      Enum.reject(vars, fn var ->
+        var in @platform_injected or String.contains?(doc, "`#{var}`")
+      end)
+
+    assert undocumented == [],
+           """
+           config/runtime.exs reads env vars that docs/configuration.md does not document:
+
+             #{Enum.join(undocumented, ", ")}
+
+           Add a row for each (in backticks), or — only for vars the platform
+           injects rather than an operator sets — add them to @platform_injected.
+           """
+  end
+end

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,125 @@
+# Configuration reference
+
+Every environment variable the server reads at runtime, grouped by concern.
+Variables are read at boot — changing one means restarting the app.
+
+This list is complete by construction: a test fails the build when
+`config/runtime.exs` reads a variable that is not documented on this page, so
+the reference cannot silently drift from the code.
+
+A few variables **refuse to boot on an invalid value** rather than falling
+back to a default — noted per row. That is deliberate: a typo that silently
+disabled a bound or a key would otherwise surface as a bill or a breach, not
+an error message.
+
+---
+
+## Core
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `DATABASE_URL` | — | prod | Postgres connection string. Boot fails without it |
+| `SECRET_KEY_BASE` | — | prod (serving) | Signs and encrypts session cookies and tokens. Generate: `openssl rand -base64 48` |
+| `MASTER_SECRETS_KEY` | — | prod | Wraps every tenant's data-encryption key ([back it up](self-hosting.md#back-up-master_secrets_key)). 32 bytes, url-safe base64, no padding: `openssl rand 32 \| base64 \| tr '+/' '-_' \| tr -d '='`. **Lose it and every stored secret is unrecoverable.** Boot refuses a malformed value |
+| `PUBLIC_URL` | `http://localhost:4000` | effectively, prod | The externally visible base URL, scheme included. Builds every link that leaves the app (verification and reset emails, `llms.txt`) and is passed to every sandbox as `FOUNTAIN_BASE_URL`. An `https://` value also switches on HTTPS redirection, HSTS, and the secure cookie flag — all derived from the scheme |
+| `PHX_HOST` | host of `PUBLIC_URL` | — | Bare host for the endpoint URL and the LiveView origin check. Set only if it differs from `PUBLIC_URL`'s host |
+| `FOUNTAIN_DOMAIN` | — | deprecated | The old combined variable; still honoured as a fallback for both of the above. Prefer `PUBLIC_URL` / `PHX_HOST` |
+| `PHX_SERVER` | `true` in the shipped image | — | `1`/`true`/`yes` starts the web listener. Release tasks run with `PHX_SERVER=false … eval '…'` to boot the app without binding the port |
+| `PORT` | `4000` | — | HTTP listen port |
+
+## Database
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `DATABASE_SSL` | `true` | — | TLS to Postgres. Set `false` for a stock `postgres` container, which does not serve TLS |
+| `DATABASE_SSL_VERIFY` | off | — | Unset, the connection is encrypted but the server certificate is **not** verified. `true` verifies it, against the OS trust store unless a CA file is given |
+| `DATABASE_SSL_CA_FILE` | OS trust store | — | CA bundle used when `DATABASE_SSL_VERIFY=true` |
+| `POOL_SIZE` | `10` | — | Database connection pool size |
+
+## Sandboxes
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `SPRITES_TOKEN` | — | for conversations | Platform token for [sprites.dev](https://sprites.dev). The app boots without it, but every conversation fails. Never expose it to tenants — it pays for every sandbox |
+| `SPRITES_BASE_URL` | `https://api.sprites.dev` | — | Repoints the sandbox API. Anything else must implement the same contract; there is no bundled alternative |
+| `SPRITES_TIMEOUT_MS` | `30000` | — | Bounds every HTTP call to the Sprites API. Long-running commands (package installs, clones) set their own per-call timeouts. Boot refuses a non-positive value |
+| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long and the sandbox is reclaimed — the conversation stays [resumable](self-hosting.md#sandbox-lifetime). `0` disables the bound; boot refuses anything that is not a non-negative integer |
+| `SANDBOX_MAX_LIFETIME_HOURS` | `24` | — | Absolute sandbox age ceiling, regardless of activity. Same `0`-disables and boot-refusal rules |
+
+## Registration and accounts
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `REGISTRATION_ENABLED` | `true` | — | `false` closes signup entirely. An open instance on the public internet will be found |
+| `REGISTRATION_ALLOWED_EMAIL_DOMAINS` | any | — | Comma-separated list; signups outside these domains are refused. Empty means no restriction |
+| `UNVERIFIED_PRUNE_AFTER_DAYS` | `30` | — | Accounts that never verified their email are deleted after this many days — they cannot log in, so they are rows, not users. `0` disables the sweep |
+| `UNVERIFIED_PRUNE_EXEMPT` | — | — | Comma-separated email substrings never pruned (operator or test accounts that deliberately stay unverified) |
+
+## Email
+
+Production **refuses to boot** unless exactly one of the three delivery
+options is configured — a silently discarded verification email dead-ends
+signup with no visible error. See [Email](self-hosting.md#email).
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `RESEND_API_KEY` | — | one of three | Delivery via Resend |
+| `SMTP_HOST` | — | one of three | Delivery via any SMTP server |
+| `SMTP_PORT` | `587` | — | SMTP port |
+| `SMTP_USERNAME` | — | — | Omit entirely for an unauthenticated relay |
+| `SMTP_PASSWORD` | — | — | |
+| `SMTP_TLS` | `always` | — | STARTTLS by default; `never` for a relay on a trusted network that does not offer it |
+| `EMAIL_DELIVERY` | — | one of three | `none` deliberately disables email. Password-and-email accounts then cannot verify themselves; use `Fountain.Release.verify_email/1` |
+| `EMAIL_FROM` | `noreply@updates.inevitable.fyi` | — | The From address. Change it — the default is the hosted instance's sending domain |
+
+## Authentication
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `GITHUB_OAUTH_CLIENT_ID` | — | — | Enables the GitHub sign-in button. Unset, email + password auth still works |
+| `GITHUB_OAUTH_CLIENT_SECRET` | — | — | |
+
+## Billing
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `BILLING_ENABLED` | `true` | — | The subscription gate. On a self-hosted instance it is a lock with no key — set `false` unless you run Fountain commercially with Stripe configured |
+| `STRIPE_SECRET_KEY` | — | for billing | Stripe API key |
+| `STRIPE_WEBHOOK_SECRET` | — | for billing | Verifies `POST /api/stripe/webhook` signatures |
+| `STRIPE_PRICE_ID` | — | for checkout | The subscription price surfaced by Checkout. Unset with billing enabled, signups get a purely local 14-day trial and a logged warning |
+
+## Proxies and origins
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `TRUSTED_PROXIES` | — | behind a proxy | Comma-separated CIDRs stepped over when resolving the client IP from `X-Forwarded-For`. Without it, per-IP rate limits collapse into one bucket keyed on the proxy; over-broad, it lets a client spoof past rate limiting |
+| `CHECK_ORIGIN_EXTRA` | — | — | Comma-separated extra origins allowed to open a LiveView websocket. Your own host is always included |
+
+## Clustering
+
+Only needed for more than one replica — see
+[Kubernetes](self-hosting.md#kubernetes) for where the wiring is shown.
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `CLUSTER_DNS_QUERY` | — | multi-replica | DNS name polled for peer discovery (a headless service in Kubernetes). Empty or unset, clustering is off |
+| `RELEASE_NAME` | set by the release | — | Node basename used in peer discovery; must match what each node registered as. The release tooling sets it — override only if you know why |
+| `DNS_CLUSTER_QUERY` | — | — | A second, separate discovery mechanism (Phoenix's `DNSCluster`). Leave unset when using `CLUSTER_DNS_QUERY` |
+
+## Observability
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `METRICS_PORT` | `9568` in prod, off elsewhere | — | The private Prometheus listener (`/metrics`, `/health`). `""` or `0` disables it. Keep it off the public internet |
+| `SENTRY_DSN` | — | — | Error tracking. Unset, the SDK is inert and nothing leaves the instance. Accepts sentry.io or any Sentry-API-compatible endpoint (GlitchTip) |
+| `SENTRY_ENVIRONMENT` | the build env | — | Environment tag on reported errors |
+| `FOUNTAIN_BUILD_SHA` | set by the image build | — | Correlates errors and traces with deploys; also shown in the app footer |
+| `OTEL_SERVICE_NAME` | `fountain` | — | Service name on exported traces |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `HONEYCOMB_ENDPOINT` | — | OTLP (HTTP/protobuf) trace export target |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | — | `key=val,key=val` headers on trace export |
+| `HONEYCOMB_ENDPOINT` | `https://api.honeycomb.io` | — | Honeycomb shortcut for the endpoint above |
+| `HONEYCOMB_API_KEY` | — | — | Honeycomb shortcut: adds the `x-honeycomb-team` header |
+
+Trace export is configured only in production while serving. The OTel SDK also
+honours its own standard variables — the hosted deployment sets
+`OTEL_TRACES_EXPORTER=none` to disable export without a collector.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ an error message.
 |---|---|---|---|
 | `DATABASE_URL` | — | prod | Postgres connection string. Boot fails without it |
 | `SECRET_KEY_BASE` | — | prod (serving) | Signs and encrypts session cookies and tokens. Generate: `openssl rand -base64 48` |
-| `MASTER_SECRETS_KEY` | — | prod | Wraps every tenant's data-encryption key ([back it up](self-hosting.md#back-up-master_secrets_key)). 32 bytes, url-safe base64, no padding: `openssl rand 32 \| base64 \| tr '+/' '-_' \| tr -d '='`. **Lose it and every stored secret is unrecoverable.** Boot refuses a malformed value |
+| `MASTER_SECRETS_KEY` | — | prod | Wraps every tenant's data-encryption key ([the secrets model](architecture.md#the-secrets-model)). 32 bytes, url-safe base64, no padding: `openssl rand 32 \| base64 \| tr '+/' '-_' \| tr -d '='`. **Lose it and every stored secret is unrecoverable.** Boot refuses a malformed value |
 | `PUBLIC_URL` | `http://localhost:4000` | effectively, prod | The externally visible base URL, scheme included. Builds every link that leaves the app (verification and reset emails, `llms.txt`) and is passed to every sandbox as `FOUNTAIN_BASE_URL`. An `https://` value also switches on HTTPS redirection, HSTS, and the secure cookie flag — all derived from the scheme |
 | `PHX_HOST` | host of `PUBLIC_URL` | — | Bare host for the endpoint URL and the LiveView origin check. Set only if it differs from `PUBLIC_URL`'s host |
 | `FOUNTAIN_DOMAIN` | — | deprecated | The old combined variable; still honoured as a fallback for both of the above. Prefer `PUBLIC_URL` / `PHX_HOST` |
@@ -98,7 +98,7 @@ signup with no visible error. See [Email](self-hosting.md#email).
 ## Clustering
 
 Only needed for more than one replica — see
-[Kubernetes](self-hosting.md#kubernetes) for where the wiring is shown.
+[Clustering](architecture.md#clustering) for what breaks without it.
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -34,6 +34,10 @@ echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n'
 docker compose up -d
 ```
 
+This page explains the variables that shape a deployment as they come up; the
+complete list — including the deploy-level ones the compose file never
+mentions — is the [configuration reference](configuration.md).
+
 Then open <http://localhost:4000> and register. With the default
 `EMAIL_DELIVERY=none` nothing is sent, so verify your own account:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
   - Setup: setup.md
   - Self-hosting: self-hosting.md
   - Architecture: architecture.md
+  - Configuration reference: configuration.md
   - The four primitives: primitives.md
   - CLI reference: cli.md
   - API reference: api.md


### PR DESCRIPTION
Closes #280 (operability push #281).

- **`docs/configuration.md`** — the complete reference, one row per variable (default / required / effect), grouped by concern. Boot-refusal behaviors are called out per row. The self-hosting guide now links it instead of being the incomplete de-facto list.
- **`.env.example` brought current** — everything `runtime.exs` reads that the example file never mentioned (`SPRITES_BASE_URL`, `TRUSTED_PROXIES`, `CHECK_ORIGIN_EXTRA`, `METRICS_PORT`, `POOL_SIZE`, the sandbox lifetime bounds, `CLUSTER_DNS_QUERY`, `SECRET_KEY_BASE`, the `OTEL_*`/`HONEYCOMB_*` family, …) is now present and grouped. Removed `STRIPE_PUBLISHABLE_KEY`: no code reads it (only `render.yaml` and plan docs ever mentioned it).
- **The enforcement** — `apps/fountain/test/fountain/config_reference_test.exs` extracts env var names from `config/runtime.exs` and asserts each is documented (in backticks) in the reference. Two extraction passes: direct `System.get_env`/`fetch_env` calls, plus any quoted `UNDERSCORED_ALL_CAPS` literal — the second catches vars passed through helpers like `parse_bound.("SANDBOX_IDLE_TIMEOUT_MINUTES", …)`, which a `get_env`-only regex misses. A count floor guards against the extraction going vacuously empty after a refactor. `@platform_injected` (currently `FLY_APP_NAME`) is the explicit ignore list the issue asked for.

Verified:
- Test fails correctly when a documented var is removed from the doc (checked by breaking and restoring it), passes on the real files.
- `mix format --check-formatted`, `mix credo` (clean after folding a chained reject), the new test green.
- `mkdocs build --strict` green with the same mkdocs-material pin as `docs/requirements.txt`; cross-page anchors checked in the built HTML.

Note: written against current `main`, independent of #291 — the two touch adjacent `mkdocs.yml` nav lines and one nearby region of `self-hosting.md`, so whichever merges second gets a trivial conflict; I can rebase either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)