### PR TITLE
docs: third-party integration guides — Sprites, GitHub OAuth, Stripe, Sentry, mail

### DIFF
--- a/docs/integrations/github-oauth.md
+++ b/docs/integrations/github-oauth.md
@@ -1,0 +1,47 @@
+# GitHub OAuth
+
+**Optional.** Adds "Continue with GitHub" to the login and registration pages.
+Email + password auth works without it.
+
+## Provider side
+
+Create an OAuth app at
+[github.com/settings/developers](https://github.com/settings/developers):
+
+| Field | Value |
+|---|---|
+| Homepage URL | your `PUBLIC_URL` |
+| Authorization callback URL | `<PUBLIC_URL>/auth/oauth/github/callback` |
+
+The requested scope is `user:email`.
+
+## Env vars
+
+| Variable | Effect |
+|---|---|
+| `GITHUB_OAUTH_CLIENT_ID` | From the OAuth app |
+| `GITHUB_OAUTH_CLIENT_SECRET` | From the OAuth app |
+
+One honest caveat: the GitHub button renders whether or not these are set.
+Unconfigured, clicking it lands on a GitHub-side error page rather than an
+in-app message.
+
+## Behavior worth knowing
+
+- **Only a GitHub-verified email is accepted.** Fountain checks the address's
+  `verified` flag with GitHub rather than trusting the primary email, because
+  sign-ins link to existing accounts by email — an unverified address set to
+  someone else's email must not attach to their account. An unverified email
+  is refused with a message telling the user to confirm it on GitHub first.
+- OAuth signups arrive with their email already verified — no verification
+  email is sent, so OAuth works fine on an instance with
+  `EMAIL_DELIVERY=none`.
+- `REGISTRATION_ENABLED=false` and `REGISTRATION_ALLOWED_EMAIL_DOMAINS` apply
+  to OAuth signups too, not just the forms. Existing users can still sign in
+  when registration is closed.
+
+## Verify
+
+Sign in with the button. The audit log (`/audit`) records
+`auth.oauth.signup` or `auth.oauth.login`; rejections are recorded as
+`auth.oauth.rejected` with the reason.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,0 +1,29 @@
+# Integrations
+
+Every external service a Fountain instance can talk to, what it is for, and
+what breaks without it. One page per integration covers what to create on the
+provider side, which env vars result, and how to verify it works.
+
+| Integration | Required? | Env vars | Without it |
+|---|---|---|---|
+| [Sprites](sprites.md) | **Yes** | `SPRITES_TOKEN`, `SPRITES_BASE_URL`, `SPRITES_TIMEOUT_MS` | The app boots, but every conversation fails |
+| [Mail](mail.md) | **A decision, yes** | `RESEND_API_KEY` *or* `SMTP_*` *or* `EMAIL_DELIVERY=none`, `EMAIL_FROM` | Production refuses to boot with none of the three set |
+| [GitHub OAuth](github-oauth.md) | Optional | `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET` | Email + password auth only |
+| [Stripe](stripe.md) | Optional | `BILLING_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID` | No billing. Correct for most self-hosted instances — leave the gate off |
+| [Sentry](sentry.md) | Optional | `SENTRY_DSN`, `SENTRY_ENVIRONMENT` | No error tracking; the SDK is inert and nothing leaves the instance |
+
+## The integration you do not configure
+
+**Inference providers — Anthropic, OpenAI, Gemini — are not set up by the
+operator.** There is no platform-level API key: each user brings their own
+credentials, entered at `/account/inference-credentials` in the running app
+(an Anthropic API key or Claude Code OAuth token, an OpenAI API key, a Gemini
+API key — validated against the provider on save, stored encrypted per
+tenant, and never echoed back).
+
+This is a deliberate design
+([ADR 0008](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0008-byo-inference-credentials.md)):
+inference cost scales with usage and belongs to the person using it, and many
+users want their own Claude subscription doing the work. If you are looking
+for where to put `ANTHROPIC_API_KEY` in the server environment — there is
+nowhere, on purpose.

--- a/docs/integrations/mail.md
+++ b/docs/integrations/mail.md
@@ -1,0 +1,63 @@
+# Mail
+
+**A decision is required.** Production refuses to boot with no mail setting,
+because a silently discarded verification email dead-ends signup with no
+visible error. There are exactly three options, checked in this order:
+
+## Option 1: Resend
+
+| Variable | Effect |
+|---|---|
+| `RESEND_API_KEY` | Delivery via [Resend](https://resend.com) |
+
+Provider side: verify your sending domain in Resend (SPF, DKIM, DMARC
+records) before pointing `EMAIL_FROM` at it — an unverified domain will not
+deliver to arbitrary inboxes.
+
+## Option 2: any SMTP server
+
+| Variable | Default | Effect |
+|---|---|---|
+| `SMTP_HOST` | — | Selects SMTP delivery |
+| `SMTP_PORT` | `587` | |
+| `SMTP_USERNAME` | — | Omit entirely for an unauthenticated relay |
+| `SMTP_PASSWORD` | — | |
+| `SMTP_TLS` | `always` | STARTTLS by default; `never` for a relay on a trusted network that does not offer it |
+
+If `RESEND_API_KEY` is also set, Resend wins — the options are checked in
+order.
+
+## Option 3: no email, deliberately
+
+| Variable | Effect |
+|---|---|
+| `EMAIL_DELIVERY=none` | Disables email with a stderr notice at boot |
+
+For an OAuth-only instance, or while evaluating. Accounts created with email
++ password then cannot verify themselves — an operator does it:
+
+```bash
+bin/fountain_server eval 'Fountain.Release.verify_email("you@example.com")'
+```
+
+Password reset is also dead in this mode; the only route back into a
+locked-out account is operator intervention.
+
+## In every mode
+
+| Variable | Default | Effect |
+|---|---|---|
+| `EMAIL_FROM` | `noreply@updates.inevitable.fyi` | The From address. **Change it** — the default is the hosted instance's sending domain, which will not be verified for yours |
+
+What actually sends email today: account verification (24-hour link),
+password reset (1-hour link), and — only with [Stripe](stripe.md) configured
+— the trial-ending reminder three days out. OAuth signups skip verification
+entirely, so [GitHub OAuth](github-oauth.md) plus `EMAIL_DELIVERY=none` is a
+coherent minimal setup.
+
+## Verify
+
+Register a throwaway account and confirm the verification email arrives —
+check spam, which is where an unverified sending domain lands. On a running
+instance, boot logs state the chosen mode (`EMAIL_DELIVERY=none` prints its
+notice to stderr; a missing configuration refuses to boot and says so).

--- a/docs/integrations/sentry.md
+++ b/docs/integrations/sentry.md
@@ -1,0 +1,46 @@
+# Sentry
+
+**Optional, and inert until you opt in.** With no DSN set, the SDK is
+configured but does nothing — no account, no events, nothing leaves your
+instance.
+
+## Provider side
+
+Create a project (platform: Elixir) on [sentry.io](https://sentry.io) or any
+Sentry-API-compatible endpoint — GlitchTip works, for a fully self-hosted
+stack — and take its DSN.
+
+## Env vars
+
+| Variable | Default | Effect |
+|---|---|---|
+| `SENTRY_DSN` | — | Turns reporting on. Crashes — including ones that never touch a web request — are reported with stack traces, grouped, rate-limited to 20 events/minute |
+| `SENTRY_ENVIRONMENT` | the build env | Environment tag on events |
+| `FOUNTAIN_BUILD_SHA` | set by the image build | Correlates events with releases: "this started with `sha-…`" |
+
+Reporting is deliberately conservative: `send_default_pii` is off, so
+cookies, user IPs and request bodies are not attached — this app holds tenant
+secrets, and nothing the SDK gathers on its own should ride along.
+
+## Crons: alerting when a scheduled job stops running
+
+Sentry Monitors (Crons) catch the failure mode Prometheus alerts often miss:
+a backup job that silently stops being scheduled. The pattern Fountain's own
+deployment uses for its nightly `pg_dump`, reusable for any scheduled job:
+
+- After the job **verifiably succeeds** (upload confirmed, not merely
+  attempted), ping the check-in URL derived from the DSN:
+
+    ```
+    curl -fsS -m 10 "https://<sentry-host>/api/<project-id>/cron/<monitor-slug>/<public-key>/?status=ok"
+    ```
+
+- The monitor is auto-created on the first check-in. Then set its schedule
+  and a grace period in the Sentry UI — that arms the alert for *missed*
+  runs, which is the point.
+- Keep it best-effort: a Sentry outage must never fail a successful backup.
+
+## Verify
+
+Set the DSN, restart, and cause any error — it appears in the project within
+seconds, tagged with environment and release. Unset it and nothing does.

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -1,0 +1,43 @@
+# Sprites
+
+**Required.** [sprites.dev](https://sprites.dev) is the sandbox platform every
+conversation runs in. It is a hosted service and currently the only backend —
+a Fountain instance is not fully self-contained without it.
+
+## Provider side
+
+Create a sprites.dev account and issue an API token. That token is the whole
+provider-side setup.
+
+## Env vars
+
+| Variable | Default | Effect |
+|---|---|---|
+| `SPRITES_TOKEN` | — | The platform token. Not checked at boot: the app starts without it, and the first conversation fails at provision time instead |
+| `SPRITES_BASE_URL` | `https://api.sprites.dev` | Repoints the sandbox API. Anything else must implement the same contract; there is no bundled alternative |
+| `SPRITES_TIMEOUT_MS` | `30000` | Bounds every HTTP call to the Sprites API. Long-running commands (package installs, clones) set their own per-call timeouts. Boot refuses a non-positive value |
+
+## The cost model
+
+**One platform token pays for every sandbox.** Fountain provisions all
+tenants' sandboxes with `SPRITES_TOKEN` and the bill lands on that token's
+account — on the hosted instance, subscription pricing recovers it; on yours,
+you are the one paying. Two consequences:
+
+- Every signup that can start a conversation can spend your money. Close
+  registration, or restrict it, before putting an instance on the internet.
+- Per-user concurrency is capped (`max_concurrent_sandboxes`, default 5,
+  adjustable per user from the admin panel). Sandboxes count from the moment
+  provisioning begins, because that is when they start being paid for.
+
+The token is never surfaced to tenants, the admin UI, or the sandboxes
+themselves — a sprite receives only a scoped, expiring token whose sole
+audience is your Fountain instance's own API.
+
+## Verify
+
+Start a conversation. Provisioning progress streams as stage events; a bad or
+missing token surfaces as the `provision` stage failing, visible in the
+conversation's log view. A Sprites outage does not affect anything else —
+sign-in, dashboards and configuration keep working, and the health endpoints
+deliberately do not consult Sprites.

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -1,0 +1,59 @@
+# Stripe
+
+**Optional.** The subscription gate exists for the hosted service; the compose
+file ships `BILLING_ENABLED=false`, and that is the right setting for most
+self-hosted instances — a gate with no checkout behind it is a lock with no
+key. Set this up only if you run Fountain commercially.
+
+## Provider side
+
+1. **A product with a recurring price.** Its price ID (`price_…`) becomes
+   `STRIPE_PRICE_ID`.
+2. **An API key** (Developers → API keys) — `STRIPE_SECRET_KEY`.
+3. **A webhook endpoint** pointed at `<PUBLIC_URL>/api/stripe/webhook`,
+   subscribed to:
+    - `checkout.session.completed`
+    - `customer.subscription.created`
+    - `customer.subscription.updated`
+    - `customer.subscription.deleted`
+    - `customer.subscription.trial_will_end`
+
+    Its signing secret becomes `STRIPE_WEBHOOK_SECRET`.
+
+Use test-mode keys and a test-mode price everywhere except a production
+instance taking real money.
+
+## Env vars
+
+| Variable | Effect |
+|---|---|
+| `BILLING_ENABLED` | `true` (the default) enforces the subscription gate on conversations |
+| `STRIPE_SECRET_KEY` | API key |
+| `STRIPE_WEBHOOK_SECRET` | Verifies webhook signatures; a bad signature is rejected with a 400 |
+| `STRIPE_PRICE_ID` | The price surfaced by Checkout. Unset with billing enabled, signups get a purely local 14-day trial and a logged warning — and Checkout is broken |
+
+## Behavior worth knowing
+
+- On email verification (or OAuth signup), Fountain creates the Stripe
+  customer and opens a **14-day trial subscription** with no payment method;
+  Stripe cancels it at trial end if none is added. Trial expiry is *also*
+  checked against the local clock, so a missed webhook delays revenue rather
+  than opening the gate.
+- Webhook processing is idempotent (event IDs are claimed in a dedup table)
+  and order-safe (stale events are ignored). Transient failures return a 500
+  so Stripe redelivers.
+- Comped accounts are never overwritten by Stripe events.
+
+## Verify
+
+The webhook endpoint's delivery log in the Stripe dashboard should show 2xx
+responses; a fresh signup should show a `trialing` status on
+`/account/billing` and in the admin panel.
+
+To exercise the full trial lifecycle without waiting 14 days, use
+[Stripe Test Clocks](https://docs.stripe.com/billing/testing/test-clocks):
+a customer created under a test clock can have its clock advanced past the
+trial-ending threshold (the reminder email enqueues) and past trial end (the
+status flips and the gate refuses). The clock must be attached when the
+customer is created, so this is a deliberate test-mode exercise rather than
+something you bolt onto an existing signup.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -151,7 +151,9 @@ Pick one:
 | `EMAIL_DELIVERY=none` | No email. Verify accounts with `Fountain.Release.verify_email/1` |
 
 Password reset also needs working mail. With `EMAIL_DELIVERY=none` the only
-route back into a locked-out account is the database.
+route back into a locked-out account is the database. Provider-side setup —
+domain verification, SMTP details, what each mode means for signup — is in
+the [mail integration guide](integrations/mail.md).
 
 ## Sandbox lifetime
 
@@ -175,7 +177,8 @@ re-provisioning wait, not lost work.
 
 The compose file sets `BILLING_ENABLED=false`. The subscription gate exists for
 the hosted service; on your own instance it is a lock with no key. Leave it off
-unless you are running Fountain commercially and have configured Stripe.
+unless you are running Fountain commercially and have configured Stripe — the
+[Stripe integration guide](integrations/stripe.md) covers that setup.
 
 ## Putting it on the internet
 
@@ -216,7 +219,8 @@ Error tracking is off unless you opt in: set `SENTRY_DSN` and crashes —
 including the ones that never touch a web request — are reported with stack
 traces, grouped, and correlated with releases. The endpoint can be sentry.io
 or anything Sentry-API-compatible (GlitchTip, for a fully self-hosted stack).
-Unset, nothing ever leaves your instance.
+Unset, nothing ever leaves your instance. Setup and the Crons pattern for
+backup-job alerting are in the [Sentry integration guide](integrations/sentry.md).
 
 ### Health endpoints
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,13 @@ nav:
   - Self-hosting: self-hosting.md
   - Architecture: architecture.md
   - Configuration reference: configuration.md
+  - Integrations:
+      - Overview: integrations/index.md
+      - Sprites: integrations/sprites.md
+      - GitHub OAuth: integrations/github-oauth.md
+      - Stripe: integrations/stripe.md
+      - Sentry: integrations/sentry.md
+      - Mail: integrations/mail.md
   - The four primitives: primitives.md
   - CLI reference: cli.md
   - API reference: api.md


### PR DESCRIPTION
Closes #274 (operability push #281).

New `docs/integrations/` section, one page per integration plus an overview:

- **Overview** — the required/optional matrix (integration / env vars / what breaks without it), and a prominent "the integration you do not configure" section: per ADR 0008 there is no platform-level inference key, users bring their own at `/account/inference-credentials`.
- **Sprites** (required) — token setup, the three env vars, and the cost model stated plainly: one platform token pays for every tenant's sandboxes, so open registration is an open wallet; per-user concurrency quota noted. Token hygiene: sprites only ever receive a scoped callback token, never the platform token.
- **GitHub OAuth** (optional) — exact callback URL (`<PUBLIC_URL>/auth/oauth/github/callback`), the `user:email` scope, the GitHub-verified-email requirement and why (email-based account linking), that registration controls apply to OAuth signups too, and the honest caveat that the button renders even when unconfigured.
- **Stripe** (optional) — provider-side checklist including the five webhook event types the handler actually processes, the no-price-id behavior (local 14-day trial + warning), local-clock trial enforcement, webhook idempotency/ordering, and Test Clocks as the way to exercise the trial lifecycle without waiting 14 days (noting the clock must be attached at customer creation — a repeatable script for this is #289).
- **Sentry** (optional) — inert-without-DSN contract, `send_default_pii: false` rationale, and the Crons check-in pattern generalized from the hosted backup CronJob (ping after *verified* success, monitor auto-created, schedule + grace armed in the UI, always best-effort).
- **Mail** (required decision) — the three options in their real precedence order, the `EMAIL_FROM` default that must be changed, what actually sends email today, and the coherent OAuth-only + `EMAIL_DELIVERY=none` minimal setup.

Everything was verified against the code first (config/runtime.exs, billing.ex, oauth_email.ex, the k8s backup CronJob) — no aspirational behavior.

Also links the section from the self-hosting guide's Email, Billing and Observability sections (regions untouched by #291/#292, so no conflicts with those).

Verified with `mkdocs build --strict` (same mkdocs-material pin as `docs/requirements.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)