### PR TITLE
self-host: first-admin bootstrap without SQL

### DIFF
--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -52,6 +52,60 @@ defmodule Fountain.Release do
   end
 
   @doc """
+  Grant an account the admin role, audit-recorded.
+
+  The first-admin bootstrap. Both deploy guides used to end with raw SQL
+  (`UPDATE users SET role = 'admin' ...`) — the only step in the self-deploy
+  path that required editing the production database by hand. Symmetrical
+  with `verify_email/1`.
+
+  Recorded as `admin.role.granted` with a nil actor (system-originated), so a
+  promotion through this task is as visible in the admin audit trail as one
+  through the admin panel. Revoking has no release task — that is done from
+  the panel, by an admin, on purpose.
+
+      bin/fountain_server eval 'Fountain.Release.promote_admin("you@example.com")'
+  """
+  def promote_admin(email) when is_binary(email) do
+    with_repo(fn -> do_promote_admin(email) end)
+  end
+
+  defp do_promote_admin(email) do
+    case Fountain.Accounts.get_user_by_email(email) do
+      nil ->
+        IO.puts(:stderr, "No account found for #{email}")
+        {:error, :not_found}
+
+      %{role: "admin"} = user ->
+        IO.puts("#{user.email} is already an admin.")
+        {:ok, user}
+
+      user ->
+        case Fountain.Accounts.update_user_role(user, "admin") do
+          {:ok, promoted} ->
+            Fountain.Audit.record_admin(%{
+              actor_user_id: nil,
+              target_user_id: promoted.id,
+              event_type: "admin.role.granted",
+              metadata: %{
+                "email" => promoted.email,
+                "from" => user.role,
+                "to" => "admin",
+                "via" => "release_task"
+              }
+            })
+
+            IO.puts("Granted admin to #{promoted.email}.")
+            {:ok, promoted}
+
+          {:error, _} = err ->
+            IO.puts(:stderr, "Could not grant admin to #{email}")
+            err
+        end
+    end
+  end
+
+  @doc """
   Gives existing trialing accounts a trial end date.
 
   159 production accounts are `trialing` with `trial_ends_at` set to nil, some

--- a/apps/fountain/priv/help/runbook.md
+++ b/apps/fountain/priv/help/runbook.md
@@ -231,6 +231,21 @@ Sending domains must be verified with the provider (SPF/DKIM/DMARC) before
 `EMAIL_FROM` can deliver to arbitrary inboxes, so a freshly configured provider
 can accept mail and still have it rejected downstream.
 
+## Granting admin without the panel
+
+The first admin — or an instance whose only admin is locked out — cannot use
+**/admin**. Grant the role from a release task instead; it is recorded as
+`admin.role.granted` with a system actor, so it shows in the admin audit trail
+like any panel-originated grant:
+
+```bash
+kubectl exec -n fountain deploy/fountain -- \
+  sh -c "PHX_SERVER=false bin/fountain_server eval 'Fountain.Release.promote_admin(\"you@example.com\")'"
+```
+
+Revoking has no release task; that is done from **/admin**, by an admin, on
+purpose.
+
 ## Postgres backup + restore
 
 A `fountain-pg-backup` CronJob (`k8s/backup-cronjob.yaml`) takes a compressed

--- a/apps/fountain/test/fountain/release_test.exs
+++ b/apps/fountain/test/fountain/release_test.exs
@@ -68,4 +68,53 @@ defmodule Fountain.ReleaseTest do
       end)
     end
   end
+
+  describe "promote_admin/1" do
+    import Ecto.Query
+
+    defp admin_events_for(user_id) do
+      Repo.all(
+        from e in Fountain.Audit.AdminEvent,
+          where: e.target_user_id == ^user_id and e.event_type == "admin.role.granted"
+      )
+    end
+
+    test "grants the role and records a system-actor audit event" do
+      user = insert_user()
+      assert user.role == "user"
+
+      capture_io(fn ->
+        assert {:ok, promoted} = Release.promote_admin(user.email)
+        assert promoted.role == "admin"
+      end)
+
+      assert Repo.reload!(user).role == "admin"
+
+      assert [event] = admin_events_for(user.id)
+      assert is_nil(event.actor_user_id)
+      assert event.metadata["email"] == user.email
+      assert event.metadata["via"] == "release_task"
+      assert event.metadata["to"] == "admin"
+    end
+
+    test "an already-admin account is a no-op and records nothing" do
+      user = insert_user()
+
+      capture_io(fn ->
+        assert {:ok, _} = Release.promote_admin(user.email)
+        assert {:ok, again} = Release.promote_admin(user.email)
+        assert again.role == "admin"
+      end)
+
+      # Only the first call recorded an event.
+      assert [_one] = admin_events_for(user.id)
+    end
+
+    test "returns not_found for an unknown email" do
+      capture_io(:stderr, fn ->
+        assert {:error, :not_found} =
+                 Release.promote_admin("nobody-#{System.unique_integer([:positive])}@example.com")
+      end)
+    end
+  end
 end

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -43,12 +43,12 @@ kubectl exec -n fountain deploy/fountain -- \
   sh -c "PHX_SERVER=false bin/fountain_server eval 'Fountain.Release.verify_email(\"you@example.com\")'"
 ```
 
-Then close registration (`REGISTRATION_ENABLED: "false"` + re-apply) and, to
-make yourself admin, set the role in SQL — there is no first-admin bootstrap
-yet:
+Then close registration (`REGISTRATION_ENABLED: "false"` + re-apply) and make
+yourself admin — audit-recorded like any other role grant:
 
 ```bash
-psql "$DATABASE_URL" -c "UPDATE users SET role = 'admin' WHERE email = 'you@example.com';"
+kubectl exec -n fountain deploy/fountain -- \
+  sh -c "PHX_SERVER=false bin/fountain_server eval 'Fountain.Release.promote_admin(\"you@example.com\")'"
 ```
 
 ## Upgrades

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -53,12 +53,12 @@ echo "REGISTRATION_ENABLED=false" >> .env
 docker compose up -d
 ```
 
-To make yourself an admin, set the role directly — there is no bootstrap flow
-for the first admin yet:
+Make yourself the admin — recorded in the admin audit trail like any other
+role grant:
 
 ```bash
-docker compose exec postgres psql -U postgres -d fountain \
-  -c "UPDATE users SET role = 'admin' WHERE email = 'you@example.com';"
+docker compose exec app bin/fountain_server eval \
+  'Fountain.Release.promote_admin("you@example.com")'
 ```
 
 ## Versioning and upgrades
@@ -270,4 +270,3 @@ Being straight about what self-hosting does not yet include:
 
 - **Sprites is a hosted dependency** — `SPRITES_BASE_URL` can repoint it, but
   there is no self-hostable sandbox backend to point it at.
-- **No first-admin bootstrap**; the role is set in SQL.


### PR DESCRIPTION
Closes #275 (operability push #281). Removes the last raw-SQL step from the self-deploy path.

```bash
bin/fountain_server eval 'Fountain.Release.promote_admin("you@example.com")'
```

- **Repo-only startup** — goes through the same `with_repo/1` as `verify_email/1` (#256 pattern): starts the repo, never the app, so it cannot compete with the running cluster for ports, Oban jobs, or Horde processes.
- **Audit-recorded** — `admin.role.granted` with `actor_user_id: nil` (the system-actor convention `AdminEvent` documents), metadata carrying email, from/to, and `"via" => "release_task"` so a bootstrap grant is distinguishable from a panel grant. The event type was already in the allowlist.
- **Idempotent** — an already-admin account returns `{:ok, user}` and records nothing; unknown email is `{:error, :not_found}` on stderr, matching `verify_email/1`.
- **Docs**: the compose guide and `deploy/k8s/README.md` replace their `UPDATE users SET role = 'admin'` blocks with the task; the self-hosting "Known gaps" bullet is deleted; the in-app runbook gains a "Granting admin without the panel" section. Revoking deliberately has no release task — that stays in `/admin`.

**On the issue's optional second step** (`FOUNTAIN_ADMIN_EMAIL` auto-promote on boot): I recommend **not** building it. The explicit task is one command run once; a standing env var re-promotes on *every* boot, so a deliberately demoted admin comes back after the next restart — a silent standing grant where the task is a visible, one-time, audited action. Happy to add it if you disagree.

Tests: the three `promote_admin/1` cases mirror the existing `release_test.exs` style. The audit assertion was verified to actually catch the allowlist trap the `AdminEvent` moduledoc warns about — with the event type misspelled (which `record_admin/1` swallows silently), the test fails; restored, it passes. Full `mix precommit` green (1532 tests), `mkdocs build --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)