### PR TITLE
self-host: backup and restore story for both deploy paths

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -70,6 +70,9 @@ supported once a newer version's migrations have run — restore from a backup.
   never expose it.
 - **Scaling**: one replica by default, and going higher is not just a number —
   see the comment atop `deployment.yaml`.
-- **Backups**: nothing here backs up your database, and `MASTER_SECRETS_KEY`
-  must be backed up separately from it — a database backup alone cannot
-  decrypt itself.
+- **Backups**: `backup-cronjob.yaml` ships a nightly `pg_dump` to any
+  S3-compatible bucket — commented out of `kustomization.yaml` until you
+  create its secret; setup is at the top of the file, the restore drill in
+  [the docs](https://binarybourbon.github.io/fountain/operations/#backup-and-restore).
+  `MASTER_SECRETS_KEY` must still be backed up separately — a database backup
+  alone cannot decrypt itself.

--- a/deploy/k8s/backup-cronjob.yaml
+++ b/deploy/k8s/backup-cronjob.yaml
@@ -1,0 +1,196 @@
+# Nightly logical backup to any S3-compatible bucket.
+#
+# Off by default: this file is commented out of kustomization.yaml. To enable:
+#
+#   1. Create the fountain-backup-s3 Secret:
+#
+#        kubectl create secret generic fountain-backup-s3 -n fountain \
+#          --from-literal=BUCKET=my-fountain-backups \
+#          --from-literal=AWS_ACCESS_KEY_ID=... \
+#          --from-literal=AWS_SECRET_ACCESS_KEY=... \
+#          --from-literal=AWS_DEFAULT_REGION=us-east-1 \
+#          --from-literal=S3_ENDPOINT= \
+#          --from-literal=S3_FORCE_PATH_STYLE=false
+#
+#      S3_ENDPOINT: blank for AWS S3; the endpoint URL for MinIO, Garage, R2,
+#      or any other S3-compatible store. S3_FORCE_PATH_STYLE: "true" for most
+#      self-hosted stores, which do not serve bucket-as-subdomain addressing.
+#
+#   2. Uncomment backup-cronjob.yaml in kustomization.yaml and re-apply.
+#
+# The shape mirrors what the hosted instance runs, and the ordering is the
+# point: dump to completion first, upload only a size-checked artifact,
+# verify the uploaded size, and prune old backups only after a verified
+# upload — so a failed run can never delete a good backup or leave a
+# truncated one looking valid.
+#
+# A backup nobody has restored is a hypothesis. The restore drill:
+# https://binarybourbon.github.io/fountain/operations/#backup-and-restore
+#
+# And the standing rule: a database backup alone cannot decrypt itself.
+# MASTER_SECRETS_KEY is backed up separately, and a restore needs the same
+# key the dump was written under.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fountain-pg-backup
+  labels:
+    app: fountain
+spec:
+  # 03:17 UTC — off the hour so it does not pile onto other cluster crons.
+  schedule: "17 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  # If the cluster is down at 03:17, still run on recovery — once, not a
+  # stampede of missed runs.
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            # uid 999 is `postgres` in the postgres image; the aws-cli
+            # container just needs a non-root uid that can read the volume.
+            runAsUser: 999
+            fsGroup: 999
+          volumes:
+            - name: work
+              emptyDir:
+                # Dumps are compressed. Bump this if your database outgrows it;
+                # bounded so a runaway dump cannot fill the node.
+                sizeLimit: 2Gi
+          # pg_dump runs first, to completion, into the shared volume. The
+          # upload container starts only once it has succeeded, so a failed
+          # dump can never be uploaded as a valid-looking object.
+          initContainers:
+            - name: dump
+              image: postgres:16
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+                  TS="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+                  OUT="/work/fountain-${TS}.dump"
+
+                  echo "Dumping..."
+                  # -Fc: custom format, compressed, selectively restorable
+                  # with pg_restore.
+                  pg_dump -Fc -Z6 --no-owner --no-privileges -f "$OUT" "$DATABASE_URL"
+
+                  ls -lh "$OUT"
+                  # Refuse to hand a suspiciously small file to the uploader —
+                  # a truncated dump that uploads cleanly is worse than a
+                  # failed job, because it looks like a backup.
+                  SIZE=$(stat -c %s "$OUT")
+                  if [ "$SIZE" -lt 10240 ]; then
+                    echo "FAIL: dump is only ${SIZE} bytes, refusing to upload"
+                    exit 1
+                  fi
+                  echo "$OUT" > /work/latest
+              env:
+                # The same URL the app uses, from the same Secret.
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef: { name: fountain-secrets, key: DATABASE_URL }
+              volumeMounts:
+                - { name: work, mountPath: /work }
+              resources:
+                requests: { cpu: 50m, memory: 128Mi }
+                limits: { memory: 512Mi }
+          containers:
+            - name: upload
+              image: amazon/aws-cli:2.31.19
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  # Path-style addressing for stores that do not resolve the
+                  # bucket as a DNS subdomain. There is no env var for this in
+                  # the CLI, so write a config file — on the shared volume,
+                  # because this uid has no writable home.
+                  if [ "${S3_FORCE_PATH_STYLE:-false}" = "true" ]; then
+                    printf '[default]\ns3 =\n    addressing_style = path\n' > /work/aws-config
+                    export AWS_CONFIG_FILE=/work/aws-config
+                  fi
+                  ENDPOINT_ARGS=""
+                  if [ -n "${S3_ENDPOINT:-}" ]; then
+                    ENDPOINT_ARGS="--endpoint-url ${S3_ENDPOINT}"
+                  fi
+
+                  FILE="$(cat /work/latest)"
+                  BASE="$(basename "$FILE")"
+                  DEST="s3://${BUCKET}/pg_dump/${BASE}"
+
+                  echo "Uploading ${BASE}..."
+                  # --no-progress: per-chunk progress lines are pure noise in
+                  # a log aggregator.
+                  aws $ENDPOINT_ARGS s3 cp --no-progress "$FILE" "$DEST"
+
+                  # Read the object size back and compare against the local
+                  # file. A silently truncated upload is the failure mode that
+                  # goes unnoticed until a restore. list-objects-v2 rather
+                  # than head-object: some stores (Garage) answer HeadObject
+                  # with 400, and a verification step that always fails is
+                  # worse than none.
+                  LOCAL=$(stat -c %s "$FILE")
+                  REMOTE=$(aws $ENDPOINT_ARGS s3api list-objects-v2 \
+                    --bucket "$BUCKET" --prefix "pg_dump/${BASE}" \
+                    --query "Contents[?Key=='pg_dump/${BASE}'].Size | [0]" --output text)
+                  echo "local=${LOCAL} remote=${REMOTE}"
+                  if [ "$LOCAL" != "$REMOTE" ]; then
+                    echo "FAIL: size mismatch after upload"
+                    exit 1
+                  fi
+
+                  # Prune only after a verified upload, so a run that failed
+                  # to produce a new backup never deletes an old one.
+                  CUTOFF=$(date -u -d "-${RETENTION_DAYS} days" +%Y-%m-%d)
+                  echo "Pruning dumps older than ${CUTOFF}..."
+                  aws $ENDPOINT_ARGS s3api list-objects-v2 \
+                    --bucket "$BUCKET" --prefix "pg_dump/" \
+                    --query "Contents[?LastModified<'${CUTOFF}'].Key" --output text \
+                    | tr '\t' '\n' | grep -v '^$' | grep -v '^None$' | while read -r KEY; do
+                        echo "  deleting ${KEY}"
+                        aws $ENDPOINT_ARGS s3api delete-object \
+                          --bucket "$BUCKET" --key "$KEY"
+                      done || true
+
+                  echo "Backup complete: ${DEST}"
+
+                  # Optional Sentry Crons check-in: catches the job quietly
+                  # ceasing to run — the failure mode in-cluster alerts often
+                  # cannot see. Best-effort; a Sentry outage must never fail a
+                  # backup that succeeded. The monitor auto-creates on first
+                  # check-in; set its schedule (daily, 03:17 UTC, grace ~60min)
+                  # in the Sentry UI to arm missed-run alerting.
+                  if [ -n "${SENTRY_DSN:-}" ]; then
+                    K="${SENTRY_DSN#https://}"; K="${K%%@*}"
+                    HP="${SENTRY_DSN#*@}"; H="${HP%%/*}"; P="${HP##*/}"
+                    curl -fsS -m 10 \
+                      "https://${H}/api/${P}/cron/fountain-pg-dump/${K}/?status=ok" \
+                      >/dev/null && echo "Sentry check-in sent." \
+                      || echo "Sentry check-in failed (ignored)."
+                  fi
+              env:
+                - name: RETENTION_DAYS
+                  value: "14"
+                # Optional: enables the check-in above; absent, the job still
+                # runs and simply does not report.
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: fountain-secrets
+                      key: SENTRY_DSN
+                      optional: true
+              envFrom:
+                - secretRef:
+                    name: fountain-backup-s3
+              volumeMounts:
+                - { name: work, mountPath: /work }
+              resources:
+                requests: { cpu: 50m, memory: 128Mi }
+                limits: { memory: 512Mi }

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -12,6 +12,9 @@ resources:
   # because ingress controllers and TLS setups vary too much to guess at —
   # see README.md for the contract yours must satisfy.
   # - ingress.yaml
+  # Nightly pg_dump to any S3-compatible bucket. Uncomment after creating the
+  # fountain-backup-s3 Secret — setup is documented at the top of the file.
+  # - backup-cronjob.yaml
 
 images:
   # Pin a release, not `latest` — `latest` moves on every merge to main.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,5 +83,53 @@ services:
       OTEL_TRACES_EXPORTER: "none"
     restart: unless-stopped
 
+  # Nightly pg_dump into the backup_data volume, pruned after
+  # BACKUP_RETENTION_DAYS. Off unless you opt in:
+  #
+  #   docker compose --profile backup up -d
+  #
+  # The volume lives on the same host as the database, so this protects
+  # against bad migrations and fat fingers, not a dead machine — copy dumps
+  # off-host too, and back up MASTER_SECRETS_KEY separately: a database
+  # backup alone cannot decrypt itself. Restore drill:
+  # https://binarybourbon.github.io/fountain/operations/#backup-and-restore
+  backup:
+    image: postgres:16
+    profiles: ["backup"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      PGDATABASE: fountain
+      BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-86400}
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-14}
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      # A failed dump logs, deletes its partial file, and leaves every old
+      # backup alone — pruning happens only after a successful dump, so a
+      # broken database can never age out the backups you would restore from.
+      - |
+        while true; do
+          TS="$$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+          OUT="/backups/fountain-$${TS}.dump"
+          echo "Dumping to $${OUT}..."
+          if pg_dump -Fc -Z6 --no-owner --no-privileges -f "$$OUT" \
+             && [ "$$(stat -c %s "$$OUT")" -ge 10240 ]; then
+            echo "Backup complete: $${OUT} ($$(stat -c %s "$$OUT") bytes)"
+            find /backups -name 'fountain-*.dump' -mtime "+$${BACKUP_RETENTION_DAYS}" -delete
+          else
+            echo "FAIL: dump did not complete; keeping old backups"
+            rm -f "$$OUT"
+          fi
+          sleep "$$BACKUP_INTERVAL_SECONDS"
+        done
+    volumes:
+      - backup_data:/backups
+    restart: unless-stopped
+
 volumes:
   postgres_data:
+  backup_data:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -168,6 +168,89 @@ it. If you scrape metrics, provisioning failures show as
 
 ---
 
+## Backup and restore
+
+A backup here is two things: a `pg_dump` of Postgres **and the
+`MASTER_SECRETS_KEY` it was written under**. The key wraps every tenant's
+encryption key; a dump restored without it has secrets that nothing will
+ever decrypt. Store the key separately from the dumps, and treat "which key
+was live when this was taken" as part of a backup's identity.
+
+Taking them:
+
+- **Compose** — the bundled service, opt-in:
+  `docker compose --profile backup up -d`. Nightly `pg_dump` into the
+  `backup_data` volume, pruned after 14 days
+  ([details](self-hosting.md#backups)).
+- **Kubernetes** — `deploy/k8s/backup-cronjob.yaml`, nightly to any
+  S3-compatible bucket, commented out of the kustomization until you create
+  its secret. Setup is at the top of the file.
+
+### The restore drill
+
+A backup nobody has restored is a hypothesis. Periodically — and always
+before an upgrade — restore the newest dump into a scratch database and look
+at it. Compose:
+
+```bash
+docker compose --profile backup exec backup ls -lh /backups
+docker compose exec postgres createdb -U postgres fountain_drill
+docker compose --profile backup exec backup \
+  pg_restore --no-owner -d "dbname=fountain_drill" /backups/fountain-<ts>.dump
+
+# Does it hold what production holds?
+docker compose exec postgres psql -U postgres -d fountain_drill -c \
+  "SELECT (SELECT count(*) FROM users) AS users,
+          (SELECT count(*) FROM conversations) AS conversations,
+          (SELECT max(inserted_at) FROM audit_events) AS newest_audit_row"
+
+docker compose exec postgres dropdb -U postgres fountain_drill
+```
+
+Kubernetes: fetch the dump from the bucket and do the same against a scratch
+database on your Postgres:
+
+```bash
+aws s3 cp s3://<bucket>/pg_dump/fountain-<ts>.dump .
+createdb -h <host> -U <user> fountain_drill
+pg_restore --no-owner -h <host> -U <user> -d fountain_drill fountain-<ts>.dump
+```
+
+The drill passes when the counts look like production and the newest rows
+are from the night of the dump — not when `pg_restore` merely exits zero.
+
+### Restoring for real
+
+Stop the app first so nothing writes mid-restore (`docker compose stop app`,
+or scale the deployment to zero), then replace the live database and start
+the app again:
+
+```bash
+pg_restore --clean --if-exists --no-owner -d "$DATABASE_URL" fountain-<ts>.dump
+```
+
+Two rules that decide whether this works:
+
+- The restored data decrypts only under the `MASTER_SECRETS_KEY` that was
+  live when the dump was taken. If you rotated the key since, you need the
+  old one.
+- If the restore crosses an upgrade boundary, run the image version that
+  matches the dump — see [Upgrade gone wrong](#upgrade-gone-wrong).
+
+### Knowing the job still runs
+
+A backup job that quietly stops is the classic way backups rot. The
+Kubernetes CronJob has the [Sentry Crons
+check-in](integrations/sentry.md#crons-alerting-when-a-scheduled-job-stops-running)
+built in — set `SENTRY_DSN` and arm the monitor's schedule. On compose,
+check the service's log line dates:
+
+```bash
+docker compose --profile backup logs backup | tail -5
+```
+
+---
+
 ## Upgrade gone wrong
 
 The rules, in order of preference:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -126,17 +126,27 @@ DATABASE_SSL_CA_FILE=/etc/ssl/certs/rds-ca.pem
 
 ### Backups
 
-Nothing here backs up your database. Fountain's own deployment uses a nightly
-`pg_dump` to object storage; the mechanism is described in the
-[operator runbook](https://github.com/BinaryBourbon/fountain/blob/main/apps/fountain/priv/help/runbook.md).
-At minimum:
+The compose file ships a nightly `pg_dump` service, off unless you opt in:
 
 ```bash
-docker compose exec postgres pg_dump -U postgres -Fc fountain > fountain-$(date +%F).dump
+docker compose --profile backup up -d
 ```
 
-Restore into a scratch database and check the row counts before you need it in
-anger. A backup nobody has restored is a hypothesis.
+Dumps land in the `backup_data` volume and are pruned after
+`BACKUP_RETENTION_DAYS` (default 14; `BACKUP_INTERVAL_SECONDS` sets the
+cadence). **That volume is on the same host as the database** — it protects
+against bad migrations and fat fingers, not a dead machine. Copy dumps
+off-host on a schedule, and remember the standing rule: a database backup
+alone cannot decrypt itself — it pairs with the
+[`MASTER_SECRETS_KEY` you backed up separately](#back-up-master_secrets_key).
+
+On Kubernetes, `deploy/k8s/backup-cronjob.yaml` is the same discipline
+against any S3-compatible bucket — dump, size-check, upload, verify, then
+prune — commented out of the kustomization until you create its secret.
+
+Restoring, and proving you can, is in
+[Operations](operations.md#backup-and-restore). A backup nobody has restored
+is a hypothesis.
 
 ## Email
 


### PR DESCRIPTION
Closes #276 (operability push #281, operate tier).

**Compose path** — a `backup` service in `docker-compose.yml` behind a compose profile: `docker compose --profile backup up -d`. Nightly `pg_dump -Fc` into a `backup_data` volume, size-sanity-checked, pruned after `BACKUP_RETENTION_DAYS` (14). A failed dump deletes its partial file and skips pruning, so a broken database can never age out the backups you'd restore from. The issue's off-vs-on decision: **off by default via the profile** — it's one documented flag to enable, and a default-on service writing to the same disk as the database would look like a backup while protecting against much less than people assume (the docs say this loudly).

**deploy/k8s path** — `backup-cronjob.yaml`, the hosted CronJob generalized: `DATABASE_URL` comes from the existing `fountain-secrets` (no CNPG assumption), the target is any S3-compatible bucket via a new `fountain-backup-s3` secret (`S3_ENDPOINT` blank for AWS, `S3_FORCE_PATH_STYLE` for MinIO/Garage/R2), Garage-specific hardcoding dropped. What's deliberately kept from the hosted version: dump-to-completion in an initContainer before upload can start, the small-file refusal, upload-size verification via `list-objects-v2` (some stores 400 on HeadObject), prune-only-after-verified-upload, and the optional best-effort Sentry Crons check-in. Commented out of `kustomization.yaml` like the ingress, with the secret contract documented at the top of the file.

**The restore drill** — new `Backup and restore` section in `docs/operations.md`: scratch-database drill with a pass condition that's about row counts and newest-row dates, not `pg_restore` exiting zero; the real-restore procedure (stop the app first, `--clean --if-exists`); and the two rules that decide whether a restore works — the `MASTER_SECRETS_KEY` pairing and the image-version/no-downgrade boundary. Both deploy paths point at the Sentry Crons pattern for silent-stop alerting, as the issue asked.

Validation: compose YAML parsed and `$$`-escaping asserted programmatically (docker isn't on this machine, so no `compose config` run — worth a second look if anything smells off), CronJob passes `kubectl apply --dry-run=client` schema validation (nothing sent to any cluster), `kubectl kustomize deploy/k8s` builds, `mkdocs build --strict` green with the new cross-page anchors checked in the built HTML. Nothing in this PR touches the hosted `k8s/` overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)