### PR TITLE
self-host: observability pack — generic alerts and a starter dashboard

### DIFF
--- a/deploy/grafana/fountain-dashboard.json
+++ b/deploy/grafana/fountain-dashboard.json
@@ -1,0 +1,261 @@
+{
+  "__comment": "Starter Grafana dashboard for Fountain. Import via Dashboards > Import, then pick your Prometheus datasource. Panels use only metrics the app actually exports on :9568 (see FountainWeb.Telemetry.prometheus_metrics/0). Assumes the scrape adds a `namespace` label of `fountain` (kube-prometheus-stack style); strip those matchers if yours does not.",
+  "title": "Fountain",
+  "uid": "fountain-starter",
+  "schemaVersion": 39,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "1m",
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "5xx share (5m)",
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(phoenix_router_dispatch_stop_count{namespace=\"fountain\", status=~\"5..\"}[5m])) / sum(rate(phoenix_router_dispatch_stop_count{namespace=\"fountain\"}[5m]))"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Unhandled exceptions /s (5m)",
+      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(phoenix_router_dispatch_exception_count{namespace=\"fountain\"}[5m])) or vector(0)"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Provision failures /s (15m)",
+      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(fountain_provision_exception_count{namespace=\"fountain\"}[15m])) or vector(0)"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "BEAM memory",
+      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "deckbytes" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(vm_memory_total{namespace=\"fountain\"})",
+          "legendFormat": "total (kB)"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Turns completed /h",
+      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(fountain_turn_stop_count{namespace=\"fountain\"}[1h])) or vector(0)"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Provisions /h",
+      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(fountain_provision_stop_count{namespace=\"fountain\"}[1h])) or vector(0)"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP requests by status class",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 15, "stacking": { "mode": "normal" } }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (status) (label_replace(rate(phoenix_router_dispatch_stop_count{namespace=\"fountain\"}[5m]), \"status\", \"${1}xx\", \"status\", \"(.).+\"))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP request duration p50 / p95 / p99",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(phoenix_router_dispatch_stop_duration_bucket{namespace=\"fountain\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(phoenix_router_dispatch_stop_duration_bucket{namespace=\"fountain\"}[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(phoenix_router_dispatch_stop_duration_bucket{namespace=\"fountain\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Database: p95 query time vs p95 pool wait",
+      "description": "Pool wait (queue_time) climbing while query time stays flat means the pool is exhausted — everything gets slow at once. See the FountainDatabasePoolSaturated alert.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(fountain_repo_query_total_time_bucket{namespace=\"fountain\"}[5m])))",
+          "legendFormat": "p95 query time"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(fountain_repo_query_queue_time_bucket{namespace=\"fountain\"}[5m])))",
+          "legendFormat": "p95 pool wait"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Sandbox provisioning",
+      "description": "Completions and failures. Failures are post-retry — users saw a conversation fail to start.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(fountain_provision_stop_count{namespace=\"fountain\"}[15m]))",
+          "legendFormat": "completed /s"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(fountain_provision_exception_count{namespace=\"fountain\"}[15m]))",
+          "legendFormat": "failed /s"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(fountain_provision_stop_duration_bucket{namespace=\"fountain\"}[30m]))) / 1000",
+          "legendFormat": "p95 duration (s)"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "BEAM run queues",
+      "description": "Sustained non-zero CPU run queue means the schedulers cannot keep up — the VM-level 'wedged' signal.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(vm_total_run_queue_lengths_cpu{namespace=\"fountain\"})",
+          "legendFormat": "cpu"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(vm_total_run_queue_lengths_io{namespace=\"fountain\"})",
+          "legendFormat": "io"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Slowest routes (p95, top 5)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(5, histogram_quantile(0.95, sum by (route, le) (rate(phoenix_router_dispatch_stop_duration_bucket{namespace=\"fountain\"}[15m]))))",
+          "legendFormat": "{{route}}"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -67,7 +67,10 @@ supported once a newer version's migrations have run — restore from a backup.
   startup probe allows 150s for boot-time migrations. Reasons are inline in
   `deployment.yaml`.
 - **Metrics**: Prometheus format on port 9568 (`metrics`). Scrape in-cluster;
-  never expose it.
+  never expose it. `prometheusrule.yaml` ships generic alerts (commented out
+  of `kustomization.yaml`; needs the PrometheusRule CRD), and
+  `../grafana/fountain-dashboard.json` is a starter dashboard for the same
+  metrics.
 - **Scaling**: one replica by default, and going higher is not just a number —
   see the comment atop `deployment.yaml`.
 - **Backups**: `backup-cronjob.yaml` ships a nightly `pg_dump` to any

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -15,6 +15,9 @@ resources:
   # Nightly pg_dump to any S3-compatible bucket. Uncomment after creating the
   # fountain-backup-s3 Secret — setup is documented at the top of the file.
   # - backup-cronjob.yaml
+  # Generic alerts. Needs the PrometheusRule CRD (prometheus-operator) and a
+  # scrape of the metrics port — see the notes at the top of the file.
+  # - prometheusrule.yaml
 
 images:
   # Pin a release, not `latest` — `latest` moves on every merge to main.

--- a/deploy/k8s/prometheusrule.yaml
+++ b/deploy/k8s/prometheusrule.yaml
@@ -1,0 +1,187 @@
+# Generic alerts for a self-hosted Fountain — the operational knowledge from
+# running the hosted instance, with the hosted-specific routing and thresholds
+# removed.
+#
+# Off by default: this file is commented out of kustomization.yaml, because it
+# needs the PrometheusRule CRD (prometheus-operator / kube-prometheus-stack).
+# To enable: make sure your Prometheus scrapes the app's metrics port (9568 —
+# this baseline ships no ServiceMonitor, so wire the scrape however your stack
+# does it), check the label matchers below against how your scrape names
+# things, then uncomment the file in kustomization.yaml and re-apply.
+#
+# What is deliberately NOT here: node pressure, PVC fill, pod crash-looping,
+# replica mismatch — kube-prometheus-stack ships all of those; duplicating
+# them just doubles the paging.
+#
+# Every alert says what it means and what to do. The symptom → component map
+# is https://binarybourbon.github.io/fountain/architecture/ and the actions
+# are https://binarybourbon.github.io/fountain/operations/.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fountain-alerts
+  labels:
+    app: fountain
+spec:
+  groups:
+    # ── Backups ───────────────────────────────────────────────────────────
+    #
+    # These watch the optional backup-cronjob.yaml and are inert until it
+    # exists: each expression is gated on kube-state-metrics seeing the
+    # CronJob, so enabling alerts without enabling backups does not page you
+    # about backups you chose not to take.
+    - name: fountain-backups
+      interval: 60s
+      rules:
+        - alert: FountainBackupStale
+          # last_successful_time is seconds-since-epoch of the last successful
+          # run. 36h allows one missed nightly plus the startingDeadline
+          # window before shouting.
+          expr: |
+            time() - kube_cronjob_status_last_successful_time{
+              namespace="fountain", cronjob="fountain-pg-backup"
+            } > 36 * 3600
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Fountain Postgres backup has not succeeded in over 36h"
+            description: |
+              The newest restorable dump is at least {{ $value | humanizeDuration }}
+              old; recovery would lose everything since.
+              Check: kubectl get jobs -n fountain --sort-by=.metadata.creationTimestamp | tail
+              Logs:  kubectl logs -n fountain job/<name> -c dump
+                     kubectl logs -n fountain job/<name> -c upload
+
+        # The staleness alert cannot fire if the CronJob has never succeeded
+        # even once — the metric is simply absent. Gated on the CronJob
+        # existing so it stays silent when backups are not enabled at all.
+        - alert: FountainBackupNeverSucceeded
+          expr: |
+            absent(kube_cronjob_status_last_successful_time{
+              namespace="fountain", cronjob="fountain-pg-backup"
+            })
+              and on()
+            count(kube_cronjob_info{namespace="fountain", cronjob="fountain-pg-backup"}) > 0
+          for: 26h
+          labels:
+            severity: critical
+          annotations:
+            summary: "Fountain Postgres backup has never completed successfully"
+            description: |
+              The backup CronJob exists but no successful run has ever been
+              recorded. Either it was just created, or every run has failed.
+              Either way there is no verified backup yet.
+
+        - alert: FountainBackupJobFailing
+          expr: |
+            kube_job_status_failed{namespace="fountain", job_name=~"fountain-pg-backup.*"} > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "A Fountain backup job failed"
+            description: |
+              {{ $labels.job_name }} has a failed pod; the nightly dump may not
+              have been uploaded. One failure is not yet data loss —
+              FountainBackupStale escalates if it keeps happening.
+
+        - alert: FountainBackupSuspended
+          expr: kube_cronjob_spec_suspend{namespace="fountain", cronjob="fountain-pg-backup"} == 1
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain backup CronJob is suspended"
+            description: |
+              No backups are being taken. Fine during maintenance, dangerous
+              if forgotten.
+
+    # ── Application health ────────────────────────────────────────────────
+    - name: fountain-app
+      interval: 30s
+      rules:
+        - alert: FountainMetricsTargetDown
+          # The metrics listener is a separate socket inside the same BEAM, so
+          # a scrape failure while the pod still looks Ready means the VM
+          # itself is in trouble — this doubles as the "up but wedged" canary.
+          # NOTE: `job` here is whatever your scrape config named the target;
+          # adjust the matcher to yours.
+          expr: up{namespace="fountain"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Fountain metrics endpoint is not scrapeable"
+            description: |
+              Prometheus cannot scrape {{ $labels.pod }} on the metrics port.
+              The pod may pass its readiness probe while the BEAM cannot serve.
+
+        - alert: FountainHighServerErrorRate
+          # 5xx as a share of all responses; 5% sustained for 10m is a real
+          # regression, a single blip is not.
+          expr: |
+            sum(rate(phoenix_router_dispatch_stop_count{namespace="fountain", status=~"5.."}[5m]))
+              /
+            sum(rate(phoenix_router_dispatch_stop_count{namespace="fountain"}[5m]))
+              > 0.05
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Over 5% of Fountain responses are 5xx"
+            description: |
+              {{ $value | humanizePercentage }} of responses are server errors.
+              Detail is in Sentry if you configured it, otherwise the pod logs.
+
+        - alert: FountainUnhandledExceptions
+          expr: |
+            sum(rate(phoenix_router_dispatch_exception_count{namespace="fountain"}[5m])) > 0.1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain is raising unhandled exceptions"
+            description: |
+              Exceptions escaping the router on {{ $labels.route }}. Stack
+              traces are in Sentry if configured, otherwise only the logs.
+
+        - alert: FountainDatabasePoolSaturated
+          # queue_time is time waiting for a pool connection. It climbs when
+          # every connection is checked out — the failure that presents as
+          # "everything got slow" rather than "one query got slow".
+          expr: |
+            histogram_quantile(0.95,
+              sum(rate(fountain_repo_query_queue_time_bucket{namespace="fountain"}[5m])) by (le)
+            ) > 100
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain is waiting on the database connection pool"
+            description: |
+              p95 wait for a connection is {{ $value | humanize }}ms. The pool
+              is POOL_SIZE per replica (default 10). Sustained waits are slow
+              queries holding connections, or genuine saturation — raise
+              POOL_SIZE only after ruling out the former.
+
+    # ── Sandboxes ─────────────────────────────────────────────────────────
+    - name: fountain-sandboxes
+      interval: 60s
+      rules:
+        - alert: FountainProvisionFailures
+          # Provision calls already retry transient Sprites errors with
+          # backoff, so anything counted here failed after retries — users
+          # are seeing conversations that fail to start.
+          expr: |
+            sum(rate(fountain_provision_exception_count{namespace="fountain"}[15m])) > 0.05
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain sandbox provisioning is failing"
+            description: |
+              Likely causes, in the order to check them: SPRITES_TOKEN invalid
+              or rate-limited, the Sprites API unhealthy, or tenants at their
+              concurrency cap. Triage:
+              https://binarybourbon.github.io/fountain/operations/#sprites-errors

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -223,6 +223,19 @@ The app serves Prometheus metrics on port 9568, which the compose file does not
 publish. Add a port mapping if you are scraping it, and keep it off the public
 internet — it enumerates routes, request rates and database timings.
 
+You do not have to start from a blank scrape. The repo ships an observability
+pack built from running the hosted instance:
+
+- **Alerts** — `deploy/k8s/prometheusrule.yaml`: error rate, unhandled
+  exceptions, pool saturation, provisioning failures, and staleness watches
+  for the optional backup CronJob, each commented with what it means and what
+  to do. Needs the PrometheusRule CRD; commented out of the kustomization
+  until you enable it.
+- **A starter dashboard** — `deploy/grafana/fountain-dashboard.json`, built
+  only from metrics the app actually exports. Import it into Grafana and pick
+  your Prometheus datasource; on compose, point any Prometheus at the metrics
+  port and import the same file.
+
 Logs go to stdout: `docker compose logs -f app`.
 
 Error tracking is off unless you opt in: set `SENTRY_DSN` and crashes —


### PR DESCRIPTION
Closes #277 (operability push #281, operate tier — completes it).

**`deploy/k8s/prometheusrule.yaml`** — the hosted `k8s/prometheusrule.yaml` generalized for self-hosters:
- Hosted-specific routing (ntfy/Alertmanager comments, `home-cloud` labels) dropped; each alert now carries what-it-means / what-to-do annotations linking the architecture and operations pages.
- The four backup watches are **gated on the backup CronJob existing** (via `kube_cronjob_info`) — the hosted `absent()` expression would false-alarm for anyone who didn't enable the optional backup CronJob from #296.
- One factual correction vs the hosted copy: its `FountainProvisionFailures` description says "there are no retries on the provisioning path", which predates the retry layer (#168). The generic version says failures are post-retry.
- Commented out of `kustomization.yaml` (needs the PrometheusRule CRD); the header documents the scrape prerequisite and the label matchers to check, since this baseline deliberately ships no ServiceMonitor.

**`deploy/grafana/fountain-dashboard.json`** — a 12-panel starter: stat row (5xx share, exception rate, provision failures, BEAM memory, turns/h, provisions/h) plus request rate by status class, latency quantiles, query-time-vs-pool-wait (the pool-saturation diagnostic pattern), provisioning rate/duration, BEAM run queues, and slowest-routes-p95. Built **only from metrics the app actually exports** — metric names verified against `TelemetryMetricsPrometheus.Core`'s exporter (plain underscore join, no unit suffix). The issue's wishlist also named conversation/sandbox counts and Oban queue depth; those aren't exported today, so they're not on the dashboard — adding those metrics would be its own small PR, happy to file it.

Docs: the self-hosting Observability section and the k8s README now point at both artifacts, and note the compose path is the same dashboard against a Prometheus scraping :9568, with Sentry covering the error-tracking half.

Validation: YAML/JSON parse clean, `kubectl kustomize deploy/k8s` builds, `mkdocs build --strict` green. Nothing touches the hosted `k8s/` overlay. The dashboard and alert expressions can't be exercised against a live Prometheus from here — worth a one-time import/apply on the hosted stack to confirm rendering after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)