### PR TITLE
ops: trust Cloudflare's egress ranges in TRUSTED_PROXIES

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -104,6 +104,17 @@ spec:
             # unverified-account pruner (#258).
             - name: UNVERIFIED_PRUNE_EXEMPT
               value: jhgaylor
+            # The zone is proxied through Cloudflare (managed challenge on
+            # /auth/register, #259), so X-Forwarded-For arrives as
+            # "client, cf-egress" — Traefik trusts CF's ranges and appends its
+            # egress IP (home-cloud k8s/traefik/helmchartconfig.yaml). This
+            # list must skip that CF hop to resolve the real client, and it
+            # REPLACES the app's built-in default, so the k3s pod/service
+            # networks and loopback are re-listed first. Ranges:
+            # https://www.cloudflare.com/ips/ — keep in sync with the Traefik
+            # side when CF announces new blocks.
+            - name: TRUSTED_PROXIES
+              value: "10.42.0.0/16,10.43.0.0/16,127.0.0.1/32,::1/128,173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22,2400:cb00::/32,2606:4700::/32,2803:f800::/32,2405:b500::/32,2405:8100::/32,2a06:98c0::/29,2c0f:f248::/32"
             # No OTLP collector in-cluster yet — without this,
             # opentelemetry_exporter retries localhost:4318 per span and
             # floods logs with :econnrefused. Swap to the real


### PR DESCRIPTION
Part of #259 (the Cloudflare managed-challenge rollout — the challenge itself is dashboard-side and already live; this is the third item from the decision comment's checklist).

With the zone orange-clouded, `X-Forwarded-For` at the app is `client, <cf-egress>`. The XFF walk stops at the first untrusted hop, so without Cloudflare's ranges in `TRUSTED_PROXIES` the "client" is a Cloudflare egress IP: every visitor behind the same colo shares one 600 req/min bucket, audit rows attribute to CF, and per-IP throttling stops distinguishing bots from humans.

- The env var **replaces** the app's built-in default list (`FountainWeb.Endpoint.trusted_proxies/0`), so the k3s pod/service networks and loopback are deliberately re-listed first, then all 15 IPv4 + 7 IPv6 published Cloudflare ranges (fetched from cloudflare.com/ips today).
- Hosted overlay only (`k8s/deployment.yaml`) — self-hosters' defaults are untouched, and the var is already documented in the configuration reference.
- **Companion PR:** jhgaylor/home-cloud#37 makes Traefik trust the same ranges so it forwards CF's XFF instead of discarding it (`ClientIp`'s moduledoc documents that Traefik currently rewrites XFF — with only this PR and not that one, the app falls back to the peer address, which is safe but keeps buckets shared). Either merge order is safe; no intermediate state is worse than today.

Verified: overlay builds with `kubectl kustomize`; all 26 CIDRs parse with `RemoteIp.Block.parse/1` (the exact code path that consumes them — a typo'd CIDR is silently dropped by `ClientIp.blocks/0`, so worth checking programmatically), and a sample CF egress address matches the set. After both PRs deploy I'll verify end-to-end that a request through Cloudflare logs the real client IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)