### PR TITLE
fix: unwrap IPv4-mapped IPv6 peers before the trusted-proxy check

### DIFF
--- a/apps/fountain/lib/fountain_web/plugs/client_ip.ex
+++ b/apps/fountain/lib/fountain_web/plugs/client_ip.ex
@@ -36,10 +36,22 @@ defmodule FountainWeb.Plugs.ClientIp do
 
   @impl Plug
   def call(conn, _opts) do
+    conn = %{conn | remote_ip: normalize(conn.remote_ip)}
     conn = %{conn | remote_ip: resolve(conn)}
     Logger.metadata(remote_ip: format(conn.remote_ip))
     conn
   end
+
+  # The endpoint listens on [::] (runtime.exs binds ip: {0,0,0,0,0,0,0,0}), so
+  # an IPv4 peer arrives as an IPv4-mapped IPv6 tuple — ::ffff:10.42.0.1 —
+  # which RemoteIp.Block never matches against an IPv4 CIDR. Left unwrapped,
+  # the peer gate below fails on every request, the forwarded header is never
+  # consulted, and every bucket and audit row keys on the node gateway again —
+  # the exact regression #216 fixed. Unwrap before any matching or storage.
+  defp normalize({0, 0, 0, 0, 0, 0xFFFF, hi, lo}),
+    do: {div(hi, 256), rem(hi, 256), div(lo, 256), rem(lo, 256)}
+
+  defp normalize(ip), do: ip
 
   defp resolve(conn) do
     if from_trusted_proxy?(conn.remote_ip) do
@@ -51,6 +63,7 @@ defmodule FountainWeb.Plugs.ClientIp do
 
   @doc "Whether `ip` is one of the configured proxy addresses."
   def from_trusted_proxy?(ip) when is_tuple(ip) do
+    ip = normalize(ip)
     Enum.any?(blocks(), &Block.contains?(&1, Block.encode(ip)))
   end
 

--- a/apps/fountain/test/fountain_web/client_ip_test.exs
+++ b/apps/fountain/test/fountain_web/client_ip_test.exs
@@ -72,6 +72,30 @@ defmodule FountainWeb.ClientIpTest do
     end
   end
 
+  describe "an IPv4-mapped IPv6 peer (endpoint bound on [::])" do
+    # The endpoint listens on [::], so an IPv4 peer arrives as an IPv4-mapped
+    # IPv6 tuple — ::ffff:10.42.0.1 — which a v4 CIDR block never matches.
+    # Production bore this out: the peer gate failed on every request, the
+    # header was never consulted, and buckets keyed on the node gateway again.
+    test "a mapped cluster hop is still a trusted proxy" do
+      # ::ffff:10.42.0.1
+      assert resolve([{"x-forwarded-for", "203.0.113.7"}], {0, 0, 0, 0, 0, 65_535, 2602, 1}) ==
+               {203, 0, 113, 7}
+    end
+
+    test "the no-header fallback stores the unwrapped v4 address" do
+      assert resolve([], {0, 0, 0, 0, 0, 65_535, 2602, 1}) == {10, 42, 0, 1}
+    end
+
+    test "a mapped public peer still cannot forge its address" do
+      # ::ffff:198.51.100.9 — unwrapping must not widen trust.
+      assert resolve(
+               [{"x-forwarded-for", "1.2.3.4"}],
+               {0, 0, 0, 0, 0, 65_535, 50_739, 25_609}
+             ) == {198, 51, 100, 9}
+    end
+  end
+
   describe "trusted_proxies/0" do
     test "covers the k3s pod and service networks" do
       proxies = Endpoint.trusted_proxies()


### PR DESCRIPTION
Found while verifying #259's `TRUSTED_PROXIES` rollout end-to-end, and it's load-bearing for that whole chain.

**Symptom (live, verified via rpc on a prod pod):** after the Traefik + `TRUSTED_PROXIES` changes, a probe through Cloudflare still produced a rate-limit bucket keyed `{"auth_token", "::ffff:10.42.0.1"}` — the node gateway, not the client.

**Cause:** the endpoint binds `[::]` (`runtime.exs` sets `ip: {0,0,0,0,0,0,0,0}`), so an IPv4 peer arrives as an IPv4-mapped IPv6 tuple. `RemoteIp.Block.contains?` never matches that against a v4 CIDR, so `from_trusted_proxy?/1` returned false for the in-cluster hop, the header was never consulted, and `remote_ip` fell back to the peer. Confirmed in the running node: `from_trusted_proxy?({0,0,0,0,0,65535,2602,1})` → `false` while `from_trusted_proxy?({10,42,0,1})` → `true`, and the XFF walk itself resolved the real client correctly when handed the header — the peer gate was the only broken link. This is the same regression #216 fixed, resurfaced in a different encoding.

**Fix:** normalize `{0,0,0,0,0,0xFFFF,hi,lo}` → the v4 tuple, at the top of the plug (so the stored `remote_ip`, buckets, audit rows and logs all get the clean v4 form) and inside `from_trusted_proxy?/1` (so the LiveView connect-info path in `FountainWeb.Audited` heals too — it calls the same function).

**Tests:** three new cases covering the mapped shapes — a mapped cluster hop consults the header, the no-header fallback stores the unwrapped v4, and a mapped *public* peer still cannot forge its address (unwrapping must not widen trust). All three fail against the unfixed plug (verified before applying the fix), pass after. Full `mix precommit` green (1535 tests).

After merge + deploy I'll re-run the live verification: the bucket key should be the real client IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)