### PR TITLE
ops: drop the TRUSTED_PROXIES override — the tunnel made it unnecessary

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -104,17 +104,13 @@ spec:
             # unverified-account pruner (#258).
             - name: UNVERIFIED_PRUNE_EXEMPT
               value: jhgaylor
-            # The zone is proxied through Cloudflare (managed challenge on
-            # /auth/register, #259), so X-Forwarded-For arrives as
-            # "client, cf-egress" — Traefik trusts CF's ranges and appends its
-            # egress IP (home-cloud k8s/traefik/helmchartconfig.yaml). This
-            # list must skip that CF hop to resolve the real client, and it
-            # REPLACES the app's built-in default, so the k3s pod/service
-            # networks and loopback are re-listed first. Ranges:
-            # https://www.cloudflare.com/ips/ — keep in sync with the Traefik
-            # side when CF announces new blocks.
-            - name: TRUSTED_PROXIES
-              value: "10.42.0.0/16,10.43.0.0/16,127.0.0.1/32,::1/128,173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22,2400:cb00::/32,2606:4700::/32,2803:f800::/32,2405:b500::/32,2405:8100::/32,2a06:98c0::/29,2c0f:f248::/32"
+            # TRUSTED_PROXIES is deliberately NOT set. Public traffic arrives
+            # via the Cloudflare Tunnel (home-cloud k8s/cloudflared/), so the
+            # X-Forwarded-For chain is "client, <cloudflared pod>" — every
+            # proxy hop is inside the pod network, which the app's built-in
+            # default trust list already covers. (Cloudflare egress ranges
+            # were listed here briefly; the tunnel made them unnecessary —
+            # CF's own addresses never appear as hops.)
             # No OTLP collector in-cluster yet — without this,
             # opentelemetry_exporter retries localhost:4318 per span and
             # floods logs with :econnrefused. Swap to the real


### PR DESCRIPTION
Final cleanup for #259's infrastructure half, now that ingress rides the Cloudflare Tunnel (jhgaylor/home-cloud#38/#39).

With cloudflared in-cluster, the `X-Forwarded-For` chain at the app is `client, <cloudflared pod IP>` — every hop is pod-network, which `FountainWeb.Endpoint.trusted_proxies/0`'s built-in default already trusts. The CF egress ranges added in #298 can never appear as hops anymore (CF talks to cloudflared over the tunnel, not to Traefik over TCP), so the override now only adds maintenance surface (a list to keep in sync with cloudflare.com/ips for no effect).

End-to-end state verified live *before* this PR, through the tunnel: rate-limit bucket keyed on the real client egress IP, challenge firing on `POST /auth/register`, site healthy — with only pod-network hops involved in the resolution, i.e. exactly what the defaults cover. The #300 v4-mapped-peer fix remains the load-bearing app-side piece.

k8s-only change, so the deploy branch needs a manual `build.yml` dispatch after merge (the known pipeline quirk); I'll do that, watch the rollout, and re-verify the buckets still key on real client IPs with the override gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)