### PR TITLE
ops: publish manifests as an OCI artifact alongside the deploy branch (#301)

### DIFF
--- a/.github/workflows/pin-image.yml
+++ b/.github/workflows/pin-image.yml
@@ -1,24 +1,33 @@
 name: Pin image
 
-# Publishes the `deploy` branch: the only thing Flux reads.
-#
-# Every commit here is the exact tree that was built, plus the image tag built
-# from it. That pairing is the point. Flux used to track `main`, where the two
-# arrive in separate commits minutes apart — the PR changes k8s/deployment.yaml,
-# the image finishes building later, and the pin lands after that. Flux polls
-# every 5 minutes, so it routinely applied a manifest against the previous
-# image.
+# Publishes what Flux deploys: the exact tree that was built, plus the image
+# tag built from it. That pairing is the point. Flux used to track `main`,
+# where the two arrive in separate commits minutes apart — the PR changes
+# k8s/deployment.yaml, the image finishes building later, and the pin lands
+# after that. Flux polls every 5 minutes, so it routinely applied a manifest
+# against the previous image.
 #
 # That is not theoretical: #241 moved the readiness probe to a new path, Flux
 # applied it against an image with no such route, and every pod 404'd its probe
 # and never became ready. Suspending Flux by hand did not prevent it either,
-# because the GitRepository can still be behind at the moment you resume.
+# because the source can still be behind at the moment you resume.
+#
+# Two targets during the #304 transition, same tree in both:
+#
+#   1. The `deploy` branch — what the cluster's GitRepository reads today.
+#   2. An OCI artifact at ghcr.io/binarybourbon/fountain-manifests (#301) —
+#      what the OCIRepository will read after the cutover (#302). Immutable
+#      `sha-<short>` tags plus a moving `latest`; rollback is
+#      `flux tag artifact oci://…:sha-<old> --tag latest`.
+#
+# The branch publish (and this comment) go away in #303 once the cutover has
+# survived a real watched rollout.
 #
 # Flow: push to main → build.yml builds and pushes
 #   ghcr.io/binarybourbon/fountain:sha-<sha>
-#       → this workflow rebuilds `deploy` from *that sha's tree* with the
-#         matching tag committed on top
-#       → Flux reconciles `deploy`.
+#       → this workflow publishes both targets from *that sha's tree* with the
+#         matching tag pinned in k8s/deployment.yaml
+#       → Flux reconciles.
 #
 # `main` is never deployed directly and its k8s/deployment.yaml image tag is
 # inert — see the note in that file.
@@ -28,6 +37,16 @@ on:
     workflows: [build]
     types: [completed]
     branches: [main]
+  # Manual escape hatch, and the bootstrap path for the first artifact push
+  # (#301): republishes from an already-built commit. The image-existence
+  # check below is what makes this safe — a sha whose image was never built
+  # is refused before anything is published.
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit to publish (defaults to the branch tip)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -35,36 +54,55 @@ permissions:
 jobs:
   pin:
     name: Pin image SHA in deployment.yaml
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
+      packages: write
+    env:
+      # The commit that was actually built — NOT main's tip. Pinning onto
+      # the tip is what let a newer manifest ride out with an older image.
+      SRC_SHA: ${{ github.event.workflow_run.head_sha || inputs.sha || github.sha }}
+      MANIFESTS: ghcr.io/binarybourbon/fountain-manifests
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # The commit that was actually built — NOT main's tip. Pinning onto
-          # the tip is what let a newer manifest ride out with an older image.
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ env.SRC_SHA }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve image tag
         id: tag
         run: |
-          sha="${{ github.event.workflow_run.head_sha }}"
+          sha="${SRC_SHA}"
           {
             echo "sha=${sha}"
             echo "short=${sha:0:7}"
             echo "image=ghcr.io/binarybourbon/fountain:sha-${sha}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Verify the image exists
+        # A no-op after workflow_run (the build just succeeded), but the guard
+        # that keeps workflow_dispatch honest: never publish a manifest whose
+        # image cannot be pulled.
+        run: docker manifest inspect "${{ steps.tag.outputs.image }}" > /dev/null
+
+      - name: Pin the image tag in the working tree
+        env:
+          IMAGE: ${{ steps.tag.outputs.image }}
+        run: |
+          set -euo pipefail
+          sed -i -E \
+            "s|ghcr\.io/binarybourbon/fountain:sha-[0-9a-f]+|${IMAGE}|" \
+            k8s/deployment.yaml
+          git diff --stat k8s/deployment.yaml
+
       - name: Publish the deploy branch
         env:
           SHA: ${{ steps.tag.outputs.sha }}
           SHORT: ${{ steps.tag.outputs.short }}
-          IMAGE: ${{ steps.tag.outputs.image }}
         run: |
           set -euo pipefail
 
@@ -89,12 +127,11 @@ jobs:
             fi
           fi
 
-          sed -i -E \
-            "s|ghcr\.io/binarybourbon/fountain:sha-[0-9a-f]+|${IMAGE}|" \
-            k8s/deployment.yaml
-
           git add k8s/deployment.yaml
-          git commit -m "deploy: sha-${SHORT}" -m "Deployed-From: ${SHA}"
+          # --allow-empty: a workflow_dispatch republish of a tree that already
+          # pins its own sha seds nothing; the tree is still the right one to
+          # publish, and a failed commit here would abort the artifact step too.
+          git commit --allow-empty -m "deploy: sha-${SHORT}" -m "Deployed-From: ${SHA}"
 
           # Fully qualified on purpose. `HEAD:deploy` cannot create the branch
           # on the first run — git refuses to guess a destination that does not
@@ -105,4 +142,55 @@ jobs:
           # commit rather than accumulating history of its own.
           git push --force origin HEAD:refs/heads/deploy
 
-          echo "deploy now at $(git rev-parse --short HEAD) (from ${SHORT}, image ${IMAGE})"
+          echo "deploy now at $(git rev-parse --short HEAD) (from ${SHORT})"
+
+      - name: Setup flux CLI
+        uses: fluxcd/flux2/action@54e4ba378e155ada619caafdc599e5c4d759ce5c # v2.8.7
+        with:
+          # Matches the cluster's source-controller. Nothing here is
+          # version-sensitive, but drift is one more thing to reason about
+          # during an incident.
+          version: 2.8.7
+
+      - name: Publish the manifest artifact
+        env:
+          SHA: ${{ steps.tag.outputs.sha }}
+          SHORT: ${{ steps.tag.outputs.short }}
+        run: |
+          set -euo pipefail
+
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+          # The same refuse-to-move-backwards guard as the branch publish
+          # above, reading the source sha from the artifact's OCI revision
+          # annotation (set by --revision below) instead of a commit trailer.
+          # Absent annotation (first run) or an unknown sha both fall through
+          # to publishing.
+          previous=$(docker buildx imagetools inspect --raw "${MANIFESTS}:latest" 2>/dev/null \
+            | jq -r '.annotations["org.opencontainers.image.revision"] // empty' || true)
+
+          if [ -n "${previous}" ] && [ "${previous}" != "${SHA}" ]; then
+            if git merge-base --is-ancestor "${SHA}" "${previous}" 2>/dev/null; then
+              echo "sha-${SHORT} is an ancestor of the published ${previous:0:7}; refusing to move latest backwards."
+              exit 0
+            fi
+          fi
+
+          # Stage exactly what the cluster Kustomization consumes: ./k8s plus
+          # the ../deploy/k8s baseline its kustomization references, relative
+          # layout intact. The tree is evaluated in-cluster by
+          # kustomize-controller, same as it is from the branch today.
+          staging=$(mktemp -d)
+          cp -R k8s "${staging}/k8s"
+          mkdir -p "${staging}/deploy"
+          cp -R deploy/k8s "${staging}/deploy/k8s"
+
+          flux push artifact "oci://${MANIFESTS}:sha-${SHORT}" \
+            --path="${staging}" \
+            --source="https://github.com/${{ github.repository }}" \
+            --revision="${SHA}"
+
+          flux tag artifact "oci://${MANIFESTS}:sha-${SHORT}" --tag latest
+
+          echo "manifest artifact published: ${MANIFESTS}:sha-${SHORT} (revision ${SHA}), latest re-tagged"


### PR DESCRIPTION
Closes #301. Part of #304.

## What

`pin-image.yml` now publishes **two targets from the same built tree**:

1. The `deploy` branch — unchanged, still what the cluster's GitRepository reads. Retired in #303.
2. An OCI artifact at `ghcr.io/binarybourbon/fountain-manifests` — immutable `sha-<short>` tags plus a moving `latest`, published with `flux push artifact` from the checked-out built sha's tree (`k8s/` + `deploy/k8s/`, relative layout intact, evaluated in-cluster as today). This is what the OCIRepository reads after the #302 cutover.

## Invariants preserved

- **Manifest and image are never separately visible** (#231/#241): the artifact is staged from the same checkout the image was built from, in the same job, with the tag sed'd in first.
- **Refuse to move backwards**: ported to the artifact side by reading the source sha from the standard OCI revision annotation (set via `--revision`) instead of the `Deployed-From:` trailer, then the same `merge-base --is-ancestor` check.

## Also

- `workflow_dispatch` trigger: bootstraps the first artifact push (creates the GHCR package under the repo's `GITHUB_TOKEN` so it stays linked with write access) and doubles as a manual republish path. Gated by a `docker manifest inspect` image-existence check so a never-built sha cannot be published.
- `packages: write` added to job permissions (`contents: write` remains until #303 drops the branch push).
- `git commit --allow-empty` on the branch publish: a same-sha republish seds nothing, and a failed commit would otherwise abort the artifact step too.
- flux CLI pinned to 2.8.7, matching the cluster's source-controller.

## After merge (tracked in #301)

Dispatch the workflow once, flip the `fountain-manifests` package to public (first push creates it private), anonymous-pull and diff against the `deploy` branch tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)