### PR TITLE
admin: lifecycle funnel visibility (#282)

### DIFF
--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -1,0 +1,212 @@
+defmodule Fountain.Funnel do
+  @moduledoc """
+  Lifecycle funnel: registered → verified → onboarded → activated → subscribed.
+
+  Admin-only aggregates (no tenant scoping — callers are the admin panel and
+  the metrics poller). Answers two operator questions:
+
+  - `summary_admin/0` — how many users reach each stage, the conversion from
+    the previous stage, and the median time between stages.
+  - included stall breakdown — of the users who verified but never started a
+    conversation, how far did they get? This is the "38 verified, zero
+    conversations" question: did they finish onboarding, build an agent,
+    create an environment, or bounce straight off?
+
+  Stage definitions:
+
+  - **registered** — a `users` row exists
+  - **verified** — `email_verified_at` set
+  - **onboarded** — `onboarding_completed_at` set
+  - **activated** — first conversation: the earliest of a `conversations` row
+    or a `sandbox_provisioned` usage event. The union matters: conversations
+    can be deleted, usage events predate nothing after metering (#213) — either
+    alone under-counts.
+  - **subscribed** — `subscription_status` in active/past_due. Comped accounts
+    are operator-granted, not conversions, and are excluded; converted-then-
+    canceled users drop out of this stage (a churn view is #286's job).
+
+  Everything is computed from one pass over `users` plus two grouped min
+  queries — O(users) in memory, which is fine well past 10k users; push the
+  math into SQL if that stops being true.
+  """
+
+  import Ecto.Query
+
+  alias Fountain.Accounts.User
+  alias Fountain.Billing.UsageEvent
+  alias Fountain.Conversations.Conversation
+  alias Fountain.Repo
+
+  @subscribed_statuses ~w(active past_due)
+
+  @type stage :: %{
+          key: atom(),
+          count: non_neg_integer(),
+          conversion: float() | nil,
+          median_hours: float() | nil
+        }
+
+  @doc """
+  The funnel: five stages plus the stalled-at-activation breakdown.
+
+  Returns `%{stages: [stage], stalled: %{count: n, by_onboarding_state: map,
+  built_agent: n, built_environment: n, built_nothing: n}}`.
+
+  `conversion` is the fraction of the *previous* stage (nil for registered);
+  `median_hours` is the median time from the previous stage's timestamp, for
+  users that have both (nil for registered and subscribed — there is no
+  subscribed-at timestamp to measure against).
+  """
+  @spec summary_admin() :: %{stages: [stage()], stalled: map()}
+  def summary_admin do
+    users =
+      Repo.all(
+        from u in User,
+          select: %{
+            id: u.id,
+            registered_at: u.inserted_at,
+            verified_at: u.email_verified_at,
+            onboarded_at: u.onboarding_completed_at,
+            onboarding_state: u.onboarding_state,
+            subscription_status: u.subscription_status
+          }
+      )
+
+    first_activity = first_activity_by_user()
+
+    registered = users
+    verified = Enum.filter(users, & &1.verified_at)
+    onboarded = Enum.filter(users, & &1.onboarded_at)
+    activated = Enum.filter(users, &Map.has_key?(first_activity, &1.id))
+    subscribed = Enum.filter(users, &(&1.subscription_status in @subscribed_statuses))
+
+    stages = [
+      %{key: :registered, count: length(registered), conversion: nil, median_hours: nil},
+      %{
+        key: :verified,
+        count: length(verified),
+        conversion: ratio(length(verified), length(registered)),
+        median_hours: median_hours(verified, & &1.registered_at, & &1.verified_at)
+      },
+      %{
+        key: :onboarded,
+        count: length(onboarded),
+        conversion: ratio(length(onboarded), length(verified)),
+        median_hours: median_hours(onboarded, & &1.verified_at, & &1.onboarded_at)
+      },
+      %{
+        key: :activated,
+        count: length(activated),
+        conversion: ratio(length(activated), length(onboarded)),
+        median_hours:
+          median_hours(activated, & &1.onboarded_at, &Map.get(first_activity, &1.id))
+      },
+      %{
+        key: :subscribed,
+        count: length(subscribed),
+        conversion: ratio(length(subscribed), length(activated)),
+        median_hours: nil
+      }
+    ]
+
+    %{stages: stages, stalled: stalled_breakdown(verified, first_activity)}
+  end
+
+  @doc """
+  Poller hook for `FountainWeb.Telemetry.periodic_measurements/0`: emits stage
+  counts as a `[:fountain, :funnel]` telemetry event so Prometheus/Grafana can
+  trend them. Counts only — no medians (a median makes a poor gauge).
+  """
+  @spec emit_telemetry() :: :ok
+  def emit_telemetry do
+    %{stages: stages, stalled: %{count: stalled}} = summary_admin()
+
+    measurements =
+      stages
+      |> Map.new(fn %{key: key, count: count} -> {key, count} end)
+      |> Map.put(:stalled_verified, stalled)
+
+    :telemetry.execute([:fountain, :funnel], measurements, %{})
+  end
+
+  # Of the verified users with no conversation ever: how far did each get?
+  defp stalled_breakdown(verified, first_activity) do
+    stalled = Enum.reject(verified, &Map.has_key?(first_activity, &1.id))
+    stalled_ids = MapSet.new(stalled, & &1.id)
+
+    agent_owners = owners_in(Fountain.Agents.Agent, stalled_ids)
+    env_owners = owners_in(Fountain.Environments.Environment, stalled_ids)
+
+    built_nothing =
+      Enum.count(stalled, fn u ->
+        not MapSet.member?(agent_owners, u.id) and not MapSet.member?(env_owners, u.id)
+      end)
+
+    %{
+      count: length(stalled),
+      by_onboarding_state: Enum.frequencies_by(stalled, & &1.onboarding_state),
+      built_agent: MapSet.size(agent_owners),
+      built_environment: MapSet.size(env_owners),
+      built_nothing: built_nothing
+    }
+  end
+
+  defp owners_in(schema, stalled_ids) do
+    ids = MapSet.to_list(stalled_ids)
+
+    from(r in schema, where: r.user_id in ^ids, distinct: true, select: r.user_id)
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  # %{user_id => first-ever conversation timestamp}, from the union of the
+  # conversations table and sandbox_provisioned usage events.
+  defp first_activity_by_user do
+    conversations =
+      Repo.all(
+        from c in Conversation,
+          group_by: c.user_id,
+          select: {c.user_id, min(c.inserted_at)}
+      )
+
+    usage =
+      Repo.all(
+        from e in UsageEvent,
+          where: e.event_type == "sandbox_provisioned",
+          group_by: e.user_id,
+          select: {e.user_id, min(e.inserted_at)}
+      )
+
+    Map.merge(Map.new(conversations), Map.new(usage), fn _id, a, b ->
+      if DateTime.compare(a, b) == :lt, do: a, else: b
+    end)
+  end
+
+  defp ratio(_num, 0), do: nil
+  defp ratio(num, denom), do: num / denom
+
+  defp median_hours(users, from_fun, to_fun) do
+    diffs =
+      for u <- users,
+          from_ts = from_fun.(u),
+          to_ts = to_fun.(u),
+          not is_nil(from_ts) and not is_nil(to_ts) do
+        DateTime.diff(to_ts, from_ts, :second) / 3600
+      end
+
+    median(diffs)
+  end
+
+  defp median([]), do: nil
+
+  defp median(values) do
+    sorted = Enum.sort(values)
+    mid = div(length(sorted), 2)
+
+    if rem(length(sorted), 2) == 1 do
+      Enum.at(sorted, mid)
+    else
+      (Enum.at(sorted, mid - 1) + Enum.at(sorted, mid)) / 2
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -18,6 +18,7 @@ defmodule FountainWeb.AdminLive.Index do
      socket
      |> FountainWeb.Audited.put_client_ip()
      |> assign(:page_title, "Admin")
+     |> assign(:funnel, Fountain.Funnel.summary_admin())
      |> assign(:sandboxes, Conversations.list_sandboxes_admin())
      |> assign(:admin_events, Fountain.Audit.list_recent_admin(25))}
   end
@@ -39,6 +40,7 @@ defmodule FountainWeb.AdminLive.Index do
     {:noreply,
      socket
      |> assign_users()
+     |> assign(:funnel, Fountain.Funnel.summary_admin())
      |> assign(:sandboxes, Conversations.list_sandboxes_admin())
      |> assign(:admin_events, Fountain.Audit.list_recent_admin(25))}
   end
@@ -365,6 +367,40 @@ defmodule FountainWeb.AdminLive.Index do
       </div>
 
       <section class="space-y-3">
+        <h2 class="text-lg font-medium">Funnel</h2>
+        <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
+          <div
+            :for={stage <- @funnel.stages}
+            class="bg-white rounded shadow border border-zinc-200 px-4 py-3"
+          >
+            <div class="text-xs text-zinc-500">{stage_label(stage.key)}</div>
+            <div class="text-2xl font-semibold tabular-nums">{stage.count}</div>
+            <div class="text-xs text-zinc-500 space-x-2">
+              <span :if={stage.conversion}>{format_pct(stage.conversion)} of prev</span>
+              <span :if={stage.median_hours}>· median {format_hours(stage.median_hours)}</span>
+            </div>
+          </div>
+        </div>
+        <div
+          :if={@funnel.stalled.count > 0}
+          class="bg-amber-50 border border-amber-200 rounded px-4 py-3 text-sm text-amber-900 space-y-1"
+        >
+          <div class="font-medium">
+            {@funnel.stalled.count} verified {if @funnel.stalled.count == 1, do: "user has", else: "users have"} never started a conversation
+          </div>
+          <div class="text-xs">
+            onboarding:
+            <span :for={{state, n} <- Enum.sort(@funnel.stalled.by_onboarding_state)} class="mr-2">
+              {state} ×{n}
+            </span>
+          </div>
+          <div class="text-xs">
+            built an agent: {@funnel.stalled.built_agent} · created an environment: {@funnel.stalled.built_environment} · built nothing: {@funnel.stalled.built_nothing}
+          </div>
+        </div>
+      </section>
+
+      <section class="space-y-3">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <h2 class="text-lg font-medium">Users ({@total_users})</h2>
           <form phx-change="filter" id="user-filters" class="flex flex-wrap items-center gap-2">
@@ -671,6 +707,18 @@ defmodule FountainWeb.AdminLive.Index do
   defp sandbox_status_color("ready"), do: "bg-green-100 text-green-800 border-green-200"
   defp sandbox_status_color("failed"), do: "bg-red-100 text-red-700 border-red-200"
   defp sandbox_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
+
+  defp stage_label(:registered), do: "Registered"
+  defp stage_label(:verified), do: "Verified"
+  defp stage_label(:onboarded), do: "Onboarded"
+  defp stage_label(:activated), do: "Activated"
+  defp stage_label(:subscribed), do: "Subscribed"
+
+  defp format_pct(fraction), do: "#{round(fraction * 100)}%"
+
+  defp format_hours(h) when h < 1, do: "#{round(h * 60)}m"
+  defp format_hours(h) when h < 48, do: "#{Float.round(h * 1.0, 1)}h"
+  defp format_hours(h), do: "#{Float.round(h / 24, 1)}d"
 
   defp format_date(nil), do: ""
   defp format_date(dt), do: Calendar.strftime(dt, "%Y-%m-%d")

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -114,6 +114,40 @@ defmodule FountainWeb.Telemetry do
         description: "Agent turns completed"
       ),
 
+      # ── Lifecycle funnel (#282) ───────────────────────────────────────────
+      # Gauges polled from Fountain.Funnel.emit_telemetry/0 so Grafana can
+      # trend stage counts and conversion over time.
+      last_value("fountain.funnel.registered",
+        event_name: [:fountain, :funnel],
+        measurement: :registered,
+        description: "Users registered (all time)"
+      ),
+      last_value("fountain.funnel.verified",
+        event_name: [:fountain, :funnel],
+        measurement: :verified,
+        description: "Users with a verified email"
+      ),
+      last_value("fountain.funnel.onboarded",
+        event_name: [:fountain, :funnel],
+        measurement: :onboarded,
+        description: "Users who completed onboarding"
+      ),
+      last_value("fountain.funnel.activated",
+        event_name: [:fountain, :funnel],
+        measurement: :activated,
+        description: "Users with at least one conversation"
+      ),
+      last_value("fountain.funnel.subscribed",
+        event_name: [:fountain, :funnel],
+        measurement: :subscribed,
+        description: "Users with an active or past_due subscription"
+      ),
+      last_value("fountain.funnel.stalled_verified",
+        event_name: [:fountain, :funnel],
+        measurement: :stalled_verified,
+        description: "Verified users who never started a conversation"
+      ),
+
       # ── VM ────────────────────────────────────────────────────────────────
       last_value("vm.memory.total", unit: {:byte, :kilobyte}),
       last_value("vm.total_run_queue_lengths.total"),
@@ -201,10 +235,14 @@ defmodule FountainWeb.Telemetry do
   end
 
   defp periodic_measurements do
-    [
-      # A module, function and arguments to be invoked periodically.
-      # This function must call :telemetry.execute/3 and a metric must be added above.
-      # {FountainWeb, :count_users, []}
-    ]
+    # Funnel stage gauges (#282). Full-table pass over users every tick —
+    # cheap at current scale; Fountain.Funnel's moduledoc says when to
+    # revisit. Off in test: the poller's Repo calls would race the
+    # SQL Sandbox's connection ownership.
+    if Application.get_env(:fountain, :funnel_poller_enabled, true) do
+      [{Fountain.Funnel, :emit_telemetry, []}]
+    else
+      []
+    end
   end
 end

--- a/apps/fountain/test/fountain/funnel_test.exs
+++ b/apps/fountain/test/fountain/funnel_test.exs
@@ -1,0 +1,177 @@
+defmodule Fountain.FunnelTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Funnel
+
+  defp set!(user, changes), do: Repo.update!(Ecto.Changeset.change(user, changes))
+
+  defp at(hours_ago) do
+    DateTime.utc_now()
+    |> DateTime.add(-round(hours_ago * 3600), :second)
+    |> DateTime.truncate(:second)
+  end
+
+  defp stage(summary, key), do: Enum.find(summary.stages, &(&1.key == key))
+
+  describe "summary_admin/0 — stage counts" do
+    test "empty database: zero counts, nil conversions and medians" do
+      summary = Funnel.summary_admin()
+
+      for s <- summary.stages do
+        assert s.count == 0
+        assert s.conversion == nil
+        assert s.median_hours == nil
+      end
+
+      assert summary.stalled.count == 0
+    end
+
+    test "counts each stage cumulatively" do
+      _registered_only = insert_user()
+      _verified_only = insert_verified_user()
+
+      onboarded = insert_verified_user()
+      set!(onboarded, onboarding_completed_at: at(1))
+
+      activated = insert_verified_user()
+      set!(activated, onboarding_completed_at: at(2))
+      insert_conversation(user_id: activated.id)
+
+      subscribed = insert_verified_user()
+      set!(subscribed, onboarding_completed_at: at(3), subscription_status: "active")
+      insert_conversation(user_id: subscribed.id)
+
+      summary = Funnel.summary_admin()
+
+      assert stage(summary, :registered).count == 5
+      assert stage(summary, :verified).count == 4
+      assert stage(summary, :onboarded).count == 3
+      assert stage(summary, :activated).count == 2
+      assert stage(summary, :subscribed).count == 1
+
+      assert stage(summary, :verified).conversion == 4 / 5
+      assert stage(summary, :onboarded).conversion == 3 / 4
+      assert stage(summary, :activated).conversion == 2 / 3
+      assert stage(summary, :subscribed).conversion == 1 / 2
+    end
+
+    test "past_due counts as subscribed; comped and canceled do not" do
+      set!(insert_verified_user(), subscription_status: "past_due")
+      set!(insert_verified_user(), subscription_status: "comped")
+      set!(insert_verified_user(), subscription_status: "canceled")
+
+      assert stage(Funnel.summary_admin(), :subscribed).count == 1
+    end
+  end
+
+  describe "summary_admin/0 — activation sources" do
+    test "a usage event alone counts as activated (conversation may be deleted)" do
+      user = insert_verified_user()
+      {:ok, _} = Fountain.Billing.record_usage(user.id, "sandbox_provisioned", nil, nil)
+
+      assert stage(Funnel.summary_admin(), :activated).count == 1
+    end
+
+    test "a conversation row alone counts as activated" do
+      user = insert_verified_user()
+      insert_conversation(user_id: user.id)
+
+      assert stage(Funnel.summary_admin(), :activated).count == 1
+    end
+
+    test "non-provisioning usage events do not count as activation" do
+      user = insert_verified_user()
+      {:ok, _} = Fountain.Billing.record_usage(user.id, "turn_started", nil, nil)
+
+      assert stage(Funnel.summary_admin(), :activated).count == 0
+    end
+  end
+
+  describe "summary_admin/0 — timings" do
+    test "median hours between stages" do
+      # Two verified users: 2h and 4h from registration to verification.
+      fast = insert_verified_user()
+      set!(fast, inserted_at: at(10), email_verified_at: at(8))
+
+      slow = insert_verified_user()
+      set!(slow, inserted_at: at(10), email_verified_at: at(6))
+
+      summary = Funnel.summary_admin()
+      assert_in_delta stage(summary, :verified).median_hours, 3.0, 0.01
+    end
+
+    test "activation timing uses the earliest of conversation and usage event" do
+      user = insert_verified_user()
+      set!(user, inserted_at: at(10), email_verified_at: at(9), onboarding_completed_at: at(8))
+
+      # Conversation at -2h, usage event at -5h: the event is earlier and wins.
+      conv = insert_conversation(user_id: user.id)
+      Repo.update!(Ecto.Changeset.change(conv, inserted_at: at(2)))
+
+      {:ok, event} = Fountain.Billing.record_usage(user.id, "sandbox_provisioned", nil, nil)
+      Repo.update!(Ecto.Changeset.change(event, inserted_at: at(5)))
+
+      summary = Funnel.summary_admin()
+      # onboarded at -8h, first activity at -5h → 3h
+      assert_in_delta stage(summary, :activated).median_hours, 3.0, 0.01
+    end
+  end
+
+  describe "summary_admin/0 — stalled breakdown" do
+    test "verified users with no conversation, by how far they got" do
+      nothing = insert_verified_user()
+      set!(nothing, onboarding_state: "step_1")
+
+      agent_builder = insert_verified_user()
+      set!(agent_builder, onboarding_state: "step_3")
+      insert_agent(user_id: agent_builder.id)
+
+      env_builder = insert_verified_user()
+      set!(env_builder, onboarding_state: "step_3")
+      insert_env(user_id: env_builder.id)
+
+      # Activated user is not stalled, whatever else is true.
+      activated = insert_verified_user()
+      insert_conversation(user_id: activated.id)
+
+      # Unverified users are not in the stalled cohort.
+      _unverified = insert_user()
+
+      %{stalled: stalled} = Funnel.summary_admin()
+
+      assert stalled.count == 3
+      assert stalled.by_onboarding_state == %{"step_1" => 1, "step_3" => 2}
+      assert stalled.built_agent == 1
+      assert stalled.built_environment == 1
+      assert stalled.built_nothing == 1
+    end
+  end
+
+  describe "emit_telemetry/0" do
+    test "executes a [:fountain, :funnel] event with all stage counts" do
+      insert_verified_user()
+
+      ref = make_ref()
+      test_pid = self()
+
+      :telemetry.attach(
+        "funnel-test-#{inspect(ref)}",
+        [:fountain, :funnel],
+        fn _event, measurements, _meta, _config -> send(test_pid, {ref, measurements}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach("funnel-test-#{inspect(ref)}") end)
+
+      Funnel.emit_telemetry()
+
+      assert_receive {^ref, measurements}
+      assert measurements.registered == 1
+      assert measurements.verified == 1
+      assert measurements.activated == 0
+      assert measurements.stalled_verified == 1
+      assert Map.has_key?(measurements, :onboarded)
+      assert Map.has_key?(measurements, :subscribed)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -445,6 +445,38 @@ defmodule FountainWeb.AdminLiveTest do
     end
   end
 
+  describe "AdminLive.Index — funnel section" do
+    test "renders stage tiles with counts and conversions", %{conn: conn} do
+      admin = insert_admin()
+      _unverified = insert_user()
+      conn = login_user(conn, admin)
+
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "Funnel"
+      assert html =~ "Registered"
+      assert html =~ "Verified"
+      assert html =~ "Onboarded"
+      assert html =~ "Activated"
+      assert html =~ "Subscribed"
+      # 2 registered, 1 verified → 50% conversion tile
+      assert html =~ "50% of prev"
+    end
+
+    test "shows the stalled-verified breakdown", %{conn: conn} do
+      admin = insert_admin()
+      stalled = insert_verified_user()
+      insert_agent(user_id: stalled.id)
+      conn = login_user(conn, admin)
+
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      # admin + stalled are both verified with no conversations
+      assert html =~ "2 verified users have never started a conversation"
+      assert html =~ "built an agent: 1"
+    end
+  end
+
   describe "AdminLive.Index — search, filter, sort" do
     # The layout renders the logged-in admin's email in the nav, so negative
     # assertions must target a third user, never the admin.

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,6 +23,10 @@ config :fountain, :ueberauth_test_mode, true
 # ExUnit tests don't share counters. Each test runs in its own process.
 config :fountain, :rate_limit_test_isolation, true
 
+# The funnel telemetry poller queries the DB outside any test's SQL Sandbox
+# ownership; keep it off here (Fountain.Funnel is tested directly).
+config :fountain, :funnel_poller_enabled, false
+
 # Fountain.Retry sleeps between attempts; 1ms keeps retry-path tests fast
 # without changing the retry logic under test.
 config :fountain, :retry_base_ms, 1


### PR DESCRIPTION
Closes #282.

Stacked on #340 (shares the admin page); GitHub will retarget to main when that merges.

## What changed

- **`Fountain.Funnel`** — the five stages with counts, conversion from the previous stage, and median inter-stage timing, computed from one pass over `users` plus two grouped min queries. **Activation is the union of the `conversations` table and `sandbox_provisioned` usage events**: conversations can be deleted and metering starts at #213, so either source alone under-counts. Subscribed = `active`/`past_due`; comped is operator-granted and excluded.
- **The stall breakdown** — the "38 verified, 0 conversations" question, made answerable: for verified users with no conversation ever, a count plus how far each got — onboarding-state distribution, built an agent, created an environment, or built nothing.
- **Prometheus gauges** — `fountain.funnel.{registered,verified,onboarded,activated,subscribed,stalled_verified}` fed by the telemetry poller (the previously empty `periodic_measurements` slot), so Grafana can trend the funnel. Off in test via `:funnel_poller_enabled` — the poller's Repo calls would race the SQL Sandbox.
- **Admin panel section** — stage tiles with count / conversion / median time, and an amber stall callout, refreshing on the existing 10s cycle.

## Tests

9 context tests (stage counts, both activation sources, non-provisioning events don't activate, conversions, medians, earliest-source timing, stall breakdown, telemetry event) + 2 LiveView tests. Verified two tests detect regressions by breaking the behavior (usage-event union removed → 3 failures; telemetry emit no-op'd → 1 failure), then restoring.

`mix precommit`: 1572 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)