### PR TITLE
billing: self-serve subscription management — portal coverage and the return path (#284)

### DIFF
--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -31,6 +31,11 @@ defmodule Fountain.Accounts.User do
     # Stripe `created` of the last subscription event applied — the ordering
     # guard's watermark. See Billing.sync_subscription/1.
     field :subscription_synced_at, :utc_datetime
+    # A portal cancellation leaves the subscription "active" with this flag set;
+    # access continues until current_period_end, when `.deleted` fires. Synced
+    # from subscription webhooks so the UI can say "access until <date>".
+    field :cancel_at_period_end, :boolean, default: false
+    field :current_period_end, :utc_datetime
     field :session_version, :integer, default: 0
     field :theme_preference, :string, default: "system"
     field :conversations_roots_only, :boolean, default: false
@@ -92,7 +97,9 @@ defmodule Fountain.Accounts.User do
       :stripe_customer_id,
       :subscription_status,
       :trial_ends_at,
-      :subscription_synced_at
+      :subscription_synced_at,
+      :cancel_at_period_end,
+      :current_period_end
     ])
     |> validate_inclusion(:subscription_status, @subscription_statuses)
   end

--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -387,6 +387,35 @@ defmodule Fountain.Billing do
   end
 
   @doc """
+  Whether the user's Stripe customer has any subscription that can still
+  produce a charge. `{:ok, true}` / `{:ok, false}`, or `{:error, reason}` when
+  Stripe cannot be asked — the caller must not guess.
+
+  This is the guard in front of Checkout. Our local `subscription_status` can
+  read `canceled` while a live subscription still exists in Stripe (a lost or
+  misordered webhook, or a `.deleted` from an old trial subscription landing
+  after the paid one's events) — and a subscription cancelled at period end is
+  still `active` in Stripe until the period ends. Opening Checkout in either
+  state creates a second, duplicate subscription; such a user belongs in the
+  Billing Portal, where the existing subscription can be renewed instead.
+
+  "Live" is the same set `cancel_subscriptions/1` cancels: everything except
+  the terminal `canceled` and `incomplete_expired`.
+  """
+  @spec has_live_subscription?(User.t()) :: {:ok, boolean()} | {:error, term()}
+  def has_live_subscription?(%User{stripe_customer_id: id}) when id in [nil, ""], do: {:ok, false}
+
+  def has_live_subscription?(%User{stripe_customer_id: customer_id}) do
+    case Stripe.Subscription.list(%{customer: customer_id, status: :all, limit: 100}) do
+      {:ok, %{data: subs}} ->
+        {:ok, Enum.any?(subs, &(to_string(&1.status) in @cancellable))}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
   Returns the user with a `stripe_customer_id`, creating the Stripe Customer if
   it is missing.
 
@@ -541,6 +570,20 @@ defmodule Fountain.Billing do
         ts when is_integer(ts) -> DateTime.from_unix!(ts) |> DateTime.truncate(:second)
       end
 
+    # A portal cancellation flips this flag while the status stays "active":
+    # the user keeps access until the period ends and `.deleted` arrives. Synced
+    # so the billing page can say "access until <date>" instead of hard-locking
+    # (or saying nothing) at the webhook. `.deleted` clears it — the pending
+    # cancellation has happened, and a stale flag would haunt a resubscription.
+    cancel_at_period_end =
+      type != "customer.subscription.deleted" and Map.get(sub, :cancel_at_period_end) == true
+
+    current_period_end =
+      case Map.get(sub, :current_period_end) do
+        ts when is_integer(ts) -> DateTime.from_unix!(ts) |> DateTime.truncate(:second)
+        _ -> nil
+      end
+
     event_created = event_created_at(event)
 
     case get_user_by_stripe_customer_id(customer_id) do
@@ -565,7 +608,9 @@ defmodule Fountain.Billing do
           |> User.billing_changeset(%{
             subscription_status: status,
             trial_ends_at: trial_ends_at,
-            subscription_synced_at: event_created || user.subscription_synced_at
+            subscription_synced_at: event_created || user.subscription_synced_at,
+            cancel_at_period_end: cancel_at_period_end,
+            current_period_end: current_period_end
           })
           |> Repo.update()
         end

--- a/apps/fountain/lib/fountain_web/live/billing_live.ex
+++ b/apps/fountain/lib/fountain_web/live/billing_live.ex
@@ -48,6 +48,28 @@ defmodule FountainWeb.Live.BillingLive do
     end
   end
 
+  # Invoices live in the Stripe portal, and a canceled account still needs its
+  # receipts — the Manage Subscription button no longer leads there once the
+  # status leaves active/past_due, so this is the direct route. Portal always,
+  # never Checkout: this must work for an account with no live subscription.
+  @impl true
+  def handle_event("billing_history", _params, socket) do
+    user = socket.assigns.current_user
+    socket = assign(socket, :stripe_url_loading, true)
+    return_url = FountainWeb.Endpoint.url() <> ~p"/account/billing"
+
+    case user.stripe_customer_id && portal_url(user.stripe_customer_id, return_url) do
+      {:ok, url} ->
+        {:noreply, redirect(socket, external: url)}
+
+      _ ->
+        {:noreply,
+         socket
+         |> assign(:stripe_url_loading, false)
+         |> put_flash(:error, "Unable to reach Stripe. Please try again.")}
+    end
+  end
+
   @impl true
   def handle_event("confirm_delete_input", %{"email" => email}, socket) do
     {:noreply, assign(socket, :delete_confirmation, email)}
@@ -112,6 +134,19 @@ defmodule FountainWeb.Live.BillingLive do
         </div>
       <% end %>
 
+      <%!-- cancel-at-period-end notice: canceled in the portal, still inside
+           the paid period. Access continues until the period ends. --%>
+      <%= if canceling_at_period_end?(@current_user) do %>
+        <div
+          class="rounded border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          role="alert"
+        >
+          Your subscription is set to cancel — you keep full access until
+          <%= access_until_text(@current_user) %>. You can renew any time from
+          Manage Subscription.
+        </div>
+      <% end %>
+
       <%!-- Subscription status card --%>
       <div class="rounded-lg border bg-white p-6 shadow-sm">
         <h2 class="mb-4 text-lg font-medium">Subscription</h2>
@@ -139,6 +174,14 @@ defmodule FountainWeb.Live.BillingLive do
               </dd>
             </div>
           <% end %>
+          <%= if canceling_at_period_end?(@current_user) do %>
+            <div class="flex items-center justify-between">
+              <dt class="text-sm text-gray-500">Access until</dt>
+              <dd class="text-sm font-medium">
+                <%= access_until_text(@current_user) %>
+              </dd>
+            </div>
+          <% end %>
           <%= if @current_user.subscription_status == "active" do %>
             <div class="flex items-center justify-between">
               <dt class="text-sm text-gray-500">Billing period</dt>
@@ -150,7 +193,7 @@ defmodule FountainWeb.Live.BillingLive do
           <% end %>
         </dl>
 
-        <div class="mt-6">
+        <div class="mt-6 flex items-center gap-4">
           <button
             phx-click="manage_subscription"
             disabled={@stripe_url_loading}
@@ -162,6 +205,20 @@ defmodule FountainWeb.Live.BillingLive do
               Upgrade
             <% end %>
           </button>
+          <%!-- Invoices live in the portal. Manage Subscription already leads
+               there for active/past_due; every other status with a Stripe
+               customer (canceled above all — they paid, they need receipts)
+               gets a direct route. --%>
+          <%= if @current_user.stripe_customer_id &&
+                   @current_user.subscription_status not in ~w(active past_due) do %>
+            <button
+              phx-click="billing_history"
+              disabled={@stripe_url_loading}
+              class="text-sm font-medium text-indigo-600 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Billing history &amp; invoices
+            </button>
+          <% end %>
         </div>
       </div>
 
@@ -248,43 +305,83 @@ defmodule FountainWeb.Live.BillingLive do
     return_url = FountainWeb.Endpoint.url() <> ~p"/account/billing"
 
     if user.subscription_status in ~w(active past_due) and user.stripe_customer_id do
-      case Stripe.BillingPortal.Session.create(%{
-             customer: user.stripe_customer_id,
-             return_url: return_url
-           }) do
-        {:ok, session} -> {:ok, session.url}
-        error -> error
-      end
+      portal_url(user.stripe_customer_id, return_url)
     else
-      price_id = Application.get_env(:fountain, :stripe_price_id, "")
-
-      # Never fall back to `customer_email`. That makes Stripe mint its own
-      # Customer whose id we never learn, so the subscription webhook matches no
-      # user: the card is charged and the account is never activated. Creating
-      # the Customer first means the id is always ours.
-      with {:ok, user} <- Billing.ensure_stripe_customer(user) do
-        params = %{
-          mode: :subscription,
-          line_items: [%{price: price_id, quantity: 1}],
-          success_url: return_url <> "?checkout=success",
-          cancel_url: return_url,
-          customer: user.stripe_customer_id,
-          # Second route back to the user if the customer link is ever lost —
-          # checkout.session.completed carries this through.
-          client_reference_id: user.id,
-          # Show "Add promotion code" link on the Checkout page. Promotion codes
-          # are user-facing redeemable strings tied to coupons created in the
-          # Stripe dashboard. Without this flag, the field is hidden by default.
-          allow_promotion_codes: true
-        }
-
-        case Stripe.Checkout.Session.create(params) do
-          {:ok, session} -> {:ok, session.url}
-          error -> error
-        end
-      end
+      checkout_or_portal(user, return_url)
     end
   end
+
+  # An existing customer may still hold a live subscription even when our local
+  # status says otherwise — most notably one cancelled at period end, which
+  # Stripe keeps "active" until the period actually ends (and a lost webhook
+  # leaves the same mismatch). Checkout would open a second, duplicate
+  # subscription on top of it, so those users go to the Portal, where the
+  # existing subscription can be renewed instead. A fresh customer has no
+  # subscriptions to duplicate, so no lookup is needed.
+  defp checkout_or_portal(%{stripe_customer_id: id} = user, return_url)
+       when is_binary(id) and id != "" do
+    case Billing.has_live_subscription?(user) do
+      {:ok, true} -> portal_url(id, return_url)
+      {:ok, false} -> checkout_url(user, return_url)
+      {:error, _} = error -> error
+    end
+  end
+
+  defp checkout_or_portal(user, return_url) do
+    # Never fall back to `customer_email`. That makes Stripe mint its own
+    # Customer whose id we never learn, so the subscription webhook matches no
+    # user: the card is charged and the account is never activated. Creating
+    # the Customer first means the id is always ours.
+    with {:ok, user} <- Billing.ensure_stripe_customer(user) do
+      checkout_url(user, return_url)
+    end
+  end
+
+  defp portal_url(customer_id, return_url) do
+    case Stripe.BillingPortal.Session.create(%{
+           customer: customer_id,
+           return_url: return_url
+         }) do
+      {:ok, session} -> {:ok, session.url}
+      error -> error
+    end
+  end
+
+  defp checkout_url(user, return_url) do
+    price_id = Application.get_env(:fountain, :stripe_price_id, "")
+
+    params = %{
+      mode: :subscription,
+      line_items: [%{price: price_id, quantity: 1}],
+      success_url: return_url <> "?checkout=success",
+      cancel_url: return_url,
+      customer: user.stripe_customer_id,
+      # Second route back to the user if the customer link is ever lost —
+      # checkout.session.completed carries this through.
+      client_reference_id: user.id,
+      # Show "Add promotion code" link on the Checkout page. Promotion codes
+      # are user-facing redeemable strings tied to coupons created in the
+      # Stripe dashboard. Without this flag, the field is hidden by default.
+      allow_promotion_codes: true
+    }
+
+    case Stripe.Checkout.Session.create(params) do
+      {:ok, session} -> {:ok, session.url}
+      error -> error
+    end
+  end
+
+  # Only an active subscription can be pending cancellation; once `.deleted`
+  # lands the status is canceled and the flag is cleared by the sync.
+  defp canceling_at_period_end?(user) do
+    user.subscription_status == "active" and user.cancel_at_period_end
+  end
+
+  defp access_until_text(%{current_period_end: %DateTime{} = ends_at}) do
+    Calendar.strftime(ends_at, "%B %-d, %Y")
+  end
+
+  defp access_until_text(_), do: "the end of the current billing period"
 
   defp trial_countdown_text(%{trial_ends_at: nil}), do: "Trial active"
 

--- a/apps/fountain/priv/repo/migrations/20260802100000_add_cancel_at_period_end_to_users.exs
+++ b/apps/fountain/priv/repo/migrations/20260802100000_add_cancel_at_period_end_to_users.exs
@@ -1,0 +1,15 @@
+defmodule Fountain.Repo.Migrations.AddCancelAtPeriodEndToUsers do
+  use Ecto.Migration
+
+  # A portal cancellation sets cancel_at_period_end on the Stripe subscription
+  # while its status stays "active" until the period actually ends. Storing the
+  # flag (and the period end) lets the billing page say "access until <date>"
+  # instead of pretending nothing happened — without it, the first sign of the
+  # cancellation the user sees is the hard lock when `.deleted` finally fires.
+  def change do
+    alter table(:users) do
+      add :cancel_at_period_end, :boolean, default: false, null: false
+      add :current_period_end, :utc_datetime
+    end
+  end
+end

--- a/apps/fountain/test/fountain/billing_test.exs
+++ b/apps/fountain/test/fountain/billing_test.exs
@@ -260,6 +260,181 @@ defmodule Fountain.BillingTest do
     end
   end
 
+  describe "sync_subscription/1 — cancel at period end" do
+    setup do
+      user = insert_verified_user()
+
+      user =
+        Repo.update!(
+          Ecto.Changeset.change(user,
+            stripe_customer_id: "cus_cap",
+            subscription_status: "active"
+          )
+        )
+
+      {:ok, user: user}
+    end
+
+    test "a portal cancellation keeps the account active until period end", %{user: _user} do
+      period_end = 1_800_000_000
+
+      event = %Stripe.Event{
+        type: "customer.subscription.updated",
+        data: %{
+          object: %{
+            customer: "cus_cap",
+            status: "active",
+            trial_end: nil,
+            cancel_at_period_end: true,
+            current_period_end: period_end
+          }
+        }
+      }
+
+      assert {:ok, updated} = Billing.sync_subscription(event)
+
+      # The webhook must not hard-lock the account: Stripe keeps the
+      # subscription "active" until the period ends, and so do we.
+      assert updated.subscription_status == "active"
+      assert Billing.check_active(updated) == :ok
+
+      # ...but the pending cancellation and its date are recorded for the UI.
+      assert updated.cancel_at_period_end
+      assert updated.current_period_end == DateTime.from_unix!(period_end)
+    end
+
+    test "renewing from the portal clears the pending cancellation", %{user: user} do
+      Repo.update!(Ecto.Changeset.change(user, cancel_at_period_end: true))
+
+      event = %Stripe.Event{
+        type: "customer.subscription.updated",
+        data: %{
+          object: %{
+            customer: "cus_cap",
+            status: "active",
+            trial_end: nil,
+            cancel_at_period_end: false,
+            current_period_end: 1_800_000_000
+          }
+        }
+      }
+
+      assert {:ok, updated} = Billing.sync_subscription(event)
+      assert updated.subscription_status == "active"
+      refute updated.cancel_at_period_end
+    end
+
+    test "subscription.deleted locks the account and clears the pending flag", %{user: user} do
+      Repo.update!(Ecto.Changeset.change(user, cancel_at_period_end: true))
+
+      # Stripe's .deleted payload still carries cancel_at_period_end: true from
+      # the portal cancellation. It must not survive: a resubscription would
+      # otherwise show as "set to cancel" forever.
+      event = %Stripe.Event{
+        type: "customer.subscription.deleted",
+        data: %{
+          object: %{
+            customer: "cus_cap",
+            status: "canceled",
+            trial_end: nil,
+            cancel_at_period_end: true
+          }
+        }
+      }
+
+      assert {:ok, updated} = Billing.sync_subscription(event)
+      assert updated.subscription_status == "canceled"
+      refute updated.cancel_at_period_end
+      assert {:error, :subscription_required} = Billing.check_active(updated)
+    end
+
+    test "events without the field (older payload shapes) default to false", %{user: _user} do
+      event = %Stripe.Event{
+        type: "customer.subscription.updated",
+        data: %{object: %{customer: "cus_cap", status: "active", trial_end: nil}}
+      }
+
+      assert {:ok, updated} = Billing.sync_subscription(event)
+      refute updated.cancel_at_period_end
+      assert updated.current_period_end == nil
+    end
+  end
+
+  describe "sync_subscription/1 — the return path for canceled" do
+    test "a canceled account that buys again is re-activated by the webhook" do
+      user = insert_verified_user()
+
+      user =
+        Repo.update!(
+          Ecto.Changeset.change(user,
+            stripe_customer_id: "cus_return",
+            subscription_status: "canceled"
+          )
+        )
+
+      assert {:error, :subscription_required} = Billing.check_active(user)
+
+      # Checkout completed -> Stripe opens a fresh subscription and sends this.
+      event = %Stripe.Event{
+        type: "customer.subscription.created",
+        data: %{object: %{customer: "cus_return", status: "active", trial_end: nil}}
+      }
+
+      assert {:ok, updated} = Billing.sync_subscription(event)
+      assert updated.id == user.id
+      assert updated.subscription_status == "active"
+      assert Billing.check_active(updated) == :ok
+    end
+  end
+
+  describe "has_live_subscription?/1" do
+    test "false without a Stripe customer — nothing to duplicate" do
+      assert {:ok, false} = Billing.has_live_subscription?(insert_verified_user())
+    end
+
+    test "true when a subscription canceled at period end is still live" do
+      user = user_with_customer("cus_live_cap")
+
+      stub(Stripe.Subscription, :list, fn %{customer: "cus_live_cap", status: :all} ->
+        # cancel_at_period_end keeps the Stripe status "active" until the
+        # period ends — exactly the subscription Checkout would duplicate.
+        {:ok,
+         %{
+           data: [
+             %Stripe.Subscription{id: "sub_cap", status: "active", cancel_at_period_end: true}
+           ],
+           has_more: false
+         }}
+      end)
+
+      assert {:ok, true} = Billing.has_live_subscription?(user)
+    end
+
+    test "false when every subscription is terminal" do
+      user = user_with_customer("cus_all_dead")
+
+      stub(Stripe.Subscription, :list, fn _ ->
+        {:ok,
+         %{
+           data: [
+             %Stripe.Subscription{id: "sub_c", status: "canceled"},
+             %Stripe.Subscription{id: "sub_ie", status: "incomplete_expired"}
+           ],
+           has_more: false
+         }}
+      end)
+
+      assert {:ok, false} = Billing.has_live_subscription?(user)
+    end
+
+    test "a Stripe failure is reported, not guessed at" do
+      user = user_with_customer("cus_down")
+      stub(Stripe.Subscription, :list, fn _ -> {:error, :stripe_down} end)
+
+      assert {:error, :stripe_down} = Billing.has_live_subscription?(user)
+    end
+  end
+
   describe "create_stripe_customer/1" do
     test "on Stripe success: stores stripe_customer_id on user and sets trial_ends_at ~14 days from now" do
       user = insert_verified_user()
@@ -408,6 +583,11 @@ defmodule Fountain.BillingTest do
   defp user_with_status(status) do
     user = insert_verified_user()
     Ecto.Changeset.change(user, subscription_status: status) |> Repo.update!()
+  end
+
+  defp user_with_customer(customer_id) do
+    user = insert_verified_user()
+    Ecto.Changeset.change(user, stripe_customer_id: customer_id) |> Repo.update!()
   end
 
   defp insert_event(user, event_type, inserted_at, metadata \\ %{}) do

--- a/apps/fountain/test/fountain_web/live/billing_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/billing_live_test.exs
@@ -32,6 +32,20 @@ defmodule FountainWeb.BillingLiveTest do
     :ok
   end
 
+  defp billing_state(status, customer_id) do
+    user = insert_verified_user()
+
+    {:ok, user} =
+      user
+      |> Fountain.Accounts.User.billing_changeset(%{
+        subscription_status: status,
+        stripe_customer_id: customer_id
+      })
+      |> Fountain.Repo.update()
+
+    user
+  end
+
   describe "upgrade with no existing Stripe customer" do
     test "creates the customer first and never passes customer_email", %{conn: conn} do
       user = insert_verified_user()
@@ -80,6 +94,12 @@ defmodule FountainWeb.BillingLiveTest do
 
       test_pid = self()
 
+      # An existing customer is checked for live subscriptions before Checkout
+      # is opened — none here, so Checkout proceeds.
+      stub(Stripe.Subscription, :list, fn %{customer: "cus_already"} ->
+        {:ok, %{data: [], has_more: false}}
+      end)
+
       stub(Stripe.Checkout.Session, :create, fn params ->
         send(test_pid, {:checkout_params, params})
         {:ok, %{url: "https://checkout.test"}}
@@ -116,6 +136,156 @@ defmodule FountainWeb.BillingLiveTest do
 
       assert_receive {:portal_params, params}
       assert params.customer == "cus_active"
+    end
+  end
+
+  describe "past_due subscribers" do
+    test "are sent to the billing portal — the fix lives there", %{conn: conn} do
+      user = billing_state("past_due", "cus_pastdue")
+
+      test_pid = self()
+
+      stub(Stripe.BillingPortal.Session, :create, fn params ->
+        send(test_pid, {:portal_params, params})
+        {:ok, %{url: "https://portal.test"}}
+      end)
+
+      # No stub on Checkout.Session.create — a past_due user already has a
+      # subscription; opening Checkout would duplicate it.
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      render_click(lv, "manage_subscription", %{})
+
+      assert_receive {:portal_params, params}
+      assert params.customer == "cus_pastdue"
+    end
+  end
+
+  describe "canceled subscribers" do
+    test "with no live subscription left go through Checkout again", %{conn: conn} do
+      user = billing_state("canceled", "cus_gone")
+
+      test_pid = self()
+
+      stub(Stripe.Subscription, :list, fn %{customer: "cus_gone", status: :all} ->
+        {:ok, %{data: [%Stripe.Subscription{id: "sub_old", status: "canceled"}], has_more: false}}
+      end)
+
+      stub(Stripe.Checkout.Session, :create, fn params ->
+        send(test_pid, {:checkout_params, params})
+        {:ok, %{url: "https://checkout.test"}}
+      end)
+
+      # No stub on Stripe.Customer.create — the customer must be reused, and
+      # none on BillingPortal.Session — this user's way back in is Checkout.
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      render_click(lv, "manage_subscription", %{})
+
+      assert_receive {:checkout_params, params}
+      assert params.customer == "cus_gone"
+      assert params.client_reference_id == user.id
+      assert params.mode == :subscription
+    end
+
+    test "with a subscription still canceling at period end get the portal, never a duplicate",
+         %{conn: conn} do
+      # Local status says canceled, but Stripe still holds a live subscription
+      # (canceled at period end -> still "active" until the period ends).
+      # Checkout here would open a second subscription on top of it.
+      user = billing_state("canceled", "cus_still_live")
+
+      test_pid = self()
+
+      stub(Stripe.Subscription, :list, fn %{customer: "cus_still_live", status: :all} ->
+        {:ok,
+         %{
+           data: [
+             %Stripe.Subscription{id: "sub_cap", status: "active", cancel_at_period_end: true}
+           ],
+           has_more: false
+         }}
+      end)
+
+      stub(Stripe.BillingPortal.Session, :create, fn params ->
+        send(test_pid, {:portal_params, params})
+        {:ok, %{url: "https://portal.test"}}
+      end)
+
+      # No stub on Checkout.Session.create — opening one IS the orphaned
+      # duplicate subscription, so a call here must fail the test.
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      render_click(lv, "manage_subscription", %{})
+
+      assert_receive {:portal_params, params}
+      assert params.customer == "cus_still_live"
+    end
+
+    test "can open the portal for billing history and invoices", %{conn: conn} do
+      user = billing_state("canceled", "cus_receipts")
+
+      test_pid = self()
+
+      stub(Stripe.BillingPortal.Session, :create, fn params ->
+        send(test_pid, {:portal_params, params})
+        {:ok, %{url: "https://portal.test/history"}}
+      end)
+
+      {:ok, lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      assert html =~ "Billing history"
+
+      render_click(lv, "billing_history", %{})
+
+      assert_receive {:portal_params, params}
+      assert params.customer == "cus_receipts"
+    end
+
+    test "the billing history link is hidden without a Stripe customer", %{conn: conn} do
+      user = insert_verified_user()
+      refute user.stripe_customer_id
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      refute html =~ "Billing history"
+    end
+
+    test "active users reach invoices via Manage Subscription, not a second link",
+         %{conn: conn} do
+      user = billing_state("active", "cus_active_inv")
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      assert html =~ "Manage Subscription"
+      refute html =~ "Billing history"
+    end
+  end
+
+  describe "cancel at period end" do
+    test "the page says access continues until the period end date", %{conn: conn} do
+      user = billing_state("active", "cus_cap_ui")
+
+      {:ok, user} =
+        user
+        |> Fountain.Accounts.User.billing_changeset(%{
+          cancel_at_period_end: true,
+          current_period_end: ~U[2026-08-30 12:00:00Z]
+        })
+        |> Fountain.Repo.update()
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+      # Not hard-locked, and not silent either: the pending cancellation is
+      # named, dated, and the way back (the portal) is still the primary button.
+      assert html =~ "you keep full access until"
+      assert html =~ "Access until"
+      assert html =~ "August 30, 2026"
+      assert html =~ "Manage Subscription"
+      refute html =~ "requires attention"
+    end
+
+    test "an active subscription with no pending cancellation shows none of it",
+         %{conn: conn} do
+      user = billing_state("active", "cus_no_cap")
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      refute html =~ "Access until"
+      refute html =~ "set to cancel"
     end
   end
 


### PR DESCRIPTION
Closes #284.

This was partly a verification ticket. Per item, what was already correct (now proven by a test) vs actually fixed:

## 1. The return path for `canceled` — partly proven, partly fixed

**Proven:** a canceled user is routed through Checkout (existing customer reused, `client_reference_id` set), and the `customer.subscription.created` webhook re-activates the account (`canceled → active`, gate reopens). Tests: `billing_live_test.exs` "canceled subscribers with no live subscription left go through Checkout again", `billing_test.exs` "a canceled account that buys again is re-activated by the webhook".

**Fixed:** the orphaned-duplicate hazard was real. A user whose local status reads `canceled` can still hold a live subscription in Stripe — above all one canceled at period end, which Stripe keeps `active` until the period actually ends (lost/misordered webhooks produce the same mismatch). Checkout in that state opens a second, duplicate subscription. New guard: `Billing.has_live_subscription?/1` (same "live" set `cancel_subscriptions/1` uses — everything except terminal `canceled`/`incomplete_expired`) runs before Checkout for any existing customer; if anything live is found, the user gets the Billing Portal instead, where the existing subscription can be renewed. A Stripe failure surfaces as an error rather than guessing. Fresh customers skip the lookup (nothing to duplicate).

## 2. Cancel-at-period-end — sync proven, UI fixed

**Proven:** the webhook does not hard-lock. `customer.subscription.updated` with `status: "active", cancel_at_period_end: true` keeps `subscription_status` `active` and `Billing.check_active/1` returns `:ok`; the eventual `.deleted` is what locks. Test: "a portal cancellation keeps the account active until period end".

**Fixed:** nothing recorded or showed the pending cancellation — the first sign the user saw was the hard lock. Added `users.cancel_at_period_end` + `users.current_period_end` (migration), synced from subscription webhooks (`.deleted` clears the flag so it can't haunt a resubscription; renewal clears it too). BillingLive now shows an amber "your subscription is set to cancel — you keep full access until <date>" notice plus an "Access until <date>" row, with Manage Subscription (→ portal) as the way to renew.

## 3. Invoice/receipt access for every status that ever paid — fixed

`active`/`past_due` already reached invoices via Manage Subscription → portal. Everyone else (canceled above all) had no route. New "Billing history & invoices" link opens a portal session directly for any user with a Stripe customer whose primary button isn't already the portal; hidden when there's no customer (nothing to show).

## 4. Tests via the Mimic'd portal/session modules per status branch — added

- trialing, no customer → Checkout, customer created first (pre-existing)
- trialing, existing customer, nothing live → Checkout, customer reused (updated for the new guard)
- `active` → portal (pre-existing); `past_due` → portal (new)
- `canceled`, nothing live → Checkout; `canceled` but live canceled-at-period-end sub in Stripe → portal, with `Checkout.Session.create` deliberately unstubbed so a duplicate subscription fails the test (new)
- `billing_history` → portal session for the canceled user (new)
- sync branches: flag set / cleared on renewal / cleared on `.deleted` / absent-field default; re-activation webhook; `has_live_subscription?/1` all four branches (new)

## Regression verification

Two tests were verified to detect their regression by temporarily breaking the code, watching the test fail, and restoring:

1. Forcing the sync to drop `cancel_at_period_end` (hard-coding `false`) fails **"a portal cancellation keeps the account active until period end"**.
2. Removing the pre-Checkout live-subscription guard fails **"canceled subscribers with a subscription still canceling at period end get the portal, never a duplicate"**.

## Test summary

`mix precommit` passes in full (compile `--warnings-as-errors`, format, credo `--strict`, dialyzer, 1577 tests + 5 doctests + 3 properties, 0 failures). No real Stripe calls anywhere — Mimic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)