### PR TITLE
accounts: self-serve data export (#288)

### DIFF
--- a/apps/fountain/lib/fountain/exports.ex
+++ b/apps/fountain/lib/fountain/exports.ex
@@ -1,0 +1,436 @@
+defmodule Fountain.Exports do
+  @moduledoc """
+  Self-serve account data export — the other half of leave-ability (#288).
+
+  Deletion is self-serve (`Fountain.Accounts.Deletion`); this makes the exit
+  story export-then-delete rather than delete-and-trust. A user requests an
+  export from the account page, `Fountain.Workers.AccountExport` builds one
+  JSON document covering everything the account owns, and the account page
+  offers a download until the artifact expires.
+
+  ## What is included
+
+  Agents, environments, vaults, conversations with their turns and log output,
+  and the account's own audit trail.
+
+  ## What is deliberately excluded
+
+  **Decrypted secret values.** Environment and vault secrets were write-only on
+  the way in and stay that way on the way out — the export carries secret
+  *names* only, never plaintext values and never ciphertext. This is stated in
+  the UI, not just here.
+
+  ## Tenant scoping
+
+  Every query in `build/1` is scoped by `user_id` — either directly or via a
+  join through `conversations.user_id`. Nothing in this module calls an
+  `_unsafe_` function, and the artifact itself is only readable through
+  `get_downloadable_export/2`, which is user-scoped.
+
+  ## Storage
+
+  The artifact is a gzipped JSON blob in Postgres, following the existing
+  pattern for generated binaries (`agent_avatars`, `turn_images`): the app has
+  no object store and its local disk is ephemeral across deploys. Expiry
+  (`@ttl_hours`) plus one-export-per-user keeps the table bounded; expired rows
+  are purged by the worker on each run.
+
+  ## Rate limit
+
+  Once per hour per user, enforced against the export rows themselves rather
+  than `FountainWeb.Plugs.RateLimit`: that limiter is per-IP, per-node and
+  resets on deploy, which is right for anti-runaway request limiting but wrong
+  for a durable per-user business rule on an expensive operation. Anchoring on
+  the row's `inserted_at` survives restarts and is naturally isolated under the
+  SQL sandbox in tests (no `:rate_limit_test_isolation` needed).
+  """
+
+  import Ecto.Query
+
+  alias Fountain.Accounts.User
+  alias Fountain.Agents
+  alias Fountain.Audit
+  alias Fountain.Conversations.{Conversation, LogEvent, Turn}
+  alias Fountain.Environments
+  alias Fountain.Exports.Export
+  alias Fountain.Repo
+  alias Fountain.Vaults
+
+  @rate_window_seconds 3600
+  @ttl_hours 24
+
+  @doc "Seconds a user must wait between export requests."
+  def rate_window_seconds, do: @rate_window_seconds
+
+  @doc "Hours a completed export stays downloadable."
+  def ttl_hours, do: @ttl_hours
+
+  # ── requesting ─────────────────────────────────────────────────────────────
+
+  @doc """
+  Request an export for `user`: rate-check, replace any previous export rows,
+  insert a pending row and enqueue the build job.
+
+  Returns `{:ok, export}` or `{:error, {:rate_limited, retry_after_seconds}}`.
+
+  Options:
+
+    * `:actor` — for the audit trail, defaults to `"self"`.
+    * `:request_ip` — passed through to the audit event.
+  """
+  @spec request_export(User.t(), keyword()) ::
+          {:ok, Export.t()} | {:error, {:rate_limited, pos_integer()}} | {:error, term()}
+  def request_export(%User{id: user_id} = user, opts \\ []) do
+    case seconds_until_allowed(user_id) do
+      0 ->
+        do_request(user, opts)
+
+      retry_after ->
+        {:error, {:rate_limited, retry_after}}
+    end
+  end
+
+  defp do_request(%User{id: user_id} = user, opts) do
+    # Replace rather than accumulate: at most one export artifact per user.
+    # This runs only after the rate check passed, so the new row becomes the
+    # rate-limit anchor for the next hour.
+    Repo.delete_all(from e in Export, where: e.user_id == ^user_id)
+
+    with {:ok, export} <-
+           %Export{}
+           |> Export.changeset(%{status: "pending", user_id: user_id})
+           |> Repo.insert(),
+         {:ok, _job} <- Fountain.Workers.AccountExport.enqueue(export) do
+      Audit.record(%{
+        user_id: user_id,
+        action: "account.export_requested",
+        resource_type: "export",
+        resource_id: export.id,
+        actor: Keyword.get(opts, :actor, "self"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{"email" => user.email}
+      })
+
+      {:ok, export}
+    end
+  end
+
+  # 0 when a request is allowed now, otherwise seconds until it is.
+  defp seconds_until_allowed(user_id) do
+    last =
+      Repo.one(
+        from e in Export,
+          where: e.user_id == ^user_id,
+          order_by: [desc: e.inserted_at],
+          limit: 1,
+          select: e.inserted_at
+      )
+
+    case last do
+      nil ->
+        0
+
+      inserted_at ->
+        elapsed = DateTime.diff(DateTime.utc_now(), inserted_at, :second)
+        max(@rate_window_seconds - elapsed, 0)
+    end
+  end
+
+  # ── reading ────────────────────────────────────────────────────────────────
+
+  @doc "The user's current export row (any status), or nil."
+  @spec latest_export(Ecto.UUID.t()) :: Export.t() | nil
+  def latest_export(user_id) when is_binary(user_id) do
+    Repo.one(
+      from e in Export,
+        where: e.user_id == ^user_id,
+        order_by: [desc: e.inserted_at],
+        limit: 1,
+        select: %{e | payload: nil}
+    )
+  end
+
+  @doc "Get an export scoped to its owner. Returns nil on wrong owner or missing id."
+  @spec get_export(Ecto.UUID.t(), Ecto.UUID.t()) :: Export.t() | nil
+  def get_export(id, user_id) when is_binary(user_id) do
+    Repo.get_by(Export, id: id, user_id: user_id)
+  end
+
+  @doc """
+  Fetch an export for download: owner-scoped, completed, and not expired.
+
+  Returns `{:ok, export}` (with payload) or `{:error, :not_found}` — a wrong
+  tenant, a missing row, a pending/failed export and an expired one are all the
+  same answer on purpose.
+  """
+  @spec get_downloadable_export(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, Export.t()} | {:error, :not_found}
+  def get_downloadable_export(id, user_id) when is_binary(user_id) do
+    now = DateTime.utc_now()
+
+    case Repo.get_by(Export, id: id, user_id: user_id) do
+      %Export{status: "completed", payload: payload, expires_at: %DateTime{} = expires_at} =
+          export
+      when is_binary(payload) ->
+        if DateTime.compare(expires_at, now) == :gt do
+          {:ok, export}
+        else
+          {:error, :not_found}
+        end
+
+      _ ->
+        {:error, :not_found}
+    end
+  end
+
+  @doc "True when `export` is past its expiry (or has none yet)."
+  def expired?(%Export{expires_at: nil}), do: true
+
+  def expired?(%Export{expires_at: expires_at}),
+    do: DateTime.compare(expires_at, DateTime.utc_now()) != :gt
+
+  # ── lifecycle (worker-facing) ──────────────────────────────────────────────
+
+  @doc "Mark `export` completed with the gzipped `payload` (raw size `raw_bytes`)."
+  def complete_export(%Export{} = export, payload, raw_bytes) when is_binary(payload) do
+    expires_at =
+      DateTime.utc_now()
+      |> DateTime.add(@ttl_hours * 3600, :second)
+      |> DateTime.truncate(:second)
+
+    export
+    |> Export.changeset(%{
+      status: "completed",
+      payload: payload,
+      byte_size: raw_bytes,
+      expires_at: expires_at
+    })
+    |> Repo.update()
+    |> tap(fn
+      {:ok, updated} -> broadcast(updated.user_id)
+      _ -> :ok
+    end)
+  end
+
+  @doc "Mark `export` failed."
+  def fail_export(%Export{} = export, reason) do
+    export
+    |> Export.changeset(%{status: "failed", error: String.slice(inspect(reason), 0, 250)})
+    |> Repo.update()
+    |> tap(fn
+      {:ok, updated} -> broadcast(updated.user_id)
+      _ -> :ok
+    end)
+  end
+
+  @doc "Delete exports past their expiry. Returns the number deleted."
+  def purge_expired do
+    now = DateTime.utc_now()
+
+    {count, _} =
+      Repo.delete_all(
+        from e in Export, where: not is_nil(e.expires_at) and e.expires_at <= ^now
+      )
+
+    count
+  end
+
+  @doc "PubSub topic the account page subscribes to for export status changes."
+  def topic(user_id), do: "account_exports:#{user_id}"
+
+  defp broadcast(user_id) when is_binary(user_id) do
+    Phoenix.PubSub.broadcast(Fountain.PubSub, topic(user_id), {:export_updated, user_id})
+  end
+
+  # ── building the document ──────────────────────────────────────────────────
+
+  @doc """
+  Build the export document for `user_id` as a plain map, ready for JSON
+  encoding. Every query is tenant-scoped; secret **values** never appear —
+  only secret names.
+  """
+  @spec build(Ecto.UUID.t()) :: map()
+  def build(user_id) when is_binary(user_id) do
+    user = Repo.get!(User, user_id)
+
+    %{
+      "format" => "fountain.account-export",
+      "version" => 1,
+      "generated_at" => DateTime.utc_now(),
+      "notes" => %{
+        "secrets" =>
+          "Secret values are deliberately excluded. They were write-only on " <>
+            "the way in and stay that way on the way out; only secret names " <>
+            "are listed."
+      },
+      "account" => account_section(user),
+      "agents" => agents_section(user_id),
+      "environments" => environments_section(user_id),
+      "vaults" => vaults_section(user_id),
+      "conversations" => conversations_section(user_id),
+      "audit_trail" => audit_section(user_id)
+    }
+  end
+
+  defp account_section(%User{} = user) do
+    %{
+      "id" => user.id,
+      "email" => user.email,
+      "role" => user.role,
+      "subscription_status" => user.subscription_status,
+      "trial_ends_at" => user.trial_ends_at,
+      "email_verified_at" => user.email_verified_at,
+      "created_at" => user.inserted_at
+    }
+  end
+
+  defp agents_section(user_id) do
+    user_id
+    |> Agents.list_agents([])
+    |> Enum.map(fn agent ->
+      %{
+        "id" => agent.id,
+        "name" => agent.name,
+        "description" => agent.description,
+        "system" => agent.system,
+        "model" => agent.model,
+        "runtime" => agent.runtime,
+        "skills" => agent.skills,
+        "mcp_servers" => agent.mcp_servers,
+        "metadata" => agent.metadata,
+        "allowed_vault_ids" => agent.allowed_vault_ids,
+        "environment_id" => agent.environment_id,
+        "created_at" => agent.inserted_at,
+        "updated_at" => agent.updated_at
+      }
+    end)
+  end
+
+  defp environments_section(user_id) do
+    user_id
+    |> Environments.list_environments()
+    |> Enum.map(fn env ->
+      %{
+        "id" => env.id,
+        "name" => env.name,
+        "packages" => env.packages,
+        "env_vars" => env.env_vars,
+        "setup_script" => env.setup_script,
+        "networking_type" => env.networking_type,
+        "networking_config" => env.networking_config,
+        "repositories" => env.repositories,
+        "metadata" => env.metadata,
+        # Names only — values are write-only by design.
+        "secret_keys" => env |> Environments.list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
+        "created_at" => env.inserted_at,
+        "updated_at" => env.updated_at
+      }
+    end)
+  end
+
+  defp vaults_section(user_id) do
+    user_id
+    |> Vaults.list_vaults()
+    |> Enum.map(fn vault ->
+      %{
+        "id" => vault.id,
+        "name" => vault.name,
+        "description" => vault.description,
+        "metadata" => vault.metadata,
+        # Names only — values are write-only by design.
+        "secret_keys" => vault |> Vaults.list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
+        "created_at" => vault.inserted_at,
+        "updated_at" => vault.updated_at
+      }
+    end)
+  end
+
+  defp conversations_section(user_id) do
+    conversations =
+      Repo.all(
+        from c in Conversation,
+          where: c.user_id == ^user_id,
+          order_by: [asc: c.inserted_at, asc: c.id]
+      )
+
+    turns_by_conv =
+      Repo.all(
+        from t in Turn,
+          join: c in Conversation,
+          on: t.conversation_id == c.id,
+          where: c.user_id == ^user_id,
+          order_by: [asc: t.conversation_id, asc: t.turn_number]
+      )
+      |> Enum.group_by(& &1.conversation_id)
+
+    logs_by_conv =
+      Repo.all(
+        from le in LogEvent,
+          join: c in Conversation,
+          on: le.conversation_id == c.id,
+          where: c.user_id == ^user_id,
+          order_by: [asc: le.conversation_id, asc: le.id]
+      )
+      |> Enum.group_by(& &1.conversation_id)
+
+    Enum.map(conversations, fn conv ->
+      %{
+        "id" => conv.id,
+        "title" => conv.title,
+        "status" => conv.status,
+        "runtime" => conv.runtime,
+        "source" => conv.source,
+        "agent_id" => conv.agent_id,
+        "vault_id" => conv.vault_id,
+        "parent_conversation_id" => conv.parent_conversation_id,
+        "created_at" => conv.inserted_at,
+        "updated_at" => conv.updated_at,
+        "turns" => Enum.map(Map.get(turns_by_conv, conv.id, []), &turn_entry/1),
+        "log_events" => Enum.map(Map.get(logs_by_conv, conv.id, []), &log_entry/1)
+      }
+    end)
+  end
+
+  defp turn_entry(turn) do
+    %{
+      "turn_number" => turn.turn_number,
+      "prompt" => turn.prompt,
+      "status" => turn.status,
+      "exit_code" => turn.exit_code,
+      "started_at" => turn.started_at,
+      "ended_at" => turn.ended_at
+    }
+  end
+
+  defp log_entry(le) do
+    %{
+      "kind" => le.kind,
+      "stream" => le.stream,
+      "data" => le.data,
+      "stage" => le.stage,
+      "state" => le.state,
+      "duration_ms" => le.duration_ms,
+      "turn_id" => le.turn_id,
+      "at" => le.inserted_at
+    }
+  end
+
+  defp audit_section(user_id) do
+    Repo.all(
+      from e in Audit.Event,
+        where: e.user_id == ^user_id,
+        order_by: [asc: e.inserted_at, asc: e.id]
+    )
+    |> Enum.map(fn e ->
+      %{
+        "action" => e.action,
+        "resource_type" => e.resource_type,
+        "resource_id" => e.resource_id,
+        "actor" => e.actor,
+        "request_ip" => e.request_ip,
+        "metadata" => e.metadata,
+        "at" => e.inserted_at
+      }
+    end)
+  end
+end

--- a/apps/fountain/lib/fountain/exports/export.ex
+++ b/apps/fountain/lib/fountain/exports/export.ex
@@ -1,0 +1,39 @@
+defmodule Fountain.Exports.Export do
+  @moduledoc """
+  One requested account-data export.
+
+  `payload` is the gzipped JSON document, present once `status` is
+  `"completed"`. `byte_size` is the size of the raw JSON before compression,
+  kept for display. `expires_at` bounds how long the artifact is downloadable;
+  after that the row is purged.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Fountain.Accounts.User
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @statuses ~w(pending completed failed)
+
+  schema "account_exports" do
+    field :status, :string, default: "pending"
+    field :payload, :binary
+    field :byte_size, :integer
+    field :error, :string
+    field :expires_at, :utc_datetime
+    belongs_to :user, User
+    timestamps(type: :utc_datetime)
+  end
+
+  def statuses, do: @statuses
+
+  def changeset(export, attrs) do
+    export
+    |> cast(attrs, [:status, :payload, :byte_size, :error, :expires_at, :user_id])
+    |> validate_required([:status, :user_id])
+    |> validate_inclusion(:status, @statuses)
+  end
+end

--- a/apps/fountain/lib/fountain/exports/export.ex
+++ b/apps/fountain/lib/fountain/exports/export.ex
@@ -18,6 +18,8 @@ defmodule Fountain.Exports.Export do
 
   @statuses ~w(pending completed failed)
 
+  @type t :: %__MODULE__{}
+
   schema "account_exports" do
     field :status, :string, default: "pending"
     field :payload, :binary

--- a/apps/fountain/lib/fountain/workers/account_export.ex
+++ b/apps/fountain/lib/fountain/workers/account_export.ex
@@ -1,0 +1,67 @@
+defmodule Fountain.Workers.AccountExport do
+  @moduledoc """
+  Builds a requested account data export (#288).
+
+  Runs async because an export reads every row the account owns — log output
+  dominates, and a heavy account is tens of megabytes of it — which has no
+  business happening inside a LiveView event.
+
+  The JSON document is gzipped before storage: sprite log output compresses
+  roughly 20x, which is the difference between a multi-megabyte row and a
+  hundreds-of-kilobytes one. Each run starts by purging expired exports, so
+  the table never accumulates dead payloads between requests.
+
+  A final failed attempt marks the export row `failed` so the account page
+  shows an honest status instead of "generating…" forever.
+  """
+
+  use Oban.Worker, queue: :exports, max_attempts: 3
+
+  require Logger
+
+  alias Fountain.Exports
+  alias Fountain.Exports.Export
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"export_id" => export_id, "user_id" => user_id}} = job) do
+    Exports.purge_expired()
+
+    case Exports.get_export(export_id, user_id) do
+      nil ->
+        # Superseded by a newer request or the account is gone. Nothing to
+        # build, and retrying will not bring the row back.
+        :ok
+
+      %Export{status: "completed"} ->
+        :ok
+
+      %Export{} = export ->
+        build(export, job)
+    end
+  end
+
+  defp build(%Export{user_id: user_id} = export, job) do
+    json = user_id |> Exports.build() |> Jason.encode!()
+    payload = :zlib.gzip(json)
+
+    with {:ok, _} <- Exports.complete_export(export, payload, byte_size(json)) do
+      :ok
+    end
+  rescue
+    e ->
+      if job.attempt >= job.max_attempts do
+        Logger.error("account_export: giving up on #{export.id}: #{Exception.message(e)}")
+        Exports.fail_export(export, e)
+      end
+
+      reraise e, __STACKTRACE__
+  end
+
+  @doc "Enqueue the build job for `export`."
+  @spec enqueue(Export.t()) :: {:ok, Oban.Job.t()} | {:error, term()}
+  def enqueue(%Export{id: id, user_id: user_id}) do
+    %{export_id: id, user_id: user_id}
+    |> new()
+    |> Oban.insert()
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/export_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/export_controller.ex
@@ -1,0 +1,43 @@
+defmodule FountainWeb.ExportController do
+  @moduledoc """
+  Serves a completed account data export (#288).
+
+  Session-authenticated and owner-scoped: `Exports.get_downloadable_export/2`
+  answers `:not_found` identically for a wrong tenant, a missing id, a
+  pending/failed export and an expired one, so the response leaks nothing
+  about other tenants' artifacts.
+
+  The payload is stored gzipped and served with `content-encoding: gzip`, so
+  the bytes on the wire stay small while the browser writes a plain,
+  human-readable `.json` file to disk.
+  """
+
+  use FountainWeb, :controller
+
+  alias Fountain.Exports
+  alias FountainWeb.Audited
+
+  def download(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case Exports.get_downloadable_export(id, user.id) do
+      {:ok, export} ->
+        Audited.from_conn(conn, "account.export_downloaded", "export",
+          resource_id: export.id,
+          metadata: %{"byte_size" => export.byte_size}
+        )
+
+        filename = "fountain-export-#{Date.to_iso8601(Date.utc_today())}.json"
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> put_resp_header("content-encoding", "gzip")
+        |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}"))
+        |> put_resp_header("cache-control", "private, no-store")
+        |> send_resp(200, export.payload)
+
+      {:error, :not_found} ->
+        send_resp(conn, 404, "")
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/billing_live.ex
+++ b/apps/fountain/lib/fountain_web/live/billing_live.ex
@@ -11,6 +11,7 @@ defmodule FountainWeb.Live.BillingLive do
 
   alias Fountain.Accounts.Deletion
   alias Fountain.Billing
+  alias Fountain.Exports
 
   @impl true
   def mount(_params, _session, socket) do
@@ -18,6 +19,10 @@ defmodule FountainWeb.Live.BillingLive do
     user = socket.assigns.current_user
     {period_start, period_end} = current_month_range()
     usage = Billing.usage_summary(user.id, period_start, period_end)
+
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Fountain.PubSub, Exports.topic(user.id))
+    end
 
     {:ok,
      assign(socket,
@@ -27,7 +32,8 @@ defmodule FountainWeb.Live.BillingLive do
        period_end: period_end,
        stripe_url_loading: false,
        delete_confirmation: "",
-       deleting: false
+       deleting: false,
+       export: Exports.latest_export(user.id)
      )}
   end
 
@@ -45,6 +51,32 @@ defmodule FountainWeb.Live.BillingLive do
          socket
          |> assign(:stripe_url_loading, false)
          |> put_flash(:error, "Unable to reach Stripe. Please try again.")}
+    end
+  end
+
+  @impl true
+  def handle_event("request_export", _params, socket) do
+    user = socket.assigns.current_user
+
+    case Exports.request_export(user, actor: "self", request_ip: socket.assigns[:client_ip]) do
+      {:ok, export} ->
+        {:noreply,
+         socket
+         |> assign(:export, export)
+         |> put_flash(:info, "Export started — the download will appear here when it is ready.")}
+
+      {:error, {:rate_limited, retry_after}} ->
+        minutes = max(div(retry_after + 59, 60), 1)
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "You can request one export per hour. Try again in about #{minutes} minute(s)."
+         )}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, "Could not start the export. Please try again.")}
     end
   end
 
@@ -96,6 +128,11 @@ defmodule FountainWeb.Live.BillingLive do
              |> put_flash(:error, "Account deletion failed. Nothing was deleted.")}
         end
     end
+  end
+
+  @impl true
+  def handle_info({:export_updated, _user_id}, socket) do
+    {:noreply, assign(socket, :export, Exports.latest_export(socket.assigns.current_user.id))}
   end
 
   @impl true
@@ -188,6 +225,64 @@ defmodule FountainWeb.Live.BillingLive do
         </dl>
       </div>
 
+      <%!-- Data export --%>
+      <div class="rounded-lg border bg-white p-6 shadow-sm">
+        <h2 class="mb-1 text-lg font-medium">Export your data</h2>
+        <p class="mb-2 text-sm text-gray-600">
+          Download a single JSON file containing your agents, environments, vaults,
+          conversations with their full log output, and your audit trail.
+        </p>
+        <p class="mb-4 text-sm text-gray-600">
+          Environment and vault <strong>secret values are deliberately excluded</strong>
+          — only secret names are listed. Secrets were write-only on the way in and
+          stay that way on the way out.
+        </p>
+
+        <%= if @export do %>
+          <div class="mb-4 rounded-md bg-gray-50 p-4 text-sm" id="export-status">
+            <%= case export_state(@export) do %>
+              <% :pending -> %>
+                <span class="text-gray-700">
+                  Export requested <%= Calendar.strftime(@export.inserted_at, "%Y-%m-%d %H:%M UTC") %>
+                  — generating&hellip; The download will appear here when it is ready.
+                </span>
+              <% :ready -> %>
+                <div class="flex items-center justify-between gap-4">
+                  <span class="text-gray-700">
+                    Export ready (<%= format_bytes(@export.byte_size) %>) — link expires
+                    <%= Calendar.strftime(@export.expires_at, "%Y-%m-%d %H:%M UTC") %>.
+                  </span>
+                  <a
+                    href={~p"/account/exports/#{@export.id}/download"}
+                    class="shrink-0 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700"
+                  >
+                    Download
+                  </a>
+                </div>
+              <% :expired -> %>
+                <span class="text-gray-500">
+                  Your last export has expired. Request a new one to download your data.
+                </span>
+              <% :failed -> %>
+                <span class="text-red-700">
+                  The last export failed. Please request a new one; contact support if it
+                  keeps failing.
+                </span>
+            <% end %>
+          </div>
+        <% end %>
+
+        <button
+          phx-click="request_export"
+          class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Request export
+        </button>
+        <p class="mt-2 text-xs text-gray-400">
+          One export per hour. Downloads expire after <%= Exports.ttl_hours() %> hours.
+        </p>
+      </div>
+
       <%!-- Danger zone --%>
       <div class="rounded-lg border border-red-200 bg-white p-6 shadow-sm">
         <h2 class="mb-1 text-lg font-medium text-red-700">Delete account</h2>
@@ -226,6 +321,18 @@ defmodule FountainWeb.Live.BillingLive do
   end
 
   # ─── Private helpers ───────────────────────────────────────────────────────────
+
+  defp export_state(%{status: "pending"}), do: :pending
+  defp export_state(%{status: "failed"}), do: :failed
+
+  defp export_state(%{status: "completed"} = export) do
+    if Exports.expired?(export), do: :expired, else: :ready
+  end
+
+  defp format_bytes(nil), do: "unknown size"
+  defp format_bytes(n) when n < 1024, do: "#{n} B"
+  defp format_bytes(n) when n < 1024 * 1024, do: "#{Float.round(n / 1024, 1)} KB"
+  defp format_bytes(n), do: "#{Float.round(n / (1024 * 1024), 1)} MB"
 
   defp current_month_range do
     now = DateTime.utc_now()

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -216,6 +216,9 @@ defmodule FountainWeb.Router do
     # ── Avatar serving — tenant-scoped image endpoint ─────────────────────────────────────────────────────
     get "/agents/:id/avatar", AgentAvatarController, :show
 
+    # ── Account data export download — owner-scoped, expiring artifact (#288) ─────────────────────────────
+    get "/account/exports/:id/download", ExportController, :download
+
     # ── Turn image serving — session-authenticated so <img> tags can load without a bearer token ──────────
     get "/conversations/:conversation_id/turns/:turn_id/images/:position",
         TurnImageController,

--- a/apps/fountain/priv/repo/migrations/20260802120000_create_account_exports.exs
+++ b/apps/fountain/priv/repo/migrations/20260802120000_create_account_exports.exs
@@ -1,0 +1,22 @@
+defmodule Fountain.Repo.Migrations.CreateAccountExports do
+  use Ecto.Migration
+
+  def change do
+    create table(:account_exports, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+      add :status, :string, null: false, default: "pending"
+      # Gzipped JSON document. Populated when status becomes "completed".
+      add :payload, :binary
+      # Size of the raw (uncompressed) JSON, for display.
+      add :byte_size, :bigint
+      add :error, :string
+      add :expires_at, :utc_datetime
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:account_exports, [:user_id, :inserted_at])
+    create index(:account_exports, [:expires_at])
+  end
+end

--- a/apps/fountain/test/fountain/exports_test.exs
+++ b/apps/fountain/test/fountain/exports_test.exs
@@ -1,0 +1,256 @@
+defmodule Fountain.ExportsTest do
+  @moduledoc """
+  Self-serve account data export (#288).
+
+  The properties that matter, in order: secret values never leave the system
+  through an export, no tenant can read another tenant's artifact, the rate
+  limit holds, and the download link actually expires.
+  """
+
+  use Fountain.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Fountain.Audit
+  alias Fountain.Exports
+  alias Fountain.Exports.Export
+  alias Fountain.Repo
+  alias Fountain.Workers.AccountExport
+
+  # The plaintext that must never appear in an export. Distinctive on purpose
+  # so a substring assertion cannot pass by accident.
+  @secret_value "hunter2-super-secret-export-canary"
+
+  defp backdate(export, seconds) do
+    {1, _} =
+      Repo.update_all(
+        from(e in Export, where: e.id == ^export.id),
+        set: [
+          inserted_at:
+            DateTime.utc_now() |> DateTime.add(-seconds, :second) |> DateTime.truncate(:second)
+        ]
+      )
+
+    Repo.get!(Export, export.id)
+  end
+
+  describe "request_export/2" do
+    test "creates a pending export, enqueues the job, records the audit event" do
+      user = insert_verified_user()
+
+      assert {:ok, %Export{status: "pending"} = export} = Exports.request_export(user)
+
+      assert_enqueued(
+        worker: AccountExport,
+        args: %{export_id: export.id, user_id: user.id}
+      )
+
+      assert [event] = Audit.list_recent_for_user(user.id, 10)
+      assert event.action == "account.export_requested"
+      assert event.resource_id == export.id
+      assert event.actor == "self"
+    end
+
+    test "a second request within the hour is rate limited" do
+      user = insert_verified_user()
+
+      assert {:ok, _} = Exports.request_export(user)
+      assert {:error, {:rate_limited, retry_after}} = Exports.request_export(user)
+      assert retry_after > 0 and retry_after <= Exports.rate_window_seconds()
+
+      # Still only one export row and one job.
+      assert Repo.aggregate(from(e in Export, where: e.user_id == ^user.id), :count) == 1
+    end
+
+    test "after the window passes, a new request replaces the old export" do
+      user = insert_verified_user()
+
+      {:ok, old} = Exports.request_export(user)
+      backdate(old, Exports.rate_window_seconds() + 1)
+
+      assert {:ok, new} = Exports.request_export(user)
+      assert new.id != old.id
+      refute Repo.get(Export, old.id)
+    end
+
+    test "one user's requests do not consume another user's allowance" do
+      a = insert_verified_user()
+      b = insert_verified_user()
+
+      assert {:ok, _} = Exports.request_export(a)
+      assert {:ok, _} = Exports.request_export(b)
+    end
+  end
+
+  # Seed one account with every kind of owned data, including a real encrypted
+  # secret, and a second account whose data must never bleed in.
+  defp seed_account do
+    user = insert_verified_user()
+
+    env = insert_env(user_id: user.id, name: "export-env")
+    insert_secret(env, %{"key" => "EXPORT_TOKEN", "value" => @secret_value})
+
+    vault = insert_vault(user_id: user.id, name: "export-vault")
+    insert_vault_secret(vault, %{"key" => "VAULT_TOKEN", "value" => @secret_value})
+
+    agent = insert_agent(user_id: user.id, name: "export-agent")
+    conv = insert_conversation(user_id: user.id, agent: agent, title: "export conversation")
+    turn = insert_turn(conv, prompt: "please export me")
+    insert_log_event(conv, turn_id: turn.id, data: "log line from the sprite")
+
+    {:ok, _} =
+      Audit.record(%{
+        user_id: user.id,
+        action: "agent.created",
+        resource_type: "agent",
+        resource_id: agent.id,
+        actor: "ui"
+      })
+
+    other = insert_verified_user()
+    insert_agent(user_id: other.id, name: "other-tenant-agent")
+    other_conv = insert_conversation(user_id: other.id)
+    insert_log_event(other_conv, data: "other tenant log line")
+
+    %{user: user, env: env, vault: vault, agent: agent, conv: conv, other: other}
+  end
+
+  describe "build/1 and the worker" do
+    test "the export contains everything the account owns" do
+      %{user: user, conv: conv} = seed_account()
+
+      {:ok, export} = Exports.request_export(user)
+      assert :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
+
+      export = Repo.get!(Export, export.id)
+      assert export.status == "completed"
+      assert %DateTime{} = export.expires_at
+      assert export.byte_size > 0
+
+      doc = export.payload |> :zlib.gunzip() |> Jason.decode!()
+
+      assert doc["account"]["email"] == user.email
+      assert [%{"name" => "export-agent"}] = doc["agents"]
+
+      assert [env_doc] = doc["environments"]
+      assert env_doc["name"] == "export-env"
+      assert env_doc["secret_keys"] == ["EXPORT_TOKEN"]
+
+      assert [vault_doc] = doc["vaults"]
+      assert vault_doc["secret_keys"] == ["VAULT_TOKEN"]
+
+      assert [conv_doc] = doc["conversations"]
+      assert conv_doc["id"] == conv.id
+      assert [%{"prompt" => "please export me"}] = conv_doc["turns"]
+      assert [%{"data" => "log line from the sprite"}] = conv_doc["log_events"]
+
+      actions = Enum.map(doc["audit_trail"], & &1["action"])
+      assert "agent.created" in actions
+      assert "account.export_requested" in actions
+    end
+
+    test "secret values never appear in the export — names only" do
+      %{user: user} = seed_account()
+
+      {:ok, export} = Exports.request_export(user)
+      assert :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
+
+      json = Repo.get!(Export, export.id).payload |> :zlib.gunzip()
+
+      # The plaintext round-trips through real envelope encryption in the
+      # fixture, so this catches any path that decrypts on the way out.
+      refute json =~ @secret_value
+
+      # The names are the only trace, plus the UI-facing note saying so.
+      doc = Jason.decode!(json)
+      assert doc["notes"]["secrets"] =~ "write-only"
+    end
+
+    test "the export never contains another tenant's data" do
+      %{user: user} = seed_account()
+
+      doc = Exports.build(user.id)
+      json = Jason.encode!(doc)
+
+      refute json =~ "other-tenant-agent"
+      refute json =~ "other tenant log line"
+    end
+
+    test "a superseded or deleted export id is a no-op, not a crash loop" do
+      user = insert_verified_user()
+      assert :ok = perform_job(AccountExport, %{export_id: Ecto.UUID.generate(), user_id: user.id})
+    end
+
+    test "completion broadcasts so the account page updates" do
+      user = insert_verified_user()
+      Phoenix.PubSub.subscribe(Fountain.PubSub, Exports.topic(user.id))
+
+      {:ok, export} = Exports.request_export(user)
+      assert :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
+
+      assert_receive {:export_updated, _}
+    end
+  end
+
+  describe "get_downloadable_export/2" do
+    setup do
+      %{user: user} = seed_account()
+      {:ok, export} = Exports.request_export(user)
+      :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
+      %{user: user, export: Repo.get!(Export, export.id)}
+    end
+
+    test "the owner can fetch it", %{user: user, export: export} do
+      assert {:ok, %Export{payload: payload}} = Exports.get_downloadable_export(export.id, user.id)
+      assert is_binary(payload)
+    end
+
+    test "another tenant cannot fetch the artifact", %{export: export} do
+      other = insert_verified_user()
+      assert {:error, :not_found} = Exports.get_downloadable_export(export.id, other.id)
+    end
+
+    test "an expired export is not downloadable", %{user: user, export: export} do
+      {1, _} =
+        Repo.update_all(
+          from(e in Export, where: e.id == ^export.id),
+          set: [expires_at: DateTime.utc_now() |> DateTime.add(-1) |> DateTime.truncate(:second)]
+        )
+
+      assert {:error, :not_found} = Exports.get_downloadable_export(export.id, user.id)
+    end
+
+    test "a pending export is not downloadable", %{user: user} do
+      pending =
+        %Export{}
+        |> Export.changeset(%{status: "pending", user_id: user.id})
+        |> Repo.insert!()
+
+      assert {:error, :not_found} = Exports.get_downloadable_export(pending.id, user.id)
+    end
+  end
+
+  describe "purge_expired/0" do
+    test "removes expired exports and keeps live ones" do
+      %{user: user} = seed_account()
+      {:ok, export} = Exports.request_export(user)
+      :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
+
+      other = insert_verified_user()
+
+      expired =
+        %Export{}
+        |> Export.changeset(%{
+          status: "completed",
+          user_id: other.id,
+          payload: <<1>>,
+          expires_at: DateTime.utc_now() |> DateTime.add(-60) |> DateTime.truncate(:second)
+        })
+        |> Repo.insert!()
+
+      assert Exports.purge_expired() == 1
+      refute Repo.get(Export, expired.id)
+      assert Repo.get(Export, export.id)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/export_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/export_controller_test.exs
@@ -1,0 +1,94 @@
+defmodule FountainWeb.ExportControllerTest do
+  @moduledoc """
+  The download endpoint for account data exports (#288).
+
+  Wrong tenant, missing id, pending, failed and expired are all the same 404
+  on purpose — the response must not reveal whether another tenant's artifact
+  exists.
+  """
+
+  use FountainWeb.ConnCase, async: true
+  use Oban.Testing, repo: Fountain.Repo
+
+  import Ecto.Query
+
+  alias Fountain.Audit
+  alias Fountain.Exports
+  alias Fountain.Exports.Export
+  alias Fountain.Repo
+  alias Fountain.Workers.AccountExport
+
+  defp completed_export(user) do
+    {:ok, export} = Exports.request_export(user)
+    :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
+    Repo.get!(Export, export.id)
+  end
+
+  test "the owner downloads a plain JSON file", %{conn: conn} do
+    user = insert_verified_user()
+    insert_agent(user_id: user.id, name: "download-agent")
+    export = completed_export(user)
+
+    conn = get(login_user(conn, user), ~p"/account/exports/#{export.id}/download")
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "content-encoding") == ["gzip"]
+    assert [disposition] = get_resp_header(conn, "content-disposition")
+    assert disposition =~ ~s(attachment; filename="fountain-export-)
+
+    doc = conn.resp_body |> :zlib.gunzip() |> Jason.decode!()
+    assert doc["account"]["email"] == user.email
+    assert [%{"name" => "download-agent"}] = doc["agents"]
+  end
+
+  test "the download is audit-recorded", %{conn: conn} do
+    user = insert_verified_user()
+    export = completed_export(user)
+
+    get(login_user(conn, user), ~p"/account/exports/#{export.id}/download")
+
+    actions = user.id |> Audit.list_recent_for_user(10) |> Enum.map(& &1.action)
+    assert "account.export_downloaded" in actions
+  end
+
+  test "another tenant gets 404 for the same id", %{conn: conn} do
+    owner = insert_verified_user()
+    export = completed_export(owner)
+
+    other = insert_verified_user()
+    conn = get(login_user(conn, other), ~p"/account/exports/#{export.id}/download")
+
+    assert conn.status == 404
+    assert conn.resp_body == ""
+  end
+
+  test "an expired export gets 404 for its owner", %{conn: conn} do
+    user = insert_verified_user()
+    export = completed_export(user)
+
+    {1, _} =
+      Repo.update_all(
+        from(e in Export, where: e.id == ^export.id),
+        set: [expires_at: DateTime.utc_now() |> DateTime.add(-1) |> DateTime.truncate(:second)]
+      )
+
+    conn = get(login_user(conn, user), ~p"/account/exports/#{export.id}/download")
+    assert conn.status == 404
+  end
+
+  test "a pending export gets 404", %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, export} = Exports.request_export(user)
+
+    conn = get(login_user(conn, user), ~p"/account/exports/#{export.id}/download")
+    assert conn.status == 404
+  end
+
+  test "unauthenticated requests are redirected to login", %{conn: conn} do
+    user = insert_verified_user()
+    export = completed_export(user)
+
+    conn = get(conn, ~p"/account/exports/#{export.id}/download")
+    assert redirected_to(conn) =~ "/auth/login"
+  end
+end

--- a/apps/fountain/test/fountain_web/live/account_export_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/account_export_live_test.exs
@@ -1,0 +1,76 @@
+defmodule FountainWeb.AccountExportLiveTest do
+  @moduledoc """
+  The account-page surface of data export (#288): the card, its promise about
+  secrets, the request flow, the rate-limit message, and the download link.
+  """
+
+  use FountainWeb.ConnCase, async: true
+  use Oban.Testing, repo: Fountain.Repo
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Exports
+  alias Fountain.Exports.Export
+  alias Fountain.Repo
+  alias Fountain.Workers.AccountExport
+
+  test "the card states that secret values are excluded", %{conn: conn} do
+    user = insert_verified_user()
+
+    {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+    assert html =~ "Export your data"
+    assert html =~ "secret values are deliberately excluded"
+    assert html =~ "write-only on the way in"
+  end
+
+  test "requesting an export enqueues the job and shows pending status", %{conn: conn} do
+    user = insert_verified_user()
+
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+
+    html = render_click(lv, "request_export")
+    assert html =~ "Export started"
+    assert html =~ "generating"
+
+    assert [export] = Repo.all(Export)
+    assert export.user_id == user.id
+    assert_enqueued(worker: AccountExport, args: %{export_id: export.id, user_id: user.id})
+  end
+
+  test "a second request within the hour is refused", %{conn: conn} do
+    user = insert_verified_user()
+
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+
+    render_click(lv, "request_export")
+    html = render_click(lv, "request_export")
+
+    assert html =~ "one export per hour"
+    assert Repo.aggregate(Export, :count) == 1
+  end
+
+  test "a completed export shows the download link and its expiry", %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, export} = Exports.request_export(user)
+    :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
+
+    {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+    assert html =~ "Export ready"
+    assert html =~ ~p"/account/exports/#{export.id}/download"
+    assert html =~ "link expires"
+  end
+
+  test "the completion broadcast flips pending to ready without a reload", %{conn: conn} do
+    user = insert_verified_user()
+
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+    assert render_click(lv, "request_export") =~ "generating"
+
+    [export] = Repo.all(Export)
+    :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
+
+    assert render(lv) =~ "Export ready"
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,10 @@ import Config
 # the problem the Rehydrator solves by hand.
 config :fountain, Oban,
   repo: Fountain.Repo,
-  queues: [maintenance: 1, billing: 5],
+  # exports is its own queue so a user-requested data export is never stuck
+  # behind a maintenance sweep; concurrency 1 because each job reads every row
+  # an account owns and two at once doubles that memory.
+  queues: [maintenance: 1, billing: 5, exports: 1],
   plugins: [
     # Oban's own job-table pruning: completed jobs older than 7 days.
     {Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60},


### PR DESCRIPTION
Closes #288.

Self-serve data export from the account page, so the exit story is export-then-delete (#234) instead of delete-and-trust. One JSON document covering agents, environments, vaults, conversations with turns and full log output, and the account's own audit trail — generated async via Oban, downloadable from `/account/billing` until it expires.

## Design decisions

**Storage: gzipped JSON blob in Postgres (`account_exports.payload`).** The app has no object store — generated binaries already live in Postgres (`agent_avatars`, `turn_images`) and are served through owner-scoped controllers — and local disk is ephemeral across deploys, so a file path would break on every rollout. Bounded by construction: at most one export row per user (a new request replaces the old), rows expire after 24h, and the worker purges expired rows on every run.

**Format: one JSON file, stored and transferred gzipped — no tarball.** Measured against a synthetic account sized from prod numbers (RetentionPruner: log_events ≈114MB across ~255 conversations ⇒ ~450KB of log output per conversation, written as ~2KB chunks):

| account | raw JSON | build | encode |
|---|---|---|---|
| 15 conversations | 5.9 MB | 47 ms | 22 ms |
| 50 conversations (heavy) | 19.7 MB | 130 ms | 112 ms |

Synthetic logs over-compress (~140x); at a conservative real-world 5–10x, the heavy account is a 2–4 MB stored blob. A tarball adds structure a single logical document doesn't need; instead the payload is stored gzipped and served with `content-encoding: gzip` + `content-disposition: attachment`, so the wire stays small and the browser writes a plain, human-readable `.json` to disk.

**Secrets are excluded — names only.** Environment and vault secret *values* were write-only on the way in and stay that way on the way out: the export carries `secret_keys` lists, never plaintext and never ciphertext. The document itself says so (`notes.secrets`), and the account-page card states it before the user requests anything.

**Expiry: `expires_at` on the row, enforced at read time, purged by the worker.** The download route sits in the session-authenticated browser scope and `Exports.get_downloadable_export/2` is owner-scoped — wrong tenant, missing id, pending, failed and expired are all the same 404, so the endpoint reveals nothing about other tenants' artifacts. No capability URL: a bearer-token link would outlive the session and be sharable/leakable for no benefit when the requester is by definition logged in.

**Rate limit: once per hour per user, anchored on the export row's `inserted_at`.** I looked at `FountainWeb.Plugs.RateLimit` first: it's per-IP, per-node ETS, and resets on deploy — right for anti-runaway request limiting, wrong for a durable per-user rule on an expensive operation (and the request path is a LiveView event, not a plug pipeline). The DB check survives restarts, works across replicas, and is naturally isolated under the SQL sandbox, so `:rate_limit_test_isolation` isn't needed here.

**Everything tenant-scoped.** Every query behind `Exports.build/1` filters on `user_id` directly or joins through `conversations.user_id`; no `_unsafe_` function is called anywhere on this path. Both the request and the download are audit-recorded (`account.export_requested`, `account.export_downloaded`).

## Tests

25 new tests across three files:

- `test/fountain/exports_test.exs` — request/enqueue/audit; rate limit (second request refused, allowance restored after the window, per-user not global); full document contents against a seeded account; **secret plaintext absent, proven against a real envelope-encrypted fixture**; cross-tenant data never bleeds into a build; owner-scoped download fetch; expiry; purge.
- `test/fountain_web/controllers/export_controller_test.exs` — owner download round-trips to valid JSON with gzip encoding + attachment headers; download audit-recorded; **another tenant gets 404 for the same id**; expired 404; pending 404; unauthenticated redirect to login.
- `test/fountain_web/live/account_export_live_test.exs` — the card states the secrets exclusion; requesting enqueues the job and shows pending; second request refused; completed export shows download link + expiry; the completion PubSub broadcast flips pending → ready without a reload.

**Regression-verified** (break, observe failure, restore), per the checklist:

1. Temporarily made the builder decrypt environment secrets into the document (via `Crypto.load_tenant_key` + `decrypted_env`) → `secret values never appear in the export` failed as intended.
2. Temporarily dropped the `user_id` scope from `get_downloadable_export/2` (`Repo.get` instead of `Repo.get_by(..., user_id:)`) → both `another tenant cannot fetch the artifact` (context) and `another tenant gets 404 for the same id` (controller) failed as intended.

`mix precommit` passes in full (format, compile --warnings-as-errors, credo, dialyzer, 1585 tests + 5 doctests + 3 properties, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
