### PR TITLE
admin: billing overview — the numbers an operator checks daily (#286)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,9 @@ STRIPE_WEBHOOK_SECRET=
 # Price ID for the subscription tier (price_xxx). Use the test-mode
 # price in dev (created in Stripe Dashboard > Test mode > Products).
 STRIPE_PRICE_ID=
+# Monthly price in cents (e.g. 2900), display-only: feeds the admin billing
+# overview's MRR tile. Optional — unset shows "price not configured".
+STRIPE_PRICE_MONTHLY_CENTS=
 
 # ── Database TLS and pool ────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -754,6 +754,85 @@ defmodule Fountain.Billing do
   defp to_minutes(%Decimal{} = ms), do: Decimal.to_float(ms) / 60_000.0
   defp to_minutes(ms) when is_number(ms), do: ms / 60_000.0
 
+  # ─── Admin billing overview (#286) ──────────────────────────────────────────
+
+  @doc """
+  The numbers an operator checks daily, in one read-only pass — for the admin
+  panel (no tenant scoping; the caller is behind `require_admin`).
+
+  - `status_counts` — users per `subscription_status`
+  - `trials_ending_7d` — trialing users whose `trial_ends_at` is within the
+    next 7 days
+  - `conversions_this_month` — `checkout.session.completed` webhook events
+    since the start of the current UTC month. Every verified webhook is
+    claimed into `stripe_events` before handling, so the claim table is a
+    complete record of checkouts — including a canceled user coming back.
+  - `mrr_cents` — active subscriptions × the configured monthly price
+    (`:stripe_price_monthly_cents`, from `STRIPE_PRICE_MONTHLY_CENTS`).
+    `nil` when the price isn't configured — no number is better than a made-up
+    one. Deliberately `active` only: `past_due` is at-risk revenue, comped is
+    not revenue. Honesty note: this breaks the day there is a second price;
+    the config is a single amount on purpose so that day is loud.
+  - `recent_events` — the last processed webhook events, newest first.
+    Failures are not listed because failed deliveries are never claimed —
+    they exist only in Stripe's dashboard and our logs today.
+
+  Options: `:price_cents` overrides the configured price (tests), `:now`
+  pins the clock, `:event_limit` caps `recent_events` (default 10).
+  """
+  @spec overview_admin(keyword()) :: map()
+  def overview_admin(opts \\ []) do
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+
+    price_cents =
+      Keyword.get(opts, :price_cents, Application.get_env(:fountain, :stripe_price_monthly_cents))
+
+    event_limit = Keyword.get(opts, :event_limit, 10)
+
+    status_counts =
+      from(u in User, group_by: u.subscription_status, select: {u.subscription_status, count(u.id)})
+      |> Repo.all()
+      |> Map.new()
+
+    in_7d = DateTime.add(now, 7, :day)
+
+    trials_ending_7d =
+      Repo.one(
+        from u in User,
+          where:
+            u.subscription_status == "trialing" and not is_nil(u.trial_ends_at) and
+              u.trial_ends_at >= ^now and u.trial_ends_at <= ^in_7d,
+          select: count(u.id)
+      ) || 0
+
+    month_start = %{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 6}}
+
+    conversions_this_month =
+      Repo.one(
+        from e in "stripe_events",
+          where: e.type == "checkout.session.completed" and e.inserted_at >= ^month_start,
+          select: count(e.id)
+      ) || 0
+
+    recent_events =
+      Repo.all(
+        from e in "stripe_events",
+          order_by: [desc: e.inserted_at],
+          limit: ^event_limit,
+          select: %{id: e.id, type: e.type, inserted_at: e.inserted_at}
+      )
+
+    active = Map.get(status_counts, "active", 0)
+
+    %{
+      status_counts: status_counts,
+      trials_ending_7d: trials_ending_7d,
+      conversions_this_month: conversions_this_month,
+      mrr_cents: price_cents && active * price_cents,
+      recent_events: recent_events
+    }
+  end
+
   # ─── Usage emission ─────────────────────────────────────────────────────────
 
   @doc """

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -19,6 +19,7 @@ defmodule FountainWeb.AdminLive.Index do
      |> FountainWeb.Audited.put_client_ip()
      |> assign(:page_title, "Admin")
      |> assign(:funnel, Fountain.Funnel.summary_admin())
+     |> assign(:billing_overview, Billing.overview_admin())
      |> assign(:sandboxes, Conversations.list_sandboxes_admin())
      |> assign(:admin_events, Fountain.Audit.list_recent_admin(25))}
   end
@@ -41,6 +42,7 @@ defmodule FountainWeb.AdminLive.Index do
      socket
      |> assign_users()
      |> assign(:funnel, Fountain.Funnel.summary_admin())
+     |> assign(:billing_overview, Billing.overview_admin())
      |> assign(:sandboxes, Conversations.list_sandboxes_admin())
      |> assign(:admin_events, Fountain.Audit.list_recent_admin(25))}
   end
@@ -401,6 +403,70 @@ defmodule FountainWeb.AdminLive.Index do
       </section>
 
       <section class="space-y-3">
+        <h2 class="text-lg font-medium">Billing</h2>
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+            <div class="text-xs text-zinc-500">MRR</div>
+            <div class="text-2xl font-semibold tabular-nums">
+              {format_mrr(@billing_overview.mrr_cents)}
+            </div>
+            <div class="text-xs text-zinc-500">
+              {if @billing_overview.mrr_cents,
+                do: "active × monthly price",
+                else: "set STRIPE_PRICE_MONTHLY_CENTS"}
+            </div>
+          </div>
+          <.link
+            navigate={~p"/admin?status=trialing&sort=trial_end&dir=asc"}
+            class="bg-white rounded shadow border border-zinc-200 px-4 py-3 hover:border-zinc-400"
+          >
+            <div class="text-xs text-zinc-500">Trials ending in 7 days</div>
+            <div class="text-2xl font-semibold tabular-nums">
+              {@billing_overview.trials_ending_7d}
+            </div>
+            <div class="text-xs text-zinc-500">soonest first ↗</div>
+          </.link>
+          <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+            <div class="text-xs text-zinc-500">Conversions this month</div>
+            <div class="text-2xl font-semibold tabular-nums">
+              {@billing_overview.conversions_this_month}
+            </div>
+            <div class="text-xs text-zinc-500">completed checkouts</div>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <.link
+            :for={status <- ~w(trialing active past_due canceled comped)}
+            navigate={~p"/admin?status=#{status}"}
+            class={[
+              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium border hover:opacity-75",
+              subscription_status_color(status)
+            ]}
+          >
+            {status}
+            <span class="tabular-nums">{Map.get(@billing_overview.status_counts, status, 0)}</span>
+          </.link>
+        </div>
+        <details class="text-sm">
+          <summary class="cursor-pointer text-zinc-500 hover:text-zinc-900">
+            Recent webhook events ({length(@billing_overview.recent_events)})
+          </summary>
+          <table class="w-full mt-2 text-sm bg-white rounded shadow border border-zinc-200 font-mono">
+            <tbody>
+              <tr
+                :for={e <- @billing_overview.recent_events}
+                class="border-b border-zinc-100 last:border-0"
+              >
+                <td class="px-4 py-1.5 text-xs text-zinc-500">{format_ts(e.inserted_at)}</td>
+                <td class="px-4 py-1.5 text-xs">{e.type}</td>
+                <td class="px-4 py-1.5 text-xs text-zinc-400">{e.id}</td>
+              </tr>
+            </tbody>
+          </table>
+        </details>
+      </section>
+
+      <section class="space-y-3">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <h2 class="text-lg font-medium">Users ({@total_users})</h2>
           <form phx-change="filter" id="user-filters" class="flex flex-wrap items-center gap-2">
@@ -715,6 +781,14 @@ defmodule FountainWeb.AdminLive.Index do
   defp stage_label(:subscribed), do: "Subscribed"
 
   defp format_pct(fraction), do: "#{round(fraction * 100)}%"
+
+  defp format_mrr(nil), do: "—"
+
+  defp format_mrr(cents) do
+    dollars = div(cents, 100)
+    remainder = rem(cents, 100)
+    "$#{dollars}.#{String.pad_leading(to_string(remainder), 2, "0")}/mo"
+  end
 
   defp format_hours(h) when h < 1, do: "#{round(h * 60)}m"
   defp format_hours(h) when h < 48, do: "#{Float.round(h * 1.0, 1)}h"

--- a/apps/fountain/test/fountain/billing_overview_test.exs
+++ b/apps/fountain/test/fountain/billing_overview_test.exs
@@ -1,0 +1,97 @@
+defmodule Fountain.BillingOverviewTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Billing
+
+  @now ~U[2026-08-15 12:00:00Z]
+
+  defp set_status!(user, status, extra \\ []) do
+    Repo.update!(Ecto.Changeset.change(user, [subscription_status: status] ++ extra))
+  end
+
+  defp insert_stripe_event!(id, type, inserted_at) do
+    Repo.insert_all("stripe_events", [
+      %{id: id, type: type, inserted_at: DateTime.truncate(inserted_at, :second)}
+    ])
+  end
+
+  describe "overview_admin/1 — status counts" do
+    test "groups users by subscription status" do
+      _trialing = insert_verified_user()
+      set_status!(insert_verified_user(), "active")
+      set_status!(insert_verified_user(), "active")
+      set_status!(insert_verified_user(), "canceled")
+
+      %{status_counts: counts} = Billing.overview_admin(now: @now)
+
+      assert counts["trialing"] == 1
+      assert counts["active"] == 2
+      assert counts["canceled"] == 1
+      refute Map.has_key?(counts, "comped")
+    end
+  end
+
+  describe "overview_admin/1 — trials ending in 7 days" do
+    test "counts only trialing users inside the window" do
+      in_window = insert_verified_user()
+      set_status!(in_window, "trialing", trial_ends_at: ~U[2026-08-20 00:00:00Z])
+
+      too_far = insert_verified_user()
+      set_status!(too_far, "trialing", trial_ends_at: ~U[2026-08-25 00:00:00Z])
+
+      already_over = insert_verified_user()
+      set_status!(already_over, "trialing", trial_ends_at: ~U[2026-08-14 00:00:00Z])
+
+      # Right status window, wrong status: an active user's stale trial date
+      wrong_status = insert_verified_user()
+      set_status!(wrong_status, "active", trial_ends_at: ~U[2026-08-20 00:00:00Z])
+
+      assert %{trials_ending_7d: 1} = Billing.overview_admin(now: @now)
+    end
+  end
+
+  describe "overview_admin/1 — conversions this month" do
+    test "counts checkout.session.completed since the start of the month" do
+      insert_stripe_event!("evt_this_month", "checkout.session.completed", ~U[2026-08-03 09:00:00Z])
+      insert_stripe_event!("evt_last_month", "checkout.session.completed", ~U[2026-07-31 23:00:00Z])
+      insert_stripe_event!("evt_other_type", "customer.subscription.updated", ~U[2026-08-04 09:00:00Z])
+
+      assert %{conversions_this_month: 1} = Billing.overview_admin(now: @now)
+    end
+  end
+
+  describe "overview_admin/1 — MRR" do
+    test "active count times the configured price; comped and past_due excluded" do
+      set_status!(insert_verified_user(), "active")
+      set_status!(insert_verified_user(), "active")
+      set_status!(insert_verified_user(), "past_due")
+      set_status!(insert_verified_user(), "comped")
+
+      assert %{mrr_cents: 5800} = Billing.overview_admin(now: @now, price_cents: 2900)
+    end
+
+    test "nil when no price is configured — no fabricated number" do
+      set_status!(insert_verified_user(), "active")
+
+      assert %{mrr_cents: nil} = Billing.overview_admin(now: @now, price_cents: nil)
+    end
+  end
+
+  describe "overview_admin/1 — recent events" do
+    test "newest first, capped at the limit" do
+      for i <- 1..4 do
+        insert_stripe_event!(
+          "evt_#{i}",
+          "customer.subscription.updated",
+          DateTime.add(~U[2026-08-10 00:00:00Z], i, :hour)
+        )
+      end
+
+      %{recent_events: events} = Billing.overview_admin(now: @now, event_limit: 3)
+
+      assert Enum.map(events, & &1.id) == ["evt_4", "evt_3", "evt_2"]
+      assert [%{type: "customer.subscription.updated"} | _] = events
+      refute is_nil(hd(events).inserted_at)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -477,6 +477,39 @@ defmodule FountainWeb.AdminLiveTest do
     end
   end
 
+  describe "AdminLive.Index — billing overview section" do
+    test "renders tiles, status chips linking to the filtered table, and events", %{conn: conn} do
+      admin = insert_admin()
+
+      Fountain.Repo.update!(
+        Ecto.Changeset.change(insert_verified_user(), subscription_status: "active")
+      )
+
+      Fountain.Repo.insert_all("stripe_events", [
+        %{
+          id: "evt_admin_test",
+          type: "checkout.session.completed",
+          inserted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        }
+      ])
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "MRR"
+      assert html =~ "Trials ending in 7 days"
+      assert html =~ "Conversions this month"
+      # no STRIPE_PRICE_MONTHLY_CENTS in test → honest placeholder, not a number
+      assert html =~ "set STRIPE_PRICE_MONTHLY_CENTS"
+      # status chips link into the filtered user table from #285
+      assert html =~ "/admin?status=active"
+      assert html =~ "/admin?status=past_due"
+      # recent webhook events listed
+      assert html =~ "evt_admin_test"
+      assert html =~ "checkout.session.completed"
+    end
+  end
+
   describe "AdminLive.Index — search, filter, sort" do
     # The layout renders the logged-in admin's email in the nav, so negative
     # assertions must target a third user, never the admin.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -277,6 +277,18 @@ config :stripity_stripe,
 # Set per environment (test-mode price in dev, live-mode price in prod).
 config :fountain, :stripe_price_id, System.get_env("STRIPE_PRICE_ID")
 
+# Monthly price in cents, display-only, for the admin billing overview's MRR
+# tile (the API only tells us the price *id*). Unset → the tile says the price
+# isn't configured rather than showing a fabricated number. One amount on
+# purpose: a second price tier must change this shape, loudly.
+stripe_price_monthly_cents =
+  case System.get_env("STRIPE_PRICE_MONTHLY_CENTS") do
+    value when value in [nil, ""] -> nil
+    value -> String.to_integer(value)
+  end
+
+config :fountain, :stripe_price_monthly_cents, stripe_price_monthly_cents
+
 # Mail delivery.
 #
 # With no adapter configured this used to silently fall back to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,7 @@ signup with no visible error. See [Email](self-hosting.md#email).
 | `STRIPE_SECRET_KEY` | — | for billing | Stripe API key |
 | `STRIPE_WEBHOOK_SECRET` | — | for billing | Verifies `POST /api/stripe/webhook` signatures |
 | `STRIPE_PRICE_ID` | — | for checkout | The subscription price surfaced by Checkout. Unset with billing enabled, signups get a purely local 14-day trial and a logged warning |
+| `STRIPE_PRICE_MONTHLY_CENTS` | — | no | Monthly price in cents (e.g. `2900`), display-only: feeds the admin billing overview's MRR tile. Unset, the tile shows a placeholder instead of a fabricated number |
 
 ## Proxies and origins
 


### PR DESCRIPTION
Closes #286.

Stacked on #342 (which stacks on #340); GitHub retargets as the chain merges.

## What changed

- **`Billing.overview_admin/1`** — one read-only pass: users per subscription status; trialing users ending within 7 days; conversions this month (counted from `checkout.session.completed` rows in the `stripe_events` claim table, which records every verified webhook before handling — so returning canceled users count too); recent webhook events, newest first.
- **MRR** — active count × `STRIPE_PRICE_MONTHLY_CENTS` (new optional env, display-only, documented in `docs/configuration.md` and `.env.example`). The API only tells us the price *id*, so the amount is operator-configured; unset shows a placeholder — no fabricated number. `past_due` (at-risk) and `comped` (not revenue) are deliberately excluded, and a second price tier must change this shape loudly.
- **Admin panel section** — MRR / trials-ending / conversions tiles, status chips that link into the #285 filtered user table (trials tile links pre-sorted by soonest trial end), and a collapsible recent-webhook-events list. Refreshes on the existing 10s cycle.

**Not included, honestly:** webhook *failures* aren't listed — failed deliveries are never claimed, so today they exist only in Stripe's dashboard and our logs. Listing them needs a failure record we don't have; noted in the moduledoc.

## Tests

6 context tests (status grouping; the 7-day window's both edges + wrong-status trap; month boundary; MRR arithmetic with exclusions; nil-price honesty; event ordering/limit) + 1 LiveView test (tiles, chip links, placeholder, event rows). Verified two tests detect regressions (widened the window to 70d, dropped the month boundary → 2 failures), then restored.

`mix precommit`: 1579 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)