### PR TITLE
billing: end-to-end lifecycle verification with Stripe Test Clocks, repeatable (#289)

### DIFF
--- a/apps/fountain/lib/mix/tasks/fountain.verify_lifecycle.ex
+++ b/apps/fountain/lib/mix/tasks/fountain.verify_lifecycle.ex
@@ -1,0 +1,377 @@
+defmodule Mix.Tasks.Fountain.VerifyLifecycle do
+  @shortdoc "Walk the billing lifecycle against Stripe test mode with a Test Clock"
+
+  @moduledoc """
+  End-to-end billing lifecycle verification (#289): a command, not a memory.
+
+      STRIPE_SECRET_KEY=sk_test_... mix fountain.verify_lifecycle
+
+  Creates a scratch user and a Stripe Test Clock, then walks:
+  signup → trialing subscription → clock to T-3d → trial-ending email
+  enqueued → clock past trial end → canceled, gate refuses → subscribe with a
+  test card (the checkout-completes equivalent) → active, gate opens → cancel
+  at period end → access retained → clock past period end → canceled, gate
+  refuses → re-subscribe → active again (the return path).
+
+  At each step it asserts the **Fountain-side** state — `subscription_status`,
+  `trial_ends_at`, `Billing.check_active/1`, enqueued email jobs. Stripe's own
+  behavior (that clocks advance, that trials cancel) is theirs to test; real
+  test-mode objects are still used so our sync sees real shapes. Webhook
+  *delivery* needs a public endpoint and is out of scope: each fetched
+  subscription state is fed through `Billing.sync_subscription/1`, exactly
+  what the webhook controller does after signature verification.
+
+  Deliberately **not CI**: external, slow (~1–2 min of clock advances), needs
+  a key. It is the documented release-verification step for billing-touching
+  changes — see `docs/integrations/stripe.md`.
+
+  Requirements: a **test-mode** key (`sk_test_`/`rk_test_` — live keys are
+  refused), and a reachable dev database. The key expires every 90 days; an
+  expired key fails the preflight with instructions, not a misleading error.
+  Cleanup deletes the Test Clock (which removes its Stripe objects) and the
+  scratch user, and runs even when a step fails.
+  """
+
+  use Mix.Task
+
+  alias Fountain.{Accounts, Billing, Repo}
+  alias Fountain.Accounts.User
+
+  @clock_poll_ms 2_000
+  @clock_poll_attempts 45
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    key = System.get_env("STRIPE_SECRET_KEY") || Application.get_env(:stripity_stripe, :api_key)
+    preflight!(key)
+    Application.put_env(:stripity_stripe, :api_key, key)
+
+    state = %{user: nil, clock: nil}
+
+    try do
+      state = step_scratch_user(state)
+      state = step_clock_and_customer(state)
+      state = step_trial(state)
+      state = step_trial_ending_warning(state)
+      state = step_trial_expiry(state)
+      state = step_subscribe(state)
+      state = step_cancel_at_period_end(state)
+      state = step_period_end(state)
+      _state = step_resubscribe(state)
+
+      info("\n✅  Lifecycle verified end to end.")
+    after
+      cleanup(state_now())
+    end
+  end
+
+  # ── Steps ──────────────────────────────────────────────────────────────────
+
+  defp preflight!(nil) do
+    Mix.raise("""
+    No Stripe key. Set STRIPE_SECRET_KEY to a *test-mode* key (sk_test_...).
+    The CLI's key lives in ~/.config/stripe/config.toml (test_mode_api_key).
+    """)
+  end
+
+  defp preflight!(key) do
+    unless String.starts_with?(key, ["sk_test_", "rk_test_"]) do
+      Mix.raise("Refusing to run: the key is not a test-mode key (sk_test_/rk_test_).")
+    end
+
+    case Stripe.Customer.list(%{limit: 1}, api_key: key) do
+      {:ok, _} ->
+        info("✓ preflight: test-mode key accepted")
+
+      {:error, %Stripe.Error{extra: %{http_status: 401}}} ->
+        Mix.raise("""
+        Stripe rejected the key (401). Test-mode keys expire every 90 days —
+        this one is likely expired, not wrong. Refresh with `stripe login`
+        and re-run.
+        """)
+
+      {:error, err} ->
+        Mix.raise("Stripe preflight failed: #{inspect(err)}")
+    end
+  end
+
+  defp step_scratch_user(state) do
+    suffix = System.system_time(:second)
+    email = "lifecycle-verify-#{suffix}@example.com"
+
+    {:ok, user} = Accounts.register_user(%{"email" => email, "password" => "scratch-#{suffix}!"})
+    {:ok, user} = Accounts.verify_email(user)
+    remember(%{state | user: user})
+
+    check!("scratch user starts trialing", user.subscription_status == "trialing")
+    check!("gate open while trialing", Billing.check_active(user.id) == :ok)
+    %{state | user: user}
+  end
+
+  defp step_clock_and_customer(%{user: user} = state) do
+    now = System.system_time(:second)
+    {:ok, clock} = Stripe.TestHelpers.TestClock.create(%{frozen_time: now})
+    state = remember(%{state | clock: clock})
+
+    {:ok, customer} =
+      Stripe.Customer.create(%{
+        email: user.email,
+        test_clock: clock.id,
+        metadata: %{"user_id" => user.id, "purpose" => "lifecycle-verify"}
+      })
+
+    {:ok, user} = user |> User.billing_changeset(%{stripe_customer_id: customer.id}) |> Repo.update()
+
+    info("✓ test clock #{clock.id} + customer #{customer.id}")
+    %{state | user: user}
+  end
+
+  defp step_trial(%{user: user} = state) do
+    price = ensure_price!()
+    previous = Application.get_env(:fountain, :stripe_price_id)
+    Application.put_env(:fountain, :stripe_price_id, price)
+
+    try do
+      {:ok, user} = Billing.start_trial_subscription(user)
+
+      check!("trialing after subscription create", user.subscription_status == "trialing")
+      check!("trial_ends_at recorded from Stripe", match?(%DateTime{}, user.trial_ends_at))
+
+      days = DateTime.diff(user.trial_ends_at, DateTime.utc_now(), :day)
+      check!("trial is ~#{Billing.trial_days()} days (got #{days})", days in 13..14)
+      check!("gate open on real trial", Billing.check_active(user.id) == :ok)
+
+      %{state | user: Repo.reload!(user)}
+    after
+      Application.put_env(:fountain, :stripe_price_id, previous)
+    end
+  end
+
+  defp step_trial_ending_warning(%{user: user, clock: clock} = state) do
+    target = DateTime.to_unix(user.trial_ends_at) - 3 * 86_400 + 3600
+    clock = advance!(clock, target)
+
+    sub = fetch_subscription!(user)
+    {:ok, _} = Billing.sync_subscription(event("customer.subscription.trial_will_end", sub))
+
+    import Ecto.Query
+
+    enqueued =
+      Repo.exists?(
+        from j in Oban.Job,
+          where:
+            j.worker == "Fountain.Workers.TrialEndingEmail" and
+              fragment("?->>'user_id' = ?", j.args, ^user.id)
+      )
+
+    check!("T-3d: trial-ending email enqueued", enqueued)
+    %{state | clock: clock}
+  end
+
+  defp step_trial_expiry(%{user: user, clock: clock} = state) do
+    clock = advance!(clock, DateTime.to_unix(user.trial_ends_at) + 3600)
+
+    # missing_payment_method: cancel — Stripe cancels the sub at trial end
+    sub = poll_subscription_status!(user, "canceled")
+
+    {:ok, user} = Billing.sync_subscription(event("customer.subscription.deleted", sub))
+
+    check!("canceled after trial expiry", user.subscription_status == "canceled")
+
+    check!(
+      "gate refuses after expiry",
+      Billing.check_active(user.id) == {:error, :subscription_required}
+    )
+
+    %{state | user: user, clock: clock}
+  end
+
+  defp step_subscribe(%{user: user} = state) do
+    sub = create_paid_subscription!(user)
+
+    {:ok, user} = Billing.sync_subscription(event("customer.subscription.created", sub))
+
+    check!("active after checkout-equivalent subscribe", user.subscription_status == "active")
+    check!("gate reopens when paid", Billing.check_active(user.id) == :ok)
+    %{state | user: user}
+  end
+
+  defp step_cancel_at_period_end(%{user: user} = state) do
+    sub = fetch_subscription!(user, :active)
+    {:ok, sub} = Stripe.Subscription.update(sub.id, %{cancel_at_period_end: true})
+
+    {:ok, user} = Billing.sync_subscription(event("customer.subscription.updated", sub))
+
+    check!(
+      "cancel-at-period-end: access retained (still active)",
+      user.subscription_status == "active"
+    )
+
+    check!("gate still open until period end", Billing.check_active(user.id) == :ok)
+    %{state | user: user}
+  end
+
+  defp step_period_end(%{user: user, clock: clock} = state) do
+    sub = fetch_subscription!(user, :active)
+    clock = advance!(clock, sub.current_period_end + 3600)
+    sub = poll_subscription_status!(user, "canceled")
+
+    {:ok, user} = Billing.sync_subscription(event("customer.subscription.deleted", sub))
+
+    check!("canceled at period end", user.subscription_status == "canceled")
+
+    check!(
+      "gate refuses after period end",
+      Billing.check_active(user.id) == {:error, :subscription_required}
+    )
+
+    %{state | user: user, clock: clock}
+  end
+
+  defp step_resubscribe(%{user: user} = state) do
+    sub = create_paid_subscription!(user)
+
+    {:ok, user} = Billing.sync_subscription(event("customer.subscription.created", sub))
+
+    check!("return path: re-subscribe reactivates", user.subscription_status == "active")
+    check!("gate open again", Billing.check_active(user.id) == :ok)
+    %{state | user: user}
+  end
+
+  # ── Stripe helpers ─────────────────────────────────────────────────────────
+
+  # A synthetic event around a real fetched object — what the webhook
+  # controller would hand to sync after signature verification. Fed to
+  # `sync_subscription/1` directly (not `handle_event/1`), so the synthetic id
+  # is never claimed into `stripe_events` and cannot pollute admin counts.
+  defp event(type, object) do
+    %Stripe.Event{
+      id: "evt_lifecycle_verify_#{System.unique_integer([:positive])}",
+      account: "",
+      api_version: nil,
+      created: System.system_time(:second),
+      data: %{object: object},
+      livemode: false,
+      object: "event",
+      pending_webhooks: 0,
+      request: nil,
+      type: type
+    }
+  end
+
+  defp ensure_price! do
+    case System.get_env("STRIPE_PRICE_ID") do
+      id when is_binary(id) and id != "" ->
+        id
+
+      _ ->
+        {:ok, product} = Stripe.Product.create(%{name: "lifecycle-verify (scratch)"})
+
+        {:ok, price} =
+          Stripe.Price.create(%{
+            product: product.id,
+            unit_amount: 2900,
+            currency: "usd",
+            recurring: %{interval: :month}
+          })
+
+        price.id
+    end
+  end
+
+  defp create_paid_subscription!(user) do
+    {:ok, pm} = Stripe.PaymentMethod.attach("pm_card_visa", %{customer: user.stripe_customer_id})
+
+    {:ok, _} =
+      Stripe.Customer.update(user.stripe_customer_id, %{
+        invoice_settings: %{default_payment_method: pm.id}
+      })
+
+    {:ok, sub} =
+      Stripe.Subscription.create(%{
+        customer: user.stripe_customer_id,
+        items: [%{price: ensure_price!()}]
+      })
+
+    sub
+  end
+
+  defp advance!(clock, unix_time) do
+    {:ok, clock} = Stripe.TestHelpers.TestClock.advance(clock.id, %{frozen_time: unix_time})
+    wait_ready!(clock, @clock_poll_attempts)
+  end
+
+  defp wait_ready!(%{status: "ready"} = clock, _attempts), do: clock
+
+  defp wait_ready!(clock, 0), do: Mix.raise("test clock #{clock.id} never became ready")
+
+  defp wait_ready!(clock, attempts) do
+    Process.sleep(@clock_poll_ms)
+    {:ok, clock} = Stripe.TestHelpers.TestClock.retrieve(clock.id)
+    wait_ready!(clock, attempts - 1)
+  end
+
+  defp fetch_subscription!(user, status \\ :all) do
+    {:ok, %{data: subs}} =
+      Stripe.Subscription.list(%{customer: user.stripe_customer_id, status: status, limit: 10})
+
+    case subs do
+      [sub | _] -> sub
+      [] -> Mix.raise("no subscription with status #{status} for #{user.stripe_customer_id}")
+    end
+  end
+
+  defp poll_subscription_status!(user, want, attempts \\ 30)
+
+  defp poll_subscription_status!(_user, want, 0),
+    do: Mix.raise("subscription never reached status #{want}")
+
+  defp poll_subscription_status!(user, want, attempts) do
+    sub = fetch_subscription!(user)
+
+    if sub.status == want do
+      sub
+    else
+      Process.sleep(@clock_poll_ms)
+      poll_subscription_status!(user, want, attempts - 1)
+    end
+  end
+
+  # ── Bookkeeping ────────────────────────────────────────────────────────────
+
+  # `try/after` cannot see rebound step state, so keep the latest for cleanup.
+  defp remember(state) do
+    Process.put(:lifecycle_verify_state, state)
+    state
+  end
+
+  defp state_now, do: Process.get(:lifecycle_verify_state, %{user: nil, clock: nil})
+
+  defp cleanup(%{user: user, clock: clock}) do
+    if clock do
+      case Stripe.TestHelpers.TestClock.delete(clock.id) do
+        {:ok, _} -> info("✓ cleanup: test clock deleted (removes its Stripe objects)")
+        {:error, err} -> info("! cleanup: could not delete clock #{clock.id}: #{inspect(err)}")
+      end
+    end
+
+    if user do
+      # The clock deletion tears down the Stripe side; detach the customer so
+      # local deletion does not try to cancel an already-torn-down subscription.
+      user = Repo.reload!(user)
+      {:ok, user} = user |> Ecto.Changeset.change(stripe_customer_id: nil) |> Repo.update()
+
+      case Fountain.Accounts.Deletion.delete_user(user, actor: "system:lifecycle-verify") do
+        {:ok, _} -> info("✓ cleanup: scratch user deleted")
+        {:error, err} -> info("! cleanup: scratch user #{user.id} not deleted: #{inspect(err)}")
+      end
+    end
+  end
+
+  defp check!(description, true), do: info("✓ #{description}")
+  defp check!(description, other), do: Mix.raise("✗ #{description} — got: #{inspect(other)}")
+
+  defp info(msg), do: Mix.shell().info(msg)
+end

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -57,3 +57,35 @@ trial-ending threshold (the reminder email enqueues) and past trial end (the
 status flips and the gate refuses). The clock must be attached when the
 customer is created, so this is a deliberate test-mode exercise rather than
 something you bolt onto an existing signup.
+
+## Release verification: `mix fountain.verify_lifecycle`
+
+The Test Clock exercise above is automated as a repeatable command — run it
+before releasing **any billing-touching change**:
+
+```bash
+STRIPE_SECRET_KEY=sk_test_... mix fountain.verify_lifecycle
+```
+
+It creates a scratch user and a Test Clock, then walks the whole lifecycle —
+trial → T-3d warning email enqueued → expiry (gate refuses) → paid
+subscription with a test card (gate opens) → cancel at period end (access
+retained) → period end (gate refuses) → re-subscribe (the return path) —
+asserting the **Fountain-side** state at every step. Each fetched Stripe
+state is fed through `Billing.sync_subscription/1`, exactly what the webhook
+controller does after signature verification; webhook *delivery* needs a
+public endpoint and stays out of scope. Cleanup (clock + scratch user) runs
+even when a step fails.
+
+Notes:
+
+- **Test-mode key only** — live keys are refused outright. The CLI's key
+  lives in `~/.config/stripe/config.toml` (`test_mode_api_key`) and expires
+  every 90 days; an expired key fails the preflight with a `stripe login`
+  hint rather than a misleading mid-run error.
+- Runs against the dev database; the scratch user is deleted afterwards.
+- Deliberately **not CI**: external, ~1–2 minutes of clock advances, needs a
+  key. It is a release-check, run by a person (or an agent) with the result
+  pasted into the PR that motivated it.
+- `STRIPE_PRICE_ID` is honored when set; otherwise a throwaway test-mode
+  product/price is created under the clock's lifetime.

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,11 @@ defmodule Fountain.Umbrella.MixProject do
         # fails to credit string-form filters as used and would fail the run.
         # Audit the ignore file by hand with `mix dialyzer --list-unused-filters`
         # (tuple entries report accurately) when trimming it.
-        plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
+        plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
+        # :mix so Mix.Task-based tasks (mix fountain.verify_lifecycle)
+        # analyze cleanly — without it every Mix.* call is "unknown function"
+        # and the task's whole call graph degrades to no_return noise.
+        plt_add_apps: [:mix]
       ]
     ]
   end


### PR DESCRIPTION
Closes #289.

## What changed

**`mix fountain.verify_lifecycle`** — the one-off Test Clock session from the #244 verification, made a command. It creates a scratch user and a Stripe Test Clock, then walks: trial subscription (via the real `Billing.start_trial_subscription/1` path) → clock to T-3d → `TrialEndingEmail` enqueued → clock past trial end → `canceled`, gate refuses → subscribe with a test card (the checkout-completes equivalent) → `active`, gate opens → portal-style cancel-at-period-end → access retained → clock past period end → `canceled`, gate refuses → re-subscribe → `active` again (the return path).

Design decisions:
- **Asserts Fountain-side state only** (status, `trial_ends_at`, `Billing.check_active/1`, enqueued jobs) — per the issue, the Stripe side is theirs to test. Real test-mode objects are still used so our sync sees real shapes; each fetched state is fed through `Billing.sync_subscription/1`, exactly what the webhook controller does after signature verification. Webhook *delivery* needs a public endpoint and stays out of scope. Synthetic event ids are never claimed into `stripe_events` (sync is called directly), so admin conversion counts can't be polluted.
- **Test-mode keys only** — `sk_live_`/`rk_live_` refused outright. An expired key (they expire every 90 days) fails the preflight with a `stripe login` hint instead of a misleading mid-run error — the issue's explicit requirement.
- **Cleanup always runs** (`try/after`): the Test Clock is deleted (tearing down its Stripe objects) and the scratch user is deleted through the real `Accounts.Deletion` path.
- **Not CI**, documented as the release-verification step for billing-touching changes in `docs/integrations/stripe.md`.
- Adds `:mix` to the dialyzer PLT so `Mix.Task` code analyzes cleanly.

## Kept honest by running it

Full run against Stripe test mode from this branch — every step:

```
✓ preflight: test-mode key accepted
✓ scratch user starts trialing
✓ gate open while trialing
✓ test clock … + customer …
✓ trialing after subscription create
✓ trial_ends_at recorded from Stripe
✓ trial is ~14 days (got 13)
✓ gate open on real trial
✓ T-3d: trial-ending email enqueued
✓ canceled after trial expiry
✓ gate refuses after expiry
✓ active after checkout-equivalent subscribe
✓ gate reopens when paid
✓ cancel-at-period-end: access retained (still active)
✓ gate still open until period end
✓ canceled at period end
✓ gate refuses after period end
✓ return path: re-subscribe reactivates
✓ gate open again
✅  Lifecycle verified end to end.
✓ cleanup: test clock deleted (removes its Stripe objects)
✓ cleanup: scratch user deleted
```

`mix precommit`: 1560 tests, 0 failures. (The task itself has no unit tests on purpose — it *is* the test, and CI must not call Stripe.)

After the rest of the lifecycle push merges (#341 emails, #343 period-end fields), this script is the natural place to also assert the trial-expired/canceled emails and the `cancel_at_period_end` flag — noted here so the follow-up is loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)