### PR TITLE
billing: roll back the webhook claim when the apply fails (#312)

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -457,16 +457,28 @@ defmodule Fountain.Billing do
   `customer.subscription.updated{active}` arriving after `.deleted` silently
   reactivates a cancelled account.
 
+  Claim and apply run in one transaction: a failed apply rolls the claim back.
+  Otherwise the two halves defeat each other — the controller answers 500 so
+  Stripe redelivers, but the redelivery hits the already-claimed id and dedupes
+  into a no-op, and the event is lost for good. If that event was the
+  `customer.subscription.deleted` that ends a trial, no later event ever
+  corrects it.
+
   Returns `{:ok, :duplicate}` for an event already seen.
   """
   @spec handle_event(Stripe.Event.t()) ::
           {:ok, User.t() | :ignored | :duplicate | :stale} | {:error, term()}
   def handle_event(%Stripe.Event{id: id, type: type} = event) when is_binary(id) do
-    if claim_event(id, type) == :claimed do
-      sync_subscription(event)
-    else
-      {:ok, :duplicate}
-    end
+    Repo.transaction(fn ->
+      if claim_event(id, type) == :claimed do
+        case sync_subscription(event) do
+          {:ok, result} -> result
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      else
+        :duplicate
+      end
+    end)
   end
 
   # No id (hand-built events in tests) — nothing to dedupe against.

--- a/apps/fountain/test/fountain/stripe_webhook_idempotency_test.exs
+++ b/apps/fountain/test/fountain/stripe_webhook_idempotency_test.exs
@@ -191,6 +191,52 @@ defmodule Fountain.StripeWebhookIdempotencyTest do
     end
   end
 
+  describe "a failed apply releases the claim" do
+    # The 2026-08 audit's cancelling-pair finding (#312): idempotency claimed the
+    # event id, then the apply failed outside the claim's transaction. The 500
+    # made Stripe redeliver — into {:ok, :duplicate}. Both halves passed their
+    # own tests; this one exercises them together.
+    test "the redelivery that the 500 obtains actually applies" do
+      event =
+        sub_event(
+          "evt_retry",
+          "customer.subscription.deleted",
+          "cus_late_link",
+          "canceled",
+          now_unix()
+        )
+
+      # First delivery fails mid-apply: no user carries this customer id yet.
+      assert {:error, :user_not_found} = Billing.handle_event(event)
+
+      # The customer gets linked, then Stripe redelivers the same event id.
+      # With the claim rolled back this applies; before, it deduped to a no-op
+      # and the cancellation was lost forever.
+      user = user_with_customer("cus_late_link")
+
+      assert {:ok, updated} = Billing.handle_event(event)
+      assert updated.subscription_status == "canceled"
+      assert Repo.reload(user).subscription_status == "canceled"
+    end
+
+    test "a successful apply still claims — the redelivery dedupes" do
+      user = user_with_customer("cus_claimed")
+
+      event =
+        sub_event(
+          "evt_claimed",
+          "customer.subscription.updated",
+          "cus_claimed",
+          "active",
+          now_unix()
+        )
+
+      assert {:ok, _} = Billing.handle_event(event)
+      assert {:ok, :duplicate} = Billing.handle_event(event)
+      assert Repo.reload(user).subscription_status == "active"
+    end
+  end
+
   describe "unrelated events" do
     test "an unhandled type is claimed but ignored" do
       event = %Stripe.Event{


### PR DESCRIPTION
Closes #312 — the first of the audit's cancelling pairs: webhook idempotency (#214) claimed the event id before the apply, so the 500-driven redelivery (also #214) deduped into a no-op and a failed event was lost forever. If that event was the `customer.subscription.deleted` ending a trial, the account stayed active indefinitely with no later signal.

## Change

- `Billing.handle_event/1` now runs claim + apply in one `Repo.transaction`: a failed apply rolls the claim back, so Stripe's redelivery finds the id unclaimed and actually applies.
- A successful apply commits the claim exactly as before — replay and ordering protection unchanged; all existing idempotency tests pass untouched.
- Side benefit: concurrent deliveries of the same id now serialize on the claim row's unique key, and the loser only dedupes if the winner *committed*.

## Test

Per the audit's note on paired fixes, the new test exercises both halves on the same path: a `customer.subscription.deleted` for a not-yet-linked customer fails mid-apply (`{:error, :user_not_found}`), the customer is then linked, and the redelivery of the same event id must cancel the account. **Verified to fail against the previous code** (redelivery returned `{:ok, :duplicate}` and the cancellation was lost).

Full suite: 1537 tests, 0 failures. `mix format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)