### PR TITLE
billing: key webhook sync by subscription, not customer (#309)

### DIFF
--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -26,6 +26,10 @@ defmodule Fountain.Accounts.User do
     field :max_concurrent_sandboxes, :integer, default: 5
     field :role, :string, default: "user"
     field :stripe_customer_id, :string
+    # The subscription of record. Webhook sync applies events for this
+    # subscription only — a customer can briefly carry two (mid-trial upgrade),
+    # and customer-keyed sync let the doomed one write the account's status.
+    field :stripe_subscription_id, :string
     field :subscription_status, :string, default: "trialing"
     field :trial_ends_at, :utc_datetime
     field :suspended_at, :utc_datetime
@@ -96,6 +100,7 @@ defmodule Fountain.Accounts.User do
     user
     |> cast(attrs, [
       :stripe_customer_id,
+      :stripe_subscription_id,
       :subscription_status,
       :trial_ends_at,
       :subscription_synced_at,

--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -205,6 +205,7 @@ defmodule Fountain.Billing do
       {:ok, sub} ->
         user
         |> User.billing_changeset(%{
+          stripe_subscription_id: sub.id,
           subscription_status: to_string(sub.status),
           trial_ends_at: unix_to_datetime(Map.get(sub, :trial_end)),
           subscription_synced_at: DateTime.utc_now() |> DateTime.truncate(:second)
@@ -467,7 +468,9 @@ defmodule Fountain.Billing do
   Returns `{:ok, :duplicate}` for an event already seen.
   """
   @spec handle_event(Stripe.Event.t()) ::
-          {:ok, User.t() | :ignored | :duplicate | :stale} | {:error, term()}
+          {:ok,
+           User.t() | :ignored | :duplicate | :stale | :comped_ignored | :other_subscription}
+          | {:error, term()}
   def handle_event(%Stripe.Event{id: id, type: type} = event) when is_binary(id) do
     Repo.transaction(fn ->
       if claim_event(id, type) == :claimed do
@@ -507,33 +510,36 @@ defmodule Fountain.Billing do
   Syncs `users.subscription_status` (and `trial_ends_at`) from a verified
   Stripe webhook event.
 
-  Handles `customer.subscription.created`, `.updated`, `.deleted`.
+  Handles `customer.subscription.created`, `.updated`, `.deleted` — keyed by
+  **subscription**, not customer: the customer only locates the user, and an
+  event naming any subscription other than `users.stripe_subscription_id`
+  returns `{:ok, :other_subscription}` without touching the account. The
+  subscription of record is set at trial creation
+  (`start_trial_subscription/1`) and replaced when a Checkout completes
+  (`checkout.session.completed` adopts the new subscription and cancels every
+  other live one on the customer).
+
   All other event types return `{:ok, :ignored}` without touching the DB.
   """
-  @spec sync_subscription(Stripe.Event.t()) :: {:ok, User.t() | :ignored} | {:error, term()}
+  @spec sync_subscription(Stripe.Event.t()) ::
+          {:ok, User.t() | :ignored | :stale | :comped_ignored | :other_subscription}
+          | {:error, term()}
   def sync_subscription(%Stripe.Event{
         type: "checkout.session.completed",
         data: %{object: session}
       }) do
-    customer_id = extract_customer_id(Map.get(session, :customer))
+    customer_id = extract_stripe_id(Map.get(session, :customer))
+    subscription_id = extract_stripe_id(Map.get(session, :subscription))
     user_id = Map.get(session, :client_reference_id)
 
+    user =
+      get_user_by_stripe_customer_id(customer_id) ||
+        (is_binary(user_id) && Repo.get(User, user_id)) || nil
+
     cond do
-      is_nil(customer_id) ->
-        {:ok, :ignored}
-
-      # Already linked — the subscription events will carry the same customer.
-      not is_nil(get_user_by_stripe_customer_id(customer_id)) ->
-        {:ok, :ignored}
-
-      is_binary(user_id) ->
-        case Repo.get(User, user_id) do
-          nil -> {:error, :user_not_found}
-          user -> attach_stripe_customer(user, customer_id)
-        end
-
-      true ->
-        {:error, :user_not_found}
+      is_nil(customer_id) -> {:ok, :ignored}
+      is_nil(user) -> {:error, :user_not_found}
+      true -> complete_checkout(user, customer_id, subscription_id)
     end
   end
 
@@ -549,7 +555,7 @@ defmodule Fountain.Billing do
         type: "customer.subscription.trial_will_end",
         data: %{object: sub}
       }) do
-    customer_id = extract_customer_id(Map.get(sub, :customer))
+    customer_id = extract_stripe_id(Map.get(sub, :customer))
 
     case customer_id && get_user_by_stripe_customer_id(customer_id) do
       %User{} = user ->
@@ -573,7 +579,8 @@ defmodule Fountain.Billing do
              "customer.subscription.updated",
              "customer.subscription.deleted"
            ] do
-    customer_id = extract_customer_id(sub.customer)
+    customer_id = extract_stripe_id(sub.customer)
+    subscription_id = Map.get(sub, :id)
     status = coerce_status(sub.status, type)
 
     trial_ends_at =
@@ -610,25 +617,38 @@ defmodule Fountain.Billing do
         {:ok, :comped_ignored}
 
       user ->
-        if stale?(user.subscription_synced_at, event_created) do
-          # An older event arriving after a newer one. Applying it would move the
-          # account backwards — reactivating a cancellation, or re-locking an
-          # account that has already recovered.
-          {:ok, :stale}
-        else
-          user
-          |> User.billing_changeset(%{
-            subscription_status: status,
-            trial_ends_at: trial_ends_at,
-            subscription_synced_at: event_created || user.subscription_synced_at,
-            cancel_at_period_end: cancel_at_period_end,
-            current_period_end: current_period_end
-          })
-          |> Repo.update()
-          |> tap(fn
-            {:ok, updated} -> enqueue_lifecycle_email(user.subscription_status, updated)
-            _ -> :ok
-          end)
+        cond do
+          # The customer is how we find the user; the subscription is what the
+          # event is *about*, and only the subscription of record may write the
+          # account's status. A customer briefly carries two subscriptions
+          # during a mid-trial upgrade, and before this filter the doomed
+          # trial's deletion event locked out the paying account (#309).
+          other_subscription?(user, subscription_id) ->
+            {:ok, :other_subscription}
+
+          stale?(user.subscription_synced_at, event_created) ->
+            # An older event arriving after a newer one. Applying it would move
+            # the account backwards — reactivating a cancellation, or
+            # re-locking an account that has already recovered.
+            {:ok, :stale}
+
+          true ->
+            user
+            |> User.billing_changeset(
+              %{
+                subscription_status: status,
+                trial_ends_at: trial_ends_at,
+                subscription_synced_at: event_created || user.subscription_synced_at,
+                cancel_at_period_end: cancel_at_period_end,
+                current_period_end: current_period_end
+              }
+              |> maybe_adopt_subscription_id(user, subscription_id, type)
+            )
+            |> Repo.update()
+            |> tap(fn
+              {:ok, updated} -> enqueue_lifecycle_email(user.subscription_status, updated)
+              _ -> :ok
+            end)
         end
     end
   end
@@ -676,6 +696,100 @@ defmodule Fountain.Billing do
         end
     end
   end
+
+  # A session with no subscription (payment mode, or an old-style session) only
+  # backfills the customer link, exactly as before.
+  defp complete_checkout(%User{} = user, customer_id, nil) do
+    if user.stripe_customer_id == customer_id do
+      {:ok, :ignored}
+    else
+      attach_stripe_customer(user, customer_id)
+    end
+  end
+
+  defp complete_checkout(%User{} = user, customer_id, subscription_id) do
+    linked =
+      if user.stripe_customer_id == customer_id do
+        {:ok, user}
+      else
+        attach_stripe_customer(user, customer_id)
+      end
+
+    with {:ok, user} <- linked, do: adopt_subscription(user, subscription_id)
+  end
+
+  # Checkout in subscription mode always creates a *new* subscription, so a
+  # mid-trial upgrade leaves the old trialing subscription alive alongside it.
+  # Left alone, that subscription either dies at trial end — and its deletion
+  # webhook locks out a now-paying customer — or converts and double-bills
+  # them. Adopt the checkout's subscription as the account's subscription of
+  # record and cancel every other live one.
+  #
+  # The status write is the optimistic copy the new subscription's own webhook
+  # will confirm — necessary because that webhook may have already arrived and
+  # been ignored for carrying an unrecorded subscription id.
+  #
+  # A failed Stripe call surfaces as an error so the webhook answers 500 and
+  # Stripe redelivers; handle_event/1 rolls the claim (and the writes here)
+  # back, and already-cancelled subscriptions are skipped on the retry.
+  defp adopt_subscription(%User{subscription_status: "comped"} = user, _subscription_id),
+    do: {:ok, user}
+
+  defp adopt_subscription(%User{stripe_subscription_id: sub_id} = user, sub_id), do: {:ok, user}
+
+  defp adopt_subscription(%User{} = user, subscription_id) do
+    with {:ok, _cancelled} <- cancel_other_subscriptions(user, subscription_id) do
+      user
+      |> User.billing_changeset(%{
+        stripe_subscription_id: subscription_id,
+        subscription_status: "active"
+      })
+      |> Repo.update()
+    end
+  end
+
+  defp cancel_other_subscriptions(%User{stripe_customer_id: customer_id}, keep_sub_id) do
+    case Stripe.Subscription.list(%{customer: customer_id, status: :all, limit: 100}) do
+      {:ok, %{data: subs} = list} ->
+        if Map.get(list, :has_more, false) do
+          {:error, :too_many_subscriptions}
+        else
+          subs
+          |> Enum.filter(&(&1.id != keep_sub_id and to_string(&1.status) in @cancellable))
+          |> cancel_each()
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # An event that names a different subscription than the account's recorded
+  # one is about a subscription this account no longer answers to. An event
+  # with no subscription id (hand-built in tests) and an account with none
+  # recorded (created before the id was persisted) both fall back to the old
+  # customer-keyed behavior.
+  defp other_subscription?(%User{stripe_subscription_id: recorded}, incoming)
+       when is_binary(recorded) and is_binary(incoming),
+       do: recorded != incoming
+
+  defp other_subscription?(_user, _incoming), do: false
+
+  # A legacy account (nil recorded id) adopts the subscription from the first
+  # live event that names one — but never from a deletion: during a pre-fix
+  # double-subscription window the dying trial must not become the subscription
+  # of record while a paying one is alive; the paying one's next event adopts
+  # and corrects instead.
+  defp maybe_adopt_subscription_id(
+         attrs,
+         %User{stripe_subscription_id: nil},
+         subscription_id,
+         type
+       )
+       when is_binary(subscription_id) and type != "customer.subscription.deleted",
+       do: Map.put(attrs, :stripe_subscription_id, subscription_id)
+
+  defp maybe_adopt_subscription_id(attrs, _user, _subscription_id, _type), do: attrs
 
   defp event_created_at(%Stripe.Event{created: ts}) when is_integer(ts),
     do: DateTime.from_unix!(ts) |> DateTime.truncate(:second)
@@ -908,10 +1022,11 @@ defmodule Fountain.Billing do
     Repo.get_by(User, stripe_customer_id: customer_id)
   end
 
-  # Stripe can return the customer as a plain string ID or as an expanded object.
-  defp extract_customer_id(customer) when is_binary(customer), do: customer
-  defp extract_customer_id(%{id: id}) when is_binary(id), do: id
-  defp extract_customer_id(_), do: nil
+  # Stripe returns related objects (customer, subscription) as either a plain
+  # string id or an expanded object, depending on the event and API version.
+  defp extract_stripe_id(value) when is_binary(value), do: value
+  defp extract_stripe_id(%{id: id}) when is_binary(id), do: id
+  defp extract_stripe_id(_), do: nil
 
   # Deleted events always map to "canceled" regardless of the Stripe status field.
   defp coerce_status(_stripe_status, "customer.subscription.deleted"), do: "canceled"

--- a/apps/fountain/priv/repo/migrations/20260802190000_add_stripe_subscription_id_to_users.exs
+++ b/apps/fountain/priv/repo/migrations/20260802190000_add_stripe_subscription_id_to_users.exs
@@ -1,0 +1,13 @@
+defmodule Fountain.Repo.Migrations.AddStripeSubscriptionIdToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      # The account's Stripe subscription of record. Webhook sync is keyed by
+      # this, not by customer: a customer can briefly carry two subscriptions
+      # (mid-trial upgrade), and customer-keyed sync let either one write the
+      # account's status (#309).
+      add :stripe_subscription_id, :string
+    end
+  end
+end

--- a/apps/fountain/test/fountain/billing_payment_path_test.exs
+++ b/apps/fountain/test/fountain/billing_payment_path_test.exs
@@ -111,6 +111,241 @@ defmodule Fountain.BillingPaymentPathTest do
     end
   end
 
+  describe "mid-trial upgrade" do
+    # The #309 chain: Checkout in subscription mode always creates a *new*
+    # subscription, so an upgrade during the trial leaves two alive. Stripe
+    # then cancels the trial one (created with missing_payment_method: :cancel)
+    # at trial end, and customer-keyed sync applied that cancellation to the
+    # account of a customer who is paying on the other subscription.
+
+    defp trialing_user_on(customer_id, sub_id) do
+      user = insert_verified_user()
+      {:ok, user} = Billing.attach_stripe_customer(user, customer_id)
+
+      {:ok, user} =
+        user
+        |> User.billing_changeset(%{stripe_subscription_id: sub_id})
+        |> Repo.update()
+
+      user
+    end
+
+    defp sub_event(id, type, customer, sub_id, status, created) do
+      %Stripe.Event{
+        id: id,
+        type: type,
+        created: created,
+        data: %{object: %{id: sub_id, customer: customer, status: status, trial_end: nil}}
+      }
+    end
+
+    defp now_unix, do: DateTime.utc_now() |> DateTime.to_unix()
+
+    test "checkout completion adopts the new subscription and cancels the trial one" do
+      user = trialing_user_on("cus_upgrade", "sub_trial")
+      test = self()
+
+      expect(Stripe.Subscription, :list, fn %{customer: "cus_upgrade", status: :all} ->
+        {:ok,
+         %{
+           data: [
+             %Stripe.Subscription{id: "sub_trial", status: "trialing"},
+             %Stripe.Subscription{id: "sub_paid", status: "active"}
+           ],
+           has_more: false
+         }}
+      end)
+
+      expect(Stripe.Subscription, :cancel, fn id ->
+        send(test, {:cancelled, id})
+        {:ok, %Stripe.Subscription{id: id, status: "canceled"}}
+      end)
+
+      event = %Stripe.Event{
+        id: "evt_checkout_up",
+        type: "checkout.session.completed",
+        created: now_unix(),
+        data: %{
+          object: %{
+            customer: "cus_upgrade",
+            subscription: "sub_paid",
+            client_reference_id: user.id
+          }
+        }
+      }
+
+      assert {:ok, updated} = Billing.handle_event(event)
+      assert updated.stripe_subscription_id == "sub_paid"
+      assert updated.subscription_status == "active"
+
+      # Only the trial subscription is cancelled — never the one just paid for.
+      assert_received {:cancelled, "sub_trial"}
+      refute_received {:cancelled, "sub_paid"}
+    end
+
+    test "the dead trial subscription's deletion cannot lock out the paying account" do
+      # Both halves on one path: the upgrade above, then the straggler event
+      # Stripe sends when the abandoned trial subscription dies.
+      user = trialing_user_on("cus_locked", "sub_trial2")
+
+      stub(Stripe.Subscription, :list, fn _ ->
+        {:ok, %{data: [%Stripe.Subscription{id: "sub_trial2", status: "trialing"}], has_more: false}}
+      end)
+
+      stub(Stripe.Subscription, :cancel, fn id ->
+        {:ok, %Stripe.Subscription{id: id, status: "canceled"}}
+      end)
+
+      t0 = now_unix()
+
+      {:ok, _} =
+        Billing.handle_event(%Stripe.Event{
+          id: "evt_up2",
+          type: "checkout.session.completed",
+          created: t0,
+          data: %{
+            object: %{
+              customer: "cus_locked",
+              subscription: "sub_paid2",
+              client_reference_id: user.id
+            }
+          }
+        })
+
+      # The deletion for the old subscription arrives later, so the staleness
+      # guard alone would have let it through.
+      assert {:ok, :other_subscription} =
+               Billing.handle_event(
+                 sub_event(
+                   "evt_trial_dies",
+                   "customer.subscription.deleted",
+                   "cus_locked",
+                   "sub_trial2",
+                   "canceled",
+                   t0 + 60
+                 )
+               )
+
+      reloaded = Repo.reload(user)
+      assert reloaded.subscription_status == "active"
+      assert reloaded.stripe_subscription_id == "sub_paid2"
+
+      # The subscription of record still syncs normally.
+      assert {:ok, updated} =
+               Billing.handle_event(
+                 sub_event(
+                   "evt_paid_pd",
+                   "customer.subscription.updated",
+                   "cus_locked",
+                   "sub_paid2",
+                   "past_due",
+                   t0 + 120
+                 )
+               )
+
+      assert updated.subscription_status == "past_due"
+    end
+
+    test "a legacy account with no recorded subscription adopts from the first live event" do
+      user = insert_verified_user()
+      {:ok, user} = Billing.attach_stripe_customer(user, "cus_legacy")
+
+      assert {:ok, updated} =
+               Billing.sync_subscription(
+                 sub_event(
+                   "evt_legacy",
+                   "customer.subscription.updated",
+                   "cus_legacy",
+                   "sub_adopted",
+                   "active",
+                   now_unix()
+                 )
+               )
+
+      assert updated.stripe_subscription_id == "sub_adopted"
+      assert updated.subscription_status == "active"
+      assert Repo.reload(user).stripe_subscription_id == "sub_adopted"
+    end
+
+    test "a legacy account applies but does not adopt from a deletion" do
+      # During a pre-fix double-subscription window the dying trial must not
+      # become the subscription of record; the paying subscription's next
+      # event adopts and corrects instead.
+      user = insert_verified_user()
+      {:ok, user} = Billing.attach_stripe_customer(user, "cus_legacy_del")
+      t0 = now_unix()
+
+      assert {:ok, updated} =
+               Billing.sync_subscription(
+                 sub_event(
+                   "evt_legacy_del",
+                   "customer.subscription.deleted",
+                   "cus_legacy_del",
+                   "sub_doomed",
+                   "canceled",
+                   t0
+                 )
+               )
+
+      assert updated.subscription_status == "canceled"
+      assert updated.stripe_subscription_id == nil
+
+      # The paying subscription's monthly event recovers the account.
+      assert {:ok, recovered} =
+               Billing.sync_subscription(
+                 sub_event(
+                   "evt_legacy_rec",
+                   "customer.subscription.updated",
+                   "cus_legacy_del",
+                   "sub_alive",
+                   "active",
+                   t0 + 60
+                 )
+               )
+
+      assert recovered.subscription_status == "active"
+      assert recovered.stripe_subscription_id == "sub_alive"
+      assert Repo.reload(user).subscription_status == "active"
+    end
+
+    test "a failed Stripe cancel rolls the whole checkout apply back for redelivery" do
+      user = trialing_user_on("cus_rollback", "sub_trial3")
+
+      stub(Stripe.Subscription, :list, fn _ -> {:error, :stripe_down} end)
+
+      event = %Stripe.Event{
+        id: "evt_up_fail",
+        type: "checkout.session.completed",
+        created: now_unix(),
+        data: %{
+          object: %{
+            customer: "cus_rollback",
+            subscription: "sub_paid3",
+            client_reference_id: user.id
+          }
+        }
+      }
+
+      assert {:error, :stripe_down} = Billing.handle_event(event)
+
+      # Nothing half-applied, and the event id is unclaimed for the retry.
+      reloaded = Repo.reload(user)
+      assert reloaded.stripe_subscription_id == "sub_trial3"
+
+      stub(Stripe.Subscription, :list, fn _ ->
+        {:ok, %{data: [%Stripe.Subscription{id: "sub_trial3", status: "trialing"}], has_more: false}}
+      end)
+
+      stub(Stripe.Subscription, :cancel, fn id ->
+        {:ok, %Stripe.Subscription{id: id, status: "canceled"}}
+      end)
+
+      assert {:ok, updated} = Billing.handle_event(event)
+      assert updated.stripe_subscription_id == "sub_paid3"
+      assert updated.subscription_status == "active"
+    end
+  end
+
   describe "OAuth signups" do
     test "get a Stripe customer and a trial end date" do
       # The email+password path creates the customer after verification. OAuth

--- a/apps/fountain/test/fountain/trial_expiry_test.exs
+++ b/apps/fountain/test/fountain/trial_expiry_test.exs
@@ -131,6 +131,7 @@ defmodule Fountain.TrialExpiryTest do
       assert [%{price: "price_test"}] = params.items
 
       assert updated.stripe_customer_id == "cus_new"
+      assert updated.stripe_subscription_id == "sub_new"
       assert updated.subscription_status == "trialing"
       assert updated.trial_ends_at
     end


### PR DESCRIPTION
Closes #309 (P0). **Stacked on #348** — the checkout apply relies on #348's claim rollback for safe redelivery after a failed Stripe cancel. Merge #348 first, then retarget this to `main`.

## The bug

A mid-trial upgrade created a second Stripe subscription and nothing cancelled the first. Customer-keyed sync let events from either subscription write the account: when Stripe cancelled the abandoned trial sub at trial end (`missing_payment_method: :cancel`), its `customer.subscription.deleted` passed the staleness guard and locked out a paying customer — for up to a month, until sub B's next lifecycle event. The other branch (card becomes customer default) double-billed instead.

## The fix — the durable one from the issue

- **`users.stripe_subscription_id`** (migration + schema): the subscription of record, set at trial creation, replaced when `checkout.session.completed` adopts the session's subscription.
- **Sync is subscription-keyed**: the customer locates the user; an event naming any other subscription returns `{:ok, :other_subscription}` and never touches the account.
- **Checkout completion cancels every other live subscription** on the customer — the doomed trial sub can neither die loudly nor convert and double-bill. Its status write is the optimistic copy the new subscription's own webhook confirms (that webhook may already have arrived and been ignored as unrecorded — ordering is handled both ways).
- **Legacy accounts** (nil recorded id, pre-migration) keep today's customer-keyed behavior and adopt from the first live event — but never from a deletion, so an account already in the double-subscription window still recovers via the paying subscription's next event.
- A failed Stripe cancel returns an error → webhook 500 → #348 rolls the claim and the partial writes back → redelivery retries cleanly (covered by a test).

## Tests

The headline test runs both halves on one path per the audit's paired-fixes note: upgrade adopts sub B and cancels sub A via Stripe (Mimic-verified it cancels *only* A), then A's later deletion event arrives and the account must stay active. Plus: legacy adopt, legacy deletion-doesn't-adopt, rollback-on-failed-cancel, and the trial-creation id recording. **All five verified to fail against the previous code.**

Full suite: 1542 tests, 0 failures. format / warnings-as-errors / credo --strict / dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)