### PR TITLE
billing: actually start the Stripe trial subscription at signup (#351)

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -166,7 +166,10 @@ defmodule Fountain.Billing do
 
   `trial_ends_at` comes from the subscription's `trial_end` rather than being
   computed locally, so the database agrees with the thing that will actually do
-  the charging.
+  the charging. In the other direction, the subscription is *anchored* to the
+  trial end registration already stamped — creating it at verification time
+  must not restart the clock — and is not created at all when that date has
+  already passed.
 
   A missing `STRIPE_PRICE_ID` is not an error: a self-hosted instance has no
   price and no Stripe. It falls back to recording a local trial end so the
@@ -193,13 +196,43 @@ defmodule Fountain.Billing do
   end
 
   defp create_trial_subscription(user, price_id) do
-    params = %{
-      customer: user.stripe_customer_id,
-      items: [%{price: price_id}],
-      trial_period_days: @trial_days,
-      trial_settings: %{end_behavior: %{missing_payment_method: :cancel}},
-      metadata: %{"user_id" => user.id}
-    }
+    case trial_end_param(user.trial_ends_at) do
+      :expired ->
+        # The locally-stamped clock has already ended this trial; opening a
+        # live Stripe trial now would re-grant time the account no longer has,
+        # and Stripe rejects a past trial_end anyway. The clock side of the
+        # gate covers these accounts.
+        {:ok, user}
+
+      trial_param ->
+        do_create_trial_subscription(user, price_id, trial_param)
+    end
+  end
+
+  # Anchor the subscription to the trial end registration already stamped, so
+  # a subscription created at verification time (or backfilled later) does not
+  # restart the clock. Only an account with no local date gets a fresh window.
+  defp trial_end_param(nil), do: %{trial_period_days: @trial_days}
+
+  defp trial_end_param(%DateTime{} = ends_at) do
+    if DateTime.compare(ends_at, DateTime.add(DateTime.utc_now(), 300, :second)) == :gt do
+      %{trial_end: DateTime.to_unix(ends_at)}
+    else
+      :expired
+    end
+  end
+
+  defp do_create_trial_subscription(user, price_id, trial_param) do
+    params =
+      Map.merge(
+        %{
+          customer: user.stripe_customer_id,
+          items: [%{price: price_id}],
+          trial_settings: %{end_behavior: %{missing_payment_method: :cancel}},
+          metadata: %{"user_id" => user.id}
+        },
+        trial_param
+      )
 
     case Stripe.Subscription.create(params) do
       {:ok, sub} ->
@@ -216,6 +249,11 @@ defmodule Fountain.Billing do
         {:error, reason}
     end
   end
+
+  # A date that is already set stands: the worker re-runs on every OAuth login,
+  # and re-stamping +14d from "now" would quietly extend a self-host trial on
+  # each one.
+  defp record_local_trial(%User{trial_ends_at: %DateTime{}} = user), do: {:ok, user}
 
   defp record_local_trial(user) do
     user

--- a/apps/fountain/lib/fountain/workers/stripe_customer_sync.ex
+++ b/apps/fountain/lib/fountain/workers/stripe_customer_sync.ex
@@ -59,12 +59,19 @@ defmodule Fountain.Workers.StripeCustomerSync do
   # Billing.create_stripe_customer/1 is also on the Checkout path, where opening
   # a trial moments before a paid subscription would be wrong.
   #
-  # A user who already has a subscription is left alone: this job is unique per
-  # user for 5 minutes but not forever, and minting a second subscription for
-  # someone who already converted would bill them twice.
+  # A user who already has a subscription of record is left alone: this job is
+  # unique per user for 5 minutes but not forever, and minting a second
+  # subscription for someone who already converted would bill them twice.
+  #
+  # The guard is the subscription id, NOT trial_ends_at (#351): registration
+  # stamps trial_ends_at on every account as the pre-verification floor, so a
+  # nil check here was permanently false and start_trial_subscription was
+  # unreachable — no signup ever got a Stripe subscription, and nothing
+  # Stripe-driven (trial_will_end, the deletion at trial end, the lifecycle
+  # emails hanging off both) could happen for those accounts.
   defp ensure_customer_and_trial(user) do
     with {:ok, user} <- Billing.ensure_stripe_customer(user) do
-      if user.subscription_status == "trialing" and is_nil(user.trial_ends_at) do
+      if user.subscription_status == "trialing" and is_nil(user.stripe_subscription_id) do
         Billing.start_trial_subscription(user)
       else
         {:ok, user}

--- a/apps/fountain/test/fountain/trial_expiry_test.exs
+++ b/apps/fountain/test/fountain/trial_expiry_test.exs
@@ -127,7 +127,9 @@ defmodule Fountain.TrialExpiryTest do
 
       assert_received {:subscription_params, params}
       assert params.customer == "cus_new"
-      assert params.trial_period_days == 14
+      # Anchored to the trial end registration stamped — not a fresh 14-day
+      # window that would restart the clock at verification time (#351).
+      assert params.trial_end == DateTime.to_unix(user.trial_ends_at)
       assert [%{price: "price_test"}] = params.items
 
       assert updated.stripe_customer_id == "cus_new"

--- a/apps/fountain/test/fountain/workers/stripe_customer_sync_trial_test.exs
+++ b/apps/fountain/test/fountain/workers/stripe_customer_sync_trial_test.exs
@@ -1,0 +1,99 @@
+defmodule Fountain.Workers.StripeCustomerSyncTrialTest do
+  @moduledoc """
+  The signup path must end with a real Stripe trial subscription (#351).
+
+  Registration stamps `trial_ends_at` on every account, so the worker's old
+  `is_nil(trial_ends_at)` guard was permanently false and
+  `start_trial_subscription/1` was unreachable — no signup ever got a Stripe
+  subscription, and everything Stripe-driven (trial_will_end, the deletion at
+  trial end, the lifecycle emails hanging off both) was dead for post-#244
+  accounts. Each half had passing tests; these are the
+  registration → verification → worker tests that exercise them together.
+
+  `async: false` because these set `:stripe_price_id`, which is global.
+  """
+
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Fountain.Accounts.User
+  alias Fountain.Repo
+  alias Fountain.Workers.StripeCustomerSync
+
+  setup do
+    previous = Application.get_env(:fountain, :stripe_price_id)
+    Application.put_env(:fountain, :stripe_price_id, "price_test")
+    on_exit(fn -> Application.put_env(:fountain, :stripe_price_id, previous) end)
+    :ok
+  end
+
+  test "the verified signup path ends with a real Stripe subscription" do
+    user = insert_verified_user()
+    assert user.trial_ends_at
+    test = self()
+
+    stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_e2e"}} end)
+
+    stub(Stripe.Subscription, :create, fn params ->
+      send(test, {:sub_params, params})
+      {:ok, %{id: "sub_e2e", status: "trialing", trial_end: params.trial_end}}
+    end)
+
+    assert :ok = perform_job(StripeCustomerSync, %{user_id: user.id})
+
+    # Anchored to the registration-stamped end, not a fresh 14-day window that
+    # would restart the clock at verification time.
+    assert_received {:sub_params, params}
+    assert params.trial_end == DateTime.to_unix(user.trial_ends_at)
+
+    reloaded = Repo.get(User, user.id)
+    assert reloaded.stripe_subscription_id == "sub_e2e"
+    assert reloaded.subscription_status == "trialing"
+  end
+
+  test "a user with a subscription of record is left alone" do
+    user = insert_verified_user()
+    {:ok, user} = Fountain.Billing.attach_stripe_customer(user, "cus_has_sub")
+
+    {:ok, _} =
+      user
+      |> User.billing_changeset(%{stripe_subscription_id: "sub_already"})
+      |> Repo.update()
+
+    # No Subscription.create stub: a call would fail the test.
+    assert :ok = perform_job(StripeCustomerSync, %{user_id: user.id})
+    assert Repo.get(User, user.id).stripe_subscription_id == "sub_already"
+  end
+
+  test "an expired local trial does not open a live subscription" do
+    user = insert_verified_user()
+
+    {:ok, _} =
+      user
+      |> User.billing_changeset(%{
+        trial_ends_at: DateTime.utc_now() |> DateTime.add(-1, :day) |> DateTime.truncate(:second)
+      })
+      |> Repo.update()
+
+    stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_late"}} end)
+    reject(&Stripe.Subscription.create/1)
+
+    assert :ok = perform_job(StripeCustomerSync, %{user_id: user.id})
+    assert Repo.get(User, user.id).stripe_subscription_id == nil
+  end
+
+  test "a rerun on a priceless instance cannot extend the local trial" do
+    # The worker re-runs on every OAuth login; without the standing-date guard
+    # each one re-stamped trial_ends_at to now+14d.
+    Application.put_env(:fountain, :stripe_price_id, nil)
+    user = insert_verified_user()
+    original_end = user.trial_ends_at
+
+    stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_sh"}} end)
+
+    assert :ok = perform_job(StripeCustomerSync, %{user_id: user.id})
+    assert :ok = perform_job(StripeCustomerSync, %{user_id: user.id})
+
+    assert Repo.get(User, user.id).trial_ends_at == original_end
+  end
+end


### PR DESCRIPTION
Closes #351 — found while working #309/#314. **Stacked on #350** (chain: #348 → #349 → #350 → this); it needs `stripe_subscription_id` from #349.

Two halves of #244 cancel each other: registration stamps `trial_ends_at` on every account, and the worker only starts the Stripe trial subscription when `trial_ends_at` is nil — so the branch is unreachable and **no signup since #244 has ever received a Stripe subscription**. The local clock gates trials silently, but everything Stripe-driven is disconnected: no `trial_will_end` (T-3d warning email), no `.deleted` at trial end, so #341's `trial_expired` email never sends and expired accounts sit at `trialing` forever (which also skews #345's status counts).

## Change

- Worker guard becomes "no subscription of record yet" (`is_nil(stripe_subscription_id)`) — the thing the old check was trying to say.
- `create_trial_subscription` anchors `trial_end` to the locally-stamped date instead of `trial_period_days: 14`, so verification-time creation doesn't restart the clock; skips creation entirely when the local date has passed.
- `record_local_trial` no longer overwrites a standing date — the worker re-runs on every OAuth login and was one guard change away from extending self-host trials indefinitely.

## Tests

New `async: false` module (it sets `:stripe_price_id`) runs **registration → verification → worker** end-to-end and asserts the subscription exists, is anchored to the registration-stamped end, and is recorded — the composition test the audit keeps asking for. Plus: already-subscribed left alone, expired trial doesn't open a live sub, priceless-instance rerun can't extend. Headline test **fails against the previous code**.

Full suite: 1670 tests, 0 failures; format / warnings-as-errors / credo --strict / dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)