### PR TITLE
security: verified-email gate on API key minting, fail-closed nil trials (#314)

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -92,12 +92,22 @@ defmodule Fountain.Billing do
   # undelivered webhook, a Stripe outage or a misconfigured endpoint delays
   # revenue rather than forfeiting it.
   #
-  # A nil `trial_ends_at` is treated as no expiry. 159 production accounts were
-  # in that state, from before a trial end was recorded at all; they were given
-  # an expiry on 2026-08-02 via Fountain.Release.expire_legacy_trials/1, which
-  # exists for any that reappear. A *deliberate* free account is "comped", not
-  # this.
-  defp do_check_active(%User{subscription_status: "trialing", trial_ends_at: nil}), do: :ok
+  # A nil `trial_ends_at` is "no expiry" only for accounts that predate the
+  # 2026-08-02 backfill (Fountain.Release.expire_legacy_trials/1 exists for any
+  # of those that reappear). Registration has stamped a trial end on every
+  # account since #244, so a newer account at nil means a stalled sync or data
+  # drift — and an open-ended branch here turned every such account into a free
+  # one (#314). Those fail closed; support can extend_trial to reopen them.
+  # A *deliberate* free account is "comped", not this.
+  @legacy_trial_cutoff ~U[2026-08-02 00:00:00Z]
+
+  defp do_check_active(%User{subscription_status: "trialing", trial_ends_at: nil} = user) do
+    if DateTime.compare(user.inserted_at, @legacy_trial_cutoff) == :lt do
+      :ok
+    else
+      {:error, :subscription_required}
+    end
+  end
 
   defp do_check_active(%User{subscription_status: "trialing", trial_ends_at: ends_at}) do
     if DateTime.compare(DateTime.utc_now(), ends_at) == :lt do

--- a/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
@@ -17,6 +17,18 @@ defmodule FountainWeb.AuthTokenController do
   def create(conn, %{"email" => email, "password" => password})
       when is_binary(email) and is_binary(password) do
     case Accounts.authenticate_user(email, password) do
+      # A full-scope API key is everything the browser session is, minus the
+      # verification gate the browser hooks enforce \u2014 so the same gate applies
+      # here. Without it, register \u2192 token \u2192 provision worked without ever
+      # touching an inbox (#314). 403 rather than 401: the password was right.
+      {:ok, %{email_verified_at: nil}} ->
+        conn
+        |> put_status(:forbidden)
+        |> json(%{
+          error: "Verify your email address before requesting an API key",
+          reason: "email_unverified"
+        })
+
       {:ok, user} ->
         name = "CLI login \u2014 #{DateTime.utc_now() |> DateTime.to_date()}"
 

--- a/apps/fountain/test/fountain/trial_expiry_test.exs
+++ b/apps/fountain/test/fountain/trial_expiry_test.exs
@@ -67,11 +67,24 @@ defmodule Fountain.TrialExpiryTest do
       assert {:error, :subscription_required} = Billing.check_active(user)
     end
 
-    test "a nil trial end is treated as no expiry" do
-      # 159 production accounts are in this state, from before a trial end was
-      # recorded at all. Expiring them is a business decision with a support
-      # cost, so it belongs in a task someone runs — not in this boolean.
-      assert :ok = Billing.check_active(trialing_user(nil))
+    test "a nil trial end is no expiry only for pre-backfill accounts" do
+      # 159 production accounts were in this state, from before a trial end was
+      # recorded at all; they were backfilled on 2026-08-02. Accounts older
+      # than the backfill keep the lenient reading in case any reappear.
+      legacy =
+        Repo.update!(
+          Ecto.Changeset.change(trialing_user(nil), inserted_at: ~U[2026-07-01 00:00:00Z])
+        )
+
+      assert :ok = Billing.check_active(legacy)
+    end
+
+    test "a post-backfill account with a nil trial end fails closed" do
+      # Registration stamps trial_ends_at on every account, so nil on a new
+      # account means a stalled sync or data drift. The open-ended branch here
+      # turned every such account into a free one (#314); support has
+      # extend_trial to reopen a legitimate casualty.
+      assert {:error, :subscription_required} = Billing.check_active(trialing_user(nil))
     end
 
     test "an active subscription is unaffected by the trial clock" do

--- a/apps/fountain/test/fountain_web/controllers/auth_token_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_token_controller_test.exs
@@ -14,6 +14,24 @@ defmodule FountainWeb.AuthTokenControllerTest do
       assert String.starts_with?(prefix, "ftn_")
     end
 
+    test "returns 403 with a machine-readable reason for an unverified account", %{conn: conn} do
+      # The chain this closes (#314): register → token → create agent →
+      # provision sprites, without ever touching an inbox. Verification was
+      # enforced in the browser hooks only; the API surface that mints
+      # full-scope keys must apply the same gate.
+      user =
+        insert_user(%{
+          "email" => "unverified#{System.unique_integer()}@example.com",
+          "password" => "password123"
+        })
+
+      refute user.email_verified_at
+
+      conn = post_json(conn, "/api/auth/token", %{email: user.email, password: "password123"})
+
+      assert %{"reason" => "email_unverified"} = json_response(conn, 403)
+    end
+
     test "returns 401 on wrong password", %{conn: conn} do
       user = insert_verified_user(%{"email" => "login#{System.unique_integer()}@example.com", "password" => "password123"})
 


### PR DESCRIPTION
Closes #314 (P1). Independent of the #348→#353 billing chain — branches from `main`.

The API surface never checked email verification: `POST /api/auth/token` minted a **full-scope** key for any valid password, so `register → token → create agent → provision sprites` worked without ever touching an inbox. The browser's verification gate (`hooks.ex`) had no API counterpart.

## Changes

1. **`AuthTokenController` refuses unverified accounts** — 403 with machine-readable `reason: "email_unverified"` (403 not 401: the password was right). Existing keys aren't touched; pre-fix unverified key holders are bounded by the fail-closed gate below and the 30-day pruner.
2. **`Billing.do_check_active` fails closed on `trialing` + nil `trial_ends_at` for accounts created on/after 2026-08-02** (the legacy backfill date). Registration stamps a trial end on every account since #244, so nil on a newer account means a stalled sync or drift — exactly the state the issue calls out as "every stalled sync becomes a free account". Pre-backfill accounts keep the lenient reading in case any reappear; `expire_legacy_trials` and `extend_trial` remain the operator levers.

## Scope notes

- The issue's "trial clock never starts" sub-claim is already fixed on `main`: `put_trial_end` (from #244) stamps `trial_ends_at` at insert on every registration path, including `POST /api/auth/register` — I verified this empirically. What was still real: the token-mint gate and the open-ended nil branch, both fixed here.
- While verifying, I found the *other* half of #244 is dead — no signup ever gets an actual Stripe subscription. Filed as #351, fixed in #353.

Both new tests **fail against the previous code**. Full suite: 1659 tests, 0 failures; format / warnings-as-errors / credo --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)