### PR TITLE
billing: an admin trial extension outranks in-flight webhooks (#334) [re-open]

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -248,6 +248,14 @@ defmodule Fountain.Billing do
   `canceled` or `past_due` account back to `trialing`: the support lever for
   "give this person another look".
 
+  The extension also advances `subscription_synced_at`, because an operator
+  decision outranks anything already in flight: without the stamp, a straggler
+  event from the old cancelled subscription (or a re-checkout race) with a
+  newer `created` than the last synced event would silently revert the
+  extension and gate the user again. Events younger than the extension still
+  apply — Stripe remains the authority for everything that happens *after* the
+  operator acted.
+
   Refused for `active` (they are paying; there is no trial) and `comped`
   (already free; extending would demote them to a trial that ends).
   """
@@ -270,7 +278,11 @@ defmodule Fountain.Billing do
 
     with :ok <- push_stripe_trial_end(user, new_end) do
       user
-      |> User.billing_changeset(%{subscription_status: "trialing", trial_ends_at: new_end})
+      |> User.billing_changeset(%{
+        subscription_status: "trialing",
+        trial_ends_at: new_end,
+        subscription_synced_at: DateTime.truncate(now, :second)
+      })
       |> Repo.update()
     end
   end

--- a/apps/fountain/test/fountain/billing_test.exs
+++ b/apps/fountain/test/fountain/billing_test.exs
@@ -684,6 +684,78 @@ defmodule Fountain.BillingTest do
       assert {:error, :active_subscription} = Billing.extend_trial(active, 7)
       assert {:error, :comped} = Billing.extend_trial(comped, 7)
     end
+
+    test "a straggler webhook cannot revert the extension" do
+      # The #334 shape: the operator re-opens a canceled account, then a
+      # delayed event from the old subscription arrives. Its `created` predates
+      # the extension, so the stamp the extension writes makes it stale.
+      user =
+        billing_state(insert_verified_user(),
+          subscription_status: "canceled",
+          stripe_customer_id: "cus_straggler",
+          stripe_subscription_id: "sub_straggler",
+          trial_ends_at: nil
+        )
+
+      stub(Stripe.Subscription, :list, fn _ -> {:ok, %{data: []}} end)
+
+      straggler_created = DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.to_unix()
+
+      assert {:ok, extended} = Billing.extend_trial(user, 7)
+      assert extended.subscription_status == "trialing"
+
+      assert {:ok, :stale} =
+               Billing.sync_subscription(%Stripe.Event{
+                 id: "evt_straggler",
+                 type: "customer.subscription.deleted",
+                 created: straggler_created,
+                 data: %{
+                   object: %{
+                     id: "sub_straggler",
+                     customer: "cus_straggler",
+                     status: "canceled",
+                     trial_end: nil
+                   }
+                 }
+               })
+
+      assert Repo.reload!(user).subscription_status == "trialing"
+    end
+
+    test "an event younger than the extension still applies" do
+      # Stripe stays authoritative for what happens after the operator acted —
+      # the stamp only outranks the past, not the future.
+      user =
+        billing_state(insert_verified_user(),
+          subscription_status: "canceled",
+          stripe_customer_id: "cus_after_ext",
+          stripe_subscription_id: "sub_after_ext",
+          trial_ends_at: nil
+        )
+
+      stub(Stripe.Subscription, :list, fn _ -> {:ok, %{data: []}} end)
+
+      assert {:ok, _} = Billing.extend_trial(user, 7)
+
+      later = DateTime.utc_now() |> DateTime.add(60, :second) |> DateTime.to_unix()
+
+      assert {:ok, updated} =
+               Billing.sync_subscription(%Stripe.Event{
+                 id: "evt_after_ext",
+                 type: "customer.subscription.updated",
+                 created: later,
+                 data: %{
+                   object: %{
+                     id: "sub_after_ext",
+                     customer: "cus_after_ext",
+                     status: "active",
+                     trial_end: nil
+                   }
+                 }
+               })
+
+      assert updated.subscription_status == "active"
+    end
   end
 
   describe "comp_account/1 and revoke_comp/1" do


### PR DESCRIPTION
Replaces #350, which GitHub marked merged with an **empty diff**: my rebase onto the post-lifecycle `main` briefly left this branch with no commits, and the merge click landed in exactly that window (mergeCommit == base tip, zero changes). The actual fix (`268a796`) only ever lived on the branch — this PR carries it for real. Sorry for the confusion; the force-push race was mine.

Original description: `extend_trial` set `trialing` locally but never advanced `subscription_synced_at`, so a straggler event from the old cancelled subscription silently reverted the operator's decision. The extension now stamps `subscription_synced_at` at the moment the operator acted — older events go stale via the existing guard, younger events still apply. Tests cover both directions; the straggler test fails against the previous code.

Stacked on #349 (chain: #348 → #349 → this → #353).

🤖 Generated with [Claude Code](https://claude.com/claude-code)