### PR TITLE
billing: gate every turn, not just fresh provisioning (#313)

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -8,13 +8,17 @@ defmodule Fountain.Billing do
       Fountain.Billing.assert_active!(current_user)
 
   Call sites:
-  - `Conversations.start_conversation/1` and the wake path — the backstop. Every
-    route to a sprite passes through one of these, so a new surface cannot
-    silently skip the gate the way `POST /api/conversations/:id/prompts` did.
+  - `ConversationServer.turn_gate/1` — the backstop. Every turn passes through
+    it, whichever door it entered by (controller, LiveView, or the queued
+    initial prompt a wake delivers), so a live session cannot outrun a
+    subscription that expires mid-flight and no new prompt surface can
+    silently skip the gate.
+  - `Conversations.start_conversation/1` and both arms of the wake path —
+    refuse before provisioning (or reattaching to) a sprite, so the caller
+    hears the refusal synchronously.
   - `POST /api/conversations` controller — fast 402 before doing any work
-  - `on_mount :require_active_subscription` LiveView hook — redirects to billing.
-    Mount-time only, so it does not cover a session that is cancelled mid-flight;
-    the context-level check does.
+  - `on_mount :require_active_subscription` LiveView hook — redirects to
+    billing at mount time.
 
   ## Webhook sync
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -983,7 +983,16 @@ defmodule Fountain.Conversations do
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(conv.runtime) do
       case maybe_reuse_sandbox(conv) do
         {:reuse, sandbox_id} ->
-          start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt)
+          # Reuse provisions nothing, so the fresh-path gates below never ran
+          # here — a canceled or suspended user could restart a server against
+          # a live sprite and keep prompting (#313). Same checks, minus the
+          # quota (reusing adds no concurrency). The per-turn gate in
+          # ConversationServer is the backstop; this one makes the refusal
+          # synchronous at the API door.
+          with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
+               :ok <- Fountain.Billing.check_active(conv.user_id) do
+            start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt)
+          end
 
         :create_new ->
           create_fresh_sandbox_and_start(conv, agent, runtime_module, initial_prompt)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -743,8 +743,15 @@ defmodule Fountain.Conversations.ConversationServer do
       {:reply, {:error, :busy}, state}
     else
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-      agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
-      {:reply, :ok, kick_turn(state, prompt, agent, images)}
+
+      case turn_gate(conv.user_id) do
+        :ok ->
+          agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
+          {:reply, :ok, kick_turn(state, prompt, agent, images)}
+
+        {:error, _} = err ->
+          {:reply, err, state}
+      end
     end
   end
 
@@ -819,8 +826,21 @@ defmodule Fountain.Conversations.ConversationServer do
       {:noreply, state}
     else
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-      agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
-      {:noreply, kick_turn(state, prompt, agent, images)}
+
+      case turn_gate(conv.user_id) do
+        :ok ->
+          agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
+          {:noreply, kick_turn(state, prompt, agent, images)}
+
+        {:error, reason} ->
+          # No caller to reply to — the wake door reports the same refusal
+          # synchronously; this backstop only has to not run the turn.
+          Logger.info(
+            "conv #{state.conversation_id}: dropping initial prompt (#{inspect(reason)})"
+          )
+
+          {:noreply, state}
+      end
     end
   end
 
@@ -1391,6 +1411,19 @@ defmodule Fountain.Conversations.ConversationServer do
       "conv:#{conv_id}",
       {:log_event, event}
     )
+  end
+
+  # Every turn passes through here, whichever door it came in by — the
+  # controller/LiveView call above, or the queued initial prompt a wake
+  # delivers as a cast. The provisioning gates cover fresh sprites only; a
+  # live server (or the reuse arm of a wake) outlives the subscription state
+  # it was started under, and each turn resets the idle clock, so an expired
+  # trial or failed card otherwise bought up to the 24h max lifetime of
+  # continued service per live sandbox (#313). Suspension is the same shape.
+  defp turn_gate(user_id) do
+    with :ok <- Fountain.Accounts.check_not_suspended(user_id) do
+      Fountain.Billing.check_active(user_id)
+    end
   end
 
   defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -192,6 +192,9 @@ defmodule FountainWeb.ConversationController do
 
           {:error, :subscription_required} = err ->
             err
+
+          {:error, :account_suspended} = err ->
+            err
         end
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -49,6 +49,14 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "subscription_required", upgrade_url: "/account/billing"})
   end
 
+  # Operator suspension (#287). 403 rather than 402: there is nothing the
+  # caller can buy their way out of.
+  def call(conn, {:error, :account_suspended}) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{error: "account_suspended"})
+  end
+
   # Per-tenant sandbox concurrency cap (ADR 0005). 429 rather than 402: this is
   # a rate/concurrency condition the caller can clear by terminating a
   # conversation, not a billing state they have to resolve by paying.

--- a/apps/fountain/test/fountain/billing_gate_test.exs
+++ b/apps/fountain/test/fountain/billing_gate_test.exs
@@ -106,6 +106,108 @@ defmodule Fountain.BillingGateTest do
     end
   end
 
+  describe "wake_conversation/2 — the reuse arm (#313)" do
+    # The fresh arm above provisions and was gated; the reuse arm reattaches
+    # to a live sprite, provisions nothing, and skipped every check — a
+    # canceled user could restart a server against their still-warm sandbox
+    # and keep prompting.
+
+    defp reusable_conversation(user) do
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    end
+
+    defp stub_sprite_alive do
+      stub(Fountain.SpritesClient, :get!, fn -> :fake_client end)
+      stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{name: "alive"}} end)
+    end
+
+    test "is refused for a canceled subscription without starting a server" do
+      user = user_with_status("canceled")
+      conv = reusable_conversation(user)
+      stub_sprite_alive()
+      reject(&Horde.DynamicSupervisor.start_child/2)
+
+      assert {:error, :subscription_required} = Conversations.wake_conversation(conv.id, "hi")
+    end
+
+    test "is refused for a suspended account" do
+      user = user_with_status("active")
+      {:ok, _, _} = Fountain.Accounts.suspend_user(user)
+      conv = reusable_conversation(user)
+      stub_sprite_alive()
+      reject(&Horde.DynamicSupervisor.start_child/2)
+
+      assert {:error, :account_suspended} = Conversations.wake_conversation(conv.id, "hi")
+    end
+
+    test "an active subscription still reattaches" do
+      user = user_with_status("active")
+      conv = reusable_conversation(user)
+      stub_sprite_alive()
+      stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+      assert {:ok, _} = Conversations.wake_conversation(conv.id, "hi")
+    end
+  end
+
+  describe "the per-turn gate on a live server (#313)" do
+    # A live ConversationServer outlives the subscription state it started
+    # under, and each turn resets the idle clock — so a trial that expired at
+    # minute 1 bought up to 24h of gated service. The server re-checks on
+    # every prompt; these drive the callbacks directly with the minimal state
+    # the guarded branch touches.
+
+    alias Fountain.Conversations.ConversationServer
+
+    defp live_server_state(conv) do
+      %{current_command: nil, conversation_id: conv.id}
+    end
+
+    test "send_prompt on a live server is refused after cancellation" do
+      user = user_with_status("canceled")
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "running")
+
+      assert {:reply, {:error, :subscription_required}, state} =
+               ConversationServer.handle_call(
+                 {:send_prompt, "hi", []},
+                 {self(), make_ref()},
+                 live_server_state(conv)
+               )
+
+      assert state.current_command == nil
+    end
+
+    test "send_prompt on a live server is refused after suspension" do
+      user = user_with_status("active")
+      {:ok, _, _} = Fountain.Accounts.suspend_user(user)
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "running")
+
+      assert {:reply, {:error, :account_suspended}, _state} =
+               ConversationServer.handle_call(
+                 {:send_prompt, "hi", []},
+                 {self(), make_ref()},
+                 live_server_state(conv)
+               )
+    end
+
+    test "a queued initial prompt is dropped, not run, for a gated account" do
+      # The wake door reports the refusal synchronously; the cast is the
+      # backstop and only has to not start a turn.
+      user = user_with_status("past_due")
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
+
+      state = live_server_state(conv)
+
+      assert {:noreply, ^state} =
+               ConversationServer.handle_cast({:initial_prompt, "hi", []}, state)
+    end
+  end
+
   describe "gate ordering" do
     test "billing is reported before quota" do
       # A cancelled tenant sitting at their sandbox cap should be told to fix


### PR DESCRIPTION
Closes #313 (P1). Independent of the #348→#353 chain — branches from `main`.

Two ungated routes past the billing gate, per the audit:

1. **The reuse arm of `wake_conversation`** — reattaches to a live sprite, provisions nothing, so the fresh-path gates never ran. Reached whenever the sandbox is `ready` and the sprite alive but the server is gone (BEAM restart, rehydrator gap, deploy race).
2. **A live `ConversationServer`** — `:send_prompt` went straight to `kick_turn`, and each turn resets `last_activity_at`, so an expired trial or failed card bought up to 24h of continued service per live sandbox.

## Change

- The reuse arm now applies the same billing + suspension checks as the fresh arm (minus quota — reuse adds no concurrency), so callers hear the refusal synchronously (402/403 at the API).
- `ConversationServer.turn_gate/1` re-checks billing **and suspension** on every turn. One deviation from the issue's suggested fix: gating `:send_prompt` alone is *not* a single choke point — the wake path's initial prompt travels as a `queue_initial_prompt` **cast** and never passes through `send_prompt`. Both handlers are gated; the cast drops the prompt with a log (no caller to reply to; the wake door already reported the refusal).
- Suspension (#287/#346) had exactly the same two holes — the issue called this adjacency out — so the gate covers it; `FallbackController` learns `account_suspended` → 403 and the prompts action passes it through instead of 500ing.
- The `billing.ex` moduledoc claim ("every route passes through one of these") is corrected to describe the real topology.

## Tests

New coverage in `billing_gate_test.exs`: reuse-arm refusal (canceled + suspended, asserting **no server starts** via Mimic `reject`), reuse still works when active, live-server `handle_call` refusal for both statuses, and the initial-prompt cast dropping rather than running. **All five fail against the previous code.**

Full suite: 1672 tests, 0 failures; format / warnings-as-errors / credo --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)