### PR TITLE
api: prompts endpoint maps every refusal to a 4xx (#332)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -183,17 +183,12 @@ defmodule FountainWeb.ConversationController do
           {:error, :busy} ->
             {:error, "conversation_busy"}
 
-          # Waking a dormant conversation provisions a fresh sprite, so it is
-          # subject to both the concurrency cap and the subscription gate. Pass
-          # these through to the fallback controller rather than letting them
-          # blow the case clause — an unmatched tuple here is a 500, not a 402.
-          {:error, {:sandbox_quota_exceeded, _}} = err ->
-            err
-
-          {:error, :subscription_required} = err ->
-            err
-
-          {:error, :account_suspended} = err ->
+          # Everything else renders via the FallbackController. This case has
+          # had error shapes threaded through it by hand four times (#212's
+          # 402, then :gone / :no_agent / changeset in #332), and each one it
+          # was missing was a CaseClauseError 500. The fallback owns the
+          # error → status mapping; new shapes land there, not here.
+          {:error, _} = err ->
             err
         end
     end

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -73,9 +73,38 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # Prompting a terminated conversation. 410 rather than 404: the id was
+  # real, the resource is gone for good, and the caller should stop retrying.
+  def call(conn, {:error, :gone}) do
+    conn
+    |> put_status(:gone)
+    |> json(%{error: "conversation_terminated"})
+  end
+
+  # The conversation's agent was deleted out from under it; it cannot resume.
+  def call(conn, {:error, :no_agent}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "no_agent", message: "the conversation's agent has been deleted"})
+  end
+
   def call(conn, {:error, reason}) when is_binary(reason) do
     conn
     |> put_status(:bad_request)
     |> json(%{error: reason})
+  end
+
+  # Terminal safety net (#332): an error shape nothing above recognises.
+  # Contexts grow new refusal atoms faster than controllers learn them, and
+  # every miss used to be a CaseClauseError 500. A domain refusal is the
+  # caller's problem, so 422 with the atom beats a blank 500 — and anything
+  # that genuinely is a server fault still shows up in the logs below.
+  def call(conn, {:error, reason}) when is_atom(reason) do
+    require Logger
+    Logger.warning("fallback: unmapped error atom #{inspect(reason)} on #{conn.request_path}")
+
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: to_string(reason)})
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -376,6 +376,78 @@ defmodule FountainWeb.ConversationControllerTest do
       assert json_response(conn, 404)
     end
 
+    # The #332 trio: each of these used to blow the hand-maintained case
+    # clause and 500. All three run the real wake path, no stubs.
+
+    test "returns 410 when the conversation is terminated", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id, status: "terminated")
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations/#{conv.id}/prompts", %{"prompt" => "hello"})
+
+      assert json_response(conn, 410)["error"] == "conversation_terminated"
+    end
+
+    test "returns 422 when the conversation's agent was deleted", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id, status: "idle")
+      assert conv.agent_id == nil
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations/#{conv.id}/prompts", %{"prompt" => "hello"})
+
+      assert json_response(conn, 422)["error"] == "no_agent"
+    end
+
+    test "returns 422 when the wake path surfaces a changeset error", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images ->
+        {:error, Fountain.Conversations.Sandbox.changeset(%Fountain.Conversations.Sandbox{}, %{})}
+      end)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations/#{conv.id}/prompts", %{"prompt" => "hello"})
+
+      assert %{"errors" => _} = json_response(conn, 422)
+    end
+
+    test "an unknown refusal atom is a 422, not a CaseClauseError 500", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images ->
+        {:error, :some_future_refusal}
+      end)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations/#{conv.id}/prompts", %{"prompt" => "hello"})
+
+      assert json_response(conn, 422)["error"] == "some_future_refusal"
+    end
+
     test "returns 404 when conversation belongs to a different user", %{
       conn: conn,
       raw_key: raw_key


### PR DESCRIPTION
Closes #332 (P2). **Stacked on #356** — both rework the same `do_prompt` case; merge #356 first, then retarget this to `main`.

The prompts endpoint 500ed on `{:error, :gone}` (prompting a terminated conversation — reachable by any user), `{:error, :no_agent}` (agent deleted), and changeset errors. Fourth time a new error shape blew this hand-maintained `case`.

Taken the issue's "better still" option: the case keeps only its two local translations (`:not_running` → 404, `:busy`) and forwards every other `{:error, _}` to the `FallbackController`, which now owns the full mapping — `:gone` → **410** (`conversation_terminated`), `:no_agent` → **422**, changesets → the standard 422 renderer. A terminal `is_atom` clause converts any *future* unmapped refusal atom into a logged 422 instead of a blank 500, so shape number five can't reproduce this issue. (That clause is fallback-wide by design — any controller that leaks a new refusal atom gets a logged 422 rather than a crash.)

Four new tests; the `:gone` / `:no_agent` ones drive the real wake path with no stubs. **All verified to fail as 500s against the previous code.**

Full suite: 1676 tests, 0 failures; format / warnings-as-errors / credo --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)