### PR TITLE
self-host: no Stripe job, no upgrade theater when billing is off (#335)

### DIFF
--- a/apps/fountain/lib/fountain/workers/stripe_customer_sync.ex
+++ b/apps/fountain/lib/fountain/workers/stripe_customer_sync.ex
@@ -24,6 +24,20 @@ defmodule Fountain.Workers.StripeCustomerSync do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
+    if Billing.enabled?() do
+      sync_user(user_id)
+    else
+      # A billing-disabled instance has no Stripe to sync against. Without
+      # this, every signup enqueued a job that 401ed through all five
+      # attempts — harmless (the gate is off and trial_ends_at is stamped at
+      # registration) but indistinguishable from a real failure in the logs
+      # of a self-hosted instance (#335). Belt to enqueue/1's braces: jobs
+      # already queued when the flag flips off also land here.
+      :ok
+    end
+  end
+
+  defp sync_user(user_id) do
     case Accounts.get_user(user_id) do
       nil ->
         # The account was deleted between enqueue and execution. Nothing to do,
@@ -46,13 +60,23 @@ defmodule Fountain.Workers.StripeCustomerSync do
     end
   end
 
-  @doc "Enqueue customer creation for `user`."
+  @doc """
+  Enqueue customer creation for `user`.
+
+  A no-op when billing is disabled — a self-hosted instance without Stripe
+  must not accumulate a dead job per signup. `perform/1` carries the same
+  guard for jobs that were already queued when the flag changed.
+  """
   def enqueue(%Accounts.User{id: id}), do: enqueue(id)
 
   def enqueue(user_id) when is_binary(user_id) do
-    %{user_id: user_id}
-    |> new()
-    |> Oban.insert()
+    if Billing.enabled?() do
+      %{user_id: user_id}
+      |> new()
+      |> Oban.insert()
+    else
+      {:ok, :billing_disabled}
+    end
   end
 
   # The customer and the trial subscription, in that order. Split because

--- a/apps/fountain/lib/fountain_web/live/billing_live.ex
+++ b/apps/fountain/lib/fountain_web/live/billing_live.ex
@@ -33,7 +33,11 @@ defmodule FountainWeb.Live.BillingLive do
        stripe_url_loading: false,
        delete_confirmation: "",
        deleting: false,
-       export: Exports.latest_export(user.id)
+       export: Exports.latest_export(user.id),
+       # On a billing-disabled instance the subscription card is noise: the
+       # status is meaningless with the gate off, and the Upgrade button can
+       # only ever flash "Unable to reach Stripe" (#335).
+       billing_enabled: Billing.enabled?()
      )}
   end
 
@@ -164,7 +168,7 @@ defmodule FountainWeb.Live.BillingLive do
       <h1 class="text-2xl font-semibold">Billing</h1>
 
       <%!-- past_due banner --%>
-      <%= if @current_user.subscription_status == "past_due" do %>
+      <%= if @billing_enabled and @current_user.subscription_status == "past_due" do %>
         <div class="rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800" role="alert">
           Your subscription requires attention. Update your payment method to
           continue starting conversations.
@@ -173,7 +177,7 @@ defmodule FountainWeb.Live.BillingLive do
 
       <%!-- cancel-at-period-end notice: canceled in the portal, still inside
            the paid period. Access continues until the period ends. --%>
-      <%= if canceling_at_period_end?(@current_user) do %>
+      <%= if @billing_enabled and canceling_at_period_end?(@current_user) do %>
         <div
           class="rounded border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
           role="alert"
@@ -184,8 +188,19 @@ defmodule FountainWeb.Live.BillingLive do
         </div>
       <% end %>
 
+      <%!-- Billing disabled: no status theater, no button that can only fail --%>
+      <%= if not @billing_enabled do %>
+        <div class="rounded-lg border bg-white p-6 shadow-sm">
+          <h2 class="mb-2 text-lg font-medium">Subscription</h2>
+          <p class="text-sm text-gray-600">
+            Billing is disabled on this instance. All features are available
+            without a subscription.
+          </p>
+        </div>
+      <% end %>
+
       <%!-- Subscription status card --%>
-      <div class="rounded-lg border bg-white p-6 shadow-sm">
+      <div :if={@billing_enabled} class="rounded-lg border bg-white p-6 shadow-sm">
         <h2 class="mb-4 text-lg font-medium">Subscription</h2>
         <dl class="space-y-3">
           <div class="flex items-center justify-between">

--- a/apps/fountain/test/fountain/self_host_switches_test.exs
+++ b/apps/fountain/test/fountain/self_host_switches_test.exs
@@ -82,6 +82,42 @@ defmodule Fountain.SelfHostSwitchesTest do
     end
   end
 
+  describe "BILLING_ENABLED=false silences the Stripe sync (#335)" do
+    # Every signup enqueued a StripeCustomerSync that 401ed through all five
+    # attempts — dead Oban jobs and error noise a self-hoster has no way to
+    # know are benign.
+
+    test "enqueue is a no-op" do
+      user = insert_verified_user()
+
+      with_env([billing_enabled: false], fn ->
+        assert {:ok, :billing_disabled} = Fountain.Workers.StripeCustomerSync.enqueue(user)
+
+        refute_enqueued(worker: Fountain.Workers.StripeCustomerSync)
+      end)
+    end
+
+    test "an already-queued job completes without touching Stripe" do
+      # The flag can flip off with jobs still in the queue.
+      user = insert_verified_user()
+      Mimic.reject(&Stripe.Customer.create/1)
+
+      with_env([billing_enabled: false], fn ->
+        assert :ok =
+                 perform_job(Fountain.Workers.StripeCustomerSync, %{user_id: user.id})
+      end)
+
+      refute Fountain.Repo.reload(user).stripe_customer_id
+    end
+
+    test "enqueue still works when billing is on" do
+      user = insert_verified_user()
+
+      assert {:ok, %Oban.Job{}} = Fountain.Workers.StripeCustomerSync.enqueue(user)
+      assert_enqueued(worker: Fountain.Workers.StripeCustomerSync)
+    end
+  end
+
   describe "REGISTRATION_ENABLED" do
     test "registration is open by default" do
       assert :ok = Accounts.registration_allowed?("someone@example.com")

--- a/apps/fountain/test/fountain_web/live/billing_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/billing_live_test.exs
@@ -46,6 +46,46 @@ defmodule FountainWeb.BillingLiveTest do
     user
   end
 
+  describe "billing disabled (#335)" do
+    # A self-hosted instance shows a trial countdown and an Upgrade button
+    # whose only possible outcome is "Unable to reach Stripe".
+
+    defp with_billing_disabled(fun) do
+      previous = Application.get_env(:fountain, :billing_enabled)
+      Application.put_env(:fountain, :billing_enabled, false)
+
+      try do
+        fun.()
+      after
+        Application.put_env(:fountain, :billing_enabled, previous)
+      end
+    end
+
+    test "no upgrade affordance, no trial countdown, a plain explanation", %{conn: conn} do
+      user = insert_verified_user()
+
+      with_billing_disabled(fn ->
+        {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+        assert html =~ "Billing is disabled on this instance"
+        refute html =~ "Upgrade"
+        refute html =~ "Manage Subscription"
+        refute html =~ "Trial"
+      end)
+    end
+
+    test "usage and the danger zone are still there", %{conn: conn} do
+      user = insert_verified_user()
+
+      with_billing_disabled(fn ->
+        {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+        assert html =~ "Usage This Month"
+        assert html =~ "Delete account"
+      end)
+    end
+  end
+
   describe "upgrade with no existing Stripe customer" do
     test "creates the customer first and never passes customer_email", %{conn: conn} do
       user = insert_verified_user()


### PR DESCRIPTION
Closes #335 (P2). Independent — branches from `main`.

With `BILLING_ENABLED=false` and no Stripe key, every signup enqueued a `StripeCustomerSync` job that 401ed to `max_attempts: 5` — accumulating dead Oban jobs and error noise indistinguishable from real failures in a self-hoster's logs.

- **`enqueue/1` no-ops when billing is disabled** (returns `{:ok, :billing_disabled}`; both call sites ignore the return); **`perform/1` carries the same guard** so jobs already queued when the flag flips off also complete quietly — same guard shape `deletion.ex` already uses.
- **The cosmetic sibling**: `/account/billing` on a disabled instance no longer renders the trial countdown, status badge, `past_due`/cancel banners, or the Upgrade button that could only flash "Unable to reach Stripe" — it states plainly that billing is disabled. Usage and the delete-account flow stay.

Tests: no-op enqueue (`refute_enqueued`), already-queued job with Mimic `reject` proving Stripe is never called, enabled-path regression, and both page renders. **Fail against the previous code.**

Full suite: 1671 tests, 0 failures; format / warnings-as-errors / credo --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)