### PR TITLE
cost: reserve the quota slot atomically; the wake loser cleans up (#330)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -801,15 +801,19 @@ defmodule Fountain.Conversations do
          {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Accounts.check_not_suspended(user_id),
          :ok <- Fountain.Billing.check_active(user_id),
-         :ok <- Fountain.Quotas.check_sandbox_quota(user_id),
+         # Quota check + row insert under one per-user advisory lock: checked
+         # separately they are check-then-insert, and N concurrent requests at
+         # the cap could each pass and provision N-1 sprites over it (#330).
          {:ok, sandbox} <-
-           create_sandbox(%{
-             environment_id: agent.environment_id,
-             sprite_name:
-               attrs["sprite_name"] || "fountain-#{tenant_prefix(user_id)}-#{short_id()}",
-             status: "pending",
-             user_id: user_id
-           }),
+           Fountain.Quotas.with_sandbox_reservation(user_id, fn ->
+             create_sandbox(%{
+               environment_id: agent.environment_id,
+               sprite_name:
+                 attrs["sprite_name"] || "fountain-#{tenant_prefix(user_id)}-#{short_id()}",
+               status: "pending",
+               user_id: user_id
+             })
+           end),
          {:ok, conv} <-
            create_conversation(%{
              sandbox_id: sandbox.id,
@@ -1055,19 +1059,42 @@ defmodule Fountain.Conversations do
     # conversation was an unmetered way past billing entirely.
     with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
          :ok <- Fountain.Billing.check_active(conv.user_id),
-         :ok <-
-           Fountain.Quotas.check_sandbox_quota(conv.user_id, exclude: conv.sandbox_id),
+         # Same reservation as start_conversation/1 — see the note there (#330).
          {:ok, new_sandbox} <-
-           create_sandbox(%{
-             environment_id: agent.environment_id,
-             sprite_name: "fountain-#{tenant_prefix(conv.user_id)}-#{short_id()}",
-             status: "pending",
-             user_id: conv.user_id
-           }),
+           Fountain.Quotas.with_sandbox_reservation(conv.user_id, [exclude: conv.sandbox_id], fn ->
+             create_sandbox(%{
+               environment_id: agent.environment_id,
+               sprite_name: "fountain-#{tenant_prefix(conv.user_id)}-#{short_id()}",
+               status: "pending",
+               user_id: conv.user_id
+             })
+           end),
          _ <- mark_old_sandbox_terminated(conv.sandbox_id),
          {:ok, conv} <-
            update_conversation(conv, %{sandbox_id: new_sandbox.id, status: "pending"}) do
-      start_conversation_server(conv, new_sandbox.id, runtime_module, initial_prompt)
+      case start_conversation_server(conv, new_sandbox.id, runtime_module, initial_prompt) do
+        {:ok, _} = ok ->
+          ok
+
+        {:error, {:already_started, _pid}} ->
+          # Lost a concurrent wake of the same conversation. The winner's
+          # server is running against its own sandbox; this one's just-created
+          # row would otherwise sit pending — holding a quota slot — until the
+          # reaper's pass an hour later, so a user at their cap could lock
+          # themselves out by double-clicking (#330). Clean up our own row and
+          # hand the prompt to the winner, which drops it if a turn is already
+          # running — exactly right for a double-click.
+          _ = mark_old_sandbox_terminated(new_sandbox.id)
+
+          if is_binary(initial_prompt) and initial_prompt != "" do
+            ConversationServer.queue_initial_prompt(conv.id, initial_prompt)
+          end
+
+          {:ok, _unsafe_get_conversation!(conv.id)}
+
+        {:error, _} = err ->
+          err
+      end
     end
   end
 

--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -132,6 +132,42 @@ defmodule Fountain.Quotas do
     end
   end
 
+  # Advisory-lock namespace for sandbox reservations; the second key is a hash
+  # of the user id. A hash collision between users only over-serializes two
+  # tenants' creations — never under-counts.
+  @lock_namespace 4315
+
+  @doc """
+  Check the cap and run `fun` (which must create the sandbox row) atomically,
+  under a per-user Postgres advisory lock.
+
+  `check_sandbox_quota/2` alone is check-then-insert: N concurrent requests at
+  the cap could each read `count < limit` before any row landed, and each go
+  on to provision a paid sprite (#330). The lock serializes check + insert per
+  user, so the second request re-counts after the first has committed. Scoped
+  per user: one tenant's burst cannot queue behind another's.
+
+  `fun` must return `{:ok, value}` or `{:error, reason}`; any error — the
+  quota's or `fun`'s — rolls the whole reservation back.
+  """
+  @spec with_sandbox_reservation(binary(), keyword(), (-> {:ok, term()} | {:error, term()})) ::
+          {:ok, term()} | {:error, term()}
+  def with_sandbox_reservation(user_id, quota_opts \\ [], fun) when is_binary(user_id) do
+    Repo.transaction(fn ->
+      Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
+        @lock_namespace,
+        :erlang.phash2(user_id)
+      ])
+
+      with :ok <- check_sandbox_quota(user_id, quota_opts),
+           {:ok, value} <- fun.() do
+        value
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
+
   @doc "Default cap applied when a user has none set."
   def default_limit, do: @default_limit
 

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -2006,4 +2006,62 @@ defmodule Fountain.ConversationsContextTest do
       assert {:error, :not_found} = Conversations._unsafe_reap_sandbox(Ecto.UUID.generate())
     end
   end
+
+  describe "concurrent wake loses cleanly (#330)" do
+    # Two prompts race to wake the same dormant conversation. Both used to
+    # reach create_fresh_sandbox_and_start; the loser's start_child returned
+    # {:error, {:already_started, _}}, the `with` fell through, and its
+    # just-created pending sandbox row sat holding a quota slot until the
+    # reaper's pass an hour later — a user at their cap could lock themselves
+    # out for an hour by double-clicking.
+
+    test "the loser terminates its own sandbox row instead of stranding it" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:error, {:already_started, self()}}
+      end)
+
+      stub(Fountain.Conversations.ConversationServer, :queue_initial_prompt, fn _conv_id, _prompt -> :ok end)
+
+      assert {:ok, _conv} = Conversations.wake_conversation(conv.id, "hi")
+
+      # No slot held: the old sandbox was retired by the wake, and the row the
+      # loser created for itself is terminated, not pending.
+      assert Fountain.Quotas.active_sandbox_count(user.id) == 0
+    end
+
+    test "the loser forwards its prompt to the winner" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
+      test_pid = self()
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:error, {:already_started, self()}}
+      end)
+
+      stub(Fountain.Conversations.ConversationServer, :queue_initial_prompt, fn conv_id, prompt ->
+        send(test_pid, {:forwarded, conv_id, prompt})
+        :ok
+      end)
+
+      assert {:ok, _} = Conversations.wake_conversation(conv.id, "the racing prompt")
+      assert_received {:forwarded, _conv_id, "the racing prompt"}
+    end
+
+    test "a genuine start failure still surfaces as an error" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:error, :max_children}
+      end)
+
+      assert {:error, :max_children} = Conversations.wake_conversation(conv.id, "hi")
+    end
+  end
 end

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -126,6 +126,63 @@ defmodule Fountain.QuotasTest do
     end
   end
 
+  describe "with_sandbox_reservation/3 (#330)" do
+    # The cross-connection serialization itself rests on
+    # pg_advisory_xact_lock and cannot be observed under the SQL sandbox
+    # (every allowed process shares one transaction). What these pin is the
+    # transactional composition: check + insert commit or roll back as one.
+
+    alias Fountain.Quotas
+
+    test "creates the row when below the cap" do
+      user = insert_verified_user()
+
+      assert {:ok, sandbox} =
+               Quotas.with_sandbox_reservation(user.id, fn ->
+                 {:ok, insert_sandbox(user_id: user.id, status: "pending")}
+               end)
+
+      assert Quotas.active_sandbox_count(user.id) == 1
+      assert sandbox.user_id == user.id
+    end
+
+    test "refuses at the cap and creates nothing" do
+      user = insert_verified_user()
+      for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+
+      assert {:error, {:sandbox_quota_exceeded, %{count: 5, limit: 5}}} =
+               Quotas.with_sandbox_reservation(user.id, fn ->
+                 flunk("fun must not run once the quota refuses")
+               end)
+
+      assert Quotas.active_sandbox_count(user.id) == 5
+    end
+
+    test "a failure in fun rolls the reservation back" do
+      user = insert_verified_user()
+
+      assert {:error, :boom} =
+               Quotas.with_sandbox_reservation(user.id, fn ->
+                 insert_sandbox(user_id: user.id, status: "pending")
+                 {:error, :boom}
+               end)
+
+      # The row created inside the reservation is gone with it.
+      assert Quotas.active_sandbox_count(user.id) == 0
+    end
+
+    test "honours the :exclude option the wake path needs" do
+      user = insert_verified_user()
+      sandboxes = for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+      replacing = hd(sandboxes)
+
+      assert {:ok, _} =
+               Quotas.with_sandbox_reservation(user.id, [exclude: replacing.id], fn ->
+                 {:ok, insert_sandbox(user_id: user.id, status: "pending")}
+               end)
+    end
+  end
+
   describe "check_sandbox_quota!/2" do
     test "returns :ok below the cap" do
       assert :ok = Quotas.check_sandbox_quota!(insert_verified_user().id)


### PR DESCRIPTION
Closes #330 (P2). Independent — branches from `main`. (Touches `create_fresh_sandbox_and_start`, adjacent to but not overlapping #356's wake-arm changes; if both are queued, merge order doesn't matter beyond a trivial rebase.)

## 1. Check-then-insert

`Quotas.with_sandbox_reservation/3` runs the quota check and the sandbox insert in one transaction under a per-user `pg_advisory_xact_lock`, so concurrent requests serialize per tenant and the second re-counts after the first commits. Both call sites — `start_conversation` and the wake path (with its `:exclude`) — go through it. A failure inside the reservation rolls the row back.

## 2. The stranded row

The loser of a concurrent wake (`{:error, {:already_started, _}}`) now terminates its own just-created sandbox row instead of leaving it `pending` for the reaper's 60-minute pass — the double-click self-lockout at the cap is gone. Its prompt is forwarded to the winner's server via `queue_initial_prompt`, which drops it if a turn is already running (the right outcome for a double-click, and better than losing a genuinely different racing prompt). Real start failures still surface as errors.

## Tests

Honest caveat: the advisory lock's cross-connection blocking **cannot be exercised under the SQL sandbox** (allowed processes share one transaction), so the race-prevention itself rests on Postgres semantics. The tests pin everything observable: refuse-at-cap never runs the creation fun, fun-failure rolls back the row, `:exclude` honored, loser-cleanup frees the slot, prompt forwarded, genuine failure surfaces. **Fail against the previous code.**

Full suite: 1673 tests, 0 failures; format / warnings-as-errors / credo --strict / dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)