### PR TITLE
ops: 22-minute deploys → single-digit — native arm64 builds, layer cache, manifest fast path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,17 +2,25 @@
 # ghcr.io/binarybourbon/fountain on every push to main. Multi-arch
 # (amd64 + arm64) — home-cloud k3s nodes are arm64 Apple Silicon Lima
 # VMs, single-arch amd64 images fail at pull with
-# "no match for platform".
+# "no match for platform"; amd64 stays for self-hosters.
+#
+# Each architecture builds NATIVELY (arm64 on the free ubuntu-24.04-arm
+# runners) and pushes by digest; a merge job stitches the digests into one
+# multi-arch manifest. The previous single-runner QEMU build spent ~22
+# minutes emulating the arm64 Erlang compile; native + the registry-backed
+# BuildKit cache below brings a warm code-change build to single-digit
+# minutes. The `build` workflow name and its completion event are load-
+# bearing: publish-manifests.yml listens for them.
 name: build
 
 on:
   workflow_dispatch:
   push:
     branches: [main]
-    # These paths never affect the OCI image, so skip the (multi-arch,
-    # ~slow) build when a commit touches only them. A manifest-only change
-    # still reaches the cluster: publish-manifests.yml can be dispatched to
-    # republish the artifact from an already-built commit.
+    # These paths never affect the OCI image, so skip the build when a
+    # commit touches only them. Manifest-only changes still deploy:
+    # publish-manifests.yml triggers directly on k8s/deploy pushes and
+    # pins the newest already-built image.
     paths-ignore:
       - "k8s/**"
       # The portable self-hosting manifests — never part of the image.
@@ -33,17 +41,27 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            # Free for public repos; the cluster's own architecture, so the
+            # image that matters most is the one built natively.
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -55,18 +73,77 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           build-args: |
             BUILD_SHA=${{ github.sha }}
-          tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:sha-${{ github.sha }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
+          # Digest-only push; the merge job below owns the tags. Provenance
+          # off so each push is exactly one image manifest — attestation
+          # manifests would confuse the imagetools merge.
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+          # Layer cache in the registry, one ref per arch so the two builds
+          # never thrash each other. mode=max also caches the build stage —
+          # that's the deps.compile layer, which is the whole point.
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache-${{ matrix.arch }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digest-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge the multi-arch manifest
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push the manifest list
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            --tag "${IMAGE}:sha-${SHA}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools inspect "${IMAGE}:sha-${SHA}"

--- a/.github/workflows/publish-manifests.yml
+++ b/.github/workflows/publish-manifests.yml
@@ -22,6 +22,11 @@ name: publish-manifests
 #         `latest`
 #       → the cluster's OCIRepository reconciles `latest`.
 #
+# Manifest-only pushes (k8s/**, deploy/k8s/**) skip the build entirely and
+# publish directly, pinning the newest ancestor image that exists — the tree
+# changed nothing the image is built from, so "manifests paired with the
+# image they were written against" still holds.
+#
 # Rollback is one command, no git involved:
 #   flux tag artifact oci://ghcr.io/binarybourbon/fountain-manifests:sha-<old> --tag latest
 #
@@ -33,9 +38,21 @@ on:
     workflows: [build]
     types: [completed]
     branches: [main]
-  # Manual escape hatch: republishes from an already-built commit. The
-  # image-existence check below is what makes this safe — a sha whose image
-  # was never built is refused before anything is published.
+  # The manifest fast path: a push touching only the deployed manifests
+  # publishes directly — no image build to wait for. The image pin resolves
+  # to the newest *ancestor* commit whose image exists (see below), which is
+  # exactly the image already running plus this manifest change. Without
+  # this trigger a k8s-only push would never deploy at all: build.yml
+  # paths-ignores k8s/**, and this workflow otherwise only fires when a
+  # build completes.
+  push:
+    branches: [main]
+    paths:
+      - "k8s/**"
+      - "deploy/k8s/**"
+  # Manual escape hatch: republishes from a given commit's tree. The
+  # ancestor-walk image resolution keeps it honest — a tree whose history
+  # contains no built image is refused before anything is published.
   workflow_dispatch:
     inputs:
       sha:
@@ -49,7 +66,7 @@ permissions:
 jobs:
   publish:
     name: Publish the manifest artifact
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -70,19 +87,35 @@ jobs:
 
       - name: Resolve image tag
         id: tag
+        # The manifest tree is SRC_SHA's; the image pin is the newest
+        # first-parent ancestor (SRC_SHA included) whose image actually
+        # exists in the registry. After a build workflow_run that is SRC_SHA
+        # itself — identical to the old behavior. After a manifest-only push
+        # it is the image already running, which is the point: the pushed
+        # tree changed nothing the image is built from. The walk doubles as
+        # the existence guard — no image in the last 50 commits aborts.
         run: |
-          sha="${SRC_SHA}"
-          {
-            echo "sha=${sha}"
-            echo "short=${sha:0:7}"
-            echo "image=ghcr.io/binarybourbon/fountain:sha-${sha}"
-          } >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          image=""
+          for candidate in $(git rev-list --first-parent -n 50 "${SRC_SHA}"); do
+            if docker manifest inspect \
+                 "ghcr.io/binarybourbon/fountain:sha-${candidate}" > /dev/null 2>&1; then
+              image="ghcr.io/binarybourbon/fountain:sha-${candidate}"
+              break
+            fi
+          done
 
-      - name: Verify the image exists
-        # A no-op after workflow_run (the build just succeeded), but the guard
-        # that keeps workflow_dispatch honest: never publish a manifest whose
-        # image cannot be pulled.
-        run: docker manifest inspect "${{ steps.tag.outputs.image }}" > /dev/null
+          if [ -z "${image}" ]; then
+            echo "no built image found in the 50 commits behind ${SRC_SHA:0:7}; refusing to publish." >&2
+            exit 1
+          fi
+
+          echo "manifest tree ${SRC_SHA:0:7} pins image ${image}"
+          {
+            echo "sha=${SRC_SHA}"
+            echo "short=${SRC_SHA:0:7}"
+            echo "image=${image}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Pin the image tag in the working tree
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,19 @@ RUN apt-get update -y \
 RUN mix local.hex --force \
  && mix local.rebar --force
 
-# Umbrella deps live at the root.
+# Umbrella deps live at the root. Copy ONLY what dependency resolution
+# reads — the root mix files, config, and each app's mix.exs — before
+# fetching and compiling deps, so the (expensive, slow-moving) deps layer
+# survives any change to application code. Copying apps/ wholesale here
+# is what used to force a full dep recompile on every commit.
 COPY mix.exs mix.lock ./
 COPY config ./config
-COPY apps ./apps
+COPY apps/fountain/mix.exs ./apps/fountain/mix.exs
 
 RUN mix deps.get --only prod \
  && mix deps.compile
+
+COPY apps ./apps
 
 RUN mix compile \
  && mix release fountain_server


### PR DESCRIPTION
Today's eight deploys each took 21–23 min to build + ~20s publish + ≤5m Flux + <1m rollout ≈ **25–28 min merge→prod**, ~85% of it the image build. Three causes, three fixes:

## 1. Native arm64 instead of QEMU

The old build ran `linux/amd64,linux/arm64` on one amd64 runner — the arm64 half (the architecture the cluster actually runs) compiled the whole Erlang/Elixir tree under QEMU emulation. Now each arch builds natively (`ubuntu-24.04-arm` is free for public repos), pushes by digest, and a merge job stitches the multi-arch manifest with `imagetools create`. The workflow keeps its `build` name and completion event — publish-manifests listens for them; it fires when *all* jobs (including merge) succeed, same as before.

## 2. Registry-backed layer cache + Dockerfile reorder

No `cache-from/to` existed, and the Dockerfile `COPY`'d all of `apps/` before `mix deps.get` — so even with cache, any code change would recompile every dep. Now only `mix.exs`/`mix.lock`/`config`/per-app `mix.exs` precede the deps layer, and each arch caches to its own `:buildcache-<arch>` ref (`mode=max`, so the build stage's deps layer is cached). Verified the deps layer resolves and compiles with exactly those files present (replicated outside Docker — no Docker on this workstation, and CI never builds the image on PRs, so this was the only pre-merge check available).

## 3. Manifest-only fast path — also a latent-outage fix

Today's `STRIPE_PRICE_MONTHLY_CENTS` change (k8s-only) waited a full 22-minute rebuild. Worse: `build.yml` paths-ignores `k8s/**`, and publish-manifests only fired off a completed build — **had paths-ignore worked as written, a k8s-only push would never have deployed at all** without a manual dispatch. Now publish-manifests triggers directly on `k8s/**` / `deploy/k8s/**` pushes and pins the newest first-parent-ancestor image that exists in the registry (walk capped at 50; doubles as the existence guard, and after a build workflow_run the first candidate is the built sha itself — identical to old behavior). The pairing doctrine holds: a manifest-only tree changed nothing the image is built from. The backwards-move guard is untouched and still keyed on the tree sha.

## Expected numbers

- Code change: ~5–7 min cold, **~2–4 min warm** (was 21–23)
- Manifest change: **~20s publish + Flux poll** (was the full build, or nothing)

First post-merge build seeds the cold caches; the warm number proves out on the next code merge. I'll time both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)