### PR TITLE
ops: webhook-nudge Flux after manifest publish — deploys stop waiting on the 5m poll

### DIFF
--- a/.github/workflows/publish-manifests.yml
+++ b/.github/workflows/publish-manifests.yml
@@ -178,3 +178,25 @@ jobs:
           flux tag artifact "oci://${MANIFESTS}:sha-${SHORT}" --tag latest
 
           echo "manifest artifact published: ${MANIFESTS}:sha-${SHORT} (revision ${SHA}), latest re-tagged"
+
+      - name: Nudge Flux
+        # Tells the cluster's notification-controller the artifact moved, so
+        # the OCIRepository reconciles now instead of on its next 5m poll
+        # (the fountain-artifact-receiver in home-cloud k8s/flux-webhooks/).
+        # Strictly best-effort: a deploy must never fail because a webhook
+        # did — the poll interval remains the fallback. The URL embeds the
+        # receiver's token-derived path; it rotates with
+        # github-webhook-token, so update this secret when that rotates.
+        env:
+          FLUX_WEBHOOK_URL: ${{ secrets.FLUX_WEBHOOK_URL }}
+        run: |
+          if [ -z "${FLUX_WEBHOOK_URL}" ]; then
+            echo "FLUX_WEBHOOK_URL not set; relying on the poll interval."
+            exit 0
+          fi
+
+          if curl -fsS -m 10 -X POST "${FLUX_WEBHOOK_URL}" > /dev/null; then
+            echo "flux nudged — reconcile requested"
+          else
+            echo "webhook ping failed; the 5m poll will pick it up"
+          fi


### PR DESCRIPTION
Companion to the cluster-side change (home-cloud `k8s/flux-webhooks/receiver-fountain.yaml`): a generic Flux Receiver for the fountain OCIRepository + Kustomization, exposed on the existing `cd.inevitable.fyi` webhook host — no new ingress, tunnel, or DNS.

This adds the calling side: after `flux tag artifact … latest`, publish-manifests POSTs the receiver URL (`FLUX_WEBHOOK_URL` repo secret, already set). Design notes:

- **Fires at the right moment.** The existing push-event github-receiver can't serve OCI-deployed apps: a push fires minutes before the artifact exists, the reconcile finds the old artifact, and you wait out the poll anyway. This pings exactly when `latest` moves.
- **Strictly best-effort.** Missing secret → logged skip; failed POST → logged, workflow still succeeds. The 5m poll is the unchanged fallback — a deploy must never fail because a webhook did.
- **Auth** is the receiver's token-derived `/hook/<digest>` path (rotates with `github-webhook-token`; the comment says to update the secret then). Verified live: POST returns 200 and the controller logs both resources annotated.

Expected effect: merge→prod loses the 0–5 min poll wait — with the #361 build times, a code change should now land in **~2–3 minutes**. Will verify on the merge of this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)