### PR TITLE
security: agents may only attach environments owned by the same tenant (#308)

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -6,6 +6,7 @@ defmodule Fountain.Agents do
   alias Fountain.Agents.Agent
   alias Fountain.Agents.AgentAvatar
   alias Fountain.Conversations.Conversation
+  alias Fountain.Environments
   alias Fountain.Repo
 
   @doc "WARNING: lookup by id without owner check. Admin/internal use only."
@@ -76,13 +77,35 @@ defmodule Fountain.Agents do
   def create_agent(attrs) do
     %Agent{}
     |> Agent.changeset(attrs)
+    |> validate_environment_owner()
     |> Repo.insert()
   end
 
   def update_agent(%Agent{} = agent, attrs) do
     agent
     |> Agent.changeset(attrs)
+    |> validate_environment_owner()
     |> Repo.update()
+  end
+
+  # An agent may only reference an environment owned by the same tenant —
+  # the environment's secrets and checkpoints materialise inside the
+  # agent's sprite. The error mirrors a nonexistent id so a foreign
+  # environment UUID can't be confirmed by probing.
+  defp validate_environment_owner(changeset) do
+    env_id = Ecto.Changeset.get_change(changeset, :environment_id)
+    user_id = Ecto.Changeset.get_field(changeset, :user_id)
+
+    cond do
+      is_nil(env_id) ->
+        changeset
+
+      is_binary(user_id) && Environments.get_environment(env_id, user_id) ->
+        changeset
+
+      true ->
+        Ecto.Changeset.add_error(changeset, :environment_id, "does not exist")
+    end
   end
 
   def delete_agent(%Agent{} = agent), do: Repo.delete(agent)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -177,9 +177,25 @@ defmodule Fountain.Conversations.ConversationServer do
     sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
     agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id), else: nil
 
+    # Scoped by the conversation's owner even though create/update_agent
+    # already validates ownership: a cross-tenant environment_id that
+    # predates that check (or slips in through a future path) must not
+    # materialise another tenant's secrets or checkpoint here.
     env =
-      if agent && agent.environment_id,
-        do: Environments._unsafe_get_environment(agent.environment_id)
+      if agent && agent.environment_id do
+        case Environments.get_environment(agent.environment_id, conv.user_id) do
+          nil ->
+            Logger.warning(
+              "Agent #{agent.id} references environment #{agent.environment_id} " <>
+                "not owned by user #{conv.user_id}; provisioning without it"
+            )
+
+            nil
+
+          env ->
+            env
+        end
+      end
 
     vault = if conv.vault_id, do: Vaults._unsafe_get_vault(conv.vault_id)
 

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -17,6 +17,33 @@ defmodule Fountain.AgentsTest do
       assert {:error, changeset} = Agents.create_agent(%{})
       assert changeset.errors != []
     end
+
+    test "accepts an environment owned by the same user" do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id)
+      attrs = agent_attrs(user_id: user.id, environment_id: env.id)
+
+      assert {:ok, agent} = Agents.create_agent(attrs)
+      assert agent.environment_id == env.id
+    end
+
+    test "rejects another tenant's environment" do
+      attacker = insert_verified_user()
+      victim = insert_verified_user()
+      victim_env = insert_env(user_id: victim.id)
+      attrs = agent_attrs(user_id: attacker.id, environment_id: victim_env.id)
+
+      assert {:error, changeset} = Agents.create_agent(attrs)
+      assert %{environment_id: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "rejects a nonexistent environment with the same error as a foreign one" do
+      user = insert_verified_user()
+      attrs = agent_attrs(user_id: user.id, environment_id: Ecto.UUID.generate())
+
+      assert {:error, changeset} = Agents.create_agent(attrs)
+      assert %{environment_id: ["does not exist"]} = errors_on(changeset)
+    end
   end
 
   describe "get_agent/2" do
@@ -114,6 +141,25 @@ defmodule Fountain.AgentsTest do
 
       assert {:error, changeset} = Agents.update_agent(agent, %{"name" => nil})
       assert changeset.errors != []
+    end
+
+    test "accepts switching to an environment owned by the same user" do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id)
+      agent = insert_agent(user_id: user.id)
+
+      assert {:ok, updated} = Agents.update_agent(agent, %{"environment_id" => env.id})
+      assert updated.environment_id == env.id
+    end
+
+    test "rejects switching to another tenant's environment" do
+      attacker = insert_verified_user()
+      victim = insert_verified_user()
+      victim_env = insert_env(user_id: victim.id)
+      agent = insert_agent(user_id: attacker.id)
+
+      assert {:error, changeset} = Agents.update_agent(agent, %{"environment_id" => victim_env.id})
+      assert %{environment_id: ["does not exist"]} = errors_on(changeset)
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -101,6 +101,60 @@ defmodule Fountain.Conversations.ConversationServerTest do
     end
   end
 
+  describe "provisioning — tenant isolation" do
+    test "a cross-tenant environment_id on the agent is not materialised" do
+      attacker = insert_verified_user()
+      victim = insert_verified_user()
+      victim_env = insert_env(user_id: victim.id, checkpoint_id: "cp_victim")
+
+      # A legacy row from before create_agent validated environment ownership,
+      # inserted through the bare changeset the context no longer exposes to
+      # cross-tenant ids. The server must refuse to load it.
+      {:ok, agent} =
+        %Fountain.Agents.Agent{}
+        |> Fountain.Agents.Agent.changeset(%{
+          "name" => "legacy-cross-tenant",
+          "model" => "anthropic/claude-sonnet-4-6",
+          "runtime" => "claude",
+          "user_id" => attacker.id,
+          "environment_id" => victim_env.id
+        })
+        |> Repo.insert()
+
+      sandbox = insert_sandbox(user_id: attacker.id, status: "pending")
+
+      conv =
+        insert_conversation(
+          user_id: attacker.id,
+          agent: agent,
+          sandbox_id: sandbox.id,
+          status: "pending"
+        )
+
+      stub_happy_sprite()
+      test_pid = self()
+
+      Mimic.stub(Fountain.Conversations.Provisioning, :restore_checkpoint, fn _s, id ->
+        send(test_pid, {:restore_checkpoint, id})
+        {:ok, :restored}
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          {pid, _ref, :alive} = start_server(conv)
+
+          # The victim's checkpoint must never be restored into the
+          # attacker's sprite; the conversation still provisions, just
+          # without the foreign environment.
+          refute_received {:restore_checkpoint, _}
+          assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
+          GenServer.stop(pid)
+        end)
+
+      assert log =~ "not owned by user #{attacker.id}"
+    end
+  end
+
   describe "provisioning — failure paths" do
     test "a sprite that cannot be created marks both rows failed", %{conv: conv, sandbox: sandbox} do
       stub_happy_sprite()

--- a/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
@@ -103,6 +103,45 @@ defmodule FountainWeb.AgentControllerTest do
 
       assert json_response(conn, 422)
     end
+
+    test "returns 422 when environment_id belongs to another tenant", %{conn: conn, raw_key: raw_key} do
+      victim = insert_verified_user()
+      victim_env = insert_env(user_id: victim.id)
+
+      payload = %{
+        name: "probe",
+        model: "anthropic/claude-sonnet-4-6",
+        runtime: "claude",
+        environment_id: victim_env.id
+      }
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/agents", payload)
+
+      body = json_response(conn, 422)
+      assert body["errors"]["environment_id"] == ["does not exist"]
+    end
+
+    test "accepts environment_id owned by the caller", %{conn: conn, user: user, raw_key: raw_key} do
+      env = insert_env(user_id: user.id)
+
+      payload = %{
+        name: "with-env",
+        model: "anthropic/claude-sonnet-4-6",
+        runtime: "claude",
+        environment_id: env.id
+      }
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/agents", payload)
+
+      body = json_response(conn, 201)
+      assert body["data"]["environment_id"] == env.id
+    end
   end
 
   describe "PUT /api/agents/:id" do
@@ -135,6 +174,24 @@ defmodule FountainWeb.AgentControllerTest do
       agent = insert_agent(user_id: user.id)
       conn = put_json(conn, "/api/agents/#{agent.id}", %{name: "updated"})
       assert json_response(conn, 401)
+    end
+
+    test "returns 422 when updating environment_id to another tenant's", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      victim = insert_verified_user()
+      victim_env = insert_env(user_id: victim.id)
+      agent = insert_agent(user_id: user.id)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_json("/api/agents/#{agent.id}", %{environment_id: victim_env.id})
+
+      body = json_response(conn, 422)
+      assert body["errors"]["environment_id"] == ["does not exist"]
     end
   end
 


### PR DESCRIPTION
Fixes #308 (P0, audit-2026-08).

## What

- `Agents.create_agent/1` and `update_agent/2` validate `environment_id` against the owning tenant. The error is `environment_id: "does not exist"` — identical for a foreign env and a nonexistent one, so a foreign UUID can't be confirmed by probing.
- `ConversationServer.handle_continue(:provision)` loads the environment via `Environments.get_environment(id, conv.user_id)` instead of `_unsafe_get_environment/1`. A cross-tenant row that predates the validation (or slips in through a future path) provisions without the environment and logs a warning, rather than restoring the victim's checkpoint (plaintext `.env`, PAT in `.git/config`) into the attacker's sprite.

## Coverage of the paths named in the issue

| Path | Covered by |
|---|---|
| `POST /api/agents` / `PUT` | context validation (controller funnels through it) |
| LiveView form crafted `phx-submit` | context validation |
| Onboarding wizard | context validation |
| Manifest | already tenant-scoped by name; id passthrough now validated |
| `ConversationServer` env load + checkpoint restore | scoped load, defense in depth |

## Tests

- Context: same-tenant accepted; cross-tenant and nonexistent rejected with the identical error (create + update).
- Controller: 422 with the error body on create and update; 201 for owned env.
- ConversationServer: a legacy cross-tenant row (inserted through the bare changeset) provisions to `ready` **without** calling `restore_checkpoint` on the victim's checkpoint, and logs the ownership warning.

Each new test was run against the reverted fix and fails without it (4 context/controller failures, 1 server failure).

`mix precommit` green: 1703 tests, 0 failures.

Production data check for pre-existing cross-tenant rows is next (tracked in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)