### PR TITLE
ops: a failed funnel tick skips the datapoint instead of dying forever (#365)

### DIFF
--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -32,6 +32,8 @@ defmodule Fountain.Funnel do
 
   import Ecto.Query
 
+  require Logger
+
   alias Fountain.Accounts.User
   alias Fountain.Billing.UsageEvent
   alias Fountain.Conversations.Conversation
@@ -127,6 +129,15 @@ defmodule Fountain.Funnel do
       |> Map.put(:stalled_verified, stalled)
 
     :telemetry.execute([:fountain, :funnel], measurements, %{})
+  rescue
+    # A raise here must not escape: telemetry_poller permanently drops a
+    # measurement whose tick raises, so one failure — the boot tick racing
+    # Repo startup, a transient DB blip — would silently kill the funnel
+    # gauges for the node's lifetime (#365). Skip the datapoint instead;
+    # the next 10s tick retries.
+    error ->
+      Logger.warning("funnel telemetry tick skipped: #{Exception.message(error)}")
+      :ok
   end
 
   # Of the verified users with no conversation ever: how far did each get?

--- a/apps/fountain/test/fountain/funnel_test.exs
+++ b/apps/fountain/test/fountain/funnel_test.exs
@@ -173,5 +173,37 @@ defmodule Fountain.FunnelTest do
       assert Map.has_key?(measurements, :onboarded)
       assert Map.has_key?(measurements, :subscribed)
     end
+
+    test "a tick that cannot reach the database logs and returns :ok instead of raising" do
+      # telemetry_poller permanently drops a measurement whose tick raises,
+      # so the boot tick racing Repo startup used to kill the funnel gauges
+      # for the node's lifetime (#365). Reproduce that exact failure by
+      # pointing this process's dynamic repo at a name that isn't started.
+      ref = make_ref()
+      test_pid = self()
+
+      :telemetry.attach(
+        "funnel-fail-test-#{inspect(ref)}",
+        [:fountain, :funnel],
+        fn _event, measurements, _meta, _config -> send(test_pid, {ref, measurements}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach("funnel-fail-test-#{inspect(ref)}") end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Fountain.Repo.put_dynamic_repo(:repo_that_is_not_started)
+
+          try do
+            assert Funnel.emit_telemetry() == :ok
+          after
+            Fountain.Repo.put_dynamic_repo(Fountain.Repo)
+          end
+        end)
+
+      assert log =~ "funnel telemetry tick skipped"
+      refute_received {^ref, _measurements}
+    end
   end
 end


### PR DESCRIPTION
Fixes #365 (found while verifying the #310 rollout).

`telemetry_poller` permanently drops a measurement whose tick raises. The first collect fires ~5s after boot while `Fountain.Repo` is still starting, so `Funnel.emit_telemetry/0` raised once and the funnel gauges were silently unhooked for the pod's lifetime — both prod pods show exactly one such error at start +5s, and Prometheus has no `fountain_funnel_*` history at all. Any transient DB failure during a tick would re-kill them the same way.

The fix: `emit_telemetry/0` rescues, logs `funnel telemetry tick skipped: <reason>`, and returns `:ok`, so a bad tick costs one datapoint and the next 10s tick retries. Verified in dev: boot now logs the warning once and the gauges survive.

The new test reproduces the exact prod failure mode (`put_dynamic_repo(:repo_that_is_not_started)` → the "could not lookup Ecto repo" raise) and asserts `:ok`, the warning, and that no event was emitted. It fails against the unfixed code.

`mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)