### PR TITLE
docs: amend ADRs 0004/0005/0006 — dated addenda for moved mechanisms, mark unbuilt claims (#319)

### DIFF
--- a/decisions/0004-postgres-day-one.md
+++ b/decisions/0004-postgres-day-one.md
@@ -21,8 +21,8 @@ Concretely:
 - `render.yaml` declares a managed Postgres database, exposes `DATABASE_URL` to the web service, and removes the persistent disk that SQLite required.
 - Ecto repo configured for `Ecto.Adapters.Postgres`.
 - Schema definitions use `jsonb` for `metadata` columns (`usage_events`, `admin_audit_events`), `binary_id` (UUID) for primary keys, and `bigint` for the append-only event PKs.
-- All new tables use UUID v7 (separate decision, OQ-1c) — the time-ordering benefit is realized on Postgres B-tree indexes specifically.
-- Backups: rely on Render's managed Postgres daily backups + PITR. No Litestream needed; OQ-9b is N/A.
+- All new tables use UUID v7 (separate decision, OQ-1c) — the time-ordering benefit is realized on Postgres B-tree indexes specifically. *(**Never built** — primary keys are UUIDv4; see Addendum 2026-08-02.)*
+- Backups: rely on Render's managed Postgres daily backups + PITR. No Litestream needed; OQ-9b is N/A. *(Superseded — see Addendum 2026-08-02.)*
 
 ## Consequences
 
@@ -37,3 +37,10 @@ Concretely:
 - **SQLite + Litestream at launch, Postgres cutover later.** The original engineering-plan default. Rejected: pushes a known migration into a future sprint, requires Litestream tuning the operator hasn't done before, and saves only the cost of a managed Postgres line item — not enough to justify the future-toil debt.
 - **SQLite at launch, no Litestream, accept the backup gap.** Rejected: Render persistent disks are not cross-AZ replicated; a disk failure would lose data between snapshots. Unacceptable for a paid product (G2 chose a hard billing gate, ADR 0006).
 - **Postgres-compatible managed serverless (Neon, Supabase) instead of Render-managed Postgres.** Rejected for launch: adds a vendor relationship and egress considerations that aren't justified before there's evidence Render's managed Postgres is the bottleneck. Easy to revisit if it becomes one.
+
+## Addendum — 2026-08-02
+
+Two claims above no longer match (or never matched) the code:
+
+- **UUID v7 was never built.** Every schema uses `@primary_key {:id, :binary_id, autogenerate: true}` (e.g. `apps/fountain/lib/fountain/accounts/user.ex`), which generates `Ecto.UUID` values — **UUIDv4**. No v7 library is in the dependency tree. The B-tree time-ordering benefit claimed above therefore does not exist. If time-ordered ids become necessary, that is a new decision (and a migration), not something this ADR delivered.
+- **Backups are no longer Render's.** Production Postgres is CloudNativePG on the home-cloud Kubernetes cluster; backups are handled by `k8s/backup-cronjob.yaml`, `k8s/objectstore.yaml`, and `k8s/scheduledbackup.yaml`. The "Render managed backups + PITR" line is superseded. The core decision (Postgres from day one, no SQLite path) stands and is unaffected.

--- a/decisions/0005-platform-shared-sprites-token.md
+++ b/decisions/0005-platform-shared-sprites-token.md
@@ -30,3 +30,12 @@ Fountain holds a single **platform-level `SPRITES_TOKEN`** that is used to provi
 
 - **BYO Sprites token per tenant** — Rejected at launch. Adds a required setup step that breaks self-serve onboarding; tenants would need to create and manage their own Sprites accounts before using Fountain.
 - **Per-tenant Sprites sub-accounts** — Rejected. Not a feature the Sprites API currently supports.
+
+## Addendum — 2026-08-02
+
+Two mechanisms named above live somewhere other than where this ADR says:
+
+- **Token read location.** `ConversationServer` does not read the token, and nothing calls `Application.fetch_env!(:fountain, :sprites_token)`. Access is centralized in `Fountain.SpritesClient.get!/0` (`apps/fountain/lib/fountain/sprites_client.ex`), which reads `Application.get_env(:fountain, :sprites_token)` and raises explicitly ("SPRITES_TOKEN is not set") when absent. All Sprites API callers go through that client.
+- **Cap enforcement.** The production path does not call `Fountain.Quotas.check_sandbox_quota!/1`. Sandbox creation goes through `Fountain.Quotas.with_sandbox_reservation/2,3`, which runs the non-raising `check_sandbox_quota/2` together with the sandbox row insert under a per-user advisory lock (closing the check-then-insert race, #330). It is invoked from `Fountain.Conversations.start_conversation/1` and the wake path (`create_fresh_sandbox_and_start`). The raising `check_sandbox_quota!/2` exists but is exercised only by tests.
+
+The decision itself — one platform token, per-tenant concurrency cap as the noisy-neighbor mitigation — is unchanged.

--- a/decisions/0006-hard-stripe-billing-gate-at-launch.md
+++ b/decisions/0006-hard-stripe-billing-gate-at-launch.md
@@ -22,7 +22,7 @@ Gate enforcement, via `Fountain.Billing.assert_active!(user)`:
 
 Plan management uses Stripe Checkout (new subscriptions) and Stripe Customer Portal (existing subscriptions, payment method updates, cancellation). Webhook endpoint `POST /api/stripe/webhook` is signature-verified via `Stripe.Webhook.construct_event/3`.
 
-Usage period (OQ-5c): **calendar month in the user's selected timezone** (default UTC). `BillingLive` aggregates `usage_events` for the current calendar month.
+Usage period (OQ-5c): **calendar month in the user's selected timezone** (default UTC). `BillingLive` aggregates `usage_events` for the current calendar month. *(Per-user timezone was **never built** — the period is calendar-month **UTC**, hardcoded; see Addendum 2026-08-02.)*
 
 Pricing tier shape (Free / Pro / etc.) is **not** decided here — that's growth/marketing's call before launch. This ADR commits to the gate mechanism, not the price points.
 
@@ -43,3 +43,13 @@ Pricing tier shape (Free / Pro / etc.) is **not** decided here — that's growth
 - **Soft warn at launch (track usage, surface warnings, no enforcement).** Rejected: same cost problem as the stub, plus a worse story for "we never said this was free." A hard gate with a generous trial is more honest.
 - **Paddle or Lemon Squeezy as merchant-of-record (handles tax/VAT globally).** Rejected for launch: Stripe has materially better Elixir tooling and a faster path to a working Checkout flow. International tax compliance is a real concern but addressable post-launch (Stripe Tax, or a provider switch if Stripe Tax proves inadequate). Don't trade ship velocity for problems that don't exist yet.
 - **Lifetime / one-time payment instead of subscription.** Rejected: incompatible with a per-conversation cost model where Fountain pays Sprites continuously. Subscription matches the cost shape.
+
+## Addendum — 2026-08-02
+
+Five points where this ADR has drifted from (or never matched) the code:
+
+- **Enforcement sites.** There is no billing check in `ConversationServer.init/1` — there never was. The gate's backstops are `Fountain.Conversations.start_conversation/1` and the wake path (both reuse and fresh-sandbox arms call `Fountain.Billing.check_active/1` alongside the suspension check), plus a per-turn gate inside `ConversationServer` (`turn_gate/1`, added for #313 so a live sandbox doesn't outlive its subscription), and the `:require_active_subscription` LiveView hook. `assert_active!/1` still exists; the pipeline call sites use the non-raising `check_active/1`.
+- **Allowed statuses.** The code allows `~w(trialing active comped)` (`apps/fountain/lib/fountain/billing.ex`), not `[:trialing, :active]`. `comped` is operator-granted free access, set only from the admin panel.
+- **`past_due` cannot view past conversations.** `/conversations`, `/conversations/new`, and `/conversations/:id` sit inside the `:active_subscription` live_session in the router, so a `past_due` user is redirected to billing. What remains reachable is the log viewer (`/conversations/:id/logs`) plus dashboard, resource, onboarding, and billing/settings routes in the `:authenticated` live_session. The "read-only window" as described above is narrower in practice.
+- **Usage period timezone was never built.** There is no user timezone field; `BillingLive.current_month_range/0` computes the calendar month in UTC, hardcoded. Per-user timezone selection remains unbuilt; if it matters, it is a new piece of work, not something this ADR delivered.
+- **The gate is now conditional.** `BILLING_ENABLED` (default `"true"`, `config/runtime.exs`) feeds `Fountain.Billing.enabled?/0`; setting it to `false` disables the gate entirely. This exists for self-hosted instances, where the gate is a lock on the front door with no key. The "hard gate" decision stands for the hosted product, but it is now config, not an invariant of the source.


### PR DESCRIPTION
Closes #319.

Per the CLAUDE.md "Decisions" convention: dated addenda for mechanisms that moved, explicit **never built** markers for claims describing behavior that does not exist in code. Every finding was re-verified against the current tree before writing. ADRs 0002/0003/0007/0008 untouched (verified clean by the audit).

## ADR 0004 — Postgres day one
- **UUID v7 marked never built** (inline marker + addendum): every schema uses `@primary_key {:id, :binary_id, autogenerate: true}` → `Ecto.UUID` (v4); no v7 library in the dep tree; the claimed B-tree time-ordering benefit does not exist.
- **Backup story superseded** (addendum): production is CNPG on home-cloud k8s; backups via `k8s/backup-cronjob.yaml`, `k8s/objectstore.yaml`, `k8s/scheduledbackup.yaml` — not Render managed backups/PITR.

## ADR 0005 — Platform-shared Sprites token
Addendum correcting two locations:
- Token is read in `Fountain.SpritesClient.get!/0` via `Application.get_env` + explicit raise — not per-`ConversationServer` `fetch_env!`.
- Cap is enforced by `Fountain.Quotas.with_sandbox_reservation/2,3` (non-raising `check_sandbox_quota/2` + row insert under a per-user advisory lock, #330), called from `Conversations.start_conversation/1` and the wake path; `check_sandbox_quota!/2` is test-only.

## ADR 0006 — Hard Stripe billing gate
Addendum with five corrections:
- No billing check in `ConversationServer.init/1` (never was); backstops are `start_conversation/1`, both wake arms, the per-turn `turn_gate/1` (#313), and the LiveView hook — via non-raising `check_active/1`.
- Allowed statuses are `~w(trialing active comped)`, not `[:trialing, :active]`.
- `past_due` cannot view past conversations: `/conversations*` routes are in the `:active_subscription` live_session and redirect; only `/conversations/:id/logs` (plus dashboard/resources/settings) stays reachable.
- **Per-user timezone marked never built** (inline marker + addendum): no timezone field; `BillingLive.current_month_range/0` is hardcoded UTC.
- Records the `BILLING_ENABLED` conditional (`config/runtime.exs` → `Billing.enabled?/0`) — the gate is now config, not a source invariant.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)