### PR TITLE
release: cut the [0.3.0] changelog section and gate release bumps on a matching heading (#318)

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -70,6 +70,20 @@ jobs:
             exit 1
           fi
 
+      - name: Require a changelog section for the new version
+        env:
+          NEXT: ${{ steps.ver.outputs.next }}
+        run: |
+          set -euo pipefail
+          # v0.3.0 shipped with its upgrade notes stranded under
+          # [Unreleased] (#318). Refuse to tag until CHANGELOG.md has a
+          # heading for the version being released.
+          if ! grep -qF "## [${NEXT}]" CHANGELOG.md; then
+            echo "CHANGELOG.md has no \"## [${NEXT}]\" section." >&2
+            echo "Roll the [Unreleased] entries into a dated [${NEXT}] section before running the release bump." >&2
+            exit 1
+          fi
+
       - name: Update mix.exs files
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,6 @@ upgrade, is in
 
 ## [Unreleased]
 
-### Upgrade notes
-
-- Set `PUBLIC_URL` to your external URL, scheme included. It is now separate
-  from `PHX_HOST` and is what generated links, OAuth callbacks, and sandbox
-  callbacks are built from (#204). An `https://` `PUBLIC_URL` also switches on
-  the HTTPS redirect, HSTS, and secure session cookies (#241) — if you
-  terminate TLS in front of Fountain, your proxy must set `X-Forwarded-Proto`.
-- Production now refuses to boot without a mail setting. Configure
-  `RESEND_API_KEY`, `SMTP_HOST`, or explicitly opt out with
-  `EMAIL_DELIVERY=none` (#223).
-- Migrations continue to run automatically at boot; no manual steps.
-
 ### Added
 
 - Point-in-time recovery for the hosted database (#209): continuous WAL
@@ -68,6 +56,30 @@ upgrade, is in
   action (#169). Admin account deletions are now actually audit-recorded —
   the event type was missing from the audit allowlist and failed validation
   silently
+
+### Removed
+
+- SSH repository clones (#228). Implemented and hardened but unreachable —
+  validation has required `https://` since the schema existed, and production
+  confirmed zero use. Private repos are covered by https + token secrets; the
+  implementation stays in git history if demand appears
+
+## [0.3.0] — 2026-08-02
+
+### Upgrade notes
+
+- Set `PUBLIC_URL` to your external URL, scheme included. It is now separate
+  from `PHX_HOST` and is what generated links, OAuth callbacks, and sandbox
+  callbacks are built from (#204). An `https://` `PUBLIC_URL` also switches on
+  the HTTPS redirect, HSTS, and secure session cookies (#241) — if you
+  terminate TLS in front of Fountain, your proxy must set `X-Forwarded-Proto`.
+- Production now refuses to boot without a mail setting. Configure
+  `RESEND_API_KEY`, `SMTP_HOST`, or explicitly opt out with
+  `EMAIL_DELIVERY=none` (#223).
+- Migrations continue to run automatically at boot; no manual steps.
+
+### Added
+
 - Bulk manifest apply — a whole manifest in one request, and the CLI's
   `fountain apply` uses it (#151)
 - Agent-scoped vault allowlists: an agent can be restricted to a named set of
@@ -109,13 +121,6 @@ upgrade, is in
   against its own health probes (#249)
 - Deploys pin the exact built image on a dedicated `deploy` branch so manifest
   and image can never diverge (#250)
-
-### Removed
-
-- SSH repository clones (#228). Implemented and hardened but unreachable —
-  validation has required `https://` since the schema existed, and production
-  confirmed zero use. Private repos are covered by https + token secrets; the
-  implementation stays in git history if demand appears
 
 ### Fixed
 
@@ -194,7 +199,8 @@ upgrade, is in
 - Audit log for state-changing actions (append-only, best-effort)
 - Substitution engine for `${VAR}` / `$$` interpolation in agent configs
 
-[Unreleased]: https://github.com/BinaryBourbon/fountain/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/BinaryBourbon/fountain/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/BinaryBourbon/fountain/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/BinaryBourbon/fountain/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/BinaryBourbon/fountain/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/BinaryBourbon/fountain/releases/tag/v0.1.0


### PR DESCRIPTION
## What

Fixes the stranded v0.3.0 release notes and adds a guard so a release can't ship without a changelog section again.

**1. Retroactive `[0.3.0] — 2026-08-02` section in `CHANGELOG.md`.** Tag `v0.3.0` (commit `b82012f`, 2026-08-02) bumped only the two `mix.exs` versions; the changelog was never rolled, so the release's **Upgrade notes** — the `PUBLIC_URL` split (#204/#241) and the production mail boot-refusal (#223) — sat under `[Unreleased]`, exactly where `docs/self-hosting.md` and `deploy/k8s/README.md` tell upgraders they *won't* be.

The partition was determined by diffing `git show v0.3.0:CHANGELOG.md` against main:

- **Moved into `[0.3.0]`** — everything that was under `[Unreleased]` at the tag: the three Upgrade notes bullets, and the full Added / Changed / Fixed / Security sections (#151, #144, #146, #145, #143, #149, #234, billing #244/#251/#213/#214/#212, sandbox bounds #205/#233/#232, #217, self-hosting #225/#189/#224/#223/#230/#226, docs/OTel #125/#210, editors #122–#124, #70, clustering #132/#133, CI #237/#249, deploy branch #250, and all Fixed/Security entries).
- **Stays under `[Unreleased]`** — entries whose commits landed after the tag: PITR (#209), unverified-account pruning (#258), Sentry (#211), the `deploy/k8s` baseline (#191), dialyzer gating (#236), Sprites retries (#168), admin support tooling (#169), and the Removed section for SSH clones (#228).
- The #227 Security line keeps its post-tag amendment (#266 dropped the unreachable "SSH host keys verified" claim); link refs at the bottom now include `[0.3.0]` and `[Unreleased]` compares against `v0.3.0`.

**2. Changelog gate in `.github/workflows/release-bump.yml`.** A new step between version computation and the `mix.exs` edits fails the run if `CHANGELOG.md` lacks a `## [<next>]` heading — a fixed-string `grep`, no restructuring. I chose the gate over auto-rolling `[Unreleased]` into the bump commit because it's the smaller diff and it keeps a human accountable for the release notes: auto-rolling would happily publish an empty or half-written section, which is the same failure with better camouflage.

**3. Docs untouched.** `docs/self-hosting.md` and `deploy/k8s/README.md` describe the intended contract ("minor bumps call out breaking changes under Upgrade notes in the changelog") — that statement becomes true again with this fix, so there is nothing to correct.

## Verification

- `[0.3.0]` section body diffed against the tag's `[Unreleased]` body: identical except the deliberate #227 amendment.
- Workflow YAML parses; `grep -qF "## [0.3.0]"` passes on the new file, `"## [0.4.0]"` fails — so the next bump is gated until the changelog is rolled.

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)