### PR TITLE
docs: production is k8s not Render; fix five wrong claims in contributor/operator docs (#320)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ mix deps.get
 mix setup                           # dev DB: create + migrate
 MIX_ENV=test mix ecto.create && MIX_ENV=test mix ecto.migrate
 mix test                            # full suite (~200 tests)
-mix precommit                       # same checks CI runs
+mix precommit                       # the core CI checks, locally
 ```
 
 See [SETUP.md](SETUP.md) for full workstation bootstrap (Postgres, OAuth keys, etc.).
@@ -103,10 +103,10 @@ Environments.upsert_secret(env, %{"key" => "TOKEN", "value" => "plaintext"}, dek
 | Hook | Unauthenticated | Authenticated but ineligible |
 |---|---|---|
 | `require_authenticated_user` | `redirect` to `/auth/login` | — |
-| `require_active_subscription` | `redirect` to `/auth/login` | `push_navigate` to `/billing` |
+| `require_active_subscription` | `redirect` to `/auth/login` (via `require_authenticated_user`, which must run first) | `redirect` to `/account/billing` |
 | `require_admin` | `redirect` to `/auth/login` | `push_navigate` to `/dashboard` |
 
-The distinction matters in tests: `{:redirect, _}` vs `{:live_redirect, _}`.
+The distinction matters in tests: plain `redirect` yields `{:redirect, _}` (login and billing redirects), while `push_navigate` yields `{:live_redirect, _}` (the non-admin case in `require_admin`).
 
 ## Rate limiter
 
@@ -131,13 +131,20 @@ The `UeberAuthController` skips `plug Ueberauth` when `ueberauth_test_mode: true
 
 `.github/workflows/ci.yml` runs on every push to `main` and all PRs:
 
-1. `mix format --check-formatted`
-2. `mix compile --warnings-as-errors`
-3. `mix credo`
-4. `mix ecto.create && mix ecto.migrate`
-5. `mix test`
+1. `mix deps.unlock --unused` (fails if `mix.lock` has unused entries)
+2. `mix format --check-formatted`
+3. `mix compile --warnings-as-errors`
+4. `mix credo --strict`
+5. `mix hex.audit` (non-blocking — visible in the log, doesn't fail the build)
+6. `mix sobelow --config` (security scan)
+7. `MIX_ENV=dev mix dialyzer`
+8. Go CLI checks: `go test ./...` and `go vet ./...` in `cli/`
+9. `mix ecto.create && mix ecto.migrate`
+10. `mix coveralls` (the test suite, with coverage)
+11. Release boot check — builds a prod release, probes `/health` and `/health/ready`, runs a release task beside the live server
+12. `mix openapi.spec.json` + `jq empty` (OpenAPI spec validates)
 
-Run `mix precommit` locally before pushing — it's the same sequence.
+Run `mix precommit` locally before pushing — it covers the core gate (compile with warnings-as-errors, unused deps, format, `credo --strict`, dialyzer, tests). CI additionally runs sobelow, hex.audit, the Go CLI checks, the release boot check, and OpenAPI validation.
 
 ## Test patterns
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ After that, telling Claude “spin up a researcher agent on Fountain and have it
 
 ## Bootstrap a workstation
 
-See [`SETUP.md`](SETUP.md) for the full local bootstrap (mise + Postgres + deps). The toolchain version is pinned in `.tool-versions` and mirrored in `render.yaml`, so a fresh laptop or ephemeral VM gets the same Erlang/Elixir as production.
+See [`SETUP.md`](SETUP.md) for the full local bootstrap (mise + Postgres + deps). The local toolchain is pinned in `.tool-versions` (via mise), so a fresh laptop or ephemeral VM gets the same Erlang/Elixir as everyone else. Production runs a release image built from the repo-root `Dockerfile` and deployed to home-cloud Kubernetes via Flux (manifests in `k8s/`); the Dockerfile's `hexpm/elixir` base image pins the production toolchain, so a toolchain bump must update both `.tool-versions` and the Dockerfile — see the parity reference in `SETUP.md`.
 
 ## Contributing
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -36,7 +36,7 @@ cd fountain
 mise install
 ```
 
-This reads `.tool-versions` and installs the pinned Erlang/OTP and Elixir versions (~5 min on first run, cached after). The same `.tool-versions` is what Render uses in production, so dev and prod stay in lockstep.
+This reads `.tool-versions` and installs the pinned Erlang/OTP and Elixir versions (~5 min on first run, cached after). `.tool-versions` pins the *local* toolchain only; production runs the release image built from the repo-root `Dockerfile`, whose base image pins its own Erlang/Elixir (see [Production parity reference](#production-parity-reference)).
 
 Verify:
 
@@ -103,16 +103,17 @@ mix test         # full suite
 
 ## Production parity reference
 
-`render.yaml` and `.tool-versions` are kept aligned. If you bump the toolchain, change both:
+Production is home-cloud Kubernetes, deployed via Flux: the image is built from the repo-root `Dockerfile` and the manifests live in `k8s/`. The Erlang/Elixir toolchain is pinned in three places, and a toolchain bump must update all of them:
 
-| Where           | Erlang/OTP | Elixir        |
-| --------------- | ---------- | ------------- |
-| `.tool-versions`| `28.3`     | `1.19.2-otp-28` |
-| `render.yaml`   | `28.3`     | `1.19.2`      |
+| Where                      | What pins the toolchain                                              |
+| -------------------------- | -------------------------------------------------------------------- |
+| `.tool-versions`           | `erlang` / `elixir` lines (local dev via mise)                       |
+| `Dockerfile`               | the `FROM hexpm/elixir:<elixir>-erlang-<otp>-...` build-stage base image |
+| `.github/workflows/ci.yml` | `elixir-version` / `otp-version` in the `erlef/setup-beam` step      |
 
 ## Troubleshooting
 
 - **`role "postgres" does not exist`** — see step 4. Either `docker compose up -d postgres` or create the native role.
 - **Compile warnings about `OpentelemetryPhoenix` / `OpentelemetryEcto`** — these deps are `:prod`-only; `apply/3` is used to defer symbol resolution. If you see warnings, you're probably on stale `_build`; `rm -rf _build deps && mix deps.get && mix compile` to reset.
 - **mise installs Erlang from source and it's slow** — that's normal on first run. Subsequent installs (and ephemeral machines that share a mise cache) reuse the build.
-- **Tests fail with `rate_limited` errors** — `FountainWeb.Plugs.RateLimit` shares an ETS table across the suite; run `mix test --seed 0` or isolate the failing file.
+- **Tests fail with `rate_limited` errors** — shouldn't happen: `config/test.exs` sets `rate_limit_test_isolation: true`, which keys `FountainWeb.Plugs.RateLimit` buckets by the calling test process instead of a shared IP. If you see this, check that the flag is still set in `config/test.exs` (it's a correctness guard — don't remove it) and that your test isn't issuing enough requests from one process to legitimately exceed a bucket's limit.

--- a/apps/fountain/lib/fountain_web/plugs/rate_limit.ex
+++ b/apps/fountain/lib/fountain_web/plugs/rate_limit.ex
@@ -1,8 +1,9 @@
 defmodule FountainWeb.Plugs.RateLimit do
   @moduledoc """
-  Lightweight ETS-based fixed-window rate limiter. Single-tenant, so the
-  intent isn't anti-abuse multitenancy — it's anti-runaway: stop a buggy
-  client from spamming sprite spawns or saturating the BEAM.
+  Lightweight ETS-based fixed-window rate limiter. Fountain is multi-tenant;
+  per-IP limiting is a coarse abuse control, not a per-tenant quota — the
+  goal is to stop a buggy or hostile client from spamming sprite spawns or
+  saturating the BEAM, not to meter individual tenants.
 
   Buckets are per-IP. The ETS table is created in `Fountain.Application`
   startup. Returns 429 + `Retry-After` (seconds) when the bucket is full.
@@ -28,6 +29,8 @@ defmodule FountainWeb.Plugs.RateLimit do
 
   import Plug.Conn
 
+  # Table name inherited from an earlier project; renaming it is a behavior
+  # change (persistent named table), so it stays.
   @table :aod_rate_limit
 
   def table, do: @table

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,7 @@ DELETE /api/auth/api-keys/:id      # revoke a key
 
 ## Rate limiting
 
-Requests are rate-limited per API key (or IP for unauthenticated requests). On limit hit: `429 Too Many Requests` with `Retry-After` header.
+Requests are rate-limited per client IP (authenticated or not — the limiter does not key by API key). On limit hit: `429 Too Many Requests` with `Retry-After` header.
 
 ## Agents
 

--- a/docs/home-cloud-cutover.md
+++ b/docs/home-cloud-cutover.md
@@ -137,7 +137,7 @@ If no specific record exists, you're done.
 curl -sSf https://fountain.inevitable.fyi/health   # expect 200
 
 # Login flow validates GitHub OAuth callback (still pointing at
-# fountain.inevitable.fyi/auth/github/callback — unchanged from Render)
+# fountain.inevitable.fyi/auth/oauth/github/callback — unchanged from Render)
 open https://fountain.inevitable.fyi/auth/login
 
 # Once logged in, open an agent and run a turn — exercises the
@@ -149,7 +149,7 @@ open https://fountain.inevitable.fyi/auth/login
 ### 9. Verify Stripe webhooks
 
 The Stripe webhook URL doesn't change (still
-`https://fountain.inevitable.fyi/billing/webhook`), so webhooks delivered
+`https://fountain.inevitable.fyi/api/stripe/webhook`), so webhooks delivered
 during the cutover window will retry into the new env automatically.
 Check the Stripe dashboard → Webhooks → recent deliveries for any 5xx
 during the window.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -79,7 +79,7 @@ reaper logs one summary line per run:
 
 ```bash
 kubectl logs -n fountain -l app=fountain --since=2h | grep 'reaper:'
-# reaper: released=0 destroyed=2 untracked=102 live=114
+# reaper: released=0 expired=0 destroyed=2 untracked=102 live=114
 ```
 
 ---


### PR DESCRIPTION
Closes #320

Every correction below was re-verified against code before editing.

## Render staleness (README.md, SETUP.md)
- `README.md`: `.tool-versions` pins the local toolchain; production runs the release image built from the repo-root `Dockerfile`, deployed to home-cloud k8s via Flux (manifests in `k8s/`). No longer claims `render.yaml` mirrors production.
- `SETUP.md` step 2: same correction — the Dockerfile base image (`hexpm/elixir:...`) pins the production toolchain, not Render.
- `SETUP.md` "Production parity reference": table now lists the three places a toolchain bump must touch — `.tool-versions`, the Dockerfile build-stage base image, and `ci.yml`'s `erlef/setup-beam` versions. (`render.yaml` itself is left in place — out of scope.)

## Wrong claims
- **docs/api.md**: rate limiting is per client IP always (`rate_limit.ex` `key_for/2`), never per API key. Sentence corrected.
- **CLAUDE.md hooks table**: `require_active_subscription` does a plain `redirect(to: ~p"/account/billing")` (hooks.ex:71-79), not `push_navigate` to `/billing`. Table and the `{:redirect,_}` vs `{:live_redirect,_}` note fixed; `require_admin` row verified correct (`push_navigate` to `/dashboard`) and left alone.
- **CLAUDE.md CI pipeline**: list now matches `.github/workflows/ci.yml` exactly — unused-deps check, format, compile, `credo --strict`, `hex.audit` (non-blocking), `sobelow --config`, `MIX_ENV=dev mix dialyzer`, Go CLI test/vet, migrations, `mix coveralls`, release boot check, OpenAPI validation. "Same sequence" softened: precommit is the core subset (per the `precommit` alias in `mix.exs`; sobelow not attributed to precommit).
- **docs/home-cloud-cutover.md**: OAuth callback corrected to `/auth/oauth/github/callback` (router.ex `scope "/auth"` + `get "/oauth/:provider/callback"`); Stripe webhook corrected to `https://fountain.inevitable.fyi/api/stripe/webhook` (router.ex `POST /api/stripe/webhook`).
- **docs/operations.md**: reaper sample log line now includes `expired=`, matching the exact format emitted by `SandboxReaper.perform/1`.
- **SETUP.md troubleshooting**: removed the stale "shared ETS table, run `mix test --seed 0`" advice — `config/test.exs` sets `rate_limit_test_isolation: true` (per-process buckets).
- **RateLimit moduledoc**: no longer claims "single-tenant"; describes per-IP limiting as a coarse abuse control in a multi-tenant app. Prose only — the `:aod_rate_limit` table atom is unchanged, with a one-line comment noting the name is inherited. `mix format --check-formatted` passes on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)