### PR TITLE
security: CSP for browser routes; escape block HTML and filter markdown URL schemes (#323)

### DIFF
--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -640,17 +640,10 @@ defmodule FountainWeb.ConversationsLive.Show do
     """
   end
 
-  defp render_markdown(text) when is_binary(text) do
-    # Both Earmark outcomes carry usable html — the :error tuple still renders,
-    # just with warnings. There is deliberately no catch-all: as_html/2 returns
-    # nothing else, and a defensive clause here was dead code.
-    case Earmark.as_html(text, compact_output: true, smartypants: false) do
-      {:ok, html, _warnings} -> html
-      {:error, html, _warnings} -> html
-    end
-  end
-
-  defp render_markdown(_), do: ""
+  # Agent output is untrusted by construction (sandboxed code, prompt
+  # injection) — FountainWeb.Markdown strips javascript:-style URL schemes
+  # that survive Earmark's HTML escaping (#323).
+  defp render_markdown(text), do: FountainWeb.Markdown.to_html(text)
 
   defp format_chat_time(nil), do: ""
 

--- a/apps/fountain/lib/fountain_web/live/help_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/help_live/show.ex
@@ -49,14 +49,9 @@ defmodule FountainWeb.HelpLive.Show do
     end
   end
 
-  defp render_markdown(text) do
-    # Both Earmark outcomes carry usable html; as_html/2 returns nothing else,
-    # so there is deliberately no catch-all.
-    case Earmark.as_html(text, compact_output: true, smartypants: false) do
-      {:ok, html, _} -> html
-      {:error, html, _} -> html
-    end
-  end
+  # Help topics are repo-controlled markdown, but rendering through the same
+  # sanitizing pipeline as agent output keeps one code path (#323).
+  defp render_markdown(text), do: FountainWeb.Markdown.to_html(text)
 
   @impl true
   def render(assigns) do

--- a/apps/fountain/lib/fountain_web/markdown.ex
+++ b/apps/fountain/lib/fountain_web/markdown.ex
@@ -1,0 +1,142 @@
+defmodule FountainWeb.Markdown do
+  @moduledoc """
+  Markdown → HTML for untrusted input (agent output), fixing two holes in a
+  plain `Earmark.as_html/2` pipeline (#323):
+
+  1. Block-level raw HTML passes through Earmark **unescaped** (inline HTML
+     is escaped, block HTML is not) — so agent output containing
+     `<img src=x onerror=...>` as its own paragraph was live XSS.
+  2. Markdown link/image syntax accepts any URL scheme —
+     `[x](javascript:...)` rendered as a live link.
+
+  `to_html/1` renders through the Earmark AST: block-HTML (`verbatim`)
+  nodes are re-serialized and emitted as text — `Earmark.Transform` escapes
+  text nodes, so raw HTML displays as code rather than executing, matching
+  how Earmark already treats inline HTML. Link/image URLs are dropped unless
+  their scheme is on the allowlist — http/https/mailto for links, http/https
+  for images, relative URLs for both. The element itself is kept so the text
+  still reads; only the URL is removed.
+
+  Scheme checks run on a normalized copy of the URL: character references
+  decoded and the whitespace/control characters browsers ignore stripped, so
+  `java&#115;cript:` or `java\\tscript:` cannot smuggle a scheme past the
+  check. Normalization is deliberately generous — over-decoding can only
+  make the filter stricter.
+  """
+
+  @doc """
+  Renders untrusted markdown to HTML with raw HTML neutralized and unsafe
+  link/image URLs removed.
+
+  Both Earmark outcomes carry usable AST — the :error tuple still renders,
+  just with warnings. There is deliberately no catch-all: as_ast/2 returns
+  nothing else.
+  """
+  def to_html(text) when is_binary(text) do
+    case Earmark.as_ast(text, smartypants: false) do
+      {:ok, ast, _warnings} -> render(ast)
+      {:error, ast, _warnings} -> render(ast)
+    end
+  end
+
+  def to_html(_), do: ""
+
+  defp render(ast) do
+    ast
+    |> sanitize()
+    |> Earmark.transform(compact_output: true)
+  end
+
+  defp sanitize(nodes) when is_list(nodes), do: Enum.map(nodes, &sanitize/1)
+
+  # Block-level raw HTML. Re-serialized to a plain string so Transform
+  # escapes it as text instead of emitting it verbatim into the DOM.
+  defp sanitize({_tag, _attrs, _children, %{verbatim: true}} = node), do: reserialize(node)
+
+  defp sanitize({"a", attrs, children, meta}),
+    do: {"a", filter_url(attrs, "href", ~w(http https mailto)), sanitize(children), meta}
+
+  defp sanitize({"img", attrs, children, meta}),
+    do: {"img", filter_url(attrs, "src", ~w(http https)), sanitize(children), meta}
+
+  defp sanitize({tag, attrs, children, meta}), do: {tag, attrs, sanitize(children), meta}
+
+  # Text nodes (escaped by Transform) and comment nodes.
+  defp sanitize(other), do: other
+
+  # Verbatim children are the raw source lines as strings; nested markup
+  # arrives inside those strings, so joining them reconstructs the block.
+  defp reserialize({tag, attrs, children, _meta}) do
+    attrs_src = Enum.map_join(attrs, "", fn {k, v} -> ~s( #{k}="#{v}") end)
+    open = "<#{tag}#{attrs_src}>"
+
+    case children do
+      [] -> open
+      lines -> Enum.join([open | lines], "\n") <> "</#{tag}>"
+    end
+  end
+
+  defp filter_url(attrs, name, allowed_schemes) do
+    Enum.reject(attrs, fn
+      {^name, url} -> not safe_url?(url, allowed_schemes)
+      _ -> false
+    end)
+  end
+
+  defp safe_url?(url, allowed_schemes) do
+    normalized = normalize(url)
+
+    case String.split(normalized, ":", parts: 2) do
+      [_no_scheme] ->
+        true
+
+      [scheme, _rest] ->
+        # A ":" after a path/query/fragment delimiter is not a scheme
+        # separator (e.g. "/docs?q=a:b" or "#sec:1" are relative).
+        String.contains?(scheme, ["/", "?", "#"]) or scheme in allowed_schemes
+    end
+  end
+
+  defp normalize(url) do
+    url
+    |> decode_char_refs()
+    # Browsers strip tab/CR/LF anywhere in a URL and ignore leading control
+    # characters and spaces, so the check must too.
+    |> String.replace(~r/[\x00-\x20]/, "")
+    |> String.downcase()
+  end
+
+  # Decodes numeric character references (&#106; / &#x6A;) and the handful of
+  # named ones that could obfuscate a scheme. Two passes, so a reference that
+  # decodes into another reference (&amp;#58;) cannot survive normalization.
+  defp decode_char_refs(url) do
+    url |> decode_pass() |> decode_pass()
+  end
+
+  defp decode_pass(url) do
+    Regex.replace(~r/&(?:#x([0-9a-f]+)|#([0-9]+)|([a-z]+));?/i, url, fn whole, hex, dec, named ->
+      cond do
+        hex != "" -> codepoint(String.to_integer(hex, 16))
+        dec != "" -> codepoint(String.to_integer(dec))
+        true -> named_ref(String.downcase(named), whole)
+      end
+    end)
+  end
+
+  defp codepoint(n) when n > 0 and n < 0x110000 and not (n >= 0xD800 and n <= 0xDFFF),
+    do: <<n::utf8>>
+
+  defp codepoint(_), do: ""
+
+  @named_refs %{
+    "colon" => ":",
+    "sol" => "/",
+    "amp" => "&",
+    "tab" => "\t",
+    "newline" => "\n",
+    "num" => "#",
+    "quest" => "?"
+  }
+
+  defp named_ref(name, whole), do: Map.get(@named_refs, name, whole)
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -30,6 +30,27 @@ defmodule FountainWeb.Router do
     plug :accepts, ["json"]
   end
 
+  # As tight as the current asset setup allows: the root layout runs Tailwind
+  # and Phoenix/LiveView/d3 off CDNs and carries large inline scripts and
+  # onclick handlers, so script-src needs 'unsafe-inline' plus the two CDN
+  # hosts (a nonce scheme can't cover inline event handlers). That means this
+  # CSP does NOT block javascript: URLs — FountainWeb.Markdown filters those
+  # at render time (#323). What it does pin down: no framing, no <object>,
+  # no off-origin form posts, fetch/websocket restricted to self + the LV
+  # socket, images to self + the data: URLs the image picker and avatars use.
+  @csp [
+         "default-src 'self'",
+         "base-uri 'self'",
+         "frame-ancestors 'self'",
+         "form-action 'self'",
+         "object-src 'none'",
+         "img-src 'self' data:",
+         "style-src 'self' 'unsafe-inline'",
+         "script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net",
+         "connect-src 'self' ws: wss:"
+       ]
+       |> Enum.join("; ")
+
   # Base browser pipeline — session, flash, CSRF, secure headers
   pipeline :browser do
     plug :accepts, ["html"]
@@ -37,7 +58,7 @@ defmodule FountainWeb.Router do
     plug :fetch_live_flash
     plug :put_root_layout, html: {FountainWeb.Layouts, :root}
     plug :protect_from_forgery
-    plug :put_secure_browser_headers
+    plug :put_secure_browser_headers, %{"content-security-policy" => @csp}
   end
 
   # Public browser routes (login, register, verify) — no auth check

--- a/apps/fountain/test/fountain_web/csp_test.exs
+++ b/apps/fountain/test/fountain_web/csp_test.exs
@@ -1,0 +1,21 @@
+defmodule FountainWeb.CSPTest do
+  use FountainWeb.ConnCase, async: true
+
+  # #323: the browser pipeline had no Content-Security-Policy at all. The
+  # policy is deliberately loose on script-src (the root layout runs CDN
+  # scripts and inline handlers) — what must hold is that a policy exists and
+  # pins the high-value directives.
+  test "browser responses carry a Content-Security-Policy", %{conn: conn} do
+    conn = get(conn, ~p"/")
+    assert [csp] = get_resp_header(conn, "content-security-policy")
+    assert csp =~ "default-src 'self'"
+    assert csp =~ "frame-ancestors 'self'"
+    assert csp =~ "object-src 'none'"
+    assert csp =~ "base-uri 'self'"
+  end
+
+  test "API responses are not affected", %{conn: conn} do
+    conn = get(conn, ~p"/health")
+    assert get_resp_header(conn, "content-security-policy") == []
+  end
+end

--- a/apps/fountain/test/fountain_web/markdown_test.exs
+++ b/apps/fountain/test/fountain_web/markdown_test.exs
@@ -1,0 +1,118 @@
+defmodule FountainWeb.MarkdownTest do
+  use ExUnit.Case, async: true
+
+  alias FountainWeb.Markdown
+
+  describe "to_html/1 — safe URLs pass through" do
+    test "https, http and mailto links survive" do
+      html = Markdown.to_html("[a](https://x.com) [b](http://x.com) [c](mailto:a@b.c)")
+      assert html =~ ~s(href="https://x.com")
+      assert html =~ ~s(href="http://x.com")
+      assert html =~ ~s(href="mailto:a@b.c")
+    end
+
+    test "relative and fragment links survive" do
+      html = Markdown.to_html("[a](/docs) [b](docs/page.md) [c](#section) [d](?q=a:b)")
+      assert html =~ ~s(href="/docs")
+      assert html =~ ~s(href="docs/page.md")
+      assert html =~ ~s(href="#section")
+      assert html =~ ~s(href="?q=a:b")
+    end
+
+    test "a colon later in a relative path is not treated as a scheme" do
+      html = Markdown.to_html("[a](/search?q=foo:bar)")
+      assert html =~ ~s(href="/search?q=foo:bar")
+    end
+
+    test "http images survive" do
+      html = Markdown.to_html("![i](https://x.com/i.png)")
+      assert html =~ ~s(src="https://x.com/i.png")
+    end
+  end
+
+  describe "to_html/1 — unsafe URLs are dropped" do
+    test "javascript: links lose their href but keep their text" do
+      html = Markdown.to_html("[click](javascript:alert&#40;1&#41;)")
+      refute html =~ "javascript"
+      refute html =~ "href"
+      assert html =~ "click"
+    end
+
+    test "uppercase and mixed-case schemes are caught" do
+      refute Markdown.to_html("[x](JAVASCRIPT:alert(1))") =~ "href"
+      refute Markdown.to_html("[x](JaVaScRiPt:alert(1))") =~ "href"
+    end
+
+    test "numeric character references cannot smuggle a scheme" do
+      # &#106; = j, &#x6A; = j, &colon; = :
+      refute Markdown.to_html("[x](&#106;avascript:alert(1))") =~ "href"
+      refute Markdown.to_html("[x](&#x6A;avascript:alert(1))") =~ "href"
+      refute Markdown.to_html("[x](javascript&colon;alert(1))") =~ "href"
+    end
+
+    test "double-encoded references cannot smuggle a scheme" do
+      refute Markdown.to_html("[x](javascript&amp;colon;alert(1))") =~ "href"
+    end
+
+    test "embedded whitespace cannot split the scheme" do
+      refute Markdown.to_html("[x](java\tscript:alert(1))") =~ "href"
+      refute Markdown.to_html("[x](&#9;javascript:alert(1))") =~ "href"
+    end
+
+    test "data: and vbscript: links are dropped" do
+      refute Markdown.to_html("[x](data:text/html;base64,PHNjcmlwdD4=)") =~ "href"
+      refute Markdown.to_html("[x](vbscript:msgbox)") =~ "href"
+    end
+
+    test "data: image sources are dropped" do
+      html = Markdown.to_html("![i](data:image/svg+xml;base64,AAAA)")
+      refute html =~ "src"
+      assert html =~ "img"
+    end
+
+    test "mailto is not an allowed image scheme" do
+      refute Markdown.to_html("![i](mailto:a@b.c)") =~ "src"
+    end
+  end
+
+  describe "to_html/1 — raw HTML is neutralized" do
+    test "block-level script tags are escaped, not emitted verbatim" do
+      # Plain Earmark.as_html passes block-level raw HTML through unescaped —
+      # this was live XSS from agent output before #323.
+      html = Markdown.to_html("<script>alert(1)</script>")
+      refute html =~ "<script>"
+      assert html =~ "&lt;script&gt;"
+    end
+
+    test "block-level event-handler HTML is escaped" do
+      html = Markdown.to_html("para\n\n<img src=x onerror=alert(1)>\n\nend")
+      refute html =~ "<img"
+      assert html =~ "&lt;img"
+    end
+
+    test "block-level HTML with nested elements and attributes is escaped" do
+      html = Markdown.to_html(~s(<div class="x"><span onclick=x>hi</span></div>))
+      refute html =~ "<div"
+      refute html =~ "<span"
+      assert html =~ "&lt;div"
+      assert html =~ "hi"
+    end
+
+    test "inline HTML stays escaped" do
+      html = Markdown.to_html("text <b onclick=x>bold</b> end")
+      refute html =~ "<b "
+      assert html =~ "&lt;b"
+    end
+
+    test "ordinary markdown renders" do
+      html = Markdown.to_html("# Title\n\nSome **bold** text")
+      assert html =~ "<h1>"
+      assert html =~ "<strong>"
+    end
+
+    test "non-binary input renders as empty" do
+      assert Markdown.to_html(nil) == ""
+      assert Markdown.to_html(123) == ""
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **Found while fixing: the issue understates the bug.** Earmark escapes *inline* raw HTML but emits *block-level* raw HTML verbatim — `<img src=x onerror=...>` as its own paragraph in agent output executed in the viewer's browser. No click required. This PR fixes that too.
- New `FountainWeb.Markdown.to_html/1` renders through the Earmark AST: verbatim (block-HTML) nodes are re-serialized and emitted as escaped text (matching how inline HTML already behaved), and link/image URLs are dropped unless the scheme is http/https/mailto (links) or http/https (images). Scheme checks run on a normalized URL — numeric/named character references decoded, browser-ignored whitespace stripped — so `java&#106;script:` variants can't smuggle through. Both markdown render sites (conversation turns, help topics) now use it.
- Adds a Content-Security-Policy to the `:browser` pipeline. It is necessarily loose on `script-src` ('unsafe-inline' + the Tailwind/jsdelivr CDN hosts — the root layout's inline scripts and onclick handlers rule out nonces), but pins `frame-ancestors`, `object-src`, `base-uri`, `form-action`, `img-src 'self' data:` and `connect-src 'self' ws: wss:`. External images in agent output are therefore also blocked at the browser level (exfil-pixel resistance).
- Clears sobelow's High-confidence `Config.CSP` finding — with #371 (#327), the last blocker for re-pointing the sobelow gate (#311).
- 21 new tests (scheme allowlist, entity/whitespace obfuscation, block/inline HTML escaping, CSP header presence).

## Follow-up worth considering
Vendoring the CDN assets and moving the root-layout inline JS into `/assets` would allow dropping 'unsafe-inline' and the CDN hosts from script-src, at which point the CSP would also block `javascript:` URLs by itself.

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)