### PR TITLE
security: redact ConversationServer secrets from crash reports (#315)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -829,6 +829,15 @@ defmodule Fountain.Conversations.ConversationServer do
     {:stop, :normal, :ok, state}
   end
 
+  # Catch-all: an unmatched call must not die with a FunctionClauseError at
+  # the callback head — that exception's message embeds the full state
+  # (plaintext secrets included) in the crash report, and format_status/1
+  # cannot redact an exception message (#315).
+  def handle_call(msg, _from, state) do
+    Logger.warning("conv #{state.conversation_id}: unexpected call #{inspect(msg)}")
+    {:reply, {:error, :unknown_call}, state}
+  end
+
   # The prompt a conversation was started for. Ignored if a turn is somehow
   # already running — the cast is queued behind provisioning, so that should not
   # happen, and re-running is the failure this whole mechanism exists to avoid.
@@ -858,6 +867,12 @@ defmodule Fountain.Conversations.ConversationServer do
           {:noreply, state}
       end
     end
+  end
+
+  # Catch-all for the same reason as the handle_call one above (#315).
+  def handle_cast(msg, state) do
+    Logger.warning("conv #{state.conversation_id}: unexpected cast #{inspect(msg)}")
+    {:noreply, state}
   end
 
   @impl true
@@ -1040,6 +1055,43 @@ defmodule Fountain.Conversations.ConversationServer do
 
     :ok
   end
+
+  # Redacts secrets from crash reports and :sys.get_status output (#315). An
+  # unhandled raise in any callback logs `State:` via inspect — without this,
+  # that meant plaintext env secrets, the raw tenant DEK, decrypted BYO
+  # inference credentials, the callback API key, and the platform Sprites
+  # token (inside sprite.client) on stdout and, with SENTRY_DSN set, in a
+  # Sentry event body. Sentry's PlugContext scrubbing never sees process
+  # crash reports, so the redaction has to happen here.
+  #
+  # Key names are kept (values replaced) so crash reports stay debuggable.
+  @impl true
+  def format_status(status) do
+    Map.new(status, fn
+      {:state, %{conversation_id: _} = state} -> {:state, redact_state(state)}
+      other -> other
+    end)
+  end
+
+  defp redact_state(state) do
+    %{
+      state
+      | sprite: redact_sprite(state.sprite),
+        sprite_env: Enum.map(state.sprite_env, fn {k, _v} -> {k, "[REDACTED]"} end),
+        tenant_key: redact(state.tenant_key),
+        inference_credentials: redact_map(state.inference_credentials),
+        callback_token: redact(state.callback_token)
+    }
+  end
+
+  defp redact_sprite(%{client: _} = sprite), do: Map.put(sprite, :client, "[REDACTED]")
+  defp redact_sprite(other), do: other
+
+  defp redact_map(%{} = map), do: Map.new(map, fn {k, _v} -> {k, "[REDACTED]"} end)
+  defp redact_map(other), do: redact(other)
+
+  defp redact(nil), do: nil
+  defp redact(_present), do: "[REDACTED]"
 
   # ── helpers ───────────────────────────────────────────────────────────────
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_redaction_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_redaction_test.exs
@@ -1,0 +1,108 @@
+defmodule Fountain.Conversations.ConversationServerRedactionTest do
+  # #315: ConversationServer state holds plaintext tenant secrets, the raw
+  # DEK, decrypted BYO inference credentials, the callback API key and the
+  # platform Sprites token. Three leak vectors, each covered here:
+  #
+  #   1. A FunctionClauseError at a callback head embeds the full state in
+  #      the exception message — format_status/1 cannot redact an exception
+  #      message, so unknown calls/casts must not crash at the head.
+  #   2. A crash inside a callback body produces a crash report whose state
+  #      field feeds structured handlers (Sentry.LoggerHandler) —
+  #      format_status/1 redacts it at the gen_server level.
+  #   3. :sys.get_status (ops tooling, remote console) renders state through
+  #      the same callback.
+  use Fountain.ConversationServerCase
+
+  import ExUnit.CaptureLog
+
+  @secret_env_value "sprite-env-secret-value-315"
+  @dek_value "raw-tenant-dek-bytes-315"
+  @inference_value "sk-ant-byo-credential-315"
+  @callback_value "fnt_callback_key_315"
+  @sprites_token "sprites-platform-token-315"
+
+  defp start_server_with_secrets do
+    stub_happy_sprite()
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+
+    {pid, ref, :alive} = start_server(conv)
+
+    # Provisioning under stubs leaves most secret fields empty, so plant
+    # realistic values through the server itself — whatever the state holds
+    # at crash time is exactly what must come out redacted.
+    :sys.replace_state(pid, fn state ->
+      %{
+        state
+        | sprite: %Sprites.Sprite{
+            name: "test-sprite",
+            client: %Sprites.Client{token: @sprites_token}
+          },
+          sprite_env: [{"MY_SECRET", @secret_env_value}, {"OTHER", "other-value-315"}],
+          tenant_key: @dek_value,
+          inference_credentials: %{"anthropic" => @inference_value},
+          callback_token: @callback_value
+      }
+    end)
+
+    {pid, ref}
+  end
+
+  defp refute_secrets(rendered) do
+    refute rendered =~ @secret_env_value
+    refute rendered =~ "other-value-315"
+    refute rendered =~ @dek_value
+    refute rendered =~ @inference_value
+    refute rendered =~ @callback_value
+    refute rendered =~ @sprites_token
+  end
+
+  test "unknown calls and casts do not crash at the callback head" do
+    {pid, _ref} = start_server_with_secrets()
+
+    log =
+      capture_log(fn ->
+        assert {:error, :unknown_call} = GenServer.call(pid, :no_such_call)
+        GenServer.cast(pid, :no_such_cast)
+        # Synchronize so the cast has been handled before asserting.
+        _ = :sys.get_state(pid)
+      end)
+
+    assert Process.alive?(pid)
+    assert log =~ "unexpected call"
+    assert log =~ "unexpected cast"
+    refute_secrets(log)
+  end
+
+  test "a crash inside a callback body does not leak secrets into the crash report" do
+    {pid, ref} = start_server_with_secrets()
+
+    # Corrupt a lifecycle field so the next :lifecycle_check raises deep in
+    # the callback body — the unhandled-crash shape the issue describes.
+    :sys.replace_state(pid, fn state ->
+      %{state | sandbox_started_at: DateTime.utc_now(), last_activity_at: :corrupt}
+    end)
+
+    log =
+      capture_log(fn ->
+        send(pid, :lifecycle_check)
+        assert_stopped(ref)
+      end)
+
+    assert log =~ "terminating"
+    refute_secrets(log)
+  end
+
+  test "format_status redacts state for structured crash reports and :sys.get_status" do
+    {pid, _ref} = start_server_with_secrets()
+
+    rendered = inspect(:sys.get_status(pid), limit: :infinity, printable_limit: :infinity)
+
+    refute_secrets(rendered)
+
+    # Key names survive so reports stay debuggable.
+    assert rendered =~ "MY_SECRET"
+    assert rendered =~ "[REDACTED]"
+  end
+end


### PR DESCRIPTION
## Summary
- `format_status/1` on `ConversationServer` redacts `sprite_env` values, `tenant_key` (the raw DEK), `inference_credentials`, `callback_token`, and `sprite.client` (which embeds the platform Sprites bearer token — one the issue didn't list) from gen_server crash reports and `:sys.get_status`. Key names are kept so reports stay debuggable.
- Catch-all `handle_call`/`handle_cast` clauses (`handle_info` already had one). This matters because a `FunctionClauseError` at the callback head embeds the **full state in the exception message** — verified live: `GenServer.cast(pid, :boom)` printed every secret to stdout through the head-clause arguments, a path `format_status` cannot redact.
- One empirical note: on OTP 28/Elixir 1.19 the console translator doesn't print a `State:` line for GenServer crashes — the state travels in the structured logger report (what `Sentry.LoggerHandler` consumes), which is exactly what `format_status/1` now redacts at the source.
- Three tests crash a real server (via the `ConversationServerCase` harness) with planted secrets and assert none survive in the captured log or rendered status.

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)