### PR TITLE
security: rate-limit /api before TenantAPIAuth so failed auth is metered (#316)

### DIFF
--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -21,8 +21,14 @@ defmodule FountainWeb.Router do
   # plugs would be one forgotten line away from an unauthenticated endpoint.
   pipeline :api do
     plug FountainWeb.Plugs.PutApiSpec, module: FountainWeb.ApiSpec
-    plug FountainWeb.Plugs.TenantAPIAuth
+    # RateLimit BEFORE TenantAPIAuth (#316): auth halts on failure, so with
+    # the old order the limiter only ever saw authenticated requests —
+    # unauthenticated callers got unlimited attempts, each costing a SHA-256
+    # plus an indexed api_keys lookup. This was the one auth surface without
+    # a pre-auth limit; session login, registration, password reset and
+    # POST /api/auth/token all have one.
     plug FountainWeb.Plugs.RateLimit, bucket: "api", max: 600
+    plug FountainWeb.Plugs.TenantAPIAuth
     plug FountainWeb.Plugs.Audit
   end
 

--- a/apps/fountain/test/fountain_web/plugs/pre_auth_rate_limit_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/pre_auth_rate_limit_test.exs
@@ -1,0 +1,57 @@
+defmodule FountainWeb.PreAuthRateLimitTest do
+  # #316: TenantAPIAuth halts 401 before RateLimit ever ran, so failed API
+  # auth was unmetered — anonymous callers got unlimited attempts, each
+  # costing a SHA-256 plus an indexed api_keys lookup. The limiter must run
+  # first. These go through the real router pipeline; the bucket is keyed to
+  # this test process (rate_limit_test_isolation), so filling it only
+  # affects requests dispatched here.
+  use FountainWeb.ConnCase, async: true
+
+  alias FountainWeb.Plugs.RateLimit
+
+  defp fill_api_bucket do
+    RateLimit.ensure_table()
+    now = System.system_time(:millisecond)
+    :ets.insert(RateLimit.table(), {{"api", self()}, now, 600})
+  end
+
+  test "unauthenticated requests are metered — 429 wins over 401 when the bucket is full",
+       %{conn: conn} do
+    fill_api_bucket()
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer not-a-real-key")
+      |> get(~p"/api/agents")
+
+    # With the pre-#316 plug order this was a 401: auth halted first and the
+    # limiter never saw the request.
+    assert conn.status == 429
+  end
+
+  test "a missing Authorization header is metered too", %{conn: conn} do
+    fill_api_bucket()
+    assert get(conn, ~p"/api/agents").status == 429
+  end
+
+  test "under the limit, unauthenticated requests still 401", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer not-a-real-key")
+      |> get(~p"/api/agents")
+
+    assert conn.status == 401
+  end
+
+  test "under the limit, authenticated requests still work", %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, {_key, raw_key}} = Fountain.Accounts.create_api_key(user.id, "t")
+
+    conn =
+      conn
+      |> authed_with_key(raw_key)
+      |> get(~p"/api/agents")
+
+    assert conn.status == 200
+  end
+end


### PR DESCRIPTION
## Summary
- Moves `RateLimit` above `TenantAPIAuth` in the `:api` pipeline. Auth halts on failure, so with the old order unauthenticated callers were never metered — an unaudited DB-load amplifier (SHA-256 + indexed `api_keys` lookup per attempt), and the only auth surface without a pre-auth limit.
- Same bucket ("api") and budget (600/min/IP); legitimate authenticated traffic sees no change. Over-limit callers now get 429 before the auth work happens, which also sheds the hashing/DB cost under abuse.
- Tests dispatch through the real router pipeline: with the bucket full, 429 must win over 401 (verified to fail against the old plug order); under the limit, 401/200 behavior is unchanged.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)