### PR TITLE
self-host: trace export is off unless an export target is configured (#317)

### DIFF
--- a/apps/fountain/test/fountain/otel_config_test.exs
+++ b/apps/fountain/test/fountain/otel_config_test.exs
@@ -1,0 +1,73 @@
+defmodule Fountain.OtelConfigTest do
+  @moduledoc """
+  Evaluates `config/runtime.exs` the way the release config provider does,
+  pinning #317: trace export must be OFF unless an export target is
+  explicitly configured. The old default was :otlp aimed at
+  api.honeycomb.io, which made a stock self-host install attempt outbound
+  telemetry to a third-party vendor.
+  """
+
+  # Mutates process env, so it must not run alongside anything else.
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+
+  @otel_vars ~w(OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_HEADERS HONEYCOMB_ENDPOINT HONEYCOMB_API_KEY)
+
+  @required %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "RESEND_API_KEY" => "re_test_key",
+    "PUBLIC_URL" => "https://fountain.example.com"
+  }
+
+  setup do
+    key = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+    previous = System.get_env()
+
+    on_exit(fn ->
+      System.put_env(previous)
+
+      for k <- @otel_vars ++ ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN RESEND_API_KEY EMAIL_DELIVERY),
+          not Map.has_key?(previous, k),
+          do: System.delete_env(k)
+    end)
+
+    {:ok, base: Map.put(@required, "MASTER_SECRETS_KEY", key)}
+  end
+
+  defp read_prod_config(env) do
+    for k <- @otel_vars, do: System.delete_env(k)
+    System.put_env(env)
+    Config.Reader.read!(@runtime_exs, env: :prod)
+  end
+
+  test "with no export target configured, the traces exporter is off", %{base: base} do
+    cfg = read_prod_config(base)
+
+    assert cfg[:opentelemetry][:traces_exporter] == :none
+  end
+
+  test "an explicit OTLP endpoint turns the exporter on", %{base: base} do
+    cfg = read_prod_config(Map.put(base, "OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318"))
+
+    assert cfg[:opentelemetry][:traces_exporter] == :otlp
+    assert cfg[:opentelemetry_exporter][:otlp_endpoint] == "http://collector:4318"
+  end
+
+  test "HONEYCOMB_API_KEY alone turns the exporter on with the auth header", %{base: base} do
+    cfg = read_prod_config(Map.put(base, "HONEYCOMB_API_KEY", "hc-key"))
+
+    assert cfg[:opentelemetry][:traces_exporter] == :otlp
+    assert cfg[:opentelemetry_exporter][:otlp_endpoint] == "https://api.honeycomb.io"
+    assert {"x-honeycomb-team", "hc-key"} in cfg[:opentelemetry_exporter][:otlp_headers]
+  end
+
+  test "HONEYCOMB_ENDPOINT alone turns the exporter on", %{base: base} do
+    cfg = read_prod_config(Map.put(base, "HONEYCOMB_ENDPOINT", "https://api.eu1.honeycomb.io"))
+
+    assert cfg[:opentelemetry][:traces_exporter] == :otlp
+    assert cfg[:opentelemetry_exporter][:otlp_endpoint] == "https://api.eu1.honeycomb.io"
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -477,6 +477,19 @@ if config_env() == :prod and server? do
   #
   # For Honeycomb specifically you can also set HONEYCOMB_API_KEY and the
   # exporter config below will wire it up automatically.
+  #
+  # OFF unless an export target is explicitly configured (#317): the exporter
+  # used to default to :otlp aimed at api.honeycomb.io, so a self-hoster who
+  # set none of these got continuous rejected span batches against a
+  # third-party vendor plus exporter noise in the logs. The SDK still honours
+  # OTEL_TRACES_EXPORTER itself (with higher precedence than this), so
+  # export can be forced on or off either way.
+  otel_configured? =
+    Enum.any?(
+      ~w(OTEL_EXPORTER_OTLP_ENDPOINT HONEYCOMB_ENDPOINT HONEYCOMB_API_KEY),
+      &System.get_env/1
+    )
+
   otel_endpoint =
     System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT") ||
       System.get_env("HONEYCOMB_ENDPOINT", "https://api.honeycomb.io")
@@ -507,7 +520,7 @@ if config_env() == :prod and server? do
 
   config :opentelemetry,
     span_processor: :batch,
-    traces_exporter: :otlp,
+    traces_exporter: if(otel_configured?, do: :otlp, else: :none),
     resource: [
       {"service.name", System.get_env("OTEL_SERVICE_NAME", "fountain")},
       {"deployment.environment", System.get_env("FLY_APP_NAME", "prod")}

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -33,3 +33,7 @@ data:
   # DATABASE_SSL_VERIFY / DATABASE_SSL_CA_FILE upgrade encryption to actual
   # verification — see the self-hosting guide.
   DATABASE_SSL: "true"
+
+  # Trace export is off by default — nothing leaves the instance. To ship
+  # traces to a collector, set OTEL_EXPORTER_OTLP_ENDPOINT (and
+  # OTEL_EXPORTER_OTLP_HEADERS if it needs auth); see docs/configuration.md.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,9 @@ Only needed for more than one replica — see
 | `HONEYCOMB_ENDPOINT` | `https://api.honeycomb.io` | — | Honeycomb shortcut for the endpoint above |
 | `HONEYCOMB_API_KEY` | — | — | Honeycomb shortcut: adds the `x-honeycomb-team` header |
 
-Trace export is configured only in production while serving. The OTel SDK also
-honours its own standard variables — the hosted deployment sets
-`OTEL_TRACES_EXPORTER=none` to disable export without a collector.
+Trace export is configured only in production while serving, and is **off by
+default**: spans are exported only when `OTEL_EXPORTER_OTLP_ENDPOINT`,
+`HONEYCOMB_ENDPOINT` or `HONEYCOMB_API_KEY` is explicitly set. The OTel SDK
+also honours its own standard variables, which take precedence — set
+`OTEL_TRACES_EXPORTER=otlp` or `=none` to force export on or off regardless
+of the above.


### PR DESCRIPTION
## Summary
- `config/runtime.exs` now sets `traces_exporter: :none` unless `OTEL_EXPORTER_OTLP_ENDPOINT`, `HONEYCOMB_ENDPOINT` or `HONEYCOMB_API_KEY` is explicitly set — a default install no longer attempts outbound telemetry to a vendor endpoint it was never told about. `OTEL_TRACES_EXPORTER` is read by the OTel SDK itself with higher precedence, so export can still be forced on/off either way.
- `deploy/k8s/configmap.yaml` gains a comment documenting how to opt in; `docs/configuration.md` states the off-by-default behavior.
- No change for the maintainer's deployments: compose and the hosted `k8s/deployment.yaml` already set `OTEL_TRACES_EXPORTER=none`.
- New `Config.Reader` tests pin: no vars → `:none`; endpoint → `:otlp`; `HONEYCOMB_API_KEY` alone → `:otlp` + auth header; `HONEYCOMB_ENDPOINT` alone → `:otlp`.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)