### PR TITLE
security: OAuth-only accounts get a 401 on password login, not a 500 (#324)

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -136,6 +136,15 @@ defmodule Fountain.Accounts do
 
     if user do
       cond do
+        # OAuth-only accounts have no password_hash; verify_pass would raise,
+        # turning POST /auth/login into a 500 that doubles as an
+        # account-existence oracle (#324). Burn the same dummy verify as the
+        # no-user branch so the timing shape stays uniform, and answer
+        # exactly what any bad password gets.
+        is_nil(user.password_hash) ->
+          Bcrypt.no_user_verify()
+          {:error, :wrong_password}
+
         not Bcrypt.verify_pass(password, user.password_hash) ->
           {:error, :wrong_password}
 

--- a/apps/fountain/test/fountain/accounts_oauth_only_login_test.exs
+++ b/apps/fountain/test/fountain/accounts_oauth_only_login_test.exs
@@ -1,0 +1,66 @@
+defmodule Fountain.AccountsOauthOnlyLoginTest do
+  # #324: authenticate_user/2 called Bcrypt.verify_pass on a nil
+  # password_hash for OAuth-only accounts — an ArgumentError, so
+  # POST /auth/login and POST /api/auth/token answered 500 for exactly the
+  # emails that have an OAuth-only account: a crash and an
+  # account-existence oracle in one.
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts
+  alias Fountain.Accounts.User
+
+  defp insert_oauth_only_user do
+    %User{}
+    |> User.oauth_registration_changeset(%{
+      email: "oauthonly-#{System.unique_integer([:positive])}@example.com",
+      email_verified_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> Repo.insert!()
+  end
+
+  test "a password attempt against an OAuth-only account fails like any wrong password" do
+    user = insert_oauth_only_user()
+    assert is_nil(user.password_hash)
+
+    assert {:error, :wrong_password} = Accounts.authenticate_user(user.email, "any-password")
+  end
+
+  test "password accounts still authenticate" do
+    user = insert_verified_user()
+    assert {:ok, %User{}} = Accounts.authenticate_user(user.email, "password123")
+  end
+end
+
+defmodule FountainWeb.OauthOnlyLoginControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Accounts.User
+
+  defp insert_oauth_only_user do
+    %User{}
+    |> User.oauth_registration_changeset(%{
+      email: "oauthonly-#{System.unique_integer([:positive])}@example.com",
+      email_verified_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> Fountain.Repo.insert!()
+  end
+
+  test "POST /auth/login answers the standard 401, not a 500", %{conn: conn} do
+    user = insert_oauth_only_user()
+
+    conn = post(conn, ~p"/auth/login", %{"email" => user.email, "password" => "x"})
+
+    body = html_response(conn, 401)
+    assert body =~ "Invalid email or password"
+  end
+
+  test "POST /api/auth/token answers the standard 401, not a 500", %{conn: conn} do
+    user = insert_oauth_only_user()
+
+    conn = post_json(conn, ~p"/api/auth/token", %{email: user.email, password: "x"})
+
+    assert conn.status == 401
+    # Same body an unknown email gets — no oracle.
+    assert %{"error" => _} = json_response(conn, 401)
+  end
+end


### PR DESCRIPTION
## Summary
- `authenticate_user/2` treats a nil `password_hash` (OAuth-only account) as a failed password check: burns `Bcrypt.no_user_verify()` for uniform timing and returns the same `{:error, :wrong_password}` any bad password gets.
- Before: `Bcrypt.verify_pass(password, nil)` raised `ArgumentError` → 500 from `POST /auth/login` and `POST /api/auth/token` — distinguishable from the 401 everything else returns, i.e. an account-existence oracle, plus a trivially reachable Sentry flood.
- Tests cover the context function and both endpoints; verified to fail (with the exact ArgumentError) against the old code.
- The issue's suggestion to tell users their account uses GitHub sign-in *after* successful OAuth is UX work out of scope here.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)