### PR TITLE
security: password-reset tokens are single-use (#325)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
@@ -40,7 +40,11 @@ defmodule FountainWeb.PasswordResetController do
     user = Accounts.get_user_by_email(email)
 
     if user do
-      token = Phoenix.Token.sign(conn, "password_reset", user.id)
+      # session_version rides inside the token (#325): reset_password/2
+      # bumps it, so a successful reset invalidates every outstanding reset
+      # token for the user — without this, a used link stayed live for the
+      # rest of its hour (shared inbox, forwarded mail, proxy log).
+      token = Phoenix.Token.sign(conn, "password_reset", {user.id, user.session_version})
       Task.async(fn -> UserEmails.deliver_password_reset_email(user, token) end)
     end
 
@@ -58,8 +62,8 @@ defmodule FountainWeb.PasswordResetController do
   ## HTML — render reset form
 
   def reset_form(conn, %{"token" => token}) do
-    case Phoenix.Token.verify(conn, "password_reset", token, max_age: @token_max_age) do
-      {:ok, _user_id} ->
+    case verify_reset_token(conn, token) do
+      {:ok, _user} ->
         render(conn, :reset_form, token: token, error: nil, layout: false)
 
       {:error, :expired} ->
@@ -77,16 +81,9 @@ defmodule FountainWeb.PasswordResetController do
   ## HTML — apply the reset
 
   def reset(conn, %{"token" => token, "password" => password}) do
-    case Phoenix.Token.verify(conn, "password_reset", token, max_age: @token_max_age) do
-      {:ok, user_id} ->
-        case Accounts.get_user(user_id) do
-          nil ->
-            conn
-            |> put_flash(:error, "That reset link is invalid.")
-            |> redirect(to: ~p"/auth/forgot-password")
-
-          user ->
-            case Accounts.reset_password(user, password) do
+    case verify_reset_token(conn, token) do
+      {:ok, user} ->
+        case Accounts.reset_password(user, password) do
               {:ok, _user} ->
                 # Also invalidates every existing session, so this is a
                 # security-relevant event even when the user initiated it.
@@ -113,7 +110,6 @@ defmodule FountainWeb.PasswordResetController do
                   error: password_error || "Could not update password.",
                   layout: false
                 )
-            end
         end
 
       {:error, :expired} ->
@@ -132,5 +128,21 @@ defmodule FountainWeb.PasswordResetController do
     conn
     |> put_status(:unprocessable_entity)
     |> json(%{error: "token and password are required"})
+  end
+
+  # Single-use check (#325): the token carries the session_version it was
+  # issued against; reset_password/2 bumps it, so a token issued before the
+  # last successful reset — including the one just used — no longer matches
+  # and is treated as invalid. Legacy bare-user_id tokens (issued before
+  # this shipped) fail the tuple match and die at most one TTL after deploy.
+  defp verify_reset_token(conn, token) do
+    with {:ok, {user_id, session_version}} <-
+           Phoenix.Token.verify(conn, "password_reset", token, max_age: @token_max_age),
+         %{session_version: ^session_version} = user <- Accounts.get_user(user_id) do
+      {:ok, user}
+    else
+      {:error, :expired} -> {:error, :expired}
+      _ -> {:error, :invalid}
+    end
   end
 end

--- a/apps/fountain/test/fountain_web/audit_coverage_test.exs
+++ b/apps/fountain/test/fountain_web/audit_coverage_test.exs
@@ -105,7 +105,8 @@ defmodule FountainWeb.AuditCoverageTest do
 
     test "a password reset is recorded" do
       user = insert_verified_user()
-      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", user.id)
+      token =
+        Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
 
       build_conn()
       |> post(~p"/auth/reset", %{"token" => token, "password" => "new-password-123"})

--- a/apps/fountain/test/fountain_web/controllers/password_reset_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/password_reset_controller_test.exs
@@ -44,7 +44,7 @@ defmodule FountainWeb.PasswordResetControllerTest do
   describe "GET /auth/reset/:token" do
     test "renders reset form for valid token", %{conn: conn} do
       user = insert_verified_user()
-      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", user.id)
+      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
 
       conn = get(conn, ~p"/auth/reset/#{token}")
       assert html_response(conn, 200) =~ "new password"
@@ -57,7 +57,12 @@ defmodule FountainWeb.PasswordResetControllerTest do
 
     test "redirects with error when reset token has expired", %{conn: conn} do
       user = insert_verified_user()
-      expired_token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", user.id, signed_at: 0)
+      expired_token = Phoenix.Token.sign(
+          FountainWeb.Endpoint,
+          "password_reset",
+          {user.id, user.session_version},
+          signed_at: 0
+        )
 
       conn = get(conn, ~p"/auth/reset/#{expired_token}")
       assert redirected_to(conn) == ~p"/auth/forgot-password"
@@ -68,7 +73,7 @@ defmodule FountainWeb.PasswordResetControllerTest do
     test "updates password and drops session", %{conn: conn} do
       user = insert_verified_user()
       old_hash = Accounts.get_user!(user.id).password_hash
-      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", user.id)
+      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
 
       conn = post(conn, ~p"/auth/reset", %{"token" => token, "password" => "newpassword123"})
       assert redirected_to(conn) == ~p"/auth/login"
@@ -81,7 +86,7 @@ defmodule FountainWeb.PasswordResetControllerTest do
 
     test "re-renders form with error on short password", %{conn: conn} do
       user = insert_verified_user()
-      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", user.id)
+      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
 
       conn = post(conn, ~p"/auth/reset", %{"token" => token, "password" => "short"})
       assert html_response(conn, 422) =~ "new password"
@@ -95,7 +100,7 @@ defmodule FountainWeb.PasswordResetControllerTest do
     test "redirects with error when user no longer exists in database", %{conn: conn} do
       # Sign a token with a UUID that doesn't correspond to any user
       missing_id = Ecto.UUID.generate()
-      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", missing_id)
+      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {missing_id, 1})
 
       conn = post(conn, ~p"/auth/reset", %{"token" => token, "password" => "validpassword123"})
       assert redirected_to(conn) == ~p"/auth/forgot-password"
@@ -103,9 +108,57 @@ defmodule FountainWeb.PasswordResetControllerTest do
 
     test "redirects with error when reset token has expired", %{conn: conn} do
       user = insert_verified_user()
-      expired_token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", user.id, signed_at: 0)
+      expired_token = Phoenix.Token.sign(
+          FountainWeb.Endpoint,
+          "password_reset",
+          {user.id, user.session_version},
+          signed_at: 0
+        )
 
       conn = post(conn, ~p"/auth/reset", %{"token" => expired_token, "password" => "newpassword123"})
+      assert redirected_to(conn) == ~p"/auth/forgot-password"
+    end
+
+    # #325: tokens used to stay valid for the rest of their hour after a
+    # successful reset — anyone who later obtained the link (shared inbox,
+    # forwarded mail, proxy log) could re-reset the password.
+    test "a token cannot be replayed after a successful reset", %{conn: conn} do
+      user = insert_verified_user()
+      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
+
+      conn1 = post(conn, ~p"/auth/reset", %{"token" => token, "password" => "newpassword123"})
+      assert redirected_to(conn1) == ~p"/auth/login"
+      hash_after_first = Accounts.get_user!(user.id).password_hash
+
+      conn2 = post(conn, ~p"/auth/reset", %{"token" => token, "password" => "attackerpass99"})
+      assert redirected_to(conn2) == ~p"/auth/forgot-password"
+
+      # The replay changed nothing.
+      assert Accounts.get_user!(user.id).password_hash == hash_after_first
+
+      # The form view refuses it too.
+      assert redirected_to(get(conn, ~p"/auth/reset/#{token}")) == ~p"/auth/forgot-password"
+    end
+
+    test "any token issued before the last successful reset is dead", %{conn: conn} do
+      user = insert_verified_user()
+      sign = fn -> Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version}) end
+      earlier_token = sign.()
+      used_token = sign.()
+
+      assert redirected_to(
+               post(conn, ~p"/auth/reset", %{"token" => used_token, "password" => "newpassword123"})
+             ) == ~p"/auth/login"
+
+      conn = post(conn, ~p"/auth/reset", %{"token" => earlier_token, "password" => "otherpass123"})
+      assert redirected_to(conn) == ~p"/auth/forgot-password"
+    end
+
+    test "legacy bare-user_id tokens are refused", %{conn: conn} do
+      user = insert_verified_user()
+      legacy = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", user.id)
+
+      conn = post(conn, ~p"/auth/reset", %{"token" => legacy, "password" => "newpassword123"})
       assert redirected_to(conn) == ~p"/auth/forgot-password"
     end
 


### PR DESCRIPTION
## Summary
- Reset tokens now sign `{user_id, session_version}` instead of a bare user id, and verification requires the version to still match. Since `reset_password/2` bumps `session_version`, a successful reset invalidates **every** outstanding reset token for that user — the used one and any earlier ones — implementing exactly the issue's suggested "sign session_version into the token" design.
- Both the form view (`GET /auth/reset/:token`) and the apply path (`POST /auth/reset`) go through one `verify_reset_token/2`.
- Deploy note: reset links issued before this deploy fail the tuple match and are refused ("invalid link") — at most a 1-hour window given the token TTL. Users just request a fresh link.
- Tests: replay after use is refused and changes nothing; earlier tokens die after a reset; legacy bare-id tokens are refused; the pre-existing suite (expiry, bad token, missing user) updated to the new format and still green.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)