### PR TITLE
ci: precommit gates on credo, verify the manifest image pin, gate builds on CI (#333)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 # Builds the Fountain OCI image and pushes it to
-# ghcr.io/binarybourbon/fountain on every push to main. Multi-arch
+# ghcr.io/binarybourbon/fountain for every push to main whose CI
+# workflow succeeded. Multi-arch
 # (amd64 + arm64) — home-cloud k3s nodes are arm64 Apple Silicon Lima
 # VMs, single-arch amd64 images fail at pull with
 # "no match for platform"; amd64 stays for self-hosters.
@@ -15,19 +16,16 @@ name: build
 
 on:
   workflow_dispatch:
-  push:
+  # Gated on CI instead of triggering directly on push: a commit whose CI
+  # failed used to get built, published, and reconciled by Flux anyway.
+  # Same idiom publish-manifests.yml uses to gate on this workflow. The
+  # old push-trigger paths-ignore (paths that never affect the OCI image)
+  # is re-implemented as the `changes` job below — workflow_run cannot
+  # express path filters.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
-    # These paths never affect the OCI image, so skip the build when a
-    # commit touches only them. Manifest-only changes still deploy:
-    # publish-manifests.yml triggers directly on k8s/deploy pushes and
-    # pins the newest already-built image.
-    paths-ignore:
-      - "k8s/**"
-      # The portable self-hosting manifests — never part of the image.
-      - "deploy/**"
-      - "docs/**"
-      - "decisions/**"
-      - "**/*.md"
 
 env:
   # ${{ github.repository_owner }} resolves to "BinaryBourbon" with the
@@ -35,13 +33,65 @@ env:
   # lowercase. Hardcoded rather than ${,,} via a shell step — the org
   # name is stable enough that the indirection isn't worth it.
   IMAGE: ghcr.io/binarybourbon/fountain
+  # The commit CI actually ran on — NOT github.sha, which for workflow_run
+  # events is the default branch tip at trigger time and can race ahead if
+  # another push lands while CI runs. Everything below (checkout, tags,
+  # labels) uses this so the image is built from and tagged with the exact
+  # commit that passed CI. Falls back to github.sha for workflow_dispatch.
+  SRC_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Decide whether the image needs a build
+    # Only commits whose CI succeeded get built. workflow_dispatch stays an
+    # ungated escape hatch, exactly as before.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.SRC_SHA }}
+          # The parent commit, for the diff below.
+          fetch-depth: 2
+
+      - name: Skip paths that never affect the OCI image
+        id: filter
+        # The old push-trigger paths-ignore list (k8s/**, deploy/**, docs/**,
+        # decisions/**, **/*.md — deploy/ is the portable self-hosting
+        # manifests, never part of the image), re-implemented as a first-parent
+        # diff. main only moves by PR merges, so HEAD^..HEAD is exactly what
+        # the push brought in. Manifest-only changes still deploy:
+        # publish-manifests.yml triggers directly on k8s/deploy pushes and
+        # pins the newest already-built image.
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "manual dispatch — building unconditionally"
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only HEAD^ HEAD \
+              | grep -qvE '^(k8s|deploy|docs|decisions)/|\.md$'; then
+            echo "image-affecting changes found — building"
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "only ignored paths changed — skipping the build"
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build ${{ matrix.arch }}
+    needs: changes
+    if: ${{ needs.changes.outputs.build == 'true' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
@@ -62,6 +112,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.SRC_SHA }}
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -81,10 +133,10 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           build-args: |
-            BUILD_SHA=${{ github.sha }}
+            BUILD_SHA=${{ env.SRC_SHA }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ env.SRC_SHA }}
           # Digest-only push; the merge job below owns the tags. Provenance
           # off so each push is exactly one image manifest — attestation
           # manifests would confuse the imagetools merge.
@@ -139,7 +191,7 @@ jobs:
       - name: Create and push the manifest list
         working-directory: ${{ runner.temp }}/digests
         env:
-          SHA: ${{ github.sha }}
+          SHA: ${{ env.SRC_SHA }}
         run: |
           set -euo pipefail
           docker buildx imagetools create \

--- a/.github/workflows/publish-manifests.yml
+++ b/.github/workflows/publish-manifests.yml
@@ -125,6 +125,13 @@ jobs:
           sed -i -E \
             "s|ghcr\.io/binarybourbon/fountain:sha-[0-9a-f]+|${IMAGE}|" \
             k8s/deployment.yaml
+          # sed exits 0 whether or not the pattern matched, so verify the pin
+          # actually landed — if deployment.yaml's image line ever stops
+          # matching the regex, the old tag would otherwise ship silently.
+          grep -qF "${IMAGE}" k8s/deployment.yaml || {
+            echo "image pin substitution failed: ${IMAGE} not found in k8s/deployment.yaml" >&2
+            exit 1
+          }
           git diff --stat k8s/deployment.yaml
 
       - name: Setup flux CLI

--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,7 @@ defmodule Fountain.Umbrella.MixProject do
         "compile --warnings-as-errors",
         "deps.unlock --unused",
         "format --check-formatted",
-        "credo --strict --mute-exit-status",
+        "credo --strict",
         &dialyzer_in_dev/1,
         "test"
       ]


### PR DESCRIPTION
Closes #333. Three parts:

## 1. precommit credo drift (`mix.exs`)

The precommit alias ran `credo --strict --mute-exit-status`, which can never fail, while CI runs `mix credo --strict` and gates on it — so a strict violation sailed through `mix precommit` and died in CI. Dropped `--mute-exit-status`; only that one line changed to keep the conflict surface with the pending #311 sobelow PR (which also edits this alias) minimal. No sobelow step added here — that belongs to #311.

## 2. Manifest image-pin verification (`publish-manifests.yml`)

The "Pin the image tag" step rewrites `k8s/deployment.yaml` with `sed`, and sed exits 0 whether or not the pattern matched — if the image line ever drifts from the `ghcr\.io/binarybourbon/fountain:sha-[0-9a-f]+` regex, the old tag would ship silently. Added a `grep -qF "${IMAGE}" k8s/deployment.yaml` check right after the sed that fails the job with a clear message if the substitution didn't land.

## 3. Builds gated on CI (`build.yml`)

`build.yml` triggered directly on push to main, independent of `ci.yml` — a commit whose CI failed still got built, published, and reconciled by Flux into production. It now triggers on `workflow_run` of the CI workflow (`completed` + `conclusion == 'success'` + `main`), the exact idiom `publish-manifests.yml` already uses to gate on build. `workflow_dispatch` remains an ungated manual escape hatch, as before. The downstream chain is untouched: build still completes as the `build` workflow, so publish-manifests fires exactly as it did. **Nothing about *what* gets deployed changes — only when.**

### paths-ignore semantics

`workflow_run` cannot express `paths-ignore`, so the old ignore list (`k8s/**`, `deploy/**`, `docs/**`, `decisions/**`, `**/*.md`) is re-implemented as a small `changes` job that diffs `HEAD^..HEAD` on the CI run's head commit and skips the build (and, via `needs`, the merge job) when only ignored paths changed. Since main only moves by PR merges (direct pushes are disallowed), the first-parent diff covers exactly what each push brought in; the one semantic difference is a hypothetical multi-commit direct push to main, where only the tip commit's diff would be inspected — a case the repo's workflow already forbids. Manifest-only pushes still deploy through publish-manifests' own `push: paths: k8s/**` trigger, unchanged.

### sha correctness

For `workflow_run` events `github.sha` is the default-branch tip *at trigger time*, not the commit CI ran on — if another push lands while CI runs, the old wiring would have built one tree and tagged it as another. All references (checkout ref, `BUILD_SHA`, OCI revision label, the `sha-<sha>` tag) now use `github.event.workflow_run.head_sha` (falling back to `github.sha` for dispatch), so the image is always built from and tagged with the exact commit that passed CI. This also keeps publish-manifests' ancestor-walk resolution exact.

### Tradeoffs

- **Deploy latency**: the image build now starts only after CI succeeds, adding CI's ~5–10 min wall time before the ~1.3 min warm build + publish + Flux reconcile. Merge→prod goes from ~2 min to roughly CI-time + 2 min. That is the point of the gate: red commits no longer reach the cluster at all.
- **Rapid successive merges**: `ci.yml` cancels in-progress runs per ref, so if two commits land on main quickly the first CI run may be cancelled and that intermediate commit gets no image. The tip commit's CI, build, and deploy proceed normally, and publish-manifests' ancestor-walk already tolerates missing intermediate images. Production converges on the tip either way.
- **Docs-only pushes** now create a (skipped) build workflow run instead of no run; if GitHub reports that run's conclusion as success, publish-manifests may republish an identical-content artifact pinning the same image — a no-op apply for Flux, no pod restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)