### PR TITLE
ops: alert on CNPG PITR backups; refresh stale backup/Sentry annotations (#338)

### DIFF
--- a/k8s/backup-cronjob.yaml
+++ b/k8s/backup-cronjob.yaml
@@ -1,27 +1,20 @@
 # Nightly logical backup of the Fountain database to the private
 # `fountain-backups` Garage bucket.
 #
-# WHY THIS RATHER THAN CNPG'S OWN BACKUPS
+# WHY THIS EXISTS ALONGSIDE CNPG'S PITR BACKUPS
 #
-# CNPG's in-tree `spec.backup.barmanObjectStore` is the obvious answer and is
-# NOT usable on this cluster today. The operator is 1.29.1, and as of 1.26 the
-# barman-cloud tooling was moved out of the operand images into a separate
-# CNPG-I plugin. Verified directly: `ghcr.io/cloudnative-pg/postgresql:18.4-
-# standard-trixie` contains no `barman-cloud-*` binaries and no Python at all,
-# and no barman-cloud plugin or ObjectStore CRD is installed in the cluster.
-# Configuring barmanObjectStore in that state produces a Cluster that looks
-# backed up and archives nothing.
+# The cluster also runs continuous WAL archiving plus a nightly 02:47 base
+# backup through the barman-cloud CNPG-I plugin (objectstore.yaml +
+# scheduledbackup.yaml) — that path owns point-in-time recovery. This job is
+# kept anyway, deliberately, for mechanism diversity: a plain `pg_dump` is
+# restorable with nothing but a Postgres client — no operator, no plugin, no
+# barman tooling — and the 2026-07 restore proved the value of never trusting
+# a single backup path. The database is ~155MB, so a nightly full dump is
+# cheap insurance.
 #
-# So this is a deliberate interim: a plain `pg_dump` on a schedule, entirely
-# self-contained in this repo, giving a real restorable artifact today. The
-# database is ~155MB, so a nightly full dump is cheap.
-#
-# WHAT IT DOES NOT GIVE YOU
-#
-# No point-in-time recovery — recovery granularity is 24 hours, back to the
-# last nightly dump. PITR needs continuous WAL archiving, which needs the
-# barman-cloud plugin installed cluster-wide (a home-cloud repo change, since
-# it affects every CNPG cluster there). Tracked separately.
+# Recovery granularity here is 24 hours, back to the last nightly dump. Use
+# the barman/PITR path when minutes matter; use this one when the operator
+# stack itself is the problem.
 #
 # RESTORE
 #

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -41,6 +41,14 @@ spec:
       parameters:
         barmanObjectName: fountain-backups
 
+  # Exports the cnpg_* instance metrics (base-backup timestamps, WAL archive
+  # status) to the cluster Prometheus — the fountain-pitr alert group in
+  # prometheusrule.yaml is built on these series. Unlike the plugins block
+  # above, this only creates a PodMonitor; it does not change the pod spec,
+  # so enabling it does NOT roll the postgres pod.
+  monitoring:
+    enablePodMonitor: true
+
   imageName: ghcr.io/cloudnative-pg/postgresql:18.4-standard-trixie
 
   bootstrap:

--- a/k8s/prometheusrule.yaml
+++ b/k8s/prometheusrule.yaml
@@ -93,6 +93,137 @@ spec:
               fountain-pg-backup is suspended, so no backups are being taken.
               This is fine during maintenance and dangerous if forgotten.
 
+    # ── PITR (CNPG barman-cloud) ──────────────────────────────────────────
+    #
+    # The group above watches the pg_dump CronJob. This one watches the
+    # other backup mechanism: continuous WAL archiving plus the nightly
+    # 02:47 base backup through the barman-cloud plugin (objectstore.yaml +
+    # scheduledbackup.yaml). None of the kube_cronjob_*/kube_job_* metrics
+    # see any of it — CNPG's ScheduledBackup is a CRD, not a CronJob — so
+    # these use the cnpg_* metrics the instance pod exports, scraped via
+    # the PodMonitor that `monitoring.enablePodMonitor: true` in
+    # postgres.yaml creates.
+    - name: fountain-pitr
+      interval: 60s
+      rules:
+        - alert: FountainPitrBaseBackupStale
+          # last_available_backup_timestamp is seconds since epoch of the
+          # newest completed base backup. The ScheduledBackup fires nightly
+          # at 02:47; 26h allows one slow or late run before shouting.
+          # Guarded on > 0 because before the first-ever backup the metric
+          # is exported as 0, not absent — time() - 0 would fire this with
+          # a nonsense age. FountainPitrBaseBackupNeverSucceeded owns that
+          # case.
+          expr: |
+            (
+              time() - cnpg_collector_last_available_backup_timestamp{namespace="fountain"}
+                > 26 * 3600
+            )
+              and
+            cnpg_collector_last_available_backup_timestamp{namespace="fountain"} > 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG base backup for fountain-pg is over 26h old"
+            description: |
+              The newest barman base backup is {{ $value | humanizeDuration }}
+              old. WAL archiving may still be running, but recovery time grows
+              with every hour of WAL replayed since the last base — and if the
+              plugin is broken the WAL stream is probably rotting too.
+
+              Check: kubectl get backups -n fountain --sort-by=.metadata.creationTimestamp | tail
+                     kubectl get scheduledbackup -n fountain fountain-pg-base
+              Logs:  kubectl logs -n fountain fountain-pg-1 -c plugin-barman-cloud
+              The 03:17 pg_dump path is independent of this one and still
+              covers 24h-granularity recovery while this is broken.
+
+        - alert: FountainPitrBaseBackupNeverSucceeded
+          # Before the first successful base backup the timestamp is 0, so
+          # the staleness alert above deliberately ignores it. Mirrors
+          # FountainBackupNeverSucceeded: either the ScheduledBackup was
+          # just created, or every backup so far has failed — both mean
+          # there is no base to replay WAL against, i.e. no PITR at all.
+          expr: |
+            cnpg_collector_last_available_backup_timestamp{namespace="fountain"} == 0
+          for: 26h
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG has never completed a base backup for fountain-pg"
+            description: |
+              WAL may be archiving, but without a base backup to replay it
+              against there is no point-in-time recovery. Check that the
+              ScheduledBackup exists and its Backups are completing:
+              kubectl get scheduledbackup,backups -n fountain
+
+        - alert: FountainPitrBackupFailed
+          # A failure timestamp newer than the newest good backup means the
+          # most recent attempt failed. Clears on its own once a later
+          # backup succeeds.
+          expr: |
+            cnpg_collector_last_failed_backup_timestamp{namespace="fountain"}
+              >
+            cnpg_collector_last_available_backup_timestamp{namespace="fountain"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "The most recent CNPG base backup for fountain-pg failed"
+            description: |
+              The last base backup attempt failed; the newest restorable base
+              is one night older than it should be. One failure is not yet
+              data loss — FountainPitrBaseBackupStale escalates if it keeps
+              happening.
+              Check: kubectl get backups -n fountain --sort-by=.metadata.creationTimestamp | tail
+              Logs:  kubectl logs -n fountain fountain-pg-1 -c plugin-barman-cloud
+
+        - alert: FountainPitrWalArchivingFailing
+          # cnpg_collector_pg_wal_archive_status counts WAL segments in
+          # pg_wal/archive_status: value="ready" is waiting to be archived,
+          # value="done" is archived. Postgres archives serially and retries
+          # a failing segment forever, so a ready count that stays elevated
+          # means the archiver is failing and the PITR window has stopped
+          # advancing. Left failing long enough, unarchivable WAL also
+          # cannot be recycled and eventually fills the 10Gi volume.
+          expr: |
+            cnpg_collector_pg_wal_archive_status{namespace="fountain", value="ready"} > 2
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "WAL archiving for fountain-pg is falling behind"
+            description: |
+              {{ $value }} WAL segments are stuck waiting to be archived to
+              s3://fountain-backups/barman/. PITR only reaches the last
+              archived segment, so the recoverable window is no longer
+              advancing. Likely causes: Garage unreachable, rotated
+              credentials, or the bucket at its 5GiB quota.
+
+              Check: kubectl exec -n fountain fountain-pg-1 -c postgres -- \
+                       psql -c 'select * from pg_stat_archiver'
+              Logs:  kubectl logs -n fountain fountain-pg-1 -c plugin-barman-cloud
+
+        - alert: FountainPitrMetricsAbsent
+          # None of the alerts above can fire on a metric that is not being
+          # scraped at all — this is the watcher's watcher. It fires if the
+          # cnpg_* series vanish: PodMonitor deleted, selector drift in
+          # kube-prometheus-stack, or the instance exporter broken. Scoped
+          # to one representative series; they come from the same exporter.
+          expr: |
+            absent(cnpg_collector_last_available_backup_timestamp{namespace="fountain"})
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "CNPG backup metrics for fountain-pg are not being scraped"
+            description: |
+              cnpg_collector_last_available_backup_timestamp has been absent
+              for an hour, so every PITR alert is blind. Check that the
+              PodMonitor exists and Prometheus has the target:
+              kubectl get podmonitor -n fountain
+              then look for fountain-pg under Status > Targets in Prometheus.
+
     # ── Application health ────────────────────────────────────────────────
     - name: fountain-app
       interval: 30s
@@ -127,8 +258,8 @@ spec:
             summary: "Over 5% of Fountain responses are 5xx"
             description: |
               {{ $value | humanizePercentage }} of responses over the last 5
-              minutes were server errors. There is no error tracking yet, so the
-              detail is in the pod logs (Loki: {namespace="fountain"}).
+              minutes were server errors. Detail is in Sentry; the raw request
+              logs are in Loki ({namespace="fountain"}).
 
         - alert: FountainUnhandledExceptions
           expr: |
@@ -139,8 +270,8 @@ spec:
           annotations:
             summary: "Fountain is raising unhandled exceptions"
             description: |
-              Exceptions escaping the router on {{ $labels.route }}. Until error
-              tracking lands these have no stack traces anywhere but the logs.
+              Exceptions escaping the router on {{ $labels.route }}. Stack
+              traces are in Sentry; the logs have the raw output.
 
         - alert: FountainDatabasePoolSaturated
           # queue_time is time spent waiting for a connection. It climbs when the


### PR DESCRIPTION
Closes #338

## What

The CNPG PITR path (`k8s/objectstore.yaml` + `k8s/scheduledbackup.yaml` — nightly 02:47 base backup, continuous WAL archiving, 14d retention) had zero alert coverage: the `fountain-backups` group only matches `cronjob="fountain-pg-backup"`, and `kube_cronjob_*`/`kube_job_*` never see CNPG's ScheduledBackup CRD. A dead WAL archiver would have rotted silently until a restore was needed.

### 1. New `fountain-pitr` alert group (`k8s/prometheusrule.yaml`)

Built on the CNPG instance-exported metrics:

| Alert | Metric / expr | Severity |
|---|---|---|
| `FountainPitrBaseBackupStale` | `time() - cnpg_collector_last_available_backup_timestamp > 26h` (guarded `> 0`) | critical |
| `FountainPitrBaseBackupNeverSucceeded` | `cnpg_collector_last_available_backup_timestamp == 0` for 26h (the metric is exported as 0, not absent, before the first backup) | critical |
| `FountainPitrBackupFailed` | `cnpg_collector_last_failed_backup_timestamp > cnpg_collector_last_available_backup_timestamp` | warning |
| `FountainPitrWalArchivingFailing` | `cnpg_collector_pg_wal_archive_status{value="ready"} > 2` for 30m — segments stuck in `pg_wal/archive_status` waiting to archive | warning |
| `FountainPitrMetricsAbsent` | `absent(cnpg_collector_last_available_backup_timestamp)` for 1h — the watcher's watcher; none of the above can fire on a series that isn't scraped | warning |

Annotations follow the existing runbook style (what it means, what to check, where the logs are, what the fallback is).

### 2. Enable CNPG metrics scraping (`k8s/postgres.yaml`)

The Cluster had no `monitoring:` section, so nothing exported the `cnpg_*` series. Added `monitoring.enablePodMonitor: true`. This only creates a PodMonitor — no pod spec change, so **it does not roll the postgres pod** (unlike the plugin block, whose comment warns about that).

### 3. Stale annotations

- `k8s/prometheusrule.yaml`: "There is no error tracking yet" / "Until error tracking lands" — Sentry shipped in #211. Ported the corrected wording from `deploy/k8s/prometheusrule.yaml`, adapted for the hosted copy where Sentry is definitely configured.
- `k8s/backup-cronjob.yaml`: header claimed "no barman-cloud plugin or ObjectStore CRD is installed in the cluster… Tracked separately" — false since the PITR manifests landed. Rewritten to the current rationale: the pg_dump job is kept deliberately for mechanism diversity (the 2026-07 restore proved the value of not trusting one backup path); it's the restore path that needs nothing but a Postgres client.

## Deployment note (operator action)

`build.yml` has `paths-ignore: k8s/**`, so this change does **not** trigger an image build. It reaches the cluster only via the manifest publish workflow — either trigger it manually (`workflow_dispatch`) after merge, or let the next code merge carry it. @jhgaylor flagging so it doesn't sit unapplied.

## Verification / caveats

- YAML validated with a parser; PromQL sanity-checked (promtool not available locally).
- `cnpg_collector_last_available_backup_timestamp` / `cnpg_collector_last_failed_backup_timestamp` are populated from the Cluster status (`lastSuccessfulBackup` / `lastFailedBackup`), which plugin-method backups do update — but this is worth eyeballing after the first post-merge nightly: check the timestamp series is nonzero in Prometheus the morning after.
- `cnpg_collector_pg_wal_archive_status` carries a `value` label of `"ready"`/`"done"` (counts of segment status files); there is no `value="failed"`. A stuck archiver shows up as the `ready` count staying elevated, which is what the alert watches. If you'd rather alert on the failure timestamps directly, the default-monitoring queries also export `cnpg_pg_stat_archiver_last_failed_time`/`last_archived_time` — can switch if the `ready` heuristic proves noisy on this write volume.
- Prometheus must select the new PodMonitor: rules are picked up because `ruleSelectorNilUsesHelmValues: false` is set in the kube-prometheus-stack HelmRelease (per the file header); verify the PodMonitor analog (`podMonitorSelectorNilUsesHelmValues: false`) is set in home-cloud too, else the PodMonitor will exist but never be scraped — `FountainPitrMetricsAbsent` will fire within an hour and say exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)