### PR TITLE
ops: evict expired rate-limit buckets on a 10-minute sweep (#326)

### DIFF
--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -30,6 +30,7 @@ defmodule Fountain.Application do
          repos: Application.fetch_env!(:fountain, :ecto_repos), skip: skip_migrations?()},
         {DNSCluster, query: Application.get_env(:fountain, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: Fountain.PubSub},
+        FountainWeb.Plugs.RateLimit.Sweeper,
         Fountain.Conversations.Redaction,
         {Oban, Application.fetch_env!(:fountain, Oban)}
       ] ++

--- a/apps/fountain/lib/fountain_web/plugs/rate_limit.ex
+++ b/apps/fountain/lib/fountain_web/plugs/rate_limit.ex
@@ -52,6 +52,20 @@ defmodule FountainWeb.Plugs.RateLimit do
     end
   end
 
+  @doc """
+  Delete rows whose window started more than `max_age_ms` ago.
+
+  A row older than its bucket's window no longer affects any decision —
+  `bump/2` resets it on the next hit — so eviction is invisible to
+  limiting behavior as long as `max_age_ms` is at least the longest
+  window configured anywhere. Returns the number of rows deleted.
+  """
+  def evict_expired(max_age_ms) do
+    ensure_table()
+    cutoff = System.system_time(:millisecond) - max_age_ms
+    :ets.select_delete(@table, [{{:_, :"$1", :_}, [{:<, :"$1", cutoff}], [true]}])
+  end
+
   def init(opts) do
     %{
       bucket: Keyword.fetch!(opts, :bucket),

--- a/apps/fountain/lib/fountain_web/plugs/rate_limit_sweeper.ex
+++ b/apps/fountain/lib/fountain_web/plugs/rate_limit_sweeper.ex
@@ -1,0 +1,47 @@
+defmodule FountainWeb.Plugs.RateLimit.Sweeper do
+  @moduledoc """
+  Periodic eviction for the rate-limit ETS table (#326).
+
+  `bump/2` only ever overwrites a row when its own key comes back, so the
+  table grew by one row per distinct `{bucket, ip}` seen since boot —
+  unbounded in proportion to source IPs, and invisible until an instance
+  stayed up long enough or someone walked a v6 range.
+
+  Sweeps every 10 minutes, deleting rows whose window started more than
+  `@max_age_ms` ago. That bound must exceed the longest window configured
+  on any plug — currently 1h (the auth buckets) — so expired-but-swept
+  rows can never differ from expired-and-reset rows in behavior. 2h keeps
+  a comfortable margin for future windows.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @sweep_interval_ms :timer.minutes(10)
+  @max_age_ms :timer.hours(2)
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @impl true
+  def init(nil) do
+    FountainWeb.Plugs.RateLimit.ensure_table()
+    :timer.send_interval(@sweep_interval_ms, :sweep)
+    {:ok, nil}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    deleted = FountainWeb.Plugs.RateLimit.evict_expired(@max_age_ms)
+
+    if deleted > 0 do
+      Logger.debug("rate_limit sweeper: evicted #{deleted} expired buckets")
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+end

--- a/apps/fountain/test/fountain_web/plugs/rate_limit_sweeper_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/rate_limit_sweeper_test.exs
@@ -1,0 +1,53 @@
+defmodule FountainWeb.Plugs.RateLimit.SweeperTest do
+  # #326: the rate-limit ETS table never evicted — one row per distinct
+  # {bucket, ip} since boot, unbounded. The sweeper deletes rows whose
+  # window is long over; those are behaviorally identical to absent rows
+  # (bump/2 resets them on the next hit).
+  use ExUnit.Case, async: true
+
+  alias FountainWeb.Plugs.RateLimit
+
+  defp unique_bucket, do: "sweep-#{System.unique_integer([:positive, :monotonic])}"
+
+  test "evict_expired deletes only rows older than max_age" do
+    RateLimit.ensure_table()
+    now = System.system_time(:millisecond)
+    stale = {unique_bucket(), "203.0.113.7"}
+    fresh = {unique_bucket(), "203.0.113.8"}
+    :ets.insert(RateLimit.table(), {stale, now - :timer.hours(3), 5})
+    :ets.insert(RateLimit.table(), {fresh, now, 5})
+
+    assert RateLimit.evict_expired(:timer.hours(2)) >= 1
+
+    assert :ets.lookup(RateLimit.table(), stale) == []
+    assert [{^fresh, _, 5}] = :ets.lookup(RateLimit.table(), fresh)
+  end
+
+  test "eviction is invisible to limiting: a swept row behaves like a reset one" do
+    RateLimit.ensure_table()
+    opts = %{bucket: unique_bucket(), max: 2, window_ms: 60_000}
+    key = {opts.bucket, "203.0.113.9"}
+
+    # Full bucket whose window is long over.
+    :ets.insert(RateLimit.table(), {key, System.system_time(:millisecond) - :timer.hours(3), 2})
+    RateLimit.evict_expired(:timer.hours(2))
+
+    # Same outcome an expired-but-present row gets: the window restarts.
+    assert RateLimit.bump(key, opts) == :ok
+  end
+
+  test "the sweeper process is in the supervision tree and sweeps on tick" do
+    pid = Process.whereis(FountainWeb.Plugs.RateLimit.Sweeper)
+    assert is_pid(pid)
+
+    now = System.system_time(:millisecond)
+    stale = {unique_bucket(), "203.0.113.10"}
+    :ets.insert(RateLimit.table(), {stale, now - :timer.hours(3), 1})
+
+    send(pid, :sweep)
+    # Synchronize on the GenServer having processed the message.
+    _ = :sys.get_state(pid)
+
+    assert :ets.lookup(RateLimit.table(), stale) == []
+  end
+end


### PR DESCRIPTION
## Summary
- New `FountainWeb.Plugs.RateLimit.Sweeper` (supervised GenServer) runs every 10 minutes and deletes ETS rows whose window started more than 2 hours ago, via a new `RateLimit.evict_expired/1` (`:ets.select_delete`, no table scan copy).
- The 2h bound deliberately exceeds the longest configured window (the 1h auth buckets), so eviction can never change limiting behavior — a swept row and an expired-in-place row produce the same `bump/2` outcome, and there's a test pinning exactly that equivalence.
- Tests: selective eviction, behavioral equivalence, and that the sweeper is actually in the supervision tree and sweeps on tick (guards against the wiring-vs-logic gap the audit keeps finding).

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)