### PR TITLE
security: revoke the sprite callback token on supervisor shutdown (#322)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -127,6 +127,14 @@ defmodule Fountain.Conversations.ConversationServer do
 
   @impl true
   def init(args) do
+    # Without trap_exit, terminate/2 only runs on {:stop, …} or a raise — a
+    # Horde rebalance or application shutdown (i.e. every deploy) sends an
+    # exit signal and skips it, so the callback-token revoke never fired on
+    # the most common teardown there is (#322). Trapping makes OTP call
+    # terminate/2 on supervisor shutdown, bounded by the child shutdown
+    # timeout.
+    Process.flag(:trap_exit, true)
+
     state = %{
       conversation_id: Keyword.fetch!(args, :conversation_id),
       sandbox_id: Keyword.fetch!(args, :sandbox_id),
@@ -979,6 +987,15 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
+  # trap_exit is on (see init/1), so exit signals from linked processes
+  # arrive here instead of killing the server outright. Preserve the
+  # pre-trap semantics: a linked crash still takes the server down (through
+  # terminate/2, which is the point), a :normal exit is ignored. Exits from
+  # the parent supervisor never reach this clause — OTP intercepts those
+  # and calls terminate/2 directly.
+  def handle_info({:EXIT, _from, :normal}, state), do: {:noreply, state}
+  def handle_info({:EXIT, _from, reason}, state), do: {:stop, reason, state}
+
   def handle_info(_msg, state), do: {:noreply, state}
 
   defp schedule_lifecycle_check do
@@ -1030,14 +1047,17 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   # Best-effort revoke of the per-conversation API key when this server
-  # exits — covers both clean termination (`:terminate_conv`) and crash
-  # paths that hit `{:stop, :normal, state}` after a provision failure.
-  # If the BEAM crashes hard the row in `api_keys` is left behind, but it is no
-  # longer dangerous: `callback_api_key_opts/0` sets an `expires_at`, so an
-  # un-revoked key stops authenticating on its own, and RetentionPruner deletes
-  # the row later. It used to live forever, which is what made a sweeper
-  # necessary — see SandboxReaper for the sprite half, which does not
-  # self-heal.
+  # exits — clean termination (`:terminate_conv`), crash paths that hit
+  # `{:stop, :normal, state}`, and (because init/1 traps exits, #322)
+  # supervisor shutdown on deploys and Horde rebalances.
+  # If the BEAM crashes hard (SIGKILL — untrappable) the row in `api_keys`
+  # is left behind, but it is no longer dangerous: `callback_api_key_opts/0`
+  # sets an `expires_at`, so an un-revoked key stops authenticating on its
+  # own, and rotation-on-reattach revokes it if the conversation ever
+  # resumes. Note RetentionPruner only deletes rows whose `revoked_at` is
+  # set — an un-revoked orphan goes inert at expiry but its row stays until
+  # something revokes it. See SandboxReaper for the sprite half, which does
+  # not self-heal.
   @impl true
   def terminate(_reason, state) do
     Fountain.Conversations.Redaction.delete(state.conversation_id)

--- a/apps/fountain/test/fountain/conversations/conversation_server_shutdown_revoke_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_shutdown_revoke_test.exs
@@ -1,0 +1,50 @@
+defmodule Fountain.Conversations.ConversationServerShutdownRevokeTest do
+  # #322: terminate/2 revokes the sprite's callback API key, but without
+  # trap_exit a supervisor shutdown (every deploy, every Horde rebalance)
+  # skips terminate/2 entirely — leaving a live sprite-scoped tenant
+  # credential outstanding for up to 30 days if the conversation is never
+  # resumed. init/1 now traps exits so shutdown runs terminate/2.
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Accounts.ApiKey
+
+  defp start_provisioned_server do
+    stub_happy_sprite()
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+
+    {pid, ref, :alive} = start_server(conv)
+    conv = Conversations._unsafe_get_conversation!(conv.id)
+    assert is_binary(conv.callback_api_key_id), "provision should have minted a callback key"
+    {pid, ref, conv}
+  end
+
+  defp key_revoked?(key_id) do
+    %ApiKey{revoked_at: revoked_at} = Repo.get!(ApiKey, key_id)
+    revoked_at != nil
+  end
+
+  test "a supervisor-style :shutdown exit revokes the callback key" do
+    {pid, ref, conv} = start_provisioned_server()
+    refute key_revoked?(conv.callback_api_key_id)
+
+    # The exact signal a supervisor sends at teardown. Without trap_exit
+    # this killed the process with no terminate/2 — verified against the
+    # old code: this test fails there with the key still live.
+    Process.exit(pid, :shutdown)
+    assert_stopped(ref)
+
+    assert key_revoked?(conv.callback_api_key_id)
+  end
+
+  test "a linked crash still takes the server down and revokes on the way" do
+    {pid, ref, conv} = start_provisioned_server()
+
+    Process.exit(pid, :some_linked_crash)
+    reason = assert_stopped(ref)
+    assert reason == :some_linked_crash
+
+    assert key_revoked?(conv.callback_api_key_id)
+  end
+end


### PR DESCRIPTION
## Summary
- `init/1` sets `Process.flag(:trap_exit, true)` so OTP calls `terminate/2` — which revokes the per-conversation callback API key — on supervisor shutdown and Horde rebalances (every deploy). Previously that path skipped `terminate/2` entirely, leaving a live sprite-scoped tenant credential for up to 30 days when a conversation was never resumed.
- New `{:EXIT, from, reason}` clauses preserve pre-trap semantics: a linked crash still takes the server down (now through `terminate/2`, which is the point); `:normal` exits are ignored; parent-supervisor exits never reach `handle_info` (OTP intercepts them).
- Corrects the same comment block's doc drift the issue flagged: `RetentionPruner` deletes only rows with `revoked_at` set, so an un-revoked orphan was never "deleted later" — it merely goes inert at `expires_at`.
- Tests: a `:shutdown` exit revokes the key (fails on old code — verified), and a linked-crash exit still stops the server with the same reason and revokes on the way out.

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)