### PR TITLE
cost: an absolute provision deadline kills a hung provision (#329)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -32,6 +32,14 @@ defmodule Fountain.Conversations.ConversationServer do
   # irrelevant and the overshoot is bounded by it.
   @lifecycle_check_ms :timer.minutes(1)
 
+  # Absolute ceiling on provisioning (#329). Generous against the summed
+  # per-step timeouts (packages 300s + clone 600s + setup 120s + slack), so
+  # it only ever fires when a step stalls without raising — the case where
+  # the row sat in `starting` holding a quota slot until the next deploy:
+  # the reaper exempts rows whose server is alive, and the server's own
+  # timers queue behind the stuck handle_continue. Overridable in tests.
+  @provision_deadline_ms :timer.minutes(30)
+
   # ── public api ────────────────────────────────────────────────────────────
 
   def start_link(args) do
@@ -168,7 +176,62 @@ defmodule Fountain.Conversations.ConversationServer do
     }
 
     schedule_lifecycle_check()
+    start_provision_watchdog(state.conversation_id, state.sandbox_id)
     {:ok, state, {:continue, :provision}}
+  end
+
+  # A deadline for provisioning cannot live inside this server: a stuck
+  # handle_continue(:provision) blocks the mailbox, so a send_after (or a
+  # trapped exit signal) queues behind the very thing it is meant to bound.
+  # The watchdog is a separate process that, at the deadline, consults the
+  # sandbox row — the provision path's own source of truth — and only if it
+  # is still pending/starting brutally kills the server and applies the same
+  # failed/failed row transitions as the normal provision-failure path. The
+  # sprite, if one was created, is picked up by SandboxReaper's untracked
+  # sweep. A monitor exits the watchdog quietly whenever the server stops
+  # first, which covers every success and ordinary-failure path.
+  defp start_provision_watchdog(conv_id, sandbox_id) do
+    server = self()
+    deadline_ms = Application.get_env(:fountain, :provision_deadline_ms, @provision_deadline_ms)
+
+    spawn(fn ->
+      ref = Process.monitor(server)
+
+      receive do
+        {:DOWN, ^ref, :process, ^server, _reason} -> :ok
+      after
+        deadline_ms ->
+          sandbox = Conversations._unsafe_get_sandbox!(sandbox_id)
+
+          if sandbox.status in ["pending", "starting"] do
+            Logger.error(
+              "conv #{conv_id}: provisioning exceeded #{deadline_ms}ms; " <>
+                "killing the stuck server and failing the sandbox"
+            )
+
+            # :kill, not :shutdown — a trapped exit would just queue behind
+            # the stuck callback. terminate/2 does not run; the row updates
+            # below free the quota slot, expires_at bounds the un-revoked
+            # callback key, and the reaper reclaims the sprite.
+            Process.exit(server, :kill)
+
+            publish_stage(conv_id, "provision", "failed", %{reason: "provision deadline exceeded"})
+            {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
+
+            case Conversations._unsafe_get_conversation(conv_id) do
+              %Conversation{status: status} = conv when status not in ["terminated", "failed"] ->
+                Conversations.update_conversation(conv, %{status: "failed"})
+
+              _ ->
+                :ok
+            end
+
+            :telemetry.execute([:fountain, :provision, :deadline_exceeded], %{count: 1}, %{
+              conversation_id: conv_id
+            })
+          end
+      end
+    end)
   end
 
   @impl true

--- a/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
@@ -1,0 +1,74 @@
+defmodule Fountain.Conversations.ConversationServerProvisionDeadlineTest do
+  # #329: a ConversationServer stuck inside provisioning was invisible to
+  # every reclamation mechanism — the reaper exempts rows whose server is
+  # alive, and the server's own timers queue behind the stuck
+  # handle_continue. The provision watchdog is an external process that
+  # kills the server at an absolute deadline and applies the same
+  # failed/failed transitions as the normal provision-failure path.
+  use Fountain.ConversationServerCase
+
+  setup do
+    Application.put_env(:fountain, :provision_deadline_ms, 300)
+    on_exit(fn -> Application.delete_env(:fountain, :provision_deadline_ms) end)
+    :ok
+  end
+
+  defp wait_until(fun, tries \\ 50) do
+    cond do
+      fun.() -> :ok
+      tries == 0 -> flunk("condition never became true")
+      true ->
+        Process.sleep(100)
+        wait_until(fun, tries - 1)
+    end
+  end
+
+  test "a hung provision is killed at the deadline and its rows are failed" do
+    stub_happy_sprite()
+
+    # Stall provisioning indefinitely — the shape of a step that hangs
+    # without raising (e.g. a stream that stops yielding chunks).
+    Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->
+      Process.sleep(:infinity)
+    end)
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+
+    args = [
+      conversation_id: conv.id,
+      sandbox_id: conv.sandbox_id,
+      runtime_module: Fountain.Test.FakeRuntime
+    ]
+
+    {:ok, pid} = GenServer.start(Fountain.Conversations.ConversationServer, args)
+    ref = Process.monitor(pid)
+
+    # The watchdog must kill the stuck server…
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 5_000
+
+    # …and then free the quota slot by failing the rows.
+    wait_until(fn ->
+      Conversations._unsafe_get_sandbox!(conv.sandbox_id).status == "failed"
+    end)
+
+    assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
+  end
+
+  test "a provision that completes in time is left alone" do
+    stub_happy_sprite()
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+
+    {pid, _ref, :alive} = start_server(conv)
+
+    # Outlive the deadline, then confirm the watchdog did not fire.
+    Process.sleep(600)
+    assert Process.alive?(pid)
+    assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).status == "ready"
+
+    GenServer.call(pid, :terminate_conv, 30_000)
+  end
+end


### PR DESCRIPTION
## Summary
- New provision watchdog: an external process spawned in `init/1` that, 30 minutes in (generous vs. the summed per-step timeouts of ~17 min), checks the sandbox row and — only if it is still `pending`/`starting` — kills the stuck server and fails the sandbox + conversation rows, freeing the quota slot. Emits `[:fountain, :provision, :deadline_exceeded]`.
- Why external and why `:kill`: a stuck `handle_continue(:provision)` blocks the mailbox, so a `send_after` timer or a trapped exit signal queues behind the very thing it must bound. `:kill` is the only untrappable signal; `terminate/2` doesn't run, which is accounted for — the row updates free the quota, `expires_at` bounds the un-revoked callback key (#322's revoke can't help here by construction), and `SandboxReaper`'s untracked sweep reclaims the sprite.
- The watchdog monitors the server and exits quietly on any normal stop, so every success/ordinary-failure path is unaffected (tested).
- Deadline overridable via `:provision_deadline_ms` app env (used by tests; verified the hung-provision test fails without the watchdog).

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)