### PR TITLE
cleanup: unscoped context functions get the _unsafe_ prefix; dead unscoped surface removed (#328)

### DIFF
--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -75,8 +75,8 @@ defmodule Fountain.Audit do
   end
 
   @doc "Most recent administrative actions, newest first. Admin surfaces only."
-  @spec list_recent_admin(pos_integer()) :: [AdminEvent.t()]
-  def list_recent_admin(limit \\ 100) do
+  @spec _unsafe_list_recent_admin(pos_integer()) :: [AdminEvent.t()]
+  def _unsafe_list_recent_admin(limit \\ 100) do
     Repo.all(from e in AdminEvent, order_by: [desc: e.inserted_at, desc: e.id], limit: ^limit)
   end
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -32,12 +32,8 @@ defmodule Fountain.Conversations do
 
   # ── sandboxes ──────────────────────────────────────────────────────────────────────────
 
-  def _unsafe_list_sandboxes do
-    Repo.all(from s in Sandbox, order_by: [desc: s.inserted_at])
-  end
-
   @doc "List active sandboxes across all tenants (admin use only)."
-  def list_sandboxes_admin do
+  def _unsafe_list_sandboxes_admin do
     alias Fountain.Accounts.User
 
     Repo.all(
@@ -326,46 +322,6 @@ defmodule Fountain.Conversations do
     end
   end
 
-  @doc """
-  WARNING: walks the spawn tree across all tenants. Admin/internal use only —
-  user-facing callers must use `get_conversation_tree/2`.
-  """
-  def _unsafe_get_conversation_tree(conversation_id) do
-    sql = """
-    WITH RECURSIVE
-    ancestors(id, parent_conversation_id) AS (
-      SELECT id, parent_conversation_id FROM conversations WHERE id = $1
-      UNION ALL
-      SELECT c.id, c.parent_conversation_id FROM conversations c
-      INNER JOIN ancestors a ON c.id = a.parent_conversation_id
-    ),
-    root_row AS (
-      SELECT id FROM ancestors WHERE parent_conversation_id IS NULL LIMIT 1
-    ),
-    tree(id, source, status, parent_id) AS (
-      SELECT c.id, c.source, c.status, c.parent_conversation_id
-      FROM conversations c, root_row r WHERE c.id = r.id
-      UNION ALL
-      SELECT c.id, c.source, c.status, c.parent_conversation_id
-      FROM conversations c
-      INNER JOIN tree t ON c.parent_conversation_id = t.id
-    )
-    SELECT id, source, status, parent_id FROM tree
-    """
-
-    {:ok, uuid} = Ecto.UUID.dump(conversation_id)
-    %{rows: rows} = Repo.query!(sql, [uuid])
-
-    Enum.map(rows, fn [id, source, status, parent_id] ->
-      %{
-        id: load_uuid!(id),
-        source: source,
-        status: status,
-        parent_id: load_uuid(parent_id)
-      }
-    end)
-  end
-
   defp load_uuid!(bin) when is_binary(bin) do
     {:ok, str} = Ecto.UUID.load(bin)
     str
@@ -536,25 +492,6 @@ defmodule Fountain.Conversations do
     )
   end
 
-  def list_turns_with_images(conversation_id) do
-    Repo.all(
-      from t in Turn,
-        where: t.conversation_id == ^conversation_id,
-        order_by: [asc: t.turn_number],
-        preload: [images: ^from(i in TurnImage, order_by: [asc: i.position])]
-    )
-  end
-
-  @doc """
-  Fetch a turn by conversation without tenant scoping.
-
-  Prefer `get_turn_by_conversation/3` anywhere the caller is reachable from a
-  user-facing surface.
-  """
-  def get_turn_by_conversation(turn_id, conversation_id) do
-    Repo.get_by(Turn, id: turn_id, conversation_id: conversation_id)
-  end
-
   @doc """
   Fetch a turn by conversation, scoped to the owning user.
 
@@ -610,7 +547,7 @@ defmodule Fountain.Conversations do
     end)
   end
 
-  def get_turn_image(turn_id, position) do
+  def _unsafe_get_turn_image(turn_id, position) do
     Repo.get_by(TurnImage, turn_id: turn_id, position: position)
   end
 

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -99,11 +99,11 @@ defmodule Fountain.Environments do
 
   # ── secrets ───────────────────────────────────────────────────────────────
 
-  def list_secrets(%Environment{id: env_id}) do
+  def _unsafe_list_secrets(%Environment{id: env_id}) do
     Repo.all(from s in Secret, where: s.environment_id == ^env_id, order_by: [asc: s.key])
   end
 
-  def get_secret(env_id, key) do
+  def _unsafe_get_secret(env_id, key) do
     Repo.get_by(Secret, environment_id: env_id, key: key)
   end
 
@@ -113,7 +113,7 @@ defmodule Fountain.Environments do
   """
   def upsert_secret(%Environment{id: env_id}, %{"key" => key} = attrs, dek)
       when is_binary(dek) do
-    case get_secret(env_id, key) do
+    case _unsafe_get_secret(env_id, key) do
       nil ->
         %Secret{}
         |> Secret.changeset(Map.put(attrs, "environment_id", env_id), dek)
@@ -135,7 +135,7 @@ defmodule Fountain.Environments do
   """
   def decrypted_env(%Environment{} = env, dek) when is_binary(dek) do
     env
-    |> list_secrets()
+    |> _unsafe_list_secrets()
     |> Enum.reduce(%{}, fn secret, acc ->
       case Secret.decrypt(secret, dek) do
         {:ok, plain} -> Map.put(acc, secret.key, plain)

--- a/apps/fountain/lib/fountain/exports.ex
+++ b/apps/fountain/lib/fountain/exports.ex
@@ -321,7 +321,9 @@ defmodule Fountain.Exports do
         "repositories" => env.repositories,
         "metadata" => env.metadata,
         # Names only — values are write-only by design.
-        "secret_keys" => env |> Environments.list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
+        # Env comes from the tenant-scoped list_environments above.
+        "secret_keys" =>
+          env |> Environments._unsafe_list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
         "created_at" => env.inserted_at,
         "updated_at" => env.updated_at
       }
@@ -338,7 +340,8 @@ defmodule Fountain.Exports do
         "description" => vault.description,
         "metadata" => vault.metadata,
         # Names only — values are write-only by design.
-        "secret_keys" => vault |> Vaults.list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
+        # Vault comes from the tenant-scoped list_vaults above.
+        "secret_keys" => vault |> Vaults._unsafe_list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
         "created_at" => vault.inserted_at,
         "updated_at" => vault.updated_at
       }

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -91,13 +91,13 @@ defmodule Fountain.Vaults do
 
   # ── secrets ───────────────────────────────────────────────────────────────
 
-  def list_secrets(%Vault{id: vault_id}) do
+  def _unsafe_list_secrets(%Vault{id: vault_id}) do
     Repo.all(
       from s in VaultSecret, where: s.vault_id == ^vault_id, order_by: [asc: s.key]
     )
   end
 
-  def get_secret(vault_id, key) do
+  def _unsafe_get_secret(vault_id, key) do
     Repo.get_by(VaultSecret, vault_id: vault_id, key: key)
   end
 
@@ -106,7 +106,7 @@ defmodule Fountain.Vaults do
   with the supplied per-tenant `dek` before persisting.
   """
   def upsert_secret(%Vault{id: vault_id}, %{"key" => key} = attrs, dek) when is_binary(dek) do
-    case get_secret(vault_id, key) do
+    case _unsafe_get_secret(vault_id, key) do
       nil ->
         %VaultSecret{}
         |> VaultSecret.changeset(Map.put(attrs, "vault_id", vault_id), dek)
@@ -128,7 +128,7 @@ defmodule Fountain.Vaults do
   """
   def decrypted_env(%Vault{} = vault, dek) when is_binary(dek) do
     vault
-    |> list_secrets()
+    |> _unsafe_list_secrets()
     |> Enum.reduce(%{}, fn secret, acc ->
       case VaultSecret.decrypt(secret, dek) do
         {:ok, plain} -> Map.put(acc, secret.key, plain)

--- a/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
@@ -24,7 +24,8 @@ defmodule FountainWeb.SecretController do
   def index(conn, %{"environment_id" => env_id}) do
     case Environments.get_environment(env_id, conn.assigns.current_user.id) do
       nil -> {:error, :not_found}
-      env -> render(conn, :index, secrets: Environments.list_secrets(env))
+      # Ownership established by the scoped get_environment above.
+      env -> render(conn, :index, secrets: Environments._unsafe_list_secrets(env))
     end
   end
 
@@ -75,7 +76,8 @@ defmodule FountainWeb.SecretController do
     user = conn.assigns.current_user
 
     with %_{} <- Environments.get_environment(env_id, user.id),
-         %_{} = secret <- Environments.get_secret(env_id, key) do
+         # Ownership established by the scoped get_environment above.
+         %_{} = secret <- Environments._unsafe_get_secret(env_id, key) do
       {:ok, _} = Environments.delete_secret(secret)
       send_resp(conn, :no_content, "")
     else

--- a/apps/fountain/lib/fountain_web/controllers/turn_image_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/turn_image_controller.ex
@@ -13,7 +13,8 @@ defmodule FountainWeb.TurnImageController do
          {:ok, turn_id} <- Ecto.UUID.cast(turn_id),
          turn when not is_nil(turn) <-
            Conversations.get_turn_by_conversation(turn_id, conv_id, user_id),
-         image when not is_nil(image) <- Conversations.get_turn_image(turn.id, position),
+         # Ownership established by the scoped turn lookup above.
+         image when not is_nil(image) <- Conversations._unsafe_get_turn_image(turn.id, position),
          true <- image.media_type in TurnImage.valid_media_types() do
       conn
       |> put_resp_content_type(image.media_type)

--- a/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
@@ -26,7 +26,8 @@ defmodule FountainWeb.VaultSecretController do
 
     case Vaults.get_vault(vault_id, user.id) do
       nil -> {:error, :not_found}
-      vault -> render(conn, :index, secrets: Vaults.list_secrets(vault))
+      # Ownership established by the scoped get_vault above.
+      vault -> render(conn, :index, secrets: Vaults._unsafe_list_secrets(vault))
     end
   end
 
@@ -79,7 +80,8 @@ defmodule FountainWeb.VaultSecretController do
     user = conn.assigns.current_user
 
     with %_{} <- Vaults.get_vault(vault_id, user.id),
-         %_{} = secret <- Vaults.get_secret(vault_id, key) do
+         # Ownership established by the scoped get_vault above.
+         %_{} = secret <- Vaults._unsafe_get_secret(vault_id, key) do
       {:ok, _} = Vaults.delete_secret(secret)
       send_resp(conn, :no_content, "")
     else

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -20,8 +20,8 @@ defmodule FountainWeb.AdminLive.Index do
      |> assign(:page_title, "Admin")
      |> assign(:funnel, Fountain.Funnel.summary_admin())
      |> assign(:billing_overview, Billing.overview_admin())
-     |> assign(:sandboxes, Conversations.list_sandboxes_admin())
-     |> assign(:admin_events, Fountain.Audit.list_recent_admin(25))}
+     |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
+     |> assign(:admin_events, Fountain.Audit._unsafe_list_recent_admin(25))}
   end
 
   # Filter/sort/page state lives in the URL, so the 10s refresh, admin
@@ -43,8 +43,8 @@ defmodule FountainWeb.AdminLive.Index do
      |> assign_users()
      |> assign(:funnel, Fountain.Funnel.summary_admin())
      |> assign(:billing_overview, Billing.overview_admin())
-     |> assign(:sandboxes, Conversations.list_sandboxes_admin())
-     |> assign(:admin_events, Fountain.Audit.list_recent_admin(25))}
+     |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
+     |> assign(:admin_events, Fountain.Audit._unsafe_list_recent_admin(25))}
   end
 
   @impl true
@@ -194,7 +194,7 @@ defmodule FountainWeb.AdminLive.Index do
 
         {:noreply,
          socket
-         |> assign(:sandboxes, Conversations.list_sandboxes_admin())
+         |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
          |> assign_users()
          |> put_flash(:info, msg)}
 
@@ -243,7 +243,7 @@ defmodule FountainWeb.AdminLive.Index do
             {:noreply,
              socket
              |> assign_users()
-             |> assign(:sandboxes, Conversations.list_sandboxes_admin())
+             |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
              |> put_flash(:info, "Suspended — #{reaped} sandbox(es) reaped")}
 
           {:error, _} ->
@@ -283,7 +283,7 @@ defmodule FountainWeb.AdminLive.Index do
           {:noreply,
            socket
            |> assign_users()
-           |> assign(:sandboxes, Conversations.list_sandboxes_admin())
+           |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
            |> put_flash(:info, "Deleted #{user.email}")}
 
         {:error, {:stripe, _}} ->

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -60,7 +60,8 @@ defmodule FountainWeb.EnvironmentsLive.Form do
   end
 
   defp secrets_for(%Environment{id: nil}), do: []
-  defp secrets_for(env), do: Environments.list_secrets(env)
+  # Env is loaded via the tenant-scoped lookup in load/2.
+  defp secrets_for(env), do: Environments._unsafe_list_secrets(env)
 
   @impl true
   def handle_event("validate", %{"env" => params}, socket) do

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -38,7 +38,8 @@ defmodule FountainWeb.VaultsLive.Form do
   end
 
   defp secrets_for(%Vault{id: nil}), do: []
-  defp secrets_for(vault), do: Vaults.list_secrets(vault)
+  # Vault is loaded via the tenant-scoped get_vault!/2 in load/2.
+  defp secrets_for(vault), do: Vaults._unsafe_list_secrets(vault)
 
   @impl true
   def handle_event("validate", %{"vault" => params}, socket) do

--- a/apps/fountain/test/fountain/conversations/conversation_tree_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_tree_test.exs
@@ -4,19 +4,23 @@ defmodule Fountain.Conversations.ConversationTreeTest do
   alias Fountain.Conversations
 
   # ---------------------------------------------------------------------------
-  # _unsafe_get_conversation_tree/1
+  # get_conversation_tree/2 — tree shape
+  #
+  # Cross-tenant behavior is covered in conversation_tree_scoping_test.exs;
+  # these tests pin down the shape of the returned tree for the owner.
   # ---------------------------------------------------------------------------
 
-  describe "_unsafe_get_conversation_tree/1" do
+  describe "get_conversation_tree/2 tree shape" do
     test "returns empty list for a non-existent conversation_id" do
-      assert Conversations._unsafe_get_conversation_tree(Ecto.UUID.generate()) == []
+      user = insert_verified_user()
+      assert Conversations.get_conversation_tree(Ecto.UUID.generate(), user.id) == []
     end
 
     test "returns a single-item list for a standalone conversation (no parent, no children)" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      tree = Conversations._unsafe_get_conversation_tree(conv.id)
+      tree = Conversations.get_conversation_tree(conv.id, user.id)
 
       assert length(tree) == 1
       assert hd(tree).id == conv.id
@@ -28,7 +32,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
       grandchild = insert_conversation(user_id: user.id, parent_conversation_id: child.id)
 
-      tree = Conversations._unsafe_get_conversation_tree(grandchild.id)
+      tree = Conversations.get_conversation_tree(grandchild.id, user.id)
       ids = Enum.map(tree, & &1.id) |> Enum.sort()
 
       assert ids == Enum.sort([root.id, child.id, grandchild.id])
@@ -40,7 +44,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
       grandchild = insert_conversation(user_id: user.id, parent_conversation_id: child.id)
 
-      tree = Conversations._unsafe_get_conversation_tree(root.id)
+      tree = Conversations.get_conversation_tree(root.id, user.id)
       ids = Enum.map(tree, & &1.id) |> Enum.sort()
 
       assert ids == Enum.sort([root.id, child.id, grandchild.id])
@@ -52,7 +56,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
       grandchild = insert_conversation(user_id: user.id, parent_conversation_id: child.id)
 
-      tree = Conversations._unsafe_get_conversation_tree(child.id)
+      tree = Conversations.get_conversation_tree(child.id, user.id)
       ids = Enum.map(tree, & &1.id) |> Enum.sort()
 
       assert ids == Enum.sort([root.id, child.id, grandchild.id])
@@ -64,7 +68,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
       _unrelated = insert_conversation(user_id: user.id)
 
-      tree = Conversations._unsafe_get_conversation_tree(child.id)
+      tree = Conversations.get_conversation_tree(child.id, user.id)
       ids = Enum.map(tree, & &1.id)
 
       assert length(ids) == 2
@@ -76,7 +80,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      [entry] = Conversations._unsafe_get_conversation_tree(conv.id)
+      [entry] = Conversations.get_conversation_tree(conv.id, user.id)
 
       assert Map.has_key?(entry, :id)
       assert Map.has_key?(entry, :source)
@@ -89,7 +93,7 @@ defmodule Fountain.Conversations.ConversationTreeTest do
       root = insert_conversation(user_id: user.id)
       child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
 
-      tree = Conversations._unsafe_get_conversation_tree(root.id)
+      tree = Conversations.get_conversation_tree(root.id, user.id)
 
       root_entry = Enum.find(tree, fn e -> e.id == root.id end)
       child_entry = Enum.find(tree, fn e -> e.id == child.id end)

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -9,43 +9,6 @@ defmodule Fountain.ConversationsContextTest do
   # Sandboxes
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "_unsafe_list_sandboxes/0" do
-    test "returns an empty list when no sandboxes exist" do
-      assert Conversations._unsafe_list_sandboxes() == []
-    end
-
-    test "returns all sandboxes" do
-      user = insert_verified_user()
-      s1 = insert_sandbox(user_id: user.id)
-      s2 = insert_sandbox(user_id: user.id)
-
-      ids = Conversations._unsafe_list_sandboxes() |> Enum.map(& &1.id)
-      assert s1.id in ids
-      assert s2.id in ids
-    end
-
-    test "returns sandboxes ordered by inserted_at descending" do
-      user = insert_verified_user()
-      s1 = insert_sandbox(user_id: user.id)
-      s2 = insert_sandbox(user_id: user.id)
-
-      [first | _] = Conversations._unsafe_list_sandboxes()
-      # Most recently inserted is first
-      assert first.id == s2.id || first.inserted_at >= s1.inserted_at
-    end
-
-    test "returns sandboxes across different users" do
-      user1 = insert_verified_user()
-      user2 = insert_verified_user()
-      s1 = insert_sandbox(user_id: user1.id)
-      s2 = insert_sandbox(user_id: user2.id)
-
-      ids = Conversations._unsafe_list_sandboxes() |> Enum.map(& &1.id)
-      assert s1.id in ids
-      assert s2.id in ids
-    end
-  end
-
   describe "_unsafe_get_sandbox/1" do
     test "returns the sandbox when it exists" do
       user = insert_verified_user()
@@ -481,13 +444,13 @@ defmodule Fountain.ConversationsContextTest do
     end
   end
 
-  describe "get_turn_by_conversation/2" do
-    test "returns the turn when turn_id and conversation_id match" do
+  describe "get_turn_by_conversation/3" do
+    test "returns the turn when turn_id, conversation_id and user_id match" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
       turn = insert_turn(conv)
 
-      result = Conversations.get_turn_by_conversation(turn.id, conv.id)
+      result = Conversations.get_turn_by_conversation(turn.id, conv.id, user.id)
       assert result.id == turn.id
     end
 
@@ -495,7 +458,7 @@ defmodule Fountain.ConversationsContextTest do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      assert Conversations.get_turn_by_conversation(Ecto.UUID.generate(), conv.id) == nil
+      assert Conversations.get_turn_by_conversation(Ecto.UUID.generate(), conv.id, user.id) == nil
     end
 
     test "returns nil when turn belongs to a different conversation" do
@@ -504,7 +467,16 @@ defmodule Fountain.ConversationsContextTest do
       conv2 = insert_conversation(user_id: user.id)
       turn = insert_turn(conv1)
 
-      assert Conversations.get_turn_by_conversation(turn.id, conv2.id) == nil
+      assert Conversations.get_turn_by_conversation(turn.id, conv2.id, user.id) == nil
+    end
+
+    test "returns nil when the conversation belongs to a different user" do
+      owner = insert_verified_user()
+      other = insert_verified_user()
+      conv = insert_conversation(user_id: owner.id)
+      turn = insert_turn(conv)
+
+      assert Conversations.get_turn_by_conversation(turn.id, conv.id, other.id) == nil
     end
   end
 
@@ -621,9 +593,14 @@ defmodule Fountain.ConversationsContextTest do
 
       Conversations.mark_orphaned_turns_interrupted(conv.id)
 
-      assert Conversations.get_turn_by_conversation(pending.id, conv.id).status == "pending"
-      assert Conversations.get_turn_by_conversation(completed.id, conv.id).status == "completed"
-      assert Conversations.get_turn_by_conversation(failed.id, conv.id).status == "failed"
+      assert Conversations.get_turn_by_conversation(pending.id, conv.id, user.id).status ==
+               "pending"
+
+      assert Conversations.get_turn_by_conversation(completed.id, conv.id, user.id).status ==
+               "completed"
+
+      assert Conversations.get_turn_by_conversation(failed.id, conv.id, user.id).status ==
+               "failed"
     end
 
     test "returns 0 when no running turns exist" do
@@ -645,7 +622,7 @@ defmodule Fountain.ConversationsContextTest do
       assert count == 0
 
       # conv2's running turn should be untouched
-      assert Conversations.get_turn_by_conversation(running_in_conv2.id, conv2.id).status ==
+      assert Conversations.get_turn_by_conversation(running_in_conv2.id, conv2.id, user.id).status ==
                "running"
     end
 
@@ -656,7 +633,7 @@ defmodule Fountain.ConversationsContextTest do
 
       Conversations.mark_orphaned_turns_interrupted(conv.id)
 
-      result = Conversations.get_turn_by_conversation(running.id, conv.id)
+      result = Conversations.get_turn_by_conversation(running.id, conv.id, user.id)
       assert result.status == "interrupted"
     end
   end
@@ -838,17 +815,17 @@ defmodule Fountain.ConversationsContextTest do
   end
 
   # ────────────────────────────────────────────────────────────────────────────
-  # list_sandboxes_admin/0
+  # _unsafe_list_sandboxes_admin/0
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "list_sandboxes_admin/0" do
+  describe "_unsafe_list_sandboxes_admin/0" do
     test "returns sandboxes with pending and ready statuses" do
       user = insert_verified_user()
       pending = insert_sandbox(user_id: user.id)
       ready = insert_sandbox(user_id: user.id)
       {:ok, _} = Conversations.update_sandbox(ready, %{status: "ready"})
 
-      ids = Conversations.list_sandboxes_admin() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_sandboxes_admin() |> Enum.map(& &1.id)
       assert pending.id in ids
       assert ready.id in ids
     end
@@ -858,7 +835,7 @@ defmodule Fountain.ConversationsContextTest do
       sandbox = insert_sandbox(user_id: user.id)
       {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "terminated"})
 
-      ids = Conversations.list_sandboxes_admin() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_sandboxes_admin() |> Enum.map(& &1.id)
       refute sandbox.id in ids
     end
 
@@ -867,7 +844,7 @@ defmodule Fountain.ConversationsContextTest do
       sandbox = insert_sandbox(user_id: user.id)
       {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
 
-      ids = Conversations.list_sandboxes_admin() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_sandboxes_admin() |> Enum.map(& &1.id)
       refute sandbox.id in ids
     end
 
@@ -877,7 +854,7 @@ defmodule Fountain.ConversationsContextTest do
       terminated = insert_sandbox(user_id: user.id)
       {:ok, _} = Conversations.update_sandbox(terminated, %{status: "terminated"})
 
-      ids = Conversations.list_sandboxes_admin() |> Enum.map(& &1.id)
+      ids = Conversations._unsafe_list_sandboxes_admin() |> Enum.map(& &1.id)
       assert active.id in ids
       refute terminated.id in ids
     end
@@ -886,7 +863,7 @@ defmodule Fountain.ConversationsContextTest do
       user = insert_verified_user()
       _sandbox = insert_sandbox(user_id: user.id)
 
-      results = Conversations.list_sandboxes_admin()
+      results = Conversations._unsafe_list_sandboxes_admin()
       assert results != []
       result = Enum.find(results, &(&1.user_id == user.id))
       assert result.user.id == user.id
@@ -897,7 +874,7 @@ defmodule Fountain.ConversationsContextTest do
       sandbox = insert_sandbox(user_id: user.id)
       _conv = insert_conversation(user_id: user.id, sandbox_id: sandbox.id)
 
-      results = Conversations.list_sandboxes_admin()
+      results = Conversations._unsafe_list_sandboxes_admin()
       result = Enum.find(results, &(&1.id == sandbox.id))
       assert is_list(result.conversations)
     end
@@ -910,7 +887,7 @@ defmodule Fountain.ConversationsContextTest do
       {:ok, _} = Conversations.update_sandbox(s2, %{status: "failed"})
 
       # All sandboxes in this test's db partition are terminal
-      results = Conversations.list_sandboxes_admin()
+      results = Conversations._unsafe_list_sandboxes_admin()
       ids = Enum.map(results, & &1.id)
       refute s1.id in ids
       refute s2.id in ids
@@ -1196,71 +1173,7 @@ defmodule Fountain.ConversationsContextTest do
   # ────────────────────────────────────────────────────────────────────────────
 
   # ────────────────────────────────────────────────────────────────────────────
-  # _unsafe_get_conversation_tree/1
-  # ────────────────────────────────────────────────────────────────────────────
-
-  describe "_unsafe_get_conversation_tree/1" do
-    test "returns empty list when conversation id does not exist" do
-      assert Conversations._unsafe_get_conversation_tree(Ecto.UUID.generate()) == []
-    end
-
-    test "returns single-element tree for a root conversation with no children" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-
-      tree = Conversations._unsafe_get_conversation_tree(conv.id)
-      assert length(tree) == 1
-      [node] = tree
-      assert node.id == conv.id
-      assert node.parent_id == nil
-    end
-
-    test "returned node contains :id, :source, :status, :parent_id keys" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-
-      [node] = Conversations._unsafe_get_conversation_tree(conv.id)
-      assert Map.has_key?(node, :id)
-      assert Map.has_key?(node, :source)
-      assert Map.has_key?(node, :status)
-      assert Map.has_key?(node, :parent_id)
-    end
-
-    test "includes parent and child when called with child id" do
-      user = insert_verified_user()
-      parent = insert_conversation(user_id: user.id)
-      child = insert_conversation(user_id: user.id, parent_conversation_id: parent.id)
-
-      tree = Conversations._unsafe_get_conversation_tree(child.id)
-      ids = Enum.map(tree, & &1.id)
-      assert parent.id in ids
-      assert child.id in ids
-    end
-
-    test "child node has parent_id set to the parent conversation id" do
-      user = insert_verified_user()
-      parent = insert_conversation(user_id: user.id)
-      child = insert_conversation(user_id: user.id, parent_conversation_id: parent.id)
-
-      tree = Conversations._unsafe_get_conversation_tree(child.id)
-      child_node = Enum.find(tree, &(&1.id == child.id))
-      assert child_node.parent_id == parent.id
-    end
-
-    test "includes parent when called with parent id and child exists" do
-      user = insert_verified_user()
-      parent = insert_conversation(user_id: user.id)
-      child = insert_conversation(user_id: user.id, parent_conversation_id: parent.id)
-
-      tree = Conversations._unsafe_get_conversation_tree(parent.id)
-      ids = Enum.map(tree, & &1.id)
-      assert parent.id in ids
-      assert child.id in ids
-    end
-  end
-
-  # ────────────────────────────────────────────────────────────────────────────
-  # insert_turn_images/2 and get_turn_image/2
+  # insert_turn_images/2 and _unsafe_get_turn_image/2
   # ────────────────────────────────────────────────────────────────────────────
 
   # Helper to insert a TurnImage via changeset directly, for tests that need a
@@ -1301,8 +1214,8 @@ defmodule Fountain.ConversationsContextTest do
                  %{media_type: "image/jpeg", data: <<2>>}
                ])
 
-      assert Conversations.get_turn_image(turn.id, 0).media_type == "image/png"
-      assert Conversations.get_turn_image(turn.id, 1).media_type == "image/jpeg"
+      assert Conversations._unsafe_get_turn_image(turn.id, 0).media_type == "image/png"
+      assert Conversations._unsafe_get_turn_image(turn.id, 1).media_type == "image/jpeg"
     end
 
     test "a disallowed media type is refused instead of stored" do
@@ -1319,7 +1232,7 @@ defmodule Fountain.ConversationsContextTest do
                ])
 
       assert {"is invalid", _} = changeset.errors[:media_type]
-      assert Conversations.get_turn_image(turn.id, 0) == nil
+      assert Conversations._unsafe_get_turn_image(turn.id, 0) == nil
     end
 
     test "an unknown turn is refused rather than orphaning a row" do
@@ -1332,7 +1245,7 @@ defmodule Fountain.ConversationsContextTest do
     end
   end
 
-  describe "get_turn_image/2" do
+  describe "_unsafe_get_turn_image/2" do
     test "returns the TurnImage when turn_id and position match" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
@@ -1340,7 +1253,7 @@ defmodule Fountain.ConversationsContextTest do
 
       insert_turn_image!(turn.id, 0, "image/png", <<7, 8, 9>>)
 
-      result = Conversations.get_turn_image(turn.id, 0)
+      result = Conversations._unsafe_get_turn_image(turn.id, 0)
       assert result != nil
       assert result.turn_id == turn.id
       assert result.position == 0
@@ -1352,11 +1265,11 @@ defmodule Fountain.ConversationsContextTest do
       conv = insert_conversation(user_id: user.id)
       turn = insert_turn(conv)
 
-      assert Conversations.get_turn_image(turn.id, 99) == nil
+      assert Conversations._unsafe_get_turn_image(turn.id, 99) == nil
     end
 
     test "returns nil when turn_id does not exist" do
-      assert Conversations.get_turn_image(Ecto.UUID.generate(), 0) == nil
+      assert Conversations._unsafe_get_turn_image(Ecto.UUID.generate(), 0) == nil
     end
 
     test "returns nil when position belongs to a different turn" do
@@ -1368,7 +1281,7 @@ defmodule Fountain.ConversationsContextTest do
       insert_turn_image!(turn1.id, 0, "image/png", <<1>>)
 
       # turn1 has an image at position 0, but turn2 does not
-      assert Conversations.get_turn_image(turn2.id, 0) == nil
+      assert Conversations._unsafe_get_turn_image(turn2.id, 0) == nil
     end
   end
 
@@ -1727,52 +1640,10 @@ defmodule Fountain.ConversationsContextTest do
   end
 
   # ────────────────────────────────────────────────────────────────────────────
-  # list_turns_with_images/1
+  # _unsafe_list_turns/1 — image preloads
   # ────────────────────────────────────────────────────────────────────────────
 
-  describe "list_turns_with_images/1" do
-    test "returns empty list when conversation has no turns" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-
-      assert Conversations.list_turns_with_images(conv.id) == []
-    end
-
-    test "returns all turns for the conversation" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-      t1 = insert_turn(conv)
-      t2 = insert_turn(conv)
-
-      ids = Conversations.list_turns_with_images(conv.id) |> Enum.map(& &1.id)
-      assert t1.id in ids
-      assert t2.id in ids
-    end
-
-    test "orders turns by turn_number ascending" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-      t1 = insert_turn(conv)
-      t2 = insert_turn(conv)
-
-      [first, second] = Conversations.list_turns_with_images(conv.id)
-      assert first.turn_number < second.turn_number
-      assert first.id == t1.id
-      assert second.id == t2.id
-    end
-
-    test "does not return turns from other conversations" do
-      user = insert_verified_user()
-      conv1 = insert_conversation(user_id: user.id)
-      conv2 = insert_conversation(user_id: user.id)
-      t1 = insert_turn(conv1)
-      _t2 = insert_turn(conv2)
-
-      results = Conversations.list_turns_with_images(conv1.id)
-      assert length(results) == 1
-      assert hd(results).id == t1.id
-    end
-
+  describe "_unsafe_list_turns/1 image preloads" do
     test "preloads images association on each turn" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
@@ -1788,7 +1659,7 @@ defmodule Fountain.ConversationsContextTest do
       |> Ecto.Changeset.put_change(:inserted_at, DateTime.utc_now() |> DateTime.truncate(:second))
       |> Repo.insert!()
 
-      [loaded_turn] = Conversations.list_turns_with_images(conv.id)
+      [loaded_turn] = Conversations._unsafe_list_turns(conv.id)
       assert length(loaded_turn.images) == 1
       [img] = loaded_turn.images
       assert img.media_type == "image/png"
@@ -1800,7 +1671,7 @@ defmodule Fountain.ConversationsContextTest do
       conv = insert_conversation(user_id: user.id)
       _turn = insert_turn(conv)
 
-      [loaded_turn] = Conversations.list_turns_with_images(conv.id)
+      [loaded_turn] = Conversations._unsafe_list_turns(conv.id)
       assert loaded_turn.images == []
     end
 
@@ -1827,7 +1698,7 @@ defmodule Fountain.ConversationsContextTest do
         |> Repo.insert!()
       end
 
-      [loaded_turn] = Conversations.list_turns_with_images(conv.id)
+      [loaded_turn] = Conversations._unsafe_list_turns(conv.id)
       positions = Enum.map(loaded_turn.images, & &1.position)
       assert positions == Enum.sort(positions)
     end

--- a/apps/fountain/test/fountain/environments_test.exs
+++ b/apps/fountain/test/fountain/environments_test.exs
@@ -112,19 +112,19 @@ defmodule Fountain.EnvironmentsTest do
       {:ok, _} = Environments.upsert_secret(env, %{"key" => "API_KEY", "value" => "first"}, dek)
       {:ok, _} = Environments.upsert_secret(env, %{"key" => "API_KEY", "value" => "second"}, dek)
 
-      secrets = Environments.list_secrets(env)
+      secrets = Environments._unsafe_list_secrets(env)
       assert length(secrets) == 1
     end
   end
 
-  describe "list_secrets/1" do
+  describe "_unsafe_list_secrets/1" do
     test "returns all secrets for an environment" do
       user = insert_verified_user()
       env = insert_env(user_id: user.id)
       insert_secret(env, key: "FOO")
       insert_secret(env, key: "BAR")
 
-      secrets = Environments.list_secrets(env)
+      secrets = Environments._unsafe_list_secrets(env)
       assert length(secrets) == 2
     end
 
@@ -132,7 +132,7 @@ defmodule Fountain.EnvironmentsTest do
       user = insert_verified_user()
       env = insert_env(user_id: user.id)
 
-      assert Environments.list_secrets(env) == []
+      assert Environments._unsafe_list_secrets(env) == []
     end
   end
 
@@ -143,7 +143,7 @@ defmodule Fountain.EnvironmentsTest do
       secret = insert_secret(env, key: "TO_DELETE")
 
       assert {:ok, _} = Environments.delete_secret(secret)
-      assert Environments.list_secrets(env) == []
+      assert Environments._unsafe_list_secrets(env) == []
     end
   end
 
@@ -253,14 +253,14 @@ defmodule Fountain.EnvironmentsTest do
     end
   end
 
-  describe "get_secret/2" do
+  describe "_unsafe_get_secret/2" do
     test "returns the secret when env_id and key match" do
       user = insert_verified_user()
       env = insert_env(user_id: user.id)
       {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
       {:ok, secret} = Environments.upsert_secret(env, %{"key" => "MY_KEY", "value" => "val"}, dek)
 
-      result = Environments.get_secret(env.id, "MY_KEY")
+      result = Environments._unsafe_get_secret(env.id, "MY_KEY")
       assert result != nil
       assert result.id == secret.id
       assert result.key == "MY_KEY"
@@ -270,11 +270,11 @@ defmodule Fountain.EnvironmentsTest do
       user = insert_verified_user()
       env = insert_env(user_id: user.id)
 
-      assert Environments.get_secret(env.id, "MISSING_KEY") == nil
+      assert Environments._unsafe_get_secret(env.id, "MISSING_KEY") == nil
     end
 
     test "returns nil when env_id does not exist" do
-      assert Environments.get_secret(Ecto.UUID.generate(), "ANY_KEY") == nil
+      assert Environments._unsafe_get_secret(Ecto.UUID.generate(), "ANY_KEY") == nil
     end
   end
 end

--- a/apps/fountain/test/fountain/vaults_test.exs
+++ b/apps/fountain/test/fountain/vaults_test.exs
@@ -100,19 +100,19 @@ defmodule Fountain.VaultsTest do
       {:ok, _} = Vaults.upsert_secret(vault, %{"key" => "TOKEN", "value" => "first"}, dek)
       {:ok, _} = Vaults.upsert_secret(vault, %{"key" => "TOKEN", "value" => "second"}, dek)
 
-      secrets = Vaults.list_secrets(vault)
+      secrets = Vaults._unsafe_list_secrets(vault)
       assert length(secrets) == 1
     end
   end
 
-  describe "list_secrets/1" do
+  describe "_unsafe_list_secrets/1" do
     test "returns all secrets for a vault" do
       user = insert_verified_user()
       vault = insert_vault(user_id: user.id)
       insert_vault_secret(vault, key: "FOO")
       insert_vault_secret(vault, key: "BAR")
 
-      secrets = Vaults.list_secrets(vault)
+      secrets = Vaults._unsafe_list_secrets(vault)
       assert length(secrets) == 2
     end
 
@@ -120,7 +120,7 @@ defmodule Fountain.VaultsTest do
       user = insert_verified_user()
       vault = insert_vault(user_id: user.id)
 
-      assert Vaults.list_secrets(vault) == []
+      assert Vaults._unsafe_list_secrets(vault) == []
     end
   end
 
@@ -131,17 +131,17 @@ defmodule Fountain.VaultsTest do
       secret = insert_vault_secret(vault, key: "TO_DELETE")
 
       assert {:ok, _} = Vaults.delete_secret(secret)
-      assert Vaults.list_secrets(vault) == []
+      assert Vaults._unsafe_list_secrets(vault) == []
     end
   end
 
-  describe "get_secret/2" do
+  describe "_unsafe_get_secret/2" do
     test "returns the secret for the given vault_id and key" do
       user = insert_verified_user()
       vault = insert_vault(user_id: user.id)
       insert_vault_secret(vault, key: "MY_SECRET")
 
-      result = Vaults.get_secret(vault.id, "MY_SECRET")
+      result = Vaults._unsafe_get_secret(vault.id, "MY_SECRET")
       assert result != nil
       assert result.key == "MY_SECRET"
       assert result.vault_id == vault.id
@@ -151,7 +151,7 @@ defmodule Fountain.VaultsTest do
       user = insert_verified_user()
       vault = insert_vault(user_id: user.id)
 
-      assert Vaults.get_secret(vault.id, "NONEXISTENT") == nil
+      assert Vaults._unsafe_get_secret(vault.id, "NONEXISTENT") == nil
     end
 
     test "returns nil when the vault_id does not match" do
@@ -160,7 +160,7 @@ defmodule Fountain.VaultsTest do
       vault_b = insert_vault(user_id: user.id)
       insert_vault_secret(vault_a, key: "ONLY_IN_A")
 
-      assert Vaults.get_secret(vault_b.id, "ONLY_IN_A") == nil
+      assert Vaults._unsafe_get_secret(vault_b.id, "ONLY_IN_A") == nil
     end
   end
 
@@ -289,7 +289,7 @@ defmodule Fountain.VaultsTest do
         Vaults.upsert_secret(vault, %{"key" => "DECRYPT_ME", "value" => "plaintext_value"}, dek)
 
       # Load the raw secret (with ciphertext) to test decrypt directly
-      [raw_secret] = Vaults.list_secrets(vault)
+      [raw_secret] = Vaults._unsafe_list_secrets(vault)
       assert {:ok, "plaintext_value"} = Fountain.Vaults.VaultSecret.decrypt(raw_secret, dek)
     end
 

--- a/apps/fountain/test/fountain_web/cross_tenant_isolation_test.exs
+++ b/apps/fountain/test/fountain_web/cross_tenant_isolation_test.exs
@@ -298,7 +298,7 @@ defmodule FountainWeb.CrossTenantIsolationTest do
       })
       |> json_response(404)
 
-      assert Fountain.Environments.list_secrets(env_a) == []
+      assert Fountain.Environments._unsafe_list_secrets(env_a) == []
     end
   end
 
@@ -341,7 +341,7 @@ defmodule FountainWeb.CrossTenantIsolationTest do
       })
       |> json_response(404)
 
-      assert Vaults.list_secrets(vault_a) == []
+      assert Vaults._unsafe_list_secrets(vault_a) == []
     end
 
     test "DELETE /api/vaults/:vault_id/secrets/:id returns 404 and does not delete",

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -147,7 +147,7 @@ defmodule FountainWeb.AdminLiveTest do
       admin = insert_admin()
       _sandbox = insert_sandbox(user_id: admin.id, status: "failed")
       conn = login_user(conn, admin)
-      # failed is excluded by list_sandboxes_admin (status not in ["terminated","failed"])
+      # failed is excluded by _unsafe_list_sandboxes_admin (status not in ["terminated","failed"])
       # so page should show "No active sandboxes"
       {:ok, _lv, html} = live(conn, ~p"/admin")
       assert html =~ "Active sandboxes"
@@ -375,7 +375,7 @@ defmodule FountainWeb.AdminLiveTest do
       assert abs(DateTime.diff(updated.trial_ends_at, expected, :second)) < 60
 
       assert Enum.any?(
-               Fountain.Audit.list_recent_admin(10),
+               Fountain.Audit._unsafe_list_recent_admin(10),
                &(&1.event_type == "admin.trial.extended" and &1.target_user_id == user.id)
              )
     end
@@ -414,7 +414,7 @@ defmodule FountainWeb.AdminLiveTest do
 
       assert Fountain.Repo.reload!(user).subscription_status == "canceled"
 
-      events = Fountain.Audit.list_recent_admin(10)
+      events = Fountain.Audit._unsafe_list_recent_admin(10)
       assert Enum.any?(events, &(&1.event_type == "admin.comp.granted"))
       assert Enum.any?(events, &(&1.event_type == "admin.comp.revoked"))
     end
@@ -438,7 +438,7 @@ defmodule FountainWeb.AdminLiveTest do
       assert reloaded.terminated_at
 
       assert Enum.any?(
-               Fountain.Audit.list_recent_admin(10),
+               Fountain.Audit._unsafe_list_recent_admin(10),
                &(&1.event_type == "admin.sandbox.reaped" and
                    &1.metadata["sandbox_id"] == sandbox.id)
              )
@@ -503,7 +503,7 @@ defmodule FountainWeb.AdminLiveTest do
       refute Fountain.Accounts.suspended?(Fountain.Repo.reload!(target))
       assert html =~ "Suspension lifted"
 
-      events = Fountain.Audit.list_recent_admin(10)
+      events = Fountain.Audit._unsafe_list_recent_admin(10)
       assert Enum.any?(events, &(&1.event_type == "admin.account.suspended"))
       assert Enum.any?(events, &(&1.event_type == "admin.account.unsuspended"))
     end


### PR DESCRIPTION
Enforces the CLAUDE.md tenant-isolation naming contract: every function that bypasses tenant scoping carries the `_unsafe_` prefix, even when its callers establish ownership first. Also removes the dead unscoped surface.

## Deletions (dead unscoped surface — zero `lib/` callers, verified by grepping `lib/` and `test/`)

| Function | Test handling |
|---|---|
| `Conversations._unsafe_list_sandboxes/0` | describe block (4 tests) deleted; admin listing stays covered by `_unsafe_list_sandboxes_admin/0` tests |
| `Conversations._unsafe_get_conversation_tree/1` | duplicate describe (6 tests) in `conversations_context_test.exs` deleted; `conversation_tree_test.exs` (8 tree-shape tests) adapted to the scoped `get_conversation_tree/2` |
| `Conversations.get_turn_by_conversation/2` | describe adapted to the scoped 3-arity variant (which had no direct coverage before) + a new cross-tenant `nil` test; 7 assertion call sites in the `mark_orphaned_turns_interrupted/1` tests moved to the 3-arity |
| `Conversations.list_turns_with_images/1` | byte-identical to `_unsafe_list_turns/1`; 4 duplicate tests dropped (already covered by the existing `_unsafe_list_turns/1` describe), 3 image-preload tests repointed at `_unsafe_list_turns/1` |

## Renames (all verified unscoped — no `user_id` predicate)

| Old | New | lib/ call sites | test/ call sites |
|---|---|---|---|
| `Conversations.list_sandboxes_admin/0` | `_unsafe_list_sandboxes_admin/0` | 5 (`admin_live/index.ex`) | 7 |
| `Audit.list_recent_admin/1` | `_unsafe_list_recent_admin/1` | 2 (`admin_live/index.ex`) | 4 |
| `Conversations.get_turn_image/2` | `_unsafe_get_turn_image/2` | 1 (`turn_image_controller.ex`) | 8 |
| `Environments.get_secret/2` | `_unsafe_get_secret/2` | 2 (`secret_controller.ex` delete, internal `upsert_secret/3`) | 3 |
| `Environments.list_secrets/1` | `_unsafe_list_secrets/1` | 4 (`secret_controller.ex` index, `exports.ex`, `environments_live/form.ex`, internal `decrypted_env/2`) | 6 |
| `Vaults.get_secret/2` | `_unsafe_get_secret/2` | 2 (`vault_secret_controller.ex` delete, internal `upsert_secret/3`) | 3 |
| `Vaults.list_secrets/1` | `_unsafe_list_secrets/1` | 4 (`vault_secret_controller.ex` index, `exports.ex`, `vaults_live/form.ex`, internal `decrypted_env/2`) | 7 |

Every remaining caller establishes ownership first (scoped `get_environment`/`get_vault`/`get_turn_by_conversation/3` lookup, tenant-scoped list, or `require_admin` surface); non-obvious call sites got a one-line comment per the CLAUDE.md rationale.

Nothing on the issue's list turned out to be scoped — all renames applied as specified.

## Verification

- `MIX_ENV=test mix compile --warnings-as-errors` — clean
- All test files compiled via `Kernel.ParallelCompiler` (no DB) — no undefined-function warnings; the 6 warnings present are all pre-existing on `main`
- `mix format --check-formatted` — clean
- Repo-wide grep — zero remaining references to any old name

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)