### PR TITLE
cost: per-conversation durable log budget with a truncation marker (#331)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -677,6 +677,20 @@ defmodule Fountain.Conversations do
   # ── log events ──────────────────────────────────────────────────────────────────────────
 
   @doc """
+  Total persisted bytes of `kind: "output"` log data for a conversation.
+  Without tenant scoping — the caller is the conversation's own server,
+  seeding the durable-output budget (#331).
+  """
+  def _unsafe_output_byte_total(conversation_id) do
+    Repo.one(
+      from(l in LogEvent,
+        where: l.conversation_id == ^conversation_id and l.kind == "output",
+        select: coalesce(sum(fragment("octet_length(?)", l.data)), 0)
+      )
+    )
+  end
+
+  @doc """
   Insert a log event. Returns the inserted struct (with integer `:id`,
   used as the SSE event id).
   """

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -164,7 +164,13 @@ defmodule Fountain.Conversations.ConversationServer do
       # Fountain.Conversations.Lifecycle for what the bounds are and why
       # reclaiming a sandbox does not end the conversation.
       sandbox_started_at: nil,
-      last_activity_at: DateTime.utc_now()
+      last_activity_at: DateTime.utc_now(),
+      # Durable-output budget bookkeeping (#331). `output_bytes` is loaded
+      # lazily from the DB on the first output of this server's lifetime, so
+      # the budget is cumulative per conversation across wakes rather than
+      # per BEAM lifetime.
+      output_bytes: nil,
+      output_capped: false
     }
 
     schedule_lifecycle_check()
@@ -1410,7 +1416,60 @@ defmodule Fountain.Conversations.ConversationServer do
     OpenTelemetry.Tracer.end_span()
   end
 
+  # Persist + broadcast one chunk of sandbox output, subject to the
+  # per-conversation byte budget (#331). log_events is unbounded per row
+  # count and lives on the same Postgres volume the app depends on, so a
+  # `while true; do base64 /dev/urandom; done` sandbox was an availability
+  # risk, not just a storage bill — retention (#217) bounds age, not rate.
+  # Once the budget is exceeded, one truncation marker is persisted and
+  # every later chunk is dropped. Dropped rather than broadcast-only:
+  # consumers key ordering off the DB-assigned event id, and an unbounded
+  # broadcast stream would still let a hostile sandbox saturate PubSub.
   defp log_output(state, stream, data) do
+    state = ensure_output_bytes(state)
+    budget = output_byte_budget()
+
+    cond do
+      state.output_capped ->
+        state
+
+      budget > 0 and state.output_bytes + byte_size(data) > budget ->
+        Logger.warning(
+          "conv #{state.conversation_id}: durable output budget " <>
+            "(#{budget} bytes) reached; dropping further sandbox output"
+        )
+
+        :telemetry.execute([:fountain, :log_output, :capped], %{count: 1}, %{
+          conversation_id: state.conversation_id
+        })
+
+        persist_output(state, "stderr", cap_marker(budget))
+        %{state | output_capped: true}
+
+      true ->
+        persist_output(state, stream, data)
+        %{state | output_bytes: state.output_bytes + byte_size(data)}
+    end
+  end
+
+  defp cap_marker(budget) do
+    "\n[fountain] This conversation reached its durable log budget of " <>
+      "#{div(budget, 1_000_000)} MB. Further sandbox output is discarded — " <>
+      "the turn keeps running, and stage events still appear.\n"
+  end
+
+  defp ensure_output_bytes(%{output_bytes: nil} = state) do
+    %{state | output_bytes: Conversations._unsafe_output_byte_total(state.conversation_id)}
+  end
+
+  defp ensure_output_bytes(state), do: state
+
+  # 0 disables the cap.
+  defp output_byte_budget do
+    Application.get_env(:fountain, :log_output_byte_budget, 50_000_000)
+  end
+
+  defp persist_output(state, stream, data) do
     # Tag this output with the stage that's active right now. The
     # runtime CLI is always spawned inside a `turn` so all stdout /
     # stderr from it gets `stage: "turn"`. Any operator on the
@@ -1453,13 +1512,12 @@ defmodule Fountain.Conversations.ConversationServer do
     cond do
       skip == 0 ->
         log_output(state, stream, data)
-        state
 
       skip >= size ->
         put_in(state.replay_skip[stream], skip - size)
 
       true ->
-        log_output(state, stream, binary_part(data, skip, size - skip))
+        state = log_output(state, stream, binary_part(data, skip, size - skip))
         put_in(state.replay_skip[stream], 0)
     end
   end

--- a/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
@@ -1,0 +1,105 @@
+defmodule Fountain.Conversations.ConversationServerLogBudgetTest do
+  # #331: log_events had no per-conversation volume bound inside the
+  # retention window — retention bounds age, not rate, and Postgres is the
+  # same volume the app depends on. Once the budget is exceeded, one
+  # truncation marker is persisted and later chunks are dropped.
+  use Fountain.ConversationServerCase
+
+  setup do
+    Application.put_env(:fountain, :log_output_byte_budget, 100)
+    on_exit(fn -> Application.delete_env(:fountain, :log_output_byte_budget) end)
+    :ok
+  end
+
+  defp start_with_turn(conv) do
+    cmd_ref = make_ref()
+
+    Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
+      {:ok, %{ref: cmd_ref, pid: self()}}
+    end)
+
+    Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
+    Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+
+    {pid, mon, :alive} = start_server(conv, initial_prompt: "go")
+    _ = :sys.get_state(pid)
+    {pid, cmd_ref, mon}
+  end
+
+  defp setup_conv do
+    stub_happy_sprite()
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    insert_conversation(user_id: user.id, agent_id: agent.id)
+  end
+
+  defp output_events(conv_id) do
+    conv_id
+    |> Conversations._unsafe_list_log_events()
+    |> Enum.filter(&(&1.kind == "output"))
+  end
+
+  test "output over the budget is replaced by a single marker and then dropped" do
+    conv = setup_conv()
+    {pid, cmd_ref, _ref} = start_with_turn(conv)
+
+    # 3 x 60 bytes against a 100-byte budget: chunk 1 persists, chunk 2
+    # crosses the budget → marker, chunk 3 is silently dropped.
+    chunk = String.duplicate("a", 60)
+    for _ <- 1..3, do: send(pid, {:stdout, %{ref: cmd_ref}, chunk})
+    _ = :sys.get_state(pid)
+
+    events = output_events(conv.id)
+    data = Enum.map(events, & &1.data)
+
+    assert Enum.count(data, &(&1 == chunk)) == 1
+    assert [marker] = Enum.filter(data, &(&1 =~ "durable log budget"))
+    assert marker =~ "discarded"
+
+    # Nothing after the marker.
+    assert length(events) == 2
+
+    GenServer.stop(pid)
+  end
+
+  test "the budget seeds from bytes already persisted, so it is cumulative across wakes" do
+    conv = setup_conv()
+    {pid, cmd_ref, _ref} = start_with_turn(conv)
+
+    send(pid, {:stdout, %{ref: cmd_ref}, String.duplicate("b", 90)})
+    _ = :sys.get_state(pid)
+
+    # The seed a fresh server for this conversation would start from: the
+    # DB total, not zero — which is what makes the budget per-conversation
+    # rather than per-BEAM-lifetime.
+    assert Conversations._unsafe_output_byte_total(conv.id) == 90
+
+    # And the in-flight counter agrees with the durable one.
+    assert :sys.get_state(pid).output_bytes == 90
+    GenServer.stop(pid)
+  end
+
+  test "a 0 budget disables the cap" do
+    Application.put_env(:fountain, :log_output_byte_budget, 0)
+    conv = setup_conv()
+    {pid, cmd_ref, _ref} = start_with_turn(conv)
+
+    for _ <- 1..5, do: send(pid, {:stdout, %{ref: cmd_ref}, String.duplicate("d", 60)})
+    _ = :sys.get_state(pid)
+
+    assert Enum.count(output_events(conv.id), &(&1.data =~ "dddd")) == 5
+    GenServer.stop(pid)
+  end
+
+  test "under the budget, output persists exactly as before" do
+    conv = setup_conv()
+    {pid, cmd_ref, _ref} = start_with_turn(conv)
+
+    send(pid, {:stdout, %{ref: cmd_ref}, "hello"})
+    _ = :sys.get_state(pid)
+
+    assert Enum.any?(output_events(conv.id), &(&1.data == "hello"))
+    refute Enum.any?(output_events(conv.id), &(&1.data =~ "durable log budget"))
+    GenServer.stop(pid)
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -205,6 +205,13 @@ config :fountain,
   sandbox_idle_timeout_minutes: parse_bound.("SANDBOX_IDLE_TIMEOUT_MINUTES", "60"),
   sandbox_max_lifetime_hours: parse_bound.("SANDBOX_MAX_LIFETIME_HOURS", "24")
 
+# Durable log volume per conversation (#331). Retention bounds the age of
+# log_events rows; this bounds the rate — without it a sandbox printing
+# garbage could write tens of GB into the same Postgres volume the app
+# depends on. 0 disables the cap.
+config :fountain,
+  log_output_byte_budget: parse_bound.("LOG_OUTPUT_BUDGET_MB", "50") * 1_000_000
+
 # Accounts that registered and never verified are deleted after this many
 # days (#258) — they cannot log in, so they are rows, not users. 0 disables
 # the sweep. UNVERIFIED_PRUNE_EXEMPT is a comma-separated list of email

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,7 @@ an error message.
 | `SPRITES_TIMEOUT_MS` | `30000` | — | Bounds every HTTP call to the Sprites API. Long-running commands (package installs, clones) set their own per-call timeouts. Boot refuses a non-positive value |
 | `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long and the sandbox is reclaimed — the conversation stays [resumable](self-hosting.md#sandbox-lifetime). `0` disables the bound; boot refuses anything that is not a non-negative integer |
 | `SANDBOX_MAX_LIFETIME_HOURS` | `24` | — | Absolute sandbox age ceiling, regardless of activity. Same `0`-disables and boot-refusal rules |
+| `LOG_OUTPUT_BUDGET_MB` | `50` | — | Durable log volume per conversation. Once a conversation has persisted this much sandbox output, one truncation marker is written and further output is discarded (retention bounds age; this bounds rate). Same `0`-disables and boot-refusal rules |
 
 ## Registration and accounts
 


### PR DESCRIPTION
## Summary
- `log_output/3` now enforces a per-conversation byte budget over `kind: "output"` events: under budget → persist as before; crossing it → one truncation marker (persisted + broadcast) and a `[:fountain, :log_output, :capped]` telemetry event; after that → chunks are dropped. Stage events are untouched, so turn progress stays visible.
- One deliberate deviation from the issue text: it suggested the live SSE stream could keep flowing while only persistence stops. Consumers order events by the DB-assigned id (LiveView's `ev.id > last_event_id`), so broadcast-only events would corrupt ordering — and an unbounded broadcast still lets a hostile sandbox saturate PubSub. Post-cap output is dropped instead, and the marker says so.
- Budget config: `LOG_OUTPUT_BUDGET_MB` (default 50, `0` disables, boot-refuses garbage — same `parse_bound` contract as the sandbox bounds), documented in `docs/configuration.md` (the drift test covers it).
- The counter seeds from `_unsafe_output_byte_total/1` (SQL `octet_length` sum) once per server lifetime, so the budget is per conversation across wakes, not per BEAM boot — tested.
- 4 tests: marker + drop behavior (verified to fail against the uncapped code), DB seeding, `0` disables, under-budget unchanged.

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)