### PR TITLE
ci: the sobelow gate actually scans the app (#311)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,11 @@ jobs:
         continue-on-error: true
         run: mix hex.audit
 
+      # working-directory matters: at the umbrella root sobelow detects no
+      # Phoenix app, scans nothing, and exits 0 — indistinguishable from a
+      # pass. Reported by two audits (#194, #311) before it was fixed.
       - name: Security scan (sobelow)
+        working-directory: apps/fountain
         run: mix sobelow --config
 
       # The PLT encodes OTP + deps; rebuilding it cold takes minutes, so it is

--- a/mix.exs
+++ b/mix.exs
@@ -73,6 +73,7 @@ defmodule Fountain.Umbrella.MixProject do
         "format --check-formatted",
         "credo --strict --mute-exit-status",
         &dialyzer_in_dev/1,
+        &sobelow_in_app/1,
         "test"
       ]
     ]
@@ -87,6 +88,16 @@ defmodule Fountain.Umbrella.MixProject do
     case Mix.shell().cmd("mix dialyzer", env: [{"MIX_ENV", "dev"}]) do
       0 -> :ok
       status -> Mix.raise("mix dialyzer failed with exit status #{status}")
+    end
+  end
+
+  # Runs from apps/fountain because sobelow at the umbrella root detects no
+  # Phoenix app, scans nothing, and exits 0 — a gate that passes because it
+  # scanned nothing looks identical to a gate that passed (#311).
+  defp sobelow_in_app(_args) do
+    case Mix.shell().cmd("mix sobelow --config", cd: "apps/fountain") do
+      0 -> :ok
+      status -> Mix.raise("mix sobelow failed with exit status #{status}")
     end
   end
 end


### PR DESCRIPTION
## Summary
- Adds `working-directory: apps/fountain` to the CI sobelow step. At the umbrella root, sobelow detects no Phoenix app, scans nothing, and exits 0 — it has gated nothing since it was added, as two audits (#194, #311) reported.
- Adds the same scan to `mix precommit` via a `cd`'d shell step (sobelow must run from `apps/fountain`), so local runs match CI.
- Sequencing note: pointed at the app for real, sobelow found two **High-confidence** findings that would have failed this gate — CSRF action reuse on the legacy login (removed in #371) and missing CSP (added in #372). Those merged first; on this rebased branch `mix sobelow --config` exits 0.
- The configured bar stays `exit: "high"` (from `.sobelow-conf`): Medium/Low-confidence findings print but don't fail the build. Current residue: one Medium XSS.ContentType on the turn-image controller (a false positive — it pins content-type and nosniff) and a handful of Low Traversal/SQL notes. Tightening the bar is a separate decision.

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)