### PR TITLE
testing: close the three vacuity gaps from the audit (#337)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -999,7 +999,11 @@ defmodule Fountain.Conversations.ConversationServer do
   def handle_info(_msg, state), do: {:noreply, state}
 
   defp schedule_lifecycle_check do
-    Process.send_after(self(), :lifecycle_check, @lifecycle_check_ms)
+    # Interval overridable in tests so the timer wiring itself is testable —
+    # dropping schedule_lifecycle_check() from init/1 used to pass the whole
+    # suite (#337) while silently disabling idle/max-lifetime reclamation.
+    interval = Application.get_env(:fountain, :lifecycle_check_ms, @lifecycle_check_ms)
+    Process.send_after(self(), :lifecycle_check, interval)
   end
 
   defp touch_activity(state), do: %{state | last_activity_at: DateTime.utc_now()}

--- a/apps/fountain/test/fountain/config_reference_test.exs
+++ b/apps/fountain/test/fountain/config_reference_test.exs
@@ -58,4 +58,88 @@ defmodule Fountain.ConfigReferenceTest do
            injects rather than an operator sets — add them to @platform_injected.
            """
   end
+
+  # ── reverse direction (#337) ─────────────────────────────────────────────
+  #
+  # The original test only caught runtime.exs → doc drift. Nothing caught a
+  # documented variable that no longer exists in code, or a compose variable
+  # the app never reads — an operator following either would set a knob wired
+  # to nothing.
+
+  # Documented variables legitimately read outside config/runtime.exs.
+  # Each entry needs a reason; an entry without a real reader is exactly the
+  # rot this test exists to catch.
+  @read_elsewhere %{
+    # The OTel SDK reads its own standard variables directly.
+    "OTEL_TRACES_EXPORTER" => "read by the OTel Erlang SDK",
+    # Set by release tooling; read in Fountain.Application.skip_migrations?/0.
+    "RELEASE_NAME" => "release tooling + Fountain.Application"
+  }
+
+  test "every variable documented in configuration.md is actually read by code" do
+    source = File.read!(Path.join(@repo_root, "config/runtime.exs"))
+    doc = File.read!(Path.join(@repo_root, "docs/configuration.md"))
+
+    documented =
+      Regex.scan(~r/^\| `([A-Z][A-Z0-9_]*)`/m, doc, capture: :all_but_first)
+      |> List.flatten()
+      |> Enum.uniq()
+
+    # Vacuous-pass guard, mirroring the forward test.
+    assert length(documented) > 30,
+           "extracted only #{length(documented)} documented vars — the table format changed"
+
+    dead =
+      Enum.reject(documented, fn var ->
+        String.contains?(source, ~s("#{var}")) or Map.has_key?(@read_elsewhere, var)
+      end)
+
+    assert dead == [],
+           """
+           docs/configuration.md documents variables that config/runtime.exs never reads:
+
+             #{Enum.join(dead, ", ")}
+
+           Delete the row, or — only when a real reader exists outside
+           runtime.exs — add the var to @read_elsewhere with the reader.
+           """
+  end
+
+  # Compose-side keys that are not app env vars: consumed by compose
+  # interpolation or by another service, not by the release.
+  @compose_only ~w()
+
+  test "every env var the compose app service sets is one the app reads" do
+    source = File.read!(Path.join(@repo_root, "config/runtime.exs"))
+    compose = File.read!(Path.join(@repo_root, "docker-compose.yml"))
+
+    # The environment mapping of the `app:` service: keys at 6-space indent
+    # between its `environment:` line and the next 4-space-indented key.
+    [_, app_section] = String.split(compose, ~r/^  app:\n/m, parts: 2)
+    [_, env_and_rest] = String.split(app_section, ~r/^    environment:\n/m, parts: 2)
+    [env_block | _] = String.split(env_and_rest, ~r/^    [a-z]/m, parts: 2)
+
+    keys =
+      Regex.scan(~r/^      ([A-Z][A-Z0-9_]*):/m, env_block, capture: :all_but_first)
+      |> List.flatten()
+      |> Enum.uniq()
+
+    assert length(keys) > 5,
+           "extracted only #{length(keys)} compose env keys — the compose layout changed"
+
+    unread =
+      Enum.reject(keys, fn var ->
+        String.contains?(source, ~s("#{var}")) or var in @compose_only or
+          Map.has_key?(@read_elsewhere, var)
+      end)
+
+    assert unread == [],
+           """
+           docker-compose.yml sets env vars on the app service that the app never reads:
+
+             #{Enum.join(unread, ", ")}
+
+           Remove the key, or add it to @compose_only/@read_elsewhere with a reason.
+           """
+  end
 end

--- a/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
@@ -2,9 +2,11 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
   @moduledoc """
   A live ConversationServer reclaiming its own sandbox.
 
-  The bound is checked on a one-minute timer, so these send `:lifecycle_check`
-  directly rather than waiting for it — the timer's only job is to call the
-  same code path.
+  The bound is checked on a one-minute timer. Most tests send
+  `:lifecycle_check` directly to exercise the check itself; the "timer is
+  actually wired" test shrinks the interval and waits for a real tick, so
+  dropping `schedule_lifecycle_check()` from `init/1` fails a test instead
+  of silently disabling reclamation (#337).
   """
 
   use Fountain.ConversationServerCase
@@ -71,6 +73,27 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
       end)
 
       assert_received :destroyed
+      assert Fountain.Repo.reload(sandbox).status == "terminated"
+    end
+
+    test "the timer is actually wired: reclamation fires with no manual tick" do
+      {conv, sandbox} = aged_conversation(180)
+      stub_reattach()
+
+      Application.put_env(:fountain, :lifecycle_check_ms, 50)
+      on_exit(fn -> Application.delete_env(:fountain, :lifecycle_check_ms) end)
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        {pid, ref, :alive} = start_server(conv)
+
+        :sys.replace_state(pid, fn state ->
+          %{state | last_activity_at: DateTime.add(DateTime.utc_now(), -7200, :second)}
+        end)
+
+        # No send(pid, :lifecycle_check) — the scheduled tick must do it.
+        assert :normal = assert_stopped(ref, 5_000)
+      end)
+
       assert Fountain.Repo.reload(sandbox).status == "terminated"
     end
 

--- a/apps/fountain/test/fountain_web/controllers/stripe_webhook_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/stripe_webhook_controller_test.exs
@@ -68,6 +68,12 @@ defmodule FountainWeb.StripeWebhookControllerTest do
         |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :post, "/api/stripe/webhook", @raw_body)
 
       assert conn.status == 200
+
+      # The 200 alone is vacuous — the controller 200s on every handle_event
+      # outcome (#337). The state change is the assertion that can fail when
+      # the apply path breaks.
+      assert Fountain.Repo.get!(Fountain.Accounts.User, user.id).subscription_status ==
+               "active"
     end
   end
 end


### PR DESCRIPTION
## Summary
- **Idle-timeout timer wiring** (`money leak with a green suite`): `schedule_lifecycle_check/0` reads an overridable `:lifecycle_check_ms`, and a new test shrinks it to 50ms, starts a real server, and waits for a *scheduled* tick to reclaim an aged sandbox — no manual `send(pid, :lifecycle_check)`. Verified by removing the `init/1` call: exactly this test fails.
- **Webhook apply path**: the "customer matches a real user" test now reloads the user and asserts `subscription_status == "active"` — the 200 was vacuous since the controller 200s on every outcome.
- **Config drift, reverse direction**: two new tests — every var documented in `configuration.md` must be read by `runtime.exs` (or carry a justified `@read_elsewhere` entry: OTel SDK reads `OTEL_TRACES_EXPORTER`, release tooling owns `RELEASE_NAME`), and every env key the compose `app` service sets must be one the app reads. Both have the same vacuous-pass extraction guards as the forward test.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)