### PR TITLE
ops: conversation/sandbox gauges, Oban queue metrics and alerts (#321)

### DIFF
--- a/apps/fountain/lib/fountain/ops_gauges.ex
+++ b/apps/fountain/lib/fountain/ops_gauges.ex
@@ -1,0 +1,88 @@
+defmodule Fountain.OpsGauges do
+  @moduledoc """
+  Periodic conversation / sandbox / Oban gauges (#321).
+
+  Runs from the telemetry poller every 10s. Emits one datapoint per known
+  status — including zeros — so every series exists from boot: an alert on
+  `depth > N` needs the series to come back down to 0 on recovery rather
+  than disappear, and a dashboard panel that only materializes during an
+  incident is a panel nobody trusts.
+
+  Oban states are the non-terminal ones plus `discarded`: `completed` and
+  `cancelled` rows are unbounded history (Oban's Pruner owns them) and their
+  count is not a queue-health signal. `discarded` is — a job that exhausted
+  its retries failed permanently, and before this existed a nightly
+  RetentionPruner or hourly SandboxReaper failure was invisible: Oban
+  catches job exceptions internally, so nothing crashed and nothing paged.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Fountain.Repo
+
+  @oban_states ~w(available scheduled executing retryable discarded)
+
+  def emit_telemetry do
+    emit_status_counts(
+      [:fountain, :conversations],
+      Fountain.Conversations.Conversation,
+      Fountain.Conversations.Conversation.statuses()
+    )
+
+    emit_status_counts(
+      [:fountain, :sandboxes],
+      Fountain.Conversations.Sandbox,
+      Fountain.Conversations.Sandbox.statuses()
+    )
+
+    emit_oban_depths()
+    :ok
+  rescue
+    # A raise here must not escape: telemetry_poller permanently drops a
+    # measurement whose tick raises (#365), so one boot-race or DB blip
+    # would silently kill these gauges for the node's lifetime. Skip the
+    # datapoint; the next tick retries.
+    error ->
+      Logger.warning("ops gauges tick skipped: #{Exception.message(error)}")
+      :ok
+  end
+
+  defp emit_status_counts(event, schema, statuses) do
+    counts =
+      Repo.all(from(r in schema, group_by: r.status, select: {r.status, count(r.id)}))
+      |> Map.new()
+
+    for status <- statuses do
+      :telemetry.execute(event, %{count: Map.get(counts, status, 0)}, %{status: status})
+    end
+  end
+
+  defp emit_oban_depths do
+    counts =
+      Repo.all(
+        from(j in Oban.Job,
+          where: j.state in @oban_states,
+          group_by: [j.queue, j.state],
+          select: {{j.queue, j.state}, count(j.id)}
+        )
+      )
+      |> Map.new()
+
+    for queue <- known_queues(), state <- @oban_states do
+      :telemetry.execute(
+        [:fountain, :oban_queue],
+        %{depth: Map.get(counts, {queue, state}, 0)},
+        %{queue: queue, state: state}
+      )
+    end
+  end
+
+  defp known_queues do
+    :fountain
+    |> Application.fetch_env!(Oban)
+    |> Keyword.get(:queues, [])
+    |> Enum.map(fn {queue, _conc} -> to_string(queue) end)
+  end
+end

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -178,6 +178,48 @@ defmodule FountainWeb.Telemetry do
         description: "Verified users who never started a conversation"
       ),
 
+      # ── Ops gauges (#321) ─────────────────────────────────────────────────
+      # Polled from Fountain.OpsGauges.emit_telemetry/0; zeros emitted for
+      # every known status so the series exist from boot.
+      last_value("fountain.conversations.count",
+        event_name: [:fountain, :conversations],
+        measurement: :count,
+        tags: [:status],
+        description: "Conversations by status"
+      ),
+      last_value("fountain.sandboxes.count",
+        event_name: [:fountain, :sandboxes],
+        measurement: :count,
+        tags: [:status],
+        description: "Sandbox rows by status"
+      ),
+      last_value("fountain.oban_queue.depth",
+        event_name: [:fountain, :oban_queue],
+        measurement: :depth,
+        tags: [:queue, :state],
+        description: "Oban jobs by queue and state (non-terminal states + discarded)"
+      ),
+
+      # ── Oban job outcomes (#321) ──────────────────────────────────────────
+      # Oban catches job exceptions internally and reports them only via
+      # telemetry, so neither the Sentry LoggerHandler nor any crash report
+      # reliably sees a failing RetentionPruner or SandboxReaper. These hang
+      # directly off Oban's own events — no poller involved.
+      counter("fountain.oban_job.stop.count",
+        event_name: [:oban, :job, :stop],
+        measurement: :duration,
+        tags: [:queue, :state],
+        tag_values: &oban_job_tags/1,
+        description: "Completed Oban job executions by queue and result state"
+      ),
+      counter("fountain.oban_job.exception.count",
+        event_name: [:oban, :job, :exception],
+        measurement: :duration,
+        tags: [:queue, :worker],
+        tag_values: &oban_job_tags/1,
+        description: "Oban job executions that raised, by queue and worker"
+      ),
+
       # ── VM ────────────────────────────────────────────────────────────────
       last_value("vm.memory.total", unit: {:byte, :kilobyte}),
       last_value("vm.total_run_queue_lengths.total"),
@@ -198,6 +240,17 @@ defmodule FountainWeb.Telemetry do
 
   defp exception_tags(meta) do
     %{route: meta[:route] || "unmatched", kind: meta[:kind]}
+  end
+
+  # Worker cardinality is bounded by the workers defined in this repo; the
+  # queue set by config. `state` is present on :stop (:success, :failure,
+  # :snoozed, …) and absent on :exception, where the worker is the signal.
+  defp oban_job_tags(meta) do
+    %{
+      queue: meta.job.queue,
+      worker: meta.job.worker,
+      state: Map.get(meta, :state, "exception")
+    }
   end
 
   def metrics do
@@ -265,12 +318,15 @@ defmodule FountainWeb.Telemetry do
   end
 
   defp periodic_measurements do
-    # Funnel stage gauges (#282). Full-table pass over users every tick —
-    # cheap at current scale; Fountain.Funnel's moduledoc says when to
-    # revisit. Off in test: the poller's Repo calls would race the
-    # SQL Sandbox's connection ownership.
+    # Funnel stage gauges (#282) and ops gauges (#321). Full-table passes
+    # every tick — cheap at current scale. Off in test: the poller's Repo
+    # calls would race the SQL Sandbox's connection ownership (the modules
+    # are exercised directly by tests instead).
     if Application.get_env(:fountain, :funnel_poller_enabled, true) do
-      [{Fountain.Funnel, :emit_telemetry, []}]
+      [
+        {Fountain.Funnel, :emit_telemetry, []},
+        {Fountain.OpsGauges, :emit_telemetry, []}
+      ]
     else
       []
     end

--- a/apps/fountain/test/fountain/ops_gauges_test.exs
+++ b/apps/fountain/test/fountain/ops_gauges_test.exs
@@ -1,0 +1,86 @@
+defmodule Fountain.OpsGaugesTest do
+  # #321: conversation/sandbox count gauges and Oban queue metrics. The
+  # poller is off in test (funnel_poller_enabled: false), so these call
+  # emit_telemetry/0 directly — the same function the poller invokes.
+  use Fountain.DataCase, async: false
+
+  alias Fountain.OpsGauges
+
+  defp attach(events) do
+    ref = make_ref()
+    test = self()
+
+    for event <- events do
+      :telemetry.attach(
+        {ref, event},
+        event,
+        fn ev, measurements, meta, _ -> send(test, {:telemetry, ev, measurements, meta}) end,
+        nil
+      )
+    end
+
+    on_exit(fn ->
+      for event <- events, do: :telemetry.detach({ref, event})
+    end)
+  end
+
+  test "emits a datapoint for every known status, zeros included" do
+    attach([[:fountain, :conversations], [:fountain, :sandboxes], [:fountain, :oban_queue]])
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    insert_conversation(user_id: user.id, agent_id: agent.id, status: "idle")
+
+    assert :ok = OpsGauges.emit_telemetry()
+
+    # One series per conversation status — the zero series must exist too,
+    # or alerts can't see recovery and panels only appear mid-incident.
+    for status <- Fountain.Conversations.Conversation.statuses() do
+      expected = if status == "idle", do: 1, else: 0
+
+      assert_receive {:telemetry, [:fountain, :conversations], %{count: ^expected},
+                      %{status: ^status}}
+    end
+
+    for status <- Fountain.Conversations.Sandbox.statuses() do
+      assert_receive {:telemetry, [:fountain, :sandboxes], %{count: _}, %{status: ^status}}
+    end
+
+    # Every configured queue × watched state, zeros included.
+    for queue <- ~w(maintenance billing exports),
+        state <- ~w(available scheduled executing retryable discarded) do
+      assert_receive {:telemetry, [:fountain, :oban_queue], %{depth: _},
+                      %{queue: ^queue, state: ^state}}
+    end
+  end
+
+  test "counts queued Oban jobs by queue and state" do
+    attach([[:fountain, :oban_queue]])
+
+    Repo.insert!(%Oban.Job{queue: "maintenance", worker: "Test.Worker", state: "available"})
+    Repo.insert!(%Oban.Job{queue: "maintenance", worker: "Test.Worker", state: "available"})
+    Repo.insert!(%Oban.Job{queue: "exports", worker: "Test.Worker", state: "discarded"})
+
+    assert :ok = OpsGauges.emit_telemetry()
+
+    assert_receive {:telemetry, [:fountain, :oban_queue], %{depth: 2},
+                    %{queue: "maintenance", state: "available"}}
+
+    assert_receive {:telemetry, [:fountain, :oban_queue], %{depth: 1},
+                    %{queue: "exports", state: "discarded"}}
+  end
+
+  test "a raising tick is skipped, not propagated — the poller trap (#365)" do
+    import ExUnit.CaptureLog
+
+    # Corrupt the Oban config so the tick raises mid-function — the shape of
+    # any transient failure. It must rescue: telemetry_poller permanently
+    # drops a measurement whose tick raises.
+    previous = Application.fetch_env!(:fountain, Oban)
+    Application.put_env(:fountain, Oban, :corrupt)
+    on_exit(fn -> Application.put_env(:fountain, Oban, previous) end)
+
+    log = capture_log(fn -> assert :ok = OpsGauges.emit_telemetry() end)
+    assert log =~ "ops gauges tick skipped"
+  end
+end

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -95,6 +95,14 @@ defmodule FountainWeb.MetricsTest do
         [:fountain, :sandbox, :reclaimed],
         [:fountain, :reaper, :run],
         [:fountain, :reaper, :untracked],
+        # Fountain.OpsGauges.emit_telemetry/0 (#321) — exercised directly by
+        # Fountain.OpsGaugesTest since the poller is off in test
+        [:fountain, :conversations],
+        [:fountain, :sandboxes],
+        [:fountain, :oban_queue],
+        # Emitted by Oban itself around every job execution
+        [:oban, :job, :stop],
+        [:oban, :job, :exception],
         # Library-emitted
         [:phoenix, :router_dispatch, :stop],
         [:phoenix, :router_dispatch, :exception],
@@ -148,6 +156,44 @@ defmodule FountainWeb.MetricsTest do
       # conv_id is metadata, never a label — one series per conversation
       # would eat Prometheus.
       refute body =~ "conv_id="
+    end
+
+    test "ops gauges and Oban events land in the scrape (#321)" do
+      :telemetry.execute([:fountain, :conversations], %{count: 3}, %{status: "idle"})
+      :telemetry.execute([:fountain, :oban_queue], %{depth: 2}, %{
+        queue: "maintenance",
+        state: "available"
+      })
+
+      job = %Oban.Job{queue: "maintenance", worker: "Fountain.Workers.SandboxReaper"}
+      :telemetry.execute([:oban, :job, :stop], %{duration: 1_000}, %{job: job, state: :success})
+
+      :telemetry.execute([:oban, :job, :exception], %{duration: 1_000}, %{
+        job: job,
+        kind: :error,
+        reason: %RuntimeError{message: "boom"},
+        stacktrace: []
+      })
+
+      Process.sleep(50)
+      {200, body} = scrape()
+
+      assert Regex.match?(~r/fountain_conversations_count\{[^}]*status="idle"[^}]*\} 3/, body)
+
+      assert Regex.match?(
+               ~r/fountain_oban_queue_depth\{[^}]*queue="maintenance"[^}]*state="available"[^}]*\} 2/,
+               body
+             )
+
+      assert Regex.match?(
+               ~r/fountain_oban_job_stop_count\{[^}]*queue="maintenance"[^}]*state="success"[^}]*\}/,
+               body
+             )
+
+      assert Regex.match?(
+               ~r/fountain_oban_job_exception_count\{[^}]*worker="Fountain.Workers.SandboxReaper"[^}]*\}/,
+               body
+             )
     end
 
     test "route tags are the matched pattern, not the raw path", %{conn: conn} do

--- a/k8s/prometheusrule.yaml
+++ b/k8s/prometheusrule.yaml
@@ -315,3 +315,64 @@ spec:
               that fail to start. Most likely causes: the platform
               SPRITES_TOKEN is invalid or rate-limited, the Sprites API is
               unhealthy, or tenants are hitting the concurrency cap.
+
+    # ── Oban background jobs (#321) ───────────────────────────────────────
+    #
+    # Oban catches job exceptions internally and reports them only via
+    # telemetry — no process crashes, so neither Sentry's LoggerHandler nor
+    # any crash report sees a failing nightly RetentionPruner or hourly
+    # SandboxReaper. These watch the metrics the app exports from Oban's
+    # own events (fountain_oban_job_*) and the polled queue-depth gauge.
+    - name: fountain-oban
+      interval: 60s
+      rules:
+        - alert: FountainObanJobsRaising
+          # Every raising execution counts, including retries — the early
+          # signal, while Oban is still retrying and the job might yet
+          # succeed. Worker is in the labels so the page says which job.
+          expr: |
+            sum by (queue, worker) (increase(fountain_oban_job_exception_count{namespace="fountain"}[1h])) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: "Oban jobs are raising in {{ $labels.queue }} ({{ $labels.worker }})"
+            description: |
+              {{ $value }} raising execution(s) in the last hour. Oban retries
+              with backoff, so this may self-heal — but a persistently raising
+              maintenance job means reaping/pruning/metering is not happening.
+              Detail is in Sentry only if the worker reports it explicitly;
+              check the job row's errors array:
+              kubectl exec -n fountain fountain-pg-1 -c postgres -- \
+                psql -U postgres fountain -c "select id, worker, state, attempt, errors[array_upper(errors,1)] from oban_jobs where queue='{{ $labels.queue }}' order by id desc limit 5"
+        - alert: FountainObanJobsDiscarded
+          # A discarded job exhausted every retry and failed permanently.
+          # delta on the gauge rather than a static > 0: discarded rows sit
+          # for 7 days until Oban's Pruner removes them, and an alert that
+          # stays red for a week after one bad job trains people to ignore it.
+          expr: |
+            delta(fountain_oban_queue_depth{namespace="fountain", state="discarded"}[2h]) > 0
+          labels:
+            severity: critical
+          annotations:
+            summary: "An Oban job in {{ $labels.queue }} was discarded (all retries exhausted)"
+            description: |
+              The scheduled work this job represents did not happen — for the
+              maintenance queue that means reaping, retention or metering
+              silently stopped. Inspect and re-run:
+              kubectl exec -n fountain fountain-pg-1 -c postgres -- \
+                psql -U postgres fountain -c "select id, worker, errors[array_upper(errors,1)] from oban_jobs where state='discarded' order by id desc limit 5"
+        - alert: FountainObanQueueBacklog
+          # available = runnable now but not picked up. A sustained backlog
+          # means concurrency is saturated or a worker is wedged.
+          expr: |
+            fountain_oban_queue_depth{namespace="fountain", state="available"} > 25
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Oban queue {{ $labels.queue }} has a sustained backlog"
+            description: |
+              {{ $value }} jobs runnable-but-waiting for 30m. Check whether
+              the queue's workers are wedged (executing depth pinned at its
+              concurrency limit) or something is enqueueing faster than the
+              queue drains.


### PR DESCRIPTION
## Summary
- New `Fountain.OpsGauges` fills the empty `periodic_measurements/0` scaffold: conversations and sandboxes by status, and Oban queue depth by queue × state (non-terminal states + `discarded`). Zeros are emitted for every known status/queue combination so series exist from boot — alerts can see recovery and panels don't materialize only mid-incident. Wrapped in the #365 rescue (a raising poller tick is dropped forever), with a test that corrupts config and asserts the tick is skipped, not propagated.
- `fountain_oban_job_stop_count{queue,state}` and `fountain_oban_job_exception_count{queue,worker}` hang directly off Oban's own telemetry events — no poller, no handler process. This is the visibility gap the issue centered on: Oban swallows job exceptions internally, so nothing else ever saw a failing `RetentionPruner`/`SandboxReaper`.
- Three alerts in `k8s/prometheusrule.yaml` (`fountain-oban` group): **FountainObanJobsRaising** (warning, per-worker, includes retries — the early signal), **FountainObanJobsDiscarded** (critical, `delta` on the gauge rather than `> 0` so one bad job doesn't stay red for the Pruner's 7-day window), **FountainObanQueueBacklog** (warning, sustained `available` depth).
- The #310 producer-liveness guard test gains the five new event names, and an e2e scrape test asserts all four new metric families render with correct labels.
- Follow-up (not here): Grafana panels for the new series in the #277 dashboard.
- Note: the reaper's existing `[:fountain, :reaper, :run]` released/expired sums were already subscribed post-#364; the issue's mention predates that fix.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)