### PR TITLE
conversations: deliver the initial prompt to the pid, not through the registry (#367)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -821,10 +821,10 @@ defmodule Fountain.Conversations do
         )
 
       case start_result do
-        {:ok, _pid} ->
+        {:ok, pid} ->
           if is_binary(attrs["prompt"]) and attrs["prompt"] != "" do
             ConversationServer.queue_initial_prompt(
-              conv.id,
+              pid,
               attrs["prompt"],
               attrs["images"] || []
             )
@@ -1025,7 +1025,7 @@ defmodule Fountain.Conversations do
   # provisioning finishes; if provisioning fails the server stops and the cast
   # dies with it, which is the right outcome — no turn on a failed provision.
   defp start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt) do
-    with {:ok, _pid} <-
+    with {:ok, pid} <-
            Horde.DynamicSupervisor.start_child(
              Fountain.ConversationSupervisor,
              {ConversationServer,
@@ -1036,7 +1036,7 @@ defmodule Fountain.Conversations do
               ]}
            ) do
       if is_binary(initial_prompt) and initial_prompt != "" do
-        ConversationServer.queue_initial_prompt(conv.id, initial_prompt)
+        ConversationServer.queue_initial_prompt(pid, initial_prompt)
       end
 
       {:ok, _unsafe_get_conversation!(conv.id)}
@@ -1068,7 +1068,7 @@ defmodule Fountain.Conversations do
         {:ok, _} = ok ->
           ok
 
-        {:error, {:already_started, _pid}} ->
+        {:error, {:already_started, winner_pid}} ->
           # Lost a concurrent wake of the same conversation. The winner's
           # server is running against its own sandbox; this one's just-created
           # row would otherwise sit pending — holding a quota slot — until the
@@ -1079,7 +1079,7 @@ defmodule Fountain.Conversations do
           _ = mark_old_sandbox_terminated(new_sandbox.id)
 
           if is_binary(initial_prompt) and initial_prompt != "" do
-            ConversationServer.queue_initial_prompt(conv.id, initial_prompt)
+            ConversationServer.queue_initial_prompt(winner_pid, initial_prompt)
           end
 
           {:ok, _unsafe_get_conversation!(conv.id)}

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -85,11 +85,18 @@ defmodule Fountain.Conversations.ConversationServer do
   cluster membership change — which every deploy causes. A prompt in the spec
   therefore re-ran the user's last message on each rollout.
 
+  Takes the pid `start_child` returned, not the conversation id: Horde's
+  registry is a CRDT whose registrations propagate asynchronously, and a cast
+  to a via-name that hasn't resolved yet is a silent no-op — the server
+  provisions, the user's first prompt is simply gone (#367). The pid needs no
+  resolution, works across nodes, and is for exactly the server just started;
+  if that server already died, losing the cast is the right outcome.
+
   A cast rather than a call: it queues behind `handle_continue(:provision)`,
   which can take minutes, and no caller is waiting on the turn to finish.
   """
-  def queue_initial_prompt(conv_id, prompt, images \\ []) do
-    GenServer.cast(via(conv_id), {:initial_prompt, prompt, images})
+  def queue_initial_prompt(pid, prompt, images \\ []) when is_pid(pid) do
+    GenServer.cast(pid, {:initial_prompt, prompt, images})
   end
 
   def interrupt(conv_id) do

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -99,6 +99,32 @@ defmodule Fountain.Conversations.ConversationServerTest do
       assert Conversations._unsafe_list_turns(conv.id) == []
       GenServer.stop(pid)
     end
+
+    test "the prompt reaches a server the Horde registry cannot resolve", %{conv: conv} do
+      # The #367 regression: queue_initial_prompt used to cast through the
+      # Horde registry, and Horde's CRDT registrations propagate
+      # asynchronously — a cast fired right after start_child could hit an
+      # unresolved via-name and vanish. The server provisioned, the user's
+      # first prompt was silently gone. Delivery now targets the pid, which
+      # this harness proves by construction: its servers run outside Horde,
+      # so the registry genuinely cannot resolve them.
+      stub_happy_sprite()
+
+      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
+        {:ok, %{ref: make_ref(), pid: self()}}
+      end)
+
+      Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
+      Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+
+      {pid, _ref, :alive} = start_server(conv, initial_prompt: "first prompt")
+
+      assert Horde.Registry.lookup(Fountain.ConversationRegistry, conv.id) == []
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.prompt == "first prompt"
+
+      GenServer.stop(pid)
+    end
   end
 
   describe "provisioning — tenant isolation" do

--- a/apps/fountain/test/fountain/conversations/prompt_replay_test.exs
+++ b/apps/fountain/test/fountain/conversations/prompt_replay_test.exs
@@ -41,7 +41,9 @@ defmodule Fountain.Conversations.PromptReplayTest do
     # Capture what would be handed to Horde, and do not actually start anything.
     stub(Horde.DynamicSupervisor, :start_child, fn _sup, spec ->
       send(test, {:child_spec, spec})
-      {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+      pid = spawn(fn -> Process.sleep(:infinity) end)
+      send(test, {:started_pid, pid})
+      {:ok, pid}
     end)
 
     stub(Conversations.ConversationServer, :queue_initial_prompt, fn id, prompt, images ->
@@ -77,11 +79,15 @@ defmodule Fountain.Conversations.PromptReplayTest do
     end
 
     test "delivers the prompt out of band instead", %{conv: conv} do
-      # It must still arrive — the fix is about how, not whether.
+      # It must still arrive — the fix is about how, not whether. And it goes
+      # to the pid start_child returned, not through the registry: a cast to
+      # a not-yet-propagated via-name is a silent no-op that eats the first
+      # prompt (#367).
       {:ok, _} = Conversations.wake_conversation(conv.id, "run the migration")
 
-      assert_received {:queued_prompt, conv_id, "run the migration", _}
-      assert conv_id == conv.id
+      assert_received {:started_pid, started_pid}
+      assert_received {:queued_prompt, target, "run the migration", _}
+      assert target == started_pid
     end
 
     test "waking without a prompt queues nothing", %{conv: conv} do

--- a/apps/fountain/test/fountain_web/live/conversations_live/new_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/new_test.exs
@@ -85,8 +85,10 @@ defmodule FountainWeb.ConversationsLive.NewSubmitTest do
     end
 
     test "redirects to the new conversation on success", %{lv: lv, agent: agent} do
+      # A real (inert) pid: since #367 the initial prompt is cast to the pid
+      # start_child returned, so the stand-in must satisfy the is_pid guard.
       stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
-        {:ok, :test_pid}
+        {:ok, spawn(fn -> Process.sleep(:infinity) end)}
       end)
 
       params = %{"agent_id" => agent.id, "prompt" => "hello", "vault_id" => ""}

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -110,12 +110,20 @@ defmodule Fountain.ConversationServerCase do
 
     # The prompt is delivered out of band, exactly as production does it: it is
     # not a start_link argument, because Horde replays a stored child spec on
-    # every redistribution and would re-run the prompt on each deploy. Cast to
-    # the pid rather than through the registry, since this harness starts the
-    # server outside Horde.
+    # every redistribution and would re-run the prompt on each deploy. Since
+    # #367 the public API delivers to the pid, so this harness — whose servers
+    # are outside Horde and invisible to the registry — exercises the exact
+    # production path.
     case Keyword.get(opts, :initial_prompt) do
-      nil -> :ok
-      prompt -> GenServer.cast(pid, {:initial_prompt, prompt, Keyword.get(opts, :images, [])})
+      nil ->
+        :ok
+
+      prompt ->
+        Fountain.Conversations.ConversationServer.queue_initial_prompt(
+          pid,
+          prompt,
+          Keyword.get(opts, :images, [])
+        )
     end
 
     # handle_continue(:provision) runs before any call is answered, so a


### PR DESCRIPTION
Fixes #367 (found on prod while verifying #310's `fountain_stage_count`: provision succeeded, 201 returned, zero turns — the first prompt silently vanished).

## Root cause

`queue_initial_prompt/3` cast to `via(conv_id)` immediately after `Horde.DynamicSupervisor.start_child`. Horde's registry is a CRDT with asynchronous propagation, and `GenServer.cast` to an unresolved via-name is a silent no-op. Nothing fails, nothing logs — the sprite provisions and bills, the client waits on a stream that never produces a turn.

## Fix

`queue_initial_prompt(pid, prompt, images \\ [])` — the caller passes the pid it already has:

- `start_conversation/1` and `start_conversation_server/4`: the pid from `{:ok, pid}`.
- The `{:error, {:already_started, winner_pid}}` arm of `create_fresh_sandbox_and_start` (#330's loser-forwards-prompt path): the winner's pid.

A pid cast needs no resolution, is delivered across Distributed Erlang nodes (Horde may place the child on the other pod), and is addressed to exactly the server just started — if that server died, losing the cast is the correct outcome (no turn on a failed provision).

## Tests

- The `ConversationServerCase` harness now queues prompts through the public function. Its servers run **outside Horde** — the registry genuinely cannot resolve them — so every existing initial-prompt test now exercises the production delivery path by construction.
- New regression test asserts `Horde.Registry.lookup(...) == []` while the prompt still produces a turn.
- `prompt_replay_test` "delivers out of band" now asserts the queued target **is the pid `start_child` returned**.
- One LiveView test stubbed `start_child` with `{:ok, :test_pid}`; it now returns a real inert pid to satisfy the `is_pid` guard.

Reverting the lib change fails 9 tests. `mix precommit` green: 1757 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)