### PR TITLE
security: Stripe webhook fails closed when STRIPE_WEBHOOK_SECRET is unset (#390)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/stripe_webhook_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/stripe_webhook_controller.ex
@@ -10,6 +10,11 @@ defmodule FountainWeb.StripeWebhookController do
   returned only on signature verification failure; Stripe uses this to detect
   misconfigured webhook secrets.
 
+  When no webhook secret is configured (nil or empty), every request is
+  rejected with 400 instead of being verified against an empty HMAC key (#390).
+  Signature verification is this route's only authentication, so a missing
+  secret must fail closed.
+
   The raw request body is read from `conn.assigns[:raw_body]`, which is populated
   by `FountainWeb.CachingBodyReader` before `Plug.Parsers` consumes it.
   """
@@ -21,9 +26,26 @@ defmodule FountainWeb.StripeWebhookController do
   require Logger
 
   def create(conn, _params) do
+    case webhook_secret() do
+      {:ok, secret} ->
+        verify_and_process(conn, secret)
+
+      :error ->
+        # Fail closed. `Stripe.Webhook.construct_event/3` computes a plain
+        # HMAC with whatever secret it is given — an empty string verifies
+        # "successfully" against a signature anyone can forge, turning this
+        # unauthenticated route into write access to subscription state.
+        Logger.error(
+          "[stripe_webhook] Rejecting webhook: STRIPE_WEBHOOK_SECRET is not configured"
+        )
+
+        send_resp(conn, 400, "Webhook secret not configured")
+    end
+  end
+
+  defp verify_and_process(conn, secret) do
     raw_body = conn.assigns[:raw_body] || ""
     sig_header = conn |> get_req_header("stripe-signature") |> List.first()
-    secret = webhook_secret()
 
     case Stripe.Webhook.construct_event(raw_body, sig_header, secret) do
       {:ok, event} ->
@@ -73,8 +95,14 @@ defmodule FountainWeb.StripeWebhookController do
       :retry
   end
 
+  # Single source of truth: config/runtime.exs writes STRIPE_WEBHOOK_SECRET
+  # to `:stripity_stripe, :webhook_secret`. (A previous version read
+  # `:fountain, :stripe_webhook_secret` — a key nothing sets — and fell back
+  # to `System.get_env(..., "")`, so an unset var meant verifying against "".)
   defp webhook_secret do
-    Application.get_env(:fountain, :stripe_webhook_secret) ||
-      System.get_env("STRIPE_WEBHOOK_SECRET", "")
+    case Application.get_env(:stripity_stripe, :webhook_secret) do
+      secret when is_binary(secret) and secret != "" -> {:ok, secret}
+      _ -> :error
+    end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/stripe_webhook_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/stripe_webhook_controller_test.exs
@@ -10,6 +10,29 @@ defmodule FountainWeb.StripeWebhookControllerTest do
   # it in assigns[:raw_body] so the controller can forward it to the mock.
   @raw_body ~s({"id":"evt_test_123","type":"customer.subscription.updated","data":{"object":{}}})
 
+  # A complete event body for the tests that exercise the REAL
+  # Stripe.Webhook.construct_event/3 — no stubbing, so the payload has to
+  # survive Stripe.Converter and the signature has to be genuine.
+  @signed_body ~s({"id":"evt_real_sig_test","object":"event","api_version":"2019-12-03",) <>
+                 ~s("type":"customer.subscription.updated",) <>
+                 ~s("data":{"object":{"id":"sub_real_sig_test","object":"subscription",) <>
+                 ~s("status":"active","customer":"cus_real_sig_unknown","trial_end":null}}})
+
+  defp stripe_signature(payload, secret, timestamp \\ System.system_time(:second)) do
+    signature =
+      :crypto.mac(:hmac, :sha256, secret, "#{timestamp}.#{payload}")
+      |> Base.encode16(case: :lower)
+
+    "t=#{timestamp},v1=#{signature}"
+  end
+
+  defp post_webhook(conn, body, sig_header) do
+    conn
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Plug.Conn.put_req_header("stripe-signature", sig_header)
+    |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :post, "/api/stripe/webhook", body)
+  end
+
   describe "POST /api/stripe/webhook" do
     test "returns 400 when Stripe signature verification fails", %{conn: conn} do
       stub(Stripe.Webhook, :construct_event, fn _body, _sig, _secret ->
@@ -74,6 +97,37 @@ defmodule FountainWeb.StripeWebhookControllerTest do
       # the apply path breaks.
       assert Fountain.Repo.get!(Fountain.Accounts.User, user.id).subscription_status ==
                "active"
+    end
+  end
+
+  describe "POST /api/stripe/webhook — real signature verification (no stub)" do
+    # These exercise the controller's secret resolution end to end. The
+    # pre-#390 code resolved the secret from an app-env key nothing sets and
+    # fell back to "", so it was never covered: every earlier test handed a
+    # stubbed construct_event whatever secret happened to resolve.
+
+    test "accepts a payload genuinely signed with the configured secret", %{conn: conn} do
+      secret = Application.fetch_env!(:stripity_stripe, :webhook_secret)
+      conn = post_webhook(conn, @signed_body, stripe_signature(@signed_body, secret))
+
+      # cus_real_sig_unknown matches no user; the controller logs and acks.
+      # What matters is that verification passed — a signature failure or a
+      # missing secret would be 400.
+      assert conn.status == 200
+    end
+
+    test "rejects a payload signed with an empty key", %{conn: conn} do
+      # The forgery #390 describes: with the secret unset, the old code
+      # verified against "", so exactly this request was accepted.
+      conn = post_webhook(conn, @signed_body, stripe_signature(@signed_body, ""))
+
+      assert conn.status == 400
+    end
+
+    test "rejects a payload signed with the wrong secret", %{conn: conn} do
+      conn = post_webhook(conn, @signed_body, stripe_signature(@signed_body, "whsec_other"))
+
+      assert conn.status == 400
     end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/stripe_webhook_secret_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/stripe_webhook_secret_test.exs
@@ -1,0 +1,63 @@
+defmodule FountainWeb.StripeWebhookSecretTest do
+  # async: false — these tests mutate the global :stripity_stripe application
+  # env to simulate an instance where STRIPE_WEBHOOK_SECRET was never set.
+  use FountainWeb.ConnCase, async: false
+
+  # Regression tests for #390: with no webhook secret configured, the old
+  # controller verified signatures against "" — a key anyone can compute
+  # with — so a forged event reached Billing.handle_event/1 on any instance
+  # (e.g. every self-hosted one) that never set STRIPE_WEBHOOK_SECRET.
+  #
+  # Per the audit lesson, the missing-secret cases must supply the empty
+  # value as well as the absent one: `${VAR:-}`-style deployment plumbing
+  # produces "", not nil, and "" is truthy.
+
+  @signed_body ~s({"id":"evt_no_secret_test","object":"event","api_version":"2019-12-03",) <>
+                 ~s("type":"customer.subscription.updated",) <>
+                 ~s("data":{"object":{"id":"sub_no_secret_test","object":"subscription",) <>
+                 ~s("status":"active","customer":"cus_no_secret_unknown","trial_end":null}}})
+
+  setup do
+    original = Application.fetch_env!(:stripity_stripe, :webhook_secret)
+    on_exit(fn -> Application.put_env(:stripity_stripe, :webhook_secret, original) end)
+    :ok
+  end
+
+  defp forge(conn, key) do
+    # Exactly what an attacker sends: a fresh timestamp and a v1 signature
+    # HMAC'd with the guessed key.
+    timestamp = System.system_time(:second)
+
+    signature =
+      :crypto.mac(:hmac, :sha256, key, "#{timestamp}.#{@signed_body}")
+      |> Base.encode16(case: :lower)
+
+    conn
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Plug.Conn.put_req_header("stripe-signature", "t=#{timestamp},v1=#{signature}")
+    |> Phoenix.ConnTest.dispatch(
+      FountainWeb.Endpoint,
+      :post,
+      "/api/stripe/webhook",
+      @signed_body
+    )
+  end
+
+  test "rejects an empty-key forgery when the secret is unset (nil)", %{conn: conn} do
+    Application.put_env(:stripity_stripe, :webhook_secret, nil)
+
+    conn = forge(conn, "")
+
+    assert conn.status == 400
+    assert conn.resp_body =~ "not configured"
+  end
+
+  test "rejects an empty-key forgery when the secret is set but blank", %{conn: conn} do
+    Application.put_env(:stripity_stripe, :webhook_secret, "")
+
+    conn = forge(conn, "")
+
+    assert conn.status == 400
+    assert conn.resp_body =~ "not configured"
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -291,9 +291,28 @@ if github_client_id = System.get_env("GITHUB_OAUTH_CLIENT_ID") do
 end
 
 # Stripe (§5.2)
-config :stripity_stripe,
-  api_key: System.get_env("STRIPE_SECRET_KEY"),
-  webhook_secret: System.get_env("STRIPE_WEBHOOK_SECRET")
+config :stripity_stripe, api_key: System.get_env("STRIPE_SECRET_KEY")
+
+# Absent stays absent, and "" counts as absent (#390). An unconditional write
+# would clobber the secret config/test.exs pins with nil, and a blank value
+# must never reach signature verification — Stripe.Webhook.construct_event
+# happily HMACs with an empty key, so the webhook controller fails closed
+# when this is unset. A billing-enabled prod instance without the secret
+# cannot process any subscription event, so refuse to boot rather than let
+# every webhook 400 quietly.
+case System.get_env("STRIPE_WEBHOOK_SECRET") do
+  blank when blank in [nil, ""] ->
+    if config_env() == :prod and System.get_env("BILLING_ENABLED", "false") != "false" do
+      raise """
+      BILLING_ENABLED is set but STRIPE_WEBHOOK_SECRET is empty or unset.
+      Set it to the signing secret of your Stripe webhook endpoint
+      (Stripe dashboard → Developers → Webhooks).
+      """
+    end
+
+  secret ->
+    config :stripity_stripe, webhook_secret: secret
+end
 
 # Stripe Price ID for the subscription tier surfaced by Checkout.
 # Set per environment (test-mode price in dev, live-mode price in prod).

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,6 +30,11 @@ config :ueberauth, Ueberauth.Strategy.Github.OAuth,
 # toggles it per-test via the application env.
 config :fountain, :billing_enabled, true
 
+# A known webhook secret so StripeWebhookController's fail-closed secret
+# resolution (#390) succeeds; signature-path tests sign payloads with the
+# value they read back from this key, exercising the real construct_event.
+config :stripity_stripe, webhook_secret: "whsec_test_signing_secret"
+
 # Key rate limit buckets by calling process PID instead of IP, so async
 # ExUnit tests don't share counters. Each test runs in its own process.
 config :fountain, :rate_limit_test_isolation, true


### PR DESCRIPTION
Closes #390 (P0, audit-2026-08-03 #416).

## Problem

`StripeWebhookController` resolved its signing secret from `:fountain, :stripe_webhook_secret` — a key nothing sets — then fell back to `System.get_env("STRIPE_WEBHOOK_SECRET", "")`. `Stripe.Webhook.construct_event/3` happily HMACs with an empty key, so on any instance without the env var (every self-hosted instance with billing off), `POST /api/stripe/webhook` accepted forged events: paid-access bypass via `checkout.session.completed`, and forced cancellation via subscription-lifecycle events.

## Fix

- The controller reads `:stripity_stripe, :webhook_secret` — the one key `config/runtime.exs` actually writes — and **rejects with 400 when it is nil or empty**, before any verification runs.
- `runtime.exs` only writes the key when the env var is present and non-blank (the audit's "empty string is truthy" idiom; an unconditional write also clobbered the test-pinned secret with nil), and **raises at boot** if a prod instance sets `BILLING_ENABLED` without a webhook secret — silent 400s on every real event would be strictly worse.
- The dead `:fountain, :stripe_webhook_secret` lookup is gone; one source of truth.

## Tests

The old suite stubbed `construct_event` everywhere, so secret resolution was never exercised. Added:

- Real-verification tests (no stub): genuinely signed payload → 200; empty-key forgery → 400; wrong-key forgery → 400.
- `StripeWebhookSecretTest` (`async: false`, app-env swap with restore): the exact pre-fix forgery — empty-key signature with the secret **nil** and with it **""** (the `${VAR:-}` deployment case) → 400.

Reverting just the controller fix makes 4 of the new tests fail, so they catch the bug they claim to.

`mix precommit` green: 1,762 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)