### PR TITLE
security: keep the tenant DEK out of secret-form LiveView assigns (#391)

### DIFF
--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -11,19 +11,22 @@ defmodule FountainWeb.EnvironmentsLive.Form do
   def mount(params, _session, socket) do
     user_id = socket.assigns.current_user.id
     {env, action} = load(params, user_id)
-    {:ok, dek} = Crypto.load_tenant_key(user_id)
 
+    # No DEK in assigns (#391): LiveView crash reports dump the channel
+    # state — assigns included — to the logger and Sentry, and the tenant
+    # DEK decrypts every secret the tenant owns. add_secret loads it per
+    # write instead. Same reason the secret form below is uncontrolled:
+    # the in-flight plaintext must not live in assigns either.
     {:ok,
      socket
      |> assign(:page_title, page_title(action))
      |> assign(:user_id, user_id)
-     |> assign(:tenant_key, dek)
      |> assign(:action, action)
      |> assign(:env, env)
      |> assign(:form, env_to_form(env))
      |> assign(:errors, %{})
      |> assign(:secrets, secrets_for(env))
-     |> assign(:new_secret, %{"key" => "", "value" => ""})
+     |> assign(:secret_form_version, 0)
      |> assign(:repositories, env.repositories || [])
      |> assign(:env_vars, env_to_env_var_list(env.env_vars || %{}))
      |> assign(:packages, env_to_packages_strings(env.packages || %{}))
@@ -157,31 +160,27 @@ defmodule FountainWeb.EnvironmentsLive.Form do
     end
   end
 
-  def handle_event("validate_secret", %{"secret" => params}, socket) do
-    {:noreply, assign(socket, :new_secret, params)}
-  end
-
   def handle_event("add_secret", %{"secret" => %{"key" => k, "value" => v}}, socket)
       when k != "" and v != "" do
-    case Environments.upsert_secret(
-           socket.assigns.env,
-           %{"key" => k, "value" => v},
-           socket.assigns.tenant_key
-         ) do
-      {:ok, _} ->
-        FountainWeb.Audited.from_socket(socket, "environment.secret.write", "secret",
-          resource_id: socket.assigns.env.id,
-          metadata: %{"key" => k}
-        )
+    with {:ok, dek} <- Crypto.load_tenant_key(socket.assigns.user_id),
+         {:ok, _} <-
+           Environments.upsert_secret(socket.assigns.env, %{"key" => k, "value" => v}, dek) do
+      FountainWeb.Audited.from_socket(socket, "environment.secret.write", "secret",
+        resource_id: socket.assigns.env.id,
+        metadata: %{"key" => k}
+      )
 
-        {:noreply,
-         socket
-         |> assign(:secrets, secrets_for(socket.assigns.env))
-         |> assign(:new_secret, %{"key" => "", "value" => ""})
-         |> put_flash(:info, "Secret saved")}
-
-      {:error, cs} ->
+      {:noreply,
+       socket
+       |> assign(:secrets, secrets_for(socket.assigns.env))
+       |> update(:secret_form_version, &(&1 + 1))
+       |> put_flash(:info, "Secret saved")}
+    else
+      {:error, %Ecto.Changeset{} = cs} ->
         {:noreply, put_flash(socket, :error, secret_error(cs))}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, "Could not load encryption key: #{inspect(reason)}")}
     end
   end
 
@@ -563,11 +562,19 @@ defmodule FountainWeb.EnvironmentsLive.Form do
           </tbody>
         </table>
 
-        <form phx-change="validate_secret" phx-submit="add_secret" class="flex flex-col sm:flex-row gap-2">
-          <input type="text" name="secret[key]" value={@new_secret["key"]} placeholder="KEY"
+        <%!-- Uncontrolled on purpose (#391): no phx-change, no value bindings,
+              so the plaintext never round-trips per keystroke or sits in
+              assigns. The versioned id replaces the DOM node after a
+              successful save, which is what clears the fields. --%>
+        <form
+          id={"env-secret-form-#{@secret_form_version}"}
+          phx-submit="add_secret"
+          class="flex flex-col sm:flex-row gap-2"
+        >
+          <input type="text" name="secret[key]" placeholder="KEY"
             pattern="[A-Z][A-Z0-9_]*"
             class="flex-1 rounded border border-zinc-300 px-3 py-2 text-sm font-mono"/>
-          <input type="password" name="secret[value]" value={@new_secret["value"]} placeholder="value"
+          <input type="password" name="secret[value]" placeholder="value"
             class="flex-[2] rounded border border-zinc-300 px-3 py-2 text-sm font-mono"/>
           <.btn type="submit">Add secret</.btn>
         </form>

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -9,19 +9,22 @@ defmodule FountainWeb.VaultsLive.Form do
   def mount(params, _session, socket) do
     user_id = socket.assigns.current_user.id
     {vault, action} = load(params, user_id)
-    {:ok, dek} = Crypto.load_tenant_key(user_id)
 
+    # No DEK in assigns (#391): LiveView crash reports dump the channel
+    # state — assigns included — to the logger and Sentry, and the tenant
+    # DEK decrypts every secret the tenant owns. add_secret loads it per
+    # write instead. Same reason the secret form below is uncontrolled:
+    # the in-flight plaintext must not live in assigns either.
     {:ok,
      socket
      |> assign(:page_title, page_title(action))
      |> assign(:user_id, user_id)
-     |> assign(:tenant_key, dek)
      |> assign(:action, action)
      |> assign(:vault, vault)
      |> assign(:form, vault_to_form(vault))
      |> assign(:errors, %{})
      |> assign(:secrets, secrets_for(vault))
-     |> assign(:new_secret, %{"key" => "", "value" => ""})}
+     |> assign(:secret_form_version, 0)}
   end
 
   defp load(%{"id" => id}, user_id), do: {Vaults.get_vault!(id, user_id), :edit}
@@ -50,27 +53,26 @@ defmodule FountainWeb.VaultsLive.Form do
     save(socket, params)
   end
 
-  def handle_event("validate_secret", %{"secret" => params}, socket) do
-    {:noreply, assign(socket, :new_secret, params)}
-  end
-
   def handle_event("add_secret", %{"secret" => %{"key" => k, "value" => v}}, socket)
       when k != "" and v != "" do
-    case Vaults.upsert_secret(socket.assigns.vault, %{"key" => k, "value" => v}, socket.assigns.tenant_key) do
-      {:ok, _} ->
-        FountainWeb.Audited.from_socket(socket, "vault.secret.write", "vault_secret",
-          resource_id: socket.assigns.vault.id,
-          metadata: %{"key" => k}
-        )
+    with {:ok, dek} <- Crypto.load_tenant_key(socket.assigns.user_id),
+         {:ok, _} <- Vaults.upsert_secret(socket.assigns.vault, %{"key" => k, "value" => v}, dek) do
+      FountainWeb.Audited.from_socket(socket, "vault.secret.write", "vault_secret",
+        resource_id: socket.assigns.vault.id,
+        metadata: %{"key" => k}
+      )
 
-        {:noreply,
-         socket
-         |> assign(:secrets, secrets_for(socket.assigns.vault))
-         |> assign(:new_secret, %{"key" => "", "value" => ""})
-         |> put_flash(:info, "Secret saved")}
-
-      {:error, cs} ->
+      {:noreply,
+       socket
+       |> assign(:secrets, secrets_for(socket.assigns.vault))
+       |> update(:secret_form_version, &(&1 + 1))
+       |> put_flash(:info, "Secret saved")}
+    else
+      {:error, %Ecto.Changeset{} = cs} ->
         {:noreply, put_flash(socket, :error, secret_error(cs))}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, "Could not load encryption key: #{inspect(reason)}")}
     end
   end
 
@@ -177,11 +179,19 @@ defmodule FountainWeb.VaultsLive.Form do
           </tbody>
         </table>
 
-        <form phx-change="validate_secret" phx-submit="add_secret" class="flex flex-col sm:flex-row gap-2">
-          <input type="text" name="secret[key]" value={@new_secret["key"]} placeholder="KEY"
+        <%!-- Uncontrolled on purpose (#391): no phx-change, no value bindings,
+              so the plaintext never round-trips per keystroke or sits in
+              assigns. The versioned id replaces the DOM node after a
+              successful save, which is what clears the fields. --%>
+        <form
+          id={"vault-secret-form-#{@secret_form_version}"}
+          phx-submit="add_secret"
+          class="flex flex-col sm:flex-row gap-2"
+        >
+          <input type="text" name="secret[key]" placeholder="KEY"
             pattern="[A-Z][A-Z0-9_]*"
             class="flex-1 rounded border border-zinc-300 px-3 py-2 text-sm font-mono"/>
-          <input type="password" name="secret[value]" value={@new_secret["value"]} placeholder="value"
+          <input type="password" name="secret[value]" placeholder="value"
             class="flex-[2] rounded border border-zinc-300 px-3 py-2 text-sm font-mono"/>
           <.btn type="submit">Add secret</.btn>
         </form>

--- a/apps/fountain/test/fountain_web/live/secret_forms_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/secret_forms_live_test.exs
@@ -1,0 +1,138 @@
+defmodule FountainWeb.SecretFormsLiveTest do
+  use FountainWeb.ConnCase, async: true
+
+  import Mimic
+  import Phoenix.LiveViewTest
+
+  alias Fountain.{Crypto, Environments, Vaults}
+
+  # Regression tests for #391: the environment and vault forms used to unwrap
+  # the tenant DEK at mount and hold it in socket assigns for the life of the
+  # LiveView. LiveView crash reports dump the channel state — assigns included —
+  # to the logger and to Sentry, so any unhandled exception leaked the key that
+  # decrypts the tenant's entire secret set (plus whatever secret was being
+  # typed, via the :new_secret assign refreshed on every phx-change).
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, conn: login_user(conn, user), user: user}
+  end
+
+  # The DEK is 32 random bytes, so a byte-level scan of the serialized process
+  # state cannot false-positive. :sys.get_state reaches the LiveView channel
+  # process — the same state OTP would put in a crash report.
+  defp refute_in_state(view, bytes) do
+    state_bin = view.pid |> :sys.get_state() |> :erlang.term_to_binary()
+    assert :binary.match(state_bin, bytes) == :nomatch
+  end
+
+  describe "EnvironmentsLive.Form secrets (#391)" do
+    setup %{user: user} do
+      {:ok, env: insert_env(user_id: user.id)}
+    end
+
+    test "never holds the tenant DEK or plaintext secret in process state",
+         %{conn: conn, user: user, env: env} do
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      value = "plaintext-sentinel-2b0c9e41"
+
+      {:ok, view, _html} = live(conn, ~p"/environments/#{env.id}/edit")
+      refute_in_state(view, dek)
+
+      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => value}})
+
+      assert html =~ "Secret saved"
+      refute_in_state(view, dek)
+      refute_in_state(view, value)
+    end
+
+    test "add_secret persists through the handler-scoped DEK and resets the form",
+         %{conn: conn, user: user, env: env} do
+      {:ok, view, html} = live(conn, ~p"/environments/#{env.id}/edit")
+      assert html =~ "env-secret-form-0"
+
+      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => "v1"}})
+
+      assert html =~ "TOKEN"
+      # The versioned form id is the reset mechanism for the uncontrolled
+      # inputs — a stale id means the fields keep the submitted plaintext.
+      assert html =~ "env-secret-form-1"
+
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      assert Environments.decrypted_env(env, dek) == %{"TOKEN" => "v1"}
+    end
+
+    test "add_secret flashes instead of crashing when the tenant key cannot be loaded",
+         %{conn: conn, env: env} do
+      {:ok, view, _html} = live(conn, ~p"/environments/#{env.id}/edit")
+
+      stub(Fountain.Crypto, :load_tenant_key, fn _user_id -> {:error, :unwrap_failed} end)
+
+      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => "v"}})
+
+      assert html =~ "Could not load encryption key"
+      assert Process.alive?(view.pid)
+    end
+
+    test "mounts without touching the tenant key at all", %{conn: conn, env: env} do
+      # Pre-#391 mount did `{:ok, dek} = Crypto.load_tenant_key(user_id)`,
+      # so an unwrap failure was a MatchError before first render.
+      stub(Fountain.Crypto, :load_tenant_key, fn _user_id -> {:error, :unwrap_failed} end)
+
+      assert {:ok, _view, _html} = live(conn, ~p"/environments/#{env.id}/edit")
+    end
+  end
+
+  describe "VaultsLive.Form secrets (#391)" do
+    setup %{user: user} do
+      {:ok, vault: insert_vault(user_id: user.id)}
+    end
+
+    test "never holds the tenant DEK or plaintext secret in process state",
+         %{conn: conn, user: user, vault: vault} do
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      value = "plaintext-sentinel-7d4a1f83"
+
+      {:ok, view, _html} = live(conn, ~p"/vaults/#{vault.id}/edit")
+      refute_in_state(view, dek)
+
+      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => value}})
+
+      assert html =~ "Secret saved"
+      refute_in_state(view, dek)
+      refute_in_state(view, value)
+    end
+
+    test "add_secret persists through the handler-scoped DEK and resets the form",
+         %{conn: conn, user: user, vault: vault} do
+      {:ok, view, html} = live(conn, ~p"/vaults/#{vault.id}/edit")
+      assert html =~ "vault-secret-form-0"
+
+      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => "v1"}})
+
+      assert html =~ "TOKEN"
+      assert html =~ "vault-secret-form-1"
+
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      assert Vaults.decrypted_env(vault, dek) == %{"TOKEN" => "v1"}
+    end
+
+    test "add_secret flashes instead of crashing when the tenant key cannot be loaded",
+         %{conn: conn, vault: vault} do
+      {:ok, view, _html} = live(conn, ~p"/vaults/#{vault.id}/edit")
+
+      stub(Fountain.Crypto, :load_tenant_key, fn _user_id -> {:error, :unwrap_failed} end)
+
+      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => "v"}})
+
+      assert html =~ "Could not load encryption key"
+      assert Process.alive?(view.pid)
+    end
+
+    test "mounts without touching the tenant key at all", %{conn: conn, vault: vault} do
+      stub(Fountain.Crypto, :load_tenant_key, fn _user_id -> {:error, :unwrap_failed} end)
+
+      assert {:ok, _view, _html} = live(conn, ~p"/vaults/#{vault.id}/edit")
+    end
+  end
+end


### PR DESCRIPTION
Closes #391 (P0, audit-2026-08-03 #416).

## Problem

Both secret-editing LiveViews unwrapped the tenant DEK at mount and kept it in socket assigns, next to the in-flight plaintext secret (`:new_secret`, refreshed on every `phx-change`). LiveView's channel exports the legacy `format_status/2` whose `:terminate` clause returns state unmodified, so an unhandled exception wrote the raw DEK — the key to the tenant's entire secret set — to stdout and Sentry. And the crash wasn't hypothetical: the `{:ok, dek} =` match at mount raised on `{:error, :unwrap_failed}`.

## Fix

Removes the class rather than redacting one instance (a `format_status/1` on the LiveView module would do nothing — OTP consults the callback module, which is `Phoenix.LiveView.Channel`):

- **DEK**: loaded inside `add_secret` via `with {:ok, dek} <-`, out of scope when the handler returns — the same pattern as `secret_controller.ex`, `vault_secret_controller.ex`, and the onboarding wizard. Unwrap failure now flashes "Could not load encryption key" instead of crashing; mount no longer touches the key at all.
- **In-flight plaintext**: the secret form is now uncontrolled — no `phx-change="validate_secret"` handler, no `value=` bindings — so the plaintext no longer round-trips per keystroke or sits in assigns. A versioned form `id` replaces the DOM node after a successful save to clear the fields.

## Tests

New `secret_forms_live_test.exs` (these forms had zero LiveView coverage):

- Byte-scans the serialized LiveView process state (`:sys.get_state` — the same state OTP puts in crash reports) for the 32-byte DEK and a plaintext sentinel, after mount and after a save.
- Persistence through the handler-scoped DEK (`decrypted_env/2` read-back), form-reset via the versioned id, flash-not-crash on key-load failure, and mount-with-broken-key.

All 8 fail against the pre-fix modules. `mix precommit` green: 1,765 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)