### PR TITLE
self-host: docker compose up -d postgres works on a fresh clone (#392)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,3 +226,22 @@ jobs:
 
       - name: Validate OpenAPI spec
         run: mix openapi.spec.json --spec FountainWeb.ApiSpec --output /tmp/openapi.json && jq empty /tmp/openapi.json
+
+  compose-fresh-clone:
+    name: Compose fresh-clone check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # Regression guard for #392: compose interpolates the entire file at
+      # load time regardless of which service a command targets, so a
+      # `:?`-required variable anywhere in it aborted even the documented
+      # database-only dev path (`docker compose up -d postgres`) on a fresh
+      # clone with no .env. This is the same load step that command runs.
+      - name: docker compose config with no .env and no secrets in the environment
+        run: env -u SECRET_KEY_BASE -u MASTER_SECRETS_KEY docker compose config --quiet

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -45,13 +45,16 @@ env = config_env()
 # alone — gating it on `server?` too would hand that public key to every prod
 # process started without PHX_SERVER=true (release eval tasks, migrations, seeds,
 # a remote console), and any of those can create a tenant DEK.
+# "" counts as missing (#392): docker-compose.yml passes `${VAR:-}` defaults,
+# which deliver a present-but-empty variable, and .env.example ships the key
+# present but blank. Both must hit the raise, not the decode branch.
 master_secrets_key =
   case {System.get_env("MASTER_SECRETS_KEY"), env} do
-    {nil, :prod} ->
+    {blank, :prod} when blank in [nil, ""] ->
       raise "environment variable MASTER_SECRETS_KEY is missing (32 bytes, url-safe base64, no padding). " <>
               "Generate: openssl rand 32 | base64 | tr '+/' '-_' | tr -d '='"
 
-    {nil, _} ->
+    {blank, _} when blank in [nil, ""] ->
       :crypto.hash(:sha256, "fountain:dev:master_secrets_key")
 
     {encoded, _} ->
@@ -420,9 +423,16 @@ if config_env() == :prod do
 end
 
 if config_env() == :prod and server? do
+  # "" counts as missing (#392): the compose file passes `${SECRET_KEY_BASE:-}`,
+  # and an empty string must not sail past an `||` guard into the endpoint.
   secret_key_base =
-    System.get_env("SECRET_KEY_BASE") ||
-      raise "environment variable SECRET_KEY_BASE is missing."
+    case System.get_env("SECRET_KEY_BASE") do
+      blank when blank in [nil, ""] ->
+        raise "environment variable SECRET_KEY_BASE is missing."
+
+      value ->
+        value
+    end
 
   host = phx_host
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,14 @@ services:
       # this instance by anything other than localhost.
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:4000}
 
-      SECRET_KEY_BASE: ${SECRET_KEY_BASE:?set SECRET_KEY_BASE in .env — see .env.compose.example}
-      MASTER_SECRETS_KEY: ${MASTER_SECRETS_KEY:?set MASTER_SECRETS_KEY in .env — see .env.compose.example}
+      # Required, but enforced by the app at boot (config/runtime.exs raises
+      # a descriptive error for either one missing or empty) rather than by a
+      # compose `:?` marker: compose interpolates this whole file at load
+      # time regardless of which service is targeted, so a hard requirement
+      # here made even `docker compose up -d postgres` — the documented
+      # database-only dev path — abort on a fresh clone (#392).
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:-}
+      MASTER_SECRETS_KEY: ${MASTER_SECRETS_KEY:-}
 
       # Conversations need a Sprites token. The app boots without one; every
       # attempt to start a conversation then fails.


### PR DESCRIPTION
Closes #392 (P0, audit-2026-08-03 #416).

## Problem

Compose interpolates the entire file at load time regardless of the targeted service, and `:?` errors on unset **or empty**. The `:?`-required `SECRET_KEY_BASE`/`MASTER_SECRETS_KEY` in the `app` service therefore aborted `docker compose up -d postgres` — the first command in SETUP.md — on a fresh clone, naming variables relevant only to a service the contributor didn't start.

## Fix

Took the issue's first direction (non-fatal defaults + app-side enforcement). The profile alternative would have made plain `docker compose up -d` silently not start the app, breaking the self-host one-liner in the file header.

- `docker-compose.yml` passes `${VAR:-}` for both keys, with a comment explaining why there's no `:?` (so it doesn't get "fixed" back).
- `config/runtime.exs` now treats `""` as missing for both — the audit's empty-string-is-truthy idiom, and load-bearing here because `${VAR:-}` delivers present-but-empty:
  - `MASTER_SECRETS_KEY=""` → the descriptive missing-var raise in prod (previously the misleading "must be 32 bytes" decode error), dev fallback in dev. This also un-breaks dev boot with `.env.example`'s blank `MASTER_SECRETS_KEY`.
  - `SECRET_KEY_BASE=""` → raise (previously `""` sailed past the `||` guard into the endpoint).
- An operator who runs the full `docker compose up -d` without a `.env` now gets a crash-looping app container whose logs carry the descriptive runtime.exs raise, instead of the compose-time error. The guarantee moved, it didn't vanish.

## Verification

Docker isn't installed on this workstation (same gap the audit hit), so the compose-level proof is a **new permanent CI job**: `docker compose config --quiet` with no `.env` and both vars scrubbed — the exact load step the fresh-clone command performs. It fails against the old file and is a standing regression guard for this class.

Verified locally: blank `MASTER_SECRETS_KEY` in dev raised the decode error on old code, boots on the dev fallback with this change. `mix precommit` green: 1,757 tests, 0 failures. The existing CI release-boot check exercises the prod path with real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)