### PR TITLE
billing: evaluate webhook sync guards under a row lock (#393)

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -536,20 +536,66 @@ defmodule Fountain.Billing do
            User.t() | :ignored | :duplicate | :stale | :comped_ignored | :other_subscription}
           | {:error, term()}
   def handle_event(%Stripe.Event{id: id, type: type} = event) when is_binary(id) do
-    Repo.transaction(fn ->
-      if claim_event(id, type) == :claimed do
-        case sync_subscription(event) do
-          {:ok, result} -> result
-          {:error, reason} -> Repo.rollback(reason)
+    # Stripe side effects run BEFORE the claim transaction opens (#393):
+    # holding a DB transaction — and, since #393, a row lock on the user —
+    # across a third-party HTTP call is what made the sync race window wide
+    # enough to hit, and it pins a pool connection for the duration.
+    # Cancellation is idempotent (already-cancelled subscriptions are
+    # filtered out on the retry), so a failure here leaves the event
+    # unclaimed for Stripe redelivery, exactly as the rollback used to.
+    with :ok <- prepare_event(event) do
+      Repo.transaction(fn ->
+        if claim_event(id, type) == :claimed do
+          case sync_subscription(event) do
+            {:ok, result} -> result
+            {:error, reason} -> Repo.rollback(reason)
+          end
+        else
+          :duplicate
         end
-      else
-        :duplicate
-      end
-    end)
+      end)
+    end
   end
 
   # No id (hand-built events in tests) — nothing to dedupe against.
-  def handle_event(%Stripe.Event{} = event), do: sync_subscription(event)
+  def handle_event(%Stripe.Event{} = event) do
+    with :ok <- prepare_event(event), do: sync_subscription(event)
+  end
+
+  # checkout.session.completed is the one event whose apply has a Stripe side
+  # effect: cancelling every other live subscription on the customer. The
+  # short-circuits mirror adopt_subscription/3's — no user (sync will report
+  # :user_not_found), comped, or the subscription already adopted (a
+  # redelivery) mean no cancellations either.
+  defp prepare_event(%Stripe.Event{type: "checkout.session.completed", data: %{object: session}}) do
+    customer_id = extract_stripe_id(Map.get(session, :customer))
+    subscription_id = extract_stripe_id(Map.get(session, :subscription))
+    user_id = Map.get(session, :client_reference_id)
+
+    user =
+      get_user_by_stripe_customer_id(customer_id) ||
+        (is_binary(user_id) && Repo.get(User, user_id)) || nil
+
+    cond do
+      is_nil(customer_id) or is_nil(subscription_id) ->
+        :ok
+
+      is_nil(user) ->
+        :ok
+
+      user.subscription_status == "comped" ->
+        :ok
+
+      user.stripe_subscription_id == subscription_id ->
+        :ok
+
+      true ->
+        with {:ok, _cancelled} <- cancel_other_subscriptions(customer_id, subscription_id),
+             do: :ok
+    end
+  end
+
+  defp prepare_event(_event), do: :ok
 
   # Atomic claim: the unique primary key is what makes concurrent deliveries of
   # the same event resolve to exactly one winner.
@@ -580,30 +626,36 @@ defmodule Fountain.Billing do
   returns `{:ok, :other_subscription}` without touching the account. The
   subscription of record is set at trial creation
   (`start_trial_subscription/1`) and replaced when a Checkout completes
-  (`checkout.session.completed` adopts the new subscription and cancels every
-  other live one on the customer).
+  (`checkout.session.completed` adopts the new subscription; `handle_event/1`
+  cancels every other live one on the customer before the claim transaction
+  opens, so no Stripe call runs inside it).
+
+  Reads the user row `FOR UPDATE` so the ownership and ordering guards are
+  evaluated against the same snapshot the write commits against (#393).
 
   All other event types return `{:ok, :ignored}` without touching the DB.
   """
   @spec sync_subscription(Stripe.Event.t()) ::
           {:ok, User.t() | :ignored | :stale | :comped_ignored | :other_subscription}
           | {:error, term()}
-  def sync_subscription(%Stripe.Event{
-        type: "checkout.session.completed",
-        data: %{object: session}
-      }) do
+  def sync_subscription(
+        %Stripe.Event{
+          type: "checkout.session.completed",
+          data: %{object: session}
+        } = event
+      ) do
     customer_id = extract_stripe_id(Map.get(session, :customer))
     subscription_id = extract_stripe_id(Map.get(session, :subscription))
     user_id = Map.get(session, :client_reference_id)
 
     user =
-      get_user_by_stripe_customer_id(customer_id) ||
-        (is_binary(user_id) && Repo.get(User, user_id)) || nil
+      get_user_by_stripe_customer_id(customer_id, :for_update) ||
+        get_user_for_update(user_id)
 
     cond do
       is_nil(customer_id) -> {:ok, :ignored}
       is_nil(user) -> {:error, :user_not_found}
-      true -> complete_checkout(user, customer_id, subscription_id)
+      true -> complete_checkout(user, customer_id, subscription_id, event_created_at(event))
     end
   end
 
@@ -669,7 +721,7 @@ defmodule Fountain.Billing do
 
     event_created = event_created_at(event)
 
-    case get_user_by_stripe_customer_id(customer_id) do
+    case get_user_by_stripe_customer_id(customer_id, :for_update) do
       nil ->
         {:error, :user_not_found}
 
@@ -763,7 +815,7 @@ defmodule Fountain.Billing do
 
   # A session with no subscription (payment mode, or an old-style session) only
   # backfills the customer link, exactly as before.
-  defp complete_checkout(%User{} = user, customer_id, nil) do
+  defp complete_checkout(%User{} = user, customer_id, nil, _event_created) do
     if user.stripe_customer_id == customer_id do
       {:ok, :ignored}
     else
@@ -771,7 +823,7 @@ defmodule Fountain.Billing do
     end
   end
 
-  defp complete_checkout(%User{} = user, customer_id, subscription_id) do
+  defp complete_checkout(%User{} = user, customer_id, subscription_id, event_created) do
     linked =
       if user.stripe_customer_id == customer_id do
         {:ok, user}
@@ -779,7 +831,7 @@ defmodule Fountain.Billing do
         attach_stripe_customer(user, customer_id)
       end
 
-    with {:ok, user} <- linked, do: adopt_subscription(user, subscription_id)
+    with {:ok, user} <- linked, do: adopt_subscription(user, subscription_id, event_created)
   end
 
   # Checkout in subscription mode always creates a *new* subscription, so a
@@ -787,32 +839,40 @@ defmodule Fountain.Billing do
   # Left alone, that subscription either dies at trial end — and its deletion
   # webhook locks out a now-paying customer — or converts and double-bills
   # them. Adopt the checkout's subscription as the account's subscription of
-  # record and cancel every other live one.
+  # record; the other live subscriptions were cancelled by prepare_event/1
+  # before the claim transaction opened (a failed cancellation never reaches
+  # this point — the webhook answers 500 and Stripe redelivers an unclaimed
+  # event).
   #
   # The status write is the optimistic copy the new subscription's own webhook
   # will confirm — necessary because that webhook may have already arrived and
   # been ignored for carrying an unrecorded subscription id.
   #
-  # A failed Stripe call surfaces as an error so the webhook answers 500 and
-  # Stripe redelivers; handle_event/1 rolls the claim (and the writes here)
-  # back, and already-cancelled subscriptions are skipped on the retry.
-  defp adopt_subscription(%User{subscription_status: "comped"} = user, _subscription_id),
+  # The watermark stamp (#393) makes the adoption participate in the stale?/2
+  # ordering guard: without it, any older event for the adopted subscription
+  # that straggled in afterwards was treated as fresh and could move the
+  # account backwards. Never moves the watermark backwards itself.
+  defp adopt_subscription(%User{subscription_status: "comped"} = user, _sub_id, _event_created),
     do: {:ok, user}
 
-  defp adopt_subscription(%User{stripe_subscription_id: sub_id} = user, sub_id), do: {:ok, user}
+  defp adopt_subscription(%User{stripe_subscription_id: sub_id} = user, sub_id, _event_created),
+    do: {:ok, user}
 
-  defp adopt_subscription(%User{} = user, subscription_id) do
-    with {:ok, _cancelled} <- cancel_other_subscriptions(user, subscription_id) do
-      user
-      |> User.billing_changeset(%{
-        stripe_subscription_id: subscription_id,
-        subscription_status: "active"
-      })
-      |> Repo.update()
-    end
+  defp adopt_subscription(%User{} = user, subscription_id, event_created) do
+    user
+    |> User.billing_changeset(%{
+      stripe_subscription_id: subscription_id,
+      subscription_status: "active",
+      subscription_synced_at: latest(event_created, user.subscription_synced_at)
+    })
+    |> Repo.update()
   end
 
-  defp cancel_other_subscriptions(%User{stripe_customer_id: customer_id}, keep_sub_id) do
+  defp latest(nil, b), do: b
+  defp latest(a, nil), do: a
+  defp latest(a, b), do: if(DateTime.compare(a, b) == :lt, do: b, else: a)
+
+  defp cancel_other_subscriptions(customer_id, keep_sub_id) when is_binary(customer_id) do
     case Stripe.Subscription.list(%{customer: customer_id, status: :all, limit: 100}) do
       {:ok, %{data: subs} = list} ->
         if Map.get(list, :has_more, false) do
@@ -1085,6 +1145,27 @@ defmodule Fountain.Billing do
   defp get_user_by_stripe_customer_id(customer_id) when is_binary(customer_id) do
     Repo.get_by(User, stripe_customer_id: customer_id)
   end
+
+  # FOR UPDATE (#393): the webhook sync paths evaluate their ownership
+  # (other_subscription?/2) and ordering (stale?/2) guards on this read and
+  # write afterwards. Unlocked, a concurrent sync for the same user — e.g.
+  # the customer.subscription.deleted that a mid-upgrade cancellation
+  # triggers — could pass the guards against a snapshot another transaction
+  # was about to make stale, and the #309 lockout came back as a race. The
+  # lock makes a concurrent sync wait here and re-evaluate against the
+  # committed row. Outside a transaction (bare sync_subscription/1 calls in
+  # tests) the lock is released at statement end and changes nothing.
+  defp get_user_by_stripe_customer_id(nil, _lock_mode), do: nil
+
+  defp get_user_by_stripe_customer_id(customer_id, :for_update) when is_binary(customer_id) do
+    Repo.one(from(u in User, where: u.stripe_customer_id == ^customer_id, lock: "FOR UPDATE"))
+  end
+
+  defp get_user_for_update(user_id) when is_binary(user_id) do
+    Repo.one(from(u in User, where: u.id == ^user_id, lock: "FOR UPDATE"))
+  end
+
+  defp get_user_for_update(_), do: nil
 
   # Stripe returns related objects (customer, subscription) as either a plain
   # string id or an expanded object, depending on the event and API version.

--- a/apps/fountain/test/fountain/billing_webhook_sync_race_test.exs
+++ b/apps/fountain/test/fountain/billing_webhook_sync_race_test.exs
@@ -1,0 +1,234 @@
+defmodule Fountain.BillingWebhookSyncRaceTest do
+  @moduledoc """
+  Regression tests for #393: webhook sync evaluated its ownership and
+  ordering guards on an unlocked read, so the #309 lockout was reachable as
+  a race during a mid-trial upgrade — the deletion of the superseded trial
+  subscription could read the user before the checkout's transaction
+  committed, pass the guards, and land its cancellation after the checkout's
+  write.
+
+  The SQL Sandbox serializes everything onto one connection, so the
+  interleaving itself cannot be reproduced here. These tests pin the three
+  mechanisms that close it instead:
+
+  1. the sync paths read the user row `FOR UPDATE` (asserted via query
+     telemetry), so a concurrent sync blocks until the competing
+     transaction commits and re-evaluates against the committed row;
+  2. checkout adoption stamps `subscription_synced_at`, so the ordering
+     guard defends the adoption against stragglers (pre-#393 it never
+     participated and could not defend itself even in principle);
+  3. the Stripe cancellation calls run before the claim transaction opens,
+     which is what kept the DB transaction — and now the row lock — from
+     being held across third-party HTTP.
+  """
+
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Billing, Repo}
+  alias Fountain.Accounts.User
+
+  defp trialing_user_on(customer_id, sub_id) do
+    user = insert_verified_user()
+    {:ok, user} = Billing.attach_stripe_customer(user, customer_id)
+
+    {:ok, user} =
+      user
+      |> User.billing_changeset(%{stripe_subscription_id: sub_id})
+      |> Repo.update()
+
+    user
+  end
+
+  defp checkout_event(id, customer, sub_id, user_id, created) do
+    %Stripe.Event{
+      id: id,
+      type: "checkout.session.completed",
+      created: created,
+      data: %{object: %{customer: customer, subscription: sub_id, client_reference_id: user_id}}
+    }
+  end
+
+  defp sub_event(id, type, customer, sub_id, status, created) do
+    %Stripe.Event{
+      id: id,
+      type: type,
+      created: created,
+      data: %{object: %{id: sub_id, customer: customer, status: status, trial_end: nil}}
+    }
+  end
+
+  defp now_unix, do: DateTime.utc_now() |> DateTime.to_unix()
+
+  defp capture_locked_queries do
+    test_pid = self()
+    handler_id = "for-update-#{inspect(test_pid)}"
+
+    :telemetry.attach(
+      handler_id,
+      [:fountain, :repo, :query],
+      fn _event, _measurements, meta, _config ->
+        if meta.query =~ "FOR UPDATE", do: send(test_pid, {:locked_query, meta.query})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  describe "row lock (#393 mechanism 1)" do
+    test "subscription lifecycle sync reads the user under FOR UPDATE" do
+      capture_locked_queries()
+      user = trialing_user_on("cus_lock_read", "sub_lr")
+
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event("evt_lr", "customer.subscription.updated", "cus_lock_read", "sub_lr", "active", now_unix())
+        )
+
+      assert_received {:locked_query, query}
+      assert query =~ "users"
+      assert Repo.reload(user).subscription_status == "active"
+    end
+
+    test "checkout sync reads the user under FOR UPDATE, via customer id and via client_reference_id" do
+      capture_locked_queries()
+      user = trialing_user_on("cus_lock_co", "sub_lc_old")
+
+      stub(Stripe.Subscription, :list, fn _ -> {:ok, %{data: [], has_more: false}} end)
+
+      {:ok, _} =
+        Billing.handle_event(checkout_event("evt_lc", "cus_lock_co", "sub_lc_new", user.id, now_unix()))
+
+      assert_received {:locked_query, _}
+
+      # A user with no customer link yet resolves through client_reference_id;
+      # that read must be locked too.
+      unlinked = insert_verified_user()
+
+      {:ok, _} =
+        Billing.handle_event(
+          checkout_event("evt_lc2", "cus_lock_co2", "sub_lc2", unlinked.id, now_unix())
+        )
+
+      assert_received {:locked_query, _}
+    end
+  end
+
+  describe "adoption watermark (#393 mechanism 2)" do
+    test "checkout adoption stamps subscription_synced_at with the event timestamp" do
+      user = trialing_user_on("cus_wm", "sub_wm_old")
+      stub(Stripe.Subscription, :list, fn _ -> {:ok, %{data: [], has_more: false}} end)
+
+      t0 = now_unix()
+      {:ok, updated} = Billing.handle_event(checkout_event("evt_wm", "cus_wm", "sub_wm_new", user.id, t0))
+
+      assert updated.subscription_synced_at ==
+               t0 |> DateTime.from_unix!() |> DateTime.truncate(:second)
+    end
+
+    test "an out-of-order event for the adopted subscription cannot move the account backwards" do
+      user = trialing_user_on("cus_wm2", "sub_wm2_old")
+      stub(Stripe.Subscription, :list, fn _ -> {:ok, %{data: [], has_more: false}} end)
+
+      t0 = now_unix()
+
+      {:ok, _} =
+        Billing.handle_event(checkout_event("evt_wm2", "cus_wm2", "sub_wm2_new", user.id, t0))
+
+      # A straggler about the adopted subscription, created before the
+      # checkout. Pre-#393 the adoption left subscription_synced_at
+      # untouched, stale?/2 saw nil, and this cancelled a paying account.
+      assert {:ok, :stale} =
+               Billing.handle_event(
+                 sub_event(
+                   "evt_wm2_straggler",
+                   "customer.subscription.deleted",
+                   "cus_wm2",
+                   "sub_wm2_new",
+                   "canceled",
+                   t0 - 60
+                 )
+               )
+
+      reloaded = Repo.reload(user)
+      assert reloaded.subscription_status == "active"
+      assert reloaded.stripe_subscription_id == "sub_wm2_new"
+    end
+
+    test "the adoption never moves an existing watermark backwards" do
+      user = trialing_user_on("cus_wm3", "sub_wm3_old")
+      stub(Stripe.Subscription, :list, fn _ -> {:ok, %{data: [], has_more: false}} end)
+
+      t0 = now_unix()
+
+      # A lifecycle event stamps the watermark at t0...
+      {:ok, _} =
+        Billing.handle_event(
+          sub_event("evt_wm3_a", "customer.subscription.updated", "cus_wm3", "sub_wm3_old", "trialing", t0)
+        )
+
+      # ...then a checkout whose event timestamp is older must keep it at t0.
+      {:ok, updated} =
+        Billing.handle_event(checkout_event("evt_wm3_b", "cus_wm3", "sub_wm3_new", user.id, t0 - 120))
+
+      assert updated.subscription_synced_at ==
+               t0 |> DateTime.from_unix!() |> DateTime.truncate(:second)
+    end
+  end
+
+  describe "Stripe calls outside the transaction (#393 mechanism 3)" do
+    test "checkout cancellations run before the claim transaction opens" do
+      user = trialing_user_on("cus_notxn", "sub_notxn_old")
+      test_pid = self()
+
+      # Mimic stubs execute in the calling process, so Repo.in_transaction?
+      # here reports the transaction state of the sync path itself.
+      expect(Stripe.Subscription, :list, fn _ ->
+        send(test_pid, {:list_in_txn, Repo.in_transaction?()})
+        {:ok, %{data: [%Stripe.Subscription{id: "sub_notxn_old", status: "trialing"}], has_more: false}}
+      end)
+
+      expect(Stripe.Subscription, :cancel, fn id ->
+        send(test_pid, {:cancel_in_txn, Repo.in_transaction?()})
+        {:ok, %Stripe.Subscription{id: id, status: "canceled"}}
+      end)
+
+      event = checkout_event("evt_notxn", "cus_notxn", "sub_notxn_new", user.id, now_unix())
+
+      assert {:ok, updated} = Billing.handle_event(event)
+      assert updated.stripe_subscription_id == "sub_notxn_new"
+      assert updated.subscription_status == "active"
+
+      assert_received {:list_in_txn, false}
+      assert_received {:cancel_in_txn, false}
+
+      # A redelivery after adoption is a duplicate and must not call Stripe
+      # again — the expect/3 counts above (one call each) enforce that.
+      assert {:ok, :duplicate} = Billing.handle_event(event)
+    end
+
+    test "a failed cancellation still leaves the event unclaimed for redelivery" do
+      user = trialing_user_on("cus_fail", "sub_fail_old")
+
+      stub(Stripe.Subscription, :list, fn _ -> {:error, :stripe_down} end)
+
+      event = checkout_event("evt_fail", "cus_fail", "sub_fail_new", user.id, now_unix())
+      assert {:error, :stripe_down} = Billing.handle_event(event)
+
+      reloaded = Repo.reload(user)
+      assert reloaded.stripe_subscription_id == "sub_fail_old"
+
+      stub(Stripe.Subscription, :list, fn _ ->
+        {:ok, %{data: [%Stripe.Subscription{id: "sub_fail_old", status: "trialing"}], has_more: false}}
+      end)
+
+      stub(Stripe.Subscription, :cancel, fn id ->
+        {:ok, %Stripe.Subscription{id: id, status: "canceled"}}
+      end)
+
+      assert {:ok, updated} = Billing.handle_event(event)
+      assert updated.stripe_subscription_id == "sub_fail_new"
+    end
+  end
+end


### PR DESCRIPTION
Closes #393 (P0, audit-2026-08-03 #416).

## Problem

`sync_subscription/1` evaluated the #309 ownership filter and the staleness watermark against an unlocked `Repo.get_by` read. During a mid-trial upgrade, `adopt_subscription/2` cancelled the old trial subscription via the Stripe API from **inside** the still-open claim transaction; the resulting `customer.subscription.deleted` could read the user before that transaction committed, pass the filter (old subscription still looked like the one of record), and land its UPDATE after the checkout's. Final state: `stripe_subscription_id` = the new paid subscription, `subscription_status` = `"canceled"` — the exact lockout #309 was filed to prevent, reachable as a race.

## Fix (the issue's three parts)

1. **Row lock** — both webhook sync paths read the user `FOR UPDATE` (checkout resolves via customer id *or* `client_reference_id`; both reads lock). A concurrent sync now blocks at the read until the competing transaction commits, then re-evaluates the guards against the committed row — the deleted-event straggler sees the adopted subscription id and returns `{:ok, :other_subscription}`.
2. **Watermark** — `adopt_subscription/3` stamps `subscription_synced_at` from the checkout event (never moving it backwards), so the adoption participates in the `stale?/2` ordering guard it previously couldn't use in its own defense.
3. **HTTP out of the transaction** — `handle_event/1` runs the cancellations in a new `prepare_event/1` **before** the claim transaction opens, so neither the transaction nor the row lock is held across third-party HTTP. Retry semantics preserved: a failed cancellation aborts before the claim → 500 → Stripe redelivers an unclaimed event; cancellation is idempotent on retry (already-cancelled subs are filtered), and a redelivery after adoption short-circuits without any Stripe call (enforced by `expect/3` call counts in the tests).

## Tests

The SQL Sandbox serializes onto one connection, so the interleaving itself can't run in the suite. `billing_webhook_sync_race_test.exs` pins each mechanism:

- `FOR UPDATE` on the user read, asserted via `[:fountain, :repo, :query]` telemetry, on both sync paths.
- Watermark stamped from the checkout event; an out-of-order `deleted` for the adopted subscription now returns `{:ok, :stale}` and leaves the account active (pre-fix: cancelled it); watermark never moves backwards.
- `Repo.in_transaction?` is false inside the `Stripe.Subscription.list`/`cancel` stubs (verified that this reads false outside explicit transactions under the sandbox); failed-cancellation-leaves-event-unclaimed redelivery flow.

5 of 7 fail against the old `billing.ex`; the other two pin invariants that must not regress. All 15 pre-existing #309/checkout tests pass unchanged. `mix precommit` green: 1,764 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)