### PR TITLE
security: allowlist-scrub request bodies before they reach Sentry (#402)

### DIFF
--- a/apps/fountain/lib/fountain_web/endpoint.ex
+++ b/apps/fountain/lib/fountain_web/endpoint.ex
@@ -120,9 +120,11 @@ defmodule FountainWeb.Endpoint do
 
   # Attaches request context (method, path, scrubbed headers/params) to any
   # Sentry event reported while this request is being handled. Sentry's
-  # default scrubbers drop auth headers, cookies and password-shaped params.
-  # A no-op while SENTRY_DSN is unset.
-  plug Sentry.PlugContext
+  # default scrubbers drop auth headers and cookies, but its body scrubber
+  # is a three-name denylist that let the secret-write endpoints' plaintext
+  # values through (#402) — so the body goes through FountainWeb.SentryScrubber,
+  # which keeps parameter shape only. A no-op while SENTRY_DSN is unset.
+  plug Sentry.PlugContext, body_scrubber: {FountainWeb.SentryScrubber, :scrub_body}
 
   plug Plug.MethodOverride
   plug Plug.Head

--- a/apps/fountain/lib/fountain_web/sentry_scrubber.ex
+++ b/apps/fountain/lib/fountain_web/sentry_scrubber.ex
@@ -1,0 +1,37 @@
+defmodule FountainWeb.SentryScrubber do
+  @moduledoc """
+  Body scrubber for `Sentry.PlugContext` (#402).
+
+  Sentry's default scrubber is a denylist of three exact parameter names
+  (`password`, `passwd`, `secret`), so the secret-write endpoints
+  (`%{"key" => ..., "value" => <plaintext>}`) and the manifest apply's
+  `spec.secrets` map sailed through it verbatim — any exception mid-request
+  shipped tenant plaintext to Sentry.
+
+  This app holds tenant secrets by definition, so the policy is an
+  allowlist of *shape*, not a longer denylist the next endpoint outruns:
+  every string value is replaced with a length tag, keeping only the
+  structure (keys, nesting, sizes) that debugging actually uses.
+  """
+
+  @doc """
+  Returns `conn.params` with every string value replaced by `"[string:N]"`.
+
+  Numbers, booleans and nil pass through — they carry no secret material
+  and are the values most often load-bearing in an error report. Anything
+  else (uploads, structs) is flattened to a tag.
+  """
+  def scrub_body(%Plug.Conn{params: %Plug.Conn.Unfetched{}}), do: %{}
+  def scrub_body(%Plug.Conn{params: params}), do: summarize(params)
+
+  defp summarize(%Plug.Upload{filename: name}), do: "[upload:#{name}]"
+  defp summarize(%_{} = _struct), do: "[struct]"
+  defp summarize(map) when is_map(map), do: Map.new(map, fn {k, v} -> {k, summarize(v)} end)
+  defp summarize(list) when is_list(list), do: Enum.map(list, &summarize/1)
+  defp summarize(value) when is_binary(value), do: "[string:#{byte_size(value)}]"
+
+  defp summarize(value) when is_number(value) or is_boolean(value) or is_nil(value),
+    do: value
+
+  defp summarize(_other), do: "[redacted]"
+end

--- a/apps/fountain/test/fountain_web/sentry_scrubber_test.exs
+++ b/apps/fountain/test/fountain_web/sentry_scrubber_test.exs
@@ -1,0 +1,103 @@
+defmodule FountainWeb.SentryScrubberTest do
+  use FountainWeb.ConnCase, async: true
+
+  alias FountainWeb.SentryScrubber
+
+  # Regression tests for #402: Sentry's default body scrubber is an exact-name
+  # denylist ("password", "passwd", "secret"), so the secret-write endpoints'
+  # "value" field and the manifest apply's "secrets" map reached Sentry as
+  # plaintext whenever an exception fired mid-request.
+
+  describe "scrub_body/1 (unit)" do
+    test "replaces every string value with a length tag, keeping shape" do
+      conn = %Plug.Conn{params: %{"key" => "GITHUB_TOKEN", "value" => "ghp_plaintext"}}
+
+      assert SentryScrubber.scrub_body(conn) == %{
+               "key" => "[string:12]",
+               "value" => "[string:13]"
+             }
+    end
+
+    test "recurses through the manifest-apply shape" do
+      conn = %Plug.Conn{
+        params: %{
+          "resources" => [
+            %{
+              "kind" => "Environment",
+              "spec" => %{"secrets" => %{"ANTHROPIC_API_KEY" => "sk-ant-plaintext"}}
+            }
+          ]
+        }
+      }
+
+      assert SentryScrubber.scrub_body(conn) == %{
+               "resources" => [
+                 %{
+                   "kind" => "[string:11]",
+                   "spec" => %{"secrets" => %{"ANTHROPIC_API_KEY" => "[string:16]"}}
+                 }
+               ]
+             }
+    end
+
+    test "passes numbers, booleans and nil; tags uploads and structs" do
+      conn = %Plug.Conn{
+        params: %{
+          "count" => 3,
+          "flag" => true,
+          "nothing" => nil,
+          "file" => %Plug.Upload{filename: "a.txt"},
+          "when" => ~U[2026-08-03 00:00:00Z]
+        }
+      }
+
+      assert SentryScrubber.scrub_body(conn) == %{
+               "count" => 3,
+               "flag" => true,
+               "nothing" => nil,
+               "file" => "[upload:a.txt]",
+               "when" => "[struct]"
+             }
+    end
+
+    test "returns an empty map for unfetched params" do
+      assert SentryScrubber.scrub_body(%Plug.Conn{}) == %{}
+    end
+  end
+
+  describe "endpoint wiring (end to end)" do
+    # Phoenix.ConnTest dispatches in the test process, so the request context
+    # Sentry.PlugContext stored during the request is readable right here —
+    # the same data an exception mid-request would ship.
+    setup do
+      on_exit(fn -> Sentry.Context.clear_all() end)
+
+      user = insert_verified_user()
+      {_key_record, raw_key} = insert_api_key(user)
+      {:ok, user: user, raw_key: raw_key}
+    end
+
+    test "a secret write leaves no plaintext in the Sentry request context",
+         %{conn: conn, user: user, raw_key: raw_key} do
+      env = insert_env(user_id: user.id)
+      plaintext = "plaintext-sentry-sentinel-51c2"
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/environments/#{env.id}/secrets", %{
+          "key" => "SENTRY_PROBE",
+          "value" => plaintext
+        })
+
+      assert conn.status in [200, 201]
+
+      request_context = Sentry.Context.get_all().request
+      rendered = inspect(request_context, limit: :infinity, printable_limit: :infinity)
+
+      refute rendered =~ plaintext
+      # The shape survives — this is what makes the allowlist debuggable.
+      assert get_in(request_context, [:data, "value"]) == "[string:30]"
+    end
+  end
+end


### PR DESCRIPTION
Closes #402 (P1, audit-2026-08-03 #416).

Sentry's default body scrubber matches exactly three parameter names, so `POST .../secrets` (`value`) and `POST /api/apply` (`spec.secrets`) shipped tenant plaintext into any Sentry event raised mid-request.

Per the issue's recommendation this is an **allowlist of shape**, not an extended denylist: `FountainWeb.SentryScrubber.scrub_body/1` replaces every string value with `[string:N]`, passes numbers/booleans/nil, tags uploads/structs, and recurses through maps and lists — so keys, nesting and sizes stay debuggable and no future endpoint can outrun the list.

Tests: unit coverage of the secret and manifest shapes, plus an end-to-end test that posts a real secret through the endpoint and asserts the stored Sentry request context contains the length tag and not the plaintext sentinel. The e2e test fails with the scrubber un-wired. `mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)