### PR TITLE
api: fix OpenAPI spec identity and ADMIN_TOKEN auth description (#403)

### DIFF
--- a/apps/fountain/lib/fountain_web/api_spec.ex
+++ b/apps/fountain/lib/fountain_web/api_spec.ex
@@ -16,13 +16,17 @@ defmodule FountainWeb.ApiSpec do
     %OpenApi{
       servers: [Server.from_endpoint(Endpoint)],
       info: %Info{
-        title: "Agent on Demand",
+        title: "Fountain",
         version: @app_version,
         description: """
-        HTTP API for Agent on Demand. The same surface backs the LiveView UI
-        and the `aod` CLI; if it's not here, it doesn't exist yet.
+        HTTP API for Fountain. The same surface backs the LiveView UI and the
+        `fountain` CLI (`brew install BinaryBourbon/tap/fountain`); if it's not
+        here, it doesn't exist yet.
 
-        All `/api/*` endpoints require a bearer token (`ADMIN_TOKEN`).
+        All `/api/*` endpoints require a per-user API key (`ftn_...`) passed as
+        a bearer token. Mint one at `POST /api/auth/api-keys` (or exchange
+        email + password at `POST /api/auth/token`); keys carry scopes and an
+        expiry.
         """
       },
       paths: Paths.from_router(Router),
@@ -31,7 +35,9 @@ defmodule FountainWeb.ApiSpec do
           "bearer" => %SecurityScheme{
             type: "http",
             scheme: "bearer",
-            description: "ADMIN_TOKEN configured at boot."
+            description:
+              "Per-user API key (`ftn_...`), minted at `POST /api/auth/api-keys` " <>
+                "or exchanged at `POST /api/auth/token`. Keys carry scopes and an expiry."
           }
         }
       },

--- a/apps/fountain/test/fountain_web/api_spec_test.exs
+++ b/apps/fountain/test/fountain_web/api_spec_test.exs
@@ -1,0 +1,37 @@
+defmodule FountainWeb.ApiSpecTest do
+  use ExUnit.Case, async: true
+
+  alias FountainWeb.ApiSpec
+
+  # #403: the published spec described the pre-rename identity ("Agent on
+  # Demand", the `aod` CLI) and an auth mechanism that no longer exists
+  # (ADMIN_TOKEN). Pin the real identity and auth scheme.
+  describe "spec/0 identity and auth (issue #403)" do
+    setup do
+      spec = ApiSpec.spec()
+      %{info: spec.info, bearer: spec.components.securitySchemes["bearer"]}
+    end
+
+    test "info names the current product and CLI", %{info: info} do
+      assert info.title == "Fountain"
+      refute info.description =~ "Agent on Demand"
+      refute info.description =~ "`aod`"
+      assert info.description =~ "`fountain` CLI"
+    end
+
+    test "info describes API-key auth, not ADMIN_TOKEN", %{info: info} do
+      refute info.description =~ "ADMIN_TOKEN"
+      assert info.description =~ "API key"
+      assert info.description =~ "POST /api/auth/api-keys"
+      assert info.description =~ "POST /api/auth/token"
+    end
+
+    test "bearer security scheme describes API keys, not ADMIN_TOKEN", %{bearer: bearer} do
+      assert bearer.type == "http"
+      assert bearer.scheme == "bearer"
+      refute bearer.description =~ "ADMIN_TOKEN"
+      assert bearer.description =~ "API key"
+      assert bearer.description =~ "POST /api/auth/api-keys"
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -119,8 +119,10 @@ GET    /api/conversations/:id/stream       # SSE log stream (?streams=stdout,std
 |---|---|
 | `400` | Invalid request body |
 | `401` | Missing or invalid auth |
+| `402` | Active subscription required (`subscription_required`, includes `upgrade_url`) |
 | `403` | Wrong tenant |
 | `404` | Not found |
+| `410` | Conversation terminated (`conversation_terminated`) — stop retrying |
 | `422` | Validation error |
 | `429` | Rate limited |
 | `500` | Internal error |


### PR DESCRIPTION
## Problem

The OpenAPI spec published at `/api/openapi.json` (Swagger UI at `/api/docs`) still carried the pre-rename identity and a deleted auth mechanism (#403):

- `Info.title` was "Agent on Demand" and the description referenced the `aod` CLI.
- Both the Info description and the bearer `SecurityScheme` description told integrators to authenticate with `ADMIN_TOKEN`, which was removed in phase 3 and exists nowhere else in the codebase.

This is the machine-readable contract on a public endpoint — it described a token that cannot be created, under a product name that no longer exists.

## Fix

`apps/fountain/lib/fountain_web/api_spec.ex`:

- Title is now "Fountain"; the description names the `fountain` CLI (`brew install BinaryBourbon/tap/fountain`).
- Both auth descriptions now describe the real scheme: a per-user API key (`ftn_...`) passed as a bearer token, minted at `POST /api/auth/api-keys` or exchanged (email + password) at `POST /api/auth/token`, with scopes and an expiry. Both routes verified in `router.ex`; enforcement verified in `FountainWeb.Plugs.TenantAPIAuth`.

`docs/api.md` (also flagged in the issue): the error table now includes `402` (`subscription_required`, includes `upgrade_url`) and `410` (`conversation_terminated`), both returned by `FallbackController`.

## Tests

New `apps/fountain/test/fountain_web/api_spec_test.exs` generates `FountainWeb.ApiSpec.spec()` and asserts the info title/description and bearer scheme description do NOT contain "ADMIN_TOKEN", "Agent on Demand", or the `aod` CLI, and DO describe API-key auth with the two mint/exchange endpoints.

**Revert verification:** with the fix stashed (`git stash push -- apps/fountain/lib/fountain_web/api_spec.ex`), all 3 new tests fail against the old spec; with the fix restored, all 3 pass.

- `mix openapi.spec.json --spec FountainWeb.ApiSpec` + `jq empty` — spec still generates and validates.
- `mix precommit` — green (exit 0; 5 doctests, 3 properties, 1780 tests, 0 failures).

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)