### PR TITLE
ops: cover exit and throw in the poller tick guards (#395)

### DIFF
--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -121,23 +121,18 @@ defmodule Fountain.Funnel do
   """
   @spec emit_telemetry() :: :ok
   def emit_telemetry do
-    %{stages: stages, stalled: %{count: stalled}} = summary_admin()
+    # Guarded because telemetry_poller permanently drops a measurement
+    # whose tick fails in any class — see Fountain.TelemetryTick (#365, #395).
+    Fountain.TelemetryTick.run("funnel telemetry", fn ->
+      %{stages: stages, stalled: %{count: stalled}} = summary_admin()
 
-    measurements =
-      stages
-      |> Map.new(fn %{key: key, count: count} -> {key, count} end)
-      |> Map.put(:stalled_verified, stalled)
+      measurements =
+        stages
+        |> Map.new(fn %{key: key, count: count} -> {key, count} end)
+        |> Map.put(:stalled_verified, stalled)
 
-    :telemetry.execute([:fountain, :funnel], measurements, %{})
-  rescue
-    # A raise here must not escape: telemetry_poller permanently drops a
-    # measurement whose tick raises, so one failure — the boot tick racing
-    # Repo startup, a transient DB blip — would silently kill the funnel
-    # gauges for the node's lifetime (#365). Skip the datapoint instead;
-    # the next 10s tick retries.
-    error ->
-      Logger.warning("funnel telemetry tick skipped: #{Exception.message(error)}")
-      :ok
+      :telemetry.execute([:fountain, :funnel], measurements, %{})
+    end)
   end
 
   # Of the verified users with no conversation ever: how far did each get?

--- a/apps/fountain/lib/fountain/ops_gauges.ex
+++ b/apps/fountain/lib/fountain/ops_gauges.ex
@@ -25,28 +25,23 @@ defmodule Fountain.OpsGauges do
   @oban_states ~w(available scheduled executing retryable discarded)
 
   def emit_telemetry do
-    emit_status_counts(
-      [:fountain, :conversations],
-      Fountain.Conversations.Conversation,
-      Fountain.Conversations.Conversation.statuses()
-    )
+    # Guarded because telemetry_poller permanently drops a measurement
+    # whose tick fails in any class — see Fountain.TelemetryTick (#365, #395).
+    Fountain.TelemetryTick.run("ops gauges", fn ->
+      emit_status_counts(
+        [:fountain, :conversations],
+        Fountain.Conversations.Conversation,
+        Fountain.Conversations.Conversation.statuses()
+      )
 
-    emit_status_counts(
-      [:fountain, :sandboxes],
-      Fountain.Conversations.Sandbox,
-      Fountain.Conversations.Sandbox.statuses()
-    )
+      emit_status_counts(
+        [:fountain, :sandboxes],
+        Fountain.Conversations.Sandbox,
+        Fountain.Conversations.Sandbox.statuses()
+      )
 
-    emit_oban_depths()
-    :ok
-  rescue
-    # A raise here must not escape: telemetry_poller permanently drops a
-    # measurement whose tick raises (#365), so one boot-race or DB blip
-    # would silently kill these gauges for the node's lifetime. Skip the
-    # datapoint; the next tick retries.
-    error ->
-      Logger.warning("ops gauges tick skipped: #{Exception.message(error)}")
-      :ok
+      emit_oban_depths()
+    end)
   end
 
   defp emit_status_counts(event, schema, statuses) do

--- a/apps/fountain/lib/fountain/telemetry_tick.ex
+++ b/apps/fountain/lib/fountain/telemetry_tick.ex
@@ -1,0 +1,28 @@
+defmodule Fountain.TelemetryTick do
+  @moduledoc """
+  Guard for `telemetry_poller` measurement functions (#365, #395).
+
+  The poller catches all three classes — `error`, `exit` and `throw` — and
+  permanently drops a measurement that fails, so a single boot tick racing
+  Repo startup or one DB blip silently kills a gauge for the node's
+  lifetime. The class Repo actually produces under a checkout timeout or a
+  dying pool is an *exit*, which the original `rescue`-only guard (#365)
+  did not cover (#395). Skip the datapoint and let the next tick retry.
+  """
+
+  require Logger
+
+  @spec run(String.t(), (-> any())) :: :ok
+  def run(label, fun) do
+    fun.()
+    :ok
+  rescue
+    error ->
+      Logger.warning("#{label} tick skipped: #{Exception.message(error)}")
+      :ok
+  catch
+    kind, reason ->
+      Logger.warning("#{label} tick skipped: #{inspect({kind, reason})}")
+      :ok
+  end
+end

--- a/apps/fountain/test/fountain/telemetry_tick_test.exs
+++ b/apps/fountain/test/fountain/telemetry_tick_test.exs
@@ -1,0 +1,54 @@
+defmodule Fountain.TelemetryTickTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Fountain.TelemetryTick
+
+  # Regression tests for #395: the #365 guard was rescue-only, but
+  # telemetry_poller drops a measurement that fails in ANY class — and the
+  # class Repo actually produces under a checkout timeout or a dying pool
+  # is an exit. The existing #365 tests force a raise, which rescue already
+  # covered, so they passed with the exit hole open.
+
+  test "a raising tick is skipped" do
+    log = capture_log(fn -> assert TelemetryTick.run("t", fn -> raise "boom" end) == :ok end)
+    assert log =~ "t tick skipped: boom"
+  end
+
+  test "an exiting tick is skipped — the class Repo produces (#395)" do
+    log =
+      capture_log(fn ->
+        assert TelemetryTick.run("t", fn ->
+                 exit({:timeout, {DBConnection.Holder, :checkout, []}})
+               end) == :ok
+      end)
+
+    assert log =~ "t tick skipped"
+    assert log =~ ":timeout"
+  end
+
+  test "a throwing tick is skipped" do
+    log = capture_log(fn -> assert TelemetryTick.run("t", fn -> throw(:oops) end) == :ok end)
+    assert log =~ "t tick skipped"
+    assert log =~ ":oops"
+  end
+
+  test "a healthy tick returns :ok and logs nothing" do
+    log = capture_log(fn -> assert TelemetryTick.run("t", fn -> :fine end) == :ok end)
+    refute log =~ "skipped"
+  end
+
+  # The wiring half: both poller measurement functions must run through the
+  # guard. String-level rather than behavioral because forcing a genuine
+  # Repo exit deterministically in a sandboxed test is not possible — and a
+  # future refactor that reintroduces a bare rescue is exactly what this
+  # catches.
+  test "funnel and ops gauges ticks run through the guard" do
+    # Umbrella tests run with cwd at the app root.
+    for source <- ["lib/fountain/funnel.ex", "lib/fountain/ops_gauges.ex"] do
+      assert File.read!(source) =~ "Fountain.TelemetryTick.run(",
+             "#{source} no longer routes its poller tick through Fountain.TelemetryTick (#395)"
+    end
+  end
+end


### PR DESCRIPTION
Closes #395 (P1, audit-2026-08-03 #416).

`telemetry_poller` drops a measurement that fails in **any** class (`Class:Reason:Stacktrace` matches error, exit and throw), but the #365 guards were `rescue`-only — so a `Repo` exit (checkout timeout, dying pool: `exit({:timeout, ...})`, `exit({:noproc, ...})`) still permanently unhooked the funnel and #321 ops gauges, silently.

Both ticks now run through a shared `Fountain.TelemetryTick.run/2` that covers all three classes, keeping the skip-and-retry semantics and the log line. The duplicated guard comment lives once, on the module.

Tests: the guard is driven with a raise, an **exit** (the case the old code failed — forcing a genuine Repo exit deterministically under the SQL sandbox isn't possible, which is also why the existing #365 tests, which force a raise, kept passing with this hole open), and a throw; plus a wiring assertion that both measurement functions still route through the guard, so a refactor back to a bare `rescue` fails. Existing #365 tests pass unchanged. `mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)