### PR TITLE
toolchain: reconcile the prod image with .tool-versions and enforce the lockstep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #     generation here — fail-fast at boot if it's missing rather than
 #     silently invalidate cookie sessions on every restart.
 
-FROM hexpm/elixir:1.19.5-erlang-28.0.1-debian-bookworm-20260505-slim AS build
+FROM hexpm/elixir:1.19.2-erlang-28.3-debian-bookworm-20260505-slim AS build
 
 ENV MIX_ENV=prod
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -111,6 +111,8 @@ Production is home-cloud Kubernetes, deployed via Flux: the image is built from 
 | `Dockerfile`               | the `FROM hexpm/elixir:<elixir>-erlang-<otp>-...` build-stage base image |
 | `.github/workflows/ci.yml` | `elixir-version` / `otp-version` in the `erlef/setup-beam` step      |
 
+The lockstep is enforced by `apps/fountain/test/fountain/toolchain_lockstep_test.exs` — if the three pins disagree, the test suite goes red.
+
 ## Troubleshooting
 
 - **`role "postgres" does not exist`** — see step 4. Either `docker compose up -d postgres` or create the native role.

--- a/apps/fountain/test/fountain/toolchain_lockstep_test.exs
+++ b/apps/fountain/test/fountain/toolchain_lockstep_test.exs
@@ -1,0 +1,108 @@
+defmodule Fountain.ToolchainLockstepTest do
+  use ExUnit.Case, async: true
+
+  # Guards the Erlang/Elixir toolchain pins against drifting apart (#404).
+  # The toolchain is pinned in three places — `.tool-versions` (local dev via
+  # mise), the `Dockerfile` build-stage base image (production release), and
+  # the `erlef/setup-beam` inputs in `.github/workflows/ci.yml` — and
+  # SETUP.md's parity reference says a bump must update all of them. Before
+  # this test the rule existed only as prose, and had already been violated:
+  # production built on an Elixir/OTP pair the suite never ran against.
+  #
+  # Parsing is tolerant of surrounding format (image tag suffix, quoting,
+  # `-otp-N` qualifiers); version equality is strict.
+
+  @repo_root Path.expand("../../../..", __DIR__)
+
+  test ".tool-versions, the Dockerfile base image, and CI setup-beam pin the same Elixir and OTP" do
+    tool_versions = parse_tool_versions()
+    dockerfile = parse_dockerfile()
+    ci = parse_ci()
+
+    mismatches =
+      for {language, key} <- [{"Elixir", :elixir}, {"Erlang/OTP", :otp}],
+          pins = [
+            {".tool-versions", tool_versions[key]},
+            {"Dockerfile", dockerfile[key]},
+            {".github/workflows/ci.yml", ci[key]}
+          ],
+          pins |> Enum.map(&elem(&1, 1)) |> Enum.uniq() |> length() > 1 do
+        rows = Enum.map_join(pins, "\n", fn {where, version} -> "    #{where}: #{version}" end)
+        "  #{language} pins disagree:\n#{rows}"
+      end
+
+    assert mismatches == [],
+           """
+           The toolchain pins have drifted apart:
+
+           #{Enum.join(mismatches, "\n")}
+
+           Dev/CI and the production release image must build on the same
+           Elixir and OTP. Update all three pins together — see the
+           "Production parity reference" section of SETUP.md.
+           """
+  end
+
+  # ── extraction ────────────────────────────────────────────────────────────
+  #
+  # Each parser asserts its own success so a format change fails loudly with
+  # a pointer at the file that changed, instead of the main assertion
+  # comparing nils.
+
+  defp parse_tool_versions do
+    source = File.read!(Path.join(@repo_root, ".tool-versions"))
+
+    # `erlang 28.3`
+    otp = capture(~r/^erlang\s+(\d+(?:\.\d+)*)\s*$/m, source)
+
+    # `elixir 1.19.2-otp-28` — the `-otp-N` qualifier names the OTP major the
+    # precompiled Elixir targets; the toolchain version is the leading part.
+    elixir = capture(~r/^elixir\s+(\d+(?:\.\d+)*)(?:-otp-\d+)?\s*$/m, source)
+
+    assert otp && elixir,
+           "could not extract erlang/elixir pins from .tool-versions — the file format changed"
+
+    %{elixir: elixir, otp: otp}
+  end
+
+  defp parse_dockerfile do
+    source = File.read!(Path.join(@repo_root, "Dockerfile"))
+
+    # `FROM hexpm/elixir:<elixir>-erlang-<otp>-<os...>` — tolerate any OS
+    # suffix (debian/ubuntu/alpine, snapshot date, -slim).
+    case Regex.run(
+           ~r/^FROM\s+hexpm\/elixir:(\d+(?:\.\d+)*)-erlang-(\d+(?:\.\d+)*)-/m,
+           source
+         ) do
+      [_, elixir, otp] ->
+        %{elixir: elixir, otp: otp}
+
+      nil ->
+        flunk(
+          "could not extract the hexpm/elixir base image tag from the Dockerfile — " <>
+            "the FROM line or tag format changed"
+        )
+    end
+  end
+
+  defp parse_ci do
+    source = File.read!(Path.join(@repo_root, ".github/workflows/ci.yml"))
+
+    # `elixir-version: "1.19.2"` / `otp-version: "28.3"` (quotes optional)
+    elixir = capture(~r/^\s*elixir-version:\s*"?(\d+(?:\.\d+)*)"?\s*$/m, source)
+    otp = capture(~r/^\s*otp-version:\s*"?(\d+(?:\.\d+)*)"?\s*$/m, source)
+
+    assert elixir && otp,
+           "could not extract elixir-version/otp-version from .github/workflows/ci.yml — " <>
+             "the setup-beam inputs changed"
+
+    %{elixir: elixir, otp: otp}
+  end
+
+  defp capture(regex, source) do
+    case Regex.run(regex, source, capture: :all_but_first) do
+      [value] -> value
+      nil -> nil
+    end
+  end
+end

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,7 +26,7 @@ cd fountain
 mise install
 ```
 
-Reads `.tool-versions` and installs Erlang/OTP 28 + Elixir 1.19.2. The same pinned versions are used in production.
+Reads `.tool-versions` and installs the pinned Erlang/OTP and Elixir versions. `.tool-versions` pins the *local* toolchain only; production runs the release image built from the repo-root `Dockerfile`, whose base image pins its own Erlang/Elixir (see the production parity reference in `SETUP.md`).
 
 Verify:
 


### PR DESCRIPTION
Fixes #404.

## What drifted

| Where | Elixir | OTP |
|---|---|---|
| `.tool-versions` | 1.19.2 | 28.3 |
| `.github/workflows/ci.yml` | 1.19.2 | 28.3 |
| `Dockerfile` (before) | **1.19.5** | **28.0.1** |

The production release image built on a higher Elixir and a *lower* OTP than anything the test suite ran against, while `SETUP.md`, `README.md`, and `docs/setup.md` all claimed the pins move in lockstep. Nothing enforced the rule.

## Changes

- **`Dockerfile`** — build-stage base image is now `hexpm/elixir:1.19.2-erlang-28.3-debian-bookworm-20260505-slim`: same debian variant and snapshot date as before, Elixir/OTP now matching `.tool-versions` and CI exactly. The tag was verified to exist on Docker Hub before choosing it.
- **`docs/setup.md`** — removes the stale "The same pinned versions are used in production" sentence; this is the claim #320 corrected in `SETUP.md` but the published twin was not in that commit. Wording now mirrors `SETUP.md`.
- **`apps/fountain/test/fountain/toolchain_lockstep_test.exs`** (new) — parses `.tool-versions`, the `hexpm/elixir` base-image tag in the `Dockerfile`, and the `erlef/setup-beam` inputs in `ci.yml`, and fails with a per-file breakdown if any Elixir or OTP pin disagrees. Parsing is tolerant of tag/format changes (and fails loudly if extraction stops matching); version equality is strict.
- **`SETUP.md`** — one-line note that the parity rule is now test-enforced rather than prose-only.

## Verification

- The new test **fails** against the pre-fix Dockerfile (verified by stashing the Dockerfile change and re-running: it reports `Elixir 1.19.2 vs 1.19.5`, `OTP 28.3 vs 28.0.1`) and **passes** with the fix.
- `mix precommit` fully green (1780 tests, 0 failures).

## Note for reviewers

CI does not build the Docker image on PRs — the image build itself is exercised by the repo's build workflow on merge. Please watch the first post-merge build: it is the first compile of the release on the 1.19.2/28.3 base image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)