### PR TITLE
self-host: treat compose-style empty strings as unset for mail and SPRITES_TOKEN

### DIFF
--- a/apps/fountain/test/fountain/mailer_config_test.exs
+++ b/apps/fountain/test/fountain/mailer_config_test.exs
@@ -133,6 +133,69 @@ defmodule Fountain.MailerConfigTest do
     end
   end
 
+  describe "compose-style empty strings (#396)" do
+    # docker-compose.yml passes optional vars as `${VAR:-}`, which interpolates
+    # to an empty *string* — the variable is set, not absent — and "" is truthy
+    # in Elixir. These tests therefore SET the variables to "" rather than
+    # deleting them; deleting is the case every other test already covers and
+    # is exactly how this bug survived.
+    test "a blank RESEND_API_KEY does not select the Resend adapter", %{base: base} do
+      # The stock compose file: EMAIL_DELIVERY=none plus every mail var blank.
+      # The opt-out branch must be reachable, not shadowed by Resend.
+      config =
+        base
+        |> Map.merge(%{
+          "RESEND_API_KEY" => "",
+          "SMTP_HOST" => "",
+          "SMTP_USERNAME" => "",
+          "SMTP_PASSWORD" => "",
+          "EMAIL_DELIVERY" => "none"
+        })
+        |> read_prod()
+
+      assert config == nil or config[:adapter] == Swoosh.Adapters.Local
+    end
+
+    test "a blank RESEND_API_KEY does not shadow a configured SMTP host", %{base: base} do
+      config =
+        base
+        |> Map.merge(%{"RESEND_API_KEY" => "", "SMTP_HOST" => "smtp.example.com"})
+        |> read_prod()
+
+      assert config[:adapter] == Swoosh.Adapters.SMTP
+      assert config[:relay] == "smtp.example.com"
+    end
+
+    test "a blank SMTP_USERNAME skips auth", %{base: base} do
+      # `${SMTP_USERNAME:-}` against an unauthenticated relay must not force
+      # auth: :always with an empty username.
+      config =
+        base
+        |> Map.merge(%{"SMTP_HOST" => "relay.internal", "SMTP_USERNAME" => ""})
+        |> read_prod()
+
+      assert config[:auth] == :never
+      assert config[:username] == nil
+    end
+
+    test "all-blank mail vars still refuse to boot", %{base: base} do
+      # Blank must behave exactly like unset: with no EMAIL_DELIVERY opt-out,
+      # the actionable raise fires rather than Resend being selected with "".
+      for k <- @mail_vars, do: System.delete_env(k)
+
+      base
+      |> Map.merge(%{"RESEND_API_KEY" => "", "SMTP_HOST" => "", "SMTP_USERNAME" => ""})
+      |> System.put_env()
+
+      error =
+        assert_raise RuntimeError, fn ->
+          Config.Reader.read!(@runtime_exs, env: :prod)
+        end
+
+      assert error.message =~ "No mail delivery is configured"
+    end
+  end
+
   describe "EMAIL_DELIVERY=none" do
     test "boots without configuring an adapter", %{base: base} do
       # Deliberate opt-out for an OAuth-only or evaluation instance. It must be

--- a/apps/fountain/test/fountain/sprites_token_config_test.exs
+++ b/apps/fountain/test/fountain/sprites_token_config_test.exs
@@ -1,0 +1,60 @@
+defmodule Fountain.SpritesTokenConfigTest do
+  @moduledoc """
+  Evaluates `config/runtime.exs` the way the release config provider does,
+  pinning #396: a blank SPRITES_TOKEN must be stored as nil, not "".
+
+  docker-compose.yml passes `${SPRITES_TOKEN:-}` and .env.compose.example
+  ships the key blank, so the compose quick-start delivers a present-but-empty
+  variable. Stored verbatim, `""` is truthy and defeats the
+  `Application.get_env(:fountain, :sprites_token) || raise` guard in
+  `Fountain.SpritesClient.get!/0` — the operator's first conversation then
+  fails with an opaque 401 from sprites.dev instead of the message written
+  for exactly that case.
+  """
+
+  # Mutates process env, so it must not run alongside anything else.
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+
+  @base %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "RESEND_API_KEY" => "re_test_key"
+  }
+
+  setup do
+    previous = System.get_env()
+    key = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+
+    on_exit(fn ->
+      System.put_env(previous)
+
+      for k <- ["SPRITES_TOKEN", "MASTER_SECRETS_KEY"],
+          not Map.has_key?(previous, k),
+          do: System.delete_env(k)
+    end)
+
+    {:ok, base: Map.put(@base, "MASTER_SECRETS_KEY", key)}
+  end
+
+  defp read_prod(env) do
+    System.delete_env("SPRITES_TOKEN")
+    System.put_env(env)
+    Config.Reader.read!(@runtime_exs, env: :prod)[:fountain][:sprites_token]
+  end
+
+  test "a blank SPRITES_TOKEN is stored as nil, so the SpritesClient guard fires", %{base: base} do
+    # SET to "" rather than deleted — the compose `${SPRITES_TOKEN:-}` case.
+    assert read_prod(Map.put(base, "SPRITES_TOKEN", "")) == nil
+  end
+
+  test "an unset SPRITES_TOKEN is stored as nil", %{base: base} do
+    assert read_prod(base) == nil
+  end
+
+  test "a real token is stored verbatim", %{base: base} do
+    assert read_prod(Map.put(base, "SPRITES_TOKEN", "sk-sprites-abc")) == "sk-sprites-abc"
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -68,7 +68,19 @@ master_secrets_key =
   end
 
 config :fountain, :master_secrets_key, master_secrets_key
-config :fountain, :sprites_token, System.get_env("SPRITES_TOKEN")
+
+# "" counts as unset (#396): docker-compose.yml passes `${SPRITES_TOKEN:-}`,
+# which delivers a present-but-empty variable, and .env.compose.example ships
+# the key blank. Stored verbatim, "" is truthy, so SpritesClient.get!/0's
+# `|| raise "SPRITES_TOKEN is not set"` never fired and the operator got an
+# opaque 401 from sprites.dev instead of the message written for this case.
+sprites_token =
+  case System.get_env("SPRITES_TOKEN") do
+    blank when blank in [nil, ""] -> nil
+    token -> token
+  end
+
+config :fountain, :sprites_token, sprites_token
 
 # SpritesClient has read :sprites_base_url from application env since it was
 # written, but nothing ever set it — so the default was the only value, and
@@ -350,21 +362,47 @@ config :fountain, :stripe_price_monthly_cents, stripe_price_monthly_cents
 if config_env() == :prod do
   config :fountain, :email_from, System.get_env("EMAIL_FROM", "noreply@updates.inevitable.fyi")
 
-  cond do
-    api_key = System.get_env("RESEND_API_KEY") ->
-      config :fountain, Fountain.Mailer, adapter: Swoosh.Adapters.Resend, api_key: api_key
+  # "" counts as unset for the adapter choice (#396): docker-compose.yml passes
+  # `${RESEND_API_KEY:-}` / `${SMTP_HOST:-}` / `${SMTP_USERNAME:-}`, which
+  # deliver present-but-empty variables — and "" is truthy, so a blank
+  # RESEND_API_KEY selected the Resend adapter, made the EMAIL_DELIVERY=none
+  # and SMTP branches unreachable under compose, and POSTed every verification
+  # email (recipient address + signed URL) to api.resend.com to be 401'd.
+  # A blank SMTP_USERNAME likewise forced `auth: :always` with an empty
+  # username against unauthenticated relays.
+  resend_api_key =
+    case System.get_env("RESEND_API_KEY") do
+      blank when blank in [nil, ""] -> nil
+      key -> key
+    end
 
-    smtp_host = System.get_env("SMTP_HOST") ->
+  smtp_host =
+    case System.get_env("SMTP_HOST") do
+      blank when blank in [nil, ""] -> nil
+      host -> host
+    end
+
+  smtp_username =
+    case System.get_env("SMTP_USERNAME") do
+      blank when blank in [nil, ""] -> nil
+      username -> username
+    end
+
+  cond do
+    resend_api_key ->
+      config :fountain, Fountain.Mailer, adapter: Swoosh.Adapters.Resend, api_key: resend_api_key
+
+    smtp_host ->
       config :fountain, Fountain.Mailer,
         adapter: Swoosh.Adapters.SMTP,
         relay: smtp_host,
         port: String.to_integer(System.get_env("SMTP_PORT", "587")),
-        username: System.get_env("SMTP_USERNAME"),
+        username: smtp_username,
         password: System.get_env("SMTP_PASSWORD"),
         # STARTTLS by default; set SMTP_TLS=never for a relay on a trusted
         # network that does not offer it.
         tls: String.to_atom(System.get_env("SMTP_TLS", "always")),
-        auth: if(System.get_env("SMTP_USERNAME"), do: :always, else: :never),
+        auth: if(smtp_username, do: :always, else: :never),
         retries: 2
 
     System.get_env("EMAIL_DELIVERY") == "none" ->


### PR DESCRIPTION
Fixes #396.

## Problem

`docker-compose.yml` passes optional variables as `${VAR:-}`, which interpolates to an empty **string** — Compose sets the variable rather than omitting it — and `""` is truthy in Elixir. Every `runtime.exs` guard written for "unset" therefore failed under compose:

- `RESEND_API_KEY=""` matched the first `cond` clause, so the `EMAIL_DELIVERY=none` branch (the stock compose configuration, whose stderr notice is the operator's only signpost to `Fountain.Release.verify_email/1`) and the SMTP branch were both unreachable — and every signup/password-reset POSTed the recipient's address plus a live signed URL to `api.resend.com`, which 401'd it.
- `SMTP_USERNAME=""` forced `auth: :always` with an empty username against unauthenticated relays.
- `SPRITES_TOKEN=""` was stored verbatim into `:fountain, :sprites_token`, defeating the `|| raise "SPRITES_TOKEN is not set"` guard in `Fountain.SpritesClient.get!/0` (`apps/fountain/lib/fountain/sprites_client.ex:15-17`) — an operator following the quick start got an opaque 401 on their first conversation instead of the message written for exactly that case.

## Fix

Normalize blank → absent at the config boundary in `config/runtime.exs` for `RESEND_API_KEY`, `SMTP_HOST`, `SMTP_USERNAME` and `SPRITES_TOKEN`, using the `case System.get_env(...) do blank when blank in [nil, ""] ->` idiom the file already applies to `METRICS_PORT`, `PHX_HOST`, `SECRET_KEY_BASE`, `MASTER_SECRETS_KEY` and others — this was an inconsistency, not a house style.

## Tests

Per the audit lesson, the new tests **set each variable to `""`** rather than deleting it — deleting is the case the existing tests already covered, and is exactly how this bug survived:

- `mailer_config_test.exs`: blank `RESEND_API_KEY` doesn't select Resend (the `EMAIL_DELIVERY=none` branch is reachable), doesn't shadow a configured SMTP host; blank `SMTP_USERNAME` yields `auth: :never`; all-blank mail vars still hit the actionable "No mail delivery is configured" raise.
- New `sprites_token_config_test.exs`: `SPRITES_TOKEN=""` stores `nil` (so the SpritesClient raise fires), plus unset→nil and real-token→verbatim.

**Revert verification**: with the `runtime.exs` change stashed, exactly the five new tests fail (and only they do); restored, all 15 in the two files pass. `mix precommit` green (1784 tests, 0 failures).

## Blast radius

- k8s unaffected: `deploy/k8s/configmap.yaml` sets real values or omits keys entirely.
- CI's release boot check uses `EMAIL_DELIVERY=none` with no blank siblings — unaffected.
- `config/test.exs` doesn't set any of these vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)