### PR TITLE
ops: fail the rows before killing a deadline-exceeded provision (#394)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -227,16 +227,17 @@ defmodule Fountain.Conversations.ConversationServer do
           if sandbox.status in ["pending", "starting"] do
             Logger.error(
               "conv #{conv_id}: provisioning exceeded #{deadline_ms}ms; " <>
-                "killing the stuck server and failing the sandbox"
+                "failing the sandbox and killing the stuck server"
             )
 
-            # :kill, not :shutdown — a trapped exit would just queue behind
-            # the stuck callback. terminate/2 does not run; the row updates
-            # below free the quota slot, expires_at bounds the un-revoked
-            # callback key, and the reaper reclaims the sprite.
-            Process.exit(server, :kill)
-
-            publish_stage(conv_id, "provision", "failed", %{reason: "provision deadline exceeded"})
+            # Rows BEFORE the kill (#394). The server is restart: :transient
+            # and :killed is an abnormal exit, so a kill-first ordering let
+            # Horde restart it into handle_continue(:provision) while the row
+            # still said pending — and the restart re-provisioned a second
+            # billable sprite, then kept streaming into it while this stale
+            # struct's late "failed" write made the row lie about it. With
+            # the terminal status committed first, a restarted server stops
+            # at the terminal-status guard in :provision.
             {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
 
             case Conversations._unsafe_get_conversation(conv_id) do
@@ -245,6 +246,22 @@ defmodule Fountain.Conversations.ConversationServer do
 
               _ ->
                 :ok
+            end
+
+            publish_stage(conv_id, "provision", "failed", %{reason: "provision deadline exceeded"})
+
+            # Prefer supervisor termination over Process.exit: it removes the
+            # child, so no restart happens at all, and it bounds the wait —
+            # the server traps exits and is stuck in a callback, so the
+            # :shutdown signal queues until the child-spec shutdown timeout
+            # expires and the supervisor escalates to :kill. terminate/2
+            # still does not run for the stuck server; expires_at bounds the
+            # un-revoked callback key, and the reaper reclaims the sprite.
+            # The fallback covers a server not running under the supervisor
+            # (tests) or one that died in the meantime.
+            case Horde.DynamicSupervisor.terminate_child(Fountain.ConversationSupervisor, server) do
+              :ok -> :ok
+              {:error, _} -> Process.exit(server, :kill)
             end
 
             :telemetry.execute([:fountain, :provision, :deadline_exceeded], %{count: 1}, %{

--- a/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
@@ -56,6 +56,85 @@ defmodule Fountain.Conversations.ConversationServerProvisionDeadlineTest do
     assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
   end
 
+  test "the rows are terminal before the server is terminated (#394)" do
+    # Pre-#394 the watchdog killed first and wrote the rows after. The server
+    # is restart: :transient, so under Horde the kill triggered a restart that
+    # re-read a still-pending row and provisioned a second billable sprite.
+    # This pins the new contract: termination goes through the supervisor,
+    # and by the time it happens the sandbox row is already failed — which is
+    # what makes any restart stop at the terminal-status guard.
+    stub_happy_sprite()
+
+    Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->
+      Process.sleep(:infinity)
+    end)
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+    test_pid = self()
+    sandbox_id = conv.sandbox_id
+
+    Mimic.stub(Horde.DynamicSupervisor, :terminate_child, fn _sup, pid ->
+      status = Conversations._unsafe_get_sandbox!(sandbox_id).status
+      send(test_pid, {:status_at_termination, status})
+      Process.exit(pid, :kill)
+      :ok
+    end)
+
+    args = [
+      conversation_id: conv.id,
+      sandbox_id: conv.sandbox_id,
+      runtime_module: Fountain.Test.FakeRuntime
+    ]
+
+    {:ok, pid} = GenServer.start(Fountain.Conversations.ConversationServer, args)
+    ref = Process.monitor(pid)
+
+    assert_receive {:status_at_termination, "failed"}, 5_000
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 5_000
+  end
+
+  test "a server restarted after the deadline provisions no second sprite (#394)" do
+    sprite = stub_happy_sprite()
+    test_pid = self()
+
+    # Count every sprite creation across all processes (global mode).
+    Mimic.stub(Sprites, :create, fn _client, _name ->
+      send(test_pid, :sprite_created)
+      {:ok, sprite}
+    end)
+
+    Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->
+      Process.sleep(:infinity)
+    end)
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+
+    args = [
+      conversation_id: conv.id,
+      sandbox_id: conv.sandbox_id,
+      runtime_module: Fountain.Test.FakeRuntime
+    ]
+
+    {:ok, pid} = GenServer.start(Fountain.Conversations.ConversationServer, args)
+    ref = Process.monitor(pid)
+
+    assert_receive :sprite_created, 5_000
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 5_000
+
+    # What Horde's transient restart does after the watchdog fires: start a
+    # fresh server on the same conversation, immediately. It must read the
+    # terminal row and stop — never create a second sprite.
+    {:ok, pid2} = GenServer.start(Fountain.Conversations.ConversationServer, args)
+    ref2 = Process.monitor(pid2)
+
+    assert_receive {:DOWN, ^ref2, :process, ^pid2, :normal}, 5_000
+    refute_received :sprite_created
+  end
+
   test "a provision that completes in time is left alone" do
     stub_happy_sprite()
     user = insert_verified_user()


### PR DESCRIPTION
Closes #394 (P1, audit-2026-08-03 #416).

## Problem

The #329 watchdog did `Process.exit(server, :kill)` and then wrote the failed/failed transitions. `restart: :transient` + `:killed` means Horde restarts the server; the restart re-read a still-`pending` row and ran `fresh_provision` — a second billable sprite per watchdog firing, a server whose row disagrees with reality, and the reaper destroying the live sprite within the hour.

## Fix

- Row transitions (sandbox `failed`, conversation `failed`, the stage event) commit **before** termination, so a restarted server stops at the existing terminal-status guard.
- Termination prefers `Horde.DynamicSupervisor.terminate_child/2` — it removes the child (no restart at all) and bounds the wait: the server traps exits and is stuck in a callback, so the `:shutdown` signal queues until the child-spec shutdown timeout and the supervisor escalates to `:kill`. `Process.exit(:kill)` stays as the fallback for servers not under the supervisor (the test harness) or already gone.

## Tests

- **Ordering, deterministic**: a `terminate_child` stub (Mimic global mode) reads the sandbox row at termination time and asserts it is already `failed`. Fails against the old watchdog.
- **Restart emulation**: after the deadline fires, a second server started on the same conversation (what the transient restart did) stops `:normal` with **no second `Sprites.create`** — the regression the issue asked for. Note stated honestly: pre-fix this one is timing-dependent (the emulated restart starts after DOWN, and the old code's late row-write can land first); the ordering test above is the deterministic pre-fix failure.
- Both original deadline tests pass unchanged.

`mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)