### PR TITLE
self-host: pass every advertised optional through the compose environment block

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -72,3 +72,17 @@ SPRITES_TOKEN=
 # Close registration once your own account exists.
 # REGISTRATION_ENABLED=false
 # REGISTRATION_ALLOWED_EMAIL_DOMAINS=example.com
+
+# Behind a reverse proxy, list the proxy's address range(s) before exposing
+# the instance, so the app resolves real client IPs from X-Forwarded-For —
+# otherwise per-IP rate limits collapse into one bucket keyed on the proxy.
+# TRUSTED_PROXIES=172.16.0.0/12
+
+# Error tracking. Off unless set — nothing leaves your instance without it.
+# SENTRY_DSN=
+
+# Only meaningful against an external Postgres serving TLS (which also means
+# editing DATABASE_URL and DATABASE_SSL in docker-compose.yml): verify the
+# server certificate, with an explicit CA bundle or the OS trust store.
+# DATABASE_SSL_VERIFY=true
+# DATABASE_SSL_CA_FILE=/etc/ssl/certs/your-ca.pem

--- a/apps/fountain/test/fountain/compose_passthrough_config_test.exs
+++ b/apps/fountain/test/fountain/compose_passthrough_config_test.exs
@@ -1,0 +1,115 @@
+defmodule Fountain.ComposePassthroughConfigTest do
+  @moduledoc """
+  Evaluates `config/runtime.exs` the way the release config provider does,
+  pinning the blank-string behaviour of the variables #397 newly passes
+  through the compose `environment:` block as `${VAR:-}`.
+
+  Compose interpolates an unset `${VAR:-}` to an empty *string* — the
+  variable arrives set, not absent — so every default here must survive `""`.
+  These tests SET the variables to `""` rather than deleting them; deleting
+  is how the #396 predecessors of these bugs went unnoticed.
+  """
+
+  # Mutates process env, so it must not run alongside anything else.
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+
+  @vars ~w(TRUSTED_PROXIES SENTRY_DSN DATABASE_SSL_VERIFY DATABASE_SSL_CA_FILE)
+
+  @base %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "RESEND_API_KEY" => "re_test_key"
+  }
+
+  setup do
+    previous = System.get_env()
+    key = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+
+    on_exit(fn ->
+      System.put_env(previous)
+
+      for k <- @vars ++ ["MASTER_SECRETS_KEY"],
+          not Map.has_key?(previous, k),
+          do: System.delete_env(k)
+    end)
+
+    {:ok, base: Map.put(@base, "MASTER_SECRETS_KEY", key)}
+  end
+
+  defp read_prod(env) do
+    for k <- @vars, do: System.delete_env(k)
+    System.put_env(env)
+    Config.Reader.read!(@runtime_exs, env: :prod)
+  end
+
+  describe "TRUSTED_PROXIES" do
+    test "blank leaves the built-in default in place", %{base: base} do
+      # An empty list here would override the endpoint's default CIDRs — a
+      # blank value must mean "not configured", not "trust nothing".
+      cfg = read_prod(Map.put(base, "TRUSTED_PROXIES", ""))
+
+      refute Keyword.has_key?(cfg[:fountain], :trusted_proxies)
+    end
+
+    test "a real list is split and trimmed", %{base: base} do
+      cfg = read_prod(Map.put(base, "TRUSTED_PROXIES", "10.0.0.0/8, 172.16.0.0/12"))
+
+      assert cfg[:fountain][:trusted_proxies] == ["10.0.0.0/8", "172.16.0.0/12"]
+    end
+  end
+
+  describe "SENTRY_DSN" do
+    test "blank stays nil rather than handing the SDK an empty DSN", %{base: base} do
+      cfg = read_prod(Map.put(base, "SENTRY_DSN", ""))
+
+      assert cfg[:sentry][:dsn] == nil
+    end
+
+    test "a real DSN is stored verbatim", %{base: base} do
+      cfg = read_prod(Map.put(base, "SENTRY_DSN", "https://k@o0.ingest.sentry.io/1"))
+
+      assert cfg[:sentry][:dsn] == "https://k@o0.ingest.sentry.io/1"
+    end
+  end
+
+  describe "DATABASE_SSL_VERIFY / DATABASE_SSL_CA_FILE" do
+    test "verify with a blank CA file falls back to the OS trust store", %{base: base} do
+      # verify_peer with `cacertfile: ''` would reject every certificate.
+      cfg =
+        base
+        |> Map.merge(%{"DATABASE_SSL_VERIFY" => "true", "DATABASE_SSL_CA_FILE" => ""})
+        |> read_prod()
+
+      opts = cfg[:fountain][Fountain.Repo][:ssl_opts]
+      assert opts[:verify] == :verify_peer
+      assert is_list(opts[:cacerts])
+      refute Keyword.has_key?(opts, :cacertfile)
+    end
+
+    test "verify with an explicit CA file uses it", %{base: base} do
+      cfg =
+        base
+        |> Map.merge(%{
+          "DATABASE_SSL_VERIFY" => "true",
+          "DATABASE_SSL_CA_FILE" => "/etc/ssl/certs/rds.pem"
+        })
+        |> read_prod()
+
+      opts = cfg[:fountain][Fountain.Repo][:ssl_opts]
+      assert opts[:verify] == :verify_peer
+      assert opts[:cacertfile] == ~c"/etc/ssl/certs/rds.pem"
+    end
+
+    test "a blank DATABASE_SSL_VERIFY keeps the historical verify_none", %{base: base} do
+      cfg =
+        base
+        |> Map.merge(%{"DATABASE_SSL_VERIFY" => "", "DATABASE_SSL_CA_FILE" => ""})
+        |> read_prod()
+
+      assert cfg[:fountain][Fountain.Repo][:ssl_opts] == [verify: :verify_none]
+    end
+  end
+end

--- a/apps/fountain/test/fountain/config_reference_test.exs
+++ b/apps/fountain/test/fountain/config_reference_test.exs
@@ -109,20 +109,23 @@ defmodule Fountain.ConfigReferenceTest do
   # interpolation or by another service, not by the release.
   @compose_only ~w()
 
-  test "every env var the compose app service sets is one the app reads" do
-    source = File.read!(Path.join(@repo_root, "config/runtime.exs"))
-    compose = File.read!(Path.join(@repo_root, "docker-compose.yml"))
-
-    # The environment mapping of the `app:` service: keys at 6-space indent
-    # between its `environment:` line and the next 4-space-indented key.
+  # The environment mapping of the `app:` service: keys at 6-space indent
+  # between its `environment:` line and the next 4-space-indented key.
+  defp compose_app_env_keys(compose) do
     [_, app_section] = String.split(compose, ~r/^  app:\n/m, parts: 2)
     [_, env_and_rest] = String.split(app_section, ~r/^    environment:\n/m, parts: 2)
     [env_block | _] = String.split(env_and_rest, ~r/^    [a-z]/m, parts: 2)
 
-    keys =
-      Regex.scan(~r/^      ([A-Z][A-Z0-9_]*):/m, env_block, capture: :all_but_first)
-      |> List.flatten()
-      |> Enum.uniq()
+    Regex.scan(~r/^      ([A-Z][A-Z0-9_]*):/m, env_block, capture: :all_but_first)
+    |> List.flatten()
+    |> Enum.uniq()
+  end
+
+  test "every env var the compose app service sets is one the app reads" do
+    source = File.read!(Path.join(@repo_root, "config/runtime.exs"))
+    compose = File.read!(Path.join(@repo_root, "docker-compose.yml"))
+
+    keys = compose_app_env_keys(compose)
 
     assert length(keys) > 5,
            "extracted only #{length(keys)} compose env keys — the compose layout changed"
@@ -140,6 +143,59 @@ defmodule Fountain.ConfigReferenceTest do
              #{Enum.join(unread, ", ")}
 
            Remove the key, or add it to @compose_only/@read_elsewhere with a reason.
+           """
+  end
+
+  # ── advertised → passed through (#397) ───────────────────────────────────
+  #
+  # The compose `environment:` block is a closed allowlist: only the keys it
+  # names reach the container. The test above is one-directional by
+  # construction — it checks every key compose *sets* is read, never that
+  # every variable the example file *advertises* is passed through. That gap
+  # is how SPRITES_BASE_URL, CHECK_ORIGIN_EXTRA, the sandbox bounds and
+  # REGISTRATION_ALLOWED_EMAIL_DOMAINS shipped in .env.compose.example while
+  # silently doing nothing.
+
+  # Consumed by compose interpolation itself, never by the app process:
+  #   FOUNTAIN_IMAGE_TAG — the app image tag (`image:` line)
+  #   POSTGRES_PASSWORD  — postgres/backup services and the DATABASE_URL
+  #                        interpolation; the app only sees the composed URL
+  #   PORT               — the host side of the port mapping; the container
+  #                        side is pinned to 4000
+  @interpolation_only ~w(FOUNTAIN_IMAGE_TAG POSTGRES_PASSWORD PORT)
+
+  test "every variable advertised in .env.compose.example reaches the app service" do
+    example = File.read!(Path.join(@repo_root, ".env.compose.example"))
+    compose = File.read!(Path.join(@repo_root, "docker-compose.yml"))
+
+    # A key is "advertised" when a line offers it for the operator to set:
+    # either active (`KEY=`) or commented out as an example (`# KEY=value`).
+    advertised =
+      Regex.scan(~r/^(?:# )?([A-Z][A-Z0-9_]*)=/m, example, capture: :all_but_first)
+      |> List.flatten()
+      |> Enum.uniq()
+
+    # Vacuous-pass guard, mirroring the other tests in this file.
+    assert length(advertised) > 10,
+           "extracted only #{length(advertised)} advertised keys — the example format changed"
+
+    passed = compose_app_env_keys(compose)
+
+    dropped =
+      Enum.reject(advertised, fn var ->
+        var in passed or var in @interpolation_only
+      end)
+
+    assert dropped == [],
+           """
+           .env.compose.example advertises variables the compose app service never passes through:
+
+             #{Enum.join(dropped, ", ")}
+
+           Setting them in .env silently does nothing. Add each to the app
+           service's environment: block (as ${VAR:-} or with the app's own
+           default), or — only for keys compose itself consumes during
+           interpolation — add them to @interpolation_only with a reason.
            """
   end
 end

--- a/apps/fountain/test/fountain/mailer_config_test.exs
+++ b/apps/fountain/test/fountain/mailer_config_test.exs
@@ -133,6 +133,69 @@ defmodule Fountain.MailerConfigTest do
     end
   end
 
+  describe "compose-style empty strings (#396)" do
+    # docker-compose.yml passes optional vars as `${VAR:-}`, which interpolates
+    # to an empty *string* — the variable is set, not absent — and "" is truthy
+    # in Elixir. These tests therefore SET the variables to "" rather than
+    # deleting them; deleting is the case every other test already covers and
+    # is exactly how this bug survived.
+    test "a blank RESEND_API_KEY does not select the Resend adapter", %{base: base} do
+      # The stock compose file: EMAIL_DELIVERY=none plus every mail var blank.
+      # The opt-out branch must be reachable, not shadowed by Resend.
+      config =
+        base
+        |> Map.merge(%{
+          "RESEND_API_KEY" => "",
+          "SMTP_HOST" => "",
+          "SMTP_USERNAME" => "",
+          "SMTP_PASSWORD" => "",
+          "EMAIL_DELIVERY" => "none"
+        })
+        |> read_prod()
+
+      assert config == nil or config[:adapter] == Swoosh.Adapters.Local
+    end
+
+    test "a blank RESEND_API_KEY does not shadow a configured SMTP host", %{base: base} do
+      config =
+        base
+        |> Map.merge(%{"RESEND_API_KEY" => "", "SMTP_HOST" => "smtp.example.com"})
+        |> read_prod()
+
+      assert config[:adapter] == Swoosh.Adapters.SMTP
+      assert config[:relay] == "smtp.example.com"
+    end
+
+    test "a blank SMTP_USERNAME skips auth", %{base: base} do
+      # `${SMTP_USERNAME:-}` against an unauthenticated relay must not force
+      # auth: :always with an empty username.
+      config =
+        base
+        |> Map.merge(%{"SMTP_HOST" => "relay.internal", "SMTP_USERNAME" => ""})
+        |> read_prod()
+
+      assert config[:auth] == :never
+      assert config[:username] == nil
+    end
+
+    test "all-blank mail vars still refuse to boot", %{base: base} do
+      # Blank must behave exactly like unset: with no EMAIL_DELIVERY opt-out,
+      # the actionable raise fires rather than Resend being selected with "".
+      for k <- @mail_vars, do: System.delete_env(k)
+
+      base
+      |> Map.merge(%{"RESEND_API_KEY" => "", "SMTP_HOST" => "", "SMTP_USERNAME" => ""})
+      |> System.put_env()
+
+      error =
+        assert_raise RuntimeError, fn ->
+          Config.Reader.read!(@runtime_exs, env: :prod)
+        end
+
+      assert error.message =~ "No mail delivery is configured"
+    end
+  end
+
   describe "EMAIL_DELIVERY=none" do
     test "boots without configuring an adapter", %{base: base} do
       # Deliberate opt-out for an OAuth-only or evaluation instance. It must be

--- a/apps/fountain/test/fountain/sprites_token_config_test.exs
+++ b/apps/fountain/test/fountain/sprites_token_config_test.exs
@@ -1,0 +1,60 @@
+defmodule Fountain.SpritesTokenConfigTest do
+  @moduledoc """
+  Evaluates `config/runtime.exs` the way the release config provider does,
+  pinning #396: a blank SPRITES_TOKEN must be stored as nil, not "".
+
+  docker-compose.yml passes `${SPRITES_TOKEN:-}` and .env.compose.example
+  ships the key blank, so the compose quick-start delivers a present-but-empty
+  variable. Stored verbatim, `""` is truthy and defeats the
+  `Application.get_env(:fountain, :sprites_token) || raise` guard in
+  `Fountain.SpritesClient.get!/0` — the operator's first conversation then
+  fails with an opaque 401 from sprites.dev instead of the message written
+  for exactly that case.
+  """
+
+  # Mutates process env, so it must not run alongside anything else.
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+
+  @base %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "RESEND_API_KEY" => "re_test_key"
+  }
+
+  setup do
+    previous = System.get_env()
+    key = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+
+    on_exit(fn ->
+      System.put_env(previous)
+
+      for k <- ["SPRITES_TOKEN", "MASTER_SECRETS_KEY"],
+          not Map.has_key?(previous, k),
+          do: System.delete_env(k)
+    end)
+
+    {:ok, base: Map.put(@base, "MASTER_SECRETS_KEY", key)}
+  end
+
+  defp read_prod(env) do
+    System.delete_env("SPRITES_TOKEN")
+    System.put_env(env)
+    Config.Reader.read!(@runtime_exs, env: :prod)[:fountain][:sprites_token]
+  end
+
+  test "a blank SPRITES_TOKEN is stored as nil, so the SpritesClient guard fires", %{base: base} do
+    # SET to "" rather than deleted — the compose `${SPRITES_TOKEN:-}` case.
+    assert read_prod(Map.put(base, "SPRITES_TOKEN", "")) == nil
+  end
+
+  test "an unset SPRITES_TOKEN is stored as nil", %{base: base} do
+    assert read_prod(base) == nil
+  end
+
+  test "a real token is stored verbatim", %{base: base} do
+    assert read_prod(Map.put(base, "SPRITES_TOKEN", "sk-sprites-abc")) == "sk-sprites-abc"
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -68,7 +68,19 @@ master_secrets_key =
   end
 
 config :fountain, :master_secrets_key, master_secrets_key
-config :fountain, :sprites_token, System.get_env("SPRITES_TOKEN")
+
+# "" counts as unset (#396): docker-compose.yml passes `${SPRITES_TOKEN:-}`,
+# which delivers a present-but-empty variable, and .env.compose.example ships
+# the key blank. Stored verbatim, "" is truthy, so SpritesClient.get!/0's
+# `|| raise "SPRITES_TOKEN is not set"` never fired and the operator got an
+# opaque 401 from sprites.dev instead of the message written for this case.
+sprites_token =
+  case System.get_env("SPRITES_TOKEN") do
+    blank when blank in [nil, ""] -> nil
+    token -> token
+  end
+
+config :fountain, :sprites_token, sprites_token
 
 # SpritesClient has read :sprites_base_url from application env since it was
 # written, but nothing ever set it — so the default was the only value, and
@@ -350,21 +362,47 @@ config :fountain, :stripe_price_monthly_cents, stripe_price_monthly_cents
 if config_env() == :prod do
   config :fountain, :email_from, System.get_env("EMAIL_FROM", "noreply@updates.inevitable.fyi")
 
-  cond do
-    api_key = System.get_env("RESEND_API_KEY") ->
-      config :fountain, Fountain.Mailer, adapter: Swoosh.Adapters.Resend, api_key: api_key
+  # "" counts as unset for the adapter choice (#396): docker-compose.yml passes
+  # `${RESEND_API_KEY:-}` / `${SMTP_HOST:-}` / `${SMTP_USERNAME:-}`, which
+  # deliver present-but-empty variables — and "" is truthy, so a blank
+  # RESEND_API_KEY selected the Resend adapter, made the EMAIL_DELIVERY=none
+  # and SMTP branches unreachable under compose, and POSTed every verification
+  # email (recipient address + signed URL) to api.resend.com to be 401'd.
+  # A blank SMTP_USERNAME likewise forced `auth: :always` with an empty
+  # username against unauthenticated relays.
+  resend_api_key =
+    case System.get_env("RESEND_API_KEY") do
+      blank when blank in [nil, ""] -> nil
+      key -> key
+    end
 
-    smtp_host = System.get_env("SMTP_HOST") ->
+  smtp_host =
+    case System.get_env("SMTP_HOST") do
+      blank when blank in [nil, ""] -> nil
+      host -> host
+    end
+
+  smtp_username =
+    case System.get_env("SMTP_USERNAME") do
+      blank when blank in [nil, ""] -> nil
+      username -> username
+    end
+
+  cond do
+    resend_api_key ->
+      config :fountain, Fountain.Mailer, adapter: Swoosh.Adapters.Resend, api_key: resend_api_key
+
+    smtp_host ->
       config :fountain, Fountain.Mailer,
         adapter: Swoosh.Adapters.SMTP,
         relay: smtp_host,
         port: String.to_integer(System.get_env("SMTP_PORT", "587")),
-        username: System.get_env("SMTP_USERNAME"),
+        username: smtp_username,
         password: System.get_env("SMTP_PASSWORD"),
         # STARTTLS by default; set SMTP_TLS=never for a relay on a trusted
         # network that does not offer it.
         tls: String.to_atom(System.get_env("SMTP_TLS", "always")),
-        auth: if(System.get_env("SMTP_USERNAME"), do: :always, else: :never),
+        auth: if(smtp_username, do: :always, else: :never),
         retries: 2
 
     System.get_env("EMAIL_DELIVERY") == "none" ->

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -160,8 +160,17 @@ config :fountain, :metrics_port, metrics_port
 # error tracker running on the same cluster as the app is down exactly when
 # it is needed. The sentry package is API-compatible with GlitchTip, so
 # pointing SENTRY_DSN at one later is the whole migration.
+#
+# "" counts as unset (#397): the compose file passes `${SENTRY_DSN:-}`, and a
+# blank string is not a DSN the SDK should be asked to parse.
+sentry_dsn =
+  case System.get_env("SENTRY_DSN") do
+    blank when blank in [nil, ""] -> nil
+    dsn -> dsn
+  end
+
 config :sentry,
-  dsn: System.get_env("SENTRY_DSN"),
+  dsn: sentry_dsn,
   environment_name: System.get_env("SENTRY_ENVIRONMENT", to_string(env)),
   # Correlates events with deploys: "this started with sha-…". Set by the
   # image build; nil locally, which the SDK accepts.
@@ -255,10 +264,18 @@ config :fountain,
 # Only widen this to cover addresses that are genuinely proxies — anything
 # trusted here is stepped over, so an over-broad list lets a client spoof its
 # way past rate limiting.
-if proxies = System.get_env("TRUSTED_PROXIES") do
-  config :fountain,
-         :trusted_proxies,
-         proxies |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+#
+# "" counts as unset (#397): the compose file passes `${TRUSTED_PROXIES:-}`,
+# and a blank value must leave the built-in default in place rather than
+# replacing it with an empty list.
+case System.get_env("TRUSTED_PROXIES") do
+  blank when blank in [nil, ""] ->
+    :ok
+
+  proxies ->
+    config :fountain,
+           :trusted_proxies,
+           proxies |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
 end
 
 # Inference credentials are per-user (BYO, ADR 0008) and live in the
@@ -453,8 +470,18 @@ if config_env() == :prod do
   # verify_none is the historical behaviour. DATABASE_SSL_VERIFY=true turns on
   # real certificate verification, using an explicit CA bundle when given and
   # the OS trust store otherwise — no extra dependency, and OTP loads it.
+  #
+  # A blank CA file counts as unset (#397): the compose file passes
+  # `${DATABASE_SSL_CA_FILE:-}`, and verify_peer with `cacertfile: ''` would
+  # reject every certificate instead of falling back to the OS trust store.
+  database_ssl_ca_file =
+    case System.get_env("DATABASE_SSL_CA_FILE") do
+      blank when blank in [nil, ""] -> nil
+      path -> path
+    end
+
   database_ssl_opts =
-    case {System.get_env("DATABASE_SSL_VERIFY"), System.get_env("DATABASE_SSL_CA_FILE")} do
+    case {System.get_env("DATABASE_SSL_VERIFY"), database_ssl_ca_file} do
       {"true", nil} ->
         [verify: :verify_peer, cacerts: :public_key.cacerts_get(), depth: 3]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,11 +44,25 @@ services:
       # A stock postgres image does not serve TLS, and this was hardcoded on —
       # which is why a compose setup could not have worked before.
       DATABASE_SSL: "false"
+      # Only meaningful against an external Postgres that serves TLS (which
+      # also means editing DATABASE_URL and DATABASE_SSL above): verify its
+      # certificate instead of the default encrypted-but-unauthenticated mode.
+      DATABASE_SSL_VERIFY: ${DATABASE_SSL_VERIFY:-}
+      DATABASE_SSL_CA_FILE: ${DATABASE_SSL_CA_FILE:-}
 
       # Absolute and scheme-ful: it builds the links in verification emails and
       # is handed to every sprite as FOUNTAIN_BASE_URL. Change it if you reach
       # this instance by anything other than localhost.
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:4000}
+
+      # Extra origins allowed to open a LiveView websocket, comma-separated.
+      # The PUBLIC_URL host is always allowed.
+      CHECK_ORIGIN_EXTRA: ${CHECK_ORIGIN_EXTRA:-}
+
+      # Behind a reverse proxy, set this to the proxy's address range before
+      # exposing the instance — otherwise per-IP rate limits collapse into a
+      # single bucket keyed on the proxy's address.
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-}
 
       # Required, but enforced by the app at boot (config/runtime.exs raises
       # a descriptive error for either one missing or empty) rather than by a
@@ -62,6 +76,16 @@ services:
       # Conversations need a Sprites token. The app boots without one; every
       # attempt to start a conversation then fails.
       SPRITES_TOKEN: ${SPRITES_TOKEN:-}
+      # Point at a different Sprites endpoint (#189). The fallback mirrors the
+      # app's own default — an unset ${VAR:-} interpolates to "", and a blank
+      # base URL is not a usable endpoint.
+      SPRITES_BASE_URL: ${SPRITES_BASE_URL:-https://api.sprites.dev}
+
+      # Sandbox lifetime bounds; 0 disables one. The fallbacks mirror the
+      # app's own defaults and are spelled out because the app refuses to
+      # boot on a non-integer, and an unset ${VAR:-} interpolates to "".
+      SANDBOX_IDLE_TIMEOUT_MINUTES: ${SANDBOX_IDLE_TIMEOUT_MINUTES:-60}
+      SANDBOX_MAX_LIFETIME_HOURS: ${SANDBOX_MAX_LIFETIME_HOURS:-24}
 
       # Off by default (the app's own default since #336, pinned here too):
       # the subscription gate is meaningful for the hosted service and is a
@@ -84,6 +108,11 @@ services:
       # Open by default so the first account can be created. Close it once
       # yours exists.
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
+      # Comma-separated. Empty means any domain may register.
+      REGISTRATION_ALLOWED_EMAIL_DOMAINS: ${REGISTRATION_ALLOWED_EMAIL_DOMAINS:-}
+
+      # Error tracking. Off unless set — nothing leaves the instance.
+      SENTRY_DSN: ${SENTRY_DSN:-}
 
       # There is no OTLP collector in a default compose setup, and without this
       # the exporter retries per span and floods the logs.


### PR DESCRIPTION
Fixes #397. **Stacked on #426** (`fix/396-blank-env-guards`) — merge after #426 lands, or retarget this PR to `main` once it does. The base matters: the pass-through deliberately builds on the blank-string normalization from #396.

## Problem

The compose `environment:` block is a closed allowlist — only the keys it names reach the container. `.env.compose.example` advertised `SPRITES_BASE_URL`, `CHECK_ORIGIN_EXTRA`, `SANDBOX_IDLE_TIMEOUT_MINUTES`, `SANDBOX_MAX_LIFETIME_HOURS` and `REGISTRATION_ALLOWED_EMAIL_DOMAINS`, and `docs/self-hosting.md` instructed setting `TRUSTED_PROXIES`, `SENTRY_DSN` and `DATABASE_SSL_VERIFY`/`DATABASE_SSL_CA_FILE` — none passed through, so following the documentation silently did nothing (and downgraded #189/#188 to partial under compose).

## Approach: explicit pass-through, not `env_file: .env`

- The `environment:` block stays a **reviewable contract** of exactly what reaches the container; `env_file` makes any future doc/example key silently load-bearing.
- `env_file` would also inject compose-side keys (`POSTGRES_PASSWORD`, `FOUNTAIN_IMAGE_TAG`, `PORT`) into the app process, and widens the present-but-empty surface #426 just closed to every variable at once.
- The issue's own caveat (env_file only after blank normalization) cuts the same way — explicit keeps the blank surface enumerable, and the drift test now makes "explicit" self-maintaining.

Where `""` would misbehave, the compose fallback mirrors the app's own default: `SPRITES_BASE_URL` (a blank base URL is not an endpoint) and the sandbox bounds (`runtime.exs` refuses to boot on a non-integer, and an unset `${VAR:-}` interpolates to `""` — `:-60`/`:-24` keep a stock `docker compose up` booting). Everything else is plain `${VAR:-}` because the app already treats blank as unset.

Three newly exposed vars needed the #396-style blank→absent guard in `runtime.exs` first, added here since this PR is what makes blanks arrive for them:

- `TRUSTED_PROXIES` — `""` was truthy and would replace the built-in default with an **empty** trusted list;
- `SENTRY_DSN` — the SDK should not be handed `""` as a DSN;
- `DATABASE_SSL_CA_FILE` — `verify_peer` with `cacertfile: ''` rejects every certificate instead of falling back to the OS trust store.

`.env.compose.example` now also advertises the prose-only vars (`TRUSTED_PROXIES`, `SENTRY_DSN`, `DATABASE_SSL_*`), so the drift test guards them.

## The drift test

`config_reference_test.exs` gains the missing direction: every `KEY=` advertised in `.env.compose.example` (active or `# KEY=` example) must appear in the app service's `environment:` block or on a justified interpolation-only allowlist (`FOUNTAIN_IMAGE_TAG`, `POSTGRES_PASSWORD`, `PORT`). The existing compose check was one-directional by construction — it asserted every key compose *sets* is read, never that every advertised key is *passed* — which is exactly how this survived.

## Verification

- Drift test run **before** the compose edit fails listing exactly the five dropped vars from the issue: `SPRITES_BASE_URL, CHECK_ORIGIN_EXTRA, SANDBOX_IDLE_TIMEOUT_MINUTES, SANDBOX_MAX_LIFETIME_HOURS, REGISTRATION_ALLOWED_EMAIL_DOMAINS`; green after.
- New `compose_passthrough_config_test.exs` pins the blank behaviour of the three guarded vars by **setting them to `""`** (never deleting); with the runtime.exs guards reverted, exactly those three blank tests fail.
- `docker-compose.yml` parses (YAML validated; docker not available in this environment).
- `mix precommit` green (1792 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)