### PR TITLE
testing: give the thirteen vacuous audit-fix tests real teeth (#406)

### DIFF
--- a/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
@@ -191,27 +191,35 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
   end
 
   describe "before a sprite exists" do
-    test "nothing is reclaimed while provisioning is still in flight" do
-      # sandbox_started_at is nil until the sprite is up. Reclaiming here would
-      # fight the provisioner; the reaper's stuck-row pass owns this case.
-      {conv, _sandbox} = aged_conversation(60 * 24)
+    test "nothing is reclaimed while sandbox_started_at is unset" do
+      # sandbox_started_at is nil until the sprite is up. Reclaiming in that
+      # window would fight the provisioner; the reaper's stuck-row pass owns
+      # it. The harness cannot hold a server mid-provision (handle_continue
+      # blocks the mailbox until it settles), so: settle the server, then
+      # clear sandbox_started_at to reproduce the in-flight state and age
+      # last_activity_at past the (tight) bounds. Only the nil guard in
+      # :lifecycle_check keeps this server alive.
+      {conv, sandbox} = aged_conversation(60 * 24)
       stub_reattach()
-      stub(Sprites, :get_sprite, fn _client, _name -> {:error, :not_found} end)
 
       with_bounds([sandbox_idle_timeout_minutes: 1, sandbox_max_lifetime_hours: 1], fn ->
-        {pid, ref, settled} = start_server(conv)
+        {pid, _ref, :alive} = start_server(conv)
 
-        if settled == :alive do
-          assert %{sandbox_started_at: nil} = :sys.get_state(pid)
-          send(pid, :lifecycle_check)
-          assert is_map(:sys.get_state(pid))
-          GenServer.stop(pid)
-        else
-          # A provision failure stops the server on its own, which is fine —
-          # the point is that the lifecycle check did not do it.
-          assert_stopped(ref)
-        end
+        :sys.replace_state(pid, fn state ->
+          %{
+            state
+            | sandbox_started_at: nil,
+              last_activity_at: DateTime.add(DateTime.utc_now(), -7200, :second)
+          }
+        end)
+
+        send(pid, :lifecycle_check)
+        # Alive, untouched, and started_at still unset after the tick.
+        assert %{sandbox_started_at: nil} = :sys.get_state(pid)
+        GenServer.stop(pid)
       end)
+
+      assert Fountain.Repo.reload(sandbox).status == "ready"
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
@@ -69,14 +69,38 @@ defmodule Fountain.Conversations.ConversationServerLogBudgetTest do
     send(pid, {:stdout, %{ref: cmd_ref}, String.duplicate("b", 90)})
     _ = :sys.get_state(pid)
 
-    # The seed a fresh server for this conversation would start from: the
-    # DB total, not zero — which is what makes the budget per-conversation
-    # rather than per-BEAM-lifetime.
+    # Close the turn so the second wake below finds nothing running, then
+    # stop the first server entirely.
+    send(pid, {:exit, %{ref: cmd_ref}, 0})
+    _ = :sys.get_state(pid)
+    GenServer.stop(pid)
+
     assert Conversations._unsafe_output_byte_total(conv.id) == 90
 
-    # And the in-flight counter agrees with the durable one.
-    assert :sys.get_state(pid).output_bytes == 90
-    GenServer.stop(pid)
+    # Second server, same conversation. The sandbox is "ready" now, so this
+    # wake goes down the reattach path — stub its two extra calls. The new
+    # server has persisted nothing itself; only a seed read from the DB can
+    # make a 20-byte chunk cross the 100-byte budget. A seed of zero (the
+    # per-BEAM-lifetime bug this pins against) would let it straight through.
+    Mimic.stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{}} end)
+
+    Mimic.stub(Sprites, :sprite, fn _client, _name ->
+      %{name: "test-sprite", id: "sprite_test-sprite"}
+    end)
+
+    {pid2, cmd_ref2, _ref2} = start_with_turn(conv)
+
+    send(pid2, {:stdout, %{ref: cmd_ref2}, String.duplicate("c", 20)})
+    _ = :sys.get_state(pid2)
+
+    data = Enum.map(output_events(conv.id), & &1.data)
+    refute Enum.any?(data, &(&1 =~ "cccc")), "the over-budget chunk must be dropped, not persisted"
+    assert Enum.any?(data, &(&1 =~ "durable log budget"))
+
+    # The counter seeded from the DB (90) and the capped chunk never counted.
+    assert :sys.get_state(pid2).output_bytes == 90
+
+    GenServer.stop(pid2)
   end
 
   test "a 0 budget disables the cap" do

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -119,6 +119,10 @@ defmodule Fountain.Conversations.ConversationServerTest do
 
       {pid, _ref, :alive} = start_server(conv, initial_prompt: "first prompt")
 
+      # Guards the premise, not the fix: the harness must keep its servers
+      # out of Horde, or the turn assertion below stops demonstrating
+      # anything about registry-independent delivery. It can only fail if
+      # the harness changes (#406 item 11).
       assert Horde.Registry.lookup(Fountain.ConversationRegistry, conv.id) == []
       assert [turn] = Conversations._unsafe_list_turns(conv.id)
       assert turn.prompt == "first prompt"
@@ -182,9 +186,11 @@ defmodule Fountain.Conversations.ConversationServerTest do
   end
 
   describe "stage metrics — the producer end of #310" do
-    # These drive the real server and then read the Prometheus scrape, so
-    # they fail if the stage events the metrics subscribe to ever stop being
-    # emitted — the gap the name-list-only test shape could not see.
+    # These drive the real server and read the Prometheus scrape before and
+    # after. The reporter is node-global and cumulative and other tests in
+    # this file emit the very same events, so "a sample exists" is satisfied
+    # before these tests even run (#406) — only the delta across this test's
+    # own action is evidence the action emitted.
     defp scrape_body do
       # The reporter aggregates synchronously on the telemetry event, but give
       # the handler a moment before scraping.
@@ -194,38 +200,71 @@ defmodule Fountain.Conversations.ConversationServerTest do
       conn.resp_body
     end
 
-    defp assert_stage_sample(body, stage, status) do
-      sample =
-        body
-        |> String.split("\n")
-        |> Enum.find(fn line ->
-          String.starts_with?(line, "fountain_stage_count{") and
-            line =~ ~s(stage="#{stage}") and line =~ ~s(status="#{status}")
-        end)
+    # Current value of the {stage, status} counter series, 0 when absent.
+    # stage and status are the metric's only tags, so at most one line matches.
+    defp stage_count(body, stage, status) do
+      body
+      |> String.split("\n")
+      |> Enum.find_value(0, fn line ->
+        if String.starts_with?(line, "fountain_stage_count{") and
+             line =~ ~s(stage="#{stage}") and line =~ ~s(status="#{status}") do
+          {value, ""} = line |> String.split(" ") |> List.last() |> Integer.parse()
+          value
+        end
+      end)
+    end
 
-      assert sample, "no fountain_stage_count sample for #{stage}/#{status} in scrape"
+    # Total observations recorded by a histogram (its _count line), 0 when absent.
+    defp histogram_count(body, prefix) do
+      body
+      |> String.split("\n")
+      |> Enum.filter(fn line ->
+        String.starts_with?(line, prefix) and line =~ "_count"
+      end)
+      |> Enum.map(fn line ->
+        {value, ""} = line |> String.split(" ") |> List.last() |> Integer.parse()
+        value
+      end)
+      |> Enum.sum()
     end
 
     test "a successful provision lands in the scrape as provision/done", %{conv: conv} do
       stub_happy_sprite()
+      before_body = scrape_body()
 
       {pid, _ref, :alive} = start_server(conv)
       GenServer.stop(pid)
 
-      body = scrape_body()
-      assert_stage_sample(body, "provision", "done")
+      after_body = scrape_body()
+
+      # Exactly this provision — and a *successful* one: done moved, failed
+      # did not.
+      assert stage_count(after_body, "provision", "done") ==
+               stage_count(before_body, "provision", "done") + 1
+
+      assert stage_count(after_body, "provision", "failed") ==
+               stage_count(before_body, "provision", "failed")
+
       # The span around fresh provisioning feeds the duration histogram.
-      assert body =~ "fountain_fresh_provision_stop_duration"
+      assert histogram_count(after_body, "fountain_fresh_provision_stop_duration") ==
+               histogram_count(before_body, "fountain_fresh_provision_stop_duration") + 1
     end
 
     test "a failed provision lands in the scrape as provision/failed", %{conv: conv} do
       stub_happy_sprite()
       Mimic.stub(Sprites, :create, fn _client, _name -> {:error, :quota_exceeded} end)
+      before_body = scrape_body()
 
       {_pid, ref, _} = start_server(conv)
       assert_stopped(ref)
 
-      assert_stage_sample(scrape_body(), "provision", "failed")
+      after_body = scrape_body()
+
+      assert stage_count(after_body, "provision", "failed") ==
+               stage_count(before_body, "provision", "failed") + 1
+
+      assert stage_count(after_body, "provision", "done") ==
+               stage_count(before_body, "provision", "done")
     end
 
     test "a completed turn lands in the scrape as turn/done", %{conv: conv} do
@@ -239,12 +278,17 @@ defmodule Fountain.Conversations.ConversationServerTest do
       Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
       Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
 
+      before_body = scrape_body()
+
       {pid, _mon, :alive} = start_server(conv, initial_prompt: "count me")
       send(pid, {:exit, %{ref: cmd_ref}, 0})
       _ = :sys.get_state(pid)
       GenServer.stop(pid)
 
-      assert_stage_sample(scrape_body(), "turn", "done")
+      after_body = scrape_body()
+
+      assert stage_count(after_body, "turn", "done") ==
+               stage_count(before_body, "turn", "done") + 1
     end
   end
 

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -51,8 +51,13 @@ defmodule Fountain.QuotasTest do
   end
 
   describe "sandbox_limit/1" do
+    # Both literals below are deliberate: comparing against
+    # Quotas.default_limit() would compare the function under test to its
+    # own module attribute and pass for any value (#406).
+
     test "defaults to 5" do
-      assert Quotas.sandbox_limit(insert_verified_user().id) == Quotas.default_limit()
+      # Pins the schema/migration column default a fresh user gets.
+      assert Quotas.sandbox_limit(insert_verified_user().id) == 5
     end
 
     test "reflects an admin-adjusted cap" do
@@ -63,7 +68,9 @@ defmodule Fountain.QuotasTest do
     end
 
     test "an unknown user falls back to the default rather than being unlimited" do
-      assert Quotas.sandbox_limit(Ecto.UUID.generate()) == Quotas.default_limit()
+      # A missing row makes Repo.one/1 return nil, which is the only way to
+      # reach the @default_limit fallback — the column itself is NOT NULL.
+      assert Quotas.sandbox_limit(Ecto.UUID.generate()) == 5
     end
   end
 

--- a/apps/fountain/test/fountain/self_host_switches_test.exs
+++ b/apps/fountain/test/fountain/self_host_switches_test.exs
@@ -15,6 +15,41 @@ defmodule Fountain.SelfHostSwitchesTest do
 
   alias Fountain.{Accounts, Billing}
 
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+
+  # The minimum a :prod evaluation of runtime.exs demands (the same set
+  # otel_config_test.exs uses).
+  @required_release_env %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "RESEND_API_KEY" => "re_test_key",
+    "PUBLIC_URL" => "https://fountain.example.com"
+  }
+
+  @switch_vars ~w(BILLING_ENABLED REGISTRATION_ENABLED REGISTRATION_ALLOWED_EMAIL_DOMAINS STRIPE_WEBHOOK_SECRET)
+
+  defp read_prod_config(extra) do
+    previous = System.get_env()
+
+    try do
+      for k <- @switch_vars, do: System.delete_env(k)
+
+      @required_release_env
+      |> Map.put(
+        "MASTER_SECRETS_KEY",
+        Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+      )
+      |> Map.merge(extra)
+      |> System.put_env()
+
+      Config.Reader.read!(@runtime_exs, env: :prod)
+    after
+      System.put_env(previous)
+      for k <- @switch_vars, not Map.has_key?(previous, k), do: System.delete_env(k)
+    end
+  end
+
   defp with_env(pairs, fun) do
     previous = Enum.map(pairs, fn {k, _} -> {k, Application.get_env(:fountain, k)} end)
     Enum.each(pairs, fn {k, v} -> Application.put_env(:fountain, k, v) end)
@@ -35,6 +70,55 @@ defmodule Fountain.SelfHostSwitchesTest do
       |> Fountain.Repo.update()
 
     user
+  end
+
+  describe "the env-var side, read the way the release config provider does" do
+    # runtime.exs skips the BILLING_ENABLED mapping under :test (the suite
+    # pins :billing_enabled in config/test.exs), and the domain-list tests
+    # below inject the parsed application env directly — so without these,
+    # nothing fails if the runtime.exs default flips or the parsing breaks.
+
+    test "BILLING_ENABLED defaults off — a bare self-host must not lock itself out (#336)" do
+      cfg = read_prod_config(%{})
+      assert cfg[:fountain][:billing_enabled] == false
+    end
+
+    test "BILLING_ENABLED=true opts the hosted deployment in" do
+      # Billing on requires the webhook secret at boot (#416), so supply one.
+      cfg =
+        read_prod_config(%{
+          "BILLING_ENABLED" => "true",
+          "STRIPE_WEBHOOK_SECRET" => "whsec_test"
+        })
+
+      assert cfg[:fountain][:billing_enabled] == true
+    end
+
+    test "REGISTRATION_ALLOWED_EMAIL_DOMAINS is split, trimmed and downcased" do
+      cfg =
+        read_prod_config(%{
+          "REGISTRATION_ALLOWED_EMAIL_DOMAINS" => "Example.com, BETA.org ,gamma.io,"
+        })
+
+      assert cfg[:fountain][:registration_allowed_email_domains] ==
+               ["example.com", "beta.org", "gamma.io"]
+    end
+
+    test "unset or empty REGISTRATION_ALLOWED_EMAIL_DOMAINS means no domain filter" do
+      assert read_prod_config(%{})[:fountain][:registration_allowed_email_domains] == []
+
+      assert read_prod_config(%{"REGISTRATION_ALLOWED_EMAIL_DOMAINS" => ""})[:fountain][
+               :registration_allowed_email_domains
+             ] == []
+    end
+
+    test "REGISTRATION_ENABLED=false closes signup at the config level" do
+      assert read_prod_config(%{"REGISTRATION_ENABLED" => "false"})[:fountain][
+               :registration_enabled
+             ] == false
+
+      assert read_prod_config(%{})[:fountain][:registration_enabled] == true
+    end
   end
 
   describe "BILLING_ENABLED" do

--- a/apps/fountain/test/fountain/trial_expiry_test.exs
+++ b/apps/fountain/test/fountain/trial_expiry_test.exs
@@ -126,6 +126,14 @@ defmodule Fountain.TrialExpiryTest do
   describe "starting a trial" do
     test "creates a real Stripe subscription, not just a customer" do
       user = insert_verified_user()
+
+      # A distinctive anchor. Registration stamps now+14d, which is the same
+      # unix second the #351 regression (a fresh 14-day window restarting the
+      # clock) would produce — asserting against that proves nothing. 9 days
+      # can only appear in the params by reading the stamped date.
+      anchor = ahead(9)
+      {:ok, user} = user |> User.billing_changeset(%{trial_ends_at: anchor}) |> Repo.update()
+
       test = self()
 
       stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_new"}} end)
@@ -142,13 +150,30 @@ defmodule Fountain.TrialExpiryTest do
       assert params.customer == "cus_new"
       # Anchored to the trial end registration stamped — not a fresh 14-day
       # window that would restart the clock at verification time (#351).
-      assert params.trial_end == DateTime.to_unix(user.trial_ends_at)
+      assert params.trial_end == DateTime.to_unix(anchor)
+      refute Map.has_key?(params, :trial_period_days)
       assert [%{price: "price_test"}] = params.items
 
       assert updated.stripe_customer_id == "cus_new"
       assert updated.stripe_subscription_id == "sub_new"
       assert updated.subscription_status == "trialing"
       assert updated.trial_ends_at
+    end
+
+    test "an already-elapsed local trial does not open a live Stripe trial" do
+      # The other half of the anchoring logic: Stripe rejects a past
+      # trial_end, and opening a fresh window here would re-grant time the
+      # local clock already took away. The clock side of the gate covers
+      # these accounts instead.
+      user = insert_verified_user()
+      {:ok, user} = user |> User.billing_changeset(%{trial_ends_at: ago(1)}) |> Repo.update()
+
+      stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_late"}} end)
+      reject(&Stripe.Subscription.create/1)
+
+      assert {:ok, user} = Billing.create_stripe_customer(user)
+      assert {:ok, updated} = Billing.start_trial_subscription(user)
+      refute updated.stripe_subscription_id
     end
 
     test "cancels rather than invoicing when the trial ends with no card" do

--- a/apps/fountain/test/fountain_web/audit_coverage_test.exs
+++ b/apps/fountain/test/fountain_web/audit_coverage_test.exs
@@ -57,7 +57,14 @@ defmodule FountainWeb.AuditCoverageTest do
       |> element("form[phx-submit='add_secret']")
       |> render_submit(%{"secret" => %{"key" => "K", "value" => "super-secret-value"}})
 
-      for event <- events_for(user.id) do
+      events = events_for(user.id)
+
+      # Guard the guard: if vault-secret auditing disappeared entirely this
+      # list would be empty and the refute below would vacuously pass over
+      # nothing (#406). The write above must have produced its record.
+      assert Enum.any?(events, &(&1.action == "vault.secret.write"))
+
+      for event <- events do
         refute inspect(event.metadata) =~ "super-secret-value"
       end
     end

--- a/apps/fountain/test/fountain_web/csp_test.exs
+++ b/apps/fountain/test/fountain_web/csp_test.exs
@@ -14,7 +14,12 @@ defmodule FountainWeb.CSPTest do
     assert csp =~ "base-uri 'self'"
   end
 
-  test "API responses are not affected", %{conn: conn} do
+  # The CSP plug lives in the :browser pipeline only, so today nothing on an
+  # API path *could* set the header — this cannot catch #323 regressing.
+  # What it pins is scope: if the policy ever migrates to the Endpoint or an
+  # API pipeline, where it would ride along on every JSON/SSE response, this
+  # is the test that notices.
+  test "the policy stays scoped to browser responses — API paths carry none", %{conn: conn} do
     conn = get(conn, ~p"/health")
     assert get_resp_header(conn, "content-security-policy") == []
   end

--- a/apps/fountain/test/fountain_web/markdown_test.exs
+++ b/apps/fountain/test/fountain_web/markdown_test.exs
@@ -28,6 +28,23 @@ defmodule FountainWeb.MarkdownTest do
       html = Markdown.to_html("![i](https://x.com/i.png)")
       assert html =~ ~s(src="https://x.com/i.png")
     end
+
+    # safe_url?/2 is an allowlist, so normalization is only *observable* in
+    # the allow direction: JAVASCRIPT: is off the allowlist with or without
+    # the downcase, but HTTPS: is on it only because of the downcase. These
+    # are the tests that fail if normalize/1 loses a step (#406).
+
+    test "case-folding is for the check only: uppercase safe schemes keep their href" do
+      assert Markdown.to_html("[x](HTTPS://x.com)") =~ ~s(href="HTTPS://x.com")
+      assert Markdown.to_html("[x](MailTo:a@b.c)") =~ ~s(href="MailTo:a@b.c")
+    end
+
+    test "whitespace stripping is for the check only: a ref-encoded tab inside a safe scheme keeps the href" do
+      # Browsers strip tabs anywhere in a URL, so an href of ht&#9;tps://…
+      # is a live https link and must survive. Without the strip the scheme
+      # normalizes to "ht\ttps" — off the allowlist — and a safe link dies.
+      assert Markdown.to_html("[x](ht&#9;tps://x.com)") =~ "href"
+    end
   end
 
   describe "to_html/1 — unsafe URLs are dropped" do
@@ -55,6 +72,11 @@ defmodule FountainWeb.MarkdownTest do
     end
 
     test "embedded whitespace cannot split the scheme" do
+      # Deny-direction: these are dropped with or without the whitespace
+      # strip ("java\tscript" is off the allowlist either way). The second
+      # line pins char-ref decoding: undecoded, "&#9;javascript" contains
+      # "#" and would be classified relative — and *kept*. The strip itself
+      # is pinned by the allow-direction test above.
       refute Markdown.to_html("[x](java\tscript:alert(1))") =~ "href"
       refute Markdown.to_html("[x](&#9;javascript:alert(1))") =~ "href"
     end

--- a/apps/fountain/test/fountain_web/plugs/rate_limit_sweeper_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/rate_limit_sweeper_test.exs
@@ -26,14 +26,28 @@ defmodule FountainWeb.Plugs.RateLimit.SweeperTest do
   test "eviction is invisible to limiting: a swept row behaves like a reset one" do
     RateLimit.ensure_table()
     opts = %{bucket: unique_bucket(), max: 2, window_ms: 60_000}
-    key = {opts.bucket, "203.0.113.9"}
+    stale_key = {opts.bucket, "203.0.113.9"}
+    fresh_key = {opts.bucket, "203.0.113.11"}
+    now = System.system_time(:millisecond)
 
-    # Full bucket whose window is long over.
-    :ets.insert(RateLimit.table(), {key, System.system_time(:millisecond) - :timer.hours(3), 2})
+    # A full bucket whose window is long over, and one still inside it.
+    :ets.insert(RateLimit.table(), {stale_key, now - :timer.hours(3), 2})
+    :ets.insert(RateLimit.table(), {fresh_key, now, 2})
+
     RateLimit.evict_expired(:timer.hours(2))
 
-    # Same outcome an expired-but-present row gets: the window restarts.
-    assert RateLimit.bump(key, opts) == :ok
+    # bump/2 answers :ok for a swept row and an expired-but-present row
+    # alike, so it cannot distinguish a working sweep from a no-op — the
+    # membership check is what proves the row was actually removed.
+    assert :ets.lookup(RateLimit.table(), stale_key) == []
+
+    # And the sweep left live limiting state alone: a full bucket inside its
+    # window still limits, so eviction was selective rather than a purge.
+    assert {:limited, _} = RateLimit.bump(fresh_key, opts)
+
+    # The swept row gets the same outcome an expired-but-present one does:
+    # the window restarts.
+    assert RateLimit.bump(stale_key, opts) == :ok
   end
 
   test "the sweeper process is in the supervision tree and sweeps on tick" do


### PR DESCRIPTION
Fixes the thirteen tests #406 found that could not fail the way they claim. Test-only change — no `lib/` code is touched.

## The discipline

For every strengthened test, the guarded code was temporarily broken the way the issue describes, the test was run and observed to **fail**, and the code was restored. The table below is that record.

| # | Test | Broke what (temporarily) | Test failed? |
|---|------|--------------------------|--------------|
| 1 | `conversation_server_log_budget_test.exs` — cumulative across wakes | `ensure_output_bytes/1` reverted to seed `0` instead of the DB total | Yes |
| 2 | `quotas_test.exs` — `sandbox_limit/1` defaults | (a) `@default_limit 5 → 7`; (b) schema `default: 5 → 7` | Yes — (a) fails the unknown-user test, (b) fails "defaults to 5" |
| 3 | `trial_expiry_test.exs` — Stripe trial anchoring | `trial_end_param/1` replaced with a fresh `now+14d` window (which also drops the >300s guard) | Yes — both the anchor assertion and the new expired-trial test |
| 4 | `self_host_switches_test.exs` — domain list parsing | deleted `String.downcase()` from the `REGISTRATION_ALLOWED_EMAIL_DOMAINS` parsing in `config/runtime.exs` | Yes |
| 5 | `self_host_switches_test.exs` — `BILLING_ENABLED` default | flipped the runtime.exs default `"false" → "true"` | Yes |
| 6 | `conversation_server_lifetime_test.exs` — nothing reclaimed before a sprite exists | deleted the `is_nil(started_at)` branch in `handle_info(:lifecycle_check, …)` | Yes |
| 7 | `rate_limit_sweeper_test.exs` — eviction invisible to limiting | (a) `evict_expired/1` made a no-op returning 0; (b) made an indiscriminate purge | Yes — (a) fails the membership assert, (b) fails the fresh-bucket `{:limited, _}` assert |
| 8 | `csp_test.exs` — API paths carry no CSP | added the CSP `put_secure_browser_headers` to the `:api_public` pipeline | Yes |
| 9 | `markdown_test.exs` — uppercase safe schemes keep href | deleted `String.downcase()` from `normalize/1` | Yes (and only the new allow-direction test fails — the old deny-direction ones stay green, confirming they were vacuous for this step) |
| 10 | `markdown_test.exs` — ref-encoded tab in safe scheme keeps href | deleted the whitespace `String.replace` from `normalize/1` | Yes (same pattern as 9) |
| 11 | `conversation_server_test.exs:122` Horde lookup | — (see notes) | Not applicable — kept as an explicit harness-premise check |
| 12 | `conversation_server_test.exs` — three stage-metrics tests | removed, one at a time: the `provision/done`, `provision/failed`, and `turn/done` `publish_stage` calls in `conversation_server.ex` | Yes — each removal fails exactly its own delta test, with the rest of the file (and `metrics_test.exs`'s synthetic event, run in the same invocation for the `failed` case) still populating the global reporter |
| 13 | `audit_coverage_test.exs` — secret value never in the audit log | removed the `vault.secret.write` `Audited.from_socket` call in `vaults_live/form.ex` | Yes |

## Departures from the issue's fix directions

- **Item 2**: the issue suggests nulling `max_concurrent_sandboxes` via `update_all` to exercise the `nil -> @default_limit` fallback. The column is `NOT NULL` in the migration, so that update cannot land. The unknown-user test reaches the same `nil` clause through the only path that exists (missing row → `Repo.one/1` returns `nil`); with the literal `5` it now pins `@default_limit`, and "defaults to 5" pins the schema/column default. Both verified independently.
- **Item 8**: no unit-level assertion can make "no CSP on `/health`" guard #323 itself — nothing on an API path could ever set the header. The test is recast (comment + name) as what it *can* pin: the policy staying scoped to `:browser` rather than migrating to the Endpoint or an API pipeline, where it would ride on every JSON/SSE response. Verified failable in that direction.
- **Item 11**: the `Horde.Registry.lookup(...) == []` line is guaranteed by the harness and cannot fail on any lib revert. Rather than delete it, it is kept and recommented as a harness-premise check: if the harness ever started registering its servers with Horde, this is the line that would notice the test no longer demonstrates registry-independent prompt delivery. Explicitly **not** claimed as fail-on-revert.
- **Item 6**: the harness cannot hold a server mid-provision (`handle_continue` blocks the mailbox until it settles), so the test settles a reattach successfully (`:alive` is now pattern-matched, not branched on), then clears `sandbox_started_at` via `:sys.replace_state` to reproduce the in-flight state, with both bounds tight and activity aged. The previously dead `if settled == :alive` branch is gone.

## Also added while in the files

- Item 3 gained a sibling test pinning the previously-unpinned `>300s` expiry guard in `trial_end_param/1` (no live Stripe trial for an elapsed local clock — `Mimic.reject` on `Stripe.Subscription.create/1`).
- Items 4/5's new `describe` also pins `REGISTRATION_ENABLED` parsing and the empty-list default, since the `Config.Reader` scaffolding was already there. The `BILLING_ENABLED=true` case supplies `STRIPE_WEBHOOK_SECRET` (the #416 boot guard fires without it).
- Item 10's deny-direction test kept its two lines but gained a comment stating what each actually pins (the `&#9;` line pins char-ref decoding, not the strip).

## Verification

- `mix test` — 1785 tests, 0 failures
- `mix precommit` — exit 0 (compile w/ warnings-as-errors, format, credo --strict, dialyzer, unused deps, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
