### PR TITLE
ops: fail the turn when the sprite WebSocket drops mid-run (#413)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1037,6 +1037,48 @@ defmodule Fountain.Conversations.ConversationServer do
      }}
   end
 
+  # An error naming the CURRENT command is terminal for the turn (#413):
+  # Sprites.Command sends it when the WebSocket to the sprite drops mid-run,
+  # then stops — and since the command process is neither linked nor
+  # monitored, this message is the only signal there will ever be. Ignoring
+  # it left current_command set forever: every prompt answered {:error,
+  # :busy}, idle reclaim was suppressed (busy? true), the reaper skipped the
+  # sandbox (server alive), and the sprite billed until max_lifetime. Fail
+  # the turn and return to idle, exactly like a non-zero :exit.
+  def handle_info({:error, %{ref: ref}, reason}, %{current_command_ref: ref} = state)
+      when not is_nil(ref) do
+    Logger.error("sprite command error mid-turn: #{inspect(reason)} — failing the turn")
+
+    {:ok, turn} =
+      Conversations.update_turn(state.current_turn, %{
+        status: "failed",
+        ended_at: now()
+      })
+
+    publish_stage(state.conversation_id, "turn", "failed", %{
+      turn_id: turn.id,
+      turn_number: turn.turn_number,
+      reason: "sprite connection lost: #{inspect(reason)}"
+    })
+
+    Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
+    end_turn_span(state.current_turn_span, :error, %{"error" => inspect(reason)})
+
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+
+    {:noreply,
+     %{
+       touch_activity(state)
+       | current_command: nil,
+         current_command_ref: nil,
+         current_turn: nil,
+         current_turn_span: nil,
+         stream_tracer: nil
+     }}
+  end
+
+  # A stale ref — an error from a command already superseded or finished.
   def handle_info({:error, _ref, reason}, state) do
     Logger.error("sprite command error: #{inspect(reason)}")
     {:noreply, state}

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -384,6 +384,47 @@ defmodule Fountain.Conversations.ConversationServerTest do
       GenServer.stop(pid)
     end
 
+    test "a dropped sprite WebSocket fails the turn and frees the conversation (#413)", %{
+      conv: conv
+    } do
+      # Sprites.Command sends {:error, %{ref: ...}, reason} when the socket
+      # drops mid-run, then stops. Pre-#413 the handler logged and kept
+      # current_command set, so the turn stayed "running" forever, every
+      # prompt got {:error, :busy}, and both reclaim paths were suppressed —
+      # the sprite billed until max_lifetime.
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:error, %{ref: ref}, :closed})
+      _ = :sys.get_state(pid)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "failed"
+      refute is_nil(turn.ended_at)
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      # The recovery the user actually needs: prompting again works.
+      assert :ok = GenServer.call(pid, {:send_prompt, "again", []})
+      assert length(Conversations._unsafe_list_turns(conv.id)) == 2
+
+      GenServer.stop(pid)
+    end
+
+    test "an error for a stale command ref does not touch the current turn", %{conv: conv} do
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:error, %{ref: make_ref()}, :closed})
+      _ = :sys.get_state(pid)
+
+      # Still mid-turn: the running turn is untouched and busy is still busy.
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "running"
+      assert {:error, :busy} = GenServer.call(pid, {:send_prompt, "second", []})
+
+      send(pid, {:exit, %{ref: ref}, 0})
+      _ = :sys.get_state(pid)
+      GenServer.stop(pid)
+    end
+
     test "prompting while a turn is running is refused rather than queued", %{conv: conv} do
       {pid, _ref} = start_with_turn(conv)
 


### PR DESCRIPTION
Closes #413 (P1, audit-2026-08-03 #416).

A dropped Fountain↔sprites.dev WebSocket mid-turn sent `{:error, %{ref}, reason}` to the server, which logged it and kept `current_command` set. Nothing else could ever notice (the command process is unlinked and unmonitored), so: turn row `running` forever, every prompt `conversation_busy`, idle reclaim suppressed, reaper suppressed — the sprite billed until the 24-hour `max_lifetime`.

The handler now treats an error carrying the **current** command's ref as terminal, mirroring the non-zero `:exit` path: turn `failed` + `ended_at`, `turn/failed` published with the reason (so streaming clients stop instead of going silent), tracer/OTel span closed, conversation back to `idle`, command state cleared — which re-enables both reclaim mechanisms and the next prompt. A stale ref (a superseded command's late error) keeps the log-only behavior.

Tests: the issue's suggested regression — `{:error, ref, :closed}` against a live command → turn row failed and the next `send_prompt` succeeds (fails pre-fix) — plus a stale-ref test asserting the running turn is untouched. `mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)