### PR TITLE
api: catch GenServer.call exits from the conversation server (#412)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -73,8 +73,30 @@ defmodule Fountain.Conversations.ConversationServer do
         end
 
       pid ->
-        GenServer.call(pid, {:send_prompt, prompt, images}, 30_000)
+        call_server(pid, {:send_prompt, prompt, images})
     end
+  end
+
+  # Every public entry point calls through here so a GenServer.call exit
+  # cannot escape to the caller (#412). The realistic exit is :timeout: a
+  # handle_continue(:provision) blocks the mailbox for up to the provision
+  # deadline, so any call issued during provisioning waits 30s and then
+  # *exits* — which none of the seven controller/LiveView call sites caught,
+  # turning prompt/interrupt/terminate into 500s and making
+  # delete_conversation/1 return before its Repo.delete. :noproc and
+  # shutdown-shaped exits are the server dying between whereis and call.
+  defp call_server(pid, msg) do
+    GenServer.call(
+      pid,
+      msg,
+      Application.get_env(:fountain, :conversation_call_timeout_ms, 30_000)
+    )
+  catch
+    :exit, {:timeout, _} -> {:error, :provisioning}
+    :exit, {:noproc, _} -> {:error, :not_running}
+    :exit, {:normal, _} -> {:error, :not_running}
+    :exit, {:shutdown, _} -> {:error, :not_running}
+    :exit, {{:shutdown, _}, _} -> {:error, :not_running}
   end
 
   @doc """
@@ -102,7 +124,7 @@ defmodule Fountain.Conversations.ConversationServer do
   def interrupt(conv_id) do
     case whereis(conv_id) do
       nil -> {:error, :not_running}
-      pid -> GenServer.call(pid, :interrupt, 30_000)
+      pid -> call_server(pid, :interrupt)
     end
   end
 
@@ -134,7 +156,7 @@ defmodule Fountain.Conversations.ConversationServer do
         end
 
       pid ->
-        GenServer.call(pid, :terminate_conv, 30_000)
+        call_server(pid, :terminate_conv)
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -217,6 +217,8 @@ defmodule FountainWeb.ConversationController do
         case ConversationServer.terminate(id) do
           :ok -> send_resp(conn, :no_content, "")
           {:error, :not_running} -> {:error, :not_found}
+          # :provisioning and future shapes render via the FallbackController.
+          {:error, _} = err -> err
         end
     end
   end
@@ -248,6 +250,10 @@ defmodule FountainWeb.ConversationController do
 
           {:error, :idle} ->
             conn |> put_status(:conflict) |> json(%{error: "no_turn_running"})
+
+          # :provisioning and future shapes render via the FallbackController.
+          {:error, _} = err ->
+            err
         end
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -73,6 +73,21 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # The ConversationServer did not answer within the call timeout — almost
+  # always a server still inside handle_continue(:provision), whose blocked
+  # mailbox makes every call wait the full 30s and exit (#412). 503 with
+  # Retry-After rather than 500: the conversation is coming up, the request
+  # was fine, and the caller should try again shortly.
+  def call(conn, {:error, :provisioning}) do
+    conn
+    |> put_resp_header("retry-after", "30")
+    |> put_status(:service_unavailable)
+    |> json(%{
+      error: "provisioning",
+      message: "the conversation is still provisioning; retry shortly"
+    })
+  end
+
   # Prompting a terminated conversation. 410 rather than 404: the id was
   # real, the resource is gone for good, and the caller should stop retrying.
   def call(conn, {:error, :gone}) do

--- a/apps/fountain/test/fountain_web/controllers/conversation_call_timeout_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_call_timeout_test.exs
@@ -1,0 +1,77 @@
+defmodule FountainWeb.ConversationCallTimeoutTest do
+  # async: false — registers a process in the global Horde registry under the
+  # conversation id and lowers the global call-timeout app env.
+  use FountainWeb.ConnCase, async: false
+
+  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Repo
+
+  # Regression tests for #412: a GenServer.call timeout EXITS rather than
+  # returning an error, and no controller or LiveView call site caught it.
+  # A server stuck in handle_continue(:provision) blocks its mailbox, so
+  # prompt/interrupt/terminate 500'd — and DELETE returned 500 with the row
+  # silently kept, because `_ = ConversationServer.terminate(id)` discards a
+  # return value, not an exit.
+
+  setup %{conn: conn} do
+    Application.put_env(:fountain, :conversation_call_timeout_ms, 150)
+    on_exit(fn -> Application.delete_env(:fountain, :conversation_call_timeout_ms) end)
+
+    user = insert_verified_user()
+    {_key_record, raw_key} = insert_api_key(user)
+    conv = insert_conversation(user_id: user.id, status: "pending")
+
+    # The shape of a server whose mailbox is blocked by provisioning:
+    # registered under the conversation id, never answering calls.
+    test_pid = self()
+
+    stuck =
+      spawn(fn ->
+        Horde.Registry.register(Fountain.ConversationRegistry, conv.id, nil)
+        send(test_pid, :registered)
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive :registered, 2_000
+    on_exit(fn -> Process.exit(stuck, :kill) end)
+
+    {:ok, conn: authed_with_key(conn, raw_key), user: user, conv: conv}
+  end
+
+  test "send_prompt during provisioning returns 503 provisioning, not a 500",
+       %{conn: conn, conv: conv} do
+    conn = post_json(conn, "/api/conversations/#{conv.id}/prompts", %{prompt: "hi"})
+
+    assert %{"error" => "provisioning"} = json_response(conn, 503)
+    assert get_resp_header(conn, "retry-after") == ["30"]
+  end
+
+  test "interrupt during provisioning returns 503, not a 500", %{conn: conn, conv: conv} do
+    conn = post(conn, "/api/conversations/#{conv.id}/interrupt")
+
+    assert %{"error" => "provisioning"} = json_response(conn, 503)
+  end
+
+  test "terminate during provisioning returns 503, not a 500", %{conn: conn, conv: conv} do
+    conn = post(conn, "/api/conversations/#{conv.id}/terminate")
+
+    assert %{"error" => "provisioning"} = json_response(conn, 503)
+  end
+
+  test "DELETE still deletes the row when the server does not answer",
+       %{conn: conn, conv: conv} do
+    # The worst pre-#412 case: the terminate exit blew through
+    # delete_conversation/1 before Repo.delete ran, so the DELETE 500'd and
+    # the row silently survived.
+    conn = delete(conn, "/api/conversations/#{conv.id}")
+
+    assert conn.status == 204
+    assert Repo.get(Fountain.Conversations.Conversation, conv.id) == nil
+  end
+
+  test "the public functions return error tuples rather than exiting", %{conv: conv} do
+    assert {:error, :provisioning} = ConversationServer.send_prompt(conv.id, "hi", [])
+    assert {:error, :provisioning} = ConversationServer.interrupt(conv.id)
+    assert {:error, :provisioning} = ConversationServer.terminate(conv.id)
+  end
+end


### PR DESCRIPTION
Closes #412 (P1, audit-2026-08-03 #416).

`GenServer.call` timeouts **exit**, and only `Accounts.Deletion` caught them — the six controller/LiveView call sites and `delete_conversation/1` did not. During provisioning (blocked mailbox, up to 30 minutes), prompt/interrupt/terminate 500'd after a 30s hang, and `DELETE /api/conversations/:id` 500'd **and silently kept the row** (`_ =` discards a return value, not an exit).

Per the issue's fix direction, the knowledge lives in the module that owns the timeout: the three public `ConversationServer` functions route through a `call_server/2` that catches the exits — `:timeout` → `{:error, :provisioning}`, `:noproc`/`:normal`/`:shutdown` shapes → `{:error, :not_running}` — fixing all seven call sites at once. `FallbackController` maps `:provisioning` to **503 + `Retry-After: 30`**. The `terminate`/`interrupt` controller actions gained the `{:error, _} = err` fallthrough `do_prompt` already had (they would otherwise CaseClauseError on the new shape). The call timeout is overridable via `:conversation_call_timeout_ms` so tests don't wait 30s.

Tests (`conversation_call_timeout_test.exs`, async: false): a process registered in the Horde registry under the conversation id that never answers calls — the exact shape of a blocked mailbox — driven through the real API: 503 `provisioning` on all three actions, DELETE now actually deletes the row, and the public functions return tuples instead of exiting. 5/5 fail against the old call sites. `mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)