### PR TITLE
billing: never offer Checkout to a comped account (#399)

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -852,8 +852,35 @@ defmodule Fountain.Billing do
   # ordering guard: without it, any older event for the adopted subscription
   # that straggled in afterwards was treated as fresh and could move the
   # account backwards. Never moves the watermark backwards itself.
-  defp adopt_subscription(%User{subscription_status: "comped"} = user, _sub_id, _event_created),
-    do: {:ok, user}
+  # A webhook must never silently un-comp an account, so status is left
+  # alone. But if a checkout DID complete for a comped account (#399 — the
+  # billing page used to offer it), the customer is now being charged for a
+  # subscription the app held no reference to: invisible to the MRR tile,
+  # and revoke_comp/1 would lock out someone actively paying. Record the id
+  # as a backstop and log loudly so an operator refunds or revokes the comp
+  # deliberately.
+  defp adopt_subscription(
+         %User{subscription_status: "comped"} = user,
+         subscription_id,
+         event_created
+       ) do
+    if is_binary(subscription_id) and subscription_id != user.stripe_subscription_id do
+      Logger.error(
+        "[billing] comped user #{user.id} completed checkout for subscription " <>
+          "#{subscription_id}; recording the id without changing status — " <>
+          "they are being charged, investigate (refund or revoke the comp)"
+      )
+
+      user
+      |> User.billing_changeset(%{
+        stripe_subscription_id: subscription_id,
+        subscription_synced_at: latest(event_created, user.subscription_synced_at)
+      })
+      |> Repo.update()
+    else
+      {:ok, user}
+    end
+  end
 
   defp adopt_subscription(%User{stripe_subscription_id: sub_id} = user, sub_id, _event_created),
     do: {:ok, user}

--- a/apps/fountain/lib/fountain_web/live/billing_live.ex
+++ b/apps/fountain/lib/fountain_web/live/billing_live.ex
@@ -50,6 +50,12 @@ defmodule FountainWeb.Live.BillingLive do
       {:ok, url} ->
         {:noreply, redirect(socket, external: url)}
 
+      {:error, :comped} ->
+        {:noreply,
+         socket
+         |> assign(:stripe_url_loading, false)
+         |> put_flash(:info, "This account is comped — there is nothing to pay.")}
+
       {:error, _reason} ->
         {:noreply,
          socket
@@ -246,17 +252,28 @@ defmodule FountainWeb.Live.BillingLive do
         </dl>
 
         <div class="mt-6 flex items-center gap-4">
-          <button
-            phx-click="manage_subscription"
-            disabled={@stripe_url_loading}
-            class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <%= if @current_user.subscription_status in ~w(active past_due) do %>
-              Manage Subscription
-            <% else %>
-              Upgrade
-            <% end %>
-          </button>
+          <%!-- A comped account must not be offered Checkout (#399):
+               comp_account/1 cancels the live subscriptions, so the routing
+               below reads the account as a fresh customer, Checkout charges
+               them, and the webhook adoption ignores the subscription — a
+               paying customer the app knows nothing about. --%>
+          <%= if @current_user.subscription_status == "comped" do %>
+            <span class="text-sm text-zinc-600">
+              This account is comped — no payment needed.
+            </span>
+          <% else %>
+            <button
+              phx-click="manage_subscription"
+              disabled={@stripe_url_loading}
+              class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <%= if @current_user.subscription_status in ~w(active past_due) do %>
+                Manage Subscription
+              <% else %>
+                Upgrade
+              <% end %>
+            </button>
+          <% end %>
           <%!-- Invoices live in the portal. Manage Subscription already leads
                there for active/past_due; every other status with a Stripe
                customer (canceled above all — they paid, they need receipts)
@@ -423,6 +440,11 @@ defmodule FountainWeb.Live.BillingLive do
     {period_start, period_end}
   end
 
+  # Refused outright rather than relying on the button being hidden (#399):
+  # a stale socket or a hand-sent event must not open Checkout for an
+  # account whose subscriptions comp_account/1 deliberately cancelled.
+  defp build_stripe_url(%{subscription_status: "comped"}), do: {:error, :comped}
+
   defp build_stripe_url(user) do
     return_url = FountainWeb.Endpoint.url() <> ~p"/account/billing"
 
@@ -524,6 +546,7 @@ defmodule FountainWeb.Live.BillingLive do
   defp format_status("canceled"), do: "Canceled"
   defp format_status(s), do: String.capitalize(s || "Unknown")
 
+  defp status_badge_class("comped"), do: "bg-purple-100 text-purple-800"
   defp status_badge_class("trialing"), do: "bg-blue-100 text-blue-800"
   defp status_badge_class("active"), do: "bg-green-100 text-green-800"
   defp status_badge_class("past_due"), do: "bg-red-100 text-red-800"

--- a/apps/fountain/test/fountain/billing_payment_path_test.exs
+++ b/apps/fountain/test/fountain/billing_payment_path_test.exs
@@ -346,6 +346,57 @@ defmodule Fountain.BillingPaymentPathTest do
     end
   end
 
+  describe "comped checkout backstop (#399)" do
+    test "a completed checkout records the subscription id without un-comping" do
+      # The page-level fix stops Checkout being offered; this is the backstop
+      # for a session opened before the comp (or a stale tab): the customer
+      # IS being charged, so the app must at least hold the reference —
+      # pre-#399 the adoption dropped it, making the subscription invisible
+      # to the MRR tile and to revoke_comp.
+      user = insert_verified_user()
+      {:ok, user} = Billing.attach_stripe_customer(user, "cus_comped_bs")
+
+      {:ok, user} =
+        user
+        |> User.billing_changeset(%{subscription_status: "comped"})
+        |> Repo.update()
+
+      test_pid = self()
+
+      stub(Stripe.Subscription, :list, fn _ ->
+        send(test_pid, :list_called)
+        {:ok, %{data: [], has_more: false}}
+      end)
+
+      event = %Stripe.Event{
+        id: "evt_comped_bs",
+        type: "checkout.session.completed",
+        created: DateTime.utc_now() |> DateTime.to_unix(),
+        data: %{
+          object: %{
+            customer: "cus_comped_bs",
+            subscription: "sub_comped_paid",
+            client_reference_id: user.id
+          }
+        }
+      }
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, %User{}} = Billing.handle_event(event)
+        end)
+
+      reloaded = Repo.reload(user)
+      assert reloaded.subscription_status == "comped"
+      assert reloaded.stripe_subscription_id == "sub_comped_paid"
+      assert log =~ "comped user #{user.id} completed checkout"
+
+      # Comped accounts skip the cancellation sweep — comp_account already
+      # cancelled everything, and a webhook must not touch the rest.
+      refute_received :list_called
+    end
+  end
+
   describe "OAuth signups" do
     test "get a Stripe customer and a trial end date" do
       # The email+password path creates the customer after verification. OAuth

--- a/apps/fountain/test/fountain_web/live/billing_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/billing_live_test.exs
@@ -86,6 +86,51 @@ defmodule FountainWeb.BillingLiveTest do
     end
   end
 
+  describe "comped accounts (#399)" do
+    defp comped_user do
+      user = insert_verified_user()
+
+      {:ok, user} =
+        user
+        |> Fountain.Accounts.User.billing_changeset(%{subscription_status: "comped"})
+        |> Fountain.Repo.update()
+
+      user
+    end
+
+    test "are told the account is comped instead of being offered Checkout", %{conn: conn} do
+      # comp_account/1 cancels every live subscription, so pre-#399 the
+      # routing below read a comped account as a fresh customer, offered
+      # Upgrade, charged them through Checkout — and the webhook adoption
+      # then ignored the subscription entirely.
+      {:ok, _lv, html} = live(login_user(conn, comped_user()), ~p"/account/billing")
+
+      assert html =~ "This account is comped"
+      refute html =~ ~s(phx-click="manage_subscription")
+    end
+
+    test "a hand-sent manage_subscription event is refused before Stripe", %{conn: conn} do
+      test_pid = self()
+
+      stub(Stripe.Checkout.Session, :create, fn _ ->
+        send(test_pid, :checkout_reached)
+        {:ok, %{url: "https://checkout.test"}}
+      end)
+
+      stub(Stripe.BillingPortal.Session, :create, fn _ ->
+        send(test_pid, :portal_reached)
+        {:ok, %{url: "https://portal.test"}}
+      end)
+
+      {:ok, lv, _html} = live(login_user(conn, comped_user()), ~p"/account/billing")
+      html = render_click(lv, "manage_subscription", %{})
+
+      assert html =~ "nothing to pay"
+      refute_received :checkout_reached
+      refute_received :portal_reached
+    end
+  end
+
   describe "upgrade with no existing Stripe customer" do
     test "creates the customer first and never passes customer_email", %{conn: conn} do
       user = insert_verified_user()


### PR DESCRIPTION
Closes #399 (P1, audit-2026-08-03 #416).

`comp_account/1` cancels the account's live subscriptions, which made a comped account look like a fresh customer to `build_stripe_url/1`: "Upgrade" rendered, Checkout opened, the customer was charged monthly — and `adopt_subscription`'s comped guard (correct for its own purpose) dropped the subscription id, so nothing in the app knew the subscription existed. Invisible to MRR; `revoke_comp/1` would lock out someone actively paying.

Two layers, per the issue's fix direction:

- **Don't reach Checkout**: the page renders a "This account is comped — no payment needed" state instead of the button, and `build_stripe_url/1` refuses `comped` outright so a stale socket or hand-sent event can't get through either (distinct info flash, not the generic Stripe error). Comped also gets its own badge colour instead of the grey catch-all.
- **Backstop in the webhook**: if a checkout completes for a comped account anyway (session opened before the comp), `adopt_subscription/3` records `stripe_subscription_id` — status and gating untouched — and logs at error level naming the user and subscription, so the operator can refund or revoke the comp deliberately. The cancellation sweep stays skipped for comped (comp already cancelled everything).

Tests: page state + button absence; hand-sent `manage_subscription` event flashes and provably never calls Checkout/Portal (message-sending stubs + `refute_received`); webhook backstop records the id, keeps `comped`, logs, and skips `Subscription.list`. 3/3 fail against the old code. `mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)