### PR TITLE
billing: idempotent trial creation with webhook-grade status coercion (#400)

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -248,12 +248,25 @@ defmodule Fountain.Billing do
         trial_param
       )
 
-    case Stripe.Subscription.create(params) do
+    # Idempotent across Oban retries (#400): when the create succeeded but
+    # the local write below failed, the retry re-entered here (the worker's
+    # guard checks stripe_subscription_id, which the failed write never set)
+    # and minted another trialing subscription — up to five per user, all of
+    # them converting and charging if a card was added before trial end. A
+    # stable per-user key makes Stripe return the original subscription for
+    # every retry inside the 24h idempotency window instead.
+    request_opts = [headers: %{"Idempotency-Key" => "trial-subscription-#{user.id}"}]
+
+    case Stripe.Subscription.create(params, request_opts) do
       {:ok, sub} ->
         user
         |> User.billing_changeset(%{
           stripe_subscription_id: sub.id,
-          subscription_status: to_string(sub.status),
+          # The same coercion the webhook path applies (#400): Stripe can
+          # answer with incomplete/unpaid/paused, none of which the
+          # changeset's inclusion list accepts — and that rejected write was
+          # the realistic trigger for the duplicating retries above.
+          subscription_status: coerce_status(to_string(sub.status), nil),
           trial_ends_at: unix_to_datetime(Map.get(sub, :trial_end)),
           subscription_synced_at: DateTime.utc_now() |> DateTime.truncate(:second)
         })

--- a/apps/fountain/test/fountain/trial_expiry_test.exs
+++ b/apps/fountain/test/fountain/trial_expiry_test.exs
@@ -130,7 +130,7 @@ defmodule Fountain.TrialExpiryTest do
 
       stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_new"}} end)
 
-      stub(Stripe.Subscription, :create, fn params ->
+      stub(Stripe.Subscription, :create, fn params, _opts ->
         send(test, {:subscription_params, params})
         {:ok, %{id: "sub_new", status: "trialing", trial_end: DateTime.to_unix(ahead(14))}}
       end)
@@ -160,7 +160,7 @@ defmodule Fountain.TrialExpiryTest do
 
       stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_x"}} end)
 
-      stub(Stripe.Subscription, :create, fn params ->
+      stub(Stripe.Subscription, :create, fn params, _opts ->
         send(test, {:params, params})
         {:ok, %{id: "sub_x", status: "trialing", trial_end: DateTime.to_unix(ahead(14))}}
       end)
@@ -179,7 +179,7 @@ defmodule Fountain.TrialExpiryTest do
 
       stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_y"}} end)
 
-      stub(Stripe.Subscription, :create, fn _ ->
+      stub(Stripe.Subscription, :create, fn _, _opts ->
         {:ok, %{id: "sub_y", status: "trialing", trial_end: DateTime.to_unix(stripe_end)}}
       end)
 
@@ -194,7 +194,7 @@ defmodule Fountain.TrialExpiryTest do
       user = insert_verified_user()
 
       stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_partial"}} end)
-      stub(Stripe.Subscription, :create, fn _ -> {:error, :stripe_down} end)
+      stub(Stripe.Subscription, :create, fn _, _opts -> {:error, :stripe_down} end)
 
       assert {:ok, user} = Billing.create_stripe_customer(user)
       assert {:error, :stripe_down} = Billing.start_trial_subscription(user)

--- a/apps/fountain/test/fountain/trial_subscription_idempotency_test.exs
+++ b/apps/fountain/test/fountain/trial_subscription_idempotency_test.exs
@@ -1,0 +1,59 @@
+defmodule Fountain.TrialSubscriptionIdempotencyTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Billing, Repo}
+  alias Fountain.Accounts.User
+
+  # Regression tests for #400: trial-subscription creation wrote Stripe's
+  # status straight through (the changeset rejects incomplete/unpaid/paused,
+  # unlike the webhook path, which coerces them) and re-entered on every Oban
+  # retry because the worker's guard checks a field the failed write never
+  # set — each retry minting another trialing subscription.
+
+  setup do
+    Application.put_env(:fountain, :stripe_price_id, "price_trial_test")
+    on_exit(fn -> Application.delete_env(:fountain, :stripe_price_id) end)
+
+    user = insert_verified_user()
+    {:ok, user} = Billing.attach_stripe_customer(user, "cus_trial_idem")
+    {:ok, user: user}
+  end
+
+  test "a status outside the changeset's set is coerced, not rejected", %{user: user} do
+    # Pre-#400 this returned {:error, %Ecto.Changeset{}} — the failed local
+    # write that made Oban retry and duplicate the subscription.
+    stub(Stripe.Subscription, :create, fn _params, _opts ->
+      {:ok, %Stripe.Subscription{id: "sub_trial_inc", status: "incomplete", trial_end: nil}}
+    end)
+
+    assert {:ok, %User{} = updated} = Billing.start_trial_subscription(user)
+    assert updated.stripe_subscription_id == "sub_trial_inc"
+    # incomplete coerces to past_due, exactly as the webhook path does.
+    assert updated.subscription_status == "past_due"
+    assert Repo.reload(user).stripe_subscription_id == "sub_trial_inc"
+  end
+
+  test "creation sends a stable per-user idempotency key", %{user: user} do
+    test_pid = self()
+
+    stub(Stripe.Subscription, :create, fn _params, opts ->
+      send(test_pid, {:idempotency_key, get_in(opts, [:headers, "Idempotency-Key"])})
+      {:ok, %Stripe.Subscription{id: "sub_trial_ok", status: "trialing", trial_end: nil}}
+    end)
+
+    {:ok, _} = Billing.start_trial_subscription(user)
+
+    # The retry shape: the local write failed, the worker re-enters, and the
+    # SAME key must reach Stripe so it returns the original subscription
+    # rather than minting a second one.
+    {:ok, user} = Repo.reload(user) |> User.billing_changeset(%{stripe_subscription_id: nil}) |> Repo.update()
+    {:ok, _} = Billing.start_trial_subscription(user)
+
+    assert_received {:idempotency_key, key1}
+    assert_received {:idempotency_key, key2}
+    assert is_binary(key1) and key1 != ""
+    assert key1 == key2
+    assert key1 =~ user.id
+  end
+end

--- a/apps/fountain/test/fountain/workers/stripe_customer_sync_trial_test.exs
+++ b/apps/fountain/test/fountain/workers/stripe_customer_sync_trial_test.exs
@@ -34,7 +34,7 @@ defmodule Fountain.Workers.StripeCustomerSyncTrialTest do
 
     stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_e2e"}} end)
 
-    stub(Stripe.Subscription, :create, fn params ->
+    stub(Stripe.Subscription, :create, fn params, _opts ->
       send(test, {:sub_params, params})
       {:ok, %{id: "sub_e2e", status: "trialing", trial_end: params.trial_end}}
     end)


### PR DESCRIPTION
Closes #400 (P1, audit-2026-08-03 #416).

Two composing defects in `do_create_trial_subscription/3`:

1. **No status coercion** — Stripe's `incomplete`/`unpaid`/`paused` fail `billing_changeset`'s inclusion list (the webhook path coerces exactly these), so the local write errored after the subscription was created.
2. **Non-idempotent re-entry** — the failed write left `stripe_subscription_id` nil, which is precisely the field `StripeCustomerSync`'s guard checks, so each of Oban's five retries called `Stripe.Subscription.create` again. Up to five trialing subscriptions per user; `missing_payment_method: :cancel` spares any with a card, so adding a card converted **all** of them.

Fix: the created status runs through the same `coerce_status/2` the webhook uses, and the create call carries a stable per-user `Idempotency-Key` (`trial-subscription-<user_id>`) — chosen over list-and-adopt because it's race-free for concurrent invocations and Oban's retry window sits well inside Stripe's 24h idempotency window. `stripity_stripe`'s `Map.put_new` semantics keep a caller-provided key intact (verified in `deps`).

The call is now `create/2`, so the existing arity-1 Mimic stubs in `trial_expiry_test.exs` and `stripe_customer_sync_trial_test.exs` were updated (Mimic matches on arity; unstubbed arities fall through to the real module).

Tests: an `"incomplete"` answer persists as `past_due` instead of `{:error, changeset}` — the exact re-entry trigger; and two invocations for the same user send byte-identical idempotency keys containing the user id. 2/2 fail pre-fix. `mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)