### PR TITLE
web: reconcile mount-time LiveView state and stop crashing on stale rows (#401)

### DIFF
--- a/apps/fountain/lib/fountain_web/components/core_components.ex
+++ b/apps/fountain/lib/fountain_web/components/core_components.ex
@@ -152,8 +152,10 @@ defmodule FountainWeb.CoreComponents do
 
   # ────────────────────────────────────────────────────────────────────────────
   # badge/1
-  # Conversation status values: pending | starting | running | ready |
-  #                              terminated | failed
+  # Renders both status vocabularies (#401 — the old comment labelled the
+  # sandbox set as the conversation one, which is how `idle` got left out):
+  #   conversation: pending | running | idle | failed | terminated
+  #   sandbox:      pending | starting | running | ready | terminated | failed
   # ────────────────────────────────────────────────────────────────────────────
 
   attr :status, :string, required: true
@@ -182,6 +184,11 @@ defmodule FountainWeb.CoreComponents do
   defp badge_bg_class("ready"),
     do: "bg-[var(--status-ready-bg)] text-[var(--status-ready-text)]"
 
+  # The resting state of every healthy conversation between turns — green,
+  # not the unrecognised-value grey it fell into before (#401).
+  defp badge_bg_class("idle"),
+    do: "bg-[var(--status-ready-bg)] text-[var(--status-ready-text)]"
+
   defp badge_bg_class("terminated"),
     do: "bg-[var(--status-terminated-bg)] text-[var(--status-terminated-text)]"
 
@@ -195,6 +202,7 @@ defmodule FountainWeb.CoreComponents do
   defp badge_dot_class("running"), do: "bg-[var(--status-starting-text)] animate-pulse"
   defp badge_dot_class("pending"), do: "bg-[var(--status-pending-text)]"
   defp badge_dot_class("ready"), do: "bg-[var(--status-ready-text)]"
+  defp badge_dot_class("idle"), do: "bg-[var(--status-ready-text)]"
   defp badge_dot_class("terminated"), do: "bg-[var(--status-terminated-text)]"
   defp badge_dot_class("failed"), do: "bg-[var(--status-failed-text)]"
   defp badge_dot_class(_), do: "bg-[var(--color-text-muted)]"

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -63,24 +63,7 @@ defmodule FountainWeb.AdminLive.Index do
 
   @impl true
   def handle_event("toggle_admin", %{"id" => id}, socket) do
-    user = Accounts.get_user!(id)
-    new_role = if user.role == "admin", do: "user", else: "admin"
-
-    case Accounts.update_user_role(user, new_role) do
-      {:ok, _} ->
-        Fountain.Audit.record_admin(%{
-          actor_user_id: socket.assigns.current_user.id,
-          target_user_id: user.id,
-          event_type:
-            if(new_role == "admin", do: "admin.role.granted", else: "admin.role.revoked"),
-          metadata: %{"email" => user.email, "from" => user.role, "to" => new_role}
-        })
-
-        {:noreply, socket |> assign_users() |> put_flash(:info, "Role updated")}
-
-      {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to update role")}
-    end
+    with_target_user(socket, id, fn user -> do_toggle_admin(socket, user) end)
   end
 
   # The concurrency cap is the only lever for a noisy or abusive tenant
@@ -89,7 +72,7 @@ defmodule FountainWeb.AdminLive.Index do
   @impl true
   def handle_event("set_sandbox_limit", %{"user_id" => id, "limit" => raw}, socket) do
     with {limit, ""} <- Integer.parse(String.trim(raw)),
-         user = Accounts.get_user!(id),
+         %Accounts.User{} = user <- Accounts.get_user(id),
          {:ok, _} <- Accounts.update_sandbox_limit(user, limit) do
       Fountain.Audit.record_admin(%{
         actor_user_id: socket.assigns.current_user.id,
@@ -104,14 +87,21 @@ defmodule FountainWeb.AdminLive.Index do
 
       {:noreply, socket |> assign_users() |> put_flash(:info, "Sandbox limit updated")}
     else
-      _ -> {:noreply, put_flash(socket, :error, "Limit must be a whole number of 0 or more")}
+      nil ->
+        {:noreply,
+         socket
+         |> assign_users()
+         |> put_flash(:error, "User not found — the account may have been deleted")}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "Limit must be a whole number of 0 or more")}
     end
   end
 
   @impl true
   def handle_event("extend_trial", %{"user_id" => id, "days" => raw}, socket) do
     with {days, ""} when days > 0 <- Integer.parse(String.trim(raw)),
-         user = Accounts.get_user!(id),
+         %Accounts.User{} = user <- Accounts.get_user(id),
          {:ok, updated} <- Billing.extend_trial(user, days) do
       Fountain.Audit.record_admin(%{
         actor_user_id: socket.assigns.current_user.id,
@@ -138,6 +128,12 @@ defmodule FountainWeb.AdminLive.Index do
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Could not extend trial — Stripe refused")}
 
+      nil ->
+        {:noreply,
+         socket
+         |> assign_users()
+         |> put_flash(:error, "User not found — the account may have been deleted")}
+
       _ ->
         {:noreply, put_flash(socket, :error, "Days must be a whole number of 1 or more")}
     end
@@ -145,33 +141,7 @@ defmodule FountainWeb.AdminLive.Index do
 
   @impl true
   def handle_event("toggle_comp", %{"id" => id}, socket) do
-    user = Accounts.get_user!(id)
-
-    result =
-      if user.subscription_status == "comped",
-        do: {Billing.revoke_comp(user), "admin.comp.revoked"},
-        else: {Billing.comp_account(user), "admin.comp.granted"}
-
-    case result do
-      {{:ok, updated}, event_type} ->
-        Fountain.Audit.record_admin(%{
-          actor_user_id: socket.assigns.current_user.id,
-          target_user_id: user.id,
-          event_type: event_type,
-          metadata: %{
-            "email" => user.email,
-            "from" => user.subscription_status,
-            "to" => updated.subscription_status
-          }
-        })
-
-        {:noreply,
-         socket |> assign_users() |> put_flash(:info, "Now #{updated.subscription_status}")}
-
-      {{:error, _}, _} ->
-        {:noreply,
-         put_flash(socket, :error, "Could not change comp — Stripe cancellation failed")}
-    end
+    with_target_user(socket, id, fn user -> do_toggle_comp(socket, user) end)
   end
 
   @impl true
@@ -213,43 +183,7 @@ defmodule FountainWeb.AdminLive.Index do
     if id == admin.id do
       {:noreply, put_flash(socket, :error, "You cannot suspend your own account")}
     else
-      user = Accounts.get_user!(id)
-
-      if Accounts.suspended?(user) do
-        case Accounts.unsuspend_user(user) do
-          {:ok, _} ->
-            Fountain.Audit.record_admin(%{
-              actor_user_id: admin.id,
-              target_user_id: user.id,
-              event_type: "admin.account.unsuspended",
-              metadata: %{"email" => user.email}
-            })
-
-            {:noreply, socket |> assign_users() |> put_flash(:info, "Suspension lifted")}
-
-          {:error, _} ->
-            {:noreply, put_flash(socket, :error, "Could not lift the suspension")}
-        end
-      else
-        case Accounts.suspend_user(user) do
-          {:ok, _, reaped} ->
-            Fountain.Audit.record_admin(%{
-              actor_user_id: admin.id,
-              target_user_id: user.id,
-              event_type: "admin.account.suspended",
-              metadata: %{"email" => user.email, "sandboxes_reaped" => reaped}
-            })
-
-            {:noreply,
-             socket
-             |> assign_users()
-             |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
-             |> put_flash(:info, "Suspended — #{reaped} sandbox(es) reaped")}
-
-          {:error, _} ->
-            {:noreply, put_flash(socket, :error, "Could not suspend the account")}
-        end
-      end
+      with_target_user(socket, id, fn user -> do_toggle_suspend(socket, admin, user) end)
     end
   end
 
@@ -266,37 +200,141 @@ defmodule FountainWeb.AdminLive.Index do
       # feature.
       {:noreply, put_flash(socket, :error, "Use your own account page to delete your account")}
     else
-      user = Accounts.get_user!(id)
+      with_target_user(socket, id, fn user -> do_delete_user(socket, admin, user) end)
+    end
+  end
 
-      case Deletion.delete_user(user,
-             actor: "admin:#{admin.id}",
-             request_ip: socket.assigns[:client_ip]
-           ) do
-        {:ok, _summary} ->
+  # Non-bang lookup for every admin action targeting a user row (#401): the
+  # table is loaded at mount, so acting on a user deleted since (another
+  # admin tab, self-deletion) made get_user! raise and kill the LiveView.
+  defp with_target_user(socket, id, fun) do
+    case Accounts.get_user(id) do
+      nil ->
+        {:noreply,
+         socket
+         |> assign_users()
+         |> put_flash(:error, "User not found — the account may have been deleted")}
+
+      user ->
+        fun.(user)
+    end
+  end
+
+  defp do_toggle_admin(socket, user) do
+    new_role = if user.role == "admin", do: "user", else: "admin"
+
+    case Accounts.update_user_role(user, new_role) do
+      {:ok, _} ->
+        Fountain.Audit.record_admin(%{
+          actor_user_id: socket.assigns.current_user.id,
+          target_user_id: user.id,
+          event_type:
+            if(new_role == "admin", do: "admin.role.granted", else: "admin.role.revoked"),
+          metadata: %{"email" => user.email, "from" => user.role, "to" => new_role}
+        })
+
+        {:noreply, socket |> assign_users() |> put_flash(:info, "Role updated")}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to update role")}
+    end
+  end
+
+  defp do_toggle_comp(socket, user) do
+    result =
+      if user.subscription_status == "comped",
+        do: {Billing.revoke_comp(user), "admin.comp.revoked"},
+        else: {Billing.comp_account(user), "admin.comp.granted"}
+
+    case result do
+      {{:ok, updated}, event_type} ->
+        Fountain.Audit.record_admin(%{
+          actor_user_id: socket.assigns.current_user.id,
+          target_user_id: user.id,
+          event_type: event_type,
+          metadata: %{
+            "email" => user.email,
+            "from" => user.subscription_status,
+            "to" => updated.subscription_status
+          }
+        })
+
+        {:noreply,
+         socket |> assign_users() |> put_flash(:info, "Now #{updated.subscription_status}")}
+
+      {{:error, _}, _} ->
+        {:noreply,
+         put_flash(socket, :error, "Could not change comp — Stripe cancellation failed")}
+    end
+  end
+
+  defp do_toggle_suspend(socket, admin, user) do
+    if Accounts.suspended?(user) do
+      case Accounts.unsuspend_user(user) do
+        {:ok, _} ->
           Fountain.Audit.record_admin(%{
             actor_user_id: admin.id,
             target_user_id: user.id,
-            event_type: "admin.account.deleted",
+            event_type: "admin.account.unsuspended",
             metadata: %{"email" => user.email}
+          })
+
+          {:noreply, socket |> assign_users() |> put_flash(:info, "Suspension lifted")}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, "Could not lift the suspension")}
+      end
+    else
+      case Accounts.suspend_user(user) do
+        {:ok, _, reaped} ->
+          Fountain.Audit.record_admin(%{
+            actor_user_id: admin.id,
+            target_user_id: user.id,
+            event_type: "admin.account.suspended",
+            metadata: %{"email" => user.email, "sandboxes_reaped" => reaped}
           })
 
           {:noreply,
            socket
            |> assign_users()
            |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
-           |> put_flash(:info, "Deleted #{user.email}")}
-
-        {:error, {:stripe, _}} ->
-          {:noreply,
-           put_flash(
-             socket,
-             :error,
-             "Could not cancel #{user.email}'s subscription — nothing was deleted"
-           )}
+           |> put_flash(:info, "Suspended — #{reaped} sandbox(es) reaped")}
 
         {:error, _} ->
-          {:noreply, put_flash(socket, :error, "Deletion failed — nothing was deleted")}
+          {:noreply, put_flash(socket, :error, "Could not suspend the account")}
       end
+    end
+  end
+
+  defp do_delete_user(socket, admin, user) do
+    case Deletion.delete_user(user,
+           actor: "admin:#{admin.id}",
+           request_ip: socket.assigns[:client_ip]
+         ) do
+      {:ok, _summary} ->
+        Fountain.Audit.record_admin(%{
+          actor_user_id: admin.id,
+          target_user_id: user.id,
+          event_type: "admin.account.deleted",
+          metadata: %{"email" => user.email}
+        })
+
+        {:noreply,
+         socket
+         |> assign_users()
+         |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
+         |> put_flash(:info, "Deleted #{user.email}")}
+
+      {:error, {:stripe, _}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Could not cancel #{user.email}'s subscription — nothing was deleted"
+         )}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Deletion failed — nothing was deleted")}
     end
   end
 

--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -65,9 +65,24 @@ defmodule FountainWeb.AgentsLive.Index do
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
     user_id = socket.assigns.user_id
-    agent = Agents.get_agent!(id, user_id)
-    {:ok, _} = Agents.delete_agent(agent)
 
+    # Non-bang + nil branch (#401): the list is loaded at mount, so a row
+    # deleted from another tab or the API made get_agent! raise and kill
+    # the LiveView on the second click.
+    case Agents.get_agent(id, user_id) do
+      nil ->
+        {:noreply,
+         socket
+         |> assign(:agents, Agents.list_agents_with_counts(user_id, current_filters(socket.assigns)))
+         |> put_flash(:error, "Agent not found — it may already be deleted")}
+
+      agent ->
+        {:ok, _} = Agents.delete_agent(agent)
+        delete_refresh(socket, user_id, agent)
+    end
+  end
+
+  defp delete_refresh(socket, user_id, agent) do
     all_agents = Agents.list_agents_with_counts(user_id, [])
     filters = current_filters(socket.assigns)
 

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -110,8 +110,22 @@ defmodule FountainWeb.ConversationsLive.Show do
           socket.assigns.turns_by_id
         end
 
+      # Stage events are exactly when the server rewrites conversation.status,
+      # and everything in the header (badge, Interrupt/Terminate visibility)
+      # keys off @conv — which was loaded once at mount and never again, so
+      # the page showed "pending" through a whole run and kept Interrupt
+      # rendered after the turn ended (#401).
+      conv =
+        if ev.kind == "stage" do
+          Conversations.get_conversation(socket.assigns.conv.id, socket.assigns.current_user.id) ||
+            socket.assigns.conv
+        else
+          socket.assigns.conv
+        end
+
       {:noreply,
        socket
+       |> assign(:conv, conv)
        |> assign(:events, events)
        |> assign(:turns_by_id, turns_by_id)}
     else
@@ -168,6 +182,28 @@ defmodule FountainWeb.ConversationsLive.Show do
       {:error, :no_agent} ->
         {:noreply, put_flash(socket, :error, "Conversation has no agent — can't resume")}
 
+      # The on_mount hook gates at mount only, so a socket that connected
+      # while the subscription was active survives a mid-session lapse (#401).
+      # Same handling ConversationsLive.New already has.
+      {:error, :subscription_required} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "An active subscription is required to send a prompt.")
+         |> push_navigate(to: ~p"/account/billing")}
+
+      {:error, {:sandbox_quota_exceeded, %{count: count, limit: limit}}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "You have #{count} of #{limit} concurrent sandboxes in use. " <>
+             "Terminate a conversation before starting another."
+         )}
+
+      {:error, :provisioning} ->
+        {:noreply,
+         put_flash(socket, :error, "The conversation is still provisioning — try again shortly.")}
+
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Couldn't send: #{inspect(reason)}")}
     end
@@ -201,12 +237,24 @@ defmodule FountainWeb.ConversationsLive.Show do
   end
 
   def handle_event("delete", _, socket) do
-    {:ok, _} = Conversations.delete_conversation(socket.assigns.conv)
+    # Re-fetch instead of deleting the mount-time struct: a row already
+    # deleted from another tab or the API raised StaleEntryError and killed
+    # the LiveView (#401). Already-gone means the user got what they wanted.
+    case Conversations.get_conversation(socket.assigns.conv.id, socket.assigns.current_user.id) do
+      nil ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Conversation already deleted")
+         |> push_navigate(to: ~p"/conversations")}
 
-    {:noreply,
-     socket
-     |> put_flash(:info, "Conversation deleted")
-     |> push_navigate(to: ~p"/conversations")}
+      conv ->
+        {:ok, _} = Conversations.delete_conversation(conv)
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Conversation deleted")
+         |> push_navigate(to: ~p"/conversations")}
+    end
   end
 
   def handle_event("update_prompt", %{"prompt" => p}, socket) do

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -96,6 +96,9 @@ defmodule FountainWeb.DashboardLive.Index do
     color =
       case assigns.status do
         "ready" -> "bg-green-100 text-green-800 border-green-200"
+        # The resting state of every healthy conversation — it fell to the
+        # unrecognised-value grey before (#401).
+        "idle" -> "bg-green-100 text-green-800 border-green-200"
         "running" -> "bg-blue-100 text-blue-800 border-blue-200"
         "pending" -> "bg-zinc-100 text-zinc-600 border-zinc-200"
         "starting" -> "bg-blue-50 text-blue-600 border-blue-200"

--- a/apps/fountain/lib/fountain_web/live/environments_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/index.ex
@@ -28,13 +28,24 @@ defmodule FountainWeb.EnvironmentsLive.Index do
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    env = Environments.get_environment!(id, socket.assigns.user_id)
-    {:ok, _} = Environments.delete_environment(env)
+    # Non-bang + nil branch (#401): the list is loaded at mount, so a row
+    # deleted from another tab or the API made get_environment! raise and
+    # kill the LiveView on the second click.
+    case Environments.get_environment(id, socket.assigns.user_id) do
+      nil ->
+        {:noreply,
+         socket
+         |> assign(:envs, load_envs(socket.assigns.user_id, socket.assigns.filter_search))
+         |> put_flash(:error, "Environment not found — it may already be deleted")}
 
-    {:noreply,
-     socket
-     |> assign(:envs, load_envs(socket.assigns.user_id, socket.assigns.filter_search))
-     |> put_flash(:info, "Deleted #{env.name}")}
+      env ->
+        {:ok, _} = Environments.delete_environment(env)
+
+        {:noreply,
+         socket
+         |> assign(:envs, load_envs(socket.assigns.user_id, socket.assigns.filter_search))
+         |> put_flash(:info, "Deleted #{env.name}")}
+    end
   end
 
   defp load_envs(user_id, search) do

--- a/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
@@ -17,10 +17,12 @@ defmodule FountainWeb.LogViewerLive.Show do
 
     if conversation do
       if connected?(socket) do
-        Phoenix.PubSub.subscribe(
-          Fountain.PubSub,
-          "conv:#{user.id}:#{conversation.id}"
-        )
+        # "conv:<conversation_id>" — the topic every publisher uses
+        # (publish_stage, ConversationServer, Provisioning). This subscribed
+        # to "conv:<user>:<conv>", which nothing publishes on, so the page
+        # was a static snapshot while claiming live updates (#401).
+        # Ownership is already established by get_conversation!/2 above.
+        Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conversation.id}")
       end
 
       logs = Conversations._unsafe_list_log_events(conversation.id)
@@ -43,10 +45,9 @@ defmodule FountainWeb.LogViewerLive.Show do
     {:noreply, update(socket, :logs, fn logs -> logs ++ [event] end)}
   end
 
-  def handle_info({:conversation_updated, conv}, socket) do
-    {:noreply, assign(socket, :conversation, conv)}
-  end
-
+  # No {:conversation_updated, _} clause: nothing anywhere broadcasts that
+  # message — it was aspirational (#401). Status changes arrive as stage
+  # log events, which the clause above appends.
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   @impl true

--- a/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
@@ -28,13 +28,24 @@ defmodule FountainWeb.VaultsLive.Index do
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    vault = Vaults.get_vault!(id, socket.assigns.user_id)
-    {:ok, _} = Vaults.delete_vault(vault)
+    # Non-bang + nil branch (#401): the list is loaded at mount, so a row
+    # deleted from another tab or the API made get_vault! raise and kill
+    # the LiveView on the second click.
+    case Vaults.get_vault(id, socket.assigns.user_id) do
+      nil ->
+        {:noreply,
+         socket
+         |> assign(:vaults, load_vaults(socket.assigns.user_id, socket.assigns.filter_search))
+         |> put_flash(:error, "Vault not found — it may already be deleted")}
 
-    {:noreply,
-     socket
-     |> assign(:vaults, load_vaults(socket.assigns.user_id, socket.assigns.filter_search))
-     |> put_flash(:info, "Deleted #{vault.name}")}
+      vault ->
+        {:ok, _} = Vaults.delete_vault(vault)
+
+        {:noreply,
+         socket
+         |> assign(:vaults, load_vaults(socket.assigns.user_id, socket.assigns.filter_search))
+         |> put_flash(:info, "Deleted #{vault.name}")}
+    end
   end
 
   defp load_vaults(user_id, search) do

--- a/apps/fountain/test/fountain_web/live/liveview_reconciliation_test.exs
+++ b/apps/fountain/test/fountain_web/live/liveview_reconciliation_test.exs
@@ -1,0 +1,154 @@
+defmodule FountainWeb.LiveviewReconciliationTest do
+  use FountainWeb.ConnCase, async: true
+
+  import Mimic
+  import Phoenix.LiveViewTest
+
+  alias Fountain.{Agents, Conversations, Environments, Vaults}
+
+  # Regression tests for #401: LiveView state loaded at mount and never
+  # reconciled — a log viewer subscribed to a topic nothing publishes on, a
+  # conversation header keyed off a mount-time struct, delete handlers that
+  # crashed on rows deleted elsewhere, and an unmapped `idle` badge.
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, conn: login_user(conn, user), user: user}
+  end
+
+  describe "log viewer topic (#401 item 1)" do
+    test "receives live log events", %{conn: conn, user: user} do
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conv.id}/logs")
+
+      # The real publisher path — publish_stage broadcasts on
+      # "conv:<conversation_id>". The old subscription was on
+      # "conv:<user>:<conv>", which nothing publishes on, so this event
+      # never arrived and the page was a static snapshot.
+      Conversations.publish_stage(conv.id, "provision", "done", %{})
+
+      assert render(view) =~ "provision"
+    end
+  end
+
+  describe "conversation header reconciliation (#401 item 2)" do
+    test "the status badge and buttons track stage events", %{conn: conn, user: user} do
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent_id: agent.id, status: "pending")
+
+      {:ok, view, html} = live(conn, ~p"/conversations/#{conv.id}")
+      assert html =~ "pending"
+      refute html =~ "phx-click=\"interrupt\""
+
+      # The server's real sequence: write the row, then publish the stage
+      # event. Pre-#401 the handler updated :events but never :conv, so the
+      # badge said "pending" through the whole run and Interrupt never
+      # appeared.
+      {:ok, _} =
+        Conversations.get_conversation(conv.id, user.id)
+        |> Conversations.update_conversation(%{status: "running"})
+
+      Conversations.publish_stage(conv.id, "turn", "started", %{})
+
+      html = render(view)
+      assert html =~ "running"
+      assert html =~ "phx-click=\"interrupt\""
+    end
+  end
+
+  describe "delete handlers on stale rows (#401 item 3)" do
+    test "agents index survives deleting an already-deleted agent", %{conn: conn, user: user} do
+      agent = insert_agent(user_id: user.id)
+      {:ok, view, _html} = live(conn, ~p"/agents")
+
+      {:ok, _} = Agents.delete_agent(agent)
+
+      html = render_click(view, "delete", %{"id" => agent.id})
+      assert html =~ "may already be deleted"
+      assert Process.alive?(view.pid)
+    end
+
+    test "environments index survives deleting an already-deleted environment",
+         %{conn: conn, user: user} do
+      env = insert_env(user_id: user.id)
+      {:ok, view, _html} = live(conn, ~p"/environments")
+
+      {:ok, _} = Environments.delete_environment(env)
+
+      html = render_click(view, "delete", %{"id" => env.id})
+      assert html =~ "may already be deleted"
+      assert Process.alive?(view.pid)
+    end
+
+    test "vaults index survives deleting an already-deleted vault", %{conn: conn, user: user} do
+      vault = insert_vault(user_id: user.id)
+      {:ok, view, _html} = live(conn, ~p"/vaults")
+
+      {:ok, _} = Vaults.delete_vault(vault)
+
+      html = render_click(view, "delete", %{"id" => vault.id})
+      assert html =~ "may already be deleted"
+      assert Process.alive?(view.pid)
+    end
+
+    test "conversation show survives deleting an already-deleted conversation",
+         %{conn: conn, user: user} do
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conv.id}")
+
+      {:ok, _} = Conversations.delete_conversation(conv)
+
+      # Pre-#401 this deleted the mount-time struct: StaleEntryError, dead
+      # LiveView, reconnect loop. Now: already gone is success.
+      assert {:error, {:live_redirect, %{to: "/conversations"}}} =
+               render_click(view, "delete", %{})
+    end
+
+    test "admin actions flash instead of crashing on a deleted user", %{conn: conn} do
+      admin = insert_verified_user(role: "admin")
+      victim = insert_verified_user()
+      conn = login_user(conn, admin)
+
+      {:ok, view, _html} = live(conn, ~p"/admin")
+
+      {:ok, _} = Fountain.Repo.delete(victim)
+
+      html = render_click(view, "toggle_admin", %{"id" => victim.id})
+      assert html =~ "may have been deleted"
+      assert Process.alive?(view.pid)
+    end
+  end
+
+  describe "mid-session refusal flashes (#401 item 5)" do
+    test "a lapsed subscription shows a real message, not a raw atom",
+         %{conn: conn, user: user} do
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent_id: agent.id, status: "idle")
+
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conv.id}")
+
+      stub(Fountain.Conversations.ConversationServer, :send_prompt, fn _id, _p, _i ->
+        {:error, :subscription_required}
+      end)
+
+      render_click(view, "send_prompt", %{"prompt" => "hello"})
+
+      flash = assert_redirect(view, "/account/billing")
+      refute inspect(flash) =~ ":subscription_required"
+    end
+  end
+
+  describe "idle badge (#401 item 6)" do
+    test "idle renders with the healthy colour, not the unknown-value grey" do
+      html = render_component(&FountainWeb.CoreComponents.badge/1, status: "idle")
+      assert html =~ "status-ready-bg"
+
+      unknown = render_component(&FountainWeb.CoreComponents.badge/1, status: "wat")
+      refute unknown =~ "status-ready-bg"
+    end
+  end
+end


### PR DESCRIPTION
Closes #401 (P1, audit-2026-08-03 #416).

All six items, sharing one cause (mount-time state never reconciled, bang-calls with non-raising siblings):

1. **Log viewer** subscribed to `conv:<user>:<conv>` — a topic with zero publishers — so `/conversations/:id/logs` was a static snapshot claiming live updates. Now `conv:<conversation_id>` (ownership already established by the tenant-scoped fetch at mount); the unreachable `{:conversation_updated, _}` clause is deleted rather than given a phantom broadcast.
2. **Show header**: `handle_info({:log_event, ...})` re-reads the conversation on stage events — exactly when the server rewrites `status` — so the badge and Interrupt/Terminate visibility track the run.
3. **Stale-row deletes**: agents/environments/vaults indexes, the conversation show delete (re-fetch, "already deleted" is success), and all six AdminLive user actions (shared `with_target_user/3`; the two `with`-pipeline sites get a `nil ->` else clause) now flash instead of killing the LiveView.
4. **DEK MatchError in mount** — already fixed by #418 (mount no longer calls `load_tenant_key` at all); nothing further here.
5. **Mid-session refusals**: `send_prompt` flashes lifted from `ConversationsLive.New` (billing redirect, quota wording) plus the new `:provisioning` from #412 — no more `Couldn't send: :subscription_required`.
6. **`idle` badge**: mapped to the healthy colour in `core_components.badge/1` and the dashboard's private copy; the comment that mislabelled the sandbox set as the conversation set (the likely origin of the gap) is corrected.

Nine regression tests — live event delivery through the real `publish_stage`, header reconciliation, four stale-delete paths, no-raw-atom flash, and idle-vs-unknown badge colours. **9/9 fail against the old code.** `mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)