### PR TITLE
ci: close the three gates that could not fail (#414)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,18 +60,23 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.SRC_SHA }}
-          # The parent commit, for the diff below.
-          fetch-depth: 2
+          # Full history: the diff below walks ancestry for the newest
+          # commit whose image actually exists.
+          fetch-depth: 0
 
       - name: Skip paths that never affect the OCI image
         id: filter
         # The old push-trigger paths-ignore list (k8s/**, deploy/**, docs/**,
         # decisions/**, **/*.md — deploy/ is the portable self-hosting
-        # manifests, never part of the image), re-implemented as a first-parent
-        # diff. main only moves by PR merges, so HEAD^..HEAD is exactly what
-        # the push brought in. Manifest-only changes still deploy:
-        # publish-manifests.yml triggers directly on k8s/deploy pushes and
-        # pins the newest already-built image.
+        # manifests, never part of the image), re-implemented as a diff from
+        # the newest first-parent ancestor whose image EXISTS in the registry
+        # (#414) — not HEAD^. Diffing one commit back assumed every ancestor
+        # got built; a cancelled CI run plus a docs-only follow-up broke that
+        # assumption, and the follow-up's one-commit diff reported "nothing
+        # image-affecting" while the cancelled commit's code sat un-built.
+        # Same ancestor walk publish-manifests.yml uses for its image pin.
+        # Manifest-only changes still deploy without a build:
+        # publish-manifests.yml triggers directly on k8s/deploy pushes.
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -79,12 +84,29 @@ jobs:
             echo "build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --name-only HEAD^ HEAD \
+
+          base=""
+          for candidate in $(git rev-list --first-parent -n 50 HEAD~1 2>/dev/null); do
+            if docker manifest inspect \
+                 "ghcr.io/binarybourbon/fountain:sha-${candidate}" > /dev/null 2>&1; then
+              base="${candidate}"
+              break
+            fi
+          done
+
+          if [ -z "${base}" ]; then
+            echo "no built ancestor image found — building unconditionally"
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "diffing against newest built ancestor ${base:0:7}"
+          if git diff --name-only "${base}" HEAD \
               | grep -qvE '^(k8s|deploy|docs|decisions)/|\.md$'; then
-            echo "image-affecting changes found — building"
+            echo "image-affecting changes since ${base:0:7} — building"
             echo "build=true" >> "$GITHUB_OUTPUT"
           else
-            echo "only ignored paths changed — skipping the build"
+            echo "only ignored paths changed since ${base:0:7} — skipping the build"
             echo "build=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,12 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # PRs only (#414): cancelling superseded MAIN runs meant a rapid merge
+  # sequence could strand a code commit un-built — commit A's CI cancelled
+  # by docs-only commit B, whose own HEAD^..HEAD build filter then reported
+  # "nothing image-affecting", so A never produced an image and every check
+  # stayed green. Main runs queue instead of cancelling.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/publish-manifests.yml
+++ b/.github/workflows/publish-manifests.yml
@@ -64,8 +64,64 @@ permissions:
   contents: read
 
 jobs:
+  # Nothing deployed unvalidated (#414): before this job existed, the
+  # manifest fast path pushed the live Deployment, the CNPG cluster and the
+  # PrometheusRule straight to the artifact Flux reconciles, with no check
+  # of any kind — a typo'd manifest was applied to prod by the reconciler.
+  validate:
+    name: Validate the manifests
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      SRC_SHA: ${{ github.event.workflow_run.head_sha || inputs.sha || github.sha }}
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.SRC_SHA }}
+
+      - name: kustomize build + kubeconform (k8s/ and deploy/k8s/)
+        run: |
+          set -euo pipefail
+          KUBECONFORM_VERSION=v0.7.0
+          curl -sSfL \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar xz kubeconform
+
+          for dir in k8s deploy/k8s; do
+            echo "── ${dir}"
+            kubectl kustomize "${dir}" > "/tmp/${dir//\//-}.yaml"
+            # The CRDs catalog covers PrometheusRule, ServiceMonitor, CNPG,
+            # Infisical et al; -strict rejects unknown fields, which is the
+            # class of typo that survives YAML parsing.
+            ./kubeconform -strict -summary \
+              -schema-location default \
+              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+              "/tmp/${dir//\//-}.yaml"
+          done
+
+      - name: promtool check rules (PrometheusRule alert expressions)
+        run: |
+          set -euo pipefail
+          PROM_VERSION=3.5.0
+          curl -sSfL \
+            "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz" \
+            | tar xz --strip-components=1 "prometheus-${PROM_VERSION}.linux-amd64/promtool"
+
+          # promtool reads a bare rules file; the PrometheusRule wraps the
+          # groups under spec.groups.
+          for f in k8s/prometheusrule.yaml deploy/k8s/prometheusrule.yaml; do
+            echo "── ${f}"
+            python3 -c "import yaml; yaml.safe_dump(yaml.safe_load(open('${f}'))['spec'], open('/tmp/rules.yaml', 'w'))"
+            ./promtool check rules /tmp/rules.yaml
+          done
+
   publish:
     name: Publish the manifest artifact
+    needs: validate
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/apps/fountain/.sobelow-conf
+++ b/apps/fountain/.sobelow-conf
@@ -1,9 +1,9 @@
 [
   verbose: false,
   private: false,
-  skip: false,
+  skip: true,
   router: "lib/fountain_web/router.ex",
-  exit: "high",
+  exit: "low",
   format: "txt",
   ignore: [],
   ignore_files: []

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -275,6 +275,10 @@ defmodule Fountain.Conversations do
   foreign parent link already exists in the data, and picking the boundary node
   degrades to "show the part of the tree you own" instead of returning nothing.
   """
+  # sobelow_skip ["SQL.Query"] — static SQL, values bound as parameters
+  # ($1/$2 UUIDs dumped above); nothing user-controlled is interpolated.
+  # sobelow_skip ["SQL.Query"] — static SQL, values bound as parameters
+  # ($1/$2 UUIDs dumped below); nothing user-controlled is interpolated.
   def get_conversation_tree(conversation_id, user_id) when is_binary(user_id) do
     sql = """
     WITH RECURSIVE
@@ -861,6 +865,8 @@ defmodule Fountain.Conversations do
     end
   end
 
+  # sobelow_skip ["SQL.Query"] — static SQL with a bound $1 UUID parameter.
+  # sobelow_skip ["SQL.Query"] — static SQL with a bound $1 UUID parameter.
   defp get_root_conversation_id(conversation_id) do
     sql = """
     WITH RECURSIVE ancestors(id, parent_conversation_id) AS (

--- a/apps/fountain/lib/fountain/sprite_skills.ex
+++ b/apps/fountain/lib/fountain/sprite_skills.ex
@@ -73,6 +73,10 @@ defmodule Fountain.SpriteSkills do
     end)
   end
 
+  # sobelow_skip ["Traversal.FileModule"] — fixed path assembled from
+  # priv_dir and a module attribute; no user input.
+  # sobelow_skip ["Traversal.FileModule"] — fixed path assembled from
+  # priv_dir and a module attribute; no user input.
   defp fountain_inline_skill do
     %{
       "name" => @fountain_skill_name,

--- a/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
@@ -4,6 +4,8 @@ defmodule FountainWeb.AgentAvatarController do
 
   alias Fountain.Agents
 
+  # sobelow_skip ["XSS.SendResp", "XSS.ContentType"] — bytes and media type
+  # come from the tenant-scoped agent row, validated at upload.
   def show(conn, %{"id" => id}) do
     user_id = conn.assigns.current_user.id
 

--- a/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
@@ -112,6 +112,8 @@ defmodule FountainWeb.LlmsController do
 
   ## ─── File reads ───────────────────────────────────────────────────────────
 
+  # sobelow_skip ["Traversal.FileModule"] — slug comes from the compile-time
+  # Fountain.Help.topics() list, never from the request.
   defp read_help(slug) do
     path = Path.join([priv_dir(), "help", slug <> ".md"])
 
@@ -121,6 +123,7 @@ defmodule FountainWeb.LlmsController do
     end
   end
 
+  # sobelow_skip ["Traversal.FileModule"] — fixed priv path, no user input.
   defp read_skill do
     path = Path.join([priv_dir(), "external_skills", "fountain", "SKILL.md"])
 

--- a/apps/fountain/lib/fountain_web/controllers/turn_image_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/turn_image_controller.ex
@@ -5,6 +5,9 @@ defmodule FountainWeb.TurnImageController do
   alias Fountain.Conversations
   alias Fountain.Conversations.TurnImage
 
+  # sobelow_skip ["XSS.SendResp", "XSS.ContentType"] — media type is checked
+  # against TurnImage.valid_media_types/0 and the response pins nosniff +
+  # a sandboxing CSP precisely because the bytes are client-originated.
   def show(conn, %{"conversation_id" => conv_id, "turn_id" => turn_id, "position" => pos_str}) do
     user_id = conn.assigns.current_user.id
 

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -329,6 +329,8 @@ defmodule FountainWeb.AgentsLive.Form do
     end
   end
 
+  # sobelow_skip ["Traversal.FileModule"] — path is the Phoenix-managed
+  # upload tempfile, not client-supplied.
   defp maybe_set_avatar(socket, agent) do
     uploaded =
       consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->

--- a/apps/fountain/lib/fountain_web/live/help_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/help_live/show.ex
@@ -40,6 +40,8 @@ defmodule FountainWeb.HelpLive.Show do
     end
   end
 
+  # sobelow_skip ["Traversal.FileModule"] — slug is allowlisted against
+  # Fountain.Help.topics() in handle_params before this is called.
   defp load_topic(slug) do
     path = Path.join([:code.priv_dir(:fountain) |> to_string(), "help", slug <> ".md"])
 

--- a/apps/fountain/test/fountain/sobelow_gate_test.exs
+++ b/apps/fountain/test/fountain/sobelow_gate_test.exs
@@ -1,0 +1,29 @@
+defmodule Fountain.SobelowGateTest do
+  use ExUnit.Case, async: true
+
+  # Regression test for #414: the sobelow gate ran with exit: "high", but
+  # sobelow rates non-controller raw/1 (this repo's entire XSS surface) as
+  # :low and the interpolated-variable case as :medium — so the gate could
+  # not fail on the exact class it exists for. #311 fixed the scan's
+  # working directory and never revisited the threshold.
+  #
+  # The gate's teeth were demonstrated when this landed: with any one
+  # sobelow_skip marker removed, `mix sobelow --config` exits 1.
+  test "the sobelow config fails on low-confidence findings and honours named skips" do
+    {config, _} = Code.eval_file(".sobelow-conf")
+
+    assert config[:exit] == "low",
+           ".sobelow-conf exit threshold was raised above \"low\" — sobelow rates " <>
+             "non-controller raw/1 XSS as :low, so anything higher makes the gate " <>
+             "unable to fail on this repo's XSS class (#414)"
+
+    assert config[:skip] == true,
+           ".sobelow-conf skip: true is what makes the per-site sobelow_skip " <>
+             "markers (the named-exception list) work; without it every accepted " <>
+             "finding fails the build"
+
+    assert config[:ignore] == [] and config[:ignore_files] == [],
+           "blanket ignores defeat the named-exception discipline — accept a " <>
+             "finding with a justified sobelow_skip marker at the call site instead"
+  end
+end


### PR DESCRIPTION
Closes #414 (P1, audit-2026-08-03 #416). The smaller findings are filed as follow-up #435.

## 1. The sobelow gate can now fail on this repo's XSS class

`exit: "high"` → `exit: "low"` + `skip: true`, with a **justified `sobelow_skip` marker on each of the 11 findings** that surface at the new threshold — each site reviewed individually before excepting (bound-parameter SQL in the recursive-CTE queries, help slugs allowlisted against compile-time `Fountain.Help.topics()`, fixed priv-dir reads, upload-validated avatar/turn-image media types with nosniff+sandbox CSP, Phoenix-managed upload tempfiles). Evidence the gate works, per the issue's own standard: with any one marker removed, `mix sobelow --config` **exits 1**; with them, 0. `sobelow_gate_test.exs` pins the threshold, `skip: true`, and empty blanket-ignore lists.

## 2. Manifests validate before Flux can see them

New `validate` job gating `publish` in publish-manifests.yml: `kubectl kustomize` + `kubeconform -strict` (default schemas + the datree CRDs catalog, so the PrometheusRule, CNPG cluster, ServiceMonitor and InfisicalSecret are schema-checked rather than skipped) over both `k8s/` and `deploy/k8s/`, then `promtool check rules` on both PrometheusRules (extracted from `spec.groups`).

Verified locally with the exact commands: current manifests pass (21+4 resources valid, 17+9 rules OK), an injected unknown field (`replicaas`) fails kubeconform, and a broken PromQL expression fails promtool.

## 3. A cancelled run can no longer strand a commit un-built

- `ci.yml`: `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — main runs queue instead of cancelling.
- `build.yml`: the image-affecting filter now diffs against the **newest first-parent ancestor whose image exists in the registry** (same ancestor walk publish-manifests already uses; `fetch-depth: 0`), instead of `HEAD^` — so even if a main run is ever lost, the next commit's diff covers the gap. No built ancestor in 50 commits → build unconditionally.

Note for review: the workflow changes only take effect on main after merge; the first post-merge manifest push exercises the validate job for real.

`mix precommit` green (1,787 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)