### PR TITLE
testing: reject the Subscription.create arity the code actually calls

### DIFF
--- a/apps/fountain/test/fountain/trial_expiry_test.exs
+++ b/apps/fountain/test/fountain/trial_expiry_test.exs
@@ -169,7 +169,7 @@ defmodule Fountain.TrialExpiryTest do
       {:ok, user} = user |> User.billing_changeset(%{trial_ends_at: ago(1)}) |> Repo.update()
 
       stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_late"}} end)
-      reject(&Stripe.Subscription.create/1)
+      reject(&Stripe.Subscription.create/2)
 
       assert {:ok, user} = Billing.create_stripe_customer(user)
       assert {:ok, updated} = Billing.start_trial_subscription(user)
@@ -233,7 +233,7 @@ defmodule Fountain.TrialExpiryTest do
       user = insert_verified_user()
 
       stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_selfhost"}} end)
-      reject(&Stripe.Subscription.create/1)
+      reject(&Stripe.Subscription.create/2)
 
       assert {:ok, user} = Billing.create_stripe_customer(user)
       assert {:ok, updated} = Billing.start_trial_subscription(user)
@@ -246,7 +246,7 @@ defmodule Fountain.TrialExpiryTest do
       # would be wrong, so starting the trial is a separate call.
       user = insert_verified_user()
       stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_checkout"}} end)
-      reject(&Stripe.Subscription.create/1)
+      reject(&Stripe.Subscription.create/2)
 
       assert {:ok, _} = Billing.create_stripe_customer(user)
     end


### PR DESCRIPTION
One-line semantic-merge fix: #429 (written pre-#433) rejects `create/1`, but since #433 the code calls `create/2` — making the reject vacuous, the exact class #406 exists to prevent. No behavior change; the guarded path makes no create call either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)