### PR TITLE
ops: make untracked-sprites a gauge, alert on cost signals, subscribe the orphan events (#405)

### DIFF
--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -138,10 +138,33 @@ defmodule FountainWeb.Telemetry do
         measurement: :expired,
         description: "Sandbox rows expired by SandboxReaper runs"
       ),
-      sum("fountain.reaper.untracked.count",
+      # Untracked is a LEVEL, not a delta: every reaper run re-measures the
+      # full set of sprites alive at sprites.dev with no sandbox row. As a
+      # `sum` it accumulated each hourly observation — a steady 102 leaked
+      # sprites read as 2,448 after a day and climbed forever (#405). As a
+      # `last_value` the exported gauge is the number of sprites currently
+      # leaking money, and it falls when they are cleaned up.
+      # released/expired above stay `sum`: those are per-run deltas.
+      last_value("fountain.reaper.untracked.count",
         event_name: [:fountain, :reaper, :untracked],
         measurement: :count,
-        description: "Untracked sprites found running with no live sandbox row"
+        description: "Untracked sprites currently running with no live sandbox row"
+      ),
+
+      # ── Cost signals (#405) ───────────────────────────────────────────────
+      # Both events fired into nothing before this: the provision watchdog
+      # (#329) declaring a provision wedged — which per #394 may also leak a
+      # sprite — and the durable-output budget (#331) engaging. The emitters
+      # attach conversation_id as metadata; it must never become a tag, or
+      # every conversation mints its own time series.
+      counter("fountain.provision.deadline_exceeded.count",
+        event_name: [:fountain, :provision, :deadline_exceeded],
+        description:
+          "Provisions force-failed by the watchdog deadline; each may leak a sprite (#394)"
+      ),
+      counter("fountain.log_output.capped.count",
+        event_name: [:fountain, :log_output, :capped],
+        description: "Conversations whose durable output hit the byte budget and was dropped"
       ),
 
       # ── Lifecycle funnel (#282) ───────────────────────────────────────────

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -81,6 +81,28 @@ defmodule FountainWeb.MetricsTest do
       assert [:fountain, :fresh_provision, :stop, :duration] in names
     end
 
+    test "reaper untracked is a last_value; released/expired stay sums (#405)" do
+      # Untracked is a LEVEL — the current count of leaked sprites, re-measured
+      # every reaper run. Declared as a `sum` it accumulated each hourly
+      # observation: a steady 102 read as 2,448 after a day, uninterpretable
+      # by any dashboard or alert.
+      by_name = Map.new(AppTelemetry.prometheus_metrics(), &{&1.name, &1})
+
+      untracked = by_name[[:fountain, :reaper, :untracked, :count]]
+      assert untracked, "fountain.reaper.untracked.count is no longer declared"
+
+      assert untracked.__struct__ == Telemetry.Metrics.LastValue,
+             "untracked is a level, not a delta; as #{inspect(untracked.__struct__)} " <>
+               "it accumulates forever instead of tracking the current leak count"
+
+      # released/expired are per-run deltas — those are correct as sums.
+      for measurement <- [:released, :expired] do
+        metric = by_name[[:fountain, :reaper, :run, measurement]]
+        assert metric, "fountain.reaper.run.#{measurement} is no longer declared"
+        assert metric.__struct__ == Telemetry.Metrics.Sum
+      end
+    end
+
     test "every subscribed fountain event has a live producer" do
       # The class of bug behind #310: metrics subscribed to event names that
       # nothing emits, passing every name-list assertion while the scrape
@@ -95,6 +117,10 @@ defmodule FountainWeb.MetricsTest do
         [:fountain, :sandbox, :reclaimed],
         [:fountain, :reaper, :run],
         [:fountain, :reaper, :untracked],
+        # ConversationServer: provision watchdog (#329) and durable-output
+        # budget (#331) — the two cost signals #405 gave subscribers
+        [:fountain, :provision, :deadline_exceeded],
+        [:fountain, :log_output, :capped],
         # Fountain.OpsGauges.emit_telemetry/0 (#321) — exercised directly by
         # Fountain.OpsGaugesTest since the poller is off in test
         [:fountain, :conversations],
@@ -160,6 +186,7 @@ defmodule FountainWeb.MetricsTest do
 
     test "ops gauges and Oban events land in the scrape (#321)" do
       :telemetry.execute([:fountain, :conversations], %{count: 3}, %{status: "idle"})
+
       :telemetry.execute([:fountain, :oban_queue], %{depth: 2}, %{
         queue: "maintenance",
         state: "available"
@@ -194,6 +221,63 @@ defmodule FountainWeb.MetricsTest do
                ~r/fountain_oban_job_exception_count\{[^}]*worker="Fountain.Workers.SandboxReaper"[^}]*\}/,
                body
              )
+    end
+
+    test "untracked scrapes as a gauge that falls when the level drops (#405)" do
+      # The sum-vs-level bug: as a `sum`, 102 followed by 3 scrapes as 105 and
+      # climbs forever; as a `last_value` it scrapes as the current level.
+      # Values are distinctive so a concurrent reaper test (which emits 2)
+      # is distinguishable in a failure message.
+      :telemetry.execute([:fountain, :reaper, :untracked], %{count: 102}, %{})
+      Process.sleep(50)
+      {200, body} = scrape()
+
+      assert body =~ ~r/^fountain_reaper_untracked_count 102$/m
+      assert body =~ ~r/^# TYPE fountain_reaper_untracked_count gauge$/m
+
+      :telemetry.execute([:fountain, :reaper, :untracked], %{count: 3}, %{})
+      Process.sleep(50)
+      {200, body} = scrape()
+
+      assert body =~ ~r/^fountain_reaper_untracked_count 3$/m
+      refute body =~ ~r/^fountain_reaper_untracked_count 105$/m
+    end
+
+    test "cost-signal counters increment on their events (#405)" do
+      deadline = ~r/^fountain_provision_deadline_exceeded_count (\d+)$/m
+      capped = ~r/^fountain_log_output_capped_count (\d+)$/m
+
+      emit_both = fn ->
+        # Measurements/metadata mirror the emitters in conversation_server.ex.
+        :telemetry.execute([:fountain, :provision, :deadline_exceeded], %{count: 1}, %{
+          conversation_id: Ecto.UUID.generate()
+        })
+
+        :telemetry.execute([:fountain, :log_output, :capped], %{count: 1}, %{
+          conversation_id: Ecto.UUID.generate()
+        })
+      end
+
+      emit_both.()
+      Process.sleep(50)
+      {200, body} = scrape()
+
+      assert [_, deadline_before] = Regex.run(deadline, body)
+      assert [_, capped_before] = Regex.run(capped, body)
+
+      emit_both.()
+      Process.sleep(50)
+      {200, body} = scrape()
+
+      assert [_, deadline_after] = Regex.run(deadline, body)
+      assert [_, capped_after] = Regex.run(capped, body)
+
+      assert String.to_integer(deadline_after) == String.to_integer(deadline_before) + 1
+      assert String.to_integer(capped_after) == String.to_integer(capped_before) + 1
+
+      # conversation_id is metadata, never a label — one series per
+      # conversation would eat Prometheus.
+      refute body =~ "conversation_id="
     end
 
     test "route tags are the matched pattern, not the raw path", %{conn: conn} do

--- a/k8s/prometheusrule.yaml
+++ b/k8s/prometheusrule.yaml
@@ -316,6 +316,124 @@ spec:
               SPRITES_TOKEN is invalid or rate-limited, the Sprites API is
               unhealthy, or tenants are hitting the concurrency cap.
 
+        - alert: FountainProvisionDeadlineExceeded
+          # The provision watchdog (#329) declared a provision wedged and
+          # force-failed it. Per #394 the accompanying destroy is best-effort,
+          # so each firing may also leak a sprite that keeps billing — this is
+          # a cost signal as much as a UX one. Absolute count, not a rate:
+          # the event is rare by design and any occurrence is worth a look.
+          expr: |
+            sum(increase(fountain_provision_deadline_exceeded_count{namespace="fountain"}[1h])) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: "A Fountain provision hit the watchdog deadline"
+            description: |
+              {{ $value }} provision(s) in the last hour ran past the watchdog
+              deadline and were force-failed. Each one may have leaked a
+              sprite (#394) — check whether the reaper's untracked count rose
+              on its next run, and why the provision wedged:
+              kubectl logs -n fountain deploy/fountain | grep "provisioning exceeded"
+
+        - alert: FountainSandboxBudgetExceeded
+          # Platform-wide concurrency ceiling (#405). Every tenant's sprites
+          # bill to the single platform SPRITES_TOKEN and the only enforced
+          # cap is per-tenant (default 5), so total concurrent spend is
+          # otherwise `users x 5` with no ceiling. The 50 here is the initial
+          # platform budget — an operator knob, not a law: raise it
+          # deliberately when paying for more concurrency is intended. The
+          # durable fix is a global reservation check in
+          # Quotas.with_sandbox_reservation/3; until that exists this alert
+          # is the only platform-level ceiling.
+          expr: |
+            sum(fountain_sandboxes_count{namespace="fountain", status=~"pending|starting|ready"}) > 50
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain sandbox concurrency is above the platform budget"
+            description: |
+              {{ $value }} sandboxes are pending/starting/ready against a
+              budget of 50, all billing to the one platform SPRITES_TOKEN.
+              Find who is driving it:
+              kubectl exec -n fountain fountain-pg-1 -c postgres -- \
+                psql -U postgres fountain -c "select user_id, count(*) from sandboxes where status in ('pending','starting','ready') group by 1 order by 2 desc limit 10"
+
+        - alert: FountainConversationsAboveBudget
+          # Companion to the sandbox budget above, on the conversation gauge
+          # (#321): a pending/running conversation implies a live sprite, so
+          # in steady state the two track each other. This one still fires
+          # when sandbox rows are wrong — the exact drift SandboxReaper
+          # measures — and shares the same 50 operator knob.
+          expr: |
+            sum(fountain_conversations_count{namespace="fountain", status=~"pending|running"}) > 50
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain has more live conversations than the platform budget"
+            description: |
+              {{ $value }} conversations are pending/running against a budget
+              of 50. If FountainSandboxBudgetExceeded is not also firing, the
+              sandbox rows and reality have diverged — check the reaper log
+              line for released/expired/untracked counts.
+
+    # ── Sprite reaper (#405) ──────────────────────────────────────────────
+    #
+    # SandboxReaper reconciles the sandboxes table against sprites.dev
+    # hourly (crontab :07). Its third pass counts sprites running with no
+    # sandbox row and deliberately never destroys them — so its entire
+    # output is a gauge someone must be looking at, plus these alerts.
+    - name: fountain-reaper
+      interval: 60s
+      rules:
+        - alert: FountainUntrackedSprites
+          # fountain_reaper_untracked_count is the LEVEL of sprites alive at
+          # sprites.dev with no live sandbox row, re-measured every run.
+          # Sustained non-zero is leaked money, not an outage — hence
+          # warning, not critical. 2h means at least two consecutive hourly
+          # runs both saw leaks, which filters the legitimate transients the
+          # reaper moduledoc describes (a sprite created seconds before the
+          # sweep, a developer using the shared token).
+          expr: fountain_reaper_untracked_count{namespace="fountain"} > 0
+          for: 2h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Sprites are running with no sandbox row (leaked spend)"
+            description: |
+              {{ $value }} sprite(s) have been running at sprites.dev with no
+              live sandbox row for over 2h, billing the platform
+              SPRITES_TOKEN. The reaper deliberately never destroys these —
+              absence of a row is not proof of a leak — so a human has to
+              look at the list and clean up. The run log includes a sample of
+              the sprite names:
+              kubectl logs -n fountain deploy/fountain | grep "no sandbox row"
+
+        - alert: FountainReaperSilent
+          # The wedged-reaper canary. fountain_reaper_run_released is emitted
+          # at the end of every hourly run, so the series (re)appears within
+          # about an hour of pod start; absent() for 3h means no run has
+          # completed since boot — crontab dropped, maintenance queue
+          # misconfigured, or every run crashing before the emit. A reaper
+          # that runs and raises is caught by FountainObanJobsRaising /
+          # FountainObanJobsDiscarded instead. An increase()-based staleness
+          # check cannot work here: released/expired are legitimately zero
+          # for weeks at a time, so the counter is flat when healthy.
+          expr: absent(fountain_reaper_run_released{namespace="fountain"})
+          for: 3h
+          labels:
+            severity: warning
+          annotations:
+            summary: "SandboxReaper has not completed a run since boot"
+            description: |
+              No fountain_reaper_run_released series exists, meaning no
+              SandboxReaper run has finished on this pod (it runs hourly at
+              :07). Stuck rows are holding tenant quota and dead sprites are
+              not being destroyed. Check the maintenance queue:
+              kubectl exec -n fountain fountain-pg-1 -c postgres -- \
+                psql -U postgres fountain -c "select id, state, attempt, errors[array_upper(errors,1)] from oban_jobs where worker like '%SandboxReaper%' order by id desc limit 5"
+
     # ── Oban background jobs (#321) ───────────────────────────────────────
     #
     # Oban catches job exceptions internally and reports them only via


### PR DESCRIPTION
Closes #405 — the three cost-visibility gaps: an unreadable leak metric, no platform-wide concurrency ceiling, and two cost signals with no subscriber.

## 1. `fountain.reaper.untracked.count`: sum → last_value

The reaper's third pass re-measures the full **level** of sprites alive at sprites.dev with no sandbox row on every hourly run. Declared as `sum`, each observation accumulated — a steady 102 leaked sprites read as 2,448 after a day and climbed forever. It is now a `last_value`, scraping as a gauge that equals the current leak count and falls when leaks are cleaned up. `released`/`expired` stay `sum` — those are per-run deltas.

New alerts in `k8s/prometheusrule.yaml` (new `fountain-reaper` group):

- **FountainUntrackedSprites** — `fountain_reaper_untracked_count{namespace="fountain"} > 0` `for: 2h`, severity warning. Leaked money, not an emergency page; 2h means two consecutive hourly runs both saw leaks, filtering the transients the reaper moduledoc describes.
- **FountainReaperSilent** — `absent(fountain_reaper_run_released{namespace="fountain"})` `for: 3h`, mirroring the existing `absent()` style (FountainBackupNeverSucceeded). This catches a reaper that never completes a run after boot. An `increase()`-based staleness check is impossible here — `released`/`expired` are legitimately zero for weeks, so the series is flat when healthy; a reaper that runs and raises is already covered by FountainObanJobsRaising/Discarded.

## 2. Platform-wide sandbox ceiling (the cheap version)

- **FountainSandboxBudgetExceeded** — `sum(fountain_sandboxes_count{namespace="fountain", status=~"pending|starting|ready"}) > 50` `for: 10m`. The 50 is documented in the rule file as an operator knob — the initial platform budget, to be raised deliberately. Includes a psql one-liner to find the driving tenant.
- **FountainConversationsAboveBudget** — the companion on the other #321 gauge, `sum(fountain_conversations_count{namespace="fountain", status=~"pending|running"}) > 50` `for: 10m`; it still fires when sandbox rows have diverged from reality (the exact drift the reaper measures). Both #321 gauges are now consumed by alerts instead of existing only in the emitter and one test.

**Follow-up (not built here, per the issue):** the durable fix is a global reservation check in `Quotas.with_sandbox_reservation/3` — it already takes a per-user advisory lock, and a second fixed-key lock would serialize a platform-wide count. Until then these alerts are the only platform-level ceiling.

## 3. Subscribers for the two orphan events

`counter("fountain.provision.deadline_exceeded.count")` and `counter("fountain.log_output.capped.count")` now subscribe to the events at `conversation_server.ex:250` and `:1536` (event names and `%{count: 1}` measurements verified against the emitters; `conversation_id` stays metadata, never a tag). New alert:

- **FountainProvisionDeadlineExceeded** — `sum(increase(fountain_provision_deadline_exceeded_count{namespace="fountain"}[1h])) > 0`, warning. Each firing may leak a sprite per #394, so the runbook says to check the reaper's untracked count on its next run.

## Tests

`metrics_test.exs` additions:

- untracked is pinned as `Telemetry.Metrics.LastValue` (with `released`/`expired` pinned as `Sum`);
- an end-to-end scrape test emits 102 then 3 and asserts the exported gauge **falls** to 3 (as a sum it read 105 and the TYPE line said `counter`);
- both new counters are asserted to increment by exactly 1 on synthesized events, and the two events were added to the "every subscribed event has a live producer" pin list.

**Revert verification:** with the telemetry.ex change stashed, all three new tests fail (`untracked` is a Sum; scrape shows `TYPE ... counter` with the accumulating value; neither counter series exists in the scrape). With the fix restored, 14/14 pass. Full `mix precommit` green (1780 tests, 0 failures).

**Rule validation:** `promtool check rules` on the extracted `spec` — `SUCCESS: 22 rules found` (promtool was not on the machine; installed via `brew install prometheus` for this check). YAML also validated with `python3 yaml.safe_load`.

Note: `deploy/k8s/prometheusrule.yaml` (the self-host baseline) was deliberately not extended — the budget number is a hosted-operator knob; porting genericized versions of these alerts there can ride along with the next self-host ops pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
