### PR TITLE
api: SSE server-death terminal event, replay disconnect, stuck running status, #197 schema remnant (#415)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -966,7 +966,7 @@ defmodule Fountain.Conversations do
      `runtime_session_id`.
 
   Returns `{:error, :gone}` if the conversation is in a terminal status
-  (`terminated`, `failed`, `completed`) — those don't auto-resume.
+  (`terminated`, `failed`) — those don't auto-resume.
   """
   def wake_conversation(conv_id, initial_prompt \\ nil) do
     with %Conversation{} = conv <- _unsafe_get_conversation(conv_id) || {:error, :not_found},

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1548,6 +1548,16 @@ defmodule Fountain.Conversations.ConversationServer do
             reason: inspect(reason)
           })
 
+          # The conversation was set to "running" just before the spawn
+          # attempt; without this it stays "running" in the API and UI until
+          # some later turn completes, even though nothing is executing. The
+          # :exit and :interrupt handlers both do the same reset.
+          failed_conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+
+          if failed_conv.status == "running" do
+            {:ok, _} = Conversations.update_conversation(failed_conv, %{status: "idle"})
+          end
+
           # Spawn never started; close the span we just opened so it
           # doesn't leak.
           OpenTelemetry.Tracer.set_status(

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -22,8 +22,8 @@ defmodule Fountain.Conversations.Lifecycle do
   ## Why reclaiming is safe
 
   Only the *sandbox* is torn down. The conversation row stays `idle`, which
-  keeps it resumable — `assert_resumable/1` only refuses `terminated`, `failed`
-  and `completed`. The next prompt goes through `wake_conversation/2`, which
+  keeps it resumable — `assert_resumable/1` only refuses `terminated` and
+  `failed`. The next prompt goes through `wake_conversation/2`, which
   sees a sandbox that is no longer `ready`, provisions a fresh one, and passes
   the persisted `runtime_session_id` so the runtime resumes the same chat.
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -358,6 +358,22 @@ defmodule FountainWeb.ConversationController do
           Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{id}")
         end
 
+        # A ConversationServer that dies without publishing a terminal
+        # stage (a crash, a Horde rebalance, a deploy) would otherwise
+        # leave this stream heartbeating forever with no data and no
+        # reason to reconnect. Monitoring is best-effort: no server just
+        # means an idle/finished conversation being drained from history.
+        # The ref is matched exactly in sse_loop — this process holds other
+        # monitors (DB ownership among them) whose :DOWN messages must not
+        # end the stream.
+        monitor_ref =
+          if wait? do
+            case ConversationServer.whereis(id) do
+              pid when is_pid(pid) -> Process.monitor(pid)
+              _ -> nil
+            end
+          end
+
         conn =
           conn
           |> put_resp_header("content-type", "text/event-stream")
@@ -366,11 +382,11 @@ defmodule FountainWeb.ConversationController do
           |> send_chunked(200)
 
         # Replay buffered events the client missed.
-        {conn, last_id} = replay(conn, id, last_event_id, streams)
+        {status, conn, last_id} = replay(conn, id, last_event_id, streams)
 
-        if wait? do
+        if wait? and status == :ok do
           Process.send_after(self(), :heartbeat, heartbeat_ms())
-          sse_loop(conn, last_id, streams)
+          sse_loop(conn, last_id, streams, monitor_ref)
         else
           # `?wait=false` → close immediately after replay. Useful when
           # the caller already knows the conversation is finished and
@@ -471,13 +487,18 @@ defmodule FountainWeb.ConversationController do
     end
   end
 
+  # Returns `{:ok, conn, last_id}`, or `{:closed, conn, last_id}` when the
+  # client went away mid-replay — a routine disconnect (Ctrl-C on a curl, a
+  # closed tab, an EventSource reconnect against a long backlog), not an
+  # error. This used to `throw` the chunk error with no catch anywhere in
+  # the module, producing a crash report and a Sentry event per disconnect.
   defp replay(conn, conv_id, after_id, streams) do
     conv_id
     |> Conversations._unsafe_list_log_events(after_id, streams: streams)
-    |> Enum.reduce({conn, after_id}, fn ev, {acc_conn, _} ->
+    |> Enum.reduce_while({:ok, conn, after_id}, fn ev, {:ok, acc_conn, last_id} ->
       case write_event(acc_conn, ev) do
-        {:ok, c} -> {c, ev.id}
-        {:error, _} = e -> throw(e)
+        {:ok, c} -> {:cont, {:ok, c, ev.id}}
+        {:error, _} -> {:halt, {:closed, acc_conn, last_id}}
       end
     end)
   end
@@ -494,36 +515,78 @@ defmodule FountainWeb.ConversationController do
 
   defp event_in_streams?(_ev, _streams), do: false
 
-  defp sse_loop(conn, last_id, streams) do
+  defp sse_loop(conn, last_id, streams, monitor_ref) do
     receive do
       {:log_event, %LogEvent{id: ev_id} = ev} when ev_id > last_id ->
         cond do
           not event_in_streams?(ev, streams) ->
-            sse_loop(conn, ev_id, streams)
+            sse_loop(conn, ev_id, streams, monitor_ref)
 
           true ->
             case write_event(conn, ev) do
-              {:ok, conn} -> sse_loop(conn, ev_id, streams)
+              {:ok, conn} -> sse_loop(conn, ev_id, streams, monitor_ref)
               {:error, _} -> conn
             end
         end
 
       {:log_event, _stale} ->
-        sse_loop(conn, last_id, streams)
+        sse_loop(conn, last_id, streams, monitor_ref)
 
       :heartbeat ->
         case Plug.Conn.chunk(conn, ": heartbeat\n\n") do
           {:ok, conn} ->
             Process.send_after(self(), :heartbeat, heartbeat_ms())
-            sse_loop(conn, last_id, streams)
+            sse_loop(conn, last_id, streams, monitor_ref)
 
           {:error, _} ->
             conn
         end
+
+      {:DOWN, ^monitor_ref, :process, _pid, reason} when is_reference(monitor_ref) ->
+        # The conversation server died without publishing a terminal stage.
+        # Say so and close, so the client reconnects (and, if the server was
+        # rehydrated elsewhere, resumes) instead of receiving heartbeats
+        # forever on a topic nothing will publish to again.
+        write_server_down_event(conn, reason)
     after
       idle_timeout_ms() ->
         # Long quiet — exit cleanly so the client reconnects.
         conn
+    end
+  end
+
+  # Synthetic (not persisted, so no SSE id — it must not disturb
+  # Last-Event-ID resume) stage event telling the client why the stream is
+  # closing. Same payload shape as write_event/2. A clean shutdown or Horde
+  # handoff is the stage reaching its end ("done"); anything else is a crash
+  # ("failed") — the stage vocabulary clients already switch on.
+  defp write_server_down_event(conn, reason) do
+    state =
+      case reason do
+        :normal -> "done"
+        :shutdown -> "done"
+        {:shutdown, _} -> "done"
+        _ -> "failed"
+      end
+
+    payload =
+      Jason.encode!(%{
+        kind: "stage",
+        stream: nil,
+        data:
+          Jason.encode!(%{
+            reason: inspect(reason),
+            message: "conversation server exited — reconnect to resume streaming"
+          }),
+        stage: "server",
+        state: state,
+        turn_id: nil,
+        ts: DateTime.utc_now()
+      })
+
+    case Plug.Conn.chunk(conn, "event: stage\ndata: #{payload}\n\n") do
+      {:ok, conn} -> conn
+      {:error, _} -> conn
     end
   end
 

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -1445,6 +1445,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   defp stage_icon("clone"), do: "&#129319;"
   defp stage_icon("turn"), do: "&#128172;"
   defp stage_icon("reattach"), do: "&#128268;"
+  defp stage_icon("sandbox"), do: "&#128164;"
   defp stage_icon("terminate"), do: "&#128721;"
   defp stage_icon(_), do: "&bull;"
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -44,9 +44,11 @@ defmodule FountainWeb.Schemas do
         runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
         status: %Schema{
           type: :string,
-          enum: ~w(pending running idle completed failed terminated)
+          enum: ~w(pending running idle failed terminated)
         },
         runtime_session_id: %Schema{type: :string, nullable: true},
+        source: %Schema{type: :string, enum: ~w(ui api agent)},
+        parent_conversation_id: %Schema{type: :string, format: :uuid, nullable: true},
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -416,6 +416,23 @@ defmodule Fountain.Conversations.ConversationServerTest do
       GenServer.stop(pid)
     end
 
+    test "a spawn that never starts returns the conversation to idle", %{conv: conv} do
+      # The conversation is set to "running" just before the spawn attempt.
+      # Before this reset, a failed spawn marked the turn failed but left the
+      # conversation reporting "running" in the API and UI indefinitely.
+      stub_happy_sprite()
+      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts -> {:error, :econnrefused} end)
+
+      {pid, _ref, :alive} = start_server(conv, initial_prompt: "hello")
+      _ = :sys.get_state(pid)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "failed"
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      GenServer.stop(pid)
+    end
+
     test "stdout is persisted as log events", %{conv: conv} do
       {pid, ref} = start_with_turn(conv)
 

--- a/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
@@ -243,4 +243,105 @@ defmodule FountainWeb.SseStreamTest do
       Task.shutdown(task, :brutal_kill)
     end
   end
+
+  describe "conversation server death" do
+    # Before the stream monitored the server, every death that skipped the
+    # explicit :terminate_conv path — a crash, a Horde rebalance, a deploy —
+    # left the topic silent while the heartbeat kept the connection alive:
+    # the client received heartbeats forever with no data, no terminal event
+    # and no disconnect to trigger a reconnect.
+    defp fake_server(conv_id) do
+      test_pid = self()
+
+      pid =
+        spawn(fn ->
+          Horde.Registry.register(Fountain.ConversationRegistry, conv_id, nil)
+          send(test_pid, :registered)
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive :registered, 2_000
+      pid
+    end
+
+    test "a crashing server ends the stream with a synthetic failed stage", %{
+      raw_key: key,
+      conv: conv
+    } do
+      # Idle timeout far beyond the await below: only the :DOWN can close it.
+      fast_loop(60_000, 60_000)
+
+      server = fake_server(conv.id)
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+          stream(key, "/api/conversations/#{conv.id}/stream")
+        end)
+
+      # Give the loop time to subscribe and monitor before the kill.
+      Process.sleep(300)
+      Process.exit(server, :kill)
+
+      conn = Task.await(task, 5_000)
+
+      assert conn.status == 200
+      assert conn.resp_body =~ ~s("stage":"server")
+      assert conn.resp_body =~ ~s("state":"failed")
+    end
+
+    test "a clean shutdown reads as the server stage reaching done", %{
+      raw_key: key,
+      conv: conv
+    } do
+      fast_loop(60_000, 60_000)
+
+      server = fake_server(conv.id)
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+          stream(key, "/api/conversations/#{conv.id}/stream")
+        end)
+
+      Process.sleep(300)
+      Process.exit(server, :shutdown)
+
+      conn = Task.await(task, 5_000)
+
+      assert conn.resp_body =~ ~s("stage":"server")
+      assert conn.resp_body =~ ~s("state":"done")
+    end
+
+    test "a synthetic terminal event carries no SSE id, preserving resume", %{
+      raw_key: key,
+      conv: conv
+    } do
+      # Resuming from a synthetic id would skip real events; the reconnect
+      # must replay from the last PERSISTED event the client saw.
+      fast_loop(60_000, 60_000)
+
+      server = fake_server(conv.id)
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+          stream(key, "/api/conversations/#{conv.id}/stream")
+        end)
+
+      Process.sleep(300)
+      Process.exit(server, :kill)
+      conn = Task.await(task, 5_000)
+
+      [chunk] =
+        conn.resp_body
+        |> String.split("\n\n", trim: true)
+        |> Enum.filter(&(&1 =~ ~s("stage":"server")))
+
+      refute chunk =~ ~r/^id: /m
+    end
+  end
 end

--- a/apps/fountain/test/fountain_web/schemas_test.exs
+++ b/apps/fountain/test/fountain_web/schemas_test.exs
@@ -1,0 +1,35 @@
+defmodule FountainWeb.SchemasTest do
+  @moduledoc """
+  The published OpenAPI spec against what the code actually does.
+
+  #197 removed the unreachable `completed` status from the Conversation
+  schema, but the OpenAPI enum kept advertising it — so generated clients
+  handled a status the server cannot emit, and `source` /
+  `parent_conversation_id` were emitted but undocumented. These pin the
+  spec to the schema and the JSON view so the next drift fails a test
+  instead of an integration.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Fountain.Conversations.Conversation
+
+  defp conversation_schema, do: FountainWeb.Schemas.Conversation.schema()
+
+  test "the status enum matches the statuses the server can emit" do
+    assert conversation_schema().properties.status.enum == Conversation.statuses()
+  end
+
+  test "every field ConversationJSON emits is documented" do
+    emitted =
+      %Conversation{id: Ecto.UUID.generate()}
+      |> FountainWeb.ConversationJSON.data()
+      |> Map.keys()
+      |> MapSet.new()
+
+    documented = conversation_schema().properties |> Map.keys() |> MapSet.new()
+
+    missing = MapSet.difference(emitted, documented)
+    assert MapSet.size(missing) == 0, "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
+  end
+end

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -420,8 +420,33 @@ func handleStageEvent(data map[string]any) (bool, error) {
 		fmt.Fprintf(os.Stderr, "▸ provisioning failed — the sandbox never started\n")
 		return true, errProvisionFailed
 
+	case stage == "reattach" && state == "failed":
+		// The server stops after this (conversation_server.ex); no more
+		// events are coming. The conversation itself stays promptable —
+		// the next prompt auto-wakes a fresh sandbox.
+		fmt.Fprintf(os.Stderr, "▸ reattach failed — prompt again to provision a fresh sandbox\n")
+		return true, errReattachFailed
+
 	case stage == "terminate" && state == "done":
 		fmt.Fprintf(os.Stderr, "▸ conversation terminated\n")
+		return true, nil
+
+	case stage == "turn" && state == "interrupted":
+		// Deliberate `fountain conv interrupt` (possibly from another
+		// shell). Clean exit: without this case the stream sat out the
+		// full idle timeout waiting for a turn/done that never comes.
+		fmt.Fprintf(os.Stderr, "▸ turn interrupted\n")
+		return true, nil
+
+	case stage == "sandbox" && state == "done":
+		// The sandbox was reclaimed and the server stopped. An idle
+		// reclaim means no turn was running — a clean end. A max-lifetime
+		// reclaim can cut a running turn short, so it exits non-zero.
+		reason := innerDataString(data, "reason")
+		fmt.Fprintf(os.Stderr, "▸ sandbox reclaimed (%s) — the conversation stays resumable\n", reason)
+		if reason == "max_lifetime" {
+			return true, errSandboxExpired
+		}
 		return true, nil
 	}
 
@@ -430,18 +455,23 @@ func handleStageEvent(data map[string]any) (bool, error) {
 }
 
 // exitCodeFromStageDone digs `data.data.exit_code` out of a turn-done event.
-// The Elixir code looked up the same path; the inner `data` was JSON-encoded,
-// so we accept either a nested map or a JSON string.
 func exitCodeFromStageDone(data map[string]any) string {
+	return innerDataString(data, "exit_code")
+}
+
+// innerDataString digs `data.data.<key>` out of a stage event. The Elixir
+// code JSON-encodes the stage metadata into the inner `data`, so we accept
+// either a nested map or a JSON string.
+func innerDataString(data map[string]any, key string) string {
 	inner := data["data"]
 	if s, ok := inner.(string); ok {
 		var m map[string]any
 		if json.Unmarshal([]byte(s), &m) == nil {
-			return output.ToString(m["exit_code"])
+			return output.ToString(m[key])
 		}
 	}
 	if m, ok := inner.(map[string]any); ok {
-		return output.ToString(m["exit_code"])
+		return output.ToString(m[key])
 	}
 	return ""
 }

--- a/cli/internal/cmd/conv_test.go
+++ b/cli/internal/cmd/conv_test.go
@@ -75,6 +75,44 @@ func TestHandleStageEvent(t *testing.T) {
 			terminal: false,
 			wantErr:  nil,
 		},
+		{
+			// After `fountain conv interrupt` from another shell, the stream
+			// used to sit out the full idle timeout and exit 1.
+			name:     "turn interrupted is a clean terminal",
+			data:     map[string]any{"stage": "turn", "state": "interrupted", "data": "{}"},
+			terminal: true,
+			wantErr:  nil,
+		},
+		{
+			// The server stops after publishing this (conversation_server.ex),
+			// so nothing more is coming.
+			name:     "reattach failed is terminal and fails",
+			data:     map[string]any{"stage": "reattach", "state": "failed", "data": `{"reason":"gone"}`},
+			terminal: true,
+			wantErr:  errReattachFailed,
+		},
+		{
+			// The server falls back to cold provisioning after a failed
+			// checkpoint restore — the stream must keep going.
+			name:     "checkpoint restore failed is not terminal (cold provision follows)",
+			data:     map[string]any{"stage": "checkpoint_restore", "state": "failed", "data": "{}"},
+			terminal: false,
+			wantErr:  nil,
+		},
+		{
+			// Idle reclaim means no turn was running: a clean end.
+			name:     "sandbox reclaimed for idleness is a clean terminal",
+			data:     map[string]any{"stage": "sandbox", "state": "done", "data": `{"event":"reclaimed","reason":"idle"}`},
+			terminal: true,
+			wantErr:  nil,
+		},
+		{
+			// A max-lifetime reclaim can cut a running turn short.
+			name:     "sandbox reclaimed at max lifetime fails",
+			data:     map[string]any{"stage": "sandbox", "state": "done", "data": `{"event":"reclaimed","reason":"max_lifetime"}`},
+			terminal: true,
+			wantErr:  errSandboxExpired,
+		},
 	}
 
 	for _, tc := range cases {

--- a/cli/internal/cmd/stream.go
+++ b/cli/internal/cmd/stream.go
@@ -41,6 +41,8 @@ var errIdleTimeout = errors.New("no output received")
 var (
 	errTurnFailed      = errors.New("turn failed")
 	errProvisionFailed = errors.New("provisioning failed — the sandbox never started")
+	errReattachFailed  = errors.New("reattach failed — the sandbox was marked failed")
+	errSandboxExpired  = errors.New("sandbox hit its max lifetime")
 )
 
 // reconnectBackoff is a variable so tests do not have to sit through real


### PR DESCRIPTION
Fixes the four findings in #415, plus the related CLI/LiveView terminal-event gaps.

## 1. SSE clients learn the conversation server died
The stream action now monitors the ConversationServer (best-effort — no server just means history is being drained) and on `:DOWN` writes a synthetic `server` stage event (`done` for `:normal`/`:shutdown`, `failed` otherwise), then closes. The client reconnects — and if the server was rehydrated elsewhere, resumes — instead of heartbeating forever. The synthetic event deliberately carries no SSE id so `Last-Event-ID` resume still replays from the last persisted event; there's a test pinning that.

The `:DOWN` match is pinned to the monitor ref — the request process holds other monitors (DB ownership proxies among them) whose normal exits must not end the stream. First version of the test run caught exactly that.

## 2. Mid-replay disconnect no longer crashes
`replay/4` uses `reduce_while` and returns `{:closed, conn, last_id}` instead of `throw`ing the chunk error into a module with no catch. `?wait=true` skips the live loop when replay already found the socket closed. (No automated test for this one — the ConnTest adapter can't fail a chunk — but the throw is gone by construction.)

## 3. Spawn failure no longer leaves the conversation `running`
The `{:error, reason}` spawn branch now resets `running → idle`, same as the `:exit` and `:interrupt` handlers. Test drives a real server with a stubbed `Sprites.spawn` error.

## 4. #197 remnant + undocumented fields
`completed` dropped from the OpenAPI status enum; `source` and `parent_conversation_id` added. New `schemas_test.exs` pins the enum to `Conversation.statuses()` and asserts every field `ConversationJSON` emits is documented. Both docstrings still naming `completed` corrected.

## Related CLI/LiveView gaps (from the issue's 'Related' notes)
- `turn`/`interrupted` → clean terminal (was: sit out the 30-minute idle default, exit 1)
- `reattach`/`failed` → terminal, non-zero (the server stops after publishing it)
- `sandbox`/`done` → terminal; idle reclaim exits clean, `max_lifetime` exits non-zero since it can cut a running turn short
- `checkpoint_restore`/`failed` **stays non-terminal**, diverging from the issue's suggestion: the server falls back to cold provisioning after it (`conversation_server.ex`), so treating it terminal would abort a stream that's about to provision. Test documents this.
- LiveView `stage_icon("sandbox")` clause added.

Revert-verified: 6 Elixir failures + a Go build failure with the fixes stashed.

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)