### PR TITLE
security: avatar content-type allowlist, RemoteIp for LiveView audit, shared image decode, _unsafe_ sweep completion (#407)

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -110,22 +110,34 @@ defmodule Fountain.Agents do
 
   def delete_agent(%Agent{} = agent), do: Repo.delete(agent)
 
-  @doc "Upload or replace the avatar for an agent."
+  @doc """
+  Upload or replace the avatar for an agent.
+
+  The media type is validated against `Fountain.Images.valid_media_types/0`:
+  it is echoed back verbatim by the avatar endpoint, and LiveView's upload
+  `accept:` list does not constrain it — `accepted?/2` passes an entry whose
+  *filename extension* matches even when the declared MIME type does not, so
+  a crafted client can declare `text/html` with a `.png` name.
+  """
   def upload_avatar(%Agent{} = agent, data, media_type)
       when is_binary(data) and is_binary(media_type) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    if Fountain.Images.valid_media_type?(media_type) do
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    Repo.transaction(fn ->
-      Repo.insert!(
-        %AgentAvatar{agent_id: agent.id, data: data, inserted_at: now},
-        on_conflict: {:replace, [:data, :inserted_at]},
-        conflict_target: :agent_id
-      )
+      Repo.transaction(fn ->
+        Repo.insert!(
+          %AgentAvatar{agent_id: agent.id, data: data, inserted_at: now},
+          on_conflict: {:replace, [:data, :inserted_at]},
+          conflict_target: :agent_id
+        )
 
-      agent
-      |> Ecto.Changeset.change(%{avatar_media_type: media_type})
-      |> Repo.update!()
-    end)
+        agent
+        |> Ecto.Changeset.change(%{avatar_media_type: media_type})
+        |> Repo.update!()
+      end)
+    else
+      {:error, :invalid_media_type}
+    end
   end
 
   @doc "Remove the avatar for an agent."

--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -1158,7 +1158,7 @@ defmodule Fountain.Billing do
   on a conversation's critical path should use `record_usage/5`, which cannot
   fail the operation it is measuring.
 
-  Emitted from `Conversations.update_sandbox/2` and `Conversations.create_turn/1`
+  Emitted from `Conversations.update_sandbox/2` and `Conversations._unsafe_create_turn/1`
   rather than from `ConversationServer`, so every path that provisions, runs or
   tears down a sandbox is counted — including the wake path and the
   terminate-when-the-server-is-already-dead path.

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -514,7 +514,7 @@ defmodule Fountain.Conversations do
     )
   end
 
-  def insert_turn_images(_turn_id, []), do: {:ok, 0}
+  def _unsafe_insert_turn_images(_turn_id, []), do: {:ok, 0}
 
   @doc """
   Store a turn's images.
@@ -529,7 +529,7 @@ defmodule Fountain.Conversations do
   Returns `{:ok, count}` or `{:error, changeset}`. Both are handled by the
   caller; a rejected image must not take a turn down with it.
   """
-  def insert_turn_images(turn_id, images) do
+  def _unsafe_insert_turn_images(turn_id, images) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     images
@@ -555,7 +555,7 @@ defmodule Fountain.Conversations do
     Repo.get_by(TurnImage, turn_id: turn_id, position: position)
   end
 
-  def next_turn_number(conversation_id) do
+  def _unsafe_next_turn_number(conversation_id) do
     last =
       Repo.one(
         from t in Turn,
@@ -566,7 +566,7 @@ defmodule Fountain.Conversations do
     (last || 0) + 1
   end
 
-  def create_turn(attrs) do
+  def _unsafe_create_turn(attrs) do
     with {:ok, turn} <- %Turn{} |> Turn.changeset(attrs) |> Repo.insert() do
       record_turn_usage(turn)
       {:ok, turn}
@@ -589,30 +589,10 @@ defmodule Fountain.Conversations do
     end
   end
 
-  def update_turn(%Turn{} = turn, attrs) do
+  def _unsafe_update_turn(%Turn{} = turn, attrs) do
     turn
     |> Turn.changeset(attrs)
     |> Repo.update()
-  end
-
-  @doc """
-  Mark any `running` turns for the given conversation as `interrupted`.
-  Used during reattach: a BEAM restart orphaned whatever turn was in
-  flight, and we can't know its outcome — mark it so the user gets a
-  clear signal instead of a permanently-stuck status.
-  """
-  def mark_orphaned_turns_interrupted(conversation_id) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    {n, _} =
-      Repo.update_all(
-        from(t in Turn,
-          where: t.conversation_id == ^conversation_id and t.status == "running"
-        ),
-        set: [status: "interrupted", ended_at: now]
-      )
-
-    n
   end
 
   # ── log events ──────────────────────────────────────────────────────────────────────────
@@ -691,18 +671,6 @@ defmodule Fountain.Conversations do
     event
   end
 
-  @doc """
-  Stream persisted log events for a conversation, ordered by id.
-  Optionally start after a given event id (for SSE Last-Event-ID resume).
-  """
-  def stream_log_events(conversation_id, after_id \\ 0) do
-    from(e in LogEvent,
-      where: e.conversation_id == ^conversation_id and e.id > ^after_id,
-      order_by: [asc: e.id]
-    )
-    |> Repo.stream(max_rows: 100)
-  end
-
   def _unsafe_list_log_events(conversation_id, after_id \\ 0, opts \\ []) do
     base =
       from e in LogEvent,
@@ -748,7 +716,7 @@ defmodule Fountain.Conversations do
   Used by ConversationServer on reattach to know how many bytes of
   replayed output to skip before persisting fresh, post-disconnect data.
   """
-  def output_bytes_by_stream(conversation_id, turn_id) do
+  def _unsafe_output_bytes_by_stream(conversation_id, turn_id) do
     from(e in LogEvent,
       where:
         e.conversation_id == ^conversation_id and

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -703,7 +703,7 @@ defmodule Fountain.Conversations.ConversationServer do
         # Count the bytes we already persisted for this turn so the
         # stdout/stderr handlers can drop the replayed prefix.
         replay_skip =
-          Conversations.output_bytes_by_stream(state.conversation_id, running_turn.id)
+          Conversations._unsafe_output_bytes_by_stream(state.conversation_id, running_turn.id)
 
         publish_stage(state.conversation_id, "reattach", "done", %{
           outcome: "session_attached",
@@ -733,7 +733,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp mark_orphan(state, running_turn, why) do
     {:ok, _} =
-      Conversations.update_turn(running_turn, %{
+      Conversations._unsafe_update_turn(running_turn, %{
         status: "interrupted",
         ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
       })
@@ -910,7 +910,7 @@ defmodule Fountain.Conversations.ConversationServer do
     end
 
     {:ok, _turn} =
-      Conversations.update_turn(state.current_turn, %{
+      Conversations._unsafe_update_turn(state.current_turn, %{
         status: "interrupted",
         ended_at: now()
       })
@@ -1040,7 +1040,7 @@ defmodule Fountain.Conversations.ConversationServer do
     turn = state.current_turn
 
     {:ok, turn} =
-      Conversations.update_turn(turn, %{
+      Conversations._unsafe_update_turn(turn, %{
         status: if(code == 0, do: "completed", else: "failed"),
         exit_code: code,
         ended_at: now()
@@ -1089,7 +1089,7 @@ defmodule Fountain.Conversations.ConversationServer do
     Logger.error("sprite command error mid-turn: #{inspect(reason)} — failing the turn")
 
     {:ok, turn} =
-      Conversations.update_turn(state.current_turn, %{
+      Conversations._unsafe_update_turn(state.current_turn, %{
         status: "failed",
         ended_at: now()
       })
@@ -1374,10 +1374,10 @@ defmodule Fountain.Conversations.ConversationServer do
   defp kick_turn(state, prompt, agent, images) do
     state = touch_activity(state)
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    turn_number = Conversations.next_turn_number(state.conversation_id)
+    turn_number = Conversations._unsafe_next_turn_number(state.conversation_id)
 
     {:ok, turn} =
-      Conversations.create_turn(%{
+      Conversations._unsafe_create_turn(%{
         conversation_id: conv.id,
         turn_number: turn_number,
         prompt: prompt,
@@ -1388,7 +1388,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # Store images. A rejected image must not take the turn down with it: this
     # used to hard-match {:ok, _}, which is why validation could not be added to
     # the insert path without crashing the server mid-turn.
-    case Conversations.insert_turn_images(turn.id, images) do
+    case Conversations._unsafe_insert_turn_images(turn.id, images) do
       {:ok, _count} ->
         :ok
 
@@ -1538,7 +1538,7 @@ defmodule Fountain.Conversations.ConversationServer do
           Logger.error("spawn failed: #{inspect(reason)}")
 
           {:ok, _} =
-            Conversations.update_turn(turn, %{
+            Conversations._unsafe_update_turn(turn, %{
               status: "failed",
               ended_at: now()
             })

--- a/apps/fountain/lib/fountain/conversations/turn_image.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_image.ex
@@ -7,16 +7,15 @@ defmodule Fountain.Conversations.TurnImage do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
-  @valid_media_types ~w(image/png image/jpeg image/gif image/webp)
-
   @doc """
   Media types this endpoint is willing to store or serve.
 
   Read at serve time as well as in `changeset/2`: rows reach this table via
-  `Conversations.insert_turn_images/2`, which uses `Repo.insert_all` against a
-  raw table name and therefore never runs the changeset.
+  `Conversations._unsafe_insert_turn_images/2`, which uses `Repo.insert_all` against a
+  raw table name and therefore never runs the changeset. The list itself
+  lives in `Fountain.Images` so the avatar path validates the same one.
   """
-  def valid_media_types, do: @valid_media_types
+  def valid_media_types, do: Fountain.Images.valid_media_types()
 
   schema "turn_images" do
     field :position, :integer
@@ -30,7 +29,7 @@ defmodule Fountain.Conversations.TurnImage do
     image
     |> cast(attrs, [:position, :media_type, :data, :turn_id, :inserted_at])
     |> validate_required([:position, :media_type, :data, :turn_id])
-    |> validate_inclusion(:media_type, @valid_media_types)
+    |> validate_inclusion(:media_type, Fountain.Images.valid_media_types())
     |> validate_number(:position, greater_than_or_equal_to: 0)
     |> unique_constraint([:turn_id, :position])
     # Without this a missing turn raises Ecto.ConstraintError instead of

--- a/apps/fountain/lib/fountain/images.ex
+++ b/apps/fountain/lib/fountain/images.ex
@@ -1,0 +1,18 @@
+defmodule Fountain.Images do
+  @moduledoc """
+  The image media types the platform accepts, in one place.
+
+  Every path that stores or serves client-originated image bytes — turn
+  images and agent avatars — must validate against this same list at ingest
+  AND re-check at serve time. The avatar path once validated nothing while
+  the turn-image path next to it validated both ends, and the asymmetry is
+  how a client-declared `text/html` ended up servable from the app's own
+  origin. A shared list keeps the two from diverging again.
+  """
+
+  @valid_media_types ~w(image/png image/jpeg image/gif image/webp)
+
+  def valid_media_types, do: @valid_media_types
+
+  def valid_media_type?(media_type), do: media_type in @valid_media_types
+end

--- a/apps/fountain/lib/fountain_web/audited.ex
+++ b/apps/fountain/lib/fountain_web/audited.ex
@@ -84,27 +84,14 @@ defmodule FountainWeb.Audited do
 
     case peer do
       %{address: address} ->
-        if FountainWeb.Plugs.ClientIp.from_trusted_proxy?(address) do
-          forwarded_ip(headers) || format_ip(address)
-        else
-          format_ip(address)
-        end
-
-      _ ->
-        nil
-    end
-  end
-
-  defp forwarded_ip(headers) do
-    headers
-    |> Enum.find(fn {name, _} -> String.downcase(name) == "x-forwarded-for" end)
-    |> case do
-      {_, value} ->
-        value
-        |> String.split(",")
-        |> Enum.map(&String.trim/1)
-        |> Enum.reject(&(&1 == ""))
-        |> List.first()
+        # Delegates the whole rule — peer gate AND header walk — to the HTTP
+        # path's implementation. A previous copy here parsed x-forwarded-for
+        # itself and took the leftmost (client-supplied) entry, so UI audit
+        # rows and API audit rows disagreed whenever the chain had more than
+        # one hop.
+        address
+        |> FountainWeb.Plugs.ClientIp.resolve_address(headers)
+        |> format_ip()
 
       _ ->
         nil

--- a/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
@@ -4,16 +4,25 @@ defmodule FountainWeb.AgentAvatarController do
 
   alias Fountain.Agents
 
-  # sobelow_skip ["XSS.SendResp", "XSS.ContentType"] — bytes and media type
-  # come from the tenant-scoped agent row, validated at upload.
+  # sobelow_skip ["XSS.SendResp", "XSS.ContentType"] — media type is checked
+  # against Fountain.Images.valid_media_types/0 and the response pins
+  # nosniff + a sandboxing CSP precisely because the bytes are
+  # client-originated. Same treatment as TurnImageController.
   def show(conn, %{"id" => id}) do
     user_id = conn.assigns.current_user.id
 
     with %{avatar_media_type: media_type} = agent
          when not is_nil(media_type) <- Agents.get_agent(id, user_id),
+         # Re-checked at serve time: a row whose media_type slipped past
+         # ingest validation (or predates it) must not be served as active
+         # content from the app's own origin, where the page CSP allows
+         # 'unsafe-inline'.
+         true <- Fountain.Images.valid_media_type?(media_type),
          %{data: data} <- Agents.get_avatar(agent) do
       conn
       |> put_resp_content_type(media_type)
+      |> put_resp_header("x-content-type-options", "nosniff")
+      |> put_resp_header("content-security-policy", "default-src 'none'; sandbox")
       |> put_resp_header("cache-control", "private, max-age=3600")
       |> send_resp(200, data)
     else

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -396,70 +396,9 @@ defmodule FountainWeb.ConversationController do
     s |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
   end
 
-  @max_image_bytes 10 * 1024 * 1024
-
-  @doc false
-  # Exposed for tests: a body large enough to exercise the size guard through
-  # HTTP is rejected by the body parser first, so the guard itself would
-  # otherwise be untestable.
-  def decode_images_for_test(images), do: decode_images(images)
-
-  # Validates before anything is stored, and returns an error the caller can
-  # turn into a 400. Previously this decoded with `Base.decode64!` and raised a
-  # bare ArgumentError past the size limit — both surfaced as a 500, telling a
-  # client with a malformed request that the server was broken. The media type
-  # was not checked at all, so a client could store an arbitrary one.
-  defp decode_images(nil), do: {:ok, []}
-  defp decode_images([]), do: {:ok, []}
-
-  defp decode_images(images) when is_list(images) do
-    Enum.reduce_while(images, {:ok, []}, fn img, {:ok, acc} ->
-      case decode_image(img) do
-        {:ok, decoded} -> {:cont, {:ok, acc ++ [decoded]}}
-        {:error, _} = err -> {:halt, err}
-      end
-    end)
-  end
-
-  defp decode_images(_), do: {:error, "images must be a list"}
-
-  defp decode_image(img) when is_map(img) do
-    b64 = img["data"] || img[:data]
-    mt = img["media_type"] || img[:media_type]
-
-    with :ok <- validate_media_type(mt),
-         {:ok, data} <- decode_base64(b64),
-         :ok <- validate_size(data) do
-      {:ok, %{media_type: mt, data: data}}
-    end
-  end
-
-  defp decode_image(_), do: {:error, "each image must be an object"}
-
-  defp validate_media_type(mt) do
-    if mt in Fountain.Conversations.TurnImage.valid_media_types() do
-      :ok
-    else
-      {:error,
-       "unsupported image media_type #{inspect(mt)} — must be one of " <>
-         Enum.join(Fountain.Conversations.TurnImage.valid_media_types(), ", ")}
-    end
-  end
-
-  defp decode_base64(b64) when is_binary(b64) do
-    case Base.decode64(b64) do
-      {:ok, data} -> {:ok, data}
-      :error -> {:error, "image data must be base64-encoded"}
-    end
-  end
-
-  defp decode_base64(_), do: {:error, "image data is required"}
-
-  defp validate_size(data) do
-    if byte_size(data) > @max_image_bytes,
-      do: {:error, "image exceeds the 10MB limit"},
-      else: :ok
-  end
+  # Validation, decode and size cap live in FountainWeb.PromptImages so the
+  # LiveView prompt path applies exactly the same checks.
+  defp decode_images(images), do: FountainWeb.PromptImages.decode(images)
 
   defp parse_last_event_id(nil), do: 0
   defp parse_last_event_id(""), do: 0

--- a/apps/fountain/lib/fountain_web/endpoint.ex
+++ b/apps/fountain/lib/fountain_web/endpoint.ex
@@ -70,8 +70,13 @@ defmodule FountainWeb.Endpoint do
   # which is most of the value of auditing the UI in the first place.
   @connect_info [session: @session_options, peer_data: true, x_headers: true]
 
+  # max_frame_size: Phoenix's default is "infinity", and the conversation
+  # page pushes base64 image payloads over this socket. 15 MB fits the
+  # 10 MB decoded image ceiling (PromptImages) at base64's 4/3 expansion
+  # with headroom, while bounding what an authenticated client can make
+  # the server buffer per frame.
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: @connect_info],
+    websocket: [connect_info: @connect_info, max_frame_size: 15_000_000],
     longpoll: [connect_info: @connect_info]
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -153,59 +153,16 @@ defmodule FountainWeb.ConversationsLive.Show do
         %{"data" => img["data"], "media_type" => img["media_type"]}
       end)
 
-    decoded_images =
-      Enum.map(images, fn %{"data" => b64, "media_type" => mt} ->
-        %{media_type: mt, data: Base.decode64!(b64)}
-      end)
+    # Same validation as the API path (media-type allowlist, non-raising
+    # base64, 10MB cap). This used to Base.decode64! whatever the client
+    # sent, so malformed input crashed the LiveView process — and crash
+    # reports log socket assigns.
+    case FountainWeb.PromptImages.decode(images) do
+      {:error, message} ->
+        {:noreply, put_flash(socket, :error, message)}
 
-    case ConversationServer.send_prompt(socket.assigns.conv.id, p, decoded_images) do
-      :ok ->
-        # Refetch the conversation — wake-from-cold flips sandbox + status.
-        conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
-
-        {:noreply,
-         socket
-         |> assign(:conv, conv)
-         |> assign(:prompt, "")
-         |> assign(:pending_images, [])
-         |> put_flash(:info, "Queued")}
-
-      {:error, :busy} ->
-        {:noreply, put_flash(socket, :error, "A turn is already running")}
-
-      {:error, :gone} ->
-        {:noreply, put_flash(socket, :error, "Conversation is terminated and can't be resumed")}
-
-      {:error, :not_running} ->
-        {:noreply, put_flash(socket, :error, "Conversation is no longer running")}
-
-      {:error, :no_agent} ->
-        {:noreply, put_flash(socket, :error, "Conversation has no agent — can't resume")}
-
-      # The on_mount hook gates at mount only, so a socket that connected
-      # while the subscription was active survives a mid-session lapse (#401).
-      # Same handling ConversationsLive.New already has.
-      {:error, :subscription_required} ->
-        {:noreply,
-         socket
-         |> put_flash(:error, "An active subscription is required to send a prompt.")
-         |> push_navigate(to: ~p"/account/billing")}
-
-      {:error, {:sandbox_quota_exceeded, %{count: count, limit: limit}}} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           "You have #{count} of #{limit} concurrent sandboxes in use. " <>
-             "Terminate a conversation before starting another."
-         )}
-
-      {:error, :provisioning} ->
-        {:noreply,
-         put_flash(socket, :error, "The conversation is still provisioning — try again shortly.")}
-
-      {:error, reason} ->
-        {:noreply, put_flash(socket, :error, "Couldn't send: #{inspect(reason)}")}
+      {:ok, decoded_images} ->
+        send_decoded_prompt(socket, p, decoded_images)
     end
   end
 
@@ -1436,6 +1393,58 @@ defmodule FountainWeb.ConversationsLive.Show do
   defp truncate(s, _), do: s
 
   # ── stage row helpers ───────────────────────────────────────────────────────
+
+  defp send_decoded_prompt(socket, p, decoded_images) do
+    case ConversationServer.send_prompt(socket.assigns.conv.id, p, decoded_images) do
+      :ok ->
+        # Refetch the conversation — wake-from-cold flips sandbox + status.
+        conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
+
+        {:noreply,
+         socket
+         |> assign(:conv, conv)
+         |> assign(:prompt, "")
+         |> assign(:pending_images, [])
+         |> put_flash(:info, "Queued")}
+
+      {:error, :busy} ->
+        {:noreply, put_flash(socket, :error, "A turn is already running")}
+
+      {:error, :gone} ->
+        {:noreply, put_flash(socket, :error, "Conversation is terminated and can't be resumed")}
+
+      {:error, :not_running} ->
+        {:noreply, put_flash(socket, :error, "Conversation is no longer running")}
+
+      {:error, :no_agent} ->
+        {:noreply, put_flash(socket, :error, "Conversation has no agent — can't resume")}
+
+      # The on_mount hook gates at mount only, so a socket that connected
+      # while the subscription was active survives a mid-session lapse (#401).
+      # Same handling ConversationsLive.New already has.
+      {:error, :subscription_required} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "An active subscription is required to send a prompt.")
+         |> push_navigate(to: ~p"/account/billing")}
+
+      {:error, {:sandbox_quota_exceeded, %{count: count, limit: limit}}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "You have #{count} of #{limit} concurrent sandboxes in use. " <>
+             "Terminate a conversation before starting another."
+         )}
+
+      {:error, :provisioning} ->
+        {:noreply,
+         put_flash(socket, :error, "The conversation is still provisioning — try again shortly.")}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, "Couldn't send: #{inspect(reason)}")}
+    end
+  end
 
   defp stage_icon("provision"), do: "&#10024;"
   defp stage_icon("checkpoint_restore"), do: "&#128230;"

--- a/apps/fountain/lib/fountain_web/plugs/client_ip.ex
+++ b/apps/fountain/lib/fountain_web/plugs/client_ip.ex
@@ -54,10 +54,23 @@ defmodule FountainWeb.Plugs.ClientIp do
   defp normalize(ip), do: ip
 
   defp resolve(conn) do
-    if from_trusted_proxy?(conn.remote_ip) do
-      RemoteIp.from(conn.req_headers, headers: @headers, proxies: proxies()) || conn.remote_ip
+    resolve_address(conn.remote_ip, conn.req_headers)
+  end
+
+  @doc """
+  The full resolution rule, for callers that hold a peer address and headers
+  rather than a `Plug.Conn` — the LiveView mount path in `FountainWeb.Audited`.
+
+  One implementation on purpose: an earlier copy in `Audited` reparsed
+  `x-forwarded-for` itself and took the LEFTMOST entry — client-supplied and
+  attacker-chosen the moment a proxy hop stops rewriting the header — while
+  this path walks from the right and returns the first non-proxy address.
+  """
+  def resolve_address(peer_ip, headers) do
+    if from_trusted_proxy?(peer_ip) do
+      RemoteIp.from(headers, headers: @headers, proxies: proxies()) || peer_ip
     else
-      conn.remote_ip
+      peer_ip
     end
   end
 

--- a/apps/fountain/lib/fountain_web/prompt_images.ex
+++ b/apps/fountain/lib/fountain_web/prompt_images.ex
@@ -1,0 +1,72 @@
+defmodule FountainWeb.PromptImages do
+  @moduledoc """
+  Decodes and validates client-supplied prompt images, for BOTH transports.
+
+  The API controller and the conversation LiveView accept the same
+  `[%{"data" => base64, "media_type" => mt}]` shape, and they must apply the
+  same three checks — media-type allowlist, non-raising base64 decode, size
+  ceiling. The LiveView once skipped all three: malformed base64 raised out
+  of `Base.decode64!/1` and took the LiveView process down (crash-logging
+  its assigns), and nothing bounded the payload.
+
+  Validates before anything is stored, and returns an error the caller can
+  render. Returns `{:ok, [%{media_type: mt, data: binary}]}` or
+  `{:error, message}`.
+  """
+
+  @max_image_bytes 10 * 1024 * 1024
+
+  def max_image_bytes, do: @max_image_bytes
+
+  def decode(nil), do: {:ok, []}
+  def decode([]), do: {:ok, []}
+
+  def decode(images) when is_list(images) do
+    Enum.reduce_while(images, {:ok, []}, fn img, {:ok, acc} ->
+      case decode_image(img) do
+        {:ok, decoded} -> {:cont, {:ok, acc ++ [decoded]}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  def decode(_), do: {:error, "images must be a list"}
+
+  defp decode_image(img) when is_map(img) do
+    b64 = img["data"] || img[:data]
+    mt = img["media_type"] || img[:media_type]
+
+    with :ok <- validate_media_type(mt),
+         {:ok, data} <- decode_base64(b64),
+         :ok <- validate_size(data) do
+      {:ok, %{media_type: mt, data: data}}
+    end
+  end
+
+  defp decode_image(_), do: {:error, "each image must be an object"}
+
+  defp validate_media_type(mt) do
+    if Fountain.Images.valid_media_type?(mt) do
+      :ok
+    else
+      {:error,
+       "unsupported image media_type #{inspect(mt)} — must be one of " <>
+         Enum.join(Fountain.Images.valid_media_types(), ", ")}
+    end
+  end
+
+  defp decode_base64(b64) when is_binary(b64) do
+    case Base.decode64(b64) do
+      {:ok, data} -> {:ok, data}
+      :error -> {:error, "image data must be base64-encoded"}
+    end
+  end
+
+  defp decode_base64(_), do: {:error, "image data is required"}
+
+  defp validate_size(data) do
+    if byte_size(data) > @max_image_bytes,
+      do: {:error, "image exceeds the 10MB limit"},
+      else: :ok
+  end
+end

--- a/apps/fountain/test/fountain/agents/agent_avatar_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_avatar_test.exs
@@ -21,6 +21,20 @@ defmodule Fountain.Agents.AgentAvatarTest do
       avatar = Agents.get_avatar(replaced)
       assert avatar.data == "second"
     end
+
+    test "rejects a media type outside the image allowlist" do
+      # The stored media type is echoed into Content-Type at serve time, and
+      # LiveView's upload accept: list passes an entry whose filename
+      # extension matches even when the declared MIME type does not — so
+      # without this check a crafted client stores text/html and gets it
+      # served as active content from the app's own origin.
+      agent = insert_agent()
+
+      assert {:error, :invalid_media_type} =
+               Agents.upload_avatar(agent, "<script>alert(1)</script>", "text/html")
+
+      assert Agents.get_avatar(agent) == nil
+    end
   end
 
   describe "delete_avatar/1" do

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -480,12 +480,12 @@ defmodule Fountain.ConversationsContextTest do
     end
   end
 
-  describe "next_turn_number/1" do
+  describe "_unsafe_next_turn_number/1" do
     test "returns 1 when conversation has no turns" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      assert Conversations.next_turn_number(conv.id) == 1
+      assert Conversations._unsafe_next_turn_number(conv.id) == 1
     end
 
     test "returns max_turn_number + 1 when turns exist" do
@@ -494,7 +494,7 @@ defmodule Fountain.ConversationsContextTest do
       _t1 = insert_turn(conv)
       _t2 = insert_turn(conv)
 
-      assert Conversations.next_turn_number(conv.id) == 3
+      assert Conversations._unsafe_next_turn_number(conv.id) == 3
     end
 
     test "is not affected by turns from other conversations" do
@@ -505,11 +505,11 @@ defmodule Fountain.ConversationsContextTest do
       _t2 = insert_turn(conv1)
       _t3 = insert_turn(conv1)
 
-      assert Conversations.next_turn_number(conv2.id) == 1
+      assert Conversations._unsafe_next_turn_number(conv2.id) == 1
     end
   end
 
-  describe "create_turn/1" do
+  describe "_unsafe_create_turn/1" do
     test "creates a turn with valid attrs" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
@@ -521,7 +521,7 @@ defmodule Fountain.ConversationsContextTest do
         status: "pending"
       }
 
-      assert {:ok, turn} = Conversations.create_turn(attrs)
+      assert {:ok, turn} = Conversations._unsafe_create_turn(attrs)
       assert turn.conversation_id == conv.id
       assert turn.turn_number == 1
       assert turn.prompt == "Hello, world"
@@ -529,7 +529,7 @@ defmodule Fountain.ConversationsContextTest do
     end
 
     test "returns error changeset when required fields are missing" do
-      assert {:error, changeset} = Conversations.create_turn(%{})
+      assert {:error, changeset} = Conversations._unsafe_create_turn(%{})
       assert changeset.valid? == false
       assert errors_on(changeset)[:conversation_id]
       assert errors_on(changeset)[:turn_number]
@@ -546,18 +546,18 @@ defmodule Fountain.ConversationsContextTest do
         status: "bogus"
       }
 
-      assert {:error, changeset} = Conversations.create_turn(attrs)
+      assert {:error, changeset} = Conversations._unsafe_create_turn(attrs)
       assert errors_on(changeset)[:status]
     end
   end
 
-  describe "update_turn/2" do
+  describe "_unsafe_update_turn/2" do
     test "updates a turn with valid attrs" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
       turn = insert_turn(conv)
 
-      assert {:ok, updated} = Conversations.update_turn(turn, %{status: "completed"})
+      assert {:ok, updated} = Conversations._unsafe_update_turn(turn, %{status: "completed"})
       assert updated.id == turn.id
       assert updated.status == "completed"
     end
@@ -567,74 +567,8 @@ defmodule Fountain.ConversationsContextTest do
       conv = insert_conversation(user_id: user.id)
       turn = insert_turn(conv)
 
-      assert {:error, changeset} = Conversations.update_turn(turn, %{status: "invalid"})
+      assert {:error, changeset} = Conversations._unsafe_update_turn(turn, %{status: "invalid"})
       assert errors_on(changeset)[:status]
-    end
-  end
-
-  describe "mark_orphaned_turns_interrupted/1" do
-    test "marks running turns as interrupted and returns count" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-      _pending = insert_turn(conv, status: "pending")
-      _running1 = insert_turn(conv, status: "running")
-      _running2 = insert_turn(conv, status: "running")
-
-      count = Conversations.mark_orphaned_turns_interrupted(conv.id)
-      assert count == 2
-    end
-
-    test "does not modify non-running turns" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-      pending = insert_turn(conv, status: "pending")
-      completed = insert_turn(conv, status: "completed")
-      failed = insert_turn(conv, status: "failed")
-
-      Conversations.mark_orphaned_turns_interrupted(conv.id)
-
-      assert Conversations.get_turn_by_conversation(pending.id, conv.id, user.id).status ==
-               "pending"
-
-      assert Conversations.get_turn_by_conversation(completed.id, conv.id, user.id).status ==
-               "completed"
-
-      assert Conversations.get_turn_by_conversation(failed.id, conv.id, user.id).status ==
-               "failed"
-    end
-
-    test "returns 0 when no running turns exist" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-      _t = insert_turn(conv, status: "pending")
-
-      assert Conversations.mark_orphaned_turns_interrupted(conv.id) == 0
-    end
-
-    test "only affects turns for the given conversation" do
-      user = insert_verified_user()
-      conv1 = insert_conversation(user_id: user.id)
-      conv2 = insert_conversation(user_id: user.id)
-      running_in_conv2 = insert_turn(conv2, status: "running")
-
-      # Only interrupt conv1's running turns (none exist)
-      count = Conversations.mark_orphaned_turns_interrupted(conv1.id)
-      assert count == 0
-
-      # conv2's running turn should be untouched
-      assert Conversations.get_turn_by_conversation(running_in_conv2.id, conv2.id, user.id).status ==
-               "running"
-    end
-
-    test "updates running turns to interrupted status in db" do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-      running = insert_turn(conv, status: "running")
-
-      Conversations.mark_orphaned_turns_interrupted(conv.id)
-
-      result = Conversations.get_turn_by_conversation(running.id, conv.id, user.id)
-      assert result.status == "interrupted"
     end
   end
 
@@ -969,13 +903,13 @@ defmodule Fountain.ConversationsContextTest do
     end
   end
 
-  describe "output_bytes_by_stream/2" do
+  describe "_unsafe_output_bytes_by_stream/2" do
     test "returns empty map when there are no output events for the turn" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
       turn = insert_turn(conv)
 
-      assert Conversations.output_bytes_by_stream(conv.id, turn.id) == %{}
+      assert Conversations._unsafe_output_bytes_by_stream(conv.id, turn.id) == %{}
     end
 
     test "sums byte lengths of data grouped by stream" do
@@ -1006,7 +940,7 @@ defmodule Fountain.ConversationsContextTest do
         turn_id: turn.id
       )
 
-      result = Conversations.output_bytes_by_stream(conv.id, turn.id)
+      result = Conversations._unsafe_output_bytes_by_stream(conv.id, turn.id)
       assert result["stdout"] == 10
       assert result["stderr"] == 3
     end
@@ -1023,7 +957,7 @@ defmodule Fountain.ConversationsContextTest do
         turn_id: turn.id
       )
 
-      result = Conversations.output_bytes_by_stream(conv.id, turn.id)
+      result = Conversations._unsafe_output_bytes_by_stream(conv.id, turn.id)
       # Stage events have empty stream and are kind "stage", not "output"
       assert result == %{}
     end
@@ -1041,7 +975,7 @@ defmodule Fountain.ConversationsContextTest do
         turn_id: turn2.id
       )
 
-      result = Conversations.output_bytes_by_stream(conv.id, turn1.id)
+      result = Conversations._unsafe_output_bytes_by_stream(conv.id, turn1.id)
       assert result == %{}
     end
 
@@ -1059,7 +993,7 @@ defmodule Fountain.ConversationsContextTest do
         turn_id: turn2.id
       )
 
-      result = Conversations.output_bytes_by_stream(conv1.id, turn1.id)
+      result = Conversations._unsafe_output_bytes_by_stream(conv1.id, turn1.id)
       assert result == %{}
     end
 
@@ -1075,96 +1009,8 @@ defmodule Fountain.ConversationsContextTest do
         turn_id: turn.id
       )
 
-      result = Conversations.output_bytes_by_stream(conv.id, turn.id)
+      result = Conversations._unsafe_output_bytes_by_stream(conv.id, turn.id)
       assert Map.has_key?(result, "stdout")
-    end
-  end
-
-  # ────────────────────────────────────────────────────────────────────────────
-  # stream_log_events/2
-  # ────────────────────────────────────────────────────────────────────────────
-
-  describe "stream_log_events/2" do
-    setup do
-      user = insert_verified_user()
-      conv = insert_conversation(user_id: user.id)
-      %{user: user, conv: conv}
-    end
-
-    test "streams all events for a conversation when after_id is 0", %{conv: conv} do
-      e1 = insert_log_event(conv, kind: "output", stream: "stdout", data: "a")
-      e2 = insert_log_event(conv, kind: "output", stream: "stderr", data: "b")
-
-      ids =
-        Repo.transaction(fn ->
-          Conversations.stream_log_events(conv.id) |> Enum.map(& &1.id)
-        end)
-
-      assert {:ok, result_ids} = ids
-      assert e1.id in result_ids
-      assert e2.id in result_ids
-    end
-
-    test "returns events ordered by id ascending", %{conv: conv} do
-      e1 = insert_log_event(conv, kind: "output", stream: "stdout", data: "first")
-      e2 = insert_log_event(conv, kind: "output", stream: "stdout", data: "second")
-      e3 = insert_log_event(conv, kind: "output", stream: "stdout", data: "third")
-
-      {:ok, ids} =
-        Repo.transaction(fn ->
-          Conversations.stream_log_events(conv.id) |> Enum.map(& &1.id)
-        end)
-
-      assert ids == [e1.id, e2.id, e3.id]
-    end
-
-    test "filters events with id greater than after_id", %{conv: conv} do
-      e1 = insert_log_event(conv, kind: "output", stream: "stdout", data: "a")
-      e2 = insert_log_event(conv, kind: "output", stream: "stdout", data: "b")
-      e3 = insert_log_event(conv, kind: "output", stream: "stdout", data: "c")
-
-      {:ok, ids} =
-        Repo.transaction(fn ->
-          Conversations.stream_log_events(conv.id, e1.id) |> Enum.map(& &1.id)
-        end)
-
-      refute e1.id in ids
-      assert e2.id in ids
-      assert e3.id in ids
-    end
-
-    test "returns empty stream when no events exist", %{conv: conv} do
-      {:ok, ids} =
-        Repo.transaction(fn ->
-          Conversations.stream_log_events(conv.id) |> Enum.map(& &1.id)
-        end)
-
-      assert ids == []
-    end
-
-    test "does not return events from other conversations", %{conv: conv} do
-      user = insert_verified_user()
-      other_conv = insert_conversation(user_id: user.id)
-      _other = insert_log_event(other_conv, kind: "output", stream: "stdout", data: "other")
-      mine = insert_log_event(conv, kind: "output", stream: "stdout", data: "mine")
-
-      {:ok, ids} =
-        Repo.transaction(fn ->
-          Conversations.stream_log_events(conv.id) |> Enum.map(& &1.id)
-        end)
-
-      assert ids == [mine.id]
-    end
-
-    test "returns empty stream when all events are at or before after_id", %{conv: conv} do
-      e1 = insert_log_event(conv, kind: "output", stream: "stdout", data: "a")
-
-      {:ok, ids} =
-        Repo.transaction(fn ->
-          Conversations.stream_log_events(conv.id, e1.id) |> Enum.map(& &1.id)
-        end)
-
-      assert ids == []
     end
   end
 
@@ -1173,11 +1019,11 @@ defmodule Fountain.ConversationsContextTest do
   # ────────────────────────────────────────────────────────────────────────────
 
   # ────────────────────────────────────────────────────────────────────────────
-  # insert_turn_images/2 and _unsafe_get_turn_image/2
+  # _unsafe_insert_turn_images/2 and _unsafe_get_turn_image/2
   # ────────────────────────────────────────────────────────────────────────────
 
   # Helper to insert a TurnImage via changeset directly, for tests that need a
-  # row without exercising insert_turn_images/2.
+  # row without exercising _unsafe_insert_turn_images/2.
   defp insert_turn_image!(turn_id, position, media_type, data) do
     %Fountain.Conversations.TurnImage{}
     |> Fountain.Conversations.TurnImage.changeset(%{
@@ -1190,9 +1036,9 @@ defmodule Fountain.ConversationsContextTest do
     |> Repo.insert!()
   end
 
-  describe "insert_turn_images/2" do
+  describe "_unsafe_insert_turn_images/2" do
     test "returns {:ok, 0} immediately when images list is empty" do
-      assert {:ok, 0} = Conversations.insert_turn_images(Ecto.UUID.generate(), [])
+      assert {:ok, 0} = Conversations._unsafe_insert_turn_images(Ecto.UUID.generate(), [])
     end
 
     test "inserts images and returns count" do
@@ -1200,7 +1046,7 @@ defmodule Fountain.ConversationsContextTest do
       conv = insert_conversation(user_id: user.id)
       turn = insert_turn(conv)
       images = [%{media_type: "image/png", data: <<1, 2, 3>>}]
-      assert {:ok, 1} = Conversations.insert_turn_images(turn.id, images)
+      assert {:ok, 1} = Conversations._unsafe_insert_turn_images(turn.id, images)
     end
 
     test "positions are assigned in order" do
@@ -1209,7 +1055,7 @@ defmodule Fountain.ConversationsContextTest do
       turn = insert_turn(conv)
 
       assert {:ok, 2} =
-               Conversations.insert_turn_images(turn.id, [
+               Conversations._unsafe_insert_turn_images(turn.id, [
                  %{media_type: "image/png", data: <<1>>},
                  %{media_type: "image/jpeg", data: <<2>>}
                ])
@@ -1227,7 +1073,7 @@ defmodule Fountain.ConversationsContextTest do
       turn = insert_turn(conv)
 
       assert {:error, changeset} =
-               Conversations.insert_turn_images(turn.id, [
+               Conversations._unsafe_insert_turn_images(turn.id, [
                  %{media_type: "text/html", data: "<script>alert(1)</script>"}
                ])
 
@@ -1237,7 +1083,7 @@ defmodule Fountain.ConversationsContextTest do
 
     test "an unknown turn is refused rather than orphaning a row" do
       assert {:error, changeset} =
-               Conversations.insert_turn_images(Ecto.UUID.generate(), [
+               Conversations._unsafe_insert_turn_images(Ecto.UUID.generate(), [
                  %{media_type: "image/png", data: <<1>>}
                ])
 

--- a/apps/fountain/test/fountain/usage_metering_test.exs
+++ b/apps/fountain/test/fountain/usage_metering_test.exs
@@ -99,7 +99,7 @@ defmodule Fountain.UsageMeteringTest do
       conv = insert_conversation(user_id: user.id)
 
       {:ok, turn} =
-        Conversations.create_turn(%{
+        Conversations._unsafe_create_turn(%{
           conversation_id: conv.id,
           turn_number: 1,
           prompt: "hello",
@@ -117,7 +117,7 @@ defmodule Fountain.UsageMeteringTest do
       conv = insert_conversation(user_id: owner.id)
 
       {:ok, _} =
-        Conversations.create_turn(%{
+        Conversations._unsafe_create_turn(%{
           conversation_id: conv.id,
           turn_number: 1,
           prompt: "x",
@@ -139,7 +139,7 @@ defmodule Fountain.UsageMeteringTest do
 
       for n <- 1..3 do
         {:ok, _} =
-          Conversations.create_turn(%{
+          Conversations._unsafe_create_turn(%{
             conversation_id: conv.id,
             turn_number: n,
             prompt: "p#{n}",

--- a/apps/fountain/test/fountain_web/client_ip_test.exs
+++ b/apps/fountain/test/fountain_web/client_ip_test.exs
@@ -96,6 +96,32 @@ defmodule FountainWeb.ClientIpTest do
     end
   end
 
+  describe "resolve_address/2 — the LiveView audit path" do
+    # Audited.put_client_ip delegates here. Its previous private copy took
+    # the LEFTMOST x-forwarded-for entry — client-supplied and
+    # attacker-chosen the moment the chain has more than one hop — so
+    # UI-originated audit rows disagreed with API rows on the same request.
+    alias FountainWeb.Plugs.ClientIp
+
+    test "walks from the right, matching the HTTP path" do
+      assert ClientIp.resolve_address(
+               {10, 42, 0, 1},
+               [{"x-forwarded-for", "1.2.3.4, 203.0.113.7"}]
+             ) == {203, 0, 113, 7}
+    end
+
+    test "a direct peer's header is ignored entirely" do
+      assert ClientIp.resolve_address(
+               {198, 51, 100, 9},
+               [{"x-forwarded-for", "1.2.3.4"}]
+             ) == {198, 51, 100, 9}
+    end
+
+    test "no header falls back to the peer" do
+      assert ClientIp.resolve_address({10, 42, 0, 1}, []) == {10, 42, 0, 1}
+    end
+  end
+
   describe "trusted_proxies/0" do
     test "covers the k3s pod and service networks" do
       proxies = Endpoint.trusted_proxies()

--- a/apps/fountain/test/fountain_web/controllers/agent_avatar_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_avatar_controller_test.exs
@@ -25,6 +25,38 @@ defmodule FountainWeb.AgentAvatarControllerTest do
       assert conn.resp_body == "fake-img"
     end
 
+    test "pins nosniff and a sandboxing CSP on the bytes", %{conn: conn} do
+      # Same treatment as the turn-image endpoint: the bytes are
+      # client-originated, so the browser must not be allowed to infer a
+      # different type or run the response as active content.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      {:ok, _} = Agents.upload_avatar(agent, "fake-img", "image/png")
+      conn = login_user(conn, user)
+
+      conn = get(conn, ~p"/agents/#{agent.id}/avatar")
+      assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+      assert get_resp_header(conn, "content-security-policy") == ["default-src 'none'; sandbox"]
+    end
+
+    test "a stored media type outside the allowlist is a 404, not served", %{conn: conn} do
+      # A row that slipped past ingest validation (or predates it) must not
+      # be reflected into Content-Type — that is the self-XSS this endpoint
+      # once allowed.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      {:ok, updated} = Agents.upload_avatar(agent, "<script>alert(1)</script>", "image/png")
+
+      updated
+      |> Ecto.Changeset.change(%{avatar_media_type: "text/html"})
+      |> Fountain.Repo.update!()
+
+      conn = login_user(conn, user)
+      conn = get(conn, ~p"/agents/#{agent.id}/avatar")
+
+      assert conn.status == 404
+    end
+
     test "returns 404 for another tenant's agent", %{conn: conn} do
       owner = insert_verified_user()
       other = insert_verified_user()

--- a/apps/fountain/test/fountain_web/controllers/turn_image_ingest_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/turn_image_ingest_test.exs
@@ -17,7 +17,7 @@ defmodule FountainWeb.TurnImageIngestTest do
   So the assertions below accept either 4xx where the spec layer gets there
   first, and pin 400 exactly where the controller is the only thing checking.
   The context-level guard that makes all of this defence in depth rather than a
-  single boundary is in `Conversations.insert_turn_images/2`.
+  single boundary is in `Conversations._unsafe_insert_turn_images/2`.
   """
 
   use FountainWeb.ConnCase, async: true
@@ -115,7 +115,7 @@ defmodule FountainWeb.TurnImageIngestTest do
       big = :binary.copy(<<0>>, 10 * 1024 * 1024 + 1)
 
       assert {:error, msg} =
-               FountainWeb.ConversationController.decode_images_for_test([
+               FountainWeb.PromptImages.decode([
                  %{"media_type" => "image/png", "data" => Base.encode64(big)}
                ])
 

--- a/apps/fountain/test/fountain_web/cross_tenant_isolation_test.exs
+++ b/apps/fountain/test/fountain_web/cross_tenant_isolation_test.exs
@@ -72,7 +72,7 @@ defmodule FountainWeb.CrossTenantIsolationTest do
       turn = insert_turn(conv)
 
       {:ok, _} =
-        Fountain.Conversations.insert_turn_images(turn.id, [
+        Fountain.Conversations._unsafe_insert_turn_images(turn.id, [
           %{media_type: "image/png", data: <<137, 80, 78, 71>>}
         ])
 
@@ -131,7 +131,7 @@ defmodule FountainWeb.CrossTenantIsolationTest do
 
     test "an image stored with a non-image media type is not served", %{conn: conn} do
       # #203 closed the ingest path, so this row can no longer be written through
-      # insert_turn_images/2 — it is inserted raw here on purpose. Rows written
+      # _unsafe_insert_turn_images/2 — it is inserted raw here on purpose. Rows written
       # before that fix still exist, and defence at serve time is what keeps
       # them from coming back as active content on the app's origin.
       {user_a, _user_b, key_a, _key_b} = two_users()

--- a/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
@@ -65,6 +65,53 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
     end
   end
 
+  describe "send_prompt image validation" do
+    setup do
+      user = insert_verified_user()
+      conversation = insert_conversation(user_id: user.id)
+      %{user: user, conversation: conversation}
+    end
+
+    test "malformed base64 flashes an error instead of crashing the LiveView", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
+      # This path used to Base.decode64! the client payload, so malformed
+      # input took the whole LiveView process down — and crash reports log
+      # socket assigns.
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      render_hook(view, "images_selected", %{
+        "images" => [%{"data" => "not base64 !!!", "media_type" => "image/png"}]
+      })
+
+      html = render_hook(view, "send_prompt", %{"prompt" => "hi"})
+
+      assert html =~ "base64"
+      assert Process.alive?(view.pid)
+    end
+
+    test "a disallowed media type is refused like the API refuses it", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      render_hook(view, "images_selected", %{
+        "images" => [%{"data" => Base.encode64("x"), "media_type" => "text/html"}]
+      })
+
+      html = render_hook(view, "send_prompt", %{"prompt" => "hi"})
+
+      assert html =~ "unsupported image media_type"
+      assert Process.alive?(view.pid)
+    end
+  end
+
   describe "toggle_stream persists visible_streams" do
     setup do
       user = insert_verified_user()

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -176,7 +176,7 @@ defmodule Fountain.Factory do
     attrs =
       %{
         conversation_id: conv.id,
-        turn_number: Fountain.Conversations.next_turn_number(conv.id),
+        turn_number: Fountain.Conversations._unsafe_next_turn_number(conv.id),
         prompt: "test prompt",
         status: "pending"
       }


### PR DESCRIPTION
Fixes the four findings in #407.

## 1. Avatar media type
- `Fountain.Images` now owns the image media-type allowlist; `TurnImage.valid_media_types/0` delegates to it, so the two image paths can't diverge again.
- `Agents.upload_avatar/3` rejects anything off the list with `{:error, :invalid_media_type}` (LiveView's `accept:` doesn't constrain the declared type — `accepted?/2` passes on filename extension alone).
- The avatar endpoint re-checks the stored type at serve time (a bad row 404s instead of being reflected into Content-Type) and pins `x-content-type-options: nosniff` + `default-src 'none'; sandbox`, matching `TurnImageController`.

## 2. LiveView audit XFF
`Audited.resolve_client_ip/1` no longer reparses `x-forwarded-for` and takes the leftmost entry. The whole rule (peer gate + right-to-left walk) now lives once in `ClientIp.resolve_address/2`, which both the HTTP plug and the LiveView mount path call. Tests pin the rightmost-non-proxy behavior against a forged left-hand entry.

## 3. LiveView image decode
The controller's validation (media-type allowlist, non-raising base64, 10MB cap) is extracted to `FountainWeb.PromptImages` and the conversation LiveView now uses it — malformed base64 flashes an error instead of crashing the LiveView process (which crash-logs socket assigns, the DEK-in-assigns vector). The LiveView websocket gets `max_frame_size: 15_000_000` (fits the 10MB decoded ceiling at base64 expansion) instead of Phoenix's `"infinity"` default.

## 4. `_unsafe_` sweep completion (#328)
Renamed the five remaining unscoped helpers: `_unsafe_insert_turn_images/2`, `_unsafe_next_turn_number/1`, `_unsafe_create_turn/1`, `_unsafe_update_turn/2`, `_unsafe_output_bytes_by_stream/2` (all call sites are inside `ConversationServer`). Deleted `stream_log_events/2` as the issue proposed — and also `mark_orphaned_turns_interrupted/1`, which the issue counted as live but which now has no production caller either (reattach handles orphaned turns via `mark_orphan`/`_unsafe_update_turn`).

Note for #415/#440: with `stream_log_events/2` deleted, replay stays on `_unsafe_list_log_events/3` (`Repo.all`). Streaming inside a chunked SSE response would hold a DB transaction across client-paced writes, so the loaded-replay tradeoff is deliberate; the backlog is bounded by the #331 output budget.

Revert-verified: 6 failures with the avatar/XFF fixes stashed; the LiveView decode tests crash the view against the old code.

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)