### PR TITLE
self-host + cli: pin the compose tag, close the example-file drift gap, gate upgrade notes, CLI precision fixes (#410)

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -33,10 +33,12 @@ SPRITES_TOKEN=
 
 # POSTGRES_PASSWORD=postgres
 
-# Pin the image rather than tracking latest. Releases publish vX.Y.Z
-# (immutable) and vX.Y (newest patch in the line) tags:
+# Which release to run. The compose file falls back to a release pinned at
+# the time this checkout was cut; set this to upgrade (never to `latest` —
+# it moves under you on every merge). Releases publish vX.Y.Z (immutable)
+# and vX.Y (newest patch in the line) tags:
 # https://binarybourbon.github.io/fountain/self-hosting/#versioning-and-upgrades
-# FOUNTAIN_IMAGE_TAG=v0.3.0
+FOUNTAIN_IMAGE_TAG=v0.3.0
 
 # Mail. The default (EMAIL_DELIVERY=none) sends nothing, so verify accounts
 # with:

--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ SPRITES_TOKEN=
 # SANDBOX_IDLE_TIMEOUT_MINUTES=60
 # SANDBOX_MAX_LIFETIME_HOURS=24
 
+# Durable log volume per conversation (#331): once this much sandbox output
+# is persisted, a truncation marker is written and further output dropped.
+# 0 disables the bound.
+# LOG_OUTPUT_BUDGET_MB=50
+
 # ── Registration and accounts ────────────────────────────────────────────────
 
 # Registration is open by default. Close it once your accounts exist, or

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -84,6 +84,29 @@ jobs:
             exit 1
           fi
 
+      - name: Require upgrade notes for a minor bump
+        if: ${{ inputs.bump == 'minor' }}
+        env:
+          NEXT: ${{ steps.ver.outputs.next }}
+        run: |
+          set -euo pipefail
+          # Pre-1.0, a minor may break; the changelog header promises such a
+          # release carries an "Upgrade notes" section. The heading-exists
+          # check above cannot see a missing section, which is how the
+          # BILLING_ENABLED flip nearly shipped without one. A minor with
+          # genuinely nothing to note still gets the section, saying so —
+          # explicit beats absent.
+          section="$(awk -v ver="## [${NEXT}]" '
+            index($0, ver) == 1 {on=1; next}
+            on && /^## \[/ {exit}
+            on {print}
+          ' CHANGELOG.md)"
+          if ! grep -q '^### Upgrade notes' <<< "$section"; then
+            echo "The [${NEXT}] section has no \"### Upgrade notes\"." >&2
+            echo "Minor releases may break (pre-1.0); add the section — \"- None.\" is fine when true." >&2
+            exit 1
+          fi
+
       - name: Update mix.exs files
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Upgrade notes
+
+- **`BILLING_ENABLED` now defaults to `false`** — the subscription gate is
+  opt-in. An instance that relies on the gate must set `BILLING_ENABLED=true`
+  explicitly before upgrading, or every account gets ungated access (the
+  repo's hosted manifest under `k8s/` already sets it). See the #336 entry
+  under Changed
+
 ### Added
 
 - Point-in-time recovery for the hosted database (#209): continuous WAL
@@ -64,9 +72,7 @@ upgrade, is in
   dead-ended on a GitHub error page); the compose `app` service now has a
   healthcheck against `/health`; `TRUSTED_PROXIES` is documented in the
   `deploy/k8s` baseline; and **`BILLING_ENABLED` now defaults to `false`** —
-  the subscription gate is opt-in. An instance that relies on the gate must
-  set `BILLING_ENABLED=true` explicitly (the repo's hosted manifest under
-  `k8s/` does)
+  the subscription gate is opt-in (breaking; see Upgrade notes above)
 
 ### Removed
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,8 +8,8 @@ Bootstrap a fresh machine (laptop, ephemeral VM, codespace) to run, test, and de
 | ---------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `mise`     | Pins Elixir/Erlang to the exact versions in `.tool-versions`.       | `brew install mise` (macOS) · `curl https://mise.run \| sh` (Linux/WSL) |
 | `gh`       | GitHub CLI for cloning and PRs.                                     | `brew install gh && gh auth login`                                      |
-| `psql`     | Client for the dev/test Postgres.                                   | Comes with `brew install postgresql@16` (or any 14+).                   |
-| Docker *or* native Postgres 14+ | One way to host the dev/test database.                  | `brew install --cask orbstack` (or Docker Desktop), or `brew install postgresql@16 && brew services start postgresql@16`. |
+| `psql`     | Client for the dev/test Postgres.                                   | Comes with `brew install postgresql@16`. Match the server major (16): an older `pg_dump` refuses a newer server, which is the backup drill.                   |
+| Docker *or* native Postgres 16 | One way to host the dev/test database.                  | `brew install --cask orbstack` (or Docker Desktop), or `brew install postgresql@16 && brew services start postgresql@16`. |
 
 After installing `mise`, [activate it in your shell](https://mise.jdx.dev/getting-started.html#activate-mise):
 

--- a/apps/fountain/test/fountain/config_reference_test.exs
+++ b/apps/fountain/test/fountain/config_reference_test.exs
@@ -142,4 +142,44 @@ defmodule Fountain.ConfigReferenceTest do
            Remove the key, or add it to @compose_only/@read_elsewhere with a reason.
            """
   end
+
+  # Keys in .env.compose.example consumed by compose interpolation itself
+  # (image tag, published port, sibling services), not passed through the
+  # app service's environment block.
+  @interpolation_only ~w(FOUNTAIN_IMAGE_TAG PORT POSTGRES_PASSWORD)
+
+  test "every variable .env.compose.example advertises is actually passed to the app" do
+    # The other compose test is one-directional by construction: it asserts
+    # every key compose SETS is read, never that every key the example file
+    # ADVERTISES is passed through. That gap is exactly how a documented
+    # variable can be set by an operator and silently ignored.
+    compose = File.read!(Path.join(@repo_root, "docker-compose.yml"))
+    example = File.read!(Path.join(@repo_root, ".env.compose.example"))
+
+    advertised =
+      Regex.scan(~r/^#?\s*([A-Z][A-Z0-9_]*)=/m, example, capture: :all_but_first)
+      |> List.flatten()
+      |> Enum.uniq()
+
+    assert length(advertised) > 5,
+           "extracted only #{length(advertised)} keys from .env.compose.example — its layout changed"
+
+    unpassed =
+      Enum.reject(advertised, fn var ->
+        # Passed through as `VAR: ${VAR...}` (any default), or interpolated
+        # directly by compose.
+        Regex.match?(~r/#{var}:\s*.*\$\{#{var}[:}]/, compose) or
+          var in @interpolation_only
+      end)
+
+    assert unpassed == [],
+           """
+           .env.compose.example advertises variables the compose file never passes to the app:
+
+             #{Enum.join(unpassed, ", ")}
+
+           Add the key to the app service's environment block, or to
+           @interpolation_only with a reason.
+           """
+  end
 end

--- a/cli/internal/api/api.go
+++ b/cli/internal/api/api.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/BinaryBourbon/fountain/cli/internal/config"
@@ -27,7 +29,65 @@ func (e *HTTPError) Error() string {
 	if e.Body == nil {
 		return fmt.Sprintf("http %d", e.Status)
 	}
+	// The server writes genuinely actionable messages ("You have 3 of 3
+	// concurrent sandboxes in use. ..."); a raw Go map dump buries them.
+	// Prefer message, then error, flatten nested validation errors, and
+	// append upgrade_url when the server offers one.
+	if body, ok := e.Body.(map[string]any); ok {
+		var b strings.Builder
+		fmt.Fprintf(&b, "http %d", e.Status)
+		switch {
+		case toString(body["message"]) != "":
+			fmt.Fprintf(&b, ": %s", toString(body["message"]))
+		case toString(body["error"]) != "":
+			fmt.Fprintf(&b, ": %s", toString(body["error"]))
+		}
+		if errs, ok := body["errors"].(map[string]any); ok && len(errs) > 0 {
+			fmt.Fprintf(&b, ": %s", flattenErrors(errs))
+		}
+		if u := toString(body["upgrade_url"]); u != "" {
+			fmt.Fprintf(&b, " (upgrade: %s)", u)
+		}
+		if s := b.String(); s != fmt.Sprintf("http %d", e.Status) {
+			return s
+		}
+	}
 	return fmt.Sprintf("http %d: %v", e.Status, e.Body)
+}
+
+func toString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+// flattenErrors renders the nested field → messages shape Ecto's
+// traverse_errors produces: {"name": ["can't be blank"]} → `name: can't be
+// blank`, recursing into nested maps with dotted paths.
+func flattenErrors(errs map[string]any) string {
+	keys := make([]string, 0, len(errs))
+	for k := range errs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		switch v := errs[k].(type) {
+		case []any:
+			msgs := make([]string, 0, len(v))
+			for _, m := range v {
+				msgs = append(msgs, fmt.Sprintf("%v", m))
+			}
+			parts = append(parts, fmt.Sprintf("%s: %s", k, strings.Join(msgs, ", ")))
+		case map[string]any:
+			for _, nested := range strings.Split(flattenErrors(v), "; ") {
+				parts = append(parts, fmt.Sprintf("%s.%s", k, nested))
+			}
+		default:
+			parts = append(parts, fmt.Sprintf("%s: %v", k, v))
+		}
+	}
+	return strings.Join(parts, "; ")
 }
 
 // Client wraps the HTTP client and credential resolution.

--- a/cli/internal/api/api_test.go
+++ b/cli/internal/api/api_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// The server writes actionable messages; the CLI used to print the raw Go
+// map ("http 429: map[active_sandboxes:3 error:sandbox_quota_exceeded ...]").
+func TestHTTPErrorError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  HTTPError
+		want string
+	}{
+		{
+			name: "message is preferred over the error slug",
+			err: HTTPError{Status: 429, Body: map[string]any{
+				"error":   "sandbox_quota_exceeded",
+				"message": "You have 3 of 3 concurrent sandboxes in use.",
+			}},
+			want: "http 429: You have 3 of 3 concurrent sandboxes in use.",
+		},
+		{
+			name: "error slug when there is no message",
+			err:  HTTPError{Status: 410, Body: map[string]any{"error": "conversation_terminated"}},
+			want: "http 410: conversation_terminated",
+		},
+		{
+			name: "upgrade_url is appended",
+			err: HTTPError{Status: 402, Body: map[string]any{
+				"error":       "subscription_required",
+				"upgrade_url": "/account/billing",
+			}},
+			want: "http 402: subscription_required (upgrade: /account/billing)",
+		},
+		{
+			name: "validation errors are flattened, not map-dumped",
+			err: HTTPError{Status: 422, Body: map[string]any{
+				"errors": map[string]any{"name": []any{"can't be blank"}},
+			}},
+			want: "http 422: name: can't be blank",
+		},
+		{
+			name: "nested validation errors keep their path",
+			err: HTTPError{Status: 422, Body: map[string]any{
+				"errors": map[string]any{
+					"secrets": map[string]any{"value": []any{"is required"}},
+				},
+			}},
+			want: "http 422: secrets.value: is required",
+		},
+		{
+			name: "a bare status still renders",
+			err:  HTTPError{Status: 500},
+			want: "http 500",
+		},
+		{
+			name: "a non-map body falls back to the old rendering",
+			err:  HTTPError{Status: 502, Body: "bad gateway"},
+			want: "http 502: bad gateway",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHTTPErrorUnknownMapFallsBack(t *testing.T) {
+	// A map with none of the known keys must not render as just "http 418".
+	e := HTTPError{Status: 418, Body: map[string]any{"weird": "shape"}}
+	if got := e.Error(); !strings.Contains(got, "weird") {
+		t.Errorf("unknown body shape lost information: %q", got)
+	}
+}

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -485,6 +485,18 @@ func formatOutput(data map[string]any) string {
 	if raw == "" {
 		return ""
 	}
+	// Only turn output is runtime stream-JSON. The setup script and the
+	// provisioning stages (packages, network, clone) log raw text under
+	// their own stage — formatStreamJSONLine returns "" for anything that
+	// is not JSON, so a failing `apt install` or `git clone` produced zero
+	// visible output. Rows predating stage stamping have no stage and are
+	// turn output.
+	if stage, _ := data["stage"].(string); stage != "" && stage != "turn" {
+		if strings.HasSuffix(raw, "\n") {
+			return raw
+		}
+		return raw + "\n"
+	}
 	var b strings.Builder
 	for _, line := range strings.Split(raw, "\n") {
 		if line == "" {

--- a/cli/internal/cmd/conv_test.go
+++ b/cli/internal/cmd/conv_test.go
@@ -131,6 +131,41 @@ func TestHandleStageEvent(t *testing.T) {
 	}
 }
 
+// Only turn output is runtime stream-JSON; setup and provisioning stages log
+// raw text. Routing everything through the JSON formatter made a failing
+// `apt install` or `git clone` produce zero visible output.
+func TestFormatOutputByStage(t *testing.T) {
+	setup := map[string]any{
+		"stream": "stdout",
+		"stage":  "setup",
+		"data":   "E: Unable to locate package libweird",
+	}
+	if got := formatOutput(setup); got != "E: Unable to locate package libweird\n" {
+		t.Errorf("setup-stage output was not passed through verbatim: %q", got)
+	}
+
+	packages := map[string]any{
+		"stream": "stdout",
+		"stage":  "packages",
+		"data":   "installing 3 packages\n",
+	}
+	if got := formatOutput(packages); got != "installing 3 packages\n" {
+		t.Errorf("packages-stage output was not passed through: %q", got)
+	}
+
+	// Turn output that is not valid stream-JSON still renders as before
+	// (formatStreamJSONLine owns that behaviour); the key property is that
+	// the raw-text passthrough does NOT apply to the turn stage.
+	turn := map[string]any{
+		"stream": "stdout",
+		"stage":  "turn",
+		"data":   `{"type":"unknown"}`,
+	}
+	if got := formatOutput(turn); got == `{"type":"unknown"}`+"\n" {
+		t.Errorf("turn-stage output must go through the stream-JSON formatter, got passthrough: %q", got)
+	}
+}
+
 // lastEventIDIn extracts the stream head from a `?wait=false` drain, which is
 // what lets conv prompt / conv stream skip the history replay (#398).
 func TestLastEventIDIn(t *testing.T) {

--- a/cli/internal/cmd/keys.go
+++ b/cli/internal/cmd/keys.go
@@ -13,12 +13,16 @@ import (
 
 func init() {
 	keysCmd := &cobra.Command{Use: "keys", Short: "Manage Fountain API keys"}
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List API keys",
+		RunE:  func(cmd *cobra.Command, args []string) error { return keysList(cmd) },
+	}
+	// Every other list command takes --json; docs/cli.md promises it
+	// generally.
+	listCmd.Flags().Bool("json", false, "output JSON")
 	keysCmd.AddCommand(
-		&cobra.Command{
-			Use:   "list",
-			Short: "List API keys",
-			RunE:  func(cmd *cobra.Command, args []string) error { return keysList() },
-		},
+		listCmd,
 		&cobra.Command{
 			Use:   "create <name>",
 			Short: "Create a new API key",
@@ -58,13 +62,17 @@ type apiKeySummary struct {
 	LastUsedAt string `json:"last_used_at"`
 }
 
-func keysList() error {
+func keysList(cmd *cobra.Command) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
 	c := activeClient()
 	var resp struct {
 		Data []apiKeySummary `json:"data"`
 	}
 	if err := c.Get("/auth/api-keys", &resp); err != nil {
 		Fatal(err.Error())
+	}
+	if jsonOut {
+		return output.PrintJSON(resp.Data)
 	}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, k := range resp.Data {

--- a/deploy/k8s/prometheusrule.yaml
+++ b/deploy/k8s/prometheusrule.yaml
@@ -188,3 +188,172 @@ spec:
               or rate-limited, the Sprites API unhealthy, or tenants at their
               concurrency cap. Triage:
               https://binarybourbon.github.io/fountain/operations/#sprites-errors
+
+        - alert: FountainProvisionDeadlineExceeded
+          # The provision watchdog (#329) declared a provision wedged and
+          # force-failed it. The accompanying sprite destroy is best-effort
+          # (#394), so each firing may also leak a sprite that keeps billing
+          # your SPRITES_TOKEN — a cost signal as much as a UX one. Absolute
+          # count, not a rate: the event is rare by design.
+          expr: |
+            sum(increase(fountain_provision_deadline_exceeded_count{namespace="fountain"}[1h])) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: "A Fountain provision hit the watchdog deadline"
+            description: |
+              {{ $value }} provision(s) in the last hour ran past the watchdog
+              deadline and were force-failed. Each may have leaked a sprite —
+              check whether the reaper's untracked count rises on its next
+              run, and grep the app logs for "provisioning exceeded".
+
+        - alert: FountainSandboxBudgetExceeded
+          # Instance-wide concurrency ceiling (#405). Every sprite bills to
+          # your single SPRITES_TOKEN and the only enforced cap is per-tenant
+          # (default 5), so total concurrent spend is otherwise
+          # `users x cap` with no ceiling. 50 is a starter budget — an
+          # operator knob, not a law: size it to what you are willing to pay
+          # for.
+          expr: |
+            sum(fountain_sandboxes_count{namespace="fountain", status=~"pending|starting|ready"}) > 50
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain sandbox concurrency is above the instance budget"
+            description: |
+              {{ $value }} sandboxes are pending/starting/ready, all billing
+              your SPRITES_TOKEN. Find who is driving it (psql into your
+              database):
+              select user_id, count(*) from sandboxes
+                where status in ('pending','starting','ready')
+                group by 1 order by 2 desc limit 10;
+
+        - alert: FountainConversationsAboveBudget
+          # Companion to the sandbox budget, on the conversation gauge: a
+          # pending/running conversation implies a live sprite, so in steady
+          # state the two track each other. This one still fires when the
+          # sandbox rows are wrong — the drift SandboxReaper measures — and
+          # shares the same 50 knob.
+          expr: |
+            sum(fountain_conversations_count{namespace="fountain", status=~"pending|running"}) > 50
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain has more live conversations than the instance budget"
+            description: |
+              {{ $value }} conversations are pending/running against a budget
+              of 50. If FountainSandboxBudgetExceeded is not also firing, the
+              sandbox rows and reality have diverged — check the reaper log
+              line for released/expired/untracked counts.
+
+    # ── Sprite reaper (#405) ──────────────────────────────────────────────
+    #
+    # SandboxReaper reconciles the sandboxes table against the Sprites API
+    # hourly. Its third pass counts sprites running with no sandbox row and
+    # deliberately never destroys them — so its output is a gauge someone
+    # must be looking at, plus these alerts.
+    - name: fountain-reaper
+      interval: 60s
+      rules:
+        - alert: FountainUntrackedSprites
+          # The LEVEL of sprites alive with no live sandbox row, re-measured
+          # every run. Sustained non-zero is leaked money, not an outage —
+          # hence warning. 2h means two consecutive hourly runs both saw
+          # leaks, filtering legitimate transients (a sprite created seconds
+          # before the sweep, a developer using the shared token).
+          expr: fountain_reaper_untracked_count{namespace="fountain"} > 0
+          for: 2h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Sprites are running with no sandbox row (leaked spend)"
+            description: |
+              {{ $value }} sprite(s) have been running with no live sandbox
+              row for over 2h, billing your SPRITES_TOKEN. The reaper
+              deliberately never destroys these — a human has to look. The
+              run log includes a sample of the sprite names: grep the app
+              logs for "no sandbox row".
+
+        - alert: FountainReaperSilent
+          # The wedged-reaper canary. fountain_reaper_run_released is emitted
+          # at the end of every hourly run; absent() for 3h means no run has
+          # completed since boot. A reaper that runs and raises is caught by
+          # the Oban alerts below instead. An increase()-based staleness
+          # check cannot work here: the counter is legitimately flat for
+          # weeks when healthy.
+          expr: absent(fountain_reaper_run_released{namespace="fountain"})
+          for: 3h
+          labels:
+            severity: warning
+          annotations:
+            summary: "SandboxReaper has not completed a run since boot"
+            description: |
+              No SandboxReaper run has finished on this pod (it runs hourly).
+              Stuck rows are holding tenant quota and dead sprites are not
+              being destroyed. Inspect the job (psql into your database):
+              select id, state, attempt, errors[array_upper(errors,1)]
+                from oban_jobs where worker like '%SandboxReaper%'
+                order by id desc limit 5;
+
+    # ── Oban background jobs ──────────────────────────────────────────────
+    #
+    # Oban catches job exceptions internally and reports them only via
+    # telemetry — no process crashes, so no crash report ever sees a failing
+    # nightly RetentionPruner or hourly SandboxReaper. These watch the
+    # metrics the app exports from Oban's own events.
+    - name: fountain-oban
+      interval: 60s
+      rules:
+        - alert: FountainObanJobsRaising
+          # Every raising execution counts, including retries — the early
+          # signal, while Oban is still retrying and the job might yet
+          # succeed.
+          expr: |
+            sum by (queue, worker) (increase(fountain_oban_job_exception_count{namespace="fountain"}[1h])) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: "Oban jobs are raising in {{ $labels.queue }} ({{ $labels.worker }})"
+            description: |
+              {{ $value }} raising execution(s) in the last hour. Oban retries
+              with backoff, so this may self-heal — but a persistently raising
+              maintenance job means reaping/pruning/metering is not happening.
+              Check the job row's errors array (psql into your database):
+              select id, worker, state, attempt, errors[array_upper(errors,1)]
+                from oban_jobs order by id desc limit 5;
+
+        - alert: FountainObanJobsDiscarded
+          # A discarded job exhausted every retry and failed permanently.
+          # delta on the gauge rather than a static > 0: discarded rows sit
+          # for 7 days until Oban's pruner removes them, and an alert that
+          # stays red for a week trains people to ignore it.
+          expr: |
+            delta(fountain_oban_queue_depth{namespace="fountain", state="discarded"}[2h]) > 0
+          labels:
+            severity: critical
+          annotations:
+            summary: "An Oban job in {{ $labels.queue }} was discarded (all retries exhausted)"
+            description: |
+              The scheduled work this job represents did not happen — for the
+              maintenance queue that means reaping, retention or metering
+              silently stopped. Inspect and re-run (psql into your database):
+              select id, worker, errors[array_upper(errors,1)]
+                from oban_jobs where state='discarded' order by id desc limit 5;
+
+        - alert: FountainObanQueueBacklog
+          # available = runnable now but not picked up. A sustained backlog
+          # means concurrency is saturated or a worker is wedged.
+          expr: |
+            fountain_oban_queue_depth{namespace="fountain", state="available"} > 25
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Oban queue {{ $labels.queue }} has a sustained backlog"
+            description: |
+              {{ $value }} jobs runnable-but-waiting for 30m. Check whether
+              the queue's workers are wedged (executing depth pinned at its
+              concurrency limit) or something is enqueueing faster than the
+              queue drains.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,12 @@ services:
       retries: 10
 
   app:
-    image: ghcr.io/binarybourbon/fountain:${FOUNTAIN_IMAGE_TAG:-latest}
+    # The fallback tag is a pinned release, deliberately not `latest`:
+    # `latest` moves on every merge to main, across breaking minors, with
+    # migrations applied at boot and downgrade unsupported — the exact
+    # combination the versioning guide tells you never to run. Upgrade by
+    # setting FOUNTAIN_IMAGE_TAG in .env (see .env.compose.example).
+    image: ghcr.io/binarybourbon/fountain:${FOUNTAIN_IMAGE_TAG:-v0.3.0}
     # To run your own build instead of the published image, comment the line
     # above and uncomment this:
     #   build: .
@@ -62,6 +67,15 @@ services:
       # Conversations need a Sprites token. The app boots without one; every
       # attempt to start a conversation then fails.
       SPRITES_TOKEN: ${SPRITES_TOKEN:-}
+      SPRITES_BASE_URL: ${SPRITES_BASE_URL:-}
+
+      # Empty means the app's defaults apply. Advertised in
+      # .env.compose.example; a key listed there but not passed through here
+      # is silently ignored, which is what the drift test now refuses.
+      CHECK_ORIGIN_EXTRA: ${CHECK_ORIGIN_EXTRA:-}
+      SANDBOX_IDLE_TIMEOUT_MINUTES: ${SANDBOX_IDLE_TIMEOUT_MINUTES:-}
+      SANDBOX_MAX_LIFETIME_HOURS: ${SANDBOX_MAX_LIFETIME_HOURS:-}
+      REGISTRATION_ALLOWED_EMAIL_DOMAINS: ${REGISTRATION_ALLOWED_EMAIL_DOMAINS:-}
 
       # Off by default (the app's own default since #336, pinned here too):
       # the subscription gate is meaningful for the hosted service and is a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,16 +129,46 @@ fountain apply -f dir/ --var REGION=eu-west-1 # ${VAR} substitution, repeatable
 Apply is idempotent — create if new, update if changed. Supported kinds:
 `Environment`, `Vault`, `Agent`.
 
+`--var`/`${VAR}` substitution applies to `spec.secrets` values only — a
+`${VAR}` anywhere else in the document (a `setup_script`, a name) is
+transmitted literally.
+
 The CLI compiles every document into a single manifest and sends it to
 `POST /api/apply` in one request; the server reconciles environments, then
 vaults, then agents, and resolves agent `environment:` name references —
 including environments that already exist on the server. Against older servers
 without `/api/apply`, the CLI falls back to per-resource calls.
 
+### Secret references
+
+`spec.secrets` values can reference a secret manager instead of holding
+plaintext — this is what makes manifests committable to git. A value starting
+with one of these schemes is resolved client-side at apply time by shelling
+out to the manager's own CLI (which must be installed and authenticated):
+
+| Scheme | Manager | Resolved with |
+|---|---|---|
+| `op://vault/item/field` | 1Password | `op read` |
+| `bws://<secret-uuid>` | Bitwarden Secrets Manager | the `bws` CLI |
+| `infisical://<project?>/<env>/<path?>/<name>` | Infisical | the `infisical` CLI |
+
+```yaml
+kind: Vault
+metadata: { name: prod-tokens }
+spec:
+  secrets:
+    GITHUB_TOKEN: op://Private/github/token
+    STRIPE_KEY: bws://8f0a3c1e-...
+```
+
+Resolution failures (and empty values, which nearly always mean "secret not
+found") fail the apply for that document rather than writing an empty secret.
+Only `spec.secrets` values are resolved; the schemes are inert anywhere else.
+
 ## API keys
 
 ```bash
-fountain keys list
+fountain keys list [--json]
 fountain keys create <name>     # prints the key once; it is not recoverable
 fountain keys revoke <id>
 ```
@@ -154,12 +184,12 @@ fountain agent list --json | jq '.[].name'
 ## Configuration
 
 `~/.fountain/credentials` is an INI-style file written by `fountain auth login`,
-with one section per profile:
+with one section per profile (values are written double-quoted):
 
 ```ini
 [default]
-api_key = ftn_...
-base_url = https://fountain.inevitable.fyi
+api_key = "ftn_..."
+base_url = "https://fountain.inevitable.fyi"
 ```
 
 The file is written `0600` and the directory `0700`.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -81,12 +81,10 @@ under two tags, alongside the tags that track development:
 Releases v0.2.1 and earlier predate image tagging and exist only as `sha-`
 tags.
 
-The compose file reads `FOUNTAIN_IMAGE_TAG` from `.env`, so pinning is one
-line:
-
-```bash
-echo "FOUNTAIN_IMAGE_TAG=v0.3.0" >> .env
-```
+The compose file reads `FOUNTAIN_IMAGE_TAG` from `.env`, and
+`.env.compose.example` ships it set to a pinned release — so the quick start
+above is pinned by construction. Even with the variable unset, the compose
+file falls back to a pinned release rather than `latest`.
 
 Upgrading is editing that value, then `docker compose pull && docker compose
 up -d`. Migrations run automatically at boot — idempotently, under an advisory


### PR DESCRIPTION
Fixes the ten findings in #410.

## Self-host
1. **Compose no longer defaults to `latest`** — the fallback tag is the pinned current release (v0.3.0), `.env.compose.example` ships the pin uncommented (so the quick start pins by construction), and the versioning doc reflects both. Compose and k8s now agree.
2. **New drift test** (`config_reference_test.exs`): every `UPPER_CASE=` key the example file advertises must be passed through the compose `environment:` block, with a 3-entry interpolation-only allowlist. It immediately caught **five real advertised-but-ignored variables** (`SPRITES_BASE_URL`, `CHECK_ORIGIN_EXTRA`, `SANDBOX_IDLE_TIMEOUT_MINUTES`, `SANDBOX_MAX_LIFETIME_HOURS`, `REGISTRATION_ALLOWED_EMAIL_DOMAINS`) — exactly the class the issue predicted. All five are now passed through. `LOG_OUTPUT_BUDGET_MB` added to `.env.example`.
3. **Upgrade notes**: the breaking `BILLING_ENABLED` flip sits under `### Upgrade notes` in `[Unreleased]`, and `release-bump.yml` refuses to tag a **minor** whose changelog section lacks that heading (`- None.` satisfies it when true).
4. **Postgres floor**: SETUP.md aligned to 16 across both cells, with the pg_dump rationale inline.
5. **Portable alert pack**: the watchdog-deadline, sandbox/conversation budget, reaper and Oban alert groups ported to `deploy/k8s/prometheusrule.yaml`, with hosted `kubectl exec fountain-pg-1` commands generalized to "psql into your database".

## CLI
6. **Verified already fixed in #422** — `auth whoami` decodes the flat shape, `keys list` reads `prefix`. No change needed.
7. **`HTTPError.Error()`** prefers `message`, then `error`, flattens nested `errors` with dotted paths, appends `upgrade_url`. `http 429: You have 3 of 3 concurrent sandboxes in use.` instead of a Go map dump. Unknown shapes keep the old rendering (test pins that nothing is lost).
8. Terminal stream events — landed in #440.
9. **Provisioning/setup stdout visible**: only `stage == "turn"` output goes through the stream-JSON formatter (which returns "" for non-JSON); `setup`/`packages`/`network`/`clone` output prints verbatim. Rows predating stage stamping (no stage) keep the old path.
10. **docs/cli.md**: `keys list` gains `--json` (cheaper than carving an exception into the docs — it was the only list command without it); `--var` substitution documented as `spec.secrets`-only; credentials example matches the double-quoted output of `serialize`; and the `op://` / `bws://` / `infisical://` resolvers get a docs section with ref formats verified against the resolver code.

Elixir: 1,846 tests green (4 config-reference tests, one new). Go: `go test ./...` + `go vet` green, with new table tests for the error rendering and stage-aware output.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)