### PR TITLE
ops: per-server callback-key revocation, explicit restart budget, growth bounds, graceful shutdown, rehydrator telemetry (#408)

### DIFF
--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -47,7 +47,19 @@ defmodule Fountain.Application do
              name: Fountain.ConversationSupervisor,
              strategy: :one_for_one,
              distribution_strategy: Horde.UniformDistribution,
-             members: :auto
+             members: :auto,
+             # Explicit, and sized to the fleet: the default (3 restarts in
+             # 5s) is a budget SHARED by every ConversationServer on the
+             # node — one child that crashes deterministically on start
+             # exhausts it in under a second, and exceeding it terminates
+             # this supervisor and with it every running conversation here.
+             # 100/10s tolerates a correlated transient burst (a Sprites
+             # outage failing many provisions at once) while still stopping
+             # a genuine infinite loop. The known deterministic crash paths
+             # (rows deleted before handle_continue(:provision)) are also
+             # guarded in the server itself.
+             max_restarts: 100,
+             max_seconds: 10
            ]},
           FountainWeb.Endpoint
         ]

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -204,6 +204,13 @@ defmodule Fountain.Conversations.ConversationServer do
       # GenServer is alive. Rotated on every fresh provision/reattach;
       # revoked in terminate/2.
       callback_token: nil,
+      # The id of the key THIS server minted. Revocation acts only on this
+      # id, never on whatever the conversation row currently points at:
+      # duplicate servers exist (Horde CRDT merges mass-terminate losers,
+      # registry lag starts seconds-apart doubles — #367), and a server
+      # that revokes the row's key can be revoking the credential the
+      # SURVIVING server's sprite is actively using.
+      callback_api_key_id: nil,
       # Sandbox lifetime bookkeeping. `started_at` is set once the sprite
       # exists; `last_activity_at` moves on every turn start and end. See
       # Fountain.Conversations.Lifecycle for what the bounds are and why
@@ -296,9 +303,36 @@ defmodule Fountain.Conversations.ConversationServer do
 
   @impl true
   def handle_continue(:provision, state) do
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
-    agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id), else: nil
+    conv = Conversations._unsafe_get_conversation(state.conversation_id)
+    sandbox = state.sandbox_id && Conversations._unsafe_get_sandbox(state.sandbox_id)
+
+    if is_nil(conv) or is_nil(sandbox) do
+      # A conversation or sandbox deleted between start_child and this
+      # continue used to raise Ecto.NoResultsError — unrescued, in a
+      # restart: :transient child, so the supervisor restarted it straight
+      # back into the same raise. That burns the supervisor's SHARED
+      # restart budget, and exhausting it terminates every conversation on
+      # the node. A server whose rows are gone has nothing to provision.
+      Logger.warning(
+        "conv #{state.conversation_id}: row missing before provisioning " <>
+          "(conversation_gone=#{is_nil(conv)}, sandbox_gone=#{is_nil(sandbox)}); stopping"
+      )
+
+      {:stop, :normal, state}
+    else
+      provision_with_rows(state, conv, sandbox)
+    end
+  end
+
+  defp provision_with_rows(state, conv, sandbox) do
+    # Non-bang for the same reason as the rows above: a deleted agent must
+    # not crash-loop the server. Provisioning proceeds without it, exactly
+    # as for a conversation created with no agent.
+    agent = conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)
+
+    if conv.agent_id && is_nil(agent) do
+      Logger.warning("conv #{conv.id}: agent #{conv.agent_id} is gone; provisioning without it")
+    end
 
     # Scoped by the conversation's owner even though create/update_agent
     # already validates ownership: a cross-tenant environment_id that
@@ -1211,23 +1245,29 @@ defmodule Fountain.Conversations.ConversationServer do
   # exits — clean termination (`:terminate_conv`), crash paths that hit
   # `{:stop, :normal, state}`, and (because init/1 traps exits, #322)
   # supervisor shutdown on deploys and Horde rebalances.
+  #
+  # Revokes only the key THIS server minted, and only while the
+  # conversation row still points at it. Reading the row's id at call time
+  # made a dying duplicate (Horde's CRDT merge mass-terminates losers)
+  # revoke the SURVIVING server's live credential — its sprite then 401'd
+  # on every callback and sub-agent spawn, surfaced nowhere. If the row has
+  # moved past our key, a successor owns the live credential and ours is
+  # already dead or inert.
+  #
   # If the BEAM crashes hard (SIGKILL — untrappable) the row in `api_keys`
-  # is left behind, but it is no longer dangerous: `callback_api_key_opts/0`
+  # is left behind, but it is not dangerous: `callback_api_key_opts/0`
   # sets an `expires_at`, so an un-revoked key stops authenticating on its
-  # own, and rotation-on-reattach revokes it if the conversation ever
-  # resumes. Note RetentionPruner only deletes rows whose `revoked_at` is
-  # set — an un-revoked orphan goes inert at expiry but its row stays until
-  # something revokes it. See SandboxReaper for the sprite half, which does
-  # not self-heal.
+  # own, and RetentionPruner deletes long-expired rows. See SandboxReaper
+  # for the sprite half, which does not self-heal.
   @impl true
   def terminate(_reason, state) do
     Fountain.Conversations.Redaction.delete(state.conversation_id)
 
-    if state.conversation_id do
+    if state.conversation_id && state.callback_api_key_id do
       case Conversations._unsafe_get_conversation(state.conversation_id) do
-        %Conversation{user_id: user_id, callback_api_key_id: id}
-        when is_binary(user_id) and is_binary(id) ->
-          _ = Accounts.revoke_api_key(user_id, id)
+        %Conversation{user_id: user_id, callback_api_key_id: row_id}
+        when is_binary(user_id) and row_id == state.callback_api_key_id ->
+          _ = Accounts.revoke_api_key(user_id, state.callback_api_key_id)
 
         _ ->
           :ok
@@ -1344,12 +1384,20 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   # Issue a fresh per-conversation API key scoped to the conversation
-  # owner, revoking any prior one. The plaintext is only kept in
+  # owner, revoking the one THIS server previously minted (a re-provision
+  # or reattach within one server life). The plaintext is only kept in
   # `state.callback_token` — the durable record is a hash in `api_keys`,
   # which we can't reverse, so we rotate on every fresh provision /
   # reattach instead of trying to recover the old plaintext.
+  #
+  # Deliberately NOT revoking `conv.callback_api_key_id` when it isn't
+  # ours: with duplicate servers (registry lag, #367), the row's id can be
+  # the live credential of the other server's sprite — revoking it 401s
+  # every callback and sub-agent spawn there, surfaced nowhere. A
+  # predecessor's un-revoked key goes inert at its `expires_at` and its
+  # row is pruned by RetentionPruner.
   defp rotate_callback_api_key(state, %Conversation{} = conv) do
-    if id = conv.callback_api_key_id do
+    if id = state.callback_api_key_id do
       _ = Accounts.revoke_api_key(conv.user_id, id)
     end
 
@@ -1360,7 +1408,7 @@ defmodule Fountain.Conversations.ConversationServer do
          ) do
       {:ok, {%Accounts.ApiKey{id: key_id}, raw}} ->
         {:ok, conv} = Conversations.update_conversation(conv, %{callback_api_key_id: key_id})
-        {%{state | callback_token: raw}, conv}
+        {%{state | callback_token: raw, callback_api_key_id: key_id}, conv}
 
       {:error, cs} ->
         Logger.warning(

--- a/apps/fountain/lib/fountain/telemetry.ex
+++ b/apps/fountain/lib/fountain/telemetry.ex
@@ -108,10 +108,11 @@ defmodule Fountain.Telemetry do
     # to a name that never fires logs nothing and looks identical to healthy
     # silence (#310). Span names: ConversationServer wraps fresh_provision,
     # reattach and setup_script; Provisioning wraps packages, network_policy,
-    # clone_repositories and checkpoint create/restore.
+    # clone_repositories and checkpoint create/restore; Rehydrator wraps its
+    # post-boot sweep in rehydrate.
     spans =
       for stage <-
-            ~w(fresh_provision reattach setup_script packages network_policy clone_repositories)a,
+            ~w(fresh_provision reattach setup_script packages network_policy clone_repositories rehydrate)a,
           phase <- ~w(start stop exception)a,
           do: @prefix ++ [stage, phase]
 

--- a/apps/fountain/lib/fountain/workers/retention_pruner.ex
+++ b/apps/fountain/lib/fountain/workers/retention_pruner.ex
@@ -46,7 +46,9 @@ defmodule Fountain.Workers.RetentionPruner do
 
   @impl Oban.Worker
   def perform(_job) do
-    results = Enum.map(@defaults, fn {table, _} -> {table, prune(table)} end)
+    results =
+      Enum.map(@defaults, fn {table, _} -> {table, prune(table)} end) ++
+        [{:exports, Fountain.Exports.purge_expired()}]
 
     deleted = results |> Enum.map(&elem(&1, 1)) |> Enum.sum()
 
@@ -104,11 +106,21 @@ defmodule Fountain.Workers.RetentionPruner do
   end
 
   defp do_prune(:revoked_api_keys, cutoff) do
-    # Only revoked keys. An active key is never pruned no matter how old, since
-    # deleting one would silently break whoever is holding it.
+    # Revoked keys past the window, plus keys whose own expires_at is that
+    # far in the past. A key that is neither revoked nor expiring is never
+    # pruned no matter how old — deleting one would silently break whoever
+    # is holding it. The expires_at leg exists because every hard kill
+    # (SIGKILL on the pod, the provision watchdog) leaves an un-revoked
+    # sprite callback key behind: inert at expiry (auth enforces
+    # expires_at), but its row otherwise accumulated forever in the table
+    # every authenticated request looks up against.
     delete_where(
       "api_keys",
-      dynamic([r], not is_nil(r.revoked_at) and r.revoked_at < ^cutoff)
+      dynamic(
+        [r],
+        (not is_nil(r.revoked_at) and r.revoked_at < ^cutoff) or
+          (not is_nil(r.expires_at) and r.expires_at < ^cutoff)
+      )
     )
   end
 

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -150,6 +150,23 @@ defmodule FountainWeb.Telemetry do
         measurement: :count,
         description: "Untracked sprites currently running with no live sandbox row"
       ),
+      # The rehydrator sweep runs once per boot in an unsupervised Task; a
+      # crash reaches Sentry via the LoggerHandler, but a sweep that is
+      # SKIPPED (leader election) or finds work and starts nothing was
+      # invisible — and conversations not resumed after a deploy are exactly
+      # what it exists to prevent. last_value: one observation per boot.
+      # `:telemetry.span/3` carries the sweep's `{result, extra}` map as stop
+      # METADATA, not measurements — hence the measurement functions.
+      last_value("fountain.rehydrate.stop.candidates",
+        event_name: [:fountain, :rehydrate, :stop],
+        measurement: fn _measurements, metadata -> metadata[:candidates] || 0 end,
+        description: "Resumable conversations the last rehydrator sweep found"
+      ),
+      last_value("fountain.rehydrate.stop.started",
+        event_name: [:fountain, :rehydrate, :stop],
+        measurement: fn _measurements, metadata -> metadata[:started] || 0 end,
+        description: "ConversationServers the last rehydrator sweep started"
+      ),
 
       # ── Cost signals (#405) ───────────────────────────────────────────────
       # Both events fired into nothing before this: the provision watchdog

--- a/apps/fountain/priv/repo/migrations/20260803171945_index_log_events_inserted_at.exs
+++ b/apps/fountain/priv/repo/migrations/20260803171945_index_log_events_inserted_at.exs
@@ -1,0 +1,21 @@
+defmodule Fountain.Repo.Migrations.IndexLogEventsInsertedAt do
+  use Ecto.Migration
+
+  # The nightly RetentionPruner filters log_events — the largest table in the
+  # database — on inserted_at, which had no index: every batch of its delete
+  # loop re-ran a sequential scan, and a run that deletes nothing still
+  # scanned the whole table to find zero rows. audit_events and usage_events
+  # both already carry this index.
+  #
+  # Concurrent build so the write path (every byte of sandbox output) is not
+  # blocked while it runs; that requires running outside a transaction and
+  # without the migration lock, and makes the operation non-atomic — safe
+  # here because an index creation that fails halfway leaves an INVALID
+  # index to drop, not data loss.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index(:log_events, [:inserted_at], concurrently: true)
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_shutdown_revoke_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_shutdown_revoke_test.exs
@@ -47,4 +47,63 @@ defmodule Fountain.Conversations.ConversationServerShutdownRevokeTest do
 
     assert key_revoked?(conv.callback_api_key_id)
   end
+
+  test "a dying duplicate does not revoke the surviving server's key" do
+    # Horde's CRDT merge mass-terminates duplicate servers, and registry
+    # lag makes duplicates real (#367). The loser's terminate/2 used to
+    # read callback_api_key_id off the row at call time — revoking whatever
+    # key the WINNER had rotated in, so the surviving sprite 401'd on every
+    # callback and sub-agent spawn.
+    {pid, ref, conv} = start_provisioned_server()
+    losers_key = conv.callback_api_key_id
+
+    # A winner rotates: the row now points at a key this server did not mint.
+    {:ok, {%Fountain.Accounts.ApiKey{id: winners_key}, _raw}} =
+      Fountain.Accounts.create_api_key(
+        conv.user_id,
+        "sprite:winner",
+        Fountain.Conversations.ConversationServer.callback_api_key_opts()
+      )
+
+    {:ok, _} = Conversations.update_conversation(conv, %{callback_api_key_id: winners_key})
+
+    Process.exit(pid, :shutdown)
+    assert_stopped(ref)
+
+    refute key_revoked?(winners_key), "the loser revoked the winner's live credential"
+    # The loser's own key was already superseded by the winner's rotation;
+    # nothing revokes it here — it goes inert at expires_at and its row is
+    # pruned by RetentionPruner.
+    refute key_revoked?(losers_key)
+  end
+
+  test "provisioning does not revoke a predecessor's key it did not mint" do
+    # The reverse race: a second server starting during the registry-lag
+    # window used to revoke the row's key while rotating — pulling the live
+    # credential out from under the first server.
+    stub_happy_sprite()
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+
+    {:ok, {%Fountain.Accounts.ApiKey{id: predecessor_key}, _raw}} =
+      Fountain.Accounts.create_api_key(
+        user.id,
+        "sprite:first",
+        Fountain.Conversations.ConversationServer.callback_api_key_opts()
+      )
+
+    {:ok, _} = Conversations.update_conversation(conv, %{callback_api_key_id: predecessor_key})
+
+    {pid, _ref, :alive} = start_server(conv)
+
+    refute key_revoked?(predecessor_key),
+           "the second server revoked the first server's live credential"
+
+    reloaded = Conversations._unsafe_get_conversation!(conv.id)
+    assert is_binary(reloaded.callback_api_key_id)
+    assert reloaded.callback_api_key_id != predecessor_key
+
+    GenServer.stop(pid)
+  end
 end

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -416,6 +416,42 @@ defmodule Fountain.Conversations.ConversationServerTest do
       GenServer.stop(pid)
     end
 
+    test "a conversation deleted before provisioning stops the server instead of crash-looping", %{
+      conv: conv
+    } do
+      # This used to raise Ecto.NoResultsError out of
+      # handle_continue(:provision) — unrescued, restart: :transient, so
+      # Horde restarted it straight back into the same raise, burning the
+      # supervisor's SHARED restart budget until it terminated and took
+      # every conversation on the node with it.
+      {:ok, _} = Repo.delete(Repo.get!(Fountain.Conversations.Conversation, conv.id))
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          {_pid, ref, settled} = start_server(conv)
+          assert settled == :stopped
+          assert assert_stopped(ref) == :normal
+        end)
+
+      assert log =~ "row missing before provisioning"
+    end
+
+    test "a sandbox deleted before provisioning stops the server instead of crash-looping", %{
+      conv: conv,
+      sandbox: sandbox
+    } do
+      {:ok, _} = Repo.delete(Repo.get!(Fountain.Conversations.Sandbox, sandbox.id))
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          {_pid, ref, settled} = start_server(conv)
+          assert settled == :stopped
+          assert assert_stopped(ref) == :normal
+        end)
+
+      assert log =~ "row missing before provisioning"
+    end
+
     test "a spawn that never starts returns the conversation to idle", %{conv: conv} do
       # The conversation is set to "running" just before the spawn attempt.
       # Before this reset, a failed spawn marked the turn failed but left the

--- a/apps/fountain/test/fountain/workers/retention_pruner_test.exs
+++ b/apps/fountain/test/fountain/workers/retention_pruner_test.exs
@@ -142,6 +142,67 @@ defmodule Fountain.Workers.RetentionPrunerTest do
 
       assert Repo.get(Fountain.Accounts.ApiKey, key.id)
     end
+
+    test "prunes a long-expired key that nothing ever revoked" do
+      # Every hard kill (SIGKILL on the pod, the provision watchdog) leaves
+      # an un-revoked sprite callback key behind. It goes inert at
+      # expires_at — auth enforces expiry — but its row used to stay
+      # forever in the table every authenticated request looks up against.
+      user = insert_verified_user()
+      {key, _raw} = insert_api_key(user, "orphaned-sprite-key")
+
+      {:ok, _} =
+        key
+        |> Ecto.Changeset.change(expires_at: days_ago(60))
+        |> Repo.update()
+
+      with_windows([revoked_api_keys: 30], fn ->
+        assert RetentionPruner.prune(:revoked_api_keys) == 1
+      end)
+
+      refute Repo.get(Fountain.Accounts.ApiKey, key.id)
+    end
+
+    test "keeps an expired-but-recent key inside the window" do
+      # The window is grace time: a just-expired key may still matter for
+      # debugging ("why did the sprite 401?").
+      user = insert_verified_user()
+      {key, _raw} = insert_api_key(user, "freshly-expired")
+
+      {:ok, _} =
+        key
+        |> Ecto.Changeset.change(expires_at: days_ago(2))
+        |> Repo.update()
+
+      with_windows([revoked_api_keys: 30], fn ->
+        assert RetentionPruner.prune(:revoked_api_keys) == 0
+      end)
+
+      assert Repo.get(Fountain.Accounts.ApiKey, key.id)
+    end
+  end
+
+  describe "exports" do
+    test "perform/1 purges expired export payloads" do
+      # Exports.purge_expired/0 used to have exactly one production call
+      # site — the first line of the next export request. After the last
+      # export on an instance, every expired gzipped payload sat in
+      # Postgres indefinitely.
+      user = insert_verified_user()
+
+      {:ok, export} =
+        %Fountain.Exports.Export{
+          user_id: user.id,
+          status: "completed",
+          payload: :zlib.gzip("data"),
+          expires_at: days_ago(3)
+        }
+        |> Repo.insert()
+
+      assert :ok = perform_job(RetentionPruner, %{})
+
+      refute Repo.get(Fountain.Exports.Export, export.id)
+    end
   end
 
   describe "usage_events" do

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -113,6 +113,11 @@ defmodule FountainWeb.MetricsTest do
         # Fountain.Telemetry.span/3 callers
         [:fountain, :fresh_provision, :stop],
         [:fountain, :reattach, :stop],
+        # Rehydrator.sweep/0 wraps its post-boot sweep in this span; the
+        # candidates/started numbers ride the stop event's METADATA (a
+        # 2-tuple span return), which is why the metrics use measurement
+        # functions.
+        [:fountain, :rehydrate, :stop],
         # :telemetry.execute call sites
         [:fountain, :sandbox, :reclaimed],
         [:fountain, :reaper, :run],

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -30,12 +30,26 @@ spec:
       labels:
         app: fountain
     spec:
+      # ConversationServers trap exits so terminate/2 can revoke each
+      # sprite's callback key on the way down (#322); with many live
+      # conversations that teardown can outrun the 30s default, after which
+      # SIGKILL leaves un-revoked keys and orphaned sprites for the reaper.
+      terminationGracePeriodSeconds: 120
       containers:
         - name: fountain
           # Retagged by kustomization.yaml's images: block — edit the pin
           # there, not here.
           image: ghcr.io/binarybourbon/fountain:v0.3.0
           imagePullPolicy: IfNotPresent
+          lifecycle:
+            # Endpoints propagation is asynchronous: without this pause the
+            # pod stops accepting while kube-proxy/ingress still route to
+            # it, dropping SSE streams mid-conversation. Sleep long enough
+            # for the Endpoints update to reach the dataplane, then let the
+            # BEAM shut down.
+            preStop:
+              exec:
+                command: ["sleep", "5"]
           ports:
             - name: http
               containerPort: 4000

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -18,6 +18,9 @@ resources:
   # Generic alerts. Needs the PrometheusRule CRD (prometheus-operator) and a
   # scrape of the metrics port — see the notes at the top of the file.
   # - prometheusrule.yaml
+  # Keeps one replica serving through node drains. Only enable together with
+  # replicas: 2+ — at the base's single replica it blocks drains outright.
+  # - pdb.yaml
 
 images:
   # Pin a release, not `latest` — `latest` moves on every merge to main.

--- a/deploy/k8s/pdb.yaml
+++ b/deploy/k8s/pdb.yaml
@@ -1,0 +1,20 @@
+# Keeps at least one replica serving through voluntary disruptions — node
+# drains, cluster upgrades. Without it a drain can evict every replica at
+# once: the Deployment's maxUnavailable: 0 governs rollouts only, not
+# evictions.
+#
+# Only meaningful at 2+ replicas: with the base's single replica this PDB
+# makes the pod un-evictable and blocks node drains outright, which is why it
+# is commented out of kustomization.yaml. Enable it together with a replica
+# bump (and the Erlang clustering that requires — see the hosted overlay).
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: fountain
+  labels:
+    app: fountain
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: fountain

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -32,6 +32,9 @@ resources:
   - prometheusrule.yaml
   - ingressroute.yaml
   - certificate.yaml
+  # Two replicas: a node drain must not take both at once (maxUnavailable: 0
+  # governs rollouts, not evictions).
+  - pdb.yaml
 
 patches:
   # The production Deployment: clustering env, Infisical auto-reload, two

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,16 @@
+# Keeps at least one replica serving through voluntary disruptions — node
+# drains, cluster upgrades. Without it a drain can evict both replicas at
+# once: the Deployment's maxUnavailable: 0 governs rollouts only, not
+# evictions.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: fountain
+  namespace: fountain
+  labels:
+    app: fountain
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: fountain


### PR DESCRIPTION
Fixes the seven findings in #408.

## Lifecycle races
**1. Callback-key revocation is per-server.** `ConversationServer` state gains `callback_api_key_id` — the key THIS server minted. Rotation revokes only the server's own previous key; `terminate/2` revokes its own key only while the conversation row still points at it. A dying Horde-dedup loser can no longer revoke the surviving server's live credential (sprite 401s on every callback, surfaced nowhere), and a second server starting during registry lag no longer rotates the key out from under the first. A predecessor's un-revoked key goes inert at `expires_at` and is pruned by the RetentionPruner change below. Two new tests drive real servers through both directions of the race; both fail against the old code.

**2. Restart budget + provision guard.** `ConversationSupervisor` sets `max_restarts: 100, max_seconds: 10` instead of Horde's default 3-in-5s — a budget shared by every conversation on the node, whose exhaustion terminates all of them. The known deterministic burner is also closed: `handle_continue(:provision)` fetches its rows non-bang and stops `:normal` (with a log line) when the conversation or sandbox was deleted before it ran; a deleted agent provisions without one instead of raising. Tests pin both stop paths.

## Unbounded growth
**3.** `log_events(inserted_at)` index, built `concurrently` (`@disable_ddl_transaction` + `@disable_migration_lock`) so the write path isn't blocked.
**4.** `RetentionPruner.perform/1` calls `Exports.purge_expired/0` every nightly run — previously its only production call site was the first line of the *next* export request.
**5.** The api_keys predicate becomes `revoked_at < cutoff OR expires_at < cutoff`. A never-revoked key with no expiry is still never pruned; tests cover the orphaned-expired case, the freshly-expired grace window, and the existing never-prune-active invariant.

## Deploy and visibility
**6.** `terminationGracePeriodSeconds: 120` + `preStop: sleep 5` land in the shared deployment base (`deploy/k8s`, inherited by the hosted patch). A `PodDisruptionBudget` (`minAvailable: 1`) is wired into the hosted manifests (2 replicas) and shipped **commented-out** in the portable base — at its 1-replica default a PDB would block node drains outright, so it's documented to enable with a replica bump. Both kustomizations build clean.
**7.** `[:fountain, :rehydrate]` joins the telemetry logger's span list, and `fountain.rehydrate.stop.{candidates,started}` are exported as `last_value` gauges. One subtlety: `:telemetry.span/3` carries the sweep's `{result, extra}` as stop **metadata**, not measurements, so the metrics use arity-2 measurement functions — a plain `measurement: :candidates` would silently never record. The metrics guard test (the #310 producer allowlist) gets the new event registered with a note.

Not changed: the `Task.start` launch of the rehydrator stays — a crash already reaches Sentry via the LoggerHandler, and the gauges now make a skipped/empty sweep visible, which was the invisible case.

Revert-verified: 6 failures with the server + pruner fixes stashed. Full suite 1,849 green.

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)