### PR TITLE
auth: resend-verification route, durable verification email, welcome email (#445, #449)

### DIFF
--- a/apps/fountain/lib/fountain/emails/user_emails.ex
+++ b/apps/fountain/lib/fountain/emails/user_emails.ex
@@ -3,7 +3,8 @@ defmodule Fountain.Emails.UserEmails do
   Swoosh email templates for user-facing transactional emails.
 
   Sends:
-  - Email verification (24 h token)
+  - Email verification (24 h token, from `Workers.VerificationEmail`)
+  - Welcome (once, on the verification transition, from `Workers.WelcomeEmail`)
   - Password reset (1 h token)
   - Trial ending (3 days out, from Stripe's trial_will_end)
   - Trial expired / payment failed / subscription cancelled
@@ -33,6 +34,37 @@ defmodule Fountain.Emails.UserEmails do
     |> subject("Verify your Fountain account")
     |> html_body(verification_html(verify_url))
     |> text_body(verification_text(verify_url))
+    |> Mailer.deliver()
+  end
+
+  @doc """
+  Welcome a just-verified user (#449).
+
+  The first email that isn't a chore: everything before it is a verification
+  link and everything after it is billing. Says what to do next (the
+  onboarding wizard) and, for trialing accounts, when the trial ends — the
+  same phrasing `deliver_trial_ending_email/2` will use later, so the two
+  emails agree on the date.
+  """
+  @spec deliver_welcome_email(User.t()) :: {:ok, term()} | {:error, term()}
+  def deliver_welcome_email(%User{} = user) do
+    base_url = Fountain.PublicUrl.base()
+
+    start_url =
+      if user.onboarding_completed_at do
+        base_url
+      else
+        "#{base_url}/onboarding/step_1"
+      end
+
+    trial_text = welcome_trial_phrase(user)
+
+    new()
+    |> from(from_address())
+    |> to({user.email, user.email})
+    |> subject("Welcome to Fountain")
+    |> html_body(welcome_html(start_url, trial_text))
+    |> text_body(welcome_text(start_url, trial_text))
     |> Mailer.deliver()
   end
 
@@ -166,6 +198,51 @@ defmodule Fountain.Emails.UserEmails do
       1 -> "tomorrow (#{date})"
       d -> "in #{d} days (#{date})"
     end
+  end
+
+  defp welcome_trial_phrase(%User{subscription_status: "trialing", trial_ends_at: %DateTime{} = at}),
+    do: "Your free trial ends #{ends_at_phrase(at)} — no card needed until then."
+
+  defp welcome_trial_phrase(_user), do: nil
+
+  defp welcome_html(start_url, trial_text) do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>Welcome to Fountain</h2>
+      <p>
+        Your account is verified and ready. Set up an agent, give it an
+        environment, and start a conversation — it runs in an isolated sandbox
+        and streams back live.
+      </p>
+      <p style="margin: 32px 0;">
+        <a href="#{start_url}"
+           style="background: #18181b; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-size: 14px;">
+          Get started
+        </a>
+      </p>
+      #{if trial_text, do: "<p>#{trial_text}</p>", else: ""}
+      <p style="color: #71717a; font-size: 13px;">
+        Or copy this link into your browser:<br/>
+        <a href="#{start_url}" style="color: #3b82f6;">#{start_url}</a>
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp welcome_text(start_url, trial_text) do
+    """
+    Welcome to Fountain
+
+    Your account is verified and ready. Set up an agent, give it an
+    environment, and start a conversation — it runs in an isolated sandbox
+    and streams back live:
+
+    #{start_url}
+    #{if trial_text, do: "\n#{trial_text}\n", else: ""}
+    """
   end
 
   defp trial_ending_html(billing_url, when_text) do

--- a/apps/fountain/lib/fountain/workers/verification_email.ex
+++ b/apps/fountain/lib/fountain/workers/verification_email.ex
@@ -1,0 +1,76 @@
+defmodule Fountain.Workers.VerificationEmail do
+  @moduledoc """
+  Sends the email-verification link as a durable job (#445).
+
+  Registration used to send this with a bare `Task.async` and no `await`. The
+  task was *linked* to the request process, so finishing the HTTP response
+  could kill an in-flight send, and a delivery error had no retry and no log —
+  the same failure mode `Workers.StripeCustomerSync` was extracted for, one
+  step earlier in the funnel. This one was worse: with no resend route, a
+  dropped verification email left the account permanently unusable until the
+  `UnverifiedAccountPruner` deleted it.
+
+  The token is signed in `perform/1`, not at enqueue time. Job args are stored
+  in `oban_jobs`, so a token minted at enqueue would sit in the database in
+  plaintext, and by the time a retried job finally delivered it could be well
+  into its 24 h TTL. Each attempt sends a fresh, full-TTL link instead.
+  """
+
+  # fields must include :worker: other workers take the same %{user_id: ...}
+  # args, and a [:args]-only uniqueness key would swallow this job as a
+  # duplicate of theirs (WelcomeEmail found this the hard way).
+  use Oban.Worker,
+    queue: :mailer,
+    max_attempts: 5,
+    unique: [period: 60, fields: [:worker, :args]]
+
+  require Logger
+
+  alias Fountain.{Accounts, Emails.UserEmails}
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
+    case Accounts.get_user(user_id) do
+      nil ->
+        # Deleted between enqueue and execution. Nothing to do, and retrying
+        # will not bring them back.
+        Logger.info("verification_email: user #{user_id} no longer exists")
+        :ok
+
+      %{email_verified_at: %DateTime{}} ->
+        # Verified in the meantime — usually a resend racing the click on the
+        # original link. The email would only say "already verified".
+        :ok
+
+      user ->
+        token = Phoenix.Token.sign(FountainWeb.Endpoint, "email_verification", user.id)
+
+        case UserEmails.deliver_verification_email(user, token) do
+          {:ok, _} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning(
+              "verification_email: delivery failed for #{user.id}: #{inspect(reason)}"
+            )
+
+            {:error, reason}
+        end
+    end
+  end
+
+  @doc """
+  Enqueue a verification email for `user`.
+
+  Unique per user for 60 seconds, so a double-submitted resend form (or a
+  request retry) collapses into one email without blocking a genuine resend
+  a few minutes later.
+  """
+  def enqueue(%Accounts.User{id: id}), do: enqueue(id)
+
+  def enqueue(user_id) when is_binary(user_id) do
+    %{user_id: user_id}
+    |> new()
+    |> Oban.insert()
+  end
+end

--- a/apps/fountain/lib/fountain/workers/welcome_email.ex
+++ b/apps/fountain/lib/fountain/workers/welcome_email.ex
@@ -1,0 +1,63 @@
+defmodule Fountain.Workers.WelcomeEmail do
+  @moduledoc """
+  Sends the welcome email once a user's address is verified (#449).
+
+  Enqueued only on the verification *transition* — the unverified branch of
+  `EmailVerificationController.confirm/2` and the brand-new-user branch of the
+  OAuth callback. Both fire at most once in an account's life, so once-per-user
+  is structural; the `unique` window is the belt for a retried request. The
+  "already verified" confirm branch deliberately does not enqueue, which is
+  also what keeps accounts that predate this worker from being welcomed months
+  after they signed up.
+  """
+
+  # fields must include :worker — StripeCustomerSync is enqueued in the same
+  # request with byte-identical args (%{user_id: ...}), and a [:args]-only
+  # uniqueness key silently swallows this job as its duplicate.
+  use Oban.Worker,
+    queue: :mailer,
+    max_attempts: 5,
+    unique: [period: :infinity, fields: [:worker, :args]]
+
+  require Logger
+
+  alias Fountain.{Accounts, Emails.UserEmails}
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
+    case Accounts.get_user(user_id) do
+      nil ->
+        # Deleted between enqueue and execution. Nothing to do, and retrying
+        # will not bring them back.
+        Logger.info("welcome_email: user #{user_id} no longer exists")
+        :ok
+
+      %{email_verified_at: nil} = user ->
+        # Both enqueue sites run after verification, so this shouldn't happen —
+        # but a welcome email must never be the thing that confirms an
+        # unverified address exists.
+        Logger.warning("welcome_email: user #{user.id} is not verified, skipping")
+        :ok
+
+      user ->
+        case UserEmails.deliver_welcome_email(user) do
+          {:ok, _} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning("welcome_email: delivery failed for #{user.id}: #{inspect(reason)}")
+
+            {:error, reason}
+        end
+    end
+  end
+
+  @doc "Enqueue the welcome email for `user`. At most one per user, ever."
+  def enqueue(%Accounts.User{id: id}), do: enqueue(id)
+
+  def enqueue(user_id) when is_binary(user_id) do
+    %{user_id: user_id}
+    |> new()
+    |> Oban.insert()
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
@@ -48,6 +48,10 @@ defmodule FountainWeb.EmailVerificationController do
                 # leaving an account with no customer id.
                 Fountain.Workers.StripeCustomerSync.enqueue(verified_user)
 
+                # Only on this branch, never the already-verified one below —
+                # the welcome fires on the verification transition (#449).
+                Fountain.Workers.WelcomeEmail.enqueue(verified_user)
+
                 conn
                 |> log_in_user(verified_user)
                 |> redirect(to: ~p"/onboarding/step_1")

--- a/apps/fountain/lib/fountain_web/controllers/registration_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/registration_controller.ex
@@ -4,17 +4,32 @@ defmodule FountainWeb.RegistrationController do
   - HTML form: GET/POST /auth/register
   - JSON API:  POST /api/auth/register
 
-  Rate-limited to 5 registrations per IP per hour.
+  and verification-email resend (#445):
+  - HTML form: GET/POST /auth/resend-verification
+  - JSON API:  POST /api/auth/resend-verification
+
+  Registration is rate-limited to 5 per IP per hour; resend to 5 per IP per
+  hour in its own bucket, so a stuck user retrying resend does not burn their
+  registration budget (or vice versa).
+
+  The verification email goes through `Workers.VerificationEmail`, not an
+  inline send — it used to be a linked `Task.async` that the finishing request
+  could kill, and a dropped send here was unrecoverable before the resend
+  route existed.
   """
 
   use FountainWeb, :controller
 
   alias Fountain.Accounts
-  alias Fountain.Emails.UserEmails
+  alias Fountain.Workers.VerificationEmail
 
   plug FountainWeb.Plugs.RateLimit,
        [bucket: "registration", max: 5, window_ms: 3_600_000]
        when action in [:create, :api_create]
+
+  plug FountainWeb.Plugs.RateLimit,
+       [bucket: "resend_verification", max: 5, window_ms: 3_600_000]
+       when action in [:resend, :api_resend]
 
   ## HTML path
 
@@ -29,8 +44,7 @@ defmodule FountainWeb.RegistrationController do
   def create(conn, %{"user" => user_params}) do
     case Accounts.register_user(user_params) do
       {:ok, user} ->
-        token = generate_verification_token(conn, user)
-        Task.async(fn -> UserEmails.deliver_verification_email(user, token) end)
+        VerificationEmail.enqueue(user)
 
         conn
         |> put_flash(:info, "Account created! Check your email to verify your address.")
@@ -58,13 +72,26 @@ defmodule FountainWeb.RegistrationController do
 
   defp registration_message(_), do: "Registration is not available."
 
+  ## HTML — resend verification
+
+  def resend_form(conn, _params) do
+    render(conn, :resend_form, layout: false)
+  end
+
+  def resend(conn, params) do
+    maybe_resend(params["email"])
+
+    conn
+    |> put_flash(:info, resend_message())
+    |> redirect(to: ~p"/auth/check-email")
+  end
+
   ## JSON path
 
   def api_create(conn, %{"email" => _, "password" => _} = params) do
     case Accounts.register_user(params) do
       {:ok, user} ->
-        token = generate_verification_token(conn, user)
-        Task.async(fn -> UserEmails.deliver_verification_email(user, token) end)
+        VerificationEmail.enqueue(user)
 
         conn
         |> put_status(:created)
@@ -92,9 +119,30 @@ defmodule FountainWeb.RegistrationController do
     |> json(%{error: "email and password are required"})
   end
 
+  def api_resend(conn, params) do
+    maybe_resend(params["email"])
+
+    conn
+    |> put_status(:ok)
+    |> json(%{message: resend_message()})
+  end
+
   ## Helpers
 
-  defp generate_verification_token(conn, user) do
-    Phoenix.Token.sign(conn, "email_verification", user.id)
+  # Always the same response whether the address is unknown, unverified, or
+  # already verified — same anti-enumeration contract as the password-reset
+  # request. A verified account gets nothing: the email would only say
+  # "already verified", and sending it would make this an account oracle for
+  # anyone watching their own inbox timing.
+  defp maybe_resend(email) when is_binary(email) do
+    case Accounts.get_user_by_email(email) do
+      %{email_verified_at: nil} = user -> VerificationEmail.enqueue(user)
+      _ -> :ok
+    end
   end
+
+  defp maybe_resend(_), do: :ok
+
+  defp resend_message,
+    do: "If that address needs verification, a new email is on its way."
 end

--- a/apps/fountain/lib/fountain_web/controllers/registration_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/registration_html.ex
@@ -90,9 +90,47 @@ defmodule FountainWeb.RegistrationHTML do
         </p>
         <p class="text-xs text-zinc-400">
           Didn't receive it? Check your spam folder or
-          <a href="/auth/resend-verification" class="underline">resend the email</a>.
+          <a href={~p"/auth/resend-verification"} class="underline">resend the email</a>.
         </p>
       </div>
+    </div>
+    """
+  end
+
+  def resend_form(assigns) do
+    ~H"""
+    <div class="min-h-screen flex items-center justify-center bg-zinc-50 text-zinc-900 font-sans">
+      <form
+        method="post"
+        action={~p"/auth/resend-verification"}
+        class="w-full max-w-sm bg-white rounded-lg shadow p-8 space-y-4"
+      >
+        <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
+        <div>
+          <h1 class="text-xl font-semibold">Resend verification email</h1>
+          <p class="text-sm text-zinc-500">
+            Enter your email and we'll send a fresh verification link. Links
+            expire after 24 hours.
+          </p>
+        </div>
+        <input
+          type="email"
+          name="email"
+          placeholder="you@example.com"
+          autocomplete="email"
+          autofocus
+          class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-400"
+        />
+        <button
+          type="submit"
+          class="w-full rounded-md bg-zinc-900 text-white py-2 text-sm font-medium hover:bg-zinc-800"
+        >
+          Send verification link
+        </button>
+        <p class="text-center text-sm text-zinc-400">
+          <a href={~p"/auth/login"} class="underline">Back to sign in</a>
+        </p>
+      </form>
     </div>
     """
   end

--- a/apps/fountain/lib/fountain_web/controllers/session_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/session_html.ex
@@ -41,7 +41,13 @@ defmodule FountainWeb.SessionHTML do
               autocomplete="current-password"
               class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-400"
             />
-            <div class="text-right mt-1">
+            <div class="flex justify-between mt-1">
+              <a
+                href={~p"/auth/resend-verification"}
+                class="text-xs text-zinc-400 hover:underline"
+              >
+                Resend verification email
+              </a>
               <a href={~p"/auth/forgot-password"} class="text-xs text-zinc-400 hover:underline">
                 Forgot password?
               </a>

--- a/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
@@ -82,6 +82,10 @@ defmodule FountainWeb.UeberauthController do
         # this every GitHub signup had no Stripe customer and no trial_ends_at.
         Fountain.Workers.StripeCustomerSync.enqueue(user)
 
+        # Same reasoning for the welcome email (#449): an OAuth signup is
+        # created verified, so this is its verification transition.
+        Fountain.Workers.WelcomeEmail.enqueue(user)
+
         conn
         |> configure_session(renew: true)
         |> put_session(:user_id, user.id)

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -133,6 +133,9 @@ defmodule FountainWeb.Router do
     post "/register", RegistrationController, :create
     get "/check-email", RegistrationController, :check_email
 
+    get "/resend-verification", RegistrationController, :resend_form
+    post "/resend-verification", RegistrationController, :resend
+
     get "/forgot-password", PasswordResetController, :forgot_form
     get "/reset/:token", PasswordResetController, :reset_form
     post "/reset", PasswordResetController, :reset
@@ -155,6 +158,7 @@ defmodule FountainWeb.Router do
 
     post "/token", AuthTokenController, :create
     post "/register", RegistrationController, :api_create
+    post "/resend-verification", RegistrationController, :api_resend
     post "/forgot", PasswordResetController, :api_forgot
   end
 

--- a/apps/fountain/test/fountain/emails/user_emails_test.exs
+++ b/apps/fountain/test/fountain/emails/user_emails_test.exs
@@ -40,6 +40,36 @@ defmodule Fountain.Emails.UserEmailsTest do
     end
   end
 
+  describe "deliver_welcome_email/1" do
+    test "welcomes the user with an onboarding link" do
+      user = insert_verified_user()
+
+      assert {:ok, _email} = UserEmails.deliver_welcome_email(user)
+
+      assert_email_sent(fn email ->
+        assert email.subject == "Welcome to Fountain"
+        assert email.to == [{user.email, user.email}]
+        assert email.html_body =~ "/onboarding/step_1"
+        assert email.text_body =~ "/onboarding/step_1"
+      end)
+    end
+
+    test "links to the dashboard instead once onboarding is complete" do
+      user = insert_verified_user()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      {:ok, user} =
+        user |> Ecto.Changeset.change(onboarding_completed_at: now) |> Repo.update()
+
+      assert {:ok, _email} = UserEmails.deliver_welcome_email(user)
+
+      assert_email_sent(fn email ->
+        refute email.text_body =~ "/onboarding"
+        assert email.subject == "Welcome to Fountain"
+      end)
+    end
+  end
+
   describe "link absoluteness" do
     # These assert on the scheme, not just the path. The original tests only
     # checked "/users/confirm/<token>", which passed happily while production

--- a/apps/fountain/test/fountain/workers/verification_email_test.exs
+++ b/apps/fountain/test/fountain/workers/verification_email_test.exs
@@ -1,0 +1,64 @@
+defmodule Fountain.Workers.VerificationEmailTest do
+  use Fountain.DataCase, async: true
+
+  import Swoosh.TestAssertions
+
+  alias Fountain.Workers.VerificationEmail
+
+  describe "perform/1" do
+    test "sends a verification email whose token the confirm route will accept" do
+      user = insert_user()
+
+      assert :ok = perform_job(VerificationEmail, %{"user_id" => user.id})
+
+      assert_email_sent(fn email ->
+        assert email.subject == "Verify your Fountain account"
+        assert email.to == [{user.email, user.email}]
+
+        # The worker signs the token itself (there is no conn in a job), so
+        # prove the artifact it mails is one the controller's verify will take.
+        [_, token] = Regex.run(~r{/users/confirm/([A-Za-z0-9_\-\.]+)}, email.text_body)
+
+        assert {:ok, user.id} ==
+                 Phoenix.Token.verify(FountainWeb.Endpoint, "email_verification", token,
+                   max_age: 86_400
+                 )
+      end)
+    end
+
+    test "each attempt signs a fresh token rather than reusing one from enqueue time" do
+      user = insert_user()
+
+      assert {:ok, job} = VerificationEmail.enqueue(user)
+
+      # No token in the stored args — nothing secret at rest in oban_jobs,
+      # and a retry days later cannot deliver a nearly-expired link.
+      assert job.args == %{user_id: user.id}
+    end
+
+    test "is a no-op for a user who verified in the meantime" do
+      user = insert_verified_user()
+
+      assert :ok = perform_job(VerificationEmail, %{"user_id" => user.id})
+
+      assert_no_email_sent()
+    end
+
+    test "is a no-op for a deleted user" do
+      assert :ok = perform_job(VerificationEmail, %{"user_id" => Ecto.UUID.generate()})
+
+      assert_no_email_sent()
+    end
+  end
+
+  describe "enqueue/1 uniqueness" do
+    test "a double-submitted resend collapses into one job" do
+      user = insert_user()
+
+      assert {:ok, %Oban.Job{conflict?: false}} = VerificationEmail.enqueue(user)
+      assert {:ok, %Oban.Job{conflict?: true}} = VerificationEmail.enqueue(user)
+
+      assert [_only_one] = all_enqueued(worker: VerificationEmail)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/workers/welcome_email_test.exs
+++ b/apps/fountain/test/fountain/workers/welcome_email_test.exs
@@ -1,0 +1,72 @@
+defmodule Fountain.Workers.WelcomeEmailTest do
+  use Fountain.DataCase, async: true
+
+  import Swoosh.TestAssertions
+
+  alias Fountain.Workers.WelcomeEmail
+
+  describe "perform/1" do
+    test "welcomes a verified user and points at the onboarding wizard" do
+      user = insert_verified_user()
+      assert is_nil(user.onboarding_completed_at)
+
+      assert :ok = perform_job(WelcomeEmail, %{"user_id" => user.id})
+
+      assert_email_sent(fn email ->
+        assert email.subject == "Welcome to Fountain"
+        assert email.to == [{user.email, user.email}]
+        assert email.text_body =~ "/onboarding/step_1"
+      end)
+    end
+
+    test "tells a trialing user when the trial ends" do
+      user = insert_verified_user()
+      assert user.subscription_status == "trialing"
+      assert %DateTime{} = user.trial_ends_at
+
+      assert :ok = perform_job(WelcomeEmail, %{"user_id" => user.id})
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ "free trial ends"
+      end)
+    end
+
+    test "omits trial copy for a non-trialing account" do
+      user = insert_verified_user()
+      {:ok, _} = user |> Ecto.Changeset.change(subscription_status: "comped") |> Repo.update()
+
+      assert :ok = perform_job(WelcomeEmail, %{"user_id" => user.id})
+
+      assert_email_sent(fn email ->
+        refute email.text_body =~ "free trial"
+        assert email.subject == "Welcome to Fountain"
+      end)
+    end
+
+    test "never emails an unverified address" do
+      user = insert_user()
+      assert is_nil(user.email_verified_at)
+
+      assert :ok = perform_job(WelcomeEmail, %{"user_id" => user.id})
+
+      assert_no_email_sent()
+    end
+
+    test "is a no-op for a deleted user" do
+      assert :ok = perform_job(WelcomeEmail, %{"user_id" => Ecto.UUID.generate()})
+
+      assert_no_email_sent()
+    end
+  end
+
+  describe "enqueue/1 uniqueness" do
+    test "at most one welcome job per user, ever" do
+      user = insert_verified_user()
+
+      assert {:ok, %Oban.Job{conflict?: false}} = WelcomeEmail.enqueue(user)
+      assert {:ok, %Oban.Job{conflict?: true}} = WelcomeEmail.enqueue(user)
+
+      assert [_only_one] = all_enqueued(worker: WelcomeEmail)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/email_verification_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/email_verification_controller_test.exs
@@ -1,9 +1,11 @@
 defmodule FountainWeb.EmailVerificationControllerTest do
   use FountainWeb.ConnCase, async: true
+  use Oban.Testing, repo: Fountain.Repo
   use Mimic
 
   alias Fountain.Accounts
   alias Fountain.Repo
+  alias Fountain.Workers.WelcomeEmail
 
   describe "GET /users/confirm/:token" do
     test "verifies email, sets session, and redirects to onboarding for new user", %{conn: conn} do
@@ -19,6 +21,18 @@ defmodule FountainWeb.EmailVerificationControllerTest do
       # User should be verified in DB
       updated = Accounts.get_user!(user.id)
       refute is_nil(updated.email_verified_at)
+
+      # The welcome email rides the verification transition (#449)
+      assert_enqueued(worker: WelcomeEmail, args: %{user_id: user.id})
+    end
+
+    test "does not enqueue a welcome email for an already-verified user (#449)", %{conn: conn} do
+      user = insert_verified_user()
+
+      token = Phoenix.Token.sign(FountainWeb.Endpoint, "email_verification", user.id)
+      get(conn, ~p"/users/confirm/#{token}")
+
+      refute_enqueued(worker: WelcomeEmail)
     end
 
     test "redirects already-verified user without onboarding_completed_at to onboarding", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/controllers/oauth_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/oauth_controller_test.exs
@@ -7,6 +7,7 @@ defmodule FountainWeb.UeberauthControllerTest do
   """
 
   use FountainWeb.ConnCase, async: true
+  use Oban.Testing, repo: Fountain.Repo
   use Mimic
 
   alias Fountain.Accounts
@@ -82,6 +83,21 @@ defmodule FountainWeb.UeberauthControllerTest do
       assert identity
       assert identity.provider_uid == to_string(auth.uid)
     end
+
+    test "enqueues the welcome email — OAuth signup is the verification transition (#449)", %{
+      conn: conn
+    } do
+      auth = github_auth("github_welcome_#{System.unique_integer()}@example.com")
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> assign_auth(auth)
+        |> get(~p"/auth/oauth/github/callback")
+
+      user_id = get_session(conn, :user_id)
+      assert_enqueued(worker: Fountain.Workers.WelcomeEmail, args: %{user_id: user_id})
+    end
   end
 
   describe "callback/2 — success (existing user)" do
@@ -97,6 +113,20 @@ defmodule FountainWeb.UeberauthControllerTest do
 
       assert redirected_to(conn) == ~p"/conversations"
       assert get_session(conn, :user_id) == user.id
+    end
+
+    test "does not enqueue a welcome email — login is not a verification transition (#449)", %{
+      conn: conn
+    } do
+      user = insert_verified_user()
+      auth = github_auth(user.email, "gh_existing_#{System.unique_integer()}")
+
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> assign_auth(auth)
+      |> get(~p"/auth/oauth/github/callback")
+
+      refute_enqueued(worker: Fountain.Workers.WelcomeEmail)
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/registration_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/registration_controller_test.exs
@@ -1,6 +1,9 @@
 defmodule FountainWeb.RegistrationControllerTest do
   use FountainWeb.ConnCase, async: true
+  use Oban.Testing, repo: Fountain.Repo
   use Mimic
+
+  alias Fountain.Workers.VerificationEmail
 
   describe "GET /auth/register" do
     test "renders registration form", %{conn: conn} do
@@ -31,6 +34,17 @@ defmodule FountainWeb.RegistrationControllerTest do
         })
 
       assert redirected_to(conn) == ~p"/auth/check-email"
+    end
+
+    test "enqueues the verification email as a durable job, not an inline send (#445)", %{
+      conn: conn
+    } do
+      post(conn, ~p"/auth/register", %{
+        "user" => %{"email" => "durable@example.com", "password" => "password123"}
+      })
+
+      user = Fountain.Accounts.get_user_by_email("durable@example.com")
+      assert_enqueued(worker: VerificationEmail, args: %{user_id: user.id})
     end
 
     test "re-renders form with errors on invalid email", %{conn: conn} do
@@ -71,6 +85,8 @@ defmodule FountainWeb.RegistrationControllerTest do
         |> post("/api/auth/register", Jason.encode!(%{email: "json@example.com", password: "password123"}))
 
       assert json_response(conn, 201)["message"] =~ "verify"
+      user = Fountain.Accounts.get_user_by_email("json@example.com")
+      assert_enqueued(worker: VerificationEmail, args: %{user_id: user.id})
     end
 
     test "returns 422 on missing password", %{conn: conn} do
@@ -98,6 +114,90 @@ defmodule FountainWeb.RegistrationControllerTest do
     test "renders the check-email page", %{conn: conn} do
       conn = get(conn, ~p"/auth/check-email")
       assert html_response(conn, 200) =~ ~r/email/i
+    end
+  end
+
+  describe "GET /auth/resend-verification" do
+    test "renders the resend form", %{conn: conn} do
+      conn = get(conn, ~p"/auth/resend-verification")
+      assert html_response(conn, 200) =~ "Resend verification email"
+    end
+  end
+
+  describe "POST /auth/resend-verification" do
+    test "enqueues a fresh verification email for an unverified account", %{conn: conn} do
+      user = insert_user()
+      assert is_nil(user.email_verified_at)
+
+      conn = post(conn, ~p"/auth/resend-verification", %{"email" => user.email})
+
+      assert redirected_to(conn) == ~p"/auth/check-email"
+      assert_enqueued(worker: VerificationEmail, args: %{user_id: user.id})
+    end
+
+    # The next three must be indistinguishable from the success case — the
+    # endpoint takes an unauthenticated email address, so any difference in
+    # response makes it an account-existence oracle.
+    test "responds identically for an already-verified account, without enqueueing", %{
+      conn: conn
+    } do
+      user = insert_verified_user()
+
+      conn = post(conn, ~p"/auth/resend-verification", %{"email" => user.email})
+
+      assert redirected_to(conn) == ~p"/auth/check-email"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "on its way"
+      refute_enqueued(worker: VerificationEmail)
+    end
+
+    test "responds identically for an unknown address, without enqueueing", %{conn: conn} do
+      conn = post(conn, ~p"/auth/resend-verification", %{"email" => "nobody@example.com"})
+
+      assert redirected_to(conn) == ~p"/auth/check-email"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "on its way"
+      refute_enqueued(worker: VerificationEmail)
+    end
+
+    test "responds identically when the email param is missing", %{conn: conn} do
+      conn = post(conn, ~p"/auth/resend-verification", %{})
+
+      assert redirected_to(conn) == ~p"/auth/check-email"
+      refute_enqueued(worker: VerificationEmail)
+    end
+
+    test "blocks the 6th resend from the same IP within the hour", %{conn: conn} do
+      user = insert_user()
+
+      for _ <- 1..5 do
+        post(conn, ~p"/auth/resend-verification", %{"email" => user.email})
+      end
+
+      conn6 = post(conn, ~p"/auth/resend-verification", %{"email" => user.email})
+      assert conn6.status == 429
+    end
+  end
+
+  describe "POST /api/auth/resend-verification (JSON)" do
+    test "returns 200 and enqueues for an unverified account", %{conn: conn} do
+      user = insert_user()
+
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> post("/api/auth/resend-verification", Jason.encode!(%{email: user.email}))
+
+      assert json_response(conn, 200)["message"] =~ "on its way"
+      assert_enqueued(worker: VerificationEmail, args: %{user_id: user.id})
+    end
+
+    test "returns the same 200 for an unknown address", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> post("/api/auth/resend-verification", Jason.encode!(%{email: "nobody@example.com"}))
+
+      assert json_response(conn, 200)["message"] =~ "on its way"
+      refute_enqueued(worker: VerificationEmail)
     end
   end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,7 @@ config :fountain, Oban,
   # exports is its own queue so a user-requested data export is never stuck
   # behind a maintenance sweep; concurrency 1 because each job reads every row
   # an account owns and two at once doubles that memory.
-  queues: [maintenance: 1, billing: 5, exports: 1],
+  queues: [maintenance: 1, billing: 5, exports: 1, mailer: 5],
   plugins: [
     # Oban's own job-table pruning: completed jobs older than 7 days.
     {Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60},


### PR DESCRIPTION
Closes #445, closes #449 — the first two items of the `story-2026-08` batch.

## #445 — resend-verification + durable send

**The bug this kills:** the verification email was sent from a linked `Task.async` with no `await` (the exact failure mode `StripeCustomerSync` was extracted for — its moduledoc describes it). A dropped send was unrecoverable: no resend route existed, re-registering hits the unique-email constraint, and the `UnverifiedAccountPruner` deletes the account after 30 days. The check-email page even linked to `/auth/resend-verification` already — a dead link in production until this PR.

- **`Workers.VerificationEmail`** (new `:mailer` queue): retries with backoff, survives restarts. The token is signed in `perform/1`, not at enqueue — job args live in `oban_jobs`, so signing at enqueue would store the token in plaintext and a retried job could deliver a nearly-expired link. Every attempt mails a fresh 24 h token. A worker-side guard skips users who verified in the meantime.
- **Routes:** `GET/POST /auth/resend-verification` (HTML form) and `POST /api/auth/resend-verification` (JSON), rate-limited 5/IP/hour in their own bucket. Response is byte-identical whether the address is unknown, unverified, or already verified — same anti-enumeration contract as `POST /api/auth/forgot`. Verified accounts get no email (an "already verified" mail would be an account oracle).
- Links added on the login page (next to "Forgot password?"); the check-email page's existing link now resolves.

## #449 — welcome email

- **`Workers.WelcomeEmail`**, enqueued only on the verification *transition*: the unverified branch of `EmailVerificationController.confirm/2` and the new-user branch of the OAuth callback (OAuth accounts are created verified, so signup is their transition). The already-verified confirm branch deliberately does not enqueue — that's also what prevents pre-existing accounts from being welcomed on deploy. `unique: [period: :infinity]` is the belt for request retries.
- Content: onboarding-wizard CTA (dashboard once onboarding is complete) and, for trialing accounts, the trial end date using the same phrasing `deliver_trial_ending_email/2` uses later, so the two emails agree.

## A trap worth knowing about

Both new workers scope uniqueness to `fields: [:worker, :args]`. The first draft copied `fields: [:args]` from the existing workers — and `StripeCustomerSync` is enqueued in the same request with byte-identical args (`%{user_id: ...}`), so Oban silently swallowed the welcome job as its duplicate. The existing `[:args]`-only workers don't collide today only because their args shapes differ. Caught by the controller tests.

## Testing

- Worker tests prove the mailed token round-trips through `Phoenix.Token.verify` with the controller's salt/TTL, that no token is stored in job args, and the skip paths (deleted user, verified-in-the-meantime, unverified-for-welcome).
- Controller tests assert enqueue on the right branches only (confirm transition yes / already-verified no; OAuth signup yes / OAuth login no), the identical-response contract across unknown/verified/missing-email resends, and the 429 on the 6th resend.
- `mix precommit` green: 1,875 tests, 0 failures.

Note for review: `config/config.exs` adds a `mailer: 5` Oban queue — verification/welcome emails aren't billing traffic, so they don't ride the `:billing` queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)