### PR TITLE
admin: per-user detail view, admin conversation read, sandbox owner column (#446)

### DIFF
--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -81,6 +81,21 @@ defmodule Fountain.Audit do
   end
 
   @doc """
+  Administrative actions taken against one user, newest first. Admin surfaces
+  only — this is the "what happened to account Y" half of the support story.
+  """
+  @spec _unsafe_list_admin_events_for_target(Ecto.UUID.t(), pos_integer()) :: [AdminEvent.t()]
+  def _unsafe_list_admin_events_for_target(target_user_id, limit \\ 50)
+      when is_binary(target_user_id) do
+    Repo.all(
+      from e in AdminEvent,
+        where: e.target_user_id == ^target_user_id,
+        order_by: [desc: e.inserted_at, desc: e.id],
+        limit: ^limit
+    )
+  end
+
+  @doc """
   List the most recent N events for one tenant, newest first.
 
   System events (`user_id = nil`) are excluded — those belong to admin

--- a/apps/fountain/lib/fountain/audit/admin_event.ex
+++ b/apps/fountain/lib/fountain/audit/admin_event.ex
@@ -45,6 +45,8 @@ defmodule Fountain.Audit.AdminEvent do
     admin.sandbox.reaped
     admin.account.suspended
     admin.account.unsuspended
+    admin.user.viewed
+    admin.conversation.viewed
   )
 
   def event_types, do: @event_types

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -50,6 +50,56 @@ defmodule Fountain.Conversations do
   def _unsafe_get_sandbox!(id), do: Repo.get!(Sandbox, id)
 
   @doc """
+  Load any tenant's conversation for the admin support view (#446).
+
+  Returns the conversation with owner/agent/sandbox preloaded plus turn and
+  log-event **counts** — deliberately not the turns or log events themselves.
+  The admin surface renders metadata only (status, timing, exit codes); prompt
+  and output content stay tenant-private. `_unsafe_list_turn_summaries_admin/1`
+  carries the same rule.
+  """
+  def _unsafe_get_conversation_admin(id) do
+    case Repo.get(Conversation, id) do
+      nil ->
+        nil
+
+      conv ->
+        conv = Repo.preload(conv, [:user, :agent, :sandbox])
+
+        turn_count =
+          Repo.aggregate(from(t in Turn, where: t.conversation_id == ^id), :count)
+
+        log_event_count =
+          Repo.aggregate(from(le in LogEvent, where: le.conversation_id == ^id), :count)
+
+        %{conversation: conv, turn_count: turn_count, log_event_count: log_event_count}
+    end
+  end
+
+  @doc """
+  Turn metadata for the admin support view: numbers, statuses, exit codes and
+  timing — never `prompt`. The select list is the privacy boundary; keep
+  content columns out of it.
+  """
+  def _unsafe_list_turn_summaries_admin(conversation_id, limit \\ 100) do
+    Repo.all(
+      from t in Turn,
+        where: t.conversation_id == ^conversation_id,
+        order_by: [desc: t.turn_number],
+        limit: ^limit,
+        select: %{
+          id: t.id,
+          turn_number: t.turn_number,
+          status: t.status,
+          exit_code: t.exit_code,
+          started_at: t.started_at,
+          ended_at: t.ended_at,
+          inserted_at: t.inserted_at
+        }
+    )
+  end
+
+  @doc """
   Support teardown of any tenant's sandbox, from the admin panel.
 
   A conversation with a live `ConversationServer` is terminated through the

--- a/apps/fountain/lib/fountain_web/live/admin_live/conversation_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/conversation_detail.ex
@@ -1,0 +1,161 @@
+defmodule FountainWeb.AdminLive.ConversationDetail do
+  @moduledoc """
+  Admin support view of any tenant's conversation (#446). This is the page the
+  admin sandbox table links to — until it existed, those links resolved
+  through the tenant-scoped `ConversationsLive.Show` and 404ed for every
+  conversation the admin didn't own.
+
+  **Metadata only, by design.** Status, timing, turn numbers, exit codes and
+  counts are visible; prompts, outputs and log content are not — support can
+  see *that* turn 7 failed with exit 137 without reading what the user typed.
+  Titles are shown (they're how a user refers to their conversation in a
+  support thread) and are the only content-derived field on the page. Each
+  visit records an `admin.conversation.viewed` admin audit event.
+  """
+  use FountainWeb, :live_view
+
+  import FountainWeb.AdminLive.Helpers
+
+  alias Fountain.{Audit, Conversations}
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    # Ownership context for the _unsafe_ calls: admin surface behind
+    # require_admin (router :admin live_session).
+    case Conversations._unsafe_get_conversation_admin(id) do
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, "Conversation not found")
+         |> push_navigate(to: ~p"/admin")}
+
+      %{conversation: conv, turn_count: turn_count, log_event_count: log_event_count} ->
+        # connected?-guard: mount runs for both the static render and the
+        # socket; one visit must be one audit row.
+        if connected?(socket) do
+          Audit.record_admin(%{
+            actor_user_id: socket.assigns.current_user.id,
+            target_user_id: conv.user_id,
+            event_type: "admin.conversation.viewed",
+            metadata: %{
+              "email" => conv.user && conv.user.email,
+              "conversation_id" => conv.id
+            }
+          })
+        end
+
+        {:ok,
+         socket
+         |> assign(:page_title, "Admin · conversation #{String.slice(conv.id, 0, 8)}")
+         |> assign(:conv, conv)
+         |> assign(:turn_count, turn_count)
+         |> assign(:log_event_count, log_event_count)
+         |> assign(:turns, Conversations._unsafe_list_turn_summaries_admin(conv.id))}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-8">
+      <div>
+        <.link navigate={~p"/admin"} class="text-xs text-zinc-500 hover:text-zinc-900 underline">
+          ← Admin
+        </.link>
+        <h1 class="text-2xl font-semibold mt-1">
+          <span class="font-mono">{String.slice(@conv.id, 0, 8)}</span>
+          <span :if={@conv.title} class="text-zinc-500 text-lg ml-2">{@conv.title}</span>
+        </h1>
+        <div class="flex flex-wrap items-center gap-2 mt-2 text-xs">
+          <span class={[
+            "inline-flex items-center rounded px-1.5 py-0.5 font-medium border",
+            conversation_status_color(@conv.status)
+          ]}>
+            {@conv.status}
+          </span>
+          <span class="text-zinc-500">runtime {@conv.runtime}</span>
+          <span :if={@conv.source} class="text-zinc-500">via {@conv.source}</span>
+        </div>
+        <p class="text-xs text-zinc-400 mt-2 font-mono">{@conv.id}</p>
+      </div>
+
+      <section class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Owner</div>
+          <div class="text-sm font-medium font-mono truncate">
+            <.link
+              :if={@conv.user}
+              navigate={~p"/admin/users/#{@conv.user.id}"}
+              class="hover:underline"
+            >
+              {@conv.user.email}
+            </.link>
+            <span :if={is_nil(@conv.user)}>—</span>
+          </div>
+        </div>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Agent</div>
+          <div class="text-sm font-medium truncate">
+            {if @conv.agent, do: @conv.agent.name, else: "—"}
+          </div>
+        </div>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Sandbox</div>
+          <div class="text-sm font-medium font-mono">
+            {if @conv.sandbox, do: String.slice(@conv.sandbox.id, 0, 8), else: "—"}
+          </div>
+          <div :if={@conv.sandbox} class="text-xs text-zinc-500">{@conv.sandbox.status}</div>
+        </div>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Volume</div>
+          <div class="text-sm font-medium tabular-nums">
+            {@turn_count} turns · {@log_event_count} log events
+          </div>
+          <div class="text-xs text-zinc-500">
+            started {format_ts(@conv.inserted_at)}
+          </div>
+        </div>
+      </section>
+
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Turns (latest {length(@turns)})</h2>
+        <p class="text-sm text-zinc-500">
+          Metadata only — prompt and output content are not shown to admins.
+        </p>
+        <div :if={@turns == []} class="text-sm text-zinc-500">None.</div>
+        <table :if={@turns != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
+          <thead class="text-left text-zinc-500 border-b border-zinc-200">
+            <tr>
+              <th class="px-4 py-2">#</th>
+              <th class="px-4 py-2">Status</th>
+              <th class="px-4 py-2">Exit</th>
+              <th class="px-4 py-2">Started</th>
+              <th class="px-4 py-2">Ended</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={t <- @turns} class="border-b border-zinc-100 last:border-0">
+              <td class="px-4 py-2 text-xs tabular-nums">{t.turn_number}</td>
+              <td class="px-4 py-2">
+                <span class={[
+                  "inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium border",
+                  conversation_status_color(t.status)
+                ]}>
+                  {t.status}
+                </span>
+              </td>
+              <td class="px-4 py-2 text-xs tabular-nums">
+                {if is_nil(t.exit_code), do: "—", else: t.exit_code}
+              </td>
+              <td class="px-4 py-2 text-xs text-zinc-500">
+                {format_ts(t.started_at || t.inserted_at)}
+              </td>
+              <td class="px-4 py-2 text-xs text-zinc-500">{format_ts(t.ended_at)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </div>
+    """
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/admin_live/helpers.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/helpers.ex
@@ -1,0 +1,31 @@
+defmodule FountainWeb.AdminLive.Helpers do
+  @moduledoc """
+  Formatting and badge-color helpers shared by the admin LiveViews.
+
+  Extracted from `AdminLive.Index` when the per-user and per-conversation
+  detail views arrived (#446) so the three pages render dates and status
+  badges identically.
+  """
+
+  def subscription_status_color("active"), do: "bg-green-100 text-green-800 border-green-200"
+  def subscription_status_color("trialing"), do: "bg-blue-100 text-blue-800 border-blue-200"
+  def subscription_status_color("comped"), do: "bg-purple-100 text-purple-800 border-purple-200"
+  def subscription_status_color("past_due"), do: "bg-amber-100 text-amber-800 border-amber-200"
+  def subscription_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
+
+  def sandbox_status_color("running"), do: "bg-blue-100 text-blue-800 border-blue-200"
+  def sandbox_status_color("ready"), do: "bg-green-100 text-green-800 border-green-200"
+  def sandbox_status_color("failed"), do: "bg-red-100 text-red-700 border-red-200"
+  def sandbox_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
+
+  def conversation_status_color("running"), do: "bg-blue-100 text-blue-800 border-blue-200"
+  def conversation_status_color("completed"), do: "bg-green-100 text-green-800 border-green-200"
+  def conversation_status_color("failed"), do: "bg-red-100 text-red-700 border-red-200"
+  def conversation_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
+
+  def format_date(nil), do: ""
+  def format_date(dt), do: Calendar.strftime(dt, "%Y-%m-%d")
+
+  def format_ts(nil), do: ""
+  def format_ts(dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
+end

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -2,6 +2,8 @@ defmodule FountainWeb.AdminLive.Index do
   @moduledoc false
   use FountainWeb, :live_view
 
+  import FountainWeb.AdminLive.Helpers
+
   alias Fountain.{Accounts, Billing, Conversations, Quotas}
   alias Fountain.Accounts.Deletion
 
@@ -617,7 +619,9 @@ defmodule FountainWeb.AdminLive.Index do
             </tr>
             <tr :for={u <- @users} class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50">
               <td class="px-4 py-2 font-mono text-xs">
-                {u.email}
+                <.link navigate={~p"/admin/users/#{u.id}"} class="hover:underline">
+                  {u.email}
+                </.link>
                 <span
                   :if={is_nil(u.email_verified_at)}
                   class="ml-1 inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium border bg-zinc-100 text-zinc-500 border-zinc-200"
@@ -794,6 +798,7 @@ defmodule FountainWeb.AdminLive.Index do
           <thead class="text-left text-zinc-500 border-b border-zinc-200">
             <tr>
               <th class="px-4 py-2">ID</th>
+              <th class="px-4 py-2">Owner</th>
               <th class="px-4 py-2">Status</th>
               <th class="px-4 py-2">Conversations</th>
               <th class="px-4 py-2">Started</th>
@@ -803,6 +808,16 @@ defmodule FountainWeb.AdminLive.Index do
           <tbody>
             <tr :for={s <- @sandboxes} class="border-b border-zinc-100 last:border-0">
               <td class="px-4 py-2 text-xs">{String.slice(s.id, 0, 8)}</td>
+              <td class="px-4 py-2 text-xs">
+                <.link
+                  :if={s.user}
+                  navigate={~p"/admin/users/#{s.user.id}"}
+                  class="hover:underline"
+                >
+                  {s.user.email}
+                </.link>
+                <span :if={is_nil(s.user)} class="text-zinc-400">—</span>
+              </td>
               <td class="px-4 py-2">
                 <span class={[
                   "inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium border",
@@ -816,7 +831,7 @@ defmodule FountainWeb.AdminLive.Index do
                 <span :if={s.conversations != []} class="space-x-2">
                   <.link
                     :for={c <- s.conversations}
-                    navigate={~p"/conversations/#{c.id}"}
+                    navigate={~p"/admin/conversations/#{c.id}"}
                     class="hover:underline"
                   >{String.slice(c.id, 0, 8)}</.link>
                 </span>
@@ -872,17 +887,6 @@ defmodule FountainWeb.AdminLive.Index do
     """
   end
 
-  defp subscription_status_color("active"), do: "bg-green-100 text-green-800 border-green-200"
-  defp subscription_status_color("trialing"), do: "bg-blue-100 text-blue-800 border-blue-200"
-  defp subscription_status_color("comped"), do: "bg-purple-100 text-purple-800 border-purple-200"
-  defp subscription_status_color("past_due"), do: "bg-amber-100 text-amber-800 border-amber-200"
-  defp subscription_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
-
-  defp sandbox_status_color("running"), do: "bg-blue-100 text-blue-800 border-blue-200"
-  defp sandbox_status_color("ready"), do: "bg-green-100 text-green-800 border-green-200"
-  defp sandbox_status_color("failed"), do: "bg-red-100 text-red-700 border-red-200"
-  defp sandbox_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
-
   defp stage_label(:registered), do: "Registered"
   defp stage_label(:verified), do: "Verified"
   defp stage_label(:onboarded), do: "Onboarded"
@@ -902,10 +906,4 @@ defmodule FountainWeb.AdminLive.Index do
   defp format_hours(h) when h < 1, do: "#{round(h * 60)}m"
   defp format_hours(h) when h < 48, do: "#{Float.round(h * 1.0, 1)}h"
   defp format_hours(h), do: "#{Float.round(h / 24, 1)}d"
-
-  defp format_date(nil), do: ""
-  defp format_date(dt), do: Calendar.strftime(dt, "%Y-%m-%d")
-
-  defp format_ts(nil), do: ""
-  defp format_ts(dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
 end

--- a/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
@@ -1,0 +1,291 @@
+defmodule FountainWeb.AdminLive.UserDetail do
+  @moduledoc """
+  Admin support view of a single account (#446): the investigative half of the
+  admin story. Everything on this page is read-only — the levers (suspend,
+  comp, delete, role) stay on `/admin` next to their confirmations.
+
+  Shows account/billing state, resource counts, conversations, API-key
+  metadata (never key material), the user's own audit trail, and every admin
+  action taken against them. Each visit records an `admin.user.viewed` admin
+  audit event: cross-tenant reads are privileged actions and get the same
+  trail as cross-tenant writes.
+  """
+  use FountainWeb, :live_view
+
+  import FountainWeb.AdminLive.Helpers
+
+  alias Fountain.{Accounts, Agents, Audit, Conversations, Environments, Quotas, Vaults}
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    case Accounts.get_user(id) do
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, "User not found — the account may have been deleted")
+         |> push_navigate(to: ~p"/admin")}
+
+      user ->
+        # connected?-guard: mount runs for both the static render and the
+        # socket; one visit must be one audit row.
+        if connected?(socket) do
+          Audit.record_admin(%{
+            actor_user_id: socket.assigns.current_user.id,
+            target_user_id: user.id,
+            event_type: "admin.user.viewed",
+            metadata: %{"email" => user.email}
+          })
+        end
+
+        {:ok,
+         socket
+         |> assign(:page_title, "Admin · #{user.email}")
+         |> load_user(user)}
+    end
+  end
+
+  # Ownership context for the _unsafe_ call below: this is an admin surface
+  # behind require_admin, and `user` came from the mount fetch above.
+  defp load_user(socket, user) do
+    conversations = user.id |> Conversations.list_conversations() |> Enum.take(25)
+
+    # last_activity_at is a computed column in list_users_admin/1, not a User
+    # field — here the freshest conversation stands in for it.
+    last_activity =
+      conversations
+      |> Enum.map(& &1.last_active_at)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.max(DateTime, fn -> nil end)
+
+    socket
+    |> assign(:user, user)
+    |> assign(:last_activity_at, last_activity)
+    |> assign(:active_sandboxes, Map.get(Quotas.active_sandbox_counts(), user.id, 0))
+    |> assign(:conversations, conversations)
+    |> assign(:api_keys, Accounts.list_api_keys(user.id))
+    |> assign(:agent_count, length(Agents.list_agents(user.id, [])))
+    |> assign(:environment_count, length(Environments.list_environments(user.id)))
+    |> assign(:vault_count, length(Vaults.list_vaults(user.id)))
+    |> assign(:audit_events, Audit.list_recent_for_user(user.id, 50))
+    |> assign(:admin_events, Audit._unsafe_list_admin_events_for_target(user.id, 50))
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-8">
+      <div>
+        <.link navigate={~p"/admin"} class="text-xs text-zinc-500 hover:text-zinc-900 underline">
+          ← Admin
+        </.link>
+        <h1 class="text-2xl font-semibold font-mono mt-1">{@user.email}</h1>
+        <div class="flex flex-wrap items-center gap-2 mt-2 text-xs">
+          <span class={[
+            "inline-flex items-center rounded px-1.5 py-0.5 font-medium border",
+            if(@user.role == "admin",
+              do: "bg-amber-100 text-amber-800 border-amber-200",
+              else: "bg-zinc-100 text-zinc-600 border-zinc-200"
+            )
+          ]}>
+            {@user.role}
+          </span>
+          <span class={[
+            "inline-flex items-center rounded px-1.5 py-0.5 font-medium border",
+            subscription_status_color(@user.subscription_status)
+          ]}>
+            {@user.subscription_status}
+          </span>
+          <span
+            :if={is_nil(@user.email_verified_at)}
+            class="inline-flex items-center rounded px-1.5 py-0.5 font-medium border bg-zinc-100 text-zinc-500 border-zinc-200"
+          >
+            unverified
+          </span>
+          <span
+            :if={@user.suspended_at}
+            class="inline-flex items-center rounded px-1.5 py-0.5 font-medium border bg-red-100 text-red-700 border-red-200"
+          >
+            suspended since {format_ts(@user.suspended_at)}
+          </span>
+          <a
+            :if={@user.stripe_customer_id not in [nil, ""]}
+            href={"https://dashboard.stripe.com/customers/#{@user.stripe_customer_id}"}
+            target="_blank"
+            rel="noopener"
+            class="text-zinc-400 hover:text-zinc-700 underline"
+          >
+            stripe ↗
+          </a>
+        </div>
+        <p class="text-xs text-zinc-400 mt-2 font-mono">{@user.id}</p>
+      </div>
+
+      <section class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Joined</div>
+          <div class="text-sm font-medium">{format_date(@user.inserted_at)}</div>
+          <div class="text-xs text-zinc-500">
+            last active {if @last_activity_at, do: format_date(@last_activity_at), else: "—"}
+          </div>
+        </div>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Trial / period</div>
+          <div class="text-sm font-medium">
+            {cond do
+              @user.subscription_status == "trialing" && @user.trial_ends_at ->
+                "trial ends #{format_date(@user.trial_ends_at)}"
+
+              @user.cancel_at_period_end && @user.current_period_end ->
+                "access until #{format_date(@user.current_period_end)}"
+
+              true ->
+                "—"
+            end}
+          </div>
+          <div class="text-xs text-zinc-500">
+            onboarding {@user.onboarding_state}
+          </div>
+        </div>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Sandboxes</div>
+          <div class="text-sm font-medium tabular-nums">
+            {@active_sandboxes} / {@user.max_concurrent_sandboxes}
+          </div>
+          <div class="text-xs text-zinc-500">active / limit</div>
+        </div>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Resources</div>
+          <div class="text-sm font-medium tabular-nums">
+            {@agent_count}a · {@environment_count}e · {@vault_count}v
+          </div>
+          <div class="text-xs text-zinc-500">agents · environments · vaults</div>
+        </div>
+      </section>
+
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Conversations (latest {length(@conversations)})</h2>
+        <div :if={@conversations == []} class="text-sm text-zinc-500">None.</div>
+        <table
+          :if={@conversations != []}
+          class="w-full text-sm bg-white rounded shadow border border-zinc-200"
+        >
+          <thead class="text-left text-zinc-500 border-b border-zinc-200">
+            <tr>
+              <th class="px-4 py-2">Conversation</th>
+              <th class="px-4 py-2">Status</th>
+              <th class="px-4 py-2">Runtime</th>
+              <th class="px-4 py-2">Started</th>
+              <th class="px-4 py-2">Last active</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={c <- @conversations} class="border-b border-zinc-100 last:border-0">
+              <td class="px-4 py-2 text-xs">
+                <.link
+                  navigate={~p"/admin/conversations/#{c.id}"}
+                  class="font-mono hover:underline"
+                >
+                  {String.slice(c.id, 0, 8)}
+                </.link>
+                <span :if={c.title} class="text-zinc-500 ml-1">{c.title}</span>
+              </td>
+              <td class="px-4 py-2">
+                <span class={[
+                  "inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium border",
+                  conversation_status_color(c.status)
+                ]}>
+                  {c.status}
+                </span>
+              </td>
+              <td class="px-4 py-2 text-xs text-zinc-500">{c.runtime}</td>
+              <td class="px-4 py-2 text-xs text-zinc-500">{format_ts(c.inserted_at)}</td>
+              <td class="px-4 py-2 text-xs text-zinc-500">{format_ts(c.last_active_at)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">API keys ({length(@api_keys)})</h2>
+        <div :if={@api_keys == []} class="text-sm text-zinc-500">None.</div>
+        <table
+          :if={@api_keys != []}
+          class="w-full text-sm bg-white rounded shadow border border-zinc-200"
+        >
+          <thead class="text-left text-zinc-500 border-b border-zinc-200">
+            <tr>
+              <th class="px-4 py-2">Name</th>
+              <th class="px-4 py-2">Prefix</th>
+              <th class="px-4 py-2">Scopes</th>
+              <th class="px-4 py-2">Created</th>
+              <th class="px-4 py-2">Last used</th>
+              <th class="px-4 py-2">State</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={k <- @api_keys} class="border-b border-zinc-100 last:border-0">
+              <td class="px-4 py-2 text-xs">{k.name}</td>
+              <td class="px-4 py-2 font-mono text-xs">{k.key_prefix}…</td>
+              <td class="px-4 py-2 text-xs text-zinc-500">{Enum.join(k.scopes, ", ")}</td>
+              <td class="px-4 py-2 text-xs text-zinc-500">{format_date(k.inserted_at)}</td>
+              <td class="px-4 py-2 text-xs text-zinc-500">
+                {if k.last_used_at, do: format_ts(k.last_used_at), else: "never"}
+              </td>
+              <td class="px-4 py-2 text-xs">
+                <span :if={k.revoked_at} class="text-red-600">revoked</span>
+                <span :if={is_nil(k.revoked_at) and k.expires_at} class="text-zinc-500">
+                  expires {format_date(k.expires_at)}
+                </span>
+                <span :if={is_nil(k.revoked_at) and is_nil(k.expires_at)} class="text-zinc-500">
+                  active
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Admin actions on this account</h2>
+        <div :if={@admin_events == []} class="text-sm text-zinc-500">None recorded.</div>
+        <table
+          :if={@admin_events != []}
+          class="w-full text-sm bg-white rounded shadow border border-zinc-200"
+        >
+          <tbody>
+            <tr :for={e <- @admin_events} class="border-b border-zinc-100 last:border-0">
+              <td class="px-4 py-1.5 text-xs text-zinc-500">{format_ts(e.inserted_at)}</td>
+              <td class="px-4 py-1.5 font-mono text-xs">{e.event_type}</td>
+              <td class="px-4 py-1.5 text-xs text-zinc-500">
+                <span :if={e.metadata["from"] != nil}>
+                  {e.metadata["from"]} &rarr; {e.metadata["to"]}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Recent activity (audit trail)</h2>
+        <div :if={@audit_events == []} class="text-sm text-zinc-500">Nothing recorded.</div>
+        <table
+          :if={@audit_events != []}
+          class="w-full text-sm bg-white rounded shadow border border-zinc-200"
+        >
+          <tbody>
+            <tr :for={e <- @audit_events} class="border-b border-zinc-100 last:border-0">
+              <td class="px-4 py-1.5 text-xs text-zinc-500 whitespace-nowrap">
+                {format_ts(e.inserted_at)}
+              </td>
+              <td class="px-4 py-1.5 font-mono text-xs">{e.action}</td>
+              <td class="px-4 py-1.5 text-xs text-zinc-500">{e.resource_type}</td>
+              <td class="px-4 py-1.5 text-xs text-zinc-400">{e.request_ip}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </div>
+    """
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -297,6 +297,8 @@ defmodule FountainWeb.Router do
         {FountainWeb.Live.Hooks, :require_admin}
       ] do
       live "/admin", AdminLive.Index, :index
+      live "/admin/users/:id", AdminLive.UserDetail, :show
+      live "/admin/conversations/:id", AdminLive.ConversationDetail, :show
     end
   end
 

--- a/apps/fountain/test/fountain_web/live/admin_conversation_detail_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_conversation_detail_live_test.exs
@@ -1,0 +1,91 @@
+defmodule FountainWeb.AdminConversationDetailLiveTest do
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Ecto.Query
+
+  alias Fountain.Accounts
+  alias Fountain.Audit.AdminEvent
+  alias Fountain.Repo
+
+  defp insert_admin(overrides \\ %{}) do
+    user = insert_verified_user(overrides)
+    {:ok, admin} = Accounts.update_user_role(user, "admin")
+    admin
+  end
+
+  describe "access control" do
+    test "regular user is redirected away — even from their own conversation", %{conn: conn} do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      conn = login_user(conn, user)
+      assert {:error, {:live_redirect, _}} = live(conn, ~p"/admin/conversations/#{conv.id}")
+    end
+
+    test "unauthenticated user is redirected to login", %{conn: conn} do
+      conv = insert_conversation()
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/admin/conversations/#{conv.id}")
+      assert path =~ "/auth/login"
+    end
+  end
+
+  describe "cross-tenant read" do
+    test "admin can view another tenant's conversation metadata", %{conn: conn} do
+      admin = insert_admin()
+      target = insert_verified_user()
+      conv = insert_conversation(user_id: target.id, status: "running")
+      insert_turn(conv, %{status: "completed", exit_code: 0})
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin/conversations/#{conv.id}")
+
+      assert html =~ String.slice(conv.id, 0, 8)
+      assert html =~ target.email
+      assert html =~ "running"
+      # owner links back to the user detail page
+      assert html =~ ~p"/admin/users/#{target.id}"
+    end
+
+    test "prompt and log content never render — metadata only", %{conn: conn} do
+      admin = insert_admin()
+      target = insert_verified_user()
+      conv = insert_conversation(user_id: target.id)
+      insert_turn(conv, %{prompt: "TENANT_PRIVATE_PROMPT_a8f3"})
+      insert_log_event(conv, %{data: "TENANT_PRIVATE_OUTPUT_c61b"})
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin/conversations/#{conv.id}")
+
+      refute html =~ "TENANT_PRIVATE_PROMPT_a8f3"
+      refute html =~ "TENANT_PRIVATE_OUTPUT_c61b"
+      # but the turn's existence and the log volume are visible
+      assert html =~ "1 turns · 1 log events"
+    end
+
+    test "records an admin.conversation.viewed audit event on visit", %{conn: conn} do
+      admin = insert_admin()
+      target = insert_verified_user()
+      conv = insert_conversation(user_id: target.id)
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, _html} = live(conn, ~p"/admin/conversations/#{conv.id}")
+
+      assert [event] =
+               Repo.all(
+                 from e in AdminEvent, where: e.event_type == "admin.conversation.viewed"
+               )
+
+      assert event.actor_user_id == admin.id
+      assert event.target_user_id == target.id
+      assert event.metadata["conversation_id"] == conv.id
+    end
+
+    test "unknown conversation id redirects back to /admin", %{conn: conn} do
+      admin = insert_admin()
+      conn = login_user(conn, admin)
+
+      assert {:error, {:live_redirect, %{to: "/admin"}}} =
+               live(conn, ~p"/admin/conversations/#{Ecto.UUID.generate()}")
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -125,6 +125,26 @@ defmodule FountainWeb.AdminLiveTest do
       assert html =~ "ready"
     end
 
+    test "shows the sandbox owner and links conversations to the admin view (#446)", %{
+      conn: conn
+    } do
+      admin = insert_admin()
+      owner = insert_verified_user()
+      sandbox = insert_sandbox(user_id: owner.id, status: "ready")
+      conv = insert_conversation(user_id: owner.id, sandbox: sandbox)
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      # owner column, linking to the user detail page
+      assert html =~ owner.email
+      assert html =~ ~p"/admin/users/#{owner.id}"
+      # conversation link resolves through the admin read path, not the
+      # tenant-scoped show (which 404s for other tenants' conversations)
+      assert html =~ ~p"/admin/conversations/#{conv.id}"
+      refute html =~ ~s{href="/conversations/#{conv.id}"}
+    end
+
     test "does not show terminated sandboxes", %{conn: conn} do
       admin = insert_admin()
       terminated = insert_sandbox(user_id: admin.id, status: "terminated")

--- a/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
@@ -1,0 +1,92 @@
+defmodule FountainWeb.AdminUserDetailLiveTest do
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Ecto.Query
+
+  alias Fountain.Accounts
+  alias Fountain.Audit.AdminEvent
+  alias Fountain.Repo
+
+  defp insert_admin(overrides \\ %{}) do
+    user = insert_verified_user(overrides)
+    {:ok, admin} = Accounts.update_user_role(user, "admin")
+    admin
+  end
+
+  describe "access control" do
+    test "regular user is redirected away", %{conn: conn} do
+      user = insert_verified_user()
+      target = insert_verified_user()
+      conn = login_user(conn, user)
+      assert {:error, {:live_redirect, _}} = live(conn, ~p"/admin/users/#{target.id}")
+    end
+
+    test "unauthenticated user is redirected to login", %{conn: conn} do
+      target = insert_verified_user()
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/admin/users/#{target.id}")
+      assert path =~ "/auth/login"
+    end
+  end
+
+  describe "detail page" do
+    test "shows another tenant's account, conversations and API-key metadata", %{conn: conn} do
+      admin = insert_admin()
+      target = insert_verified_user()
+      conv = insert_conversation(user_id: target.id)
+      {_key, _raw} = insert_api_key(target, "support-visible-key")
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin/users/#{target.id}")
+
+      assert html =~ target.email
+      assert html =~ String.slice(conv.id, 0, 8)
+      assert html =~ "support-visible-key"
+      # key material never renders — only the prefix column
+      refute html =~ "key_hash"
+    end
+
+    test "shows admin actions taken against the account", %{conn: conn} do
+      admin = insert_admin()
+      target = insert_verified_user()
+
+      {:ok, _} =
+        Fountain.Audit.record_admin(%{
+          actor_user_id: admin.id,
+          target_user_id: target.id,
+          event_type: "admin.account.suspended",
+          metadata: %{"email" => target.email}
+        })
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin/users/#{target.id}")
+
+      assert html =~ "admin.account.suspended"
+    end
+
+    test "records an admin.user.viewed audit event on visit", %{conn: conn} do
+      admin = insert_admin()
+      target = insert_verified_user()
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, _html} = live(conn, ~p"/admin/users/#{target.id}")
+
+      assert [event] =
+               Repo.all(
+                 from e in AdminEvent,
+                   where: e.event_type == "admin.user.viewed" and e.target_user_id == ^target.id
+               )
+
+      assert event.actor_user_id == admin.id
+      assert event.metadata["email"] == target.email
+    end
+
+    test "unknown user id redirects back to /admin with a flash", %{conn: conn} do
+      admin = insert_admin()
+      conn = login_user(conn, admin)
+
+      assert {:error, {:live_redirect, %{to: "/admin"}}} =
+               live(conn, ~p"/admin/users/#{Ecto.UUID.generate()}")
+    end
+  end
+end


### PR DESCRIPTION
Closes #446 — third item of the `story-2026-08` batch.

## What this adds

The **investigative half** of administration. The enforcement half (suspend/comp/delete/reap) was already complete; this makes it possible to *look* at an account before reaching for a lever, without psql.

- **`/admin/users/:id`** — read-only support view of one account: role/status/suspension badges, trial-or-period line, active-sandbox count vs limit, agent/environment/vault counts, latest 25 conversations, API-key **metadata** (name, prefix, scopes, last-used, revoked/expiry state — never key material), the user's own audit trail (50), and every admin action ever taken against them (new `Audit._unsafe_list_admin_events_for_target/2`).
- **`/admin/conversations/:id`** — the page the admin sandbox table now links to. Previously those links resolved through the tenant-scoped `ConversationsLive.Show`, which scopes to `current_user.id` — so they 404ed for every tenant except the admin themselves. Shows owner (linked), agent, sandbox, turn/log-event counts, and per-turn metadata.
- **Sandbox table Owner column** — `_unsafe_list_sandboxes_admin/0` already preloaded the user and the render dropped it; now it's a column linking to the detail page. User emails in the users table also link through.

## Decisions made explicit

- **Metadata only, no content.** Prompts, outputs, and log-event data never render on admin pages — support can see *that* turn 7 failed with exit 137 without reading what the user typed. The select list in the new `_unsafe_list_turn_summaries_admin/2` is the enforcement point (no `prompt` column). Conversation **titles** are shown — they're how a user refers to their conversation in a support thread — and are the only content-derived field; called out in the moduledoc.
- **Cross-tenant reads are audited like writes**: `admin.user.viewed` / `admin.conversation.viewed` admin-audit events, recorded once per visit (connected?-guarded so the static render doesn't double-record).
- **Read-only pages.** The levers stay on `/admin` next to their confirm dialogs.
- **Impersonation stays out of scope** (as filed in #446 — needs its own design discussion).
- The issue's "target-user filtering on audit views" is delivered as the per-user page's two audit sections (the "what happened to account Y" query); a generalized filter UI on `/audit` wasn't needed for that and isn't included.

## Tests

- Both new views: admin access, non-admin `live_redirect` away (including from *their own* conversation via the admin route), unauthenticated → login, unknown-id → back to `/admin` with flash.
- **Privacy test plants distinctive prompt/log content and refutes it in the rendered HTML** while asserting the counts still show.
- Audit-event recording asserted with actor/target/metadata.
- Index test asserts the owner column links and that conversation links point at `/admin/conversations/...`, refuting the old tenant-scoped href.
- `mix precommit` green: 1,888 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)