### PR TITLE
billing: handle invoice.payment_failed / payment_action_required / paid webhooks (#447)

### DIFF
--- a/apps/fountain/lib/fountain/billing.ex
+++ b/apps/fountain/lib/fountain/billing.ex
@@ -782,6 +782,92 @@ defmodule Fountain.Billing do
     end
   end
 
+  @doc false
+  # invoice.payment_failed / invoice.payment_action_required (#447): the
+  # first-class dunning signals. Status is NOT written here — that stays with
+  # `customer.subscription.updated`, which carries the authoritative status —
+  # these events only drive the notification. Both usually arrive in the same
+  # delivery burst as the subscription update, and `Workers.LifecycleEmail`'s
+  # 24 h uniqueness collapses the invoice-driven and transition-driven
+  # enqueues into one email.
+  #
+  # Unknown customers return {:ok, :ignored}, not {:error, :user_not_found}:
+  # a deleted account's trailing invoice events are expected traffic, and
+  # there is no state to repair by redelivering.
+  def sync_subscription(%Stripe.Event{type: type, data: %{object: invoice}})
+      when type in ["invoice.payment_failed", "invoice.payment_action_required"] do
+    customer_id = extract_stripe_id(Map.get(invoice, :customer))
+    subscription_id = extract_stripe_id(Map.get(invoice, :subscription))
+
+    case customer_id && get_user_by_stripe_customer_id(customer_id) do
+      %User{subscription_status: "comped"} ->
+        {:ok, :comped_ignored}
+
+      %User{} = user ->
+        if other_subscription?(user, subscription_id) do
+          {:ok, :other_subscription}
+        else
+          email =
+            case type do
+              "invoice.payment_failed" -> "payment_failed"
+              "invoice.payment_action_required" -> "payment_action_required"
+            end
+
+          enqueue_email(user, email)
+          {:ok, user}
+        end
+
+      _ ->
+        {:ok, :ignored}
+    end
+  end
+
+  @doc false
+  # invoice.paid (#447) drives exactly one thing: dunning recovery. It must
+  # never write status except off `past_due` — Stripe pays a $0 invoice at
+  # trial-subscription creation and one per normal renewal, and applying
+  # those would flip a fresh trialing account straight to active. The
+  # past_due → active write below routes through the same watermark and
+  # subscription-of-record guards as the subscription events, and the
+  # transition enqueues the payment_recovered email via lifecycle_email/2.
+  def sync_subscription(%Stripe.Event{type: "invoice.paid", data: %{object: invoice}} = event) do
+    customer_id = extract_stripe_id(Map.get(invoice, :customer))
+    subscription_id = extract_stripe_id(Map.get(invoice, :subscription))
+    event_created = event_created_at(event)
+
+    case customer_id && get_user_by_stripe_customer_id(customer_id, :for_update) do
+      %User{subscription_status: "comped"} ->
+        {:ok, :comped_ignored}
+
+      %User{subscription_status: "past_due"} = user ->
+        cond do
+          other_subscription?(user, subscription_id) ->
+            {:ok, :other_subscription}
+
+          stale?(user.subscription_synced_at, event_created) ->
+            {:ok, :stale}
+
+          true ->
+            user
+            |> User.billing_changeset(%{
+              subscription_status: "active",
+              subscription_synced_at: event_created || user.subscription_synced_at
+            })
+            |> Repo.update()
+            |> tap(fn
+              {:ok, updated} -> enqueue_lifecycle_email("past_due", updated)
+              _ -> :ok
+            end)
+        end
+
+      %User{} ->
+        {:ok, :ignored}
+
+      _ ->
+        {:ok, :ignored}
+    end
+  end
+
   def sync_subscription(_event), do: {:ok, :ignored}
 
   # ─── Lifecycle emails (#283) ────────────────────────────────────────────────
@@ -801,6 +887,9 @@ defmodule Fountain.Billing do
   defp lifecycle_email(old, "canceled") when old in ["trialing", nil], do: "trial_expired"
   defp lifecycle_email(_old, "canceled"), do: "subscription_canceled"
   defp lifecycle_email(_old, "past_due"), do: "payment_failed"
+  # Dunning recovery (#447): the counterpart to payment_failed. Fires whether
+  # the recovery arrives via customer.subscription.updated or invoice.paid.
+  defp lifecycle_email("past_due", "active"), do: "payment_recovered"
   defp lifecycle_email(_old, _new), do: nil
 
   # Only enqueues; the send is a job (`Workers.LifecycleEmail`). A mail — or
@@ -808,21 +897,22 @@ defmodule Fountain.Billing do
   # Stripe retry the whole event, so this always returns :ok.
   defp enqueue_lifecycle_email(old_status, %User{} = user) do
     case lifecycle_email(old_status, user.subscription_status) do
-      nil ->
+      nil -> :ok
+      email -> enqueue_email(user, email)
+    end
+  end
+
+  defp enqueue_email(%User{} = user, email) do
+    case Fountain.Workers.LifecycleEmail.enqueue(user.id, email) do
+      {:ok, _job} ->
         :ok
 
-      email ->
-        case Fountain.Workers.LifecycleEmail.enqueue(user.id, email) do
-          {:ok, _job} ->
-            :ok
+      {:error, reason} ->
+        Logger.warning(
+          "lifecycle_email: enqueue #{email} for #{user.id} failed: #{inspect(reason)}"
+        )
 
-          {:error, reason} ->
-            Logger.warning(
-              "lifecycle_email: enqueue #{email} for #{user.id} failed: #{inspect(reason)}"
-            )
-
-            :ok
-        end
+        :ok
     end
   end
 

--- a/apps/fountain/lib/fountain/emails/user_emails.ex
+++ b/apps/fountain/lib/fountain/emails/user_emails.ex
@@ -7,8 +7,9 @@ defmodule Fountain.Emails.UserEmails do
   - Welcome (once, on the verification transition, from `Workers.WelcomeEmail`)
   - Password reset (1 h token)
   - Trial ending (3 days out, from Stripe's trial_will_end)
-  - Trial expired / payment failed / subscription cancelled
-    (from `Workers.LifecycleEmail`, enqueued on webhook status transitions)
+  - Trial expired / payment failed / payment action required / payment
+    recovered / subscription cancelled (from `Workers.LifecycleEmail`,
+    enqueued on webhook status transitions and `invoice.*` events)
   """
 
   import Swoosh.Email
@@ -159,6 +160,45 @@ defmodule Fountain.Emails.UserEmails do
     |> subject("Payment failed for your Fountain subscription")
     |> html_body(payment_failed_html(billing_url))
     |> text_body(payment_failed_text(billing_url))
+    |> Mailer.deliver()
+  end
+
+  @doc """
+  The bank wants confirmation before the charge goes through (#447).
+
+  Driven by Stripe's `invoice.payment_action_required` — an SCA/3DS challenge
+  on a renewal. This is the one dunning-adjacent email where the user can
+  still prevent the failure, so it leads with the action, not the problem.
+  """
+  @spec deliver_payment_action_required_email(User.t()) :: {:ok, term()} | {:error, term()}
+  def deliver_payment_action_required_email(%User{} = user) do
+    billing_url = "#{Fountain.PublicUrl.base()}/account/billing"
+
+    new()
+    |> from(from_address())
+    |> to({user.email, user.email})
+    |> subject("Action needed: confirm your Fountain payment")
+    |> html_body(payment_action_required_html(billing_url))
+    |> text_body(payment_action_required_text(billing_url))
+    |> Mailer.deliver()
+  end
+
+  @doc """
+  Dunning recovered (#447): a past_due account's payment went through.
+
+  The counterpart to `deliver_payment_failed_email/1`. Without it the account
+  silently unlocks and the failure notice stays the last thing we ever said.
+  """
+  @spec deliver_payment_recovered_email(User.t()) :: {:ok, term()} | {:error, term()}
+  def deliver_payment_recovered_email(%User{} = user) do
+    billing_url = "#{Fountain.PublicUrl.base()}/account/billing"
+
+    new()
+    |> from(from_address())
+    |> to({user.email, user.email})
+    |> subject("Payment received — your Fountain subscription is active")
+    |> html_body(payment_recovered_html(billing_url))
+    |> text_body(payment_recovered_text(billing_url))
     |> Mailer.deliver()
   end
 
@@ -394,6 +434,88 @@ defmodule Fountain.Emails.UserEmails do
     payment succeeds.
 
     If the retries keep failing, your subscription will be cancelled.
+    """
+  end
+
+  defp payment_action_required_html(billing_url) do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>Confirm your Fountain payment</h2>
+      <p>
+        Your bank is asking for an extra confirmation before it will approve
+        your latest Fountain payment. Until then the charge stays pending.
+      </p>
+      <p style="margin: 32px 0;">
+        <a href="#{billing_url}"
+           style="background: #18181b; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-size: 14px;">
+          Confirm payment
+        </a>
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        Or copy this link into your browser:<br/>
+        <a href="#{billing_url}" style="color: #3b82f6;">#{billing_url}</a>
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        If the payment is not confirmed, it will be treated as failed and
+        retried — you'll hear from us again if that happens.
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp payment_action_required_text(billing_url) do
+    """
+    Confirm your Fountain payment
+
+    Your bank is asking for an extra confirmation before it will approve your
+    latest Fountain payment. Until then the charge stays pending. Confirm it
+    here:
+
+    #{billing_url}
+
+    If the payment is not confirmed, it will be treated as failed and retried
+    — you'll hear from us again if that happens.
+    """
+  end
+
+  defp payment_recovered_html(billing_url) do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>Payment received — you're all set</h2>
+      <p>
+        Your payment went through and your Fountain subscription is active
+        again. Starting new conversations works as normal, and nothing was
+        deleted while the payment was outstanding.
+      </p>
+      <p style="margin: 32px 0;">
+        <a href="#{billing_url}"
+           style="background: #18181b; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-size: 14px;">
+          View billing
+        </a>
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        Or copy this link into your browser:<br/>
+        <a href="#{billing_url}" style="color: #3b82f6;">#{billing_url}</a>
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp payment_recovered_text(billing_url) do
+    """
+    Payment received — you're all set
+
+    Your payment went through and your Fountain subscription is active again.
+    Starting new conversations works as normal, and nothing was deleted while
+    the payment was outstanding.
+
+    #{billing_url}
     """
   end
 

--- a/apps/fountain/lib/fountain/workers/lifecycle_email.ex
+++ b/apps/fountain/lib/fountain/workers/lifecycle_email.ex
@@ -8,6 +8,12 @@ defmodule Fountain.Workers.LifecycleEmail do
     a link to update the payment method.
   - `"subscription_canceled"` — the subscription ended (their choice or
     dunning exhaustion). Confirmation, the data-retention story, the way back.
+  - `"payment_action_required"` (#447) — the bank wants SCA/3DS confirmation
+    before the charge goes through. Without it the user's first sign is the
+    dunning email for a failure they could have prevented in one click.
+  - `"payment_recovered"` (#447) — a past_due account paid up. The counterpart
+    to `"payment_failed"`; without it the account silently unlocks and the
+    dunning email stays the last word.
 
   Enqueued from `Billing.sync_subscription/1` on the status *transition*, never
   on the status itself — Stripe fires several `customer.subscription.updated`
@@ -29,7 +35,7 @@ defmodule Fountain.Workers.LifecycleEmail do
 
   alias Fountain.{Accounts, Emails.UserEmails}
 
-  @emails ~w(trial_expired payment_failed subscription_canceled)
+  @emails ~w(trial_expired payment_failed subscription_canceled payment_action_required payment_recovered)
 
   @doc "The email kinds this worker knows how to send."
   def emails, do: @emails
@@ -67,6 +73,17 @@ defmodule Fountain.Workers.LifecycleEmail do
 
   defp maybe_send(%{subscription_status: "canceled"} = user, "subscription_canceled"),
     do: deliver(user, "subscription_canceled", &UserEmails.deliver_subscription_canceled_email/1)
+
+  # An open invoice can want SCA while the account is in any live state — a
+  # renewal on an active account, a retry on a past_due one. Only a canceled
+  # account is past the point where confirming would help.
+  defp maybe_send(%{subscription_status: s} = user, "payment_action_required")
+       when s in ["trialing", "active", "past_due"],
+       do:
+         deliver(user, "payment_action_required", &UserEmails.deliver_payment_action_required_email/1)
+
+  defp maybe_send(%{subscription_status: "active"} = user, "payment_recovered"),
+    do: deliver(user, "payment_recovered", &UserEmails.deliver_payment_recovered_email/1)
 
   defp maybe_send(user, email) do
     Logger.info(

--- a/apps/fountain/lib/mix/tasks/fountain.verify_lifecycle.ex
+++ b/apps/fountain/lib/mix/tasks/fountain.verify_lifecycle.ex
@@ -52,6 +52,11 @@ defmodule Mix.Tasks.Fountain.VerifyLifecycle do
     preflight!(key)
     Application.put_env(:stripity_stripe, :api_key, key)
 
+    # Half the checks assert what the gate refuses, and dev defaults
+    # BILLING_ENABLED=false — without this the run dies at "gate refuses
+    # after expiry" for a reason that has nothing to do with the lifecycle.
+    Application.put_env(:fountain, :billing_enabled, true)
+
     state = %{user: nil, clock: nil}
 
     try do
@@ -64,7 +69,8 @@ defmodule Mix.Tasks.Fountain.VerifyLifecycle do
       state = step_cancel_at_period_end(state)
       state = step_period_end(state)
       state = step_resubscribe(state)
-      _state = step_dunning(state)
+      state = step_dunning(state)
+      _state = step_dunning_recovery(state)
 
       info("\n✅  Lifecycle verified end to end.")
     after
@@ -314,7 +320,58 @@ defmodule Mix.Tasks.Fountain.VerifyLifecycle do
       lifecycle_email_enqueued?(user.id, "payment_failed")
     )
 
+    # The invoice-driven dunning signal (#447): feed the real failed invoice
+    # through sync. LifecycleEmail's 24 h uniqueness collapses this with the
+    # transition-driven enqueue above — one dunning cycle, one email.
+    {:ok, %{data: [invoice | _]}} =
+      Stripe.Invoice.list(%{subscription: sub.id, status: :open, limit: 1})
+
+    {:ok, %Fountain.Accounts.User{}} =
+      Billing.sync_subscription(event("invoice.payment_failed", invoice))
+
+    check!(
+      "invoice.payment_failed handled for the subscription of record (#447)",
+      lifecycle_email_enqueued?(user.id, "payment_failed")
+    )
+
     %{state | user: user, clock: clock}
+  end
+
+  # Real dunning recovery (#447): put a working card back, pay the open
+  # invoice through Stripe, and feed the real paid invoice through sync —
+  # past_due → active plus the payment_recovered email, all off invoice.paid
+  # rather than the subscription event.
+  defp step_dunning_recovery(%{user: user} = state) do
+    {:ok, pm} = Stripe.PaymentMethod.attach("pm_card_visa", %{customer: user.stripe_customer_id})
+
+    {:ok, _} =
+      Stripe.Customer.update(user.stripe_customer_id, %{
+        invoice_settings: %{default_payment_method: pm.id}
+      })
+
+    sub = fetch_subscription!(user, :past_due)
+
+    {:ok, %{data: [invoice | _]}} =
+      Stripe.Invoice.list(%{subscription: sub.id, status: :open, limit: 1})
+
+    {:ok, paid} = Stripe.Invoice.pay(invoice.id, %{})
+
+    {:ok, %Fountain.Accounts.User{} = user} =
+      Billing.sync_subscription(event("invoice.paid", paid))
+
+    check!(
+      "invoice.paid recovers past_due → active (#447)",
+      user.subscription_status == "active"
+    )
+
+    check!("gate open after recovery", Billing.check_active(user.id) == :ok)
+
+    check!(
+      "payment-recovered email enqueued (#447)",
+      lifecycle_email_enqueued?(user.id, "payment_recovered")
+    )
+
+    %{state | user: user}
   end
 
   # ── Assertions ─────────────────────────────────────────────────────────────

--- a/apps/fountain/test/fountain/billing_test.exs
+++ b/apps/fountain/test/fountain/billing_test.exs
@@ -888,4 +888,143 @@ defmodule Fountain.BillingTest do
       assert "has already been taken" in errors_on(changeset).stripe_customer_id
     end
   end
+
+  # ── invoice.* events (#447) ────────────────────────────────────────────────
+
+  defp invoice_user(status, opts \\ []) do
+    user = insert_verified_user()
+
+    Repo.update!(
+      Ecto.Changeset.change(user,
+        stripe_customer_id: "cus_inv#{System.unique_integer([:positive])}",
+        stripe_subscription_id: Keyword.get(opts, :sub_id, "sub_of_record"),
+        subscription_status: status,
+        subscription_synced_at: Keyword.get(opts, :synced_at)
+      )
+    )
+  end
+
+  defp invoice_event(type, user, opts \\ []) do
+    %Stripe.Event{
+      type: type,
+      created: Keyword.get(opts, :created),
+      data: %{
+        object: %{
+          customer: user.stripe_customer_id,
+          subscription: Keyword.get(opts, :subscription, user.stripe_subscription_id)
+        }
+      }
+    }
+  end
+
+  describe "invoice.* events (#447)" do
+    alias Fountain.Workers.LifecycleEmail
+
+    test "invoice.payment_failed enqueues the dunning email without touching status" do
+      user = invoice_user("active")
+
+      assert {:ok, %Fountain.Accounts.User{}} =
+               Billing.sync_subscription(invoice_event("invoice.payment_failed", user))
+
+      # status stays with the subscription events
+      assert Repo.reload(user).subscription_status == "active"
+
+      assert_enqueued(
+        worker: LifecycleEmail,
+        args: %{"user_id" => user.id, "email" => "payment_failed"}
+      )
+    end
+
+    test "invoice.payment_action_required enqueues the SCA email" do
+      user = invoice_user("active")
+
+      assert {:ok, %Fountain.Accounts.User{}} =
+               Billing.sync_subscription(invoice_event("invoice.payment_action_required", user))
+
+      assert_enqueued(
+        worker: LifecycleEmail,
+        args: %{"user_id" => user.id, "email" => "payment_action_required"}
+      )
+    end
+
+    test "an invoice for another subscription never reaches the account" do
+      user = invoice_user("past_due")
+
+      assert {:ok, :other_subscription} =
+               Billing.sync_subscription(
+                 invoice_event("invoice.payment_failed", user, subscription: "sub_other")
+               )
+
+      refute_enqueued(worker: LifecycleEmail)
+    end
+
+    test "an unknown customer is ignored, not an error — deleted accounts trail invoices" do
+      event = %Stripe.Event{
+        type: "invoice.payment_failed",
+        data: %{object: %{customer: "cus_gone_forever", subscription: "sub_x"}}
+      }
+
+      assert {:ok, :ignored} = Billing.sync_subscription(event)
+    end
+
+    test "a comped account is never touched by invoice events" do
+      user = invoice_user("comped")
+
+      assert {:ok, :comped_ignored} =
+               Billing.sync_subscription(invoice_event("invoice.payment_failed", user))
+
+      assert {:ok, :comped_ignored} =
+               Billing.sync_subscription(invoice_event("invoice.paid", user))
+
+      refute_enqueued(worker: LifecycleEmail)
+    end
+
+    test "invoice.paid recovers past_due → active and advances the watermark" do
+      ts = 1_800_000_000
+      user = invoice_user("past_due")
+
+      assert {:ok, updated} =
+               Billing.sync_subscription(invoice_event("invoice.paid", user, created: ts))
+
+      assert updated.subscription_status == "active"
+      assert updated.subscription_synced_at == DateTime.from_unix!(ts)
+
+      assert_enqueued(
+        worker: LifecycleEmail,
+        args: %{"user_id" => user.id, "email" => "payment_recovered"}
+      )
+    end
+
+    test "invoice.paid off any state but past_due is a no-op — the $0 trial invoice" do
+      # Stripe pays a $0 invoice the moment a trial subscription is created;
+      # applying it would flip a fresh trialing account straight to active.
+      user = invoice_user("trialing")
+
+      assert {:ok, :ignored} = Billing.sync_subscription(invoice_event("invoice.paid", user))
+      assert Repo.reload(user).subscription_status == "trialing"
+      refute_enqueued(worker: LifecycleEmail)
+    end
+
+    test "a stale invoice.paid cannot move the account" do
+      synced = ~U[2026-08-01 00:00:00Z]
+      user = invoice_user("past_due", synced_at: synced)
+      old_ts = DateTime.to_unix(synced) - 3600
+
+      assert {:ok, :stale} =
+               Billing.sync_subscription(invoice_event("invoice.paid", user, created: old_ts))
+
+      assert Repo.reload(user).subscription_status == "past_due"
+    end
+
+    test "invoice.paid for another subscription is ignored even off past_due" do
+      user = invoice_user("past_due")
+
+      assert {:ok, :other_subscription} =
+               Billing.sync_subscription(
+                 invoice_event("invoice.paid", user, subscription: "sub_other")
+               )
+
+      assert Repo.reload(user).subscription_status == "past_due"
+    end
+  end
 end

--- a/apps/fountain/test/fountain/lifecycle_email_test.exs
+++ b/apps/fountain/test/fountain/lifecycle_email_test.exs
@@ -132,6 +132,26 @@ defmodule Fountain.LifecycleEmailTest do
     end
   end
 
+  describe "webhook transitions that send (#447 additions)" do
+    test "dunning recovery via the subscription event enqueues payment_recovered" do
+      user = user_with_status("past_due")
+
+      assert {:ok, %User{subscription_status: "active"}} =
+               Billing.sync_subscription(
+                 subscription_event(
+                   "customer.subscription.updated",
+                   user.stripe_customer_id,
+                   "active"
+                 )
+               )
+
+      assert_enqueued(
+        worker: LifecycleEmail,
+        args: %{"user_id" => user.id, "email" => "payment_recovered"}
+      )
+    end
+  end
+
   describe "webhook transitions that stay silent" do
     test "a second past_due event in the same dunning cycle does not re-send" do
       # Stripe fires several subscription.updated events per dunning cycle, all
@@ -150,11 +170,10 @@ defmodule Fountain.LifecycleEmailTest do
       refute_enqueued(worker: LifecycleEmail)
     end
 
-    test "recovery and other non-triggering transitions enqueue nothing" do
+    test "non-triggering transitions enqueue nothing" do
+      # past_due → active moved out of this list in #447: dunning recovery
+      # now sends payment_recovered (asserted in the sends describe above).
       for {old, stripe_status} <- [
-            # past_due → active: they fixed the card; congratulating them is
-            # someone else's feature.
-            {"past_due", "active"},
             # trialing → active: they subscribed.
             {"trialing", "active"},
             # active → active: routine sync.
@@ -318,6 +337,50 @@ defmodule Fountain.LifecycleEmailTest do
       assert email.subject =~ "cancelled"
     end
 
+    test "sends action-required to any live account, skips a canceled one (#447)" do
+      for status <- ["trialing", "active", "past_due"] do
+        user = user_with_status(status)
+
+        assert :ok =
+                 perform_job(LifecycleEmail, %{
+                   "user_id" => user.id,
+                   "email" => "payment_action_required"
+                 })
+
+        assert_received {:email, email}
+        assert email.subject =~ "confirm your Fountain payment"
+      end
+
+      canceled = user_with_status("canceled")
+
+      assert :ok =
+               perform_job(LifecycleEmail, %{
+                 "user_id" => canceled.id,
+                 "email" => "payment_action_required"
+               })
+
+      refute_received {:email, _}
+    end
+
+    test "sends payment-recovered only once the account is actually active (#447)" do
+      active = user_with_status("active")
+
+      assert :ok =
+               perform_job(LifecycleEmail, %{"user_id" => active.id, "email" => "payment_recovered"})
+
+      assert_received {:email, email}
+      assert email.subject =~ "Payment received"
+
+      # Still past_due at send time: the recovery hasn't synced, and "you're
+      # all set" while the gate is closed would be a lie.
+      stuck = user_with_status("past_due")
+
+      assert :ok =
+               perform_job(LifecycleEmail, %{"user_id" => stuck.id, "email" => "payment_recovered"})
+
+      refute_received {:email, _}
+    end
+
     test "does not send to someone whose state moved on" do
       # The queue can lag the account. Someone who subscribed after their trial
       # expired, or fixed their card an hour after it bounced, must not then be
@@ -407,6 +470,29 @@ defmodule Fountain.LifecycleEmailTest do
       flat = email.text_body |> String.replace(~r/\s+/, " ")
 
       assert flat =~ "your subscription will be cancelled"
+    end
+
+    test "action required: leads with the fix and says what happens otherwise (#447)" do
+      email =
+        sent(&UserEmails.deliver_payment_action_required_email/1, user_with_status("active"))
+
+      flat = email.text_body |> String.replace(~r/\s+/, " ")
+
+      assert email.subject =~ "Action needed"
+      assert flat =~ "bank is asking for an extra confirmation"
+      assert flat =~ "treated as failed"
+      assert email.html_body =~ "/account/billing"
+      assert email.text_body =~ "/account/billing"
+    end
+
+    test "payment recovered: access is back and nothing was deleted (#447)" do
+      email = sent(&UserEmails.deliver_payment_recovered_email/1, user_with_status("active"))
+      flat = email.text_body |> String.replace(~r/\s+/, " ")
+
+      assert email.subject =~ "Payment received"
+      assert flat =~ "active again"
+      assert flat =~ "nothing was deleted"
+      assert email.html_body =~ "/account/billing"
     end
 
     test "cancellation: no more charges, nothing deleted, and the way back" do

--- a/apps/fountain/test/fountain/stripe_webhook_idempotency_test.exs
+++ b/apps/fountain/test/fountain/stripe_webhook_idempotency_test.exs
@@ -45,6 +45,22 @@ defmodule Fountain.StripeWebhookIdempotencyTest do
       assert Repo.reload(user).subscription_status == "active"
     end
 
+    test "an invoice event id is claimed once — one redelivery, one dunning email (#447)" do
+      _user = user_with_customer("cus_inv_claim")
+
+      event = %Stripe.Event{
+        id: "evt_inv_claim_1",
+        type: "invoice.payment_failed",
+        created: now_unix(),
+        data: %{object: %{customer: "cus_inv_claim", subscription: nil}}
+      }
+
+      assert {:ok, %Fountain.Accounts.User{}} = Billing.handle_event(event)
+      assert {:ok, :duplicate} = Billing.handle_event(event)
+
+      assert [_only_one] = all_enqueued(worker: Fountain.Workers.LifecycleEmail)
+    end
+
     test "a redelivered activation cannot resurrect a cancelled account" do
       # The scenario that motivates this: Stripe retries an older event after a
       # newer one has already been applied.

--- a/apps/fountain/test/fountain/workers/stripe_customer_sync_test.exs
+++ b/apps/fountain/test/fountain/workers/stripe_customer_sync_test.exs
@@ -30,7 +30,19 @@ defmodule Fountain.Workers.StripeCustomerSyncTest do
       user = insert_verified_user()
       {:ok, _} = Fountain.Billing.attach_stripe_customer(user, "cus_existing")
 
-      # No stub: a call to Stripe would fail the test.
+      # Customer.create flunks if called — that is the property under test.
+      # Subscription.create is stubbed benignly instead of left bare: several
+      # async test files put_env :stripe_price_id globally, and when one
+      # overlaps this test the trial-subscription branch legitimately fires —
+      # previously with no stub, so it hit real Stripe and 401ed (flake).
+      stub(Stripe.Customer, :create, fn _ ->
+        flunk("a rerun must not create a second Stripe customer")
+      end)
+
+      stub(Stripe.Subscription, :create, fn _ ->
+        {:ok, %Stripe.Subscription{id: "sub_benign", status: "trialing"}}
+      end)
+
       assert :ok = perform_job(StripeCustomerSync, %{user_id: user.id})
       assert Repo.get(User, user.id).stripe_customer_id == "cus_existing"
     end

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -17,8 +17,16 @@ no key. Set this up only if you run Fountain commercially.
     - `customer.subscription.updated`
     - `customer.subscription.deleted`
     - `customer.subscription.trial_will_end`
+    - `invoice.payment_failed`
+    - `invoice.payment_action_required`
+    - `invoice.paid`
 
     Its signing secret becomes `STRIPE_WEBHOOK_SECRET`.
+
+    An existing endpoint keeps working without the three `invoice.*` events —
+    dunning state still syncs from the subscription events — but the SCA
+    ("confirm your payment") email never fires and recovery notices depend
+    solely on `customer.subscription.updated`. Add them when upgrading.
 
 Use test-mode keys and a test-mode price everywhere except a production
 instance taking real money.
@@ -43,6 +51,12 @@ instance taking real money.
   and order-safe (stale events are ignored). Transient failures return a 500
   so Stripe redelivers.
 - Comped accounts are never overwritten by Stripe events.
+- `invoice.payment_failed` / `invoice.payment_action_required` drive dunning
+  and SCA emails but never write subscription status — that stays with the
+  subscription events. `invoice.paid` writes status in exactly one case:
+  `past_due → active` (dunning recovery), because Stripe also pays a $0
+  invoice at trial creation and one per normal renewal, which must not touch
+  the account.
 
 ## Verify
 
@@ -73,8 +87,11 @@ email) → paid subscription with a test card (gate opens) → cancel at period
 end (access retained, `cancel_at_period_end`/`current_period_end` synced) →
 period end (gate refuses, cancellation email, flag cleared) → re-subscribe
 (the return path) → failed renewal on an always-failing test card (real
-dunning: `past_due`, gate refuses, payment-failed email) —
-asserting the **Fountain-side** state at every step. Each fetched Stripe
+dunning: `past_due`, gate refuses, payment-failed email, and the real failed
+invoice fed through `invoice.payment_failed`) → dunning recovery (a working
+card pays the open invoice; `invoice.paid` flips `past_due → active`, the
+gate opens, payment-recovered email) — asserting the **Fountain-side** state
+at every step. Each fetched Stripe
 state is fed through `Billing.sync_subscription/1`, exactly what the webhook
 controller does after signature verification; webhook *delivery* needs a
 public endpoint and stays out of scope. Cleanup (clock + scratch user) runs


### PR DESCRIPTION
Closes #447 — fourth item of the `story-2026-08` batch.

## What this adds

The three `invoice.*` events, through the existing claim-transaction idempotency machinery:

- **`invoice.payment_failed` / `invoice.payment_action_required`** — notification-only. Status writes stay with the subscription events; these enqueue the dunning email (deduped against the transition-driven enqueue by `LifecycleEmail`'s 24 h uniqueness — one dunning cycle, one email) and a **new SCA email** ("your bank is asking for an extra confirmation") that previously had no signal at all. Unknown customers return `{:ok, :ignored}` rather than `:user_not_found` — a deleted account's trailing invoices are expected traffic.
- **`invoice.paid`** — writes status in exactly **one** case: `past_due → active` (dunning recovery), through the same `subscription_synced_at` watermark and subscription-of-record guards as the subscription events. The narrow scope is load-bearing: Stripe pays a **$0 invoice at trial-subscription creation** and one per normal renewal, and applying those would flip a fresh trialing account straight to active. Pinned by a test.
- **New `payment_recovered` email** on the `past_due → active` transition from *either* path (subscription event or invoice.paid) — the old code even had a comment on the silent-transition test calling recovery "someone else's feature"; this is that feature. Guarded at send time: it only goes out while the account is actually `active`.

## Release verification (the mandatory pre-release check) — ran green

`mix fountain.verify_lifecycle` extended and executed against real Stripe Test Clocks:
- the dunning leg now feeds the **real failed invoice** through `invoice.payment_failed`;
- a new **recovery step** attaches a working card, pays the open invoice via the Stripe API, feeds the real paid invoice through `invoice.paid`, and asserts `past_due → active`, gate open, and the recovery email.

Result: `✅ Lifecycle verified end to end.` Two task fixes fell out of running it: `Stripe.Invoice.list` status must be an atom (dialyzer caught it), and the task now forces `:billing_enabled` — half its checks assert gate refusals and dev defaults the gate off, which failed the run with a misleading error.

## Ops note for the prod Stripe dashboard

The webhook endpoint must be subscribed to the three new events (`invoice.payment_failed`, `invoice.payment_action_required`, `invoice.paid`) — documented in `docs/integrations/stripe.md`, including the graceful degradation if they're missing (dunning still syncs from subscription events; only the SCA email is lost). **I have not touched the Stripe dashboard; the endpoint's event list needs updating when this deploys.**

## Also in this PR

- Deflaked `StripeCustomerSyncTest`'s idempotency test: several async files `put_env :stripe_price_id` globally, and an overlap made its deliberately-unstubbed trial branch hit real Stripe (401). It now stubs `Subscription.create` benignly and makes `Customer.create` flunk — the actual property under test.

## Tests

9 new billing tests (status-untouched, other-subscription, unknown-customer, comped, the $0-trial-invoice no-op, watermark advance, stale rejection), an invoice-event claim/redelivery test asserting exactly one email job, LifecycleEmail guard tests for both new kinds, email-copy tests, and the silent-transition test updated to reflect that recovery now sends. `mix precommit` green: 1,890 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)