### PR TITLE
audit: rejected admin events fail loudly + static allowlist guard (#451)

### DIFF
--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -13,6 +13,8 @@ defmodule Fountain.Audit do
 
   import Ecto.Query
 
+  require Logger
+
   alias Fountain.Audit.AdminEvent
   alias Fountain.Audit.Event
   alias Fountain.Repo
@@ -66,12 +68,37 @@ defmodule Fountain.Audit do
       |> Map.put_new(:metadata, %{})
       |> Map.put_new(:inserted_at, DateTime.utc_now() |> DateTime.truncate(:second))
 
-    %AdminEvent{} |> AdminEvent.changeset(attrs) |> Repo.insert()
+    case %AdminEvent{} |> AdminEvent.changeset(attrs) |> Repo.insert() do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, changeset} = err ->
+        # Callers ignore this return by design (best-effort), so a rejected
+        # write — usually an event type missing from the AdminEvent allowlist
+        # — silently erased its privilege-trail row. Twice, before #451. Log
+        # at error and count it so the drop is visible and alertable.
+        admin_record_lost(attrs, changeset.errors)
+        err
+    end
   rescue
     e ->
-      require Logger
-      Logger.warning("audit: admin record failed: #{inspect(e)}")
+      admin_record_lost(attrs, e)
       {:error, :exception}
+  end
+
+  defp admin_record_lost(attrs, reason) do
+    event_type = to_string(attrs[:event_type] || "unknown")
+
+    Logger.error(
+      "audit: admin event REJECTED, no privilege-trail row written " <>
+        "(event_type=#{event_type}): #{inspect(reason)}"
+    )
+
+    :telemetry.execute(
+      [:fountain, :audit, :admin_record_rejected],
+      %{count: 1},
+      %{event_type: event_type}
+    )
   end
 
   @doc "Most recent administrative actions, newest first. Admin surfaces only."

--- a/apps/fountain/lib/fountain/audit/admin_event.ex
+++ b/apps/fountain/lib/fountain/audit/admin_event.ex
@@ -29,11 +29,13 @@ defmodule Fountain.Audit.AdminEvent do
     field :inserted_at, :utc_datetime
   end
 
-  # Closed allowlist: an unknown type fails validation and record_admin/1
-  # swallows the error, so an event type missing from this list is silently
-  # never recorded. That already happened once — admin.account.deleted shipped
-  # in the deletion work without being added here, and admin deletions left no
-  # audit row until the admin billing work tripped over the same behaviour.
+  # Closed allowlist: an unknown type fails validation, so an event type
+  # missing from this list is never recorded. That bit twice
+  # (admin.account.deleted, then again in the billing work) while the drop
+  # was silent. Since #451 a rejected write logs at error and emits
+  # [:fountain, :audit, :admin_record_rejected], and a static test
+  # (audit_coverage_test.exs) fails if a record_admin call site uses a type
+  # that is not listed here — add the type below before shipping the call.
   @event_types ~w(
     admin.role.granted
     admin.role.revoked

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -108,6 +108,13 @@ defmodule FountainWeb.Telemetry do
         tags: [:stage, :status],
         description: "Conversation stage transitions by stage and status"
       ),
+      # Any non-zero value here means a privilege-trail row was silently
+      # dropped (#451) — alert-worthy, not informational.
+      counter("fountain.audit.admin_record_rejected.count",
+        event_name: [:fountain, :audit, :admin_record_rejected],
+        tags: [:event_type],
+        description: "Admin audit events rejected at write time (lost trail rows)"
+      ),
       distribution("fountain.fresh_provision.stop.duration",
         event_name: [:fountain, :fresh_provision, :stop],
         measurement: :duration,

--- a/apps/fountain/test/fountain/audit_test.exs
+++ b/apps/fountain/test/fountain/audit_test.exs
@@ -1,6 +1,8 @@
 defmodule Fountain.AuditTest do
   use Fountain.DataCase, async: true
 
+  import ExUnit.CaptureLog
+
   alias Fountain.Audit
 
   defp valid_attrs(user_id, overrides \\ %{}) do
@@ -147,6 +149,63 @@ defmodule Fountain.AuditTest do
       # Passing a non-enumerable triggers Protocol.UndefinedError inside cast,
       # which is rescued and returns {:error, :exception} with a warning log.
       assert {:error, :exception} = Audit.record(:not_a_map)
+    end
+  end
+
+  describe "record_admin/1 — rejected writes are loud (#451)" do
+    test "an unknown event type is rejected with an error log, not silently" do
+      actor = insert_verified_user()
+
+      log =
+        capture_log(fn ->
+          assert {:error, %Ecto.Changeset{}} =
+                   Audit.record_admin(%{
+                     actor_user_id: actor.id,
+                     target_user_id: nil,
+                     event_type: "admin.not.in.the.allowlist"
+                   })
+        end)
+
+      assert log =~ "REJECTED"
+      assert log =~ "admin.not.in.the.allowlist"
+    end
+
+    test "a rejected write emits the admin_record_rejected telemetry event" do
+      test_pid = self()
+      handler_id = "audit-reject-#{inspect(self())}"
+
+      :telemetry.attach(
+        handler_id,
+        [:fountain, :audit, :admin_record_rejected],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:rejected, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      capture_log(fn ->
+        Audit.record_admin(%{event_type: "admin.also.unknown"})
+      end)
+
+      assert_receive {:rejected, %{count: 1}, %{event_type: "admin.also.unknown"}}
+    end
+
+    test "a valid write emits nothing and logs nothing" do
+      actor = insert_verified_user()
+
+      log =
+        capture_log(fn ->
+          assert {:ok, _} =
+                   Audit.record_admin(%{
+                     actor_user_id: actor.id,
+                     event_type: "admin.account.suspended",
+                     metadata: %{"email" => "x@example.com"}
+                   })
+        end)
+
+      refute log =~ "REJECTED"
     end
   end
 end

--- a/apps/fountain/test/fountain_web/audit_coverage_test.exs
+++ b/apps/fountain/test/fountain_web/audit_coverage_test.exs
@@ -209,6 +209,37 @@ defmodule FountainWeb.AuditCoverageTest do
     end
   end
 
+  describe "the AdminEvent allowlist matches the code (#451)" do
+    test "every admin.* event type used in lib/ is in the allowlist" do
+      # The allowlist is a closed validate_inclusion, and record_admin is
+      # best-effort — an event type shipped without being added here is
+      # rejected at write time and the privilege trail silently loses the
+      # row. That happened twice before #451. This scan turns the mistake
+      # into a test failure at development time.
+      #
+      # The regex catches the dominant call-site shape (a string literal
+      # under an event_type: key). Types built dynamically (e.g. the
+      # role-grant if/else) are not caught here, but their branches are
+      # string literals matched elsewhere in the same expression.
+      used =
+        Path.wildcard("lib/**/*.ex")
+        |> Enum.flat_map(fn file ->
+          ~r/"(admin\.[a-z_]+(?:\.[a-z_]+)+)"/
+          |> Regex.scan(File.read!(file))
+          |> Enum.map(fn [_, type] -> type end)
+        end)
+        |> Enum.uniq()
+
+      assert used != [], "expected to find admin.* event types in lib/ — did call sites move?"
+
+      missing = used -- AdminEvent.event_types()
+
+      assert missing == [],
+             "admin event types used in code but missing from the AdminEvent allowlist — " <>
+               "these writes would be rejected and the trail rows lost: #{inspect(missing)}"
+    end
+  end
+
   describe "API key lifecycle through the UI" do
     test "creation and revocation are both recorded", %{conn: conn} do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -122,6 +122,9 @@ defmodule FountainWeb.MetricsTest do
         [:fountain, :sandbox, :reclaimed],
         [:fountain, :reaper, :run],
         [:fountain, :reaper, :untracked],
+        # Audit.record_admin/1 rejection path (#451) — exercised by
+        # Fountain.AuditTest's rejected-write telemetry test
+        [:fountain, :audit, :admin_record_rejected],
         # ConversationServer: provision watchdog (#329) and durable-output
         # budget (#331) — the two cost signals #405 gave subscribers
         [:fountain, :provision, :deadline_exceeded],


### PR DESCRIPTION
Closes #451 — from the `story-2026-08` batch.

The `AdminEvent` `@event_types` allowlist is a closed `validate_inclusion`, and `record_admin/1` is best-effort by design — so an event type shipped without being added to the list was rejected at write time and the privilege trail **silently lost the row**. The comment in the schema documents this biting twice already.

Three layers, per the issue's preferred option:

1. **Loud at runtime**: a rejected write now logs at `error` ("admin event REJECTED, no privilege-trail row written") and emits `[:fountain, :audit, :admin_record_rejected]`, on both the changeset-rejection and exception paths. Call sites stay best-effort — the operation still succeeds.
2. **Alertable**: the counter is registered in telemetry (`fountain.audit.admin_record_rejected.count`, tagged by `event_type`) with a comment noting any non-zero value is a lost trail row, not information.
3. **Caught at development time**: a static test scans `lib/**/*.ex` for `admin.*` event-type string literals and fails with the missing types listed if any isn't in the allowlist. Shipping a new admin action without updating the allowlist is now a red test, not a silent hole.

Tests: error-log content, telemetry emission with the offending event type, silence on the happy path, and the static scan (which found all current call sites covered). `mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)