### PR TITLE
emails: suspension/deletion notifications + export nudge before delete (#450)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,10 @@ RESEND_API_KEY=
 
 EMAIL_FROM=noreply@updates.inevitable.fyi
 
+# Optional: where "contact support" in account emails (suspension, deletion)
+# points. Unset, the emails say "contact support" with no address.
+# SUPPORT_EMAIL=support@example.com
+
 # ── Authentication ───────────────────────────────────────────────────────────
 
 # GitHub OAuth (register at https://github.com/settings/developers). Optional:

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -652,6 +652,12 @@ defmodule Fountain.Accounts do
            |> User.invalidate_sessions_changeset()
            |> Repo.update() do
       reaped = Fountain.Conversations._unsafe_reap_all_for_user(user.id)
+
+      # Best-effort notification (#450): before this the user's only signal
+      # was "account currently unavailable" at their next login attempt. The
+      # worker re-checks state and verification at send time.
+      Fountain.Workers.AccountEmail.enqueue_suspended(updated)
+
       {:ok, updated, reaped}
     end
   end
@@ -662,7 +668,10 @@ defmodule Fountain.Accounts do
   """
   @spec unsuspend_user(User.t()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def unsuspend_user(%User{} = user) do
-    user |> Ecto.Changeset.change(suspended_at: nil) |> Repo.update()
+    with {:ok, updated} <- user |> Ecto.Changeset.change(suspended_at: nil) |> Repo.update() do
+      Fountain.Workers.AccountEmail.enqueue_unsuspended(updated)
+      {:ok, updated}
+    end
   end
 
   @doc "Whether the account is currently suspended."

--- a/apps/fountain/lib/fountain/accounts/deletion.ex
+++ b/apps/fountain/lib/fountain/accounts/deletion.ex
@@ -96,6 +96,16 @@ defmodule Fountain.Accounts.Deletion do
       case Repo.delete(user) do
         {:ok, _} ->
           Logger.info("account deleted: #{user.id} (#{sprites} sprite(s) destroyed)")
+
+          # Confirmation to the departing user (#450). Gated on verification,
+          # which covers the UnverifiedAccountPruner path for free — an
+          # address that never proved it was theirs gets no mail from us,
+          # whoever triggered the deletion. The job carries the address
+          # itself; the row is already gone.
+          if user.email_verified_at do
+            Fountain.Workers.AccountEmail.enqueue_deleted(user.email)
+          end
+
           {:ok, %{user_id: user.id, sprites_destroyed: sprites}}
 
         {:error, reason} ->

--- a/apps/fountain/lib/fountain/emails/user_emails.ex
+++ b/apps/fountain/lib/fountain/emails/user_emails.ex
@@ -223,6 +223,57 @@ defmodule Fountain.Emails.UserEmails do
     |> Mailer.deliver()
   end
 
+  @doc """
+  Tell a user their account was suspended (#450).
+
+  Before this the only signal was a generic "account currently unavailable"
+  at the next login attempt — no explanation, no route to appeal. Deliberately
+  does not say *why*: the reason lives in the admin audit trail, and an email
+  template can't know it. Points at support instead.
+  """
+  @spec deliver_account_suspended_email(User.t()) :: {:ok, term()} | {:error, term()}
+  def deliver_account_suspended_email(%User{} = user) do
+    new()
+    |> from(from_address())
+    |> to({user.email, user.email})
+    |> subject("Your Fountain account has been suspended")
+    |> html_body(account_suspended_html())
+    |> text_body(account_suspended_text())
+    |> Mailer.deliver()
+  end
+
+  @doc "The counterpart: the suspension was lifted; sign in again (#450)."
+  @spec deliver_account_unsuspended_email(User.t()) :: {:ok, term()} | {:error, term()}
+  def deliver_account_unsuspended_email(%User{} = user) do
+    login_url = "#{Fountain.PublicUrl.base()}/auth/login"
+
+    new()
+    |> from(from_address())
+    |> to({user.email, user.email})
+    |> subject("Your Fountain account is available again")
+    |> html_body(account_unsuspended_html(login_url))
+    |> text_body(account_unsuspended_text(login_url))
+    |> Mailer.deliver()
+  end
+
+  @doc """
+  Confirm an account deletion (#450).
+
+  Takes a raw address, not a `User` — by send time the row is gone. Honest
+  about the two things that survive: Stripe keeps the invoices (financial
+  records), and backups age out on their own schedule.
+  """
+  @spec deliver_account_deleted_email(String.t()) :: {:ok, term()} | {:error, term()}
+  def deliver_account_deleted_email(email) when is_binary(email) do
+    new()
+    |> from(from_address())
+    |> to({email, email})
+    |> subject("Your Fountain account has been deleted")
+    |> html_body(account_deleted_html())
+    |> text_body(account_deleted_text())
+    |> Mailer.deliver()
+  end
+
   ## Private helpers
 
   # "in 3 days" reads better than a timestamp, but a date is unambiguous across
@@ -574,6 +625,130 @@ defmodule Fountain.Emails.UserEmails do
   defp from_address do
     addr = Application.get_env(:fountain, :email_from, "noreply@updates.inevitable.fyi")
     {addr, addr}
+  end
+
+  # "contact us at x@y" when SUPPORT_EMAIL is configured; a from-address that
+  # starts with noreply@ makes "reply to this email" a lie, so without it the
+  # copy stays vague rather than pointing somewhere replies go to die.
+  defp support_phrase do
+    case Application.get_env(:fountain, :support_email) do
+      addr when is_binary(addr) and addr != "" -> "contact us at #{addr}"
+      _ -> "contact support"
+    end
+  end
+
+  defp account_suspended_html do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>Your Fountain account has been suspended</h2>
+      <p>
+        Your account has been suspended: existing sessions are signed out, API
+        keys stop working, and running conversations have been stopped.
+      </p>
+      <p>
+        <strong>Nothing is deleted.</strong> Your agents, environments, vaults and
+        conversation history stay exactly as they are, and your subscription is
+        not changed by a suspension.
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        If you believe this is an error, #{support_phrase()}.
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp account_suspended_text do
+    """
+    Your Fountain account has been suspended
+
+    Your account has been suspended: existing sessions are signed out, API
+    keys stop working, and running conversations have been stopped.
+
+    Nothing is deleted. Your agents, environments, vaults and conversation
+    history stay exactly as they are, and your subscription is not changed by
+    a suspension.
+
+    If you believe this is an error, #{support_phrase()}.
+    """
+  end
+
+  defp account_unsuspended_html(login_url) do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>Your Fountain account is available again</h2>
+      <p>
+        The suspension on your account has been lifted. Sign in to pick up
+        where you left off — everything is as you left it.
+      </p>
+      <p style="margin: 32px 0;">
+        <a href="#{login_url}"
+           style="background: #18181b; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-size: 14px;">
+          Sign in
+        </a>
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        Or copy this link into your browser:<br/>
+        <a href="#{login_url}" style="color: #3b82f6;">#{login_url}</a>
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp account_unsuspended_text(login_url) do
+    """
+    Your Fountain account is available again
+
+    The suspension on your account has been lifted. Sign in to pick up where
+    you left off — everything is as you left it:
+
+    #{login_url}
+    """
+  end
+
+  defp account_deleted_html do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>Your Fountain account has been deleted</h2>
+      <p>
+        This confirms your Fountain account and its data — agents,
+        environments, vaults, conversations and stored secrets — have been
+        permanently deleted. Any subscription was cancelled first; you will
+        not be charged again.
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        Past invoices remain available from Stripe, as financial records.
+        Database backups that predate the deletion age out on their own
+        retention schedule.
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        If you did not request this, #{support_phrase()} immediately.
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp account_deleted_text do
+    """
+    Your Fountain account has been deleted
+
+    This confirms your Fountain account and its data — agents, environments,
+    vaults, conversations and stored secrets — have been permanently deleted.
+    Any subscription was cancelled first; you will not be charged again.
+
+    Past invoices remain available from Stripe, as financial records. Database
+    backups that predate the deletion age out on their own retention schedule.
+
+    If you did not request this, #{support_phrase()} immediately.
+    """
   end
 
   defp verification_html(url) do

--- a/apps/fountain/lib/fountain/workers/account_email.ex
+++ b/apps/fountain/lib/fountain/workers/account_email.ex
@@ -1,0 +1,93 @@
+defmodule Fountain.Workers.AccountEmail do
+  @moduledoc """
+  Account-state notifications (#450): suspended, unsuspended, deleted.
+
+  Separate from `Workers.LifecycleEmail` because these are not billing-status
+  transitions and its status guards don't fit — a suspension can happen to an
+  account in any billing state, and a deletion has no user row left to guard
+  on at all.
+
+  State-dependent kinds re-check at send time: a suspension lifted before the
+  queue drained must not then be announced. The `"deleted"` kind carries the
+  address itself (captured before the row delete) and sends unconditionally —
+  there is nothing left to check against. Verification is enforced where the
+  user row still exists: the worker skips unverified accounts, and the
+  deletion path only enqueues for verified ones, so no kind ever confirms an
+  unverified address exists.
+  """
+
+  use Oban.Worker,
+    queue: :mailer,
+    max_attempts: 5,
+    unique: [period: 300, fields: [:worker, :args]]
+
+  require Logger
+
+  alias Fountain.{Accounts, Emails.UserEmails}
+
+  @doc "Enqueue the suspension notice for `user`."
+  def enqueue_suspended(%Accounts.User{id: id}) do
+    %{user_id: id, kind: "suspended"} |> new() |> Oban.insert()
+  end
+
+  @doc "Enqueue the suspension-lifted notice for `user`."
+  def enqueue_unsuspended(%Accounts.User{id: id}) do
+    %{user_id: id, kind: "unsuspended"} |> new() |> Oban.insert()
+  end
+
+  @doc """
+  Enqueue the deletion confirmation for a raw address — call BEFORE the row
+  delete commits is fine (the job only carries the string), but the caller
+  must have already established the address was verified.
+  """
+  def enqueue_deleted(email) when is_binary(email) do
+    %{email: email, kind: "deleted"} |> new() |> Oban.insert()
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"kind" => "deleted", "email" => email}}) do
+    deliver("deleted", email, fn -> UserEmails.deliver_account_deleted_email(email) end)
+  end
+
+  def perform(%Oban.Job{args: %{"kind" => kind, "user_id" => user_id}})
+      when kind in ["suspended", "unsuspended"] do
+    case Accounts.get_user(user_id) do
+      nil ->
+        Logger.info("account_email: user #{user_id} no longer exists")
+        :ok
+
+      %{email_verified_at: nil} ->
+        # Never confirm an unverified address exists, whatever the state.
+        :ok
+
+      user ->
+        maybe_send(user, kind)
+    end
+  end
+
+  # Send only while the state the email describes still holds.
+  defp maybe_send(%{suspended_at: %DateTime{}} = user, "suspended"),
+    do: deliver("suspended", user.id, fn -> UserEmails.deliver_account_suspended_email(user) end)
+
+  defp maybe_send(%{suspended_at: nil} = user, "unsuspended"),
+    do:
+      deliver("unsuspended", user.id, fn ->
+        UserEmails.deliver_account_unsuspended_email(user)
+      end)
+
+  defp maybe_send(user, kind) do
+    Logger.info("account_email: skipping #{kind} for #{user.id}, state has moved on")
+    :ok
+  end
+
+  defp deliver(kind, ref, fun) do
+    case fun.() do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("account_email: #{kind} delivery failed for #{ref}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/billing_live.ex
+++ b/apps/fountain/lib/fountain_web/live/billing_live.ex
@@ -316,7 +316,7 @@ defmodule FountainWeb.Live.BillingLive do
 
       <%!-- Data export --%>
       <div class="rounded-lg border bg-white p-6 shadow-sm">
-        <h2 class="mb-1 text-lg font-medium">Export your data</h2>
+        <h2 class="mb-1 text-lg font-medium" id="export">Export your data</h2>
         <p class="mb-2 text-sm text-gray-600">
           Download a single JSON file containing your agents, environments, vaults,
           conversations with their full log output, and your audit trail.
@@ -381,6 +381,11 @@ defmodule FountainWeb.Live.BillingLive do
           Secrets are encrypted with a key held only for your account; deleting the
           account destroys that key, so they cannot be recovered afterwards by anyone.
           <strong>This cannot be undone.</strong>
+        </p>
+        <p class="mb-4 text-sm text-gray-600" id="delete-export-nudge">
+          Want a copy of your data first?
+          <a href="#export" class="underline">Request an export above</a>
+          before deleting — nothing can be recovered afterwards.
         </p>
 
         <form phx-submit="delete_account" class="space-y-3">

--- a/apps/fountain/test/fountain/accounts/deletion_test.exs
+++ b/apps/fountain/test/fountain/accounts/deletion_test.exs
@@ -36,6 +36,29 @@ defmodule Fountain.Accounts.DeletionTest do
     user
   end
 
+  describe "deletion confirmation email (#450)" do
+    test "a verified account's deletion enqueues the confirmation, carrying the address" do
+      user = insert_verified_user()
+
+      capture_log(fn -> assert {:ok, _} = Deletion.delete_user(user) end)
+
+      assert_enqueued(
+        worker: Fountain.Workers.AccountEmail,
+        args: %{kind: "deleted", email: user.email}
+      )
+    end
+
+    test "an unverified account gets no confirmation — covers the pruner path" do
+      # An address that never proved it was theirs gets no mail from us,
+      # whoever triggered the deletion (UnverifiedAccountPruner included).
+      user = insert_user()
+
+      capture_log(fn -> assert {:ok, _} = Deletion.delete_user(user) end)
+
+      refute_enqueued(worker: Fountain.Workers.AccountEmail)
+    end
+  end
+
   describe "what is removed" do
     test "the user and everything cascading from them" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain/workers/account_email_test.exs
+++ b/apps/fountain/test/fountain/workers/account_email_test.exs
@@ -1,0 +1,87 @@
+defmodule Fountain.Workers.AccountEmailTest do
+  use Fountain.DataCase, async: true
+
+  import Swoosh.TestAssertions
+
+  alias Fountain.Accounts
+  alias Fountain.Workers.AccountEmail
+
+  describe "suspended" do
+    test "notifies a suspended, verified user" do
+      user = insert_verified_user()
+      {:ok, user, _reaped} = Accounts.suspend_user(user)
+
+      assert :ok = perform_job(AccountEmail, %{"kind" => "suspended", "user_id" => user.id})
+
+      assert_email_sent(fn email ->
+        assert email.subject == "Your Fountain account has been suspended"
+        assert email.to == [{user.email, user.email}]
+        assert email.text_body =~ "Nothing is deleted"
+      end)
+    end
+
+    test "stays silent when the suspension was lifted before the queue drained" do
+      user = insert_verified_user()
+
+      assert :ok = perform_job(AccountEmail, %{"kind" => "suspended", "user_id" => user.id})
+
+      assert_no_email_sent()
+    end
+
+    test "never emails an unverified address" do
+      user = insert_user()
+      {:ok, _user, _} = Accounts.suspend_user(user)
+
+      assert :ok = perform_job(AccountEmail, %{"kind" => "suspended", "user_id" => user.id})
+
+      assert_no_email_sent()
+    end
+  end
+
+  describe "unsuspended" do
+    test "notifies once the account is actually unsuspended" do
+      user = insert_verified_user()
+
+      assert :ok = perform_job(AccountEmail, %{"kind" => "unsuspended", "user_id" => user.id})
+
+      assert_email_sent(fn email ->
+        assert email.subject == "Your Fountain account is available again"
+        assert email.text_body =~ "/auth/login"
+      end)
+    end
+
+    test "stays silent while the account is still suspended" do
+      user = insert_verified_user()
+      {:ok, user, _} = Accounts.suspend_user(user)
+
+      assert :ok = perform_job(AccountEmail, %{"kind" => "unsuspended", "user_id" => user.id})
+
+      assert_no_email_sent()
+    end
+  end
+
+  describe "deleted" do
+    test "confirms to the raw address — the row is gone by send time" do
+      assert :ok =
+               perform_job(AccountEmail, %{"kind" => "deleted", "email" => "gone@example.com"})
+
+      assert_email_sent(fn email ->
+        assert email.subject == "Your Fountain account has been deleted"
+        assert email.to == [{"gone@example.com", "gone@example.com"}]
+        assert email.text_body =~ "will not be charged again"
+      end)
+    end
+  end
+
+  describe "wiring" do
+    test "suspend_user and unsuspend_user enqueue their notices" do
+      user = insert_verified_user()
+
+      {:ok, user, _} = Accounts.suspend_user(user)
+      assert_enqueued(worker: AccountEmail, args: %{user_id: user.id, kind: "suspended"})
+
+      {:ok, _user} = Accounts.unsuspend_user(user)
+      assert_enqueued(worker: AccountEmail, args: %{user_id: user.id, kind: "unsuspended"})
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/account_deletion_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/account_deletion_live_test.exs
@@ -33,6 +33,10 @@ defmodule FountainWeb.AccountDeletionLiveTest do
 
       {:ok, lv, html} = live(login_user(conn, user), ~p"/account/billing")
       assert html =~ "Delete account"
+      # The export nudge sits in the danger zone and anchors to the export
+      # section above it (#450).
+      assert html =~ "Request an export above"
+      assert html =~ ~s{id="export"}
 
       capture_log(fn ->
         assert {:error, {:redirect, %{to: to}}} =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -362,6 +362,11 @@ config :fountain, :stripe_price_monthly_cents, stripe_price_monthly_cents
 if config_env() == :prod do
   config :fountain, :email_from, System.get_env("EMAIL_FROM", "noreply@updates.inevitable.fyi")
 
+  # Optional (#450): where "contact support" in account emails points. Unset,
+  # the copy stays vague — EMAIL_FROM is usually a noreply@ address, so
+  # "reply to this email" would point somewhere replies go to die.
+  config :fountain, :support_email, System.get_env("SUPPORT_EMAIL")
+
   # "" counts as unset for the adapter choice (#396): docker-compose.yml passes
   # `${RESEND_API_KEY:-}` / `${SMTP_HOST:-}` / `${SMTP_USERNAME:-}`, which
   # deliver present-but-empty variables — and "" is truthy, so a blank

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,7 @@ signup with no visible error. See [Email](self-hosting.md#email).
 | `SMTP_TLS` | `always` | — | STARTTLS by default; `never` for a relay on a trusted network that does not offer it |
 | `EMAIL_DELIVERY` | — | one of three | `none` deliberately disables email. Password-and-email accounts then cannot verify themselves; use `Fountain.Release.verify_email/1` |
 | `EMAIL_FROM` | `noreply@updates.inevitable.fyi` | — | The From address. Change it — the default is the hosted instance's sending domain |
+| `SUPPORT_EMAIL` | — | — | Where "contact support" in account emails (suspension, deletion) points. Unset, the copy names no address |
 
 ## Authentication
 


### PR DESCRIPTION
Closes #450 — from the `story-2026-08` batch.

## What this adds

- **`Workers.AccountEmail`** (`:mailer` queue), three kinds:
  - `suspended` / `unsuspended` — state-guarded at send time (a suspension lifted before the queue drained is not announced) and skip unverified addresses. Suspension copy deliberately doesn't state a reason (that lives in the admin audit trail); it says what happened — sessions out, keys refused, running work stopped — and leads with **nothing is deleted, billing untouched**, matching `suspend_user/1`'s actual semantics.
  - `deleted` — carries the raw address in job args (the row is gone by send time). Honest about what survives: Stripe keeps invoices as financial records; backups age out on their own retention schedule — the same two boundaries the `Deletion` moduledoc documents.
- **Wiring** in `Accounts.suspend_user/1`, `unsuspend_user/1`, and `Deletion.delete_user/2`. The deletion email is gated on `email_verified_at` **at enqueue** — which covers the `UnverifiedAccountPruner` path for free, exactly as filed: an address that never proved it was theirs gets no mail from us, whoever triggered the deletion.
- **Export nudge** in the billing page's danger zone ("Want a copy of your data first?"), anchoring to the export section above it. (The typed-email deletion confirmation the issue asked about already existed.)
- **`SUPPORT_EMAIL`** (optional): "contact us at x@y" in the suspension/deletion emails when set. When unset the copy names no address — `EMAIL_FROM` is usually `noreply@`, so "reply to this email" would point somewhere replies go to die. Documented in `docs/configuration.md` (the config-reference test enforced that) and `.env.example`.

All sends are best-effort: enqueue failures never fail the suspend/delete, and delivery failures retry via Oban without touching the underlying operation.

## Tests

Worker guards (state-moved-on silence, unverified silence, raw-address delivery), wiring assertions on suspend/unsuspend/delete, the pruner-path negative case, and the danger-zone nudge. `mix precommit` green: 1,912 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)