### PR TITLE
accounts: logged-in change-password and verified change-email flows (#448)

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -181,6 +181,129 @@ defmodule Fountain.Accounts do
     |> Repo.update()
   end
 
+  # ── credential management (#448) ─────────────────────────────────────────
+
+  @email_change_salt "email_change"
+  @email_change_max_age 86_400
+
+  @doc """
+  Change a logged-in user's password (#448).
+
+  Requires the current password — a stolen session must not be enough to set
+  a new one. Delegates to `reset_password/2`, so `session_version` bumps and
+  every other session dies; the calling controller re-issues the current
+  session from the updated user. OAuth-only accounts (nil `password_hash`)
+  are refused — they set a first password through the reset flow.
+  """
+  @spec change_password(User.t(), String.t(), String.t()) ::
+          {:ok, User.t()} | {:error, :no_password | :invalid_current_password | Ecto.Changeset.t()}
+  def change_password(%User{password_hash: nil}, _current, _new), do: {:error, :no_password}
+
+  def change_password(%User{} = user, current, new) when is_binary(current) and is_binary(new) do
+    if Bcrypt.verify_pass(current, user.password_hash) do
+      reset_password(user, new)
+    else
+      {:error, :invalid_current_password}
+    end
+  end
+
+  @doc """
+  Start a verified email change (#448): the address only changes when a link
+  sent to the NEW address is clicked (`apply_email_change/1`).
+
+  Requires the current password — same session-theft reasoning as
+  `change_password/3`, and doubly so here because controlling the address
+  controls password recovery. Whether the new address is free is never
+  revealed: the confirmation is enqueued only when it is, and the caller
+  shows the same response either way.
+  """
+  @spec request_email_change(User.t(), String.t(), String.t()) ::
+          :ok | {:error, :no_password | :invalid_current_password | :invalid_email | :same_email}
+  def request_email_change(%User{password_hash: nil}, _new_email, _current),
+    do: {:error, :no_password}
+
+  def request_email_change(%User{} = user, new_email, current) when is_binary(current) do
+    new_email = new_email |> to_string() |> String.trim() |> String.downcase()
+
+    cond do
+      not Bcrypt.verify_pass(current, user.password_hash) ->
+        {:error, :invalid_current_password}
+
+      not (new_email =~ ~r/^[^\s@]+@[^\s@]+$/) ->
+        {:error, :invalid_email}
+
+      new_email == user.email ->
+        {:error, :same_email}
+
+      true ->
+        if is_nil(get_user_by_email(new_email)) do
+          Fountain.Workers.EmailChangeEmail.enqueue_confirmation(user, new_email)
+        end
+
+        :ok
+    end
+  end
+
+  @doc """
+  Token for the email-change confirmation link. Carries the target address and
+  the `session_version` it was issued against, so a password change (or
+  suspension, or a completed change) in the meantime invalidates it.
+  """
+  @spec email_change_token(User.t(), String.t()) :: String.t()
+  def email_change_token(%User{} = user, new_email) do
+    Phoenix.Token.sign(
+      FountainWeb.Endpoint,
+      @email_change_salt,
+      {user.id, new_email, user.session_version}
+    )
+  end
+
+  @doc """
+  Complete an email change from a confirmation token.
+
+  Clicking the link is proof of control of the new address, so
+  `email_verified_at` is stamped fresh. `session_version` bumps — the change
+  is security-relevant and every outstanding session (and any other
+  outstanding email-change token) must die with it. The old address is
+  notified after the write.
+
+  Returns `{:ok, user, old_email}`, or `{:error, :expired | :invalid |
+  :email_taken}`.
+  """
+  @spec apply_email_change(String.t()) ::
+          {:ok, User.t(), String.t()} | {:error, :expired | :invalid | :email_taken}
+  def apply_email_change(token) when is_binary(token) do
+    with {:ok, {user_id, new_email, session_version}} <-
+           Phoenix.Token.verify(FountainWeb.Endpoint, @email_change_salt, token,
+             max_age: @email_change_max_age
+           ),
+         %User{session_version: ^session_version} = user <- get_user(user_id) do
+      old_email = user.email
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      result =
+        user
+        |> Ecto.Changeset.change(email: new_email, email_verified_at: now)
+        |> Ecto.Changeset.unique_constraint(:email)
+        |> User.invalidate_sessions_changeset()
+        |> Repo.update()
+
+      case result do
+        {:ok, updated} ->
+          Fountain.Workers.EmailChangeEmail.enqueue_notice(old_email, new_email)
+          {:ok, updated, old_email}
+
+        {:error, %Ecto.Changeset{errors: errors}} ->
+          if Keyword.has_key?(errors, :email),
+            do: {:error, :email_taken},
+            else: {:error, :invalid}
+      end
+    else
+      {:error, :expired} -> {:error, :expired}
+      _ -> {:error, :invalid}
+    end
+  end
+
   @doc """
   Mark onboarding as completed by setting `onboarding_completed_at` to now.
   """

--- a/apps/fountain/lib/fountain/emails/user_emails.ex
+++ b/apps/fountain/lib/fountain/emails/user_emails.ex
@@ -274,6 +274,43 @@ defmodule Fountain.Emails.UserEmails do
     |> Mailer.deliver()
   end
 
+  @doc """
+  The email-change confirmation, sent to the NEW address (#448).
+
+  Clicking the link is what performs the change; until then nothing happens,
+  and the copy says so — the recipient may never have heard of Fountain.
+  """
+  @spec deliver_email_change_confirmation(String.t(), String.t()) ::
+          {:ok, term()} | {:error, term()}
+  def deliver_email_change_confirmation(new_email, token) when is_binary(new_email) do
+    confirm_url = "#{Fountain.PublicUrl.base()}/account/email/confirm/#{token}"
+
+    new()
+    |> from(from_address())
+    |> to({new_email, new_email})
+    |> subject("Confirm your new Fountain email address")
+    |> html_body(email_change_html(confirm_url))
+    |> text_body(email_change_text(confirm_url))
+    |> Mailer.deliver()
+  end
+
+  @doc """
+  Tell the OLD address its account's email changed (#448). This is the
+  account-takeover tripwire: the old address can no longer sign in, so the
+  copy points at support rather than at a login form.
+  """
+  @spec deliver_email_changed_notice(String.t(), String.t()) ::
+          {:ok, term()} | {:error, term()}
+  def deliver_email_changed_notice(old_email, new_email) do
+    new()
+    |> from(from_address())
+    |> to({old_email, old_email})
+    |> subject("Your Fountain email address was changed")
+    |> html_body(email_changed_notice_html(new_email))
+    |> text_body(email_changed_notice_text(new_email))
+    |> Mailer.deliver()
+  end
+
   ## Private helpers
 
   # "in 3 days" reads better than a timestamp, but a date is unambiguous across
@@ -619,6 +656,83 @@ defmodule Fountain.Emails.UserEmails do
 
     If you meant to cancel, you do not need to do anything. Thanks for giving
     Fountain a try.
+    """
+  end
+
+  defp email_change_html(url) do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>Confirm your new Fountain email address</h2>
+      <p>
+        A Fountain account asked to change its email address to this one.
+        Click the button below to confirm — the change only happens when you
+        do. The link expires in 24 hours.
+      </p>
+      <p style="margin: 32px 0;">
+        <a href="#{url}"
+           style="background: #18181b; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-size: 14px;">
+          Confirm new address
+        </a>
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        Or copy this link into your browser:<br/>
+        <a href="#{url}" style="color: #3b82f6;">#{url}</a>
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        If you didn't request this, you can safely ignore this email — nothing
+        changes unless the link is clicked.
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp email_change_text(url) do
+    """
+    Confirm your new Fountain email address
+
+    A Fountain account asked to change its email address to this one. Open
+    the link below to confirm — the change only happens when you do. The link
+    expires in 24 hours.
+
+    #{url}
+
+    If you didn't request this, you can safely ignore this email — nothing
+    changes unless the link is clicked.
+    """
+  end
+
+  defp email_changed_notice_html(new_email) do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>Your Fountain email address was changed</h2>
+      <p>
+        The email address on your Fountain account was changed to
+        <strong>#{new_email}</strong>. This address can no longer be used to
+        sign in.
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        If you made this change, no action is needed. If you did not,
+        #{support_phrase()} immediately — do not wait.
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp email_changed_notice_text(new_email) do
+    """
+    Your Fountain email address was changed
+
+    The email address on your Fountain account was changed to #{new_email}.
+    This address can no longer be used to sign in.
+
+    If you made this change, no action is needed. If you did not,
+    #{support_phrase()} immediately — do not wait.
     """
   end
 

--- a/apps/fountain/lib/fountain/workers/email_change_email.ex
+++ b/apps/fountain/lib/fountain/workers/email_change_email.ex
@@ -1,0 +1,72 @@
+defmodule Fountain.Workers.EmailChangeEmail do
+  @moduledoc """
+  The two emails of a verified email change (#448).
+
+  - `"confirmation"` — the link to the NEW address that actually performs the
+    change. The token is signed in `perform/1`, not at enqueue: nothing
+    secret at rest in `oban_jobs`, and a retried job mails a fresh full-TTL
+    link. Re-checks availability at send time — an address claimed between
+    request and send gets no mail naming it.
+  - `"notice"` — tells the OLD address the change happened. Carries both
+    addresses as strings: by send time the user row already holds the new
+    one.
+  """
+
+  use Oban.Worker,
+    queue: :mailer,
+    max_attempts: 5,
+    unique: [period: 60, fields: [:worker, :args]]
+
+  require Logger
+
+  alias Fountain.{Accounts, Emails.UserEmails}
+
+  @doc "Enqueue the confirmation link to `new_email` for `user`."
+  def enqueue_confirmation(%Accounts.User{id: id}, new_email) when is_binary(new_email) do
+    %{kind: "confirmation", user_id: id, new_email: new_email} |> new() |> Oban.insert()
+  end
+
+  @doc "Enqueue the change notice to the old address."
+  def enqueue_notice(old_email, new_email)
+      when is_binary(old_email) and is_binary(new_email) do
+    %{kind: "notice", old_email: old_email, new_email: new_email} |> new() |> Oban.insert()
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{
+        args: %{"kind" => "confirmation", "user_id" => user_id, "new_email" => new_email}
+      }) do
+    case Accounts.get_user(user_id) do
+      nil ->
+        Logger.info("email_change: user #{user_id} no longer exists")
+        :ok
+
+      user ->
+        if Accounts.get_user_by_email(new_email) do
+          # Claimed since the request. The requester sees nothing either way
+          # (no availability oracle); they simply won't receive a link.
+          :ok
+        else
+          token = Accounts.email_change_token(user, new_email)
+          deliver(fn -> UserEmails.deliver_email_change_confirmation(new_email, token) end)
+        end
+    end
+  end
+
+  def perform(%Oban.Job{
+        args: %{"kind" => "notice", "old_email" => old_email, "new_email" => new_email}
+      }) do
+    deliver(fn -> UserEmails.deliver_email_changed_notice(old_email, new_email) end)
+  end
+
+  defp deliver(fun) do
+    case fun.() do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("email_change: delivery failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -81,7 +81,7 @@ defmodule FountainWeb.Layouts do
 
     footer_open =
       Enum.any?(
-        ["/api-keys", "/account/billing", "/audit", "/help", "/admin"],
+        ["/api-keys", "/account/billing", "/account/security", "/audit", "/help", "/admin"],
         &String.starts_with?(assigns[:current_path] || "", &1)
       )
 
@@ -296,6 +296,7 @@ defmodule FountainWeb.Layouts do
               <div class="px-2 pt-0.5 pb-2 space-y-0.5 border-t border-[var(--color-border)]">
                 <.nav_link href={~p"/api-keys"} label="API Keys" current={@current_path} />
                 <.nav_link href={~p"/account/billing"} label="Billing" current={@current_path} />
+                <.nav_link href={~p"/account/security"} label="Security" current={@current_path} />
                 <.nav_link href={~p"/audit"} label="Audit log" current={@current_path} />
                 <.nav_link href={~p"/help"} label="Help" current={@current_path} />
                 <.nav_link

--- a/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
@@ -1,0 +1,154 @@
+defmodule FountainWeb.AccountSecurityController do
+  @moduledoc """
+  Credential management for a logged-in user (#448).
+
+  The forms live on `AccountSecurityLive`, but the actions are controller
+  POSTs, for two reasons a LiveView handler can't satisfy: `change_password/2`
+  must rewrite the session cookie (the password change bumps
+  `session_version`, and only a controller can re-issue the session so the
+  *current* browser survives while every other session dies), and both
+  actions want `FountainWeb.Plugs.RateLimit`, which is a plug.
+
+  `confirm_email_change/2` is public (no session): the link lands from an
+  inbox, possibly in a browser that has never seen this app.
+  """
+
+  use FountainWeb, :controller
+
+  alias Fountain.Accounts
+
+  plug FountainWeb.Plugs.RateLimit,
+       [bucket: "account_security", max: 10, window_ms: 3_600_000]
+       when action in [:change_password, :request_email_change]
+
+  def change_password(conn, %{"current_password" => current, "new_password" => new}) do
+    user = conn.assigns.current_user
+
+    case Accounts.change_password(user, current, new) do
+      {:ok, updated} ->
+        FountainWeb.Audited.from_conn(conn, "auth.password.changed", "user",
+          user_id: updated.id,
+          resource_id: updated.id
+        )
+
+        conn
+        # Re-issue this session against the bumped session_version: the
+        # change kills every OTHER session, not the one that made it.
+        |> configure_session(renew: true)
+        |> put_session(:user_id, updated.id)
+        |> put_session(:session_version, updated.session_version)
+        |> put_flash(:info, "Password updated. Other sessions have been signed out.")
+        |> redirect(to: ~p"/account/security")
+
+      {:error, :invalid_current_password} ->
+        conn
+        |> put_flash(:error, "Current password is incorrect.")
+        |> redirect(to: ~p"/account/security")
+
+      {:error, :no_password} ->
+        conn
+        |> put_flash(:error, "This account signs in with GitHub and has no password.")
+        |> redirect(to: ~p"/account/security")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        msg =
+          changeset
+          |> Ecto.Changeset.traverse_errors(fn {m, _} -> m end)
+          |> Map.get(:password, ["Could not update password."])
+          |> List.first()
+
+        conn
+        |> put_flash(:error, "New password: #{msg}")
+        |> redirect(to: ~p"/account/security")
+    end
+  end
+
+  def change_password(conn, _params) do
+    conn
+    |> put_flash(:error, "Current and new password are required.")
+    |> redirect(to: ~p"/account/security")
+  end
+
+  def request_email_change(conn, %{"new_email" => new_email, "current_password" => current}) do
+    user = conn.assigns.current_user
+
+    case Accounts.request_email_change(user, new_email, current) do
+      :ok ->
+        FountainWeb.Audited.from_conn(conn, "auth.email.change_requested", "user",
+          user_id: user.id,
+          resource_id: user.id,
+          metadata: %{"new_email" => String.downcase(String.trim(new_email))}
+        )
+
+        conn
+        # Same phrasing whether or not the address was free — this endpoint
+        # must not be an availability oracle.
+        |> put_flash(
+          :info,
+          "If that address is available, a confirmation link is on its way to it. " <>
+            "Your email only changes when the link is clicked."
+        )
+        |> redirect(to: ~p"/account/security")
+
+      {:error, :invalid_current_password} ->
+        conn
+        |> put_flash(:error, "Current password is incorrect.")
+        |> redirect(to: ~p"/account/security")
+
+      {:error, :no_password} ->
+        conn
+        |> put_flash(:error, "This account signs in with GitHub and has no password.")
+        |> redirect(to: ~p"/account/security")
+
+      {:error, :invalid_email} ->
+        conn
+        |> put_flash(:error, "That doesn't look like an email address.")
+        |> redirect(to: ~p"/account/security")
+
+      {:error, :same_email} ->
+        conn
+        |> put_flash(:error, "That is already your email address.")
+        |> redirect(to: ~p"/account/security")
+    end
+  end
+
+  def request_email_change(conn, _params) do
+    conn
+    |> put_flash(:error, "New email and current password are required.")
+    |> redirect(to: ~p"/account/security")
+  end
+
+  def confirm_email_change(conn, %{"token" => token}) do
+    case Accounts.apply_email_change(token) do
+      {:ok, updated, old_email} ->
+        FountainWeb.Audited.from_conn(conn, "auth.email.changed", "user",
+          user_id: updated.id,
+          resource_id: updated.id,
+          metadata: %{"from" => old_email, "to" => updated.email}
+        )
+
+        conn
+        # apply_email_change bumped session_version — every session is dead,
+        # including any in this browser. A clean sign-in is the honest next
+        # step.
+        |> configure_session(drop: true)
+        |> put_flash(:info, "Email updated to #{updated.email}. Please sign in.")
+        |> redirect(to: ~p"/auth/login")
+
+      {:error, :email_taken} ->
+        conn
+        |> put_flash(:error, "That address is no longer available.")
+        |> redirect(to: ~p"/auth/login")
+
+      {:error, :expired} ->
+        conn
+        |> put_flash(:error, "This confirmation link has expired. Request the change again.")
+        |> redirect(to: ~p"/auth/login")
+
+      {:error, :invalid} ->
+        conn
+        |> put_flash(:error, "This confirmation link is invalid.")
+        |> redirect(to: ~p"/auth/login")
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/account_security_live.ex
+++ b/apps/fountain/lib/fountain_web/live/account_security_live.ex
@@ -1,0 +1,112 @@
+defmodule FountainWeb.AccountSecurityLive do
+  @moduledoc """
+  The /account/security page (#448): change password, change email.
+
+  A LiveView shell for layout consistency, but both forms are plain HTML
+  POSTs to `AccountSecurityController` — see its moduledoc for why (session
+  rewrite, rate-limit plugs). OAuth-only accounts (no password hash) see an
+  explanation instead of forms: their identity is the provider-asserted
+  address, and without a password there is nothing to confirm a sensitive
+  change against.
+  """
+  use FountainWeb, :live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user = socket.assigns.current_user
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Security")
+     |> assign(:has_password, not is_nil(user.password_hash))}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="max-w-2xl space-y-8">
+      <div>
+        <h1 class="text-2xl font-semibold">Security</h1>
+        <p class="text-sm text-zinc-500 mt-1">
+          Signed in as <span class="font-mono">{@current_user.email}</span>
+        </p>
+      </div>
+
+      <div
+        :if={!@has_password}
+        class="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm text-sm text-zinc-600"
+      >
+        This account signs in with GitHub and has no password, so there is
+        nothing to change here. To add a password, use
+        <.link navigate={~p"/auth/forgot-password"} class="underline">password reset</.link>
+        with your account's email address.
+      </div>
+
+      <section :if={@has_password} class="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+        <h2 class="mb-1 text-lg font-medium">Change password</h2>
+        <p class="mb-4 text-sm text-zinc-500">
+          Every other session is signed out when the password changes; this one stays.
+        </p>
+        <form method="post" action={~p"/account/security/password"} class="space-y-3" id="change-password">
+          <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+          <div>
+            <label class="block text-sm font-medium text-zinc-700 mb-1">Current password</label>
+            <input
+              type="password"
+              name="current_password"
+              autocomplete="current-password"
+              class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-zinc-700 mb-1">New password</label>
+            <input
+              type="password"
+              name="new_password"
+              placeholder="At least 8 characters"
+              autocomplete="new-password"
+              class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+            />
+          </div>
+          <button class="rounded-md bg-zinc-900 text-white px-4 py-2 text-sm font-medium hover:bg-zinc-800">
+            Update password
+          </button>
+        </form>
+      </section>
+
+      <section :if={@has_password} class="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+        <h2 class="mb-1 text-lg font-medium">Change email address</h2>
+        <p class="mb-4 text-sm text-zinc-500">
+          A confirmation link goes to the new address; nothing changes until it is
+          clicked. Your current address is notified when the change completes.
+        </p>
+        <form method="post" action={~p"/account/security/email"} class="space-y-3" id="change-email">
+          <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+          <div>
+            <label class="block text-sm font-medium text-zinc-700 mb-1">New email address</label>
+            <input
+              type="email"
+              name="new_email"
+              placeholder="new@example.com"
+              autocomplete="email"
+              class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-zinc-700 mb-1">Current password</label>
+            <input
+              type="password"
+              name="current_password"
+              autocomplete="current-password"
+              class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+            />
+          </div>
+          <button class="rounded-md bg-zinc-900 text-white px-4 py-2 text-sm font-medium hover:bg-zinc-800">
+            Send confirmation link
+          </button>
+        </form>
+      </section>
+    </div>
+    """
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -151,6 +151,13 @@ defmodule FountainWeb.Router do
     get "/confirm/:token", EmailVerificationController, :confirm
   end
 
+  # Email-change confirmation (#448) — public like /users/confirm: the link
+  # lands from an inbox, possibly in a browser with no session.
+  scope "/account", FountainWeb do
+    pipe_through :browser
+    get "/email/confirm/:token", AccountSecurityController, :confirm_email_change
+  end
+
   ## ─── Public JSON auth endpoints ───────────────────────────────────────────────────────────────────────
 
   scope "/api/auth", FountainWeb do
@@ -240,6 +247,12 @@ defmodule FountainWeb.Router do
     # ── Account data export download — owner-scoped, expiring artifact (#288) ─────────────────────────────
     get "/account/exports/:id/download", ExportController, :download
 
+    # ── Credential management (#448) — controller POSTs so the session can be
+    # re-issued after a password change and RateLimit applies; the page they
+    # POST from is AccountSecurityLive below ─────────────────────────────────
+    post "/account/security/password", AccountSecurityController, :change_password
+    post "/account/security/email", AccountSecurityController, :request_email_change
+
     # ── Turn image serving — session-authenticated so <img> tags can load without a bearer token ──────────
     get "/conversations/:conversation_id/turns/:turn_id/images/:position",
         TurnImageController,
@@ -289,6 +302,9 @@ defmodule FountainWeb.Router do
 
       # ── BYO inference credentials (ADR 0008) ───────────────────────────────────────────────
       live "/account/inference-credentials", InferenceCredentialsLive.Index, :index
+
+      # ── Credential management (#448) ───────────────────────────────────────────────────────
+      live "/account/security", AccountSecurityLive, :index
     end
 
     live_session :admin,

--- a/apps/fountain/test/fountain/accounts_credential_test.exs
+++ b/apps/fountain/test/fountain/accounts_credential_test.exs
@@ -1,0 +1,144 @@
+defmodule Fountain.AccountsCredentialTest do
+  @moduledoc """
+  Logged-in credential management (#448): change password, verified email
+  change. The properties that matter: the current password gates both, the
+  email never changes without proof of control of the new address, and
+  neither flow leaks whether an address is taken.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts
+  alias Fountain.Workers.EmailChangeEmail
+
+  defp oauth_only_user do
+    {:ok, user, :new} =
+      Accounts.upsert_oauth_user("github", "uid-#{System.unique_integer([:positive])}", %{
+        "email" => "oauth#{System.unique_integer([:positive])}@example.com"
+      })
+
+    user
+  end
+
+  describe "change_password/3" do
+    test "changes the password and invalidates other sessions" do
+      user = insert_verified_user(%{"password" => "old-password-123"})
+
+      assert {:ok, updated} = Accounts.change_password(user, "old-password-123", "new-password-456")
+
+      assert updated.session_version > user.session_version
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "new-password-456")
+      assert {:error, :wrong_password} = Accounts.authenticate_user(user.email, "old-password-123")
+    end
+
+    test "refuses a wrong current password without touching anything" do
+      user = insert_verified_user(%{"password" => "old-password-123"})
+
+      assert {:error, :invalid_current_password} =
+               Accounts.change_password(user, "not-the-password", "new-password-456")
+
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "old-password-123")
+    end
+
+    test "a too-short new password comes back as a changeset error" do
+      user = insert_verified_user(%{"password" => "old-password-123"})
+
+      assert {:error, %Ecto.Changeset{}} =
+               Accounts.change_password(user, "old-password-123", "short")
+    end
+
+    test "an OAuth-only account has no password to change" do
+      assert {:error, :no_password} =
+               Accounts.change_password(oauth_only_user(), "anything", "new-password-456")
+    end
+  end
+
+  describe "request_email_change/3" do
+    test "enqueues the confirmation when the address is free" do
+      user = insert_verified_user(%{"password" => "password-123"})
+
+      assert :ok = Accounts.request_email_change(user, "Fresh@Example.com", "password-123")
+
+      # downcased before it reaches the job
+      assert_enqueued(
+        worker: EmailChangeEmail,
+        args: %{kind: "confirmation", user_id: user.id, new_email: "fresh@example.com"}
+      )
+    end
+
+    test "returns :ok for a taken address but enqueues nothing — no oracle" do
+      user = insert_verified_user(%{"password" => "password-123"})
+      other = insert_verified_user()
+
+      assert :ok = Accounts.request_email_change(user, other.email, "password-123")
+      refute_enqueued(worker: EmailChangeEmail)
+    end
+
+    test "the current password gates the request" do
+      user = insert_verified_user(%{"password" => "password-123"})
+
+      assert {:error, :invalid_current_password} =
+               Accounts.request_email_change(user, "new@example.com", "wrong")
+
+      refute_enqueued(worker: EmailChangeEmail)
+    end
+
+    test "rejects a non-address and the account's own address" do
+      user = insert_verified_user(%{"password" => "password-123"})
+
+      assert {:error, :invalid_email} =
+               Accounts.request_email_change(user, "not an email", "password-123")
+
+      assert {:error, :same_email} =
+               Accounts.request_email_change(user, user.email, "password-123")
+    end
+
+    test "an OAuth-only account cannot change its email" do
+      assert {:error, :no_password} =
+               Accounts.request_email_change(oauth_only_user(), "new@example.com", "x")
+    end
+  end
+
+  describe "apply_email_change/1" do
+    test "changes the email, stamps verification, kills sessions, notifies the old address" do
+      user = insert_verified_user()
+      token = Accounts.email_change_token(user, "changed@example.com")
+
+      assert {:ok, updated, old_email} = Accounts.apply_email_change(token)
+
+      assert updated.email == "changed@example.com"
+      assert old_email == user.email
+      assert updated.email_verified_at
+      assert updated.session_version > user.session_version
+
+      assert_enqueued(
+        worker: EmailChangeEmail,
+        args: %{kind: "notice", old_email: user.email, new_email: "changed@example.com"}
+      )
+    end
+
+    test "a token outlives neither its TTL nor a session_version bump" do
+      user = insert_verified_user(%{"password" => "password-123"})
+      token = Accounts.email_change_token(user, "changed@example.com")
+
+      # A password change (or a completed email change, or a suspension)
+      # bumps session_version, and the token was issued against the old one.
+      {:ok, _} = Accounts.change_password(user, "password-123", "another-password-9")
+
+      assert {:error, :invalid} = Accounts.apply_email_change(token)
+    end
+
+    test "an address claimed between request and click fails cleanly" do
+      user = insert_verified_user()
+      token = Accounts.email_change_token(user, "claimed@example.com")
+      insert_verified_user(%{"email" => "claimed@example.com"})
+
+      assert {:error, :email_taken} = Accounts.apply_email_change(token)
+      assert Repo.reload(user).email == user.email
+    end
+
+    test "garbage tokens are invalid, not crashes" do
+      assert {:error, :invalid} = Accounts.apply_email_change("not-a-token")
+    end
+  end
+end

--- a/apps/fountain/test/fountain/workers/email_change_email_test.exs
+++ b/apps/fountain/test/fountain/workers/email_change_email_test.exs
@@ -1,0 +1,76 @@
+defmodule Fountain.Workers.EmailChangeEmailTest do
+  use Fountain.DataCase, async: true
+
+  import Swoosh.TestAssertions
+
+  alias Fountain.Accounts
+  alias Fountain.Workers.EmailChangeEmail
+
+  describe "confirmation" do
+    test "mails the NEW address a token that completes the change end to end" do
+      user = insert_verified_user()
+
+      assert :ok =
+               perform_job(EmailChangeEmail, %{
+                 "kind" => "confirmation",
+                 "user_id" => user.id,
+                 "new_email" => "next@example.com"
+               })
+
+      assert_email_sent(fn email ->
+        assert email.subject == "Confirm your new Fountain email address"
+        assert email.to == [{"next@example.com", "next@example.com"}]
+
+        # The mailed artifact must be one apply_email_change/1 accepts.
+        [_, token] =
+          Regex.run(~r{/account/email/confirm/([A-Za-z0-9_\-\.]+)}, email.text_body)
+
+        assert {:ok, updated, _old} = Accounts.apply_email_change(token)
+        assert updated.email == "next@example.com"
+      end)
+    end
+
+    test "stays silent when the address was claimed after the request" do
+      user = insert_verified_user()
+      insert_verified_user(%{"email" => "gone@example.com"})
+
+      assert :ok =
+               perform_job(EmailChangeEmail, %{
+                 "kind" => "confirmation",
+                 "user_id" => user.id,
+                 "new_email" => "gone@example.com"
+               })
+
+      assert_no_email_sent()
+    end
+
+    test "is a no-op for a deleted user" do
+      assert :ok =
+               perform_job(EmailChangeEmail, %{
+                 "kind" => "confirmation",
+                 "user_id" => Ecto.UUID.generate(),
+                 "new_email" => "x@example.com"
+               })
+
+      assert_no_email_sent()
+    end
+  end
+
+  describe "notice" do
+    test "tells the old address what the account's email became" do
+      assert :ok =
+               perform_job(EmailChangeEmail, %{
+                 "kind" => "notice",
+                 "old_email" => "was@example.com",
+                 "new_email" => "now@example.com"
+               })
+
+      assert_email_sent(fn email ->
+        assert email.to == [{"was@example.com", "was@example.com"}]
+        assert email.subject == "Your Fountain email address was changed"
+        assert email.text_body =~ "now@example.com"
+        assert email.text_body =~ "can no longer be used to sign in"
+      end)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/account_security_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/account_security_controller_test.exs
@@ -1,0 +1,169 @@
+defmodule FountainWeb.AccountSecurityControllerTest do
+  use FountainWeb.ConnCase, async: true
+  use Oban.Testing, repo: Fountain.Repo
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Accounts
+  alias Fountain.Workers.EmailChangeEmail
+
+  describe "the page" do
+    test "renders both forms for a password account", %{conn: conn} do
+      user = insert_verified_user()
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/security")
+
+      assert html =~ "Change password"
+      assert html =~ "Change email address"
+      assert html =~ user.email
+    end
+
+    test "explains instead of offering forms to an OAuth-only account", %{conn: conn} do
+      {:ok, user, :new} =
+        Accounts.upsert_oauth_user("github", "uid-sec-test", %{"email" => "oauth-sec@example.com"})
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/security")
+
+      assert html =~ "signs in with GitHub"
+      refute html =~ "Update password"
+    end
+
+    test "requires authentication", %{conn: conn} do
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/account/security")
+      assert path =~ "/auth/login"
+    end
+  end
+
+  describe "POST /account/security/password" do
+    test "changes the password and keeps THIS session alive", %{conn: conn} do
+      user = insert_verified_user(%{"password" => "old-password-123"})
+
+      conn =
+        conn
+        |> login_user(user)
+        |> post(~p"/account/security/password", %{
+          "current_password" => "old-password-123",
+          "new_password" => "new-password-456"
+        })
+
+      assert redirected_to(conn) == ~p"/account/security"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Other sessions"
+
+      # The session cookie was re-issued against the bumped session_version —
+      # a stale one would bounce the very next request to login.
+      updated = Accounts.get_user!(user.id)
+      assert get_session(conn, :session_version) == updated.session_version
+      assert updated.session_version > user.session_version
+
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "new-password-456")
+    end
+
+    test "a wrong current password changes nothing", %{conn: conn} do
+      user = insert_verified_user(%{"password" => "old-password-123"})
+
+      conn =
+        conn
+        |> login_user(user)
+        |> post(~p"/account/security/password", %{
+          "current_password" => "wrong",
+          "new_password" => "new-password-456"
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "incorrect"
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "old-password-123")
+    end
+
+    test "unauthenticated requests bounce to login", %{conn: conn} do
+      conn =
+        post(conn, ~p"/account/security/password", %{
+          "current_password" => "x",
+          "new_password" => "y"
+        })
+
+      assert redirected_to(conn) == ~p"/auth/login"
+    end
+  end
+
+  describe "POST /account/security/email" do
+    test "enqueues the confirmation and answers without an availability oracle", %{conn: conn} do
+      user = insert_verified_user(%{"password" => "password-123"})
+
+      conn =
+        conn
+        |> login_user(user)
+        |> post(~p"/account/security/email", %{
+          "new_email" => "next@example.com",
+          "current_password" => "password-123"
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "confirmation link"
+      assert_enqueued(worker: EmailChangeEmail, args: %{user_id: user.id})
+    end
+
+    test "a taken address gets the identical response and no job", %{conn: conn} do
+      user = insert_verified_user(%{"password" => "password-123"})
+      other = insert_verified_user()
+
+      conn =
+        conn
+        |> login_user(user)
+        |> post(~p"/account/security/email", %{
+          "new_email" => other.email,
+          "current_password" => "password-123"
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "confirmation link"
+      refute_enqueued(worker: EmailChangeEmail)
+    end
+
+    test "blocks the 11th request in the shared bucket", %{conn: conn} do
+      user = insert_verified_user(%{"password" => "password-123"})
+      conn = login_user(conn, user)
+
+      for i <- 1..10 do
+        post(conn, ~p"/account/security/email", %{
+          "new_email" => "n#{i}@example.com",
+          "current_password" => "password-123"
+        })
+      end
+
+      conn11 =
+        post(conn, ~p"/account/security/email", %{
+          "new_email" => "n11@example.com",
+          "current_password" => "password-123"
+        })
+
+      assert conn11.status == 429
+    end
+  end
+
+  describe "GET /account/email/confirm/:token" do
+    test "completes the change and drops every session", %{conn: conn} do
+      user = insert_verified_user()
+      token = Accounts.email_change_token(user, "confirmed@example.com")
+
+      conn = get(conn, ~p"/account/email/confirm/#{token}")
+
+      assert redirected_to(conn) == ~p"/auth/login"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "confirmed@example.com"
+      assert Accounts.get_user!(user.id).email == "confirmed@example.com"
+    end
+
+    test "a nonsense token reports invalid", %{conn: conn} do
+      conn = get(conn, ~p"/account/email/confirm/garbage")
+
+      assert redirected_to(conn) == ~p"/auth/login"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "invalid"
+    end
+
+    test "a claimed address reports unavailable and changes nothing", %{conn: conn} do
+      user = insert_verified_user()
+      token = Accounts.email_change_token(user, "raced@example.com")
+      insert_verified_user(%{"email" => "raced@example.com"})
+
+      conn = get(conn, ~p"/account/email/confirm/#{token}")
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "no longer available"
+      assert Accounts.get_user!(user.id).email == user.email
+    end
+  end
+end


### PR DESCRIPTION
Closes #448 — the last feature item of the `story-2026-08` batch.

## What this adds

**Change password (logged in).** `Accounts.change_password/3` requires the current password (a stolen session must not be enough) and delegates to `reset_password/2`, so `session_version` bumps and every *other* session dies. The controller then re-issues the current session against the new version — the browser that made the change stays signed in, everything else bounces to login. OAuth-only accounts (nil `password_hash`) are refused with a pointer at the reset flow for setting a first password.

**Change email (verified, two-sided).** The address only changes when a link sent to the **new** address is clicked:
- `request_email_change/3` is password-gated and **never reveals availability**: the confirmation is enqueued only when the address is free, and the response is byte-identical either way.
- The token carries `{user_id, new_email, session_version}` — a password change, suspension, or completed change in the meantime invalidates it. 24 h TTL, signed in the worker's `perform/1` so nothing secret sits in `oban_jobs` and retries mail fresh links; availability is re-checked at send time.
- `apply_email_change/1` stamps `email_verified_at` (the click is proof of control), bumps `session_version` (all sessions die — the confirm controller drops the session and sends the user to a clean sign-in), and **notifies the old address** — the account-takeover tripwire, with "if this wasn't you, contact support immediately" copy.
- The claimed-in-the-meantime race resolves via the unique constraint into a clean "no longer available".

## Shape

`/account/security` is a LiveView shell (sidebar, Security nav link) whose forms are plain controller POSTs — deliberately: only a controller can rewrite the session cookie after the version bump, and both actions take a `RateLimit` plug (shared 10/IP/hour bucket). The confirm route is public like `/users/confirm` — the link lands from an inbox. Audit events on all three actions.

## Tests (29 new)

- Full round-trip: the worker's mailed link is regex-extracted and driven through `apply_email_change/1`.
- Session semantics pinned: the changing browser's session survives (`get_session` version equals the bumped one); a pre-change token dies after a password change.
- Oracle checks: taken address → identical flash, no job, at both the context and controller layers.
- OAuth-only refusals, rate-limit 429 on the 11th request, claimed-address race, garbage tokens.

`mix precommit` green: 1,945 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)