### PR TITLE
cli: tests for internal/secrets, config, output and the api client (#435)

### DIFF
--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/config"
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+)
+
+// newTestClient points the client at a httptest server via the env vars that
+// sit at the top of config's precedence order.
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	t.Setenv("FOUNTAIN_BASE_URL", srv.URL)
+	t.Setenv("FOUNTAIN_API_KEY", "ftn_test_key")
+	return New(credentials.Opts{})
+}
+
+func TestClientDo(t *testing.T) {
+	t.Run("prefixes /api, sends bearer token and JSON body", func(t *testing.T) {
+		var gotPath, gotAuth, gotContentType string
+		var gotBody map[string]any
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotAuth = r.Header.Get("Authorization")
+			gotContentType = r.Header.Get("Content-Type")
+			json.NewDecoder(r.Body).Decode(&gotBody)
+			w.Write([]byte(`{"id":"a1"}`))
+		})
+
+		var out map[string]any
+		if err := c.Post("/agents", map[string]string{"name": "demo"}, &out); err != nil {
+			t.Fatal(err)
+		}
+		if gotPath != "/api/agents" {
+			t.Errorf("path = %q, want /api/agents", gotPath)
+		}
+		if gotAuth != "Bearer ftn_test_key" {
+			t.Errorf("Authorization = %q", gotAuth)
+		}
+		if gotContentType != "application/json" {
+			t.Errorf("Content-Type = %q", gotContentType)
+		}
+		if gotBody["name"] != "demo" {
+			t.Errorf("body = %v", gotBody)
+		}
+		if out["id"] != "a1" {
+			t.Errorf("out = %v", out)
+		}
+	})
+
+	t.Run("GET sends no content-type and discards body into nil out", func(t *testing.T) {
+		var gotContentType string
+		var gotMethod string
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotContentType = r.Header.Get("Content-Type")
+			w.Write([]byte(`{"ignored":true}`))
+		})
+		if err := c.Get("/conversations", nil); err != nil {
+			t.Fatal(err)
+		}
+		if gotMethod != http.MethodGet || gotContentType != "" {
+			t.Errorf("method %q content-type %q", gotMethod, gotContentType)
+		}
+	})
+
+	t.Run("non-2xx returns HTTPError with decoded JSON body", func(t *testing.T) {
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(429)
+			w.Write([]byte(`{"error":"sandbox_quota_exceeded","message":"3 of 3 in use"}`))
+		})
+		err := c.Get("/conversations", nil)
+		var he *HTTPError
+		if !errors.As(err, &he) {
+			t.Fatalf("err = %v, want *HTTPError", err)
+		}
+		if he.Status != 429 || StatusCode(err) != 429 {
+			t.Errorf("status = %d, StatusCode = %d", he.Status, StatusCode(err))
+		}
+		body, ok := he.Body.(map[string]any)
+		if !ok || body["error"] != "sandbox_quota_exceeded" {
+			t.Errorf("body = %v", he.Body)
+		}
+	})
+
+	t.Run("non-JSON error body is kept as a string", func(t *testing.T) {
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(502)
+			w.Write([]byte("bad gateway"))
+		})
+		err := c.Get("/x", nil)
+		var he *HTTPError
+		if !errors.As(err, &he) {
+			t.Fatalf("err = %v, want *HTTPError", err)
+		}
+		if he.Body != "bad gateway" {
+			t.Errorf("body = %v", he.Body)
+		}
+	})
+
+	t.Run("empty 2xx body with non-nil out is not an error", func(t *testing.T) {
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(204)
+		})
+		var out map[string]any
+		if err := c.Delete("/agents/a1", &out); err != nil {
+			t.Fatal(err)
+		}
+		if out != nil {
+			t.Errorf("out = %v, want untouched nil map", out)
+		}
+	})
+
+	t.Run("missing API key fails before any request", func(t *testing.T) {
+		called := false
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+		t.Setenv("FOUNTAIN_API_KEY", "")
+		credentials.SetPathOverride("/nonexistent/credentials")
+		t.Cleanup(func() { credentials.SetPathOverride("") })
+
+		err := c.Get("/x", nil)
+		if !errors.Is(err, config.ErrNoAPIKey) {
+			t.Fatalf("err = %v, want ErrNoAPIKey", err)
+		}
+		if called {
+			t.Error("request was sent despite missing key")
+		}
+	})
+}
+
+func TestNewStreamRequest(t *testing.T) {
+	t.Setenv("FOUNTAIN_BASE_URL", "https://stream.example")
+	t.Setenv("FOUNTAIN_API_KEY", "ftn_test_key")
+	c := New(credentials.Opts{})
+
+	req, err := c.NewStreamRequest(context.Background(), "/conversations/c1/stream", "ev-42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.URL.String() != "https://stream.example/api/conversations/c1/stream" {
+		t.Errorf("url = %s", req.URL)
+	}
+	if req.Header.Get("Accept") != "text/event-stream" {
+		t.Errorf("Accept = %q", req.Header.Get("Accept"))
+	}
+	if req.Header.Get("Last-Event-ID") != "ev-42" {
+		t.Errorf("Last-Event-ID = %q", req.Header.Get("Last-Event-ID"))
+	}
+
+	req, err = c.NewStreamRequest(context.Background(), "/x", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := req.Header["Last-Event-Id"]; present {
+		t.Error("Last-Event-ID header set despite empty id")
+	}
+}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+)
+
+// withCredentials points the credentials package at a temp file with the
+// given content and clears the env vars that outrank it.
+func withCredentials(t *testing.T, content string) {
+	t.Helper()
+	t.Setenv("FOUNTAIN_API_KEY", "")
+	t.Setenv("FOUNTAIN_BASE_URL", "")
+	t.Setenv("FOUNTAIN_PROFILE", "")
+	path := filepath.Join(t.TempDir(), "credentials")
+	if content != "" {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	credentials.SetPathOverride(path)
+	t.Cleanup(func() { credentials.SetPathOverride("") })
+}
+
+func TestAPIKey(t *testing.T) {
+	t.Run("env var outranks the credentials file", func(t *testing.T) {
+		withCredentials(t, "[default]\napi_key = \"ftn_from_file\"\n")
+		t.Setenv("FOUNTAIN_API_KEY", "ftn_from_env")
+		got, err := APIKey(credentials.Opts{})
+		if err != nil || got != "ftn_from_env" {
+			t.Fatalf("APIKey = %q, %v", got, err)
+		}
+	})
+
+	t.Run("falls back to the active profile", func(t *testing.T) {
+		withCredentials(t, "[default]\napi_key = \"ftn_default\"\n\n[staging]\napi_key = \"ftn_staging\"\n")
+		got, err := APIKey(credentials.Opts{})
+		if err != nil || got != "ftn_default" {
+			t.Fatalf("APIKey = %q, %v", got, err)
+		}
+		got, err = APIKey(credentials.Opts{Profile: "staging"})
+		if err != nil || got != "ftn_staging" {
+			t.Fatalf("APIKey(staging) = %q, %v", got, err)
+		}
+	})
+
+	t.Run("FOUNTAIN_PROFILE selects the profile", func(t *testing.T) {
+		withCredentials(t, "[default]\napi_key = \"ftn_default\"\n\n[staging]\napi_key = \"ftn_staging\"\n")
+		t.Setenv("FOUNTAIN_PROFILE", "staging")
+		got, err := APIKey(credentials.Opts{})
+		if err != nil || got != "ftn_staging" {
+			t.Fatalf("APIKey = %q, %v", got, err)
+		}
+	})
+
+	t.Run("ErrNoAPIKey when nothing is configured", func(t *testing.T) {
+		withCredentials(t, "")
+		_, err := APIKey(credentials.Opts{})
+		if !errors.Is(err, ErrNoAPIKey) {
+			t.Fatalf("err = %v, want ErrNoAPIKey", err)
+		}
+	})
+
+	t.Run("ErrNoAPIKey when the profile exists without an api_key", func(t *testing.T) {
+		withCredentials(t, "[default]\nbase_url = \"https://x\"\n")
+		_, err := APIKey(credentials.Opts{})
+		if !errors.Is(err, ErrNoAPIKey) {
+			t.Fatalf("err = %v, want ErrNoAPIKey", err)
+		}
+	})
+}
+
+func TestBaseURL(t *testing.T) {
+	t.Run("env var wins and loses its trailing slash", func(t *testing.T) {
+		withCredentials(t, "[default]\nbase_url = \"https://file.example\"\n")
+		t.Setenv("FOUNTAIN_BASE_URL", "https://env.example/")
+		if got := BaseURL(credentials.Opts{}); got != "https://env.example" {
+			t.Fatalf("BaseURL = %q", got)
+		}
+	})
+
+	t.Run("profile base_url is next", func(t *testing.T) {
+		withCredentials(t, "[default]\nbase_url = \"https://file.example/\"\n")
+		if got := BaseURL(credentials.Opts{}); got != "https://file.example" {
+			t.Fatalf("BaseURL = %q", got)
+		}
+	})
+
+	t.Run("compile-time default is last", func(t *testing.T) {
+		withCredentials(t, "")
+		if got := BaseURL(credentials.Opts{}); got != DefaultBaseURL {
+			t.Fatalf("BaseURL = %q, want %q", got, DefaultBaseURL)
+		}
+	})
+}

--- a/cli/internal/output/output_test.go
+++ b/cli/internal/output/output_test.go
@@ -1,0 +1,168 @@
+package output
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs f with os.Stdout redirected to a pipe and returns what
+// it printed. The package prints via fmt.Println, so this is the seam.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	f()
+	w.Close()
+	return <-done
+}
+
+func TestPrintJSON(t *testing.T) {
+	got := captureStdout(t, func() {
+		if err := PrintJSON(map[string]any{"name": "demo", "n": 2}); err != nil {
+			t.Error(err)
+		}
+	})
+	want := "{\n  \"n\": 2,\n  \"name\": \"demo\"\n}\n"
+	if got != want {
+		t.Fatalf("PrintJSON printed %q, want %q", got, want)
+	}
+}
+
+func TestPrintJSONUnmarshalable(t *testing.T) {
+	captureStdout(t, func() {
+		if err := PrintJSON(func() {}); err == nil {
+			t.Error("want error for unmarshalable value")
+		}
+	})
+}
+
+func TestTable(t *testing.T) {
+	got := captureStdout(t, func() {
+		Table([]string{"ID", "NAME"}, [][]string{
+			{"1", "alpha"},
+			{"22", "b"},
+		})
+	})
+	want := strings.Join([]string{
+		"ID  NAME ",
+		"--  -----",
+		"1   alpha",
+		"22  b    ",
+		"",
+	}, "\n")
+	if got != want {
+		t.Fatalf("Table printed:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestTableRaggedRows(t *testing.T) {
+	// Rows shorter or longer than the header must not panic; extra cells
+	// are dropped, missing cells render empty.
+	got := captureStdout(t, func() {
+		Table([]string{"A", "B"}, [][]string{
+			{"1"},
+			{"2", "3", "ignored"},
+		})
+	})
+	want := strings.Join([]string{
+		"A  B",
+		"-  -",
+		"1   ",
+		"2  3",
+		"",
+	}, "\n")
+	if got != want {
+		t.Fatalf("Table printed:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestTableWidthCountsRunes(t *testing.T) {
+	// Multibyte cells must align by rune count, not byte count.
+	got := captureStdout(t, func() {
+		Table([]string{"N"}, [][]string{{"héllo"}, {"x"}})
+	})
+	want := strings.Join([]string{
+		"N    ",
+		"-----",
+		"héllo",
+		"x    ",
+		"",
+	}, "\n")
+	if got != want {
+		t.Fatalf("Table printed:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		s    string
+		n    int
+		want string
+	}{
+		{"short", 10, "short"},
+		{"exact", 5, "exact"},
+		{"truncated", 4, "trun…"},
+		{"héllo wörld", 5, "héllo…"}, // rune-aware slicing
+		{"héllo", 5, "héllo"},        // rune-aware length check: 6 bytes, 5 runes, no cut
+		{"", 3, ""},
+	}
+	for _, tc := range cases {
+		if got := Truncate(tc.s, tc.n); got != tc.want {
+			t.Errorf("Truncate(%q, %d) = %q, want %q", tc.s, tc.n, got, tc.want)
+		}
+	}
+}
+
+func TestShortID(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"0193bf1d-0000-7000-8000-000000000000", "0193bf1d"},
+		{"12345678", "12345678"},
+		{"short", "short"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := ShortID(tc.in); got != tc.want {
+			t.Errorf("ShortID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestToString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"string", "x", "x"},
+		{"true", true, "true"},
+		{"false", false, "false"},
+		{"integral float renders as int", float64(42), "42"},
+		{"fractional float", 1.5, "1.5"},
+		{"negative integral float", float64(-3), "-3"},
+		{"other types via %v", []any{"a"}, "[a]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ToString(tc.in); got != tc.want {
+				t.Fatalf("ToString(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/internal/secrets/bws_test.go
+++ b/cli/internal/secrets/bws_test.go
@@ -1,0 +1,89 @@
+package secrets
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestBitwardenRead(t *testing.T) {
+	t.Run("extracts value from JSON output", func(t *testing.T) {
+		dir := fakeCLI(t, "bws", `printf '{"id":"u-u-i-d","key":"DB_URL","value":"postgres://x"}'`)
+		got, err := (&Bitwarden{}).Read("bws://u-u-i-d")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "postgres://x" {
+			t.Fatalf("Read = %q", got)
+		}
+		if args := recordedArgs(t, dir, "bws"); args != "secret get u-u-i-d" {
+			t.Fatalf("bws invoked with %q", args)
+		}
+	})
+
+	t.Run("empty value string is returned as-is", func(t *testing.T) {
+		fakeCLI(t, "bws", `printf '{"value":""}'`)
+		got, err := (&Bitwarden{}).Read("bws://u")
+		if err != nil || got != "" {
+			t.Fatalf("Read = %q, %v; want empty string, nil", got, err)
+		}
+	})
+
+	t.Run("rejects ref without the bws:// prefix", func(t *testing.T) {
+		_, err := (&Bitwarden{}).Read("op://nope")
+		if !errors.Is(err, errBwsInvalidRef) {
+			t.Fatalf("err = %v, want errBwsInvalidRef", err)
+		}
+	})
+
+	t.Run("rejects ref with empty uuid", func(t *testing.T) {
+		_, err := (&Bitwarden{}).Read("bws://")
+		if !errors.Is(err, errBwsEmptyRef) {
+			t.Fatalf("err = %v, want errBwsEmptyRef", err)
+		}
+		if msg := (&Bitwarden{}).FormatError(err); !strings.Contains(msg, "missing the UUID") {
+			t.Fatalf("FormatError = %q", msg)
+		}
+	})
+
+	t.Run("not installed", func(t *testing.T) {
+		noCLI(t)
+		_, err := (&Bitwarden{}).Read("bws://u")
+		if !errors.Is(err, errBwsNotInstalled) {
+			t.Fatalf("err = %v, want errBwsNotInstalled", err)
+		}
+	})
+
+	t.Run("non-zero exit carries output", func(t *testing.T) {
+		fakeCLI(t, "bws", `echo '404: secret not found'; exit 1`)
+		_, err := (&Bitwarden{}).Read("bws://u")
+		if err == nil {
+			t.Fatal("want error")
+		}
+		if msg := (&Bitwarden{}).FormatError(err); msg != "404: secret not found" {
+			t.Fatalf("FormatError = %q", msg)
+		}
+	})
+
+	t.Run("non-JSON output", func(t *testing.T) {
+		fakeCLI(t, "bws", `printf 'not json'`)
+		_, err := (&Bitwarden{}).Read("bws://u")
+		if err == nil {
+			t.Fatal("want error")
+		}
+		if msg := (&Bitwarden{}).FormatError(err); !strings.Contains(msg, "could not parse") {
+			t.Fatalf("FormatError = %q", msg)
+		}
+	})
+
+	t.Run("JSON without a value field", func(t *testing.T) {
+		fakeCLI(t, "bws", `printf '{"id":"u"}'`)
+		_, err := (&Bitwarden{}).Read("bws://u")
+		if err == nil {
+			t.Fatal("want error")
+		}
+		if msg := (&Bitwarden{}).FormatError(err); !strings.Contains(msg, "no string `value` field") {
+			t.Fatalf("FormatError = %q", msg)
+		}
+	})
+}

--- a/cli/internal/secrets/exec_fake_test.go
+++ b/cli/internal/secrets/exec_fake_test.go
@@ -1,0 +1,38 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeCLI installs an executable shell script named cmd on a PATH containing
+// only the returned temp dir, so Read's LookPath and combinedOutput hit the
+// fake instead of any real secret-manager CLI. The script appends its
+// arguments to <dir>/<cmd>.args for command-construction assertions.
+func fakeCLI(t *testing.T, cmd, script string) string {
+	t.Helper()
+	dir := t.TempDir()
+	body := "#!/bin/sh\necho \"$@\" >> \"" + filepath.Join(dir, cmd+".args") + "\"\n" + script + "\n"
+	if err := os.WriteFile(filepath.Join(dir, cmd), []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	return dir
+}
+
+// noCLI empties PATH so LookPath fails for every command.
+func noCLI(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
+func recordedArgs(t *testing.T, dir, cmd string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, cmd+".args"))
+	if err != nil {
+		t.Fatalf("fake %s was never invoked: %v", cmd, err)
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/cli/internal/secrets/infisical_test.go
+++ b/cli/internal/secrets/infisical_test.go
@@ -1,0 +1,120 @@
+package secrets
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseInfisical(t *testing.T) {
+	cases := []struct {
+		name    string
+		rest    string
+		want    infisicalParts
+		wantErr string
+	}{
+		{
+			name: "project/env/name",
+			rest: "proj123/dev/API_KEY",
+			want: infisicalParts{Project: "proj123", Env: "dev", Path: "/", Name: "API_KEY"},
+		},
+		{
+			name: "empty project falls through to CLI resolution",
+			rest: "/dev/API_KEY",
+			want: infisicalParts{Project: "", Env: "dev", Path: "/", Name: "API_KEY"},
+		},
+		{
+			name: "single path segment",
+			rest: "proj/staging/backend/DB_URL",
+			want: infisicalParts{Project: "proj", Env: "staging", Path: "/backend", Name: "DB_URL"},
+		},
+		{
+			name: "nested path segments",
+			rest: "proj/prod/backend/db/PASSWORD",
+			want: infisicalParts{Project: "proj", Env: "prod", Path: "/backend/db", Name: "PASSWORD"},
+		},
+		{name: "too few segments", rest: "dev/API_KEY", wantErr: "at least env and name"},
+		{name: "empty env", rest: "proj//API_KEY", wantErr: "at least env and name"},
+		{name: "empty name", rest: "proj/dev/", wantErr: "at least env and name"},
+		{name: "empty name after path", rest: "proj/dev/backend/", wantErr: "missing secret name"},
+		{name: "empty path segment", rest: "proj/dev//NAME", wantErr: "empty path segment"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseInfisical(tc.rest)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parseInfisical(%q) = %+v, want error", tc.rest, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want it to mention %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseInfisical(%q) = %+v, want %+v", tc.rest, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInfisicalRead(t *testing.T) {
+	t.Run("builds the CLI invocation and trims the trailing newline", func(t *testing.T) {
+		dir := fakeCLI(t, "infisical", `echo 'plain-value'`)
+		got, err := (&Infisical{}).Read("infisical://proj/dev/backend/API_KEY")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "plain-value" {
+			t.Fatalf("Read = %q", got)
+		}
+		want := "secrets get API_KEY --env=dev --path=/backend --plain --projectId=proj"
+		if args := recordedArgs(t, dir, "infisical"); args != want {
+			t.Fatalf("infisical invoked with %q, want %q", args, want)
+		}
+	})
+
+	t.Run("omits --projectId when project segment is empty", func(t *testing.T) {
+		dir := fakeCLI(t, "infisical", `echo v`)
+		if _, err := (&Infisical{}).Read("infisical:///dev/API_KEY"); err != nil {
+			t.Fatal(err)
+		}
+		if args := recordedArgs(t, dir, "infisical"); strings.Contains(args, "--projectId") {
+			t.Fatalf("infisical invoked with %q, want no --projectId", args)
+		}
+	})
+
+	t.Run("invalid ref fails before any exec", func(t *testing.T) {
+		noCLI(t)
+		_, err := (&Infisical{}).Read("infisical://proj")
+		var ir *infisicalInvalidRef
+		if !errors.As(err, &ir) {
+			t.Fatalf("err = %v, want infisicalInvalidRef", err)
+		}
+	})
+
+	t.Run("not installed", func(t *testing.T) {
+		noCLI(t)
+		_, err := (&Infisical{}).Read("infisical://proj/dev/API_KEY")
+		if !errors.Is(err, errInfisicalNotInstalled) {
+			t.Fatalf("err = %v, want errInfisicalNotInstalled", err)
+		}
+		if msg := (&Infisical{}).FormatError(err); !strings.Contains(msg, "not on PATH") {
+			t.Fatalf("FormatError = %q", msg)
+		}
+	})
+
+	t.Run("non-zero exit carries output", func(t *testing.T) {
+		fakeCLI(t, "infisical", `echo 'secret not found'; exit 1`)
+		_, err := (&Infisical{}).Read("infisical://proj/dev/API_KEY")
+		if err == nil {
+			t.Fatal("want error")
+		}
+		if msg := (&Infisical{}).FormatError(err); msg != "secret not found" {
+			t.Fatalf("FormatError = %q", msg)
+		}
+	})
+}

--- a/cli/internal/secrets/op_test.go
+++ b/cli/internal/secrets/op_test.go
@@ -1,0 +1,62 @@
+package secrets
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestOnePasswordRead(t *testing.T) {
+	t.Run("returns stdout verbatim on success", func(t *testing.T) {
+		dir := fakeCLI(t, "op", `printf 's3cret'`)
+		got, err := (&OnePassword{}).Read("op://vault/item/field")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "s3cret" {
+			t.Fatalf("Read = %q, want s3cret", got)
+		}
+		if args := recordedArgs(t, dir, "op"); args != "read --no-newline op://vault/item/field" {
+			t.Fatalf("op invoked with %q", args)
+		}
+	})
+
+	t.Run("not installed", func(t *testing.T) {
+		noCLI(t)
+		_, err := (&OnePassword{}).Read("op://vault/item/field")
+		if !errors.Is(err, errOpNotInstalled) {
+			t.Fatalf("err = %v, want errOpNotInstalled", err)
+		}
+		if msg := (&OnePassword{}).FormatError(err); !strings.Contains(msg, "not on PATH") {
+			t.Fatalf("FormatError = %q", msg)
+		}
+	})
+
+	t.Run("non-zero exit carries trimmed combined output", func(t *testing.T) {
+		fakeCLI(t, "op", `echo 'item not found' >&2; exit 1`)
+		_, err := (&OnePassword{}).Read("op://vault/missing/field")
+		if err == nil {
+			t.Fatal("want error")
+		}
+		if msg := (&OnePassword{}).FormatError(err); msg != "item not found" {
+			t.Fatalf("FormatError = %q, want the CLI's stderr", msg)
+		}
+	})
+
+	t.Run("non-zero exit with no output", func(t *testing.T) {
+		fakeCLI(t, "op", `exit 3`)
+		_, err := (&OnePassword{}).Read("op://vault/item/field")
+		if err == nil {
+			t.Fatal("want error")
+		}
+		if msg := (&OnePassword{}).FormatError(err); msg != "op exited non-zero with no output" {
+			t.Fatalf("FormatError = %q", msg)
+		}
+	})
+}
+
+func TestOnePasswordFormatErrorFallback(t *testing.T) {
+	if msg := (&OnePassword{}).FormatError(errors.New("boom")); msg != "boom" {
+		t.Fatalf("FormatError = %q, want boom", msg)
+	}
+}

--- a/cli/internal/secrets/resolver_test.go
+++ b/cli/internal/secrets/resolver_test.go
@@ -1,0 +1,42 @@
+package secrets
+
+import "testing"
+
+func TestForValue(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string // expected prefix of the matched resolver, "" for nil
+	}{
+		{"op ref", "op://vault/item/field", "op://"},
+		{"bws ref", "bws://0193bf1d-0000-7000-8000-000000000000", "bws://"},
+		{"infisical ref", "infisical://proj/dev/API_KEY", "infisical://"},
+		{"plain value", "hunter2", ""},
+		{"empty value", "", ""},
+		{"scheme-like but unknown", "vault://foo", ""},
+		{"prefix must anchor at start", "x op://vault/item/field", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ForValue(tc.value, Default)
+			if tc.want == "" {
+				if got != nil {
+					t.Fatalf("ForValue(%q) = %v, want nil", tc.value, got.Prefix())
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("ForValue(%q) = nil, want resolver for %s", tc.value, tc.want)
+			}
+			if got.Prefix() != tc.want {
+				t.Fatalf("ForValue(%q).Prefix() = %s, want %s", tc.value, got.Prefix(), tc.want)
+			}
+		})
+	}
+}
+
+func TestForValueEmptyRegistry(t *testing.T) {
+	if got := ForValue("op://vault/item/field", nil); got != nil {
+		t.Fatalf("ForValue with empty registry = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
Second of the #435 batch: the Go CLI packages that had no tests — `internal/secrets` (shells out to `op`/`bws`/`infisical`), `internal/config`, `internal/output` — plus transport-level tests for `internal/api` (its existing test only covered `HTTPError` rendering).

- **secrets**: fake CLI scripts installed on a controlled `PATH` exercise `Read` end to end; the fakes record their argv so the exact `op read --no-newline …` / `bws secret get …` / `infisical secrets get … --env= --path= --plain [--projectId=]` invocations are asserted. All `FormatError` branches and the `parseInfisical` segment grammar are covered.
- **config**: precedence env var > active profile > default, `FOUNTAIN_PROFILE`, both `ErrNoAPIKey` shapes, trailing-slash stripping.
- **output**: `Table` (alignment, ragged rows, rune-counted widths), `Truncate`, `ShortID`, `ToString`, `PrintJSON`.
- **api**: httptest-backed `Client` tests — `/api` prefix, bearer token, JSON round-trip, `HTTPError` decode (JSON + non-JSON bodies), 204 handling, missing-key short-circuit, `NewStreamRequest` headers.

Verification: mutation-checked three spots (env-var precedence removed, `--plain` dropped, `Truncate` byte-counted) — each fails the suite. The third mutation initially survived, which exposed a missing case (5-runes/6-bytes string at the boundary); it's in now. `go test ./...`, `go vet ./...`, `gofmt -l` all clean.

Part of #435. The gofmt CI step itself is in the companion config PR #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)