### PR TITLE
credo: custom check enforcing ownership comments on _unsafe_ call sites (#435)

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -41,7 +41,7 @@
       # If you create your own checks, you must specify the source files for
       # them here, so they can be loaded by Credo before running the analysis.
       #
-      requires: [],
+      requires: ["credo/checks/"],
       #
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
@@ -66,6 +66,29 @@
       #
       checks: %{
         enabled: [
+          #
+          ## Project checks
+          #
+          # Replaces the manual `_unsafe_` call-site sweeps (#328/#383):
+          # every remote `Mod._unsafe_*` call needs a nearby `# ownership:`
+          # comment. Exemptions are the caller shapes from CLAUDE.md's
+          # tenant isolation section where ownership is structural, plus
+          # tests (which create their own data).
+          {Fountain.Credo.Check.UnsafeCallOwnership,
+           [
+             exempt_paths: [
+               # admin surface: whole directory behind the router's :admin
+               # live_session (require_admin)
+               "lib/fountain_web/live/admin_live/",
+               # GenServer: ownership established at init/rehydrate
+               "lib/fountain/conversations/conversation_server.ex",
+               # system-level sweeps, run with no user in scope
+               "lib/fountain/conversations/rehydrator.ex",
+               "lib/fountain/workers/",
+               "/test/"
+             ]
+           ]},
+
           #
           ## Consistency Checks
           #

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -774,6 +774,9 @@ defmodule Fountain.Accounts do
            |> Ecto.Changeset.change(suspended_at: now)
            |> User.invalidate_sessions_changeset()
            |> Repo.update() do
+      # Ownership: admin/system suspension flow — the %User{} being acted on
+      # IS the tenant whose sandboxes are reaped; there is no requesting user
+      # to scope by.
       reaped = Fountain.Conversations._unsafe_reap_all_for_user(user.id)
 
       # Best-effort notification (#450): before this the user's only signal

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1003,6 +1003,9 @@ defmodule Fountain.Conversations do
   (`terminated`, `failed`) — those don't auto-resume.
   """
   def wake_conversation(conv_id, initial_prompt \\ nil) do
+    # Ownership: called from ConversationServer (which established ownership
+    # before starting) and the boot-time rehydrator sweep. The agent fetched
+    # below is the conversation's own agent_id, same tenant by construction.
     with %Conversation{} = conv <- _unsafe_get_conversation(conv_id) || {:error, :not_found},
          :ok <- assert_resumable(conv),
          %Agents.Agent{} = agent <-

--- a/apps/fountain/lib/fountain/exports.ex
+++ b/apps/fountain/lib/fountain/exports.ex
@@ -324,7 +324,7 @@ defmodule Fountain.Exports do
         "repositories" => env.repositories,
         "metadata" => env.metadata,
         # Names only — values are write-only by design.
-        # Env comes from the tenant-scoped list_environments above.
+        # Ownership: env comes from the tenant-scoped list_environments above.
         "secret_keys" =>
           env |> Environments._unsafe_list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
         "created_at" => env.inserted_at,
@@ -343,7 +343,7 @@ defmodule Fountain.Exports do
         "description" => vault.description,
         "metadata" => vault.metadata,
         # Names only — values are write-only by design.
-        # Vault comes from the tenant-scoped list_vaults above.
+        # Ownership: vault comes from the tenant-scoped list_vaults above.
         "secret_keys" => vault |> Vaults._unsafe_list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
         "created_at" => vault.inserted_at,
         "updated_at" => vault.updated_at

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -61,6 +61,7 @@ defmodule FountainWeb.ConversationController do
         {:error, :not_found}
 
       _ ->
+        # Ownership: established by the scoped get_conversation above.
         render(conn, :turns, turns: Conversations._unsafe_list_turns(id))
     end
   end
@@ -432,6 +433,7 @@ defmodule FountainWeb.ConversationController do
   # error. This used to `throw` the chunk error with no catch anywhere in
   # the module, producing a crash report and a Sentry event per disconnect.
   defp replay(conn, conv_id, after_id, streams) do
+    # Ownership: only called from stream/2, after its scoped get_conversation.
     conv_id
     |> Conversations._unsafe_list_log_events(after_id, streams: streams)
     |> Enum.reduce_while({:ok, conn, after_id}, fn ev, {:ok, acc_conn, last_id} ->

--- a/apps/fountain/lib/fountain_web/live/audit_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/audit_live/index.ex
@@ -25,6 +25,8 @@ defmodule FountainWeb.AuditLive.Index do
     {:noreply, assign(socket, :events, events)}
   end
 
+  # Ownership: the function head is the admin gate — same predicate as
+  # require_admin; every other user hits the tenant-scoped clause below.
   defp load_events(%{role: "admin"}), do: Audit._unsafe_list_recent(200)
   defp load_events(%{id: id}), do: Audit.list_recent_for_user(id, 200)
 

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -32,6 +32,7 @@ defmodule FountainWeb.ConversationsLive.Show do
           Conversations.mark_read(id, user_id)
         end
 
+        # Ownership: established by the scoped get_conversation in mount above.
         events = Conversations._unsafe_list_log_events(id) |> annotate_durations()
 
         {:ok,
@@ -50,6 +51,8 @@ defmodule FountainWeb.ConversationsLive.Show do
   end
 
   defp load_turns(conv_id) do
+    # Ownership: only called from mount/handle_info after the scoped
+    # get_conversation.
     Conversations._unsafe_list_turns(conv_id)
     |> Enum.map(fn t ->
       image_count = length(t.images || [])

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -63,7 +63,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
   end
 
   defp secrets_for(%Environment{id: nil}), do: []
-  # Env is loaded via the tenant-scoped lookup in load/2.
+  # Ownership: env is loaded via the tenant-scoped lookup in load/2.
   defp secrets_for(env), do: Environments._unsafe_list_secrets(env)
 
   @impl true

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -41,7 +41,7 @@ defmodule FountainWeb.VaultsLive.Form do
   end
 
   defp secrets_for(%Vault{id: nil}), do: []
-  # Vault is loaded via the tenant-scoped get_vault!/2 in load/2.
+  # Ownership: vault is loaded via the tenant-scoped get_vault!/2 in load/2.
   defp secrets_for(vault), do: Vaults._unsafe_list_secrets(vault)
 
   @impl true

--- a/credo/checks/unsafe_call_ownership.ex
+++ b/credo/checks/unsafe_call_ownership.ex
@@ -1,0 +1,97 @@
+defmodule Fountain.Credo.Check.UnsafeCallOwnership do
+  @moduledoc """
+  Every remote call to a `_unsafe_*` function must carry a nearby comment
+  containing the word "ownership" explaining which tenant-scoped fetch (or
+  which structural property — admin surface, system sweep) establishes
+  ownership. This automates the manual `_unsafe_` call-site sweeps
+  (#328/#383); the policy itself lives in CLAUDE.md's tenant isolation
+  section.
+
+  Local calls (inside the module that defines the `_unsafe_` function) are
+  not flagged — scoping is that context module's own concern, reviewed with
+  the module.
+  """
+
+  use Credo.Check,
+    id: "FN0001",
+    base_priority: :high,
+    category: :warning,
+    param_defaults: [lookback: 10, exempt_paths: []],
+    explanations: [
+      check: """
+      Functions prefixed `_unsafe_` bypass tenant scoping. A remote call to
+      one is only legitimate when ownership of the fetched data is already
+      established on that code path — by an adjacent tenant-scoped parent
+      fetch, an admin-only surface, or a system-level process.
+
+      Whichever it is, the call site must say so: a comment containing the
+      word "ownership" within `lookback` lines above the call (or on the
+      call's own line). One comment covers every `_unsafe_` call in the
+      window below it, so clustered calls need only one.
+
+          # ownership: established by the scoped get_vault/2 above
+          secrets = Vaults._unsafe_list_secrets(vault)
+
+      Files whose path matches `exempt_paths` (GenServers that establish
+      ownership at init, system sweeps, tests) are skipped entirely.
+      """,
+      params: [
+        lookback: "How many lines above a call to search for an ownership comment.",
+        exempt_paths:
+          "Path fragments; files matching any of them may call `_unsafe_` functions uncommented."
+      ]
+    ]
+
+  @ownership_comment ~r/#.*ownership/i
+
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    exempt = Params.get(params, :exempt_paths, __MODULE__)
+
+    if Enum.any?(exempt, &String.contains?(source_file.filename, &1)) do
+      []
+    else
+      issue_meta = IssueMeta.for(source_file, params)
+      lookback = Params.get(params, :lookback, __MODULE__)
+      lines = source_file |> SourceFile.lines() |> Map.new()
+
+      source_file
+      |> Credo.Code.prewalk(&traverse/2, [])
+      |> Enum.reject(fn {line_no, _fun} -> justified?(line_no, lines, lookback) end)
+      |> Enum.map(fn {line_no, fun} ->
+        format_issue(issue_meta,
+          message:
+            "Remote call to #{fun}/? bypasses tenant scoping — add a `# ownership: ...` " <>
+              "comment (within #{lookback} lines above) naming what establishes ownership here.",
+          trigger: to_string(fun),
+          line_no: line_no
+        )
+      end)
+    end
+  end
+
+  # Remote calls only: `Mod._unsafe_x(...)`, `__MODULE__._unsafe_x(...)` and
+  # remote captures `&Mod._unsafe_x/1`. Local calls and the `def` of the
+  # function itself never produce a dot node, so they fall through.
+  defp traverse({{:., _, [_mod, fun]}, meta, args} = ast, acc)
+       when is_atom(fun) and is_list(args) do
+    if unsafe?(fun) do
+      {ast, [{meta[:line], fun} | acc]}
+    else
+      {ast, acc}
+    end
+  end
+
+  defp traverse(ast, acc), do: {ast, acc}
+
+  defp unsafe?(fun), do: String.starts_with?(Atom.to_string(fun), "_unsafe_")
+
+  defp justified?(line_no, lines, lookback) do
+    Enum.any?(max(1, line_no - lookback)..line_no, fn n ->
+      case lines[n] do
+        nil -> false
+        text -> text =~ @ownership_comment
+      end
+    end)
+  end
+end


### PR DESCRIPTION
Third of the #435 batch: the automated replacement for the manual `_unsafe_` sweeps.

## The check
`Fountain.Credo.Check.UnsafeCallOwnership` (`credo/checks/`, loaded via `requires:`) walks the AST for **remote** calls to `_unsafe_*` functions — `Mod._unsafe_x(...)` and `&Mod._unsafe_x/1` captures — and requires a comment containing "ownership" within a 10-line window above the call (one comment covers a cluster). Local calls inside the defining context module are deliberately not flagged: scoping is that module's own concern, reviewed with the module.

`exempt_paths` in `.credo.exs` encodes the structural caller shapes from CLAUDE.md's tenant isolation section, where ownership isn't per-call-site:
- `admin_live/` — entire directory behind the router's `:admin` live_session
- `conversation_server.ex` — GenServer, ownership at init/rehydrate
- `rehydrator.ex`, `workers/` — system sweeps with no user in scope
- `/test/`

Any **new** file calling `_unsafe_` (or a new call in a non-exempt file) now fails `mix credo --strict` (CI + precommit) until it's either annotated or explicitly exempted — a reviewable act, which is what the manual sweep used to provide.

## The annotations
Running the check on the current tree flagged 21 sites; all were legitimate (unsurprising — #328/#383 swept them), and each now says *why*: scoped parent fetch (controllers/LiveViews), admin gate in a function head (`audit_live`), system flow (`suspend_user`'s reap, `wake_conversation`). Several sites already had the explanation and only needed the word "ownership".

## Verification
- `mix credo --strict`: clean on the annotated tree.
- Mutation: stripping one annotation fails with exit 16 and points at the call line.
- Existing #383-era "Ownership context" comments pass unmodified (case-insensitive match).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`: clean.

Part of #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)