### PR TITLE
tests: stripe webhook :retry/500 arm + telemetry poller wiring (#435)

### DIFF
--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -364,18 +364,25 @@ defmodule FountainWeb.Telemetry do
     ]
   end
 
-  defp periodic_measurements do
-    # Funnel stage gauges (#282) and ops gauges (#321). Full-table passes
-    # every tick — cheap at current scale. Off in test: the poller's Repo
-    # calls would race the SQL Sandbox's connection ownership (the modules
-    # are exercised directly by tests instead).
-    if Application.get_env(:fountain, :funnel_poller_enabled, true) do
-      [
-        {Fountain.Funnel, :emit_telemetry, []},
-        {Fountain.OpsGauges, :emit_telemetry, []}
-      ]
-    else
-      []
-    end
+  # Funnel stage gauges (#282) and ops gauges (#321). Full-table passes
+  # every tick — cheap at current scale. Off in test: the poller's Repo
+  # calls would race the SQL Sandbox's connection ownership (the modules
+  # are exercised directly by tests instead).
+  #
+  # Public (with the flag as an argument) so telemetry_test can assert the
+  # poller wiring: every MFA here must exist, or telemetry_poller crashes at
+  # boot in the only environment where the list is non-empty — production.
+  @doc false
+  def periodic_measurements(
+        enabled? \\ Application.get_env(:fountain, :funnel_poller_enabled, true)
+      )
+
+  def periodic_measurements(true) do
+    [
+      {Fountain.Funnel, :emit_telemetry, []},
+      {Fountain.OpsGauges, :emit_telemetry, []}
+    ]
   end
+
+  def periodic_measurements(false), do: []
 end

--- a/apps/fountain/test/fountain_web/controllers/stripe_webhook_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/stripe_webhook_controller_test.exs
@@ -98,6 +98,73 @@ defmodule FountainWeb.StripeWebhookControllerTest do
       assert Fountain.Repo.get!(Fountain.Accounts.User, user.id).subscription_status ==
                "active"
     end
+
+    # The :retry/500 arm (#337 gave every outcome a 200; #414 flagged that the
+    # 500 path had no controller test). 500 is the only thing that makes
+    # Stripe redeliver, so these are the tests that fail if someone
+    # "simplifies" the controller back to always-200.
+    @tag capture_log: true
+    test "returns 500 so Stripe redelivers when processing fails transiently", %{conn: conn} do
+      event = %Stripe.Event{
+        id: "evt_retry_test",
+        type: "customer.subscription.updated",
+        data: %{object: %{status: "active", customer: "cus_x", trial_end: nil}}
+      }
+
+      stub(Stripe.Webhook, :construct_event, fn _body, _sig, _secret -> {:ok, event} end)
+      stub(Fountain.Billing, :handle_event, fn _event -> {:error, :database_unavailable} end)
+
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("stripe-signature", "t=1,v1=validhash")
+        |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :post, "/api/stripe/webhook", @raw_body)
+
+      assert conn.status == 500
+    end
+
+    @tag capture_log: true
+    test "returns 500 when processing raises (rescue funnels into :retry)", %{conn: conn} do
+      event = %Stripe.Event{
+        id: "evt_raise_test",
+        type: "customer.subscription.updated",
+        data: %{object: %{status: "active", customer: "cus_x", trial_end: nil}}
+      }
+
+      stub(Stripe.Webhook, :construct_event, fn _body, _sig, _secret -> {:ok, event} end)
+      stub(Fountain.Billing, :handle_event, fn _event -> raise "boom mid-processing" end)
+
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("stripe-signature", "t=1,v1=validhash")
+        |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :post, "/api/stripe/webhook", @raw_body)
+
+      assert conn.status == 500
+    end
+
+    @tag capture_log: true
+    test "still acks with 200 when the customer is unknown — retrying cannot fix it",
+         %{conn: conn} do
+      # The one error branch that deliberately answers 200: user_not_found.
+      # Kept next to the 500 tests so the asymmetry is visible in one place.
+      event = %Stripe.Event{
+        id: "evt_unknown_customer",
+        type: "customer.subscription.updated",
+        data: %{object: %{status: "active", customer: "cus_nobody", trial_end: nil}}
+      }
+
+      stub(Stripe.Webhook, :construct_event, fn _body, _sig, _secret -> {:ok, event} end)
+      stub(Fountain.Billing, :handle_event, fn _event -> {:error, :user_not_found} end)
+
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("stripe-signature", "t=1,v1=validhash")
+        |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :post, "/api/stripe/webhook", @raw_body)
+
+      assert conn.status == 200
+    end
   end
 
   describe "POST /api/stripe/webhook — real signature verification (no stub)" do

--- a/apps/fountain/test/fountain_web/telemetry_test.exs
+++ b/apps/fountain/test/fountain_web/telemetry_test.exs
@@ -1,0 +1,34 @@
+defmodule FountainWeb.TelemetryTest do
+  # Pure wiring assertions — no DB, no poller started.
+  use ExUnit.Case, async: true
+
+  describe "periodic_measurements/1" do
+    test "defaults to the test-env flag, which disables polling" do
+      # config/test.exs sets funnel_poller_enabled: false so the poller's
+      # Repo calls can't race the SQL Sandbox. If this ever flips on in
+      # test, async suites start flaking on connection ownership.
+      assert FountainWeb.Telemetry.periodic_measurements() == []
+    end
+
+    test "when enabled, polls the funnel and ops gauges" do
+      measurements = FountainWeb.Telemetry.periodic_measurements(true)
+
+      assert {Fountain.Funnel, :emit_telemetry, []} in measurements
+      assert {Fountain.OpsGauges, :emit_telemetry, []} in measurements
+    end
+
+    test "every polled MFA exists — a missing one crashes telemetry_poller at boot" do
+      # The emitter modules are tested directly, so a rename there passes
+      # its own tests while the poller list — empty in every env where the
+      # suite runs — still points at the old name. This is the joint check:
+      # the production list must reference functions that exist.
+      for {mod, fun, args} <- FountainWeb.Telemetry.periodic_measurements(true) do
+        assert Code.ensure_loaded?(mod), "#{inspect(mod)} is not loadable"
+
+        assert function_exported?(mod, fun, length(args)),
+               "#{inspect(mod)}.#{fun}/#{length(args)} is not exported — " <>
+                 "telemetry_poller would crash at boot in prod"
+      end
+    end
+  end
+end

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -15,6 +15,10 @@ Mimic.copy(Horde.DynamicSupervisor)
 Mimic.copy(Req)
 
 # Stripe modules — needed by billing tests and webhook controller tests.
+# Billing itself is copied so the webhook controller's :retry/500 arm can be
+# driven with an injected transient failure — there is no real Stripe outage
+# to reproduce in a test.
+Mimic.copy(Fountain.Billing)
 Mimic.copy(Stripe.Webhook)
 Mimic.copy(Stripe.Customer)
 Mimic.copy(Stripe.BillingPortal.Session)


### PR DESCRIPTION
Last of the #435 batch: the two untested joints from #414's paired-fixes section.

## Webhook `:retry`/500 arm
The controller answers 500 only on `:retry` (so Stripe redelivers, #337) — and that arm had no controller test; the existing composition test drives `user_not_found`, the one error branch that deliberately gets a 200. New tests, kept side by side so the asymmetry is visible in one place:

- transient `{:error, :database_unavailable}` → **500**
- `handle_event` raising mid-processing (the `rescue` funnels into `:retry`) → **500**
- `{:error, :user_not_found}` → **200** (retrying can't fix an unknown customer)

`Fountain.Billing` is now `Mimic.copy`'d in `test_helper.exs` — there's no real transient Stripe/DB outage to reproduce, and copy-without-stub passes through for everyone else (full suite green).

**Verified by reverting the fix**: changing the controller's `send_resp(conn, 500, "")` back to 200 fails exactly the two new 500 tests.

## Telemetry poller wiring
`periodic_measurements/0` returned `[]` in every environment the test suite runs in, so the production poller list was structurally untestable — a rename of `Funnel.emit_telemetry`/`OpsGauges.emit_telemetry` passes those modules' own tests while `telemetry_poller` crashes at boot in the only env where the list is non-empty. It's now public with the flag as an argument; the new test asserts the enabled list contains both MFAs and that **every MFA in it is exported**, plus that the default (test-env) path stays `[]` (the SQL-Sandbox race guard).

**Verified**: renaming an MFA inside the list fails the joint test; restoring it goes green.

Full suite: 1951 tests, 0 failures.

Part of #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)