### PR TITLE
sobelow: scan ee/lib web modules via a merged-tree script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,12 @@ jobs:
         continue-on-error: true
         run: mix hex.audit
 
-      # working-directory matters: at the umbrella root sobelow detects no
+      # Not plain `mix sobelow`: at the umbrella root sobelow detects no
       # Phoenix app, scans nothing, and exits 0 — indistinguishable from a
-      # pass. Reported by two audits (#194, #311) before it was fixed.
+      # pass (#194, #311). The script scans a merged tree so ee/lib web
+      # modules are covered too (decisions/0010).
       - name: Security scan (sobelow)
-        working-directory: apps/fountain
-        run: mix sobelow --config
+        run: scripts/sobelow.sh
 
       # The PLT encodes OTP + deps; rebuilding it cold takes minutes, so it is
       # cached on the exact beam versions + lockfile. mix.exs pins its path to

--- a/apps/fountain/test/fountain/sobelow_gate_test.exs
+++ b/apps/fountain/test/fountain/sobelow_gate_test.exs
@@ -26,4 +26,34 @@ defmodule Fountain.SobelowGateTest do
            "blanket ignores defeat the named-exception discipline — accept a " <>
              "finding with a justified sobelow_skip marker at the call site instead"
   end
+
+  # Since #472 the billing/email web modules live in ee/lib, outside sobelow's
+  # reach from apps/fountain. scripts/sobelow.sh scans a merged core+ee tree;
+  # a revert to bare `mix sobelow --config` would drop ee from the scan and
+  # still exit 0 — the same invisible-gate failure mode as #311.
+  test "the sobelow gate runs through scripts/sobelow.sh so ee/lib is scanned" do
+    import Bitwise
+
+    root = Path.expand("../../../..", __DIR__)
+    script = Path.join(root, "scripts/sobelow.sh")
+
+    assert File.exists?(script),
+           "scripts/sobelow.sh is missing — it is what puts ee/lib inside the " <>
+             "sobelow scan (decisions/0010)"
+
+    assert (File.stat!(script).mode &&& 0o111) != 0,
+           "scripts/sobelow.sh is not executable"
+
+    assert File.read!(script) =~ "ee/lib",
+           "scripts/sobelow.sh no longer overlays ee/lib into the scan tree"
+
+    for {caller, path} <- [
+          {"CI", Path.join(root, ".github/workflows/ci.yml")},
+          {"mix precommit", Path.join(root, "mix.exs")}
+        ] do
+      assert File.read!(path) =~ "scripts/sobelow.sh",
+             "#{caller} no longer runs sobelow through scripts/sobelow.sh — " <>
+               "ee/lib web modules would silently leave the scan (decisions/0010)"
+    end
+  end
 end

--- a/decisions/0010-ee-directory-boundary.md
+++ b/decisions/0010-ee-directory-boundary.md
@@ -61,10 +61,11 @@ Per the repo rule that ADRs must not describe unbuilt behavior as existing:
   without `ee/`; billing gates have no always-allow default; there is no
   community-build CI job.
 - **BillingLive export/deletion extraction** (the impurity above).
-- **Sobelow coverage of ee web modules.** Sobelow scans from `apps/fountain`,
-  so the moved controllers/LiveView left its scope. Every moved file was
-  scanned pre-move and content is unchanged; the gap applies only to future
-  edits of ee web files.
+- ~~**Sobelow coverage of ee web modules.**~~ Closed in the follow-up PR:
+  `scripts/sobelow.sh` (used by `mix precommit` and CI) assembles a temporary
+  merged tree — core `lib` with `ee/lib` overlaid — and scans that, restoring
+  the exact pre-move scan. The script fails on any core/ee path collision
+  rather than letting one file shadow the other.
 
 ## Consequences
 

--- a/mix.exs
+++ b/mix.exs
@@ -111,13 +111,15 @@ defmodule Fountain.Umbrella.MixProject do
     end
   end
 
-  # Runs from apps/fountain because sobelow at the umbrella root detects no
-  # Phoenix app, scans nothing, and exits 0 — a gate that passes because it
-  # scanned nothing looks identical to a gate that passed (#311).
+  # Not plain `mix sobelow`: at the umbrella root sobelow detects no Phoenix
+  # app, scans nothing, and exits 0 — a gate that passes because it scanned
+  # nothing looks identical to a gate that passed (#311). The script also
+  # overlays ee/lib into the scan tree, which sobelow cannot reach from
+  # apps/fountain on its own (decisions/0010).
   defp sobelow_in_app(_args) do
-    case Mix.shell().cmd("mix sobelow --config", cd: "apps/fountain") do
+    case Mix.shell().cmd("scripts/sobelow.sh") do
       0 -> :ok
-      status -> Mix.raise("mix sobelow failed with exit status #{status}")
+      status -> Mix.raise("sobelow failed with exit status #{status}")
     end
   end
 end

--- a/scripts/sobelow.sh
+++ b/scripts/sobelow.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Sobelow scan covering core AND ee/ (decisions/0010).
+#
+# Sobelow scans a single Phoenix app root: it needs root/mix.exs for the app
+# name and a router among the scanned files, so it cannot scan ee/ directly
+# (no mix.exs, no router). Instead we assemble a throwaway merged tree —
+# apps/fountain's lib with ee/lib overlaid (their file sets are disjoint by
+# construction; the move was pure renames) — and point sobelow at that. This
+# reproduces the exact pre-#472 scan, when the ee files still lived in core.
+#
+# Callers: `mix precommit` (root mix.exs) and .github/workflows/ci.yml.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+scan="$(mktemp -d)"
+trap 'rm -rf "$scan"' EXIT
+
+cp "$root/apps/fountain/mix.exs" "$scan/mix.exs"
+cp "$root/apps/fountain/.sobelow-conf" "$scan/.sobelow-conf"
+cp -R "$root/apps/fountain/lib" "$scan/lib"
+# tar pipe rather than cp: portable directory merge on both BSD/macOS and GNU
+tar -C "$root/ee/lib" -cf - . | tar -C "$scan/lib" -xf -
+
+# Guard the "disjoint by construction" assumption: a core file and an ee file
+# at the same path would silently shadow each other in the merged tree.
+dupes="$(cd "$root/apps/fountain/lib" && find . -type f | sort >"$scan/.core-files" && cd "$root/ee/lib" && find . -type f | sort | comm -12 "$scan/.core-files" -)"
+if [ -n "$dupes" ]; then
+  echo "sobelow.sh: path collision between apps/fountain/lib and ee/lib:" >&2
+  echo "$dupes" >&2
+  exit 1
+fi
+
+cd "$root/apps/fountain"
+exec mix sobelow --root "$scan" --config


### PR DESCRIPTION
## What

Closes the sobelow gap accepted in `decisions/0010` (#472): sobelow scans a single Phoenix app root — it needs `root/mix.exs` and a router among scanned files — so it cannot scan `ee/` directly, and the moved `StripeWebhookController`, `EmailVerificationController`, and `BillingLive` had left its scope.

`scripts/sobelow.sh` assembles a throwaway merged tree (`apps/fountain/lib` with `ee/lib` overlaid — disjoint by construction since #472 was pure renames) and points `mix sobelow --root` at it, reproducing the exact pre-#472 scan with the real router present. The script fails loudly if a core file and an ee file ever occupy the same path, rather than letting one silently shadow the other.

- `mix precommit` (`sobelow_in_app/1`) and the CI step both run the script now.
- New regression test in `sobelow_gate_test.exs` asserts the script exists, is executable, still overlays `ee/lib`, and that CI + precommit still route through it — reverting to bare `mix sobelow --config` would drop ee from the scan while still exiting 0, the same invisible-gate failure mode as #311.
- ADR 0010's "not done yet" entry updated to record the closure.

## Verification

- Canary: injecting `Code.eval_string(params["x"])` into the ee-origin webhook controller inside the merged tree makes the scan report `RCE.CodeModule - High Confidence` at the right file/line — proof the ee files are genuinely read.
- Clean run: `scripts/sobelow.sh` → `SCAN COMPLETE`, exit 0.
- `mix precommit` passes end to end with the script wired in (1952 tests, 0 failures — +1 is the new gate test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)