### PR TITLE
tests: stub Stripe.Subscription.create at the arity billing actually calls

### DIFF
--- a/ee/test/fountain/workers/stripe_customer_sync_test.exs
+++ b/ee/test/fountain/workers/stripe_customer_sync_test.exs
@@ -27,16 +27,29 @@ defmodule Fountain.Workers.StripeCustomerSyncTest do
     end
 
     test "is idempotent — a rerun does not mint a second customer" do
+      # price_id set on purpose: several async test files put_env
+      # :stripe_price_id globally, and whenever one overlapped this test the
+      # trial-subscription branch fired here too. That configuration used to be
+      # the flaky one (twice: first with no Subscription.create stub at all,
+      # then with a stub at arity 1 while billing calls create/2 — either way
+      # the call fell through to real Stripe and 401ed). Forcing the branch on
+      # makes the once-flaky configuration the deterministic one; the priceless
+      # branch is covered in stripe_customer_sync_trial_test.exs.
+      Application.put_env(:fountain, :stripe_price_id, "price_sync_idem")
+      on_exit(fn -> Application.delete_env(:fountain, :stripe_price_id) end)
       user = insert_verified_user()
       {:ok, _} = Fountain.Billing.attach_stripe_customer(user, "cus_existing")
 
       # Customer.create flunks if called — that is the property under test.
-      # Subscription.create is stubbed benignly instead of left bare: several
-      # async test files put_env :stripe_price_id globally, and when one
-      # overlaps this test the trial-subscription branch legitimately fires —
-      # previously with no stub, so it hit real Stripe and 401ed (flake).
       stub(Stripe.Customer, :create, fn _ ->
         flunk("a rerun must not create a second Stripe customer")
+      end)
+
+      # Both arities: billing calls create/2 (params, idempotency-key opts);
+      # /1 exists via the default arg and is stubbed so an arity change in
+      # billing can never fall through to real Stripe again.
+      stub(Stripe.Subscription, :create, fn _, _ ->
+        {:ok, %Stripe.Subscription{id: "sub_benign", status: "trialing"}}
       end)
 
       stub(Stripe.Subscription, :create, fn _ ->

--- a/ee/test/fountain/workers/stripe_customer_sync_trial_test.exs
+++ b/ee/test/fountain/workers/stripe_customer_sync_trial_test.exs
@@ -76,7 +76,11 @@ defmodule Fountain.Workers.StripeCustomerSyncTrialTest do
       |> Repo.update()
 
     stub(Stripe.Customer, :create, fn _ -> {:ok, %Stripe.Customer{id: "cus_late"}} end)
+    # Both arities: billing calls create/2 — a /1-only reject watches an
+    # arity nothing calls, and the real call would fall through to live
+    # Stripe instead of tripping the tripwire.
     reject(&Stripe.Subscription.create/1)
+    reject(&Stripe.Subscription.create/2)
 
     assert :ok = perform_job(StripeCustomerSync, %{user_id: user.id})
     assert Repo.get(User, user.id).stripe_subscription_id == nil


### PR DESCRIPTION
## What

Fixes the intermittent CI failure that hit main on 3bfb60f (`stripe_customer_sync_test.exs:29` returning a real Stripe 401 instead of `:ok`) — same class as occasional local flakes.

Root cause: `Billing.do_create_trial_subscription` calls `Stripe.Subscription.create/2` (`billing.ex:260`, params + idempotency-key opts), but the idempotency test stubbed **arity 1**. Mimic stubs are per-arity, so the stub never intercepted. The trial branch only fires when another async test file's global `Application.put_env(:fountain, :stripe_price_id, ...)` overlaps this test — which is why it was timing-dependent. When it fired, the unstubbed `/2` call fell through to live Stripe and 401ed. (Unrelated to the ee/ move and to the Mimic 2.3 bump — the test's own comments record a previous round of this same flake.)

Changes:
- `stripe_customer_sync_test.exs`: the contamination scenario is now **forced on deterministically** (`put_env` inside the test + `on_exit` cleanup) so the once-flaky configuration is the always-tested one; `Subscription.create` stubbed at both arities. The priceless branch remains covered by `stripe_customer_sync_trial_test.exs`.
- `stripe_customer_sync_trial_test.exs`: the `reject(&Stripe.Subscription.create/1)` tripwire also watches `/2` — a /1-only reject guards an arity nothing calls while the real call goes to live Stripe.

## Verification

- Deterministic repro first: injecting the `put_env` with the old arity-1 stub reproduces the exact CI failure locally (real-Stripe 401).
- Fix-reverted check: removing only the arity-2 stub makes the test fail with that same error; restoring it, both files pass (11 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)