### PR TITLE
docs: re-scope ee/ to billing + growth mail (#477)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,11 @@ fountain/                  umbrella root
       test/fountain/       context unit tests (async: true, DataCase)
       test/fountain_web/   controller/LiveView integration tests
       test/support/        DataCase, ConnCase, factory.ex
-  ee/                      billing + ALL transactional email, compiled into the
-    lib/fountain/          same :fountain app via elixirc_paths/test_paths.
-    lib/fountain_web/      Future-license boundary (MIT today) — see
-    test/                  decisions/0010. Module names unchanged by the move.
+  ee/                      billing + growth email (welcome/trial/payment),
+    lib/fountain/          compiled into the same :fountain app via
+    lib/fountain_web/      elixirc_paths/test_paths. Possible-license boundary
+    test/                  (MIT today) — decisions/0010 + its addendum.
+                           Account email + Mailer are core (#475/#476).
   config/
     config.exs             shared config
     dev.exs                dev overrides

--- a/decisions/0010-ee-directory-boundary.md
+++ b/decisions/0010-ee-directory-boundary.md
@@ -2,7 +2,9 @@
 
 **Status:** Accepted (documents the file move built in the PR that adds this
 ADR; the license change and the core/ee seam are explicitly **not yet built**
-— see "Not done yet" below)
+— see "Not done yet" below). **Scope narrowed by the 2026-08-05 addendum at
+the bottom: account email returned to core; ee/ is billing + billing-adjacent
+growth mail.**
 
 ## Context
 
@@ -81,3 +83,32 @@ Per the repo rule that ADRs must not describe unbuilt behavior as existing:
   unanchored and still match.
 - Historical ADRs (notably 0006) reference pre-move file paths; they describe
   the state at their time and are not rewritten.
+
+## Addendum — 2026-08-05: scope narrowed to billing + growth mail (#475/#476)
+
+The original scope put **all** transactional email in ee/. The retrospective
+the same day settled two product positions that changed the calculus: Fountain
+ships a **single image** (no separate community/ee artifacts planned), and a
+community instance must never depend on ee/ for anything it actually needs.
+Password reset living behind a possible future ee license failed that test.
+
+What moved back to core (#475, #476):
+
+- `Fountain.Mailer` and the account templates in `Fountain.Emails.UserEmails`:
+  verification, password reset, suspended/unsuspended, deleted, email-change
+  confirmation/notice.
+- `EmailVerificationController` and the `verification_email`,
+  `email_change_email`, `account_email`, `unverified_account_pruner` workers.
+
+What ee/ holds now: the Stripe billing surface, and billing-adjacent/growth
+mail — `Fountain.Emails.BillingEmails` (welcome, trial ending/expired, the
+four payment-lifecycle emails, subscription canceled) with the
+`welcome_email`, `trial_ending_email`, `lifecycle_email`,
+`stripe_customer_sync` workers. `BillingEmails` borrows the now-public
+`UserEmails.from_address/0` / `support_phrase/0` so the mail surface keeps
+one sender and one support-contact policy.
+
+One framing correction, per the same retrospective: this boundary
+**preserves the option** of licensing ee/ differently; it is not a plan of
+record. Everything remains MIT until an explicit license decision says
+otherwise.

--- a/ee/README.md
+++ b/ee/README.md
@@ -3,21 +3,23 @@
 Code in `ee/` is compiled into the same `:fountain` OTP app as everything
 under `apps/fountain` (wired in via `elixirc_paths` / `test_paths` in
 `apps/fountain/mix.exs`), but sits behind a directory boundary intended to
-carry a different license in the future, GitLab-style. **Today it is MIT**
-(`ee/LICENSE`, identical to the root license).
+carry a different license someday, GitLab-style — an option preserved, not a
+plan of record. **Today it is MIT** (`ee/LICENSE`, identical to the root
+license).
 
 ## Contents
 
 - **Billing** — the Stripe integration: `Fountain.Billing`, the usage-event
-  schema, the webhook controller, the billing LiveView, the billing Oban
-  workers, and the `fountain.verify_lifecycle` mix task.
-- **Transactional email** — `Fountain.Mailer`, `Fountain.Emails.UserEmails`,
-  the email Oban workers (verification, welcome, account, email-change,
-  lifecycle, trial-ending), the unverified-account pruner, and the email
-  verification controller.
+  schema, the webhook controller, the billing LiveView, the
+  `stripe_customer_sync` worker, and the `fountain.verify_lifecycle` mix task.
+- **Billing-adjacent / growth email** — `Fountain.Emails.BillingEmails`
+  (welcome, trial, payment-lifecycle mail) and the `welcome_email`,
+  `trial_ending_email`, `lifecycle_email` workers.
 
-Module names are unchanged from their pre-move locations — only file paths
-moved. See `decisions/0010-ee-directory-boundary.md` for the decision record.
+Account email (verification, password reset, suspension/deletion notices,
+email change) and `Fountain.Mailer` are **core** — a community instance must
+never depend on ee/ for mail it actually needs (#475/#476). See
+`decisions/0010-ee-directory-boundary.md` and its 2026-08-05 addendum.
 
 ## Boundary status
 


### PR DESCRIPTION
Implements #477 (tracker #482). Merge **after** #484 and #485 so the docs never describe a state the tree isn't in.

- `decisions/0010`: dated addendum (ADR-0006 style) recording the #475/#476 scope narrowing, plus the framing correction from the 2026-08-04 retrospective — single image, license split is a preserved *option*, not a plan of record. Status line points at the addendum.
- `ee/README.md`: contents list matches the post-move tree; states the community-mail invariant.
- `CLAUDE.md`: repo-layout ee/ block updated.
- `config/runtime.exs` mail copy checked per the ticket — already current (#478 rewrote it around self-verification; verification is core-side after #485, so it stands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)