### PR TITLE
release: bump self-host pins to v0.4.1, keep them bumped at release time

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -38,12 +38,10 @@ SPRITES_TOKEN=
 # it moves under you on every merge). Releases publish vX.Y.Z (immutable)
 # and vX.Y (newest patch in the line) tags:
 # https://binarybourbon.github.io/fountain/self-hosting/#versioning-and-upgrades
-FOUNTAIN_IMAGE_TAG=v0.3.0
+FOUNTAIN_IMAGE_TAG=v0.4.1
 
-# Mail. The default (EMAIL_DELIVERY=none) sends nothing, so verify accounts
-# with:
-#   docker compose exec app bin/fountain_server eval \
-#     'Fountain.Release.verify_email("you@example.com")'
+# Mail. The default (EMAIL_DELIVERY=none) sends nothing; accounts self-verify
+# at registration instead (ADR 0011), so signup works without a mail provider.
 #
 # For real mail, set one of these and remove EMAIL_DELIVERY.
 # RESEND_API_KEY=

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -118,6 +118,28 @@ jobs:
           sed -i -E "s/version: \"${current}\"/version: \"${next}\"/" apps/fountain/mix.exs
           git diff --stat
 
+      - name: Update self-host image pins
+        run: |
+          set -euo pipefail
+          current='v${{ steps.ver.outputs.current }}'
+          next='${{ steps.ver.outputs.tag }}'
+          # The quick-start pins sat at v0.3.0 through two releases, handing
+          # newcomers an image from before the in-app first-login flow
+          # (#478). Bump them in the release commit so the tag's own tree
+          # pins the tag. ReleasePinTest keeps this list and the files in
+          # lockstep between releases.
+          pins='docker-compose.yml .env.compose.example deploy/k8s/kustomization.yaml deploy/k8s/deployment.yaml'
+          for f in ${pins}; do
+            sed -i "s/${current}/${next}/g" "$f"
+            # sed exits 0 whether or not it matched; a pin that no longer
+            # matches ${current} must abort the release, not ship stale.
+            if ! grep -qF "${next}" "$f" || grep -qF "${current}" "$f"; then
+              echo "pin bump failed in ${f}: expected ${current} -> ${next}" >&2
+              exit 1
+            fi
+          done
+          git diff --stat
+
       - name: Commit, tag, push
         env:
           TAG: ${{ steps.ver.outputs.tag }}
@@ -126,7 +148,9 @@ jobs:
           set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add mix.exs apps/fountain/mix.exs
+          git add mix.exs apps/fountain/mix.exs \
+            docker-compose.yml .env.compose.example \
+            deploy/k8s/kustomization.yaml deploy/k8s/deployment.yaml
           # [skip ci] keeps this commit from re-triggering CI on main.
           # release.yml is dispatched explicitly in the next step.
           git commit -m "chore(release): ${TAG} [skip ci]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,14 @@ upgrade, is in
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- The self-host quick start pinned `v0.3.0` — an image from before the
+  in-app first-login flow (#478), so following the docs verbatim dead-ended
+  signup under `EMAIL_DELIVERY=none`. The compose and `deploy/k8s` pins now
+  sit at `v0.4.1`, the release workflow bumps them inside every release
+  commit, and a test fails any PR where a pin drifts from the released
+  version. (#489)
 
 ## [0.4.1] — 2026-08-05
 

--- a/apps/fountain/test/fountain/release_pin_test.exs
+++ b/apps/fountain/test/fountain/release_pin_test.exs
@@ -1,0 +1,34 @@
+defmodule Fountain.ReleasePinTest do
+  # The self-host quick start pins a release image in four places. Those pins
+  # sat at v0.3.0 through two releases, handing newcomers an image from before
+  # the in-app first-login flow (#478), where EMAIL_DELIVERY=none dead-ends
+  # signup. release-bump.yml now bumps the pins inside the release commit;
+  # since that commit is [skip ci], this test is the net that catches a pin
+  # the workflow missed — on the next PR, not two releases later.
+  use ExUnit.Case, async: true
+
+  @root Path.expand("../../../..", __DIR__)
+
+  @pins [
+    {"docker-compose.yml", ~r/fountain:\$\{FOUNTAIN_IMAGE_TAG:-(v[\d.]+)\}/},
+    {".env.compose.example", ~r/^FOUNTAIN_IMAGE_TAG=(v[\d.]+)$/m},
+    {"deploy/k8s/kustomization.yaml", ~r/newTag: (v[\d.]+)/},
+    {"deploy/k8s/deployment.yaml", ~r/image: ghcr\.io\/binarybourbon\/fountain:(v[\d.]+)/}
+  ]
+
+  test "self-host image pins match the released version" do
+    expected = "v" <> to_string(Application.spec(:fountain, :vsn))
+
+    for {file, regex} <- @pins do
+      pinned =
+        case Regex.run(regex, File.read!(Path.join(@root, file))) do
+          [_, tag] -> tag
+          nil -> flunk("#{file}: image pin not found (pattern #{inspect(regex)})")
+        end
+
+      assert pinned == expected,
+             "#{file} pins #{pinned} but the released version is #{expected}; " <>
+               "release-bump.yml should have bumped it in the release commit"
+    end
+  end
+end

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: fountain
           # Retagged by kustomization.yaml's images: block — edit the pin
           # there, not here.
-          image: ghcr.io/binarybourbon/fountain:v0.3.0
+          image: ghcr.io/binarybourbon/fountain:v0.4.1
           imagePullPolicy: IfNotPresent
           lifecycle:
             # Endpoints propagation is asynchronous: without this pause the

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -27,4 +27,4 @@ images:
   # Released tags: vX.Y.Z (immutable) and vX.Y (newest patch in the line).
   # https://binarybourbon.github.io/fountain/self-hosting/#versioning-and-upgrades
   - name: ghcr.io/binarybourbon/fountain
-    newTag: v0.3.0
+    newTag: v0.4.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     # migrations applied at boot and downgrade unsupported — the exact
     # combination the versioning guide tells you never to run. Upgrade by
     # setting FOUNTAIN_IMAGE_TAG in .env (see .env.compose.example).
-    image: ghcr.io/binarybourbon/fountain:${FOUNTAIN_IMAGE_TAG:-v0.3.0}
+    image: ghcr.io/binarybourbon/fountain:${FOUNTAIN_IMAGE_TAG:-v0.4.1}
     # To run your own build instead of the published image, comment the line
     # above and uncomment this:
     #   build: .


### PR DESCRIPTION
## Problem

`docker-compose.yml`, `.env.compose.example`, `deploy/k8s/kustomization.yaml`, and `deploy/k8s/deployment.yaml` all pinned `v0.3.0` — two releases stale. A newcomer following docs/self-hosting.md verbatim got an image from before the in-app first-login flow (#478): under the compose default `EMAIL_DELIVERY=none`, signup dead-ended on a verification email that never sends — the exact bug #478 fixed.

Beyond the stale values, nothing in the release process updated these pins, so they would have drifted again on the next release.

## Changes

- **Bump the four pins to `v0.4.1`** (the user-visible fix — note `deploy/k8s/deployment.yaml` was a fourth stale pin beyond the three originally flagged), and update the `.env.compose.example` mail comment that still described the pre-#478 manual `verify_email` workaround; accounts self-verify at registration now (ADR 0011).
- **`release-bump.yml` bumps the pins inside the release commit**, with a verify-after-sed guard borrowed from `publish-manifests.yml` (sed exits 0 on no match; a pin that stops matching aborts the release instead of shipping stale). The tag's own tree now pins the tag.
- **`ReleasePinTest`** asserts every pin equals `v` + the app version. The release commit is `[skip ci]`, so the test is the net that catches a missed pin on the next PR rather than two releases later.

## Verification

- New test passes at `v0.4.1`; reverting one pin to `v0.3.0` makes it fail with a pointed message (verified, then restored).
- The workflow's sed step simulated locally under bash on copies of all four files: `v0.4.1 → v0.4.2` lands in every file and the guard passes; the guard correctly aborts when a file doesn't contain the expected current tag.
- **Inert for prod**: `k8s/deployment.yaml` is a strategic-merge patch applied *after* the base's `images:` transformer, so its `sha-…` pin still wins — confirmed with `kubectl kustomize` on both `deploy/k8s` (renders `v0.4.1`) and `k8s` (still renders the `sha-…` pin).
- `mix precommit` green: 5 doctests, 3 properties, 1967 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)