### PR TITLE
self-host: split BillingLive — core /account page for export/deletion, billing page hidden when disabled (#479)

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -81,7 +81,7 @@ defmodule FountainWeb.Layouts do
 
     footer_open =
       Enum.any?(
-        ["/api-keys", "/account/billing", "/account/security", "/audit", "/help", "/admin"],
+        ["/api-keys", "/account", "/audit", "/help", "/admin"],
         &String.starts_with?(assigns[:current_path] || "", &1)
       )
 
@@ -294,8 +294,14 @@ defmodule FountainWeb.Layouts do
                 </svg>
               </summary>
               <div class="px-2 pt-0.5 pb-2 space-y-0.5 border-t border-[var(--color-border)]">
+                <.nav_link href={~p"/account"} label="Account" current={@current_path} exact />
                 <.nav_link href={~p"/api-keys"} label="API Keys" current={@current_path} />
-                <.nav_link href={~p"/account/billing"} label="Billing" current={@current_path} />
+                <.nav_link
+                  :if={Fountain.Billing.enabled?()}
+                  href={~p"/account/billing"}
+                  label="Billing"
+                  current={@current_path}
+                />
                 <.nav_link href={~p"/account/security"} label="Security" current={@current_path} />
                 <.nav_link href={~p"/audit"} label="Audit log" current={@current_path} />
                 <.nav_link href={~p"/help"} label="Help" current={@current_path} />
@@ -404,11 +410,18 @@ defmodule FountainWeb.Layouts do
   attr :href, :string, required: true
   attr :label, :string, required: true
   attr :current, :string, default: ""
+  # Highlight only on an exact path match — for links like /account whose
+  # href is a prefix of sibling pages (/account/billing, /account/security).
+  attr :exact, :boolean, default: false
 
   defp nav_link(assigns) do
     active =
-      (String.starts_with?(assigns.current || "", assigns.href) and assigns.href != "/") or
+      if assigns.exact do
         assigns.current == assigns.href
+      else
+        (String.starts_with?(assigns.current || "", assigns.href) and assigns.href != "/") or
+          assigns.current == assigns.href
+      end
 
     assigns = assign(assigns, active: active, link_attrs: [href: assigns.href])
 

--- a/apps/fountain/lib/fountain_web/live/account_live.ex
+++ b/apps/fountain/lib/fountain_web/live/account_live.ex
@@ -1,0 +1,232 @@
+defmodule FountainWeb.Live.AccountLive do
+  @moduledoc """
+  `/account` — data export and account deletion.
+
+  Extracted from `FountainWeb.Live.BillingLive` (#479): export and deletion
+  are core account features a billing-disabled instance still needs, so they
+  cannot live on a page that only exists when billing does. The handlers
+  delegate to `Fountain.Exports` and `Fountain.Accounts.Deletion`.
+  """
+
+  use FountainWeb, :live_view
+
+  alias Fountain.Accounts.Deletion
+  alias Fountain.Exports
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket = FountainWeb.Audited.put_client_ip(socket)
+    user = socket.assigns.current_user
+
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Fountain.PubSub, Exports.topic(user.id))
+    end
+
+    {:ok,
+     assign(socket,
+       page_title: "Account",
+       delete_confirmation: "",
+       deleting: false,
+       export: Exports.latest_export(user.id)
+     )}
+  end
+
+  @impl true
+  def handle_event("request_export", _params, socket) do
+    user = socket.assigns.current_user
+
+    case Exports.request_export(user, actor: "self", request_ip: socket.assigns[:client_ip]) do
+      {:ok, export} ->
+        {:noreply,
+         socket
+         |> assign(:export, export)
+         |> put_flash(:info, "Export started — the download will appear here when it is ready.")}
+
+      {:error, {:rate_limited, retry_after}} ->
+        minutes = max(div(retry_after + 59, 60), 1)
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "You can request one export per hour. Try again in about #{minutes} minute(s)."
+         )}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, "Could not start the export. Please try again.")}
+    end
+  end
+
+  @impl true
+  def handle_event("confirm_delete_input", %{"email" => email}, socket) do
+    {:noreply, assign(socket, :delete_confirmation, email)}
+  end
+
+  # Typing the account's own email is the confirmation. It is not a security
+  # control — the session already proves who this is — it is a speed bump, so
+  # the irreversible button cannot be hit by reflex.
+  @impl true
+  def handle_event("delete_account", %{"email" => email}, socket) do
+    user = socket.assigns.current_user
+
+    cond do
+      email != user.email ->
+        {:noreply, put_flash(socket, :error, "Type your email address exactly to confirm.")}
+
+      socket.assigns.deleting ->
+        {:noreply, socket}
+
+      true ->
+        socket = assign(socket, :deleting, true)
+
+        case Deletion.delete_user(user,
+               actor: "self",
+               request_ip: socket.assigns[:client_ip]
+             ) do
+          {:ok, _summary} ->
+            # Straight out through the controller so the session is dropped;
+            # a LiveView cannot clear the session cookie itself.
+            {:noreply, redirect(socket, to: ~p"/auth/logout?deleted=1")}
+
+          {:error, {:stripe, _reason}} ->
+            {:noreply,
+             socket
+             |> assign(:deleting, false)
+             |> put_flash(
+               :error,
+               "Your subscription could not be cancelled, so nothing was deleted. " <>
+                 "Please try again, or contact support if it keeps failing."
+             )}
+
+          {:error, _reason} ->
+            {:noreply,
+             socket
+             |> assign(:deleting, false)
+             |> put_flash(:error, "Account deletion failed. Nothing was deleted.")}
+        end
+    end
+  end
+
+  @impl true
+  def handle_info({:export_updated, _user_id}, socket) do
+    {:noreply, assign(socket, :export, Exports.latest_export(socket.assigns.current_user.id))}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-2xl space-y-8 px-4 py-8">
+      <h1 class="text-2xl font-semibold">Account</h1>
+
+      <%!-- Data export --%>
+      <div class="rounded-lg border bg-white p-6 shadow-sm">
+        <h2 class="mb-1 text-lg font-medium" id="export">Export your data</h2>
+        <p class="mb-2 text-sm text-gray-600">
+          Download a single JSON file containing your agents, environments, vaults,
+          conversations with their full log output, and your audit trail.
+        </p>
+        <p class="mb-4 text-sm text-gray-600">
+          Environment and vault <strong>secret values are deliberately excluded</strong>
+          — only secret names are listed. Secrets were write-only on the way in and
+          stay that way on the way out.
+        </p>
+
+        <%= if @export do %>
+          <div class="mb-4 rounded-md bg-gray-50 p-4 text-sm" id="export-status">
+            <%= case export_state(@export) do %>
+              <% :pending -> %>
+                <span class="text-gray-700">
+                  Export requested <%= Calendar.strftime(@export.inserted_at, "%Y-%m-%d %H:%M UTC") %>
+                  — generating&hellip; The download will appear here when it is ready.
+                </span>
+              <% :ready -> %>
+                <div class="flex items-center justify-between gap-4">
+                  <span class="text-gray-700">
+                    Export ready (<%= format_bytes(@export.byte_size) %>) — link expires
+                    <%= Calendar.strftime(@export.expires_at, "%Y-%m-%d %H:%M UTC") %>.
+                  </span>
+                  <a
+                    href={~p"/account/exports/#{@export.id}/download"}
+                    class="shrink-0 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700"
+                  >
+                    Download
+                  </a>
+                </div>
+              <% :expired -> %>
+                <span class="text-gray-500">
+                  Your last export has expired. Request a new one to download your data.
+                </span>
+              <% :failed -> %>
+                <span class="text-red-700">
+                  The last export failed. Please request a new one; contact support if it
+                  keeps failing.
+                </span>
+            <% end %>
+          </div>
+        <% end %>
+
+        <button
+          phx-click="request_export"
+          class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Request export
+        </button>
+        <p class="mt-2 text-xs text-gray-400">
+          One export per hour. Downloads expire after <%= Exports.ttl_hours() %> hours.
+        </p>
+      </div>
+
+      <%!-- Danger zone --%>
+      <div class="rounded-lg border border-red-200 bg-white p-6 shadow-sm">
+        <h2 class="mb-1 text-lg font-medium text-red-700">Delete account</h2>
+        <p class="mb-4 text-sm text-gray-600">
+          Cancels your subscription, destroys every running sandbox, and permanently
+          deletes your agents, environments, vaults, conversations and stored secrets.
+          Secrets are encrypted with a key held only for your account; deleting the
+          account destroys that key, so they cannot be recovered afterwards by anyone.
+          <strong>This cannot be undone.</strong>
+        </p>
+        <p class="mb-4 text-sm text-gray-600" id="delete-export-nudge">
+          Want a copy of your data first?
+          <a href="#export" class="underline">Request an export above</a>
+          before deleting — nothing can be recovered afterwards.
+        </p>
+
+        <form phx-submit="delete_account" class="space-y-3">
+          <label class="block text-sm text-gray-700">
+            Type <span class="font-mono font-semibold"><%= @current_user.email %></span> to confirm
+            <input
+              type="text"
+              name="email"
+              autocomplete="off"
+              value={@delete_confirmation}
+              phx-change="confirm_delete_input"
+              class="mt-1 block w-full rounded border-gray-300 text-sm shadow-sm"
+            />
+          </label>
+
+          <button
+            type="submit"
+            disabled={@delete_confirmation != @current_user.email or @deleting}
+            class="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-300"
+          >
+            <%= if @deleting, do: "Deleting…", else: "Delete my account" %>
+          </button>
+        </form>
+      </div>
+    </div>
+    """
+  end
+
+  defp export_state(%{status: "pending"}), do: :pending
+  defp export_state(%{status: "failed"}), do: :failed
+
+  defp export_state(%{status: "completed"} = export) do
+    if Exports.expired?(export), do: :expired, else: :ready
+  end
+
+  defp format_bytes(nil), do: "unknown size"
+  defp format_bytes(n) when n < 1024, do: "#{n} B"
+  defp format_bytes(n) when n < 1024 * 1024, do: "#{Float.round(n / 1024, 1)} KB"
+  defp format_bytes(n), do: "#{Float.round(n / (1024 * 1024), 1)} MB"
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -297,7 +297,10 @@ defmodule FountainWeb.Router do
       live "/help", HelpLive.Show, :index
       live "/help/:topic", HelpLive.Show, :show
 
-      # ── Phase-3-billing: account/billing ─────────────────────────────────────────────────────
+      # ── Account page: data export + deletion (#479) ────────────────────────────────────────
+      live "/account", Live.AccountLive, :index
+
+      # ── Phase-3-billing: account/billing. Redirects to /account when billing is disabled ────
       live "/account/billing", Live.BillingLive, :index
 
       # ── BYO inference credentials (ADR 0008) ───────────────────────────────────────────────

--- a/apps/fountain/priv/help/runbook.md
+++ b/apps/fountain/priv/help/runbook.md
@@ -109,7 +109,7 @@ As of 2026-08-01 the untracked set is 102 sprites named `aod-*`, all `cold`, cre
 
 ## Account deletion / erasure request
 
-Users close their own account at **/account/billing → Delete account**, typing their email to confirm. For someone locked out, or a request that arrived by email, use **/admin → Delete** on their row.
+Users close their own account at **/account → Delete account**, typing their email to confirm. For someone locked out, or a request that arrived by email, use **/admin → Delete** on their row.
 
 Both run `Fountain.Accounts.Deletion.delete_user/2`, in this order:
 

--- a/apps/fountain/test/fountain_web/live/account_deletion_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/account_deletion_live_test.exs
@@ -27,11 +27,11 @@ defmodule FountainWeb.AccountDeletionLiveTest do
     :ok
   end
 
-  describe "self-serve, on /account/billing" do
+  describe "self-serve, on /account" do
     test "typing the account's email deletes it", %{conn: conn} do
       user = insert_verified_user()
 
-      {:ok, lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      {:ok, lv, html} = live(login_user(conn, user), ~p"/account")
       assert html =~ "Delete account"
       # The export nudge sits in the danger zone and anchors to the export
       # section above it (#450).
@@ -55,7 +55,7 @@ defmodule FountainWeb.AccountDeletionLiveTest do
     test "the wrong email deletes nothing", %{conn: conn} do
       user = insert_verified_user()
 
-      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account")
 
       html = render_submit(lv, "delete_account", %{"email" => "someone-else@example.com"})
 
@@ -66,7 +66,7 @@ defmodule FountainWeb.AccountDeletionLiveTest do
     test "an empty confirmation deletes nothing", %{conn: conn} do
       user = insert_verified_user()
 
-      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account")
       render_submit(lv, "delete_account", %{"email" => ""})
 
       assert Repo.get(User, user.id)
@@ -82,7 +82,7 @@ defmodule FountainWeb.AccountDeletionLiveTest do
 
       stub(Stripe.Subscription, :list, fn _ -> {:error, :down} end)
 
-      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/account")
 
       html =
         with_log(fn -> render_submit(lv, "delete_account", %{"email" => user.email}) end)

--- a/apps/fountain/test/fountain_web/live/account_export_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/account_export_live_test.exs
@@ -17,7 +17,7 @@ defmodule FountainWeb.AccountExportLiveTest do
   test "the card states that secret values are excluded", %{conn: conn} do
     user = insert_verified_user()
 
-    {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+    {:ok, _lv, html} = live(login_user(conn, user), ~p"/account")
 
     assert html =~ "Export your data"
     assert html =~ "secret values are deliberately excluded"
@@ -27,7 +27,7 @@ defmodule FountainWeb.AccountExportLiveTest do
   test "requesting an export enqueues the job and shows pending status", %{conn: conn} do
     user = insert_verified_user()
 
-    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account")
 
     html = render_click(lv, "request_export")
     assert html =~ "Export started"
@@ -41,7 +41,7 @@ defmodule FountainWeb.AccountExportLiveTest do
   test "a second request within the hour is refused", %{conn: conn} do
     user = insert_verified_user()
 
-    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account")
 
     render_click(lv, "request_export")
     html = render_click(lv, "request_export")
@@ -55,7 +55,7 @@ defmodule FountainWeb.AccountExportLiveTest do
     {:ok, export} = Exports.request_export(user)
     :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
 
-    {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+    {:ok, _lv, html} = live(login_user(conn, user), ~p"/account")
 
     assert html =~ "Export ready"
     assert html =~ ~p"/account/exports/#{export.id}/download"
@@ -65,7 +65,7 @@ defmodule FountainWeb.AccountExportLiveTest do
   test "the completion broadcast flips pending to ready without a reload", %{conn: conn} do
     user = insert_verified_user()
 
-    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/billing")
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account")
     assert render_click(lv, "request_export") =~ "generating"
 
     [export] = Repo.all(Export)

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -5,40 +5,34 @@ defmodule FountainWeb.Live.BillingLive do
 
   Accessible to all authenticated users regardless of subscription status
   (including `past_due` and `canceled`) so they can update payment details.
+
+  Purely billing since #479: data export and account deletion live on the
+  core `/account` page. On a billing-disabled instance this page does not
+  exist — old bookmarks redirect to `/account`.
   """
 
   use FountainWeb, :live_view
 
-  alias Fountain.Accounts.Deletion
   alias Fountain.Billing
-  alias Fountain.Exports
 
   @impl true
   def mount(_params, _session, socket) do
-    socket = FountainWeb.Audited.put_client_ip(socket)
-    user = socket.assigns.current_user
-    {period_start, period_end} = current_month_range()
-    usage = Billing.usage_summary(user.id, period_start, period_end)
+    if Billing.enabled?() do
+      user = socket.assigns.current_user
+      {period_start, period_end} = current_month_range()
+      usage = Billing.usage_summary(user.id, period_start, period_end)
 
-    if connected?(socket) do
-      Phoenix.PubSub.subscribe(Fountain.PubSub, Exports.topic(user.id))
+      {:ok,
+       assign(socket,
+         page_title: "Billing",
+         usage: usage,
+         period_start: period_start,
+         period_end: period_end,
+         stripe_url_loading: false
+       )}
+    else
+      {:ok, redirect(socket, to: ~p"/account")}
     end
-
-    {:ok,
-     assign(socket,
-       page_title: "Billing",
-       usage: usage,
-       period_start: period_start,
-       period_end: period_end,
-       stripe_url_loading: false,
-       delete_confirmation: "",
-       deleting: false,
-       export: Exports.latest_export(user.id),
-       # On a billing-disabled instance the subscription card is noise: the
-       # status is meaningless with the gate off, and the Upgrade button can
-       # only ever flash "Unable to reach Stripe" (#335).
-       billing_enabled: Billing.enabled?()
-     )}
   end
 
   @impl true
@@ -87,94 +81,13 @@ defmodule FountainWeb.Live.BillingLive do
   end
 
   @impl true
-  def handle_event("request_export", _params, socket) do
-    user = socket.assigns.current_user
-
-    case Exports.request_export(user, actor: "self", request_ip: socket.assigns[:client_ip]) do
-      {:ok, export} ->
-        {:noreply,
-         socket
-         |> assign(:export, export)
-         |> put_flash(:info, "Export started — the download will appear here when it is ready.")}
-
-      {:error, {:rate_limited, retry_after}} ->
-        minutes = max(div(retry_after + 59, 60), 1)
-
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           "You can request one export per hour. Try again in about #{minutes} minute(s)."
-         )}
-
-      {:error, _reason} ->
-        {:noreply, put_flash(socket, :error, "Could not start the export. Please try again.")}
-    end
-  end
-
-  @impl true
-  def handle_event("confirm_delete_input", %{"email" => email}, socket) do
-    {:noreply, assign(socket, :delete_confirmation, email)}
-  end
-
-  # Typing the account's own email is the confirmation. It is not a security
-  # control — the session already proves who this is — it is a speed bump, so
-  # the irreversible button cannot be hit by reflex.
-  @impl true
-  def handle_event("delete_account", %{"email" => email}, socket) do
-    user = socket.assigns.current_user
-
-    cond do
-      email != user.email ->
-        {:noreply, put_flash(socket, :error, "Type your email address exactly to confirm.")}
-
-      socket.assigns.deleting ->
-        {:noreply, socket}
-
-      true ->
-        socket = assign(socket, :deleting, true)
-
-        case Deletion.delete_user(user,
-               actor: "self",
-               request_ip: socket.assigns[:client_ip]
-             ) do
-          {:ok, _summary} ->
-            # Straight out through the controller so the session is dropped;
-            # a LiveView cannot clear the session cookie itself.
-            {:noreply, redirect(socket, to: ~p"/auth/logout?deleted=1")}
-
-          {:error, {:stripe, _reason}} ->
-            {:noreply,
-             socket
-             |> assign(:deleting, false)
-             |> put_flash(
-               :error,
-               "Your subscription could not be cancelled, so nothing was deleted. " <>
-                 "Please try again, or contact support if it keeps failing."
-             )}
-
-          {:error, _reason} ->
-            {:noreply,
-             socket
-             |> assign(:deleting, false)
-             |> put_flash(:error, "Account deletion failed. Nothing was deleted.")}
-        end
-    end
-  end
-
-  @impl true
-  def handle_info({:export_updated, _user_id}, socket) do
-    {:noreply, assign(socket, :export, Exports.latest_export(socket.assigns.current_user.id))}
-  end
-
-  @impl true
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl space-y-8 px-4 py-8">
       <h1 class="text-2xl font-semibold">Billing</h1>
 
       <%!-- past_due banner --%>
-      <%= if @billing_enabled and @current_user.subscription_status == "past_due" do %>
+      <%= if @current_user.subscription_status == "past_due" do %>
         <div class="rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800" role="alert">
           Your subscription requires attention. Update your payment method to
           continue starting conversations.
@@ -183,7 +96,7 @@ defmodule FountainWeb.Live.BillingLive do
 
       <%!-- cancel-at-period-end notice: canceled in the portal, still inside
            the paid period. Access continues until the period ends. --%>
-      <%= if @billing_enabled and canceling_at_period_end?(@current_user) do %>
+      <%= if canceling_at_period_end?(@current_user) do %>
         <div
           class="rounded border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
           role="alert"
@@ -194,19 +107,8 @@ defmodule FountainWeb.Live.BillingLive do
         </div>
       <% end %>
 
-      <%!-- Billing disabled: no status theater, no button that can only fail --%>
-      <%= if not @billing_enabled do %>
-        <div class="rounded-lg border bg-white p-6 shadow-sm">
-          <h2 class="mb-2 text-lg font-medium">Subscription</h2>
-          <p class="text-sm text-gray-600">
-            Billing is disabled on this instance. All features are available
-            without a subscription.
-          </p>
-        </div>
-      <% end %>
-
       <%!-- Subscription status card --%>
-      <div :if={@billing_enabled} class="rounded-lg border bg-white p-6 shadow-sm">
+      <div class="rounded-lg border bg-white p-6 shadow-sm">
         <h2 class="mb-4 text-lg font-medium">Subscription</h2>
         <dl class="space-y-3">
           <div class="flex items-center justify-between">
@@ -313,120 +215,11 @@ defmodule FountainWeb.Live.BillingLive do
           </div>
         </dl>
       </div>
-
-      <%!-- Data export --%>
-      <div class="rounded-lg border bg-white p-6 shadow-sm">
-        <h2 class="mb-1 text-lg font-medium" id="export">Export your data</h2>
-        <p class="mb-2 text-sm text-gray-600">
-          Download a single JSON file containing your agents, environments, vaults,
-          conversations with their full log output, and your audit trail.
-        </p>
-        <p class="mb-4 text-sm text-gray-600">
-          Environment and vault <strong>secret values are deliberately excluded</strong>
-          — only secret names are listed. Secrets were write-only on the way in and
-          stay that way on the way out.
-        </p>
-
-        <%= if @export do %>
-          <div class="mb-4 rounded-md bg-gray-50 p-4 text-sm" id="export-status">
-            <%= case export_state(@export) do %>
-              <% :pending -> %>
-                <span class="text-gray-700">
-                  Export requested <%= Calendar.strftime(@export.inserted_at, "%Y-%m-%d %H:%M UTC") %>
-                  — generating&hellip; The download will appear here when it is ready.
-                </span>
-              <% :ready -> %>
-                <div class="flex items-center justify-between gap-4">
-                  <span class="text-gray-700">
-                    Export ready (<%= format_bytes(@export.byte_size) %>) — link expires
-                    <%= Calendar.strftime(@export.expires_at, "%Y-%m-%d %H:%M UTC") %>.
-                  </span>
-                  <a
-                    href={~p"/account/exports/#{@export.id}/download"}
-                    class="shrink-0 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700"
-                  >
-                    Download
-                  </a>
-                </div>
-              <% :expired -> %>
-                <span class="text-gray-500">
-                  Your last export has expired. Request a new one to download your data.
-                </span>
-              <% :failed -> %>
-                <span class="text-red-700">
-                  The last export failed. Please request a new one; contact support if it
-                  keeps failing.
-                </span>
-            <% end %>
-          </div>
-        <% end %>
-
-        <button
-          phx-click="request_export"
-          class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-        >
-          Request export
-        </button>
-        <p class="mt-2 text-xs text-gray-400">
-          One export per hour. Downloads expire after <%= Exports.ttl_hours() %> hours.
-        </p>
-      </div>
-
-      <%!-- Danger zone --%>
-      <div class="rounded-lg border border-red-200 bg-white p-6 shadow-sm">
-        <h2 class="mb-1 text-lg font-medium text-red-700">Delete account</h2>
-        <p class="mb-4 text-sm text-gray-600">
-          Cancels your subscription, destroys every running sandbox, and permanently
-          deletes your agents, environments, vaults, conversations and stored secrets.
-          Secrets are encrypted with a key held only for your account; deleting the
-          account destroys that key, so they cannot be recovered afterwards by anyone.
-          <strong>This cannot be undone.</strong>
-        </p>
-        <p class="mb-4 text-sm text-gray-600" id="delete-export-nudge">
-          Want a copy of your data first?
-          <a href="#export" class="underline">Request an export above</a>
-          before deleting — nothing can be recovered afterwards.
-        </p>
-
-        <form phx-submit="delete_account" class="space-y-3">
-          <label class="block text-sm text-gray-700">
-            Type <span class="font-mono font-semibold"><%= @current_user.email %></span> to confirm
-            <input
-              type="text"
-              name="email"
-              autocomplete="off"
-              value={@delete_confirmation}
-              phx-change="confirm_delete_input"
-              class="mt-1 block w-full rounded border-gray-300 text-sm shadow-sm"
-            />
-          </label>
-
-          <button
-            type="submit"
-            disabled={@delete_confirmation != @current_user.email or @deleting}
-            class="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-300"
-          >
-            <%= if @deleting, do: "Deleting…", else: "Delete my account" %>
-          </button>
-        </form>
-      </div>
     </div>
     """
   end
 
   # ─── Private helpers ───────────────────────────────────────────────────────────
-
-  defp export_state(%{status: "pending"}), do: :pending
-  defp export_state(%{status: "failed"}), do: :failed
-
-  defp export_state(%{status: "completed"} = export) do
-    if Exports.expired?(export), do: :expired, else: :ready
-  end
-
-  defp format_bytes(nil), do: "unknown size"
-  defp format_bytes(n) when n < 1024, do: "#{n} B"
-  defp format_bytes(n) when n < 1024 * 1024, do: "#{Float.round(n / 1024, 1)} KB"
-  defp format_bytes(n), do: "#{Float.round(n / (1024 * 1024), 1)} MB"
 
   defp current_month_range do
     now = DateTime.utc_now()

--- a/ee/test/fountain_web/live/billing_live_test.exs
+++ b/ee/test/fountain_web/live/billing_live_test.exs
@@ -46,9 +46,10 @@ defmodule FountainWeb.BillingLiveTest do
     user
   end
 
-  describe "billing disabled (#335)" do
-    # A self-hosted instance shows a trial countdown and an Upgrade button
-    # whose only possible outcome is "Unable to reach Stripe".
+  describe "billing disabled (#335, #479)" do
+    # A self-hosted instance must never see this page — not even a degraded
+    # version of it. Old bookmarks land on the core account page, which owns
+    # export and deletion since #479.
 
     defp with_billing_disabled(fun) do
       previous = Application.get_env(:fountain, :billing_enabled)
@@ -61,28 +62,22 @@ defmodule FountainWeb.BillingLiveTest do
       end
     end
 
-    test "no upgrade affordance, no trial countdown, a plain explanation", %{conn: conn} do
+    test "the page redirects to /account", %{conn: conn} do
       user = insert_verified_user()
 
       with_billing_disabled(fn ->
-        {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
-
-        assert html =~ "Billing is disabled on this instance"
-        refute html =~ "Upgrade"
-        refute html =~ "Manage Subscription"
-        refute html =~ "Trial"
+        assert {:error, {:redirect, %{to: "/account"}}} =
+                 live(login_user(conn, user), ~p"/account/billing")
       end)
     end
 
-    test "usage and the danger zone are still there", %{conn: conn} do
+    test "with billing enabled the page renders instead of redirecting", %{conn: conn} do
       user = insert_verified_user()
 
-      with_billing_disabled(fn ->
-        {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
 
-        assert html =~ "Usage This Month"
-        assert html =~ "Delete account"
-      end)
+      assert html =~ "Subscription"
+      assert html =~ "Usage This Month"
     end
   end
 


### PR DESCRIPTION
Part of the community-defaults track (#482). A community instance should never *see* billing — but `/account/billing` couldn't simply be hidden because it also hosted account export and deletion. This splits them.

## What changed

- **New core `FountainWeb.Live.AccountLive` at `/account`** — data export and account deletion, moved verbatim from BillingLive. The handlers already delegated to core `Fountain.Exports` / `Fountain.Accounts.Deletion`, so this is a mechanical extraction plus a route.
- **BillingLive is purely billing** (stays in `ee/`). When `Billing.enabled?()` is false it redirects to `/account` instead of rendering the degraded "billing is disabled" page — old bookmarks keep working, and a community instance never renders a billing surface.
- **Sidebar**: unconditional **Account** link; **Billing** renders only when billing is enabled. `nav_link` gained an `exact` attr so the `/account` link doesn't double-highlight on `/account/billing` / `/account/security`.
- **Tests moved with the UI**: `account_export_live_test.exs` / `account_deletion_live_test.exs` now mount `/account`; the ee BillingLive test's billing-disabled block asserts the redirect instead of the degraded page.
- Runbook: account deletion path is now `/account → Delete account`.

## Verified

- 402 `upgrade_url: "/account/billing"` contract (fallback + conversation controllers, CLI `api_test.go`) is untouched — it only fires when billing is *enabled*, where the page still exists. Same for the `require_active_subscription` hook redirect and the billing lifecycle emails.
- Full suite: 1,966 tests, 0 failures.

Completes the "BillingLive export/deletion extraction" future-work item in decisions/0010.

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)