### PR TITLE
self-host: don't stamp trials on billing-disabled instances (#480)

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -679,8 +679,19 @@ defmodule Fountain.Accounts do
   # exactly how 159 production accounts got there. Stripe's `trial_end`
   # overwrites this with the authoritative value as soon as the subscription
   # exists; until then the local date is a floor, not a guess nobody checks.
+  #
+  # None of which applies when billing is disabled (#480): there is no trial to
+  # expire and no status to display, and stamping one anyway is exactly the
+  # residue a community operator then sees in the admin list, /api/auth/me and
+  # exports. Both fields stay nil. Enabling billing later leaves these accounts
+  # failing closed at the gate until the documented backfill runs —
+  # Fountain.Release.expire_legacy_trials/1 starts their trial clocks.
   defp put_trial_end(changeset) do
-    Ecto.Changeset.put_change(changeset, :trial_ends_at, Fountain.Billing.trial_end_from_now())
+    if Fountain.Billing.enabled?() do
+      Ecto.Changeset.put_change(changeset, :trial_ends_at, Fountain.Billing.trial_end_from_now())
+    else
+      Ecto.Changeset.put_change(changeset, :subscription_status, nil)
+    end
   end
 
   defp create_user_data_key(user_id) do

--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -112,20 +112,29 @@ defmodule Fountain.Release do
   end
 
   @doc """
-  Gives existing trialing accounts a trial end date.
+  Gives accounts without a trial clock a status and a trial end date.
 
-  159 production accounts are `trialing` with `trial_ends_at` set to nil, some
-  since 2026-05-10, because a trial end was only ever recorded for users who got
-  as far as Stripe customer creation. The gate treats nil as "no expiry", so
-  those accounts stay active until this is run.
+  Two cohorts land here, both of which the gate would otherwise handle badly
+  after billing is (re-)enabled:
 
-  That is deliberate. Cutting off people who have been using the product free
-  for months is a business decision with a support cost, not something a deploy
-  should do silently at 3am. Run it when you have decided.
+  - **Legacy trialing accounts** — `trialing` with `trial_ends_at` nil. 159
+    production accounts were in this state, some since 2026-05-10, because a
+    trial end was only ever recorded for users who got as far as Stripe
+    customer creation. The gate treats nil as "no expiry" for pre-cutoff
+    accounts, so they stay active until this is run.
+  - **Accounts registered while billing was disabled** — `subscription_status`
+    nil, no trial end (#480). Enabling billing on such an instance leaves them
+    failing *closed* at the gate; this task is the documented way to start
+    their trials.
 
-  (Queried 2026-08-02: the cohort turned out to be one internal test account
-  plus 158 signups that never verified their email and so have never been able
-  to log in — nobody real loses access when this runs.)
+  Not running it automatically is deliberate. Cutting off (or starting a paid
+  clock for) people who have been using the product free is a business decision
+  with a support cost, not something a deploy should do silently at 3am. Run it
+  when you have decided.
+
+  (Queried 2026-08-02: the legacy cohort turned out to be one internal test
+  account plus 158 signups that never verified their email and so have never
+  been able to log in — nobody real loses access when this runs.)
 
       # See who would be affected, change nothing:
       bin/fountain_server eval 'Fountain.Release.expire_legacy_trials(dry_run: true)'
@@ -153,16 +162,22 @@ defmodule Fountain.Release do
 
     query =
       from u in Fountain.Accounts.User,
-        where: u.subscription_status == "trialing" and is_nil(u.trial_ends_at)
+        where:
+          (u.subscription_status == "trialing" and is_nil(u.trial_ends_at)) or
+            is_nil(u.subscription_status)
 
     count = Fountain.Repo.aggregate(query, :count)
 
     if dry_run? do
-      IO.puts("#{count} trialing account(s) have no trial end.")
+      IO.puts("#{count} account(s) have no trial clock (trialing/nil or nil status).")
       IO.puts("Running without dry_run: would set trial_ends_at to #{ends_at} (#{days} days).")
       {:ok, count}
     else
-      {updated, _} = Fountain.Repo.update_all(query, set: [trial_ends_at: ends_at])
+      {updated, _} =
+        Fountain.Repo.update_all(query,
+          set: [subscription_status: "trialing", trial_ends_at: ends_at]
+        )
+
       IO.puts("Set trial_ends_at to #{ends_at} on #{updated} account(s).")
       {:ok, updated}
     end

--- a/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
@@ -15,7 +15,10 @@ defmodule FountainWeb.AuthMeController do
       id: user.id,
       email: user.email,
       role: user.role,
-      subscription_status: user.subscription_status
+      # The key stays for JSON-shape compatibility, but on a billing-disabled
+      # instance the value is null even for accounts that carry pre-disable
+      # residue — there is no subscription for the status to be about (#480).
+      subscription_status: if(Fountain.Billing.enabled?(), do: user.subscription_status)
     })
   end
 end

--- a/apps/fountain/priv/repo/migrations/20260804090000_subscription_status_nullable.exs
+++ b/apps/fountain/priv/repo/migrations/20260804090000_subscription_status_nullable.exs
@@ -1,0 +1,22 @@
+defmodule Fountain.Repo.Migrations.SubscriptionStatusNullable do
+  use Ecto.Migration
+
+  @moduledoc """
+  On a billing-disabled instance registration stamps neither a trial end nor a
+  subscription status (#480) — nil means "billing has never applied to this
+  account" and keeps trial residue out of the admin list, /api/auth/me and
+  GDPR exports. The column keeps its 'trialing' default for raw inserts; only
+  the NOT NULL constraint goes.
+  """
+
+  def up do
+    execute "ALTER TABLE users ALTER COLUMN subscription_status DROP NOT NULL"
+  end
+
+  def down do
+    # Restore the constraint the way it was created; rows minted while billing
+    # was disabled must be given a status first or this fails — which is
+    # correct, silently inventing one would misstate what those accounts are.
+    execute "ALTER TABLE users ALTER COLUMN subscription_status SET NOT NULL"
+  end
+end

--- a/apps/fountain/test/fountain/release_test.exs
+++ b/apps/fountain/test/fountain/release_test.exs
@@ -49,6 +49,24 @@ defmodule Fountain.ReleaseTest do
       assert Repo.reload!(already_dated).trial_ends_at == ~U[2027-01-01 00:00:00Z]
       assert is_nil(Repo.reload!(active).trial_ends_at)
     end
+
+    test "starts a trial for accounts registered while billing was disabled (#480)" do
+      # Those accounts have no status at all; after enabling billing they fail
+      # closed at the gate until this runs.
+      community = put_billing(insert_user(), nil, nil)
+      active = put_billing(insert_user(), "active", nil)
+
+      capture_io(fn ->
+        assert {:ok, count} = Release.expire_legacy_trials(days: 14)
+        assert count >= 1
+      end)
+
+      reloaded = Repo.reload!(community)
+      assert reloaded.subscription_status == "trialing"
+      assert %DateTime{} = reloaded.trial_ends_at
+
+      assert Repo.reload!(active).subscription_status == "active"
+    end
   end
 
   describe "verify_email/1" do

--- a/apps/fountain/test/fountain/self_host_switches_test.exs
+++ b/apps/fountain/test/fountain/self_host_switches_test.exs
@@ -193,6 +193,84 @@ defmodule Fountain.SelfHostSwitchesTest do
     end
   end
 
+  describe "BILLING_ENABLED=false leaves no trial residue (#480)" do
+    # Registration used to stamp a 14-day trial unconditionally (the
+    # free-forever incident made stamp-always the right hosted behavior), so
+    # every community account read as "trialing, ends <date>" in the admin
+    # list, /api/auth/me and GDPR exports — a trial nobody is on.
+
+    test "registration stamps neither a status nor a trial end" do
+      with_env([billing_enabled: false], fn ->
+        {:ok, user} =
+          Accounts.register_user(%{
+            "email" => "community-#{System.unique_integer([:positive])}@example.com",
+            "password" => "password123"
+          })
+
+        assert is_nil(user.subscription_status)
+        assert is_nil(user.trial_ends_at)
+      end)
+    end
+
+    test "OAuth signup stamps neither" do
+      with_env([billing_enabled: false], fn ->
+        {:ok, user, :new} =
+          Accounts.upsert_oauth_user(
+            "github",
+            "gh-#{System.unique_integer([:positive])}",
+            %{"email" => "oauth-community-#{System.unique_integer([:positive])}@example.com"}
+          )
+
+        assert is_nil(user.subscription_status)
+        assert is_nil(user.trial_ends_at)
+      end)
+    end
+
+    test "with billing enabled the hosted stamp-always behavior stands" do
+      # The stamp exists because 159 accounts whose Stripe call failed sat at
+      # nil forever. Disabling it must be scoped to the switch, not removed.
+      {:ok, user} =
+        Accounts.register_user(%{
+          "email" => "hosted-#{System.unique_integer([:positive])}@example.com",
+          "password" => "password123"
+        })
+
+      assert user.subscription_status == "trialing"
+      assert %DateTime{} = user.trial_ends_at
+    end
+
+    test "the gate still passes for a status-less account while disabled" do
+      with_env([billing_enabled: false], fn ->
+        {:ok, user} =
+          Accounts.register_user(%{
+            "email" => "gateless-#{System.unique_integer([:positive])}@example.com",
+            "password" => "password123"
+          })
+
+        assert :ok = Billing.check_active(user)
+      end)
+    end
+
+    test "after enabling billing a status-less account fails closed until the backfill runs" do
+      # The flip-on contract (documented in docs/self-hosting.md): accounts
+      # registered while billing was off have no trial to measure, so the gate
+      # refuses them rather than minting a silent free tier —
+      # Release.expire_legacy_trials/1 is the way to start their clocks.
+      user =
+        with_env([billing_enabled: false], fn ->
+          {:ok, user} =
+            Accounts.register_user(%{
+              "email" => "flip-on-#{System.unique_integer([:positive])}@example.com",
+              "password" => "password123"
+            })
+
+          user
+        end)
+
+      assert {:error, :subscription_required} = Billing.check_active(user)
+    end
+  end
+
   describe "BILLING_ENABLED=false silences the Stripe sync (#335)" do
     # Every signup enqueued a StripeCustomerSync that 401ed through all five
     # attempts — dead Oban jobs and error noise a self-hoster has no way to

--- a/apps/fountain/test/fountain_web/controllers/auth_me_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_me_controller_test.exs
@@ -1,5 +1,17 @@
 defmodule FountainWeb.AuthMeControllerTest do
-  use FountainWeb.ConnCase, async: true
+  # async: false for the billing-disabled tests, which flip global app env.
+  use FountainWeb.ConnCase, async: false
+
+  defp with_billing_disabled(fun) do
+    previous = Application.get_env(:fountain, :billing_enabled)
+    Application.put_env(:fountain, :billing_enabled, false)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:fountain, :billing_enabled, previous)
+    end
+  end
 
   describe "GET /api/auth/me" do
     test "returns user identity for an authenticated request", %{conn: conn} do
@@ -48,6 +60,25 @@ defmodule FountainWeb.AuthMeControllerTest do
         |> get("/api/auth/me")
 
       assert %{"role" => "admin"} = json_response(conn, 200)
+    end
+
+    test "subscription_status is null when billing is disabled — key kept for shape compat (#480)",
+         %{conn: conn} do
+      # Residue case on purpose: even an account that still carries a status
+      # from before the flag flipped must not leak it to API consumers.
+      user = insert_verified_user()
+      {_key_record, raw_key} = insert_api_key(user)
+
+      with_billing_disabled(fn ->
+        conn =
+          conn
+          |> authed_with_key(raw_key)
+          |> get("/api/auth/me")
+
+        body = json_response(conn, 200)
+        assert Map.has_key?(body, "subscription_status")
+        assert body["subscription_status"] == nil
+      end)
     end
 
     test "email in response is downcased", %{conn: conn} do

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -192,6 +192,20 @@ it is a lock with no key. Leave it off
 unless you are running Fountain commercially and have configured Stripe — the
 [Stripe integration guide](integrations/stripe.md) covers that setup.
 
+With billing disabled, accounts carry no subscription status and no trial
+clock — nothing billing-shaped appears in the UI, the admin panel, or the API.
+If you later enable billing on an existing instance, those accounts have no
+trial to measure and **fail closed** at the subscription gate. Start their
+trial clocks explicitly with the release task:
+
+```bash
+# See who would be affected, change nothing:
+bin/fountain_server eval 'Fountain.Release.expire_legacy_trials(dry_run: true)'
+
+# Mark them trialing with 14 days from now:
+bin/fountain_server eval 'Fountain.Release.expire_legacy_trials(days: 14)'
+```
+
 ## Putting it on the internet
 
 The compose file publishes port 4000 with no TLS. Terminate TLS in front of it


### PR DESCRIPTION
Part of the community-defaults track (#482). Stacked on #491 — merge that first, then retarget this to `main`.

Registration stamped a 14-day trial on every account, so a community instance showed "trialing" badges, a `trial_end` sort, `subscription_status: "trialing"` in `/api/auth/me`, and a meaningless `trial_ends_at` in GDPR exports — a trial nobody is on.

## What changed

- **`put_trial_end/1` is conditional on `Billing.enabled?()`**. Disabled instances stamp neither a trial end nor a subscription status: both stay `nil` (migration drops the column's NOT NULL; the `'trialing'` default remains for the hosted path). The hosted stamp-always behavior — the answer to the 159-account free-forever incident — is untouched.
- **`/api/auth/me`** returns `subscription_status: null` when billing is disabled, even for accounts carrying pre-disable residue. The key stays for JSON-shape compatibility; the CLI's `authMe` struct never decoded the field, so nothing breaks (`keys_decode_test.go` verified).
- **Toggle-flip semantics documented**: enabling billing on an existing instance leaves nil-status accounts **failing closed** at the gate (the `do_check_active` catch-all). `Release.expire_legacy_trials/1` now also picks up the nil-status cohort — sets `trialing` + a fresh trial end — and `docs/self-hosting.md` documents running it. This is the #258 backfill precedent, extended.
- **`record_local_trial` needed no change**: `StripeCustomerSync` is already a no-op when billing is disabled (#335), so that path can't run.
- GDPR export and admin badges follow from the data being nil (the admin *UI* cleanup is #481's job).

## Tests

- `self_host_switches_test.exs`: new describe — no residue on register/OAuth paths, hosted behavior guarded, gate passes while disabled, fails closed after flip-on.
- `release_test.exs`: nil-status cohort gets a trial; active accounts untouched.
- `auth_me_controller_test.exs`: null status with key present when disabled.
- Full suite: 1,973 tests, 0 failures. `go test ./...` green.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)