### PR TITLE
self-host: admin dashboard without billing noise when billing is disabled (#481)

### DIFF
--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -80,7 +80,15 @@ defmodule Fountain.Funnel do
     verified = Enum.filter(users, & &1.verified_at)
     onboarded = Enum.filter(users, & &1.onboarded_at)
     activated = Enum.filter(users, &Map.has_key?(first_activity, &1.id))
-    subscribed = Enum.filter(users, &(&1.subscription_status in @subscribed_statuses))
+
+    # With billing disabled there is nothing to subscribe to; statuses are nil
+    # for accounts registered that way (#480), but pre-disable residue must not
+    # count either. The stage stays in the list at 0 so the telemetry gauge
+    # keeps its shape — the admin panel hides the tile (#481).
+    subscribed =
+      if Fountain.Billing.enabled?(),
+        do: Enum.filter(users, &(&1.subscription_status in @subscribed_statuses)),
+        else: []
 
     stages = [
       %{key: :registered, count: length(registered), conversion: nil, median_hours: nil},

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -20,8 +20,9 @@ defmodule FountainWeb.AdminLive.Index do
      socket
      |> FountainWeb.Audited.put_client_ip()
      |> assign(:page_title, "Admin")
+     |> assign(:billing_enabled, Billing.enabled?())
      |> assign(:funnel, Fountain.Funnel.summary_admin())
-     |> assign(:billing_overview, Billing.overview_admin())
+     |> assign_billing_overview()
      |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
      |> assign(:admin_events, Fountain.Audit._unsafe_list_recent_admin(25))}
   end
@@ -44,9 +45,19 @@ defmodule FountainWeb.AdminLive.Index do
      socket
      |> assign_users()
      |> assign(:funnel, Fountain.Funnel.summary_admin())
-     |> assign(:billing_overview, Billing.overview_admin())
+     |> assign_billing_overview()
      |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
      |> assign(:admin_events, Fountain.Audit._unsafe_list_recent_admin(25))}
+  end
+
+  # overview_admin/0 runs real queries (MRR, status counts, webhook events);
+  # on a billing-disabled instance nothing renders them, so don't run them.
+  defp assign_billing_overview(socket) do
+    if socket.assigns.billing_enabled do
+      assign(socket, :billing_overview, Billing.overview_admin())
+    else
+      assign(socket, :billing_overview, nil)
+    end
   end
 
   @impl true
@@ -98,6 +109,14 @@ defmodule FountainWeb.AdminLive.Index do
       _ ->
         {:noreply, put_flash(socket, :error, "Limit must be a whole number of 0 or more")}
     end
+  end
+
+  # The buttons are hidden when billing is disabled, but events can still be
+  # sent by hand (#399's lesson) — and both actions talk to Stripe.
+  @impl true
+  def handle_event(event, _params, %{assigns: %{billing_enabled: false}} = socket)
+      when event in ~w(extend_trial toggle_comp) do
+    {:noreply, put_flash(socket, :error, "Billing is disabled on this instance")}
   end
 
   @impl true
@@ -463,6 +482,7 @@ defmodule FountainWeb.AdminLive.Index do
         <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
           <div
             :for={stage <- @funnel.stages}
+            :if={stage.key != :subscribed or @billing_enabled}
             class="bg-white rounded shadow border border-zinc-200 px-4 py-3"
           >
             <div class="text-xs text-zinc-500">{stage_label(stage.key)}</div>
@@ -492,7 +512,7 @@ defmodule FountainWeb.AdminLive.Index do
         </div>
       </section>
 
-      <section class="space-y-3">
+      <section :if={@billing_enabled} class="space-y-3">
         <h2 class="text-lg font-medium">Billing</h2>
         <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
           <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
@@ -569,7 +589,11 @@ defmodule FountainWeb.AdminLive.Index do
               autocomplete="off"
               class="w-48 rounded border border-zinc-200 px-2 py-1 text-xs"
             />
-            <select name="status" class="rounded border border-zinc-200 px-1 py-1 text-xs">
+            <select
+              :if={@billing_enabled}
+              name="status"
+              class="rounded border border-zinc-200 px-1 py-1 text-xs"
+            >
               <option value="">any status</option>
               <option :for={s <- ~w(trialing active past_due canceled comped)} value={s} selected={@filters.status == s}>
                 {s}
@@ -594,7 +618,7 @@ defmodule FountainWeb.AdminLive.Index do
                 <.sort_header label="Email" col="email" filters={@filters} />
               </th>
               <th class="px-4 py-2">Role</th>
-              <th class="px-4 py-2">
+              <th :if={@billing_enabled} class="px-4 py-2">
                 <.sort_header label="Billing" col="trial_end" filters={@filters} />
               </th>
               <th class="px-4 py-2" title="Last 30 days: conversations / turns / sandbox minutes">
@@ -613,7 +637,10 @@ defmodule FountainWeb.AdminLive.Index do
           </thead>
           <tbody>
             <tr :if={@users == []}>
-              <td colspan="9" class="px-4 py-6 text-center text-sm text-zinc-500">
+              <td
+                colspan={if @billing_enabled, do: "9", else: "8"}
+                class="px-4 py-6 text-center text-sm text-zinc-500"
+              >
                 No users match.
               </td>
             </tr>
@@ -647,7 +674,7 @@ defmodule FountainWeb.AdminLive.Index do
                   {u.role}
                 </span>
               </td>
-              <td class="px-4 py-2">
+              <td :if={@billing_enabled} class="px-4 py-2">
                 <div class="space-y-1">
                   <div class="flex items-center gap-2">
                     <span class={[

--- a/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
@@ -40,6 +40,7 @@ defmodule FountainWeb.AdminLive.UserDetail do
         {:ok,
          socket
          |> assign(:page_title, "Admin · #{user.email}")
+         |> assign(:billing_enabled, Fountain.Billing.enabled?())
          |> load_user(user)}
     end
   end
@@ -89,10 +90,13 @@ defmodule FountainWeb.AdminLive.UserDetail do
           ]}>
             {@user.role}
           </span>
-          <span class={[
-            "inline-flex items-center rounded px-1.5 py-0.5 font-medium border",
-            subscription_status_color(@user.subscription_status)
-          ]}>
+          <span
+            :if={@billing_enabled}
+            class={[
+              "inline-flex items-center rounded px-1.5 py-0.5 font-medium border",
+              subscription_status_color(@user.subscription_status)
+            ]}
+          >
             {@user.subscription_status}
           </span>
           <span
@@ -108,7 +112,7 @@ defmodule FountainWeb.AdminLive.UserDetail do
             suspended since {format_ts(@user.suspended_at)}
           </span>
           <a
-            :if={@user.stripe_customer_id not in [nil, ""]}
+            :if={@billing_enabled and @user.stripe_customer_id not in [nil, ""]}
             href={"https://dashboard.stripe.com/customers/#{@user.stripe_customer_id}"}
             target="_blank"
             rel="noopener"
@@ -128,7 +132,7 @@ defmodule FountainWeb.AdminLive.UserDetail do
             last active {if @last_activity_at, do: format_date(@last_activity_at), else: "—"}
           </div>
         </div>
-        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+        <div :if={@billing_enabled} class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
           <div class="text-xs text-zinc-500">Trial / period</div>
           <div class="text-sm font-medium">
             {cond do
@@ -144,6 +148,15 @@ defmodule FountainWeb.AdminLive.UserDetail do
           </div>
           <div class="text-xs text-zinc-500">
             onboarding {@user.onboarding_state}
+          </div>
+        </div>
+        <div :if={not @billing_enabled} class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Onboarding</div>
+          <div class="text-sm font-medium">{@user.onboarding_state}</div>
+          <div class="text-xs text-zinc-500">
+            {if @user.onboarding_completed_at,
+              do: "completed #{format_date(@user.onboarding_completed_at)}",
+              else: "not completed"}
           </div>
         </div>
         <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">

--- a/apps/fountain/test/fountain_web/live/admin_billing_disabled_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_billing_disabled_test.exs
@@ -1,0 +1,180 @@
+defmodule FountainWeb.AdminBillingDisabledTest do
+  @moduledoc """
+  The admin panel on a billing-disabled instance (#481): no billing tiles,
+  filters, sorts or Stripe actions — while the user-management half (verified
+  filter, suspension, deletion, sandbox limits) stays fully present.
+
+  async: false because these flip the global :billing_enabled app env, the
+  same pattern as `Fountain.SelfHostSwitchesTest`.
+  """
+
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Accounts
+
+  defp insert_admin(overrides \\ %{}) do
+    user = insert_verified_user(overrides)
+    {:ok, admin} = Accounts.update_user_role(user, "admin")
+    admin
+  end
+
+  defp with_billing_disabled(fun) do
+    previous = Application.get_env(:fountain, :billing_enabled)
+    Application.put_env(:fountain, :billing_enabled, false)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:fountain, :billing_enabled, previous)
+    end
+  end
+
+  describe "/admin" do
+    test "renders no billing tiles, filters, sorts or actions", %{conn: conn} do
+      admin = insert_admin()
+      insert_verified_user()
+
+      with_billing_disabled(fn ->
+        {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin")
+
+        refute html =~ "MRR"
+        refute html =~ "Trials ending in 7 days"
+        refute html =~ "Conversions this month"
+        refute html =~ "Recent webhook events"
+        # Funnel keeps its four real stages; the subscribed tile is noise here.
+        refute html =~ "Subscribed"
+        # No subscription-status filter, no trial_end sort (the Billing column
+        # header carries it), no Stripe-backed row actions.
+        refute html =~ ~s(name="status")
+        refute html =~ "sort=trial_end"
+        refute html =~ ~s(phx-submit="extend_trial")
+        refute html =~ ~s(phx-click="toggle_comp")
+        refute html =~ "dashboard.stripe.com"
+      end)
+    end
+
+    test "user management is fully present", %{conn: conn} do
+      admin = insert_admin()
+      other = insert_verified_user()
+
+      with_billing_disabled(fn ->
+        {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin")
+
+        assert html =~ other.email
+        assert html =~ ~s(name="verified")
+        assert html =~ ~s(phx-click="toggle_suspend")
+        assert html =~ ~s(phx-click="delete_user")
+        assert html =~ ~s(phx-submit="set_sandbox_limit")
+        assert html =~ "Registered"
+        assert html =~ "Activated"
+      end)
+    end
+
+    test "hand-sent extend_trial and toggle_comp events are refused before Stripe",
+         %{conn: conn} do
+      # The buttons are hidden, but an event can still be sent by hand (#399's
+      # lesson) — and both talk to Stripe, which this instance does not have.
+      admin = insert_admin()
+      target = insert_verified_user()
+
+      with_billing_disabled(fn ->
+        {:ok, lv, _html} = live(login_user(conn, admin), ~p"/admin")
+
+        html = render_submit(lv, "extend_trial", %{"user_id" => target.id, "days" => "14"})
+        assert html =~ "Billing is disabled on this instance"
+
+        html = render_click(lv, "toggle_comp", %{"id" => target.id})
+        assert html =~ "Billing is disabled on this instance"
+      end)
+    end
+
+    test "with billing enabled the billing surface is unchanged", %{conn: conn} do
+      admin = insert_admin()
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin")
+
+      assert html =~ "MRR"
+      assert html =~ "Subscribed"
+      assert html =~ ~s(name="status")
+      assert html =~ ~s(phx-submit="extend_trial")
+    end
+  end
+
+  describe "/admin/users/:id" do
+    test "shows no subscription badge, trial tile or Stripe link", %{conn: conn} do
+      admin = insert_admin()
+
+      # Residue on purpose: an account that kept billing fields from before
+      # the flag flipped must still render clean.
+      user = insert_verified_user()
+
+      {:ok, user} =
+        user
+        |> Accounts.User.billing_changeset(%{
+          subscription_status: "trialing",
+          stripe_customer_id: "cus_residue"
+        })
+        |> Fountain.Repo.update()
+
+      with_billing_disabled(fn ->
+        {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/users/#{user.id}")
+
+        refute html =~ "trialing"
+        refute html =~ "Trial / period"
+        refute html =~ "dashboard.stripe.com"
+        assert html =~ "Onboarding"
+        assert html =~ user.email
+      end)
+    end
+  end
+
+  describe "funnel" do
+    test "subscribed stage reports 0 even for residue statuses" do
+      user = insert_verified_user()
+
+      {:ok, _} =
+        user
+        |> Accounts.User.billing_changeset(%{subscription_status: "active"})
+        |> Fountain.Repo.update()
+
+      with_billing_disabled(fn ->
+        summary = Fountain.Funnel.summary_admin()
+        subscribed = Enum.find(summary.stages, &(&1.key == :subscribed))
+
+        # The stage stays in the list (the telemetry gauge keeps its shape);
+        # only the count is pinned to zero.
+        assert subscribed.count == 0
+      end)
+    end
+
+    test "telemetry emits subscribed as 0" do
+      ref = make_ref()
+      test = self()
+
+      :telemetry.attach(
+        ref,
+        [:fountain, :funnel],
+        fn _ev, measurements, _meta, _ -> send(test, {:funnel, measurements}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(ref) end)
+
+      user = insert_verified_user()
+
+      {:ok, _} =
+        user
+        |> Accounts.User.billing_changeset(%{subscription_status: "active"})
+        |> Fountain.Repo.update()
+
+      with_billing_disabled(fn ->
+        assert :ok = Fountain.Funnel.emit_telemetry()
+        assert_receive {:funnel, measurements}
+        assert measurements.subscribed == 0
+        assert measurements.registered >= 1
+      end)
+    end
+  end
+end


### PR DESCRIPTION
Part of the community-defaults track (#482). Stacked on #493 (which stacks on #491) — merge in order, retargeting as each lands.

`AdminLive.Index` assigned `Billing.overview_admin()` unconditionally and rendered MRR tiles, trial filters/sorts, and comp / extend-trial actions — all dead controls on a community instance.

## What changed

- **`AdminLive.Index`**: when `Billing.enabled?()` is false, `overview_admin/0` is not called (it runs real queries — MRR, status counts, webhook events) and the Billing section, subscription-status filter, `trial_end` sort (the Billing column carries it), and comp/extend-trial buttons don't render. Hand-sent `extend_trial` / `toggle_comp` events are refused with a flash before reaching Stripe — #399's stale-socket lesson applied.
- **`AdminLive.UserDetail`**: subscription badge, Trial/period tile and the Stripe dashboard deep-link are hidden — including for accounts carrying pre-disable residue. An Onboarding tile keeps that (core) info visible.
- **`Funnel`**: the `subscribed` stage is pinned to 0 when billing is disabled rather than counting residue statuses. The stage stays in `summary_admin/0`'s list so `emit_telemetry/0` keeps the gauge shape (`fountain.funnel.subscribed` = 0); the admin panel drops the tile.
- **User management untouched**: verified filter, suspension, deletion, sandbox limits all render and work exactly as before (asserted in the new tests).

## Tests

- New `admin_billing_disabled_test.exs` (async: false, the `self_host_switches_test` env-flip pattern): no billing tiles/filters/actions, user management fully present, refused hand-sent Stripe events, clean user-detail render for residue accounts, funnel + telemetry report subscribed 0, and a billing-enabled control test pinning the hosted surface.
- Full suite: 1,980 tests, 0 failures; `credo --strict` clean.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)