### PR TITLE
config: require PUBLIC_URL in prod and EMAIL_FROM when mail is on

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -49,7 +49,8 @@ FOUNTAIN_IMAGE_TAG=v0.4.1
 # SMTP_PORT=587
 # SMTP_USERNAME=
 # SMTP_PASSWORD=
-# EMAIL_FROM=fountain@example.com
+# EMAIL_FROM=fountain@example.com   # required with real mail: an address on
+                                     # a domain your provider is verified for
 
 # The subscription gate. Off by default — it exists for the hosted service
 # and is a lock with no key on your own instance. Set true (with Stripe

--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,9 @@ RESEND_API_KEY=
 # delivered, so a forgotten password is unrecoverable in this mode.
 # EMAIL_DELIVERY=none
 
-EMAIL_FROM=noreply@updates.inevitable.fyi
+# Required with a real delivery provider (options 1–2): an address on a
+# domain your provider is verified for. Prod refuses to boot without it.
+EMAIL_FROM=noreply@fountain.example.com
 
 # Optional: where "contact support" in account emails (suspension, deletion)
 # points. Unset, the emails say "contact support" with no address.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ upgrade, is in
 
 ### Changed
 
+- **Two silent misconfigurations now refuse to boot in prod with actionable
+  errors.** `PUBLIC_URL` is required (or the deprecated `FOUNTAIN_DOMAIN`) —
+  the old `http://localhost:4000` fallback meant a prod instance ran fine
+  while every verification/reset link and every sprite's `FOUNTAIN_BASE_URL`
+  silently pointed at localhost. And `EMAIL_FROM` is required whenever a
+  real delivery provider (Resend/SMTP) is configured — the old default was
+  the hosted instance's sending domain, so an instance that didn't set it
+  sent mail as someone else's domain, which providers checking SPF/DKIM
+  reject anyway. With `EMAIL_DELIVERY=none`, `EMAIL_FROM` stays optional
+  (nothing is sent) and falls back to a neutral `noreply@localhost`. The
+  compose quick start and `deploy/k8s` baseline already set `PUBLIC_URL`,
+  and instances that took the mail integration guide's advice to change
+  `EMAIL_FROM` are unaffected (#495)
+
 - The README no longer contradicts the licence story: it said nothing lived
   in `ee/` and that ee code would not be MIT — both false since #472. It now
   states what `ee/` holds (billing + growth mail) and that it is MIT today,

--- a/apps/fountain/lib/fountain/emails/user_emails.ex
+++ b/apps/fountain/lib/fountain/emails/user_emails.ex
@@ -231,7 +231,10 @@ defmodule Fountain.Emails.UserEmails do
   # and support-contact policy rather than duplicating it.
   @doc false
   def from_address do
-    addr = Application.get_env(:fountain, :email_from, "noreply@updates.inevitable.fyi")
+    # The fallback only ever renders in dev/test (the Local mailbox) and under
+    # EMAIL_DELIVERY=none, where nothing is sent: prod refuses to boot with a
+    # real adapter and no EMAIL_FROM (config/runtime.exs).
+    addr = Application.get_env(:fountain, :email_from, "noreply@localhost")
     {addr, addr}
   end
 

--- a/apps/fountain/test/fountain/mailer_config_test.exs
+++ b/apps/fountain/test/fountain/mailer_config_test.exs
@@ -22,10 +22,12 @@ defmodule Fountain.MailerConfigTest do
   @base %{
     "PHX_SERVER" => "true",
     "SECRET_KEY_BASE" => String.duplicate("a", 64),
-    "DATABASE_URL" => "postgres://u:p@localhost/db"
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "PUBLIC_URL" => "https://fountain.example.com",
+    "EMAIL_FROM" => "noreply@fountain.example.com"
   }
 
-  @mail_vars ~w(RESEND_API_KEY SMTP_HOST SMTP_PORT SMTP_USERNAME SMTP_PASSWORD SMTP_TLS EMAIL_DELIVERY)
+  @mail_vars ~w(RESEND_API_KEY SMTP_HOST SMTP_PORT SMTP_USERNAME SMTP_PASSWORD SMTP_TLS EMAIL_DELIVERY EMAIL_FROM)
 
   setup do
     previous = System.get_env()
@@ -46,6 +48,12 @@ defmodule Fountain.MailerConfigTest do
     for k <- @mail_vars, do: System.delete_env(k)
     System.put_env(env)
     Config.Reader.read!(@runtime_exs, env: :prod)[:fountain][Fountain.Mailer]
+  end
+
+  defp read_prod_full(env) do
+    for k <- @mail_vars, do: System.delete_env(k)
+    System.put_env(env)
+    Config.Reader.read!(@runtime_exs, env: :prod)[:fountain]
   end
 
   describe "with nothing configured" do
@@ -206,6 +214,59 @@ defmodule Fountain.MailerConfigTest do
 
       # No prod override, so the base Local adapter from config.exs stands.
       assert config == nil or config[:adapter] == Swoosh.Adapters.Local
+    end
+  end
+
+  describe "EMAIL_FROM" do
+    # The old default was the hosted instance's sending domain: a self-hoster
+    # who configured a provider but not EMAIL_FROM sent mail as someone
+    # else's domain — rejected by any provider checking SPF/DKIM, and wrong
+    # even where it wasn't.
+    test "prod refuses to boot with a provider configured and no EMAIL_FROM", %{base: base} do
+      env = base |> Map.delete("EMAIL_FROM") |> Map.put("RESEND_API_KEY", "re_live_abc")
+
+      for k <- @mail_vars, do: System.delete_env(k)
+      System.put_env(env)
+
+      error =
+        assert_raise RuntimeError, fn ->
+          Config.Reader.read!(@runtime_exs, env: :prod)
+        end
+
+      assert error.message =~ "EMAIL_FROM"
+      assert error.message =~ "SPF/DKIM"
+    end
+
+    test "a blank EMAIL_FROM counts as unset with SMTP configured", %{base: base} do
+      # `${EMAIL_FROM:-}` under compose delivers "", not absence.
+      env =
+        base
+        |> Map.merge(%{"EMAIL_FROM" => "", "SMTP_HOST" => "smtp.example.com"})
+
+      for k <- @mail_vars, do: System.delete_env(k)
+      System.put_env(env)
+
+      assert_raise RuntimeError, ~r/EMAIL_FROM/, fn ->
+        Config.Reader.read!(@runtime_exs, env: :prod)
+      end
+    end
+
+    test "is used verbatim when set", %{base: base} do
+      config = read_prod_full(Map.put(base, "RESEND_API_KEY", "re_live_abc"))
+
+      assert config[:email_from] == "noreply@fountain.example.com"
+    end
+
+    test "falls back to a neutral placeholder when mail is off", %{base: base} do
+      # Nothing is ever sent in this mode; the placeholder must not be a real
+      # domain someone owns.
+      config =
+        base
+        |> Map.delete("EMAIL_FROM")
+        |> Map.put("EMAIL_DELIVERY", "none")
+        |> read_prod_full()
+
+      assert config[:email_from] == "noreply@localhost"
     end
   end
 end

--- a/apps/fountain/test/fountain/master_key_config_test.exs
+++ b/apps/fountain/test/fountain/master_key_config_test.exs
@@ -18,8 +18,11 @@ defmodule Fountain.MasterKeyConfigTest do
     previous = System.get_env()
 
     # Prod refuses to boot with no mail delivery configured; these cases are
-    # about the master key, so give them one.
+    # about the master key, so give them one — with the EMAIL_FROM and
+    # PUBLIC_URL a configured provider and a prod boot now require.
     System.put_env("RESEND_API_KEY", "re_test_key")
+    System.put_env("EMAIL_FROM", "noreply@fountain.example.com")
+    System.put_env("PUBLIC_URL", "https://fountain.example.com")
 
     # Prod requires a database URL regardless of PHX_SERVER since #256 (release
     # eval tasks need the repo). Without this the test only passed when a
@@ -30,7 +33,7 @@ defmodule Fountain.MasterKeyConfigTest do
     on_exit(fn ->
       System.put_env(previous)
 
-      for k <- ~w(MASTER_SECRETS_KEY PHX_SERVER),
+      for k <- ~w(MASTER_SECRETS_KEY PHX_SERVER EMAIL_FROM PUBLIC_URL),
           not Map.has_key?(previous, k),
           do: System.delete_env(k)
     end)

--- a/apps/fountain/test/fountain/otel_config_test.exs
+++ b/apps/fountain/test/fountain/otel_config_test.exs
@@ -19,6 +19,7 @@ defmodule Fountain.OtelConfigTest do
     "SECRET_KEY_BASE" => String.duplicate("a", 64),
     "DATABASE_URL" => "postgres://u:p@localhost/db",
     "RESEND_API_KEY" => "re_test_key",
+    "EMAIL_FROM" => "noreply@fountain.example.com",
     "PUBLIC_URL" => "https://fountain.example.com"
   }
 

--- a/apps/fountain/test/fountain/runtime_config_test.exs
+++ b/apps/fountain/test/fountain/runtime_config_test.exs
@@ -18,8 +18,10 @@ defmodule Fountain.RuntimeConfigTest do
     "SECRET_KEY_BASE" => String.duplicate("a", 64),
     "DATABASE_URL" => "postgres://u:p@localhost/db",
     # Prod now refuses to boot with no mail delivery configured, so every
-    # prod-config evaluation needs one.
-    "RESEND_API_KEY" => "re_test_key"
+    # prod-config evaluation needs one — and a configured provider requires
+    # EMAIL_FROM.
+    "RESEND_API_KEY" => "re_test_key",
+    "EMAIL_FROM" => "noreply@fountain.example.com"
   }
 
   setup do
@@ -99,5 +101,49 @@ defmodule Fountain.RuntimeConfigTest do
     cfg = read_prod_config(Map.put(base, "PUBLIC_URL", "https://fountain.example.com"))
 
     assert "//fountain.example.com" in cfg[FountainWeb.Endpoint][:check_origin]
+  end
+
+  describe "PUBLIC_URL is required in prod" do
+    # The old fallback was http://localhost:4000 — and unlike a missing
+    # secret, nothing crashed: the instance ran and silently put localhost
+    # links in every verification email and every sprite's FOUNTAIN_BASE_URL.
+    test "prod refuses to boot with neither PUBLIC_URL nor FOUNTAIN_DOMAIN", %{base: base} do
+      for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN SMTP_HOST EMAIL_DELIVERY),
+          do: System.delete_env(k)
+
+      System.put_env(base)
+
+      error =
+        assert_raise RuntimeError, fn ->
+          Config.Reader.read!(@runtime_exs, env: :prod)
+        end
+
+      # Actionable: name the variable, the consequence, and the shape.
+      assert error.message =~ "PUBLIC_URL"
+      assert error.message =~ "localhost:4000"
+      assert error.message =~ "https://fountain.example.com"
+    end
+
+    test "a blank PUBLIC_URL counts as unset", %{base: base} do
+      # Compose-style `${VAR:-}` interpolation delivers "", not absence.
+      for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN SMTP_HOST EMAIL_DELIVERY),
+          do: System.delete_env(k)
+
+      System.put_env(Map.put(base, "PUBLIC_URL", ""))
+
+      assert_raise RuntimeError, ~r/PUBLIC_URL/, fn ->
+        Config.Reader.read!(@runtime_exs, env: :prod)
+      end
+    end
+
+    test "dev keeps the localhost default", %{base: base} do
+      for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN SMTP_HOST EMAIL_DELIVERY),
+          do: System.delete_env(k)
+
+      System.put_env(base)
+      cfg = Config.Reader.read!(@runtime_exs, env: :dev)[:fountain]
+
+      assert cfg[:public_url] == "http://localhost:4000"
+    end
   end
 end

--- a/apps/fountain/test/fountain/sandbox_bounds_config_test.exs
+++ b/apps/fountain/test/fountain/sandbox_bounds_config_test.exs
@@ -15,7 +15,8 @@ defmodule Fountain.SandboxBoundsConfigTest do
     "PHX_SERVER" => "true",
     "SECRET_KEY_BASE" => String.duplicate("a", 64),
     "DATABASE_URL" => "postgres://u:p@localhost/db",
-    "EMAIL_DELIVERY" => "none"
+    "EMAIL_DELIVERY" => "none",
+    "PUBLIC_URL" => "https://fountain.example.com"
   }
 
   @vars ~w(SANDBOX_IDLE_TIMEOUT_MINUTES SANDBOX_MAX_LIFETIME_HOURS)

--- a/apps/fountain/test/fountain/self_host_switches_test.exs
+++ b/apps/fountain/test/fountain/self_host_switches_test.exs
@@ -24,6 +24,7 @@ defmodule Fountain.SelfHostSwitchesTest do
     "SECRET_KEY_BASE" => String.duplicate("a", 64),
     "DATABASE_URL" => "postgres://u:p@localhost/db",
     "RESEND_API_KEY" => "re_test_key",
+    "EMAIL_FROM" => "noreply@fountain.example.com",
     "PUBLIC_URL" => "https://fountain.example.com"
   }
 

--- a/apps/fountain/test/fountain/sentry_config_test.exs
+++ b/apps/fountain/test/fountain/sentry_config_test.exs
@@ -15,7 +15,8 @@ defmodule Fountain.SentryConfigTest do
     "PHX_SERVER" => "true",
     "SECRET_KEY_BASE" => String.duplicate("a", 64),
     "DATABASE_URL" => "postgres://u:p@localhost/db",
-    "EMAIL_DELIVERY" => "none"
+    "EMAIL_DELIVERY" => "none",
+    "PUBLIC_URL" => "https://fountain.example.com"
   }
 
   @vars ~w(SENTRY_DSN SENTRY_ENVIRONMENT FOUNTAIN_BUILD_SHA)

--- a/apps/fountain/test/fountain/sprites_token_config_test.exs
+++ b/apps/fountain/test/fountain/sprites_token_config_test.exs
@@ -21,7 +21,9 @@ defmodule Fountain.SpritesTokenConfigTest do
     "PHX_SERVER" => "true",
     "SECRET_KEY_BASE" => String.duplicate("a", 64),
     "DATABASE_URL" => "postgres://u:p@localhost/db",
-    "RESEND_API_KEY" => "re_test_key"
+    "RESEND_API_KEY" => "re_test_key",
+    "EMAIL_FROM" => "noreply@fountain.example.com",
+    "PUBLIC_URL" => "https://fountain.example.com"
   }
 
   setup do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -123,11 +123,32 @@ config :fountain, :sprites_timeout_ms, sprites_timeout_ms
 # deployments keep booting and get correct links without an env change.
 default_scheme = if env == :prod, do: "https", else: "http"
 
-public_url =
-  Fountain.PublicUrl.absolute(
-    System.get_env("PUBLIC_URL") || System.get_env("FOUNTAIN_DOMAIN"),
-    default_scheme
-  )
+public_url_env =
+  case String.trim(System.get_env("PUBLIC_URL") || System.get_env("FOUNTAIN_DOMAIN") || "") do
+    "" -> nil
+    value -> value
+  end
+
+# In prod the fallback would be http://localhost:4000 — and unlike a missing
+# secret, nothing crashes: the instance runs, and every verification/reset
+# link and every sprite's FOUNTAIN_BASE_URL silently points at localhost.
+# Same treatment mail got: refuse to boot and say what to set. Dev and test
+# keep the localhost default. Compose always passes PUBLIC_URL
+# (`${PUBLIC_URL:-http://localhost:4000}`), so the quick start is unaffected.
+if env == :prod and is_nil(public_url_env) do
+  raise """
+  PUBLIC_URL is not set.
+
+  It is the absolute base URL users reach this instance at. Without it,
+  every link that leaves the app — verification and password-reset emails,
+  llms.txt — and every sprite's FOUNTAIN_BASE_URL would silently point at
+  http://localhost:4000. Set it, scheme included:
+
+    PUBLIC_URL=https://fountain.example.com
+  """
+end
+
+public_url = Fountain.PublicUrl.absolute(public_url_env, default_scheme)
 
 phx_host =
   case System.get_env("PHX_HOST") do
@@ -370,7 +391,17 @@ config :fountain, :stripe_price_monthly_cents, stripe_price_monthly_cents
 # actually implemented, so operators were told to set SMTP_* variables that did
 # nothing.
 if config_env() == :prod do
-  config :fountain, :email_from, System.get_env("EMAIL_FROM", "noreply@updates.inevitable.fyi")
+  # No default: the old fallback was the hosted instance's sending domain, so
+  # a self-hoster who configured a provider but not EMAIL_FROM sent mail as
+  # someone else's domain — rejected by any provider checking SPF/DKIM, and
+  # wrong even where it wasn't. Required when a real adapter is selected
+  # (enforced after the adapter choice below); with mail off it is only a
+  # placeholder in headers that are never sent.
+  email_from =
+    case System.get_env("EMAIL_FROM") do
+      blank when blank in [nil, ""] -> nil
+      from -> from
+    end
 
   # Optional (#450): where "contact support" in account emails points. Unset,
   # the copy stays vague — EMAIL_FROM is usually a noreply@ address, so
@@ -454,6 +485,20 @@ if config_env() == :prod do
       password-reset email cannot be delivered.
       """
   end
+
+  if (resend_api_key || smtp_host) && is_nil(email_from) do
+    raise """
+    Mail delivery is configured but EMAIL_FROM is not set.
+
+    Every provider that checks SPF/DKIM would reject mail sent from a domain
+    you don't control, so there is no usable default. Set it to an address on
+    a domain your provider is verified for:
+
+      EMAIL_FROM=noreply@fountain.example.com
+    """
+  end
+
+  config :fountain, :email_from, email_from || "noreply@localhost"
 end
 
 # Database config is deliberately NOT behind `server?`. Release tasks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,10 @@ services:
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USERNAME: ${SMTP_USERNAME:-}
       SMTP_PASSWORD: ${SMTP_PASSWORD:-}
-      EMAIL_FROM: ${EMAIL_FROM:-noreply@localhost}
+      # Deliberately blank, not defaulted: with real mail configured the app
+      # refuses to boot until EMAIL_FROM names an address on a domain your
+      # provider is verified for. With EMAIL_DELIVERY=none it is unused.
+      EMAIL_FROM: ${EMAIL_FROM:-}
 
       # Open by default so the first account can be created. Close it once
       # yours exists.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ an error message.
 | `DATABASE_URL` | — | prod | Postgres connection string. Boot fails without it |
 | `SECRET_KEY_BASE` | — | prod (serving) | Signs and encrypts session cookies and tokens. Generate: `openssl rand -base64 48` |
 | `MASTER_SECRETS_KEY` | — | prod | Wraps every tenant's data-encryption key ([the secrets model](architecture.md#the-secrets-model)). 32 bytes, url-safe base64, no padding: `openssl rand 32 \| base64 \| tr '+/' '-_' \| tr -d '='`. **Lose it and every stored secret is unrecoverable.** Boot refuses a malformed value |
-| `PUBLIC_URL` | `http://localhost:4000` | effectively, prod | The externally visible base URL, scheme included. Builds every link that leaves the app (verification and reset emails, `llms.txt`) and is passed to every sandbox as `FOUNTAIN_BASE_URL`. An `https://` value also switches on HTTPS redirection, HSTS, and the secure cookie flag — all derived from the scheme |
+| `PUBLIC_URL` | — | prod | The externally visible base URL, scheme included. A prod instance refuses to boot without it (or the deprecated `FOUNTAIN_DOMAIN`) — the old `http://localhost:4000` fallback silently put localhost links in every verification email. Builds every link that leaves the app (verification and reset emails, `llms.txt`) and is passed to every sandbox as `FOUNTAIN_BASE_URL`. An `https://` value also switches on HTTPS redirection, HSTS, and the secure cookie flag — all derived from the scheme |
 | `PHX_HOST` | host of `PUBLIC_URL` | — | Bare host for the endpoint URL and the LiveView origin check. Set only if it differs from `PUBLIC_URL`'s host |
 | `FOUNTAIN_DOMAIN` | — | deprecated | The old combined variable; still honoured as a fallback for both of the above. Prefer `PUBLIC_URL` / `PHX_HOST` |
 | `PHX_SERVER` | `true` in the shipped image | — | `1`/`true`/`yes` starts the web listener. Release tasks run with `PHX_SERVER=false … eval '…'` to boot the app without binding the port |
@@ -72,7 +72,7 @@ signup with no visible error. See [Email](self-hosting.md#email).
 | `SMTP_PASSWORD` | — | — | |
 | `SMTP_TLS` | `always` | — | STARTTLS by default; `never` for a relay on a trusted network that does not offer it |
 | `EMAIL_DELIVERY` | — | one of three | `none` deliberately disables email. Accounts then self-verify at registration (ADR 0011), but password-reset email cannot be delivered, so a forgotten password is unrecoverable in this mode |
-| `EMAIL_FROM` | `noreply@updates.inevitable.fyi` | — | The From address. Change it — the default is the hosted instance's sending domain |
+| `EMAIL_FROM` | — | when mail is on | The From address. Required whenever a real delivery provider is configured — a prod instance refuses to boot without it, since mail from an unverified domain is rejected anyway. Unused under `EMAIL_DELIVERY=none` |
 | `SUPPORT_EMAIL` | — | — | Where "contact support" in account emails (suspension, deletion) points. Unset, the copy names no address |
 
 ## Authentication

--- a/docs/integrations/mail.md
+++ b/docs/integrations/mail.md
@@ -44,7 +44,7 @@ account is operator intervention.
 
 | Variable | Default | Effect |
 |---|---|---|
-| `EMAIL_FROM` | `noreply@updates.inevitable.fyi` | The From address. **Change it** — the default is the hosted instance's sending domain, which will not be verified for yours |
+| `EMAIL_FROM` | — (required) | The From address, on a domain your provider is verified for. Required with any real delivery provider — the app refuses to boot without it rather than sending mail your provider will reject |
 
 What actually sends email today: account verification (24-hour link),
 password reset (1-hour link), and — only with [Stripe](stripe.md) configured


### PR DESCRIPTION
## Problem

Two misconfigurations ran silently where a missing secret would have crashed:

1. **`PUBLIC_URL` unset in prod fell back to `http://localhost:4000`** — the instance ran fine while every verification/reset link and every sprite's `FOUNTAIN_BASE_URL` silently pointed at localhost.
2. **`EMAIL_FROM` defaulted to `noreply@updates.inevitable.fyi`** — in `runtime.exs` *and* again in `UserEmails.from_address/0`. A self-hoster who configured Resend/SMTP but not `EMAIL_FROM` sent mail as the hosted instance's domain — rejected by any provider checking SPF/DKIM, and wrong even where it wasn't.

## Changes

Same refuse-to-boot-with-an-actionable-error treatment mail delivery got (#390-style):

- Prod refuses to boot without `PUBLIC_URL` (or deprecated `FOUNTAIN_DOMAIN`); blank counts as unset. Dev/test keep the localhost default.
- `EMAIL_FROM` is required whenever a real adapter is selected; blank counts as unset (the compose `${VAR:-}` shape). With `EMAIL_DELIVERY=none` it falls back to a neutral `noreply@localhost` — nothing is ever sent in that mode.
- `docker-compose.yml` passes `EMAIL_FROM` through blank instead of defaulting it to `noreply@localhost`, so the boot check reaches compose users who enable a real provider.
- Personal-domain defaults removed from `runtime.exs`, `user_emails.ex`, and `.env.example`; docs rows updated (`configuration.md`, `integrations/mail.md`).

## Blast radius checked

- **Hosted instance**: `k8s/deployment.yaml` sets both explicitly — unaffected.
- **CI release boot check**: sets `PUBLIC_URL` + `EMAIL_DELIVERY=none` — unaffected.
- **Compose quick start**: always passes `PUBLIC_URL` (`${PUBLIC_URL:-http://localhost:4000}`) and defaults to `EMAIL_DELIVERY=none` — unaffected.
- Instances that followed the mail guide's existing "**Change it**" advice on `EMAIL_FROM` — unaffected. The changelog entry spells out who must act.

## Verification

- Five new enforcement tests (raise-without, blank-counts-as-unset, verbatim use, neutral fallback, dev default) — **verified to fail against the reverted fix** (exactly those 5, nothing else).
- `PUBLIC_URL`/`EMAIL_FROM` added to every runtime-config test's base env; all 59 config tests green across ten seeds.
- `mix precommit` green: 1,974 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)