### PR TITLE
marketing: add /terms and /privacy pages, link from signup and footer

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -42,6 +42,8 @@
     <div class="max-w-5xl mx-auto px-6 py-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-[var(--color-text-muted)]">
       <span>© 2026 Fountain. Managed agent infrastructure for teams who'd rather build than configure.</span>
       <div class="flex items-center gap-4">
+        <a href={~p"/terms"} class="hover:text-[var(--color-text-secondary)] transition-colors">Terms</a>
+        <a href={~p"/privacy"} class="hover:text-[var(--color-text-secondary)] transition-colors">Privacy</a>
         <%= if @current_user do %>
           <a href={~p"/conversations"} class="hover:text-[var(--color-text-secondary)] transition-colors">Go to app</a>
         <% else %>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -2,7 +2,25 @@ defmodule FountainWeb.MarketingController do
   @moduledoc false
   use FountainWeb, :controller
 
+  # Placeholders for the legal pages, kept in one place so filling them is a
+  # single edit. They must be replaced with real values before charging
+  # customers — a page that says {{COMPANY_LEGAL_NAME}} is deliberately loud.
+  @legal %{
+    entity: "{{COMPANY_LEGAL_NAME}}",
+    contact_email: "{{CONTACT_EMAIL}}",
+    jurisdiction: "{{JURISDICTION}}",
+    updated: "{{EFFECTIVE_DATE}}"
+  }
+
   def home(conn, _params) do
     render(conn, :home, layout: {FountainWeb.Layouts, :marketing})
+  end
+
+  def terms(conn, _params) do
+    render(conn, :terms, layout: {FountainWeb.Layouts, :marketing}, legal: @legal)
+  end
+
+  def privacy(conn, _params) do
+    render(conn, :privacy, layout: {FountainWeb.Layouts, :marketing}, legal: @legal)
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
@@ -1,0 +1,151 @@
+<section class="max-w-3xl mx-auto px-6 py-16">
+  <h1 class="text-3xl font-bold tracking-tight text-[var(--color-text-primary)] mb-2">
+    Privacy Policy
+  </h1>
+  <p class="text-sm text-[var(--color-text-muted)] mb-10">Last updated: {@legal.updated}</p>
+
+  <div class="space-y-8 text-[var(--color-text-secondary)] leading-relaxed text-[15px]">
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">1. Who we are</h2>
+      <p>
+        Fountain is operated by {@legal.entity} ("we", "us"). This policy describes what
+        personal data we collect when you use the Fountain service, why we collect it, and the
+        choices you have. For questions or requests, contact
+        <a href={"mailto:#{@legal.contact_email}"} class="underline">{@legal.contact_email}</a>.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        2. What we collect
+      </h2>
+      <ul class="list-disc pl-6 space-y-2">
+        <li>
+          <strong class="text-[var(--color-text-primary)]">Account data.</strong>
+          Your email address and a hashed password. If you sign in with GitHub, we receive your
+          GitHub account email and profile identifier; we never see your GitHub password.
+        </li>
+        <li>
+          <strong class="text-[var(--color-text-primary)]">Billing data.</strong>
+          Payments are processed by Stripe. We store your Stripe customer and subscription
+          identifiers and subscription status; your card details go directly to Stripe and never
+          touch our servers.
+        </li>
+        <li>
+          <strong class="text-[var(--color-text-primary)]">Service content.</strong>
+          The agent configurations, environments, vaults, and secrets you create, and the
+          conversations your agents run, including their logs. Environment and vault secrets are
+          encrypted at rest with a per-tenant key.
+        </li>
+        <li>
+          <strong class="text-[var(--color-text-primary)]">Usage and security records.</strong>
+          Usage events (which conversations ran and when, for billing and quota purposes) and
+          audit logs of security-relevant actions, which include your IP address. We also use IP
+          addresses transiently for rate limiting.
+        </li>
+        <li>
+          <strong class="text-[var(--color-text-primary)]">Cookies.</strong>
+          A session cookie to keep you signed in. We do not use advertising or third-party
+          analytics cookies on the Service.
+        </li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        3. How we use it
+      </h2>
+      <p>
+        We use this data to provide and secure the Service: authenticating you, running your
+        agents, billing your subscription, sending transactional email (verification, billing
+        and account notices), preventing abuse, and debugging problems. We do not sell personal
+        data, we do not use your content to train AI models, and we do not send marketing email
+        you haven't asked for.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        4. Who we share it with
+      </h2>
+      <p class="mb-2">
+        We share data with service providers only as needed to run Fountain:
+      </p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li><strong class="text-[var(--color-text-primary)]">Stripe</strong> — payment processing and subscription management;</li>
+        <li><strong class="text-[var(--color-text-primary)]">our email provider</strong> — transactional email delivery;</li>
+        <li>
+          <strong class="text-[var(--color-text-primary)]">sandbox infrastructure</strong>
+          — the isolated compute environments your conversations run in, which receive the
+          configuration and decrypted credentials needed to run each conversation;
+        </li>
+        <li>
+          <strong class="text-[var(--color-text-primary)]">AI model providers you configure</strong>
+          — your agents call them with credentials you supply, under those providers' terms;
+        </li>
+        <li><strong class="text-[var(--color-text-primary)]">GitHub</strong> — only if you choose GitHub sign-in.</li>
+      </ul>
+      <p class="mt-2">
+        We may also disclose data if required by law, or as part of a merger or acquisition, in
+        which case this policy continues to apply to it.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">5. Security</h2>
+      <p>
+        Traffic to the Service is encrypted in transit with TLS. Secrets you store are encrypted
+        at rest using envelope encryption with a per-tenant data key. Passwords are stored only
+        as salted hashes. Access to production systems is restricted. No system is perfectly
+        secure; if we learn of a breach affecting your data, we will notify you without undue
+        delay.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">6. Retention</h2>
+      <p>
+        We keep your data while your account is active. When you delete your account, your
+        content and personal data are removed from our systems, subject to short-lived backups
+        and any records we must keep for legal or accounting reasons (such as invoices held by
+        Stripe).
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">7. Your rights</h2>
+      <p class="mb-2">
+        From your account page you can, at any time and without asking us: export your data in a
+        machine-readable format, and permanently delete your account. Depending on where you
+        live you may have additional rights (access, correction, erasure, portability,
+        objection); we honor these regardless of location — email
+        <a href={"mailto:#{@legal.contact_email}"} class="underline">{@legal.contact_email}</a>
+        and we will respond within 30 days.
+      </p>
+      <p>
+        The Service is not directed at children under 16, and we do not knowingly collect their
+        data.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        8. International transfers
+      </h2>
+      <p>
+        Our systems and providers may process data in countries other than yours, including the
+        United States. Where required, we rely on appropriate safeguards for those transfers,
+        such as our providers' standard contractual clauses.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">9. Changes</h2>
+      <p>
+        We may update this policy. For material changes we will notify you by email or in-app
+        notice before they take effect. The "Last updated" date above reflects the current
+        version.
+      </p>
+    </div>
+  </div>
+</section>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/terms.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/terms.html.heex
@@ -1,0 +1,189 @@
+<section class="max-w-3xl mx-auto px-6 py-16">
+  <h1 class="text-3xl font-bold tracking-tight text-[var(--color-text-primary)] mb-2">
+    Terms of Service
+  </h1>
+  <p class="text-sm text-[var(--color-text-muted)] mb-10">Last updated: {@legal.updated}</p>
+
+  <div class="space-y-8 text-[var(--color-text-secondary)] leading-relaxed text-[15px]">
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">1. Agreement</h2>
+      <p>
+        These Terms of Service ("Terms") are an agreement between you and {@legal.entity}
+        ("Fountain", "we", "us") governing your use of the Fountain service — the web
+        application, API, and command-line tools available through this site (the "Service").
+        By creating an account or using the Service you agree to these Terms. If you are using
+        the Service on behalf of an organization, you represent that you have authority to bind
+        that organization, and "you" refers to it.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">2. The Service</h2>
+      <p>
+        Fountain lets you configure and run AI agents in isolated, sandboxed environments. You
+        define agent configurations, environments, and encrypted credential vaults; the Service
+        provisions sandboxes, runs conversations, and streams logs back to you. Sandboxes are
+        provisioned on third-party infrastructure, and agents may call third-party AI model
+        providers using credentials you supply.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">3. Accounts</h2>
+      <p class="mb-2">
+        You must provide a valid email address and keep your credentials secure. You are
+        responsible for all activity under your account, including activity via API keys you
+        create. Notify us promptly at
+        <a href={"mailto:#{@legal.contact_email}"} class="underline">{@legal.contact_email}</a>
+        if you believe your account has been compromised.
+      </p>
+      <p>
+        You must be at least 16 years old (or the age of digital consent where you live) to use
+        the Service.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        4. Trials, subscriptions, and billing
+      </h2>
+      <p class="mb-2">
+        New accounts start with a 14-day free trial; no payment method is required to begin.
+        After the trial, continued use of the Service requires a paid subscription, billed
+        monthly in advance through our payment processor, Stripe. Prices are shown before you
+        subscribe; we will give at least 30 days' notice before a price change takes effect for
+        an existing subscription.
+      </p>
+      <p class="mb-2">
+        You can cancel at any time from your account's billing page; cancellation takes effect
+        at the end of the current billing period, and we do not prorate partial months. If a
+        renewal payment fails we may restrict the Service to read-only access while you update
+        your payment method, and suspend it if payment is not resolved.
+      </p>
+      <p>
+        Except where required by law, payments are non-refundable. If you believe you were
+        charged in error, contact us and we will review it.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">5. Acceptable use</h2>
+      <p class="mb-2">You agree not to use the Service to:</p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>break the law, or infringe others' rights, including intellectual property and privacy rights;</li>
+        <li>
+          probe, disrupt, or overload the Service or its underlying infrastructure, or attempt to
+          escape or abuse the sandbox environments (including cryptocurrency mining, spam, or
+          denial-of-service activity);
+        </li>
+        <li>attempt to access other tenants' data or circumvent usage limits, billing, or access controls;</li>
+        <li>resell or white-label the Service without our written agreement.</li>
+      </ul>
+      <p class="mt-2">
+        We may suspend or terminate accounts that violate this section. Where practical we will
+        warn you first.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">6. Your content</h2>
+      <p class="mb-2">
+        You retain all rights to the content you bring to the Service — agent configurations,
+        environment variables, secrets, prompts, and the output of your conversations ("Customer
+        Content"). You grant us the limited rights needed to operate the Service: to store,
+        encrypt, transmit, and process Customer Content on your behalf, including passing it to
+        the sandbox and model providers involved in running your agents. We do not use Customer
+        Content to train models and we do not sell it.
+      </p>
+      <p>
+        You are responsible for the Customer Content you submit, including having the rights to
+        the credentials and repositories you connect.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">7. AI output</h2>
+      <p>
+        Agent conversations produce output from third-party AI models. AI output can be wrong,
+        incomplete, or unsuitable for your purpose, and the same prompt can produce different
+        results. You are responsible for reviewing output before relying on it — including any
+        code an agent writes or actions an agent takes against systems you connect it to.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        8. Third-party services
+      </h2>
+      <p>
+        The Service depends on third parties — payment processing (Stripe), transactional email,
+        sandbox infrastructure, and the model providers you configure. Their services are
+        governed by their own terms, and we are not responsible for their acts or omissions,
+        though we choose and monitor them with reasonable care.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        9. Termination and data
+      </h2>
+      <p>
+        You can export your data and delete your account at any time from your account page.
+        Deleting your account permanently removes your Customer Content from our systems,
+        subject to short-lived backups. We may terminate or suspend accounts for material breach
+        of these Terms, and may discontinue the Service with at least 30 days' notice, during
+        which export remains available.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">10. Disclaimers</h2>
+      <p>
+        The Service is provided "as is" and "as available", without warranties of any kind,
+        express or implied, including merchantability, fitness for a particular purpose, and
+        non-infringement. We do not warrant that the Service will be uninterrupted, error-free,
+        or secure.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        11. Limitation of liability
+      </h2>
+      <p>
+        To the maximum extent permitted by law, neither party is liable for indirect,
+        incidental, special, consequential, or punitive damages, or for lost profits, revenue,
+        or data. Our total liability arising out of or relating to the Service is limited to the
+        amounts you paid us in the 12 months before the claim arose. Nothing in these Terms
+        limits liability that cannot be limited by law.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">12. Changes</h2>
+      <p>
+        We may update these Terms. For material changes we will notify you by email or in-app
+        notice at least 14 days before they take effect; continued use after that date is
+        acceptance. The "Last updated" date above reflects the current version.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        13. Governing law
+      </h2>
+      <p>
+        These Terms are governed by the laws of {@legal.jurisdiction}, without regard to
+        conflict-of-law rules, and disputes will be resolved in the courts of {@legal.jurisdiction}.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">14. Contact</h2>
+      <p>
+        Questions about these Terms:
+        <a href={"mailto:#{@legal.contact_email}"} class="underline">{@legal.contact_email}</a>.
+      </p>
+    </div>
+  </div>
+</section>

--- a/apps/fountain/lib/fountain_web/controllers/registration_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/registration_html.ex
@@ -72,7 +72,9 @@ defmodule FountainWeb.RegistrationHTML do
         </a>
 
         <p class="text-xs text-zinc-400 text-center">
-          By signing up you agree to our terms of service.
+          By signing up you agree to our
+          <a href={~p"/terms"} class="underline">terms of service</a>
+          and <a href={~p"/privacy"} class="underline">privacy policy</a>.
         </p>
       </div>
     </div>

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -115,10 +115,12 @@ defmodule FountainWeb.Router do
 
   ## ─── Public browser routes ────────────────────────────────────────────────────────────────────────
 
-  # Marketing landing page — public, shows auth-aware nav for logged-in users
+  # Marketing landing page + legal pages — public, auth-aware nav for logged-in users
   scope "/", FountainWeb do
     pipe_through [:browser, :browser_optional_auth]
     get "/", MarketingController, :home
+    get "/terms", MarketingController, :terms
+    get "/privacy", MarketingController, :privacy
   end
 
   # Multi-tenant auth routes (no session auth required)

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule FountainWeb.MarketingControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  describe "GET /terms" do
+    test "renders the terms of service", %{conn: conn} do
+      body = conn |> get(~p"/terms") |> html_response(200)
+      assert body =~ "Terms of Service"
+      assert body =~ "Limitation of liability"
+      assert body =~ ~p"/privacy"
+    end
+  end
+
+  describe "GET /privacy" do
+    test "renders the privacy policy", %{conn: conn} do
+      body = conn |> get(~p"/privacy") |> html_response(200)
+      assert body =~ "Privacy Policy"
+      assert body =~ "Your rights"
+      assert body =~ ~p"/terms"
+    end
+  end
+
+  describe "legal links" do
+    test "registration form links to terms and privacy", %{conn: conn} do
+      body = conn |> get(~p"/auth/register") |> html_response(200)
+      assert body =~ ~p"/terms"
+      assert body =~ ~p"/privacy"
+    end
+
+    test "marketing footer links to terms and privacy", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+      assert body =~ ~p"/terms"
+      assert body =~ ~p"/privacy"
+    end
+  end
+end


### PR DESCRIPTION
Part of #500 (item 1 — the launch blocker).

The signup form asserted "By signing up you agree to our terms of service" while no terms existed anywhere in the router, and emails were collected with no privacy policy. This adds:

- `GET /terms` and `GET /privacy` in the public marketing scope, rendered with the marketing layout
- complete drafted documents for both, with **loud `{{PLACEHOLDER}}` tokens** for the legal entity, contact email, jurisdiction, and effective date — all defined once in `MarketingController.@legal` so filling them is a single edit
- signup copy now links both documents; the marketing footer gets Terms/Privacy links
- controller tests for both pages and both link sites

**Before merge (Jake):** fill the four placeholders in `MarketingController`. The documents only claim behavior that exists — 14-day trial, Stripe checkout/portal, self-serve export + deletion (ADR 0009), per-tenant envelope encryption, session-cookie-only tracking, no analytics scripts. These are drafts, not legal advice; worth a counsel pass when convenient, but strictly better than asserting terms that don't exist.

`mix precommit` green locally.

Closes the item-1 half of #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)