### PR TITLE
marketing: render homepage price from STRIPE_PRICE_MONTHLY_CENTS

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -3,4 +3,25 @@ defmodule FountainWeb.MarketingHTML do
   use FountainWeb, :html
 
   embed_templates "marketing_html/*"
+
+  @doc """
+  Display price for the marketing page, read from `:stripe_price_monthly_cents`
+  (`STRIPE_PRICE_MONTHLY_CENTS`) — the same value the admin MRR tile uses, so
+  the homepage cannot drift from the configured Stripe price.
+
+  Returns e.g. `"$29"`, or `nil` when billing is disabled or the price isn't
+  configured — the pricing sentence is omitted rather than fabricated.
+  """
+  def monthly_price do
+    with true <- Fountain.Billing.enabled?(),
+         cents when is_integer(cents) and cents > 0 <-
+           Application.get_env(:fountain, :stripe_price_monthly_cents) do
+      format_usd(cents)
+    else
+      _ -> nil
+    end
+  end
+
+  defp format_usd(cents) when rem(cents, 100) == 0, do: "$#{div(cents, 100)}"
+  defp format_usd(cents), do: "$#{:erlang.float_to_binary(cents / 100, decimals: 2)}"
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -20,7 +20,12 @@
       Sign in
     </a>
   </div>
-  <p class="text-xs text-[var(--color-text-muted)]">Free 14-day trial — then $29/mo per team. Cancel anytime.</p>
+  <p :if={monthly_price()} class="text-xs text-[var(--color-text-muted)]">
+    Free 14-day trial — then {monthly_price()}/mo per team. Cancel anytime.
+  </p>
+  <p :if={!monthly_price()} class="text-xs text-[var(--color-text-muted)]">
+    Free 14-day trial. Cancel anytime.
+  </p>
 </section>
 
 <%!-- Problem --%>
@@ -147,5 +152,10 @@
   >
     Get started free
   </a>
-  <p class="mt-4 text-sm text-[var(--color-text-muted)]">$29/mo per team after trial. Cancel anytime. No lock-in.</p>
+  <p :if={monthly_price()} class="mt-4 text-sm text-[var(--color-text-muted)]">
+    {monthly_price()}/mo per team after trial. Cancel anytime. No lock-in.
+  </p>
+  <p :if={!monthly_price()} class="mt-4 text-sm text-[var(--color-text-muted)]">
+    Cancel anytime. No lock-in.
+  </p>
 </section>

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -1,0 +1,49 @@
+# async: false — these tests mutate the global :stripe_price_monthly_cents /
+# :billing_enabled app env, which concurrent tests (admin MRR) also read.
+defmodule FountainWeb.MarketingPricingTest do
+  use FountainWeb.ConnCase, async: false
+
+  setup do
+    price = Application.get_env(:fountain, :stripe_price_monthly_cents)
+    billing = Application.get_env(:fountain, :billing_enabled)
+
+    on_exit(fn ->
+      Application.put_env(:fountain, :stripe_price_monthly_cents, price)
+      Application.put_env(:fountain, :billing_enabled, billing)
+    end)
+
+    :ok
+  end
+
+  test "homepage renders the configured monthly price in both pricing lines", %{conn: conn} do
+    Application.put_env(:fountain, :stripe_price_monthly_cents, 2900)
+
+    body = conn |> get(~p"/") |> html_response(200)
+    assert body =~ "then $29/mo per team"
+    assert body =~ "$29/mo per team after trial"
+  end
+
+  test "non-whole-dollar prices render with cents", %{conn: conn} do
+    Application.put_env(:fountain, :stripe_price_monthly_cents, 2950)
+
+    body = conn |> get(~p"/") |> html_response(200)
+    assert body =~ "$29.50/mo per team"
+  end
+
+  test "omits the price when STRIPE_PRICE_MONTHLY_CENTS is unset", %{conn: conn} do
+    Application.put_env(:fountain, :stripe_price_monthly_cents, nil)
+
+    body = conn |> get(~p"/") |> html_response(200)
+    refute body =~ "/mo per team"
+    assert body =~ "Free 14-day trial. Cancel anytime."
+    assert body =~ "Cancel anytime. No lock-in."
+  end
+
+  test "omits the price when billing is disabled even if a price is configured", %{conn: conn} do
+    Application.put_env(:fountain, :stripe_price_monthly_cents, 2900)
+    Application.put_env(:fountain, :billing_enabled, false)
+
+    body = conn |> get(~p"/") |> html_response(200)
+    refute body =~ "/mo per team"
+  end
+end


### PR DESCRIPTION
Part of #500 (item 2).

`$29/mo` was hardcoded twice in `marketing_html/home.html.heex`, connected to neither `STRIPE_PRICE_ID` nor `STRIPE_PRICE_MONTHLY_CENTS` — change the Stripe price and the homepage lies. Both pricing lines now render via `MarketingHTML.monthly_price/0`, which reads the same `:stripe_price_monthly_cents` config the admin MRR tile uses.

When the price is unset or billing is disabled (self-host), the price sentence is **omitted rather than fabricated** — the lines degrade to "Free 14-day trial. Cancel anytime." / "Cancel anytime. No lock-in."

Tests cover: whole-dollar rendering, cents rendering ($29.50), unset price, and billing-disabled (async: false since they mutate global app env). `mix precommit` green locally.

Note for the deploy: prod's homepage price now requires `STRIPE_PRICE_MONTHLY_CENTS` to be set (it already is, for the admin MRR tile) — if it were unset the homepage would show no price rather than a wrong one, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)