### PR TITLE
compose: finish the #397 environment pass-through (TRUSTED_PROXIES, SENTRY_DSN, DATABASE_SSL_VERIFY)

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -73,3 +73,17 @@ FOUNTAIN_IMAGE_TAG=v0.4.1
 # Close registration once your own account exists.
 # REGISTRATION_ENABLED=false
 # REGISTRATION_ALLOWED_EMAIL_DOMAINS=example.com
+
+# Behind a reverse proxy, list the proxy's address range(s) before exposing
+# the instance, so the app resolves real client IPs from X-Forwarded-For —
+# otherwise per-IP rate limits collapse into one bucket keyed on the proxy.
+# TRUSTED_PROXIES=172.16.0.0/12
+
+# Error tracking. Off unless set — nothing leaves your instance without it.
+# SENTRY_DSN=
+
+# Only meaningful against an external Postgres serving TLS (which also means
+# editing DATABASE_URL and DATABASE_SSL in docker-compose.yml): verify the
+# server certificate, with an explicit CA bundle or the OS trust store.
+# DATABASE_SSL_VERIFY=true
+# DATABASE_SSL_CA_FILE=/etc/ssl/certs/your-ca.pem

--- a/apps/fountain/test/fountain/compose_passthrough_config_test.exs
+++ b/apps/fountain/test/fountain/compose_passthrough_config_test.exs
@@ -1,0 +1,116 @@
+defmodule Fountain.ComposePassthroughConfigTest do
+  @moduledoc """
+  Evaluates `config/runtime.exs` the way the release config provider does,
+  pinning the blank-string behaviour of the variables #497 newly passes
+  through the compose `environment:` block as `${VAR:-}`.
+
+  Compose interpolates an unset `${VAR:-}` to an empty *string* — the
+  variable arrives set, not absent — so every default here must survive `""`.
+  These tests SET the variables to `""` rather than deleting them; deleting
+  is how the #396 predecessors of these bugs went unnoticed.
+  """
+
+  # Mutates process env, so it must not run alongside anything else.
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+
+  @vars ~w(TRUSTED_PROXIES SENTRY_DSN DATABASE_SSL_VERIFY DATABASE_SSL_CA_FILE)
+
+  @base %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "EMAIL_DELIVERY" => "none",
+    "PUBLIC_URL" => "https://fountain.example.com"
+  }
+
+  setup do
+    previous = System.get_env()
+    key = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+
+    on_exit(fn ->
+      System.put_env(previous)
+
+      for k <- @vars ++ ["MASTER_SECRETS_KEY"],
+          not Map.has_key?(previous, k),
+          do: System.delete_env(k)
+    end)
+
+    {:ok, base: Map.put(@base, "MASTER_SECRETS_KEY", key)}
+  end
+
+  defp read_prod(env) do
+    for k <- @vars, do: System.delete_env(k)
+    System.put_env(env)
+    Config.Reader.read!(@runtime_exs, env: :prod)
+  end
+
+  describe "TRUSTED_PROXIES" do
+    test "blank leaves the built-in default in place", %{base: base} do
+      # An empty list here would override the endpoint's default CIDRs — a
+      # blank value must mean "not configured", not "trust nothing".
+      cfg = read_prod(Map.put(base, "TRUSTED_PROXIES", ""))
+
+      refute Keyword.has_key?(cfg[:fountain], :trusted_proxies)
+    end
+
+    test "a real list is split and trimmed", %{base: base} do
+      cfg = read_prod(Map.put(base, "TRUSTED_PROXIES", "10.0.0.0/8, 172.16.0.0/12"))
+
+      assert cfg[:fountain][:trusted_proxies] == ["10.0.0.0/8", "172.16.0.0/12"]
+    end
+  end
+
+  describe "SENTRY_DSN" do
+    test "blank stays nil rather than handing the SDK an empty DSN", %{base: base} do
+      cfg = read_prod(Map.put(base, "SENTRY_DSN", ""))
+
+      assert cfg[:sentry][:dsn] == nil
+    end
+
+    test "a real DSN is stored verbatim", %{base: base} do
+      cfg = read_prod(Map.put(base, "SENTRY_DSN", "https://k@o0.ingest.sentry.io/1"))
+
+      assert cfg[:sentry][:dsn] == "https://k@o0.ingest.sentry.io/1"
+    end
+  end
+
+  describe "DATABASE_SSL_VERIFY / DATABASE_SSL_CA_FILE" do
+    test "verify with a blank CA file falls back to the OS trust store", %{base: base} do
+      # verify_peer with `cacertfile: ''` would reject every certificate.
+      cfg =
+        base
+        |> Map.merge(%{"DATABASE_SSL_VERIFY" => "true", "DATABASE_SSL_CA_FILE" => ""})
+        |> read_prod()
+
+      opts = cfg[:fountain][Fountain.Repo][:ssl_opts]
+      assert opts[:verify] == :verify_peer
+      assert is_list(opts[:cacerts])
+      refute Keyword.has_key?(opts, :cacertfile)
+    end
+
+    test "verify with an explicit CA file uses it", %{base: base} do
+      cfg =
+        base
+        |> Map.merge(%{
+          "DATABASE_SSL_VERIFY" => "true",
+          "DATABASE_SSL_CA_FILE" => "/etc/ssl/certs/rds.pem"
+        })
+        |> read_prod()
+
+      opts = cfg[:fountain][Fountain.Repo][:ssl_opts]
+      assert opts[:verify] == :verify_peer
+      assert opts[:cacertfile] == ~c"/etc/ssl/certs/rds.pem"
+    end
+
+    test "a blank DATABASE_SSL_VERIFY keeps the historical verify_none", %{base: base} do
+      cfg =
+        base
+        |> Map.merge(%{"DATABASE_SSL_VERIFY" => "", "DATABASE_SSL_CA_FILE" => ""})
+        |> read_prod()
+
+      assert cfg[:fountain][Fountain.Repo][:ssl_opts] == [verify: :verify_none]
+    end
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -181,8 +181,17 @@ config :fountain, :metrics_port, metrics_port
 # error tracker running on the same cluster as the app is down exactly when
 # it is needed. The sentry package is API-compatible with GlitchTip, so
 # pointing SENTRY_DSN at one later is the whole migration.
+#
+# "" counts as unset (#497): the compose file passes `${SENTRY_DSN:-}`, and a
+# blank string is not a DSN the SDK should be asked to parse.
+sentry_dsn =
+  case System.get_env("SENTRY_DSN") do
+    blank when blank in [nil, ""] -> nil
+    dsn -> dsn
+  end
+
 config :sentry,
-  dsn: System.get_env("SENTRY_DSN"),
+  dsn: sentry_dsn,
   environment_name: System.get_env("SENTRY_ENVIRONMENT", to_string(env)),
   # Correlates events with deploys: "this started with sha-…". Set by the
   # image build; nil locally, which the SDK accepts.
@@ -286,10 +295,17 @@ config :fountain,
 # Only widen this to cover addresses that are genuinely proxies — anything
 # trusted here is stepped over, so an over-broad list lets a client spoof its
 # way past rate limiting.
-if proxies = System.get_env("TRUSTED_PROXIES") do
-  config :fountain,
-         :trusted_proxies,
-         proxies |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+# "" counts as unset (#497): the compose file passes `${TRUSTED_PROXIES:-}`,
+# and a blank value must leave the built-in default in place rather than
+# replacing it with an empty list.
+case System.get_env("TRUSTED_PROXIES") do
+  blank when blank in [nil, ""] ->
+    :ok
+
+  proxies ->
+    config :fountain,
+           :trusted_proxies,
+           proxies |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
 end
 
 # Inference credentials are per-user (BYO, ADR 0008) and live in the
@@ -513,8 +529,18 @@ if config_env() == :prod do
   # verify_none is the historical behaviour. DATABASE_SSL_VERIFY=true turns on
   # real certificate verification, using an explicit CA bundle when given and
   # the OS trust store otherwise — no extra dependency, and OTP loads it.
+  #
+  # A blank CA file counts as unset (#497): the compose file passes
+  # `${DATABASE_SSL_CA_FILE:-}`, and verify_peer with `cacertfile: ''` would
+  # reject every certificate instead of falling back to the OS trust store.
+  database_ssl_ca_file =
+    case System.get_env("DATABASE_SSL_CA_FILE") do
+      blank when blank in [nil, ""] -> nil
+      path -> path
+    end
+
   database_ssl_opts =
-    case {System.get_env("DATABASE_SSL_VERIFY"), System.get_env("DATABASE_SSL_CA_FILE")} do
+    case {System.get_env("DATABASE_SSL_VERIFY"), database_ssl_ca_file} do
       {"true", nil} ->
         [verify: :verify_peer, cacerts: :public_key.cacerts_get(), depth: 3]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,11 +49,21 @@ services:
       # A stock postgres image does not serve TLS, and this was hardcoded on —
       # which is why a compose setup could not have worked before.
       DATABASE_SSL: "false"
+      # Only meaningful against an external Postgres that serves TLS (which
+      # also means editing DATABASE_URL and DATABASE_SSL above): verify its
+      # certificate instead of the default encrypted-but-unauthenticated mode.
+      DATABASE_SSL_VERIFY: ${DATABASE_SSL_VERIFY:-}
+      DATABASE_SSL_CA_FILE: ${DATABASE_SSL_CA_FILE:-}
 
       # Absolute and scheme-ful: it builds the links in verification emails and
       # is handed to every sprite as FOUNTAIN_BASE_URL. Change it if you reach
       # this instance by anything other than localhost.
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:4000}
+
+      # Behind a reverse proxy, set this to the proxy's address range before
+      # exposing the instance — otherwise per-IP rate limits collapse into a
+      # single bucket keyed on the proxy's address.
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-}
 
       # Required, but enforced by the app at boot (config/runtime.exs raises
       # a descriptive error for either one missing or empty) rather than by a
@@ -99,6 +109,9 @@ services:
       # Open by default so the first account can be created. Close it once
       # yours exists.
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
+
+      # Error tracking. Off unless set — nothing leaves the instance.
+      SENTRY_DSN: ${SENTRY_DSN:-}
 
       # Compose is the single-operator quickstart, so the first account to
       # verify becomes the admin (ADR 0011) — register before exposing the


### PR DESCRIPTION
Closes #497. Re-derives the remainder of unmerged PR #428 (the #397 fix lost in the stacked-PR rebase) on current main — the five pass-throughs that already re-landed via other PRs are untouched; this adds the three that never did.

## What was broken

`TRUSTED_PROXIES`, `SENTRY_DSN`, and `DATABASE_SSL_VERIFY`/`DATABASE_SSL_CA_FILE` are documented in docs/self-hosting.md, but the compose `environment:` block never passed them through — setting them in `.env` silently did nothing. The TRUSTED_PROXIES one has security weight: the docs' "putting it on the internet" section instructs operators to set it, and without the pass-through per-IP rate limits collapse into one bucket keyed on the proxy's address.

## Changes

- **docker-compose.yml** — pass all four through as `${VAR:-}`, keeping the `environment:` block a reviewable contract (the #428 rationale for not switching to `env_file: .env`, which would inject compose-side keys like `POSTGRES_PASSWORD` into the app process).
- **.env.compose.example** — advertise them; the existing config_reference drift test enforces that every advertised key is passed through, so this pairing can't silently regress again.
- **config/runtime.exs** — #396-style blank→absent guards for the compose `${VAR:-}` empty-string case:
  - blank `TRUSTED_PROXIES` leaves the built-in default in place rather than replacing it with an empty trusted list;
  - blank `SENTRY_DSN` stays `nil` rather than being handed to the SDK;
  - `verify_peer` with a blank CA file falls back to the OS trust store instead of rejecting every certificate.
- **compose_passthrough_config_test.exs** — pins the blank-string behaviour of all three. The tests SET the vars to `""` rather than deleting them (deleting is how the #396 predecessors went unnoticed), and were verified to fail (3/7) against the unguarded runtime.exs.

The rest of the preserved branch's ~300 test lines (mailer blank guards, SPRITES_TOKEN test, drift test) already landed on main via other PRs and are not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)