### PR TITLE
docs: keep the CLI's hosted default base_url, call the self-host footgun out

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -18,6 +18,11 @@ import (
 	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
 )
 
+// DefaultBaseURL is the hosted instance, kept as the fallback deliberately
+// (#498): the hosted service is the primary audience. Self-hosters must point
+// the CLI at their own instance (FOUNTAIN_BASE_URL, recorded by `auth login`)
+// before exporting FOUNTAIN_API_KEY — docs/cli.md and docs/self-hosting.md
+// call the footgun out.
 const DefaultBaseURL = "https://fountain.inevitable.fyi"
 
 // ErrNoAPIKey signals that no API key is configured.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -210,3 +210,8 @@ FOUNTAIN_API_KEY=ftn_... FOUNTAIN_BASE_URL=https://other.example.com fountain ag
 Resolution order for both the key and the URL is: environment variable, then the
 active profile in the credentials file, then — for the URL only — the built-in
 default `https://fountain.inevitable.fyi`.
+
+**Self-hosting?** That built-in default is the hosted instance, not yours. Run
+`fountain auth login` with `FOUNTAIN_BASE_URL` pointed at your instance before
+anything else: an unconfigured CLI with `FOUNTAIN_API_KEY` exported sends that
+key to `fountain.inevitable.fyi`. Configure the URL before the key.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -99,6 +99,17 @@ backup instead.
 The CLI and the server are cut from the same tag, so matching versions are the
 tested pairing.
 
+The CLI's built-in default `base_url` is the hosted instance
+(`https://fountain.inevitable.fyi`), not yours. Point it at your instance
+before exporting an API key — otherwise the first unconfigured command sends
+that key to the hosted domain:
+
+```bash
+FOUNTAIN_BASE_URL=https://your-fountain.example.com fountain auth login
+```
+
+`auth login` records the URL in the saved profile, so this is a one-time step.
+
 ## Back up `MASTER_SECRETS_KEY`
 
 Every environment and vault secret is encrypted with a per-tenant key that is


### PR DESCRIPTION
Closes #498 with option 3 from the issue: **keep the hosted default** — the hosted service is the CLI's primary audience — and make the footgun explicit in the self-host docs instead.

The footgun: a self-hoster who installs the CLI and runs a command with `FOUNTAIN_API_KEY` exported but no `FOUNTAIN_BASE_URL` configured sends that key to `fountain.inevitable.fyi`.

- **docs/cli.md** — warning right beside the resolution-order section: configure the URL before the key.
- **docs/self-hosting.md** — the CLI paragraph now spells out the one-time `FOUNTAIN_BASE_URL=... fountain auth login` step and why it must come before exporting a key.
- **cli/internal/config/config.go** — comment on `DefaultBaseURL` recording the decision so the next audit doesn't reopen it.

No behavior change, so no Upgrade-notes line. This also unblocks the `docs/cli.md` half of #499: the page documents the compiled-in default, which now stays accurate as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)