### PR TITLE
billing: trial sweeper — daily backstop for stale trialing rows

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,12 @@ config :fountain, Oban,
        {"7 * * * *", Fountain.Workers.SandboxReaper},
        # 05:41 UTC — after the 03:17 backup and the 04:23 retention prune, so
        # a backup always captures the accounts before the sweep removes them.
-       {"41 5 * * *", Fountain.Workers.UnverifiedAccountPruner}
+       {"41 5 * * *", Fountain.Workers.UnverifiedAccountPruner},
+       # 06:53 UTC — backstop for trials Stripe never closed out (#504). The
+       # 48h grace inside the sweep means Stripe's webhook retries always get
+       # the first shot; daily is fast enough for a backstop. The worker
+       # no-ops when billing is disabled.
+       {"53 6 * * *", Fountain.Workers.TrialSweeper}
      ]}
   ]
 

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -378,6 +378,134 @@ defmodule Fountain.Billing do
   end
 
   @doc """
+  Expires `trialing` accounts whose trial end passed more than `:grace_hours`
+  ago and whose status never moved (#504).
+
+  Stripe normally ends trials itself — the signup subscription carries
+  `missing_payment_method: "cancel"` and the cancellation webhook flips the
+  status. This sweep is the backstop for when that signal never lands: a
+  missed webhook, or a local-only trial that has no subscription at all (no
+  `STRIPE_PRICE_ID`). Access is already denied at read time the moment the
+  clock passes (`check_active/1`); what a stale row corrupts is recorded
+  status — admin counts, status-based queries — and the trial-expired email,
+  which only fires on a status transition.
+
+  For an account with a Stripe subscription the truth is in Stripe, so the
+  sweep retrieves the live subscription and applies its status through the
+  same changeset-and-lifecycle-email path webhooks use — a trial extended in
+  Stripe's dashboard updates the local clock rather than being cancelled. The
+  retrieve happens before the row lock is taken (third-party HTTP must not
+  run inside the transaction — see `BillingWebhookSyncRaceTest`), and the row
+  is re-checked under lock so a concurrent conversion is never overwritten.
+  Accounts with no subscription are flipped to `canceled` directly.
+
+  The grace window (default 48h) gives Stripe's webhook and its retries the
+  first shot; rows with a nil `trial_ends_at` are left alone — legacy
+  accounts are deliberately grandfathered and newer nil rows already fail
+  closed at read time.
+
+  Returns counts: `:expired` (local trials cancelled), `:synced` (status
+  adopted from Stripe), `:extended` (Stripe still trialing; clock repaired),
+  `:skipped` (Stripe error or concurrent change — retried next run).
+  """
+  @spec expire_stale_trials(keyword()) :: %{
+          expired: non_neg_integer(),
+          synced: non_neg_integer(),
+          extended: non_neg_integer(),
+          skipped: non_neg_integer()
+        }
+  def expire_stale_trials(opts \\ []) do
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+    grace_hours = Keyword.get(opts, :grace_hours, 48)
+    batch = Keyword.get(opts, :batch, 100)
+    cutoff = DateTime.add(now, -grace_hours * 3600, :second)
+
+    stale =
+      Repo.all(
+        from(u in User,
+          where: u.subscription_status == "trialing",
+          where: u.trial_ends_at < ^cutoff,
+          order_by: [asc: u.trial_ends_at],
+          limit: ^batch
+        )
+      )
+
+    Enum.reduce(stale, %{expired: 0, synced: 0, extended: 0, skipped: 0}, fn user, acc ->
+      Map.update!(acc, sweep_stale_trial(user, now), &(&1 + 1))
+    end)
+  end
+
+  defp sweep_stale_trial(%User{stripe_subscription_id: sub_id} = user, now)
+       when is_binary(sub_id) and sub_id != "" do
+    case Stripe.Subscription.retrieve(sub_id) do
+      {:ok, %Stripe.Subscription{status: "trialing"} = sub} ->
+        # Stripe still says trialing — the local clock is behind (a trial
+        # extended in the dashboard). Adopt Stripe's end; don't cancel.
+        apply_trial_sweep(
+          user,
+          %{trial_ends_at: unix_field(Map.get(sub, :trial_end))},
+          now,
+          :extended
+        )
+
+      {:ok, %Stripe.Subscription{} = sub} ->
+        apply_trial_sweep(
+          user,
+          %{
+            subscription_status: coerce_status(sub.status, "trial_sweep"),
+            trial_ends_at: unix_field(Map.get(sub, :trial_end)),
+            current_period_end: unix_field(Map.get(sub, :current_period_end))
+          },
+          now,
+          :synced
+        )
+
+      {:error, reason} ->
+        Logger.warning(
+          "trial sweep: Stripe retrieve failed for #{user.id} (#{sub_id}): #{inspect(reason)}"
+        )
+
+        :skipped
+    end
+  end
+
+  defp sweep_stale_trial(%User{} = user, now) do
+    # No subscription (local trial): nothing else will ever flip this row.
+    apply_trial_sweep(user, %{subscription_status: "canceled"}, now, :expired)
+  end
+
+  # The attrs were decided outside the transaction (the Stripe read must not
+  # hold a row lock); the recheck under lock makes them safe to apply — a row
+  # that converted, was comped, or was deleted in the meantime is left alone.
+  defp apply_trial_sweep(%User{id: user_id}, attrs, now, tally) do
+    result =
+      Repo.transaction(fn ->
+        case get_user_for_update(user_id) do
+          %User{subscription_status: "trialing"} = user ->
+            user
+            |> User.billing_changeset(
+              Map.put(attrs, :subscription_synced_at, DateTime.truncate(now, :second))
+            )
+            |> Repo.update!()
+            |> tap(&enqueue_lifecycle_email(user.subscription_status, &1))
+
+          _ ->
+            Repo.rollback(:not_trialing)
+        end
+      end)
+
+    case result do
+      {:ok, _user} -> tally
+      {:error, :not_trialing} -> :skipped
+    end
+  end
+
+  defp unix_field(ts) when is_integer(ts),
+    do: DateTime.from_unix!(ts) |> DateTime.truncate(:second)
+
+  defp unix_field(_), do: nil
+
+  @doc """
   Marks an account comped: free access granted by an operator, indefinitely.
 
   Any live Stripe subscription is cancelled first — a comped account must not

--- a/ee/lib/fountain/workers/trial_sweeper.ex
+++ b/ee/lib/fountain/workers/trial_sweeper.ex
@@ -1,0 +1,39 @@
+defmodule Fountain.Workers.TrialSweeper do
+  @moduledoc """
+  Daily backstop that expires stale `trialing` rows (#504).
+
+  Stripe ends trials itself — the signup subscription cancels when the trial
+  lapses with no payment method, and the webhook flips the status — but that
+  depends on a signal arriving. When it doesn't (missed webhook, or a
+  local-only trial with no Stripe subscription), the row sits at `trialing`
+  forever. Access is already denied at read time (`Billing.check_active/1`
+  checks the clock), so what this sweep repairs is recorded status: admin
+  counts, status-based queries, and the trial-expired lifecycle email.
+
+  Thin shell over `Billing.expire_stale_trials/1`; no-ops when billing is
+  disabled — on a self-hosted instance trial state is not stamped at all
+  (#480) and there is nothing to sweep.
+  """
+
+  use Oban.Worker, queue: :billing, max_attempts: 1
+
+  alias Fountain.Billing
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_job) do
+    if Billing.enabled?() do
+      counts = Billing.expire_stale_trials()
+
+      if counts |> Map.values() |> Enum.sum() > 0 do
+        Logger.info(
+          "trial sweeper: expired #{counts.expired} local, synced #{counts.synced} " <>
+            "from Stripe, repaired #{counts.extended} clocks, skipped #{counts.skipped}"
+        )
+      end
+    end
+
+    :ok
+  end
+end

--- a/ee/test/fountain/trial_sweeper_test.exs
+++ b/ee/test/fountain/trial_sweeper_test.exs
@@ -1,0 +1,149 @@
+defmodule Fountain.TrialSweeperTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Accounts.User
+  alias Fountain.{Billing, Repo}
+  alias Fountain.Workers.LifecycleEmail
+
+  @now ~U[2026-08-05 12:00:00Z]
+  # Comfortably past the 48h grace window relative to @now.
+  @long_expired ~U[2026-08-01 12:00:00Z]
+
+  defp trialing_user(attrs) do
+    user = insert_verified_user()
+
+    {:ok, user} =
+      user
+      |> User.billing_changeset(Map.merge(%{subscription_status: "trialing"}, attrs))
+      |> Repo.update()
+
+    user
+  end
+
+  describe "expire_stale_trials/1 — local trials (no Stripe subscription)" do
+    test "flips a long-expired trial to canceled and enqueues the trial-expired email" do
+      user = trialing_user(%{trial_ends_at: @long_expired})
+
+      assert %{expired: 1, synced: 0, extended: 0, skipped: 0} =
+               Billing.expire_stale_trials(now: @now)
+
+      reloaded = Repo.reload(user)
+      assert reloaded.subscription_status == "canceled"
+      assert DateTime.compare(reloaded.subscription_synced_at, @now) == :eq
+
+      assert_enqueued(
+        worker: LifecycleEmail,
+        args: %{"user_id" => user.id, "email" => "trial_expired"}
+      )
+    end
+
+    test "leaves a trial inside the grace window alone" do
+      user = trialing_user(%{trial_ends_at: DateTime.add(@now, -3600, :second)})
+
+      assert %{expired: 0, synced: 0, extended: 0, skipped: 0} =
+               Billing.expire_stale_trials(now: @now)
+
+      assert Repo.reload(user).subscription_status == "trialing"
+    end
+
+    test "leaves nil trial_ends_at rows alone" do
+      user = trialing_user(%{trial_ends_at: nil})
+
+      assert %{expired: 0, synced: 0, extended: 0, skipped: 0} =
+               Billing.expire_stale_trials(now: @now)
+
+      assert Repo.reload(user).subscription_status == "trialing"
+    end
+
+    test "never touches non-trialing statuses" do
+      users =
+        for status <- ["active", "past_due", "canceled", "comped"] do
+          {status, trialing_user(%{subscription_status: status, trial_ends_at: @long_expired})}
+        end
+
+      assert %{expired: 0, synced: 0, extended: 0, skipped: 0} =
+               Billing.expire_stale_trials(now: @now)
+
+      for {status, user} <- users do
+        assert Repo.reload(user).subscription_status == status
+      end
+    end
+  end
+
+  describe "expire_stale_trials/1 — Stripe-backed trials" do
+    test "adopts a canceled Stripe status through the lifecycle-email path" do
+      user =
+        trialing_user(%{trial_ends_at: @long_expired, stripe_subscription_id: "sub_sweep_1"})
+
+      expect(Stripe.Subscription, :retrieve, fn "sub_sweep_1" ->
+        {:ok,
+         %Stripe.Subscription{
+           id: "sub_sweep_1",
+           status: "canceled",
+           trial_end: DateTime.to_unix(@long_expired)
+         }}
+      end)
+
+      assert %{expired: 0, synced: 1, extended: 0, skipped: 0} =
+               Billing.expire_stale_trials(now: @now)
+
+      reloaded = Repo.reload(user)
+      assert reloaded.subscription_status == "canceled"
+      assert DateTime.compare(reloaded.subscription_synced_at, @now) == :eq
+
+      assert_enqueued(
+        worker: LifecycleEmail,
+        args: %{"user_id" => user.id, "email" => "trial_expired"}
+      )
+    end
+
+    test "repairs the local clock when Stripe says the trial was extended" do
+      new_end = DateTime.add(@now, 7 * 24 * 3600, :second)
+
+      user =
+        trialing_user(%{trial_ends_at: @long_expired, stripe_subscription_id: "sub_sweep_2"})
+
+      expect(Stripe.Subscription, :retrieve, fn "sub_sweep_2" ->
+        {:ok,
+         %Stripe.Subscription{
+           id: "sub_sweep_2",
+           status: "trialing",
+           trial_end: DateTime.to_unix(new_end)
+         }}
+      end)
+
+      assert %{expired: 0, synced: 0, extended: 1, skipped: 0} =
+               Billing.expire_stale_trials(now: @now)
+
+      reloaded = Repo.reload(user)
+      assert reloaded.subscription_status == "trialing"
+      assert DateTime.compare(reloaded.trial_ends_at, new_end) == :eq
+
+      refute_enqueued(worker: LifecycleEmail)
+    end
+
+    test "skips the row when Stripe is unreachable, leaving it for the next run" do
+      user =
+        trialing_user(%{trial_ends_at: @long_expired, stripe_subscription_id: "sub_sweep_3"})
+
+      expect(Stripe.Subscription, :retrieve, fn "sub_sweep_3" -> {:error, :stripe_down} end)
+
+      assert %{expired: 0, synced: 0, extended: 0, skipped: 1} =
+               Billing.expire_stale_trials(now: @now)
+
+      assert Repo.reload(user).subscription_status == "trialing"
+      refute_enqueued(worker: LifecycleEmail)
+    end
+  end
+
+  describe "TrialSweeper worker" do
+    test "sweeps via perform/1" do
+      user = trialing_user(%{trial_ends_at: @long_expired})
+
+      assert :ok = perform_job(Fountain.Workers.TrialSweeper, %{})
+
+      assert Repo.reload(user).subscription_status == "canceled"
+    end
+  end
+end


### PR DESCRIPTION
Closes #504, part of #500 (item 4d).

There was no continuous mechanism moving `trialing` rows off that status when the trial end passes without conversion — Stripe's webhook is the primary path, but a missed delivery or a local-only trial (no `STRIPE_PRICE_ID`) left rows stale forever. Access was already denied at read time; what a stale row corrupts is recorded status (admin counts, status-based queries) and the trial-expired lifecycle email, which only fires on a transition.

**`Billing.expire_stale_trials/1`** sweeps `trialing` rows whose `trial_ends_at` passed more than 48h ago (grace so Stripe's webhook retries always win when they're going to):

- **Stripe-backed rows**: retrieve the live subscription and adopt its status through the same changeset-and-lifecycle-email path webhooks use. If Stripe says the trial was *extended* (dashboard action), the local clock is repaired instead of cancelling. The Stripe read happens **before** the row lock (the #393 rule: no third-party HTTP inside the transaction) and the row is rechecked under `FOR UPDATE` so a concurrent conversion is never overwritten. Stripe errors skip the row for the next run.
- **Local trials** (no subscription): flipped to `canceled` directly — nothing else will ever flip them.
- Nil `trial_ends_at` rows are left alone (legacy grandfathering; newer nils already fail closed at read time).

**`Workers.TrialSweeper`** runs daily at 06:53 UTC via Oban cron and no-ops when billing is disabled (self-host instances don't stamp trial state at all, #480).

8 tests: local expiry + email, grace window, nil dates, non-trialing statuses untouched, Stripe canceled-adoption, Stripe extension repair, Stripe-down skip, worker perform. `mix precommit` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)