### PR TITLE
billing: emit telemetry when a usage event is dropped (#503)

### DIFF
--- a/apps/fountain/lib/fountain/telemetry.ex
+++ b/apps/fountain/lib/fountain/telemetry.ex
@@ -125,7 +125,8 @@ defmodule Fountain.Telemetry do
       @prefix ++ [:stage],
       @prefix ++ [:sandbox, :reclaimed],
       @prefix ++ [:reaper, :run],
-      @prefix ++ [:reaper, :untracked]
+      @prefix ++ [:reaper, :untracked],
+      @prefix ++ [:usage, :dropped]
     ]
 
     :telemetry.attach_many(

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -115,6 +115,14 @@ defmodule FountainWeb.Telemetry do
         tags: [:event_type],
         description: "Admin audit events rejected at write time (lost trail rows)"
       ),
+      # Any non-zero value here means billing data is being lost (#503) —
+      # record_usage/5 swallows failures by contract, so this counter is the
+      # only signal that distinguishes "no usage" from "metering broken".
+      counter("fountain.usage.dropped.count",
+        event_name: [:fountain, :usage, :dropped],
+        tags: [:event_type, :kind],
+        description: "Usage events dropped at write time (lost billing data)"
+      ),
       distribution("fountain.fresh_provision.stop.duration",
         event_name: [:fountain, :fresh_provision, :stop],
         measurement: :duration,

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -125,6 +125,9 @@ defmodule FountainWeb.MetricsTest do
         # Audit.record_admin/1 rejection path (#451) — exercised by
         # Fountain.AuditTest's rejected-write telemetry test
         [:fountain, :audit, :admin_record_rejected],
+        # Billing.record_usage/5 swallow path (#503) — exercised by
+        # Fountain.UsageMeteringTest's dropped-usage telemetry test
+        [:fountain, :usage, :dropped],
         # ConversationServer: provision watchdog (#329) and durable-output
         # budget (#331) — the two cost signals #405 gave subscribers
         [:fountain, :provision, :deadline_exceeded],

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -1365,9 +1365,10 @@ defmodule Fountain.Billing do
 
   Metering is bookkeeping: it must never be able to fail a conversation. A bad
   changeset, a dropped connection or an unexpected raise is logged and swallowed,
-  the same contract `Fountain.Audit.record/1` uses. The cost is that a silent
-  metering outage looks like zero usage — worth an alert once there is anything
-  to bill.
+  the same contract `Fountain.Audit.record/1` uses. Because the swallow makes a
+  metering outage look like zero usage, every drop also emits
+  `[:fountain, :usage, :dropped]` — any non-zero count on that counter means
+  billing data is being lost (#503).
   """
   @spec record_usage(binary(), String.t(), binary() | nil, String.t() | nil, map()) ::
           {:ok, UsageEvent.t()} | {:error, term()}
@@ -1377,13 +1378,23 @@ defmodule Fountain.Billing do
         ok
 
       {:error, %Ecto.Changeset{} = cs} ->
-        Logger.warning("usage: #{event_type} rejected: #{inspect(cs.errors)}")
+        usage_dropped(event_type, "rejected", cs.errors)
         {:error, :invalid}
     end
   rescue
     e ->
-      Logger.warning("usage: #{event_type} failed: #{Exception.message(e)}")
+      usage_dropped(event_type, "exception", Exception.message(e))
       {:error, :exception}
+  end
+
+  defp usage_dropped(event_type, kind, reason) do
+    Logger.warning("usage: #{event_type} #{kind}, event dropped: #{inspect(reason)}")
+
+    :telemetry.execute(
+      [:fountain, :usage, :dropped],
+      %{count: 1},
+      %{event_type: event_type, kind: kind}
+    )
   end
 
   @doc """

--- a/ee/test/fountain/usage_metering_test.exs
+++ b/ee/test/fountain/usage_metering_test.exs
@@ -12,6 +12,8 @@ defmodule Fountain.UsageMeteringTest do
 
   use Fountain.DataCase, async: true
 
+  import ExUnit.CaptureLog
+
   alias Fountain.{Billing, Conversations}
   alias Fountain.Billing.UsageEvent
   alias Fountain.Repo
@@ -245,6 +247,57 @@ defmodule Fountain.UsageMeteringTest do
 
       assert {:error, :invalid} =
                Billing.record_usage(user.id, "not_a_real_event", nil, nil, %{})
+    end
+
+    test "a dropped event emits the usage.dropped telemetry event (#503)" do
+      # The swallow contract makes a metering outage indistinguishable from
+      # zero usage; this counter is the signal that says "broken, not idle".
+      user = insert_verified_user()
+      test_pid = self()
+      handler_id = "usage-dropped-#{inspect(self())}"
+
+      :telemetry.attach(
+        handler_id,
+        [:fountain, :usage, :dropped],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:dropped, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      capture_log(fn ->
+        Billing.record_usage(user.id, "not_a_real_event", nil, nil, %{})
+      end)
+
+      assert_receive {:dropped, %{count: 1}, %{event_type: "not_a_real_event", kind: "rejected"}}
+    end
+
+    test "a raise inside emit is swallowed and counted as dropped" do
+      user = insert_verified_user()
+      test_pid = self()
+      handler_id = "usage-raise-#{inspect(self())}"
+
+      :telemetry.attach(
+        handler_id,
+        [:fountain, :usage, :dropped],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:dropped, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      # Metadata that Jason can't encode makes Repo.insert raise, which is as
+      # close to a real infrastructure failure as a unit test can get.
+      capture_log(fn ->
+        assert {:error, :exception} =
+                 Billing.record_usage(user.id, "turn_started", nil, nil, %{bad: self()})
+      end)
+
+      assert_receive {:dropped, %{count: 1}, %{event_type: "turn_started", kind: "exception"}}
     end
 
     test "a metering failure does not fail the operation being measured" do


### PR DESCRIPTION
## Summary
- `Billing.record_usage/5` keeps its swallow contract (metering must never fail a conversation) but now emits `[:fountain, :usage, :dropped]` from both error arms — changeset rejection and rescue — tagged by `event_type` and `kind`.
- Registered `counter("fountain.usage.dropped.count")` in `FountainWeb.Telemetry` (same shape as the `audit.admin_record_rejected` counter from #451) and subscribed the event in `Fountain.Telemetry.attach_default_logger/0`'s one-shots, so drops show up in the JSON log stream and the Prometheus scrape without any new infrastructure.
- Pinned the new event in the metrics "every subscribed event has a live producer" test (#310 guard).

Any non-zero value on `fountain.usage.dropped.count` now means "metering broken", distinguishing it from genuine zero usage.

Closes #503

## Test plan
- Two new tests in `usage_metering_test.exs`: a rejected changeset and a raised insert each emit the event with the right tags. Both verified to fail with the fix reverted.
- `mix precommit` green locally (2006 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)