### PR TITLE
admin: force-resync a user's subscription state from Stripe (#502)

### DIFF
--- a/apps/fountain/lib/fountain/audit/admin_event.ex
+++ b/apps/fountain/lib/fountain/audit/admin_event.ex
@@ -49,6 +49,7 @@ defmodule Fountain.Audit.AdminEvent do
     admin.account.unsuspended
     admin.user.viewed
     admin.conversation.viewed
+    admin.stripe.resynced
   )
 
   def event_types, do: @event_types

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -112,10 +112,10 @@ defmodule FountainWeb.AdminLive.Index do
   end
 
   # The buttons are hidden when billing is disabled, but events can still be
-  # sent by hand (#399's lesson) — and both actions talk to Stripe.
+  # sent by hand (#399's lesson) — and all of these actions talk to Stripe.
   @impl true
   def handle_event(event, _params, %{assigns: %{billing_enabled: false}} = socket)
-      when event in ~w(extend_trial toggle_comp) do
+      when event in ~w(extend_trial toggle_comp resync_stripe) do
     {:noreply, put_flash(socket, :error, "Billing is disabled on this instance")}
   end
 
@@ -163,6 +163,14 @@ defmodule FountainWeb.AdminLive.Index do
   @impl true
   def handle_event("toggle_comp", %{"id" => id}, socket) do
     with_target_user(socket, id, fn user -> do_toggle_comp(socket, user) end)
+  end
+
+  # The in-app remedy for webhook drift (#502): re-read the subscription of
+  # record from Stripe and adopt what it says, without a Stripe dashboard
+  # round-trip.
+  @impl true
+  def handle_event("resync_stripe", %{"id" => id}, socket) do
+    with_target_user(socket, id, fn user -> do_resync_stripe(socket, user) end)
   end
 
   @impl true
@@ -286,6 +294,49 @@ defmodule FountainWeb.AdminLive.Index do
       {{:error, _}, _} ->
         {:noreply,
          put_flash(socket, :error, "Could not change comp — Stripe cancellation failed")}
+    end
+  end
+
+  defp do_resync_stripe(socket, user) do
+    case Billing.resync_from_stripe(user) do
+      {:ok, %Accounts.User{} = updated} ->
+        Fountain.Audit.record_admin(%{
+          actor_user_id: socket.assigns.current_user.id,
+          target_user_id: user.id,
+          event_type: "admin.stripe.resynced",
+          metadata: %{
+            "email" => user.email,
+            "from" => user.subscription_status,
+            "to" => updated.subscription_status
+          }
+        })
+
+        {:noreply,
+         socket
+         |> assign_users()
+         |> put_flash(:info, "Resynced from Stripe — status #{updated.subscription_status}")}
+
+      {:ok, :sync_enqueued} ->
+        Fountain.Audit.record_admin(%{
+          actor_user_id: socket.assigns.current_user.id,
+          target_user_id: user.id,
+          event_type: "admin.stripe.resynced",
+          metadata: %{"email" => user.email, "outcome" => "customer_sync_enqueued"}
+        })
+
+        {:noreply,
+         put_flash(
+           socket,
+           :info,
+           "No subscription on record — customer sync enqueued, check back shortly"
+         )}
+
+      {:error, :comped} ->
+        {:noreply,
+         put_flash(socket, :error, "Account is comped — Stripe does not drive its status")}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Could not resync — Stripe refused the read")}
     end
   end
 
@@ -727,6 +778,15 @@ defmodule FountainWeb.AdminLive.Index do
                       class="text-xs text-zinc-500 hover:text-zinc-900 underline"
                     >
                       {if u.subscription_status == "comped", do: "revoke comp", else: "comp"}
+                    </button>
+                    <button
+                      :if={u.subscription_status != "comped"}
+                      phx-click="resync_stripe"
+                      phx-value-id={u.id}
+                      title="Re-read subscription state from Stripe — repairs webhook drift"
+                      class="text-xs text-zinc-500 hover:text-zinc-900 underline"
+                    >
+                      resync
                     </button>
                   </div>
                 </div>

--- a/apps/fountain/test/fountain_web/live/admin_billing_disabled_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_billing_disabled_test.exs
@@ -51,6 +51,7 @@ defmodule FountainWeb.AdminBillingDisabledTest do
         refute html =~ "sort=trial_end"
         refute html =~ ~s(phx-submit="extend_trial")
         refute html =~ ~s(phx-click="toggle_comp")
+        refute html =~ ~s(phx-click="resync_stripe")
         refute html =~ "dashboard.stripe.com"
       end)
     end
@@ -86,6 +87,9 @@ defmodule FountainWeb.AdminBillingDisabledTest do
         assert html =~ "Billing is disabled on this instance"
 
         html = render_click(lv, "toggle_comp", %{"id" => target.id})
+        assert html =~ "Billing is disabled on this instance"
+
+        html = render_click(lv, "resync_stripe", %{"id" => target.id})
         assert html =~ "Billing is disabled on this instance"
       end)
     end

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -767,4 +767,56 @@ defmodule FountainWeb.AdminLiveErrorTest do
       assert html =~ "Failed to update role"
     end
   end
+
+  describe "AdminLive.Index — resync_stripe (#502)" do
+    test "adopts Stripe's state and records an audit event", %{conn: conn} do
+      admin = insert_admin()
+
+      user =
+        Fountain.Repo.update!(
+          Ecto.Changeset.change(insert_verified_user(),
+            subscription_status: "past_due",
+            stripe_customer_id: "cus_lv_resync",
+            stripe_subscription_id: "sub_lv_resync"
+          )
+        )
+
+      result =
+        {:ok, %Stripe.Subscription{id: "sub_lv_resync", status: "active", trial_end: nil}}
+
+      stub(Stripe.Subscription, :retrieve, fn "sub_lv_resync" -> result end)
+      stub(Stripe.Subscription, :retrieve, fn "sub_lv_resync", _opts -> result end)
+
+      conn = login_user(conn, admin)
+      {:ok, lv, _html} = live(conn, ~p"/admin")
+
+      html =
+        lv
+        |> element("button[phx-value-id='#{user.id}'][phx-click='resync_stripe']")
+        |> render_click()
+
+      assert html =~ "Resynced from Stripe"
+      assert Fountain.Repo.reload!(user).subscription_status == "active"
+
+      assert Enum.any?(
+               Fountain.Audit._unsafe_list_recent_admin(10),
+               &(&1.event_type == "admin.stripe.resynced" and &1.target_user_id == user.id)
+             )
+    end
+
+    test "a user with no subscription of record gets a customer sync enqueued", %{conn: conn} do
+      admin = insert_admin()
+      user = insert_verified_user()
+
+      conn = login_user(conn, admin)
+      {:ok, lv, _html} = live(conn, ~p"/admin")
+
+      html =
+        lv
+        |> element("button[phx-value-id='#{user.id}'][phx-click='resync_stripe']")
+        |> render_click()
+
+      assert html =~ "customer sync enqueued"
+    end
+  end
 end

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -506,6 +506,68 @@ defmodule Fountain.Billing do
   defp unix_field(_), do: nil
 
   @doc """
+  Admin repair for webhook drift (#502): re-reads the subscription of record
+  from Stripe and applies what Stripe says, writing the same fields the
+  webhook path writes.
+
+  `subscription_synced_at` is stamped with the read time, so a delayed older
+  webhook event arriving after the resync is dropped by `sync_subscription/1`'s
+  ordering guard instead of undoing the repair.
+
+  Comped accounts are refused — a comp is an operator decision Stripe does not
+  override, same guard as webhook sync. A user with no subscription of record
+  has nothing to re-read; `Workers.StripeCustomerSync` is enqueued instead,
+  which creates whichever of customer/trial subscription is missing.
+  """
+  @spec resync_from_stripe(User.t()) ::
+          {:ok, User.t() | :sync_enqueued} | {:error, term()}
+  def resync_from_stripe(%User{subscription_status: "comped"}), do: {:error, :comped}
+
+  def resync_from_stripe(%User{stripe_subscription_id: sub_id} = user)
+      when is_binary(sub_id) and sub_id != "" do
+    case Stripe.Subscription.retrieve(sub_id) do
+      {:ok, %Stripe.Subscription{} = sub} -> apply_resync(user, sub)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def resync_from_stripe(%User{} = user) do
+    case Fountain.Workers.StripeCustomerSync.enqueue(user) do
+      {:ok, _} -> {:ok, :sync_enqueued}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # The Stripe read happens outside the transaction (it must not hold a row
+  # lock); the recheck under lock keeps the comp guard honest against an
+  # operator comping the account between read and write.
+  defp apply_resync(%User{id: user_id}, %Stripe.Subscription{} = sub) do
+    attrs = %{
+      subscription_status: coerce_status(sub.status, "admin_resync"),
+      trial_ends_at: unix_field(Map.get(sub, :trial_end)),
+      current_period_end: unix_field(Map.get(sub, :current_period_end)),
+      cancel_at_period_end: Map.get(sub, :cancel_at_period_end) == true,
+      subscription_synced_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    }
+
+    Repo.transaction(fn ->
+      case get_user_for_update(user_id) do
+        nil ->
+          Repo.rollback(:user_not_found)
+
+        %User{subscription_status: "comped"} ->
+          Repo.rollback(:comped)
+
+        %User{} = user ->
+          user
+          |> User.billing_changeset(attrs)
+          |> Repo.update!()
+          |> tap(&enqueue_lifecycle_email(user.subscription_status, &1))
+      end
+    end)
+  end
+
+  @doc """
   Marks an account comped: free access granted by an operator, indefinitely.
 
   Any live Stripe subscription is cancelled first — a comped account must not

--- a/ee/test/fountain/billing_test.exs
+++ b/ee/test/fountain/billing_test.exs
@@ -567,6 +567,104 @@ defmodule Fountain.BillingTest do
     end
   end
 
+  describe "resync_from_stripe/1 (#502)" do
+    # stripity_stripe's functions carry a default opts arg, and Mimic stubs
+    # are arity-specific — stub both arities or the miss silently falls
+    # through to the live client (#474).
+    defp stub_retrieve(sub_id, result) do
+      stub(Stripe.Subscription, :retrieve, fn ^sub_id -> result end)
+      stub(Stripe.Subscription, :retrieve, fn ^sub_id, _opts -> result end)
+    end
+
+    test "adopts what Stripe says for a drifted account" do
+      period_end =
+        DateTime.utc_now() |> DateTime.add(30, :day) |> DateTime.truncate(:second)
+
+      user =
+        billing_state(insert_verified_user(),
+          subscription_status: "past_due",
+          stripe_customer_id: "cus_resync",
+          stripe_subscription_id: "sub_resync"
+        )
+
+      stub_retrieve(
+        "sub_resync",
+        {:ok,
+         %Stripe.Subscription{
+           id: "sub_resync",
+           status: "active",
+           trial_end: nil,
+           current_period_end: DateTime.to_unix(period_end),
+           cancel_at_period_end: false
+         }}
+      )
+
+      assert {:ok, updated} = Billing.resync_from_stripe(user)
+      assert updated.subscription_status == "active"
+      assert updated.current_period_end == period_end
+      assert updated.subscription_synced_at
+    end
+
+    test "a webhook event older than the resync is dropped as stale" do
+      user =
+        billing_state(insert_verified_user(),
+          subscription_status: "past_due",
+          stripe_customer_id: "cus_resync_stale",
+          stripe_subscription_id: "sub_resync_stale"
+        )
+
+      stub_retrieve(
+        "sub_resync_stale",
+        {:ok, %Stripe.Subscription{id: "sub_resync_stale", status: "active", trial_end: nil}}
+      )
+
+      assert {:ok, _} = Billing.resync_from_stripe(user)
+
+      # A delayed delivery from before the repair must not undo it.
+      old_event = %Stripe.Event{
+        type: "customer.subscription.updated",
+        created: DateTime.to_unix(DateTime.utc_now()) - 3600,
+        data: %{
+          object: %{
+            id: "sub_resync_stale",
+            customer: "cus_resync_stale",
+            status: "canceled",
+            trial_end: nil
+          }
+        }
+      }
+
+      assert {:ok, :stale} = Billing.sync_subscription(old_event)
+      assert Repo.reload!(user).subscription_status == "active"
+    end
+
+    test "comped accounts are refused without touching Stripe" do
+      user = user_with_status("comped")
+      assert {:error, :comped} = Billing.resync_from_stripe(user)
+      assert Repo.reload!(user).subscription_status == "comped"
+    end
+
+    test "no subscription of record enqueues StripeCustomerSync instead" do
+      user = insert_verified_user()
+
+      assert {:ok, :sync_enqueued} = Billing.resync_from_stripe(user)
+      assert_enqueued(worker: Fountain.Workers.StripeCustomerSync, args: %{user_id: user.id})
+    end
+
+    test "a Stripe error is returned and the account is untouched" do
+      user =
+        billing_state(insert_verified_user(),
+          subscription_status: "past_due",
+          stripe_subscription_id: "sub_resync_err"
+        )
+
+      stub_retrieve("sub_resync_err", {:error, %Stripe.ApiErrors{message: "nope"}})
+
+      assert {:error, %Stripe.ApiErrors{}} = Billing.resync_from_stripe(user)
+      assert Repo.reload!(user).subscription_status == "past_due"
+    end
+  end
+
   describe "sync_subscription/1 — coerce_status catch-all" do
     setup do
       user = insert_verified_user()


### PR DESCRIPTION
## Summary
First half of #502 — the webhook-drift remedy. The invoice view is deliberately not here; #502 stays open for it.

- **`Billing.resync_from_stripe/1`**: retrieves the subscription of record from Stripe and adopts its status/trial end/period end/cancel-at-period-end — the same fields webhook sync writes, applied under the same `FOR UPDATE` + comp-guard discipline. `subscription_synced_at` is stamped with the read time, so a delayed older webhook event arriving after the repair is dropped by the existing ordering guard instead of undoing it (pinned by a test).
- Comped accounts are refused — a comp is an operator decision Stripe does not override, matching `sync_subscription/1`. A user with no subscription of record has nothing to re-read, so `StripeCustomerSync` is enqueued instead (it creates whichever of customer/trial is missing, idempotently).
- **Admin UI**: a "resync" action in the billing column of `/admin`, next to extend-trial/comp, with the same billing-disabled refusal for hand-sent events (#399's lesson) and a new `admin.stripe.resynced` audit event.

## Test plan
- Unit tests: drift adoption, stale-webhook-after-resync dropped, comped refusal, no-subscription enqueue path (`assert_enqueued`), Stripe-error passthrough. Stripe stubbed at both arities (the #474 arity trap).
- LiveView tests: button click end-to-end with audit assertion; billing-disabled guard extended to `resync_stripe`.
- All new tests verified to fail with the lib changes reverted (7 failures).
- `mix precommit` green locally (2011 tests, 0 failures).

Part of #502 / #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)