### PR TITLE
billing ops: persist Stripe webhook failures and surface them on /admin (#501)

### DIFF
--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -557,6 +557,36 @@ defmodule FountainWeb.AdminLive.Index do
             <span class="tabular-nums">{Map.get(@billing_overview.status_counts, status, 0)}</span>
           </.link>
         </div>
+        <div
+          :if={@billing_overview.failed_events != []}
+          class="bg-red-50 border border-red-200 rounded px-4 py-3 text-sm space-y-2"
+        >
+          <div class="font-medium text-red-900">
+            {length(@billing_overview.failed_events)} webhook {if length(@billing_overview.failed_events) == 1,
+              do: "event is",
+              else: "events are"} failing — subscription state may lag Stripe
+          </div>
+          <table class="w-full text-sm bg-white rounded border border-red-100 font-mono">
+            <tbody>
+              <tr
+                :for={f <- @billing_overview.failed_events}
+                class="border-b border-red-50 last:border-0"
+              >
+                <td class="px-3 py-1.5 text-xs text-zinc-500 whitespace-nowrap">
+                  {format_ts(f.last_failed_at)}
+                </td>
+                <td class="px-3 py-1.5 text-xs">{f.event_type}</td>
+                <td class="px-3 py-1.5 text-xs text-zinc-400">{f.event_id}</td>
+                <td class="px-3 py-1.5 text-xs text-red-700" title={f.error}>
+                  ×{f.failure_count} · {String.slice(f.error, 0, 80)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div :if={@billing_overview.failed_events == []} class="text-xs text-zinc-400">
+          No unresolved webhook failures.
+        </div>
         <details class="text-sm">
           <summary class="cursor-pointer text-zinc-500 hover:text-zinc-900">
             Recent webhook events ({length(@billing_overview.recent_events)})

--- a/apps/fountain/priv/repo/migrations/20260805090000_create_stripe_webhook_failures.exs
+++ b/apps/fountain/priv/repo/migrations/20260805090000_create_stripe_webhook_failures.exs
@@ -1,0 +1,22 @@
+defmodule Fountain.Repo.Migrations.CreateStripeWebhookFailures do
+  use Ecto.Migration
+
+  # A failed webhook leaves no DB trace: the stripe_events claim row rolls
+  # back with the failed transaction, so failures exist only in Stripe's
+  # dashboard and our logs — subscription state silently lags reality until
+  # someone thinks to look (#501). One row per event id, upserted on each
+  # retry, resolved when a later delivery of the same event succeeds.
+  def change do
+    create table(:stripe_webhook_failures, primary_key: false) do
+      add :event_id, :string, primary_key: true
+      add :event_type, :string, null: false
+      add :error, :text, null: false
+      add :failure_count, :integer, null: false, default: 1
+      add :first_failed_at, :utc_datetime, null: false
+      add :last_failed_at, :utc_datetime, null: false
+      add :resolved_at, :utc_datetime
+    end
+
+    create index(:stripe_webhook_failures, [:last_failed_at])
+  end
+end

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -570,6 +570,25 @@ defmodule FountainWeb.AdminLiveTest do
       # recent webhook events listed
       assert html =~ "evt_admin_test"
       assert html =~ "checkout.session.completed"
+      # no failures → the quiet all-clear, not the red alert (#501)
+      assert html =~ "No unresolved webhook failures"
+    end
+
+    test "unresolved webhook failures render as a red alert (#501)", %{conn: conn} do
+      admin = insert_admin()
+
+      Fountain.Billing.record_webhook_failure(
+        %Stripe.Event{id: "evt_admin_fail", type: "invoice.paid"},
+        :database_unavailable
+      )
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "webhook event is failing"
+      assert html =~ "evt_admin_fail"
+      assert html =~ "database_unavailable"
+      refute html =~ "No unresolved webhook failures"
     end
   end
 

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -737,6 +737,81 @@ defmodule Fountain.Billing do
 
   defp prepare_event(_event), do: :ok
 
+  @doc """
+  Best-effort record of a webhook processing failure (#501).
+
+  A failed apply rolls the `stripe_events` claim back by design, so without
+  this a failing event leaves zero DB trace — the failure exists only in
+  Stripe's dashboard and our logs, and subscription state silently lags
+  reality. One row per event id: a retried delivery bumps `failure_count`
+  and `last_failed_at` (and un-resolves a previously resolved row) rather
+  than accumulating a row per attempt across Stripe's three days of retries.
+
+  Best-effort on the same contract as `record_usage/5`: recording the
+  failure must never change the webhook response.
+  """
+  @spec record_webhook_failure(Stripe.Event.t(), term()) :: :ok | :error
+  def record_webhook_failure(%Stripe.Event{id: id, type: type}, reason) when is_binary(id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    error = reason |> inspect() |> String.slice(0, 500)
+
+    Repo.insert_all(
+      "stripe_webhook_failures",
+      [
+        %{
+          event_id: id,
+          event_type: type,
+          error: error,
+          failure_count: 1,
+          first_failed_at: now,
+          last_failed_at: now
+        }
+      ],
+      on_conflict: [
+        set: [error: error, last_failed_at: now, resolved_at: nil],
+        inc: [failure_count: 1]
+      ],
+      conflict_target: :event_id
+    )
+
+    :ok
+  rescue
+    e ->
+      Logger.error(
+        "webhook failure record failed for #{inspect(reason)}: #{Exception.message(e)}"
+      )
+
+      :error
+  end
+
+  def record_webhook_failure(_event, _reason), do: :ok
+
+  @doc """
+  Marks a previously recorded webhook failure resolved — called when a later
+  delivery of the same event processes successfully (or dedupes/goes stale,
+  which means the event no longer needs applying). Best-effort, like
+  `record_webhook_failure/2`.
+  """
+  @spec resolve_webhook_failure(String.t() | nil) :: :ok
+  def resolve_webhook_failure(event_id) when is_binary(event_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Repo.update_all(
+      from(f in "stripe_webhook_failures",
+        where: f.event_id == ^event_id and is_nil(f.resolved_at)
+      ),
+      set: [resolved_at: now]
+    )
+
+    :ok
+  rescue
+    e ->
+      Logger.error("webhook failure resolve failed for #{event_id}: #{Exception.message(e)}")
+      :ok
+  end
+
+  def resolve_webhook_failure(_), do: :ok
+
   # Atomic claim: the unique primary key is what makes concurrent deliveries of
   # the same event resolve to exactly one winner.
   defp claim_event(id, type) do
@@ -1296,11 +1371,14 @@ defmodule Fountain.Billing do
     not revenue. Honesty note: this breaks the day there is a second price;
     the config is a single amount on purpose so that day is loud.
   - `recent_events` — the last processed webhook events, newest first.
-    Failures are not listed because failed deliveries are never claimed —
-    they exist only in Stripe's dashboard and our logs today.
+  - `failed_events` — unresolved webhook processing failures, most recently
+    failed first (#501). Failed deliveries are never claimed (the claim rolls
+    back with the failed apply), so these come from `stripe_webhook_failures`,
+    written by the controller outside the rolled-back transaction.
 
   Options: `:price_cents` overrides the configured price (tests), `:now`
-  pins the clock, `:event_limit` caps `recent_events` (default 10).
+  pins the clock, `:event_limit` caps `recent_events`/`failed_events`
+  (default 10).
   """
   @spec overview_admin(keyword()) :: map()
   def overview_admin(opts \\ []) do
@@ -1347,6 +1425,21 @@ defmodule Fountain.Billing do
           select: %{id: e.id, type: e.type, inserted_at: e.inserted_at}
       )
 
+    failed_events =
+      Repo.all(
+        from f in "stripe_webhook_failures",
+          where: is_nil(f.resolved_at),
+          order_by: [desc: f.last_failed_at],
+          limit: ^event_limit,
+          select: %{
+            event_id: f.event_id,
+            event_type: f.event_type,
+            error: f.error,
+            failure_count: f.failure_count,
+            last_failed_at: f.last_failed_at
+          }
+      )
+
     active = Map.get(status_counts, "active", 0)
 
     %{
@@ -1354,7 +1447,8 @@ defmodule Fountain.Billing do
       trials_ending_7d: trials_ending_7d,
       conversions_this_month: conversions_this_month,
       mrr_cents: price_cents && active * price_cents,
-      recent_events: recent_events
+      recent_events: recent_events,
+      failed_events: failed_events
     }
   end
 

--- a/ee/lib/fountain_web/controllers/stripe_webhook_controller.ex
+++ b/ee/lib/fountain_web/controllers/stripe_webhook_controller.ex
@@ -5,10 +5,13 @@ defmodule FountainWeb.StripeWebhookController do
   Verifies the `Stripe-Signature` header using `Stripe.Webhook.construct_event/3`,
   then dispatches to `Fountain.Billing.sync_subscription/1`.
 
-  Per Stripe's guidelines the endpoint always returns 200 to Stripe, even on
-  processing errors (which are logged and monitored via telemetry). A 400 is
-  returned only on signature verification failure; Stripe uses this to detect
-  misconfigured webhook secrets.
+  Transient processing errors answer 500 so Stripe redelivers; permanent ones
+  (unknown customer) answer 200 so Stripe stops. Both are logged and persisted
+  to `stripe_webhook_failures` (#501) — written here, outside the claim
+  transaction that a failed apply rolls back — and surfaced on the admin
+  billing overview. A later successful delivery of the same event marks its
+  failure row resolved. A 400 is returned only on signature verification
+  failure; Stripe uses this to detect misconfigured webhook secrets.
 
   When no webhook secret is configured (nil or empty), every request is
   rejected with 400 instead of being verified against an empty HMAC key (#390).
@@ -70,28 +73,36 @@ defmodule FountainWeb.StripeWebhookController do
     case Billing.handle_event(event) do
       {:ok, :duplicate} ->
         Logger.info("[stripe_webhook] Ignoring duplicate delivery of #{event.id}")
+        Billing.resolve_webhook_failure(event.id)
         :ok
 
       {:ok, :stale} ->
         Logger.info("[stripe_webhook] Ignoring out-of-order event #{event.id}")
+        Billing.resolve_webhook_failure(event.id)
         :ok
 
       {:ok, _} ->
+        Billing.resolve_webhook_failure(event.id)
         :ok
 
       # Retrying cannot fix an event whose customer we do not recognise, so
       # acknowledge it rather than making Stripe redeliver for three days.
+      # Recorded as a failure all the same: the event is gone for good, and
+      # that is exactly what an operator needs to see (#501).
       {:error, :user_not_found} ->
         Logger.error("[stripe_webhook] No user for event #{event.id} (#{event.type})")
+        Billing.record_webhook_failure(event, :user_not_found)
         :ok
 
       {:error, reason} ->
         Logger.error("[stripe_webhook] Event processing error: #{inspect(reason)}")
+        Billing.record_webhook_failure(event, reason)
         :retry
     end
   rescue
     e ->
       Logger.error("[stripe_webhook] Unhandled error: #{Exception.message(e)}")
+      Billing.record_webhook_failure(event, e)
       :retry
   end
 

--- a/ee/test/fountain/billing_overview_test.exs
+++ b/ee/test/fountain/billing_overview_test.exs
@@ -108,4 +108,51 @@ defmodule Fountain.BillingOverviewTest do
       refute is_nil(hd(events).inserted_at)
     end
   end
+
+  describe "overview_admin/1 — failed events (#501)" do
+    defp fail_event!(event) do
+      Billing.record_webhook_failure(event, :database_unavailable)
+    end
+
+    test "lists unresolved failures, most recently failed first" do
+      fail_event!(%Stripe.Event{id: "evt_fail_a", type: "customer.subscription.updated"})
+      fail_event!(%Stripe.Event{id: "evt_fail_b", type: "invoice.paid"})
+
+      %{failed_events: failed} = Billing.overview_admin(now: @now)
+
+      assert Enum.map(failed, & &1.event_id) |> Enum.sort() == ["evt_fail_a", "evt_fail_b"]
+      assert [%{error: error, failure_count: 1} | _] = failed
+      assert error =~ "database_unavailable"
+    end
+
+    test "a repeated failure is one row with a bumped count, not a row per retry" do
+      event = %Stripe.Event{id: "evt_fail_retry", type: "customer.subscription.updated"}
+      fail_event!(event)
+      fail_event!(event)
+      fail_event!(event)
+
+      %{failed_events: failed} = Billing.overview_admin(now: @now)
+
+      assert [%{event_id: "evt_fail_retry", failure_count: 3}] = failed
+    end
+
+    test "a resolved failure disappears; a new failure un-resolves it" do
+      event = %Stripe.Event{id: "evt_fail_resolve", type: "customer.subscription.updated"}
+      fail_event!(event)
+
+      :ok = Billing.resolve_webhook_failure("evt_fail_resolve")
+      assert %{failed_events: []} = Billing.overview_admin(now: @now)
+
+      fail_event!(event)
+
+      assert %{failed_events: [%{event_id: "evt_fail_resolve"}]} =
+               Billing.overview_admin(now: @now)
+    end
+
+    test "an event with no id records nothing rather than raising" do
+      assert :ok = Billing.record_webhook_failure(%Stripe.Event{id: nil, type: "x"}, :boom)
+      assert :ok = Billing.resolve_webhook_failure(nil)
+      assert %{failed_events: []} = Billing.overview_admin(now: @now)
+    end
+  end
 end

--- a/ee/test/fountain_web/controllers/stripe_webhook_controller_test.exs
+++ b/ee/test/fountain_web/controllers/stripe_webhook_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule FountainWeb.StripeWebhookControllerTest do
   use FountainWeb.ConnCase, async: true
 
+  import Ecto.Query
   import Mimic
 
   setup :verify_on_exit!
@@ -196,6 +197,83 @@ defmodule FountainWeb.StripeWebhookControllerTest do
         )
 
       assert conn.status == 200
+    end
+  end
+
+  describe "POST /api/stripe/webhook — failure persistence (#501)" do
+    defp failure_row(event_id) do
+      Fountain.Repo.one(
+        from f in "stripe_webhook_failures",
+          where: f.event_id == ^event_id,
+          select: %{
+            type: f.event_type,
+            error: f.error,
+            count: f.failure_count,
+            resolved_at: f.resolved_at
+          }
+      )
+    end
+
+    defp post_stubbed(conn, event) do
+      stub(Stripe.Webhook, :construct_event, fn _body, _sig, _secret -> {:ok, event} end)
+
+      conn
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> Plug.Conn.put_req_header("stripe-signature", "t=1,v1=validhash")
+      |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :post, "/api/stripe/webhook", @raw_body)
+    end
+
+    @tag capture_log: true
+    test "a transient failure persists a row; a retried failure bumps the count", %{conn: conn} do
+      event = %Stripe.Event{
+        id: "evt_fail_persist",
+        type: "customer.subscription.updated",
+        data: %{object: %{status: "active", customer: "cus_x", trial_end: nil}}
+      }
+
+      stub(Fountain.Billing, :handle_event, fn _event -> {:error, :database_unavailable} end)
+
+      assert post_stubbed(conn, event).status == 500
+
+      row = failure_row("evt_fail_persist")
+      assert %{count: 1, resolved_at: nil, type: "customer.subscription.updated"} = row
+      assert row.error =~ "database_unavailable"
+
+      assert post_stubbed(conn, event).status == 500
+      assert %{count: 2, resolved_at: nil} = failure_row("evt_fail_persist")
+    end
+
+    @tag capture_log: true
+    test "an unknown customer is acked to Stripe but recorded — the event is gone for good",
+         %{conn: conn} do
+      event = %Stripe.Event{
+        id: "evt_fail_nobody",
+        type: "customer.subscription.updated",
+        data: %{object: %{status: "active", customer: "cus_nobody", trial_end: nil}}
+      }
+
+      assert post_stubbed(conn, event).status == 200
+
+      row = failure_row("evt_fail_nobody")
+      assert %{count: 1, resolved_at: nil} = row
+      assert row.error =~ "user_not_found"
+    end
+
+    @tag capture_log: true
+    test "a later successful delivery marks the failure resolved", %{conn: conn} do
+      event = %Stripe.Event{
+        id: "evt_fail_recovers",
+        type: "customer.subscription.updated",
+        data: %{object: %{status: "active", customer: "cus_x", trial_end: nil}}
+      }
+
+      stub(Fountain.Billing, :handle_event, fn _event -> {:error, :database_unavailable} end)
+      assert post_stubbed(conn, event).status == 500
+      assert %{resolved_at: nil} = failure_row("evt_fail_recovers")
+
+      stub(Fountain.Billing, :handle_event, fn _event -> {:ok, :ignored} end)
+      assert post_stubbed(conn, event).status == 200
+      refute failure_row("evt_fail_recovers").resolved_at == nil
     end
   end
 


### PR DESCRIPTION
## Summary
Failed webhook processing was visible only in Stripe's dashboard and our logs — and left zero DB trace, because the `stripe_events` claim row rolls back with the failed apply (deliberately, so redelivery works). An operator had no way to notice subscription state lagging reality without tailing logs.

- **`stripe_webhook_failures` table** — one row per event id. A retried failure bumps `failure_count`/`last_failed_at` instead of accumulating a row per attempt across Stripe's three days of retries; a later successful (or duplicate/stale — i.e. no-longer-needed) delivery of the same event stamps `resolved_at`; a new failure un-resolves it.
- **Recorded in the controller, outside the rolled-back transaction**: the transient `:retry`/500 arm, the rescue arm, and the permanently-dropped `user_not_found` arm (that one still answers 200, but it's exactly the loss an operator needs to see). Best-effort on the `record_usage/5` contract — recording can never change the webhook response.
- **Admin surface**: `Billing.overview_admin/1` gains `failed_events` (unresolved only, most recent first); the `/admin` billing section renders them as a red alert with error text and failure counts, and shows a quiet "No unresolved webhook failures" line otherwise — so a healthy instance is distinguishable from a missing feature.
- **Doc honesty**: the controller moduledoc claimed failures were "monitored via telemetry" — no billing telemetry existed. Rewritten to describe the real mechanism, along with `overview_admin/1`'s "failures are not listed" caveat.

Closes #501. Part of #500.

## Test plan
- Controller tests: transient failure persists + 500s, retry bumps the count, unknown-customer records + 200s, success resolves.
- Overview tests: unresolved-only listing, one-row-per-event upsert, resolve/un-resolve cycle, nil-id no-op.
- LiveView tests: red alert renders with failure details; all-clear line when none.
- All new tests verified to fail with the lib changes reverted (9 failures).
- `mix precommit` green locally (2012 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)