### PR TITLE
tests: stop MasterKeyConfigTest leaking RESEND_API_KEY into the suite

### DIFF
--- a/apps/fountain/test/fountain/compose_passthrough_config_test.exs
+++ b/apps/fountain/test/fountain/compose_passthrough_config_test.exs
@@ -17,6 +17,11 @@ defmodule Fountain.ComposePassthroughConfigTest do
 
   @vars ~w(TRUSTED_PROXIES SENTRY_DSN DATABASE_SSL_VERIFY DATABASE_SSL_CA_FILE)
 
+  # Not under test here, but they change what the prod boot requires (a
+  # configured mail provider demands EMAIL_FROM). Cleared before every read
+  # so a leak from an earlier env-mutating module can't fail these cases.
+  @mail_vars ~w(RESEND_API_KEY SMTP_HOST EMAIL_FROM)
+
   @base %{
     "PHX_SERVER" => "true",
     "SECRET_KEY_BASE" => String.duplicate("a", 64),
@@ -32,7 +37,7 @@ defmodule Fountain.ComposePassthroughConfigTest do
     on_exit(fn ->
       System.put_env(previous)
 
-      for k <- @vars ++ ["MASTER_SECRETS_KEY"],
+      for k <- @vars ++ @mail_vars ++ ["MASTER_SECRETS_KEY"],
           not Map.has_key?(previous, k),
           do: System.delete_env(k)
     end)
@@ -41,7 +46,7 @@ defmodule Fountain.ComposePassthroughConfigTest do
   end
 
   defp read_prod(env) do
-    for k <- @vars, do: System.delete_env(k)
+    for k <- @vars ++ @mail_vars, do: System.delete_env(k)
     System.put_env(env)
     Config.Reader.read!(@runtime_exs, env: :prod)
   end

--- a/apps/fountain/test/fountain/master_key_config_test.exs
+++ b/apps/fountain/test/fountain/master_key_config_test.exs
@@ -33,7 +33,14 @@ defmodule Fountain.MasterKeyConfigTest do
     on_exit(fn ->
       System.put_env(previous)
 
-      for k <- ~w(MASTER_SECRETS_KEY PHX_SERVER EMAIL_FROM PUBLIC_URL),
+      # Every key this setup writes must be listed: put_env(previous) restores
+      # old values but cannot delete keys that were never set before this
+      # module ran. RESEND_API_KEY was missing from this list, so it leaked
+      # into the rest of the suite and made ComposePassthroughConfigTest's
+      # prod boot raise on the EMAIL_FROM guard — but only when this module
+      # drew the earlier seed slot, the same class of flake the #256 comment
+      # above describes.
+      for k <- ~w(MASTER_SECRETS_KEY PHX_SERVER EMAIL_FROM PUBLIC_URL RESEND_API_KEY DATABASE_URL),
           not Map.has_key?(previous, k),
           do: System.delete_env(k)
     end)


### PR DESCRIPTION
## Summary
PR #516's Build and Test failed in `ComposePassthroughConfigTest` — code that PR didn't touch. Root cause: `MasterKeyConfigTest`'s setup writes `RESEND_API_KEY`/`DATABASE_URL` but its `on_exit` cleanup list omitted them (`System.put_env(previous)` restores old values but can't delete keys that didn't exist before). The leaked `RESEND_API_KEY` makes `config/runtime.exs`'s prod evaluation raise on the EMAIL_FROM guard in every later test that evaluates prod config — but only when the seed orders `MasterKeyConfigTest` first, so it's a coin-flip failure. Both modules are `async: false` and mutate process env; this is the same seed-dependent class the #256 comment in that very file warns about.

- `MasterKeyConfigTest` on_exit now deletes every key its setup writes.
- `ComposePassthroughConfigTest.read_prod/1` also clears `RESEND_API_KEY`/`SMTP_HOST`/`EMAIL_FROM` before each read, so it stays hermetic against any future leaker.

## Test plan
- Before: `mix test master_key_config_test.exs compose_passthrough_config_test.exs --seed 0` → 7 failures. After: 0 failures across seeds 0–3 and 49690 (the failing CI run's seed).
- `mix precommit` green (2028 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)