### PR TITLE
self-host: instance-configurable legal identity for /terms and /privacy (#517)

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -74,6 +74,14 @@ FOUNTAIN_IMAGE_TAG=v0.4.1
 # REGISTRATION_ENABLED=false
 # REGISTRATION_ALLOWED_EMAIL_DOMAINS=example.com
 
+# The legal identity /terms and /privacy render — yours, not the Fountain
+# project's. All four or none (partially set refuses to boot). Unset, the
+# pages are hidden and their links removed from signup and the footer.
+# LEGAL_ENTITY=Example Corp Inc.
+# LEGAL_CONTACT_EMAIL=legal@example.com
+# LEGAL_JURISDICTION=the State of Delaware, USA
+# LEGAL_EFFECTIVE_DATE=2026-01-01
+
 # Behind a reverse proxy, list the proxy's address range(s) before exposing
 # the instance, so the app resolves real client IPs from X-Forwarded-For —
 # otherwise per-IP rate limits collapse into one bucket keyed on the proxy.

--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,18 @@ SPRITES_TOKEN=
 # UNVERIFIED_PRUNE_AFTER_DAYS=30
 # UNVERIFIED_PRUNE_EXEMPT=
 
+# ── Legal pages ──────────────────────────────────────────────────────────────
+
+# The legal identity /terms and /privacy render — yours, not the Fountain
+# project's. All four or none: partially set refuses to boot. Unset, the pages
+# are hidden and their links removed (or, with BILLING_ENABLED=true, served
+# with loud {{...}} placeholders — an instance charging money should publish
+# terms).
+# LEGAL_ENTITY=Example Corp Inc.
+# LEGAL_CONTACT_EMAIL=legal@example.com
+# LEGAL_JURISDICTION=the State of Delaware, USA
+# LEGAL_EFFECTIVE_DATE=2026-01-01
+
 # ── Email ────────────────────────────────────────────────────────────────────
 
 # Mail delivery. Production refuses to boot unless one of these is set —

--- a/apps/fountain/lib/fountain/legal.ex
+++ b/apps/fountain/lib/fountain/legal.ex
@@ -1,0 +1,50 @@
+defmodule Fountain.Legal do
+  @moduledoc """
+  The instance operator's legal identity for `/terms` and `/privacy` (#517).
+
+  The pages' copy reads "an agreement between you and {entity}" — so the
+  identity must be the *operator's*, not the upstream project's. It comes from
+  the `LEGAL_ENTITY` / `LEGAL_CONTACT_EMAIL` / `LEGAL_JURISDICTION` /
+  `LEGAL_EFFECTIVE_DATE` env vars (config/runtime.exs), never from source.
+
+  When unconfigured, what happens depends on the billing gate:
+
+    * billing disabled (the self-host default) — the pages are unpublished:
+      links are hidden and the routes render a neutral 404. A self-hosted
+      instance must never serve someone else's terms.
+    * billing enabled — the pages stay up and render the deliberately-loud
+      `{{COMPANY_LEGAL_NAME}}` placeholders from #506. An instance charging
+      money with no published terms should be embarrassing in the browser,
+      not silent.
+  """
+
+  # The loud fallback for a billing-enabled instance that has not set its
+  # legal identity. Deliberately unmistakable in rendered copy (#506).
+  @placeholders %{
+    entity: "{{COMPANY_LEGAL_NAME}}",
+    contact_email: "{{CONTACT_EMAIL}}",
+    jurisdiction: "{{JURISDICTION}}",
+    updated: "{{EFFECTIVE_DATE}}"
+  }
+
+  @doc """
+  The operator-configured legal identity, or `nil` when unset.
+  """
+  def configured, do: Application.get_env(:fountain, :legal)
+
+  @doc """
+  Whether `/terms` and `/privacy` should be linked and served.
+
+  True when the operator configured a legal identity, or when billing is
+  enabled (placeholders stay loud rather than the pages going dark).
+  """
+  def published?, do: configured() != nil or Fountain.Billing.enabled?()
+
+  @doc """
+  The map the legal templates render: the configured identity, the loud
+  placeholders on a billing-enabled instance, or `nil` (pages unpublished).
+  """
+  def content do
+    configured() || if Fountain.Billing.enabled?(), do: @placeholders
+  end
+end

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -42,8 +42,10 @@
     <div class="max-w-5xl mx-auto px-6 py-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-[var(--color-text-muted)]">
       <span>© 2026 Fountain. Managed agent infrastructure for teams who'd rather build than configure.</span>
       <div class="flex items-center gap-4">
-        <a href={~p"/terms"} class="hover:text-[var(--color-text-secondary)] transition-colors">Terms</a>
-        <a href={~p"/privacy"} class="hover:text-[var(--color-text-secondary)] transition-colors">Privacy</a>
+        <%= if Fountain.Legal.published?() do %>
+          <a href={~p"/terms"} class="hover:text-[var(--color-text-secondary)] transition-colors">Terms</a>
+          <a href={~p"/privacy"} class="hover:text-[var(--color-text-secondary)] transition-colors">Privacy</a>
+        <% end %>
         <%= if @current_user do %>
           <a href={~p"/conversations"} class="hover:text-[var(--color-text-secondary)] transition-colors">Go to app</a>
         <% else %>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -2,25 +2,30 @@ defmodule FountainWeb.MarketingController do
   @moduledoc false
   use FountainWeb, :controller
 
-  # Placeholders for the legal pages, kept in one place so filling them is a
-  # single edit. They must be replaced with real values before charging
-  # customers — a page that says {{COMPANY_LEGAL_NAME}} is deliberately loud.
-  @legal %{
-    entity: "{{COMPANY_LEGAL_NAME}}",
-    contact_email: "{{CONTACT_EMAIL}}",
-    jurisdiction: "{{JURISDICTION}}",
-    updated: "{{EFFECTIVE_DATE}}"
-  }
-
   def home(conn, _params) do
     render(conn, :home, layout: {FountainWeb.Layouts, :marketing})
   end
 
   def terms(conn, _params) do
-    render(conn, :terms, layout: {FountainWeb.Layouts, :marketing}, legal: @legal)
+    render_legal(conn, :terms)
   end
 
   def privacy(conn, _params) do
-    render(conn, :privacy, layout: {FountainWeb.Layouts, :marketing}, legal: @legal)
+    render_legal(conn, :privacy)
+  end
+
+  # The legal identity is the operator's, set via LEGAL_* env vars (#517) —
+  # see Fountain.Legal for the unconfigured behaviour (neutral 404 on a
+  # billing-disabled instance, loud placeholders on a billing-enabled one).
+  defp render_legal(conn, page) do
+    case Fountain.Legal.content() do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> render(:legal_unpublished, layout: {FountainWeb.Layouts, :marketing})
+
+      legal ->
+        render(conn, page, layout: {FountainWeb.Layouts, :marketing}, legal: legal)
+    end
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/legal_unpublished.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/legal_unpublished.html.heex
@@ -1,0 +1,10 @@
+<section class="max-w-3xl mx-auto px-6 py-16">
+  <h1 class="text-3xl font-bold tracking-tight text-[var(--color-text-primary)] mb-2">
+    No published terms
+  </h1>
+  <p class="text-[var(--color-text-secondary)] leading-relaxed text-[15px]">
+    The operator of this Fountain instance has not published terms of service
+    or a privacy policy. Contact the operator directly with any questions
+    about how this instance is run.
+  </p>
+</section>

--- a/apps/fountain/lib/fountain_web/controllers/registration_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/registration_html.ex
@@ -71,7 +71,7 @@ defmodule FountainWeb.RegistrationHTML do
           Sign up with GitHub
         </a>
 
-        <p class="text-xs text-zinc-400 text-center">
+        <p :if={Fountain.Legal.published?()} class="text-xs text-zinc-400 text-center">
           By signing up you agree to our
           <a href={~p"/terms"} class="underline">terms of service</a>
           and <a href={~p"/privacy"} class="underline">privacy policy</a>.

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -1,20 +1,30 @@
 defmodule FountainWeb.MarketingControllerTest do
   use FountainWeb.ConnCase, async: true
 
+  # config/test.exs pins :legal, so these cover the configured-identity path;
+  # the unpublished and placeholder paths live in MarketingLegalUnpublishedTest
+  # (async: false — they mutate global app env).
+
   describe "GET /terms" do
-    test "renders the terms of service", %{conn: conn} do
+    test "renders the terms of service with the configured identity", %{conn: conn} do
       body = conn |> get(~p"/terms") |> html_response(200)
       assert body =~ "Terms of Service"
       assert body =~ "Limitation of liability"
+      assert body =~ "Test Legal Entity LLC"
+      assert body =~ "legal@example.com"
+      assert body =~ "the State of Testing"
+      refute body =~ "{{"
       assert body =~ ~p"/privacy"
     end
   end
 
   describe "GET /privacy" do
-    test "renders the privacy policy", %{conn: conn} do
+    test "renders the privacy policy with the configured identity", %{conn: conn} do
       body = conn |> get(~p"/privacy") |> html_response(200)
       assert body =~ "Privacy Policy"
       assert body =~ "Your rights"
+      assert body =~ "Test Legal Entity LLC"
+      refute body =~ "{{"
       assert body =~ ~p"/terms"
     end
   end

--- a/apps/fountain/test/fountain_web/controllers/marketing_legal_unpublished_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_legal_unpublished_test.exs
@@ -1,0 +1,84 @@
+# async: false — these tests mutate the global :legal / :billing_enabled app
+# env, which concurrent tests (marketing pages, billing gate) also read.
+defmodule FountainWeb.MarketingLegalUnpublishedTest do
+  use FountainWeb.ConnCase, async: false
+
+  setup do
+    legal = Application.get_env(:fountain, :legal)
+    billing = Application.get_env(:fountain, :billing_enabled)
+
+    on_exit(fn ->
+      Application.put_env(:fountain, :legal, legal)
+      Application.put_env(:fountain, :billing_enabled, billing)
+    end)
+
+    :ok
+  end
+
+  describe "legal identity unset, billing disabled (self-host default)" do
+    setup do
+      Application.put_env(:fountain, :legal, nil)
+      Application.put_env(:fountain, :billing_enabled, false)
+      :ok
+    end
+
+    test "/terms renders a neutral 404 instead of placeholders", %{conn: conn} do
+      body = conn |> get(~p"/terms") |> html_response(404)
+      assert body =~ "No published terms"
+      refute body =~ "{{"
+      refute body =~ "Terms of Service"
+    end
+
+    test "/privacy renders a neutral 404 instead of placeholders", %{conn: conn} do
+      body = conn |> get(~p"/privacy") |> html_response(404)
+      assert body =~ "No published terms"
+      refute body =~ "{{"
+      refute body =~ "Privacy Policy"
+    end
+
+    test "registration form hides the terms/privacy agreement line", %{conn: conn} do
+      body = conn |> get(~p"/auth/register") |> html_response(200)
+      refute body =~ ~p"/terms"
+      refute body =~ ~p"/privacy"
+      refute body =~ "By signing up you agree"
+    end
+
+    test "marketing footer hides the terms/privacy links", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+      refute body =~ ~p"/terms"
+      refute body =~ ~p"/privacy"
+    end
+  end
+
+  describe "legal identity unset, billing enabled" do
+    setup do
+      Application.put_env(:fountain, :legal, nil)
+      Application.put_env(:fountain, :billing_enabled, true)
+      :ok
+    end
+
+    # An instance charging money must not lose its terms pages — they stay up
+    # with #506's deliberately-loud placeholders until the operator sets the
+    # LEGAL_* vars.
+    test "/terms stays up with loud placeholders", %{conn: conn} do
+      body = conn |> get(~p"/terms") |> html_response(200)
+      assert body =~ "Terms of Service"
+      assert body =~ "{{COMPANY_LEGAL_NAME}}"
+    end
+
+    test "/privacy stays up with loud placeholders", %{conn: conn} do
+      body = conn |> get(~p"/privacy") |> html_response(200)
+      assert body =~ "Privacy Policy"
+      assert body =~ "{{COMPANY_LEGAL_NAME}}"
+    end
+
+    test "links remain visible on signup and the footer", %{conn: conn} do
+      signup = conn |> get(~p"/auth/register") |> html_response(200)
+      assert signup =~ ~p"/terms"
+
+      footer = conn |> get(~p"/") |> html_response(200)
+      assert footer =~ ~p"/terms"
+      assert footer =~ ~p"/privacy"
+    end
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -215,6 +215,69 @@ if config_env() != :test do
   config :fountain, :billing_enabled, System.get_env("BILLING_ENABLED", "false") != "false"
 end
 
+# The legal identity /terms and /privacy render (#517). Instance config, not
+# source: a self-hosted operator must never serve the upstream project's legal
+# terms, and the hosted instance's real entity does not belong in the repo.
+# All four or none — a partial set is a typo, and a terms page with a real
+# entity but a blank jurisdiction is broken legal copy, so refuse to boot
+# rather than render it. Unset entirely, the pages are hidden (billing off)
+# or keep #506's loud {{...}} placeholders (billing on) — see Fountain.Legal.
+# Skipped in :test — config/test.exs pins values so the developer's shell
+# cannot leak into the suite.
+if config_env() != :test do
+  legal_vars = [
+    "LEGAL_ENTITY",
+    "LEGAL_CONTACT_EMAIL",
+    "LEGAL_JURISDICTION",
+    "LEGAL_EFFECTIVE_DATE"
+  ]
+
+  legal_values =
+    Map.new(legal_vars, fn var ->
+      case System.get_env(var) do
+        blank when blank in [nil, ""] -> {var, nil}
+        value -> {var, String.trim(value)}
+      end
+    end)
+
+  case Enum.split_with(legal_vars, &legal_values[&1]) do
+    {_set, []} ->
+      config :fountain, :legal, %{
+        entity: legal_values["LEGAL_ENTITY"],
+        contact_email: legal_values["LEGAL_CONTACT_EMAIL"],
+        jurisdiction: legal_values["LEGAL_JURISDICTION"],
+        updated: legal_values["LEGAL_EFFECTIVE_DATE"]
+      }
+
+    {[], _unset} ->
+      config :fountain, :legal, nil
+
+      # A billing-enabled instance is charging money with no published terms.
+      # Warn hard rather than refuse to boot: /terms and /privacy keep serving
+      # the loud {{COMPANY_LEGAL_NAME}} placeholders, which is the visible
+      # enforcement, and a raise here would take down a running deployment
+      # over copy rather than correctness.
+      if env == :prod and System.get_env("BILLING_ENABLED", "false") != "false" do
+        IO.puts(:stderr, """
+
+        WARNING: BILLING_ENABLED is set but no legal identity is configured.
+        /terms and /privacy are rendering {{COMPANY_LEGAL_NAME}} placeholders
+        to your paying users. Set LEGAL_ENTITY, LEGAL_CONTACT_EMAIL,
+        LEGAL_JURISDICTION, and LEGAL_EFFECTIVE_DATE.
+        """)
+      end
+
+    {set, unset} ->
+      raise """
+      Legal identity is partially configured: #{Enum.join(set, ", ")} set,
+      but #{Enum.join(unset, ", ")} missing. /terms and /privacy need all
+      four (entity, contact email, jurisdiction, effective date) to render
+      coherent legal copy — set the missing ones, or unset all four to leave
+      the pages unpublished.
+      """
+  end
+end
+
 # Registration was open to the world with no way to close it. A self-hoster
 # exposing an instance had no control over who signed up, and on the hosted
 # side every signup consumes the platform Sprites token.

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,6 +30,16 @@ config :ueberauth, Ueberauth.Strategy.Github.OAuth,
 # toggles it per-test via the application env.
 config :fountain, :billing_enabled, true
 
+# Legal identity pinned (LEGAL_* env vars are not read in :test — see
+# config/runtime.exs) so the developer's shell can't change suite behavior;
+# unpublished-page tests set :legal to nil through the application env.
+config :fountain, :legal, %{
+  entity: "Test Legal Entity LLC",
+  contact_email: "legal@example.com",
+  jurisdiction: "the State of Testing",
+  updated: "2026-01-01"
+}
+
 # A known webhook secret so StripeWebhookController's fail-closed secret
 # resolution (#390) succeeds; signature-path tests sign payloads with the
 # value they read back from this key, exercising the real construct_event.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,13 @@ services:
       # yours exists.
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
 
+      # Legal identity for /terms and /privacy (#517). Empty means unset:
+      # the pages are hidden rather than rendering someone else's terms.
+      LEGAL_ENTITY: ${LEGAL_ENTITY:-}
+      LEGAL_CONTACT_EMAIL: ${LEGAL_CONTACT_EMAIL:-}
+      LEGAL_JURISDICTION: ${LEGAL_JURISDICTION:-}
+      LEGAL_EFFECTIVE_DATE: ${LEGAL_EFFECTIVE_DATE:-}
+
       # Error tracking. Off unless set — nothing leaves the instance.
       SENTRY_DSN: ${SENTRY_DSN:-}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,17 @@ signup with no visible error. See [Email](self-hosting.md#email).
 | `STRIPE_PRICE_ID` | — | for checkout | The subscription price surfaced by Checkout. Unset with billing enabled, signups get a purely local 14-day trial and a logged warning |
 | `STRIPE_PRICE_MONTHLY_CENTS` | — | no | Monthly price in cents (e.g. `2900`), display-only: feeds the admin billing overview's MRR tile. Unset, the tile shows a placeholder instead of a fabricated number |
 
+## Legal pages
+
+The identity rendered on `/terms` and `/privacy` — the operator's, not the Fountain project's. Set all four or none: a partial set refuses to boot. With none set, the pages return 404 and their links disappear from signup and the footer — unless billing is enabled, in which case the pages stay up with loud `{{...}}` placeholders until you configure them (an instance charging money should publish terms).
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `LEGAL_ENTITY` | — | no | The legal entity operating this instance (e.g. `Example Corp Inc.`) |
+| `LEGAL_CONTACT_EMAIL` | — | no | Contact address shown on both pages |
+| `LEGAL_JURISDICTION` | — | no | Governing law / venue (e.g. `the State of Delaware, USA`) |
+| `LEGAL_EFFECTIVE_DATE` | — | no | The "Last updated" date on both pages |
+
 ## Proxies and origins
 
 | Variable | Default | Required | Effect |

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -106,6 +106,10 @@ spec:
             # hosted instance is the deployment that opts in.
             - name: BILLING_ENABLED
               value: "true"
+            # TODO(#500): before billing launch, set LEGAL_ENTITY,
+            # LEGAL_CONTACT_EMAIL, LEGAL_JURISDICTION, LEGAL_EFFECTIVE_DATE
+            # (#517) — until then /terms and /privacy render loud
+            # {{COMPANY_LEGAL_NAME}} placeholders and boot logs a warning.
             # Display-only price for the admin billing overview's MRR tile
             # (#286). Matches the live price (price_1TVSgwDbTpLaSfbPV8fLtPT9,
             # $29/mo as of 2026-08-02) — the API only exposes the price *id*,


### PR DESCRIPTION
Closes #517.

## What

The legal identity on `/terms` and `/privacy` — entity, contact email, jurisdiction, effective date — moves from a compile-time module attribute in `MarketingController` to instance config: `LEGAL_ENTITY`, `LEGAL_CONTACT_EMAIL`, `LEGAL_JURISDICTION`, `LEGAL_EFFECTIVE_DATE`, read in `config/runtime.exs` into `:fountain, :legal` and surfaced through a new `Fountain.Legal` module.

Behavior by configuration:

| State | `/terms` + `/privacy` | Links (signup, footer) |
|---|---|---|
| All four vars set | Rendered with the operator's identity | Shown |
| Unset, billing disabled (self-host default) | Neutral "no published terms" page, 404 | Hidden |
| Unset, billing enabled | **Unchanged**: #506's loud `{{COMPANY_LEGAL_NAME}}` placeholders, plus a hard boot warning on stderr | Shown |
| Partially set | Refuses to boot — a terms page with a real entity but a blank jurisdiction is broken legal copy | — |

## Why the billing-enabled fallback instead of refusing to boot

#517 offered "refuse to boot or warn hard". The hosted deployment already runs `BILLING_ENABLED=true` with no legal values, so a boot refusal would crash-loop prod on the next rollout over copy rather than correctness. The loud placeholder page *is* the visible enforcement (the point of #506's design), so a billing-enabled instance keeps serving it, plus a stderr warning at boot. `k8s/deployment.yaml` carries a TODO(#500) to set the four vars before billing launch — that satisfies the #500 pre-launch requirement without baking our entity into source.

## Also

- `LEGAL_*` passed through `docker-compose.yml` / advertised in `.env.compose.example` and `.env.example`; documented in `docs/configuration.md` (the config-reference drift tests enforce all of this).
- `config/test.exs` pins a test identity and runtime.exs skips `LEGAL_*` in `:test`, so a developer's shell can't change suite behavior (same pattern as `BILLING_ENABLED` / `FIRST_USER_ADMIN`).
- Tests: configured path in `MarketingControllerTest` (async), unpublished + placeholder paths in a new `MarketingLegalUnpublishedTest` (`async: false` — mutates global app env). Verified the new tests fail against the pre-change code (6 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)