### PR TITLE
billing: widen past_due/canceled access to read-only conversations (#505)

### DIFF
--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -145,7 +145,25 @@ defmodule FountainWeb.ConversationsLive.Show do
   @impl true
   def handle_info(_msg, socket), do: {:noreply, socket}
 
+  # The read-only contract for past_due/canceled (#505, ADR 0006): viewing is
+  # open, so the gate moved from the router to the events that create spend.
+  # The composer is hidden in the template, but events can still be sent by
+  # hand (#399's lesson). terminate/interrupt stay allowed — they STOP spend,
+  # and blocking a lapsed user from ending a running sprite would protect
+  # spend in reverse. delete stays allowed — removing data isn't consumption.
+  @spend_events ~w(send_prompt update_prompt images_selected)
+
   @impl true
+  def handle_event(event, _params, %{assigns: %{subscription_active: false}} = socket)
+      when event in @spend_events do
+    {:noreply,
+     put_flash(
+       socket,
+       :error,
+       "Your subscription is inactive — this conversation is read-only. Update billing to send prompts."
+     )}
+  end
+
   def handle_event("images_selected", %{"images" => images}, socket) do
     {:noreply, assign(socket, :pending_images, images)}
   end
@@ -397,7 +415,19 @@ defmodule FountainWeb.ConversationsLive.Show do
           </div>
       <% end %>
 
-      <form phx-submit="send_prompt" phx-change="update_prompt" class="bg-white rounded shadow border border-zinc-200 p-4 space-y-3">
+      <div
+        :if={!@subscription_active}
+        class="bg-amber-50 border border-amber-200 rounded px-4 py-3 text-sm text-amber-900"
+      >
+        <span class="font-medium">Read-only:</span>
+        your subscription is inactive, so you can view this conversation and stop
+        running work but not send prompts.
+        <.link navigate={~p"/account/billing"} class="underline font-medium">
+          Update billing
+        </.link>
+      </div>
+
+      <form :if={@subscription_active} phx-submit="send_prompt" phx-change="update_prompt" class="bg-white rounded shadow border border-zinc-200 p-4 space-y-3">
         <.input id="prompt" name="prompt" type="textarea" rows="3"
           value={@prompt} placeholder="Send another prompt…" phx-hook="SubmitOnCmdEnter"/>
         <div :if={@pending_images != []} class="flex flex-wrap gap-2">

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -27,6 +27,10 @@ defmodule FountainWeb.Live.Hooks do
   - `:require_admin` — halts if current_user is absent or not an admin.
     Unauthenticated users are redirected to login (HTTP redirect). Authenticated
     non-admin users are redirected to /dashboard (live redirect).
+  - `:assign_subscription_state` — never halts; assigns `@subscription_active`
+    so read-only-capable views (#505: conversation list/detail) can render for
+    past_due/canceled users while disabling what would spend. Must run after
+    `:require_authenticated_user`.
   """
 
   import Phoenix.LiveView
@@ -77,6 +81,11 @@ defmodule FountainWeb.Live.Hooks do
          )
          |> redirect(to: ~p"/account/billing")}
     end
+  end
+
+  def on_mount(:assign_subscription_state, _params, _session, socket) do
+    active = Billing.check_active(socket.assigns.current_user) == :ok
+    {:cont, assign(socket, :subscription_active, active)}
   end
 
   def on_mount(:require_admin, _params, session, socket) do

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -260,30 +260,35 @@ defmodule FountainWeb.Router do
         TurnImageController,
         :show
 
-    # ── Phase-3-billing: conversation routes require an active subscription ─────────────────
+    # ── Phase-3-billing: starting a conversation requires an active subscription ────────────
     # :require_active_subscription runs after :require_authenticated_user and
-    # redirects to /account/billing on SubscriptionRequiredError.
+    # redirects to /account/billing on SubscriptionRequiredError. Only /new
+    # lives here since #505 — viewing moved to :authenticated below.
     live_session :active_subscription,
       on_mount: [
         {FountainWeb.Live.Hooks, :require_authenticated_user},
         {FountainWeb.Live.Hooks, :require_active_subscription}
       ] do
-      live "/conversations", ConversationsLive.Index, :index
       live "/conversations/new", ConversationsLive.New, :new
-      live "/conversations/:id", ConversationsLive.Show, :show
     end
 
     # ── Read-only and settings routes — no subscription gate ──────────────────────────────────
     # Users can reach these routes even when past_due / canceled so they can
-    # view past logs, manage resources, complete onboarding, and update payment
-    # details. See decisions/0006-hard-stripe-billing-gate-at-launch.md.
+    # view past conversations and logs, manage resources, complete onboarding,
+    # and update payment details. Conversation list/detail moved here in #505
+    # (the ADR 0006 read-only promise): the gate protects spend, so the
+    # spend-creating events inside ConversationsLive.Show are guarded
+    # per-event via @subscription_active instead of gating the whole view.
     live_session :authenticated,
       on_mount: [
-        {FountainWeb.Live.Hooks, :require_authenticated_user}
+        {FountainWeb.Live.Hooks, :require_authenticated_user},
+        {FountainWeb.Live.Hooks, :assign_subscription_state}
       ] do
       live "/dashboard", DashboardLive.Index, :index
       live "/onboarding", OnboardingLive.Wizard, :index
       live "/onboarding/:step", OnboardingLive.Wizard, :show
+      live "/conversations", ConversationsLive.Index, :index
+      live "/conversations/:id", ConversationsLive.Show, :show
       live "/conversations/:id/logs", LogViewerLive.Show, :show
       live "/agents", AgentsLive.Index, :index
       live "/agents/new", AgentsLive.Form, :new

--- a/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
@@ -3,6 +3,8 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
 
   import Phoenix.LiveViewTest
 
+  alias Fountain.Conversations
+
   describe "view_mode loaded from database" do
     setup do
       user = insert_verified_user()
@@ -109,6 +111,93 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
 
       assert html =~ "unsupported image media_type"
       assert Process.alive?(view.pid)
+    end
+  end
+
+  describe "read-only for lapsed subscriptions (#505)" do
+    setup do
+      user =
+        insert_verified_user()
+        |> Fountain.Accounts.User.billing_changeset(%{subscription_status: "past_due"})
+        |> Fountain.Repo.update!()
+
+      conversation = insert_conversation(user_id: user.id)
+      %{user: user, conversation: conversation}
+    end
+
+    test "the conversation renders with a banner and no composer", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
+      conn = login_user(conn, user)
+      {:ok, _view, html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      assert html =~ "Read-only"
+      assert html =~ "/account/billing"
+      refute html =~ ~s(phx-submit="send_prompt")
+    end
+
+    test "hand-sent spend events are refused before reaching the runtime", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
+      # The composer is hidden, but events can still be sent by hand (#399's
+      # lesson) — each spend event must be blocked server-side.
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      for {event, params} <- [
+            {"send_prompt", %{"prompt" => "hi"}},
+            {"update_prompt", %{"prompt" => "hi"}},
+            {"images_selected", %{"images" => []}}
+          ] do
+        html = render_hook(view, event, params)
+        assert html =~ "read-only", "#{event} was not refused"
+      end
+
+      assert Conversations._unsafe_list_turns(conversation.id) == []
+    end
+
+    test "terminate still reaches its handler — stopping spend stays allowed", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      # Reaching the real handler (which terminates via the server-already-dead
+      # path here) is the proof the event was not blocked by the subscription
+      # guard — a lapsed user must be able to stop a running sprite.
+      html = render_hook(view, "terminate", %{})
+      assert html =~ "Terminated"
+    end
+
+    test "delete still works — removing data is not consumption", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
+      conn = login_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      render_hook(view, "delete", %{})
+
+      assert_redirect(view, "/conversations")
+      assert Conversations.get_conversation(conversation.id, user.id) == nil
+    end
+
+    test "an active user still gets the composer and no banner", %{conn: conn} do
+      user = insert_verified_user()
+      conversation = insert_conversation(user_id: user.id)
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+      assert html =~ ~s(phx-submit="send_prompt")
+      refute html =~ "Read-only"
     end
   end
 

--- a/apps/fountain/test/fountain_web/live/hooks_test.exs
+++ b/apps/fountain/test/fountain_web/live/hooks_test.exs
@@ -54,19 +54,21 @@ defmodule FountainWeb.Live.HooksTest do
   # ── :require_active_subscription ────────────────────────────────────────────
 
   describe ":require_active_subscription hook" do
+    # Since #505 only /conversations/new is router-gated — viewing moved to
+    # the :authenticated live_session, tested below.
     test "allows access for a user with trialing subscription", %{conn: conn} do
       user = insert_verified_user()
       # default subscription_status is "trialing"
       conn = login_user(conn, user)
-      {:ok, _lv, html} = live(conn, ~p"/conversations")
-      assert html =~ ~r/conversations/i
+      {:ok, _lv, html} = live(conn, ~p"/conversations/new")
+      assert html =~ ~r/conversation/i
     end
 
     test "redirects canceled user to /account/billing", %{conn: conn} do
       user = insert_canceled_user()
       conn = login_user(conn, user)
 
-      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/conversations")
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/conversations/new")
       assert path == "/account/billing"
     end
 
@@ -74,8 +76,38 @@ defmodule FountainWeb.Live.HooksTest do
       user = insert_past_due_user()
       conn = login_user(conn, user)
 
-      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/conversations")
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/conversations/new")
       assert path == "/account/billing"
+    end
+  end
+
+  # ── :assign_subscription_state — read-only conversation access (#505) ───────
+
+  describe ":assign_subscription_state hook" do
+    test "past_due user can view the conversation list", %{conn: conn} do
+      user = insert_past_due_user()
+      insert_conversation(user_id: user.id)
+      conn = login_user(conn, user)
+
+      {:ok, _lv, html} = live(conn, ~p"/conversations")
+      assert html =~ ~r/conversations/i
+    end
+
+    test "canceled user can view the conversation list", %{conn: conn} do
+      user = insert_canceled_user()
+      conn = login_user(conn, user)
+
+      {:ok, _lv, html} = live(conn, ~p"/conversations")
+      assert html =~ ~r/conversations/i
+    end
+
+    test "past_due user can open a conversation", %{conn: conn} do
+      user = insert_past_due_user()
+      conversation = insert_conversation(user_id: user.id)
+      conn = login_user(conn, user)
+
+      {:ok, _lv, html} = live(conn, ~p"/conversations/#{conversation.id}")
+      assert html =~ conversation.id
     end
   end
 

--- a/decisions/0006-hard-stripe-billing-gate-at-launch.md
+++ b/decisions/0006-hard-stripe-billing-gate-at-launch.md
@@ -81,3 +81,28 @@ a billing gate.
 The remaining `past_due` drift — ADR promised read access to past
 conversations, code delivers log-view-only — is an open decision tracked in
 #505, not resolved here.
+
+## Addendum — 2026-08-05: read-only access widened to match the promise (#505)
+
+Decision (Jake, 2026-08-05): the original read-only window is the intent —
+a card decline must not hide the user's data. The code now matches it:
+
+- `/conversations` and `/conversations/:id` moved from the
+  `:active_subscription` live_session to `:authenticated`, so `past_due` and
+  `canceled` users can list and view their conversations. Only
+  `/conversations/new` remains router-gated.
+- Inside `ConversationsLive.Show`, the gate moved to the events that create
+  spend: `send_prompt`, `update_prompt`, and `images_selected` are refused
+  (flash, no effect) when the subscription is inactive, and the composer is
+  replaced by a read-only banner linking to billing. This is the same
+  "gate protects spend, not features" invariant as the addendum above.
+- `terminate` and `interrupt` stay available to lapsed users deliberately:
+  they *stop* spend, and blocking a lapsed user from ending a running sprite
+  would protect spend in reverse. `delete` stays available too — removing
+  data is not consumption (consistent with ADR 0009).
+- The API surface is unchanged: conversation start/wake/turn processing
+  remain gated by `Billing.check_active/1`; conversation *reads* over the API
+  were and are governed by the addendum above, not this one.
+
+This closes the third bullet of the 2026-08-02 addendum ("`past_due` cannot
+view past conversations") — that drift no longer exists.


### PR DESCRIPTION
## Summary
Implements Jake's #505 decision (2026-08-05): ADR 0006's read-only promise is the intent — a card decline must not hide the user's data — so the code now matches it.

- **Router**: `/conversations` (list) and `/conversations/:id` (detail) move from the `:active_subscription` live_session to `:authenticated`; only `/conversations/new` remains router-gated.
- **Per-event gate**: a new first `handle_event` clause in `ConversationsLive.Show` refuses the spend-creating events (`send_prompt`, `update_prompt`, `images_selected`) when the subscription is inactive — the composer is hidden in the template, but hand-sent events are blocked server-side (#399's lesson). A read-only banner links to `/account/billing`.
- **Deliberately still allowed for lapsed users**: `terminate`/`interrupt` (they *stop* spend — blocking them would protect spend in reverse) and `delete` (removing data is not consumption, per ADR 0009). Pinned by tests.
- **New hook**: `:assign_subscription_state` assigns `@subscription_active` for the whole `:authenticated` live_session without halting; billing-disabled instances get `true` via `Billing.check_active/1`.
- **ADR 0006**: new addendum records the decision and closes the 2026-08-02 addendum's "past_due cannot view past conversations" drift bullet.
- **Unchanged**: the API gate (conversation start/wake/turns) and the log viewer route.

## Test plan
- Hook tests updated: the router gate now pins `/conversations/new`; new `:assign_subscription_state` describe proves past_due/canceled users can mount the list and detail pages.
- Show tests: banner + no composer for lapsed; all three spend events refused with zero turns created; terminate and delete still reach their real handlers; active users see the composer with no banner.
- New tests verified to fail with the lib changes reverted (7 failures).
- `mix precommit` green (2,036 tests, 0 failures) — no other test relied on the old gating.

Closes #505. Part of #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)