### PR TITLE
admin: read-only Stripe invoice view on /admin/users/:id (#502)

### DIFF
--- a/apps/fountain/lib/fountain_web/live/admin_live/helpers.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/helpers.ex
@@ -23,9 +23,26 @@ defmodule FountainWeb.AdminLive.Helpers do
   def conversation_status_color("failed"), do: "bg-red-100 text-red-700 border-red-200"
   def conversation_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
 
+  def invoice_status_color("paid"), do: "bg-green-100 text-green-800 border-green-200"
+  def invoice_status_color("open"), do: "bg-blue-100 text-blue-800 border-blue-200"
+  def invoice_status_color("uncollectible"), do: "bg-red-100 text-red-700 border-red-200"
+  def invoice_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
+
   def format_date(nil), do: ""
   def format_date(dt), do: Calendar.strftime(dt, "%Y-%m-%d")
 
   def format_ts(nil), do: ""
   def format_ts(dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
+
+  @doc """
+  Stripe amounts are integer minor units ("2900", "usd"). USD gets the
+  symbol; anything else renders as "29.00 EUR" rather than guessing symbols
+  or zero-decimal currencies wrong for money we don't charge in.
+  """
+  def format_money(cents, "usd"), do: "$#{minor_units(cents)}"
+  def format_money(cents, currency), do: "#{minor_units(cents)} #{String.upcase(currency)}"
+
+  defp minor_units(cents) do
+    :erlang.float_to_binary(cents / 100, decimals: 2)
+  end
 end

--- a/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
@@ -5,8 +5,9 @@ defmodule FountainWeb.AdminLive.UserDetail do
   comp, delete, role) stay on `/admin` next to their confirmations.
 
   Shows account/billing state, resource counts, conversations, API-key
-  metadata (never key material), the user's own audit trail, and every admin
-  action taken against them. Each visit records an `admin.user.viewed` admin
+  metadata (never key material), Stripe invoices (billing-enabled instances,
+  fetched live, #502), the user's own audit trail, and every admin action
+  taken against them. Each visit records an `admin.user.viewed` admin
   audit event: cross-tenant reads are privileged actions and get the same
   trail as cross-tenant writes.
   """
@@ -37,11 +38,27 @@ defmodule FountainWeb.AdminLive.UserDetail do
           })
         end
 
+        billing_enabled = Fountain.Billing.enabled?()
+
+        # Invoices come from a live Stripe call; loading them here would hold
+        # the mount (and the page) hostage to Stripe latency, so the fetch is
+        # deferred to handle_info and the section renders a loading state.
+        if connected?(socket) and billing_enabled, do: send(self(), :load_invoices)
+
         {:ok,
          socket
          |> assign(:page_title, "Admin · #{user.email}")
-         |> assign(:billing_enabled, Fountain.Billing.enabled?())
+         |> assign(:billing_enabled, billing_enabled)
+         |> assign(:invoices, :loading)
          |> load_user(user)}
+    end
+  end
+
+  @impl true
+  def handle_info(:load_invoices, socket) do
+    case Fountain.Billing.list_invoices(socket.assigns.user) do
+      {:ok, invoices} -> {:noreply, assign(socket, :invoices, invoices)}
+      {:error, _reason} -> {:noreply, assign(socket, :invoices, :error)}
     end
   end
 
@@ -252,6 +269,65 @@ defmodule FountainWeb.AdminLive.UserDetail do
                 <span :if={is_nil(k.revoked_at) and is_nil(k.expires_at)} class="text-zinc-500">
                   active
                 </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section :if={@billing_enabled} id="invoices" class="space-y-3">
+        <h2 class="text-lg font-medium">Invoices</h2>
+        <div :if={@invoices == :loading} class="text-sm text-zinc-500">Loading from Stripe…</div>
+        <div :if={@invoices == :error} class="text-sm text-amber-700">
+          Couldn't load invoices from Stripe — check the
+          <a
+            :if={@user.stripe_customer_id not in [nil, ""]}
+            href={"https://dashboard.stripe.com/customers/#{@user.stripe_customer_id}"}
+            target="_blank"
+            rel="noopener"
+            class="underline"
+          >
+            Stripe dashboard
+          </a> directly.
+        </div>
+        <div :if={@invoices == []} class="text-sm text-zinc-500">None.</div>
+        <table
+          :if={is_list(@invoices) and @invoices != []}
+          class="w-full text-sm bg-white rounded shadow border border-zinc-200"
+        >
+          <thead class="text-left text-zinc-500 border-b border-zinc-200">
+            <tr>
+              <th class="px-4 py-2">Invoice</th>
+              <th class="px-4 py-2">Status</th>
+              <th class="px-4 py-2">Total</th>
+              <th class="px-4 py-2">Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={inv <- @invoices} class="border-b border-zinc-100 last:border-0">
+              <td class="px-4 py-2 text-xs">
+                <a
+                  href={"https://dashboard.stripe.com/invoices/#{inv.id}"}
+                  target="_blank"
+                  rel="noopener"
+                  class="font-mono hover:underline"
+                >
+                  {inv.number || inv.id}
+                </a>
+              </td>
+              <td class="px-4 py-2">
+                <span class={[
+                  "inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium border",
+                  invoice_status_color(inv.status)
+                ]}>
+                  {inv.status}
+                </span>
+              </td>
+              <td class="px-4 py-2 text-xs tabular-nums">
+                {format_money(inv.total, inv.currency)}
+              </td>
+              <td class="px-4 py-2 text-xs text-zinc-500">
+                {inv.created |> DateTime.from_unix!() |> format_date()}
               </td>
             </tr>
           </tbody>

--- a/apps/fountain/test/fountain_web/live/admin_billing_disabled_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_billing_disabled_test.exs
@@ -128,6 +128,7 @@ defmodule FountainWeb.AdminBillingDisabledTest do
         refute html =~ "trialing"
         refute html =~ "Trial / period"
         refute html =~ "dashboard.stripe.com"
+        refute html =~ "Invoices"
         assert html =~ "Onboarding"
         assert html =~ user.email
       end)

--- a/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
@@ -1,5 +1,6 @@
 defmodule FountainWeb.AdminUserDetailLiveTest do
   use FountainWeb.ConnCase, async: true
+  use Mimic
 
   import Phoenix.LiveViewTest
   import Ecto.Query
@@ -87,6 +88,71 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
 
       assert {:error, {:live_redirect, %{to: "/admin"}}} =
                live(conn, ~p"/admin/users/#{Ecto.UUID.generate()}")
+    end
+  end
+
+  describe "invoices (#502)" do
+    defp insert_target_with_customer(customer_id) do
+      {:ok, user} =
+        insert_verified_user()
+        |> Accounts.User.billing_changeset(%{stripe_customer_id: customer_id})
+        |> Repo.update()
+
+      user
+    end
+
+    # Both arities, or the miss silently falls through to the live client
+    # (#474): stripity_stripe functions carry a default opts arg.
+    defp stub_invoice_list(result) do
+      stub(Stripe.Invoice, :list, fn _params -> result end)
+      stub(Stripe.Invoice, :list, fn _params, _opts -> result end)
+    end
+
+    test "renders the invoice history fetched from Stripe", %{conn: conn} do
+      target = insert_target_with_customer("cus_inv_lv")
+
+      stub_invoice_list(
+        {:ok,
+         %Stripe.List{
+           data: [
+             %Stripe.Invoice{
+               id: "in_lv_1",
+               number: "INV-2026-0001",
+               status: "paid",
+               total: 2900,
+               currency: "usd",
+               created: 1_754_000_000
+             }
+           ]
+         }}
+      )
+
+      {:ok, lv, _html} = live(login_user(conn, insert_admin()), ~p"/admin/users/#{target.id}")
+
+      invoices = lv |> element("#invoices") |> render()
+      assert invoices =~ "INV-2026-0001"
+      assert invoices =~ "paid"
+      assert invoices =~ "$29.00"
+      assert invoices =~ "https://dashboard.stripe.com/invoices/in_lv_1"
+    end
+
+    test "a Stripe failure degrades to an error note, not a broken page", %{conn: conn} do
+      target = insert_target_with_customer("cus_inv_down")
+      stub_invoice_list({:error, :stripe_down})
+
+      {:ok, lv, _html} = live(login_user(conn, insert_admin()), ~p"/admin/users/#{target.id}")
+
+      invoices = lv |> element("#invoices") |> render()
+      assert invoices =~ "Couldn&#39;t load invoices from Stripe"
+      assert invoices =~ "https://dashboard.stripe.com/customers/cus_inv_down"
+    end
+
+    test "a user with no Stripe customer shows an empty state", %{conn: conn} do
+      target = insert_verified_user()
+
+      {:ok, lv, _html} = live(login_user(conn, insert_admin()), ~p"/admin/users/#{target.id}")
+
+      assert lv |> element("#invoices") |> render() =~ "None."
     end
   end
 end

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -24,6 +24,7 @@ Mimic.copy(Stripe.Customer)
 Mimic.copy(Stripe.BillingPortal.Session)
 Mimic.copy(Stripe.Checkout.Session)
 Mimic.copy(Stripe.Subscription)
+Mimic.copy(Stripe.Invoice)
 Mimic.copy(Fountain.SpritesClient)
 
 Mimic.copy(Fountain.Conversations.ConversationServer)

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -568,6 +568,31 @@ defmodule Fountain.Billing do
   end
 
   @doc """
+  Read-only invoice history for the admin user detail page (#502), fetched
+  live from Stripe — nothing is stored locally, so this can never drift from
+  the billing system of record the way webhook-derived state can.
+
+  Refused before Stripe when billing is disabled (#399), and a user with no
+  Stripe customer has no invoices to fetch — `{:ok, []}` without a call.
+  """
+  @spec list_invoices(User.t()) :: {:ok, [Stripe.Invoice.t()]} | {:error, term()}
+  def list_invoices(%User{} = user) do
+    cond do
+      not enabled?() ->
+        {:error, :billing_disabled}
+
+      user.stripe_customer_id in [nil, ""] ->
+        {:ok, []}
+
+      true ->
+        case Stripe.Invoice.list(%{customer: user.stripe_customer_id, limit: 20}) do
+          {:ok, %Stripe.List{data: invoices}} -> {:ok, invoices}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  @doc """
   Marks an account comped: free access granted by an operator, indefinitely.
 
   Any live Stripe subscription is cancelled first — a comped account must not

--- a/ee/test/fountain/billing_invoices_test.exs
+++ b/ee/test/fountain/billing_invoices_test.exs
@@ -1,0 +1,77 @@
+# async: false — the billing-disabled case mutates the global :billing_enabled
+# app env, which concurrent tests also read.
+defmodule Fountain.BillingInvoicesTest do
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Fountain.Accounts.User
+  alias Fountain.Billing
+
+  setup do
+    billing = Application.get_env(:fountain, :billing_enabled)
+    on_exit(fn -> Application.put_env(:fountain, :billing_enabled, billing) end)
+    :ok
+  end
+
+  defp user_with_customer(customer_id) do
+    {:ok, user} =
+      insert_verified_user()
+      |> User.billing_changeset(%{stripe_customer_id: customer_id})
+      |> Repo.update()
+
+    user
+  end
+
+  # stripity_stripe's functions carry a default opts arg, and Mimic stubs
+  # are arity-specific — stub both arities or the miss silently falls
+  # through to the live client (#474).
+  defp stub_list(result) do
+    stub(Stripe.Invoice, :list, fn _params -> result end)
+    stub(Stripe.Invoice, :list, fn _params, _opts -> result end)
+  end
+
+  describe "list_invoices/1 (#502)" do
+    test "fetches the customer's invoices live from Stripe" do
+      user = user_with_customer("cus_inv")
+
+      invoice = %Stripe.Invoice{id: "in_1", number: "INV-0001", status: "paid", total: 2900}
+
+      stub(Stripe.Invoice, :list, fn %{customer: "cus_inv", limit: 20} ->
+        {:ok, %Stripe.List{data: [invoice]}}
+      end)
+
+      stub(Stripe.Invoice, :list, fn %{customer: "cus_inv", limit: 20}, _opts ->
+        {:ok, %Stripe.List{data: [invoice]}}
+      end)
+
+      assert {:ok, [%Stripe.Invoice{id: "in_1"}]} = Billing.list_invoices(user)
+    end
+
+    test "a user with no Stripe customer has no invoices, without a Stripe call" do
+      stub_list_flunk()
+      assert {:ok, []} = Billing.list_invoices(insert_verified_user())
+    end
+
+    test "refused before Stripe when billing is disabled" do
+      Application.put_env(:fountain, :billing_enabled, false)
+      stub_list_flunk()
+      assert {:error, :billing_disabled} = Billing.list_invoices(user_with_customer("cus_inv"))
+    end
+
+    test "a Stripe error passes through" do
+      user = user_with_customer("cus_down")
+      stub_list({:error, :stripe_down})
+      assert {:error, :stripe_down} = Billing.list_invoices(user)
+    end
+  end
+
+  # For cases asserting Stripe is never reached: the stub runs in the test
+  # process, so flunk surfaces as a normal test failure.
+  defp stub_list_flunk do
+    stub(Stripe.Invoice, :list, fn _params -> flunk("Stripe.Invoice.list was called") end)
+
+    stub(Stripe.Invoice, :list, fn _params, _opts ->
+      flunk("Stripe.Invoice.list was called")
+    end)
+  end
+end

--- a/ee/test/fountain/trial_subscription_idempotency_test.exs
+++ b/ee/test/fountain/trial_subscription_idempotency_test.exs
@@ -1,5 +1,10 @@
 defmodule Fountain.TrialSubscriptionIdempotencyTest do
-  use Fountain.DataCase, async: true
+  # async: false because the setup sets `:stripe_price_id`, which is global —
+  # same reason as stripe_customer_sync_trial_test.exs. As async: true this
+  # flaked in CI (PR #539): another test's teardown removed the price
+  # mid-test, start_trial_subscription took the no-price local-trial fallback,
+  # and the assertion saw stripe_subscription_id nil.
+  use Fountain.DataCase, async: false
   use Mimic
 
   alias Fountain.{Billing, Repo}
@@ -12,8 +17,15 @@ defmodule Fountain.TrialSubscriptionIdempotencyTest do
   # set — each retry minting another trialing subscription.
 
   setup do
+    previous = Application.get_env(:fountain, :stripe_price_id)
     Application.put_env(:fountain, :stripe_price_id, "price_trial_test")
-    on_exit(fn -> Application.delete_env(:fountain, :stripe_price_id) end)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:fountain, :stripe_price_id)
+        value -> Application.put_env(:fountain, :stripe_price_id, value)
+      end
+    end)
 
     user = insert_verified_user()
     {:ok, user} = Billing.attach_stripe_customer(user, "cus_trial_idem")


### PR DESCRIPTION
Closes #502 — the remaining half; the force-resync lever shipped in #515.

## What

- `Billing.list_invoices/1` (ee/): the first outbound `Stripe.Invoice` call in the codebase — fetches the user's last 20 invoices live from Stripe, nothing stored locally. Refused before Stripe when billing is disabled (#399 pattern); a user with no Stripe customer returns `{:ok, []}` without a call.
- `/admin/users/:id` gains an **Invoices** section (billing-enabled instances only): number linking to the Stripe dashboard invoice, status badge, total, created date. Read-only, which fits the page's "no levers here" convention.
- The fetch is deferred to `handle_info` after mount so Stripe latency or an outage can't hold the page hostage — the section renders "Loading from Stripe…" and degrades to an error note with a dashboard link if the call fails.
- `format_money/2` + `invoice_status_color/1` added to `AdminLive.Helpers`; USD gets a symbol, anything else renders `29.00 EUR` rather than guessing symbols or zero-decimal currencies wrong.

## Tests

- `ee/test/fountain/billing_invoices_test.exs` (async: false — toggles the global billing flag): live fetch, empty-without-a-call for customerless users, refused-before-Stripe when billing disabled, error passthrough.
- LiveView coverage in `admin_user_detail_live_test.exs`: rendered table, Stripe-failure degradation, empty state; the existing billing-disabled test now also refutes the section.
- `Mimic.copy(Stripe.Invoice)` added; all stubs cover **both arities** (the #474 trap — stripity_stripe's default `opts` arg makes a wrong-arity stub fall through to the live client).
- Verified by reverting: with the implementation files reverted to main, 7 of the 13 touched tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)