### PR TITLE
config: blank sandbox bounds and SPRITES_BASE_URL count as unset (#513)

### DIFF
--- a/apps/fountain/test/fountain/compose_passthrough_config_test.exs
+++ b/apps/fountain/test/fountain/compose_passthrough_config_test.exs
@@ -1,8 +1,10 @@
 defmodule Fountain.ComposePassthroughConfigTest do
   @moduledoc """
   Evaluates `config/runtime.exs` the way the release config provider does,
-  pinning the blank-string behaviour of the variables #497 newly passes
-  through the compose `environment:` block as `${VAR:-}`.
+  pinning the blank-string behaviour of the variables the compose
+  `environment:` block passes through as `${VAR:-}` (#497, and the #513
+  fresh-machine walkthrough, which caught the sandbox bounds crash-looping
+  boot and SPRITES_BASE_URL going blank).
 
   Compose interpolates an unset `${VAR:-}` to an empty *string* — the
   variable arrives set, not absent — so every default here must survive `""`.
@@ -15,7 +17,8 @@ defmodule Fountain.ComposePassthroughConfigTest do
 
   @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
 
-  @vars ~w(TRUSTED_PROXIES SENTRY_DSN DATABASE_SSL_VERIFY DATABASE_SSL_CA_FILE)
+  @vars ~w(TRUSTED_PROXIES SENTRY_DSN DATABASE_SSL_VERIFY DATABASE_SSL_CA_FILE
+           SANDBOX_IDLE_TIMEOUT_MINUTES SANDBOX_MAX_LIFETIME_HOURS SPRITES_BASE_URL)
 
   # Not under test here, but they change what the prod boot requires (a
   # configured mail provider demands EMAIL_FROM). Cleared before every read
@@ -116,6 +119,53 @@ defmodule Fountain.ComposePassthroughConfigTest do
         |> read_prod()
 
       assert cfg[:fountain][Fountain.Repo][:ssl_opts] == [verify: :verify_none]
+    end
+  end
+
+  describe "sandbox lifetime bounds" do
+    test "blank falls back to the defaults instead of refusing to boot", %{base: base} do
+      # This was the first thing `docker compose up` hit on a fresh machine
+      # (#513): both bounds arrive as "", Integer.parse("") fails, and the
+      # raise meant for typos crash-looped the quick start.
+      cfg =
+        base
+        |> Map.merge(%{"SANDBOX_IDLE_TIMEOUT_MINUTES" => "", "SANDBOX_MAX_LIFETIME_HOURS" => ""})
+        |> read_prod()
+
+      assert cfg[:fountain][:sandbox_idle_timeout_minutes] == 60
+      assert cfg[:fountain][:sandbox_max_lifetime_hours] == 24
+    end
+
+    test "a real value is parsed", %{base: base} do
+      cfg =
+        base
+        |> Map.merge(%{"SANDBOX_IDLE_TIMEOUT_MINUTES" => "0", "SANDBOX_MAX_LIFETIME_HOURS" => "72"})
+        |> read_prod()
+
+      assert cfg[:fountain][:sandbox_idle_timeout_minutes] == 0
+      assert cfg[:fountain][:sandbox_max_lifetime_hours] == 72
+    end
+
+    test "a non-blank garbage value still refuses to boot", %{base: base} do
+      # The refusal exists so a typo cannot silently disable the bound — only
+      # blank means "not configured".
+      assert_raise RuntimeError, ~r/SANDBOX_IDLE_TIMEOUT_MINUTES/, fn ->
+        read_prod(Map.put(base, "SANDBOX_IDLE_TIMEOUT_MINUTES", "6O"))
+      end
+    end
+  end
+
+  describe "SPRITES_BASE_URL" do
+    test "blank keeps the hosted default rather than an empty base URL", %{base: base} do
+      cfg = read_prod(Map.put(base, "SPRITES_BASE_URL", ""))
+
+      assert cfg[:fountain][:sprites_base_url] == "https://api.sprites.dev"
+    end
+
+    test "a real endpoint is stored verbatim", %{base: base} do
+      cfg = read_prod(Map.put(base, "SPRITES_BASE_URL", "https://sprites.internal.example.com"))
+
+      assert cfg[:fountain][:sprites_base_url] == "https://sprites.internal.example.com"
     end
   end
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -87,9 +87,18 @@ config :fountain, :sprites_token, sprites_token
 # pointing an instance at a different sandbox backend meant editing config and
 # rebuilding. Wiring it does not make Sprites self-hostable (see #189), it just
 # stops the endpoint being baked into the release.
-config :fountain,
-       :sprites_base_url,
-       System.get_env("SPRITES_BASE_URL", "https://api.sprites.dev")
+#
+# "" counts as unset (#513): the compose file passes `${SPRITES_BASE_URL:-}`,
+# and `System.get_env/2` only applies its default when the variable is absent
+# — a present-but-empty value would become the API base URL and every Sprites
+# call would fail.
+sprites_base_url =
+  case System.get_env("SPRITES_BASE_URL") do
+    blank when blank in [nil, ""] -> "https://api.sprites.dev"
+    url -> url
+  end
+
+config :fountain, :sprites_base_url, sprites_base_url
 
 # Bounds every HTTP call to the Sprites API. Long-running commands
 # (package installs, clones) pass their own per-call :timeout and are not
@@ -314,8 +323,18 @@ end
 # Refused at boot rather than ignored: a typo here would otherwise silently
 # disable the bound, and an operator who set a limit deserves to find out that
 # it did not take effect now rather than from a bill.
+# "" counts as unset (#513): the compose file passes `${VAR:-}`, which
+# delivers a present-but-empty variable — that is "not configured", not a
+# typo, so it gets the default instead of the refusal below. The refusal
+# still applies to anything non-blank that fails to parse.
 parse_bound = fn var, default ->
-  case System.get_env(var, default) |> Integer.parse() do
+  value =
+    case System.get_env(var) do
+      blank when blank in [nil, ""] -> default
+      set -> set
+    end
+
+  case Integer.parse(value) do
     {n, ""} when n >= 0 ->
       n
 


### PR DESCRIPTION
Found by the #513 fresh-machine compose walkthrough — the documented quick start (`docs/self-hosting.md` § Quick start, followed verbatim) crash-loops before serving a single request.

## What happens

Compose interpolates unset `${VAR:-}` passthroughs to **present-but-empty** strings. Two reads in `config/runtime.exs` didn't survive that:

- **`SANDBOX_IDLE_TIMEOUT_MINUTES` / `SANDBOX_MAX_LIFETIME_HOURS`** — `parse_bound` fed `""` to `Integer.parse/1` and hit the refusal written for typos. Boot crash-loop, on both v0.4.1 and main.
- **`SPRITES_BASE_URL`** — `System.get_env/2` only applies its default when the variable is *absent*, so `""` became the Sprites API base URL; every conversation would fail at provision once boot was unblocked.

## Fix

Both now follow the established blank-guard pattern (#392/#396/#497): `""` means "not configured" and gets the default. The boot refusal still applies to anything non-blank that fails to parse, so a typo cannot silently disable a bound.

Pinned in `ComposePassthroughConfigTest` alongside the #497 vars; the new tests were verified to fail against the unfixed `runtime.exs` (2 failures on revert).

Note this alone does not un-break the quick start a fresh user runs today — the pinned `v0.4.1` image has these bugs baked in (plus the `SENTRY_DSN=""` crash #497 already fixed). That needs a release + pin bump, tracked separately off the #513 report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)