### PR TITLE
audit: emit secret write/delete events from the API paths (#530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ upgrade, is in
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Secrets written through the API now leave the same audit trail as
+  secrets written through the UI.** `POST/DELETE /api/environments/:id/secrets`,
+  the vault equivalents, and the secret half of `POST /api/apply` recorded
+  only the generic request row — so the trail could answer "who wrote a
+  secret" only for people who used a browser, and the account export's
+  `audit_trail` under-reported API-driven secret activity. All three paths
+  now emit the same `environment.secret.write` / `vault.secret.write` (and
+  `.delete`) events the LiveView forms do, carrying the key, never the
+  value, and attributed to `api` or `sprite` as appropriate (#530)
+
 ## [0.5.2] — 2026-08-05
 
 ### Fixed

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -29,8 +29,10 @@ defmodule Fountain.Manifest do
   Returns `{:ok, results}` with one result map per resource in apply order
   (environments, vaults, agents, then any malformed entries). Each result
   holds `:kind`, `:name`, an `:action` of `:created` / `:updated` / `:error`,
-  changeset-style `:errors` when the action is `:error`, and a `:secrets`
-  list with the per-key upsert outcome. Secret values are never echoed back.
+  changeset-style `:errors` when the action is `:error`, a `:secrets`
+  list with the per-key upsert outcome, and the reconciled record's `:id`
+  (nil for errors and for kinds that carry no secrets). Secret values are
+  never echoed back.
   """
   def apply_manifest(user_id, resources) when is_binary(user_id) and is_list(resources) do
     {valid, invalid} = Enum.split_with(resources, &valid_resource?/1)
@@ -72,7 +74,7 @@ defmodule Fountain.Manifest do
     case outcome do
       {action, {:ok, env}} ->
         secret_results = upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek))
-        {result("Environment", name, action, nil, secret_results), env}
+        {result("Environment", name, action, nil, secret_results, env.id), env}
 
       {_action, {:error, changeset}} ->
         {result("Environment", name, :error, changeset_errors(changeset), []), nil}
@@ -91,7 +93,7 @@ defmodule Fountain.Manifest do
     case outcome do
       {action, {:ok, vault}} ->
         secret_results = upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek))
-        result("Vault", name, action, nil, secret_results)
+        result("Vault", name, action, nil, secret_results, vault.id)
 
       {_action, {:error, changeset}} ->
         result("Vault", name, :error, changeset_errors(changeset), [])
@@ -207,8 +209,11 @@ defmodule Fountain.Manifest do
 
   defp split_spec(_res, name), do: {%{"name" => name}, %{}}
 
-  defp result(kind, name, action, errors, secrets) do
-    %{kind: kind, name: name, action: action, errors: errors, secrets: secrets}
+  # `id` is the reconciled record's id when there is one. It is not serialized
+  # in the API response; callers use it to attribute the secret writes this
+  # manifest performed to a concrete resource in the audit trail (#530).
+  defp result(kind, name, action, errors, secrets, id \\ nil) do
+    %{kind: kind, name: name, action: action, errors: errors, secrets: secrets, id: id}
   end
 
   defp invalid_result(res) do

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -4,7 +4,7 @@ defmodule FountainWeb.ApplyController do
   use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Manifest
-  alias FountainWeb.Schemas
+  alias FountainWeb.{Audited, Schemas}
 
   action_fallback FountainWeb.FallbackController
 
@@ -32,7 +32,30 @@ defmodule FountainWeb.ApplyController do
     user = conn.assigns.current_user
 
     with {:ok, results} <- Manifest.apply_manifest(user.id, resources) do
+      audit_secret_writes(conn, results)
       render(conn, :create, results: results)
     end
   end
+
+  # A manifest apply is a secret write like any other — `fountain apply` was the
+  # third API path that moved secrets without leaving a semantic trail (#530).
+  # One event per key actually written, matching the per-key events the LiveView
+  # forms and the secret controllers emit.
+  defp audit_secret_writes(conn, results) do
+    for %{id: id, secrets: secrets} = result <- results,
+        not is_nil(id),
+        %{key: key, action: :upserted} <- secrets do
+      {action, resource_type} = audit_names(result.kind)
+
+      Audited.from_conn(conn, action, resource_type,
+        resource_id: id,
+        metadata: %{"key" => key, "via" => "apply"}
+      )
+    end
+
+    :ok
+  end
+
+  defp audit_names("Environment"), do: {"environment.secret.write", "secret"}
+  defp audit_names("Vault"), do: {"vault.secret.write", "vault_secret"}
 end

--- a/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
@@ -4,7 +4,7 @@ defmodule FountainWeb.SecretController do
   use OpenApiSpex.ControllerSpecs
 
   alias Fountain.{Crypto, Environments}
-  alias FountainWeb.Schemas
+  alias FountainWeb.{Audited, Schemas}
 
   action_fallback FountainWeb.FallbackController
 
@@ -53,6 +53,13 @@ defmodule FountainWeb.SecretController do
         {:ok, dek} = Crypto.load_tenant_key(conn.assigns.current_user.id)
 
         with {:ok, secret} <- Environments.upsert_secret(env, attrs, dek) do
+          # Same event the LiveView form emits (environments_live/form.ex), so
+          # the trail reads identically whichever surface wrote the secret.
+          Audited.from_conn(conn, "environment.secret.write", "secret",
+            resource_id: env.id,
+            metadata: %{"key" => secret.key}
+          )
+
           conn
           |> put_status(:created)
           |> render(:show, secret: secret)
@@ -79,6 +86,12 @@ defmodule FountainWeb.SecretController do
          # Ownership established by the scoped get_environment above.
          %_{} = secret <- Environments._unsafe_get_secret(env_id, key) do
       {:ok, _} = Environments.delete_secret(secret)
+
+      Audited.from_conn(conn, "environment.secret.delete", "secret",
+        resource_id: env_id,
+        metadata: %{"key" => secret.key}
+      )
+
       send_resp(conn, :no_content, "")
     else
       _ -> {:error, :not_found}

--- a/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
@@ -4,7 +4,7 @@ defmodule FountainWeb.VaultSecretController do
   use OpenApiSpex.ControllerSpecs
 
   alias Fountain.{Crypto, Vaults}
-  alias FountainWeb.Schemas
+  alias FountainWeb.{Audited, Schemas}
 
   action_fallback FountainWeb.FallbackController
 
@@ -57,6 +57,13 @@ defmodule FountainWeb.VaultSecretController do
         {:ok, dek} = Crypto.load_tenant_key(user.id)
 
         with {:ok, secret} <- Vaults.upsert_secret(vault, attrs, dek) do
+          # Same event the LiveView form emits (vaults_live/form.ex), so the
+          # trail reads identically whichever surface wrote the secret.
+          Audited.from_conn(conn, "vault.secret.write", "vault_secret",
+            resource_id: vault.id,
+            metadata: %{"key" => secret.key}
+          )
+
           conn
           |> put_status(:created)
           |> render(:show, secret: secret)
@@ -83,6 +90,12 @@ defmodule FountainWeb.VaultSecretController do
          # Ownership established by the scoped get_vault above.
          %_{} = secret <- Vaults._unsafe_get_secret(vault_id, key) do
       {:ok, _} = Vaults.delete_secret(secret)
+
+      Audited.from_conn(conn, "vault.secret.delete", "vault_secret",
+        resource_id: vault_id,
+        metadata: %{"key" => secret.key}
+      )
+
       send_resp(conn, :no_content, "")
     else
       _ -> {:error, :not_found}

--- a/apps/fountain/test/fountain_web/audit_coverage_test.exs
+++ b/apps/fountain/test/fountain_web/audit_coverage_test.exs
@@ -85,6 +85,134 @@ defmodule FountainWeb.AuditCoverageTest do
     end
   end
 
+  describe "secret writes through the API (#530)" do
+    setup do
+      user = insert_verified_user()
+      {_rec, key} = insert_api_key(user)
+      {:ok, user: user, key: key}
+    end
+
+    test "an environment secret write and delete are recorded", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      env = insert_env(user_id: user.id)
+
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/environments/#{env.id}/secrets", %{"key" => "DB_URL", "value" => "pg://x"})
+      |> json_response(201)
+
+      write = find_action(user.id, "environment.secret.write")
+      assert write, "writing a secret through the API must be audited like the UI does"
+      assert write.actor == "api"
+      assert write.resource_id == env.id
+      assert write.metadata["key"] == "DB_URL"
+
+      build_conn()
+      |> authed_with_key(key)
+      |> delete("/api/environments/#{env.id}/secrets/DB_URL")
+      |> response(204)
+
+      delete_event = find_action(user.id, "environment.secret.delete")
+      assert delete_event
+      assert delete_event.resource_id == env.id
+      assert delete_event.metadata["key"] == "DB_URL"
+    end
+
+    test "a vault secret write and delete are recorded", %{conn: conn, user: user, key: key} do
+      vault = insert_vault(user_id: user.id)
+
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/vaults/#{vault.id}/secrets", %{"key" => "TOKEN", "value" => "s3cret"})
+      |> json_response(201)
+
+      write = find_action(user.id, "vault.secret.write")
+      assert write
+      assert write.resource_id == vault.id
+      assert write.metadata["key"] == "TOKEN"
+
+      build_conn()
+      |> authed_with_key(key)
+      |> delete("/api/vaults/#{vault.id}/secrets/TOKEN")
+      |> response(204)
+
+      assert find_action(user.id, "vault.secret.delete")
+    end
+
+    test "a sprite token's secret write is attributed to the sandbox", %{conn: conn, user: user} do
+      # The whole point of the semantic event: "the agent wrote this secret" and
+      # "the account owner wrote this secret" must be distinguishable.
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+      vault = insert_vault(user_id: user.id)
+
+      conn
+      |> authed_with_key(sprite_key)
+      |> post_json("/api/vaults/#{vault.id}/secrets", %{"key" => "K", "value" => "v"})
+      |> json_response(201)
+
+      write = find_action(user.id, "vault.secret.write")
+      assert write.actor == "sprite"
+    end
+
+    test "the secret value never reaches the audit log", %{conn: conn, user: user, key: key} do
+      env = insert_env(user_id: user.id)
+
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/environments/#{env.id}/secrets", %{
+        "key" => "K",
+        "value" => "super-secret-value"
+      })
+      |> json_response(201)
+
+      events = events_for(user.id)
+
+      # Guard the guard (#406): an empty list would make the refute vacuous.
+      assert Enum.any?(events, &(&1.action == "environment.secret.write"))
+
+      for event <- events do
+        refute inspect(event.metadata) =~ "super-secret-value"
+      end
+    end
+
+    test "secrets written by a manifest apply are recorded per key", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/apply", %{
+        "resources" => [
+          %{
+            "kind" => "Environment",
+            "name" => "prod",
+            "spec" => %{"secrets" => %{"A" => "1", "B" => "2"}}
+          },
+          %{
+            "kind" => "Vault",
+            "name" => "creds",
+            "spec" => %{"secrets" => %{"C" => "3"}}
+          }
+        ]
+      })
+      |> json_response(200)
+
+      env_writes =
+        Enum.filter(events_for(user.id), &(&1.action == "environment.secret.write"))
+
+      assert Enum.map(env_writes, & &1.metadata["key"]) |> Enum.sort() == ["A", "B"]
+      assert Enum.all?(env_writes, &(&1.metadata["via"] == "apply"))
+      assert Enum.all?(env_writes, &(&1.resource_id != nil))
+
+      vault_write = find_action(user.id, "vault.secret.write")
+      assert vault_write.metadata["key"] == "C"
+    end
+  end
+
   describe "authentication events" do
     test "a successful login is recorded", %{conn: conn} do
       user = insert_verified_user(%{"password" => "password12345"})


### PR DESCRIPTION
Closes #530.

## What was wrong

Secret writes were audited from the browser and not from the API:

- `EnvironmentsLive.Form` / `VaultsLive.Form` emit `environment.secret.write` / `vault.secret.write` (and `.delete`) with the key.
- `SecretController` / `VaultSecretController` did the identical write with no semantic event — only the generic `POST /api/...` row the `:api` pipeline's audit plug records.

So "who wrote this secret" was answerable only for people who used a browser, and the account export's `audit_trail` (and `/audit`) under-reported API-driven secret activity.

## What this does

- Both secret controllers emit the same events the forms do — same action names, same `resource_type`, same `resource_id` (the parent environment/vault), `metadata.key` only, never the value.
- **Beyond the issue text:** `POST /api/apply` was a third unaudited secret path — `fountain apply` writes secrets in bulk through `Fountain.Manifest` and left no semantic trail. It now emits one event per key actually written, tagged `metadata.via = "apply"`. To attribute those to a concrete resource, manifest results now carry the reconciled record's `id`; it is **not** serialized in `ApplyResponse`, so the API contract is unchanged.
- Actor attribution comes free from `Audited.from_conn/4`: a sprite callback token records as `sprite`, an ordinary key as `api`.

Recording stays best-effort per CLAUDE.md — `Audit.record/1` rescues, so a logging failure can't break a secret write.

## Tests

Five tests in `audit_coverage_test.exs`, alongside the existing UI ones: env write+delete, vault write+delete, sprite attribution, no-plaintext-in-the-trail (with the #406 guard-the-guard assertion), and per-key events from a manifest apply. **Verified by reverting:** with `lib/` stashed all five fail, and they pass with the fix.

`mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` clean; manifest/apply/secret/vault-secret suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)