### PR TITLE
api: inference-credential endpoints for headless bootstrap (#518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ upgrade, is in
   `.delete`) events the LiveView forms do, carrying the key, never the
   value, and attributed to `api` or `sprite` as appropriate (#530)
 
+### Added
+
+- **Inference credentials can be set over the API**, so an account can be
+  bootstrapped without ever opening a browser: `GET/PUT/DELETE
+  /api/account/inference-credentials[/:provider]`. A conversation cannot run
+  without one of these, and until now `put_credential` had exactly two
+  callers — the settings LiveView and the onboarding wizard — which made a
+  headless `register → configure → run` flow impossible. `PUT` runs the same
+  provider ping the settings page does and reports the outcomes distinctly
+  (422 rejected, 504 timed out, 502 unreachable) so a client knows whether to
+  re-type or retry; `validate: false` stores without the ping. Values stay
+  write-only, and the endpoints need a `full`-scoped key — a leaked
+  per-conversation sprite token must not be able to swap the keys the account
+  runs on. Both surfaces now emit `inference_credential.write` / `.delete`
+  audit events (#518)
+
 ## [0.5.2] — 2026-08-05
 
 ### Fixed

--- a/apps/fountain/lib/fountain_web/controllers/inference_credential_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/inference_credential_controller.ex
@@ -1,0 +1,198 @@
+defmodule FountainWeb.InferenceCredentialController do
+  @moduledoc """
+  Per-user inference provider credentials over the API (ADR 0008, #518).
+
+  A conversation cannot run without one of these, and until now they could only
+  be set in a browser — so an API-only consumer could register, create an agent,
+  and then fail at the one step that matters. This is the same validate → encrypt
+  path the settings LiveView uses, including the provider ping.
+
+  Values are write-only: the API reports which providers are set and never
+  returns a credential, decrypted or otherwise.
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.{Crypto, InferenceCredentials}
+  alias Fountain.InferenceCredentials.{Credential, Validator}
+  alias FountainWeb.{Audited, Schemas}
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  @providers Credential.providers()
+  @provider_strings Enum.map(@providers, &Atom.to_string/1)
+
+  tags(["Inference credentials"])
+
+  operation(:index,
+    summary: "List inference-credential status per provider",
+    description:
+      "Reports which providers have a credential set. Values are never returned — " <>
+        "not even truncated.",
+    responses: [
+      ok: {"Provider status", "application/json", Schemas.InferenceCredentialListResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index(conn, _params) do
+    status = InferenceCredentials.status_for_user(conn.assigns.current_user.id)
+    render(conn, :index, status: status, providers: @providers)
+  end
+
+  operation(:update,
+    summary: "Set a provider credential",
+    description:
+      "Validates the credential against the provider, then stores it encrypted " <>
+        "under the tenant DEK. Set `validate: false` to skip the provider ping — " <>
+        "useful when the provider is unreachable from this instance, at the cost " <>
+        "of finding out about a typo mid-conversation instead of here.",
+    parameters: [
+      provider: [
+        in: :path,
+        type: %OpenApiSpex.Schema{type: :string, enum: @provider_strings},
+        required: true
+      ]
+    ],
+    request_body: {"Credential", "application/json", Schemas.InferenceCredentialRequest},
+    responses: [
+      ok: {"Provider status", "application/json", Schemas.InferenceCredentialResponse},
+      bad_gateway: {"Provider unreachable", "application/json", Schemas.Error},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      gateway_timeout: {"Provider timed out", "application/json", Schemas.Error},
+      unprocessable_entity:
+        {"Rejected credential, blank value, or unknown provider", "application/json",
+         Schemas.Error}
+    ]
+  )
+
+  def update(conn, %{"provider" => provider_str} = params) do
+    user = conn.assigns.current_user
+    value = params |> Map.get("value") |> to_trimmed_string()
+
+    with {:ok, provider} <- parse_provider(provider_str),
+         :ok <- reject_empty(value),
+         :ok <- validate_with_provider(provider, value, params) do
+      persist(conn, user, provider, value)
+    else
+      # Provider-ping outcomes are distinguishable by design (#518): a rejected
+      # credential is the caller's problem, a timeout or an unreachable provider
+      # is not, and a client retrying blindly on 422 would burn quota for
+      # nothing. The LiveView draws the same three distinctions in prose.
+      {:error, :invalid, %{status: status}} ->
+        error(conn, :unprocessable_entity, %{
+          error: "the provider rejected this credential (HTTP #{status})",
+          reason: "invalid",
+          provider_status: status
+        })
+
+      {:error, :timeout} ->
+        error(conn, :gateway_timeout, %{
+          error: "validation timed out talking to the provider",
+          reason: "timeout"
+        })
+
+      {:error, reason} when reason in [:empty_value, :empty] ->
+        error(conn, :unprocessable_entity, %{error: "value is required", reason: "empty_value"})
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+
+      {:error, _network} ->
+        error(conn, :bad_gateway, %{
+          error: "could not reach the provider to validate this credential",
+          reason: "network"
+        })
+    end
+  end
+
+  operation(:delete,
+    summary: "Clear a provider credential",
+    parameters: [
+      provider: [
+        in: :path,
+        type: %OpenApiSpex.Schema{type: :string, enum: @provider_strings},
+        required: true
+      ]
+    ],
+    responses: [
+      no_content: "Cleared",
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      unprocessable_entity: {"Unknown provider", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"provider" => provider_str}) do
+    user = conn.assigns.current_user
+
+    with {:ok, provider} <- parse_provider(provider_str),
+         {:ok, dek} <- load_dek(user.id),
+         {:ok, _cred} <- InferenceCredentials.put_credential(user.id, dek, provider, nil) do
+      audit(conn, "inference_credential.delete", provider)
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  ## Private
+
+  defp persist(conn, user, provider, value) do
+    with {:ok, dek} <- load_dek(user.id),
+         {:ok, _cred} <- InferenceCredentials.put_credential(user.id, dek, provider, value) do
+      audit(conn, "inference_credential.write", provider)
+
+      render(conn, :show,
+        provider: provider,
+        status: InferenceCredentials.status_for_user(user.id)
+      )
+    end
+  end
+
+  # The path parameter is an enum in the spec, so CastAndValidate refuses an
+  # unknown provider (422) before the action runs. This clause is the
+  # fail-closed backstop for a request that somehow arrives without it.
+  defp parse_provider(provider_str) when provider_str in @provider_strings do
+    {:ok, String.to_existing_atom(provider_str)}
+  end
+
+  defp parse_provider(_), do: {:error, :not_found}
+
+  defp reject_empty(""), do: {:error, :empty_value}
+  defp reject_empty(nil), do: {:error, :empty_value}
+  defp reject_empty(_), do: :ok
+
+  defp validate_with_provider(provider, value, params) do
+    if Map.get(params, "validate", true) == false do
+      :ok
+    else
+      Validator.validate(provider, value)
+    end
+  end
+
+  defp load_dek(user_id) do
+    case Crypto.load_tenant_key(user_id) do
+      {:ok, dek} -> {:ok, dek}
+      {:error, _reason} -> {:error, :tenant_key_unavailable}
+    end
+  end
+
+  defp audit(conn, action, provider) do
+    # The provider name is the whole payload — the credential itself must never
+    # reach a second table.
+    Audited.from_conn(conn, action, "inference_credential",
+      resource_id: Atom.to_string(provider),
+      metadata: %{"provider" => Atom.to_string(provider)}
+    )
+  end
+
+  defp to_trimmed_string(value) when is_binary(value), do: String.trim(value)
+  defp to_trimmed_string(_), do: nil
+
+  defp error(conn, status, body) do
+    conn
+    |> put_status(status)
+    |> json(body)
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/inference_credential_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/inference_credential_json.ex
@@ -1,0 +1,15 @@
+defmodule FountainWeb.InferenceCredentialJSON do
+  @moduledoc false
+
+  def index(%{status: status, providers: providers}) do
+    %{data: Enum.map(providers, &provider_json(&1, status))}
+  end
+
+  def show(%{provider: provider, status: status}) do
+    %{data: provider_json(provider, status)}
+  end
+
+  defp provider_json(provider, status) do
+    %{provider: Atom.to_string(provider), set: Map.get(status, provider, false)}
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/inference_credentials_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/inference_credentials_live/index.ex
@@ -93,6 +93,8 @@ defmodule FountainWeb.InferenceCredentialsLive.Index do
       {:ok, dek} ->
         case InferenceCredentials.put_credential(socket.assigns.user_id, dek, provider, nil) do
           {:ok, _} ->
+            audit(socket, "inference_credential.delete", provider)
+
             {:noreply,
              socket
              |> assign(:status, InferenceCredentials.status_for_user(socket.assigns.user_id))
@@ -118,6 +120,8 @@ defmodule FountainWeb.InferenceCredentialsLive.Index do
     with {:ok, dek} <- load_dek(socket.assigns.user_id),
          {:ok, _cred} <-
            InferenceCredentials.put_credential(socket.assigns.user_id, dek, provider, value) do
+      audit(socket, "inference_credential.write", provider)
+
       {:noreply,
        socket
        |> assign(:status, InferenceCredentials.status_for_user(socket.assigns.user_id))
@@ -136,6 +140,16 @@ defmodule FountainWeb.InferenceCredentialsLive.Index do
 
   defp load_dek(user_id) do
     Crypto.load_tenant_key(user_id)
+  end
+
+  # The provider name is the whole payload — the credential itself must never
+  # reach a second table. Matches the events the API controller emits (#518),
+  # so the trail reads the same whichever surface set the credential.
+  defp audit(socket, action, provider) do
+    FountainWeb.Audited.from_socket(socket, action, "inference_credential",
+      resource_id: Atom.to_string(provider),
+      metadata: %{"provider" => Atom.to_string(provider)}
+    )
   end
 
   defp put_provider_message(socket, provider, kind, msg) do

--- a/apps/fountain/lib/fountain_web/plugs/require_full_scope.ex
+++ b/apps/fountain/lib/fountain_web/plugs/require_full_scope.ex
@@ -1,0 +1,57 @@
+defmodule FountainWeb.Plugs.RequireFullScope do
+  @moduledoc """
+  Restricts account-level writes to `full`-scoped API keys.
+
+  Every conversation hands its sprite a tenant API key so the agent can stream,
+  prompt, and spawn sub-agents. Those tokens are `sprite`-scoped and are
+  deliberately weaker than the owner's own key: code running in a sandbox is
+  untrusted by design, so it must not be able to change the account out from
+  under the person who owns it — replace the tenant's inference credentials,
+  rotate the password, delete the account.
+
+  `FountainWeb.Plugs.RequireKeyManagement` is the original, API-key-specific
+  instance of this rule and now delegates here so there is one implementation
+  of "is this credential allowed to act on the account itself".
+
+  Pass `:error` to describe the refused capability; the response always carries
+  `reason: "insufficient_scope"` and `required_scope: "full"` so callers can
+  branch on shape rather than prose.
+
+  Session-authenticated browser routes never reach this plug; it guards the
+  bearer-token API pipeline only.
+  """
+
+  import Plug.Conn
+  import Phoenix.Controller, only: [json: 2]
+
+  alias Fountain.Accounts.ApiKey
+
+  @default_error "This API key is not permitted to perform account-level writes"
+
+  def init(opts), do: opts
+
+  def call(%{assigns: %{current_api_key: %ApiKey{} = key}} = conn, opts) do
+    if ApiKey.may_manage_keys?(key) do
+      conn
+    else
+      refuse(conn, Keyword.get(opts, :error, @default_error))
+    end
+  end
+
+  # No key on the connection means this ran outside the bearer-token pipeline.
+  # Fail closed rather than assume the caller is privileged.
+  def call(conn, _opts) do
+    refuse(conn, "API key scope could not be determined")
+  end
+
+  defp refuse(conn, message) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{
+      error: message,
+      reason: "insufficient_scope",
+      required_scope: "full"
+    })
+    |> halt()
+  end
+end

--- a/apps/fountain/lib/fountain_web/plugs/require_key_management.ex
+++ b/apps/fountain/lib/fountain_web/plugs/require_key_management.ex
@@ -12,38 +12,18 @@ defmodule FountainWeb.Plugs.RequireKeyManagement do
   Sandboxes run untrusted code by design, so that path has to be closed at the
   boundary rather than trusted not to be walked.
 
+  The rule itself now lives in `FountainWeb.Plugs.RequireFullScope`, which other
+  account-level writes reuse; this plug is the key-management wording of it.
+
   Session-authenticated browser routes never reach this plug; it guards the
   bearer-token API pipeline only.
   """
 
-  import Plug.Conn
-  import Phoenix.Controller, only: [json: 2]
+  alias FountainWeb.Plugs.RequireFullScope
 
-  alias Fountain.Accounts.ApiKey
+  @error "This API key is not permitted to manage API keys"
 
   def init(opts), do: opts
 
-  def call(%{assigns: %{current_api_key: %ApiKey{} = key}} = conn, _opts) do
-    if ApiKey.may_manage_keys?(key) do
-      conn
-    else
-      conn
-      |> put_status(:forbidden)
-      |> json(%{
-        error: "This API key is not permitted to manage API keys",
-        reason: "insufficient_scope",
-        required_scope: "full"
-      })
-      |> halt()
-    end
-  end
-
-  # No key on the connection means this ran outside the bearer-token pipeline.
-  # Fail closed rather than assume the caller is privileged.
-  def call(conn, _opts) do
-    conn
-    |> put_status(:forbidden)
-    |> json(%{error: "API key scope could not be determined", reason: "insufficient_scope"})
-    |> halt()
-  end
+  def call(conn, _opts), do: RequireFullScope.call(conn, error: @error)
 end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -87,6 +87,14 @@ defmodule FountainWeb.Router do
     plug FountainWeb.Plugs.RequireKeyManagement
   end
 
+  # Layered on top of :api for account-level writes. Same rule as
+  # :require_key_management, wider remit: a leaked per-conversation sprite token
+  # must not be able to replace the tenant's inference credentials any more than
+  # it can mint a second API key.
+  pipeline :require_full_scope do
+    plug FountainWeb.Plugs.RequireFullScope
+  end
+
   ## ─── Public routes ────────────────────────────────────────────────────────────────────
 
   scope "/", FountainWeb do
@@ -196,6 +204,17 @@ defmodule FountainWeb.Router do
     get "/api-keys", ApiKeyController, :index
     post "/api-keys", ApiKeyController, :create
     delete "/api-keys/:id", ApiKeyController, :delete
+  end
+
+  # Account-level configuration. Inference credentials are what a conversation
+  # actually runs on, so a sprite token replacing them is the same class of
+  # escalation as minting an API key — hence the full-scope gate (#518).
+  scope "/api/account", FountainWeb do
+    pipe_through [:accepts_json, :api, :require_full_scope]
+
+    get "/inference-credentials", InferenceCredentialController, :index
+    put "/inference-credentials/:provider", InferenceCredentialController, :update
+    delete "/inference-credentials/:provider", InferenceCredentialController, :delete
   end
 
   scope "/api", FountainWeb do

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -795,6 +795,75 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule InferenceCredentialStatus do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "InferenceCredentialStatus",
+      description:
+        "Whether a provider credential is set for the tenant. Values are " <>
+          "write-only — the API never returns a credential, truncated or otherwise.",
+      type: :object,
+      properties: %{
+        provider: %Schema{
+          type: :string,
+          enum: ~w(anthropic_api_key claude_code_oauth_token openai_api_key gemini_api_key)
+        },
+        set: %Schema{type: :boolean}
+      },
+      required: [:provider, :set]
+    })
+  end
+
+  defmodule InferenceCredentialResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "InferenceCredentialResponse",
+      type: :object,
+      properties: %{data: InferenceCredentialStatus},
+      required: [:data]
+    })
+  end
+
+  defmodule InferenceCredentialListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "InferenceCredentialListResponse",
+      type: :object,
+      properties: %{data: %Schema{type: :array, items: InferenceCredentialStatus}},
+      required: [:data]
+    })
+  end
+
+  defmodule InferenceCredentialRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "InferenceCredentialRequest",
+      type: :object,
+      properties: %{
+        value: %Schema{
+          type: :string,
+          description: "The provider token (write-only)."
+        },
+        validate: %Schema{
+          type: :boolean,
+          default: true,
+          description:
+            "Ping the provider to check the credential before storing it. " <>
+              "false stores it unchecked."
+        }
+      },
+      required: [:value]
+    })
+  end
+
   defmodule HealthResponse do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/inference_credential_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/inference_credential_controller_test.exs
@@ -1,0 +1,313 @@
+defmodule FountainWeb.InferenceCredentialControllerTest do
+  @moduledoc """
+  BYO inference credentials over the API (#518).
+
+  A conversation cannot run without one of these, and they could only be set in
+  a browser — so an API-only consumer could register, create an agent, and then
+  fail at the one step that matters. These tests pin the headless path, the
+  provider-ping outcomes it has to distinguish, and the scope gate that keeps a
+  sandbox from replacing the tenant's keys.
+  """
+
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.{Crypto, InferenceCredentials}
+
+  setup do
+    user = insert_verified_user()
+    {_rec, key} = insert_api_key(user)
+    {:ok, user: user, key: key}
+  end
+
+  defp ping_ok, do: stub(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 200}} end)
+
+  defp stored_value(user, provider) do
+    {:ok, dek} = Crypto.load_tenant_key(user.id)
+    {:ok, creds} = InferenceCredentials.decrypted_for_user(user.id, dek)
+    Map.get(creds, provider)
+  end
+
+  defp audit_actions(user_id) do
+    user_id |> Fountain.Audit.list_recent_for_user(100) |> Enum.map(& &1.action)
+  end
+
+  describe "GET /api/account/inference-credentials" do
+    test "reports every provider, unset", %{conn: conn, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/account/inference-credentials")
+        |> json_response(200)
+
+      providers = Enum.map(body["data"], & &1["provider"])
+
+      assert Enum.sort(providers) ==
+               ~w(anthropic_api_key claude_code_oauth_token gemini_api_key openai_api_key)
+
+      refute Enum.any?(body["data"], & &1["set"])
+    end
+
+    test "reports a set provider without ever returning the value", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :openai_api_key, "sk-live-xyz")
+
+      conn = conn |> authed_with_key(key) |> get("/api/account/inference-credentials")
+      body = json_response(conn, 200)
+
+      assert Enum.find(body["data"], &(&1["provider"] == "openai_api_key"))["set"]
+      refute conn.resp_body =~ "sk-live-xyz"
+    end
+  end
+
+  describe "PUT /api/account/inference-credentials/:provider" do
+    test "validates against the provider, then stores encrypted", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      ping_ok()
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_json("/api/account/inference-credentials/anthropic_api_key", %{
+          "value" => "sk-ant-real"
+        })
+        |> json_response(200)
+
+      assert body["data"] == %{"provider" => "anthropic_api_key", "set" => true}
+      assert stored_value(user, :anthropic_api_key) == "sk-ant-real"
+      assert "inference_credential.write" in audit_actions(user.id)
+    end
+
+    test "the credential is never echoed back", %{conn: conn, key: key} do
+      ping_ok()
+
+      conn =
+        conn
+        |> authed_with_key(key)
+        |> put_json("/api/account/inference-credentials/openai_api_key", %{
+          "value" => "sk-openai-secret"
+        })
+
+      assert json_response(conn, 200)
+      refute conn.resp_body =~ "sk-openai-secret"
+    end
+
+    test "the credential never reaches the audit log", %{conn: conn, user: user, key: key} do
+      ping_ok()
+
+      conn
+      |> authed_with_key(key)
+      |> put_json("/api/account/inference-credentials/openai_api_key", %{
+        "value" => "sk-openai-secret"
+      })
+      |> json_response(200)
+
+      events = Fountain.Audit.list_recent_for_user(user.id, 100)
+
+      # Guard the guard (#406): an empty trail would make the refute vacuous.
+      assert Enum.any?(events, &(&1.action == "inference_credential.write"))
+
+      for event <- events, do: refute(inspect(event.metadata) =~ "sk-openai-secret")
+    end
+
+    test "a provider rejection is 422 and stores nothing", %{conn: conn, user: user, key: key} do
+      stub(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 401}} end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_json("/api/account/inference-credentials/anthropic_api_key", %{"value" => "typo"})
+        |> json_response(422)
+
+      assert body["reason"] == "invalid"
+      assert body["provider_status"] == 401
+      refute stored_value(user, :anthropic_api_key)
+    end
+
+    test "a timeout is 504, not 422 — the caller should retry, not re-type", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      stub(Req, :get, fn _url, _opts -> {:error, %{reason: :timeout}} end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_json("/api/account/inference-credentials/gemini_api_key", %{"value" => "g-key"})
+        |> json_response(504)
+
+      assert body["reason"] == "timeout"
+      refute stored_value(user, :gemini_api_key)
+    end
+
+    test "an unreachable provider is 502", %{conn: conn, key: key} do
+      stub(Req, :get, fn _url, _opts -> {:error, %{reason: :nxdomain}} end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_json("/api/account/inference-credentials/openai_api_key", %{"value" => "sk-x"})
+        |> json_response(502)
+
+      assert body["reason"] == "network"
+    end
+
+    test "validate: false stores without pinging the provider", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      # The settings page tells users they can "save anyway from the API" when
+      # validation fails; that has to be true.
+      reject(Req, :get, 2)
+
+      conn
+      |> authed_with_key(key)
+      |> put_json("/api/account/inference-credentials/openai_api_key", %{
+        "value" => "sk-unchecked",
+        "validate" => false
+      })
+      |> json_response(200)
+
+      assert stored_value(user, :openai_api_key) == "sk-unchecked"
+    end
+
+    test "a blank value is refused before any provider call", %{conn: conn, key: key} do
+      reject(Req, :get, 2)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_json("/api/account/inference-credentials/openai_api_key", %{"value" => "   "})
+        |> json_response(422)
+
+      assert body["reason"] == "empty_value"
+    end
+
+    test "an unknown provider is refused by the spec, before any provider call", %{
+      conn: conn,
+      key: key
+    } do
+      # The provider list is an enum in the OpenAPI path parameter, so
+      # CastAndValidate refuses it (422) before the action runs.
+      reject(Req, :get, 2)
+
+      conn
+      |> authed_with_key(key)
+      |> put_json("/api/account/inference-credentials/nope", %{"value" => "x"})
+      |> json_response(422)
+    end
+  end
+
+  describe "DELETE /api/account/inference-credentials/:provider" do
+    test "clears the credential", %{conn: conn, user: user, key: key} do
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :gemini_api_key, "g-key")
+
+      conn
+      |> authed_with_key(key)
+      |> delete("/api/account/inference-credentials/gemini_api_key")
+      |> response(204)
+
+      refute stored_value(user, :gemini_api_key)
+      assert "inference_credential.delete" in audit_actions(user.id)
+    end
+
+    test "clearing one provider leaves the others alone", %{conn: conn, user: user, key: key} do
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :gemini_api_key, "g-key")
+      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :openai_api_key, "o-key")
+
+      conn
+      |> authed_with_key(key)
+      |> delete("/api/account/inference-credentials/gemini_api_key")
+      |> response(204)
+
+      assert stored_value(user, :openai_api_key) == "o-key"
+    end
+  end
+
+  describe "the full-scope gate" do
+    setup %{user: user} do
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+      {:ok, sprite_key: sprite_key}
+    end
+
+    test "a sprite token cannot replace the tenant's credentials", %{
+      conn: conn,
+      user: user,
+      sprite_key: sprite_key
+    } do
+      # The escalation that matters: code inside a sandbox swapping the keys the
+      # account runs on, or reading which providers are configured.
+      reject(Req, :get, 2)
+
+      body =
+        conn
+        |> authed_with_key(sprite_key)
+        |> put_json("/api/account/inference-credentials/anthropic_api_key", %{"value" => "sk-evil"})
+        |> json_response(403)
+
+      assert body["reason"] == "insufficient_scope"
+      assert body["required_scope"] == "full"
+      refute stored_value(user, :anthropic_api_key)
+    end
+
+    test "a sprite token cannot clear a credential", %{conn: conn, user: user, sprite_key: key} do
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :openai_api_key, "o-key")
+
+      conn
+      |> authed_with_key(key)
+      |> delete("/api/account/inference-credentials/openai_api_key")
+      |> json_response(403)
+
+      assert stored_value(user, :openai_api_key) == "o-key"
+    end
+
+    test "a sprite token cannot list credential status", %{conn: conn, sprite_key: key} do
+      conn
+      |> authed_with_key(key)
+      |> get("/api/account/inference-credentials")
+      |> json_response(403)
+    end
+
+    test "an ordinary full key is allowed", %{conn: conn, key: key} do
+      conn
+      |> authed_with_key(key)
+      |> get("/api/account/inference-credentials")
+      |> json_response(200)
+    end
+  end
+
+  describe "authentication" do
+    test "no bearer token is 401", %{conn: conn} do
+      conn
+      |> put_req_header("accept", "application/json")
+      |> get("/api/account/inference-credentials")
+      |> json_response(401)
+    end
+
+    test "one tenant cannot see another's status", %{conn: conn, key: key} do
+      other = insert_verified_user()
+      {:ok, dek} = Crypto.load_tenant_key(other.id)
+      {:ok, _} = InferenceCredentials.put_credential(other.id, dek, :openai_api_key, "not-yours")
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/account/inference-credentials")
+        |> json_response(200)
+
+      refute Enum.any?(body["data"], & &1["set"])
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,31 @@ DELETE /api/auth/api-keys/:id      # revoke a key
 
 **Session cookie:** Obtained via OAuth at `/auth/oauth/:provider` or email/password login. Used by the web UI.
 
+## Inference credentials
+
+Conversations run on your own provider tokens (BYO — Fountain never sees your inference traffic), so a new account cannot start a conversation until at least one is set.
+
+```
+GET    /api/account/inference-credentials             # per-provider set/not-set
+PUT    /api/account/inference-credentials/:provider   # {"value": "...", "validate": true}
+DELETE /api/account/inference-credentials/:provider   # clear
+```
+
+Providers: `anthropic_api_key`, `claude_code_oauth_token`, `openai_api_key`, `gemini_api_key`.
+
+`PUT` pings the provider to check the credential before storing it. The outcomes are distinguishable so a client knows whether to re-type or retry:
+
+| Status | Meaning |
+|---|---|
+| `200` | Stored (encrypted under your tenant key) |
+| `422` | `invalid` — the provider rejected it (`provider_status` carries the upstream code); or a blank value; or an unknown provider |
+| `502` | `network` — the provider was unreachable from this instance |
+| `504` | `timeout` — the provider did not answer in time |
+
+Send `{"validate": false}` to store a credential without the ping.
+
+Values are **write-only** — these endpoints report only whether a provider is set. They require a `full`-scoped key: the per-conversation token a sandbox holds cannot read or replace the account's credentials.
+
 ## Rate limiting
 
 Requests are rate-limited per client IP (authenticated or not — the limiter does not key by API key). On limit hit: `429 Too Many Requests` with `Retry-After` header.


### PR DESCRIPTION
Closes #518. **Merge after #556** (stacked on `api/530-secret-audit`; GitHub retargets this to `main` once that merges).

## Why

`Fountain.InferenceCredentials.put_credential/4` had two callers — the settings LiveView and the onboarding wizard. A conversation can't run without a credential, so an API-only consumer could register, mint a key, create an agent, and then dead-end. This was the hardest blocker on the headless `register → configure → run` path.

## Endpoints

```
GET    /api/account/inference-credentials             # [{provider, set}] — never a value
PUT    /api/account/inference-credentials/:provider   # {"value": "...", "validate": true}
DELETE /api/account/inference-credentials/:provider
```

Same validate → encrypt path the LiveView uses. Provider-ping outcomes are surfaced distinctly, which the issue asked for and a CLI genuinely needs:

| Status | `reason` | Meaning |
|---|---|---|
| 422 | `invalid` | provider rejected it; `provider_status` carries the upstream code |
| 422 | `empty_value` | blank value, refused before any provider call |
| 504 | `timeout` | provider didn't answer |
| 502 | `network` | provider unreachable from this instance |

`{"validate": false}` stores without the ping — the settings page already tells users they can "save anyway from the API", so now that's true. Unknown providers are refused by the spec enum (422) before the action runs.

## Scope gate

Behind `full` scope, per the issue's leaning: a leaked sprite token replacing the tenant's inference keys is the same class of escalation as minting a second API key. Reads are gated too — a sandbox has no reason to enumerate account configuration.

The rule moved into a reusable `Plugs.RequireFullScope` (new `:require_full_scope` pipeline); `RequireKeyManagement` now delegates to it, keeping its own wording. #521/#523/#527 need the same gate, and one implementation beats a copy each. Existing scope tests assert on `reason`, which is unchanged; responses now also carry `required_scope: "full"`.

## Also

- `inference_credential.write` / `.delete` audit events from **both** surfaces — the LiveView emitted none either.
- OpenAPI schemas + `docs/api.md` section; spec regenerates and validates.

## Tests

19 in `inference_credential_controller_test.exs`: status listing, store+decrypt round-trip, value never echoed and never in the audit trail (with the #406 guard-the-guard), each of the four ping outcomes, `validate: false` asserting `Req.get` is never called, clear-one-leaves-others, the sprite-token gate on all three verbs, 401 unauthenticated, and cross-tenant isolation.

Full suite green (2,079 tests), `mix format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)