### PR TITLE
api: JSON endpoint for conversation log events (#519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ upgrade, is in
 
 ### Added
 
+- **A conversation's log events are readable as JSON**, not only as an SSE
+  stream: `GET /api/conversations/:id/events`, cursor-paginated
+  (`?after=`, `?limit=`) with the same `?streams=` filter the stream takes.
+  Draining history with `?wait=false` still returned `text/event-stream`, so
+  anything fetching, archiving or analysing a conversation's output had to
+  implement an event-stream parser for what is a paginated list read. Rows
+  carry the same fields the stream sends plus each event's `id` — the same
+  value the stream uses as `Last-Event-ID`, so a client can page through
+  history and then attach the tail exactly where it stopped (#519)
+
 - **Inference credentials can be set over the API**, so an account can be
   bootstrapped without ever opening a browser: `GET/PUT/DELETE
   /api/account/inference-credentials[/:provider]`. A conversation cannot run

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -737,6 +737,16 @@ defmodule Fountain.Conversations do
     event
   end
 
+  @doc """
+  List a conversation's log events after `after_id`, oldest first.
+
+  Options:
+
+    * `:streams` — allow-list of `"stdout"` / `"stderr"` / `"stage"`
+    * `:limit` — cap the number of rows returned. A log feed is unbounded
+      in principle (a chatty agent writes tens of thousands of rows), so
+      the JSON read-model paginates rather than materialising all of it.
+  """
   def _unsafe_list_log_events(conversation_id, after_id \\ 0, opts \\ []) do
     base =
       from e in LogEvent,
@@ -745,8 +755,14 @@ defmodule Fountain.Conversations do
 
     base
     |> apply_streams_filter(Keyword.get(opts, :streams))
+    |> apply_limit(Keyword.get(opts, :limit))
     |> Repo.all()
   end
+
+  defp apply_limit(query, nil), do: query
+
+  defp apply_limit(query, limit) when is_integer(limit) and limit > 0,
+    do: from(e in query, limit: ^limit)
 
   # `streams` is a list of allowed stream identifiers. We accept the
   # three values that show up in log_events: `"stdout"`, `"stderr"`, and

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -66,6 +66,93 @@ defmodule FountainWeb.ConversationController do
     end
   end
 
+  @default_event_limit 100
+  @max_event_limit 1000
+
+  operation(:events,
+    summary: "List a conversation's log events",
+    description:
+      "The read-model behind the SSE stream. Same rows, same fields, as JSON — " <>
+        "fetching or archiving a conversation's output no longer requires an SSE " <>
+        "parser. Oldest first, cursor-paginated: pass the previous page's " <>
+        "`meta.next_cursor` as `after`. SSE remains the tail/follow mechanism.",
+    parameters: [
+      conversation_id: [in: :path, type: :string, required: true],
+      streams: [
+        in: :query,
+        type: :string,
+        required: false,
+        description:
+          "Comma-separated allow-list of `stdout`, `stderr`, `stage`. " <>
+            "Same semantics as the SSE route; omitted means everything."
+      ],
+      after: [
+        in: :query,
+        type: :integer,
+        required: false,
+        description: "Return events with an id greater than this. Defaults to 0."
+      ],
+      limit: [
+        in: :query,
+        type: :integer,
+        required: false,
+        description: "Page size, 1..#{@max_event_limit}. Defaults to #{@default_event_limit}."
+      ]
+    ],
+    responses: [
+      ok: {"Log events", "application/json", Schemas.LogEventListResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def events(conn, %{"conversation_id" => id} = params) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
+      nil ->
+        {:error, :not_found}
+
+      _ ->
+        limit = parse_limit(params["limit"])
+        after_id = parse_after(params["after"])
+        streams = parse_streams_param(params["streams"])
+
+        # Ownership: established by the scoped get_conversation above.
+        # One extra row decides has_more without a second count query.
+        events =
+          Conversations._unsafe_list_log_events(id, after_id,
+            streams: streams,
+            limit: limit + 1
+          )
+
+        {page, has_more?} = split_page(events, limit)
+
+        render(conn, :events, events: page, has_more: has_more?, limit: limit)
+    end
+  end
+
+  defp split_page(events, limit) do
+    case Enum.split(events, limit) do
+      {page, []} -> {page, false}
+      {page, _extra} -> {page, true}
+    end
+  end
+
+  defp parse_limit(nil), do: @default_event_limit
+  defp parse_limit(n) when is_integer(n), do: n |> max(1) |> min(@max_event_limit)
+
+  defp parse_limit(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, _} -> parse_limit(n)
+      :error -> @default_event_limit
+    end
+  end
+
+  defp parse_after(nil), do: 0
+  defp parse_after(n) when is_integer(n) and n > 0, do: n
+  defp parse_after(n) when is_integer(n), do: 0
+  defp parse_after(s) when is_binary(s), do: s |> parse_last_event_id() |> max(0)
+
   operation(:create,
     summary: "Start a conversation",
     description:

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -1,10 +1,24 @@
 defmodule FountainWeb.ConversationJSON do
   @moduledoc false
-  alias Fountain.Conversations.{Conversation, Sandbox, Turn}
+  alias Fountain.Conversations.{Conversation, LogEvent, Sandbox, Turn}
 
   def index(%{conversations: convs}), do: %{data: Enum.map(convs, &data/1)}
   def show(%{conversation: conv}), do: %{data: data(conv)}
   def turns(%{turns: turns}), do: %{data: Enum.map(turns, &turn_data/1)}
+
+  def events(%{events: events, has_more: has_more?, limit: limit}) do
+    %{
+      data: Enum.map(events, &log_event_data/1),
+      meta: %{
+        limit: limit,
+        has_more: has_more?,
+        # The id to pass back as `after`. nil on an empty page — there is
+        # nothing to resume from, and echoing the request's cursor would
+        # invite a client to loop on it.
+        next_cursor: events |> List.last() |> event_id()
+      }
+    }
+  end
 
   def data(%Conversation{} = c) do
     %{
@@ -32,6 +46,26 @@ defmodule FountainWeb.ConversationJSON do
   end
 
   defp sandbox_data(_), do: nil
+
+  # Field-for-field the SSE payload, plus `id` (the pagination cursor and the
+  # SSE `Last-Event-ID`) and `duration_ms`, which stage events carry and the
+  # UI's timeline reads.
+  defp log_event_data(%LogEvent{} = e) do
+    %{
+      id: e.id,
+      kind: e.kind,
+      stream: e.stream,
+      data: e.data,
+      stage: e.stage,
+      state: e.state,
+      duration_ms: e.duration_ms,
+      turn_id: e.turn_id,
+      ts: e.inserted_at
+    }
+  end
+
+  defp event_id(%LogEvent{id: id}), do: id
+  defp event_id(nil), do: nil
 
   defp turn_data(%Turn{} = t) do
     %{

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -238,6 +238,8 @@ defmodule FountainWeb.Router do
       post "/interrupt", ConversationController, :interrupt, as: :interrupt
       post "/terminate", ConversationController, :terminate, as: :terminate
       get "/turns", ConversationController, :turns, as: :turns
+      # The JSON read-model for the log feed; /stream below is the tail (#519).
+      get "/events", ConversationController, :events, as: :events
       get "/turns/:turn_id/images/:position", TurnImageController, :show, as: :turn_image
     end
   end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -795,6 +795,67 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule LogEvent do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "LogEvent",
+      description:
+        "One line of a conversation's log feed: runtime output or a lifecycle " <>
+          "stage transition. Same fields the SSE stream sends, plus `id`.",
+      type: :object,
+      properties: %{
+        id: %Schema{
+          type: :integer,
+          description: "Monotonic id. Pagination cursor here, `Last-Event-ID` on the SSE route."
+        },
+        kind: %Schema{type: :string, enum: ~w(output stage)},
+        stream: %Schema{
+          type: :string,
+          description: "`stdout` / `stderr` for output events; empty for stage events."
+        },
+        data: %Schema{
+          type: :string,
+          description: "Output text, or JSON-encoded metadata for stage events."
+        },
+        stage: %Schema{type: :string, description: "Lifecycle stage name (stage events)."},
+        state: %Schema{type: :string, enum: ~w(started done failed interrupted), nullable: true},
+        duration_ms: %Schema{type: :integer, nullable: true},
+        turn_id: %Schema{type: :string, format: :uuid, nullable: true},
+        ts: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :kind, :ts]
+    })
+  end
+
+  defmodule LogEventListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "LogEventListResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{type: :array, items: LogEvent},
+        meta: %Schema{
+          type: :object,
+          properties: %{
+            limit: %Schema{type: :integer},
+            has_more: %Schema{type: :boolean},
+            next_cursor: %Schema{
+              type: :integer,
+              nullable: true,
+              description: "Pass as `after` to fetch the next page. null when the page is empty."
+            }
+          },
+          required: [:limit, :has_more]
+        }
+      },
+      required: [:data, :meta]
+    })
+  end
+
   defmodule InferenceCredentialStatus do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/conversation_events_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_events_controller_test.exs
@@ -1,0 +1,191 @@
+defmodule FountainWeb.ConversationEventsControllerTest do
+  @moduledoc """
+  The JSON read-model for a conversation's log feed (#519).
+
+  Before this, the only access to log events over the API was the SSE stream —
+  so anything wanting to fetch, archive or analyse a conversation's output had
+  to implement an event-stream parser for what is a paginated list read.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  setup do
+    user = insert_verified_user()
+    {_rec, key} = insert_api_key(user)
+    conv = insert_conversation(user_id: user.id)
+    {:ok, user: user, key: key, conv: conv}
+  end
+
+  defp get_events(conn, key, conv, query \\ "") do
+    conn |> authed_with_key(key) |> get("/api/conversations/#{conv.id}/events" <> query)
+  end
+
+  describe "GET /api/conversations/:id/events" do
+    test "returns the feed oldest-first with the SSE payload's fields", %{
+      conn: conn,
+      key: key,
+      conv: conv
+    } do
+      first = insert_log_event(conv, kind: "output", stream: "stdout", data: "hello")
+      second = insert_log_event(conv, kind: "stage", stream: "", stage: "provision")
+
+      body = conn |> get_events(key, conv) |> json_response(200)
+
+      assert Enum.map(body["data"], & &1["id"]) == [first.id, second.id]
+
+      assert %{
+               "id" => _,
+               "kind" => "output",
+               "stream" => "stdout",
+               "data" => "hello",
+               "stage" => _,
+               "state" => _,
+               "duration_ms" => _,
+               "turn_id" => _,
+               "ts" => _
+             } = hd(body["data"])
+    end
+
+    test "an empty feed is an empty page, not an error", %{conn: conn, key: key, conv: conv} do
+      body = conn |> get_events(key, conv) |> json_response(200)
+
+      assert body["data"] == []
+      assert body["meta"]["has_more"] == false
+      assert body["meta"]["next_cursor"] == nil
+    end
+
+    test "filters by stream, with the same semantics as the SSE route", %{
+      conn: conn,
+      key: key,
+      conv: conv
+    } do
+      out = insert_log_event(conv, kind: "output", stream: "stdout", data: "o")
+      err = insert_log_event(conv, kind: "output", stream: "stderr", data: "e")
+      stage = insert_log_event(conv, kind: "stage", stream: "", stage: "boot")
+
+      ids = fn query ->
+        conn |> get_events(key, conv, query) |> json_response(200) |> Map.fetch!("data")
+      end
+
+      assert ids.("?streams=stdout") |> Enum.map(& &1["id"]) == [out.id]
+      assert ids.("?streams=stage") |> Enum.map(& &1["id"]) == [stage.id]
+
+      assert ids.("?streams=stderr,stage") |> Enum.map(& &1["id"]) == [err.id, stage.id]
+    end
+
+    test "an unknown stream name returns nothing rather than everything", %{
+      conn: conn,
+      key: key,
+      conv: conv
+    } do
+      insert_log_event(conv, kind: "output", stream: "stdout")
+
+      body = conn |> get_events(key, conv, "?streams=bogus") |> json_response(200)
+      assert body["data"] == []
+    end
+  end
+
+  describe "pagination" do
+    test "pages through the feed with next_cursor", %{conn: conn, key: key, conv: conv} do
+      events = for i <- 1..5, do: insert_log_event(conv, data: "line #{i}")
+      ids = Enum.map(events, & &1.id)
+
+      page1 = conn |> get_events(key, conv, "?limit=2") |> json_response(200)
+      assert Enum.map(page1["data"], & &1["id"]) == Enum.take(ids, 2)
+      assert page1["meta"]["has_more"]
+      assert page1["meta"]["next_cursor"] == Enum.at(ids, 1)
+
+      page2 =
+        conn
+        |> get_events(key, conv, "?limit=2&after=#{page1["meta"]["next_cursor"]}")
+        |> json_response(200)
+
+      assert Enum.map(page2["data"], & &1["id"]) == Enum.slice(ids, 2, 2)
+      assert page2["meta"]["has_more"]
+
+      page3 =
+        conn
+        |> get_events(key, conv, "?limit=2&after=#{page2["meta"]["next_cursor"]}")
+        |> json_response(200)
+
+      assert Enum.map(page3["data"], & &1["id"]) == [List.last(ids)]
+
+      # The last page must say so — a client that keeps following has_more
+      # would loop forever on a finished conversation.
+      refute page3["meta"]["has_more"]
+    end
+
+    test "the limit is capped so a huge feed cannot be pulled in one request", %{
+      conn: conn,
+      key: key,
+      conv: conv
+    } do
+      insert_log_event(conv)
+
+      body = conn |> get_events(key, conv, "?limit=99999") |> json_response(200)
+      assert body["meta"]["limit"] == 1000
+    end
+
+    test "a zero or negative limit clamps to one page of one", %{
+      conn: conn,
+      key: key,
+      conv: conv
+    } do
+      insert_log_event(conv)
+
+      assert conn |> get_events(key, conv, "?limit=0") |> json_response(200) |> get_in([
+               "meta",
+               "limit"
+             ]) == 1
+
+      assert conn |> get_events(key, conv, "?limit=-5") |> json_response(200) |> get_in([
+               "meta",
+               "limit"
+             ]) == 1
+    end
+
+    test "a non-numeric limit is refused by the spec", %{conn: conn, key: key, conv: conv} do
+      conn |> get_events(key, conv, "?limit=abc") |> json_response(422)
+    end
+
+    test "has_more accounts for the stream filter, not just the raw feed", %{
+      conn: conn,
+      key: key,
+      conv: conv
+    } do
+      # Two stdout rows either side of noise: paging over a filtered feed must
+      # not report more pages because of rows the filter removed.
+      a = insert_log_event(conv, kind: "output", stream: "stdout", data: "a")
+      insert_log_event(conv, kind: "output", stream: "stderr", data: "noise")
+      b = insert_log_event(conv, kind: "output", stream: "stdout", data: "b")
+
+      body = conn |> get_events(key, conv, "?streams=stdout&limit=2") |> json_response(200)
+
+      assert Enum.map(body["data"], & &1["id"]) == [a.id, b.id]
+      refute body["meta"]["has_more"]
+    end
+  end
+
+  describe "tenant scoping" do
+    test "another tenant's conversation is 404, not 403", %{conn: conn, key: key} do
+      other = insert_verified_user()
+      other_conv = insert_conversation(user_id: other.id)
+      insert_log_event(other_conv, data: "secret output")
+
+      conn =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations/#{other_conv.id}/events")
+
+      assert json_response(conn, 404)
+      refute conn.resp_body =~ "secret output"
+    end
+
+    test "requires authentication", %{conn: conn, conv: conv} do
+      conn
+      |> put_req_header("accept", "application/json")
+      |> get("/api/conversations/#{conv.id}/events")
+      |> json_response(401)
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,8 +131,18 @@ POST   /api/conversations/:id/prompts      # follow-up turn
 POST   /api/conversations/:id/interrupt    # stop the running turn
 POST   /api/conversations/:id/terminate    # end the conversation and sandbox
 GET    /api/conversations/:id/turns
+GET    /api/conversations/:id/events       # log events as JSON (?streams=  ?after=  ?limit=)
 GET    /api/conversations/:id/stream       # SSE log stream (?streams=stdout,stderr,stage  ?wait=false)
 ```
+
+`/events` is the read-model for the log feed and `/stream` is the tail. The JSON endpoint returns the same rows the stream sends — `kind`, `stream`, `data`, `stage`, `state`, `duration_ms`, `turn_id`, `ts` — plus each event's `id`, oldest first:
+
+```json
+{"data": [{"id": 41, "kind": "output", "stream": "stdout", "data": "...", "ts": "..."}],
+ "meta": {"limit": 100, "has_more": true, "next_cursor": 41}}
+```
+
+Page by passing the previous response's `meta.next_cursor` as `after`; keep going while `meta.has_more` is true. `limit` defaults to 100 and caps at 1000. The `id` is the same value the SSE route uses as `Last-Event-ID`, so a client can drain history as JSON and then attach the stream from where it left off.
 
 ## Error responses
 


### PR DESCRIPTION
Closes #519. **Merge after #557** (stack: #556 → #557 → this).

## Why

The log feed had exactly one API surface: SSE. `?wait=false` drains history but still answers `text/event-stream`, so anything that wants to fetch/archive/analyse a conversation's output had to implement an event-stream parser for what is a paginated list read.

## Shape

```
GET /api/conversations/:id/events?streams=stdout,stderr,stage&after=<id>&limit=<n>
```

```json
{"data": [{"id": 41, "kind": "output", "stream": "stdout", "data": "…",
           "stage": "", "state": "", "duration_ms": null, "turn_id": "…", "ts": "…"}],
 "meta": {"limit": 100, "has_more": true, "next_cursor": 41}}
```

- Same rows and field names the SSE payload uses, plus `id` and `duration_ms` (stage events carry it; the issue asked whether to expose the UI's computed annotation — the column already exists, so it's served rather than recomputed).
- `?streams=` has identical semantics to the stream route, including "all names unknown → return nothing, not everything".
- Cursor pagination: `next_cursor` is the last row's id, `has_more` comes from fetching `limit + 1` (no second count query). `limit` defaults to 100, caps at 1000, clamps at 1.
- The cursor **is** the SSE `Last-Event-ID`, so a client can page through history as JSON and then attach the stream exactly where it stopped.

`Conversations._unsafe_list_log_events/3` grows a `:limit` option; the SSE replay path passes none and is unchanged. Ownership follows the #383 pattern — scoped `get_conversation`, `_unsafe_` child call adjacent, comment naming the fetch that established it.

## Tests

11 in a new `conversation_events_controller_test.exs`: field shape, ordering, empty feed, each stream filter, unknown stream name, three-page walk asserting the last page reports `has_more: false` (a client following it blindly would otherwise loop), limit cap/clamp, non-numeric limit refused by the spec, `has_more` computed **after** the stream filter, cross-tenant 404 with a body check that no foreign output leaked, and 401.

`mix format` / `credo --strict` clean; conversation + context suites pass (153 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)