### PR TITLE
api: close the conversation read-model gaps (#520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ upgrade, is in
 
 ### Added
 
+- **The conversation read-model the UI has is now the one the API serves.**
+  Conversation JSON gained `title`, `turn_count`, `last_active_at`,
+  `last_read_at` and a computed `unread`; `GET /api/conversations` takes
+  `?roots_only=true` (the context supported it, no caller passed it);
+  `POST /api/conversations/:id/read` marks one read; and
+  `GET /api/conversations/:id/tree` returns the whole spawn tree —
+  ancestors and descendants — so an agent that fanned out can enumerate its
+  own sub-conversations instead of keeping client-side bookkeeping.
+  `GET /api/conversations/:id` now reports real counts rather than the
+  struct defaults. The unread rule had three copies in the web layer and now
+  has one, in the context (#520)
+
 - **A conversation's log events are readable as JSON**, not only as an SSE
   stream: `GET /api/conversations/:id/events`, cursor-paginated
   (`?after=`, `?limit=`) with the same `?streams=` filter the stream takes.

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -463,28 +463,7 @@ defmodule Fountain.Conversations do
   def list_conversations(user_id, opts \\ []) when is_binary(user_id) do
     roots_only = Keyword.get(opts, :roots_only, false)
 
-    last_log_at =
-      from le in LogEvent,
-        where: le.kind == "output",
-        group_by: le.conversation_id,
-        select: %{conversation_id: le.conversation_id, last_at: max(le.inserted_at)}
-
-    base =
-      from c in Conversation,
-        as: :conv,
-        where: c.user_id == ^user_id,
-        left_join: ll in subquery(last_log_at),
-        on: ll.conversation_id == c.id,
-        order_by: [desc: c.updated_at, desc: c.id],
-        select: %{
-          c
-          | last_active_at:
-              fragment(
-                "COALESCE(? AT TIME ZONE 'UTC', ? AT TIME ZONE 'UTC')",
-                ll.last_at,
-                c.inserted_at
-              )
-        }
+    base = from(c in annotated_query(user_id), order_by: [desc: c.updated_at, desc: c.id])
 
     query =
       if roots_only do
@@ -496,6 +475,75 @@ defmodule Fountain.Conversations do
     Repo.all(query)
     |> Repo.preload([:agent, turns: first_turn_query()])
   end
+
+  @doc """
+  Scoped fetch that also populates the read-model annotations —
+  `turn_count` and `last_active_at` — which `get_conversation/2` leaves at
+  their defaults.
+
+  Separate from `get_conversation/2` on purpose: that one is on the hot path
+  of every prompt and interrupt, and does not need two extra joins to answer
+  "does this conversation exist and is it yours".
+  """
+  def get_conversation_with_activity(id, user_id) when is_binary(user_id) do
+    case Repo.one(from(c in annotated_query(user_id), where: c.id == ^id)) do
+      nil -> nil
+      conv -> Repo.preload(conv, [:sandbox, :agent, :vault])
+    end
+  end
+
+  # The conversation list read-model: turn counts and last activity, both as
+  # LEFT JOINed subqueries so the result stays a plain list of structs and no
+  # caller N+1s.
+  #
+  # Only `kind: "output"` log events count toward `last_active_at` — stage
+  # events (reconnects, sandbox lifecycle) would otherwise produce false
+  # unread indicators.
+  defp annotated_query(user_id) do
+    turn_counts =
+      from t in Turn,
+        group_by: t.conversation_id,
+        select: %{conversation_id: t.conversation_id, count: count(t.id)}
+
+    last_log_at =
+      from le in LogEvent,
+        where: le.kind == "output",
+        group_by: le.conversation_id,
+        select: %{conversation_id: le.conversation_id, last_at: max(le.inserted_at)}
+
+    from c in Conversation,
+      as: :conv,
+      where: c.user_id == ^user_id,
+      left_join: tc in subquery(turn_counts),
+      on: tc.conversation_id == c.id,
+      left_join: ll in subquery(last_log_at),
+      on: ll.conversation_id == c.id,
+      select: %{
+        c
+        | turn_count: fragment("COALESCE(?, 0)", tc.count),
+          last_active_at:
+            fragment(
+              "COALESCE(? AT TIME ZONE 'UTC', ? AT TIME ZONE 'UTC')",
+              ll.last_at,
+              c.inserted_at
+            )
+      }
+  end
+
+  @doc """
+  Whether a conversation has activity the owner has not seen.
+
+  Unread until read at least once; read conversations go unread again when
+  output arrives after the last read. Lived in three copies across the nav,
+  the index and (implicitly) the API — one definition, so they cannot drift.
+  """
+  def unread?(%{last_read_at: nil, last_active_at: _}), do: true
+  def unread?(%{last_read_at: _, last_active_at: nil}), do: false
+
+  def unread?(%{last_read_at: read_at, last_active_at: active_at}),
+    do: DateTime.compare(active_at, read_at) == :gt
+
+  def unread?(_), do: false
 
   def create_conversation(attrs) do
     %Conversation{}

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -582,14 +582,7 @@ defmodule FountainWeb.Layouts do
   # time the user viewed it. Stage events (reconnects, lifecycle) are already
   # excluded from last_active_at by the query layer, so this comparison is
   # reconnect-safe.
-  defp unread_conv?(%{last_read_at: nil, last_active_at: _}), do: true
-  defp unread_conv?(%{last_read_at: _, last_active_at: nil}), do: false
-
-  defp unread_conv?(%{last_read_at: read_at, last_active_at: active_at}) do
-    DateTime.compare(active_at, read_at) == :gt
-  end
-
-  defp unread_conv?(_), do: false
+  defp unread_conv?(conv), do: Fountain.Conversations.unread?(conv)
 
   # Returns {initials, tailwind_classes} for a role chip.
   # Known roles use the curated @role_styles map.

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -16,14 +16,77 @@ defmodule FountainWeb.ConversationController do
 
   operation(:index,
     summary: "List conversations",
+    parameters: [
+      roots_only: [
+        in: :query,
+        type: :boolean,
+        required: false,
+        description:
+          "Exclude sub-conversations (those with a `parent_conversation_id`), " <>
+            "leaving only top-level sessions. Defaults to false."
+      ]
+    ],
     responses: [
       ok: {"Conversations", "application/json", Schemas.ConversationListResponse}
     ]
   )
 
-  def index(conn, _params) do
+  def index(conn, params) do
     user = conn.assigns.current_user
-    render(conn, :index, conversations: Conversations.list_conversations(user.id))
+    roots_only = parse_bool_param(params["roots_only"], false)
+
+    render(conn, :index,
+      conversations: Conversations.list_conversations(user.id, roots_only: roots_only)
+    )
+  end
+
+  operation(:read,
+    summary: "Mark a conversation read",
+    description:
+      "Sets the conversation's `last_read_at` to now, which is what clears its " <>
+        "unread state. Idempotent.",
+    parameters: [conversation_id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Marked read",
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def read(conn, %{"conversation_id" => id}) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
+      nil ->
+        {:error, :not_found}
+
+      _conv ->
+        :ok = Conversations.mark_read(id, user.id)
+        send_resp(conn, :no_content, "")
+    end
+  end
+
+  operation(:tree,
+    summary: "Get the conversation's spawn tree",
+    description:
+      "Every conversation in the same spawn tree — ancestors and descendants of " <>
+        "this one — as flat `{id, source, status, parent_id}` entries. The API is " <>
+        "how sub-conversations get created (`X-Fountain-Parent-Conversation-Id`), " <>
+        "so this is how an agent that fanned out enumerates what it started " <>
+        "without client-side bookkeeping.",
+    parameters: [conversation_id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Conversation tree", "application/json", Schemas.ConversationTreeResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def tree(conn, %{"conversation_id" => id}) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
+      nil -> {:error, :not_found}
+      _conv -> render(conn, :tree, nodes: Conversations.get_conversation_tree(id, user.id))
+    end
   end
 
   operation(:show,
@@ -38,7 +101,10 @@ defmodule FountainWeb.ConversationController do
   def show(conn, %{"id" => id}) do
     user = conn.assigns.current_user
 
-    case Conversations.get_conversation(id, user.id) do
+    # The annotated variant: a `show` that reported turn_count 0 and a null
+    # last_active_at, as the plain fetch would, is worse than not serving
+    # the fields at all.
+    case Conversations.get_conversation_with_activity(id, user.id) do
       nil -> {:error, :not_found}
       conv -> render(conn, :show, conversation: conv)
     end

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -20,9 +20,12 @@ defmodule FountainWeb.ConversationJSON do
     }
   end
 
+  def tree(%{nodes: nodes}), do: %{data: Enum.map(nodes, &tree_node/1)}
+
   def data(%Conversation{} = c) do
     %{
       id: c.id,
+      title: c.title,
       sandbox_id: c.sandbox_id,
       sandbox: sandbox_data(c.sandbox),
       agent_id: c.agent_id,
@@ -32,9 +35,19 @@ defmodule FountainWeb.ConversationJSON do
       runtime_session_id: c.runtime_session_id,
       source: c.source,
       parent_conversation_id: c.parent_conversation_id,
+      turn_count: c.turn_count,
+      last_active_at: c.last_active_at,
+      last_read_at: c.last_read_at,
+      # Served rather than left to each client: the rule has three cases and
+      # the nil ones are easy to get backwards.
+      unread: Fountain.Conversations.unread?(c),
       inserted_at: c.inserted_at,
       updated_at: c.updated_at
     }
+  end
+
+  defp tree_node(%{id: id, source: source, status: status, parent_id: parent_id}) do
+    %{id: id, source: source, status: status, parent_id: parent_id}
   end
 
   defp sandbox_data(%Sandbox{} = s) do

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -248,12 +248,7 @@ defmodule FountainWeb.ConversationsLive.Index do
     end
   end
 
-  defp unread?(%{last_read_at: nil, last_active_at: _}), do: true
-  defp unread?(%{last_read_at: _, last_active_at: nil}), do: false
-  defp unread?(%{last_read_at: read_at, last_active_at: active_at}) do
-    DateTime.compare(active_at, read_at) == :gt
-  end
-  defp unread?(_), do: false
+  defp unread?(conv), do: Conversations.unread?(conv)
 
   attr :source, :string, default: "api"
 

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -240,6 +240,8 @@ defmodule FountainWeb.Router do
       get "/turns", ConversationController, :turns, as: :turns
       # The JSON read-model for the log feed; /stream below is the tail (#519).
       get "/events", ConversationController, :events, as: :events
+      post "/read", ConversationController, :read, as: :read
+      get "/tree", ConversationController, :tree, as: :tree
       get "/turns/:turn_id/images/:position", TurnImageController, :show, as: :turn_image
     end
   end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -37,6 +37,11 @@ defmodule FountainWeb.Schemas do
       type: :object,
       properties: %{
         id: %Schema{type: :string, format: :uuid},
+        title: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Generated from the first turn; null until one exists."
+        },
         sandbox_id: %Schema{type: :string, format: :uuid, nullable: true},
         sandbox: %Schema{oneOf: [Sandbox], nullable: true},
         agent_id: %Schema{type: :string, format: :uuid, nullable: true},
@@ -49,10 +54,59 @@ defmodule FountainWeb.Schemas do
         runtime_session_id: %Schema{type: :string, nullable: true},
         source: %Schema{type: :string, enum: ~w(ui api agent)},
         parent_conversation_id: %Schema{type: :string, format: :uuid, nullable: true},
+        turn_count: %Schema{type: :integer},
+        last_active_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          nullable: true,
+          description:
+            "Most recent runtime output, falling back to creation time. Stage " <>
+              "events (reconnects, sandbox lifecycle) do not count."
+        },
+        last_read_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          nullable: true,
+          description: "Set by `POST /api/conversations/:id/read`. Null if never read."
+        },
+        unread: %Schema{
+          type: :boolean,
+          description: "last_active_at is later than last_read_at (true if never read)."
+        },
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
       required: [:id, :runtime, :status]
+    })
+  end
+
+  defmodule ConversationTreeNode do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ConversationTreeNode",
+      description: "One conversation in a spawn tree, flat with a parent pointer.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        source: %Schema{type: :string, enum: ~w(ui api agent)},
+        status: %Schema{type: :string, enum: ~w(pending running idle failed terminated)},
+        parent_id: %Schema{type: :string, format: :uuid, nullable: true}
+      },
+      required: [:id]
+    })
+  end
+
+  defmodule ConversationTreeResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ConversationTreeResponse",
+      type: :object,
+      properties: %{data: %Schema{type: :array, items: ConversationTreeNode}},
+      required: [:data]
     })
   end
 

--- a/apps/fountain/test/fountain_web/controllers/conversation_read_model_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_read_model_test.exs
@@ -1,0 +1,236 @@
+defmodule FountainWeb.ConversationReadModelTest do
+  @moduledoc """
+  The conversation read-model pieces that existed only in the LiveView layer
+  (#520): title, read state, turn counts, the roots_only filter, and the spawn
+  tree an agent needs to enumerate what it fanned out.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Conversations
+
+  setup do
+    user = insert_verified_user()
+    {_rec, key} = insert_api_key(user)
+    {:ok, user: user, key: key}
+  end
+
+  describe "conversation JSON" do
+    test "index carries title, turn_count, read state and unread", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      conv = insert_conversation(user_id: user.id, title: "Ship the thing")
+      insert_turn(conv)
+      insert_turn(conv, turn_number: 2)
+
+      [json] =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert json["title"] == "Ship the thing"
+      assert json["turn_count"] == 2
+      assert json["last_read_at"] == nil
+      assert json["last_active_at"]
+      assert json["unread"] == true
+    end
+
+    test "show reports the same numbers as index, not zeroes", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      # get_conversation/2 leaves turn_count at its default; serving that from
+      # show would report 0 turns for a conversation with turns.
+      conv = insert_conversation(user_id: user.id)
+      insert_turn(conv)
+
+      json =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations/#{conv.id}")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert json["turn_count"] == 1
+      assert json["last_active_at"]
+    end
+
+    test "a read conversation reports unread false", %{conn: conn, user: user, key: key} do
+      conv = insert_conversation(user_id: user.id)
+      :ok = Conversations.mark_read(conv.id, user.id)
+
+      json =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations/#{conv.id}")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert json["last_read_at"]
+      assert json["unread"] == false
+    end
+  end
+
+  describe "GET /api/conversations?roots_only" do
+    setup %{user: user} do
+      root = insert_conversation(user_id: user.id)
+      child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
+      {:ok, root: root, child: child}
+    end
+
+    test "defaults to including sub-conversations", %{
+      conn: conn,
+      key: key,
+      root: root,
+      child: child
+    } do
+      ids =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations")
+        |> json_response(200)
+        |> Map.fetch!("data")
+        |> Enum.map(& &1["id"])
+
+      assert root.id in ids
+      assert child.id in ids
+    end
+
+    test "roots_only=true excludes them", %{conn: conn, key: key, root: root, child: child} do
+      ids =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations?roots_only=true")
+        |> json_response(200)
+        |> Map.fetch!("data")
+        |> Enum.map(& &1["id"])
+
+      assert root.id in ids
+      refute child.id in ids
+    end
+
+    test "roots_only=false is the default behaviour, not an error", %{
+      conn: conn,
+      key: key,
+      child: child
+    } do
+      ids =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations?roots_only=false")
+        |> json_response(200)
+        |> Map.fetch!("data")
+        |> Enum.map(& &1["id"])
+
+      assert child.id in ids
+    end
+  end
+
+  describe "POST /api/conversations/:id/read" do
+    test "marks the conversation read", %{conn: conn, user: user, key: key} do
+      conv = insert_conversation(user_id: user.id)
+
+      conn
+      |> authed_with_key(key)
+      |> post("/api/conversations/#{conv.id}/read")
+      |> response(204)
+
+      assert Conversations.get_conversation(conv.id, user.id).last_read_at
+    end
+
+    test "is idempotent", %{conn: conn, user: user, key: key} do
+      conv = insert_conversation(user_id: user.id)
+
+      for _ <- 1..2 do
+        build_conn()
+        |> authed_with_key(key)
+        |> post("/api/conversations/#{conv.id}/read")
+        |> response(204)
+      end
+
+      assert Conversations.get_conversation(conv.id, user.id).last_read_at
+    end
+
+    test "another tenant's conversation is 404 and stays unread", %{conn: conn, key: key} do
+      other = insert_verified_user()
+      other_conv = insert_conversation(user_id: other.id)
+
+      conn
+      |> authed_with_key(key)
+      |> post("/api/conversations/#{other_conv.id}/read")
+      |> json_response(404)
+
+      refute Conversations.get_conversation(other_conv.id, other.id).last_read_at
+    end
+  end
+
+  describe "GET /api/conversations/:id/tree" do
+    test "returns ancestors and descendants, flat, with parent pointers", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      root = insert_conversation(user_id: user.id)
+      child = insert_conversation(user_id: user.id, parent_conversation_id: root.id)
+      grandchild = insert_conversation(user_id: user.id, parent_conversation_id: child.id)
+
+      # Asked from the middle: the tree is the whole family, not the subtree.
+      nodes =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations/#{child.id}/tree")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      by_id = Map.new(nodes, &{&1["id"], &1})
+
+      assert Map.keys(by_id) |> Enum.sort() == Enum.sort([root.id, child.id, grandchild.id])
+      assert by_id[root.id]["parent_id"] == nil
+      assert by_id[child.id]["parent_id"] == root.id
+      assert by_id[grandchild.id]["parent_id"] == child.id
+      assert by_id[grandchild.id]["status"]
+      assert by_id[grandchild.id]["source"]
+    end
+
+    test "a conversation with no relatives is a tree of one", %{conn: conn, user: user, key: key} do
+      conv = insert_conversation(user_id: user.id)
+
+      nodes =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations/#{conv.id}/tree")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert Enum.map(nodes, & &1["id"]) == [conv.id]
+    end
+
+    test "another tenant's conversation is 404, and no ids leak", %{conn: conn, key: key} do
+      other = insert_verified_user()
+      other_root = insert_conversation(user_id: other.id)
+      other_child = insert_conversation(user_id: other.id, parent_conversation_id: other_root.id)
+
+      conn =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations/#{other_root.id}/tree")
+
+      assert json_response(conn, 404)
+      refute conn.resp_body =~ other_child.id
+    end
+
+    test "requires authentication", %{conn: conn, user: user} do
+      conv = insert_conversation(user_id: user.id)
+
+      conn
+      |> put_req_header("accept", "application/json")
+      |> get("/api/conversations/#{conv.id}/tree")
+      |> json_response(401)
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -123,10 +123,12 @@ Resources are upserted by name in a fixed order (environments, then vaults, then
 Conversations are multi-turn: create one with an initial prompt, then keep prompting it.
 
 ```
-GET    /api/conversations
+GET    /api/conversations                  # list (?roots_only=true hides sub-conversations)
 POST   /api/conversations                  # start (agent_id; optional vault_id, prompt, images)
 GET    /api/conversations/:id
 DELETE /api/conversations/:id
+POST   /api/conversations/:id/read         # clear unread state
+GET    /api/conversations/:id/tree         # the whole spawn tree this conversation belongs to
 POST   /api/conversations/:id/prompts      # follow-up turn
 POST   /api/conversations/:id/interrupt    # stop the running turn
 POST   /api/conversations/:id/terminate    # end the conversation and sandbox
@@ -134,6 +136,17 @@ GET    /api/conversations/:id/turns
 GET    /api/conversations/:id/events       # log events as JSON (?streams=  ?after=  ?limit=)
 GET    /api/conversations/:id/stream       # SSE log stream (?streams=stdout,stderr,stage  ?wait=false)
 ```
+
+Conversation objects carry `title`, `turn_count`, `last_active_at`, `last_read_at` and a computed `unread` alongside the lifecycle fields. `unread` is true when `last_active_at` is later than `last_read_at` (and for a conversation never read); `POST /api/conversations/:id/read` clears it.
+
+`/tree` returns every conversation in the same spawn tree — ancestors and descendants, flat, each with a `parent_id`:
+
+```json
+{"data": [{"id": "…", "source": "ui", "status": "idle", "parent_id": null},
+          {"id": "…", "source": "agent", "status": "running", "parent_id": "…"}]}
+```
+
+Since sub-conversations are created over the API (`X-Fountain-Parent-Conversation-Id`), this is how an agent that fanned out enumerates what it started without keeping its own bookkeeping.
 
 `/events` is the read-model for the log feed and `/stream` is the tail. The JSON endpoint returns the same rows the stream sends — `kind`, `stream`, `data`, `stage`, `state`, `duration_ms`, `turn_id`, `ts` — plus each event's `id`, oldest first:
 


### PR DESCRIPTION
Closes #520. **Merge after #558** (stack: #556 → #557 → #558 → this).

## What was missing

| Gap | Fix |
|---|---|
| `conversation_json` omitted `title`, `turn_count`, `last_active_at`, `last_read_at` — all shown in the UI list | serialized, plus a computed `unread` |
| `roots_only` supported by `list_conversations/2`, never passed by a caller | `GET /api/conversations?roots_only=true` |
| `mark_read/2` had no endpoint | `POST /api/conversations/:id/read` → 204 |
| `get_conversation_tree/2` had zero controller callers | `GET /api/conversations/:id/tree` |

## Notes

- **`show` reports real numbers.** `get_conversation/2` leaves `turn_count` at its default and never populates `last_active_at`, so serving those from `show` would report 0 turns for a conversation with turns. Added `get_conversation_with_activity/2` for the read paths; `get_conversation/2` is untouched and stays cheap for prompt/interrupt, which only need "does this exist and is it yours".
- **`unread` is served, not left to clients.** The rule has three cases and the nil ones are easy to get backwards. It had three copies in the web layer; now one `Conversations.unread?/1` that the nav, the index LiveView and the JSON view all call.
- The tree endpoint pairs with `X-Fountain-Parent-Conversation-Id`: an agent that fanned out can now enumerate what it started. Tenant scoping is the context's recursive-CTE predicate, unchanged; the controller does the scoped fetch first so a foreign id is 404 before the CTE runs.

## Tests

13 in `conversation_read_model_test.exs`: index and show field coverage, show-reports-real-counts (the regression the naive version would have shipped), unread true/false either side of a read, all three `roots_only` values, read idempotency, read on a foreign conversation is 404 **and leaves it unread**, tree from the middle of a three-generation chain returning the whole family with correct parent pointers, single-node tree, foreign tree 404 with a body assertion that no child ids leaked, and 401.

Full suite green (2,103 tests); `format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)