### PR TITLE
api: include usage counts in agent/environment/vault reads (#529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ upgrade, is in
 
 ### Added
 
+- **Usage counts are in the resource read-model**: agents carry
+  `conversation_count`, environments `secret_count` and `agent_count`, vaults
+  `secret_count` — on the list *and* single-resource reads, so "is this
+  environment in use / safe to delete" is one request instead of an N+1 the
+  client assembles. The counting queries already existed for the UI and had
+  no controller caller (#529)
+
 - **The conversation read-model the UI has is now the one the API serves.**
   Conversation JSON gained `title`, `turn_count`, `last_active_at`,
   `last_read_at` and a computed `unread`; `GET /api/conversations` takes

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -23,6 +23,29 @@ defmodule Fountain.Agents do
     end
   end
 
+  @doc """
+  Scoped fetch plus the `conversation_count` the list read-model carries.
+
+  Separate from `get_agent/2`, which is on the conversation-start path and
+  does not need the count. Serving the struct default (0) from a read that
+  advertises the field would report "no conversations" for a busy agent.
+  """
+  def get_agent_with_counts(id, user_id) when is_binary(user_id) do
+    case get_agent(id, user_id) do
+      nil ->
+        nil
+
+      agent ->
+        count =
+          Repo.aggregate(
+            from(c in Conversation, where: c.user_id == ^user_id and c.agent_id == ^agent.id),
+            :count
+          )
+
+        %{agent | conversation_count: count}
+    end
+  end
+
   @doc "Get agent scoped to user. Raises Ecto.NoResultsError if wrong owner."
   def get_agent!(id, user_id) when is_binary(user_id) do
     Repo.get_by!(Agent, id: id, user_id: user_id) |> Repo.preload(:environment)

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -73,6 +73,29 @@ defmodule Fountain.Environments do
     Repo.get_by(Environment, id: id, user_id: user_id)
   end
 
+  @doc """
+  Scoped fetch plus the counts the list read-model carries — how many secrets
+  the environment holds and how many agents reference it. The second is the
+  "is this safe to delete" answer, which callers otherwise N+1 client-side.
+  """
+  def get_environment_with_counts(id, user_id) when is_binary(user_id) do
+    case get_environment(id, user_id) do
+      nil ->
+        nil
+
+      env ->
+        secret_count = Repo.aggregate(from(s in Secret, where: s.environment_id == ^env.id), :count)
+
+        agent_count =
+          Repo.aggregate(
+            from(a in Agent, where: a.user_id == ^user_id and a.environment_id == ^env.id),
+            :count
+          )
+
+        %{env | secret_count: secret_count, agent_count: agent_count}
+    end
+  end
+
   @doc "Get environment scoped to user. Raises Ecto.NoResultsError on wrong owner."
   def get_environment!(id, user_id) when is_binary(user_id) do
     Repo.get_by!(Environment, id: id, user_id: user_id)

--- a/apps/fountain/lib/fountain/environments/environment.ex
+++ b/apps/fountain/lib/fountain/environments/environment.ex
@@ -33,6 +33,12 @@ defmodule Fountain.Environments.Environment do
     # Free-form caller bookkeeping. Deliberately NOT a warm-start field:
     # changing it must not invalidate the provisioning checkpoint.
     field :metadata, :map, default: %{}
+
+    # Populated by the *_with_counts reads — not persisted. "Is this
+    # environment in use / safe to delete" is the question these answer.
+    field :secret_count, :integer, virtual: true, default: 0
+    field :agent_count, :integer, virtual: true, default: 0
+
     belongs_to :user, User
     has_many :secrets, Secret
     timestamps(type: :utc_datetime)

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -65,6 +65,20 @@ defmodule Fountain.Vaults do
     Repo.get_by(Vault, id: id, user_id: user_id)
   end
 
+  @doc """
+  Scoped fetch plus the `secret_count` the list read-model carries.
+  """
+  def get_vault_with_counts(id, user_id) when is_binary(user_id) do
+    case get_vault(id, user_id) do
+      nil ->
+        nil
+
+      vault ->
+        count = Repo.aggregate(from(s in VaultSecret, where: s.vault_id == ^vault.id), :count)
+        %{vault | secret_count: count}
+    end
+  end
+
   @doc "Get vault scoped to user. Raises Ecto.NoResultsError on wrong owner."
   def get_vault!(id, user_id) when is_binary(user_id) do
     Repo.get_by!(Vault, id: id, user_id: user_id)

--- a/apps/fountain/lib/fountain/vaults/vault.ex
+++ b/apps/fountain/lib/fountain/vaults/vault.ex
@@ -12,6 +12,10 @@ defmodule Fountain.Vaults.Vault do
     field :name, :string
     field :description, :string, default: ""
     field :metadata, :map, default: %{}
+
+    # Populated by the *_with_counts reads — not persisted.
+    field :secret_count, :integer, virtual: true, default: 0
+
     belongs_to :user, User
     has_many :secrets, VaultSecret
     timestamps(type: :utc_datetime)

--- a/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
@@ -58,7 +58,7 @@ defmodule FountainWeb.AgentController do
   # behaviour only ever worked in the LiveView.
   def index(conn, params) do
     user = conn.assigns.current_user
-    render(conn, :index, agents: Agents.list_agents(user.id, agent_filters(params)))
+    render(conn, :index, agents: Agents.list_agents_with_counts(user.id, agent_filters(params)))
   end
 
   defp agent_filters(params) do
@@ -95,7 +95,7 @@ defmodule FountainWeb.AgentController do
   def show(conn, %{"id" => id}) do
     user = conn.assigns.current_user
 
-    case Agents.get_agent(id, user.id) do
+    case Agents.get_agent_with_counts(id, user.id) do
       nil -> {:error, :not_found}
       agent -> render(conn, :show, agent: agent)
     end
@@ -119,7 +119,7 @@ defmodule FountainWeb.AgentController do
     with {:ok, %Agent{} = agent} <- Agents.create_agent(attrs) do
       conn
       |> put_status(:created)
-      |> render(:show, agent: Agents.get_agent!(agent.id, user.id))
+      |> render(:show, agent: Agents.get_agent_with_counts(agent.id, user.id))
     end
   end
 
@@ -146,7 +146,7 @@ defmodule FountainWeb.AgentController do
 
       agent ->
         with {:ok, agent} <- Agents.update_agent(agent, attrs) do
-          render(conn, :show, agent: Agents.get_agent!(agent.id, user.id))
+          render(conn, :show, agent: Agents.get_agent_with_counts(agent.id, user.id))
         end
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/agent_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_json.ex
@@ -18,6 +18,7 @@ defmodule FountainWeb.AgentJSON do
       mcp_servers: a.mcp_servers,
       metadata: a.metadata,
       allowed_vault_ids: a.allowed_vault_ids,
+      conversation_count: a.conversation_count,
       inserted_at: a.inserted_at,
       updated_at: a.updated_at
     }

--- a/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
@@ -22,7 +22,7 @@ defmodule FountainWeb.EnvironmentController do
 
   def index(conn, _params) do
     user = conn.assigns.current_user
-    render(conn, :index, environments: Environments.list_environments(user.id))
+    render(conn, :index, environments: Environments.list_environments_with_counts(user.id))
   end
 
   operation(:show,
@@ -37,7 +37,7 @@ defmodule FountainWeb.EnvironmentController do
   def show(conn, %{"id" => id}) do
     user = conn.assigns.current_user
 
-    case Environments.get_environment(id, user.id) do
+    case Environments.get_environment_with_counts(id, user.id) do
       nil -> {:error, :not_found}
       env -> render(conn, :show, environment: env)
     end
@@ -59,7 +59,7 @@ defmodule FountainWeb.EnvironmentController do
     with {:ok, %Environment{} = env} <- Environments.create_environment(attrs) do
       conn
       |> put_status(:created)
-      |> render(:show, environment: env)
+      |> render(:show, environment: Environments.get_environment_with_counts(env.id, user.id))
     end
   end
 
@@ -86,7 +86,9 @@ defmodule FountainWeb.EnvironmentController do
 
       env ->
         with {:ok, env} <- Environments.update_environment(env, attrs) do
-          render(conn, :show, environment: env)
+          # Re-read for the counts: a response that advertises secret_count and
+          # agent_count must not report the struct defaults after a write.
+          render(conn, :show, environment: Environments.get_environment_with_counts(env.id, user.id))
         end
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/environment_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/environment_json.ex
@@ -16,6 +16,8 @@ defmodule FountainWeb.EnvironmentJSON do
       networking_config: env.networking_config,
       repositories: env.repositories,
       metadata: env.metadata,
+      secret_count: env.secret_count,
+      agent_count: env.agent_count,
       inserted_at: env.inserted_at,
       updated_at: env.updated_at
     }

--- a/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
@@ -22,7 +22,7 @@ defmodule FountainWeb.VaultController do
 
   def index(conn, _params) do
     user = conn.assigns.current_user
-    render(conn, :index, vaults: Vaults.list_vaults(user.id))
+    render(conn, :index, vaults: Vaults.list_vaults_with_counts(user.id))
   end
 
   operation(:show,
@@ -37,7 +37,7 @@ defmodule FountainWeb.VaultController do
   def show(conn, %{"id" => id}) do
     user = conn.assigns.current_user
 
-    case Vaults.get_vault(id, user.id) do
+    case Vaults.get_vault_with_counts(id, user.id) do
       nil -> {:error, :not_found}
       vault -> render(conn, :show, vault: vault)
     end
@@ -59,7 +59,7 @@ defmodule FountainWeb.VaultController do
     with {:ok, %Vault{} = vault} <- Vaults.create_vault(attrs) do
       conn
       |> put_status(:created)
-      |> render(:show, vault: vault)
+      |> render(:show, vault: Vaults.get_vault_with_counts(vault.id, user.id))
     end
   end
 
@@ -85,7 +85,9 @@ defmodule FountainWeb.VaultController do
 
       vault ->
         with {:ok, vault} <- Vaults.update_vault(vault, attrs) do
-          render(conn, :show, vault: vault)
+          # Re-read for the counts: a response that advertises secret_count
+          # must not report the struct default after a write.
+          render(conn, :show, vault: Vaults.get_vault_with_counts(vault.id, user.id))
         end
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/vault_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_json.ex
@@ -11,6 +11,7 @@ defmodule FountainWeb.VaultJSON do
       name: v.name,
       description: v.description,
       metadata: v.metadata,
+      secret_count: v.secret_count,
       inserted_at: v.inserted_at,
       updated_at: v.updated_at
     }

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -331,6 +331,10 @@ defmodule FountainWeb.Schemas do
               "a non-empty list is an allowlist. Vault values override the agent's " <>
               "environment on key collision, so this scopes who can override reviewed config."
         },
+        conversation_count: %Schema{
+          type: :integer,
+          description: "Conversations started from this agent."
+        },
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
@@ -544,6 +548,11 @@ defmodule FountainWeb.Schemas do
         },
         repositories: %Schema{type: :array, items: Repository},
         metadata: %Schema{type: :object, additionalProperties: true},
+        secret_count: %Schema{type: :integer, description: "Secrets stored on this environment."},
+        agent_count: %Schema{
+          type: :integer,
+          description: "Agents referencing this environment — 0 means safe to delete."
+        },
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
@@ -725,6 +734,7 @@ defmodule FountainWeb.Schemas do
         name: %Schema{type: :string},
         description: %Schema{type: :string},
         metadata: %Schema{type: :object, additionalProperties: true},
+        secret_count: %Schema{type: :integer, description: "Secrets stored in this vault."},
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },

--- a/apps/fountain/test/fountain_web/controllers/list_counts_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/list_counts_test.exs
@@ -1,0 +1,156 @@
+defmodule FountainWeb.ListCountsTest do
+  @moduledoc """
+  Usage counts in the resource read-model (#529).
+
+  `list_agents_with_counts/2`, `list_environments_with_counts/1` and
+  `list_vaults_with_counts/1` existed for the UI and had no controller caller,
+  so an API consumer asking "is this environment in use / safe to delete" had
+  to N+1 it client-side.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  setup do
+    user = insert_verified_user()
+    {_rec, key} = insert_api_key(user)
+    {:ok, user: user, key: key}
+  end
+
+  defp first(conn, path) do
+    conn |> get(path) |> json_response(200) |> Map.fetch!("data") |> hd()
+  end
+
+  describe "agents" do
+    test "list and get both report conversation_count", %{conn: conn, user: user, key: key} do
+      agent = insert_agent(user_id: user.id)
+      insert_conversation(user_id: user.id, agent_id: agent.id)
+      insert_conversation(user_id: user.id, agent_id: agent.id)
+
+      conn = authed_with_key(conn, key)
+
+      assert first(conn, "/api/agents")["conversation_count"] == 2
+
+      # The single-resource read has to agree with the list; serving the
+      # struct default here would report "no conversations" for a busy agent.
+      assert conn
+             |> get("/api/agents/#{agent.id}")
+             |> json_response(200)
+             |> get_in(["data", "conversation_count"]) == 2
+    end
+
+    test "a fresh agent reports zero, not null", %{conn: conn, user: user, key: key} do
+      insert_agent(user_id: user.id)
+
+      assert conn |> authed_with_key(key) |> first("/api/agents") |> Map.fetch!(
+               "conversation_count"
+             ) == 0
+    end
+
+    test "another tenant's conversations do not count", %{conn: conn, user: user, key: key} do
+      agent = insert_agent(user_id: user.id)
+      other = insert_verified_user()
+      insert_conversation(user_id: other.id, agent_id: agent.id)
+
+      assert conn |> authed_with_key(key) |> first("/api/agents") |> Map.fetch!(
+               "conversation_count"
+             ) == 0
+    end
+
+    test "creating an agent returns counts too", %{conn: conn, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/agents", %{
+          "name" => "fresh",
+          "model" => "anthropic/claude-sonnet-4-6",
+          "runtime" => "claude"
+        })
+        |> json_response(201)
+
+      assert body["data"]["conversation_count"] == 0
+    end
+  end
+
+  describe "environments" do
+    setup %{user: user} do
+      env = insert_env(user_id: user.id)
+      {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+      {:ok, _} = Fountain.Environments.upsert_secret(env, %{"key" => "A", "value" => "1"}, dek)
+      insert_agent(user_id: user.id, environment_id: env.id)
+      {:ok, env: env}
+    end
+
+    test "list reports secret_count and agent_count", %{conn: conn, key: key} do
+      json = conn |> authed_with_key(key) |> first("/api/environments")
+
+      assert json["secret_count"] == 1
+      assert json["agent_count"] == 1
+    end
+
+    test "get agrees with list", %{conn: conn, key: key, env: env} do
+      json =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/environments/#{env.id}")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert json["secret_count"] == 1
+      assert json["agent_count"] == 1
+    end
+
+    test "updating an environment still reports counts", %{conn: conn, key: key, env: env} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_json("/api/environments/#{env.id}", %{"name" => "renamed"})
+        |> json_response(200)
+
+      assert body["data"]["name"] == "renamed"
+      assert body["data"]["secret_count"] == 1
+      assert body["data"]["agent_count"] == 1
+    end
+
+    test "an unused environment reports agent_count 0 — the safe-to-delete answer", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      unused = insert_env(user_id: user.id, name: "unused")
+
+      json =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/environments/#{unused.id}")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert json["agent_count"] == 0
+      assert json["secret_count"] == 0
+    end
+  end
+
+  describe "vaults" do
+    test "list and get report secret_count", %{conn: conn, user: user, key: key} do
+      vault = insert_vault(user_id: user.id)
+      {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+      {:ok, _} = Fountain.Vaults.upsert_secret(vault, %{"key" => "K", "value" => "v"}, dek)
+
+      conn = authed_with_key(conn, key)
+
+      assert first(conn, "/api/vaults")["secret_count"] == 1
+
+      assert conn
+             |> get("/api/vaults/#{vault.id}")
+             |> json_response(200)
+             |> get_in(["data", "secret_count"]) == 1
+    end
+
+    test "an empty vault reports zero", %{conn: conn, user: user, key: key} do
+      insert_vault(user_id: user.id)
+
+      assert conn |> authed_with_key(key) |> first("/api/vaults") |> Map.fetch!("secret_count") ==
+               0
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -68,6 +68,8 @@ PUT    /api/agents/:id
 DELETE /api/agents/:id
 ```
 
+Agent objects carry `conversation_count`; environments carry `secret_count` and `agent_count`; vaults carry `secret_count`. They are on both the list and single-resource reads, so "is this environment in use / safe to delete" is one request.
+
 ## Environments
 
 ```


### PR DESCRIPTION
Closes #529. **Merge after #559** (stack: #556 → #557 → #558 → #559 → this).

## Why

`list_agents_with_counts/2`, `list_environments_with_counts/1` and `list_vaults_with_counts/1` were written for the UI and had **no controller caller**. An API consumer asking "is this environment in use / safe to delete" had to N+1 it client-side.

## What

Counts are always included (the issue's second option — they're one query server-side, and an `?include=` flag is a knob nobody would leave off):

| Resource | Fields |
|---|---|
| Agent | `conversation_count` |
| Environment | `secret_count`, `agent_count` |
| Vault | `secret_count` |

**Single-resource reads report them too.** Counts on the list only would leave `GET /api/environments/:id` either missing the field or reporting the struct default — and a response saying `secret_count: 0` for an environment holding secrets is worse than one saying nothing. New `get_agent_with_counts/2`, `get_environment_with_counts/2`, `get_vault_with_counts/2`; create/update responses go through them as well. The plain `get_*` functions are untouched and stay on the provisioning/prompt paths, which don't need the extra queries.

`Environment` and `Vault` gain the virtual count fields `Agent` already had, so the list functions populate declared fields instead of grafting keys onto a struct.

## Tests

10 in `list_counts_test.exs`: list/get agreement for each resource (the regression a list-only version would ship), fresh resources reporting `0` rather than null, **another tenant's conversations not counting toward an agent**, counts surviving an update, and `agent_count: 0` on an unused environment — the safe-to-delete answer.

Full suite green (2,113 tests); `format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)