### PR TITLE
config: delete a blank SENTRY_DSN so the SDK's own env read can't crash boot (#513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ upgrade, is in
 
 ---
 
+## [0.5.1] — 2026-08-05
+
+### Fixed
+
+- **The compose quick start still crash-looped on v0.5.0 — actually fixed
+  now, verified by booting the built image through compose.** The #497/#541
+  blank guards protect the config value, but the Sentry SDK also reads the
+  `SENTRY_DSN` env var itself: `Sentry.Config.put_config/2` re-validates a
+  partial keyword with no `:dsn` entry and `fill_in_from_env` injects the
+  raw env value into it — and `Sentry.Application.start` calls `put_config`
+  at boot, so the compose-supplied `SENTRY_DSN=""` crashed the `:sentry`
+  application regardless of the config. A blank `SENTRY_DSN` is now deleted
+  from the environment during config, before any application starts, so the
+  SDK never sees it. Instances with a real DSN are unaffected (#513, #561)
+
 ## [0.5.0] — 2026-08-05
 
 ### Upgrade notes
@@ -792,6 +807,7 @@ upgrade, is in
 - Audit log for state-changing actions (append-only, best-effort)
 - Substitution engine for `${VAR}` / `$$` interpolation in agent configs
 
+[0.5.1]: https://github.com/BinaryBourbon/fountain/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/BinaryBourbon/fountain/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/BinaryBourbon/fountain/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/BinaryBourbon/fountain/compare/v0.3.0...v0.4.0

--- a/apps/fountain/test/fountain/compose_passthrough_config_test.exs
+++ b/apps/fountain/test/fountain/compose_passthrough_config_test.exs
@@ -75,6 +75,12 @@ defmodule Fountain.ComposePassthroughConfigTest do
       cfg = read_prod(Map.put(base, "SENTRY_DSN", ""))
 
       assert cfg[:sentry][:dsn] == nil
+
+      # The config value alone is not the contract: the SDK re-reads the env
+      # var itself (Sentry.Config.put_config/2 validates a partial keyword
+      # and fill_in_from_env put_news the raw value in), so a blank variable
+      # must be deleted, not merely mapped to a nil config (#513).
+      assert System.get_env("SENTRY_DSN") == nil
     end
 
     test "a real DSN is stored verbatim", %{base: base} do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -193,10 +193,23 @@ config :fountain, :metrics_port, metrics_port
 #
 # "" counts as unset (#497): the compose file passes `${SENTRY_DSN:-}`, and a
 # blank string is not a DSN the SDK should be asked to parse.
+#
+# Guarding the config value alone is NOT enough (#513 re-run): the SDK reads
+# the SENTRY_DSN env var itself. `Sentry.Config.put_config/2` re-validates a
+# partial keyword that has no :dsn entry, `fill_in_from_env` then
+# `Keyword.put_new`s the raw env value into it — and Sentry.Application.start
+# calls put_config at boot, so a blank SENTRY_DSN crashes the :sentry app no
+# matter what `config :sentry, dsn:` says. Config providers run in the
+# release VM before any application starts, so deleting the blank variable
+# here is what actually keeps it away from the SDK.
 sentry_dsn =
   case System.get_env("SENTRY_DSN") do
-    blank when blank in [nil, ""] -> nil
-    dsn -> dsn
+    blank when blank in [nil, ""] ->
+      System.delete_env("SENTRY_DSN")
+      nil
+
+    dsn ->
+      dsn
   end
 
 config :sentry,


### PR DESCRIPTION
The #513 walkthrough re-run on freshly-released v0.5.0 still crash-looped — on the same `SENTRY_DSN=""` that #497 was supposed to fix. #497's guard is real but guards the wrong thing: it maps a blank env var to a nil **config** value, while sentry 13.x also reads the env var **itself**. `Sentry.Config.put_config/2` re-validates a partial keyword (`[{key, value}]`) that has no `:dsn` entry, `fill_in_from_env/3` `Keyword.put_new`s the raw `SENTRY_DSN` value into it, and `Sentry.Application.start/2` calls `put_config(:in_app_module_allow_list, ...)` at boot — so any invalid `SENTRY_DSN` env value, including the `""` compose's `${SENTRY_DSN:-}` always delivers, crashes the `:sentry` application no matter what `config :sentry, dsn:` says. The first walkthrough's workaround (unsetting the var via compose override) masked exactly this path, which is how #497 looked sufficient.

**Fix:** a blank `SENTRY_DSN` is deleted from the environment inside the config provider, which runs in the release VM before any application starts — the SDK never sees it. A real DSN is untouched.

**Verified against the artifact this time, not just the config test:** built the release image from this branch and booted it through the fresh-clone compose file with every `${VAR:-}` blank passthrough in place → `/health/ready` ok. The v0.5.0 image crash-loops under identical env. The passthrough test now pins the deletion itself (`System.get_env("SENTRY_DSN") == nil` after config), and fails without the fix.

Includes the `[0.5.1]` changelog section so release-bump (patch) can be dispatched directly after merge; pins bump to v0.5.1 in the release commit. `mix precommit` green (2055 tests, 0 failures).

This is also #548's thesis demonstrated twice in one day: the config-level test can't see SDK-internal env reads, and nothing in CI boots the real image through the real compose file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)