### PR TITLE
api: finish email verification and password reset over JSON (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ upgrade, is in
 
 ### Added
 
+- **The auth email flows can be finished over the API.** An API consumer
+  could start every one of them — register, resend-verification, forgot —
+  and finish none: confirmation and reset were browser routes, so account
+  activation required a browser round-trip. `POST /api/auth/verify`,
+  `POST /api/auth/reset` and `POST /api/auth/email/confirm` accept the same
+  tokens the emailed links carry, so a CLI can prompt "paste the code from
+  your email". The links themselves still point at the browser pages.
+  `verify` is idempotent and issues no session — an API client mints a key
+  at `POST /api/auth/token` once the account is live — and every flow keeps
+  the browser path's rate limits, single-use token semantics and audit
+  events (#522)
+
 - **Usage counts are in the resource read-model**: agents carry
   `conversation_count`, environments `secret_count` and `agent_count`, vaults
   `secret_count` — on the list *and* single-resource reads, so "is this

--- a/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
@@ -118,6 +118,50 @@ defmodule FountainWeb.AccountSecurityController do
     |> redirect(to: ~p"/account/security")
   end
 
+  @doc """
+  JSON completion of the email change (#522). Same token as the emailed
+  browser link; no session is touched, because an API client has none.
+  """
+  def api_confirm_email_change(conn, %{"token" => token}) do
+    case Accounts.apply_email_change(token) do
+      {:ok, updated, old_email} ->
+        FountainWeb.Audited.from_conn(conn, "auth.email.changed", "user",
+          user_id: updated.id,
+          resource_id: updated.id,
+          metadata: %{"from" => old_email, "to" => updated.email}
+        )
+
+        # apply_email_change bumps session_version, so every session and API
+        # key session for this account is dead — say so rather than let the
+        # caller discover it as a mystery 401.
+        json(conn, %{
+          email: updated.email,
+          message: "Email updated. Existing sessions have been signed out."
+        })
+
+      {:error, :email_taken} ->
+        email_change_error(conn, "email_taken", "That address is already in use.")
+
+      {:error, :expired} ->
+        email_change_error(conn, "expired", "This confirmation link has expired.")
+
+      {:error, _} ->
+        email_change_error(conn, "invalid_token", "This confirmation link is invalid.")
+    end
+  end
+
+  def api_confirm_email_change(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "token is required"})
+  end
+
+  defp email_change_error(conn, error, message) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: error, message: message})
+  end
+
   def confirm_email_change(conn, %{"token" => token}) do
     case Accounts.apply_email_change(token) do
       {:ok, updated, old_email} ->

--- a/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
@@ -1,9 +1,16 @@
 defmodule FountainWeb.EmailVerificationController do
   @moduledoc """
-  Handles the email verification link: GET /users/confirm/:token
+  Handles the email verification link: GET /users/confirm/:token, and its
+  JSON twin POST /api/auth/verify.
 
   Validates a Phoenix.Token (24 h TTL), marks the user verified, sets
-  the session cookie, and redirects to onboarding or dashboard.
+  the session cookie (browser route only), and redirects to onboarding or
+  dashboard.
+
+  The API route exists so account activation does not require a browser
+  (#522): the emailed link keeps pointing at the browser route, and a CLI
+  prompts for the token from that URL. Both routes accept the same token —
+  there is one verification secret, not two.
 
   After a successful verification, a Stripe Customer record is created
   via the `Fountain.Workers.StripeCustomerSync` job so that
@@ -73,6 +80,71 @@ defmodule FountainWeb.EmailVerificationController do
         |> put_flash(:error, "This verification link is invalid.")
         |> redirect(to: ~p"/auth/login")
     end
+  end
+
+  @doc """
+  JSON completion of the same flow. Returns 200 on success (and on an
+  already-verified account, which is the idempotent case a CLI retrying a
+  request needs), 422 on an expired or invalid token.
+
+  No session is issued: an API client wants a key, which it mints at
+  `POST /api/auth/token` once the account is live.
+  """
+  def api_verify(conn, %{"token" => token}) do
+    case Phoenix.Token.verify(conn, "email_verification", token, max_age: @token_max_age) do
+      {:ok, user_id} -> verify_user(conn, Accounts.get_user(user_id))
+      {:error, :expired} -> token_error(conn, "expired", "This verification link has expired.")
+      {:error, _} -> token_error(conn, "invalid_token", "This verification link is invalid.")
+    end
+  end
+
+  def api_verify(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "token is required"})
+  end
+
+  defp verify_user(conn, nil),
+    do: token_error(conn, "invalid_token", "This verification link is invalid.")
+
+  defp verify_user(conn, %{email_verified_at: %DateTime{}} = user) do
+    json(conn, %{
+      user_id: user.id,
+      email_verified: true,
+      message: "Your email is already verified."
+    })
+  end
+
+  defp verify_user(conn, user) do
+    case Accounts.verify_email(user) do
+      {:ok, verified} ->
+        FountainWeb.Audited.from_conn(conn, "auth.email.verified", "user",
+          user_id: verified.id,
+          resource_id: verified.id
+        )
+
+        # Same follow-on work the browser route does — the account must not
+        # end up in a different state depending on which surface finished it.
+        Fountain.Workers.StripeCustomerSync.enqueue(verified)
+        Fountain.Workers.WelcomeEmail.enqueue(verified)
+
+        json(conn, %{
+          user_id: verified.id,
+          email_verified: true,
+          message: "Email verified. You can sign in now."
+        })
+
+      {:error, _changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "verification_failed"})
+    end
+  end
+
+  defp token_error(conn, error, message) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: error, message: message})
   end
 
   ## Helpers

--- a/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
@@ -3,9 +3,14 @@ defmodule FountainWeb.PasswordResetController do
   Password reset flow.
 
   POST /api/auth/forgot          — request a reset email (rate-limited, always 200)
+  POST /api/auth/reset           — apply the reset over JSON (#522)
   GET  /auth/reset/:token        — render the new-password form
   POST /auth/reset               — apply the reset, invalidate sessions
   GET  /auth/forgot-password     — render the "forgot password" request form
+
+  The API and browser completions accept the same token: the emailed link
+  keeps pointing at the browser route, and a CLI can prompt for the token
+  out of that URL rather than shelling out to a browser.
   """
 
   use FountainWeb, :controller
@@ -25,7 +30,7 @@ defmodule FountainWeb.PasswordResetController do
   # endpoint that does bcrypt work on every call is a cheap way to burn CPU.
   plug FountainWeb.Plugs.RateLimit,
        [bucket: "password_reset_submit", max: 10, window_ms: 3_600_000]
-       when action in [:reset]
+       when action in [:reset, :api_reset]
 
   ## HTML — "forgot password" form
 
@@ -57,6 +62,54 @@ defmodule FountainWeb.PasswordResetController do
     conn
     |> put_status(:ok)
     |> json(%{message: "If that address is registered, a reset email is on its way."})
+  end
+
+  ## API — apply the reset
+
+  def api_reset(conn, %{"token" => token, "password" => password}) do
+    case verify_reset_token(conn, token) do
+      {:ok, user} ->
+        apply_api_reset(conn, user, password)
+
+      {:error, :expired} ->
+        reset_token_error(conn, "expired", "This reset link has expired. Request a new one.")
+
+      {:error, _} ->
+        reset_token_error(conn, "invalid_token", "This reset link is invalid.")
+    end
+  end
+
+  def api_reset(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "token and password are required"})
+  end
+
+  defp apply_api_reset(conn, user, password) do
+    case Accounts.reset_password(user, password) do
+      {:ok, _user} ->
+        # session_version is bumped, so every session and every other
+        # outstanding reset token dies here too — the same security-relevant
+        # event the browser path records.
+        FountainWeb.Audited.from_conn(conn, "auth.password.reset", "user",
+          user_id: user.id,
+          resource_id: user.id
+        )
+
+        json(conn, %{message: "Password updated. Sign in with your new password."})
+
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> put_view(FountainWeb.ChangesetJSON)
+        |> render(:error, changeset: changeset)
+    end
+  end
+
+  defp reset_token_error(conn, error, message) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: error, message: message})
   end
 
   ## HTML — render reset form

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -177,6 +177,13 @@ defmodule FountainWeb.Router do
     post "/register", RegistrationController, :api_create
     post "/resend-verification", RegistrationController, :api_resend
     post "/forgot", PasswordResetController, :api_forgot
+
+    # Completions (#522). Authenticated by the emailed token itself, so an
+    # account can be activated and a password reset without a browser. The
+    # links in the mail keep pointing at the browser routes above.
+    post "/verify", EmailVerificationController, :api_verify
+    post "/reset", PasswordResetController, :api_reset
+    post "/email/confirm", AccountSecurityController, :api_confirm_email_change
   end
 
   ## ─── Stripe webhook (phase-3-billing) ───────────────────────────────────────────────────────────────────

--- a/apps/fountain/test/fountain_web/controllers/auth_completion_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_completion_controller_test.exs
@@ -1,0 +1,200 @@
+defmodule FountainWeb.AuthCompletionControllerTest do
+  @moduledoc """
+  Finishing the auth email flows over JSON (#522).
+
+  An API consumer could *start* every one of these — register,
+  resend-verification, forgot — and finish none of them: confirmation and
+  reset were browser routes. Account activation required a browser round-trip,
+  which is the one step a headless bootstrap cannot fake.
+
+  The emailed links still point at the browser routes. These endpoints accept
+  the same tokens, so a CLI can say "paste the code from your email".
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Accounts
+
+  defp verification_token(user),
+    do: Phoenix.Token.sign(FountainWeb.Endpoint, "email_verification", user.id)
+
+  defp reset_token(user),
+    do:
+      Phoenix.Token.sign(
+        FountainWeb.Endpoint,
+        "password_reset",
+        {user.id, user.session_version}
+      )
+
+  defp json_post(conn, path, payload) do
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("accept", "application/json")
+    |> post(path, Jason.encode!(payload))
+  end
+
+  describe "POST /api/auth/verify" do
+    test "verifies an account without a browser", %{conn: conn} do
+      user = insert_user()
+
+      body =
+        conn
+        |> json_post("/api/auth/verify", %{"token" => verification_token(user)})
+        |> json_response(200)
+
+      assert body["user_id"] == user.id
+      assert body["email_verified"] == true
+      assert Accounts.get_user(user.id).email_verified_at
+    end
+
+    test "issues no session — an API client wants a key, not a cookie", %{conn: conn} do
+      user = insert_user()
+
+      conn = json_post(conn, "/api/auth/verify", %{"token" => verification_token(user)})
+
+      assert json_response(conn, 200)
+      assert conn.resp_cookies == %{}
+    end
+
+    test "records the audit event the browser route records", %{conn: conn} do
+      user = insert_user()
+
+      conn
+      |> json_post("/api/auth/verify", %{"token" => verification_token(user)})
+      |> json_response(200)
+
+      actions = Fountain.Audit.list_recent_for_user(user.id, 50) |> Enum.map(& &1.action)
+      assert "auth.email.verified" in actions
+    end
+
+    test "is idempotent — a retried request is not an error", %{conn: conn} do
+      user = insert_verified_user()
+
+      body =
+        conn
+        |> json_post("/api/auth/verify", %{"token" => verification_token(user)})
+        |> json_response(200)
+
+      assert body["email_verified"] == true
+    end
+
+    test "a garbage token is 422, not a 500", %{conn: conn} do
+      body = conn |> json_post("/api/auth/verify", %{"token" => "nonsense"}) |> json_response(422)
+      assert body["error"] == "invalid_token"
+    end
+
+    test "a missing token is 422", %{conn: conn} do
+      conn |> json_post("/api/auth/verify", %{}) |> json_response(422)
+    end
+
+    test "a token for a deleted user is invalid, not a crash", %{conn: conn} do
+      user = insert_user()
+      token = verification_token(user)
+      {:ok, _} = Fountain.Repo.delete(user)
+
+      body = conn |> json_post("/api/auth/verify", %{"token" => token}) |> json_response(422)
+      assert body["error"] == "invalid_token"
+    end
+  end
+
+  describe "POST /api/auth/reset" do
+    setup do
+      {:ok, user: insert_verified_user(%{"password" => "old-password-123"})}
+    end
+
+    test "resets the password", %{conn: conn, user: user} do
+      conn
+      |> json_post("/api/auth/reset", %{
+        "token" => reset_token(user),
+        "password" => "brand-new-password"
+      })
+      |> json_response(200)
+
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "brand-new-password")
+      assert {:error, _} = Accounts.authenticate_user(user.email, "old-password-123")
+    end
+
+    test "the token is single-use", %{conn: conn, user: user} do
+      token = reset_token(user)
+
+      conn
+      |> json_post("/api/auth/reset", %{"token" => token, "password" => "first-new-password"})
+      |> json_response(200)
+
+      # session_version moved, so the token that just worked must not work
+      # again — the whole point of carrying it inside the token (#325).
+      body =
+        build_conn()
+        |> json_post("/api/auth/reset", %{"token" => token, "password" => "second-password"})
+        |> json_response(422)
+
+      assert body["error"] == "invalid_token"
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "first-new-password")
+    end
+
+    test "a weak password is a changeset error, and the password is unchanged", %{
+      conn: conn,
+      user: user
+    } do
+      body =
+        conn
+        |> json_post("/api/auth/reset", %{"token" => reset_token(user), "password" => "short"})
+        |> json_response(422)
+
+      assert body["errors"]["password"]
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "old-password-123")
+    end
+
+    test "records the audit event", %{conn: conn, user: user} do
+      conn
+      |> json_post("/api/auth/reset", %{"token" => reset_token(user), "password" => "a-new-one-1"})
+      |> json_response(200)
+
+      actions = Fountain.Audit.list_recent_for_user(user.id, 50) |> Enum.map(& &1.action)
+      assert "auth.password.reset" in actions
+    end
+
+    test "a garbage token is 422", %{conn: conn} do
+      body =
+        conn
+        |> json_post("/api/auth/reset", %{"token" => "nope", "password" => "whatever-123"})
+        |> json_response(422)
+
+      assert body["error"] == "invalid_token"
+    end
+
+    test "missing params are 422", %{conn: conn} do
+      conn |> json_post("/api/auth/reset", %{"token" => "x"}) |> json_response(422)
+    end
+  end
+
+  describe "POST /api/auth/email/confirm" do
+    test "applies the pending email change", %{conn: conn} do
+      user = insert_verified_user(%{"password" => "password12345"})
+      token = Accounts.email_change_token(user, "new-address@example.com")
+
+      body = conn |> json_post("/api/auth/email/confirm", %{"token" => token}) |> json_response(200)
+
+      assert body["email"] == "new-address@example.com"
+      assert Accounts.get_user(user.id).email == "new-address@example.com"
+    end
+
+    test "an address already taken is refused with a distinct error", %{conn: conn} do
+      user = insert_verified_user(%{"password" => "password12345"})
+      taken = insert_verified_user()
+      token = Accounts.email_change_token(user, taken.email)
+
+      body = conn |> json_post("/api/auth/email/confirm", %{"token" => token}) |> json_response(422)
+
+      assert body["error"] == "email_taken"
+      assert Accounts.get_user(user.id).email == user.email
+    end
+
+    test "a garbage token is 422", %{conn: conn} do
+      body =
+        conn |> json_post("/api/auth/email/confirm", %{"token" => "junk"}) |> json_response(422)
+
+      assert body["error"] == "invalid_token"
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,21 @@ POST   /api/auth/api-keys          # create a key (plaintext returned once)
 DELETE /api/auth/api-keys/:id      # revoke a key
 ```
 
+**Registration and account recovery** (no auth — the emailed token authenticates the completion):
+
+```
+POST   /api/auth/register          # {email, password}
+POST   /api/auth/resend-verification
+POST   /api/auth/verify            # {token} -> activate the account
+POST   /api/auth/forgot            # {email} — always 200, never reveals whether it exists
+POST   /api/auth/reset             # {token, password}
+POST   /api/auth/email/confirm     # {token} — completes a pending email change
+```
+
+The verification and reset emails keep linking to the browser pages; these endpoints accept the same tokens, so a CLI can prompt "paste the code from your email" and never open a browser. `verify` is idempotent (an already-verified account is a 200) and issues no session — mint a key at `POST /api/auth/token` once the account is live. Token failures are `422` with `error` of `invalid_token` or `expired`.
+
+Completing a reset or an email change bumps `session_version`, which signs out every existing session.
+
 **Session cookie:** Obtained via OAuth at `/auth/oauth/:provider` or email/password login. Used by the web UI.
 
 ## Inference credentials


### PR DESCRIPTION
Closes #522. **Merge after #560** (stack: #556 → #557 → #558 → #559 → #560 → this).

## Why

An API consumer could *start* every auth email flow — `register`, `resend-verification`, `forgot` — and finish none. Confirmation was `GET /users/confirm/:token` (browser pipeline, also sets a cookie), reset was `POST /auth/reset`, email-change confirm likewise. **Activating an account required a browser**, which is the one step a headless bootstrap can't fake.

## Endpoints (`:api_public`, authenticated by the token itself)

```
POST /api/auth/verify          {token}
POST /api/auth/reset           {token, password}
POST /api/auth/email/confirm   {token}
```

- The emailed links still point at the browser routes; these accept the same tokens, so a CLI prompts "paste the code from your email" — the issue's stated design.
- Each API action sits next to its browser twin in the same controller, so token semantics stay in one place per flow: 24h verification TTL, the reset token's `session_version` single-use check (#325), the same rate-limit buckets (`password_reset_submit`, 10/hr) and the same audit events (`auth.email.verified`, `auth.password.reset`, `auth.email.changed`).
- `verify` is **idempotent** (already-verified is a 200 — a retrying client isn't an error case) and issues **no session**: an API client wants a key, minted at `POST /api/auth/token` once the account is live. It enqueues the same `StripeCustomerSync` + `WelcomeEmail` work the browser route does, so an account can't end up in a different state depending on which surface finished it.
- Token failures are `422` with `error: "invalid_token" | "expired"`; a weak password comes back as a normal changeset error.

Not in the OpenAPI spec — the whole `/api/auth/*` surface is absent from it today (those controllers don't `use OpenApiSpex.ControllerSpecs`), and wiring that up is a bigger change than this issue. Documented in `docs/api.md` instead, alongside the endpoints they complete.

## Tests

16 in `auth_completion_controller_test.exs`: verification without a browser, **no session cookie issued**, audit parity, idempotent retry, garbage/missing token, token for a deleted user; reset happy path, **token single-use after the session_version bump**, weak password leaving the old password working, audit parity; email-change apply, `email_taken` refusal leaving the address unchanged, garbage token.

Full suite green (2,129 tests); `format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)