### PR TITLE
api: password and email change over a bearer token (#521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ upgrade, is in
 
 ### Added
 
+- **Password and email changes work over a bearer token**:
+  `POST /api/auth/password` and `POST /api/auth/email`. Both existed only as
+  browser POSTs with session auth and CSRF, so an API-driven account could
+  never rotate its own credentials. Both still require the current password —
+  a stolen bearer token must not be enough — and sit behind the `full`-scope
+  gate so a sandbox's per-conversation token cannot rotate the account
+  password. A password change signs out browser sessions but does not revoke
+  API keys, which is what it has always done; the response now says so
+  (`sessions_invalidated`, `api_keys_revoked`) instead of leaving a caller
+  rotating a leaked password to find out later (#521)
+
 - **The auth email flows can be finished over the API.** An API consumer
   could start every one of them — register, resend-verification, forgot —
   and finish none: confirmation and reset were browser routes, so account

--- a/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
@@ -19,7 +19,12 @@ defmodule FountainWeb.AccountSecurityController do
 
   plug FountainWeb.Plugs.RateLimit,
        [bucket: "account_security", max: 10, window_ms: 3_600_000]
-       when action in [:change_password, :request_email_change]
+       when action in [
+              :change_password,
+              :request_email_change,
+              :api_change_password,
+              :api_request_email_change
+            ]
 
   def change_password(conn, %{"current_password" => current, "new_password" => new}) do
     user = conn.assigns.current_user
@@ -116,6 +121,132 @@ defmodule FountainWeb.AccountSecurityController do
     conn
     |> put_flash(:error, "New email and current password are required.")
     |> redirect(to: ~p"/account/security")
+  end
+
+  @doc """
+  Change the password over JSON (#521).
+
+  Requires the current password, exactly like the browser path: a stolen
+  bearer token must not be enough to set a new one.
+
+  ## What this does and does not invalidate
+
+  `change_password/3` bumps `session_version`, which kills every browser
+  session. It does **not** revoke API keys — those are separate credentials
+  with their own hashes and expiries, and always have been. This endpoint
+  keeps that behaviour rather than quietly diverging from the browser path,
+  and says so in the response: a caller rotating a password because
+  something leaked has to revoke keys explicitly at
+  `DELETE /api/auth/api-keys/:id`.
+
+  Behind the `full`-scope gate: the per-conversation token a sandbox holds
+  must not be able to rotate the account password.
+  """
+  def api_change_password(conn, %{"current_password" => current, "new_password" => new}) do
+    user = conn.assigns.current_user
+
+    case Accounts.change_password(user, current, new) do
+      {:ok, updated} ->
+        FountainWeb.Audited.from_conn(conn, "auth.password.changed", "user",
+          user_id: updated.id,
+          resource_id: updated.id
+        )
+
+        json(conn, %{
+          message: "Password updated. Browser sessions have been signed out.",
+          sessions_invalidated: true,
+          api_keys_revoked: false
+        })
+
+      {:error, :invalid_current_password} ->
+        credential_error(conn, :forbidden, "invalid_current_password", "Current password is incorrect.")
+
+      {:error, :no_password} ->
+        credential_error(
+          conn,
+          :unprocessable_entity,
+          "no_password",
+          "This account signs in with GitHub and has no password. Use the reset flow to set one."
+        )
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> put_view(FountainWeb.ChangesetJSON)
+        |> render(:error, changeset: changeset)
+    end
+  end
+
+  def api_change_password(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "current_password and new_password are required"})
+  end
+
+  @doc """
+  Start an email change over JSON (#521). Sends the confirmation link; the
+  address only changes when the token comes back to
+  `POST /api/auth/email/confirm`.
+  """
+  def api_request_email_change(conn, %{"new_email" => new_email, "current_password" => current}) do
+    user = conn.assigns.current_user
+
+    case Accounts.request_email_change(user, new_email, current) do
+      :ok ->
+        FountainWeb.Audited.from_conn(conn, "auth.email.change_requested", "user",
+          user_id: user.id,
+          resource_id: user.id,
+          metadata: %{"new_email" => String.downcase(String.trim(new_email))}
+        )
+
+        # Same response whether or not the address was free — this endpoint
+        # must not be an availability oracle, the same rule the browser path
+        # follows.
+        json(conn, %{
+          message:
+            "If that address is available, a confirmation link is on its way to it. " <>
+              "Your email only changes when that link is used."
+        })
+
+      {:error, :invalid_current_password} ->
+        credential_error(conn, :forbidden, "invalid_current_password", "Current password is incorrect.")
+
+      {:error, :no_password} ->
+        credential_error(
+          conn,
+          :unprocessable_entity,
+          "no_password",
+          "This account signs in with GitHub and has no password."
+        )
+
+      {:error, :invalid_email} ->
+        credential_error(
+          conn,
+          :unprocessable_entity,
+          "invalid_email",
+          "That doesn't look like an email address."
+        )
+
+      {:error, :same_email} ->
+        credential_error(
+          conn,
+          :unprocessable_entity,
+          "same_email",
+          "That is already your email address."
+        )
+    end
+  end
+
+  def api_request_email_change(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "new_email and current_password are required"})
+  end
+
+  defp credential_error(conn, status, error, message) do
+    conn
+    |> put_status(status)
+    |> json(%{error: error, message: message})
   end
 
   @doc """

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -213,6 +213,16 @@ defmodule FountainWeb.Router do
     delete "/api-keys/:id", ApiKeyController, :delete
   end
 
+  # Credential changes (#521) — same gate, same reason: a conversation-scoped
+  # sprite token must not be able to rotate the account password or start an
+  # email change. Both require the current password on top of the bearer token.
+  scope "/api/auth", FountainWeb do
+    pipe_through [:accepts_json, :api, :require_full_scope]
+
+    post "/password", AccountSecurityController, :api_change_password
+    post "/email", AccountSecurityController, :api_request_email_change
+  end
+
   # Account-level configuration. Inference credentials are what a conversation
   # actually runs on, so a sprite token replacing them is the same class of
   # escalation as minting an API key — hence the full-scope gate (#518).

--- a/apps/fountain/test/fountain_web/controllers/account_credentials_api_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/account_credentials_api_test.exs
@@ -1,0 +1,232 @@
+defmodule FountainWeb.AccountCredentialsApiTest do
+  @moduledoc """
+  Password change and email change over a bearer token (#521).
+
+  Both existed only as browser POSTs with session auth and CSRF, so an
+  API-driven account could never rotate its own credentials.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Accounts
+
+  setup do
+    user = insert_verified_user(%{"password" => "old-password-123"})
+    {_rec, key} = insert_api_key(user)
+    {:ok, user: user, key: key}
+  end
+
+  describe "POST /api/auth/password" do
+    test "changes the password when the current one is supplied", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/auth/password", %{
+          "current_password" => "old-password-123",
+          "new_password" => "a-brand-new-password"
+        })
+        |> json_response(200)
+
+      assert body["sessions_invalidated"] == true
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "a-brand-new-password")
+    end
+
+    test "refuses without the current password — a stolen key is not enough", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/auth/password", %{
+          "current_password" => "not-the-password",
+          "new_password" => "attacker-chosen"
+        })
+        |> json_response(403)
+
+      assert body["error"] == "invalid_current_password"
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "old-password-123")
+    end
+
+    test "the response states that API keys survive, because they do", %{
+      conn: conn,
+      key: key
+    } do
+      # The asymmetry that makes this endpoint sensitive: session_version is
+      # bumped (browser sessions die) but API keys are separate credentials
+      # and keep working. Documented in the response rather than left for a
+      # caller rotating a leaked password to discover.
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/auth/password", %{
+          "current_password" => "old-password-123",
+          "new_password" => "another-new-password"
+        })
+        |> json_response(200)
+
+      assert body["api_keys_revoked"] == false
+      assert {:ok, _user, _key} = Accounts.authenticate_api_key(key)
+    end
+
+    test "a weak new password is a changeset error and changes nothing", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/auth/password", %{
+          "current_password" => "old-password-123",
+          "new_password" => "short"
+        })
+        |> json_response(422)
+
+      assert body["errors"]["password"]
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "old-password-123")
+    end
+
+    test "missing params are 422", %{conn: conn, key: key} do
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/auth/password", %{"new_password" => "only-one-field"})
+      |> json_response(422)
+    end
+
+    test "records the same audit event the browser path does", %{conn: conn, user: user, key: key} do
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/auth/password", %{
+        "current_password" => "old-password-123",
+        "new_password" => "audited-new-password"
+      })
+      |> json_response(200)
+
+      actions = Fountain.Audit.list_recent_for_user(user.id, 50) |> Enum.map(& &1.action)
+      assert "auth.password.changed" in actions
+    end
+
+    test "a sprite token cannot rotate the password", %{conn: conn, user: user} do
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+
+      body =
+        conn
+        |> authed_with_key(sprite_key)
+        |> post_json("/api/auth/password", %{
+          "current_password" => "old-password-123",
+          "new_password" => "sandbox-chosen-password"
+        })
+        |> json_response(403)
+
+      assert body["reason"] == "insufficient_scope"
+      assert {:ok, _} = Accounts.authenticate_user(user.email, "old-password-123")
+    end
+  end
+
+  describe "POST /api/auth/email" do
+    test "starts the change without applying it", %{conn: conn, user: user, key: key} do
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/auth/email", %{
+        "new_email" => "moved@example.com",
+        "current_password" => "old-password-123"
+      })
+      |> json_response(200)
+
+      # The address changes only when the emailed token comes back.
+      assert Accounts.get_user(user.id).email == user.email
+    end
+
+    test "is not an availability oracle", %{conn: conn, user: user, key: key} do
+      taken = insert_verified_user()
+
+      free =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/auth/email", %{
+          "new_email" => "definitely-free@example.com",
+          "current_password" => "old-password-123"
+        })
+        |> json_response(200)
+
+      used =
+        build_conn()
+        |> authed_with_key(key)
+        |> post_json("/api/auth/email", %{
+          "new_email" => taken.email,
+          "current_password" => "old-password-123"
+        })
+        |> json_response(200)
+
+      assert free == used
+      assert Accounts.get_user(user.id).email == user.email
+    end
+
+    test "refuses a wrong current password", %{conn: conn, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/auth/email", %{
+          "new_email" => "moved@example.com",
+          "current_password" => "wrong"
+        })
+        |> json_response(403)
+
+      assert body["error"] == "invalid_current_password"
+    end
+
+    test "refuses a malformed address", %{conn: conn, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/auth/email", %{
+          "new_email" => "not-an-email",
+          "current_password" => "old-password-123"
+        })
+        |> json_response(422)
+
+      assert body["error"] == "invalid_email"
+    end
+
+    test "refuses the address the account already has", %{conn: conn, user: user, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/auth/email", %{
+          "new_email" => user.email,
+          "current_password" => "old-password-123"
+        })
+        |> json_response(422)
+
+      assert body["error"] == "same_email"
+    end
+
+    test "a sprite token cannot start an email change", %{conn: conn, user: user} do
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+
+      conn
+      |> authed_with_key(sprite_key)
+      |> post_json("/api/auth/email", %{
+        "new_email" => "sandbox@example.com",
+        "current_password" => "old-password-123"
+      })
+      |> json_response(403)
+    end
+
+    test "requires authentication", %{conn: conn} do
+      conn
+      |> put_req_header("accept", "application/json")
+      |> post_json("/api/auth/email", %{
+        "new_email" => "x@example.com",
+        "current_password" => "y"
+      })
+      |> json_response(401)
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,6 +42,17 @@ The verification and reset emails keep linking to the browser pages; these endpo
 
 Completing a reset or an email change bumps `session_version`, which signs out every existing session.
 
+**Credential changes** (bearer token **plus** the current password; `full`-scoped keys only):
+
+```
+POST   /api/auth/password          # {current_password, new_password}
+POST   /api/auth/email             # {new_email, current_password} — sends a confirmation link
+```
+
+Changing the password signs out browser sessions (`session_version` bumps) but does **not** revoke API keys — they are separate credentials with their own expiries. The response says so explicitly (`sessions_invalidated`, `api_keys_revoked`); if you are rotating because something leaked, revoke keys yourself with `DELETE /api/auth/api-keys/:id`.
+
+The email endpoint answers identically whether or not the address is free — it is not an availability oracle — and the address only changes when the emailed token is submitted to `POST /api/auth/email/confirm`.
+
 **Session cookie:** Obtained via OAuth at `/auth/oauth/:provider` or email/password login. Used by the web UI.
 
 ## Inference credentials


### PR DESCRIPTION
Closes #521. **Merge after #562** (stack: #556 → #557 → #558 → #559 → #560 → #562 → this).

## What

```
POST /api/auth/password   {current_password, new_password}
POST /api/auth/email      {new_email, current_password}
```

Both sit next to their browser twins in `AccountSecurityController` and reuse the same context calls, the same `account_security` rate-limit bucket (10/hr), and the same audit events (`auth.password.changed`, `auth.email.change_requested`). Both still require the **current password** — a stolen bearer token must not be enough — and both are behind the `full`-scope gate from #557: a conversation-scoped sprite token rotating the account password is precisely the escalation that gate exists for.

## The decision the issue asked for

A password change bumps `session_version` (browser sessions die) and **does not revoke API keys** — they're separate credentials with their own hashes and expiries. I kept that: silently diverging from the browser path would be worse than the asymmetry. What changes is that it's no longer invisible — the response carries `sessions_invalidated: true, api_keys_revoked: false`, and `docs/api.md` points a caller rotating because-something-leaked at `DELETE /api/auth/api-keys/:id`.

Say the word if you'd rather it revoke keys and I'll flip it (it would also kill the key making the call, which is why I didn't pick it by default).

## Tests

14 in `account_credentials_api_test.exs`, including the ones that matter: **wrong current password is refused and leaves the old password working**, the surviving-API-key claim asserted against `authenticate_api_key/1` rather than just the response body, a weak new password changing nothing, **sprite tokens refused on both endpoints with the password left intact**, the email endpoint returning byte-identical responses for a free and a taken address (not an availability oracle), and the address staying put until the emailed token is used.

Full suite green (2,143 tests); `format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)