### PR TITLE
api: audit log endpoint (#526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ upgrade, is in
 
 ### Added
 
+- **`GET /api/audit`** serves the account's own audit trail — tenant-scoped,
+  newest first, cursor-paginated, with filters the `/audit` LiveView does not
+  have yet (`action_prefix`, `resource_type`, `since`, `until`). Programmatic
+  access previously meant scraping a LiveView or requesting a whole account
+  export, which is a poor fit for shipping events to a SIEM or an archive.
+  `action_prefix` is matched as a literal, so a `%` filters to nothing rather
+  than returning the entire trail, and a malformed `since`/`until` is a 400
+  rather than a silently unfiltered response (#526)
+
 - **Password and email changes work over a bearer token**:
   `POST /api/auth/password` and `POST /api/auth/email`. Both existed only as
   browser POSTs with session auth and CSRF, so an API-driven account could

--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -130,12 +130,77 @@ defmodule Fountain.Audit do
   """
   @spec list_recent_for_user(Ecto.UUID.t(), pos_integer()) :: [Event.t()]
   def list_recent_for_user(user_id, limit \\ 200) when is_binary(user_id) do
-    Repo.all(
-      from e in Event,
-        where: e.user_id == ^user_id,
-        order_by: [desc: e.inserted_at, desc: e.id],
-        limit: ^limit
+    list_for_user(user_id, limit: limit)
+  end
+
+  @doc """
+  Tenant-scoped events, newest first, with filters and a cursor.
+
+  Options:
+
+    * `:limit` — page size (default 200)
+    * `:before_id` — only events with a smaller id; the cursor for paging
+      back through history, since the order is newest-first
+    * `:action_prefix` — e.g. `"vault."` for everything vault-related.
+      LIKE metacharacters in the value are escaped, so a prefix of `%` is a
+      literal `%` and not "match everything"
+    * `:resource_type` — exact match
+    * `:since` / `:until` — `DateTime` bounds on `inserted_at`, inclusive
+
+  Unknown options are ignored. The trail is append-only, so paging by id is
+  stable: nothing is inserted behind the cursor.
+  """
+  @spec list_for_user(Ecto.UUID.t(), keyword()) :: [Event.t()]
+  def list_for_user(user_id, opts \\ []) when is_binary(user_id) do
+    from(e in Event,
+      where: e.user_id == ^user_id,
+      order_by: [desc: e.inserted_at, desc: e.id],
+      limit: ^Keyword.get(opts, :limit, 200)
     )
+    |> filter_before_id(Keyword.get(opts, :before_id))
+    |> filter_action_prefix(Keyword.get(opts, :action_prefix))
+    |> filter_resource_type(Keyword.get(opts, :resource_type))
+    |> filter_since(Keyword.get(opts, :since))
+    |> filter_until(Keyword.get(opts, :until))
+    |> Repo.all()
+  end
+
+  defp filter_before_id(query, nil), do: query
+
+  defp filter_before_id(query, id) when is_integer(id),
+    do: from(e in query, where: e.id < ^id)
+
+  defp filter_action_prefix(query, nil), do: query
+  defp filter_action_prefix(query, ""), do: query
+
+  defp filter_action_prefix(query, prefix) when is_binary(prefix) do
+    from(e in query, where: like(e.action, ^(escape_like(prefix) <> "%")))
+  end
+
+  defp filter_resource_type(query, nil), do: query
+  defp filter_resource_type(query, ""), do: query
+
+  defp filter_resource_type(query, type) when is_binary(type),
+    do: from(e in query, where: e.resource_type == ^type)
+
+  defp filter_since(query, nil), do: query
+
+  defp filter_since(query, %DateTime{} = since),
+    do: from(e in query, where: e.inserted_at >= ^since)
+
+  defp filter_until(query, nil), do: query
+
+  defp filter_until(query, %DateTime{} = until),
+    do: from(e in query, where: e.inserted_at <= ^until)
+
+  # A caller-supplied prefix is a literal, not a pattern: without this,
+  # `?action_prefix=%` would match the whole trail and `_` would be a
+  # single-character wildcard.
+  defp escape_like(value) do
+    value
+    |> String.replace("\\", "\\\\")
+    |> String.replace("%", "\\%")
+    |> String.replace("_", "\\_")
   end
 
   @doc """

--- a/apps/fountain/lib/fountain_web/controllers/audit_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/audit_controller.ex
@@ -1,0 +1,139 @@
+defmodule FountainWeb.AuditController do
+  @moduledoc """
+  The tenant's own audit trail over the API (#526).
+
+  The trail was readable at `/audit` in a browser and, indirectly, inside an
+  account export. Anything that wanted to ship its own audit events somewhere —
+  a SIEM, a compliance archive, a weekly digest — had to scrape a LiveView or
+  request a full export.
+
+  Tenant-scoped by construction: `Audit.list_for_user/2` filters on `user_id`,
+  and cross-tenant listing belongs to the admin API, not here.
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Audit
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  @default_limit 100
+  @max_limit 500
+
+  tags(["Audit"])
+
+  operation(:index,
+    summary: "List the account's audit events",
+    description:
+      "Newest first, cursor-paginated: pass the previous page's " <>
+        "`meta.next_cursor` as `before`. Only this tenant's events; system and " <>
+        "cross-tenant rows are not visible here.",
+    parameters: [
+      limit: [
+        in: :query,
+        type: :integer,
+        required: false,
+        description: "Page size, 1..#{@max_limit}. Defaults to #{@default_limit}."
+      ],
+      before: [
+        in: :query,
+        type: :integer,
+        required: false,
+        description: "Return events older than this event id."
+      ],
+      action_prefix: [
+        in: :query,
+        type: :string,
+        required: false,
+        description:
+          "Match actions starting with this string, e.g. `vault.` for every " <>
+            "vault event. Treated as a literal — LIKE metacharacters do not apply."
+      ],
+      resource_type: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Exact match, e.g. `secret`, `vault_secret`, `conversation`."
+      ],
+      since: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "ISO 8601 timestamp; events at or after it."
+      ],
+      until: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "ISO 8601 timestamp; events at or before it."
+      ]
+    ],
+    responses: [
+      ok: {"Audit events", "application/json", Schemas.AuditEventListResponse},
+      bad_request: {"Malformed since/until", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index(conn, params) do
+    user = conn.assigns.current_user
+    limit = parse_limit(params["limit"])
+
+    with {:ok, since} <- parse_time(params["since"], "since"),
+         {:ok, until} <- parse_time(params["until"], "until") do
+      # One extra row answers has_more without a second count query.
+      events =
+        Audit.list_for_user(user.id,
+          limit: limit + 1,
+          before_id: parse_before(params["before"]),
+          action_prefix: params["action_prefix"],
+          resource_type: params["resource_type"],
+          since: since,
+          until: until
+        )
+
+      {page, has_more?} =
+        case Enum.split(events, limit) do
+          {page, []} -> {page, false}
+          {page, _} -> {page, true}
+        end
+
+      render(conn, :index, events: page, has_more: has_more?, limit: limit)
+    end
+  end
+
+  defp parse_limit(nil), do: @default_limit
+  defp parse_limit(n) when is_integer(n), do: n |> max(1) |> min(@max_limit)
+
+  defp parse_limit(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, _} -> parse_limit(n)
+      :error -> @default_limit
+    end
+  end
+
+  defp parse_before(nil), do: nil
+  defp parse_before(n) when is_integer(n), do: n
+
+  defp parse_before(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp parse_time(nil, _field), do: {:ok, nil}
+  defp parse_time("", _field), do: {:ok, nil}
+
+  defp parse_time(value, field) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> {:ok, dt}
+      # A silently-ignored bad timestamp would return the unfiltered trail and
+      # look like "nothing matched my window" — worse than a refusal.
+      {:error, _} -> {:error, "#{field} must be an ISO 8601 timestamp"}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/audit_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/audit_json.ex
@@ -1,0 +1,34 @@
+defmodule FountainWeb.AuditJSON do
+  @moduledoc false
+
+  alias Fountain.Audit.Event
+
+  def index(%{events: events, has_more: has_more?, limit: limit}) do
+    %{
+      data: Enum.map(events, &data/1),
+      meta: %{
+        limit: limit,
+        has_more: has_more?,
+        # Pass back as `before`. nil on an empty page: there is nothing to
+        # resume from, and echoing the request's cursor invites a loop.
+        next_cursor: events |> List.last() |> event_id()
+      }
+    }
+  end
+
+  defp data(%Event{} = e) do
+    %{
+      id: e.id,
+      inserted_at: e.inserted_at,
+      actor: e.actor,
+      action: e.action,
+      resource_type: e.resource_type,
+      resource_id: e.resource_id,
+      metadata: e.metadata,
+      request_ip: e.request_ip
+    }
+  end
+
+  defp event_id(%Event{id: id}), do: id
+  defp event_id(nil), do: nil
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -237,6 +237,9 @@ defmodule FountainWeb.Router do
   scope "/api", FountainWeb do
     pipe_through [:accepts_json, :api]
 
+    # The tenant's own trail (#526). Cross-tenant listing is an admin concern.
+    get "/audit", AuditController, :index
+
     resources "/environments", EnvironmentController, except: [:new, :edit] do
       resources "/secrets", SecretController, only: [:index, :create, :delete]
     end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -920,6 +920,61 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule AuditEvent do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuditEvent",
+      description: "One entry in the account's append-only audit trail.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :integer, description: "Cursor for `before`."},
+        inserted_at: %Schema{type: :string, format: :"date-time"},
+        actor: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "Which surface acted: `ui` (browser session), `api` (bearer key), " <>
+              "`sprite` (a per-conversation token held by a sandbox), `system`."
+        },
+        action: %Schema{type: :string, example: "vault.secret.write"},
+        resource_type: %Schema{type: :string, nullable: true},
+        resource_id: %Schema{type: :string, nullable: true},
+        metadata: %Schema{type: :object, additionalProperties: true},
+        request_ip: %Schema{type: :string, nullable: true}
+      },
+      required: [:id, :action, :inserted_at]
+    })
+  end
+
+  defmodule AuditEventListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuditEventListResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{type: :array, items: AuditEvent},
+        meta: %Schema{
+          type: :object,
+          properties: %{
+            limit: %Schema{type: :integer},
+            has_more: %Schema{type: :boolean},
+            next_cursor: %Schema{
+              type: :integer,
+              nullable: true,
+              description: "Pass as `before` for the next (older) page."
+            }
+          },
+          required: [:limit, :has_more]
+        }
+      },
+      required: [:data, :meta]
+    })
+  end
+
   defmodule InferenceCredentialStatus do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/audit_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/audit_controller_test.exs
@@ -1,0 +1,173 @@
+defmodule FountainWeb.AuditControllerTest do
+  @moduledoc """
+  The account's audit trail over the API (#526).
+
+  Before this, programmatic access meant either scraping the `/audit`
+  LiveView or requesting a whole account export.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Audit
+
+  setup do
+    user = insert_verified_user()
+    {_rec, key} = insert_api_key(user)
+    {:ok, user: user, key: key}
+  end
+
+  defp record(user, attrs) do
+    {:ok, event} =
+      Audit.record(
+        Map.merge(
+          %{
+            action: "vault.secret.write",
+            resource_type: "vault_secret",
+            actor: "api",
+            user_id: user.id
+          },
+          attrs
+        )
+      )
+
+    event
+  end
+
+  defp list(conn, key, query \\ "") do
+    conn |> authed_with_key(key) |> get("/api/audit" <> query) |> json_response(200)
+  end
+
+  describe "GET /api/audit" do
+    test "returns the tenant's events newest first with the columns the UI shows", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      _older = record(user, %{action: "agent.created", resource_type: "agent"})
+
+      newer =
+        record(user, %{
+          action: "vault.secret.write",
+          resource_id: "vault-123",
+          metadata: %{"key" => "TOKEN"},
+          request_ip: "203.0.113.7"
+        })
+
+      body = list(conn, key)
+      first = hd(body["data"])
+
+      assert first["id"] == newer.id
+      assert first["action"] == "vault.secret.write"
+      assert first["resource_type"] == "vault_secret"
+      assert first["resource_id"] == "vault-123"
+      assert first["actor"] == "api"
+      assert first["metadata"] == %{"key" => "TOKEN"}
+      assert first["request_ip"] == "203.0.113.7"
+      assert first["inserted_at"]
+    end
+
+    test "never shows another tenant's events", %{conn: conn, key: key} do
+      other = insert_verified_user()
+      record(other, %{action: "someone.elses.event", resource_id: "not-yours"})
+
+      body = list(conn, key)
+
+      refute Enum.any?(body["data"], &(&1["action"] == "someone.elses.event"))
+    end
+
+    test "requires authentication", %{conn: conn} do
+      conn
+      |> put_req_header("accept", "application/json")
+      |> get("/api/audit")
+      |> json_response(401)
+    end
+  end
+
+  describe "filters" do
+    setup %{user: user} do
+      record(user, %{action: "agent.created", resource_type: "agent"})
+      record(user, %{action: "vault.secret.write", resource_type: "vault_secret"})
+      record(user, %{action: "vault.secret.delete", resource_type: "vault_secret"})
+      :ok
+    end
+
+    test "action_prefix narrows to a family of actions", %{conn: conn, key: key} do
+      body = list(conn, key, "?action_prefix=vault.")
+
+      assert length(body["data"]) == 2
+      assert Enum.all?(body["data"], &String.starts_with?(&1["action"], "vault."))
+    end
+
+    test "action_prefix is a literal, not a LIKE pattern", %{conn: conn, key: key} do
+      # Without escaping, `%` would match the whole trail — a filter that
+      # silently returns everything is worse than one that returns nothing.
+      assert list(conn, key, "?action_prefix=%")["data"] == []
+      assert list(conn, key, "?action_prefix=_gent.created")["data"] == []
+    end
+
+    test "resource_type is an exact match", %{conn: conn, key: key} do
+      body = list(conn, key, "?resource_type=agent")
+
+      assert length(body["data"]) == 1
+      assert hd(body["data"])["resource_type"] == "agent"
+    end
+
+    test "since and until bound the window", %{conn: conn, user: user, key: key} do
+      # Everything above was recorded "now"; an until in the past excludes it.
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.to_iso8601()
+      future = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.to_iso8601()
+
+      assert list(conn, key, "?until=#{past}")["data"] == []
+      assert list(conn, key, "?since=#{past}")["data"] != []
+      assert list(conn, key, "?since=#{future}")["data"] == []
+
+      assert length(list(conn, key, "?since=#{past}&until=#{future}")["data"]) ==
+               length(Audit.list_recent_for_user(user.id, 100))
+    end
+
+    test "a malformed timestamp is refused rather than ignored", %{conn: conn, key: key} do
+      # Ignoring it would return the unfiltered trail and read as "nothing
+      # matched my window".
+      conn
+      |> authed_with_key(key)
+      |> get("/api/audit?since=yesterday")
+      |> json_response(400)
+    end
+  end
+
+  describe "pagination" do
+    test "pages backwards through history with next_cursor", %{conn: conn, user: user, key: key} do
+      for i <- 1..5, do: record(user, %{action: "event.#{i}"})
+
+      page1 = list(conn, key, "?limit=2")
+      assert length(page1["data"]) == 2
+      assert page1["meta"]["has_more"]
+
+      page2 = list(conn, key, "?limit=2&before=#{page1["meta"]["next_cursor"]}")
+      page3 = list(conn, key, "?limit=2&before=#{page2["meta"]["next_cursor"]}")
+
+      ids =
+        (page1["data"] ++ page2["data"] ++ page3["data"])
+        |> Enum.map(& &1["id"])
+
+      # Five distinct events, newest first, no repeats across pages.
+      assert length(ids) == 5
+      assert ids == Enum.uniq(ids)
+      assert ids == Enum.sort(ids, :desc)
+      refute page3["meta"]["has_more"]
+    end
+
+    test "the limit is capped", %{conn: conn, user: user, key: key} do
+      record(user, %{})
+      assert list(conn, key, "?limit=99999")["meta"]["limit"] == 500
+    end
+
+    test "an empty trail returns a null cursor rather than looping", %{conn: conn, key: key} do
+      body = list(conn, key, "?action_prefix=nothing.matches.this")
+
+      assert body["data"] == []
+      assert body["meta"]["next_cursor"] == nil
+      refute body["meta"]["has_more"]
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -185,6 +185,18 @@ Since sub-conversations are created over the API (`X-Fountain-Parent-Conversatio
 
 Page by passing the previous response's `meta.next_cursor` as `after`; keep going while `meta.has_more` is true. `limit` defaults to 100 and caps at 1000. The `id` is the same value the SSE route uses as `Last-Event-ID`, so a client can drain history as JSON and then attach the stream from where it left off.
 
+## Audit
+
+```
+GET    /api/audit    # ?limit= ?before= ?action_prefix= ?resource_type= ?since= ?until=
+```
+
+The account's own append-only trail, newest first: `id`, `inserted_at`, `actor`, `action`, `resource_type`, `resource_id`, `metadata`, `request_ip`. `actor` distinguishes `ui` (browser session), `api` (a bearer key), `sprite` (the per-conversation token a sandbox holds) and `system`.
+
+Page backwards with `meta.next_cursor` as `before`; `limit` defaults to 100 and caps at 500. `action_prefix` matches a family of actions (`vault.`) and is treated as a literal, not a LIKE pattern. `since` / `until` take ISO 8601 timestamps and are refused with `400` if malformed rather than silently ignored.
+
+Only this tenant's events are visible.
+
 ## Error responses
 
 ```json


### PR DESCRIPTION
Closes #526. **Merge after #563** (stack: #556 → #557 → #558 → #559 → #560 → #562 → #563 → this).

## What

```
GET /api/audit?limit=&before=&action_prefix=&resource_type=&since=&until=
```

Tenant-scoped (`Audit.list_for_user/2` — cross-tenant listing stays with the admin API, per the issue), newest first, serializing exactly the columns the `/audit` LiveView shows: `inserted_at`, `actor`, `action`, `resource_type`, `resource_id`, `metadata`, `request_ip`, plus `id` as the cursor.

The filters are the ones the issue wanted and the LiveView doesn't have yet — `action_prefix`, `resource_type`, `since`, `until`. Giving AuditLive the same filters is left for a follow-up, as the issue suggests.

## Two deliberate refusals

- **`action_prefix` is a literal.** Un-escaped, `?action_prefix=%` would match the entire trail — a filter that silently returns *everything* is worse than one that returns nothing. LIKE metacharacters are escaped; there's a test asserting `%` and `_` filter to empty.
- **A malformed `since`/`until` is a 400.** Ignoring it would return the unfiltered trail, which reads to a caller as "nothing matched my window".

Cursor paging is stable by construction — the trail is append-only, so nothing appears behind the cursor.

## Tests

11 in `audit_controller_test.exs`: column coverage, **another tenant's events never appearing**, 401, each filter, the two refusals above, a three-page walk asserting 5 distinct ids in descending order with no repeats and `has_more: false` on the last page, the limit cap, and an empty result returning a null cursor rather than something a client would loop on.

Full suite green (2,154 tests); `format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)