### PR TITLE
api: expose and complete onboarding over the API (#525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ upgrade, is in
 
 ### Added
 
+- **Onboarding can be completed over the API** —
+  `POST /api/account/onboarding/complete`, with `GET /api/account/onboarding`
+  and new `onboarding_state` / `onboarding_completed` / `email_verified`
+  fields on `GET /api/auth/me`. `complete_onboarding/1` had exactly one
+  caller, the wizard LiveView, so an account configured entirely through the
+  API stayed permanently un-onboarded and a later browser visit dropped the
+  user into a wizard they had no reason to see (#525)
+
 - **`GET /api/audit`** serves the account's own audit trail — tenant-scoped,
   newest first, cursor-paginated, with filters the `/audit` LiveView does not
   have yet (`action_prefix`, `resource_type`, `since`, `until`). Programmatic

--- a/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
@@ -15,6 +15,11 @@ defmodule FountainWeb.AuthMeController do
       id: user.id,
       email: user.email,
       role: user.role,
+      email_verified: not is_nil(user.email_verified_at),
+      # Read side of #525: a client that just bootstrapped an account can see
+      # whether the browser will drop this user into the wizard.
+      onboarding_state: user.onboarding_state,
+      onboarding_completed: not is_nil(user.onboarding_completed_at),
       # The key stays for JSON-shape compatibility, but on a billing-disabled
       # instance the value is null even for accounts that carry pre-disable
       # residue — there is no subscription for the status to be about (#480).

--- a/apps/fountain/lib/fountain_web/controllers/onboarding_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/onboarding_controller.ex
@@ -1,0 +1,61 @@
+defmodule FountainWeb.OnboardingController do
+  @moduledoc """
+  Onboarding state over the API (#525).
+
+  `complete_onboarding/1` and `advance_onboarding/2` were called only from the
+  wizard LiveView, so an account driven entirely through the API stayed
+  permanently un-onboarded: `onboarding_state` never reached `"completed"`, and
+  a later browser visit to `/onboarding` dropped the user back into the wizard
+  they had no reason to see.
+
+  Nothing hard-gates on the flag today — it drives the dashboard banner and the
+  post-login redirect — so this is a small write, not a new gate.
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Accounts
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Account"])
+
+  operation(:show,
+    summary: "Get onboarding state",
+    responses: [
+      ok: {"Onboarding state", "application/json", Schemas.OnboardingResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, _params) do
+    render(conn, :show, user: conn.assigns.current_user)
+  end
+
+  operation(:complete,
+    summary: "Mark onboarding complete",
+    description:
+      "Idempotent: completing an already-completed account keeps the original " <>
+        "`completed_at` rather than moving it.",
+    responses: [
+      ok: {"Onboarding state", "application/json", Schemas.OnboardingResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error}
+    ]
+  )
+
+  def complete(conn, _params) do
+    user = conn.assigns.current_user
+
+    if user.onboarding_completed_at do
+      render(conn, :show, user: user)
+    else
+      with {:ok, updated} <- Accounts.complete_onboarding(user) do
+        render(conn, :show, user: updated)
+      end
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/onboarding_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/onboarding_json.ex
@@ -1,0 +1,13 @@
+defmodule FountainWeb.OnboardingJSON do
+  @moduledoc false
+
+  def show(%{user: user}) do
+    %{
+      data: %{
+        state: user.onboarding_state,
+        completed: not is_nil(user.onboarding_completed_at),
+        completed_at: user.onboarding_completed_at
+      }
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -229,6 +229,9 @@ defmodule FountainWeb.Router do
   scope "/api/account", FountainWeb do
     pipe_through [:accepts_json, :api, :require_full_scope]
 
+    get "/onboarding", OnboardingController, :show
+    post "/onboarding/complete", OnboardingController, :complete
+
     get "/inference-credentials", InferenceCredentialController, :index
     put "/inference-credentials/:provider", InferenceCredentialController, :update
     delete "/inference-credentials/:provider", InferenceCredentialController, :delete

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -920,6 +920,33 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule OnboardingResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "OnboardingResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            state: %Schema{
+              type: :string,
+              nullable: true,
+              enum: ~w(step_1 step_2 step_3 step_4 completed),
+              description: "Wizard position. Only `completed` means anything to an API client."
+            },
+            completed: %Schema{type: :boolean},
+            completed_at: %Schema{type: :string, format: :"date-time", nullable: true}
+          },
+          required: [:completed]
+        }
+      },
+      required: [:data]
+    })
+  end
+
   defmodule AuditEvent do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/onboarding_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/onboarding_controller_test.exs
@@ -1,0 +1,106 @@
+defmodule FountainWeb.OnboardingControllerTest do
+  @moduledoc """
+  Onboarding completion over the API (#525).
+
+  `complete_onboarding/1` had one caller, the wizard LiveView, so an account
+  driven entirely through the API stayed permanently un-onboarded and a later
+  browser visit re-entered a wizard the user had no reason to see.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Accounts
+
+  setup do
+    user = insert_verified_user()
+    {_rec, key} = insert_api_key(user)
+    {:ok, user: user, key: key}
+  end
+
+  describe "GET /api/account/onboarding" do
+    test "reports an un-onboarded account", %{conn: conn, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/account/onboarding")
+        |> json_response(200)
+
+      assert body["data"]["completed"] == false
+      assert body["data"]["completed_at"] == nil
+    end
+  end
+
+  describe "POST /api/account/onboarding/complete" do
+    test "completes onboarding", %{conn: conn, user: user, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/account/onboarding/complete")
+        |> json_response(200)
+
+      assert body["data"]["completed"] == true
+      assert body["data"]["state"] == "completed"
+
+      reloaded = Accounts.get_user(user.id)
+      assert reloaded.onboarding_completed_at
+      assert reloaded.onboarding_state == "completed"
+    end
+
+    test "is idempotent and does not move the original timestamp", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      conn
+      |> authed_with_key(key)
+      |> post("/api/account/onboarding/complete")
+      |> json_response(200)
+
+      first_at = Accounts.get_user(user.id).onboarding_completed_at
+
+      build_conn()
+      |> authed_with_key(key)
+      |> post("/api/account/onboarding/complete")
+      |> json_response(200)
+
+      assert Accounts.get_user(user.id).onboarding_completed_at == first_at
+    end
+
+    test "a sprite token cannot complete onboarding for the account", %{conn: conn, user: user} do
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+
+      conn
+      |> authed_with_key(sprite_key)
+      |> post("/api/account/onboarding/complete")
+      |> json_response(403)
+
+      refute Accounts.get_user(user.id).onboarding_completed_at
+    end
+
+    test "requires authentication", %{conn: conn} do
+      conn
+      |> put_req_header("accept", "application/json")
+      |> post("/api/account/onboarding/complete")
+      |> json_response(401)
+    end
+  end
+
+  describe "GET /api/auth/me" do
+    test "carries onboarding and verification state", %{conn: conn, key: key} do
+      body = conn |> authed_with_key(key) |> get("/api/auth/me") |> json_response(200)
+
+      assert body["email_verified"] == true
+      assert body["onboarding_completed"] == false
+
+      build_conn()
+      |> authed_with_key(key)
+      |> post("/api/account/onboarding/complete")
+      |> json_response(200)
+
+      after_body = build_conn() |> authed_with_key(key) |> get("/api/auth/me") |> json_response(200)
+
+      assert after_body["onboarding_completed"] == true
+      assert after_body["onboarding_state"] == "completed"
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,6 +55,15 @@ The email endpoint answers identically whether or not the address is free — it
 
 **Session cookie:** Obtained via OAuth at `/auth/oauth/:provider` or email/password login. Used by the web UI.
 
+## Account state
+
+```
+GET    /api/account/onboarding           # {state, completed, completed_at}
+POST   /api/account/onboarding/complete  # idempotent
+```
+
+An account configured entirely through the API never passes through the browser wizard, so nothing marks it onboarded and a later browser visit re-enters that wizard. Completing it over the API closes the loop. `GET /api/auth/me` also carries `email_verified`, `onboarding_state` and `onboarding_completed`.
+
 ## Inference credentials
 
 Conversations run on your own provider tokens (BYO — Fountain never sees your inference traffic), so a new account cannot start a conversation until at least one is set.


### PR DESCRIPTION
Closes #525. **Merge after #564** (stack tip; full order in #556 → #557 → #558 → #559 → #560 → #562 → #563 → #564 → this).

## What

```
GET  /api/account/onboarding           # {state, completed, completed_at}
POST /api/account/onboarding/complete  # idempotent
```

plus `email_verified`, `onboarding_state` and `onboarding_completed` on `GET /api/auth/me`, so a client that just bootstrapped an account can *see* the flag rather than only set it.

I took the issue's "smallest fix" option rather than deriving completion from "≥1 credential and ≥1 agent". Deriving would retroactively change what existing browser accounts see — an account that has a credential and an agent but genuinely hasn't finished the wizard would silently skip it — and it couples an onboarding flag to unrelated resource state. The endpoint is honest about who's asserting completion.

Idempotent: completing an already-completed account keeps the original `completed_at` rather than moving it. Behind the `full`-scope gate along with the rest of `/api/account/*` — one rule for account-level writes, and there's no reason a sandbox should be finishing the owner's onboarding.

**Not a bug after all:** the parked note about `DashboardLive`'s `not is_nil(onboarding_completed_at)` predicate looking inverted — it isn't. That banner reads "You're up and running", i.e. it's the post-completion congratulation, so showing it to completed accounts is correct. No change.

## Tests

6 in `onboarding_controller_test.exs`: un-onboarded read, completion writing both `onboarding_state` and `onboarding_completed_at`, **idempotency asserting the timestamp doesn't move**, sprite token refused with the flag left unset, 401, and `/api/auth/me` before and after.

Full suite green (2,160 tests); `format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)