### PR TITLE
api: account data export and deletion (#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ upgrade, is in
 
 ### Added
 
+- **Account data export and account deletion are driveable over the API** —
+  `POST/GET /api/account/exports`, `GET /api/account/exports/:id/download`
+  and `DELETE /api/account`. These are the closest things Fountain has to
+  GDPR flows and both were browser-only. Export keeps its one-per-hour limit
+  (429 with `Retry-After`) and, since the API has no PubSub, reports progress
+  by polling instead of pushing; the download is the same owner-scoped,
+  expiring, audited artifact the session route serves. Deletion is
+  irreversible and takes the tenant encryption key with it, so it requires
+  both a typed `{"confirm": "<account email>"}` body — the API equivalent of
+  the UI's typed-email gate — and a `full`-scoped key, which keeps a
+  sandbox's per-conversation token from destroying the account it is running
+  inside (#523)
+
 - **Agent avatars have an API**: `GET/PUT/DELETE /api/agents/:id/avatar`, and
   `avatar_media_type` is serialized on the agent so a client can tell one
   exists. Upload and delete lived only in the agents LiveView, and even

--- a/apps/fountain/lib/fountain_web/controllers/account_data_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/account_data_controller.ex
@@ -1,0 +1,214 @@
+defmodule FountainWeb.AccountDataController do
+  @moduledoc """
+  Account data export and account deletion over the API (#523).
+
+  Both were browser-only: export lived in `AccountLive` with PubSub progress
+  and a session-scoped download, deletion behind a typed-email confirmation.
+  These are the closest things Fountain has to GDPR flows, and a product whose
+  pitch is "drive everything programmatically" could drive neither.
+
+  The API has no PubSub, so export progress is polled rather than pushed —
+  `POST` returns the pending row, `GET` reports where it got to.
+
+  Deletion is gated on `full` scope (a sandbox's token must not be able to
+  destroy the tenant) *and* on a typed confirmation, the same double check the
+  UI applies.
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Accounts.Deletion
+  alias Fountain.Exports
+  alias FountainWeb.{Audited, Schemas}
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Account"])
+
+  operation(:create_export,
+    summary: "Request an account data export",
+    description:
+      "Builds asynchronously. At most one export exists per account and one " <>
+        "request per hour; a request inside that window is refused with 429 and " <>
+        "a `Retry-After` header. Poll `GET /api/account/exports` for status.",
+    responses: [
+      accepted: {"Pending export", "application/json", Schemas.ExportResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      too_many_requests: {"Rate limited", "application/json", Schemas.Error}
+    ]
+  )
+
+  def create_export(conn, _params) do
+    user = conn.assigns.current_user
+
+    case Exports.request_export(user, actor: "api", request_ip: client_ip(conn)) do
+      {:ok, export} ->
+        conn
+        |> put_status(:accepted)
+        |> render(:show_export, export: export)
+
+      {:error, {:rate_limited, retry_after}} ->
+        conn
+        |> put_resp_header("retry-after", Integer.to_string(retry_after))
+        |> put_status(:too_many_requests)
+        |> json(%{
+          error: "rate_limited",
+          message: "One export per hour. Try again in #{retry_after}s.",
+          retry_after: retry_after
+        })
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  operation(:index_exports,
+    summary: "List account data exports",
+    description:
+      "At most one export exists per account, so this is a zero- or one-element " <>
+        "list — the shape matches the rest of the API rather than 404-ing when " <>
+        "no export has been requested.",
+    responses: [
+      ok: {"Exports", "application/json", Schemas.ExportListResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index_exports(conn, _params) do
+    case Exports.latest_export(conn.assigns.current_user.id) do
+      nil -> render(conn, :index_exports, exports: [])
+      export -> render(conn, :index_exports, exports: [export])
+    end
+  end
+
+  operation(:show_export,
+    summary: "Get an export's status",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Export", "application/json", Schemas.ExportResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show_export(conn, %{"id" => id}) do
+    case Exports.get_export(id, conn.assigns.current_user.id) do
+      nil -> {:error, :not_found}
+      export -> render(conn, :show_export, export: export)
+    end
+  end
+
+  operation(:download_export,
+    summary: "Download a completed export",
+    description:
+      "The gzipped JSON payload, served with `content-encoding: gzip`. 404 " <>
+        "covers every not-downloadable case identically — wrong tenant, missing " <>
+        "id, still pending, failed, expired — so nothing about other tenants' " <>
+        "artifacts is inferable.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Export payload", "application/json", %OpenApiSpex.Schema{type: :string}},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def download_export(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case Exports.get_downloadable_export(id, user.id) do
+      {:ok, export} ->
+        # Same audit event the session route records — the trail should not
+        # care which surface pulled the bytes.
+        Audited.from_conn(conn, "account.export_downloaded", "export",
+          resource_id: export.id,
+          metadata: %{"byte_size" => export.byte_size}
+        )
+
+        filename = "fountain-export-#{Date.to_iso8601(Date.utc_today())}.json"
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> put_resp_header("content-encoding", "gzip")
+        |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}"))
+        |> put_resp_header("cache-control", "private, no-store")
+        |> send_resp(200, export.payload)
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
+  operation(:delete_account,
+    summary: "Delete the account and everything in it",
+    description:
+      "Irreversible. Cancels billing, destroys sandboxes, deletes every " <>
+        "resource and the tenant encryption key. Requires `{\"confirm\": " <>
+        "\"<your account email>\"}` in the body — the API equivalent of the " <>
+        "UI's typed-email gate — and a `full`-scoped key.",
+    request_body: {"Confirmation", "application/json", Schemas.AccountDeleteRequest},
+    responses: [
+      ok: {"Deleted", "application/json", Schemas.AccountDeletedResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      unprocessable_entity: {"Confirmation mismatch", "application/json", Schemas.Error},
+      bad_gateway: {"Billing cancellation failed", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete_account(conn, params) do
+    user = conn.assigns.current_user
+
+    if confirmed?(params["confirm"], user.email) do
+      perform_deletion(conn, user)
+    else
+      conn
+      |> put_status(:unprocessable_entity)
+      |> json(%{
+        error: "confirmation_required",
+        message: "Send {\"confirm\": \"<your account email>\"} to delete this account."
+      })
+    end
+  end
+
+  defp perform_deletion(conn, user) do
+    case Deletion.delete_user(user, actor: "api", request_ip: client_ip(conn)) do
+      {:ok, summary} ->
+        json(conn, %{
+          deleted: true,
+          user_id: summary.user_id,
+          sprites_destroyed: summary.sprites_destroyed
+        })
+
+      # The one failure that aborts before anything is destroyed. 502 rather
+      # than 500: the account is intact and the caller can retry.
+      {:error, {:stripe, _reason}} ->
+        conn
+        |> put_status(:bad_gateway)
+        |> json(%{
+          error: "billing_cancellation_failed",
+          message: "Could not cancel the subscription with Stripe; nothing was deleted."
+        })
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Exact match, like the UI's typed-email gate. Compared in constant time out
+  # of habit rather than need — this is a confirmation, not a secret.
+  defp confirmed?(confirm, email) when is_binary(confirm) and is_binary(email),
+    do: Plug.Crypto.secure_compare(confirm, email)
+
+  defp confirmed?(_, _), do: false
+
+  defp client_ip(conn) do
+    case conn.remote_ip do
+      nil -> nil
+      tuple when is_tuple(tuple) -> tuple |> :inet.ntoa() |> to_string()
+      other -> to_string(other)
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/account_data_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/account_data_json.ex
@@ -1,0 +1,22 @@
+defmodule FountainWeb.AccountDataJSON do
+  @moduledoc false
+
+  alias Fountain.Exports.Export
+
+  def index_exports(%{exports: exports}), do: %{data: Enum.map(exports, &data/1)}
+  def show_export(%{export: export}), do: %{data: data(export)}
+
+  defp data(%Export{} = e) do
+    %{
+      id: e.id,
+      status: e.status,
+      byte_size: e.byte_size,
+      error: e.error,
+      expires_at: e.expires_at,
+      # The payload is never serialized here — it is downloaded, not embedded.
+      downloadable: e.status == "completed" and not Fountain.Exports.expired?(e),
+      inserted_at: e.inserted_at,
+      updated_at: e.updated_at
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -229,6 +229,14 @@ defmodule FountainWeb.Router do
   scope "/api/account", FountainWeb do
     pipe_through [:accepts_json, :api, :require_full_scope]
 
+    # Export and deletion (#523). Deletion is irreversible and takes the
+    # tenant key with it, so it wants the strongest credential the account has.
+    post "/exports", AccountDataController, :create_export
+    get "/exports", AccountDataController, :index_exports
+    get "/exports/:id", AccountDataController, :show_export
+    get "/exports/:id/download", AccountDataController, :download_export
+    delete "/", AccountDataController, :delete_account
+
     get "/onboarding", OnboardingController, :show
     post "/onboarding/complete", OnboardingController, :complete
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -928,6 +928,90 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule Export do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Export",
+      description:
+        "An account data export. Built asynchronously; the payload is fetched " <>
+          "from the download endpoint, never embedded here.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        status: %Schema{type: :string, enum: ~w(pending completed failed)},
+        byte_size: %Schema{type: :integer, nullable: true, description: "Uncompressed size."},
+        error: %Schema{type: :string, nullable: true},
+        expires_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        downloadable: %Schema{
+          type: :boolean,
+          description: "Completed and not yet expired — the only state the download serves."
+        },
+        inserted_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :status]
+    })
+  end
+
+  defmodule ExportResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ExportResponse",
+      type: :object,
+      properties: %{data: Export},
+      required: [:data]
+    })
+  end
+
+  defmodule ExportListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ExportListResponse",
+      type: :object,
+      properties: %{data: %Schema{type: :array, items: Export}},
+      required: [:data]
+    })
+  end
+
+  defmodule AccountDeleteRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AccountDeleteRequest",
+      type: :object,
+      properties: %{
+        confirm: %Schema{
+          type: :string,
+          description: "The account's own email address, exactly."
+        }
+      },
+      required: [:confirm]
+    })
+  end
+
+  defmodule AccountDeletedResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AccountDeletedResponse",
+      type: :object,
+      properties: %{
+        deleted: %Schema{type: :boolean},
+        user_id: %Schema{type: :string, format: :uuid},
+        sprites_destroyed: %Schema{type: :integer}
+      },
+      required: [:deleted]
+    })
+  end
+
   defmodule AvatarRequest do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/account_data_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/account_data_controller_test.exs
@@ -1,0 +1,255 @@
+defmodule FountainWeb.AccountDataControllerTest do
+  @moduledoc """
+  Account data export and account deletion over the API (#523).
+
+  Both were browser-only — export through `AccountLive` with PubSub progress
+  and a session-scoped download, deletion behind a typed-email confirmation —
+  which left the two flows closest to GDPR undriveable by an API consumer.
+  """
+
+  use FountainWeb.ConnCase, async: true
+  use Oban.Testing, repo: Fountain.Repo
+
+  alias Fountain.Accounts
+  alias Fountain.Exports
+  alias Fountain.Exports.Export
+  alias Fountain.Repo
+  alias Fountain.Workers.AccountExport
+
+  setup do
+    user = insert_verified_user()
+    {_rec, key} = insert_api_key(user)
+    {:ok, user: user, key: key}
+  end
+
+  defp complete_export(user, export) do
+    :ok = perform_job(AccountExport, %{export_id: export.id, user_id: user.id})
+    Repo.get!(Export, export.id)
+  end
+
+  describe "POST /api/account/exports" do
+    test "accepts the request and returns the pending row", %{conn: conn, user: user, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/account/exports")
+        |> json_response(202)
+
+      assert body["data"]["status"] == "pending"
+      assert body["data"]["downloadable"] == false
+      assert Exports.latest_export(user.id)
+    end
+
+    test "a second request inside the window is 429 with Retry-After", %{
+      conn: conn,
+      key: key
+    } do
+      conn |> authed_with_key(key) |> post("/api/account/exports") |> json_response(202)
+
+      conn = build_conn() |> authed_with_key(key) |> post("/api/account/exports")
+      body = json_response(conn, 429)
+
+      assert body["error"] == "rate_limited"
+      assert body["retry_after"] > 0
+      assert [retry_after] = get_resp_header(conn, "retry-after")
+      assert String.to_integer(retry_after) > 0
+    end
+
+    test "a sprite token cannot request an export of the whole account", %{
+      conn: conn,
+      user: user
+    } do
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+
+      conn
+      |> authed_with_key(sprite_key)
+      |> post("/api/account/exports")
+      |> json_response(403)
+
+      refute Exports.latest_export(user.id)
+    end
+  end
+
+  describe "GET /api/account/exports" do
+    test "is an empty list before anything is requested", %{conn: conn, key: key} do
+      body = conn |> authed_with_key(key) |> get("/api/account/exports") |> json_response(200)
+      assert body["data"] == []
+    end
+
+    test "reports status as the build progresses", %{conn: conn, user: user, key: key} do
+      {:ok, export} = Exports.request_export(user)
+
+      pending =
+        conn |> authed_with_key(key) |> get("/api/account/exports") |> json_response(200)
+
+      assert hd(pending["data"])["status"] == "pending"
+      assert hd(pending["data"])["downloadable"] == false
+
+      complete_export(user, export)
+
+      done =
+        build_conn() |> authed_with_key(key) |> get("/api/account/exports") |> json_response(200)
+
+      assert hd(done["data"])["status"] == "completed"
+      assert hd(done["data"])["downloadable"] == true
+      assert hd(done["data"])["byte_size"] > 0
+    end
+
+    test "never carries the payload itself", %{conn: conn, user: user, key: key} do
+      {:ok, export} = Exports.request_export(user)
+      insert_agent(user_id: user.id, name: "in-the-export")
+      complete_export(user, export)
+
+      conn = conn |> authed_with_key(key) |> get("/api/account/exports")
+
+      assert json_response(conn, 200)
+      refute conn.resp_body =~ "in-the-export"
+      refute conn.resp_body =~ "payload"
+    end
+
+    test "another tenant's export id is 404", %{conn: conn, key: key} do
+      other = insert_verified_user()
+      {:ok, export} = Exports.request_export(other)
+
+      conn
+      |> authed_with_key(key)
+      |> get("/api/account/exports/#{export.id}")
+      |> json_response(404)
+    end
+  end
+
+  describe "GET /api/account/exports/:id/download" do
+    test "serves the gzipped payload to the owner", %{conn: conn, user: user, key: key} do
+      insert_agent(user_id: user.id, name: "download-me")
+      {:ok, export} = Exports.request_export(user)
+      complete_export(user, export)
+
+      conn =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/account/exports/#{export.id}/download")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-encoding") == ["gzip"]
+
+      doc = conn.resp_body |> :zlib.gunzip() |> Jason.decode!()
+      assert doc["account"]["email"] == user.email
+      assert [%{"name" => "download-me"}] = doc["agents"]
+    end
+
+    test "is audit-recorded like the session route", %{conn: conn, user: user, key: key} do
+      {:ok, export} = Exports.request_export(user)
+      complete_export(user, export)
+
+      conn
+      |> authed_with_key(key)
+      |> get("/api/account/exports/#{export.id}/download")
+
+      actions = user.id |> Fountain.Audit.list_recent_for_user(20) |> Enum.map(& &1.action)
+      assert "account.export_downloaded" in actions
+    end
+
+    test "a pending export is 404, not a partial file", %{conn: conn, user: user, key: key} do
+      {:ok, export} = Exports.request_export(user)
+
+      conn
+      |> authed_with_key(key)
+      |> get("/api/account/exports/#{export.id}/download")
+      |> json_response(404)
+    end
+
+    test "another tenant's completed export is 404", %{conn: conn, key: key} do
+      owner = insert_verified_user()
+      {:ok, export} = Exports.request_export(owner)
+      complete_export(owner, export)
+
+      conn
+      |> authed_with_key(key)
+      |> get("/api/account/exports/#{export.id}/download")
+      |> json_response(404)
+    end
+  end
+
+  describe "DELETE /api/account" do
+    test "deletes the account when the email is confirmed", %{conn: conn, user: user, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> delete_json("/api/account", %{"confirm" => user.email})
+        |> json_response(200)
+
+      assert body["deleted"] == true
+      assert body["user_id"] == user.id
+      refute Accounts.get_user(user.id)
+    end
+
+    test "refuses without the confirmation and deletes nothing", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      # `confirm` is required by the schema, so this one is refused before the
+      # action runs; the empty-string case below is the controller's own check.
+      conn
+      |> authed_with_key(key)
+      |> delete_json("/api/account", %{})
+      |> json_response(422)
+
+      body =
+        build_conn()
+        |> authed_with_key(key)
+        |> delete_json("/api/account", %{"confirm" => ""})
+        |> json_response(422)
+
+      assert body["error"] == "confirmation_required"
+      assert Accounts.get_user(user.id)
+    end
+
+    test "refuses a mismatched confirmation", %{conn: conn, user: user, key: key} do
+      conn
+      |> authed_with_key(key)
+      |> delete_json("/api/account", %{"confirm" => "someone-else@example.com"})
+      |> json_response(422)
+
+      assert Accounts.get_user(user.id)
+    end
+
+    test "a sprite token cannot delete the account it is running inside", %{
+      conn: conn,
+      user: user
+    } do
+      # The escalation this gate exists for: untrusted sandbox code holding a
+      # conversation token must not be able to destroy the tenant.
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+
+      body =
+        conn
+        |> authed_with_key(sprite_key)
+        |> delete_json("/api/account", %{"confirm" => user.email})
+        |> json_response(403)
+
+      assert body["reason"] == "insufficient_scope"
+      assert Accounts.get_user(user.id)
+    end
+
+    test "one tenant cannot delete another by naming their email", %{conn: conn, key: key} do
+      victim = insert_verified_user()
+
+      conn
+      |> authed_with_key(key)
+      |> delete_json("/api/account", %{"confirm" => victim.email})
+      |> json_response(422)
+
+      assert Accounts.get_user(victim.id)
+    end
+
+    test "requires authentication", %{conn: conn, user: user} do
+      conn
+      |> put_req_header("accept", "application/json")
+      |> delete_json("/api/account", %{"confirm" => user.email})
+      |> json_response(401)
+
+      assert Accounts.get_user(user.id)
+    end
+  end
+end

--- a/apps/fountain/test/support/conn_case.ex
+++ b/apps/fountain/test/support/conn_case.ex
@@ -68,4 +68,14 @@ defmodule FountainWeb.ConnCase do
     |> Plug.Conn.put_req_header("content-type", "application/json")
     |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :put, path, Jason.encode!(payload))
   end
+
+  @doc """
+  DELETE with a JSON body — account deletion takes a typed confirmation, so
+  the body matters on a verb that usually has none.
+  """
+  def delete_json(conn, path, payload) do
+    conn
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :delete, path, Jason.encode!(payload))
+  end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,20 @@ POST   /api/account/onboarding/complete  # idempotent
 
 An account configured entirely through the API never passes through the browser wizard, so nothing marks it onboarded and a later browser visit re-enters that wizard. Completing it over the API closes the loop. `GET /api/auth/me` also carries `email_verified`, `onboarding_state` and `onboarding_completed`.
 
+### Data export and deletion
+
+```
+POST   /api/account/exports              # 202 with a pending export; 429 + Retry-After inside the hour
+GET    /api/account/exports              # status (zero- or one-element list)
+GET    /api/account/exports/:id
+GET    /api/account/exports/:id/download # gzipped JSON
+DELETE /api/account                      # {"confirm": "<your account email>"} — irreversible
+```
+
+Exports build asynchronously; the API has no PubSub, so poll `GET /api/account/exports` until `downloadable` is true. At most one export exists per account and one request per hour.
+
+Deleting the account cancels billing, destroys sandboxes and removes every resource **and the tenant encryption key**. It requires the confirmation body — the API equivalent of the UI's typed-email gate — and a `full`-scoped key.
+
 ## Inference credentials
 
 Conversations run on your own provider tokens (BYO — Fountain never sees your inference traffic), so a new account cannot start a conversation until at least one is set.


### PR DESCRIPTION
Closes #523. **Merge after #566.**

## What

```
POST   /api/account/exports              # 202 + pending row
GET    /api/account/exports              # status; GET /:id too
GET    /api/account/exports/:id/download # gzipped JSON
DELETE /api/account                      # {"confirm": "<account email>"}
```

- **Export** keeps the one-per-hour limit, refused with `429` + `Retry-After` (the issue's explicit ask). The API has no PubSub, so progress is polled — `downloadable` on the export object is the flag to wait on. The download reuses `get_downloadable_export/2`, so wrong tenant / missing id / pending / failed / expired stay one indistinguishable 404, and it records the same `account.export_downloaded` event the session route does.
- **Deletion** gets two independent gates: a typed `confirm` body carrying the account's own email (the API equivalent of the UI's typed-email input) **and** `full` scope, so a sprite token can't destroy the tenant it's running inside. A Stripe cancellation failure aborts before anything is destroyed and answers `502` — the account is intact and the call can be retried.

`delete_json/3` is new in `ConnCase` — DELETE with a body is unusual enough to be worth a helper.

## Tests

17 in `account_data_controller_test.exs` (the existing session-route export tests still pass untouched): request → 202, second request 429 with a positive `Retry-After` header, sprite token refused with no export created, empty list before any request, status transition pending → completed with `downloadable` flipping, **the payload never appearing in a status response** (asserted against the response body, not just the shape), foreign export id 404, download round-trip gunzipped and checked, audit parity, pending download 404, and for deletion: happy path, missing/blank/mismatched confirmation each leaving the account intact, **sprite token refused**, **one tenant naming another's email deleting nobody**, and 401.

Full suite green (2,193 tests); `format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)