### PR TITLE
api: billing self-serve — usage, checkout and portal URLs (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ upgrade, is in
 
 ### Added
 
+- **Billing is self-serve over the API**: `GET /api/account/billing` for
+  status, trial and period dates and the current month's usage, plus
+  `POST /api/account/billing/portal` and `.../checkout` to mint Stripe URLs.
+  All user-facing billing lived in `BillingLive`, so a CLI user who hit the
+  subscription gate got a 402 with no programmatic way out, and an expiring
+  trial was invisible — `/api/auth/me` carried `subscription_status` and
+  nothing else. Checkout refuses with 409 when Stripe already holds a live
+  subscription instead of quietly minting a duplicate, and refuses outright
+  when Stripe cannot be asked. With billing disabled the endpoints are 404
+  with `billing: "disabled"`, matching the UI's redirect. The URL-minting
+  rules moved into the billing context so the LiveView and the API cannot
+  drift; everything stays in `ee/` (#524)
+
 - **Account data export and account deletion are driveable over the API** —
   `POST/GET /api/account/exports`, `GET /api/account/exports/:id/download`
   and `DELETE /api/account`. These are the closest things Fountain has to

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -103,6 +103,15 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "no_agent", message: "the conversation's agent has been deleted"})
   end
 
+  # Billing is off on this instance (#524). 404 rather than 402/403: the
+  # endpoint does not exist here, and the UI likewise redirects away from the
+  # billing page entirely.
+  def call(conn, {:error, :billing_disabled}) do
+    conn
+    |> put_status(:not_found)
+    |> json(%{error: "billing_disabled", billing: "disabled"})
+  end
+
   def call(conn, {:error, reason}) when is_binary(reason) do
     conn
     |> put_status(:bad_request)

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -229,6 +229,12 @@ defmodule FountainWeb.Router do
   scope "/api/account", FountainWeb do
     pipe_through [:accepts_json, :api, :require_full_scope]
 
+    # Billing self-serve (#524). The controller lives in ee/ with the rest of
+    # billing; the route has to be here, like the Stripe webhook above.
+    get "/billing", BillingApiController, :show
+    post "/billing/portal", BillingApiController, :portal
+    post "/billing/checkout", BillingApiController, :checkout
+
     # Export and deletion (#523). Deletion is irreversible and takes the
     # tenant key with it, so it wants the strongest credential the account has.
     post "/exports", AccountDataController, :create_export

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -928,6 +928,72 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule BillingResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "BillingResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            status: %Schema{
+              type: :string,
+              enum: ~w(trialing active past_due canceled comped),
+              nullable: true
+            },
+            trial_ends_at: %Schema{type: :string, format: :"date-time", nullable: true},
+            current_period_end: %Schema{type: :string, format: :"date-time", nullable: true},
+            cancel_at_period_end: %Schema{
+              type: :boolean,
+              description: "Access continues until current_period_end."
+            },
+            has_stripe_customer: %Schema{type: :boolean},
+            period: %Schema{
+              type: :object,
+              description: "The window the usage numbers cover (current calendar month).",
+              properties: %{
+                start: %Schema{type: :string, format: :"date-time"},
+                end: %Schema{type: :string, format: :"date-time"}
+              }
+            },
+            usage: %Schema{
+              type: :object,
+              properties: %{
+                conversations: %Schema{type: :integer},
+                turns: %Schema{type: :integer},
+                sandbox_minutes: %Schema{type: :number}
+              }
+            }
+          },
+          required: [:status, :usage]
+        }
+      },
+      required: [:data]
+    })
+  end
+
+  defmodule StripeUrlResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "StripeUrlResponse",
+      description: "A Stripe-hosted URL to open in a browser. Single-use and short-lived.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{url: %Schema{type: :string, format: :uri}},
+          required: [:url]
+        }
+      },
+      required: [:data]
+    })
+  end
+
   defmodule Export do
     @moduledoc false
     require OpenApiSpex

--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,18 @@ POST   /api/account/onboarding/complete  # idempotent
 
 An account configured entirely through the API never passes through the browser wizard, so nothing marks it onboarded and a later browser visit re-enters that wizard. Completing it over the API closes the loop. `GET /api/auth/me` also carries `email_verified`, `onboarding_state` and `onboarding_completed`.
 
+### Billing
+
+```
+GET    /api/account/billing           # status, trial/period dates, current-month usage
+POST   /api/account/billing/portal    # Stripe Billing Portal URL
+POST   /api/account/billing/checkout  # Stripe Checkout URL
+```
+
+Stripe requires a browser to finish, so the URL is the deliverable — mint it here, open it there. Return URLs are server-chosen; a caller-supplied one would be an open redirect.
+
+`checkout` refuses with `409 subscription_exists` when Stripe already holds a live subscription (Checkout on top of one creates a duplicate) — use the portal instead. Both refuse a comped account with `422`, and answer `502` rather than guessing when Stripe is unreachable. On an instance with billing disabled all three are `404` with `"billing": "disabled"`.
+
 ### Data export and deletion
 
 ```

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -725,6 +725,93 @@ defmodule Fountain.Billing do
   def ensure_stripe_customer(%User{} = user), do: create_stripe_customer(user)
 
   @doc """
+  Mint a Stripe Billing Portal session URL for `user`, returning `{:ok, url}`.
+
+  Refuses a comped account: there is nothing to manage and nothing to pay.
+  Refuses an account with no Stripe customer — the portal is per-customer, and
+  a user who has never been one has no portal to visit.
+  """
+  @spec portal_url(User.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def portal_url(%User{subscription_status: "comped"}, _return_url), do: {:error, :comped}
+
+  def portal_url(%User{stripe_customer_id: id}, _return_url) when id in [nil, ""],
+    do: {:error, :no_customer}
+
+  def portal_url(%User{stripe_customer_id: customer_id}, return_url) do
+    case Stripe.BillingPortal.Session.create(%{customer: customer_id, return_url: return_url}) do
+      {:ok, session} -> {:ok, session.url}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Mint a Stripe Checkout session URL for `user`, returning `{:ok, url}`.
+
+  Creates the Stripe Customer first when the user has none: passing
+  `customer_email` instead makes Stripe mint its own Customer whose id we never
+  learn, so the resulting webhook matches no user and the card is charged
+  without the account ever activating.
+
+  Refuses a comped account. Callers must check `has_live_subscription?/1`
+  first — Checkout opened on top of a live subscription creates a second,
+  duplicate one.
+  """
+  @spec checkout_url(User.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def checkout_url(%User{subscription_status: "comped"}, _return_url), do: {:error, :comped}
+
+  def checkout_url(%User{} = user, return_url) do
+    with {:ok, user} <- ensure_stripe_customer(user) do
+      params = %{
+        mode: :subscription,
+        line_items: [%{price: Application.get_env(:fountain, :stripe_price_id, ""), quantity: 1}],
+        success_url: return_url <> "?checkout=success",
+        cancel_url: return_url,
+        customer: user.stripe_customer_id,
+        # Second route back to the user if the customer link is ever lost —
+        # checkout.session.completed carries this through.
+        client_reference_id: user.id,
+        # Show the "Add promotion code" link; without the flag it is hidden.
+        allow_promotion_codes: true
+      }
+
+      case Stripe.Checkout.Session.create(params) do
+        {:ok, session} -> {:ok, session.url}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @doc """
+  The Stripe URL a "manage my subscription" action should send `user` to:
+  the Portal when they already have something live to manage, Checkout when
+  they do not.
+
+  An existing customer may hold a live subscription even when the local status
+  says otherwise — a cancel-at-period-end stays `active` in Stripe until the
+  period ends, and a lost webhook leaves the same mismatch — so the lookup is
+  what keeps Checkout from opening a duplicate subscription on top.
+  """
+  @spec manage_url(User.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def manage_url(%User{subscription_status: "comped"}, _return_url), do: {:error, :comped}
+
+  def manage_url(%User{} = user, return_url) do
+    cond do
+      user.subscription_status in ~w(active past_due) and user.stripe_customer_id ->
+        portal_url(user, return_url)
+
+      user.stripe_customer_id in [nil, ""] ->
+        checkout_url(user, return_url)
+
+      true ->
+        case has_live_subscription?(user) do
+          {:ok, true} -> portal_url(user, return_url)
+          {:ok, false} -> checkout_url(user, return_url)
+          {:error, _} = error -> error
+        end
+    end
+  end
+
+  @doc """
   Attach a Stripe customer id to a user that has none.
 
   Used to repair the accounts created before Checkout guaranteed a customer:

--- a/ee/lib/fountain_web/controllers/billing_api_controller.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_controller.ex
@@ -1,0 +1,191 @@
+defmodule FountainWeb.BillingApiController do
+  @moduledoc """
+  Billing self-serve over the API (#524).
+
+  All user-facing billing lived in `BillingLive`: the usage summary, Checkout
+  session minting, Portal session minting. `GET /api/auth/me` exposed
+  `subscription_status` and nothing else, so a CLI user who hit the
+  subscription gate got a 402 with no programmatic way out of it.
+
+  Stripe requires a browser to finish, so URLs are the deliverable — this mints
+  them, the user opens them. Return URLs are server-chosen on purpose: a
+  caller-supplied one would be an open redirect wearing a Stripe badge.
+
+  Lives in `ee/` with the rest of billing (#472).
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Billing
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Billing"])
+
+  operation(:show,
+    summary: "Subscription status and current-period usage",
+    description:
+      "Trial and period dates alongside the usage numbers the billing page " <>
+        "shows. On an instance with billing disabled this is a 404 carrying " <>
+        "`billing: \"disabled\"`, mirroring the UI, which redirects away from " <>
+        "the billing page entirely.",
+    responses: [
+      ok: {"Billing", "application/json", Schemas.BillingResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      not_found: {"Billing disabled", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, _params) do
+    with :ok <- require_billing() do
+      user = conn.assigns.current_user
+      {period_start, period_end} = current_month_range()
+
+      render(conn, :show,
+        user: user,
+        usage: Billing.usage_summary(user.id, period_start, period_end),
+        period_start: period_start,
+        period_end: period_end
+      )
+    end
+  end
+
+  operation(:portal,
+    summary: "Mint a Stripe Billing Portal URL",
+    description:
+      "Where an existing customer manages payment methods, invoices and " <>
+        "cancellation. Refused for a comped account and for an account that has " <>
+        "never been a Stripe customer.",
+    responses: [
+      ok: {"Stripe URL", "application/json", Schemas.StripeUrlResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      not_found: {"Billing disabled", "application/json", Schemas.Error},
+      unprocessable_entity: {"Nothing to manage", "application/json", Schemas.Error},
+      bad_gateway: {"Stripe unreachable", "application/json", Schemas.Error}
+    ]
+  )
+
+  def portal(conn, _params) do
+    with :ok <- require_billing() do
+      conn.assigns.current_user
+      |> Billing.portal_url(return_url())
+      |> render_url(conn)
+    end
+  end
+
+  operation(:checkout,
+    summary: "Mint a Stripe Checkout URL",
+    description:
+      "Starts a subscription. Refused for a comped account, and refused with " <>
+        "`subscription_exists` when Stripe already holds a live subscription — " <>
+        "Checkout on top of one creates a second, duplicate subscription. Use " <>
+        "the portal endpoint in that case.",
+    responses: [
+      ok: {"Stripe URL", "application/json", Schemas.StripeUrlResponse},
+      conflict: {"Live subscription exists", "application/json", Schemas.Error},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      not_found: {"Billing disabled", "application/json", Schemas.Error},
+      unprocessable_entity: {"Comped", "application/json", Schemas.Error},
+      bad_gateway: {"Stripe unreachable", "application/json", Schemas.Error}
+    ]
+  )
+
+  def checkout(conn, _params) do
+    user = conn.assigns.current_user
+
+    with :ok <- require_billing(),
+         {:ok, false} <- live_subscription(user) do
+      user
+      |> Billing.checkout_url(return_url())
+      |> render_url(conn)
+    else
+      {:ok, true} ->
+        # The duplicate-subscription trap the LiveView routes around silently.
+        # An API caller asked for Checkout specifically, so say why it is the
+        # wrong door rather than quietly handing back a Portal URL.
+        conn
+        |> put_status(:conflict)
+        |> json(%{
+          error: "subscription_exists",
+          message:
+            "This account already has a live subscription in Stripe. " <>
+              "Use POST /api/account/billing/portal to manage it."
+        })
+
+      {:error, :stripe_unreachable} ->
+        stripe_unreachable(conn)
+
+      other ->
+        other
+    end
+  end
+
+  ## Private
+
+  defp require_billing do
+    if Billing.enabled?(), do: :ok, else: {:error, :billing_disabled}
+  end
+
+  defp live_subscription(user) do
+    case Billing.has_live_subscription?(user) do
+      {:ok, live?} -> {:ok, live?}
+      # Never guess: opening Checkout on an unknown state is what mints a
+      # duplicate subscription.
+      {:error, _reason} -> {:error, :stripe_unreachable}
+    end
+  end
+
+  defp render_url({:ok, url}, conn), do: render(conn, :url, url: url)
+
+  defp render_url({:error, :comped}, conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "comped",
+      message: "This account is comped — there is nothing to pay and nothing to manage."
+    })
+  end
+
+  defp render_url({:error, :no_customer}, conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "no_stripe_customer",
+      message:
+        "This account has never been a Stripe customer, so it has no portal. " <>
+          "Start a subscription at POST /api/account/billing/checkout."
+    })
+  end
+
+  defp render_url({:error, _reason}, conn), do: stripe_unreachable(conn)
+
+  defp stripe_unreachable(conn) do
+    conn
+    |> put_status(:bad_gateway)
+    |> json(%{error: "stripe_unreachable", message: "Could not reach Stripe. Try again."})
+  end
+
+  defp return_url, do: FountainWeb.Endpoint.url() <> "/account/billing"
+
+  # The same calendar-month window the billing page reports.
+  defp current_month_range do
+    now = DateTime.utc_now()
+    period_start = %DateTime{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 0}}
+    last_day = :calendar.last_day_of_the_month(now.year, now.month)
+
+    period_end = %DateTime{
+      now
+      | day: last_day,
+        hour: 23,
+        minute: 59,
+        second: 59,
+        microsecond: {0, 0}
+    }
+
+    {period_start, period_end}
+  end
+end

--- a/ee/lib/fountain_web/controllers/billing_api_json.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_json.ex
@@ -1,0 +1,26 @@
+defmodule FountainWeb.BillingApiJSON do
+  @moduledoc false
+
+  def show(%{user: user, usage: usage, period_start: period_start, period_end: period_end}) do
+    %{
+      data: %{
+        status: user.subscription_status,
+        trial_ends_at: user.trial_ends_at,
+        current_period_end: user.current_period_end,
+        # Only an active subscription can be pending cancellation; once the
+        # `.deleted` event lands the status is canceled and the flag clears.
+        cancel_at_period_end:
+          user.subscription_status == "active" and user.cancel_at_period_end == true,
+        has_stripe_customer: user.stripe_customer_id not in [nil, ""],
+        period: %{start: period_start, end: period_end},
+        usage: %{
+          conversations: usage.conversations,
+          turns: usage.turns,
+          sandbox_minutes: Float.round(usage.sandbox_minutes, 2)
+        }
+      }
+    }
+  end
+
+  def url(%{url: url}), do: %{data: %{url: url}}
+end

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -68,7 +68,7 @@ defmodule FountainWeb.Live.BillingLive do
     socket = assign(socket, :stripe_url_loading, true)
     return_url = FountainWeb.Endpoint.url() <> ~p"/account/billing"
 
-    case user.stripe_customer_id && portal_url(user.stripe_customer_id, return_url) do
+    case user.stripe_customer_id && Billing.portal_url(user, return_url) do
       {:ok, url} ->
         {:noreply, redirect(socket, external: url)}
 
@@ -241,77 +241,11 @@ defmodule FountainWeb.Live.BillingLive do
   # Refused outright rather than relying on the button being hidden (#399):
   # a stale socket or a hand-sent event must not open Checkout for an
   # account whose subscriptions comp_account/1 deliberately cancelled.
-  defp build_stripe_url(%{subscription_status: "comped"}), do: {:error, :comped}
+  # Both surfaces mint the same URLs under the same rules, so the rules live in
+  # the context (#524) rather than in a copy per surface.
+  defp build_stripe_url(user), do: Billing.manage_url(user, billing_return_url())
 
-  defp build_stripe_url(user) do
-    return_url = FountainWeb.Endpoint.url() <> ~p"/account/billing"
-
-    if user.subscription_status in ~w(active past_due) and user.stripe_customer_id do
-      portal_url(user.stripe_customer_id, return_url)
-    else
-      checkout_or_portal(user, return_url)
-    end
-  end
-
-  # An existing customer may still hold a live subscription even when our local
-  # status says otherwise — most notably one cancelled at period end, which
-  # Stripe keeps "active" until the period actually ends (and a lost webhook
-  # leaves the same mismatch). Checkout would open a second, duplicate
-  # subscription on top of it, so those users go to the Portal, where the
-  # existing subscription can be renewed instead. A fresh customer has no
-  # subscriptions to duplicate, so no lookup is needed.
-  defp checkout_or_portal(%{stripe_customer_id: id} = user, return_url)
-       when is_binary(id) and id != "" do
-    case Billing.has_live_subscription?(user) do
-      {:ok, true} -> portal_url(id, return_url)
-      {:ok, false} -> checkout_url(user, return_url)
-      {:error, _} = error -> error
-    end
-  end
-
-  defp checkout_or_portal(user, return_url) do
-    # Never fall back to `customer_email`. That makes Stripe mint its own
-    # Customer whose id we never learn, so the subscription webhook matches no
-    # user: the card is charged and the account is never activated. Creating
-    # the Customer first means the id is always ours.
-    with {:ok, user} <- Billing.ensure_stripe_customer(user) do
-      checkout_url(user, return_url)
-    end
-  end
-
-  defp portal_url(customer_id, return_url) do
-    case Stripe.BillingPortal.Session.create(%{
-           customer: customer_id,
-           return_url: return_url
-         }) do
-      {:ok, session} -> {:ok, session.url}
-      error -> error
-    end
-  end
-
-  defp checkout_url(user, return_url) do
-    price_id = Application.get_env(:fountain, :stripe_price_id, "")
-
-    params = %{
-      mode: :subscription,
-      line_items: [%{price: price_id, quantity: 1}],
-      success_url: return_url <> "?checkout=success",
-      cancel_url: return_url,
-      customer: user.stripe_customer_id,
-      # Second route back to the user if the customer link is ever lost —
-      # checkout.session.completed carries this through.
-      client_reference_id: user.id,
-      # Show "Add promotion code" link on the Checkout page. Promotion codes
-      # are user-facing redeemable strings tied to coupons created in the
-      # Stripe dashboard. Without this flag, the field is hidden by default.
-      allow_promotion_codes: true
-    }
-
-    case Stripe.Checkout.Session.create(params) do
-      {:ok, session} -> {:ok, session.url}
-      error -> error
-    end
-  end
+  defp billing_return_url, do: FountainWeb.Endpoint.url() <> ~p"/account/billing"
 
   # Only an active subscription can be pending cancellation; once `.deleted`
   # lands the status is canceled and the flag is cleared by the sync.

--- a/ee/test/fountain_web/controllers/billing_api_controller_test.exs
+++ b/ee/test/fountain_web/controllers/billing_api_controller_test.exs
@@ -1,0 +1,261 @@
+defmodule FountainWeb.BillingApiControllerTest do
+  @moduledoc """
+  Billing self-serve over the API (#524).
+
+  A CLI user who hit the subscription gate got a 402 and no programmatic route
+  out of it: usage numbers, Checkout and the Portal all lived in `BillingLive`.
+  """
+
+  # async: false — billing_enabled and stripe_price_id are application env.
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+
+  alias Fountain.Accounts.User
+  alias Fountain.Repo
+
+  setup do
+    original = Application.get_env(:fountain, :stripe_price_id)
+    Application.put_env(:fountain, :stripe_price_id, "price_test123")
+
+    on_exit(fn ->
+      case original do
+        nil -> Application.delete_env(:fountain, :stripe_price_id)
+        v -> Application.put_env(:fountain, :stripe_price_id, v)
+      end
+    end)
+
+    user = insert_verified_user()
+    {_rec, key} = insert_api_key(user)
+    {:ok, user: user, key: key}
+  end
+
+  defp billing_state(user, attrs) do
+    {:ok, user} = user |> User.billing_changeset(attrs) |> Repo.update()
+    user
+  end
+
+  defp with_billing_disabled(fun) do
+    previous = Application.get_env(:fountain, :billing_enabled)
+    Application.put_env(:fountain, :billing_enabled, false)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:fountain, :billing_enabled, previous)
+    end
+  end
+
+  defp no_live_subscription do
+    stub(Stripe.Subscription, :list, fn _ -> {:ok, %{data: []}} end)
+  end
+
+  describe "GET /api/account/billing" do
+    test "reports status, dates and current-period usage", %{conn: conn, user: user, key: key} do
+      trial_end = DateTime.utc_now() |> DateTime.add(7, :day) |> DateTime.truncate(:second)
+      billing_state(user, %{subscription_status: "trialing", trial_ends_at: trial_end})
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/account/billing")
+        |> json_response(200)
+
+      assert body["data"]["status"] == "trialing"
+      assert body["data"]["trial_ends_at"]
+      assert body["data"]["usage"]["conversations"] == 0
+      assert body["data"]["usage"]["turns"] == 0
+      assert body["data"]["usage"]["sandbox_minutes"] == 0
+      assert body["data"]["period"]["start"]
+      assert body["data"]["period"]["end"]
+    end
+
+    test "trial dates answer the 'why did my API calls start failing' question", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      # An expiring trial is invisible from /api/auth/me, which carries only
+      # subscription_status.
+      ends_at = DateTime.utc_now() |> DateTime.add(2, :day) |> DateTime.truncate(:second)
+      billing_state(user, %{subscription_status: "trialing", trial_ends_at: ends_at})
+
+      body = conn |> authed_with_key(key) |> get("/api/account/billing") |> json_response(200)
+
+      assert {:ok, returned, _} = DateTime.from_iso8601(body["data"]["trial_ends_at"])
+      assert DateTime.compare(returned, ends_at) == :eq
+    end
+
+    test "is 404 with billing: disabled on a self-hosted instance", %{conn: conn, key: key} do
+      with_billing_disabled(fn ->
+        body =
+          conn
+          |> authed_with_key(key)
+          |> get("/api/account/billing")
+          |> json_response(404)
+
+        assert body["billing"] == "disabled"
+      end)
+    end
+
+    test "a sprite token cannot read the account's billing state", %{conn: conn, user: user} do
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+
+      conn
+      |> authed_with_key(sprite_key)
+      |> get("/api/account/billing")
+      |> json_response(403)
+    end
+
+    test "requires authentication", %{conn: conn} do
+      conn
+      |> put_req_header("accept", "application/json")
+      |> get("/api/account/billing")
+      |> json_response(401)
+    end
+  end
+
+  describe "POST /api/account/billing/portal" do
+    test "returns a portal URL for an existing customer", %{conn: conn, user: user, key: key} do
+      billing_state(user, %{subscription_status: "active", stripe_customer_id: "cus_123"})
+
+      stub(Stripe.BillingPortal.Session, :create, fn params ->
+        assert params.customer == "cus_123"
+        {:ok, %{url: "https://billing.stripe.com/session/abc"}}
+      end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/account/billing/portal")
+        |> json_response(200)
+
+      assert body["data"]["url"] == "https://billing.stripe.com/session/abc"
+    end
+
+    test "refuses a comped account", %{conn: conn, user: user, key: key} do
+      billing_state(user, %{subscription_status: "comped", stripe_customer_id: "cus_123"})
+      reject(&Stripe.BillingPortal.Session.create/1)
+
+      body =
+        conn |> authed_with_key(key) |> post("/api/account/billing/portal") |> json_response(422)
+
+      assert body["error"] == "comped"
+    end
+
+    test "refuses an account that was never a Stripe customer", %{conn: conn, key: key} do
+      reject(&Stripe.BillingPortal.Session.create/1)
+
+      body =
+        conn |> authed_with_key(key) |> post("/api/account/billing/portal") |> json_response(422)
+
+      assert body["error"] == "no_stripe_customer"
+    end
+
+    test "an unreachable Stripe is 502, not a 500", %{conn: conn, user: user, key: key} do
+      billing_state(user, %{subscription_status: "active", stripe_customer_id: "cus_123"})
+      stub(Stripe.BillingPortal.Session, :create, fn _ -> {:error, :nxdomain} end)
+
+      body =
+        conn |> authed_with_key(key) |> post("/api/account/billing/portal") |> json_response(502)
+
+      assert body["error"] == "stripe_unreachable"
+    end
+  end
+
+  describe "POST /api/account/billing/checkout" do
+    test "returns a checkout URL, with the customer and promotion codes set", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      billing_state(user, %{subscription_status: "canceled", stripe_customer_id: "cus_123"})
+      no_live_subscription()
+
+      stub(Stripe.Checkout.Session, :create, fn params ->
+        # The bug this pins in the LiveView too: never customer_email, or
+        # Stripe mints a customer whose id we never learn.
+        assert params.customer == "cus_123"
+        assert params.client_reference_id == user.id
+        assert params.allow_promotion_codes
+        assert params.line_items == [%{price: "price_test123", quantity: 1}]
+        {:ok, %{url: "https://checkout.stripe.com/session/xyz"}}
+      end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/account/billing/checkout")
+        |> json_response(200)
+
+      assert body["data"]["url"] == "https://checkout.stripe.com/session/xyz"
+    end
+
+    test "refuses when Stripe already holds a live subscription", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      # Checkout on top of a live subscription mints a duplicate. The LiveView
+      # silently routes to the Portal; an API caller who asked for Checkout
+      # gets told which door to use instead.
+      billing_state(user, %{subscription_status: "canceled", stripe_customer_id: "cus_123"})
+      stub(Stripe.Subscription, :list, fn _ -> {:ok, %{data: [%{status: "active"}]}} end)
+      reject(&Stripe.Checkout.Session.create/1)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/account/billing/checkout")
+        |> json_response(409)
+
+      assert body["error"] == "subscription_exists"
+    end
+
+    test "refuses when Stripe cannot be asked, rather than guessing", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      billing_state(user, %{subscription_status: "canceled", stripe_customer_id: "cus_123"})
+      stub(Stripe.Subscription, :list, fn _ -> {:error, :timeout} end)
+      reject(&Stripe.Checkout.Session.create/1)
+
+      conn |> authed_with_key(key) |> post("/api/account/billing/checkout") |> json_response(502)
+    end
+
+    test "refuses a comped account", %{conn: conn, user: user, key: key} do
+      billing_state(user, %{subscription_status: "comped", stripe_customer_id: "cus_123"})
+      no_live_subscription()
+      reject(&Stripe.Checkout.Session.create/1)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/account/billing/checkout")
+        |> json_response(422)
+
+      assert body["error"] == "comped"
+    end
+
+    test "is 404 when billing is disabled", %{conn: conn, key: key} do
+      with_billing_disabled(fn ->
+        reject(&Stripe.Checkout.Session.create/1)
+
+        conn
+        |> authed_with_key(key)
+        |> post("/api/account/billing/checkout")
+        |> json_response(404)
+      end)
+    end
+
+    test "a sprite token cannot start a subscription", %{conn: conn, user: user} do
+      {_rec, sprite_key} = insert_sprite_api_key(user)
+      reject(&Stripe.Checkout.Session.create/1)
+
+      conn
+      |> authed_with_key(sprite_key)
+      |> post("/api/account/billing/checkout")
+      |> json_response(403)
+    end
+  end
+end


### PR DESCRIPTION
Closes #524. **Merge after #567.**

## What

```
GET  /api/account/billing            # status, trial/period dates, cancel_at_period_end, current-month usage
POST /api/account/billing/portal     # Stripe Billing Portal URL
POST /api/account/billing/checkout   # Stripe Checkout URL
```

Everything stays in `ee/` per the #472 boundary — controller, view and tests. Only the three route entries live in the core router, exactly as the Stripe webhook's already does.

## Decisions worth reviewing

- **Checkout refuses instead of redirecting.** `BillingLive` silently routes to the Portal when Stripe already holds a live subscription (right for a button). An API caller asked for Checkout by name, so it answers `409 subscription_exists` and points at the portal endpoint — quietly returning a Portal URL from a `/checkout` call is the kind of thing that gets debugged at 2am. If Stripe can't be asked at all, it refuses (`502`) rather than guessing, because guessing wrong mints a duplicate subscription.
- **Billing disabled → `404` with `billing: "disabled"`**, matching the UI's redirect-away semantics (new `FallbackController` clause).
- **Return URLs are server-chosen.** A caller-supplied `return_url` would be an open redirect wearing a Stripe badge.
- **The URL-minting rules moved into the context** (`Billing.portal_url/2`, `checkout_url/2`, `manage_url/2`) and `BillingLive` now delegates — including the "never `customer_email`" rule and the duplicate-subscription guard, which are exactly the things that must not drift between two copies. This deletes ~60 lines of LiveView privates.
- Gated on `full` scope with the rest of `/api/account/*`.

## Tests

15 in `ee/test/.../billing_api_controller_test.exs`; the existing `billing_live_test.exs` passes untouched, which is the check that the extraction preserved behaviour. Covers usage/date reporting, trial dates surviving the round-trip, billing-disabled 404 on read and write, sprite-token 403s, 401, portal happy path asserting the customer id reaches Stripe, comped and no-customer refusals, Stripe-unreachable 502, checkout happy path asserting `customer` / `client_reference_id` / `allow_promotion_codes` / price, the 409 duplicate guard, and the refuse-when-Stripe-is-unreachable path — the last three with `reject(&Stripe.Checkout.Session.create/1)` so a regression that calls Stripe anyway fails loudly.

Full suite green (2,208 tests); `format` / `--warnings-as-errors` / `credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)