### PR TITLE
account: deletion warning drops "Cancels your subscription" when billing is off (#513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ upgrade, is in
 
 ---
 
+## [0.5.2] — 2026-08-05
+
+### Fixed
+
+- The account-deletion warning on `/account` opened with "Cancels your
+  subscription" on instances where billing is disabled and no subscription
+  exists — the last billing reference the #513 fresh-machine sweep found on
+  any surface. The clause now renders only when `BILLING_ENABLED=true`
+  (#513, #569)
+
 ## [0.5.1] — 2026-08-05
 
 ### Fixed
@@ -807,6 +817,7 @@ upgrade, is in
 - Audit log for state-changing actions (append-only, best-effort)
 - Substitution engine for `${VAR}` / `$$` interpolation in agent configs
 
+[0.5.2]: https://github.com/BinaryBourbon/fountain/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/BinaryBourbon/fountain/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/BinaryBourbon/fountain/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/BinaryBourbon/fountain/compare/v0.4.0...v0.4.1

--- a/apps/fountain/lib/fountain_web/live/account_live.ex
+++ b/apps/fountain/lib/fountain_web/live/account_live.ex
@@ -180,7 +180,12 @@ defmodule FountainWeb.Live.AccountLive do
       <div class="rounded-lg border border-red-200 bg-white p-6 shadow-sm">
         <h2 class="mb-1 text-lg font-medium text-red-700">Delete account</h2>
         <p class="mb-4 text-sm text-gray-600">
-          Cancels your subscription, destroys every running sandbox, and permanently
+          <%!-- "Cancels your subscription" is billing residue on a
+               billing-disabled instance — there is no subscription to
+               cancel (#513, the last surface the walkthrough sweep found). --%>
+          <%= if Fountain.Billing.enabled?(),
+            do: "Cancels your subscription, destroys",
+            else: "Destroys" %> every running sandbox, and permanently
           deletes your agents, environments, vaults, conversations and stored secrets.
           Secrets are encrypted with a key held only for your account; deleting the
           account destroys that key, so they cannot be recovered afterwards by anyone.

--- a/apps/fountain/test/fountain_web/live/account_deletion_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/account_deletion_live_test.exs
@@ -28,6 +28,31 @@ defmodule FountainWeb.AccountDeletionLiveTest do
   end
 
   describe "self-serve, on /account" do
+    test "billing disabled: the deletion warning does not mention a subscription", %{conn: conn} do
+      # There is no subscription to cancel on a billing-disabled instance —
+      # the last billing reference the #513 walkthrough sweep found.
+      previous = Application.get_env(:fountain, :billing_enabled)
+      Application.put_env(:fountain, :billing_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, previous) end)
+
+      user = insert_verified_user()
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account")
+
+      assert html =~ "Destroys every running sandbox"
+      refute html =~ "subscription"
+    end
+
+    test "billing enabled: the deletion warning covers the subscription", %{conn: conn} do
+      previous = Application.get_env(:fountain, :billing_enabled)
+      Application.put_env(:fountain, :billing_enabled, true)
+      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, previous) end)
+
+      user = insert_verified_user()
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account")
+
+      assert html =~ "Cancels your subscription"
+    end
+
     test "typing the account's email deletes it", %{conn: conn} do
       user = insert_verified_user()
 


### PR DESCRIPTION
The #513 walkthrough re-run on v0.5.1 passed every step with exactly one residual: the `/account` danger-zone copy opens with "Cancels your subscription," on instances where `BILLING_ENABLED=false` and no subscription exists — the last billing reference the sweep found on any surface.

The clause now renders only when billing is enabled, pinned in both directions in `AccountDeletionLiveTest` (verified to fail against the unfixed template). `mix precommit` green (2057 tests, 0 failures). Includes the `[0.5.2]` changelog section so release-bump (patch) can be dispatched directly after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)