### PR TITLE
api: operator surface for scripted admin tasks (#527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ upgrade, is in
 
 ### Added
 
+- **`/api/admin/*` makes operator tasks scriptable** — list and inspect
+  accounts with the filters the admin UI has, set the sandbox cap, extend a
+  trial, comp, suspend, resync from Stripe, delete an account, list and reap
+  sandboxes, and read both the cross-tenant audit trail and the privilege
+  trail. Every one of these was AdminLive-only, so a bulk trial extension or
+  a suspension from an incident runbook meant a human clicking. The surface
+  needs three things at once: an authenticated key, `full` scope (a
+  sandbox's per-conversation token is not an operator credential even when
+  the account is an admin) and the admin role. Refusals mirror the UI — no
+  self-suspend, no self-delete, billing actions refused when billing is
+  disabled — plus one the UI has no need for: you cannot revoke your own
+  admin role, which over an API is a lockout one scripted typo away. Actions
+  record the same `admin.*` privilege-trail events, so a curl'd suspension
+  is as visible as a clicked one (#527)
+
 - **Billing is self-serve over the API**: `GET /api/account/billing` for
   status, trial and period dates and the current month's usage, plus
   `POST /api/account/billing/portal` and `.../checkout` to mint Stripe URLs.

--- a/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
@@ -1,0 +1,656 @@
+defmodule FountainWeb.AdminController do
+  @moduledoc """
+  Operator surface over the API (#527).
+
+  Every admin operation was `AdminLive`-only, so nothing could be scripted: a
+  bulk trial extension, a suspension from an incident runbook, a nightly export
+  of the privilege trail all meant a human clicking. This mirrors the LiveView's
+  actions one-for-one, including its refusals.
+
+  Three things are carried over deliberately:
+
+    * the same self-action refusals — no suspending or deleting yourself, and
+      (new here) no revoking your own admin role, which over an API is a
+      lockout one typo away rather than a button you can see;
+    * billing actions refuse when `billing_enabled` is false, because they talk
+      to Stripe;
+    * the same `admin.*` privilege-trail events, so an action taken with curl
+      is as visible as one taken with a mouse.
+
+  Cross-tenant reads stay metadata-only, the `ConversationDetail` principle:
+  prompt and output content never cross a tenant boundary, whatever the role.
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.{Accounts, Audit, Billing, Conversations, Quotas}
+  alias Fountain.Accounts.Deletion
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  @default_per_page 25
+  @max_per_page 100
+  @statuses ~w(trialing active past_due canceled comped)
+
+  tags(["Admin"])
+
+  ## ── users ────────────────────────────────────────────────────────────────
+
+  operation(:index_users,
+    summary: "List accounts (admin)",
+    parameters: [
+      q: [in: :query, type: :string, required: false, description: "Email substring."],
+      status: [
+        in: :query,
+        type: %OpenApiSpex.Schema{type: :string, enum: @statuses},
+        required: false
+      ],
+      role: [
+        in: :query,
+        type: %OpenApiSpex.Schema{type: :string, enum: ~w(admin user)},
+        required: false
+      ],
+      verified: [in: :query, type: :boolean, required: false],
+      sort: [
+        in: :query,
+        type: %OpenApiSpex.Schema{type: :string, enum: ~w(email joined trial_end last_activity)},
+        required: false
+      ],
+      dir: [
+        in: :query,
+        type: %OpenApiSpex.Schema{type: :string, enum: ~w(asc desc)},
+        required: false
+      ],
+      page: [in: :query, type: :integer, required: false],
+      per_page: [
+        in: :query,
+        type: :integer,
+        required: false,
+        description: "1..#{@max_per_page}, default #{@default_per_page}."
+      ]
+    ],
+    responses: [
+      ok: {"Accounts", "application/json", Schemas.AdminUserListResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index_users(conn, params) do
+    page = parse_int(params["page"], 1) |> max(1)
+    per_page = parse_int(params["per_page"], @default_per_page) |> max(1) |> min(@max_per_page)
+
+    %{users: users, total: total} =
+      Accounts.list_users_admin(
+        search: params["q"] || "",
+        status: if(params["status"] in @statuses, do: params["status"]),
+        role: if(params["role"] in ~w(admin user), do: params["role"]),
+        verified: parse_verified(params["verified"]),
+        sort: params["sort"],
+        dir: params["dir"] || "desc",
+        page: page,
+        per_page: per_page
+      )
+
+    render(conn, :index_users,
+      users: users,
+      sandbox_counts: Quotas.active_sandbox_counts(),
+      page: page,
+      per_page: per_page,
+      total: total
+    )
+  end
+
+  operation(:show_user,
+    summary: "Get one account (admin)",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Account", "application/json", Schemas.AdminUserResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show_user(conn, %{"id" => id}) do
+    with_user(conn, id, fn user ->
+      # ownership: admin surface — the :require_admin_api pipeline established
+      # the caller's role before this action ran; cross-tenant reads are the
+      # point of the endpoint.
+      render(conn, :show_user,
+        user: user,
+        sandbox_counts: Quotas.active_sandbox_counts(),
+        admin_events: Audit._unsafe_list_admin_events_for_target(user.id, 50)
+      )
+    end)
+  end
+
+  operation(:set_role,
+    summary: "Grant or revoke the admin role",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    request_body: {"Role", "application/json", Schemas.AdminRoleRequest},
+    responses: [
+      ok: {"Account", "application/json", Schemas.AdminUserResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def set_role(conn, %{"id" => id, "role" => role}) when role in ~w(admin user) do
+    admin = conn.assigns.current_user
+
+    cond do
+      id == admin.id ->
+        # Not a rule the LiveView has, because there the toggle is in front of
+        # you. Over an API, revoking your own role is a lockout one scripted
+        # typo away, recoverable only with a release task.
+        refuse(conn, "cannot_change_own_role", "Change your own role from another admin account.")
+
+      true ->
+        with_user(conn, id, fn user -> apply_role(conn, admin, user, role) end)
+    end
+  end
+
+  def set_role(conn, _params),
+    do: refuse(conn, "invalid_role", ~s(role must be "admin" or "user".))
+
+  operation(:set_sandbox_limit,
+    summary: "Set an account's concurrent-sandbox cap",
+    description:
+      "The only lever for a noisy or abusive tenant (ADR 0005). 0 stops the " <>
+        "account from starting new conversations without suspending it.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    request_body: {"Limit", "application/json", Schemas.AdminSandboxLimitRequest},
+    responses: [
+      ok: {"Account", "application/json", Schemas.AdminUserResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def set_sandbox_limit(conn, %{"id" => id, "limit" => limit}) when is_integer(limit) and limit >= 0 do
+    admin = conn.assigns.current_user
+
+    with_user(conn, id, fn user ->
+      case Accounts.update_sandbox_limit(user, limit) do
+        {:ok, updated} ->
+          record_admin(admin, user, "admin.sandbox_limit.changed", %{
+            "email" => user.email,
+            "from" => user.max_concurrent_sandboxes,
+            "to" => limit
+          })
+
+          render_user(conn, updated)
+
+        {:error, _} ->
+          refuse(conn, "invalid_limit", "Limit must be a whole number of 0 or more.")
+      end
+    end)
+  end
+
+  def set_sandbox_limit(conn, _params),
+    do: refuse(conn, "invalid_limit", "Limit must be a whole number of 0 or more.")
+
+  operation(:extend_trial,
+    summary: "Extend an account's trial",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    request_body: {"Days", "application/json", Schemas.AdminExtendTrialRequest},
+    responses: [
+      ok: {"Account", "application/json", Schemas.AdminUserResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def extend_trial(conn, %{"id" => id, "days" => days}) when is_integer(days) and days > 0 do
+    admin = conn.assigns.current_user
+
+    with :ok <- require_billing() do
+      with_user(conn, id, fn user -> apply_extend_trial(conn, admin, user, days) end)
+    end
+  end
+
+  def extend_trial(conn, _params),
+    do: refuse(conn, "invalid_days", "Days must be a whole number of 1 or more.")
+
+  operation(:set_comp,
+    summary: "Comp or un-comp an account",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    request_body: {"Comped", "application/json", Schemas.AdminCompRequest},
+    responses: [
+      ok: {"Account", "application/json", Schemas.AdminUserResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def set_comp(conn, %{"id" => id, "comped" => comped}) when is_boolean(comped) do
+    admin = conn.assigns.current_user
+
+    with :ok <- require_billing() do
+      with_user(conn, id, fn user -> apply_comp(conn, admin, user, comped) end)
+    end
+  end
+
+  def set_comp(conn, _params),
+    do: refuse(conn, "invalid_request", "Send {\"comped\": true} or {\"comped\": false}.")
+
+  operation(:set_suspended,
+    summary: "Suspend or unsuspend an account",
+    description:
+      "The reversible lever between comp and delete (#287): sessions die, API " <>
+        "keys refuse, sandboxes are reaped. Billing is deliberately untouched.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    request_body: {"Suspended", "application/json", Schemas.AdminSuspendRequest},
+    responses: [
+      ok: {"Account", "application/json", Schemas.AdminUserResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def set_suspended(conn, %{"id" => id, "suspended" => suspended}) when is_boolean(suspended) do
+    admin = conn.assigns.current_user
+
+    if id == admin.id do
+      refuse(conn, "cannot_suspend_self", "You cannot suspend your own account.")
+    else
+      with_user(conn, id, fn user -> apply_suspend(conn, admin, user, suspended) end)
+    end
+  end
+
+  def set_suspended(conn, _params),
+    do: refuse(conn, "invalid_request", "Send {\"suspended\": true} or {\"suspended\": false}.")
+
+  operation(:resync_stripe,
+    summary: "Re-read an account's subscription from Stripe",
+    description: "The in-app remedy for webhook drift (#502).",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Outcome", "application/json", Schemas.AdminResyncResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def resync_stripe(conn, %{"id" => id}) do
+    admin = conn.assigns.current_user
+
+    with :ok <- require_billing() do
+      with_user(conn, id, fn user -> apply_resync(conn, admin, user) end)
+    end
+  end
+
+  operation(:delete_user,
+    summary: "Delete an account (admin)",
+    description:
+      "The support path for a deletion request that cannot go through the " <>
+        "account page — a locked-out user, or one who asked by email. Same " <>
+        "teardown as self-serve; only the recorded actor differs.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Deleted", "application/json", Schemas.AccountDeletedResponse},
+      bad_gateway: {"Billing cancellation failed", "application/json", Schemas.Error},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete_user(conn, %{"id" => id}) do
+    admin = conn.assigns.current_user
+
+    if id == admin.id do
+      refuse(
+        conn,
+        "cannot_delete_self",
+        "Delete your own account through DELETE /api/account."
+      )
+    else
+      with_user(conn, id, fn user -> apply_delete(conn, admin, user) end)
+    end
+  end
+
+  ## ── sandboxes ────────────────────────────────────────────────────────────
+
+  operation(:index_sandboxes,
+    summary: "List live sandboxes across all tenants",
+    responses: [
+      ok: {"Sandboxes", "application/json", Schemas.AdminSandboxListResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index_sandboxes(conn, _params) do
+    # ownership: admin surface — :require_admin_api gated this request.
+    render(conn, :index_sandboxes, sandboxes: Conversations._unsafe_list_sandboxes_admin())
+  end
+
+  operation(:reap_sandbox,
+    summary: "Reap a sandbox",
+    description:
+      "`terminated` when live conversations were ended with it, `released` " <>
+        "when the sprite went and the conversations stay resumable, " <>
+        "`already_terminal` when there was nothing to do.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Outcome", "application/json", Schemas.AdminReapResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def reap_sandbox(conn, %{"id" => id}) do
+    admin = conn.assigns.current_user
+
+    # ownership: admin surface — :require_admin_api gated this request. Reaping
+    # is cross-tenant by nature; the sandbox is identified by id alone.
+    case Conversations._unsafe_reap_sandbox(id) do
+      {:ok, outcome} ->
+        Audit.record_admin(%{
+          actor_user_id: admin.id,
+          target_user_id: nil,
+          event_type: "admin.sandbox.reaped",
+          metadata: %{"sandbox_id" => id, "outcome" => to_string(outcome)}
+        })
+
+        json(conn, %{data: %{sandbox_id: id, outcome: to_string(outcome)}})
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
+  ## ── trails ───────────────────────────────────────────────────────────────
+
+  operation(:index_audit,
+    summary: "Cross-tenant audit events",
+    description:
+      "Every tenant's events, newest first — the unscoped view behind `/audit` " <>
+        "for admins. Use `GET /api/audit` for the caller's own trail.",
+    parameters: [
+      limit: [in: :query, type: :integer, required: false, description: "1..500, default 100."]
+    ],
+    responses: [
+      ok: {"Audit events", "application/json", Schemas.AdminAuditListResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index_audit(conn, params) do
+    limit = parse_int(params["limit"], 100) |> max(1) |> min(500)
+    # ownership: admin surface — :require_admin_api gated this request. This is
+    # the cross-tenant view; GET /api/audit is the tenant-scoped one.
+    render(conn, :index_audit, events: Audit._unsafe_list_recent(limit))
+  end
+
+  operation(:index_admin_events,
+    summary: "The privilege trail",
+    description:
+      "Administrative actions taken against accounts — who did what to whom. " <>
+        "Separate from the audit trail because these carry both an actor and a " <>
+        "target.",
+    parameters: [
+      limit: [in: :query, type: :integer, required: false, description: "1..500, default 100."]
+    ],
+    responses: [
+      ok: {"Admin events", "application/json", Schemas.AdminEventListResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index_admin_events(conn, params) do
+    limit = parse_int(params["limit"], 100) |> max(1) |> min(500)
+    # ownership: admin surface — :require_admin_api gated this request.
+    render(conn, :index_admin_events, events: Audit._unsafe_list_recent_admin(limit))
+  end
+
+  ## ── action bodies ────────────────────────────────────────────────────────
+
+  defp apply_role(conn, admin, user, role) do
+    case Accounts.update_user_role(user, role) do
+      {:ok, updated} ->
+        record_admin(
+          admin,
+          user,
+          if(role == "admin", do: "admin.role.granted", else: "admin.role.revoked"),
+          %{"email" => user.email, "from" => user.role, "to" => role}
+        )
+
+        render_user(conn, updated)
+
+      {:error, _} ->
+        refuse(conn, "role_update_failed", "Could not update the role.")
+    end
+  end
+
+  defp apply_extend_trial(conn, admin, user, days) do
+    case Billing.extend_trial(user, days) do
+      {:ok, updated} ->
+        record_admin(admin, user, "admin.trial.extended", %{
+          "email" => user.email,
+          "from" => user.trial_ends_at && DateTime.to_iso8601(user.trial_ends_at),
+          "to" => DateTime.to_iso8601(updated.trial_ends_at)
+        })
+
+        render_user(conn, updated)
+
+      {:error, :active_subscription} ->
+        refuse(conn, "active_subscription", "Account has an active paid subscription.")
+
+      {:error, :comped} ->
+        refuse(conn, "comped", "Account is comped — there is no trial to extend.")
+
+      {:error, _} ->
+        stripe_refused(conn, "Could not extend the trial — Stripe refused.")
+    end
+  end
+
+  defp apply_comp(conn, admin, user, true) do
+    case Billing.comp_account(user) do
+      {:ok, updated} ->
+        record_admin(admin, user, "admin.comp.granted", %{
+          "email" => user.email,
+          "from" => user.subscription_status,
+          "to" => updated.subscription_status
+        })
+
+        render_user(conn, updated)
+
+      {:error, _} ->
+        stripe_refused(conn, "Could not comp the account — Stripe cancellation failed.")
+    end
+  end
+
+  defp apply_comp(conn, admin, user, false) do
+    case Billing.revoke_comp(user) do
+      {:ok, updated} ->
+        record_admin(admin, user, "admin.comp.revoked", %{
+          "email" => user.email,
+          "from" => user.subscription_status,
+          "to" => updated.subscription_status
+        })
+
+        render_user(conn, updated)
+
+      # revoke_comp/1 has no other failure mode — it only rejects an account
+      # that was not comped in the first place.
+      {:error, :not_comped} ->
+        refuse(conn, "not_comped", "Account is not comped.")
+    end
+  end
+
+  defp apply_suspend(conn, admin, user, true) do
+    if Accounts.suspended?(user) do
+      render_user(conn, user)
+    else
+      case Accounts.suspend_user(user) do
+        {:ok, updated, reaped} ->
+          record_admin(admin, user, "admin.account.suspended", %{
+            "email" => user.email,
+            "sandboxes_reaped" => reaped
+          })
+
+          render_user(conn, updated)
+
+        {:error, _} ->
+          refuse(conn, "suspend_failed", "Could not suspend the account.")
+      end
+    end
+  end
+
+  defp apply_suspend(conn, admin, user, false) do
+    if Accounts.suspended?(user) do
+      case Accounts.unsuspend_user(user) do
+        {:ok, updated} ->
+          record_admin(admin, user, "admin.account.unsuspended", %{"email" => user.email})
+          render_user(conn, updated)
+
+        {:error, _} ->
+          refuse(conn, "unsuspend_failed", "Could not lift the suspension.")
+      end
+    else
+      render_user(conn, user)
+    end
+  end
+
+  defp apply_resync(conn, admin, user) do
+    case Billing.resync_from_stripe(user) do
+      {:ok, %Accounts.User{} = updated} ->
+        record_admin(admin, user, "admin.stripe.resynced", %{
+          "email" => user.email,
+          "from" => user.subscription_status,
+          "to" => updated.subscription_status
+        })
+
+        json(conn, %{
+          data: %{outcome: "resynced", subscription_status: updated.subscription_status}
+        })
+
+      {:ok, :sync_enqueued} ->
+        record_admin(admin, user, "admin.stripe.resynced", %{
+          "email" => user.email,
+          "outcome" => "customer_sync_enqueued"
+        })
+
+        json(conn, %{data: %{outcome: "customer_sync_enqueued"}})
+
+      {:error, :comped} ->
+        refuse(conn, "comped", "Account is comped — Stripe does not drive its status.")
+
+      {:error, _} ->
+        stripe_refused(conn, "Could not resync — Stripe refused the read.")
+    end
+  end
+
+  defp apply_delete(conn, admin, user) do
+    case Deletion.delete_user(user,
+           actor: "admin:#{admin.id}",
+           request_ip: client_ip(conn)
+         ) do
+      {:ok, summary} ->
+        record_admin(admin, user, "admin.account.deleted", %{"email" => user.email})
+
+        json(conn, %{
+          deleted: true,
+          user_id: summary.user_id,
+          sprites_destroyed: summary.sprites_destroyed
+        })
+
+      {:error, {:stripe, _}} ->
+        conn
+        |> put_status(:bad_gateway)
+        |> json(%{
+          error: "billing_cancellation_failed",
+          message: "Could not cancel the subscription with Stripe; nothing was deleted."
+        })
+
+      {:error, _} ->
+        refuse(conn, "delete_failed", "Could not delete the account.")
+    end
+  end
+
+  ## ── helpers ──────────────────────────────────────────────────────────────
+
+  # Non-bang lookup for every action (#401's lesson from the LiveView): acting
+  # on an account deleted since the caller listed it is a 404, not a crash.
+  defp with_user(_conn, id, fun) do
+    case Ecto.UUID.cast(id) do
+      {:ok, uuid} ->
+        case Accounts.get_user(uuid) do
+          nil -> {:error, :not_found}
+          user -> fun.(user)
+        end
+
+      :error ->
+        {:error, :not_found}
+    end
+  end
+
+  defp render_user(conn, user) do
+    render(conn, :show_user,
+      user: user,
+      sandbox_counts: Quotas.active_sandbox_counts(),
+      admin_events: []
+    )
+  end
+
+  defp record_admin(admin, user, event_type, metadata) do
+    Audit.record_admin(%{
+      actor_user_id: admin.id,
+      target_user_id: user.id,
+      event_type: event_type,
+      metadata: metadata
+    })
+  end
+
+  # The UI hides billing buttons on a billing-disabled instance, but events can
+  # still be sent by hand (#399's lesson) — and these all talk to Stripe.
+  defp require_billing do
+    if Billing.enabled?(), do: :ok, else: {:error, :billing_disabled}
+  end
+
+  defp refuse(conn, error, message) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: error, message: message})
+  end
+
+  defp stripe_refused(conn, message) do
+    conn
+    |> put_status(:bad_gateway)
+    |> json(%{error: "stripe_refused", message: message})
+  end
+
+  defp parse_int(nil, default), do: default
+  defp parse_int(n, _default) when is_integer(n), do: n
+
+  defp parse_int(s, default) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, _} -> n
+      :error -> default
+    end
+  end
+
+  defp parse_verified("true"), do: true
+  defp parse_verified("false"), do: false
+  defp parse_verified(true), do: true
+  defp parse_verified(false), do: false
+  defp parse_verified(_), do: nil
+
+  defp client_ip(conn) do
+    case conn.remote_ip do
+      nil -> nil
+      tuple when is_tuple(tuple) -> tuple |> :inet.ntoa() |> to_string()
+      other -> to_string(other)
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/admin_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/admin_json.ex
@@ -1,0 +1,98 @@
+defmodule FountainWeb.AdminJSON do
+  @moduledoc false
+
+  alias Fountain.Accounts.User
+  alias Fountain.Audit.{AdminEvent, Event}
+  alias Fountain.Conversations.Sandbox
+
+  def index_users(%{
+        users: users,
+        sandbox_counts: counts,
+        page: page,
+        per_page: per_page,
+        total: total
+      }) do
+    %{
+      data: Enum.map(users, &user_data(&1, counts)),
+      meta: %{page: page, per_page: per_page, total: total}
+    }
+  end
+
+  def show_user(%{user: user, sandbox_counts: counts, admin_events: events}) do
+    %{
+      data:
+        user
+        |> user_data(counts)
+        |> Map.put(:admin_events, Enum.map(events, &admin_event_data/1))
+    }
+  end
+
+  def index_sandboxes(%{sandboxes: sandboxes}),
+    do: %{data: Enum.map(sandboxes, &sandbox_data/1)}
+
+  def index_audit(%{events: events}), do: %{data: Enum.map(events, &audit_event_data/1)}
+
+  def index_admin_events(%{events: events}), do: %{data: Enum.map(events, &admin_event_data/1)}
+
+  defp user_data(%User{} = u, sandbox_counts) do
+    %{
+      id: u.id,
+      email: u.email,
+      role: u.role,
+      email_verified: not is_nil(u.email_verified_at),
+      email_verified_at: u.email_verified_at,
+      suspended: not is_nil(u.suspended_at),
+      suspended_at: u.suspended_at,
+      subscription_status: u.subscription_status,
+      trial_ends_at: u.trial_ends_at,
+      current_period_end: u.current_period_end,
+      cancel_at_period_end: u.cancel_at_period_end,
+      has_stripe_customer: u.stripe_customer_id not in [nil, ""],
+      max_concurrent_sandboxes: u.max_concurrent_sandboxes,
+      active_sandboxes: Map.get(sandbox_counts, u.id, 0),
+      onboarding_completed_at: u.onboarding_completed_at,
+      last_activity_at: Map.get(u, :last_activity_at),
+      inserted_at: u.inserted_at
+    }
+  end
+
+  # Metadata only, deliberately — the ConversationDetail principle. An admin
+  # can see that a sandbox exists and who owns it, never what ran inside it.
+  defp sandbox_data(%Sandbox{} = s) do
+    %{
+      id: s.id,
+      sprite_name: s.sprite_name,
+      status: s.status,
+      user_id: s.user_id,
+      user_email: s.user && s.user.email,
+      conversation_count: length(s.conversations || []),
+      inserted_at: s.inserted_at,
+      updated_at: s.updated_at
+    }
+  end
+
+  defp audit_event_data(%Event{} = e) do
+    %{
+      id: e.id,
+      inserted_at: e.inserted_at,
+      user_id: e.user_id,
+      actor: e.actor,
+      action: e.action,
+      resource_type: e.resource_type,
+      resource_id: e.resource_id,
+      metadata: e.metadata,
+      request_ip: e.request_ip
+    }
+  end
+
+  defp admin_event_data(%AdminEvent{} = e) do
+    %{
+      id: e.id,
+      inserted_at: e.inserted_at,
+      event_type: e.event_type,
+      actor_user_id: e.actor_user_id,
+      target_user_id: e.target_user_id,
+      metadata: e.metadata
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/plugs/require_admin_api.ex
+++ b/apps/fountain/lib/fountain_web/plugs/require_admin_api.ex
@@ -1,0 +1,32 @@
+defmodule FountainWeb.Plugs.RequireAdminApi do
+  @moduledoc """
+  The bearer-token analogue of `Live.Hooks.require_admin` (#527).
+
+  Layered on top of `:api` (which authenticates the key and loads the user) and
+  `:require_full_scope` (which keeps a sandbox's per-conversation token out).
+  This plug is the last of the three: operator powers need an admin, a
+  human-held credential, and both checks passing.
+
+  A non-admin gets 403 rather than 404. There is nothing to hide — the admin
+  API's existence is documented — and a 404 would make "you are not an admin"
+  indistinguishable from "that endpoint moved", which is a bad half-hour during
+  an incident.
+  """
+
+  import Plug.Conn
+  import Phoenix.Controller, only: [json: 2]
+
+  def init(opts), do: opts
+
+  def call(%{assigns: %{current_user: %{role: "admin"}}} = conn, _opts), do: conn
+
+  def call(conn, _opts) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{
+      error: "admin_required",
+      message: "This endpoint requires an account with the admin role."
+    })
+    |> halt()
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -95,6 +95,11 @@ defmodule FountainWeb.Router do
     plug FountainWeb.Plugs.RequireFullScope
   end
 
+  # Layered on top of :api + :require_full_scope for the operator surface.
+  pipeline :require_admin_api do
+    plug FountainWeb.Plugs.RequireAdminApi
+  end
+
   ## ─── Public routes ────────────────────────────────────────────────────────────────────
 
   scope "/", FountainWeb do
@@ -306,6 +311,30 @@ defmodule FountainWeb.Router do
 
     get "/conversations/:conversation_id/stream", ConversationController, :stream,
       as: :conversation_stream
+  end
+
+  # Operator surface (#527). Three gates in order: :api authenticates the key,
+  # :require_full_scope keeps a sandbox's per-conversation token out, and
+  # :require_admin_api demands the role — the bearer-token analogue of
+  # Live.Hooks.require_admin.
+  scope "/api/admin", FountainWeb do
+    pipe_through [:accepts_json, :api, :require_full_scope, :require_admin_api]
+
+    get "/users", AdminController, :index_users
+    get "/users/:id", AdminController, :show_user
+    post "/users/:id/role", AdminController, :set_role
+    post "/users/:id/sandbox-limit", AdminController, :set_sandbox_limit
+    post "/users/:id/extend-trial", AdminController, :extend_trial
+    post "/users/:id/comp", AdminController, :set_comp
+    post "/users/:id/suspend", AdminController, :set_suspended
+    post "/users/:id/resync-stripe", AdminController, :resync_stripe
+    delete "/users/:id", AdminController, :delete_user
+
+    get "/sandboxes", AdminController, :index_sandboxes
+    post "/sandboxes/:id/reap", AdminController, :reap_sandbox
+
+    get "/audit", AdminController, :index_audit
+    get "/events", AdminController, :index_admin_events
   end
 
   ## ─── Authenticated browser / LiveView routes ──────────────────────────────────────────────────────────────────

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -928,6 +928,254 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule AdminUser do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminUser",
+      description: "An account as the operator surface sees it. Metadata only.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        email: %Schema{type: :string},
+        role: %Schema{type: :string, enum: ~w(admin user)},
+        email_verified: %Schema{type: :boolean},
+        email_verified_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        suspended: %Schema{type: :boolean},
+        suspended_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        subscription_status: %Schema{type: :string, nullable: true},
+        trial_ends_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        current_period_end: %Schema{type: :string, format: :"date-time", nullable: true},
+        cancel_at_period_end: %Schema{type: :boolean, nullable: true},
+        has_stripe_customer: %Schema{type: :boolean},
+        max_concurrent_sandboxes: %Schema{type: :integer, nullable: true},
+        active_sandboxes: %Schema{type: :integer},
+        onboarding_completed_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        last_activity_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        inserted_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :email, :role]
+    })
+  end
+
+  defmodule AdminUserResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminUserResponse",
+      type: :object,
+      properties: %{data: AdminUser},
+      required: [:data]
+    })
+  end
+
+  defmodule AdminUserListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminUserListResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{type: :array, items: AdminUser},
+        meta: %Schema{
+          type: :object,
+          properties: %{
+            page: %Schema{type: :integer},
+            per_page: %Schema{type: :integer},
+            total: %Schema{type: :integer}
+          },
+          required: [:page, :per_page, :total]
+        }
+      },
+      required: [:data, :meta]
+    })
+  end
+
+  defmodule AdminRoleRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminRoleRequest",
+      type: :object,
+      properties: %{role: %Schema{type: :string, enum: ~w(admin user)}},
+      required: [:role]
+    })
+  end
+
+  defmodule AdminSandboxLimitRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminSandboxLimitRequest",
+      type: :object,
+      properties: %{
+        limit: %Schema{type: :integer, minimum: 0, description: "Concurrent sandbox cap."}
+      },
+      required: [:limit]
+    })
+  end
+
+  defmodule AdminExtendTrialRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminExtendTrialRequest",
+      type: :object,
+      properties: %{days: %Schema{type: :integer, minimum: 1}},
+      required: [:days]
+    })
+  end
+
+  defmodule AdminCompRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminCompRequest",
+      type: :object,
+      properties: %{comped: %Schema{type: :boolean}},
+      required: [:comped]
+    })
+  end
+
+  defmodule AdminSuspendRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminSuspendRequest",
+      type: :object,
+      properties: %{suspended: %Schema{type: :boolean}},
+      required: [:suspended]
+    })
+  end
+
+  defmodule AdminResyncResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminResyncResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            outcome: %Schema{type: :string, enum: ~w(resynced customer_sync_enqueued)},
+            subscription_status: %Schema{type: :string, nullable: true}
+          },
+          required: [:outcome]
+        }
+      },
+      required: [:data]
+    })
+  end
+
+  defmodule AdminSandbox do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminSandbox",
+      description: "A live sandbox, cross-tenant. Metadata only — never contents.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        sprite_name: %Schema{type: :string},
+        status: %Schema{type: :string},
+        user_id: %Schema{type: :string, format: :uuid, nullable: true},
+        user_email: %Schema{type: :string, nullable: true},
+        conversation_count: %Schema{type: :integer},
+        inserted_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :status]
+    })
+  end
+
+  defmodule AdminSandboxListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminSandboxListResponse",
+      type: :object,
+      properties: %{data: %Schema{type: :array, items: AdminSandbox}},
+      required: [:data]
+    })
+  end
+
+  defmodule AdminReapResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminReapResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            sandbox_id: %Schema{type: :string, format: :uuid},
+            outcome: %Schema{type: :string, enum: ~w(terminated released already_terminal)}
+          },
+          required: [:outcome]
+        }
+      },
+      required: [:data]
+    })
+  end
+
+  defmodule AdminAuditListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminAuditListResponse",
+      description: "Cross-tenant audit events; each carries the tenant it belongs to.",
+      type: :object,
+      # Fully qualified: AuditEvent is defined further down this file, and the
+      # implicit alias a nested defmodule creates only exists after it.
+      properties: %{data: %Schema{type: :array, items: FountainWeb.Schemas.AuditEvent}},
+      required: [:data]
+    })
+  end
+
+  defmodule AdminEventListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminEventListResponse",
+      description: "The privilege trail: who did what to whom.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              id: %Schema{type: :integer},
+              inserted_at: %Schema{type: :string, format: :"date-time"},
+              event_type: %Schema{type: :string, example: "admin.account.suspended"},
+              actor_user_id: %Schema{type: :string, format: :uuid, nullable: true},
+              target_user_id: %Schema{type: :string, format: :uuid, nullable: true},
+              metadata: %Schema{type: :object, additionalProperties: true}
+            },
+            required: [:event_type]
+          }
+        }
+      },
+      required: [:data]
+    })
+  end
+
   defmodule BillingResponse do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/admin_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/admin_controller_test.exs
@@ -1,0 +1,391 @@
+defmodule FountainWeb.AdminControllerTest do
+  @moduledoc """
+  The operator surface over the API (#527).
+
+  Every admin operation was AdminLive-only, so nothing could be scripted — no
+  bulk trial extension, no suspension from an incident runbook. These tests pin
+  the three gates (auth, full scope, admin role), the refusals the UI has, and
+  the privilege-trail events, which are what make a scripted action as visible
+  as a clicked one.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Accounts
+  alias Fountain.Audit.AdminEvent
+  alias Fountain.Repo
+
+  setup do
+    admin = insert_verified_user()
+    {:ok, admin} = Accounts.update_user_role(admin, "admin")
+    {_rec, key} = insert_api_key(admin)
+    target = insert_verified_user()
+    {:ok, admin: admin, key: key, target: target}
+  end
+
+  defp admin_events, do: Repo.all(AdminEvent)
+
+  defp event_types, do: admin_events() |> Enum.map(& &1.event_type)
+
+  describe "the gate" do
+    test "a non-admin key is refused everywhere", %{target: target} do
+      {_rec, plain_key} = insert_api_key(target)
+
+      for path <- [
+            "/api/admin/users",
+            "/api/admin/sandboxes",
+            "/api/admin/audit",
+            "/api/admin/events"
+          ] do
+        body =
+          build_conn()
+          |> authed_with_key(plain_key)
+          |> get(path)
+          |> json_response(403)
+
+        assert body["error"] == "admin_required"
+      end
+    end
+
+    test "a non-admin cannot act on another account", %{conn: conn, admin: admin, target: target} do
+      {_rec, plain_key} = insert_api_key(target)
+
+      conn
+      |> authed_with_key(plain_key)
+      |> post_json("/api/admin/users/#{admin.id}/role", %{"role" => "user"})
+      |> json_response(403)
+
+      assert Accounts.get_user(admin.id).role == "admin"
+    end
+
+    test "an admin's sprite-scoped token is refused — role is not enough", %{
+      conn: conn,
+      admin: admin,
+      target: target
+    } do
+      # Operator powers need a human-held credential, not the token a sandbox
+      # is holding on the admin's behalf.
+      {_rec, sprite_key} = insert_sprite_api_key(admin)
+
+      body =
+        conn
+        |> authed_with_key(sprite_key)
+        |> post_json("/api/admin/users/#{target.id}/suspend", %{"suspended" => true})
+        |> json_response(403)
+
+      assert body["reason"] == "insufficient_scope"
+      refute Accounts.suspended?(Accounts.get_user(target.id))
+    end
+
+    test "unauthenticated is 401", %{conn: conn} do
+      conn
+      |> put_req_header("accept", "application/json")
+      |> get("/api/admin/users")
+      |> json_response(401)
+    end
+  end
+
+  describe "GET /api/admin/users" do
+    test "lists accounts with operator metadata and pagination", %{conn: conn, key: key} do
+      body = conn |> authed_with_key(key) |> get("/api/admin/users") |> json_response(200)
+
+      assert body["meta"]["total"] >= 2
+      assert body["meta"]["page"] == 1
+
+      row = hd(body["data"])
+      assert row["email"]
+      assert row["role"]
+      assert Map.has_key?(row, "active_sandboxes")
+      assert Map.has_key?(row, "suspended")
+      assert Map.has_key?(row, "max_concurrent_sandboxes")
+    end
+
+    test "filters by email, role and verification", %{conn: conn, key: key, target: target} do
+      by_email =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/admin/users?q=#{target.email}")
+        |> json_response(200)
+
+      assert Enum.map(by_email["data"], & &1["email"]) == [target.email]
+
+      admins =
+        build_conn()
+        |> authed_with_key(key)
+        |> get("/api/admin/users?role=admin")
+        |> json_response(200)
+
+      assert Enum.all?(admins["data"], &(&1["role"] == "admin"))
+
+      unverified_user = insert_user()
+
+      unverified =
+        build_conn()
+        |> authed_with_key(key)
+        |> get("/api/admin/users?verified=false")
+        |> json_response(200)
+
+      assert unverified_user.id in Enum.map(unverified["data"], & &1["id"])
+    end
+
+    test "per_page is capped", %{conn: conn, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/admin/users?per_page=9999")
+        |> json_response(200)
+
+      assert body["meta"]["per_page"] == 100
+    end
+
+    test "show reports the account's privilege trail", %{conn: conn, key: key, target: target} do
+      build_conn()
+      |> authed_with_key(key)
+      |> post_json("/api/admin/users/#{target.id}/sandbox-limit", %{"limit" => 3})
+      |> json_response(200)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/admin/users/#{target.id}")
+        |> json_response(200)
+
+      assert body["data"]["id"] == target.id
+      assert Enum.any?(body["data"]["admin_events"], &(&1["event_type"] =~ "sandbox_limit"))
+    end
+
+    test "an unknown id is 404, not a crash", %{conn: conn, key: key} do
+      conn
+      |> authed_with_key(key)
+      |> get("/api/admin/users/#{Ecto.UUID.generate()}")
+      |> json_response(404)
+
+      build_conn()
+      |> authed_with_key(key)
+      |> get("/api/admin/users/not-a-uuid")
+      |> json_response(404)
+    end
+  end
+
+  describe "role" do
+    test "grants and revokes, recording each distinctly", %{
+      conn: conn,
+      key: key,
+      target: target
+    } do
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/admin/users/#{target.id}/role", %{"role" => "admin"})
+      |> json_response(200)
+
+      assert Accounts.get_user(target.id).role == "admin"
+      assert "admin.role.granted" in event_types()
+
+      build_conn()
+      |> authed_with_key(key)
+      |> post_json("/api/admin/users/#{target.id}/role", %{"role" => "user"})
+      |> json_response(200)
+
+      assert Accounts.get_user(target.id).role == "user"
+      assert "admin.role.revoked" in event_types()
+    end
+
+    test "refuses to change your own role — a scripted lockout", %{
+      conn: conn,
+      admin: admin,
+      key: key
+    } do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/admin/users/#{admin.id}/role", %{"role" => "user"})
+        |> json_response(422)
+
+      assert body["error"] == "cannot_change_own_role"
+      assert Accounts.get_user(admin.id).role == "admin"
+    end
+  end
+
+  describe "sandbox limit" do
+    test "sets the cap and records it", %{conn: conn, key: key, target: target} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/admin/users/#{target.id}/sandbox-limit", %{"limit" => 0})
+        |> json_response(200)
+
+      assert body["data"]["max_concurrent_sandboxes"] == 0
+      assert "admin.sandbox_limit.changed" in event_types()
+    end
+
+    test "refuses a negative limit", %{conn: conn, key: key, target: target} do
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/admin/users/#{target.id}/sandbox-limit", %{"limit" => -1})
+      |> json_response(422)
+
+      assert admin_events() == []
+    end
+  end
+
+  describe "suspend" do
+    test "suspends and unsuspends, recording both", %{conn: conn, key: key, target: target} do
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/admin/users/#{target.id}/suspend", %{"suspended" => true})
+      |> json_response(200)
+
+      assert Accounts.suspended?(Accounts.get_user(target.id))
+      assert "admin.account.suspended" in event_types()
+
+      build_conn()
+      |> authed_with_key(key)
+      |> post_json("/api/admin/users/#{target.id}/suspend", %{"suspended" => false})
+      |> json_response(200)
+
+      refute Accounts.suspended?(Accounts.get_user(target.id))
+      assert "admin.account.unsuspended" in event_types()
+    end
+
+    test "refuses self-suspension", %{conn: conn, admin: admin, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/admin/users/#{admin.id}/suspend", %{"suspended" => true})
+        |> json_response(422)
+
+      assert body["error"] == "cannot_suspend_self"
+      refute Accounts.suspended?(Accounts.get_user(admin.id))
+    end
+
+    test "suspending an already-suspended account is a no-op, not an error", %{
+      key: key,
+      target: target
+    } do
+      for _ <- 1..2 do
+        build_conn()
+        |> authed_with_key(key)
+        |> post_json("/api/admin/users/#{target.id}/suspend", %{"suspended" => true})
+        |> json_response(200)
+      end
+
+      assert Accounts.suspended?(Accounts.get_user(target.id))
+    end
+  end
+
+  describe "delete" do
+    test "deletes another account and records it", %{conn: conn, key: key, target: target} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> delete("/api/admin/users/#{target.id}")
+        |> json_response(200)
+
+      assert body["deleted"] == true
+      refute Accounts.get_user(target.id)
+      assert "admin.account.deleted" in event_types()
+    end
+
+    test "refuses self-deletion", %{conn: conn, admin: admin, key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> delete("/api/admin/users/#{admin.id}")
+        |> json_response(422)
+
+      assert body["error"] == "cannot_delete_self"
+      assert Accounts.get_user(admin.id)
+    end
+  end
+
+  describe "billing actions when billing is disabled" do
+    setup do
+      previous = Application.get_env(:fountain, :billing_enabled)
+      Application.put_env(:fountain, :billing_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, previous) end)
+      :ok
+    end
+
+    test "extend-trial, comp and resync are all refused", %{key: key, target: target} do
+      # The UI hides the buttons; events could still be sent by hand (#399).
+      # Each of these talks to Stripe.
+      for {path, payload} <- [
+            {"extend-trial", %{"days" => 7}},
+            {"comp", %{"comped" => true}},
+            {"resync-stripe", %{}}
+          ] do
+        body =
+          build_conn()
+          |> authed_with_key(key)
+          |> post_json("/api/admin/users/#{target.id}/#{path}", payload)
+          |> json_response(404)
+
+        assert body["billing"] == "disabled"
+      end
+
+      assert admin_events() == []
+    end
+
+    test "non-billing actions still work", %{conn: conn, key: key, target: target} do
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/admin/users/#{target.id}/sandbox-limit", %{"limit" => 2})
+      |> json_response(200)
+    end
+  end
+
+  describe "trails" do
+    test "cross-tenant audit events carry the tenant they belong to", %{
+      conn: conn,
+      key: key,
+      target: target
+    } do
+      {:ok, _} =
+        Fountain.Audit.record(%{
+          action: "agent.created",
+          resource_type: "agent",
+          actor: "ui",
+          user_id: target.id
+        })
+
+      body = conn |> authed_with_key(key) |> get("/api/admin/audit") |> json_response(200)
+
+      row = Enum.find(body["data"], &(&1["action"] == "agent.created"))
+      assert row["user_id"] == target.id
+    end
+
+    test "the privilege trail lists actor and target", %{conn: conn, key: key, target: target} do
+      build_conn()
+      |> authed_with_key(key)
+      |> post_json("/api/admin/users/#{target.id}/role", %{"role" => "admin"})
+      |> json_response(200)
+
+      body = conn |> authed_with_key(key) |> get("/api/admin/events") |> json_response(200)
+
+      row = hd(body["data"])
+      assert row["event_type"] == "admin.role.granted"
+      assert row["target_user_id"] == target.id
+      assert row["actor_user_id"]
+    end
+  end
+
+  describe "sandboxes" do
+    test "lists live sandboxes with owner metadata only", %{conn: conn, key: key, target: target} do
+      sandbox = insert_sandbox(user_id: target.id)
+
+      body = conn |> authed_with_key(key) |> get("/api/admin/sandboxes") |> json_response(200)
+
+      row = Enum.find(body["data"], &(&1["id"] == sandbox.id))
+      assert row["user_email"] == target.email
+      assert Map.has_key?(row, "conversation_count")
+      refute Map.has_key?(row, "conversations")
+    end
+
+    test "reaping an unknown sandbox is 404", %{conn: conn, key: key} do
+      conn
+      |> authed_with_key(key)
+      |> post("/api/admin/sandboxes/#{Ecto.UUID.generate()}/reap")
+      |> json_response(404)
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -228,6 +228,28 @@ Since sub-conversations are created over the API (`X-Fountain-Parent-Conversatio
 
 Page by passing the previous response's `meta.next_cursor` as `after`; keep going while `meta.has_more` is true. `limit` defaults to 100 and caps at 1000. The `id` is the same value the SSE route uses as `Last-Event-ID`, so a client can drain history as JSON and then attach the stream from where it left off.
 
+## Admin
+
+For operator accounts (`role: "admin"`) holding a `full`-scoped key. Every action mirrors the admin UI, including its refusals, and records the same privilege-trail event.
+
+```
+GET    /api/admin/users                     # ?q= ?status= ?role= ?verified= ?sort= ?dir= ?page= ?per_page=
+GET    /api/admin/users/:id
+POST   /api/admin/users/:id/role            # {"role": "admin"|"user"}
+POST   /api/admin/users/:id/sandbox-limit   # {"limit": n}
+POST   /api/admin/users/:id/extend-trial    # {"days": n}
+POST   /api/admin/users/:id/comp            # {"comped": true|false}
+POST   /api/admin/users/:id/suspend         # {"suspended": true|false}
+POST   /api/admin/users/:id/resync-stripe
+DELETE /api/admin/users/:id
+GET    /api/admin/sandboxes
+POST   /api/admin/sandboxes/:id/reap
+GET    /api/admin/audit                     # cross-tenant audit events
+GET    /api/admin/events                    # the privilege trail: who did what to whom
+```
+
+Refusals: you cannot suspend, delete, or change the role of your own account (use another admin, or `DELETE /api/account` for self-deletion). Billing actions — extend-trial, comp, resync-stripe — are `404` with `"billing": "disabled"` on an instance without billing. Cross-tenant reads are metadata only; prompt and output content never cross a tenant boundary, whatever the role.
+
 ## Audit
 
 ```


### PR DESCRIPTION
Closes #527. **Merge after #568** — last of the stack.

## What

```
GET    /api/admin/users                     # q/status/role/verified/sort/dir/page/per_page — the UI's filter set
GET    /api/admin/users/:id                 # + that account's privilege trail
POST   /api/admin/users/:id/role            # {"role": "admin"|"user"}
POST   /api/admin/users/:id/sandbox-limit   # {"limit": n}
POST   /api/admin/users/:id/extend-trial    # {"days": n}
POST   /api/admin/users/:id/comp            # {"comped": bool}
POST   /api/admin/users/:id/suspend         # {"suspended": bool}
POST   /api/admin/users/:id/resync-stripe
DELETE /api/admin/users/:id
GET    /api/admin/sandboxes
POST   /api/admin/sandboxes/:id/reap
GET    /api/admin/audit                     # cross-tenant audit events
GET    /api/admin/events                    # privilege trail: who did what to whom
```

Booleans instead of the LiveView's toggles (`{"comped": true}` rather than "flip it") — a scripted toggle is a race, and a runbook wants to state the intended end state.

## The gate

Three plugs in order: `:api` (authenticate) → `:require_full_scope` (a sandbox's per-conversation token is **not** an operator credential, even when the account is an admin) → `:require_admin_api` (the role). A non-admin gets 403, not 404: the surface is documented, and a 404 makes "you're not an admin" indistinguishable from "that endpoint moved" — a bad half-hour mid-incident.

## Refusals

Carried over from the UI: no self-suspend, no self-delete, and billing actions (extend-trial/comp/resync) refused with `404 billing: "disabled"` when billing is off — the UI hides those buttons but requests can still be sent by hand, which is #399's lesson.

**One refusal is new and worth your call: you cannot change your own role.** The LiveView shows you that toggle; over an API, revoking your own admin is a lockout one scripted typo away, recoverable only with a release task. Say the word if you'd rather it mirror the UI exactly.

Everything records the same `admin.*` privilege-trail events, so a curl'd suspension is as visible as a clicked one. Cross-tenant reads stay metadata-only per the ConversationDetail principle — sandbox rows carry owner email and a conversation *count*, never contents.

## Tests

24 in `admin_controller_test.exs`: the gate from every angle (non-admin key on all read endpoints, non-admin acting on another account, **an admin's own sprite token refused**, 401), listing with filters and the per_page cap, show including the account's trail, unknown/malformed id → 404 rather than a crash, role grant/revoke recording distinct event types, self-role refusal, sandbox-limit set + negative refused with no event written, suspend/unsuspend round trip, self-suspend refused, idempotent re-suspend, delete + self-delete refusal, all three billing actions refused with no privilege-trail rows when billing is off while non-billing actions still work, cross-tenant audit rows carrying `user_id`, and the privilege trail carrying actor and target.

Full suite green (2,232 tests); `format` / `--warnings-as-errors` / `credo --strict` clean; OpenAPI spec regenerates and validates (48 paths now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)