### PR TITLE
api: put the /api/auth/* surface into the OpenAPI spec (#571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ upgrade, is in
   in another tab or on a phone — with no second login. It cannot be camped on:
   a verified user hitting it is sent where they were going (#533)
 
+- **The `/api/auth/*` endpoints are now in the OpenAPI spec.** They never
+  were: the spec is generated from the router, and a controller that does
+  not declare operations is skipped in silence — so the published spec
+  described every resource endpoint but not the one thing a client needs
+  first, which is how to get a bearer token. `/api/docs` opened on a surface
+  whose front door was invisible, and generated clients had to hand-roll
+  authentication. All thirteen auth routes are documented now, with the seven
+  public ones (`token`, `register`, `resend-verification`, `verify`, `forgot`,
+  `reset`, `email/confirm`) declaring `security: []` so a generated client
+  will actually call them without a credential it cannot yet have. A test
+  walks the router and fails on any `/api/` route without an operation, so
+  the gap cannot silently re-open (#571)
+
 - **Secrets written through the API now leave the same audit trail as
   secrets written through the UI.** `POST/DELETE /api/environments/:id/secrets`,
   the vault equivalents, and the secret half of `POST /api/apply` recorded

--- a/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
@@ -14,8 +14,10 @@ defmodule FountainWeb.AccountSecurityController do
   """
 
   use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Accounts
+  alias FountainWeb.Schemas
 
   plug FountainWeb.Plugs.RateLimit,
        [bucket: "account_security", max: 10, window_ms: 3_600_000]
@@ -25,6 +27,13 @@ defmodule FountainWeb.AccountSecurityController do
               :api_change_password,
               :api_request_email_change
             ]
+
+  tags(["Auth"])
+
+  # Browser form POSTs and the emailed confirmation link — not API routes.
+  operation(:change_password, false)
+  operation(:request_email_change, false)
+  operation(:confirm_email_change, false)
 
   def change_password(conn, %{"current_password" => current, "new_password" => new}) do
     user = conn.assigns.current_user
@@ -142,6 +151,30 @@ defmodule FountainWeb.AccountSecurityController do
   Behind the `full`-scope gate: the per-conversation token a sandbox holds
   must not be able to rotate the account password.
   """
+  operation(:api_change_password,
+    summary: "Change the account password",
+    description:
+      "Needs the current password on top of the bearer token, and `full` " <>
+        "scope — a sandbox's per-conversation token must not be able to " <>
+        "rotate the account password. Browser sessions are signed out; API " <>
+        "keys are **not** revoked, which the response states outright " <>
+        "(`api_keys_revoked: false`). If you are rotating because something " <>
+        "leaked, revoke keys yourself at `DELETE /api/auth/api-keys/{id}`.",
+    request_body:
+      {"Current and new password", "application/json", Schemas.PasswordChangeRequest,
+       required: true},
+    responses: [
+      ok: {"Password changed", "application/json", Schemas.PasswordChangeResponse},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden:
+        {"`invalid_current_password`, or a key without full scope", "application/json",
+         Schemas.AuthError},
+      unprocessable_entity:
+        {"`no_password` (OAuth-only account), missing fields, or a password that fails validation",
+         "application/json", Schemas.AuthError}
+    ]
+  )
+
   def api_change_password(conn, %{"current_password" => current, "new_password" => new}) do
     user = conn.assigns.current_user
 
@@ -188,6 +221,28 @@ defmodule FountainWeb.AccountSecurityController do
   address only changes when the token comes back to
   `POST /api/auth/email/confirm`.
   """
+  operation(:api_request_email_change,
+    summary: "Start an email change",
+    description:
+      "Sends a confirmation link to the new address; the address only changes " <>
+        "when that token comes back to `POST /api/auth/email/confirm`. The " <>
+        "response is identical whether or not the address was free — this is " <>
+        "not an availability oracle. Requires the current password and `full` scope.",
+    request_body:
+      {"New address and current password", "application/json", Schemas.EmailChangeRequest,
+       required: true},
+    responses: [
+      ok: {"Confirmation link sent (if the address was available)", "application/json", Schemas.MessageResponse},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden:
+        {"`invalid_current_password`, or a key without full scope", "application/json",
+         Schemas.AuthError},
+      unprocessable_entity:
+        {"`no_password`, `invalid_email`, `same_email`, or missing fields", "application/json",
+         Schemas.AuthError}
+    ]
+  )
+
   def api_request_email_change(conn, %{"new_email" => new_email, "current_password" => current}) do
     user = conn.assigns.current_user
 
@@ -253,6 +308,24 @@ defmodule FountainWeb.AccountSecurityController do
   JSON completion of the email change (#522). Same token as the emailed
   browser link; no session is touched, because an API client has none.
   """
+  operation(:api_confirm_email_change,
+    summary: "Complete a pending email change",
+    description:
+      "Public: the token arrives in an inbox, and the caller may hold no " <>
+        "credential for the account at all. Applying it bumps " <>
+        "`session_version`, so every session and every API key session for " <>
+        "the account is dead afterwards — the response says so rather than " <>
+        "letting the caller discover it as a mystery 401.",
+    security: [],
+    request_body: {"The emailed token", "application/json", Schemas.TokenRequest, required: true},
+    responses: [
+      ok: {"Email changed", "application/json", Schemas.EmailChangedResponse},
+      unprocessable_entity:
+        {"`email_taken`, `expired`, `invalid_token`, or a missing token", "application/json",
+         Schemas.AuthError}
+    ]
+  )
+
   def api_confirm_email_change(conn, %{"token" => token}) do
     case Accounts.apply_email_change(token) do
       {:ok, updated, old_email} ->

--- a/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
@@ -8,13 +8,48 @@ defmodule FountainWeb.ApiKeyController do
   """
 
   use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Accounts
+  alias FountainWeb.Schemas
+
+  tags(["Auth"])
+
+  operation(:index,
+    summary: "List active API keys",
+    description:
+      "Metadata only — key material is returned once, at creation, and is not " <>
+        "recoverable. Most of a busy tenant's list is auto-issued " <>
+        "`sprite:<conversation_id>` tokens; `scopes` and `expires_at` are what " <>
+        "tell those apart from a key a person minted.",
+    responses: [
+      ok: {"Active keys", "application/json", Schemas.ApiKeyListResponse},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden:
+        {"The presented key lacks key-management scope", "application/json", Schemas.Error}
+    ]
+  )
 
   def index(conn, _params) do
     user = conn.assigns.current_user
     render(conn, :index, keys: Accounts.list_api_keys(user.id))
   end
+
+  operation(:create,
+    summary: "Mint an API key",
+    description:
+      "The response is the only time the plaintext key is available. A key " <>
+        "minted here carries `full` scope, so it can do everything the " <>
+        "presenting key can — including minting more.",
+    request_body: {"Key name", "application/json", Schemas.ApiKeyRequest, required: true},
+    responses: [
+      created: {"The new key, with plaintext", "application/json", Schemas.ApiKeyCreatedResponse},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden:
+        {"The presented key lacks key-management scope", "application/json", Schemas.Error},
+      unprocessable_entity: {"Missing or invalid name", "application/json", Schemas.Error}
+    ]
+  )
 
   def create(conn, %{"name" => name}) when is_binary(name) and name != "" do
     user = conn.assigns.current_user
@@ -38,6 +73,23 @@ defmodule FountainWeb.ApiKeyController do
     |> put_status(:unprocessable_entity)
     |> json(%{error: "name is required"})
   end
+
+  operation(:delete,
+    summary: "Revoke an API key",
+    description:
+      "Immediate — the key stops authenticating on the next request. Revoking " <>
+        "the key you are presenting is allowed and is the last thing that key does.",
+    parameters: [
+      id: [in: :path, type: :string, required: true, description: "Key id."]
+    ],
+    responses: [
+      no_content: "Revoked",
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden:
+        {"The presented key lacks key-management scope", "application/json", Schemas.Error},
+      not_found: {"No such key on this account", "application/json", Schemas.Error}
+    ]
+  )
 
   def delete(conn, %{"id" => id}) do
     user = conn.assigns.current_user

--- a/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
@@ -7,6 +7,22 @@ defmodule FountainWeb.AuthMeController do
   """
 
   use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias FountainWeb.Schemas
+
+  tags(["Auth"])
+
+  operation(:show,
+    summary: "Identity of the authenticated account",
+    description:
+      "What the presented bearer token resolves to. `fountain auth whoami` " <>
+        "calls this to show which account a key belongs to.",
+    responses: [
+      ok: {"The account", "application/json", Schemas.AuthMeResponse},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
 
   def show(conn, _params) do
     user = conn.assigns.current_user

--- a/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
@@ -7,12 +7,37 @@ defmodule FountainWeb.AuthTokenController do
   """
 
   use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Accounts
+  alias FountainWeb.Schemas
 
   plug FountainWeb.Plugs.RateLimit,
        [bucket: "auth_token", max: 10, window_ms: 3_600_000]
        when action in [:create]
+
+  tags(["Auth"])
+
+  operation(:create,
+    summary: "Exchange email and password for an API key",
+    description:
+      "The front door: every other `/api/*` endpoint needs the bearer token " <>
+        "this returns. Each call mints a **new** full-scope key rather than " <>
+        "returning an existing one, so a client that calls it on every run " <>
+        "accumulates keys — store the result. The account must be verified; " <>
+        "an unverified one is refused with 403 and `reason: email_unverified`. " <>
+        "Rate-limited to 10 attempts per IP per hour.",
+    # Overrides the spec-wide bearer requirement: this endpoint cannot require
+    # the credential it exists to issue.
+    security: [],
+    request_body: {"Credentials", "application/json", Schemas.AuthTokenRequest, required: true},
+    responses: [
+      created: {"A new API key", "application/json", Schemas.AuthTokenResponse},
+      unauthorized: {"Invalid email or password", "application/json", Schemas.Error},
+      forbidden: {"Email not verified", "application/json", Schemas.AuthError},
+      unprocessable_entity: {"Missing email or password", "application/json", Schemas.Error}
+    ]
+  )
 
   def create(conn, %{"email" => email, "password" => password})
       when is_binary(email) and is_binary(password) do

--- a/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
@@ -19,11 +19,18 @@ defmodule FountainWeb.EmailVerificationController do
   """
 
   use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Accounts
+  alias FountainWeb.Schemas
 
   # 24 hours in seconds
   @token_max_age 86_400
+
+  tags(["Auth"])
+
+  # `GET /users/confirm/:token` — the emailed browser link, not an API route.
+  operation(:confirm, false)
 
   def confirm(conn, %{"token" => token}) do
     case Phoenix.Token.verify(conn, "email_verification", token, max_age: @token_max_age) do
@@ -90,6 +97,21 @@ defmodule FountainWeb.EmailVerificationController do
   No session is issued: an API client wants a key, which it mints at
   `POST /api/auth/token` once the account is live.
   """
+  operation(:api_verify,
+    summary: "Activate an account from a verification token",
+    description:
+      "Idempotent: an already-verified account is a 200, which is what a CLI " <>
+        "retrying a request needs. No session is issued — mint a key at " <>
+        "`POST /api/auth/token` once the account is live. Tokens last 24 hours.",
+    security: [],
+    request_body: {"The emailed token", "application/json", Schemas.TokenRequest, required: true},
+    responses: [
+      ok: {"Verified (or already verified)", "application/json", Schemas.VerifyEmailResponse},
+      unprocessable_entity:
+        {"`expired`, `invalid_token`, or a missing token", "application/json", Schemas.AuthError}
+    ]
+  )
+
   def api_verify(conn, %{"token" => token}) do
     case Phoenix.Token.verify(conn, "email_verification", token, max_age: @token_max_age) do
       {:ok, user_id} -> verify_user(conn, Accounts.get_user(user_id))

--- a/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
@@ -14,9 +14,11 @@ defmodule FountainWeb.PasswordResetController do
   """
 
   use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Accounts
   alias Fountain.Emails.UserEmails
+  alias FountainWeb.Schemas
 
   # 1 hour TTL for reset tokens
   @token_max_age 3_600
@@ -32,6 +34,13 @@ defmodule FountainWeb.PasswordResetController do
        [bucket: "password_reset_submit", max: 10, window_ms: 3_600_000]
        when action in [:reset, :api_reset]
 
+  tags(["Auth"])
+
+  # `/auth/*` HTML actions — see RegistrationController for why these are false.
+  operation(:forgot_form, false)
+  operation(:reset_form, false)
+  operation(:reset, false)
+
   ## HTML — "forgot password" form
 
   def forgot_form(conn, _params) do
@@ -39,6 +48,20 @@ defmodule FountainWeb.PasswordResetController do
   end
 
   ## API — request a reset email
+
+  operation(:api_forgot,
+    summary: "Request a password-reset email",
+    description:
+      "Always 200 with the same message, registered address or not — this is " <>
+        "not an enumeration oracle. Rate-limited to 5 per IP per hour. The " <>
+        "emailed link points at the browser page; the token in it also works " <>
+        "at `POST /api/auth/reset`.",
+    security: [],
+    request_body: {"Address to reset", "application/json", Schemas.EmailRequest},
+    responses: [
+      ok: {"Accepted", "application/json", Schemas.MessageResponse}
+    ]
+  )
 
   def api_forgot(conn, %{"email" => email}) do
     # Always return 200 to prevent email enumeration
@@ -65,6 +88,24 @@ defmodule FountainWeb.PasswordResetController do
   end
 
   ## API — apply the reset
+
+  operation(:api_reset,
+    summary: "Set a new password from a reset token",
+    description:
+      "Takes the token out of the reset email, so a CLI can prompt for it " <>
+        "instead of opening a browser. A successful reset bumps " <>
+        "`session_version`: every browser session dies, and so does every " <>
+        "other outstanding reset token for the account. Rate-limited to 10 " <>
+        "per IP per hour.",
+    security: [],
+    request_body: {"Token and new password", "application/json", Schemas.PasswordResetRequest, required: true},
+    responses: [
+      ok: {"Password updated", "application/json", Schemas.MessageResponse},
+      unprocessable_entity:
+        {"`expired`, `invalid_token`, missing fields, or a password that fails validation",
+         "application/json", Schemas.AuthError}
+    ]
+  )
 
   def api_reset(conn, %{"token" => token, "password" => password}) do
     case verify_reset_token(conn, token) do

--- a/apps/fountain/lib/fountain_web/controllers/registration_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/registration_controller.ex
@@ -19,9 +19,11 @@ defmodule FountainWeb.RegistrationController do
   """
 
   use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Accounts
   alias Fountain.Workers.VerificationEmail
+  alias FountainWeb.Schemas
 
   plug FountainWeb.Plugs.RateLimit,
        [bucket: "registration", max: 5, window_ms: 3_600_000]
@@ -30,6 +32,17 @@ defmodule FountainWeb.RegistrationController do
   plug FountainWeb.Plugs.RateLimit,
        [bucket: "resend_verification", max: 5, window_ms: 3_600_000]
        when action in [:resend, :api_resend]
+
+  tags(["Auth"])
+
+  # The HTML actions serve `/auth/*`, not the API. Declared `false` so
+  # `Paths.from_router/1` skips them instead of warning about a missing spec
+  # (same treatment as AgentAvatarController's raw-bytes :show).
+  operation(:new, false)
+  operation(:check_email, false)
+  operation(:create, false)
+  operation(:resend_form, false)
+  operation(:resend, false)
 
   ## HTML path
 
@@ -96,6 +109,25 @@ defmodule FountainWeb.RegistrationController do
 
   ## JSON path
 
+  operation(:api_create,
+    summary: "Register an account",
+    description:
+      "Creates the account and sends the verification email. The account " <>
+        "cannot mint an API key until it is verified, so a headless bootstrap " <>
+        "is register → `POST /api/auth/verify` with the emailed token → " <>
+        "`POST /api/auth/token`. Rate-limited to 5 per IP per hour. On an " <>
+        "instance with open registration disabled this answers 403 with a " <>
+        "reason code.",
+    security: [],
+    request_body: {"Credentials", "application/json", Schemas.RegisterRequest, required: true},
+    responses: [
+      created: {"Account created", "application/json", Schemas.RegisterResponse},
+      forbidden: {"Registration refused", "application/json", Schemas.AuthError},
+      unprocessable_entity:
+        {"Missing fields or validation errors", "application/json", Schemas.ChangesetError}
+    ]
+  )
+
   def api_create(conn, %{"email" => _, "password" => _} = params) do
     case Accounts.register_user(params) do
       {:ok, %{email_verified_at: %DateTime{}} = user} ->
@@ -134,6 +166,20 @@ defmodule FountainWeb.RegistrationController do
     |> put_status(:unprocessable_entity)
     |> json(%{error: "email and password are required"})
   end
+
+  operation(:api_resend,
+    summary: "Resend the verification email",
+    description:
+      "Always 200 with the same message whether the address is unknown, " <>
+        "unverified, or already verified — this endpoint is not an account " <>
+        "oracle. Rate-limited to 5 per IP per hour in its own bucket, so " <>
+        "retrying resend does not burn the registration budget.",
+    security: [],
+    request_body: {"Address to resend to", "application/json", Schemas.EmailRequest},
+    responses: [
+      ok: {"Accepted", "application/json", Schemas.MessageResponse}
+    ]
+  )
 
   def api_resend(conn, params) do
     maybe_resend(params["email"])

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1647,4 +1647,333 @@ defmodule FountainWeb.Schemas do
       required: [:errors]
     })
   end
+
+  ## ─── Auth (#571) ───────────────────────────────────────────────────────────
+  #
+  # The `/api/auth/*` surface. Errors here carry a machine-readable `error`
+  # alongside the prose `message`, which the resource endpoints' plain
+  # `Schemas.Error` does not — a client retrying a reset needs to tell
+  # `expired` from `invalid_token` without parsing English.
+
+  defmodule AuthError do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuthError",
+      description: "An auth failure with a stable reason code.",
+      type: :object,
+      properties: %{
+        error: %Schema{
+          type: :string,
+          description: "Reason code, e.g. `expired`, `invalid_token`, `invalid_current_password`.",
+          example: "invalid_token"
+        },
+        message: %Schema{type: :string, description: "Human-readable detail."}
+      },
+      required: [:error]
+    })
+  end
+
+  defmodule MessageResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "MessageResponse",
+      type: :object,
+      properties: %{message: %Schema{type: :string}},
+      required: [:message]
+    })
+  end
+
+  defmodule AuthTokenRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuthTokenRequest",
+      type: :object,
+      properties: %{
+        email: %Schema{type: :string, format: :email},
+        password: %Schema{type: :string, format: :password}
+      },
+      required: [:email, :password]
+    })
+  end
+
+  defmodule AuthTokenResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuthTokenResponse",
+      description: "A freshly minted full-scope key. `api_key` is shown once and never again.",
+      type: :object,
+      properties: %{
+        api_key: %Schema{type: :string, example: "ftn_live_..."},
+        key_id: %Schema{type: :string, format: :uuid},
+        prefix: %Schema{
+          type: :string,
+          description: "Leading characters of the key, the only part stored in the clear."
+        }
+      },
+      required: [:api_key, :key_id, :prefix]
+    })
+  end
+
+  defmodule AuthMeResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuthMeResponse",
+      description: "Identity of the account the bearer token belongs to.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        email: %Schema{type: :string, format: :email},
+        role: %Schema{type: :string, enum: ~w(user admin)},
+        email_verified: %Schema{type: :boolean},
+        onboarding_state: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Wizard position. Only `completed` means anything to an API client."
+        },
+        onboarding_completed: %Schema{type: :boolean},
+        subscription_status: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Always null when billing is disabled on the instance (#480)."
+        }
+      },
+      required: [:id, :email, :role, :email_verified]
+    })
+  end
+
+  defmodule ApiKey do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ApiKey",
+      description: "Key metadata. Never the key itself, and never its hash.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        name: %Schema{type: :string},
+        prefix: %Schema{type: :string},
+        created_at: %Schema{type: :string, format: :"date-time"},
+        last_used_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        scopes: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description:
+            "`full` for a key a person minted; `sprite:<conversation_id>` for the " <>
+              "auto-issued token a sandbox holds."
+        },
+        expires_at: %Schema{type: :string, format: :"date-time", nullable: true}
+      },
+      required: [:id, :name, :prefix, :created_at]
+    })
+  end
+
+  defmodule ApiKeyListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ApiKeyListResponse",
+      type: :object,
+      # ApiKey is referenced by the implicit alias the nested defmodule above
+      # created; it only exists after that definition, hence the ordering.
+      properties: %{data: %Schema{type: :array, items: ApiKey}},
+      required: [:data]
+    })
+  end
+
+  defmodule ApiKeyRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ApiKeyRequest",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, minLength: 1, description: "What this key is for."}
+      },
+      required: [:name]
+    })
+  end
+
+  defmodule ApiKeyCreatedResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ApiKeyCreatedResponse",
+      description: "The one and only response that carries key material.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        name: %Schema{type: :string},
+        key: %Schema{type: :string, description: "Plaintext key. Not recoverable afterwards."},
+        prefix: %Schema{type: :string},
+        created_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :name, :key, :prefix]
+    })
+  end
+
+  defmodule RegisterRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RegisterRequest",
+      type: :object,
+      properties: %{
+        email: %Schema{type: :string, format: :email},
+        password: %Schema{type: :string, format: :password}
+      },
+      required: [:email, :password]
+    })
+  end
+
+  defmodule RegisterResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RegisterResponse",
+      type: :object,
+      properties: %{
+        user_id: %Schema{type: :string, format: :uuid},
+        message: %Schema{type: :string}
+      },
+      required: [:user_id, :message]
+    })
+  end
+
+  defmodule EmailRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EmailRequest",
+      type: :object,
+      properties: %{email: %Schema{type: :string, format: :email}},
+      required: [:email]
+    })
+  end
+
+  defmodule TokenRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TokenRequest",
+      description: "A token lifted out of an emailed link.",
+      type: :object,
+      properties: %{token: %Schema{type: :string}},
+      required: [:token]
+    })
+  end
+
+  defmodule VerifyEmailResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "VerifyEmailResponse",
+      type: :object,
+      properties: %{
+        user_id: %Schema{type: :string, format: :uuid},
+        email_verified: %Schema{type: :boolean},
+        message: %Schema{type: :string}
+      },
+      required: [:user_id, :email_verified, :message]
+    })
+  end
+
+  defmodule PasswordResetRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "PasswordResetRequest",
+      type: :object,
+      properties: %{
+        token: %Schema{type: :string, description: "From the reset email."},
+        password: %Schema{type: :string, format: :password}
+      },
+      required: [:token, :password]
+    })
+  end
+
+  defmodule PasswordChangeRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "PasswordChangeRequest",
+      type: :object,
+      properties: %{
+        current_password: %Schema{type: :string, format: :password},
+        new_password: %Schema{type: :string, format: :password}
+      },
+      required: [:current_password, :new_password]
+    })
+  end
+
+  defmodule PasswordChangeResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "PasswordChangeResponse",
+      type: :object,
+      properties: %{
+        message: %Schema{type: :string},
+        sessions_invalidated: %Schema{type: :boolean},
+        api_keys_revoked: %Schema{
+          type: :boolean,
+          description:
+            "Always false. API keys are separate credentials with their own " <>
+              "expiries; revoke them yourself at `DELETE /api/auth/api-keys/{id}`."
+        }
+      },
+      required: [:message, :sessions_invalidated, :api_keys_revoked]
+    })
+  end
+
+  defmodule EmailChangeRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EmailChangeRequest",
+      type: :object,
+      properties: %{
+        new_email: %Schema{type: :string, format: :email},
+        current_password: %Schema{type: :string, format: :password}
+      },
+      required: [:new_email, :current_password]
+    })
+  end
+
+  defmodule EmailChangedResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EmailChangedResponse",
+      type: :object,
+      properties: %{
+        email: %Schema{type: :string, format: :email, description: "The new address."},
+        message: %Schema{type: :string}
+      },
+      required: [:email, :message]
+    })
+  end
 end

--- a/apps/fountain/test/fountain_web/api_spec_test.exs
+++ b/apps/fountain/test/fountain_web/api_spec_test.exs
@@ -34,4 +34,128 @@ defmodule FountainWeb.ApiSpecTest do
       assert bearer.description =~ "POST /api/auth/api-keys"
     end
   end
+
+  # #571: the whole /api/auth/* surface was absent from the spec, because
+  # Paths.from_router/1 only emits a path when the route's controller exports
+  # open_api_operation/1 — and a controller that never `use`s ControllerSpecs
+  # is skipped in silence. Nothing failed; the endpoints simply were not there.
+  # This walks the router instead of the spec, so the next controller added
+  # without an operation decl fails here rather than going missing quietly.
+  describe "every /api/ route is in the spec (issue #571)" do
+    # Each exception is a route under /api/ that is deliberately not part of
+    # the documented JSON surface. Adding to this list is a decision, which is
+    # the point of making it explicit.
+    @exceptions [
+      # The spec machinery itself — plugs, not controllers.
+      {"/api/openapi.json", :get},
+      {"/api/docs", :get},
+      # Authenticated by Stripe-Signature, not a bearer token. Its caller is
+      # Stripe, which does not read our spec.
+      {"/api/stripe/webhook", :post},
+      # A browser-session route that happens to live under /api/ — CSRF-
+      # protected, session-authenticated, and driven by the theme toggle.
+      {"/api/settings/theme", :patch},
+      # Raw image bytes. The one action serves both the bearer route and the
+      # browser route, so it cannot be specced without splitting it the way
+      # #528 split AgentAvatarController into :show and :api_show.
+      {"/api/conversations/{conversation_id}/turns/{turn_id}/images/{position}", :get}
+    ]
+
+    setup do
+      spec = ApiSpec.spec()
+
+      documented =
+        for {path, item} <- spec.paths,
+            {verb, %OpenApiSpex.Operation{}} <- Map.from_struct(item),
+            into: MapSet.new(),
+            do: {path, verb}
+
+      %{documented: documented}
+    end
+
+    test "no /api/ route is undocumented", %{documented: documented} do
+      undocumented =
+        FountainWeb.Router.__routes__()
+        |> Enum.filter(&String.starts_with?(&1.path, "/api/"))
+        |> Enum.map(&{open_api_path(&1.path), &1.verb})
+        |> Enum.reject(&(&1 in @exceptions or MapSet.member?(documented, &1)))
+        |> Enum.uniq()
+
+      assert undocumented == [],
+             "these /api/ routes have no OpenAPI operation: #{inspect(undocumented)}. " <>
+               "Add an `operation/2` decl to the controller, or add the route to " <>
+               "@exceptions in this test with a reason."
+    end
+
+    test "every exception is still a live route" do
+      live =
+        FountainWeb.Router.__routes__()
+        |> Enum.map(&{open_api_path(&1.path), &1.verb})
+        |> MapSet.new()
+
+      stale = Enum.reject(@exceptions, &MapSet.member?(live, &1))
+
+      assert stale == [],
+             "these @exceptions no longer match any route: #{inspect(stale)}"
+    end
+
+    test "the auth surface specifically is present", %{documented: documented} do
+      for route <- [
+            {"/api/auth/token", :post},
+            {"/api/auth/me", :get},
+            {"/api/auth/api-keys", :get},
+            {"/api/auth/api-keys", :post},
+            {"/api/auth/api-keys/{id}", :delete},
+            {"/api/auth/register", :post},
+            {"/api/auth/resend-verification", :post},
+            {"/api/auth/verify", :post},
+            {"/api/auth/forgot", :post},
+            {"/api/auth/reset", :post},
+            {"/api/auth/password", :post},
+            {"/api/auth/email", :post},
+            {"/api/auth/email/confirm", :post}
+          ] do
+        assert MapSet.member?(documented, route), "#{inspect(route)} is missing from the spec"
+      end
+    end
+
+    # The spec carries a global bearer requirement. An endpoint you call
+    # *before* you have a token must override it with `security: []`, or a
+    # generated client refuses to call it without a credential it cannot have.
+    test "public auth endpoints do not require a bearer token" do
+      spec = ApiSpec.spec()
+
+      for path <- [
+            "/api/auth/token",
+            "/api/auth/register",
+            "/api/auth/resend-verification",
+            "/api/auth/verify",
+            "/api/auth/forgot",
+            "/api/auth/reset",
+            "/api/auth/email/confirm"
+          ] do
+        assert spec.paths[path].post.security == [],
+               "#{path} must declare `security: []` — it is reachable without a key"
+      end
+    end
+
+    # The mirror of the above: an authenticated endpoint that accidentally
+    # declared `security: []` would document itself as public.
+    test "authenticated auth endpoints inherit the bearer requirement" do
+      spec = ApiSpec.spec()
+
+      assert spec.paths["/api/auth/me"].get.security == nil
+      assert spec.paths["/api/auth/api-keys"].post.security == nil
+      assert spec.paths["/api/auth/password"].post.security == nil
+    end
+  end
+
+  defp open_api_path(path) do
+    path
+    |> String.split("/")
+    |> Enum.map_join("/", fn
+      ":" <> segment -> "{#{segment}}"
+      segment -> segment
+    end)
+  end
 end

--- a/apps/fountain/test/fountain_web/controllers/admin_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/admin_controller_test.exs
@@ -9,7 +9,13 @@ defmodule FountainWeb.AdminControllerTest do
   as a clicked one.
   """
 
-  use FountainWeb.ConnCase, async: true
+  # async: false — the "billing actions when billing is disabled" block below
+  # flips `:billing_enabled`, which is application env and therefore global to
+  # the VM, not to this test. Run async, it made every concurrent test that
+  # reads `Billing.enabled?/0` see `false` for the duration, which is how
+  # AdminUserDetailLiveTest's `#invoices` section intermittently vanished
+  # (#576). Every other module that mutates this env is already async: false.
+  use FountainWeb.ConnCase, async: false
 
   alias Fountain.Accounts
   alias Fountain.Audit.AdminEvent

--- a/apps/fountain/test/fountain_web/schemas_test.exs
+++ b/apps/fountain/test/fountain_web/schemas_test.exs
@@ -32,4 +32,37 @@ defmodule FountainWeb.SchemasTest do
     missing = MapSet.difference(emitted, documented)
     assert MapSet.size(missing) == 0, "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
   end
+
+  # #571 brought the API-key views into the spec. Same drift guard: the
+  # listing must never grow a field the schema does not mention, because the
+  # one field that must never appear there is the key itself.
+  describe "API key views (issue #571)" do
+    defp api_key, do: %Fountain.Accounts.ApiKey{id: Ecto.UUID.generate(), key_prefix: "ftn_abc"}
+
+    test "every field the key listing emits is documented" do
+      [emitted] = FountainWeb.ApiKeyJSON.index(%{keys: [api_key()]}).data
+
+      documented =
+        FountainWeb.Schemas.ApiKey.schema().properties |> Map.keys() |> MapSet.new()
+
+      missing = MapSet.difference(emitted |> Map.keys() |> MapSet.new(), documented)
+      assert MapSet.size(missing) == 0, "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
+    end
+
+    test "the listing schema has no field that could carry key material" do
+      documented = FountainWeb.Schemas.ApiKey.schema().properties |> Map.keys()
+      refute :key in documented
+      refute :key_hash in documented
+    end
+
+    test "every field the creation response emits is documented" do
+      emitted = FountainWeb.ApiKeyJSON.created(%{key: api_key(), raw_key: "ftn_abc_secret"})
+
+      documented =
+        FountainWeb.Schemas.ApiKeyCreatedResponse.schema().properties |> Map.keys() |> MapSet.new()
+
+      missing = MapSet.difference(emitted |> Map.keys() |> MapSet.new(), documented)
+      assert MapSet.size(missing) == 0, "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
+    end
+  end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,10 @@ The authoritative, always-current reference is the served OpenAPI spec:
 - `GET /api/openapi.json` - OpenAPI 3.1 spec, generated from the code (public, no auth)
 - `GET /api/docs` - Swagger UI over the same spec
 
-The endpoint listings below are a convenience summary of that spec.
+The endpoint listings below are a convenience summary of that spec. Every
+`/api/` endpoint is in it, including the auth surface — a test walks the router
+and fails if a route is added without one, so a generated client covers the
+whole API and not just the parts someone remembered to document.
 
 ## Authentication
 


### PR DESCRIPTION
Closes #571.

## The gap

`FountainWeb.ApiSpec` builds its paths with `Paths.from_router/1`, which only
emits a path when the route's controller exports `open_api_operation/1` — i.e.
when it `use`s `OpenApiSpex.ControllerSpecs`. None of the seven auth
controllers did, so all thirteen `/api/auth/*` routes were missing from
`/api/openapi.json`. Nothing failed. The endpoints simply were not there.

That left the published spec describing every resource endpoint but not the
one thing a client needs first: how to get a bearer token. `/api/docs` opened
on a surface with no visible front door, and any generated client had to
hand-roll authentication against `docs/api.md`.

This is the gap #531 flagged deliberately — #521 and #522 documented their
endpoints in prose rather than half-converting three controllers that also
serve browser HTML.

## What this does

| Route | Controller |
|---|---|
| `POST /api/auth/token` | AuthTokenController |
| `GET /api/auth/me` | AuthMeController |
| `GET`/`POST /api/auth/api-keys`, `DELETE /api/auth/api-keys/{id}` | ApiKeyController |
| `POST /api/auth/register`, `POST /api/auth/resend-verification` | RegistrationController |
| `POST /api/auth/forgot`, `POST /api/auth/reset` | PasswordResetController |
| `POST /api/auth/verify` | EmailVerificationController |
| `POST /api/auth/password`, `POST /api/auth/email`, `POST /api/auth/email/confirm` | AccountSecurityController |

Four of those controllers also serve browser HTML (`/auth/register`,
`/auth/reset/:token`, `/users/confirm/:token`, the account form POSTs). Adding
`ControllerSpecs` makes `open_api_operation/1` exist for *every* action in the
module, so each browser action is declared `operation(:x, false)` — the
treatment #528 already gave `AgentAvatarController`'s raw-bytes `:show`. That
makes `Paths.from_router` skip them instead of emitting an `IO.warn` at
spec-build time. No browser path leaks into the spec; a test asserts it.

**`security: []` on the seven public endpoints.** The spec sets a global
bearer requirement. `POST /api/auth/token` cannot require the credential it
exists to issue, and neither can register/verify/forgot/reset/resend/
`email/confirm` — the caller of the last one may hold no credential for the
account at all. Without the override a generated client refuses to call them.

Error bodies here carry a machine-readable reason beside the prose (`expired`
vs `invalid_token` vs `invalid_current_password`), which the resource
endpoints' plain `Schemas.Error` does not, so they get their own
`Schemas.AuthError`. Descriptions state the behaviour a client will otherwise
discover the hard way: `token` mints a *new* key on every call, `verify` is
idempotent, `password` does not revoke API keys, `email` is not an
availability oracle.

No behaviour changes — no `CastAndValidate` was added, so every controller
keeps its own hand-rolled param handling and its own responses.

## Guard

`ApiSpecTest` walks `Router.__routes__()` and fails on any `/api/` route with
no operation, so the next controller added without a spec fails a test rather
than going missing quietly. Five routes are explicit exceptions, each with a
reason:

- `/api/openapi.json`, `/api/docs` — the spec machinery, plugs not controllers
- `/api/stripe/webhook` — authenticated by `Stripe-Signature`; its caller does not read our spec
- `PATCH /api/settings/theme` — a CSRF-protected browser-session route that happens to live under `/api/`
- the turn-image bytes — **a real remaining gap**, not machinery: one action
  serves both the bearer route and the browser route, so speccing it means
  splitting it into `:show` / `:api_show` the way #528 split avatars. Left out
  as scope creep; say the word and I will file it.

A second test fails if an exception stops matching a live route, so the list
cannot rot into permanent blanket coverage.

`SchemasTest` gains the same drift check the Conversation schema has, over
the API-key views — including an assertion that no field which could carry
key material is in the listing schema.

## Verification

- `mix precommit` green: 2242 tests, 0 failures
- `mix openapi.spec.json` regenerates and validates; **48 paths → 60**
- All seven public auth operations confirmed carrying `security: []` in the
  generated JSON; `/api/auth/me`, `/api/auth/api-keys` and `/api/auth/password`
  confirmed still inheriting the bearer requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)