### PR TITLE
compose: pinned-image boot check in CI + parameterised postgres host publish

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -33,6 +33,12 @@ SPRITES_TOKEN=
 
 # POSTGRES_PASSWORD=postgres
 
+# Host port the database is published on — for host-side psql and the
+# database-only dev path. The app reaches Postgres over the compose network
+# either way, so set this only if something on your machine already listens
+# on 5432 (a local Postgres usually does).
+# POSTGRES_HOST_PORT=5433
+
 # Which release to run. The compose file falls back to a release pinned at
 # the time this checkout was cut; set this to upgrade (never to `latest` —
 # it moves under you on every merge). Releases publish vX.Y.Z (immutable)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,3 +266,65 @@ jobs:
       # clone with no .env. This is the same load step that command runs.
       - name: docker compose config with no .env and no secrets in the environment
         run: env -u SECRET_KEY_BASE -u MASTER_SECRETS_KEY docker compose config --quiet
+
+  # docker-compose.yml and .env.compose.example evolve on main while the
+  # image they run stays pinned to a released tag. Every other check pairs
+  # main's config with main's code — ComposePassthroughConfigTest evaluates
+  # main's runtime.exs, the release boot check boots a fresh build. The
+  # pairing a fresh `git clone && docker compose up` actually gets — current
+  # compose file, *pinned* image — was exercised by nothing, and both #513
+  # boot failures shipped through exactly that gap (#548). So this job runs
+  # the documented quick start verbatim against the pin and asks the app
+  # what the walkthrough asks.
+  compose-pinned-image-boot:
+    name: Compose boots the pinned image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      # The exact commands the quick start documents (cp, the two openssl
+      # lines, up) rather than a synthetic env — the job exists to run what
+      # a fresh user runs, so any divergence here would defeat it. The
+      # appended keys shadow the blank ones from the example file; that
+      # last-value-wins reliance is part of the documented flow under test.
+      - name: Run the documented quick start
+        run: |
+          set -euo pipefail
+          cp .env.compose.example .env
+          echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')" >> .env
+          echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" >> .env
+          docker compose up -d
+
+      - name: Probe /health and /health/ready
+        run: |
+          set -euo pipefail
+          probe() {
+            # Boot runs migrations before the endpoint listens, so tolerate
+            # refused connections while waiting — but a non-200 answer is a
+            # verdict, not a retry.
+            for _ in $(seq 1 60); do
+              code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:4000$1") || code=000
+              if [ "$code" = "200" ]; then
+                echo "  $1 -> 200"
+                return 0
+              fi
+              if [ "$code" != "000" ]; then
+                echo "  $1 -> $code (expected 200)" >&2
+                return 1
+              fi
+              sleep 2
+            done
+            echo "  $1 never answered" >&2
+            return 1
+          }
+          probe /health
+          probe /health/ready
+
+      - name: Dump container logs
+        if: failure()
+        run: docker compose logs --timestamps

--- a/SETUP.md
+++ b/SETUP.md
@@ -63,7 +63,7 @@ Pick **one** path:
 docker compose up -d postgres
 ```
 
-Brings up Postgres 16 on `localhost:5432` with role `postgres`/`postgres`. `mix setup` creates `fountain_dev` itself. (`docker compose up` with no service name also starts Fountain — see [self-hosting](docs/self-hosting.md).) Stop with `docker compose down`; data persists in the `postgres_data` volume.
+Brings up Postgres 16 on `localhost:5432` with role `postgres`/`postgres` (already running your own Postgres? set `POSTGRES_HOST_PORT` in `.env` to publish elsewhere). `mix setup` creates `fountain_dev` itself. (`docker compose up` with no service name also starts Fountain — see [self-hosting](docs/self-hosting.md).) Stop with `docker compose down`; data persists in the `postgres_data` volume.
 
 ### Option B — Native Postgres
 

--- a/apps/fountain/test/fountain/config_reference_test.exs
+++ b/apps/fountain/test/fountain/config_reference_test.exs
@@ -144,9 +144,9 @@ defmodule Fountain.ConfigReferenceTest do
   end
 
   # Keys in .env.compose.example consumed by compose interpolation itself
-  # (image tag, published port, sibling services), not passed through the
+  # (image tag, published ports, sibling services), not passed through the
   # app service's environment block.
-  @interpolation_only ~w(FOUNTAIN_IMAGE_TAG PORT POSTGRES_PASSWORD)
+  @interpolation_only ~w(FOUNTAIN_IMAGE_TAG PORT POSTGRES_PASSWORD POSTGRES_HOST_PORT)
 
   test "every variable .env.compose.example advertises is actually passed to the app" do
     # The other compose test is one-directional by construction: it asserts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: fountain
     ports:
-      - "5432:5432"
+      # Host-side convenience only (psql, and the database-only dev path) —
+      # the app reaches Postgres over the compose network. Parameterised
+      # because a machine evaluating Fountain usually already runs its own
+      # Postgres on 5432 (#549).
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -51,7 +51,7 @@ mix local.rebar --force
 docker compose up -d postgres
 ```
 
-Brings up Postgres 16 on `localhost:5432`. Stop with `docker compose down`; data persists in the `postgres_data` volume.
+Brings up Postgres 16 on `localhost:5432` (already running your own Postgres? set `POSTGRES_HOST_PORT` in `.env` to publish elsewhere). Stop with `docker compose down`; data persists in the `postgres_data` volume.
 
 **Option B - Native Postgres:**
 


### PR DESCRIPTION
Two findings from the #513 walkthrough, both about the fresh-clone compose experience.

## #549 — postgres host publish was hardcoded `5432:5432`

`docker compose up` failed to bind on any machine already running Postgres — most developer laptops evaluating Fountain, the walkthrough machine included. The publish exists only for host-side psql and the database-only dev path; the app reaches Postgres over the compose network.

- `${POSTGRES_HOST_PORT:-5432}:5432`, advertised (commented) in `.env.compose.example`
- the drift-test carve-out #549 predicted: `POSTGRES_HOST_PORT` joins `@interpolation_only` (consumed in `ports:`, never passed to the app)
- SETUP.md / docs/setup.md mention the knob where they mention `localhost:5432`

## #548 — nothing checked that main's compose file still boots the pinned image

Every existing check pairs main's config with main's code: `ComposePassthroughConfigTest` evaluates main's `runtime.exs`, the release boot check boots a fresh build. The pairing every fresh user actually runs — **current compose file + pinned image** — was exercised by nothing, and both #513 boot failures (the `SENTRY_DSN` passthrough, the sandbox bounds) shipped through exactly that gap.

New always-on CI job `compose-pinned-image-boot`: runs the documented quick start verbatim (`cp .env.compose.example .env`, the two openssl lines, `docker compose up -d` — the example's uncommented `FOUNTAIN_IMAGE_TAG` pins the image), then probes `/health` and `/health/ready` from the host expecting exactly 200, with container logs dumped on failure. Went with always-on rather than path-filtered: it's a ~2-minute parallel job, and the pairing can break from either side.

## Verification

- Ran the new job's steps locally against v0.5.2: both probes 200.
- Booted the full stack with `POSTGRES_HOST_PORT=5433` beside a live local Postgres on 5432 (the exact #549 collision); default interpolation still publishes 5432.
- `config_reference_test.exs`, `release_pin_test.exs`, `compose_passthrough_config_test.exs`: 17 tests, 0 failures.

Closes #548. Closes #549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)