### PR TITLE
ui: give the audit page the filters #526 gave the API (#572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,18 @@ upgrade, is in
 
 ### Added
 
+- **The `/audit` page has the filters the API got in #526.** `GET /api/audit`
+  could narrow the trail by action prefix, resource type and time window; the
+  page could not, so the API was strictly better than the UI at the one thing
+  the UI is for — "show me every `vault.` event since Tuesday" was a curl away
+  and impossible in a browser, where you scrolled 200 rows and hoped. The
+  page now takes the same four filters through the same query, with the
+  resource-type list built from what is actually in your trail. Filter state
+  lives in the URL, so a filtered view is a link you can send someone and it
+  survives the 5s refresh. Admins get the filters over the cross-tenant view
+  too — previously the person seeing the most events could filter the least
+  (#572)
+
 - **`/api/admin/*` makes operator tasks scriptable** — list and inspect
   accounts with the filters the admin UI has, set the sandbox cap, extend a
   trial, comp, suspend, resync from Stripe, delete an account, list and reap

--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -152,8 +152,33 @@ defmodule Fountain.Audit do
   """
   @spec list_for_user(Ecto.UUID.t(), keyword()) :: [Event.t()]
   def list_for_user(user_id, opts \\ []) when is_binary(user_id) do
-    from(e in Event,
-      where: e.user_id == ^user_id,
+    from(e in Event, where: e.user_id == ^user_id)
+    |> recent_query(opts)
+    |> Repo.all()
+  end
+
+  @doc """
+  The distinct `resource_type` values present in one tenant's trail, sorted.
+
+  Populates the resource-type filter on `/audit` — a select of what is
+  actually there beats a free-text box the user has to guess into.
+  """
+  @spec list_resource_types_for_user(Ecto.UUID.t()) :: [String.t()]
+  def list_resource_types_for_user(user_id) when is_binary(user_id) do
+    Repo.all(
+      from e in Event,
+        where: e.user_id == ^user_id and not is_nil(e.resource_type),
+        distinct: true,
+        order_by: e.resource_type,
+        select: e.resource_type
+    )
+  end
+
+  # Ordering, page size and the five filters, shared by the tenant-scoped and
+  # unscoped listings so the two cannot drift — the browser trail and
+  # GET /api/audit answer the same question the same way.
+  defp recent_query(query, opts) do
+    from(e in query,
       order_by: [desc: e.inserted_at, desc: e.id],
       limit: ^Keyword.get(opts, :limit, 200)
     )
@@ -162,7 +187,6 @@ defmodule Fountain.Audit do
     |> filter_resource_type(Keyword.get(opts, :resource_type))
     |> filter_since(Keyword.get(opts, :since))
     |> filter_until(Keyword.get(opts, :until))
-    |> Repo.all()
   end
 
   defp filter_before_id(query, nil), do: query
@@ -211,7 +235,41 @@ defmodule Fountain.Audit do
   """
   @spec _unsafe_list_recent(pos_integer()) :: [Event.t()]
   def _unsafe_list_recent(limit \\ 200) do
-    Repo.all(from e in Event, order_by: [desc: e.inserted_at, desc: e.id], limit: ^limit)
+    _unsafe_list_events(limit: limit)
+  end
+
+  @doc """
+  Unscoped, with the same options as `list_for_user/2`.
+
+  The admin half of `/audit`: an admin sees every tenant's events and needs
+  the same filters a tenant has over their own, or the cross-tenant view is
+  strictly worse than the scoped one.
+
+  Reserved for admin/system surfaces. Anything user-facing must use
+  `list_for_user/2` instead.
+  """
+  @spec _unsafe_list_events(keyword()) :: [Event.t()]
+  def _unsafe_list_events(opts \\ []) do
+    Event
+    |> recent_query(opts)
+    |> Repo.all()
+  end
+
+  @doc """
+  Unscoped `list_resource_types_for_user/1` — every tenant's resource types.
+
+  Reserved for admin surfaces; populates the `/audit` filter for an admin,
+  who is looking at the whole system's trail.
+  """
+  @spec _unsafe_list_resource_types() :: [String.t()]
+  def _unsafe_list_resource_types do
+    Repo.all(
+      from e in Event,
+        where: not is_nil(e.resource_type),
+        distinct: true,
+        order_by: e.resource_type,
+        select: e.resource_type
+    )
   end
 
   @doc """

--- a/apps/fountain/lib/fountain_web/live/audit_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/audit_live/index.ex
@@ -1,43 +1,209 @@
 defmodule FountainWeb.AuditLive.Index do
-  @moduledoc false
+  @moduledoc """
+  The audit trail in a browser.
+
+  #526 gave `GET /api/audit` filters — action prefix, resource type, time
+  bounds — and this page had none, so the API was strictly better than the UI
+  at the one thing the UI exists for: "show me every `vault.` event since
+  Tuesday" was a curl away and impossible in a browser. #572 gives the page
+  the same filters, backed by the same `Audit` query.
+
+  Filter state lives in the URL, so a filtered view is a link you can send
+  someone and it survives the 5s refresh and a reload.
+  """
   use FountainWeb, :live_view
 
   alias Fountain.Audit
+
+  @limit 200
 
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket), do: Process.send_after(self(), :tick, 5_000)
 
     user = socket.assigns.current_user
-    events = load_events(user)
 
     {:ok,
      socket
      |> assign(:page_title, "Audit log")
      |> assign(:is_admin, user.role == "admin")
-     |> assign(:events, events)}
+     |> assign(:limit, @limit)
+     |> assign(:resource_types, load_resource_types(user))}
+  end
+
+  # Filters live in the URL rather than in socket state: the 5s refresh, a
+  # reload and a shared link all land on the same view.
+  @impl true
+  def handle_params(params, _uri, socket) do
+    filters = parse_filters(params)
+
+    {:noreply,
+     socket
+     |> assign(:filters, filters)
+     |> assign(:events, load_events(socket.assigns.current_user, filters))}
+  end
+
+  @impl true
+  def handle_event("filter", params, socket) do
+    {:noreply, push_patch(socket, to: audit_path(parse_filters(params)))}
   end
 
   @impl true
   def handle_info(:tick, socket) do
     Process.send_after(self(), :tick, 5_000)
-    events = load_events(socket.assigns.current_user)
-    {:noreply, assign(socket, :events, events)}
+
+    {:noreply,
+     assign(socket, :events, load_events(socket.assigns.current_user, socket.assigns.filters))}
   end
 
   # Ownership: the function head is the admin gate — same predicate as
   # require_admin; every other user hits the tenant-scoped clause below.
-  defp load_events(%{role: "admin"}), do: Audit._unsafe_list_recent(200)
-  defp load_events(%{id: id}), do: Audit.list_recent_for_user(id, 200)
+  defp load_events(%{role: "admin"}, filters),
+    do: Audit._unsafe_list_events(query_opts(filters))
+
+  defp load_events(%{id: id}, filters), do: Audit.list_for_user(id, query_opts(filters))
+
+  # Ownership: as above.
+  defp load_resource_types(%{role: "admin"}), do: Audit._unsafe_list_resource_types()
+  defp load_resource_types(%{id: id}), do: Audit.list_resource_types_for_user(id)
+
+  defp query_opts(f) do
+    [
+      limit: @limit,
+      action_prefix: f.action_prefix,
+      resource_type: f.resource_type,
+      since: f.since,
+      until: f.until
+    ]
+  end
+
+  ## Filter parsing
+
+  defp parse_filters(params) do
+    %{
+      action_prefix: params["action"] |> to_string() |> String.trim(),
+      resource_type: params["resource"] |> to_string() |> String.trim(),
+      # Kept as the raw form value as well as the parsed DateTime: the input
+      # has to render what the user typed, and an unparseable value must not
+      # silently vanish from the box while the results ignore it.
+      since_raw: params["since"] |> to_string() |> String.trim(),
+      until_raw: params["until"] |> to_string() |> String.trim(),
+      since: parse_time(params["since"]),
+      until: parse_time(params["until"])
+    }
+  end
+
+  # `datetime-local` posts "2026-08-05T14:30", and some browsers append
+  # seconds. Read as UTC, which is what the table renders. An unparseable
+  # value filters nothing rather than erroring — the input keeps showing it,
+  # so a half-typed date is visibly half-typed and not silently applied.
+  defp parse_time(value) when is_binary(value) do
+    trimmed = String.trim(value)
+
+    with {:error, _} <- NaiveDateTime.from_iso8601(trimmed),
+         {:error, _} <- NaiveDateTime.from_iso8601(trimmed <> ":00") do
+      nil
+    else
+      {:ok, naive} -> DateTime.from_naive!(naive, "Etc/UTC")
+    end
+  end
+
+  defp parse_time(_), do: nil
+
+  defp audit_path(f) do
+    params =
+      [
+        action: blank_to_nil(f.action_prefix),
+        resource: blank_to_nil(f.resource_type),
+        since: blank_to_nil(f.since_raw),
+        until: blank_to_nil(f.until_raw)
+      ]
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+
+    ~p"/audit?#{params}"
+  end
+
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
+
+  defp any_filter?(f) do
+    f.action_prefix != "" or f.resource_type != "" or f.since_raw != "" or f.until_raw != ""
+  end
 
   @impl true
   def render(assigns) do
     ~H"""
     <div class="space-y-4">
       <h1 class="text-2xl font-semibold">Audit log</h1>
-      <p class="text-sm text-zinc-500">Last 200 state-changing API calls. Updates every 5s.</p>
+      <p class="text-sm text-zinc-500">
+        Last {@limit} state-changing API calls. Updates every 5s.
+        <span :if={@is_admin}>Admin view: every tenant.</span>
+      </p>
 
-      <div :if={@events == []} class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500">
+      <form phx-change="filter" id="audit-filters" class="flex flex-wrap items-end gap-2">
+        <label class="flex flex-col gap-1 text-xs text-zinc-500">
+          action starts with
+          <input
+            type="text"
+            name="action"
+            value={@filters.action_prefix}
+            placeholder="vault."
+            phx-debounce="300"
+            autocomplete="off"
+            class="w-40 rounded border border-zinc-200 px-2 py-1 font-mono text-xs"
+          />
+        </label>
+        <label class="flex flex-col gap-1 text-xs text-zinc-500">
+          resource
+          <select name="resource" class="rounded border border-zinc-200 px-1 py-1 text-xs">
+            <option value="">any</option>
+            <option
+              :for={type <- @resource_types}
+              value={type}
+              selected={@filters.resource_type == type}
+            >
+              {type}
+            </option>
+          </select>
+        </label>
+        <label class="flex flex-col gap-1 text-xs text-zinc-500">
+          since (UTC)
+          <input
+            type="datetime-local"
+            name="since"
+            value={@filters.since_raw}
+            class="rounded border border-zinc-200 px-2 py-1 text-xs"
+          />
+        </label>
+        <label class="flex flex-col gap-1 text-xs text-zinc-500">
+          until (UTC)
+          <input
+            type="datetime-local"
+            name="until"
+            value={@filters.until_raw}
+            class="rounded border border-zinc-200 px-2 py-1 text-xs"
+          />
+        </label>
+        <.link
+          :if={any_filter?(@filters)}
+          patch={~p"/audit"}
+          class="px-2 py-1 text-xs text-zinc-500 underline hover:text-zinc-700"
+        >
+          clear filters
+        </.link>
+      </form>
+
+      <div
+        :if={@events == [] and any_filter?(@filters)}
+        class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500"
+      >
+        No events match these filters.
+      </div>
+
+      <div
+        :if={@events == [] and not any_filter?(@filters)}
+        class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500"
+      >
         No events yet.
       </div>
 
@@ -66,6 +232,11 @@ defmodule FountainWeb.AuditLive.Index do
           </tr>
         </tbody>
       </table>
+
+      <p :if={length(@events) == @limit} class="text-xs text-zinc-500">
+        Showing the newest {@limit} matches — narrow the filters to see further back,
+        or page the whole trail with <code>GET /api/audit</code>.
+      </p>
     </div>
     """
   end

--- a/apps/fountain/test/fountain/audit_test.exs
+++ b/apps/fountain/test/fountain/audit_test.exs
@@ -144,6 +144,100 @@ defmodule Fountain.AuditTest do
     end
   end
 
+  # #572: the admin half of /audit is the unscoped listing, and it had no
+  # filters at all — so an admin, who sees the most events, could filter the
+  # least. These share one query builder with list_for_user/2 so the two
+  # cannot drift.
+  describe "_unsafe_list_events/1 — cross-tenant with filters" do
+    test "spans tenants and includes system events" do
+      user1 = insert_verified_user()
+      user2 = insert_verified_user()
+      Audit.record!(valid_attrs(user1.id, %{action: "vault.secret.write"}))
+      Audit.record!(valid_attrs(user2.id, %{action: "vault.secret.write"}))
+      Audit.record!(valid_attrs(nil, %{action: "vault.secret.write"}))
+
+      events = Audit._unsafe_list_events(action_prefix: "vault.")
+      user_ids = Enum.map(events, & &1.user_id)
+
+      assert user1.id in user_ids
+      assert user2.id in user_ids
+      assert nil in user_ids
+    end
+
+    test "action_prefix narrows to matching actions" do
+      user = insert_verified_user()
+      Audit.record!(valid_attrs(user.id, %{action: "vault.secret.write"}))
+      Audit.record!(valid_attrs(user.id, %{action: "agent.created"}))
+
+      actions = Audit._unsafe_list_events(action_prefix: "vault.") |> Enum.map(& &1.action)
+
+      assert "vault.secret.write" in actions
+      refute "agent.created" in actions
+    end
+
+    test "action_prefix treats LIKE metacharacters as literals" do
+      user = insert_verified_user()
+      Audit.record!(valid_attrs(user.id, %{action: "vault.secret.write"}))
+
+      # Unescaped, "%" would match the entire trail.
+      assert Audit._unsafe_list_events(action_prefix: "%") == []
+    end
+
+    test "resource_type is an exact match" do
+      user = insert_verified_user()
+      Audit.record!(valid_attrs(user.id, %{resource_type: "vault_secret"}))
+      Audit.record!(valid_attrs(user.id, %{resource_type: "agent"}))
+
+      types = Audit._unsafe_list_events(resource_type: "vault_secret") |> Enum.map(& &1.resource_type)
+
+      assert types == ["vault_secret"]
+    end
+
+    test "since and until bound the window inclusively" do
+      user = insert_verified_user()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      old = DateTime.add(now, -3600, :second)
+
+      Audit.record!(valid_attrs(user.id, %{action: "old.event", inserted_at: old}))
+      Audit.record!(valid_attrs(user.id, %{action: "new.event", inserted_at: now}))
+
+      recent = Audit._unsafe_list_events(since: DateTime.add(now, -60, :second))
+      assert Enum.map(recent, & &1.action) == ["new.event"]
+
+      earlier = Audit._unsafe_list_events(until: DateTime.add(now, -60, :second))
+      assert Enum.map(earlier, & &1.action) == ["old.event"]
+
+      # Inclusive on both ends: the boundary timestamp itself matches.
+      assert Enum.any?(Audit._unsafe_list_events(since: now), &(&1.action == "new.event"))
+      assert Enum.any?(Audit._unsafe_list_events(until: old), &(&1.action == "old.event"))
+    end
+  end
+
+  describe "resource-type listings (#572)" do
+    test "the tenant's list is distinct, sorted, and excludes other tenants" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+
+      Audit.record!(valid_attrs(user.id, %{resource_type: "vault"}))
+      Audit.record!(valid_attrs(user.id, %{resource_type: "vault"}))
+      Audit.record!(valid_attrs(user.id, %{resource_type: "agent"}))
+      Audit.record!(valid_attrs(other.id, %{resource_type: "environment"}))
+
+      assert Audit.list_resource_types_for_user(user.id) == ["agent", "vault"]
+    end
+
+    test "the unscoped list spans tenants" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      Audit.record!(valid_attrs(user.id, %{resource_type: "vault"}))
+      Audit.record!(valid_attrs(other.id, %{resource_type: "environment"}))
+
+      types = Audit._unsafe_list_resource_types()
+      assert "vault" in types
+      assert "environment" in types
+    end
+  end
+
   describe "record/1 — exception rescue" do
     test "returns {:error, :exception} when attrs cause a runtime exception" do
       # Passing a non-enumerable triggers Protocol.UndefinedError inside cast,

--- a/apps/fountain/test/fountain_web/live/audit_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/audit_live_test.exs
@@ -104,6 +104,188 @@ defmodule FountainWeb.AuditLiveTest do
     end
   end
 
+  # #572: /api/audit got these filters in #526 and the page did not, so the
+  # API was better than the UI at the thing the UI is for.
+  describe "AuditLive.Index — filters" do
+    setup %{conn: conn} do
+      user = insert_verified_user()
+
+      Audit.record!(%{
+        action: "vault.secret.write",
+        resource_type: "vault_secret",
+        resource_id: "vaultvault-secret",
+        actor: "ui",
+        user_id: user.id,
+        metadata: %{"status" => 200}
+      })
+
+      Audit.record!(%{
+        action: "agent.created",
+        resource_type: "agent",
+        resource_id: "agentagent-created",
+        actor: "api",
+        user_id: user.id,
+        metadata: %{"status" => 201}
+      })
+
+      %{conn: login_user(conn, user), user: user}
+    end
+
+    test "an action prefix in the URL narrows the table", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/audit?action=vault.")
+
+      assert html =~ "vaultvau"
+      refute html =~ "agentage"
+    end
+
+    test "a resource type in the URL narrows the table", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/audit?resource=agent")
+
+      assert html =~ "agentage"
+      refute html =~ "vaultvau"
+    end
+
+    test "changing the form pushes the filters into the URL", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/audit")
+
+      html =
+        lv
+        |> form("#audit-filters", %{"action" => "vault.", "resource" => "", "since" => "", "until" => ""})
+        |> render_change()
+
+      assert html =~ "vaultvau"
+      refute html =~ "agentage"
+      assert_patched(lv, ~p"/audit?action=vault.")
+    end
+
+    test "filters survive the 5s tick", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/audit?action=vault.")
+
+      send(lv.pid, :tick)
+      html = render(lv)
+
+      assert html =~ "vaultvau"
+      refute html =~ "agentage"
+    end
+
+    test "a filter that matches nothing says so, distinctly from an empty trail", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/audit?action=nothing.matches.this")
+
+      assert html =~ "No events match these filters"
+      refute html =~ "No events yet"
+    end
+
+    test "an empty trail says 'no events yet', not 'no matches'", %{conn: conn} do
+      # A fresh user with nothing recorded — and no filters applied.
+      conn = login_user(conn, insert_verified_user())
+      {:ok, _lv, html} = live(conn, ~p"/audit")
+
+      assert html =~ "No events yet"
+      refute html =~ "No events match these filters"
+    end
+
+    test "the resource-type select offers only this tenant's types", %{conn: conn} do
+      other = insert_verified_user()
+
+      Audit.record!(%{
+        action: "environment.created",
+        resource_type: "environment",
+        resource_id: Ecto.UUID.generate(),
+        actor: "ui",
+        user_id: other.id
+      })
+
+      {:ok, _lv, html} = live(conn, ~p"/audit")
+
+      assert html =~ ~s(<option value="agent")
+      assert html =~ ~s(<option value="vault_secret")
+      refute html =~ ~s(<option value="environment")
+    end
+
+    test "a half-typed date filters nothing and stays in the box", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/audit?since=2026-08")
+
+      # Both events still listed — an unparseable bound is not applied...
+      assert html =~ "vaultvau"
+      assert html =~ "agentage"
+      # ...and the input still shows what was typed rather than blanking it.
+      assert html =~ ~s(value="2026-08")
+    end
+
+    test "a since bound excludes older events", %{conn: conn, user: user} do
+      Audit.record!(%{
+        action: "ancient.event",
+        resource_type: "agent",
+        resource_id: "ancientancient",
+        actor: "ui",
+        user_id: user.id,
+        inserted_at: ~U[2020-01-01 00:00:00Z]
+      })
+
+      {:ok, _lv, html} = live(conn, ~p"/audit?since=2021-01-01T00:00")
+
+      refute html =~ "ancienta"
+      assert html =~ "vaultvau"
+    end
+
+    test "the clear link only appears when a filter is active", %{conn: conn} do
+      {:ok, _lv, unfiltered} = live(conn, ~p"/audit")
+      refute unfiltered =~ "clear filters"
+
+      {:ok, _lv, filtered} = live(conn, ~p"/audit?action=vault.")
+      assert filtered =~ "clear filters"
+    end
+  end
+
+  describe "AuditLive.Index — admin filters" do
+    test "an admin gets the same filters over the cross-tenant trail", %{conn: conn} do
+      admin = insert_verified_user(%{"role" => "admin"})
+      other = insert_verified_user()
+
+      # Distinct 8-char prefixes: the table renders String.slice(id, 0, 8).
+      Audit.record!(%{
+        action: "vault.secret.write",
+        resource_type: "vault_secret",
+        resource_id: "vvvvvvvv-other-tenant",
+        actor: "api",
+        user_id: other.id
+      })
+
+      Audit.record!(%{
+        action: "agent.created",
+        resource_type: "agent",
+        resource_id: "gggggggg-other-tenant",
+        actor: "api",
+        user_id: other.id
+      })
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/audit?action=vault.")
+
+      # Still cross-tenant — and now filtered, which it was not before #572.
+      assert html =~ "vvvvvvvv"
+      refute html =~ "gggggggg"
+    end
+
+    test "the admin resource-type select spans tenants", %{conn: conn} do
+      admin = insert_verified_user(%{"role" => "admin"})
+      other = insert_verified_user()
+
+      Audit.record!(%{
+        action: "environment.created",
+        resource_type: "environment",
+        resource_id: Ecto.UUID.generate(),
+        actor: "ui",
+        user_id: other.id
+      })
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/audit")
+
+      assert html =~ ~s(<option value="environment")
+    end
+  end
+
   describe "AuditLive.Index — :tick refresh" do
     test ":tick message reloads events without crashing", %{conn: conn} do
       user = insert_verified_user()
@@ -166,7 +348,7 @@ defmodule FountainWeb.AuditLiveFormatTsTest do
       metadata: %{}
     }
 
-    stub(Fountain.Audit, :list_recent_for_user, fn _id, _limit -> [synthetic_event] end)
+    stub(Fountain.Audit, :list_for_user, fn _id, _opts -> [synthetic_event] end)
 
     conn = login_user(conn, user)
     {:ok, _lv, html} = live(conn, ~p"/audit")

--- a/docs/api.md
+++ b/docs/api.md
@@ -265,6 +265,8 @@ Page backwards with `meta.next_cursor` as `before`; `limit` defaults to 100 and 
 
 Only this tenant's events are visible.
 
+The `/audit` page in the browser takes the same `action_prefix`, `resource_type`, `since` and `until` filters (as `?action=`, `?resource=`, `?since=`, `?until=`) and runs them through the same query, so a filtered view is a shareable link. It shows the newest 200 matches and does not page — use this endpoint to walk the whole trail.
+
 ## Error responses
 
 ```json


### PR DESCRIPTION
Closes #572. **Stacked on #573** — base is `api/571-auth-openapi-spec`, so
merge that first and GitHub will retarget this to `main`. The two touch
disjoint code; they are stacked only to keep the `[Unreleased]` CHANGELOG
section conflict-free.

## The gap

#526 gave `GET /api/audit` filters — `action_prefix`, `resource_type`,
`since`, `until` — all implemented in `Audit.list_for_user/2`. `AuditLive.Index`
kept calling the two unfiltered helpers and rendering a fixed last-200 table:

```elixir
defp load_events(%{role: "admin"}), do: Audit._unsafe_list_recent(200)
defp load_events(%{id: id}), do: Audit.list_recent_for_user(id, 200)
```

So the API ended up strictly better than the UI at the one thing the UI exists
for. "Show me every `vault.` event since Tuesday" was a curl away and
impossible in a browser.

## What this does

The page takes the same four filters, through the same query. Filter state
lives in the URL (`?action=`, `?resource=`, `?since=`, `?until=`), which makes
a filtered view a link you can send someone, and makes the 5s poll re-run with
the active filters instead of resetting to everything.

**Context.** `list_for_user/2`'s ordering, page size and five filters move
into a shared private `recent_query/2`; a new `_unsafe_list_events/1` runs the
same builder unscoped. The admin half of the page needed the filters too —
an admin sees every tenant's events, so before this the person looking at the
most events could filter the least. Sharing one builder is what keeps the
browser trail and `GET /api/audit` answering the same question the same way.
`_unsafe_list_recent/1` stays, now delegating, so the admin API and the pruner
tests are untouched.

`list_resource_types_for_user/1` and `_unsafe_list_resource_types/0` back the
resource-type select — the issue asked for a select of what is actually in the
trail rather than a free-text box, if cheap, and a `distinct` on an
append-only table is cheap.

**UI details worth a look in review:**

- "No events match these filters" and "No events yet" are distinct empty
  states. One means narrow differently; the other means nothing has happened.
- Time bounds are `datetime-local`, read as UTC because that is what the table
  renders. An unparseable value filters nothing **and stays in the box** —
  a half-typed date must not silently vanish while the results ignore it.
- A footer appears only when the page is full, pointing at `GET /api/audit`
  for anything past the newest 200.

**Out of scope, deliberately:** cursor pagination. The API needs it for
scripted export; the browser's use is "look at what just happened", and a
visible active-filter state plus a real empty state matter more there. Called
out in the issue.

## Verification

Tests cover filter-by-URL, form-change-pushes-to-URL, filters surviving the
tick, both empty states, the half-typed date, tenant-scoping of the
resource-type select, and the admin cross-tenant filtered view. Context-level
coverage for `_unsafe_list_events/1` includes the LIKE-metacharacter escape
(`?action=%` must match nothing, not everything) and inclusive time bounds.

Each of the three load-bearing tests was checked against the bug it targets:

| Reverted to | Test that fails |
|---|---|
| admin path calling `_unsafe_list_recent/1` | "an admin gets the same filters over the cross-tenant trail" |
| `:tick` reloading with empty filters | "filters survive the 5s tick" |
| non-admins calling `_unsafe_list_resource_types/0` | "the resource-type select offers only this tenant's types" |

`mix precommit` green: 2261 tests, 0 failures. One earlier run had a single
failure with `Postgrex.Protocol ... DBConnection.ConnectionError: client
exited` in the log — a sandbox-ownership flake, not reproducible; three
subsequent full runs are clean and the audit tests pass in isolation every
time.

The pre-existing `AuditLiveFormatTsTest` Mimic stub moved from
`list_recent_for_user/2` to `list_for_user/2`, since that is what the page
calls now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)