### PR TITLE
ui: land unverified logins on a waiting page, not the login form (#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ upgrade, is in
 
 ### Fixed
 
+- **An unverified login no longer looks like a failed one.** Signing in with
+  the right password but an unverified address issued a perfectly good session
+  and then bounced it to `/auth/login` with "Please verify your email address"
+  — so the user landed back on the form they had just used successfully, with
+  nothing to say their session was fine and the resend path nowhere in sight.
+  Worse, re-entering the password never helped: the verification link logs you
+  in by itself. Those sessions now land on `/auth/verify-pending`, a page that
+  names the address the link went to, offers a resend (same five-an-hour
+  budget, keyed by account rather than IP) and a sign-out for anyone who typed
+  the wrong address, and advances on its own the moment verification lands —
+  in another tab or on a phone — with no second login. It cannot be camped on:
+  a verified user hitting it is sent where they were going (#533)
+
 - **Secrets written through the API now leave the same audit trail as
   secrets written through the UI.** `POST/DELETE /api/environments/:id/secrets`,
   the vault equivalents, and the secret half of `POST /api/apply` recorded

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -144,8 +144,28 @@ defmodule Fountain.Accounts do
       |> Repo.update()
 
     with {:ok, verified} <- result do
-      {:ok, maybe_bootstrap_first_admin(verified)}
+      verified = maybe_bootstrap_first_admin(verified)
+      broadcast_verification(verified)
+      {:ok, verified}
     end
+  end
+
+  @doc """
+  PubSub topic carrying a user's verification transition.
+
+  `FountainWeb.VerifyPendingLive` subscribes to it so the waiting page in one
+  tab advances the moment the emailed link is clicked in another (#533).
+  """
+  def verification_topic(user_id), do: "user_verification:#{user_id}"
+
+  # After the first-admin bootstrap, so a subscriber that re-reads the user
+  # sees the settled role and not a half-applied verification.
+  defp broadcast_verification(%User{} = user) do
+    Phoenix.PubSub.broadcast(
+      Fountain.PubSub,
+      verification_topic(user.id),
+      {:email_verified, user.id}
+    )
   end
 
   # Advisory lock key for the first-admin bootstrap. Any stable bigint works;

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -20,7 +20,11 @@ defmodule FountainWeb.Live.Hooks do
   ## Hooks
 
   - `:require_authenticated_user` — halts and redirects to login if no
-    current_user is set, or if the user's email is unverified.
+    current_user is set, or to `/auth/verify-pending` if the user's email is
+    unverified.
+  - `:require_pending_verification` — the inverse gate, for the waiting page
+    itself: requires a session but tolerates an unverified one, and bounces
+    already-verified users to where they belong so the page can't be camped on.
   - `:require_active_subscription` — halts and redirects to `/account/billing`
     if the user's subscription is `past_due` or `canceled`. Must run after
     `:require_authenticated_user` (current_user must already be assigned).
@@ -50,11 +54,11 @@ defmodule FountainWeb.Live.Hooks do
       is_nil(user) ->
         {:halt, redirect(socket, to: ~p"/auth/login")}
 
+      # Not the login form (#533): the session is valid and the password was
+      # right, so bouncing them there reads as a failed login and invites a
+      # second, pointless sign-in. The waiting page explains the real state.
       is_nil(user.email_verified_at) ->
-        {:halt,
-         socket
-         |> put_flash(:error, "Please verify your email address before continuing.")
-         |> redirect(to: ~p"/auth/login")}
+        {:halt, redirect(socket, to: ~p"/auth/verify-pending")}
 
       true ->
         {:cont,
@@ -62,6 +66,24 @@ defmodule FountainWeb.Live.Hooks do
          |> FountainWeb.Audited.put_client_ip()
          |> track_current_path()
          |> mount_live_sidebar()}
+    end
+  end
+
+  def on_mount(:require_pending_verification, _params, session, socket) do
+    socket = mount_current_user(session, socket)
+    user = socket.assigns[:current_user]
+
+    cond do
+      is_nil(user) ->
+        {:halt, redirect(socket, to: ~p"/auth/login")}
+
+      is_nil(user.email_verified_at) ->
+        {:cont, socket}
+
+      # Already verified — nothing to wait for. Without this the page would be
+      # a dead end anyone could sit on after finishing verification.
+      true ->
+        {:halt, redirect(socket, to: verified_destination(user))}
     end
   end
 
@@ -103,6 +125,17 @@ defmodule FountainWeb.Live.Hooks do
         {:cont, socket}
     end
   end
+
+  @doc """
+  Where a verified user belongs: onboarding until it is finished, the
+  conversation list after.
+
+  Public so `FountainWeb.VerifyPendingLive` sends users to the same place
+  `:require_pending_verification` does — the page and the gate that guards it
+  must not disagree, or the two bounce off each other.
+  """
+  def verified_destination(%{onboarding_completed_at: nil}), do: ~p"/onboarding/step_1"
+  def verified_destination(_user), do: ~p"/conversations"
 
   # Mount current_user from session into socket assigns without hitting the
   # DB a second time if it was already assigned (e.g. from a previous hook).

--- a/apps/fountain/lib/fountain_web/live/verify_pending_live.ex
+++ b/apps/fountain/lib/fountain_web/live/verify_pending_live.ex
@@ -1,0 +1,161 @@
+defmodule FountainWeb.VerifyPendingLive do
+  @moduledoc """
+  The waiting room for a signed-in but unverified account (#533).
+
+  Before this page an unverified login was bounced to `/auth/login` with a
+  flash, which read as a failed sign-in even though the session was fine — and
+  re-entering the password never actually helped, because the emailed link logs
+  the user in itself.
+
+  ## Auto-advance
+
+  The page watches for verification landing elsewhere — the link opened in
+  another tab, or on a phone — and sends the user on without a second login:
+
+    * `Accounts.verify_email/1` broadcasts on `Accounts.verification_topic/1`,
+      which is instant; and
+    * a five-second poll backstops it, because the broadcast only crosses nodes
+      when BEAM clustering is actually configured (`DNS_CLUSTER_QUERY`), and a
+      page that silently fails to advance is the dead end this replaced.
+
+  Both paths re-read the user from the database rather than trusting the
+  message, so the redirect is never issued on a stale assign.
+  """
+
+  use FountainWeb, :live_view
+
+  alias Fountain.Accounts
+  alias Fountain.Workers.VerificationEmail
+  alias FountainWeb.Live.Hooks
+  alias FountainWeb.Plugs.RateLimit
+
+  @poll_interval_ms 5_000
+
+  # Same budget as the `resend_verification` bucket on
+  # `RegistrationController.resend`, keyed by user id rather than IP: on this
+  # page we know exactly who is asking, which is both a fairer key (one office
+  # NAT can't exhaust everyone's allowance) and a tighter one (a resend spammer
+  # can't reset it by changing address).
+  @resend_max 5
+  @resend_window_ms 3_600_000
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user = socket.assigns.current_user
+
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Fountain.PubSub, Accounts.verification_topic(user.id))
+      :timer.send_interval(@poll_interval_ms, self(), :check_verification)
+    end
+
+    socket =
+      socket
+      |> assign(:page_title, "Check your email")
+      |> assign(:resend, :idle)
+
+    # Re-checked after subscribing, not before: a verification landing in that
+    # gap would have broadcast to nobody, and the page would wait forever.
+    {:ok, advance_if_verified(socket)}
+  end
+
+  @impl true
+  def handle_info({:email_verified, _user_id}, socket) do
+    {:noreply, advance_if_verified(socket)}
+  end
+
+  def handle_info(:check_verification, socket) do
+    {:noreply, advance_if_verified(socket)}
+  end
+
+  @impl true
+  def handle_event("resend", _params, socket) do
+    user = socket.assigns.current_user
+    RateLimit.ensure_table()
+
+    case RateLimit.bump({"resend_verification", user.id}, %{
+           max: @resend_max,
+           window_ms: @resend_window_ms
+         }) do
+      :ok ->
+        VerificationEmail.enqueue(user)
+        {:noreply, assign(socket, :resend, :sent)}
+
+      {:limited, _retry_after_secs} ->
+        {:noreply, assign(socket, :resend, :limited)}
+    end
+  end
+
+  # A full-page redirect rather than push_navigate: the destination lives in a
+  # different live_session, which live navigation cannot cross.
+  defp advance_if_verified(socket) do
+    case Accounts.get_user(socket.assigns.current_user.id) do
+      %{email_verified_at: %DateTime{}} = user ->
+        redirect(socket, to: Hooks.verified_destination(user))
+
+      _ ->
+        socket
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-screen flex items-center justify-center bg-zinc-50 text-zinc-900 font-sans">
+      <div class="w-full max-w-sm bg-white rounded-lg shadow p-8 space-y-5 text-center">
+        <div class="flex justify-center">
+          <svg
+            class="w-8 h-8 animate-spin text-zinc-400"
+            viewBox="0 0 24 24"
+            fill="none"
+            aria-hidden="true"
+          >
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            />
+          </svg>
+        </div>
+
+        <div class="space-y-2">
+          <h1 class="text-xl font-semibold">Check your email</h1>
+          <p class="text-sm text-zinc-600">
+            We sent a verification link to
+            <span class="font-medium text-zinc-900">{@current_user.email}</span>. Open it and this
+            page will continue on its own — you're already signed in, so there's nothing else to
+            type here.
+          </p>
+          <p class="text-xs text-zinc-400">
+            Links expire after 24 hours. Nothing in your inbox? Check the spam folder.
+          </p>
+        </div>
+
+        <div :if={@resend == :sent} class="rounded bg-emerald-50 text-emerald-700 px-3 py-2 text-sm">
+          A fresh verification link is on its way.
+        </div>
+
+        <div :if={@resend == :limited} class="rounded bg-amber-50 text-amber-700 px-3 py-2 text-sm">
+          That's a lot of resends. Wait a little while before trying again.
+        </div>
+
+        <div class="space-y-2">
+          <button
+            type="button"
+            phx-click="resend"
+            class="w-full rounded-md bg-zinc-900 text-white py-2 text-sm font-medium hover:bg-zinc-800"
+          >
+            Resend verification email
+          </button>
+
+          <p class="text-xs text-zinc-400">
+            Signed up with the wrong address?
+            <.link href={~p"/auth/logout"} class="underline">Sign out</.link>
+            and start again.
+          </p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -362,6 +362,18 @@ defmodule FountainWeb.Router do
         TurnImageController,
         :show
 
+    # ── Unverified waiting room (#533) ──────────────────────────────────────────────────────
+    # Its own live_session because :require_pending_verification is the only
+    # gate that *tolerates* an unverified session — and bounces verified users
+    # out, so the page cannot be camped on. layout: false: the app chrome reads
+    # the sidebar assigns that only :require_authenticated_user sets, and an
+    # unverified account has nothing to show in it anyway.
+    live_session :verify_pending,
+      layout: false,
+      on_mount: [{FountainWeb.Live.Hooks, :require_pending_verification}] do
+      live "/auth/verify-pending", VerifyPendingLive, :index
+    end
+
     # ── Phase-3-billing: starting a conversation requires an active subscription ────────────
     # :require_active_subscription runs after :require_authenticated_user and
     # redirects to /account/billing on SubscriptionRequiredError. Only /new

--- a/apps/fountain/test/fountain_web/live/hooks_test.exs
+++ b/apps/fountain/test/fountain_web/live/hooks_test.exs
@@ -35,18 +35,57 @@ defmodule FountainWeb.Live.HooksTest do
   # ── :require_authenticated_user ─────────────────────────────────────────────
 
   describe ":require_authenticated_user hook" do
-    test "redirects unverified user to /auth/login with flash error", %{conn: conn} do
+    test "redirects unverified user to the waiting page, not the login form", %{conn: conn} do
       user = insert_user()
       # user has no email_verified_at — do NOT call verify_email
       conn = login_user(conn, user)
 
       assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/dashboard")
-      assert path =~ "/auth/login"
+      assert path == "/auth/verify-pending"
     end
 
     test "redirects unauthenticated user (no session) to /auth/login", %{conn: conn} do
       # No login — session has no user_id, so current_user is nil
       assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/dashboard")
+      assert path =~ "/auth/login"
+    end
+  end
+
+  # ── :require_pending_verification ───────────────────────────────────────────
+
+  describe ":require_pending_verification hook" do
+    test "lets an unverified user through to the waiting page", %{conn: conn} do
+      user = insert_user()
+      conn = login_user(conn, user)
+
+      {:ok, _lv, html} = live(conn, ~p"/auth/verify-pending")
+      assert html =~ "Check your email"
+    end
+
+    test "bounces a verified user to onboarding so the page can't be camped on", %{conn: conn} do
+      user = insert_verified_user()
+      conn = login_user(conn, user)
+
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/auth/verify-pending")
+      assert path == "/onboarding/step_1"
+    end
+
+    test "sends a verified, onboarded user to the conversation list", %{conn: conn} do
+      user = insert_verified_user()
+
+      {:ok, user} =
+        user
+        |> Ecto.Changeset.change(onboarding_completed_at: DateTime.utc_now(:second))
+        |> Repo.update()
+
+      conn = login_user(conn, user)
+
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/auth/verify-pending")
+      assert path == "/conversations"
+    end
+
+    test "redirects an unauthenticated visitor to login", %{conn: conn} do
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/auth/verify-pending")
       assert path =~ "/auth/login"
     end
   end
@@ -249,6 +288,49 @@ defmodule FountainWeb.Live.HooksTest do
         FountainWeb.Live.Hooks.on_mount(:require_admin, %{}, %{}, minimal_socket())
 
       assert socket.redirected == {:redirect, %{status: 302, to: "/auth/login"}}
+    end
+
+    test ":require_pending_verification halts with login redirect when current_user is nil" do
+      {:halt, socket} =
+        FountainWeb.Live.Hooks.on_mount(
+          :require_pending_verification,
+          %{},
+          %{},
+          minimal_socket()
+        )
+
+      assert socket.redirected == {:redirect, %{status: 302, to: "/auth/login"}}
+    end
+
+    # VerifyPendingLive re-checks in mount/3 as well, so going through the
+    # router cannot tell the two guards apart. Called directly, this pins the
+    # hook itself: the live_session must reject a verified user on its own.
+    test ":require_pending_verification halts for a user who is already verified" do
+      user = insert_verified_user()
+
+      socket =
+        struct(Phoenix.LiveView.Socket, %{
+          endpoint: FountainWeb.Endpoint,
+          assigns: %{__changed__: %{}, current_user: user}
+        })
+
+      {:halt, socket} =
+        FountainWeb.Live.Hooks.on_mount(:require_pending_verification, %{}, %{}, socket)
+
+      assert socket.redirected == {:redirect, %{status: 302, to: "/onboarding/step_1"}}
+    end
+
+    test ":require_pending_verification continues for a user who is not verified" do
+      user = insert_user()
+
+      socket =
+        struct(Phoenix.LiveView.Socket, %{
+          endpoint: FountainWeb.Endpoint,
+          assigns: %{__changed__: %{}, current_user: user}
+        })
+
+      assert {:cont, _socket} =
+               FountainWeb.Live.Hooks.on_mount(:require_pending_verification, %{}, %{}, socket)
     end
   end
 end

--- a/apps/fountain/test/fountain_web/live/verify_pending_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/verify_pending_live_test.exs
@@ -1,0 +1,116 @@
+defmodule FountainWeb.VerifyPendingLiveTest do
+  use FountainWeb.ConnCase, async: true
+  use Oban.Testing, repo: Fountain.Repo
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Accounts
+  alias Fountain.Repo
+  alias Fountain.Workers.VerificationEmail
+
+  setup %{conn: conn} do
+    user = insert_user()
+    %{conn: login_user(conn, user), user: user}
+  end
+
+  describe "the waiting page" do
+    test "names the address the link was sent to", %{conn: conn, user: user} do
+      {:ok, _lv, html} = live(conn, ~p"/auth/verify-pending")
+
+      assert html =~ "Check your email"
+      assert html =~ user.email
+    end
+
+    test "offers a way out for someone who used the wrong address", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/auth/verify-pending")
+
+      assert lv |> element("a[href='/auth/logout']") |> has_element?()
+    end
+  end
+
+  describe "auto-advance" do
+    test "verification elsewhere sends the page on without a second login", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, lv, _html} = live(conn, ~p"/auth/verify-pending")
+
+      # Stands in for the emailed link being clicked in another tab or on a
+      # phone: verify_email/1 is what every verification route ends up calling.
+      {:ok, _verified} = Accounts.verify_email(user)
+
+      assert_redirect(lv, "/onboarding/step_1")
+    end
+
+    test "an onboarded user is advanced to the conversation list", %{conn: conn, user: user} do
+      {:ok, user} =
+        user
+        |> Ecto.Changeset.change(onboarding_completed_at: DateTime.utc_now(:second))
+        |> Repo.update()
+
+      {:ok, lv, _html} = live(conn, ~p"/auth/verify-pending")
+
+      {:ok, _verified} = Accounts.verify_email(user)
+
+      assert_redirect(lv, "/conversations")
+    end
+
+    test "the poll advances even when the broadcast never arrives", %{conn: conn, user: user} do
+      {:ok, lv, _html} = live(conn, ~p"/auth/verify-pending")
+
+      # Stamp the column directly, bypassing verify_email/1 — this is the
+      # cross-node case where the PubSub message is emitted on another node
+      # that this one is not clustered with.
+      {:ok, _} =
+        user
+        |> Ecto.Changeset.change(email_verified_at: DateTime.utc_now(:second))
+        |> Repo.update()
+
+      send(lv.pid, :check_verification)
+
+      assert_redirect(lv, "/onboarding/step_1")
+    end
+
+    test "a broadcast that does not match the database does not advance", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, lv, _html} = live(conn, ~p"/auth/verify-pending")
+
+      # The message is a trigger to re-read, never the evidence itself.
+      Phoenix.PubSub.broadcast(
+        Fountain.PubSub,
+        Accounts.verification_topic(user.id),
+        {:email_verified, user.id}
+      )
+
+      assert render(lv) =~ "Check your email"
+    end
+  end
+
+  describe "resend" do
+    test "enqueues a fresh verification email and says so", %{conn: conn, user: user} do
+      {:ok, lv, _html} = live(conn, ~p"/auth/verify-pending")
+
+      html = lv |> element("button[phx-click='resend']") |> render_click()
+
+      assert html =~ "on its way"
+      assert_enqueued(worker: VerificationEmail, args: %{user_id: user.id})
+    end
+
+    test "refuses past the hourly budget instead of enqueueing forever", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/auth/verify-pending")
+
+      # The bucket allows 5 an hour, keyed by user id. Oban's own 60s
+      # uniqueness collapses the burst into a single job, so the count of jobs
+      # says nothing here — the refusal on the sixth click is the assertion.
+      for _ <- 1..5 do
+        html = lv |> element("button[phx-click='resend']") |> render_click()
+        assert html =~ "on its way"
+      end
+
+      html = lv |> element("button[phx-click='resend']") |> render_click()
+      assert html =~ "lot of resends"
+    end
+  end
+end


### PR DESCRIPTION
Closes #533.

## The problem

An unverified user who logged in with the **correct** password got a valid session cookie, was redirected toward onboarding, and was then immediately bounced by the `require_authenticated_user` LiveView hook back to `/auth/login` with *"Please verify your email address before continuing."*

It read as a failed login. They had just used that form successfully; nothing told them their session was fine; the resend path wasn't visible from where they landed. And re-entering the password never actually helped — `EmailVerificationController.confirm` sets its own session, so the second sign-in was always pointless theatre.

## What this does

Unverified sessions now land on **`/auth/verify-pending`** (`FountainWeb.VerifyPendingLive`), which:

- names the address the link went to, and says plainly that they're already signed in and have nothing left to type;
- **auto-advances** when verification lands — the link opened in another tab or on a phone — straight to onboarding (or `/conversations` if already onboarded), with no second login;
- **resends** on a button, same five-an-hour budget as `RegistrationController.resend`, keyed by account id rather than IP. On this page we know exactly who is asking, which is both fairer (one office NAT can't exhaust everyone's allowance) and tighter (a spammer can't reset it by changing address);
- **signs out**, for someone who registered with the wrong address.

### Auto-advance

`Accounts.verify_email/1` now broadcasts `{:email_verified, user_id}` on `Accounts.verification_topic/1` — instant, and it fires from every verification route because they all funnel through that one function (emailed link, `POST /api/auth/verify`, `Release.verify_email/1`, the `EMAIL_DELIVERY=none` auto-verify).

A five-second poll backstops it. The broadcast only crosses nodes when BEAM clustering is actually configured (`DNS_CLUSTER_QUERY`), and with multiple replicas a verification handled by another pod would otherwise never reach this page — a page that silently fails to advance is exactly the dead end this replaces.

Both paths **re-read the user from the database** rather than trusting the message, and `mount/3` subscribes *before* its first check, so a verification landing between the hook's read and the subscribe isn't lost.

### The gate

`:require_pending_verification` is the mirror of `:require_authenticated_user`: it requires a session but *tolerates* an unverified one, and redirects an already-verified user to where they were going — so the page can't be camped on. It gets its own `live_session` with `layout: false`, since the app chrome reads sidebar assigns only `:require_authenticated_user` sets.

`verified_destination/1` is shared between the hook and the LiveView deliberately: if the page and the gate guarding it disagreed, they'd bounce off each other.

## Deliberately not changed

- **`TenantSessionAuth` still doesn't check verification.** Unchanged by this issue, per its notes — but it means the verification gate lives entirely in the LiveView hook, so any future non-LiveView authenticated browser route bypasses it.
- **Post-registration still lands on `/auth/check-email`.** The issue asks for it to land on the pending page instead of the login form; it never went to the login form, and registration issues no session, which the pending page requires. Making it land there would mean issuing a session before email ownership is proven — a real change to the auth surface, and not one this issue asks for.
- API path is already correct (403 `email_unverified`, #314).

## Tests

`apps/fountain/test/fountain_web/live/verify_pending_live_test.exs` (new) and additions to `hooks_test.exs`: the redirect target, both auto-advance paths, a broadcast that disagrees with the database (must *not* advance), the resend budget, and the camping guard both through the router and as a direct `on_mount/4` call — the latter because the LiveView re-checks in `mount/3`, so a router-level test alone can't tell the two guards apart.

Each new assertion was verified by reverting the corresponding change and confirming it fails.

Full suite green (2249 tests), plus `compile --warnings-as-errors`, `format --check-formatted`, `credo --strict`, `sobelow`, and `dialyzer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)