### PR TITLE
api: turn images 406 on `Accept: image/*`, and were in no spec (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ upgrade, is in
   in another tab or on a phone — with no second login. It cannot be camped on:
   a verified user hitting it is sent where they were going (#533)
 
+- **Fetching a turn image over the API no longer fails when you ask for an
+  image.** `GET /api/conversations/:id/turns/:turn_id/images/:position`
+  returns PNG or JPEG bytes, but sat behind a JSON-only content-negotiation
+  pipeline, so a client sending `Accept: image/png` — the natural header for
+  the request — got `406 Not Acceptable` before the endpoint ran. It worked
+  only if you asked for `*/*`, which is why browsers never hit it. The
+  endpoint was also in no spec at all, while the `Turn` schema advertised
+  `image_count`: the API told you two images existed and documented no way to
+  reach them. Both fixed, and the endpoint is now in `/api/openapi.json` and
+  `docs/api.md` (#578)
+
 - **The `/api/auth/*` endpoints are now in the OpenAPI spec.** They never
   were: the spec is generated from the router, and a controller that does
   not declare operations is skipped in silence — so the published spec

--- a/apps/fountain/lib/fountain_web/controllers/turn_image_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/turn_image_controller.ex
@@ -1,14 +1,71 @@
 defmodule FountainWeb.TurnImageController do
-  @moduledoc false
+  @moduledoc """
+  Images attached to a turn, for the browser session
+  (`GET /conversations/:conversation_id/turns/:turn_id/images/:position`) and
+  for bearer tokens (`/api/conversations/...`, #578).
+
+  Both routes used to be one `:show` action, which caused two problems. The
+  bearer route sat inside the `:accepts_json` pipeline, so
+  `plug :accepts, ["json"]` refused `Accept: image/png` with 406 *before* the
+  action ran — an endpoint returning PNG bytes worked only if the caller did
+  not ask for an image. And a single action behind two routes cannot be given
+  an OpenAPI operation without also emitting the session-authenticated browser
+  route into the spec as a bearer endpoint, so turn images were in no spec at
+  all while `Turn.image_count` advertised them.
+
+  Split the way #528 split `AgentAvatarController`: `:show` for the browser,
+  `:api_show` for bearer tokens, one private serve path so the guards cannot
+  drift between them.
+  """
   use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Conversations
   alias Fountain.Conversations.TurnImage
+  alias FountainWeb.Schemas
+
+  tags(["Conversations"])
+
+  # Browser route: session-authenticated so <img> tags load without a token.
+  operation(:show, false)
+
+  def show(conn, %{"conversation_id" => conv_id, "turn_id" => turn_id, "position" => pos}) do
+    serve_image(conn, conv_id, turn_id, pos)
+  end
+
+  operation(:api_show,
+    summary: "Fetch an image attached to a turn",
+    description:
+      "The image bytes, with the stored media type. `position` is the " <>
+        "zero-based index into the turn's images; `image_count` on the turn " <>
+        "(from `GET /api/conversations/{id}/turns`) says how many there are. " <>
+        "404 covers every miss — unknown conversation, a turn belonging to a " <>
+        "different conversation, an absent position, and a stored media type " <>
+        "that is not an image — so this is not a probe for ids.",
+    parameters: [
+      conversation_id: [in: :path, type: :string, required: true],
+      turn_id: [in: :path, type: :string, required: true],
+      position: [
+        in: :path,
+        type: :integer,
+        required: true,
+        description: "Zero-based index into the turn's images."
+      ]
+    ],
+    responses: [
+      ok: {"Image bytes", "image/*", %OpenApiSpex.Schema{type: :string, format: :binary}},
+      not_found: {"No such image", "application/json", Schemas.Error}
+    ]
+  )
+
+  def api_show(conn, %{"conversation_id" => conv_id, "turn_id" => turn_id, "position" => pos}) do
+    serve_image(conn, conv_id, turn_id, pos)
+  end
 
   # sobelow_skip ["XSS.SendResp", "XSS.ContentType"] — media type is checked
   # against TurnImage.valid_media_types/0 and the response pins nosniff +
   # a sandboxing CSP precisely because the bytes are client-originated.
-  def show(conn, %{"conversation_id" => conv_id, "turn_id" => turn_id, "position" => pos_str}) do
+  defp serve_image(conn, conv_id, turn_id, pos_str) do
     user_id = conn.assigns.current_user.id
 
     with {position, ""} <- Integer.parse(pos_str),

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -284,21 +284,30 @@ defmodule FountainWeb.Router do
       get "/events", ConversationController, :events, as: :events
       post "/read", ConversationController, :read, as: :read
       get "/tree", ConversationController, :tree, as: :tree
-      get "/turns/:turn_id/images/:position", TurnImageController, :show, as: :turn_image
     end
   end
 
-  # Avatar bytes over a bearer token (#528). Outside the :accepts_json scope
-  # for the same reason the SSE route is: a client fetching an image sends
+  # Image bytes over a bearer token. Outside the :accepts_json scope for the
+  # same reason the SSE route is: a client fetching an image sends
   # `Accept: image/*`, which `plug :accepts, ["json"]` would refuse with 406
   # before the action ran. The JSON responses on the write paths are explicit,
   # so nothing here depends on negotiation.
+  #
+  # Avatars (#528) were written here from the start. Turn images were not —
+  # they sat in the :accepts_json conversations scope and 406'd on
+  # `Accept: image/png` until #578 moved them here, which is also what let
+  # them be specced: one action per route, so `:api_show` can carry an
+  # operation without dragging the browser route into the spec with it.
   scope "/api", FountainWeb do
     pipe_through :api
 
     get "/agents/:id/avatar", AgentAvatarController, :api_show
     put "/agents/:id/avatar", AgentAvatarController, :api_update
     delete "/agents/:id/avatar", AgentAvatarController, :api_delete
+
+    get "/conversations/:conversation_id/turns/:turn_id/images/:position",
+        TurnImageController,
+        :api_show
   end
 
   # Server-sent events. Same auth chain as the rest of /api, minus content

--- a/apps/fountain/test/fountain_web/api_spec_test.exs
+++ b/apps/fountain/test/fountain_web/api_spec_test.exs
@@ -54,11 +54,7 @@ defmodule FountainWeb.ApiSpecTest do
       {"/api/stripe/webhook", :post},
       # A browser-session route that happens to live under /api/ — CSRF-
       # protected, session-authenticated, and driven by the theme toggle.
-      {"/api/settings/theme", :patch},
-      # Raw image bytes. The one action serves both the bearer route and the
-      # browser route, so it cannot be specced without splitting it the way
-      # #528 split AgentAvatarController into :show and :api_show.
-      {"/api/conversations/{conversation_id}/turns/{turn_id}/images/{position}", :get}
+      {"/api/settings/theme", :patch}
     ]
 
     setup do

--- a/apps/fountain/test/fountain_web/controllers/turn_image_serve_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/turn_image_serve_test.exs
@@ -1,0 +1,140 @@
+defmodule FountainWeb.TurnImageServeTest do
+  @moduledoc """
+  Content negotiation and spec coverage on the turn-image routes (#578).
+
+  The bearer route lived in the `:accepts_json` pipeline, so
+  `plug :accepts, ["json"]` refused an image Accept header with 406 before the
+  action ran: an endpoint returning PNG bytes worked only for a client that
+  did not ask for an image. Browsers hid it on the session route because they
+  append `*/*` to the Accept header they send for `<img>`.
+
+  Tenant scoping and the serve-time media-type guard are covered in
+  `cross_tenant_isolation_test.exs`; these are about reaching the action at
+  all, and about the endpoint being discoverable once you do.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  @png <<137, 80, 78, 71>>
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    agent = insert_agent(user_id: user.id)
+    conv = insert_conversation(user_id: user.id, agent: agent)
+    turn = insert_turn(conv)
+
+    {:ok, _} =
+      Fountain.Conversations._unsafe_insert_turn_images(turn.id, [
+        %{media_type: "image/png", data: @png}
+      ])
+
+    %{conn: conn, user: user, key: raw_key, path: "/conversations/#{conv.id}/turns/#{turn.id}/images/0"}
+  end
+
+  describe "bearer route — Accept negotiation" do
+    # The regression. Pre-#578 this raised Phoenix.NotAcceptableError (406 in
+    # prod) from the :accepts_json pipeline, before the controller ran.
+    for accept <- ["image/png", "image/*", "image/avif,image/webp,image/*,*/*;q=0.8"] do
+      test "serves the bytes with Accept: #{accept}", %{conn: conn, key: key, path: path} do
+        conn =
+          conn
+          |> authed_with_key(key)
+          |> put_req_header("accept", unquote(accept))
+          |> get("/api" <> path)
+
+        assert response(conn, 200) == @png
+        assert Plug.Conn.get_resp_header(conn, "content-type") |> hd() =~ "image/png"
+      end
+    end
+
+    test "still serves with Accept: */* — the only header that worked before", %{
+      conn: conn,
+      key: key,
+      path: path
+    } do
+      conn =
+        conn
+        |> authed_with_key(key)
+        |> put_req_header("accept", "*/*")
+        |> get("/api" <> path)
+
+      assert response(conn, 200) == @png
+    end
+
+    test "keeps the nosniff and sandbox guards", %{conn: conn, key: key, path: path} do
+      conn =
+        conn
+        |> authed_with_key(key)
+        |> put_req_header("accept", "image/png")
+        |> get("/api" <> path)
+
+      assert response(conn, 200)
+      assert Plug.Conn.get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+
+      assert Plug.Conn.get_resp_header(conn, "content-security-policy") == [
+               "default-src 'none'; sandbox"
+             ]
+    end
+
+    test "an unauthenticated request is refused, not served", %{conn: conn, path: path} do
+      conn =
+        conn
+        |> put_req_header("accept", "image/png")
+        |> get("/api" <> path)
+
+      assert conn.status in [401, 403]
+    end
+  end
+
+  describe "browser route — unchanged" do
+    test "the session route still serves with a browser-shaped Accept header", %{
+      conn: conn,
+      user: user,
+      path: path
+    } do
+      conn =
+        conn
+        |> login_user(user)
+        |> put_req_header("accept", "image/avif,image/webp,image/apng,image/*,*/*;q=0.8")
+        |> get(path)
+
+      assert response(conn, 200) == @png
+    end
+
+    test "the session route is not reachable with only a bearer token", %{
+      conn: conn,
+      key: key,
+      path: path
+    } do
+      conn = conn |> authed_with_key(key) |> get(path)
+
+      # Session-authenticated: a bearer token is not a session, so this
+      # redirects to login rather than serving.
+      assert conn.status in [302, 401, 403]
+    end
+  end
+
+  describe "OpenAPI coverage" do
+    test "the bearer route is in the spec and the browser route is not" do
+      paths = FountainWeb.ApiSpec.spec().paths
+
+      assert %OpenApiSpex.Operation{} =
+               paths["/api/conversations/{conversation_id}/turns/{turn_id}/images/{position}"].get
+
+      refute Map.has_key?(
+               paths,
+               "/conversations/{conversation_id}/turns/{turn_id}/images/{position}"
+             )
+    end
+
+    test "the operation documents image bytes, not JSON" do
+      op =
+        FountainWeb.ApiSpec.spec().paths[
+          "/api/conversations/{conversation_id}/turns/{turn_id}/images/{position}"
+        ].get
+
+      assert Map.has_key?(op.responses[200].content, "image/*")
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -209,7 +209,10 @@ POST   /api/conversations/:id/terminate    # end the conversation and sandbox
 GET    /api/conversations/:id/turns
 GET    /api/conversations/:id/events       # log events as JSON (?streams=  ?after=  ?limit=)
 GET    /api/conversations/:id/stream       # SSE log stream (?streams=stdout,stderr,stage  ?wait=false)
+GET    /api/conversations/:id/turns/:turn_id/images/:position   # image bytes
 ```
+
+Turns carry `image_count`; the image endpoint takes a zero-based `position` into that count and returns the raw bytes with the stored media type. Anything that does not resolve — unknown conversation, a turn from a different conversation, an absent position, a stored media type that is not an image — is a `404`, so it is not a probe for ids.
 
 Conversation objects carry `title`, `turn_count`, `last_active_at`, `last_read_at` and a computed `unread` alongside the lifecycle fields. `unread` is true when `last_active_at` is later than `last_read_at` (and for a conversation never read); `POST /api/conversations/:id/read` clears it.
 


### PR DESCRIPTION
Closes #578. **Third in the stack** — base is `ui/572-audit-filters` (#575),
which is based on `api/571-auth-openapi-spec` (#573). Merge #573 → #575 → this;
GitHub retargets each as the one below lands.

Found while answering "what is actually impacted by the turn-image spec gap I
left out of #571" — the answer turned out to be more than a doc gap.

## 1. The endpoint 406s on the Accept header its own clients send

`GET /api/conversations/:id/turns/:turn_id/images/:position` returns PNG or
JPEG bytes and lived inside the `:accepts_json` pipeline, whose
`plug :accepts, ["json"]` rejects an image Accept header **before the action
runs**. Probed on `main`:

```
Accept: image/png  ->  Phoenix.NotAcceptableError   (406 in prod)
Accept: */*        ->  the bytes
```

The endpoint worked only for a client that did not ask for an image. Browsers
never hit it: they append `*/*` to the Accept header they send for `<img>`,
and the session route is HTML-pipelined anyway. So this only ever bit API
consumers — the exact audience #531 is about.

It is the trap #528 documented when it added avatars, whose route comment
reads:

> Outside the `:accepts_json` scope for the same reason the SSE route is: a
> client fetching an image sends `Accept: image/*`, which
> `plug :accepts, ["json"]` would refuse with 406 before the action ran.

Avatars were written outside `:accepts_json`. Turn images predate that and
never got the same treatment.

## 2. Same cause put it in no spec at all

One `:show` action served both the bearer route and the session route, and
`operation/2` attaches to the **action**, not the route — so declaring an
operation would also have emitted the session-authenticated browser path into
the spec as a bearer endpoint with a security scheme that does not apply to
it. Hence the explicit exception #571 left in `ApiSpecTest`.

Meanwhile the `Turn` schema advertises `image_count`, described as "Number of
images attached to this turn". The spec told a generated client two images
existed and described no endpoint to fetch them. It was absent from
`docs/api.md` too — the only mention of images there was as *input* on
conversation create.

## The fix, mirroring #528

- `:show` (browser, `operation(:show, false)`) split from `:api_show`
  (bearer, specced with an `image/*` response), with one private
  `serve_image/4` behind both so the tenant scoping, serve-time media-type
  re-check, `nosniff` and sandboxing CSP cannot drift apart.
- The bearer route moves out of the `:accepts_json` conversations scope into
  the `scope "/api"` where the avatar byte routes already live.
- The exception drops out of `ApiSpecTest`, so the router guard now covers
  this path. **Spec goes 60 → 61 paths.**

The `as: :turn_image` helper the old route defined was unused — the LiveView
builds the browser URL as a string literal.

## Verification

New `TurnImageServeTest`: bytes come back under `image/png`, `image/*` and a
real browser Accept header; `*/*` still works; `nosniff` and the sandbox CSP
survive; an unauthenticated call is refused rather than 406'd; the session
route is unchanged and still not reachable with a bearer token; and the spec
carries the bearer path with an `image/*` response but not the browser path.

Checked against the bug: reverting only the pipeline move fails exactly four
tests, all Accept-related — the `*/*`, browser-route and spec tests keep
passing, which is the isolation you want.

Existing tenant-scoping and serve-time media-type coverage in
`cross_tenant_isolation_test.exs` passes unchanged.

`mix precommit` exits 0: 2271 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)