### PR TITLE
auth: enforce email verification at the auth boundaries (#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ upgrade, is in
 
 ### Fixed
 
+- **Email verification is now enforced where identity is established, not at
+  each door.** #533 moved unverified logins onto a waiting page but left the
+  check inside the LiveView hook, so it held only because every entry point
+  remembered it — four of them on the API side alone. Two consequences were
+  real: every controller route in the session pipeline (theme, avatars, export
+  downloads, turn images, the credential POSTs) was reachable by an unverified
+  session, and the bearer-token plug never checked verification at all, so a
+  key minted before #314 closed `POST /api/auth/token` would still work
+  forever. `TenantSessionAuth` now redirects such sessions to
+  `/auth/verify-pending`, and `authenticate_api_key/1` refuses with 403
+  `email_unverified` — the same status and reason the token endpoint gives
+  when refusing to mint for that account. No key is affected in practice:
+  across 163 unverified accounts, zero API keys have ever been issued (#533)
+
 - **An unverified login no longer looks like a failed one.** Signing in with
   the right password but an unverified address issued a perfectly good session
   and then bounced it to `/auth/login` with "Please verify your email address"

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -611,7 +611,7 @@ defmodule Fountain.Accounts do
   401.
   """
   @spec get_user_by_api_key(String.t()) ::
-          {:ok, User.t()} | {:error, :revoked | :expired | :not_found}
+          {:ok, User.t()} | {:error, :revoked | :expired | :suspended | :unverified | :not_found}
   def get_user_by_api_key(raw_key) when is_binary(raw_key) do
     case authenticate_api_key(raw_key) do
       {:ok, user, _key} -> {:ok, user}
@@ -627,10 +627,11 @@ defmodule Fountain.Accounts do
   human who owns the tenant.
 
   Returns `{:ok, user, api_key}`, or
-  `{:error, :revoked | :expired | :suspended | :not_found}`.
+  `{:error, :revoked | :expired | :suspended | :unverified | :not_found}`.
   """
   @spec authenticate_api_key(String.t()) ::
-          {:ok, User.t(), ApiKey.t()} | {:error, :revoked | :expired | :suspended | :not_found}
+          {:ok, User.t(), ApiKey.t()}
+          | {:error, :revoked | :expired | :suspended | :unverified | :not_found}
   def authenticate_api_key(raw_key) when is_binary(raw_key) do
     key_hash = hash_key(raw_key)
 
@@ -651,6 +652,13 @@ defmodule Fountain.Accounts do
         cond do
           ApiKey.expired?(key) -> {:error, :expired}
           suspended?(key.user) -> {:error, :suspended}
+          # Asserted here rather than only where keys are minted (#533). Every
+          # minting path already refuses an unverified account, so this changes
+          # nothing for a key issued today — but that made four call sites the
+          # invariant depended on, and a fifth would have reopened the gap in
+          # silence. Keys predating #314, when `POST /api/auth/token` would mint
+          # for an unverified account, stop working here: that is the point.
+          is_nil(key.user.email_verified_at) -> {:error, :unverified}
           true -> {:ok, key.user, key}
         end
     end

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -118,6 +118,14 @@ defmodule FountainWeb.Live.Hooks do
       is_nil(user) ->
         {:halt, redirect(socket, to: ~p"/auth/login")}
 
+      # Not reachable today — the router always pairs this hook after
+      # :require_authenticated_user, which already refused. Checked anyway
+      # because this hook mounts current_user itself, so it is a complete
+      # gate on paper, and a future live_session using it alone would
+      # otherwise admit an unverified admin (#533).
+      is_nil(user.email_verified_at) ->
+        {:halt, redirect(socket, to: ~p"/auth/verify-pending")}
+
       user.role != "admin" ->
         {:halt, push_navigate(socket, to: ~p"/dashboard")}
 

--- a/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
+++ b/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
@@ -13,6 +13,10 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
 
       {"error": "API key has been revoked", "reason": "api_key_revoked"}
       {"error": "Invalid or missing API key", "reason": "api_key_invalid"}
+
+  An unverified account is refused with 403 and `email_unverified` (#533) —
+  the one non-401 here, because the key itself is fine and the account, not
+  the credential, is what needs fixing.
   """
 
   import Plug.Conn
@@ -44,6 +48,19 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
       # account exists; the response still doesn't say why it's unusable.
       {:error, :suspended} ->
         unauthorized(conn, "This account is currently unavailable", "account_unavailable")
+
+      # 403, and named: same status and same `reason` as POST /api/auth/token
+      # refusing to mint for this account, so a CLI holding a stale key reads
+      # the same answer it would get from asking for a new one. Nothing is
+      # leaked by being specific — the holder owns the key.
+      {:error, :unverified} ->
+        conn
+        |> put_status(:forbidden)
+        |> json(%{
+          error: "Verify your email address before using the API",
+          reason: "email_unverified"
+        })
+        |> halt()
 
       _ ->
         unauthorized(conn, "Invalid or missing API key", "api_key_invalid")

--- a/apps/fountain/lib/fountain_web/plugs/tenant_session_auth.ex
+++ b/apps/fountain/lib/fountain_web/plugs/tenant_session_auth.ex
@@ -5,7 +5,15 @@ defmodule FountainWeb.Plugs.TenantSessionAuth do
   password resets invalidate existing sessions), and sets
   `conn.assigns.current_user`.
 
-  Redirects to `/auth/login` if the session is absent or stale.
+  Redirects to `/auth/login` if the session is absent or stale, and to
+  `/auth/verify-pending` if the account has not verified its email.
+
+  That last check used to live only in the LiveView hook (#533), which left
+  every controller route in this pipeline — theme, avatars, export downloads,
+  turn images, the credential POSTs — reachable by an unverified session, and
+  made the gate something each new route had to remember rather than something
+  the pipeline guaranteed. `/auth/verify-pending` itself is deliberately
+  routed outside this pipeline; putting it back inside would loop.
   """
 
   import Plug.Conn
@@ -25,7 +33,13 @@ defmodule FountainWeb.Plugs.TenantSessionAuth do
          true <- is_integer(session_version),
          %Accounts.User{} = user <- Accounts.get_user(user_id),
          true <- user.session_version == session_version do
-      assign(conn, :current_user, user)
+      if is_nil(user.email_verified_at) do
+        conn
+        |> redirect(to: ~p"/auth/verify-pending")
+        |> halt()
+      else
+        assign(conn, :current_user, user)
+      end
     else
       _ ->
         conn

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -166,6 +166,24 @@ defmodule FountainWeb.Router do
     get "/confirm/:token", EmailVerificationController, :confirm
   end
 
+  # ── Unverified waiting room (#533) ────────────────────────────────────────────────────────────────
+  # Deliberately NOT behind :browser_authenticated. That plug now redirects
+  # unverified sessions here, so routing this page through it would make it
+  # redirect to itself. :require_pending_verification is the whole gate: it
+  # sends a session-less visitor to login, tolerates an unverified session —
+  # the only gate in the app that does — and bounces a verified one out so the
+  # page cannot be camped on. layout: false because the app chrome reads
+  # sidebar assigns only :require_authenticated_user sets.
+  scope "/", FountainWeb do
+    pipe_through :browser
+
+    live_session :verify_pending,
+      layout: false,
+      on_mount: [{FountainWeb.Live.Hooks, :require_pending_verification}] do
+      live "/auth/verify-pending", VerifyPendingLive, :index
+    end
+  end
+
   # Email-change confirmation (#448) — public like /users/confirm: the link
   # lands from an inbox, possibly in a browser with no session.
   scope "/account", FountainWeb do
@@ -361,18 +379,6 @@ defmodule FountainWeb.Router do
     get "/conversations/:conversation_id/turns/:turn_id/images/:position",
         TurnImageController,
         :show
-
-    # ── Unverified waiting room (#533) ──────────────────────────────────────────────────────
-    # Its own live_session because :require_pending_verification is the only
-    # gate that *tolerates* an unverified session — and bounces verified users
-    # out, so the page cannot be camped on. layout: false: the app chrome reads
-    # the sidebar assigns that only :require_authenticated_user sets, and an
-    # unverified account has nothing to show in it anyway.
-    live_session :verify_pending,
-      layout: false,
-      on_mount: [{FountainWeb.Live.Hooks, :require_pending_verification}] do
-      live "/auth/verify-pending", VerifyPendingLive, :index
-    end
 
     # ── Phase-3-billing: starting a conversation requires an active subscription ────────────
     # :require_active_subscription runs after :require_authenticated_user and

--- a/apps/fountain/test/fountain_web/live/hooks_test.exs
+++ b/apps/fountain/test/fountain_web/live/hooks_test.exs
@@ -320,6 +320,26 @@ defmodule FountainWeb.Live.HooksTest do
       assert socket.redirected == {:redirect, %{status: 302, to: "/onboarding/step_1"}}
     end
 
+    # The router pairs :require_admin after :require_authenticated_user, so
+    # this branch is unreachable through it. Called directly, because the hook
+    # mounts current_user itself and is therefore a gate in its own right.
+    test ":require_admin halts an unverified admin" do
+      user = insert_user(%{role: "admin"})
+      # Pinned: verification is checked before role, so this test would pass on
+      # a plain user too if the factory ever stopped honouring :role.
+      assert user.role == "admin"
+
+      socket =
+        struct(Phoenix.LiveView.Socket, %{
+          endpoint: FountainWeb.Endpoint,
+          assigns: %{__changed__: %{}, current_user: user}
+        })
+
+      {:halt, socket} = FountainWeb.Live.Hooks.on_mount(:require_admin, %{}, %{}, socket)
+
+      assert socket.redirected == {:redirect, %{status: 302, to: "/auth/verify-pending"}}
+    end
+
     test ":require_pending_verification continues for a user who is not verified" do
       user = insert_user()
 

--- a/apps/fountain/test/fountain_web/live/verify_pending_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/verify_pending_live_test.exs
@@ -26,6 +26,34 @@ defmodule FountainWeb.VerifyPendingLiveTest do
 
       assert lv |> element("a[href='/auth/logout']") |> has_element?()
     end
+
+    # The trap this route is shaped around: TenantSessionAuth sends unverified
+    # sessions here, so routing this page through that pipeline would make it
+    # redirect to itself forever. It is deliberately outside :browser_authenticated.
+    test "does not redirect to itself", %{conn: conn} do
+      assert {:ok, _lv, _html} = live(conn, ~p"/auth/verify-pending")
+    end
+
+    # Logout has to stay reachable without verification or the escape hatch
+    # above is decorative.
+    test "signing out works without being verified", %{conn: conn} do
+      conn = get(conn, ~p"/auth/logout")
+      assert redirected_to(conn) == "/auth/login"
+
+      # Asserted by replaying the dropped cookie rather than reading
+      # get_session/2, which still shows the old value — configure_session
+      # drop only takes effect when the response is written.
+      next = conn |> recycle() |> get(~p"/auth/verify-pending")
+      assert redirected_to(next) == "/auth/login"
+    end
+  end
+
+  describe "the controller pipeline" do
+    test "an unverified session is turned away from a session-authenticated route", %{conn: conn} do
+      conn = patch(conn, ~p"/api/settings/theme", %{"theme" => "dark"})
+
+      assert redirected_to(conn) == "/auth/verify-pending"
+    end
   end
 
   describe "auto-advance" do

--- a/apps/fountain/test/fountain_web/plugs/tenant_api_auth_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/tenant_api_auth_test.exs
@@ -66,6 +66,41 @@ defmodule FountainWeb.Plugs.TenantAPIAuthTest do
       assert body["reason"] == "api_key_revoked"
     end
 
+    # Every minting path refuses an unverified account, so a key in this state
+    # can only be a legacy one — minted before #314 closed
+    # `POST /api/auth/token`. insert_api_key/1 goes straight to the context,
+    # which is exactly how those keys came to exist.
+    test "returns 403 with email_unverified for a key held by an unverified account", %{
+      conn: conn
+    } do
+      user = insert_user()
+      {_record, raw_key} = insert_api_key(user)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> TenantAPIAuth.call([])
+
+      assert conn.halted
+      assert conn.status == 403
+      body = Jason.decode!(conn.resp_body)
+      assert body["reason"] == "email_unverified"
+    end
+
+    test "the same key works once the account verifies", %{conn: conn} do
+      user = insert_user()
+      {_record, raw_key} = insert_api_key(user)
+      {:ok, _verified} = Fountain.Accounts.verify_email(user)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> TenantAPIAuth.call([])
+
+      refute conn.halted
+      assert conn.assigns.current_user.id == user.id
+    end
+
     test "cross-tenant key does not authenticate another user", %{conn: conn} do
       user_a = insert_verified_user()
       user_b = insert_verified_user()

--- a/apps/fountain/test/fountain_web/plugs/tenant_session_auth_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/tenant_session_auth_test.exs
@@ -16,6 +16,19 @@ defmodule FountainWeb.Plugs.TenantSessionAuthTest do
       assert conn.assigns.current_user.id == user.id
     end
 
+    test "redirects an unverified session to the waiting page, not login", %{conn: conn} do
+      user = insert_user()
+
+      conn =
+        conn
+        |> login_user(user)
+        |> TenantSessionAuth.call([])
+
+      assert conn.halted
+      assert Phoenix.ConnTest.redirected_to(conn) == "/auth/verify-pending"
+      refute conn.assigns[:current_user]
+    end
+
     test "redirects to /auth/login when session is absent", %{conn: conn} do
       conn =
         conn


### PR DESCRIPTION
Follow-up to #577, from the review question it raised. Relates to #533.

## The problem

#577 fixed the *symptom* — unverified logins bouncing to the login form — but left the verification check where it already lived: inside the `require_authenticated_user` LiveView hook. That made it something each entry point has to remember rather than something the boundary guarantees.

It was correct only by accident. Two of those accidents were load-bearing:

- **`TenantSessionAuth` never checked verification.** Every controller route in the `:browser_authenticated` pipeline — theme, agent avatars, export downloads, turn images, the credential POSTs — was reachable by an unverified session, because the hook only guards LiveViews.
- **`TenantAPIAuth` never checked verification.** It validates that the key exists, isn't revoked, isn't expired, and the account isn't suspended. What actually closed the hole was that all four key-minting sites happen to refuse unverified accounts — an invariant spread across four call sites, where a fifth would reopen it in silence.

## What this does

Pushes the check down to the two places identity is actually established:

- `TenantSessionAuth` redirects an unverified session to `/auth/verify-pending`.
- `authenticate_api_key/1` returns `{:error, :unverified}`; `TenantAPIAuth` renders it as **403 `email_unverified`** — deliberately the same status and `reason` that `POST /api/auth/token` returns when refusing to mint a key for that same account, so a CLI holding a stale key reads one consistent answer rather than two different ones.

`:require_admin` gets the same check. It's unreachable today (the router always pairs it after `require_authenticated_user`), but it mounts `current_user` itself and therefore reads as a complete gate — a future `live_session` using it alone would admit an unverified admin. That is exactly the failure mode this PR exists to remove, so leaving it would have been inconsistent.

## The trap, and why a route moved

`/auth/verify-pending` moves out of `:browser_authenticated` into a plain `:browser` scope. That plug now redirects unverified sessions *to that page*, so leaving it inside the gated pipeline would make it **redirect to itself forever**. The `require_pending_verification` hook was always the whole gate there, so nothing is lost. Two tests pin it: one that the page doesn't redirect to itself, one that `/auth/logout` stays reachable unverified — otherwise the page's "Sign out" escape hatch is decorative.

## Is this breaking?

**No — verified against production, not assumed.** The population at risk is keys minted before #314 closed the token endpoint. There are none:

```
unverified_users | keys_ever_issued | keys_ever_used
             163 |                0 |              0
```

Every unverified account has zero API keys, revoked or otherwise. The cutoff this introduces has no one on the far side of it.

## Review

An independent review agent swept all routes in the pipeline and every identity-establishing surface. It found no route an unverified user legitimately needs, confirmed no background `fetch()`/`<img>` gets a confusing HTML redirect (the theme toggle renders only on gated pages and swallows errors anyway), and confirmed login/register/confirm/resend/reset/OAuth/logout all sit outside the new plug. It also confirmed there are no Phoenix Channels and no custom socket `connect/3`, so those aren't a third surface. `:require_admin` was its one real finding, fixed here; two `@spec`s that had gone stale are also corrected.

## Tests

New coverage in `tenant_api_auth_test.exs`, `tenant_session_auth_test.exs`, `hooks_test.exs`, and `verify_pending_live_test.exs`. Each new assertion was verified by reverting the corresponding change and confirming it fails.

**On the local suite:** it flakes, and not because of this branch — unmodified `main` fails the same way. Root cause is #576 (`admin_controller_test.exs` flipping global `:billing_enabled` while `async: true`). I've added detail there: a second mechanism the issue doesn't cover, where a user *created* during the window is written with `subscription_status: nil` permanently and then fails the gate long after the window closes. CI is the arbiter here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)