### PR TITLE
docs: unverified accounts can sign in — they just get nowhere (#533)

### DIFF
--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -22,7 +22,11 @@ defmodule Fountain.Release do
   Mark an account's email verified, without sending anything.
 
   The escape hatch for an instance whose mail provider is misconfigured or
-  broken — login is refused while `email_verified_at` is nil. Under
+  broken. While `email_verified_at` is nil the password still authenticates —
+  login is *not* refused, which is the part worth knowing when someone reports
+  "I can sign in but nothing works". The session is simply parked on
+  `/auth/verify-pending` and reaches nothing else, and the API refuses both to
+  mint a key and to accept one, with 403 `email_unverified` (#533). Under
   `EMAIL_DELIVERY=none` this is no longer part of first login: registration
   auto-verifies accounts there (ADR 0011). It remains for accounts created
   before mail broke, or before that mode was set.

--- a/apps/fountain/lib/fountain/workers/unverified_account_pruner.ex
+++ b/apps/fountain/lib/fountain/workers/unverified_account_pruner.ex
@@ -2,8 +2,9 @@ defmodule Fountain.Workers.UnverifiedAccountPruner do
   @moduledoc """
   Deletes accounts that registered and never verified their email (#258).
 
-  Unverified accounts cannot log in — `require_authenticated_user` halts them —
-  so after the grace period they are rows, not users. They are not free rows
+  An unverified account can authenticate but reaches nothing: the session is
+  held on `/auth/verify-pending`, and the API refuses to mint or accept a key
+  (#533). So after the grace period they are rows, not users. They are not free rows
   either: each carries a wrapped DEK, they distort every metric that counts
   `users`, and 158 of them were briefly mistaken for a 159-person legacy trial
   cohort (see `Fountain.Release.expire_legacy_trials/1`). The steady inflow is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ an error message.
 |---|---|---|---|
 | `REGISTRATION_ENABLED` | `true` | — | `false` closes signup entirely. An open instance on the public internet will be found |
 | `REGISTRATION_ALLOWED_EMAIL_DOMAINS` | any | — | Comma-separated list; signups outside these domains are refused. Empty means no restriction |
-| `UNVERIFIED_PRUNE_AFTER_DAYS` | `30` | — | Accounts that never verified their email are deleted after this many days — they cannot log in, so they are rows, not users. `0` disables the sweep |
+| `UNVERIFIED_PRUNE_AFTER_DAYS` | `30` | — | Accounts that never verified their email are deleted after this many days — they can sign in but reach nothing, so they are rows, not users. `0` disables the sweep |
 | `UNVERIFIED_PRUNE_EXEMPT` | — | — | Comma-separated email substrings never pruned (operator or test accounts that deliberately stay unverified) |
 | `FIRST_USER_ADMIN` | `false` | — | `true`: while the instance has no admin, the first account to become verified is promoted to admin, audit-recorded (ADR 0011). Leave off on a multi-tenant deployment — it hands admin to whoever verifies first |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -120,9 +120,11 @@ Failure modes that are real:
 
 Work down the chain:
 
-1. **Did the verification email go anywhere?** Login is refused until the
-   email is verified, and an instance with `EMAIL_DELIVERY=none` sends
-   nothing — that is the compose default. Verify by hand:
+1. **Did the verification email go anywhere?** Note the symptom: the password
+   is accepted and the session is real, but it never leaves the "check your
+   email" page, so this reads as a broken app rather than a refused login. An
+   instance with `EMAIL_DELIVERY=none` sends nothing — that is the compose
+   default. Verify by hand:
 
     ```bash
     docker compose exec app bin/fountain_server eval \


### PR DESCRIPTION
Follow-up to #577/#580. Docs and docstrings only — no behavior change.

## The stale claim

Four places asserted that login is refused while an address is unverified. That was true before #533, which made the password authenticate and issue a real session, then hold it on `/auth/verify-pending`. #580 then closed the API side, but the browser login still is not refused.

| Location | Said |
|---|---|
| `Release.verify_email/1` | "login is refused while `email_verified_at` is nil" |
| `UnverifiedAccountPruner` moduledoc | "Unverified accounts cannot log in — `require_authenticated_user` halts them" |
| `docs/operations.md` | "Login is refused until the email is verified" |
| `docs/configuration.md` | "they cannot log in, so they are rows, not users" |

The pruner's version was doubly stale — it also named `require_authenticated_user` as the mechanism, which stopped being the whole story once #580 moved the check into `TenantSessionAuth` and `authenticate_api_key/1`.

## Why this is worth a PR rather than a shrug

`docs/operations.md` sits under the heading **"Nobody can log in"**, and step 1 tells an operator to check whether verification mail is arriving — framed as diagnosing a *refused* login. That is a symptom they will never observe. What they will actually get is "I can sign in but the app is broken", which under the old wording does not match the runbook step that would have solved it.

That is the same failure the repo's own guidance about ADRs describing unbuilt behavior is aimed at: documentation that reads as authoritative and sends the reader looking for the wrong thing. Here it had the extra sting of appearing in the runbook for exactly this incident.

Scope note: you asked for the one docstring. Grepping for the claim turned up three more copies of it, so all four are fixed together — leaving behind three copies of a sentence I had just corrected seemed worse than the slightly wider diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
