### PR TITLE
audit: mint API keys through one audited context function (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ upgrade, is in
 
 ### Fixed
 
+- **Minting an API key always leaves an audit trail now, whichever door you
+  came through.** There are four ways to get a key, and `POST /api/auth/token`
+  — the one that exchanges a password for a full-scope key, and the most
+  attack-relevant of them — was the only one that minted silently, because it
+  runs on a public pipeline that carries no audit plug. Anyone auditing "who
+  issued a key and when" saw the UI and `POST /api/auth/api-keys` but not the
+  CLI login door. The audit moves into `Accounts.create_api_key/3`, which
+  every mint already goes through, so UI, API, CLI and the per-conversation
+  callback rotation are covered by construction and a future surface gets it
+  for free. Events carry the key's name, scopes and public prefix — enough to
+  match a trail row to a listed key — and never the key (#542)
+
 - **Email verification is now enforced where identity is established, not at
   each door.** #533 moved unverified logins onto a waiting page but left the
   check inside the LiveView hook, so it held only because every entry point

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -23,6 +23,7 @@ defmodule Fountain.Accounts do
   require Logger
   alias Fountain.Repo
   alias Fountain.Accounts.{User, ApiKey, UserDataKey, OauthIdentity}
+  alias Fountain.Audit
   alias Fountain.Crypto
 
   ## Users
@@ -552,6 +553,22 @@ defmodule Fountain.Accounts do
   The raw key is `"ftn_" <> 64 hex chars`. It is returned once and never stored.
   Only the SHA-256 hash and the first 8-character prefix are persisted.
 
+  Minting is audited here rather than by each caller. There are four ways to
+  get a key — the settings LiveView, `POST /api/auth/api-keys`, `POST
+  /api/auth/token` and the per-conversation callback rotation — and only the
+  first two used to leave a trail. `/api/auth/token` sits on `:api_public`, so
+  the pipeline's audit plug never saw it: the one path that exchanges a
+  password for a full-scope key was the only one that minted silently (#542).
+
+  Options:
+
+    * `:scopes` — defaults to `["full"]`
+    * `:expires_at` — defaults to no expiry
+    * `:actor` — who minted it, for the audit trail. Defaults to `"self"`;
+      pass `FountainWeb.Audited.attribution/2` from a web surface, or a
+      `"system:<worker>"` string from a background one.
+    * `:request_ip` — passed through to the audit event.
+
   Returns `{:ok, {%ApiKey{}, raw_key_string}}` or `{:error, changeset}`.
   """
   @spec create_api_key(binary(), String.t(), keyword()) ::
@@ -572,8 +589,29 @@ defmodule Fountain.Accounts do
     })
     |> Repo.insert()
     |> case do
-      {:ok, key} -> {:ok, {key, raw}}
-      {:error, cs} -> {:error, cs}
+      {:ok, key} ->
+        Audit.record(%{
+          user_id: user_id,
+          action: "api_key.created",
+          resource_type: "api_key",
+          resource_id: key.id,
+          actor: Keyword.get(opts, :actor, "self"),
+          request_ip: Keyword.get(opts, :request_ip),
+          # Name, scopes and prefix identify *which* key without being the
+          # key: the prefix is already stored in the clear and is what the
+          # settings UI shows, so it is the handle a reader can match a
+          # trail row against a listed key by.
+          metadata: %{
+            "name" => key.name,
+            "scopes" => key.scopes,
+            "key_prefix" => key.key_prefix
+          }
+        })
+
+        {:ok, {key, raw}}
+
+      {:error, cs} ->
+        {:error, cs}
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1379,7 +1379,12 @@ defmodule Fountain.Conversations.ConversationServer do
       expires_at:
         DateTime.utc_now()
         |> DateTime.add(callback_key_ttl_seconds(), :second)
-        |> DateTime.truncate(:second)
+        |> DateTime.truncate(:second),
+      # Minting a sprite credential is exactly the event the trail is for, and
+      # this is the one mint the account owner did not ask for by hand. Low
+      # volume by construction: rotation happens on fresh provision and on
+      # wake, not per turn.
+      actor: "system:conversation_server"
     ]
   end
 

--- a/apps/fountain/lib/fountain_web/audited.ex
+++ b/apps/fountain/lib/fountain_web/audited.ex
@@ -66,6 +66,31 @@ defmodule FountainWeb.Audited do
   end
 
   @doc """
+  The `:actor` / `:request_ip` pair for a context function that audits itself.
+
+      Accounts.create_api_key(user.id, name, Audited.attribution(conn))
+
+  `from_conn/4` and `from_socket/4` record on behalf of a web surface. This is
+  for the other direction: the mutation is audited inside the context (so UI,
+  API and system callers are covered alike) and the caller supplies only what
+  the context cannot know — who was on the other end of the request.
+
+  Pass overrides where the connection cannot reveal the actor. `POST
+  /api/auth/token` runs on the `:api_public` pipeline, so nothing has assigned
+  `:current_user` yet and derivation would report `"system"` for what is
+  plainly a CLI sign-in — the same caveat `from_conn/4` carries for login.
+  """
+  def attribution(conn_or_socket, overrides \\ [])
+
+  def attribution(%Plug.Conn{} = conn, overrides) do
+    Keyword.merge([actor: conn_actor(conn), request_ip: format_ip(conn.remote_ip)], overrides)
+  end
+
+  def attribution(%Phoenix.LiveView.Socket{} = socket, overrides) do
+    Keyword.merge([actor: "ui", request_ip: socket.assigns[:client_ip]], overrides)
+  end
+
+  @doc """
   Resolve the client address for a LiveView socket at mount.
 
   `get_connect_info/2` is only callable during mount, so the result is stashed

--- a/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
@@ -11,6 +11,7 @@ defmodule FountainWeb.ApiKeyController do
   use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Accounts
+  alias FountainWeb.Audited
   alias FountainWeb.Schemas
 
   tags(["Auth"])
@@ -54,7 +55,7 @@ defmodule FountainWeb.ApiKeyController do
   def create(conn, %{"name" => name}) when is_binary(name) and name != "" do
     user = conn.assigns.current_user
 
-    case Accounts.create_api_key(user.id, name) do
+    case Accounts.create_api_key(user.id, name, Audited.attribution(conn)) do
       {:ok, {key_record, raw_key}} ->
         conn
         |> put_status(:created)

--- a/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
@@ -10,6 +10,7 @@ defmodule FountainWeb.AuthTokenController do
   use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Accounts
+  alias FountainWeb.Audited
   alias FountainWeb.Schemas
 
   plug FountainWeb.Plugs.RateLimit,
@@ -57,7 +58,11 @@ defmodule FountainWeb.AuthTokenController do
       {:ok, user} ->
         name = "CLI login \u2014 #{DateTime.utc_now() |> DateTime.to_date()}"
 
-        {:ok, {api_key, raw_key}} = Accounts.create_api_key(user.id, name)
+        # `:api_public` has no auth plug, so nothing has assigned
+        # `:current_user` here and derivation would call this sign-in
+        # `"system"`. It is a CLI exchanging a password for a key.
+        {:ok, {api_key, raw_key}} =
+          Accounts.create_api_key(user.id, name, Audited.attribution(conn, actor: "api"))
 
         conn
         |> put_status(:created)

--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -19,13 +19,15 @@ defmodule FountainWeb.ApiKeysLive.Index do
 
   @impl true
   def handle_event("create_key", %{"label" => label}, socket) do
-    case Accounts.create_api_key(socket.assigns.user_id, label) do
+    # `create_api_key/3` records `api_key.created` itself now, so the
+    # `from_socket` call that used to live here would be a second row for one
+    # mint. All this surface still owes the trail is who was on the socket.
+    case Accounts.create_api_key(
+           socket.assigns.user_id,
+           label,
+           FountainWeb.Audited.attribution(socket)
+         ) do
       {:ok, {key, raw_token}} ->
-        FountainWeb.Audited.from_socket(socket, "api_key.created", "api_key",
-          resource_id: key.id,
-          metadata: %{"name" => key.name, "scopes" => key.scopes}
-        )
-
         {:noreply,
          socket
          |> assign(:keys, Accounts.list_api_keys(socket.assigns.user_id))

--- a/apps/fountain/test/fountain_web/audit_coverage_test.exs
+++ b/apps/fountain/test/fountain_web/audit_coverage_test.exs
@@ -27,6 +27,10 @@ defmodule FountainWeb.AuditCoverageTest do
     Enum.find(events_for(user_id), &(&1.action == action))
   end
 
+  defp created_events(user_id) do
+    Enum.filter(events_for(user_id), &(&1.action == "api_key.created"))
+  end
+
   describe "secret writes through the UI" do
     test "a vault secret write is recorded", %{conn: conn} do
       user = insert_verified_user()
@@ -383,6 +387,114 @@ defmodule FountainWeb.AuditCoverageTest do
       render_click(lv, "revoke", %{"id" => key_id})
 
       assert find_action(user.id, "api_key.revoked")
+    end
+  end
+
+  describe "API key minting is audited wherever it happens (#542)" do
+    test "POST /api/auth/token records the mint", %{conn: conn} do
+      # The gap this closes: the route lives on `:api_public`, which has no
+      # audit plug, so the one path that trades a password for a full-scope
+      # key was the only one of the four that minted with no trail.
+      user =
+        insert_verified_user(%{
+          "email" => "cli#{System.unique_integer([:positive])}@example.com",
+          "password" => "password123"
+        })
+
+      conn = post_json(conn, "/api/auth/token", %{email: user.email, password: "password123"})
+      %{"key_id" => key_id, "prefix" => prefix} = json_response(conn, 201)
+
+      assert [event] = created_events(user.id)
+      assert event.user_id == user.id
+      assert event.resource_type == "api_key"
+      assert event.resource_id == key_id
+      assert event.actor == "api"
+      assert event.metadata["scopes"] == ["full"]
+      assert event.metadata["key_prefix"] == prefix
+    end
+
+    test "POST /api/auth/token never records the key itself", %{conn: conn} do
+      user =
+        insert_verified_user(%{
+          "email" => "cli#{System.unique_integer([:positive])}@example.com",
+          "password" => "password123"
+        })
+
+      conn = post_json(conn, "/api/auth/token", %{email: user.email, password: "password123"})
+      %{"api_key" => raw_key} = json_response(conn, 201)
+
+      events = events_for(user.id)
+
+      # Guard the guard (#406): with no mint event at all the refute below
+      # would pass over an empty list and prove nothing.
+      assert Enum.any?(events, &(&1.action == "api_key.created"))
+
+      # The 8-character prefix is in the trail by design; the other 64
+      # characters are the credential and must not follow it into a second
+      # table.
+      for event <- events do
+        refute inspect(event) =~ raw_key
+      end
+    end
+
+    test "a rejected credential mints nothing and records nothing", %{conn: conn} do
+      user =
+        insert_verified_user(%{
+          "email" => "cli#{System.unique_integer([:positive])}@example.com",
+          "password" => "password123"
+        })
+
+      conn = post_json(conn, "/api/auth/token", %{email: user.email, password: "wrongpassword"})
+      assert json_response(conn, 401)
+
+      assert created_events(user.id) == []
+    end
+
+    test "POST /api/auth/api-keys records a semantic event, not just the request", %{conn: conn} do
+      user = insert_verified_user()
+      {_record, raw_key} = insert_api_key(user, "bootstrap")
+
+      # The factory mints through the same context function, so the bootstrap
+      # key is itself audited — this asserts on the one the request adds.
+      before = created_events(user.id)
+
+      conn
+      |> authed_with_key(raw_key)
+      |> post_json("/api/auth/api-keys", %{name: "CI pipeline"})
+      |> json_response(201)
+
+      assert [event] = created_events(user.id) -- before
+      assert event.actor == "api"
+      assert event.metadata["name"] == "CI pipeline"
+    end
+
+    test "one mint through the UI writes one row, not two", %{conn: conn} do
+      # `create_api_key/3` audits itself now; the LiveView's own `from_socket`
+      # call had to go with it or every UI mint would land twice.
+      user = insert_verified_user()
+
+      {:ok, lv, _html} = live(login_user(conn, user), ~p"/api-keys")
+      render_submit(lv, "create_key", %{"label" => "ci-deploy"})
+
+      assert [event] = created_events(user.id)
+      assert event.actor == "ui"
+      assert event.request_ip
+    end
+
+    test "a sprite callback key is attributed to the server, not the owner" do
+      user = insert_verified_user()
+
+      {:ok, {key, _raw}} =
+        Fountain.Accounts.create_api_key(
+          user.id,
+          "sprite:abc123",
+          Fountain.Conversations.ConversationServer.callback_api_key_opts()
+        )
+
+      assert [event] = created_events(user.id)
+      assert event.resource_id == key.id
+      assert event.actor == "system:conversation_server"
+      assert event.metadata["scopes"] == ["sprite"]
     end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
@@ -61,7 +61,9 @@ defmodule FountainWeb.ApiKeyControllerTest do
       user = insert_verified_user()
       {_record, raw_key} = insert_api_key(user)
 
-      stub(Fountain.Accounts, :create_api_key, fn _user_id, _name ->
+      # Arity 3: the controller passes `Audited.attribution/1` through so the
+      # context can attribute the mint it audits (#542).
+      stub(Fountain.Accounts, :create_api_key, fn _user_id, _name, _opts ->
         cs = %Ecto.Changeset{valid?: false, errors: [name: {"has already been taken", []}]}
         {:error, cs}
       end)

--- a/apps/fountain/test/fountain_web/controllers/audit_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/audit_controller_test.exs
@@ -150,8 +150,11 @@ defmodule FountainWeb.AuditControllerTest do
         (page1["data"] ++ page2["data"] ++ page3["data"])
         |> Enum.map(& &1["id"])
 
-      # Five distinct events, newest first, no repeats across pages.
-      assert length(ids) == 5
+      # Every event in the trail, newest first, no repeats across pages.
+      # Counted rather than hardcoded: the setup's own `insert_api_key` mints
+      # through `Accounts.create_api_key`, which audits itself since #542, so
+      # the trail is the five recorded above plus that mint.
+      assert length(ids) == length(Audit.list_recent_for_user(user.id, 100))
       assert ids == Enum.uniq(ids)
       assert ids == Enum.sort(ids, :desc)
       refute page3["meta"]["has_more"]

--- a/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
@@ -125,7 +125,9 @@ defmodule FountainWeb.ApiKeysLiveErrorTest do
     test "create_key shows flash error when Accounts.create_api_key returns error", %{conn: conn} do
       user = insert_verified_user()
 
-      stub(Accounts, :create_api_key, fn _user_id, _label ->
+      # Arity 3: the LiveView passes `Audited.attribution/1` through so the
+      # context can attribute the mint it audits (#542).
+      stub(Accounts, :create_api_key, fn _user_id, _label, _opts ->
         cs =
           %Fountain.Accounts.ApiKey{}
           |> Ecto.Changeset.change()


### PR DESCRIPTION
Closes #542. First child of #540.

## The gap

`POST /api/auth/token` sits on the `:api_public` pipeline, which carries no audit plug. So the one path that exchanges a password for a full-scope API key — the most attack-relevant of the four — was the only one that minted with no trail:

| Surface | Before | After |
|---|---|---|
| `POST /api/auth/token` | **nothing** | `api_key.created`, actor `api` |
| `POST /api/auth/api-keys` | `:api` plug's request log only | request log **+** `api_key.created` |
| Settings LiveView | `api_key.created` via `from_socket` | `api_key.created` from the context |
| Sprite callback rotation | nothing | `api_key.created`, actor `system:conversation_server` |

## The approach

Rather than bolt a fourth call site onto the third surface, the audit moves into `Accounts.create_api_key/3` — every mint already goes through it. This is the context-level pattern #540 converges the rest of the campaign on, prototyped here on the smallest surface that has one.

Callers supply only what the context cannot know: a new `FountainWeb.Audited.attribution/2` returns the `:actor` / `:request_ip` pair for a `Plug.Conn` or a LiveView socket. `/api/auth/token` overrides the actor to `"api"` — with no auth plug on `:api_public` nothing has assigned `:current_user`, and derivation would file a CLI sign-in under `"system"`. The same caveat `from_conn/4` already documents for login.

The LiveView's own `from_socket` call goes with it, or every UI mint would land twice.

Metadata carries name, scopes and the 8-character prefix — the handle that matches a trail row against a listed key — and never the key itself.

## Two consequences worth naming

- **API mints now write two rows.** The `:api` pipeline plug still logs `POST /api/auth/api-keys` + status alongside the semantic event. Deliberate: keeping the plug untouched means no route can silently lose coverage while the campaign is in flight. #552 decides its fate once the other contexts emit semantic events.
- **The factory audits now.** `insert_api_key` mints through the same function, so any test setting up a bearer key has an `api_key.created` row in its trail. One test was counting a hardcoded 5 events; it now counts the trail, which is what it meant. Two Mimic stubs moved from arity 2 to arity 3.

## Tests

Six new cases in `audit_coverage_test.exs`:

- `/api/auth/token` records the mint — user, key id, actor, scopes, prefix (the acceptance criterion)
- the raw key never reaches the trail, with a guard-the-guard assert so it can't pass vacuously
- a rejected credential mints nothing and records nothing
- `/api/auth/api-keys` records a semantic event, not just the request
- one UI mint writes **one** row, not two
- a sprite callback key is attributed to the server, not the owner

`mix precommit` exits 0 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)