### PR TITLE
audit: record resource CRUD in the contexts, not the callers (#543)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -16,5 +16,5 @@
   # position for the synthesized boolean pattern), so 1 is the tightest pin
   # available; the exact_compare arm carries a real {line, column}.
   {"lib/fountain/conversations/conversation_server.ex", :pattern_match, 1},
-  {"lib/fountain/conversations/conversation_server.ex", :exact_compare, {1339, 64}}
+  {"lib/fountain/conversations/conversation_server.ex", :exact_compare, {1341, 64}}
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ upgrade, is in
 
 ### Fixed
 
+- **Creating, changing or deleting an agent, environment or vault is audited
+  from the browser too.** These mutations were recorded when driven through
+  `/api`, because a blanket plug on that pipeline caught every write, and
+  recorded nothing at all when driven through the UI — the inverse of the
+  secrets gap fixed earlier, and backwards for the surface where most of this
+  work actually happens. Someone reviewing their own trail saw an account
+  where resources appeared and vanished with no explanation. The audit moves
+  into the context functions, so the UI, the API, the onboarding wizard and
+  `fountain apply` all leave the same record, and update events name the
+  fields that moved — never their values (#543)
+
 - **Minting an API key always leaves an audit trail now, whichever door you
   came through.** There are four ways to get a key, and `POST /api/auth/token`
   — the one that exchanges a password for a full-scope key, and the most

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -5,6 +5,7 @@ defmodule Fountain.Agents do
 
   alias Fountain.Agents.Agent
   alias Fountain.Agents.AgentAvatar
+  alias Fountain.Audit
   alias Fountain.Conversations.Conversation
   alias Fountain.Environments
   alias Fountain.Repo
@@ -97,18 +98,32 @@ defmodule Fountain.Agents do
     Repo.get_by(Agent, name: name, user_id: user_id)
   end
 
-  def create_agent(attrs) do
+  @doc """
+  Create an agent.
+
+  `opts` carries the audit attribution — `:actor` and `:request_ip`, from
+  `FountainWeb.Audited.attribution/2` on a web surface. Recording here rather
+  than at each caller is what makes the UI, the API, the onboarding wizard and
+  manifest apply all leave the same trail (#543).
+  """
+  def create_agent(attrs, opts \\ []) do
     %Agent{}
     |> Agent.changeset(attrs)
     |> validate_environment_owner()
     |> Repo.insert()
+    |> audited("agent.created", opts)
   end
 
-  def update_agent(%Agent{} = agent, attrs) do
-    agent
-    |> Agent.changeset(attrs)
-    |> validate_environment_owner()
+  @doc "Update an agent. See `create_agent/2` for `opts`."
+  def update_agent(%Agent{} = agent, attrs, opts \\ []) do
+    changeset =
+      agent
+      |> Agent.changeset(attrs)
+      |> validate_environment_owner()
+
+    changeset
     |> Repo.update()
+    |> audited("agent.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
   end
 
   # An agent may only reference an environment owned by the same tenant —
@@ -131,7 +146,9 @@ defmodule Fountain.Agents do
     end
   end
 
-  def delete_agent(%Agent{} = agent), do: Repo.delete(agent)
+  @doc "Delete an agent. See `create_agent/2` for `opts`."
+  def delete_agent(%Agent{} = agent, opts \\ []),
+    do: agent |> Repo.delete() |> audited("agent.deleted", opts)
 
   @doc """
   Upload or replace the avatar for an agent.
@@ -142,7 +159,7 @@ defmodule Fountain.Agents do
   *filename extension* matches even when the declared MIME type does not, so
   a crafted client can declare `text/html` with a `.png` name.
   """
-  def upload_avatar(%Agent{} = agent, data, media_type)
+  def upload_avatar(%Agent{} = agent, data, media_type, opts \\ [])
       when is_binary(data) and is_binary(media_type) do
     if Fountain.Images.valid_media_type?(media_type) do
       now = DateTime.utc_now() |> DateTime.truncate(:second)
@@ -158,13 +175,18 @@ defmodule Fountain.Agents do
         |> Ecto.Changeset.change(%{avatar_media_type: media_type})
         |> Repo.update!()
       end)
+      # Outside the transaction on purpose. `Audit.record/1` is best-effort by
+      # rescuing, but that guarantee does not hold inside a transaction: a
+      # failed insert there aborts the enclosing one, so a lost audit row
+      # would take the avatar write with it.
+      |> audited("agent.avatar.set", merge_metadata(opts, %{"media_type" => media_type}))
     else
       {:error, :invalid_media_type}
     end
   end
 
-  @doc "Remove the avatar for an agent."
-  def delete_avatar(%Agent{} = agent) do
+  @doc "Remove the avatar for an agent. See `create_agent/2` for `opts`."
+  def delete_avatar(%Agent{} = agent, opts \\ []) do
     Repo.transaction(fn ->
       Repo.delete_all(from(av in AgentAvatar, where: av.agent_id == ^agent.id))
 
@@ -172,6 +194,21 @@ defmodule Fountain.Agents do
       |> Ecto.Changeset.change(%{avatar_media_type: nil})
       |> Repo.update!()
     end)
+    |> audited("agent.avatar.removed", opts)
+  end
+
+  # Audits a successful mutation and passes the result through untouched, so a
+  # context function stays a one-liner and the failure case cannot accidentally
+  # record a change that did not happen.
+  defp audited({:ok, %Agent{} = agent} = ok, action, opts) do
+    Audit.record_resource(action, "agent", agent, opts)
+    ok
+  end
+
+  defp audited(other, _action, _opts), do: other
+
+  defp merge_metadata(opts, extra) do
+    Keyword.update(opts, :metadata, extra, &Map.merge(&1, extra))
   end
 
   @doc "Fetch the raw avatar blob for an agent. Returns nil if none uploaded."

--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -55,6 +55,52 @@ defmodule Fountain.Audit do
   end
 
   @doc """
+  Record a mutation of an owned resource, from inside the context that made it.
+
+      Audit.record_resource("agent.created", "agent", agent, opts)
+
+  Auditing used to depend on which door a mutation came through: the `:api`
+  pipeline plug covered every write, and the browser surface covered whatever
+  its LiveView remembered to record. Resource CRUD landed on the wrong side of
+  that — audited via `/api`, silent via the UI (#543). Recording inside the
+  context covers UI, API, the onboarding wizard, manifest apply and any future
+  caller from one place.
+
+  The resource supplies `user_id`, `id` and `name`; the caller supplies
+  `:actor` and `:request_ip` (see `FountainWeb.Audited.attribution/2`) and any
+  extra `:metadata`. Values are never recorded — only which fields moved — so
+  this cannot become a second copy of anything a resource holds.
+  """
+  @spec record_resource(String.t(), String.t(), struct(), keyword()) ::
+          {:ok, Event.t()} | {:error, term()}
+  def record_resource(action, resource_type, resource, opts \\ []) do
+    record(%{
+      user_id: Map.get(resource, :user_id),
+      action: action,
+      resource_type: resource_type,
+      resource_id: Map.get(resource, :id),
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata:
+        %{"name" => Map.get(resource, :name)}
+        |> Map.merge(Keyword.get(opts, :metadata, %{}))
+    })
+  end
+
+  @doc """
+  The names of the fields a changeset actually moves, sorted, as metadata.
+
+  "What changed" is the whole value of an update event — an `agent.updated`
+  row that does not say which fields moved is barely more than a timestamp.
+  Names only: field *values* are the tenant's data, and the audit trail is
+  not a place to keep a second copy of it.
+  """
+  @spec changed_fields(Ecto.Changeset.t()) :: map()
+  def changed_fields(%Ecto.Changeset{changes: changes}) do
+    %{"changed" => changes |> Map.keys() |> Enum.map(&to_string/1) |> Enum.sort()}
+  end
+
+  @doc """
   Record an administrative action taken against another user.
 
   Separate from `record/1` because these need both an actor and a target, which

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -601,7 +601,9 @@ defmodule Fountain.Conversations.ConversationServer do
         })
 
         # Clear the stale checkpoint so future runs don't keep retrying.
-        Fountain.Environments.update_environment(env, %{"checkpoint_id" => nil})
+        Fountain.Environments.update_environment(env, %{"checkpoint_id" => nil},
+          actor: "system:conversation_server"
+        )
         :cold
     end
   end

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -111,9 +111,11 @@ defmodule Fountain.Conversations.Provisioning do
 
           if is_binary(checkpoint_id) and checkpoint_id != "" do
             {:ok, _} =
-              Fountain.Environments.update_environment(env, %{
-                "checkpoint_id" => checkpoint_id
-              })
+              Fountain.Environments.update_environment(
+                env,
+                %{"checkpoint_id" => checkpoint_id},
+                actor: "system:provisioning"
+              )
 
             {{:ok, checkpoint_id}, %{outcome: :ok, checkpoint_id: checkpoint_id}}
           else

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -4,6 +4,7 @@ defmodule Fountain.Environments do
   import Ecto.Query, only: [from: 2]
 
   alias Fountain.Agents.Agent
+  alias Fountain.Audit
   alias Fountain.Environments.{Environment, Secret}
   alias Fountain.Repo
 
@@ -106,19 +107,55 @@ defmodule Fountain.Environments do
     Repo.get_by(Environment, name: name, user_id: user_id)
   end
 
-  def create_environment(attrs) do
+  @doc """
+  Create an environment.
+
+  `opts` carries the audit attribution — `:actor` and `:request_ip`, from
+  `FountainWeb.Audited.attribution/2` on a web surface. Recording here rather
+  than at each caller is what makes the UI, the API, the onboarding wizard and
+  manifest apply all leave the same trail (#543).
+  """
+  def create_environment(attrs, opts \\ []) do
     %Environment{}
     |> Environment.changeset(attrs)
     |> Repo.insert()
+    |> audited("environment.created", opts)
   end
 
-  def update_environment(%Environment{} = env, attrs) do
-    env
-    |> Environment.changeset(attrs)
+  @doc """
+  Update an environment. See `create_environment/2` for `opts`.
+
+  The checkpoint writers in `ConversationServer` and `Provisioning` come
+  through here too, with a `system:` actor. Those rows are worth keeping: a
+  checkpoint pointer moving under the tenant is exactly what someone
+  debugging a cold provision needs to see, and the changed-field list says
+  plainly that nothing the tenant configured was touched.
+  """
+  def update_environment(%Environment{} = env, attrs, opts \\ []) do
+    changeset = Environment.changeset(env, attrs)
+
+    changeset
     |> Repo.update()
+    |> audited("environment.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
   end
 
-  def delete_environment(%Environment{} = env), do: Repo.delete(env)
+  @doc "Delete an environment. See `create_environment/2` for `opts`."
+  def delete_environment(%Environment{} = env, opts \\ []),
+    do: env |> Repo.delete() |> audited("environment.deleted", opts)
+
+  # See the note in `Fountain.Agents.audited/3`: this runs outside any
+  # enclosing transaction, because best-effort audit recording is only
+  # best-effort outside one.
+  defp audited({:ok, %Environment{} = env} = ok, action, opts) do
+    Audit.record_resource(action, "environment", env, opts)
+    ok
+  end
+
+  defp audited(other, _action, _opts), do: other
+
+  defp merge_metadata(opts, extra) do
+    Keyword.update(opts, :metadata, extra, &Map.merge(&1, extra))
+  end
 
   # ── secrets ───────────────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -34,7 +34,8 @@ defmodule Fountain.Manifest do
   (nil for errors and for kinds that carry no secrets). Secret values are
   never echoed back.
   """
-  def apply_manifest(user_id, resources) when is_binary(user_id) and is_list(resources) do
+  def apply_manifest(user_id, resources, opts \\ [])
+      when is_binary(user_id) and is_list(resources) do
     {valid, invalid} = Enum.split_with(resources, &valid_resource?/1)
     groups = Enum.group_by(valid, & &1["kind"])
     envs = Map.get(groups, "Environment", [])
@@ -45,7 +46,7 @@ defmodule Fountain.Manifest do
 
     {env_results, env_id_by_name} =
       Enum.map_reduce(envs, %{}, fn res, acc ->
-        case apply_environment(user_id, res, dek) do
+        case apply_environment(user_id, res, dek, opts) do
           {result, nil} -> {result, acc}
           {result, env} -> {result, Map.put(acc, env.name, env.id)}
         end
@@ -53,8 +54,8 @@ defmodule Fountain.Manifest do
 
     results =
       env_results ++
-        Enum.map(vaults, &apply_vault(user_id, &1, dek)) ++
-        Enum.map(agents, &apply_agent(user_id, &1, env_id_by_name)) ++
+        Enum.map(vaults, &apply_vault(user_id, &1, dek, opts)) ++
+        Enum.map(agents, &apply_agent(user_id, &1, env_id_by_name, opts)) ++
         Enum.map(invalid, &invalid_result/1)
 
     {:ok, results}
@@ -62,13 +63,17 @@ defmodule Fountain.Manifest do
 
   # ── per-kind reconciliation ───────────────────────────────────────────────
 
-  defp apply_environment(user_id, %{"name" => name} = res, dek) do
+  defp apply_environment(user_id, %{"name" => name} = res, dek, opts) do
     {attrs, secrets} = split_spec(res, name)
 
     outcome =
       case Environments.get_environment_by_name(name, user_id) do
-        nil -> {:created, Environments.create_environment(Map.put(attrs, "user_id", user_id))}
-        env -> {:updated, Environments.update_environment(env, attrs)}
+        nil ->
+          {:created,
+           Environments.create_environment(Map.put(attrs, "user_id", user_id), opts)}
+
+        env ->
+          {:updated, Environments.update_environment(env, attrs, opts)}
       end
 
     case outcome do
@@ -81,13 +86,13 @@ defmodule Fountain.Manifest do
     end
   end
 
-  defp apply_vault(user_id, %{"name" => name} = res, dek) do
+  defp apply_vault(user_id, %{"name" => name} = res, dek, opts) do
     {attrs, secrets} = split_spec(res, name)
 
     outcome =
       case Vaults.get_vault_by_name(name, user_id) do
-        nil -> {:created, Vaults.create_vault(Map.put(attrs, "user_id", user_id))}
-        vault -> {:updated, Vaults.update_vault(vault, attrs)}
+        nil -> {:created, Vaults.create_vault(Map.put(attrs, "user_id", user_id), opts)}
+        vault -> {:updated, Vaults.update_vault(vault, attrs, opts)}
       end
 
     case outcome do
@@ -100,7 +105,7 @@ defmodule Fountain.Manifest do
     end
   end
 
-  defp apply_agent(user_id, %{"name" => name} = res, env_id_by_name) do
+  defp apply_agent(user_id, %{"name" => name} = res, env_id_by_name, opts) do
     {attrs, _secrets} = split_spec(res, name)
     {env_ref, attrs} = Map.pop(attrs, "environment")
 
@@ -110,8 +115,8 @@ defmodule Fountain.Manifest do
 
         outcome =
           case Agents.get_agent_by_name(name, user_id) do
-            nil -> {:created, Agents.create_agent(Map.put(attrs, "user_id", user_id))}
-            agent -> {:updated, Agents.update_agent(agent, attrs)}
+            nil -> {:created, Agents.create_agent(Map.put(attrs, "user_id", user_id), opts)}
+            agent -> {:updated, Agents.update_agent(agent, attrs, opts)}
           end
 
         case outcome do

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -7,6 +7,7 @@ defmodule Fountain.Vaults do
 
   import Ecto.Query, only: [from: 2]
 
+  alias Fountain.Audit
   alias Fountain.Repo
   alias Fountain.Vaults.{Vault, VaultSecret}
 
@@ -89,19 +90,53 @@ defmodule Fountain.Vaults do
     Repo.get_by(Vault, name: name, user_id: user_id)
   end
 
-  def create_vault(attrs) do
+  @doc """
+  Create a vault.
+
+  `opts` carries the audit attribution — `:actor` and `:request_ip`, from
+  `FountainWeb.Audited.attribution/2` on a web surface. Recording here rather
+  than at each caller is what makes the UI, the API and manifest apply all
+  leave the same trail (#543).
+  """
+  def create_vault(attrs, opts \\ []) do
     %Vault{}
     |> Vault.changeset(attrs)
     |> Repo.insert()
+    |> audited("vault.created", opts)
   end
 
-  def update_vault(%Vault{} = vault, attrs) do
-    vault
-    |> Vault.changeset(attrs)
+  @doc "Update a vault. See `create_vault/2` for `opts`."
+  def update_vault(%Vault{} = vault, attrs, opts \\ []) do
+    changeset = Vault.changeset(vault, attrs)
+
+    changeset
     |> Repo.update()
+    |> audited("vault.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
   end
 
-  def delete_vault(%Vault{} = vault), do: Repo.delete(vault)
+  @doc """
+  Delete a vault. See `create_vault/2` for `opts`.
+
+  The secrets inside go with it by cascade, and the trail already carries a
+  `vault.secret.write` for each one that was ever set — so a single
+  `vault.deleted` row is enough to explain their disappearance.
+  """
+  def delete_vault(%Vault{} = vault, opts \\ []),
+    do: vault |> Repo.delete() |> audited("vault.deleted", opts)
+
+  # See the note in `Fountain.Agents.audited/3`: this runs outside any
+  # enclosing transaction, because best-effort audit recording is only
+  # best-effort outside one.
+  defp audited({:ok, %Vault{} = vault} = ok, action, opts) do
+    Audit.record_resource(action, "vault", vault, opts)
+    ok
+  end
+
+  defp audited(other, _action, _opts), do: other
+
+  defp merge_metadata(opts, extra) do
+    Keyword.update(opts, :metadata, extra, &Map.merge(&1, extra))
+  end
 
   # ── secrets ───────────────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
@@ -17,6 +17,7 @@ defmodule FountainWeb.AgentAvatarController do
   use OpenApiSpex.ControllerSpecs
 
   alias Fountain.{Agents, Images}
+  alias FountainWeb.Audited
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
@@ -78,7 +79,7 @@ defmodule FountainWeb.AgentAvatarController do
 
     with %_{} = agent <- fetch_agent(id, user.id),
          {:ok, data, media_type, conn} <- read_image(conn, params),
-         {:ok, _} <- Agents.upload_avatar(agent, data, media_type) do
+         {:ok, _} <- Agents.upload_avatar(agent, data, media_type, Audited.attribution(conn)) do
       # The agent is what the caller cares about after the write — it now
       # carries avatar_media_type, which is how a client knows one exists.
       #
@@ -130,7 +131,7 @@ defmodule FountainWeb.AgentAvatarController do
       agent ->
         # Idempotent: clearing an absent avatar is a no-op, not a 404. The
         # resource being addressed is the agent, and it exists.
-        {:ok, _} = Agents.delete_avatar(agent)
+        {:ok, _} = Agents.delete_avatar(agent, Audited.attribution(conn))
         send_resp(conn, :no_content, "")
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
@@ -5,6 +5,7 @@ defmodule FountainWeb.AgentController do
 
   alias Fountain.Agents
   alias Fountain.Agents.Agent
+  alias FountainWeb.Audited
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
@@ -116,7 +117,7 @@ defmodule FountainWeb.AgentController do
     # client-supplied user_id to prevent owner spoofing.
     attrs = Map.put(params, "user_id", user.id)
 
-    with {:ok, %Agent{} = agent} <- Agents.create_agent(attrs) do
+    with {:ok, %Agent{} = agent} <- Agents.create_agent(attrs, Audited.attribution(conn)) do
       conn
       |> put_status(:created)
       |> render(:show, agent: Agents.get_agent_with_counts(agent.id, user.id))
@@ -145,7 +146,7 @@ defmodule FountainWeb.AgentController do
         {:error, :not_found}
 
       agent ->
-        with {:ok, agent} <- Agents.update_agent(agent, attrs) do
+        with {:ok, agent} <- Agents.update_agent(agent, attrs, Audited.attribution(conn)) do
           render(conn, :show, agent: Agents.get_agent_with_counts(agent.id, user.id))
         end
     end
@@ -168,7 +169,7 @@ defmodule FountainWeb.AgentController do
         {:error, :not_found}
 
       agent ->
-        {:ok, _} = Agents.delete_agent(agent)
+        {:ok, _} = Agents.delete_agent(agent, Audited.attribution(conn))
         send_resp(conn, :no_content, "")
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -31,7 +31,7 @@ defmodule FountainWeb.ApplyController do
   def create(conn, %{"resources" => resources}) do
     user = conn.assigns.current_user
 
-    with {:ok, results} <- Manifest.apply_manifest(user.id, resources) do
+    with {:ok, results} <- Manifest.apply_manifest(user.id, resources, Audited.attribution(conn)) do
       audit_secret_writes(conn, results)
       render(conn, :create, results: results)
     end

--- a/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
@@ -5,6 +5,7 @@ defmodule FountainWeb.EnvironmentController do
 
   alias Fountain.Environments
   alias Fountain.Environments.Environment
+  alias FountainWeb.Audited
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
@@ -56,7 +57,7 @@ defmodule FountainWeb.EnvironmentController do
     user = conn.assigns.current_user
     attrs = Map.put(params, "user_id", user.id)
 
-    with {:ok, %Environment{} = env} <- Environments.create_environment(attrs) do
+    with {:ok, %Environment{} = env} <- Environments.create_environment(attrs, Audited.attribution(conn)) do
       conn
       |> put_status(:created)
       |> render(:show, environment: Environments.get_environment_with_counts(env.id, user.id))
@@ -85,7 +86,7 @@ defmodule FountainWeb.EnvironmentController do
         {:error, :not_found}
 
       env ->
-        with {:ok, env} <- Environments.update_environment(env, attrs) do
+        with {:ok, env} <- Environments.update_environment(env, attrs, Audited.attribution(conn)) do
           # Re-read for the counts: a response that advertises secret_count and
           # agent_count must not report the struct defaults after a write.
           render(conn, :show, environment: Environments.get_environment_with_counts(env.id, user.id))
@@ -110,7 +111,7 @@ defmodule FountainWeb.EnvironmentController do
         {:error, :not_found}
 
       env ->
-        {:ok, _} = Environments.delete_environment(env)
+        {:ok, _} = Environments.delete_environment(env, Audited.attribution(conn))
         send_resp(conn, :no_content, "")
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
@@ -5,6 +5,7 @@ defmodule FountainWeb.VaultController do
 
   alias Fountain.Vaults
   alias Fountain.Vaults.Vault
+  alias FountainWeb.Audited
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
@@ -56,7 +57,7 @@ defmodule FountainWeb.VaultController do
     user = conn.assigns.current_user
     attrs = Map.put(params, "user_id", user.id)
 
-    with {:ok, %Vault{} = vault} <- Vaults.create_vault(attrs) do
+    with {:ok, %Vault{} = vault} <- Vaults.create_vault(attrs, Audited.attribution(conn)) do
       conn
       |> put_status(:created)
       |> render(:show, vault: Vaults.get_vault_with_counts(vault.id, user.id))
@@ -84,7 +85,7 @@ defmodule FountainWeb.VaultController do
         {:error, :not_found}
 
       vault ->
-        with {:ok, vault} <- Vaults.update_vault(vault, attrs) do
+        with {:ok, vault} <- Vaults.update_vault(vault, attrs, Audited.attribution(conn)) do
           # Re-read for the counts: a response that advertises secret_count
           # must not report the struct default after a write.
           render(conn, :show, vault: Vaults.get_vault_with_counts(vault.id, user.id))
@@ -109,7 +110,7 @@ defmodule FountainWeb.VaultController do
         {:error, :not_found}
 
       vault ->
-        {:ok, _} = Vaults.delete_vault(vault)
+        {:ok, _} = Vaults.delete_vault(vault, Audited.attribution(conn))
         send_resp(conn, :no_content, "")
     end
   end

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -151,7 +151,7 @@ defmodule FountainWeb.AgentsLive.Form do
     agent = socket.assigns.agent
 
     if agent.id do
-      Agents.delete_avatar(agent)
+      Agents.delete_avatar(agent, FountainWeb.Audited.attribution(socket))
       {:noreply, assign(socket, :agent, %{agent | avatar_media_type: nil})}
     else
       {:noreply, socket}
@@ -300,7 +300,7 @@ defmodule FountainWeb.AgentsLive.Form do
   end
 
   defp save(%{assigns: %{action: :new}} = socket, attrs) do
-    case Agents.create_agent(attrs) do
+    case Agents.create_agent(attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, agent} ->
         maybe_set_avatar(socket, agent)
 
@@ -315,7 +315,7 @@ defmodule FountainWeb.AgentsLive.Form do
   end
 
   defp save(%{assigns: %{action: :edit, agent: existing}} = socket, attrs) do
-    case Agents.update_agent(existing, attrs) do
+    case Agents.update_agent(existing, attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, saved} ->
         maybe_set_avatar(socket, saved)
 
@@ -335,14 +335,14 @@ defmodule FountainWeb.AgentsLive.Form do
     uploaded =
       consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
         data = File.read!(path)
-        Agents.upload_avatar(agent, data, entry.client_type)
+        Agents.upload_avatar(agent, data, entry.client_type, FountainWeb.Audited.attribution(socket))
         {:ok, :uploaded}
       end)
 
     if uploaded == [] do
       case socket.assigns.generated_avatar_data do
         nil -> :ok
-        data -> Agents.upload_avatar(agent, data, "image/png")
+        data -> Agents.upload_avatar(agent, data, "image/png", FountainWeb.Audited.attribution(socket))
       end
     end
   end

--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -77,7 +77,7 @@ defmodule FountainWeb.AgentsLive.Index do
          |> put_flash(:error, "Agent not found — it may already be deleted")}
 
       agent ->
-        {:ok, _} = Agents.delete_agent(agent)
+        {:ok, _} = Agents.delete_agent(agent, FountainWeb.Audited.attribution(socket))
         delete_refresh(socket, user_id, agent)
     end
   end

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -209,7 +209,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
   defp save(%{assigns: %{action: :new}} = socket, attrs) do
     attrs = Map.put(attrs, "user_id", socket.assigns.user_id)
 
-    case Environments.create_environment(attrs) do
+    case Environments.create_environment(attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, env} ->
         {:noreply,
          socket
@@ -222,7 +222,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
   end
 
   defp save(%{assigns: %{action: :edit, env: env}} = socket, attrs) do
-    case Environments.update_environment(env, attrs) do
+    case Environments.update_environment(env, attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, _env} ->
         {:noreply,
          socket

--- a/apps/fountain/lib/fountain_web/live/environments_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/index.ex
@@ -39,7 +39,7 @@ defmodule FountainWeb.EnvironmentsLive.Index do
          |> put_flash(:error, "Environment not found — it may already be deleted")}
 
       env ->
-        {:ok, _} = Environments.delete_environment(env)
+        {:ok, _} = Environments.delete_environment(env, FountainWeb.Audited.attribution(socket))
 
         {:noreply,
          socket

--- a/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
+++ b/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
@@ -125,7 +125,7 @@ defmodule FountainWeb.OnboardingLive.Wizard do
   def handle_event("create_env", %{"env" => params}, socket) do
     attrs = Map.put(params, "user_id", socket.assigns.user_id)
 
-    case Environments.create_environment(attrs) do
+    case Environments.create_environment(attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, _env} -> advance(socket, "step_3")
       {:error, cs} -> {:noreply, assign(socket, :env_errors, changeset_errors(cs))}
     end
@@ -150,7 +150,7 @@ defmodule FountainWeb.OnboardingLive.Wizard do
       |> Map.put("system", Map.get(params, "system_prompt", ""))
       |> Map.delete("system_prompt")
 
-    case Agents.create_agent(attrs) do
+    case Agents.create_agent(attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, _agent} -> advance(socket, "step_4")
       {:error, cs} -> {:noreply, assign(socket, :agent_errors, changeset_errors(cs))}
     end

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -100,7 +100,7 @@ defmodule FountainWeb.VaultsLive.Form do
 
   defp save(%{assigns: %{action: :new}} = socket, attrs) do
     attrs = Map.put(attrs, "user_id", socket.assigns.user_id)
-    case Vaults.create_vault(attrs) do
+    case Vaults.create_vault(attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, vault} ->
         {:noreply,
          socket
@@ -113,7 +113,7 @@ defmodule FountainWeb.VaultsLive.Form do
   end
 
   defp save(%{assigns: %{action: :edit, vault: vault}} = socket, attrs) do
-    case Vaults.update_vault(vault, attrs) do
+    case Vaults.update_vault(vault, attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, _vault} ->
         {:noreply, socket |> put_flash(:info, "Vault updated") |> push_navigate(to: ~p"/vaults")}
 

--- a/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
@@ -39,7 +39,7 @@ defmodule FountainWeb.VaultsLive.Index do
          |> put_flash(:error, "Vault not found — it may already be deleted")}
 
       vault ->
-        {:ok, _} = Vaults.delete_vault(vault)
+        {:ok, _} = Vaults.delete_vault(vault, FountainWeb.Audited.attribution(socket))
 
         {:noreply,
          socket

--- a/apps/fountain/test/fountain_web/audit_resource_crud_test.exs
+++ b/apps/fountain/test/fountain_web/audit_resource_crud_test.exs
@@ -1,0 +1,205 @@
+defmodule FountainWeb.AuditResourceCrudTest do
+  @moduledoc """
+  Resource CRUD leaves a trail whichever door it came through (#543).
+
+  Before this, every agent/environment/vault mutation was audited when driven
+  through `/api` — the blanket plug on that pipeline caught it — and silent
+  when driven through the UI. That is the exact inverse of the secrets gap
+  `FountainWeb.Audited` documents as previously fixed, and it meant the
+  browser, where most of these mutations actually happen, was the one surface
+  with no record.
+
+  The fix records inside the context function, so these tests come in two
+  halves: the context half proves each mutation audits at all, and the surface
+  half proves each door passes its own attribution down.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.{Agents, Audit, Environments, Vaults}
+
+  defp events_for(user_id), do: Audit.list_recent_for_user(user_id, 200)
+
+  defp find_action(user_id, action) do
+    Enum.find(events_for(user_id), &(&1.action == action))
+  end
+
+  defp actions_for(user_id), do: Enum.map(events_for(user_id), & &1.action)
+
+  describe "the context audits every resource mutation" do
+    setup do
+      {:ok, user: insert_verified_user()}
+    end
+
+    test "agent create, update and delete", %{user: user} do
+      {:ok, agent} = Agents.create_agent(agent_attrs(%{"user_id" => user.id}))
+
+      created = find_action(user.id, "agent.created")
+      assert created.resource_type == "agent"
+      assert created.resource_id == agent.id
+      assert created.metadata["name"] == agent.name
+      # No caller said who they were, so the trail says the account itself —
+      # never a guess at a surface that was not involved.
+      assert created.actor == "self"
+
+      {:ok, _} = Agents.update_agent(agent, %{"model" => "anthropic/claude-opus-4-5"})
+      assert find_action(user.id, "agent.updated").metadata["changed"] == ["model"]
+
+      {:ok, _} = Agents.delete_agent(agent)
+      assert find_action(user.id, "agent.deleted").resource_id == agent.id
+    end
+
+    test "environment create, update and delete", %{user: user} do
+      {:ok, env} = Environments.create_environment(env_attrs(%{"user_id" => user.id}))
+      assert find_action(user.id, "environment.created").resource_id == env.id
+
+      {:ok, _} = Environments.update_environment(env, %{"setup_script" => "apt-get update"})
+      assert find_action(user.id, "environment.updated").metadata["changed"] == ["setup_script"]
+
+      {:ok, _} = Environments.delete_environment(env)
+      assert find_action(user.id, "environment.deleted").resource_id == env.id
+    end
+
+    test "vault create, update and delete", %{user: user} do
+      {:ok, vault} = Vaults.create_vault(vault_attrs(%{"user_id" => user.id}))
+      assert find_action(user.id, "vault.created").resource_id == vault.id
+
+      {:ok, _} = Vaults.update_vault(vault, %{"description" => "prod overrides"})
+      assert find_action(user.id, "vault.updated").metadata["changed"] == ["description"]
+
+      {:ok, _} = Vaults.delete_vault(vault)
+      assert find_action(user.id, "vault.deleted").resource_id == vault.id
+    end
+
+    test "avatar set and remove", %{user: user} do
+      agent = insert_agent(user_id: user.id)
+      png = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
+
+      {:ok, _} = Agents.upload_avatar(agent, png, "image/png")
+      set = find_action(user.id, "agent.avatar.set")
+      assert set.resource_id == agent.id
+      assert set.metadata["media_type"] == "image/png"
+
+      {:ok, _} = Agents.delete_avatar(agent)
+      assert find_action(user.id, "agent.avatar.removed").resource_id == agent.id
+    end
+
+    test "a rejected changeset records nothing", %{user: user} do
+      # The mutation did not happen, so the trail must not claim it did.
+      {:error, _} = Agents.create_agent(agent_attrs(%{"user_id" => user.id, "name" => ""}))
+
+      refute "agent.created" in actions_for(user.id)
+    end
+
+    test "an update records which fields moved, never their values", %{user: user} do
+      env = insert_env(user_id: user.id)
+
+      {:ok, _} =
+        Environments.update_environment(env, %{"setup_script" => "curl secret.example/install"})
+
+      event = find_action(user.id, "environment.updated")
+      assert event.metadata["changed"] == ["setup_script"]
+
+      # Guard the guard (#406): if the update stopped auditing, the refute
+      # below would pass over nothing.
+      assert event
+      refute inspect(event) =~ "secret.example"
+    end
+  end
+
+  describe "the UI passes its own attribution down" do
+    setup %{conn: conn} do
+      user = insert_verified_user()
+      {:ok, user: user, conn: login_user(conn, user)}
+    end
+
+    test "creating a vault through the form", %{conn: conn, user: user} do
+      {:ok, lv, _html} = live(conn, ~p"/vaults/new")
+
+      render_submit(lv, "submit", %{"vault" => %{"name" => "from-the-ui", "description" => ""}})
+
+      event = find_action(user.id, "vault.created")
+      assert event, "a vault created through the UI must be audited"
+      assert event.actor == "ui"
+      assert event.request_ip
+      assert event.metadata["name"] == "from-the-ui"
+    end
+
+    test "deleting an agent from the index", %{conn: conn, user: user} do
+      agent = insert_agent(user_id: user.id)
+
+      {:ok, lv, _html} = live(conn, ~p"/agents")
+      render_click(lv, "delete", %{"id" => agent.id})
+
+      event = find_action(user.id, "agent.deleted")
+      assert event, "deleting an agent through the UI must be audited"
+      assert event.actor == "ui"
+      assert event.resource_id == agent.id
+    end
+
+    test "deleting an environment from the index", %{conn: conn, user: user} do
+      env = insert_env(user_id: user.id)
+
+      {:ok, lv, _html} = live(conn, ~p"/environments")
+      render_click(lv, "delete", %{"id" => env.id})
+
+      assert find_action(user.id, "environment.deleted").actor == "ui"
+    end
+
+    test "deleting a vault from the index", %{conn: conn, user: user} do
+      vault = insert_vault(user_id: user.id)
+
+      {:ok, lv, _html} = live(conn, ~p"/vaults")
+      render_click(lv, "delete", %{"id" => vault.id})
+
+      assert find_action(user.id, "vault.deleted").actor == "ui"
+    end
+  end
+
+  describe "the API surface" do
+    test "a create through /api records the semantic event alongside the plug's request log",
+         %{conn: conn} do
+      user = insert_verified_user()
+      {_record, raw_key} = insert_api_key(user)
+
+      conn
+      |> authed_with_key(raw_key)
+      |> post_json("/api/agents", %{
+        name: "from-the-api",
+        model: "anthropic/claude-sonnet-4-6",
+        runtime: "claude"
+      })
+      |> json_response(201)
+
+      semantic = find_action(user.id, "agent.created")
+      assert semantic.actor == "api"
+      assert semantic.metadata["name"] == "from-the-api"
+
+      # The pipeline plug still records the request itself. Deliberate while
+      # the campaign is in flight — dropping it would take coverage away from
+      # routes whose contexts do not audit yet (#552 decides its fate).
+      assert find_action(user.id, "POST /api/agents")
+    end
+  end
+
+  describe "system callers" do
+    test "a checkpoint write is attributed to the worker, not the owner" do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id)
+
+      {:ok, _} =
+        Environments.update_environment(env, %{"checkpoint_id" => "ckpt_123"},
+          actor: "system:provisioning"
+        )
+
+      event = find_action(user.id, "environment.updated")
+      assert event.actor == "system:provisioning"
+
+      # The changed-field list is what makes this row readable: it says
+      # plainly that nothing the tenant configured was touched.
+      assert event.metadata["changed"] == ["checkpoint_id"]
+    end
+  end
+end


### PR DESCRIPTION
Closes #543. Second child of #540, and the one that establishes the pattern the rest of the campaign reuses. Builds on #582 (#542), now merged.

## The gap

Every agent, environment and vault mutation was audited through `/api` — the blanket plug on that pipeline caught it — and silent through the UI. That is the exact inverse of the secrets gap `FountainWeb.Audited` documents as previously fixed, and backwards for the surface where most of this work actually happens. A tenant reading their own trail saw resources appear and vanish unexplained.

## The approach

Eleven context functions audit themselves — create/update/delete × three resources, plus avatar set and remove. Callers pass only what a context cannot know about its caller: `Audited.attribution/2` (added by #542), returning the `:actor` / `:request_ip` pair for a conn or a socket.

Covered from one place: LiveViews, API controllers, the onboarding wizard, `fountain apply`, and any future caller.

Two shared helpers stop eleven sites hand-rolling the same map:
- `Audit.record_resource/4` — pulls `user_id`, `id` and `name` off the resource
- `Audit.changed_fields/1` — turns a changeset into the sorted list of fields it moves

Update events carry that list and **never** the values. "What changed" is the whole value of an update row; the audit trail is not a place to keep a second copy of tenant data.

## Four details worth review

- **The avatar audit calls sit outside the transactions.** `Audit.record/1` is best-effort by rescuing, but that guarantee does not survive inside a transaction — a failed audit insert there aborts the enclosing one, so a lost trail row would have taken the avatar write with it. This is the one place the pattern could have silently broken a mutation.
- **`manifest.ex` grew an opts pass-through**, so `fountain apply` attributes to the API caller instead of defaulting to `"self"`.
- **The two checkpoint writers keep their rows.** `ConversationServer` and `Provisioning` reach `update_environment/3` with `system:` actors. Kept rather than suppressed: a checkpoint pointer moving under the tenant is what someone debugging a cold provision needs to see, and the changed-field list (`["checkpoint_id"]`) says plainly that nothing the tenant configured was touched. Volume is per checkpoint create, not per turn.
- **`.dialyzer_ignore.exs` needed repinning**, 1339 → 1341. The two lines this adds to `conversation_server.ex` moved a pinned skip — exactly the staleness that file's own comment warns about. Worth knowing for the rest of the campaign: any edit above that line breaks the build until the pin moves.

## Tests

New `audit_resource_crud_test.exs`, 12 cases in four groups:

- **context** — all eleven mutations audit; a rejected changeset records nothing; an update names the fields that moved and not their values (with a guard-the-guard assert)
- **UI** — vault create via form, agent/environment/vault delete via index, each asserting `actor == "ui"` and a resolved `request_ip`
- **API** — a create records the semantic event *alongside* the plug's request log
- **system** — a checkpoint write is attributed to the worker, not the owner

Full suite 2311 tests, 0 failures; `mix precommit` exits 0.

Notably **no existing test needed changing.** The factory creates through these same functions, so every `insert_agent`/`insert_env`/`insert_vault` now writes a trail row — and nothing in the suite asserted on exact trail contents for these resources.

## Still open in #540

The API plug keeps writing its request-log row alongside the semantic event, so an API mutation produces two. Deliberate while the campaign is in flight: scoping the plug down now would take coverage away from routes whose contexts do not audit yet. #552 decides its fate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)