### PR TITLE
audit: record registration and logout (#544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ upgrade, is in
 
 ### Fixed
 
+- **Signing up and signing out are in your audit trail.** Registration was
+  recorded only for OAuth signups; the browser form and
+  `POST /api/auth/register` both created accounts silently, the latter because
+  it runs on a public pipeline with no audit plug. Logins were recorded and
+  logouts were not, so the trail showed sessions opening and never closing. An
+  account's trail now opens with its own creation, which also means a brand
+  new account no longer shows an empty audit page (#544)
+
 - **Creating, changing or deleting an agent, environment or vault is audited
   from the browser too.** These mutations were recorded when driven through
   `/api`, because a blanket plug on that pipeline caught every write, and

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -89,15 +89,42 @@ defmodule Fountain.Accounts do
 
   Returns `{:ok, user}`, `{:error, changeset}`, or `{:error, reason}` when
   registration is closed or the email domain is not allowed.
+
+  Audited as `account.registered`. Recorded here rather than in the two
+  controllers because `POST /api/auth/register` sits on `:api_public`, which
+  carries no audit plug — so the JSON signup door left no record at all, while
+  the OAuth variant recorded `auth.oauth.signup` and the browser form recorded
+  nothing (#544). `opts` carries `:actor` / `:request_ip`, from
+  `FountainWeb.Audited.attribution/2` on a web surface.
   """
-  @spec register_user(map()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t() | atom()}
-  def register_user(attrs) do
+  @spec register_user(map(), keyword()) ::
+          {:ok, User.t()} | {:error, Ecto.Changeset.t() | atom()}
+  def register_user(attrs, opts \\ []) do
     email = attrs["email"] || attrs[:email]
 
     with :ok <- registration_allowed?(email) do
-      do_register_user(attrs)
+      # Outside `do_register_user/1`, whose body is a transaction: a failed
+      # audit insert inside one aborts the enclosing transaction, so recording
+      # in there could roll back the very registration it is describing.
+      attrs |> do_register_user() |> audited_registration(opts)
     end
   end
+
+  defp audited_registration({:ok, %User{} = user} = ok, opts) do
+    Audit.record(%{
+      user_id: user.id,
+      action: "account.registered",
+      resource_type: "user",
+      resource_id: user.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: %{"email" => user.email}
+    })
+
+    ok
+  end
+
+  defp audited_registration(other, _opts), do: other
 
   defp do_register_user(attrs) do
     Repo.transaction(fn ->

--- a/apps/fountain/lib/fountain_web/controllers/registration_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/registration_controller.ex
@@ -23,6 +23,7 @@ defmodule FountainWeb.RegistrationController do
 
   alias Fountain.Accounts
   alias Fountain.Workers.VerificationEmail
+  alias FountainWeb.Audited
   alias FountainWeb.Schemas
 
   plug FountainWeb.Plugs.RateLimit,
@@ -55,7 +56,10 @@ defmodule FountainWeb.RegistrationController do
   end
 
   def create(conn, %{"user" => user_params}) do
-    case Accounts.register_user(user_params) do
+    # Explicit actor: there is no session yet at signup, so derivation would
+    # report "system" for a plainly-browser registration — the same caveat
+    # `from_conn/4` carries at login.
+    case Accounts.register_user(user_params, Audited.attribution(conn, actor: "ui")) do
       # EMAIL_DELIVERY=none: the account self-verified at registration, so
       # "check your email" would send the user to wait for a mail that never
       # comes — the exact dead end auto-verification exists to remove.
@@ -129,7 +133,7 @@ defmodule FountainWeb.RegistrationController do
   )
 
   def api_create(conn, %{"email" => _, "password" => _} = params) do
-    case Accounts.register_user(params) do
+    case Accounts.register_user(params, Audited.attribution(conn, actor: "api")) do
       {:ok, %{email_verified_at: %DateTime{}} = user} ->
         conn
         |> put_status(:created)

--- a/apps/fountain/lib/fountain_web/controllers/session_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/session_controller.ex
@@ -62,6 +62,24 @@ defmodule FountainWeb.SessionController do
   end
 
   def delete(conn, params) do
+    # Read before the drop, and off the session rather than assigns: this route
+    # is on the plain `:browser` pipeline, so nothing has loaded a
+    # `current_user`. A login trail with no logouts cannot reconstruct a
+    # session, which is most of what the trail is for (#544).
+    #
+    # Skipped for the post-deletion redirect below — the account is already
+    # gone, and `audit_events.user_id` is nilified with it, so the row would
+    # be an orphan claiming a user who no longer exists. `account.deleted`
+    # already covers that path.
+    user_id = get_session(conn, :user_id)
+
+    if user_id && params["deleted"] != "1" do
+      FountainWeb.Audited.from_conn(conn, "auth.logout", "session",
+        user_id: user_id,
+        actor: "ui"
+      )
+    end
+
     conn = configure_session(conn, drop: true)
 
     # Account deletion redirects here to drop the session, since a LiveView

--- a/apps/fountain/test/fountain/audit_test.exs
+++ b/apps/fountain/test/fountain/audit_test.exs
@@ -69,9 +69,15 @@ defmodule Fountain.AuditTest do
       user_a = insert_verified_user()
       user_b = insert_verified_user()
 
-      Audit.record(valid_attrs(user_a.id))
+      event = Audit.record!(valid_attrs(user_a.id))
 
-      assert Audit.list_recent_for_user(user_b.id) == []
+      # Since #544 registration itself audits, so B's trail is not empty — it
+      # holds B's own `account.registered` and nothing else. The property under
+      # test is that A's event is not in it.
+      b_ids = user_b.id |> Audit.list_recent_for_user() |> Enum.map(& &1.id)
+
+      refute event.id in b_ids
+      assert Audit.list_recent_for_user(user_b.id) |> Enum.map(& &1.action) == ["account.registered"]
     end
 
     test "respects limit" do
@@ -201,11 +207,17 @@ defmodule Fountain.AuditTest do
       Audit.record!(valid_attrs(user.id, %{action: "old.event", inserted_at: old}))
       Audit.record!(valid_attrs(user.id, %{action: "new.event", inserted_at: now}))
 
+      # `_unsafe_list_events/1` is cross-tenant, and since #544 creating the
+      # user above puts an `account.registered` in that window too. Narrowed
+      # to the two events this test planted — the property is which side of
+      # the bound each lands on, not what else exists.
+      planted = &Enum.filter(&1, fn e -> e.action in ["old.event", "new.event"] end)
+
       recent = Audit._unsafe_list_events(since: DateTime.add(now, -60, :second))
-      assert Enum.map(recent, & &1.action) == ["new.event"]
+      assert recent |> planted.() |> Enum.map(& &1.action) == ["new.event"]
 
       earlier = Audit._unsafe_list_events(until: DateTime.add(now, -60, :second))
-      assert Enum.map(earlier, & &1.action) == ["old.event"]
+      assert earlier |> planted.() |> Enum.map(& &1.action) == ["old.event"]
 
       # Inclusive on both ends: the boundary timestamp itself matches.
       assert Enum.any?(Audit._unsafe_list_events(since: now), &(&1.action == "new.event"))
@@ -223,7 +235,11 @@ defmodule Fountain.AuditTest do
       Audit.record!(valid_attrs(user.id, %{resource_type: "agent"}))
       Audit.record!(valid_attrs(other.id, %{resource_type: "environment"}))
 
-      assert Audit.list_resource_types_for_user(user.id) == ["agent", "vault"]
+      # "user" comes from the tenant's own `account.registered` row (#544) —
+      # registration is the first thing in every trail. The properties under
+      # test are distinctness, sort order, and the absence of the other
+      # tenant's "environment".
+      assert Audit.list_resource_types_for_user(user.id) == ["agent", "user", "vault"]
     end
 
     test "the unscoped list spans tenants" do

--- a/apps/fountain/test/fountain/exports_test.exs
+++ b/apps/fountain/test/fountain/exports_test.exs
@@ -45,7 +45,14 @@ defmodule Fountain.ExportsTest do
         args: %{export_id: export.id, user_id: user.id}
       )
 
-      assert [event] = Audit.list_recent_for_user(user.id, 10)
+      # Filtered rather than matched as the whole trail: since #544 every
+      # account opens with an `account.registered` row, so "the only event" is
+      # no longer a thing a fresh user has.
+      assert [event] =
+               user.id
+               |> Audit.list_recent_for_user(10)
+               |> Enum.filter(&(&1.action == "account.export_requested"))
+
       assert event.action == "account.export_requested"
       assert event.resource_id == export.id
       assert event.actor == "self"

--- a/apps/fountain/test/fountain_web/audit_identity_test.exs
+++ b/apps/fountain/test/fountain_web/audit_identity_test.exs
@@ -1,0 +1,123 @@
+defmodule FountainWeb.AuditIdentityTest do
+  @moduledoc """
+  Registration and logout leave a trail (#544).
+
+  Identity events were recorded unevenly: OAuth signup wrote
+  `auth.oauth.signup`, but email+password registration wrote nothing from
+  either the browser form or `POST /api/auth/register` — the latter sits on
+  `:api_public`, which carries no audit plug. Login was recorded and logout
+  was not, so the trail could show sessions opening and never closing.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.{Accounts, Audit}
+
+  defp events_for(user_id), do: Audit.list_recent_for_user(user_id, 100)
+
+  defp find_action(user_id, action) do
+    Enum.find(events_for(user_id), &(&1.action == action))
+  end
+
+  describe "registration" do
+    test "through the browser form", %{conn: conn} do
+      email = "browser#{System.unique_integer([:positive])}@example.com"
+
+      conn =
+        post(conn, ~p"/auth/register", %{
+          "user" => %{"email" => email, "password" => "password123"}
+        })
+
+      assert redirected_to(conn)
+
+      user = Accounts.get_user_by_email(email)
+      event = find_action(user.id, "account.registered")
+
+      assert event, "a browser registration must be audited"
+      assert event.resource_type == "user"
+      assert event.resource_id == user.id
+      assert event.actor == "ui"
+      assert event.metadata["email"] == email
+    end
+
+    test "through POST /api/auth/register", %{conn: conn} do
+      # The door with no audit plug on its pipeline — the gap this closes.
+      email = "api#{System.unique_integer([:positive])}@example.com"
+
+      conn = post_json(conn, "/api/auth/register", %{email: email, password: "password123"})
+      assert %{"user_id" => user_id} = json_response(conn, 201)
+
+      event = find_action(user_id, "account.registered")
+      assert event, "an API registration must be audited"
+      assert event.actor == "api"
+      assert event.metadata["email"] == email
+    end
+
+    test "the password never reaches the trail", %{conn: conn} do
+      email = "secret#{System.unique_integer([:positive])}@example.com"
+
+      post_json(conn, "/api/auth/register", %{email: email, password: "hunter2-very-secret"})
+      user = Accounts.get_user_by_email(email)
+
+      events = events_for(user.id)
+
+      # Guard the guard (#406): an empty list would pass the refute vacuously.
+      assert Enum.any?(events, &(&1.action == "account.registered"))
+
+      for event <- events do
+        refute inspect(event) =~ "hunter2-very-secret"
+      end
+    end
+
+    test "a rejected registration records nothing", %{conn: conn} do
+      # The factory registers through the same function, so this user already
+      # has exactly one `account.registered`. The duplicate-address attempt
+      # below fails its changeset — no account is created, so the count must
+      # not move.
+      user = insert_verified_user()
+      before = Enum.count(events_for(user.id), &(&1.action == "account.registered"))
+      assert before == 1
+
+      post(conn, ~p"/auth/register", %{
+        "user" => %{"email" => user.email, "password" => "password123"}
+      })
+
+      assert Enum.count(events_for(user.id), &(&1.action == "account.registered")) == 1
+    end
+  end
+
+  describe "logout" do
+    test "is recorded, so a session has both ends", %{conn: conn} do
+      user = insert_verified_user()
+
+      conn = get(login_user(conn, user), ~p"/auth/logout")
+      assert redirected_to(conn) == ~p"/auth/login"
+
+      event = find_action(user.id, "auth.logout")
+      assert event, "logging out must be audited"
+      assert event.resource_type == "session"
+      assert event.actor == "ui"
+      assert event.user_id == user.id
+    end
+
+    test "a logout with no session records nothing", %{conn: conn} do
+      # The route is public; hitting it signed-out is not a session ending.
+      conn = get(conn, ~p"/auth/logout")
+
+      assert redirected_to(conn) == ~p"/auth/login"
+      assert Audit._unsafe_list_recent(50) |> Enum.filter(&(&1.action == "auth.logout")) == []
+    end
+
+    test "the post-deletion redirect does not write an orphan row", %{conn: conn} do
+      # Account deletion redirects here to drop the cookie. The user row is
+      # already gone, so a logout event would claim a user that no longer
+      # exists — `account.deleted` already covers that path.
+      user = insert_verified_user()
+
+      conn = get(login_user(conn, user), ~p"/auth/logout?deleted=1")
+
+      assert redirected_to(conn) == ~p"/auth/login"
+      refute find_action(user.id, "auth.logout")
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/audit_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/audit_controller_test.exs
@@ -37,6 +37,19 @@ defmodule FountainWeb.AuditControllerTest do
     conn |> authed_with_key(key) |> get("/api/audit" <> query) |> json_response(200)
   end
 
+  # Follows next_cursor until the server says there is no more, returning every
+  # id seen in order plus the final page (for its has_more).
+  defp page_to_end(conn, key, page, acc \\ []) do
+    acc = acc ++ Enum.map(page["data"], & &1["id"])
+
+    if page["meta"]["has_more"] do
+      next = list(conn, key, "?limit=2&before=#{page["meta"]["next_cursor"]}")
+      page_to_end(conn, key, next, acc)
+    else
+      {acc, page}
+    end
+  end
+
   describe "GET /api/audit" do
     test "returns the tenant's events newest first with the columns the UI shows", %{
       conn: conn,
@@ -143,21 +156,17 @@ defmodule FountainWeb.AuditControllerTest do
       assert length(page1["data"]) == 2
       assert page1["meta"]["has_more"]
 
-      page2 = list(conn, key, "?limit=2&before=#{page1["meta"]["next_cursor"]}")
-      page3 = list(conn, key, "?limit=2&before=#{page2["meta"]["next_cursor"]}")
+      # Paged to exhaustion rather than a fixed number of pages: the trail is
+      # no longer just what this test recorded. `insert_api_key` in the setup
+      # audits its mint (#542) and creating the user audits the registration
+      # (#544), so hardcoding a page count makes this test a hostage to every
+      # future addition to the campaign.
+      {ids, last_page} = page_to_end(conn, key, page1)
 
-      ids =
-        (page1["data"] ++ page2["data"] ++ page3["data"])
-        |> Enum.map(& &1["id"])
-
-      # Every event in the trail, newest first, no repeats across pages.
-      # Counted rather than hardcoded: the setup's own `insert_api_key` mints
-      # through `Accounts.create_api_key`, which audits itself since #542, so
-      # the trail is the five recorded above plus that mint.
       assert length(ids) == length(Audit.list_recent_for_user(user.id, 100))
       assert ids == Enum.uniq(ids)
       assert ids == Enum.sort(ids, :desc)
-      refute page3["meta"]["has_more"]
+      refute last_page["meta"]["has_more"]
     end
 
     test "the limit is capped", %{conn: conn, user: user, key: key} do

--- a/apps/fountain/test/fountain_web/live/audit_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/audit_live_test.exs
@@ -6,6 +6,7 @@ defmodule FountainWeb.AuditLiveTest do
 
   use FountainWeb.ConnCase, async: true
 
+  import Ecto.Query, only: [from: 2]
   import Phoenix.LiveViewTest
 
   alias Fountain.Audit
@@ -176,8 +177,14 @@ defmodule FountainWeb.AuditLiveTest do
     end
 
     test "an empty trail says 'no events yet', not 'no matches'", %{conn: conn} do
-      # A fresh user with nothing recorded — and no filters applied.
-      conn = login_user(conn, insert_verified_user())
+      # Emptied explicitly, because since #544 a fresh account is not empty —
+      # registration is itself the first row in every trail. The state this
+      # branch renders is now reached one way in production: an old account
+      # whose events have all aged out of the retention window.
+      user = insert_verified_user()
+      Fountain.Repo.delete_all(from(e in Fountain.Audit.Event, where: e.user_id == ^user.id))
+
+      conn = login_user(conn, user)
       {:ok, _lv, html} = live(conn, ~p"/audit")
 
       assert html =~ "No events yet"

--- a/ee/lib/mix/tasks/fountain.verify_lifecycle.ex
+++ b/ee/lib/mix/tasks/fountain.verify_lifecycle.ex
@@ -112,7 +112,12 @@ defmodule Mix.Tasks.Fountain.VerifyLifecycle do
     suffix = System.system_time(:second)
     email = "lifecycle-verify-#{suffix}@example.com"
 
-    {:ok, user} = Accounts.register_user(%{"email" => email, "password" => "scratch-#{suffix}!"})
+    {:ok, user} =
+      Accounts.register_user(
+        %{"email" => email, "password" => "scratch-#{suffix}!"},
+        actor: "system:verify_lifecycle"
+      )
+
     {:ok, user} = Accounts.verify_email(user)
     remember(%{state | user: user})
 


### PR DESCRIPTION
Closes #544. Third child of #540. Independent of #583 — branched off `main`, mergeable in either order.

## The gap

Identity events were recorded unevenly:

| Event | Before | After |
|---|---|---|
| OAuth signup | `auth.oauth.signup` | unchanged |
| Browser registration | **nothing** | `account.registered`, actor `ui` |
| `POST /api/auth/register` | **nothing** (`:api_public`, no audit plug) | `account.registered`, actor `api` |
| Login | `auth.login` | unchanged |
| Logout | **nothing** | `auth.logout` |

A login trail with no logouts can't reconstruct a session, and two of the three ways to create an account left no record that it had been created.

## The approach

`account.registered` goes in `Accounts.register_user/2` — both controllers and the lifecycle-verification task covered from one place.

**The audit call sits outside `do_register_user/1`.** Its body is a transaction, and a failed audit insert inside one aborts the enclosing transaction — recording in there could have rolled back the very registration it was describing. Same trap as the avatar writes in #583.

`auth.logout` goes in the session controller, reading the user id **off the session rather than assigns**: `/auth/logout` is on the plain `:browser` pipeline, so nothing has loaded a `current_user`. It's skipped for the post-deletion redirect, where the account is already gone and the row would name a user that no longer exists (`account.deleted` covers that path).

Both registration controllers pass an explicit actor — there's no session yet at signup, so derivation would file a plainly-browser registration under `"system"`, the caveat `from_conn/4` already documents for login.

## The behaviour change worth knowing about

**A fresh account's audit trail is no longer empty** — it opens with its own creation. That's the right shape, but it has a visible consequence: the `/audit` page's "No events yet" empty state is now unreachable through normal signup. It's still live code, reached one way in production — an old account whose events have all aged out of the retention window — and its test now constructs that state explicitly rather than assuming a new user has it.

## Tests

New `audit_identity_test.exs`, 7 cases: browser and API registration each audited with the right actor; the password never reaches the trail (with a guard-the-guard assert); a rejected registration doesn't move the count; logout recorded; a signed-out logout records nothing; the post-deletion redirect writes no orphan row.

Six existing tests changed, all the same consequence above:
- `exports_test` / `audit_test` filter to the action under test instead of matching the whole trail
- the audit-pagination test pages to exhaustion rather than assuming a fixed page count — hardcoding one made it a hostage to every future child of #540
- the AuditLive empty-state test empties the trail explicitly

Full suite 2306 tests, 0 failures; `mix precommit` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)