### PR TITLE
audit: record inference-credential writes in the context (#546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ upgrade, is in
 
 ### Fixed
 
+- **Saving an inference credential during onboarding is audited like saving
+  one anywhere else.** BYO provider keys are secret material on par with
+  environment and vault secrets, and the settings page and API already
+  recorded every write — but the onboarding wizard, saving the same
+  credential through the same code, recorded nothing. The recording moved
+  into the context, so all three surfaces share it and a fourth cannot
+  quietly miss it. The provider name is still the whole payload; the
+  credential never reaches the trail (#546)
+
 - **Signing up and signing out are in your audit trail.** Registration was
   recorded only for OAuth signups; the browser form and
   `POST /api/auth/register` both created accounts silently, the latter because

--- a/apps/fountain/lib/fountain/inference_credentials.ex
+++ b/apps/fountain/lib/fountain/inference_credentials.ex
@@ -14,6 +14,7 @@ defmodule Fountain.InferenceCredentials do
 
   import Ecto.Query
 
+  alias Fountain.Audit
   alias Fountain.Crypto
   alias Fountain.InferenceCredentials.Credential
   alias Fountain.Repo
@@ -66,11 +67,21 @@ defmodule Fountain.InferenceCredentials do
   - `value` is a plaintext string (will be encrypted with `dek`).
   - To clear, pass `nil` or an empty string.
 
+  Audited as `inference_credential.write` or `.delete`. These are BYO
+  inference keys — secret material on par with environment and vault secrets,
+  which have audited since #530. The settings LiveView and the API controller
+  each recorded their own event, and the onboarding wizard, saving the same
+  credential through the same function, recorded nothing (#546). Recording
+  here removes the third caller's gap and the chance of a fourth.
+
+  `opts` carries `:actor` / `:request_ip`, from
+  `FountainWeb.Audited.attribution/2` on a web surface.
+
   Returns `{:ok, credential}` (the updated row) or `{:error, changeset}`.
   """
-  @spec put_credential(binary(), binary(), atom(), String.t() | nil) ::
+  @spec put_credential(binary(), binary(), atom(), String.t() | nil, keyword()) ::
           {:ok, Credential.t()} | {:error, Ecto.Changeset.t()}
-  def put_credential(user_id, dek, provider, value)
+  def put_credential(user_id, dek, provider, value, opts \\ [])
       when is_binary(user_id) and is_binary(dek) and provider in @providers do
     ct_field = ciphertext_field(provider)
 
@@ -88,7 +99,29 @@ defmodule Fountain.InferenceCredentials do
     existing
     |> Credential.changeset(attrs)
     |> Repo.insert_or_update()
+    |> audited(user_id, provider, ciphertext, opts)
   end
+
+  # The provider name is the whole payload. The credential must never reach a
+  # second table — the same rule the secret-write events follow, and the
+  # reason those record a key and not a value.
+  defp audited({:ok, _cred} = ok, user_id, provider, ciphertext, opts) do
+    action = if is_nil(ciphertext), do: "inference_credential.delete", else: "inference_credential.write"
+
+    Audit.record(%{
+      user_id: user_id,
+      action: action,
+      resource_type: "inference_credential",
+      resource_id: Atom.to_string(provider),
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: %{"provider" => Atom.to_string(provider)}
+    })
+
+    ok
+  end
+
+  defp audited(other, _user_id, _provider, _ciphertext, _opts), do: other
 
   @doc """
   Returns `true` if the user has at least one provider set.

--- a/apps/fountain/lib/fountain_web/controllers/inference_credential_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/inference_credential_controller.ex
@@ -130,8 +130,14 @@ defmodule FountainWeb.InferenceCredentialController do
 
     with {:ok, provider} <- parse_provider(provider_str),
          {:ok, dek} <- load_dek(user.id),
-         {:ok, _cred} <- InferenceCredentials.put_credential(user.id, dek, provider, nil) do
-      audit(conn, "inference_credential.delete", provider)
+         {:ok, _cred} <-
+           InferenceCredentials.put_credential(
+             user.id,
+             dek,
+             provider,
+             nil,
+             Audited.attribution(conn)
+           ) do
       send_resp(conn, :no_content, "")
     end
   end
@@ -140,9 +146,14 @@ defmodule FountainWeb.InferenceCredentialController do
 
   defp persist(conn, user, provider, value) do
     with {:ok, dek} <- load_dek(user.id),
-         {:ok, _cred} <- InferenceCredentials.put_credential(user.id, dek, provider, value) do
-      audit(conn, "inference_credential.write", provider)
-
+         {:ok, _cred} <-
+           InferenceCredentials.put_credential(
+             user.id,
+             dek,
+             provider,
+             value,
+             Audited.attribution(conn)
+           ) do
       render(conn, :show,
         provider: provider,
         status: InferenceCredentials.status_for_user(user.id)
@@ -176,15 +187,6 @@ defmodule FountainWeb.InferenceCredentialController do
       {:ok, dek} -> {:ok, dek}
       {:error, _reason} -> {:error, :tenant_key_unavailable}
     end
-  end
-
-  defp audit(conn, action, provider) do
-    # The provider name is the whole payload — the credential itself must never
-    # reach a second table.
-    Audited.from_conn(conn, action, "inference_credential",
-      resource_id: Atom.to_string(provider),
-      metadata: %{"provider" => Atom.to_string(provider)}
-    )
   end
 
   defp to_trimmed_string(value) when is_binary(value), do: String.trim(value)

--- a/apps/fountain/lib/fountain_web/live/inference_credentials_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/inference_credentials_live/index.ex
@@ -91,10 +91,14 @@ defmodule FountainWeb.InferenceCredentialsLive.Index do
 
     case load_dek(socket.assigns.user_id) do
       {:ok, dek} ->
-        case InferenceCredentials.put_credential(socket.assigns.user_id, dek, provider, nil) do
+        case InferenceCredentials.put_credential(
+               socket.assigns.user_id,
+               dek,
+               provider,
+               nil,
+               FountainWeb.Audited.attribution(socket)
+             ) do
           {:ok, _} ->
-            audit(socket, "inference_credential.delete", provider)
-
             {:noreply,
              socket
              |> assign(:status, InferenceCredentials.status_for_user(socket.assigns.user_id))
@@ -119,9 +123,13 @@ defmodule FountainWeb.InferenceCredentialsLive.Index do
   defp persist_and_flash(socket, provider, value) do
     with {:ok, dek} <- load_dek(socket.assigns.user_id),
          {:ok, _cred} <-
-           InferenceCredentials.put_credential(socket.assigns.user_id, dek, provider, value) do
-      audit(socket, "inference_credential.write", provider)
-
+           InferenceCredentials.put_credential(
+             socket.assigns.user_id,
+             dek,
+             provider,
+             value,
+             FountainWeb.Audited.attribution(socket)
+           ) do
       {:noreply,
        socket
        |> assign(:status, InferenceCredentials.status_for_user(socket.assigns.user_id))
@@ -140,16 +148,6 @@ defmodule FountainWeb.InferenceCredentialsLive.Index do
 
   defp load_dek(user_id) do
     Crypto.load_tenant_key(user_id)
-  end
-
-  # The provider name is the whole payload — the credential itself must never
-  # reach a second table. Matches the events the API controller emits (#518),
-  # so the trail reads the same whichever surface set the credential.
-  defp audit(socket, action, provider) do
-    FountainWeb.Audited.from_socket(socket, action, "inference_credential",
-      resource_id: Atom.to_string(provider),
-      metadata: %{"provider" => Atom.to_string(provider)}
-    )
   end
 
   defp put_provider_message(socket, provider, kind, msg) do

--- a/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
+++ b/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
@@ -68,7 +68,7 @@ defmodule FountainWeb.OnboardingLive.Wizard do
     else
       case Validator.validate(provider, value) do
         :ok ->
-          case persist_credential(socket.assigns.user_id, provider, value) do
+          case persist_credential(socket, provider, value) do
             {:ok, _} ->
               {:noreply,
                socket
@@ -178,9 +178,21 @@ defmodule FountainWeb.OnboardingLive.Wizard do
     {:noreply, socket |> assign(:user, user) |> push_navigate(to: ~p"/onboarding/#{next_step}")}
   end
 
-  defp persist_credential(user_id, provider, value) do
+  # Takes the socket rather than a bare user_id so the credential save made
+  # during onboarding is attributed like every other one. This was the surface
+  # #546 found unaudited: the same context function, reached through a third
+  # door that nobody had added a recording call to.
+  defp persist_credential(socket, provider, value) do
+    user_id = socket.assigns.user_id
+
     with {:ok, dek} <- Crypto.load_tenant_key(user_id) do
-      InferenceCredentials.put_credential(user_id, dek, provider, value)
+      InferenceCredentials.put_credential(
+        user_id,
+        dek,
+        provider,
+        value,
+        FountainWeb.Audited.attribution(socket)
+      )
     end
   end
 

--- a/apps/fountain/test/fountain_web/audit_inference_credentials_test.exs
+++ b/apps/fountain/test/fountain_web/audit_inference_credentials_test.exs
@@ -1,0 +1,196 @@
+defmodule FountainWeb.AuditInferenceCredentialsTest do
+  @moduledoc """
+  BYO inference credentials are audited from every surface (#546).
+
+  These are secret material on par with environment and vault secrets, which
+  have audited since #530. Two of the three surfaces that write them already
+  recorded their own event — the settings LiveView and the API controller —
+  and the onboarding wizard, saving the same credential through the same
+  context function, recorded nothing. That is the shape this campaign keeps
+  finding: a per-caller obligation one caller does not know about.
+
+  The recording now lives in `put_credential/5`, so these tests split into the
+  event itself and each surface's attribution.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.{Audit, Crypto, InferenceCredentials}
+
+  @token "sk-ant-audit-canary-must-not-leak"
+
+  defp events_for(user_id), do: Audit.list_recent_for_user(user_id, 100)
+
+  defp find_action(user_id, action) do
+    Enum.find(events_for(user_id), &(&1.action == action))
+  end
+
+  defp dek!(user_id) do
+    {:ok, dek} = Crypto.load_tenant_key(user_id)
+    dek
+  end
+
+  describe "the context records the write" do
+    test "setting a credential" do
+      user = insert_verified_user()
+
+      {:ok, _} =
+        InferenceCredentials.put_credential(user.id, dek!(user.id), :anthropic_api_key, @token)
+
+      event = find_action(user.id, "inference_credential.write")
+      assert event.resource_type == "inference_credential"
+      assert event.resource_id == "anthropic_api_key"
+      assert event.metadata["provider"] == "anthropic_api_key"
+      assert event.actor == "self"
+    end
+
+    test "clearing a credential is a distinct action" do
+      user = insert_verified_user()
+      dek = dek!(user.id)
+
+      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, @token)
+      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, nil)
+
+      assert find_action(user.id, "inference_credential.delete").resource_id ==
+               "anthropic_api_key"
+    end
+
+    test "an empty string clears rather than writes" do
+      # `put_credential/5` treats "" as a clear, so the event has to agree —
+      # otherwise the trail claims a credential was set when it was removed.
+      user = insert_verified_user()
+
+      {:ok, _} = InferenceCredentials.put_credential(user.id, dek!(user.id), :openai_api_key, "")
+
+      assert find_action(user.id, "inference_credential.delete")
+      refute find_action(user.id, "inference_credential.write")
+    end
+
+    test "the credential itself never reaches the trail" do
+      user = insert_verified_user()
+
+      {:ok, _} =
+        InferenceCredentials.put_credential(user.id, dek!(user.id), :anthropic_api_key, @token)
+
+      events = events_for(user.id)
+
+      # Guard the guard (#406): an empty list would pass the refute vacuously.
+      assert Enum.any?(events, &(&1.action == "inference_credential.write"))
+
+      for event <- events do
+        refute inspect(event) =~ @token
+      end
+    end
+  end
+
+  describe "the API surface attributes its write" do
+    test "PUT /api/inference-credentials/:provider", %{conn: conn} do
+      user = insert_verified_user()
+      {_record, raw_key} = insert_api_key(user)
+
+      # validate: false skips the provider ping, so this stays in the async
+      # module — the network stub is what forces the UI tests into their own.
+      conn
+      |> authed_with_key(raw_key)
+      |> put_json("/api/account/inference-credentials/anthropic_api_key", %{
+        "value" => @token,
+        "validate" => false
+      })
+      |> json_response(200)
+
+      event = find_action(user.id, "inference_credential.write")
+      assert event.actor == "api"
+      assert event.resource_id == "anthropic_api_key"
+    end
+
+    test "DELETE clears and records", %{conn: conn} do
+      user = insert_verified_user()
+      {_record, raw_key} = insert_api_key(user)
+
+      {:ok, _} =
+        InferenceCredentials.put_credential(user.id, dek!(user.id), :anthropic_api_key, @token)
+
+      conn
+      |> authed_with_key(raw_key)
+      |> delete("/api/account/inference-credentials/anthropic_api_key")
+      |> response(204)
+
+      assert find_action(user.id, "inference_credential.delete").actor == "api"
+    end
+  end
+end
+
+# The validator makes a real HTTP call, stubbed with Mimic — the stub has to be
+# visible to the LiveView process, which needs global mode and therefore its own
+# non-async module. Same split the onboarding wizard's own tests use.
+defmodule FountainWeb.AuditInferenceCredentialsUiTest do
+  @moduledoc false
+
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Audit
+
+  @token "sk-ant-ui-canary"
+
+  setup :set_mimic_global
+
+  setup do
+    stub(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 200}} end)
+    :ok
+  end
+
+  defp events_for(user_id), do: Audit.list_recent_for_user(user_id, 100)
+
+  defp find_action(user_id, action) do
+    Enum.find(events_for(user_id), &(&1.action == action))
+  end
+
+  test "saving from the settings page is attributed to the browser", %{conn: conn} do
+    user = insert_verified_user()
+
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/inference-credentials")
+
+    render_click(lv, "save", %{"provider" => "anthropic_api_key", "value" => @token})
+
+    event = find_action(user.id, "inference_credential.write")
+    assert event, "saving from settings must be audited"
+    assert event.actor == "ui"
+    assert event.request_ip
+  end
+
+  test "saving during onboarding is audited — the surface that recorded nothing", %{conn: conn} do
+    user = insert_verified_user()
+
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/onboarding/step_1")
+
+    render_click(lv, "save_credential", %{"provider" => "anthropic_api_key", "value" => @token})
+
+    event = find_action(user.id, "inference_credential.write")
+    assert event, "saving during onboarding must be audited (#546)"
+    assert event.actor == "ui"
+  end
+
+  test "one write through the UI records one event, not two", %{conn: conn} do
+    # The LiveView used to record its own event; that call had to go when the
+    # context took the job over, or every save would land twice.
+    user = insert_verified_user()
+
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/inference-credentials")
+    render_click(lv, "save", %{"provider" => "anthropic_api_key", "value" => @token})
+
+    assert Enum.count(events_for(user.id), &(&1.action == "inference_credential.write")) == 1
+  end
+
+  test "clearing from the settings page is attributed too", %{conn: conn} do
+    user = insert_verified_user()
+
+    {:ok, lv, _html} = live(login_user(conn, user), ~p"/account/inference-credentials")
+    render_click(lv, "save", %{"provider" => "anthropic_api_key", "value" => @token})
+    render_click(lv, "clear", %{"provider" => "anthropic_api_key"})
+
+    assert find_action(user.id, "inference_credential.delete").actor == "ui"
+  end
+end


### PR DESCRIPTION
Closes #546. Fourth child of #540. Independent of #583/#584 — branched off `main`, mergeable in any order.

## The issue was substantially stale — worth reading before review

#546 says these writes have "no audited surface at all" and that "there is no `/api` route for credentials." Neither is true of the current tree:

| Surface | Issue says | Actually |
|---|---|---|
| Settings LiveView | no audit | **already audits** both write and clear |
| API controller | route doesn't exist | **exists and audits** — #518/#557 added both |
| Onboarding wizard | no audit | **no audit** — the real gap |

So the finding survives, but as one surface, not three: the wizard saves the same credential through the same context function and records nothing, because it was a third caller nobody added a recording call to.

## The approach

That is the failure mode this campaign keeps meeting, so the fix is the campaign's answer rather than a fourth call site. `put_credential/5` records `inference_credential.write` / `.delete` itself. The two surfaces that had their own recording hand the job over and pass `Audited.attribution/2` instead; the wizard is covered without knowing it needed to be.

`persist_credential/3` in the wizard now takes the socket rather than a bare `user_id` — that signature is precisely why its writes were anonymous.

## Three things kept deliberately

- **The existing action names.** `inference_credential.write` / `.delete` are already in production trails. Renaming them to the `.written` / `.cleared` the issue proposes would fragment history for no gain.
- **The provider name as the whole payload.** These are BYO API keys; the credential must never reach a second table — the same rule the secret-write events follow.
- **An empty string clears rather than writes.** `put_credential/5` already treated `""` as a clear; the event follows the *ciphertext*, not the argument, so clearing via `""` records `.delete`. A trail saying `.write` there would describe the opposite of what happened. There's a test pinning it.

## Tests

New `audit_inference_credentials_test.exs`, 10 cases across two modules (the UI half needs Mimic global mode for the provider-ping stub, so it gets its own non-async module — the split the wizard's own tests already use):

- **context** — write and clear each record; `""` records a clear, not a write; the credential never reaches the trail (guard-the-guard included)
- **API** — PUT and DELETE attributed `api`
- **UI** — settings save attributed `ui` with a resolved IP; **the onboarding save**, which is the gap; one write records one event, not two; clearing attributed too

Full suite 2309 tests, 0 failures; `mix precommit` exits 0. **No existing test needed changing** — the API controller tests already assert these action names and still pass, because they're the same events emitted one layer down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)