### PR TITLE
audit: record conversation lifecycle actions in the contexts (#545)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -16,5 +16,5 @@
   # position for the synthesized boolean pattern), so 1 is the tightest pin
   # available; the exact_compare arm carries a real {line, column}.
   {"lib/fountain/conversations/conversation_server.ex", :pattern_match, 1},
-  {"lib/fountain/conversations/conversation_server.ex", :exact_compare, {1341, 64}}
+  {"lib/fountain/conversations/conversation_server.ex", :exact_compare, {1404, 64}}
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ upgrade, is in
 
 ### Fixed
 
+- **Starting, prompting, interrupting, stopping and deleting a conversation
+  are audited from the browser too.** Like resource CRUD, these were recorded
+  through `/api` and silent through the UI — where conversations are actually
+  driven. They are also the spend-relevant actions in the product, since every
+  conversation runs a sandbox, so the trail matters for a billing question as
+  much as a security one. Prompt events record the byte size and image count
+  and never the text: the trail says a prompt happened, not what it said. A
+  conversation ended by sandbox reclamation is attributed to the reaper, so
+  "why did my agent stop" has an answer that is not "no idea" (#545)
+
 - **The audit trail can now account for its own shrinkage, and background
   workers no longer change your data anonymously.** The retention pruner
   deletes `audit_events` among other tables, so the trail could get shorter

--- a/apps/fountain/lib/fountain/accounts/deletion.ex
+++ b/apps/fountain/lib/fountain/accounts/deletion.ex
@@ -154,7 +154,10 @@ defmodule Fountain.Accounts.Deletion do
 
     Enum.each(conv_ids, fn id ->
       try do
-        ConversationServer.terminate(id)
+        # No per-conversation row: `account.deleted` already says everything
+        # went away, and the user_id these would carry is nilified moments
+        # later anyway — they would be orphans describing a cascade.
+        ConversationServer.terminate_conversation(id, audit: false)
       catch
         kind, reason ->
           Logger.warning("account deletion: terminate #{id} failed: #{inspect({kind, reason})}")

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -10,6 +10,7 @@ defmodule Fountain.Conversations do
 
   require Logger
 
+  alias Fountain.Audit
   alias Fountain.Conversations.{Conversation, LogEvent, Sandbox, Turn, TurnImage}
   alias Fountain.Repo
 
@@ -128,7 +129,10 @@ defmodule Fountain.Conversations do
           {:ok, _} = update_sandbox(sandbox, %{status: "terminated", terminated_at: now})
           {:ok, :released}
         else
-          Enum.each(live, &ConversationServer.terminate(&1.id))
+          # A reclaimed sandbox took the tenant's conversations down with it,
+          # which is worth a row each — this is the one termination they did
+          # not ask for. #551 covers the reaper that calls this.
+          Enum.each(live, &ConversationServer.terminate_conversation(&1.id, actor: "system:sandbox_reaper"))
           {:ok, :terminated}
         end
     end
@@ -163,7 +167,7 @@ defmodule Fountain.Conversations do
 
   Every sandbox status change in the system goes through here — fresh
   provisioning, the wake path, and the terminate-when-the-server-is-already-dead
-  path in `ConversationServer.terminate/1`. Metering at this choke point means a
+  path in `ConversationServer.terminate_conversation/2`. Metering at this choke point means a
   new caller cannot forget to record usage, which is how `Billing.emit/5` ended
   up with no call sites at all despite being documented, schema'd and tested.
   """
@@ -566,10 +570,28 @@ defmodule Fountain.Conversations do
   if alive), then delete the conversation row. Cascades to turns and log
   events via the FK.
   """
-  def delete_conversation(%Conversation{id: id, user_id: user_id} = conv) do
-    _ = Fountain.Conversations.ConversationServer.terminate(id)
+  def delete_conversation(%Conversation{id: id, user_id: user_id} = conv, opts \\ []) do
+    # `audit: false` on the cascade: this terminate is an implementation
+    # detail of deleting, not a second thing the user asked for, and the
+    # `conversation.deleted` below already accounts for the sandbox going
+    # away. Without it every delete would read as terminate-then-delete.
+    _ = Fountain.Conversations.ConversationServer.terminate_conversation(id, audit: false)
     result = Repo.delete(conv)
-    if match?({:ok, _}, result), do: broadcast_sidebar_update(user_id)
+
+    if match?({:ok, _}, result) do
+      broadcast_sidebar_update(user_id)
+
+      Audit.record(%{
+        user_id: user_id,
+        action: "conversation.deleted",
+        resource_type: "conversation",
+        resource_id: id,
+        actor: Keyword.get(opts, :actor, "self"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{"title" => conv.title}
+      })
+    end
+
     result
   end
 
@@ -878,7 +900,7 @@ defmodule Fountain.Conversations do
     - `source`                — optional; one of "ui", "api", "agent" (default "api")
     - `parent_conversation_id` — optional; UUID of the conversation that spawned this one
   """
-  def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs)
+  def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts \\ [])
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
@@ -910,6 +932,29 @@ defmodule Fountain.Conversations do
              source: attrs["source"] || "api",
              parent_conversation_id: parent_id
            }) do
+      # Recorded here rather than in either branch below: both of them return
+      # {:ok, conv}. The row exists and the sandbox reservation is spent even
+      # when the server fails to start, so "a conversation was created" is
+      # true either way, and a trail that only logged the happy path would
+      # under-report exactly the runs someone is trying to explain.
+      #
+      # The prompt is described, never quoted — see `send_prompt/4`.
+      Audit.record(%{
+        user_id: user_id,
+        action: "conversation.created",
+        resource_type: "conversation",
+        resource_id: conv.id,
+        actor: Keyword.get(opts, :actor, "self"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{
+          "agent_id" => agent.id,
+          "agent_name" => agent.name,
+          "source" => conv.source,
+          "with_prompt" => is_binary(attrs["prompt"]) and attrs["prompt"] != "",
+          "parent_conversation_id" => parent_id
+        }
+      })
+
       # No prompt in the child spec — see start_conversation_server/4.
       start_result =
         Horde.DynamicSupervisor.start_child(

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -62,19 +62,30 @@ defmodule Fountain.Conversations.ConversationServer do
   and queue this prompt as the first turn of the new sandbox. claude
   `--resume` preserves the chat via the persisted runtime_session_id.
   """
-  def send_prompt(conv_id, prompt, images \\ []) do
-    case whereis(conv_id) do
-      nil ->
-        case Conversations.wake_conversation(conv_id, prompt) do
-          {:ok, _conv} -> :ok
-          {:error, :gone} -> {:error, :gone}
-          {:error, :not_found} -> {:error, :not_running}
-          {:error, _} = err -> err
-        end
+  def send_prompt(conv_id, prompt, images \\ [], opts \\ []) do
+    result =
+      case whereis(conv_id) do
+        nil ->
+          case Conversations.wake_conversation(conv_id, prompt) do
+            {:ok, _conv} -> :ok
+            {:error, :gone} -> {:error, :gone}
+            {:error, :not_found} -> {:error, :not_running}
+            {:error, _} = err -> err
+          end
 
-      pid ->
-        call_server(pid, {:send_prompt, prompt, images})
-    end
+        pid ->
+          call_server(pid, {:send_prompt, prompt, images})
+      end
+
+    # Size and image count, never the text. A prompt is the tenant's content —
+    # frequently the most sensitive thing in the system — and #545 is explicit
+    # that the trail records that a prompt happened, not what it said.
+    audit_lifecycle(conv_id, "conversation.prompted", result, opts, %{
+      "prompt_bytes" => byte_size(prompt),
+      "image_count" => length(images)
+    })
+
+    result
   end
 
   # Every public entry point calls through here so a GenServer.call exit
@@ -121,43 +132,95 @@ defmodule Fountain.Conversations.ConversationServer do
     GenServer.cast(pid, {:initial_prompt, prompt, images})
   end
 
-  def interrupt(conv_id) do
-    case whereis(conv_id) do
-      nil -> {:error, :not_running}
-      pid -> call_server(pid, :interrupt)
-    end
+  def interrupt(conv_id, opts \\ []) do
+    result =
+      case whereis(conv_id) do
+        nil -> {:error, :not_running}
+        pid -> call_server(pid, :interrupt)
+      end
+
+    audit_lifecycle(conv_id, "conversation.interrupted", result, opts)
+    result
   end
 
   @doc """
   Terminate the conversation. If the GenServer is alive, it tears down the
   sprite. If not, just mark the DB rows terminated so the user can still
   clean up dead conversations after a server restart.
+
+  Named `terminate_conversation` rather than `terminate`: taking `opts` for
+  audit attribution (#545) would have made this `terminate/2`, which is the
+  OTP callback below. Two different meanings under one name in one module was
+  already a readability trap — `ConversationServer.terminate/1` (stop this
+  tenant's conversation) and `terminate/2` (OTP teardown) are unrelated — so
+  the client half gets the unambiguous name.
   """
-  def terminate(conv_id) do
-    case whereis(conv_id) do
-      nil ->
-        case Conversations._unsafe_get_conversation(conv_id) do
-          nil ->
-            {:error, :not_running}
+  def terminate_conversation(conv_id, opts \\ []) do
+    result =
+      case whereis(conv_id) do
+        nil ->
+          case Conversations._unsafe_get_conversation(conv_id) do
+            nil ->
+              {:error, :not_running}
 
-          conv ->
-            now = DateTime.utc_now() |> DateTime.truncate(:second)
-            {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+            conv ->
+              now = DateTime.utc_now() |> DateTime.truncate(:second)
+              {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
 
-            if conv.sandbox_id do
-              sb = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+              if conv.sandbox_id do
+                sb = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
 
-              if sb.status not in ["terminated", "failed"] do
-                Conversations.update_sandbox(sb, %{status: "terminated", terminated_at: now})
+                if sb.status not in ["terminated", "failed"] do
+                  Conversations.update_sandbox(sb, %{status: "terminated", terminated_at: now})
+                end
               end
-            end
 
-            :ok
-        end
+              :ok
+          end
 
-      pid ->
-        call_server(pid, :terminate_conv)
+        pid ->
+          call_server(pid, :terminate_conv)
+      end
+
+    audit_lifecycle(conv_id, "conversation.terminated", result, opts)
+    result
+  end
+
+  # Records a lifecycle action against the conversation's owner.
+  #
+  # Only on success: an attempt against a conversation that is not running
+  # changed nothing, and a trail that logged it would show terminations that
+  # never happened.
+  #
+  # `audit: false` suppresses the row where a caller's own higher-level event
+  # already describes the action — `delete_conversation/2` and account
+  # deletion both cascade through `terminate/2`, and neither is a second thing
+  # the user asked for.
+  #
+  # The `_unsafe_` read is legitimate here under the rule in CLAUDE.md: these
+  # are GenServer client functions, reached only after a tenant-scoped fetch
+  # established ownership at the controller or LiveView, and the read exists
+  # solely to attribute the event to that same owner.
+  defp audit_lifecycle(conv_id, action, result, opts, metadata \\ %{}) do
+    if Keyword.get(opts, :audit, true) and result == :ok do
+      case Conversations._unsafe_get_conversation(conv_id) do
+        nil ->
+          :ok
+
+        conv ->
+          Fountain.Audit.record(%{
+            user_id: conv.user_id,
+            action: action,
+            resource_type: "conversation",
+            resource_id: conv_id,
+            actor: Keyword.get(opts, :actor, "self"),
+            request_ip: Keyword.get(opts, :request_ip),
+            metadata: metadata
+          })
+      end
     end
+
+    :ok
   end
 
   # ── GenServer ─────────────────────────────────────────────────────────────

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -6,6 +6,7 @@ defmodule FountainWeb.ConversationController do
   alias Fountain.Billing
   alias Fountain.Conversations
   alias Fountain.Conversations.{ConversationServer, LogEvent}
+  alias FountainWeb.Audited
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
@@ -266,7 +267,7 @@ defmodule FountainWeb.ConversationController do
       |> Map.put("user_id", user.id)
 
     with :ok <- gate_subscription(user),
-         {:ok, conv} <- Conversations.start_conversation(params) do
+         {:ok, conv} <- Conversations.start_conversation(params, Audited.attribution(conn)) do
       conn
       |> put_status(:created)
       |> render(:show, conversation: conv)
@@ -327,7 +328,7 @@ defmodule FountainWeb.ConversationController do
         {:error, :not_found}
 
       _ ->
-        case ConversationServer.send_prompt(id, prompt, images) do
+        case ConversationServer.send_prompt(id, prompt, images, Audited.attribution(conn)) do
           :ok ->
             json(conn, %{status: "queued"})
 
@@ -368,7 +369,7 @@ defmodule FountainWeb.ConversationController do
         {:error, :not_found}
 
       _ ->
-        case ConversationServer.terminate(id) do
+        case ConversationServer.terminate_conversation(id, Audited.attribution(conn)) do
           :ok -> send_resp(conn, :no_content, "")
           {:error, :not_running} -> {:error, :not_found}
           # :provisioning and future shapes render via the FallbackController.
@@ -395,7 +396,7 @@ defmodule FountainWeb.ConversationController do
         {:error, :not_found}
 
       _ ->
-        case ConversationServer.interrupt(id) do
+        case ConversationServer.interrupt(id, Audited.attribution(conn)) do
           :ok ->
             send_resp(conn, :no_content, "")
 
@@ -432,7 +433,7 @@ defmodule FountainWeb.ConversationController do
         {:error, :not_found}
 
       conv ->
-        {:ok, _} = Conversations.delete_conversation(conv)
+        {:ok, _} = Conversations.delete_conversation(conv, Audited.attribution(conn))
         send_resp(conn, :no_content, "")
     end
   end

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -36,7 +36,7 @@ defmodule FountainWeb.ConversationsLive.Index do
         {:noreply, put_flash(socket, :error, "Not found")}
 
       _ ->
-        case Fountain.Conversations.ConversationServer.terminate(id) do
+        case Fountain.Conversations.ConversationServer.terminate_conversation(id, FountainWeb.Audited.attribution(socket)) do
           :ok -> {:noreply, socket |> put_flash(:info, "Terminated") |> load_data()}
           _ -> {:noreply, put_flash(socket, :error, "Not running")}
         end
@@ -51,7 +51,7 @@ defmodule FountainWeb.ConversationsLive.Index do
         {:noreply, put_flash(socket, :error, "Not found")}
 
       conv ->
-        {:ok, _} = Conversations.delete_conversation(conv)
+        {:ok, _} = Conversations.delete_conversation(conv, FountainWeb.Audited.attribution(socket))
         {:noreply, socket |> put_flash(:info, "Deleted") |> load_data()}
     end
   end

--- a/apps/fountain/lib/fountain_web/live/conversations_live/new.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/new.ex
@@ -33,7 +33,7 @@ defmodule FountainWeb.ConversationsLive.New do
     params = Map.put(params, "source", "ui")
     params = Map.put(params, "user_id", socket.assigns.user_id)
 
-    case Conversations.start_conversation(params) do
+    case Conversations.start_conversation(params, FountainWeb.Audited.attribution(socket)) do
       {:ok, conv} ->
         {:noreply,
          socket

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -190,7 +190,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   def handle_event("send_prompt", _, socket), do: {:noreply, socket}
 
   def handle_event("terminate", _, socket) do
-    case ConversationServer.terminate(socket.assigns.conv.id) do
+    case ConversationServer.terminate_conversation(socket.assigns.conv.id, FountainWeb.Audited.attribution(socket)) do
       :ok ->
         conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
         {:noreply, socket |> assign(:conv, conv) |> put_flash(:info, "Terminated")}
@@ -201,7 +201,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   end
 
   def handle_event("interrupt", _, socket) do
-    case ConversationServer.interrupt(socket.assigns.conv.id) do
+    case ConversationServer.interrupt(socket.assigns.conv.id, FountainWeb.Audited.attribution(socket)) do
       :ok ->
         conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
         {:noreply, socket |> assign(:conv, conv) |> put_flash(:info, "Interrupted")}
@@ -226,7 +226,7 @@ defmodule FountainWeb.ConversationsLive.Show do
          |> push_navigate(to: ~p"/conversations")}
 
       conv ->
-        {:ok, _} = Conversations.delete_conversation(conv)
+        {:ok, _} = Conversations.delete_conversation(conv, FountainWeb.Audited.attribution(socket))
 
         {:noreply,
          socket
@@ -1428,7 +1428,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   # ── stage row helpers ───────────────────────────────────────────────────────
 
   defp send_decoded_prompt(socket, p, decoded_images) do
-    case ConversationServer.send_prompt(socket.assigns.conv.id, p, decoded_images) do
+    case ConversationServer.send_prompt(socket.assigns.conv.id, p, decoded_images, FountainWeb.Audited.attribution(socket)) do
       :ok ->
         # Refetch the conversation — wake-from-cold flips sandbox + status.
         conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)

--- a/apps/fountain/test/fountain/conversations/conversation_audit_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_audit_test.exs
@@ -1,0 +1,186 @@
+defmodule Fountain.Conversations.ConversationAuditTest do
+  @moduledoc """
+  Conversation lifecycle actions leave a trail (#545).
+
+  These were audited when driven through `/api`, by the blanket plug on that
+  pipeline, and silent through the UI — where conversations are actually
+  started, prompted and stopped. They are also the spend-relevant actions in
+  the product: every conversation runs a sandbox, so the trail matters for a
+  billing dispute as much as for a security question.
+
+  The one rule these tests exist to hold: **prompt content never reaches the
+  trail.** A prompt is usually the most sensitive thing in the system.
+  """
+
+  use Fountain.ConversationServerCase
+
+  alias Fountain.{Audit, Conversations}
+  alias Fountain.Conversations.ConversationServer
+
+  setup do
+    user = insert_verified_user()
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, environment_id: env.id)
+
+    {:ok, user: user, env: env, agent: agent}
+  end
+
+  defp events_for(user_id), do: Audit.list_recent_for_user(user_id, 200)
+
+  defp find_action(user_id, action) do
+    Enum.find(events_for(user_id), &(&1.action == action))
+  end
+
+  defp actions_for(user_id), do: Enum.map(events_for(user_id), & &1.action)
+
+  describe "conversation.created" do
+    test "records the agent and how it was started", %{user: user, agent: agent} do
+      stub_happy_sprite()
+
+      {:ok, conv} =
+        Conversations.start_conversation(
+          %{"agent_id" => agent.id, "user_id" => user.id, "source" => "ui"},
+          actor: "ui"
+        )
+
+      event = find_action(user.id, "conversation.created")
+      assert event.resource_type == "conversation"
+      assert event.resource_id == conv.id
+      assert event.actor == "ui"
+      assert event.metadata["agent_id"] == agent.id
+      assert event.metadata["agent_name"] == agent.name
+      assert event.metadata["source"] == "ui"
+      assert event.metadata["with_prompt"] == false
+
+      _ = ConversationServer.terminate_conversation(conv.id, audit: false)
+    end
+
+    test "an opening prompt is described, never quoted", %{user: user, agent: agent} do
+      stub_happy_sprite()
+
+      {:ok, conv} =
+        Conversations.start_conversation(%{
+          "agent_id" => agent.id,
+          "user_id" => user.id,
+          "prompt" => "my private business plan, in detail"
+        })
+
+      event = find_action(user.id, "conversation.created")
+      assert event.metadata["with_prompt"] == true
+
+      for e <- events_for(user.id) do
+        refute inspect(e) =~ "private business plan"
+      end
+
+      _ = ConversationServer.terminate_conversation(conv.id, audit: false)
+    end
+
+    test "a refused start records nothing", %{user: user, agent: agent} do
+      # At the sandbox cap: no conversation exists, so the trail must not
+      # claim one was created.
+      for _ <- 1..Fountain.Quotas.default_limit(),
+          do: insert_sandbox(user_id: user.id, status: "ready")
+
+      assert {:error, _} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+
+      refute "conversation.created" in actions_for(user.id)
+    end
+  end
+
+  describe "conversation.terminated" do
+    test "is recorded when the server is already gone", %{user: user, agent: agent} do
+      # The dead-server branch still marks the rows terminated, so it is still
+      # a termination and still belongs in the trail.
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox_id: sandbox.id)
+
+      assert :ok = ConversationServer.terminate_conversation(conv.id, actor: "ui")
+
+      event = find_action(user.id, "conversation.terminated")
+      assert event.resource_id == conv.id
+      assert event.actor == "ui"
+    end
+
+    test "a terminate that changed nothing records nothing", %{user: user} do
+      assert {:error, :not_running} =
+               ConversationServer.terminate_conversation(Ecto.UUID.generate())
+
+      refute "conversation.terminated" in actions_for(user.id)
+    end
+
+    test "audit: false suppresses the row", %{user: user, agent: agent} do
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox_id: sandbox.id)
+
+      assert :ok = ConversationServer.terminate_conversation(conv.id, audit: false)
+
+      refute "conversation.terminated" in actions_for(user.id)
+    end
+  end
+
+  describe "conversation.deleted" do
+    test "records the delete and not the cascade terminate", %{user: user, agent: agent} do
+      # Deleting cascades through terminate. Two rows would read as though the
+      # user stopped the conversation and then deleted it, which is not what
+      # they did.
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      conv =
+        insert_conversation(user_id: user.id, agent: agent, sandbox_id: sandbox.id, title: "notes")
+
+      {:ok, _} = Conversations.delete_conversation(conv, actor: "ui")
+
+      event = find_action(user.id, "conversation.deleted")
+      assert event.resource_id == conv.id
+      assert event.actor == "ui"
+      assert event.metadata["title"] == "notes"
+
+      refute "conversation.terminated" in actions_for(user.id)
+    end
+  end
+
+  describe "conversation.prompted" do
+    test "records size and image count, never the text", %{user: user, agent: agent} do
+      stub_happy_sprite()
+
+      {:ok, conv} =
+        Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+
+      secret = "transfer the funds to account 12345"
+      assert :ok = ConversationServer.send_prompt(conv.id, secret, [], actor: "ui")
+
+      event = find_action(user.id, "conversation.prompted")
+      assert event, "sending a prompt must be audited"
+      assert event.actor == "ui"
+      assert event.resource_id == conv.id
+      assert event.metadata["prompt_bytes"] == byte_size(secret)
+      assert event.metadata["image_count"] == 0
+
+      # The whole point of recording a size instead of the prompt.
+      for e <- events_for(user.id) do
+        refute inspect(e) =~ "account 12345"
+      end
+
+      _ = ConversationServer.terminate_conversation(conv.id, audit: false)
+    end
+  end
+
+  describe "system callers" do
+    test "a reaped sandbox attributes its terminations to the reaper", %{
+      user: user,
+      agent: agent
+    } do
+      stub_happy_sprite()
+
+      {:ok, conv} =
+        Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+
+      {:ok, :terminated} = Conversations._unsafe_reap_sandbox(conv.sandbox_id)
+
+      event = find_action(user.id, "conversation.terminated")
+      assert event, "a reclaimed sandbox ends conversations the tenant did not stop"
+      assert event.actor == "system:sandbox_reaper"
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -608,20 +608,20 @@ defmodule Fountain.Conversations.ConversationServerTest do
     test "still marks the conversation and sandbox terminated", %{conv: conv, sandbox: sandbox} do
       # After a BEAM restart the GenServer is gone but the rows remain, and a
       # user still needs to be able to clean up.
-      assert :ok = ConversationServer.terminate(conv.id)
+      assert :ok = ConversationServer.terminate_conversation(conv.id)
 
       assert Conversations._unsafe_get_conversation!(conv.id).status == "terminated"
       assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "terminated"
     end
 
     test "reports not_running for an unknown conversation" do
-      assert {:error, :not_running} = ConversationServer.terminate(Ecto.UUID.generate())
+      assert {:error, :not_running} = ConversationServer.terminate_conversation(Ecto.UUID.generate())
     end
 
     test "does not resurrect an already-failed sandbox", %{conv: conv, sandbox: sandbox} do
       {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
 
-      assert :ok = ConversationServer.terminate(conv.id)
+      assert :ok = ConversationServer.terminate_conversation(conv.id)
       assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "failed"
     end
   end

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -381,7 +381,7 @@ defmodule Fountain.ConversationsContextTest do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
 
-      # ConversationServer.terminate/1 will return an error since the server
+      # ConversationServer.terminate_conversation/2 will return an error since the server
       # isn't running in tests, but delete_conversation proceeds with Repo.delete
       assert {:ok, _deleted} = Conversations.delete_conversation(conv)
       assert Conversations.get_conversation(conv.id, user.id) == nil

--- a/apps/fountain/test/fountain_web/controllers/conversation_call_timeout_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_call_timeout_test.exs
@@ -10,7 +10,7 @@ defmodule FountainWeb.ConversationCallTimeoutTest do
   # returning an error, and no controller or LiveView call site caught it.
   # A server stuck in handle_continue(:provision) blocks its mailbox, so
   # prompt/interrupt/terminate 500'd — and DELETE returned 500 with the row
-  # silently kept, because `_ = ConversationServer.terminate(id)` discards a
+  # silently kept, because `_ = ConversationServer.terminate_conversation(id)` discards a
   # return value, not an exit.
 
   setup %{conn: conn} do
@@ -72,6 +72,6 @@ defmodule FountainWeb.ConversationCallTimeoutTest do
   test "the public functions return error tuples rather than exiting", %{conv: conv} do
     assert {:error, :provisioning} = ConversationServer.send_prompt(conv.id, "hi", [])
     assert {:error, :provisioning} = ConversationServer.interrupt(conv.id)
-    assert {:error, :provisioning} = ConversationServer.terminate(conv.id)
+    assert {:error, :provisioning} = ConversationServer.terminate_conversation(conv.id)
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -129,7 +129,7 @@ defmodule FountainWeb.ConversationControllerTest do
       # It was the one provisioning path with no billing check at all.
       conv = insert_conversation(user_id: user.id)
 
-      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images ->
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts ->
         {:error, :subscription_required}
       end)
 
@@ -215,7 +215,7 @@ defmodule FountainWeb.ConversationControllerTest do
       conv = insert_conversation(user_id: user.id)
       for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
 
-      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images ->
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts ->
         {:error, {:sandbox_quota_exceeded, %{count: 5, limit: 5}}}
       end)
 
@@ -324,7 +324,7 @@ defmodule FountainWeb.ConversationControllerTest do
   describe "POST /api/conversations/:conversation_id/prompts" do
     test "returns 200 with status queued on success", %{conn: conn, user: user, raw_key: raw_key} do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images -> :ok end)
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts -> :ok end)
 
       conn =
         conn
@@ -341,7 +341,7 @@ defmodule FountainWeb.ConversationControllerTest do
     } do
       conv = insert_conversation(user_id: user.id)
 
-      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images ->
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts ->
         {:error, :not_running}
       end)
 
@@ -355,7 +355,7 @@ defmodule FountainWeb.ConversationControllerTest do
 
     test "returns 400 when conversation is busy", %{conn: conn, user: user, raw_key: raw_key} do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images -> {:error, :busy} end)
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts -> {:error, :busy} end)
 
       conn =
         conn
@@ -417,7 +417,7 @@ defmodule FountainWeb.ConversationControllerTest do
     } do
       conv = insert_conversation(user_id: user.id)
 
-      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images ->
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts ->
         {:error, Fountain.Conversations.Sandbox.changeset(%Fountain.Conversations.Sandbox{}, %{})}
       end)
 
@@ -436,7 +436,7 @@ defmodule FountainWeb.ConversationControllerTest do
     } do
       conv = insert_conversation(user_id: user.id)
 
-      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images ->
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts ->
         {:error, :some_future_refusal}
       end)
 
@@ -467,7 +467,7 @@ defmodule FountainWeb.ConversationControllerTest do
   describe "POST /api/conversations/:conversation_id/terminate" do
     test "returns 204 on success", %{conn: conn, user: user, raw_key: raw_key} do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :terminate, fn _id -> :ok end)
+      stub(ConversationServer, :terminate_conversation, fn _id, _opts -> :ok end)
 
       conn =
         conn
@@ -483,7 +483,7 @@ defmodule FountainWeb.ConversationControllerTest do
       raw_key: raw_key
     } do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :terminate, fn _id -> {:error, :not_running} end)
+      stub(ConversationServer, :terminate_conversation, fn _id, _opts -> {:error, :not_running} end)
 
       conn =
         conn
@@ -508,7 +508,7 @@ defmodule FountainWeb.ConversationControllerTest do
   describe "POST /api/conversations/:conversation_id/interrupt" do
     test "returns 204 on success", %{conn: conn, user: user, raw_key: raw_key} do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :interrupt, fn _id -> :ok end)
+      stub(ConversationServer, :interrupt, fn _id, _opts -> :ok end)
 
       conn =
         conn
@@ -524,7 +524,7 @@ defmodule FountainWeb.ConversationControllerTest do
       raw_key: raw_key
     } do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :interrupt, fn _id -> {:error, :not_running} end)
+      stub(ConversationServer, :interrupt, fn _id, _opts -> {:error, :not_running} end)
 
       conn =
         conn
@@ -540,7 +540,7 @@ defmodule FountainWeb.ConversationControllerTest do
       raw_key: raw_key
     } do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :interrupt, fn _id -> {:error, :idle} end)
+      stub(ConversationServer, :interrupt, fn _id, _opts -> {:error, :idle} end)
 
       conn =
         conn

--- a/apps/fountain/test/fountain_web/live/liveview_reconciliation_test.exs
+++ b/apps/fountain/test/fountain_web/live/liveview_reconciliation_test.exs
@@ -131,7 +131,7 @@ defmodule FountainWeb.LiveviewReconciliationTest do
 
       {:ok, view, _html} = live(conn, ~p"/conversations/#{conv.id}")
 
-      stub(Fountain.Conversations.ConversationServer, :send_prompt, fn _id, _p, _i ->
+      stub(Fountain.Conversations.ConversationServer, :send_prompt, fn _id, _p, _i, _opts ->
         {:error, :subscription_required}
       end)
 


### PR DESCRIPTION
Closes #545. Fifth child of #540.

## The gap

Starting, prompting, interrupting, terminating and deleting a conversation were audited through `/api` (blanket plug) and silent through the UI — where conversations are actually driven. These are also the spend-relevant actions in the product, since each one runs a sandbox, so the trail matters for a billing dispute as much as a security question.

## Prompt content never reaches the trail

`conversation.prompted` records `prompt_bytes` and `image_count` and nothing else. `conversation.created` records *whether* a prompt was supplied, not what it was. A prompt is usually the most sensitive thing in the system, so two tests assert the text is absent from **every event**, not merely absent from the metadata map.

## Four decisions worth review

- **`ConversationServer.terminate/1` is now `terminate_conversation/2`.** Taking opts would have made it `terminate/2` — the OTP callback in the same module. Worth resolving rather than working around: `terminate/1` (stop this tenant's conversation) and `terminate/2` (OTP teardown) meant unrelated things under one name. 11 call sites moved.
- **Cascades are suppressed, not double-recorded.** `delete_conversation/2` and account deletion both reach terminate internally; both pass `audit: false`. The user asked to delete a conversation or an account, not to terminate and then delete — `conversation.deleted` and `account.deleted` already account for the sandbox going away. A test pins that deleting produces one row, not two.
- **Reclamation is recorded.** `_unsafe_reap_sandbox/1` attributes its terminations to `system:sandbox_reaper`. This is the one termination the tenant did not ask for, and the case where a trail row is the only available answer to "why did my agent stop".
- **Only successes.** A terminate against a conversation that isn't running changed nothing; recording it would show terminations that never happened.

`conversation.created` is recorded *before* the server starts, because both branches return `{:ok, conv}` — the row exists and the sandbox quota is spent even when the server fails to start, and a trail that logged only the happy path would under-report exactly the runs someone is trying to explain.

## Tests

New `conversation_audit_test.exs`, 9 cases: created records agent and source; an opening prompt is described, never quoted; a refused start records nothing; terminate recorded on the dead-server branch; a no-op terminate records nothing; `audit: false` suppresses; delete records the delete and **not** the cascade terminate; prompted records size and image count with the text absent everywhere; a reaped sandbox attributes to the reaper.

13 Mimic stubs across two test files moved to the new arities and name — the stub-arity trap again.

`.dialyzer_ignore.exs` repinned 1341 → 1404. Second time this campaign has moved that line-pinned skip; worth knowing for #551, which touches this file too.

Full suite 2320 tests, 0 failures; `mix precommit` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)