### PR TITLE
audit: give system-actor writes a trail, starting with the pruner (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ upgrade, is in
 
 ### Fixed
 
+- **The audit trail can now account for its own shrinkage, and background
+  workers no longer change your data anonymously.** The retention pruner
+  deletes `audit_events` among other tables, so the trail could get shorter
+  with nothing to say when or by how much; it now records one summary per run
+  with per-table counts, written after the pruning so a shortened window
+  cannot delete the record of the deletion. The sandbox reaper's expiries and
+  stuck-sandbox releases, an export completing, failing or aging out, and the
+  bulk trial backfill in the release task all record too, each attributed to
+  the worker that did it. Previously "my sandbox vanished" and "I asked for my
+  data and never heard back" had answers only in the server log (#551)
+
 - **Saving an inference credential during onboarding is audited like saving
   one anywhere else.** BYO provider keys are secret material on par with
   environment and vault secrets, and the settings page and API already

--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -9,6 +9,39 @@ defmodule Fountain.Audit do
   Logging is best-effort: a log failure must never break the operation
   it's recording. Use `record!/1` only when you can tolerate raising;
   default to `record/1`.
+
+  Best-effort means *rescuing*, which does not survive a transaction: a failed
+  insert inside one aborts the enclosing transaction. Call this outside the
+  transaction whose work you are recording — `Accounts.Deletion`,
+  `Agents.upload_avatar/4` and `Accounts.register_user/2` all do.
+
+  ## Where events come from
+
+  Mutations audit **inside the context function**, not at each caller, so the
+  UI, the API, background workers and any future surface are covered by
+  construction rather than by remembering. Callers pass only what a context
+  cannot know about its caller — `:actor` and `:request_ip`, from
+  `FountainWeb.Audited.attribution/2` on a web surface, or a
+  `"system:<worker>"` string from a background one.
+
+  ## Deliberately not audited
+
+  High-volume machine state is not audit material, and recording it would bury
+  the events that are. These are decisions, not oversights (#551):
+
+    * `ConversationServer`'s per-turn state-machine writes — turn started,
+      output chunk, turn ended. The conversation's own log events already hold
+      this, at the right granularity.
+    * `Accounts.touch_api_key/1` — a last-used stamp on every authenticated
+      request. The key's *creation* and *revocation* are audited; its use is
+      what the request log is for.
+    * `Conversations.mark_read/2` and theme/preference updates — reading and
+      display settings are not state changes anyone audits.
+
+  Two system paths record a **summary per run** rather than per row, for the
+  same reason: `Workers.RetentionPruner` (which deletes `audit_events`, so the
+  trail must be able to account for its own shrinkage) and the trial-backfill
+  release task.
   """
 
   import Ecto.Query

--- a/apps/fountain/lib/fountain/exports.ex
+++ b/apps/fountain/lib/fountain/exports.ex
@@ -210,8 +210,12 @@ defmodule Fountain.Exports do
     })
     |> Repo.update()
     |> tap(fn
-      {:ok, updated} -> broadcast(updated.user_id)
-      _ -> :ok
+      {:ok, updated} ->
+        broadcast(updated.user_id)
+        record_transition(updated, "account.export_completed", %{"bytes" => raw_bytes})
+
+      _ ->
+        :ok
     end)
   end
 
@@ -221,19 +225,60 @@ defmodule Fountain.Exports do
     |> Export.changeset(%{status: "failed", error: String.slice(inspect(reason), 0, 250)})
     |> Repo.update()
     |> tap(fn
-      {:ok, updated} -> broadcast(updated.user_id)
-      _ -> :ok
+      {:ok, updated} ->
+        broadcast(updated.user_id)
+        # The reason is already truncated to 250 chars on the row itself.
+        record_transition(updated, "account.export_failed", %{"error" => updated.error})
+
+      _ ->
+        :ok
     end)
+  end
+
+  # The request and the download were audited; the outcome in between was not,
+  # so a trail could show a user asking for their data and never show whether
+  # the export succeeded, failed, or quietly expired before they fetched it
+  # (#551). The worker is the actor — nobody asked for these transitions.
+  defp record_transition(%Export{} = export, action, metadata) do
+    Audit.record(%{
+      user_id: export.user_id,
+      action: action,
+      resource_type: "export",
+      resource_id: export.id,
+      actor: "system:account_export",
+      metadata: metadata
+    })
   end
 
   @doc "Delete exports past their expiry. Returns the number deleted."
   def purge_expired do
     now = DateTime.utc_now()
 
+    # Read the owners before deleting: an expiry is the user's artifact going
+    # away, so it belongs in their trail, and after the delete nothing links
+    # the rows to anybody.
+    expiring =
+      Repo.all(
+        from e in Export,
+          where: not is_nil(e.expires_at) and e.expires_at <= ^now,
+          select: {e.id, e.user_id}
+      )
+
     {count, _} =
       Repo.delete_all(
         from e in Export, where: not is_nil(e.expires_at) and e.expires_at <= ^now
       )
+
+    Enum.each(expiring, fn {id, user_id} ->
+      Audit.record(%{
+        user_id: user_id,
+        action: "account.export_expired",
+        resource_type: "export",
+        resource_id: id,
+        actor: "system:retention_pruner",
+        metadata: %{}
+      })
+    end)
 
     count
   end

--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -182,6 +182,23 @@ defmodule Fountain.Release do
           set: [subscription_status: "trialing", trial_ends_at: ends_at]
         )
 
+      # One summary row, not one per account: a bulk backfill is a single
+      # operator action. Without it the only trace of an operator moving every
+      # account's billing clock was stdout on whichever shell ran it — and the
+      # promote-admin task beside this one has recorded since it was written
+      # (#551).
+      Fountain.Audit.record(%{
+        user_id: nil,
+        action: "release.trials_backfilled",
+        resource_type: "release_task",
+        actor: "system:release_task",
+        metadata: %{
+          "accounts_updated" => updated,
+          "trial_ends_at" => DateTime.to_iso8601(ends_at),
+          "days" => days
+        }
+      })
+
       IO.puts("Set trial_ends_at to #{ends_at} on #{updated} account(s).")
       {:ok, updated}
     end

--- a/apps/fountain/lib/fountain/workers/retention_pruner.ex
+++ b/apps/fountain/lib/fountain/workers/retention_pruner.ex
@@ -69,7 +69,40 @@ defmodule Fountain.Workers.RetentionPruner do
       Logger.info("retention: pruned #{deleted} rows (#{detail})")
     end
 
+    record_run(results, deleted)
+
     :ok
+  end
+
+  # One summary row per run, not one per deleted row — the point is that the
+  # trail can account for its own shrinkage, and per-row events would be the
+  # thing being pruned.
+  #
+  # Written *after* the pruning, deliberately: a row written first would sit
+  # inside the same transaction-less pass that deletes `audit_events`, and on a
+  # run where the window had been shortened it could delete the record of
+  # itself. Written after, this run's summary is always newer than its own
+  # cutoff.
+  #
+  # `user_id: nil` — this is a system event spanning every tenant, so it
+  # belongs to the admin views (`_unsafe_list_recent/1`) rather than to any one
+  # trail. A zero-deletion run records nothing: it is the deletions that need
+  # accounting for, and a daily row saying "removed nothing" would bury them.
+  defp record_run(_results, 0), do: :ok
+
+  defp record_run(results, deleted) do
+    counts =
+      results
+      |> Enum.reject(&(elem(&1, 1) == 0))
+      |> Map.new(fn {table, n} -> {to_string(table), n} end)
+
+    Fountain.Audit.record(%{
+      user_id: nil,
+      action: "retention.pruned",
+      resource_type: "retention_run",
+      actor: "system:retention_pruner",
+      metadata: Map.put(counts, "total", deleted)
+    })
   end
 
   @doc "Retention window in days for `table`, or nil when disabled."

--- a/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
@@ -110,6 +110,8 @@ defmodule Fountain.Workers.SandboxReaper do
     |> Repo.preload(:conversations)
     |> Enum.reject(&server_alive?/1)
     |> Enum.map(fn sandbox ->
+      was = sandbox.status
+
       {:ok, _} =
         Conversations.update_sandbox(sandbox, %{
           status: "failed",
@@ -121,6 +123,11 @@ defmodule Fountain.Workers.SandboxReaper do
           "after #{@stuck_after_minutes}m in #{sandbox.status}"
       )
 
+      record_reap(sandbox, "sandbox.released_stuck", %{
+        "previous_status" => was,
+        "stuck_after_minutes" => @stuck_after_minutes
+      })
+
       sandbox
     end)
     |> length()
@@ -129,6 +136,22 @@ defmodule Fountain.Workers.SandboxReaper do
   # A live ConversationServer means provisioning is still in flight somewhere in
   # the cluster, however long it has taken. Horde's registry is cluster-wide, so
   # this is not just a local check.
+  # A sandbox the tenant did not stop, ending for a reason only the reaper
+  # knows. Attributed to the worker so "my agent's sandbox vanished" has an
+  # answer in the tenant's own trail rather than only in the server log —
+  # `admin.sandbox.reaped` covered the admin-clicked path and nothing covered
+  # this one (#551).
+  defp record_reap(%Sandbox{} = sandbox, action, metadata) do
+    Fountain.Audit.record(%{
+      user_id: sandbox.user_id,
+      action: action,
+      resource_type: "sandbox",
+      resource_id: sandbox.id,
+      actor: "system:sandbox_reaper",
+      metadata: Map.put(metadata, "sprite_name", sandbox.sprite_name)
+    })
+  end
+
   defp server_alive?(%Sandbox{conversations: conversations}) do
     Enum.any?(conversations, fn conv -> ConversationServer.whereis(conv.id) != nil end)
   end
@@ -204,6 +227,8 @@ defmodule Fountain.Workers.SandboxReaper do
       "reaper: expired abandoned sandbox #{sandbox.id} (#{sandbox.sprite_name}) — " <>
         "ready with no live server past its lifetime bound"
     )
+
+    record_reap(sandbox, "sandbox.expired", %{"reason" => "past lifetime bound"})
 
     # The conversation is deliberately left alone. It stays resumable, and the
     # next prompt provisions a fresh sandbox with the same runtime session.

--- a/apps/fountain/test/fountain/audit_system_actors_test.exs
+++ b/apps/fountain/test/fountain/audit_system_actors_test.exs
@@ -1,0 +1,122 @@
+defmodule Fountain.AuditSystemActorsTest do
+  @moduledoc """
+  Background paths that mutate tenant data leave a trail too (#551).
+
+  The precedent this follows is `UnverifiedAccountPruner`, which deletes
+  through `Accounts.Deletion` with `actor: "system:unverified_pruner"` and gets
+  audited for free. Everything here was the opposite: real changes to a
+  tenant's data, attributable to nothing but a line in the server log.
+
+  The sharpest case is the retention pruner, which deletes `audit_events`
+  itself — so before this the trail could shrink with no record of when or by
+  how much.
+  """
+
+  use Fountain.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Fountain.{Audit, Exports, Repo}
+  alias Fountain.Workers.RetentionPruner
+
+  defp system_events(action) do
+    Audit._unsafe_list_recent(200) |> Enum.filter(&(&1.action == action))
+  end
+
+  defp find_for_user(user_id, action) do
+    user_id |> Audit.list_recent_for_user(200) |> Enum.find(&(&1.action == action))
+  end
+
+  defp backdate_audit_events(days) do
+    cutoff = DateTime.utc_now() |> DateTime.add(-days * 86_400, :second)
+
+    Repo.update_all(from(e in Audit.Event), set: [inserted_at: cutoff])
+  end
+
+  describe "the retention pruner accounts for its own deletions" do
+    test "a run that deleted rows records a summary with per-table counts" do
+      user = insert_verified_user()
+
+      # Give it something to delete: age every audit row past the window.
+      # These are the account's own registration/creation events (#544).
+      assert Repo.aggregate(from(e in Audit.Event), :count) > 0
+      backdate_audit_events(400)
+
+      # perform/1, not prune/1 — the summary is a property of a run, and
+      # pruning first would leave the run with nothing to account for.
+      :ok = RetentionPruner.perform(%Oban.Job{args: %{}})
+
+      assert [event] = system_events("retention.pruned")
+      assert event.actor == "system:retention_pruner"
+      assert event.resource_type == "retention_run"
+
+      # A system event spans every tenant, so it belongs to the admin view
+      # rather than to any one trail.
+      assert event.user_id == nil
+      refute find_for_user(user.id, "retention.pruned")
+    end
+
+    test "the summary survives the run that wrote it" do
+      # Written after the pruning, so a shortened window cannot delete the
+      # record of the deletion. This is the property that makes the trail able
+      # to account for its own shrinkage.
+      insert_verified_user()
+      backdate_audit_events(400)
+
+      :ok = RetentionPruner.perform(%Oban.Job{args: %{}})
+
+      assert [event] = system_events("retention.pruned")
+      assert event.metadata["total"] > 0
+      assert event.metadata["audit_events"] > 0
+    end
+
+    test "a run that deleted nothing records nothing" do
+      # A daily row saying "removed nothing" would bury the ones that matter.
+      :ok = RetentionPruner.perform(%Oban.Job{args: %{}})
+
+      assert system_events("retention.pruned") == []
+    end
+  end
+
+  describe "export transitions" do
+    setup do
+      user = insert_verified_user()
+      {:ok, export} = Exports.request_export(user)
+      {:ok, user: user, export: export}
+    end
+
+    test "completion is recorded against the owner", %{user: user, export: export} do
+      {:ok, _} = Exports.complete_export(export, :zlib.gzip("{}"), 2)
+
+      event = find_for_user(user.id, "account.export_completed")
+      assert event, "an export finishing must be visible to the person who asked for it"
+      assert event.actor == "system:account_export"
+      assert event.resource_id == export.id
+    end
+
+    test "failure is recorded, so a request cannot just go quiet", %{user: user, export: export} do
+      {:ok, _} = Exports.fail_export(export, :boom)
+
+      event = find_for_user(user.id, "account.export_failed")
+      assert event.actor == "system:account_export"
+      assert event.metadata["error"] =~ "boom"
+    end
+
+    test "expiry is recorded against the owner", %{user: user, export: export} do
+      {:ok, export} = Exports.complete_export(export, :zlib.gzip("{}"), 2)
+
+      # Past its expiry.
+      Repo.update_all(
+        from(e in Exports.Export, where: e.id == ^export.id),
+        set: [expires_at: DateTime.utc_now() |> DateTime.add(-60, :second)]
+      )
+
+      assert Exports.purge_expired() == 1
+
+      event = find_for_user(user.id, "account.export_expired")
+      assert event, "an artifact aging out is still the user's data going away"
+      assert event.actor == "system:retention_pruner"
+      assert event.resource_id == export.id
+    end
+  end
+end


### PR DESCRIPTION
Closes #551. Sixth child of #540.

## The sharpest gap: the pruner deletes the trail

`RetentionPruner` deletes `audit_events` among other tables, so the trail could get **shorter with no record of when or by how much** — the one gap in an append-only log that undermines everything else in it. It now records one summary per run with per-table counts.

Two details there matter:

- **The row is written after the pruning, not before.** A row written first would sit in the same pass that deletes `audit_events`, and on a run where the window had been shortened it could delete the record of itself. A test pins that the summary survives the run that wrote it.
- **A run that deleted nothing records nothing.** A daily row saying "removed zero rows" would bury the runs that removed something.

## Also covered

Each attributed to the worker, not to the tenant who didn't ask for it:

| Path | Event | Why it matters |
|---|---|---|
| `SandboxReaper` | `sandbox.expired`, `sandbox.released_stuck` | The admin-clicked path recorded `admin.sandbox.reaped`; the automatic one — far more common — recorded nothing. "Why did my sandbox vanish" now has an answer in the tenant's own trail. |
| `Exports.complete_export` / `fail_export` / `purge_expired` | `account.export_completed` / `_failed` / `_expired` | The request and download were audited; the outcome between them wasn't. A trail could show someone asking for their data and never show whether it succeeded, failed, or expired unfetched. |
| `release.ex` trial backfill | `release.trials_backfilled` | A bulk `update_all` over every account's billing clock whose only trace was stdout on whichever shell ran it — while the promote-admin task beside it has recorded since it was written. |

`purge_expired/0` reads the owners **before** deleting: afterwards nothing links those rows to anybody.

## The exclusions are now written down

The `Fountain.Audit` moduledoc carries the deliberate non-coverage as a decision rather than an omission — per-turn `ConversationServer` state, `touch_api_key` last-used stamps, `mark_read`, theme preferences — with the reasoning that high-volume machine state would bury the events that matter.

It also documents the two rules this campaign established:
- mutations audit **in the context**, not the caller;
- never **inside a transaction**, because best-effort-by-rescuing doesn't survive one (the trap that hit `upload_avatar`, `delete_avatar` and `register_user`).

## Tests

New `audit_system_actors_test.exs`, 6 cases: the pruner records a summary with per-table counts as a system event (`user_id: nil`, admin-visible, absent from any tenant trail); the summary survives its own run; a no-op run records nothing; export completion, failure and expiry each recorded against the owner.

Full suite 2324 tests, 0 failures; `mix precommit` exits 0, first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)