### PR TITLE
audit: record subscription state changes in the billing context (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ upgrade, is in
 
 ### Fixed
 
+- **Your subscription changing state is in your own audit trail now.** The
+  billing context recorded nothing, so an account could move from active to
+  cancelled, or from trialing to gated, and the person it happened to saw only
+  the result. Admin-initiated changes did land in the privilege trail, but the
+  page users actually read never showed that table. Every transition —
+  Stripe-driven, operator-driven, or decided by the trial sweeper — now
+  records both ends of the change plus which of those three moved it, because
+  "cancelled" means something different depending on who did it. A sync that
+  reasserts the status an account already had records nothing, so the real
+  transitions stay findable (#550)
+
 - **Starting, prompting, interrupting, stopping and deleting a conversation
   are audited from the browser too.** Like resource CRUD, these were recorded
   through `/api` and silent through the UI — where conversations are actually

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -32,6 +32,7 @@ defmodule Fountain.Billing do
   require Logger
 
   alias Fountain.Accounts.User
+  alias Fountain.Audit
   alias Fountain.Billing.UsageEvent
   alias Fountain.Repo
 
@@ -271,6 +272,7 @@ defmodule Fountain.Billing do
           subscription_synced_at: DateTime.utc_now() |> DateTime.truncate(:second)
         })
         |> Repo.update()
+        |> audit_billing(user, "billing.trial.started", "stripe")
 
       {:error, reason} ->
         {:error, reason}
@@ -286,6 +288,65 @@ defmodule Fountain.Billing do
     user
     |> User.billing_changeset(%{trial_ends_at: trial_end_from_now()})
     |> Repo.update()
+    |> audit_billing(user, "billing.trial.started", "local")
+  end
+
+  # ── audit ─────────────────────────────────────────────────────────────────
+  #
+  # Subscription state changed under the tenant with nothing to explain it:
+  # this module had zero `Audit.record` calls, so an account could go from
+  # `active` to `canceled` and the person it happened to saw only the result
+  # (#550). Admin-initiated billing changes landed in `admin_audit_events`,
+  # which the tenant-facing `/audit` never reads.
+  #
+  # `source` is the point. "Your subscription was cancelled" means something
+  # different depending on whether Stripe said so, an operator did it, or a
+  # sweeper decided a trial had run out, and the status column cannot tell
+  # those apart.
+  #
+  # Only real transitions are recorded — a sync that reasserts the status the
+  # account already had is not news, and the webhook path re-syncs constantly.
+
+  defp audit_billing(result, before, action, source, extra \\ %{})
+
+  defp audit_billing({:ok, %User{} = updated} = ok, %User{} = before, action, source, extra) do
+    record_billing_transition(before, updated, action, source, extra)
+    ok
+  end
+
+  defp audit_billing(%User{} = updated, %User{} = before, action, source, extra) do
+    record_billing_transition(before, updated, action, source, extra)
+    updated
+  end
+
+  defp audit_billing(other, _before, _action, _source, _extra), do: other
+
+  defp record_billing_transition(%User{} = before, %User{} = updated, action, source, extra) do
+    changed? =
+      before.subscription_status != updated.subscription_status or
+        before.trial_ends_at != updated.trial_ends_at or
+        before.stripe_customer_id != updated.stripe_customer_id or
+        before.cancel_at_period_end != updated.cancel_at_period_end
+
+    if changed? do
+      Audit.record(%{
+        user_id: updated.id,
+        action: action,
+        resource_type: "subscription",
+        resource_id: updated.stripe_subscription_id,
+        actor: "system:#{source}",
+        metadata:
+          Map.merge(
+            %{
+              "source" => source,
+              "from_status" => before.subscription_status,
+              "to_status" => updated.subscription_status,
+              "cancel_at_period_end" => updated.cancel_at_period_end
+            },
+            extra
+          )
+      })
+    end
   end
 
   @doc false
@@ -349,6 +410,7 @@ defmodule Fountain.Billing do
         subscription_synced_at: DateTime.truncate(now, :second)
       })
       |> Repo.update()
+      |> audit_billing(user, "billing.trial.extended", "admin", %{"days" => days})
     end
   end
 
@@ -488,6 +550,7 @@ defmodule Fountain.Billing do
             )
             |> Repo.update!()
             |> tap(&enqueue_lifecycle_email(user.subscription_status, &1))
+            |> audit_billing(user, "billing.trial.expired", "trial_sweeper")
 
           _ ->
             Repo.rollback(:not_trialing)
@@ -563,6 +626,7 @@ defmodule Fountain.Billing do
           |> User.billing_changeset(attrs)
           |> Repo.update!()
           |> tap(&enqueue_lifecycle_email(user.subscription_status, &1))
+          |> audit_billing(user, "billing.subscription.resynced", "admin")
       end
     end)
   end
@@ -609,6 +673,7 @@ defmodule Fountain.Billing do
       user
       |> User.billing_changeset(%{subscription_status: "comped"})
       |> Repo.update()
+      |> audit_billing(user, "billing.comped", "admin")
     end
   end
 
@@ -621,6 +686,7 @@ defmodule Fountain.Billing do
     user
     |> User.billing_changeset(%{subscription_status: "canceled"})
     |> Repo.update()
+    |> audit_billing(user, "billing.comp_revoked", "admin")
   end
 
   def revoke_comp(%User{}), do: {:error, :not_comped}
@@ -1154,6 +1220,9 @@ defmodule Fountain.Billing do
               {:ok, updated} -> enqueue_lifecycle_email(user.subscription_status, updated)
               _ -> :ok
             end)
+            |> audit_billing(user, "billing.subscription.synced", "webhook", %{
+              "event_type" => type
+            })
         end
     end
   end
@@ -1234,6 +1303,7 @@ defmodule Fountain.Billing do
               {:ok, updated} -> enqueue_lifecycle_email("past_due", updated)
               _ -> :ok
             end)
+            |> audit_billing(user, "billing.payment.recovered", "webhook")
         end
 
       %User{} ->

--- a/ee/test/fountain/billing_audit_test.exs
+++ b/ee/test/fountain/billing_audit_test.exs
@@ -1,0 +1,151 @@
+defmodule Fountain.BillingAuditTest do
+  @moduledoc """
+  Subscription state changes leave a trail (#550).
+
+  `Fountain.Billing` had zero `Audit.record` calls, so an account could move
+  from `active` to `canceled` — or from `trialing` to gated — and the person it
+  happened to saw only the result. Admin-initiated billing changes did land in
+  `admin_audit_events`, but the tenant-facing `/audit` never reads that table,
+  so from the user's own trail their subscription changed state for no stated
+  reason.
+
+  The `source` in each event is the point: "your subscription was cancelled"
+  means something different depending on whether Stripe said so, an operator
+  did it, or a sweeper decided the trial had run out — and `subscription_status`
+  alone cannot tell those apart.
+  """
+
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Audit, Billing, Repo}
+
+  defp customer_user do
+    user = insert_verified_user()
+    Repo.update!(Ecto.Changeset.change(user, stripe_customer_id: "cus_audit123"))
+  end
+
+  defp billing_events(user_id) do
+    user_id
+    |> Audit.list_recent_for_user(100)
+    |> Enum.filter(&String.starts_with?(&1.action, "billing."))
+  end
+
+  defp find_action(user_id, action) do
+    Enum.find(billing_events(user_id), &(&1.action == action))
+  end
+
+  describe "the webhook path" do
+    test "a status change produces a row for the affected user" do
+      # The acceptance criterion of #550.
+      user = customer_user()
+
+      event = %Stripe.Event{
+        type: "customer.subscription.updated",
+        data: %{object: %{customer: "cus_audit123", status: "active", trial_end: nil}}
+      }
+
+      assert {:ok, updated} = Billing.sync_subscription(event)
+      assert updated.subscription_status == "active"
+
+      event = find_action(user.id, "billing.subscription.synced")
+      assert event, "a webhook that changes subscription status must be audited"
+      assert event.user_id == user.id
+      assert event.resource_type == "subscription"
+      assert event.actor == "system:webhook"
+      assert event.metadata["source"] == "webhook"
+      assert event.metadata["from_status"] == user.subscription_status
+      assert event.metadata["to_status"] == "active"
+      assert event.metadata["event_type"] == "customer.subscription.updated"
+    end
+
+    test "a cancellation is recorded with both ends of the transition" do
+      user = customer_user()
+
+      {:ok, _} =
+        Billing.sync_subscription(%Stripe.Event{
+          type: "customer.subscription.updated",
+          data: %{object: %{customer: "cus_audit123", status: "active", trial_end: nil}}
+        })
+
+      {:ok, _} =
+        Billing.sync_subscription(%Stripe.Event{
+          type: "customer.subscription.deleted",
+          data: %{object: %{customer: "cus_audit123", status: "active", trial_end: nil}}
+        })
+
+      cancelled =
+        billing_events(user.id)
+        |> Enum.find(&(&1.metadata["to_status"] == "canceled"))
+
+      assert cancelled, "a cancellation is the change a user is most likely to ask about"
+      assert cancelled.metadata["from_status"] == "active"
+    end
+
+    test "a sync that changes nothing records nothing" do
+      # The webhook path re-syncs constantly; a row per no-op would bury the
+      # transitions that matter.
+      user = customer_user()
+
+      event = %Stripe.Event{
+        type: "customer.subscription.updated",
+        data: %{object: %{customer: "cus_audit123", status: "active", trial_end: nil}}
+      }
+
+      assert {:ok, _} = Billing.sync_subscription(event)
+      before = length(billing_events(user.id))
+
+      assert {:ok, _} = Billing.sync_subscription(event)
+      assert length(billing_events(user.id)) == before
+    end
+  end
+
+  describe "operator levers" do
+    test "comping and un-comping are attributed to an admin" do
+      user = customer_user()
+      stub(Stripe.Subscription, :list, fn _params -> {:ok, %{data: []}} end)
+
+      {:ok, _} = Billing.comp_account(user)
+      comped = find_action(user.id, "billing.comped")
+      assert comped.metadata["to_status"] == "comped"
+      assert comped.metadata["source"] == "admin"
+
+      {:ok, comped_user} = {:ok, Repo.reload!(user)}
+      {:ok, _} = Billing.revoke_comp(comped_user)
+
+      revoked = find_action(user.id, "billing.comp_revoked")
+      assert revoked.metadata["from_status"] == "comped"
+      assert revoked.metadata["to_status"] == "canceled"
+    end
+
+    test "extending a trial records how long by" do
+      user = customer_user()
+      # `push_stripe_trial_end/2` lists first and only updates if it finds a
+      # trialing subscription; an empty list short-circuits to :ok.
+      stub(Stripe.Subscription, :list, fn _params -> {:ok, %{data: []}} end)
+
+      {:ok, _} = Billing.extend_trial(user, 7)
+
+      event = find_action(user.id, "billing.trial.extended")
+      assert event.metadata["days"] == 7
+      assert event.metadata["source"] == "admin"
+    end
+  end
+
+  describe "attribution" do
+    test "the source distinguishes who moved the account" do
+      # Two accounts reaching "canceled" by different routes must be
+      # distinguishable in the trail — that is the whole reason source exists.
+      webhook_user = customer_user()
+
+      {:ok, _} =
+        Billing.sync_subscription(%Stripe.Event{
+          type: "customer.subscription.deleted",
+          data: %{object: %{customer: "cus_audit123", status: "canceled", trial_end: nil}}
+        })
+
+      assert find_action(webhook_user.id, "billing.subscription.synced").actor ==
+               "system:webhook"
+    end
+  end
+end


### PR DESCRIPTION
Closes #550. Seventh child of #540.

## The gap

`Fountain.Billing` contained **zero** `Audit.record` calls. Every Stripe-driven and lifecycle change to a user's subscription mutated `users` with nothing to explain it — an account could go from `active` to `canceled`, or from `trialing` to gated, and the person it happened to saw only the result.

Admin-initiated changes *did* land in `admin_audit_events`, but the tenant-facing `/audit` never reads that table. So from the user's own trail, their subscription changed state for no stated reason.

## The approach

Every billing write in the module already funnels through `User.billing_changeset/2`, so nine call sites gained a single piped `audit_billing/5` rather than nine hand-rolled maps.

Two properties the helper enforces:

- **`source` is recorded, not just the status.** "Your subscription was cancelled" means something different depending on whether Stripe said so (`webhook`), an operator did it (`admin`), or a sweeper decided the trial ran out (`trial_sweeper`) — and `subscription_status` cannot tell those apart after the fact. Each event carries `from_status` and `to_status` too, so the trail describes a *transition* rather than a state.
- **Only real transitions record.** The webhook path re-syncs constantly and frequently reasserts the status an account already has. A row per no-op would bury the changes worth finding. A test pins that a repeated identical webhook adds nothing.

## Covered

`sync_subscription/1` (both the subscription-lifecycle branch and the past-due recovery branch), `start_trial_subscription`, the local no-Stripe trial, `extend_trial`, the trial sweeper's expiry, `resync_from_stripe`, `comp_account`, `revoke_comp`.

Events: `billing.subscription.synced`, `billing.subscription.resynced`, `billing.payment.recovered`, `billing.trial.started` / `.extended` / `.expired`, `billing.comped`, `billing.comp_revoked`.

## `ee/` boundary

Untouched. `Fountain.Audit` is core and `ee/` compiles into the same `:fountain` app, so this is an ordinary call rather than a new dependency (decisions/0010).

## Tests

New `ee/test/fountain/billing_audit_test.exs`, 6 cases: a webhook status change produces a row for the affected user (**the issue's acceptance criterion**); a cancellation records both ends of the transition; a no-op sync records nothing; comp and un-comp attributed to `admin`; extending a trial records the day count; the source distinguishes who moved the account.

Full suite 2324 tests, 0 failures; `mix precommit` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)