### PR TITLE
chore: scope the dialyzer skips to a function, not a line number

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,20 +1,25 @@
 # Dialyzer warnings that are understood and deliberately kept, each with its
-# reason. Entries are {file, warning_type, location} — pinned to a location so
-# a new warning of the same class elsewhere in the file still fails the build.
-# The pinned dialyxir ref matches the location term exactly as dialyzer
-# reports it: a bare line number when there is no column, or a
-# {line, column} tuple when there is.
-# If a fix moves the code, the location must move with it; a stale entry
-# shows up as an "unnecessary skip" in `mix dialyzer --list-unused-filters`.
-[
-  # fountain_callback_env/1 guards PUBLIC_URL-derived values with
-  # `is_binary(x) and x != ""`. Dialyzer proves the condition always true from
-  # today's success typings (PublicUrl.base/0 cannot currently return "") and
-  # flags both the comparison and the if's dead else-branch. The guard is
-  # defending against operator config, not against types — it stays.
-  # The pattern_match arm is reported at line 1 (dialyzer drops the real
-  # position for the synthesized boolean pattern), so 1 is the tightest pin
-  # available; the exact_compare arm carries a real {line, column}.
-  {"lib/fountain/conversations/conversation_server.ex", :pattern_match, 1},
-  {"lib/fountain/conversations/conversation_server.ex", :exact_compare, {1406, 64}}
-]
+# reason. Entries are {file, warning_type, location}.
+#
+# **Prefer `@dialyzer {:nowarn_function, name: arity}` beside the function.**
+# A location pin here is only stable while nothing above it in the file moves.
+# The two `conversation_server.ex` entries that used to live here pinned a
+# guard near the bottom of a 1400-line module, and they moved three times
+# during the #540 audit campaign (1339 -> 1341 -> 1404 -> 1406). Each time the
+# build failed with "Unnecessary Skips: 1", which reads like a suppression that
+# is no longer needed rather than "you inserted lines above it" — so the real
+# error underneath was the second thing you looked at, not the first. They are
+# now a `@dialyzer` attribute on `fountain_callback_env/1`: it travels with the
+# code, is visible to whoever edits that code, and is still far narrower than a
+# file-wide skip.
+#
+# Reach for this file when the warning has no single owning function — a
+# module-level or cross-function inference — or when the code is somewhere you
+# cannot put an attribute.
+#
+# Entries are pinned to a location so a new warning of the same class elsewhere
+# in the file still fails the build. The pinned dialyxir ref matches the
+# location term exactly as dialyzer reports it: a bare line number when there
+# is no column, a {line, column} tuple when there is. A stale entry shows up as
+# an "unnecessary skip" in `mix dialyzer --list-unused-filters`.
+[]

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1400,6 +1400,22 @@ defmodule Fountain.Conversations.ConversationServer do
     )
   end
 
+  # The `x != ""` guards here defend against operator configuration, not against
+  # types. Dialyzer proves them always-true from today's success typings —
+  # `PublicUrl.base/0` cannot currently return `""` — and flags both the
+  # comparison (`exact_compare`) and the `if`'s consequently-dead else branch
+  # (`pattern_match`). The guards stay: a future config path that yields an
+  # empty base or token must produce no callback env, not a sprite told to call
+  # back to `""`.
+  #
+  # Suppressed here rather than in `.dialyzer_ignore.exs` because that file
+  # pins by `{line, column}`, and this function sits near the bottom of a
+  # 1400-line module: the pin moved three times during #540 alone, each time
+  # failing the build with a misleading "Unnecessary Skips: 1" that reads like
+  # a stale suppression rather than "you added lines above". A function-scoped
+  # attribute travels with the code it describes and is narrower than the
+  # file-wide alternative.
+  @dialyzer {:nowarn_function, fountain_callback_env: 1}
   defp fountain_callback_env(token) do
     base = Fountain.PublicUrl.base()
 


### PR DESCRIPTION
Follow-up to the #540 audit campaign, where this bit three times.

## The problem

`.dialyzer_ignore.exs` pinned two warnings by `{line, column}` against a guard near the bottom of a 1400-line module. That is only stable while nothing above it moves — and during #540 it moved **three times**: 1339 → 1341 → 1404 → 1406.

Each time the build failed with:

```
Total errors: 2, Skipped: 1, Unnecessary Skips: 1
```

which reads like *"a suppression that is no longer needed"*, not *"you inserted lines above it"*. So the real warning underneath was the second thing you looked at rather than the first, every time.

## The fix

Both entries become one attribute beside the function they describe:

```elixir
@dialyzer {:nowarn_function, fountain_callback_env: 1}
defp fountain_callback_env(token) do
```

- **travels with the code** — no line numbers involved
- **visible to whoever edits that function**, rather than sitting in a root dotfile
- still far narrower than the file-wide skip that would be the other way to make this stable
- suppresses at the source, so dialyzer now reports **0 errors, 0 skips** instead of 2 and 2

The comment explaining *why* the guards stay (they defend against operator config, not against types — `PublicUrl.base/0` cannot currently return `""`, but a future config path could) moves next to the guards too, which is where someone tempted to "simplify" them will actually read it.

## Verified, not assumed

Inserted three lines above the function and re-ran dialyzer: passes. The old pin would have failed exactly there. Probe reverted.

## The ignore file stays

Now with an empty list and a note preferring the attribute, carrying this history as the reason. It is still the right home for a warning with no single owning function — a module-level or cross-function inference — or for code you cannot annotate.

`mix precommit` exits 0; 2369 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)