### PR TITLE
audit: move secret and auth events into the contexts (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ upgrade, is in
 
 ### Fixed
 
+- **Secret and credential events are recorded in one place instead of five.**
+  Writing an environment or vault secret was audited identically by both
+  LiveView forms, both API endpoints and `fountain apply` — five copies of the
+  same event that had to agree, on the most sensitive data in the system, with
+  a sixth surface one forgotten call from silence. Password resets, password
+  changes and email verification had the same shape across two controllers
+  each. All of them now record inside the context, so every surface present
+  and future leaves the same trail, and the guardrail test covers them (#593)
+
 - **Suspending an account, changing its role or cap, and revoking a key are in
   the affected account's own audit trail.** These recorded only into the
   admin privilege trail, which the page a user actually reads never shows — so

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -162,14 +162,15 @@ defmodule Fountain.Accounts do
 
   Returns `{:ok, user}` or `{:error, changeset}`.
   """
-  @spec verify_email(User.t()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
-  def verify_email(%User{} = user) do
+  @spec verify_email(User.t(), keyword()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  def verify_email(%User{} = user, opts \\ []) do
     result =
       user
       |> Ecto.Changeset.change(
         email_verified_at: DateTime.utc_now() |> DateTime.truncate(:second)
       )
       |> Repo.update()
+      |> audited_account("auth.email.verified", "user", opts, fn _ -> %{} end)
 
     with {:ok, verified} <- result do
       verified = maybe_bootstrap_first_admin(verified)
@@ -305,13 +306,22 @@ defmodule Fountain.Accounts do
 
   Returns `{:ok, user}` or `{:error, changeset}`.
   """
-  @spec reset_password(User.t(), String.t()) ::
+  @spec reset_password(User.t(), String.t(), keyword()) ::
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
-  def reset_password(%User{} = user, new_password) when is_binary(new_password) do
+  def reset_password(%User{} = user, new_password, opts \\ []) when is_binary(new_password) do
+    set_password(user, new_password, "auth.password.reset", opts)
+  end
+
+  # Shared by the reset and change paths, which write the same columns but are
+  # not the same event: a reset is someone who could not get in proving control
+  # of the mailbox, a change is someone already signed in. Both were recorded
+  # by their controllers — four call sites for two events (#593).
+  defp set_password(%User{} = user, new_password, action, opts) do
     user
     |> User.password_reset_changeset(%{password: new_password})
     |> User.invalidate_sessions_changeset()
     |> Repo.update()
+    |> audited_account(action, "user", opts, fn _ -> %{} end)
   end
 
   # ── credential management (#448) ─────────────────────────────────────────
@@ -328,13 +338,17 @@ defmodule Fountain.Accounts do
   session from the updated user. OAuth-only accounts (nil `password_hash`)
   are refused — they set a first password through the reset flow.
   """
-  @spec change_password(User.t(), String.t(), String.t()) ::
+  @spec change_password(User.t(), String.t(), String.t(), keyword()) ::
           {:ok, User.t()} | {:error, :no_password | :invalid_current_password | Ecto.Changeset.t()}
-  def change_password(%User{password_hash: nil}, _current, _new), do: {:error, :no_password}
+  def change_password(user, current, new, opts \\ [])
 
-  def change_password(%User{} = user, current, new) when is_binary(current) and is_binary(new) do
+  def change_password(%User{password_hash: nil}, _current, _new, _opts), do: {:error, :no_password}
+
+  def change_password(%User{} = user, current, new, opts)
+      when is_binary(current) and is_binary(new) do
     if Bcrypt.verify_pass(current, user.password_hash) do
-      reset_password(user, new)
+      # Not `reset_password/3`: the columns are the same but the event is not.
+      set_password(user, new, "auth.password.changed", opts)
     else
       {:error, :invalid_current_password}
     end

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -170,13 +170,19 @@ defmodule Fountain.Environments do
   @doc """
   Insert or update an environment secret. The plaintext `attrs["value"]` is
   encrypted with the supplied per-tenant `dek` before persisting.
+
+  Audited as `environment.secret.write`. Recorded here rather than by each
+  caller: five surfaces wrote this same event independently — both LiveView
+  forms, both API controllers, and `fountain apply` — and a sixth would have
+  been one forgotten call from silence (#593). The key is recorded, never the
+  value; that is the whole point of a write-only secret.
   """
-  def upsert_secret(%Environment{id: env_id}, %{"key" => key} = attrs, dek)
+  def upsert_secret(%Environment{} = env, %{"key" => key} = attrs, dek, opts \\ [])
       when is_binary(dek) do
-    case _unsafe_get_secret(env_id, key) do
+    case _unsafe_get_secret(env.id, key) do
       nil ->
         %Secret{}
-        |> Secret.changeset(Map.put(attrs, "environment_id", env_id), dek)
+        |> Secret.changeset(Map.put(attrs, "environment_id", env.id), dek)
         |> Repo.insert()
 
       existing ->
@@ -184,9 +190,41 @@ defmodule Fountain.Environments do
         |> Secret.changeset(attrs, dek)
         |> Repo.update()
     end
+    |> audited_secret(env, key, "environment.secret.write", opts)
   end
 
-  def delete_secret(%Secret{} = secret), do: Repo.delete(secret)
+  @doc """
+  Delete an environment secret.
+
+  Takes the owning environment as well as the secret: `secrets` carries no
+  `user_id`, so without it the audit event could not be attributed without a
+  second query — and every call site already has the environment in hand.
+  """
+  def delete_secret(%Environment{} = env, %Secret{} = secret, opts \\ []) do
+    secret
+    |> Repo.delete()
+    |> audited_secret(env, secret.key, "environment.secret.delete", opts)
+  end
+
+  # `resource_id` is the environment, not the secret row: a deleted secret's id
+  # points at nothing, and "which environment" is the question a reader of the
+  # trail is actually asking. Matches the shape the five call sites emitted
+  # before this moved, so existing trails stay readable.
+  defp audited_secret({:ok, _} = ok, %Environment{} = env, key, action, opts) do
+    Audit.record(%{
+      user_id: env.user_id,
+      action: action,
+      resource_type: "secret",
+      resource_id: env.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: Map.merge(%{"key" => key}, Keyword.get(opts, :metadata, %{}))
+    })
+
+    ok
+  end
+
+  defp audited_secret(other, _env, _key, _action, _opts), do: other
 
   @doc """
   Returns a flat map `%{"KEY" => "plaintext"}` of all decrypted secrets

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -61,6 +61,14 @@ defmodule Fountain.Manifest do
     {:ok, results}
   end
 
+  # Keeps the `via: apply` marker the ApplyController used to attach when it
+  # audited these itself. It is the one thing distinguishing a secret written
+  # by `fountain apply` from the same key written through a form, and worth
+  # keeping now that the context emits the event (#593).
+  defp secret_opts(opts) do
+    Keyword.update(opts, :metadata, %{"via" => "apply"}, &Map.put(&1, "via", "apply"))
+  end
+
   # ── per-kind reconciliation ───────────────────────────────────────────────
 
   defp apply_environment(user_id, %{"name" => name} = res, dek, opts) do
@@ -78,7 +86,8 @@ defmodule Fountain.Manifest do
 
     case outcome do
       {action, {:ok, env}} ->
-        secret_results = upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek))
+        secret_results =
+          upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek, secret_opts(opts)))
         {result("Environment", name, action, nil, secret_results, env.id), env}
 
       {_action, {:error, changeset}} ->
@@ -97,7 +106,8 @@ defmodule Fountain.Manifest do
 
     case outcome do
       {action, {:ok, vault}} ->
-        secret_results = upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek))
+        secret_results =
+          upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek, secret_opts(opts)))
         result("Vault", name, action, nil, secret_results, vault.id)
 
       {_action, {:error, changeset}} ->

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -154,11 +154,12 @@ defmodule Fountain.Vaults do
   Insert or update a vault secret. The plaintext `attrs["value"]` is encrypted
   with the supplied per-tenant `dek` before persisting.
   """
-  def upsert_secret(%Vault{id: vault_id}, %{"key" => key} = attrs, dek) when is_binary(dek) do
-    case _unsafe_get_secret(vault_id, key) do
+  def upsert_secret(%Vault{} = vault, %{"key" => key} = attrs, dek, opts \\ [])
+      when is_binary(dek) do
+    case _unsafe_get_secret(vault.id, key) do
       nil ->
         %VaultSecret{}
-        |> VaultSecret.changeset(Map.put(attrs, "vault_id", vault_id), dek)
+        |> VaultSecret.changeset(Map.put(attrs, "vault_id", vault.id), dek)
         |> Repo.insert()
 
       existing ->
@@ -166,9 +167,38 @@ defmodule Fountain.Vaults do
         |> VaultSecret.changeset(attrs, dek)
         |> Repo.update()
     end
+    |> audited_secret(vault, key, "vault.secret.write", opts)
   end
 
-  def delete_secret(%VaultSecret{} = secret), do: Repo.delete(secret)
+  @doc """
+  Delete a vault secret.
+
+  Takes the owning vault as well as the secret — see
+  `Fountain.Environments.delete_secret/3` for why.
+  """
+  def delete_secret(%Vault{} = vault, %VaultSecret{} = secret, opts \\ []) do
+    secret
+    |> Repo.delete()
+    |> audited_secret(vault, secret.key, "vault.secret.delete", opts)
+  end
+
+  # See the note on `Fountain.Environments.audited_secret/5`: the vault is the
+  # resource, the key is the whole payload, the value never appears.
+  defp audited_secret({:ok, _} = ok, %Vault{} = vault, key, action, opts) do
+    Audit.record(%{
+      user_id: vault.user_id,
+      action: action,
+      resource_type: "vault_secret",
+      resource_id: vault.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: Map.merge(%{"key" => key}, Keyword.get(opts, :metadata, %{}))
+    })
+
+    ok
+  end
+
+  defp audited_secret(other, _vault, _key, _action, _opts), do: other
 
   @doc """
   Returns a flat map `%{"KEY" => "plaintext"}` of all decrypted secrets

--- a/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
@@ -38,13 +38,8 @@ defmodule FountainWeb.AccountSecurityController do
   def change_password(conn, %{"current_password" => current, "new_password" => new}) do
     user = conn.assigns.current_user
 
-    case Accounts.change_password(user, current, new) do
+    case Accounts.change_password(user, current, new, FountainWeb.Audited.attribution(conn)) do
       {:ok, updated} ->
-        FountainWeb.Audited.from_conn(conn, "auth.password.changed", "user",
-          user_id: updated.id,
-          resource_id: updated.id
-        )
-
         conn
         # Re-issue this session against the bumped session_version: the
         # change kills every OTHER session, not the one that made it.
@@ -178,13 +173,8 @@ defmodule FountainWeb.AccountSecurityController do
   def api_change_password(conn, %{"current_password" => current, "new_password" => new}) do
     user = conn.assigns.current_user
 
-    case Accounts.change_password(user, current, new) do
-      {:ok, updated} ->
-        FountainWeb.Audited.from_conn(conn, "auth.password.changed", "user",
-          user_id: updated.id,
-          resource_id: updated.id
-        )
-
+    case Accounts.change_password(user, current, new, FountainWeb.Audited.attribution(conn)) do
+      {:ok, _updated} ->
         json(conn, %{
           message: "Password updated. Browser sessions have been signed out.",
           sessions_invalidated: true,

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -32,30 +32,8 @@ defmodule FountainWeb.ApplyController do
     user = conn.assigns.current_user
 
     with {:ok, results} <- Manifest.apply_manifest(user.id, resources, Audited.attribution(conn)) do
-      audit_secret_writes(conn, results)
       render(conn, :create, results: results)
     end
   end
 
-  # A manifest apply is a secret write like any other — `fountain apply` was the
-  # third API path that moved secrets without leaving a semantic trail (#530).
-  # One event per key actually written, matching the per-key events the LiveView
-  # forms and the secret controllers emit.
-  defp audit_secret_writes(conn, results) do
-    for %{id: id, secrets: secrets} = result <- results,
-        not is_nil(id),
-        %{key: key, action: :upserted} <- secrets do
-      {action, resource_type} = audit_names(result.kind)
-
-      Audited.from_conn(conn, action, resource_type,
-        resource_id: id,
-        metadata: %{"key" => key, "via" => "apply"}
-      )
-    end
-
-    :ok
-  end
-
-  defp audit_names("Environment"), do: {"environment.secret.write", "secret"}
-  defp audit_names("Vault"), do: {"vault.secret.write", "vault_secret"}
 end

--- a/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
@@ -49,13 +49,8 @@ defmodule FountainWeb.EmailVerificationController do
             |> redirect(to: destination(user))
 
           user ->
-            case Accounts.verify_email(user) do
+            case Accounts.verify_email(user, FountainWeb.Audited.attribution(conn)) do
               {:ok, verified_user} ->
-                FountainWeb.Audited.from_conn(conn, "auth.email.verified", "user",
-                  user_id: verified_user.id,
-                  resource_id: verified_user.id
-                )
-
                 # Durable job rather than a linked Task: this used to be a bare
                 # Task.async with no await, so it could be killed when the
                 # request process finished and a Stripe error vanished silently,
@@ -138,13 +133,8 @@ defmodule FountainWeb.EmailVerificationController do
   end
 
   defp verify_user(conn, user) do
-    case Accounts.verify_email(user) do
+    case Accounts.verify_email(user, FountainWeb.Audited.attribution(conn)) do
       {:ok, verified} ->
-        FountainWeb.Audited.from_conn(conn, "auth.email.verified", "user",
-          user_id: verified.id,
-          resource_id: verified.id
-        )
-
         # Same follow-on work the browser route does — the account must not
         # end up in a different state depending on which surface finished it.
         Fountain.Workers.StripeCustomerSync.enqueue(verified)

--- a/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
@@ -127,16 +127,11 @@ defmodule FountainWeb.PasswordResetController do
   end
 
   defp apply_api_reset(conn, user, password) do
-    case Accounts.reset_password(user, password) do
+    case Accounts.reset_password(user, password, FountainWeb.Audited.attribution(conn)) do
       {:ok, _user} ->
         # session_version is bumped, so every session and every other
         # outstanding reset token dies here too — the same security-relevant
         # event the browser path records.
-        FountainWeb.Audited.from_conn(conn, "auth.password.reset", "user",
-          user_id: user.id,
-          resource_id: user.id
-        )
-
         json(conn, %{message: "Password updated. Sign in with your new password."})
 
       {:error, changeset} ->
@@ -177,15 +172,10 @@ defmodule FountainWeb.PasswordResetController do
   def reset(conn, %{"token" => token, "password" => password}) do
     case verify_reset_token(conn, token) do
       {:ok, user} ->
-        case Accounts.reset_password(user, password) do
+        case Accounts.reset_password(user, password, FountainWeb.Audited.attribution(conn)) do
               {:ok, _user} ->
                 # Also invalidates every existing session, so this is a
                 # security-relevant event even when the user initiated it.
-                FountainWeb.Audited.from_conn(conn, "auth.password.reset", "user",
-                  user_id: user.id,
-                  resource_id: user.id
-                )
-
                 conn
                 |> configure_session(drop: true)
                 |> put_flash(:info, "Password updated. Please sign in with your new password.")

--- a/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
@@ -52,14 +52,8 @@ defmodule FountainWeb.SecretController do
         attrs = Map.take(params, ["key", "value"])
         {:ok, dek} = Crypto.load_tenant_key(conn.assigns.current_user.id)
 
-        with {:ok, secret} <- Environments.upsert_secret(env, attrs, dek) do
-          # Same event the LiveView form emits (environments_live/form.ex), so
-          # the trail reads identically whichever surface wrote the secret.
-          Audited.from_conn(conn, "environment.secret.write", "secret",
-            resource_id: env.id,
-            metadata: %{"key" => secret.key}
-          )
-
+        with {:ok, secret} <-
+               Environments.upsert_secret(env, attrs, dek, Audited.attribution(conn)) do
           conn
           |> put_status(:created)
           |> render(:show, secret: secret)
@@ -82,15 +76,10 @@ defmodule FountainWeb.SecretController do
   def delete(conn, %{"environment_id" => env_id, "id" => key}) do
     user = conn.assigns.current_user
 
-    with %_{} <- Environments.get_environment(env_id, user.id),
+    with %_{} = env <- Environments.get_environment(env_id, user.id),
          # Ownership established by the scoped get_environment above.
          %_{} = secret <- Environments._unsafe_get_secret(env_id, key) do
-      {:ok, _} = Environments.delete_secret(secret)
-
-      Audited.from_conn(conn, "environment.secret.delete", "secret",
-        resource_id: env_id,
-        metadata: %{"key" => secret.key}
-      )
+      {:ok, _} = Environments.delete_secret(env, secret, Audited.attribution(conn))
 
       send_resp(conn, :no_content, "")
     else

--- a/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
@@ -56,14 +56,7 @@ defmodule FountainWeb.VaultSecretController do
         attrs = Map.take(params, ["key", "value"])
         {:ok, dek} = Crypto.load_tenant_key(user.id)
 
-        with {:ok, secret} <- Vaults.upsert_secret(vault, attrs, dek) do
-          # Same event the LiveView form emits (vaults_live/form.ex), so the
-          # trail reads identically whichever surface wrote the secret.
-          Audited.from_conn(conn, "vault.secret.write", "vault_secret",
-            resource_id: vault.id,
-            metadata: %{"key" => secret.key}
-          )
-
+        with {:ok, secret} <- Vaults.upsert_secret(vault, attrs, dek, Audited.attribution(conn)) do
           conn
           |> put_status(:created)
           |> render(:show, secret: secret)
@@ -86,15 +79,10 @@ defmodule FountainWeb.VaultSecretController do
   def delete(conn, %{"vault_id" => vault_id, "id" => key}) do
     user = conn.assigns.current_user
 
-    with %_{} <- Vaults.get_vault(vault_id, user.id),
+    with %_{} = vault <- Vaults.get_vault(vault_id, user.id),
          # Ownership established by the scoped get_vault above.
          %_{} = secret <- Vaults._unsafe_get_secret(vault_id, key) do
-      {:ok, _} = Vaults.delete_secret(secret)
-
-      Audited.from_conn(conn, "vault.secret.delete", "vault_secret",
-        resource_id: vault_id,
-        metadata: %{"key" => secret.key}
-      )
+      {:ok, _} = Vaults.delete_secret(vault, secret, Audited.attribution(conn))
 
       send_resp(conn, :no_content, "")
     else

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -164,12 +164,12 @@ defmodule FountainWeb.EnvironmentsLive.Form do
       when k != "" and v != "" do
     with {:ok, dek} <- Crypto.load_tenant_key(socket.assigns.user_id),
          {:ok, _} <-
-           Environments.upsert_secret(socket.assigns.env, %{"key" => k, "value" => v}, dek) do
-      FountainWeb.Audited.from_socket(socket, "environment.secret.write", "secret",
-        resource_id: socket.assigns.env.id,
-        metadata: %{"key" => k}
-      )
-
+           Environments.upsert_secret(
+             socket.assigns.env,
+             %{"key" => k, "value" => v},
+             dek,
+             FountainWeb.Audited.attribution(socket)
+           ) do
       {:noreply,
        socket
        |> assign(:secrets, secrets_for(socket.assigns.env))
@@ -190,12 +190,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
     secret = Enum.find(socket.assigns.secrets, &(&1.id == id))
 
     if secret do
-      Environments.delete_secret(secret)
-
-      FountainWeb.Audited.from_socket(socket, "environment.secret.delete", "secret",
-        resource_id: socket.assigns.env.id,
-        metadata: %{"key" => secret.key}
-      )
+      Environments.delete_secret(socket.assigns.env, secret, FountainWeb.Audited.attribution(socket))
 
       {:noreply,
        socket

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -56,12 +56,13 @@ defmodule FountainWeb.VaultsLive.Form do
   def handle_event("add_secret", %{"secret" => %{"key" => k, "value" => v}}, socket)
       when k != "" and v != "" do
     with {:ok, dek} <- Crypto.load_tenant_key(socket.assigns.user_id),
-         {:ok, _} <- Vaults.upsert_secret(socket.assigns.vault, %{"key" => k, "value" => v}, dek) do
-      FountainWeb.Audited.from_socket(socket, "vault.secret.write", "vault_secret",
-        resource_id: socket.assigns.vault.id,
-        metadata: %{"key" => k}
-      )
-
+         {:ok, _} <-
+           Vaults.upsert_secret(
+             socket.assigns.vault,
+             %{"key" => k, "value" => v},
+             dek,
+             FountainWeb.Audited.attribution(socket)
+           ) do
       {:noreply,
        socket
        |> assign(:secrets, secrets_for(socket.assigns.vault))
@@ -82,12 +83,7 @@ defmodule FountainWeb.VaultsLive.Form do
     secret = Enum.find(socket.assigns.secrets, &(&1.id == id))
 
     if secret do
-      Vaults.delete_secret(secret)
-
-      FountainWeb.Audited.from_socket(socket, "vault.secret.delete", "vault_secret",
-        resource_id: socket.assigns.vault.id,
-        metadata: %{"key" => secret.key}
-      )
+      Vaults.delete_secret(socket.assigns.vault, secret, FountainWeb.Audited.attribution(socket))
 
       {:noreply,
        socket

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -47,7 +47,19 @@ defmodule Fountain.AuditGuardrailTest do
     {"role change", &__MODULE__.do_role_change/1, "account.role_changed"},
     {"sandbox limit change", &__MODULE__.do_limit_change/1, "account.sandbox_limit_changed"},
     {"suspend", &__MODULE__.do_suspend/1, "account.suspended"},
-    {"unsuspend", &__MODULE__.do_unsuspend/1, "account.unsuspended"}
+    {"unsuspend", &__MODULE__.do_unsuspend/1, "account.unsuspended"},
+    # Secrets and credentials (#593). These had five and four call sites
+    # respectively before the recording moved into the context; the entries
+    # below are what stops a sixth from being silent.
+    {"environment secret write", &__MODULE__.do_env_secret_write/1,
+     "environment.secret.write"},
+    {"environment secret delete", &__MODULE__.do_env_secret_delete/1,
+     "environment.secret.delete"},
+    {"vault secret write", &__MODULE__.do_vault_secret_write/1, "vault.secret.write"},
+    {"vault secret delete", &__MODULE__.do_vault_secret_delete/1, "vault.secret.delete"},
+    {"password reset", &__MODULE__.do_password_reset/1, "auth.password.reset"},
+    {"password change", &__MODULE__.do_password_change/1, "auth.password.changed"},
+    {"email verification", &__MODULE__.do_verify_email/1, "auth.email.verified"}
   ]
 
   # Documented non-coverage. Mirrors the `Fountain.Audit` moduledoc; if the two
@@ -186,4 +198,39 @@ defmodule Fountain.AuditGuardrailTest do
     {:ok, suspended, _} = Fountain.Accounts.suspend_user(user)
     {:ok, _} = Fountain.Accounts.unsuspend_user(suspended)
   end
+
+  defp dek!(user_id) do
+    {:ok, dek} = Fountain.Crypto.load_tenant_key(user_id)
+    dek
+  end
+
+  def do_env_secret_write(user) do
+    env = insert_env(user_id: user.id)
+    {:ok, _} = Environments.upsert_secret(env, %{"key" => "K", "value" => "v"}, dek!(user.id))
+  end
+
+  def do_env_secret_delete(user) do
+    env = insert_env(user_id: user.id)
+    secret = insert_secret(env, %{"key" => "GONE"})
+    {:ok, _} = Environments.delete_secret(env, secret)
+  end
+
+  def do_vault_secret_write(user) do
+    vault = insert_vault(user_id: user.id)
+    {:ok, _} = Vaults.upsert_secret(vault, %{"key" => "K", "value" => "v"}, dek!(user.id))
+  end
+
+  def do_vault_secret_delete(user) do
+    vault = insert_vault(user_id: user.id)
+    secret = insert_vault_secret(vault, %{"key" => "GONE"})
+    {:ok, _} = Vaults.delete_secret(vault, secret)
+  end
+
+  def do_password_reset(user), do: {:ok, _} = Fountain.Accounts.reset_password(user, "newpass123")
+
+  def do_password_change(user) do
+    {:ok, _} = Fountain.Accounts.change_password(user, "password123", "newpass123")
+  end
+
+  def do_verify_email(user), do: {:ok, _} = Fountain.Accounts.verify_email(user)
 end

--- a/apps/fountain/test/fountain/audit_test.exs
+++ b/apps/fountain/test/fountain/audit_test.exs
@@ -77,7 +77,11 @@ defmodule Fountain.AuditTest do
       b_ids = user_b.id |> Audit.list_recent_for_user() |> Enum.map(& &1.id)
 
       refute event.id in b_ids
-      assert Audit.list_recent_for_user(user_b.id) |> Enum.map(& &1.action) == ["account.registered"]
+      # Registration and the verification that `insert_verified_user` performs
+      # are both audited in the context now (#544, #593), so a fresh verified
+      # account opens with two events rather than one.
+      assert Audit.list_recent_for_user(user_b.id) |> Enum.map(& &1.action) ==
+               ["auth.email.verified", "account.registered"]
     end
 
     test "respects limit" do

--- a/apps/fountain/test/fountain/environments_test.exs
+++ b/apps/fountain/test/fountain/environments_test.exs
@@ -136,13 +136,13 @@ defmodule Fountain.EnvironmentsTest do
     end
   end
 
-  describe "delete_secret/1" do
+  describe "delete_secret/3" do
     test "deletes the secret" do
       user = insert_verified_user()
       env = insert_env(user_id: user.id)
       secret = insert_secret(env, key: "TO_DELETE")
 
-      assert {:ok, _} = Environments.delete_secret(secret)
+      assert {:ok, _} = Environments.delete_secret(env, secret)
       assert Environments._unsafe_list_secrets(env) == []
     end
   end

--- a/apps/fountain/test/fountain/vaults_test.exs
+++ b/apps/fountain/test/fountain/vaults_test.exs
@@ -124,13 +124,13 @@ defmodule Fountain.VaultsTest do
     end
   end
 
-  describe "delete_secret/1" do
+  describe "delete_secret/3" do
     test "deletes the secret" do
       user = insert_verified_user()
       vault = insert_vault(user_id: user.id)
       secret = insert_vault_secret(vault, key: "TO_DELETE")
 
-      assert {:ok, _} = Vaults.delete_secret(secret)
+      assert {:ok, _} = Vaults.delete_secret(vault, secret)
       assert Vaults._unsafe_list_secrets(vault) == []
     end
   end

--- a/apps/fountain/test/fountain_web/controllers/email_verification_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/email_verification_controller_test.exs
@@ -101,9 +101,11 @@ defmodule FountainWeb.EmailVerificationControllerTest do
     test "redirects with error when verify_email returns an error changeset", %{conn: conn} do
       user = insert_user()
 
-      # Stub Accounts.verify_email/1 to simulate a DB-level failure so that
-      # line 53 (the {:error, _changeset} branch) is exercised.
-      stub(Accounts, :verify_email, fn _user ->
+      # Stub Accounts.verify_email/2 to simulate a DB-level failure so that
+      # the {:error, _changeset} branch is exercised. Arity 2 since #593: the
+      # controller passes attribution through so the context can record
+      # `auth.email.verified` itself.
+      stub(Accounts, :verify_email, fn _user, _opts ->
         changeset =
           %Fountain.Accounts.User{}
           |> Ecto.Changeset.change()


### PR DESCRIPTION
Closes #593 — the last of the per-caller auditing #540 set out to remove.

**Not a coverage gap.** Every one of these paths already audited. This is five copies of one event that had to agree, on the most sensitive data in the system, with a sixth surface one forgotten call from silence.

## Secrets: five call sites → one

`environment.secret.write` / `.delete` and the vault equivalents were emitted independently by both LiveView forms, both API controllers, and twice by the apply controller. They move into `Environments.upsert_secret/4`, `delete_secret/3` and the `Vaults` equivalents.

Three details worth review:

- **`delete_secret` now takes the owning environment/vault as well as the secret.** `secrets` carries no `user_id`, so without it the event couldn't be attributed without a second query — and every call site already had the parent in hand.
- **`resource_id` stays the environment/vault, not the secret row.** Matches what the five call sites emitted, so existing trails stay readable; and a deleted secret's id points at nothing, while "which environment" is the question a reader is actually asking.
- **The apply path keeps its `via: apply` marker**, threaded through the manifest as metadata. It's the one thing distinguishing a secret written by `fountain apply` from the same key written through a form, and moving the recording without it would have silently dropped it.

The key is recorded, never the value — the whole point of a write-only secret.

## Auth: two call sites each → one

`auth.password.reset`, `auth.password.changed` and `auth.email.verified` each had two controller branches. They move into `reset_password/3`, `change_password/4` and `verify_email/2`.

Reset and change share a private `set_password/4` because they write the same columns but **are not the same event**: a reset is someone who couldn't get in proving control of the mailbox; a change is someone already signed in. Collapsing them would have lost that distinction.

## The guardrail grows 18 → 25

Four secret mutations and three auth ones. That's the actual point of the move — it's what stops a sixth surface from ever being silent.

## Test fallout, all from the arity changes

Two `delete_secret/1` tests take the parent now; one Mimic stub moves to arity 2; one audit-scoping assertion grows an `auth.email.verified`, because `insert_verified_user` verifies through the context — so a fresh verified account now opens with **two** events rather than one.

## Deliberately not moved

`upsert_oauth_user/3`. Its two events (`auth.oauth.signup` vs `auth.oauth.login`) depend on the `:new` / `:existing` return the ueberauth controller already branches on, so it's a different shape rather than a mechanical lift. Left as a decision on the record rather than a silent omission.

`mix precommit` exits 0; 2376 tests, 0 failures; dialyzer 0 errors / 0 skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)