### PR TITLE
metrics: give the provisioning sub-steps their own histograms (#537)

### DIFF
--- a/apps/fountain/lib/fountain/telemetry.ex
+++ b/apps/fountain/lib/fountain/telemetry.ex
@@ -110,6 +110,11 @@ defmodule Fountain.Telemetry do
     # reattach and setup_script; Provisioning wraps packages, network_policy,
     # clone_repositories and checkpoint create/restore; Rehydrator wraps its
     # post-boot sweep in rehydrate.
+    #
+    # Every provisioning span here also has a `distribution(...)` in
+    # FountainWeb.Telemetry.prometheus_metrics/0 (#537). A new span wants both
+    # — this list to make it visible in the logs, that one to make it
+    # trendable — and metrics_test pins the pairing.
     spans =
       for stage <-
             ~w(fresh_provision reattach setup_script packages network_policy clone_repositories rehydrate)a,

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -138,6 +138,62 @@ defmodule FountainWeb.Telemetry do
         description: "How long a sandbox reattach takes"
       ),
 
+      # ── Provisioning sub-steps (#537) ─────────────────────────────────────
+      # The two spans above answer "did provisioning get slower"; these answer
+      # "which step". All six were already emitting :stop events with a
+      # duration — they just went nowhere but the JSON log and OTel, so a
+      # regression in the provision histogram meant grepping log lines or
+      # opening individual traces to find the culprit.
+      #
+      # Same buckets as fresh_provision on purpose: these are its components,
+      # so shared boundaries make them comparable at a glance. 120s is also
+      # exactly the setup-script timeout, so the top bucket is that ceiling.
+      #
+      # No tags. The span metadata carries conv_id / env_id / checkpoint_id,
+      # and every one of those would mint a time series per conversation.
+      distribution("fountain.setup_script.stop.duration",
+        event_name: [:fountain, :setup_script, :stop],
+        measurement: :duration,
+        unit: {:native, :millisecond},
+        reporter_options: [buckets: [1000, 5000, 10_000, 30_000, 60_000, 120_000]],
+        description: "How long an environment's setup script takes"
+      ),
+      distribution("fountain.packages.stop.duration",
+        event_name: [:fountain, :packages, :stop],
+        measurement: :duration,
+        unit: {:native, :millisecond},
+        reporter_options: [buckets: [1000, 5000, 10_000, 30_000, 60_000, 120_000]],
+        description: "How long package installation takes"
+      ),
+      distribution("fountain.network_policy.stop.duration",
+        event_name: [:fountain, :network_policy, :stop],
+        measurement: :duration,
+        unit: {:native, :millisecond},
+        reporter_options: [buckets: [1000, 5000, 10_000, 30_000, 60_000, 120_000]],
+        description: "How long applying the sprite network policy takes"
+      ),
+      distribution("fountain.clone_repositories.stop.duration",
+        event_name: [:fountain, :clone_repositories, :stop],
+        measurement: :duration,
+        unit: {:native, :millisecond},
+        reporter_options: [buckets: [1000, 5000, 10_000, 30_000, 60_000, 120_000]],
+        description: "How long cloning an environment's repositories takes"
+      ),
+      distribution("fountain.checkpoint.create.stop.duration",
+        event_name: [:fountain, :checkpoint, :create, :stop],
+        measurement: :duration,
+        unit: {:native, :millisecond},
+        reporter_options: [buckets: [1000, 5000, 10_000, 30_000, 60_000, 120_000]],
+        description: "How long creating an environment checkpoint takes"
+      ),
+      distribution("fountain.checkpoint.restore.stop.duration",
+        event_name: [:fountain, :checkpoint, :restore, :stop],
+        measurement: :duration,
+        unit: {:native, :millisecond},
+        reporter_options: [buckets: [1000, 5000, 10_000, 30_000, 60_000, 120_000]],
+        description: "How long restoring an environment checkpoint takes"
+      ),
+
       # ── Lifecycle sweeps ──────────────────────────────────────────────────
       counter("fountain.sandbox.reclaimed.count",
         event_name: [:fountain, :sandbox, :reclaimed],

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -103,6 +103,43 @@ defmodule FountainWeb.MetricsTest do
       end
     end
 
+    test "every provisioning sub-step has a duration histogram (#537)" do
+      # fresh_provision/reattach say provisioning got slower; these say which
+      # step did. Before #537 the events fired into nothing but the JSON log,
+      # so the only way to attribute a regression was grepping log lines.
+      names = Enum.map(AppTelemetry.prometheus_metrics(), & &1.name)
+
+      for span <- [
+            [:fountain, :setup_script, :stop, :duration],
+            [:fountain, :packages, :stop, :duration],
+            [:fountain, :network_policy, :stop, :duration],
+            [:fountain, :clone_repositories, :stop, :duration],
+            [:fountain, :checkpoint, :create, :stop, :duration],
+            [:fountain, :checkpoint, :restore, :stop, :duration]
+          ] do
+        assert span in names,
+               "#{Enum.join(span, ".")} is no longer exported — the span still " <>
+                 "fires, but the regression it would explain is invisible again"
+      end
+    end
+
+    test "provisioning histograms carry no id tags — cardinality (#537)" do
+      # Their span metadata holds conv_id / env_id / checkpoint_id. Any of
+      # those promoted to a tag mints a time series per conversation.
+      for metric <- AppTelemetry.prometheus_metrics(),
+          metric.event_name in [
+            [:fountain, :setup_script, :stop],
+            [:fountain, :packages, :stop],
+            [:fountain, :network_policy, :stop],
+            [:fountain, :clone_repositories, :stop],
+            [:fountain, :checkpoint, :create, :stop],
+            [:fountain, :checkpoint, :restore, :stop]
+          ] do
+        assert metric.tags == [],
+               "#{inspect(metric.name)} tags on #{inspect(metric.tags)}"
+      end
+    end
+
     test "every subscribed fountain event has a live producer" do
       # The class of bug behind #310: metrics subscribed to event names that
       # nothing emits, passing every name-list assertion while the scrape
@@ -113,6 +150,14 @@ defmodule FountainWeb.MetricsTest do
         # Fountain.Telemetry.span/3 callers
         [:fountain, :fresh_provision, :stop],
         [:fountain, :reattach, :stop],
+        # The provisioning sub-steps those two are made of (#537):
+        # ConversationServer.run_setup_script/4 and Conversations.Provisioning
+        [:fountain, :setup_script, :stop],
+        [:fountain, :packages, :stop],
+        [:fountain, :network_policy, :stop],
+        [:fountain, :clone_repositories, :stop],
+        [:fountain, :checkpoint, :create, :stop],
+        [:fountain, :checkpoint, :restore, :stop],
         # Rehydrator.sweep/0 wraps its post-boot sweep in this span; the
         # candidates/started numbers ride the stop event's METADATA (a
         # 2-tuple span return), which is why the metrics use measurement
@@ -289,6 +334,38 @@ defmodule FountainWeb.MetricsTest do
       # conversation_id is metadata, never a label — one series per
       # conversation would eat Prometheus.
       refute body =~ "conversation_id="
+    end
+
+    test "a provisioning sub-step span lands in the scrape (#537)" do
+      # Driven through the real Fountain.Telemetry.span/3 rather than a raw
+      # :telemetry.execute, so the event name and the `duration` measurement
+      # are the ones the provisioning code actually produces. A series exists
+      # in the scrape only once its event has fired, so each name asserted
+      # below is emitted here.
+      conv_id = Ecto.UUID.generate()
+
+      Fountain.Telemetry.span([:packages], %{conv_id: conv_id, commands: 2}, fn ->
+        {:ok, %{outcome: :ok}}
+      end)
+
+      Fountain.Telemetry.span([:checkpoint, :create], %{env_id: Ecto.UUID.generate()}, fn ->
+        {:ok, %{outcome: :ok}}
+      end)
+
+      Fountain.Telemetry.span([:checkpoint, :restore], %{checkpoint_id: "ckpt_1"}, fn ->
+        {:ok, %{outcome: :ok}}
+      end)
+
+      Process.sleep(50)
+      {200, body} = scrape()
+
+      assert body =~ "fountain_packages_stop_duration_bucket"
+      assert body =~ "fountain_checkpoint_create_stop_duration_bucket"
+      assert body =~ "fountain_checkpoint_restore_stop_duration_bucket"
+
+      # conv_id / checkpoint_id are span metadata, never labels.
+      refute body =~ conv_id
+      refute body =~ "checkpoint_id="
     end
 
     test "route tags are the matched pattern, not the raw path", %{conn: conn} do


### PR DESCRIPTION
Closes #537.

`fresh_provision` and `reattach` have had Prometheus histograms since #405, so a provision that gets slower is visible. *Which step* got slower was not: `setup_script`, `packages`, `network_policy`, `clone_repositories` and `checkpoint` create/restore are all already wrapped in `Fountain.Telemetry.span/3` — firing `:stop` events with a `duration` measurement — but nothing subscribed to them outside the JSON log and OTel. Attributing a regression meant grepping log lines or opening individual traces.

Six `distribution/2` entries, one per span. **The emitters are untouched; the events already fire.**

### Choices

- **Buckets are `fresh_provision`'s, deliberately** — `[1s, 5s, 10s, 30s, 60s, 120s]`. These are its components, so shared boundaries make them comparable at a glance, and 120s is exactly the setup-script timeout, so the top bucket is that ceiling.
- **No tags on any of them.** The span metadata carries `conv_id`, `env_id` and `checkpoint_id`; promoting any of those to a label mints a time series per conversation — the cardinality trap #405 called out.

### Tests

Three failure modes pinned: the metric disappearing, an id becoming a tag, and the name drifting from what the emitter fires. The end-to-end case goes through `Fountain.Telemetry.span/3` rather than a raw `:telemetry.execute`, so a renamed span fails the scrape assertion rather than passing a name-list check while the scrape stays empty forever (#310).

Verified by reverting: deleting one `distribution` block fails both the wiring test and the scrape test.

### Stack

This is the base of three. #536 (turn duration) sits on top, then #535 (TTFT). Merge in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)