### PR TITLE
metrics: trend turn duration, not just turn outcomes (#536)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -249,6 +249,13 @@ defmodule Fountain.Conversations.ConversationServer do
       # OTel span context for the in-flight turn (started in kick_turn,
       # ended in the :exit / :interrupt handlers).
       current_turn_span: nil,
+      # Aggregate-metric bookkeeping for the in-flight turn (#536):
+      # `%{started_mono: ms, runtime: "claude"}`, set once the turn's
+      # command is spawned and dropped on every terminal path. nil
+      # whenever no turn is running. Monotonic rather than the turn row's
+      # timestamps because `now/0` truncates to the second, which rounds a
+      # sub-second turn to a duration of zero.
+      turn_metrics: nil,
       # Stream tracer for parsing Claude's stream-json stdout into OTel
       # child spans and events. nil for non-Claude runtimes.
       stream_tracer: nil,
@@ -815,6 +822,11 @@ defmodule Fountain.Conversations.ConversationServer do
         conv = Conversations._unsafe_get_conversation!(state.conversation_id)
         {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
 
+        # turn_metrics stays nil on purpose, so this turn contributes no
+        # duration sample (#536). Its start is in a previous BEAM lifetime:
+        # monotonic time isn't comparable across a restart, and measuring
+        # from the row's started_at would fold the whole deploy gap into the
+        # histogram. A missing sample beats a wrong one.
         %{
           state
           | current_command: command,
@@ -1024,6 +1036,8 @@ defmodule Fountain.Conversations.ConversationServer do
 
     end_turn_span(state.current_turn_span, :error, %{"outcome" => "interrupted"})
 
+    emit_turn_completed(state, "interrupted")
+
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
 
@@ -1034,6 +1048,7 @@ defmodule Fountain.Conversations.ConversationServer do
          current_command_ref: nil,
          current_turn: nil,
          current_turn_span: nil,
+         turn_metrics: nil,
          stream_tracer: nil
      }}
   end
@@ -1161,6 +1176,8 @@ defmodule Fountain.Conversations.ConversationServer do
       %{"exit_code" => code}
     )
 
+    emit_turn_completed(state, turn.status)
+
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
 
@@ -1171,6 +1188,7 @@ defmodule Fountain.Conversations.ConversationServer do
          current_command_ref: nil,
          current_turn: nil,
          current_turn_span: nil,
+         turn_metrics: nil,
          stream_tracer: nil
      }}
   end
@@ -1202,6 +1220,8 @@ defmodule Fountain.Conversations.ConversationServer do
     Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
     end_turn_span(state.current_turn_span, :error, %{"error" => inspect(reason)})
 
+    emit_turn_completed(state, turn.status)
+
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
 
@@ -1212,6 +1232,7 @@ defmodule Fountain.Conversations.ConversationServer do
          current_command_ref: nil,
          current_turn: nil,
          current_turn_span: nil,
+         turn_metrics: nil,
          stream_tracer: nil
      }}
   end
@@ -1633,6 +1654,13 @@ defmodule Fountain.Conversations.ConversationServer do
 
     previous_span = OpenTelemetry.Tracer.set_current_span(turn_span)
 
+    # Stamped before the spawn so the duration covers the round trip to
+    # sprites.dev — that latency is part of what the user waits through.
+    # Kept local until the spawn succeeds: a spawn that never starts has no
+    # run to time, and a stamp left in state would attach itself to the
+    # next turn.
+    turn_started_mono = System.monotonic_time(:millisecond)
+
     try do
       spawn_opts =
         [
@@ -1667,6 +1695,7 @@ defmodule Fountain.Conversations.ConversationServer do
               current_turn: turn,
               runtime_session_id: runtime_session_id,
               current_turn_span: turn_span,
+              turn_metrics: %{started_mono: turn_started_mono, runtime: conv.runtime},
               stream_tracer: stream_tracer
           }
 
@@ -1713,6 +1742,29 @@ defmodule Fountain.Conversations.ConversationServer do
       # caller's previous current-span here.
       OpenTelemetry.Tracer.set_current_span(previous_span)
     end
+  end
+
+  # Emit the aggregate turn-duration event (#536). Called from every path
+  # that ends a turn which actually ran: the :exit handler, the mid-turn
+  # {:error, ...} handler (#413) and :interrupt.
+  #
+  # The `fountain.turn` OTel span and the turn row's started_at/ended_at
+  # both already describe one turn each; neither trends. This is the
+  # dashboard/alert signal.
+  #
+  # Tags are `runtime` (four values, gated by Runtimes.for_runtime/1 on the
+  # only path that starts a server) and the terminal `status`
+  # (completed/failed/interrupted). conv_id rides along as metadata — it is
+  # what makes the JSON log line actionable, and as a tag it would mint a
+  # time series per conversation.
+  defp emit_turn_completed(%{turn_metrics: nil}, _status), do: :ok
+
+  defp emit_turn_completed(%{turn_metrics: metrics} = state, status) do
+    Fountain.Telemetry.event(
+      [:turn, :completed],
+      %{runtime: metrics.runtime, status: status, conv_id: state.conversation_id},
+      %{duration_ms: System.monotonic_time(:millisecond) - metrics.started_mono}
+    )
   end
 
   # End the OTel turn span (if any) with a status reflecting the

--- a/apps/fountain/lib/fountain/telemetry.ex
+++ b/apps/fountain/lib/fountain/telemetry.ex
@@ -128,6 +128,7 @@ defmodule Fountain.Telemetry do
 
     one_shots = [
       @prefix ++ [:stage],
+      @prefix ++ [:turn, :completed],
       @prefix ++ [:sandbox, :reclaimed],
       @prefix ++ [:reaper, :run],
       @prefix ++ [:reaper, :untracked],

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -138,6 +138,28 @@ defmodule FountainWeb.Telemetry do
         description: "How long a sandbox reattach takes"
       ),
 
+      # How long a turn takes end to end (#536). Until this, turn duration
+      # existed only as a `fountain.turn` OTel span (traces, and only with
+      # OTLP export configured) and as turns.started_at/ended_at in Postgres
+      # (queryable by hand, not trended). fountain.stage.count already covers
+      # turn rates and outcomes — this is the duration.
+      #
+      # ConversationServer emits it from every path that ends a turn which
+      # ran; a turn resumed after a restart contributes no sample, since its
+      # start is in a previous BEAM lifetime.
+      #
+      # Buckets go much further out than the provision ones: a provision that
+      # takes 2 minutes is broken, a turn that takes 20 is a Tuesday.
+      distribution("fountain.turn.completed.duration_ms",
+        event_name: [:fountain, :turn, :completed],
+        measurement: :duration_ms,
+        tags: [:runtime, :status],
+        reporter_options: [
+          buckets: [1000, 5000, 15_000, 30_000, 60_000, 120_000, 300_000, 600_000, 1_800_000]
+        ],
+        description: "Turn duration by runtime and terminal status"
+      ),
+
       # ── Provisioning sub-steps (#537) ─────────────────────────────────────
       # The two spans above answer "did provisioning get slower"; these answer
       # "which step". All six were already emitting :stop events with a

--- a/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
@@ -1,0 +1,160 @@
+defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
+  @moduledoc """
+  Producer side of the turn-duration metric (#536).
+
+  `FountainWeb.Telemetry` declares a histogram over
+  `[:fountain, :turn, :completed]`; a metric subscribed to an event nobody
+  emits scrapes empty forever and looks exactly like a healthy quiet system
+  (#310). These pin that ConversationServer actually fires it, on every path
+  that ends a turn, with the tags the histogram reads.
+  """
+
+  use Fountain.ConversationServerCase
+
+  setup do
+    user = insert_verified_user()
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, environment_id: env.id)
+    sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        sandbox_id: sandbox.id,
+        status: "pending"
+      )
+
+    {:ok, conv: conv}
+  end
+
+  # Forward turn-completed events to the test process for the duration of
+  # one test. Handler ids are per-test so parallel modules can't collide —
+  # these are async: false, but the handler table is global either way.
+  defp capture_turn_completed do
+    test_pid = self()
+    handler_id = "turn-metrics-#{inspect(test_pid)}"
+
+    :telemetry.attach(
+      handler_id,
+      [:fountain, :turn, :completed],
+      fn _event, measurements, metadata, _config ->
+        send(test_pid, {:turn_completed, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  defp start_with_turn(conv) do
+    stub_happy_sprite()
+    ref = make_ref()
+
+    Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
+      {:ok, %{ref: ref, pid: self()}}
+    end)
+
+    Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
+    Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+
+    {pid, _mon, :alive} = start_server(conv, initial_prompt: "first")
+    {pid, ref}
+  end
+
+  describe "[:fountain, :turn, :completed]" do
+    test "a clean exit emits a duration tagged runtime + completed", %{conv: conv} do
+      capture_turn_completed()
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:exit, %{ref: ref}, 0})
+      _ = :sys.get_state(pid)
+
+      assert_received {:turn_completed, measurements, metadata}
+      assert metadata.runtime == "claude"
+      assert metadata.status == "completed"
+
+      # Metadata, never a tag: it's what makes the JSON log line point at a
+      # conversation, and as a label it would mint a series per conversation.
+      assert metadata.conv_id == conv.id
+
+      # Milliseconds, not native units or seconds: the histogram's buckets
+      # are in ms and a unit mix-up puts every turn in the first or last one.
+      assert is_integer(measurements.duration_ms)
+      assert measurements.duration_ms >= 0
+      assert measurements.duration_ms < 60_000
+
+      GenServer.stop(pid)
+    end
+
+    test "a non-zero exit emits with status failed", %{conv: conv} do
+      capture_turn_completed()
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:exit, %{ref: ref}, 1})
+      _ = :sys.get_state(pid)
+
+      assert_received {:turn_completed, _measurements, %{status: "failed"}}
+
+      GenServer.stop(pid)
+    end
+
+    test "a dropped sprite socket mid-turn still emits (#413)", %{conv: conv} do
+      # This path fails the turn without an :exit ever arriving. Left out, a
+      # runtime whose sockets drop would look like it had no slow turns at
+      # all — the histogram would simply lose those samples.
+      capture_turn_completed()
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:error, %{ref: ref}, :closed})
+      _ = :sys.get_state(pid)
+
+      assert_received {:turn_completed, _measurements, %{status: "failed"}}
+
+      GenServer.stop(pid)
+    end
+
+    test "an interrupt emits with status interrupted", %{conv: conv} do
+      capture_turn_completed()
+      {pid, _ref} = start_with_turn(conv)
+
+      assert :ok = GenServer.call(pid, :interrupt)
+
+      assert_received {:turn_completed, _measurements, %{status: "interrupted"}}
+
+      GenServer.stop(pid)
+    end
+
+    test "a spawn that never starts emits nothing", %{conv: conv} do
+      # There is no run to time — the turn is marked failed before any
+      # command exists. A sample here would be a few milliseconds of "turn
+      # duration" dragging the histogram's low end down.
+      capture_turn_completed()
+      stub_happy_sprite()
+      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts -> {:error, :econnrefused} end)
+
+      {pid, _ref, :alive} = start_server(conv, initial_prompt: "hello")
+      _ = :sys.get_state(pid)
+
+      refute_received {:turn_completed, _, _}
+
+      GenServer.stop(pid)
+    end
+
+    test "one turn emits exactly one sample", %{conv: conv} do
+      # The stamp is cleared on the terminal path. If it were not, a stale
+      # one would attach to the next turn and report a duration spanning
+      # both.
+      capture_turn_completed()
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:exit, %{ref: ref}, 0})
+      _ = :sys.get_state(pid)
+
+      assert_received {:turn_completed, _, _}
+      refute_received {:turn_completed, _, _}
+
+      GenServer.stop(pid)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -163,6 +163,9 @@ defmodule FountainWeb.MetricsTest do
         # 2-tuple span return), which is why the metrics use measurement
         # functions.
         [:fountain, :rehydrate, :stop],
+        # ConversationServer's terminal turn paths (#536) — exercised by
+        # conversation_server_turn_metrics_test.exs against a real server
+        [:fountain, :turn, :completed],
         # :telemetry.execute call sites
         [:fountain, :sandbox, :reclaimed],
         [:fountain, :reaper, :run],
@@ -366,6 +369,32 @@ defmodule FountainWeb.MetricsTest do
       # conv_id / checkpoint_id are span metadata, never labels.
       refute body =~ conv_id
       refute body =~ "checkpoint_id="
+    end
+
+    test "turn duration scrapes with runtime and status labels (#536)" do
+      # The subscription side. The producer side — ConversationServer emitting
+      # this on every terminal turn path — is asserted in
+      # conversation_server_turn_metrics_test.exs against a real server.
+      # The reporter is global to the VM and the ConversationServer tests feed
+      # the same histogram with runtime="claude". "opencode" is emitted by
+      # nothing else, so the bucket counts below are this test's alone.
+      Fountain.Telemetry.event(
+        [:turn, :completed],
+        %{runtime: "opencode", status: "completed", conv_id: Ecto.UUID.generate()},
+        %{duration_ms: 42_000}
+      )
+
+      Process.sleep(50)
+      {200, body} = scrape()
+
+      series = ~s(fountain_turn_completed_duration_ms_bucket{runtime="opencode",status="completed")
+
+      # 42s lands above the 30s boundary and below 60s. A duration handed over
+      # in seconds or in native units lands in a different bucket entirely.
+      assert body =~ ~s(#{series},le="60000"} 1)
+      assert body =~ ~s(#{series},le="30000"} 0)
+
+      refute body =~ "conv_id="
     end
 
     test "route tags are the matched pattern, not the raw path", %{conn: conn} do


### PR DESCRIPTION
Closes #536. **Stacked on #596 — base is `metrics/537-span-histograms`; review only the top commit.**

How long a turn takes existed in two places, neither of which supports a dashboard or an alert: the `fountain.turn` OTel span (traces only, and only where OTLP export is configured) and `turns.started_at`/`ended_at` in Postgres (queryable by hand). `fountain.stage.count` already covers turn *rates and outcomes* — started/done/failed/interrupted — so the gap was specifically the duration.

`ConversationServer` now emits `[:fountain, :turn, :completed]` with a `duration_ms` measurement; `FountainWeb.Telemetry` exports it as a histogram tagged by `runtime` and terminal `status`. Both tag sets are bounded: `runtime` is gated by `Runtimes.for_runtime/1` on the only path that starts a server, `status` is completed/failed/interrupted. `conv_id` stays metadata — it's what makes the JSON log line point at a conversation, and as a label it would mint a series per conversation.

### Three details worth the review time

**Monotonic, not the turn row.** `now/0` truncates to the second, so a duration derived from `started_at`/`ended_at` is ±1s granular and reports *zero* for a fast turn. The stamp is taken just before `Sprites.spawn` so the round trip to sprites.dev is inside the measurement — the user waits through that too — and is held in a local until the spawn succeeds, so a spawn that never starts leaves nothing behind to attach itself to the next turn.

**Every terminal path emits, not just `:exit`.** The mid-turn `{:error, ...}` handler (#413) ends turns without an `:exit` ever arriving; omitting it would silently drop exactly the samples from a runtime whose sockets keep dropping. `:interrupt` likewise.

**A turn resumed after a restart emits nothing.** Its start is in a previous BEAM lifetime — monotonic time doesn't survive that, and measuring from `started_at` would fold the whole deploy gap into the histogram. A missing sample beats a wrong one.

### Buckets

`[1s, 5s, 15s, 30s, 1m, 2m, 5m, 10m, 30m]` — much further out than the provision buckets, which top out at 120s. A provision that takes two minutes is broken; a turn that takes twenty is a Tuesday.

### Tests

`conversation_server_turn_metrics_test.exs` drives a real `ConversationServer` through each terminal path — clean exit, non-zero exit, dropped socket, interrupt — plus the two negative cases (a spawn that never starts emits nothing; one turn emits exactly one sample). Verified by reverting: removing the three emit calls fails five of the six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)