### PR TITLE
metrics: measure time to first token (#535)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -249,12 +249,12 @@ defmodule Fountain.Conversations.ConversationServer do
       # OTel span context for the in-flight turn (started in kick_turn,
       # ended in the :exit / :interrupt handlers).
       current_turn_span: nil,
-      # Aggregate-metric bookkeeping for the in-flight turn (#536):
-      # `%{started_mono: ms, runtime: "claude"}`, set once the turn's
-      # command is spawned and dropped on every terminal path. nil
-      # whenever no turn is running. Monotonic rather than the turn row's
-      # timestamps because `now/0` truncates to the second, which rounds a
-      # sub-second turn to a duration of zero.
+      # Aggregate-metric bookkeeping for the in-flight turn (#536, #535):
+      # `%{started_mono: ms, runtime: "claude", first_output?: bool}`, set
+      # once the turn's command is spawned and dropped on every terminal
+      # path. nil whenever no turn is running. Monotonic rather than the
+      # turn row's timestamps because `now/0` truncates to the second,
+      # which rounds a sub-second turn to a duration of zero.
       turn_metrics: nil,
       # Stream tracer for parsing Claude's stream-json stdout into OTel
       # child spans and events. nil for non-Claude runtimes.
@@ -1114,6 +1114,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   @impl true
   def handle_info({:stdout, %{ref: ref}, data}, %{current_command_ref: ref} = state) do
+    state = maybe_emit_first_output(state)
     new_state = log_with_replay_skip(state, "stdout", data)
 
     # Feed non-replayed bytes into the stream tracer (Claude only).
@@ -1695,7 +1696,11 @@ defmodule Fountain.Conversations.ConversationServer do
               current_turn: turn,
               runtime_session_id: runtime_session_id,
               current_turn_span: turn_span,
-              turn_metrics: %{started_mono: turn_started_mono, runtime: conv.runtime},
+              turn_metrics: %{
+                started_mono: turn_started_mono,
+                runtime: conv.runtime,
+                first_output?: false
+              },
               stream_tracer: stream_tracer
           }
 
@@ -1757,6 +1762,37 @@ defmodule Fountain.Conversations.ConversationServer do
   # (completed/failed/interrupted). conv_id rides along as metadata — it is
   # what makes the JSON log line actionable, and as a tag it would mint a
   # time series per conversation.
+  # Time to first token (#535): the gap a user actually feels between
+  # hitting enter and seeing the agent do something. Provision time and
+  # turn duration are both trended; a regression that delays *first
+  # output* — slow runtime startup inside the sprite, model latency,
+  # stdin plumbing — sat between them, visible only per-trace in
+  # Honeycomb, only for Claude, and only with OTLP export configured.
+  #
+  # One-shot per turn: the first stdout chunk wins and the flag is set,
+  # so the whole rest of a streaming turn costs one map update.
+  #
+  # First *bytes*, not first parsed token. Only Claude emits structured
+  # stream-json; measuring bytes keeps this identical for codex, gemini
+  # and opencode. It does mean a runtime that greets on stdout before
+  # calling a model reports its own startup — which is still the number
+  # the user is waiting on.
+  defp maybe_emit_first_output(%{turn_metrics: %{first_output?: false} = metrics} = state) do
+    Fountain.Telemetry.event(
+      [:turn, :first_output],
+      %{runtime: metrics.runtime, conv_id: state.conversation_id},
+      %{elapsed_ms: System.monotonic_time(:millisecond) - metrics.started_mono}
+    )
+
+    %{state | turn_metrics: %{metrics | first_output?: true}}
+  end
+
+  # No turn running, or this turn already reported. Also the reattach case:
+  # turn_metrics is nil there, so the replayed output a resumed session
+  # opens with can't be mistaken for a first token (its real one arrived in
+  # a previous BEAM lifetime).
+  defp maybe_emit_first_output(state), do: state
+
   defp emit_turn_completed(%{turn_metrics: nil}, _status), do: :ok
 
   defp emit_turn_completed(%{turn_metrics: metrics} = state, status) do

--- a/apps/fountain/lib/fountain/telemetry.ex
+++ b/apps/fountain/lib/fountain/telemetry.ex
@@ -128,6 +128,7 @@ defmodule Fountain.Telemetry do
 
     one_shots = [
       @prefix ++ [:stage],
+      @prefix ++ [:turn, :first_output],
       @prefix ++ [:turn, :completed],
       @prefix ++ [:sandbox, :reclaimed],
       @prefix ++ [:reaper, :run],

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -159,6 +159,25 @@ defmodule FountainWeb.Telemetry do
         ],
         description: "Turn duration by runtime and terminal status"
       ),
+      # Time to first token (#535) — the latency between hitting enter and
+      # seeing the agent do something, which is the one a user actually
+      # feels. Turn duration above says how long the whole thing took; this
+      # says how long it took to start.
+      #
+      # Buckets are much tighter than the turn ones on purpose: past ~30s of
+      # silence the user has already concluded it's broken, so resolution
+      # below that is where the signal is.
+      #
+      # Runtime-agnostic — ConversationServer measures the first stdout
+      # bytes, not parsed tokens, so claude/codex/gemini/opencode are all
+      # comparable here.
+      distribution("fountain.turn.first_output.elapsed_ms",
+        event_name: [:fountain, :turn, :first_output],
+        measurement: :elapsed_ms,
+        tags: [:runtime],
+        reporter_options: [buckets: [250, 500, 1000, 2500, 5000, 10_000, 30_000, 60_000]],
+        description: "Time from turn start to the sandbox's first output byte"
+      ),
 
       # ── Provisioning sub-steps (#537) ─────────────────────────────────────
       # The two spans above answer "did provisioning get slower"; these answer

--- a/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
@@ -1,12 +1,14 @@
 defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
   @moduledoc """
-  Producer side of the turn-duration metric (#536).
+  Producer side of the turn metrics — duration (#536) and time to first
+  token (#535).
 
-  `FountainWeb.Telemetry` declares a histogram over
-  `[:fountain, :turn, :completed]`; a metric subscribed to an event nobody
-  emits scrapes empty forever and looks exactly like a healthy quiet system
-  (#310). These pin that ConversationServer actually fires it, on every path
-  that ends a turn, with the tags the histogram reads.
+  `FountainWeb.Telemetry` declares histograms over
+  `[:fountain, :turn, :completed]` and `[:fountain, :turn, :first_output]`;
+  a metric subscribed to an event nobody emits scrapes empty forever and
+  looks exactly like a healthy quiet system (#310). These pin that
+  ConversationServer actually fires them, on every path that ends a turn and
+  on the first byte out of the sandbox, with the tags the histograms read.
   """
 
   use Fountain.ConversationServerCase
@@ -28,18 +30,22 @@ defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
     {:ok, conv: conv}
   end
 
-  # Forward turn-completed events to the test process for the duration of
-  # one test. Handler ids are per-test so parallel modules can't collide —
-  # these are async: false, but the handler table is global either way.
-  defp capture_turn_completed do
+  # Forward turn metric events to the test process for the duration of one
+  # test. Handler ids are per-test so parallel modules can't collide — these
+  # are async: false, but the handler table is global either way.
+  defp capture_turn_completed, do: capture([:fountain, :turn, :completed], :turn_completed)
+
+  defp capture_first_output, do: capture([:fountain, :turn, :first_output], :first_output)
+
+  defp capture(event, tag) do
     test_pid = self()
-    handler_id = "turn-metrics-#{inspect(test_pid)}"
+    handler_id = "turn-metrics-#{tag}-#{inspect(test_pid)}"
 
     :telemetry.attach(
       handler_id,
-      [:fountain, :turn, :completed],
+      event,
       fn _event, measurements, metadata, _config ->
-        send(test_pid, {:turn_completed, measurements, metadata})
+        send(test_pid, {tag, measurements, metadata})
       end,
       nil
     )
@@ -153,6 +159,96 @@ defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
 
       assert_received {:turn_completed, _, _}
       refute_received {:turn_completed, _, _}
+
+      GenServer.stop(pid)
+    end
+  end
+
+  describe "[:fountain, :turn, :first_output]" do
+    test "the first stdout chunk reports elapsed time tagged by runtime", %{conv: conv} do
+      capture_first_output()
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:stdout, %{ref: ref}, "thinking..."})
+      _ = :sys.get_state(pid)
+
+      assert_received {:first_output, measurements, metadata}
+      assert metadata.runtime == "claude"
+      assert metadata.conv_id == conv.id
+      assert is_integer(measurements.elapsed_ms)
+      assert measurements.elapsed_ms >= 0
+      assert measurements.elapsed_ms < 60_000
+
+      GenServer.stop(pid)
+    end
+
+    test "only the first chunk reports — the rest of the stream is free", %{conv: conv} do
+      # A streaming turn produces thousands of chunks. Emitting on each
+      # would make TTFT indistinguishable from "time to last token" and put
+      # a telemetry dispatch on every byte of the hot path.
+      capture_first_output()
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:stdout, %{ref: ref}, "first"})
+      send(pid, {:stdout, %{ref: ref}, "second"})
+      send(pid, {:stdout, %{ref: ref}, "third"})
+      _ = :sys.get_state(pid)
+
+      assert_received {:first_output, _, _}
+      refute_received {:first_output, _, _}
+
+      GenServer.stop(pid)
+    end
+
+    test "each turn reports its own first output", %{conv: conv} do
+      # The flag lives with the turn's stamp and is dropped with it, so turn
+      # 2 measures turn 2. A flag that survived the turn would leave every
+      # conversation contributing exactly one sample, forever.
+      capture_first_output()
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:stdout, %{ref: ref}, "turn one output"})
+      send(pid, {:exit, %{ref: ref}, 0})
+      _ = :sys.get_state(pid)
+      assert_received {:first_output, _, _}
+
+      assert :ok = GenServer.call(pid, {:send_prompt, "again", []})
+      send(pid, {:stdout, %{ref: ref}, "turn two output"})
+      _ = :sys.get_state(pid)
+      assert_received {:first_output, _, _}
+
+      GenServer.stop(pid)
+    end
+
+    test "a turn with no output before it exits reports nothing", %{conv: conv} do
+      # Nothing to measure — the sandbox never spoke. A zero here would read
+      # as an instant first token, which is the opposite of what happened.
+      capture_first_output()
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:exit, %{ref: ref}, 1})
+      _ = :sys.get_state(pid)
+
+      refute_received {:first_output, _, _}
+
+      GenServer.stop(pid)
+    end
+
+    test "stderr alone does not count as first output", %{conv: conv} do
+      # The metric is first *output*, and every runtime's actual answer comes
+      # down stdout; a warning on stderr at startup would otherwise report a
+      # TTFT of a few milliseconds for a turn that hadn't started yet.
+      capture_first_output()
+      {pid, ref} = start_with_turn(conv)
+
+      send(pid, {:stderr, %{ref: ref}, "npm notice: new version available"})
+      _ = :sys.get_state(pid)
+
+      refute_received {:first_output, _, _}
+
+      send(pid, {:stdout, %{ref: ref}, "hello"})
+      _ = :sys.get_state(pid)
+      assert_received {:first_output, _, _}
 
       GenServer.stop(pid)
     end

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -163,9 +163,11 @@ defmodule FountainWeb.MetricsTest do
         # 2-tuple span return), which is why the metrics use measurement
         # functions.
         [:fountain, :rehydrate, :stop],
-        # ConversationServer's terminal turn paths (#536) — exercised by
+        # ConversationServer's terminal turn paths (#536) and its stdout
+        # handler (#535) — both exercised by
         # conversation_server_turn_metrics_test.exs against a real server
         [:fountain, :turn, :completed],
+        [:fountain, :turn, :first_output],
         # :telemetry.execute call sites
         [:fountain, :sandbox, :reclaimed],
         [:fountain, :reaper, :run],
@@ -394,6 +396,30 @@ defmodule FountainWeb.MetricsTest do
       assert body =~ ~s(#{series},le="60000"} 1)
       assert body =~ ~s(#{series},le="30000"} 0)
 
+      refute body =~ "conv_id="
+    end
+
+    test "time to first token scrapes tagged by runtime (#535)" do
+      # Distinct runtime for the same reason as the turn-duration test: the
+      # reporter is global and the ConversationServer tests feed claude.
+      Fountain.Telemetry.event(
+        [:turn, :first_output],
+        %{runtime: "gemini", conv_id: Ecto.UUID.generate()},
+        %{elapsed_ms: 1_500}
+      )
+
+      Process.sleep(50)
+      {200, body} = scrape()
+
+      series = ~s(fountain_turn_first_output_elapsed_ms_bucket{runtime="gemini")
+
+      # 1.5s is above the 1s boundary and below 2.5s.
+      assert body =~ ~s(#{series},le="2500"} 1)
+      assert body =~ ~s(#{series},le="1000"} 0)
+
+      # No status tag here: a turn reports first output once, before any
+      # outcome is known.
+      refute body =~ ~s(fountain_turn_first_output_elapsed_ms_bucket{runtime="gemini",status)
       refute body =~ "conv_id="
     end
 


### PR DESCRIPTION
Closes #535. **Top of a stack of three — base is `metrics/536-turn-duration` (#597), which sits on #596. Review only the top commit.**

Nothing captured the gap between hitting enter and the agent visibly doing something. Provision time has a histogram, and #597 gives turns one, but the latency *between* them — slow runtime startup inside the sprite, model latency, stdin plumbing — was measurable only per-trace in Honeycomb, only for the Claude runtime (via `StreamTracer`'s content-block span events), and only where OTLP export is configured. Never as an aggregate.

`ConversationServer`'s stdout handler now emits `[:fountain, :turn, :first_output]` with an `elapsed_ms` measurement, once per turn, against the same monotonic stamp #597 takes at spawn. `FountainWeb.Telemetry` exports it tagged by `runtime`; `conv_id` rides along as metadata, for the log line, never as a label.

### Choices

**First stdout *bytes*, not parsed tokens.** Only Claude produces structured stream-json, so parsing would make this a Claude-only metric — bytes keep claude, codex, gemini and opencode directly comparable. The tradeoff, stated plainly: a runtime that greets on stdout before calling a model reports its own startup. That's still latency the user sits through.

**The one-shot flag lives in the per-turn metrics map**, so it's dropped with the turn rather than persisting — turn 2 measures turn 2, and the remaining thousands of chunks in a streaming turn cost one map read.

**stderr deliberately doesn't count.** An npm notice at startup would otherwise report a TTFT of a few milliseconds for a turn that hadn't begun.

**A turn resumed after a restart emits nothing**, same as #597: the replayed output a reattached session opens with is not a first token.

**Buckets are much tighter than the turn ones** — 250ms → 60s. Past ~30s of silence the user has already decided it's broken, so the resolution belongs below that.

### Tests

Five producer cases against a real server: the first chunk reports with the right tags; only the first chunk reports; each turn reports its own; a turn that exits without ever speaking reports nothing; stderr alone doesn't trigger it. Verified by reverting: removing the single emit call fails four of the five.

Full suite green at the top of the stack (2,385 tests, `mix precommit` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)