### PR TITLE
api: guard the OpenAPI enums against the domain lists they restate (#599)

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -26,6 +26,13 @@ defmodule Fountain.Accounts do
   alias Fountain.Audit
   alias Fountain.Crypto
 
+  # The onboarding wizard's states, in order. An attribute rather than an
+  # inline literal so `advance_onboarding/2` can guard on it and the OpenAPI
+  # schema can be checked against it — see the enum guardrail test.
+  @onboarding_states ~w(step_1 step_2 step_3 step_4 completed)
+
+  def onboarding_states, do: @onboarding_states
+
   ## Users
 
   @doc "Look up a user by (downcased) email. Returns `nil` if not found."
@@ -475,7 +482,7 @@ defmodule Fountain.Accounts do
   @spec advance_onboarding(User.t(), String.t()) ::
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def advance_onboarding(%User{} = user, state)
-      when state in ~w(step_1 step_2 step_3 step_4 completed) do
+      when state in @onboarding_states do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     changes =

--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -54,6 +54,9 @@ defmodule Fountain.Accounts.User do
     timestamps(type: :utc_datetime)
   end
 
+  def roles, do: @roles
+  def subscription_statuses, do: @subscription_statuses
+
   @doc "Changeset for new user registration (email + password path)."
   def registration_changeset(user, attrs) do
     user

--- a/apps/fountain/lib/fountain/environments/environment.ex
+++ b/apps/fountain/lib/fountain/environments/environment.ex
@@ -45,6 +45,7 @@ defmodule Fountain.Environments.Environment do
   end
 
   def warm_start_fields, do: @warm_start_fields
+  def networking, do: @networking
 
   def changeset(env, attrs) do
     env

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -19,6 +19,8 @@ defmodule Fountain.Manifest do
 
   @kinds ~w(Environment Vault Agent)
 
+  def kinds, do: @kinds
+
   # Ownership/identity fields are never taken from a manifest spec; secrets
   # are split out and written through the envelope-encryption path instead.
   @stripped_keys ~w(id user_id created_by secrets)

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -1,0 +1,208 @@
+defmodule FountainWeb.SchemaEnumGuardrailTest do
+  @moduledoc """
+  The OpenAPI enums against the domain lists they restate (issue #599).
+
+  `FountainWeb.Schemas` declares every enum a second time, by hand. Twelve
+  lists were duplicated verbatim from an Ecto schema — `agent.runtime` alone
+  in four places — and nothing checked that the copies agreed. The drift is
+  silent in the worst direction: add a value to `@statuses` and the changeset
+  accepts it, the API returns it, the spec says it cannot exist,
+  `mix openapi.spec.json` still passes, and only a generated client with a
+  strict enum decoder finds out, in production. #197 is the precedent — the
+  unreachable `completed` conversation status stayed in the published enum
+  after the schema dropped it.
+
+  This walks every `FountainWeb.Schemas.*` module, finds every property
+  carrying an `:enum`, and requires each one to be either
+
+    * mapped in `@derived` to the domain function that owns the list, and
+      equal to it; or
+    * listed in `@api_local` with a reason — an enum with no domain
+      counterpart, which is a decision rather than an oversight.
+
+  Add an enum to a schema and this test fails until you do one or the other.
+  Comparison is by set: OpenAPI enum order is not meaningful, and two of
+  these lists were already written in a different order than their source
+  (`~w(admin user)` against `User.roles/0`'s `~w(user admin)`).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Fountain.Accounts.User
+  alias Fountain.Agents.Agent
+  alias Fountain.Conversations.{Conversation, LogEvent, Sandbox, Turn}
+  alias Fountain.Environments.Environment
+  alias Fountain.Exports.Export
+  alias Fountain.InferenceCredentials.Credential
+  alias Fountain.{Accounts, Images, Manifest}
+  alias OpenApiSpex.Schema
+
+  # {schema module, dotted property path} => {owning module, function}
+  #
+  # The value is compared as a set against `apply(mod, fun, [])`. A provider
+  # list of atoms is stringified first — the domain keeps them as atoms, the
+  # wire carries strings.
+  @derived %{
+    {FountainWeb.Schemas.AdminRoleRequest, "role"} => {User, :roles},
+    {FountainWeb.Schemas.AdminUser, "role"} => {User, :roles},
+    {FountainWeb.Schemas.AuthMeResponse, "role"} => {User, :roles},
+    {FountainWeb.Schemas.Agent, "runtime"} => {Agent, :runtimes},
+    {FountainWeb.Schemas.AgentRequest, "runtime"} => {Agent, :runtimes},
+    {FountainWeb.Schemas.AgentUpdate, "runtime"} => {Agent, :runtimes},
+    # A conversation's runtime is copied from its agent at spawn, so it must
+    # speak the same vocabulary even though the column carries no inclusion
+    # validation of its own.
+    {FountainWeb.Schemas.Conversation, "runtime"} => {Agent, :runtimes},
+    {FountainWeb.Schemas.Agent, "avatar_media_type"} => {Images, :valid_media_types},
+    {FountainWeb.Schemas.AvatarRequest, "media_type"} => {Images, :valid_media_types},
+    {FountainWeb.Schemas.ImageInput, "media_type"} => {Images, :valid_media_types},
+    {FountainWeb.Schemas.BillingResponse, "data.status"} => {User, :subscription_statuses},
+    {FountainWeb.Schemas.Conversation, "status"} => {Conversation, :statuses},
+    {FountainWeb.Schemas.Conversation, "source"} => {Conversation, :sources},
+    {FountainWeb.Schemas.ConversationTreeNode, "status"} => {Conversation, :statuses},
+    {FountainWeb.Schemas.ConversationTreeNode, "source"} => {Conversation, :sources},
+    {FountainWeb.Schemas.Environment, "networking_type"} => {Environment, :networking},
+    {FountainWeb.Schemas.EnvironmentRequest, "networking_type"} => {Environment, :networking},
+    {FountainWeb.Schemas.EnvironmentUpdate, "networking_type"} => {Environment, :networking},
+    {FountainWeb.Schemas.Export, "status"} => {Export, :statuses},
+    {FountainWeb.Schemas.InferenceCredentialStatus, "provider"} => {Credential, :providers},
+    {FountainWeb.Schemas.LogEvent, "kind"} => {LogEvent, :kinds},
+    {FountainWeb.Schemas.LogEvent, "state"} => {LogEvent, :states},
+    {FountainWeb.Schemas.ManifestResource, "kind"} => {Manifest, :kinds},
+    {FountainWeb.Schemas.OnboardingResponse, "data.state"} => {Accounts, :onboarding_states},
+    {FountainWeb.Schemas.Sandbox, "status"} => {Sandbox, :statuses},
+    {FountainWeb.Schemas.Turn, "status"} => {Turn, :statuses}
+  }
+
+  # Enums with no domain list behind them. Each entry needs a reason: the
+  # point of the list is that adding to it is a deliberate act.
+  @api_local %{
+    # Outcomes of two admin actions. Computed in the controller from what the
+    # action did; they describe an HTTP response, not a stored value.
+    {FountainWeb.Schemas.AdminReapResponse, "data.outcome"} =>
+      "admin reap result — response vocabulary, not persisted state",
+    {FountainWeb.Schemas.AdminResyncResponse, "data.outcome"} =>
+      "admin resync result — response vocabulary, not persisted state",
+    # Per-resource results from `fountain apply`. Manifest reports these as
+    # atoms built inline per branch; there is no list to compare against.
+    {FountainWeb.Schemas.ApplyResult, "action"} =>
+      "manifest apply outcome — built per branch in Manifest, not a declared list",
+    {FountainWeb.Schemas.ApplySecretResult, "action"} =>
+      "manifest secret apply outcome — as above",
+    # Health probe vocabulary, owned by the readiness endpoint.
+    {FountainWeb.Schemas.ReadinessResponse, "status"} => "health probe vocabulary",
+    {FountainWeb.Schemas.ReadinessResponse, "checks.{}"} => "health probe vocabulary"
+  }
+
+  # Domain lists that are exposed on the wire but deliberately carry no enum
+  # in the spec. Recorded here so the omission stays a decision — this test
+  # cannot catch drift in a field it does not constrain.
+  #
+  #   LogEvent.stream (LogEvent.streams/0 == ~w(stdout stderr)) — stage events
+  #   carry "" for this field, so the honest enum would be
+  #   ["stdout", "stderr", ""]. Left unconstrained with a prose description
+  #   instead. Revisit if stage events stop sharing the shape.
+
+  describe "every OpenAPI enum is accounted for" do
+    setup do
+      %{sites: enum_sites()}
+    end
+
+    test "each enum matches the domain list it restates", %{sites: sites} do
+      mismatches =
+        for {mod, path, enum} <- sites,
+            {owner, fun} = Map.get(@derived, {mod, path}, {nil, nil}),
+            owner != nil,
+            expected = owner |> apply(fun, []) |> Enum.map(&to_string/1) |> MapSet.new(),
+            actual = enum |> Enum.map(&to_string/1) |> MapSet.new(),
+            not MapSet.equal?(expected, actual) do
+          """
+            #{short(mod)}.#{path}
+              spec has:   #{inspect(Enum.sort(actual))}
+              #{inspect(owner)}.#{fun}/0 has: #{inspect(Enum.sort(expected))}
+              only in spec:   #{inspect(actual |> MapSet.difference(expected) |> Enum.sort())}
+              only in domain: #{inspect(expected |> MapSet.difference(actual) |> Enum.sort())}
+          """
+        end
+
+      assert mismatches == [],
+             "OpenAPI enums have drifted from the domain lists they restate:\n\n" <>
+               Enum.join(mismatches, "\n")
+    end
+
+    test "no enum is unclassified", %{sites: sites} do
+      unclassified =
+        for {mod, path, enum} <- sites,
+            not Map.has_key?(@derived, {mod, path}),
+            not Map.has_key?(@api_local, {mod, path}),
+            do: "  #{short(mod)}.#{path} => #{inspect(enum)}"
+
+      assert unclassified == [],
+             """
+             New OpenAPI enum(s) with no declared source:
+
+             #{Enum.join(unclassified, "\n")}
+
+             Add each to @derived pointing at the domain function that owns the
+             list, or to @api_local with a reason if it has no domain counterpart.
+             """
+    end
+
+    test "the registries have no stale entries", %{sites: sites} do
+      live = MapSet.new(sites, fn {mod, path, _} -> {mod, path} end)
+
+      stale =
+        (Map.keys(@derived) ++ Map.keys(@api_local))
+        |> Enum.reject(&MapSet.member?(live, &1))
+        |> Enum.map(fn {mod, path} -> "  #{short(mod)}.#{path}" end)
+
+      assert stale == [],
+             "Registry entries pointing at enums that no longer exist:\n" <>
+               Enum.join(stale, "\n")
+    end
+  end
+
+  # Every enum reachable from a schema, as {module, dotted path, values}.
+  defp enum_sites do
+    :fountain
+    |> :application.get_key(:modules)
+    |> elem(1)
+    |> Enum.filter(&String.starts_with?(Atom.to_string(&1), "Elixir.FountainWeb.Schemas."))
+    |> Enum.sort()
+    |> Enum.flat_map(fn mod ->
+      Code.ensure_loaded(mod)
+
+      if function_exported?(mod, :schema, 0) do
+        mod.schema() |> walk([]) |> Enum.map(fn {path, enum} -> {mod, path, enum} end)
+      else
+        []
+      end
+    end)
+  end
+
+  # `properties` values may be a %Schema{}, a nested schema module (a $ref),
+  # or a bare type atom. Only inline %Schema{} structs are walked — a module
+  # reference is that module's own responsibility and is visited on its own.
+  defp walk(%Schema{} = schema, path) do
+    own =
+      if is_list(schema.enum),
+        do: [{path |> Enum.reverse() |> Enum.join("."), schema.enum}],
+        else: []
+
+    own ++
+      walk_props(schema.properties, path) ++
+      walk(schema.items, ["[]" | path]) ++
+      walk(schema.additionalProperties, ["{}" | path]) ++
+      Enum.flat_map(schema.oneOf || [], &walk(&1, path)) ++
+      Enum.flat_map(schema.allOf || [], &walk(&1, path))
+  end
+
+  defp walk(_, _), do: []
+
+  defp walk_props(props, path) when is_map(props),
+    do: Enum.flat_map(props, fn {key, value} -> walk(value, [to_string(key) | path]) end)
+
+  defp walk_props(_, _), do: []
+
+  defp short(mod), do: mod |> inspect() |> String.replace("FountainWeb.Schemas.", "")
+end


### PR DESCRIPTION
Closes #599 — the guardrail half. The `DerivedSchema` macro proposed in that issue is deliberately **not** here; the issue's suggested order was to contain the drift risk first and evaluate derivation separately, with the hole already closed.

## What it does

`apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs` walks all 95 `FountainWeb.Schemas.*` modules, recursively collects every property carrying an `:enum` — 32 sites, matching a grep of `schemas.ex` exactly — and runs three checks:

1. **Drift** — each registered enum must set-equal the domain function that owns it. 26 sites are now pinned to `Agent.runtimes/0`, `Conversation.statuses/0`, `Images.valid_media_types/0`, and friends.
2. **Unclassified** — a newly added enum must go in `@derived` pointing at its owner, or in `@api_local` **with a reason**. Same shape as `audit_guardrail_test.exs`: adding to the exclusion list is a decision, and it's visible in review.
3. **Stale** — a registry entry pointing at an enum that no longer exists fails, so the lists can't rot as the spec changes.

The walk handles nested paths (`data.status`), `items`, `additionalProperties`, `oneOf`/`allOf`. Schema-module `$ref`s aren't followed — each module is visited on its own, so nothing is checked twice.

Comparison is by **set**, not list. That's load-bearing: `~w(admin user)` in the spec was already written in a different order than `User.roles/0`'s `~w(user admin)`, and OpenAPI enum order carries no meaning.

## Why

The failure mode is silent in the worst direction. Add a value to `@statuses` and the changeset accepts it, the API returns it, the spec says it cannot exist, `mix openapi.spec.json` passes, CI goes green — and a generated client with a strict enum decoder finds out in production. #197 is exactly this: the unreachable `completed` conversation status stayed in the published enum after the schema dropped it.

## The five accessors

The guard needs a runtime-readable source of truth. Six schemas already exposed one (`Conversation.statuses/0`, `LogEvent.kinds/0`, …); these didn't:

- `User.roles/0`, `User.subscription_statuses/0`
- `Environment.networking/0`
- `Manifest.kinds/0`
- `Accounts.onboarding_states/0`

The last one also extracts an inline `~w(step_1 step_2 step_3 step_4 completed)` from `advance_onboarding/2`'s guard into `@onboarding_states`, which the guard clause now uses — the list existed twice and now exists once. Module attributes are legal in guards, so this is a straight substitution.

## Verification

Each check was confirmed to fail on the scenario it exists for, rather than trusted because the suite was green:

| Injected | Result |
|---|---|
| `archived` added to `Conversation.@statuses` | drift test fails, naming **both** `Conversation.status` and `ConversationTreeNode.status`, with an only-in-domain diff |
| new `tier` enum added to the LogEvent schema | classification test fails |
| registry entry for a non-existent property | staleness test fails |

Gate: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), `mix dialyzer` (0 errors), `mix deps.unlock --unused`. Full suite **2,379 tests, 0 failures**.

## Known gap, recorded not fixed

`LogEvent.stream` is on the wire and the domain declares `LogEvent.streams/0` as `~w(stdout stderr)`, but the spec gives it a prose description and **no enum** — so this guard cannot constrain it. The omission is defensible: stage events carry `""` for that field, so an honest enum would be `["stdout", "stderr", ""]`. It's noted in a comment in the test rather than left as a silent hole. This is the one class of drift the design can't catch — a field with no enum at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
