### PR TITLE
api: declare the %{data: ...} response envelopes instead of writing them out

### DIFF
--- a/apps/fountain/lib/fountain_web/schema_wrappers.ex
+++ b/apps/fountain/lib/fountain_web/schema_wrappers.ex
@@ -1,0 +1,88 @@
+defmodule FountainWeb.SchemaWrappers do
+  @moduledoc """
+  Declare the `%{data: ...}` envelope schemas every JSON collection uses.
+
+  Twenty-two modules in `FountainWeb.Schemas` said nothing but "this response
+  is one X" or "this response is a list of X", in nine lines each, and not
+  even consistently — `ConversationListResponse` spelled across three lines
+  what `TurnListResponse` said in one. They carry no knowledge: one
+  description among the twenty-two.
+
+      list_response(ConversationListResponse, of: Conversation)
+      item_response(ConversationResponse, of: Conversation)
+
+  `description:` is accepted for the rare envelope that has something to say.
+
+  ## Scope
+
+  Only the pure envelopes. The three paginated responses
+  (`AdminUserListResponse`, `LogEventListResponse`, `AuditEventListResponse`)
+  stay hand-written: they carry a `meta` block, and the API has two
+  pagination idioms — cursor (`limit`/`has_more`/`next_cursor`) and offset
+  (`page`/`per_page`/`total`). Folding those in would harden a choice between
+  them that nobody has made yet, so it is deliberately left alone.
+
+  ## Definition order still matters
+
+  These expand to real `defmodule`s nested in `FountainWeb.Schemas`, so the
+  item module must already be defined above the call — the implicit alias a
+  nested `defmodule` creates only exists after it. That constraint predates
+  this macro and is unchanged by it; `AdminAuditListResponse` still passes a
+  fully qualified name because `AuditEvent` is defined further down the file.
+  """
+
+  @doc "Define a `%{data: [item]}` response schema module."
+  defmacro list_response(name, opts) do
+    item = Keyword.fetch!(opts, :of)
+    description = Keyword.get(opts, :description)
+
+    quote do
+      defmodule unquote(name) do
+        @moduledoc false
+        require OpenApiSpex
+
+        OpenApiSpex.schema(
+          FountainWeb.SchemaWrappers.envelope(
+            __MODULE__,
+            %OpenApiSpex.Schema{type: :array, items: unquote(item)},
+            unquote(description)
+          )
+        )
+      end
+    end
+  end
+
+  @doc "Define a `%{data: item}` response schema module."
+  defmacro item_response(name, opts) do
+    item = Keyword.fetch!(opts, :of)
+    description = Keyword.get(opts, :description)
+
+    quote do
+      defmodule unquote(name) do
+        @moduledoc false
+        require OpenApiSpex
+
+        OpenApiSpex.schema(
+          FountainWeb.SchemaWrappers.envelope(__MODULE__, unquote(item), unquote(description))
+        )
+      end
+    end
+  end
+
+  @doc """
+  Build the envelope map `OpenApiSpex.schema/1` expects.
+
+  The title is the module's own last segment, which is what all twenty-two
+  hand-written envelopes used.
+  """
+  def envelope(module, data_schema, description) do
+    envelope = %{
+      title: module |> Module.split() |> List.last(),
+      type: :object,
+      properties: %{data: data_schema},
+      required: [:data]
+    }
+
+    if description, do: Map.put(envelope, :description, description), else: envelope
+  end
+end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -5,6 +5,8 @@ defmodule FountainWeb.Schemas do
   `Schemas.Agent`).
   """
 
+  import FountainWeb.SchemaWrappers, only: [list_response: 2, item_response: 2]
+
   alias OpenApiSpex.Schema
 
   defmodule Sandbox do
@@ -98,43 +100,11 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule ConversationTreeResponse do
-    @moduledoc false
-    require OpenApiSpex
+  list_response(ConversationTreeResponse, of: ConversationTreeNode)
 
-    OpenApiSpex.schema(%{
-      title: "ConversationTreeResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: ConversationTreeNode}},
-      required: [:data]
-    })
-  end
+  item_response(ConversationResponse, of: Conversation)
 
-  defmodule ConversationResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "ConversationResponse",
-      type: :object,
-      properties: %{data: Conversation},
-      required: [:data]
-    })
-  end
-
-  defmodule ConversationListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "ConversationListResponse",
-      type: :object,
-      properties: %{
-        data: %Schema{type: :array, items: Conversation}
-      },
-      required: [:data]
-    })
-  end
+  list_response(ConversationListResponse, of: Conversation)
 
   defmodule ImageInput do
     @moduledoc false
@@ -253,17 +223,7 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule TurnListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "TurnListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: Turn}},
-      required: [:data]
-    })
-  end
+  list_response(TurnListResponse, of: Turn)
 
   defmodule Agent do
     @moduledoc false
@@ -350,29 +310,9 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule AgentResponse do
-    @moduledoc false
-    require OpenApiSpex
+  item_response(AgentResponse, of: Agent)
 
-    OpenApiSpex.schema(%{
-      title: "AgentResponse",
-      type: :object,
-      properties: %{data: Agent},
-      required: [:data]
-    })
-  end
-
-  defmodule AgentListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "AgentListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: Agent}},
-      required: [:data]
-    })
-  end
+  list_response(AgentListResponse, of: Agent)
 
   defmodule AgentRequest do
     @moduledoc false
@@ -568,29 +508,9 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule EnvironmentResponse do
-    @moduledoc false
-    require OpenApiSpex
+  item_response(EnvironmentResponse, of: Environment)
 
-    OpenApiSpex.schema(%{
-      title: "EnvironmentResponse",
-      type: :object,
-      properties: %{data: Environment},
-      required: [:data]
-    })
-  end
-
-  defmodule EnvironmentListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "EnvironmentListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: Environment}},
-      required: [:data]
-    })
-  end
+  list_response(EnvironmentListResponse, of: Environment)
 
   defmodule EnvironmentRequest do
     @moduledoc false
@@ -688,29 +608,9 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule SecretResponse do
-    @moduledoc false
-    require OpenApiSpex
+  item_response(SecretResponse, of: Secret)
 
-    OpenApiSpex.schema(%{
-      title: "SecretResponse",
-      type: :object,
-      properties: %{data: Secret},
-      required: [:data]
-    })
-  end
-
-  defmodule SecretListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "SecretListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: Secret}},
-      required: [:data]
-    })
-  end
+  list_response(SecretListResponse, of: Secret)
 
   defmodule SecretRequest do
     @moduledoc false
@@ -750,29 +650,9 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule VaultResponse do
-    @moduledoc false
-    require OpenApiSpex
+  item_response(VaultResponse, of: Vault)
 
-    OpenApiSpex.schema(%{
-      title: "VaultResponse",
-      type: :object,
-      properties: %{data: Vault},
-      required: [:data]
-    })
-  end
-
-  defmodule VaultListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "VaultListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: Vault}},
-      required: [:data]
-    })
-  end
+  list_response(VaultListResponse, of: Vault)
 
   defmodule VaultRequest do
     @moduledoc false
@@ -828,29 +708,9 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule VaultSecretResponse do
-    @moduledoc false
-    require OpenApiSpex
+  item_response(VaultSecretResponse, of: VaultSecret)
 
-    OpenApiSpex.schema(%{
-      title: "VaultSecretResponse",
-      type: :object,
-      properties: %{data: VaultSecret},
-      required: [:data]
-    })
-  end
-
-  defmodule VaultSecretListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "VaultSecretListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: VaultSecret}},
-      required: [:data]
-    })
-  end
+  list_response(VaultSecretListResponse, of: VaultSecret)
 
   defmodule VaultSecretRequest do
     @moduledoc false
@@ -959,17 +819,7 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule AdminUserResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "AdminUserResponse",
-      type: :object,
-      properties: %{data: AdminUser},
-      required: [:data]
-    })
-  end
+  item_response(AdminUserResponse, of: AdminUser)
 
   defmodule AdminUserListResponse do
     @moduledoc false
@@ -1099,17 +949,7 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule AdminSandboxListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "AdminSandboxListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: AdminSandbox}},
-      required: [:data]
-    })
-  end
+  list_response(AdminSandboxListResponse, of: AdminSandbox)
 
   defmodule AdminReapResponse do
     @moduledoc false
@@ -1132,20 +972,12 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule AdminAuditListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "AdminAuditListResponse",
-      description: "Cross-tenant audit events; each carries the tenant it belongs to.",
-      type: :object,
-      # Fully qualified: AuditEvent is defined further down this file, and the
-      # implicit alias a nested defmodule creates only exists after it.
-      properties: %{data: %Schema{type: :array, items: FountainWeb.Schemas.AuditEvent}},
-      required: [:data]
-    })
-  end
+  # Fully qualified: AuditEvent is defined further down this file, and the
+  # implicit alias a nested defmodule creates only exists after it.
+  list_response(AdminAuditListResponse,
+    of: FountainWeb.Schemas.AuditEvent,
+    description: "Cross-tenant audit events; each carries the tenant it belongs to."
+  )
 
   defmodule AdminEventListResponse do
     @moduledoc false
@@ -1269,29 +1101,9 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule ExportResponse do
-    @moduledoc false
-    require OpenApiSpex
+  item_response(ExportResponse, of: Export)
 
-    OpenApiSpex.schema(%{
-      title: "ExportResponse",
-      type: :object,
-      properties: %{data: Export},
-      required: [:data]
-    })
-  end
-
-  defmodule ExportListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "ExportListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: Export}},
-      required: [:data]
-    })
-  end
+  list_response(ExportListResponse, of: Export)
 
   defmodule AccountDeleteRequest do
     @moduledoc false
@@ -1450,29 +1262,9 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule InferenceCredentialResponse do
-    @moduledoc false
-    require OpenApiSpex
+  item_response(InferenceCredentialResponse, of: InferenceCredentialStatus)
 
-    OpenApiSpex.schema(%{
-      title: "InferenceCredentialResponse",
-      type: :object,
-      properties: %{data: InferenceCredentialStatus},
-      required: [:data]
-    })
-  end
-
-  defmodule InferenceCredentialListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "InferenceCredentialListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: InferenceCredentialStatus}},
-      required: [:data]
-    })
-  end
+  list_response(InferenceCredentialListResponse, of: InferenceCredentialStatus)
 
   defmodule InferenceCredentialRequest do
     @moduledoc false
@@ -1666,7 +1458,8 @@ defmodule FountainWeb.Schemas do
       properties: %{
         error: %Schema{
           type: :string,
-          description: "Reason code, e.g. `expired`, `invalid_token`, `invalid_current_password`.",
+          description:
+            "Reason code, e.g. `expired`, `invalid_token`, `invalid_current_password`.",
           example: "invalid_token"
         },
         message: %Schema{type: :string, description: "Human-readable detail."}
@@ -1778,19 +1571,9 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule ApiKeyListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "ApiKeyListResponse",
-      type: :object,
-      # ApiKey is referenced by the implicit alias the nested defmodule above
-      # created; it only exists after that definition, hence the ordering.
-      properties: %{data: %Schema{type: :array, items: ApiKey}},
-      required: [:data]
-    })
-  end
+  # ApiKey is referenced by the implicit alias the nested defmodule above
+  # created; it only exists after that definition, hence the ordering.
+  list_response(ApiKeyListResponse, of: ApiKey)
 
   defmodule ApiKeyRequest do
     @moduledoc false

--- a/apps/fountain/test/fountain_web/schema_wrappers_test.exs
+++ b/apps/fountain/test/fountain_web/schema_wrappers_test.exs
@@ -1,0 +1,151 @@
+defmodule FountainWeb.SchemaWrappersTest do
+  @moduledoc """
+  The `%{data: ...}` envelope schemas, and the shape they must keep.
+
+  Twenty-two modules said nothing but "one X" or "a list of X" in nine lines
+  each. `list_response/2` and `item_response/2` replace them. These check the
+  generated modules are indistinguishable from what they replaced — same
+  title, same properties, same generated struct — and that a hand-written
+  envelope does not creep back in beside them.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias FountainWeb.Schemas
+  alias OpenApiSpex.Schema
+
+  @schemas_source "lib/fountain_web/schemas.ex"
+
+  describe "list_response/2" do
+    test "wraps the item in an array under data" do
+      schema = Schemas.ConversationListResponse.schema()
+
+      assert %Schema{
+               type: :object,
+               properties: %{data: %Schema{type: :array, items: Schemas.Conversation}},
+               required: [:data]
+             } = schema
+    end
+
+    test "titles the schema after the module" do
+      assert Schemas.TurnListResponse.schema().title == "TurnListResponse"
+    end
+
+    test "carries a description when one is given" do
+      assert Schemas.AdminAuditListResponse.schema().description =~ "Cross-tenant audit events"
+    end
+
+    test "omits description when none is given" do
+      refute Schemas.TurnListResponse.schema().description
+    end
+
+    test "accepts a fully qualified item, for forward references" do
+      assert %Schema{properties: %{data: %Schema{items: Schemas.AuditEvent}}} =
+               Schemas.AdminAuditListResponse.schema()
+    end
+  end
+
+  describe "item_response/2" do
+    test "puts the item directly under data" do
+      assert %Schema{
+               type: :object,
+               properties: %{data: Schemas.Conversation},
+               required: [:data]
+             } = Schemas.ConversationResponse.schema()
+    end
+
+    test "titles the schema after the module" do
+      assert Schemas.AgentResponse.schema().title == "AgentResponse"
+    end
+  end
+
+  # OpenApiSpex gives every schema module a struct and a Jason encoder. The
+  # hand-written envelopes had them; losing them silently would change what
+  # `x-struct` reports in the published spec.
+  test "generated modules still get a struct, like the ones they replaced" do
+    assert %Schemas.ConversationListResponse{data: nil} =
+             struct(Schemas.ConversationListResponse)
+
+    assert Schemas.ConversationListResponse.schema()."x-struct" ==
+             Schemas.ConversationListResponse
+  end
+
+  # Every module the macros are expected to define, listed rather than counted
+  # so a conversion that silently stops generating one fails here by name.
+  @generated [
+    Schemas.AdminAuditListResponse,
+    Schemas.AdminSandboxListResponse,
+    Schemas.AdminUserResponse,
+    Schemas.AgentListResponse,
+    Schemas.AgentResponse,
+    Schemas.ApiKeyListResponse,
+    Schemas.ConversationListResponse,
+    Schemas.ConversationResponse,
+    Schemas.ConversationTreeResponse,
+    Schemas.EnvironmentListResponse,
+    Schemas.EnvironmentResponse,
+    Schemas.ExportListResponse,
+    Schemas.ExportResponse,
+    Schemas.InferenceCredentialListResponse,
+    Schemas.InferenceCredentialResponse,
+    Schemas.SecretListResponse,
+    Schemas.SecretResponse,
+    Schemas.TurnListResponse,
+    Schemas.VaultListResponse,
+    Schemas.VaultResponse,
+    Schemas.VaultSecretListResponse,
+    Schemas.VaultSecretResponse
+  ]
+
+  test "all 22 generated envelopes exist and keep the envelope invariants" do
+    assert length(@generated) == 22
+
+    for mod <- @generated do
+      assert Code.ensure_loaded?(mod), "#{inspect(mod)} was not defined"
+      schema = mod.schema()
+      assert schema.title == mod |> Module.split() |> List.last()
+      assert schema.type == :object
+      assert schema.required == [:data]
+      assert Map.keys(schema.properties) == [:data]
+    end
+  end
+
+  # The point of the macros is that this shape stops being written out by
+  # hand. A new `%{data: ...}` envelope written the long way should be
+  # converted, not added alongside — otherwise the 22 grow back one at a time.
+  test "no pure envelope is hand-written in schemas.ex" do
+    source = File.read!(Path.join(__DIR__, "../../" <> @schemas_source))
+
+    # Module by module — a body pattern that can span `end` would match a
+    # `properties:` from one module against a `required:` from another.
+    hand_written =
+      ~r/  defmodule (\w+) do\n((?:(?!\n  end\n).)*)\n  end\n/s
+      |> Regex.scan(source)
+      |> Enum.filter(fn [_, _name, body] -> pure_envelope?(body) end)
+      |> Enum.map(fn [_, name, _body] -> name end)
+
+    assert hand_written == [],
+           """
+           These are pure `%{data: ...}` envelopes written by hand:
+
+             #{Enum.join(hand_written, "\n  ")}
+
+           Use `list_response(Name, of: Item)` or `item_response(Name, of: Item)`
+           from FountainWeb.SchemaWrappers instead. If the envelope carries a
+           `meta:` block it is not pure — those stay hand-written, see the
+           SchemaWrappers moduledoc on pagination.
+           """
+  end
+
+  # Exactly the two shapes the macros produce: `data` holding a schema module,
+  # or an array of one. An envelope whose `data` is an inline object
+  # (ApplyResponse, StripeUrlResponse, the admin outcome responses) is not
+  # pure — it carries a shape of its own — and neither is one with a `meta`
+  # block, which is what excludes the three paginated responses.
+  @item_envelope ~r/properties: %\{\s*data: [A-Z][\w.]*\s*\},?\n\s*required: \[:data\]/
+  @list_envelope ~r/properties: %\{\s*data: %Schema\{type: :array, items: [A-Z][\w.]*\}\s*\},?\n\s*required: \[:data\]/
+
+  defp pure_envelope?(body) do
+    Regex.match?(@item_envelope, body) or Regex.match?(@list_envelope, body)
+  end
+end


### PR DESCRIPTION
Independent of #600 — based on `main`, touches different files, mergeable in either order.

Twenty-two modules in `FountainWeb.Schemas` said nothing but "this response is one X" or "this response is a list of X", in nine lines each. They weren't even consistent: `ConversationListResponse` spelled across three lines what `TurnListResponse` said in one. Between all twenty-two there was a single description.

```elixir
list_response(ConversationListResponse, of: Conversation)
item_response(ConversationResponse, of: Conversation)
```

**Net −129 lines** (`schemas.ex` 1,979 → 1,762; `schema_wrappers.ex` +88).

## The published spec is byte-identical

129,065 bytes, 95 schemas, zero diff against a snapshot taken before the change. Checked through a script that fails loudly if compilation or spec generation fails, so a stale artefact can't pass as an unchanged spec.

Generated modules keep the struct and Jason encoder OpenApiSpex derives, so `x-struct` is unchanged too — that's asserted in the tests rather than assumed.

## Scope: pure envelopes only

Three categories are deliberately left hand-written:

- **The three paginated responses** (`AdminUserListResponse`, `LogEventListResponse`, `AuditEventListResponse`). They carry a `meta` block, and the API has **two pagination idioms** — cursor (`limit`/`has_more`/`next_cursor`) on log and audit events, offset (`page`/`per_page`/`total`) on admin users. Folding these in would harden a choice between them that nobody has made. Worth deciding separately; a macro shouldn't decide it by accident.
- **Envelopes whose `data` is an inline object** rather than a schema module — `ApplyResponse`, `StripeUrlResponse`, `OnboardingResponse`, the two admin outcome responses. They carry a shape of their own.
- **`AdminEventListResponse`**, whose list items are an anonymous inline schema. Noted below.

## Definition order

These expand to real nested `defmodule`s, so the item module must be defined above the call — the implicit alias a nested `defmodule` creates only exists after it. That constraint predates this change and is unchanged by it. The two comments explaining it moved to the call sites rather than being dropped, and `AdminAuditListResponse` still passes a fully qualified name because `AuditEvent` is defined further down the file.

## Tests

`schema_wrappers_test.exs` — 10 tests covering both macro shapes, title derivation, description passthrough, forward references, struct generation, and all 22 generated modules **listed by name** rather than counted, so a conversion that silently stops generating one fails by name.

Plus a source-level guard: **a pure envelope written by hand again fails the build.** Otherwise the twenty-two grow back one at a time. Verified by re-adding `TurnListResponse` the long way — the guard names it.

Gate: `format --check-formatted`, `compile --warnings-as-errors`, `credo --strict` (no issues), `dialyzer` (0 errors). Full suite **2,386 tests, 0 failures**.

## Two things found along the way, not fixed here

**`AdminEventListResponse` has an anonymous inline item schema** — the only list in the file whose items aren't a named schema module. `Fountain.Audit.AdminEvent` exists as an Ecto schema (`admin_audit_events`: `actor_user_id`, `target_user_id`, `event_type`, `metadata`, `inserted_at`) but has no OpenAPI counterpart, so its shape can't be referenced or checked like every other resource. Worth extracting separately.

**`apps/*/lib/**` is outside the root formatter's `inputs`.** The root `.formatter.exs` covers `{config,lib,test}/**` and `ee/**`, which does not match `apps/fountain/lib/...`. So `mix format --check-formatted` in CI does not check the main application source, and `locals_without_parens` has no effect there — which is why these read as `list_response(Name, of: Item)` rather than the paren-less form. Fixing it would reformat a lot of files and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
