### PR TITLE
audit: record the trail's rules as an ADR, and converge the actor vocabulary (#604)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,16 @@ Three rules that are easy to get wrong:
 context mutation and the guardrail fails until it audits, or until you add it
 to the documented exclusion list with a reason.
 
+The actor vocabulary is closed: `self` (the context default), `ui`, `api`,
+`sprite`, `admin`, `admin:<operator_id>` (account deletion only) and
+`system:<worker>`. A bare `"system"` — what `attribution/2` derives when a
+request has no principal — is a defect, not a value: the unauthenticated
+routes (login, registration, `POST /api/auth/token`, email verification) pass
+an explicit actor. **decisions/0013-audit-trail.md** owns all of this, plus
+the deliberate exclusions, the two-rows-per-API-mutation choice and the
+deletion semantics; read it before adding an actor string or moving a
+recording out of a context.
+
 `Fountain.Audit.record!/1` is deliberately test-only — see its docstring. Never
 wrap `record/1` in a way that makes it blocking for the user.
 

--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -24,6 +24,10 @@ defmodule Fountain.Audit do
   `FountainWeb.Audited.attribution/2` on a web surface, or a
   `"system:<worker>"` string from a background one.
 
+  ADR 0013 owns this rule and the closed actor vocabulary (`self`, `ui`,
+  `api`, `sprite`, `admin`, `admin:<id>`, `system:<worker>`); this moduledoc
+  keeps the mechanics.
+
   ## Deliberately not audited
 
   High-volume machine state is not audit material, and recording it would bury

--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -84,7 +84,7 @@ defmodule Fountain.Release do
         {:error, :not_found}
 
       user ->
-        case Fountain.Accounts.verify_email(user) do
+        case Fountain.Accounts.verify_email(user, actor: "system:release_task") do
           {:ok, verified} ->
             IO.puts("Verified #{verified.email}. You can now sign in.")
             {:ok, verified}

--- a/apps/fountain/lib/fountain_web/audited.ex
+++ b/apps/fountain/lib/fountain_web/audited.ex
@@ -20,6 +20,13 @@ defmodule FountainWeb.Audited do
     * `"ui"` — a browser session
     * `"system"` — no identifiable actor
 
+  The vocabulary is closed and ADR 0013 owns it; `"self"`, `"admin"` and
+  `"system:<worker>"` are the members contexts and background callers supply.
+  Derived `"system"` is **not** a member — it means the request had no
+  principal, which on the unauthenticated pipelines (login, registration,
+  `POST /api/auth/token`, email verification) is always a human whose actor the
+  call site knows. Pass the override there; a `"system"` row is a bug.
+
   Recording is best-effort throughout: `Fountain.Audit.record/1` rescues, so a
   logging failure can never break the operation being logged.
   """

--- a/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
@@ -49,7 +49,10 @@ defmodule FountainWeb.EmailVerificationController do
             |> redirect(to: destination(user))
 
           user ->
-            case Accounts.verify_email(user, FountainWeb.Audited.attribution(conn)) do
+            # Explicit actor: this route runs before a session exists, so
+            # derivation would report "system" for a person clicking a link in
+            # their mail client (ADR 0013 — bare "system" is a defect signal).
+            case Accounts.verify_email(user, FountainWeb.Audited.attribution(conn, actor: "ui")) do
               {:ok, verified_user} ->
                 # Durable job rather than a linked Task: this used to be a bare
                 # Task.async with no await, so it could be killed when the
@@ -133,7 +136,9 @@ defmodule FountainWeb.EmailVerificationController do
   end
 
   defp verify_user(conn, user) do
-    case Accounts.verify_email(user, FountainWeb.Audited.attribution(conn)) do
+    # `:api_public` — nothing has authenticated yet, so the actor is stated
+    # rather than derived. Same caveat as the browser route above.
+    case Accounts.verify_email(user, FountainWeb.Audited.attribution(conn, actor: "api")) do
       {:ok, verified} ->
         # Same follow-on work the browser route does — the account must not
         # end up in a different state depending on which surface finished it.

--- a/apps/fountain/lib/fountain_web/plugs/audit.ex
+++ b/apps/fountain/lib/fountain_web/plugs/audit.ex
@@ -37,6 +37,9 @@ defmodule FountainWeb.Plugs.Audit do
   alternative, and it was rejected: that list would be a second place to
   remember, one forgotten entry away from a silently unaudited route — the
   exact failure mode #540 existed to remove.
+
+  Recorded as a decision in ADR 0013 §4 — two rows per API mutation is
+  intended, and deduplicating them in the UI would lose the refused requests.
   """
 
   import Plug.Conn

--- a/apps/fountain/test/fountain/audit_actor_vocabulary_test.exs
+++ b/apps/fountain/test/fountain/audit_actor_vocabulary_test.exs
@@ -1,0 +1,80 @@
+defmodule Fountain.AuditActorVocabularyTest do
+  @moduledoc """
+  The actor vocabulary is closed (ADR 0013).
+
+  `actor` started life hardcoded to `"api"`, and the #540 campaign replaced
+  that with a set of strings written at ~30 call sites across core and `ee/`.
+  Nothing held the set together: `ee/` billing composed `system:admin` for an
+  action a person took, one mix task spelled its worker `lifecycle-verify`
+  while the rest use snake_case, and the unauthenticated routes recorded a
+  bare `"system"` for people clicking links in their mail client.
+
+  A vocabulary that only exists as a habit drifts. This test is the shape
+  check; the ADR is the decision.
+  """
+
+  use ExUnit.Case, async: true
+
+  # The whole list. Adding to it is an ADR amendment, not a call-site choice.
+  @plain ~w(self ui api sprite admin)
+
+  # `admin:<operator_id>` (account deletion) and `system:<worker>`, either
+  # literal or interpolated at the call site.
+  @qualified ~r/^(admin|system):(\#\{[^}]+\}|[a-z][a-z0-9_]*)$/
+
+  @adr Path.expand("../../../../decisions/0013-audit-trail.md", __DIR__)
+
+  defp lib_files do
+    ["../../lib/**/*.ex", "../../../../ee/lib/**/*.ex"]
+    |> Enum.flat_map(&(__DIR__ |> Path.expand() |> Path.join(&1) |> Path.wildcard()))
+  end
+
+  defp actor_literals do
+    for path <- lib_files(),
+        [_, actor] <- Regex.scan(~r/actor: "([^"]+)"/, File.read!(path)),
+        do: {Path.relative_to_cwd(path), actor}
+  end
+
+  test "every actor written in lib/ is in the vocabulary" do
+    literals = actor_literals()
+
+    # Guard the guard: a regex that stopped matching would make every
+    # assertion below vacuous.
+    assert length(literals) > 20,
+           "found only #{length(literals)} actor literals — the scan is probably broken"
+
+    for {path, actor} <- literals do
+      assert actor in @plain or Regex.match?(@qualified, actor), """
+      #{path} records actor #{inspect(actor)}, which is not in the vocabulary.
+
+      The members are #{Enum.join(@plain, ", ")}, admin:<operator_id> and
+      system:<worker> (snake_case, named after the module doing the work).
+      Adding one is an amendment to decisions/0013-audit-trail.md.
+      """
+    end
+  end
+
+  test "no call site records a bare \"system\"" do
+    # `attribution/2` derives "system" when a request has no principal, which
+    # only happens on the unauthenticated pipelines — login, registration,
+    # POST /api/auth/token, email verification. Every one of those is a person,
+    # and the call site knows which surface they came through, so it says so.
+    # A "system" row means somebody forgot the override.
+    for {path, actor} <- actor_literals() do
+      refute actor == "system",
+             "#{path} records a bare \"system\" actor — pass the surface explicitly (ADR 0013)"
+    end
+  end
+
+  test "the ADR names every member of the vocabulary" do
+    # The code and the decision drift apart quietly otherwise: adding a member
+    # above without arguing for it in the ADR is exactly the move this is
+    # meant to make hard.
+    adr = File.read!(@adr)
+
+    for member <- @plain ++ ["admin:<operator_id>", "system:<worker>"] do
+      assert String.contains?(adr, member),
+             "decisions/0013-audit-trail.md does not mention the #{inspect(member)} actor"
+    end
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -9,7 +9,8 @@ defmodule Fountain.AuditGuardrailTest do
 
   That property is invisible to the compiler. Without a test, the next context
   function to be added joins the gap list silently — which is exactly how the
-  original gap grew. This file is the guard.
+  original gap grew. This file is the guard; ADR 0013 is the decision it
+  guards.
 
   ## Adding a mutation
 
@@ -122,7 +123,11 @@ defmodule Fountain.AuditGuardrailTest do
           {Conversations, :start_conversation, 2},
           {Conversations, :delete_conversation, 2}
         ] do
-      assert function_exported?(mod, fun, arity),
+      # `Code.ensure_loaded?/1` first: `function_exported?/3` answers about
+      # *loaded* modules, so on a seed where this test ran before anything had
+      # referenced the context it reported a perfectly present function as
+      # missing.
+      assert Code.ensure_loaded?(mod) and function_exported?(mod, fun, arity),
              "#{inspect(mod)}.#{fun}/#{arity} is missing — an audited context " <>
                "function must accept an opts list carrying :actor and :request_ip"
     end

--- a/apps/fountain/test/fountain_web/controllers/auth_completion_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_completion_controller_test.exs
@@ -63,8 +63,13 @@ defmodule FountainWeb.AuthCompletionControllerTest do
       |> json_post("/api/auth/verify", %{"token" => verification_token(user)})
       |> json_response(200)
 
-      actions = Fountain.Audit.list_recent_for_user(user.id, 50) |> Enum.map(& &1.action)
-      assert "auth.email.verified" in actions
+      events = Fountain.Audit.list_recent_for_user(user.id, 50)
+      assert event = Enum.find(events, &(&1.action == "auth.email.verified"))
+
+      # This route is `:api_public`, so nothing has authenticated and derived
+      # attribution would say "system" — of a CLI finishing a signup. The
+      # actor is stated instead (ADR 0013).
+      assert event.actor == "api"
     end
 
     test "is idempotent — a retried request is not an error", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/controllers/email_verification_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/email_verification_controller_test.exs
@@ -26,6 +26,24 @@ defmodule FountainWeb.EmailVerificationControllerTest do
       assert_enqueued(worker: WelcomeEmail, args: %{user_id: user.id})
     end
 
+    test "attributes the verification to the browser, not to the system", %{conn: conn} do
+      # The link is clicked before a session exists, so derivation would report
+      # "system" for a person reading their mail. Bare "system" is a defect
+      # signal, not an actor (ADR 0013).
+      user = insert_user()
+
+      token = Phoenix.Token.sign(FountainWeb.Endpoint, "email_verification", user.id)
+      get(conn, ~p"/users/confirm/#{token}")
+
+      event =
+        user.id
+        |> Fountain.Audit.list_recent_for_user(50)
+        |> Enum.find(&(&1.action == "auth.email.verified"))
+
+      assert event, "verifying through the browser route must be audited"
+      assert event.actor == "ui"
+    end
+
     test "does not enqueue a welcome email for an already-verified user (#449)", %{conn: conn} do
       user = insert_verified_user()
 

--- a/decisions/0013-audit-trail.md
+++ b/decisions/0013-audit-trail.md
@@ -1,0 +1,209 @@
+# 0013 — Where auditing happens, and who the actor is
+
+**Status:** Accepted (documents behavior built by the #540 campaign and the
+convergence in the PR that adds this ADR; nothing described here is unbuilt)
+
+## Context
+
+Before #540, auditing depended on which door a mutation came through. A plug
+on the `:api` pipeline recorded every API write; the browser surface recorded
+whatever its LiveView remembered to; seven contexts recorded nothing at all.
+Creating a **secret** through the UI left no trace, while the same write
+through the API left one — the wrong way round for a product whose job is
+holding tenant secrets (#543).
+
+The campaign fixed that, and in doing so settled a rule, an actor vocabulary
+and a set of exclusions that now bind roughly thirty context functions and a
+guardrail test. Those live in `CLAUDE.md`, the `Fountain.Audit` moduledoc and
+`audit_guardrail_test.exs`. All accurate, all enforced — and none of it
+arguable-with. A future change that wants to audit at the caller, or to invent
+a new actor string, has nothing to push against. Per this repo's own rule, an
+ADR is how a decision constrains rather than merely describes.
+
+## Decision
+
+### 1. Mutations audit inside the context function, not at the caller
+
+A function that changes tenant-owned state records its own event. The UI, the
+API, background workers, the onboarding wizard, manifest apply and any future
+surface are covered by construction rather than by each caller remembering.
+
+Callers supply only what a context cannot know about its caller — `:actor` and
+`:request_ip`, from `FountainWeb.Audited.attribution/2` on a web surface or a
+`"system:<worker>"` string from a background one.
+
+```elixir
+def create_agent(attrs, opts \\ []) do
+  %Agent{} |> Agent.changeset(attrs) |> Repo.insert() |> audited("agent.created", opts)
+end
+
+Agents.create_agent(attrs, Audited.attribution(conn))   # or (socket)
+Agents.create_agent(attrs, actor: "system:my_worker")   # background caller
+```
+
+Three constraints fell out of building it, each of which cost real debugging:
+
+- **Never record inside a transaction.** `Audit.record/1` is best-effort *by
+  rescuing*, and a rescue does not undo an aborted transaction: a failed audit
+  insert inside one poisons the enclosing transaction, so a lost audit row
+  would take the mutation with it. Record outside. This bit
+  `Agents.upload_avatar/4`, `Agents.delete_avatar/2` and
+  `Accounts.register_user/2`.
+- **Never record values.** Update events name the fields that moved
+  (`Audit.changed_fields/1`); secret, credential and prompt events record
+  keys, sizes and providers. The trail is not a second copy of tenant data —
+  if it were, it would be the most sensitive table in the database and the one
+  with the loosest read path.
+- **Only record what happened.** A rejected changeset, a no-op sync, a
+  re-assertion of a status the account already had: none of these record. A
+  trail that logs attempts as changes is worse than no trail, because it
+  cannot be read literally.
+
+`apps/fountain/test/fountain/audit_guardrail_test.exs` enforces the rule: add a
+context mutation and the guardrail fails until it audits, or until the function
+is added to the documented exclusion list with a reason.
+
+### 2. The actor vocabulary is closed
+
+| Actor | Meaning |
+|---|---|
+| `self` | the account acted on its own behalf; the context default when no caller says otherwise |
+| `ui` | a browser session |
+| `api` | a bearer token |
+| `sprite` | a per-conversation callback token — an agent acting *as* the tenant |
+| `admin` | an operator acting on another account |
+| `admin:<operator_id>` | the same, where the row must name the operator itself (see below) |
+| `system:<worker>` | an unattended path, named after the worker |
+
+`sprite` is separated from `api` deliberately: "the agent did this" and "the
+account owner did this" are materially different claims, and the scopes added
+for the sandbox privilege-escalation fix make them distinguishable.
+
+`system:<worker>` names are snake_case and match the module doing the work:
+`conversation_server`, `sandbox_reaper`, `retention_pruner`, `release_task`,
+`provisioning`, `account_export`, `unverified_pruner`, `verify_lifecycle`, and
+in `ee/` the billing sources `webhook`, `stripe`, `local`, `trial_sweeper`.
+
+Two rules keep the list from fraying:
+
+- **`admin` beats `system:` when a human operator is behind the action.**
+  `ee/` billing composes its actor from a `source` term, which produced
+  `system:admin` for operator-driven trial extensions, comps and resyncs —
+  the `system:` prefix asserting "unattended" about the one source that is a
+  person. Operator sources now record `admin`; the `source` stays in metadata,
+  so queries that group by source are unaffected. Rows written before this ADR
+  still carry `system:admin`.
+- **`admin:<operator_id>` is for account deletion only.** An admin action
+  normally writes a paired `admin_audit_events` row that names actor and
+  target, so the tenant-facing row does not need the operator's id. Deletion
+  is the exception worth the special case: it is the action whose subject
+  stops existing, and `audit_events.user_id` nilifies underneath it.
+
+**Bare `"system"` is not a member of the vocabulary — it is a defect signal.**
+`attribution/2` derives it when a request has no `:current_user` and no API
+key, which happens on the unauthenticated pipelines: login, registration,
+`POST /api/auth/token`, email verification. Every one of those is a plainly
+human action, so every such call site passes an explicit `:actor` override:
+
+```elixir
+Accounts.register_user(params, Audited.attribution(conn, actor: "ui"))
+Accounts.verify_email(user, Audited.attribution(conn, actor: "api"))
+```
+
+The fallback stays in `attribution/2` because a wrong actor is worse than an
+unknown one — but a `"system"` row in the trail means a call site forgot to
+say who it was, and should be read as a bug rather than as information.
+
+**This settles `self` vs `system`, which previously depended on whether the
+caller passed attribution at all.** They are not two spellings of "unknown".
+`self` is a *claim*: the account, acting for itself, through no surface worth
+naming — the correct default for a tenant-scoped context function, since the
+overwhelming majority of its callers are the tenant. `system` was an *absence*:
+no principal on the request. Absences are now overridden at the call site, so
+the two no longer compete for the same rows.
+
+### 3. The exclusions are decisions, not gaps
+
+High-volume machine state is not audit material, and recording it would bury
+the events that are:
+
+- `ConversationServer`'s per-turn state-machine writes — turn started, output
+  chunk, turn ended. The conversation's own log events already hold this, at
+  the right granularity.
+- `Accounts.touch_api_key/1` — a last-used stamp on every authenticated
+  request. The key's *creation* and *revocation* are audited; its use is what
+  the request log is for.
+- `Conversations.mark_read/2`, theme and display preferences — reading and
+  presentation are not state changes anyone reconstructs an incident from.
+
+Two system paths record a **summary per run** rather than per row, for the same
+reason: `Workers.RetentionPruner` (which deletes `audit_events`, so the trail
+must account for its own shrinkage) and the trial-backfill release task.
+
+Adding to this list is allowed; doing it silently is not. The exclusion goes in
+`@deliberately_silent` in the guardrail test with a reason, and in the
+`Fountain.Audit` moduledoc.
+
+### 4. Two rows per API mutation, deliberately
+
+An API write leaves both a semantic context event (`agent.updated`, naming the
+fields that moved) and a request-log row from the `:api` pipeline plug
+(`PUT /api/agents/:id` and the status code). This looks like duplication and is
+kept anyway (#552): they answer different questions. The context event says
+**what changed**; the plug says **what was attempted**, including for requests
+that were refused. A 403 on a route whose context never ran leaves no semantic
+event at all, and a run of them is the signal you actually want.
+
+Scoping the plug down to "only routes whose context does not audit yet" was
+considered and rejected: that list is a second place to remember, one forgotten
+entry away from a silently unaudited route — the exact failure mode #540
+existed to remove.
+
+### 5. Deleting an account anonymises its trail
+
+`audit_events.user_id` is `on_delete: :nilify_all`. Deleting an account does
+not delete its audit rows; it detaches them, leaving operational history that
+names nobody (ADR 0009). One row is exempt: `account.deleted` denormalises the
+email and user id into `metadata`, because the event describing a deletion is
+the one that must still stand alone afterwards.
+
+The tempting generalisation — denormalising ids into other rows so the trail
+stays correlatable — is **rejected**. It would defeat the nilify on every path
+and quietly undo ADR 0009's erasure promise. `Audit.record/1`'s
+`record_unattributed` fallback follows the same line: when the account
+disappears mid-write, the row is kept and attributed to nobody, rather than
+kept with the id put back.
+
+## Consequences
+
+- A new context mutation has one correct shape, and the guardrail fails until
+  it has it. A reviewer does not have to reason about which surfaces call it.
+- A new actor string is now an ADR amendment rather than a judgement call at a
+  call site. `self`, `ui`, `api`, `sprite`, `admin`, `admin:<id>` and
+  `system:<worker>` are the whole list.
+- Actor history is not uniform across time: operator-driven billing rows
+  written before this ADR read `system:admin`, and rows from the
+  email-verification paths read `system` where they now read `ui`/`api`.
+  Anything querying by actor must tolerate both, or filter by date.
+- The `/audit` page shows two rows for one API mutation. That is intended, and
+  the UI should not "fix" it by deduplicating.
+- `Fountain.Audit.record!/1` stays test-only: no mutation in this system is
+  one where losing the audit row is worse than failing the mutation.
+
+## Alternatives considered
+
+- **Audit at the caller (controller/LiveView), where the actor is known** —
+  what the system did before #540. Coverage then depends on which door a
+  request came through, and the gap is invisible until someone goes looking.
+  Rejected; it is the bug this campaign existed to remove.
+- **Audit in a `Repo` hook or an Ecto callback** — catches every write, and
+  can name none of them. `agent.updated` with the fields that moved is the
+  value; `UPDATE agents` is not. Rejected.
+- **Retire the `:api` plug's request-log row** — see §4. Rejected.
+- **One actor string per surface, dropping `self`** — would mean every context
+  function is unsafe to call without attribution, including from tests,
+  releases and future internal callers. `self` as the default keeps the
+  common case honest and makes the override the interesting thing. Rejected.
+- **Keeping `system:admin` in `ee/` billing** — it is the same shape reached
+  by a different route, and it makes the one human source look unattended.
+  Rejected in favour of converging on `admin`.

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -334,7 +334,7 @@ defmodule Fountain.Billing do
         action: action,
         resource_type: "subscription",
         resource_id: updated.stripe_subscription_id,
-        actor: "system:#{source}",
+        actor: actor_for(source),
         metadata:
           Map.merge(
             %{
@@ -348,6 +348,14 @@ defmodule Fountain.Billing do
       })
     end
   end
+
+  # `source` says what drove the transition; the actor says who. Every source
+  # here is unattended except one — an operator extending a trial, comping an
+  # account or forcing a resync is a person, and `system:admin` claimed the
+  # opposite. Core records those as `admin` and so does this (ADR 0013). The
+  # source survives in metadata either way.
+  defp actor_for("admin"), do: "admin"
+  defp actor_for(source), do: "system:#{source}"
 
   @doc false
   def trial_end_from_now do

--- a/ee/lib/mix/tasks/fountain.verify_lifecycle.ex
+++ b/ee/lib/mix/tasks/fountain.verify_lifecycle.ex
@@ -520,7 +520,7 @@ defmodule Mix.Tasks.Fountain.VerifyLifecycle do
       user = Repo.reload!(user)
       {:ok, user} = user |> Ecto.Changeset.change(stripe_customer_id: nil) |> Repo.update()
 
-      case Fountain.Accounts.Deletion.delete_user(user, actor: "system:lifecycle-verify") do
+      case Fountain.Accounts.Deletion.delete_user(user, actor: "system:verify_lifecycle") do
         {:ok, _} -> info("✓ cleanup: scratch user deleted")
         {:error, err} -> info("! cleanup: scratch user #{user.id} not deleted: #{inspect(err)}")
       end

--- a/ee/test/fountain/billing_audit_test.exs
+++ b/ee/test/fountain/billing_audit_test.exs
@@ -110,6 +110,11 @@ defmodule Fountain.BillingAuditTest do
       assert comped.metadata["to_status"] == "comped"
       assert comped.metadata["source"] == "admin"
 
+      # `admin`, not `system:admin`: an operator comping an account is a
+      # person, and the vocabulary reserves `system:` for unattended paths
+      # (ADR 0013). The source stays in metadata regardless.
+      assert comped.actor == "admin"
+
       {:ok, comped_user} = {:ok, Repo.reload!(user)}
       {:ok, _} = Billing.revoke_comp(comped_user)
 
@@ -146,6 +151,19 @@ defmodule Fountain.BillingAuditTest do
 
       assert find_action(webhook_user.id, "billing.subscription.synced").actor ==
                "system:webhook"
+    end
+
+    test "an operator-driven transition is not disguised as a system one" do
+      # The two routes to the same status must not both read `system:`, or the
+      # actor column stops answering "was a person behind this?".
+      user = customer_user()
+      stub(Stripe.Subscription, :list, fn _params -> {:ok, %{data: []}} end)
+
+      {:ok, _} = Billing.extend_trial(user, 7)
+
+      event = find_action(user.id, "billing.trial.extended")
+      assert event.actor == "admin"
+      assert event.metadata["source"] == "admin"
     end
   end
 end


### PR DESCRIPTION
Closes #604.

`decisions/0013-audit-trail.md` promotes what the #540 campaign settled — the rule, the actor vocabulary, the exclusions — out of `CLAUDE.md` and the `Fountain.Audit` moduledoc and into a document that constrains rather than describes. Sections: the context-level rule and its three constraints (no recording inside a transaction, no values, only what happened), the closed actor vocabulary, the deliberate exclusions, the two-rows-per-API-mutation choice (#552), and the nilify deletion semantics (#590 / ADR 0009).

## The open question, settled

The issue asked the ADR to settle `self` vs `system`. They are not two spellings of "unknown":

- **`self`** is a claim — the account acting for itself, through no surface worth naming. It stays the context default.
- **bare `"system"`** was an absence — no principal on the request. It is now a **defect signal, not a vocabulary member**.

Making that true meant fixing the call sites that produced it:

| Site | Was | Now |
|---|---|---|
| `GET /users/confirm/:token` | derived `system` (no session yet) | `ui` |
| `POST /api/auth/verify` (`:api_public`) | derived `system` | `api` |
| `ee/` billing operator sources | `system:admin` | `admin` |
| `fountain.verify_lifecycle` cleanup | `system:lifecycle-verify` | `system:verify_lifecycle` |
| `Release.verify_email/1` | `self` | `system:release_task` |

The billing change is the one with a data consequence: rows written before this keep `system:admin`, so anything querying by actor sees both spellings. `metadata["source"]` is unchanged, and the ADR states the discontinuity.

## Enforcement

`apps/fountain/test/fountain/audit_actor_vocabulary_test.exs` scans every `actor: "..."` literal in core and `ee/` `lib/`, and fails on:

- anything outside `self` / `ui` / `api` / `sprite` / `admin` / `admin:<id>` / `system:<snake_case_worker>`
- a bare `"system"`
- an ADR that has stopped naming a member (so the code and the decision cannot drift apart quietly)

Also fixes a latent seed-dependent failure in `audit_guardrail_test.exs`: `function_exported?/3` only answers about *loaded* modules, so on some orderings it reported `Conversations.start_conversation/2` as missing. Reproduced on a clean tree with `--seed 941490`.

## Verification

`mix precommit` — exit 0 (compile with warnings-as-errors, format, `credo --strict`, sobelow, dialyzer 0 errors, 2417 tests / 5 doctests / 3 properties, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)