### PR TITLE
conversations: fail the turn when the runtime exits before the prompt is written (#603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ upgrade, is in
 
 ### Fixed
 
+- **A runtime that dies at startup now fails its turn instead of orphaning
+  it.** Writing the prompt to a command whose process had already stopped —
+  what happens when the runtime exits before reading stdin, from a bad flag, a
+  missing binary or an OOM kill — exited the conversation's own server rather
+  than returning an error. The supervisor restarted it, the restart found the
+  sandbox already `ready` and so reattached, and the turn was left hanging
+  behind a `list_sessions` error that named nothing real. The turn now ends
+  `failed` and the conversation returns to idle, ready for another prompt.
+  Healthy runtimes never took this path — the claude runtime blocks on stdin —
+  but fast-exiting ones did, and against a one-shot exec it was close to a
+  coin flip (#603)
+
 - **Deleting your account no longer leaves a hole in the record of it.** The
   request that deleted the account was itself audited on the way out — after
   the account row was gone — so the write referenced a user that no longer

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -21,6 +21,7 @@ defmodule Fountain.Conversations.ConversationServer do
     Environments,
     InferenceCredentials,
     SpritesClient,
+    SpriteStdin,
     Substitution,
     Vaults
   }
@@ -1677,69 +1678,55 @@ defmodule Fountain.Conversations.ConversationServer do
 
       case Sprites.spawn(state.sprite, cmd, args, spawn_opts) do
         {:ok, command} ->
-          if use_stdin? do
-            :ok = Sprites.write(command, prompt <> prompt_suffix)
-            :ok = Sprites.close_stdin(command)
-          end
-
-          # Start a stream tracer for Claude (stream-json → OTel child spans).
-          # Other runtimes produce unstructured output; tracer stays nil.
-          stream_tracer =
-            if state.runtime_module == Fountain.Runtimes.Claude do
-              Fountain.Runtimes.Claude.StreamTracer.new(turn_span)
+          # SpriteStdin.write/2 rather than Sprites.write/2: the latter exits
+          # its caller when the runtime has already gone, and this process
+          # being mid-turn is exactly what turned that into an orphaned turn
+          # (#603). See `Fountain.SpriteStdin` for the whole chain.
+          stdin_result =
+            if use_stdin? do
+              case SpriteStdin.write(command, prompt <> prompt_suffix) do
+                :ok -> Sprites.close_stdin(command)
+                {:error, reason} -> {:error, reason}
+              end
+            else
+              :ok
             end
 
-          %{
-            state
-            | current_command: command,
-              current_command_ref: command.ref,
-              current_turn: turn,
-              runtime_session_id: runtime_session_id,
-              current_turn_span: turn_span,
-              turn_metrics: %{
-                started_mono: turn_started_mono,
-                runtime: conv.runtime,
-                first_output?: false
-              },
-              stream_tracer: stream_tracer
-          }
+          case stdin_result do
+            :ok ->
+              # Start a stream tracer for Claude (stream-json → OTel child spans).
+              # Other runtimes produce unstructured output; tracer stays nil.
+              stream_tracer =
+                if state.runtime_module == Fountain.Runtimes.Claude do
+                  Fountain.Runtimes.Claude.StreamTracer.new(turn_span)
+                end
 
-        {:error, reason} ->
-          Logger.error("spawn failed: #{inspect(reason)}")
+              %{
+                state
+                | current_command: command,
+                  current_command_ref: command.ref,
+                  current_turn: turn,
+                  runtime_session_id: runtime_session_id,
+                  current_turn_span: turn_span,
+                  turn_metrics: %{
+                    started_mono: turn_started_mono,
+                    runtime: conv.runtime,
+                    first_output?: false
+                  },
+                  stream_tracer: stream_tracer
+              }
 
-          {:ok, _} =
-            Conversations._unsafe_update_turn(turn, %{
-              status: "failed",
-              ended_at: now()
-            })
-
-          publish_stage(state.conversation_id, "turn", "failed", %{
-            turn_id: turn.id,
-            reason: inspect(reason)
-          })
-
-          # The conversation was set to "running" just before the spawn
-          # attempt; without this it stays "running" in the API and UI until
-          # some later turn completes, even though nothing is executing. The
-          # :exit and :interrupt handlers both do the same reset.
-          failed_conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-
-          if failed_conv.status == "running" do
-            {:ok, _} = Conversations.update_conversation(failed_conv, %{status: "idle"})
+            {:error, reason} ->
+              # The runtime exited before it read the prompt, so nothing is
+              # running and no output will ever arrive: a spawn-level failure
+              # in every way that matters. The turn ends `failed` naming the
+              # reason instead of the server dying and its restart orphaning
+              # the turn behind a reattach.
+              fail_turn_before_start(state, turn, reason, "prompt write failed")
           end
 
-          # Spawn never started; close the span we just opened so it
-          # doesn't leak.
-          OpenTelemetry.Tracer.set_status(
-            OpenTelemetry.status(:error, "spawn_failed: #{inspect(reason)}")
-          )
-
-          # No-arg: end_span/1 takes a timestamp, not a span. turn_span is
-          # the current span here (set above), which is what no-arg ends.
-          OpenTelemetry.Tracer.end_span()
-          OpenTelemetry.Tracer.set_current_span(previous_span)
-
-          state
+        {:error, reason} ->
+          fail_turn_before_start(state, turn, reason, "spawn failed")
       end
     after
       # The successful path keeps the span open until :exit; the error
@@ -1747,6 +1734,49 @@ defmodule Fountain.Conversations.ConversationServer do
       # caller's previous current-span here.
       OpenTelemetry.Tracer.set_current_span(previous_span)
     end
+  end
+
+  # A turn that never produced a single byte of output: either the spawn
+  # itself failed, or the runtime exited before the prompt reached its stdin
+  # (#603). Both leave nothing running, so both end the same way — the turn
+  # `failed` with the reason, a `turn`/`failed` stage event, and the
+  # conversation back to "idle".
+  #
+  # Called only from inside kick_turn's try block, which restores the caller's
+  # previous current-span in its `after`; the span this ends is the turn span
+  # kick_turn opened a few lines above the call.
+  defp fail_turn_before_start(state, turn, reason, what) do
+    Logger.error("#{what}: #{inspect(reason)}")
+
+    {:ok, _} =
+      Conversations._unsafe_update_turn(turn, %{
+        status: "failed",
+        ended_at: now()
+      })
+
+    publish_stage(state.conversation_id, "turn", "failed", %{
+      turn_id: turn.id,
+      reason: inspect(reason)
+    })
+
+    # The conversation was set to "running" just before the spawn attempt;
+    # without this it stays "running" in the API and UI until some later turn
+    # completes, even though nothing is executing. The :exit and :interrupt
+    # handlers both do the same reset.
+    failed_conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+
+    if failed_conv.status == "running" do
+      {:ok, _} = Conversations.update_conversation(failed_conv, %{status: "idle"})
+    end
+
+    # The turn never started; close the span we just opened so it doesn't leak.
+    OpenTelemetry.Tracer.set_status(OpenTelemetry.status(:error, "#{what}: #{inspect(reason)}"))
+
+    # No-arg: end_span/1 takes a timestamp, not a span. turn_span is the
+    # current span here (kick_turn made it current), which is what no-arg ends.
+    OpenTelemetry.Tracer.end_span()
+
+    state
   end
 
   # Emit the aggregate turn-duration event (#536). Called from every path

--- a/apps/fountain/lib/fountain/runtimes/codex.ex
+++ b/apps/fountain/lib/fountain/runtimes/codex.ex
@@ -148,17 +148,25 @@ defmodule Fountain.Runtimes.Codex do
                env: sprite_env
              ) do
           {:ok, command} ->
-            :ok = Sprites.write(command, key <> "\n")
-            :ok = Sprites.close_stdin(command)
+            # Same exposure as #603: `codex login` exiting before it reads the
+            # key — a missing binary, a bad flag — would otherwise exit whoever
+            # is provisioning, rather than returning an error they can report.
+            case Fountain.SpriteStdin.write(command, key <> "\n") do
+              :ok ->
+                :ok = Sprites.close_stdin(command)
 
-            receive do
-              {:exit, %{ref: ref}, 0} when ref == command.ref ->
-                :ok
+                receive do
+                  {:exit, %{ref: ref}, 0} when ref == command.ref ->
+                    :ok
 
-              {:exit, %{ref: ref}, code} when ref == command.ref ->
-                {:error, {:codex_login_exit, code}}
-            after
-              30_000 -> {:error, :codex_login_timeout}
+                  {:exit, %{ref: ref}, code} when ref == command.ref ->
+                    {:error, {:codex_login_exit, code}}
+                after
+                  30_000 -> {:error, :codex_login_timeout}
+                end
+
+              {:error, reason} ->
+                {:error, {:codex_login_write, reason}}
             end
 
           err ->

--- a/apps/fountain/lib/fountain/sprite_stdin.ex
+++ b/apps/fountain/lib/fountain/sprite_stdin.ex
@@ -1,0 +1,64 @@
+defmodule Fountain.SpriteStdin do
+  @moduledoc """
+  Writing to a sprite command's stdin without the write taking the caller down.
+
+  `Sprites.write/2` is specced `:ok | {:error, term()}`, but underneath it is a
+  bare `GenServer.call/2` into the `Sprites.Command` process — and that process
+  stops `:normal` the moment the runtime's exit frame arrives. A call landing
+  after that exits the *caller*; it does not return `{:error, _}`. The library
+  has a graceful clause for the still-alive-but-disconnected case
+  (`{:error, :not_connected}`), so recovery was clearly intended; the
+  dead-process case is the gap, and it is the one that reaches us.
+
+  That is #603. A runtime that exits before the prompt is written — a bad flag,
+  a missing binary, an immediate non-zero exit, an OOM kill at startup — took
+  the whole `ConversationServer` down. The supervisor restarted it, the
+  restarted server found its sandbox already `ready` and so took the reattach
+  branch, and the turn ended up orphaned behind a `list_sessions` error that
+  named nothing real. Against the spritzer emulator, whose exec is one-shot,
+  this lost roughly half of all turns.
+
+  `write/2` turns that exit into the `{:error, reason}` its callers already
+  know how to handle. The real fix belongs upstream in
+  [`sprites-ex`](https://github.com/ravi-hq/sprites-ex), where `write_stdin/2`
+  should honour its own `@spec`; until then every stdin write in this app goes
+  through here.
+  """
+
+  @typedoc """
+  Why the prompt never reached the runtime.
+
+  `:command_exited` means the command process was gone — the runtime exited
+  before it read stdin. Anything else is the library's own error term, or a
+  call that timed out.
+  """
+  @type error :: :command_exited | {:write_failed, term()} | term()
+
+  @doc """
+  Write `data` to `command`'s stdin.
+
+  Same contract as `Sprites.write/2`, except that it is actually total: a
+  command process that has already stopped yields `{:error, :command_exited}`
+  rather than exiting the caller.
+  """
+  @spec write(Sprites.Command.t(), iodata()) :: :ok | {:error, error()}
+  def write(command, data) do
+    Sprites.write(command, data)
+  catch
+    # GenServer.call re-wraps the callee's exit reason together with the call
+    # that provoked it. `:normal` is the command process stopping mid-call (the
+    # runtime's exit frame won the race); `:noproc` is it having stopped before
+    # the call was even sent. Both mean the same thing to a caller: there is no
+    # runtime left to read this prompt.
+    :exit, {reason, {GenServer, :call, _args}} when reason in [:normal, :noproc, :shutdown] ->
+      {:error, :command_exited}
+
+    # A timeout or any other exit is not the #603 shape, but killing the caller
+    # is no better an answer for it either.
+    :exit, {reason, {GenServer, :call, _args}} ->
+      {:error, {:write_failed, reason}}
+
+    :exit, reason ->
+      {:error, {:write_failed, reason}}
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -469,6 +469,35 @@ defmodule Fountain.Conversations.ConversationServerTest do
       GenServer.stop(pid)
     end
 
+    test "a runtime that exits before the prompt is written fails the turn (#603)", %{conv: conv} do
+      # The real Sprites.write/2 against a real command process that stops
+      # :normal on the write, which is what Sprites.Command does the moment the
+      # runtime's exit frame arrives. Nothing about this path is stubbed.
+      #
+      # The GenServer.call inside Sprites.write used to exit THIS server, and
+      # the supervisor's restart then found the sandbox already "ready", took
+      # the reattach branch, and orphaned the turn behind a list_sessions error
+      # that named nothing real. Against spritzer's one-shot exec that lost
+      # roughly half of all turns.
+      stub_happy_sprite()
+      dead_on_write = spawn(fn -> receive(do: (_ -> exit(:normal))) end)
+
+      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
+        {:ok, %Sprites.Command{ref: make_ref(), pid: dead_on_write, tty_mode: false}}
+      end)
+
+      # :alive is the regression: the prompt is delivered before this returns.
+      {pid, _ref, :alive} = start_server(conv, initial_prompt: "hello")
+      _ = :sys.get_state(pid)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "failed"
+      refute is_nil(turn.ended_at)
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      GenServer.stop(pid)
+    end
+
     test "stdout is persisted as log events", %{conv: conv} do
       {pid, ref} = start_with_turn(conv)
 

--- a/apps/fountain/test/fountain/sprite_stdin_test.exs
+++ b/apps/fountain/test/fountain/sprite_stdin_test.exs
@@ -1,0 +1,66 @@
+defmodule Fountain.SpriteStdinTest do
+  @moduledoc """
+  These drive the real `Sprites.write/2` — no stubbing of the thing under test.
+  The command process is a plain process standing in for `Sprites.Command`,
+  which is enough because the only behaviour that matters here is how it dies.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Fountain.SpriteStdin
+
+  defp command(pid), do: %Sprites.Command{ref: make_ref(), pid: pid, tty_mode: false}
+
+  test "a live command process still gets the data" do
+    test = self()
+
+    pid =
+      spawn(fn ->
+        receive do
+          {:"$gen_call", from, {:write_stdin, data}} ->
+            send(test, {:wrote, data})
+            GenServer.reply(from, :ok)
+        end
+      end)
+
+    assert SpriteStdin.write(command(pid), "hello") == :ok
+    assert_receive {:wrote, "hello"}
+  end
+
+  test "a command that stops :normal mid-write is an error, not an exit (#603)" do
+    # Sprites.Command stops :normal the instant the runtime's exit frame
+    # arrives. Before #603 the GenServer.call landing after that exited the
+    # caller — which, in kick_turn, was the ConversationServer mid-turn.
+    pid = spawn(fn -> receive(do: (_ -> exit(:normal))) end)
+
+    assert SpriteStdin.write(command(pid), "prompt") == {:error, :command_exited}
+    assert Process.alive?(self())
+  end
+
+  test "a command process that is already gone is an error, not an exit" do
+    pid = spawn(fn -> :ok end)
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _}
+
+    assert SpriteStdin.write(command(pid), "prompt") == {:error, :command_exited}
+  end
+
+  test "an abnormal exit is reported rather than propagated" do
+    pid = spawn(fn -> receive(do: (_ -> exit(:boom))) end)
+
+    assert SpriteStdin.write(command(pid), "prompt") == {:error, {:write_failed, :boom}}
+  end
+
+  test "the library's own {:error, _} passes through untouched" do
+    # The still-alive-but-disconnected clause the library already has.
+    pid =
+      spawn(fn ->
+        receive do
+          {:"$gen_call", from, {:write_stdin, _}} ->
+            GenServer.reply(from, {:error, :not_connected})
+        end
+      end)
+
+    assert SpriteStdin.write(command(pid), "prompt") == {:error, :not_connected}
+  end
+end


### PR DESCRIPTION
Closes #603.

## The bug

`Sprites.write/2` is specced `:ok | {:error, term()}` but is a bare
`GenServer.call/2` into the `Sprites.Command` process, which stops `:normal`
the moment the runtime's exit frame arrives. A call landing after that exits
the **caller** — it never returns a value at all, which is why the `:ok =`
match was never the thing making this fatal.

Mid-turn the caller is the `ConversationServer`. So a runtime that exits before
the prompt is written took the whole server down; the supervisor restarted it,
the restarted server found its sandbox already `ready` and took the reattach
branch, and the turn was orphaned behind a `list_sessions` error that named
nothing real. The reattach was the symptom, not the cause.

## The fix

`Fountain.SpriteStdin.write/2` catches the exit and returns it as a value.
That lets the failure reach the recovery that already existed twenty lines
below in the spawn-error branch — turn `failed` with the reason, a
`turn`/`failed` stage event, conversation reset from `running` to `idle`, span
closed. That branch is now a shared `fail_turn_before_start/4`, since both
pre-output failure modes want exactly the same thing. `close_stdin` is a cast
and was always harmless.

Level 1 of the two the issue suggests. Level 2 — making `write_stdin/2` honour
its own `@spec` — belongs upstream in
[`ravi-hq/sprites-ex`](https://github.com/ravi-hq/sprites-ex) and would fix it
for every caller; this makes fountain correct against the library as it is.

## Also fixed

`Fountain.Runtimes.Codex.prepare_sprite/3` writes the OpenAI key to `codex
login --with-api-key` the same way and had the identical exposure — a codex
that exits early would exit whoever is provisioning instead of returning an
error they can report. It now returns `{:error, {:codex_login_write, reason}}`,
which fits the error tuples it already produces. Those were the only two stdin
writes in the app.

## Testing

The regression test in `conversation_server_test.exs` drives the **real**
`Sprites.write/2` against a real process that stops `:normal` on the write —
the actual `Sprites.Command` failure shape, with nothing about the path under
test stubbed. Its `{pid, _ref, :alive}` match is the regression itself.

Verified by reverting `SpriteStdin.write/2` to a plain passthrough:

```
1) test ... a runtime that exits before the prompt is written fails the turn (#603)
   ** (MatchError) no match of right hand side value:   # settled == :stopped
36 tests, 1 failure
```

Plus five unit tests for `SpriteStdin` covering live / stops-`:normal` /
already-dead / abnormal-exit / the library's own `{:error, :not_connected}`
passthrough.

`mix precommit` clean: credo `found no issues`, dialyzer `Total errors: 0`,
2418 tests 0 failures.

## Not covered

The `426` from `list_sessions`
([`INTENTIUS/spritzer#18`](https://github.com/INTENTIUS/spritzer/issues/18)) is
real and still breaks the legitimate reattach-after-BEAM-restart case. It is
downstream of this crash and unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
