### PR TITLE
conversations: keep the exit code of a runtime that dies before the prompt (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Fixed
+
+- **A turn that fails before it starts now says why.** When a runtime exits
+  before it reads the prompt, it has already sent its exit code and whatever
+  it printed on the way out — but those arrived just after the turn was
+  marked failed, on the one path that never registers the command they
+  belong to, so they were dropped without a trace. `turns.exit_code` stayed
+  `NULL` and every such failure reported the same `:command_exited`: an
+  expired key, a renamed binary and an OOM kill were indistinguishable. The
+  turn now records the exit code, keeps the runtime's last lines of
+  stdout/stderr as ordinary turn output, and reports
+  `:command_exited (runtime exited 1)`. The outcome is unchanged — this is
+  the diagnosis #603 left missing (#608)
+
 ## [0.6.0] — 2026-08-06
 
 ### Upgrade notes

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1722,7 +1722,21 @@ defmodule Fountain.Conversations.ConversationServer do
               # in every way that matters. The turn ends `failed` naming the
               # reason instead of the server dying and its restart orphaning
               # the turn behind a reattach.
-              fail_turn_before_start(state, turn, reason, "prompt write failed")
+              #
+              # Take the runtime's exit code and last words with us (#608).
+              # `:command_exited` names the mechanism; the code and whatever
+              # it printed on the way out are the diagnosis, and they are
+              # already sitting in our mailbox.
+              {exit_code, output} = drain_exited_command(command.ref)
+
+              fail_turn_before_start(
+                state,
+                turn,
+                reason,
+                "prompt write failed",
+                exit_code,
+                output
+              )
           end
 
         {:error, reason} ->
@@ -1736,27 +1750,43 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
-  # A turn that never produced a single byte of output: either the spawn
-  # itself failed, or the runtime exited before the prompt reached its stdin
-  # (#603). Both leave nothing running, so both end the same way — the turn
-  # `failed` with the reason, a `turn`/`failed` stage event, and the
-  # conversation back to "idle".
+  # A turn that never got as far as running: either the spawn itself failed,
+  # or the runtime exited before the prompt reached its stdin (#603). Both
+  # leave nothing running, so both end the same way — the turn `failed` with
+  # the reason, a `turn`/`failed` stage event, and the conversation back to
+  # "idle".
+  #
+  # `exit_code` and `output` are what the runtime managed to say before it
+  # went (#608); the spawn-failure path has neither, since there was never a
+  # process to say anything.
   #
   # Called only from inside kick_turn's try block, which restores the caller's
   # previous current-span in its `after`; the span this ends is the turn span
   # kick_turn opened a few lines above the call.
-  defp fail_turn_before_start(state, turn, reason, what) do
-    Logger.error("#{what}: #{inspect(reason)}")
+  defp fail_turn_before_start(state, turn, reason, what, exit_code \\ nil, output \\ []) do
+    detail = "#{inspect(reason)}#{exit_detail(exit_code)}"
+    Logger.error("#{what}: #{detail}")
+
+    # Persist the runtime's parting words against the turn they explain.
+    # current_turn is nil on this path — it is only assigned once the prompt
+    # is away — and persist_output reads it for the turn_id, so stand it up
+    # for the duration and clear it again before returning.
+    state =
+      Enum.reduce(output, %{state | current_turn: turn}, fn {stream, data}, acc ->
+        log_output(acc, stream, data)
+      end)
 
     {:ok, _} =
       Conversations._unsafe_update_turn(turn, %{
         status: "failed",
+        exit_code: exit_code,
         ended_at: now()
       })
 
     publish_stage(state.conversation_id, "turn", "failed", %{
       turn_id: turn.id,
-      reason: inspect(reason)
+      reason: detail,
+      exit_code: exit_code
     })
 
     # The conversation was set to "running" just before the spawn attempt;
@@ -1770,13 +1800,64 @@ defmodule Fountain.Conversations.ConversationServer do
     end
 
     # The turn never started; close the span we just opened so it doesn't leak.
-    OpenTelemetry.Tracer.set_status(OpenTelemetry.status(:error, "#{what}: #{inspect(reason)}"))
+    if exit_code, do: OpenTelemetry.Tracer.set_attribute("exit_code", exit_code)
+    OpenTelemetry.Tracer.set_status(OpenTelemetry.status(:error, "#{what}: #{detail}"))
 
     # No-arg: end_span/1 takes a timestamp, not a span. turn_span is the
     # current span here (kick_turn made it current), which is what no-arg ends.
     OpenTelemetry.Tracer.end_span()
 
-    state
+    %{state | current_turn: nil}
+  end
+
+  # Appended to the reason everywhere it is reported. `:command_exited` stays
+  # in front of it: it is what downstream consumers (fountain-ops' e2e gate
+  # among them) match on, and it is still true — this only says why.
+  defp exit_detail(nil), do: ""
+  defp exit_detail(code), do: " (runtime exited #{code})"
+
+  # How long to wait for an exit that is, on this path, already queued.
+  @drain_timeout_ms 50
+
+  # Collect what a command said before it stopped: `{exit_code, output}`,
+  # with a nil code if no exit arrives.
+  #
+  # `Sprites.Command` sends the owner `{:exit, %{ref: ref}, code}` — behind
+  # any `{:stdout, …}` / `{:stderr, …}` the runtime produced first — and only
+  # *then* stops. So when a stdin write comes back `{:error, :command_exited}`
+  # it is because that already happened, and those messages are in this
+  # server's mailbox as we handle the failure.
+  #
+  # They have nowhere to land on their own: `current_command_ref` is assigned
+  # only on the success branch, so every handler guard misses and the
+  # catch-all drops them silently (#608). Receive them here instead, while we
+  # still have the ref and a turn to attribute them to. The triggers for this
+  # path — a bad flag, a missing binary, an OOM kill, an immediate non-zero
+  # exit — are exactly the ones where the code is the whole diagnosis, and
+  # for a runtime that prints `invalid api key` and exits 1, that line is the
+  # answer.
+  #
+  # The deadline is absolute rather than per-message: a `receive` timeout
+  # restarts on every match, and this runs inside a GenServer callback.
+  defp drain_exited_command(ref) do
+    drain_exited_command(ref, System.monotonic_time(:millisecond) + @drain_timeout_ms, [])
+  end
+
+  defp drain_exited_command(ref, deadline, output) do
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:exit, %{ref: ^ref}, code} ->
+        {code, Enum.reverse(output)}
+
+      {:stdout, %{ref: ^ref}, data} ->
+        drain_exited_command(ref, deadline, [{"stdout", data} | output])
+
+      {:stderr, %{ref: ^ref}, data} ->
+        drain_exited_command(ref, deadline, [{"stderr", data} | output])
+    after
+      timeout -> {nil, Enum.reverse(output)}
+    end
   end
 
   # Emit the aggregate turn-duration event (#536). Called from every path

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -386,6 +386,16 @@ defmodule Fountain.Conversations.ConversationServerTest do
       {pid, ref}
     end
 
+    # The `turn`/`failed` stage event's meta, decoded. Stage events persist
+    # their meta as JSON in `data`.
+    defp turn_failed_meta(conv_id) do
+      conv_id
+      |> Conversations._unsafe_list_log_events()
+      |> Enum.find(&(&1.kind == "stage" and &1.stage == "turn" and &1.state == "failed"))
+      |> then(& &1.data)
+      |> Jason.decode!()
+    end
+
     test "a completed command closes the turn and returns the conversation to idle", %{conv: conv} do
       {pid, ref} = start_with_turn(conv)
 
@@ -494,6 +504,59 @@ defmodule Fountain.Conversations.ConversationServerTest do
       assert turn.status == "failed"
       refute is_nil(turn.ended_at)
       assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      GenServer.stop(pid)
+    end
+
+    test "a runtime that exits before the prompt is written keeps its exit code (#608)", %{
+      conv: conv
+    } do
+      # Same path as #603 above, but about what the failure *says*. A real
+      # Sprites.Command sends the owner its {:stderr, ...} and {:exit, ...}
+      # frames and only then stops — so by the time the write comes back
+      # {:error, :command_exited}, both are already in this server's mailbox.
+      #
+      # current_command_ref is never assigned on this path, so every
+      # handle_info guard misses them and the catch-all used to drop them
+      # silently: turns.exit_code stayed NULL and the operator was told
+      # ":command_exited" for an expired key, a renamed binary and an OOM
+      # kill alike.
+      stub_happy_sprite()
+      ref = make_ref()
+
+      # Frames first, then stop :normal — the order the library guarantees,
+      # and the reason the messages beat the write's failure to the server.
+      exits_1_on_write =
+        spawn(fn ->
+          receive do
+            {:"$gen_call", {caller, _tag}, _request} ->
+              send(caller, {:stderr, %{ref: ref}, "invalid api key\n"})
+              send(caller, {:exit, %{ref: ref}, 1})
+              exit(:normal)
+          end
+        end)
+
+      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
+        {:ok, %Sprites.Command{ref: ref, pid: exits_1_on_write, tty_mode: false}}
+      end)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
+      _ = :sys.get_state(pid)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "failed"
+      assert turn.exit_code == 1
+
+      # The reason still leads with the mechanism — downstream gates match on
+      # `:command_exited` — and now carries the cause behind it.
+      assert %{"reason" => reason, "exit_code" => 1} = turn_failed_meta(conv.id)
+      assert reason =~ ":command_exited"
+      assert reason =~ "runtime exited 1"
+
+      # The runtime's last words, attributed to the turn they explain.
+      events = Conversations._unsafe_list_log_events(conv.id)
+      assert stderr = Enum.find(events, &(&1.stream == "stderr" and &1.data =~ "invalid api key"))
+      assert stderr.turn_id == turn.id
 
       GenServer.stop(pid)
     end


### PR DESCRIPTION
Closes #608.

#603 stopped this path from destroying the turn; it did not give the turn
anything to say. `fail_turn_before_start/4` reported `reason: :command_exited`
— the mechanism, not the cause — and `turns.exit_code` stayed `NULL`. The
issue's run against a live `v0.6.0` found all 17 failed turns null, against 13
of 13 for completed ones.

## What was dropped

The diagnosis was already in the mailbox. `Sprites.Command` sends the owner
`{:exit, %{ref: ref}, code}`, behind any `{:stdout, …}` / `{:stderr, …}` the
runtime produced first, and only *then* stops — and the stdin write fails
precisely because it stopped. But `current_command_ref` is assigned only on
the success branch of `stdin_result`, so on this one path every `handle_info`
guard misses and the catch-all drops all three silently, a few milliseconds
after the turn is marked failed without them.

## The fix

Selectively receive them before failing the turn:

- the exit code goes into `turns.exit_code` and onto the `turn`/`failed`
  stage event's meta;
- the runtime's last lines of stdout/stderr are persisted as ordinary turn
  output, attributed to the turn they explain — for a runtime that prints
  `invalid api key` and exits 1, that line is the answer;
- the reason becomes `:command_exited (runtime exited 1)`.

**The mechanism stays in front of the reason on purpose.** fountain-ops' e2e
gate matches on `:command_exited`, and it is still true — the suffix only says
why. Nothing downstream needs to change.

## Why the drain rather than the shared handler

The issue offers a second option: set `current_command_ref` before the write
so the existing `{:exit, …}` handler finishes the turn. That gives one code
path for "the runtime exited", but a write that fails for any *other* reason
(a timeout, a live-but-unhappy process) would leave a turn `running` behind a
ref whose exit never arrives — a wedge, in exchange for a P3 diagnostic. The
drain is bounded by an absolute 50ms deadline; absolute rather than
per-message because a `receive` timeout restarts on every match and this runs
inside a GenServer callback.

The turn outcome is unchanged: `failed`, `ended_at` set, conversation back to
`idle`, span closed (now with an `exit_code` attribute).

## Test

`a runtime that exits before the prompt is written keeps its exit code
(#608)` drives a real command process that sends its stderr and exit frames
and then stops `:normal` on the write — the order the library guarantees, and
the reason those messages beat the write's failure to the server. It asserts
the exit code on the turn row, the reason on the stage event, and the stderr
line attributed to the turn.

Verified by reverting: without the drain the test fails on
`turn.exit_code == 1` (nil); with the drain but without persisting the output
it fails on the stderr assertion.

`mix precommit` green — 2,419 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)