### PR TITLE
release: verify_email/1 crashed on a broadcast after doing the work (#609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ upgrade, is in
   `:command_exited (runtime exited 1)`. The outcome is unchanged — this is
   the diagnosis #603 left missing (#608)
 
+- **`Fountain.Release.verify_email/1` no longer reports failure for work it
+  completed.** The account was verified, the first-admin bootstrap ran, and
+  then the task crashed on a PubSub broadcast and exited non-zero having
+  printed nothing but a stack trace — so any caller checking the exit code
+  concluded it had failed and an operator re-running it saw the same crash on
+  an already-verified account. The broadcast exists so a waiting page in one
+  tab advances when the link is clicked in another, and the release VM starts
+  the Repo and nothing else on purpose; it is now skipped when there is
+  nobody to hear it. The web paths are unchanged, and `promote_admin/1` was
+  never affected (#609)
+
 ## [0.6.0] — 2026-08-06
 
 ### Upgrade notes

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -196,12 +196,29 @@ defmodule Fountain.Accounts do
 
   # After the first-admin bootstrap, so a subscriber that re-reads the user
   # sees the settled role and not a half-applied verification.
+  #
+  # Skipped when `Fountain.PubSub` is not running (#609). `verify_email/2` is
+  # shared with `Fountain.Release.verify_email/1`, whose VM starts the Repo
+  # and nothing else — deliberately, since an eval task that booted the whole
+  # app would fight the running server for the metrics port and the Horde
+  # registry (#256). There, `Registry.meta/2` raised `unknown registry`
+  # *after* the row was written and the first-admin bootstrap had run, so the
+  # task exited non-zero having already done the work.
+  #
+  # A guard rather than an opt-out flag: the point of putting verification in
+  # the context was that every route behaves the same, and "tell anyone
+  # listening" is honestly satisfied by doing nothing when nobody can be. If
+  # PubSub is down in the web VM the waiting page is the least of it.
   defp broadcast_verification(%User{} = user) do
-    Phoenix.PubSub.broadcast(
-      Fountain.PubSub,
-      verification_topic(user.id),
-      {:email_verified, user.id}
-    )
+    if Process.whereis(Fountain.PubSub) do
+      Phoenix.PubSub.broadcast(
+        Fountain.PubSub,
+        verification_topic(user.id),
+        {:email_verified, user.id}
+      )
+    end
+
+    :ok
   end
 
   # Advisory lock key for the first-admin bootstrap. Any stable bigint works;

--- a/apps/fountain/test/fountain/release_without_pubsub_test.exs
+++ b/apps/fountain/test/fountain/release_without_pubsub_test.exs
@@ -1,0 +1,88 @@
+defmodule Fountain.ReleaseWithoutPubSubTest do
+  @moduledoc """
+  The release tasks against the VM they actually run in.
+
+  `Fountain.Release` starts the Repo and nothing else (#256), so a context
+  function that reaches for `Fountain.PubSub` raises there and nowhere else —
+  which is how #609 shipped past `Fountain.ReleaseTest`, whose VM has the whole
+  application up. This module takes PubSub down for the duration so the tasks
+  run in the shape production gives them.
+  """
+
+  # async: false, and it stops a VM-wide process: ExUnit runs sync modules one
+  # at a time after every async one has finished, which is what makes that safe.
+  use Fountain.DataCase, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Fountain.Release
+
+  setup do
+    :ok = Supervisor.terminate_child(Fountain.Supervisor, Phoenix.PubSub.Supervisor)
+
+    on_exit(fn ->
+      {:ok, _} = Supervisor.restart_child(Fountain.Supervisor, Phoenix.PubSub.Supervisor)
+    end)
+
+    refute Process.whereis(Fountain.PubSub)
+    :ok
+  end
+
+  describe "verify_email/1 without PubSub (#609)" do
+    test "verifies the account and reports success" do
+      user = insert_user()
+      assert is_nil(user.email_verified_at)
+
+      # Pre-#609 this raised ArgumentError from Registry.meta/2 — after the
+      # row was written and the first-admin bootstrap had run. The account
+      # came out verified and the task exited non-zero having printed nothing
+      # but a stack trace, so every caller that checks the exit code (the
+      # fountain-ops e2e gate among them) concluded it had failed.
+      out =
+        capture_io(fn ->
+          assert {:ok, verified} = Release.verify_email(user.email)
+          assert %DateTime{} = verified.email_verified_at
+        end)
+
+      assert out =~ "You can now sign in."
+      assert %DateTime{} = Repo.reload!(user).email_verified_at
+    end
+
+    test "still reports not_found for an unknown email" do
+      capture_io(:stderr, fn ->
+        assert {:error, :not_found} =
+                 Release.verify_email("nobody-#{System.unique_integer([:positive])}@example.com")
+      end)
+    end
+  end
+
+  describe "the other release tasks without PubSub" do
+    # None of these broadcast today. They are here because #609 was a shared
+    # context function acquiring a broadcast for a web concern with nothing
+    # watching the task side — the tasks are what notices, so let them.
+    test "promote_admin/1 grants the role" do
+      user = insert_user()
+
+      capture_io(fn ->
+        assert {:ok, promoted} = Release.promote_admin(user.email)
+        assert promoted.role == "admin"
+      end)
+
+      assert Repo.reload!(user).role == "admin"
+    end
+
+    test "expire_legacy_trials/1 backfills the trial clock" do
+      user =
+        insert_user()
+        |> Ecto.Changeset.change(subscription_status: "trialing", trial_ends_at: nil)
+        |> Repo.update!()
+
+      capture_io(fn ->
+        assert {:ok, count} = Release.expire_legacy_trials(days: 14)
+        assert count >= 1
+      end)
+
+      assert %DateTime{} = Repo.reload!(user).trial_ends_at
+    end
+  end
+end


### PR DESCRIPTION
Closes #609.

`bin/fountain_server eval 'Fountain.Release.verify_email("…")'` verified the
account, ran the first-admin bootstrap, and then raised `unknown registry:
Fountain.PubSub` and exited non-zero having printed nothing but a stack trace.
The row was written; every caller that checks the exit code — the fountain-ops
e2e gate among them — concluded it had failed, and an operator re-running it
got the same crash on an already-verified account.

## The fix

`broadcast_verification/1` arrived with #533, so the waiting page in one tab
advances when the emailed link is clicked in another. That is a web concern on
a shared context function, and `Release.with_repo/1` starts the Repo and
nothing else — deliberately, since an eval task that booted the whole app would
fight the running server for the metrics port and the Horde registry (#256).
Nothing updated the task side.

The broadcast is now skipped when `Fountain.PubSub` is not running, rather than
adding an opt-out the release task passes. Putting verification in the context
is what made every route behave the same; "tell anyone listening" is honestly
satisfied by doing nothing when nobody can be, and if PubSub is down in the web
VM the waiting page is the least of it. The web paths are unchanged.

## The test that could have caught it

`Fountain.ReleaseTest` already covers `verify_email/1` and passes — its VM has
the whole application up, which is the only reason it does. That is the actual
gap: the task is tested, but never in the VM it runs in.

`Fountain.ReleaseWithoutPubSubTest` takes `Phoenix.PubSub.Supervisor` down for
the duration (`async: false`, restored in `on_exit` — safe because ExUnit runs
sync modules one at a time, after every async one has finished) and runs the
tasks in production's shape. Reverting the guard fails it with the issue's
exact error:

```
** (ArgumentError) unknown registry: Fountain.PubSub. Either the registry name
   is invalid or the registry is not running, possibly because its application
   isn't started
```

It also covers `promote_admin/1` and `expire_legacy_trials/1` in the same VM.
Neither broadcasts today — they are there because this bug was a shared
function quietly acquiring a broadcast, and the tasks are what notice.

## The recurrence question

Per the issue: `verify_email/2` is the only `Phoenix.PubSub` call in
`accounts.ex`, and none of the other broadcast sites (`exports.ex`,
`conversations.ex`, `conversations/provisioning.ex`,
`conversations/conversation_server.ex`) are reachable from `migrate`,
`rollback`, `verify_email`, `promote_admin` or `expire_legacy_trials`. The new
module is the ongoing guard: a release task that picks up a broadcast fails
there.

`mix precommit` green — 2,423 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
