### PR TITLE
changelog: roll [Unreleased] into 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ upgrade, is in
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-08-07
+
 ### Fixed
 
 - **A turn that fails before it starts now says why.** When a runtime exits
@@ -39,7 +41,8 @@ upgrade, is in
   tab advances when the link is clicked in another, and the release VM starts
   the Repo and nothing else on purpose; it is now skipped when there is
   nobody to hear it. The web paths are unchanged, and `promote_admin/1` was
-  never affected (#609)
+  never affected. Regression in v0.6.0; v0.4.1 and earlier are unaffected
+  (#609, #614)
 
 ## [0.6.0] — 2026-08-06
 
@@ -1229,6 +1232,8 @@ upgrade, is in
 - Audit log for state-changing actions (append-only, best-effort)
 - Substitution engine for `${VAR}` / `$$` interpolation in agent configs
 
+[0.6.1]: https://github.com/BinaryBourbon/fountain/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/BinaryBourbon/fountain/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/BinaryBourbon/fountain/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/BinaryBourbon/fountain/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/BinaryBourbon/fountain/compare/v0.4.1...v0.5.0


### PR DESCRIPTION
Release prep for v0.6.1. Two commits since v0.6.0, both documented — cross-checked
`git log v0.6.0..main` against the `[Unreleased]` entries, since `[Unreleased]` was
not a reliable record at v0.6.0 (3 of 37 commits undocumented).

- #608 / #611 — a turn that failed before it started dropped the runtime exit code
- #609 / #613 — `Release.verify_email/1` crashed after doing its work

Both are diagnostics regressions rather than behaviour changes, and the second is a
v0.6.0 regression reported externally as #614. No migrations and no configuration
change, so no upgrade notes — `release-bump.yml` only requires them for a minor.

Also adds the compare links for `[0.6.1]` and `[0.6.0]`: the v0.6.0 roll-up (#607)
added the section but not its link reference, so `[0.6.0]` currently renders as
literal text.

After this merges, run **Actions → Release bump → patch**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)