### PR TITLE
ci: the format gate did not cover apps/ (#612)

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,10 +1,11 @@
 [
   import_deps: [:ecto, :ecto_sql, :phoenix],
-  subdirectories: ["priv/*/migrations"],
+  # Umbrella children carry their own .formatter.exs; without this the globs
+  # below (root-relative) would never reach apps/. See #612.
+  subdirectories: ["apps/*"],
   inputs: [
     "*.{ex,exs}",
     "{config,lib,test}/**/*.{ex,exs}",
-    "ee/**/*.{ex,exs}",
-    "priv/*/seeds.exs"
+    "ee/**/*.{ex,exs}"
   ]
 ]

--- a/apps/fountain/.formatter.exs
+++ b/apps/fountain/.formatter.exs
@@ -1,0 +1,9 @@
+[
+  import_deps: [:ecto, :ecto_sql, :phoenix],
+  inputs: [
+    "*.{ex,exs}",
+    "{lib,test}/**/*.{ex,exs}",
+    "priv/repo/migrations/*.exs",
+    "priv/repo/seeds.exs"
+  ]
+]

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -363,10 +363,12 @@ defmodule Fountain.Accounts do
   are refused — they set a first password through the reset flow.
   """
   @spec change_password(User.t(), String.t(), String.t(), keyword()) ::
-          {:ok, User.t()} | {:error, :no_password | :invalid_current_password | Ecto.Changeset.t()}
+          {:ok, User.t()}
+          | {:error, :no_password | :invalid_current_password | Ecto.Changeset.t()}
   def change_password(user, current, new, opts \\ [])
 
-  def change_password(%User{password_hash: nil}, _current, _new, _opts), do: {:error, :no_password}
+  def change_password(%User{password_hash: nil}, _current, _new, _opts),
+    do: {:error, :no_password}
 
   def change_password(%User{} = user, current, new, opts)
       when is_binary(current) and is_binary(new) do
@@ -898,7 +900,10 @@ defmodule Fountain.Accounts do
 
     users =
       base
-      |> join(:left, [u], a in subquery(last_activity_query()), on: a.user_id == u.id, as: :activity)
+      |> join(:left, [u], a in subquery(last_activity_query()),
+        on: a.user_id == u.id,
+        as: :activity
+      )
       |> order_users(Keyword.get(opts, :sort), Keyword.get(opts, :dir, "desc"))
       |> offset(^((page - 1) * per_page))
       |> limit(^per_page)

--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -40,8 +40,7 @@ defmodule Fountain.Application do
           # cluster-aware replacements. Single-node behavior is
           # unchanged; on multiple nodes they sync state and let
           # processes be addressed across the cluster.
-          {Horde.Registry,
-           [name: Fountain.ConversationRegistry, keys: :unique, members: :auto]},
+          {Horde.Registry, [name: Fountain.ConversationRegistry, keys: :unique, members: :auto]},
           {Horde.DynamicSupervisor,
            [
              name: Fountain.ConversationSupervisor,

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -132,7 +132,11 @@ defmodule Fountain.Conversations do
           # A reclaimed sandbox took the tenant's conversations down with it,
           # which is worth a row each — this is the one termination they did
           # not ask for. #551 covers the reaper that calls this.
-          Enum.each(live, &ConversationServer.terminate_conversation(&1.id, actor: "system:sandbox_reaper"))
+          Enum.each(
+            live,
+            &ConversationServer.terminate_conversation(&1.id, actor: "system:sandbox_reaper")
+          )
+
           {:ok, :terminated}
         end
     end
@@ -1205,14 +1209,18 @@ defmodule Fountain.Conversations do
          :ok <- Fountain.Billing.check_active(conv.user_id),
          # Same reservation as start_conversation/1 — see the note there (#330).
          {:ok, new_sandbox} <-
-           Fountain.Quotas.with_sandbox_reservation(conv.user_id, [exclude: conv.sandbox_id], fn ->
-             create_sandbox(%{
-               environment_id: agent.environment_id,
-               sprite_name: "fountain-#{tenant_prefix(conv.user_id)}-#{short_id()}",
-               status: "pending",
-               user_id: conv.user_id
-             })
-           end),
+           Fountain.Quotas.with_sandbox_reservation(
+             conv.user_id,
+             [exclude: conv.sandbox_id],
+             fn ->
+               create_sandbox(%{
+                 environment_id: agent.environment_id,
+                 sprite_name: "fountain-#{tenant_prefix(conv.user_id)}-#{short_id()}",
+                 status: "pending",
+                 user_id: conv.user_id
+               })
+             end
+           ),
          _ <- mark_old_sandbox_terminated(conv.sandbox_id),
          {:ok, conv} <-
            update_conversation(conv, %{sandbox_id: new_sandbox.id, status: "pending"}) do

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -675,6 +675,7 @@ defmodule Fountain.Conversations.ConversationServer do
         Fountain.Environments.update_environment(env, %{"checkpoint_id" => nil},
           actor: "system:conversation_server"
         )
+
         :cold
     end
   end
@@ -1355,9 +1356,10 @@ defmodule Fountain.Conversations.ConversationServer do
       case Conversations._unsafe_get_conversation(state.conversation_id) do
         %Conversation{user_id: user_id, callback_api_key_id: row_id}
         when is_binary(user_id) and row_id == state.callback_api_key_id ->
-          _ = Accounts.revoke_api_key(user_id, state.callback_api_key_id,
-            actor: "system:conversation_server"
-          )
+          _ =
+            Accounts.revoke_api_key(user_id, state.callback_api_key_id,
+              actor: "system:conversation_server"
+            )
 
         _ ->
           :ok

--- a/apps/fountain/lib/fountain/conversations/redaction.ex
+++ b/apps/fountain/lib/fountain/conversations/redaction.ex
@@ -36,11 +36,19 @@ defmodule Fountain.Conversations.Redaction do
   @min_length 8
   @placeholder "[REDACTED]"
 
-  def start_link(opts), do: GenServer.start_link(__MODULE__, :ok, Keyword.put_new(opts, :name, __MODULE__))
+  def start_link(opts),
+    do: GenServer.start_link(__MODULE__, :ok, Keyword.put_new(opts, :name, __MODULE__))
 
   @impl true
   def init(:ok) do
-    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true, write_concurrency: true])
+    :ets.new(@table, [
+      :named_table,
+      :public,
+      :set,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
     {:ok, %{}}
   end
 

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -85,7 +85,8 @@ defmodule Fountain.Environments do
         nil
 
       env ->
-        secret_count = Repo.aggregate(from(s in Secret, where: s.environment_id == ^env.id), :count)
+        secret_count =
+          Repo.aggregate(from(s in Secret, where: s.environment_id == ^env.id), :count)
 
         agent_count =
           Repo.aggregate(

--- a/apps/fountain/lib/fountain/exports.ex
+++ b/apps/fountain/lib/fountain/exports.ex
@@ -265,9 +265,7 @@ defmodule Fountain.Exports do
       )
 
     {count, _} =
-      Repo.delete_all(
-        from e in Export, where: not is_nil(e.expires_at) and e.expires_at <= ^now
-      )
+      Repo.delete_all(from e in Export, where: not is_nil(e.expires_at) and e.expires_at <= ^now)
 
     Enum.each(expiring, fn {id, user_id} ->
       Audit.record(%{
@@ -389,7 +387,8 @@ defmodule Fountain.Exports do
         "metadata" => vault.metadata,
         # Names only — values are write-only by design.
         # Ownership: vault comes from the tenant-scoped list_vaults above.
-        "secret_keys" => vault |> Vaults._unsafe_list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
+        "secret_keys" =>
+          vault |> Vaults._unsafe_list_secrets() |> Enum.map(& &1.key) |> Enum.sort(),
         "created_at" => vault.inserted_at,
         "updated_at" => vault.updated_at
       }

--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -108,8 +108,7 @@ defmodule Fountain.Funnel do
         key: :activated,
         count: length(activated),
         conversion: ratio(length(activated), length(onboarded)),
-        median_hours:
-          median_hours(activated, & &1.onboarded_at, &Map.get(first_activity, &1.id))
+        median_hours: median_hours(activated, & &1.onboarded_at, &Map.get(first_activity, &1.id))
       },
       %{
         key: :subscribed,

--- a/apps/fountain/lib/fountain/inference_credentials.ex
+++ b/apps/fountain/lib/fountain/inference_credentials.ex
@@ -106,7 +106,8 @@ defmodule Fountain.InferenceCredentials do
   # second table — the same rule the secret-write events follow, and the
   # reason those record a key and not a value.
   defp audited({:ok, _cred} = ok, user_id, provider, ciphertext, opts) do
-    action = if is_nil(ciphertext), do: "inference_credential.delete", else: "inference_credential.write"
+    action =
+      if is_nil(ciphertext), do: "inference_credential.delete", else: "inference_credential.write"
 
     Audit.record(%{
       user_id: user_id,

--- a/apps/fountain/lib/fountain/inference_credentials/validator.ex
+++ b/apps/fountain/lib/fountain/inference_credentials/validator.ex
@@ -21,7 +21,8 @@ defmodule Fountain.InferenceCredentials.Validator do
 
   @timeout 5_000
 
-  @type provider :: :anthropic_api_key | :claude_code_oauth_token | :openai_api_key | :gemini_api_key
+  @type provider ::
+          :anthropic_api_key | :claude_code_oauth_token | :openai_api_key | :gemini_api_key
   @type result ::
           :ok
           | {:error, :invalid, %{status: integer()}}

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -79,8 +79,7 @@ defmodule Fountain.Manifest do
     outcome =
       case Environments.get_environment_by_name(name, user_id) do
         nil ->
-          {:created,
-           Environments.create_environment(Map.put(attrs, "user_id", user_id), opts)}
+          {:created, Environments.create_environment(Map.put(attrs, "user_id", user_id), opts)}
 
         env ->
           {:updated, Environments.update_environment(env, attrs, opts)}
@@ -90,6 +89,7 @@ defmodule Fountain.Manifest do
       {action, {:ok, env}} ->
         secret_results =
           upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek, secret_opts(opts)))
+
         {result("Environment", name, action, nil, secret_results, env.id), env}
 
       {_action, {:error, changeset}} ->
@@ -110,6 +110,7 @@ defmodule Fountain.Manifest do
       {action, {:ok, vault}} ->
         secret_results =
           upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek, secret_opts(opts)))
+
         result("Vault", name, action, nil, secret_results, vault.id)
 
       {_action, {:error, changeset}} ->

--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -98,7 +98,9 @@ defmodule Fountain.Quotas do
   `Sprites.create/2`, so guarding row creation guards sprite creation.
   """
   @spec check_sandbox_quota(binary(), keyword()) ::
-          :ok | {:error, {:sandbox_quota_exceeded, %{count: non_neg_integer(), limit: non_neg_integer()}}}
+          :ok
+          | {:error,
+             {:sandbox_quota_exceeded, %{count: non_neg_integer(), limit: non_neg_integer()}}}
   def check_sandbox_quota(user_id, opts \\ []) when is_binary(user_id) do
     limit = sandbox_limit(user_id)
     count = active_sandbox_count(user_id, opts)

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -141,9 +141,7 @@ defmodule Fountain.Vaults do
   # ── secrets ───────────────────────────────────────────────────────────────
 
   def _unsafe_list_secrets(%Vault{id: vault_id}) do
-    Repo.all(
-      from s in VaultSecret, where: s.vault_id == ^vault_id, order_by: [asc: s.key]
-    )
+    Repo.all(from s in VaultSecret, where: s.vault_id == ^vault_id, order_by: [asc: s.key])
   end
 
   def _unsafe_get_secret(vault_id, key) do

--- a/apps/fountain/lib/fountain_web/components/core_components.ex
+++ b/apps/fountain/lib/fountain_web/components/core_components.ex
@@ -21,6 +21,7 @@ defmodule FountainWeb.CoreComponents do
   attr :variant, :string, default: "primary", values: ~w(primary secondary danger ghost)
   attr :loading, :boolean, default: false
   attr :class, :string, default: ""
+
   attr :rest, :global,
     include: ~w(disabled form name value phx-click phx-disable-with phx-value-id data-confirm)
 
@@ -345,8 +346,7 @@ defmodule FountainWeb.CoreComponents do
   end
 
   defp flash_class(:info),
-    do:
-      "bg-[var(--color-info-bg)] border-[var(--color-info)] text-[var(--color-info-text)]"
+    do: "bg-[var(--color-info-bg)] border-[var(--color-info)] text-[var(--color-info-text)]"
 
   defp flash_class(:success),
     do:
@@ -357,8 +357,7 @@ defmodule FountainWeb.CoreComponents do
       "bg-[var(--color-warning-bg)] border-[var(--color-warning)] text-[var(--color-warning-text)]"
 
   defp flash_class(:error),
-    do:
-      "bg-[var(--color-error-bg)] border-[var(--color-error)] text-[var(--color-error-text)]"
+    do: "bg-[var(--color-error-bg)] border-[var(--color-error)] text-[var(--color-error-text)]"
 
   defp flash_icon(:info),
     do:

--- a/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/account_security_controller.ex
@@ -182,7 +182,12 @@ defmodule FountainWeb.AccountSecurityController do
         })
 
       {:error, :invalid_current_password} ->
-        credential_error(conn, :forbidden, "invalid_current_password", "Current password is incorrect.")
+        credential_error(
+          conn,
+          :forbidden,
+          "invalid_current_password",
+          "Current password is incorrect."
+        )
 
       {:error, :no_password} ->
         credential_error(
@@ -222,7 +227,9 @@ defmodule FountainWeb.AccountSecurityController do
       {"New address and current password", "application/json", Schemas.EmailChangeRequest,
        required: true},
     responses: [
-      ok: {"Confirmation link sent (if the address was available)", "application/json", Schemas.MessageResponse},
+      ok:
+        {"Confirmation link sent (if the address was available)", "application/json",
+         Schemas.MessageResponse},
       unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
       forbidden:
         {"`invalid_current_password`, or a key without full scope", "application/json",
@@ -254,7 +261,12 @@ defmodule FountainWeb.AccountSecurityController do
         })
 
       {:error, :invalid_current_password} ->
-        credential_error(conn, :forbidden, "invalid_current_password", "Current password is incorrect.")
+        credential_error(
+          conn,
+          :forbidden,
+          "invalid_current_password",
+          "Current password is incorrect."
+        )
 
       {:error, :no_password} ->
         credential_error(

--- a/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
@@ -172,7 +172,8 @@ defmodule FountainWeb.AdminController do
     ]
   )
 
-  def set_sandbox_limit(conn, %{"id" => id, "limit" => limit}) when is_integer(limit) and limit >= 0 do
+  def set_sandbox_limit(conn, %{"id" => id, "limit" => limit})
+      when is_integer(limit) and limit >= 0 do
     admin = conn.assigns.current_user
 
     with_user(conn, id, fn user ->

--- a/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_avatar_controller.ex
@@ -86,7 +86,10 @@ defmodule FountainWeb.AgentAvatarController do
       # Rendered explicitly rather than through `render/3`: this scope has no
       # `plug :accepts` (the GET below serves image bytes and would 406 on
       # `Accept: image/*`), so there is no negotiated format to render into.
-      json(conn, FountainWeb.AgentJSON.show(%{agent: Agents.get_agent_with_counts(agent.id, user.id)}))
+      json(
+        conn,
+        FountainWeb.AgentJSON.show(%{agent: Agents.get_agent_with_counts(agent.id, user.id)})
+      )
     else
       nil ->
         {:error, :not_found}

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -35,5 +35,4 @@ defmodule FountainWeb.ApplyController do
       render(conn, :create, results: results)
     end
   end
-
 end

--- a/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
@@ -57,7 +57,8 @@ defmodule FountainWeb.EnvironmentController do
     user = conn.assigns.current_user
     attrs = Map.put(params, "user_id", user.id)
 
-    with {:ok, %Environment{} = env} <- Environments.create_environment(attrs, Audited.attribution(conn)) do
+    with {:ok, %Environment{} = env} <-
+           Environments.create_environment(attrs, Audited.attribution(conn)) do
       conn
       |> put_status(:created)
       |> render(:show, environment: Environments.get_environment_with_counts(env.id, user.id))
@@ -89,7 +90,9 @@ defmodule FountainWeb.EnvironmentController do
         with {:ok, env} <- Environments.update_environment(env, attrs, Audited.attribution(conn)) do
           # Re-read for the counts: a response that advertises secret_count and
           # agent_count must not report the struct defaults after a write.
-          render(conn, :show, environment: Environments.get_environment_with_counts(env.id, user.id))
+          render(conn, :show,
+            environment: Environments.get_environment_with_counts(env.id, user.id)
+          )
         end
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -30,7 +30,10 @@ defmodule FountainWeb.FallbackController do
   def call(conn, {:error, :vault_not_allowed}) do
     conn
     |> put_status(:unprocessable_entity)
-    |> json(%{error: "vault_not_allowed", message: "vault is not in the agent's allowed_vault_ids"})
+    |> json(%{
+      error: "vault_not_allowed",
+      message: "vault is not in the agent's allowed_vault_ids"
+    })
   end
 
   # An unknown or cross-tenant parent conversation. 404 rather than 403 so the

--- a/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
@@ -98,7 +98,8 @@ defmodule FountainWeb.PasswordResetController do
         "other outstanding reset token for the account. Rate-limited to 10 " <>
         "per IP per hour.",
     security: [],
-    request_body: {"Token and new password", "application/json", Schemas.PasswordResetRequest, required: true},
+    request_body:
+      {"Token and new password", "application/json", Schemas.PasswordResetRequest, required: true},
     responses: [
       ok: {"Password updated", "application/json", Schemas.MessageResponse},
       unprocessable_entity:
@@ -173,27 +174,27 @@ defmodule FountainWeb.PasswordResetController do
     case verify_reset_token(conn, token) do
       {:ok, user} ->
         case Accounts.reset_password(user, password, FountainWeb.Audited.attribution(conn)) do
-              {:ok, _user} ->
-                # Also invalidates every existing session, so this is a
-                # security-relevant event even when the user initiated it.
-                conn
-                |> configure_session(drop: true)
-                |> put_flash(:info, "Password updated. Please sign in with your new password.")
-                |> redirect(to: ~p"/auth/login")
+          {:ok, _user} ->
+            # Also invalidates every existing session, so this is a
+            # security-relevant event even when the user initiated it.
+            conn
+            |> configure_session(drop: true)
+            |> put_flash(:info, "Password updated. Please sign in with your new password.")
+            |> redirect(to: ~p"/auth/login")
 
-              {:error, changeset} ->
-                errors =
-                  Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
+          {:error, changeset} ->
+            errors =
+              Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
 
-                password_error = errors |> Map.get(:password, []) |> List.first()
+            password_error = errors |> Map.get(:password, []) |> List.first()
 
-                conn
-                |> put_status(:unprocessable_entity)
-                |> render(:reset_form,
-                  token: token,
-                  error: password_error || "Could not update password.",
-                  layout: false
-                )
+            conn
+            |> put_status(:unprocessable_entity)
+            |> render(:reset_form,
+              token: token,
+              error: password_error || "Could not update password.",
+              layout: false
+            )
         end
 
       {:error, :expired} ->

--- a/apps/fountain/lib/fountain_web/controllers/session_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/session_html.ex
@@ -82,5 +82,4 @@ defmodule FountainWeb.SessionHTML do
     </div>
     """
   end
-
 end

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -77,7 +77,13 @@ defmodule FountainWeb.AgentsLive.Form do
     Enum.map(mcp_servers, fn {name, config} ->
       args_str = (config["args"] || []) |> Enum.join("\n")
       env_vars = (config["env"] || %{}) |> Enum.map(fn {k, v} -> %{"key" => k, "value" => v} end)
-      %{"name" => name, "command" => config["command"] || "", "args" => args_str, "env_vars" => env_vars}
+
+      %{
+        "name" => name,
+        "command" => config["command"] || "",
+        "args" => args_str,
+        "env_vars" => env_vars
+      }
     end)
   end
 
@@ -85,11 +91,19 @@ defmodule FountainWeb.AgentsLive.Form do
   def handle_event("validate", %{"agent" => params}, socket) do
     skills = extract_skills_from_params(params, socket.assigns.skills)
     mcp_servers = extract_mcp_servers_from_params(params, socket.assigns.mcp_servers)
-    {:noreply, socket |> assign(:form, params) |> assign(:skills, skills) |> assign(:mcp_servers, mcp_servers)}
+
+    {:noreply,
+     socket
+     |> assign(:form, params)
+     |> assign(:skills, skills)
+     |> assign(:mcp_servers, mcp_servers)}
   end
 
   def handle_event("add_skill", _, socket) do
-    skills = socket.assigns.skills ++ [%{"type" => "github", "source" => "", "name" => "", "content" => ""}]
+    skills =
+      socket.assigns.skills ++
+        [%{"type" => "github", "source" => "", "name" => "", "content" => ""}]
+
     {:noreply, assign(socket, :skills, skills)}
   end
 
@@ -131,7 +145,11 @@ defmodule FountainWeb.AgentsLive.Form do
     {:noreply, assign(socket, :mcp_servers, servers)}
   end
 
-  def handle_event("remove_mcp_env_var", %{"server" => server_idx_str, "index" => idx_str}, socket) do
+  def handle_event(
+        "remove_mcp_env_var",
+        %{"server" => server_idx_str, "index" => idx_str},
+        socket
+      ) do
     server_idx = String.to_integer(server_idx_str)
     idx = String.to_integer(idx_str)
 
@@ -335,48 +353,71 @@ defmodule FountainWeb.AgentsLive.Form do
     uploaded =
       consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
         data = File.read!(path)
-        Agents.upload_avatar(agent, data, entry.client_type, FountainWeb.Audited.attribution(socket))
+
+        Agents.upload_avatar(
+          agent,
+          data,
+          entry.client_type,
+          FountainWeb.Audited.attribution(socket)
+        )
+
         {:ok, :uploaded}
       end)
 
     if uploaded == [] do
       case socket.assigns.generated_avatar_data do
-        nil -> :ok
-        data -> Agents.upload_avatar(agent, data, "image/png", FountainWeb.Audited.attribution(socket))
+        nil ->
+          :ok
+
+        data ->
+          Agents.upload_avatar(agent, data, "image/png", FountainWeb.Audited.attribution(socket))
       end
     end
   end
 
   defp extract_skills_from_params(params, current_skills) do
     case params["skills"] do
-      nil -> current_skills
+      nil ->
+        current_skills
+
       skills_map when is_map(skills_map) ->
         skills_map
         |> Enum.sort_by(fn {k, _} -> String.to_integer(k) end)
         |> Enum.map(fn {_, s} -> s end)
-      _ -> current_skills
+
+      _ ->
+        current_skills
     end
   end
 
   defp extract_mcp_servers_from_params(params, current_servers) do
     case params["mcp_servers"] do
-      nil -> current_servers
+      nil ->
+        current_servers
+
       servers_map when is_map(servers_map) ->
         servers_map
         |> Enum.sort_by(fn {k, _} -> String.to_integer(k) end)
         |> Enum.map(fn {_, s} ->
           env_vars =
             case s["env_vars"] do
-              nil -> []
+              nil ->
+                []
+
               evs when is_map(evs) ->
                 evs
                 |> Enum.sort_by(fn {k, _} -> String.to_integer(k) end)
                 |> Enum.map(fn {_, r} -> r end)
-              _ -> []
+
+              _ ->
+                []
             end
+
           Map.put(s, "env_vars", env_vars)
         end)
-      _ -> current_servers
+
+      _ ->
+        current_servers
     end
   end
 

--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -73,7 +73,10 @@ defmodule FountainWeb.AgentsLive.Index do
       nil ->
         {:noreply,
          socket
-         |> assign(:agents, Agents.list_agents_with_counts(user_id, current_filters(socket.assigns)))
+         |> assign(
+           :agents,
+           Agents.list_agents_with_counts(user_id, current_filters(socket.assigns))
+         )
          |> put_flash(:error, "Agent not found — it may already be deleted")}
 
       agent ->

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -36,7 +36,10 @@ defmodule FountainWeb.ConversationsLive.Index do
         {:noreply, put_flash(socket, :error, "Not found")}
 
       _ ->
-        case Fountain.Conversations.ConversationServer.terminate_conversation(id, FountainWeb.Audited.attribution(socket)) do
+        case Fountain.Conversations.ConversationServer.terminate_conversation(
+               id,
+               FountainWeb.Audited.attribution(socket)
+             ) do
           :ok -> {:noreply, socket |> put_flash(:info, "Terminated") |> load_data()}
           _ -> {:noreply, put_flash(socket, :error, "Not running")}
         end
@@ -51,7 +54,9 @@ defmodule FountainWeb.ConversationsLive.Index do
         {:noreply, put_flash(socket, :error, "Not found")}
 
       conv ->
-        {:ok, _} = Conversations.delete_conversation(conv, FountainWeb.Audited.attribution(socket))
+        {:ok, _} =
+          Conversations.delete_conversation(conv, FountainWeb.Audited.attribution(socket))
+
         {:noreply, socket |> put_flash(:info, "Deleted") |> load_data()}
     end
   end
@@ -241,8 +246,12 @@ defmodule FountainWeb.ConversationsLive.Index do
 
   defp first_prompt(conv) do
     case conv.turns do
-      %Ecto.Association.NotLoaded{} -> nil
-      [] -> nil
+      %Ecto.Association.NotLoaded{} ->
+        nil
+
+      [] ->
+        nil
+
       [%{prompt: prompt} | _] ->
         prompt |> String.trim() |> String.replace(~r/\s+/, " ")
     end

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -19,7 +19,10 @@ defmodule FountainWeb.ConversationsLive.Show do
 
     case conv do
       nil ->
-        {:ok, socket |> put_flash(:error, "Conversation not found") |> push_navigate(to: ~p"/conversations")}
+        {:ok,
+         socket
+         |> put_flash(:error, "Conversation not found")
+         |> push_navigate(to: ~p"/conversations")}
 
       conv ->
         graph = Conversations.get_conversation_tree(id, socket.assigns.current_user.id)
@@ -41,7 +44,10 @@ defmodule FountainWeb.ConversationsLive.Show do
          |> assign(:conv, conv)
          |> assign(:events, events)
          |> assign(:turns_by_id, load_turns(id))
-         |> assign(:visible_streams, MapSet.new(initial_visible_streams(socket.assigns.current_user)))
+         |> assign(
+           :visible_streams,
+           MapSet.new(initial_visible_streams(socket.assigns.current_user))
+         )
          |> assign(:view_mode, initial_view_mode(socket.assigns.current_user))
          |> assign(:prompt, "")
          |> assign(:pending_images, [])
@@ -139,7 +145,13 @@ defmodule FountainWeb.ConversationsLive.Show do
   @impl true
   def handle_info({:graph_updated}, socket) do
     id = socket.assigns.conv.id
-    {:noreply, assign(socket, :graph, Conversations.get_conversation_tree(id, socket.assigns.current_user.id))}
+
+    {:noreply,
+     assign(
+       socket,
+       :graph,
+       Conversations.get_conversation_tree(id, socket.assigns.current_user.id)
+     )}
   end
 
   @impl true
@@ -190,9 +202,14 @@ defmodule FountainWeb.ConversationsLive.Show do
   def handle_event("send_prompt", _, socket), do: {:noreply, socket}
 
   def handle_event("terminate", _, socket) do
-    case ConversationServer.terminate_conversation(socket.assigns.conv.id, FountainWeb.Audited.attribution(socket)) do
+    case ConversationServer.terminate_conversation(
+           socket.assigns.conv.id,
+           FountainWeb.Audited.attribution(socket)
+         ) do
       :ok ->
-        conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
+        conv =
+          Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
+
         {:noreply, socket |> assign(:conv, conv) |> put_flash(:info, "Terminated")}
 
       _ ->
@@ -201,9 +218,14 @@ defmodule FountainWeb.ConversationsLive.Show do
   end
 
   def handle_event("interrupt", _, socket) do
-    case ConversationServer.interrupt(socket.assigns.conv.id, FountainWeb.Audited.attribution(socket)) do
+    case ConversationServer.interrupt(
+           socket.assigns.conv.id,
+           FountainWeb.Audited.attribution(socket)
+         ) do
       :ok ->
-        conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
+        conv =
+          Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
+
         {:noreply, socket |> assign(:conv, conv) |> put_flash(:info, "Interrupted")}
 
       {:error, :idle} ->
@@ -226,7 +248,8 @@ defmodule FountainWeb.ConversationsLive.Show do
          |> push_navigate(to: ~p"/conversations")}
 
       conv ->
-        {:ok, _} = Conversations.delete_conversation(conv, FountainWeb.Audited.attribution(socket))
+        {:ok, _} =
+          Conversations.delete_conversation(conv, FountainWeb.Audited.attribution(socket))
 
         {:noreply,
          socket
@@ -1428,10 +1451,16 @@ defmodule FountainWeb.ConversationsLive.Show do
   # ── stage row helpers ───────────────────────────────────────────────────────
 
   defp send_decoded_prompt(socket, p, decoded_images) do
-    case ConversationServer.send_prompt(socket.assigns.conv.id, p, decoded_images, FountainWeb.Audited.attribution(socket)) do
+    case ConversationServer.send_prompt(
+           socket.assigns.conv.id,
+           p,
+           decoded_images,
+           FountainWeb.Audited.attribution(socket)
+         ) do
       :ok ->
         # Refetch the conversation — wake-from-cold flips sandbox + status.
-        conv = Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
+        conv =
+          Conversations.get_conversation!(socket.assigns.conv.id, socket.assigns.current_user.id)
 
         {:noreply,
          socket

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -190,7 +190,11 @@ defmodule FountainWeb.EnvironmentsLive.Form do
     secret = Enum.find(socket.assigns.secrets, &(&1.id == id))
 
     if secret do
-      Environments.delete_secret(socket.assigns.env, secret, FountainWeb.Audited.attribution(socket))
+      Environments.delete_secret(
+        socket.assigns.env,
+        secret,
+        FountainWeb.Audited.attribution(socket)
+      )
 
       {:noreply,
        socket

--- a/apps/fountain/lib/fountain_web/live/environments_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/index.ex
@@ -191,7 +191,8 @@ defmodule FountainWeb.EnvironmentsLive.Index do
       "bg-[var(--color-bg-2)] text-[var(--color-text-secondary)] border border-[var(--color-border)]"
 
   defp stat_badge_class(_type, 0),
-    do: "bg-[var(--color-bg-2)] text-[var(--color-text-muted)] border border-[var(--color-border)]"
+    do:
+      "bg-[var(--color-bg-2)] text-[var(--color-text-muted)] border border-[var(--color-border)]"
 
   defp stat_badge_class(:secrets, _),
     do:

--- a/apps/fountain/lib/fountain_web/live/hooks.ex
+++ b/apps/fountain/lib/fountain_web/live/hooks.ex
@@ -211,6 +211,7 @@ defmodule FountainWeb.Live.Hooks do
 
       "sidebar_toggle_roots_only", _params, socket ->
         next = !socket.assigns.sidebar_roots_only
+
         Accounts.update_preferences(socket.assigns.current_user, %{conversations_roots_only: next})
 
         {:halt,

--- a/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
+++ b/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
@@ -80,7 +80,12 @@ defmodule FountainWeb.OnboardingLive.Wizard do
 
             {:error, reason} ->
               {:noreply,
-               put_inference_message(socket, provider, :error, "Could not save: #{inspect(reason)}")}
+               put_inference_message(
+                 socket,
+                 provider,
+                 :error,
+                 "Could not save: #{inspect(reason)}"
+               )}
           end
 
         {:error, :invalid, %{status: status}} ->

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -96,6 +96,7 @@ defmodule FountainWeb.VaultsLive.Form do
 
   defp save(%{assigns: %{action: :new}} = socket, attrs) do
     attrs = Map.put(attrs, "user_id", socket.assigns.user_id)
+
     case Vaults.create_vault(attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, vault} ->
         {:noreply,

--- a/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
@@ -158,7 +158,8 @@ defmodule FountainWeb.VaultsLive.Index do
   end
 
   defp secrets_badge_class(0),
-    do: "bg-[var(--color-bg-2)] text-[var(--color-text-muted)] border border-[var(--color-border)]"
+    do:
+      "bg-[var(--color-bg-2)] text-[var(--color-text-muted)] border border-[var(--color-border)]"
 
   defp secrets_badge_class(_),
     do:

--- a/apps/fountain/priv/repo/migrations/20260508000000_create_turn_images.exs
+++ b/apps/fountain/priv/repo/migrations/20260508000000_create_turn_images.exs
@@ -5,8 +5,7 @@ defmodule Fountain.Repo.Migrations.CreateTurnImages do
     create table(:turn_images, primary_key: false) do
       add :id, :binary_id, primary_key: true
 
-      add :turn_id, references(:turns, type: :binary_id, on_delete: :delete_all),
-        null: false
+      add :turn_id, references(:turns, type: :binary_id, on_delete: :delete_all), null: false
 
       add :position, :integer, null: false
       add :media_type, :string, null: false

--- a/apps/fountain/priv/repo/migrations/20260510210000_create_inference_credentials.exs
+++ b/apps/fountain/priv/repo/migrations/20260510210000_create_inference_credentials.exs
@@ -5,8 +5,7 @@ defmodule Fountain.Repo.Migrations.CreateInferenceCredentials do
     create table(:inference_credentials, primary_key: false) do
       add :id, :binary_id, primary_key: true
 
-      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all),
-        null: false
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
 
       # Each ciphertext is encrypted with the user's per-tenant DEK.
       # Nullable: a user may have set zero, one, or many providers.

--- a/apps/fountain/priv/repo/migrations/20260513000000_add_user_filter_preferences.exs
+++ b/apps/fountain/priv/repo/migrations/20260513000000_add_user_filter_preferences.exs
@@ -4,7 +4,10 @@ defmodule Fountain.Repo.Migrations.AddUserFilterPreferences do
   def change do
     alter table(:users) do
       add :conversations_roots_only, :boolean, null: false, default: false
-      add :conversation_visible_streams, {:array, :string}, null: false, default: ["stdout", "stderr", "stage"]
+
+      add :conversation_visible_streams, {:array, :string},
+        null: false,
+        default: ["stdout", "stderr", "stage"]
     end
   end
 end

--- a/apps/fountain/test/fountain/accounts_additional_test.exs
+++ b/apps/fountain/test/fountain/accounts_additional_test.exs
@@ -228,6 +228,7 @@ defmodule Fountain.AccountsAdditionalTest do
       # Back-date user1 so ordering is deterministic even when both inserts
       # happen within the same timestamp tick
       earlier = DateTime.add(DateTime.utc_now(), -5, :second) |> DateTime.truncate(:second)
+
       Repo.update_all(from(u in Fountain.Accounts.User, where: u.id == ^user1.id),
         set: [inserted_at: earlier]
       )
@@ -273,7 +274,8 @@ defmodule Fountain.AccountsAdditionalTest do
     end
 
     test "returns {:error, :not_found} when no user exists with that email" do
-      assert {:error, :not_found} = Accounts.authenticate_user("nobody@nowhere.test", "anypassword")
+      assert {:error, :not_found} =
+               Accounts.authenticate_user("nobody@nowhere.test", "anypassword")
     end
   end
 
@@ -281,7 +283,12 @@ defmodule Fountain.AccountsAdditionalTest do
 
   describe "verify_email/1" do
     test "sets email_verified_at to a non-nil datetime" do
-      {:ok, user} = Fountain.Accounts.register_user(%{"email" => "unverified#{System.unique_integer([:positive])}@example.com", "password" => "password123"})
+      {:ok, user} =
+        Fountain.Accounts.register_user(%{
+          "email" => "unverified#{System.unique_integer([:positive])}@example.com",
+          "password" => "password123"
+        })
+
       assert is_nil(user.email_verified_at)
 
       assert {:ok, verified} = Accounts.verify_email(user)
@@ -357,7 +364,10 @@ defmodule Fountain.AccountsAdditionalTest do
   describe "register_user/1" do
     test "returns {:ok, user} with valid attrs" do
       email = "reg_#{System.unique_integer([:positive])}@example.com"
-      assert {:ok, user} = Accounts.register_user(%{"email" => email, "password" => "password123"})
+
+      assert {:ok, user} =
+               Accounts.register_user(%{"email" => email, "password" => "password123"})
+
       assert user.email == email
     end
 
@@ -370,13 +380,19 @@ defmodule Fountain.AccountsAdditionalTest do
     test "returns {:error, changeset} on duplicate email" do
       email = "dup_#{System.unique_integer([:positive])}@example.com"
       {:ok, _} = Accounts.register_user(%{"email" => email, "password" => "password123"})
-      assert {:error, changeset} = Accounts.register_user(%{"email" => email, "password" => "password123"})
+
+      assert {:error, changeset} =
+               Accounts.register_user(%{"email" => email, "password" => "password123"})
+
       assert changeset.errors != []
     end
 
     test "returns {:error, changeset} when password is too short" do
       email = "short_#{System.unique_integer([:positive])}@example.com"
-      assert {:error, changeset} = Accounts.register_user(%{"email" => email, "password" => "short"})
+
+      assert {:error, changeset} =
+               Accounts.register_user(%{"email" => email, "password" => "short"})
+
       assert changeset.errors[:password] != nil
     end
   end
@@ -418,7 +434,9 @@ defmodule Fountain.AccountsAdditionalTest do
 
       # Second call reuses existing identity
       assert {:ok, user, :existing} =
-               Accounts.upsert_oauth_user("github", provider_uid, %{"email" => existing_user.email})
+               Accounts.upsert_oauth_user("github", provider_uid, %{
+                 "email" => existing_user.email
+               })
 
       assert user.id == existing_user.id
     end

--- a/apps/fountain/test/fountain/accounts_credential_test.exs
+++ b/apps/fountain/test/fountain/accounts_credential_test.exs
@@ -24,11 +24,14 @@ defmodule Fountain.AccountsCredentialTest do
     test "changes the password and invalidates other sessions" do
       user = insert_verified_user(%{"password" => "old-password-123"})
 
-      assert {:ok, updated} = Accounts.change_password(user, "old-password-123", "new-password-456")
+      assert {:ok, updated} =
+               Accounts.change_password(user, "old-password-123", "new-password-456")
 
       assert updated.session_version > user.session_version
       assert {:ok, _} = Accounts.authenticate_user(user.email, "new-password-456")
-      assert {:error, :wrong_password} = Accounts.authenticate_user(user.email, "old-password-123")
+
+      assert {:error, :wrong_password} =
+               Accounts.authenticate_user(user.email, "old-password-123")
     end
 
     test "refuses a wrong current password without touching anything" do

--- a/apps/fountain/test/fountain/accounts_preferences_test.exs
+++ b/apps/fountain/test/fountain/accounts_preferences_test.exs
@@ -13,14 +13,23 @@ defmodule Fountain.AccountsPreferencesTest do
     end
 
     test "accepts valid conversation_visible_streams subsets" do
-      for streams <- [[], ["stdout"], ["stderr"], ["stage"], ["stdout", "stderr"], ["stdout", "stderr", "stage"]] do
+      for streams <- [
+            [],
+            ["stdout"],
+            ["stderr"],
+            ["stage"],
+            ["stdout", "stderr"],
+            ["stdout", "stderr", "stage"]
+          ] do
         cs = User.preferences_changeset(%User{}, %{conversation_visible_streams: streams})
         assert cs.valid?, "expected #{inspect(streams)} to be valid"
       end
     end
 
     test "rejects invalid stream values" do
-      cs = User.preferences_changeset(%User{}, %{conversation_visible_streams: ["stdout", "invalid"]})
+      cs =
+        User.preferences_changeset(%User{}, %{conversation_visible_streams: ["stdout", "invalid"]})
+
       refute cs.valid?
       assert cs.errors[:conversation_visible_streams] != nil
     end
@@ -51,7 +60,10 @@ defmodule Fountain.AccountsPreferencesTest do
 
     test "persists conversation_visible_streams", %{user: user} do
       streams = ["stdout", "stage"]
-      assert {:ok, updated} = Accounts.update_preferences(user, %{conversation_visible_streams: streams})
+
+      assert {:ok, updated} =
+               Accounts.update_preferences(user, %{conversation_visible_streams: streams})
+
       assert updated.conversation_visible_streams == streams
 
       reloaded = Accounts.get_user!(user.id)
@@ -59,12 +71,16 @@ defmodule Fountain.AccountsPreferencesTest do
     end
 
     test "persists empty visible_streams list", %{user: user} do
-      assert {:ok, updated} = Accounts.update_preferences(user, %{conversation_visible_streams: []})
+      assert {:ok, updated} =
+               Accounts.update_preferences(user, %{conversation_visible_streams: []})
+
       assert updated.conversation_visible_streams == []
     end
 
     test "returns error changeset for invalid streams", %{user: user} do
-      assert {:error, changeset} = Accounts.update_preferences(user, %{conversation_visible_streams: ["bad"]})
+      assert {:error, changeset} =
+               Accounts.update_preferences(user, %{conversation_visible_streams: ["bad"]})
+
       assert changeset.errors[:conversation_visible_streams] != nil
     end
 
@@ -112,7 +128,9 @@ defmodule Fountain.AccountsPreferencesTest do
     end
 
     test "returns error changeset for invalid view mode", %{user: user} do
-      assert {:error, changeset} = Accounts.update_preferences(user, %{conversation_view_mode: "invalid"})
+      assert {:error, changeset} =
+               Accounts.update_preferences(user, %{conversation_view_mode: "invalid"})
+
       assert changeset.errors[:conversation_view_mode] != nil
     end
   end

--- a/apps/fountain/test/fountain/accounts_suspension_test.exs
+++ b/apps/fountain/test/fountain/accounts_suspension_test.exs
@@ -52,7 +52,8 @@ defmodule Fountain.AccountsSuspensionTest do
       user = insert_verified_user()
       {:ok, _, _} = Accounts.suspend_user(user)
 
-      assert {:error, :wrong_password} = Accounts.authenticate_user(user.email, "not-the-password")
+      assert {:error, :wrong_password} =
+               Accounts.authenticate_user(user.email, "not-the-password")
     end
   end
 
@@ -113,5 +114,4 @@ defmodule Fountain.AccountsSuspensionTest do
       assert synced.suspended_at
     end
   end
-
 end

--- a/apps/fountain/test/fountain/accounts_test.exs
+++ b/apps/fountain/test/fountain/accounts_test.exs
@@ -9,7 +9,12 @@ defmodule Fountain.AccountsTest do
 
   describe "User.registration_changeset/2" do
     test "valid attrs produce a valid changeset" do
-      cs = User.registration_changeset(%User{}, %{email: "Alice@Example.com", password: "password123"})
+      cs =
+        User.registration_changeset(%User{}, %{
+          email: "Alice@Example.com",
+          password: "password123"
+        })
+
       assert cs.valid?
       # email is downcased
       assert Ecto.Changeset.get_change(cs, :email) == "alice@example.com"
@@ -50,7 +55,13 @@ defmodule Fountain.AccountsTest do
     end
 
     test "invalid role is rejected" do
-      cs = User.registration_changeset(%User{}, %{email: "a@b.com", password: "password123", role: "superuser"})
+      cs =
+        User.registration_changeset(%User{}, %{
+          email: "a@b.com",
+          password: "password123",
+          role: "superuser"
+        })
+
       assert "is invalid" in errors_on(cs, :role)
     end
   end
@@ -94,6 +105,7 @@ defmodule Fountain.AccountsTest do
   describe "User.theme_changeset/2" do
     test "accepts valid theme preferences" do
       user = %Fountain.Accounts.User{}
+
       for theme <- ~w(system light dark) do
         cs = Fountain.Accounts.User.theme_changeset(user, %{theme_preference: theme})
         assert cs.valid?

--- a/apps/fountain/test/fountain/agents/agent_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_test.exs
@@ -62,7 +62,9 @@ defmodule Fountain.Agents.AgentTest do
     end
 
     test "provider/model_id with dots passes" do
-      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :model, "anthropic/claude-3.5-sonnet"))
+      changeset =
+        Agent.changeset(%Agent{}, Map.put(@valid_attrs, :model, "anthropic/claude-3.5-sonnet"))
+
       assert changeset.valid?
     end
 
@@ -86,7 +88,9 @@ defmodule Fountain.Agents.AgentTest do
     end
 
     test "name of 200 characters passes" do
-      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :name, String.duplicate("a", 200)))
+      changeset =
+        Agent.changeset(%Agent{}, Map.put(@valid_attrs, :name, String.duplicate("a", 200)))
+
       assert changeset.valid?
     end
 
@@ -97,7 +101,9 @@ defmodule Fountain.Agents.AgentTest do
     end
 
     test "name of 201 characters fails" do
-      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :name, String.duplicate("a", 201)))
+      changeset =
+        Agent.changeset(%Agent{}, Map.put(@valid_attrs, :name, String.duplicate("a", 201)))
+
       refute changeset.valid?
       assert errors_on(changeset).name != []
     end
@@ -165,7 +171,11 @@ defmodule Fountain.Agents.AgentTest do
       skills = [%{"content" => "x"}]
       changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :skills, skills))
       refute changeset.valid?
-      assert Enum.any?(errors_on(changeset).skills, &String.contains?(&1, "inline skills require a name"))
+
+      assert Enum.any?(
+               errors_on(changeset).skills,
+               &String.contains?(&1, "inline skills require a name")
+             )
     end
 
     test "non-map skill entry fails" do

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -158,7 +158,9 @@ defmodule Fountain.AgentsTest do
       victim_env = insert_env(user_id: victim.id)
       agent = insert_agent(user_id: attacker.id)
 
-      assert {:error, changeset} = Agents.update_agent(agent, %{"environment_id" => victim_env.id})
+      assert {:error, changeset} =
+               Agents.update_agent(agent, %{"environment_id" => victim_env.id})
+
       assert %{environment_id: ["does not exist"]} = errors_on(changeset)
     end
   end
@@ -247,8 +249,10 @@ defmodule Fountain.AgentsTest do
       _agent_no_skills = insert_agent(user_id: user.id)
 
       agent_with_skills =
-        insert_agent(user_id: user.id,
-          skills: [%{"name" => "foo", "content" => "bar"}])
+        insert_agent(
+          user_id: user.id,
+          skills: [%{"name" => "foo", "content" => "bar"}]
+        )
 
       results = Agents.list_agents(user.id, has_skills: true)
       ids = Enum.map(results, & &1.id)
@@ -259,9 +263,12 @@ defmodule Fountain.AgentsTest do
     test "has_skills: false (default) returns all agents including those without skills" do
       user = insert_verified_user()
       agent_no_skills = insert_agent(user_id: user.id)
+
       agent_with_skills =
-        insert_agent(user_id: user.id,
-          skills: [%{"name" => "foo", "content" => "bar"}])
+        insert_agent(
+          user_id: user.id,
+          skills: [%{"name" => "foo", "content" => "bar"}]
+        )
 
       results = Agents.list_agents(user.id, has_skills: false)
       ids = Enum.map(results, & &1.id)
@@ -276,8 +283,10 @@ defmodule Fountain.AgentsTest do
       _agent_no_mcp = insert_agent(user_id: user.id)
 
       agent_with_mcp =
-        insert_agent(user_id: user.id,
-          mcp_servers: %{"my-server" => %{"url" => "http://localhost:8080"}})
+        insert_agent(
+          user_id: user.id,
+          mcp_servers: %{"my-server" => %{"url" => "http://localhost:8080"}}
+        )
 
       results = Agents.list_agents(user.id, has_mcp: true)
       ids = Enum.map(results, & &1.id)
@@ -290,8 +299,10 @@ defmodule Fountain.AgentsTest do
       agent_no_mcp = insert_agent(user_id: user.id)
 
       agent_with_mcp =
-        insert_agent(user_id: user.id,
-          mcp_servers: %{"my-server" => %{"url" => "http://localhost:8080"}})
+        insert_agent(
+          user_id: user.id,
+          mcp_servers: %{"my-server" => %{"url" => "http://localhost:8080"}}
+        )
 
       results = Agents.list_agents(user.id, has_mcp: false)
       ids = Enum.map(results, & &1.id)

--- a/apps/fountain/test/fountain/audit_deleted_user_test.exs
+++ b/apps/fountain/test/fountain/audit_deleted_user_test.exs
@@ -128,7 +128,6 @@ defmodule Fountain.AuditDeletedUserTest do
       assert event.user_id == user.id
     end
   end
-
 end
 
 defmodule Fountain.AuditDeletedUserEndToEndTest do

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -51,8 +51,7 @@ defmodule Fountain.AuditGuardrailTest do
     # Secrets and credentials (#593). These had five and four call sites
     # respectively before the recording moved into the context; the entries
     # below are what stops a sixth from being silent.
-    {"environment secret write", &__MODULE__.do_env_secret_write/1,
-     "environment.secret.write"},
+    {"environment secret write", &__MODULE__.do_env_secret_write/1, "environment.secret.write"},
     {"environment secret delete", &__MODULE__.do_env_secret_delete/1,
      "environment.secret.delete"},
     {"vault secret write", &__MODULE__.do_vault_secret_write/1, "vault.secret.write"},
@@ -131,7 +130,8 @@ defmodule Fountain.AuditGuardrailTest do
 
   ## ── the mutations ─────────────────────────────────────────────────────────
 
-  def do_agent_create(user), do: {:ok, _} = Agents.create_agent(agent_attrs(%{"user_id" => user.id}))
+  def do_agent_create(user),
+    do: {:ok, _} = Agents.create_agent(agent_attrs(%{"user_id" => user.id}))
 
   def do_agent_update(user) do
     agent = insert_agent(user_id: user.id)
@@ -146,7 +146,8 @@ defmodule Fountain.AuditGuardrailTest do
     do: {:ok, _} = Environments.create_environment(env_attrs(%{"user_id" => user.id}))
 
   def do_env_update(user) do
-    {:ok, _} = Environments.update_environment(insert_env(user_id: user.id), %{"setup_script" => "x"})
+    {:ok, _} =
+      Environments.update_environment(insert_env(user_id: user.id), %{"setup_script" => "x"})
   end
 
   def do_env_delete(user) do

--- a/apps/fountain/test/fountain/audit_test.exs
+++ b/apps/fountain/test/fountain/audit_test.exs
@@ -54,8 +54,11 @@ defmodule Fountain.AuditTest do
       user = insert_verified_user()
       resource_id = Ecto.UUID.generate()
 
-      {:ok, first} = Audit.record(valid_attrs(user.id, %{resource_id: resource_id, action: "first"}))
-      {:ok, second} = Audit.record(valid_attrs(user.id, %{resource_id: resource_id, action: "second"}))
+      {:ok, first} =
+        Audit.record(valid_attrs(user.id, %{resource_id: resource_id, action: "first"}))
+
+      {:ok, second} =
+        Audit.record(valid_attrs(user.id, %{resource_id: resource_id, action: "second"}))
 
       events = Audit.list_recent_for_user(user.id)
       ids = Enum.map(events, & &1.id)
@@ -198,7 +201,8 @@ defmodule Fountain.AuditTest do
       Audit.record!(valid_attrs(user.id, %{resource_type: "vault_secret"}))
       Audit.record!(valid_attrs(user.id, %{resource_type: "agent"}))
 
-      types = Audit._unsafe_list_events(resource_type: "vault_secret") |> Enum.map(& &1.resource_type)
+      types =
+        Audit._unsafe_list_events(resource_type: "vault_secret") |> Enum.map(& &1.resource_type)
 
       assert types == ["vault_secret"]
     end

--- a/apps/fountain/test/fountain/compose_passthrough_config_test.exs
+++ b/apps/fountain/test/fountain/compose_passthrough_config_test.exs
@@ -145,7 +145,10 @@ defmodule Fountain.ComposePassthroughConfigTest do
     test "a real value is parsed", %{base: base} do
       cfg =
         base
-        |> Map.merge(%{"SANDBOX_IDLE_TIMEOUT_MINUTES" => "0", "SANDBOX_MAX_LIFETIME_HOURS" => "72"})
+        |> Map.merge(%{
+          "SANDBOX_IDLE_TIMEOUT_MINUTES" => "0",
+          "SANDBOX_MAX_LIFETIME_HOURS" => "72"
+        })
         |> read_prod()
 
       assert cfg[:fountain][:sandbox_idle_timeout_minutes] == 0

--- a/apps/fountain/test/fountain/conversations/conversation_audit_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_audit_test.exs
@@ -127,7 +127,12 @@ defmodule Fountain.Conversations.ConversationAuditTest do
       sandbox = insert_sandbox(user_id: user.id, status: "ready")
 
       conv =
-        insert_conversation(user_id: user.id, agent: agent, sandbox_id: sandbox.id, title: "notes")
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox_id: sandbox.id,
+          title: "notes"
+        )
 
       {:ok, _} = Conversations.delete_conversation(conv, actor: "ui")
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
@@ -94,7 +94,10 @@ defmodule Fountain.Conversations.ConversationServerLogBudgetTest do
     _ = :sys.get_state(pid2)
 
     data = Enum.map(output_events(conv.id), & &1.data)
-    refute Enum.any?(data, &(&1 =~ "cccc")), "the over-budget chunk must be dropped, not persisted"
+
+    refute Enum.any?(data, &(&1 =~ "cccc")),
+           "the over-budget chunk must be dropped, not persisted"
+
     assert Enum.any?(data, &(&1 =~ "durable log budget"))
 
     # The counter seeded from the DB (90) and the capped chunk never counted.

--- a/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
@@ -15,8 +15,12 @@ defmodule Fountain.Conversations.ConversationServerProvisionDeadlineTest do
 
   defp wait_until(fun, tries \\ 50) do
     cond do
-      fun.() -> :ok
-      tries == 0 -> flunk("condition never became true")
+      fun.() ->
+        :ok
+
+      tries == 0 ->
+        flunk("condition never became true")
+
       true ->
         Process.sleep(100)
         wait_until(fun, tries - 1)

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -426,9 +426,10 @@ defmodule Fountain.Conversations.ConversationServerTest do
       GenServer.stop(pid)
     end
 
-    test "a conversation deleted before provisioning stops the server instead of crash-looping", %{
-      conv: conv
-    } do
+    test "a conversation deleted before provisioning stops the server instead of crash-looping",
+         %{
+           conv: conv
+         } do
       # This used to raise Ecto.NoResultsError out of
       # handle_continue(:provision) — unrescued, restart: :transient, so
       # Horde restarted it straight back into the same raise, burning the
@@ -707,7 +708,8 @@ defmodule Fountain.Conversations.ConversationServerTest do
     end
 
     test "reports not_running for an unknown conversation" do
-      assert {:error, :not_running} = ConversationServer.terminate_conversation(Ecto.UUID.generate())
+      assert {:error, :not_running} =
+               ConversationServer.terminate_conversation(Ecto.UUID.generate())
     end
 
     test "does not resurrect an already-failed sandbox", %{conv: conv, sandbox: sandbox} do

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1741,7 +1741,10 @@ defmodule Fountain.ConversationsContextTest do
         {:error, {:already_started, self()}}
       end)
 
-      stub(Fountain.Conversations.ConversationServer, :queue_initial_prompt, fn _conv_id, _prompt -> :ok end)
+      stub(Fountain.Conversations.ConversationServer, :queue_initial_prompt, fn _conv_id,
+                                                                                _prompt ->
+        :ok
+      end)
 
       assert {:ok, _conv} = Conversations.wake_conversation(conv.id, "hi")
 

--- a/apps/fountain/test/fountain/crypto_test.exs
+++ b/apps/fountain/test/fountain/crypto_test.exs
@@ -116,7 +116,10 @@ defmodule Fountain.CryptoTest do
       bad_wrapped = Crypto.encrypt("short", master, "fountain.key_wrap")
 
       import Ecto.Query, only: [from: 2]
-      Fountain.Repo.delete_all(from k in Fountain.Accounts.UserDataKey, where: k.user_id == ^user.id)
+
+      Fountain.Repo.delete_all(
+        from k in Fountain.Accounts.UserDataKey, where: k.user_id == ^user.id
+      )
 
       %Fountain.Accounts.UserDataKey{}
       |> Fountain.Accounts.UserDataKey.changeset(%{
@@ -134,7 +137,10 @@ defmodule Fountain.CryptoTest do
 
       # Replace the valid UserDataKey created by register_user with garbage.
       import Ecto.Query, only: [from: 2]
-      Fountain.Repo.delete_all(from k in Fountain.Accounts.UserDataKey, where: k.user_id == ^user.id)
+
+      Fountain.Repo.delete_all(
+        from k in Fountain.Accounts.UserDataKey, where: k.user_id == ^user.id
+      )
 
       %Fountain.Accounts.UserDataKey{}
       |> Fountain.Accounts.UserDataKey.changeset(%{

--- a/apps/fountain/test/fountain/environments/environment_test.exs
+++ b/apps/fountain/test/fountain/environments/environment_test.exs
@@ -22,8 +22,14 @@ defmodule Fountain.Environments.EnvironmentTest do
   describe "warm_start_fields/0" do
     test "returns the 6 expected warm-start fields" do
       assert Environment.warm_start_fields() ==
-               [:packages, :env_vars, :setup_script, :networking_type, :networking_config,
-                :repositories]
+               [
+                 :packages,
+                 :env_vars,
+                 :setup_script,
+                 :networking_type,
+                 :networking_config,
+                 :repositories
+               ]
     end
   end
 

--- a/apps/fountain/test/fountain/environments_test.exs
+++ b/apps/fountain/test/fountain/environments_test.exs
@@ -241,7 +241,11 @@ defmodule Fountain.EnvironmentsTest do
       {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
 
       {:ok, secret} =
-        Environments.upsert_secret(env, %{"key" => "DECRYPT_ME", "value" => "plaintext_value"}, dek)
+        Environments.upsert_secret(
+          env,
+          %{"key" => "DECRYPT_ME", "value" => "plaintext_value"},
+          dek
+        )
 
       reloaded = Fountain.Repo.get!(Fountain.Environments.Secret, secret.id)
       assert {:ok, "plaintext_value"} = Fountain.Environments.Secret.decrypt(reloaded, dek)

--- a/apps/fountain/test/fountain/exports_test.exs
+++ b/apps/fountain/test/fountain/exports_test.exs
@@ -185,7 +185,9 @@ defmodule Fountain.ExportsTest do
 
     test "a superseded or deleted export id is a no-op, not a crash loop" do
       user = insert_verified_user()
-      assert :ok = perform_job(AccountExport, %{export_id: Ecto.UUID.generate(), user_id: user.id})
+
+      assert :ok =
+               perform_job(AccountExport, %{export_id: Ecto.UUID.generate(), user_id: user.id})
     end
 
     test "completion broadcasts so the account page updates" do
@@ -208,7 +210,9 @@ defmodule Fountain.ExportsTest do
     end
 
     test "the owner can fetch it", %{user: user, export: export} do
-      assert {:ok, %Export{payload: payload}} = Exports.get_downloadable_export(export.id, user.id)
+      assert {:ok, %Export{payload: payload}} =
+               Exports.get_downloadable_export(export.id, user.id)
+
       assert is_binary(payload)
     end
 

--- a/apps/fountain/test/fountain/inference_credentials/validator_test.exs
+++ b/apps/fountain/test/fountain/inference_credentials/validator_test.exs
@@ -118,7 +118,11 @@ defmodule Fountain.InferenceCredentials.ValidatorTest do
 
     test "gemini_api_key sends request to Google API with key as query param" do
       stub(Req, :get, fn url, _opts ->
-        assert String.starts_with?(url, "https://generativelanguage.googleapis.com/v1beta/models?key=")
+        assert String.starts_with?(
+                 url,
+                 "https://generativelanguage.googleapis.com/v1beta/models?key="
+               )
+
         assert String.contains?(url, "gemini-key-test")
         {:ok, %Req.Response{status: 200}}
       end)
@@ -130,7 +134,9 @@ defmodule Fountain.InferenceCredentials.ValidatorTest do
   describe "validate/2 - {:error, :invalid} on non-2xx" do
     test "returns {:error, :invalid, %{status: 401}} on 401" do
       stub(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 401}} end)
-      assert {:error, :invalid, %{status: 401}} = Validator.validate(:anthropic_api_key, "bad-key")
+
+      assert {:error, :invalid, %{status: 401}} =
+               Validator.validate(:anthropic_api_key, "bad-key")
     end
 
     test "returns {:error, :invalid, %{status: 403}} on 403" do
@@ -140,7 +146,9 @@ defmodule Fountain.InferenceCredentials.ValidatorTest do
 
     test "returns {:error, :invalid, %{status: 429}} on 429" do
       stub(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 429}} end)
-      assert {:error, :invalid, %{status: 429}} = Validator.validate(:claude_code_oauth_token, "token")
+
+      assert {:error, :invalid, %{status: 429}} =
+               Validator.validate(:claude_code_oauth_token, "token")
     end
 
     test "returns {:error, :invalid, %{status: 500}} on 500" do

--- a/apps/fountain/test/fountain/inference_credentials_test.exs
+++ b/apps/fountain/test/fountain/inference_credentials_test.exs
@@ -30,15 +30,22 @@ defmodule Fountain.InferenceCredentialsTest do
     end
 
     test "returns the row after a put", %{user: user, dek: dek} do
-      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, "sk-ant-test")
+      {:ok, _} =
+        InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, "sk-ant-test")
+
       assert %Credential{} = InferenceCredentials.get_for_user(user.id)
     end
   end
 
   describe "put_credential/4" do
-    test "creates a row on first put and stores ciphertext (not plaintext)", %{user: user, dek: dek} do
+    test "creates a row on first put and stores ciphertext (not plaintext)", %{
+      user: user,
+      dek: dek
+    } do
       plaintext = "sk-ant-very-secret"
-      {:ok, cred} = InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, plaintext)
+
+      {:ok, cred} =
+        InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, plaintext)
 
       assert is_binary(cred.anthropic_api_key_ciphertext)
       refute cred.anthropic_api_key_ciphertext == plaintext
@@ -139,6 +146,7 @@ defmodule Fountain.InferenceCredentialsTest do
   describe "status_for_user/1" do
     test "all false for a user with no credentials", %{user: user} do
       status = InferenceCredentials.status_for_user(user.id)
+
       assert status == %{
                anthropic_api_key: false,
                claude_code_oauth_token: false,
@@ -161,7 +169,8 @@ defmodule Fountain.InferenceCredentialsTest do
 
   describe "tenant scoping" do
     test "one user's credentials are not visible to another", %{user: user, dek: dek} do
-      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, "sk-ant-secret")
+      {:ok, _} =
+        InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, "sk-ant-secret")
 
       other = insert_user()
       {:ok, other_dek} = Crypto.load_tenant_key(other.id)

--- a/apps/fountain/test/fountain/release_test.exs
+++ b/apps/fountain/test/fountain/release_test.exs
@@ -82,7 +82,8 @@ defmodule Fountain.ReleaseTest do
 
     test "returns not_found for an unknown email" do
       capture_io(:stderr, fn ->
-        assert {:error, :not_found} = Release.verify_email("nobody-#{System.unique_integer([:positive])}@example.com")
+        assert {:error, :not_found} =
+                 Release.verify_email("nobody-#{System.unique_integer([:positive])}@example.com")
       end)
     end
   end

--- a/apps/fountain/test/fountain/runtime_config_test.exs
+++ b/apps/fountain/test/fountain/runtime_config_test.exs
@@ -41,7 +41,9 @@ defmodule Fountain.RuntimeConfigTest do
   end
 
   defp read_prod_config(env) do
-    for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN SMTP_HOST EMAIL_DELIVERY), do: System.delete_env(k)
+    for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN SMTP_HOST EMAIL_DELIVERY),
+        do: System.delete_env(k)
+
     System.put_env(env)
     Config.Reader.read!(@runtime_exs, env: :prod)[:fountain]
   end

--- a/apps/fountain/test/fountain/substitution_test.exs
+++ b/apps/fountain/test/fountain/substitution_test.exs
@@ -74,12 +74,14 @@ defmodule Fountain.SubstitutionTest do
 
     test "substitutes inside a nested map" do
       input = %{"outer" => %{"inner" => "${VAL}"}}
+
       assert {:ok, %{"outer" => %{"inner" => "42"}}} =
                Substitution.apply(input, %{"VAL" => "42"})
     end
 
     test "substitutes inside a map with mixed types" do
       input = %{"key" => "${X}", "num" => 42}
+
       assert {:ok, %{"key" => "hello", "num" => 42}} =
                Substitution.apply(input, %{"X" => "hello"})
     end
@@ -93,29 +95,36 @@ defmodule Fountain.SubstitutionTest do
 
   describe "apply/2 — property tests" do
     property "substituting a variable always returns the provided value" do
-      check all key <- string(:alphanumeric, min_length: 1),
-                key = String.upcase(key),
-                String.match?(key, ~r/^[A-Z_][A-Z0-9_]*$/),
-                value <- string(:printable) do
+      check all(
+              key <- string(:alphanumeric, min_length: 1),
+              key = String.upcase(key),
+              String.match?(key, ~r/^[A-Z_][A-Z0-9_]*$/),
+              value <- string(:printable)
+            ) do
         template = "${#{key}}"
         assert {:ok, ^value} = Substitution.apply(template, %{key => value})
       end
     end
 
     property "plain strings with no $ pass through unchanged" do
-      check all s <- string(:alphanumeric) do
+      check all(s <- string(:alphanumeric)) do
         assert {:ok, ^s} = Substitution.apply(s, %{})
       end
     end
 
     property "applying with all vars provided always returns :ok" do
-      check all pairs <- list_of({
-                  string(:alphanumeric, min_length: 1)
-                  |> map(&String.upcase/1)
-                  |> filter(&String.match?(&1, ~r/^[A-Z][A-Z0-9_]*$/)),
-                  string(:printable)
-                },
-                min_length: 1) do
+      check all(
+              pairs <-
+                list_of(
+                  {
+                    string(:alphanumeric, min_length: 1)
+                    |> map(&String.upcase/1)
+                    |> filter(&String.match?(&1, ~r/^[A-Z][A-Z0-9_]*$/)),
+                    string(:printable)
+                  },
+                  min_length: 1
+                )
+            ) do
         vars = Map.new(pairs)
         template = vars |> Map.keys() |> Enum.map_join(" ", &"${#{&1}}")
         assert {:ok, _} = Substitution.apply(template, vars)

--- a/apps/fountain/test/fountain_web/api_key_scope_test.exs
+++ b/apps/fountain/test/fountain_web/api_key_scope_test.exs
@@ -191,7 +191,11 @@ defmodule FountainWeb.ApiKeyScopeTest do
       user = insert_verified_user()
 
       {:ok, {_rec, raw}} =
-        Accounts.create_api_key(user.id, "sprite:test", ConversationServer.callback_api_key_opts())
+        Accounts.create_api_key(
+          user.id,
+          "sprite:test",
+          ConversationServer.callback_api_key_opts()
+        )
 
       conn =
         conn

--- a/apps/fountain/test/fountain_web/audit_coverage_test.exs
+++ b/apps/fountain/test/fountain_web/audit_coverage_test.exs
@@ -105,7 +105,10 @@ defmodule FountainWeb.AuditCoverageTest do
 
       conn
       |> authed_with_key(key)
-      |> post_json("/api/environments/#{env.id}/secrets", %{"key" => "DB_URL", "value" => "pg://x"})
+      |> post_json("/api/environments/#{env.id}/secrets", %{
+        "key" => "DB_URL",
+        "value" => "pg://x"
+      })
       |> json_response(201)
 
       write = find_action(user.id, "environment.secret.write")
@@ -244,8 +247,13 @@ defmodule FountainWeb.AuditCoverageTest do
 
     test "a password reset is recorded" do
       user = insert_verified_user()
+
       token =
-        Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
+        Phoenix.Token.sign(
+          FountainWeb.Endpoint,
+          "password_reset",
+          {user.id, user.session_version}
+        )
 
       build_conn()
       |> post(~p"/auth/reset", %{"token" => token, "password" => "new-password-123"})

--- a/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
@@ -37,7 +37,11 @@ defmodule FountainWeb.AgentControllerTest do
   end
 
   describe "GET /api/agents/:id" do
-    test "returns 200 with the agent for the authenticated user", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 with the agent for the authenticated user", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       agent = insert_agent(user_id: user.id)
 
       conn = conn |> authed_with_key(raw_key) |> get("/api/agents/#{agent.id}")
@@ -85,7 +89,10 @@ defmodule FountainWeb.AgentControllerTest do
       assert json_response(conn, 401)
     end
 
-    test "returns 422 when a skill entry has neither content nor source", %{conn: conn, raw_key: raw_key} do
+    test "returns 422 when a skill entry has neither content nor source", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       # OpenApiSpex does not enforce the content/source mutual-exclusivity rule;
       # the Ecto changeset's validate_skills/1 does, so this reaches the DB layer
       # as a pure changeset error and is rendered as 422.
@@ -104,7 +111,10 @@ defmodule FountainWeb.AgentControllerTest do
       assert json_response(conn, 422)
     end
 
-    test "returns 422 when environment_id belongs to another tenant", %{conn: conn, raw_key: raw_key} do
+    test "returns 422 when environment_id belongs to another tenant", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       victim = insert_verified_user()
       victim_env = insert_env(user_id: victim.id)
 

--- a/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
@@ -57,7 +57,10 @@ defmodule FountainWeb.ApplyControllerTest do
 
       {:ok, dek} = Crypto.load_tenant_key(user.id)
       assert Environments.decrypted_env(env, dek) == %{"TOKEN" => "t0"}
-      assert Vaults.decrypted_env(Vaults.get_vault_by_name("alice", user.id), dek) == %{"GH" => "ghp_x"}
+
+      assert Vaults.decrypted_env(Vaults.get_vault_by_name("alice", user.id), dek) == %{
+               "GH" => "ghp_x"
+             }
     end
 
     test "never echoes secret values back", %{conn: conn, raw_key: raw_key} do
@@ -79,6 +82,7 @@ defmodule FountainWeb.ApplyControllerTest do
       }
 
       auth = fn conn -> authed_with_key(conn, raw_key) end
+
       assert %{"data" => %{"results" => [%{"action" => "created"}]}} =
                conn |> auth.() |> post_json(~p"/api/apply", payload) |> json_response(200)
 

--- a/apps/fountain/test/fountain_web/controllers/auth_completion_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_completion_controller_test.exs
@@ -173,7 +173,8 @@ defmodule FountainWeb.AuthCompletionControllerTest do
       user = insert_verified_user(%{"password" => "password12345"})
       token = Accounts.email_change_token(user, "new-address@example.com")
 
-      body = conn |> json_post("/api/auth/email/confirm", %{"token" => token}) |> json_response(200)
+      body =
+        conn |> json_post("/api/auth/email/confirm", %{"token" => token}) |> json_response(200)
 
       assert body["email"] == "new-address@example.com"
       assert Accounts.get_user(user.id).email == "new-address@example.com"
@@ -184,7 +185,8 @@ defmodule FountainWeb.AuthCompletionControllerTest do
       taken = insert_verified_user()
       token = Accounts.email_change_token(user, taken.email)
 
-      body = conn |> json_post("/api/auth/email/confirm", %{"token" => token}) |> json_response(422)
+      body =
+        conn |> json_post("/api/auth/email/confirm", %{"token" => token}) |> json_response(422)
 
       assert body["error"] == "email_taken"
       assert Accounts.get_user(user.id).email == user.email

--- a/apps/fountain/test/fountain_web/controllers/auth_token_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_token_controller_test.exs
@@ -4,7 +4,11 @@ defmodule FountainWeb.AuthTokenControllerTest do
 
   describe "POST /api/auth/token" do
     test "returns 201 with api_key on valid credentials", %{conn: conn} do
-      user = insert_verified_user(%{"email" => "login#{System.unique_integer()}@example.com", "password" => "password123"})
+      user =
+        insert_verified_user(%{
+          "email" => "login#{System.unique_integer()}@example.com",
+          "password" => "password123"
+        })
 
       conn = post_json(conn, "/api/auth/token", %{email: user.email, password: "password123"})
 
@@ -33,7 +37,11 @@ defmodule FountainWeb.AuthTokenControllerTest do
     end
 
     test "returns 401 on wrong password", %{conn: conn} do
-      user = insert_verified_user(%{"email" => "login#{System.unique_integer()}@example.com", "password" => "password123"})
+      user =
+        insert_verified_user(%{
+          "email" => "login#{System.unique_integer()}@example.com",
+          "password" => "password123"
+        })
 
       conn = post_json(conn, "/api/auth/token", %{email: user.email, password: "wrongpassword"})
 
@@ -41,13 +49,18 @@ defmodule FountainWeb.AuthTokenControllerTest do
     end
 
     test "returns 401 on unknown email", %{conn: conn} do
-      conn = post_json(conn, "/api/auth/token", %{email: "nobody@example.com", password: "password123"})
+      conn =
+        post_json(conn, "/api/auth/token", %{email: "nobody@example.com", password: "password123"})
 
       assert %{"error" => "Invalid email or password"} = json_response(conn, 401)
     end
 
     test "api_key from response can authenticate GET /api/auth/me", %{conn: conn} do
-      user = insert_verified_user(%{"email" => "login#{System.unique_integer()}@example.com", "password" => "password123"})
+      user =
+        insert_verified_user(%{
+          "email" => "login#{System.unique_integer()}@example.com",
+          "password" => "password123"
+        })
 
       %{"api_key" => raw_key} =
         conn

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -355,7 +355,10 @@ defmodule FountainWeb.ConversationControllerTest do
 
     test "returns 400 when conversation is busy", %{conn: conn, user: user, raw_key: raw_key} do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts -> {:error, :busy} end)
+
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts ->
+        {:error, :busy}
+      end)
 
       conn =
         conn
@@ -483,7 +486,10 @@ defmodule FountainWeb.ConversationControllerTest do
       raw_key: raw_key
     } do
       conv = insert_conversation(user_id: user.id)
-      stub(ConversationServer, :terminate_conversation, fn _id, _opts -> {:error, :not_running} end)
+
+      stub(ConversationServer, :terminate_conversation, fn _id, _opts ->
+        {:error, :not_running}
+      end)
 
       conn =
         conn

--- a/apps/fountain/test/fountain_web/controllers/conversation_events_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_events_controller_test.exs
@@ -133,12 +133,18 @@ defmodule FountainWeb.ConversationEventsControllerTest do
     } do
       insert_log_event(conv)
 
-      assert conn |> get_events(key, conv, "?limit=0") |> json_response(200) |> get_in([
+      assert conn
+             |> get_events(key, conv, "?limit=0")
+             |> json_response(200)
+             |> get_in([
                "meta",
                "limit"
              ]) == 1
 
-      assert conn |> get_events(key, conv, "?limit=-5") |> json_response(200) |> get_in([
+      assert conn
+             |> get_events(key, conv, "?limit=-5")
+             |> json_response(200)
+             |> get_in([
                "meta",
                "limit"
              ]) == 1

--- a/apps/fountain/test/fountain_web/controllers/environment_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/environment_controller_test.exs
@@ -37,7 +37,11 @@ defmodule FountainWeb.EnvironmentControllerTest do
   end
 
   describe "GET /api/environments/:id" do
-    test "returns 200 with the environment for the authenticated user", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 with the environment for the authenticated user", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       env = insert_env(user_id: user.id)
 
       conn = conn |> authed_with_key(raw_key) |> get("/api/environments/#{env.id}")
@@ -47,7 +51,10 @@ defmodule FountainWeb.EnvironmentControllerTest do
       assert body["data"]["name"] == env.name
     end
 
-    test "returns 404 when the environment belongs to a different user", %{conn: conn, raw_key: raw_key} do
+    test "returns 404 when the environment belongs to a different user", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       other_user = insert_verified_user()
       other_env = insert_env(user_id: other_user.id)
 
@@ -110,7 +117,10 @@ defmodule FountainWeb.EnvironmentControllerTest do
       assert body["data"]["id"] == env.id
     end
 
-    test "returns 404 when the environment belongs to a different user", %{conn: conn, raw_key: raw_key} do
+    test "returns 404 when the environment belongs to a different user", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       other_user = insert_verified_user()
       other_env = insert_env(user_id: other_user.id)
 
@@ -149,7 +159,10 @@ defmodule FountainWeb.EnvironmentControllerTest do
       assert conn.status == 204
     end
 
-    test "returns 404 when the environment belongs to a different user", %{conn: conn, raw_key: raw_key} do
+    test "returns 404 when the environment belongs to a different user", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       other_user = insert_verified_user()
       other_env = insert_env(user_id: other_user.id)
 

--- a/apps/fountain/test/fountain_web/controllers/fallback_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/fallback_controller_test.exs
@@ -6,7 +6,9 @@ defmodule FountainWeb.FallbackControllerTest do
   use FountainWeb.ConnCase, async: true
 
   describe "{:error, %Ecto.Changeset{}} → 422" do
-    test "POST /api/agents with missing required fields returns 422 with errors body", %{conn: conn} do
+    test "POST /api/agents with missing required fields returns 422 with errors body", %{
+      conn: conn
+    } do
       user = insert_verified_user()
       {_key, raw_key} = insert_api_key(user)
 

--- a/apps/fountain/test/fountain_web/controllers/inference_credential_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/inference_credential_controller_test.exs
@@ -253,7 +253,9 @@ defmodule FountainWeb.InferenceCredentialControllerTest do
       body =
         conn
         |> authed_with_key(sprite_key)
-        |> put_json("/api/account/inference-credentials/anthropic_api_key", %{"value" => "sk-evil"})
+        |> put_json("/api/account/inference-credentials/anthropic_api_key", %{
+          "value" => "sk-evil"
+        })
         |> json_response(403)
 
       assert body["reason"] == "insufficient_scope"

--- a/apps/fountain/test/fountain_web/controllers/list_counts_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/list_counts_test.exs
@@ -41,9 +41,10 @@ defmodule FountainWeb.ListCountsTest do
     test "a fresh agent reports zero, not null", %{conn: conn, user: user, key: key} do
       insert_agent(user_id: user.id)
 
-      assert conn |> authed_with_key(key) |> first("/api/agents") |> Map.fetch!(
-               "conversation_count"
-             ) == 0
+      assert conn
+             |> authed_with_key(key)
+             |> first("/api/agents")
+             |> Map.fetch!("conversation_count") == 0
     end
 
     test "another tenant's conversations do not count", %{conn: conn, user: user, key: key} do
@@ -51,9 +52,10 @@ defmodule FountainWeb.ListCountsTest do
       other = insert_verified_user()
       insert_conversation(user_id: other.id, agent_id: agent.id)
 
-      assert conn |> authed_with_key(key) |> first("/api/agents") |> Map.fetch!(
-               "conversation_count"
-             ) == 0
+      assert conn
+             |> authed_with_key(key)
+             |> first("/api/agents")
+             |> Map.fetch!("conversation_count") == 0
     end
 
     test "creating an agent returns counts too", %{conn: conn, key: key} do

--- a/apps/fountain/test/fountain_web/controllers/onboarding_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/onboarding_controller_test.exs
@@ -97,7 +97,8 @@ defmodule FountainWeb.OnboardingControllerTest do
       |> post("/api/account/onboarding/complete")
       |> json_response(200)
 
-      after_body = build_conn() |> authed_with_key(key) |> get("/api/auth/me") |> json_response(200)
+      after_body =
+        build_conn() |> authed_with_key(key) |> get("/api/auth/me") |> json_response(200)
 
       assert after_body["onboarding_completed"] == true
       assert after_body["onboarding_state"] == "completed"

--- a/apps/fountain/test/fountain_web/controllers/password_reset_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/password_reset_controller_test.exs
@@ -44,7 +44,13 @@ defmodule FountainWeb.PasswordResetControllerTest do
   describe "GET /auth/reset/:token" do
     test "renders reset form for valid token", %{conn: conn} do
       user = insert_verified_user()
-      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
+
+      token =
+        Phoenix.Token.sign(
+          FountainWeb.Endpoint,
+          "password_reset",
+          {user.id, user.session_version}
+        )
 
       conn = get(conn, ~p"/auth/reset/#{token}")
       assert html_response(conn, 200) =~ "new password"
@@ -57,7 +63,9 @@ defmodule FountainWeb.PasswordResetControllerTest do
 
     test "redirects with error when reset token has expired", %{conn: conn} do
       user = insert_verified_user()
-      expired_token = Phoenix.Token.sign(
+
+      expired_token =
+        Phoenix.Token.sign(
           FountainWeb.Endpoint,
           "password_reset",
           {user.id, user.session_version},
@@ -73,7 +81,13 @@ defmodule FountainWeb.PasswordResetControllerTest do
     test "updates password and drops session", %{conn: conn} do
       user = insert_verified_user()
       old_hash = Accounts.get_user!(user.id).password_hash
-      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
+
+      token =
+        Phoenix.Token.sign(
+          FountainWeb.Endpoint,
+          "password_reset",
+          {user.id, user.session_version}
+        )
 
       conn = post(conn, ~p"/auth/reset", %{"token" => token, "password" => "newpassword123"})
       assert redirected_to(conn) == ~p"/auth/login"
@@ -86,14 +100,22 @@ defmodule FountainWeb.PasswordResetControllerTest do
 
     test "re-renders form with error on short password", %{conn: conn} do
       user = insert_verified_user()
-      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
+
+      token =
+        Phoenix.Token.sign(
+          FountainWeb.Endpoint,
+          "password_reset",
+          {user.id, user.session_version}
+        )
 
       conn = post(conn, ~p"/auth/reset", %{"token" => token, "password" => "short"})
       assert html_response(conn, 422) =~ "new password"
     end
 
     test "redirects with error for invalid token", %{conn: conn} do
-      conn = post(conn, ~p"/auth/reset", %{"token" => "badtoken", "password" => "validpassword123"})
+      conn =
+        post(conn, ~p"/auth/reset", %{"token" => "badtoken", "password" => "validpassword123"})
+
       assert redirected_to(conn) == ~p"/auth/forgot-password"
     end
 
@@ -108,14 +130,18 @@ defmodule FountainWeb.PasswordResetControllerTest do
 
     test "redirects with error when reset token has expired", %{conn: conn} do
       user = insert_verified_user()
-      expired_token = Phoenix.Token.sign(
+
+      expired_token =
+        Phoenix.Token.sign(
           FountainWeb.Endpoint,
           "password_reset",
           {user.id, user.session_version},
           signed_at: 0
         )
 
-      conn = post(conn, ~p"/auth/reset", %{"token" => expired_token, "password" => "newpassword123"})
+      conn =
+        post(conn, ~p"/auth/reset", %{"token" => expired_token, "password" => "newpassword123"})
+
       assert redirected_to(conn) == ~p"/auth/forgot-password"
     end
 
@@ -124,7 +150,13 @@ defmodule FountainWeb.PasswordResetControllerTest do
     # forwarded mail, proxy log) could re-reset the password.
     test "a token cannot be replayed after a successful reset", %{conn: conn} do
       user = insert_verified_user()
-      token = Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version})
+
+      token =
+        Phoenix.Token.sign(
+          FountainWeb.Endpoint,
+          "password_reset",
+          {user.id, user.session_version}
+        )
 
       conn1 = post(conn, ~p"/auth/reset", %{"token" => token, "password" => "newpassword123"})
       assert redirected_to(conn1) == ~p"/auth/login"
@@ -142,15 +174,28 @@ defmodule FountainWeb.PasswordResetControllerTest do
 
     test "any token issued before the last successful reset is dead", %{conn: conn} do
       user = insert_verified_user()
-      sign = fn -> Phoenix.Token.sign(FountainWeb.Endpoint, "password_reset", {user.id, user.session_version}) end
+
+      sign = fn ->
+        Phoenix.Token.sign(
+          FountainWeb.Endpoint,
+          "password_reset",
+          {user.id, user.session_version}
+        )
+      end
+
       earlier_token = sign.()
       used_token = sign.()
 
       assert redirected_to(
-               post(conn, ~p"/auth/reset", %{"token" => used_token, "password" => "newpassword123"})
+               post(conn, ~p"/auth/reset", %{
+                 "token" => used_token,
+                 "password" => "newpassword123"
+               })
              ) == ~p"/auth/login"
 
-      conn = post(conn, ~p"/auth/reset", %{"token" => earlier_token, "password" => "otherpass123"})
+      conn =
+        post(conn, ~p"/auth/reset", %{"token" => earlier_token, "password" => "otherpass123"})
+
       assert redirected_to(conn) == ~p"/auth/forgot-password"
     end
 

--- a/apps/fountain/test/fountain_web/controllers/registration_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/registration_controller_test.exs
@@ -82,7 +82,10 @@ defmodule FountainWeb.RegistrationControllerTest do
       conn =
         conn
         |> Plug.Conn.put_req_header("content-type", "application/json")
-        |> post("/api/auth/register", Jason.encode!(%{email: "json@example.com", password: "password123"}))
+        |> post(
+          "/api/auth/register",
+          Jason.encode!(%{email: "json@example.com", password: "password123"})
+        )
 
       assert json_response(conn, 201)["message"] =~ "verify"
       user = Fountain.Accounts.get_user_by_email("json@example.com")
@@ -104,7 +107,10 @@ defmodule FountainWeb.RegistrationControllerTest do
       conn =
         conn
         |> Plug.Conn.put_req_header("content-type", "application/json")
-        |> post("/api/auth/register", Jason.encode!(%{email: "taken_json@example.com", password: "password123"}))
+        |> post(
+          "/api/auth/register",
+          Jason.encode!(%{email: "taken_json@example.com", password: "password123"})
+        )
 
       assert json_response(conn, 422)
     end
@@ -214,7 +220,10 @@ defmodule FountainWeb.RegistrationControllerTest do
       # test runs synchronously to avoid interference.
       for i <- 1..5 do
         post(conn, ~p"/auth/register", %{
-          "user" => %{"email" => "rate#{i}+#{System.unique_integer()}@example.com", "password" => "password123"}
+          "user" => %{
+            "email" => "rate#{i}+#{System.unique_integer()}@example.com",
+            "password" => "password123"
+          }
         })
       end
 

--- a/apps/fountain/test/fountain_web/controllers/secret_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/secret_controller_test.exs
@@ -8,7 +8,11 @@ defmodule FountainWeb.SecretControllerTest do
   end
 
   describe "GET /api/environments/:environment_id/secrets" do
-    test "returns 200 with a list of secrets for the environment", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 with a list of secrets for the environment", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       env = insert_env(user_id: user.id)
       secret = insert_secret(env, key: "MY_KEY")
 
@@ -57,7 +61,10 @@ defmodule FountainWeb.SecretControllerTest do
       conn =
         conn
         |> authed_with_key(raw_key)
-        |> post_json("/api/environments/#{other_env.id}/secrets", %{key: "DB_PASSWORD", value: "s3cr3t"})
+        |> post_json("/api/environments/#{other_env.id}/secrets", %{
+          key: "DB_PASSWORD",
+          value: "s3cr3t"
+        })
 
       assert json_response(conn, 404)
     end
@@ -89,7 +96,11 @@ defmodule FountainWeb.SecretControllerTest do
       assert json_response(conn, 404)
     end
 
-    test "returns 404 when the secret key does not exist", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 404 when the secret key does not exist", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       env = insert_env(user_id: user.id)
 
       conn =

--- a/apps/fountain/test/fountain_web/controllers/session_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/session_controller_test.exs
@@ -52,5 +52,4 @@ defmodule FountainWeb.SessionControllerTest do
       refute body =~ "unavailable"
     end
   end
-
 end

--- a/apps/fountain/test/fountain_web/controllers/turn_image_serve_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/turn_image_serve_test.exs
@@ -29,7 +29,12 @@ defmodule FountainWeb.TurnImageServeTest do
         %{media_type: "image/png", data: @png}
       ])
 
-    %{conn: conn, user: user, key: raw_key, path: "/conversations/#{conv.id}/turns/#{turn.id}/images/0"}
+    %{
+      conn: conn,
+      user: user,
+      key: raw_key,
+      path: "/conversations/#{conv.id}/turns/#{turn.id}/images/0"
+    }
   end
 
   describe "bearer route — Accept negotiation" do

--- a/apps/fountain/test/fountain_web/controllers/vault_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/vault_controller_test.exs
@@ -37,7 +37,11 @@ defmodule FountainWeb.VaultControllerTest do
   end
 
   describe "GET /api/vaults/:id" do
-    test "returns 200 with the vault for the authenticated user", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 with the vault for the authenticated user", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       vault = insert_vault(user_id: user.id)
 
       conn = conn |> authed_with_key(raw_key) |> get("/api/vaults/#{vault.id}")

--- a/apps/fountain/test/fountain_web/controllers/vault_secret_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/vault_secret_controller_test.exs
@@ -8,7 +8,11 @@ defmodule FountainWeb.VaultSecretControllerTest do
   end
 
   describe "GET /api/vaults/:vault_id/secrets" do
-    test "returns 200 with a list of secrets for the vault", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 200 with a list of secrets for the vault", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       vault = insert_vault(user_id: user.id)
       secret = insert_vault_secret(vault, key: "MY_KEY")
 
@@ -58,7 +62,11 @@ defmodule FountainWeb.VaultSecretControllerTest do
   end
 
   describe "DELETE /api/vaults/:vault_id/secrets/:id" do
-    test "deletes a vault secret by key and returns 204", %{conn: conn, user: user, raw_key: raw_key} do
+    test "deletes a vault secret by key and returns 204", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       vault = insert_vault(user_id: user.id)
       secret = insert_vault_secret(vault, key: "TO_DELETE")
 
@@ -83,7 +91,11 @@ defmodule FountainWeb.VaultSecretControllerTest do
       assert json_response(conn, 404)
     end
 
-    test "returns 404 when the secret key does not exist", %{conn: conn, user: user, raw_key: raw_key} do
+    test "returns 404 when the secret key does not exist", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
       vault = insert_vault(user_id: user.id)
 
       conn =

--- a/apps/fountain/test/fountain_web/live/admin_conversation_detail_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_conversation_detail_live_test.exs
@@ -71,9 +71,7 @@ defmodule FountainWeb.AdminConversationDetailLiveTest do
       {:ok, _lv, _html} = live(conn, ~p"/admin/conversations/#{conv.id}")
 
       assert [event] =
-               Repo.all(
-                 from e in AdminEvent, where: e.event_type == "admin.conversation.viewed"
-               )
+               Repo.all(from e in AdminEvent, where: e.event_type == "admin.conversation.viewed")
 
       assert event.actor_user_id == admin.id
       assert event.target_user_id == target.id

--- a/apps/fountain/test/fountain_web/live/audit_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/audit_live_test.exs
@@ -151,7 +151,12 @@ defmodule FountainWeb.AuditLiveTest do
 
       html =
         lv
-        |> form("#audit-filters", %{"action" => "vault.", "resource" => "", "since" => "", "until" => ""})
+        |> form("#audit-filters", %{
+          "action" => "vault.",
+          "resource" => "",
+          "since" => "",
+          "until" => ""
+        })
         |> render_change()
 
       assert html =~ "vaultvau"

--- a/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
@@ -12,14 +12,22 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
       %{user: user, conversation: conversation}
     end
 
-    test "mounts with default pretty mode when no preference saved", %{conn: conn, user: user, conversation: conversation} do
+    test "mounts with default pretty mode when no preference saved", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
       conn = login_user(conn, user)
       {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
 
       assert view |> element("[data-view-mode]") |> render() =~ "pretty"
     end
 
-    test "mounts with chat mode when preference is saved as chat", %{conn: conn, user: user, conversation: conversation} do
+    test "mounts with chat mode when preference is saved as chat", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
       {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversation_view_mode: "chat"})
       user = Fountain.Accounts.get_user!(user.id)
 
@@ -29,7 +37,11 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
       assert view |> element("[data-view-mode]") |> render() =~ "chat"
     end
 
-    test "mounts with raw mode when preference is saved as raw", %{conn: conn, user: user, conversation: conversation} do
+    test "mounts with raw mode when preference is saved as raw", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
       {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversation_view_mode: "raw"})
       user = Fountain.Accounts.get_user!(user.id)
 
@@ -48,7 +60,11 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
     end
 
     @tag :push_view_mode_changed
-    test "pushes view_mode_changed event to client when mode is set", %{conn: conn, user: user, conversation: conversation} do
+    test "pushes view_mode_changed event to client when mode is set", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
       conn = login_user(conn, user)
       {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
 
@@ -56,7 +72,11 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
       assert_push_event(view, "view_mode_changed", %{mode: "chat"})
     end
 
-    test "persists view mode to database when changed", %{conn: conn, user: user, conversation: conversation} do
+    test "persists view mode to database when changed", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
       conn = login_user(conn, user)
       {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
 
@@ -208,7 +228,11 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
       %{user: user, conversation: conversation}
     end
 
-    test "toggling stdout off persists the preference", %{conn: conn, user: user, conversation: conversation} do
+    test "toggling stdout off persists the preference", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
       conn = login_user(conn, user)
       {:ok, view, _html} = live(conn, ~p"/conversations/#{conversation.id}")
 
@@ -220,8 +244,16 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
       assert "stage" in reloaded.conversation_visible_streams
     end
 
-    test "toggling stdout back on persists the preference", %{conn: conn, user: user, conversation: conversation} do
-      {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversation_visible_streams: ["stderr", "stage"]})
+    test "toggling stdout back on persists the preference", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
+      {:ok, _} =
+        Fountain.Accounts.update_preferences(user, %{
+          conversation_visible_streams: ["stderr", "stage"]
+        })
+
       user = Fountain.Accounts.get_user!(user.id)
 
       conn = login_user(conn, user)
@@ -233,8 +265,14 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
       assert "stdout" in reloaded.conversation_visible_streams
     end
 
-    test "mounts with saved visible_streams preference", %{conn: conn, user: user, conversation: conversation} do
-      {:ok, _} = Fountain.Accounts.update_preferences(user, %{conversation_visible_streams: ["stdout"]})
+    test "mounts with saved visible_streams preference", %{
+      conn: conn,
+      user: user,
+      conversation: conversation
+    } do
+      {:ok, _} =
+        Fountain.Accounts.update_preferences(user, %{conversation_visible_streams: ["stdout"]})
+
       user = Fountain.Accounts.get_user!(user.id)
 
       conn = login_user(conn, user)

--- a/apps/fountain/test/fountain_web/live/hooks_test.exs
+++ b/apps/fountain/test/fountain_web/live/hooks_test.exs
@@ -242,7 +242,10 @@ defmodule FountainWeb.Live.HooksTest do
     end
 
     @tag :push_roots_only_changed
-    test "sidebar_toggle_roots_only pushes roots_only_changed with value true", %{conn: conn, user: user} do
+    test "sidebar_toggle_roots_only pushes roots_only_changed with value true", %{
+      conn: conn,
+      user: user
+    } do
       conn = login_user(conn, user)
       {:ok, view, _html} = live(conn, ~p"/conversations")
 
@@ -251,7 +254,8 @@ defmodule FountainWeb.Live.HooksTest do
     end
 
     @tag :push_roots_only_changed
-    test "sidebar_toggle_roots_only pushes roots_only_changed with value false when toggled twice", %{conn: conn, user: user} do
+    test "sidebar_toggle_roots_only pushes roots_only_changed with value false when toggled twice",
+         %{conn: conn, user: user} do
       conn = login_user(conn, user)
       {:ok, view, _html} = live(conn, ~p"/conversations")
 

--- a/apps/fountain/test/fountain_web/live/log_viewer_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/log_viewer_live_test.exs
@@ -92,7 +92,14 @@ defmodule FountainWeb.LogViewerLiveTest do
     test "stage event kind renders [stage:X:Y] format", %{conn: conn} do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)
-      insert_log_event(conv, kind: "stage", stream: "", stage: "provision", state: "started", data: "")
+
+      insert_log_event(conv,
+        kind: "stage",
+        stream: "",
+        stage: "provision",
+        state: "started",
+        data: ""
+      )
 
       conn = login_user(conn, user)
       {:ok, _lv, html} = live(conn, ~p"/conversations/#{conv.id}/logs")

--- a/apps/fountain/test/fountain_web/live/onboarding_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/onboarding_live_test.exs
@@ -9,6 +9,7 @@ defmodule FountainWeb.OnboardingLiveTest do
       {:ok, completed_user} = Fountain.Accounts.complete_onboarding(user)
 
       conn = login_user(conn, completed_user)
+
       assert {:error, {:live_redirect, %{to: "/dashboard"}}} =
                live(conn, ~p"/onboarding/step_1")
     end
@@ -28,7 +29,9 @@ defmodule FountainWeb.OnboardingLiveTest do
     end
 
     # Exercises mount(_params, ...) — no step key in params
-    test "visiting /onboarding (no step) for incomplete user redirects to current step", %{conn: conn} do
+    test "visiting /onboarding (no step) for incomplete user redirects to current step", %{
+      conn: conn
+    } do
       user = insert_verified_user()
       conn = login_user(conn, user)
 
@@ -38,7 +41,9 @@ defmodule FountainWeb.OnboardingLiveTest do
                live(conn, ~p"/onboarding")
     end
 
-    test "visiting /onboarding (no step) for completed user redirects to /dashboard", %{conn: conn} do
+    test "visiting /onboarding (no step) for completed user redirects to /dashboard", %{
+      conn: conn
+    } do
       user = insert_verified_user()
       {:ok, completed_user} = Fountain.Accounts.complete_onboarding(user)
 
@@ -48,7 +53,9 @@ defmodule FountainWeb.OnboardingLiveTest do
                live(conn, ~p"/onboarding")
     end
 
-    test "visiting /onboarding (no step) for user mid-wizard redirects to their current step", %{conn: conn} do
+    test "visiting /onboarding (no step) for user mid-wizard redirects to their current step", %{
+      conn: conn
+    } do
       user = insert_verified_user()
       {:ok, user} = Fountain.Accounts.advance_onboarding(user, "step_2")
 
@@ -238,14 +245,20 @@ defmodule FountainWeb.OnboardingLiveCredentialTest do
     end
 
     test "save_credential with empty value shows error", %{lv: lv} do
-      html = render_click(lv, "save_credential", %{"provider" => "anthropic_api_key", "value" => ""})
+      html =
+        render_click(lv, "save_credential", %{"provider" => "anthropic_api_key", "value" => ""})
+
       assert html =~ "Paste a value before saving."
     end
 
     test "save_credential with invalid key shows provider-rejection error", %{lv: lv} do
       stub(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 401}} end)
 
-      html = render_click(lv, "save_credential", %{"provider" => "anthropic_api_key", "value" => "bad-key"})
+      html =
+        render_click(lv, "save_credential", %{
+          "provider" => "anthropic_api_key",
+          "value" => "bad-key"
+        })
 
       assert html =~ "Provider rejected the credential"
       assert html =~ "HTTP 401"
@@ -254,7 +267,11 @@ defmodule FountainWeb.OnboardingLiveCredentialTest do
     test "save_credential with valid anthropic key shows saved message", %{lv: lv} do
       stub(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 200}} end)
 
-      html = render_click(lv, "save_credential", %{"provider" => "anthropic_api_key", "value" => "sk-ant-valid-key"})
+      html =
+        render_click(lv, "save_credential", %{
+          "provider" => "anthropic_api_key",
+          "value" => "sk-ant-valid-key"
+        })
 
       assert html =~ "Saved and validated."
     end
@@ -264,7 +281,11 @@ defmodule FountainWeb.OnboardingLiveCredentialTest do
         {:error, %Mint.TransportError{reason: :timeout}}
       end)
 
-      html = render_click(lv, "save_credential", %{"provider" => "anthropic_api_key", "value" => "sk-ant-any-key"})
+      html =
+        render_click(lv, "save_credential", %{
+          "provider" => "anthropic_api_key",
+          "value" => "sk-ant-any-key"
+        })
 
       assert html =~ "Validation timed out"
     end
@@ -274,7 +295,11 @@ defmodule FountainWeb.OnboardingLiveCredentialTest do
         {:error, %Mint.TransportError{reason: :econnrefused}}
       end)
 
-      html = render_click(lv, "save_credential", %{"provider" => "anthropic_api_key", "value" => "sk-ant-any-key"})
+      html =
+        render_click(lv, "save_credential", %{
+          "provider" => "anthropic_api_key",
+          "value" => "sk-ant-any-key"
+        })
 
       assert html =~ "Could not reach provider"
     end

--- a/apps/fountain/test/fountain_web/live/secret_forms_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/secret_forms_live_test.exs
@@ -39,7 +39,8 @@ defmodule FountainWeb.SecretFormsLiveTest do
       {:ok, view, _html} = live(conn, ~p"/environments/#{env.id}/edit")
       refute_in_state(view, dek)
 
-      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => value}})
+      html =
+        render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => value}})
 
       assert html =~ "Secret saved"
       refute_in_state(view, dek)
@@ -51,7 +52,8 @@ defmodule FountainWeb.SecretFormsLiveTest do
       {:ok, view, html} = live(conn, ~p"/environments/#{env.id}/edit")
       assert html =~ "env-secret-form-0"
 
-      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => "v1"}})
+      html =
+        render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => "v1"}})
 
       assert html =~ "TOKEN"
       # The versioned form id is the reset mechanism for the uncontrolled
@@ -96,7 +98,8 @@ defmodule FountainWeb.SecretFormsLiveTest do
       {:ok, view, _html} = live(conn, ~p"/vaults/#{vault.id}/edit")
       refute_in_state(view, dek)
 
-      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => value}})
+      html =
+        render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => value}})
 
       assert html =~ "Secret saved"
       refute_in_state(view, dek)
@@ -108,7 +111,8 @@ defmodule FountainWeb.SecretFormsLiveTest do
       {:ok, view, html} = live(conn, ~p"/vaults/#{vault.id}/edit")
       assert html =~ "vault-secret-form-0"
 
-      html = render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => "v1"}})
+      html =
+        render_submit(view, "add_secret", %{"secret" => %{"key" => "TOKEN", "value" => "v1"}})
 
       assert html =~ "TOKEN"
       assert html =~ "vault-secret-form-1"

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -389,7 +389,8 @@ defmodule FountainWeb.MetricsTest do
       Process.sleep(50)
       {200, body} = scrape()
 
-      series = ~s(fountain_turn_completed_duration_ms_bucket{runtime="opencode",status="completed")
+      series =
+        ~s(fountain_turn_completed_duration_ms_bucket{runtime="opencode",status="completed")
 
       # 42s lands above the 30s boundary and below 60s. A duration handed over
       # in seconds or in native units lands in a different bucket entirely.

--- a/apps/fountain/test/fountain_web/plugs/audit_plug_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/audit_plug_test.exs
@@ -40,7 +40,12 @@ defmodule FountainWeb.Plugs.AuditTest do
       user = insert_verified_user()
 
       conn
-      |> Map.merge(%{method: "POST", request_path: "/api/conversations", path_info: ["api", "conversations"], params: %{}})
+      |> Map.merge(%{
+        method: "POST",
+        request_path: "/api/conversations",
+        path_info: ["api", "conversations"],
+        params: %{}
+      })
       |> Map.put(:remote_ip, {127, 0, 0, 1})
       |> Plug.Conn.assign(:current_user, user)
       |> Audit.call([])
@@ -54,7 +59,12 @@ defmodule FountainWeb.Plugs.AuditTest do
       id = Ecto.UUID.generate()
 
       conn
-      |> Map.merge(%{method: "PUT", request_path: "/api/agents/#{id}", path_info: ["api", "agents", id], params: %{}})
+      |> Map.merge(%{
+        method: "PUT",
+        request_path: "/api/agents/#{id}",
+        path_info: ["api", "agents", id],
+        params: %{}
+      })
       |> Map.put(:remote_ip, {127, 0, 0, 1})
       |> Plug.Conn.assign(:current_user, user)
       |> Audit.call([])
@@ -68,7 +78,12 @@ defmodule FountainWeb.Plugs.AuditTest do
       id = Ecto.UUID.generate()
 
       conn
-      |> Map.merge(%{method: "PATCH", request_path: "/api/agents/#{id}", path_info: ["api", "agents", id], params: %{}})
+      |> Map.merge(%{
+        method: "PATCH",
+        request_path: "/api/agents/#{id}",
+        path_info: ["api", "agents", id],
+        params: %{}
+      })
       |> Map.put(:remote_ip, {127, 0, 0, 1})
       |> Plug.Conn.assign(:current_user, user)
       |> Audit.call([])
@@ -82,7 +97,12 @@ defmodule FountainWeb.Plugs.AuditTest do
       id = Ecto.UUID.generate()
 
       conn
-      |> Map.merge(%{method: "DELETE", request_path: "/api/agents/#{id}", path_info: ["api", "agents", id], params: %{}})
+      |> Map.merge(%{
+        method: "DELETE",
+        request_path: "/api/agents/#{id}",
+        path_info: ["api", "agents", id],
+        params: %{}
+      })
       |> Map.put(:remote_ip, {127, 0, 0, 1})
       |> Plug.Conn.assign(:current_user, user)
       |> Audit.call([])
@@ -232,7 +252,12 @@ defmodule FountainWeb.Plugs.AuditTest do
       user = insert_verified_user()
 
       conn
-      |> Map.merge(%{method: "POST", request_path: "/api/conversations", path_info: ["api", "conversations"], params: %{}})
+      |> Map.merge(%{
+        method: "POST",
+        request_path: "/api/conversations",
+        path_info: ["api", "conversations"],
+        params: %{}
+      })
       |> Map.put(:remote_ip, nil)
       |> Plug.Conn.assign(:current_user, user)
       |> Audit.call([])
@@ -245,7 +270,12 @@ defmodule FountainWeb.Plugs.AuditTest do
       user = insert_verified_user()
 
       conn
-      |> Map.merge(%{method: "POST", request_path: "/api/conversations", path_info: ["api", "conversations"], params: %{}})
+      |> Map.merge(%{
+        method: "POST",
+        request_path: "/api/conversations",
+        path_info: ["api", "conversations"],
+        params: %{}
+      })
       |> Map.put(:remote_ip, "192.168.1.1")
       |> Plug.Conn.assign(:current_user, user)
       |> Audit.call([])

--- a/apps/fountain/test/fountain_web/schemas_test.exs
+++ b/apps/fountain/test/fountain_web/schemas_test.exs
@@ -30,7 +30,9 @@ defmodule FountainWeb.SchemasTest do
     documented = conversation_schema().properties |> Map.keys() |> MapSet.new()
 
     missing = MapSet.difference(emitted, documented)
-    assert MapSet.size(missing) == 0, "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
+
+    assert MapSet.size(missing) == 0,
+           "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
   end
 
   # #571 brought the API-key views into the spec. Same drift guard: the
@@ -46,7 +48,9 @@ defmodule FountainWeb.SchemasTest do
         FountainWeb.Schemas.ApiKey.schema().properties |> Map.keys() |> MapSet.new()
 
       missing = MapSet.difference(emitted |> Map.keys() |> MapSet.new(), documented)
-      assert MapSet.size(missing) == 0, "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
+
+      assert MapSet.size(missing) == 0,
+             "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
     end
 
     test "the listing schema has no field that could carry key material" do
@@ -59,10 +63,14 @@ defmodule FountainWeb.SchemasTest do
       emitted = FountainWeb.ApiKeyJSON.created(%{key: api_key(), raw_key: "ftn_abc_secret"})
 
       documented =
-        FountainWeb.Schemas.ApiKeyCreatedResponse.schema().properties |> Map.keys() |> MapSet.new()
+        FountainWeb.Schemas.ApiKeyCreatedResponse.schema().properties
+        |> Map.keys()
+        |> MapSet.new()
 
       missing = MapSet.difference(emitted |> Map.keys() |> MapSet.new(), documented)
-      assert MapSet.size(missing) == 0, "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
+
+      assert MapSet.size(missing) == 0,
+             "emitted but undocumented: #{inspect(MapSet.to_list(missing))}"
     end
   end
 end


### PR DESCRIPTION
Closes #612.

`mix format --check-formatted` is step 2 of CI and part of `mix precommit`, and
CLAUDE.md lists it as a core gate. It never looked at `apps/fountain` — the
entire application. 90 files had drifted.

## Cause

Every glob in the root `.formatter.exs` was root-relative, and the umbrella root
has no `lib/`, `test/` or `priv/*/` of its own. Three entries pointed at a
layout that does not exist there:

| entry | what it actually matched |
|---|---|
| `{config,lib,test}/**/*.{ex,exs}` | `config/` only |
| `priv/*/seeds.exs` | nothing — seeds are `apps/fountain/priv/repo/seeds.exs` |
| `subdirectories: ["priv/*/migrations"]` | nothing — migrations are under `apps/fountain/priv/` |

`mix format` reaches umbrella children through each child's own
`.formatter.exs`, and `apps/fountain` had none, so it was never visited. The
explicit `ee/**` entry is the tell: when the ee boundary moved to the top level
(#472) it would otherwise have fallen outside the inputs and was added by hand.
`apps/` was already outside and stayed there.

## Fix

Rather than bolt an `apps/*/...` glob onto the root, this does it the way
umbrellas are meant to work: the root recurses with `subdirectories: ["apps/*"]`
and `apps/fountain` carries its own `.formatter.exs` holding its `lib`, `test`,
migrations and seeds globs. The three dead root-relative entries move there with
them, which is also how the 3 unchecked migrations get picked up.

**Two commits, deliberately:** the config change alone, then nothing but the
`mix format` output. Review the first; the second is mechanical.

Not added: `import_deps: [:phoenix_live_view]`, which #612 suggested. Its
`.formatter.exs` has no `export:` section, so it would be inert — `:phoenix`
already exports the LiveView locals (`attr`, `slot`, `on_mount`, `live`,
`assert_patch`, …). Also out of scope: the `Phoenix.LiveView.HTMLFormatter`
plugin. No `plugins:` is configured anywhere, so the 6 `.heex` files are still
unformatted by anything; that is a separate sweep.

## Verification

The repro from the issue, before and after:

```console
# probe file under apps/fountain/lib          -> exit=1  (was 0)
# probe migration under apps/fountain/priv    -> exit=1  (was 0)
# clean tree                                  -> exit=0
```

Sweep is 32 `.ex` + 58 `.exs`, all under `apps/`; no file outside `apps/` is
touched. `mix compile --warnings-as-errors` clean, `mix credo --strict` no
issues, `mix test` 2423 tests / 5 doctests / 3 properties, 0 failures,
`mix deps.unlock --unused` no change. Dialyzer left to CI — a format sweep
preserves the AST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)