### PR TITLE
ci: bring HEEx markup inside the format gate (#618)

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,11 +1,12 @@
 [
   import_deps: [:ecto, :ecto_sql, :phoenix],
+  plugins: [Phoenix.LiveView.HTMLFormatter],
   # Umbrella children carry their own .formatter.exs; without this the globs
   # below (root-relative) would never reach apps/. See #612.
   subdirectories: ["apps/*"],
   inputs: [
-    "*.{ex,exs}",
-    "{config,lib,test}/**/*.{ex,exs}",
-    "ee/**/*.{ex,exs}"
+    "*.{heex,ex,exs}",
+    "{config,lib,test}/**/*.{heex,ex,exs}",
+    "ee/**/*.{heex,ex,exs}"
   ]
 ]

--- a/apps/fountain/.formatter.exs
+++ b/apps/fountain/.formatter.exs
@@ -1,8 +1,9 @@
 [
   import_deps: [:ecto, :ecto_sql, :phoenix],
+  plugins: [Phoenix.LiveView.HTMLFormatter],
   inputs: [
-    "*.{ex,exs}",
-    "{lib,test}/**/*.{ex,exs}",
+    "*.{heex,ex,exs}",
+    "{lib,test}/**/*.{heex,ex,exs}",
     "priv/repo/migrations/*.exs",
     "priv/repo/seeds.exs"
   ]

--- a/apps/fountain/lib/fountain_web/components/core_components.ex
+++ b/apps/fountain/lib/fountain_web/components/core_components.ex
@@ -99,7 +99,9 @@ defmodule FountainWeb.CoreComponents do
         @class
       ]}
       {@rest}
-    >{render_slot(@inner_block)}</button>
+    >
+      {render_slot(@inner_block)}
+    </button>
     """
   end
 
@@ -124,7 +126,9 @@ defmodule FountainWeb.CoreComponents do
         @class
       ]}
       {@rest}
-    >{render_slot(@inner_block)}</button>
+    >
+      {render_slot(@inner_block)}
+    </button>
     """
   end
 
@@ -147,7 +151,9 @@ defmodule FountainWeb.CoreComponents do
         @class
       ]}
       {@rest}
-    >{render_slot(@inner_block)}</button>
+    >
+      {render_slot(@inner_block)}
+    </button>
     """
   end
 
@@ -599,7 +605,9 @@ defmodule FountainWeb.CoreComponents do
         :if={@label}
         for={@id}
         class="block text-sm font-medium text-[var(--color-text-primary)]"
-      >{@label}</label>
+      >
+        {@label}
+      </label>
       <input
         :if={@type != "textarea"}
         type={@type}

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -167,7 +167,11 @@ defmodule FountainWeb.Layouts do
               phx-hook="RootsFilterPersist"
               type="button"
               phx-click="sidebar_toggle_roots_only"
-              title={if @sidebar_roots_only, do: "Showing roots only — click to show all", else: "Show root conversations only"}
+              title={
+                if @sidebar_roots_only,
+                  do: "Showing roots only — click to show all",
+                  else: "Show root conversations only"
+              }
               class={[
                 "shrink-0 inline-flex items-center gap-1 rounded px-2 py-1",
                 "text-[11px] font-medium leading-none transition-colors border",
@@ -329,11 +333,27 @@ defmodule FountainWeb.Layouts do
               aria-label="Toggle dark mode"
               class="shrink-0 mt-1 mr-1.5 rounded-md p-1.5 text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
             >
-              <svg id="theme-icon-moon" class="size-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <svg
+                id="theme-icon-moon"
+                class="size-4"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
                 <path d="M17.293 13.293A8 8 0 0 1 6.707 2.707a8.001 8.001 0 1 0 10.586 10.586z" />
               </svg>
-              <svg id="theme-icon-sun" class="size-4 hidden" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path fill-rule="evenodd" d="M10 2a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1Zm4 8a4 4 0 1 1-8 0 4 4 0 0 1 8 0Zm-.464 4.95.707.707a1 1 0 0 0 1.414-1.414l-.707-.707a1 1 0 0 0-1.414 1.414Zm2.12-10.607a1 1 0 0 1 0 1.414l-.706.707a1 1 0 1 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 0ZM17 11a1 1 0 1 0 0-2h-1a1 1 0 1 1 0 2h1Zm-7 4a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1ZM5.05 6.464A1 1 0 1 0 6.465 5.05l-.708-.707a1 1 0 0 0-1.414 1.414l.707.707Zm1.414 8.486-.707.707a1 1 0 0 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 1.414ZM4 11a1 1 0 1 0 0-2H3a1 1 0 0 0 0 2h1Z" clip-rule="evenodd" />
+              <svg
+                id="theme-icon-sun"
+                class="size-4 hidden"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M10 2a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1Zm4 8a4 4 0 1 1-8 0 4 4 0 0 1 8 0Zm-.464 4.95.707.707a1 1 0 0 0 1.414-1.414l-.707-.707a1 1 0 0 0-1.414 1.414Zm2.12-10.607a1 1 0 0 1 0 1.414l-.706.707a1 1 0 1 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 0ZM17 11a1 1 0 1 0 0-2h-1a1 1 0 1 1 0 2h1Zm-7 4a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1ZM5.05 6.464A1 1 0 1 0 6.465 5.05l-.708-.707a1 1 0 0 0-1.414 1.414l.707.707Zm1.414 8.486-.707.707a1 1 0 0 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 1.414ZM4 11a1 1 0 1 0 0-2H3a1 1 0 0 0 0 2h1Z"
+                  clip-rule="evenodd"
+                />
               </svg>
             </button>
           </div>
@@ -348,7 +368,11 @@ defmodule FountainWeb.Layouts do
               aria-label="Open navigation"
             >
               <svg class="size-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path fill-rule="evenodd" d="M2 4.75A.75.75 0 0 1 2.75 4h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 4.75ZM2 10a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 10Zm0 5.25a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" />
+                <path
+                  fill-rule="evenodd"
+                  d="M2 4.75A.75.75 0 0 1 2.75 4h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 4.75ZM2 10a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 10Zm0 5.25a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z"
+                  clip-rule="evenodd"
+                />
               </svg>
             </label>
             <span class="font-semibold text-sm text-[var(--color-text-primary)]">Fountain</span>
@@ -432,7 +456,8 @@ defmodule FountainWeb.Layouts do
         "block rounded-md px-3 py-1 text-sm transition-colors",
         if(@active,
           do: "bg-[var(--color-bg-2)] font-medium text-[var(--color-text-primary)]",
-          else: "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)]"
+          else:
+            "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)]"
         )
       ]}
     >
@@ -494,7 +519,8 @@ defmodule FountainWeb.Layouts do
         "block rounded-md px-3 py-1.5 text-sm transition-colors",
         if(@active,
           do: "bg-[var(--color-bg-2)] text-[var(--color-text-primary)]",
-          else: "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)]"
+          else:
+            "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)]"
         )
       ]}
     >
@@ -503,11 +529,15 @@ defmodule FountainWeb.Layouts do
         :if={@task_label}
         class="block truncate text-[13px] text-[var(--color-text-primary)]"
         title={@task_label}
-      >{@task_label}</span>
+      >
+        {@task_label}
+      </span>
       <span
         :if={!@task_label}
         class="block truncate italic text-[11px] text-[var(--color-text-muted)]"
-      >(no task yet)</span>
+      >
+        (no task yet)
+      </span>
 
       <%!-- Line 2: small avatar + subtitle + badges --%>
       <span class="flex items-center gap-1.5 mt-0.5">
@@ -543,7 +573,9 @@ defmodule FountainWeb.Layouts do
           <span
             :if={@subtitle != ""}
             class="flex-1 min-w-0 text-[11px] text-[var(--color-text-muted)] truncate"
-          >{@subtitle}</span>
+          >
+            {@subtitle}
+          </span>
           <span class="ml-auto shrink-0 flex items-center gap-1">
             <span
               :if={@turn_count > 0}
@@ -554,7 +586,11 @@ defmodule FountainWeb.Layouts do
               title={~s(#{@turn_count} #{if @turn_count == 1, do: ~s(turn), else: ~s(turns)})}
             >
               <svg class="size-2.5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                <path fill-rule="evenodd" d="M1 2.75A.75.75 0 0 1 1.75 2h12.5a.75.75 0 0 1 .75.75v8.5a.75.75 0 0 1-.75.75h-6.5L5 14v-2H1.75a.75.75 0 0 1-.75-.75v-8.5Z" clip-rule="evenodd" />
+                <path
+                  fill-rule="evenodd"
+                  d="M1 2.75A.75.75 0 0 1 1.75 2h12.5a.75.75 0 0 1 .75.75v8.5a.75.75 0 0 1-.75.75h-6.5L5 14v-2H1.75a.75.75 0 0 1-.75-.75v-8.5Z"
+                  clip-rule="evenodd"
+                />
               </svg>
               {@turn_count}
             </span>

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -40,17 +40,41 @@
   <%!-- Footer --%>
   <footer class="border-t border-[var(--color-border)] bg-[var(--color-bg-1)]">
     <div class="max-w-5xl mx-auto px-6 py-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-[var(--color-text-muted)]">
-      <span>© 2026 Fountain. Managed agent infrastructure for teams who'd rather build than configure.</span>
+      <span>
+        © 2026 Fountain. Managed agent infrastructure for teams who'd rather build than configure.
+      </span>
       <div class="flex items-center gap-4">
         <%= if Fountain.Legal.published?() do %>
-          <a href={~p"/terms"} class="hover:text-[var(--color-text-secondary)] transition-colors">Terms</a>
-          <a href={~p"/privacy"} class="hover:text-[var(--color-text-secondary)] transition-colors">Privacy</a>
+          <a href={~p"/terms"} class="hover:text-[var(--color-text-secondary)] transition-colors">
+            Terms
+          </a>
+          <a
+            href={~p"/privacy"}
+            class="hover:text-[var(--color-text-secondary)] transition-colors"
+          >
+            Privacy
+          </a>
         <% end %>
         <%= if @current_user do %>
-          <a href={~p"/conversations"} class="hover:text-[var(--color-text-secondary)] transition-colors">Go to app</a>
+          <a
+            href={~p"/conversations"}
+            class="hover:text-[var(--color-text-secondary)] transition-colors"
+          >
+            Go to app
+          </a>
         <% else %>
-          <a href={~p"/auth/login"} class="hover:text-[var(--color-text-secondary)] transition-colors">Sign in</a>
-          <a href={~p"/auth/register"} class="hover:text-[var(--color-text-secondary)] transition-colors">Register</a>
+          <a
+            href={~p"/auth/login"}
+            class="hover:text-[var(--color-text-secondary)] transition-colors"
+          >
+            Sign in
+          </a>
+          <a
+            href={~p"/auth/register"}
+            class="hover:text-[var(--color-text-secondary)] transition-colors"
+          >
+            Register
+          </a>
         <% end %>
       </div>
     </div>

--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -2,7 +2,9 @@
 <html
   lang="en"
   id="app-html"
-  data-theme={if Map.get(assigns[:current_user] || %{}, :theme_preference) == "dark", do: "dark", else: ""}
+  data-theme={
+    if Map.get(assigns[:current_user] || %{}, :theme_preference) == "dark", do: "dark", else: ""
+  }
 >
   <head>
     <meta charset="utf-8" />
@@ -34,11 +36,20 @@
         }
       };
     </script>
-    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
-    <script>window.addEventListener("phx:reload", () => location.reload());</script>
-    <script defer src="https://cdn.jsdelivr.net/npm/phoenix@1.8.7/priv/static/phoenix.min.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/phoenix_live_view@1.1.30/priv/static/phoenix_live_view.min.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+    <script src="https://cdn.tailwindcss.com?plugins=typography">
+    </script>
+    <script>
+      window.addEventListener("phx:reload", () => location.reload());
+    </script>
+    <script defer src="https://cdn.jsdelivr.net/npm/phoenix@1.8.7/priv/static/phoenix.min.js">
+    </script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/phoenix_live_view@1.1.30/priv/static/phoenix_live_view.min.js"
+    >
+    </script>
+    <script defer src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js">
+    </script>
     <script defer>
       document.addEventListener("DOMContentLoaded", () => {
         const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
@@ -361,58 +372,88 @@
             onclick="document.getElementById('kbd-cheatsheet').classList.add('hidden')"
             class="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] text-xl leading-none"
             aria-label="Close cheatsheet"
-          >&times;</button>
+          >
+            &times;
+          </button>
         </div>
         <div class="px-6 py-4 space-y-5 text-sm">
           <div>
-            <div class="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide mb-2">Global</div>
+            <div class="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide mb-2">
+              Global
+            </div>
             <div class="space-y-2">
               <div class="flex items-center justify-between">
                 <span class="text-[var(--color-text-secondary)]">Toggle this cheatsheet</span>
-                <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">?</kbd>
+                <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                  ?
+                </kbd>
               </div>
             </div>
           </div>
           <div>
-            <div class="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide mb-2">Navigate (g then&hellip;)</div>
+            <div class="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide mb-2">
+              Navigate (g then&hellip;)
+            </div>
             <div class="space-y-2">
               <div class="flex items-center justify-between">
                 <span class="text-[var(--color-text-secondary)]">New conversation</span>
                 <span class="flex gap-1">
-                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">g</kbd>
-                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">c</kbd>
+                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                    g
+                  </kbd>
+                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                    c
+                  </kbd>
                 </span>
               </div>
               <div class="flex items-center justify-between">
                 <span class="text-[var(--color-text-secondary)]">Agents</span>
                 <span class="flex gap-1">
-                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">g</kbd>
-                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">a</kbd>
+                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                    g
+                  </kbd>
+                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                    a
+                  </kbd>
                 </span>
               </div>
               <div class="flex items-center justify-between">
                 <span class="text-[var(--color-text-secondary)]">Environments</span>
                 <span class="flex gap-1">
-                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">g</kbd>
-                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">e</kbd>
+                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                    g
+                  </kbd>
+                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                    e
+                  </kbd>
                 </span>
               </div>
               <div class="flex items-center justify-between">
                 <span class="text-[var(--color-text-secondary)]">Vaults</span>
                 <span class="flex gap-1">
-                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">g</kbd>
-                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-bg-2)] rounded text-xs font-mono">v</kbd>
+                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                    g
+                  </kbd>
+                  <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-bg-2)] rounded text-xs font-mono">
+                    v
+                  </kbd>
                 </span>
               </div>
             </div>
           </div>
           <div>
-            <div class="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide mb-2">Forms</div>
+            <div class="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide mb-2">
+              Forms
+            </div>
             <div class="flex items-center justify-between">
               <span class="text-[var(--color-text-secondary)]">Submit (from textarea)</span>
               <span class="flex gap-1 items-center">
-                <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">&#8984;</kbd>
-                <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">Enter</kbd>
+                <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                  &#8984;
+                </kbd>
+                <kbd class="px-2 py-0.5 bg-[var(--color-bg-2)] border border-[var(--color-border)] rounded text-xs font-mono">
+                  Enter
+                </kbd>
               </span>
             </div>
           </div>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -44,11 +44,10 @@
       <li class="flex items-start gap-3">
         <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
         <span>
-          API keys expire mid-sprint with no single source of truth — the wrong
-          <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">
-            .env
-          </code>
-          silently breaks the agent.
+          API keys expire mid-sprint with no single source of truth — the wrong <code
+            class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm"
+            phx-no-format
+          >.env</code> silently breaks the agent.
         </span>
       </li>
       <li class="flex items-start gap-3">
@@ -135,11 +134,10 @@
         Debug in seconds, not sessions
       </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Every conversation's stdout, stderr, and lifecycle events stream live in the dashboard. No
-        <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
-          curl -N
-        </code>
-        to a raw SSE endpoint, no log pipeline to stand up. Click a conversation and see exactly what happened.
+        Every conversation's stdout, stderr, and lifecycle events stream live in the dashboard. No <code
+          class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
+          phx-no-format
+        >curl -N</code> to a raw SSE endpoint, no log pipeline to stand up. Click a conversation and see exactly what happened.
       </p>
     </div>
 
@@ -159,11 +157,10 @@
         Script it, click it, or pipe it to CI
       </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        REST API for automation, a LiveView dashboard for hands-on work, and an
-        <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
-          aod
-        </code>
-        CLI for pipelines — all reading and writing the same Environments, Agents, and Conversations. Pick the interface that fits the job.
+        REST API for automation, a LiveView dashboard for hands-on work, and an <code
+          class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
+          phx-no-format
+        >aod</code> CLI for pipelines — all reading and writing the same Environments, Agents, and Conversations. Pick the interface that fits the job.
       </p>
     </div>
   </div>
@@ -175,11 +172,10 @@
     <div class="grid sm:grid-cols-2 gap-10">
       <figure>
         <blockquote class="text-[var(--color-text-primary)] leading-relaxed mb-4">
-          "We were maintaining three separate
-          <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">
-            .env
-          </code>
-          files and a shared Notion doc to keep our agent configs in sync. Fountain replaced all of it. Onboarding the last two engineers took ten minutes each."
+          "We were maintaining three separate <code
+            class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm"
+            phx-no-format
+          >.env</code> files and a shared Notion doc to keep our agent configs in sync. Fountain replaced all of it. Onboarding the last two engineers took ten minutes each."
         </blockquote>
         <figcaption class="text-sm text-[var(--color-text-muted)] font-medium">
           — Engineering lead, early access customer
@@ -187,11 +183,10 @@
       </figure>
       <figure>
         <blockquote class="text-[var(--color-text-primary)] leading-relaxed mb-4">
-          "I evaluated Fountain on a Friday afternoon and had a shared environment running for the whole team before dinner. The Vaults alone killed our 'which
-          <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">
-            .env
-          </code>
-          is current?' Slack thread."
+          "I evaluated Fountain on a Friday afternoon and had a shared environment running for the whole team before dinner. The Vaults alone killed our 'which <code
+            class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm"
+            phx-no-format
+          >.env</code> is current?' Slack thread."
         </blockquote>
         <figcaption class="text-sm text-[var(--color-text-muted)] font-medium">
           — Developer, early access customer

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -37,15 +37,25 @@
     <ul class="max-w-xl mx-auto space-y-4 text-[var(--color-text-secondary)]">
       <li class="flex items-start gap-3">
         <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
-        <span>New teammates spend afternoons reverse-engineering setup instead of writing code.</span>
+        <span>
+          New teammates spend afternoons reverse-engineering setup instead of writing code.
+        </span>
       </li>
       <li class="flex items-start gap-3">
         <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
-        <span>API keys expire mid-sprint with no single source of truth — the wrong <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">.env</code> silently breaks the agent.</span>
+        <span>
+          API keys expire mid-sprint with no single source of truth — the wrong
+          <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">
+            .env
+          </code>
+          silently breaks the agent.
+        </span>
       </li>
       <li class="flex items-start gap-3">
         <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
-        <span>Parallel tasks with different credentials mean maintaining separate local checkouts.</span>
+        <span>
+          Parallel tasks with different credentials mean maintaining separate local checkouts.
+        </span>
       </li>
     </ul>
   </div>
@@ -60,11 +70,22 @@
     <%!-- Self-serve onboarding --%>
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
       <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
-        <svg class="size-5 text-[var(--color-brand)]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fill-rule="evenodd" d="M10 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm-7 9a7 7 0 1 1 14 0H3Z" clip-rule="evenodd" />
+        <svg
+          class="size-5 text-[var(--color-brand)]"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M10 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm-7 9a7 7 0 1 1 14 0H3Z"
+            clip-rule="evenodd"
+          />
         </svg>
       </div>
-      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">Teammates onboard themselves</h3>
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+        Teammates onboard themselves
+      </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
         A new engineer gets a URL, registers, and is running their first agent conversation before they've read a README. No documentation handoff, no ticket to the platform team.
       </p>
@@ -73,11 +94,22 @@
     <%!-- Vaults --%>
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
       <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
-        <svg class="size-5 text-[var(--color-brand)]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fill-rule="evenodd" d="M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z" clip-rule="evenodd" />
+        <svg
+          class="size-5 text-[var(--color-brand)]"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z"
+            clip-rule="evenodd"
+          />
         </svg>
       </div>
-      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">Switch credentials without touching config</h3>
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+        Switch credentials without touching config
+      </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
         Vaults are encrypted per-conversation overrides layered on top of your baseline environment. Test against staging, scope a contractor's access, or rotate a single key — without duplicating your setup.
       </p>
@@ -86,26 +118,52 @@
     <%!-- Log viewer --%>
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
       <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
-        <svg class="size-5 text-[var(--color-brand)]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fill-rule="evenodd" d="M2 4.25A2.25 2.25 0 0 1 4.25 2h11.5A2.25 2.25 0 0 1 18 4.25v8.5A2.25 2.25 0 0 1 15.75 15h-3.105a3.501 3.501 0 0 0 1.1 1.677A.75.75 0 0 1 13.26 18H6.74a.75.75 0 0 1-.484-1.323A3.501 3.501 0 0 0 7.355 15H4.25A2.25 2.25 0 0 1 2 12.75v-8.5Zm1.5 0a.75.75 0 0 1 .75-.75h11.5a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-.75.75H4.25a.75.75 0 0 1-.75-.75v-7.5Z" clip-rule="evenodd" />
+        <svg
+          class="size-5 text-[var(--color-brand)]"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M2 4.25A2.25 2.25 0 0 1 4.25 2h11.5A2.25 2.25 0 0 1 18 4.25v8.5A2.25 2.25 0 0 1 15.75 15h-3.105a3.501 3.501 0 0 0 1.1 1.677A.75.75 0 0 1 13.26 18H6.74a.75.75 0 0 1-.484-1.323A3.501 3.501 0 0 0 7.355 15H4.25A2.25 2.25 0 0 1 2 12.75v-8.5Zm1.5 0a.75.75 0 0 1 .75-.75h11.5a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-.75.75H4.25a.75.75 0 0 1-.75-.75v-7.5Z"
+            clip-rule="evenodd"
+          />
         </svg>
       </div>
-      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">Debug in seconds, not sessions</h3>
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+        Debug in seconds, not sessions
+      </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Every conversation's stdout, stderr, and lifecycle events stream live in the dashboard. No <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">curl -N</code> to a raw SSE endpoint, no log pipeline to stand up. Click a conversation and see exactly what happened.
+        Every conversation's stdout, stderr, and lifecycle events stream live in the dashboard. No
+        <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
+          curl -N
+        </code>
+        to a raw SSE endpoint, no log pipeline to stand up. Click a conversation and see exactly what happened.
       </p>
     </div>
 
     <%!-- Three surfaces --%>
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
       <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
-        <svg class="size-5 text-[var(--color-brand)]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <svg
+          class="size-5 text-[var(--color-brand)]"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
           <path d="M3.25 4A2.25 2.25 0 0 0 1 6.25v7.5A2.25 2.25 0 0 0 3.25 16h7.5A2.25 2.25 0 0 0 13 13.75v-7.5A2.25 2.25 0 0 0 10.75 4h-7.5ZM19 4.75a.75.75 0 0 0-1.28-.53l-3 3a.75.75 0 0 0-.22.53v4.5c0 .199.079.39.22.53l3 3a.75.75 0 0 0 1.28-.53V4.75Z" />
         </svg>
       </div>
-      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">Script it, click it, or pipe it to CI</h3>
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+        Script it, click it, or pipe it to CI
+      </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        REST API for automation, a LiveView dashboard for hands-on work, and an <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">aod</code> CLI for pipelines — all reading and writing the same Environments, Agents, and Conversations. Pick the interface that fits the job.
+        REST API for automation, a LiveView dashboard for hands-on work, and an
+        <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
+          aod
+        </code>
+        CLI for pipelines — all reading and writing the same Environments, Agents, and Conversations. Pick the interface that fits the job.
       </p>
     </div>
   </div>
@@ -117,7 +175,11 @@
     <div class="grid sm:grid-cols-2 gap-10">
       <figure>
         <blockquote class="text-[var(--color-text-primary)] leading-relaxed mb-4">
-          "We were maintaining three separate <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">.env</code> files and a shared Notion doc to keep our agent configs in sync. Fountain replaced all of it. Onboarding the last two engineers took ten minutes each."
+          "We were maintaining three separate
+          <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">
+            .env
+          </code>
+          files and a shared Notion doc to keep our agent configs in sync. Fountain replaced all of it. Onboarding the last two engineers took ten minutes each."
         </blockquote>
         <figcaption class="text-sm text-[var(--color-text-muted)] font-medium">
           — Engineering lead, early access customer
@@ -125,7 +187,11 @@
       </figure>
       <figure>
         <blockquote class="text-[var(--color-text-primary)] leading-relaxed mb-4">
-          "I evaluated Fountain on a Friday afternoon and had a shared environment running for the whole team before dinner. The Vaults alone killed our 'which <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">.env</code> is current?' Slack thread."
+          "I evaluated Fountain on a Friday afternoon and had a shared environment running for the whole team before dinner. The Vaults alone killed our 'which
+          <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm">
+            .env
+          </code>
+          is current?' Slack thread."
         </blockquote>
         <figcaption class="text-sm text-[var(--color-text-muted)] font-medium">
           — Developer, early access customer

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
@@ -88,10 +88,7 @@
           configuration and decrypted credentials needed to run each conversation;
         </li>
         <li>
-          <strong class="text-[var(--color-text-primary)]">
-            AI model providers you configure
-          </strong>
-          — your agents call them with credentials you supply, under those providers' terms;
+          <strong class="text-[var(--color-text-primary)]" phx-no-format>AI model providers you configure</strong> — your agents call them with credentials you supply, under those providers' terms;
         </li>
         <li>
           <strong class="text-[var(--color-text-primary)]">GitHub</strong>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
@@ -10,8 +10,10 @@
       <p>
         Fountain is operated by {@legal.entity} ("we", "us"). This policy describes what
         personal data we collect when you use the Fountain service, why we collect it, and the
-        choices you have. For questions or requests, contact
-        <a href={"mailto:#{@legal.contact_email}"} class="underline">{@legal.contact_email}</a>.
+        choices you have. For questions or requests, contact <a
+          href={"mailto:#{@legal.contact_email}"}
+          class="underline"
+        >{@legal.contact_email}</a>.
       </p>
     </div>
 
@@ -72,18 +74,29 @@
         We share data with service providers only as needed to run Fountain:
       </p>
       <ul class="list-disc pl-6 space-y-1">
-        <li><strong class="text-[var(--color-text-primary)]">Stripe</strong> — payment processing and subscription management;</li>
-        <li><strong class="text-[var(--color-text-primary)]">our email provider</strong> — transactional email delivery;</li>
+        <li>
+          <strong class="text-[var(--color-text-primary)]">Stripe</strong>
+          — payment processing and subscription management;
+        </li>
+        <li>
+          <strong class="text-[var(--color-text-primary)]">our email provider</strong>
+          — transactional email delivery;
+        </li>
         <li>
           <strong class="text-[var(--color-text-primary)]">sandbox infrastructure</strong>
           — the isolated compute environments your conversations run in, which receive the
           configuration and decrypted credentials needed to run each conversation;
         </li>
         <li>
-          <strong class="text-[var(--color-text-primary)]">AI model providers you configure</strong>
+          <strong class="text-[var(--color-text-primary)]">
+            AI model providers you configure
+          </strong>
           — your agents call them with credentials you supply, under those providers' terms;
         </li>
-        <li><strong class="text-[var(--color-text-primary)]">GitHub</strong> — only if you choose GitHub sign-in.</li>
+        <li>
+          <strong class="text-[var(--color-text-primary)]">GitHub</strong>
+          — only if you choose GitHub sign-in.
+        </li>
       </ul>
       <p class="mt-2">
         We may also disclose data if required by law, or as part of a merger or acquisition, in

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/terms.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/terms.html.heex
@@ -8,8 +8,7 @@
     <div>
       <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">1. Agreement</h2>
       <p>
-        These Terms of Service ("Terms") are an agreement between you and {@legal.entity}
-        ("Fountain", "we", "us") governing your use of the Fountain service — the web
+        These Terms of Service ("Terms") are an agreement between you and {@legal.entity} ("Fountain", "we", "us") governing your use of the Fountain service — the web
         application, API, and command-line tools available through this site (the "Service").
         By creating an account or using the Service you agree to these Terms. If you are using
         the Service on behalf of an organization, you represent that you have authority to bind
@@ -67,16 +66,22 @@
     </div>
 
     <div>
-      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">5. Acceptable use</h2>
+      <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+        5. Acceptable use
+      </h2>
       <p class="mb-2">You agree not to use the Service to:</p>
       <ul class="list-disc pl-6 space-y-1">
-        <li>break the law, or infringe others' rights, including intellectual property and privacy rights;</li>
+        <li>
+          break the law, or infringe others' rights, including intellectual property and privacy rights;
+        </li>
         <li>
           probe, disrupt, or overload the Service or its underlying infrastructure, or attempt to
           escape or abuse the sandbox environments (including cryptocurrency mining, spam, or
           denial-of-service activity);
         </li>
-        <li>attempt to access other tenants' data or circumvent usage limits, billing, or access controls;</li>
+        <li>
+          attempt to access other tenants' data or circumvent usage limits, billing, or access controls;
+        </li>
         <li>resell or white-label the Service without our written agreement.</li>
       </ul>
       <p class="mt-2">
@@ -181,8 +186,7 @@
     <div>
       <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">14. Contact</h2>
       <p>
-        Questions about these Terms:
-        <a href={"mailto:#{@legal.contact_email}"} class="underline">{@legal.contact_email}</a>.
+        Questions about these Terms: <a href={"mailto:#{@legal.contact_email}"} class="underline">{@legal.contact_email}</a>.
       </p>
     </div>
   </div>

--- a/apps/fountain/lib/fountain_web/controllers/password_reset_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/password_reset_html.ex
@@ -5,7 +5,11 @@ defmodule FountainWeb.PasswordResetHTML do
   def forgot_form(assigns) do
     ~H"""
     <div class="min-h-screen flex items-center justify-center bg-zinc-50 text-zinc-900 font-sans">
-      <form method="post" action={~p"/api/auth/forgot"} class="w-full max-w-sm bg-white rounded-lg shadow p-8 space-y-4">
+      <form
+        method="post"
+        action={~p"/api/auth/forgot"}
+        class="w-full max-w-sm bg-white rounded-lg shadow p-8 space-y-4"
+      >
         <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
         <div>
           <h1 class="text-xl font-semibold">Reset your password</h1>
@@ -38,7 +42,11 @@ defmodule FountainWeb.PasswordResetHTML do
   def reset_form(assigns) do
     ~H"""
     <div class="min-h-screen flex items-center justify-center bg-zinc-50 text-zinc-900 font-sans">
-      <form method="post" action={~p"/auth/reset"} class="w-full max-w-sm bg-white rounded-lg shadow p-8 space-y-4">
+      <form
+        method="post"
+        action={~p"/auth/reset"}
+        class="w-full max-w-sm bg-white rounded-lg shadow p-8 space-y-4"
+      >
         <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
         <input type="hidden" name="token" value={@token} />
         <div>

--- a/apps/fountain/lib/fountain_web/controllers/registration_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/registration_html.ex
@@ -72,8 +72,7 @@ defmodule FountainWeb.RegistrationHTML do
         </a>
 
         <p :if={Fountain.Legal.published?()} class="text-xs text-zinc-400 text-center">
-          By signing up you agree to our
-          <a href={~p"/terms"} class="underline">terms of service</a>
+          By signing up you agree to our <a href={~p"/terms"} class="underline">terms of service</a>
           and <a href={~p"/privacy"} class="underline">privacy policy</a>.
         </p>
       </div>
@@ -91,8 +90,10 @@ defmodule FountainWeb.RegistrationHTML do
           Click the link to activate your account.
         </p>
         <p class="text-xs text-zinc-400">
-          Didn't receive it? Check your spam folder or
-          <a href={~p"/auth/resend-verification"} class="underline">resend the email</a>.
+          Didn't receive it? Check your spam folder or <a
+            href={~p"/auth/resend-verification"}
+            class="underline"
+          >resend the email</a>.
         </p>
       </div>
     </div>

--- a/apps/fountain/lib/fountain_web/controllers/session_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/session_html.ex
@@ -7,7 +7,11 @@ defmodule FountainWeb.SessionHTML do
   def new(assigns) do
     ~H"""
     <div class="min-h-screen flex items-center justify-center bg-zinc-50 text-zinc-900 font-sans">
-      <form method="post" action={~p"/auth/login"} class="w-full max-w-sm bg-white rounded-lg shadow p-8 space-y-4">
+      <form
+        method="post"
+        action={~p"/auth/login"}
+        class="w-full max-w-sm bg-white rounded-lg shadow p-8 space-y-4"
+      >
         <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
         <div>
           <h1 class="text-xl font-semibold">Sign in to Fountain</h1>

--- a/apps/fountain/lib/fountain_web/live/account_live.ex
+++ b/apps/fountain/lib/fountain_web/live/account_live.ex
@@ -136,14 +136,15 @@ defmodule FountainWeb.Live.AccountLive do
             <%= case export_state(@export) do %>
               <% :pending -> %>
                 <span class="text-gray-700">
-                  Export requested <%= Calendar.strftime(@export.inserted_at, "%Y-%m-%d %H:%M UTC") %>
-                  — generating&hellip; The download will appear here when it is ready.
+                  Export requested {Calendar.strftime(@export.inserted_at, "%Y-%m-%d %H:%M UTC")} — generating&hellip; The download will appear here when it is ready.
                 </span>
               <% :ready -> %>
                 <div class="flex items-center justify-between gap-4">
                   <span class="text-gray-700">
-                    Export ready (<%= format_bytes(@export.byte_size) %>) — link expires
-                    <%= Calendar.strftime(@export.expires_at, "%Y-%m-%d %H:%M UTC") %>.
+                    Export ready ({format_bytes(@export.byte_size)}) — link expires {Calendar.strftime(
+                      @export.expires_at,
+                      "%Y-%m-%d %H:%M UTC"
+                    )}.
                   </span>
                   <a
                     href={~p"/account/exports/#{@export.id}/download"}
@@ -172,7 +173,7 @@ defmodule FountainWeb.Live.AccountLive do
           Request export
         </button>
         <p class="mt-2 text-xs text-gray-400">
-          One export per hour. Downloads expire after <%= Exports.ttl_hours() %> hours.
+          One export per hour. Downloads expire after {Exports.ttl_hours()} hours.
         </p>
       </div>
 
@@ -183,9 +184,9 @@ defmodule FountainWeb.Live.AccountLive do
           <%!-- "Cancels your subscription" is billing residue on a
                billing-disabled instance — there is no subscription to
                cancel (#513, the last surface the walkthrough sweep found). --%>
-          <%= if Fountain.Billing.enabled?(),
+          {if Fountain.Billing.enabled?(),
             do: "Cancels your subscription, destroys",
-            else: "Destroys" %> every running sandbox, and permanently
+            else: "Destroys"} every running sandbox, and permanently
           deletes your agents, environments, vaults, conversations and stored secrets.
           Secrets are encrypted with a key held only for your account; deleting the
           account destroys that key, so they cannot be recovered afterwards by anyone.
@@ -199,7 +200,8 @@ defmodule FountainWeb.Live.AccountLive do
 
         <form phx-submit="delete_account" class="space-y-3">
           <label class="block text-sm text-gray-700">
-            Type <span class="font-mono font-semibold"><%= @current_user.email %></span> to confirm
+            Type <span class="font-mono font-semibold">{@current_user.email}</span>
+            to confirm
             <input
               type="text"
               name="email"
@@ -215,7 +217,7 @@ defmodule FountainWeb.Live.AccountLive do
             disabled={@delete_confirmation != @current_user.email or @deleting}
             class="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-300"
           >
-            <%= if @deleting, do: "Deleting…", else: "Delete my account" %>
+            {if @deleting, do: "Deleting…", else: "Delete my account"}
           </button>
         </form>
       </div>

--- a/apps/fountain/lib/fountain_web/live/account_security_live.ex
+++ b/apps/fountain/lib/fountain_web/live/account_security_live.ex
@@ -47,7 +47,12 @@ defmodule FountainWeb.AccountSecurityLive do
         <p class="mb-4 text-sm text-zinc-500">
           Every other session is signed out when the password changes; this one stays.
         </p>
-        <form method="post" action={~p"/account/security/password"} class="space-y-3" id="change-password">
+        <form
+          method="post"
+          action={~p"/account/security/password"}
+          class="space-y-3"
+          id="change-password"
+        >
           <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
           <div>
             <label class="block text-sm font-medium text-zinc-700 mb-1">Current password</label>

--- a/apps/fountain/lib/fountain_web/live/admin_live/conversation_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/conversation_detail.ex
@@ -123,7 +123,10 @@ defmodule FountainWeb.AdminLive.ConversationDetail do
           Metadata only — prompt and output content are not shown to admins.
         </p>
         <div :if={@turns == []} class="text-sm text-zinc-500">None.</div>
-        <table :if={@turns != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
+        <table
+          :if={@turns != []}
+          class="w-full text-sm bg-white rounded shadow border border-zinc-200"
+        >
           <thead class="text-left text-zinc-500 border-b border-zinc-200">
             <tr>
               <th class="px-4 py-2">#</th>

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -549,7 +549,9 @@ defmodule FountainWeb.AdminLive.Index do
           class="bg-amber-50 border border-amber-200 rounded px-4 py-3 text-sm text-amber-900 space-y-1"
         >
           <div class="font-medium">
-            {@funnel.stalled.count} verified {if @funnel.stalled.count == 1, do: "user has", else: "users have"} never started a conversation
+            {@funnel.stalled.count} verified {if @funnel.stalled.count == 1,
+              do: "user has",
+              else: "users have"} never started a conversation
           </div>
           <div class="text-xs">
             onboarding:
@@ -613,9 +615,11 @@ defmodule FountainWeb.AdminLive.Index do
           class="bg-red-50 border border-red-200 rounded px-4 py-3 text-sm space-y-2"
         >
           <div class="font-medium text-red-900">
-            {length(@billing_overview.failed_events)} webhook {if length(@billing_overview.failed_events) == 1,
-              do: "event is",
-              else: "events are"} failing — subscription state may lag Stripe
+            {length(@billing_overview.failed_events)} webhook {if length(
+                                                                    @billing_overview.failed_events
+                                                                  ) == 1,
+                                                                  do: "event is",
+                                                                  else: "events are"} failing — subscription state may lag Stripe
           </div>
           <table class="w-full text-sm bg-white rounded border border-red-100 font-mono">
             <tbody>
@@ -676,7 +680,11 @@ defmodule FountainWeb.AdminLive.Index do
               class="rounded border border-zinc-200 px-1 py-1 text-xs"
             >
               <option value="">any status</option>
-              <option :for={s <- ~w(trialing active past_due canceled comped)} value={s} selected={@filters.status == s}>
+              <option
+                :for={s <- ~w(trialing active past_due canceled comped)}
+                value={s}
+                selected={@filters.status == s}
+              >
                 {s}
               </option>
             </select>
@@ -764,7 +772,10 @@ defmodule FountainWeb.AdminLive.Index do
                     ]}>
                       {u.subscription_status}
                     </span>
-                    <span :if={u.subscription_status == "trialing" and u.trial_ends_at} class="text-xs text-zinc-500">
+                    <span
+                      :if={u.subscription_status == "trialing" and u.trial_ends_at}
+                      class="text-xs text-zinc-500"
+                    >
                       ends {format_date(u.trial_ends_at)}
                     </span>
                     <a
@@ -825,7 +836,11 @@ defmodule FountainWeb.AdminLive.Index do
                 {u.usage.conversations}c · {u.usage.turns}t · {round(u.usage.sandbox_minutes)}m
               </td>
               <td class="px-4 py-2">
-                <form phx-submit="set_sandbox_limit" id={"sandbox-limit-#{u.id}"} class="flex items-center gap-1">
+                <form
+                  phx-submit="set_sandbox_limit"
+                  id={"sandbox-limit-#{u.id}"}
+                  class="flex items-center gap-1"
+                >
                   <input type="hidden" name="user_id" value={u.id} />
                   <span class={[
                     "text-xs tabular-nums",
@@ -833,7 +848,9 @@ defmodule FountainWeb.AdminLive.Index do
                       do: "text-red-600 font-medium",
                       else: "text-zinc-500"
                     )
-                  ]}>{u.active_sandboxes} /</span>
+                  ]}>
+                    {u.active_sandboxes} /
+                  </span>
                   <input
                     type="number"
                     name="limit"
@@ -855,9 +872,12 @@ defmodule FountainWeb.AdminLive.Index do
               </td>
               <td class="px-4 py-2 text-zinc-500 text-xs">{format_date(u.inserted_at)}</td>
               <td class="px-4 py-2 text-right space-x-3">
-                <button phx-click="toggle_admin" phx-value-id={u.id}
+                <button
+                  phx-click="toggle_admin"
+                  phx-value-id={u.id}
                   data-confirm={"Toggle admin for #{u.email}?"}
-                  class="text-xs text-zinc-600 hover:text-zinc-900 underline">
+                  class="text-xs text-zinc-600 hover:text-zinc-900 underline"
+                >
                   {if u.role == "admin", do: "Remove admin", else: "Make admin"}
                 </button>
                 <button
@@ -879,7 +899,8 @@ defmodule FountainWeb.AdminLive.Index do
                   phx-click="delete_user"
                   phx-value-id={u.id}
                   data-confirm={"Permanently delete #{u.email}? This cancels their subscription, destroys their sandboxes and erases their data. It cannot be undone."}
-                  class="text-xs text-red-600 hover:text-red-800 underline">
+                  class="text-xs text-red-600 hover:text-red-800 underline"
+                >
                   Delete
                 </button>
               </td>
@@ -892,7 +913,11 @@ defmodule FountainWeb.AdminLive.Index do
         >
           <span>Page {@filters.page} of {page_count(@total_users)}</span>
           <div class="space-x-3">
-            <.link :if={@filters.page > 1} patch={admin_path(%{@filters | page: @filters.page - 1})} class="underline">
+            <.link
+              :if={@filters.page > 1}
+              patch={admin_path(%{@filters | page: @filters.page - 1})}
+              class="underline"
+            >
               ← prev
             </.link>
             <.link
@@ -911,7 +936,10 @@ defmodule FountainWeb.AdminLive.Index do
 
         <div :if={@sandboxes == []} class="text-sm text-zinc-500">No active sandboxes.</div>
 
-        <table :if={@sandboxes != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200 font-mono">
+        <table
+          :if={@sandboxes != []}
+          class="w-full text-sm bg-white rounded shadow border border-zinc-200 font-mono"
+        >
           <thead class="text-left text-zinc-500 border-b border-zinc-200">
             <tr>
               <th class="px-4 py-2">ID</th>
@@ -950,7 +978,9 @@ defmodule FountainWeb.AdminLive.Index do
                     :for={c <- s.conversations}
                     navigate={~p"/admin/conversations/#{c.id}"}
                     class="hover:underline"
-                  >{String.slice(c.id, 0, 8)}</.link>
+                  >
+                    {String.slice(c.id, 0, 8)}
+                  </.link>
                 </span>
               </td>
               <td class="px-4 py-2 text-xs text-zinc-500">{format_ts(s.inserted_at)}</td>
@@ -971,13 +1001,16 @@ defmodule FountainWeb.AdminLive.Index do
       <section class="space-y-3">
         <h2 class="text-lg font-medium">Recent admin actions</h2>
         <p class="text-sm text-zinc-500">
-          Role grants and quota changes. Previously unrecorded — the
-          <code>admin_audit_events</code> table existed with no writer.
+          Role grants and quota changes. Previously unrecorded — the <code>admin_audit_events</code>
+          table existed with no writer.
         </p>
 
         <div :if={@admin_events == []} class="text-sm text-zinc-500">Nothing yet.</div>
 
-        <table :if={@admin_events != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200">
+        <table
+          :if={@admin_events != []}
+          class="w-full text-sm bg-white rounded shadow border border-zinc-200"
+        >
           <thead class="text-left text-zinc-500 border-b border-zinc-200">
             <tr>
               <th class="px-4 py-2">When</th>

--- a/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
@@ -167,7 +167,10 @@ defmodule FountainWeb.AdminLive.UserDetail do
             onboarding {@user.onboarding_state}
           </div>
         </div>
-        <div :if={not @billing_enabled} class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+        <div
+          :if={not @billing_enabled}
+          class="bg-white rounded shadow border border-zinc-200 px-4 py-3"
+        >
           <div class="text-xs text-zinc-500">Onboarding</div>
           <div class="text-sm font-medium">{@user.onboarding_state}</div>
           <div class="text-xs text-zinc-500">
@@ -288,7 +291,8 @@ defmodule FountainWeb.AdminLive.UserDetail do
             class="underline"
           >
             Stripe dashboard
-          </a> directly.
+          </a>
+          directly.
         </div>
         <div :if={@invoices == []} class="text-sm text-zinc-500">None.</div>
         <table

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -490,32 +490,68 @@ defmodule FountainWeb.AgentsLive.Form do
     <div class="max-w-2xl space-y-6">
       <h1 class="text-2xl font-semibold">{page_title(@action)}</h1>
 
-      <form phx-change="validate" phx-submit="submit" class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200">
+      <form
+        phx-change="validate"
+        phx-submit="submit"
+        class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200"
+      >
         <.input id="name" name="agent[name]" label="Name" value={@form["name"]} autofocus required />
-        <.error_msg field="name" errors={@errors}/>
+        <.error_msg field="name" errors={@errors} />
 
-        <.input id="description" name="agent[description]" label="Description" value={@form["description"]} />
+        <.input
+          id="description"
+          name="agent[description]"
+          label="Description"
+          value={@form["description"]}
+        />
 
-        <.input id="system" name="agent[system]" type="textarea" rows="6"
-          label="System prompt" value={@form["system"]} placeholder="You are a focused subagent..."/>
+        <.input
+          id="system"
+          name="agent[system]"
+          type="textarea"
+          rows="6"
+          label="System prompt"
+          value={@form["system"]}
+          placeholder="You are a focused subagent..."
+        />
 
         <div class="grid grid-cols-2 gap-3">
           <div class="space-y-1">
             <label class="block text-sm font-medium text-zinc-700">Runtime</label>
-            <select name="agent[runtime]" class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm">
-              <option :for={r <- ~w(claude codex gemini opencode)} value={r} selected={@form["runtime"] == r}>{r}</option>
+            <select
+              name="agent[runtime]"
+              class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+            >
+              <option
+                :for={r <- ~w(claude codex gemini opencode)}
+                value={r}
+                selected={@form["runtime"] == r}
+              >
+                {r}
+              </option>
             </select>
           </div>
-          <.input id="model" name="agent[model]" label="Model" value={@form["model"]}
-            placeholder="anthropic/claude-sonnet-4-6" required/>
+          <.input
+            id="model"
+            name="agent[model]"
+            label="Model"
+            value={@form["model"]}
+            placeholder="anthropic/claude-sonnet-4-6"
+            required
+          />
         </div>
-        <.error_msg field="model" errors={@errors}/>
+        <.error_msg field="model" errors={@errors} />
 
         <div class="space-y-1">
           <label class="block text-sm font-medium text-zinc-700">Environment</label>
-          <select name="agent[environment_id]" class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm">
+          <select
+            name="agent[environment_id]"
+            class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+          >
             <option value="">\u2014 none \u2014</option>
-            <option :for={e <- @envs} value={e.id} selected={@form["environment_id"] == e.id}>{e.name}</option>
+            <option :for={e <- @envs} value={e.id} selected={@form["environment_id"] == e.id}>
+              {e.name}
+            </option>
           </select>
         </div>
 
@@ -523,8 +559,10 @@ defmodule FountainWeb.AgentsLive.Form do
         <div class="space-y-3">
           <label class="block text-sm font-medium text-zinc-700">Avatar</label>
 
-          <div :if={@agent.id && @agent.avatar_media_type && !@generated_avatar_preview}
-               class="flex items-center gap-3">
+          <div
+            :if={@agent.id && @agent.avatar_media_type && !@generated_avatar_preview}
+            class="flex items-center gap-3"
+          >
             <img
               src={~p"/agents/#{@agent.id}/avatar"}
               class="w-14 h-14 rounded-xl object-cover border border-zinc-200"
@@ -662,9 +700,27 @@ defmodule FountainWeb.AgentsLive.Form do
                      text-white hover:bg-zinc-700 disabled:opacity-60 disabled:cursor-not-allowed"
             >
               <%= if @generating_avatar do %>
-                <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                <svg
+                  class="animate-spin h-4 w-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    class="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    stroke-width="4"
+                  >
+                  </circle>
+                  <path
+                    class="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  >
+                  </path>
                 </svg>
                 Generating\u2026
               <% else %>
@@ -680,7 +736,9 @@ defmodule FountainWeb.AgentsLive.Form do
         <div class="space-y-2">
           <label class="block text-sm font-medium text-zinc-700">Skills</label>
 
-          <div :if={@skills == []} class="text-sm text-zinc-400 italic py-1">No skills configured.</div>
+          <div :if={@skills == []} class="text-sm text-zinc-400 italic py-1">
+            No skills configured.
+          </div>
 
           <div
             :for={{skill, i} <- Enum.with_index(@skills)}
@@ -777,16 +835,18 @@ defmodule FountainWeb.AgentsLive.Form do
             <p>
               GitHub skills are fetched via
               <a href="https://skills.sh" target="_blank" class="underline">skills.sh</a>
-              using the <code>source</code> (owner/repo) and optional skill <code>name</code>.
+              using the <code>source</code>
+              (owner/repo) and optional skill <code>name</code>.
               Inline skills embed a full SKILL.md body directly.
               <.link navigate={~p"/help/skills"} class="underline">Skills help \u2192</.link>
             </p>
             <div class="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-blue-900 leading-relaxed">
               <strong>Always included:</strong>
-              the built-in <code>fountain</code> skill is automatically mounted in every
-              conversation \u2014 no need to declare it. It gives the agent
-              <code>$FOUNTAIN_TOKEN</code>, <code>$FOUNTAIN_BASE_URL</code>, and
-              <code>$FOUNTAIN_CONVERSATION_ID</code> so it can spawn and coordinate sub-agents.
+              the built-in <code>fountain</code>
+              skill is automatically mounted in every
+              conversation \u2014 no need to declare it. It gives the agent <code>$FOUNTAIN_TOKEN</code>, <code>$FOUNTAIN_BASE_URL</code>, and
+              <code>$FOUNTAIN_CONVERSATION_ID</code>
+              so it can spawn and coordinate sub-agents.
             </div>
           </div>
         </div>
@@ -804,7 +864,9 @@ defmodule FountainWeb.AgentsLive.Form do
             class="border border-zinc-200 rounded-md p-3 bg-zinc-50 space-y-2"
           >
             <div class="flex items-center justify-between">
-              <span class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Server {i + 1}</span>
+              <span class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">
+                Server {i + 1}
+              </span>
               <button
                 type="button"
                 phx-click="remove_mcp_server"
@@ -897,7 +959,9 @@ defmodule FountainWeb.AgentsLive.Form do
 
         <div class="flex gap-2">
           <.btn type="submit" phx-disable-with="Saving\u2026">Save</.btn>
-          <.link navigate={~p"/agents"}><.btn_secondary>Cancel</.btn_secondary></.link>
+          <.link navigate={~p"/agents"}>
+            <.btn_secondary>Cancel</.btn_secondary>
+          </.link>
         </div>
       </form>
     </div>
@@ -909,7 +973,9 @@ defmodule FountainWeb.AgentsLive.Form do
 
   defp error_msg(assigns) do
     ~H"""
-    <p :if={Map.has_key?(@errors, @field)} class="text-rose-600 text-xs">{Map.get(@errors, @field)}</p>
+    <p :if={Map.has_key?(@errors, @field)} class="text-rose-600 text-xs">
+      {Map.get(@errors, @field)}
+    </p>
     """
   end
 end

--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -121,7 +121,10 @@ defmodule FountainWeb.AgentsLive.Index do
           <div>
             <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1.5">Runtime</p>
             <div class="space-y-1.5">
-              <label :for={rt <- Agent.runtimes()} class="flex items-center justify-between gap-2 text-sm cursor-pointer">
+              <label
+                :for={rt <- Agent.runtimes()}
+                class="flex items-center justify-between gap-2 text-sm cursor-pointer"
+              >
                 <span class="flex items-center gap-1.5">
                   <input
                     type="checkbox"
@@ -139,7 +142,9 @@ defmodule FountainWeb.AgentsLive.Index do
 
           <%!-- Environment facet --%>
           <div>
-            <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1.5">Environment</p>
+            <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1.5">
+              Environment
+            </p>
             <div class="space-y-1.5">
               <label class="flex items-center justify-between gap-2 text-sm cursor-pointer">
                 <span class="flex items-center gap-1.5">
@@ -175,7 +180,9 @@ defmodule FountainWeb.AgentsLive.Index do
 
           <%!-- Capability facets --%>
           <div>
-            <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1.5">Capabilities</p>
+            <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1.5">
+              Capabilities
+            </p>
             <div class="space-y-1.5">
               <label class="flex items-center gap-1.5 text-sm cursor-pointer">
                 <input
@@ -184,8 +191,7 @@ defmodule FountainWeb.AgentsLive.Index do
                   value="true"
                   checked={@filter_has_skills}
                   class="rounded border-zinc-300"
-                />
-                Has skills
+                /> Has skills
               </label>
               <label class="flex items-center gap-1.5 text-sm cursor-pointer">
                 <input
@@ -194,8 +200,7 @@ defmodule FountainWeb.AgentsLive.Index do
                   value="true"
                   checked={@filter_has_mcp}
                   class="rounded border-zinc-300"
-                />
-                Has MCP servers
+                /> Has MCP servers
               </label>
             </div>
           </div>
@@ -214,7 +219,9 @@ defmodule FountainWeb.AgentsLive.Index do
       <div class="flex-1 min-w-0 space-y-4">
         <div class="flex items-center justify-between">
           <h1 class="text-2xl font-semibold">Agents</h1>
-          <.link href={~p"/agents/new"}><.btn>+ New agent</.btn></.link>
+          <.link href={~p"/agents/new"}>
+            <.btn>+ New agent</.btn>
+          </.link>
         </div>
 
         <div
@@ -237,11 +244,21 @@ defmodule FountainWeb.AgentsLive.Index do
         >
           <thead class="border-b border-[var(--color-border)]">
             <tr>
-              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Name</th>
-              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Runtime</th>
-              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Model</th>
-              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Stats</th>
-              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Env</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+                Name
+              </th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+                Runtime
+              </th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+                Model
+              </th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+                Stats
+              </th>
+              <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+                Env
+              </th>
               <th class="px-4 py-3"></th>
             </tr>
           </thead>
@@ -262,7 +279,10 @@ defmodule FountainWeb.AgentsLive.Index do
                 </div>
               </td>
               <td class="px-4 py-3">
-                <span class={["inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold", runtime_badge_class(a.runtime)]}>
+                <span class={[
+                  "inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold",
+                  runtime_badge_class(a.runtime)
+                ]}>
                   <span class="w-1.5 h-1.5 rounded-full" style="background:currentColor;"></span>
                   {a.runtime}
                 </span>
@@ -271,24 +291,44 @@ defmodule FountainWeb.AgentsLive.Index do
               <td class="px-4 py-3">
                 <div class="flex items-center gap-1.5 flex-wrap">
                   <span
-                    class={["inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium", stat_badge_class(:skills, length(a.skills))]}
+                    class={[
+                      "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
+                      stat_badge_class(:skills, length(a.skills))
+                    ]}
                     title={"#{length(a.skills)} skills"}
-                  >⚡ {length(a.skills)}</span>
+                  >
+                    ⚡ {length(a.skills)}
+                  </span>
                   <span
-                    class={["inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium", stat_badge_class(:mcp, map_size(a.mcp_servers))]}
+                    class={[
+                      "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
+                      stat_badge_class(:mcp, map_size(a.mcp_servers))
+                    ]}
                     title={"#{map_size(a.mcp_servers)} MCP servers"}
-                  >🔌 {map_size(a.mcp_servers)}</span>
+                  >
+                    🔌 {map_size(a.mcp_servers)}
+                  </span>
                   <span
-                    class={["inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium", stat_badge_class(:conversations, a.conversation_count)]}
+                    class={[
+                      "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
+                      stat_badge_class(:conversations, a.conversation_count)
+                    ]}
                     title={"#{a.conversation_count} total conversations"}
-                  >💬 {a.conversation_count}</span>
+                  >
+                    💬 {a.conversation_count}
+                  </span>
                 </div>
               </td>
               <td class="px-4 py-3">
                 <span
                   :if={a.environment}
-                  class={["inline-flex items-center px-2 py-1 rounded text-xs font-medium", env_badge_class(a.environment.name)]}
-                >{a.environment.name}</span>
+                  class={[
+                    "inline-flex items-center px-2 py-1 rounded text-xs font-medium",
+                    env_badge_class(a.environment.name)
+                  ]}
+                >
+                  {a.environment.name}
+                </span>
                 <span :if={!a.environment} class="text-[var(--color-text-muted)]">—</span>
               </td>
               <td class="px-4 py-3 text-right">
@@ -301,7 +341,9 @@ defmodule FountainWeb.AgentsLive.Index do
                     phx-click="delete"
                     phx-value-id={a.id}
                     data-confirm="Delete agent?"
-                  >Delete</button>
+                  >
+                    Delete
+                  </button>
                 </div>
               </td>
             </tr>

--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -83,14 +83,16 @@ defmodule FountainWeb.ApiKeysLive.Index do
         <div class="flex items-center gap-2">
           <code
             id="new-api-key"
-            class="flex-1 bg-[var(--color-bg-2)] rounded border border-[var(--color-border)] px-3 py-2 text-sm font-mono break-all">
+            class="flex-1 bg-[var(--color-bg-2)] rounded border border-[var(--color-border)] px-3 py-2 text-sm font-mono break-all"
+          >
             {@new_key && @new_key.raw_token}
           </code>
           <.button
             phx-hook="CopyToClipboard"
             id="copy-api-key"
             data-target="new-api-key"
-            variant="secondary">
+            variant="secondary"
+          >
             Copy
           </.button>
         </div>
@@ -117,11 +119,17 @@ defmodule FountainWeb.ApiKeysLive.Index do
         <.button type="submit">Create key</.button>
       </form>
 
-      <div :if={@keys == []} class="rounded border border-dashed border-[var(--color-border)] p-8 text-center text-[var(--color-text-muted)]">
+      <div
+        :if={@keys == []}
+        class="rounded border border-dashed border-[var(--color-border)] p-8 text-center text-[var(--color-text-muted)]"
+      >
         No API keys yet.
       </div>
 
-      <table :if={@keys != []} class="w-full text-sm bg-[var(--color-bg-1)] rounded shadow border border-[var(--color-border)]">
+      <table
+        :if={@keys != []}
+        class="w-full text-sm bg-[var(--color-bg-1)] rounded shadow border border-[var(--color-border)]"
+      >
         <thead class="text-left text-[var(--color-text-muted)] border-b border-[var(--color-border)]">
           <tr>
             <th class="px-4 py-2 font-medium">Label</th>
@@ -132,10 +140,17 @@ defmodule FountainWeb.ApiKeysLive.Index do
           </tr>
         </thead>
         <tbody>
-          <tr :for={k <- @keys} class="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-bg-2)]">
+          <tr
+            :for={k <- @keys}
+            class="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-bg-2)]"
+          >
             <td class="px-4 py-2 font-medium">{k.name}</td>
-            <td class="px-4 py-2 font-mono text-[var(--color-text-muted)] text-xs">{k.key_prefix}···</td>
-            <td class="px-4 py-2 text-[var(--color-text-muted)] text-xs">{format_date(k.inserted_at)}</td>
+            <td class="px-4 py-2 font-mono text-[var(--color-text-muted)] text-xs">
+              {k.key_prefix}···
+            </td>
+            <td class="px-4 py-2 text-[var(--color-text-muted)] text-xs">
+              {format_date(k.inserted_at)}
+            </td>
             <td class="px-4 py-2 text-[var(--color-text-muted)] text-xs">
               {if k.last_used_at, do: format_date(k.last_used_at), else: "—"}
             </td>
@@ -145,7 +160,8 @@ defmodule FountainWeb.ApiKeysLive.Index do
                 phx-click="revoke"
                 phx-value-id={k.id}
                 data-confirm="Revoke this key? Any integrations using it will stop working."
-                class="text-[var(--color-error)] hover:text-[var(--color-error-text)]">
+                class="text-[var(--color-error)] hover:text-[var(--color-error-text)]"
+              >
                 Revoke
               </.button>
             </td>

--- a/apps/fountain/lib/fountain_web/live/audit_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/audit_live/index.ex
@@ -207,7 +207,10 @@ defmodule FountainWeb.AuditLive.Index do
         No events yet.
       </div>
 
-      <table :if={@events != []} class="w-full text-sm bg-white rounded shadow border border-zinc-200 font-mono">
+      <table
+        :if={@events != []}
+        class="w-full text-sm bg-white rounded shadow border border-zinc-200 font-mono"
+      >
         <thead class="text-left text-zinc-500 border-b border-zinc-200">
           <tr>
             <th class="px-3 py-2">when</th>
@@ -225,7 +228,9 @@ defmodule FountainWeb.AuditLive.Index do
             <td class="px-3 py-1.5">{e.action}</td>
             <td class="px-3 py-1.5">
               {e.resource_type}
-              <span :if={e.resource_id} class="text-zinc-400">/{String.slice(e.resource_id, 0, 8)}</span>
+              <span :if={e.resource_id} class="text-zinc-400">
+                /{String.slice(e.resource_id, 0, 8)}
+              </span>
             </td>
             <td class="px-3 py-1.5">{e.metadata["status"] || "—"}</td>
             <td class="px-3 py-1.5 text-zinc-500">{e.request_ip || "—"}</td>

--- a/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/index.ex
@@ -137,8 +137,10 @@ defmodule FountainWeb.ConversationsLive.Index do
             class={[
               "px-3 py-1 rounded text-sm font-mono border",
               if(@roots_only,
-                do: "bg-[var(--color-bg-2)] text-[var(--color-text-primary)] border-[var(--color-border)]",
-                else: "text-[var(--color-text-muted)] border-[var(--color-border)] hover:text-[var(--color-text-secondary)]"
+                do:
+                  "bg-[var(--color-bg-2)] text-[var(--color-text-primary)] border-[var(--color-border)]",
+                else:
+                  "text-[var(--color-text-muted)] border-[var(--color-border)] hover:text-[var(--color-text-secondary)]"
               )
             ]}
           >
@@ -173,15 +175,22 @@ defmodule FountainWeb.ConversationsLive.Index do
                 <div class="font-medium truncate" title={first_prompt(c) || c.title}>{c.title}</div>
               <% else %>
                 <%= case first_prompt(c) do %>
-                  <% nil -> %><span class="text-[var(--color-text-muted)]">—</span>
-                  <% prompt -> %><div class="line-clamp-3 text-[var(--color-text-muted)]" title={prompt}>{prompt}</div>
+                  <% nil -> %>
+                    <span class="text-[var(--color-text-muted)]">—</span>
+                  <% prompt -> %>
+                    <div class="line-clamp-3 text-[var(--color-text-muted)]" title={prompt}>
+                      {prompt}
+                    </div>
                 <% end %>
               <% end %>
             </div>
           </div>
         </:col>
         <:col :let={c} label="Agent">
-          <.link navigate={~p"/conversations/#{c.id}"} class="block truncate text-[var(--color-text-primary)] hover:underline font-medium">
+          <.link
+            navigate={~p"/conversations/#{c.id}"}
+            class="block truncate text-[var(--color-text-primary)] hover:underline font-medium"
+          >
             {agent_name(@agents_by_id, c.agent_id)}
           </.link>
           <div class="text-xs text-[var(--color-text-muted)] font-mono">{short(c.id)}</div>
@@ -203,14 +212,16 @@ defmodule FountainWeb.ConversationsLive.Index do
               variant="danger"
               phx-click="terminate"
               phx-value-id={c.id}
-              data-confirm="Terminate this conversation?">
+              data-confirm="Terminate this conversation?"
+            >
               Terminate
             </.button>
             <.button
               variant="secondary"
               phx-click="delete"
               phx-value-id={c.id}
-              data-confirm="Delete this conversation and all its turns? This cannot be undone.">
+              data-confirm="Delete this conversation and all its turns? This cannot be undone."
+            >
               Delete
             </.button>
           </div>

--- a/apps/fountain/lib/fountain_web/live/conversations_live/new.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/new.ex
@@ -138,13 +138,14 @@ defmodule FountainWeb.ConversationsLive.New do
             <.btn_secondary>Cancel</.btn_secondary>
           </.link>
           <span class="text-xs text-zinc-400 ml-1">
-            or
-            <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">
-              &#8984;
-            </kbd>
-            <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">
-              Enter
-            </kbd>
+            or <kbd
+              class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono"
+              phx-no-format
+            >&#8984;</kbd>
+            <kbd
+              class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono"
+              phx-no-format
+            >Enter</kbd>
           </span>
         </div>
       </form>

--- a/apps/fountain/lib/fountain_web/live/conversations_live/new.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/new.ex
@@ -78,23 +78,39 @@ defmodule FountainWeb.ConversationsLive.New do
     <div class="max-w-2xl space-y-6">
       <h1 class="text-2xl font-semibold">New conversation</h1>
 
-      <div :if={@agents == []} class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500 space-y-2">
+      <div
+        :if={@agents == []}
+        class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500 space-y-2"
+      >
         <div>No agents defined yet.</div>
         <.link navigate={~p"/agents/new"} class="text-zinc-900 underline">Create one</.link>
       </div>
 
-      <form :if={@agents != []} phx-change="validate" phx-submit="submit" class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200">
+      <form
+        :if={@agents != []}
+        phx-change="validate"
+        phx-submit="submit"
+        class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200"
+      >
         <div class="space-y-1">
           <label class="block text-sm font-medium text-zinc-700">Agent</label>
-          <select name="conv[agent_id]" class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm">
+          <select
+            name="conv[agent_id]"
+            class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+          >
             <option :for={a <- @agents} value={a.id} selected={@form["agent_id"] == a.id}>
               {a.name} ({a.runtime} &middot; {a.model})
             </option>
           </select>
         </div>
         <div :if={@vaults != []} class="space-y-1">
-          <label class="block text-sm font-medium text-zinc-700">Vault <span class="text-zinc-400 font-normal">(optional)</span></label>
-          <select name="conv[vault_id]" class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm">
+          <label class="block text-sm font-medium text-zinc-700">
+            Vault <span class="text-zinc-400 font-normal">(optional)</span>
+          </label>
+          <select
+            name="conv[vault_id]"
+            class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+          >
             <option value="" selected={@form["vault_id"] in [nil, ""]}>&#8212; none &#8212;</option>
             <option :for={v <- @vaults} value={v.id} selected={@form["vault_id"] == v.id}>
               {v.name}
@@ -104,13 +120,32 @@ defmodule FountainWeb.ConversationsLive.New do
             Layered on top of the environment's secrets at sprite spawn. Vault values win on key collision.
           </p>
         </div>
-        <.input id="prompt" name="conv[prompt]" type="textarea" label="First prompt"
-          value={@form["prompt"]} rows="6" placeholder="What should the agent do?" autofocus required
-          phx-hook="SubmitOnCmdEnter"/>
+        <.input
+          id="prompt"
+          name="conv[prompt]"
+          type="textarea"
+          label="First prompt"
+          value={@form["prompt"]}
+          rows="6"
+          placeholder="What should the agent do?"
+          autofocus
+          required
+          phx-hook="SubmitOnCmdEnter"
+        />
         <div class="flex gap-2 items-center">
           <.btn type="submit" phx-disable-with="Starting&hellip;">Start</.btn>
-          <.link navigate={~p"/"}><.btn_secondary>Cancel</.btn_secondary></.link>
-          <span class="text-xs text-zinc-400 ml-1">or <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">&#8984;</kbd> <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">Enter</kbd></span>
+          <.link navigate={~p"/"}>
+            <.btn_secondary>Cancel</.btn_secondary>
+          </.link>
+          <span class="text-xs text-zinc-400 ml-1">
+            or
+            <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">
+              &#8984;
+            </kbd>
+            <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">
+              Enter
+            </kbd>
+          </span>
         </div>
       </form>
     </div>

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -545,13 +545,14 @@ defmodule FountainWeb.ConversationsLive.Show do
           </label>
           <div class="flex items-center gap-3">
             <span class="text-xs text-zinc-400">
-              <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">
-                &#8984;
-              </kbd>
-              <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">
-                Enter
-              </kbd>
-              to send
+              <kbd
+                class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono"
+                phx-no-format
+              >&#8984;</kbd>
+              <kbd
+                class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono"
+                phx-no-format
+              >Enter</kbd> to send
             </span>
             <.btn type="submit" phx-disable-with="Sending…">Send</.btn>
           </div>

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -338,16 +338,20 @@ defmodule FountainWeb.ConversationsLive.Show do
         <div>
           <div class="text-sm text-zinc-500 font-mono">{@conv.id}</div>
           <div class="text-2xl font-semibold flex items-center gap-3">
-            Conversation
-            <.status_badge status={@conv.status} />
+            Conversation <.status_badge status={@conv.status} />
           </div>
           <div class="text-sm text-zinc-500">runtime: {@conv.runtime}</div>
           <div :if={@conv.sandbox} class="text-sm text-zinc-500 font-mono">
             sprite: {@conv.sandbox.sprite_name}
-            <span class="text-zinc-400">({String.slice(@conv.sandbox.id, 0, 8)} &middot; {@conv.sandbox.status})</span>
+            <span class="text-zinc-400">
+              ({String.slice(@conv.sandbox.id, 0, 8)} &middot; {@conv.sandbox.status})
+            </span>
           </div>
           <div :if={@conv.vault} class="text-sm text-zinc-500">
-            vault: <.link navigate={~p"/vaults/#{@conv.vault.id}/edit"} class="font-medium underline">{@conv.vault.name}</.link>
+            vault:
+            <.link navigate={~p"/vaults/#{@conv.vault.id}/edit"} class="font-medium underline">
+              {@conv.vault.name}
+            </.link>
           </div>
           <div class="text-sm text-zinc-500 flex items-center gap-1.5">
             source: <.source_badge source={@conv.source} />
@@ -363,16 +367,24 @@ defmodule FountainWeb.ConversationsLive.Show do
           </div>
         </div>
         <div class="flex gap-2">
-          <.btn_secondary :if={@conv.status == "running"}
-            phx-click="interrupt" data-confirm="Stop the running turn?">
+          <.btn_secondary
+            :if={@conv.status == "running"}
+            phx-click="interrupt"
+            data-confirm="Stop the running turn?"
+          >
             Interrupt
           </.btn_secondary>
-          <.btn_danger :if={@conv.status not in ["terminated", "failed"]}
-            phx-click="terminate" data-confirm="Terminate this conversation?">
+          <.btn_danger
+            :if={@conv.status not in ["terminated", "failed"]}
+            phx-click="terminate"
+            data-confirm="Terminate this conversation?"
+          >
             Terminate
           </.btn_danger>
-          <.btn_secondary phx-click="delete"
-            data-confirm="Delete this conversation and all its turns? This cannot be undone.">
+          <.btn_secondary
+            phx-click="delete"
+            data-confirm="Delete this conversation and all its turns? This cannot be undone."
+          >
             Delete
           </.btn_secondary>
         </div>
@@ -396,8 +408,16 @@ defmodule FountainWeb.ConversationsLive.Show do
         <div class={["flex items-center gap-2", @view_mode == :chat && "invisible"]}>
           <span class="text-zinc-500">show:</span>
           <.stream_pill name="stage" label="stage" active={MapSet.member?(@visible_streams, "stage")} />
-          <.stream_pill name="stdout" label="stdout" active={MapSet.member?(@visible_streams, "stdout")} />
-          <.stream_pill name="stderr" label="stderr" active={MapSet.member?(@visible_streams, "stderr")} />
+          <.stream_pill
+            name="stdout"
+            label="stdout"
+            active={MapSet.member?(@visible_streams, "stdout")}
+          />
+          <.stream_pill
+            name="stderr"
+            label="stderr"
+            active={MapSet.member?(@visible_streams, "stderr")}
+          />
         </div>
         <div
           id="view-mode-persist"
@@ -413,26 +433,40 @@ defmodule FountainWeb.ConversationsLive.Show do
 
       <%= case @view_mode do %>
         <% :chat -> %>
-          <div class="bg-gradient-to-b from-zinc-50 to-white rounded-lg shadow-sm border border-zinc-200 p-6 h-[60vh] overflow-y-auto"
-            id="log-stream" phx-hook="ScrollBottom">
-            <.chat_view turns={@turns_by_id} events={@events} conv={@conv}/>
-            <div :if={map_size(@turns_by_id) == 0} class="text-zinc-400 text-sm italic">Waiting for the first turn…</div>
+          <div
+            class="bg-gradient-to-b from-zinc-50 to-white rounded-lg shadow-sm border border-zinc-200 p-6 h-[60vh] overflow-y-auto"
+            id="log-stream"
+            phx-hook="ScrollBottom"
+          >
+            <.chat_view turns={@turns_by_id} events={@events} conv={@conv} />
+            <div :if={map_size(@turns_by_id) == 0} class="text-zinc-400 text-sm italic">
+              Waiting for the first turn…
+            </div>
           </div>
-
         <% :raw -> %>
-          <div class="bg-zinc-900 text-zinc-100 rounded shadow p-4 h-[60vh] overflow-y-auto font-mono text-xs"
-            id="log-stream" phx-hook="ScrollBottom">
+          <div
+            class="bg-zinc-900 text-zinc-100 rounded shadow p-4 h-[60vh] overflow-y-auto font-mono text-xs"
+            id="log-stream"
+            phx-hook="ScrollBottom"
+          >
             <%= for ev <- @events, event_visible?(ev, @visible_streams) do %>
-              <.raw_event_line event={ev}/>
+              <.raw_event_line event={ev} />
             <% end %>
             <div :if={@events == []} class="text-zinc-500">Waiting for output…</div>
           </div>
-
         <% _ -> %>
-          <div class="bg-zinc-900 text-zinc-100 rounded shadow p-4 h-[60vh] overflow-y-auto font-mono text-xs space-y-1"
-            id="log-stream" phx-hook="ScrollBottom">
+          <div
+            class="bg-zinc-900 text-zinc-100 rounded shadow p-4 h-[60vh] overflow-y-auto font-mono text-xs space-y-1"
+            id="log-stream"
+            phx-hook="ScrollBottom"
+          >
             <%= for node <- group_into_sections(@events, @visible_streams, @view_mode) do %>
-              <.tree_node node={node} runtime={@conv.runtime} view_mode={@view_mode} turns={@turns_by_id}/>
+              <.tree_node
+                node={node}
+                runtime={@conv.runtime}
+                view_mode={@view_mode}
+                turns={@turns_by_id}
+              />
             <% end %>
             <div :if={@events == []} class="text-zinc-500">Waiting for output…</div>
           </div>
@@ -450,30 +484,75 @@ defmodule FountainWeb.ConversationsLive.Show do
         </.link>
       </div>
 
-      <form :if={@subscription_active} phx-submit="send_prompt" phx-change="update_prompt" class="bg-white rounded shadow border border-zinc-200 p-4 space-y-3">
-        <.input id="prompt" name="prompt" type="textarea" rows="3"
-          value={@prompt} placeholder="Send another prompt…" phx-hook="SubmitOnCmdEnter"/>
+      <form
+        :if={@subscription_active}
+        phx-submit="send_prompt"
+        phx-change="update_prompt"
+        class="bg-white rounded shadow border border-zinc-200 p-4 space-y-3"
+      >
+        <.input
+          id="prompt"
+          name="prompt"
+          type="textarea"
+          rows="3"
+          value={@prompt}
+          placeholder="Send another prompt…"
+          phx-hook="SubmitOnCmdEnter"
+        />
         <div :if={@pending_images != []} class="flex flex-wrap gap-2">
           <%= for img <- @pending_images do %>
             <div class="relative group">
-              <img src={img["url"]} class="h-16 w-16 object-cover rounded border border-zinc-200 cursor-pointer"
-                onclick={"window.open('#{img["url"]}', '_blank')"} />
-              <span class="absolute -top-1 -right-1 hidden group-hover:flex bg-zinc-800 text-white text-[9px] rounded px-1">{img["name"]}</span>
+              <img
+                src={img["url"]}
+                class="h-16 w-16 object-cover rounded border border-zinc-200 cursor-pointer"
+                onclick={"window.open('#{img["url"]}', '_blank')"}
+              />
+              <span class="absolute -top-1 -right-1 hidden group-hover:flex bg-zinc-800 text-white text-[9px] rounded px-1">
+                {img["name"]}
+              </span>
             </div>
           <% end %>
         </div>
         <div class="flex justify-between items-center gap-3">
           <label class="cursor-pointer flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-700">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
             </svg>
-            <span>{if @pending_images == [], do: "Attach images", else: "#{length(@pending_images)} image(s)"}</span>
-            <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" multiple class="hidden"
-              id="image-picker" phx-hook="ImagePicker" />
+            <span>
+              {if @pending_images == [],
+                do: "Attach images",
+                else: "#{length(@pending_images)} image(s)"}
+            </span>
+            <input
+              type="file"
+              accept="image/png,image/jpeg,image/gif,image/webp"
+              multiple
+              class="hidden"
+              id="image-picker"
+              phx-hook="ImagePicker"
+            />
           </label>
           <div class="flex items-center gap-3">
-            <span class="text-xs text-zinc-400"><kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">&#8984;</kbd> <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">Enter</kbd> to send</span>
+            <span class="text-xs text-zinc-400">
+              <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">
+                &#8984;
+              </kbd>
+              <kbd class="px-1 py-0.5 bg-zinc-100 border border-zinc-200 rounded text-[10px] font-mono">
+                Enter
+              </kbd>
+              to send
+            </span>
             <.btn type="submit" phx-disable-with="Sending…">Send</.btn>
           </div>
         </div>
@@ -525,19 +604,25 @@ defmodule FountainWeb.ConversationsLive.Show do
 
   defp source_badge(%{source: "ui"} = assigns) do
     ~H"""
-    <span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-700">ui</span>
+    <span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-700">
+      ui
+    </span>
     """
   end
 
   defp source_badge(%{source: "agent"} = assigns) do
     ~H"""
-    <span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-amber-100 text-amber-700">agent</span>
+    <span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-amber-100 text-amber-700">
+      agent
+    </span>
     """
   end
 
   defp source_badge(assigns) do
     ~H"""
-    <span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-zinc-100 text-zinc-600">{@source}</span>
+    <span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-zinc-100 text-zinc-600">
+      {@source}
+    </span>
     """
   end
 
@@ -558,7 +643,7 @@ defmodule FountainWeb.ConversationsLive.Show do
     ~H"""
     <div class="space-y-6">
       <%= for turn <- @ordered_turns do %>
-        <.chat_turn turn={turn} events={Map.get(@events_by_turn, turn.id, [])} conv={@conv}/>
+        <.chat_turn turn={turn} events={Map.get(@events_by_turn, turn.id, [])} conv={@conv} />
       <% end %>
     </div>
     """
@@ -601,8 +686,10 @@ defmodule FountainWeb.ConversationsLive.Show do
         <div :if={@image_count > 0} class="flex flex-wrap gap-2 mb-2">
           <%= for pos <- 0..(@image_count - 1) do %>
             <a href={"/conversations/#{@conv.id}/turns/#{@turn.id}/images/#{pos}"} target="_blank">
-              <img src={"/conversations/#{@conv.id}/turns/#{@turn.id}/images/#{pos}"}
-                class="max-w-[300px] max-h-[200px] object-contain rounded border border-blue-400/30" />
+              <img
+                src={"/conversations/#{@conv.id}/turns/#{@turn.id}/images/#{pos}"}
+                class="max-w-[300px] max-h-[200px] object-contain rounded border border-blue-400/30"
+              />
             </a>
           <% end %>
         </div>
@@ -634,9 +721,9 @@ defmodule FountainWeb.ConversationsLive.Show do
         muted
       >
         <div class="flex items-center gap-1.5">
-          <span class="size-1.5 rounded-full bg-zinc-400 animate-pulse"/>
-          <span class="size-1.5 rounded-full bg-zinc-400 animate-pulse [animation-delay:200ms]"/>
-          <span class="size-1.5 rounded-full bg-zinc-400 animate-pulse [animation-delay:400ms]"/>
+          <span class="size-1.5 rounded-full bg-zinc-400 animate-pulse" />
+          <span class="size-1.5 rounded-full bg-zinc-400 animate-pulse [animation-delay:200ms]" />
+          <span class="size-1.5 rounded-full bg-zinc-400 animate-pulse [animation-delay:400ms]" />
         </div>
       </.chat_message>
 
@@ -684,7 +771,9 @@ defmodule FountainWeb.ConversationsLive.Show do
       ]}>
         <div class="flex items-baseline gap-2 px-1">
           <span class="text-xs font-medium text-zinc-700">{@name}</span>
-          <span :if={@timestamp} class="text-[10px] text-zinc-400 font-mono">{format_chat_time(@timestamp)}</span>
+          <span :if={@timestamp} class="text-[10px] text-zinc-400 font-mono">
+            {format_chat_time(@timestamp)}
+          </span>
         </div>
         <div class={[
           "rounded-2xl px-4 py-2.5 text-sm shadow-sm",
@@ -881,7 +970,7 @@ defmodule FountainWeb.ConversationsLive.Show do
 
   defp tree_node(%{node: %{kind: :event}} = assigns) do
     ~H"""
-    <.event_line event={@node.event} runtime={@runtime} view_mode={@view_mode}/>
+    <.event_line event={@node.event} runtime={@runtime} view_mode={@view_mode} />
     """
   end
 
@@ -962,13 +1051,13 @@ defmodule FountainWeb.ConversationsLive.Show do
           <% :cards -> %>
             <div class="space-y-1">
               <%= for block <- turn_blocks(@node.children, @runtime) do %>
-                <.block_row block={block} stream="stdout"/>
+                <.block_row block={block} stream="stdout" />
               <% end %>
             </div>
           <% _ -> %>
             <div class="space-y-1">
               <%= for child <- @node.children do %>
-                <.tree_node node={child} runtime={@runtime} view_mode={@view_mode} turns={@turns}/>
+                <.tree_node node={child} runtime={@runtime} view_mode={@view_mode} turns={@turns} />
               <% end %>
             </div>
         <% end %>
@@ -1096,17 +1185,29 @@ defmodule FountainWeb.ConversationsLive.Show do
         <span class="text-zinc-400">&#128295;</span>
         <span class="font-semibold">{@block.name}</span>
         <span :if={@block[:summary]} class="text-zinc-500 truncate flex-1">{@block.summary}</span>
-        <span :if={@block[:result] && @block.result.error?} class="text-rose-300 text-[10px] shrink-0">error</span>
-        <span :if={@block[:result] && not @block.result.error?} class="text-emerald-400 text-[10px] shrink-0">&#10003;</span>
+        <span :if={@block[:result] && @block.result.error?} class="text-rose-300 text-[10px] shrink-0">
+          error
+        </span>
+        <span
+          :if={@block[:result] && not @block.result.error?}
+          class="text-emerald-400 text-[10px] shrink-0"
+        >
+          &#10003;
+        </span>
       </summary>
       <div class="mt-1 space-y-1">
         <div class="text-zinc-500 text-[10px] uppercase tracking-wider">input</div>
         <pre class="text-zinc-300 whitespace-pre-wrap text-xs">{@block.body}</pre>
-        <div :if={@block[:result]} class="text-zinc-500 text-[10px] uppercase tracking-wider mt-1">result</div>
-        <pre :if={@block[:result]} class={[
-          "whitespace-pre-wrap text-xs",
-          if(@block.result.error?, do: "text-rose-300", else: "text-zinc-300")
-        ]}>{@block.result.body}</pre>
+        <div :if={@block[:result]} class="text-zinc-500 text-[10px] uppercase tracking-wider mt-1">
+          result
+        </div>
+        <pre
+          :if={@block[:result]}
+          class={[
+            "whitespace-pre-wrap text-xs",
+            if(@block.result.error?, do: "text-rose-300", else: "text-zinc-300")
+          ]}
+        >{@block.result.body}</pre>
       </div>
     </details>
     """

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -27,35 +27,47 @@ defmodule FountainWeb.DashboardLive.Index do
   def render(assigns) do
     ~H"""
     <div class="space-y-6">
-      <div :if={@show_onboarding_banner}
-        class="rounded bg-green-50 border border-green-200 px-4 py-3 flex items-center justify-between">
+      <div
+        :if={@show_onboarding_banner}
+        class="rounded bg-green-50 border border-green-200 px-4 py-3 flex items-center justify-between"
+      >
         <span class="text-sm text-green-800">
           You're up and running. Explore Environments, Agents, and Vaults in the sidebar.
         </span>
-        <button phx-click="dismiss_banner"
-          class="text-green-600 hover:text-green-800 text-xs underline ml-4">
+        <button
+          phx-click="dismiss_banner"
+          class="text-green-600 hover:text-green-800 text-xs underline ml-4"
+        >
           Dismiss
         </button>
       </div>
 
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Dashboard</h1>
-        <.link navigate={~p"/conversations/new"}><.btn>+ New conversation</.btn></.link>
+        <.link navigate={~p"/conversations/new"}>
+          <.btn>+ New conversation</.btn>
+        </.link>
       </div>
 
       <div class="grid grid-cols-3 gap-4">
-        <.link navigate={~p"/conversations"}
-          class="rounded border border-zinc-200 bg-white shadow p-4 hover:bg-zinc-50 block">
+        <.link
+          navigate={~p"/conversations"}
+          class="rounded border border-zinc-200 bg-white shadow p-4 hover:bg-zinc-50 block"
+        >
           <p class="text-xs text-zinc-500 uppercase tracking-wide">Recent conversations</p>
           <p class="text-2xl font-semibold mt-1">{length(@recent_conversations)}</p>
         </.link>
-        <.link navigate={~p"/agents"}
-          class="rounded border border-zinc-200 bg-white shadow p-4 hover:bg-zinc-50 block">
+        <.link
+          navigate={~p"/agents"}
+          class="rounded border border-zinc-200 bg-white shadow p-4 hover:bg-zinc-50 block"
+        >
           <p class="text-xs text-zinc-500 uppercase tracking-wide">Agents</p>
           <p class="text-2xl font-semibold mt-1">{@agent_count}</p>
         </.link>
-        <.link navigate={~p"/environments"}
-          class="rounded border border-zinc-200 bg-white shadow p-4 hover:bg-zinc-50 block">
+        <.link
+          navigate={~p"/environments"}
+          class="rounded border border-zinc-200 bg-white shadow p-4 hover:bg-zinc-50 block"
+        >
           <p class="text-xs text-zinc-500 uppercase tracking-wide">Environments</p>
           <p class="text-2xl font-semibold mt-1">→</p>
         </.link>
@@ -65,8 +77,10 @@ defmodule FountainWeb.DashboardLive.Index do
         <h2 class="text-lg font-medium mb-2">Recent conversations</h2>
         <table class="w-full text-sm bg-white rounded shadow border border-zinc-200">
           <tbody>
-            <tr :for={c <- @recent_conversations}
-              class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50">
+            <tr
+              :for={c <- @recent_conversations}
+              class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50"
+            >
               <td class="px-4 py-2">
                 <.link navigate={~p"/conversations/#{c.id}"} class="font-medium hover:underline">
                   {if c.agent, do: c.agent.name, else: "(no agent)"}
@@ -79,8 +93,10 @@ defmodule FountainWeb.DashboardLive.Index do
         </table>
       </div>
 
-      <div :if={@recent_conversations == []}
-        class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500 space-y-2">
+      <div
+        :if={@recent_conversations == []}
+        class="rounded border border-dashed border-zinc-300 p-8 text-center text-zinc-500 space-y-2"
+      >
         <p>No conversations yet.</p>
         <.link navigate={~p"/conversations/new"} class="text-zinc-900 underline">
           Start your first conversation

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -344,9 +344,13 @@ defmodule FountainWeb.EnvironmentsLive.Form do
     <div class="max-w-3xl space-y-6">
       <h1 class="text-2xl font-semibold">{page_title(@action)}</h1>
 
-      <form phx-change="validate" phx-submit="submit" class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200">
+      <form
+        phx-change="validate"
+        phx-submit="submit"
+        class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200"
+      >
         <.input id="env_name" name="env[name]" label="Name" value={@form["name"]} autofocus required />
-        <.error_msg field="name" errors={@errors}/>
+        <.error_msg field="name" errors={@errors} />
 
         <%!-- Packages --%>
         <div class="space-y-2">
@@ -394,9 +398,15 @@ defmodule FountainWeb.EnvironmentsLive.Form do
           <.error_msg field="packages" errors={@errors} />
         </div>
 
-        <.input id="setup_script" name="env[setup_script]" type="textarea" rows="6"
-          label="Setup script (runs after packages, before agent turns)" value={@form["setup_script"]}
-          placeholder="curl -LsSf https://astral.sh/uv/install.sh | sh"/>
+        <.input
+          id="setup_script"
+          name="env[setup_script]"
+          type="textarea"
+          rows="6"
+          label="Setup script (runs after packages, before agent turns)"
+          value={@form["setup_script"]}
+          placeholder="curl -LsSf https://astral.sh/uv/install.sh | sh"
+        />
 
         <%!-- Env vars --%>
         <div class="space-y-2">
@@ -461,7 +471,9 @@ defmodule FountainWeb.EnvironmentsLive.Form do
             class="border border-zinc-200 rounded-md p-3 space-y-2 bg-zinc-50"
           >
             <div class="flex items-center justify-between">
-              <span class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Repo {i + 1}</span>
+              <span class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">
+                Repo {i + 1}
+              </span>
               <button
                 type="button"
                 phx-click="remove_repo"
@@ -513,10 +525,13 @@ defmodule FountainWeb.EnvironmentsLive.Form do
           <.error_msg field="repositories" errors={@errors} />
           <p class="text-xs text-zinc-500 mt-1">
             Repos are cloned into the sprite before your setup script runs.
-            Set <code>mount_path</code> to where the repo should appear — use
-            <code>/workspace/repo-name</code> as the convention (cloned repos live under
-            <code>/workspace/</code> in the sprite). Use <code>secret_key</code> to name
-            an env secret whose value is passed as <code>x-access-token</code> for
+            Set <code>mount_path</code>
+            to where the repo should appear — use <code>/workspace/repo-name</code>
+            as the convention (cloned repos live under <code>/workspace/</code>
+            in the sprite). Use <code>secret_key</code>
+            to name
+            an env secret whose value is passed as <code>x-access-token</code>
+            for
             cloning private repos.
           </p>
         </div>
@@ -524,23 +539,43 @@ defmodule FountainWeb.EnvironmentsLive.Form do
         <div class="grid grid-cols-2 gap-3">
           <div class="space-y-1">
             <label class="block text-sm font-medium text-zinc-700">Networking</label>
-            <select name="env[networking_type]" class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm">
-              <option :for={t <- ~w(unrestricted limited)} value={t} selected={@form["networking_type"] == t}>{t}</option>
+            <select
+              name="env[networking_type]"
+              class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+            >
+              <option
+                :for={t <- ~w(unrestricted limited)}
+                value={t}
+                selected={@form["networking_type"] == t}
+              >
+                {t}
+              </option>
             </select>
           </div>
-          <.input id="networking_config_json" name="env[networking_config_json]" type="textarea" rows="2"
-            label="Networking config (JSON, used when limited)" value={@form["networking_config_json"]}
-            placeholder='{"allowed_hosts": ["github.com", "api.anthropic.com"]}'/>
+          <.input
+            id="networking_config_json"
+            name="env[networking_config_json]"
+            type="textarea"
+            rows="2"
+            label="Networking config (JSON, used when limited)"
+            value={@form["networking_config_json"]}
+            placeholder='{"allowed_hosts": ["github.com", "api.anthropic.com"]}'
+          />
         </div>
-        <.error_msg field="networking_config_json" errors={@errors}/>
+        <.error_msg field="networking_config_json" errors={@errors} />
 
         <div class="flex gap-2">
           <.btn type="submit" phx-disable-with="Saving…">Save</.btn>
-          <.link navigate={~p"/environments"}><.btn_secondary>Cancel</.btn_secondary></.link>
+          <.link navigate={~p"/environments"}>
+            <.btn_secondary>Cancel</.btn_secondary>
+          </.link>
         </div>
       </form>
 
-      <section :if={@action == :edit} class="bg-white rounded shadow p-6 border border-zinc-200 space-y-4">
+      <section
+        :if={@action == :edit}
+        class="bg-white rounded shadow p-6 border border-zinc-200 space-y-4"
+      >
         <h2 class="text-lg font-semibold">Secrets</h2>
         <p class="text-sm text-zinc-500">
           Encrypted at rest with AES-256-GCM. Values are written into the sprite environment at
@@ -553,9 +588,13 @@ defmodule FountainWeb.EnvironmentsLive.Form do
           <tbody>
             <tr :for={s <- @secrets} class="border-b border-zinc-100 last:border-0">
               <td class="py-2 font-mono">{s.key}</td>
-              <td class="py-2 text-zinc-400 font-mono text-xs">&bull;&bull;&bull;&bull;&bull;&bull;&bull;</td>
+              <td class="py-2 text-zinc-400 font-mono text-xs">
+                &bull;&bull;&bull;&bull;&bull;&bull;&bull;
+              </td>
               <td class="py-2 text-right">
-                <.btn_danger phx-click="delete_secret" phx-value-id={s.id} data-confirm="Delete?">Delete</.btn_danger>
+                <.btn_danger phx-click="delete_secret" phx-value-id={s.id} data-confirm="Delete?">
+                  Delete
+                </.btn_danger>
               </td>
             </tr>
           </tbody>
@@ -570,11 +609,19 @@ defmodule FountainWeb.EnvironmentsLive.Form do
           phx-submit="add_secret"
           class="flex flex-col sm:flex-row gap-2"
         >
-          <input type="text" name="secret[key]" placeholder="KEY"
+          <input
+            type="text"
+            name="secret[key]"
+            placeholder="KEY"
             pattern="[A-Z][A-Z0-9_]*"
-            class="flex-1 rounded border border-zinc-300 px-3 py-2 text-sm font-mono"/>
-          <input type="password" name="secret[value]" placeholder="value"
-            class="flex-[2] rounded border border-zinc-300 px-3 py-2 text-sm font-mono"/>
+            class="flex-1 rounded border border-zinc-300 px-3 py-2 text-sm font-mono"
+          />
+          <input
+            type="password"
+            name="secret[value]"
+            placeholder="value"
+            class="flex-[2] rounded border border-zinc-300 px-3 py-2 text-sm font-mono"
+          />
           <.btn type="submit">Add secret</.btn>
         </form>
       </section>
@@ -587,7 +634,9 @@ defmodule FountainWeb.EnvironmentsLive.Form do
 
   defp error_msg(assigns) do
     ~H"""
-    <p :if={Map.has_key?(@errors, @field)} class="text-rose-600 text-xs">{Map.get(@errors, @field)}</p>
+    <p :if={Map.has_key?(@errors, @field)} class="text-rose-600 text-xs">
+      {Map.get(@errors, @field)}
+    </p>
     """
   end
 end

--- a/apps/fountain/lib/fountain_web/live/environments_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/index.ex
@@ -65,7 +65,9 @@ defmodule FountainWeb.EnvironmentsLive.Index do
     <div class="space-y-4">
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Environments</h1>
-        <.link navigate={~p"/environments/new"}><.btn>+ New environment</.btn></.link>
+        <.link navigate={~p"/environments/new"}>
+          <.btn>+ New environment</.btn>
+        </.link>
       </div>
 
       <%!-- Search bar --%>
@@ -86,7 +88,9 @@ defmodule FountainWeb.EnvironmentsLive.Index do
         class="rounded-lg p-10 text-center bg-[var(--color-bg-1)] border border-dashed border-[var(--color-border)]"
       >
         <p class="text-sm text-[var(--color-text-muted)]">No environments yet.</p>
-        <p class="text-xs mt-1 text-[var(--color-text-secondary)]">Create one to configure packages, secrets, and a setup script for your agents.</p>
+        <p class="text-xs mt-1 text-[var(--color-text-secondary)]">
+          Create one to configure packages, secrets, and a setup script for your agents.
+        </p>
       </div>
 
       <%!-- Empty state — search returned nothing --%>
@@ -106,10 +110,18 @@ defmodule FountainWeb.EnvironmentsLive.Index do
       >
         <thead class="border-b border-[var(--color-border)]">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Name</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Network</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Setup</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Stats</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Name
+            </th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Network
+            </th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Setup
+            </th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Stats
+            </th>
             <th class="px-4 py-3"></th>
           </tr>
         </thead>
@@ -120,7 +132,10 @@ defmodule FountainWeb.EnvironmentsLive.Index do
           >
             <td class="px-4 py-3 font-medium text-[var(--color-text-primary)]">{e.name}</td>
             <td class="px-4 py-3">
-              <span class={["inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold", networking_badge_class(e.networking_type)]}>
+              <span class={[
+                "inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold",
+                networking_badge_class(e.networking_type)
+              ]}>
                 <span class="w-1.5 h-1.5 rounded-full" style="background:currentColor;"></span>
                 {e.networking_type}
               </span>
@@ -130,29 +145,45 @@ defmodule FountainWeb.EnvironmentsLive.Index do
                 :if={e.setup_script != ""}
                 class="font-mono text-xs block truncate max-w-xs text-[var(--color-text-muted)]"
                 title={e.setup_script}
-              >{truncate(e.setup_script, 48)}</span>
+              >
+                {truncate(e.setup_script, 48)}
+              </span>
               <span :if={e.setup_script == ""} class="text-[var(--color-text-muted)]">&#8212;</span>
             </td>
             <td class="px-4 py-3">
               <div class="flex items-center gap-1.5 flex-wrap">
                 <span
-                  class={["inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium", stat_badge_class(:secrets, e.secret_count)]}
+                  class={[
+                    "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
+                    stat_badge_class(:secrets, e.secret_count)
+                  ]}
                   title={"#{e.secret_count} secrets"}
-                >&#128273; {e.secret_count}</span>
+                >
+                  &#128273; {e.secret_count}
+                </span>
                 <span
-                  class={["inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium", stat_badge_class(:agents, e.agent_count)]}
+                  class={[
+                    "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
+                    stat_badge_class(:agents, e.agent_count)
+                  ]}
                   title={"#{e.agent_count} agents"}
-                >&#9889; {e.agent_count}</span>
+                >
+                  &#9889; {e.agent_count}
+                </span>
                 <span
                   :if={map_size(e.packages) > 0}
                   class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-[var(--color-bg-2)] text-[var(--color-brand)] border border-[var(--color-brand)]"
                   title={"#{map_size(e.packages)} packages"}
-                >&#128230; {map_size(e.packages)}</span>
+                >
+                  &#128230; {map_size(e.packages)}
+                </span>
                 <span
                   :if={length(e.repositories) > 0}
                   class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-[var(--color-info-bg)] text-[var(--color-info-text)] border border-[var(--color-info)]"
                   title={"#{length(e.repositories)} repos"}
-                >&#9322; {length(e.repositories)}</span>
+                >
+                  &#9322; {length(e.repositories)}
+                </span>
               </div>
             </td>
             <td class="px-4 py-3 text-right">
@@ -165,7 +196,9 @@ defmodule FountainWeb.EnvironmentsLive.Index do
                   phx-click="delete"
                   phx-value-id={e.id}
                   data-confirm="Delete environment?"
-                >Delete</button>
+                >
+                  Delete
+                </button>
               </div>
             </td>
           </tr>

--- a/apps/fountain/lib/fountain_web/live/inference_credentials_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/inference_credentials_live/index.ex
@@ -168,8 +168,10 @@ defmodule FountainWeb.InferenceCredentialsLive.Index do
         </p>
       </div>
 
-      <div :for={{provider, label, env_name, hint} <- @providers}
-           class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-1)] p-5 space-y-3">
+      <div
+        :for={{provider, label, env_name, hint} <- @providers}
+        class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-1)] p-5 space-y-3"
+      >
         <div class="flex items-start justify-between gap-3">
           <div>
             <div class="flex items-center gap-2">
@@ -186,17 +188,25 @@ defmodule FountainWeb.InferenceCredentialsLive.Index do
         <form phx-submit="save" class="space-y-2">
           <input type="hidden" name="provider" value={Atom.to_string(provider)} />
           <div class="flex gap-2">
-            <input type="password"
-                   name="value"
-                   placeholder={if Map.get(@status, provider, false), do: "Paste a new value to replace", else: "Paste your token"}
-                   autocomplete="off"
-                   class="flex-1 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-zinc-900" />
+            <input
+              type="password"
+              name="value"
+              placeholder={
+                if Map.get(@status, provider, false),
+                  do: "Paste a new value to replace",
+                  else: "Paste your token"
+              }
+              autocomplete="off"
+              class="flex-1 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-zinc-900"
+            />
             <.button type="submit">Save</.button>
-            <.button :if={Map.get(@status, provider, false)}
-                     type="button"
-                     phx-click="clear"
-                     phx-value-provider={Atom.to_string(provider)}
-                     variant="secondary">
+            <.button
+              :if={Map.get(@status, provider, false)}
+              type="button"
+              phx-click="clear"
+              phx-value-provider={Atom.to_string(provider)}
+              variant="secondary"
+            >
               Clear
             </.button>
           </div>

--- a/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/log_viewer_live/show.ex
@@ -56,7 +56,10 @@ defmodule FountainWeb.LogViewerLive.Show do
     <div class="space-y-4">
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-3">
-          <.link navigate={~p"/conversations/#{@conversation.id}"} class="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] text-sm">
+          <.link
+            navigate={~p"/conversations/#{@conversation.id}"}
+            class="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] text-sm"
+          >
             ← Conversation
           </.link>
           <h1 class="text-lg font-semibold font-mono">
@@ -74,8 +77,12 @@ defmodule FountainWeb.LogViewerLive.Show do
         <div :if={@logs == []} class="text-zinc-500 italic">No log output yet.</div>
         <div :for={event <- @logs} class={["leading-5", log_line_class(event)]}>
           <span class="text-zinc-500 select-none mr-3">{format_ts(event.inserted_at)}</span>
-          <span :if={event.kind == "stage"} class="text-yellow-400">[stage:{event.stage}:{event.state}]</span>
-          <span :if={event.kind != "stage"} class={log_stream_class(event.stream)}>[{event.stream}]</span>
+          <span :if={event.kind == "stage"} class="text-yellow-400">
+            [stage:{event.stage}:{event.state}]
+          </span>
+          <span :if={event.kind != "stage"} class={log_stream_class(event.stream)}>
+            [{event.stream}]
+          </span>
           <span class="ml-2 whitespace-pre-wrap">{event.data}</span>
         </div>
       </.code_block>

--- a/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
+++ b/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
@@ -234,19 +234,26 @@ defmodule FountainWeb.OnboardingLive.Wizard do
                 providers={@inference_providers}
                 status={@inference_status}
                 messages={@inference_messages}
-                any_set?={Enum.any?(@inference_status, fn {_, set?} -> set? end)} />
+                any_set?={Enum.any?(@inference_status, fn {_, set?} -> set? end)}
+              />
             <% "step_2" -> %>
               <.step_env env_form={@env_form} env_errors={@env_errors} />
             <% "step_3" -> %>
-              <.step_agent agent_form={@agent_form} agent_errors={@agent_errors} environments={@environments} />
+              <.step_agent
+                agent_form={@agent_form}
+                agent_errors={@agent_errors}
+                environments={@environments}
+              />
             <% "step_4" -> %>
               <.step_start agents={@agents} />
           <% end %>
         </div>
 
         <div class="text-center">
-          <button phx-click="skip_wizard"
-            class="text-xs text-zinc-400 hover:text-zinc-600 underline">
+          <button
+            phx-click="skip_wizard"
+            class="text-xs text-zinc-400 hover:text-zinc-600 underline"
+          >
             Skip setup and go to dashboard
           </button>
         </div>
@@ -285,7 +292,10 @@ defmodule FountainWeb.OnboardingLive.Wizard do
           ]}>
             {num}
           </div>
-          <span class={["text-sm", if(i <= @current_index, do: "text-zinc-900 font-medium", else: "text-zinc-400")]}>
+          <span class={[
+            "text-sm",
+            if(i <= @current_index, do: "text-zinc-900 font-medium", else: "text-zinc-400")
+          ]}>
             {label}
           </span>
           <div :if={i < length(@steps) - 1} class="w-8 h-px bg-zinc-300 mx-1"></div>
@@ -311,29 +321,39 @@ defmodule FountainWeb.OnboardingLive.Wizard do
       </div>
 
       <div class="space-y-3">
-        <div :for={{provider, label, source} <- @providers}
-             class="rounded-md border border-zinc-200 p-3 space-y-2">
+        <div
+          :for={{provider, label, source} <- @providers}
+          class="rounded-md border border-zinc-200 p-3 space-y-2"
+        >
           <div class="flex items-center justify-between">
             <div>
               <span class="text-sm font-medium">{label}</span>
               <span class="text-xs text-zinc-500 ml-2">Get from {source}</span>
             </div>
             <%= if Map.get(@status, provider, false) do %>
-              <span class="inline-flex items-center rounded-full bg-emerald-100 text-emerald-800 px-2 py-0.5 text-xs font-medium">Set</span>
+              <span class="inline-flex items-center rounded-full bg-emerald-100 text-emerald-800 px-2 py-0.5 text-xs font-medium">
+                Set
+              </span>
             <% else %>
-              <span class="inline-flex items-center rounded-full bg-zinc-100 text-zinc-600 px-2 py-0.5 text-xs">Not set</span>
+              <span class="inline-flex items-center rounded-full bg-zinc-100 text-zinc-600 px-2 py-0.5 text-xs">
+                Not set
+              </span>
             <% end %>
           </div>
 
           <form phx-submit="save_credential" class="flex gap-2">
             <input type="hidden" name="provider" value={Atom.to_string(provider)} />
-            <input type="password"
-                   name="value"
-                   placeholder={if Map.get(@status, provider, false), do: "Replace…", else: "Paste token"}
-                   autocomplete="off"
-                   class="flex-1 rounded-md border border-zinc-300 px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-zinc-900" />
-            <button type="submit"
-                    class="rounded-md bg-zinc-900 text-white px-3 py-1.5 text-xs font-medium hover:bg-zinc-700">
+            <input
+              type="password"
+              name="value"
+              placeholder={if Map.get(@status, provider, false), do: "Replace…", else: "Paste token"}
+              autocomplete="off"
+              class="flex-1 rounded-md border border-zinc-300 px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-zinc-900"
+            />
+            <button
+              type="submit"
+              class="rounded-md bg-zinc-900 text-white px-3 py-1.5 text-xs font-medium hover:bg-zinc-700"
+            >
               Save
             </button>
           </form>
@@ -348,15 +368,17 @@ defmodule FountainWeb.OnboardingLive.Wizard do
         </div>
       </div>
 
-      <button phx-click="continue_from_inference"
-              disabled={!@any_set?}
-              class={[
-                "w-full rounded-md px-4 py-2 text-sm font-medium",
-                if(@any_set?,
-                  do: "bg-zinc-900 text-white hover:bg-zinc-700",
-                  else: "bg-zinc-200 text-zinc-400 cursor-not-allowed"
-                )
-              ]}>
+      <button
+        phx-click="continue_from_inference"
+        disabled={!@any_set?}
+        class={[
+          "w-full rounded-md px-4 py-2 text-sm font-medium",
+          if(@any_set?,
+            do: "bg-zinc-900 text-white hover:bg-zinc-700",
+            else: "bg-zinc-200 text-zinc-400 cursor-not-allowed"
+          )
+        ]}
+      >
         Continue →
       </button>
     </div>
@@ -380,28 +402,43 @@ defmodule FountainWeb.OnboardingLive.Wizard do
       <form phx-change="validate_env" phx-submit="create_env" class="space-y-4">
         <div class="space-y-1">
           <label class="block text-sm font-medium text-zinc-700">Name</label>
-          <input type="text" name="env[name]" value={@env_form["name"]}
-            placeholder="my-dev-env" autofocus
-            class="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"/>
+          <input
+            type="text"
+            name="env[name]"
+            value={@env_form["name"]}
+            placeholder="my-dev-env"
+            autofocus
+            class="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+          />
           <p :if={Map.has_key?(@env_errors, "name")} class="text-rose-600 text-xs">
             {Map.get(@env_errors, "name")}
           </p>
         </div>
 
         <div class="space-y-1">
-          <label class="block text-sm font-medium text-zinc-700">Setup script <span class="text-zinc-400 font-normal">(optional)</span></label>
-          <textarea name="env[setup_script]" rows="3"
+          <label class="block text-sm font-medium text-zinc-700">
+            Setup script <span class="text-zinc-400 font-normal">(optional)</span>
+          </label>
+          <textarea
+            name="env[setup_script]"
+            rows="3"
             placeholder="curl -LsSf https://astral.sh/uv/install.sh | sh"
-            class="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-zinc-900">{@env_form["setup_script"]}</textarea>
+            class="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-zinc-900"
+          >{@env_form["setup_script"]}</textarea>
         </div>
 
         <div class="flex gap-2 pt-2">
-          <button type="submit"
-            class="flex-1 rounded-md bg-zinc-900 text-white px-4 py-2 text-sm font-medium hover:bg-zinc-700">
+          <button
+            type="submit"
+            class="flex-1 rounded-md bg-zinc-900 text-white px-4 py-2 text-sm font-medium hover:bg-zinc-700"
+          >
             Create environment &amp; continue
           </button>
-          <button type="button" phx-click="skip_env"
-            class="rounded-md border border-zinc-300 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-50">
+          <button
+            type="button"
+            phx-click="skip_env"
+            class="rounded-md border border-zinc-300 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-50"
+          >
             Skip
           </button>
         </div>
@@ -427,37 +464,56 @@ defmodule FountainWeb.OnboardingLive.Wizard do
       <form phx-change="validate_agent" phx-submit="create_agent" class="space-y-4">
         <div class="space-y-1">
           <label class="block text-sm font-medium text-zinc-700">Name</label>
-          <input type="text" name="agent[name]" value={@agent_form["name"]}
-            placeholder="My first agent" autofocus
-            class="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"/>
+          <input
+            type="text"
+            name="agent[name]"
+            value={@agent_form["name"]}
+            placeholder="My first agent"
+            autofocus
+            class="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+          />
           <p :if={Map.has_key?(@agent_errors, "name")} class="text-rose-600 text-xs">
             {Map.get(@agent_errors, "name")}
           </p>
         </div>
 
         <div class="space-y-1">
-          <label class="block text-sm font-medium text-zinc-700">System prompt <span class="text-zinc-400 font-normal">(optional)</span></label>
-          <textarea name="agent[system_prompt]" rows="4"
+          <label class="block text-sm font-medium text-zinc-700">
+            System prompt <span class="text-zinc-400 font-normal">(optional)</span>
+          </label>
+          <textarea
+            name="agent[system_prompt]"
+            rows="4"
             placeholder="You are a helpful assistant..."
-            class="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900">{@agent_form["system_prompt"]}</textarea>
+            class="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+          >{@agent_form["system_prompt"]}</textarea>
         </div>
 
         <div :if={@environments != []} class="space-y-1">
-          <label class="block text-sm font-medium text-zinc-700">Environment <span class="text-zinc-400 font-normal">(optional)</span></label>
-          <select name="agent[environment_id]"
-            class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm">
+          <label class="block text-sm font-medium text-zinc-700">
+            Environment <span class="text-zinc-400 font-normal">(optional)</span>
+          </label>
+          <select
+            name="agent[environment_id]"
+            class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+          >
             <option value="">— none —</option>
             <option :for={e <- @environments} value={e.id}>{e.name}</option>
           </select>
         </div>
 
         <div class="flex gap-2 pt-2">
-          <button type="submit"
-            class="flex-1 rounded-md bg-zinc-900 text-white px-4 py-2 text-sm font-medium hover:bg-zinc-700">
+          <button
+            type="submit"
+            class="flex-1 rounded-md bg-zinc-900 text-white px-4 py-2 text-sm font-medium hover:bg-zinc-700"
+          >
             Create agent &amp; continue
           </button>
-          <button type="button" phx-click="skip_agent"
-            class="rounded-md border border-zinc-300 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-50">
+          <button
+            type="button"
+            phx-click="skip_agent"
+            class="rounded-md border border-zinc-300 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-50"
+          >
             Skip
           </button>
         </div>
@@ -476,7 +532,7 @@ defmodule FountainWeb.OnboardingLive.Wizard do
         <h2 class="text-lg font-semibold">You're all set!</h2>
         <p class="mt-1 text-sm text-zinc-500">
           <%= if @agents != [] do %>
-            You have <%= length(@agents) %> agent<%= if length(@agents) > 1, do: "s" %> ready to go.
+            You have {length(@agents)} agent{if length(@agents) > 1, do: "s"} ready to go.
             Start your first conversation now.
           <% else %>
             Your account is ready. Start a conversation to try it out — you can add agents anytime.
@@ -485,12 +541,16 @@ defmodule FountainWeb.OnboardingLive.Wizard do
       </div>
 
       <div class="flex flex-col gap-3 pt-2">
-        <button phx-click="start_conversation"
-          class="w-full rounded-md bg-zinc-900 text-white px-4 py-2.5 text-sm font-medium hover:bg-zinc-700">
+        <button
+          phx-click="start_conversation"
+          class="w-full rounded-md bg-zinc-900 text-white px-4 py-2.5 text-sm font-medium hover:bg-zinc-700"
+        >
           Start first conversation →
         </button>
-        <button phx-click="skip_wizard"
-          class="w-full rounded-md border border-zinc-300 px-4 py-2.5 text-sm text-zinc-600 hover:bg-zinc-50">
+        <button
+          phx-click="skip_wizard"
+          class="w-full rounded-md border border-zinc-300 px-4 py-2.5 text-sm text-zinc-600 hover:bg-zinc-50"
+        >
           Go to dashboard
         </button>
       </div>

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -140,21 +140,43 @@ defmodule FountainWeb.VaultsLive.Form do
     <div class="max-w-3xl space-y-6">
       <h1 class="text-2xl font-semibold">{page_title(@action)}</h1>
 
-      <form phx-change="validate" phx-submit="submit" class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200">
-        <.input id="vault_name" name="vault[name]" label="Name" value={@form["name"]} autofocus required />
-        <.error_msg field="name" errors={@errors}/>
+      <form
+        phx-change="validate"
+        phx-submit="submit"
+        class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200"
+      >
+        <.input
+          id="vault_name"
+          name="vault[name]"
+          label="Name"
+          value={@form["name"]}
+          autofocus
+          required
+        />
+        <.error_msg field="name" errors={@errors} />
 
-        <.input id="vault_description" name="vault[description]" type="textarea" rows="3"
-          label="Description (optional)" value={@form["description"]}
-          placeholder="Whose credentials these are, when to use them, etc."/>
+        <.input
+          id="vault_description"
+          name="vault[description]"
+          type="textarea"
+          rows="3"
+          label="Description (optional)"
+          value={@form["description"]}
+          placeholder="Whose credentials these are, when to use them, etc."
+        />
 
         <div class="flex gap-2">
           <.btn type="submit" phx-disable-with="Saving…">Save</.btn>
-          <.link navigate={~p"/vaults"}><.btn_secondary>Cancel</.btn_secondary></.link>
+          <.link navigate={~p"/vaults"}>
+            <.btn_secondary>Cancel</.btn_secondary>
+          </.link>
         </div>
       </form>
 
-      <section :if={@action == :edit} class="bg-white rounded shadow p-6 border border-zinc-200 space-y-4">
+      <section
+        :if={@action == :edit}
+        class="bg-white rounded shadow p-6 border border-zinc-200 space-y-4"
+      >
         <h2 class="text-lg font-semibold">Secrets</h2>
         <p class="text-sm text-zinc-500">
           Encrypted at rest with AES-256-GCM. When this vault is selected on a new conversation,
@@ -170,7 +192,9 @@ defmodule FountainWeb.VaultsLive.Form do
               <td class="py-2 font-mono">{s.key}</td>
               <td class="py-2 text-zinc-400 font-mono text-xs">•••••••</td>
               <td class="py-2 text-right">
-                <.btn_danger phx-click="delete_secret" phx-value-id={s.id} data-confirm="Delete?">Delete</.btn_danger>
+                <.btn_danger phx-click="delete_secret" phx-value-id={s.id} data-confirm="Delete?">
+                  Delete
+                </.btn_danger>
               </td>
             </tr>
           </tbody>
@@ -185,11 +209,19 @@ defmodule FountainWeb.VaultsLive.Form do
           phx-submit="add_secret"
           class="flex flex-col sm:flex-row gap-2"
         >
-          <input type="text" name="secret[key]" placeholder="KEY"
+          <input
+            type="text"
+            name="secret[key]"
+            placeholder="KEY"
             pattern="[A-Z][A-Z0-9_]*"
-            class="flex-1 rounded border border-zinc-300 px-3 py-2 text-sm font-mono"/>
-          <input type="password" name="secret[value]" placeholder="value"
-            class="flex-[2] rounded border border-zinc-300 px-3 py-2 text-sm font-mono"/>
+            class="flex-1 rounded border border-zinc-300 px-3 py-2 text-sm font-mono"
+          />
+          <input
+            type="password"
+            name="secret[value]"
+            placeholder="value"
+            class="flex-[2] rounded border border-zinc-300 px-3 py-2 text-sm font-mono"
+          />
           <.btn type="submit">Add secret</.btn>
         </form>
       </section>
@@ -202,7 +234,9 @@ defmodule FountainWeb.VaultsLive.Form do
 
   defp error_msg(assigns) do
     ~H"""
-    <p :if={Map.has_key?(@errors, @field)} class="text-rose-600 text-xs">{Map.get(@errors, @field)}</p>
+    <p :if={Map.has_key?(@errors, @field)} class="text-rose-600 text-xs">
+      {Map.get(@errors, @field)}
+    </p>
     """
   end
 end

--- a/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
@@ -65,11 +65,14 @@ defmodule FountainWeb.VaultsLive.Index do
     <div class="space-y-4">
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Vaults</h1>
-        <.link navigate={~p"/vaults/new"}><.btn>+ New vault</.btn></.link>
+        <.link navigate={~p"/vaults/new"}>
+          <.btn>+ New vault</.btn>
+        </.link>
       </div>
 
       <p class="text-sm max-w-2xl text-[var(--color-text-muted)]">
-        A <strong class="text-[var(--color-text-secondary)]">vault</strong> is a bag of env-var overrides — your credentials, a teammate&#39;s, or a virtual identity.
+        A <strong class="text-[var(--color-text-secondary)]">vault</strong>
+        is a bag of env-var overrides — your credentials, a teammate&#39;s, or a virtual identity.
         Pick one when starting a conversation and its values override the environment&#39;s baseline secrets at sprite spawn.
       </p>
 
@@ -91,7 +94,9 @@ defmodule FountainWeb.VaultsLive.Index do
         class="rounded-lg p-10 text-center bg-[var(--color-bg-1)] border border-dashed border-[var(--color-border)]"
       >
         <p class="text-sm text-[var(--color-text-muted)]">No vaults yet.</p>
-        <p class="text-xs mt-1 text-[var(--color-text-secondary)]">Create a vault to store a set of credential overrides you can apply per conversation.</p>
+        <p class="text-xs mt-1 text-[var(--color-text-secondary)]">
+          Create a vault to store a set of credential overrides you can apply per conversation.
+        </p>
       </div>
 
       <%!-- Empty state — search returned nothing --%>
@@ -111,9 +116,15 @@ defmodule FountainWeb.VaultsLive.Index do
       >
         <thead class="border-b border-[var(--color-border)]">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Name</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Description</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Secrets</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Name
+            </th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Description
+            </th>
+            <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Secrets
+            </th>
             <th class="px-4 py-3"></th>
           </tr>
         </thead>
@@ -128,14 +139,21 @@ defmodule FountainWeb.VaultsLive.Index do
                 :if={v.description != ""}
                 class="text-xs block truncate text-[var(--color-text-muted)]"
                 title={v.description}
-              >{v.description}</span>
+              >
+                {v.description}
+              </span>
               <span :if={v.description == ""} class="text-[var(--color-text-muted)]">&#8212;</span>
             </td>
             <td class="px-4 py-3">
               <span
-                class={["inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium", secrets_badge_class(v.secret_count)]}
+                class={[
+                  "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
+                  secrets_badge_class(v.secret_count)
+                ]}
                 title={"#{v.secret_count} secrets"}
-              >&#128273; {v.secret_count}</span>
+              >
+                &#128273; {v.secret_count}
+              </span>
             </td>
             <td class="px-4 py-3 text-right">
               <div class="inline-flex gap-1">
@@ -147,7 +165,9 @@ defmodule FountainWeb.VaultsLive.Index do
                   phx-click="delete"
                   phx-value-id={v.id}
                   data-confirm="Delete vault?"
-                >Delete</button>
+                >
+                  Delete
+                </button>
               </div>
             </td>
           </tr>

--- a/apps/fountain/lib/fountain_web/live/verify_pending_live.ex
+++ b/apps/fountain/lib/fountain_web/live/verify_pending_live.ex
@@ -121,8 +121,7 @@ defmodule FountainWeb.VerifyPendingLive do
         <div class="space-y-2">
           <h1 class="text-xl font-semibold">Check your email</h1>
           <p class="text-sm text-zinc-600">
-            We sent a verification link to
-            <span class="font-medium text-zinc-900">{@current_user.email}</span>. Open it and this
+            We sent a verification link to <span class="font-medium text-zinc-900">{@current_user.email}</span>. Open it and this
             page will continue on its own — you're already signed in, so there's nothing else to
             type here.
           </p>

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -88,7 +88,10 @@ defmodule FountainWeb.Live.BillingLive do
 
       <%!-- past_due banner --%>
       <%= if @current_user.subscription_status == "past_due" do %>
-        <div class="rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800" role="alert">
+        <div
+          class="rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800"
+          role="alert"
+        >
           Your subscription requires attention. Update your payment method to
           continue starting conversations.
         </div>
@@ -101,8 +104,9 @@ defmodule FountainWeb.Live.BillingLive do
           class="rounded border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
           role="alert"
         >
-          Your subscription is set to cancel — you keep full access until
-          <%= access_until_text(@current_user) %>. You can renew any time from
+          Your subscription is set to cancel — you keep full access until {access_until_text(
+            @current_user
+          )}. You can renew any time from
           Manage Subscription.
         </div>
       <% end %>
@@ -122,7 +126,7 @@ defmodule FountainWeb.Live.BillingLive do
                 "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
                 status_badge_class(@current_user.subscription_status)
               ]}>
-                <%= format_status(@current_user.subscription_status) %>
+                {format_status(@current_user.subscription_status)}
               </span>
             </dd>
           </div>
@@ -130,7 +134,7 @@ defmodule FountainWeb.Live.BillingLive do
             <div class="flex items-center justify-between">
               <dt class="text-sm text-gray-500">Trial</dt>
               <dd class="text-sm font-medium">
-                <%= trial_countdown_text(@current_user) %>
+                {trial_countdown_text(@current_user)}
               </dd>
             </div>
           <% end %>
@@ -138,7 +142,7 @@ defmodule FountainWeb.Live.BillingLive do
             <div class="flex items-center justify-between">
               <dt class="text-sm text-gray-500">Access until</dt>
               <dd class="text-sm font-medium">
-                <%= access_until_text(@current_user) %>
+                {access_until_text(@current_user)}
               </dd>
             </div>
           <% end %>
@@ -146,8 +150,10 @@ defmodule FountainWeb.Live.BillingLive do
             <div class="flex items-center justify-between">
               <dt class="text-sm text-gray-500">Billing period</dt>
               <dd class="text-sm font-medium">
-                <%= Calendar.strftime(@period_start, "%B %-d") %> –
-                <%= Calendar.strftime(@period_end, "%B %-d, %Y") %>
+                {Calendar.strftime(@period_start, "%B %-d")} – {Calendar.strftime(
+                  @period_end,
+                  "%B %-d, %Y"
+                )}
               </dd>
             </div>
           <% end %>
@@ -197,21 +203,20 @@ defmodule FountainWeb.Live.BillingLive do
       <div class="rounded-lg border bg-white p-6 shadow-sm">
         <h2 class="mb-1 text-lg font-medium">Usage This Month</h2>
         <p class="mb-4 text-xs text-gray-400">
-          <%= Calendar.strftime(@period_start, "%b %-d") %> –
-          <%= Calendar.strftime(@period_end, "%b %-d, %Y") %>
+          {Calendar.strftime(@period_start, "%b %-d")} – {Calendar.strftime(@period_end, "%b %-d, %Y")}
         </p>
         <dl class="grid grid-cols-3 gap-4">
           <div class="rounded-md bg-gray-50 p-4 text-center">
             <dt class="text-xs text-gray-500">Conversations</dt>
-            <dd class="mt-1 text-2xl font-semibold"><%= @usage.conversations %></dd>
+            <dd class="mt-1 text-2xl font-semibold">{@usage.conversations}</dd>
           </div>
           <div class="rounded-md bg-gray-50 p-4 text-center">
             <dt class="text-xs text-gray-500">Turns</dt>
-            <dd class="mt-1 text-2xl font-semibold"><%= @usage.turns %></dd>
+            <dd class="mt-1 text-2xl font-semibold">{@usage.turns}</dd>
           </div>
           <div class="rounded-md bg-gray-50 p-4 text-center">
             <dt class="text-xs text-gray-500">Sandbox-min</dt>
-            <dd class="mt-1 text-2xl font-semibold"><%= format_minutes(@usage.sandbox_minutes) %></dd>
+            <dd class="mt-1 text-2xl font-semibold">{format_minutes(@usage.sandbox_minutes)}</dd>
           </div>
         </dl>
       </div>


### PR DESCRIPTION
Closes #618.

#612 brought `apps/` inside the `mix format` gate, but no `plugins:` key was
configured anywhere in the repo, so `Phoenix.LiveView.HTMLFormatter` never ran.
The gate read as if it covered the tree while every `.heex` file and every `~H`
sigil inside it went unchecked. This closes that half.

Three commits, in the shape #612 used:

1. **Config** — `plugins: [Phoenix.LiveView.HTMLFormatter]` and `heex` in the
   inputs, in both `.formatter.exs` files (the umbrella root, which covers
   `ee/`, and `apps/fountain`).
2. **The sweep** — pure `mix format` output, no hand edits: 5 `.heex` files
   and 26 `.ex` files holding a `~H` sigil, one under `ee/`.
3. **The pins** — `phx-no-format` on the five blocks the sweep would have
   re-rendered.

## Why the sweep needed verifying, and how it was verified

`mix format` preserves the AST, so #612 was safe by construction. That
guarantee does not extend to HEEx: the formatter rewrites whitespace *in
markup*, and whitespace around an inline element is rendered. The issue
flagged the `<code>` chip on the marketing home page and declined to guess
which way it fell.

It falls the bad way. Rendering every browser-facing route before and after —
36 pages, including the authenticated LiveViews and admin — serving them with
the real stylesheet, and measuring every element box in Chrome found eight
sites where an inline element's box grew, because the formatter had moved its
text onto its own line and the newlines collapse to rendered spaces *inside*
the element:

| Page | Element | Change |
|---|---|---|
| marketing home | four `<code>` chips | +7.2 to +8.5px |
| privacy | one `<strong>` | +3.7px |
| conversations/new | one `<kbd>` | 16 → 22px |
| conversations/:id | two `<kbd>` | 16 → 22px, 40.1 → 46.1px |

Commit 3 pins exactly those with `phx-no-format`. Everything else the sweep
touched stays formatted.

## Result

With the pins in place, the before and after builds agree on:

- **5,543 element boxes** across the 36 pages, and **5,579 more** in a second
  pass with hidden modals and the keyboard cheatsheet forced visible so their
  markup was measured too;
- **34 of 36 full-page screenshots byte-identical.** The two that differ are
  a spinner mid-animation and a text caret — both of which also differ between
  two runs of the *same* build, so they are measurement noise, not change;
- **102 inline `<script>` blocks**: the reflow inside them is whitespace-only,
  every one still parses, and none of the reflowed ones contains a template
  literal.

The kbd chips in the keyboard cheatsheet are worth a note for anyone reading
the diff and expecting them to be affected: they are flex items, so leading and
trailing whitespace is trimmed at the flex-item edge and their boxes do not
move. Only inline elements sitting in text flow were at risk.

## Checks run locally

`mix format --check-formatted`, `mix compile --warnings-as-errors`,
`mix credo --strict`, `scripts/sobelow.sh`, `mix deps.unlock --check-unused`,
and the full suite (2,423 tests, 5 doctests, 3 properties — 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)