### PR TITLE
feat: MIGRATE_ON_BOOT, and an advisory lock for the boot race (#610)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,12 @@ STRIPE_PRICE_MONTHLY_CENTS=
 # DATABASE_SSL_CA_FILE=/etc/ssl/certs/ca.pem
 # POOL_SIZE=10
 
+# A release migrates before it serves. Set false to make it only serve, for a
+# deployment that runs `bin/migrate` once in a Job instead — that entrypoint
+# always migrates, whatever this says. Nothing checks the Job ran: with this
+# off and no migration, the app boots and fails on the first query.
+# MIGRATE_ON_BOOT=false
+
 # ── Proxies and origins ──────────────────────────────────────────────────────
 
 # CIDRs treated as proxies when resolving the client IP from X-Forwarded-For.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,33 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Added
+
+- **`MIGRATE_ON_BOOT=false` — run migrations somewhere other than at boot.**
+  The release migrates before it serves, on every replica, which is right for
+  the single-replica shape it ships as and rules out the standard Kubernetes
+  shape: migrations once in a Job, app pods that only serve. The switch turns
+  the boot-time migration off — both the paths that did it, the image's `CMD`
+  and the `Ecto.Migrator` child in the supervision tree — and leaves
+  `bin/migrate` untouched, since that is what the Job runs. Default unchanged:
+  an instance that sets nothing migrates exactly as before. Nothing checks
+  that the Job ran, so ordering it before the rollout is the operator's job;
+  [the guide](https://binarybourbon.github.io/fountain/self-hosting/#running-migrations-in-a-job)
+  and `deploy/k8s/README.md` say so and carry the manifest (#610)
+
+### Fixed
+
+- **Two replicas booting together against an empty database no longer race
+  each other into a restart.** Ecto's default migration lock is a row lock on
+  `schema_migrations` — which cannot serialize the creation of
+  `schema_migrations` itself, the one moment on a virgin database when both
+  replicas are inside `Ecto.Migrator` at once. The loser died on the type's
+  unique index (`pg_type_typname_nsp_index`), Kubernetes restarted it, and the
+  retry succeeded: a benign `RESTARTS 1` that reads exactly like a crash loop
+  on a first deploy. The lock is now a Postgres advisory lock, taken before
+  anything touches the table. Only ever observed at two or more replicas on a
+  brand-new database (#610)
+
 ## [0.6.1] — 2026-08-07
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,11 @@ USER fountain
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 # Migrations run on every boot. Idempotent (Ecto.Migrator skips
-# already-applied versions) so safe under rolling updates; the readiness
-# probe gates traffic until migrate + start completes.
-CMD ["/bin/sh", "-c", "/app/bin/fountain_server eval 'Fountain.Release.migrate()' && exec /app/bin/fountain_server start"]
+# already-applied versions) and serialized by a Postgres advisory lock, so
+# safe under rolling updates; the readiness probe gates traffic until
+# migrate + start completes.
+#
+# MIGRATE_ON_BOOT=false turns this into a plain start, for a deployment that
+# runs `bin/migrate` once in a Job instead (#610). `bin/migrate` ignores the
+# switch — it is the Job's entrypoint.
+CMD ["/bin/sh", "-c", "/app/bin/fountain_server eval 'Fountain.Release.migrate_on_boot()' && exec /app/bin/fountain_server start"]

--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -94,9 +94,20 @@ defmodule Fountain.Application do
     :ok
   end
 
-  defp skip_migrations?() do
-    # By default, sqlite migrations are run when using a release
-    System.get_env("RELEASE_NAME") == nil
+  # Migrations run at boot in a release and nowhere else — dev and test manage
+  # their own schema through mix, and RELEASE_NAME is how a release announces
+  # itself.
+  #
+  # MIGRATE_ON_BOOT=false opts a release out (#610), for the deployment that
+  # runs migrations once in a Job and lets its pods only serve. This gate and
+  # the image's CMD (`Fountain.Release.migrate_on_boot/0`) read the one
+  # switch, so turning it off leaves no path here that migrates — the switch
+  # would be a decoration if it closed only one of the two.
+  #
+  # Public for the test that pins that pairing; not part of the app's API.
+  @doc false
+  def skip_migrations? do
+    System.get_env("RELEASE_NAME") == nil or not Fountain.Release.migrate_on_boot?()
   end
 
   # Tests opt out via config; everything else (mix phx.server, releases,

--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -13,6 +13,43 @@ defmodule Fountain.Release do
     end
   end
 
+  @doc """
+  The boot-time half of `migrate/0`: migrates unless `MIGRATE_ON_BOOT=false`.
+
+  This is what the image's `CMD` runs, and the only migration path the switch
+  gates. `migrate/0` itself — and `bin/migrate`, which is what a migrations
+  Job runs — always migrates, because an explicit request to migrate should
+  never be silently skipped by an environment variable meant for pods that
+  only serve.
+
+  Skipping is not a no-op boot: the release still starts, and if migrations
+  have not in fact been run the app will fail on the first query against a
+  missing column. That is the trade a deployment makes when it moves
+  migrations into a Job — the Job is what must be ordered before the rollout.
+  """
+  def migrate_on_boot do
+    load_app()
+
+    if migrate_on_boot?() do
+      migrate()
+    else
+      IO.puts("MIGRATE_ON_BOOT=false — skipping migrations at boot.")
+      :skipped
+    end
+  end
+
+  @doc """
+  Whether this node should migrate as it boots.
+
+  Read from application env (set by `config/runtime.exs` from
+  `MIGRATE_ON_BOOT`) rather than from `System.get_env/1` directly, so the two
+  boot paths that migrate — this task and the `Ecto.Migrator` child in
+  `Fountain.Application` — decide from one value.
+  """
+  def migrate_on_boot? do
+    Application.get_env(@app, :migrate_on_boot, true)
+  end
+
   def rollback(repo, version) do
     load_app()
     {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))

--- a/apps/fountain/test/fountain/migrate_on_boot_test.exs
+++ b/apps/fountain/test/fountain/migrate_on_boot_test.exs
@@ -1,0 +1,151 @@
+defmodule Fountain.MigrateOnBootTest do
+  @moduledoc """
+  The switch that lets a deployment migrate somewhere other than at boot (#610).
+
+  A release migrates on every replica before it serves, which is right for the
+  single-replica shape the image ships as and wrong for the standard
+  Kubernetes shape — migrations once in a Job, pods that only serve. Two paths
+  migrate at boot (the image's CMD and the `Ecto.Migrator` child in
+  `Fountain.Application`), so a switch that closed only one would read as
+  working while every pod still migrated.
+  """
+
+  # Mutates process env and application env, so it must not run alongside
+  # anything else.
+  use ExUnit.Case, async: false
+
+  @repo_root Path.expand("../../../..", __DIR__)
+  @runtime_exs Path.join(@repo_root, "config/runtime.exs")
+
+  # The minimum a :prod evaluation of runtime.exs demands (the same set
+  # self_host_switches_test.exs uses).
+  @required_release_env %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "RESEND_API_KEY" => "re_test_key",
+    "EMAIL_FROM" => "noreply@fountain.example.com",
+    "PUBLIC_URL" => "https://fountain.example.com"
+  }
+
+  defp read_prod_config(extra) do
+    previous = System.get_env()
+
+    try do
+      System.delete_env("MIGRATE_ON_BOOT")
+
+      @required_release_env
+      |> Map.put(
+        "MASTER_SECRETS_KEY",
+        Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+      )
+      |> Map.merge(extra)
+      |> System.put_env()
+
+      Config.Reader.read!(@runtime_exs, env: :prod)[:fountain][:migrate_on_boot]
+    after
+      System.put_env(previous)
+      unless Map.has_key?(previous, "MIGRATE_ON_BOOT"), do: System.delete_env("MIGRATE_ON_BOOT")
+    end
+  end
+
+  defp with_switch(value, fun) do
+    previous = Application.get_env(:fountain, :migrate_on_boot)
+    Application.put_env(:fountain, :migrate_on_boot, value)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:fountain, :migrate_on_boot, previous)
+    end
+  end
+
+  defp with_release_name(name, fun) do
+    previous = System.get_env("RELEASE_NAME")
+    if name, do: System.put_env("RELEASE_NAME", name), else: System.delete_env("RELEASE_NAME")
+
+    try do
+      fun.()
+    after
+      if previous,
+        do: System.put_env("RELEASE_NAME", previous),
+        else: System.delete_env("RELEASE_NAME")
+    end
+  end
+
+  describe "MIGRATE_ON_BOOT in runtime.exs" do
+    test "defaults to migrating, so the shipped image needs no configuration" do
+      assert read_prod_config(%{}) == true
+    end
+
+    test "false, 0 and no all turn it off" do
+      for value <- ~w(false 0 no) do
+        assert read_prod_config(%{"MIGRATE_ON_BOOT" => value}) == false,
+               "MIGRATE_ON_BOOT=#{value} should disable boot-time migrations"
+      end
+    end
+
+    test "anything else keeps migrating — the safe reading of a typo" do
+      # Getting this wrong migrates as today (benign); the reverse would hand
+      # a pod a schema nobody ran.
+      for value <- ~w(true 1 yes maybe) do
+        assert read_prod_config(%{"MIGRATE_ON_BOOT" => value}) == true,
+               "MIGRATE_ON_BOOT=#{value} should leave boot-time migrations on"
+      end
+    end
+  end
+
+  describe "Fountain.Release.migrate_on_boot?/0" do
+    test "follows the application env" do
+      with_switch(false, fn -> refute Fountain.Release.migrate_on_boot?() end)
+      with_switch(true, fn -> assert Fountain.Release.migrate_on_boot?() end)
+    end
+  end
+
+  describe "the Ecto.Migrator child in Fountain.Application" do
+    test "migrates in a release" do
+      with_release_name("fountain_server", fn ->
+        with_switch(true, fn -> refute Fountain.Application.skip_migrations?() end)
+      end)
+    end
+
+    test "is skipped by the same switch that skips the CMD's migration" do
+      with_release_name("fountain_server", fn ->
+        with_switch(false, fn -> assert Fountain.Application.skip_migrations?() end)
+      end)
+    end
+
+    test "never migrates outside a release, switch or no switch" do
+      with_release_name(nil, fn ->
+        with_switch(true, fn -> assert Fountain.Application.skip_migrations?() end)
+      end)
+    end
+  end
+
+  describe "the entrypoints" do
+    test "the image CMD goes through the gated path" do
+      dockerfile = File.read!(Path.join(@repo_root, "Dockerfile"))
+
+      assert dockerfile =~ "Fountain.Release.migrate_on_boot()",
+             "the image CMD must call the gated boot migration, or MIGRATE_ON_BOOT=false " <>
+               "leaves the CMD migrating anyway"
+    end
+
+    test "bin/migrate ignores the switch, because a Job runs it to migrate" do
+      script = File.read!(Path.join(@repo_root, "rel/overlays/bin/migrate"))
+
+      assert script =~ "Fountain.Release.migrate"
+      refute script =~ "migrate_on_boot"
+    end
+  end
+
+  describe "the migration lock" do
+    test "is a Postgres advisory lock, not Ecto's default table lock" do
+      # The default (`FOR UPDATE` on schema_migrations) cannot serialize the
+      # creation of schema_migrations itself, which is the race two replicas
+      # hit on a virgin database. The deployment docs state this guarantee.
+      assert Application.get_env(:fountain, Fountain.Repo)[:migration_lock] ==
+               :pg_advisory_lock
+    end
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -56,6 +56,21 @@ config :fountain,
   ecto_repos: [Fountain.Repo],
   generators: [timestamp_type: :utc_datetime, binary_id: true]
 
+# Take the migration lock as a Postgres advisory lock rather than Ecto's
+# default `FOR UPDATE` on `schema_migrations` (#610). The default cannot
+# serialize the one moment that matters: on a virgin database the table it
+# locks does not exist yet, so two replicas booting together both reach
+# `CREATE TABLE schema_migrations` and the loser dies on the type's unique
+# index. An advisory lock is taken before anything touches the table, so the
+# bootstrap is serialized like every migration after it.
+config :fountain, Fountain.Repo, migration_lock: :pg_advisory_lock
+
+# Whether a booting release runs pending migrations before it serves. True
+# here so the shipped single-replica image needs no configuration;
+# runtime.exs turns it off for MIGRATE_ON_BOOT=false, the deployment that
+# runs migrations once in a Job instead. See Fountain.Release.migrate_on_boot/0.
+config :fountain, :migrate_on_boot, true
+
 config :fountain, FountainWeb.Endpoint,
   url: [host: "localhost"],
   adapter: Bandit.PhoenixAdapter,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -612,6 +612,22 @@ if config_env() == :prod do
   config :fountain, :email_from, email_from || "noreply@localhost"
 end
 
+# Boot-time migrations (#610). A release migrates before it serves, on every
+# replica, which is right for the single-replica shape this ships as. The
+# standard Kubernetes shape is the other one: migrations run once in a Job,
+# and the app pods only serve — which needs a way to tell a pod not to
+# migrate. MIGRATE_ON_BOOT=false is that way; `bin/migrate` (and
+# `Fountain.Release.migrate/0` behind it) always migrates regardless, because
+# it is the entrypoint the Job runs.
+#
+# Skipped in :test — config/test.exs pins it, so a developer's shell cannot
+# change what the suite exercises.
+if config_env() != :test do
+  config :fountain,
+         :migrate_on_boot,
+         System.get_env("MIGRATE_ON_BOOT", "true") not in ~w(false 0 no)
+end
+
 # Database config is deliberately NOT behind `server?`. Release tasks
 # (`bin/fountain_server eval 'Fountain.Release...'`) run without PHX_SERVER
 # and still need the repo — gating this on `server?` left them with a repo

--- a/config/test.exs
+++ b/config/test.exs
@@ -65,10 +65,12 @@ config :phoenix, sort_verified_routes_query_params: true
 config :fountain, Fountain.Mailer, adapter: Swoosh.Adapters.Test
 config :swoosh, :api_client, false
 
-# Pinned so a developer's shell (EMAIL_DELIVERY / FIRST_USER_ADMIN) can't
-# change suite behavior; tests toggle these through the application env.
+# Pinned so a developer's shell (EMAIL_DELIVERY / FIRST_USER_ADMIN /
+# MIGRATE_ON_BOOT) can't change suite behavior; tests toggle these through
+# the application env.
 config :fountain, :email_enabled, true
 config :fountain, :first_user_admin, false
+config :fountain, :migrate_on_boot, true
 
 # Jobs are asserted with Oban.Testing rather than executed as a side effect.
 config :fountain, Oban, testing: :manual

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -60,6 +60,47 @@ pre-1.0 minor bumps may carry **Upgrade notes** in the
 run at boot, idempotently, under an advisory lock. Downgrades are not
 supported once a newer version's migrations have run — restore from a backup.
 
+## Migrations in a Job
+
+Pods migrate at boot by default, which is fine at any replica count — the
+lock is a Postgres advisory lock, taken before `schema_migrations` exists, so
+a cold start of several replicas against an empty database does not race.
+
+If you want the other shape — migrations as an explicit, reviewable step, app
+pods that only serve — set `MIGRATE_ON_BOOT: "false"` in the ConfigMap and run
+the migration entrypoint as a Job. `bin/migrate` ignores the switch; it is
+what you run *to* migrate.
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Version the name. A completed Job's pod template is immutable, so
+  # re-applying under the same name after a tag bump fails instead of
+  # migrating — and a failure that looks like a no-op is the bad kind.
+  name: fountain-migrate-v0-6-1
+  namespace: fountain
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: ghcr.io/binarybourbon/fountain:v0.6.1 # match the Deployment
+          command: ["/app/bin/migrate"]
+          envFrom:
+            - configMapRef:
+                name: fountain-config
+            - secretRef:
+                name: fountain-secrets
+```
+
+Run it to completion **before** the rollout that needs it. Nothing in the app
+checks that you did: a pod with `MIGRATE_ON_BOOT=false` boots against an
+un-migrated database without complaint and fails on the first query that
+needs the new column.
+
 ## Operational notes
 
 - **Probes**: liveness checks only the process (a Postgres blip must not

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -45,6 +45,14 @@ data:
   # verification — see the self-hosting guide.
   DATABASE_SSL: "true"
 
+  # Pods migrate at boot by default, at any replica count — the migration
+  # lock is a Postgres advisory lock, so a cold start of several replicas
+  # against an empty database does not race. Set this to "false" only if you
+  # run migrations as a Job instead (README.md has the manifest); nothing
+  # checks that the Job ran, and a pod that skips migrations against an
+  # un-migrated database boots and then fails on the first query.
+  # MIGRATE_ON_BOOT: "false"
+
   # Trace export is off by default — nothing leaves the instance. To ship
   # traces to a collector, set OTEL_EXPORTER_OTLP_ENDPOINT (and
   # OTEL_EXPORTER_OTLP_HEADERS if it needs auth); see docs/configuration.md.

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -83,9 +83,10 @@ spec:
             limits:
               cpu: 500m
               memory: 1Gi
-          # Migrations run at boot, before the endpoint listens. The startup
-          # probe holds the other probes off for up to 150s so a slow
-          # migration is not mistaken for a dead pod and restart-looped.
+          # Migrations run at boot, before the endpoint listens (unless
+          # MIGRATE_ON_BOOT=false — see configmap.yaml). The startup probe
+          # holds the other probes off for up to 150s so a slow migration is
+          # not mistaken for a dead pod and restart-looped.
           startupProbe:
             httpGet:
               path: /health

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ an error message.
 | `DATABASE_SSL_VERIFY` | off | — | Unset, the connection is encrypted but the server certificate is **not** verified. `true` verifies it, against the OS trust store unless a CA file is given |
 | `DATABASE_SSL_CA_FILE` | OS trust store | — | CA bundle used when `DATABASE_SSL_VERIFY=true` |
 | `POOL_SIZE` | `10` | — | Database connection pool size |
+| `MIGRATE_ON_BOOT` | `true` | — | Whether a booting release runs pending migrations before it serves. `false` (also `0`, `no`) makes the pod only serve, for the deployment that runs migrations once in a Job — see [migrations in a Job](self-hosting.md#running-migrations-in-a-job). `bin/migrate` always migrates, whatever this is set to. **Nothing checks that the Job ran**: a pod that skips migrations against an un-migrated database boots and then fails on the first query |
 
 ## Sandboxes
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -36,7 +36,7 @@ The tasks:
 | `Fountain.Release.verify_email("a@b.c")` | Mark an account's email verified without sending anything — the escape hatch for a broken mail provider (`EMAIL_DELIVERY=none` self-verifies at registration since ADR 0011) |
 | `Fountain.Release.promote_admin("a@b.c")` | Grant the admin role, recorded in the admin audit trail with a system actor. The manual alternative to `FIRST_USER_ADMIN=true` (ADR 0011) |
 | `Fountain.Release.expire_legacy_trials(dry_run: true)` | Report (then, without `dry_run`, backfill) trial end dates on legacy `trialing` accounts that have none |
-| `Fountain.Release.migrate()` | Run pending migrations by hand. They already run at every boot; this exists for unusual situations |
+| `Fountain.Release.migrate()` | Run pending migrations by hand — what `bin/migrate` runs. They already run at every boot unless `MIGRATE_ON_BOOT=false`, in which case this (in a Job, before the rollout) is how they run at all. Never skipped by that switch |
 | `Fountain.Release.rollback(Fountain.Repo, version)` | Roll migrations back to a version. Last resort — see [Upgrade gone wrong](#upgrade-gone-wrong) before reaching for it |
 
 ---

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -88,11 +88,13 @@ file falls back to a pinned release rather than `latest`.
 
 Upgrading is editing that value, then `docker compose pull && docker compose
 up -d`. Migrations run automatically at boot — idempotently, serialized by a
-lock on the `schema_migrations` table (Ecto's default) — so rolling replicas
-do not race each other, and there are no manual migration steps unless a
-release's upgrade notes say otherwise. (A migration that builds an index
-concurrently opts out of that lock by design; such migrations are written to
-be safe to re-run.) Downgrading is
+Postgres advisory lock — so rolling replicas do not race each other, and there
+are no manual migration steps unless a release's upgrade notes say otherwise.
+(A migration that builds an index concurrently opts out of that lock by
+design; such migrations are written to be safe to re-run. And if you have
+moved migrations into a Job with `MIGRATE_ON_BOOT=false`, running the Job is
+the upgrade step — see [Running migrations in a
+Job](#running-migrations-in-a-job).) Downgrading is
 not supported once a newer version's migrations have run; restore from a
 backup instead.
 
@@ -135,6 +137,35 @@ DATABASE_SSL_VERIFY=true
 # optional, otherwise the OS trust store is used
 DATABASE_SSL_CA_FILE=/etc/ssl/certs/rds-ca.pem
 ```
+
+### Running migrations in a Job
+
+Migrating at boot is right for one replica and is not the only shape. Set
+`MIGRATE_ON_BOOT=false` and the release starts without migrating; run the
+migration entrypoint yourself, once, before the new version serves:
+
+```bash
+bin/migrate     # in the image; equivalent to
+                # bin/fountain_server eval 'Fountain.Release.migrate()'
+```
+
+`bin/migrate` ignores `MIGRATE_ON_BOOT` — it is the thing you run *to*
+migrate. In Kubernetes that is a Job ordered before the rollout;
+[`deploy/k8s/README.md`](https://github.com/BinaryBourbon/fountain/blob/main/deploy/k8s/README.md)
+has the manifest.
+
+Worth knowing before you turn it off:
+
+- **Nothing verifies the Job ran.** A pod with the switch off boots happily
+  against an un-migrated database and fails on the first query that needs the
+  new column. Ordering the Job ahead of the rollout is your job, not the
+  app's.
+- **You do not need this to run several replicas.** Boot migrations are
+  serialized by a Postgres advisory lock — taken before `schema_migrations`
+  is touched, so even the first boot against an empty database does not race.
+- **What it buys you** is migrations as an explicitly reviewable step, app
+  pods that can run with a database role that cannot `ALTER`, and faster pod
+  starts on scale-up.
 
 ### Backups
 


### PR DESCRIPTION
Closes #610.

The issue asks for an env switch so a deployment can run migrations once in a Job. The thread then narrows to something else: the restart that prompted it is Ecto's default migration lock failing to cover the one moment it can't. This does both — the lock is the fix, the switch is the capability.

## The switch

`MIGRATE_ON_BOOT=false` (also `0`, `no`). Default unchanged: an instance that sets nothing migrates exactly as it does today.

There were **two** boot-time migration paths, not one:

- the image's `CMD` — `eval 'Fountain.Release.migrate()'` before `start`
- the `{Ecto.Migrator, skip: skip_migrations?()}` child in the supervision tree, which is active whenever `RELEASE_NAME` is set — that is, in every release

A switch that closed only the first would read as working while every pod still migrated, so both now read one value (`:migrate_on_boot`, set in `runtime.exs`). `bin/migrate` and `Fountain.Release.migrate/0` ignore it — they are what a Job runs *to* migrate, and an explicit request to migrate should never be silently skipped by an env var meant for pods that only serve.

## The race

`migration_lock: :pg_advisory_lock` on the repo.

Ecto's default is `FOR UPDATE` on `schema_migrations`, which cannot serialize the creation of `schema_migrations` itself — the one moment on a virgin database when both replicas are inside `Ecto.Migrator` at once. The loser dies on the type's unique index (`pg_type_typname_nsp_index`), Kubernetes restarts it, the retry wins: a benign `RESTARTS 1` that reads exactly like a crash loop on a first deploy.

Verified locally, two concurrent `mix ecto.migrate` against an empty database:

| | process A | process B |
|---|---|---|
| with the advisory lock | exit 0, 44 migrations | exit 0, waited, 0 migrations |
| without it | exit 0, 43 migrations | **exit 1** — `duplicate_table` |

`deploy/k8s/README.md` has claimed "under an advisory lock" for a while; it is now true.

So a multi-replica cold start no longer needs the switch. The switch stays for what @lex00 lists as the nice-to-haves: migrations as an explicitly reviewable step, app pods that can run with a database role that cannot `ALTER`, and faster pod starts on scale-up.

## What is deliberately not enforced

Nothing checks that the Job ran. A pod with `MIGRATE_ON_BOOT=false` boots happily against an un-migrated database and fails on the first query that needs the new column. Ordering the Job ahead of the rollout is the operator's job — said in the configuration reference, the self-hosting guide and `deploy/k8s/README.md` rather than enforced with a schema check the default path does not need.

## Tests

`apps/fountain/test/fountain/migrate_on_boot_test.exs`, 10 cases: the runtime parse table (default on; `false`/`0`/`no` off; a typo stays on, which is the safe direction), the `Application` gate paired with the switch, source guards that the `CMD` uses the gated path and that `bin/migrate` does not, and that the migration lock is the advisory one. Each was confirmed to fail with its fix reverted before being kept.

Full suite green (2433 tests), plus format / warnings-as-errors / credo --strict / sobelow / dialyzer.

## Docs

`docs/configuration.md` row, a "Running migrations in a Job" section in `docs/self-hosting.md` (and its "serialized by a lock on the `schema_migrations` table" sentence corrected), the Job manifest in `deploy/k8s/README.md` with the completed-Job-immutability trap called out, commented entries in `configmap.yaml` and `.env.example`, the operations task table, and a CHANGELOG entry under `[Unreleased]`.

Unblocks [fountain-ops#90](https://github.com/INTENTIUS/fountain-ops/issues/90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
