### PR TITLE
fix: honor agent.model on the claude, codex, and gemini runtimes (#553)

### DIFF
--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -4,6 +4,7 @@ defmodule Fountain.Agents.Agent do
 
   alias Fountain.Accounts.User
   alias Fountain.Environments.Environment
+  alias Fountain.Runtimes.Model
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -56,10 +57,30 @@ defmodule Fountain.Agents.Agent do
     |> validate_format(:model, ~r{^[a-z0-9_-]+/[a-z0-9._-]+$},
       message: "must be in canonical provider/model_id form"
     )
+    |> validate_model_provider()
     |> validate_length(:name, min: 1, max: 200)
     |> validate_skills()
     |> unique_constraint(:name, name: :agents_user_id_name_index)
     |> foreign_key_constraint(:environment_id)
+  end
+
+  # claude / codex / gemini each drive a single provider's CLI and take a
+  # bare model id, so the runtime strips the canonical prefix at spawn.
+  # Reject a mismatched prefix here rather than shipping `gpt-5` to
+  # `claude --model`: before #553 those runtimes ignored the field
+  # entirely, so `openai/gpt-5` on a claude agent looked configured and
+  # silently ran the CLI's own default. opencode is multi-provider and
+  # takes any prefix, so it is unconstrained.
+  defp validate_model_provider(changeset) do
+    runtime = get_field(changeset, :runtime)
+
+    with expected when is_binary(expected) <- Model.provider_for_runtime(runtime),
+         actual when is_binary(actual) <- Model.provider(get_field(changeset, :model)),
+         true <- actual != expected do
+      add_error(changeset, :model, "#{runtime} runtime requires a #{expected}/ model")
+    else
+      _ -> changeset
+    end
   end
 
   defp validate_skills(changeset) do

--- a/apps/fountain/lib/fountain/runtimes/claude.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude.ex
@@ -3,15 +3,21 @@ defmodule Fountain.Runtimes.Claude do
   Anthropic Claude Code CLI runtime.
 
   Argv shape mirrors AoD's Python build_claude_command:
-      claude --dangerously-skip-permissions --print --verbose
+      claude --model <model_id>
+             --dangerously-skip-permissions --print --verbose
              --output-format stream-json
              (--session-id | --resume) <id>
+
+  `--model` takes the bare id, so the canonical `anthropic/` prefix on
+  `agent.model` is stripped (see `Fountain.Runtimes.Model`).
 
   The prompt is piped on stdin by the spawn caller. ANTHROPIC_API_KEY is
   exported into the sprite environment.
   """
 
   @behaviour Fountain.Runtimes
+
+  alias Fountain.Runtimes.Model
 
   @impl true
   def skills_root, do: "/home/sprite/.claude/skills"
@@ -20,22 +26,24 @@ defmodule Fountain.Runtimes.Claude do
   def skills_sh_agent, do: "claude-code"
 
   @impl true
-  def build_command(_agent, _prompt, mode, runtime_session_id, opts) do
+  def build_command(agent, _prompt, mode, runtime_session_id, opts) do
     if mode == :continue and is_nil(runtime_session_id) do
       raise ArgumentError, "mode=:continue requires runtime_session_id"
     end
 
     flag = if mode == :continue, do: "--resume", else: "--session-id"
 
-    base_args = [
-      "--dangerously-skip-permissions",
-      "--print",
-      "--verbose",
-      "--output-format",
-      "stream-json",
-      flag,
-      runtime_session_id || ""
-    ]
+    base_args =
+      Model.model_args(agent) ++
+        [
+          "--dangerously-skip-permissions",
+          "--print",
+          "--verbose",
+          "--output-format",
+          "stream-json",
+          flag,
+          runtime_session_id || ""
+        ]
 
     # The claude CLI has no --image flag. Append image file paths to the
     # stdin prompt so Claude can use its Read tool to load them visually.

--- a/apps/fountain/lib/fountain/runtimes/codex.ex
+++ b/apps/fountain/lib/fountain/runtimes/codex.ex
@@ -6,10 +6,14 @@ defmodule Fountain.Runtimes.Codex do
 
       mode == :run       → codex exec
                               --dangerously-bypass-approvals-and-sandbox
-                              --json <PROMPT>
+                              --json --model <model_id> <PROMPT>
       mode == :continue  → codex exec resume --last
                               --dangerously-bypass-approvals-and-sandbox
-                              --json <PROMPT>
+                              --json --model <model_id> <PROMPT>
+
+  `--model` (also spelled `-m`) takes the bare id, so the canonical
+  `openai/` prefix on `agent.model` is stripped — see
+  `Fountain.Runtimes.Model`.
 
   The prompt is passed as the **trailing positional argument** rather
   than on stdin. When codex sees a piped stdin it logs an ugly
@@ -28,6 +32,8 @@ defmodule Fountain.Runtimes.Codex do
 
   @behaviour Fountain.Runtimes
 
+  alias Fountain.Runtimes.Model
+
   @impl true
   def skills_root, do: "/home/sprite/.codex/skills"
 
@@ -35,7 +41,7 @@ defmodule Fountain.Runtimes.Codex do
   def skills_sh_agent, do: "codex"
 
   @impl true
-  def build_command(_agent, prompt, mode, _runtime_session_id, opts) do
+  def build_command(agent, prompt, mode, _runtime_session_id, opts) do
     base =
       if mode == :continue do
         [
@@ -68,7 +74,8 @@ defmodule Fountain.Runtimes.Codex do
     # AND a /dev/null redirect trigger it. Allocate a PTY (`tty?: true`)
     # so codex sees stdin as a TTY and stays quiet. We pass the prompt
     # as argv so codex doesn't actually read from the PTY.
-    {"codex", base ++ image_args ++ [prompt], stdin?: false, tty?: true}
+    {"codex", base ++ Model.model_args(agent) ++ image_args ++ [prompt],
+     stdin?: false, tty?: true}
   end
 
   @impl true

--- a/apps/fountain/lib/fountain/runtimes/gemini.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini.ex
@@ -4,8 +4,12 @@ defmodule Fountain.Runtimes.Gemini do
 
   Argv shape:
 
-      mode == :run       → gemini --output-format stream-json
-      mode == :continue  → gemini --resume --output-format stream-json
+      mode == :run       → gemini --output-format stream-json --model <model_id>
+      mode == :continue  → gemini --resume --output-format stream-json --model <model_id>
+
+  `--model` (also spelled `-m`) takes the bare id, so the canonical
+  `google/` prefix on `agent.model` is stripped — see
+  `Fountain.Runtimes.Model`.
 
   Gemini manages its own session state — `--resume` re-enters the most
   recent conversation in the workspace, so we don't pass a session id.
@@ -16,6 +20,8 @@ defmodule Fountain.Runtimes.Gemini do
   """
 
   @behaviour Fountain.Runtimes
+
+  alias Fountain.Runtimes.Model
 
   # Run gemini from a workspace dir we own and have git-init'd; avoids
   # the noisy `[WARN] [MemoryDiscovery] EACCES at /home/sprite/.git`
@@ -34,15 +40,16 @@ defmodule Fountain.Runtimes.Gemini do
 
   @impl true
   def build_command(agent, _prompt, mode, _runtime_session_id, opts) do
-    base = [
-      "--output-format",
-      "stream-json",
-      # `yolo` auto-approves tool calls — matches claude's
-      # `--dangerously-skip-permissions` and codex's
-      # `--dangerously-bypass-approvals-and-sandbox`.
-      "--approval-mode",
-      "yolo"
-    ]
+    base =
+      [
+        "--output-format",
+        "stream-json",
+        # `yolo` auto-approves tool calls — matches claude's
+        # `--dangerously-skip-permissions` and codex's
+        # `--dangerously-bypass-approvals-and-sandbox`.
+        "--approval-mode",
+        "yolo"
+      ] ++ Model.model_args(agent)
 
     # Non-interactive gemini does NOT load MCP tools by default. The
     # `--allowed-mcp-server-names` flag is the explicit allow-list.

--- a/apps/fountain/lib/fountain/runtimes/model.ex
+++ b/apps/fountain/lib/fountain/runtimes/model.ex
@@ -1,0 +1,72 @@
+defmodule Fountain.Runtimes.Model do
+  @moduledoc """
+  Translation between `agent.model` — always stored in canonical
+  `provider/model_id` form — and what each runtime's CLI actually accepts.
+
+  Only opencode is multi-provider: it takes the canonical string verbatim
+  (`opencode run --model anthropic/claude-sonnet-4-6`) and reads the prefix
+  to pick which API key to export. The other three CLIs each talk to one
+  provider and want the bare id:
+
+      claude --model claude-sonnet-4-6
+      codex  --model gpt-5-codex        # also spelled -m
+      gemini --model gemini-2.5-pro     # also spelled -m
+
+  `Fountain.Agents.Agent` rejects a model whose prefix doesn't match its
+  runtime at write time (via `provider_for_runtime/1`), so by the time a
+  spawn reaches `build_command/5` stripping the prefix is always correct.
+  Before #553 those three runtimes ignored the field entirely, so an
+  `openai/gpt-5` agent on the claude runtime looked configured and quietly
+  ran whatever the CLI defaulted to.
+  """
+
+  @provider_by_runtime %{
+    "claude" => "anthropic",
+    "codex" => "openai",
+    "gemini" => "google"
+  }
+
+  @doc """
+  The single provider a runtime's CLI can reach, or `nil` for a
+  multi-provider runtime (opencode) that accepts any prefix.
+  """
+  def provider_for_runtime(runtime) when is_binary(runtime),
+    do: Map.get(@provider_by_runtime, runtime)
+
+  def provider_for_runtime(_runtime), do: nil
+
+  @doc """
+  Split a canonical `provider/model_id` into its two halves.
+
+  Returns `{nil, nil}` for anything not in canonical form — callers treat
+  that as "no model to pass", never as something to guess at.
+  """
+  def split(model) when is_binary(model) do
+    case String.split(model, "/", parts: 2) do
+      [provider, id] when provider != "" and id != "" -> {provider, id}
+      _ -> {nil, nil}
+    end
+  end
+
+  def split(_model), do: {nil, nil}
+
+  @doc "Provider half of a canonical model string, or `nil`."
+  def provider(model), do: model |> split() |> elem(0)
+
+  @doc "Model-id half of a canonical model string, or `nil`."
+  def id(model), do: model |> split() |> elem(1)
+
+  @doc """
+  `["--model", "<bare id>"]` for the single-provider CLIs, or `[]` when the
+  agent carries no parseable model. All three spell the long flag the same
+  way, so one helper covers them.
+  """
+  def model_args(%{model: model}) do
+    case id(model) do
+      nil -> []
+      id -> ["--model", id]
+    end
+  end
+
+  def model_args(_agent), do: []
+end

--- a/apps/fountain/lib/fountain/runtimes/open_code.ex
+++ b/apps/fountain/lib/fountain/runtimes/open_code.ex
@@ -20,6 +20,8 @@ defmodule Fountain.Runtimes.OpenCode do
 
   @behaviour Fountain.Runtimes
 
+  alias Fountain.Runtimes.Model
+
   # opencode insists on being inside a git repo. Putting the workspace
   # in /tmp side-steps the sprite user's lack of write access on
   # /home/sprite (which prevents `git init` from stat'ing the work tree).
@@ -58,7 +60,7 @@ defmodule Fountain.Runtimes.OpenCode do
   def default_env(_, _inference_credentials), do: [{"HOME", "/tmp"}]
 
   defp provider_env(%{model: model}, inference_credentials) do
-    case provider_of(model) do
+    case Model.provider(model) do
       "anthropic" -> env_pair("ANTHROPIC_API_KEY", :anthropic_api_key, inference_credentials)
       "openai" -> env_pair("OPENAI_API_KEY", :openai_api_key, inference_credentials)
       "google" -> env_pair("GEMINI_API_KEY", :gemini_api_key, inference_credentials)
@@ -113,13 +115,6 @@ defmodule Fountain.Runtimes.OpenCode do
       )
 
     if code == 0, do: :ok, else: {:error, {:opencode_install_exit, code}}
-  end
-
-  defp provider_of(model) do
-    case String.split(model, "/", parts: 2) do
-      [p, _] -> p
-      _ -> nil
-    end
   end
 
   defp env_pair(name, key, inference_credentials) do

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -87,6 +87,13 @@ defmodule FountainWeb.AgentsLive.Form do
     end)
   end
 
+  # Each runtime but opencode only reaches one provider, and the changeset
+  # rejects a mismatched prefix (#553). Track the selected runtime so the hint
+  # can't lead someone into that error.
+  defp model_placeholder("codex"), do: "openai/gpt-5-codex"
+  defp model_placeholder("gemini"), do: "google/gemini-2.5-pro"
+  defp model_placeholder(_runtime), do: "anthropic/claude-sonnet-4-6"
+
   @impl true
   def handle_event("validate", %{"agent" => params}, socket) do
     skills = extract_skills_from_params(params, socket.assigns.skills)
@@ -536,7 +543,7 @@ defmodule FountainWeb.AgentsLive.Form do
             name="agent[model]"
             label="Model"
             value={@form["model"]}
-            placeholder="anthropic/claude-sonnet-4-6"
+            placeholder={model_placeholder(@form["runtime"])}
             required
           />
         </div>

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -240,7 +240,10 @@ defmodule FountainWeb.Schemas do
         system: %Schema{type: :string, description: "System prompt."},
         model: %Schema{
           type: :string,
-          description: "Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6).",
+          description:
+            "Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The " <>
+              "provider must match the runtime — anthropic for claude, openai for " <>
+              "codex, google for gemini; opencode accepts any provider.",
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
         runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},

--- a/apps/fountain/test/fountain/agents/agent_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_test.exs
@@ -9,6 +9,15 @@ defmodule Fountain.Agents.AgentTest do
     runtime: "claude"
   }
 
+  # A model whose provider prefix each runtime actually accepts. opencode is
+  # multi-provider, so any prefix is fine there.
+  @model_for %{
+    "claude" => "anthropic/claude-sonnet-4-6",
+    "codex" => "openai/gpt-5-codex",
+    "gemini" => "google/gemini-2.5-pro",
+    "opencode" => "anthropic/claude-sonnet-4-6"
+  }
+
   describe "runtimes/0" do
     test "returns the expected list of runtimes" do
       assert Agent.runtimes() == ~w(claude codex gemini opencode)
@@ -43,7 +52,13 @@ defmodule Fountain.Agents.AgentTest do
   describe "changeset/2 — runtime inclusion" do
     for runtime <- ~w(claude codex gemini opencode) do
       test "runtime #{runtime} is valid" do
-        changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :runtime, unquote(runtime)))
+        attrs =
+          Map.merge(@valid_attrs, %{
+            runtime: unquote(runtime),
+            model: @model_for[unquote(runtime)]
+          })
+
+        changeset = Agent.changeset(%Agent{}, attrs)
         assert changeset.valid?
       end
     end
@@ -52,6 +67,50 @@ defmodule Fountain.Agents.AgentTest do
       changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :runtime, "unknown"))
       refute changeset.valid?
       assert "is invalid" in errors_on(changeset).runtime
+    end
+  end
+
+  describe "changeset/2 — model provider matches runtime" do
+    # #553: these three runtimes pass the bare model id to their CLI, so a
+    # mismatched prefix would ship e.g. `gpt-5` to `claude --model`.
+    test "claude rejects a non-anthropic model" do
+      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :model, "openai/gpt-5"))
+      refute changeset.valid?
+      assert "claude runtime requires a anthropic/ model" in errors_on(changeset).model
+    end
+
+    test "codex rejects a non-openai model" do
+      attrs = Map.merge(@valid_attrs, %{runtime: "codex", model: "anthropic/claude-sonnet-4-6"})
+      changeset = Agent.changeset(%Agent{}, attrs)
+      refute changeset.valid?
+      assert "codex runtime requires a openai/ model" in errors_on(changeset).model
+    end
+
+    test "gemini rejects a non-google model" do
+      attrs = Map.merge(@valid_attrs, %{runtime: "gemini", model: "openai/gpt-5"})
+      changeset = Agent.changeset(%Agent{}, attrs)
+      refute changeset.valid?
+      assert "gemini runtime requires a google/ model" in errors_on(changeset).model
+    end
+
+    test "opencode accepts any provider — it is the multi-provider runtime" do
+      for model <- ~w(anthropic/claude-sonnet-4-6 openai/gpt-5 google/gemini-2.5-pro) do
+        attrs = Map.merge(@valid_attrs, %{runtime: "opencode", model: model})
+        assert Agent.changeset(%Agent{}, attrs).valid?
+      end
+    end
+
+    test "a runtime change alone is validated against the stored model" do
+      agent = %Agent{name: "a", model: "anthropic/claude-sonnet-4-6", runtime: "claude"}
+      changeset = Agent.changeset(agent, %{runtime: "codex"})
+      refute changeset.valid?
+      assert "codex runtime requires a openai/ model" in errors_on(changeset).model
+    end
+
+    test "a malformed model reports only the format error" do
+      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :model, "claude-sonnet-4-6"))
+      refute changeset.valid?
+      assert errors_on(changeset).model == ["must be in canonical provider/model_id form"]
     end
   end
 

--- a/apps/fountain/test/fountain/runtimes/model_test.exs
+++ b/apps/fountain/test/fountain/runtimes/model_test.exs
@@ -1,0 +1,121 @@
+defmodule Fountain.Runtimes.ModelTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Agents.Agent
+  alias Fountain.Runtimes
+
+  defp agent(runtime, model), do: %Agent{name: "a", runtime: runtime, model: model}
+
+  describe "provider_for_runtime/1" do
+    test "maps each single-provider runtime to its provider" do
+      assert Runtimes.Model.provider_for_runtime("claude") == "anthropic"
+      assert Runtimes.Model.provider_for_runtime("codex") == "openai"
+      assert Runtimes.Model.provider_for_runtime("gemini") == "google"
+    end
+
+    test "returns nil for opencode — it is multi-provider" do
+      assert Runtimes.Model.provider_for_runtime("opencode") == nil
+    end
+
+    test "returns nil for anything unrecognised" do
+      assert Runtimes.Model.provider_for_runtime("nope") == nil
+      assert Runtimes.Model.provider_for_runtime(nil) == nil
+    end
+  end
+
+  describe "split/1" do
+    test "splits a canonical model on the first slash only" do
+      assert Runtimes.Model.split("anthropic/claude-sonnet-4-6") ==
+               {"anthropic", "claude-sonnet-4-6"}
+
+      assert Runtimes.Model.split("openrouter/meta/llama-3") == {"openrouter", "meta/llama-3"}
+    end
+
+    test "refuses to guess at anything non-canonical" do
+      for bad <- ["claude-sonnet-4-6", "anthropic/", "/gpt-5", "", nil] do
+        assert Runtimes.Model.split(bad) == {nil, nil}
+      end
+    end
+  end
+
+  describe "model_args/1" do
+    test "strips the provider prefix" do
+      assert Runtimes.Model.model_args(agent("claude", "anthropic/claude-sonnet-4-6")) ==
+               ["--model", "claude-sonnet-4-6"]
+    end
+
+    test "passes no flag when there is no parseable model" do
+      assert Runtimes.Model.model_args(agent("claude", nil)) == []
+      assert Runtimes.Model.model_args(agent("claude", "bare-id")) == []
+      assert Runtimes.Model.model_args(%{}) == []
+    end
+  end
+
+  # The regression #553 describes: three of four runtimes built argv that
+  # never mentioned agent.model, so the CLI's own default ran instead.
+  describe "build_command/5 honours agent.model" do
+    test "claude passes the bare id" do
+      {"claude", argv, _opts} =
+        Runtimes.Claude.build_command(
+          agent("claude", "anthropic/claude-opus-4-7"),
+          "hi",
+          :run,
+          "sess-1",
+          []
+        )
+
+      assert "--model" in argv
+      assert Enum.at(argv, Enum.find_index(argv, &(&1 == "--model")) + 1) == "claude-opus-4-7"
+      refute "anthropic/claude-opus-4-7" in argv
+    end
+
+    test "codex passes the bare id" do
+      {"codex", argv, _opts} =
+        Runtimes.Codex.build_command(agent("codex", "openai/gpt-5-codex"), "hi", :run, nil, [])
+
+      assert "--model" in argv
+      assert Enum.at(argv, Enum.find_index(argv, &(&1 == "--model")) + 1) == "gpt-5-codex"
+    end
+
+    test "gemini passes the bare id" do
+      {"gemini", argv, _opts} =
+        Runtimes.Gemini.build_command(
+          agent("gemini", "google/gemini-2.5-pro"),
+          "hi",
+          :run,
+          nil,
+          []
+        )
+
+      assert "--model" in argv
+      assert Enum.at(argv, Enum.find_index(argv, &(&1 == "--model")) + 1) == "gemini-2.5-pro"
+    end
+
+    test "opencode still passes the canonical string verbatim" do
+      {"opencode", argv, _opts} =
+        Runtimes.OpenCode.build_command(
+          agent("opencode", "anthropic/claude-sonnet-4-6"),
+          "hi",
+          :run,
+          nil,
+          []
+        )
+
+      assert "anthropic/claude-sonnet-4-6" in argv
+    end
+
+    test "the model survives a continue turn too" do
+      {"claude", argv, _opts} =
+        Runtimes.Claude.build_command(
+          agent("claude", "anthropic/claude-opus-4-7"),
+          "hi",
+          :continue,
+          "sess-1",
+          []
+        )
+
+      assert "claude-opus-4-7" in argv
+      assert "--resume" in argv
+    end
+  end
+end

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -110,18 +110,28 @@ defmodule Fountain.Factory do
   # ── agents ────────────────────────────────────────────────────────────────
 
   def agent_attrs(overrides \\ %{}) do
+    overrides = to_string_map(overrides)
+    runtime = Map.get(overrides, "runtime", "claude")
+
     Map.merge(
       %{
         "name" => "agent-#{uniq()}",
-        "model" => "anthropic/claude-sonnet-4-6",
-        "runtime" => "claude",
+        # The changeset requires the provider prefix to match the runtime
+        # (#553), so a call site that overrides only :runtime still gets a
+        # model its runtime can actually reach.
+        "model" => default_model_for(runtime),
+        "runtime" => runtime,
         "skills" => [],
         "mcp_servers" => %{},
         "metadata" => %{}
       },
-      to_string_map(overrides)
+      overrides
     )
   end
+
+  defp default_model_for("codex"), do: "openai/gpt-5-codex"
+  defp default_model_for("gemini"), do: "google/gemini-2.5-pro"
+  defp default_model_for(_runtime), do: "anthropic/claude-sonnet-4-6"
 
   def insert_agent(overrides \\ %{}) do
     overrides = to_string_map(overrides)

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -56,7 +56,11 @@ spec:
 
 An **Agent** is a named, re-runnable configuration for an AI coding assistant:
 
-- **`model`** - `provider/model-id` (e.g. `anthropic/claude-sonnet-4-6`)
+- **`model`** - `provider/model-id` (e.g. `anthropic/claude-sonnet-4-6`), passed
+  to the runtime's CLI. The provider must match the runtime: `anthropic` for
+  `claude`, `openai` for `codex`, `google` for `gemini`. `opencode` is
+  multi-provider and takes any prefix — it also uses the prefix to pick which
+  API key to export.
 - **`runtime`** - one of `claude`, `codex`, `gemini`, `opencode`
 - **`environment`** - optional Environment to attach
 - **`system`** / **`description`** - system prompt and human-readable description


### PR DESCRIPTION
Closes #553.

## The bug

`Agent.model` is required, format-validated to canonical `provider/model_id`, front-and-centre in the agent form, and documented in the OpenAPI schema — but only **opencode** read it. `claude`, `codex`, and `gemini` all built model-agnostic argv, so an agent set to `anthropic/claude-haiku-4-5` to save cost silently ran whatever the CLI defaulted to. No error, no signal the field did nothing.

## The fix

All three CLIs do take a model flag — verified against each one rather than from memory:

| runtime | flag | wants |
|---|---|---|
| `claude` | `--model` | bare id or alias (`claude-sonnet-4-6`, `opus`) |
| `codex` | `-m, --model <MODEL>` | bare id |
| `gemini` | `-m, --model` | bare id |

So the canonical `provider/` prefix has to come off for those three, while opencode keeps taking the full string verbatim (it's the only multi-provider front-end, and it reads the prefix to decide which API key to export). `Fountain.Runtimes.Model` owns that translation in one place; each runtime's `build_command/5` gained one line.

## The behavior change worth reviewing

Honoring the field converts a previously-inert mismatch into a hard spawn failure: before this, `openai/gpt-5` on a claude-runtime agent was ignored; after, it would ship `--model gpt-5` to `claude`. So the changeset now rejects a prefix the runtime can't reach — `anthropic` for claude, `openai` for codex, `google` for gemini, with opencode unconstrained.

**This invalidates nothing already stored.** I checked prod before writing the validation:

```
runtime|provider|count
claude |anthropic|45
```

All 45 agents are claude/anthropic, and both distinct model ids (`claude-sonnet-4-6`, `claude-opus-4-7`) are real ids that `claude --model` accepts bare.

Two supporting changes fall out of the new validation:
- the agent-form model placeholder now tracks the selected runtime (`openai/gpt-5-codex` when you pick codex), so the hint can't walk you into the error;
- the test factory derives the default model from the `runtime` override — two existing test files created `runtime: "codex"` agents that inherited the `anthropic/` default and correctly started failing.

## Tests

New `Fountain.Runtimes.ModelTest` covers the prefix translation and asserts each runtime's argv actually carries the model — the assertion that was missing. I verified it fails against the bug by stubbing `model_args/1` back to `[]`: 5 failures across the four runtime cases, opencode still passing (it never used the helper). The agent changeset tests cover each runtime's mismatch, opencode's freedom, a runtime-only edit validated against the stored model, and that a malformed model reports only the format error rather than doubling up.

`mix precommit` green: 2441 tests, 0 failures; credo, sobelow, dialyzer clean.

## Not in scope

#554 (known-model validation and suggestions) stays open — this PR checks that the provider *matches the runtime*, not that the model id is a real model. `gemini/` is spelled `google/` here, following the existing `provider_of/1` mapping in `open_code.ex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
