### PR TITLE
feat: validate the model provider and suggest known models (#554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ upgrade, is in
 
 ### Added
 
+- **The agent form suggests models, and a misspelled provider is caught at
+  save time.** `agent.model` was format-checked and nothing more, so
+  `anthopic/claude-sonnet-4-6` saved cleanly and then failed inside the
+  sandbox: `opencode` reads the prefix to decide which API key to export and
+  falls through to none for an unrecognised one, so the run started with no
+  inference credentials at all and died as an auth error in the conversation
+  log. The provider is now validated on write against the three Fountain
+  actually holds credentials for — `anthropic`, `openai`, `google` — and the
+  model field offers a `<datalist>` of current models, scoped to the selected
+  runtime so it can't lead you into the runtime/provider mismatch #553 added.
+  The **model id is deliberately still unchecked**: type anything and it is
+  passed to the CLI as-is (the form says so), so a model released after your
+  Fountain version works without waiting for a release (#554)
+
 - **`MIGRATE_ON_BOOT=false` — run migrations somewhere other than at boot.**
   The release migrates before it serves, on every replica, which is right for
   the single-replica shape it ships as and rules out the standard Kubernetes

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -69,17 +69,40 @@ defmodule Fountain.Agents.Agent do
   # Reject a mismatched prefix here rather than shipping `gpt-5` to
   # `claude --model`: before #553 those runtimes ignored the field
   # entirely, so `openai/gpt-5` on a claude agent looked configured and
-  # silently ran the CLI's own default. opencode is multi-provider and
-  # takes any prefix, so it is unconstrained.
+  # silently ran the CLI's own default.
+  #
+  # opencode takes any *known* prefix. It is multi-provider but not
+  # open-ended: it reads the prefix to pick which API key to export, and
+  # Fountain only holds three (`InferenceCredentials.Credential`). A
+  # misspelled provider used to fall through to no credentials at all and
+  # fail as an auth error inside the sprite, so reject it here too (#554).
+  #
+  # The model id itself is never checked — a model released since the last
+  # deploy has to work the day it ships.
   defp validate_model_provider(changeset) do
-    runtime = get_field(changeset, :runtime)
+    case Model.provider(get_field(changeset, :model)) do
+      nil -> changeset
+      actual -> validate_provider(changeset, actual, get_field(changeset, :runtime))
+    end
+  end
 
-    with expected when is_binary(expected) <- Model.provider_for_runtime(runtime),
-         actual when is_binary(actual) <- Model.provider(get_field(changeset, :model)),
-         true <- actual != expected do
-      add_error(changeset, :model, "#{runtime} runtime requires a #{expected}/ model")
+  defp validate_provider(changeset, actual, runtime) do
+    case Model.provider_for_runtime(runtime) do
+      nil -> validate_known_provider(changeset, actual)
+      ^actual -> changeset
+      expected -> add_error(changeset, :model, "#{runtime} runtime requires a #{expected}/ model")
+    end
+  end
+
+  defp validate_known_provider(changeset, provider) do
+    if Model.known_provider?(provider) do
+      changeset
     else
-      _ -> changeset
+      add_error(
+        changeset,
+        :model,
+        "unknown provider \"#{provider}\" — must be one of: #{Enum.join(Model.providers(), ", ")}"
+      )
     end
   end
 

--- a/apps/fountain/lib/fountain/runtimes/model.ex
+++ b/apps/fountain/lib/fountain/runtimes/model.ex
@@ -18,6 +18,11 @@ defmodule Fountain.Runtimes.Model do
   Before #553 those three runtimes ignored the field entirely, so an
   `openai/gpt-5` agent on the claude runtime looked configured and quietly
   ran whatever the CLI defaulted to.
+
+  This module also owns the curated model catalog (`suggestions/1`,
+  `providers/0`) that the agent form offers and the changeset validates the
+  provider half against — see the comment on `@catalog` for what is gated and
+  what deliberately is not.
   """
 
   @provider_by_runtime %{
@@ -25,6 +30,68 @@ defmodule Fountain.Runtimes.Model do
     "codex" => "openai",
     "gemini" => "google"
   }
+
+  # Curated, deliberately short suggestion list — newest first per provider.
+  #
+  # The *model id* half is never gated on this list: a model released after the
+  # last deploy has to be usable the day it ships, so an unrecognised id is
+  # accepted and passed to the CLI verbatim (the form says so; see #554). The
+  # *provider* half is gated, because the set is not open — Fountain can only
+  # export credentials for these three (`InferenceCredentials.Credential` has a
+  # column per provider, and `OpenCode.default_env/2` maps exactly these three
+  # prefixes). A typo like `anthopic/...` used to reach the sprite with no
+  # inference credentials at all and fail as an auth error in the conversation
+  # log; `Agent.changeset/2` now rejects it at write time.
+  @catalog %{
+    "anthropic" => ~w(
+      claude-opus-5
+      claude-sonnet-5
+      claude-opus-4-8
+      claude-sonnet-4-6
+      claude-haiku-4-5
+    ),
+    "openai" => ~w(gpt-5-codex gpt-5),
+    "google" => ~w(gemini-2.5-pro gemini-2.5-flash)
+  }
+
+  # Stable order for the UI: the single-provider runtimes in the order they
+  # appear in @provider_by_runtime, so an opencode datalist reads the same way
+  # every render.
+  @provider_order ~w(anthropic openai google)
+
+  @doc "Providers Fountain can export inference credentials for, in display order."
+  def providers, do: @provider_order
+
+  @doc "Whether `provider` is one Fountain can export credentials for."
+  def known_provider?(provider), do: provider in @provider_order
+
+  @doc """
+  Suggested canonical `provider/model_id` strings for a runtime — the
+  runtime's own provider for claude / codex / gemini, every provider for
+  opencode (and for an unrecognised runtime, which the changeset rejects
+  separately).
+
+  These are suggestions, not an allowlist. `Agent.changeset/2` accepts any
+  model id under a known provider.
+  """
+  def suggestions(runtime) do
+    case provider_for_runtime(runtime) do
+      nil -> Enum.flat_map(@provider_order, &suggestions_for_provider/1)
+      provider -> suggestions_for_provider(provider)
+    end
+  end
+
+  @doc "Whether a canonical model string is one of the curated suggestions."
+  def known?(model) do
+    case split(model) do
+      {nil, nil} -> false
+      {provider, id} -> id in Map.get(@catalog, provider, [])
+    end
+  end
+
+  defp suggestions_for_provider(provider) do
+    @catalog |> Map.fetch!(provider) |> Enum.map(&"#{provider}/#{&1}")
+  end
 
   @doc """
   The single provider a runtime's CLI can reach, or `nil` for a

--- a/apps/fountain/lib/fountain_web/components/core_components.ex
+++ b/apps/fountain/lib/fountain_web/components/core_components.ex
@@ -596,7 +596,9 @@ defmodule FountainWeb.CoreComponents do
   attr :type, :string, default: "text"
   attr :value, :string, default: ""
   attr :placeholder, :string, default: nil
-  attr :rest, :global, include: ~w(autofocus required disabled rows pattern phx-hook)
+  # `list` is an <input>-specific attribute, not one of Phoenix's HTML globals,
+  # so it has to be opted in for a datalist to attach.
+  attr :rest, :global, include: ~w(autofocus required disabled rows pattern phx-hook list)
 
   def input(assigns) do
     ~H"""

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -4,6 +4,7 @@ defmodule FountainWeb.AgentsLive.Form do
 
   alias Fountain.{Agents, AvatarGenerator, Environments}
   alias Fountain.Agents.Agent
+  alias Fountain.Runtimes.Model
 
   @impl true
   def mount(params, _session, socket) do
@@ -93,6 +94,17 @@ defmodule FountainWeb.AgentsLive.Form do
   defp model_placeholder("codex"), do: "openai/gpt-5-codex"
   defp model_placeholder("gemini"), do: "google/gemini-2.5-pro"
   defp model_placeholder(_runtime), do: "anthropic/claude-sonnet-4-6"
+
+  # A model id off the curated list is legitimate — new models ship between
+  # deploys — so say it will be used rather than flagging it as wrong. Stay
+  # quiet while the value is unparseable or the provider is unknown: those are
+  # real errors and `error_msg` says so on submit.
+  defp unknown_model?(model) do
+    case Model.split(model) do
+      {nil, nil} -> false
+      {provider, _id} -> Model.known_provider?(provider) and not Model.known?(model)
+    end
+  end
 
   @impl true
   def handle_event("validate", %{"agent" => params}, socket) do
@@ -544,10 +556,20 @@ defmodule FountainWeb.AgentsLive.Form do
             label="Model"
             value={@form["model"]}
             placeholder={model_placeholder(@form["runtime"])}
+            list="model-options"
             required
           />
+          <datalist id="model-options">
+            <option :for={m <- Model.suggestions(@form["runtime"])} value={m}></option>
+          </datalist>
         </div>
         <.error_msg field="model" errors={@errors} />
+        <p
+          :if={not Map.has_key?(@errors, "model") and unknown_model?(@form["model"])}
+          class="text-zinc-500 text-xs"
+        >
+          Not one of the models Fountain lists — it will be passed to the runtime as-is.
+        </p>
 
         <div class="space-y-1">
           <label class="block text-sm font-medium text-zinc-700">Environment</label>

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -243,7 +243,10 @@ defmodule FountainWeb.Schemas do
           description:
             "Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The " <>
               "provider must match the runtime — anthropic for claude, openai for " <>
-              "codex, google for gemini; opencode accepts any provider.",
+              "codex, google for gemini; opencode accepts any of the three. Other " <>
+              "providers are rejected: Fountain has no credentials to export for " <>
+              "them. The model id is not checked against a list, so a newly " <>
+              "released model works without a Fountain release.",
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
         runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},

--- a/apps/fountain/test/fountain/agents/agent_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_test.exs
@@ -93,11 +93,38 @@ defmodule Fountain.Agents.AgentTest do
       assert "gemini runtime requires a google/ model" in errors_on(changeset).model
     end
 
-    test "opencode accepts any provider — it is the multi-provider runtime" do
+    test "opencode accepts any known provider — it is the multi-provider runtime" do
       for model <- ~w(anthropic/claude-sonnet-4-6 openai/gpt-5 google/gemini-2.5-pro) do
         attrs = Map.merge(@valid_attrs, %{runtime: "opencode", model: model})
         assert Agent.changeset(%Agent{}, attrs).valid?
       end
+    end
+
+    # #554: opencode reads the prefix to pick which API key to export and
+    # falls through to none for an unrecognised one, so a typo used to reach
+    # the sprite with no inference credentials and fail as an auth error.
+    test "opencode rejects a provider Fountain holds no credentials for" do
+      attrs = Map.merge(@valid_attrs, %{runtime: "opencode", model: "anthopic/claude-sonnet-4-6"})
+      changeset = Agent.changeset(%Agent{}, attrs)
+      refute changeset.valid?
+
+      expected = ~s(unknown provider "anthopic" — must be one of: anthropic, openai, google)
+      assert expected in errors_on(changeset).model
+    end
+
+    test "a single-provider runtime reports the runtime mismatch, not the unknown provider" do
+      changeset = Agent.changeset(%Agent{}, Map.put(@valid_attrs, :model, "anthopic/claude"))
+      refute changeset.valid?
+      assert errors_on(changeset).model == ["claude runtime requires a anthropic/ model"]
+    end
+
+    # The model id is deliberately unchecked: a model released after this
+    # deploy has to be usable the day it ships.
+    test "an unrecognised model id under a known provider is accepted" do
+      changeset =
+        Agent.changeset(%Agent{}, Map.put(@valid_attrs, :model, "anthropic/claude-opus-99"))
+
+      assert changeset.valid?
     end
 
     test "a runtime change alone is validated against the stored model" do

--- a/apps/fountain/test/fountain/runtimes/model_test.exs
+++ b/apps/fountain/test/fountain/runtimes/model_test.exs
@@ -38,6 +38,68 @@ defmodule Fountain.Runtimes.ModelTest do
     end
   end
 
+  describe "the model catalog" do
+    # The provider half is gated because this set is closed: it mirrors the
+    # per-provider credential columns on InferenceCredentials.Credential
+    # (anthropic_api_key / openai_api_key / gemini_api_key). Adding a provider
+    # here without a credential to export for it would put the old #554 bug
+    # back — a sprite spawned with no inference key at all.
+    test "providers/0 is exactly the set Fountain can export credentials for" do
+      assert Runtimes.Model.providers() == ~w(anthropic openai google)
+    end
+
+    test "known_provider?/1 accepts the three and nothing else" do
+      assert Runtimes.Model.known_provider?("anthropic")
+      assert Runtimes.Model.known_provider?("openai")
+      assert Runtimes.Model.known_provider?("google")
+      refute Runtimes.Model.known_provider?("anthopic")
+      refute Runtimes.Model.known_provider?("openrouter")
+      refute Runtimes.Model.known_provider?(nil)
+    end
+
+    test "suggestions/1 offers only the runtime's own provider" do
+      for {runtime, provider} <- [
+            {"claude", "anthropic"},
+            {"codex", "openai"},
+            {"gemini", "google"}
+          ] do
+        suggestions = Runtimes.Model.suggestions(runtime)
+        refute suggestions == []
+
+        assert Enum.all?(suggestions, &String.starts_with?(&1, provider <> "/")),
+               "#{runtime} was offered a foreign provider: #{inspect(suggestions)}"
+      end
+    end
+
+    test "suggestions/1 offers every provider to opencode" do
+      suggestions = Runtimes.Model.suggestions("opencode")
+
+      for provider <- Runtimes.Model.providers() do
+        assert Enum.any?(suggestions, &String.starts_with?(&1, provider <> "/"))
+      end
+    end
+
+    test "every suggestion is a model the changeset accepts for its runtime" do
+      for runtime <- Agent.runtimes(), model <- Runtimes.Model.suggestions(runtime) do
+        changeset =
+          Agent.changeset(%Agent{}, %{name: "a", runtime: runtime, model: model})
+
+        assert changeset.valid?,
+               "#{runtime} suggestion #{model} is rejected: #{inspect(changeset.errors)}"
+      end
+    end
+
+    test "known?/1 recognises catalog entries and nothing else" do
+      assert Runtimes.Model.known?("anthropic/claude-opus-5")
+      # Right provider, unlisted id — accepted by the changeset, just not listed.
+      refute Runtimes.Model.known?("anthropic/claude-opus-99")
+      # Listed id under the wrong provider.
+      refute Runtimes.Model.known?("openai/claude-opus-5")
+      refute Runtimes.Model.known?("bare-id")
+      refute Runtimes.Model.known?(nil)
+    end
+  end
+
   describe "model_args/1" do
     test "strips the provider prefix" do
       assert Runtimes.Model.model_args(agent("claude", "anthropic/claude-sonnet-4-6")) ==

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -3,6 +3,8 @@ defmodule FountainWeb.AgentsLive.IndexTest do
 
   import Phoenix.LiveViewTest
 
+  alias Fountain.Runtimes.Model
+
   describe "index" do
     test "renders agent list for authenticated user", %{conn: conn} do
       user = insert_verified_user()
@@ -69,6 +71,57 @@ defmodule FountainWeb.AgentsLive.IndexTest do
     test "redirects unauthenticated user to login", %{conn: conn} do
       assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/agents/new")
       assert path =~ "/auth/login"
+    end
+
+    # #554: the model field was a bare text input, so nothing in the UI said
+    # what a valid value looked like until the sprite failed at spawn time.
+    test "model field offers the curated models for the selected runtime", %{conn: conn} do
+      user = insert_verified_user()
+      conn = login_user(conn, user)
+
+      {:ok, view, html} = live(conn, ~p"/agents/new")
+
+      assert html =~ ~s(list="model-options")
+
+      for model <- Model.suggestions("claude") do
+        assert has_element?(view, ~s(datalist#model-options option[value="#{model}"]))
+      end
+
+      # Switching runtime re-scopes the list — codex can't reach an
+      # anthropic/ model, and the changeset rejects one.
+      html = render_change(view, "validate", %{"agent" => %{"runtime" => "codex"}})
+      assert html =~ "openai/gpt-5-codex"
+      refute html =~ "anthropic/claude-opus-5"
+    end
+
+    test "an unlisted model id is flagged as pass-through, not as an error", %{conn: conn} do
+      user = insert_verified_user()
+      conn = login_user(conn, user)
+
+      {:ok, view, _html} = live(conn, ~p"/agents/new")
+
+      listed =
+        render_change(view, "validate", %{
+          "agent" => %{"runtime" => "claude", "model" => "anthropic/claude-opus-5"}
+        })
+
+      refute listed =~ "passed to the runtime as-is"
+
+      unlisted =
+        render_change(view, "validate", %{
+          "agent" => %{"runtime" => "claude", "model" => "anthropic/claude-opus-99"}
+        })
+
+      assert unlisted =~ "passed to the runtime as-is"
+
+      # A bad provider is a real error, not a pass-through — stay quiet and
+      # let the changeset speak on submit.
+      bad_provider =
+        render_change(view, "validate", %{
+          "agent" => %{"runtime" => "opencode", "model" => "anthopic/claude-opus-5"}
+        })
+
+      refute bad_provider =~ "passed to the runtime as-is"
     end
   end
 

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -59,8 +59,12 @@ An **Agent** is a named, re-runnable configuration for an AI coding assistant:
 - **`model`** - `provider/model-id` (e.g. `anthropic/claude-sonnet-4-6`), passed
   to the runtime's CLI. The provider must match the runtime: `anthropic` for
   `claude`, `openai` for `codex`, `google` for `gemini`. `opencode` is
-  multi-provider and takes any prefix — it also uses the prefix to pick which
-  API key to export.
+  multi-provider and takes any of the three — it uses the prefix to pick which
+  API key to export. A provider outside that set is rejected at write time:
+  there is no credential for it, so the sandbox would have started with no
+  inference key at all. The model id itself is *not* checked against a list —
+  the agent form suggests current models, but anything you type is passed to
+  the CLI as-is, so a model released since your Fountain version still works.
 - **`runtime`** - one of `claude`, `codex`, `gemini`, `opencode`
 - **`environment`** - optional Environment to attach
 - **`system`** / **`description`** - system prompt and human-readable description


### PR DESCRIPTION
Closes #554.

## Problem

`Agent.model` was format-checked (`^[a-z0-9_-]+/[a-z0-9._-]+$`) and nothing more, so `anthopic/claude-sonnet-4-6` saved cleanly. `OpenCode.default_env/2` maps `anthropic`/`openai`/`google` prefixes to API-key env vars and falls through to `[]` for anything else — so a misspelled provider reached the sprite with **no inference credentials at all** and failed as an auth error in the conversation log, not as a validation error. And the model field was a bare text input with one placeholder: nothing in the UI said what a valid value looked like.

## What changed

**The provider half is now gated.** `Fountain.Runtimes.Model` owns the set (`anthropic`, `openai`, `google`) — it mirrors the per-provider columns on `InferenceCredentials.Credential`, which is why it's closed rather than open-ended. `Agent.changeset/2` rejects anything outside it:

```
unknown provider "anthopic" — must be one of: anthropic, openai, google
```

Single-provider runtimes keep the more specific #553 message (`claude runtime requires a anthropic/ model`) — one error, the actionable one.

**The model id half is deliberately not gated.** A model released after a given Fountain version has to be usable the day it ships, so anything under a known provider is accepted and passed to the CLI verbatim. That is the "warn-don't-block" half of the issue: the form says so under the field rather than flagging it as wrong.

**The form gained an affordance.** A `<datalist>` of current models, scoped to the selected runtime so it can't offer a value the changeset will reject; switching runtime re-scopes it live. Catalog lives next to the runtime/provider mapping it has to agree with, and a test asserts every suggestion is a model the changeset accepts for its runtime.

Also updated: the OpenAPI `model` description, `docs/primitives.md`, and `CHANGELOG.md`.

## Deliberately not done

- **The default model is unchanged** (`anthropic/claude-sonnet-4-6` in the form and factory). The catalog is ordered newest-first so the datalist leads with current models, but changing what a new agent defaults to is a product call with cost implications, not part of this issue.
- **The catalog is a module constant, not config.** Nothing is gated on it that a self-hoster can't work around by typing the model, so there was no case for the extra config surface.

## Testing

- `Model` catalog: provider set, `known_provider?/1`, per-runtime `suggestions/1`, `known?/1`, and a cross-check that every suggestion passes `Agent.changeset/2` for its runtime.
- `Agent.changeset/2`: unknown provider rejected on opencode; single-provider runtimes report the mismatch not the unknown provider; an unlisted model id under a known provider is accepted.
- LiveView: the datalist renders and re-scopes on runtime change; the pass-through hint appears only for an unlisted id under a known provider (not for a bad provider, which is a real error).

Both new behaviours were verified by reverting the fix and confirming the tests fail.

`mix precommit` green (2,462 tests), OpenAPI spec validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)