### PR TITLE
fix: copy coverage.exs into the image build (#620)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,13 @@ RUN mix local.hex --force \
 # fetching and compiling deps, so the (expensive, slow-moving) deps layer
 # survives any change to application code. Copying apps/ wholesale here
 # is what used to force a full dep recompile on every commit.
-COPY mix.exs mix.lock ./
+#
+# coverage.exs is part of that set, not test-only config: both mix.exs
+# files read it with Code.eval_file to build `test_coverage`, which runs
+# while Mix loads the project — before any task, in every MIX_ENV. Leave
+# it out and `mix deps.get` dies on Code.LoadError (#620 moved the
+# settings into this file and the prod image stopped building).
+COPY mix.exs mix.lock coverage.exs ./
 COPY config ./config
 COPY apps/fountain/mix.exs ./apps/fountain/mix.exs
 


### PR DESCRIPTION
The prod image has not built since #620 merged this morning — four consecutive `build.yml` failures over ~11½ hours, all identical.

| commit | PR | build |
|---|---|---|
| `ea49e7f` | #619 | ✅ 06:10 |
| `a56e3d1` | #620/#621 — coverage partitioning | ❌ **first failure**, 06:44 |
| `584c312` | #622 | ❌ |
| `4b5ba21` | #624 (#553 — honor `agent.model`) | ❌ |
| `46bc8ec` | #623 (`MIGRATE_ON_BOOT`) | ❌ |
| `4f1f6c1` | #625 (#554 — model validation) | queued behind the same failure |

```
#22 0.599 ** (Code.LoadError) could not load /app/coverage.exs. Reason: enoent
#22 0.599     mix.exs:50: Fountain.Umbrella.MixProject.coverage/0
#22 0.599     mix.exs:21: Fountain.Umbrella.MixProject.project/0
```

## Cause

#620 moved the coverage settings out of `coveralls.json` and into `coverage.exs` at the repo root. Both mix files read it the same way:

```elixir
# mix.exs:50
Path.expand("coverage.exs", __DIR__) |> Code.eval_file() |> elem(0)
# apps/fountain/mix.exs:29
Path.expand("../../coverage.exs", __DIR__) |> Code.eval_file() |> elem(0)
```

That runs inside `project/0` — while Mix loads the project, before any task dispatches, in **every** `MIX_ENV`. It is not test-only config even though its contents are about tests.

The Dockerfile's dependency-caching layer deliberately copies only what dependency resolution reads:

```dockerfile
COPY mix.exs mix.lock ./
COPY config ./config
COPY apps/fountain/mix.exs ./apps/fountain/mix.exs
```

`coverage.exs` belongs in that set and wasn't in it, so `mix deps.get --only prod` failed on the first line of project config.

## Fix

One line — `coverage.exs` joins the root mix files in that same layer, with a comment saying why a coverage file is a dependency-resolution input. It goes there rather than after `COPY apps` on purpose: putting it below the deps layer would work, but it moves with the mix files and copying it later would place a hand-edited path above the expensive deps cache.

## Verification

Reconstructed the exact file set the Dockerfile builds and ran the failing command against it:

```
--- WITHOUT coverage.exs (main today) ---
** (Code.LoadError) could not load /private/tmp/dockerctx/coverage.exs. Reason: enoent
    mix.exs:50: Fountain.Umbrella.MixProject.coverage/0

--- WITH coverage.exs (this PR) ---
* Getting ecto (Hex package)
...
```

Same `Code.LoadError`, same `mix.exs:50` frame as CI. `deps.get` proceeds once the file is present. The real check is `build.yml` going green on this branch's merge to main.

## Why CI didn't catch it

CI runs `mix test --cover` against a full checkout, where `coverage.exs` is obviously present, and never builds the image. Nothing in the PR gate exercises the trimmed file set the Dockerfile constructs — the only job that would have is `build.yml`, which runs *after* merge and did fail loudly on all four commits.

No changelog entry: the affected commits never produced a publishable image, so nothing user-facing changed.

## After this merges

`4b5ba21` (#553), `46bc8ec` (#610) and `4f1f6c1` (#554) are all on main and have never reached prod. Once this builds, the resulting image carries all of them — worth verifying the running pod's image sha rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)