### PR TITLE
adr: 0014 — speak the Agent Client Protocol to runtimes

### DIFF
--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -1,0 +1,186 @@
+# 0014 — Speaking the Agent Client Protocol to runtimes
+
+**Status:** Proposed — **nothing described here is built.** No ACP code exists
+in this repo today. This ADR records a direction and the gates that decide
+whether we take it; the PR that builds each gate removes its caveat.
+
+## Context
+
+Fountain supports four coding-agent CLIs, and pays for each one twice.
+
+**Once at spawn.** `Fountain.Runtimes` (`apps/fountain/lib/fountain/runtimes.ex`)
+is a six-callback behaviour that exists entirely because the four CLIs
+disagree about argv, credentials, session resume, config files and where
+skills live on disk.
+
+**Again at render.** `FountainWeb.ConversationsLive.Show` carries 24 clauses of
+`event_blocks/2` (`show.ex:1340-1530`) — four hand-written parsers for four
+proprietary line-delimited JSON dialects, living in a LiveView. Adding a fifth
+runtime means writing a fifth parser, in the render path, against an
+undocumented stream format that its vendor may change in a point release.
+
+Those parsers all reduce to the same small vocabulary, and it is very close to
+one that already has a specification. The Agent Client Protocol (ACP,
+<https://agentclientprotocol.com>) is JSON-RPC 2.0 between a *client* (an
+editor, or in our case Fountain) and an *agent* (the CLI). Its
+`session/update` notification carries exactly the block kinds we reconstruct
+by hand:
+
+| `show.ex` block | ACP `session/update` variant |
+|---|---|
+| `%{kind: :text}` | `agent_message_chunk` |
+| `%{kind: :thinking}` | `agent_thought_chunk` |
+| `%{kind: :tool_use}` | `tool_call` — `id`, `title`, `kind`, `rawInput`, `locations` |
+| `%{kind: :tool_result}` | `tool_call_update` — same `id`, plus `status` |
+| `%{kind: :init}` | the `session/new` response |
+| `%{kind: :result}` | the `session/prompt` response's stop reason |
+| — | `plan`, `available_commands_update` (no Fountain equivalent) |
+
+`pair_tool_results/1` (`show.ex:1293`) exists only because three of the four
+dialects emit a tool call and its result as unrelated top-level events that we
+have to rejoin by id. ACP threads them on one `id` by construction.
+
+Two further things the current design cannot express, both of which cost us
+something real:
+
+**We run every agent with its safety rail removed, and it is not a choice.**
+`claude.ex:39` passes `--dangerously-skip-permissions`; `gemini.ex:50` passes
+`--approval-mode yolo`; `codex.ex:51` passes
+`--dangerously-bypass-approvals-and-sandbox`; `open_code.ex:46` passes
+`--dangerously-skip-permissions`. A headless CLI has no channel back to a
+human, so bypass is the only way it runs unattended. The sprite sandbox is
+therefore not defence *in depth* — it is the only defence there is. ACP's
+`session/request_permission` is an agent→client request: the agent blocks and
+the client answers. That is a channel we do not have and cannot build without
+forking four CLIs.
+
+**Two runtimes resume by guessing.** `gemini.ex:14-17` documents that
+`--resume` re-enters "the most recent conversation in the workspace" because
+Gemini will not accept a session id; `codex.ex:24-26` documents the same for
+`--last`. Correct only while one conversation ever runs in a workspace —
+an invariant we hold by accident, not by construction, and one that no test
+asserts. ACP's model is `session/new` once, then N× `session/prompt` over one
+live connection, with `session/load` for genuine resume. The id is explicit.
+
+## Decision
+
+Adopt ACP as Fountain's **runtime I/O layer**, incrementally and behind gates,
+while keeping `Fountain.Runtimes` as the **provisioning** layer. Do not
+attempt a cutover.
+
+The split is the load-bearing part of this decision. ACP has no opinion about
+how the agent binary, its credentials, its skills or its MCP servers got into
+the sandbox. So `default_env/2`, `write_config/2`, `prepare_sprite/3`,
+`skills_root/0` and `skills_sh_agent/0` all survive unchanged; only
+`build_command/5` and the four render-path parsers are in scope. Roughly half
+of `Fountain.Runtimes` is untouched by this ADR, and that is the expected
+end state, not a transitional one.
+
+### Gate 1 — survey, no code
+
+Confirm per runtime how ACP support is actually provided and what the version
+floor is. Claude Code and Codex are documented as supported via Zed's adapter
+packages (`zed-industries/claude-agent-acp`, `zed-industries/codex-acp`).
+Gemini CLI and OpenCode are both listed as ACP-supporting, but the published
+agents page does not clearly separate native support from adapter-based
+support — **resolve this before choosing the spike runtime**, because a
+runtime needing a vendored Node adapter in the sprite image is a materially
+different proposition from one that speaks ACP with a flag.
+
+Deliverable: a table of runtime → mechanism → package (if any) → minimum
+version, and a recommendation for which single runtime to spike.
+
+### Gate 2 — one runtime, behind a per-agent flag
+
+Build `Fountain.Runtimes.ACP` as a JSON-RPC peer over the stdio pipe we
+already own (`Fountain.SpriteStdin.write/2` for the write half, the existing
+stdout tail for the read half), for exactly one runtime, selected by gate 1.
+Leading candidate is Gemini — not for protocol reasons but because its resume
+semantics are the weakest thing we ship, so the spike fixes a live hazard
+rather than only relocating code.
+
+The peer must translate `session/update` into **the same block maps
+`show.ex` already renders**. The LiveView does not change in this gate. That
+constraint is what makes the two paths A/B-able on one screen, and it is the
+only way we find out whether the ACP stream is actually richer or merely
+different.
+
+Ship it off by default, enabled per agent, with the legacy path intact.
+
+### Gate 3 — permissions
+
+Implement `session/request_permission` against the conversation LiveView: a
+real approval prompt, per tool call, with the answer written back over the
+same connection. This is the gate that justifies the project. If gates 1-2
+land and gate 3 turns out to be blocked — by adapter support, by latency, by
+the reaper killing sessions mid-prompt — the honest outcome is to stop with
+one runtime converted and say so here.
+
+### Gate 4 — remaining runtimes, and parser deletion
+
+Only after gate 3 holds in production. A parser is deleted when its runtime's
+ACP path has served real conversations, not when the code compiles.
+
+### Not in scope
+
+Fountain as an ACP **agent** — `cli/` speaking ACP so that Zed or Neovim could
+drive a Fountain conversation in a remote sandbox from inside an editor. It is
+a distribution play rather than an architectural one, and ACP's remote
+(HTTP/WebSocket) transport is documented as work in progress. Revisit when
+that transport is stable; do not let it influence the gates above.
+
+## Consequences
+
+**We take on a JSON-RPC peer.** Bidirectional, with request/response
+correlation, agent→client method dispatch and cancellation
+(`session/cancel` is a notification with no reply). This is a new GenServer
+sitting beside a `ConversationServer` that is already 2,088 lines. If the
+peer lands inside that module, this ADR has been implemented wrongly.
+
+**The connection outlives the turn.** Today we spawn a process per turn and
+resume; ACP wants one connection alive for the session. That interacts
+directly with `SandboxReaper` and the rehydrator, which are built around the
+assumption that nothing is attached between turns. A reconnect story is
+mandatory, not a follow-up: where an adapter implements `session/load` we use
+it, and where it does not we are back to the same guess-the-session resume
+we started with — which is a reason to reject that runtime for conversion,
+not a reason to paper over it.
+
+**Client-side methods point at the wrong filesystem.** `fs/read_text_file`,
+`fs/write_text_file` and `terminal/*` are implemented by the *client*. Ours
+would have to service them against the **sprite**, not the Fountain server —
+via `Sprites.cmd`, with tenant scoping that the protocol knows nothing about.
+This is where the abstraction leaks, and it is the part most likely to
+produce a security finding if implemented carelessly. Absolute-path and
+1-based-line requirements are the protocol's, not ours; a path arriving over
+this channel is untrusted input from a sandbox we do not fully control.
+
+**We gain a supply-chain surface.** Some runtimes will need a Node adapter
+package baked into the sprite image, versioned independently of the CLI it
+wraps and lagging it. `hex.audit` does not see these. Whatever we vendor gets
+pinned and shows up in the image build.
+
+**What we give up:** a small, dumb, legible spawn path. `build_command/5`
+returning argv is trivially testable and fails loudly. A live protocol
+session has states — initialised, authenticated, prompting, cancelled — and
+therefore has state bugs. The bet is that permission prompts plus explicit
+session ids are worth that, and gate 3 is where the bet is settled.
+
+## Alternatives considered
+
+- **Keep hand-writing parsers.** Honest option, and correct if we stay at four
+  runtimes forever. Rejected because it cannot produce a permission prompt at
+  any price, and because the parsers live in the render path where a vendor's
+  point release becomes our rendering bug.
+- **Normalise to our own internal event schema, no ACP.** Same render-path
+  win, no protocol dependency, no adapter supply chain. Rejected because it is
+  strictly more work than adopting a spec that four vendors already target,
+  and it still leaves permissions unreachable — the translation would be from
+  the same one-way streams we have now.
+- **Full cutover to ACP in one change.** Rejected: it would couple a protocol
+  migration, a process-lifetime change and a reaper change in one PR, across
+  four runtimes, with the LiveView moving underneath it.
+- **Fountain as an ACP agent first.** More strategically interesting and
+  answers a real distribution question, but the remote transport is WIP and it
+  does nothing for the four parsers or the permission gap. Deferred above,
+  deliberately.

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -76,6 +76,48 @@ the sandbox. So `default_env/2`, `write_config/2`, `prepare_sprite/3`,
 of `Fountain.Runtimes` is untouched by this ADR, and that is the expected
 end state, not a transitional one.
 
+### The shape, drawn
+
+This ADR is the lower half of the picture; [0015](0015-fountain-as-an-acp-agent.md)
+is the upper half. Both are drawn here so that neither is read as a tree with
+the other hanging off it — they are two protocol roles held by one process.
+
+```
+  ┌─ editor (Zed, VS Code, …) ─────────────┐   ┌─────────────┐
+  │  spawns  ▸  fountain acp               │   │   web UI    │
+  │              ▲   ACP over local stdio  │   │ (LiveView)  │
+  └──────────────┼─────────────────────────┘   └──────┬──────┘
+                 │  HTTP + SSE                        │  WebSocket
+                 ▼                                    ▼
+  ┌─────────────────────────────────────────────────────────┐
+  │                        fountain                         │
+  │    ACP *agent* upward (0015) · ACP *client* downward    │
+  │    (0014) — the four runtime dialects stop at this line │
+  └────────────────────────────┬────────────────────────────┘
+                               │  ACP over the sprite's stdio
+                               ▼
+  ┌─────────────────────────────────────────────────────────┐
+  │      sprite  —  where the workspace and the files are   │
+  │        claude  ·  codex  ·  gemini  ·  opencode         │
+  └─────────────────────────────────────────────────────────┘
+```
+
+Two things the boxes are there to make hard to misread.
+
+**The vertical edges are asymmetric, and the traffic runs both ways on each.**
+`session/prompt` travels down and its stop reason comes back up;
+`session/update` only ever travels up; `session/request_permission` originates
+at the *bottom* and is answered from the top, which is why gate 3 below is the
+gate that justifies the project.
+
+**Placement is not on this diagram, and that is deliberate.** Which sandbox
+platform runs the sprite, and in whose cloud, is a separate axis that ACP says
+nothing about — it lives in `prepare_sprite/3`, `default_env/2` and
+`write_config/2`, the half of `Fountain.Runtimes` this ADR does not touch.
+ACP unifies the leaves; it does not make the substrate pluggable, and adopting
+it buys nothing toward that. A diagram that hangs runtimes off cloud providers
+is describing a decision nobody has written.
+
 ### Gate 1 — survey, no code
 
 Confirm per runtime how ACP support is actually provided and what the version

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -118,6 +118,54 @@ ACP unifies the leaves; it does not make the substrate pluggable, and adopting
 it buys nothing toward that. A diagram that hangs runtimes off cloud providers
 is describing a decision nobody has written.
 
+### Session lifetime: the connection is scoped to the turn
+
+The sandbox is the cost unit and it has to stay disposable. `Lifecycle`
+(`apps/fountain/lib/fountain/conversations/lifecycle.ex`) reclaims an idle
+sprite after 60 minutes and any sprite after 24 hours, and the reason that is
+safe is that nothing durable lives inside it: the conversation row stays
+`idle`, `runtime_session_id` is persisted *before* the turn spawns
+(`conversation_server.ex:1595`), and the next prompt provisions a fresh sprite
+and resumes. Being wrong in the reclaiming direction costs a re-provision;
+being wrong in the other direction bills indefinitely. Nothing in this ADR is
+allowed to weaken that asymmetry.
+
+An earlier draft of this document said "ACP wants one connection alive for the
+session" and filed the collision with `SandboxReaper` under mandatory scope.
+That conflated two things the specification keeps apart. A session is named by
+its `sessionId` and is independent of the connection that created it —
+`session/load` exists so a *different* client instance can pick one up, after
+which the client "can then continue sending prompts as if the session was
+never interrupted." And a turn has a defined end: "if there are no pending
+tool calls, the turn ends and the Agent **MUST** respond to the original
+`session/prompt` request with a `StopReason`."
+
+Nothing in ACP requires a connection to outlive a turn. So:
+
+> **One ACP connection per turn.** Spawn the agent, `initialize`,
+> `session/new` on turn 1 or `session/load` / `session/resume` on turn N,
+> exactly one `session/prompt`, take the `stopReason`, close. Nothing is
+> attached between turns. `SandboxReaper`, the rehydrator and `Lifecycle` are
+> untouched by this ADR.
+
+That is the shape we already run, with the protocol swapped in underneath it:
+
+| today | under ACP |
+|---|---|
+| `Sprites.spawn` per turn (`conversation_server.ex:1683`) | the same spawn; the process speaks ACP |
+| prompt written to stdin, then `close_stdin` | prompt in `session/prompt`; **stdin stays open** for the connection |
+| `--resume <runtime_session_id>`, `--last` | `session/load` or `session/resume`, same persisted id |
+| process exit ends the turn | the `session/prompt` response ends it; exit is the backstop |
+| idle sprite reclaimed at 60m, any sprite at 24h | unchanged |
+
+**The rule that keeps this from eroding one optimisation at a time: no ACP
+state may become a reason to keep a sandbox alive.** A connection may be
+scoped to the turn (v1) or, if per-turn `initialize` proves too slow, to the
+sandbox's own idle window — both are bounded by `Lifecycle`. A connection
+scoped to the *session* is out of bounds, because it makes protocol state
+outrank the cost control, and that is the form in which this decision would
+come back to bite us.
+
 ### Gate 1 — survey, no code
 
 Confirm per runtime how ACP support is actually provided and what the version
@@ -129,23 +177,65 @@ support — **resolve this before choosing the spike runtime**, because a
 runtime needing a vendored Node adapter in the sprite image is a materially
 different proposition from one that speaks ACP with a flag.
 
+The survey must also record, per runtime, the two capability flags the
+turn-scoped connection depends on: `agentCapabilities.loadSession` and
+`sessionCapabilities.resume`, both read from the `initialize` response.
+Under one-connection-per-turn these are not a convenience for genuine resume —
+they are the *only* thing carrying a conversation across turns.
+
+**A runtime that advertises neither is not convertible.** Without one of them
+we would be doing resume-by-guessing exactly as we do today, plus a JSON-RPC
+peer: strictly worse than what we ship. That is a rejection, not a gap to work
+around, and it applies whatever the adapter's other merits.
+
+It also makes gate 2's candidate conditional. Gemini is the interesting spike
+*because* its resume semantics are the weakest thing we ship — but that is
+only true if its ACP path advertises a resumption capability. If it does not,
+the spike fixes nothing and the candidate is whichever runtime does.
+
 Deliverable: a table of runtime → mechanism → package (if any) → minimum
-version, and a recommendation for which single runtime to spike.
+version → `loadSession` → `sessionCapabilities.resume`, and a recommendation
+for which single runtime to spike.
 
 ### Gate 2 — one runtime, behind a per-agent flag
 
 Build `Fountain.Runtimes.ACP` as a JSON-RPC peer over the stdio pipe we
 already own (`Fountain.SpriteStdin.write/2` for the write half, the existing
 stdout tail for the read half), for exactly one runtime, selected by gate 1.
-Leading candidate is Gemini — not for protocol reasons but because its resume
-semantics are the weakest thing we ship, so the spike fixes a live hazard
-rather than only relocating code.
 
 The peer must translate `session/update` into **the same block maps
 `show.ex` already renders**. The LiveView does not change in this gate. That
 constraint is what makes the two paths A/B-able on one screen, and it is the
 only way we find out whether the ACP stream is actually richer or merely
 different.
+
+Three requirements come from the turn-scoped connection above, and each is a
+concrete bug if it is missed:
+
+- **stdin stays open, and the turn gains a second terminator.** Today the
+  prompt is written and `close_stdin` follows immediately. An ACP peer needs
+  the write half open for the whole connection — it is the return path for
+  `session/request_permission` answers and for `session/cancel` — so
+  `close_stdin` moves to turn end. The turn then ends on *either* the
+  `session/prompt` response or process exit, whichever arrives first, and
+  never waits for both. #603 and #413 are both this class of bug: a turn whose
+  terminator never came, leaving `current_command` set forever.
+
+- **Discard the `session/load` replay.** The agent "**MUST** replay the entire
+  conversation to the Client in the form of `session/update` notifications"
+  before responding to `session/load`. Fountain already holds that history as
+  `LogEvent` rows, so a peer that persists what arrives before the `session/load`
+  response duplicates the whole transcript into the database and onto the SSE
+  stream, on every turn after the first. The peer runs in replay-discard mode
+  until `session/load` returns. Where `sessionCapabilities.resume` is
+  advertised, prefer `session/resume`: it is specified *not* to replay, which
+  deletes the failure mode instead of handling it.
+
+- **Measure the per-turn `initialize`.** Process start, `initialize`, and the
+  resumption round trip are now paid once per turn rather than once per
+  session. That is the honest price of a disposable sandbox, and gate 2 must
+  report it against the current spawn. If it is intolerable, the escape hatch
+  is the sandbox-scoped connection named above — never a session-scoped one.
 
 Ship it off by default, enabled per agent, with the legacy path intact.
 
@@ -187,14 +277,15 @@ correlation, agent→client method dispatch and cancellation
 sitting beside a `ConversationServer` that is already 2,088 lines. If the
 peer lands inside that module, this ADR has been implemented wrongly.
 
-**The connection outlives the turn.** Today we spawn a process per turn and
-resume; ACP wants one connection alive for the session. That interacts
-directly with `SandboxReaper` and the rehydrator, which are built around the
-assumption that nothing is attached between turns. A reconnect story is
-mandatory, not a follow-up: where an adapter implements `session/load` we use
-it, and where it does not we are back to the same guess-the-session resume
-we started with — which is a reason to reject that runtime for conversion,
-not a reason to paper over it.
+**A turn now has protocol state, even though the connection does not
+outlive it.** *Session lifetime* above settles the reaper question — nothing
+is attached between turns, so `SandboxReaper`, the rehydrator and `Lifecycle`
+are unchanged. What remains is that the turn itself is no longer a process we
+watch for an exit: it is a connection with states (initialised, prompting,
+awaiting a permission answer, cancelled) and two ways to end. The failure mode
+does not go away, it changes shape — from a runtime that exits without saying
+why, to a peer that is waiting for a message that will never arrive. Both end
+as a sprite billing until `max_lifetime`; the second is harder to see.
 
 **Client-side methods point at the wrong filesystem.** `fs/read_text_file`,
 `fs/write_text_file` and `terminal/*` are implemented by the *client*. Ours

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -123,11 +123,19 @@ ACP path has served real conversations, not when the code compiles.
 
 ### Not in scope
 
-Fountain as an ACP **agent** — `cli/` speaking ACP so that Zed or Neovim could
-drive a Fountain conversation in a remote sandbox from inside an editor. It is
-a distribution play rather than an architectural one, and ACP's remote
-(HTTP/WebSocket) transport is documented as work in progress. Revisit when
-that transport is stable; do not let it influence the gates above.
+Fountain as an ACP **agent** — `cli/` speaking ACP so that an editor could
+drive a Fountain conversation running in a remote sandbox. That is
+[0015](0015-fountain-as-an-acp-agent.md), and it is deliberately a separate
+decision: it is a distribution question rather than an architectural one, and
+it must not influence the gates above.
+
+The sequencing runs the other way, though. 0015 is *gated on this ADR*,
+because the event stream it would build on forwards raw runtime stdout — an
+ACP agent on today's API would have to reimplement the four dialect parsers in
+Go. Once gate 2 here lands, Fountain is already holding ACP blocks and the
+editor-facing side forwards rather than translates. Fountain becomes an ACP
+proxy, and the dialects stop at the server boundary, which is the only place
+that knows which runtime produced them.
 
 ## Consequences
 
@@ -181,6 +189,7 @@ session ids are worth that, and gate 3 is where the bet is settled.
   migration, a process-lifetime change and a reaper change in one PR, across
   four runtimes, with the LiveView moving underneath it.
 - **Fountain as an ACP agent first.** More strategically interesting and
-  answers a real distribution question, but the remote transport is WIP and it
-  does nothing for the four parsers or the permission gap. Deferred above,
-  deliberately.
+  answers a real distribution question, but it does nothing for the four
+  parsers or the permission gap — and building it first would mean a second
+  copy of those parsers in Go. Split out as
+  [0015](0015-fountain-as-an-acp-agent.md), sequenced after this.


### PR DESCRIPTION
Proposes adopting [ACP](https://agentclientprotocol.com) as Fountain's runtime
I/O layer. **Status: Proposed — nothing described in the ADR is built.** This
PR adds one markdown file and no code.

## Why

Fountain pays for each supported CLI twice:

- **At spawn** — `Fountain.Runtimes` is a six-callback behaviour that exists
  because four CLIs disagree about argv, credentials, resume, config files and
  skills paths.
- **At render** — `show.ex:1340-1530` carries 24 clauses of `event_blocks/2`:
  four hand-written parsers for four proprietary line-delimited JSON dialects,
  living in a LiveView. A fifth runtime means a fifth parser, in the render
  path, against an undocumented format its vendor can change in a point
  release.

Those parsers reduce to a vocabulary ACP already specifies — including the
tool-call/result threading that `pair_tool_results/1` (`show.ex:1293`)
reconstructs by hand because three of the four dialects emit them as unrelated
top-level events.

Two things the current design cannot express at any price:

- **Every runtime runs with its safety rail off, and it isn't a choice.**
  `claude.ex:39`, `gemini.ex:50`, `codex.ex:51`, `open_code.ex:46` — four
  different bypass flags. A headless CLI has no channel back to a human, so
  the sprite sandbox isn't defence *in depth*, it's the only defence there is.
  ACP's `session/request_permission` is that channel.
- **Two runtimes resume by guessing.** `gemini.ex:14-17` and `codex.ex:24-26`
  both reattach to "the most recent conversation in the workspace" — correct
  only while one conversation ever runs per workspace, an invariant we hold by
  accident and no test asserts.

## What it proposes

ACP becomes the runtime **I/O** layer; `Fountain.Runtimes` stays the
**provisioning** layer. That split is the load-bearing part: `default_env/2`,
`write_config/2`, `prepare_sprite/3`, `skills_root/0` and `skills_sh_agent/0`
are outside ACP's remit and survive unchanged as the *end state*, not as a
transition. Only `build_command/5` and the four parsers are in scope.

Four gates, each stoppable:

1. **Survey, no code** — confirm per runtime whether support is native or via
   a Zed adapter package, and the version floor. Claude and Codex are
   documented as adapter-based; Gemini and OpenCode are listed as supporting
   ACP without the mechanism being clearly separated. Resolve before picking
   the spike runtime.
2. **One runtime behind a per-agent flag** — a JSON-RPC peer over the stdio
   pipe we already own, emitting *the same block maps the LiveView already
   renders*, so both paths are A/B-able on one screen and the UI doesn't move.
3. **Permissions** — the gate that justifies the project. If it's blocked, the
   honest outcome is to stop at one converted runtime and record that here.
4. **Remaining runtimes** — a parser is deleted when its runtime has served
   real conversations, not when the code compiles.

Explicitly out of scope: Fountain as an ACP *agent* (editor-drives-sandbox).
Interesting, but the remote transport is WIP and it does nothing for the
parsers or the permission gap.

## Called out as risk, not glossed

- **The reaper conflict is mandatory scope.** ACP keeps a connection alive
  between prompts; `SandboxReaper` and the rehydrator both assume nothing is
  attached between turns. A runtime whose adapter lacks `session/load` is a
  reason to reject it for conversion, not to paper over.
- **`fs/*` and `terminal/*` are client-implemented, against the sprite's
  filesystem.** Leakiest part of the abstraction, and the most likely source
  of a security finding — a path arriving over that channel is untrusted input
  from a sandbox we don't fully control.
- **New supply-chain surface** — vendored Node adapters in the sprite image,
  versioned independently of the CLIs they wrap. `hex.audit` doesn't see them.
- **What we give up** — a small, dumb, legible spawn path. Argv is trivially
  testable and fails loudly; a live protocol session has states, and therefore
  state bugs.

Numbered 0014 because 0012 is claimed by open PR #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
