### PR TITLE
feat: speak ACP to Claude behind a per-agent flag (0014 gate 2)

### DIFF
--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -11,6 +11,9 @@ defmodule Fountain.Agents.Agent do
 
   @runtimes ~w(claude codex gemini opencode)
 
+  @typedoc "A persisted agent."
+  @type t :: %__MODULE__{}
+
   schema "agents" do
     field :name, :string
     field :description, :string, default: ""

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -260,6 +260,12 @@ defmodule Fountain.Conversations.ConversationServer do
       # Stream tracer for parsing Claude's stream-json stdout into OTel
       # child spans and events. nil for non-Claude runtimes.
       stream_tracer: nil,
+      # The ACP peer driving the in-flight turn, when the agent has opted in
+      # (0014 gate 2). nil on the legacy path, which is the default. Monitored
+      # rather than linked: a protocol bug must fail a turn, not take down a
+      # server that is holding a sprite handle and a tenant's secrets.
+      acp_peer: nil,
+      acp_peer_mon: nil,
       # Bytes of replayed output to drop on reattach, keyed by stream.
       # Empty map outside a reattach window. See attempt_session_attach.
       replay_skip: %{},
@@ -982,8 +988,21 @@ defmodule Fountain.Conversations.ConversationServer do
   defp prepare_runtime_sprite(sprite, runtime_module, agent, sprite_env) do
     Code.ensure_loaded(runtime_module)
 
-    if function_exported?(runtime_module, :prepare_sprite, 3) do
-      runtime_module.prepare_sprite(sprite, agent, sprite_env)
+    with :ok <- prepare_acp_adapter(sprite, agent, sprite_env) do
+      if function_exported?(runtime_module, :prepare_sprite, 3) do
+        runtime_module.prepare_sprite(sprite, agent, sprite_env)
+      else
+        :ok
+      end
+    end
+  end
+
+  # The adapter is an npm install, so it has to happen here rather than at
+  # spawn: by the time a turn runs, the network policy has been applied and the
+  # install would fail in a way that reads as a protocol bug.
+  defp prepare_acp_adapter(sprite, agent, sprite_env) do
+    if Fountain.Runtimes.ACP.enabled?(agent) do
+      Fountain.Runtimes.ACP.install(sprite, sprite_env)
     else
       :ok
     end
@@ -1012,6 +1031,13 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   def handle_call(:interrupt, _from, state) do
+    # Tell the agent before killing its process. `session/cancel` is a
+    # notification with no reply, so this costs one write and does not delay the
+    # kill below — but it is the difference between an agent that stops its
+    # tool calls and one that is shot mid-write. This is the other reason stdin
+    # stays open on the ACP path.
+    if state.acp_peer, do: Fountain.Runtimes.ACP.Peer.cancel(state.acp_peer)
+
     cmd_pid = state.current_command.pid
 
     if Process.alive?(cmd_pid) do
@@ -1036,6 +1062,11 @@ defmodule Fountain.Conversations.ConversationServer do
     # Finalize stream tracer: close any tool spans still open (abandoned calls).
     Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
 
+    # An ACP turn can also end here — the adapter exits, is interrupted, or its
+    # socket drops before it ever answers `session/prompt`. The peer has nothing
+    # left to drive and must not outlive the turn.
+    stop_acp_peer(state)
+
     end_turn_span(state.current_turn_span, :error, %{"outcome" => "interrupted"})
 
     emit_turn_completed(state, "interrupted")
@@ -1051,7 +1082,9 @@ defmodule Fountain.Conversations.ConversationServer do
          current_turn: nil,
          current_turn_span: nil,
          turn_metrics: nil,
-         stream_tracer: nil
+         stream_tracer: nil,
+         acp_peer: nil,
+         acp_peer_mon: nil
      }}
   end
 
@@ -1114,7 +1147,20 @@ defmodule Fountain.Conversations.ConversationServer do
     {:noreply, state}
   end
 
+  # ACP path: stdout is protocol, not transcript. The peer frames it, decides
+  # what is worth keeping and reports that back as `{:acp, ref, _}` — a
+  # JSON-RPC response to `initialize` is not something a user should find in
+  # their conversation, and a `session/load` replay is history we already hold.
   @impl true
+  def handle_info(
+        {:stdout, %{ref: ref}, data},
+        %{current_command_ref: ref, acp_peer: peer} = state
+      )
+      when is_pid(peer) do
+    Fountain.Runtimes.ACP.Peer.stdout(peer, data)
+    {:noreply, maybe_emit_first_output(state)}
+  end
+
   def handle_info({:stdout, %{ref: ref}, data}, %{current_command_ref: ref} = state) do
     state = maybe_emit_first_output(state)
     new_state = log_with_replay_skip(state, "stdout", data)
@@ -1153,6 +1199,80 @@ defmodule Fountain.Conversations.ConversationServer do
     {:noreply, log_with_replay_skip(state, "stderr", data)}
   end
 
+  # ── ACP peer reports (0014 gate 2) ────────────────────────────────────────
+
+  # Persisting goes through the server's own path so the ACP stream inherits
+  # the log budget, the redaction pass and the replay skip. A peer writing rows
+  # itself would bypass all three.
+  def handle_info({:acp, ref, {:lines, stream, data}}, %{current_command_ref: ref} = state) do
+    {:noreply, log_with_replay_skip(state, stream, data)}
+  end
+
+  # `session/new` chose an id. Persisted immediately, exactly as the legacy path
+  # persists one before spawning: it is what the next turn resumes by, and a
+  # server restart between here and the end of the turn must not lose it.
+  def handle_info({:acp, ref, {:session, id}}, %{current_command_ref: ref} = state) do
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: id})
+    {:noreply, %{state | runtime_session_id: id}}
+  end
+
+  # The number gate 2 exists to produce: what a turn pays for `initialize` plus
+  # resumption, which the legacy path does not pay at all. Emitted per turn so
+  # the cost of a disposable sandbox is measurable rather than argued about.
+  def handle_info({:acp, ref, {:handshake_ms, ms}}, %{current_command_ref: ref} = state) do
+    :telemetry.execute([:fountain, :acp, :handshake], %{duration_ms: ms}, %{
+      conversation_id: state.conversation_id
+    })
+
+    {:noreply, state}
+  end
+
+  # The turn's first terminator: `session/prompt` answered with a stop reason.
+  # Closing stdin here is what makes the adapter exit, and clearing the command
+  # ref is what makes that exit a no-op instead of a second ending.
+  def handle_info({:acp, ref, {:done, stop_reason}}, %{current_command_ref: ref} = state) do
+    status = if stop_reason in ["refusal", "cancelled"], do: "failed", else: "completed"
+
+    {:noreply,
+     finish_acp_turn(state, status, %{"stop_reason" => stop_reason}, %{
+       stop_reason: stop_reason
+     })}
+  end
+
+  def handle_info({:acp, ref, {:failed, reason}}, %{current_command_ref: ref} = state) do
+    Logger.error("conv #{state.conversation_id}: acp peer failed: #{inspect(reason)}")
+
+    {:noreply,
+     finish_acp_turn(state, "failed", %{"error" => inspect(reason)}, %{
+       reason: "acp: #{inspect(reason)}"
+     })}
+  end
+
+  # A report from a superseded turn's peer. The turn it belonged to is already
+  # over; acting on it would end the *current* one.
+  def handle_info({:acp, _stale_ref, _payload}, state), do: {:noreply, state}
+
+  # The peer died without reporting. Whatever it was, the turn has no driver
+  # any more, and leaving `current_command` set is the #413 shape: every prompt
+  # answered `:busy`, idle reclaim suppressed, sprite billing to the ceiling.
+  def handle_info(
+        {:DOWN, mon, :process, _pid, reason},
+        %{acp_peer_mon: mon, current_turn: turn} = state
+      )
+      when not is_nil(turn) do
+    Logger.error("conv #{state.conversation_id}: acp peer down: #{inspect(reason)}")
+
+    {:noreply,
+     finish_acp_turn(state, "failed", %{"error" => "peer_down"}, %{
+       reason: "acp peer down: #{inspect(reason)}"
+     })}
+  end
+
+  def handle_info({:DOWN, mon, :process, _pid, _reason}, %{acp_peer_mon: mon} = state) do
+    {:noreply, %{state | acp_peer: nil, acp_peer_mon: nil}}
+  end
+
   def handle_info({:exit, %{ref: ref}, code}, %{current_command_ref: ref} = state) do
     turn = state.current_turn
 
@@ -1171,6 +1291,11 @@ defmodule Fountain.Conversations.ConversationServer do
 
     # Finalize stream tracer: close any tool spans still open (abandoned calls).
     Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
+
+    # An ACP turn can also end here — the adapter exits, is interrupted, or its
+    # socket drops before it ever answers `session/prompt`. The peer has nothing
+    # left to drive and must not outlive the turn.
+    stop_acp_peer(state)
 
     # Close the OTel turn span we opened in kick_turn.
     end_turn_span(
@@ -1192,7 +1317,9 @@ defmodule Fountain.Conversations.ConversationServer do
          current_turn: nil,
          current_turn_span: nil,
          turn_metrics: nil,
-         stream_tracer: nil
+         stream_tracer: nil,
+         acp_peer: nil,
+         acp_peer_mon: nil
      }}
   end
 
@@ -1221,6 +1348,11 @@ defmodule Fountain.Conversations.ConversationServer do
     })
 
     Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
+
+    # An ACP turn can also end here — the adapter exits, is interrupted, or its
+    # socket drops before it ever answers `session/prompt`. The peer has nothing
+    # left to drive and must not outlive the turn.
+    stop_acp_peer(state)
     end_turn_span(state.current_turn_span, :error, %{"error" => inspect(reason)})
 
     emit_turn_completed(state, turn.status)
@@ -1236,7 +1368,9 @@ defmodule Fountain.Conversations.ConversationServer do
          current_turn: nil,
          current_turn_span: nil,
          turn_metrics: nil,
-         stream_tracer: nil
+         stream_tracer: nil,
+         acp_peer: nil,
+         acp_peer_mon: nil
      }}
   end
 
@@ -1606,10 +1740,22 @@ defmodule Fountain.Conversations.ConversationServer do
           existing
       end
 
+    # 0014 gate 2: when the agent has opted in and its runtime is one gate 1
+    # cleared, the turn spawns an ACP adapter instead of the CLI. Everything
+    # about the turn — the prompt, the session id, the mode — travels over the
+    # protocol rather than in argv, so `build_command/5` is not consulted at
+    # all on this path.
+    acp? = Fountain.Runtimes.ACP.enabled?(agent)
+
     {cmd, args, build_opts} =
-      state.runtime_module.build_command(agent, prompt, mode, runtime_session_id,
-        images: image_paths
-      )
+      if acp? do
+        {c, a} = Fountain.Runtimes.ACP.command()
+        {c, a, stdin?: true}
+      else
+        state.runtime_module.build_command(agent, prompt, mode, runtime_session_id,
+          images: image_paths
+        )
+      end
 
     # If a runtime embeds the prompt in argv (codex), it returns
     # `stdin?: false` and we skip the Sprites.write/close_stdin pipeline.
@@ -1684,14 +1830,16 @@ defmodule Fountain.Conversations.ConversationServer do
           # its caller when the runtime has already gone, and this process
           # being mid-turn is exactly what turned that into an orphaned turn
           # (#603). See `Fountain.SpriteStdin` for the whole chain.
+          # On the ACP path stdin stays **open**: it is the return path for
+          # `session/request_permission` answers and `session/cancel`, and the
+          # peer writes the prompt itself as `session/prompt`. Closing it here
+          # would hang up on the agent mid-handshake. It is closed when the
+          # turn ends — see `finish_turn/4`.
           stdin_result =
-            if use_stdin? do
-              case SpriteStdin.write(command, prompt <> prompt_suffix) do
-                :ok -> Sprites.close_stdin(command)
-                {:error, reason} -> {:error, reason}
-              end
-            else
-              :ok
+            cond do
+              acp? -> :ok
+              use_stdin? -> write_prompt_and_close(command, prompt <> prompt_suffix)
+              true -> :ok
             end
 
           case stdin_result do
@@ -1699,8 +1847,15 @@ defmodule Fountain.Conversations.ConversationServer do
               # Start a stream tracer for Claude (stream-json → OTel child spans).
               # Other runtimes produce unstructured output; tracer stays nil.
               stream_tracer =
-                if state.runtime_module == Fountain.Runtimes.Claude do
+                if not acp? and state.runtime_module == Fountain.Runtimes.Claude do
                   Fountain.Runtimes.Claude.StreamTracer.new(turn_span)
+                end
+
+              {peer, peer_mon} =
+                if acp? do
+                  start_acp_peer(command, prompt, mode, runtime_session_id, cwd)
+                else
+                  {nil, nil}
                 end
 
               %{
@@ -1715,7 +1870,9 @@ defmodule Fountain.Conversations.ConversationServer do
                     runtime: conv.runtime,
                     first_output?: false
                   },
-                  stream_tracer: stream_tracer
+                  stream_tracer: stream_tracer,
+                  acp_peer: peer,
+                  acp_peer_mon: peer_mon
               }
 
             {:error, reason} ->
@@ -1947,6 +2104,88 @@ defmodule Fountain.Conversations.ConversationServer do
   # every later chunk is dropped. Dropped rather than broadcast-only:
   # consumers key ordering off the DB-assigned event id, and an unbounded
   # broadcast stream would still let a hostile sandbox saturate PubSub.
+  # The legacy stdin dance, unchanged and lifted out so the ACP branch above
+  # reads as one condition rather than a nested `if`.
+  defp write_prompt_and_close(command, payload) do
+    case SpriteStdin.write(command, payload) do
+      :ok -> Sprites.close_stdin(command)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp start_acp_peer(command, prompt, mode, runtime_session_id, cwd) do
+    {:ok, peer} =
+      Fountain.Runtimes.ACP.Peer.start(
+        owner: self(),
+        command: command,
+        ref: command.ref,
+        prompt: prompt,
+        mode: mode,
+        session_id: runtime_session_id,
+        cwd: cwd || "/home/sprite"
+      )
+
+    {peer, Process.monitor(peer)}
+  end
+
+  # Terminal path for an ACP turn. The order matters: stdin closes first so the
+  # adapter starts exiting while we do the bookkeeping, and `current_command_ref`
+  # is cleared at the end so the `{:exit, …}` that follows finds no match and
+  # falls through to the catch-all. A turn ends on the prompt response *or* the
+  # process exit, whichever arrives first, and never waits for both.
+  defp finish_acp_turn(state, status, span_attrs, stage_meta) do
+    if state.current_command, do: Sprites.close_stdin(state.current_command)
+    stop_acp_peer(state)
+
+    {:ok, turn} =
+      Conversations._unsafe_update_turn(state.current_turn, %{
+        status: status,
+        ended_at: now()
+      })
+
+    publish_stage(
+      state.conversation_id,
+      "turn",
+      if(status == "completed", do: "done", else: "failed"),
+      Map.merge(%{turn_id: turn.id, turn_number: turn.turn_number}, stage_meta)
+    )
+
+    end_turn_span(
+      state.current_turn_span,
+      if(status == "completed", do: :ok, else: :error),
+      span_attrs
+    )
+
+    emit_turn_completed(state, turn.status)
+
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+
+    %{
+      touch_activity(state)
+      | current_command: nil,
+        current_command_ref: nil,
+        current_turn: nil,
+        current_turn_span: nil,
+        turn_metrics: nil,
+        stream_tracer: nil,
+        acp_peer: nil,
+        acp_peer_mon: nil
+    }
+  end
+
+  # Demonitor before stopping so the peer's own exit does not arrive as a
+  # `:DOWN` that fails the turn we just finished.
+  defp stop_acp_peer(%{acp_peer: nil}), do: :ok
+
+  defp stop_acp_peer(%{acp_peer: peer, acp_peer_mon: mon}) do
+    if mon, do: Process.demonitor(mon, [:flush])
+    if Process.alive?(peer), do: GenServer.stop(peer, :normal, 1_000)
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
   defp log_output(state, stream, data) do
     state = ensure_output_bytes(state)
     budget = output_byte_budget()

--- a/apps/fountain/lib/fountain/conversations/log_event.ex
+++ b/apps/fountain/lib/fountain/conversations/log_event.ex
@@ -7,7 +7,13 @@ defmodule Fountain.Conversations.LogEvent do
   @foreign_key_type :binary_id
 
   @kinds ~w(output stage)
-  @streams ~w(stdout stderr)
+  # `acp` rows hold Agent Client Protocol `session/update` notifications, one
+  # per line, exactly as `stdout` rows hold raw runtime output — what is on disk
+  # is what the agent actually said. The render path tells them apart by stream
+  # rather than by the conversation's runtime, so a conversation whose agent had
+  # the flag flipped mid-way renders its earlier turns through the legacy parser
+  # and its later ones through ACP. See decisions/0014.
+  @streams ~w(stdout stderr acp)
   @states ~w(started done failed interrupted)
 
   schema "log_events" do

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -1,0 +1,139 @@
+defmodule Fountain.Runtimes.ACP do
+  @moduledoc """
+  Whether a turn speaks the Agent Client Protocol, and what to spawn if it does.
+
+  Gate 2 of [0014](decisions/0014-agent-client-protocol.md). This module is the
+  *provisioning* side of the ACP path — which adapter, which version, how it
+  gets into the sprite — and it deliberately holds no protocol state. The
+  session lives in `Fountain.Runtimes.ACP.Peer`, for one turn, and dies with it.
+
+  ## Off by default, per agent
+
+  The flag is `agent.metadata["acp"] == true`. Metadata rather than a column
+  because gate 2 is an experiment with an explicit exit — if gates 3 and 4 do
+  not hold, this is deleted, and a migration would outlive the thing it was
+  added for. A conversation started under the flag records nothing about it:
+  the flag is read per turn, so flipping it mid-conversation switches the next
+  turn and leaves the earlier ones rendering through the legacy path, which is
+  exactly the A/B the gate asks for.
+
+  ## One runtime
+
+  Claude only, and that is gate 1's answer rather than a convenience. Gemini
+  advertises `loadSession` and no `sessionCapabilities.resume`, and its
+  `session/load` replays the entire conversation before responding — under one
+  connection per turn that is the whole history re-streamed on every turn after
+  the first. Claude advertises both, and its `session/resume` does not replay.
+  Codex and OpenCode also advertise both and are gate 4's business.
+
+  ## The adapter is pinned, and that is load-bearing
+
+  Nothing about the runtime CLIs is version-pinned today: claude, codex and
+  gemini arrive with the sprite base image and OpenCode is an unpinned
+  `bun install -g`. That is survivable for a CLI whose argv changes slowly. It
+  is not survivable for an adapter whose `initialize` response decides whether
+  the feature works at all — an unpinned adapter can silently stop advertising
+  `sessionCapabilities.resume` and downgrade every conversation to a full
+  history replay per turn, with no error anywhere.
+
+  So the version is pinned here, the install is idempotent, and the pin moves
+  in a PR that says why.
+  """
+
+  alias Fountain.Agents.Agent
+
+  # Verified at gate 1 (2026-08-09): advertises `loadSession: true` and
+  # `sessionCapabilities.resume`, and its `resumeSession` reattaches without
+  # replaying while `loadSession` calls `replaySessionHistory`.
+  @adapter_package "@agentclientprotocol/claude-agent-acp"
+  @adapter_version "0.66.0"
+  @adapter_bin "claude-agent-acp"
+
+  @doc "The npm package and version this build is pinned to."
+  @spec adapter_spec() :: String.t()
+  def adapter_spec, do: "#{@adapter_package}@#{@adapter_version}"
+
+  @doc "The executable name the pinned package installs."
+  @spec adapter_bin() :: String.t()
+  def adapter_bin, do: @adapter_bin
+
+  @doc """
+  Whether this turn should speak ACP.
+
+  Both halves have to hold: the agent opted in, and its runtime is one gate 1
+  cleared. A flag set on a Gemini agent is a no-op rather than an error — the
+  legacy path is not a failure mode, it is the default.
+  """
+  @spec enabled?(Agent.t() | nil) :: boolean()
+  def enabled?(%Agent{runtime: "claude", metadata: metadata}) when is_map(metadata) do
+    Map.get(metadata, "acp") == true
+  end
+
+  def enabled?(_), do: false
+
+  @doc """
+  Argv for the adapter.
+
+  No prompt, no session id, no mode: unlike `build_command/5` this says nothing
+  about the turn, because under ACP the turn is carried by `session/prompt`
+  over the connection rather than by the process's arguments. That difference
+  is the entire architectural change, and it is why this does not implement the
+  `Fountain.Runtimes` behaviour.
+  """
+  @spec command() :: {String.t(), [String.t()]}
+  def command, do: {@adapter_bin, []}
+
+  @doc """
+  Install the pinned adapter into a sprite.
+
+  Runs at provision time, with the rest of the package installs, because it
+  needs unrestricted network — by the time a turn spawns, the network policy
+  has been applied and an install would fail in a way that looks like a
+  protocol bug.
+
+  Idempotent on the exact pinned version: an image that already carries a
+  different version is corrected rather than accepted, since "some adapter is
+  installed" is precisely the state the pin exists to prevent.
+  """
+  @spec install(sprite :: any(), [{String.t(), String.t()}]) :: :ok | {:error, term()}
+  def install(sprite, sprite_env) do
+    script = """
+    set -e
+    want=#{@adapter_version}
+    have=$(#{@adapter_bin} --version 2>/dev/null | tr -d '[:space:]' || true)
+    if [ "$have" != "$want" ]; then
+      npm install -g --no-progress --silent #{adapter_spec()}
+    fi
+    """
+
+    case Sprites.cmd(sprite, "bash", ["-lc", script], env: sprite_env, timeout: 180_000) do
+      {_out, 0} ->
+        :ok
+
+      {out, code} ->
+        {:error, {:acp_adapter_install_exit, code, String.slice(to_string(out), 0, 500)}}
+    end
+  end
+
+  @doc """
+  The `initialize` params we send.
+
+  **We declare no client filesystem or terminal capabilities.** `fs/*` and
+  `terminal/*` are client-implemented, and ours would have to service them
+  against the sprite rather than the Fountain server — 0014 names that as the
+  likeliest source of a security finding and 0016 makes it its own gate. Gate 2
+  declares nothing, so a well-behaved adapter never asks; the peer still
+  answers anything that arrives, because an unanswered request blocks the agent
+  and a blocked agent bills.
+  """
+  @spec initialize_params() :: map()
+  def initialize_params do
+    %{
+      protocolVersion: 1,
+      clientCapabilities: %{
+        fs: %{readTextFile: false, writeTextFile: false},
+        terminal: false
+      }
+    }
+  end
+end

--- a/apps/fountain/lib/fountain/runtimes/acp/blocks.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/blocks.ex
@@ -1,0 +1,192 @@
+defmodule Fountain.Runtimes.ACP.Blocks do
+  @moduledoc """
+  Translate ACP messages into the block maps the conversation view renders.
+
+  This is the module that replaces a hand-written dialect parser, and the
+  reason it lives here rather than in `FountainWeb.ConversationsLive.Show` is
+  the whole point of [0014](decisions/0014-agent-client-protocol.md): the four
+  proprietary formats are parsed in the render path, where a vendor's point
+  release becomes a rendering bug. The ACP path parses on the server, in a
+  module with its own tests, and the LiveView delegates one clause to it.
+
+  The block shapes are not ours to choose — they are what `show.ex` already
+  renders, so that the ACP path and the legacy path can be compared on one
+  screen without the UI moving. Emitting anything else would defeat gate 2's
+  only real experiment.
+
+  | ACP `session/update` | block |
+  |---|---|
+  | `agent_message_chunk` | `%{kind: :text}` |
+  | `agent_thought_chunk` | `%{kind: :thinking}` |
+  | `tool_call` | `%{kind: :tool_use}` |
+  | `tool_call_update` | `%{kind: :tool_result}` |
+  | `user_message_chunk` | dropped — we already render the prompt |
+  | `plan`, `available_commands_update` | dropped — no equivalent yet |
+
+  ## Chunks are not messages
+
+  `agent_message_chunk` is a *chunk*: a turn produces many, and each carries a
+  fragment of text. We emit one `:text` block per chunk and let the existing
+  renderer concatenate adjacent ones, which is what it already does for the
+  legacy stream. Buffering them here would mean holding a turn's whole
+  assistant message in the peer's memory to produce output that renders
+  identically.
+
+  ## Tool calls thread on one id
+
+  `pair_tool_results/1` in `show.ex` exists because three of the four dialects
+  emit a tool call and its result as unrelated top-level events. ACP threads
+  them on `toolCallId` by construction, so the pairing pass gets the ids it
+  wants for free — we map `tool_call` → `:tool_use` with `:id` and
+  `tool_call_update` → `:tool_result` with `:tool_id`, and the existing pass
+  collapses them.
+
+  A `tool_call_update` only becomes a `:tool_result` once it reports a terminal
+  status. In-flight updates (`pending`, `in_progress`) carry progress, not an
+  outcome, and turning each one into a result block would render a completed
+  tool card several times per call.
+  """
+
+  alias Fountain.Runtimes.ACP.Protocol
+
+  @terminal_statuses ~w(completed failed cancelled)
+
+  @doc """
+  Translate one stored ndjson line into blocks.
+
+  This is the entry point the render path uses: `log_events` rows hold the raw
+  protocol, exactly as the legacy path holds raw stdout, so what is on disk is
+  what the adapter actually said.
+  """
+  @spec from_line(String.t()) :: [map()]
+  def from_line(line) do
+    case Protocol.classify_line(line) do
+      {:notification, "session/update", params} -> from_update(params)
+      {:invalid, raw} -> [%{kind: :raw, body: raw, summary: "raw"}]
+      _ -> []
+    end
+  end
+
+  @doc """
+  Translate the params of one `session/update` notification.
+
+  The update variant lives under `sessionUpdate`; everything else in the map is
+  variant-specific.
+  """
+  @spec from_update(map()) :: [map()]
+  def from_update(%{"update" => update}) when is_map(update), do: update_blocks(update)
+  def from_update(update) when is_map(update), do: update_blocks(update)
+  def from_update(_), do: []
+
+  defp update_blocks(%{"sessionUpdate" => "agent_message_chunk", "content" => content}) do
+    text_block(:text, content)
+  end
+
+  defp update_blocks(%{"sessionUpdate" => "agent_thought_chunk", "content" => content}) do
+    text_block(:thinking, content)
+  end
+
+  defp update_blocks(%{"sessionUpdate" => "tool_call"} = update) do
+    input = Map.get(update, "rawInput")
+
+    [
+      %{
+        kind: :tool_use,
+        id: update["toolCallId"],
+        name: tool_name(update),
+        summary: tool_summary(update),
+        body: pretty(input)
+      }
+    ]
+  end
+
+  defp update_blocks(%{"sessionUpdate" => "tool_call_update", "status" => status} = update)
+       when status in @terminal_statuses do
+    [
+      %{
+        kind: :tool_result,
+        tool_id: update["toolCallId"],
+        body: tool_output(update),
+        error?: status != "completed"
+      }
+    ]
+  end
+
+  # Non-terminal tool_call_update, user echo, plan, command list, and any
+  # variant a future adapter version invents. Dropping an unknown variant is
+  # deliberate: the legacy parsers render unrecognised lines as a `:raw` block,
+  # which for a well-specified protocol would turn every new notification kind
+  # into visible noise in every conversation.
+  defp update_blocks(_), do: []
+
+  defp text_block(kind, content) do
+    case content_text(content) do
+      "" -> []
+      text -> [%{kind: kind, body: text}]
+    end
+  end
+
+  # ACP content blocks are the same shape used by MCP: a tagged map, or a list
+  # of them. Only `text` has a rendering here; an image arriving in an assistant
+  # chunk is named rather than dropped silently, because a blank block in the
+  # transcript reads as a bug in Fountain.
+  defp content_text(content) when is_list(content) do
+    content |> Enum.map(&content_text/1) |> Enum.reject(&(&1 == "")) |> Enum.join("")
+  end
+
+  defp content_text(%{"type" => "text", "text" => text}) when is_binary(text), do: text
+  defp content_text(%{"type" => "image"}), do: "[image]"
+  defp content_text(%{"type" => "audio"}), do: "[audio]"
+  defp content_text(%{"type" => "resource_link", "uri" => uri}) when is_binary(uri), do: uri
+  defp content_text(text) when is_binary(text), do: text
+  defp content_text(_), do: ""
+
+  defp tool_name(update) do
+    # `kind` is ACP's coarse category (read/edit/execute/…); `title` is the
+    # human string the agent chose. Prefer the title, fall back to the kind, and
+    # never render an empty tool card.
+    case {update["title"], update["kind"]} do
+      {title, _} when is_binary(title) and title != "" -> title
+      {_, kind} when is_binary(kind) and kind != "" -> kind
+      _ -> "tool"
+    end
+  end
+
+  defp tool_summary(update) do
+    case update["locations"] do
+      [%{"path" => path} | _] when is_binary(path) -> path
+      _ -> input_preview(update["rawInput"])
+    end
+  end
+
+  defp input_preview(input) when is_map(input) and map_size(input) > 0 do
+    input
+    |> Enum.map_join(" ", fn {k, v} -> "#{k}=#{truncate(to_display(v), 40)}" end)
+    |> truncate(120)
+  end
+
+  defp input_preview(_), do: ""
+
+  defp tool_output(update) do
+    case update["content"] do
+      nil -> pretty(update["rawOutput"])
+      content -> Enum.map_join(content, "\n", &tool_content_text/1)
+    end
+  end
+
+  # A tool result's content is wrapped one level deeper than a message's:
+  # `%{"type" => "content", "content" => <content block>}`.
+  defp tool_content_text(%{"type" => "content", "content" => inner}), do: content_text(inner)
+  defp tool_content_text(%{"type" => "diff", "path" => path}), do: "diff: #{path}"
+  defp tool_content_text(other), do: content_text(other)
+
+  defp to_display(v) when is_binary(v), do: v
+  defp to_display(v), do: inspect(v)
+
+  defp truncate(s, max) when byte_size(s) > max, do: binary_part(s, 0, max) <> "…"
+  defp truncate(s, _max), do: s
+
+  defp pretty(nil), do: ""
+  defp pretty(term) when is_binary(term), do: term
+  defp pretty(term), do: Jason.encode!(term, pretty: true)
+end

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -1,0 +1,374 @@
+defmodule Fountain.Runtimes.ACP.Peer do
+  @moduledoc """
+  One ACP connection, for exactly one turn.
+
+  Gate 2 of [0014](decisions/0014-agent-client-protocol.md). The peer drives
+  `initialize` → (`session/new` | `session/resume` | `session/load`) →
+  `session/prompt` over the sprite's stdio, translates nothing itself, and
+  ends when the prompt is answered.
+
+  ## Why this is not in `ConversationServer`
+
+  0014 says it outright: "This is a new GenServer sitting beside a
+  `ConversationServer` that is already 2,088 lines. If the peer lands inside
+  that module, this ADR has been implemented wrongly." The server owns the
+  sprite, the turn row and the log budget; the peer owns a protocol
+  conversation with states and a correlation table. They fail differently and
+  should not share a mailbox.
+
+  ## Lifetime is the turn, and that is the economics
+
+  0014's *Session lifetime* section is the load-bearing constraint: the ACP
+  connection is scoped to the turn, never to the session, so nothing is
+  attached between turns and `Lifecycle`/`SandboxReaper` keep reclaiming idle
+  sprites on exactly today's terms. The durable identity is
+  `conversation.runtime_session_id`, which we hand to `session/resume`.
+
+  The peer is deliberately unlinked from its owner in both directions and
+  monitored instead. A protocol bug here must fail a *turn*; linking would make
+  it take down a `ConversationServer` that is also holding a sprite handle and
+  a tenant's secrets.
+
+  ## Resumption, and why `session/load` is the unhappy path
+
+  `session/resume` restores context and returns. `session/load` "**MUST** replay
+  the entire conversation to the Client in the form of `session/update`
+  notifications" before responding — and we already hold that history as
+  `log_events` rows, so persisting the replay would duplicate the whole
+  transcript into the database and onto the SSE stream on every turn after the
+  first. While a `session/load` is outstanding the peer runs in replay-discard
+  mode and drops updates on the floor.
+
+  We prefer `resume` whenever the adapter advertises it, which the pinned Claude
+  adapter does. `load` is kept because the capability is per-adapter and per
+  version, and discovering at runtime that this build cannot resume is better
+  handled by taking the expensive path than by failing the turn.
+
+  ## What it sends back
+
+  Everything goes to the owner as `{:acp, ref, payload}` so the server can keep
+  its existing invariants — the log budget, the redaction pass and the replay
+  skip all live on the server's persistence path, and a peer writing rows
+  directly would bypass all three.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Fountain.Runtimes.ACP
+  alias Fountain.Runtimes.ACP.Protocol
+  alias Fountain.SpriteStdin
+
+  @typedoc "What the peer reports upward. `ref` is the sprite command's ref."
+  @type payload ::
+          {:lines, stream :: String.t(), data :: String.t()}
+          | {:session, String.t()}
+          | {:handshake_ms, non_neg_integer()}
+          | {:done, stop_reason :: String.t()}
+          | {:failed, term()}
+
+  defmodule State do
+    @moduledoc false
+    defstruct [
+      :owner,
+      :owner_mon,
+      :command,
+      :ref,
+      :prompt,
+      :mode,
+      :session_id,
+      :cwd,
+      :started_mono,
+      buffer: "",
+      next_id: 1,
+      pending: %{},
+      phase: :initializing,
+      replay_discard?: false,
+      capabilities: %{}
+    ]
+  end
+
+  # ── public api ────────────────────────────────────────────────────────────
+
+  @doc """
+  Start a peer for one turn.
+
+  Required opts: `:owner`, `:command`, `:ref`, `:prompt`, `:mode`,
+  `:session_id`, `:cwd`.
+  """
+  def start(opts), do: GenServer.start(__MODULE__, opts)
+
+  @doc "Feed a stdout chunk from the sprite. Chunks respect no message boundary."
+  def stdout(pid, data), do: GenServer.cast(pid, {:stdout, data})
+
+  @doc """
+  Ask the agent to stop the current turn.
+
+  `session/cancel` is a notification with no reply; the agent answers the
+  original `session/prompt` with a `cancelled` stop reason, which is what
+  actually ends the turn.
+  """
+  def cancel(pid), do: GenServer.cast(pid, :cancel)
+
+  # ── callbacks ─────────────────────────────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    owner = Keyword.fetch!(opts, :owner)
+
+    state = %State{
+      owner: owner,
+      owner_mon: Process.monitor(owner),
+      command: Keyword.fetch!(opts, :command),
+      ref: Keyword.fetch!(opts, :ref),
+      prompt: Keyword.fetch!(opts, :prompt),
+      mode: Keyword.fetch!(opts, :mode),
+      session_id: Keyword.fetch!(opts, :session_id),
+      cwd: Keyword.get(opts, :cwd, "/home/sprite"),
+      started_mono: System.monotonic_time(:millisecond)
+    }
+
+    {:ok, state, {:continue, :initialize}}
+  end
+
+  @impl true
+  def handle_continue(:initialize, state) do
+    send_request(state, :initialize, "initialize", ACP.initialize_params())
+    |> noreply()
+  end
+
+  @impl true
+  def handle_cast({:stdout, data}, state) do
+    {messages, buffer} = Protocol.feed(state.buffer, data)
+
+    messages
+    |> Enum.reduce(%{state | buffer: buffer}, &handle_message/2)
+    |> noreply()
+  end
+
+  def handle_cast(:cancel, %State{session_id: id} = state) when is_binary(id) do
+    state
+    |> write(Protocol.notification("session/cancel", %{sessionId: id}))
+    |> noreply()
+  end
+
+  def handle_cast(:cancel, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:DOWN, mon, :process, _pid, _reason}, %State{owner_mon: mon} = state) do
+    # The server is gone; there is nobody to report to and the sprite command
+    # is its property, not ours.
+    {:stop, :normal, state}
+  end
+
+  def handle_info(msg, state) do
+    Logger.debug("acp peer: unexpected message #{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  # ── message dispatch ──────────────────────────────────────────────────────
+
+  defp handle_message({:notification, "session/update", params}, state) do
+    if state.replay_discard? do
+      # Replay of history we already hold. Dropped, not persisted — see the
+      # moduledoc.
+      state
+    else
+      persist(state, "acp", Protocol.notification("session/update", params))
+    end
+  end
+
+  defp handle_message({:notification, _method, _params}, state), do: state
+
+  defp handle_message({:response, id, result}, state) do
+    case pop_pending(state, id) do
+      {nil, state} ->
+        Logger.warning("acp peer: response to unknown request #{inspect(id)}")
+        state
+
+      {tag, state} ->
+        handle_response(tag, result, state)
+    end
+  end
+
+  defp handle_message({:error_response, id, error}, state) do
+    {tag, state} = pop_pending(state, id)
+    fail(state, {:acp_error, tag, error})
+  end
+
+  # `session/request_permission` is the channel gate 3 exists to use. Gate 2
+  # answers it the way the legacy path already behaves — every runtime today
+  # runs with its rail removed (`--dangerously-skip-permissions` and friends),
+  # so auto-allowing is parity, not a new exposure. Answering *something* is not
+  # optional: the agent blocks on this request, and a blocked agent is a turn in
+  # flight, which disarms idle reclaim and bills the sprite to the ceiling.
+  defp handle_message({:request, id, "session/request_permission", params}, state) do
+    write(state, Protocol.response(id, %{outcome: permission_outcome(params)}))
+  end
+
+  # We declared no filesystem or terminal capabilities, so nothing should ask.
+  # If something does, it gets a JSON-RPC error rather than silence.
+  defp handle_message({:request, id, method, _params}, state) do
+    Logger.warning("acp peer: refusing unsupported client method #{method}")
+    write(state, Protocol.error(id, Protocol.method_not_found(), "#{method} is not supported"))
+  end
+
+  # Adapters and the Node runtime under them write warnings and stack traces to
+  # stdout. Those are output, not protocol, and the transcript is more useful
+  # with them in it.
+  defp handle_message({:invalid, line}, state), do: persist(state, "stdout", [line, "\n"])
+
+  # ── responses ─────────────────────────────────────────────────────────────
+
+  defp handle_response(:initialize, result, state) do
+    caps = Map.get(result, "agentCapabilities") || %{}
+    state = %{state | capabilities: caps}
+
+    report(state, {:handshake_ms, System.monotonic_time(:millisecond) - state.started_mono})
+
+    case state.mode do
+      :run -> start_new_session(state)
+      :continue -> resume_session(state)
+    end
+  end
+
+  defp handle_response(:new_session, result, state) do
+    case Map.get(result, "sessionId") do
+      id when is_binary(id) ->
+        report(state, {:session, id})
+        send_prompt(%{state | session_id: id})
+
+      _ ->
+        fail(state, {:acp_no_session_id, result})
+    end
+  end
+
+  defp handle_response(:resume_session, _result, state), do: send_prompt(state)
+
+  defp handle_response(:load_session, _result, state) do
+    # The replay is over; everything from here is this turn's.
+    send_prompt(%{state | replay_discard?: false})
+  end
+
+  defp handle_response(:prompt, result, state) do
+    stop = Map.get(result, "stopReason") || "end_turn"
+    report(state, {:done, stop})
+    %{state | phase: :done}
+  end
+
+  # ── session setup ─────────────────────────────────────────────────────────
+
+  defp start_new_session(state) do
+    params = %{cwd: state.cwd, mcpServers: []}
+    params = if state.session_id, do: Map.put(params, :sessionId, state.session_id), else: params
+
+    send_request(%{state | phase: :starting_session}, :new_session, "session/new", params)
+  end
+
+  defp resume_session(%State{session_id: nil} = state) do
+    # `mode == :continue` with no id is a contradiction the caller should not be
+    # able to produce; failing loudly beats silently starting a second session
+    # that renders as the same conversation.
+    fail(state, :acp_resume_without_session_id)
+  end
+
+  defp resume_session(state) do
+    params = %{sessionId: state.session_id, cwd: state.cwd, mcpServers: []}
+
+    cond do
+      supports?(state, ["sessionCapabilities", "resume"]) ->
+        send_request(
+          %{state | phase: :starting_session},
+          :resume_session,
+          "session/resume",
+          params
+        )
+
+      Map.get(state.capabilities, "loadSession") == true ->
+        # The expensive path: everything until the response is history we
+        # already have.
+        %{state | phase: :starting_session, replay_discard?: true}
+        |> send_request(:load_session, "session/load", params)
+
+      true ->
+        fail(state, :acp_agent_cannot_resume)
+    end
+  end
+
+  defp send_prompt(state) do
+    params = %{
+      sessionId: state.session_id,
+      prompt: [%{type: "text", text: state.prompt}]
+    }
+
+    send_request(%{state | phase: :prompting}, :prompt, "session/prompt", params)
+  end
+
+  # ── plumbing ──────────────────────────────────────────────────────────────
+
+  defp send_request(state, tag, method, params) do
+    id = state.next_id
+
+    %{state | next_id: id + 1, pending: Map.put(state.pending, id, tag)}
+    |> write(Protocol.request(id, method, params))
+  end
+
+  defp pop_pending(state, id) do
+    {tag, pending} = Map.pop(state.pending, id)
+    {tag, %{state | pending: pending}}
+  end
+
+  # Every write goes through `SpriteStdin` rather than `Sprites.write/2`,
+  # because the latter exits its caller when the runtime has already gone —
+  # #603, and being mid-turn is exactly the condition that made it an orphaned
+  # turn rather than an error.
+  defp write(%State{phase: :failed} = state, _iodata), do: state
+
+  defp write(state, iodata) do
+    case SpriteStdin.write(state.command, iodata) do
+      :ok -> state
+      {:error, reason} -> fail(state, {:acp_write_failed, reason})
+    end
+  end
+
+  defp persist(state, stream, iodata) do
+    report(state, {:lines, stream, IO.iodata_to_binary(iodata)})
+    state
+  end
+
+  defp fail(%State{phase: :failed} = state, _reason), do: state
+
+  defp fail(state, reason) do
+    report(state, {:failed, reason})
+    %{state | phase: :failed}
+  end
+
+  defp report(state, payload), do: send(state.owner, {:acp, state.ref, payload})
+
+  defp supports?(state, path) do
+    case get_in(state.capabilities, path) do
+      nil -> false
+      false -> false
+      _ -> true
+    end
+  end
+
+  # Prefer an option the agent itself marked as an allow. `optionId` is opaque
+  # and adapter-defined, so picking by `kind` is the only portable choice.
+  defp permission_outcome(params) do
+    options = Map.get(params, "options") || []
+
+    chosen =
+      Enum.find(options, &(&1["kind"] == "allow_always")) ||
+        Enum.find(options, &(&1["kind"] == "allow_once")) ||
+        List.first(options)
+
+    case chosen do
+      %{"optionId" => id} -> %{outcome: "selected", optionId: id}
+      _ -> %{outcome: "cancelled"}
+    end
+  end
+
+  defp noreply(state), do: {:noreply, state}
+end

--- a/apps/fountain/lib/fountain/runtimes/acp/protocol.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/protocol.ex
@@ -1,0 +1,120 @@
+defmodule Fountain.Runtimes.ACP.Protocol do
+  @moduledoc """
+  Framing and JSON-RPC 2.0 encoding for the Agent Client Protocol.
+
+  Pure functions only — no process, no I/O. The peer owns the socket; this
+  module owns the bytes, which is the part worth testing exhaustively and the
+  part that has nothing to do with sprites.
+
+  ACP is newline-delimited JSON over stdio. The sprite hands us stdout in
+  arbitrary chunks that respect no message boundary at all: one chunk can carry
+  three messages and half of a fourth, and the other half arrives later. So
+  framing has to carry a buffer across calls — `feed/2` returns the messages it
+  could complete plus whatever tail it could not, and the caller hands that tail
+  back on the next chunk.
+
+  ## Why the decode failure is a value and not a raise
+
+  A line that is not JSON is not an exception, it is an *event*: adapters print
+  warnings, npm prints deprecation notices, and a Node process writes its stack
+  trace to stdout when it dies. `feed/2` returns `{:invalid, line}` for those so
+  the peer can log them as ordinary output rather than crashing a turn on
+  somebody else's diagnostic.
+  """
+
+  @jsonrpc "2.0"
+
+  @typedoc "A framed message, already classified."
+  @type message ::
+          {:response, id :: term(), result :: map()}
+          | {:error_response, id :: term(), error :: map()}
+          | {:request, id :: term(), method :: String.t(), params :: map()}
+          | {:notification, method :: String.t(), params :: map()}
+          | {:invalid, line :: String.t()}
+
+  @doc """
+  Frame `data` against a carried `buffer`, returning complete messages and the
+  new buffer.
+
+  The tail after the last newline is *always* incomplete by definition — a
+  message is only whole once its newline has arrived — so it goes back into the
+  buffer even when it happens to be valid JSON.
+  """
+  @spec feed(binary(), binary()) :: {[message()], binary()}
+  def feed(buffer, data) when is_binary(buffer) and is_binary(data) do
+    parts = String.split(buffer <> data, "\n")
+    {complete, [rest]} = Enum.split(parts, length(parts) - 1)
+
+    messages =
+      complete
+      |> Enum.reject(&(String.trim(&1) == ""))
+      |> Enum.map(&classify_line/1)
+
+    {messages, rest}
+  end
+
+  @doc """
+  Classify one already-framed line.
+
+  Exposed for the render path, which reads lines back out of `log_events` and
+  has no buffer to carry.
+  """
+  @spec classify_line(String.t()) :: message()
+  def classify_line(line) do
+    case Jason.decode(line) do
+      {:ok, decoded} when is_map(decoded) -> classify(decoded)
+      _ -> {:invalid, line}
+    end
+  end
+
+  @doc "Classify a decoded JSON-RPC object."
+  @spec classify(map()) :: message()
+  def classify(%{"id" => id, "result" => result}), do: {:response, id, result}
+  def classify(%{"id" => id, "error" => error}), do: {:error_response, id, error}
+
+  def classify(%{"id" => id, "method" => method} = msg),
+    do: {:request, id, method, Map.get(msg, "params") || %{}}
+
+  def classify(%{"method" => method} = msg),
+    do: {:notification, method, Map.get(msg, "params") || %{}}
+
+  def classify(other), do: {:invalid, Jason.encode!(other)}
+
+  @doc "Encode an outbound request. Returns the line, newline included."
+  @spec request(term(), String.t(), map()) :: iodata()
+  def request(id, method, params) do
+    line(%{jsonrpc: @jsonrpc, id: id, method: method, params: params})
+  end
+
+  @doc "Encode an outbound notification (no id, no reply expected)."
+  @spec notification(String.t(), map()) :: iodata()
+  def notification(method, params) do
+    line(%{jsonrpc: @jsonrpc, method: method, params: params})
+  end
+
+  @doc "Encode a successful reply to an agent→client request."
+  @spec response(term(), map()) :: iodata()
+  def response(id, result) do
+    line(%{jsonrpc: @jsonrpc, id: id, result: result})
+  end
+
+  @doc """
+  Encode an error reply.
+
+  `-32601` (method not found) is the one gate 2 sends: we declare no client
+  filesystem or terminal capabilities, so an adapter calling `fs/*` or
+  `terminal/*` is asking for something we told it we do not have. Answering is
+  still mandatory — an unanswered request blocks the agent, and a blocked agent
+  is a sprite billing until the lifetime ceiling.
+  """
+  @spec error(term(), integer(), String.t()) :: iodata()
+  def error(id, code, message) do
+    line(%{jsonrpc: @jsonrpc, id: id, error: %{code: code, message: message}})
+  end
+
+  @doc "JSON-RPC's method-not-found code."
+  @spec method_not_found() :: integer()
+  def method_not_found, do: -32_601
+
+  defp line(map), do: [Jason.encode_to_iodata!(map), "\n"]
+end

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -1268,6 +1268,21 @@ defmodule FountainWeb.ConversationsLive.Show do
   # Splits an event's `data` (which may be a stream-json chunk with N
   # lines) into a flat list of structured blocks. Each block is a map
   # with at least `:kind`, plus kind-specific fields.
+  # ACP rows carry a specified protocol rather than a vendor's dialect, so the
+  # translation lives on the server in `Fountain.Runtimes.ACP.Blocks` — with its
+  # own tests, and outside the render path where a point release becomes a
+  # rendering bug. That relocation is the point of 0014; this clause is the
+  # seam, and it is deliberately the only ACP knowledge in this module.
+  #
+  # Keyed on the event's stream, not the conversation's runtime: the per-agent
+  # flag can flip between turns, and the turns before it flipped must keep
+  # rendering through the parser that produced them.
+  defp blocks_for(%{stream: "acp", data: data}, _runtime) when is_binary(data) do
+    data
+    |> String.split("\n", trim: true)
+    |> Enum.flat_map(&Fountain.Runtimes.ACP.Blocks.from_line/1)
+  end
+
   defp blocks_for(%{data: data}, runtime) when is_binary(data) do
     data
     |> String.split("\n", trim: true)

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -1,0 +1,280 @@
+defmodule Fountain.Conversations.ConversationServerACPTest do
+  @moduledoc """
+  The ACP path through a real `ConversationServer` (0014 gate 2).
+
+  These are the assertions that cannot be made against the peer alone: which
+  binary gets spawned, that stdin is *not* closed at spawn, that protocol bytes
+  never reach the transcript, and that a turn ends exactly once even though it
+  now has two possible terminators.
+  """
+
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Runtimes.ACP
+
+  defp acp_agent(user) do
+    insert_agent(user_id: user.id, runtime: "claude", metadata: %{"acp" => true})
+  end
+
+  # Starts a server whose turn speaks ACP, with the sprite side wired to this
+  # process: every byte written to stdin arrives as `{:wrote, line}`, and the
+  # command's ref is ours so tests can feed stdout back.
+  defp start_acp_turn(conv) do
+    stub_happy_sprite()
+    test = self()
+    ref = make_ref()
+
+    # The adapter install runs at provision time. It is `Sprites.cmd/4`
+    # returning `{output, exit_code}` — a different arity from the `cmd/3` the
+    # permissive harness stubs, so without this the real client is called.
+    Mimic.stub(Sprites, :cmd, fn _s, _cmd, _args, _opts -> {"", 0} end)
+
+    Mimic.stub(Sprites, :spawn, fn _s, cmd, args, opts ->
+      send(test, {:spawned, cmd, args, opts})
+      {:ok, %{ref: ref, pid: test}}
+    end)
+
+    Mimic.stub(Sprites, :close_stdin, fn _c ->
+      send(test, :stdin_closed)
+      :ok
+    end)
+
+    Mimic.stub(Sprites, :write, fn _c, data ->
+      send(test, {:wrote, IO.iodata_to_binary(data)})
+      :ok
+    end)
+
+    {pid, _mon, :alive} = start_server(conv, initial_prompt: "first")
+
+    # Unconditional teardown. A test that fails an assertion would otherwise
+    # skip its own `GenServer.stop`, leaving a server running into the next
+    # test — where its peer's next report does DB work against a sandbox
+    # connection that has already been checked in, and one real failure
+    # becomes four noisy ones.
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    {pid, ref}
+  end
+
+  defp next_write do
+    assert_receive {:wrote, line}, 1_000
+    Jason.decode!(line)
+  end
+
+  defp reply(pid, ref, id, result) do
+    line = Jason.encode!(%{"jsonrpc" => "2.0", "id" => id, "result" => result}) <> "\n"
+    send(pid, {:stdout, %{ref: ref}, line})
+    settle(pid)
+  end
+
+  # A message crosses three mailboxes: the server takes the stdout chunk and
+  # casts it to the peer, the peer acts and reports back, and the server acts on
+  # the report. Syncing only the server would assert against a state one hop
+  # behind, which is what made these tests pass alone and fail together.
+  defp settle(pid) do
+    peer = :sys.get_state(pid).acp_peer
+    if is_pid(peer) and Process.alive?(peer), do: :sys.get_state(peer)
+    _ = :sys.get_state(pid)
+    :ok
+  end
+
+  defp notify(pid, ref, update) do
+    line =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "method" => "session/update",
+        "params" => %{"sessionId" => "sess_1", "update" => update}
+      }) <> "\n"
+
+    send(pid, {:stdout, %{ref: ref}, line})
+    settle(pid)
+  end
+
+  @caps %{"loadSession" => true, "sessionCapabilities" => %{"resume" => %{}}}
+
+  # initialize → session/new → session/prompt, returning the prompt's id so a
+  # test can answer it.
+  defp drive_to_prompt(pid, ref) do
+    %{"id" => init_id, "method" => "initialize"} = next_write()
+    reply(pid, ref, init_id, %{"agentCapabilities" => @caps})
+
+    %{"id" => new_id, "method" => "session/new"} = next_write()
+    reply(pid, ref, new_id, %{"sessionId" => "sess_1"})
+
+    %{"id" => prompt_id, "method" => "session/prompt"} = next_write()
+    settle(pid)
+    prompt_id
+  end
+
+  describe "the flag" do
+    test "is off by default" do
+      user = insert_verified_user()
+      refute ACP.enabled?(insert_agent(user_id: user.id, runtime: "claude"))
+    end
+
+    test "only applies to a runtime gate 1 cleared" do
+      user = insert_verified_user()
+
+      # Gemini advertises loadSession and no resume, so every turn after the
+      # first would replay the whole conversation. Flagging it is a no-op rather
+      # than an error: the legacy path is the default, not a failure mode.
+      gemini = insert_agent(user_id: user.id, runtime: "gemini", metadata: %{"acp" => true})
+      refute ACP.enabled?(gemini)
+
+      assert ACP.enabled?(acp_agent(user))
+    end
+  end
+
+  describe "spawn" do
+    setup do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+      {pid, ref} = start_acp_turn(conv)
+      {:ok, conv: conv, pid: pid, ref: ref}
+    end
+
+    test "runs the pinned adapter rather than the claude CLI", %{pid: pid} do
+      assert_receive {:spawned, cmd, _args, opts}
+      assert cmd == ACP.adapter_bin()
+      assert opts[:stdin] == true
+    end
+
+    test "writes initialize instead of the prompt", %{pid: pid} do
+      assert %{"method" => "initialize"} = next_write()
+    end
+
+    test "does not close stdin at spawn — it is the return path for the session", %{pid: pid} do
+      # The legacy path writes the prompt and closes immediately. Doing that here
+      # hangs up on the agent mid-handshake: permission answers and
+      # `session/cancel` both travel back up this pipe.
+      _ = next_write()
+      refute_receive :stdin_closed, 200
+    end
+  end
+
+  describe "a turn, end to end" do
+    setup do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+      {pid, ref} = start_acp_turn(conv)
+      {:ok, conv: conv, pid: pid, ref: ref}
+    end
+
+    test "persists the session id so the next turn can resume it", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      drive_to_prompt(pid, ref)
+
+      assert Conversations._unsafe_get_conversation!(conv.id).runtime_session_id == "sess_1"
+    end
+
+    test "protocol chatter never reaches the transcript", %{conv: conv, pid: pid, ref: ref} do
+      drive_to_prompt(pid, ref)
+
+      events = Conversations._unsafe_list_log_events(conv.id)
+
+      # A JSON-RPC response to `initialize` is not something a user should find
+      # in their conversation.
+      refute Enum.any?(events, &(&1.data =~ "agentCapabilities"))
+    end
+
+    test "session/update lands as an acp-stream log event", %{conv: conv, pid: pid, ref: ref} do
+      drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "agent_message_chunk",
+        "content" => %{"type" => "text", "text" => "the answer"}
+      })
+
+      events = Conversations._unsafe_list_log_events(conv.id)
+      assert event = Enum.find(events, &(&1.stream == "acp"))
+      assert event.data =~ "the answer"
+    end
+
+    test "the stop reason ends the turn and closes stdin", %{conv: conv, pid: pid, ref: ref} do
+      prompt_id = drive_to_prompt(pid, ref)
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "completed"
+      refute is_nil(turn.ended_at)
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      # Closing stdin is what makes the adapter exit.
+      assert_receive :stdin_closed
+    end
+
+    test "the process exit that follows is a no-op, not a second ending", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      # A turn ends on the prompt response *or* the exit, whichever arrives
+      # first, and never waits for both.
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      send(pid, {:exit, %{ref: ref}, 1})
+      _ = :sys.get_state(pid)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "completed"
+      assert is_nil(turn.exit_code)
+    end
+
+    test "a refusal is recorded as a failed turn", %{conv: conv, pid: pid, ref: ref} do
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "refusal"})
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "failed"
+    end
+
+    test "the conversation accepts another prompt afterwards", %{conv: conv, pid: pid, ref: ref} do
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      assert :ok = GenServer.call(pid, {:send_prompt, "again", []})
+      assert length(Conversations._unsafe_list_turns(conv.id)) == 2
+    end
+
+    test "an adapter that dies mid-handshake still ends the turn", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      # No stop reason will ever arrive. Leaving `current_command` set is the
+      # #413 shape: every prompt answered `:busy`, idle reclaim suppressed, and
+      # the sprite billing until the lifetime ceiling.
+      _ = next_write()
+      send(pid, {:exit, %{ref: ref}, 1})
+      _ = :sys.get_state(pid)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "failed"
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+    end
+  end
+
+  describe "turn 2" do
+    test "resumes by the persisted id rather than guessing" do
+      # The hazard 0014 names: gemini's `--resume` and codex's `--last` re-enter
+      # "the most recent conversation in the workspace". ACP names the session.
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+      {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: "sess_prior"})
+
+      {pid, ref} = start_acp_turn(conv)
+
+      %{"id" => init_id} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => @caps})
+
+      decoded = next_write()
+      assert decoded["method"] == "session/resume"
+      assert decoded["params"]["sessionId"] == "sess_prior"
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/log_event_test.exs
+++ b/apps/fountain/test/fountain/conversations/log_event_test.exs
@@ -23,7 +23,10 @@ defmodule Fountain.Conversations.LogEventTest do
 
   describe "streams/0" do
     test "returns all valid streams" do
-      assert LogEvent.streams() == ~w(stdout stderr)
+      # `acp` joined the pair in 0014 gate 2: it holds Agent Client Protocol
+      # `session/update` notifications rather than raw runtime output, and the
+      # render path keys off it to pick a translator.
+      assert LogEvent.streams() == ~w(stdout stderr acp)
     end
   end
 

--- a/apps/fountain/test/fountain/runtimes/acp/blocks_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/blocks_test.exs
@@ -1,0 +1,206 @@
+defmodule Fountain.Runtimes.ACP.BlocksTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Runtimes.ACP.Blocks
+
+  defp update(map), do: Blocks.from_update(%{"update" => map})
+
+  defp line(method, params) do
+    Jason.encode!(%{"jsonrpc" => "2.0", "method" => method, "params" => params})
+  end
+
+  describe "message chunks" do
+    test "an agent message chunk becomes a :text block" do
+      assert [%{kind: :text, body: "hello"}] =
+               update(%{
+                 "sessionUpdate" => "agent_message_chunk",
+                 "content" => %{"type" => "text", "text" => "hello"}
+               })
+    end
+
+    test "a thought chunk becomes a :thinking block" do
+      assert [%{kind: :thinking, body: "hmm"}] =
+               update(%{
+                 "sessionUpdate" => "agent_thought_chunk",
+                 "content" => %{"type" => "text", "text" => "hmm"}
+               })
+    end
+
+    test "a list of content parts is concatenated, not split into blocks" do
+      # Adjacent text renders as one paragraph; emitting a block per part would
+      # break a sentence across cards.
+      assert [%{kind: :text, body: "abc"}] =
+               update(%{
+                 "sessionUpdate" => "agent_message_chunk",
+                 "content" => [
+                   %{"type" => "text", "text" => "a"},
+                   %{"type" => "text", "text" => "b"},
+                   %{"type" => "text", "text" => "c"}
+                 ]
+               })
+    end
+
+    test "an empty chunk produces no block at all" do
+      assert [] =
+               update(%{
+                 "sessionUpdate" => "agent_message_chunk",
+                 "content" => %{"type" => "text", "text" => ""}
+               })
+    end
+
+    test "a non-text part is named rather than rendered blank" do
+      assert [%{kind: :text, body: "[image]"}] =
+               update(%{
+                 "sessionUpdate" => "agent_message_chunk",
+                 "content" => %{"type" => "image", "data" => "..."}
+               })
+    end
+  end
+
+  describe "tool calls" do
+    test "a tool_call becomes a :tool_use carrying the id the pairing pass needs" do
+      assert [block] =
+               update(%{
+                 "sessionUpdate" => "tool_call",
+                 "toolCallId" => "call_1",
+                 "title" => "Read file",
+                 "kind" => "read",
+                 "rawInput" => %{"path" => "/tmp/x"}
+               })
+
+      assert block.kind == :tool_use
+      assert block.id == "call_1"
+      assert block.name == "Read file"
+      assert block.body =~ "/tmp/x"
+    end
+
+    test "the summary prefers a location path over the raw input" do
+      assert [%{summary: "/srv/app.ex"}] =
+               update(%{
+                 "sessionUpdate" => "tool_call",
+                 "toolCallId" => "c",
+                 "title" => "Edit",
+                 "locations" => [%{"path" => "/srv/app.ex"}],
+                 "rawInput" => %{"noise" => "lots"}
+               })
+    end
+
+    test "a title-less call falls back to its kind, never to an empty card" do
+      assert [%{name: "execute"}] =
+               update(%{"sessionUpdate" => "tool_call", "toolCallId" => "c", "kind" => "execute"})
+
+      assert [%{name: "tool"}] =
+               update(%{"sessionUpdate" => "tool_call", "toolCallId" => "c"})
+    end
+
+    test "a completed update becomes a :tool_result keyed to the same id" do
+      assert [block] =
+               update(%{
+                 "sessionUpdate" => "tool_call_update",
+                 "toolCallId" => "call_1",
+                 "status" => "completed",
+                 "content" => [
+                   %{"type" => "content", "content" => %{"type" => "text", "text" => "ok"}}
+                 ]
+               })
+
+      assert block.kind == :tool_result
+      assert block.tool_id == "call_1"
+      assert block.body == "ok"
+      refute block.error?
+    end
+
+    test "a failed update is a result flagged as an error" do
+      assert [%{kind: :tool_result, error?: true}] =
+               update(%{
+                 "sessionUpdate" => "tool_call_update",
+                 "toolCallId" => "c",
+                 "status" => "failed"
+               })
+    end
+
+    test "in-flight updates produce nothing" do
+      # A tool call reports pending → in_progress → completed. Rendering each as
+      # a result would draw the same finished tool card three times.
+      for status <- ["pending", "in_progress"] do
+        assert [] =
+                 update(%{
+                   "sessionUpdate" => "tool_call_update",
+                   "toolCallId" => "c",
+                   "status" => status
+                 })
+      end
+    end
+
+    test "ids thread through so show.ex's pairing pass can collapse them" do
+      [use_block] =
+        update(%{"sessionUpdate" => "tool_call", "toolCallId" => "x", "title" => "T"})
+
+      [result_block] =
+        update(%{
+          "sessionUpdate" => "tool_call_update",
+          "toolCallId" => "x",
+          "status" => "completed"
+        })
+
+      assert use_block.id == result_block.tool_id
+    end
+  end
+
+  describe "variants with no Fountain equivalent" do
+    test "plan, command lists and user echoes are dropped" do
+      for variant <- ["plan", "available_commands_update", "user_message_chunk"] do
+        assert [] =
+                 update(%{
+                   "sessionUpdate" => variant,
+                   "content" => %{"type" => "text", "text" => "x"}
+                 })
+      end
+    end
+
+    test "an unknown variant is dropped rather than rendered as raw" do
+      # The legacy parsers render unrecognised lines as a :raw block. For a
+      # specified protocol that would turn every new notification kind an
+      # adapter adds into visible noise in every conversation.
+      assert [] = update(%{"sessionUpdate" => "something_invented_later"})
+    end
+  end
+
+  describe "from_line/1" do
+    test "translates a session/update notification line" do
+      line =
+        line("session/update", %{
+          "sessionId" => "s",
+          "update" => %{
+            "sessionUpdate" => "agent_message_chunk",
+            "content" => %{"type" => "text", "text" => "hi"}
+          }
+        })
+
+      assert [%{kind: :text, body: "hi"}] = Blocks.from_line(line)
+    end
+
+    test "protocol chatter renders as nothing" do
+      assert [] =
+               Blocks.from_line(Jason.encode!(%{"jsonrpc" => "2.0", "id" => 1, "result" => %{}}))
+
+      assert [] = Blocks.from_line(line("session/other", %{}))
+    end
+
+    test "a non-JSON line survives as a :raw block" do
+      assert [%{kind: :raw, body: "npm warn"}] = Blocks.from_line("npm warn")
+    end
+
+    test "params without the update envelope still translate" do
+      # Some adapters put the variant directly in params rather than under
+      # `update`. Both shapes appear in the wild; neither should render blank.
+      assert [%{kind: :text, body: "flat"}] =
+               Blocks.from_line(
+                 line("session/update", %{
+                   "sessionUpdate" => "agent_message_chunk",
+                   "content" => %{"type" => "text", "text" => "flat"}
+                 })
+               )
+    end
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -1,0 +1,345 @@
+defmodule Fountain.Runtimes.ACP.PeerTest do
+  @moduledoc """
+  Drives a real peer against a scripted agent.
+
+  The sprite side is a Mimic stub on `Sprites.write/2` that forwards whatever
+  the peer writes to the test process, so every assertion here is about bytes
+  that would actually have gone down the pipe.
+  """
+
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Fountain.Runtimes.ACP.Peer
+
+  setup :set_mimic_global
+
+  setup do
+    test = self()
+
+    Mimic.stub(Sprites, :write, fn _command, data ->
+      send(test, {:wrote, IO.iodata_to_binary(data)})
+      :ok
+    end)
+
+    {:ok, ref: make_ref(), command: %{ref: :fake, pid: self()}}
+  end
+
+  defp start_peer(ctx, opts) do
+    {:ok, pid} =
+      Peer.start(
+        [
+          owner: self(),
+          command: ctx.command,
+          ref: ctx.ref,
+          prompt: "do the thing",
+          mode: :run,
+          session_id: nil,
+          cwd: "/work"
+        ]
+        |> Keyword.merge(opts)
+      )
+
+    pid
+  end
+
+  # Receive the next thing the peer wrote, decoded.
+  defp next_write do
+    assert_receive {:wrote, line}, 1_000
+    Jason.decode!(line)
+  end
+
+  defp send_response(pid, id, result) do
+    Peer.stdout(pid, Jason.encode!(%{"jsonrpc" => "2.0", "id" => id, "result" => result}) <> "\n")
+  end
+
+  defp update_line(update) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{"sessionId" => "s1", "update" => update}
+    }) <> "\n"
+  end
+
+  defp caps(extra \\ %{}) do
+    Map.merge(%{"loadSession" => true, "sessionCapabilities" => %{"resume" => %{}}}, extra)
+  end
+
+  describe "handshake" do
+    test "the first thing on the wire is initialize", ctx do
+      start_peer(ctx, [])
+
+      assert %{"method" => "initialize", "id" => _} = next_write()
+    end
+
+    test "declares no filesystem or terminal capabilities", ctx do
+      # 0016 makes servicing fs/* and terminal/* its own gate. Gate 2 asks for
+      # nothing, so a well-behaved adapter never calls them.
+      start_peer(ctx, [])
+
+      assert %{"params" => params} = next_write()
+      assert params["clientCapabilities"]["terminal"] == false
+      assert params["clientCapabilities"]["fs"]["readTextFile"] == false
+      assert params["clientCapabilities"]["fs"]["writeTextFile"] == false
+    end
+
+    test "reports the handshake cost to the owner", ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => id} = next_write()
+
+      send_response(pid, id, %{"agentCapabilities" => caps()})
+
+      assert_receive {:acp, _ref, {:handshake_ms, ms}}
+      assert is_integer(ms) and ms >= 0
+    end
+  end
+
+  describe "turn 1 — session/new" do
+    test "creates a session, reports the id, then prompts", ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+
+      assert %{"method" => "session/new", "id" => new_id, "params" => params} = next_write()
+      assert params["cwd"] == "/work"
+
+      send_response(pid, new_id, %{"sessionId" => "sess_abc"})
+
+      assert_receive {:acp, _ref, {:session, "sess_abc"}}
+
+      assert %{"method" => "session/prompt", "params" => prompt_params} = next_write()
+      assert prompt_params["sessionId"] == "sess_abc"
+      assert [%{"type" => "text", "text" => "do the thing"}] = prompt_params["prompt"]
+    end
+
+    test "a session response with no id fails the turn rather than prompting blind", ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+
+      send_response(pid, new_id, %{})
+
+      assert_receive {:acp, _ref, {:failed, {:acp_no_session_id, _}}}
+    end
+  end
+
+  describe "turn N — resumption" do
+    test "prefers session/resume when the agent advertises it", ctx do
+      # This is the whole reason Claude is the gate 2 runtime: resume restores
+      # context without replaying, so a turn costs a handshake and nothing else.
+      pid = start_peer(ctx, mode: :continue, session_id: "sess_abc")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+
+      assert %{"method" => "session/resume", "params" => params} = next_write()
+      assert params["sessionId"] == "sess_abc"
+    end
+
+    test "falls back to session/load when resume is not advertised", ctx do
+      pid = start_peer(ctx, mode: :continue, session_id: "sess_abc")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+
+      assert %{"method" => "session/load"} = next_write()
+    end
+
+    test "an agent that can do neither fails the turn instead of starting a second session",
+         ctx do
+      pid = start_peer(ctx, mode: :continue, session_id: "sess_abc")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => %{}})
+
+      assert_receive {:acp, _ref, {:failed, :acp_agent_cannot_resume}}
+    end
+
+    test "continue with no session id is a contradiction and fails loudly", ctx do
+      pid = start_peer(ctx, mode: :continue, session_id: nil)
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+
+      assert_receive {:acp, _ref, {:failed, :acp_resume_without_session_id}}
+    end
+  end
+
+  describe "replay discard" do
+    test "updates arriving during session/load are dropped, and later ones are not", ctx do
+      pid = start_peer(ctx, mode: :continue, session_id: "sess_abc")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+      %{"id" => load_id} = next_write()
+
+      # The replay: history we already hold as log_events.
+      Peer.stdout(
+        pid,
+        update_line(%{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => "OLD TURN"}
+        })
+      )
+
+      refute_receive {:acp, _, {:lines, _, _}}, 100
+
+      send_response(pid, load_id, %{})
+      %{"method" => "session/prompt"} = next_write()
+
+      Peer.stdout(
+        pid,
+        update_line(%{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => "NEW"}
+        })
+      )
+
+      assert_receive {:acp, _ref, {:lines, "acp", data}}
+      assert data =~ "NEW"
+      refute data =~ "OLD TURN"
+    end
+
+    test "session/resume never enters replay-discard, so nothing is lost", ctx do
+      pid = start_peer(ctx, mode: :continue, session_id: "sess_abc")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => resume_id} = next_write()
+      send_response(pid, resume_id, %{})
+      %{"method" => "session/prompt"} = next_write()
+
+      Peer.stdout(
+        pid,
+        update_line(%{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => "kept"}
+        })
+      )
+
+      assert_receive {:acp, _ref, {:lines, "acp", data}}
+      assert data =~ "kept"
+    end
+  end
+
+  describe "the turn's end" do
+    test "a stop reason ends the turn", ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+      %{"id" => prompt_id} = next_write()
+
+      send_response(pid, prompt_id, %{"stopReason" => "end_turn"})
+
+      assert_receive {:acp, _ref, {:done, "end_turn"}}
+    end
+
+    test "an error response fails the turn", ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => init_id,
+          "error" => %{"code" => -32_000, "message" => "bad key"}
+        }) <> "\n"
+      )
+
+      assert_receive {:acp, _ref, {:failed, {:acp_error, :initialize, %{"message" => "bad key"}}}}
+    end
+
+    test "a stdin write failure fails the turn rather than exiting the peer", ctx do
+      # #603: Sprites.write is a bare GenServer.call underneath, and the command
+      # process stops :normal the moment the runtime's exit frame arrives — so a
+      # write landing after that exits the *caller* with the call wrapped
+      # alongside the reason. SpriteStdin turns that into an error; the peer
+      # must report it, because a peer that dies silently leaves a turn with no
+      # terminator at all.
+      Mimic.stub(Sprites, :write, fn _c, _d ->
+        exit({:normal, {GenServer, :call, [self(), :write, 5_000]}})
+      end)
+
+      start_peer(ctx, [])
+
+      assert_receive {:acp, _ref, {:failed, {:acp_write_failed, :command_exited}}}
+    end
+  end
+
+  describe "agent → client requests" do
+    test "a permission request is auto-allowed, matching the legacy bypass flags", ctx do
+      # Gate 2 keeps parity with `--dangerously-skip-permissions`: answering is
+      # mandatory (a blocked agent is a turn in flight, which disarms idle
+      # reclaim), and gate 3 is where the answer starts coming from a policy.
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+      _prompt = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => 99,
+          "method" => "session/request_permission",
+          "params" => %{
+            "options" => [
+              %{"optionId" => "no", "kind" => "reject_once"},
+              %{"optionId" => "yes", "kind" => "allow_always"}
+            ]
+          }
+        }) <> "\n"
+      )
+
+      assert %{"id" => 99, "result" => %{"outcome" => outcome}} = next_write()
+      assert outcome["outcome"] == "selected"
+      assert outcome["optionId"] == "yes"
+    end
+
+    test "an fs/* request is refused, not ignored", ctx do
+      # Silence would block the agent forever. We declared no fs capability, so
+      # the honest answer is method-not-found.
+      pid = start_peer(ctx, [])
+      _init = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => 5, "method" => "fs/read_text_file"}) <> "\n"
+      )
+
+      assert %{"id" => 5, "error" => %{"code" => -32_601}} = next_write()
+    end
+  end
+
+  describe "noise" do
+    test "a non-JSON line is persisted as ordinary output", ctx do
+      pid = start_peer(ctx, [])
+      _init = next_write()
+
+      Peer.stdout(pid, "npm warn deprecated punycode@2.3.1\n")
+
+      assert_receive {:acp, _ref, {:lines, "stdout", data}}
+      assert data =~ "npm warn"
+    end
+  end
+
+  test "the peer dies with its owner", ctx do
+    owner = spawn(fn -> receive do: (:never -> :ok) end)
+
+    {:ok, pid} =
+      Peer.start(
+        owner: owner,
+        command: ctx.command,
+        ref: ctx.ref,
+        prompt: "p",
+        mode: :run,
+        session_id: nil,
+        cwd: "/work"
+      )
+
+    monitor = Process.monitor(pid)
+    Process.exit(owner, :kill)
+
+    assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}, 1_000
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/acp/protocol_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/protocol_test.exs
@@ -1,0 +1,133 @@
+defmodule Fountain.Runtimes.ACP.ProtocolTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Runtimes.ACP.Protocol
+
+  describe "feed/2 framing" do
+    test "returns whole messages and keeps the incomplete tail" do
+      {msgs, rest} = Protocol.feed("", ~s({"jsonrpc":"2.0","id":1,"result":{}}\n{"jsonr))
+
+      assert [{:response, 1, %{}}] = msgs
+      assert rest == ~s({"jsonr)
+    end
+
+    test "a message split across three chunks is delivered once, whole" do
+      {msgs, buf} = Protocol.feed("", ~s({"jsonrpc":"2.0",))
+      assert msgs == []
+
+      {msgs, buf} = Protocol.feed(buf, ~s("id":7,"result":{"sessionId":))
+      assert msgs == []
+
+      {msgs, buf} = Protocol.feed(buf, ~s("abc"}}\n))
+
+      assert [{:response, 7, %{"sessionId" => "abc"}}] = msgs
+      assert buf == ""
+    end
+
+    test "several messages in one chunk keep their order" do
+      chunk =
+        Enum.map_join(1..3, "", fn i ->
+          ~s({"jsonrpc":"2.0","method":"session/update","params":{"n":#{i}}}\n)
+        end)
+
+      {msgs, ""} = Protocol.feed("", chunk)
+
+      assert [
+               {:notification, "session/update", %{"n" => 1}},
+               {:notification, "session/update", %{"n" => 2}},
+               {:notification, "session/update", %{"n" => 3}}
+             ] = msgs
+    end
+
+    test "valid JSON with no trailing newline is held back, not emitted early" do
+      # The newline is the frame boundary. Emitting on 'it parses' would deliver
+      # a message that the agent is still writing.
+      {msgs, rest} = Protocol.feed("", ~s({"jsonrpc":"2.0","id":1,"result":{}}))
+
+      assert msgs == []
+      assert rest != ""
+    end
+
+    test "blank lines between messages are ignored" do
+      {msgs, ""} = Protocol.feed("", "\n\n" <> ~s({"jsonrpc":"2.0","id":1,"result":{}}\n))
+      assert [{:response, 1, _}] = msgs
+    end
+
+    test "a non-JSON line is an event, not a crash" do
+      {msgs, ""} = Protocol.feed("", "npm warn deprecated foo@1.0.0\n")
+      assert [{:invalid, "npm warn deprecated foo@1.0.0"}] = msgs
+    end
+
+    test "a stack trace does not stop the messages after it" do
+      chunk = "TypeError: boom\n" <> ~s({"jsonrpc":"2.0","id":2,"result":{}}\n)
+      {msgs, ""} = Protocol.feed("", chunk)
+
+      assert [{:invalid, "TypeError: boom"}, {:response, 2, _}] = msgs
+    end
+  end
+
+  describe "classify/1" do
+    test "distinguishes the four message shapes" do
+      assert {:response, 1, %{"ok" => true}} =
+               Protocol.classify(%{"id" => 1, "result" => %{"ok" => true}})
+
+      assert {:error_response, 1, %{"code" => -1}} =
+               Protocol.classify(%{"id" => 1, "error" => %{"code" => -1}})
+
+      assert {:request, 2, "session/request_permission", %{"a" => 1}} =
+               Protocol.classify(%{
+                 "id" => 2,
+                 "method" => "session/request_permission",
+                 "params" => %{"a" => 1}
+               })
+
+      assert {:notification, "session/update", %{}} =
+               Protocol.classify(%{"method" => "session/update"})
+    end
+
+    test "a request is distinguished from a notification by the id, not the method" do
+      # Both carry `method`; only a request expects a reply. Getting this
+      # backwards means either answering a notification or hanging an agent.
+      assert {:request, 9, "fs/read_text_file", _} =
+               Protocol.classify(%{"id" => 9, "method" => "fs/read_text_file"})
+
+      assert {:notification, "fs/read_text_file", _} =
+               Protocol.classify(%{"method" => "fs/read_text_file"})
+    end
+
+    test "missing params become an empty map rather than nil" do
+      assert {:notification, "session/update", %{}} =
+               Protocol.classify(%{"method" => "session/update", "params" => nil})
+    end
+  end
+
+  describe "encoding" do
+    test "every encoded frame ends in exactly one newline" do
+      for frame <- [
+            Protocol.request(1, "initialize", %{}),
+            Protocol.notification("session/cancel", %{}),
+            Protocol.response(1, %{}),
+            Protocol.error(1, -32_601, "nope")
+          ] do
+        encoded = IO.iodata_to_binary(frame)
+        assert String.ends_with?(encoded, "\n")
+        refute String.ends_with?(encoded, "\n\n")
+      end
+    end
+
+    test "a request round-trips through the framer" do
+      line = IO.iodata_to_binary(Protocol.request(3, "session/prompt", %{"sessionId" => "s1"}))
+      {[msg], ""} = Protocol.feed("", line)
+
+      assert {:request, 3, "session/prompt", %{"sessionId" => "s1"}} = msg
+    end
+
+    test "error/3 carries the code and message" do
+      line = IO.iodata_to_binary(Protocol.error(4, Protocol.method_not_found(), "no fs"))
+      {[{:error_response, 4, err}], ""} = Protocol.feed("", line)
+
+      assert err["code"] == -32_601
+      assert err["message"] == "no fs"
+    end
+  end
+end

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -313,6 +313,57 @@ concrete bug if it is missed:
 
 Ship it off by default, enabled per agent, with the legacy path intact.
 
+#### Result — built, 2026-08-10
+
+Built for Claude, off by default, behind `agent.metadata["acp"] == true`.
+`Fountain.Runtimes.ACP` decides and provisions; `…ACP.Protocol` frames;
+`…ACP.Peer` holds one connection for one turn; `…ACP.Blocks` translates. The
+peer is a separate GenServer, monitored in both directions rather than linked,
+so a protocol bug fails a turn instead of taking down a `ConversationServer`
+holding a sprite handle and a tenant's secrets.
+
+`log_events` gained an `acp` stream carrying `session/update` notifications,
+one per line — the protocol as it arrived, exactly as `stdout` rows carry raw
+output. `show.ex` gained a single delegating clause keyed on that stream. That
+is not quite "the LiveView does not change", and the difference is worth
+naming: a fifth *parser* in the render path was the thing this ADR set out to
+avoid, and there is none. The clause dispatches to a module with its own
+tests. Keying on the stream rather than on `conversation.runtime` also means a
+conversation whose flag flipped between turns renders its earlier turns
+through the legacy parser and its later ones through ACP, which is the A/B on
+one screen the gate asked for.
+
+Three things the build settled that the ADR had only asserted:
+
+- **The turn really does have two terminators, and they are not symmetric.**
+  The stop reason arrives first and closes stdin; the process exit follows and
+  must be a no-op. Clearing `current_command_ref` is what makes it one — the
+  existing `{:exit, …}` clause then finds no match and falls through. A test
+  asserts the turn stays `completed` when an exit code of 1 arrives after a
+  successful stop reason, because the alternative is a finished turn being
+  overwritten by the adapter's exit status.
+
+- **`session/request_permission` had to be answered in gate 2, before the gate
+  that is about answering it.** An unanswered request blocks the agent, and a
+  blocked agent is a turn in flight — which disarms idle reclaim and bills the
+  sprite to the ceiling, the same shape as #413. Gate 2 auto-allows, which is
+  exact parity with the `--dangerously-skip-permissions` the legacy path
+  already passes. Gate 3 replaces the answer source, not the plumbing.
+
+- **`fs/*` and `terminal/*` are refused, not ignored.** We declare no client
+  filesystem or terminal capability, so a well-behaved adapter never asks; one
+  that asks anyway gets JSON-RPC `-32601`. Silence would hang the agent.
+
+**Not delivered: the latency number.** Gate 2 says it "must report [the
+per-turn `initialize` cost] against the current spawn". The instrumentation
+exists — `[:fountain, :acp, :handshake]` is emitted per turn with the
+milliseconds from spawn to the `initialize` response — but the measurement
+needs the pinned adapter running in a real sprite against a real key, and the
+number is meaningless from anywhere else. **Gate 2 is not complete until that
+figure is recorded here.** If it turns out to be intolerable, the escape hatch
+is the sandbox-scoped connection in *Session lifetime* above, never a
+session-scoped one.
+
 ### Gate 3 — permissions
 
 Implement `session/request_permission` against the conversation LiveView: a


### PR DESCRIPTION
Builds [0014](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0014-agent-client-protocol.md) gate 2 for **one runtime, off by default**. An agent without `metadata["acp"] == true` takes exactly the path it takes today.

## Shape

Four new modules, none inside `ConversationServer` — the ADR is explicit that a peer landing there means it was implemented wrongly:

| module | job |
|---|---|
| `Runtimes.ACP` | the flag, the pinned adapter, the install, `initialize` params |
| `Runtimes.ACP.Protocol` | ndjson framing + JSON-RPC 2.0 — pure, no process |
| `Runtimes.ACP.Peer` | one connection, one turn; monitored in both directions, never linked |
| `Runtimes.ACP.Blocks` | `session/update` → the block maps `show.ex` already renders |

The connection is **scoped to the turn**, per the *Session lifetime* rule: `initialize` → `session/new` or `session/resume` → one `session/prompt` → stop reason → close. Nothing is attached between turns, so `Lifecycle`, `SandboxReaper` and the rehydrator are untouched and an idle sprite is reclaimed on exactly today's terms.

## The render seam

`log_events` gains an `acp` stream holding `session/update` notifications one per line — the protocol as it arrived, the way `stdout` rows hold raw output — and `show.ex` gains **one delegating clause**. That is not literally "the LiveView does not change", and the PR says so in the ADR: what the gate was protecting against is a fifth *parser* in the render path, and there is none. Keying on the stream rather than `conversation.runtime` also means a conversation whose flag flipped mid-way renders earlier turns through the legacy parser and later ones through ACP — the A/B on one screen.

## Three things the build settled

- **The turn has two terminators now.** The stop reason arrives first and closes stdin; the process exit that follows must be a no-op, which clearing `current_command_ref` makes it. A test asserts a `completed` turn survives a later exit code of 1 instead of being overwritten by it.
- **`session/request_permission` had to be answered here** — one gate before the gate about answering it. An unanswered request blocks the agent, and a blocked agent is a turn in flight, which disarms idle reclaim and bills the sprite to the ceiling (#413's exact shape). Gate 2 auto-allows: parity with the `--dangerously-skip-permissions` the legacy path already passes. Gate 3 replaces the answer *source*, not the plumbing.
- **`fs/*` and `terminal/*` are refused with `-32601`, not ignored.** We declare no such client capability; silence would hang the agent.

## Pinning

`@agentclientprotocol/claude-agent-acp@0.66.0`, installed at provision time (before the network policy lands). Gate 1 found nothing version-pinned anywhere in the repo, and an unpinned adapter can silently stop advertising `sessionCapabilities.resume` — downgrading every conversation to a full history replay per turn, with no error anywhere.

## Tests

63 new tests. The peer runs against a scripted agent with `Sprites.write` stubbed to the test process, so every assertion is about bytes that would really have gone down the pipe: framing across chunk boundaries, resume-vs-load preference, replay discard, permission auto-allow, `-32601`, write failure, owner death. The integration tests drive a real `ConversationServer`.

`mix precommit` green: 2530 tests, 0 failures, credo --strict clean, dialyzer clean.

## Not delivered

**The latency number gate 2 owes.** The instrumentation is here — `[:fountain, :acp, :handshake]`, emitted per turn — but measuring the per-turn `initialize` cost needs the pinned adapter running in a real sprite against a real key. **Gate 2 is not complete until that figure is recorded in the ADR**, and the ADR now says so rather than claiming the gate is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)