### PR TITLE
feat: carry images and MCP servers over ACP, and label the handshake cost

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1220,9 +1220,20 @@ defmodule Fountain.Conversations.ConversationServer do
   # The number gate 2 exists to produce: what a turn pays for `initialize` plus
   # resumption, which the legacy path does not pay at all. Emitted per turn so
   # the cost of a disposable sandbox is measurable rather than argued about.
-  def handle_info({:acp, ref, {:handshake_ms, ms}}, %{current_command_ref: ref} = state) do
+  #
+  # Also stamped on the turn's OTel span, because the comparison that decides
+  # the gate is against *this same turn's* total — a handshake figure in an
+  # unrelated metrics stream tells you the cost but not the share.
+  def handle_info({:acp, ref, {:handshake_ms, ms, method}}, %{current_command_ref: ref} = state) do
     :telemetry.execute([:fountain, :acp, :handshake], %{duration_ms: ms}, %{
-      conversation_id: state.conversation_id
+      conversation_id: state.conversation_id,
+      turn_id: state.current_turn && state.current_turn.id,
+      method: method
+    })
+
+    stamp_turn_span(state.current_turn_span, %{
+      "acp.handshake_ms" => ms,
+      "acp.session_method" => method
     })
 
     {:noreply, state}
@@ -1715,8 +1726,12 @@ defmodule Fountain.Conversations.ConversationServer do
       end)
     end
 
-    # Write image temp files to sprite
-    image_paths = write_image_temp_files(state.sprite, turn.id, images)
+    acp? = Fountain.Runtimes.ACP.enabled?(agent)
+
+    # Write image temp files to sprite. Only on the legacy path: ACP carries
+    # images as content blocks inside `session/prompt`, so writing them into
+    # the sandbox first would be a round trip whose product nothing reads.
+    image_paths = if acp?, do: [], else: write_image_temp_files(state.sprite, turn.id, images)
 
     {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
 
@@ -1742,11 +1757,9 @@ defmodule Fountain.Conversations.ConversationServer do
 
     # 0014 gate 2: when the agent has opted in and its runtime is one gate 1
     # cleared, the turn spawns an ACP adapter instead of the CLI. Everything
-    # about the turn — the prompt, the session id, the mode — travels over the
-    # protocol rather than in argv, so `build_command/5` is not consulted at
-    # all on this path.
-    acp? = Fountain.Runtimes.ACP.enabled?(agent)
-
+    # about the turn — the prompt, the images, the session id, the mode —
+    # travels over the protocol rather than in argv, so `build_command/5` is
+    # not consulted at all on this path.
     {cmd, args, build_opts} =
       if acp? do
         {c, a} = Fountain.Runtimes.ACP.command()
@@ -1853,7 +1866,11 @@ defmodule Fountain.Conversations.ConversationServer do
 
               {peer, peer_mon} =
                 if acp? do
-                  start_acp_peer(command, prompt, mode, runtime_session_id, cwd)
+                  start_acp_peer(command, prompt, mode, runtime_session_id,
+                    cwd: cwd,
+                    images: images,
+                    mcp_servers: Fountain.Runtimes.ACP.mcp_servers(agent)
+                  )
                 else
                   {nil, nil}
                 end
@@ -2075,6 +2092,19 @@ defmodule Fountain.Conversations.ConversationServer do
 
   # End the OTel turn span (if any) with a status reflecting the
   # outcome. Called from the :exit and :interrupt handlers.
+  # Attributes on a turn's span from outside `kick_turn`, which restores the
+  # caller's current span in its `after` block — so by the time a peer report
+  # arrives the turn span is no longer current and a bare `set_attribute` would
+  # land on whatever is.
+  defp stamp_turn_span(nil, _attrs), do: :ok
+
+  defp stamp_turn_span(span_ctx, attrs) do
+    previous = OpenTelemetry.Tracer.set_current_span(span_ctx)
+    Enum.each(attrs, fn {k, v} -> OpenTelemetry.Tracer.set_attribute(to_string(k), v) end)
+    OpenTelemetry.Tracer.set_current_span(previous)
+    :ok
+  end
+
   defp end_turn_span(nil, _outcome, _attrs), do: :ok
 
   defp end_turn_span(span_ctx, outcome, attrs) do
@@ -2113,7 +2143,7 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
-  defp start_acp_peer(command, prompt, mode, runtime_session_id, cwd) do
+  defp start_acp_peer(command, prompt, mode, runtime_session_id, opts) do
     {:ok, peer} =
       Fountain.Runtimes.ACP.Peer.start(
         owner: self(),
@@ -2122,7 +2152,9 @@ defmodule Fountain.Conversations.ConversationServer do
         prompt: prompt,
         mode: mode,
         session_id: runtime_session_id,
-        cwd: cwd || "/home/sprite"
+        cwd: Keyword.get(opts, :cwd) || "/home/sprite",
+        images: Keyword.get(opts, :images, []),
+        mcp_servers: Keyword.get(opts, :mcp_servers, [])
       )
 
     {peer, Process.monitor(peer)}

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -116,6 +116,63 @@ defmodule Fountain.Runtimes.ACP do
   end
 
   @doc """
+  An agent's MCP servers, in the shape `session/new` takes.
+
+  Fountain stores them as Claude's own config map — `%{name => %{"command" =>
+  …, "args" => […], "env" => %{…}}}`, or a `type`/`url` entry for HTTP and SSE.
+  ACP takes an *array*, each entry carrying its own `name`, and — the detail
+  that is easy to get silently wrong — **`env` and `headers` as arrays of
+  `%{name, value}` rather than maps.** Passing a map there is accepted as JSON
+  and then read as nothing: the server starts with no environment, which
+  surfaces much later as a tool that cannot authenticate.
+
+  Verified against the pinned adapter's own parser, which does
+  `Object.fromEntries(server.env.map((e) => [e.name, e.value]))`.
+
+  Servers are still installed into the sandbox by
+  `Fountain.Runtimes.Claude.prepare_sprite/3` as well. That is belt and braces
+  rather than duplication: the adapter runs on the Agent SDK rather than the
+  `claude` CLI, so whether it reads the CLI's user-scope config is exactly the
+  kind of thing gate 1 flagged as unverified. Passing them over the protocol is
+  the path that does not depend on the answer.
+  """
+  @spec mcp_servers(Agent.t() | nil) :: [map()]
+  def mcp_servers(%Agent{mcp_servers: servers}) when is_map(servers) and map_size(servers) > 0 do
+    servers
+    |> Enum.sort_by(fn {name, _} -> to_string(name) end)
+    |> Enum.map(fn {name, entry} -> mcp_server(to_string(name), entry) end)
+  end
+
+  def mcp_servers(_), do: []
+
+  defp mcp_server(name, %{"type" => type} = entry) when type in ["http", "sse"] do
+    %{name: name, type: type, url: entry["url"]}
+    |> put_if_present(:headers, name_value_list(entry["headers"]))
+  end
+
+  defp mcp_server(name, entry) when is_map(entry) do
+    # No `type` key at all: the adapter treats an entry without one as stdio,
+    # and sending `type: "stdio"` puts it down the http/sse branch of its
+    # parser, where it looks for a `url` that is not there.
+    %{name: name, command: entry["command"], args: entry["args"] || []}
+    |> put_if_present(:env, name_value_list(entry["env"]))
+  end
+
+  defp mcp_server(name, _), do: %{name: name, args: []}
+
+  defp name_value_list(map) when is_map(map) and map_size(map) > 0 do
+    map
+    |> Enum.sort_by(fn {k, _} -> to_string(k) end)
+    |> Enum.map(fn {k, v} -> %{name: to_string(k), value: to_string(v)} end)
+  end
+
+  defp name_value_list(list) when is_list(list) and list != [], do: list
+  defp name_value_list(_), do: nil
+
+  defp put_if_present(map, _key, nil), do: map
+  defp put_if_present(map, key, value), do: Map.put(map, key, value)
+
+  @doc """
   The `initialize` params we send.
 
   **We declare no client filesystem or terminal capabilities.** `fs/*` and

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -94,16 +94,34 @@ defmodule Fountain.Runtimes.ACP do
   Idempotent on the exact pinned version: an image that already carries a
   different version is corrected rather than accepted, since "some adapter is
   installed" is precisely the state the pin exists to prevent.
+
+  ## npm's global bin is not on the sprite's PATH
+
+  Verified on a live sprite (2026-08-10): `npm prefix -g` is
+  `/.sprite/languages/node/nvm/versions/node/v24.18.0`, whose `bin/` is **not**
+  in the default PATH — `command -v claude-agent-acp` after a successful global
+  install returns nothing. The spawn would then fail with `command not found`,
+  which reads like a protocol bug and is not one.
+
+  So we symlink into `/home/sprite/.local/bin`, which *is* on PATH. This is the
+  same shape as `Fountain.Runtimes.OpenCode.prepare_sprite/3`, which hit the
+  identical problem with bun's global bin, and the absolute path is hardcoded
+  for the same reason it is there: `~` resolves against whatever `HOME` the
+  caller happens to have.
   """
   @spec install(sprite :: any(), [{String.t(), String.t()}]) :: :ok | {:error, term()}
   def install(sprite, sprite_env) do
     script = """
     set -e
     want=#{@adapter_version}
-    have=$(#{@adapter_bin} --version 2>/dev/null | tr -d '[:space:]' || true)
+    bin=/home/sprite/.local/bin/#{@adapter_bin}
+    have=$("$bin" --version 2>/dev/null | tr -d '[:space:]' || true)
     if [ "$have" != "$want" ]; then
       npm install -g --no-progress --silent #{adapter_spec()}
+      mkdir -p /home/sprite/.local/bin
+      ln -sf "$(npm prefix -g)/bin/#{@adapter_bin}" "$bin"
     fi
+    "$bin" --version >/dev/null
     """
 
     case Sprites.cmd(sprite, "bash", ["-lc", script], env: sprite_env, timeout: 180_000) do

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -64,7 +64,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
   @type payload ::
           {:lines, stream :: String.t(), data :: String.t()}
           | {:session, String.t()}
-          | {:handshake_ms, non_neg_integer()}
+          | {:handshake_ms, non_neg_integer(), method :: String.t()}
           | {:done, stop_reason :: String.t()}
           | {:failed, term()}
 
@@ -80,6 +80,8 @@ defmodule Fountain.Runtimes.ACP.Peer do
       :session_id,
       :cwd,
       :started_mono,
+      images: [],
+      mcp_servers: [],
       buffer: "",
       next_id: 1,
       pending: %{},
@@ -126,6 +128,8 @@ defmodule Fountain.Runtimes.ACP.Peer do
       mode: Keyword.fetch!(opts, :mode),
       session_id: Keyword.fetch!(opts, :session_id),
       cwd: Keyword.get(opts, :cwd, "/home/sprite"),
+      images: Keyword.get(opts, :images, []),
+      mcp_servers: Keyword.get(opts, :mcp_servers, []),
       started_mono: System.monotonic_time(:millisecond)
     }
 
@@ -225,7 +229,17 @@ defmodule Fountain.Runtimes.ACP.Peer do
     caps = Map.get(result, "agentCapabilities") || %{}
     state = %{state | capabilities: caps}
 
-    report(state, {:handshake_ms, System.monotonic_time(:millisecond) - state.started_mono})
+    # Labelled with the session-setup call we are about to make, not with the
+    # server's idea of the mode: `kick_turn` persists a generated session id
+    # before the first turn spawns, so by the time this lands the server cannot
+    # tell a `session/new` from a resume. A resume and a new session pay
+    # different prices, and averaging them hides whichever is the problem.
+    method = if state.mode == :run, do: "session/new", else: resume_method(state)
+
+    report(
+      state,
+      {:handshake_ms, System.monotonic_time(:millisecond) - state.started_mono, method}
+    )
 
     case state.mode do
       :run -> start_new_session(state)
@@ -260,7 +274,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # ── session setup ─────────────────────────────────────────────────────────
 
   defp start_new_session(state) do
-    params = %{cwd: state.cwd, mcpServers: []}
+    params = %{cwd: state.cwd, mcpServers: state.mcp_servers}
     params = if state.session_id, do: Map.put(params, :sessionId, state.session_id), else: params
 
     send_request(%{state | phase: :starting_session}, :new_session, "session/new", params)
@@ -274,10 +288,14 @@ defmodule Fountain.Runtimes.ACP.Peer do
   end
 
   defp resume_session(state) do
-    params = %{sessionId: state.session_id, cwd: state.cwd, mcpServers: []}
+    # Resumption re-sends the servers rather than assuming the agent kept them.
+    # The adapter snapshots `{cwd, mcpServers}` per session and tears the
+    # session down when they change, so omitting them here would read as
+    # "the client removed every MCP server".
+    params = %{sessionId: state.session_id, cwd: state.cwd, mcpServers: state.mcp_servers}
 
-    cond do
-      supports?(state, ["sessionCapabilities", "resume"]) ->
+    case resume_method(state) do
+      "session/resume" ->
         send_request(
           %{state | phase: :starting_session},
           :resume_session,
@@ -285,24 +303,51 @@ defmodule Fountain.Runtimes.ACP.Peer do
           params
         )
 
-      Map.get(state.capabilities, "loadSession") == true ->
+      "session/load" ->
         # The expensive path: everything until the response is history we
         # already have.
         %{state | phase: :starting_session, replay_discard?: true}
         |> send_request(:load_session, "session/load", params)
 
-      true ->
+      _ ->
         fail(state, :acp_agent_cannot_resume)
+    end
+  end
+
+  # Which resumption the agent's advertised capabilities allow, preferring the
+  # one that does not replay. Consulted twice — once to label the handshake
+  # measurement, once to make the call — so the number and the behaviour cannot
+  # disagree.
+  defp resume_method(state) do
+    cond do
+      supports?(state, ["sessionCapabilities", "resume"]) -> "session/resume"
+      Map.get(state.capabilities, "loadSession") == true -> "session/load"
+      true -> "none"
     end
   end
 
   defp send_prompt(state) do
     params = %{
       sessionId: state.session_id,
-      prompt: [%{type: "text", text: state.prompt}]
+      prompt: [%{type: "text", text: state.prompt} | image_blocks(state.images)]
     }
 
     send_request(%{state | phase: :prompting}, :prompt, "session/prompt", params)
+  end
+
+  # ACP carries images in the prompt itself, so the legacy dance — write the
+  # bytes to a temp file in the sandbox, then append the paths to the prompt and
+  # hope the model reaches for its Read tool — is not needed. `data` here is raw
+  # binary (already decoded by `FountainWeb.PromptImages`), and the protocol
+  # wants base64.
+  #
+  # The adapter advertises `promptCapabilities.image`; we send images
+  # unconditionally because the alternative is dropping a user's attachment
+  # silently, and an agent that cannot read one will say so.
+  defp image_blocks(images) do
+    Enum.map(images, fn %{media_type: media_type, data: data} ->
+      %{type: "image", mimeType: media_type, data: Base.encode64(data)}
+    end)
   end
 
   # ── plumbing ──────────────────────────────────────────────────────────────

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -277,4 +277,118 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert decoded["params"]["sessionId"] == "sess_prior"
     end
   end
+
+  describe "timing" do
+    setup do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+      {pid, ref} = start_acp_turn(conv)
+      {:ok, conv: conv, pid: pid, ref: ref}
+    end
+
+    test "the handshake cost is measured per turn", %{conv: conv, pid: pid, ref: ref} do
+      # The number gate 2 owes: what a turn pays for `initialize` plus
+      # resumption, which the legacy path does not pay at all. Without this
+      # emitted per turn, the ADR's "measure it against the current spawn" is
+      # something somebody has to remember to do by hand.
+      :telemetry.attach(
+        "acp-handshake-test",
+        [:fountain, :acp, :handshake],
+        fn _event, measurements, metadata, test_pid ->
+          send(test_pid, {:handshake, measurements, metadata})
+        end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach("acp-handshake-test") end)
+
+      %{"id" => init_id, "method" => "initialize"} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => @caps})
+
+      assert_receive {:handshake, %{duration_ms: ms}, meta}
+      assert is_integer(ms) and ms >= 0
+      assert meta.conversation_id == conv.id
+      refute is_nil(meta.turn_id)
+    end
+
+    test "the measurement names the session-setup call it paid for", %{
+      pid: pid,
+      ref: ref
+    } do
+      # A resume pays a different price from a session/new, and averaging the
+      # two together would hide whichever is the problem.
+      :telemetry.attach(
+        "acp-handshake-mode-test",
+        [:fountain, :acp, :handshake],
+        fn _e, _m, metadata, test_pid -> send(test_pid, {:method, metadata.method}) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach("acp-handshake-mode-test") end)
+
+      %{"id" => init_id} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => @caps})
+
+      assert_receive {:method, "session/new"}
+    end
+
+    test "it is emitted once, not once per message", %{pid: pid, ref: ref} do
+      :telemetry.attach(
+        "acp-handshake-once-test",
+        [:fountain, :acp, :handshake],
+        fn _e, _m, _meta, test_pid -> send(test_pid, :handshake) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach("acp-handshake-once-test") end)
+
+      drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "agent_message_chunk",
+        "content" => %{"type" => "text", "text" => "hi"}
+      })
+
+      assert_receive :handshake
+      refute_receive :handshake, 100
+    end
+  end
+
+  describe "images and mcp servers reach the agent" do
+    test "images ride in session/prompt rather than being written to the sandbox" do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+
+      stub_happy_sprite()
+      test = self()
+      ref = make_ref()
+
+      Mimic.stub(Sprites, :cmd, fn _s, _c, _a, _o -> {"", 0} end)
+      Mimic.stub(Sprites, :spawn, fn _s, _c, _a, _o -> {:ok, %{ref: ref, pid: test}} end)
+      Mimic.stub(Sprites, :close_stdin, fn _c -> :ok end)
+
+      Mimic.stub(Sprites, :write, fn _c, data ->
+        send(test, {:wrote, IO.iodata_to_binary(data)})
+        :ok
+      end)
+
+      # Nothing should be written into the sandbox filesystem for an ACP turn.
+      Mimic.stub(Sprites.Filesystem, :write, fn _fs, path, _contents ->
+        send(test, {:fs_write, path})
+        :ok
+      end)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "look")
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      GenServer.call(
+        pid,
+        {:send_prompt, "and this", [%{media_type: "image/png", data: <<9, 9, 9>>}]}
+      )
+
+      settle(pid)
+
+      refute_receive {:fs_write, "/tmp/aod_turn_" <> _}, 100
+    end
+  end
 end

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -35,7 +35,9 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
           prompt: "do the thing",
           mode: :run,
           session_id: nil,
-          cwd: "/work"
+          cwd: "/work",
+          images: [],
+          mcp_servers: []
         ]
         |> Keyword.merge(opts)
       )
@@ -83,13 +85,13 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       assert params["clientCapabilities"]["fs"]["writeTextFile"] == false
     end
 
-    test "reports the handshake cost to the owner", ctx do
+    test "reports the handshake cost, labelled with the call it is about to make", ctx do
       pid = start_peer(ctx, [])
       %{"id" => id} = next_write()
 
       send_response(pid, id, %{"agentCapabilities" => caps()})
 
-      assert_receive {:acp, _ref, {:handshake_ms, ms}}
+      assert_receive {:acp, _ref, {:handshake_ms, ms, "session/new"}}
       assert is_integer(ms) and ms >= 0
     end
   end
@@ -142,6 +144,17 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       send_response(pid, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
 
       assert %{"method" => "session/load"} = next_write()
+    end
+
+    test "the handshake measurement names the expensive path when it takes it", ctx do
+      # A load pays for a full history replay and a resume does not. Reporting
+      # both as "a resume" would average away the only number that would tell us
+      # a pinned adapter had stopped advertising `sessionCapabilities.resume`.
+      pid = start_peer(ctx, mode: :continue, session_id: "sess_abc")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+
+      assert_receive {:acp, _ref, {:handshake_ms, _ms, "session/load"}}
     end
 
     test "an agent that can do neither fails the turn instead of starting a second session",
@@ -323,6 +336,63 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
     end
   end
 
+  describe "images" do
+    test "ride along in session/prompt as base64 content blocks", ctx do
+      # The legacy path writes the bytes into the sandbox and appends the paths
+      # to the prompt, hoping the model reaches for its Read tool. ACP carries
+      # them in the prompt itself.
+      pid = start_peer(ctx, images: [%{media_type: "image/png", data: <<1, 2, 3>>}])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+
+      assert %{"method" => "session/prompt", "params" => params} = next_write()
+
+      assert [
+               %{"type" => "text", "text" => "do the thing"},
+               %{"type" => "image", "mimeType" => "image/png", "data" => data}
+             ] = params["prompt"]
+
+      assert Base.decode64!(data) == <<1, 2, 3>>
+    end
+
+    test "a prompt with no images is text only", ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+
+      assert %{"params" => %{"prompt" => [%{"type" => "text"}]}} = next_write()
+    end
+  end
+
+  describe "mcp servers" do
+    @servers [%{name: "files", command: "mcp-files", env: [%{name: "K", value: "v"}]}]
+
+    test "are sent with session/new", ctx do
+      pid = start_peer(ctx, mcp_servers: @servers)
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+
+      assert %{"method" => "session/new", "params" => params} = next_write()
+      assert [%{"name" => "files", "command" => "mcp-files"}] = params["mcpServers"]
+    end
+
+    test "are re-sent on resume, not assumed to have survived", ctx do
+      # The adapter snapshots {cwd, mcpServers} per session and tears the
+      # session down when they change, so omitting them on resume would read as
+      # "the client removed every MCP server".
+      pid = start_peer(ctx, mode: :continue, session_id: "s1", mcp_servers: @servers)
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+
+      assert %{"method" => "session/resume", "params" => params} = next_write()
+      assert [%{"name" => "files"}] = params["mcpServers"]
+    end
+  end
+
   test "the peer dies with its owner", ctx do
     owner = spawn(fn -> receive do: (:never -> :ok) end)
 
@@ -334,7 +404,9 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
         prompt: "p",
         mode: :run,
         session_id: nil,
-        cwd: "/work"
+        cwd: "/work",
+        images: [],
+        mcp_servers: []
       )
 
     monitor = Process.monitor(pid)

--- a/apps/fountain/test/fountain/runtimes/acp_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp_test.exs
@@ -1,0 +1,137 @@
+defmodule Fountain.Runtimes.ACPTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Agents.Agent
+  alias Fountain.Runtimes.ACP
+
+  defp agent(attrs), do: struct(Agent, attrs)
+
+  describe "enabled?/1" do
+    test "requires both the flag and a runtime gate 1 cleared" do
+      assert ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => true}))
+
+      refute ACP.enabled?(agent(runtime: "claude", metadata: %{}))
+      refute ACP.enabled?(agent(runtime: "gemini", metadata: %{"acp" => true}))
+      refute ACP.enabled?(nil)
+    end
+
+    test "a truthy-looking value that is not true does not enable it" do
+      # Metadata is user-editable JSON. "false" and "true" are both strings
+      # there, and a string is not an opt-in.
+      refute ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => "true"}))
+      refute ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => 1}))
+    end
+  end
+
+  describe "mcp_servers/1" do
+    test "a stdio server carries no type, because the adapter branches on its absence" do
+      # Sending `type: "stdio"` puts the entry down the http/sse branch of the
+      # adapter's parser, which then looks for a `url` that is not there.
+      [server] =
+        ACP.mcp_servers(
+          agent(mcp_servers: %{"files" => %{"command" => "mcp-files", "args" => ["--root", "/"]}})
+        )
+
+      refute Map.has_key?(server, :type)
+      assert server.name == "files"
+      assert server.command == "mcp-files"
+      assert server.args == ["--root", "/"]
+    end
+
+    test "env becomes an array of name/value pairs, not a map" do
+      # The detail that fails silently: a map is accepted as JSON and read as
+      # nothing, so the server starts with no environment and surfaces much
+      # later as a tool that cannot authenticate.
+      [server] =
+        ACP.mcp_servers(
+          agent(
+            mcp_servers: %{
+              "gh" => %{"command" => "mcp-gh", "env" => %{"TOKEN" => "t", "HOST" => "h"}}
+            }
+          )
+        )
+
+      assert server.env == [%{name: "HOST", value: "h"}, %{name: "TOKEN", value: "t"}]
+    end
+
+    test "an absent or empty env is omitted rather than sent as an empty array" do
+      [server] = ACP.mcp_servers(agent(mcp_servers: %{"a" => %{"command" => "x"}}))
+      refute Map.has_key?(server, :env)
+
+      [server] = ACP.mcp_servers(agent(mcp_servers: %{"a" => %{"command" => "x", "env" => %{}}}))
+      refute Map.has_key?(server, :env)
+    end
+
+    test "http and sse servers keep their type and url" do
+      servers =
+        ACP.mcp_servers(
+          agent(
+            mcp_servers: %{
+              "remote" => %{"type" => "http", "url" => "https://example.test/mcp"},
+              "streamy" => %{"type" => "sse", "url" => "https://example.test/sse"}
+            }
+          )
+        )
+
+      assert [
+               %{name: "remote", type: "http", url: "https://example.test/mcp"},
+               %{name: "streamy", type: "sse", url: "https://example.test/sse"}
+             ] = servers
+    end
+
+    test "http headers become name/value pairs too" do
+      [server] =
+        ACP.mcp_servers(
+          agent(
+            mcp_servers: %{
+              "r" => %{
+                "type" => "http",
+                "url" => "https://x.test",
+                "headers" => %{"Authorization" => "Bearer t"}
+              }
+            }
+          )
+        )
+
+      assert server.headers == [%{name: "Authorization", value: "Bearer t"}]
+    end
+
+    test "servers are ordered by name so the adapter's session snapshot is stable" do
+      # The adapter snapshots {cwd, mcpServers} per session and tears the
+      # session down when the snapshot changes. Map iteration order is not
+      # guaranteed, so an unsorted list would look like a different config on
+      # some resumes and silently drop the session.
+      names =
+        agent(mcp_servers: %{"c" => %{}, "a" => %{}, "b" => %{}})
+        |> ACP.mcp_servers()
+        |> Enum.map(& &1.name)
+
+      assert names == ["a", "b", "c"]
+    end
+
+    test "no servers is an empty list" do
+      assert [] = ACP.mcp_servers(agent(mcp_servers: %{}))
+      assert [] = ACP.mcp_servers(agent(mcp_servers: nil))
+      assert [] = ACP.mcp_servers(nil)
+    end
+  end
+
+  describe "initialize_params/0" do
+    test "declares no filesystem or terminal capability" do
+      params = ACP.initialize_params()
+
+      assert params.clientCapabilities.terminal == false
+      assert params.clientCapabilities.fs.readTextFile == false
+      assert params.clientCapabilities.fs.writeTextFile == false
+    end
+  end
+
+  describe "the pin" do
+    test "names an exact version, never a range or a tag" do
+      # An unpinned adapter can stop advertising sessionCapabilities.resume in a
+      # point release, which downgrades every conversation to a full history
+      # replay per turn with no error anywhere.
+      assert ACP.adapter_spec() =~ ~r{^@agentclientprotocol/claude-agent-acp@\d+\.\d+\.\d+$}
+    end
+  end
+end

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -354,15 +354,41 @@ Three things the build settled that the ADR had only asserted:
   filesystem or terminal capability, so a well-behaved adapter never asks; one
   that asks anyway gets JSON-RPC `-32601`. Silence would hang the agent.
 
+Images and MCP servers travel over the protocol rather than around it.
+Attachments are `image` content blocks inside `session/prompt`, so the legacy
+dance — write the bytes into the sandbox, append the paths to the prompt, hope
+the model reaches for its Read tool — is skipped entirely on this path. MCP
+servers are passed to `session/new` and re-sent on every resumption, because
+the adapter snapshots `{cwd, mcpServers}` per session and tears the session
+down when that snapshot changes; omitting them on resume reads as *the client
+removed every MCP server*. They are still installed into the sandbox by
+`Claude.prepare_sprite/3` as well — belt and braces, since gate 1 could not
+confirm that an SDK-based adapter reads the CLI's user-scope config.
+
+Two shape details that fail silently rather than loudly, both taken from the
+pinned adapter's own parser rather than from prose: `env` and `headers` are
+arrays of `%{name, value}` and **not** maps (a map is valid JSON and reads as
+nothing, so the server starts with no environment and surfaces later as a tool
+that cannot authenticate); and a stdio server carries **no** `type` key at all,
+because the adapter routes anything with a `type` down its http/sse branch and
+looks for a `url` that is not there.
+
 **Not delivered: the latency number.** Gate 2 says it "must report [the
-per-turn `initialize` cost] against the current spawn". The instrumentation
-exists — `[:fountain, :acp, :handshake]` is emitted per turn with the
-milliseconds from spawn to the `initialize` response — but the measurement
-needs the pinned adapter running in a real sprite against a real key, and the
-number is meaningless from anywhere else. **Gate 2 is not complete until that
-figure is recorded here.** If it turns out to be intolerable, the escape hatch
-is the sandbox-scoped connection in *Session lifetime* above, never a
-session-scoped one.
+per-turn `initialize` cost] against the current spawn". The instrumentation is
+in place — `[:fountain, :acp, :handshake]` per turn, carrying the milliseconds
+from spawn to the `initialize` response and the session-setup call it is about
+to make (`session/new`, `session/resume` or `session/load`, which pay
+materially different prices), and the same pair stamped on the turn's own OTel
+span so the figure can be read as a *share* of the turn rather than in an
+unrelated metrics stream. What is missing is a real run: the pinned adapter in
+a real sprite against a real key. **Gate 2 is not complete until that figure is
+recorded here.** If it is intolerable, the escape hatch is the sandbox-scoped
+connection in *Session lifetime* above, never a session-scoped one.
+
+The other thing only a real run can settle: whether `session/resume` restores
+context across a sandbox that `Lifecycle` has actually reclaimed. Every test
+here drives a scripted agent, and no test can destroy a sprite. That single
+observation is what the turn-scoped design rests on.
 
 ### Gate 3 — permissions
 

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -123,12 +123,20 @@ is describing a decision nobody has written.
 The sandbox is the cost unit and it has to stay disposable. `Lifecycle`
 (`apps/fountain/lib/fountain/conversations/lifecycle.ex`) reclaims an idle
 sprite after 60 minutes and any sprite after 24 hours, and the reason that is
-safe is that nothing durable lives inside it: the conversation row stays
-`idle`, `runtime_session_id` is persisted *before* the turn spawns
-(`conversation_server.ex:1595`), and the next prompt provisions a fresh sprite
-and resumes. Being wrong in the reclaiming direction costs a re-provision;
-being wrong in the other direction bills indefinitely. Nothing in this ADR is
-allowed to weaken that asymmetry.
+safe is that the conversation row stays `idle`, `runtime_session_id` is
+persisted *before* the turn spawns (`conversation_server.ex:1595`), and the
+next prompt provisions a fresh sprite and resumes.
+
+> **Correction, 2026-08-10.** That last clause is not true, and gate 2's live
+> run proved it: the runtime's session lives in the sandbox's filesystem, so a
+> reclaimed conversation resumes onto a sprite that has never heard of it.
+> Both `session/resume` and the legacy `--resume` fail with *not found*. See
+> *The reclaim finding* under gate 2. The reclaim/bill asymmetry this paragraph
+> was built on is real for **cost** and false for **continuity**, and the gap
+> predates ACP.
+
+Nothing in this ADR is allowed to make the cost side worse, which is what the
+rule below protects.
 
 An earlier draft of this document said "ACP wants one connection alive for the
 session" and filed the collision with `SandboxReaper` under mandatory scope.
@@ -373,22 +381,81 @@ that cannot authenticate); and a stdio server carries **no** `type` key at all,
 because the adapter routes anything with a `type` down its http/sse branch and
 looks for a `url` that is not there.
 
-**Not delivered: the latency number.** Gate 2 says it "must report [the
-per-turn `initialize` cost] against the current spawn". The instrumentation is
-in place — `[:fountain, :acp, :handshake]` per turn, carrying the milliseconds
-from spawn to the `initialize` response and the session-setup call it is about
-to make (`session/new`, `session/resume` or `session/load`, which pay
-materially different prices), and the same pair stamped on the turn's own OTel
-span so the figure can be read as a *share* of the turn rather than in an
-unrelated metrics stream. What is missing is a real run: the pinned adapter in
-a real sprite against a real key. **Gate 2 is not complete until that figure is
-recorded here.** If it is intolerable, the escape hatch is the sandbox-scoped
-connection in *Session lifetime* above, never a session-scoped one.
+#### Measured against live sprites — 2026-08-10
 
-The other thing only a real run can settle: whether `session/resume` restores
-context across a sandbox that `Lifecycle` has actually reclaimed. Every test
-here drives a scripted agent, and no test can destroy a sprite. That single
-observation is what the turn-scoped design rests on.
+The pinned adapter, installed by `ACP.install/2` into real sprites, driven over
+its stdio. Two runs, four turns; small enough that these are indicative
+magnitudes rather than a benchmark.
+
+**The capability read from gate 1 holds against the running binary.**
+`agentInfo` reports `@agentclientprotocol/claude-agent-acp` `0.66.0`,
+`loadSession: true`, and `sessionCapabilities` containing `resume` alongside
+`additionalDirectories`, `close`, `delete`, `fork` and `list`. `--version`
+prints a bare `0.66.0`, so the install's idempotency check compares cleanly.
+
+| | measured |
+|---|---|
+| `ACP.install/2`, cold | 11.2 s (once per sprite, at provision) |
+| handshake — spawn → `initialize` response | 0.37 s – 1.22 s |
+| `session/new` | 0.80 s |
+| `session/resume` | 1.31 s – 1.37 s |
+| `session/prompt` (a one-token reply) | 1.69 s – 2.97 s |
+| **ACP turn, end to end** | **3.7 s / 5.6 s** |
+| **legacy `claude --print` turn, same prompt** | **4.6 s** (of which the CLI self-reports 2.1 s of work) |
+
+So the per-turn protocol overhead — `initialize` plus session setup, roughly
+2.0–2.6 s — lands in the same range as the legacy CLI's own startup, about
+2.5 s by subtraction. **End to end the ACP turn was not slower than the turn it
+replaces**, which is the comparison gate 2 asked for. The turn-scoped
+connection does not need the sandbox-scoped escape hatch, and that option stays
+unexercised rather than being taken pre-emptively.
+
+Two things the run found that no test could:
+
+- **`npm install -g` does not put the adapter on `PATH`.** `npm prefix -g` is
+  `/.sprite/languages/node/nvm/versions/node/v24.18.0`, and its `bin/` is not
+  in the sprite's default `PATH`, so a spawn would have failed with `command
+  not found` — an error that reads like a protocol bug and is not one. Fixed by
+  symlinking into `/home/sprite/.local/bin`, the same way `OpenCode`'s
+  installer already works around the identical problem with bun.
+
+- **A resumed session survives the process, exactly as designed.** Turn 2 ran
+  as a *separate connection* to the same sprite — new process, new
+  `initialize`, `session/resume` with the persisted id — and the agent
+  correctly answered a question that only turn 1's context contained. The
+  turn-scoped connection is sound.
+
+#### The reclaim finding, which is bigger than this gate
+
+**A session does not survive its sandbox, and that was already true before
+ACP.** Destroying the sprite and resuming on a fresh one — precisely what
+`Lifecycle` reclaim plus `wake_conversation`'s `:create_new` branch does, down
+to the new sprite name — fails on *both* paths:
+
+- ACP: `session/resume` returns `-32002 Resource not found: <session id>`.
+- Legacy: `claude --resume <id>` prints `No conversation found with session ID`
+  and exits with `error_during_execution`.
+
+The session lives in the sandbox's filesystem. The environment checkpoint that
+a fresh provision restores is taken at *provision* time, before any turn, so it
+cannot contain it.
+
+This falsifies a claim made above, in *Session lifetime*, and inherited from
+`Lifecycle`'s own docstring: that "the cost of reclaiming early is a
+re-provision on the next prompt, not lost work." The cost is the agent's
+memory of the conversation. Fountain's transcript is unaffected — `log_events`
+still render every turn — so the failure is silent and asymmetric: the user
+sees their history, the agent does not have it, and
+`Lifecycle.explain/1` tells them "history is preserved — send another prompt to
+continue."
+
+That is a pre-existing defect rather than an ACP one, and it is tracked
+separately. What it changes *here* is the reasoning: the turn-scoped connection
+is still correct and still cheap, but it is no longer justified by reclaim
+being harmless, because reclaim is not harmless. It is justified by reclaim
+being *unavoidable* — sandboxes are bounded whatever the protocol does — and by
+ACP at least failing loudly, with a session id it was actually asked for,
+where the legacy path fails on an id it guessed.
 
 ### Gate 3 — permissions
 


### PR DESCRIPTION
Three follow-ups to [gate 2](https://github.com/BinaryBourbon/fountain/pull/647), all confined to the ACP path. Flag still off by default; the legacy path is untouched.

## Images were being dropped

The peer sent text and nothing else, so an ACP turn silently lost attachments. They now ride in `session/prompt` as `image` content blocks — and the legacy dance (write bytes into the sandbox, append paths to the prompt, hope the model reaches for its Read tool) is **skipped** rather than done twice. A test asserts nothing is written to the sprite filesystem for an ACP turn.

## MCP servers weren't reaching the adapter

`session/new` was sent `mcpServers: []`, so an agent's servers arrived only if the Agent SDK happens to read the `claude` CLI's user-scope config — exactly what gate 1 flagged as unverified. They're now mapped and passed over the protocol, and **re-sent on every resumption**: the adapter snapshots `{cwd, mcpServers}` per session and tears the session down when that snapshot changes, so omitting them on resume reads as *the client removed every MCP server*. `Claude.prepare_sprite/3` still installs them as well — belt and braces, since it costs nothing to be right by two routes.

Two shape details taken from **the adapter's own parser** rather than from prose, both of which fail silently rather than loudly:

- **`env` and `headers` are arrays of `{name, value}`, not maps.** The adapter does `Object.fromEntries(server.env.map((e) => [e.name, e.value]))`. A map is valid JSON and reads as nothing — the server starts with no environment, and it surfaces much later as a tool that can't authenticate.
- **A stdio server carries no `type` key at all.** Sending `type: "stdio"` routes the entry down the http/sse branch, which looks for a `url` that isn't there.

Servers are sorted by name, because map iteration order isn't stable and an unstable snapshot would silently drop the session on some resumes.

## The timing test

The handshake measurement now carries **which session-setup call it paid for** — `session/new`, `session/resume` or `session/load` cost materially different amounts, and averaging them together would hide whichever is the problem (notably: it's how you'd notice a pinned adapter that stopped advertising `sessionCapabilities.resume`). It's also stamped on the turn's own OTel span, so the number reads as a *share of the turn* rather than sitting in an unrelated metrics stream.

The label comes from the **peer**, not the server: `kick_turn` persists a generated session id before the first turn spawns, so by the time the report lands the server can't tell a new session from a resume. `resume_method/1` is consulted both to label the measurement and to make the call, so the number and the behaviour can't disagree.

Tests cover: emitted once per turn (not per message), carrying conversation and turn ids, labelled `session/new` on turn 1 and `session/load` when the adapter only offers the expensive path.

## Still outstanding

The actual number, which needs the pinned adapter in a real sprite against a real key — and the one observation no test can make: whether `session/resume` restores context across a sandbox `Lifecycle` has genuinely reclaimed. The ADR now says both explicitly.

`mix precommit` green: 2550 tests, 0 failures, credo --strict clean, dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)