### PR TITLE
fix: stop promising a reclaimed conversation keeps the agent's memory (#649)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -19,18 +19,30 @@ defmodule Fountain.Conversations.Lifecycle do
     activity. Catches the case an idle timeout cannot: a conversation that keeps
     itself busy forever.
 
-  ## Why reclaiming is safe
+  ## What reclaiming costs
 
   Only the *sandbox* is torn down. The conversation row stays `idle`, which
   keeps it resumable — `assert_resumable/1` only refuses `terminated` and
-  `failed`. The next prompt goes through `wake_conversation/2`, which
-  sees a sandbox that is no longer `ready`, provisions a fresh one, and passes
-  the persisted `runtime_session_id` so the runtime resumes the same chat.
+  `failed`. The next prompt goes through `wake_conversation/2`, which sees a
+  sandbox that is no longer `ready`, provisions a fresh one, and passes the
+  persisted `runtime_session_id`.
 
-  So the cost of reclaiming early is a re-provision on the next prompt, not lost
-  work. That asymmetry is why the defaults can be fairly aggressive: being wrong
-  in the reclaiming direction is recoverable and being wrong in the other
-  direction bills indefinitely.
+  This module used to claim that the runtime then "resumes the same chat", and
+  that the cost of reclaiming early was therefore "a re-provision on the next
+  prompt, not lost work". **That is false, and #649 has the measurement.** The
+  runtime's session lives in the *sandbox's* filesystem, and the environment
+  checkpoint a fresh provision restores is taken before any turn ran, so it
+  cannot contain one. Resuming onto a new sprite fails on every path we have:
+  `claude --resume` answers "No conversation found with session ID" and ACP's
+  `session/resume` answers `-32002 Resource not found`.
+
+  So the honest asymmetry is narrower than the one the defaults were chosen
+  under. Being wrong in the reclaiming direction costs the agent's memory of
+  the conversation — Fountain's own transcript is untouched, every `log_events`
+  row still renders, so the loss is invisible in the UI and visible only in the
+  agent's answers. Being wrong in the other direction bills indefinitely.
+  Reclaiming is still right; it is just not free, and `explain/1` says so
+  rather than promising otherwise.
 
   Setting the conversation itself to `terminated` here would *not* be safe — it
   would make the conversation permanently unresumable, turning a cost control
@@ -101,18 +113,27 @@ defmodule Fountain.Conversations.Lifecycle do
   Human-readable reason, for the stage event a client sees on the stream.
 
   Worth spending words on: from the user's side the sandbox simply went away,
-  and "your sandbox was idle for 60 minutes and was reclaimed; send another
-  prompt to continue" is the difference between a bug report and a shrug.
+  and an explanation is the difference between a bug report and a shrug.
+
+  It must not overstate what survived. The transcript does; the agent's context
+  does not (#649). Telling someone "history is preserved" and then having the
+  agent answer as though the conversation never happened is worse than saying
+  nothing, because they believe the first sentence and read the second as the
+  model being broken.
   """
   @spec explain(:idle | :max_lifetime) :: String.t()
   def explain(:idle) do
-    "Sandbox reclaimed after #{minutes(idle_timeout_seconds())} minutes idle. " <>
-      "Send another prompt to continue the conversation — history is preserved."
+    "Sandbox reclaimed after #{minutes(idle_timeout_seconds())} minutes idle. " <> resume_caveat()
   end
 
   def explain(:max_lifetime) do
     "Sandbox reclaimed after reaching the #{hours(max_lifetime_seconds())} hour maximum " <>
-      "lifetime. Send another prompt to continue the conversation — history is preserved."
+      "lifetime. " <> resume_caveat()
+  end
+
+  defp resume_caveat do
+    "Send another prompt to continue — the transcript above is kept, but the " <>
+      "agent starts a fresh session and will not remember the earlier turns."
   end
 
   defp minutes(nil), do: "?"

--- a/apps/fountain/test/fountain/conversations/lifecycle_test.exs
+++ b/apps/fountain/test/fountain/conversations/lifecycle_test.exs
@@ -110,17 +110,31 @@ defmodule Fountain.Conversations.LifecycleTest do
   end
 
   describe "explain/1" do
-    test "tells the user what happened and that nothing was lost" do
+    test "names the bound that fired and what to do next" do
       # From the user's side the sandbox simply vanished. This message is the
       # difference between a bug report and a shrug.
       with_config([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
         idle = Lifecycle.explain(:idle)
         assert idle =~ "60 minutes idle"
         assert idle =~ "Send another prompt"
-        assert idle =~ "history is preserved"
 
         assert Lifecycle.explain(:max_lifetime) =~ "24 hour"
+        assert Lifecycle.explain(:max_lifetime) =~ "Send another prompt"
       end)
+    end
+
+    test "does not promise the agent remembers the conversation (#649)" do
+      # It used to say "history is preserved", which is true of the transcript
+      # and false of the agent: the runtime session lives in the sandbox that
+      # was just destroyed, so the next turn starts cold. Believing the promise
+      # makes the agent's amnesia read as a bug in the model.
+      for reason <- [:idle, :max_lifetime] do
+        message = Lifecycle.explain(reason)
+
+        refute message =~ "history is preserved"
+        assert message =~ "will not remember"
+        assert message =~ "transcript"
+      end
     end
   end
 end

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -1,8 +1,12 @@
 # 0014 — Speaking the Agent Client Protocol to runtimes
 
-**Status:** Proposed — **nothing described here is built.** No ACP code exists
-in this repo today. This ADR records a direction and the gates that decide
-whether we take it; the PR that builds each gate removes its caveat.
+**Status:** Partially accepted — **gates 1 and 2 are built; gates 3 and 4 are
+not.** `Fountain.Runtimes.ACP` and its peer exist and speak ACP to the pinned
+Claude adapter, behind a per-agent flag that is off by default; every other
+agent takes the legacy path unchanged. Nothing in *Gate 3 — permissions* or
+*Gate 4* exists, and neither should be read as describing behaviour the system
+has. Each gate below carries its own status; the PR that builds one removes its
+caveat.
 
 ## Context
 
@@ -239,13 +243,16 @@ Five things the survey turned up that the rest of this ADR has to absorb:
   *to* the protocol org, not into abandonware.
 
 - **The Claude adapter does not wrap the `claude` CLI.** It is a separate
-  agent built on the Claude Agent SDK, so the sprite would run
-  `claude-agent-acp`, not `claude`. That contradicts this ADR's claim that
-  the provisioning half of `Fountain.Runtimes` survives unchanged: for Claude,
+  agent built on the Claude Agent SDK, so the sprite runs `claude-agent-acp`,
+  not `claude`. That put a question mark over this ADR's claim that the
+  provisioning half of `Fountain.Runtimes` survives unchanged, since
   `skills_root/0` (`/home/sprite/.claude/skills`) and `skills_sh_agent/0`
-  (`claude-code`) describe the CLI's discovery paths and must be re-verified
-  against the SDK's. The claim holds for the other three; it is wrong for the
-  one we are converting first.
+  (`claude-code`) describe the *CLI's* discovery paths.
+
+  **Resolved 2026-08-10, in favour of the claim:** a skill written to
+  `/home/sprite/.claude/skills/<name>/SKILL.md` was discovered and used by the
+  adapter on a live sprite. The SDK reads the same tree, so both callbacks are
+  correct as they stand and the provisioning layer really is untouched.
 
 - **Nothing is version-pinned today, so there is no floor to hold.** Claude,
   Codex and Gemini come from the sprite base image, which we do not control;
@@ -279,7 +286,7 @@ client, rather than being a plain stdio peer. It satisfies the protocol, but
 it is a heavier process model than the other three and should not be assumed
 equivalent when its turn comes at gate 4.
 
-### Gate 2 — one runtime, behind a per-agent flag
+### Gate 2 — one runtime, behind a per-agent flag — **done, 2026-08-10**
 
 Build `Fountain.Runtimes.ACP` as a JSON-RPC peer over the stdio pipe we
 already own (`Fountain.SpriteStdin.write/2` for the write half, the existing
@@ -425,6 +432,30 @@ Two things the run found that no test could:
   correctly answered a question that only turn 1's context contained. The
   turn-scoped connection is sound.
 
+Everything the ACP path carries over the protocol rather than around it was
+then exercised against the same adapter, using the shapes the production code
+actually emits:
+
+- **MCP servers arrive, and `env` really is an array.** A stdio server passed
+  through `ACP.mcp_servers/1` into `session/new` was started, listed and
+  called; its tool returned a value read from `MCP_TEST_VAR`, which was
+  delivered exactly as the `[%{name:, value:}]` form predicted. That was the
+  riskiest guess in the mapping — a map would have been accepted as JSON and
+  silently produced an empty environment — and it is now a measured fact
+  rather than a reading of the adapter's source.
+
+- **`session/request_permission` is real, and gate 2 was right to answer it.**
+  The MCP tool call produced exactly one permission request. Had the peer not
+  replied, the agent would have blocked — a turn in flight, idle reclaim
+  disarmed, the sprite billing to its ceiling. The channel gate 3 is built on
+  demonstrably exists on this adapter.
+
+- **Images in `session/prompt` work.** A generated PNG sent as an `image`
+  content block was described correctly, so attachments survive the ACP path.
+
+- **Skills are discovered from the CLI's tree**, resolving gate 1's open
+  question above.
+
 #### The reclaim finding, which is bigger than this gate
 
 **A session does not survive its sandbox, and that was already true before
@@ -457,7 +488,7 @@ being *unavoidable* — sandboxes are bounded whatever the protocol does — and
 ACP at least failing loudly, with a session id it was actually asked for,
 where the legacy path fails on an id it guessed.
 
-### Gate 3 — permissions
+### Gate 3 — permissions — **not built**
 
 Implement `session/request_permission` against the conversation LiveView: a
 real approval prompt, per tool call, with the answer written back over the
@@ -466,7 +497,7 @@ land and gate 3 turns out to be blocked — by adapter support, by latency, by
 the reaper killing sessions mid-prompt — the honest outcome is to stop with
 one runtime converted and say so here.
 
-### Gate 4 — remaining runtimes, and parser deletion
+### Gate 4 — remaining runtimes, and parser deletion — **not built**
 
 Only after gate 3 holds in production. A parser is deleted when its runtime's
 ACP path has served real conversations, not when the code compiles.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -68,8 +68,10 @@ the event data.
 
 What the statuses mean: `failed` and `terminated` are the two terminal
 states — a further prompt is refused. `idle` with a terminated *sandbox* is
-the normal resting state, not an error: the next prompt re-provisions and
-history is preserved.
+the normal resting state, not an error: the next prompt re-provisions. The
+stored transcript is unaffected, but the agent starts a fresh session and does
+not carry the earlier turns into it — see the note under
+[Primitives → Conversation](primitives.md).
 
 **Quota knock-on:** a crash mid-provision leaves a `pending`/`starting`
 sandbox row that counts against the user's quota (default 5 concurrent).

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -105,7 +105,17 @@ A **Conversation** is a running session of an Agent inside a sandboxed VM. It st
 4. Follow-up prompts go to `POST /api/conversations/:id/prompts`; a running turn can be interrupted (`POST .../interrupt`) and the whole conversation ended early (`POST .../terminate`)
 5. The sandbox exits when the conversation terminates, or when it is reclaimed for being idle (default 60 minutes with no turn activity) or for reaching its maximum lifetime (default 24 hours)
 
-Reclaiming ends the **sandbox**, not the conversation. The conversation stays resumable: the next prompt provisions a fresh sandbox and the runtime resumes the same session, so history is preserved and the only cost is the provisioning wait. Self-hosters can widen or disable both bounds with `SANDBOX_IDLE_TIMEOUT_MINUTES` and `SANDBOX_MAX_LIFETIME_HOURS` (`0` disables).
+Reclaiming ends the **sandbox**, not the conversation. The conversation stays resumable: the next prompt provisions a fresh sandbox and carries on. Self-hosters can widen or disable both bounds with `SANDBOX_IDLE_TIMEOUT_MINUTES` and `SANDBOX_MAX_LIFETIME_HOURS` (`0` disables).
+
+!!! warning "A reclaimed conversation loses the agent's context"
+
+    The stored transcript survives — every turn still renders, and the
+    conversation is still resumable. What does not survive is the *agent's*
+    memory of it: the runtime keeps its session inside the sandbox, so a fresh
+    sandbox means a fresh session, and the next turn answers without the
+    earlier ones. Expect to restate context after a reclaim, or keep the
+    conversation active. Raising `SANDBOX_IDLE_TIMEOUT_MINUTES` trades sandbox
+    cost against how often this happens.
 
 ### Status lifecycle
 


### PR DESCRIPTION
Option 1 from #649. It fixes nothing — it stops us claiming something we don't do.

## What was wrong

Three places told the user *"history is preserved"* after a sandbox reclaim:

- `Lifecycle.explain/1`, which is the message that reaches the conversation stream
- `docs/operations.md` — status lifecycle
- `docs/primitives.md` — the Conversation section

It's true of the transcript and false of the agent. The runtime keeps its session inside the sandbox, so a fresh sandbox is a fresh session and the next turn answers as though the conversation never happened. #649 has the live measurement: `claude --resume` → *No conversation found with session ID*, ACP `session/resume` → `-32002 Resource not found`.

## Why the promise made it worse

Every `log_events` row still renders, so the UI looks perfectly continuous. A user who has just been told nothing was lost reads the agent's amnesia as **the model being broken** — and files that, instead of restating their context and moving on.

The new message says what actually survived:

> Sandbox reclaimed after 60 minutes idle. Send another prompt to continue — the transcript above is kept, but the agent starts a fresh session and will not remember the earlier turns.

`docs/primitives.md` gets an admonition rather than a clause, since it's the page people read before they hit this.

## The docstring mattered too

`Lifecycle`'s moduledoc carried the claim as a **design argument**:

> "So the cost of reclaiming early is a re-provision on the next prompt, not lost work. That asymmetry is why the defaults can be fairly aggressive."

That's the shape of thing that quietly becomes load-bearing for the next decision — it already had, in 0014. Rewritten with what the measurement showed. The aggressive defaults survive the correction: reclaiming isn't free, but billing forever is worse.

## Not in this PR

The actual repair. Checkpoint-at-reclaim (option 2 in #649) is the real answer and needs a storage cost before anyone commits to it; transcript replay (option 3) is cheaper but lossy and spends tokens on every wake. #649 stays open.

`mix precommit` green: 2551 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)