### PR TITLE
fix: a checkpoint cannot cross sprites, so stop taking them (#654)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -662,8 +662,13 @@ defmodule Fountain.Conversations.ConversationServer do
   defp attempt_warm_start(sprite, %{checkpoint_id: id} = env, conv_id) do
     publish_stage(conv_id, "checkpoint_restore", "started", %{checkpoint_id: id})
 
+    # `restore_checkpoint/2` returns a bare `:ok` — `Fountain.Telemetry.span/3`
+    # unwraps the `{result, metadata}` pair it is given, so the `{:ok, _}` this
+    # used to match never occurred and a successful restore raised
+    # CaseClauseError. Latent only because #652 kept `checkpoint_id` nil, so
+    # this branch was unreachable.
     case Fountain.Conversations.Provisioning.restore_checkpoint(sprite, id) do
-      {:ok, _} ->
+      ok when ok == :ok or (is_tuple(ok) and elem(ok, 0) == :ok) ->
         publish_stage(conv_id, "checkpoint_restore", "done", %{checkpoint_id: id})
         :warm_started
 
@@ -712,8 +717,20 @@ defmodule Fountain.Conversations.ConversationServer do
   # above. A new caller passing anything else should crash loudly here rather
   # than silently skip checkpointing.
 
+  # Off by default since #654: a checkpoint id is scoped to the sprite that
+  # created it, and an environment's checkpoint is only ever restored into a
+  # *different* sprite (sandboxes are per-conversation, with a fresh name each
+  # time). Measured against the API — a fresh sprite lists only `Current`, and
+  # restoring another sprite's `v1` answers `checkpoint not found: checkpoint
+  # with path checkpoints/v1 not found`. So the warm start this feature exists
+  # for cannot happen, and creating checkpoints only spends time and storage to
+  # record an id that every later conversation will fail to restore.
+  #
+  # Left as a flag rather than deleted: if the platform grows a fork-from-
+  # checkpoint or create-sprite-from-checkpoint call, this becomes a one-line
+  # re-enable plus a restore that can finally work.
   defp checkpoint_creation_enabled? do
-    Application.get_env(:fountain, :checkpoint_creation_enabled, true)
+    Application.get_env(:fountain, :checkpoint_creation_enabled, false)
   end
 
   defp reattach(state, conv, sandbox, agent, env, secrets) do

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -197,8 +197,23 @@ defmodule Fountain.Conversations.Provisioning do
              ) do
           {:ok, stream} ->
             try do
-              Enum.each(stream, fn _ -> :ok end)
-              {:ok, %{outcome: :ok}}
+              # A failed restore is an ordinary *element* of the stream, not a
+              # raise and not an {:error, _} from the call — the library hands
+              # back `%Sprites.StreamMessage{type: "error", error: "..."}` and
+              # keeps going. Draining without looking therefore reported every
+              # failure as a success, and `attempt_warm_start/3` treats success
+              # as "the sandbox is already provisioned": it skips packages,
+              # repo clones, the setup script *and the network policy*. A
+              # restore that silently did nothing would hand the tenant an
+              # unprovisioned sandbox with no egress lockdown.
+              case Enum.find(stream, &stream_error?/1) do
+                nil ->
+                  {:ok, %{outcome: :ok}}
+
+                %{error: error} ->
+                  Logger.warning("checkpoint restore reported an error: #{inspect(error)}")
+                  {{:error, {:restore_failed, error}}, %{outcome: :failed}}
+              end
             rescue
               e ->
                 Logger.warning("checkpoint restore stream raised: #{inspect(e)}")
@@ -212,6 +227,10 @@ defmodule Fountain.Conversations.Provisioning do
       end
     )
   end
+
+  defp stream_error?(%{type: "error"}), do: true
+  defp stream_error?(%{error: error}) when is_binary(error) and error != "", do: true
+  defp stream_error?(_), do: false
 
   # ── packages ──────────────────────────────────────────────────────────────
 

--- a/apps/fountain/test/fountain/conversations/checkpoint_test.exs
+++ b/apps/fountain/test/fountain/conversations/checkpoint_test.exs
@@ -138,4 +138,50 @@ defmodule Fountain.Conversations.CheckpointTest do
       assert {:error, :no_env} = Provisioning.create_checkpoint(%{name: "s"}, nil)
     end
   end
+
+  describe "restore_checkpoint/2" do
+    test "an error carried in the stream is a failure, not a success" do
+      # The library reports a failed restore as an ordinary element —
+      # %StreamMessage{type: "error"} — and keeps going. Draining without
+      # looking reported it as success, and a "successful" restore makes
+      # run_provisioning_pipeline/5 skip packages, clones, the setup script and
+      # the network policy. See #654.
+      Mimic.stub(Sprites, :restore_checkpoint, fn _sprite, _id ->
+        {:ok,
+         [
+           %Sprites.StreamMessage{
+             type: "info",
+             data: "Restoring from checkpoint v1...",
+             error: nil
+           },
+           %Sprites.StreamMessage{
+             type: "error",
+             data: nil,
+             error: "Failed to restore checkpoint: checkpoint not found"
+           }
+         ]}
+      end)
+
+      assert {:error, {:restore_failed, _}} = Provisioning.restore_checkpoint(%{name: "s"}, "v1")
+    end
+
+    test "a clean stream is a success" do
+      Mimic.stub(Sprites, :restore_checkpoint, fn _sprite, _id ->
+        {:ok,
+         [
+           %Sprites.StreamMessage{type: "info", data: "Restoring...", error: nil},
+           %Sprites.StreamMessage{type: "complete", data: "restored", error: nil}
+         ]}
+      end)
+
+      # A bare :ok, not {:ok, _} — Telemetry.span/3 unwraps the pair. The
+      # caller used to match {:ok, _} and would have raised on success (#654).
+      assert :ok = Provisioning.restore_checkpoint(%{name: "s"}, "v1")
+    end
+
+    test "a missing id short-circuits" do
+      assert {:error, :no_checkpoint} = Provisioning.restore_checkpoint(%{name: "s"}, nil)
+      assert {:error, :no_checkpoint} = Provisioning.restore_checkpoint(%{name: "s"}, "")
+    end
+  end
 end


### PR DESCRIPTION
**Urgent-ish: this closes a hole #653 (mine, merged today) would otherwise open on the next deploy.** Nothing is broken on main *right now* because no environment has a checkpoint id yet.

## The finding

Checkpoint ids are scoped to the sprite that created them. Measured against the API today:

- a fresh sprite lists only `Current` — no `v1`
- restoring another sprite's `v1` → `Failed to restore checkpoint: ... checkpoint with path checkpoints/v1 not found: sql: no rows in result set`
- a marker file written before the checkpoint does not cross over

An environment's checkpoint is **only ever** restored into a different sprite — sandboxes are per-conversation with a fresh name each time — so the warm start this feature exists for cannot happen. #652 kept `environments.checkpoint_id` nil, which is the only reason this was never hit.

## Why that made #653 dangerous

With ids finally recorded, the *second* conversation on an environment takes the warm-start branch, and three further defects line up behind it:

1. **`restore_checkpoint/2` drained the stream without looking at it.** A failed restore is an ordinary element — `%StreamMessage{type: "error"}` — not a raise and not `{:error, _}`. Every failure was reported as success.
2. **`attempt_warm_start/3` treats success as "already provisioned"** and skips `install_packages`, `clone_repositories`, the setup script **and `apply_network_policy`**. A restore that silently did nothing would hand the tenant an unprovisioned sandbox *with no egress lockdown*.
3. It matched `{:ok, _}` against a function returning a bare `:ok` (`Telemetry.span/3` unwraps the pair), so a genuinely successful restore would have raised `CaseClauseError`.

Each was individually latent. Together with #653 they'd have become a live regression.

## This PR

- restore inspects the stream and fails on an error element
- the caller matches the shape the callee actually returns
- **checkpoint creation is off by default** — recording an id that every later conversation must fail to restore is churn with a storage bill

Left as a flag rather than deleted: if the platform grows fork-from-checkpoint or create-sprite-from-checkpoint, it's a one-line re-enable and a restore that can finally work. That's also exactly what #649 option 2 would need.

`mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)