### PR TITLE
feat: convert all four runtimes to ACP, and stop dropping the agent's model (#638, #639, #641)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1886,7 +1886,8 @@ defmodule Fountain.Conversations.ConversationServer do
                   start_acp_peer(command, prompt, mode, runtime_session_id,
                     cwd: cwd,
                     images: images,
-                    mcp_servers: Fountain.Runtimes.ACP.mcp_servers(agent)
+                    mcp_servers: Fountain.Runtimes.ACP.mcp_servers(agent),
+                    model: agent && Fountain.Runtimes.Model.id(agent.model)
                   )
                 else
                   {nil, nil}
@@ -2171,7 +2172,8 @@ defmodule Fountain.Conversations.ConversationServer do
         session_id: runtime_session_id,
         cwd: Keyword.get(opts, :cwd) || "/home/sprite",
         images: Keyword.get(opts, :images, []),
-        mcp_servers: Keyword.get(opts, :mcp_servers, [])
+        mcp_servers: Keyword.get(opts, :mcp_servers, []),
+        model: Keyword.get(opts, :model)
       )
 
     {peer, Process.monitor(peer)}

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1019,7 +1019,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # install would fail in a way that reads as a protocol bug.
   defp prepare_acp_adapter(sprite, agent, sprite_env) do
     if Fountain.Runtimes.ACP.enabled?(agent) do
-      Fountain.Runtimes.ACP.install(sprite, sprite_env)
+      Fountain.Runtimes.ACP.install(sprite, agent.runtime, sprite_env)
     else
       :ok
     end
@@ -1779,8 +1779,8 @@ defmodule Fountain.Conversations.ConversationServer do
     # not consulted at all on this path.
     {cmd, args, build_opts} =
       if acp? do
-        {c, a} = Fountain.Runtimes.ACP.command()
-        {c, a, stdin?: true}
+        {c, a} = Fountain.Runtimes.ACP.command(conv.runtime)
+        {c, a, stdin?: true, dir: Fountain.Runtimes.ACP.cwd(conv.runtime)}
       else
         state.runtime_module.build_command(agent, prompt, mode, runtime_session_id,
           images: image_paths

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -35,7 +35,13 @@ defmodule Fountain.Runtimes.ACP do
   only while one conversation ever runs per workspace — an invariant held by
   accident and asserted by no test. ACP names the session.
 
-  Codex and OpenCode also advertise both capabilities and are still to come.
+  Codex and OpenCode both advertise `loadSession` *and*
+  `sessionCapabilities.resume`, so they resume as cheaply as Claude does. What
+  differs is how ACP is reached: Codex through an adapter package we install
+  and pin, OpenCode through its own `acp` subcommand — which starts a local
+  HTTP server inside the sprite and drives it through opencode's SDK rather
+  than being a plain stdio peer. It satisfies the protocol; it is simply a
+  second process model to remember when something hangs.
 
   ## The adapter is pinned, and that is load-bearing
 
@@ -85,6 +91,31 @@ defmodule Fountain.Runtimes.ACP do
       package: nil,
       version: nil,
       cwd: "/tmp/gemini-workspace"
+    },
+    # Adapter, on the Codex App Server. The `zed-industries/codex-acp` that
+    # earlier drafts named is archived; this is its successor under the
+    # protocol org. Auth is unchanged: `Codex.prepare_sprite/3` still runs
+    # `codex login --with-api-key`, and OPENAI_API_KEY is still exported, so
+    # the adapter inherits whichever the CLI would have used.
+    "codex" => %{
+      bin: "codex-acp",
+      args: [],
+      package: "@agentclientprotocol/codex-acp",
+      version: "1.1.14",
+      cwd: "/home/sprite"
+    },
+    # Native: `opencode acp`. Heavier than the others — the subcommand starts a
+    # local HTTP server inside the sprite and drives it through opencode's own
+    # SDK client, rather than being a plain stdio peer. It satisfies the
+    # protocol, but it is a second process model to keep in mind when something
+    # hangs. Nothing to install here: `OpenCode.prepare_sprite/3` already bun-
+    # installs the binary and symlinks it onto PATH.
+    "opencode" => %{
+      bin: "opencode",
+      args: ["acp"],
+      package: nil,
+      version: nil,
+      cwd: "/tmp/opencode-workspace"
     }
   }
 
@@ -176,11 +207,12 @@ defmodule Fountain.Runtimes.ACP do
   @spec install(sprite :: any(), String.t(), [{String.t(), String.t()}]) :: :ok | {:error, term()}
   def install(sprite, runtime, sprite_env)
 
-  # Native ACP: the runtime ships in the sprite base image and speaks the
-  # protocol behind a flag. Nothing to install, and nothing we can pin — the
-  # version floor is whatever the image carries, which gate 1 recorded as an
-  # open exposure for three of the four runtimes.
-  def install(_sprite, runtime, _sprite_env) when runtime == "gemini", do: :ok
+  # Native ACP: the runtime speaks the protocol itself, and is already on the
+  # sprite — gemini from the base image, opencode from
+  # `OpenCode.prepare_sprite/3`'s bun install. Nothing to install, and for
+  # gemini nothing we can pin either: the version floor is whatever the image
+  # carries, which gate 1 recorded as an open exposure.
+  def install(_sprite, runtime, _sprite_env) when runtime in ["gemini", "opencode"], do: :ok
 
   def install(sprite, runtime, sprite_env) do
     bin = adapter_bin(runtime)

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -17,14 +17,25 @@ defmodule Fountain.Runtimes.ACP do
   turn and leaves the earlier ones rendering through the legacy path, which is
   exactly the A/B the gate asks for.
 
-  ## One runtime
+  ## Which runtimes
 
-  Claude only, and that is gate 1's answer rather than a convenience. Gemini
-  advertises `loadSession` and no `sessionCapabilities.resume`, and its
-  `session/load` replays the entire conversation before responding — under one
-  connection per turn that is the whole history re-streamed on every turn after
-  the first. Claude advertises both, and its `session/resume` does not replay.
-  Codex and OpenCode also advertise both and are gate 4's business.
+  Claude and Gemini, and the pair is deliberate: they are the two ends of the
+  resumption story gate 1 mapped.
+
+  Claude advertises `sessionCapabilities.resume`, so a turn costs a handshake
+  and nothing else. Gemini advertises only `loadSession`, and `session/load`
+  replays the entire conversation before responding — under one connection per
+  turn that is the whole history re-streamed on every turn after the first.
+  `Peer`'s replay-discard exists for exactly this, and Gemini is the runtime
+  that actually exercises it.
+
+  Converting Gemini is still worth it despite the replay, because its legacy
+  resume is the worst thing we ship: `gemini --resume` re-enters "the most
+  recent conversation in the workspace" (`gemini.ex:14-17`), which is correct
+  only while one conversation ever runs per workspace — an invariant held by
+  accident and asserted by no test. ACP names the session.
+
+  Codex and OpenCode also advertise both capabilities and are still to come.
 
   ## The adapter is pinned, and that is load-bearing
 
@@ -42,20 +53,68 @@ defmodule Fountain.Runtimes.ACP do
 
   alias Fountain.Agents.Agent
 
-  # Verified at gate 1 (2026-08-09): advertises `loadSession: true` and
-  # `sessionCapabilities.resume`, and its `resumeSession` reattaches without
-  # replaying while `loadSession` calls `replaySessionHistory`.
-  @adapter_package "@agentclientprotocol/claude-agent-acp"
-  @adapter_version "0.66.0"
-  @adapter_bin "claude-agent-acp"
+  # Per runtime: how ACP is reached, and where the agent should run.
+  #
+  # `package` nil means native support — the runtime speaks ACP itself and
+  # arrives with the sprite base image, so there is nothing to install and
+  # nothing we can pin. That is a real difference in exposure, not a
+  # convenience: an adapter we install is a supply-chain surface we version,
+  # and a native flag is a surface the image owner versions for us.
+  @adapters %{
+    # Verified at gate 1 (2026-08-09) and live on 2026-08-10: advertises
+    # `loadSession: true` and `sessionCapabilities.resume`; `resumeSession`
+    # reattaches without replaying while `loadSession` calls
+    # `replaySessionHistory`.
+    "claude" => %{
+      bin: "claude-agent-acp",
+      args: [],
+      package: "@agentclientprotocol/claude-agent-acp",
+      version: "0.66.0",
+      cwd: "/home/sprite"
+    },
+    # Native: `gemini --acp`. Advertises `loadSession: true` and **no**
+    # `sessionCapabilities`, so every turn after the first pays a full replay
+    # that `Peer` discards. The cwd mirrors `Fountain.Runtimes.Gemini`'s
+    # `@workdir` — gemini walks up from cwd looking for a `.git`, and
+    # `Gemini.prepare_sprite/3` git-inits exactly this directory. Pointing it
+    # at /home/sprite instead reintroduces the EACCES noise that workspace
+    # exists to avoid.
+    "gemini" => %{
+      bin: "gemini",
+      args: ["--acp"],
+      package: nil,
+      version: nil,
+      cwd: "/tmp/gemini-workspace"
+    }
+  }
 
-  @doc "The npm package and version this build is pinned to."
-  @spec adapter_spec() :: String.t()
-  def adapter_spec, do: "#{@adapter_package}@#{@adapter_version}"
+  @doc "Runtimes that can currently speak ACP."
+  @spec supported_runtimes() :: [String.t()]
+  def supported_runtimes, do: Map.keys(@adapters)
 
-  @doc "The executable name the pinned package installs."
-  @spec adapter_bin() :: String.t()
-  def adapter_bin, do: @adapter_bin
+  @doc "The npm package and version pinned for a runtime, or nil when native."
+  @spec adapter_spec(String.t()) :: String.t() | nil
+  def adapter_spec(runtime) do
+    case @adapters[runtime] do
+      %{package: nil} -> nil
+      %{package: pkg, version: version} -> "#{pkg}@#{version}"
+      _ -> nil
+    end
+  end
+
+  @doc "The executable a runtime's ACP mode is reached through."
+  @spec adapter_bin(String.t()) :: String.t() | nil
+  def adapter_bin(runtime), do: get_in(@adapters, [runtime, :bin])
+
+  @doc """
+  Where the agent runs.
+
+  ACP carries `cwd` in `session/new`, and it is the *agent's* working
+  directory rather than ours — a runtime that walks up from it looking for a
+  repo (gemini does) behaves differently depending on what we say here.
+  """
+  @spec cwd(String.t()) :: String.t()
+  def cwd(runtime), do: get_in(@adapters, [runtime, :cwd]) || "/home/sprite"
 
   @doc """
   Whether this turn should speak ACP.
@@ -65,8 +124,8 @@ defmodule Fountain.Runtimes.ACP do
   legacy path is not a failure mode, it is the default.
   """
   @spec enabled?(Agent.t() | nil) :: boolean()
-  def enabled?(%Agent{runtime: "claude", metadata: metadata}) when is_map(metadata) do
-    Map.get(metadata, "acp") == true
+  def enabled?(%Agent{runtime: runtime, metadata: metadata}) when is_map(metadata) do
+    Map.has_key?(@adapters, runtime) and Map.get(metadata, "acp") == true
   end
 
   def enabled?(_), do: false
@@ -80,8 +139,13 @@ defmodule Fountain.Runtimes.ACP do
   is the entire architectural change, and it is why this does not implement the
   `Fountain.Runtimes` behaviour.
   """
-  @spec command() :: {String.t(), [String.t()]}
-  def command, do: {@adapter_bin, []}
+  @spec command(String.t()) :: {String.t(), [String.t()]}
+  def command(runtime) do
+    case @adapters[runtime] do
+      %{bin: bin, args: args} -> {bin, args}
+      _ -> raise ArgumentError, "runtime #{inspect(runtime)} has no ACP adapter"
+    end
+  end
 
   @doc """
   Install the pinned adapter into a sprite.
@@ -109,17 +173,29 @@ defmodule Fountain.Runtimes.ACP do
   for the same reason it is there: `~` resolves against whatever `HOME` the
   caller happens to have.
   """
-  @spec install(sprite :: any(), [{String.t(), String.t()}]) :: :ok | {:error, term()}
-  def install(sprite, sprite_env) do
+  @spec install(sprite :: any(), String.t(), [{String.t(), String.t()}]) :: :ok | {:error, term()}
+  def install(sprite, runtime, sprite_env)
+
+  # Native ACP: the runtime ships in the sprite base image and speaks the
+  # protocol behind a flag. Nothing to install, and nothing we can pin — the
+  # version floor is whatever the image carries, which gate 1 recorded as an
+  # open exposure for three of the four runtimes.
+  def install(_sprite, runtime, _sprite_env) when runtime == "gemini", do: :ok
+
+  def install(sprite, runtime, sprite_env) do
+    bin = adapter_bin(runtime)
+    spec = adapter_spec(runtime)
+    version = get_in(@adapters, [runtime, :version])
+
     script = """
     set -e
-    want=#{@adapter_version}
-    bin=/home/sprite/.local/bin/#{@adapter_bin}
+    want=#{version}
+    bin=/home/sprite/.local/bin/#{bin}
     have=$("$bin" --version 2>/dev/null | tr -d '[:space:]' || true)
     if [ "$have" != "$want" ]; then
-      npm install -g --no-progress --silent #{adapter_spec()}
+      npm install -g --no-progress --silent #{spec}
       mkdir -p /home/sprite/.local/bin
-      ln -sf "$(npm prefix -g)/bin/#{@adapter_bin}" "$bin"
+      ln -sf "$(npm prefix -g)/bin/#{bin}" "$bin"
     fi
     "$bin" --version >/dev/null
     """

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -88,7 +88,9 @@ defmodule Fountain.Runtimes.ACP.Peer do
       pending: %{},
       phase: :initializing,
       replay_discard?: false,
-      capabilities: %{}
+      capabilities: %{},
+      auth_methods: [],
+      authenticated?: false
     ]
   end
 
@@ -210,9 +212,32 @@ defmodule Fountain.Runtimes.ACP.Peer do
     |> send_prompt()
   end
 
+  # Some agents open a session from ambient credentials but refuse to *load*
+  # one until told which auth method to use — gemini answers `session/load`
+  # with `-32000 Authentication required` while `session/new` on the same
+  # connection succeeds, so every turn after the first failed outright.
+  #
+  # Reactive rather than eager, on purpose: claude's adapter authenticates from
+  # the environment and never asks, and calling `authenticate` at it unprompted
+  # would be us guessing a method it did not require. We ask only when an agent
+  # says we must, and only once.
   defp handle_message({:error_response, id, error}, state) do
     {tag, state} = pop_pending(state, id)
-    fail(state, {:acp_error, tag, error})
+
+    if session_setup?(tag) and auth_error?(error) and not state.authenticated? and
+         auth_method(state) do
+      method = auth_method(state)
+      Logger.info("acp peer: #{tag} needs authentication; retrying with #{method}")
+
+      send_request(
+        %{state | authenticated?: true},
+        :authenticate,
+        "authenticate",
+        %{methodId: method}
+      )
+    else
+      fail(state, {:acp_error, tag, error})
+    end
   end
 
   # `session/request_permission` is the channel gate 3 exists to use. Gate 2
@@ -241,7 +266,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   defp handle_response(:initialize, result, state) do
     caps = Map.get(result, "agentCapabilities") || %{}
-    state = %{state | capabilities: caps}
+    state = %{state | capabilities: caps, auth_methods: Map.get(result, "authMethods") || []}
 
     # Labelled with the session-setup call we are about to make, not with the
     # server's idea of the mode: `kick_turn` persists a generated session id
@@ -283,10 +308,44 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # The model was pinned (or refused); either way the turn goes ahead.
   defp handle_response(:set_model, _result, state), do: send_prompt(state)
 
+  # Authenticated on demand; retry the session setup that provoked it.
+  defp handle_response(:authenticate, _result, state) do
+    case state.mode do
+      :run -> start_new_session(state)
+      :continue -> resume_session(state)
+    end
+  end
+
   defp handle_response(:prompt, result, state) do
     stop = Map.get(result, "stopReason") || "end_turn"
     report(state, {:done, stop})
     %{state | phase: :done}
+  end
+
+  # ── authentication ────────────────────────────────────────────────────────
+
+  defp session_setup?(tag), do: tag in [:new_session, :resume_session, :load_session]
+
+  defp auth_error?(%{"code" => -32_000}), do: true
+
+  defp auth_error?(%{"message" => message}) when is_binary(message),
+    do: String.contains?(String.downcase(message), "auth")
+
+  defp auth_error?(_), do: false
+
+  # Prefer a method naming an API key in its `_meta`: that is what an agent
+  # offers for "there is a key in the environment, use it", as against an
+  # interactive OAuth flow a headless sandbox can never complete.
+  defp auth_method(state) do
+    pick =
+      Enum.find(state.auth_methods, fn m ->
+        is_map(Map.get(m, "_meta")) and Map.has_key?(m["_meta"], "api-key")
+      end) || List.first(state.auth_methods)
+
+    case pick do
+      %{"id" => id} when is_binary(id) -> id
+      _ -> nil
+    end
   end
 
   # ── session setup ─────────────────────────────────────────────────────────
@@ -364,23 +423,34 @@ defmodule Fountain.Runtimes.ACP.Peer do
       is_nil(state.model) or state.model == "" ->
         send_prompt(state)
 
-      not model_configurable?(result) ->
+      model_configurable?(result) ->
+        send_request(%{state | phase: :setting_model}, :set_model, "session/set_config_option", %{
+          sessionId: state.session_id,
+          configId: "model",
+          value: state.model
+        })
+
+      Map.has_key?(result, "models") ->
+        send_request(%{state | phase: :setting_model}, :set_model, "session/set_model", %{
+          sessionId: state.session_id,
+          modelId: state.model
+        })
+
+      true ->
         state
         |> persist("stderr", [
           "fountain: this runtime does not expose model selection over ACP; ",
           "#{state.model} was not applied and its default is in use\n"
         ])
         |> send_prompt()
-
-      true ->
-        send_request(%{state | phase: :setting_model}, :set_model, "session/set_config_option", %{
-          sessionId: state.session_id,
-          configId: "model",
-          value: state.model
-        })
     end
   end
 
+  # Two shapes in the wild, both measured against live agents on 2026-08-10.
+  # Claude's adapter advertises `configOptions` and takes
+  # `session/set_config_option` with `configId: "model"`; gemini advertises
+  # `models` and implements ACP's own `session/set_model` with a `modelId`.
+  # Neither is a superset of the other, so the session response decides.
   defp model_configurable?(result) do
     case Map.get(result, "configOptions") do
       options when is_list(options) -> Enum.any?(options, &(Map.get(&1, "id") == "model"))

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -273,11 +273,17 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   # ── session setup ─────────────────────────────────────────────────────────
 
+  # No client-proposed `sessionId`. The spec is explicit that the *agent*
+  # "MUST respond with a unique Session ID", and we overwrite whatever we sent
+  # with what comes back anyway — so proposing one was decoration that a
+  # stricter agent could reject on schema grounds.
   defp start_new_session(state) do
-    params = %{cwd: state.cwd, mcpServers: state.mcp_servers}
-    params = if state.session_id, do: Map.put(params, :sessionId, state.session_id), else: params
-
-    send_request(%{state | phase: :starting_session}, :new_session, "session/new", params)
+    send_request(
+      %{state | phase: :starting_session},
+      :new_session,
+      "session/new",
+      %{cwd: state.cwd, mcpServers: state.mcp_servers}
+    )
   end
 
   defp resume_session(%State{session_id: nil} = state) do

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -212,15 +212,9 @@ defmodule Fountain.Runtimes.ACP.Peer do
     |> send_prompt()
   end
 
-  # Some agents open a session from ambient credentials but refuse to *load*
-  # one until told which auth method to use — gemini answers `session/load`
-  # with `-32000 Authentication required` while `session/new` on the same
-  # connection succeeds, so every turn after the first failed outright.
-  #
-  # Reactive rather than eager, on purpose: claude's adapter authenticates from
-  # the environment and never asks, and calling `authenticate` at it unprompted
-  # would be us guessing a method it did not require. We ask only when an agent
-  # says we must, and only once.
+  # Backstop for an agent that advertises no auth method at `initialize` and
+  # then refuses anyway. The eager path above covers everything measured; this
+  # covers being wrong about that, once, rather than failing the turn outright.
   defp handle_message({:error_response, id, error}, state) do
     {tag, state} = pop_pending(state, id)
 
@@ -280,9 +274,27 @@ defmodule Fountain.Runtimes.ACP.Peer do
       {:handshake_ms, System.monotonic_time(:millisecond) - state.started_mono, method}
     )
 
-    case state.mode do
-      :run -> start_new_session(state)
-      :continue -> resume_session(state)
+    # Authenticate *before* opening a session, when the agent offers a method.
+    #
+    # This was reactive at first — authenticate only when a call is refused —
+    # and that is too late to be useful. Gemini will happily open a session
+    # from ambient credentials without being told which auth method to use, but
+    # it does not *persist* one: the next turn's `session/load` answers "No
+    # previous sessions found for this project", so the retry authenticates
+    # correctly and then finds nothing to load. The session has to be created
+    # under a chosen method to exist at all.
+    #
+    # Safe to do eagerly because an agent that needs nothing advertises
+    # nothing: claude's adapter returns `authMethods: []` (measured), so
+    # `auth_method/1` is nil and this is skipped entirely for it.
+    case auth_method(state) do
+      nil ->
+        start_session(state)
+
+      chosen ->
+        send_request(%{state | authenticated?: true}, :authenticate, "authenticate", %{
+          methodId: chosen
+        })
     end
   end
 
@@ -308,13 +320,8 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # The model was pinned (or refused); either way the turn goes ahead.
   defp handle_response(:set_model, _result, state), do: send_prompt(state)
 
-  # Authenticated on demand; retry the session setup that provoked it.
-  defp handle_response(:authenticate, _result, state) do
-    case state.mode do
-      :run -> start_new_session(state)
-      :continue -> resume_session(state)
-    end
-  end
+  # Authenticated; open (or reopen) the session.
+  defp handle_response(:authenticate, _result, state), do: start_session(state)
 
   defp handle_response(:prompt, result, state) do
     stop = Map.get(result, "stopReason") || "end_turn"
@@ -349,6 +356,9 @@ defmodule Fountain.Runtimes.ACP.Peer do
   end
 
   # ── session setup ─────────────────────────────────────────────────────────
+
+  defp start_session(%State{mode: :run} = state), do: start_new_session(state)
+  defp start_session(%State{mode: :continue} = state), do: resume_session(state)
 
   # No client-proposed `sessionId`. The spec is explicit that the *agent*
   # "MUST respond with a unique Session ID", and we overwrite whatever we sent

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -82,6 +82,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
       :started_mono,
       images: [],
       mcp_servers: [],
+      model: nil,
       buffer: "",
       next_id: 1,
       pending: %{},
@@ -130,6 +131,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
       cwd: Keyword.get(opts, :cwd, "/home/sprite"),
       images: Keyword.get(opts, :images, []),
       mcp_servers: Keyword.get(opts, :mcp_servers, []),
+      model: Keyword.get(opts, :model),
       started_mono: System.monotonic_time(:millisecond)
     }
 
@@ -196,6 +198,18 @@ defmodule Fountain.Runtimes.ACP.Peer do
     end
   end
 
+  # A model we could not pin is not worth failing a turn over — but it is worth
+  # the tenant seeing, because the alternative is their agent quietly running a
+  # model they did not choose. It lands in the transcript as ordinary output.
+  defp handle_message({:error_response, _id, error}, %State{phase: :setting_model} = state) do
+    state
+    |> persist("stderr", [
+      "fountain: could not select model #{state.model} over ACP (#{inspect(error)}); ",
+      "the runtime's default is in use for this turn\n"
+    ])
+    |> send_prompt()
+  end
+
   defp handle_message({:error_response, id, error}, state) do
     {tag, state} = pop_pending(state, id)
     fail(state, {:acp_error, tag, error})
@@ -251,19 +265,23 @@ defmodule Fountain.Runtimes.ACP.Peer do
     case Map.get(result, "sessionId") do
       id when is_binary(id) ->
         report(state, {:session, id})
-        send_prompt(%{state | session_id: id})
+        pin_model_then_prompt(%{state | session_id: id}, result)
 
       _ ->
         fail(state, {:acp_no_session_id, result})
     end
   end
 
-  defp handle_response(:resume_session, _result, state), do: send_prompt(state)
+  defp handle_response(:resume_session, result, state),
+    do: pin_model_then_prompt(state, result)
 
-  defp handle_response(:load_session, _result, state) do
+  defp handle_response(:load_session, result, state) do
     # The replay is over; everything from here is this turn's.
-    send_prompt(%{state | replay_discard?: false})
+    pin_model_then_prompt(%{state | replay_discard?: false}, result)
   end
+
+  # The model was pinned (or refused); either way the turn goes ahead.
+  defp handle_response(:set_model, _result, state), do: send_prompt(state)
 
   defp handle_response(:prompt, result, state) do
     stop = Map.get(result, "stopReason") || "end_turn"
@@ -329,6 +347,44 @@ defmodule Fountain.Runtimes.ACP.Peer do
       supports?(state, ["sessionCapabilities", "resume"]) -> "session/resume"
       Map.get(state.capabilities, "loadSession") == true -> "session/load"
       true -> "none"
+    end
+  end
+
+  # ACP carries no model in `session/new`. The runtime's own default therefore
+  # wins unless the client says otherwise, which would silently ignore
+  # `agent.model` — the field the tenant actually configured, and for a
+  # multi-provider runtime the entire configuration.
+  #
+  # The mechanism is `session/set_config_option` with `configId: "model"`, and
+  # the session response advertises which options exist. We only send it when
+  # the agent said it has one, so a runtime with no model concept is left alone
+  # rather than being handed a method it never offered.
+  defp pin_model_then_prompt(state, result) do
+    cond do
+      is_nil(state.model) or state.model == "" ->
+        send_prompt(state)
+
+      not model_configurable?(result) ->
+        state
+        |> persist("stderr", [
+          "fountain: this runtime does not expose model selection over ACP; ",
+          "#{state.model} was not applied and its default is in use\n"
+        ])
+        |> send_prompt()
+
+      true ->
+        send_request(%{state | phase: :setting_model}, :set_model, "session/set_config_option", %{
+          sessionId: state.session_id,
+          configId: "model",
+          value: state.model
+        })
+    end
+  end
+
+  defp model_configurable?(result) do
+    case Map.get(result, "configOptions") do
+      options when is_list(options) -> Enum.any?(options, &(Map.get(&1, "id") == "model"))
+      _ -> false
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -112,20 +112,16 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       refute ACP.enabled?(insert_agent(user_id: user.id, runtime: "claude"))
     end
 
-    test "only applies to a converted runtime" do
+    test "applies to every converted runtime" do
       user = insert_verified_user()
 
-      # Codex and OpenCode advertise the capabilities but have no adapter entry
-      # yet. Flagging one is a no-op rather than an error: the legacy path is
-      # the default, not a failure mode.
-      codex = insert_agent(user_id: user.id, runtime: "codex", metadata: %{"acp" => true})
-      refute ACP.enabled?(codex)
+      for runtime <- ACP.supported_runtimes() do
+        agent = insert_agent(user_id: user.id, runtime: runtime, metadata: %{"acp" => true})
+        assert ACP.enabled?(agent), "expected #{runtime} to be ACP-enabled"
+      end
 
-      assert ACP.enabled?(acp_agent(user))
-
-      assert ACP.enabled?(
-               insert_agent(user_id: user.id, runtime: "gemini", metadata: %{"acp" => true})
-             )
+      # All four are converted now, so the flag itself is the only off switch.
+      refute ACP.enabled?(insert_agent(user_id: user.id, runtime: "claude"))
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -12,8 +12,8 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
   alias Fountain.Runtimes.ACP
 
-  defp acp_agent(user) do
-    insert_agent(user_id: user.id, runtime: "claude", metadata: %{"acp" => true})
+  defp acp_agent(user, runtime \\ "claude") do
+    insert_agent(user_id: user.id, runtime: runtime, metadata: %{"acp" => true})
   end
 
   # Starts a server whose turn speaks ACP, with the sprite side wired to this
@@ -112,16 +112,20 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       refute ACP.enabled?(insert_agent(user_id: user.id, runtime: "claude"))
     end
 
-    test "only applies to a runtime gate 1 cleared" do
+    test "only applies to a converted runtime" do
       user = insert_verified_user()
 
-      # Gemini advertises loadSession and no resume, so every turn after the
-      # first would replay the whole conversation. Flagging it is a no-op rather
-      # than an error: the legacy path is the default, not a failure mode.
-      gemini = insert_agent(user_id: user.id, runtime: "gemini", metadata: %{"acp" => true})
-      refute ACP.enabled?(gemini)
+      # Codex and OpenCode advertise the capabilities but have no adapter entry
+      # yet. Flagging one is a no-op rather than an error: the legacy path is
+      # the default, not a failure mode.
+      codex = insert_agent(user_id: user.id, runtime: "codex", metadata: %{"acp" => true})
+      refute ACP.enabled?(codex)
 
       assert ACP.enabled?(acp_agent(user))
+
+      assert ACP.enabled?(
+               insert_agent(user_id: user.id, runtime: "gemini", metadata: %{"acp" => true})
+             )
     end
   end
 
@@ -135,7 +139,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
     test "runs the pinned adapter rather than the claude CLI", %{pid: pid} do
       assert_receive {:spawned, cmd, _args, opts}
-      assert cmd == ACP.adapter_bin()
+      assert cmd == ACP.adapter_bin("claude")
       assert opts[:stdin] == true
     end
 
@@ -389,6 +393,123 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       settle(pid)
 
       refute_receive {:fs_write, "/tmp/aod_turn_" <> _}, 100
+    end
+  end
+
+  # A gemini conversation whose first turn already happened: the session id is
+  # persisted, so the server computes mode :continue and the peer resumes.
+  # Built fresh rather than restarted, because a second server for a
+  # conversation whose sandbox is already `ready` takes the reattach path.
+  defp resumed_gemini_turn(shape \\ :bare) do
+    user = insert_verified_user()
+    agent = acp_agent(user, "gemini")
+    conv = insert_conversation(agent: agent, user_id: user.id, runtime: "gemini")
+    {:ok, conv} = Conversations.update_conversation(conv, %{runtime_session_id: "gem-1"})
+    {pid, ref} = start_acp_turn(conv)
+
+    case shape do
+      :with_conv -> {conv, pid, ref}
+      :bare -> {pid, ref}
+    end
+  end
+
+  describe "gemini" do
+    setup do
+      user = insert_verified_user()
+      agent = acp_agent(user, "gemini")
+      conv = insert_conversation(agent: agent, user_id: user.id, runtime: "gemini")
+      {pid, ref} = start_acp_turn(conv)
+      {:ok, conv: conv, pid: pid, ref: ref}
+    end
+
+    test "spawns the native flag in the workspace its runtime module git-inits", %{pid: pid} do
+      assert_receive {:spawned, cmd, args, opts}
+      assert cmd == "gemini"
+      assert args == ["--acp"]
+
+      # gemini walks up from cwd looking for a .git. /home/sprite is where the
+      # EACCES noise comes from, and Gemini.prepare_sprite/3 prepares exactly
+      # this directory.
+      assert opts[:dir] == "/tmp/gemini-workspace"
+
+      _ = next_write()
+      GenServer.stop(pid)
+    end
+
+    test "session/new carries the same cwd the process was spawned in", %{pid: pid, ref: ref} do
+      %{"id" => init_id, "method" => "initialize"} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+
+      assert %{"method" => "session/new", "params" => params} = next_write()
+      assert params["cwd"] == "/tmp/gemini-workspace"
+
+      GenServer.stop(pid)
+    end
+
+    test "session/new proposes no session id — the agent assigns it", %{pid: pid, ref: ref} do
+      # The spec says the *agent* MUST respond with a unique id, and we persist
+      # whatever comes back. Proposing one was decoration a stricter agent
+      # could reject on schema grounds.
+      %{"id" => init_id} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+
+      assert %{"method" => "session/new", "params" => params} = next_write()
+      refute Map.has_key?(params, "sessionId")
+
+      GenServer.stop(pid)
+    end
+  end
+
+  # Separate describe on purpose: these build their own conversation, and the
+  # gemini setup above would start a second server writing into the same
+  # mailbox, so every assertion would read the wrong connection's traffic.
+  describe "gemini, turn 2" do
+    test "turn 2 uses session/load, because gemini advertises no resume" do
+      {pid, ref} = resumed_gemini_turn()
+
+      %{"id" => init_id} = next_write()
+      # Exactly what gemini's dispatcher advertises: loadSession and no
+      # sessionCapabilities block at all.
+      reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+
+      decoded = next_write()
+      assert decoded["method"] == "session/load"
+      assert decoded["params"]["sessionId"] == "gem-1"
+
+      GenServer.stop(pid)
+    end
+
+    test "the replay gemini sends before session/load returns is discarded" do
+      # This is the cost of having no `resume`: the whole conversation arrives
+      # again on every turn after the first. We already hold it as log_events,
+      # so persisting it would duplicate the transcript into the DB and onto
+      # the SSE stream, every turn, for the life of the conversation.
+      {conv, pid, ref} = resumed_gemini_turn(:with_conv)
+
+      %{"id" => init_id} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+      %{"id" => load_id, "method" => "session/load"} = next_write()
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "agent_message_chunk",
+        "content" => %{"type" => "text", "text" => "REPLAYED HISTORY"}
+      })
+
+      reply(pid, ref, load_id, %{})
+      %{"method" => "session/prompt"} = next_write()
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "agent_message_chunk",
+        "content" => %{"type" => "text", "text" => "FRESH ANSWER"}
+      })
+
+      events = Conversations._unsafe_list_log_events(conv.id)
+      acp = Enum.filter(events, &(&1.stream == "acp"))
+
+      assert Enum.any?(acp, &(&1.data =~ "FRESH ANSWER"))
+      refute Enum.any?(acp, &(&1.data =~ "REPLAYED HISTORY"))
+
+      GenServer.stop(pid)
     end
   end
 end

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -525,48 +525,67 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       )
     end
 
-    test "authenticates and retries when session/load is refused", ctx do
-      pid = start_peer(ctx, mode: :continue, session_id: "gem-1")
+    test "authenticates before opening a session, not after being refused", ctx do
+      # Reactive was too late. Gemini opens a session from ambient credentials
+      # without being told a method, but does not *persist* one — the next
+      # turn's session/load then answers "No previous sessions found for this
+      # project", so the retry authenticates correctly and finds nothing.
+      # Measured live 2026-08-10.
+      pid = start_peer(ctx, [])
       init_with_auth(pid, @gemini_auth)
-
-      %{"id" => load_id, "method" => "session/load"} = next_write()
-      refuse(pid, load_id, "Authentication required")
 
       assert %{"method" => "authenticate", "id" => auth_id, "params" => params} = next_write()
 
       # The api-key method, not the OAuth one: a headless sandbox can never
-      # complete an interactive Google login.
+      # complete an interactive Google login, and gemini lists oauth first.
       assert params["methodId"] == "gemini-api-key"
 
       send_response(pid, auth_id, %{})
 
-      # And the setup that provoked it runs again.
-      assert %{"method" => "session/load"} = next_write()
+      # Only then is the session opened.
+      assert %{"method" => "session/new"} = next_write()
+    end
+
+    test "an agent advertising no methods is never sent authenticate", ctx do
+      # claude's adapter returns authMethods: [] (measured), so this must be a
+      # complete no-op for it rather than a guessed method.
+      pid = start_peer(ctx, [])
+      init_with_auth(pid, [])
+
+      assert %{"method" => "session/new"} = next_write()
     end
 
     test "does not authenticate a second time", ctx do
-      # An agent that refuses twice is refusing for a reason authentication
-      # will not fix; looping would hold the turn open indefinitely.
+      # An agent that refuses after we have already authenticated is refusing
+      # for a reason authentication will not fix; looping would hold the turn
+      # open indefinitely.
       pid = start_peer(ctx, mode: :continue, session_id: "gem-1")
       init_with_auth(pid, @gemini_auth)
 
+      %{"id" => auth_id, "method" => "authenticate"} = next_write()
+      send_response(pid, auth_id, %{})
       %{"id" => load_id} = next_write()
       refuse(pid, load_id, "Authentication required")
-      %{"id" => auth_id} = next_write()
-      send_response(pid, auth_id, %{})
-      %{"id" => load_id2} = next_write()
-      refuse(pid, load_id2, "Authentication required")
 
       assert_receive {:acp, _ref, {:failed, {:acp_error, :load_session, _}}}
     end
 
-    test "an agent advertising no methods just fails", ctx do
+    test "the reactive backstop still covers an agent that advertised nothing", ctx do
+      # Eager covers everything measured; this covers being wrong about that,
+      # once, rather than failing the turn outright.
       pid = start_peer(ctx, mode: :continue, session_id: "gem-1")
-      init_with_auth(pid, [])
 
-      %{"id" => load_id} = next_write()
+      %{"id" => init_id} = next_write()
+
+      send_response(pid, init_id, %{
+        "agentCapabilities" => %{"loadSession" => true},
+        "authMethods" => []
+      })
+
+      %{"id" => load_id, "method" => "session/load"} = next_write()
       refuse(pid, load_id, "Authentication required")
 
+      # Nothing to pick, so it fails rather than inventing a method.
       assert_receive {:acp, _ref, {:failed, {:acp_error, :load_session, _}}}
     end
 
@@ -574,6 +593,8 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       pid = start_peer(ctx, mode: :continue, session_id: "gem-1")
       init_with_auth(pid, @gemini_auth)
 
+      %{"id" => auth_id, "method" => "authenticate"} = next_write()
+      send_response(pid, auth_id, %{})
       %{"id" => load_id} = next_write()
 
       Peer.stdout(

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -414,4 +414,81 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
 
     assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}, 1_000
   end
+
+  describe "model selection" do
+    # ACP carries no model in session/new, so without this the runtime's own
+    # default silently wins over the model the tenant configured — and for a
+    # multi-provider runtime that is the entire configuration.
+    defp caps_with_model_option,
+      do: %{"sessionId" => "s", "configOptions" => [%{"id" => "model"}]}
+
+    test "pins the configured model when the agent advertises the option", ctx do
+      pid = start_peer(ctx, model: "claude-sonnet-4-6")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, caps_with_model_option())
+
+      assert %{"method" => "session/set_config_option", "id" => set_id, "params" => params} =
+               next_write()
+
+      assert params["configId"] == "model"
+      assert params["value"] == "claude-sonnet-4-6"
+      assert params["sessionId"] == "s"
+
+      send_response(pid, set_id, %{})
+      assert %{"method" => "session/prompt"} = next_write()
+    end
+
+    test "says so in the transcript when the runtime has no model option", ctx do
+      # Silently running someone else's model is the failure mode this whole
+      # campaign keeps turning up. Not fatal, but not invisible either.
+      pid = start_peer(ctx, model: "gemini-2.5-pro")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+
+      assert_receive {:acp, _ref, {:lines, "stderr", msg}}
+      assert msg =~ "does not expose model selection"
+      assert msg =~ "gemini-2.5-pro"
+
+      assert %{"method" => "session/prompt"} = next_write()
+    end
+
+    test "a refused model is reported but does not fail the turn", ctx do
+      pid = start_peer(ctx, model: "not-a-real-model")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, caps_with_model_option())
+      %{"id" => set_id} = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => set_id,
+          "error" => %{"code" => -32_602, "message" => "Invalid value for config option model"}
+        }) <> "\n"
+      )
+
+      assert_receive {:acp, _ref, {:lines, "stderr", msg}}
+      assert msg =~ "could not select model"
+
+      # The turn still runs.
+      assert %{"method" => "session/prompt"} = next_write()
+      refute_receive {:acp, _ref, {:failed, _}}, 100
+    end
+
+    test "no configured model means no round trip at all", ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, caps_with_model_option())
+
+      assert %{"method" => "session/prompt"} = next_write()
+    end
+  end
 end

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -491,4 +491,125 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       assert %{"method" => "session/prompt"} = next_write()
     end
   end
+
+  describe "authentication on demand" do
+    # gemini opens a session from ambient credentials but answers session/load
+    # with -32000 "Authentication required", so every turn after the first
+    # failed outright until the peer learned to authenticate. Measured live on
+    # 2026-08-10; the method ids below are gemini's own.
+    @gemini_auth [
+      %{"id" => "oauth-personal", "name" => "Log in with Google"},
+      %{"id" => "gemini-api-key", "name" => "Gemini API key", "_meta" => %{"api-key" => %{}}},
+      %{"id" => "vertex-ai", "name" => "Vertex AI"}
+    ]
+
+    defp init_with_auth(pid, methods) do
+      %{"id" => init_id} = next_write()
+
+      send_response(pid, init_id, %{
+        "agentCapabilities" => %{"loadSession" => true},
+        "authMethods" => methods
+      })
+
+      init_id
+    end
+
+    defp refuse(pid, id, message) do
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "error" => %{"code" => -32_000, "message" => message}
+        }) <> "\n"
+      )
+    end
+
+    test "authenticates and retries when session/load is refused", ctx do
+      pid = start_peer(ctx, mode: :continue, session_id: "gem-1")
+      init_with_auth(pid, @gemini_auth)
+
+      %{"id" => load_id, "method" => "session/load"} = next_write()
+      refuse(pid, load_id, "Authentication required")
+
+      assert %{"method" => "authenticate", "id" => auth_id, "params" => params} = next_write()
+
+      # The api-key method, not the OAuth one: a headless sandbox can never
+      # complete an interactive Google login.
+      assert params["methodId"] == "gemini-api-key"
+
+      send_response(pid, auth_id, %{})
+
+      # And the setup that provoked it runs again.
+      assert %{"method" => "session/load"} = next_write()
+    end
+
+    test "does not authenticate a second time", ctx do
+      # An agent that refuses twice is refusing for a reason authentication
+      # will not fix; looping would hold the turn open indefinitely.
+      pid = start_peer(ctx, mode: :continue, session_id: "gem-1")
+      init_with_auth(pid, @gemini_auth)
+
+      %{"id" => load_id} = next_write()
+      refuse(pid, load_id, "Authentication required")
+      %{"id" => auth_id} = next_write()
+      send_response(pid, auth_id, %{})
+      %{"id" => load_id2} = next_write()
+      refuse(pid, load_id2, "Authentication required")
+
+      assert_receive {:acp, _ref, {:failed, {:acp_error, :load_session, _}}}
+    end
+
+    test "an agent advertising no methods just fails", ctx do
+      pid = start_peer(ctx, mode: :continue, session_id: "gem-1")
+      init_with_auth(pid, [])
+
+      %{"id" => load_id} = next_write()
+      refuse(pid, load_id, "Authentication required")
+
+      assert_receive {:acp, _ref, {:failed, {:acp_error, :load_session, _}}}
+    end
+
+    test "a non-auth error is not retried as an auth problem", ctx do
+      pid = start_peer(ctx, mode: :continue, session_id: "gem-1")
+      init_with_auth(pid, @gemini_auth)
+
+      %{"id" => load_id} = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => load_id,
+          "error" => %{"code" => -32_602, "message" => "Session not found"}
+        }) <> "\n"
+      )
+
+      assert_receive {:acp, _ref, {:failed, {:acp_error, :load_session, _}}}
+    end
+  end
+
+  describe "model selection, second shape" do
+    test "uses session/set_model when the agent advertises models", ctx do
+      # gemini exposes `models` in the session response and implements ACP's
+      # own session/set_model; claude's adapter exposes `configOptions` and
+      # takes session/set_config_option. Neither is a superset of the other.
+      pid = start_peer(ctx, model: "gemini-flash-latest")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+
+      send_response(pid, new_id, %{
+        "sessionId" => "s",
+        "models" => %{"availableModels" => [], "currentModelId" => "x"}
+      })
+
+      assert %{"method" => "session/set_model", "id" => set_id, "params" => params} = next_write()
+      assert params["modelId"] == "gemini-flash-latest"
+      assert params["sessionId"] == "s"
+
+      send_response(pid, set_id, %{})
+      assert %{"method" => "session/prompt"} = next_write()
+    end
+  end
 end

--- a/apps/fountain/test/fountain/runtimes/acp_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp_test.exs
@@ -7,12 +7,19 @@ defmodule Fountain.Runtimes.ACPTest do
   defp agent(attrs), do: struct(Agent, attrs)
 
   describe "enabled?/1" do
-    test "requires both the flag and a runtime gate 1 cleared" do
+    test "requires both the flag and a converted runtime" do
       assert ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => true}))
+      assert ACP.enabled?(agent(runtime: "gemini", metadata: %{"acp" => true}))
 
       refute ACP.enabled?(agent(runtime: "claude", metadata: %{}))
-      refute ACP.enabled?(agent(runtime: "gemini", metadata: %{"acp" => true}))
       refute ACP.enabled?(nil)
+    end
+
+    test "an unconverted runtime ignores the flag rather than erroring" do
+      # Codex and OpenCode both advertise the capabilities but have no adapter
+      # entry yet. The legacy path is the default, not a failure mode.
+      refute ACP.enabled?(agent(runtime: "codex", metadata: %{"acp" => true}))
+      refute ACP.enabled?(agent(runtime: "opencode", metadata: %{"acp" => true}))
     end
 
     test "a truthy-looking value that is not true does not enable it" do
@@ -126,12 +133,39 @@ defmodule Fountain.Runtimes.ACPTest do
     end
   end
 
-  describe "the pin" do
-    test "names an exact version, never a range or a tag" do
+  describe "per-runtime launch" do
+    test "claude runs an installed adapter, pinned to an exact version" do
       # An unpinned adapter can stop advertising sessionCapabilities.resume in a
       # point release, which downgrades every conversation to a full history
       # replay per turn with no error anywhere.
-      assert ACP.adapter_spec() =~ ~r{^@agentclientprotocol/claude-agent-acp@\d+\.\d+\.\d+$}
+      assert ACP.adapter_bin("claude") == "claude-agent-acp"
+      assert {"claude-agent-acp", []} = ACP.command("claude")
+
+      assert ACP.adapter_spec("claude") =~
+               ~r{^@agentclientprotocol/claude-agent-acp@\d+\.\d+\.\d+$}
+    end
+
+    test "gemini speaks ACP natively, so there is nothing to pin" do
+      assert {"gemini", ["--acp"]} = ACP.command("gemini")
+      assert is_nil(ACP.adapter_spec("gemini"))
+    end
+
+    test "gemini runs in the workspace its own runtime module git-inits" do
+      # gemini walks up from cwd looking for a .git; pointing it at
+      # /home/sprite reintroduces the EACCES noise the workspace exists to
+      # avoid, and leaves MemoryDiscovery crawling /home.
+      assert ACP.cwd("gemini") == "/tmp/gemini-workspace"
+      assert ACP.cwd("claude") == "/home/sprite"
+    end
+
+    test "an unknown runtime raises rather than spawning something arbitrary" do
+      assert_raise ArgumentError, fn -> ACP.command("codex") end
+    end
+
+    test "a native runtime needs no install" do
+      # No Sprites stub here on purpose: if this tried to shell out, the test
+      # would fail rather than quietly pass.
+      assert :ok = ACP.install(%{name: "s"}, "gemini", [])
     end
   end
 end

--- a/apps/fountain/test/fountain/runtimes/acp_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp_test.exs
@@ -15,11 +15,18 @@ defmodule Fountain.Runtimes.ACPTest do
       refute ACP.enabled?(nil)
     end
 
-    test "an unconverted runtime ignores the flag rather than erroring" do
-      # Codex and OpenCode both advertise the capabilities but have no adapter
-      # entry yet. The legacy path is the default, not a failure mode.
-      refute ACP.enabled?(agent(runtime: "codex", metadata: %{"acp" => true}))
-      refute ACP.enabled?(agent(runtime: "opencode", metadata: %{"acp" => true}))
+    test "every supported runtime honours the flag" do
+      for runtime <- ACP.supported_runtimes() do
+        assert ACP.enabled?(agent(runtime: runtime, metadata: %{"acp" => true})),
+               "expected #{runtime} to be ACP-enabled"
+
+        refute ACP.enabled?(agent(runtime: runtime, metadata: %{}))
+      end
+    end
+
+    test "a runtime with no adapter entry ignores the flag rather than erroring" do
+      # The legacy path is the default, not a failure mode.
+      refute ACP.enabled?(agent(runtime: "somethingelse", metadata: %{"acp" => true}))
     end
 
     test "a truthy-looking value that is not true does not enable it" do
@@ -158,8 +165,26 @@ defmodule Fountain.Runtimes.ACPTest do
       assert ACP.cwd("claude") == "/home/sprite"
     end
 
+    test "codex runs a pinned adapter; opencode runs its own subcommand" do
+      assert {"codex-acp", []} = ACP.command("codex")
+      assert ACP.adapter_spec("codex") =~ ~r{^@agentclientprotocol/codex-acp@\d+\.\d+\.\d+$}
+
+      # opencode's `acp` subcommand starts a local HTTP server inside the
+      # sprite and drives it through its own SDK — a heavier process model than
+      # the others, but nothing for us to install: OpenCode.prepare_sprite/3
+      # already bun-installs it.
+      assert {"opencode", ["acp"]} = ACP.command("opencode")
+      assert is_nil(ACP.adapter_spec("opencode"))
+      assert :ok = ACP.install(%{name: "s"}, "opencode", [])
+    end
+
+    test "each runtime runs where its own runtime module prepared" do
+      assert ACP.cwd("opencode") == "/tmp/opencode-workspace"
+      assert ACP.cwd("codex") == "/home/sprite"
+    end
+
     test "an unknown runtime raises rather than spawning something arbitrary" do
-      assert_raise ArgumentError, fn -> ACP.command("codex") end
+      assert_raise ArgumentError, fn -> ACP.command("nonesuch") end
     end
 
     test "a native runtime needs no install" do

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -401,18 +401,22 @@ defmodule FountainWeb.MetricsTest do
     end
 
     test "time to first token scrapes tagged by runtime (#535)" do
-      # Distinct runtime for the same reason as the turn-duration test: the
-      # reporter is global and the ConversationServer tests feed claude.
+      # A synthetic runtime, not a real one. The reporter is global and
+      # cumulative, so this asserts an exact bucket count only as long as
+      # nothing else in the suite emits the same tag — and "gemini" stopped
+      # being safe the moment the ACP conversion grew gemini ConversationServer
+      # tests, which feed first-output telemetry of their own. A tag no runtime
+      # can ever be named keeps the exact-count assertions meaningful.
       Fountain.Telemetry.event(
         [:turn, :first_output],
-        %{runtime: "gemini", conv_id: Ecto.UUID.generate()},
+        %{runtime: "probe-runtime", conv_id: Ecto.UUID.generate()},
         %{elapsed_ms: 1_500}
       )
 
       Process.sleep(50)
       {200, body} = scrape()
 
-      series = ~s(fountain_turn_first_output_elapsed_ms_bucket{runtime="gemini")
+      series = ~s(fountain_turn_first_output_elapsed_ms_bucket{runtime="probe-runtime")
 
       # 1.5s is above the 1s boundary and below 2.5s.
       assert body =~ ~s(#{series},le="2500"} 1)
@@ -420,7 +424,9 @@ defmodule FountainWeb.MetricsTest do
 
       # No status tag here: a turn reports first output once, before any
       # outcome is known.
-      refute body =~ ~s(fountain_turn_first_output_elapsed_ms_bucket{runtime="gemini",status)
+      refute body =~
+               ~s(fountain_turn_first_output_elapsed_ms_bucket{runtime="probe-runtime",status)
+
       refute body =~ "conv_id="
     end
 


### PR DESCRIPTION
Completes the four-runtime conversion. Flag still off by default; nothing changes for an agent that hasn't opted in.

## The gap this exposed, which was already shipping

**The ACP path was ignoring `agent.model`.** It skips `build_command/5`, which is where `Model.model_args/1` put `--model <id>`, and ACP carries no model in `session/new` — so every ACP turn ran whatever the runtime defaults to, silently, regardless of what the tenant configured. That was already true for claude and gemini on `main`.

For opencode it isn't a detail: it's a multi-provider front-end where the model *is* the configuration.

Fixed via `session/set_config_option` with `configId: "model"`, sent only when the session response advertises that option — so a runtime with no model concept is left alone rather than handed a method it never offered. A model we can't pin **doesn't fail the turn**; it lands in the transcript as stderr output naming the model that was asked for and the fact that a default is running instead. Silently running someone else's model is the failure mode this campaign keeps turning up.

## The runtimes

| | mechanism | resume | cwd |
|---|---|---|---|
| claude | adapter, pinned `claude-agent-acp@0.66.0` | `resume` | `/home/sprite` |
| gemini | native `gemini --acp` | `loadSession` only → replay discarded | `/tmp/gemini-workspace` |
| codex | adapter, pinned `codex-acp@1.1.14` | `resume` | `/home/sprite` |
| opencode | native `opencode acp` | `resume` | `/tmp/opencode-workspace` |

**gemini** is the one that stresses the design — no `resume`, so every turn after the first replays the whole conversation before `session/load` returns. There's a test feeding a replayed chunk *and* a fresh one, asserting only the fresh one reaches `log_events`. It's worth converting anyway because `gemini --resume` re-enters *"the most recent conversation in the workspace"* — correct only while one conversation ever runs per workspace, an invariant held by accident and asserted by no test.

**codex**'s auth is unchanged: `prepare_sprite/3` still runs `codex login --with-api-key`, so the adapter inherits what the CLI would have used. The `zed-industries` package earlier drafts named is archived; this is its successor under the protocol org.

**opencode** needs no install (`prepare_sprite/3` already bun-installs it), but note its `acp` subcommand starts a local HTTP server inside the sprite and drives it through opencode's own SDK rather than being a plain stdio peer. Satisfies the protocol; second process model to remember when something hangs.

Two things gemini needed that claude didn't, now generalised per-runtime: a **cwd** (it walks up looking for a `.git`, and its own `prepare_sprite/3` git-inits exactly that directory), and **dropping the client-proposed `sessionId`** from `session/new` — the spec says the agent MUST assign it and we overwrite ours anyway, so it was decoration a stricter agent could reject.

## Test-suite hygiene

- `metrics_test` asserted an exact histogram bucket for `runtime="gemini"` on a **global cumulative** reporter, relying on nothing else emitting that tag — its own comment said so. Gemini `ConversationServer` tests broke that. It now uses a synthetic tag, keeping the exact-count assertions rather than loosening them to `>= 1`. Caught by running three seeds, not one.
- ACP tests now iterate `ACP.supported_runtimes/0` instead of naming runtimes, so adding one can't leave a stale "not converted" assertion passing for the wrong reason.

## Still not proven

None of the four has run against a live agent — the playground key is out of credit. Everything here is verified against scripted agents plus the live claude runs from #647/#650. Per the campaign rule in #644, a parser is deleted when its runtime has served **real conversations**, so #642 stays blocked on that regardless of this landing.

`mix precommit` green; clean across seeds 2222/4444/6666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)