### PR TITLE
fix: hold gemini back from the ACP flag until its resume works (#659)

### DIFF
--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -35,6 +35,13 @@ defmodule Fountain.Runtimes.ACP do
   only while one conversation ever runs per workspace — an invariant held by
   accident and asserted by no test. ACP names the session.
 
+  **Gemini is converted but held back** (#659): its `session/load` cannot
+  reliably find a session it created minutes earlier — 2 successes to 4
+  failures against a live agent — and its replay escapes the discard window
+  (#657). `supported_runtimes/0` therefore excludes it, so the per-agent flag
+  cannot switch it on. The entry stays because the conversion is correct as far
+  as it goes; what fails is gemini's own session store.
+
   Codex and OpenCode both advertise `loadSession` *and*
   `sessionCapabilities.resume`, so they resume as cheaply as Claude does. What
   differs is how ACP is reached: Codex through an adapter package we install
@@ -85,12 +92,17 @@ defmodule Fountain.Runtimes.ACP do
     # `Gemini.prepare_sprite/3` git-inits exactly this directory. Pointing it
     # at /home/sprite instead reintroduces the EACCES noise that workspace
     # exists to avoid.
+    # Converted, verified, and **not shippable** — see `blocked`. Left in the
+    # table rather than deleted because the conversion itself is correct: turn
+    # 1 works end to end against a live agent. What does not work is gemini's
+    # own session store.
     "gemini" => %{
       bin: "gemini",
       args: ["--acp"],
       package: nil,
       version: nil,
-      cwd: "/tmp/gemini-workspace"
+      cwd: "/tmp/gemini-workspace",
+      blocked: "#659"
     },
     # Adapter, on the Codex App Server. The `zed-industries/codex-acp` that
     # earlier drafts named is archived; this is its successor under the
@@ -119,9 +131,30 @@ defmodule Fountain.Runtimes.ACP do
     }
   }
 
-  @doc "Runtimes that can currently speak ACP."
+  @doc """
+  Runtimes that may actually be switched on.
+
+  Distinct from having an adapter entry. A runtime is listed here only when a
+  full turn *and* a resume have been observed against a live agent — a
+  conversion that resumes unreliably is worse than the legacy path it replaces,
+  because the user gets a working first turn and an agent with no memory on
+  every turn after.
+  """
   @spec supported_runtimes() :: [String.t()]
-  def supported_runtimes, do: Map.keys(@adapters)
+  def supported_runtimes do
+    @adapters |> Enum.reject(fn {_k, v} -> v[:blocked] end) |> Enum.map(&elem(&1, 0))
+  end
+
+  @doc """
+  Runtimes with an adapter entry that are held back, and why.
+
+  Public so the reason travels with the code rather than living only in an
+  issue: `%{"gemini" => "#659"}`.
+  """
+  @spec blocked_runtimes() :: %{String.t() => String.t()}
+  def blocked_runtimes do
+    for {name, %{blocked: reason}} <- @adapters, into: %{}, do: {name, reason}
+  end
 
   @doc "The npm package and version pinned for a runtime, or nil when native."
   @spec adapter_spec(String.t()) :: String.t() | nil
@@ -156,7 +189,7 @@ defmodule Fountain.Runtimes.ACP do
   """
   @spec enabled?(Agent.t() | nil) :: boolean()
   def enabled?(%Agent{runtime: runtime, metadata: metadata}) when is_map(metadata) do
-    Map.has_key?(@adapters, runtime) and Map.get(metadata, "acp") == true
+    runtime in supported_runtimes() and Map.get(metadata, "acp") == true
   end
 
   def enabled?(_), do: false

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -112,7 +112,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       refute ACP.enabled?(insert_agent(user_id: user.id, runtime: "claude"))
     end
 
-    test "applies to every converted runtime" do
+    test "applies to every shippable runtime" do
       user = insert_verified_user()
 
       for runtime <- ACP.supported_runtimes() do
@@ -392,120 +392,17 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
     end
   end
 
-  # A gemini conversation whose first turn already happened: the session id is
-  # persisted, so the server computes mode :continue and the peer resumes.
-  # Built fresh rather than restarted, because a second server for a
-  # conversation whose sandbox is already `ready` takes the reattach path.
-  defp resumed_gemini_turn(shape \\ :bare) do
-    user = insert_verified_user()
-    agent = acp_agent(user, "gemini")
-    conv = insert_conversation(agent: agent, user_id: user.id, runtime: "gemini")
-    {:ok, conv} = Conversations.update_conversation(conv, %{runtime_session_id: "gem-1"})
-    {pid, ref} = start_acp_turn(conv)
-
-    case shape do
-      :with_conv -> {conv, pid, ref}
-      :bare -> {pid, ref}
-    end
-  end
-
-  describe "gemini" do
-    setup do
-      user = insert_verified_user()
-      agent = acp_agent(user, "gemini")
-      conv = insert_conversation(agent: agent, user_id: user.id, runtime: "gemini")
-      {pid, ref} = start_acp_turn(conv)
-      {:ok, conv: conv, pid: pid, ref: ref}
-    end
-
-    test "spawns the native flag in the workspace its runtime module git-inits", %{pid: pid} do
-      assert_receive {:spawned, cmd, args, opts}
-      assert cmd == "gemini"
-      assert args == ["--acp"]
-
-      # gemini walks up from cwd looking for a .git. /home/sprite is where the
-      # EACCES noise comes from, and Gemini.prepare_sprite/3 prepares exactly
-      # this directory.
-      assert opts[:dir] == "/tmp/gemini-workspace"
-
-      _ = next_write()
-      GenServer.stop(pid)
-    end
-
-    test "session/new carries the same cwd the process was spawned in", %{pid: pid, ref: ref} do
-      %{"id" => init_id, "method" => "initialize"} = next_write()
-      reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
-
-      assert %{"method" => "session/new", "params" => params} = next_write()
-      assert params["cwd"] == "/tmp/gemini-workspace"
-
-      GenServer.stop(pid)
-    end
-
-    test "session/new proposes no session id — the agent assigns it", %{pid: pid, ref: ref} do
-      # The spec says the *agent* MUST respond with a unique id, and we persist
-      # whatever comes back. Proposing one was decoration a stricter agent
-      # could reject on schema grounds.
-      %{"id" => init_id} = next_write()
-      reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
-
-      assert %{"method" => "session/new", "params" => params} = next_write()
-      refute Map.has_key?(params, "sessionId")
-
-      GenServer.stop(pid)
-    end
-  end
-
-  # Separate describe on purpose: these build their own conversation, and the
-  # gemini setup above would start a second server writing into the same
-  # mailbox, so every assertion would read the wrong connection's traffic.
-  describe "gemini, turn 2" do
-    test "turn 2 uses session/load, because gemini advertises no resume" do
-      {pid, ref} = resumed_gemini_turn()
-
-      %{"id" => init_id} = next_write()
-      # Exactly what gemini's dispatcher advertises: loadSession and no
-      # sessionCapabilities block at all.
-      reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
-
-      decoded = next_write()
-      assert decoded["method"] == "session/load"
-      assert decoded["params"]["sessionId"] == "gem-1"
-
-      GenServer.stop(pid)
-    end
-
-    test "the replay gemini sends before session/load returns is discarded" do
-      # This is the cost of having no `resume`: the whole conversation arrives
-      # again on every turn after the first. We already hold it as log_events,
-      # so persisting it would duplicate the transcript into the DB and onto
-      # the SSE stream, every turn, for the life of the conversation.
-      {conv, pid, ref} = resumed_gemini_turn(:with_conv)
-
-      %{"id" => init_id} = next_write()
-      reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
-      %{"id" => load_id, "method" => "session/load"} = next_write()
-
-      notify(pid, ref, %{
-        "sessionUpdate" => "agent_message_chunk",
-        "content" => %{"type" => "text", "text" => "REPLAYED HISTORY"}
-      })
-
-      reply(pid, ref, load_id, %{})
-      %{"method" => "session/prompt"} = next_write()
-
-      notify(pid, ref, %{
-        "sessionUpdate" => "agent_message_chunk",
-        "content" => %{"type" => "text", "text" => "FRESH ANSWER"}
-      })
-
-      events = Conversations._unsafe_list_log_events(conv.id)
-      acp = Enum.filter(events, &(&1.stream == "acp"))
-
-      assert Enum.any?(acp, &(&1.data =~ "FRESH ANSWER"))
-      refute Enum.any?(acp, &(&1.data =~ "REPLAYED HISTORY"))
-
-      GenServer.stop(pid)
-    end
-  end
+  # The gemini describes that lived here are gone with #659: gemini is held
+  # back from `supported_runtimes/0`, so a gemini agent takes the legacy path
+  # and these could only ever assert that. The behaviour they covered did not
+  # go away with them —
+  #
+  #   * launch command and workspace  → `Fountain.Runtimes.ACPTest`
+  #     ("the held-back gemini entry still points at the right workspace")
+  #   * session/load instead of resume, and the replay discard
+  #     → `Fountain.Runtimes.ACP.PeerTest`, driven by an agent advertising
+  #       `loadSession` and no `resume`, which is exactly gemini's shape
+  #
+  # When #659 lifts the block, a gemini conversation-level test belongs here
+  # again.
 end

--- a/apps/fountain/test/fountain/runtimes/acp_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp_test.exs
@@ -7,12 +7,26 @@ defmodule Fountain.Runtimes.ACPTest do
   defp agent(attrs), do: struct(Agent, attrs)
 
   describe "enabled?/1" do
-    test "requires both the flag and a converted runtime" do
+    test "requires both the flag and a shippable runtime" do
       assert ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => true}))
-      assert ACP.enabled?(agent(runtime: "gemini", metadata: %{"acp" => true}))
 
       refute ACP.enabled?(agent(runtime: "claude", metadata: %{}))
       refute ACP.enabled?(nil)
+    end
+
+    test "a blocked runtime cannot be switched on at all" do
+      # gemini is converted and verified for turn 1, but its session/load
+      # cannot reliably find a session it just created (#659). A working first
+      # turn followed by an amnesiac agent is worse than the resume-by-guessing
+      # it replaces, so the flag must not reach it.
+      assert %{"gemini" => _} = ACP.blocked_runtimes()
+      refute "gemini" in ACP.supported_runtimes()
+      refute ACP.enabled?(agent(runtime: "gemini", metadata: %{"acp" => true}))
+    end
+
+    test "a blocked runtime keeps its adapter entry, so the work is not lost" do
+      assert {"gemini", ["--acp"]} = ACP.command("gemini")
+      assert ACP.cwd("gemini") == "/tmp/gemini-workspace"
     end
 
     test "every supported runtime honours the flag" do
@@ -157,7 +171,7 @@ defmodule Fountain.Runtimes.ACPTest do
       assert is_nil(ACP.adapter_spec("gemini"))
     end
 
-    test "gemini runs in the workspace its own runtime module git-inits" do
+    test "the held-back gemini entry still points at the right workspace" do
       # gemini walks up from cwd looking for a .git; pointing it at
       # /home/sprite reintroduces the EACCES noise the workspace exists to
       # avoid, and leaves MemoryDiscovery crawling /home.


### PR DESCRIPTION
Gemini is the one runtime of four whose conversion can't be switched on. This makes that true in code rather than only in an issue.

## Why

Turn 1 is genuinely good — verified against a live `gemini --acp`: correct workspace, eager `authenticate` with `gemini-api-key`, model pinned via ACP's own `session/set_model`, correct answer. Turn 2 is not:

- **#658** — `session/load` answers `"No previous sessions found for this project"` for a session gemini created minutes earlier in the same sandbox. 2 successes, 4 failures. Ruled out: missing auth, wrong method, flush race, process not exiting.
- **#657** — its replay escapes the discard window, duplicating the transcript on every turn after the first.

A working first turn followed by an agent with no memory is **worse than the resume-by-guessing it replaces**, so the flag must not reach it.

## How

`supported_runtimes/0` excludes any adapter entry carrying `blocked`, and `enabled?/1` reads that list rather than the raw table. `blocked_runtimes/0` is public so the reason travels with the code.

The adapter entry stays. The conversion is correct as far as it goes, and deleting it means redoing it when #659 closes.

## The tests that went with it

A gemini agent now takes the legacy path, so the gemini `ConversationServer` describes could only have asserted that. I removed them rather than leave them passing for the wrong reason — but the coverage didn't go away:

| what it covered | where it lives now |
|---|---|
| launch command + workspace | `ACPTest` — "the held-back gemini entry still points at the right workspace" |
| `session/load` instead of resume, and the replay discard | `PeerTest`, driven by an agent advertising `loadSession` and no `resume` — exactly gemini's shape |

The test file carries a comment saying where to put a conversation-level test back when #659 lifts the block.

## Not affected

Claude, codex and opencode stay enabled — all three verified end to end through the real peer today, resuming via `session/resume`.

`mix precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)