### PR TITLE
fix: stop gemini's replay escaping the discard window, and diagnose why its session/load fails (#657, #658)

### DIFF
--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -35,12 +35,39 @@ defmodule Fountain.Runtimes.ACP do
   only while one conversation ever runs per workspace — an invariant held by
   accident and asserted by no test. ACP names the session.
 
-  **Gemini is converted but held back** (#659): its `session/load` cannot
-  reliably find a session it created minutes earlier — 2 successes to 4
-  failures against a live agent — and its replay escapes the discard window
-  (#657). `supported_runtimes/0` therefore excludes it, so the per-agent flag
-  cannot switch it on. The entry stays because the conversion is correct as far
-  as it goes; what fails is gemini's own session store.
+  **Gemini is converted but held back** (#659), and the reason is not ours to
+  fix. `supported_runtimes/0` excludes it, so the per-agent flag cannot switch
+  it on; the entry stays because the conversion is correct as far as it goes.
+
+  Diagnosed against a live 0.53.0 on 2026-08-11 (#658). Turn 1 does write a
+  session, to `$HOME/.gemini/tmp/<project>/chats/session-<ISO minute>-<first 8
+  of the id>.jsonl`, and gemini's own `--list-sessions` finds it. **Loading it
+  is what destroys it.** `session/load` builds a fresh config on the same
+  session id *before* looking the session up, and that config's chat recorder
+  takes its new-session branch: it computes the same file name — the id's first
+  8 characters plus the current wall-clock minute — and appends a header and a
+  `$set` carrying a `messages` array holding only its `<session_context>`
+  bootstrap. Gemini's own reader treats a `$set.messages` as a **replacement**,
+  and a user message beginning `<session_context>` is ignored content, so the
+  file it just appended to now has no resumable content. It drops out of
+  `listSessions()`, and `findSession` reports `-32603` / "No previous sessions
+  found for this project" — about a session whose transcript is still sitting
+  in the same file, above the line that erased it.
+
+  That is why it looked random. The collision is bucketed by **minute**: a
+  resume in the same minute as the previous turn poisons the session's own file
+  and always fails; a minute later the poison lands in a sibling file and the
+  load succeeds. The "2 successes to 4 failures" was a wall clock, not a race.
+  Verified in both directions on live sprites.
+
+  Waiting is not a workaround: a *second* consecutive resume failed even with a
+  minute between every turn, and afterwards every older session file for that
+  project was gone. One resume is not a conversation.
+
+  It is also destructive rather than merely unreliable — a failed load leaves
+  the session unloadable forever, so a user would lose the conversation, not
+  just a turn. Fountain cannot work around this without reaching into another
+  product's private store, so gemini stays blocked until upstream fixes it.
 
   Codex and OpenCode both advertise `loadSession` *and*
   `sessionCapabilities.resume`, so they resume as cheaply as Claude does. What
@@ -95,7 +122,8 @@ defmodule Fountain.Runtimes.ACP do
     # Converted, verified, and **not shippable** — see `blocked`. Left in the
     # table rather than deleted because the conversion itself is correct: turn
     # 1 works end to end against a live agent. What does not work is gemini's
-    # own session store.
+    # own session store, which erases a session in the act of loading it — the
+    # moduledoc has the mechanism.
     "gemini" => %{
       bin: "gemini",
       args: ["--acp"],

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -39,6 +39,14 @@ defmodule Fountain.Runtimes.ACP.Peer do
   first. While a `session/load` is outstanding the peer runs in replay-discard
   mode and drops updates on the floor.
 
+  **The response is not the end of the replay, and we do not treat it as one.**
+  Gemini answers `session/load` before replaying — its `streamHistory` is a
+  floating promise — so a window closed on the response misses the replay
+  entirely (#657, live: one assistant message rendered twice). The window
+  closes instead on a bounded quiet period: keep discarding until the stream
+  has been silent for `@replay_quiet_ms`, then prompt, giving up after
+  `@replay_max_ms` because a turn held open disarms idle reclaim (#413).
+
   We prefer `resume` whenever the adapter advertises it, which the pinned Claude
   adapter does. `load` is kept because the capability is per-adapter and per
   version, and discovering at runtime that this build cannot resume is better
@@ -59,6 +67,11 @@ defmodule Fountain.Runtimes.ACP.Peer do
   alias Fountain.Runtimes.ACP
   alias Fountain.Runtimes.ACP.Protocol
   alias Fountain.SpriteStdin
+
+  # How long the replay has to stay quiet before we believe it is over, and how
+  # long we will wait for that in total. See `handle_response(:load_session, …)`.
+  @replay_quiet_ms 250
+  @replay_max_ms 10_000
 
   @typedoc "What the peer reports upward. `ref` is the sprite command's ref."
   @type payload ::
@@ -88,6 +101,12 @@ defmodule Fountain.Runtimes.ACP.Peer do
       pending: %{},
       phase: :initializing,
       replay_discard?: false,
+      # Both set from opts in `init/1`; the defaults live on the outer module.
+      replay_quiet_ms: nil,
+      replay_max_ms: nil,
+      replay_result: nil,
+      replay_last_ms: nil,
+      replay_until_ms: nil,
       capabilities: %{},
       auth_methods: [],
       authenticated?: false
@@ -134,6 +153,8 @@ defmodule Fountain.Runtimes.ACP.Peer do
       images: Keyword.get(opts, :images, []),
       mcp_servers: Keyword.get(opts, :mcp_servers, []),
       model: Keyword.get(opts, :model),
+      replay_quiet_ms: Keyword.get(opts, :replay_quiet_ms, @replay_quiet_ms),
+      replay_max_ms: Keyword.get(opts, :replay_max_ms, @replay_max_ms),
       started_mono: System.monotonic_time(:millisecond)
     }
 
@@ -170,6 +191,21 @@ defmodule Fountain.Runtimes.ACP.Peer do
     {:stop, :normal, state}
   end
 
+  def handle_info(:replay_check, %State{phase: :draining_replay} = state) do
+    quiet_for = now_ms() - state.replay_last_ms
+
+    if quiet_for >= state.replay_quiet_ms or now_ms() >= state.replay_until_ms do
+      %{state | replay_discard?: false}
+      |> pin_model_then_prompt(state.replay_result)
+      |> noreply()
+    else
+      state |> schedule_replay_check(state.replay_quiet_ms - quiet_for) |> noreply()
+    end
+  end
+
+  # A turn that failed or was answered while a check was in flight.
+  def handle_info(:replay_check, state), do: {:noreply, state}
+
   def handle_info(msg, state) do
     Logger.debug("acp peer: unexpected message #{inspect(msg)}")
     {:noreply, state}
@@ -180,8 +216,8 @@ defmodule Fountain.Runtimes.ACP.Peer do
   defp handle_message({:notification, "session/update", params}, state) do
     if state.replay_discard? do
       # Replay of history we already hold. Dropped, not persisted — see the
-      # moduledoc.
-      state
+      # moduledoc. The timestamp is what the quiet period below measures.
+      %{state | replay_last_ms: now_ms()}
     else
       persist(state, "acp", Protocol.notification("session/update", params))
     end
@@ -312,9 +348,33 @@ defmodule Fountain.Runtimes.ACP.Peer do
   defp handle_response(:resume_session, result, state),
     do: pin_model_then_prompt(state, result)
 
+  # ACP says the agent MUST replay the conversation as `session/update`
+  # notifications *before* responding to `session/load`, which would make this
+  # response the end of the replay. Gemini does not: it calls its
+  # `streamHistory` as a floating promise and answers first, so the replay
+  # arrives after this point and would land in `log_events` — duplicating the
+  # transcript on every turn after the first (#657, measured against a live
+  # agent: two `:text` blocks reading `"ECHO-5ECHO-5"`).
+  #
+  # So the response is not the signal. We keep discarding until the stream has
+  # been quiet for `replay_quiet_ms`, then prompt. Timing is the only thing
+  # separating replay from answer here — both arrive as `session/update` on the
+  # same session, and the fresh answer cannot begin before we send
+  # `session/prompt`, which the quiet period gates. Do not "fix" this by
+  # widening the discard past the prompt; that drops the answer.
+  #
+  # The wait is capped: an agent that never goes quiet must not hold a turn
+  # open, because a turn in flight disarms idle reclaim (#413). The cost is
+  # cheap next to gemini's ~2.8s handshake, and it comes off entirely when the
+  # upstream `await` lands.
   defp handle_response(:load_session, result, state) do
-    # The replay is over; everything from here is this turn's.
-    pin_model_then_prompt(%{state | replay_discard?: false}, result)
+    schedule_replay_check(%{
+      state
+      | phase: :draining_replay,
+        replay_result: result,
+        replay_last_ms: now_ms(),
+        replay_until_ms: now_ms() + state.replay_max_ms
+    })
   end
 
   # The model was pinned (or refused); either way the turn goes ahead.
@@ -545,6 +605,13 @@ defmodule Fountain.Runtimes.ACP.Peer do
   end
 
   defp report(state, payload), do: send(state.owner, {:acp, state.ref, payload})
+
+  defp schedule_replay_check(state, after_ms \\ nil) do
+    Process.send_after(self(), :replay_check, after_ms || state.replay_quiet_ms)
+    state
+  end
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
 
   defp supports?(state, path) do
     case get_in(state.capabilities, path) do

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -209,6 +209,89 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       refute data =~ "OLD TURN"
     end
 
+    test "a replay that lands after the load response is still discarded", ctx do
+      # #657: gemini streams its replay as a floating promise, so `session/load`
+      # answers *before* replaying. Measured against a live agent — closing the
+      # window on the response duplicated the whole transcript.
+      pid =
+        start_peer(ctx,
+          mode: :continue,
+          session_id: "sess_abc",
+          replay_quiet_ms: 40,
+          replay_max_ms: 2_000
+        )
+
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+      %{"id" => load_id} = next_write()
+
+      send_response(pid, load_id, %{})
+
+      # Late replay, in two bursts, each of which pushes the quiet period out.
+      for text <- ["OLD ONE", "OLD TWO"] do
+        Peer.stdout(
+          pid,
+          update_line(%{
+            "sessionUpdate" => "agent_message_chunk",
+            "content" => %{"type" => "text", "text" => text}
+          })
+        )
+
+        Process.sleep(20)
+      end
+
+      refute_receive {:acp, _, {:lines, _, _}}, 20
+
+      # Only once the stream goes quiet does the turn's own prompt go out.
+      assert %{"method" => "session/prompt"} = next_write()
+
+      Peer.stdout(
+        pid,
+        update_line(%{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => "NEW"}
+        })
+      )
+
+      assert_receive {:acp, _ref, {:lines, "acp", data}}
+      assert data =~ "NEW"
+      refute data =~ "OLD"
+    end
+
+    test "a replay that never goes quiet still prompts, rather than holding the turn open", ctx do
+      # An unbounded wait would be the #413 shape: a turn in flight disarms idle
+      # reclaim, so a chatty agent could bill a sprite to its ceiling.
+      pid =
+        start_peer(ctx,
+          mode: :continue,
+          session_id: "sess_abc",
+          replay_quiet_ms: 30,
+          replay_max_ms: 60
+        )
+
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+      %{"id" => load_id} = next_write()
+      send_response(pid, load_id, %{})
+
+      noisy = fn ->
+        Peer.stdout(
+          pid,
+          update_line(%{
+            "sessionUpdate" => "agent_message_chunk",
+            "content" => %{"type" => "text", "text" => "chatter"}
+          })
+        )
+      end
+
+      for _ <- 1..12 do
+        noisy.()
+        Process.sleep(10)
+      end
+
+      assert %{"method" => "session/prompt"} = next_write()
+    end
+
     test "session/resume never enters replay-discard, so nothing is lost", ctx do
       pid = start_peer(ctx, mode: :continue, session_id: "sess_abc")
       %{"id" => init_id} = next_write()

--- a/apps/fountain/test/fountain/runtimes/acp_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp_test.exs
@@ -15,10 +15,12 @@ defmodule Fountain.Runtimes.ACPTest do
     end
 
     test "a blocked runtime cannot be switched on at all" do
-      # gemini is converted and verified for turn 1, but its session/load
-      # cannot reliably find a session it just created (#659). A working first
-      # turn followed by an amnesiac agent is worse than the resume-by-guessing
-      # it replaces, so the flag must not reach it.
+      # gemini is converted and verified for turn 1, but loading a session
+      # erases it: the load path's own chat recorder overwrites the message
+      # list in the session file before the lookup reads it (#658, mechanism in
+      # the ACP moduledoc). A working first turn followed by an amnesiac agent
+      # — and an unrecoverable conversation — is worse than the
+      # resume-by-guessing it replaces, so the flag must not reach it.
       assert %{"gemini" => _} = ACP.blocked_runtimes()
       refute "gemini" in ACP.supported_runtimes()
       refute ACP.enabled?(agent(runtime: "gemini", metadata: %{"acp" => true}))

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -320,6 +320,19 @@ concrete bug if it is missed:
   advertised, prefer `session/resume`: it is specified *not* to replay, which
   deletes the failure mode instead of handling it.
 
+  > **Correction, 2026-08-11.** "Until `session/load` returns" is not a
+  > sufficient rule, because an agent may not honour the MUST. Gemini calls its
+  > `streamHistory` as a floating promise and answers `session/load` *first*,
+  > so the replay arrives after the response and lands outside the window —
+  > measured live as a duplicated assistant message (#657). The peer now closes
+  > the window on a **bounded quiet period** rather than on the response: keep
+  > discarding until no `session/update` has arrived for 250 ms, then prompt,
+  > capped at 10 s so an agent that never goes quiet cannot hold a turn open
+  > (#413's shape). Timing is the only available discriminator — replay and
+  > answer are the same notification on the same session, and what separates
+  > them is that the answer cannot begin before we send `session/prompt`. The
+  > cap comes off if the one-word upstream fix (`await`) lands.
+
 - **Measure the per-turn `initialize`.** Process start, `initialize`, and the
   resumption round trip are now paid once per turn rather than once per
   session. That is the honest price of a disposable sandbox, and gate 2 must
@@ -501,6 +514,40 @@ one runtime converted and say so here.
 
 Only after gate 3 holds in production. A parser is deleted when its runtime's
 ACP path has served real conversations, not when the code compiles.
+
+**Three of the four runtimes are converted and one is not, for a reason
+outside our code — 2026-08-11.** Claude, Codex and OpenCode each did
+`session/new` then `session/resume` against a live agent, recalling a token
+only the prior turn established. Gemini's first turn is equally good and its
+resume cannot be made to work from this side, so it is excluded from
+`ACP.supported_runtimes/0` (#659) and its dialect parser stays.
+
+The mechanism, read out of gemini 0.53.0's shipped bundle and confirmed on live
+sprites (#658): a session **is** written to disk after turn 1, and gemini's own
+`--list-sessions` finds it. `session/load` then builds a fresh config on the
+same session id *before* resolving the session, and that config's chat recorder
+takes its new-session branch — computing the same file name, which is the first
+8 characters of the session id plus the current wall-clock **minute**, and
+appending a `$set` whose `messages` array holds only its `<session_context>`
+bootstrap. The reader treats `$set.messages` as a replacement and skips
+`<session_context>` as ignored content, so the session it was asked to load now
+has no resumable content, disappears from the listing, and comes back as
+`-32603` "No previous sessions found for this project".
+
+Two consequences worth carrying into gate 4:
+
+- **The intermittency was a clock.** A resume in the same minute as the
+  previous turn always fails; one a minute later lands its poison in a sibling
+  file and succeeds. The earlier "2 successes to 4 failures" was not a race.
+  Waiting is still not a workaround — a *second* consecutive resume failed with
+  a minute between every turn, and afterwards every older session file for that
+  project had been removed. One resume is not a conversation.
+- **Failure is destructive.** The session is unloadable afterwards, so this
+  costs a conversation rather than a turn — which is the whole reason the flag
+  must not reach gemini, rather than merely being discouraged for it.
+
+A workaround would mean writing into another product's private store on a
+filename convention it can change without notice. We wait for upstream.
 
 ### Not in scope
 


### PR DESCRIPTION
Picks up #659. Two of its three parts land here: the replay-discard bug is
**fixed and verified live**, and the `session/load` failure is **diagnosed** —
it is upstream's, with a mechanism rather than a hypothesis. Gemini stays
blocked; #659 stays open.

## 1. The replay escaped the discard window — #657, fixed

ACP says an agent handling `session/load` MUST replay the conversation as
`session/update` notifications *before* responding. `Peer` relied on that:
discard from the moment the load is sent, stop when the response arrives.
Gemini answers first and replays afterwards (`session.streamHistory(...)` is a
floating promise), so the replay landed outside the window and would duplicate
the whole transcript into `log_events` and onto the SSE stream on every turn
after the first.

The window now closes on a **bounded quiet period** — keep discarding until no
`session/update` has arrived for 250 ms, then prompt, capped at 10 s. Timing is
the only discriminator: replay and answer are the same notification on the same
session, and what separates them is that the answer cannot begin before we send
`session/prompt`. The cap is there because a turn held open disarms idle reclaim
and bills the sprite to its ceiling (#413).

A/B against a live `gemini --acp` 0.53.0, same sprite shape, same prompts, the
harness driving the real `Peer`:

| binary | turn 2 blocks | assistant text |
|---|---|---|
| pre-fix (`git stash` of this commit) | `%{text: 2}` | `"ECHO-5ECHO-5"` |
| this branch | `%{text: 1}` | `"ECHO-5"` |

Two unit tests cover it: a replay arriving *after* the response is still
discarded, and a replay that never goes quiet still prompts rather than holding
the turn open.

Claude, codex and opencode are untouched — all three advertise
`sessionCapabilities.resume` and never take the load path. 250 ms is cheap next
to gemini's ~2.8 s handshake, and the whole mitigation comes off if upstream
adds the `await`.

## 2. Why `session/load` cannot find its own session — #658, diagnosed

The observation #659 asked for first: **a session is written to disk after turn
1** — right id, right messages, and gemini's own `--list-sessions` finds it. So
it is not auth, not the workspace, not a flush race, and not our peer.

**Loading it is what destroys it.** `loadSession` builds a fresh config on the
same session id *before* resolving the session. That config's
`ChatRecordingService` takes its new-session branch, derives the file name from
`<first 8 of the id>` plus the **current wall-clock minute** — the same name the
original turn wrote — and appends a `$set` whose `messages` array holds only its
`<session_context>` bootstrap. Gemini's reader treats `$set.messages` as a
replacement, and `isIgnoredUserContent` skips `<session_context>`, so the
session it was asked to load now has no resumable content, drops out of
`listSessions()`, and comes back as `-32603` "No previous sessions found for
this project" — about a session whose transcript is still in that file, above
the line that erased it.

That kills the mystery in the tally: the collision is bucketed by minute, so the
outcome was decided by the wall clock, not by a race.

| resume happens | poison lands in | result |
|---|---|---|
| same minute as the previous turn | the session's own file | fails, session unloadable for good |
| a later minute | a sibling file | succeeds, token recalled |

Both directions verified twice on live sprites. Files also survive 130 s of idle
untouched, which rules out a reaper.

**Waiting is not a workaround**: a *second* consecutive resume failed even with a
minute between every turn, and afterwards every older session file for that
project was gone. One resume is not a conversation.

So the decision is to wait for upstream rather than carry a workaround — the
only workaround available means writing into another product's private store, on
a filename convention it can change without notice. An upstream report with the
mechanism and a reproduction is drafted and waiting for you to file (it posts
publicly under your account, so I did not).

Closes #657. #658 stays open as an upstream defect (nothing left for us to do
in it but track the fix), and #659 stays open because gemini stays blocked.

## What is not in here

- `supported_runtimes/0` still excludes gemini. #659 stays open, and gemini's
  dialect parser stays until it closes.
- No conversation-level gemini test is restored, for the same reason.

## Checks

`mix precommit` clean; suite run across three seeds. Every live sprite destroyed
in an `after` block and the account verified clear of `acp-*` sprites afterwards.
