### PR TITLE
chore: raise sandbox idle reclaim to 4h for human-gated incidents

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -120,6 +120,14 @@ spec:
             # unverified-account pruner (#258).
             - name: UNVERIFIED_PRUNE_EXEMPT
               value: jhgaylor
+            # Incident conversations (estate-medic) wait on a human PR merge
+            # mid-runbook; the stock 60-minute idle reclaim erases the
+            # sandbox — and with it the agent's working memory — while the
+            # human is still reviewing. Four hours covers a slow review
+            # without giving up reclaim entirely. Global knob: fountain has
+            # no per-environment lifetime yet.
+            - name: SANDBOX_IDLE_TIMEOUT_MINUTES
+              value: "240"
             # TRUSTED_PROXIES is deliberately NOT set. Public traffic arrives
             # via the Cloudflare Tunnel (home-cloud k8s/cloudflared/), so the
             # X-Forwarded-For chain is "client, <cloudflared pod>" — every


### PR DESCRIPTION
The behold×fountain healing loop is going to production on home-cloud: estate-medic waits on a human PR merge in the middle of its runbook. The stock `SANDBOX_IDLE_TIMEOUT_MINUTES=60` reclaims the sandbox — and the agent's working memory with it — whenever the human takes more than an hour to review.

This sets the hosted deployment to 240 minutes. `SANDBOX_MAX_LIFETIME_HOURS=24` stays as the hard backstop.

Follow-up worth considering (separate issue): per-environment sandbox lifetimes, so an incident environment can hold longer than a scratch one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)