### PR TITLE
feat: suspend idle sandboxes instead of destroying them (0017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,31 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Upgrade notes
+
+- **Sandboxes now rest in a new `suspended` status instead of being
+  destroyed when idle.** Suspended sandboxes keep their sprite alive at
+  sprites.dev indefinitely (scaled to zero; treated as free) and do not
+  count toward the concurrent-sandbox quota. Anything consuming the API's
+  sandbox `status` field needs to accept the new value, and operators
+  who relied on idle reclaim to clean up sprites should know it no longer
+  does — only the max-lifetime ceiling, explicit termination, tenant
+  suspension and account deletion destroy sprites now.
+
+### Changed
+
+- **An idle sandbox is suspended rather than destroyed, and the next prompt
+  reattaches to the same sprite — the agent keeps its memory of the
+  conversation.** Idle reclaim was built on the premise that an idle sprite
+  bills until destroyed; it doesn't (sprites scale themselves to zero), and
+  the destroy was silently costing every idle conversation its runtime
+  session (#649). The max-lifetime ceiling still destroys — it exists to
+  bound runaway busy compute — and its message still says honestly that the
+  agent will not remember. The ceiling now measures a continuous run
+  (restarting on each wake) rather than calendar age, so a conversation
+  parked for a week is not destroyed the moment it is woken. See
+  decisions/0017.
+
 ## [0.7.0] — 2026-08-07
 
 ### Upgrade notes

--- a/apps/fountain/lib/fountain/accounts/deletion.ex
+++ b/apps/fountain/lib/fountain/accounts/deletion.ex
@@ -63,7 +63,10 @@ defmodule Fountain.Accounts.Deletion do
   alias Fountain.Conversations.{ConversationServer, Sandbox}
   alias Fountain.{Audit, Billing, Conversations, Repo}
 
-  @non_terminal ~w(pending starting ready)
+  # Includes `suspended`: parked sprites are excluded from the concurrency
+  # quota but still exist at sprites.dev, and deletion nilifies user_id — a
+  # sprite missed here is unfindable afterward, a permanent leak.
+  @non_terminal ~w(pending starting ready suspended)
 
   @doc """
   Delete `user` and everything belonging to them.

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -105,10 +105,11 @@ defmodule Fountain.Conversations do
 
   A conversation with a live `ConversationServer` is terminated through the
   server, which destroys the sprite and ends the conversation — that is what
-  stopping a runaway agent means. A sandbox with no live server just has its
-  row marked terminated: the conversation stays resumable (next prompt gets a
-  fresh sandbox, same session) and the reaper destroys the sprite on its next
-  pass, the same split `SandboxReaper.expire_abandoned_sandboxes/0` uses.
+  stopping a runaway agent means. A sandbox with no live server (including a
+  `suspended` one) just has its row marked terminated: the conversation stays
+  resumable (next prompt gets a fresh sandbox, with the agent's memory lost —
+  decisions/0017) and the reaper destroys the sprite on its next pass, the
+  same split `SandboxReaper.sweep_abandoned_sandboxes/0` uses.
   """
   def _unsafe_reap_sandbox(sandbox_id) do
     alias Fountain.Conversations.ConversationServer
@@ -152,8 +153,11 @@ defmodule Fountain.Conversations do
   sweeps stragglers. Returns the number of sandboxes reaped.
   """
   def _unsafe_reap_all_for_user(user_id) when is_binary(user_id) do
+    # Deliberately NOT Quotas.active_statuses(): `suspended` is excluded from
+    # the concurrency cap (a parked sprite is not compute) but its sprite is
+    # very much alive at sprites.dev, and a suspended tenant must not keep it.
     from(s in Sandbox,
-      where: s.user_id == ^user_id and s.status in ^Fountain.Quotas.active_statuses(),
+      where: s.user_id == ^user_id and s.status in ~w(pending starting ready suspended),
       select: s.id
     )
     |> Repo.all()
@@ -187,8 +191,11 @@ defmodule Fountain.Conversations do
   @billable_terminal ~w(terminated failed)
 
   # Transitions only: update_sandbox/2 is called repeatedly with the same status
-  # in places, and double-counting a sandbox would overstate a bill.
-  defp record_sandbox_usage(was, %Sandbox{status: "ready"} = sandbox) when was != "ready" do
+  # in places, and double-counting a sandbox would overstate a bill. Provision
+  # transitions only — a `suspended → ready` wake reattaches to a sprite whose
+  # provision was already recorded, so re-emitting would double-count it.
+  defp record_sandbox_usage(was, %Sandbox{status: "ready"} = sandbox)
+       when was in ["pending", "starting"] do
     Fountain.Billing.record_usage(
       sandbox.user_id,
       "sandbox_provisioned",
@@ -205,8 +212,9 @@ defmodule Fountain.Conversations do
     # duration — so the conversation count and the sandbox minutes on the
     # billing page would diverge for exactly the accounts where provisioning
     # is failing. Record the attempt under its own event type so the two
-    # sides can be reconciled.
-    if was != "ready" do
+    # sides can be reconciled. `suspended` had to pass through `ready` to get
+    # parked, so it is a completed provision, not a failed one.
+    if was in ["pending", "starting"] do
       Fountain.Billing.record_usage(
         sandbox.user_id,
         "sandbox_provision_failed",
@@ -412,6 +420,11 @@ defmodule Fountain.Conversations do
   Conversations whose `ConversationServer` would have been running at the
   time of a clean BEAM stop: status `idle` or `running`, with a fully-
   provisioned (`ready`) sandbox.
+
+  `suspended` is deliberately excluded: a parked conversation has no server
+  by design and wakes on the next prompt, not at boot — rehydrating every
+  parked conversation would start a server (and re-arm an idle clock) for
+  each one on every deploy.
   """
   def _unsafe_list_resumable_conversations do
     Repo.all(
@@ -1128,17 +1141,22 @@ defmodule Fountain.Conversations do
         {:reuse, sandbox_id} ->
           # Reuse provisions nothing, so the fresh-path gates below never ran
           # here — a canceled or suspended user could restart a server against
-          # a live sprite and keep prompting (#313). Same checks, minus the
-          # quota (reusing adds no concurrency). The per-turn gate in
-          # ConversationServer is the backstop; this one makes the refusal
-          # synchronous at the API door.
+          # a live sprite and keep prompting (#313). Same checks. Reusing a
+          # `ready` sandbox adds no concurrency, so no quota; waking a
+          # `suspended` one re-adds compute, so wake_suspended_sandbox re-runs
+          # the quota gate. The per-turn gate in ConversationServer is the
+          # backstop; this one makes the refusal synchronous at the API door.
           with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
-               :ok <- Fountain.Billing.check_active(conv.user_id) do
+               :ok <- Fountain.Billing.check_active(conv.user_id),
+               {:ok, _} <- wake_suspended_sandbox(conv.user_id, sandbox_id) do
             start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt)
           end
 
         :create_new ->
           create_fresh_sandbox_and_start(conv, agent, runtime_module, initial_prompt)
+
+        {:error, _} = err ->
+          err
       end
     else
       nil -> {:error, :not_found}
@@ -1146,23 +1164,70 @@ defmodule Fountain.Conversations do
     end
   end
 
-  # Probe the existing sandbox: if it's `ready` and sprites.dev confirms
-  # the sprite still exists, we can reattach without provisioning a new
-  # one. Otherwise, fall through to creating a fresh sandbox.
+  # Probe the existing sandbox: if it's `ready` or `suspended` and sprites.dev
+  # confirms the sprite still exists, we can reattach without provisioning a
+  # new one. Otherwise, fall through to creating a fresh sandbox.
   defp maybe_reuse_sandbox(%Conversation{sandbox_id: nil}), do: :create_new
 
   defp maybe_reuse_sandbox(%Conversation{sandbox_id: sandbox_id}) do
     case _unsafe_get_sandbox(sandbox_id) do
-      %{status: "ready", sprite_name: name} when is_binary(name) ->
+      %{status: status, sprite_name: name}
+      when status in ["ready", "suspended"] and is_binary(name) ->
         client = Fountain.SpritesClient.get!()
 
         case Sprites.get_sprite(client, name) do
-          {:ok, _info} -> {:reuse, sandbox_id}
-          _ -> :create_new
+          {:ok, _info} ->
+            {:reuse, sandbox_id}
+
+          {:error, {:not_found, _}} ->
+            :create_new
+
+          {:error, reason} when status == "suspended" ->
+            # A transient probe failure must not cost the parked disk: falling
+            # to :create_new retires this row, and the reaper then destroys the
+            # still-live sprite — with the agent's memory on it. Only a
+            # definitive not-found gives up the suspended sandbox; anything
+            # else fails the wake retryably.
+            Logger.warning(
+              "sprite probe failed for suspended sandbox #{sandbox_id}: #{inspect(reason)}"
+            )
+
+            {:error, :sprite_probe_failed}
+
+          _ ->
+            :create_new
         end
 
       _ ->
         :create_new
+    end
+  end
+
+  # Waking a suspended sandbox turns a parked sprite back into compute, so it
+  # re-runs the quota gate — under the same advisory lock as creation, with the
+  # row re-read inside. Two concurrent wakes both probe `suspended`; the loser
+  # re-reads the winner's `ready` flip and must not double-stamp the clock.
+  # `exclude: sandbox_id` makes the check identical for both ("does the user
+  # have capacity besides this sandbox"), so the loser is never spuriously
+  # refused at the cap for a wake that added no concurrency.
+  defp wake_suspended_sandbox(user_id, sandbox_id) do
+    case _unsafe_get_sandbox(sandbox_id) do
+      %Sandbox{status: "suspended"} ->
+        Fountain.Quotas.with_sandbox_reservation(user_id, [exclude: sandbox_id], fn ->
+          case _unsafe_get_sandbox(sandbox_id) do
+            %Sandbox{status: "suspended"} = sandbox ->
+              update_sandbox(sandbox, %{
+                status: "ready",
+                last_resumed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+              })
+
+            sandbox ->
+              {:ok, sandbox}
+          end
+        end)
+
+      sandbox ->
+        {:ok, sandbox}
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -478,9 +478,14 @@ defmodule Fountain.Conversations.ConversationServer do
     case substitute_agent_mcp(agent, env, secrets) do
       {:ok, agent} ->
         case sandbox.status do
-          "ready" ->
+          s when s in ["ready", "suspended"] ->
             # The sprite already exists at sprites.dev and was fully provisioned
             # in a previous BEAM lifetime. Reattach instead of recreating.
+            # `suspended` normally becomes `ready` under the quota reservation
+            # in wake_conversation before this server starts; seeing it here
+            # means the reaper parked the row mid-wake. Reattaching is still
+            # right — the catch-all below would provision a second sprite over
+            # a live one — and do_reattach flips the row back to ready.
             reattach(state, conv, sandbox, agent, env, secrets)
 
           s when s in ["pending", "starting"] ->
@@ -593,7 +598,7 @@ defmodule Fountain.Conversations.ConversationServer do
             state
             | sprite: sprite,
               sprite_env: sprite_env,
-              sandbox_started_at: sandbox.inserted_at
+              sandbox_started_at: sandbox_clock_start(sandbox)
           }
 
           # Any prompt this conversation was started for arrives as a cast,
@@ -761,11 +766,28 @@ defmodule Fountain.Conversations.ConversationServer do
         # between the original provision and this reattach.
         Fountain.Conversations.Provisioning.write_env_file(sprite, sprite_env)
 
+        # Normally the wake path already flipped suspended → ready under the
+        # quota reservation; this covers the reaper parking the row mid-wake.
+        # Without it the row would stay `suspended` under a live server —
+        # invisible to the quota and unreachable by any reaper pass.
+        sandbox =
+          if sandbox.status == "suspended" do
+            {:ok, s} =
+              Conversations.update_sandbox(sandbox, %{
+                status: "ready",
+                last_resumed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+              })
+
+            s
+          else
+            sandbox
+          end
+
         new_state = %{
           state
           | sprite: sprite,
             sprite_env: sprite_env,
-            sandbox_started_at: sandbox.inserted_at
+            sandbox_started_at: sandbox_clock_start(sandbox)
         }
 
         new_state = reattach_running_turn(new_state)
@@ -1440,6 +1462,12 @@ defmodule Fountain.Conversations.ConversationServer do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
+  # The absolute lifetime ceiling measures a continuous run, not calendar age:
+  # a wake from `suspended` stamps `last_resumed_at` and restarts the clock,
+  # while a deploy reattach of a `ready` row stamps nothing and keeps it.
+  # SandboxReaper.expired?/2 must agree with this — change both together.
+  defp sandbox_clock_start(sandbox), do: sandbox.last_resumed_at || sandbox.inserted_at
+
   defp schedule_lifecycle_check do
     # Interval overridable in tests so the timer wiring itself is testable —
     # dropping schedule_lifecycle_check() from init/1 used to pass the whole
@@ -1450,11 +1478,49 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp touch_activity(state), do: %{state | last_activity_at: DateTime.utc_now()}
 
-  # Tear down the sprite and stop, leaving the conversation `idle` so the next
-  # prompt wakes it with a fresh sandbox. Setting the conversation `terminated`
-  # here would make it permanently unresumable — a cost control turning into
-  # data loss. See Fountain.Conversations.Lifecycle.
-  defp reclaim_sandbox(state, reason) do
+  # Idle: park, don't destroy. The sprite scales to zero on its own and costs
+  # ~nothing while suspended (decisions/0017), and its disk holds the runtime
+  # session — the agent's memory of the conversation, which #649 proved cannot
+  # be rebuilt on a fresh sprite. Stopping the server frees the BEAM side; the
+  # next prompt reattaches to the same sprite via wake_conversation.
+  defp reclaim_sandbox(state, :idle) do
+    Logger.info(
+      "suspending sandbox for conv #{state.conversation_id}: idle " <>
+        "(sprite #{inspect(state.sprite && state.sprite.name)})"
+    )
+
+    if state.sandbox_id do
+      sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
+
+      if sandbox.status not in ["terminated", "failed"] do
+        {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+      end
+    end
+
+    # The conversation stays idle and resumable; the sprite stays parked.
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
+
+    # Same stage/state as the reclaim below (LogEvent's state set is closed and
+    # clients already key on the "sandbox" stage); `event` is the discriminator.
+    publish_stage(state.conversation_id, "sandbox", "done", %{
+      event: "suspended",
+      reason: "idle",
+      message: Lifecycle.explain(:idle)
+    })
+
+    :telemetry.execute([:fountain, :sandbox, :suspended], %{count: 1}, %{})
+
+    {:stop, :normal, %{state | sprite: nil}}
+  end
+
+  # Max lifetime: tear down the sprite and stop. This bound exists for the
+  # conversation that never stops being busy — it fires with a detachable
+  # session still running on the sprite, so parking would leave that exec
+  # burning unattended. The conversation stays `idle` and resumable; setting it
+  # `terminated` here would make a cost control into data loss. See
+  # Fountain.Conversations.Lifecycle.
+  defp reclaim_sandbox(state, :max_lifetime = reason) do
     Logger.info(
       "reclaiming sandbox for conv #{state.conversation_id}: #{reason} " <>
         "(sprite #{inspect(state.sprite && state.sprite.name)})"
@@ -1471,7 +1537,6 @@ defmodule Fountain.Conversations.ConversationServer do
       end
     end
 
-    # The conversation stays idle and resumable; only the sandbox is gone.
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
 
@@ -1479,8 +1544,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # started/done/failed/interrupted, and both the CLI and the LiveView switch
     # on it. A reclaimed sandbox is a stage that reached its end, so "done" is
     # accurate and needs no client to learn a new word; the `reason` and
-    # `message` fields carry what actually happened. The new part clients key on
-    # is the "sandbox" stage itself.
+    # `message` fields carry what actually happened.
     publish_stage(state.conversation_id, "sandbox", "done", %{
       event: "reclaimed",
       reason: to_string(reason),

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -1,52 +1,45 @@
 defmodule Fountain.Conversations.Lifecycle do
   @moduledoc """
-  How long a sandbox is allowed to exist.
-
-  Nothing bounded this before. A sandbox lived until something explicitly
-  terminated it, and `docs/primitives.md` told users "the sandbox exits when the
-  conversation terminates **or a timeout hits**" — describing a safeguard that
-  was never built. Production had a `ready` sandbox continuously alive since
-  2026-05-10, 83 days idle, billing and holding a slot against its owner's
-  concurrent-sandbox cap the whole time.
+  How long a sandbox is allowed to run unattended, and what crossing each
+  bound costs.
 
   Two bounds, both off by setting the value to `nil` or `0`:
 
   * **Idle timeout** — no turn activity for this long and the sandbox is
-    reclaimed. This is the one that recovers abandoned conversations, which is
-    the common case: someone starts a run, reads the answer, closes the tab.
+    **suspended**: the ConversationServer stops, the sprite stays alive at
+    sprites.dev and scales itself to zero, and the sandbox row parks in
+    `suspended`. The next prompt reattaches to the same sprite — same disk,
+    same runtime session, so the agent keeps its memory of the conversation.
+    This is the common case: someone starts a run, reads the answer, closes
+    the tab. See decisions/0017.
 
-  * **Max lifetime** — an absolute ceiling from sandbox creation, regardless of
-    activity. Catches the case an idle timeout cannot: a conversation that keeps
-    itself busy forever.
+  * **Max lifetime** — a ceiling on a *continuous run*, measured from the
+    sandbox's creation or its last wake from `suspended`
+    (`last_resumed_at || inserted_at`). Crossing it **destroys** the sprite.
+    It catches the case the idle bound cannot: a conversation that keeps
+    itself busy forever, burning compute unattended.
 
-  ## What reclaiming costs
+  ## Why the split
 
-  Only the *sandbox* is torn down. The conversation row stays `idle`, which
-  keeps it resumable — `assert_resumable/1` only refuses `terminated` and
-  `failed`. The next prompt goes through `wake_conversation/2`, which sees a
-  sandbox that is no longer `ready`, provisions a fresh one, and passes the
-  persisted `runtime_session_id`.
+  The original design (#233) destroyed the sprite on both bounds, on the
+  premise that an idle sprite bills indefinitely. It doesn't — sprites scale
+  to zero on their own — and #649 measured what the destroy costs: the
+  runtime's session lives in the sandbox's filesystem, so resuming onto a new
+  sprite fails on every path we have (`claude --resume` answers "No
+  conversation found with session ID"; ACP `session/resume` answers `-32002
+  Resource not found`). Fountain's own transcript survives either way — every
+  `log_events` row still renders — but the agent's memory does not. So the
+  idle bound, which exists for abandoned-not-runaway conversations, now parks
+  instead of destroying, and only the max-lifetime ceiling still pays the
+  #649 price. `explain/1` tells the user which one they got.
 
-  This module used to claim that the runtime then "resumes the same chat", and
-  that the cost of reclaiming early was therefore "a re-provision on the next
-  prompt, not lost work". **That is false, and #649 has the measurement.** The
-  runtime's session lives in the *sandbox's* filesystem, and the environment
-  checkpoint a fresh provision restores is taken before any turn ran, so it
-  cannot contain one. Resuming onto a new sprite fails on every path we have:
-  `claude --resume` answers "No conversation found with session ID" and ACP's
-  `session/resume` answers `-32002 Resource not found`.
+  Suspended sandboxes are never aged out — a parked sprite is treated as
+  costing nothing (decisions/0017), and the disk it holds is the agent's
+  memory.
 
-  So the honest asymmetry is narrower than the one the defaults were chosen
-  under. Being wrong in the reclaiming direction costs the agent's memory of
-  the conversation — Fountain's own transcript is untouched, every `log_events`
-  row still renders, so the loss is invisible in the UI and visible only in the
-  agent's answers. Being wrong in the other direction bills indefinitely.
-  Reclaiming is still right; it is just not free, and `explain/1` says so
-  rather than promising otherwise.
-
-  Setting the conversation itself to `terminated` here would *not* be safe — it
-  would make the conversation permanently unresumable, turning a cost control
-  into data loss.
+  Setting the conversation itself to `terminated` on either bound would *not*
+  be safe — it would make the conversation permanently unresumable, turning a
+  cost control into data loss.
   """
 
   @default_idle_minutes 60
@@ -115,24 +108,22 @@ defmodule Fountain.Conversations.Lifecycle do
   Worth spending words on: from the user's side the sandbox simply went away,
   and an explanation is the difference between a bug report and a shrug.
 
-  It must not overstate what survived. The transcript does; the agent's context
-  does not (#649). Telling someone "history is preserved" and then having the
-  agent answer as though the conversation never happened is worse than saying
-  nothing, because they believe the first sentence and read the second as the
-  model being broken.
+  The two bounds now promise different things and the copy must not blur
+  them. A suspend keeps the sprite's disk, so the agent genuinely resumes
+  with its memory; a max-lifetime reclaim destroys it, and the agent's
+  context goes with it (#649). Telling someone "history is preserved" on the
+  destroy path — or hedging on the suspend path — makes the true sentence
+  discredit the other.
   """
   @spec explain(:idle | :max_lifetime) :: String.t()
   def explain(:idle) do
-    "Sandbox reclaimed after #{minutes(idle_timeout_seconds())} minutes idle. " <> resume_caveat()
+    "Sandbox suspended after #{minutes(idle_timeout_seconds())} minutes idle. " <>
+      "Send another prompt to continue — the agent picks up right where it left off."
   end
 
   def explain(:max_lifetime) do
     "Sandbox reclaimed after reaching the #{hours(max_lifetime_seconds())} hour maximum " <>
-      "lifetime. " <> resume_caveat()
-  end
-
-  defp resume_caveat do
-    "Send another prompt to continue — the transcript above is kept, but the " <>
+      "lifetime. Send another prompt to continue — the transcript above is kept, but the " <>
       "agent starts a fresh session and will not remember the earlier turns."
   end
 

--- a/apps/fountain/lib/fountain/conversations/sandbox.ex
+++ b/apps/fountain/lib/fountain/conversations/sandbox.ex
@@ -9,12 +9,17 @@ defmodule Fountain.Conversations.Sandbox do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
-  @statuses ~w(pending starting ready terminated failed)
+  # `suspended`: the sprite still exists at sprites.dev (scaled to zero on its
+  # own) but no ConversationServer is attached. The durable resting state of an
+  # idle conversation — not counted toward the concurrency quota, woken by the
+  # next prompt via the reattach path. See decisions/0017.
+  @statuses ~w(pending starting ready suspended terminated failed)
 
   schema "sandboxes" do
     field :sprite_name, :string
     field :status, :string, default: "pending"
     field :terminated_at, :utc_datetime
+    field :last_resumed_at, :utc_datetime
     belongs_to :environment, Environment
     belongs_to :user, User
     has_many :conversations, Conversation
@@ -25,7 +30,14 @@ defmodule Fountain.Conversations.Sandbox do
 
   def changeset(sandbox, attrs) do
     sandbox
-    |> cast(attrs, [:sprite_name, :status, :terminated_at, :environment_id, :user_id])
+    |> cast(attrs, [
+      :sprite_name,
+      :status,
+      :terminated_at,
+      :last_resumed_at,
+      :environment_id,
+      :user_id
+    ])
     |> validate_required([:sprite_name, :status, :user_id])
     |> validate_inclusion(:status, @statuses)
   end

--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -12,11 +12,15 @@ defmodule Fountain.Quotas do
 
   ## What counts
 
-  A sandbox is "active" while its status is anything other than `terminated` or
-  `failed`, matching the definition used by the admin sandbox view. `pending`
-  and `starting` both count: a sprite is being paid for from the moment
-  provisioning begins, and counting only `ready` would let a burst of concurrent
-  starts sail past the cap before any of them settle.
+  A sandbox counts while it is compute: `pending`, `starting` and `ready`.
+  `pending` and `starting` count because a sprite is being paid for from the
+  moment provisioning begins, and counting only `ready` would let a burst of
+  concurrent starts sail past the cap before any of them settle. `suspended`
+  deliberately does NOT count — a parked sprite is scaled to zero and costs
+  ~nothing (decisions/0017) — which means this set is narrower than the admin
+  sandbox view's "anything non-terminal": the admin table will list a suspended
+  sandbox that the per-user counter ignores. Waking one re-runs the quota gate
+  (`Conversations.wake_suspended_sandbox/2`).
   """
 
   import Ecto.Query

--- a/apps/fountain/lib/fountain/telemetry.ex
+++ b/apps/fountain/lib/fountain/telemetry.ex
@@ -131,6 +131,7 @@ defmodule Fountain.Telemetry do
       @prefix ++ [:turn, :first_output],
       @prefix ++ [:turn, :completed],
       @prefix ++ [:sandbox, :reclaimed],
+      @prefix ++ [:sandbox, :suspended],
       @prefix ++ [:reaper, :run],
       @prefix ++ [:reaper, :untracked],
       @prefix ++ [:usage, :dropped]

--- a/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
@@ -71,7 +71,7 @@ defmodule Fountain.Workers.SandboxReaper do
   @impl Oban.Worker
   def perform(_job) do
     released = release_stuck_sandboxes()
-    expired = expire_abandoned_sandboxes()
+    {parked, expired} = sweep_abandoned_sandboxes()
 
     result =
       case list_sprites() do
@@ -80,8 +80,8 @@ defmodule Fountain.Workers.SandboxReaper do
           untracked = report_untracked(live_names)
 
           Logger.info(
-            "reaper: released=#{released} expired=#{expired} destroyed=#{destroyed} " <>
-              "untracked=#{untracked} live=#{MapSet.size(live_names)}"
+            "reaper: released=#{released} parked=#{parked} expired=#{expired} " <>
+              "destroyed=#{destroyed} untracked=#{untracked} live=#{MapSet.size(live_names)}"
           )
 
           :ok
@@ -93,7 +93,13 @@ defmodule Fountain.Workers.SandboxReaper do
           {:error, reason}
       end
 
-    :telemetry.execute([:fountain, :reaper, :run], %{released: released, expired: expired}, %{})
+    # `parked` is its own measurement: parks are reversible bookkeeping, and
+    # folding them into `expired` would silently change what that metric means.
+    :telemetry.execute(
+      [:fountain, :reaper, :run],
+      %{released: released, parked: parked, expired: expired},
+      %{}
+    )
 
     result
   end
@@ -158,44 +164,68 @@ defmodule Fountain.Workers.SandboxReaper do
 
   # ── pass 1b: ready sandboxes nobody is holding ────────────────────────────
 
+  # A `ready` row whose server died mid-wake looks identical to an abandoned
+  # one until the new server registers in Horde — whose registry is an async
+  # CRDT, so `server_alive?/1` can briefly miss a live server on another node.
+  # The wake path touches `updated_at` when it flips `suspended → ready`, so a
+  # grace period on `updated_at` makes a just-woken row untouchable for far
+  # longer than registry propagation takes.
+  @abandoned_grace_minutes 15
+
   @doc """
-  Marks `ready` sandboxes past their lifetime bound as terminated.
+  Sweeps `ready` sandboxes with no live server past a lifetime bound: past the
+  idle bound they are parked to `suspended` (the sprite stays, scaled to zero,
+  and the next prompt reattaches — decisions/0017); past the max-lifetime
+  ceiling they are terminated, and pass 2 destroys the sprite this same run.
 
   This is the half of #167 that the ConversationServer cannot do. The server
-  enforces its own idle timeout while it is alive, but a sandbox whose server
+  enforces its own bounds while it is alive, but a sandbox whose server
   died — a crash, a node that left the cluster, a deploy that happened to land
   between the rehydrator's scan and a reattach — has nothing watching it. The
   83-day-old sandbox in production was exactly that: `ready`, no server, alive
   since 2026-05-10.
+
+  `suspended` rows deliberately match no pass: that is the durable resting
+  state, aged out by nothing (decisions/0017).
 
   Activity is read from the conversation's most recent turn rather than from
   `sandboxes.updated_at` or `conversations.updated_at`, both of which get
   touched by bookkeeping the user had nothing to do with — the rehydrator moves
   `conversations.updated_at` on every boot, which would make an abandoned
   conversation look freshly active after each deploy.
+
+  Returns `{parked, expired}`.
   """
-  def expire_abandoned_sandboxes do
+  def sweep_abandoned_sandboxes do
     idle = Lifecycle.idle_timeout_seconds()
     max_lifetime = Lifecycle.max_lifetime_seconds()
 
     if is_nil(idle) and is_nil(max_lifetime) do
-      0
+      {0, 0}
     else
       now = DateTime.utc_now()
+      grace_cutoff = DateTime.add(now, -@abandoned_grace_minutes * 60, :second)
 
-      Sandbox
-      |> where([s], s.status == "ready")
-      |> Repo.all()
-      |> Repo.preload(:conversations)
-      |> Enum.reject(&server_alive?/1)
-      |> Enum.filter(&expired?(&1, now))
-      |> Enum.map(&expire/1)
-      |> length()
+      verdicts =
+        Sandbox
+        |> where([s], s.status == "ready" and s.updated_at < ^grace_cutoff)
+        |> Repo.all()
+        |> Repo.preload(:conversations)
+        |> Enum.reject(&server_alive?/1)
+        |> Enum.map(&{&1, check_bounds(&1, now)})
+
+      parked = for {sandbox, {:expired, :idle}} <- verdicts, do: park(sandbox)
+      expired = for {sandbox, {:expired, :max_lifetime}} <- verdicts, do: expire(sandbox)
+
+      {length(parked), length(expired)}
     end
   end
 
-  defp expired?(sandbox, now) do
-    Lifecycle.check(sandbox.inserted_at, last_activity_at(sandbox), false, now) != :ok
+  # Same clock as ConversationServer.sandbox_clock_start/1: the max-lifetime
+  # ceiling measures a continuous run, restarting on a wake from `suspended`.
+  defp check_bounds(sandbox, now) do
+    started_at = sandbox.last_resumed_at || sandbox.inserted_at
+    Lifecycle.check(started_at, last_activity_at(sandbox), false, now)
   end
 
   # Newest turn across the sandbox's conversations, falling back to when the
@@ -216,6 +246,22 @@ defmodule Fountain.Workers.SandboxReaper do
     latest || inserted_at
   end
 
+  # Idle with no server: the server that would have suspended it is gone, so
+  # park it here. Reversible bookkeeping — the sprite stays, and the next
+  # prompt wakes it through the ordinary reattach path.
+  defp park(sandbox) do
+    {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+
+    Logger.info(
+      "reaper: parked idle sandbox #{sandbox.id} (#{sandbox.sprite_name}) — " <>
+        "ready with no live server past the idle bound"
+    )
+
+    record_reap(sandbox, "sandbox.suspended", %{"reason" => "idle with no live server"})
+
+    sandbox
+  end
+
   defp expire(sandbox) do
     {:ok, _} =
       Conversations.update_sandbox(sandbox, %{
@@ -225,13 +271,14 @@ defmodule Fountain.Workers.SandboxReaper do
 
     Logger.info(
       "reaper: expired abandoned sandbox #{sandbox.id} (#{sandbox.sprite_name}) — " <>
-        "ready with no live server past its lifetime bound"
+        "ready with no live server past the max-lifetime ceiling"
     )
 
-    record_reap(sandbox, "sandbox.expired", %{"reason" => "past lifetime bound"})
+    record_reap(sandbox, "sandbox.expired", %{"reason" => "past max lifetime"})
 
     # The conversation is deliberately left alone. It stays resumable, and the
-    # next prompt provisions a fresh sandbox with the same runtime session.
+    # next prompt provisions a fresh sandbox (the runtime session on the
+    # destroyed disk is lost — the price of the ceiling, see decisions/0017).
     # The sprite itself is destroyed by pass 2 on this same run, now that the
     # row is terminal.
     sandbox

--- a/apps/fountain/lib/fountain_web/live/admin_live/helpers.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/helpers.ex
@@ -15,6 +15,7 @@ defmodule FountainWeb.AdminLive.Helpers do
 
   def sandbox_status_color("running"), do: "bg-blue-100 text-blue-800 border-blue-200"
   def sandbox_status_color("ready"), do: "bg-green-100 text-green-800 border-green-200"
+  def sandbox_status_color("suspended"), do: "bg-sky-100 text-sky-800 border-sky-200"
   def sandbox_status_color("failed"), do: "bg-red-100 text-red-700 border-red-200"
   def sandbox_status_color(_), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -22,7 +22,7 @@ defmodule FountainWeb.Schemas do
         sprite_name: %Schema{type: :string},
         status: %Schema{
           type: :string,
-          enum: ~w(pending starting ready terminated failed)
+          enum: ~w(pending starting ready suspended terminated failed)
         }
       },
       required: [:id, :sprite_name, :status]

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -238,12 +238,21 @@ defmodule FountainWeb.Telemetry do
       # ── Lifecycle sweeps ──────────────────────────────────────────────────
       counter("fountain.sandbox.reclaimed.count",
         event_name: [:fountain, :sandbox, :reclaimed],
-        description: "Sandboxes reclaimed by the lifecycle bounds"
+        description: "Sandboxes destroyed by the max-lifetime ceiling"
+      ),
+      counter("fountain.sandbox.suspended.count",
+        event_name: [:fountain, :sandbox, :suspended],
+        description: "Sandboxes parked by the idle bound (sprite kept, decisions/0017)"
       ),
       sum("fountain.reaper.run.released",
         event_name: [:fountain, :reaper, :run],
         measurement: :released,
         description: "Sprites released by SandboxReaper runs"
+      ),
+      sum("fountain.reaper.run.parked",
+        event_name: [:fountain, :reaper, :run],
+        measurement: :parked,
+        description: "Idle server-less sandboxes parked to suspended by SandboxReaper runs"
       ),
       sum("fountain.reaper.run.expired",
         event_name: [:fountain, :reaper, :run],

--- a/apps/fountain/priv/repo/migrations/20260813090000_add_last_resumed_at_to_sandboxes.exs
+++ b/apps/fountain/priv/repo/migrations/20260813090000_add_last_resumed_at_to_sandboxes.exs
@@ -1,0 +1,9 @@
+defmodule Fountain.Repo.Migrations.AddLastResumedAtToSandboxes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sandboxes) do
+      add :last_resumed_at, :utc_datetime
+    end
+  end
+end

--- a/apps/fountain/test/fountain/accounts/deletion_test.exs
+++ b/apps/fountain/test/fountain/accounts/deletion_test.exs
@@ -126,6 +126,22 @@ defmodule Fountain.Accounts.DeletionTest do
       assert name == sandbox.sprite_name
     end
 
+    test "suspended sandboxes are destroyed too" do
+      # Suspended is excluded from the quota but its sprite is alive at
+      # sprites.dev — and deletion nilifies user_id, so a sprite missed here
+      # is unfindable afterward, a permanent leak.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "suspended")
+
+      test = self()
+      stub(Sprites, :destroy, fn {:handle, name} -> send(test, {:destroyed, name}) && :ok end)
+
+      capture_log(fn -> assert {:ok, %{sprites_destroyed: 1}} = Deletion.delete_user(user) end)
+
+      assert_received {:destroyed, name}
+      assert name == sandbox.sprite_name
+    end
+
     test "already-terminal sandboxes are not touched again" do
       user = insert_verified_user()
       insert_sandbox(user_id: user.id, status: "terminated")

--- a/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
@@ -53,12 +53,13 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
   end
 
   describe "idle timeout" do
-    test "an idle server tears down its sandbox and stops" do
+    test "an idle server suspends its sandbox — sprite kept — and stops" do
       {conv, sandbox} = aged_conversation(180)
       stub_reattach()
 
-      test = self()
-      stub(Sprites, :destroy, fn _sprite -> send(test, :destroyed) && :ok end)
+      # The whole point of decisions/0017: the sprite's disk holds the agent's
+      # memory, and the idle bound must not destroy it.
+      reject(&Sprites.destroy/1)
 
       with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
         {pid, ref, :alive} = start_server(conv)
@@ -72,11 +73,12 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
         assert :normal = assert_stopped(ref)
       end)
 
-      assert_received :destroyed
-      assert Fountain.Repo.reload(sandbox).status == "terminated"
+      reloaded = Fountain.Repo.reload(sandbox)
+      assert reloaded.status == "suspended"
+      refute reloaded.terminated_at
     end
 
-    test "the timer is actually wired: reclamation fires with no manual tick" do
+    test "the timer is actually wired: suspension fires with no manual tick" do
       {conv, sandbox} = aged_conversation(180)
       stub_reattach()
 
@@ -94,7 +96,7 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
         assert :normal = assert_stopped(ref, 5_000)
       end)
 
-      assert Fountain.Repo.reload(sandbox).status == "terminated"
+      assert Fountain.Repo.reload(sandbox).status == "suspended"
     end
 
     test "the conversation stays resumable" do
@@ -158,9 +160,15 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
   end
 
   describe "max lifetime" do
-    test "an old sandbox is reclaimed even with recent activity" do
+    test "an old sandbox is destroyed even with recent activity" do
+      # The regression anchor for the idle/max split: the ceiling exists for
+      # runaway compute and must KEEP destroying the sprite, unlike the idle
+      # bound above.
       {conv, sandbox} = aged_conversation(60 * 48)
       stub_reattach()
+
+      test = self()
+      stub(Sprites, :destroy, fn _sprite -> send(test, :destroyed) && :ok end)
 
       with_bounds([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 24], fn ->
         {pid, ref, :alive} = start_server(conv)
@@ -169,6 +177,7 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
         assert :normal = assert_stopped(ref)
       end)
 
+      assert_received :destroyed
       assert Fountain.Repo.reload(sandbox).status == "terminated"
     end
 
@@ -187,6 +196,36 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
         send(pid, :lifecycle_check)
         assert_stopped(ref)
       end)
+    end
+
+    test "a wake from suspended restarts the ceiling clock" do
+      # A conversation parked for days must not be destroyed the moment it is
+      # woken: the ceiling measures a continuous run, so it is dated from
+      # last_resumed_at when the sandbox has been through a suspend/wake.
+      {conv, sandbox} = aged_conversation(60 * 48)
+      stub_reattach()
+      reject(&Sprites.destroy/1)
+
+      resumed_at = DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.truncate(:second)
+
+      {:ok, _} =
+        Fountain.Conversations.update_sandbox(Fountain.Repo.reload(sandbox), %{
+          last_resumed_at: resumed_at
+        })
+
+      with_bounds([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 24], fn ->
+        {pid, _ref, :alive} = start_server(conv)
+
+        assert %{sandbox_started_at: started} = :sys.get_state(pid)
+        assert DateTime.compare(started, resumed_at) == :eq
+
+        send(pid, :lifecycle_check)
+        # Two-day-old row, minute-old resume: the server must stay up.
+        assert is_map(:sys.get_state(pid))
+        GenServer.stop(pid)
+      end)
+
+      assert Fountain.Repo.reload(sandbox).status == "ready"
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/lifecycle_test.exs
+++ b/apps/fountain/test/fountain/conversations/lifecycle_test.exs
@@ -123,18 +123,20 @@ defmodule Fountain.Conversations.LifecycleTest do
       end)
     end
 
-    test "does not promise the agent remembers the conversation (#649)" do
-      # It used to say "history is preserved", which is true of the transcript
-      # and false of the agent: the runtime session lives in the sandbox that
-      # was just destroyed, so the next turn starts cold. Believing the promise
-      # makes the agent's amnesia read as a bug in the model.
-      for reason <- [:idle, :max_lifetime] do
-        message = Lifecycle.explain(reason)
+    test "the two bounds promise exactly what each one keeps (#649, 0017)" do
+      # A suspend keeps the sprite's disk — the agent's memory — so the idle
+      # copy may promise a real resume. A max-lifetime reclaim destroys it, and
+      # promising anything more than the transcript makes the agent's amnesia
+      # read as a bug in the model. The copy must not blur the two.
+      idle = Lifecycle.explain(:idle)
+      assert idle =~ "suspended"
+      assert idle =~ "picks up right where it left off"
+      refute idle =~ "will not remember"
 
-        refute message =~ "history is preserved"
-        assert message =~ "will not remember"
-        assert message =~ "transcript"
-      end
+      max = Lifecycle.explain(:max_lifetime)
+      refute max =~ "history is preserved"
+      assert max =~ "will not remember"
+      assert max =~ "transcript"
     end
   end
 end

--- a/apps/fountain/test/fountain/conversations/sandbox_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_test.exs
@@ -16,8 +16,8 @@ defmodule Fountain.Conversations.SandboxTest do
   end
 
   describe "statuses/0" do
-    test "returns all five valid statuses" do
-      assert Sandbox.statuses() == ~w(pending starting ready terminated failed)
+    test "returns all six valid statuses" do
+      assert Sandbox.statuses() == ~w(pending starting ready suspended terminated failed)
     end
   end
 

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1193,6 +1193,88 @@ defmodule Fountain.ConversationsContextTest do
       assert {:ok, _conv} = Conversations.wake_conversation(conv.id)
     end
 
+    test "waking a suspended sandbox flips it to ready and stamps the clock" do
+      # The core of decisions/0017: the parked sprite is reused, re-added to
+      # the quota, and the max-lifetime ceiling restarts from the wake.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite-parked")
+      {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      stub(Fountain.SpritesClient, :get!, fn -> %{} end)
+      stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{name: "test-sprite-parked"}} end)
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
+
+      assert {:ok, woken} = Conversations.wake_conversation(conv.id)
+      # Same sandbox — no fresh sprite was provisioned.
+      assert woken.sandbox_id == sandbox.id
+
+      reloaded = Repo.reload(sandbox)
+      assert reloaded.status == "ready"
+      assert %DateTime{} = reloaded.last_resumed_at
+    end
+
+    test "waking a suspended sandbox re-runs the quota gate" do
+      # A parked sprite is free; waking it is compute again. A user at their
+      # cap must be refused, exactly as if they were starting a conversation.
+      user = insert_verified_user()
+      {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 1)
+      agent = insert_agent(user_id: user.id)
+
+      insert_sandbox(user_id: user.id, status: "ready")
+
+      sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite-capped")
+      {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      stub(Fountain.SpritesClient, :get!, fn -> %{} end)
+      stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{}} end)
+
+      assert {:error, {:sandbox_quota_exceeded, _}} = Conversations.wake_conversation(conv.id)
+      # Refused means still parked — the row must not be half-woken.
+      assert Repo.reload(sandbox).status == "suspended"
+    end
+
+    test "a transient sprite probe failure does not give up a suspended sandbox" do
+      # Falling to :create_new would retire the row and route the still-live
+      # sprite — the agent's memory — to the reaper's destroy pass. Only a
+      # definitive not-found may do that; anything else fails retryably.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite-blip")
+      {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      stub(Fountain.SpritesClient, :get!, fn -> %{} end)
+      stub(Sprites, :get_sprite, fn _client, _name -> {:error, :timeout} end)
+
+      assert {:error, :sprite_probe_failed} = Conversations.wake_conversation(conv.id)
+      assert Repo.reload(sandbox).status == "suspended"
+    end
+
+    test "a definitively gone sprite retires the suspended sandbox and provisions fresh" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite-vanished")
+      {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      stub(Fountain.SpritesClient, :get!, fn -> %{} end)
+      stub(Sprites, :get_sprite, fn _client, _name -> {:error, {:not_found, %{}}} end)
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
+
+      assert {:ok, woken} = Conversations.wake_conversation(conv.id)
+      assert woken.sandbox_id != sandbox.id
+      assert Repo.reload(sandbox).status == "terminated"
+    end
+
     test "returns {:ok, conv} creating fresh sandbox when sprite is gone" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -36,6 +36,18 @@ defmodule Fountain.QuotasTest do
       assert Quotas.active_sandbox_count(user.id) == 1
     end
 
+    test "suspended does not count — a parked sprite is not compute (0017)" do
+      # Otherwise five abandoned conversations would permanently lock a
+      # default-cap tenant out of starting anything. Waking a suspended
+      # sandbox re-runs the gate (Conversations.wake_suspended_sandbox/2).
+      user = insert_verified_user()
+
+      insert_sandbox(user_id: user.id, status: "ready")
+      insert_sandbox(user_id: user.id, status: "suspended")
+
+      assert Quotas.active_sandbox_count(user.id) == 1
+    end
+
     test "exclude: leaves the named sandbox out" do
       user = insert_verified_user()
       keep = insert_sandbox(user_id: user.id, status: "ready")

--- a/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
+++ b/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
@@ -121,7 +121,13 @@ defmodule Fountain.Workers.SandboxReaperTest do
 
     defp age_rows(sandbox, conv, minutes) do
       ts = minutes_ago(minutes)
-      Repo.update_all(from(s in Sandbox, where: s.id == ^sandbox.id), set: [inserted_at: ts])
+
+      # updated_at ages too: the sweep's grace window keys on it, and a row
+      # this old that was genuinely abandoned has not been touched either.
+      Repo.update_all(
+        from(s in Sandbox, where: s.id == ^sandbox.id),
+        set: [inserted_at: ts, updated_at: ts]
+      )
 
       if conv do
         Repo.update_all(
@@ -133,9 +139,12 @@ defmodule Fountain.Workers.SandboxReaperTest do
       Repo.reload(sandbox)
     end
 
-    test "a ready sandbox with no server and no recent turn is expired" do
+    test "past the ceiling with no server, a ready sandbox is expired" do
       # The 83-day production sandbox. Its ConversationServer is long gone, so
-      # nothing was watching it — the server-side idle timeout cannot help.
+      # nothing was watching it. Both bounds are crossed at that age and the
+      # ceiling wins: an unattended row this old only exists if the reaper
+      # itself was down past the idle window that would have parked it, and
+      # the ceiling is the backstop that still bounds it.
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id, status: "ready")
       conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
@@ -143,7 +152,7 @@ defmodule Fountain.Workers.SandboxReaperTest do
       sandbox = age_rows(sandbox, conv, 60 * 24 * 83)
 
       with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
-        capture_log(fn -> assert 1 = SandboxReaper.expire_abandoned_sandboxes() end)
+        capture_log(fn -> assert {0, 1} = SandboxReaper.sweep_abandoned_sandboxes() end)
       end)
 
       assert Repo.reload(sandbox).status == "terminated"
@@ -155,6 +164,75 @@ defmodule Fountain.Workers.SandboxReaperTest do
       refute Repo.reload(conv).status in ~w(terminated failed completed)
     end
 
+    test "past the idle bound but under the ceiling, a ready sandbox is parked" do
+      # The common case after a crash or deploy gap: the server that would
+      # have suspended it is gone. Parking is the reaper doing the server's
+      # idle-suspend on its behalf — the sprite stays (decisions/0017).
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+      insert_turn(conv, %{status: "completed"})
+      sandbox = age_rows(sandbox, conv, 60 * 5)
+
+      capture_destroys()
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        capture_log(fn -> assert {1, 0} = SandboxReaper.sweep_abandoned_sandboxes() end)
+      end)
+
+      reloaded = Repo.reload(sandbox)
+      assert reloaded.status == "suspended"
+      refute reloaded.terminated_at
+      assert destroyed_names() == []
+      assert Repo.reload(conv).status == "idle"
+    end
+
+    test "a suspended sandbox matches no pass, however old" do
+      # The durable resting state: never released, never expired, never
+      # destroyed — its sprite is the agent's memory (decisions/0017).
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "suspended")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+      insert_turn(conv, %{status: "completed"})
+      sandbox = age_rows(sandbox, conv, 60 * 24 * 83)
+
+      stub_sprites([sandbox.sprite_name])
+      capture_destroys()
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        capture_log(fn -> assert :ok = perform_job(SandboxReaper, %{}) end)
+      end)
+
+      assert Repo.reload(sandbox).status == "suspended"
+      assert destroyed_names() == []
+    end
+
+    test "a recently touched ready row is inside the grace window" do
+      # The wake path flips suspended → ready (touching updated_at) before the
+      # new server registers in Horde, whose registry propagates async — so a
+      # mid-wake row looks server-less. The grace window keeps the reaper from
+      # parking it back out from under the reattach.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+      insert_turn(conv, %{status: "completed"})
+
+      # Old activity and an old creation date, but updated_at is fresh.
+      ts = minutes_ago(60 * 5)
+      Repo.update_all(from(s in Sandbox, where: s.id == ^sandbox.id), set: [inserted_at: ts])
+
+      Repo.update_all(
+        from(t in Fountain.Conversations.Turn, where: t.conversation_id == ^conv.id),
+        set: [inserted_at: ts]
+      )
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        assert {0, 0} = SandboxReaper.sweep_abandoned_sandboxes()
+      end)
+
+      assert Repo.reload(sandbox).status == "ready"
+    end
+
     test "recent turn activity keeps a sandbox alive" do
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id, status: "ready")
@@ -162,7 +240,7 @@ defmodule Fountain.Workers.SandboxReaperTest do
       insert_turn(conv, %{status: "completed"})
 
       with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
-        assert 0 = SandboxReaper.expire_abandoned_sandboxes()
+        assert {0, 0} = SandboxReaper.sweep_abandoned_sandboxes()
       end)
 
       assert Repo.reload(sandbox).status == "ready"
@@ -179,7 +257,7 @@ defmodule Fountain.Workers.SandboxReaperTest do
       end)
 
       with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
-        assert 0 = SandboxReaper.expire_abandoned_sandboxes()
+        assert {0, 0} = SandboxReaper.sweep_abandoned_sandboxes()
       end)
 
       assert Repo.reload(sandbox).status == "ready"
@@ -192,7 +270,7 @@ defmodule Fountain.Workers.SandboxReaperTest do
       age_rows(sandbox, conv, 60 * 24 * 83)
 
       with_bounds([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 0], fn ->
-        assert 0 = SandboxReaper.expire_abandoned_sandboxes()
+        assert {0, 0} = SandboxReaper.sweep_abandoned_sandboxes()
       end)
 
       assert Repo.reload(sandbox).status == "ready"
@@ -200,17 +278,18 @@ defmodule Fountain.Workers.SandboxReaperTest do
 
     test "a sandbox that never took a turn is dated from its own creation" do
       # Otherwise a sandbox with no turns has no activity timestamp at all and
-      # would either never expire or expire immediately.
+      # would either never expire or expire immediately. Five hours old crosses
+      # the idle bound but not the ceiling, so the verdict is a park.
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id, status: "ready")
       conv = insert_conversation(user_id: user.id, sandbox: sandbox)
       sandbox = age_rows(sandbox, conv, 60 * 5)
 
       with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
-        capture_log(fn -> assert 1 = SandboxReaper.expire_abandoned_sandboxes() end)
+        capture_log(fn -> assert {1, 0} = SandboxReaper.sweep_abandoned_sandboxes() end)
       end)
 
-      assert Repo.reload(sandbox).status == "terminated"
+      assert Repo.reload(sandbox).status == "suspended"
     end
 
     test "expiring a sandbox makes its sprite eligible for destruction the same run" do

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -95,8 +95,8 @@ defmodule FountainWeb.MetricsTest do
              "untracked is a level, not a delta; as #{inspect(untracked.__struct__)} " <>
                "it accumulates forever instead of tracking the current leak count"
 
-      # released/expired are per-run deltas — those are correct as sums.
-      for measurement <- [:released, :expired] do
+      # released/parked/expired are per-run deltas — those are correct as sums.
+      for measurement <- [:released, :parked, :expired] do
         metric = by_name[[:fountain, :reaper, :run, measurement]]
         assert metric, "fountain.reaper.run.#{measurement} is no longer declared"
         assert metric.__struct__ == Telemetry.Metrics.Sum
@@ -170,6 +170,7 @@ defmodule FountainWeb.MetricsTest do
         [:fountain, :turn, :first_output],
         # :telemetry.execute call sites
         [:fountain, :sandbox, :reclaimed],
+        [:fountain, :sandbox, :suspended],
         [:fountain, :reaper, :run],
         [:fountain, :reaper, :untracked],
         # Audit.record_admin/1 rejection path (#451) — exercised by

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -439,10 +439,15 @@ func handleStageEvent(data map[string]any) (bool, error) {
 		return true, nil
 
 	case stage == "sandbox" && state == "done":
-		// The sandbox was reclaimed and the server stopped. An idle
-		// reclaim means no turn was running — a clean end. A max-lifetime
-		// reclaim can cut a running turn short, so it exits non-zero.
+		// The server stopped and no more events are coming. An idle
+		// suspend keeps the sprite — the next prompt resumes the agent
+		// where it left off, a clean end. A max-lifetime reclaim destroys
+		// it and can cut a running turn short, so it exits non-zero.
 		reason := innerDataString(data, "reason")
+		if innerDataString(data, "event") == "suspended" {
+			fmt.Fprintf(os.Stderr, "▸ sandbox suspended (%s) — send another prompt to resume where you left off\n", reason)
+			return true, nil
+		}
 		fmt.Fprintf(os.Stderr, "▸ sandbox reclaimed (%s) — the conversation stays resumable\n", reason)
 		if reason == "max_lifetime" {
 			return true, errSandboxExpired

--- a/cli/internal/cmd/conv_test.go
+++ b/cli/internal/cmd/conv_test.go
@@ -100,8 +100,17 @@ func TestHandleStageEvent(t *testing.T) {
 			wantErr:  nil,
 		},
 		{
-			// Idle reclaim means no turn was running: a clean end.
-			name:     "sandbox reclaimed for idleness is a clean terminal",
+			// Idle suspend keeps the sprite: a clean end, resumable with
+			// the agent's memory intact.
+			name:     "sandbox suspended for idleness is a clean terminal",
+			data:     map[string]any{"stage": "sandbox", "state": "done", "data": `{"event":"suspended","reason":"idle"}`},
+			terminal: true,
+			wantErr:  nil,
+		},
+		{
+			// An old server can still send the pre-0017 idle reclaim; it
+			// stays a clean exit.
+			name:     "legacy idle reclaim is a clean terminal",
 			data:     map[string]any{"stage": "sandbox", "state": "done", "data": `{"event":"reclaimed","reason":"idle"}`},
 			terminal: true,
 			wantErr:  nil,

--- a/config/config.exs
+++ b/config/config.exs
@@ -43,11 +43,12 @@ config :fountain,
   registration_enabled: true,
   registration_allowed_email_domains: []
 
-# Sandbox lifetime bounds. A sandbox used to live until something explicitly
-# terminated it; production had one idle for 83 days. Reclaiming only tears down
-# the sandbox — the conversation stays resumable and the next prompt provisions
-# a fresh one — so the cost of being wrong here is a re-provision, not lost
-# work. Set either to 0 to disable. See Fountain.Conversations.Lifecycle.
+# Sandbox lifetime bounds. Crossing the idle bound SUSPENDS the sandbox — the
+# sprite stays (scaled to zero) and the next prompt resumes the agent with its
+# memory intact, so this bound is free to be aggressive. Crossing the
+# max-lifetime ceiling DESTROYS the sprite, and the agent's session with it
+# (#649) — it exists to bound runaway busy compute. Set either to 0 to
+# disable. See Fountain.Conversations.Lifecycle and decisions/0017.
 config :fountain,
   sandbox_idle_timeout_minutes: 60,
   sandbox_max_lifetime_hours: 24

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -501,6 +501,16 @@ being *unavoidable* — sandboxes are bounded whatever the protocol does — and
 ACP at least failing loudly, with a session id it was actually asked for,
 where the legacy path fails on an id it guessed.
 
+> **Correction, 2026-08-13 (decisions/0017).** The idle bound no longer
+> destroys the sprite: an idle sandbox is *suspended* — the sprite stays,
+> scaled to zero, and the next prompt reattaches to the same disk, so the
+> session survives and this section's failure mode applies only to the
+> max-lifetime ceiling (and to explicit termination). The premise this ADR
+> inherited from `Lifecycle` — that an idle sprite bills until destroyed —
+> was itself wrong; sprites stop billing on their own. The turn-scoped
+> connection stays correct on 0017's terms too: nothing is attached between
+> turns, whether the sandbox is parked or destroyed.
+
 ### Gate 3 — permissions — **not built**
 
 Implement `session/request_permission` against the conversation LiveView: a

--- a/decisions/0017-suspend-idle-sandboxes.md
+++ b/decisions/0017-suspend-idle-sandboxes.md
@@ -1,0 +1,91 @@
+# 0017 — Suspend idle sandboxes instead of destroying them
+
+**Status:** Accepted (built in the PR that added this document)
+**Date:** 2026-08-13
+
+## Context
+
+Since #233, both lifetime bounds destroyed the sprite: the ConversationServer
+called `Sprites.destroy` when a conversation crossed the idle timeout or the
+max-lifetime ceiling, and the reaper's abandoned-sandbox pass did the same for
+rows whose server had died. The design was chosen under the premise that an
+idle sprite bills indefinitely — the motivating incident was a sandbox idle
+for 83 days.
+
+That premise was wrong. Sprites scale themselves to zero when idle and cost
+approximately nothing while suspended; the sprite does not need Fountain's
+help to stop billing. Meanwhile #649 measured what the destroy costs: the
+runtime's session lives in the sandbox's filesystem, so resuming onto a fresh
+sprite fails on every path we have (`claude --resume` answers "No conversation
+found with session ID"; ACP `session/resume` answers `-32002 Resource not
+found`). Every idle reclaim guaranteed the agent's amnesia to save money we
+were not spending. The response at the time (#651) was honest UX copy; #664
+raised the production idle bound to four hours so human-gated incident
+conversations would survive review — treating the symptom, because the disk
+loss itself was assumed to be the price of cost control.
+
+## Decision
+
+Split the two bounds by what they actually protect against:
+
+- **Idle timeout → suspend.** The ConversationServer stops, the sprite is left
+  alone (it scales to zero on its own), and the sandbox row parks in a new
+  `suspended` status. The next prompt reattaches to the same sprite through
+  the existing reuse path — same disk, same runtime session, real resume.
+- **Max lifetime → destroy**, unchanged. The ceiling exists for the
+  conversation that never stops being busy; it fires with a detachable
+  session still running on the sprite, and parking would leave that exec
+  burning unattended. Its price — the #649 session loss — is still stated
+  honestly in the stage message.
+
+`suspended` means: sprite alive at sprites.dev, no ConversationServer, woken
+only by the next prompt. It is excluded from the concurrency quota (a parked
+sprite is not compute; waking one re-runs the quota gate under the same
+advisory lock as creation) and from boot rehydration (parked conversations
+wake on demand, not on deploy).
+
+The max-lifetime clock measures a **continuous run**, not calendar age:
+`sandboxes.last_resumed_at` is stamped on each wake from `suspended`, and the
+ceiling is measured from `last_resumed_at || inserted_at`. A deploy reattach
+of a `ready` row stamps nothing, so restarts still cannot reset the ceiling —
+the property #233 encoded — while a conversation parked for a week is not
+destroyed the moment it is woken.
+
+## Accepted costs
+
+- **Suspended sandboxes are never aged out.** Sprites accumulate per tenant at
+  sprites.dev indefinitely. This is deliberate: the parked-sprite cost is
+  treated as zero, and the disk is the agent's memory. If that cost stops
+  being ignorable — or a sprites.dev account-level sprite cap starts binding —
+  a retention bound for `suspended` rows is the knob to add, with the #649
+  caveat attached.
+- **Usage metering blurs at the edges, in both directions.** A sandbox that
+  suspends and later terminates includes its parked time in the
+  `sandbox_terminated` `duration_ms`; one that stays suspended forever emits
+  no `sandbox_terminated` at all, so billed sandbox-minutes understate. The ee
+  usage-event vocabulary is closed and suspend-aware metering was not worth
+  new event types while the cost is treated as zero. A `suspended → ready`
+  wake deliberately emits no second `sandbox_provisioned`.
+- **A rolling deploy has a one-time loss window.** An old node waking a
+  suspended row does not recognise the status, provisions a fresh sprite, and
+  the parked disk is destroyed by the reaper. Old nodes cannot *write*
+  `suspended` (their changeset rejects it), so the window is read-only and
+  self-limiting.
+
+## Consequences elsewhere
+
+- The reaper's abandoned pass splits on which bound fired: idle → park to
+  `suspended` (audited as `sandbox.suspended`, actor `system:sandbox_reaper`),
+  max lifetime → terminate as before. A grace window on `updated_at` keeps it
+  from parking a row mid-wake, before the new server registers in Horde's
+  async registry. Suspended rows match no reaper pass.
+- Every sweep that destroys sprites had to learn the status, because the
+  reaper's leak pass only touches terminal rows: account deletion
+  (`Deletion.@non_terminal`) and tenant suspension (`_unsafe_reap_all_for_user`)
+  both include `suspended` explicitly. The quota's active-status list must
+  **never** include it — those two lists now differ on purpose.
+- The admin sandbox view ("anything non-terminal") and the quota counter
+  ("compute only") now legitimately disagree about a suspended sandbox.
+- The production `SANDBOX_IDLE_TIMEOUT_MINUTES=240` override (#664) is
+  reverted: suspension is lossless, so the stock idle bound no longer
+  endangers human-gated incident conversations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,14 +141,19 @@ strings shown in the UI, the SSE stream and the log rows, each with a state of
 5. **`reattach`.** If the server is gone — a deploy, a node loss — but the
    sprite survived, the next prompt (or the boot-time rehydrator) reattaches:
    verify the sprite still exists, rewrite its env, pick a still-running
-   turn's session back up where it left off. If the sprite is gone too, the
-   conversation re-provisions from step 2; the runtime resumes the same
-   session ID, so **history survives sandbox loss**.
-6. **`sandbox`** — reclaim. Every server checks its bounds each minute:
-   [idle timeout or max lifetime](self-hosting.md#sandbox-lifetime) destroys
-   the sprite and marks the sandbox `terminated` — but the conversation goes
-   back to `idle`, resumable. The hourly reaper applies the same bounds to
-   anything a crashed server left behind.
+   turn's session back up where it left off. The runtime's session lives on
+   the sprite's disk, so reattaching to the *same* sprite keeps the agent's
+   memory. If the sprite is gone, the conversation re-provisions from step 2 —
+   Fountain's transcript survives, the agent's session does not (#649).
+6. **`sandbox`** — the lifetime bounds. Every server checks its
+   [bounds](self-hosting.md#sandbox-lifetime) each minute, and they do
+   different things: crossing the **idle timeout** *suspends* — the server
+   stops, the sprite stays (it scales itself to zero) and the sandbox parks in
+   `suspended`, to be woken with everything intact by the next prompt.
+   Crossing the **max lifetime** *destroys* the sprite and marks the sandbox
+   `terminated`; the conversation goes back to `idle`, resumable at the #649
+   price. The hourly reaper applies the same split to anything a crashed
+   server left behind.
 7. **`terminate`.** An explicit `POST .../terminate` destroys the sprite and
    marks the conversation `terminated` — one of the two terminal states,
    alongside `failed`.
@@ -156,12 +161,13 @@ strings shown in the UI, the SSE stream and the log rows, each with a state of
 The two status vocabularies, side by side:
 
 ```
-conversation:  pending -> running -> idle -> running ...  -> failed | terminated
-sandbox:       pending -> starting -> ready               -> terminated | failed
+conversation:  pending -> running -> idle -> running ...     -> failed | terminated
+sandbox:       pending -> starting -> ready <-> suspended    -> terminated | failed
 ```
 
-A conversation outlives its sandboxes: `idle` with a `terminated` sandbox is
-the normal resting state, not an error.
+A conversation outlives its sandboxes: `idle` with a `suspended` sandbox is
+the normal resting state, not an error (and `idle` with a `terminated` one is
+what a max-lifetime reclaim leaves behind).
 
 ---
 
@@ -178,4 +184,4 @@ level — what to run and what the output means — is [Operations](operations.m
 | Streaming dead for some viewers, fine for others, multiple replicas | Erlang clustering — `CLUSTER_DNS_QUERY` |
 | Signups never complete | Mail delivery — see [Email](self-hosting.md#email) |
 | `402 subscription_required` on a self-hosted instance | `BILLING_ENABLED` should be `false` |
-| Sandboxes vanish mid-conversation, work resumes on the next prompt | Working as designed — [lifecycle bounds](self-hosting.md#sandbox-lifetime) |
+| Sandbox suspends between prompts, work resumes on the next one | Working as designed — [lifecycle bounds](self-hosting.md#sandbox-lifetime) |

--- a/docs/integrations/sprites-contract.md
+++ b/docs/integrations/sprites-contract.md
@@ -20,7 +20,7 @@ for checkpoints.
 |---|---|---|
 | Create sprite | `POST /v1/sprites` — JSON `{"name": …}`, allowed 120s | Every conversation start |
 | Get sprite | `GET /v1/sprites/{name}` — 404 → not-found | Waking a conversation, sandbox reuse |
-| Destroy sprite | `DELETE /v1/sprites/{name}` — **404 counts as success** | Terminate, idle reclaim, the reaper, account deletion |
+| Destroy sprite | `DELETE /v1/sprites/{name}` — **404 counts as success** | Terminate, the max-lifetime ceiling, the reaper, account deletion (idle suspension deliberately calls nothing — the sprite scales to zero on its own) |
 | List sprites | `GET /v1/sprites` — paginated, see below | The reaper's hourly reconciliation |
 | Write file | `PUT /v1/sprites/{name}/fs/write?path=…&workingDir=…&mode=…&mkdirParents=…` — raw body | The env file, inline skills, runtime config files |
 | Execute (blocking) | WebSocket `/v1/sprites/{name}/exec` — run to exit, collect output | Package installs, git clones, setup scripts, runtime preparation |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -57,8 +57,8 @@ the event data.
   at their concurrent-sandbox quota. See [Sprites errors](#sprites-errors).
 - **Stuck with no failure** — a conversation `running` with no events
   arriving usually means the sprite-side process died and the exit was
-  missed. Interrupt it, or just send another prompt — waking provisions a
-  fresh sandbox and the runtime resumes the same session:
+  missed. Interrupt it, or just send another prompt — waking reattaches to
+  the existing sprite when it still exists:
 
     ```bash
     fountain conv show <conv-id>          # turn status, sandbox name
@@ -67,11 +67,13 @@ the event data.
     ```
 
 What the statuses mean: `failed` and `terminated` are the two terminal
-states — a further prompt is refused. `idle` with a terminated *sandbox* is
-the normal resting state, not an error: the next prompt re-provisions. The
-stored transcript is unaffected, but the agent starts a fresh session and does
-not carry the earlier turns into it — see the note under
-[Primitives → Conversation](primitives.md).
+states — a further prompt is refused. `idle` with a *suspended* sandbox is
+the normal resting state, not an error: the sprite is parked at sprites.dev,
+scaled to zero, and the next prompt wakes it with the agent's memory intact.
+`idle` with a *terminated* sandbox is what the max-lifetime ceiling (or an
+explicit reap) leaves behind: the next prompt provisions fresh, the stored
+transcript is unaffected, but the agent starts a fresh session — see the note
+under [Primitives → Conversation](primitives.md).
 
 **Quota knock-on:** a crash mid-provision leaves a `pending`/`starting`
 sandbox row that counts against the user's quota (default 5 concurrent).
@@ -81,8 +83,11 @@ reaper logs one summary line per run:
 
 ```bash
 kubectl logs -n fountain -l app=fountain --since=2h | grep 'reaper:'
-# reaper: released=0 expired=0 destroyed=2 untracked=102 live=114
+# reaper: released=0 parked=1 expired=0 destroyed=2 untracked=102 live=114
 ```
+
+(`parked` is the reaper suspending idle server-less sandboxes — reversible
+bookkeeping, not a teardown.)
 
 ---
 

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -103,19 +103,18 @@ A **Conversation** is a running session of an Agent inside a sandboxed VM. It st
 2. Fountain resolves the full env-var set and spawns a Sprites sandbox
 3. The agent runs; log events stream in real time over SSE (`GET /api/conversations/:id/stream`)
 4. Follow-up prompts go to `POST /api/conversations/:id/prompts`; a running turn can be interrupted (`POST .../interrupt`) and the whole conversation ended early (`POST .../terminate`)
-5. The sandbox exits when the conversation terminates, or when it is reclaimed for being idle (default 60 minutes with no turn activity) or for reaching its maximum lifetime (default 24 hours)
+5. After 60 minutes with no turn activity (default) the sandbox is **suspended**: it scales to zero, costs nothing while parked, and the next prompt wakes it with the agent's memory intact. At 24 hours of continuous running (default) it is **destroyed** — the ceiling for a conversation that never stops being busy.
 
-Reclaiming ends the **sandbox**, not the conversation. The conversation stays resumable: the next prompt provisions a fresh sandbox and carries on. Self-hosters can widen or disable both bounds with `SANDBOX_IDLE_TIMEOUT_MINUTES` and `SANDBOX_MAX_LIFETIME_HOURS` (`0` disables).
+Neither bound ends the conversation — it stays resumable either way. Self-hosters can widen or disable both bounds with `SANDBOX_IDLE_TIMEOUT_MINUTES` and `SANDBOX_MAX_LIFETIME_HOURS` (`0` disables).
 
-!!! warning "A reclaimed conversation loses the agent's context"
+!!! note "Suspend keeps the agent's memory; the max-lifetime ceiling does not"
 
-    The stored transcript survives — every turn still renders, and the
-    conversation is still resumable. What does not survive is the *agent's*
-    memory of it: the runtime keeps its session inside the sandbox, so a fresh
-    sandbox means a fresh session, and the next turn answers without the
-    earlier ones. Expect to restate context after a reclaim, or keep the
-    conversation active. Raising `SANDBOX_IDLE_TIMEOUT_MINUTES` trades sandbox
-    cost against how often this happens.
+    The runtime keeps its session on the sandbox's disk. A suspended sandbox
+    keeps that disk, so waking it resumes the agent right where it left off.
+    A sandbox that hits the max-lifetime ceiling is destroyed, disk and all:
+    the stored transcript survives and the conversation stays resumable, but
+    the next turn starts a fresh session and the agent answers without the
+    earlier ones. Expect to restate context after a ceiling reclaim.
 
 ### Status lifecycle
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -210,21 +210,23 @@ the [mail integration guide](integrations/mail.md).
 
 ## Sandbox lifetime
 
-Sandboxes are reclaimed when they go idle or reach a maximum age, so an
-abandoned conversation stops costing you:
+Two bounds, doing different things:
 
 | Setting | Default | |
 |---|---|---|
-| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | No turn activity for this long and the sandbox is torn down |
-| `SANDBOX_MAX_LIFETIME_HOURS` | `24` | Absolute ceiling from creation, regardless of activity |
+| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | No turn activity for this long and the sandbox is **suspended** — the sprite stays, scaled to zero, and the next prompt wakes it with the agent's memory intact |
+| `SANDBOX_MAX_LIFETIME_HOURS` | `24` | Ceiling on a continuous run (from creation or the last wake). Crossing it **destroys** the sprite — the backstop for a conversation that never stops being busy |
 
 Set either to `0` to disable it. A value that is not a non-negative integer
 refuses to boot rather than quietly disabling the bound.
 
-Reclaiming ends the **sandbox**, not the conversation. The conversation stays
-resumable — the next prompt provisions a fresh sandbox and the runtime resumes
-the same session — so the cost of a bound being too aggressive is a
-re-provisioning wait, not lost work.
+Neither bound ends the conversation; it stays resumable either way. The idle
+bound is free to be aggressive — suspension loses nothing. The max-lifetime
+ceiling is not: the runtime session lives on the destroyed disk, so after a
+ceiling reclaim the next prompt provisions fresh and the agent starts without
+its memory of the earlier turns. Suspended sandboxes are never aged out —
+their sprites persist at sprites.dev until the conversation is terminated or
+the account deleted.
 
 ## Billing
 

--- a/ee/test/fountain/usage_metering_test.exs
+++ b/ee/test/fountain/usage_metering_test.exs
@@ -55,6 +55,34 @@ defmodule Fountain.UsageMeteringTest do
 
       assert length(events_for(user.id, "sandbox_provisioned")) == 1
     end
+
+    test "is not re-emitted by a suspend/wake cycle (0017)" do
+      # Waking a suspended sandbox reattaches to a sprite whose provision was
+      # already recorded; a second event would double-count it.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      {:ok, ready} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      {:ok, parked} = Conversations.update_sandbox(ready, %{status: "suspended"})
+      {:ok, _} = Conversations.update_sandbox(parked, %{status: "ready"})
+
+      assert length(events_for(user.id, "sandbox_provisioned")) == 1
+    end
+
+    test "terminating from suspended is not a failed provision" do
+      # `suspended` had to pass through `ready` to get parked — account
+      # deletion or an admin reap of a parked sandbox must not count as a
+      # provisioning failure.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      {:ok, ready} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      {:ok, parked} = Conversations.update_sandbox(ready, %{status: "suspended"})
+      {:ok, _} = Conversations.update_sandbox(parked, %{status: "terminated"})
+
+      assert events_for(user.id, "sandbox_provision_failed") == []
+      assert [_] = events_for(user.id, "sandbox_terminated")
+    end
   end
 
   describe "sandbox_terminated" do

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -120,14 +120,12 @@ spec:
             # unverified-account pruner (#258).
             - name: UNVERIFIED_PRUNE_EXEMPT
               value: jhgaylor
-            # Incident conversations (estate-medic) wait on a human PR merge
-            # mid-runbook; the stock 60-minute idle reclaim erases the
-            # sandbox — and with it the agent's working memory — while the
-            # human is still reviewing. Four hours covers a slow review
-            # without giving up reclaim entirely. Global knob: fountain has
-            # no per-environment lifetime yet.
-            - name: SANDBOX_IDLE_TIMEOUT_MINUTES
-              value: "240"
+            # SANDBOX_IDLE_TIMEOUT_MINUTES is back at the stock 60m default.
+            # The 240m override (#664) existed because idle reclaim used to
+            # destroy the sandbox — and the agent's working memory — while a
+            # human-gated incident (estate-medic) waited on a PR review.
+            # Since decisions/0017 an idle sandbox is suspended, not
+            # destroyed, and waking it restores the agent intact.
             # TRUSTED_PROXIES is deliberately NOT set. Public traffic arrives
             # via the Cloudflare Tunnel (home-cloud k8s/cloudflared/), so the
             # X-Forwarded-For chain is "client, <cloudflared pod>" — every


### PR DESCRIPTION
## What

The idle bound now **suspends** a sandbox instead of destroying it: the ConversationServer stops, the sprite stays alive at sprites.dev (it scales itself to zero — treated as free), and the sandbox row parks in a new `suspended` status. The next prompt reattaches to the same sprite through the existing reuse path — same disk, same runtime session, so **the agent keeps its memory of the conversation**. The max-lifetime ceiling still destroys; it exists to bound runaway busy compute, and its stage message still states the #649 price honestly.

decisions/0017 records the decision and its accepted costs; decisions/0014's "reclaim finding" section gets a boxed correction.

## Why

Idle reclaim was built (#233) on the premise that an idle sprite bills until destroyed. It doesn't — sprites scale to zero on their own — and #649 proved the destroy is never free: the runtime session lives on the sprite's disk, so resuming onto a fresh sprite fails on every path (`claude --resume` → "No conversation found"; ACP `session/resume` → -32002). We were guaranteeing amnesia to save money we weren't spending. #664 (the 4h prod idle override for human-gated incidents) treated the symptom; this removes the cause, and the override reverts here.

## How

- **New `suspended` status** (varchar allowlist; no data migration) — excluded from the quota, boot rehydration, and every reaper pass. Migration adds `sandboxes.last_resumed_at`.
- **Ceiling measures a continuous run**: `last_resumed_at || inserted_at`, stamped only on wake-from-suspended (deploy reattaches don't reset it), used identically by the server and the reaper — so a week-parked conversation isn't destroyed the moment it wakes.
- **Wake path** re-runs the quota gate under the existing advisory lock (waking parked compute re-adds concurrency), with a re-read inside so the loser of a concurrent wake isn't spuriously refused at the cap. A transient sprite-probe failure fails the wake retryably instead of giving up the parked disk; only a definitive not-found falls back to fresh provisioning.
- **Reaper pass 1b splits by bound**: idle → park (audited `sandbox.suspended`, own `parked` metric), max-lifetime → terminate as before; a 15-minute `updated_at` grace window keeps it from parking a row mid-wake before Horde's registry propagates.
- **Sprite-destroying sweeps learn the status** (account deletion, tenant suspension) so parked sprites can't leak past a nilified `user_id`.
- **Billing guard**: `suspended → ready` emits no second `sandbox_provisioned` and no `sandbox_provision_failed`; metering imprecision for parked time is accepted and tracked in #665.
- **Protocol/UX**: stage event keeps `stage: "sandbox"/"done"` with `event: "suspended"`; the CLI prints suspend-specific copy (old CLIs degrade to slightly stale wording, correct exit code); `Lifecycle.explain(:idle)` now truthfully promises resume-with-memory; OpenAPI enum extended.

## Rolling-deploy caveat

During rollout, an old node waking a suspended row takes the old `maybe_reuse_sandbox` → `:create_new` path and the parked disk is destroyed by the reaper. Self-limiting and read-only (old nodes can't write `suspended` — their changeset rejects it): one-time possible agent-memory loss for conversations suspended mid-rollout.

## Testing

- `mix precommit` green (compile -W, format, credo --strict, sobelow, dialyzer, 2597 tests).
- `cd cli && go test ./... && go vet ./...` green; `mix openapi.spec.json` validates and carries the new enum value.
- New coverage: idle suspend keeps the sprite (`reject(&Sprites.destroy/1)`), max-lifetime still destroys (regression anchor), wake-from-suspended flips + stamps the clock, at-cap wake refused, transient probe failure preserves the parked row, reaper park/expire split + grace window + suspended-matches-no-pass, quota exclusion, no double `sandbox_provisioned`, deletion destroys suspended sprites, CLI suspend/legacy events.

Follow-up: #665 (suspend-aware metering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)