### PR TITLE
fix: render ACP output in the conversation view, in all three modes

### DIFF
--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -322,6 +322,15 @@ defmodule FountainWeb.ConversationsLive.Show do
        when is_binary(s) and s != "" and s != "turn",
        do: MapSet.member?(streams, "stage")
 
+  # ACP rows are the model's output channel, exactly what stdout is on the
+  # legacy path — so they follow the stdout pill rather than getting a pill
+  # of their own. Keying on a literal "acp" entry instead would hide every
+  # ACP turn for users whose persisted visible_streams predate the flag
+  # (the default list only applies when nothing is saved), which is how ACP
+  # conversations shipped invisible in all three view modes.
+  defp event_visible?(%{kind: "output", stream: "acp"}, streams),
+    do: MapSet.member?(streams, "stdout")
+
   defp event_visible?(%{kind: "output", stream: s}, streams) when is_binary(s) and s != "",
     do: MapSet.member?(streams, s)
 
@@ -818,7 +827,9 @@ defmodule FountainWeb.ConversationsLive.Show do
   # one contiguous reply.
   defp chat_assistant_reply(events, runtime) do
     events
-    |> Enum.filter(&(&1.kind == "output" and &1.stream == "stdout" and is_binary(&1.data)))
+    |> Enum.filter(
+      &(&1.kind == "output" and &1.stream in ["stdout", "acp"] and is_binary(&1.data))
+    )
     |> Enum.flat_map(&blocks_for(&1, runtime))
     |> Enum.flat_map(fn
       %{kind: :text, body: t} when is_binary(t) -> [t]

--- a/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/show_test.exs
@@ -52,6 +52,53 @@ defmodule FountainWeb.ConversationsLive.ShowTest do
     end
   end
 
+  describe "ACP output events are visible (regression)" do
+    # The ACP conversion stored the model's output under stream "acp", but
+    # every view mode filtered on "stdout": event_visible?/2 dropped ACP rows
+    # in pretty/raw (no "acp" in visible_streams and no pill to add it), and
+    # chat_assistant_reply/2 hard-filtered stream == "stdout". An ACP-flagged
+    # agent's replies rendered nowhere — the transcript looked like the agent
+    # never answered.
+    @acp_line ~s({"params":{"sessionId":"s1","update":{"content":{"text":"Acknowledged — Cassiopeia.","type":"text"},"messageId":"m1","sessionUpdate":"agent_message_chunk"}},"method":"session/update","jsonrpc":"2.0"})
+
+    setup do
+      user = insert_verified_user()
+      conversation = insert_conversation(user_id: user.id)
+
+      turn =
+        insert_turn(conversation, %{
+          status: "completed",
+          prompt: "favorite constellation?",
+          started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      insert_log_event(conversation, %{stream: "acp", turn_id: turn.id, data: @acp_line})
+      %{user: user, conversation: conversation}
+    end
+
+    for mode <- ~w(pretty raw chat) do
+      test "the agent's reply renders in #{mode} mode", %{
+        conn: conn,
+        user: user,
+        conversation: conversation
+      } do
+        {:ok, _} =
+          Fountain.Accounts.update_preferences(user, %{
+            conversation_view_mode: unquote(mode),
+            # A pre-ACP persisted preference — the shape that stayed broken
+            # even after adding "acp" to the default list would have fixed
+            # fresh accounts.
+            conversation_visible_streams: ["stdout", "stderr", "stage"]
+          })
+
+        conn = login_user(conn, Fountain.Accounts.get_user!(user.id))
+        {:ok, _view, html} = live(conn, ~p"/conversations/#{conversation.id}")
+
+        assert html =~ "Cassiopeia"
+      end
+    end
+  end
+
   describe "set_view_mode" do
     setup do
       user = insert_verified_user()


### PR DESCRIPTION
An ACP-flagged agent's replies rendered nowhere in the conversation LiveView. The ACP conversion (#656) stores the model's output under stream `"acp"`, but all three view modes filtered on `"stdout"`:

- **pretty/raw**: `event_visible?/2` checks the event's stream against `visible_streams`, which defaults to `["stdout", "stderr", "stage"]` and has no `"acp"` pill — every ACP output row was dropped.
- **chat**: `chat_assistant_reply/2` hard-filtered `stream == "stdout"`, so the assistant bubble was empty.

Found live: a suspend-verification conversation answered every prompt (visible in `log_events` and over SSE) while the web transcript showed the agent never replying.

**Fix**: ACP rows follow the **stdout pill** instead of getting their own `visible_streams` entry — the ACP stream is the model's output channel, exactly what stdout is on the legacy path. A stored `"acp"` entry would only have fixed fresh accounts: any user with a persisted pre-ACP preference list would still see nothing. Chat mode's filter accepts both streams; block parsing was already correct (`blocks_for` dispatches per-event on stream to `ACP.Blocks`).

Regression tests mount the show view in all three modes with a real `agent_message_chunk` line and a persisted pre-ACP `visible_streams` list; all three fail without the fix (verified by reverting).

`mix precommit` green (2600 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)