### PR TITLE
docs: roll the changelog for v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ upgrade, is in
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-08-13
+
+### Fixed
+
+- **ACP agents' replies now render in the conversation view.** Since the
+  ACP conversion, an ACP-flagged agent's output — stored under its own
+  event stream — was filtered out by all three view modes, which still
+  keyed on `stdout`: the transcript showed the agent never answering while
+  the API and CLI streamed the reply fine. ACP output now follows the
+  stdout pill, including for accounts with stream preferences saved before
+  the flag existed (#669).
+
 ## [0.8.0] — 2026-08-13
 
 ### Upgrade notes


### PR DESCRIPTION
Dates a [0.8.1] section for the ACP-rendering fix (#669) ahead of the patch release-bump dispatch (its gate requires the section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)