### PR TITLE
feat: ACP on by default for claude, codex and opencode agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Changed
+
+- **ACP is now the default protocol for claude, codex and opencode
+  agents.** The per-agent `metadata["acp"]` flag flips polarity: instead
+  of opting in with `true`, agents on those runtimes speak the Agent
+  Client Protocol unless the agent carries `"acp": false` (an operational
+  escape hatch, set over the API). Gemini agents stay on the legacy path
+  until gemini's `session/load` is fixed upstream (#658, #659). ADR 0014
+  gate 4 begins here.
+
 ## [0.8.1] — 2026-08-13
 
 ### Fixed

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -7,20 +7,30 @@ defmodule Fountain.Runtimes.ACP do
   gets into the sprite — and it deliberately holds no protocol state. The
   session lives in `Fountain.Runtimes.ACP.Peer`, for one turn, and dies with it.
 
-  ## Off by default, per agent
+  ## On by default, per-agent opt-out
 
-  The flag is `agent.metadata["acp"] == true`. Metadata rather than a column
-  because gate 2 is an experiment with an explicit exit — if gates 3 and 4 do
-  not hold, this is deleted, and a migration would outlive the thing it was
-  added for. A conversation started under the flag records nothing about it:
-  the flag is read per turn, so flipping it mid-conversation switches the next
-  turn and leaves the earlier ones rendering through the legacy path, which is
-  exactly the A/B the gate asks for.
+  ACP is the primary path: every supported runtime speaks it unless the agent
+  carries `metadata["acp"] == false`. The opt-out is an operational escape
+  hatch (set over the API — metadata has no form UI), not a supported
+  configuration; it exists so a broken adapter release can be routed around
+  without a deploy, and it goes away with the legacy path itself.
+
+  Metadata rather than a column because the flag is transitional — once the
+  legacy path is deleted there is nothing to opt out into, and a migration
+  would outlive the thing it was added for. The flag is read per turn, so
+  flipping it mid-conversation switches the next turn; earlier turns keep
+  rendering through whichever path produced them (the render side keys on the
+  log-event stream, not on the flag).
+
+  Gate 2 ran the inverse polarity — opt-in, off by default — and the flip to
+  default-on is the start of ADR 0014's gate 4: ACP as the primary way to talk
+  to every runtime that can hold a conversation over it.
 
   ## Which runtimes
 
-  Claude and Gemini, and the pair is deliberate: they are the two ends of the
-  resumption story gate 1 mapped.
+  All four have adapter entries; claude, codex and opencode are shippable and
+  gemini is held back (#659). The two ends of the resumption story gate 1
+  mapped are claude and gemini:
 
   Claude advertises `sessionCapabilities.resume`, so a turn costs a handshake
   and nothing else. Gemini advertises only `loadSession`, and `session/load`
@@ -211,13 +221,17 @@ defmodule Fountain.Runtimes.ACP do
   @doc """
   Whether this turn should speak ACP.
 
-  Both halves have to hold: the agent opted in, and its runtime is one gate 1
-  cleared. A flag set on a Gemini agent is a no-op rather than an error — the
-  legacy path is not a failure mode, it is the default.
+  Default-on for every supported runtime; `metadata["acp"] == false` is the
+  per-agent escape hatch. Only the literal boolean opts out — metadata arrives
+  as JSON over the API, and a string `"false"` is a typo, not a decision.
+
+  A supported runtime is still the other half: an unsupported or blocked
+  runtime (gemini, #659) takes the legacy path whatever the metadata says —
+  for those the legacy path is not a failure mode, it is the only path.
   """
   @spec enabled?(Agent.t() | nil) :: boolean()
-  def enabled?(%Agent{runtime: runtime, metadata: metadata}) when is_map(metadata) do
-    runtime in supported_runtimes() and Map.get(metadata, "acp") == true
+  def enabled?(%Agent{runtime: runtime, metadata: metadata}) do
+    runtime in supported_runtimes() and Map.get(metadata || %{}, "acp") != false
   end
 
   def enabled?(_), do: false

--- a/apps/fountain/test/fountain/conversations/conversation_audit_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_audit_test.exs
@@ -20,7 +20,12 @@ defmodule Fountain.Conversations.ConversationAuditTest do
   setup do
     user = insert_verified_user()
     env = insert_env(user_id: user.id)
-    agent = insert_agent(user_id: user.id, environment_id: env.id)
+    # These start real servers with the real runtime module, and what they
+    # assert is the audit trail, not the turn pipeline — so they pin the
+    # legacy path with the opt-out rather than by switching runtime (gemini's
+    # prepare_sprite reaches Sprites APIs this harness does not stub).
+    agent =
+      insert_agent(user_id: user.id, environment_id: env.id, metadata: %{"acp" => false})
 
     {:ok, user: user, env: env, agent: agent}
   end

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -107,21 +107,23 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
   end
 
   describe "the flag" do
-    test "is off by default" do
+    test "is on by default" do
       user = insert_verified_user()
-      refute ACP.enabled?(insert_agent(user_id: user.id, runtime: "claude"))
+      assert ACP.enabled?(insert_agent(user_id: user.id, runtime: "claude"))
     end
 
-    test "applies to every shippable runtime" do
+    test "defaults on for every shippable runtime, with a per-agent opt-out" do
       user = insert_verified_user()
 
       for runtime <- ACP.supported_runtimes() do
-        agent = insert_agent(user_id: user.id, runtime: runtime, metadata: %{"acp" => true})
-        assert ACP.enabled?(agent), "expected #{runtime} to be ACP-enabled"
+        agent = insert_agent(user_id: user.id, runtime: runtime)
+        assert ACP.enabled?(agent), "expected #{runtime} to be ACP-enabled by default"
       end
 
-      # All four are converted now, so the flag itself is the only off switch.
-      refute ACP.enabled?(insert_agent(user_id: user.id, runtime: "claude"))
+      # The opt-out is the only off switch for a shippable runtime.
+      refute ACP.enabled?(
+               insert_agent(user_id: user.id, runtime: "claude", metadata: %{"acp" => false})
+             )
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
@@ -29,7 +29,7 @@ defmodule Fountain.Conversations.ConversationServerLogBudgetTest do
   defp setup_conv do
     stub_happy_sprite()
     user = insert_verified_user()
-    agent = insert_agent(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
     insert_conversation(user_id: user.id, agent_id: agent.id)
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
@@ -37,7 +37,7 @@ defmodule Fountain.Conversations.ConversationServerProvisionDeadlineTest do
     end)
 
     user = insert_verified_user()
-    agent = insert_agent(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
     conv = insert_conversation(user_id: user.id, agent_id: agent.id)
 
     args = [
@@ -74,7 +74,7 @@ defmodule Fountain.Conversations.ConversationServerProvisionDeadlineTest do
     end)
 
     user = insert_verified_user()
-    agent = insert_agent(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
     conv = insert_conversation(user_id: user.id, agent_id: agent.id)
     test_pid = self()
     sandbox_id = conv.sandbox_id
@@ -114,7 +114,7 @@ defmodule Fountain.Conversations.ConversationServerProvisionDeadlineTest do
     end)
 
     user = insert_verified_user()
-    agent = insert_agent(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
     conv = insert_conversation(user_id: user.id, agent_id: agent.id)
 
     args = [
@@ -142,7 +142,7 @@ defmodule Fountain.Conversations.ConversationServerProvisionDeadlineTest do
   test "a provision that completes in time is left alone" do
     stub_happy_sprite()
     user = insert_verified_user()
-    agent = insert_agent(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
     conv = insert_conversation(user_id: user.id, agent_id: agent.id)
 
     {pid, _ref, :alive} = start_server(conv)

--- a/apps/fountain/test/fountain/conversations/conversation_server_redaction_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_redaction_test.exs
@@ -24,7 +24,7 @@ defmodule Fountain.Conversations.ConversationServerRedactionTest do
   defp start_server_with_secrets do
     stub_happy_sprite()
     user = insert_verified_user()
-    agent = insert_agent(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
     conv = insert_conversation(user_id: user.id, agent_id: agent.id)
 
     {pid, ref, :alive} = start_server(conv)

--- a/apps/fountain/test/fountain/conversations/conversation_server_shutdown_revoke_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_shutdown_revoke_test.exs
@@ -11,7 +11,7 @@ defmodule Fountain.Conversations.ConversationServerShutdownRevokeTest do
   defp start_provisioned_server do
     stub_happy_sprite()
     user = insert_verified_user()
-    agent = insert_agent(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
     conv = insert_conversation(user_id: user.id, agent_id: agent.id)
 
     {pid, ref, :alive} = start_server(conv)
@@ -83,7 +83,7 @@ defmodule Fountain.Conversations.ConversationServerShutdownRevokeTest do
     # credential out from under the first server.
     stub_happy_sprite()
     user = insert_verified_user()
-    agent = insert_agent(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
     conv = insert_conversation(user_id: user.id, agent_id: agent.id)
 
     {:ok, {%Fountain.Accounts.ApiKey{id: predecessor_key}, _raw}} =

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -21,7 +21,12 @@ defmodule Fountain.Conversations.ConversationServerTest do
   setup do
     user = insert_verified_user()
     env = insert_env(user_id: user.id)
-    agent = insert_agent(user_id: user.id, environment_id: env.id)
+
+    # These tests drive the legacy (non-ACP) turn pipeline through FakeRuntime.
+    # ACP is on by default for claude/codex/opencode, so the agent is pinned to
+    # gemini — the runtime that actually still runs this pipeline (#659). The
+    # ACP turn pipeline has its own harness in conversation_server_acp_test.exs.
+    agent = insert_agent(user_id: user.id, environment_id: env.id, runtime: "gemini")
     sandbox = insert_sandbox(user_id: user.id, status: "pending")
 
     conv =
@@ -144,8 +149,8 @@ defmodule Fountain.Conversations.ConversationServerTest do
         %Fountain.Agents.Agent{}
         |> Fountain.Agents.Agent.changeset(%{
           "name" => "legacy-cross-tenant",
-          "model" => "anthropic/claude-sonnet-4-6",
-          "runtime" => "claude",
+          "model" => "google/gemini-2.5-pro",
+          "runtime" => "gemini",
           "user_id" => attacker.id,
           "environment_id" => victim_env.id
         })

--- a/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
@@ -16,7 +16,7 @@ defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
   setup do
     user = insert_verified_user()
     env = insert_env(user_id: user.id)
-    agent = insert_agent(user_id: user.id, environment_id: env.id)
+    agent = insert_agent(user_id: user.id, environment_id: env.id, runtime: "gemini")
     sandbox = insert_sandbox(user_id: user.id, status: "pending")
 
     conv =
@@ -77,7 +77,7 @@ defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
       _ = :sys.get_state(pid)
 
       assert_received {:turn_completed, measurements, metadata}
-      assert metadata.runtime == "claude"
+      assert metadata.runtime == "gemini"
       assert metadata.status == "completed"
 
       # Metadata, never a tag: it's what makes the JSON log line point at a
@@ -173,7 +173,7 @@ defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
       _ = :sys.get_state(pid)
 
       assert_received {:first_output, measurements, metadata}
-      assert metadata.runtime == "claude"
+      assert metadata.runtime == "gemini"
       assert metadata.conv_id == conv.id
       assert is_integer(measurements.elapsed_ms)
       assert measurements.elapsed_ms >= 0

--- a/apps/fountain/test/fountain/runtimes/acp_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp_test.exs
@@ -7,11 +7,16 @@ defmodule Fountain.Runtimes.ACPTest do
   defp agent(attrs), do: struct(Agent, attrs)
 
   describe "enabled?/1" do
-    test "requires both the flag and a shippable runtime" do
+    test "on by default for a shippable runtime" do
+      assert ACP.enabled?(agent(runtime: "claude", metadata: %{}))
+      assert ACP.enabled?(agent(runtime: "claude", metadata: nil))
       assert ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => true}))
 
-      refute ACP.enabled?(agent(runtime: "claude", metadata: %{}))
       refute ACP.enabled?(nil)
+    end
+
+    test "metadata acp: false is the per-agent escape hatch" do
+      refute ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => false}))
     end
 
     test "a blocked runtime cannot be switched on at all" do
@@ -31,25 +36,28 @@ defmodule Fountain.Runtimes.ACPTest do
       assert ACP.cwd("gemini") == "/tmp/gemini-workspace"
     end
 
-    test "every supported runtime honours the flag" do
+    test "every supported runtime defaults on and honours the opt-out" do
       for runtime <- ACP.supported_runtimes() do
-        assert ACP.enabled?(agent(runtime: runtime, metadata: %{"acp" => true})),
-               "expected #{runtime} to be ACP-enabled"
+        assert ACP.enabled?(agent(runtime: runtime, metadata: %{})),
+               "expected #{runtime} to be ACP-enabled by default"
 
-        refute ACP.enabled?(agent(runtime: runtime, metadata: %{}))
+        refute ACP.enabled?(agent(runtime: runtime, metadata: %{"acp" => false}))
       end
     end
 
-    test "a runtime with no adapter entry ignores the flag rather than erroring" do
-      # The legacy path is the default, not a failure mode.
+    test "a runtime with no adapter entry stays legacy whatever the metadata says" do
+      # For an unconvertible runtime the legacy path is the only path.
+      refute ACP.enabled?(agent(runtime: "somethingelse", metadata: %{}))
       refute ACP.enabled?(agent(runtime: "somethingelse", metadata: %{"acp" => true}))
     end
 
-    test "a truthy-looking value that is not true does not enable it" do
-      # Metadata is user-editable JSON. "false" and "true" are both strings
-      # there, and a string is not an opt-in.
-      refute ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => "true"}))
-      refute ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => 1}))
+    test "only the literal boolean false opts out" do
+      # Metadata arrives as JSON over the API; a string "false" is a typo,
+      # not a decision, and must not silently route an agent onto the legacy
+      # path.
+      assert ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => "false"}))
+      assert ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => nil}))
+      assert ACP.enabled?(agent(runtime: "claude", metadata: %{"acp" => 0}))
     end
   end
 

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -170,7 +170,10 @@ defmodule Fountain.Factory do
       sandbox_id: sandbox.id,
       agent_id: agent && agent.id,
       user_id: user_id,
-      runtime: "claude",
+      # A conversation's runtime is snapshotted from its agent in production;
+      # a factory row that disagrees with its own agent misleads every test
+      # that branches on it.
+      runtime: (agent && agent.runtime) || "claude",
       status: "pending"
     }
 

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -1,12 +1,13 @@
 # 0014 — Speaking the Agent Client Protocol to runtimes
 
-**Status:** Partially accepted — **gates 1 and 2 are built; gates 3 and 4 are
-not.** `Fountain.Runtimes.ACP` and its peer exist and speak ACP to the pinned
-Claude adapter, behind a per-agent flag that is off by default; every other
-agent takes the legacy path unchanged. Nothing in *Gate 3 — permissions* or
-*Gate 4* exists, and neither should be read as describing behaviour the system
-has. Each gate below carries its own status; the PR that builds one removes its
-caveat.
+**Status:** Partially accepted — **gates 1 and 2 are built; gate 4 is in
+progress; gate 3 is not built.** `Fountain.Runtimes.ACP` and its peer speak
+ACP to claude, codex and opencode, **on by default** since 2026-08-13 (the
+per-agent `metadata["acp"]` flag flipped polarity: `false` is now an opt-out
+escape hatch rather than `true` an opt-in). Gemini takes the legacy path — an
+upstream defect, not a choice; see gate 4. Nothing in *Gate 3 — permissions*
+exists, and it should not be read as describing behaviour the system has. Each
+gate below carries its own status; the PR that builds one removes its caveat.
 
 ## Context
 
@@ -520,10 +521,21 @@ land and gate 3 turns out to be blocked — by adapter support, by latency, by
 the reaper killing sessions mid-prompt — the honest outcome is to stop with
 one runtime converted and say so here.
 
-### Gate 4 — remaining runtimes, and parser deletion — **not built**
+### Gate 4 — remaining runtimes, and parser deletion — **in progress**
 
-Only after gate 3 holds in production. A parser is deleted when its runtime's
-ACP path has served real conversations, not when the code compiles.
+> **Amendment, 2026-08-13.** Two changes to this gate as written. First, the
+> sequencing: #644 already departed from "only after gate 3" — if the
+> justification is deleting per-runtime code, permissions follow the
+> conversions rather than gating them, and this amendment makes the ADR match
+> the tracker. Second, the default: ACP is now **on by default** for the three
+> shippable runtimes. `enabled?/1` reads `metadata["acp"] != false`, so the
+> flag is an operational opt-out (routing around a broken adapter release
+> without a deploy), no longer an experiment's opt-in. The deletion rule below
+> is unchanged: a parser is deleted when its runtime's ACP path has served
+> real conversations, and default-on is what makes that happen.
+
+A parser is deleted when its runtime's ACP path has served real conversations,
+not when the code compiles.
 
 **Three of the four runtimes are converted and one is not, for a reason
 outside our code — 2026-08-11.** Claude, Codex and OpenCode each did


### PR DESCRIPTION
Part of #644 (ADR 0014 gate 4). First step of making ACP the primary runtime I/O path.

## What

- `Fountain.Runtimes.ACP.enabled?/1` flips polarity: agents on supported runtimes (claude, codex, opencode) speak ACP **by default**; `metadata["acp"] == false` is the per-agent opt-out. Only the literal boolean opts out — metadata arrives as JSON over the API, and a string `"false"` is a typo, not a decision.
- Gemini is unaffected: still excluded via `supported_runtimes/0` until upstream fixes `session/load` (#658, #659).
- ADR 0014 amended: status header + a dated gate-4 amendment recording the flip and the #644 sequencing departure (permissions after conversions).

## Why now

The parser-deletion rule (#642) requires each runtime's ACP path to have served *real conversations*. Opt-in default-off meant that never happens organically; default-on is what starts the burn-in.

## Test changes

The polarity flip rerouted every test that spawned a claude agent through the legacy pipeline (50 failures). Fixed by pinning intent, not by weakening coverage:

- Legacy turn-pipeline harness tests (`conversation_server_test`, metrics, log budget, redaction, shutdown-revoke, provision-deadline) now use `runtime: "gemini"` — the runtime that actually still runs that pipeline. Survives the eventual deletion of the claude/codex/opencode legacy path.
- `conversation_audit_test` pins `metadata: %{"acp" => false}` instead: it drives the real runtime module, and gemini's `prepare_sprite` reaches Sprites APIs the harness doesn't stub.
- The conversation factory now snapshots `runtime` from the agent instead of hardcoding `"claude"` — a factory row disagreeing with its own agent misled every test that branches on it.
- ACP flag tests updated to assert default-on + opt-out.

Full suite: 2601 tests, 0 failures. `mix precommit` green.

## Escape hatch

If an adapter release breaks in production, any agent can be routed back to the legacy path without a deploy: `PATCH` the agent's metadata to `{"acp": false}`. The hatch is transitional and goes away with the legacy path itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)