### PR TITLE
feat: runtime-agnostic tool-span tracing over ACP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Added
+
+- **Tool-level OTel spans for every ACP runtime.** Tool-call tracing was
+  claude-only (a parser over its proprietary stream-json); ACP's
+  `tool_call`/`tool_call_update` carry the id and status for all runtimes,
+  so every ACP turn now emits `fountain.tool_use` child spans plus
+  `fountain.text_bytes`/`thinking_bytes`/`tool_calls` turn totals. Cost
+  and token-usage attributes do not exist on the ACP path — the protocol's
+  stop reason carries no usage block (#637).
+
 ### Changed
 
 - **ACP is now the default protocol for claude, codex and opencode

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1099,7 +1099,7 @@ defmodule Fountain.Conversations.ConversationServer do
     })
 
     # Finalize stream tracer: close any tool spans still open (abandoned calls).
-    Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
+    finalize_tracer(state.stream_tracer)
 
     # An ACP turn can also end here — the adapter exits, is interrupted, or its
     # socket drops before it ever answers `session/prompt`. The peer has nothing
@@ -1216,6 +1216,12 @@ defmodule Fountain.Conversations.ConversationServer do
         is_nil(state.stream_tracer) ->
           nil
 
+        # An ACP turn whose peer died lands its raw stdout here; the ACP
+        # tracer reads protocol lines from the peer, not raw chunks, and the
+        # claude tracer below would crash on the struct.
+        is_struct(state.stream_tracer, Fountain.Runtimes.ACP.Tracer) ->
+          state.stream_tracer
+
         skip == 0 ->
           Fountain.Runtimes.Claude.StreamTracer.handle_chunk(state.stream_tracer, data)
 
@@ -1244,7 +1250,19 @@ defmodule Fountain.Conversations.ConversationServer do
   # the log budget, the redaction pass and the replay skip. A peer writing rows
   # itself would bypass all three.
   def handle_info({:acp, ref, {:lines, stream, data}}, %{current_command_ref: ref} = state) do
-    {:noreply, log_with_replay_skip(state, stream, data)}
+    new_state = log_with_replay_skip(state, stream, data)
+
+    # Each "acp" report is one session/update line; the tracer turns tool_call
+    # / tool_call_update into child spans. Peer-relayed lines never replay (a
+    # peer lives for exactly one turn), so no replay-suffix arithmetic here.
+    tracer =
+      if stream == "acp" do
+        Fountain.Runtimes.ACP.Tracer.handle_line(new_state.stream_tracer, data)
+      else
+        new_state.stream_tracer
+      end
+
+    {:noreply, %{new_state | stream_tracer: tracer}}
   end
 
   # `session/new` chose an id. Persisted immediately, exactly as the legacy path
@@ -1340,7 +1358,7 @@ defmodule Fountain.Conversations.ConversationServer do
     })
 
     # Finalize stream tracer: close any tool spans still open (abandoned calls).
-    Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
+    finalize_tracer(state.stream_tracer)
 
     # An ACP turn can also end here — the adapter exits, is interrupted, or its
     # socket drops before it ever answers `session/prompt`. The peer has nothing
@@ -1397,7 +1415,7 @@ defmodule Fountain.Conversations.ConversationServer do
       reason: "sprite connection lost: #{inspect(reason)}"
     })
 
-    Fountain.Runtimes.Claude.StreamTracer.finalize(state.stream_tracer)
+    finalize_tracer(state.stream_tracer)
 
     # An ACP turn can also end here — the adapter exits, is interrupted, or its
     # socket drops before it ever answers `session/prompt`. The peer has nothing
@@ -1938,11 +1956,20 @@ defmodule Fountain.Conversations.ConversationServer do
 
           case stdin_result do
             :ok ->
-              # Start a stream tracer for Claude (stream-json → OTel child spans).
-              # Other runtimes produce unstructured output; tracer stays nil.
+              # Tool-span tracing. Every ACP turn gets it, whatever the runtime
+              # — `session/update` carries the id and status the tracer keys on
+              # (#637). On the legacy path only claude's dialect is traced;
+              # that tracer goes away with the path.
               stream_tracer =
-                if not acp? and state.runtime_module == Fountain.Runtimes.Claude do
-                  Fountain.Runtimes.Claude.StreamTracer.new(turn_span)
+                cond do
+                  acp? ->
+                    Fountain.Runtimes.ACP.Tracer.new(turn_span)
+
+                  state.runtime_module == Fountain.Runtimes.Claude ->
+                    Fountain.Runtimes.Claude.StreamTracer.new(turn_span)
+
+                  true ->
+                    nil
                 end
 
               {peer, peer_mon} =
@@ -2248,9 +2275,21 @@ defmodule Fountain.Conversations.ConversationServer do
   # is cleared at the end so the `{:exit, …}` that follows finds no match and
   # falls through to the catch-all. A turn ends on the prompt response *or* the
   # process exit, whichever arrives first, and never waits for both.
+  # One tracer field, two shapes: ACP turns hold an `ACP.Tracer` struct, legacy
+  # claude turns the old map. Dispatch on shape so every way a turn can end
+  # closes whichever one is live; the second clause goes away with the legacy
+  # path.
+  defp finalize_tracer(%Fountain.Runtimes.ACP.Tracer{} = tracer),
+    do: Fountain.Runtimes.ACP.Tracer.finalize(tracer)
+
+  defp finalize_tracer(tracer), do: Fountain.Runtimes.Claude.StreamTracer.finalize(tracer)
+
   defp finish_acp_turn(state, status, span_attrs, stage_meta) do
     if state.current_command, do: Sprites.close_stdin(state.current_command)
     stop_acp_peer(state)
+
+    # Before the turn span ends: totals land on it, abandoned tool spans close.
+    finalize_tracer(state.stream_tracer)
 
     {:ok, turn} =
       Conversations._unsafe_update_turn(state.current_turn, %{

--- a/apps/fountain/lib/fountain/runtimes/acp/tracer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/tracer.ex
@@ -1,0 +1,193 @@
+defmodule Fountain.Runtimes.ACP.Tracer do
+  @moduledoc """
+  Turns `session/update` notifications into OTel tool spans, for every runtime.
+
+  The claude-only `Fountain.Runtimes.Claude.StreamTracer` bridged one dialect
+  into the turn span; three of four runtimes produced no tool-level traces at
+  all, and nobody noticed because the gap is invisible from inside a
+  conversation (#637). ACP's `tool_call` / `tool_call_update` carry an id and a
+  status for every runtime, which is exactly what a tracer keys on — so this
+  module is dialect-free and one per protocol, not one per agent.
+
+  Span mapping:
+
+  - **`tool_call`** opens a `fountain.tool_use` child span, keyed by
+    `toolCallId`, named by the same title-then-kind preference the render path
+    uses (`Blocks`).
+  - **`tool_call_update`** with a terminal status closes the matching span;
+    `failed` and `cancelled` mark it as an error. Non-terminal updates are
+    progress, not an outcome, and touch nothing.
+  - **`agent_message_chunk` / `agent_thought_chunk`** accumulate byte counts,
+    surfaced at `finalize/1` as `fountain.text_bytes` /
+    `fountain.thinking_bytes` on the turn span. Chunks are per-delta and a turn
+    produces hundreds; one span event each — what the legacy tracer did per
+    assistant *message* — would blow through OTel's default event limit on the
+    first real turn.
+  - **`finalize/1`** closes any span still open as `abandoned` (the runtime
+    exited or was interrupted before the matching update) and writes the
+    accumulated totals.
+
+  ## What the legacy tracer had that this one drops, on purpose
+
+  Cost and token usage (`fountain.total_cost_usd`, `fountain.input_tokens`,
+  …) came from claude's proprietary `result` event. ACP's `session/prompt`
+  response carries a stop reason and no usage block, so those attributes do
+  not exist on this path — dropped explicitly rather than silently (#637). If
+  ops dashboards need them back, the source would be per-runtime again and
+  belongs in a follow-up, not hidden in here.
+
+  All functions no-op on `nil`, so the caller keeps a `nil` tracer for turns
+  that trace nothing, without branching.
+  """
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  alias Fountain.Runtimes.ACP.Protocol
+
+  defstruct turn_span_ctx: nil,
+            open_tool_spans: %{},
+            text_bytes: 0,
+            thinking_bytes: 0,
+            tool_calls: 0
+
+  @type t :: %__MODULE__{}
+
+  @terminal_statuses ~w(completed failed cancelled)
+
+  @doc "Create a tracer attached to `turn_span_ctx`."
+  @spec new(term()) :: t()
+  def new(turn_span_ctx), do: %__MODULE__{turn_span_ctx: turn_span_ctx}
+
+  @doc """
+  Feed one stored protocol line — the same ndjson the `acp` log stream holds.
+
+  Anything that is not a `session/update` notification (responses, requests,
+  an adapter's stray non-JSON output) traces nothing.
+  """
+  @spec handle_line(t() | nil, binary()) :: t() | nil
+  def handle_line(nil, _line), do: nil
+
+  def handle_line(%__MODULE__{} = tracer, line) when is_binary(line) do
+    case Protocol.classify_line(line) do
+      {:notification, "session/update", params} -> handle_update(tracer, params)
+      _ -> tracer
+    end
+  end
+
+  @doc """
+  Close abandoned tool spans and write the accumulated totals to the turn span.
+
+  Call on every way a turn can end, before the turn span itself is ended.
+  """
+  @spec finalize(t() | nil) :: :ok
+  def finalize(nil), do: :ok
+
+  def finalize(%__MODULE__{} = tracer) do
+    Tracer.set_current_span(tracer.turn_span_ctx)
+    Tracer.set_attribute("fountain.text_bytes", tracer.text_bytes)
+    Tracer.set_attribute("fountain.thinking_bytes", tracer.thinking_bytes)
+    Tracer.set_attribute("fountain.tool_calls", tracer.tool_calls)
+
+    Enum.each(tracer.open_tool_spans, fn {_id, span_ctx} ->
+      Tracer.set_current_span(span_ctx)
+      Tracer.set_attribute("fountain.tool_status", "abandoned")
+      Tracer.set_status(OpenTelemetry.status(:error, "turn ended with open tool call"))
+      Tracer.end_span(span_ctx)
+    end)
+
+    Tracer.set_current_span(tracer.turn_span_ctx)
+    :ok
+  end
+
+  # ── update handlers ───────────────────────────────────────────────────────
+
+  # The variant lives under "update"; tolerate bare params exactly as the
+  # render path does (`Blocks.from_update/1`).
+  defp handle_update(tracer, %{"update" => update}) when is_map(update),
+    do: update_span(tracer, update)
+
+  # `classify_line/1` guarantees params is a map, so bare params is the only
+  # other shape — tolerated exactly as the render path does (`Blocks.from_update/1`).
+  defp handle_update(tracer, update), do: update_span(tracer, update)
+
+  defp update_span(tracer, %{"sessionUpdate" => "tool_call", "toolCallId" => id} = update)
+       when is_binary(id) do
+    # A second tool_call on an id that is already open is a re-announcement
+    # (some adapters resend the call with its first status change); reopening
+    # would leak the original span.
+    if Map.has_key?(tracer.open_tool_spans, id) do
+      tracer
+    else
+      Tracer.set_current_span(tracer.turn_span_ctx)
+
+      span_ctx =
+        Tracer.start_span("fountain.tool_use", %{
+          attributes: %{
+            "fountain.tool_name" => tool_name(update),
+            "fountain.tool_id" => id,
+            "fountain.tool_kind" => Map.get(update, "kind", "")
+          }
+        })
+
+      %{
+        tracer
+        | open_tool_spans: Map.put(tracer.open_tool_spans, id, span_ctx),
+          tool_calls: tracer.tool_calls + 1
+      }
+    end
+  end
+
+  defp update_span(
+         tracer,
+         %{"sessionUpdate" => "tool_call_update", "toolCallId" => id, "status" => status}
+       )
+       when status in @terminal_statuses do
+    case Map.pop(tracer.open_tool_spans, id) do
+      {nil, _} ->
+        tracer
+
+      {span_ctx, remaining} ->
+        Tracer.set_current_span(span_ctx)
+        Tracer.set_attribute("fountain.tool_status", status)
+
+        if status != "completed" do
+          Tracer.set_status(OpenTelemetry.status(:error, "tool #{status}"))
+        end
+
+        Tracer.end_span(span_ctx)
+        Tracer.set_current_span(tracer.turn_span_ctx)
+        %{tracer | open_tool_spans: remaining}
+    end
+  end
+
+  defp update_span(tracer, %{"sessionUpdate" => "agent_message_chunk", "content" => content}) do
+    %{tracer | text_bytes: tracer.text_bytes + content_bytes(content)}
+  end
+
+  defp update_span(tracer, %{"sessionUpdate" => "agent_thought_chunk", "content" => content}) do
+    %{tracer | thinking_bytes: tracer.thinking_bytes + content_bytes(content)}
+  end
+
+  defp update_span(tracer, _update), do: tracer
+
+  # ── helpers ───────────────────────────────────────────────────────────────
+
+  # Same preference as the render path: the human title, then ACP's coarse
+  # kind, never an empty name.
+  defp tool_name(update) do
+    case {update["title"], update["kind"]} do
+      {title, _} when is_binary(title) and title != "" -> title
+      {_, kind} when is_binary(kind) and kind != "" -> kind
+      _ -> "tool"
+    end
+  end
+
+  defp content_bytes(content) when is_list(content),
+    do: content |> Enum.map(&content_bytes/1) |> Enum.sum()
+
+  defp content_bytes(%{"type" => "text", "text" => text}) when is_binary(text),
+    do: byte_size(text)
+
+  defp content_bytes(text) when is_binary(text), do: byte_size(text)
+  defp content_bytes(_), do: 0
+end

--- a/apps/fountain/test/fountain/runtimes/acp/tracer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/tracer_test.exs
@@ -1,0 +1,149 @@
+defmodule Fountain.Runtimes.ACP.TracerTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Runtimes.ACP.Tracer
+
+  # The OTel SDK is prod-only (mix.exs); under test the API renders every span
+  # call a no-op. What these tests can and do hold is the tracer's bookkeeping —
+  # which ids are open, what accumulates, what survives junk input — which is
+  # exactly the part that used to be claude-only and is now protocol-wide
+  # (#637).
+
+  defp update_line(update) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{"sessionId" => "sess_1", "update" => update}
+    }) <> "\n"
+  end
+
+  defp tool_call(id, extra \\ %{}) do
+    update_line(Map.merge(%{"sessionUpdate" => "tool_call", "toolCallId" => id}, extra))
+  end
+
+  defp tool_update(id, status) do
+    update_line(%{"sessionUpdate" => "tool_call_update", "toolCallId" => id, "status" => status})
+  end
+
+  test "nil is a no-op everywhere" do
+    assert Tracer.handle_line(nil, "anything") == nil
+    assert Tracer.finalize(nil) == :ok
+  end
+
+  test "a tool_call opens a span keyed by toolCallId; a terminal update closes it" do
+    tracer =
+      Tracer.new(:span)
+      |> Tracer.handle_line(tool_call("t1", %{"title" => "Read file", "kind" => "read"}))
+
+    assert Map.has_key?(tracer.open_tool_spans, "t1")
+    assert tracer.tool_calls == 1
+
+    tracer = Tracer.handle_line(tracer, tool_update("t1", "completed"))
+    assert tracer.open_tool_spans == %{}
+  end
+
+  test "failed and cancelled close the span too" do
+    for status <- ["failed", "cancelled"] do
+      tracer =
+        Tracer.new(:span)
+        |> Tracer.handle_line(tool_call("t1"))
+        |> Tracer.handle_line(tool_update("t1", status))
+
+      assert tracer.open_tool_spans == %{}
+    end
+  end
+
+  test "non-terminal updates are progress, not an outcome" do
+    tracer =
+      Tracer.new(:span)
+      |> Tracer.handle_line(tool_call("t1"))
+      |> Tracer.handle_line(tool_update("t1", "in_progress"))
+      |> Tracer.handle_line(tool_update("t1", "pending"))
+
+    assert Map.has_key?(tracer.open_tool_spans, "t1")
+  end
+
+  test "a re-announced tool_call does not leak the original span" do
+    tracer =
+      Tracer.new(:span)
+      |> Tracer.handle_line(tool_call("t1"))
+      |> Tracer.handle_line(tool_call("t1", %{"status" => "in_progress"}))
+
+    assert map_size(tracer.open_tool_spans) == 1
+    assert tracer.tool_calls == 1
+  end
+
+  test "an update for an unknown id is ignored rather than crashing the turn" do
+    tracer = Tracer.handle_line(Tracer.new(:span), tool_update("never-opened", "completed"))
+    assert tracer.open_tool_spans == %{}
+  end
+
+  test "message and thought chunks accumulate byte counts, not span events" do
+    tracer =
+      Tracer.new(:span)
+      |> Tracer.handle_line(
+        update_line(%{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => "hello"}
+        })
+      )
+      |> Tracer.handle_line(
+        update_line(%{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => [%{"type" => "text", "text" => " world"}]
+        })
+      )
+      |> Tracer.handle_line(
+        update_line(%{
+          "sessionUpdate" => "agent_thought_chunk",
+          "content" => %{"type" => "text", "text" => "hmm"}
+        })
+      )
+
+    assert tracer.text_bytes == byte_size("hello world")
+    assert tracer.thinking_bytes == 3
+  end
+
+  test "non-text content counts nothing rather than guessing a size" do
+    tracer =
+      Tracer.handle_line(
+        Tracer.new(:span),
+        update_line(%{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "image", "data" => "aGk="}
+        })
+      )
+
+    assert tracer.text_bytes == 0
+  end
+
+  test "responses, requests and junk lines trace nothing" do
+    tracer = Tracer.new(:span)
+
+    for line <- [
+          ~s({"jsonrpc":"2.0","id":1,"result":{}}\n),
+          ~s({"jsonrpc":"2.0","id":2,"method":"session/request_permission","params":{}}\n),
+          ~s({"jsonrpc":"2.0","method":"session/other","params":{}}\n),
+          "npm WARN deprecated something\n",
+          ""
+        ] do
+      assert Tracer.handle_line(tracer, line) == tracer
+    end
+  end
+
+  test "a tool_call missing its id is dropped, not opened under a garbage key" do
+    tracer = Tracer.handle_line(Tracer.new(:span), update_line(%{"sessionUpdate" => "tool_call"}))
+    assert tracer.open_tool_spans == %{}
+    assert tracer.tool_calls == 0
+  end
+
+  test "finalize closes abandoned spans and returns :ok" do
+    tracer =
+      Tracer.new(:span)
+      |> Tracer.handle_line(tool_call("t1"))
+      |> Tracer.handle_line(tool_call("t2"))
+      |> Tracer.handle_line(tool_update("t1", "completed"))
+
+    assert Tracer.finalize(tracer) == :ok
+  end
+end


### PR DESCRIPTION
Closes #637. Part of #644 (ADR 0014 gate 4).

## What

- New `Fountain.Runtimes.ACP.Tracer`: turns `session/update` notifications into OTel spans for **every** ACP runtime — a `fountain.tool_use` child span per `tool_call` (keyed by `toolCallId`, named by the same title-then-kind preference the render path uses), closed on the terminal `tool_call_update` (`failed`/`cancelled` mark error), abandoned spans closed as `abandoned` at finalize.
- `agent_message_chunk`/`agent_thought_chunk` accumulate byte counts surfaced as `fountain.text_bytes` / `fountain.thinking_bytes` / `fountain.tool_calls` turn attributes. Chunks are per-delta and a turn produces hundreds; one span event each (what StreamTracer did per assistant *message*) would blow through OTel's default 128-event limit on the first real turn.
- Wiring: every ACP turn gets the tracer (fed one protocol line at a time from the peer's persisted `acp` stream — replay-discarded lines never reach it); `finalize` runs on every way a turn can end, before the turn span closes. Dispatch is by tracer shape, so legacy claude turns keep `StreamTracer` until the legacy path is deleted.
- Guard: raw stdout from an ACP turn whose peer died used to fall through to the legacy handler, which would feed the ACP struct into `StreamTracer.handle_chunk` and crash the server with a FunctionClauseError.

## What's dropped, on purpose

Cost/token attributes (`fountain.total_cost_usd`, `fountain.input_tokens`, …) came from claude's proprietary `result` event. ACP's `session/prompt` response carries a stop reason and no usage block, so they don't exist on this path — stated in the moduledoc rather than silently missing, per #637's requirement. If dashboards need them back, the source is per-runtime again and belongs in a follow-up.

## Tests

The OTel SDK is prod-only, so tests hold the tracer's bookkeeping: open-span keying, terminal vs progress statuses, re-announced calls not leaking spans, unknown ids ignored, byte accumulation, junk lines traced as nothing. `mix precommit` green (2612 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)