### PR TITLE
feat: MCP servers travel in session/new, not the sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ upgrade, is in
 
 ### Changed
 
+- **MCP servers now reach claude, codex and opencode agents through the
+  protocol, not the sandbox.** The three out-of-band mechanisms — claude's
+  `mcp add-json` provisioning loop, codex's `config.toml` writer,
+  opencode's `opencode.json` writer — are deleted; `session/new`'s
+  `mcpServers` param is the single path (#636). Consequence for the
+  `"acp": false` escape hatch: an opted-out agent runs its legacy turns
+  without MCP servers. Gemini's argv mechanism stays with its legacy
+  path.
 - **ACP is now the default protocol for claude, codex and opencode
   agents.** The per-agent `metadata["acp"]` flag flips polarity: instead
   of opting in with `true`, agents on those runtimes speak the Agent

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -330,12 +330,10 @@ defmodule Fountain.Runtimes.ACP do
   Verified against the pinned adapter's own parser, which does
   `Object.fromEntries(server.env.map((e) => [e.name, e.value]))`.
 
-  Servers are still installed into the sandbox by
-  `Fountain.Runtimes.Claude.prepare_sprite/3` as well. That is belt and braces
-  rather than duplication: the adapter runs on the Agent SDK rather than the
-  `claude` CLI, so whether it reads the CLI's user-scope config is exactly the
-  kind of thing gate 1 flagged as unverified. Passing them over the protocol is
-  the path that does not depend on the answer.
+  This is the *only* delivery path since #636 — the out-of-band per-runtime
+  config writers (claude's `mcp add-json` loop, codex's `config.toml`,
+  opencode's `opencode.json`) are gone. Gate 2 verified the protocol path
+  live: server started, listed, called, env delivered.
   """
   @spec mcp_servers(Agent.t() | nil) :: [map()]
   def mcp_servers(%Agent{mcp_servers: servers}) when is_map(servers) and map_size(servers) > 0 do

--- a/apps/fountain/lib/fountain/runtimes/claude.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude.ex
@@ -78,41 +78,10 @@ defmodule Fountain.Runtimes.Claude do
     end
   end
 
-  # Claude Code 2.x dropped support for top-level `mcpServers` in
-  # `~/.claude.json` and rewrites that file aggressively on first
-  # launch, clobbering anything we drop in there. Use the supported
-  # `claude mcp add-json --scope user` path instead — it goes through
-  # Claude's own state machine and survives further schema changes.
-  @impl true
-  def prepare_sprite(_sprite, nil, _sprite_env), do: :ok
-
-  def prepare_sprite(_sprite, %{mcp_servers: m}, _sprite_env)
-      when m == %{} or is_nil(m),
-      do: :ok
-
-  def prepare_sprite(sprite, %{mcp_servers: mcp_servers}, sprite_env)
-      when is_map(mcp_servers) do
-    Enum.reduce_while(mcp_servers, :ok, fn {name, entry}, :ok ->
-      args = [
-        "mcp",
-        "add-json",
-        "--scope",
-        "user",
-        to_string(name),
-        Jason.encode!(entry)
-      ]
-
-      case Sprites.cmd(sprite, "claude", args,
-             env: sprite_env,
-             stderr_to_stdout: true,
-             timeout: 30_000
-           ) do
-        {_out, 0} ->
-          {:cont, :ok}
-
-        {out, code} ->
-          {:halt, {:error, {:claude_mcp_add_failed, name, code, out}}}
-      end
-    end)
-  end
+  # MCP servers travel in `session/new`'s `mcpServers` param on the ACP path
+  # (#636); the `claude mcp add-json --scope user` provisioning loop that used
+  # to live here existed for the CLI, which the ACP adapter does not wrap. An
+  # agent opted out of ACP (`metadata["acp"] == false`) therefore runs its
+  # legacy turns without MCP servers — the opt-out is an emergency hatch, not
+  # a configuration.
 end

--- a/apps/fountain/lib/fountain/runtimes/codex.ex
+++ b/apps/fountain/lib/fountain/runtimes/codex.ex
@@ -87,60 +87,10 @@ defmodule Fountain.Runtimes.Codex do
     end
   end
 
-  # Codex reads `~/.codex/config.toml`; MCP servers go under
-  # `[mcp_servers.<name>]` (snake_case, NOT `mcpServers`).
-  @impl true
-  def write_config(_sprite, nil), do: :ok
-  def write_config(_sprite, %{mcp_servers: m}) when m == %{} or is_nil(m), do: :ok
-
-  def write_config(sprite, %{mcp_servers: mcp_servers}) do
-    fs = Sprites.filesystem(sprite, "/")
-    Sprites.Filesystem.mkdir_p(fs, "/home/sprite/.codex")
-    Sprites.Filesystem.write(fs, "/home/sprite/.codex/config.toml", render_toml(mcp_servers))
-    :ok
-  end
-
-  defp render_toml(mcp_servers) do
-    mcp_servers
-    |> Enum.sort()
-    |> Enum.map_join("\n", &render_server/1)
-  end
-
-  defp render_server({name, %{} = entry}) do
-    fields =
-      [
-        toml_kv("command", Map.get(entry, "command")),
-        toml_array("args", Map.get(entry, "args", [])),
-        toml_inline_table("env", Map.get(entry, "env", %{}))
-      ]
-      |> Enum.reject(&is_nil/1)
-      |> Enum.join("\n")
-
-    "[mcp_servers.#{name}]\n#{fields}\n"
-  end
-
-  defp toml_kv(_, nil), do: nil
-  defp toml_kv(k, v) when is_binary(v), do: ~s(#{k} = "#{toml_escape(v)}")
-
-  defp toml_array(_, []), do: nil
-
-  defp toml_array(k, list) when is_list(list) do
-    items = Enum.map_join(list, ", ", &~s("#{toml_escape(to_string(&1))}"))
-    "#{k} = [#{items}]"
-  end
-
-  defp toml_inline_table(_, m) when m == %{}, do: nil
-
-  defp toml_inline_table(k, m) when is_map(m) do
-    pairs = Enum.map_join(m, ", ", fn {ek, ev} -> ~s(#{ek} = "#{toml_escape(to_string(ev))}") end)
-    "#{k} = { #{pairs} }"
-  end
-
-  defp toml_escape(s) do
-    s
-    |> String.replace("\\", "\\\\")
-    |> String.replace(~s("), ~s(\\"  ))
-  end
+  # MCP servers travel in `session/new`'s `mcpServers` param on the ACP path
+  # (#636); the `~/.codex/config.toml` writer that used to live here served
+  # the bare CLI. An agent opted out of ACP runs its legacy turns without MCP
+  # servers.
 
   # codex 0.118+ does NOT read OPENAI_API_KEY at exec time — it only reads
   # `~/.codex/auth.json`, which `codex login --with-api-key` writes by

--- a/apps/fountain/lib/fountain/runtimes/open_code.ex
+++ b/apps/fountain/lib/fountain/runtimes/open_code.ex
@@ -125,47 +125,7 @@ defmodule Fountain.Runtimes.OpenCode do
     end
   end
 
-  # opencode reads `~/.config/opencode/opencode.json`; MCP servers go under
-  # `mcp` and each entry needs `type: "local"`, `command` as an ARRAY,
-  # and `environment` (not `env`).  We translate from the canonical
-  # claude shape stored on the agent.
-  @impl true
-  def write_config(_sprite, nil), do: :ok
-  def write_config(_sprite, %{mcp_servers: m}) when m == %{} or is_nil(m), do: :ok
-
-  def write_config(sprite, %{mcp_servers: mcp_servers}) do
-    fs = Sprites.filesystem(sprite, "/")
-    Sprites.Filesystem.mkdir_p(fs, "/tmp/.config/opencode")
-    Sprites.Filesystem.mkdir_p(fs, "/home/sprite/.config/opencode")
-
-    payload =
-      Jason.encode!(
-        %{
-          "$schema" => "https://opencode.ai/config.json",
-          "mcp" => Map.new(mcp_servers, &translate_mcp_entry/1)
-        },
-        pretty: true
-      )
-
-    # Write to both locations: the runtime overrides HOME=/tmp at spawn
-    # time, so opencode actually reads /tmp/.config/opencode/opencode.json.
-    # We keep the /home/sprite copy in sync for `opencode` invocations
-    # outside our spawn (e.g. an operator shelling in).
-    Sprites.Filesystem.write(fs, "/tmp/.config/opencode/opencode.json", payload)
-    Sprites.Filesystem.write(fs, "/home/sprite/.config/opencode/opencode.json", payload)
-    :ok
-  end
-
-  defp translate_mcp_entry({name, %{} = entry}) do
-    cmd = Map.get(entry, "command")
-    args = Map.get(entry, "args", [])
-
-    {name,
-     %{
-       "type" => "local",
-       "command" => [cmd | args],
-       "environment" => Map.get(entry, "env", %{}),
-       "enabled" => true
-     }}
-  end
+  # MCP servers travel in `session/new`'s `mcpServers` param on the ACP path
+  # (#636); the `opencode.json` writer that used to live here served the bare
+  # CLI. An agent opted out of ACP runs its legacy turns without MCP servers.
 end


### PR DESCRIPTION
Closes #636. Part of #644 (ADR 0014 gate 4).

## What

Deletes the three out-of-band MCP config mechanisms for the runtimes whose default path is now ACP (#671):

- **claude** — the `claude mcp add-json --scope user` provisioning loop (the whole of `Claude.prepare_sprite/3`; the callback is optional, so the module simply stops exporting it)
- **codex** — the `~/.codex/config.toml` writer + TOML rendering helpers (`prepare_sprite`'s `codex login` stays — it's credentials, not MCP, and ADR 0014 keeps the provisioning layer)
- **opencode** — the `opencode.json` writer to both HOMEs + entry translation (the bun install in `prepare_sprite` stays)

`session/new`'s `mcpServers` param is the single delivery path — the shape verified live in gate 2 (stdio server started, listed and called; `env` delivered as name/value pairs; servers re-sent on every resume because the adapter snapshots `{cwd, mcpServers}`).

**Gemini keeps its argv allow-list** because it keeps its legacy path (#659).

## Trade-off, stated

An agent opted out via `"acp": false` now runs its legacy turns **without MCP servers**. That's deliberate: the opt-out is an emergency hatch for a broken adapter release, not a supported configuration, and it disappears with the legacy path itself. Degraded-but-running beats blocking the collapse on a hatch that exists to be rare.

`mix precommit` green (2612 tests). The deleted code had no tests of its own — it was verified only by running the product, which is part of why it's the right thing to stop owning ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)