### PR TITLE
refactor: move the four dialect parsers out of the conversation LiveView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ upgrade, is in
 
 ### Changed
 
+- **The four dialect parsers are out of the conversation LiveView.** The
+  24 `event_blocks/2` clauses move to a dedicated, tested
+  `LegacyBlocks` module: gemini's dialect stays live (#659), and the
+  claude/codex/opencode parsers are frozen — they render pre-ACP
+  history only and are deleted when that history ages out. The rule
+  this closes: a dialect parser is never written again; a runtime that
+  doesn't speak ACP gets an adapter at the sandbox boundary (#642).
 - **The legacy spawn path for claude, codex and opencode is deleted; ACP
   is the only way Fountain talks to them.** The three `build_command/5`
   argv builders go — and with them `--dangerously-skip-permissions`,

--- a/apps/fountain/lib/fountain_web/live/conversations_live/legacy_blocks.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/legacy_blocks.ex
@@ -1,0 +1,276 @@
+defmodule FountainWeb.ConversationsLive.LegacyBlocks do
+  @moduledoc """
+  Translate stored legacy-dialect stdout lines into the block maps the
+  conversation view renders.
+
+  This is the twin of `Fountain.Runtimes.ACP.Blocks`, for the `stdout` stream:
+  the four hand-written parsers that used to be 24 `event_blocks/2` clauses
+  inside the LiveView render path (#642). Getting them out of `show.ex` was
+  ADR 0014's original complaint — a vendor's point release becoming our
+  rendering bug, in the render path, with no tests of their own.
+
+  ## What is live and what is frozen
+
+  - **gemini** is the only dialect still *produced*: its ACP conversion is
+    held back by an upstream defect (#659), so gemini turns keep writing
+    stream-json to the `stdout` stream and this parser keeps earning its
+    place.
+  - **claude, codex, opencode** are **frozen**: their runtimes speak only ACP
+    now, so their parsers exist solely to render `stdout` rows recorded
+    before the conversion. Frozen means exactly that — the input set is
+    historical and can no longer change, so these clauses must never be
+    extended. When pre-ACP history ages out of retention, they are deleted.
+
+  **A dialect parser must never be written again.** A fifth runtime that does
+  not speak ACP gets an adapter at the sandbox boundary, not a fifth set of
+  clauses here (and never one in `cli/` — ADR 0015).
+
+  Unrecognised lines render as `:raw` blocks rather than disappearing:
+  something will always write a non-protocol line to stdout, and visible
+  noise beats silent loss.
+  """
+
+  @doc """
+  Translate one stored stdout line into blocks for `runtime`'s dialect.
+
+  Returns `[%{kind: :raw, ...}]` for anything the dialect does not claim.
+  """
+  @spec from_line(String.t(), String.t() | nil) :: [map()]
+  def from_line(line, runtime) do
+    case Jason.decode(line) do
+      {:ok, decoded} ->
+        case event_blocks(runtime, decoded) do
+          nil -> [%{kind: :raw, body: line, summary: short_kind(decoded)}]
+          blocks when is_list(blocks) -> blocks
+        end
+
+      {:error, _} ->
+        [%{kind: :raw, body: line, summary: "raw"}]
+    end
+  end
+
+  defp short_kind(%{"type" => t}), do: to_string(t)
+  defp short_kind(_), do: "raw"
+
+  # ── claude (stream-json) — FROZEN: renders pre-ACP history only ────────────
+  defp event_blocks("claude", %{"type" => "system", "subtype" => "init"} = ev) do
+    model = ev["model"]
+
+    tool_count =
+      ev["tools"]
+      |> case do
+        l when is_list(l) -> length(l)
+        _ -> nil
+      end
+
+    summary =
+      ["session started", model, tool_count && "#{tool_count} tools"]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(" · ")
+
+    [%{kind: :init, summary: summary, body: Jason.encode!(ev, pretty: true)}]
+  end
+
+  defp event_blocks("claude", %{"type" => "assistant", "message" => %{"content" => content}}) do
+    Enum.flat_map(content, fn
+      %{"type" => "text", "text" => t} ->
+        [%{kind: :text, body: t}]
+
+      %{"type" => "thinking", "thinking" => t} ->
+        [%{kind: :thinking, body: t}]
+
+      %{"type" => "tool_use", "name" => name, "input" => input} = tu ->
+        [
+          %{
+            kind: :tool_use,
+            id: tu["id"],
+            name: name,
+            summary: tool_input_preview(input),
+            body: Jason.encode!(input, pretty: true)
+          }
+        ]
+
+      _ ->
+        []
+    end)
+  end
+
+  defp event_blocks("claude", %{"type" => "user", "message" => %{"content" => content}}) do
+    Enum.flat_map(content, fn
+      %{"tool_use_id" => tid, "content" => c} = tr when is_binary(c) ->
+        [%{kind: :tool_result, tool_id: tid, body: c, error?: tr["is_error"] == true}]
+
+      %{"tool_use_id" => tid, "content" => list} = tr when is_list(list) ->
+        [
+          %{
+            kind: :tool_result,
+            tool_id: tid,
+            body: Enum.map_join(list, "\n", &content_part_to_text/1),
+            error?: tr["is_error"] == true
+          }
+        ]
+
+      _ ->
+        []
+    end)
+  end
+
+  defp event_blocks("claude", %{"type" => "result"} = ev) do
+    bits =
+      [
+        format_status(ev["subtype"]),
+        ev["duration_ms"] && format_duration_ms(ev["duration_ms"]),
+        ev["usage"] && "in:#{ev["usage"]["input_tokens"]} out:#{ev["usage"]["output_tokens"]}"
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(" · ")
+
+    # Body is intentionally left out here — it's a copy of the final
+    # assistant message which we already rendered as a :text block.
+    [%{kind: :result, body: bits, raw: Jason.encode!(ev, pretty: true)}]
+  end
+
+  defp event_blocks("claude", %{"type" => "rate_limit_event"}), do: []
+
+  # ── codex (`codex exec --json`) — FROZEN: renders pre-ACP history only ─────
+  defp event_blocks("codex", %{"type" => "thread.started", "thread_id" => id}),
+    do: [%{kind: :init, summary: "thread: #{id}"}]
+
+  defp event_blocks("codex", %{"type" => "turn.started"}), do: []
+  defp event_blocks("codex", %{"type" => "item.started"}), do: []
+
+  defp event_blocks("codex", %{
+         "type" => "item.completed",
+         "item" => %{"type" => "agent_message", "text" => text}
+       }),
+       do: [%{kind: :text, body: text}]
+
+  defp event_blocks("codex", %{"type" => "item.completed", "item" => %{"type" => t} = item}),
+    do: [%{kind: :tool_use, name: to_string(t), body: Jason.encode!(item, pretty: true)}]
+
+  defp event_blocks("codex", %{"type" => "turn.completed", "usage" => usage}),
+    do: [
+      %{
+        kind: :result,
+        body: "in:#{usage["input_tokens"]} out:#{usage["output_tokens"]}"
+      }
+    ]
+
+  defp event_blocks("codex", %{"type" => "turn.failed", "error" => %{"message" => m}}),
+    do: [%{kind: :error, body: m}]
+
+  defp event_blocks("codex", %{"type" => "error", "message" => m}),
+    do: [%{kind: :error, body: m}]
+
+  # ── gemini (`gemini --output-format stream-json`) — LIVE (#659) ────────────
+  defp event_blocks("gemini", %{"type" => "init"} = ev) do
+    summary =
+      ["session started", ev["model"]]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(" · ")
+
+    [%{kind: :init, summary: summary, body: Jason.encode!(ev, pretty: true)}]
+  end
+
+  defp event_blocks("gemini", %{"type" => "message", "role" => "user"}), do: []
+
+  defp event_blocks("gemini", %{"type" => "message", "role" => "assistant", "content" => c})
+       when is_binary(c),
+       do: [%{kind: :text, body: c}]
+
+  defp event_blocks("gemini", %{"type" => "tool_use"} = ev) do
+    [
+      %{
+        kind: :tool_use,
+        id: ev["tool_id"],
+        name: ev["tool_name"],
+        summary: tool_input_preview(ev["parameters"]),
+        body: Jason.encode!(ev["parameters"] || %{}, pretty: true)
+      }
+    ]
+  end
+
+  defp event_blocks("gemini", %{"type" => "tool_result", "output" => out} = ev)
+       when is_binary(out),
+       do: [
+         %{
+           kind: :tool_result,
+           tool_id: ev["tool_id"],
+           body: out,
+           error?: ev["status"] != "success"
+         }
+       ]
+
+  defp event_blocks("gemini", %{"type" => "result"} = ev) do
+    stats = ev["stats"] || %{}
+
+    bits =
+      [
+        ev["status"] && to_string(ev["status"]),
+        stats["duration_ms"] && format_duration_ms(stats["duration_ms"]),
+        stats["total_tokens"] && "#{stats["total_tokens"]} tokens"
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(" · ")
+
+    [%{kind: :result, body: bits, raw: Jason.encode!(ev, pretty: true)}]
+  end
+
+  # ── opencode (`opencode run --format json`) — FROZEN: pre-ACP history ──────
+  defp event_blocks("opencode", %{"type" => "step_start"}), do: []
+
+  defp event_blocks("opencode", %{"type" => "text", "part" => %{"text" => t}})
+       when is_binary(t),
+       do: [%{kind: :text, body: t}]
+
+  defp event_blocks("opencode", %{
+         "type" => "tool_use",
+         "part" => %{"tool" => name, "state" => %{"input" => input}}
+       }),
+       do: [
+         %{
+           kind: :tool_use,
+           name: name,
+           summary: tool_input_preview(input),
+           body: Jason.encode!(input, pretty: true)
+         }
+       ]
+
+  defp event_blocks("opencode", %{"type" => "tool_use", "part" => %{"tool" => name}}),
+    do: [%{kind: :tool_use, name: name}]
+
+  defp event_blocks("opencode", %{"type" => "step_finish", "part" => %{"reason" => reason}} = ev),
+    do: [%{kind: :result, body: reason, raw: Jason.encode!(ev, pretty: true)}]
+
+  # Unknown dialect or unclaimed event — caller falls back to a :raw block.
+  defp event_blocks(_runtime, _decoded), do: nil
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  defp content_part_to_text(%{"type" => "text", "text" => t}), do: t
+  defp content_part_to_text(other), do: Jason.encode!(other)
+
+  # One-line preview of a tool's input for display next to the tool name.
+  defp tool_input_preview(input) when is_map(input) do
+    cond do
+      Map.has_key?(input, "command") -> to_string(input["command"]) |> truncate(80)
+      Map.has_key?(input, "file_path") -> to_string(input["file_path"])
+      Map.has_key?(input, "pattern") -> to_string(input["pattern"])
+      true -> input |> Jason.encode!() |> truncate(80)
+    end
+  end
+
+  defp tool_input_preview(_), do: nil
+
+  defp truncate(s, n) when is_binary(s) and byte_size(s) > n,
+    do: binary_part(s, 0, n) <> "…"
+
+  defp truncate(s, _), do: s
+
+  defp format_duration_ms(ms) when is_integer(ms) and ms < 1_000, do: "#{ms}ms"
+  defp format_duration_ms(ms) when is_integer(ms), do: "#{Float.round(ms / 1000, 1)}s"
+  defp format_duration_ms(_), do: ""
+
+  defp format_status(nil), do: nil
+  defp format_status(s), do: to_string(s)
+end

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -1294,10 +1294,13 @@ defmodule FountainWeb.ConversationsLive.Show do
     |> Enum.flat_map(&Fountain.Runtimes.ACP.Blocks.from_line/1)
   end
 
+  # Legacy stdout rows: gemini's live dialect (#659) and pre-ACP history for
+  # the converted runtimes. The parsers live in `LegacyBlocks`, out of the
+  # render path, with their own tests — this clause is the whole seam (#642).
   defp blocks_for(%{data: data}, runtime) when is_binary(data) do
     data
     |> String.split("\n", trim: true)
-    |> Enum.flat_map(&line_to_blocks(&1, runtime))
+    |> Enum.flat_map(&FountainWeb.ConversationsLive.LegacyBlocks.from_line(&1, runtime))
   end
 
   defp blocks_for(_, _), do: []
@@ -1345,231 +1348,6 @@ defmodule FountainWeb.ConversationsLive.Show do
     |> elem(0)
     |> Enum.reverse()
   end
-
-  defp line_to_blocks(line, runtime) do
-    case Jason.decode(line) do
-      {:ok, decoded} ->
-        case event_blocks(runtime, decoded) do
-          nil -> [%{kind: :raw, body: line, summary: short_kind(decoded)}]
-          blocks when is_list(blocks) -> blocks
-        end
-
-      {:error, _} ->
-        [%{kind: :raw, body: line, summary: "raw"}]
-    end
-  end
-
-  defp short_kind(%{"type" => t}), do: to_string(t)
-  defp short_kind(_), do: "raw"
-
-  # ── claude (stream-json) ────────────────────────────────────────────────────────────
-  defp event_blocks("claude", %{"type" => "system", "subtype" => "init"} = ev) do
-    model = ev["model"]
-
-    tool_count =
-      ev["tools"]
-      |> case do
-        l when is_list(l) -> length(l)
-        _ -> nil
-      end
-
-    summary =
-      ["session started", model, tool_count && "#{tool_count} tools"]
-      |> Enum.reject(&is_nil/1)
-      |> Enum.join(" · ")
-
-    [%{kind: :init, summary: summary, body: Jason.encode!(ev, pretty: true)}]
-  end
-
-  defp event_blocks("claude", %{"type" => "assistant", "message" => %{"content" => content}}) do
-    Enum.flat_map(content, fn
-      %{"type" => "text", "text" => t} ->
-        [%{kind: :text, body: t}]
-
-      %{"type" => "thinking", "thinking" => t} ->
-        [%{kind: :thinking, body: t}]
-
-      %{"type" => "tool_use", "name" => name, "input" => input} = tu ->
-        [
-          %{
-            kind: :tool_use,
-            id: tu["id"],
-            name: name,
-            summary: tool_input_preview(input),
-            body: Jason.encode!(input, pretty: true)
-          }
-        ]
-
-      _ ->
-        []
-    end)
-  end
-
-  defp event_blocks("claude", %{"type" => "user", "message" => %{"content" => content}}) do
-    Enum.flat_map(content, fn
-      %{"tool_use_id" => tid, "content" => c} = tr when is_binary(c) ->
-        [%{kind: :tool_result, tool_id: tid, body: c, error?: tr["is_error"] == true}]
-
-      %{"tool_use_id" => tid, "content" => list} = tr when is_list(list) ->
-        [
-          %{
-            kind: :tool_result,
-            tool_id: tid,
-            body: Enum.map_join(list, "\n", &content_part_to_text/1),
-            error?: tr["is_error"] == true
-          }
-        ]
-
-      _ ->
-        []
-    end)
-  end
-
-  defp event_blocks("claude", %{"type" => "result"} = ev) do
-    bits =
-      [
-        format_status(ev["subtype"]),
-        ev["duration_ms"] && format_duration_ms(ev["duration_ms"]),
-        ev["usage"] && "in:#{ev["usage"]["input_tokens"]} out:#{ev["usage"]["output_tokens"]}"
-      ]
-      |> Enum.reject(&is_nil/1)
-      |> Enum.join(" · ")
-
-    # Body is intentionally left out here — it's a copy of the final
-    # assistant message which we already rendered as a :text block.
-    [%{kind: :result, body: bits, raw: Jason.encode!(ev, pretty: true)}]
-  end
-
-  defp event_blocks("claude", %{"type" => "rate_limit_event"}), do: []
-
-  # ── codex (`codex exec --json`) ────────────────────────────────────────────────────────
-  defp event_blocks("codex", %{"type" => "thread.started", "thread_id" => id}),
-    do: [%{kind: :init, summary: "thread: #{id}"}]
-
-  defp event_blocks("codex", %{"type" => "turn.started"}), do: []
-  defp event_blocks("codex", %{"type" => "item.started"}), do: []
-
-  defp event_blocks("codex", %{
-         "type" => "item.completed",
-         "item" => %{"type" => "agent_message", "text" => text}
-       }),
-       do: [%{kind: :text, body: text}]
-
-  defp event_blocks("codex", %{"type" => "item.completed", "item" => %{"type" => t} = item}),
-    do: [%{kind: :tool_use, name: to_string(t), body: Jason.encode!(item, pretty: true)}]
-
-  defp event_blocks("codex", %{"type" => "turn.completed", "usage" => usage}),
-    do: [
-      %{
-        kind: :result,
-        body: "in:#{usage["input_tokens"]} out:#{usage["output_tokens"]}"
-      }
-    ]
-
-  defp event_blocks("codex", %{"type" => "turn.failed", "error" => %{"message" => m}}),
-    do: [%{kind: :error, body: m}]
-
-  defp event_blocks("codex", %{"type" => "error", "message" => m}),
-    do: [%{kind: :error, body: m}]
-
-  # ── gemini (`gemini --output-format stream-json`) ──────────────────────────
-  defp event_blocks("gemini", %{"type" => "init"} = ev) do
-    summary =
-      ["session started", ev["model"]]
-      |> Enum.reject(&is_nil/1)
-      |> Enum.join(" · ")
-
-    [%{kind: :init, summary: summary, body: Jason.encode!(ev, pretty: true)}]
-  end
-
-  defp event_blocks("gemini", %{"type" => "message", "role" => "user"}), do: []
-
-  defp event_blocks("gemini", %{"type" => "message", "role" => "assistant", "content" => c})
-       when is_binary(c),
-       do: [%{kind: :text, body: c}]
-
-  defp event_blocks("gemini", %{"type" => "tool_use"} = ev) do
-    [
-      %{
-        kind: :tool_use,
-        id: ev["tool_id"],
-        name: ev["tool_name"],
-        summary: tool_input_preview(ev["parameters"]),
-        body: Jason.encode!(ev["parameters"] || %{}, pretty: true)
-      }
-    ]
-  end
-
-  defp event_blocks("gemini", %{"type" => "tool_result", "output" => out} = ev)
-       when is_binary(out),
-       do: [
-         %{
-           kind: :tool_result,
-           tool_id: ev["tool_id"],
-           body: out,
-           error?: ev["status"] != "success"
-         }
-       ]
-
-  defp event_blocks("gemini", %{"type" => "result"} = ev) do
-    stats = ev["stats"] || %{}
-
-    bits =
-      [
-        ev["status"] && to_string(ev["status"]),
-        stats["duration_ms"] && format_duration_ms(stats["duration_ms"]),
-        stats["total_tokens"] && "#{stats["total_tokens"]} tokens"
-      ]
-      |> Enum.reject(&is_nil/1)
-      |> Enum.join(" · ")
-
-    [%{kind: :result, body: bits, raw: Jason.encode!(ev, pretty: true)}]
-  end
-
-  # ── opencode (`opencode run --format json`) ───────────────────────────────────
-  defp event_blocks("opencode", %{"type" => "step_start"}), do: []
-
-  defp event_blocks("opencode", %{"type" => "text", "part" => %{"text" => t}})
-       when is_binary(t),
-       do: [%{kind: :text, body: t}]
-
-  defp event_blocks("opencode", %{
-         "type" => "tool_use",
-         "part" => %{"tool" => name, "state" => %{"input" => input}}
-       }),
-       do: [
-         %{
-           kind: :tool_use,
-           name: name,
-           summary: tool_input_preview(input),
-           body: Jason.encode!(input, pretty: true)
-         }
-       ]
-
-  defp event_blocks("opencode", %{"type" => "tool_use", "part" => %{"tool" => name}}),
-    do: [%{kind: :tool_use, name: name}]
-
-  defp event_blocks("opencode", %{"type" => "step_finish", "part" => %{"reason" => reason}} = ev),
-    do: [%{kind: :result, body: reason, raw: Jason.encode!(ev, pretty: true)}]
-
-  # Unknown — caller falls back to a :raw block.
-  defp event_blocks(_runtime, _decoded), do: nil
-
-  # Small helpers
-  defp content_part_to_text(%{"type" => "text", "text" => t}), do: t
-  defp content_part_to_text(other), do: Jason.encode!(other)
-
-  # One-line preview of a tool's input for display next to the tool name.
-  defp tool_input_preview(input) when is_map(input) do
-    cond do
-      Map.has_key?(input, "command") -> to_string(input["command"]) |> truncate(80)
-      Map.has_key?(input, "file_path") -> to_string(input["file_path"])
-      Map.has_key?(input, "pattern") -> to_string(input["pattern"])
-      true -> input |> Jason.encode!() |> truncate(80)
-    end
-  end
-
-  defp tool_input_preview(_), do: nil
 
   defp truncate(s, n) when is_binary(s) and byte_size(s) > n,
     do: binary_part(s, 0, n) <> "…"
@@ -1685,9 +1463,6 @@ defmodule FountainWeb.ConversationsLive.Show do
 
   defp format_extra_val(v) when is_binary(v), do: truncate(v, 40)
   defp format_extra_val(v), do: inspect(v)
-
-  defp format_status(nil), do: nil
-  defp format_status(s), do: to_string(s)
 
   # Pull the turn_id out of the `turn started` event's JSON data and
   # look up the prompt the user submitted for that turn. Returns the

--- a/apps/fountain/test/fountain_web/live/conversations_live/legacy_blocks_test.exs
+++ b/apps/fountain/test/fountain_web/live/conversations_live/legacy_blocks_test.exs
@@ -1,0 +1,253 @@
+defmodule FountainWeb.ConversationsLive.LegacyBlocksTest do
+  use ExUnit.Case, async: true
+
+  alias FountainWeb.ConversationsLive.LegacyBlocks
+
+  # First tests these parsers have ever had: they spent their whole life as
+  # private clauses of a LiveView (#642). Gemini's dialect is live; the other
+  # three are frozen and render pre-ACP history only — these tests pin the
+  # frozen behavior so a refactor can't silently change how old transcripts
+  # render.
+
+  defp line(map), do: Jason.encode!(map)
+
+  describe "claude (frozen)" do
+    test "init, text, thinking, tool_use, tool_result, result" do
+      assert [%{kind: :init, summary: summary}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "system",
+                   "subtype" => "init",
+                   "model" => "claude-sonnet-4-6",
+                   "tools" => ["a", "b"]
+                 }),
+                 "claude"
+               )
+
+      assert summary =~ "claude-sonnet-4-6"
+      assert summary =~ "2 tools"
+
+      assert [%{kind: :text, body: "hi"}, %{kind: :thinking, body: "hmm"}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "assistant",
+                   "message" => %{
+                     "content" => [
+                       %{"type" => "text", "text" => "hi"},
+                       %{"type" => "thinking", "thinking" => "hmm"}
+                     ]
+                   }
+                 }),
+                 "claude"
+               )
+
+      assert [%{kind: :tool_use, id: "t1", name: "Bash", summary: "ls"}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "assistant",
+                   "message" => %{
+                     "content" => [
+                       %{
+                         "type" => "tool_use",
+                         "id" => "t1",
+                         "name" => "Bash",
+                         "input" => %{"command" => "ls"}
+                       }
+                     ]
+                   }
+                 }),
+                 "claude"
+               )
+
+      assert [%{kind: :tool_result, tool_id: "t1", body: "ok", error?: false}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "user",
+                   "message" => %{
+                     "content" => [%{"tool_use_id" => "t1", "content" => "ok"}]
+                   }
+                 }),
+                 "claude"
+               )
+
+      assert [%{kind: :result, body: body}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "result",
+                   "subtype" => "success",
+                   "duration_ms" => 1500,
+                   "usage" => %{"input_tokens" => 10, "output_tokens" => 5}
+                 }),
+                 "claude"
+               )
+
+      assert body == "success · 1.5s · in:10 out:5"
+    end
+
+    test "rate_limit_event renders nothing" do
+      assert [] = LegacyBlocks.from_line(line(%{"type" => "rate_limit_event"}), "claude")
+    end
+  end
+
+  describe "codex (frozen)" do
+    test "thread, message, tool item, usage, errors" do
+      assert [%{kind: :init, summary: "thread: th_1"}] =
+               LegacyBlocks.from_line(
+                 line(%{"type" => "thread.started", "thread_id" => "th_1"}),
+                 "codex"
+               )
+
+      assert [%{kind: :text, body: "hello"}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "item.completed",
+                   "item" => %{"type" => "agent_message", "text" => "hello"}
+                 }),
+                 "codex"
+               )
+
+      assert [%{kind: :tool_use, name: "command_execution"}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "item.completed",
+                   "item" => %{"type" => "command_execution", "command" => "ls"}
+                 }),
+                 "codex"
+               )
+
+      assert [%{kind: :result, body: "in:7 out:3"}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "turn.completed",
+                   "usage" => %{"input_tokens" => 7, "output_tokens" => 3}
+                 }),
+                 "codex"
+               )
+
+      assert [%{kind: :error, body: "boom"}] =
+               LegacyBlocks.from_line(
+                 line(%{"type" => "turn.failed", "error" => %{"message" => "boom"}}),
+                 "codex"
+               )
+    end
+  end
+
+  describe "gemini (live, #659)" do
+    test "init, assistant text, tool pair, result" do
+      assert [%{kind: :init, summary: summary}] =
+               LegacyBlocks.from_line(
+                 line(%{"type" => "init", "model" => "gemini-2.5-pro"}),
+                 "gemini"
+               )
+
+      assert summary =~ "gemini-2.5-pro"
+
+      assert [] =
+               LegacyBlocks.from_line(
+                 line(%{"type" => "message", "role" => "user", "content" => "prompt"}),
+                 "gemini"
+               )
+
+      assert [%{kind: :text, body: "answer"}] =
+               LegacyBlocks.from_line(
+                 line(%{"type" => "message", "role" => "assistant", "content" => "answer"}),
+                 "gemini"
+               )
+
+      assert [%{kind: :tool_use, id: "g1", name: "read_file", summary: "/tmp/x"}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "tool_use",
+                   "tool_id" => "g1",
+                   "tool_name" => "read_file",
+                   "parameters" => %{"file_path" => "/tmp/x"}
+                 }),
+                 "gemini"
+               )
+
+      assert [%{kind: :tool_result, tool_id: "g1", body: "contents", error?: false}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "tool_result",
+                   "tool_id" => "g1",
+                   "output" => "contents",
+                   "status" => "success"
+                 }),
+                 "gemini"
+               )
+
+      assert [%{kind: :result, body: body}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "result",
+                   "status" => "done",
+                   "stats" => %{"duration_ms" => 800, "total_tokens" => 42}
+                 }),
+                 "gemini"
+               )
+
+      assert body == "done · 800ms · 42 tokens"
+    end
+
+    test "a failed tool result is marked as an error" do
+      assert [%{kind: :tool_result, error?: true}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "tool_result",
+                   "tool_id" => "g1",
+                   "output" => "denied",
+                   "status" => "error"
+                 }),
+                 "gemini"
+               )
+    end
+  end
+
+  describe "opencode (frozen)" do
+    test "text, tool_use with and without input, step_finish" do
+      assert [%{kind: :text, body: "hey"}] =
+               LegacyBlocks.from_line(
+                 line(%{"type" => "text", "part" => %{"text" => "hey"}}),
+                 "opencode"
+               )
+
+      assert [%{kind: :tool_use, name: "bash", summary: "pwd"}] =
+               LegacyBlocks.from_line(
+                 line(%{
+                   "type" => "tool_use",
+                   "part" => %{"tool" => "bash", "state" => %{"input" => %{"command" => "pwd"}}}
+                 }),
+                 "opencode"
+               )
+
+      assert [%{kind: :tool_use, name: "bash"}] =
+               LegacyBlocks.from_line(
+                 line(%{"type" => "tool_use", "part" => %{"tool" => "bash"}}),
+                 "opencode"
+               )
+
+      assert [%{kind: :result, body: "stop"}] =
+               LegacyBlocks.from_line(
+                 line(%{"type" => "step_finish", "part" => %{"reason" => "stop"}}),
+                 "opencode"
+               )
+    end
+  end
+
+  describe "the raw fallback" do
+    test "non-JSON stdout renders as a raw block, never disappears" do
+      assert [%{kind: :raw, body: "npm WARN deprecated", summary: "raw"}] =
+               LegacyBlocks.from_line("npm WARN deprecated", "claude")
+    end
+
+    test "an unclaimed JSON event keeps its type as the summary" do
+      assert [%{kind: :raw, summary: "totally_new_event"}] =
+               LegacyBlocks.from_line(line(%{"type" => "totally_new_event"}), "claude")
+    end
+
+    test "an unknown runtime falls back to raw rather than raising" do
+      assert [%{kind: :raw}] = LegacyBlocks.from_line(line(%{"type" => "text"}), "somethingelse")
+      assert [%{kind: :raw}] = LegacyBlocks.from_line(line(%{"type" => "text"}), nil)
+    end
+  end
+end

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -541,6 +541,16 @@ one runtime converted and say so here.
 A parser is deleted when its runtime's ACP path has served real conversations,
 not when the code compiles.
 
+> **Amendment, 2026-08-14.** The render path is clean: the four dialect
+> parsers left the LiveView for a dedicated `LegacyBlocks` module (#642).
+> Three of them are *frozen*, not deleted — the converted runtimes' `stdout`
+> rows predate ACP and still need rendering, but the input set is historical
+> and can no longer change, so the maintenance surface this gate exists to
+> shed is gone. They are deleted outright when pre-ACP history ages out of
+> retention. `pair_tool_results/1` also survives, deliberately: the ACP
+> translation leans on it to collapse `tool_call`/`tool_call_update` block
+> pairs, which is cheaper than a second pairing pass.
+
 **Three of the four runtimes are converted and one is not, for a reason
 outside our code — 2026-08-11.** Claude, Codex and OpenCode each did
 `session/new` then `session/resume` against a live agent, recalling a token


### PR DESCRIPTION
Closes #642. Part of #644 (ADR 0014 gate 4) — the payoff PR.

## What

- `FountainWeb.ConversationsLive.Show` loses all 24 `event_blocks/2` clauses plus their private helpers (~230 lines out of the render path). What remains is the seam: one clause delegating the `acp` stream to `Fountain.Runtimes.ACP.Blocks`, one delegating `stdout` to the new `FountainWeb.ConversationsLive.LegacyBlocks`.
- `LegacyBlocks` gets the first tests these parsers have ever had — they spent their whole life as private LiveView clauses, verified only by running the product.

## Frozen vs live, stated precisely

- **gemini** — live. Its ACP conversion is upstream-blocked (#658/#659), so its turns still produce this dialect.
- **claude / codex / opencode** — **frozen**. Their runtimes speak only ACP (#674), so these clauses render pre-ACP `stdout` history and nothing else. The input set is historical and cannot change, which is why relocation rather than deletion is honest here: deleting them would degrade every pre-ACP transcript to raw JSON, while freezing them sheds the maintenance surface this gate exists to shed. They're deleted outright when pre-ACP history ages out of retention.

## Two deliberate survivals (deviations from #642 as written)

- `pair_tool_results/1` stays in `show.ex`: the ACP translation deliberately leans on it to collapse `tool_call`/`tool_call_update` block pairs (`Blocks` moduledoc says so), so deleting it means writing it again.
- The raw-line fallback stays, as the issue itself required.

The rule this closes: **a dialect parser is never written again**, in this repo or in `cli/` (ADR 0015). A fifth runtime that doesn't speak ACP gets an adapter at the sandbox boundary. ADR 0014 gate 4 amended accordingly.

`mix precommit` green (2615 tests, dialyzer 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)