### PR TITLE
feat: move the leaf sandbox call sites onto the Fountain.Sandbox facade

### DIFF
--- a/apps/fountain/lib/fountain/accounts/deletion.ex
+++ b/apps/fountain/lib/fountain/accounts/deletion.ex
@@ -174,10 +174,10 @@ defmodule Fountain.Accounts.Deletion do
   end
 
   defp destroy_sprite(%Sandbox{sprite_name: name} = sandbox) when is_binary(name) do
-    client = Fountain.SpritesClient.get!()
+    handle = Fountain.Sandbox.build_handle(:sprites, name)
 
     result =
-      case Sprites.destroy(Sprites.sprite(client, name)) do
+      case Fountain.Sandbox.destroy(handle) do
         :ok ->
           true
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -570,23 +570,27 @@ defmodule Fountain.Conversations.ConversationServer do
 
     case create_sprite(sandbox.sprite_name) do
       {:ok, sprite} ->
+        # Transitional while this server still holds the SDK sprite: the
+        # already-migrated leaf modules (skills, runtime prepare/config)
+        # take a Fountain.Sandbox.Handle.
+        handle = Fountain.Sandbox.Sprites.from_sdk(sprite)
         skills = (agent && agent.skills) || []
         # conv.runtime is validated-required and outlives the agent; the agent
         # fallback only covers rows predating the runtime column.
         runtime = conv.runtime || (agent && agent.runtime) || "claude"
-        Fountain.SpriteSkills.mount(sprite, runtime, skills)
+        Fountain.SpriteSkills.mount(handle, runtime, skills)
 
         {state, conv} = rotate_callback_api_key(state, conv)
 
         sprite_env = build_sprite_env(state, agent, env, secrets)
 
-        write_runtime_config(sprite, state.runtime_module, agent)
+        write_runtime_config(handle, state.runtime_module, agent)
         Fountain.Conversations.Provisioning.write_env_file(sprite, sprite_env)
 
         with :ok <-
                run_provisioning_pipeline(sprite, env, sprite_env, secrets, state.conversation_id),
              :ok <-
-               prepare_runtime_sprite(sprite, runtime, state.runtime_module, agent, sprite_env) do
+               prepare_runtime_sprite(handle, runtime, state.runtime_module, agent, sprite_env) do
           {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
           publish_stage(state.conversation_id, "provision", "done")
 
@@ -1019,20 +1023,20 @@ defmodule Fountain.Conversations.ConversationServer do
     )
   end
 
-  defp write_runtime_config(sprite, runtime_module, agent) do
+  defp write_runtime_config(handle, runtime_module, agent) do
     Code.ensure_loaded(runtime_module)
 
     if function_exported?(runtime_module, :write_config, 2) do
-      runtime_module.write_config(sprite, agent)
+      runtime_module.write_config(handle, agent)
     end
   end
 
-  defp prepare_runtime_sprite(sprite, runtime, runtime_module, agent, sprite_env) do
+  defp prepare_runtime_sprite(handle, runtime, runtime_module, agent, sprite_env) do
     Code.ensure_loaded(runtime_module)
 
-    with :ok <- prepare_acp_adapter(sprite, runtime, sprite_env) do
+    with :ok <- prepare_acp_adapter(handle, runtime, sprite_env) do
       if function_exported?(runtime_module, :prepare_sprite, 3) do
-        runtime_module.prepare_sprite(sprite, agent, sprite_env)
+        runtime_module.prepare_sprite(handle, agent, sprite_env)
       else
         :ok
       end
@@ -1043,9 +1047,9 @@ defmodule Fountain.Conversations.ConversationServer do
   # spawn: by the time a turn runs, the network policy has been applied and the
   # install would fail in a way that reads as a protocol bug. Keyed on the
   # conversation's runtime, matching the spawn decision in kick_turn/4.
-  defp prepare_acp_adapter(sprite, runtime, sprite_env) do
+  defp prepare_acp_adapter(handle, runtime, sprite_env) do
     if Fountain.Runtimes.ACP.enabled?(runtime) do
-      Fountain.Runtimes.ACP.install(sprite, runtime, sprite_env)
+      Fountain.Runtimes.ACP.install(handle, runtime, sprite_env)
     else
       :ok
     end

--- a/apps/fountain/lib/fountain/runtimes.ex
+++ b/apps/fountain/lib/fountain/runtimes.ex
@@ -51,7 +51,7 @@ defmodule Fountain.Runtimes do
   provision time (e.g. claude's `~/.claude.json` for MCP servers).
   No-op by default.
   """
-  @callback write_config(sprite :: any(), agent :: %Agent{} | nil) :: :ok
+  @callback write_config(handle :: Fountain.Sandbox.Handle.t(), agent :: %Agent{} | nil) :: :ok
 
   @doc """
   Optionally run any sprite-side bootstrap that has to happen *before*
@@ -63,7 +63,7 @@ defmodule Fountain.Runtimes do
   pull whichever keys they need out of that list. No-op by default.
   """
   @callback prepare_sprite(
-              sprite :: any(),
+              handle :: Fountain.Sandbox.Handle.t(),
               agent :: %Agent{} | nil,
               sprite_env :: [{String.t(), String.t()}]
             ) :: :ok | {:error, term()}

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -277,9 +277,9 @@ defmodule Fountain.Runtimes.ACP do
   # `OpenCode.prepare_sprite/3`'s bun install. Nothing to install, and for
   # gemini nothing we can pin either: the version floor is whatever the image
   # carries, which gate 1 recorded as an open exposure.
-  def install(_sprite, runtime, _sprite_env) when runtime in ["gemini", "opencode"], do: :ok
+  def install(_handle, runtime, _sprite_env) when runtime in ["gemini", "opencode"], do: :ok
 
-  def install(sprite, runtime, sprite_env) do
+  def install(handle, runtime, sprite_env) do
     bin = adapter_bin(runtime)
     spec = adapter_spec(runtime)
     version = get_in(@adapters, [runtime, :version])
@@ -297,12 +297,18 @@ defmodule Fountain.Runtimes.ACP do
     "$bin" --version >/dev/null
     """
 
-    case Sprites.cmd(sprite, "bash", ["-lc", script], env: sprite_env, timeout: 180_000) do
-      {_out, 0} ->
+    case Fountain.Sandbox.exec(handle, "bash", ["-lc", script],
+           env: sprite_env,
+           timeout: 180_000
+         ) do
+      {:ok, _out, 0} ->
         :ok
 
-      {out, code} ->
+      {:ok, out, code} ->
         {:error, {:acp_adapter_install_exit, code, String.slice(to_string(out), 0, 500)}}
+
+      {:error, reason} ->
+        {:error, {:acp_adapter_install, reason}}
     end
   end
 

--- a/apps/fountain/lib/fountain/runtimes/codex.ex
+++ b/apps/fountain/lib/fountain/runtimes/codex.ex
@@ -39,10 +39,10 @@ defmodule Fountain.Runtimes.Codex do
   # `~/.codex/auth.json`, which `codex login --with-api-key` writes by
   # consuming the key on stdin. Run the login once at provision time.
   @impl true
-  def prepare_sprite(sprite, _agent, sprite_env) do
+  def prepare_sprite(handle, _agent, sprite_env) do
     case List.keyfind(sprite_env, "OPENAI_API_KEY", 0) do
       {"OPENAI_API_KEY", key} when is_binary(key) and key != "" ->
-        case Sprites.spawn(sprite, "codex", ["login", "--with-api-key"],
+        case Fountain.Sandbox.spawn(handle, "codex", ["login", "--with-api-key"],
                owner: self(),
                stdin: true,
                env: sprite_env
@@ -51,9 +51,10 @@ defmodule Fountain.Runtimes.Codex do
             # Same exposure as #603: `codex login` exiting before it reads the
             # key — a missing binary, a bad flag — would otherwise exit whoever
             # is provisioning, rather than returning an error they can report.
-            case Fountain.SpriteStdin.write(command, key <> "\n") do
+            # write_stdin/2 is total by contract, so that exposure stays closed.
+            case Fountain.Sandbox.write_stdin(command, key <> "\n") do
               :ok ->
-                :ok = Sprites.close_stdin(command)
+                Fountain.Sandbox.close_stdin(command)
 
                 receive do
                   {:exit, %{ref: ref}, 0} when ref == command.ref ->

--- a/apps/fountain/lib/fountain/runtimes/gemini.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini.ex
@@ -101,14 +101,12 @@ defmodule Fountain.Runtimes.Gemini do
   # was making gemini register every MCP tool twice on startup and
   # spam the log with `Tool ... already registered. Overwriting.` lines.
   @impl true
-  def write_config(_sprite, nil), do: :ok
-  def write_config(_sprite, %{mcp_servers: m}) when m == %{} or is_nil(m), do: :ok
+  def write_config(_handle, nil), do: :ok
+  def write_config(_handle, %{mcp_servers: m}) when m == %{} or is_nil(m), do: :ok
 
-  def write_config(sprite, %{mcp_servers: mcp_servers}) do
-    fs = Sprites.filesystem(sprite, "/")
+  def write_config(handle, %{mcp_servers: mcp_servers}) do
     payload = Jason.encode!(%{"mcpServers" => mcp_servers}, pretty: true)
-    Sprites.Filesystem.mkdir_p(fs, "/tmp/.gemini")
-    Sprites.Filesystem.write(fs, "/tmp/.gemini/settings.json", payload)
+    Fountain.Sandbox.write_file(handle, "/tmp/.gemini/settings.json", payload)
     :ok
   end
 
@@ -116,7 +114,7 @@ defmodule Fountain.Runtimes.Gemini do
   # MemoryDiscovery is happy as long as it finds *some* .git when it
   # walks up from cwd.
   @impl true
-  def prepare_sprite(sprite, _agent, sprite_env) do
+  def prepare_sprite(handle, _agent, sprite_env) do
     script = """
     set -e
     if [ ! -d #{@workdir}/.git ]; then
@@ -128,12 +126,13 @@ defmodule Fountain.Runtimes.Gemini do
     fi
     """
 
-    {_out, code} =
-      Sprites.cmd(sprite, "bash", ["-lc", script],
-        env: sprite_env,
-        timeout: 30_000
-      )
-
-    if code == 0, do: :ok, else: {:error, {:gemini_workspace_init_exit, code}}
+    case Fountain.Sandbox.exec(handle, "bash", ["-lc", script],
+           env: sprite_env,
+           timeout: 30_000
+         ) do
+      {:ok, _out, 0} -> :ok
+      {:ok, _out, code} -> {:error, {:gemini_workspace_init_exit, code}}
+      {:error, reason} -> {:error, {:gemini_workspace_init, reason}}
+    end
   end
 end

--- a/apps/fountain/lib/fountain/runtimes/open_code.ex
+++ b/apps/fountain/lib/fountain/runtimes/open_code.ex
@@ -58,7 +58,7 @@ defmodule Fountain.Runtimes.OpenCode do
   # bun's own global bin at /.sprite/languages/bun/bin is not on PATH).
   # Idempotent — `command -v` short-circuits on subsequent calls.
   @impl true
-  def prepare_sprite(sprite, _agent, sprite_env) do
+  def prepare_sprite(handle, _agent, sprite_env) do
     install_script = """
     set -e
 
@@ -93,13 +93,14 @@ defmodule Fountain.Runtimes.OpenCode do
     fi
     """
 
-    {_out, code} =
-      Sprites.cmd(sprite, "bash", ["-lc", install_script],
-        env: sprite_env,
-        timeout: 120_000
-      )
-
-    if code == 0, do: :ok, else: {:error, {:opencode_install_exit, code}}
+    case Fountain.Sandbox.exec(handle, "bash", ["-lc", install_script],
+           env: sprite_env,
+           timeout: 120_000
+         ) do
+      {:ok, _out, 0} -> :ok
+      {:ok, _out, code} -> {:error, {:opencode_install_exit, code}}
+      {:error, reason} -> {:error, {:opencode_install, reason}}
+    end
   end
 
   defp env_pair(name, key, inference_credentials) do

--- a/apps/fountain/lib/fountain/sandbox/sprites.ex
+++ b/apps/fountain/lib/fountain/sandbox/sprites.ex
@@ -52,6 +52,16 @@ defmodule Fountain.Sandbox.Sprites do
     %Handle{provider: :sprites, name: name}
   end
 
+  @doc """
+  Transitional: wrap the SDK sprite `ConversationServer` still holds in a
+  `Handle` so already-migrated modules can be called from not-yet-migrated
+  ones. Accepts the bare `%{name: ...}` map the test harness uses as its
+  stand-in sprite. Deleted once the server builds handles itself.
+  """
+  @spec from_sdk(Sprites.Sprite.t() | %{required(:name) => String.t()}) :: Handle.t()
+  def from_sdk(%Sprites.Sprite{} = sprite), do: wrap(sprite)
+  def from_sdk(%{name: name}) when is_binary(name), do: build_handle(name)
+
   @impl true
   def create(name, opts) when is_binary(name) do
     client = Fountain.SpritesClient.get!()

--- a/apps/fountain/lib/fountain/sprite_skills.ex
+++ b/apps/fountain/lib/fountain/sprite_skills.ex
@@ -20,31 +20,32 @@ defmodule Fountain.SpriteSkills do
 
   This must run before the network policy locks the sprite down: github
   installs hit npm + GitHub. Inside `mount/3` the github installs run
-  before the inline writes — `Sprites.cmd` blocks until the sprite is
-  fully ready, which is the readiness gate the HTTP `/fs/*` endpoints
+  before the inline writes — a blocking exec waits until the sandbox is
+  fully ready, which is the readiness gate the file-write endpoints
   silently need too.
   """
 
   require Logger
 
   alias Fountain.Runtimes
-  alias Sprites.Filesystem
+  alias Fountain.Sandbox
 
   @bundle_root "sprite_skills"
   @fountain_skill_name "fountain"
 
   @doc """
-  Mount `skills` (a list of inline/github maps) on `sprite` for the
-  named runtime. The bundled `fountain` skill is always prepended.
+  Mount `skills` (a list of inline/github maps) on the sandbox behind
+  `handle` for the named runtime. The bundled `fountain` skill is always
+  prepended.
   """
-  def mount(sprite, runtime, skills) when is_binary(runtime) do
+  def mount(handle, runtime, skills) when is_binary(runtime) do
     case Runtimes.for_runtime(runtime) do
-      {:ok, mod} -> mount(sprite, mod, skills)
+      {:ok, mod} -> mount(handle, mod, skills)
       {:error, _} = err -> err
     end
   end
 
-  def mount(sprite, runtime_module, skills) when is_atom(runtime_module) do
+  def mount(handle, runtime_module, skills) when is_atom(runtime_module) do
     skills_root = runtime_module.skills_root()
     sh_agent = runtime_module.skills_sh_agent()
 
@@ -53,13 +54,12 @@ defmodule Fountain.SpriteSkills do
     {inline, github} =
       Enum.split_with(all, fn s -> is_binary(s["content"]) end)
 
-    # Github installs first, inline writes second: `Sprites.cmd` waits for
-    # the sprite to be running, so by the time we touch the HTTP `/fs/*`
+    # Github installs first, inline writes second: a blocking exec waits for
+    # the sandbox to be running, so by the time we touch the file-write
     # endpoints they're definitely up. (Not strictly required after the
     # SDK URL fix, but cheap defense against future readiness regressions.)
-    install_github_skills(sprite, sh_agent, github)
-    fs = Sprites.filesystem(sprite, "/")
-    write_inline_skills(fs, skills_root, inline)
+    install_github_skills(handle, sh_agent, github)
+    write_inline_skills(handle, skills_root, inline)
     :ok
   end
 
@@ -84,17 +84,16 @@ defmodule Fountain.SpriteSkills do
     }
   end
 
-  defp write_inline_skills(_fs, _root, []), do: :ok
+  defp write_inline_skills(_handle, _root, []), do: :ok
 
-  defp write_inline_skills(fs, root, inline) do
+  defp write_inline_skills(handle, root, inline) do
     Enum.each(inline, fn %{"name" => name, "content" => content} ->
-      # `mkdirParents: true` inside `Filesystem.write/4` creates the
-      # `<root>/<name>` directory atomically with the file write, so we
-      # don't need a separate `mkdir_p` round-trip (each one was another
-      # opportunity for the same readiness race).
+      # write_file/4 creates the `<root>/<name>` directory atomically with
+      # the file write, so we don't need a separate mkdir round-trip (each
+      # one was another opportunity for the same readiness race).
       path = Path.join([root, name, "SKILL.md"])
 
-      case Filesystem.write(fs, path, content) do
+      case Sandbox.write_file(handle, path, content) do
         :ok ->
           :ok
 
@@ -104,24 +103,28 @@ defmodule Fountain.SpriteSkills do
     end)
   end
 
-  defp install_github_skills(_sprite, _agent_id, []), do: :ok
+  defp install_github_skills(_handle, _agent_id, []), do: :ok
 
-  defp install_github_skills(sprite, agent_id, github) do
+  defp install_github_skills(handle, agent_id, github) do
     safe_agent = safe_token!(agent_id)
 
     Enum.each(github, fn entry ->
       cmd = github_install_cmd(entry, safe_agent)
 
-      {output, code} =
-        Sprites.cmd(sprite, "bash", ["-lc", cmd],
-          stderr_to_stdout: true,
-          timeout: 120_000
-        )
+      case Sandbox.exec(handle, "bash", ["-lc", cmd],
+             stderr_to_stdout: true,
+             timeout: 120_000
+           ) do
+        {:ok, _output, 0} ->
+          :ok
 
-      if code != 0 do
-        Logger.warning(
-          "skills.sh install failed (#{code}) for #{inspect(entry)}: #{String.slice(output, 0, 500)}"
-        )
+        {:ok, output, code} ->
+          Logger.warning(
+            "skills.sh install failed (#{code}) for #{inspect(entry)}: #{String.slice(output, 0, 500)}"
+          )
+
+        {:error, reason} ->
+          Logger.warning("skills.sh install failed for #{inspect(entry)}: #{inspect(reason)}")
       end
     end)
   end

--- a/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
@@ -287,22 +287,19 @@ defmodule Fountain.Workers.SandboxReaper do
   # ── pass 2: terminal rows whose sprite is still there ─────────────────────
 
   defp destroy_dead_sprites(live_names) do
-    client = Fountain.SpritesClient.get!()
-
     Sandbox
     |> where([s], s.status in ^@terminal_statuses)
     |> select([s], {s.id, s.sprite_name})
     |> Repo.all()
     |> Enum.filter(fn {_id, name} -> MapSet.member?(live_names, name) end)
     |> Enum.take(@destroy_limit)
-    |> Enum.count(fn {id, name} -> destroy(client, id, name) end)
+    |> Enum.count(fn {id, name} -> destroy(id, name) end)
   end
 
-  defp destroy(client, sandbox_id, sprite_name) do
-    # `Sprites.sprite/2` builds the handle; `get_sprite/2` only returns a map
-    # and cannot be passed to destroy. We already know it exists — it came out
-    # of the listing — so there is nothing to look up first.
-    case Sprites.destroy(Sprites.sprite(client, sprite_name)) do
+  defp destroy(sandbox_id, sprite_name) do
+    # build_handle/2 is pure — we already know the sandbox exists (it came
+    # out of the listing), so there is nothing to look up first.
+    case Fountain.Sandbox.destroy(Fountain.Sandbox.build_handle(:sprites, sprite_name)) do
       :ok ->
         Logger.info("reaper: destroyed leaked sprite #{sprite_name} (sandbox #{sandbox_id})")
         true
@@ -343,12 +340,12 @@ defmodule Fountain.Workers.SandboxReaper do
 
   # ── sprites.dev ───────────────────────────────────────────────────────────
 
-  # Paginated deliberately — see Fountain.SpritesClient.list_all_sprite_names/0.
-  # A single `Sprites.list/2` call returns the first 50 and looks complete,
-  # which for a function that decides what to delete is the worst possible
-  # shape of wrong.
+  # Paginated deliberately inside the adapter — a first-page-only listing
+  # looks complete, which for a function that decides what to delete is the
+  # worst possible shape of wrong; the adapter returns {:error, :truncated}
+  # rather than a partial view.
   defp list_sprites do
-    Fountain.SpritesClient.list_all_sprite_names()
+    Fountain.Sandbox.list_all_names(:sprites)
   rescue
     e -> {:error, e}
   end

--- a/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
+++ b/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
@@ -422,7 +422,9 @@ defmodule Fountain.Workers.SandboxReaperTest do
       stub(Fountain.SpritesClient, :list_all_sprite_names, fn -> {:error, :nxdomain} end)
 
       capture_log(fn ->
-        assert {:error, :nxdomain} = perform_job(SandboxReaper, %{})
+        # The adapter normalizes unknown transport reasons into the sandbox
+        # error taxonomy; any {:error, _} is what lets Oban retry.
+        assert {:error, {:provider, :sprites, :nxdomain}} = perform_job(SandboxReaper, %{})
       end)
 
       assert Repo.reload(sandbox).status == "failed"

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -54,13 +54,23 @@ defmodule Fountain.ConversationServerCase do
     Mimic.stub(Sprites, :destroy, fn _sprite -> :ok end)
     Mimic.stub(Sprites, :cmd, fn _sprite, _cmd, _opts -> {:ok, %{exit_code: 0, stdout: ""}} end)
 
-    # The 4-arity variant returns {output, exit_code} and is what the ACP
-    # adapter install and the runtimes' prepare_sprite scripts call; without
-    # this stub those reach the real client.
+    # The 4-arity variant returns {output, exit_code} and is what the
+    # not-yet-migrated call sites' scripts call; without this stub those
+    # reach the real client.
     Mimic.stub(Sprites, :cmd, fn _sprite, _cmd, _args, _opts -> {"", 0} end)
     Mimic.stub(Sprites, :list_sessions, fn _sprite -> {:ok, []} end)
     Mimic.stub(Sprites, :update_network_policy, fn _sprite, _policy -> :ok end)
     Mimic.stub(Sprites.Filesystem, :write, fn _sprite, _path, _contents -> :ok end)
+
+    # Modules already migrated onto the Fountain.Sandbox facade (ACP adapter
+    # install, runtime prepare/config) go through the Sprites adapter rather
+    # than the SDK; stub that layer too until the migration completes and the
+    # SDK stubs above can go entirely.
+    Mimic.stub(Fountain.Sandbox.Sprites, :exec, fn _handle, _cmd, _args, _opts ->
+      {:ok, "", 0}
+    end)
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :write_file, fn _handle, _path, _data, _opts -> :ok end)
 
     Mimic.stub(Fountain.SpriteSkills, :mount, fn _sprite, _runtime, _skills -> :ok end)
 


### PR DESCRIPTION
## What

Second step of the pluggable-sandbox-backend campaign (behaviour landed in #676). The leaf call sites stop naming the `Sprites` SDK:

- **`Fountain.SpriteSkills`** — github installs via `Sandbox.exec/4`, inline skills via `Sandbox.write_file/4`.
- **Runtime provisioning hooks** — codex's `login --with-api-key` (facade `spawn`/`write_stdin`/`close_stdin`; the #603 totality now comes from the contract), gemini's settings write + workspace init, opencode's bun install, and the ACP adapter install all take a `Fountain.Sandbox.Handle`. The `Runtimes` behaviour retypes `write_config`/`prepare_sprite` from `sprite :: any()` to `Handle.t()`.
- **`Accounts.Deletion` + `SandboxReaper`** — destroy and full-account listing through the facade (`build_handle/2` is pure; the reaper's listing now returns taxonomy errors, e.g. `{:provider, :sprites, :nxdomain}`, which Oban retries the same way).
- Blocking execs are on tagged-return `exec/4`: each site gains an explicit `{:error, reason}` branch where the SDK used to raise.

## Transitional scaffolding (deleted in the ConversationServer PR)

`ConversationServer` still holds the raw SDK sprite, so `Fountain.Sandbox.Sprites.from_sdk/1` wraps it at the boundary into the migrated modules, and `stub_happy_sprite` stubs the adapter layer alongside the SDK.

## Testing

`mix precommit` green (full suite). One reaper test assertion updated for the normalized listing error; everything else unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)