### PR TITLE
feat: ConversationServer, Conversations and the ACP peer speak Fountain.Sandbox

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1173,13 +1173,11 @@ defmodule Fountain.Conversations do
     case _unsafe_get_sandbox(sandbox_id) do
       %{status: status, sprite_name: name}
       when status in ["ready", "suspended"] and is_binary(name) ->
-        client = Fountain.SpritesClient.get!()
-
-        case Sprites.get_sprite(client, name) do
+        case Fountain.Sandbox.get(Fountain.Sandbox.build_handle(:sprites, name)) do
           {:ok, _info} ->
             {:reuse, sandbox_id}
 
-          {:error, {:not_found, _}} ->
+          {:error, :not_found} ->
             :create_new
 
           {:error, reason} when status == "suspended" ->

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -20,8 +20,6 @@ defmodule Fountain.Conversations.ConversationServer do
     Crypto,
     Environments,
     InferenceCredentials,
-    SpritesClient,
-    SpriteStdin,
     Substitution,
     Vaults
   }
@@ -241,7 +239,7 @@ defmodule Fountain.Conversations.ConversationServer do
       sandbox_id: Keyword.fetch!(args, :sandbox_id),
       runtime_module: Keyword.fetch!(args, :runtime_module),
       user_id: nil,
-      sprite: nil,
+      handle: nil,
       sprite_env: [],
       current_command: nil,
       current_command_ref: nil,
@@ -568,12 +566,8 @@ defmodule Fountain.Conversations.ConversationServer do
     {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
     publish_stage(state.conversation_id, "provision", "started")
 
-    case create_sprite(sandbox.sprite_name) do
-      {:ok, sprite} ->
-        # Transitional while this server still holds the SDK sprite: the
-        # already-migrated leaf modules (skills, runtime prepare/config)
-        # take a Fountain.Sandbox.Handle.
-        handle = Fountain.Sandbox.Sprites.from_sdk(sprite)
+    case create_sandbox_handle(sandbox.sprite_name) do
+      {:ok, handle} ->
         skills = (agent && agent.skills) || []
         # conv.runtime is validated-required and outlives the agent; the agent
         # fallback only covers rows predating the runtime column.
@@ -603,7 +597,7 @@ defmodule Fountain.Conversations.ConversationServer do
           # ceiling survives a restart and a reattach rather than resetting.
           new_state = %{
             state
-            | sprite: sprite,
+            | handle: handle,
               sprite_env: sprite_env,
               sandbox_started_at: sandbox_clock_start(sandbox)
           }
@@ -615,7 +609,7 @@ defmodule Fountain.Conversations.ConversationServer do
         else
           {:error, reason} ->
             Logger.error("provision step failed: #{inspect(reason)}")
-            _ = Sprites.destroy(sprite)
+            _ = Fountain.Sandbox.destroy(handle)
             {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
 
             publish_stage(state.conversation_id, "provision", "failed", %{
@@ -758,23 +752,19 @@ defmodule Fountain.Conversations.ConversationServer do
       sprite_name: sandbox.sprite_name
     })
 
-    client = SpritesClient.get!()
+    handle = Fountain.Sandbox.build_handle(:sprites, sandbox.sprite_name)
 
     case Fountain.Retry.with_backoff(
-           fn -> Sprites.get_sprite(client, sandbox.sprite_name) end,
+           fn -> Fountain.Sandbox.get(handle) end,
            label: "sprite lookup on wake"
          ) do
       {:ok, _info} ->
-        sprite = Sprites.sprite(client, sandbox.sprite_name)
         {state, _conv} = rotate_callback_api_key(state, conv)
         sprite_env = build_sprite_env(state, agent, env, secrets)
 
         # Refresh the .env file in case secrets/env_vars were edited
         # between the original provision and this reattach.
-        Fountain.Conversations.Provisioning.write_env_file(
-          Fountain.Sandbox.Sprites.from_sdk(sprite),
-          sprite_env
-        )
+        Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
 
         # Normally the wake path already flipped suspended → ready under the
         # quota reservation; this covers the reaper parking the row mid-wake.
@@ -795,7 +785,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
         new_state = %{
           state
-          | sprite: sprite,
+          | handle: handle,
             sprite_env: sprite_env,
             sandbox_started_at: sandbox_clock_start(sandbox)
         }
@@ -836,7 +826,7 @@ defmodule Fountain.Conversations.ConversationServer do
       publish_stage(state.conversation_id, "reattach", "done", %{outcome: "no_running_turn"})
       state
     else
-      case Fountain.Retry.with_backoff(fn -> Sprites.list_sessions(state.sprite) end,
+      case Fountain.Retry.with_backoff(fn -> Fountain.Sandbox.list_sessions(state.handle) end,
              label: "session list on reattach"
            ) do
         {:ok, sessions} ->
@@ -860,7 +850,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp attempt_session_attach(state, running_turn, [session | _]) do
-    case Sprites.attach_session(state.sprite, session.id, owner: self(), stdin: true) do
+    case Fountain.Sandbox.attach(state.handle, session.id, owner: self(), stdin: true) do
       {:ok, command} ->
         # sprites replays the session's buffered output before live-tailing.
         # Count the bytes we already persisted for this turn so the
@@ -1092,15 +1082,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # stays open on the ACP path.
     if state.acp_peer, do: Fountain.Runtimes.ACP.Peer.cancel(state.acp_peer)
 
-    cmd_pid = state.current_command.pid
-
-    if Process.alive?(cmd_pid) do
-      try do
-        GenServer.stop(cmd_pid, :normal, 1_000)
-      catch
-        :exit, _ -> :ok
-      end
-    end
+    Fountain.Sandbox.stop_command(state.current_command)
 
     {:ok, _turn} =
       Conversations._unsafe_update_turn(state.current_turn, %{
@@ -1143,7 +1125,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   def handle_call(:terminate_conv, _from, state) do
-    if state.sprite, do: _ = Sprites.destroy(state.sprite)
+    if state.handle, do: _ = Fountain.Sandbox.destroy(state.handle)
     sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
 
     {:ok, _} =
@@ -1376,7 +1358,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   # An error naming the CURRENT command is terminal for the turn (#413):
-  # Sprites.Command sends it when the WebSocket to the sprite drops mid-run,
+  # The adapter sends it when the transport to the sandbox drops mid-run,
   # then stops — and since the command process is neither linked nor
   # monitored, this message is the only signal there will ever be. Ignoring
   # it left current_command set forever: every prompt answered {:error,
@@ -1488,7 +1470,7 @@ defmodule Fountain.Conversations.ConversationServer do
   defp reclaim_sandbox(state, :idle) do
     Logger.info(
       "suspending sandbox for conv #{state.conversation_id}: idle " <>
-        "(sprite #{inspect(state.sprite && state.sprite.name)})"
+        "(sprite #{inspect(state.handle && state.handle.name)})"
     )
 
     if state.sandbox_id do
@@ -1513,7 +1495,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
     :telemetry.execute([:fountain, :sandbox, :suspended], %{count: 1}, %{})
 
-    {:stop, :normal, %{state | sprite: nil}}
+    {:stop, :normal, %{state | handle: nil}}
   end
 
   # Max lifetime: tear down the sprite and stop. This bound exists for the
@@ -1525,10 +1507,10 @@ defmodule Fountain.Conversations.ConversationServer do
   defp reclaim_sandbox(state, :max_lifetime = reason) do
     Logger.info(
       "reclaiming sandbox for conv #{state.conversation_id}: #{reason} " <>
-        "(sprite #{inspect(state.sprite && state.sprite.name)})"
+        "(sprite #{inspect(state.handle && state.handle.name)})"
     )
 
-    if state.sprite, do: _ = Sprites.destroy(state.sprite)
+    if state.handle, do: _ = Fountain.Sandbox.destroy(state.handle)
 
     if state.sandbox_id do
       sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
@@ -1555,7 +1537,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
     :telemetry.execute([:fountain, :sandbox, :reclaimed], %{count: 1}, %{reason: reason})
 
-    {:stop, :normal, %{state | sprite: nil}}
+    {:stop, :normal, %{state | handle: nil}}
   end
 
   # Best-effort revoke of the per-conversation API key when this server
@@ -1617,16 +1599,13 @@ defmodule Fountain.Conversations.ConversationServer do
   defp redact_state(state) do
     %{
       state
-      | sprite: redact_sprite(state.sprite),
+      | handle: state.handle && %{state.handle | private: nil},
         sprite_env: Enum.map(state.sprite_env, fn {k, _v} -> {k, "[REDACTED]"} end),
         tenant_key: redact(state.tenant_key),
         inference_credentials: redact_map(state.inference_credentials),
         callback_token: redact(state.callback_token)
     }
   end
-
-  defp redact_sprite(%{client: _} = sprite), do: Map.put(sprite, :client, "[REDACTED]")
-  defp redact_sprite(other), do: other
 
   defp redact_map(%{} = map), do: Map.new(map, fn {k, _v} -> {k, "[REDACTED]"} end)
   defp redact_map(other), do: redact(other)
@@ -1636,19 +1615,11 @@ defmodule Fountain.Conversations.ConversationServer do
 
   # ── helpers ───────────────────────────────────────────────────────────────
 
-  defp create_sprite(name) do
-    client = SpritesClient.get!()
-
+  # Provider hardcoded until the sandboxes row carries one; adopt-on-409 is
+  # the adapter's job now.
+  defp create_sandbox_handle(name) do
     Fountain.Retry.with_backoff(
-      fn ->
-        case Sprites.create(client, name) do
-          # A 409 means a sprite with this name already exists. Names are
-          # unique per sandbox row, so the only way that happens is an earlier
-          # attempt that created it but lost the response — adopt it.
-          {:error, {:api_error, 409, _body}} -> {:ok, Sprites.sprite(client, name)}
-          other -> other
-        end
-      end,
+      fn -> Fountain.Sandbox.create(:sprites, name) end,
       label: "sprite create #{name}"
     )
   end
@@ -1817,7 +1788,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # Write image temp files to sprite. Only on the legacy path: ACP carries
     # images as content blocks inside `session/prompt`, so writing them into
     # the sandbox first would be a round trip whose product nothing reads.
-    image_paths = if acp?, do: [], else: write_image_temp_files(state.sprite, turn.id, images)
+    image_paths = if acp?, do: [], else: write_image_temp_files(state.handle, turn.id, images)
 
     {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
 
@@ -1857,7 +1828,7 @@ defmodule Fountain.Conversations.ConversationServer do
       end
 
     # If a runtime embeds the prompt in argv (codex), it returns
-    # `stdin?: false` and we skip the Sprites.write/close_stdin pipeline.
+    # `stdin?: false` and we skip the write_stdin/close_stdin pipeline.
     # claude / gemini / opencode default to true and read from stdin.
     use_stdin? = Keyword.get(build_opts, :stdin?, true)
 
@@ -1923,12 +1894,11 @@ defmodule Fountain.Conversations.ConversationServer do
         ]
         |> then(&if cwd, do: Keyword.put(&1, :dir, cwd), else: &1)
 
-      case Sprites.spawn(state.sprite, cmd, args, spawn_opts) do
+      case Fountain.Sandbox.spawn(state.handle, cmd, args, spawn_opts) do
         {:ok, command} ->
-          # SpriteStdin.write/2 rather than Sprites.write/2: the latter exits
-          # its caller when the runtime has already gone, and this process
-          # being mid-turn is exactly what turned that into an orphaned turn
-          # (#603). See `Fountain.SpriteStdin` for the whole chain.
+          # write_stdin/2 is total by contract — a runtime that exits before
+          # reading its prompt yields {:error, :command_exited} rather than
+          # taking this server down (#603).
           # On the ACP path stdin stays **open**: it is the return path for
           # `session/request_permission` answers and `session/cancel`, and the
           # peer writes the prompt itself as `session/prompt`. Closing it here
@@ -2084,7 +2054,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # Collect what a command said before it stopped: `{exit_code, output}`,
   # with a nil code if no exit arrives.
   #
-  # `Sprites.Command` sends the owner `{:exit, %{ref: ref}, code}` — behind
+  # The adapter sends the owner `{:exit, %{ref: ref}, code}` — behind
   # any `{:stdout, …}` / `{:stderr, …}` the runtime produced first — and only
   # *then* stops. So when a stdin write comes back `{:error, :command_exited}`
   # it is because that already happened, and those messages are in this
@@ -2223,8 +2193,8 @@ defmodule Fountain.Conversations.ConversationServer do
   # The legacy stdin dance, unchanged and lifted out so the ACP branch above
   # reads as one condition rather than a nested `if`.
   defp write_prompt_and_close(command, payload) do
-    case SpriteStdin.write(command, payload) do
-      :ok -> Sprites.close_stdin(command)
+    case Fountain.Sandbox.write_stdin(command, payload) do
+      :ok -> Fountain.Sandbox.close_stdin(command)
       {:error, reason} -> {:error, reason}
     end
   end
@@ -2258,7 +2228,7 @@ defmodule Fountain.Conversations.ConversationServer do
   defp finalize_tracer(tracer), do: Fountain.Runtimes.ACP.Tracer.finalize(tracer)
 
   defp finish_acp_turn(state, status, span_attrs, stage_meta) do
-    if state.current_command, do: Sprites.close_stdin(state.current_command)
+    if state.current_command, do: Fountain.Sandbox.close_stdin(state.current_command)
     stop_acp_peer(state)
 
     # Before the turn span ends: totals land on it, abandoned tool spans close.
@@ -2431,17 +2401,15 @@ defmodule Fountain.Conversations.ConversationServer do
 
   # Write each image to a temp path in the sprite filesystem and return
   # a list of {path, media_type} tuples for passing to the runtime.
-  defp write_image_temp_files(_sprite, _turn_id, []), do: []
+  defp write_image_temp_files(_handle, _turn_id, []), do: []
 
-  defp write_image_temp_files(sprite, turn_id, images) do
-    fs = Sprites.filesystem(sprite, "/")
-
+  defp write_image_temp_files(handle, turn_id, images) do
     images
     |> Enum.with_index()
     |> Enum.map(fn {%{media_type: mt, data: data}, idx} ->
       ext = media_type_to_ext(mt)
       path = "/tmp/aod_turn_#{turn_id}_#{idx}.#{ext}"
-      Sprites.Filesystem.write(fs, path, data)
+      Fountain.Sandbox.write_file(handle, path, data)
       {path, mt}
     end)
   end

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -66,7 +66,6 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   alias Fountain.Runtimes.ACP
   alias Fountain.Runtimes.ACP.Protocol
-  alias Fountain.SpriteStdin
 
   # How long the replay has to stay quiet before we believe it is over, and how
   # long we will wait for that in total. See `handle_response(:load_session, …)`.
@@ -579,14 +578,14 @@ defmodule Fountain.Runtimes.ACP.Peer do
     {tag, %{state | pending: pending}}
   end
 
-  # Every write goes through `SpriteStdin` rather than `Sprites.write/2`,
-  # because the latter exits its caller when the runtime has already gone —
-  # #603, and being mid-turn is exactly the condition that made it an orphaned
-  # turn rather than an error.
+  # `Fountain.Sandbox.write_stdin/2` is total by contract: a runtime that has
+  # already gone yields {:error, :command_exited} rather than exiting this
+  # process — #603, and being mid-turn is exactly the condition that made
+  # that an orphaned turn rather than an error.
   defp write(%State{phase: :failed} = state, _iodata), do: state
 
   defp write(state, iodata) do
-    case SpriteStdin.write(state.command, iodata) do
+    case Fountain.Sandbox.write_stdin(state.command, iodata) do
       :ok -> state
       {:error, reason} -> fail(state, {:acp_write_failed, reason})
     end

--- a/apps/fountain/lib/fountain/sandbox.ex
+++ b/apps/fountain/lib/fountain/sandbox.ex
@@ -168,6 +168,14 @@ defmodule Fountain.Sandbox do
   @doc "Send stdin EOF."
   @callback close_stdin(Command.t()) :: :ok | {:error, error()}
 
+  @doc """
+  Stop the local command handle, terminating its transport. Total — an
+  already-stopped command is `:ok`. For a detachable command the remote
+  process keeps running (that is what reattach exists for); this only tears
+  down this node's end.
+  """
+  @callback stop_command(Command.t()) :: :ok
+
   @doc "List the sandbox's detachable sessions."
   @callback list_sessions(Handle.t()) :: {:ok, [Session.t()]} | {:error, error()}
 
@@ -289,6 +297,12 @@ defmodule Fountain.Sandbox do
   @spec close_stdin(Command.t()) :: :ok | {:error, error()}
   def close_stdin(%Command{} = command) do
     adapter_for(command.provider).close_stdin(command)
+  end
+
+  @doc "Stop the local command handle. Total."
+  @spec stop_command(Command.t()) :: :ok
+  def stop_command(%Command{} = command) do
+    adapter_for(command.provider).stop_command(command)
   end
 
   @doc "List a sandbox's detachable sessions."

--- a/apps/fountain/lib/fountain/sandbox/sprites.ex
+++ b/apps/fountain/lib/fountain/sandbox/sprites.ex
@@ -211,6 +211,16 @@ defmodule Fountain.Sandbox.Sprites do
     Sprites.close_stdin(sdk_command(command))
   end
 
+  @impl true
+  def stop_command(%Command{provider: :sprites, private: %Sprites.Command{pid: pid}}) do
+    GenServer.stop(pid, :normal, 1_000)
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  def stop_command(%Command{provider: :sprites}), do: :ok
+
   # ── sessions ───────────────────────────────────────────────────────────────
 
   @impl true

--- a/apps/fountain/test/fountain/accounts/deletion_test.exs
+++ b/apps/fountain/test/fountain/accounts/deletion_test.exs
@@ -20,9 +20,7 @@ defmodule Fountain.Accounts.DeletionTest do
   setup :set_mimic_global
 
   setup do
-    stub(Fountain.SpritesClient, :get!, fn -> :client end)
-    stub(Sprites, :sprite, fn :client, name -> {:handle, name} end)
-    stub(Sprites, :destroy, fn _handle -> :ok end)
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _handle -> :ok end)
     stub(Fountain.Conversations.ConversationServer, :whereis, fn _ -> nil end)
     :ok
   end
@@ -118,7 +116,10 @@ defmodule Fountain.Accounts.DeletionTest do
       sandbox = insert_sandbox(user_id: user.id, status: "ready")
 
       test = self()
-      stub(Sprites, :destroy, fn {:handle, name} -> send(test, {:destroyed, name}) && :ok end)
+
+      stub(Fountain.Sandbox.Sprites, :destroy, fn handle ->
+        send(test, {:destroyed, handle.name}) && :ok
+      end)
 
       capture_log(fn -> assert {:ok, %{sprites_destroyed: 1}} = Deletion.delete_user(user) end)
 
@@ -134,7 +135,10 @@ defmodule Fountain.Accounts.DeletionTest do
       sandbox = insert_sandbox(user_id: user.id, status: "suspended")
 
       test = self()
-      stub(Sprites, :destroy, fn {:handle, name} -> send(test, {:destroyed, name}) && :ok end)
+
+      stub(Fountain.Sandbox.Sprites, :destroy, fn handle ->
+        send(test, {:destroyed, handle.name}) && :ok
+      end)
 
       capture_log(fn -> assert {:ok, %{sprites_destroyed: 1}} = Deletion.delete_user(user) end)
 
@@ -145,7 +149,7 @@ defmodule Fountain.Accounts.DeletionTest do
     test "already-terminal sandboxes are not touched again" do
       user = insert_verified_user()
       insert_sandbox(user_id: user.id, status: "terminated")
-      reject(&Sprites.destroy/1)
+      reject(&Fountain.Sandbox.Sprites.destroy/1)
 
       capture_log(fn -> assert {:ok, %{sprites_destroyed: 0}} = Deletion.delete_user(user) end)
     end
@@ -156,7 +160,7 @@ defmodule Fountain.Accounts.DeletionTest do
       # leave the person unable to leave.
       user = insert_verified_user()
       insert_sandbox(user_id: user.id, status: "ready")
-      stub(Sprites, :destroy, fn _ -> {:error, :boom} end)
+      stub(Fountain.Sandbox.Sprites, :destroy, fn _ -> {:error, :boom} end)
 
       capture_log(fn -> assert {:ok, _} = Deletion.delete_user(user) end)
 
@@ -166,7 +170,7 @@ defmodule Fountain.Accounts.DeletionTest do
     test "the sandbox row is marked terminated so the reaper can finish the job" do
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id, status: "ready")
-      stub(Sprites, :destroy, fn _ -> {:error, :boom} end)
+      stub(Fountain.Sandbox.Sprites, :destroy, fn _ -> {:error, :boom} end)
 
       capture_log(fn -> assert {:ok, _} = Deletion.delete_user(user) end)
 
@@ -201,7 +205,7 @@ defmodule Fountain.Accounts.DeletionTest do
       # cancel from. So this is the one failure that stops everything.
       user = billing_user(%{stripe_customer_id: "cus_123", subscription_status: "active"})
       sandbox = insert_sandbox(user_id: user.id, status: "ready")
-      reject(&Sprites.destroy/1)
+      reject(&Fountain.Sandbox.Sprites.destroy/1)
 
       stub(Stripe.Subscription, :list, fn _ -> {:error, :stripe_down} end)
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -24,22 +24,17 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
     test = self()
     ref = make_ref()
 
-    # The adapter install runs at provision time. It is `Sprites.cmd/4`
-    # returning `{output, exit_code}` — a different arity from the `cmd/3` the
-    # permissive harness stubs, so without this the real client is called.
-    Mimic.stub(Sprites, :cmd, fn _s, _cmd, _args, _opts -> {"", 0} end)
-
-    Mimic.stub(Sprites, :spawn, fn _s, cmd, args, opts ->
+    Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, cmd, args, opts ->
       send(test, {:spawned, cmd, args, opts})
-      {:ok, %{ref: ref, pid: test}}
+      {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
     end)
 
-    Mimic.stub(Sprites, :close_stdin, fn _c ->
+    Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _c ->
       send(test, :stdin_closed)
       :ok
     end)
 
-    Mimic.stub(Sprites, :write, fn _c, data ->
+    Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _c, data ->
       send(test, {:wrote, IO.iodata_to_binary(data)})
       :ok
     end)
@@ -361,17 +356,19 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       test = self()
       ref = make_ref()
 
-      Mimic.stub(Sprites, :cmd, fn _s, _c, _a, _o -> {"", 0} end)
-      Mimic.stub(Sprites, :spawn, fn _s, _c, _a, _o -> {:ok, %{ref: ref, pid: test}} end)
-      Mimic.stub(Sprites, :close_stdin, fn _c -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _c, _a, _o ->
+        {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
+      end)
 
-      Mimic.stub(Sprites, :write, fn _c, data ->
+      Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _c -> :ok end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _c, data ->
         send(test, {:wrote, IO.iodata_to_binary(data)})
         :ok
       end)
 
       # Nothing should be written into the sandbox filesystem for an ACP turn.
-      Mimic.stub(Sprites.Filesystem, :write, fn _fs, path, _contents ->
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_file, fn _h, path, _contents, _opts ->
         send(test, {:fs_write, path})
         :ok
       end)

--- a/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
@@ -28,10 +28,9 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
   # reattach path rather than a fresh provision. The shared harness only covers
   # provisioning, so the two reattach-specific calls are stubbed here.
   defp stub_reattach do
-    sprite = stub_happy_sprite()
-    stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{}} end)
-    stub(Sprites, :sprite, fn _client, _name -> sprite end)
-    sprite
+    # stub_happy_sprite/0 already stubs the adapter's get/1 probe, which is
+    # all the reattach path needs beyond the shared harness.
+    stub_happy_sprite()
   end
 
   defp aged_conversation(minutes) do
@@ -59,7 +58,7 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
 
       # The whole point of decisions/0017: the sprite's disk holds the agent's
       # memory, and the idle bound must not destroy it.
-      reject(&Sprites.destroy/1)
+      reject(&Fountain.Sandbox.Sprites.destroy/1)
 
       with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
         {pid, ref, :alive} = start_server(conv)
@@ -168,7 +167,7 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
       stub_reattach()
 
       test = self()
-      stub(Sprites, :destroy, fn _sprite -> send(test, :destroyed) && :ok end)
+      stub(Fountain.Sandbox.Sprites, :destroy, fn _handle -> send(test, :destroyed) && :ok end)
 
       with_bounds([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 24], fn ->
         {pid, ref, :alive} = start_server(conv)
@@ -204,7 +203,7 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
       # last_resumed_at when the sandbox has been through a suspend/wake.
       {conv, sandbox} = aged_conversation(60 * 48)
       stub_reattach()
-      reject(&Sprites.destroy/1)
+      reject(&Fountain.Sandbox.Sprites.destroy/1)
 
       resumed_at = DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.truncate(:second)
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_log_budget_test.exs
@@ -14,12 +14,12 @@ defmodule Fountain.Conversations.ConversationServerLogBudgetTest do
   defp start_with_turn(conv) do
     cmd_ref = make_ref()
 
-    Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
-      {:ok, %{ref: cmd_ref, pid: self()}}
+    Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+      {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: cmd_ref}}
     end)
 
-    Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
-    Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _cmd, _data -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _cmd -> :ok end)
 
     {pid, mon, :alive} = start_server(conv, initial_prompt: "go")
     _ = :sys.get_state(pid)
@@ -82,10 +82,8 @@ defmodule Fountain.Conversations.ConversationServerLogBudgetTest do
     # server has persisted nothing itself; only a seed read from the DB can
     # make a 20-byte chunk cross the 100-byte budget. A seed of zero (the
     # per-BEAM-lifetime bug this pins against) would let it straight through.
-    Mimic.stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{}} end)
-
-    Mimic.stub(Sprites, :sprite, fn _client, _name ->
-      %{name: "test-sprite", id: "sprite_test-sprite"}
+    Mimic.stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+      {:ok, %{status: :running, raw: %{}}}
     end)
 
     {pid2, cmd_ref2, _ref2} = start_with_turn(conv)

--- a/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_provision_deadline_test.exs
@@ -100,13 +100,13 @@ defmodule Fountain.Conversations.ConversationServerProvisionDeadlineTest do
   end
 
   test "a server restarted after the deadline provisions no second sprite (#394)" do
-    sprite = stub_happy_sprite()
+    handle = stub_happy_sprite()
     test_pid = self()
 
     # Count every sprite creation across all processes (global mode).
-    Mimic.stub(Sprites, :create, fn _client, _name ->
+    Mimic.stub(Fountain.Sandbox.Sprites, :create, fn _name, _opts ->
       send(test_pid, :sprite_created)
-      {:ok, sprite}
+      {:ok, handle}
     end)
 
     Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->

--- a/apps/fountain/test/fountain/conversations/conversation_server_redaction_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_redaction_test.exs
@@ -35,9 +35,13 @@ defmodule Fountain.Conversations.ConversationServerRedactionTest do
     :sys.replace_state(pid, fn state ->
       %{
         state
-        | sprite: %Sprites.Sprite{
+        | handle: %Fountain.Sandbox.Handle{
+            provider: :sprites,
             name: "test-sprite",
-            client: %Sprites.Client{token: @sprites_token}
+            private: %Sprites.Sprite{
+              name: "test-sprite",
+              client: %Sprites.Client{token: @sprites_token}
+            }
           },
           sprite_env: [{"MY_SECRET", @secret_env_value}, {"OTHER", "other-value-315"}],
           tenant_key: @dek_value,

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -80,12 +80,12 @@ defmodule Fountain.Conversations.ConversationServerTest do
       stub_happy_sprite()
       # The server reads command.ref, so the spawn result must be a command struct
       # rather than a bare pid.
-      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
-        {:ok, %{ref: make_ref(), pid: self()}}
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: make_ref()}}
       end)
 
-      Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
-      Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _cmd, _data -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _cmd -> :ok end)
 
       {pid, _ref, :alive} = start_server(conv, initial_prompt: "hello there")
 
@@ -115,12 +115,12 @@ defmodule Fountain.Conversations.ConversationServerTest do
       # so the registry genuinely cannot resolve them.
       stub_happy_sprite()
 
-      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
-        {:ok, %{ref: make_ref(), pid: self()}}
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: make_ref()}}
       end)
 
-      Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
-      Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _cmd, _data -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _cmd -> :ok end)
 
       {pid, _ref, :alive} = start_server(conv, initial_prompt: "first prompt")
 
@@ -257,7 +257,11 @@ defmodule Fountain.Conversations.ConversationServerTest do
 
     test "a failed provision lands in the scrape as provision/failed", %{conv: conv} do
       stub_happy_sprite()
-      Mimic.stub(Sprites, :create, fn _client, _name -> {:error, :quota_exceeded} end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :create, fn _name, _opts ->
+        {:error, :quota_exceeded}
+      end)
+
       before_body = scrape_body()
 
       {_pid, ref, _} = start_server(conv)
@@ -276,12 +280,12 @@ defmodule Fountain.Conversations.ConversationServerTest do
       stub_happy_sprite()
       cmd_ref = make_ref()
 
-      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
-        {:ok, %{ref: cmd_ref, pid: self()}}
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: cmd_ref}}
       end)
 
-      Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
-      Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _cmd, _data -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _cmd -> :ok end)
 
       before_body = scrape_body()
 
@@ -300,7 +304,10 @@ defmodule Fountain.Conversations.ConversationServerTest do
   describe "provisioning — failure paths" do
     test "a sprite that cannot be created marks both rows failed", %{conv: conv, sandbox: sandbox} do
       stub_happy_sprite()
-      Mimic.stub(Sprites, :create, fn _client, _name -> {:error, :quota_exceeded} end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :create, fn _name, _opts ->
+        {:error, :quota_exceeded}
+      end)
 
       {_pid, ref, _} = start_server(conv)
       assert_stopped(ref)
@@ -317,8 +324,8 @@ defmodule Fountain.Conversations.ConversationServerTest do
         {:error, :apt_failed}
       end)
 
-      Mimic.stub(Sprites, :destroy, fn sprite ->
-        send(test_pid, {:destroyed, sprite.name})
+      Mimic.stub(Fountain.Sandbox.Sprites, :destroy, fn handle ->
+        send(test_pid, {:destroyed, handle.name})
         :ok
       end)
 
@@ -380,12 +387,12 @@ defmodule Fountain.Conversations.ConversationServerTest do
       stub_happy_sprite()
       ref = make_ref()
 
-      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
-        {:ok, %{ref: ref, pid: self()}}
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
       end)
 
-      Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
-      Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _cmd, _data -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _cmd -> :ok end)
 
       {pid, _mon, :alive} = start_server(conv, initial_prompt: "first")
       {pid, ref}
@@ -473,7 +480,10 @@ defmodule Fountain.Conversations.ConversationServerTest do
       # Before this reset, a failed spawn marked the turn failed but left the
       # conversation reporting "running" in the API and UI indefinitely.
       stub_happy_sprite()
-      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts -> {:error, :econnrefused} end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        {:error, :econnrefused}
+      end)
 
       {pid, _ref, :alive} = start_server(conv, initial_prompt: "hello")
       _ = :sys.get_state(pid)
@@ -486,11 +496,11 @@ defmodule Fountain.Conversations.ConversationServerTest do
     end
 
     test "a runtime that exits before the prompt is written fails the turn (#603)", %{conv: conv} do
-      # The real Sprites.write/2 against a real command process that stops
+      # The real adapter write path against a real command process that stops
       # :normal on the write, which is what Sprites.Command does the moment the
       # runtime's exit frame arrives. Nothing about this path is stubbed.
       #
-      # The GenServer.call inside Sprites.write used to exit THIS server, and
+      # The GenServer.call inside the SDK write used to exit THIS server, and
       # the supervisor's restart then found the sandbox already "ready", took
       # the reattach branch, and orphaned the turn behind a list_sessions error
       # that named nothing real. Against spritzer's one-shot exec that lost
@@ -498,8 +508,15 @@ defmodule Fountain.Conversations.ConversationServerTest do
       stub_happy_sprite()
       dead_on_write = spawn(fn -> receive(do: (_ -> exit(:normal))) end)
 
-      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
-        {:ok, %Sprites.Command{ref: make_ref(), pid: dead_on_write, tty_mode: false}}
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        ref = make_ref()
+
+        {:ok,
+         %Fountain.Sandbox.Command{
+           provider: :sprites,
+           ref: ref,
+           private: %Sprites.Command{ref: ref, pid: dead_on_write, tty_mode: false}
+         }}
       end)
 
       # :alive is the regression: the prompt is delivered before this returns.
@@ -542,8 +559,13 @@ defmodule Fountain.Conversations.ConversationServerTest do
           end
         end)
 
-      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
-        {:ok, %Sprites.Command{ref: ref, pid: exits_1_on_write, tty_mode: false}}
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        {:ok,
+         %Fountain.Sandbox.Command{
+           provider: :sprites,
+           ref: ref,
+           private: %Sprites.Command{ref: ref, pid: exits_1_on_write, tty_mode: false}
+         }}
       end)
 
       {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")

--- a/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
@@ -57,12 +57,12 @@ defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
     stub_happy_sprite()
     ref = make_ref()
 
-    Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts ->
-      {:ok, %{ref: ref, pid: self()}}
+    Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+      {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
     end)
 
-    Mimic.stub(Sprites, :write, fn _cmd, _data -> :ok end)
-    Mimic.stub(Sprites, :close_stdin, fn _cmd -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _cmd, _data -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _cmd -> :ok end)
 
     {pid, _mon, :alive} = start_server(conv, initial_prompt: "first")
     {pid, ref}
@@ -137,7 +137,10 @@ defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
       # duration" dragging the histogram's low end down.
       capture_turn_completed()
       stub_happy_sprite()
-      Mimic.stub(Sprites, :spawn, fn _s, _cmd, _args, _opts -> {:error, :econnrefused} end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        {:error, :econnrefused}
+      end)
 
       {pid, _ref, :alive} = start_server(conv, initial_prompt: "hello")
       _ = :sys.get_state(pid)

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1183,8 +1183,9 @@ defmodule Fountain.ConversationsContextTest do
 
       fake_client = %{}
 
-      stub(Fountain.SpritesClient, :get!, fn -> fake_client end)
-      stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{name: "test-sprite-alive"}} end)
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+        {:ok, %{status: :running, raw: %{name: "test-sprite-alive"}}}
+      end)
 
       stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
         {:ok, spawn(fn -> :ok end)}
@@ -1202,8 +1203,9 @@ defmodule Fountain.ConversationsContextTest do
       {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
       conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
 
-      stub(Fountain.SpritesClient, :get!, fn -> %{} end)
-      stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{name: "test-sprite-parked"}} end)
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+        {:ok, %{status: :suspended, raw: %{name: "test-sprite-parked"}}}
+      end)
 
       stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
         {:ok, spawn(fn -> :ok end)}
@@ -1231,8 +1233,7 @@ defmodule Fountain.ConversationsContextTest do
       {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
       conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
 
-      stub(Fountain.SpritesClient, :get!, fn -> %{} end)
-      stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{}} end)
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle -> {:ok, %{status: :unknown, raw: %{}}} end)
 
       assert {:error, {:sandbox_quota_exceeded, _}} = Conversations.wake_conversation(conv.id)
       # Refused means still parked — the row must not be half-woken.
@@ -1249,8 +1250,7 @@ defmodule Fountain.ConversationsContextTest do
       {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
       conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
 
-      stub(Fountain.SpritesClient, :get!, fn -> %{} end)
-      stub(Sprites, :get_sprite, fn _client, _name -> {:error, :timeout} end)
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle -> {:error, {:unavailable, :timeout}} end)
 
       assert {:error, :sprite_probe_failed} = Conversations.wake_conversation(conv.id)
       assert Repo.reload(sandbox).status == "suspended"
@@ -1263,8 +1263,7 @@ defmodule Fountain.ConversationsContextTest do
       {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
       conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
 
-      stub(Fountain.SpritesClient, :get!, fn -> %{} end)
-      stub(Sprites, :get_sprite, fn _client, _name -> {:error, {:not_found, %{}}} end)
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle -> {:error, :not_found} end)
 
       stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
         {:ok, spawn(fn -> :ok end)}
@@ -1284,8 +1283,7 @@ defmodule Fountain.ConversationsContextTest do
 
       fake_client = %{}
 
-      stub(Fountain.SpritesClient, :get!, fn -> fake_client end)
-      stub(Sprites, :get_sprite, fn _client, _name -> {:error, :not_found} end)
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle -> {:error, :not_found} end)
 
       stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
         {:ok, spawn(fn -> :ok end)}

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -17,12 +17,12 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
   setup do
     test = self()
 
-    Mimic.stub(Sprites, :write, fn _command, data ->
+    Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _command, data ->
       send(test, {:wrote, IO.iodata_to_binary(data)})
       :ok
     end)
 
-    {:ok, ref: make_ref(), command: %{ref: :fake, pid: self()}}
+    {:ok, ref: make_ref(), command: %Fountain.Sandbox.Command{provider: :sprites, ref: :fake}}
   end
 
   defp start_peer(ctx, opts) do
@@ -344,14 +344,14 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
     end
 
     test "a stdin write failure fails the turn rather than exiting the peer", ctx do
-      # #603: Sprites.write is a bare GenServer.call underneath, and the command
-      # process stops :normal the moment the runtime's exit frame arrives — so a
-      # write landing after that exits the *caller* with the call wrapped
-      # alongside the reason. SpriteStdin turns that into an error; the peer
-      # must report it, because a peer that dies silently leaves a turn with no
-      # terminator at all.
-      Mimic.stub(Sprites, :write, fn _c, _d ->
-        exit({:normal, {GenServer, :call, [self(), :write, 5_000]}})
+      # #603: the SDK write is a bare GenServer.call underneath, and the command
+      # process stops :normal the moment the runtime's exit frame arrives. The
+      # adapter's write_stdin/2 turns that into {:error, :command_exited}; the
+      # peer must report it, because a peer that dies silently leaves a turn
+      # with no terminator at all. (The exit-to-error catch itself is pinned in
+      # the adapter's own tests.)
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _c, _d ->
+        {:error, :command_exited}
       end)
 
       start_peer(ctx, [])

--- a/apps/fountain/test/fountain/sandbox/sprites_test.exs
+++ b/apps/fountain/test/fountain/sandbox/sprites_test.exs
@@ -239,6 +239,25 @@ defmodule Fountain.Sandbox.SpritesTest do
       assert :ok = Adapter.write_stdin(command, "data")
     end
 
+    test "stop_command stops a live command process and tolerates a dead one" do
+      {:ok, agent} = Agent.start(fn -> :ok end)
+
+      live = %Command{
+        provider: :sprites,
+        ref: make_ref(),
+        private: %Sprites.Command{ref: make_ref(), pid: agent}
+      }
+
+      assert :ok = Adapter.stop_command(live)
+      refute Process.alive?(agent)
+
+      # Already stopped — total, no exit.
+      assert :ok = Adapter.stop_command(live)
+
+      # No private state at all (a handle that never carried the SDK struct).
+      assert :ok = Adapter.stop_command(%Command{provider: :sprites, ref: make_ref()})
+    end
+
     test "close_stdin on a dead command process is still :ok" do
       dead = spawn(fn -> :ok end)
       ref = Process.monitor(dead)

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -44,35 +44,38 @@ defmodule Fountain.ConversationServerCase do
   @doc """
   Stub every external boundary a provision touches, on the happy path.
 
-  Returns the sprite the stubbed `Sprites.create/2` will hand back.
+  The whole sandbox seam is the `Fountain.Sandbox.Sprites` adapter — the
+  server never names the SDK anymore. Returns the handle the stubbed
+  `create/2` will hand back.
   """
   def stub_happy_sprite(name \\ "test-sprite") do
-    sprite = %{name: name, id: "sprite_" <> name}
+    handle = Fountain.Sandbox.Sprites.build_handle(name)
 
-    Mimic.stub(Fountain.SpritesClient, :get!, fn -> %{token: "test"} end)
-    Mimic.stub(Sprites, :create, fn _client, _name -> {:ok, sprite} end)
-    Mimic.stub(Sprites, :destroy, fn _sprite -> :ok end)
-    Mimic.stub(Sprites, :cmd, fn _sprite, _cmd, _opts -> {:ok, %{exit_code: 0, stdout: ""}} end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :create, fn _name, _opts -> {:ok, handle} end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :destroy, fn _handle -> :ok end)
 
-    # The 4-arity variant returns {output, exit_code} and is what the
-    # not-yet-migrated call sites' scripts call; without this stub those
-    # reach the real client.
-    Mimic.stub(Sprites, :cmd, fn _sprite, _cmd, _args, _opts -> {"", 0} end)
-    Mimic.stub(Sprites, :list_sessions, fn _sprite -> {:ok, []} end)
-    Mimic.stub(Sprites, :update_network_policy, fn _sprite, _policy -> :ok end)
-    Mimic.stub(Sprites.Filesystem, :write, fn _sprite, _path, _contents -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+      {:ok, %{status: :running, raw: %{}}}
+    end)
 
-    # Modules already migrated onto the Fountain.Sandbox facade (ACP adapter
-    # install, runtime prepare/config) go through the Sprites adapter rather
-    # than the SDK; stub that layer too until the migration completes and the
-    # SDK stubs above can go entirely.
     Mimic.stub(Fountain.Sandbox.Sprites, :exec, fn _handle, _cmd, _args, _opts ->
       {:ok, "", 0}
     end)
 
     Mimic.stub(Fountain.Sandbox.Sprites, :write_file, fn _handle, _path, _data, _opts -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :list_sessions, fn _handle -> {:ok, []} end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :apply_network_policy, fn _handle, _policy -> :ok end)
 
-    Mimic.stub(Fountain.SpriteSkills, :mount, fn _sprite, _runtime, _skills -> :ok end)
+    # A turn's spawn fails cleanly unless the test stubs it — mirroring the
+    # pre-facade behavior where spawning against the fake sprite errored and
+    # the turn was marked failed. Tests exercising turns re-stub spawn (and
+    # write_stdin/close_stdin where their turn writes; the #603 tests rely on
+    # the adapter's REAL write path, so those stay unstubbed here).
+    Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _handle, _cmd, _args, _opts ->
+      {:error, {:unavailable, :spawn_not_stubbed}}
+    end)
+
+    Mimic.stub(Fountain.SpriteSkills, :mount, fn _handle, _runtime, _skills -> :ok end)
 
     Mimic.stub(Fountain.Conversations.Provisioning, :write_env_file, fn _s, _e -> :ok end)
 
@@ -101,7 +104,7 @@ defmodule Fountain.ConversationServerCase do
     Mimic.stub(Fountain.Crypto, :load_tenant_key, fn _user_id -> {:ok, <<0::256>>} end)
     Mimic.stub(Fountain.InferenceCredentials, :decrypted_for_user, fn _u, _k -> {:ok, %{}} end)
 
-    sprite
+    handle
   end
 
   @doc """

--- a/ee/test/fountain/billing_gate_test.exs
+++ b/ee/test/fountain/billing_gate_test.exs
@@ -119,8 +119,9 @@ defmodule Fountain.BillingGateTest do
     end
 
     defp stub_sprite_alive do
-      stub(Fountain.SpritesClient, :get!, fn -> :fake_client end)
-      stub(Sprites, :get_sprite, fn _client, _name -> {:ok, %{name: "alive"}} end)
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+        {:ok, %{status: :running, raw: %{name: "alive"}}}
+      end)
     end
 
     test "is refused for a canceled subscription without starting a server" do


### PR DESCRIPTION
## What

Fourth step of the pluggable-sandbox-backend campaign (#676 behaviour, #677 leaf sites, #678 provisioning). The last production call sites leave the SDK:

- `ConversationServer` state holds a provider-tagged `Handle` (`state.sprite` → `state.handle`). Create goes through the facade (adopt-on-409 is the adapter's job now); the wake probe and reattach rebuild the handle from the row; `list_sessions`/`attach` return normalized structs; spawn/stdin/turn-teardown dispatch through the facade; image temp files use `write_file`.
- The suspended-sandbox wake probe in `Conversations` matches the taxonomy's `{:error, :not_found}` — the parked-disk protection now keys on a provider-neutral term.
- The ACP peer writes through `Fountain.Sandbox.write_stdin/2` (total by contract).
- **New contract operation:** the interrupt path was reaching into the SDK command's pid to stop the transport — provider mechanics. The behaviour gains `stop_command/1` (total; a detachable command's remote side keeps running) and the server calls that.
- `format_status` redaction simplifies: `Handle` derives `Inspect` without `private`, so the scrub drops it instead of knowing SDK client internals.

## Tests

`stub_happy_sprite` now stubs the **adapter**, not the SDK — one rewrite in the shared harness plus a mechanical stub-target sweep across the server/context/deletion/peer/billing-gate test files. The #603/#608 regressions still drive the adapter's real write path against a genuinely dead command process. After this PR the Sprites SDK appears only under `lib/fountain/sandbox/sprites*` plus the two legacy shims (`SpritesClient`, `SpriteStdin`) that the next PR deletes.

`mix precommit` green (2661 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)