### PR TITLE
feat: sandboxes carry their provider

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -201,7 +201,7 @@ defmodule Fountain.Conversations do
       "sandbox_provisioned",
       sandbox.id,
       "sandbox",
-      %{"sprite_name" => sandbox.sprite_name}
+      %{"sprite_name" => sandbox.sprite_name, "provider" => sandbox.provider}
     )
   end
 
@@ -220,7 +220,11 @@ defmodule Fountain.Conversations do
         "sandbox_provision_failed",
         sandbox.id,
         "sandbox",
-        %{"sprite_name" => sandbox.sprite_name, "status_before_failure" => was}
+        %{
+          "sprite_name" => sandbox.sprite_name,
+          "provider" => sandbox.provider,
+          "status_before_failure" => was
+        }
       )
     end
 
@@ -234,7 +238,8 @@ defmodule Fountain.Conversations do
       "sandbox",
       %{
         "duration_ms" => sandbox_duration_ms(sandbox),
-        "final_status" => status
+        "final_status" => status,
+        "provider" => sandbox.provider
       }
     )
   end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1450,6 +1450,11 @@ defmodule Fountain.Conversations.ConversationServer do
   # a wake from `suspended` stamps `last_resumed_at` and restarts the clock,
   # while a deploy reattach of a `ready` row stamps nothing and keeps it.
   # SandboxReaper.expired?/2 must agree with this — change both together.
+  # The provider tag for telemetry: read off the live handle, which was
+  # built from the sandbox row's provider column.
+  defp provider(%{handle: %Fountain.Sandbox.Handle{provider: provider}}), do: provider
+  defp provider(_state), do: :sprites
+
   defp sandbox_clock_start(sandbox), do: sandbox.last_resumed_at || sandbox.inserted_at
 
   defp schedule_lifecycle_check do
@@ -1493,7 +1498,9 @@ defmodule Fountain.Conversations.ConversationServer do
       message: Lifecycle.explain(:idle)
     })
 
-    :telemetry.execute([:fountain, :sandbox, :suspended], %{count: 1}, %{})
+    :telemetry.execute([:fountain, :sandbox, :suspended], %{count: 1}, %{
+      provider: provider(state)
+    })
 
     {:stop, :normal, %{state | handle: nil}}
   end
@@ -1535,7 +1542,10 @@ defmodule Fountain.Conversations.ConversationServer do
       message: Lifecycle.explain(reason)
     })
 
-    :telemetry.execute([:fountain, :sandbox, :reclaimed], %{count: 1}, %{reason: reason})
+    :telemetry.execute([:fountain, :sandbox, :reclaimed], %{count: 1}, %{
+      reason: reason,
+      provider: provider(state)
+    })
 
     {:stop, :normal, %{state | handle: nil}}
   end

--- a/apps/fountain/lib/fountain/conversations/sandbox.ex
+++ b/apps/fountain/lib/fountain/conversations/sandbox.ex
@@ -16,8 +16,18 @@ defmodule Fountain.Conversations.Sandbox do
   @statuses ~w(pending starting ready suspended terminated failed)
 
   schema "sandboxes" do
+    # Provider-scoped sandbox identity: the name Fountain mints
+    # (`fountain-<tenant-prefix>-<hex>`) and uses as the primary external ref.
+    # The column name predates multiple providers and survives for API and
+    # historical-metadata compatibility.
     field :sprite_name, :string
     field :status, :string, default: "pending"
+    # Which sandbox backend owns this row. Stamped at creation and never
+    # re-resolved: a parked sandbox wakes on the provider that holds its
+    # disk, whatever the instance default is by then.
+    field :provider, :string, default: "sprites"
+    # Adapter-opaque state (e.g. a server-assigned id). Never tenant-visible.
+    field :provider_meta, :map, default: %{}
     field :terminated_at, :utc_datetime
     field :last_resumed_at, :utc_datetime
     belongs_to :environment, Environment
@@ -33,12 +43,15 @@ defmodule Fountain.Conversations.Sandbox do
     |> cast(attrs, [
       :sprite_name,
       :status,
+      :provider,
+      :provider_meta,
       :terminated_at,
       :last_resumed_at,
       :environment_id,
       :user_id
     ])
-    |> validate_required([:sprite_name, :status, :user_id])
+    |> validate_required([:sprite_name, :status, :provider, :user_id])
     |> validate_inclusion(:status, @statuses)
+    |> validate_inclusion(:provider, Fountain.Sandbox.known_providers())
   end
 end

--- a/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
@@ -154,7 +154,10 @@ defmodule Fountain.Workers.SandboxReaper do
       resource_type: "sandbox",
       resource_id: sandbox.id,
       actor: "system:sandbox_reaper",
-      metadata: Map.put(metadata, "sprite_name", sandbox.sprite_name)
+      metadata:
+        metadata
+        |> Map.put("sprite_name", sandbox.sprite_name)
+        |> Map.put("provider", sandbox.provider)
     })
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/admin_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/admin_json.ex
@@ -62,6 +62,7 @@ defmodule FountainWeb.AdminJSON do
     %{
       id: s.id,
       sprite_name: s.sprite_name,
+      provider: s.provider,
       status: s.status,
       user_id: s.user_id,
       user_email: s.user && s.user.email,

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -351,7 +351,7 @@ defmodule FountainWeb.ConversationsLive.Show do
           </div>
           <div class="text-sm text-zinc-500">runtime: {@conv.runtime}</div>
           <div :if={@conv.sandbox} class="text-sm text-zinc-500 font-mono">
-            sprite: {@conv.sandbox.sprite_name}
+            sprite: {@conv.sandbox.sprite_name} ({@conv.sandbox.provider})
             <span class="text-zinc-400">
               ({String.slice(@conv.sandbox.id, 0, 8)} &middot; {@conv.sandbox.status})
             </span>

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -944,6 +944,7 @@ defmodule FountainWeb.Schemas do
       properties: %{
         id: %Schema{type: :string, format: :uuid},
         sprite_name: %Schema{type: :string},
+        provider: %Schema{type: :string, description: "Sandbox backend that owns this row"},
         status: %Schema{type: :string},
         user_id: %Schema{type: :string, format: :uuid, nullable: true},
         user_email: %Schema{type: :string, nullable: true},

--- a/apps/fountain/priv/repo/migrations/20260814090000_add_provider_to_sandboxes.exs
+++ b/apps/fountain/priv/repo/migrations/20260814090000_add_provider_to_sandboxes.exs
@@ -1,0 +1,20 @@
+defmodule Fountain.Repo.Migrations.AddProviderToSandboxes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sandboxes) do
+      # Which sandbox backend owns this row. Every existing row is Sprites —
+      # a non-volatile default on Postgres 11+ backfills as a metadata-only
+      # change, and the default stays as belt-and-suspenders for raw inserts
+      # during a rolling deploy.
+      add :provider, :string, null: false, default: "sprites"
+
+      # Adapter-opaque state (e.g. a server-assigned sandbox id where the
+      # provider does not honor our minted name). Never exposed to tenants.
+      add :provider_meta, :map, null: false, default: %{}
+    end
+
+    # The reaper's per-provider passes filter on exactly this pair.
+    create index(:sandboxes, [:provider, :status])
+  end
+end


### PR DESCRIPTION
## What

Sixth step of the campaign (#676–#680). The schema learns about providers:

- `sandboxes.provider` — string, NOT NULL, default `"sprites"` (non-volatile default = metadata-only backfill), `validate_inclusion` against `Fountain.Sandbox.known_providers()`. **Stamped at creation, never re-resolved**: a parked sandbox wakes on the provider that holds its disk, whatever the instance default becomes.
- `sandboxes.provider_meta` — jsonb, adapter-opaque state (e.g. a server-assigned id where a provider doesn't honor our minted name; E2B needs this). Never tenant-visible.
- `[provider, status]` index for the reaper's coming per-provider passes.
- `sprite_name` deliberately keeps its name: it's the provider-scoped identity Fountain mints, and renaming would break the public API field plus immutable historical audit/usage metadata.
- Provider lands in the operational trail: usage-event metadata (`sandbox_provisioned`/`sandbox_provision_failed`/`sandbox_terminated` — the ee event vocabulary itself stays closed), reaper audit metadata, suspend/reclaim telemetry tags, admin sandbox JSON + OpenAPI schema, and the conversation debug panel.

## Testing

`mix precommit` green (2674 tests); OpenAPI spec validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)