### PR TITLE
feat: multi-provider sandbox configuration with boot validation

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -66,6 +66,15 @@ FOUNTAIN_IMAGE_TAG=v0.8.1
 # Point at a different Sprites endpoint. Defaults to the hosted service.
 # SPRITES_BASE_URL=https://api.sprites.dev
 
+# Run new sandboxes on a different backend (sprites | e2b | daytona). A
+# provider is enabled by the presence of its credential; the default must
+# have one. Existing sandboxes stay where they were created.
+# SANDBOX_PROVIDER=sprites
+# E2B_API_KEY=
+# E2B_BASE_URL=https://api.e2b.app
+# DAYTONA_API_KEY=
+# DAYTONA_API_URL=https://app.daytona.io/api
+
 # Extra origins allowed to open a LiveView websocket, comma-separated. Your own
 # PUBLIC_URL host is always allowed.
 # CHECK_ORIGIN_EXTRA=//*.preview.example.com

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,20 @@ SPRITES_TOKEN=
 # (package installs, clones) set their own per-call timeouts.
 # SPRITES_TIMEOUT_MS=30000
 
+# Which backend newly-created sandboxes run on: sprites (default), e2b, or
+# daytona. A provider is enabled by the presence of its credential below;
+# setting a default whose credential is missing fails at boot. Existing
+# sandboxes always stay on the provider they were created on.
+# SANDBOX_PROVIDER=sprites
+
+# E2B (e2b.dev) — enables the e2b provider when set.
+# E2B_API_KEY=
+# E2B_BASE_URL=https://api.e2b.app
+
+# Daytona (daytona.io) — enables the daytona provider when set.
+# DAYTONA_API_KEY=
+# DAYTONA_API_URL=https://app.daytona.io/api
+
 # Sandbox lifetime bounds: reclaim after this long idle, and an absolute age
 # ceiling. 0 disables a bound; the conversation always stays resumable.
 # SANDBOX_IDLE_TIMEOUT_MINUTES=60

--- a/apps/fountain/lib/fountain/sandbox.ex
+++ b/apps/fountain/lib/fountain/sandbox.ex
@@ -223,11 +223,38 @@ defmodule Fountain.Sandbox do
     end
   end
 
-  @doc "The instance-default provider."
+  @doc "The instance-default provider (`SANDBOX_PROVIDER`; validated at boot)."
   @spec default_provider() :: provider()
   def default_provider do
     Application.get_env(:fountain, :sandbox_default_provider, :sprites)
   end
+
+  @doc """
+  Whether a provider is usable on this instance: its adapter is registered
+  **and** its credential is configured. Enabledness is runtime state — the
+  schema validates against `known_providers/0`, selection validates against
+  this.
+  """
+  @spec enabled?(provider()) :: boolean()
+  def enabled?(provider) when is_atom(provider) do
+    adapters = Application.get_env(:fountain, :sandbox_adapters, @default_adapters)
+    Map.has_key?(adapters, provider) and credential_present?(provider)
+  end
+
+  @doc "Every provider currently usable on this instance."
+  @spec enabled_providers() :: [provider()]
+  def enabled_providers do
+    known_providers()
+    |> Enum.map(&String.to_existing_atom/1)
+    |> Enum.filter(&enabled?/1)
+  end
+
+  defp credential_present?(:sprites), do: Application.get_env(:fountain, :sprites_token) != nil
+  defp credential_present?(:e2b), do: Application.get_env(:fountain, :e2b_api_key) != nil
+  defp credential_present?(:daytona), do: Application.get_env(:fountain, :daytona_api_key) != nil
+  # Non-production adapters (the in-memory Fake) carry no credentials; being
+  # registered in :sandbox_adapters is what enables them.
+  defp credential_present?(_other), do: true
 
   @doc "Whether a provider (or the provider owning a handle) has a capability."
   @spec supports?(provider() | Handle.t(), capability()) :: boolean()

--- a/apps/fountain/test/fountain/compose_passthrough_config_test.exs
+++ b/apps/fountain/test/fountain/compose_passthrough_config_test.exs
@@ -18,7 +18,8 @@ defmodule Fountain.ComposePassthroughConfigTest do
   @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
 
   @vars ~w(TRUSTED_PROXIES SENTRY_DSN DATABASE_SSL_VERIFY DATABASE_SSL_CA_FILE
-           SANDBOX_IDLE_TIMEOUT_MINUTES SANDBOX_MAX_LIFETIME_HOURS SPRITES_BASE_URL)
+           SANDBOX_IDLE_TIMEOUT_MINUTES SANDBOX_MAX_LIFETIME_HOURS SPRITES_BASE_URL
+           SANDBOX_PROVIDER E2B_API_KEY E2B_BASE_URL DAYTONA_API_KEY DAYTONA_API_URL)
 
   # Not under test here, but they change what the prod boot requires (a
   # configured mail provider demands EMAIL_FROM). Cleared before every read
@@ -175,6 +176,45 @@ defmodule Fountain.ComposePassthroughConfigTest do
       cfg = read_prod(Map.put(base, "SPRITES_BASE_URL", "https://sprites.internal.example.com"))
 
       assert cfg[:fountain][:sprites_base_url] == "https://sprites.internal.example.com"
+    end
+  end
+
+  describe "sandbox provider selection" do
+    test "blank SANDBOX_PROVIDER defaults to sprites; blank credentials stay unset", %{base: base} do
+      cfg =
+        read_prod(
+          Map.merge(base, %{
+            "SANDBOX_PROVIDER" => "",
+            "E2B_API_KEY" => "",
+            "E2B_BASE_URL" => "",
+            "DAYTONA_API_KEY" => "",
+            "DAYTONA_API_URL" => ""
+          })
+        )
+
+      assert cfg[:fountain][:sandbox_default_provider] == :sprites
+      assert cfg[:fountain][:e2b_api_key] == nil
+      assert cfg[:fountain][:e2b_base_url] == "https://api.e2b.app"
+      assert cfg[:fountain][:daytona_api_key] == nil
+      assert cfg[:fountain][:daytona_api_url] == "https://app.daytona.io/api"
+    end
+
+    test "an explicit default with its credential present is stored as an atom", %{base: base} do
+      cfg = read_prod(Map.merge(base, %{"SANDBOX_PROVIDER" => "e2b", "E2B_API_KEY" => "e2b_x"}))
+      assert cfg[:fountain][:sandbox_default_provider] == :e2b
+      assert cfg[:fountain][:e2b_api_key] == "e2b_x"
+    end
+
+    test "an explicit default without its credential refuses to boot", %{base: base} do
+      assert_raise RuntimeError, ~r/E2B_API_KEY is not set/, fn ->
+        read_prod(Map.merge(base, %{"SANDBOX_PROVIDER" => "e2b", "E2B_API_KEY" => ""}))
+      end
+    end
+
+    test "an unknown provider refuses to boot", %{base: base} do
+      assert_raise RuntimeError, ~r/must be one of sprites\|e2b\|daytona/, fn ->
+        read_prod(Map.put(base, "SANDBOX_PROVIDER", "modal"))
+      end
     end
   end
 end

--- a/apps/fountain/test/fountain/sandbox_config_test.exs
+++ b/apps/fountain/test/fountain/sandbox_config_test.exs
@@ -1,0 +1,39 @@
+defmodule Fountain.SandboxConfigTest do
+  # Mutates global application env, so it must not run alongside anything
+  # that reads sandbox configuration.
+  use ExUnit.Case, async: false
+
+  alias Fountain.Sandbox
+
+  setup do
+    previous = Application.get_env(:fountain, :sprites_token)
+    previous_e2b = Application.get_env(:fountain, :e2b_api_key)
+
+    on_exit(fn ->
+      restore(:sprites_token, previous)
+      restore(:e2b_api_key, previous_e2b)
+    end)
+
+    :ok
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:fountain, key)
+  defp restore(key, value), do: Application.put_env(:fountain, key, value)
+
+  test "a provider is enabled only when its credential is configured" do
+    Application.delete_env(:fountain, :sprites_token)
+    refute Sandbox.enabled?(:sprites)
+    assert Sandbox.enabled_providers() == []
+
+    Application.put_env(:fountain, :sprites_token, "tok")
+    assert Sandbox.enabled?(:sprites)
+    assert Sandbox.enabled_providers() == [:sprites]
+  end
+
+  test "a credential without a registered adapter does not enable the provider" do
+    # E2B credentials can be configured ahead of the adapter shipping; the
+    # provider stays unusable until its module is in :sandbox_adapters.
+    Application.put_env(:fountain, :e2b_api_key, "e2b_x")
+    refute Sandbox.enabled?(:e2b)
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -115,6 +115,78 @@ sprites_timeout_ms =
 
 config :fountain, :sprites_timeout_ms, sprites_timeout_ms
 
+# ── sandbox providers ────────────────────────────────────────────────────────
+#
+# Fountain can run sandboxes on more than one backend. Each provider is
+# *enabled* by the presence of its credential; `SANDBOX_PROVIDER` picks the
+# instance default for newly-created sandboxes (existing rows keep the
+# provider stamped on them). Blank counts as unset throughout, matching the
+# compose `${VAR:-}` pattern (#396/#513).
+
+e2b_api_key =
+  case System.get_env("E2B_API_KEY") do
+    blank when blank in [nil, ""] -> nil
+    key -> key
+  end
+
+e2b_base_url =
+  case System.get_env("E2B_BASE_URL") do
+    blank when blank in [nil, ""] -> "https://api.e2b.app"
+    url -> url
+  end
+
+daytona_api_key =
+  case System.get_env("DAYTONA_API_KEY") do
+    blank when blank in [nil, ""] -> nil
+    key -> key
+  end
+
+daytona_api_url =
+  case System.get_env("DAYTONA_API_URL") do
+    blank when blank in [nil, ""] -> "https://app.daytona.io/api"
+    url -> url
+  end
+
+config :fountain, :e2b_api_key, e2b_api_key
+config :fountain, :e2b_base_url, e2b_base_url
+config :fountain, :daytona_api_key, daytona_api_key
+config :fountain, :daytona_api_url, daytona_api_url
+
+sandbox_provider_env = System.get_env("SANDBOX_PROVIDER")
+
+sandbox_default_provider =
+  case sandbox_provider_env do
+    blank when blank in [nil, ""] ->
+      :sprites
+
+    value when value in ["sprites", "e2b", "daytona"] ->
+      # An *explicitly chosen* default must be usable: failing at boot with
+      # the missing variable named beats every conversation failing at
+      # provision time. An unset SANDBOX_PROVIDER keeps the old behavior —
+      # default sprites, credential checked lazily at first use — so
+      # migration-only boots and credential-less dev/test still start.
+      credential =
+        case value do
+          "sprites" -> {sprites_token, "SPRITES_TOKEN"}
+          "e2b" -> {e2b_api_key, "E2B_API_KEY"}
+          "daytona" -> {daytona_api_key, "DAYTONA_API_KEY"}
+        end
+
+      case credential do
+        {nil, var} ->
+          raise "SANDBOX_PROVIDER=#{value} but #{var} is not set — the default " <>
+                  "sandbox provider must have credentials"
+
+        _ ->
+          String.to_atom(value)
+      end
+
+    other ->
+      raise "SANDBOX_PROVIDER must be one of sprites|e2b|daytona, got: #{inspect(other)}"
+  end
+
+config :fountain, :sandbox_default_provider, sandbox_default_provider
+
 # Two different shapes are needed and they are not interchangeable:
 #
 #   :public_url — absolute, scheme-ful. Used to build links that leave the app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,11 @@ services:
       # attempt to start a conversation then fails.
       SPRITES_TOKEN: ${SPRITES_TOKEN:-}
       SPRITES_BASE_URL: ${SPRITES_BASE_URL:-}
+      SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-}
+      E2B_API_KEY: ${E2B_API_KEY:-}
+      E2B_BASE_URL: ${E2B_BASE_URL:-}
+      DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
+      DAYTONA_API_URL: ${DAYTONA_API_URL:-}
 
       # Empty means the app's defaults apply. Advertised in
       # .env.compose.example; a key listed there but not passed through here

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,11 @@ an error message.
 | `SPRITES_TOKEN` | — | for conversations | Platform token for [sprites.dev](https://sprites.dev). The app boots without it, but every conversation fails. Never expose it to tenants — it pays for every sandbox |
 | `SPRITES_BASE_URL` | `https://api.sprites.dev` | — | Repoints the sandbox API. Anything else must implement the same contract; there is no bundled alternative |
 | `SPRITES_TIMEOUT_MS` | `30000` | — | Bounds every HTTP call to the Sprites API. Long-running commands (package installs, clones) set their own per-call timeouts. Boot refuses a non-positive value |
+| `SANDBOX_PROVIDER` | `sprites` | — | Which backend newly-created sandboxes run on: `sprites`, `e2b`, or `daytona`. A provider is enabled by the presence of its credential; boot refuses an explicit default whose credential is missing. Existing sandboxes stay on the provider they were created on |
+| `E2B_API_KEY` | — | for the `e2b` provider | [E2B](https://e2b.dev) API key. Its presence enables the provider |
+| `E2B_BASE_URL` | `https://api.e2b.app` | — | Repoints the E2B control plane |
+| `DAYTONA_API_KEY` | — | for the `daytona` provider | [Daytona](https://daytona.io) API key. Its presence enables the provider |
+| `DAYTONA_API_URL` | `https://app.daytona.io/api` | — | Repoints the Daytona API (self-hosted Daytona) |
 | `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long and the sandbox is reclaimed — the conversation stays [resumable](self-hosting.md#sandbox-lifetime). `0` disables the bound; boot refuses anything that is not a non-negative integer |
 | `SANDBOX_MAX_LIFETIME_HOURS` | `24` | — | Absolute sandbox age ceiling, regardless of activity. Same `0`-disables and boot-refusal rules |
 | `LOG_OUTPUT_BUDGET_MB` | `50` | — | Durable log volume per conversation. Once a conversation has persisted this much sandbox output, one truncation marker is written and further output is discarded (retention bounds age; this bounds rate). Same `0`-disables and boot-refusal rules |


### PR DESCRIPTION
## What

Seventh step of the campaign (#676–#681). Operators can now configure multiple sandbox backends:

- **`SANDBOX_PROVIDER`** — instance default for newly-created sandboxes (`sprites` when unset, unchanged behavior). An *explicitly chosen* default whose credential is missing **refuses to boot** with the variable named; an unset value keeps the lazy-credential behavior that migration-only boots and credential-less dev/test rely on.
- **`E2B_API_KEY`/`E2B_BASE_URL`, `DAYTONA_API_KEY`/`DAYTONA_API_URL`** — a provider is *enabled* by its credential's presence **and** a registered adapter, so credentials can be staged before the adapter ships. Blank counts as unset throughout (compose `${VAR:-}`, #396/#513).
- `Fountain.Sandbox.enabled?/1` + `enabled_providers/0` join `default_provider/0`.
- `docs/configuration.md`, `.env.example`, `.env.compose.example`, `docker-compose.yml` all carry the new variables — the config-reference and compose-passthrough guard tests gain cases for the new block (incl. both boot-refusal paths).

## Testing

`mix precommit` green (2680 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)