### PR TITLE
feat: agents can pin a sandbox provider; sandbox rows resolve and stick

### DIFF
--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -20,6 +20,9 @@ defmodule Fountain.Agents.Agent do
     field :system, :string, default: ""
     field :model, :string
     field :runtime, :string
+    # Optional sandbox-backend override; nil inherits the instance default
+    # (SANDBOX_PROVIDER) at conversation start.
+    field :sandbox_provider, :string
     # Each entry is one of:
     #   %{"name" => name, "content" => skill_md}     # inline SKILL.md
     #   %{"source" => "owner/repo", "name" => opt}   # github via skills.sh CLI
@@ -48,6 +51,7 @@ defmodule Fountain.Agents.Agent do
       :system,
       :model,
       :runtime,
+      :sandbox_provider,
       :skills,
       :mcp_servers,
       :metadata,
@@ -61,6 +65,7 @@ defmodule Fountain.Agents.Agent do
       message: "must be in canonical provider/model_id form"
     )
     |> validate_model_provider()
+    |> validate_sandbox_provider()
     |> validate_length(:name, min: 1, max: 200)
     |> validate_skills()
     |> unique_constraint(:name, name: :agents_user_id_name_index)
@@ -107,6 +112,29 @@ defmodule Fountain.Agents.Agent do
         "unknown provider \"#{provider}\" — must be one of: #{Enum.join(Model.providers(), ", ")}"
       )
     end
+  end
+
+  # Distinct from the *model* provider above: this picks which sandbox
+  # backend the agent's conversations run on. Nil inherits the instance
+  # default. Only validated when the field changes, so removing a provider's
+  # credentials later does not brick unrelated edits to existing agents —
+  # conversation start re-checks enabledness anyway.
+  defp validate_sandbox_provider(changeset) do
+    validate_change(changeset, :sandbox_provider, fn :sandbox_provider, value ->
+      cond do
+        value not in Fountain.Sandbox.known_providers() ->
+          [
+            sandbox_provider:
+              "must be one of: " <> Enum.join(Fountain.Sandbox.known_providers(), ", ")
+          ]
+
+        not Fountain.Sandbox.enabled?(String.to_existing_atom(value)) ->
+          [sandbox_provider: "is not configured on this instance"]
+
+        true ->
+          []
+      end
+    end)
   end
 
   defp validate_skills(changeset) do

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -930,6 +930,7 @@ defmodule Fountain.Conversations do
          {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Accounts.check_not_suspended(user_id),
          :ok <- Fountain.Billing.check_active(user_id),
+         {:ok, provider} <- resolve_sandbox_provider(agent),
          # Quota check + row insert under one per-user advisory lock: checked
          # separately they are check-then-insert, and N concurrent requests at
          # the cap could each pass and provision N-1 sprites over it (#330).
@@ -940,6 +941,7 @@ defmodule Fountain.Conversations do
                sprite_name:
                  attrs["sprite_name"] || "fountain-#{tenant_prefix(user_id)}-#{short_id()}",
                status: "pending",
+               provider: Atom.to_string(provider),
                user_id: user_id
              })
            end),
@@ -1176,33 +1178,82 @@ defmodule Fountain.Conversations do
 
   defp maybe_reuse_sandbox(%Conversation{sandbox_id: sandbox_id}) do
     case _unsafe_get_sandbox(sandbox_id) do
-      %{status: status, sprite_name: name}
+      %{status: status, sprite_name: name} = sandbox
       when status in ["ready", "suspended"] and is_binary(name) ->
-        case Fountain.Sandbox.get(Fountain.Sandbox.build_handle(:sprites, name)) do
-          {:ok, _info} ->
-            {:reuse, sandbox_id}
-
-          {:error, :not_found} ->
-            :create_new
-
-          {:error, reason} when status == "suspended" ->
-            # A transient probe failure must not cost the parked disk: falling
-            # to :create_new retires this row, and the reaper then destroys the
-            # still-live sprite — with the agent's memory on it. Only a
-            # definitive not-found gives up the suspended sandbox; anything
-            # else fails the wake retryably.
-            Logger.warning(
-              "sprite probe failed for suspended sandbox #{sandbox_id}: #{inspect(reason)}"
-            )
-
-            {:error, :sprite_probe_failed}
-
-          _ ->
-            :create_new
-        end
+        probe_reusable_sandbox(sandbox, sandbox_id)
 
       _ ->
         :create_new
+    end
+  end
+
+  # The row's provider is sticky: a parked sandbox wakes on the backend that
+  # holds its disk, never on whatever the instance default is by now. A row
+  # whose (non-default) provider lost its credentials fails retryably — the
+  # same protect-the-parked-disk reasoning as :sprite_probe_failed below;
+  # falling through to :create_new would retire the row and orphan (or lose)
+  # the parked sandbox. Re-adding the credentials restores wakes.
+  defp probe_reusable_sandbox(%{status: status, sprite_name: name} = sandbox, sandbox_id) do
+    provider = sandbox_provider_atom(sandbox)
+
+    if provider != Fountain.Sandbox.default_provider() and
+         not Fountain.Sandbox.enabled?(provider) do
+      Logger.warning(
+        "sandbox #{sandbox_id} is on disabled provider #{provider}; refusing to wake or retire"
+      )
+
+      {:error, {:sandbox_provider_disabled, provider}}
+    else
+      probe_sandbox(provider, name, status, sandbox_id)
+    end
+  end
+
+  defp probe_sandbox(provider, name, status, sandbox_id) do
+    case Fountain.Sandbox.get(Fountain.Sandbox.build_handle(provider, name)) do
+      {:ok, _info} ->
+        {:reuse, sandbox_id}
+
+      {:error, :not_found} ->
+        :create_new
+
+      {:error, reason} when status == "suspended" ->
+        # A transient probe failure must not cost the parked disk: falling
+        # to :create_new retires this row, and the reaper then destroys the
+        # still-live sprite — with the agent's memory on it. Only a
+        # definitive not-found gives up the suspended sandbox; anything
+        # else fails the wake retryably.
+        Logger.warning(
+          "sprite probe failed for suspended sandbox #{sandbox_id}: #{inspect(reason)}"
+        )
+
+        {:error, :sprite_probe_failed}
+
+      _ ->
+        :create_new
+    end
+  end
+
+  def sandbox_provider_atom(%{provider: provider}) when is_binary(provider),
+    do: String.to_existing_atom(provider)
+
+  def sandbox_provider_atom(_sandbox), do: :sprites
+
+  # Placement for a NEW sandbox: the agent's override, else the instance
+  # default. Only an override is gated on enabledness — the default keeps its
+  # lazy credential check (a credential-less boot fails at provision time
+  # with the missing variable named, exactly as before), while an agent
+  # pinned to a provider whose credentials were since removed fails here
+  # with an error the API/UI can explain.
+  defp resolve_sandbox_provider(%Agents.Agent{sandbox_provider: nil}),
+    do: {:ok, Fountain.Sandbox.default_provider()}
+
+  defp resolve_sandbox_provider(%Agents.Agent{sandbox_provider: value}) do
+    provider = String.to_existing_atom(value)
+
+    if Fountain.Sandbox.enabled?(provider) do
+      {:ok, provider}
+    else
+      {:error, {:sandbox_provider_disabled, provider}}
     end
   end
 
@@ -1275,6 +1326,10 @@ defmodule Fountain.Conversations do
     # conversation was an unmetered way past billing entirely.
     with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
          :ok <- Fountain.Billing.check_active(conv.user_id),
+         # A fresh sandbox is a fresh placement decision — re-resolve from
+         # the agent, so a conversation whose old sandbox died can migrate
+         # providers naturally.
+         {:ok, provider} <- resolve_sandbox_provider(agent),
          # Same reservation as start_conversation/1 — see the note there (#330).
          {:ok, new_sandbox} <-
            Fountain.Quotas.with_sandbox_reservation(
@@ -1285,6 +1340,7 @@ defmodule Fountain.Conversations do
                  environment_id: agent.environment_id,
                  sprite_name: "fountain-#{tenant_prefix(conv.user_id)}-#{short_id()}",
                  status: "pending",
+                 provider: Atom.to_string(provider),
                  user_id: conv.user_id
                })
              end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -566,7 +566,7 @@ defmodule Fountain.Conversations.ConversationServer do
     {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
     publish_stage(state.conversation_id, "provision", "started")
 
-    case create_sandbox_handle(sandbox.sprite_name) do
+    case create_sandbox_handle(sandbox) do
       {:ok, handle} ->
         skills = (agent && agent.skills) || []
         # conv.runtime is validated-required and outlives the agent; the agent
@@ -752,7 +752,11 @@ defmodule Fountain.Conversations.ConversationServer do
       sprite_name: sandbox.sprite_name
     })
 
-    handle = Fountain.Sandbox.build_handle(:sprites, sandbox.sprite_name)
+    handle =
+      Fountain.Sandbox.build_handle(
+        Fountain.Conversations.sandbox_provider_atom(sandbox),
+        sandbox.sprite_name
+      )
 
     case Fountain.Retry.with_backoff(
            fn -> Fountain.Sandbox.get(handle) end,
@@ -1625,12 +1629,14 @@ defmodule Fountain.Conversations.ConversationServer do
 
   # ── helpers ───────────────────────────────────────────────────────────────
 
-  # Provider hardcoded until the sandboxes row carries one; adopt-on-409 is
-  # the adapter's job now.
-  defp create_sandbox_handle(name) do
+  # The row's provider decides where the sandbox is created; adopt-on-
+  # already-exists is the adapter's job.
+  defp create_sandbox_handle(sandbox) do
+    provider = Fountain.Conversations.sandbox_provider_atom(sandbox)
+
     Fountain.Retry.with_backoff(
-      fn -> Fountain.Sandbox.create(:sprites, name) end,
-      label: "sprite create #{name}"
+      fn -> Fountain.Sandbox.create(provider, sandbox.sprite_name) end,
+      label: "sprite create #{sandbox.sprite_name}"
     )
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/agent_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_json.ex
@@ -13,6 +13,7 @@ defmodule FountainWeb.AgentJSON do
       system: a.system,
       model: a.model,
       runtime: a.runtime,
+      sandbox_provider: a.sandbox_provider,
       environment_id: a.environment_id,
       skills: a.skills,
       mcp_servers: a.mcp_servers,

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -44,6 +44,21 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "parent_conversation_not_found"})
   end
 
+  # The agent pins a sandbox provider that is not usable on this instance
+  # (its adapter is missing or its credentials were removed). 422 with the
+  # provider named: an admin either configures the credentials or clears the
+  # agent's override.
+  def call(conn, {:error, {:sandbox_provider_disabled, provider}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "sandbox_provider_disabled",
+      message:
+        "sandbox provider #{provider} is not configured on this instance — " <>
+          "set its credentials or clear the agent's sandbox_provider override"
+    })
+  end
+
   # Subscription gate (ADR 0006). Raised from the context so every provisioning
   # path renders the same response, rather than each controller inventing one.
   def call(conn, {:error, :subscription_required}) do

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -17,6 +17,7 @@ defmodule FountainWeb.AgentsLive.Form do
      |> assign(:page_title, page_title(action))
      |> assign(:user_id, user_id)
      |> assign(:envs, envs)
+     |> assign(:sandbox_providers, Fountain.Sandbox.enabled_providers())
      |> assign(:action, action)
      |> assign(:agent, agent)
      |> assign(:form, agent_to_form(agent))
@@ -50,6 +51,7 @@ defmodule FountainWeb.AgentsLive.Form do
       "system" => a.system || "",
       "model" => a.model || "anthropic/claude-sonnet-4-6",
       "runtime" => a.runtime || "claude",
+      "sandbox_provider" => a.sandbox_provider || "",
       "environment_id" => a.environment_id || ""
     }
   end
@@ -284,6 +286,7 @@ defmodule FountainWeb.AgentsLive.Form do
         |> Map.put("mcp_servers", mcp_map)
         |> Map.put("user_id", socket.assigns.user_id)
         |> nil_if_blank("environment_id")
+        |> nil_if_blank("sandbox_provider")
 
       case save(socket, attrs) do
         {:ok, socket} -> {:noreply, socket}
@@ -570,6 +573,24 @@ defmodule FountainWeb.AgentsLive.Form do
         >
           Not one of the models Fountain lists — it will be passed to the runtime as-is.
         </p>
+
+        <div :if={length(@sandbox_providers) > 1} class="space-y-1">
+          <label class="block text-sm font-medium text-zinc-700">Sandbox provider</label>
+          <select
+            name="agent[sandbox_provider]"
+            class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+          >
+            <option value="">Instance default ({Fountain.Sandbox.default_provider()})</option>
+            <option
+              :for={p <- @sandbox_providers}
+              value={p}
+              selected={@form["sandbox_provider"] == to_string(p)}
+            >
+              {p}
+            </option>
+          </select>
+          <.error_msg field="sandbox_provider" errors={@errors} />
+        </div>
 
         <div class="space-y-1">
           <label class="block text-sm font-medium text-zinc-700">Environment</label>

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -250,6 +250,14 @@ defmodule FountainWeb.Schemas do
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
         runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        sandbox_provider: %Schema{
+          type: :string,
+          enum: ~w(sprites e2b daytona),
+          nullable: true,
+          description:
+            "Sandbox backend override; null inherits the instance default " <>
+              "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
+        },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         skills: %Schema{
           type: :array,
@@ -336,6 +344,14 @@ defmodule FountainWeb.Schemas do
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
         runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        sandbox_provider: %Schema{
+          type: :string,
+          enum: ~w(sprites e2b daytona),
+          nullable: true,
+          description:
+            "Sandbox backend override; null inherits the instance default " <>
+              "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
+        },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         skills: %Schema{
           type: :array,
@@ -403,6 +419,14 @@ defmodule FountainWeb.Schemas do
         system: %Schema{type: :string},
         model: %Schema{type: :string, pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"},
         runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        sandbox_provider: %Schema{
+          type: :string,
+          enum: ~w(sprites e2b daytona),
+          nullable: true,
+          description:
+            "Sandbox backend override; null inherits the instance default " <>
+              "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
+        },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         skills: %Schema{
           type: :array,

--- a/apps/fountain/priv/repo/migrations/20260814100000_add_sandbox_provider_to_agents.exs
+++ b/apps/fountain/priv/repo/migrations/20260814100000_add_sandbox_provider_to_agents.exs
@@ -1,0 +1,11 @@
+defmodule Fountain.Repo.Migrations.AddSandboxProviderToAgents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:agents) do
+      # Optional override of the instance-default sandbox backend. Null means
+      # inherit SANDBOX_PROVIDER at conversation start.
+      add :sandbox_provider, :string, null: true
+    end
+  end
+end

--- a/apps/fountain/test/fountain/agents/agent_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_test.exs
@@ -273,4 +273,32 @@ defmodule Fountain.Agents.AgentTest do
       assert errors_on(changeset).skills != []
     end
   end
+
+  describe "sandbox_provider" do
+    test "nil inherits the instance default and validates clean" do
+      changeset = Agent.changeset(%Agent{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "an unknown backend is rejected against the closed vocabulary" do
+      changeset =
+        Agent.changeset(%Agent{}, Map.put(@valid_attrs, :sandbox_provider, "modal"))
+
+      refute changeset.valid?
+      assert [msg] = errors_on(changeset).sandbox_provider
+      assert msg =~ "must be one of"
+    end
+
+    test "a known but unconfigured backend is rejected at save time" do
+      # e2b is in the vocabulary but has no adapter registered (and no
+      # credentials in test), so pinning an agent to it must fail with a
+      # message pointing at instance configuration, not at conversation start.
+      changeset =
+        Agent.changeset(%Agent{}, Map.put(@valid_attrs, :sandbox_provider, "e2b"))
+
+      refute changeset.valid?
+      assert [msg] = errors_on(changeset).sandbox_provider
+      assert msg =~ "not configured"
+    end
+  end
 end

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1366,7 +1366,61 @@ defmodule Fountain.ConversationsContextTest do
   # start_conversation/1
   # ────────────────────────────────────────────────────────────────────────────
 
+  describe "wake_conversation/2 — provider stickiness" do
+    test "a suspended sandbox on a disabled provider refuses to wake rather than retire" do
+      # Falling through to :create_new would retire the row and orphan (or
+      # lose) the parked disk; a retryable error keeps the agent's memory
+      # safe until the operator restores the provider's credentials.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, sprite_name: "parked-on-e2b")
+
+      {:ok, sandbox} =
+        Conversations.update_sandbox(sandbox, %{status: "suspended", provider: "e2b"})
+
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      assert {:error, {:sandbox_provider_disabled, :e2b}} =
+               Conversations.wake_conversation(conv.id)
+
+      assert Repo.reload(sandbox).status == "suspended"
+    end
+  end
+
   describe "start_conversation/1" do
+    test "the sandbox row is stamped with the resolved provider" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+      assert {:ok, conv} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+
+      sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+      assert sandbox.provider == "sprites"
+    end
+
+    test "an agent pinned to a disabled provider is refused before any row is allocated" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      # Simulate drift: the override was saved while the provider was
+      # configured, and its credentials/adapter have since gone away. The
+      # changeset guards saves, so write the column directly.
+      {1, _} =
+        Repo.update_all(
+          Ecto.Query.from(a in Fountain.Agents.Agent, where: a.id == ^agent.id),
+          set: [sandbox_provider: "e2b"]
+        )
+
+      before = Fountain.Quotas.active_sandbox_count(user.id)
+
+      assert {:error, {:sandbox_provider_disabled, :e2b}} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+
+      assert Fountain.Quotas.active_sandbox_count(user.id) == before
+    end
+
     test "returns {:error, :vault_not_found} when vault_id belongs to a different user" do
       user1 = insert_verified_user()
       user2 = insert_verified_user()

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -49,6 +49,10 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.Agent, "runtime"} => {Agent, :runtimes},
     {FountainWeb.Schemas.AgentRequest, "runtime"} => {Agent, :runtimes},
     {FountainWeb.Schemas.AgentUpdate, "runtime"} => {Agent, :runtimes},
+    {FountainWeb.Schemas.Agent, "sandbox_provider"} => {Fountain.Sandbox, :known_providers},
+    {FountainWeb.Schemas.AgentRequest, "sandbox_provider"} =>
+      {Fountain.Sandbox, :known_providers},
+    {FountainWeb.Schemas.AgentUpdate, "sandbox_provider"} => {Fountain.Sandbox, :known_providers},
     # A conversation's runtime is copied from its agent at spawn, so it must
     # speak the same vocabulary even though the column carries no inclusion
     # validation of its own.


### PR DESCRIPTION
## What

Eighth step of the campaign (#676–#682). Selection plumbing:

- **`agents.sandbox_provider`** (nullable — nil inherits `SANDBOX_PROVIDER` at conversation start) with a two-level guard: the changeset rejects saving an override for an unconfigured provider (validated only when the field changes, so pulling credentials later doesn't brick unrelated edits), and conversation start re-checks enabledness, refusing with `{:error, {:sandbox_provider_disabled, p}}` **before any sandbox row is allocated**.
- **Resolution happens only where rows are minted** (`start_conversation` and `create_fresh_sandbox_and_start` — a fresh sandbox is a fresh placement decision) and is stamped into `sandboxes.provider`. The instance default keeps its lazy credential check, so credential-less dev/test boots behave exactly as before.
- **Wake never re-resolves**: the probe, reattach and fresh-provision paths build handles from the row's provider. A parked sandbox whose (non-default) provider lost its credentials refuses to wake **retryably** rather than falling through to `:create_new` — which would retire the row and lose the parked disk. Re-adding credentials restores wakes.
- Exposure: agent JSON, the three agent OpenAPI schemas (registered with the enum guardrail against `Fountain.Sandbox.known_providers/0`), a fallback mapping (422 naming the provider and both ways out), and a form picker rendered only when >1 provider is enabled — single-provider self-hosts see no new UI.

## Testing

New tests: changeset vocabulary + not-configured rejections, provider stamping, refusal-before-allocation (quota count unchanged), and the disabled-provider wake guard. `mix precommit` green (2686 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)