### PR TITLE
docs: ADR 0018, provider matrix, changelog, and the sandbox naming sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ upgrade, is in
 
 ### Added
 
+- **Pluggable sandbox backends: E2B and Daytona join Sprites.** The
+  sandbox layer is a provider-agnostic behaviour (`Fountain.Sandbox`) with
+  an executable conformance suite; `SANDBOX_PROVIDER` picks the instance
+  default, an agent can pin `sandbox_provider`, and every sandbox row
+  records the provider that owns it — parked sandboxes always wake where
+  their disk lives. E2B (`E2B_API_KEY`) pauses idle sandboxes with a
+  filesystem+memory snapshot; Daytona (`DAYTONA_API_KEY`) stops them with
+  the disk preserved. A provider that cannot park degrades to
+  destroy-on-idle, and the reaper reconciles each provider independently.
+  Reference sandbox images live in `images/e2b/` and `images/daytona/`;
+  decisions/0018 has the full design (#676–#686).
+
 - **Tool-level OTel spans for every ACP runtime.** Tool-call tracing was
   claude-only (a parser over its proprietary stream-json); ACP's
   `tool_call`/`tool_call_update` carry the id and status for all runtimes,

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -174,7 +174,7 @@ defmodule Fountain.Agents.Agent do
 
   defp skill_errors(_entry, i), do: [skills: "entry #{i}: must be an object"]
 
-  # Mirrors SpriteSkills.safe_token!/1 — the ref is interpolated into the
+  # Mirrors SandboxSkills.safe_token!/1 — the ref is interpolated into the
   # sprite-side install command, so reject anything outside the allow-list
   # at write time instead of failing the spawn later.
   defp valid_ref?(ref) when is_binary(ref), do: Regex.match?(~r{\A[A-Za-z0-9._/-]+\z}, ref)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -572,7 +572,7 @@ defmodule Fountain.Conversations.ConversationServer do
         # conv.runtime is validated-required and outlives the agent; the agent
         # fallback only covers rows predating the runtime column.
         runtime = conv.runtime || (agent && agent.runtime) || "claude"
-        Fountain.SpriteSkills.mount(handle, runtime, skills)
+        Fountain.SandboxSkills.mount(handle, runtime, skills)
 
         {state, conv} = rotate_callback_api_key(state, conv)
 
@@ -1036,8 +1036,8 @@ defmodule Fountain.Conversations.ConversationServer do
     Code.ensure_loaded(runtime_module)
 
     with :ok <- prepare_acp_adapter(handle, runtime, sprite_env) do
-      if function_exported?(runtime_module, :prepare_sprite, 3) do
-        runtime_module.prepare_sprite(handle, agent, sprite_env)
+      if function_exported?(runtime_module, :prepare_sandbox, 3) do
+        runtime_module.prepare_sandbox(handle, agent, sprite_env)
       else
         :ok
       end

--- a/apps/fountain/lib/fountain/runtimes.ex
+++ b/apps/fountain/lib/fountain/runtimes.ex
@@ -62,7 +62,7 @@ defmodule Fountain.Runtimes do
   Receives the same `sprite_env` pairs the spawn will use. Implementers
   pull whichever keys they need out of that list. No-op by default.
   """
-  @callback prepare_sprite(
+  @callback prepare_sandbox(
               handle :: Fountain.Sandbox.Handle.t(),
               agent :: %Agent{} | nil,
               sprite_env :: [{String.t(), String.t()}]
@@ -83,7 +83,7 @@ defmodule Fountain.Runtimes do
   """
   @callback skills_sh_agent() :: String.t()
 
-  @optional_callbacks build_command: 5, default_env: 2, write_config: 2, prepare_sprite: 3
+  @optional_callbacks build_command: 5, default_env: 2, write_config: 2, prepare_sandbox: 3
 
   @runtime_modules %{
     "claude" => Fountain.Runtimes.Claude,

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -116,7 +116,7 @@ defmodule Fountain.Runtimes.ACP do
     # `sessionCapabilities`, so every turn after the first pays a full replay
     # that `Peer` discards. The cwd mirrors `Fountain.Runtimes.Gemini`'s
     # `@workdir` — gemini walks up from cwd looking for a `.git`, and
-    # `Gemini.prepare_sprite/3` git-inits exactly this directory. Pointing it
+    # `Gemini.prepare_sandbox/3` git-inits exactly this directory. Pointing it
     # at /home/sprite instead reintroduces the EACCES noise that workspace
     # exists to avoid.
     # Converted, verified, and **not shippable** — see `blocked`. Left in the
@@ -134,7 +134,7 @@ defmodule Fountain.Runtimes.ACP do
     },
     # Adapter, on the Codex App Server. The `zed-industries/codex-acp` that
     # earlier drafts named is archived; this is its successor under the
-    # protocol org. Auth is unchanged: `Codex.prepare_sprite/3` still runs
+    # protocol org. Auth is unchanged: `Codex.prepare_sandbox/3` still runs
     # `codex login --with-api-key`, and OPENAI_API_KEY is still exported, so
     # the adapter inherits whichever the CLI would have used.
     "codex" => %{
@@ -148,7 +148,7 @@ defmodule Fountain.Runtimes.ACP do
     # local HTTP server inside the sprite and drives it through opencode's own
     # SDK client, rather than being a plain stdio peer. It satisfies the
     # protocol, but it is a second process model to keep in mind when something
-    # hangs. Nothing to install here: `OpenCode.prepare_sprite/3` already bun-
+    # hangs. Nothing to install here: `OpenCode.prepare_sandbox/3` already bun-
     # installs the binary and symlinks it onto PATH.
     "opencode" => %{
       bin: "opencode",
@@ -264,7 +264,7 @@ defmodule Fountain.Runtimes.ACP do
   which reads like a protocol bug and is not one.
 
   So we symlink into `/home/sprite/.local/bin`, which *is* on PATH. This is the
-  same shape as `Fountain.Runtimes.OpenCode.prepare_sprite/3`, which hit the
+  same shape as `Fountain.Runtimes.OpenCode.prepare_sandbox/3`, which hit the
   identical problem with bun's global bin, and the absolute path is hardcoded
   for the same reason it is there: `~` resolves against whatever `HOME` the
   caller happens to have.
@@ -274,7 +274,7 @@ defmodule Fountain.Runtimes.ACP do
 
   # Native ACP: the runtime speaks the protocol itself, and is already on the
   # sprite — gemini from the base image, opencode from
-  # `OpenCode.prepare_sprite/3`'s bun install. Nothing to install, and for
+  # `OpenCode.prepare_sandbox/3`'s bun install. Nothing to install, and for
   # gemini nothing we can pin either: the version floor is whatever the image
   # carries, which gate 1 recorded as an open exposure.
   def install(_handle, runtime, _sprite_env) when runtime in ["gemini", "opencode"], do: :ok

--- a/apps/fountain/lib/fountain/runtimes/codex.ex
+++ b/apps/fountain/lib/fountain/runtimes/codex.ex
@@ -9,7 +9,7 @@ defmodule Fountain.Runtimes.Codex do
   deliberately kept: credentials and skills.
 
   Auth: `OPENAI_API_KEY` is consumed once at provision time via
-  `prepare_sprite/3` (see below) — codex reads `~/.codex/auth.json`, not the
+  `prepare_sandbox/3` (see below) — codex reads `~/.codex/auth.json`, not the
   process env, and the adapter runs on the same store.
   """
 
@@ -39,7 +39,7 @@ defmodule Fountain.Runtimes.Codex do
   # `~/.codex/auth.json`, which `codex login --with-api-key` writes by
   # consuming the key on stdin. Run the login once at provision time.
   @impl true
-  def prepare_sprite(handle, _agent, sprite_env) do
+  def prepare_sandbox(handle, _agent, sprite_env) do
     case List.keyfind(sprite_env, "OPENAI_API_KEY", 0) do
       {"OPENAI_API_KEY", key} when is_binary(key) and key != "" ->
         case Fountain.Sandbox.spawn(handle, "codex", ["login", "--with-api-key"],

--- a/apps/fountain/lib/fountain/runtimes/gemini.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini.ex
@@ -114,7 +114,7 @@ defmodule Fountain.Runtimes.Gemini do
   # MemoryDiscovery is happy as long as it finds *some* .git when it
   # walks up from cwd.
   @impl true
-  def prepare_sprite(handle, _agent, sprite_env) do
+  def prepare_sandbox(handle, _agent, sprite_env) do
     script = """
     set -e
     if [ ! -d #{@workdir}/.git ]; then

--- a/apps/fountain/lib/fountain/runtimes/open_code.ex
+++ b/apps/fountain/lib/fountain/runtimes/open_code.ex
@@ -58,7 +58,7 @@ defmodule Fountain.Runtimes.OpenCode do
   # bun's own global bin at /.sprite/languages/bun/bin is not on PATH).
   # Idempotent — `command -v` short-circuits on subsequent calls.
   @impl true
-  def prepare_sprite(handle, _agent, sprite_env) do
+  def prepare_sandbox(handle, _agent, sprite_env) do
     install_script = """
     set -e
 

--- a/apps/fountain/lib/fountain/sandbox_skills.ex
+++ b/apps/fountain/lib/fountain/sandbox_skills.ex
@@ -1,4 +1,4 @@
-defmodule Fountain.SpriteSkills do
+defmodule Fountain.SandboxSkills do
   @moduledoc """
   Materialize an agent's skills onto its sprite at provision time.
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -56,7 +56,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       {pid, _ref, :alive} = start_server(conv)
 
       assert_received :write_config
-      assert_received :prepare_sprite
+      assert_received :prepare_sandbox
       GenServer.stop(pid)
     end
 
@@ -357,7 +357,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
       # step cannot strand a conversation in `pending` forever.
       stub_happy_sprite()
 
-      Mimic.stub(Fountain.SpriteSkills, :mount, fn _s, _r, _sk ->
+      Mimic.stub(Fountain.SandboxSkills, :mount, fn _s, _r, _sk ->
         raise "boom"
       end)
 

--- a/apps/fountain/test/fountain/runtimes/acp_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp_test.exs
@@ -188,7 +188,7 @@ defmodule Fountain.Runtimes.ACPTest do
 
       # opencode's `acp` subcommand starts a local HTTP server inside the
       # sprite and drives it through its own SDK — a heavier process model than
-      # the others, but nothing for us to install: OpenCode.prepare_sprite/3
+      # the others, but nothing for us to install: OpenCode.prepare_sandbox/3
       # already bun-installs it.
       assert {"opencode", ["acp"]} = ACP.command("opencode")
       assert is_nil(ACP.adapter_spec("opencode"))

--- a/apps/fountain/test/fountain/sandbox_skills_test.exs
+++ b/apps/fountain/test/fountain/sandbox_skills_test.exs
@@ -1,18 +1,18 @@
-defmodule Fountain.SpriteSkillsTest do
+defmodule Fountain.SandboxSkillsTest do
   use ExUnit.Case, async: true
 
-  alias Fountain.SpriteSkills
+  alias Fountain.SandboxSkills
 
   describe "github_install_cmd/2" do
     test "unpinned source installs from the default branch" do
-      cmd = SpriteSkills.github_install_cmd(%{"source" => "owner/repo"}, "claude")
+      cmd = SandboxSkills.github_install_cmd(%{"source" => "owner/repo"}, "claude")
 
       assert cmd == "npx -y skills@latest add owner/repo --global --agent claude --yes"
     end
 
     test "ref pins the source as owner/repo@ref" do
       cmd =
-        SpriteSkills.github_install_cmd(
+        SandboxSkills.github_install_cmd(
           %{"source" => "owner/repo", "ref" => "v1.2.0"},
           "claude"
         )
@@ -21,14 +21,14 @@ defmodule Fountain.SpriteSkillsTest do
     end
 
     test "empty ref is treated as unpinned" do
-      cmd = SpriteSkills.github_install_cmd(%{"source" => "owner/repo", "ref" => ""}, "claude")
+      cmd = SandboxSkills.github_install_cmd(%{"source" => "owner/repo", "ref" => ""}, "claude")
 
       assert cmd == "npx -y skills@latest add owner/repo --global --agent claude --yes"
     end
 
     test "name adds the --skill flag alongside a ref" do
       cmd =
-        SpriteSkills.github_install_cmd(
+        SandboxSkills.github_install_cmd(
           %{"source" => "owner/repo", "ref" => "abc123", "name" => "my-skill"},
           "claude"
         )
@@ -39,7 +39,7 @@ defmodule Fountain.SpriteSkillsTest do
 
     test "shell-unsafe ref raises instead of reaching the command" do
       assert_raise ArgumentError, fn ->
-        SpriteSkills.github_install_cmd(
+        SandboxSkills.github_install_cmd(
           %{"source" => "owner/repo", "ref" => "main; rm -rf /"},
           "claude"
         )
@@ -48,7 +48,7 @@ defmodule Fountain.SpriteSkillsTest do
 
     test "shell-unsafe source raises" do
       assert_raise ArgumentError, fn ->
-        SpriteSkills.github_install_cmd(%{"source" => "owner/repo$(whoami)"}, "claude")
+        SandboxSkills.github_install_cmd(%{"source" => "owner/repo$(whoami)"}, "claude")
       end
     end
   end

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -75,7 +75,7 @@ defmodule Fountain.ConversationServerCase do
       {:error, {:unavailable, :spawn_not_stubbed}}
     end)
 
-    Mimic.stub(Fountain.SpriteSkills, :mount, fn _handle, _runtime, _skills -> :ok end)
+    Mimic.stub(Fountain.SandboxSkills, :mount, fn _handle, _runtime, _skills -> :ok end)
 
     Mimic.stub(Fountain.Conversations.Provisioning, :write_env_file, fn _s, _e -> :ok end)
 

--- a/apps/fountain/test/support/fake_runtime.ex
+++ b/apps/fountain/test/support/fake_runtime.ex
@@ -36,7 +36,7 @@ defmodule Fountain.Test.FakeRuntime do
   def write_config(_sprite, _agent), do: report(:write_config)
 
   @impl true
-  def prepare_sprite(_sprite, _agent, _sprite_env), do: report(:prepare_sprite)
+  def prepare_sandbox(_sprite, _agent, _sprite_env), do: report(:prepare_sandbox)
 
   @impl true
   def skills_root, do: "/home/sprite/.fake/skills"
@@ -47,7 +47,7 @@ end
 
 defmodule Fountain.Test.FailingRuntime do
   @moduledoc """
-  A runtime whose `prepare_sprite/3` fails, for exercising the provisioning
+  A runtime whose `prepare_sandbox/3` fails, for exercising the provisioning
   failure path without having to make a Sprites call fail.
   """
 
@@ -63,7 +63,7 @@ defmodule Fountain.Test.FailingRuntime do
   def write_config(_sprite, _agent), do: :ok
 
   @impl true
-  def prepare_sprite(_sprite, _agent, _sprite_env), do: {:error, :prepare_failed}
+  def prepare_sandbox(_sprite, _agent, _sprite_env), do: {:error, :prepare_failed}
 
   @impl true
   def skills_root, do: "/home/sprite/.fake/skills"

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -32,7 +32,7 @@ Mimic.copy(Stripe.Invoice)
 
 Mimic.copy(Fountain.Conversations.ConversationServer)
 Mimic.copy(Fountain.Conversations.Provisioning)
-Mimic.copy(Fountain.SpriteSkills)
+Mimic.copy(Fountain.SandboxSkills)
 Mimic.copy(Fountain.Accounts)
 Mimic.copy(Fountain.Audit)
 Mimic.copy(Fountain.Crypto)

--- a/coverage.exs
+++ b/coverage.exs
@@ -25,7 +25,7 @@
     Fountain.Mailer,
     Fountain.Release,
     Fountain.Telemetry,
-    Fountain.SpriteSkills,
+    Fountain.SandboxSkills,
     Fountain.Conversations.Provisioning,
     Fountain.Conversations.Rehydrator,
     ~r/^Fountain\.Runtimes\./,

--- a/decisions/0016-governance-as-an-acp-proxy.md
+++ b/decisions/0016-governance-as-an-acp-proxy.md
@@ -218,6 +218,14 @@ than exempted quietly.
 
 ### 5. The sandbox behaviour is defined by a conformance bar, not a cloud list
 
+> **Status note (2026-08-14):** built, with one deviation.
+> [0018](0018-sandbox-provider-abstraction.md) supersedes this section's
+> two-implementation cap: `Fountain.Sandbox` + its conformance suite exist,
+> and the second and third implementations are hosted providers (E2B,
+> Daytona) rather than the BYO-Kubernetes runner sketched here — proving
+> the seam against differently-shaped backends took priority over waiting
+> for a named customer. The conformance bar itself is unchanged.
+
 `Fountain.SpritesClient` is the single sandbox implementation, reached through
 a platform-shared token ([0005](0005-platform-shared-sprites-token.md)).
 "Whatever cloud" must not become a matrix of providers — that is the entire

--- a/decisions/0018-sandbox-provider-abstraction.md
+++ b/decisions/0018-sandbox-provider-abstraction.md
@@ -1,0 +1,148 @@
+# 0018 — Pluggable sandbox backends: the `Fountain.Sandbox` abstraction
+
+**Status:** Accepted (2026-08-14). Everything described here is built and
+merged (#676–#686); the one exception is called out explicitly in
+[Verification status](#verification-status).
+
+Amends [0005](0005-platform-shared-sprites-token.md) (one platform
+credential *per provider*), reaffirms
+[0017](0017-suspend-idle-sandboxes.md) with a capability-degradation rule,
+and supersedes the two-implementation cap in
+[0016 §5](0016-governance-as-an-acp-proxy.md).
+
+## Context
+
+Every conversation runs inside a sandbox, and until this campaign the
+`sprites-ex` SDK was called directly from ~15 modules — the test helper
+even documented the choice ("without requiring us to wrap sprites-ex in an
+adapter behaviour"). 0016 §5 sketched the intended seam — one
+`Fountain.Sandbox` behaviour with a conformance suite — but capped it at
+two implementations and gated the second on a named customer. The decision
+here is to build the seam now and prove it with **two additional hosted
+providers (E2B and Daytona)**, chosen over Modal (gRPC-only control plane —
+no clean path from Elixir) and raw Firecracker microVMs (a platform build,
+not an integration).
+
+## Decision
+
+### One behaviour, one facade, one error taxonomy
+
+`Fountain.Sandbox` is both the `@behaviour` adapters implement and the
+facade call sites use; nothing outside `lib/fountain/sandbox/` names a
+provider SDK or its error shapes. Handles and commands are provider-tagged
+structs whose `private` field is adapter-opaque (and excluded from
+`inspect` — the Sprites handle embeds the platform bearer token). Errors
+normalize into a closed taxonomy (`:not_found`, `{:rate_limited, _}`,
+`{:unavailable, _}`, `{:denied, _}`, `{:invalid, _}`, `{:provider, _, _}`)
+that `Fountain.Retry` classifies directly; the not-found/transient
+distinction is load-bearing on the wake path, where only a definitive
+not-found may give up a parked disk.
+
+The owner-message contract for streaming commands is normative:
+`{:stdout | :stderr, %{ref: ref}, bin}`, exactly one terminal frame
+(`{:exit, %{ref: ref}, code}` or `{:error, %{ref: ref}, reason}`), a
+deliberate close without an exit frame reads as exit 0, and **attach
+replays buffered output from byte zero** — the byte-skip arithmetic in
+reattach depends on it. `Fountain.SandboxConformanceCase` is the executable
+form of all of this; `Fountain.Sandbox.Fake` (a real in-memory adapter
+whose commands are actual processes) passes it in full and is the reference
+implementation for adapter authors.
+
+### Selection: instance default, per-agent override, sticky rows
+
+`SANDBOX_PROVIDER` picks the default for newly-created sandboxes; a
+provider is *enabled* by the presence of its credential plus a registered
+adapter, and an explicitly-chosen default without credentials refuses to
+boot. `agents.sandbox_provider` (nullable) overrides per agent, validated
+against enabled providers at save time and re-checked at conversation
+start. The resolved provider is stamped into `sandboxes.provider` at the
+two mint sites and **never re-resolved**: a parked sandbox wakes on the
+backend that holds its disk regardless of the instance default, and a row
+whose (non-default) provider lost its credentials refuses to wake
+retryably rather than being retired — retiring it would destroy the
+agent's memory.
+
+`sprite_name` keeps its name deliberately: it is the provider-scoped
+identity Fountain mints, it is public API surface, and historical
+audit/usage metadata keyed `"sprite_name"` is immutable.
+
+### Capability flags and the lifecycle degradation rule
+
+`capabilities/0` answers operational questions, most importantly
+`:suspend`: *can an idle sandbox park with its disk preserved at
+negligible cost?* Sprites advertises it implicitly (scale-to-zero; its
+`suspend/1` is a no-op), E2B (pause) and Daytona (stop) with real calls. A
+provider without it gets destroy-on-idle, priced exactly like the
+max-lifetime ceiling. `Lifecycle.idle_action/1` is the single place this
+decision lives, used by both the ConversationServer and the reaper.
+
+Two failure policies, deliberately asymmetric:
+
+- **suspend before the row flips; a failed suspend degrades to destroy** —
+  an unparked sandbox keeps billing, so cost control wins;
+- **resume before the row flips; a failed resume leaves the row
+  suspended**, failing retryably — the parked disk is the agent's memory,
+  so data protection wins.
+
+0017's "suspended rows are never aged out" stands on every provider: E2B
+retains paused snapshots indefinitely at storage-only cost, and Daytona
+auto-archives long-parked filesystems to object storage (still startable,
+slower) rather than expiring them.
+
+### Per-provider reaping
+
+The reaper's destroy/reconcile passes run per enabled provider with error
+isolation: one backend's listing failure does not stop another's destroys,
+rows on a provider whose listing failed (or whose credentials were pulled)
+are skipped and logged rather than destroyed, and untracked counts carry a
+provider tag. Usage-event metadata gains a `provider` key (the ee event
+vocabulary itself stays closed).
+
+### The two new adapters
+
+**E2B** — ids are server-assigned, so the minted name rides in sandbox
+metadata (create adopts an existing name; the reaper converges race
+duplicates). Every running sandbox has a TTL, so live commands heartbeat it
+and `autoPause: true` turns a missed heartbeat into a pause rather than a
+kill; operations that find the sandbox auto-paused resume it first. envd
+does not replay a reconnected process's output, so detachable spawns run
+under a journaling shim (`tee` to `/tmp/fountain/<tag>.*`) and attach
+replays via a `tail -c +1 -f` streamer with the real exit code read from a
+sentinel file.
+
+**Daytona** — the closest native match: name-addressed sandboxes, no TTL,
+`stop`/`start` preserving the disk, and a server-side journal whose log
+stream replays from byte zero natively. Stdin is a line-oriented FIFO with
+no EOF operation (`close_stdin` is a documented no-op — the ACP path never
+needs a mid-turn EOF).
+
+Both providers' egress control is genuinely default-deny (E2B
+`denyOut 0.0.0.0/0` + allowlist; Daytona `networkBlockAll` +
+`domainAllowList`), so the intent-level `NetworkPolicy{allow: [...]}` needs
+a fail-open translation only on Sprites, where it lives inside that
+adapter. Both get reference images (`images/e2b/`, `images/daytona/`)
+recreating the `sprite`-user layout the provisioning pipeline assumes, so
+no per-provider provisioning code exists.
+
+## Deviations from 0016 §5
+
+0016 capped the abstraction at two implementations (Sprites + a
+BYO-Kubernetes runner) and gated the second on a named customer. This ADR
+supersedes that cap: the second and third implementations are hosted
+providers, built now, because proving the seam against two differently-
+shaped backends is what keeps it honest — E2B exercises the no-native-name
+and TTL-treadmill paths, Daytona the native-replay path. The governance
+bar 0016 set (egress policy, no-long-lived-credential provisioning,
+exec + attach, reaper-drivable destruction) is exactly what the
+conformance suite pins.
+
+## Verification status
+
+Adapter logic is tested full-stack against stubbed HTTP (including E2B's
+Connect streaming end to end) and the conformance suite runs against the
+Fake and Sprites adapters. **Live smoke tests against real E2B and Daytona
+accounts have not run yet** — they need credentials, and E2B's Hobby tier
+caps continuous runtime below a long agent turn (Pro is effectively
+required). Until a live provision → turn → park → wake → terminate cycle
+has passed on each provider, treat the adapters as integration-complete
+but not production-proven.

--- a/docs/integrations/sprites-contract.md
+++ b/docs/integrations/sprites-contract.md
@@ -1,11 +1,13 @@
 # The Sprites contract
 
-Sprites is Fountain's one hard external dependency, and `SPRITES_BASE_URL` is
-a real seam: pointing it at something else means implementing everything on
-this page, and nothing less. This is the contract as actually consumed — every
-endpoint Fountain calls, the semantics it relies on, and the operational
-assumptions baked into the calling code. It exists so that evaluating a
-replacement backend is a reading exercise, not an archaeology project.
+This page documents the **Sprites adapter's** transport contract — every
+endpoint `Fountain.Sandbox.Sprites` calls, the semantics it relies on, and
+the operational assumptions baked in. The provider-neutral form of this
+contract is executable: the `Fountain.Sandbox` behaviour and its
+conformance suite (`Fountain.SandboxConformanceCase`), which the
+[E2B](e2b.md) and [Daytona](daytona.md) adapters also satisfy. Evaluating a
+new backend starts there; this page is the reference for what the original
+backend actually provides.
 
 Setup and cost model are in the [Sprites integration guide](sprites.md).
 Transport summary: REST over HTTPS with `Authorization: Bearer <token>`, one

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -10,12 +10,20 @@ is a different thing, and this page assumes you want an instance that stays up.
 | | |
 |---|---|
 | **Postgres 16+** | The compose file below runs one for you |
-| **A Sprites token** | Fountain provisions sandboxes through [sprites.dev](https://sprites.dev). The app boots without one, but every conversation fails |
+| **A sandbox provider credential** | [sprites.dev](https://sprites.dev) by default; [E2B](integrations/e2b.md) and [Daytona](integrations/daytona.md) are alternatives. The app boots without one, but every conversation fails |
 | **A mail provider** | Resend or any SMTP server. Optional — see [Email](#email) |
 
-Sprites is currently the only sandbox backend, and it is a hosted service, so a
-Fountain instance is not fully self-contained. `SPRITES_BASE_URL` repoints the
-API endpoint if you have a compatible one; there is no bundled alternative.
+Sandboxes run on one of three backends, all hosted services — a Fountain
+instance is not fully self-contained (self-hosted Daytona comes closest):
+
+| Provider | Enabled by | Idle behavior | Notes |
+|---|---|---|---|
+| **Sprites** (default) | `SPRITES_TOKEN` | Parks — scales to zero on its own | The reference backend |
+| **E2B** | `E2B_API_KEY` | Parks — explicit pause (filesystem + memory snapshot) | Needs a template built from `images/e2b/`; see [E2B](integrations/e2b.md) |
+| **Daytona** | `DAYTONA_API_KEY` | Parks — explicit stop (disk preserved; archives when long-parked) | Self-hostable via `DAYTONA_API_URL`; see [Daytona](integrations/daytona.md) |
+
+`SANDBOX_PROVIDER` picks the default for new sandboxes; an agent can pin a
+provider, and existing sandboxes always stay where they were created.
 
 For what each piece of the system does and what breaks when a dependency is
 down, see [Architecture](architecture.md).
@@ -351,7 +359,8 @@ including commercially.
 
 Being straight about what self-hosting does not yet include:
 
-- **Sprites is a hosted dependency** — `SPRITES_BASE_URL` can repoint it, but
-  there is no self-hostable sandbox backend to point it at. What one would
-  have to implement is written down in
+- **Sandbox backends are hosted dependencies** — Sprites, E2B and Daytona
+  are all services (self-hosted Daytona narrows this). The contract a new
+  backend must satisfy is executable — `Fountain.Sandbox` plus its
+  conformance suite — and written down in
   [the Sprites contract](integrations/sprites-contract.md).

--- a/k8s/prometheusrule.yaml
+++ b/k8s/prometheusrule.yaml
@@ -469,7 +469,7 @@ spec:
 
     # ── Sprite reaper (#405) ──────────────────────────────────────────────
     #
-    # SandboxReaper reconciles the sandboxes table against sprites.dev
+    # SandboxReaper reconciles the sandboxes table against each sandbox provider
     # hourly (crontab :07). Its third pass counts sprites running with no
     # sandbox row and deliberately never destroys them — so its entire
     # output is a gauge someone must be looking at, plus these alerts.
@@ -477,8 +477,8 @@ spec:
       interval: 60s
       rules:
         - alert: FountainUntrackedSprites
-          # fountain_reaper_untracked_count is the LEVEL of sprites alive at
-          # sprites.dev with no live sandbox row, re-measured every run.
+          # fountain_reaper_untracked_count is the LEVEL of sandboxes alive at
+          # a provider with no live sandbox row, re-measured every run.
           # Sustained non-zero is leaked money, not an outage — hence
           # warning, not critical. 2h means at least two consecutive hourly
           # runs both saw leaks, which filters the legitimate transients the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ nav:
       - Overview: integrations/index.md
       - Sprites: integrations/sprites.md
       - The Sprites contract: integrations/sprites-contract.md
+      - E2B: integrations/e2b.md
+      - Daytona: integrations/daytona.md
       - GitHub OAuth: integrations/github-oauth.md
       - Stripe: integrations/stripe.md
       - Sentry: integrations/sentry.md


### PR DESCRIPTION
## What

The closing step of the pluggable-sandbox-backend campaign (#676–#686).

- **`decisions/0018-sandbox-provider-abstraction.md`** records the whole design: behaviour/facade/taxonomy, sticky per-row providers, the `:suspend` capability semantics with the deliberate failure asymmetry (suspend failure degrades to destroy — cost wins; resume failure leaves the row parked — data wins), per-provider reaping, the keep-`sprite_name` decision, and how E2B and Daytona map onto the contract. It amends 0005 (one platform credential *per provider*), reaffirms 0017 (archive as the parked-cost valve), and supersedes 0016 §5's two-implementation cap (0016 carries a status note). Per the repo's ADR honesty rule, the verification section states plainly that **live smoke tests against real E2B/Daytona accounts have not run yet**.
- **Docs**: self-hosting gains the provider matrix and drops the Sprites-is-the-only-backend claims; the Sprites contract page is reframed as the Sprites *adapter's* transport contract, pointing at `Fountain.Sandbox` + the conformance suite as the executable form; mkdocs nav picks up the E2B/Daytona pages; the prometheusrule copy stops assuming sprites.dev; the changelog documents the campaign under `[Unreleased]`.
- **Naming sweep**: `Fountain.SpriteSkills` → `Fountain.SandboxSkills`, and the `Runtimes` `prepare_sprite/3` callback → `prepare_sandbox/3` — provider-neutral modules stop carrying one provider's noun. `sprite_name` (column, API field, historical metadata) deliberately keeps its name, recorded in the ADR.

## Testing

`mix precommit` green (2734 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)