### PR TITLE
docs: two moduledoc stragglers stop naming the Sprites SDK

### DIFF
--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -99,7 +99,8 @@ defmodule Fountain.Quotas do
   Returns `:ok`, or `{:error, {:sandbox_quota_exceeded, %{count: n, limit: n}}}`.
 
   Call this immediately before creating a sandbox row — every row precedes a
-  `Sprites.create/2`, so guarding row creation guards sprite creation.
+  `Fountain.Sandbox.create/3`, so guarding row creation guards sandbox
+  creation at the provider.
   """
   @spec check_sandbox_quota(binary(), keyword()) ::
           :ok

--- a/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
@@ -5,7 +5,7 @@ defmodule Fountain.Workers.SandboxReaper do
   ## What leaks, and how
 
   Both destroy call sites in `ConversationServer` discard the result —
-  `_ = Sprites.destroy(sprite)` — and then mark the row `terminated` or
+  `_ = Fountain.Sandbox.destroy(handle)` — and then mark the row `terminated` or
   `failed` regardless. So any destroy that fails for a transient reason leaves a
   sprite alive with a database row that says it is gone, and nothing ever looks
   again. This does not need a hard BEAM crash; the ordinary path is enough.


### PR DESCRIPTION
Follow-up to #687: the `Quotas` and `SandboxReaper` moduledocs still described their neighbors with pre-#679 SDK call shapes (`Sprites.create/2`, `Sprites.destroy/1`); the seam grep only checked code, not prose. Comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)