### PR TITLE
fix: Daytona adapter corrections from the first live smoke runs

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -75,7 +75,7 @@ FOUNTAIN_IMAGE_TAG=v0.8.1
 # E2B_TEMPLATE=base
 # DAYTONA_API_KEY=
 # DAYTONA_API_URL=https://app.daytona.io/api
-# DAYTONA_SNAPSHOT=daytonaio/sandbox:latest
+# DAYTONA_SNAPSHOT=fountain
 
 # Extra origins allowed to open a LiveView websocket, comma-separated. Your own
 # PUBLIC_URL host is always allowed.

--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,7 @@ SPRITES_TOKEN=
 # Daytona (daytona.io) — enables the daytona provider when set.
 # DAYTONA_API_KEY=
 # DAYTONA_API_URL=https://app.daytona.io/api
-# DAYTONA_SNAPSHOT=daytonaio/sandbox:latest
+# DAYTONA_SNAPSHOT=fountain
 
 # Sandbox lifetime bounds: reclaim after this long idle, and an absolute age
 # ceiling. 0 disables a bound; the conversation always stays resumable.

--- a/apps/fountain/lib/fountain/sandbox/daytona.ex
+++ b/apps/fountain/lib/fountain/sandbox/daytona.ex
@@ -59,13 +59,15 @@ defmodule Fountain.Sandbox.Daytona do
       {:ok, _info} ->
         {:ok, build_handle(name)}
 
-      # The name already exists — adopt it, exactly like the 409 rule on
-      # Sprites. Daytona's conflict shape is verified permissive here: any
-      # 4xx where a subsequent get succeeds is an adoption.
-      {:error, {:api_error, status, _body}} when status in [400, 409] ->
+      # A 4xx where a follow-up get finds the sandbox is a name conflict —
+      # adopt it, exactly like the 409 rule on Sprites. When the get finds
+      # nothing, the create failed for a real reason (e.g. an unregistered
+      # snapshot answers 400) and THAT error must surface, not the probe's
+      # not-found.
+      {:error, {:api_error, status, _body} = create_error} when status in [400, 409] ->
         case Api.get_sandbox(name) do
           {:ok, _info} -> {:ok, build_handle(name)}
-          {:error, reason} -> {:error, Errors.normalize(reason)}
+          {:error, _probe_miss} -> {:error, Errors.normalize(create_error)}
         end
 
       {:error, reason} ->
@@ -105,8 +107,18 @@ defmodule Fountain.Sandbox.Daytona do
 
   @impl true
   def resume(%Handle{name: name} = handle) do
-    with {:ok, _url} <- ensure_started(name) do
-      {:ok, handle}
+    case ensure_started(name) do
+      {:ok, _url} ->
+        {:ok, handle}
+
+      # `start` answers 409 while the sandbox is still mid-transition
+      # (`stopping`/`archiving`); that is weather, not a verdict — the wake
+      # path retries transient errors.
+      {:error, {:invalid, {:http, 409, body}}} ->
+        {:error, {:unavailable, {:http, 409, body}}}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -155,13 +167,65 @@ defmodule Fountain.Sandbox.Daytona do
 
   defp shell_quote(s), do: "'" <> String.replace(to_string(s), "'", "'\\''") <> "'"
 
+  # Daytona's per-command stdin FIFO delivers EOF after every input POST —
+  # measured live: one write ended a `while read` loop — so a command that
+  # needs a long-lived stdin (the ACP turn) reads from a `tail -f`-fed file
+  # instead. Writes append to the file via one-shot execs; killing the tail
+  # is a REAL stdin EOF. The tail orphaned by a command that exits on its
+  # own lingers idle until the sandbox stops — harmless, and the price of
+  # a working stdin.
+  # POSIX sh only — session commands do not run under bash, so no process
+  # substitution: the tail feeds a private FIFO the command reads as stdin,
+  # and killing the tail (close_stdin) EOFs it. The daemon's command record
+  # carries no exit code (measured live), so the shim writes it to a
+  # sentinel file the LogStream polls — the same pattern as the E2B
+  # journaling shim.
+  defp stdin_shim(tag, command) do
+    base = "/tmp/fountain/#{tag}"
+
+    """
+    mkdir -p /tmp/fountain
+    rm -f #{base}.p #{base}.code
+    mkfifo #{base}.p
+    : > #{base}.in
+    tail -c +1 -f #{base}.in > #{base}.p &
+    FOUNTAIN_TAIL=$!
+    echo $FOUNTAIN_TAIL > #{base}.tailpid
+    #{command} < #{base}.p
+    FOUNTAIN_CODE=$?
+    kill $FOUNTAIN_TAIL 2>/dev/null
+    echo $FOUNTAIN_CODE > #{base}.code
+    exit $FOUNTAIN_CODE
+    """
+  end
+
+  defp plain_shim(tag, command) do
+    base = "/tmp/fountain/#{tag}"
+
+    """
+    mkdir -p /tmp/fountain
+    rm -f #{base}.code
+    #{command}
+    FOUNTAIN_CODE=$?
+    echo $FOUNTAIN_CODE > #{base}.code
+    exit $FOUNTAIN_CODE
+    """
+  end
+
+  defp exit_file(session_id), do: "/tmp/fountain/#{session_id}.code"
+
   @impl true
   def spawn(%Handle{name: name}, cmd, args, opts) do
     with {:ok, url} <- ensure_started(name) do
       tag = "fountain-#{System.unique_integer([:positive])}"
       ref = make_ref()
       owner = Keyword.get(opts, :owner, self())
-      command = render_command(cmd, args, opts)
+      rendered = render_command(cmd, args, opts)
+
+      command =
+        if Keyword.get(opts, :stdin, false),
+          do: stdin_shim(tag, rendered),
+          else: plain_shim(tag, rendered)
 
       with :ok <- Toolbox.create_session(url, tag) |> normalize_ok(),
            {:ok, command_id} <- exec_async(url, tag, command),
@@ -170,6 +234,7 @@ defmodule Fountain.Sandbox.Daytona do
                toolbox_url: url,
                session_id: tag,
                command_id: command_id,
+               exit_file: exit_file(tag),
                ref: ref,
                owner: owner
              ) do
@@ -192,25 +257,43 @@ defmodule Fountain.Sandbox.Daytona do
 
   @impl true
   def write_stdin(%Command{provider: :daytona, private: private}, data) do
-    case Toolbox.send_input(private.toolbox_url, private.session_id, private.command_id, data) do
-      :ok ->
-        :ok
+    # One round-trip that appends only while the command lives: the shim's
+    # exit sentinel is the daemon-independent word on liveness (the command
+    # record carries no exit code), and writing after exit must be the #603
+    # error, not a silent append nobody reads.
+    encoded = Base.encode64(IO.iodata_to_binary(data))
+    base = "/tmp/fountain/#{private.session_id}"
 
-      # The daemon refuses input to a finished command; that is the #603
-      # shape, not a transport problem.
-      {:error, {:api_error, status, _body}} when status in [400, 404, 409, 410] ->
-        {:error, :command_exited}
+    command =
+      "if [ -f #{base}.code ]; then echo FOUNTAIN_EXITED; " <>
+        "else printf %s '#{encoded}' | base64 -d >> #{base}.in; fi"
+
+    case Toolbox.execute(private.toolbox_url, command, timeout: 30_000) do
+      {:ok, out, 0} ->
+        if String.contains?(out, "FOUNTAIN_EXITED"), do: {:error, :command_exited}, else: :ok
+
+      {:ok, out, code} ->
+        {:error, {:write_failed, {:stdin_append_exit, code, out}}}
 
       {:error, reason} ->
         {:error, {:write_failed, Errors.normalize(reason)}}
     end
   end
 
-  # Daytona's FIFO has no EOF operation. The ACP path never needs a mid-turn
-  # EOF (stdin deliberately stays open), and one-shot stdin consumers go
-  # through exec/4 with a pipe instead.
+  # Killing the tail that feeds the stdin file closes the command's stdin —
+  # a real EOF, unlike the daemon FIFO (which has no close operation). The
+  # tail's pid was written by the shim; `kill` is a builtin, so this works
+  # on images without procps.
   @impl true
-  def close_stdin(%Command{provider: :daytona}), do: :ok
+  def close_stdin(%Command{provider: :daytona, private: private}) do
+    base = "/tmp/fountain/#{private.session_id}"
+    command = "kill $(cat #{base}.tailpid) 2>/dev/null; true"
+
+    case Toolbox.execute(private.toolbox_url, command, timeout: 30_000) do
+      {:ok, _out, _code} -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
 
   @impl true
   def stop_command(%Command{provider: :daytona, private: %{pid: pid}}) do
@@ -253,6 +336,7 @@ defmodule Fountain.Sandbox.Daytona do
                toolbox_url: url,
                session_id: session_id,
                command_id: command_id,
+               exit_file: exit_file(session_id),
                ref: ref,
                owner: owner
              ) do

--- a/apps/fountain/lib/fountain/sandbox/daytona/api.ex
+++ b/apps/fountain/lib/fountain/sandbox/daytona/api.ex
@@ -36,20 +36,29 @@ defmodule Fountain.Sandbox.Daytona.Api do
       raise "DAYTONA_API_KEY is not set — cannot talk to daytona.io"
   end
 
-  @doc "The snapshot (image) new sandboxes are created from."
+  @doc """
+  The snapshot (image) new sandboxes are created from, or nil for the
+  organization's default. A named snapshot must be registered with the org
+  (the API rejects unknown ones with a 400).
+  """
   def snapshot do
-    Application.get_env(:fountain, :daytona_snapshot, "daytonaio/sandbox:latest")
+    Application.get_env(:fountain, :daytona_snapshot)
   end
 
   def create_sandbox(name) do
-    body = %{
+    base = %{
       name: name,
-      snapshot: snapshot(),
       labels: %{fountain: "1"},
       autoStopInterval: 0,
       autoArchiveInterval: @auto_archive_minutes,
       ttlMinutes: 0
     }
+
+    body =
+      case snapshot() do
+        nil -> base
+        snapshot -> Map.put(base, :snapshot, snapshot)
+      end
 
     case Req.post(req(), url: "/sandbox", json: body) do
       {:ok, %{status: status, body: body}} when status in 200..299 -> {:ok, body}
@@ -139,7 +148,9 @@ defmodule Fountain.Sandbox.Daytona.Api do
   translation.
   """
   def set_network(name, allow_domains) do
-    body = %{networkBlockAll: true, domainAllowList: allow_domains}
+    # The API takes the allowlist as a comma-separated string (measured
+    # live: an array answers 400 "domainAllowList must be a string").
+    body = %{networkBlockAll: true, domainAllowList: Enum.join(allow_domains, ",")}
 
     case Req.post(req(), url: "/sandbox/#{name}/network-settings", json: body) do
       {:ok, %{status: status}} when status in 200..299 -> :ok
@@ -148,21 +159,31 @@ defmodule Fountain.Sandbox.Daytona.Api do
     end
   end
 
-  @doc "The per-sandbox toolbox proxy base URL, off the sandbox DTO."
+  @doc """
+  The per-sandbox toolbox base URL: the account's proxy URL with the
+  sandbox's server-assigned **id** appended (`{proxy}/{id}` — the DTO's
+  `toolboxProxyUrl` alone carries no sandbox identity; the official SDK
+  builds exactly this base).
+  """
   def toolbox_url(name) do
-    with {:ok, info} <- get_sandbox(name) do
-      case info["toolboxProxyUrl"] do
-        url when is_binary(url) and url != "" ->
-          {:ok, url}
+    with {:ok, info} <- get_sandbox(name),
+         {:ok, proxy} <- proxy_url(info) do
+      {:ok, String.trim_trailing(proxy, "/") <> "/" <> info["id"]}
+    end
+  end
 
-        _ ->
-          case Req.get(req(), url: "/sandbox/#{name}/toolbox-proxy-url") do
-            {:ok, %{status: 200, body: %{"url" => url}}} -> {:ok, url}
-            {:ok, %{status: 200, body: url}} when is_binary(url) -> {:ok, url}
-            {:ok, %{status: status, body: body}} -> {:error, {:api_error, status, body}}
-            {:error, reason} -> {:error, reason}
-          end
-      end
+  defp proxy_url(info) do
+    case info["toolboxProxyUrl"] do
+      url when is_binary(url) and url != "" ->
+        {:ok, url}
+
+      _ ->
+        case Req.get(req(), url: "/sandbox/#{info["id"]}/toolbox-proxy-url") do
+          {:ok, %{status: 200, body: %{"url" => url}}} -> {:ok, url}
+          {:ok, %{status: 200, body: url}} when is_binary(url) -> {:ok, url}
+          {:ok, %{status: status, body: body}} -> {:error, {:api_error, status, body}}
+          {:error, reason} -> {:error, reason}
+        end
     end
   end
 end

--- a/apps/fountain/lib/fountain/sandbox/daytona/log_stream.ex
+++ b/apps/fountain/lib/fountain/sandbox/daytona/log_stream.ex
@@ -29,6 +29,9 @@ defmodule Fountain.Sandbox.Daytona.LogStream do
   @stderr_marker <<2, 2, 2>>
   @exit_poll_ms 300
   @exit_poll_attempts 10
+  # The follow stream can outlive the command (the daemon does not always
+  # close it on exit), so liveness comes from polling the command record.
+  @exit_watch_ms 2_000
 
   # Mint.WebSocket.new/4's success depends on connection privates set by
   # upgrade/5 (the websocket key nonce), which dialyzer cannot see through
@@ -46,12 +49,22 @@ defmodule Fountain.Sandbox.Daytona.LogStream do
       command_id: Keyword.fetch!(opts, :command_id),
       ref: Keyword.fetch!(opts, :ref),
       owner: Keyword.fetch!(opts, :owner),
+      # The shim's exit sentinel — the daemon's command record carries no
+      # exit code, so this file is the source of truth for command end.
+      exit_file: Keyword.get(opts, :exit_file),
       conn: nil,
       websocket: nil,
       request_ref: nil,
       upgraded?: false,
       stream: :stdout,
       carry: <<>>,
+      # Total bytes ever delivered to the owner, per stream — never reset.
+      # The daemon closes follow streams while commands still run; each
+      # reconnect replays the journal from byte zero and skips exactly this
+      # many bytes, so the skip is cumulative across any number of drops.
+      delivered: %{stdout: 0, stderr: 0},
+      skip: %{stdout: 0, stderr: 0},
+      reconnects: 0,
       exited?: false
     }
 
@@ -70,6 +83,7 @@ defmodule Fountain.Sandbox.Daytona.LogStream do
 
     with {:ok, conn} <- Mint.HTTP.connect(http_scheme, uri.host, uri.port, protocols: [:http1]),
          {:ok, conn, ref} <- Mint.WebSocket.upgrade(ws_scheme, conn, path, headers) do
+      Process.send_after(self(), :poll_exit, @exit_watch_ms)
       {:noreply, %{state | conn: conn, request_ref: ref}}
     else
       {:error, reason} -> fail(state, reason)
@@ -78,6 +92,19 @@ defmodule Fountain.Sandbox.Daytona.LogStream do
   end
 
   @impl true
+  def handle_info(:poll_exit, %{exited?: true} = state), do: {:stop, :normal, state}
+
+  def handle_info(:poll_exit, state) do
+    case check_exit(state) do
+      {:ok, code} ->
+        drain_and_exit(state, code)
+
+      _still_running_or_transient ->
+        Process.send_after(self(), :poll_exit, @exit_watch_ms)
+        {:noreply, state}
+    end
+  end
+
   def handle_info(message, %{conn: conn} = state) when conn != nil do
     case Mint.WebSocket.stream(conn, message) do
       {:ok, conn, responses} ->
@@ -98,12 +125,14 @@ defmodule Fountain.Sandbox.Daytona.LogStream do
       Enum.reduce_while(responses, state, fn response, acc ->
         case handle_response(response, acc) do
           {:cont, acc} -> {:cont, acc}
-          {:halt, acc} -> {:halt, {:done, acc}}
+          {:halt, other} -> {:halt, {:done, other}}
         end
       end)
 
     case result do
-      {:done, state} -> {:stop, :normal, state}
+      # A finish/reconnect verdict rides through as the gen_server return.
+      {:done, {:stop, _, _} = stop} -> stop
+      {:done, {:noreply, _, _} = continue} -> continue
       state -> {:noreply, state}
     end
   end
@@ -113,7 +142,7 @@ defmodule Fountain.Sandbox.Daytona.LogStream do
     if status == 101 do
       {:cont, state}
     else
-      {:halt, elem(fail(state, {:upgrade_failed, status}), 2)}
+      {:halt, fail(state, {:upgrade_failed, status})}
     end
   end
 
@@ -123,7 +152,7 @@ defmodule Fountain.Sandbox.Daytona.LogStream do
         {:cont, %{state | conn: conn, websocket: websocket, upgraded?: true}}
 
       {:error, _conn, reason} ->
-        {:halt, elem(fail(state, reason), 2)}
+        {:halt, fail(state, reason)}
     end
   end
 
@@ -131,75 +160,189 @@ defmodule Fountain.Sandbox.Daytona.LogStream do
     case Mint.WebSocket.decode(state.websocket, data) do
       {:ok, websocket, frames} ->
         state = Enum.reduce(frames, %{state | websocket: websocket}, &handle_frame/2)
-        if state.exited?, do: {:halt, state}, else: {:cont, state}
+        if state.exited?, do: {:halt, {:stop, :normal, state}}, else: {:cont, state}
 
       {:error, _websocket, reason} ->
-        {:halt, elem(finish_or_fail(state, reason), 2)}
+        {:halt, finish_or_fail(state, reason)}
     end
   end
 
   defp handle_response({:done, ref}, %{request_ref: ref} = state) do
-    {:halt, elem(finish(state), 2)}
+    {:halt, finish(state)}
   end
 
   defp handle_response(_response, state), do: {:cont, state}
 
   defp handle_frame({type, data}, state) when type in [:text, :binary] do
     {segments, stream, carry} = demux(state.carry <> data, state.stream)
-
-    Enum.each(segments, fn {seg_stream, bytes} ->
-      send(state.owner, {seg_stream, %{ref: state.ref}, bytes})
-    end)
-
+    state = Enum.reduce(segments, state, &emit_segment/2)
     %{state | stream: stream, carry: carry}
   end
 
   defp handle_frame({:close, _code, _reason}, state) do
-    {:stop, :normal, state} = finish(state)
+    # The :done (or transport-close) that follows resolves the stream via
+    # finish/1; nothing to do at the frame level.
     state
   end
 
   defp handle_frame(_frame, state), do: state
 
-  # ── termination ────────────────────────────────────────────────────────────
+  # ── segment emission with replay skipping ──────────────────────────────────
 
-  # Clean end of stream: the journal is drained and the command exited.
-  # The exit code lives on the command record, written just before the
-  # daemon closes the stream — poll briefly for the race where the close
-  # beats the write.
+  defp emit_segment({stream, bytes}, state) do
+    to_skip = state.skip[stream]
+    size = byte_size(bytes)
+
+    cond do
+      to_skip >= size ->
+        %{state | skip: Map.update!(state.skip, stream, &(&1 - size))}
+
+      to_skip > 0 ->
+        fresh = binary_part(bytes, to_skip, size - to_skip)
+        send(state.owner, {stream, %{ref: state.ref}, fresh})
+
+        %{
+          state
+          | skip: Map.put(state.skip, stream, 0),
+            delivered: Map.update!(state.delivered, stream, &(&1 + byte_size(fresh)))
+        }
+
+      true ->
+        send(state.owner, {stream, %{ref: state.ref}, bytes})
+        %{state | delivered: Map.update!(state.delivered, stream, &(&1 + size))}
+    end
+  end
+
+  # ── termination and reconnection ───────────────────────────────────────────
+
+  # The stream ended. If the command exited, report its real code; if it is
+  # still running — the daemon routinely closes follow streams mid-command —
+  # reconnect and skip the bytes already delivered. Never a fabricated
+  # exit 0: a close while the command runs is not a verdict.
   defp finish(%{exited?: true} = state), do: {:stop, :normal, state}
 
   defp finish(state) do
-    send(state.owner, {:exit, %{ref: state.ref}, poll_exit_code(state, @exit_poll_attempts)})
-    {:stop, :normal, %{state | exited?: true}}
+    case poll_exit_code(state, @exit_poll_attempts) do
+      {:ok, code} ->
+        send(state.owner, {:exit, %{ref: state.ref}, code})
+        {:stop, :normal, %{state | exited?: true}}
+
+      :still_running ->
+        reconnect(state)
+    end
   end
 
-  defp poll_exit_code(_state, 0), do: 0
+  defp reconnect(state) do
+    Process.sleep(min(500 * (state.reconnects + 1), 2_000))
+
+    state = %{
+      state
+      | conn: nil,
+        websocket: nil,
+        request_ref: nil,
+        upgraded?: false,
+        stream: :stdout,
+        carry: <<>>,
+        skip: state.delivered,
+        reconnects: state.reconnects + 1
+    }
+
+    {:noreply, state, {:continue, :connect}}
+  end
+
+  defp poll_exit_code(_state, 0), do: :still_running
 
   defp poll_exit_code(state, attempts) do
-    case Toolbox.get_command(state.toolbox_url, state.session_id, state.command_id) do
-      {:ok, %{"exitCode" => code}} when is_integer(code) ->
-        code
+    case check_exit(state) do
+      {:ok, code} ->
+        {:ok, code}
 
-      _ ->
+      :still_running ->
+        :still_running
+
+      :transient ->
         Process.sleep(@exit_poll_ms)
         poll_exit_code(state, attempts - 1)
+    end
+  end
+
+  # The command record first (a daemon that publishes exitCode wins), then
+  # the shim's sentinel file via a one-shot exec.
+  defp check_exit(state) do
+    case Toolbox.get_command(state.toolbox_url, state.session_id, state.command_id) do
+      {:ok, %{"exitCode" => code}} when is_integer(code) ->
+        {:ok, code}
+
+      {:ok, _no_exit_code} ->
+        check_exit_file(state)
+
+      {:error, :not_found} ->
+        check_exit_file(state)
+
+      {:error, _reason} ->
+        :transient
+    end
+  end
+
+  defp check_exit_file(%{exit_file: nil}), do: :still_running
+
+  defp check_exit_file(state) do
+    case Toolbox.execute(state.toolbox_url, "cat #{state.exit_file} 2>/dev/null", timeout: 15_000) do
+      {:ok, out, 0} ->
+        case Integer.parse(String.trim(out)) do
+          {code, _} -> {:ok, code}
+          :error -> :still_running
+        end
+
+      {:ok, _out, _nonzero} ->
+        :still_running
+
+      {:error, _reason} ->
+        :transient
     end
   end
 
   defp finish_or_fail(%{exited?: true} = state, _reason), do: {:stop, :normal, state}
 
   defp finish_or_fail(state, reason) do
-    # The transport dropped. If the command has in fact exited, report the
-    # real code; otherwise surface the failure — never a silent exit 0.
-    case Toolbox.get_command(state.toolbox_url, state.session_id, state.command_id) do
-      {:ok, %{"exitCode" => code}} when is_integer(code) ->
-        send(state.owner, {:exit, %{ref: state.ref}, code})
+    # The transport dropped. A real exit reports its code; a command still
+    # running gets a reconnect; only a command the daemon cannot account for
+    # surfaces the transport failure.
+    case check_exit(state) do
+      {:ok, code} ->
+        drain_and_exit(state, code)
 
-      _ ->
+      :still_running ->
+        reconnect(state)
+
+      :transient ->
         send(state.owner, {:error, %{ref: state.ref}, reason})
+        {:stop, :normal, %{state | exited?: true}}
     end
+  end
 
+  # The command exited but the follow stream may not have delivered (or may
+  # never deliver) the tail. Fetch the full journal, emit whatever the owner
+  # has not seen — the cumulative `delivered` skip makes this exact — then
+  # deliver the terminal frame.
+  defp drain_and_exit(state, code) do
+    state =
+      case Toolbox.get_logs(state.toolbox_url, state.session_id, state.command_id) do
+        {:ok, body} when is_binary(body) ->
+          {segments, _stream, _carry} = demux(body, :stdout)
+          Enum.reduce(segments, %{state | skip: state.delivered, carry: <<>>}, &emit_segment/2)
+
+        {:ok, %{} = body} ->
+          # Older daemons answer JSON with per-stream strings.
+          state = %{state | skip: state.delivered}
+          state = emit_segment({:stdout, body["stdout"] || ""}, state)
+          emit_segment({:stderr, body["stderr"] || ""}, state)
+
+        {:error, _reason} ->
+          state
+      end
+
+    send(state.owner, {:exit, %{ref: state.ref}, code})
     {:stop, :normal, %{state | exited?: true}}
   end
 

--- a/apps/fountain/lib/fountain/sandbox/daytona/toolbox.ex
+++ b/apps/fountain/lib/fountain/sandbox/daytona/toolbox.ex
@@ -102,6 +102,20 @@ defmodule Fountain.Sandbox.Daytona.Toolbox do
     end
   end
 
+  @doc """
+  The command's full journal so far (no follow) — raw bytes with the same
+  channel markers the websocket carries, or a JSON map on older daemons.
+  """
+  def get_logs(toolbox_url, session_id, command_id) do
+    url = "/process/session/#{session_id}/command/#{command_id}/logs"
+
+    case Req.get(req(toolbox_url), url: url) do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, %{status: status, body: body}} -> {:error, {:api_error, status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   @doc "The websocket URL that streams a command's journaled log from the start."
   def logs_ws_url(toolbox_url, session_id, command_id) do
     toolbox_url

--- a/apps/fountain/test/fountain/sandbox/daytona_test.exs
+++ b/apps/fountain/test/fountain/sandbox/daytona_test.exs
@@ -40,7 +40,12 @@ defmodule Fountain.Sandbox.DaytonaTest do
   defp handle, do: Adapter.build_handle(@name)
 
   defp sandbox_body(state) do
-    %{"name" => @name, "state" => state, "toolboxProxyUrl" => @toolbox}
+    %{
+      "id" => "sbx1",
+      "name" => @name,
+      "state" => state,
+      "toolboxProxyUrl" => "https://proxy.daytona.test/toolbox"
+    }
   end
 
   describe "create/2" do
@@ -64,6 +69,27 @@ defmodule Fountain.Sandbox.DaytonaTest do
       assert body["ttlMinutes"] == 0
       assert body["autoStopInterval"] == 0
       assert body["autoArchiveInterval"] > 0
+      # Unset snapshot means the organization's default image — the field
+      # must be absent, not a hardcoded name the org never registered.
+      refute Map.has_key?(body, "snapshot")
+    end
+
+    test "a create rejected outright surfaces its own error, not the probe's" do
+      # An unregistered snapshot answers 400; the follow-up get finds no
+      # sandbox, and the caller must see the 400, not :not_found.
+      Req.Test.stub(__MODULE__, fn conn ->
+        case {conn.method, conn.request_path} do
+          {"POST", "/api/sandbox"} ->
+            conn
+            |> Plug.Conn.put_status(400)
+            |> Req.Test.json(%{"message" => "Snapshot x not found"})
+
+          {"GET", "/api/sandbox/" <> @name} ->
+            conn |> Plug.Conn.put_status(404) |> Req.Test.json(%{})
+        end
+      end)
+
+      assert {:error, {:invalid, {:http, 400, %{"message" => _}}}} = Adapter.create(@name, [])
     end
 
     test "a conflicting create adopts when the follow-up get succeeds" do
@@ -255,7 +281,10 @@ defmodule Fountain.Sandbox.DaytonaTest do
                )
 
       assert command.private.command_id == "cmd-1"
-      assert_received {:exec_async, %{"runAsync" => true, "suppressInputEcho" => true}}
+      assert_received {:exec_async, %{"runAsync" => true, "suppressInputEcho" => true} = body}
+      # stdin: true wraps the command in the tail-fed stdin shim — the
+      # daemon's own FIFO EOFs after every single write (measured live).
+      assert body["command"] =~ "tail -c +1 -f /tmp/fountain/"
       assert_received {:log_stream_started, session_id, "cmd-1"}
       assert String.starts_with?(session_id, "fountain-")
     end
@@ -310,23 +339,61 @@ defmodule Fountain.Sandbox.DaytonaTest do
   end
 
   describe "stdin" do
-    test "input to a finished command is :command_exited, not a crash" do
-      Req.Test.stub(__MODULE__, fn conn ->
-        conn |> Plug.Conn.put_status(404) |> Req.Test.json(%{"error" => "completed"})
-      end)
-
-      command = %Command{
+    defp stdin_command do
+      %Command{
         provider: :daytona,
         ref: make_ref(),
         private: %{pid: self(), toolbox_url: @toolbox, session_id: "fountain-1", command_id: "c1"}
       }
-
-      assert {:error, :command_exited} = Adapter.write_stdin(command, "late\n")
     end
 
-    test "close_stdin is a documented no-op" do
-      command = %Command{provider: :daytona, ref: make_ref(), private: %{pid: self()}}
-      assert :ok = Adapter.close_stdin(command)
+    test "input to a finished command is :command_exited, not a crash" do
+      # The shim's exit sentinel exists -> the guarded append refuses.
+      Req.Test.stub(__MODULE__, fn conn ->
+        case {conn.method, conn.request_path} do
+          {"POST", "/toolbox/sbx1/process/execute"} ->
+            Req.Test.json(conn, %{"result" => "FOUNTAIN_EXITED\n", "exitCode" => 0})
+        end
+      end)
+
+      assert {:error, :command_exited} = Adapter.write_stdin(stdin_command(), "late\n")
+    end
+
+    test "input to a live command appends to the stdin file via a one-shot exec" do
+      test = self()
+
+      Req.Test.stub(__MODULE__, fn conn ->
+        case {conn.method, conn.request_path} do
+          {"POST", "/toolbox/sbx1/process/execute"} ->
+            {:ok, raw, conn} = Plug.Conn.read_body(conn)
+            send(test, {:append, Jason.decode!(raw)["command"]})
+            Req.Test.json(conn, %{"result" => "", "exitCode" => 0})
+        end
+      end)
+
+      assert :ok = Adapter.write_stdin(stdin_command(), "ping\n")
+      assert_received {:append, command}
+      assert command =~ "base64 -d >> /tmp/fountain/fountain-1.in"
+      # The append is guarded on the exit sentinel in the same round trip.
+      assert command =~ "fountain-1.code"
+    end
+
+    test "close_stdin kills the stdin tail — a real EOF" do
+      test = self()
+
+      Req.Test.stub(__MODULE__, fn conn ->
+        case {conn.method, conn.request_path} do
+          {"POST", "/toolbox/sbx1/process/execute"} ->
+            {:ok, raw, conn} = Plug.Conn.read_body(conn)
+            send(test, {:close, Jason.decode!(raw)["command"]})
+            Req.Test.json(conn, %{"result" => "", "exitCode" => 0})
+        end
+      end)
+
+      assert :ok = Adapter.close_stdin(stdin_command())
+      assert_received {:close, command}
+      assert command =~ "kill"
+      assert command =~ "/tmp/fountain/fountain-1.tailpid"
     end
   end
 
@@ -344,7 +411,7 @@ defmodule Fountain.Sandbox.DaytonaTest do
       end)
 
       assert :ok = Adapter.apply_network_policy(handle(), %NetworkPolicy{allow: []})
-      assert_received {:network, %{"networkBlockAll" => true, "domainAllowList" => []}}
+      assert_received {:network, %{"networkBlockAll" => true, "domainAllowList" => ""}}
     end
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -159,7 +159,7 @@ config :fountain, :e2b_template, e2b_template
 
 daytona_snapshot =
   case System.get_env("DAYTONA_SNAPSHOT") do
-    blank when blank in [nil, ""] -> "daytonaio/sandbox:latest"
+    blank when blank in [nil, ""] -> nil
     snapshot -> snapshot
   end
 

--- a/decisions/0018-sandbox-provider-abstraction.md
+++ b/decisions/0018-sandbox-provider-abstraction.md
@@ -140,9 +140,41 @@ conformance suite pins.
 
 Adapter logic is tested full-stack against stubbed HTTP (including E2B's
 Connect streaming end to end) and the conformance suite runs against the
-Fake and Sprites adapters. **Live smoke tests against real E2B and Daytona
-accounts have not run yet** — they need credentials, and E2B's Hobby tier
-caps continuous runtime below a long agent turn (Pro is effectively
-required). Until a live provision → turn → park → wake → terminate cycle
-has passed on each provider, treat the adapters as integration-complete
-but not production-proven.
+Fake and Sprites adapters.
+
+**Live smoke tests passed on real accounts (2026-08-14)** — full
+create → adopt → exec → streaming spawn with multi-write stdin →
+attach-with-replay-from-byte-zero → stdin EOF with real exit code →
+suspend → resume with the filesystem intact → destroy cycles on both
+providers, against the stock images (adapter wire protocols, not the
+agent-CLI templates). The E2B run also verified deny-all egress actually
+blocking and an allowlist opening exactly the listed host. What the live
+runs corrected in the adapters, kept here because each looks wrong
+without the context:
+
+- **Daytona publishes no exit code on session-command records** (measured
+  on daemon v0.204.0), and its follow-websocket both *closes while
+  commands still run* and *lingers after they exit*. The adapter
+  therefore owns command endings itself: spawned commands run under a
+  shim that writes an exit-sentinel file, and the LogStream reconnects on
+  close-while-running with a cumulative delivered-bytes skip (the
+  journal's replay-from-start makes that exact) and polls the sentinel
+  for the real exit.
+- **Daytona's per-command stdin FIFO EOFs after every single write**, so
+  stdin-consuming commands read from a `tail -f`-fed file instead; writes
+  append via one-shot execs guarded on the exit sentinel, and killing the
+  tail is a real `close_stdin`. Session commands run under plain `sh` —
+  no bashisms in shims.
+- **Daytona's `domainAllowList` is a comma-separated string**, not an
+  array, and lower org tiers refuse sandbox-level egress overrides
+  entirely (a documented platform restriction `limited` environments will
+  surface as a provision failure on such orgs).
+- **A named Daytona snapshot must be registered with the org**; the
+  default is now the organization's default image, and a rejected create
+  surfaces its own error instead of being mistaken for a name conflict.
+- The E2B run passed without adapter changes.
+
+Still unproven live: the custom agent-CLI images (`images/e2b/`,
+`images/daytona/` — including selecting the `sprite` user in-guest) and a
+full Fountain conversation cycle on either provider; E2B Hobby's 1h
+continuous-run cap stands until the account upgrades.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,7 @@ an error message.
 | `E2B_TEMPLATE` | `base` | — | Template new E2B sandboxes are created from. The stock `base` template lacks the agent CLIs — build one from `images/e2b/` for real use |
 | `DAYTONA_API_KEY` | — | for the `daytona` provider | [Daytona](https://daytona.io) API key. Its presence enables the provider |
 | `DAYTONA_API_URL` | `https://app.daytona.io/api` | — | Repoints the Daytona API (self-hosted Daytona) |
-| `DAYTONA_SNAPSHOT` | `daytonaio/sandbox:latest` | — | Snapshot (image) new Daytona sandboxes are created from. The stock image lacks the agent CLIs — build one from `images/daytona/` for real use |
+| `DAYTONA_SNAPSHOT` | org default | — | Snapshot (image) new Daytona sandboxes are created from; must be registered with the organization. The default image lacks the agent CLIs — build one from `images/daytona/` for real use |
 | `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long and the sandbox is reclaimed — the conversation stays [resumable](self-hosting.md#sandbox-lifetime). `0` disables the bound; boot refuses anything that is not a non-negative integer |
 | `SANDBOX_MAX_LIFETIME_HOURS` | `24` | — | Absolute sandbox age ceiling, regardless of activity. Same `0`-disables and boot-refusal rules |
 | `LOG_OUTPUT_BUDGET_MB` | `50` | — | Durable log volume per conversation. Once a conversation has persisted this much sandbox output, one truncation marker is written and further output is discarded (retention bounds age; this bounds rate). Same `0`-disables and boot-refusal rules |

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -9,7 +9,7 @@ were created on.
 
 ```bash
 DAYTONA_API_KEY=dtn_...            # enables the provider
-DAYTONA_SNAPSHOT=fountain          # a snapshot built from images/daytona/
+DAYTONA_SNAPSHOT=fountain          # a snapshot built from images/daytona/ (unset = org default image)
 # DAYTONA_API_URL=https://app.daytona.io/api   # self-hosted Daytona
 # SANDBOX_PROVIDER=daytona
 ```
@@ -32,8 +32,8 @@ daytona snapshot create fountain --dockerfile Dockerfile
 | Suspend / resume | `stop` preserves the whole disk; `start` resumes it. Long-parked sandboxes auto-archive to object storage (still startable, slower) so they stop consuming disk quota |
 | TTL | None — sandboxes are created with `ttlMinutes: 0` and `autoStopInterval: 0`; Fountain's own lifecycle owns suspension. No heartbeat needed |
 | Exec | One-shot toolbox `process/execute` with cwd/env/timeout |
-| Streaming / reattach | Daemon-side sessions journal output server-side, and the log websocket **replays from byte zero before following** — the replay-from-start contract holds natively, no shim. Reattach is the same stream opened again |
-| Stdin | Per-command FIFO, line-oriented (a trailing newline is appended) — fits the NDJSON JSON-RPC of the ACP path. There is no stdin-EOF operation; `close_stdin` is a documented no-op |
+| Streaming / reattach | Daemon-side sessions journal output server-side, and the log websocket **replays from byte zero before following** — reattach is the same stream opened again. The daemon publishes no exit code and its follow stream is unreliable at both ends, so the adapter's shim writes an exit sentinel and the stream reconnects with a byte-exact skip |
+| Stdin | The daemon FIFO EOFs after every write, so stdin-consuming commands read from a `tail -f`-fed file; writes append via one-shot execs and `close_stdin` kills the tail — a real EOF |
 | Network policy | `networkBlockAll` + `domainAllowList` per sandbox, updatable on a running sandbox — genuinely default-deny, so `allow: []` needs no translation |
 | Checkpoints | Not supported (`:checkpoint` is not advertised) |
 


### PR DESCRIPTION
## What

First live smoke runs against real E2B and Daytona accounts (follow-up to #676–#688). **Both providers now pass the full adapter cycle end to end**: create/adopt → exec → streaming spawn with multi-write stdin → attach with byte-zero replay → stdin EOF with the real exit code → suspend → resume with the filesystem intact → destroy. E2B passed **unchanged** (including live verification that deny-all egress actually blocks and an allowlist opens exactly the listed host). Daytona needed five corrections, each measured live on daemon v0.204.0:

- **Toolbox base URL is `{toolboxProxyUrl}/{sandbox-id}`** — the DTO's proxy URL alone carries no sandbox identity (matches the official SDK's construction; plain Bearer on the bare proxy 401s).
- **The daemon publishes no exit code on session-command records**, and its follow-websocket both closes while commands still run *and* lingers after they exit. Spawned commands now run under a shim that writes an exit-sentinel file; `LogStream` reconnects on close-while-running with a **cumulative delivered-bytes skip** (replay-from-start makes the dedupe byte-exact; the counter must never reset across reconnects), polls the sentinel for liveness, and drains the journal tail before the terminal frame. Never a fabricated exit 0.
- **The per-command stdin FIFO EOFs after every single write** — which would end an ACP turn on its first message. Stdin-consuming commands read from a `tail -f`-fed file (POSIX-sh shim; session commands are not bash); writes append via one-shot execs guarded on the exit sentinel, and `close_stdin` kills the tail by pidfile — a **real** stdin EOF, upgraded from the documented no-op.
- **`domainAllowList` is a comma-separated string**, not an array; lower org tiers refuse sandbox-level egress overrides outright (documented platform restriction — surfaced in the smoke as the expected refusal).
- **Unset `DAYTONA_SNAPSHOT` now means the org's default image** — the previously hardcoded name isn't registered in real orgs, and its 400 was masked as `:not_found` by the adopt heuristic, which now surfaces the create's own error when the follow-up get finds nothing.

ADR 0018's verification section records the smoke results and the remaining gap (custom agent-CLI images + a full conversation cycle; E2B Hobby's 1h cap stands).

## Testing

Live smoke: 32/32 checks on E2B, full pass on Daytona (one expected tier-restriction WARN on egress). Unit suites updated to pin the corrected wire shapes. `mix precommit` green (2740 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)