### PR TITLE
fix: E2B spawn must not return before envd acks the process

### DIFF
--- a/apps/fountain/lib/fountain/sandbox/e2b.ex
+++ b/apps/fountain/lib/fountain/sandbox/e2b.ex
@@ -200,14 +200,43 @@ defmodule Fountain.Sandbox.E2B do
 
       case CommandServer.start(sandbox_id: id, tag: tag, ref: ref, owner: owner, request: request) do
         {:ok, pid} ->
-          {:ok,
-           %Command{provider: :e2b, ref: ref, private: %{pid: pid, tag: tag, sandbox_id: id}}}
+          started(pid, ref, tag, id)
 
         {:error, reason} ->
           {:error, Errors.normalize(reason)}
       end
     end
   end
+
+  # Spawn returns only once envd has start-acked the tagged process. The
+  # caller's first write_stdin addresses it by tag, and a write that races
+  # registration 404s — which reads as "already exited" and killed prod
+  # turns at ~300ms (2026-08-14).
+  defp started(pid, ref, tag, sandbox_id) do
+    case CommandServer.await_start(pid, start_timeout()) do
+      :ok ->
+        {:ok,
+         %Command{
+           provider: :e2b,
+           ref: ref,
+           private: %{pid: pid, tag: tag, sandbox_id: sandbox_id}
+         }}
+
+      {:error, reason} ->
+        stop_quietly(pid)
+        {:error, Errors.normalize(reason)}
+    end
+  end
+
+  # The server may have stopped on its own between the failed await and
+  # this cleanup — racing it is fine, being taken down by it is not.
+  defp stop_quietly(pid) do
+    GenServer.stop(pid, :normal)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp start_timeout, do: Application.get_env(:fountain, :e2b_timeout_ms, 30_000)
 
   # stdout/stderr tee into append-only journals and the exit code lands in a
   # sentinel file — the raw material attach/3's replayer needs. `exec`
@@ -312,8 +341,7 @@ defmodule Fountain.Sandbox.E2B do
              exit_file: "#{@journal_dir}/#{tag}.exit"
            ) do
         {:ok, pid} ->
-          {:ok,
-           %Command{provider: :e2b, ref: ref, private: %{pid: pid, tag: tag, sandbox_id: id}}}
+          started(pid, ref, tag, id)
 
         {:error, reason} ->
           {:error, Errors.normalize(reason)}

--- a/apps/fountain/lib/fountain/sandbox/e2b/command_server.ex
+++ b/apps/fountain/lib/fountain/sandbox/e2b/command_server.ex
@@ -39,6 +39,27 @@ defmodule Fountain.Sandbox.E2B.CommandServer do
   def write_stdin(pid, data), do: GenServer.call(pid, {:write_stdin, data})
   def close_stdin(pid), do: GenServer.call(pid, :close_stdin)
 
+  @doc """
+  Block until envd acknowledges the process (its `start` event, always the
+  stream's first frame) or the stream dies first.
+
+  Spawn must not return before this: the caller's first `write_stdin` —
+  the ACP peer writes `initialize` immediately — addresses the process by
+  tag, and a SendInput that races envd's registration 404s, which reads as
+  "process exited" and fails the turn before it began. Measured live on
+  prod (2026-08-14): the race lost twice in a row at ~300ms.
+  """
+  def await_start(pid, timeout) do
+    GenServer.call(pid, :await_start, timeout)
+  catch
+    # Already gone = the command ran its whole life before we asked; its
+    # terminal frame is in the owner's mailbox and that is the truth. Only
+    # a live-but-silent server is a failed start.
+    :exit, {:noproc, _} -> :ok
+    :exit, {:normal, _} -> :ok
+    :exit, _ -> {:error, {:unavailable, :start_timeout}}
+  end
+
   @impl true
   def init(opts) do
     state = %{
@@ -53,6 +74,8 @@ defmodule Fountain.Sandbox.E2B.CommandServer do
       exit_file: Keyword.get(opts, :exit_file),
       buffer: <<>>,
       exited?: false,
+      started?: false,
+      await_from: nil,
       heartbeat: nil,
       stream_task: nil
     }
@@ -85,8 +108,23 @@ defmodule Fountain.Sandbox.E2B.CommandServer do
 
   @impl true
   def handle_call({:write_stdin, data}, _from, state) do
-    {:reply, Envd.send_input(state.sandbox_id, state.stdin_tag, data), state}
+    # By the time writes are allowed the process has been start-acked, so a
+    # 404 here means it has since exited — the contract's :command_exited.
+    reply =
+      case Envd.send_input(state.sandbox_id, state.stdin_tag, data) do
+        {:error, {:api_error, 404, _body}} -> {:error, :command_exited}
+        other -> other
+      end
+
+    {:reply, reply, state}
   end
+
+  def handle_call(:await_start, _from, %{started?: true} = state), do: {:reply, :ok, state}
+
+  def handle_call(:await_start, _from, %{exited?: true} = state),
+    do: {:reply, {:error, :command_exited}, state}
+
+  def handle_call(:await_start, from, state), do: {:noreply, %{state | await_from: from}}
 
   def handle_call(:close_stdin, _from, state) do
     {:reply, Envd.close_stdin(state.sandbox_id, state.stdin_tag), state}
@@ -153,6 +191,11 @@ defmodule Fountain.Sandbox.E2B.CommandServer do
     end
   end
 
+  defp handle_event(%{"start" => _start}, state) do
+    if state.await_from, do: GenServer.reply(state.await_from, :ok)
+    %{state | started?: true, await_from: nil}
+  end
+
   defp handle_event(%{"data" => data}, state) do
     emit_data(state, :stdout, data["stdout"])
     emit_data(state, :stderr, data["stderr"])
@@ -182,12 +225,21 @@ defmodule Fountain.Sandbox.E2B.CommandServer do
   defp finish(state, {:exit, code}) do
     code = if state.exit_file, do: read_exit_code(state, code), else: code
     send(state.owner, {:exit, %{ref: state.ref}, code})
-    %{state | exited?: true}
+    state |> fail_waiter(:command_exited) |> Map.put(:exited?, true)
   end
 
   defp finish(state, {:error, reason}) do
     send(state.owner, {:error, %{ref: state.ref}, reason})
-    %{state | exited?: true}
+    state |> fail_waiter(reason) |> Map.put(:exited?, true)
+  end
+
+  # A stream that dies before the start ack means the spawn never happened —
+  # the blocked caller gets the verdict instead of a timeout.
+  defp fail_waiter(%{await_from: nil} = state, _reason), do: state
+
+  defp fail_waiter(state, reason) do
+    GenServer.reply(state.await_from, {:error, reason})
+    %{state | await_from: nil}
   end
 
   defp read_exit_code(state, fallback) do

--- a/apps/fountain/lib/fountain/sandbox/e2b/errors.ex
+++ b/apps/fountain/lib/fountain/sandbox/e2b/errors.ex
@@ -10,6 +10,7 @@ defmodule Fountain.Sandbox.E2B.Errors do
   @spec normalize(term()) :: Sandbox.error()
   def normalize(:not_found), do: :not_found
   def normalize(:truncated), do: :truncated
+  def normalize(:command_exited), do: :command_exited
   def normalize({:api_error, 404, _body}), do: :not_found
 
   def normalize({:api_error, status, body}) when status in [401, 403],

--- a/apps/fountain/test/fountain/sandbox/e2b_test.exs
+++ b/apps/fountain/test/fountain/sandbox/e2b_test.exs
@@ -236,6 +236,7 @@ defmodule Fountain.Sandbox.E2BTest do
     test "spawn delivers frames to the owner and write_stdin is total after exit" do
       body =
         stream_body([
+          %{"event" => %{"start" => %{"pid" => 42}}},
           %{"event" => %{"data" => %{"stdout" => Base.encode64("ready")}}},
           %{"event" => %{"end" => %{"exitCode" => 0}}}
         ])
@@ -257,6 +258,22 @@ defmodule Fountain.Sandbox.E2BTest do
       # back as an error rather than exiting the caller (#603 semantics).
       wait_for_down(command.private.pid)
       assert {:error, :command_exited} = Adapter.write_stdin(command, "late\n")
+    end
+
+    test "spawn does not return :ok before envd acks the process" do
+      # A stream that dies without ever sending the start event: the process
+      # never existed, so spawn must surface an error — returning :ok here is
+      # the race that let the ACP peer's first write 404 against envd and
+      # fail prod turns in ~300ms.
+      Req.Test.stub(__MODULE__, fn conn ->
+        case {conn.method, conn.request_path} do
+          {"GET", "/v2/sandboxes"} -> Req.Test.json(conn, [listed("running")])
+          {"POST", "/process.Process/Start"} -> Plug.Conn.resp(conn, 200, end_stream_frame())
+        end
+      end)
+
+      assert {:error, _reason} =
+               Adapter.spawn(handle(), "claude-agent-acp", [], owner: self(), stdin: true)
     end
   end
 


### PR DESCRIPTION
## Why

The first prod conversation pinned to E2B failed turn 1 in ~300ms with `acp: {:acp_write_failed, :not_found}` (twice for twice). Autopsy of the live sandbox showed the adapter installed and healthy, empty journals, and exit 0 — the classic signature of `claude-agent-acp` getting EOF before the handshake.

Root cause: `CommandServer.init` opens the Connect stream in `handle_continue`, so `Fountain.Sandbox.spawn/4` returned before envd had even received the `Process/Start` request. The ACP peer writes `initialize` immediately; a `SendInput` addressed by tag that races envd's registration 404s, which reads as "process already exited" and fails the turn before it began. Local cycles had been winning this race on latency luck.

## What

- `spawn/attach` now block on envd's `start` event (always the stream's first frame) via `CommandServer.await_start/2`, bounded by `:e2b_timeout_ms`. A stream that ends before the ack surfaces its verdict to the blocked caller; a command whose whole life already ran reads as a successful spawn (its frames are in the owner's mailbox).
- Post-start stdin 404s map to the contract's `{:error, :command_exited}` (write_stdin totality), with a `normalize/1` passthrough so it isn't mangled into `{:provider, :e2b, ...}`.
- The spawn test fixture now models the `start` event the real daemon always sends, plus a regression test: a stream that dies without a start ack must fail the spawn, never return `:ok`.

## Verification

Full live E2B conversation cycle green from this branch (provision → real turn → pause → wake → turn 2 → terminate). `mix precommit` green (2738 tests). Prod smoke to be rerun after merge+deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)