### PR TITLE
feat: serve the docs site in-app at /docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ upgrade, is in
 
 ### Added
 
+- **The documentation site is served in-app at `/docs`.** The same markdown
+  GitHub Pages publishes is embedded at compile time and rendered through
+  the app's sanitizing markdown pipeline, with the sidebar mirroring the
+  `mkdocs.yml` nav (a test fails on drift). Public, like the Pages site;
+  the curated `/help` topics are unchanged and now link to it.
+
 - **Pluggable sandbox backends: E2B and Daytona join Sprites.** The
   sandbox layer is a provider-agnostic behaviour (`Fountain.Sandbox`) with
   an executable conformance suite; `SANDBOX_PROVIDER` picks the instance

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,12 @@ COPY apps ./apps
 # email — decisions/0010). Mix SILENTLY skips missing elixirc_paths dirs:
 # without this COPY the release still builds but is missing those modules.
 COPY ee ./ee
+# Fountain.Docs embeds docs/ (and the CHANGELOG.md its changelog page
+# includes) at compile time to serve them at /docs — without these the
+# compile fails on File.read!. This is also the only way the content
+# ships: the release never contains docs/ as files.
+COPY docs ./docs
+COPY CHANGELOG.md ./
 
 RUN mix compile \
  && mix release fountain_server

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -1,0 +1,95 @@
+defmodule Fountain.Docs do
+  @moduledoc """
+  The public documentation site (`docs/` at the repo root), embedded at compile
+  time so the app can serve it at `/docs`.
+
+  The same markdown is published to GitHub Pages by `.github/workflows/docs.yml`
+  (MkDocs Material). This module is the in-app rendering path: pages are read at
+  compile time (`@external_resource`, so edits recompile in dev), preprocessed
+  from MkDocs dialect to plain markdown by `Fountain.Docs.Compiler`, and served
+  through the same `FountainWeb.Markdown` pipeline as `/help`. Compile-time
+  embedding is also what ships the content — the release image never contains
+  `docs/` itself, only these ~230 KB of strings in the beam file.
+
+  This is distinct from `Fountain.Help`, the curated in-app help under
+  `priv/help/` — that stays as it is; `/docs` is the full public manual.
+
+  `@nav` mirrors the `nav:` section of `mkdocs.yml`; `docs_test.exs` parses
+  that file and fails on any drift, in either direction. The MkDocs dialect
+  the preprocessing covers is deliberately small (snippet includes,
+  admonitions, relative `.md` links) — if a doc page starts using an extension
+  beyond that, check the page at `/docs`, don't assume.
+  """
+
+  alias Fountain.Docs.Compiler
+
+  @root Path.expand("../../../..", __DIR__)
+  @docs_dir Path.join(@root, "docs")
+
+  # Mirrors mkdocs.yml `nav:` — {title, file} or {section_title, [{title, file}]}.
+  @nav [
+    {"Home", "index.md"},
+    {"Setup", "setup.md"},
+    {"Self-hosting", "self-hosting.md"},
+    {"Architecture", "architecture.md"},
+    {"Operations", "operations.md"},
+    {"Configuration reference", "configuration.md"},
+    {"Integrations",
+     [
+       {"Overview", "integrations/index.md"},
+       {"Sprites", "integrations/sprites.md"},
+       {"The Sprites contract", "integrations/sprites-contract.md"},
+       {"E2B", "integrations/e2b.md"},
+       {"Daytona", "integrations/daytona.md"},
+       {"Adding a provider", "integrations/adding-a-sandbox-provider.md"},
+       {"GitHub OAuth", "integrations/github-oauth.md"},
+       {"Stripe", "integrations/stripe.md"},
+       {"Sentry", "integrations/sentry.md"},
+       {"Mail", "integrations/mail.md"}
+     ]},
+    {"The four primitives", "primitives.md"},
+    {"CLI reference", "cli.md"},
+    {"API reference", "api.md"},
+    {"LLM integration", "llm-integration.md"},
+    {"Changelog", "changelog.md"}
+  ]
+
+  # docs/changelog.md pulls the repo-root CHANGELOG.md in via a snippet.
+  @external_resource Path.join(@root, "CHANGELOG.md")
+
+  for {_title, file} <- Compiler.flat_pages(@nav) do
+    @external_resource Path.join(@docs_dir, file)
+  end
+
+  @pages Map.new(Compiler.flat_pages(@nav), fn {title, file} ->
+           body = @docs_dir |> Path.join(file) |> File.read!() |> Compiler.preprocess(file, @root)
+           {Compiler.slug_for(file), %{title: title, body: body}}
+         end)
+
+  @doc """
+  Sidebar structure, in mkdocs.yml order: `{title, slug}` for pages,
+  `{section_title, [{title, slug}, ...]}` for sections.
+  """
+  @spec nav() :: [{String.t(), String.t() | [{String.t(), String.t()}]}]
+  def nav do
+    Enum.map(@nav, fn
+      {section, children} when is_list(children) ->
+        {section, Enum.map(children, fn {title, file} -> {title, Compiler.slug_for(file)} end)}
+
+      {title, file} ->
+        {title, Compiler.slug_for(file)}
+    end)
+  end
+
+  @doc "All page slugs (the home page is `\"\"`)."
+  @spec slugs() :: [String.t()]
+  def slugs, do: Map.keys(@pages)
+
+  @doc "Fetch a page by slug: `{:ok, %{title: ..., body: markdown}}` or `:error`."
+  @spec get(String.t()) :: {:ok, %{title: String.t(), body: String.t()}} | :error
+  def get(slug) when is_binary(slug), do: Map.fetch(@pages, slug)
+
+  @doc "The nav source as `{title, file}` pairs — for the mkdocs.yml sync test."
+  @spec nav_source() :: [{String.t(), String.t() | [{String.t(), String.t()}]}]
+  def nav_source, do: @nav
+end

--- a/apps/fountain/lib/fountain/docs/compiler.ex
+++ b/apps/fountain/lib/fountain/docs/compiler.ex
@@ -1,0 +1,132 @@
+defmodule Fountain.Docs.Compiler do
+  @moduledoc """
+  Pure functions `Fountain.Docs` runs at compile time to turn the MkDocs
+  dialect in `docs/` into plain markdown. Split out because a module cannot
+  call its own functions from its own body — and so the transforms can be
+  tested directly.
+
+  Covers exactly the dialect the docs use (see the `Fountain.Docs` moduledoc):
+  snippet includes, admonitions, and relative `.md` links. Not a general
+  MkDocs renderer.
+  """
+
+  @doc ~S(`"index.md"` → `""`, `"integrations/index.md"` → `"integrations"`, else the rootname.)
+  @spec slug_for(String.t()) :: String.t()
+  def slug_for(file) do
+    case Path.rootname(file) do
+      "index" -> ""
+      other -> String.replace_suffix(other, "/index", "")
+    end
+  end
+
+  @doc "Flattens a nav (sections one level deep) to `{title, file}` pairs in order."
+  @spec flat_pages(list()) :: [{String.t(), String.t()}]
+  def flat_pages(nav) do
+    Enum.flat_map(nav, fn
+      {_section, children} when is_list(children) -> children
+      {title, file} -> [{title, file}]
+    end)
+  end
+
+  @doc "Snippets, then admonitions, then link rewriting."
+  @spec preprocess(String.t(), String.t(), String.t()) :: String.t()
+  def preprocess(text, file, root) do
+    text
+    |> expand_snippets(root)
+    |> rewrite_admonitions()
+    |> rewrite_links(file)
+  end
+
+  # `--8<-- "FILE"` on its own line → the file's contents, read relative to
+  # the repo root — matching the `pymdownx.snippets` base_path in mkdocs.yml.
+  #
+  # sobelow_skip ["Traversal.FileModule"] — runs at compile time only, on
+  # snippet paths written in repo-controlled markdown; there is no user input.
+  @doc false
+  def expand_snippets(text, root) do
+    Regex.replace(~r/^--8<--\s+"([^"]+)"\s*$/m, text, fn _, path ->
+      root |> Path.join(path) |> File.read!()
+    end)
+  end
+
+  # `!!! note "Title"` + 4-space-indented body → a blockquote with a bold
+  # title line. Fenced code at the top level is left alone; fences inside an
+  # admonition body arrive indented, so they are consumed as body.
+  @doc false
+  def rewrite_admonitions(text) do
+    text |> String.split("\n") |> admonition_lines(false) |> Enum.join("\n")
+  end
+
+  defp admonition_lines([], _in_fence), do: []
+
+  defp admonition_lines([line | rest], in_fence) do
+    cond do
+      String.starts_with?(line, "```") ->
+        [line | admonition_lines(rest, not in_fence)]
+
+      in_fence ->
+        [line | admonition_lines(rest, true)]
+
+      match = Regex.run(~r/^!!!\s+(\w+)(?:\s+"([^"]*)")?\s*$/, line) ->
+        title =
+          case match do
+            [_, type] -> String.capitalize(type)
+            [_, _type, custom] -> custom
+          end
+
+        {body, remaining} = take_indented_body(rest, [])
+
+        quoted =
+          Enum.map(body, fn
+            "" -> ">"
+            content -> "> " <> content
+          end)
+
+        ["> **#{title}**", ">"] ++ quoted ++ [""] ++ admonition_lines(remaining, false)
+
+      true ->
+        [line | admonition_lines(rest, in_fence)]
+    end
+  end
+
+  defp take_indented_body([line | rest] = lines, acc) do
+    cond do
+      String.trim(line) == "" ->
+        take_indented_body(rest, ["" | acc])
+
+      String.starts_with?(line, "    ") ->
+        take_indented_body(rest, [String.slice(line, 4..-1//1) | acc])
+
+      true ->
+        {trim_trailing_blanks(acc), lines}
+    end
+  end
+
+  defp take_indented_body([], acc), do: {trim_trailing_blanks(acc), []}
+
+  defp trim_trailing_blanks(reversed_acc) do
+    reversed_acc |> Enum.drop_while(&(&1 == "")) |> Enum.reverse()
+  end
+
+  # `[x](setup.md#backups)` → `[x](/docs/setup#backups)`, resolved against the
+  # page's own directory so `../architecture.md` works from integrations/.
+  @doc false
+  def rewrite_links(text, file) do
+    dir = Path.dirname(file)
+
+    Regex.replace(~r/\]\((?!https?:)([^)\s#]+\.md)(#[^)]*)?\)/, text, fn _, target, anchor ->
+      slug =
+        target
+        |> Path.expand("/" <> dir)
+        |> String.trim_leading("/")
+        |> slug_for()
+
+      "](#{path_for_slug(slug)}#{anchor})"
+    end)
+  end
+
+  @doc ~S(`""` → `"/docs"`, `"setup"` → `"/docs/setup"`.)
+  @spec path_for_slug(String.t()) :: String.t()
+  def path_for_slug(""), do: "/docs"
+  def path_for_slug(slug), do: "/docs/" <> slug
+end

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -7,6 +7,12 @@
         <span class="font-semibold text-sm text-[var(--color-text-primary)]">Fountain</span>
       </a>
       <nav class="flex items-center gap-3">
+        <a
+          href="/docs"
+          class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors px-3 py-1.5 rounded-md hover:bg-[var(--color-bg-2)]"
+        >
+          Docs
+        </a>
         <%= if @current_user do %>
           <a
             href={~p"/conversations"}
@@ -44,6 +50,9 @@
         © 2026 Fountain. Managed agent infrastructure for teams who'd rather build than configure.
       </span>
       <div class="flex items-center gap-4">
+        <a href="/docs" class="hover:text-[var(--color-text-secondary)] transition-colors">
+          Docs
+        </a>
         <%= if Fountain.Legal.published?() do %>
           <a href={~p"/terms"} class="hover:text-[var(--color-text-secondary)] transition-colors">
             Terms

--- a/apps/fountain/lib/fountain_web/controllers/docs_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/docs_controller.ex
@@ -1,0 +1,36 @@
+defmodule FountainWeb.DocsController do
+  @moduledoc """
+  Serves the public documentation site (the same markdown GitHub Pages
+  publishes) at `/docs`. Content is embedded at compile time by
+  `Fountain.Docs`; rendering goes through the sanitizing
+  `FountainWeb.Markdown` pipeline, same as `/help` (#323).
+
+  Public, like the marketing pages — the GitHub Pages site has no auth, so
+  the in-app mirror has none either.
+  """
+  use FountainWeb, :controller
+
+  def show(conn, params) do
+    slug = params |> Map.get("page", []) |> Enum.join("/")
+
+    case Fountain.Docs.get(slug) do
+      {:ok, page} ->
+        render(conn, :show,
+          layout: {FountainWeb.Layouts, :marketing},
+          page_title: "Docs · " <> page.title,
+          nav: Fountain.Docs.nav(),
+          slug: slug,
+          title: page.title,
+          body_html: FountainWeb.Markdown.to_html(page.body)
+        )
+
+      :error ->
+        conn
+        |> put_status(:not_found)
+        |> render(:not_found,
+          layout: {FountainWeb.Layouts, :marketing},
+          page_title: "Docs · Not found"
+        )
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/docs_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/docs_html.ex
@@ -1,0 +1,10 @@
+defmodule FountainWeb.DocsHTML do
+  @moduledoc false
+  use FountainWeb, :html
+
+  embed_templates "docs_html/*"
+
+  @doc "Route path for a docs slug (`\"\"` is the docs home)."
+  def docs_path(""), do: "/docs"
+  def docs_path(slug), do: "/docs/" <> slug
+end

--- a/apps/fountain/lib/fountain_web/controllers/docs_html/not_found.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/docs_html/not_found.html.heex
@@ -1,0 +1,14 @@
+<section class="max-w-3xl mx-auto px-6 py-16 text-center">
+  <h1 class="text-2xl font-bold tracking-tight text-[var(--color-text-primary)] mb-3">
+    Page not found
+  </h1>
+  <p class="text-[var(--color-text-secondary)] mb-8">
+    There's no documentation page at this address.
+  </p>
+  <a
+    href="/docs"
+    class="text-sm font-medium bg-[var(--color-brand)] text-white px-4 py-2 rounded-md hover:bg-[var(--color-brand-hover)] transition-colors"
+  >
+    Back to the docs
+  </a>
+</section>

--- a/apps/fountain/lib/fountain_web/controllers/docs_html/show.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/docs_html/show.html.heex
@@ -1,0 +1,51 @@
+<div class="max-w-6xl mx-auto px-6 py-10 flex gap-8">
+  <aside class="w-56 shrink-0 hidden md:block">
+    <nav class="space-y-1 sticky top-6">
+      <%= for {title, item} <- @nav do %>
+        <%= if is_list(item) do %>
+          <div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] font-medium mt-4 mb-1 px-2">
+            {title}
+          </div>
+          <%= for {child_title, child_slug} <- item do %>
+            <a
+              href={docs_path(child_slug)}
+              class={[
+                "block rounded px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]",
+                @slug == child_slug &&
+                  "bg-[var(--color-bg-2)] font-medium text-[var(--color-text-primary)]",
+                @slug != child_slug && "text-[var(--color-text-secondary)]"
+              ]}
+            >
+              {child_title}
+            </a>
+          <% end %>
+        <% else %>
+          <a
+            href={docs_path(item)}
+            class={[
+              "block rounded px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]",
+              @slug == item &&
+                "bg-[var(--color-bg-2)] font-medium text-[var(--color-text-primary)]",
+              @slug != item && "text-[var(--color-text-secondary)]"
+            ]}
+          >
+            {title}
+          </a>
+        <% end %>
+      <% end %>
+      <a
+        href="/api/docs"
+        target="_blank"
+        class="block rounded px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)] text-[var(--color-text-secondary)] mt-4"
+      >
+        API reference (Swagger) ↗
+      </a>
+    </nav>
+  </aside>
+
+  <article class="flex-1 min-w-0 bg-[var(--color-bg-1)] border border-[var(--color-border)] rounded-lg shadow-sm p-8">
+    <div class="prose prose-zinc dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-pre:bg-zinc-900 prose-pre:text-zinc-100 prose-pre:text-xs prose-code:text-zinc-800 prose-code:bg-zinc-100 dark:prose-code:text-zinc-200 dark:prose-code:bg-zinc-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none prose-a:text-blue-600 dark:prose-a:text-indigo-400">
+      {Phoenix.HTML.raw(@body_html)}
+    </div>
+  </article>
+</div>

--- a/apps/fountain/lib/fountain_web/live/help_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/help_live/show.ex
@@ -77,6 +77,13 @@ defmodule FountainWeb.HelpLive.Show do
             </.link>
           <% end %>
           <a
+            href="/docs"
+            target="_blank"
+            class="block rounded px-3 py-1.5 text-sm hover:bg-zinc-100 text-zinc-600"
+          >
+            Full documentation ↗
+          </a>
+          <a
             href="/api/docs"
             target="_blank"
             class="block rounded px-3 py-1.5 text-sm hover:bg-zinc-100 text-zinc-600"

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -134,6 +134,11 @@ defmodule FountainWeb.Router do
     get "/", MarketingController, :home
     get "/terms", MarketingController, :terms
     get "/privacy", MarketingController, :privacy
+    # In-app mirror of the GitHub Pages docs site — content embedded at
+    # compile time by Fountain.Docs. Distinct from /help (curated in-app
+    # topics) and /api/docs (Swagger).
+    get "/docs", DocsController, :show
+    get "/docs/*page", DocsController, :show
   end
 
   # Multi-tenant auth routes (no session auth required)

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -1,0 +1,166 @@
+defmodule Fountain.DocsTest do
+  @moduledoc """
+  The embedded docs site against `mkdocs.yml` and against itself.
+
+  The nav in `Fountain.Docs` is a hand-maintained mirror of the `nav:`
+  section in `mkdocs.yml` — the sync test parses that file so adding a page
+  to one and not the other fails here rather than shipping a `/docs` that
+  silently lags the GitHub Pages site. The preprocessing tests pin the small
+  MkDocs dialect the docs are allowed to use: if a page introduces syntax
+  the compiler doesn't rewrite, the leftover-syntax checks catch it.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Fountain.Docs
+  alias Fountain.Docs.Compiler
+
+  @mkdocs_yml Path.expand("../../../../mkdocs.yml", __DIR__)
+
+  describe "nav ↔ mkdocs.yml" do
+    test "matches the nav: section of mkdocs.yml exactly, order included" do
+      assert Docs.nav_source() == mkdocs_nav()
+    end
+  end
+
+  describe "pages" do
+    test "every nav entry resolves and the home slug is empty" do
+      assert {:ok, %{title: "Home", body: body}} = Docs.get("")
+      assert body =~ "multi-tenant"
+
+      for slug <- Docs.slugs() do
+        assert {:ok, %{title: title, body: page_body}} = Docs.get(slug)
+        assert is_binary(title)
+        assert String.trim(page_body) != ""
+      end
+    end
+
+    test "the section index page lives at the section slug" do
+      assert {:ok, %{title: "Overview"}} = Docs.get("integrations")
+    end
+
+    test "unknown slugs miss" do
+      assert :error = Docs.get("nope")
+      assert :error = Docs.get("integrations/index")
+      assert :error = Docs.get("../../etc/passwd")
+    end
+
+    test "no MkDocs syntax survives preprocessing" do
+      for slug <- Docs.slugs() do
+        {:ok, %{body: body}} = Docs.get(slug)
+
+        # Relative .md links must all have been rewritten to /docs paths.
+        assert Regex.scan(~r/\]\((?!https?:)[^)]*\.md/, body) == [],
+               "unrewritten .md link in #{inspect(slug)}"
+
+        refute body =~ ~r/^!!!/m, "unrewritten admonition in #{inspect(slug)}"
+        refute body =~ "--8<--", "unexpanded snippet include in #{inspect(slug)}"
+      end
+    end
+
+    test "every internal /docs link targets a page that exists" do
+      for slug <- Docs.slugs() do
+        {:ok, %{body: body}} = Docs.get(slug)
+
+        for [_, target] <- Regex.scan(~r{\]\(/docs(/[^)#]+)?(?:#[^)]*)?\)}, body) do
+          target_slug = String.trim_leading(target, "/")
+
+          assert target_slug in Docs.slugs(),
+                 "#{inspect(slug)} links to /docs/#{target_slug}, which is not a page"
+        end
+      end
+    end
+
+    test "the changelog page carries the repo-root CHANGELOG" do
+      {:ok, %{body: body}} = Docs.get("changelog")
+      assert body =~ "Keep a Changelog"
+    end
+  end
+
+  describe "Compiler" do
+    test "slug_for strips .md and index" do
+      assert Compiler.slug_for("index.md") == ""
+      assert Compiler.slug_for("setup.md") == "setup"
+      assert Compiler.slug_for("integrations/index.md") == "integrations"
+      assert Compiler.slug_for("integrations/e2b.md") == "integrations/e2b"
+    end
+
+    test "admonitions become blockquotes, custom title preferred" do
+      md = """
+      before
+
+      !!! tip "In a hurry?"
+          line one
+
+          line two
+      after
+      """
+
+      out = Compiler.rewrite_admonitions(md)
+      assert out =~ "> **In a hurry?**\n>\n> line one\n>\n> line two\n\nafter"
+      refute out =~ "!!!"
+    end
+
+    test "admonitions without a title use the capitalized type" do
+      out = Compiler.rewrite_admonitions("!!! note\n    body\n")
+      assert out =~ "> **Note**"
+    end
+
+    test "admonition-looking lines inside fences are left alone" do
+      md = "```\n!!! note \"not one\"\n```\n"
+      assert Compiler.rewrite_admonitions(md) == md
+    end
+
+    test "links resolve against the page's own directory" do
+      assert Compiler.rewrite_links("[a](setup.md#backups)", "index.md") ==
+               "[a](/docs/setup#backups)"
+
+      assert Compiler.rewrite_links("[a](../architecture.md)", "integrations/sprites-contract.md") ==
+               "[a](/docs/architecture)"
+
+      assert Compiler.rewrite_links("[a](index.md)", "integrations/e2b.md") ==
+               "[a](/docs/integrations)"
+
+      assert Compiler.rewrite_links("[a](index.md)", "setup.md") == "[a](/docs)"
+    end
+
+    test "absolute and anchor-only links are untouched" do
+      md = "[a](https://example.com/x.md) [b](#section) [c](mailto:x@y.z)"
+      assert Compiler.rewrite_links(md, "setup.md") == md
+    end
+  end
+
+  # A deliberately narrow parser for the two shapes mkdocs.yml's nav uses:
+  # `- Title: file.md` entries at two indent levels and `- Title:` section
+  # headers. Anything it doesn't recognize fails the test, which is the point —
+  # a new nav shape needs a decision here, not silent skipping.
+  defp mkdocs_nav do
+    [_before, nav_block] = @mkdocs_yml |> File.read!() |> String.split(~r/^nav:\n/m, parts: 2)
+
+    nav_block
+    |> String.split("\n")
+    |> Enum.take_while(&(&1 == "" or String.starts_with?(&1, " ")))
+    |> Enum.reject(&(String.trim(&1) == ""))
+    |> Enum.reduce([], fn line, acc ->
+      case Regex.run(~r/^(\s+)- ([^:]+):\s*(\S+)?\s*$/, line) do
+        [_, indent, title, file] when byte_size(indent) == 2 ->
+          [{title, file} | acc]
+
+        [_, indent, title] when byte_size(indent) == 2 ->
+          [{title, []} | acc]
+
+        [_, indent, title, file] when byte_size(indent) > 2 ->
+          [{section, children} | rest] = acc
+          [{section, [{title, file} | children]} | rest]
+
+        _ ->
+          flunk("unparsed mkdocs.yml nav line: #{inspect(line)}")
+      end
+    end)
+    |> Enum.map(fn
+      {section, children} when is_list(children) -> {section, Enum.reverse(children)}
+      entry -> entry
+    end)
+    |> Enum.reverse()
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
@@ -1,0 +1,53 @@
+defmodule FountainWeb.DocsControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  # All requests here are unauthenticated on purpose: /docs mirrors the public
+  # GitHub Pages site, so it sits in the public marketing scope.
+
+  describe "GET /docs" do
+    test "serves the home page with the sidebar nav", %{conn: conn} do
+      body = conn |> get(~p"/docs") |> html_response(200)
+      assert body =~ "multi-tenant"
+      # One entry from each nav shape: a top-level page and a section child.
+      assert body =~ "Self-hosting"
+      assert body =~ "The Sprites contract"
+      assert body =~ ~s(href="/docs/integrations/sprites-contract")
+    end
+
+    test "renders the admonition as a blockquote, not raw MkDocs syntax", %{conn: conn} do
+      body = conn |> get(~p"/docs") |> html_response(200)
+      assert body =~ "In a hurry?"
+      refute body =~ "!!!"
+    end
+  end
+
+  describe "GET /docs/:page" do
+    test "serves a top-level page", %{conn: conn} do
+      body = conn |> get(~p"/docs/setup") |> html_response(200)
+      assert body =~ "Setup"
+    end
+
+    test "serves a nested integrations page", %{conn: conn} do
+      body = conn |> get(~p"/docs/integrations/sprites-contract") |> html_response(200)
+      assert body =~ "Sprites"
+    end
+
+    test "rewrites internal links to /docs paths", %{conn: conn} do
+      body = conn |> get(~p"/docs/architecture") |> html_response(200)
+      assert body =~ ~s(href="/docs/primitives")
+      refute body =~ ~s(.md")
+    end
+
+    test "serves the changelog with the repo-root CHANGELOG inlined", %{conn: conn} do
+      body = conn |> get(~p"/docs/changelog") |> html_response(200)
+      assert body =~ "Keep a Changelog"
+    end
+
+    test "404s on unknown pages", %{conn: conn} do
+      assert conn |> get(~p"/docs/nope") |> html_response(404) =~ "Page not found"
+
+      assert conn |> get("/docs/integrations/nope/deeper") |> html_response(404) =~
+               "Page not found"
+    end
+  end
+end


### PR DESCRIPTION
## What

The public MkDocs site (`docs/`, published to GitHub Pages) is now also served inside the app at **`/docs`** — public, like the Pages site. The curated `/help` topics are unchanged; the help sidebar and the marketing header/footer gain links to the docs.

## How

No Python/MkDocs in the image build. `Fountain.Docs` embeds `docs/*.md` at compile time (`@external_resource`, so edits recompile in dev) and pages render through the same sanitizing `FountainWeb.Markdown` pipeline as `/help` (#323).

The docs use a deliberately small MkDocs dialect (checked: two admonitions, one snippet include, 60 relative `.md` links, no tabs), and `Fountain.Docs.Compiler` rewrites exactly that to plain markdown at compile time:

- `!!! type "Title"` admonitions → blockquotes with a bold title line (fences respected)
- the changelog page's `--8<-- "CHANGELOG.md"` snippet → the inlined repo-root CHANGELOG
- relative `.md` links → `/docs/...` paths, resolved against the page's own directory (`../architecture.md` from `integrations/` works)

It is not a general MkDocs renderer, and says so in the moduledoc — new fancy syntax means checking the page at `/docs`.

## Guardrails

- The sidebar nav is a hand-maintained mirror of `mkdocs.yml`'s `nav:`; `docs_test.exs` parses that file and **fails on drift in either direction** (same shape as the `Fountain.Help` registry test).
- Tests also assert no MkDocs syntax survives preprocessing and that every internal `/docs` link targets a real page.
- Controller tests cover both nav shapes, nested pages, link rewriting, the changelog inline, and 404s.

## Dockerfile

`COPY docs` + `COPY CHANGELOG.md` before `mix compile` — the compile-time embed is what ships the content; the release image never contains `docs/` as files. Verified by building the prod image locally: the content lands in `Elixir.Fountain.Docs.beam` (~230 KB of strings).

## Verified

- `mix precommit` green end-to-end (2,758 tests, 0 failures; credo/sobelow/dialyzer clean)
- Dev server: `/docs`, `/docs/setup`, `/docs/integrations/sprites-contract`, `/docs/changelog` → 200 with rewritten links and the admonition rendered as a blockquote; unknown slugs → 404. Changelog (heaviest page, 88 KB markdown per request) ~100 ms in dev.
- Prod image builds and carries the embedded content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)