### PR TITLE
docs: one sandbox contract, three providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ upgrade, is in
 
 ### Changed
 
+- **The sandbox docs now tell the provider story straight.** The docs site
+  gets a "Sandbox providers" section — one contract
+  (`Fountain.Sandbox` + its conformance suite), three implementations
+  (Sprites, E2B, Daytona) — with a new contract overview page, and the
+  Sprites page no longer claims to be the only backend.
+
 - **The four dialect parsers are out of the conversation LiveView.** The
   24 `event_blocks/2` clauses move to a dedicated, tested
   `LegacyBlocks` module: gemini's dialect stays live (#659), and the

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -34,14 +34,18 @@ defmodule Fountain.Docs do
     {"Architecture", "architecture.md"},
     {"Operations", "operations.md"},
     {"Configuration reference", "configuration.md"},
+    {"Sandbox providers",
+     [
+       {"The contract", "integrations/sandbox-contract.md"},
+       {"Sprites", "integrations/sprites.md"},
+       {"Sprites transport reference", "integrations/sprites-contract.md"},
+       {"E2B", "integrations/e2b.md"},
+       {"Daytona", "integrations/daytona.md"},
+       {"Adding a provider", "integrations/adding-a-sandbox-provider.md"}
+     ]},
     {"Integrations",
      [
        {"Overview", "integrations/index.md"},
-       {"Sprites", "integrations/sprites.md"},
-       {"The Sprites contract", "integrations/sprites-contract.md"},
-       {"E2B", "integrations/e2b.md"},
-       {"Daytona", "integrations/daytona.md"},
-       {"Adding a provider", "integrations/adding-a-sandbox-provider.md"},
        {"GitHub OAuth", "integrations/github-oauth.md"},
        {"Stripe", "integrations/stripe.md"},
        {"Sentry", "integrations/sentry.md"},

--- a/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
@@ -10,7 +10,7 @@ defmodule FountainWeb.DocsControllerTest do
       assert body =~ "multi-tenant"
       # One entry from each nav shape: a top-level page and a section child.
       assert body =~ "Self-hosting"
-      assert body =~ "The Sprites contract"
+      assert body =~ "Sprites transport reference"
       assert body =~ ~s(href="/docs/integrations/sprites-contract")
     end
 

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -1,7 +1,8 @@
 # Daytona
 
-[Daytona](https://daytona.io) is an alternative sandbox backend — the
-closest semantic match to Fountain's sandbox contract of any provider.
+[Daytona](https://daytona.io) is one of the three
+[sandbox providers](sandbox-contract.md), and the closest semantic match
+to the contract of any of them.
 Setting `DAYTONA_API_KEY` enables it; `SANDBOX_PROVIDER=daytona` makes it
 the default for newly-created sandboxes, and an individual agent can pin it
 via `sandbox_provider`. Existing sandboxes always stay on the provider they

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -1,6 +1,7 @@
 # E2B
 
-[E2B](https://e2b.dev) is an alternative sandbox backend. Setting
+[E2B](https://e2b.dev) is one of the three
+[sandbox providers](sandbox-contract.md). Setting
 `E2B_API_KEY` enables it; `SANDBOX_PROVIDER=e2b` makes it the default for
 newly-created sandboxes, and an individual agent can pin it via
 `sandbox_provider`. Existing sandboxes always stay on the provider they were

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -6,11 +6,15 @@ provider side, which env vars result, and how to verify it works.
 
 | Integration | Required? | Env vars | Without it |
 |---|---|---|---|
-| [Sprites](sprites.md) | **Yes** | `SPRITES_TOKEN`, `SPRITES_BASE_URL`, `SPRITES_TIMEOUT_MS` | The app boots, but every conversation fails |
+| [A sandbox provider](sandbox-contract.md) | **Yes — one of three** | `SPRITES_TOKEN` *or* `E2B_API_KEY` *or* `DAYTONA_API_KEY`, plus `SANDBOX_PROVIDER` to pick the default | The app boots, but every conversation fails at provision time |
 | [Mail](mail.md) | **A decision, yes** | `RESEND_API_KEY` *or* `SMTP_*` *or* `EMAIL_DELIVERY=none`, `EMAIL_FROM` | Production refuses to boot with none of the three set |
 | [GitHub OAuth](github-oauth.md) | Optional | `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET` | Email + password auth only |
 | [Stripe](stripe.md) | Optional | `BILLING_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID` | No billing. Correct for most self-hosted instances — leave the gate off |
 | [Sentry](sentry.md) | Optional | `SENTRY_DSN`, `SENTRY_ENVIRONMENT` | No error tracking; the SDK is inert and nothing leaves the instance |
+
+The sandbox providers — Sprites, E2B, Daytona — have
+[a section of their own](sandbox-contract.md): one contract, three
+implementations.
 
 ## The integration you do not configure
 

--- a/docs/integrations/sandbox-contract.md
+++ b/docs/integrations/sandbox-contract.md
@@ -1,0 +1,65 @@
+# The sandbox contract
+
+Every conversation runs in a sandbox, and every sandbox backend plugs into
+the same seam: the `Fountain.Sandbox` behaviour. There is one contract a
+provider has to meet, and it is executable — the behaviour's moduledoc
+specifies the callbacks, capabilities and error taxonomy, and
+`Fountain.SandboxConformanceCase` is the conformance suite every adapter
+must pass (replay-from-start attach, total `write_stdin`, exactly one
+terminal frame per command, `allow: []` means deny-all, and the rest). The
+design rationale is
+[ADR 0018](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0018-sandbox-provider-abstraction.md).
+
+So far, three providers implement it:
+
+| Provider | What it is | Suspend semantics |
+|---|---|---|
+| [Sprites](sprites.md) | [sprites.dev](https://sprites.dev) — the original backend and the instance default | Parks implicitly: the sprite scales to zero on its own, disk preserved |
+| [E2B](e2b.md) | [e2b.dev](https://e2b.dev) | Explicit `pause`: filesystem **and memory** snapshot, restored on resume |
+| [Daytona](daytona.md) | [daytona.io](https://daytona.io) — self-hostable via `DAYTONA_API_URL` | Explicit `stop`: disk preserved; long-parked sandboxes archive to object storage |
+
+All three advertise suspend, network policy and attach. TTY support is
+Sprites-only. Checkpoint-based warm starts exist only in the Sprites
+transport and are currently off by default — a checkpoint id is scoped to
+the sprite that created it, so cross-sprite warm starts cannot work (#654).
+
+## Picking a provider
+
+- A provider is **enabled** by exactly one thing: its credential is present
+  (`SPRITES_TOKEN`, `E2B_API_KEY`, `DAYTONA_API_KEY`). There is no other
+  switch.
+- `SANDBOX_PROVIDER` (default `sprites`) sets the instance default for
+  newly-created sandboxes. Boot refuses an explicit default whose credential
+  is missing.
+- An agent can pin a provider via `sandbox_provider`; the provider select
+  appears in the agent form on its own once a second provider is enabled.
+- **Existing sandboxes always stay on the provider that created them** — a
+  parked disk lives where it was written, so waking never crosses providers.
+
+You need at least one. Without any provider credential the app boots, but
+every conversation fails at provision time.
+
+## What the contract guarantees
+
+- **Capabilities are honest.** Adapters advertise what they can actually do
+  (`:suspend`, `:network_policy`, `:attach`, `:tty`, `:checkpoint`), and the
+  lifecycle degrades accordingly: a provider without `:suspend` destroys on
+  idle rather than faking a park — agent memory lives on the sandbox disk,
+  and resume-with-a-fresh-disk would be silent data loss.
+- **Errors are one taxonomy.** Every adapter normalizes provider errors into
+  the shapes in the behaviour moduledoc (`:not_found`, `{:unavailable, _}`,
+  `{:denied, _}`, `{:rate_limited, _}`, …), so retry policy is
+  provider-independent — and `{:error, :not_found}` is kept distinct from
+  transient failure, which is what protects parked disks from being
+  destroyed on a flaky network call.
+- **Network policy means what it says.** For a `limited` environment,
+  `allow: []` is deny-all on every provider, never a no-op.
+
+## Where to go next
+
+- Setting up a specific provider: [Sprites](sprites.md), [E2B](e2b.md),
+  [Daytona](daytona.md).
+- Implementing the contract for a fourth backend:
+  [Adding a provider](adding-a-sandbox-provider.md).
+- The original backend's wire protocol, for building a Sprites-compatible
+  replacement: [the Sprites transport reference](sprites-contract.md).

--- a/docs/integrations/sprites-contract.md
+++ b/docs/integrations/sprites-contract.md
@@ -1,13 +1,14 @@
-# The Sprites contract
+# The Sprites transport reference
 
 This page documents the **Sprites adapter's** transport contract — every
 endpoint `Fountain.Sandbox.Sprites` calls, the semantics it relies on, and
-the operational assumptions baked in. The provider-neutral form of this
-contract is executable: the `Fountain.Sandbox` behaviour and its
-conformance suite (`Fountain.SandboxConformanceCase`), which the
-[E2B](e2b.md) and [Daytona](daytona.md) adapters also satisfy. Evaluating a
-new backend starts there; this page is the reference for what the original
-backend actually provides.
+the operational assumptions baked in. The provider-neutral contract every
+backend must meet is [the sandbox contract](sandbox-contract.md) — the
+`Fountain.Sandbox` behaviour and its conformance suite
+(`Fountain.SandboxConformanceCase`), which the [E2B](e2b.md) and
+[Daytona](daytona.md) adapters also satisfy. Evaluating a new backend
+starts there; this page is the reference for what the original backend
+actually provides.
 
 Setup and cost model are in the [Sprites integration guide](sprites.md).
 Transport summary: REST over HTTPS with `Authorization: Bearer <token>`, one

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -1,12 +1,14 @@
 # Sprites
 
-**Required.** [sprites.dev](https://sprites.dev) is the sandbox platform every
-conversation runs in. It is a hosted service and currently the only backend —
-a Fountain instance is not fully self-contained without it.
+[sprites.dev](https://sprites.dev) is the original of the three
+[sandbox providers](sandbox-contract.md) and the instance default
+(`SANDBOX_PROVIDER=sprites`). It is a hosted service; a Fountain instance
+needs at least one provider credential, and with none configured every
+conversation fails at provision time.
 
 The exact API surface Fountain consumes — and what a compatible replacement
 behind `SPRITES_BASE_URL` would have to provide — is written down in
-[the Sprites contract](sprites-contract.md).
+[the Sprites transport reference](sprites-contract.md).
 
 ## Provider side
 
@@ -18,13 +20,13 @@ provider-side setup.
 | Variable | Default | Effect |
 |---|---|---|
 | `SPRITES_TOKEN` | — | The platform token. Not checked at boot: the app starts without it, and the first conversation fails at provision time instead |
-| `SPRITES_BASE_URL` | `https://api.sprites.dev` | Repoints the sandbox API. Anything else must implement the same contract; there is no bundled alternative |
+| `SPRITES_BASE_URL` | `https://api.sprites.dev` | Repoints the Sprites API. Anything else must implement the same transport — [E2B](e2b.md) and [Daytona](daytona.md) are separate providers, not `SPRITES_BASE_URL` replacements |
 | `SPRITES_TIMEOUT_MS` | `30000` | Bounds every HTTP call to the Sprites API. Long-running commands (package installs, clones) set their own per-call timeouts. Boot refuses a non-positive value |
 
 ## The cost model
 
-**One platform token pays for every sandbox.** Fountain provisions all
-tenants' sandboxes with `SPRITES_TOKEN` and the bill lands on that token's
+**One platform token pays for every Sprites sandbox.** Fountain provisions
+all tenants' Sprites sandboxes with `SPRITES_TOKEN` and the bill lands on that token's
 account — on the hosted instance, subscription pricing recovers it; on yours,
 you are the one paying. Two consequences:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -363,4 +363,4 @@ Being straight about what self-hosting does not yet include:
   are all services (self-hosted Daytona narrows this). The contract a new
   backend must satisfy is executable — `Fountain.Sandbox` plus its
   conformance suite — and written down in
-  [the Sprites contract](integrations/sprites-contract.md).
+  [the sandbox contract](integrations/sandbox-contract.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,13 +58,15 @@ nav:
   - Architecture: architecture.md
   - Operations: operations.md
   - Configuration reference: configuration.md
-  - Integrations:
-      - Overview: integrations/index.md
+  - Sandbox providers:
+      - The contract: integrations/sandbox-contract.md
       - Sprites: integrations/sprites.md
-      - The Sprites contract: integrations/sprites-contract.md
+      - Sprites transport reference: integrations/sprites-contract.md
       - E2B: integrations/e2b.md
       - Daytona: integrations/daytona.md
       - Adding a provider: integrations/adding-a-sandbox-provider.md
+  - Integrations:
+      - Overview: integrations/index.md
       - GitHub OAuth: integrations/github-oauth.md
       - Stripe: integrations/stripe.md
       - Sentry: integrations/sentry.md


### PR DESCRIPTION
## What

The integrations docs still told the pre-campaign story: `sprites.md` opened with "**Required.** … currently the only backend" (false since #676–#693 / ADR 0018), the overview table listed Sprites as *the* required sandbox with no mention of E2B or Daytona, and the nav ordered the pages as Sprites → "The Sprites contract" → E2B → Daytona, framing the contract as a Sprites appendix.

This restructures them into a dedicated **Sandbox providers** section whose story is: **there is a contract you have to meet, and so far three providers implement it.**

## Nav (both `mkdocs.yml` and the in-app mirror — the sync test enforces they match)

```
Sandbox providers
├── The contract            ← NEW: integrations/sandbox-contract.md
├── Sprites
├── Sprites transport reference   (retitled from "The Sprites contract")
├── E2B
├── Daytona
└── Adding a provider
Integrations
├── Overview
├── GitHub OAuth / Stripe / Sentry / Mail
```

File paths are unchanged, so no GitHub Pages URLs or in-app `/docs` URLs break.

## The new contract page

Facts verified against `sandbox.ex` before writing: `known_providers/0` (sprites/e2b/daytona), enabled = credential present and nothing else, `SANDBOX_PROVIDER` default + boot refusal on a credential-less explicit default, per-agent pin, provider stickiness, per-adapter capabilities (TTY Sprites-only; checkpoints Sprites-transport-only and off by default per #654), honest degradation (no `:suspend` → destroy on idle), and the normalized error taxonomy.

## Factual fixes

- `sprites.md`: original-of-three + default, not "the only backend"; `SPRITES_BASE_URL` row no longer claims "no bundled alternative"; cost model scoped to *Sprites* sandboxes.
- `integrations/index.md`: required row is now "a sandbox provider — one of three".
- `e2b.md` / `daytona.md` intros and `self-hosting.md`'s known-gaps link point at the neutral contract page.

## Verified

- `mix precommit` green end-to-end (2,758 tests, 0 failures)
- `mkdocs build --strict` passes locally (only the pre-existing superpowers orphan notice)
- New page rendered through the in-app pipeline: every internal link resolves to a real `/docs` page (the docs tests also assert this globally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)