### PR TITLE
fix: visually contain docs nav sections

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/docs_html/show.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/docs_html/show.html.heex
@@ -3,22 +3,26 @@
     <nav class="space-y-1 sticky top-6">
       <%= for {title, item} <- @nav do %>
         <%= if is_list(item) do %>
-          <div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] font-medium mt-4 mb-1 px-2">
-            {title}
+          <div class="mt-4 mb-2">
+            <div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] font-medium mb-1 px-2">
+              {title}
+            </div>
+            <div class="ml-3 pl-2 border-l border-[var(--color-border)] space-y-1">
+              <%= for {child_title, child_slug} <- item do %>
+                <a
+                  href={docs_path(child_slug)}
+                  class={[
+                    "block rounded px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]",
+                    @slug == child_slug &&
+                      "bg-[var(--color-bg-2)] font-medium text-[var(--color-text-primary)]",
+                    @slug != child_slug && "text-[var(--color-text-secondary)]"
+                  ]}
+                >
+                  {child_title}
+                </a>
+              <% end %>
+            </div>
           </div>
-          <%= for {child_title, child_slug} <- item do %>
-            <a
-              href={docs_path(child_slug)}
-              class={[
-                "block rounded px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]",
-                @slug == child_slug &&
-                  "bg-[var(--color-bg-2)] font-medium text-[var(--color-text-primary)]",
-                @slug != child_slug && "text-[var(--color-text-secondary)]"
-              ]}
-            >
-              {child_title}
-            </a>
-          <% end %>
         <% else %>
           <a
             href={docs_path(item)}


### PR DESCRIPTION
With two sections in the `/docs` sidebar, a section header was just a label above a flat list — everything after the **Integrations** header, including the remaining top-level pages (The four primitives, CLI reference, API reference, LLM integration, Changelog), visually read as Integrations children.

Section children now render in an indented container with a left border; top-level entries stay at base indent, so the boundary is visible.

Verified against the rendered page in dev: each bordered container holds exactly its section's links ("The contract" → "Adding a provider"; "Overview" → "Mail") and "The four primitives" onward sit outside both. Docs controller tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)