### PR TITLE
feat: `fountain acp` — the stdio handshake an editor spawns (#698)

### DIFF
--- a/cli/internal/acp/agent.go
+++ b/cli/internal/acp/agent.go
@@ -1,0 +1,207 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+)
+
+// ProtocolVersion is the ACP major version this agent speaks. It matches what
+// the server's peer offers downward (Fountain.Runtimes.ACP.initialize_params/0),
+// which is not a coincidence worth breaking: Fountain is a proxy, and a
+// version it can receive but not re-emit is a translation problem it exists to
+// not have.
+const ProtocolVersion = 1
+
+// AuthMethodID is the id an editor passes back to `authenticate`.
+const AuthMethodID = "fountain-cli-login"
+
+// Auth is what the agent needs to know about credentials, split by cost.
+//
+// Available is a local check — a file read, no network — because it runs
+// inside `initialize`, and an editor that waits on a round trip to decide
+// whether to show a login prompt feels broken before it has done anything.
+// Verify is the network check, and only `authenticate` pays for it.
+type Auth interface {
+	Available() bool
+	Verify(ctx context.Context) error
+	// Describe names where the credentials would come from, for log lines
+	// and error messages. A wrong-instance or wrong-profile misconfiguration
+	// is otherwise invisible from inside an editor.
+	Describe() string
+}
+
+// Agent handles the ACP methods an editor calls.
+//
+// v1 is a control surface, not a workspace: it declares no client filesystem
+// or terminal capabilities and requests none. A Fountain agent edits a
+// sprite's files on a machine that is not the developer's, and ADR 0015 is
+// explicit that pretending otherwise "produces an agent that appears to be
+// editing the open project and is not". Read-through and workspace sync are
+// separate decisions with their own ADRs — they do not arrive through here.
+type Agent struct {
+	auth Auth
+	log  *slog.Logger
+
+	mu            sync.Mutex
+	initialized   bool
+	authenticated bool
+	negotiated    int
+}
+
+// NewAgent returns an agent bound to a credential source.
+func NewAgent(auth Auth, log *slog.Logger) *Agent {
+	return &Agent{auth: auth, log: log}
+}
+
+type initializeParams struct {
+	ProtocolVersion    int             `json:"protocolVersion"`
+	ClientCapabilities json.RawMessage `json:"clientCapabilities"`
+}
+
+type authenticateParams struct {
+	MethodID string `json:"methodId"`
+}
+
+// Request dispatches one ACP method.
+func (a *Agent) Request(ctx context.Context, method string, params json.RawMessage) (any, error) {
+	switch method {
+	case "initialize":
+		return a.initialize(params)
+	case "authenticate":
+		return a.authenticate(ctx, params)
+	default:
+		return nil, Errorf(CodeMethodNotFound, "method not found: %s", method)
+	}
+}
+
+// Notify handles client notifications. There are none this agent acts on yet;
+// `session/cancel` arrives here when it lands (#704).
+func (a *Agent) Notify(_ context.Context, method string, _ json.RawMessage) {
+	a.log.Debug("ignoring notification", "method", method)
+}
+
+func (a *Agent) initialize(raw json.RawMessage) (any, error) {
+	var params initializeParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, Errorf(CodeInvalidParams, "initialize: %s", err)
+		}
+	}
+
+	// The protocol negotiates down: answer with the highest version both ends
+	// speak. There is no floor to refuse below yet, because ProtocolVersion is
+	// also the oldest version that exists — when a v2 ships, the refusal for a
+	// client below our floor belongs here, not in the session methods, where
+	// it would surface as a mid-conversation failure.
+	negotiated := params.ProtocolVersion
+	if negotiated <= 0 || negotiated > ProtocolVersion {
+		negotiated = ProtocolVersion
+	}
+
+	// The client's params are logged whole and stored not at all. Whatever it
+	// offers — fs/read_text_file, terminals — v1 uses none of it, and this
+	// line is what makes that visible when an editor asks why its
+	// capabilities were ignored.
+	a.log.Info("initialize",
+		"protocolVersion", negotiated,
+		"params", string(raw),
+		"credentials", a.auth.Describe())
+
+	authenticated := a.auth.Available()
+
+	a.mu.Lock()
+	a.initialized = true
+	a.negotiated = negotiated
+	// Holding credentials is not proof they work — `authenticate` is what
+	// verifies them. It is proof we should not ask the editor to log in.
+	a.authenticated = authenticated
+	a.mu.Unlock()
+
+	return map[string]any{
+		"protocolVersion":   negotiated,
+		"agentCapabilities": agentCapabilities(),
+		"authMethods":       authMethods(authenticated),
+	}, nil
+}
+
+// agentCapabilities is deliberately the smallest honest set.
+//
+// loadSession stays false until the replay path exists (#703): claiming it
+// obliges us to replay a whole conversation as session/update notifications
+// before answering, and an agent that claims it and does not do it leaves an
+// editor showing an empty transcript for a conversation that has one.
+// Prompt capabilities stay false for the same reason — the prompt path is
+// #701 — even though the API behind them already carries images.
+func agentCapabilities() map[string]any {
+	return map[string]any{
+		"loadSession": false,
+		"promptCapabilities": map[string]any{
+			"image":           false,
+			"audio":           false,
+			"embeddedContext": false,
+		},
+	}
+}
+
+// authMethods advertises the one way in, and only when it is needed. An
+// editor shown a login prompt for a CLI that is already logged in has been
+// told something false about its own state.
+func authMethods(authenticated bool) []map[string]any {
+	if authenticated {
+		return []map[string]any{}
+	}
+	return []map[string]any{{
+		"id":          AuthMethodID,
+		"name":        "Fountain CLI login",
+		"description": "Run `fountain auth login` in a terminal, then retry.",
+	}}
+}
+
+func (a *Agent) authenticate(ctx context.Context, raw json.RawMessage) (any, error) {
+	var params authenticateParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, Errorf(CodeInvalidParams, "authenticate: %s", err)
+		}
+	}
+	if params.MethodID != "" && params.MethodID != AuthMethodID {
+		return nil, Errorf(CodeInvalidParams, "unknown auth method %q", params.MethodID)
+	}
+
+	if !a.auth.Available() {
+		return nil, Errorf(CodeAuthRequired,
+			"no credentials for %s — run `fountain auth login`", a.auth.Describe())
+	}
+
+	if err := a.auth.Verify(ctx); err != nil {
+		// The message is the whole value of this branch: it is read inside an
+		// editor by someone who cannot see a 401.
+		return nil, Errorf(CodeAuthRequired,
+			"credentials for %s were rejected (%s) — run `fountain auth login`",
+			a.auth.Describe(), err)
+	}
+
+	a.mu.Lock()
+	a.authenticated = true
+	a.mu.Unlock()
+
+	a.log.Info("authenticated", "credentials", a.auth.Describe())
+	return nil, nil
+}
+
+// Authenticated reports whether the session may call the session methods.
+// The session methods do not exist yet; this is what they will gate on.
+func (a *Agent) Authenticated() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.authenticated
+}
+
+// Initialized reports whether `initialize` has completed.
+func (a *Agent) Initialized() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.initialized
+}

--- a/cli/internal/acp/agent_test.go
+++ b/cli/internal/acp/agent_test.go
@@ -1,0 +1,274 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeAuth struct {
+	available bool
+	verifyErr error
+	verifies  int
+}
+
+func (f *fakeAuth) Available() bool { return f.available }
+
+func (f *fakeAuth) Verify(context.Context) error {
+	f.verifies++
+	return f.verifyErr
+}
+
+func (f *fakeAuth) Describe() string { return "https://example.test (profile default)" }
+
+func request(t *testing.T, a *Agent, method string, params any) (map[string]any, *Error) {
+	t.Helper()
+
+	var raw json.RawMessage
+	if params != nil {
+		encoded, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("marshal params: %v", err)
+		}
+		raw = encoded
+	}
+
+	result, err := a.Request(context.Background(), method, raw)
+	if err != nil {
+		var rpcErr *Error
+		if !errors.As(err, &rpcErr) {
+			t.Fatalf("%s returned a non-protocol error: %v", method, err)
+		}
+		return nil, rpcErr
+	}
+
+	if result == nil {
+		return nil, nil
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("%s result is %T, want a map", method, result)
+	}
+	return m, nil
+}
+
+func TestInitializeAnswersWithOurProtocolVersion(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+
+	result, rpcErr := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+	if rpcErr != nil {
+		t.Fatalf("initialize failed: %v", rpcErr)
+	}
+	if result["protocolVersion"] != ProtocolVersion {
+		t.Errorf("protocolVersion = %v, want %d", result["protocolVersion"], ProtocolVersion)
+	}
+	if !a.Initialized() {
+		t.Error("agent did not record that it was initialized")
+	}
+}
+
+// A client newer than us must be answered with a version we can actually
+// speak, not with its own echoed back.
+func TestInitializeNegotiatesDownFromANewerClient(t *testing.T) {
+	a := NewAgent(&fakeAuth{}, discardLogger())
+
+	result, _ := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion + 5})
+	if result["protocolVersion"] != ProtocolVersion {
+		t.Errorf("protocolVersion = %v, want %d", result["protocolVersion"], ProtocolVersion)
+	}
+}
+
+// ADR 0015: v1 is a control surface, not a workspace. The sprite's files are
+// on a different machine from the editor's, and an agent that claims fs or
+// terminal capability appears to be editing the open project and is not.
+func TestInitializeDeclaresNoWorkspaceCapabilities(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+
+	result, _ := request(t, a, "initialize", map[string]any{
+		"protocolVersion": ProtocolVersion,
+		"clientCapabilities": map[string]any{
+			"fs":       map[string]any{"readTextFile": true, "writeTextFile": true},
+			"terminal": true,
+		},
+	})
+
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	for _, forbidden := range []string{"readTextFile", "writeTextFile", "terminal"} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Errorf("initialize result mentions %q — v1 requests no workspace capabilities: %s", forbidden, encoded)
+		}
+	}
+}
+
+// loadSession obliges the agent to replay the whole conversation before
+// answering. Claiming it before that exists (#703) leaves an editor showing an
+// empty transcript for a conversation that has one.
+func TestInitializeDoesNotClaimCapabilitiesItCannotHonour(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+
+	result, _ := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+
+	caps, ok := result["agentCapabilities"].(map[string]any)
+	if !ok {
+		t.Fatalf("agentCapabilities missing: %v", result)
+	}
+	if caps["loadSession"] != false {
+		t.Errorf("loadSession = %v, want false until #703 builds the replay", caps["loadSession"])
+	}
+	prompt := caps["promptCapabilities"].(map[string]any)
+	for _, k := range []string{"image", "audio", "embeddedContext"} {
+		if prompt[k] != false {
+			t.Errorf("promptCapabilities.%s = %v, want false until #701 builds the prompt path", k, prompt[k])
+		}
+	}
+}
+
+func TestInitializeOffersLoginWhenThereAreNoCredentials(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: false}, discardLogger())
+
+	result, _ := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+
+	methods, ok := result["authMethods"].([]map[string]any)
+	if !ok || len(methods) != 1 {
+		t.Fatalf("authMethods = %v, want one method", result["authMethods"])
+	}
+	if methods[0]["id"] != AuthMethodID {
+		t.Errorf("auth method id = %v, want %q", methods[0]["id"], AuthMethodID)
+	}
+	if !strings.Contains(methods[0]["description"].(string), "fountain auth login") {
+		t.Errorf("description = %v, want it to name the command that fixes it", methods[0]["description"])
+	}
+	if a.Authenticated() {
+		t.Error("agent considers itself authenticated with no credentials")
+	}
+}
+
+// An editor shown a login prompt for a CLI that is already logged in has been
+// told something false about its own state.
+func TestInitializeOffersNoLoginWhenCredentialsExist(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+
+	result, _ := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+
+	if methods := result["authMethods"].([]map[string]any); len(methods) != 0 {
+		t.Errorf("authMethods = %v, want none when credentials are present", methods)
+	}
+	if !a.Authenticated() {
+		t.Error("agent should treat present credentials as good enough to proceed")
+	}
+}
+
+// initialize runs on every editor spawn and must not wait on the network to
+// decide whether to show a login prompt.
+func TestInitializeDoesNotHitTheNetwork(t *testing.T) {
+	auth := &fakeAuth{available: true}
+	a := NewAgent(auth, discardLogger())
+
+	request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+
+	if auth.verifies != 0 {
+		t.Errorf("initialize called Verify %d times, want 0", auth.verifies)
+	}
+}
+
+func TestAuthenticateVerifiesTheCredentials(t *testing.T) {
+	auth := &fakeAuth{available: true}
+	a := NewAgent(auth, discardLogger())
+
+	if _, rpcErr := request(t, a, "authenticate", map[string]any{"methodId": AuthMethodID}); rpcErr != nil {
+		t.Fatalf("authenticate failed: %v", rpcErr)
+	}
+	if auth.verifies != 1 {
+		t.Errorf("Verify called %d times, want 1", auth.verifies)
+	}
+	if !a.Authenticated() {
+		t.Error("agent did not record a successful authentication")
+	}
+}
+
+// The message is the whole value of this branch: it is read inside an editor
+// by someone who cannot see a 401.
+func TestAuthenticateRejectionNamesTheFixAndTheInstance(t *testing.T) {
+	auth := &fakeAuth{available: true, verifyErr: errors.New("http 401")}
+	a := NewAgent(auth, discardLogger())
+
+	_, rpcErr := request(t, a, "authenticate", map[string]any{"methodId": AuthMethodID})
+	if rpcErr == nil {
+		t.Fatal("authenticate accepted credentials the server rejected")
+	}
+	if rpcErr.Code != CodeAuthRequired {
+		t.Errorf("code = %d, want %d", rpcErr.Code, CodeAuthRequired)
+	}
+	if !strings.Contains(rpcErr.Message, "fountain auth login") {
+		t.Errorf("message = %q, want it to name the command that fixes it", rpcErr.Message)
+	}
+	if !strings.Contains(rpcErr.Message, "example.test") {
+		t.Errorf("message = %q, want it to name the instance it tried", rpcErr.Message)
+	}
+	if a.Authenticated() {
+		t.Error("a rejected authentication left the agent authenticated")
+	}
+}
+
+func TestAuthenticateWithNoCredentialsSaysSo(t *testing.T) {
+	auth := &fakeAuth{available: false}
+	a := NewAgent(auth, discardLogger())
+
+	_, rpcErr := request(t, a, "authenticate", map[string]any{"methodId": AuthMethodID})
+	if rpcErr == nil || rpcErr.Code != CodeAuthRequired {
+		t.Fatalf("want an auth-required error, got %v", rpcErr)
+	}
+	if auth.verifies != 0 {
+		t.Errorf("Verify called %d times with no credentials to verify, want 0", auth.verifies)
+	}
+}
+
+func TestAuthenticateRejectsAnUnknownMethod(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+
+	_, rpcErr := request(t, a, "authenticate", map[string]any{"methodId": "oauth"})
+	if rpcErr == nil || rpcErr.Code != CodeInvalidParams {
+		t.Fatalf("want invalid params for an unknown auth method, got %v", rpcErr)
+	}
+}
+
+// The session methods are the next three issues. Until they exist, saying so
+// is better than a silent success an editor would sit and wait on.
+func TestSessionMethodsAreNotFoundYet(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+
+	for _, method := range []string{"session/new", "session/prompt", "session/load", "session/cancel"} {
+		_, rpcErr := request(t, a, method, map[string]any{})
+		if rpcErr == nil || rpcErr.Code != CodeMethodNotFound {
+			t.Errorf("%s: want method-not-found, got %v", method, rpcErr)
+		}
+	}
+}
+
+func TestMalformedParamsAreInvalidParamsNotACrash(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+
+	_, err := a.Request(context.Background(), "initialize", json.RawMessage(`{"protocolVersion":`))
+	var rpcErr *Error
+	if !errors.As(err, &rpcErr) || rpcErr.Code != CodeInvalidParams {
+		t.Fatalf("want invalid params, got %v", err)
+	}
+}
+
+// Some clients send initialize with no params at all.
+func TestInitializeWithNoParamsStillAnswers(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+
+	result, rpcErr := request(t, a, "initialize", nil)
+	if rpcErr != nil {
+		t.Fatalf("initialize with no params failed: %v", rpcErr)
+	}
+	if result["protocolVersion"] != ProtocolVersion {
+		t.Errorf("protocolVersion = %v, want %d", result["protocolVersion"], ProtocolVersion)
+	}
+}

--- a/cli/internal/acp/jsonrpc.go
+++ b/cli/internal/acp/jsonrpc.go
@@ -1,0 +1,220 @@
+// Package acp implements the agent half of the Agent Client Protocol: the
+// side an editor spawns, speaks JSON-RPC to over stdio, and expects session
+// updates back from.
+//
+// It is the upward direction of [ADR 0015]. The downward direction — Fountain
+// as an ACP *client* of the coding agent running in a sprite — lives in the
+// Elixir server (Fountain.Runtimes.ACP), and that is deliberate: the four
+// runtime dialects are translated once, on the server, at the only boundary
+// that knows which runtime produced the bytes. Nothing in this package parses
+// a runtime dialect, and nothing in it ever should.
+//
+// [ADR 0015]: https://github.com/BinaryBourbon/fountain/blob/main/decisions/0015-fountain-as-an-acp-agent.md
+package acp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// JSON-RPC 2.0 error codes, plus the ones ACP leans on.
+const (
+	CodeParseError     = -32700
+	CodeInvalidRequest = -32600
+	CodeMethodNotFound = -32601
+	CodeInvalidParams  = -32602
+	CodeInternalError  = -32603
+	// CodeAuthRequired is ACP's own: the client must call `authenticate`
+	// before the session methods will answer.
+	CodeAuthRequired = -32000
+)
+
+// Error is a JSON-RPC error the handler wants reported verbatim. Any other
+// error from a handler becomes an internal error with its message attached.
+type Error struct {
+	Code    int
+	Message string
+	Data    any
+}
+
+func (e *Error) Error() string { return fmt.Sprintf("jsonrpc %d: %s", e.Code, e.Message) }
+
+// Errorf builds an *Error with a formatted message.
+func Errorf(code int, format string, a ...any) *Error {
+	return &Error{Code: code, Message: fmt.Sprintf(format, a...)}
+}
+
+// Handler answers one incoming message.
+//
+// Request returns the value to encode as `result`; returning an *Error sends
+// that error back to the client. Notify is fire-and-forget: JSON-RPC forbids
+// a response to a notification, so an error from it can only be logged.
+type Handler interface {
+	Request(ctx context.Context, method string, params json.RawMessage) (any, error)
+	Notify(ctx context.Context, method string, params json.RawMessage)
+}
+
+// message is the wire shape of everything arriving on stdin. The four
+// JSON-RPC kinds are distinguished by which fields are present, so they share
+// one struct rather than four with a discriminator that ACP does not send.
+type message struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Conn is one ACP connection: line-delimited JSON in, line-delimited JSON out.
+//
+// Writes are serialised because the agent has two writers — request responses
+// and, from the session methods, unsolicited `session/update` notifications
+// forwarded from a stream goroutine. Two interleaved writes produce one
+// unparseable line, which an editor reports as the agent crashing.
+type Conn struct {
+	in  *bufio.Reader
+	out io.Writer
+	log *slog.Logger
+
+	mu sync.Mutex // guards out
+}
+
+// NewConn wires a connection to the given streams. For `fountain acp` these
+// are the process's stdin and stdout: stdout carries the protocol and nothing
+// else, which is why every diagnostic in this package goes to the logger
+// (stderr) instead.
+func NewConn(in io.Reader, out io.Writer, log *slog.Logger) *Conn {
+	return &Conn{in: bufio.NewReader(in), out: out, log: log}
+}
+
+// Serve reads messages until stdin closes or ctx is cancelled.
+//
+// A closed stdin is how an editor says "we're done" — it is a clean exit, not
+// an error. Serve returns nil for it, and for a cancelled context.
+func (c *Conn) Serve(ctx context.Context, h Handler) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+
+		line, err := c.in.ReadString('\n')
+		if len(line) > 0 {
+			c.dispatch(ctx, h, line)
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// dispatch handles one framed line.
+//
+// A line that is not JSON is logged and skipped rather than fatal. The server
+// peer made the same call for the same reason (see Protocol.feed/2's "why the
+// decode failure is a value"): npm deprecation notices and Node stack traces
+// turn up on pipes that are supposed to carry only protocol, and killing the
+// connection over somebody else's diagnostic is the wrong trade.
+func (c *Conn) dispatch(ctx context.Context, h Handler, line string) {
+	if strings.TrimSpace(line) == "" {
+		return
+	}
+
+	var msg message
+	if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		c.log.Warn("dropping unparseable line from client", "err", err, "line", truncate(line, 256))
+		return
+	}
+
+	switch {
+	case msg.Method == "" && len(msg.ID) > 0:
+		// A response to something we sent. Nothing in this package sends
+		// requests yet; when session/request_permission forwarding lands
+		// (#708) this is where its answers arrive.
+		c.log.Debug("ignoring response to a request we did not send", "id", string(msg.ID))
+
+	case msg.Method == "":
+		c.log.Warn("dropping message with no method and no id", "line", truncate(line, 256))
+
+	case len(msg.ID) == 0:
+		h.Notify(ctx, msg.Method, msg.Params)
+
+	default:
+		result, err := h.Request(ctx, msg.Method, msg.Params)
+		c.respond(msg, result, err)
+	}
+}
+
+func (c *Conn) respond(msg message, result any, err error) {
+	if err != nil {
+		var rpcErr *Error
+		if !errors.As(err, &rpcErr) {
+			rpcErr = &Error{Code: CodeInternalError, Message: err.Error()}
+		}
+		c.log.Warn("request failed", "method", msg.Method, "code", rpcErr.Code, "err", rpcErr.Message)
+		c.write(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      msg.ID,
+			"error":   errorPayload(rpcErr),
+		})
+		return
+	}
+
+	if result == nil {
+		// ACP methods that answer with nothing (`authenticate`,
+		// `session/cancel`) still owe a response; `{}` is a result, `null`
+		// reads to some clients as a missing one.
+		result = struct{}{}
+	}
+	c.write(map[string]any{"jsonrpc": "2.0", "id": msg.ID, "result": result})
+}
+
+func errorPayload(e *Error) map[string]any {
+	payload := map[string]any{"code": e.Code, "message": e.Message}
+	if e.Data != nil {
+		payload["data"] = e.Data
+	}
+	return payload
+}
+
+// Notify sends a notification to the client. This is how `session/update`
+// will leave the process once the stream forwarding lands (#701).
+func (c *Conn) Notify(method string, params any) {
+	msg := map[string]any{"jsonrpc": "2.0", "method": method}
+	if params != nil {
+		msg["params"] = params
+	}
+	c.write(msg)
+}
+
+func (c *Conn) write(v any) {
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		// Marshalling our own message failed: writing a half-encoded line
+		// would corrupt the stream for every message after it.
+		c.log.Error("failed to encode outgoing message", "err", err)
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, err := c.out.Write(append(encoded, '\n')); err != nil {
+		c.log.Error("failed to write to client", "err", err)
+	}
+}
+
+func truncate(s string, n int) string {
+	s = strings.TrimRight(s, "\r\n")
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/cli/internal/acp/jsonrpc_test.go
+++ b/cli/internal/acp/jsonrpc_test.go
@@ -1,0 +1,246 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// recorder is a Handler that remembers what it was asked, and answers with
+// whatever the test set up.
+type recorder struct {
+	result   any
+	err      error
+	requests []string
+	notifies []string
+}
+
+func (r *recorder) Request(_ context.Context, method string, _ json.RawMessage) (any, error) {
+	r.requests = append(r.requests, method)
+	return r.result, r.err
+}
+
+func (r *recorder) Notify(_ context.Context, method string, _ json.RawMessage) {
+	r.notifies = append(r.notifies, method)
+}
+
+// serve runs one connection over a fixed input and returns the decoded output
+// lines.
+func serve(t *testing.T, h Handler, input string) []map[string]any {
+	t.Helper()
+
+	var out strings.Builder
+	conn := NewConn(strings.NewReader(input), &out, discardLogger())
+	if err := conn.Serve(context.Background(), h); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	return decodeLines(t, out.String())
+}
+
+func decodeLines(t *testing.T, s string) []map[string]any {
+	t.Helper()
+
+	var msgs []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("output line is not JSON: %q: %v", line, err)
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs
+}
+
+func TestRequestGetsAResponseWithTheSameID(t *testing.T) {
+	h := &recorder{result: map[string]any{"ok": true}}
+	out := serve(t, h, `{"jsonrpc":"2.0","id":7,"method":"initialize","params":{}}`+"\n")
+
+	if len(out) != 1 {
+		t.Fatalf("want 1 response, got %d: %v", len(out), out)
+	}
+	if got := out[0]["id"]; got != float64(7) {
+		t.Errorf("id = %v, want 7", got)
+	}
+	result, ok := out[0]["result"].(map[string]any)
+	if !ok || result["ok"] != true {
+		t.Errorf("result = %v, want {ok:true}", out[0]["result"])
+	}
+}
+
+// A string id is as legal as a numeric one, and echoing it back as a number
+// (or as a quoted number) breaks correlation on the client.
+func TestRequestIDIsEchoedVerbatim(t *testing.T) {
+	h := &recorder{result: map[string]any{}}
+	out := serve(t, h, `{"jsonrpc":"2.0","id":"abc-1","method":"initialize"}`+"\n")
+
+	if got := out[0]["id"]; got != "abc-1" {
+		t.Errorf("id = %#v, want \"abc-1\"", got)
+	}
+}
+
+// JSON-RPC forbids responding to a notification. An editor that receives a
+// response it never asked for has an orphan in its correlation table.
+func TestNotificationGetsNoResponse(t *testing.T) {
+	h := &recorder{result: map[string]any{"ok": true}}
+	out := serve(t, h, `{"jsonrpc":"2.0","method":"session/cancel","params":{}}`+"\n")
+
+	if len(out) != 0 {
+		t.Fatalf("want no output for a notification, got %v", out)
+	}
+	if len(h.notifies) != 1 || h.notifies[0] != "session/cancel" {
+		t.Errorf("notifies = %v, want [session/cancel]", h.notifies)
+	}
+	if len(h.requests) != 0 {
+		t.Errorf("a notification was dispatched as a request: %v", h.requests)
+	}
+}
+
+func TestHandlerErrorBecomesAJSONRPCError(t *testing.T) {
+	h := &recorder{err: Errorf(CodeMethodNotFound, "method not found: nope")}
+	out := serve(t, h, `{"jsonrpc":"2.0","id":1,"method":"nope"}`+"\n")
+
+	errObj, ok := out[0]["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("want an error object, got %v", out[0])
+	}
+	if errObj["code"] != float64(CodeMethodNotFound) {
+		t.Errorf("code = %v, want %d", errObj["code"], CodeMethodNotFound)
+	}
+	if _, hasResult := out[0]["result"]; hasResult {
+		t.Error("an error response must not also carry a result")
+	}
+}
+
+// A plain error is not a protocol error, and leaking it as one (or as a
+// crash) tells the editor something false about whose fault it was.
+func TestPlainErrorBecomesAnInternalError(t *testing.T) {
+	h := &recorder{err: io.ErrUnexpectedEOF}
+	out := serve(t, h, `{"jsonrpc":"2.0","id":1,"method":"initialize"}`+"\n")
+
+	errObj := out[0]["error"].(map[string]any)
+	if errObj["code"] != float64(CodeInternalError) {
+		t.Errorf("code = %v, want %d", errObj["code"], CodeInternalError)
+	}
+	if !strings.Contains(errObj["message"].(string), "unexpected EOF") {
+		t.Errorf("message = %v, want it to carry the underlying error", errObj["message"])
+	}
+}
+
+// The server peer made the same call for the same reason: adapters print
+// deprecation notices and stack traces onto pipes that are supposed to carry
+// only protocol. Killing the connection over somebody else's diagnostic would
+// end a working session.
+func TestGarbageLineIsSkippedAndTheNextMessageStillAnswers(t *testing.T) {
+	h := &recorder{result: map[string]any{}}
+	input := "npm warn deprecated something@1.0.0\n" +
+		`{"jsonrpc":"2.0","id":2,"method":"initialize"}` + "\n"
+
+	out := serve(t, h, input)
+
+	if len(out) != 1 || out[0]["id"] != float64(2) {
+		t.Fatalf("want one response to id 2, got %v", out)
+	}
+}
+
+func TestBlankLinesAreIgnored(t *testing.T) {
+	h := &recorder{result: map[string]any{}}
+	out := serve(t, h, "\n\n"+`{"jsonrpc":"2.0","id":1,"method":"initialize"}`+"\n\n")
+
+	if len(out) != 1 {
+		t.Fatalf("want 1 response, got %d: %v", len(out), out)
+	}
+}
+
+// An editor closing the pipe is how a session ends. It is not a failure, and
+// a non-zero exit turns every normal shutdown into a bug report.
+func TestClosedStdinIsACleanExit(t *testing.T) {
+	conn := NewConn(strings.NewReader(""), &strings.Builder{}, discardLogger())
+	if err := conn.Serve(context.Background(), &recorder{}); err != nil {
+		t.Errorf("Serve on empty input = %v, want nil", err)
+	}
+}
+
+// A final message with no trailing newline still has to be answered — some
+// clients do not terminate the last line before closing the pipe.
+func TestUnterminatedFinalLineIsStillHandled(t *testing.T) {
+	h := &recorder{result: map[string]any{}}
+	out := serve(t, h, `{"jsonrpc":"2.0","id":3,"method":"initialize"}`)
+
+	if len(out) != 1 || out[0]["id"] != float64(3) {
+		t.Fatalf("want a response to id 3, got %v", out)
+	}
+}
+
+func TestCancelledContextStopsServing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	conn := NewConn(strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`+"\n"), &strings.Builder{}, discardLogger())
+	if err := conn.Serve(ctx, &recorder{}); err != nil {
+		t.Errorf("Serve with a cancelled context = %v, want nil", err)
+	}
+}
+
+// Responses and forwarded session/update notifications are written by
+// different goroutines. Two interleaved writes produce one unparseable line,
+// which an editor reports as the agent crashing.
+func TestConcurrentWritesProduceWholeLines(t *testing.T) {
+	out := &splittingWriter{}
+	conn := NewConn(strings.NewReader(""), out, discardLogger())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			conn.Notify("session/update", map[string]any{"n": i, "pad": strings.Repeat("x", 512)})
+		}(i)
+	}
+	wg.Wait()
+
+	lines := decodeLines(t, out.String())
+	if len(lines) != 50 {
+		t.Fatalf("want 50 whole lines, got %d", len(lines))
+	}
+}
+
+// splittingWriter is the test's stand-in for a pipe that does not deliver a
+// Write atomically: it splits every write in two and yields in between. A
+// writer that locked for the whole call would serialise on its own behalf and
+// the test would pass with Conn's mutex removed — proving nothing.
+type splittingWriter struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (w *splittingWriter) Write(p []byte) (int, error) {
+	half := len(p) / 2
+	w.append(p[:half])
+	runtime.Gosched()
+	w.append(p[half:])
+	return len(p), nil
+}
+
+func (w *splittingWriter) append(p []byte) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.b.Write(p)
+}
+
+func (w *splittingWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.String()
+}

--- a/cli/internal/cmd/acp.go
+++ b/cli/internal/cmd/acp.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/acp"
+	"github.com/BinaryBourbon/fountain/cli/internal/api"
+	"github.com/BinaryBourbon/fountain/cli/internal/config"
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+	"github.com/spf13/cobra"
+)
+
+var acpLogLevel string
+
+func init() {
+	acpCmd := &cobra.Command{
+		Use:   "acp",
+		Short: "Speak the Agent Client Protocol on stdio (spawned by an editor)",
+		Long: `Speak the Agent Client Protocol on stdio.
+
+Not meant to be run by hand: an ACP-capable editor spawns this process and
+talks JSON-RPC to it over the pipe. stdout carries the protocol and nothing
+else; diagnostics go to stderr.
+
+What it is, and is not: a control surface for a conversation running in a
+Fountain sandbox — watch it, steer it, interrupt it. It has no access to the
+files open in your editor, and the paths it reports are inside the sandbox,
+not on your machine.`,
+		RunE: func(cmd *cobra.Command, args []string) error { return runACP() },
+	}
+	acpCmd.Flags().StringVar(&acpLogLevel, "log-level", "info", "stderr log level: debug, info, warn, error")
+	rootCmd.AddCommand(acpCmd)
+}
+
+func runACP() error {
+	level, err := parseLogLevel(acpLogLevel)
+	if err != nil {
+		return err
+	}
+
+	// Every diagnostic goes to stderr. A single stray byte on stdout is an
+	// unparseable line to the editor, which reports it as the agent crashing.
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+
+	// SIGINT/SIGTERM and a closed stdin are the two ways an editor ends this
+	// process, and both are ordinary. Neither is an error exit.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	opts := activeOpts()
+	agent := acp.NewAgent(cliAuth{opts: opts}, log)
+
+	log.Info("fountain acp starting",
+		"base_url", config.BaseURL(opts),
+		"profile", credentials.ProfileName(opts))
+
+	return acp.NewConn(os.Stdin, os.Stdout, log).Serve(ctx, agent)
+}
+
+func parseLogLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return 0, fmt.Errorf("unknown log level %q (want debug, info, warn or error)", s)
+	}
+}
+
+// cliAuth resolves credentials exactly the way every other subcommand does —
+// FOUNTAIN_API_KEY, then the active profile in ~/.fountain/credentials. ADR
+// 0015 declines ACP's remote transport partly to keep this in one place; a
+// second credential path reachable only from an editor is the thing that
+// decision exists to avoid.
+type cliAuth struct {
+	opts credentials.Opts
+}
+
+func (a cliAuth) Available() bool {
+	_, err := config.APIKey(a.opts)
+	return err == nil
+}
+
+// Verify ignores its context because api.Client builds its own (with a 60s
+// timeout) per request. Threading one through is a change to every caller of
+// that package, and belongs with the streaming work that actually needs
+// cancellation (#704), not here.
+func (a cliAuth) Verify(context.Context) error {
+	var out authMe
+	return api.New(a.opts).Get("/auth/me", &out)
+}
+
+// Describe names the instance and profile the credentials belong to. Pointing
+// an editor at the wrong instance produces auth failures that look like a bad
+// password, so the answer says which door was tried.
+func (a cliAuth) Describe() string {
+	return fmt.Sprintf("%s (profile %s)", config.BaseURL(a.opts), credentials.ProfileName(a.opts))
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -118,6 +118,31 @@ Disconnecting loses nothing — reattach at any time:
 fountain conv stream <conversation-id>
 ```
 
+## Editor integration (ACP)
+
+```bash
+fountain acp [--log-level debug]
+```
+
+Speaks the [Agent Client Protocol](https://agentclientprotocol.com) on stdio, so
+an ACP-capable editor can drive a Fountain conversation. You do not run this
+yourself — the editor spawns it and talks JSON-RPC over the pipe. stdout carries
+the protocol and nothing else; diagnostics go to stderr, which is where to look
+first when an editor reports a problem.
+
+It authenticates with the same credentials as every other command
+(`FOUNTAIN_API_KEY`, then the active profile), so `fountain auth login` is the
+only setup step. `--profile` selects the instance.
+
+**What it is not:** a way for a remote agent to edit your local files. The agent
+works inside a Fountain sandbox, on a checkout that is not yours, and this
+integration declares no filesystem or terminal access to your editor at all.
+Paths it reports are paths inside the sandbox.
+
+Status: in progress. Today the process handshakes and authenticates; the session
+methods that carry a conversation are being built
+([tracker](https://github.com/BinaryBourbon/fountain/issues/709)).
+
 ## Apply manifests
 
 ```bash


### PR DESCRIPTION
Closes #698. Gate 1 of **ADR 0015** (#631), tracked by #709.

#644 made Fountain an ACP *client* of the runtimes it runs in sprites. This is
the first piece of the other direction: Fountain as an ACP *agent*, so a
conversation is reachable from an editor. Together they make Fountain a proxy —
the same block vocabulary arriving from a sprite on one side and leaving for an
editor on the other.

## What lands

`cli/internal/acp` — a JSON-RPC 2.0 peer over stdio, and the two methods that
come before any session: `initialize` and `authenticate`. Plus `fountain acp`
wiring it to the process's stdin/stdout, and a docs section.

## Verified by hand

```console
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,
  "clientCapabilities":{"fs":{"readTextFile":true,"writeTextFile":true},"terminal":true}}}' \
  | fountain acp
{"id":1,"jsonrpc":"2.0","result":{"agentCapabilities":{"loadSession":false,
 "promptCapabilities":{"audio":false,"embeddedContext":false,"image":false}},
 "authMethods":[{"description":"Run `fountain auth login` in a terminal, then retry.",
 "id":"fountain-cli-login","name":"Fountain CLI login"}],"protocolVersion":1}}
```

With a key present, `authMethods` comes back empty. A client offering
`protocolVersion: 9` is answered with `1`. `session/new` answers
method-not-found. Diagnostics went to stderr; stdout carried protocol only.

## Three choices worth reviewing

**No workspace capabilities, declared and tested.** A Fountain agent edits a
sprite's files, on a machine that is not the developer's. The handshake
requests no `fs/*` and no `terminal/*`, and a test fails if the response so
much as mentions them. ADR 0015 is explicit that any design pretending
otherwise "produces an agent that appears to be editing the open project and is
not". Read-through and workspace sync are separate decisions and must not
arrive through a protocol adapter.

**Capabilities we cannot honour stay false.** `loadSession` obliges the agent to
replay a whole conversation as `session/update` notifications before answering
— claiming it now would leave an editor showing an empty transcript for a
conversation that has one. It flips in #703. Prompt capabilities are the same
bet on #701: the API behind them already carries images, this process does not
yet.

**Auth is local at `initialize`, network at `authenticate`.** An editor deciding
whether to show a login prompt must not wait on a round trip, so `initialize`
only checks whether credentials resolve. `authenticate` is what verifies them.
Rejections name the instance *and* the command that fixes them, because they
are read inside an editor by someone who cannot see a 401.

## Smaller decisions

- **A line that is not JSON is logged and skipped, not fatal.** The same call
  `Protocol.feed/2` makes on the server side, for the same reason: npm
  deprecation notices and Node stack traces turn up on pipes that are supposed
  to carry only protocol.
- **Writes are serialised.** Two writers exist the moment #701 lands (responses
  and forwarded `session/update`), and two interleaved writes produce one
  unparseable line, which an editor reports as the agent crashing. The test
  uses a writer that deliberately splits every write in half, so it would fail
  if the mutex were removed.
- **Everything diagnostic goes to stderr.** A single stray byte on stdout
  corrupts the session, and stderr is where every editor bug report about this
  adapter will start. `--log-level` is there for that.

## Rules this PR is holding

**No dialect parser lands in `cli/`** — the rule ADR 0015 exists to enforce and
the reason it waited for #644. Nothing here parses runtime output; when #701
lands it forwards `session/update` lines the server already stores verbatim on
the `acp` log stream.

Session methods answer method-not-found rather than succeeding silently — an
editor sitting forever on a request that will never be answered is a worse
first impression than a clear refusal.

## Tests

`go test ./... && go vet ./...` green; `internal/acp` also passes under `-race`.
The docs guard (`TestEveryCommandIsDocumented`) forced the `docs/cli.md`
section, which is working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
