### PR TITLE
feat: session/new picks a Fountain agent and opens a conversation (#699, #702)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/agent_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_json.ex
@@ -13,6 +13,13 @@ defmodule FountainWeb.AgentJSON do
       system: a.system,
       model: a.model,
       runtime: a.runtime,
+      # Derived, never stored: whether this agent's runtime speaks ACP, and so
+      # whether a client outside the server can render its output as protocol
+      # rather than as one of the four proprietary dialects. `fountain acp`
+      # asks this before it opens a session (#702) — the alternative was a
+      # hardcoded runtime list in the Go CLI, which would go stale the day a
+      # held-back runtime is converted.
+      acp: Fountain.Runtimes.ACP.enabled?(a.runtime),
       sandbox_provider: a.sandbox_provider,
       environment_id: a.environment_id,
       skills: a.skills,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -250,6 +250,16 @@ defmodule FountainWeb.Schemas do
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
         runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        acp: %Schema{
+          type: :boolean,
+          readOnly: true,
+          description:
+            "Whether this agent's runtime speaks the Agent Client Protocol. Derived " <>
+              "from the runtime, never stored. When false, the conversation's output " <>
+              "is the runtime's own dialect on the `stdout` stream rather than ACP " <>
+              "`session/update` notifications on the `acp` stream, and a protocol " <>
+              "client such as `fountain acp` cannot render it."
+        },
         sandbox_provider: %Schema{
           type: :string,
           enum: ~w(sprites e2b daytona),

--- a/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
@@ -51,6 +51,22 @@ defmodule FountainWeb.AgentControllerTest do
       assert body["data"]["name"] == agent.name
     end
 
+    # `fountain acp` asks this before opening a session, so an editor is
+    # refused a runtime whose output it could not render (#702). Deriving it
+    # here rather than hardcoding a runtime list in the Go CLI is the point:
+    # that list changes when a held-back runtime is converted, and a client
+    # shipping a copy of it would be wrong until its next release.
+    test "reports whether the runtime speaks ACP", %{conn: conn, user: user, raw_key: raw_key} do
+      acp_agent = insert_agent(user_id: user.id, runtime: "claude")
+      legacy_agent = insert_agent(user_id: user.id, runtime: "gemini")
+
+      for {agent, expected} <- [{acp_agent, true}, {legacy_agent, false}] do
+        conn = conn |> authed_with_key(raw_key) |> get("/api/agents/#{agent.id}")
+
+        assert json_response(conn, 200)["data"]["acp"] == expected
+      end
+    end
+
     test "returns 404 when the agent belongs to a different user", %{conn: conn, raw_key: raw_key} do
       other_user = insert_verified_user()
       other_agent = insert_agent(user_id: other_user.id)

--- a/cli/internal/acp/agent.go
+++ b/cli/internal/acp/agent.go
@@ -42,7 +42,23 @@ type Auth interface {
 // separate decisions with their own ADRs — they do not arrive through here.
 type Agent struct {
 	auth Auth
+	api  API
 	log  *slog.Logger
+
+	// agentTarget is the Fountain agent (name or id) this process opens
+	// sessions against. ACP's `session/new` carries a `cwd` and a list of MCP
+	// servers but no notion of *which* agent, and the unit an editor is
+	// reaching for here is a provisioned Fountain agent — an environment,
+	// vault overrides, skills, MCP servers and inference credentials that
+	// never touch the developer's machine. So the choice is made where the
+	// editor already configures things: one agent-server entry per agent,
+	// `fountain acp --agent <name-or-id>`. Carrying it in `session/new`'s
+	// `_meta` instead would put the decision in a field most clients do not
+	// surface, and a default in the credentials file would make two editors
+	// on one machine fight over it.
+	agentTarget string
+
+	sessions *sessions
 
 	mu            sync.Mutex
 	initialized   bool
@@ -50,9 +66,16 @@ type Agent struct {
 	negotiated    int
 }
 
-// NewAgent returns an agent bound to a credential source.
-func NewAgent(auth Auth, log *slog.Logger) *Agent {
-	return &Agent{auth: auth, log: log}
+// NewAgent returns an agent bound to a credential source, the Fountain API,
+// and the agent sessions open against.
+func NewAgent(auth Auth, api API, agentTarget string, log *slog.Logger) *Agent {
+	return &Agent{
+		auth:        auth,
+		api:         api,
+		agentTarget: agentTarget,
+		sessions:    newSessions(),
+		log:         log,
+	}
 }
 
 type initializeParams struct {
@@ -71,6 +94,8 @@ func (a *Agent) Request(ctx context.Context, method string, params json.RawMessa
 		return a.initialize(params)
 	case "authenticate":
 		return a.authenticate(ctx, params)
+	case "session/new":
+		return a.newSession(ctx, params)
 	default:
 		return nil, Errorf(CodeMethodNotFound, "method not found: %s", method)
 	}

--- a/cli/internal/acp/agent_test.go
+++ b/cli/internal/acp/agent_test.go
@@ -23,6 +23,12 @@ func (f *fakeAuth) Verify(context.Context) error {
 
 func (f *fakeAuth) Describe() string { return "https://example.test (profile default)" }
 
+// newTestAgent builds an agent with no Fountain agent configured — enough for
+// the handshake tests. The session tests build their own with an API.
+func newTestAgent(auth Auth) *Agent {
+	return NewAgent(auth, &fakeAPI{}, "", discardLogger())
+}
+
 func request(t *testing.T, a *Agent, method string, params any) (map[string]any, *Error) {
 	t.Helper()
 
@@ -55,7 +61,7 @@ func request(t *testing.T, a *Agent, method string, params any) (map[string]any,
 }
 
 func TestInitializeAnswersWithOurProtocolVersion(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+	a := newTestAgent(&fakeAuth{available: true})
 
 	result, rpcErr := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
 	if rpcErr != nil {
@@ -72,7 +78,7 @@ func TestInitializeAnswersWithOurProtocolVersion(t *testing.T) {
 // A client newer than us must be answered with a version we can actually
 // speak, not with its own echoed back.
 func TestInitializeNegotiatesDownFromANewerClient(t *testing.T) {
-	a := NewAgent(&fakeAuth{}, discardLogger())
+	a := newTestAgent(&fakeAuth{})
 
 	result, _ := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion + 5})
 	if result["protocolVersion"] != ProtocolVersion {
@@ -84,7 +90,7 @@ func TestInitializeNegotiatesDownFromANewerClient(t *testing.T) {
 // on a different machine from the editor's, and an agent that claims fs or
 // terminal capability appears to be editing the open project and is not.
 func TestInitializeDeclaresNoWorkspaceCapabilities(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+	a := newTestAgent(&fakeAuth{available: true})
 
 	result, _ := request(t, a, "initialize", map[string]any{
 		"protocolVersion": ProtocolVersion,
@@ -109,7 +115,7 @@ func TestInitializeDeclaresNoWorkspaceCapabilities(t *testing.T) {
 // answering. Claiming it before that exists (#703) leaves an editor showing an
 // empty transcript for a conversation that has one.
 func TestInitializeDoesNotClaimCapabilitiesItCannotHonour(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+	a := newTestAgent(&fakeAuth{available: true})
 
 	result, _ := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
 
@@ -129,7 +135,7 @@ func TestInitializeDoesNotClaimCapabilitiesItCannotHonour(t *testing.T) {
 }
 
 func TestInitializeOffersLoginWhenThereAreNoCredentials(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: false}, discardLogger())
+	a := newTestAgent(&fakeAuth{available: false})
 
 	result, _ := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
 
@@ -151,7 +157,7 @@ func TestInitializeOffersLoginWhenThereAreNoCredentials(t *testing.T) {
 // An editor shown a login prompt for a CLI that is already logged in has been
 // told something false about its own state.
 func TestInitializeOffersNoLoginWhenCredentialsExist(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+	a := newTestAgent(&fakeAuth{available: true})
 
 	result, _ := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
 
@@ -167,7 +173,7 @@ func TestInitializeOffersNoLoginWhenCredentialsExist(t *testing.T) {
 // decide whether to show a login prompt.
 func TestInitializeDoesNotHitTheNetwork(t *testing.T) {
 	auth := &fakeAuth{available: true}
-	a := NewAgent(auth, discardLogger())
+	a := newTestAgent(auth)
 
 	request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
 
@@ -178,7 +184,7 @@ func TestInitializeDoesNotHitTheNetwork(t *testing.T) {
 
 func TestAuthenticateVerifiesTheCredentials(t *testing.T) {
 	auth := &fakeAuth{available: true}
-	a := NewAgent(auth, discardLogger())
+	a := newTestAgent(auth)
 
 	if _, rpcErr := request(t, a, "authenticate", map[string]any{"methodId": AuthMethodID}); rpcErr != nil {
 		t.Fatalf("authenticate failed: %v", rpcErr)
@@ -195,7 +201,7 @@ func TestAuthenticateVerifiesTheCredentials(t *testing.T) {
 // by someone who cannot see a 401.
 func TestAuthenticateRejectionNamesTheFixAndTheInstance(t *testing.T) {
 	auth := &fakeAuth{available: true, verifyErr: errors.New("http 401")}
-	a := NewAgent(auth, discardLogger())
+	a := newTestAgent(auth)
 
 	_, rpcErr := request(t, a, "authenticate", map[string]any{"methodId": AuthMethodID})
 	if rpcErr == nil {
@@ -217,7 +223,7 @@ func TestAuthenticateRejectionNamesTheFixAndTheInstance(t *testing.T) {
 
 func TestAuthenticateWithNoCredentialsSaysSo(t *testing.T) {
 	auth := &fakeAuth{available: false}
-	a := NewAgent(auth, discardLogger())
+	a := newTestAgent(auth)
 
 	_, rpcErr := request(t, a, "authenticate", map[string]any{"methodId": AuthMethodID})
 	if rpcErr == nil || rpcErr.Code != CodeAuthRequired {
@@ -229,7 +235,7 @@ func TestAuthenticateWithNoCredentialsSaysSo(t *testing.T) {
 }
 
 func TestAuthenticateRejectsAnUnknownMethod(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+	a := newTestAgent(&fakeAuth{available: true})
 
 	_, rpcErr := request(t, a, "authenticate", map[string]any{"methodId": "oauth"})
 	if rpcErr == nil || rpcErr.Code != CodeInvalidParams {
@@ -237,12 +243,12 @@ func TestAuthenticateRejectsAnUnknownMethod(t *testing.T) {
 	}
 }
 
-// The session methods are the next three issues. Until they exist, saying so
-// is better than a silent success an editor would sit and wait on.
+// The remaining session methods are the next issues. Until they exist, saying
+// so is better than a silent success an editor would sit and wait on.
 func TestSessionMethodsAreNotFoundYet(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+	a := newTestAgent(&fakeAuth{available: true})
 
-	for _, method := range []string{"session/new", "session/prompt", "session/load", "session/cancel"} {
+	for _, method := range []string{"session/prompt", "session/load", "session/cancel"} {
 		_, rpcErr := request(t, a, method, map[string]any{})
 		if rpcErr == nil || rpcErr.Code != CodeMethodNotFound {
 			t.Errorf("%s: want method-not-found, got %v", method, rpcErr)
@@ -251,7 +257,7 @@ func TestSessionMethodsAreNotFoundYet(t *testing.T) {
 }
 
 func TestMalformedParamsAreInvalidParamsNotACrash(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+	a := newTestAgent(&fakeAuth{available: true})
 
 	_, err := a.Request(context.Background(), "initialize", json.RawMessage(`{"protocolVersion":`))
 	var rpcErr *Error
@@ -262,7 +268,7 @@ func TestMalformedParamsAreInvalidParamsNotACrash(t *testing.T) {
 
 // Some clients send initialize with no params at all.
 func TestInitializeWithNoParamsStillAnswers(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: true}, discardLogger())
+	a := newTestAgent(&fakeAuth{available: true})
 
 	result, rpcErr := request(t, a, "initialize", nil)
 	if rpcErr != nil {

--- a/cli/internal/acp/session.go
+++ b/cli/internal/acp/session.go
@@ -1,0 +1,147 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+)
+
+// API is the slice of the Fountain HTTP API this adapter needs. It is an
+// interface so the protocol logic can be tested without a server, and so
+// nothing in this package holds an HTTP client, a token or a base URL — those
+// stay in the CLI layer that already resolves them for every other command.
+type API interface {
+	// Agent resolves a name or id to the agent it names.
+	Agent(ctx context.Context, target string) (AgentRef, error)
+	// CreateConversation starts a conversation for an agent and returns its id.
+	CreateConversation(ctx context.Context, agentID string) (string, error)
+}
+
+// AgentRef is what the adapter needs to know about a Fountain agent.
+type AgentRef struct {
+	ID      string
+	Name    string
+	Runtime string
+	// ACP reports whether the runtime speaks the protocol. The server derives
+	// it (GET /api/agents/:id) precisely so this file does not carry a list of
+	// runtime names that goes stale the day a held-back runtime is converted.
+	ACP bool
+}
+
+// Session is one editor-visible conversation.
+type Session struct {
+	// ID is the Fountain conversation id, used verbatim as the ACP session id.
+	//
+	// This aliasing is deliberate. ACP session ids are opaque to the client,
+	// and minting our own would mean holding a session→conversation map that
+	// dies with the process — so an editor reopening tomorrow could hand back
+	// a session id nothing could resolve, and `session/load` (#703) would have
+	// to persist a map to disk to work at all. The conversation id is already
+	// durable, already addressable, and already the thing the web UI shows.
+	//
+	// What must NOT leak upward is the third id: `runtime_session_id` belongs
+	// to the runtime inside the sandbox, means nothing outside the sandbox
+	// that holds it, and does not survive a reclaim (#649).
+	ID    string
+	Agent AgentRef
+}
+
+// sessions is the in-memory registry of sessions opened on this connection.
+type sessions struct {
+	mu sync.Mutex
+	m  map[string]Session
+}
+
+func newSessions() *sessions { return &sessions{m: map[string]Session{}} }
+
+func (s *sessions) put(sess Session) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[sess.ID] = sess
+}
+
+func (s *sessions) get(id string) (Session, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.m[id]
+	return sess, ok
+}
+
+type newSessionParams struct {
+	Cwd        string            `json:"cwd"`
+	MCPServers []json.RawMessage `json:"mcpServers"`
+}
+
+func (a *Agent) newSession(ctx context.Context, raw json.RawMessage) (any, error) {
+	var params newSessionParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, Errorf(CodeInvalidParams, "session/new: %s", err)
+		}
+	}
+
+	if err := a.requireReady(); err != nil {
+		return nil, err
+	}
+
+	// `cwd` is the editor's project directory, on the developer's machine. The
+	// agent works in a sandbox that cloned its own checkout, so this path
+	// names nothing we can act on — logged, so an editor's expectation is
+	// visible in the record, and otherwise ignored. Same for the editor's MCP
+	// servers: they are processes on the developer's machine, and a Fountain
+	// agent carries its own MCP configuration to the sandbox (#673).
+	if params.Cwd != "" || len(params.MCPServers) > 0 {
+		a.log.Info("ignoring client-side session parameters",
+			"cwd", params.Cwd,
+			"mcpServers", len(params.MCPServers),
+			"why", "the agent runs in a sandbox, not on this machine")
+	}
+
+	if a.agentTarget == "" {
+		return nil, Errorf(CodeInvalidParams,
+			"no Fountain agent configured — spawn this as `fountain acp --agent <name-or-id>`")
+	}
+
+	ref, err := a.api.Agent(ctx, a.agentTarget)
+	if err != nil {
+		return nil, Errorf(CodeInternalError,
+			"could not resolve agent %q on %s: %s", a.agentTarget, a.auth.Describe(), err)
+	}
+
+	// The refusal is the honest half of #702. An agent on the legacy path
+	// emits its runtime's own dialect, which this adapter deliberately cannot
+	// parse — forwarding nothing would leave an editor rendering an empty
+	// conversation while a sandbox ran and billed.
+	if !ref.ACP {
+		return nil, Errorf(CodeInvalidParams,
+			"agent %q runs the %s runtime, which does not speak ACP — use it from the web UI or the CLI, "+
+				"or point this at an agent whose runtime does",
+			ref.Name, ref.Runtime)
+	}
+
+	convID, err := a.api.CreateConversation(ctx, ref.ID)
+	if err != nil {
+		return nil, Errorf(CodeInternalError, "could not start a conversation for %q: %s", ref.Name, err)
+	}
+
+	sess := Session{ID: convID, Agent: ref}
+	a.sessions.put(sess)
+	a.log.Info("session opened", "sessionId", sess.ID, "agent", ref.Name, "runtime", ref.Runtime)
+
+	return map[string]any{"sessionId": sess.ID}, nil
+}
+
+// requireReady is the gate the session methods share: a client that has not
+// handshaked, or has no working credentials, gets a protocol error naming
+// which of the two it is rather than an authorization failure from three
+// layers down.
+func (a *Agent) requireReady() error {
+	if !a.Initialized() {
+		return Errorf(CodeInvalidRequest, "initialize must come first")
+	}
+	if !a.Authenticated() {
+		return Errorf(CodeAuthRequired,
+			"not authenticated for %s — run `fountain auth login`", a.auth.Describe())
+	}
+	return nil
+}

--- a/cli/internal/acp/session_test.go
+++ b/cli/internal/acp/session_test.go
@@ -1,0 +1,221 @@
+package acp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeAPI struct {
+	ref       AgentRef
+	agentErr  error
+	createErr error
+
+	resolved []string
+	created  []string
+	convID   string
+}
+
+func (f *fakeAPI) Agent(_ context.Context, target string) (AgentRef, error) {
+	f.resolved = append(f.resolved, target)
+	if f.agentErr != nil {
+		return AgentRef{}, f.agentErr
+	}
+	return f.ref, nil
+}
+
+func (f *fakeAPI) CreateConversation(_ context.Context, agentID string) (string, error) {
+	f.created = append(f.created, agentID)
+	if f.createErr != nil {
+		return "", f.createErr
+	}
+	if f.convID == "" {
+		return "conv-1", nil
+	}
+	return f.convID, nil
+}
+
+func acpAgentRef() AgentRef {
+	return AgentRef{ID: "agent-1", Name: "researcher", Runtime: "claude", ACP: true}
+}
+
+// sessionAgent returns an initialized, authenticated agent — the state a real
+// one is in by the time `session/new` arrives.
+func sessionAgent(t *testing.T, api *fakeAPI, target string) *Agent {
+	t.Helper()
+
+	a := NewAgent(&fakeAuth{available: true}, api, target, discardLogger())
+	if _, rpcErr := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion}); rpcErr != nil {
+		t.Fatalf("initialize failed: %v", rpcErr)
+	}
+	return a
+}
+
+func TestNewSessionCreatesAConversationForTheConfiguredAgent(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef(), convID: "conv-42"}
+	a := sessionAgent(t, api, "researcher")
+
+	result, rpcErr := request(t, a, "session/new", map[string]any{"cwd": "/home/dev/proj"})
+	if rpcErr != nil {
+		t.Fatalf("session/new failed: %v", rpcErr)
+	}
+
+	if result["sessionId"] != "conv-42" {
+		t.Errorf("sessionId = %v, want the conversation id", result["sessionId"])
+	}
+	if len(api.resolved) != 1 || api.resolved[0] != "researcher" {
+		t.Errorf("resolved = %v, want [researcher]", api.resolved)
+	}
+	if len(api.created) != 1 || api.created[0] != "agent-1" {
+		t.Errorf("created for = %v, want [agent-1]", api.created)
+	}
+}
+
+// The session id IS the conversation id, deliberately: an editor that stored
+// it yesterday must be able to hand it back to a process started today, and a
+// minted id would need a map that dies with the process.
+func TestSessionIsAddressableByTheConversationID(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef(), convID: "conv-42"}
+	a := sessionAgent(t, api, "researcher")
+
+	request(t, a, "session/new", map[string]any{})
+
+	sess, ok := a.sessions.get("conv-42")
+	if !ok {
+		t.Fatal("session not registered under the conversation id")
+	}
+	if sess.Agent.Name != "researcher" {
+		t.Errorf("session agent = %v, want researcher", sess.Agent.Name)
+	}
+}
+
+// #702: an agent on the legacy path emits its runtime's own dialect, which
+// this adapter deliberately cannot parse. Starting the conversation anyway
+// would bill a sandbox to render nothing.
+func TestNewSessionRefusesARuntimeThatDoesNotSpeakACP(t *testing.T) {
+	api := &fakeAPI{ref: AgentRef{ID: "agent-2", Name: "gem", Runtime: "gemini", ACP: false}}
+	a := sessionAgent(t, api, "gem")
+
+	_, rpcErr := request(t, a, "session/new", map[string]any{})
+	if rpcErr == nil {
+		t.Fatal("session/new accepted an agent whose runtime does not speak ACP")
+	}
+	if !strings.Contains(rpcErr.Message, "gemini") {
+		t.Errorf("message = %q, want it to name the runtime", rpcErr.Message)
+	}
+	if len(api.created) != 0 {
+		t.Errorf("a conversation was created for a runtime we cannot render: %v", api.created)
+	}
+}
+
+func TestNewSessionWithNoAgentConfiguredSaysHowToConfigureOne(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef()}
+	a := sessionAgent(t, api, "")
+
+	_, rpcErr := request(t, a, "session/new", map[string]any{})
+	if rpcErr == nil {
+		t.Fatal("session/new succeeded with no agent configured")
+	}
+	if !strings.Contains(rpcErr.Message, "--agent") {
+		t.Errorf("message = %q, want it to name the flag that fixes it", rpcErr.Message)
+	}
+	if len(api.resolved) != 0 {
+		t.Errorf("resolved an agent that was never configured: %v", api.resolved)
+	}
+}
+
+func TestNewSessionReportsAnUnresolvableAgent(t *testing.T) {
+	api := &fakeAPI{agentErr: errors.New(`no agent named "typo"`)}
+	a := sessionAgent(t, api, "typo")
+
+	_, rpcErr := request(t, a, "session/new", map[string]any{})
+	if rpcErr == nil {
+		t.Fatal("session/new succeeded with an agent that does not exist")
+	}
+	if !strings.Contains(rpcErr.Message, "typo") {
+		t.Errorf("message = %q, want it to name the agent it looked for", rpcErr.Message)
+	}
+	// The instance matters: the usual cause is an editor pointed at the wrong
+	// one, where every agent name is legitimately absent.
+	if !strings.Contains(rpcErr.Message, "example.test") {
+		t.Errorf("message = %q, want it to name the instance it asked", rpcErr.Message)
+	}
+}
+
+func TestNewSessionReportsAFailedConversationStart(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef(), createErr: errors.New("http 402: subscription_required")}
+	a := sessionAgent(t, api, "researcher")
+
+	_, rpcErr := request(t, a, "session/new", map[string]any{})
+	if rpcErr == nil {
+		t.Fatal("session/new reported success for a conversation that was never created")
+	}
+	if !strings.Contains(rpcErr.Message, "subscription_required") {
+		t.Errorf("message = %q, want it to carry the server's reason", rpcErr.Message)
+	}
+}
+
+// A client that skips the handshake gets told which step it missed, rather
+// than an error from three layers down.
+func TestNewSessionBeforeInitializeIsRefused(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, &fakeAPI{ref: acpAgentRef()}, "researcher", discardLogger())
+
+	_, rpcErr := request(t, a, "session/new", map[string]any{})
+	if rpcErr == nil || rpcErr.Code != CodeInvalidRequest {
+		t.Fatalf("want an invalid-request error, got %v", rpcErr)
+	}
+	if !strings.Contains(rpcErr.Message, "initialize") {
+		t.Errorf("message = %q, want it to name the missing step", rpcErr.Message)
+	}
+}
+
+func TestNewSessionWithoutCredentialsIsRefused(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef()}
+	a := NewAgent(&fakeAuth{available: false}, api, "researcher", discardLogger())
+	request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+
+	_, rpcErr := request(t, a, "session/new", map[string]any{})
+	if rpcErr == nil || rpcErr.Code != CodeAuthRequired {
+		t.Fatalf("want an auth-required error, got %v", rpcErr)
+	}
+	if len(api.created) != 0 {
+		t.Errorf("created a conversation for an unauthenticated client: %v", api.created)
+	}
+}
+
+// The editor's cwd and its MCP servers describe the developer's machine. The
+// agent runs in a sandbox, so acting on either would be acting on the wrong
+// computer — they are logged and ignored, and the session still opens.
+func TestClientSideSessionParametersAreIgnoredNotFatal(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef(), convID: "conv-7"}
+	a := sessionAgent(t, api, "researcher")
+
+	result, rpcErr := request(t, a, "session/new", map[string]any{
+		"cwd": "/home/dev/proj",
+		"mcpServers": []map[string]any{
+			{"name": "local-fs", "command": "/usr/local/bin/mcp-fs"},
+		},
+	})
+	if rpcErr != nil {
+		t.Fatalf("session/new failed: %v", rpcErr)
+	}
+	if result["sessionId"] != "conv-7" {
+		t.Errorf("sessionId = %v, want conv-7", result["sessionId"])
+	}
+}
+
+func TestTwoSessionsAreTrackedIndependently(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef(), convID: "conv-a"}
+	a := sessionAgent(t, api, "researcher")
+
+	request(t, a, "session/new", map[string]any{})
+	api.convID = "conv-b"
+	request(t, a, "session/new", map[string]any{})
+
+	for _, id := range []string{"conv-a", "conv-b"} {
+		if _, ok := a.sessions.get(id); !ok {
+			t.Errorf("session %s was not registered", id)
+		}
+	}
+}

--- a/cli/internal/cmd/acp.go
+++ b/cli/internal/cmd/acp.go
@@ -13,10 +13,14 @@ import (
 	"github.com/BinaryBourbon/fountain/cli/internal/api"
 	"github.com/BinaryBourbon/fountain/cli/internal/config"
 	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
-var acpLogLevel string
+var (
+	acpLogLevel string
+	acpAgent    string
+)
 
 func init() {
 	acpCmd := &cobra.Command{
@@ -28,12 +32,17 @@ Not meant to be run by hand: an ACP-capable editor spawns this process and
 talks JSON-RPC to it over the pipe. stdout carries the protocol and nothing
 else; diagnostics go to stderr.
 
+--agent names the Fountain agent a session runs — the protocol has no field
+for it, so it is configured here. Point one editor entry at each agent you
+want to reach.
+
 What it is, and is not: a control surface for a conversation running in a
 Fountain sandbox — watch it, steer it, interrupt it. It has no access to the
 files open in your editor, and the paths it reports are inside the sandbox,
 not on your machine.`,
 		RunE: func(cmd *cobra.Command, args []string) error { return runACP() },
 	}
+	acpCmd.Flags().StringVar(&acpAgent, "agent", "", "Fountain agent name or id to open sessions against")
 	acpCmd.Flags().StringVar(&acpLogLevel, "log-level", "info", "stderr log level: debug, info, warn, error")
 	rootCmd.AddCommand(acpCmd)
 }
@@ -54,11 +63,16 @@ func runACP() error {
 	defer stop()
 
 	opts := activeOpts()
-	agent := acp.NewAgent(cliAuth{opts: opts}, log)
+	agent := acp.NewAgent(cliAuth{opts: opts}, fountainAPI{opts: opts}, acpAgent, log)
 
+	// An unset --agent is not fatal here: the editor still gets a working
+	// handshake, and the refusal arrives at `session/new` where the editor can
+	// show it. Exiting at startup instead produces a process that dies before
+	// it can say why, which most clients report as "the agent crashed".
 	log.Info("fountain acp starting",
 		"base_url", config.BaseURL(opts),
-		"profile", credentials.ProfileName(opts))
+		"profile", credentials.ProfileName(opts),
+		"agent", acpAgent)
 
 	return acp.NewConn(os.Stdin, os.Stdout, log).Serve(ctx, agent)
 }
@@ -106,4 +120,69 @@ func (a cliAuth) Verify(context.Context) error {
 // password, so the answer says which door was tried.
 func (a cliAuth) Describe() string {
 	return fmt.Sprintf("%s (profile %s)", config.BaseURL(a.opts), credentials.ProfileName(a.opts))
+}
+
+// fountainAPI is the adapter's view of the HTTP API. Every other subcommand
+// reaches the API through Fatal-on-error helpers, which would be exactly wrong
+// here: a failure inside a session method is a JSON-RPC error the editor
+// renders, not a reason to kill a process the editor is talking to.
+type fountainAPI struct {
+	opts credentials.Opts
+}
+
+func (f fountainAPI) Agent(_ context.Context, target string) (acp.AgentRef, error) {
+	c := api.New(f.opts)
+
+	if isUUID(target) {
+		var resp struct {
+			Data map[string]any `json:"data"`
+		}
+		if err := c.Get("/agents/"+target, &resp); err != nil {
+			return acp.AgentRef{}, err
+		}
+		return agentRef(resp.Data), nil
+	}
+
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/agents", &resp); err != nil {
+		return acp.AgentRef{}, err
+	}
+	for _, a := range resp.Data {
+		if output.ToString(a["name"]) == target {
+			return agentRef(a), nil
+		}
+	}
+	return acp.AgentRef{}, fmt.Errorf("no agent named %q", target)
+}
+
+// agentRef reads the capability from the server rather than deciding it here.
+// A runtime list compiled into this binary would be wrong from the moment a
+// held-back runtime is converted until the next CLI release.
+func agentRef(data map[string]any) acp.AgentRef {
+	acpOK, _ := data["acp"].(bool)
+	return acp.AgentRef{
+		ID:      output.ToString(data["id"]),
+		Name:    output.ToString(data["name"]),
+		Runtime: output.ToString(data["runtime"]),
+		ACP:     acpOK,
+	}
+}
+
+func (f fountainAPI) CreateConversation(_ context.Context, agentID string) (string, error) {
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	// No prompt: the conversation is created empty and the editor's first
+	// `session/prompt` becomes turn 1. Provisioning starts server-side either
+	// way, so the sandbox is warming while the developer types.
+	if err := api.New(f.opts).Post("/conversations", map[string]any{"agent_id": agentID}, &resp); err != nil {
+		return "", err
+	}
+	id := output.ToString(resp.Data["id"])
+	if id == "" {
+		return "", fmt.Errorf("conversation created but the response carried no id")
+	}
+	return id, nil
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,7 +121,7 @@ fountain conv stream <conversation-id>
 ## Editor integration (ACP)
 
 ```bash
-fountain acp [--log-level debug]
+fountain acp --agent <name-or-id> [--log-level debug]
 ```
 
 Speaks the [Agent Client Protocol](https://agentclientprotocol.com) on stdio, so
@@ -130,9 +130,18 @@ yourself — the editor spawns it and talks JSON-RPC over the pipe. stdout carri
 the protocol and nothing else; diagnostics go to stderr, which is where to look
 first when an editor reports a problem.
 
+`--agent` names the Fountain agent that sessions run: the protocol has no field
+for it, so it is configured on the command line. Add one editor entry per agent
+you want to reach. Each session the editor opens creates its own conversation
+for that agent.
+
 It authenticates with the same credentials as every other command
 (`FOUNTAIN_API_KEY`, then the active profile), so `fountain auth login` is the
 only setup step. `--profile` selects the instance.
+
+Agents whose runtime does not speak ACP are refused when the editor opens a
+session, with the runtime named — today that is `gemini`. Use those from the web
+UI or `fountain run`.
 
 **What it is not:** a way for a remote agent to edit your local files. The agent
 works inside a Fountain sandbox, on a checkout that is not yours, and this


### PR DESCRIPTION
Closes #699. Closes #702. Gate 1 of **ADR 0015**, tracked by #709.

An editor can now open a session and get a real Fountain conversation back.

## Which agent? (#699)

`session/new` carries a `cwd` and a list of MCP servers — and no notion of
*which* agent to run. But the unit an editor is reaching for is a provisioned
Fountain agent: an environment, vault overrides, skills, MCP servers, and
inference credentials that never touch the developer's machine. That is four of
the five reasons ADR 0015 gives for using Fountain from an editor at all.

So the choice is made where an editor already configures things:

```
fountain acp --agent researcher
```

One editor entry per agent. The alternatives and why not: `_meta` on
`session/new` (most clients do not surface it), a default in the credentials
file (two editors on one machine would fight over it).

## The session id is the conversation id

Deliberate aliasing, not a shortcut. ACP session ids are opaque to the client,
so minting our own buys nothing and costs a map that dies with the process —
an editor reopening tomorrow would hand back an id nothing could resolve, and
#703's `session/load` would have to persist that map to disk to work at all.
The conversation id is already durable, already addressable, already what the
web UI shows.

The id that must **not** leak upward is the third one: `runtime_session_id`
belongs to the runtime inside the sandbox, means nothing outside the sandbox
holding it, and does not survive a reclaim (#649). Nothing in this adapter
reads it.

## Refusing a runtime we cannot render (#702)

An agent on the legacy path emits its runtime's own dialect on `stdout`, not
ACP notifications on the `acp` stream. Pointed at one, an editor would render
an empty conversation while a sandbox ran and billed. `session/new` refuses it,
names the runtime, and creates nothing.

**The capability is a server fact.** `GET /api/agents/:id` gained an `acp`
boolean, derived from `Runtimes.ACP.enabled?/1` and never stored:

```json
{"id": "...", "runtime": "claude", "acp": true}
```

A runtime list compiled into the Go binary would be wrong from the moment a
held-back runtime is converted until the next CLI release — which is exactly
the situation gemini (#659) will be in. Today `acp` is false only for gemini.

Additive: one new read-only field, in the JSON view and the OpenAPI schema.

## Two smaller calls

- **The editor's `cwd` and MCP servers are logged and ignored.** They describe
  the developer's machine; the agent is not on it. A Fountain agent carries its
  own MCP configuration to the sandbox (#673).
- **A missing `--agent` is refused at `session/new`, not at startup.** Exiting
  during spawn produces a process that dies before it can say why, which most
  editors report as "the agent crashed".

## Tests

Go: refusal paths assert **no conversation was created** — the failure that
would cost money is starting one we cannot render. Elixir: `acp` is asserted
true for claude and false for gemini through the real controller.
`go test ./... && go vet ./...` green; `mix test` green on the touched file;
`mix openapi.spec.json` emits the new property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
