### PR TITLE
feat: session/prompt runs a turn and streams it to the editor (#701)

### DIFF
--- a/cli/internal/acp/agent.go
+++ b/cli/internal/acp/agent.go
@@ -61,6 +61,7 @@ type Agent struct {
 	sessions *sessions
 
 	mu            sync.Mutex
+	notifier      Notifier
 	initialized   bool
 	authenticated bool
 	negotiated    int
@@ -96,6 +97,8 @@ func (a *Agent) Request(ctx context.Context, method string, params json.RawMessa
 		return a.authenticate(ctx, params)
 	case "session/new":
 		return a.newSession(ctx, params)
+	case "session/prompt":
+		return a.prompt(ctx, params)
 	default:
 		return nil, Errorf(CodeMethodNotFound, "method not found: %s", method)
 	}
@@ -157,13 +160,17 @@ func (a *Agent) initialize(raw json.RawMessage) (any, error) {
 // obliges us to replay a whole conversation as session/update notifications
 // before answering, and an agent that claims it and does not do it leaves an
 // editor showing an empty transcript for a conversation that has one.
-// Prompt capabilities stay false for the same reason — the prompt path is
-// #701 — even though the API behind them already carries images.
+//
+// `image` is true because the prompt path carries images to the API, which has
+// taken them since before this adapter existed. `embeddedContext` stays false:
+// it means the editor may inline a local file's contents, and this agent works
+// on a sandbox's filesystem, so accepting them would be accepting context
+// about a machine the agent cannot see.
 func agentCapabilities() map[string]any {
 	return map[string]any{
 		"loadSession": false,
 		"promptCapabilities": map[string]any{
-			"image":           false,
+			"image":           true,
 			"audio":           false,
 			"embeddedContext": false,
 		},

--- a/cli/internal/acp/agent_test.go
+++ b/cli/internal/acp/agent_test.go
@@ -127,9 +127,15 @@ func TestInitializeDoesNotClaimCapabilitiesItCannotHonour(t *testing.T) {
 		t.Errorf("loadSession = %v, want false until #703 builds the replay", caps["loadSession"])
 	}
 	prompt := caps["promptCapabilities"].(map[string]any)
-	for _, k := range []string{"image", "audio", "embeddedContext"} {
+	if prompt["image"] != true {
+		t.Errorf("promptCapabilities.image = %v, want true — the prompt path carries images", prompt["image"])
+	}
+	// embeddedContext means the editor may inline a local file's contents, and
+	// the agent works on a sandbox's filesystem — accepting it would be
+	// accepting context about a machine the agent cannot see.
+	for _, k := range []string{"audio", "embeddedContext"} {
 		if prompt[k] != false {
-			t.Errorf("promptCapabilities.%s = %v, want false until #701 builds the prompt path", k, prompt[k])
+			t.Errorf("promptCapabilities.%s = %v, want false", k, prompt[k])
 		}
 	}
 }
@@ -248,7 +254,7 @@ func TestAuthenticateRejectsAnUnknownMethod(t *testing.T) {
 func TestSessionMethodsAreNotFoundYet(t *testing.T) {
 	a := newTestAgent(&fakeAuth{available: true})
 
-	for _, method := range []string{"session/prompt", "session/load", "session/cancel"} {
+	for _, method := range []string{"session/load", "session/cancel"} {
 		_, rpcErr := request(t, a, method, map[string]any{})
 		if rpcErr == nil || rpcErr.Code != CodeMethodNotFound {
 			t.Errorf("%s: want method-not-found, got %v", method, rpcErr)

--- a/cli/internal/acp/jsonrpc.go
+++ b/cli/internal/acp/jsonrpc.go
@@ -82,7 +82,8 @@ type Conn struct {
 	out io.Writer
 	log *slog.Logger
 
-	mu sync.Mutex // guards out
+	mu       sync.Mutex // guards out
+	inflight sync.WaitGroup
 }
 
 // NewConn wires a connection to the given streams. For `fountain acp` these
@@ -98,6 +99,18 @@ func NewConn(in io.Reader, out io.Writer, log *slog.Logger) *Conn {
 // A closed stdin is how an editor says "we're done" — it is a clean exit, not
 // an error. Serve returns nil for it, and for a cancelled context.
 func (c *Conn) Serve(ctx context.Context, h Handler) error {
+	// Handlers run on their own goroutines (see dispatch). When Serve ends —
+	// the editor closed stdin, or the process was signalled — their context is
+	// cancelled first, so a `session/prompt` blocked on a stream stops reading
+	// one nobody is listening to, and then we wait for them rather than
+	// returning while goroutines still hold the output pipe. The turn itself
+	// keeps running server-side; that is the whole point of Fountain.
+	hctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
+		c.inflight.Wait()
+	}()
+
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil
@@ -105,7 +118,7 @@ func (c *Conn) Serve(ctx context.Context, h Handler) error {
 
 		line, err := c.in.ReadString('\n')
 		if len(line) > 0 {
-			c.dispatch(ctx, h, line)
+			c.dispatch(hctx, h, line)
 		}
 		if err != nil {
 			if errors.Is(err, io.EOF) {
@@ -148,8 +161,18 @@ func (c *Conn) dispatch(ctx context.Context, h Handler, line string) {
 		h.Notify(ctx, msg.Method, msg.Params)
 
 	default:
-		result, err := h.Request(ctx, msg.Method, msg.Params)
-		c.respond(msg, result, err)
+		// Each request runs on its own goroutine because `session/prompt`
+		// blocks for the whole turn — minutes, sometimes — and a connection
+		// that stopped reading during it would be deaf to exactly the messages
+		// a developer sends when a turn is taking too long: `session/cancel`
+		// (#704), or a prompt in another session. Responses may then be
+		// written out of order, which JSON-RPC allows: the id correlates them.
+		c.inflight.Add(1)
+		go func() {
+			defer c.inflight.Done()
+			result, err := h.Request(ctx, msg.Method, msg.Params)
+			c.respond(msg, result, err)
+		}()
 	}
 }
 

--- a/cli/internal/acp/prompt.go
+++ b/cli/internal/acp/prompt.go
@@ -1,0 +1,319 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// Event is one event from a conversation's SSE stream, already decoded far
+// enough for the adapter to act on. The HTTP and SSE details stay in the CLI
+// layer; this package sees only what an event says.
+type Event struct {
+	Kind   string // "output" or "stage"
+	Stream string // output only: "acp", "stdout", "stderr"
+	Data   string // output: the raw line. stage: JSON-encoded metadata.
+	Stage  string // stage only: "turn", "provision", "sandbox", …
+	State  string // stage only: "started", "done", "failed", "interrupted"
+}
+
+// EventFunc consumes stream events until it reports stop.
+type EventFunc func(ev Event) (stop bool, err error)
+
+// Image is one image attached to a prompt, as the API takes it.
+type Image struct {
+	Data      string // base64
+	MediaType string
+}
+
+// Notifier sends a notification to the connected client. The connection
+// implements it; the agent holds it so a turn's updates can be forwarded as
+// they arrive rather than accumulated and sent at the end.
+type Notifier interface {
+	Notify(method string, params any)
+}
+
+// SetNotifier wires the agent to its connection. Separate from NewAgent
+// because the connection needs the agent as a handler and the agent needs the
+// connection as a notifier.
+func (a *Agent) SetNotifier(n Notifier) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.notifier = n
+}
+
+func (a *Agent) notify(method string, params any) {
+	a.mu.Lock()
+	n := a.notifier
+	a.mu.Unlock()
+	if n != nil {
+		n.Notify(method, params)
+	}
+}
+
+type promptParams struct {
+	SessionID string            `json:"sessionId"`
+	Prompt    []json.RawMessage `json:"prompt"`
+}
+
+type contentBlock struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	Data     string `json:"data"`
+	MimeType string `json:"mimeType"`
+	URI      string `json:"uri"`
+	Name     string `json:"name"`
+}
+
+// prompt runs one turn and blocks until it ends, which is what ACP requires of
+// `session/prompt` — the response IS the turn's outcome.
+//
+// Fountain's API is post-then-stream, so the turn's end has to be correlated
+// out of the event stream. That correlation is the same one `fountain run`
+// performs to produce a truthful exit code (#398), including its hardest
+// lesson: learn the stream head BEFORE posting the prompt, or the first
+// terminal event in the replay of a PRIOR turn ends this one before it starts.
+func (a *Agent) prompt(ctx context.Context, raw json.RawMessage) (any, error) {
+	var params promptParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, Errorf(CodeInvalidParams, "session/prompt: %s", err)
+	}
+
+	if err := a.requireReady(); err != nil {
+		return nil, err
+	}
+
+	sess, ok := a.sessions.get(params.SessionID)
+	if !ok {
+		return nil, Errorf(CodeInvalidParams, "unknown session %q", params.SessionID)
+	}
+
+	text, images, err := splitPrompt(params.Prompt, a.log)
+	if err != nil {
+		return nil, err
+	}
+
+	head, err := a.api.StreamHead(ctx, sess.ID)
+	if err != nil {
+		return nil, Errorf(CodeInternalError, "could not read the conversation stream: %s", err)
+	}
+
+	if err := a.api.SendPrompt(ctx, sess.ID, text, images); err != nil {
+		return nil, Errorf(CodeInternalError, "could not send the prompt: %s", err)
+	}
+
+	return a.followTurn(ctx, sess, head)
+}
+
+// followTurn forwards the turn's updates to the editor and returns its stop
+// reason.
+func (a *Agent) followTurn(ctx context.Context, sess Session, head string) (any, error) {
+	var outcome turnOutcome
+
+	err := a.api.Follow(ctx, sess.ID, head, func(ev Event) (bool, error) {
+		switch {
+		case ev.Kind == "output" && ev.Stream == "acp":
+			a.forwardUpdate(sess, ev.Data)
+			return false, nil
+
+		case ev.Kind == "output":
+			// stdout/stderr on an ACP conversation is the adapter's own
+			// diagnostics, not the agent talking. It belongs in the log, not
+			// in the editor's transcript.
+			a.log.Debug("runtime output outside the protocol", "stream", ev.Stream, "data", ev.Data)
+			return false, nil
+
+		case ev.Kind == "stage":
+			out, terminal := classifyStage(ev)
+			if !terminal {
+				a.log.Debug("stage", "stage", ev.Stage, "state", ev.State)
+				return false, nil
+			}
+			outcome = out
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		// A transport failure after the prompt was accepted: the turn is still
+		// running server-side. Saying so is the honest answer — the editor's
+		// alternative reading, that the agent stopped, is the one thing we
+		// know to be false.
+		return nil, Errorf(CodeInternalError,
+			"lost the conversation stream (%s) — the turn may still be running; it is conversation %s",
+			err, sess.ID)
+	}
+
+	if outcome.err != "" {
+		return nil, Errorf(CodeInternalError, "%s", outcome.err)
+	}
+	return map[string]any{"stopReason": outcome.stopReason}, nil
+}
+
+// forwardUpdate re-emits one stored ACP line to the editor.
+//
+// This is the whole payoff of #644: the line is already a `session/update`
+// notification, because the server stored what the sprite's adapter said,
+// verbatim. The adapter forwards it rather than translating it, and no
+// runtime dialect is parsed anywhere in this binary.
+//
+// One field must change. The stored update carries the *sprite's* session id —
+// the runtime's own, which means nothing outside the sandbox holding it and
+// does not survive a reclaim (#649). The editor knows this conversation by our
+// session id, so that is what leaves this process.
+func (a *Agent) forwardUpdate(sess Session, line string) {
+	var msg struct {
+		Method string         `json:"method"`
+		Params map[string]any `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &msg); err != nil {
+		a.log.Warn("dropping unparseable stored line", "err", err)
+		return
+	}
+
+	if msg.Method != "session/update" {
+		// Requests from the sprite (session/request_permission) are not
+		// forwarded: answering them across two hops is #708, and it is gated
+		// on an answer to what replies when the editor detaches mid-request.
+		a.log.Debug("not forwarding a non-update message", "method", msg.Method)
+		return
+	}
+
+	if msg.Params == nil {
+		msg.Params = map[string]any{}
+	}
+	msg.Params["sessionId"] = sess.ID
+	a.notify("session/update", msg.Params)
+}
+
+type turnOutcome struct {
+	stopReason string
+	err        string // non-empty means the turn did not end, it failed
+}
+
+// classifyStage decides whether a stage event ends the turn, and how.
+//
+// The stop reason is not invented here: the server publishes the sprite
+// adapter's own ACP stop reason on the terminal stage event, so a refusal
+// arrives as "refusal" and an ordinary finish as "end_turn". What this adds is
+// the cases ACP has no vocabulary for — a sandbox that never provisioned, a
+// reclaim mid-turn — which are reported as errors rather than dressed up as a
+// stop reason, because "the agent finished" is the one reading that is false.
+func classifyStage(ev Event) (turnOutcome, bool) {
+	meta := decodeMeta(ev.Data)
+	stopReason, _ := meta["stop_reason"].(string)
+
+	switch {
+	case ev.Stage == "turn" && ev.State == "done":
+		if stopReason == "" {
+			stopReason = "end_turn"
+		}
+		return turnOutcome{stopReason: stopReason}, true
+
+	case ev.Stage == "turn" && ev.State == "failed":
+		// A refusal and a cancellation are reported as failures server-side
+		// (conversation_server.ex) but they ARE ACP stop reasons — an editor
+		// should render "the agent declined", not "something broke".
+		if stopReason != "" {
+			return turnOutcome{stopReason: stopReason}, true
+		}
+		return turnOutcome{err: "the turn failed: " + reasonText(meta)}, true
+
+	case ev.Stage == "turn" && ev.State == "interrupted":
+		return turnOutcome{stopReason: "cancelled"}, true
+
+	case ev.Stage == "provision" && ev.State == "failed":
+		return turnOutcome{err: "the sandbox never started: " + reasonText(meta)}, true
+
+	case ev.Stage == "reattach" && ev.State == "failed":
+		return turnOutcome{err: "could not reattach to the sandbox — prompt again to provision a fresh one"}, true
+
+	case ev.Stage == "terminate" && ev.State == "done":
+		return turnOutcome{err: "the conversation was terminated"}, true
+
+	case ev.Stage == "sandbox" && ev.State == "done":
+		// An idle suspend keeps the sprite and the next prompt resumes it, so
+		// it is not a failure — but it does mean no more events are coming for
+		// this turn. A max-lifetime reclaim can cut a running turn short.
+		if event, _ := meta["event"].(string); event == "suspended" {
+			return turnOutcome{stopReason: "end_turn"}, true
+		}
+		return turnOutcome{err: "the sandbox was reclaimed mid-turn: " + reasonText(meta)}, true
+	}
+
+	return turnOutcome{}, false
+}
+
+// decodeMeta reads a stage event's metadata, which the server JSON-encodes
+// into the event's data field.
+func decodeMeta(data string) map[string]any {
+	if data == "" {
+		return map[string]any{}
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(data), &m); err != nil {
+		return map[string]any{}
+	}
+	return m
+}
+
+func reasonText(meta map[string]any) string {
+	for _, key := range []string{"reason", "error", "exit_code"} {
+		if v, ok := meta[key]; ok && v != nil {
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	return "no reason given"
+}
+
+// splitPrompt turns ACP content blocks into what the API takes.
+//
+// Blocks that name something on the developer's machine — a resource link, an
+// embedded resource — are dropped with a log line rather than pasted into the
+// prompt as a path. The agent works in a sandbox with a different filesystem,
+// and handing it a path that resolves to nothing there produces a turn spent
+// looking for a file that was never going to be present.
+func splitPrompt(blocks []json.RawMessage, log *slog.Logger) (string, []Image, error) {
+	var (
+		texts   []string
+		images  []Image
+		skipped []string
+	)
+
+	for _, raw := range blocks {
+		var b contentBlock
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return "", nil, Errorf(CodeInvalidParams, "session/prompt: bad content block: %s", err)
+		}
+
+		switch b.Type {
+		case "text":
+			if b.Text != "" {
+				texts = append(texts, b.Text)
+			}
+		case "image":
+			if b.Data == "" {
+				skipped = append(skipped, "image without data")
+				continue
+			}
+			images = append(images, Image{Data: b.Data, MediaType: b.MimeType})
+		default:
+			skipped = append(skipped, b.Type)
+		}
+	}
+
+	if len(skipped) > 0 {
+		log.Warn("dropped prompt content this agent cannot use",
+			"blocks", strings.Join(skipped, ","),
+			"why", "the agent runs in a sandbox, not on this machine")
+	}
+
+	text := strings.Join(texts, "\n")
+	if strings.TrimSpace(text) == "" && len(images) == 0 {
+		return "", nil, Errorf(CodeInvalidParams, "session/prompt carried no text or image content")
+	}
+	return text, images, nil
+}

--- a/cli/internal/acp/prompt_test.go
+++ b/cli/internal/acp/prompt_test.go
@@ -1,0 +1,332 @@
+package acp
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeNotifier records what the editor would have seen.
+type fakeNotifier struct {
+	mu       sync.Mutex
+	methods  []string
+	params   []map[string]any
+	rawCalls int
+}
+
+func (n *fakeNotifier) Notify(method string, params any) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.rawCalls++
+	n.methods = append(n.methods, method)
+	if m, ok := params.(map[string]any); ok {
+		n.params = append(n.params, m)
+	}
+}
+
+func acpLine(sessionID, text string) string {
+	return `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"` + sessionID +
+		`","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"` + text + `"}}}}`
+}
+
+func stageEvent(stage, state, meta string) Event {
+	return Event{Kind: "stage", Stage: stage, State: state, Data: meta}
+}
+
+// promptAgent returns an agent with one open session, ready to prompt.
+func promptAgent(t *testing.T, api *fakeAPI) (*Agent, *fakeNotifier) {
+	t.Helper()
+
+	api.ref = acpAgentRef()
+	if api.convID == "" {
+		api.convID = "conv-1"
+	}
+	a := sessionAgent(t, api, "researcher")
+	n := &fakeNotifier{}
+	a.SetNotifier(n)
+
+	if _, rpcErr := request(t, a, "session/new", map[string]any{}); rpcErr != nil {
+		t.Fatalf("session/new failed: %v", rpcErr)
+	}
+	return a, n
+}
+
+func textPrompt(sessionID, text string) map[string]any {
+	return map[string]any{
+		"sessionId": sessionID,
+		"prompt":    []map[string]any{{"type": "text", "text": text}},
+	}
+}
+
+func TestPromptForwardsUpdatesAndReturnsTheStopReason(t *testing.T) {
+	api := &fakeAPI{
+		events: []Event{
+			{Kind: "output", Stream: "acp", Data: acpLine("sprite-session", "hello")},
+			stageEvent("turn", "done", `{"stop_reason":"end_turn"}`),
+		},
+	}
+	a, notifier := promptAgent(t, api)
+
+	result, rpcErr := request(t, a, "session/prompt", textPrompt("conv-1", "do the thing"))
+	if rpcErr != nil {
+		t.Fatalf("session/prompt failed: %v", rpcErr)
+	}
+	if result["stopReason"] != "end_turn" {
+		t.Errorf("stopReason = %v, want end_turn", result["stopReason"])
+	}
+	if len(notifier.methods) != 1 || notifier.methods[0] != "session/update" {
+		t.Fatalf("notifications = %v, want one session/update", notifier.methods)
+	}
+	if len(api.prompts) != 1 || api.prompts[0].text != "do the thing" {
+		t.Errorf("prompts = %+v, want the text posted once", api.prompts)
+	}
+}
+
+// The stored update carries the sprite's own session id, which means nothing
+// outside the sandbox that holds it (#649). The editor knows this conversation
+// by ours.
+func TestForwardedUpdateCarriesOurSessionIDNotTheSprites(t *testing.T) {
+	api := &fakeAPI{
+		events: []Event{
+			{Kind: "output", Stream: "acp", Data: acpLine("sprite-session", "hi")},
+			stageEvent("turn", "done", `{"stop_reason":"end_turn"}`),
+		},
+	}
+	a, notifier := promptAgent(t, api)
+
+	request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+
+	if len(notifier.params) != 1 {
+		t.Fatalf("want one forwarded update, got %d", len(notifier.params))
+	}
+	if got := notifier.params[0]["sessionId"]; got != "conv-1" {
+		t.Errorf("sessionId = %v, want conv-1 (ours), not the sprite's", got)
+	}
+	// Everything else must survive untouched — the adapter forwards blocks it
+	// deliberately does not understand.
+	update, ok := notifier.params[0]["update"].(map[string]any)
+	if !ok || update["sessionUpdate"] != "agent_message_chunk" {
+		t.Errorf("update payload was not forwarded intact: %v", notifier.params[0])
+	}
+}
+
+// #398, from the other side: the head is learned BEFORE the prompt is posted,
+// so a replayed terminal event from a PRIOR turn cannot end this one.
+func TestPromptLearnsTheStreamHeadBeforePosting(t *testing.T) {
+	api := &fakeAPI{
+		head:   "417",
+		events: []Event{stageEvent("turn", "done", `{"stop_reason":"end_turn"}`)},
+	}
+	a, _ := promptAgent(t, api)
+
+	request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+
+	if len(api.followFrom) != 1 || api.followFrom[0] != "417" {
+		t.Errorf("followed from %v, want the head learned before the post", api.followFrom)
+	}
+}
+
+// A refusal is a legitimate ACP stop reason even though the server records the
+// turn as failed. Reporting it as an error would tell an editor something
+// broke when the agent simply declined.
+func TestRefusalIsAStopReasonNotAnError(t *testing.T) {
+	api := &fakeAPI{events: []Event{stageEvent("turn", "failed", `{"stop_reason":"refusal"}`)}}
+	a, _ := promptAgent(t, api)
+
+	result, rpcErr := request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+	if rpcErr != nil {
+		t.Fatalf("refusal surfaced as an error: %v", rpcErr)
+	}
+	if result["stopReason"] != "refusal" {
+		t.Errorf("stopReason = %v, want refusal", result["stopReason"])
+	}
+}
+
+func TestInterruptedTurnIsCancelled(t *testing.T) {
+	api := &fakeAPI{events: []Event{stageEvent("turn", "interrupted", `{}`)}}
+	a, _ := promptAgent(t, api)
+
+	result, rpcErr := request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+	if rpcErr != nil {
+		t.Fatalf("interrupt surfaced as an error: %v", rpcErr)
+	}
+	if result["stopReason"] != "cancelled" {
+		t.Errorf("stopReason = %v, want cancelled", result["stopReason"])
+	}
+}
+
+// The failures ACP has no vocabulary for must not be dressed up as a stop
+// reason: "the agent finished" is the one reading that is false.
+func TestInfrastructureFailuresAreErrorsNotStopReasons(t *testing.T) {
+	cases := []struct {
+		name  string
+		event Event
+		want  string
+	}{
+		{"provision failed", stageEvent("provision", "failed", `{"reason":"quota"}`), "sandbox never started"},
+		{"turn failed", stageEvent("turn", "failed", `{"error":"peer_down"}`), "peer_down"},
+		{"reclaimed mid-turn", stageEvent("sandbox", "done", `{"reason":"max_lifetime"}`), "reclaimed"},
+		{"terminated", stageEvent("terminate", "done", `{}`), "terminated"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &fakeAPI{events: []Event{tc.event}}
+			a, _ := promptAgent(t, api)
+
+			_, rpcErr := request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+			if rpcErr == nil {
+				t.Fatal("a failed turn reported success")
+			}
+			if !strings.Contains(rpcErr.Message, tc.want) {
+				t.Errorf("message = %q, want it to mention %q", rpcErr.Message, tc.want)
+			}
+		})
+	}
+}
+
+// A suspend keeps the sprite and the next prompt resumes it — an end, not a
+// failure.
+func TestSuspendedSandboxEndsTheTurnCleanly(t *testing.T) {
+	api := &fakeAPI{events: []Event{stageEvent("sandbox", "done", `{"event":"suspended","reason":"idle"}`)}}
+	a, _ := promptAgent(t, api)
+
+	result, rpcErr := request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+	if rpcErr != nil {
+		t.Fatalf("a suspend surfaced as an error: %v", rpcErr)
+	}
+	if result["stopReason"] != "end_turn" {
+		t.Errorf("stopReason = %v, want end_turn", result["stopReason"])
+	}
+}
+
+// A lost stream is not a finished turn. The turn keeps running server-side, so
+// the answer says so and names the conversation to reattach to.
+func TestLostStreamSaysTheTurnMayStillBeRunning(t *testing.T) {
+	api := &fakeAPI{followErr: errors.New("stream failed after 5 attempts")}
+	a, _ := promptAgent(t, api)
+
+	_, rpcErr := request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+	if rpcErr == nil {
+		t.Fatal("a lost stream reported a completed turn")
+	}
+	if !strings.Contains(rpcErr.Message, "may still be running") {
+		t.Errorf("message = %q, want it to say the turn may still be running", rpcErr.Message)
+	}
+	if !strings.Contains(rpcErr.Message, "conv-1") {
+		t.Errorf("message = %q, want it to name the conversation", rpcErr.Message)
+	}
+}
+
+func TestPromptForAnUnknownSessionIsRefused(t *testing.T) {
+	api := &fakeAPI{events: []Event{stageEvent("turn", "done", `{}`)}}
+	a, _ := promptAgent(t, api)
+
+	_, rpcErr := request(t, a, "session/prompt", textPrompt("conv-not-mine", "go"))
+	if rpcErr == nil || rpcErr.Code != CodeInvalidParams {
+		t.Fatalf("want invalid params for an unknown session, got %v", rpcErr)
+	}
+	if len(api.prompts) != 0 {
+		t.Errorf("prompted a session that does not exist: %v", api.prompts)
+	}
+}
+
+func TestPromptCarriesImages(t *testing.T) {
+	api := &fakeAPI{events: []Event{stageEvent("turn", "done", `{"stop_reason":"end_turn"}`)}}
+	a, _ := promptAgent(t, api)
+
+	_, rpcErr := request(t, a, "session/prompt", map[string]any{
+		"sessionId": "conv-1",
+		"prompt": []map[string]any{
+			{"type": "text", "text": "what is this"},
+			{"type": "image", "data": "aGVsbG8=", "mimeType": "image/png"},
+		},
+	})
+	if rpcErr != nil {
+		t.Fatalf("session/prompt failed: %v", rpcErr)
+	}
+
+	sent := api.prompts[0]
+	if len(sent.images) != 1 || sent.images[0].MediaType != "image/png" || sent.images[0].Data != "aGVsbG8=" {
+		t.Errorf("images = %+v, want the one image carried through", sent.images)
+	}
+	if sent.text != "what is this" {
+		t.Errorf("text = %q, want the text block only", sent.text)
+	}
+}
+
+// A resource link names a file on the developer's machine. Pasting its path
+// into the prompt would send the agent looking for something that is not in
+// its sandbox, so it is dropped — but the turn still runs.
+func TestLocalResourceBlocksAreDroppedNotSent(t *testing.T) {
+	api := &fakeAPI{events: []Event{stageEvent("turn", "done", `{"stop_reason":"end_turn"}`)}}
+	a, _ := promptAgent(t, api)
+
+	_, rpcErr := request(t, a, "session/prompt", map[string]any{
+		"sessionId": "conv-1",
+		"prompt": []map[string]any{
+			{"type": "text", "text": "review this"},
+			{"type": "resource_link", "uri": "file:///home/dev/proj/main.go", "name": "main.go"},
+		},
+	})
+	if rpcErr != nil {
+		t.Fatalf("session/prompt failed: %v", rpcErr)
+	}
+	if got := api.prompts[0].text; got != "review this" {
+		t.Errorf("text = %q, want the local path left out", got)
+	}
+}
+
+func TestEmptyPromptIsRefused(t *testing.T) {
+	api := &fakeAPI{}
+	a, _ := promptAgent(t, api)
+
+	_, rpcErr := request(t, a, "session/prompt", map[string]any{
+		"sessionId": "conv-1",
+		"prompt":    []map[string]any{},
+	})
+	if rpcErr == nil || rpcErr.Code != CodeInvalidParams {
+		t.Fatalf("want invalid params for an empty prompt, got %v", rpcErr)
+	}
+	if len(api.prompts) != 0 {
+		t.Errorf("posted an empty prompt: %v", api.prompts)
+	}
+}
+
+// Runtime output that is not protocol is the adapter's own noise — a stack
+// trace, an npm notice. It belongs in the log, not in the editor's transcript.
+func TestNonProtocolOutputIsNotForwarded(t *testing.T) {
+	api := &fakeAPI{
+		events: []Event{
+			{Kind: "output", Stream: "stderr", Data: "npm warn deprecated foo@1.0.0"},
+			stageEvent("turn", "done", `{"stop_reason":"end_turn"}`),
+		},
+	}
+	a, notifier := promptAgent(t, api)
+
+	request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+
+	if notifier.rawCalls != 0 {
+		t.Errorf("forwarded %d notifications for non-protocol output, want 0", notifier.rawCalls)
+	}
+}
+
+// A request from the sprite (session/request_permission) is not an update, and
+// forwarding it as one would put a question in the transcript that nothing can
+// answer. Answering it across two hops is #708.
+func TestSpriteRequestsAreNotForwardedAsUpdates(t *testing.T) {
+	api := &fakeAPI{
+		events: []Event{
+			{Kind: "output", Stream: "acp", Data: `{"jsonrpc":"2.0","id":4,"method":"session/request_permission","params":{}}`},
+			stageEvent("turn", "done", `{"stop_reason":"end_turn"}`),
+		},
+	}
+	a, notifier := promptAgent(t, api)
+
+	request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+
+	if notifier.rawCalls != 0 {
+		t.Errorf("forwarded %d messages that were not updates, want 0", notifier.rawCalls)
+	}
+}

--- a/cli/internal/acp/session.go
+++ b/cli/internal/acp/session.go
@@ -15,6 +15,16 @@ type API interface {
 	Agent(ctx context.Context, target string) (AgentRef, error)
 	// CreateConversation starts a conversation for an agent and returns its id.
 	CreateConversation(ctx context.Context, agentID string) (string, error)
+	// StreamHead returns the conversation's current last event id, so a follow
+	// can skip the history. Called BEFORE a prompt is sent — see prompt.go.
+	StreamHead(ctx context.Context, convID string) (string, error)
+	// SendPrompt queues a turn. It returns as soon as the server accepts it;
+	// the turn's outcome arrives on the stream.
+	SendPrompt(ctx context.Context, convID, prompt string, images []Image) error
+	// Follow consumes the conversation's event stream from lastEventID until
+	// fn reports stop, reconnecting across the disconnects the server produces
+	// by design.
+	Follow(ctx context.Context, convID, lastEventID string, fn EventFunc) error
 }
 
 // AgentRef is what the adapter needs to know about a Fountain agent.

--- a/cli/internal/acp/session_test.go
+++ b/cli/internal/acp/session_test.go
@@ -15,6 +15,21 @@ type fakeAPI struct {
 	resolved []string
 	created  []string
 	convID   string
+
+	// prompt path
+	head       string
+	headErr    error
+	promptErr  error
+	followErr  error
+	events     []Event
+	prompts    []sentPrompt
+	followFrom []string
+}
+
+type sentPrompt struct {
+	convID string
+	text   string
+	images []Image
 }
 
 func (f *fakeAPI) Agent(_ context.Context, target string) (AgentRef, error) {
@@ -34,6 +49,35 @@ func (f *fakeAPI) CreateConversation(_ context.Context, agentID string) (string,
 		return "conv-1", nil
 	}
 	return f.convID, nil
+}
+
+func (f *fakeAPI) StreamHead(context.Context, string) (string, error) {
+	if f.headErr != nil {
+		return "", f.headErr
+	}
+	return f.head, nil
+}
+
+func (f *fakeAPI) SendPrompt(_ context.Context, convID, text string, images []Image) error {
+	f.prompts = append(f.prompts, sentPrompt{convID: convID, text: text, images: images})
+	return f.promptErr
+}
+
+func (f *fakeAPI) Follow(_ context.Context, _, lastEventID string, fn EventFunc) error {
+	f.followFrom = append(f.followFrom, lastEventID)
+	if f.followErr != nil {
+		return f.followErr
+	}
+	for _, ev := range f.events {
+		stop, err := fn(ev)
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+	}
+	return nil
 }
 
 func acpAgentRef() AgentRef {

--- a/cli/internal/cmd/acp.go
+++ b/cli/internal/cmd/acp.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -14,6 +16,8 @@ import (
 	"github.com/BinaryBourbon/fountain/cli/internal/config"
 	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
 	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/BinaryBourbon/fountain/cli/internal/sse"
+	"github.com/BinaryBourbon/fountain/cli/internal/stream"
 	"github.com/spf13/cobra"
 )
 
@@ -63,7 +67,12 @@ func runACP() error {
 	defer stop()
 
 	opts := activeOpts()
-	agent := acp.NewAgent(cliAuth{opts: opts}, fountainAPI{opts: opts}, acpAgent, log)
+	agent := acp.NewAgent(cliAuth{opts: opts}, fountainAPI{opts: opts, log: log}, acpAgent, log)
+	conn := acp.NewConn(os.Stdin, os.Stdout, log)
+	// The connection is how a turn's updates reach the editor while the turn
+	// is still running; without it `session/prompt` would block in silence and
+	// deliver everything at the end, which is not a live session.
+	agent.SetNotifier(conn)
 
 	// An unset --agent is not fatal here: the editor still gets a working
 	// handshake, and the refusal arrives at `session/new` where the editor can
@@ -74,7 +83,7 @@ func runACP() error {
 		"profile", credentials.ProfileName(opts),
 		"agent", acpAgent)
 
-	return acp.NewConn(os.Stdin, os.Stdout, log).Serve(ctx, agent)
+	return conn.Serve(ctx, agent)
 }
 
 func parseLogLevel(s string) (slog.Level, error) {
@@ -128,6 +137,7 @@ func (a cliAuth) Describe() string {
 // renders, not a reason to kill a process the editor is talking to.
 type fountainAPI struct {
 	opts credentials.Opts
+	log  *slog.Logger
 }
 
 func (f fountainAPI) Agent(_ context.Context, target string) (acp.AgentRef, error) {
@@ -185,4 +195,64 @@ func (f fountainAPI) CreateConversation(_ context.Context, agentID string) (stri
 		return "", fmt.Errorf("conversation created but the response carried no id")
 	}
 	return id, nil
+}
+
+func (f fountainAPI) StreamHead(_ context.Context, convID string) (string, error) {
+	return streamHead(api.New(f.opts), convID)
+}
+
+func (f fountainAPI) SendPrompt(_ context.Context, convID, prompt string, images []acp.Image) error {
+	payload := make([]map[string]string, 0, len(images))
+	for _, img := range images {
+		payload = append(payload, map[string]string{
+			"data":       img.Data,
+			"media_type": img.MediaType,
+		})
+	}
+	body := map[string]any{"prompt": prompt, "images": payload}
+	return api.New(f.opts).Post("/conversations/"+convID+"/prompts", body, nil)
+}
+
+// Follow reads the conversation's stream with `?streams=acp,stage`.
+//
+// The filter is the reason this adapter is a forwarder rather than a parser:
+// the `acp` stream is the sprite adapter's own `session/update` notifications,
+// stored verbatim by the server (#644). Asking for `stdout` as well would put
+// a runtime's dialect in front of a client that has no idea what it is.
+func (f fountainAPI) Follow(ctx context.Context, convID, lastEventID string, fn acp.EventFunc) error {
+	c := api.New(f.opts)
+
+	open := func(ctx context.Context, lastEventID string) (io.ReadCloser, error) {
+		req, err := c.NewStreamRequest(ctx, "/conversations/"+convID+"/stream?streams=acp,stage", lastEventID)
+		if err != nil {
+			return nil, err
+		}
+		// No client timeout: the idle watchdog inside the follow loop is what
+		// bounds a stream, and a turn may legitimately think for a long time.
+		resp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("stream HTTP %d: %s", resp.StatusCode, body)
+		}
+		return resp.Body, nil
+	}
+
+	return stream.Follow(ctx, open, stream.IdleTimeout(), convID, lastEventID, func(ev sse.Event) (bool, error) {
+		data, ok := ev.Data.(map[string]any)
+		if !ok {
+			f.log.Debug("skipping an event with no object payload", "event", ev.Event)
+			return false, nil
+		}
+		return fn(acp.Event{
+			Kind:   output.ToString(data["kind"]),
+			Stream: output.ToString(data["stream"]),
+			Data:   output.ToString(data["data"]),
+			Stage:  output.ToString(data["stage"]),
+			State:  output.ToString(data["state"]),
+		})
+	})
 }

--- a/cli/internal/cmd/stream.go
+++ b/cli/internal/cmd/stream.go
@@ -1,216 +1,44 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
-	"os"
-	"strconv"
 	"time"
 
-	"github.com/BinaryBourbon/fountain/cli/internal/sse"
+	"github.com/BinaryBourbon/fountain/cli/internal/stream"
 )
 
 // streamOpener opens an SSE body, resuming after lastEventID when non-empty.
-//
-// Behind an interface so the reconnect logic can be tested without a server:
-// the bug this file exists to fix only appears across a disconnect, which is
-// exactly the part that is awkward to reach through the real client.
-type streamOpener func(ctx context.Context, lastEventID string) (io.ReadCloser, error)
+type streamOpener = stream.Opener
 
-const (
-	// How long to wait with no bytes at all before giving up. The server closes
-	// its SSE loop after 60s of quiet, so this has to be comfortably longer than
-	// that or every reconnect would look like an idle stream.
-	defaultStreamIdle = 30 * time.Minute
-
-	// Consecutive failures to reopen the stream before giving up. Transport
-	// errors are usually transient; a server that is genuinely gone will exhaust
-	// these quickly.
-	maxReconnectAttempts = 5
-)
-
-var errIdleTimeout = errors.New("no output received")
-
-// Terminal outcomes that must surface as a non-zero exit (#398). Before this,
-// `turn`/`failed`, `provision`/`failed` and a `turn`/`done` with a non-zero
-// exit_code all returned nil from followStream, so `fountain run` in CI
-// reported success for a crashed agent or a sandbox that never came up.
+// The follow loop itself lives in internal/stream — `fountain acp` needs the
+// same reconnect behaviour, and #398 is not a bug worth having two chances to
+// reintroduce. What stays here is what the CLI means by an event: exit codes,
+// the human lines, and the terminal outcomes below.
 var (
+	errIdleTimeout = stream.ErrIdleTimeout
+
+	// Terminal outcomes that must surface as a non-zero exit (#398). Before
+	// this, `turn`/`failed`, `provision`/`failed` and a `turn`/`done` with a
+	// non-zero exit_code all returned nil, so `fountain run` in CI reported
+	// success for a crashed agent or a sandbox that never came up.
 	errTurnFailed      = errors.New("turn failed")
 	errProvisionFailed = errors.New("provisioning failed — the sandbox never started")
 	errReattachFailed  = errors.New("reattach failed — the sandbox was marked failed")
 	errSandboxExpired  = errors.New("sandbox hit its max lifetime")
 )
 
-// reconnectBackoff is a variable so tests do not have to sit through real
-// sleeps to exercise the retry path.
-var reconnectBackoff = func(attempt int) time.Duration {
-	return time.Duration(attempt) * time.Second
-}
-
 // streamIdleTimeout allows the wait to be widened or narrowed without a rebuild.
-func streamIdleTimeout() time.Duration {
-	if v := os.Getenv("FOUNTAIN_STREAM_IDLE_TIMEOUT"); v != "" {
-		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	return defaultStreamIdle
-}
+func streamIdleTimeout() time.Duration { return stream.IdleTimeout() }
 
 // followStream consumes an SSE stream until the turn reaches a terminal state,
-// reconnecting when the server closes the connection.
-//
-// The bug this replaces: the old loop treated io.EOF as success and returned
-// nil. The server closes its SSE loop after 60 seconds of quiet, so any turn
-// that thought for longer than a minute without emitting output made the CLI
-// exit silently, reporting success while the agent was still working. For a
-// product whose normal case is a long-running agent, that is the worst possible
-// failure — it is indistinguishable from the turn actually finishing.
-//
-// A disconnect now resumes from the last event id, so output produced while
-// disconnected is replayed rather than lost, and only a terminal event or a
-// genuine timeout ends the loop.
-//
-// lastEventID seeds the first connection. Callers that pass the stream head
-// (see streamHead in conv.go) skip the server's full-history replay — without
-// that, the first `turn`/`done` in the replay of a prior turn ended the
-// stream before the current turn had even started (#398).
-//
-// A terminal event that is not a clean completion (turn failed, provisioning
-// failed, non-zero exit_code) is returned as an error so the process exits
-// non-zero.
+// printing output as it goes. See internal/stream for the reconnect semantics
+// and handleEvent (conv.go) for what the CLI does with each event.
 func followStream(open streamOpener, idle time.Duration, convID, lastEventID string) error {
-	failures := 0
-
-	for {
-		done, resumeID, err := streamOnce(open, lastEventID, idle)
-		if resumeID != "" {
-			lastEventID = resumeID
-		}
-
-		switch {
-		case done:
-			// err is nil for a clean completion, or the terminal failure
-			// (errTurnFailed / errProvisionFailed) to propagate.
-			return err
-
-		case errors.Is(err, errIdleTimeout):
-			// Explicit, rather than the old silent success.
-			return fmt.Errorf(
-				"no output for %s — the turn may still be running; reattach with `fountain conv stream %s`",
-				idle, convID,
-			)
-
-		case err != nil:
-			failures++
-			if failures >= maxReconnectAttempts {
-				return fmt.Errorf("stream failed after %d attempts: %w", failures, err)
-			}
-			// Linear backoff: enough to ride out a redeploy without hammering.
-			time.Sleep(reconnectBackoff(failures))
-
-		default:
-			// Clean EOF with no terminal event: the server closed an idle
-			// stream. Reconnect and keep waiting.
-			failures = 0
-		}
-	}
+	return stream.Follow(context.Background(), open, idle, convID, lastEventID, handleEvent)
 }
 
-// streamOnce reads one connection to completion. It returns whether a terminal
-// event was seen (with the terminal outcome as err — nil for a clean
-// completion) and the id to resume from if the connection drops.
-func streamOnce(open streamOpener, lastEventID string, idle time.Duration) (bool, string, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	body, err := open(ctx, lastEventID)
-	if err != nil {
-		return false, "", err
-	}
-	defer body.Close()
-
-	// Idle watchdog. A blocking Read cannot be given a deadline directly, so a
-	// separate goroutine cancels the request context if nothing arrives.
-	activity := make(chan struct{}, 1)
-	idled := make(chan struct{})
-	go watchIdle(ctx, cancel, activity, idled, idle)
-
-	buf := make([]byte, 8192)
-	var pending bytes.Buffer
-	resumeID := lastEventID
-
-	for {
-		n, readErr := body.Read(buf)
-		if n > 0 {
-			select {
-			case activity <- struct{}{}:
-			default:
-			}
-
-			pending.Write(buf[:n])
-			events, leftover := sse.Feed(pending.String())
-			pending.Reset()
-			pending.WriteString(leftover)
-
-			for _, ev := range events {
-				if ev.ID > 0 {
-					resumeID = strconv.Itoa(ev.ID)
-				}
-				if terminal, termErr := handleEvent(ev); terminal {
-					return true, resumeID, termErr
-				}
-			}
-		}
-
-		if readErr != nil {
-			select {
-			case <-idled:
-				return false, resumeID, errIdleTimeout
-			default:
-			}
-			if errors.Is(readErr, io.EOF) {
-				return false, resumeID, nil
-			}
-			return false, resumeID, readErr
-		}
-	}
-}
-
-// watchIdle cancels the request context when nothing has arrived for `idle`.
-// Cancelling is what actually unblocks the pending Read — closing `idled` alone
-// would leave a genuinely stalled stream hanging forever, which is the failure
-// this whole change is meant to remove.
-func watchIdle(
-	ctx context.Context,
-	cancel context.CancelFunc,
-	activity <-chan struct{},
-	idled chan<- struct{},
-	idle time.Duration,
-) {
-	timer := time.NewTimer(idle)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-activity:
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			timer.Reset(idle)
-		case <-timer.C:
-			close(idled)
-			cancel()
-			return
-		}
-	}
-}
+// Compile-time proof the opener signature has not drifted from the package it
+// now comes from; the alias above would otherwise fail far from here.
+var _ func(context.Context, string) (io.ReadCloser, error) = (streamOpener)(nil)

--- a/cli/internal/cmd/stream_test.go
+++ b/cli/internal/cmd/stream_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/stream"
 )
 
 // fakeStream serves a scripted sequence of connections. Each entry is the body
@@ -212,9 +214,11 @@ func TestIdleTimeoutIsAnErrorNotSilentSuccess(t *testing.T) {
 
 func noBackoff(t *testing.T) {
 	t.Helper()
-	original := reconnectBackoff
-	reconnectBackoff = func(int) time.Duration { return 0 }
-	t.Cleanup(func() { reconnectBackoff = original })
+	// The backoff now lives with the loop it paces (internal/stream); the
+	// tests below still exercise the retry path through followStream.
+	original := stream.Backoff
+	stream.Backoff = func(int) time.Duration { return 0 }
+	t.Cleanup(func() { stream.Backoff = original })
 }
 
 func TestGivesUpAfterRepeatedOpenFailures(t *testing.T) {
@@ -228,8 +232,8 @@ func TestGivesUpAfterRepeatedOpenFailures(t *testing.T) {
 	if !strings.Contains(err.Error(), "connection refused") {
 		t.Errorf("error should preserve the cause, got %q", err)
 	}
-	if f.opens() != maxReconnectAttempts {
-		t.Errorf("expected %d attempts, got %d", maxReconnectAttempts, f.opens())
+	if f.opens() != stream.MaxReconnectAttempts {
+		t.Errorf("expected %d attempts, got %d", stream.MaxReconnectAttempts, f.opens())
 	}
 }
 
@@ -253,7 +257,7 @@ func TestStreamIdleTimeoutOverride(t *testing.T) {
 	}
 
 	t.Setenv("FOUNTAIN_STREAM_IDLE_TIMEOUT", "not-a-number")
-	if got := streamIdleTimeout(); got != defaultStreamIdle {
+	if got := streamIdleTimeout(); got != stream.DefaultIdle {
 		t.Errorf("garbage should fall back to the default, got %s", got)
 	}
 }

--- a/cli/internal/stream/stream.go
+++ b/cli/internal/stream/stream.go
@@ -1,0 +1,225 @@
+// Package stream consumes a Fountain SSE conversation stream, surviving the
+// disconnects the server produces by design.
+//
+// It was extracted from the CLI's `fountain run` path when `fountain acp`
+// needed the same behaviour (#701). The loop is the part worth having exactly
+// once: it encodes #398, where treating io.EOF as success made the CLI report
+// a finished turn while the agent was still working. A second copy in the ACP
+// adapter would be a second chance to reintroduce that, in the surface where
+// it is hardest to notice — an editor showing a conversation that quietly
+// stopped updating.
+//
+// What the loop does NOT decide is what an event *means*. Callers pass a
+// Handler, because the CLI wants exit codes and human lines while the ACP
+// adapter wants protocol notifications and a stop reason.
+package stream
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/sse"
+)
+
+// Opener opens an SSE body, resuming after lastEventID when non-empty.
+//
+// Behind an interface so the reconnect logic can be tested without a server:
+// the bug this package exists to prevent only appears across a disconnect,
+// which is exactly the part that is awkward to reach through a real client.
+type Opener func(ctx context.Context, lastEventID string) (io.ReadCloser, error)
+
+// Handler decides what an event means. Returning terminal ends the follow;
+// the error it returns (if any) is what Follow returns, so a handler reports a
+// failed turn by returning (true, err) and a clean end by returning (true, nil).
+type Handler func(ev sse.Event) (terminal bool, err error)
+
+const (
+	// DefaultIdle is how long to wait with no bytes at all before giving up.
+	// The server closes its SSE loop after 60s of quiet, so this has to be
+	// comfortably longer than that or every reconnect would look idle.
+	DefaultIdle = 30 * time.Minute
+
+	// MaxReconnectAttempts is the number of consecutive failures to reopen the
+	// stream before giving up. Transport errors are usually transient; a server
+	// that is genuinely gone will exhaust these quickly.
+	MaxReconnectAttempts = 5
+)
+
+// ErrIdleTimeout is returned when nothing arrived for the idle window. It is
+// explicit rather than a silent success on purpose (#398).
+var ErrIdleTimeout = errors.New("no output received")
+
+// Backoff is a variable so tests do not have to sit through real sleeps to
+// exercise the retry path.
+var Backoff = func(attempt int) time.Duration {
+	return time.Duration(attempt) * time.Second
+}
+
+// IdleTimeout reads the idle window from the environment, falling back to
+// DefaultIdle, so the wait can be widened without a rebuild.
+func IdleTimeout() time.Duration {
+	if v := os.Getenv("FOUNTAIN_STREAM_IDLE_TIMEOUT"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return DefaultIdle
+}
+
+// Follow consumes an SSE stream until the handler calls an event terminal,
+// reconnecting when the server closes the connection.
+//
+// A disconnect resumes from the last event id, so output produced while
+// disconnected is replayed rather than lost, and only a terminal event or a
+// genuine timeout ends the loop.
+//
+// A cancelled ctx ends the follow at the next event or reconnect.
+//
+// lastEventID seeds the first connection. Callers that pass the stream head
+// skip the server's full-history replay — without that, the first `turn`/`done`
+// in the replay of a prior turn ends the follow before the current turn has
+// started (#398). convID appears only in the idle-timeout message, which is
+// read by a human deciding whether to reattach.
+func Follow(ctx context.Context, open Opener, idle time.Duration, convID, lastEventID string, h Handler) error {
+	failures := 0
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		done, resumeID, err := Once(ctx, open, lastEventID, idle, h)
+		if resumeID != "" {
+			lastEventID = resumeID
+		}
+
+		switch {
+		case done:
+			// err is nil for a clean completion, or the handler's terminal
+			// failure to propagate.
+			return err
+
+		case errors.Is(err, ErrIdleTimeout):
+			return fmt.Errorf(
+				"no output for %s — the turn may still be running; reattach with `fountain conv stream %s`",
+				idle, convID,
+			)
+
+		case err != nil:
+			failures++
+			if failures >= MaxReconnectAttempts {
+				return fmt.Errorf("stream failed after %d attempts: %w", failures, err)
+			}
+			// Linear backoff: enough to ride out a redeploy without hammering.
+			time.Sleep(Backoff(failures))
+
+		default:
+			// Clean EOF with no terminal event: the server closed an idle
+			// stream. Reconnect and keep waiting.
+			failures = 0
+		}
+	}
+}
+
+// Once reads one connection to completion. It returns whether a terminal event
+// was seen (with the handler's outcome as err — nil for a clean completion)
+// and the id to resume from if the connection drops.
+func Once(parent context.Context, open Opener, lastEventID string, idle time.Duration, h Handler) (bool, string, error) {
+	// Derived from the caller's context, not Background: `fountain acp` ends a
+	// follow when the editor goes away, and a loop that owned an independent
+	// context would keep reading a stream nobody is listening to.
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	body, err := open(ctx, lastEventID)
+	if err != nil {
+		return false, "", err
+	}
+	defer body.Close()
+
+	// Idle watchdog. A blocking Read cannot be given a deadline directly, so a
+	// separate goroutine cancels the request context if nothing arrives.
+	activity := make(chan struct{}, 1)
+	idled := make(chan struct{})
+	go watchIdle(ctx, cancel, activity, idled, idle)
+
+	buf := make([]byte, 8192)
+	var pending bytes.Buffer
+	resumeID := lastEventID
+
+	for {
+		n, readErr := body.Read(buf)
+		if n > 0 {
+			select {
+			case activity <- struct{}{}:
+			default:
+			}
+
+			pending.Write(buf[:n])
+			events, leftover := sse.Feed(pending.String())
+			pending.Reset()
+			pending.WriteString(leftover)
+
+			for _, ev := range events {
+				if ev.ID > 0 {
+					resumeID = strconv.Itoa(ev.ID)
+				}
+				if terminal, termErr := h(ev); terminal {
+					return true, resumeID, termErr
+				}
+			}
+		}
+
+		if readErr != nil {
+			select {
+			case <-idled:
+				return false, resumeID, ErrIdleTimeout
+			default:
+			}
+			if errors.Is(readErr, io.EOF) {
+				return false, resumeID, nil
+			}
+			return false, resumeID, readErr
+		}
+	}
+}
+
+// watchIdle cancels the request context when nothing has arrived for `idle`.
+// Cancelling is what actually unblocks the pending Read — closing `idled` alone
+// would leave a genuinely stalled stream hanging forever, which is the failure
+// this whole mechanism exists to remove.
+func watchIdle(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	activity <-chan struct{},
+	idled chan<- struct{},
+	idle time.Duration,
+) {
+	timer := time.NewTimer(idle)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-activity:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(idle)
+		case <-timer.C:
+			close(idled)
+			cancel()
+			return
+		}
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,8 +148,10 @@ works inside a Fountain sandbox, on a checkout that is not yours, and this
 integration declares no filesystem or terminal access to your editor at all.
 Paths it reports are paths inside the sandbox.
 
-Status: in progress. Today the process handshakes and authenticates; the session
-methods that carry a conversation are being built
+Status: in progress. Prompting works — text and images go up, the agent's
+messages, thoughts and tool calls stream back, and the turn ends with a real
+stop reason. Reopening a closed session (`session/load`) and cancelling a
+running turn from the editor are still being built
 ([tracker](https://github.com/BinaryBourbon/fountain/issues/709)).
 
 ## Apply manifests


### PR DESCRIPTION
Closes #701. Gate 1 of **ADR 0015** is complete with this: an editor can hold a
conversation with a Fountain agent. Tracked by #709.

## The adapter forwards; it does not parse

`Peer` already stores every `session/update` the sprite's adapter emits,
verbatim, on a log stream named `acp` (`peer.ex:221`), and the SSE endpoint
filters by stream. So `?streams=acp,stage` is an ACP-native feed, and
`session/prompt` re-emits each stored line as the notification it already is.

That is what #644 bought, and it is why **no dialect parser lands in `cli/`** —
the rule ADR 0015 exists to enforce.

One field has to change on the way through. The stored update carries the
*sprite's* session id: the runtime's own, meaningless outside the sandbox that
holds it, and gone after a reclaim (#649). The editor knows the conversation by
ours, so that is what leaves the process; everything else passes through
untouched, and a test asserts both halves.

## Stop reasons come from the sprite; failures stay failures

The server publishes the sprite adapter's own ACP stop reason on the terminal
`turn`/`done` stage event, so:

- `refusal` comes back as a **stop reason**, not an error — even though the
  server records that turn as failed. An editor should render "the agent
  declined", not "something broke".
- An interrupt becomes `cancelled`; a suspended sandbox ends the turn cleanly,
  because the next prompt resumes it.
- The cases ACP has no vocabulary for — a sandbox that never provisioned, a
  reclaim mid-turn, a terminated conversation — are returned as **errors**
  rather than dressed up as `end_turn`, which is the one reading that would be
  false.
- A lost stream says *the turn may still be running* and names the
  conversation. It is true, and the editor cannot see it.

## The follow loop moved rather than being copied

`internal/stream` now owns the reconnect/resume/idle loop, because this adapter
needs exactly what `fountain run` needs. It encodes #398 — treating `io.EOF` as
success once made the CLI report a finished turn while the agent was still
working — and a second copy here would be a second chance to reintroduce that,
in the surface where it is hardest to notice: an editor showing a conversation
that quietly stopped updating.

`fountain run` keeps its exact behaviour, and its tests still cover the loop
through `followStream`. The loop takes a context now, so a follow ends when the
editor goes away instead of reading a stream nobody is listening to.

**Requests are dispatched concurrently.** `session/prompt` blocks for the whole
turn; a connection that stopped reading during it would be deaf to exactly what
a developer sends when a turn drags — `session/cancel` (#704), or a prompt in
another session. Responses may now be written out of order, which JSON-RPC
allows: the id correlates them, and the write mutex keeps lines whole.

## Prompt content

Text and images go up — the API has taken images since before this adapter
existed, so `promptCapabilities.image` is now true. Blocks naming something on
the developer's machine (resource links, embedded context) are dropped with a
log line rather than pasted in as a path the sandbox cannot resolve; sending
one would spend a turn hunting a file that was never going to be there.
`loadSession` stays false until #703.

## Tests

`go test ./... && go vet ./...` green, `internal/acp` also under `-race`. The
tests assert the things that would cost money or mislead: no conversation
created on a refusal path, no prompt posted for an unknown session, the stream
head learned **before** the prompt is posted (#398 from the other side), and no
notification forwarded for output that is not protocol.

Not yet verified against a live instance: the `acp` capability field this
depends on ships with #711 and has not reached prod. Live smoke to follow, and
I will report the result here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
