### PR TITLE
feat: session/cancel, and proof a turn survives a dropped stream (#704)

### DIFF
--- a/cli/internal/acp/agent.go
+++ b/cli/internal/acp/agent.go
@@ -104,10 +104,19 @@ func (a *Agent) Request(ctx context.Context, method string, params json.RawMessa
 	}
 }
 
-// Notify handles client notifications. There are none this agent acts on yet;
-// `session/cancel` arrives here when it lands (#704).
-func (a *Agent) Notify(_ context.Context, method string, _ json.RawMessage) {
-	a.log.Debug("ignoring notification", "method", method)
+// Notify handles client notifications.
+//
+// `session/cancel` is a notification, not a request: ACP expects the *pending*
+// `session/prompt` to be what answers, with a `cancelled` stop reason. So this
+// asks the server to stop the turn and returns; the prompt's own follow sees
+// the interrupted stage and reports it.
+func (a *Agent) Notify(ctx context.Context, method string, params json.RawMessage) {
+	switch method {
+	case "session/cancel":
+		a.cancel(ctx, params)
+	default:
+		a.log.Debug("ignoring notification", "method", method)
+	}
 }
 
 func (a *Agent) initialize(raw json.RawMessage) (any, error) {

--- a/cli/internal/acp/cancel.go
+++ b/cli/internal/acp/cancel.go
@@ -1,0 +1,51 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type cancelParams struct {
+	SessionID string `json:"sessionId"`
+}
+
+// cancel stops the running turn.
+//
+// Three properties, each of which is a way this could go wrong:
+//
+// **It answers nothing.** JSON-RPC forbids a response to a notification, and
+// ACP puts the answer somewhere better anyway — the pending `session/prompt`
+// returns `cancelled` when the interrupted stage reaches its follow. An editor
+// therefore learns the turn stopped from the request it is already waiting on.
+//
+// **It can only work because requests dispatch concurrently.** A connection
+// that read one message at a time would not reach this notification until the
+// prompt it is meant to stop had already finished.
+//
+// **A turn that already ended is not an error.** The server answers 409 for a
+// conversation with no turn running, which is the normal outcome of a cancel
+// that raced the agent finishing. Reporting it would be reporting a failure
+// that did not happen.
+func (a *Agent) cancel(ctx context.Context, raw json.RawMessage) {
+	var params cancelParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			a.log.Warn("session/cancel: bad params", "err", err)
+			return
+		}
+	}
+
+	sess, ok := a.sessions.get(params.SessionID)
+	if !ok {
+		a.log.Warn("session/cancel for an unknown session", "sessionId", params.SessionID)
+		return
+	}
+
+	a.log.Info("cancelling", "sessionId", sess.ID)
+	if err := a.api.Interrupt(ctx, sess.ID); err != nil {
+		// Logged, not raised: there is nobody to raise it to. If the interrupt
+		// genuinely failed the turn keeps running and the prompt will report
+		// whatever it actually does — which is the truth either way.
+		a.log.Warn("interrupt failed", "sessionId", sess.ID, "err", err)
+	}
+}

--- a/cli/internal/acp/cancel_test.go
+++ b/cli/internal/acp/cancel_test.go
@@ -1,0 +1,200 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestCancelInterruptsTheConversation(t *testing.T) {
+	api := &fakeAPI{}
+	a, _ := promptAgent(t, api)
+
+	a.Notify(context.Background(), "session/cancel", mustJSON(t, map[string]any{"sessionId": "conv-1"}))
+
+	if len(api.interrupted) != 1 || api.interrupted[0] != "conv-1" {
+		t.Errorf("interrupted = %v, want [conv-1]", api.interrupted)
+	}
+}
+
+func TestCancelForAnUnknownSessionInterruptsNothing(t *testing.T) {
+	api := &fakeAPI{}
+	a, _ := promptAgent(t, api)
+
+	a.Notify(context.Background(), "session/cancel", mustJSON(t, map[string]any{"sessionId": "not-a-session"}))
+
+	if len(api.interrupted) != 0 {
+		t.Errorf("interrupted %v for a session that does not exist", api.interrupted)
+	}
+}
+
+// A cancel that raced the agent finishing is the normal case, not a failure —
+// and there is nobody to report it to anyway, since notifications have no
+// response.
+func TestCancelSurvivesAFailedInterrupt(t *testing.T) {
+	api := &fakeAPI{interruptErr: errors.New("http 409: no_turn_running")}
+	a, _ := promptAgent(t, api)
+
+	a.Notify(context.Background(), "session/cancel", mustJSON(t, map[string]any{"sessionId": "conv-1"}))
+
+	if len(api.interrupted) != 1 {
+		t.Errorf("interrupt was not attempted: %v", api.interrupted)
+	}
+}
+
+// The one that matters: a cancel has to reach the agent WHILE a prompt is
+// blocked, which is only possible because requests dispatch concurrently. This
+// drives it through a real Conn — the fake API's Follow blocks until the
+// interrupt arrives, exactly as a real turn would sit there until stopped.
+func TestCancelReachesAPromptThatIsStillRunning(t *testing.T) {
+	interrupted := make(chan struct{})
+	api := &fakeAPI{
+		ref:           acpAgentRef(),
+		convID:        "conv-1",
+		onInterrupt:   func() { close(interrupted) },
+		followBlock:   interrupted,
+		followStarted: make(chan struct{}),
+		events:        []Event{stageEvent("turn", "interrupted", `{}`)},
+	}
+
+	a := NewAgent(&fakeAuth{available: true}, api, "researcher", discardLogger())
+	client := newTestClient(t, a)
+	defer client.close()
+
+	// Driven one message at a time, as a client does: each request is sent
+	// after the previous one is answered. The cancel is the exception — it is
+	// sent while the prompt is deliberately still outstanding, which is the
+	// whole point.
+	client.request(1, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+	client.request(2, "session/new", map[string]any{})
+
+	client.send(`{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":` +
+		`{"sessionId":"conv-1","prompt":[{"type":"text","text":"go"}]}}`)
+
+	select {
+	case <-api.followStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the turn never started")
+	}
+
+	client.send(`{"jsonrpc":"2.0","method":"session/cancel","params":{"sessionId":"conv-1"}}`)
+
+	msg := client.await(3)
+
+	select {
+	case <-interrupted:
+	default:
+		t.Fatal("the turn was never interrupted")
+	}
+
+	result, ok := msg["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("the prompt answered with %v, want a cancelled stop reason", msg)
+	}
+	if result["stopReason"] != "cancelled" {
+		t.Errorf("stopReason = %v, want cancelled", result["stopReason"])
+	}
+}
+
+// testClient drives a Conn over a pipe, the way an editor does: write a
+// request, read until its response arrives. Feeding every line at once instead
+// would race a prompt against the `session/new` that creates its session —
+// which no client does, because it has nothing to prompt until the session id
+// comes back.
+type testClient struct {
+	t     *testing.T
+	in    *io.PipeWriter
+	msgs  chan map[string]any
+	serve chan error
+}
+
+func newTestClient(t *testing.T, a *Agent) *testClient {
+	t.Helper()
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	conn := NewConn(inR, outW, discardLogger())
+	a.SetNotifier(conn)
+
+	c := &testClient{
+		t:     t,
+		in:    inW,
+		msgs:  make(chan map[string]any, 32),
+		serve: make(chan error, 1),
+	}
+
+	go func() {
+		err := conn.Serve(context.Background(), a)
+		outW.Close()
+		c.serve <- err
+	}()
+
+	go func() {
+		defer close(c.msgs)
+		dec := json.NewDecoder(outR)
+		for {
+			var m map[string]any
+			if err := dec.Decode(&m); err != nil {
+				return
+			}
+			c.msgs <- m
+		}
+	}()
+
+	return c
+}
+
+func (c *testClient) send(line string) {
+	c.t.Helper()
+	if _, err := io.WriteString(c.in, line+"\n"); err != nil {
+		c.t.Fatalf("write: %v", err)
+	}
+}
+
+// await reads until the response with this id arrives, ignoring notifications.
+func (c *testClient) await(id int) map[string]any {
+	c.t.Helper()
+	for {
+		select {
+		case msg, ok := <-c.msgs:
+			if !ok {
+				c.t.Fatalf("connection closed before answering %d", id)
+			}
+			if msg["id"] == float64(id) {
+				return msg
+			}
+		case <-time.After(5 * time.Second):
+			c.t.Fatalf("timed out waiting for a response to %d", id)
+		}
+	}
+}
+
+func (c *testClient) request(id int, method string, params any) map[string]any {
+	c.t.Helper()
+	c.send(string(mustJSON(c.t, map[string]any{
+		"jsonrpc": "2.0", "id": id, "method": method, "params": params,
+	})))
+	return c.await(id)
+}
+
+func (c *testClient) close() {
+	c.in.Close()
+	select {
+	case <-c.serve:
+	case <-time.After(5 * time.Second):
+		c.t.Error("Serve did not return after stdin closed")
+	}
+}
+
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}

--- a/cli/internal/acp/session.go
+++ b/cli/internal/acp/session.go
@@ -25,6 +25,9 @@ type API interface {
 	// fn reports stop, reconnecting across the disconnects the server produces
 	// by design.
 	Follow(ctx context.Context, convID, lastEventID string, fn EventFunc) error
+	// Interrupt stops the running turn. A conversation with no turn running is
+	// not an error — see cancel.
+	Interrupt(ctx context.Context, convID string) error
 }
 
 // AgentRef is what the adapter needs to know about a Fountain agent.

--- a/cli/internal/acp/session_test.go
+++ b/cli/internal/acp/session_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 )
 
 type fakeAPI struct {
+	mu        sync.Mutex
 	ref       AgentRef
 	agentErr  error
 	createErr error
@@ -24,6 +26,17 @@ type fakeAPI struct {
 	events     []Event
 	prompts    []sentPrompt
 	followFrom []string
+
+	// cancel path
+	interruptErr error
+	interrupted  []string
+	onInterrupt  func()
+	// followBlock, when set, holds Follow open until it is closed — a stand-in
+	// for a turn that sits there until something stops it. followStarted, when
+	// set, is closed once Follow has been entered, so a test can send a cancel
+	// at the moment a real one would arrive.
+	followBlock   chan struct{}
+	followStarted chan struct{}
 }
 
 type sentPrompt struct {
@@ -63,8 +76,31 @@ func (f *fakeAPI) SendPrompt(_ context.Context, convID, text string, images []Im
 	return f.promptErr
 }
 
+func (f *fakeAPI) Interrupt(_ context.Context, convID string) error {
+	f.mu.Lock()
+	f.interrupted = append(f.interrupted, convID)
+	onInterrupt := f.onInterrupt
+	f.mu.Unlock()
+
+	if onInterrupt != nil {
+		onInterrupt()
+	}
+	return f.interruptErr
+}
+
 func (f *fakeAPI) Follow(_ context.Context, _, lastEventID string, fn EventFunc) error {
+	f.mu.Lock()
 	f.followFrom = append(f.followFrom, lastEventID)
+	block := f.followBlock
+	started := f.followStarted
+	f.mu.Unlock()
+
+	if started != nil {
+		close(started)
+	}
+	if block != nil {
+		<-block
+	}
 	if f.followErr != nil {
 		return f.followErr
 	}

--- a/cli/internal/cmd/acp.go
+++ b/cli/internal/cmd/acp.go
@@ -197,6 +197,18 @@ func (f fountainAPI) CreateConversation(_ context.Context, agentID string) (stri
 	return id, nil
 }
 
+// Interrupt stops the running turn. A 409 means the turn had already ended —
+// the normal outcome of a cancel that raced the agent finishing — and is not
+// reported as a failure.
+func (f fountainAPI) Interrupt(_ context.Context, convID string) error {
+	err := api.New(f.opts).Post("/conversations/"+convID+"/interrupt", map[string]any{}, nil)
+	if api.StatusCode(err) == 409 {
+		f.log.Info("cancel arrived after the turn ended", "conversation", convID)
+		return nil
+	}
+	return err
+}
+
 func (f fountainAPI) StreamHead(_ context.Context, convID string) (string, error) {
 	return streamHead(api.New(f.opts), convID)
 }

--- a/cli/internal/cmd/acp_test.go
+++ b/cli/internal/cmd/acp_test.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/acp"
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+	"github.com/BinaryBourbon/fountain/cli/internal/stream"
+)
+
+func acpTestAPI(t *testing.T, baseURL string) fountainAPI {
+	t.Helper()
+	t.Setenv("FOUNTAIN_BASE_URL", baseURL)
+	t.Setenv("FOUNTAIN_API_KEY", "ftn_test_0000000000000000")
+	return fountainAPI{
+		opts: credentials.Opts{},
+		log:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+// The server closes an SSE connection after 60 seconds of quiet, so a turn
+// that thinks for longer than that WILL be disconnected mid-answer. `fountain
+// run` learned this the hard way (#398); an editor session inherits the fix
+// only if the ACP path actually goes through the same loop. This drives the
+// real fountainAPI.Follow against a server that hangs up, and asserts the
+// events either side of the break both arrive.
+func TestFollowSurvivesADroppedStream(t *testing.T) {
+	var (
+		mu           sync.Mutex
+		connections  int
+		lastEventIDs []string
+		queries      []string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		connections++
+		n := connections
+		lastEventIDs = append(lastEventIDs, r.Header.Get("Last-Event-ID"))
+		queries = append(queries, r.URL.RawQuery)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("test server cannot flush")
+			return
+		}
+
+		if n == 1 {
+			// One update, then hang up mid-turn — exactly what an idle-timeout
+			// close looks like from the client side.
+			fmt.Fprint(w, "id: 11\nevent: output\ndata: "+
+				`{"kind":"output","stream":"acp","data":"{\"jsonrpc\":\"2.0\",\"method\":\"session/update\"}"}`+
+				"\n\n")
+			flusher.Flush()
+			return
+		}
+
+		// The reconnect: the turn finishes here.
+		fmt.Fprint(w, "id: 12\nevent: stage\ndata: "+
+			`{"kind":"stage","stage":"turn","state":"done","data":"{\"stop_reason\":\"end_turn\"}"}`+
+			"\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+
+	var seen []acp.Event
+	err := api.Follow(context.Background(), "conv-1", "", func(ev acp.Event) (bool, error) {
+		seen = append(seen, ev)
+		return ev.Kind == "stage", nil
+	})
+	if err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+
+	if connections < 2 {
+		t.Fatalf("connections = %d, want the client to reconnect after the hang-up", connections)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("saw %d events, want the update and the terminal stage: %+v", len(seen), seen)
+	}
+	if seen[0].Stream != "acp" || seen[1].Stage != "turn" || seen[1].State != "done" {
+		t.Errorf("events = %+v, want an acp update then turn/done", seen)
+	}
+
+	// Resuming from the last id is what stops the reconnect replaying the
+	// whole conversation — or worse, re-forwarding updates the editor already
+	// rendered.
+	if lastEventIDs[0] != "" || lastEventIDs[1] != "11" {
+		t.Errorf("Last-Event-ID headers = %v, want [\"\", \"11\"]", lastEventIDs)
+	}
+
+	// The filter is what keeps a runtime dialect off the wire: `stdout` is not
+	// requested, so a client that cannot parse it never sees it.
+	for _, q := range queries {
+		if q != "streams=acp,stage" {
+			t.Errorf("query = %q, want streams=acp,stage", q)
+		}
+	}
+}
+
+// A cancel that arrives after the turn has already ended answers 409. That is
+// the ordinary outcome of a race, not a failure to report.
+func TestInterruptTreats409AsAlreadyFinished(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"no_turn_running"}`))
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+
+	if err := api.Interrupt(context.Background(), "conv-1"); err != nil {
+		t.Errorf("Interrupt on a finished turn = %v, want nil", err)
+	}
+}
+
+func TestInterruptReportsARealFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+
+	if err := api.Interrupt(context.Background(), "conv-1"); err == nil {
+		t.Error("Interrupt swallowed a 500")
+	}
+}
+
+// A cancelled context has to end the follow rather than leave it reading a
+// stream nobody is listening to — the editor has gone.
+func TestFollowStopsWhenTheContextIsCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := api.Follow(ctx, "conv-1", "", func(acp.Event) (bool, error) { return false, nil }); err == nil {
+		t.Error("Follow with a cancelled context returned nil, want the context error")
+	}
+}
+
+// Compile-time proof that the CLI's own follow and the ACP adapter's are the
+// same loop. If they ever diverge, #398 has two places to come back.
+var _ stream.Opener = streamOpener(nil)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,11 +148,13 @@ works inside a Fountain sandbox, on a checkout that is not yours, and this
 integration declares no filesystem or terminal access to your editor at all.
 Paths it reports are paths inside the sandbox.
 
-Status: in progress. Prompting works — text and images go up, the agent's
-messages, thoughts and tool calls stream back, and the turn ends with a real
-stop reason. Reopening a closed session (`session/load`) and cancelling a
-running turn from the editor are still being built
-([tracker](https://github.com/BinaryBourbon/fountain/issues/709)).
+A turn survives a dropped connection: the server closes an idle SSE stream
+after 60 seconds, and the adapter reconnects and resumes from where it left
+off, so a long silence is never mistaken for a finished turn. Cancelling in the
+editor stops the turn.
+
+Status: in progress. Reopening a closed session (`session/load`) is still being
+built ([tracker](https://github.com/BinaryBourbon/fountain/issues/709)).
 
 ## Apply manifests
 


### PR DESCRIPTION
Closes #704. Gate 2 of **ADR 0015**, tracked by #709.

Two halves of the same promise: a turn started from the editor keeps running,
and stops when you say so.

## Cancel answers nothing, deliberately

`session/cancel` is a notification. ACP puts the answer where the editor is
already looking — the pending `session/prompt` returns `cancelled` when the
interrupted stage reaches its follow — so the handler asks the server to stop
the turn and returns.

It only works because requests dispatch concurrently (#701). A connection that
read one message at a time would not reach the cancel until the turn it is
meant to stop had already finished, and the feature would appear to work in
every unit test while never working in an editor.

So the test that matters drives a **real connection over a pipe**: it blocks
the turn until the interrupt arrives, then asserts the outstanding prompt comes
back `cancelled`.

That test is written the way a client actually behaves — one message at a time,
each sent after the last is answered. My first version fed all four lines at
once and hung, because the prompt raced the `session/new` that creates its
session. No real client does that (it has nothing to prompt until the session
id comes back), but it was worth the detour: the harness now models a client
rather than a file.

A cancel arriving after the turn ended gets a 409, and that is **not** a
failure — it is the ordinary outcome of racing the agent to the finish, and
reporting it would report a failure that did not happen.

## Surviving a dropped stream was inherited, but unproven

#701 put the follow loop in `internal/stream` so both surfaces share #398's
fix. This adds the test that the ACP path really goes through it: an httptest
server that hangs up mid-turn, a client that reconnects, and the events either
side of the break both arriving.

It also pins the two things that make the reconnect *correct* rather than
merely present:

- **`Last-Event-ID` carries the last id**, so the editor is not re-sent updates
  it already rendered.
- **The request asks for `streams=acp,stage`**, so a runtime dialect never
  reaches a client that cannot parse it.

Plus: a cancelled context ends a follow, so when the editor goes away we stop
reading a stream nobody is listening to.

## Tests

`go test ./... && go vet ./...` green; `internal/acp` also under `-race
-count=2`, which is where a concurrency claim like this one earns its keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
