### PR TITLE
feat: sandbox paths stop being editor-clickable locations (#705)

### DIFF
--- a/cli/internal/acp/locations_test.go
+++ b/cli/internal/acp/locations_test.go
@@ -1,0 +1,108 @@
+package acp
+
+import "testing"
+
+func toolCallLine(sessionID string) string {
+	return `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"` + sessionID + `",` +
+		`"update":{"sessionUpdate":"tool_call","toolCallId":"t1","title":"Edit lib/foo.ex","kind":"edit",` +
+		`"status":"pending","locations":[{"path":"/workspace/lib/foo.ex","line":42}]}}}`
+}
+
+// #705. The paths are the sandbox's, on a machine that is not the developer's.
+// An editor that opens them either shows the wrong file or fails silently, and
+// either way the developer concludes the agent is editing their project.
+func TestToolCallLocationsDoNotReachTheEditor(t *testing.T) {
+	api := &fakeAPI{
+		events: []Event{
+			{Kind: "output", Stream: "acp", Data: toolCallLine("sprite-session")},
+			stageEvent("turn", "done", `{"stop_reason":"end_turn"}`),
+		},
+	}
+	a, notifier := promptAgent(t, api)
+
+	request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+
+	if len(notifier.params) != 1 {
+		t.Fatalf("want one forwarded update, got %d", len(notifier.params))
+	}
+	update := notifier.params[0]["update"].(map[string]any)
+
+	if _, present := update["locations"]; present {
+		t.Error("locations were forwarded — an editor will try to open a path that is not on this machine")
+	}
+}
+
+// Removed from where an editor acts on them, kept where a future client could
+// use them: read-through is a separate decision, not a reason to lose the data.
+func TestSandboxLocationsAreKeptUnderMeta(t *testing.T) {
+	api := &fakeAPI{
+		events: []Event{
+			{Kind: "output", Stream: "acp", Data: toolCallLine("sprite-session")},
+			stageEvent("turn", "done", `{"stop_reason":"end_turn"}`),
+		},
+	}
+	a, notifier := promptAgent(t, api)
+
+	request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+
+	update := notifier.params[0]["update"].(map[string]any)
+	meta, ok := update["_meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("no _meta on the forwarded update: %v", update)
+	}
+	locations, ok := meta[MetaSandboxLocations].([]any)
+	if !ok || len(locations) != 1 {
+		t.Fatalf("_meta[%s] = %v, want the one location", MetaSandboxLocations, meta[MetaSandboxLocations])
+	}
+	first := locations[0].(map[string]any)
+	if first["path"] != "/workspace/lib/foo.ex" || first["line"] != float64(42) {
+		t.Errorf("location = %v, want the sandbox path and line preserved intact", first)
+	}
+}
+
+// Everything else about the tool call still has to arrive: the title is what
+// the human reads, and it usually names the file anyway.
+func TestTheRestOfTheToolCallIsUntouched(t *testing.T) {
+	api := &fakeAPI{
+		events: []Event{
+			{Kind: "output", Stream: "acp", Data: toolCallLine("sprite-session")},
+			stageEvent("turn", "done", `{"stop_reason":"end_turn"}`),
+		},
+	}
+	a, notifier := promptAgent(t, api)
+
+	request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+
+	update := notifier.params[0]["update"].(map[string]any)
+	for key, want := range map[string]any{
+		"sessionUpdate": "tool_call",
+		"toolCallId":    "t1",
+		"title":         "Edit lib/foo.ex",
+		"kind":          "edit",
+		"status":        "pending",
+	} {
+		if update[key] != want {
+			t.Errorf("update[%q] = %v, want %v", key, update[key], want)
+		}
+	}
+}
+
+// An update with no locations must pass through without growing an empty
+// `_meta` — most updates are message chunks, and every one of them would carry
+// the noise.
+func TestUpdatesWithoutLocationsAreNotRewritten(t *testing.T) {
+	api := &fakeAPI{
+		events: []Event{
+			{Kind: "output", Stream: "acp", Data: acpLine("sprite-session", "hello")},
+			stageEvent("turn", "done", `{"stop_reason":"end_turn"}`),
+		},
+	}
+	a, notifier := promptAgent(t, api)
+
+	request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+
+	update := notifier.params[0]["update"].(map[string]any)
+	if _, present := update["_meta"]; present {
+		t.Errorf("an update with no locations grew a _meta: %v", update)
+	}
+}

--- a/cli/internal/acp/prompt.go
+++ b/cli/internal/acp/prompt.go
@@ -186,7 +186,57 @@ func (a *Agent) forwardUpdate(sess Session, line string) {
 		msg.Params = map[string]any{}
 	}
 	msg.Params["sessionId"] = sess.ID
+	a.moveSandboxLocations(msg.Params)
 	a.notify("session/update", msg.Params)
+}
+
+// MetaSandboxLocations is where a tool call's file locations go instead of
+// `locations`. An editor that learns to read it can show them as remote; every
+// other editor simply does not act on paths it never received.
+const MetaSandboxLocations = "fountain.sandboxLocations"
+
+// moveSandboxLocations takes `locations` off a tool call and files it under
+// `_meta`.
+//
+// ACP's `tool_call.locations` exists so an editor can follow along: open the
+// file, jump to the line. Every path a Fountain agent reports is a path in the
+// **sandbox**, on a checkout the sprite made, on a machine that is not the
+// developer's. An editor that takes `/workspace/lib/foo.ex` at face value
+// either opens the wrong file or silently fails, and the developer concludes
+// the agent is editing their project. ADR 0015: "Every design that pretends
+// otherwise produces an agent that appears to be editing the open project and
+// is not."
+//
+// The protocol has no way to say "this path is somewhere else", so the honest
+// options were to label or to remove. This removes — and keeps the paths under
+// `_meta`, so nothing is lost for a client that grows the ability to fetch a
+// sandbox file (the read-through escalation ADR 0015 parks as a separate
+// decision), and nothing is actionable for one that has not.
+//
+// The paths remain visible to the human either way: the sprite's own tool
+// title and raw input carry them, and the server's block translation already
+// falls back to `rawInput` when there are no locations.
+func (a *Agent) moveSandboxLocations(params map[string]any) {
+	update, ok := params["update"].(map[string]any)
+	if !ok {
+		return
+	}
+	locations, ok := update["locations"]
+	if !ok || locations == nil {
+		return
+	}
+
+	delete(update, "locations")
+
+	meta, ok := update["_meta"].(map[string]any)
+	if !ok {
+		meta = map[string]any{}
+	}
+	meta[MetaSandboxLocations] = locations
+	update["_meta"] = meta
+
+	a.log.Debug("moved sandbox paths out of tool_call.locations",
+		"why", "they name files in the sandbox, not on this machine")
 }
 
 type turnOutcome struct {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -146,7 +146,12 @@ UI or `fountain run`.
 **What it is not:** a way for a remote agent to edit your local files. The agent
 works inside a Fountain sandbox, on a checkout that is not yours, and this
 integration declares no filesystem or terminal access to your editor at all.
-Paths it reports are paths inside the sandbox.
+
+Tool calls name files in the sandbox, so those paths are deliberately not sent
+as editor-clickable locations — clicking one would open the wrong file on your
+machine, or nothing. The file a tool touched is still named in the tool call
+itself, and the full paths travel under `_meta.fountain.sandboxLocations` for
+clients that know what to do with a remote path.
 
 A turn survives a dropped connection: the server closes an idle SSE stream
 after 60 seconds, and the adapter reconnects and resumes from where it left


### PR DESCRIPTION
Closes #705. Gate 2 of **ADR 0015**, tracked by #709. Stacked on #713.

The smallest change in this campaign, and the one with the largest capacity to
mislead if skipped.

## The problem

`tool_call.locations` exists so an editor can follow along — open the file,
jump to the line. Every path a Fountain agent reports is a path in the
**sandbox**, on a checkout the sprite made, on a machine that is not the
developer's. An editor that takes `/workspace/lib/foo.ex` at face value opens
the wrong file or fails silently, and the developer concludes the agent is
editing their project.

ADR 0015 names this as the misreading the whole design exists to prevent.

## What this does

The protocol has no way to say "this path is somewhere else", so the honest
options were label or remove. This removes `locations` from the forwarded
update and files the paths under `_meta.fountain.sandboxLocations`:

```jsonc
// before, from the sprite            // after, to the editor
"locations": [                        "_meta": {
  {"path": "/workspace/lib/foo.ex",     "fountain.sandboxLocations": [
   "line": 42}                            {"path": "/workspace/lib/foo.ex", "line": 42}]}
]
```

Nothing is actionable for a client that would open them; nothing is lost for
one that later learns to fetch a sandbox file. That read-through escalation
stays what ADR 0015 says it is — a separate decision with its own endpoint and
its own path-traversal story — rather than something smuggled in through a
protocol adapter.

**The human still sees the file.** The sprite's own tool title carries it
("Edit lib/foo.ex"), which is also what the server's block translation falls
back to when there are no locations (`blocks.ex:155`).

Updates without locations pass through untouched — most updates are message
chunks, and every one of them would otherwise grow an empty `_meta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
