### PR TITLE
feat: session/load replays a conversation into a fresh editor (#703)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -31,6 +31,10 @@ defmodule FountainWeb.ConversationJSON do
       agent_id: c.agent_id,
       vault_id: c.vault_id,
       runtime: c.runtime,
+      # Derived, never stored — the same signal as on an agent (#702). A
+      # protocol client asks before reopening a conversation, because a
+      # legacy-runtime one has no ACP transcript to replay.
+      acp: Fountain.Runtimes.ACP.enabled?(c.runtime),
       status: c.status,
       runtime_session_id: c.runtime_session_id,
       source: c.source,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -49,6 +49,15 @@ defmodule FountainWeb.Schemas do
         agent_id: %Schema{type: :string, format: :uuid, nullable: true},
         vault_id: %Schema{type: :string, format: :uuid, nullable: true},
         runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        acp: %Schema{
+          type: :boolean,
+          readOnly: true,
+          description:
+            "Whether this conversation's runtime speaks the Agent Client Protocol. " <>
+              "When true its output is stored as ACP `session/update` notifications on " <>
+              "the `acp` event stream, which is what a protocol client replays; when " <>
+              "false the output is the runtime's own dialect on `stdout`."
+        },
         status: %Schema{
           type: :string,
           enum: ~w(pending running idle failed terminated)

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -57,6 +57,25 @@ defmodule FountainWeb.ConversationControllerTest do
       assert body["data"]["id"] == conv.id
     end
 
+    # `fountain acp` asks before replaying a conversation an editor handed
+    # back: a legacy-runtime conversation has a transcript, but not one stored
+    # as protocol, so there is nothing a protocol client can render (#703).
+    test "reports whether the runtime speaks ACP", %{conn: conn, user: user, raw_key: raw_key} do
+      acp_agent = insert_agent(user_id: user.id, runtime: "claude")
+      legacy_agent = insert_agent(user_id: user.id, runtime: "gemini")
+
+      acp_conv = insert_conversation(user_id: user.id, agent_id: acp_agent.id, runtime: "claude")
+
+      legacy_conv =
+        insert_conversation(user_id: user.id, agent_id: legacy_agent.id, runtime: "gemini")
+
+      for {conv, expected} <- [{acp_conv, true}, {legacy_conv, false}] do
+        conn = conn |> authed_with_key(raw_key) |> get("/api/conversations/#{conv.id}")
+
+        assert json_response(conn, 200)["data"]["acp"] == expected
+      end
+    end
+
     test "returns 404 when the conversation belongs to a different user", %{
       conn: conn,
       raw_key: raw_key

--- a/cli/internal/acp/agent.go
+++ b/cli/internal/acp/agent.go
@@ -99,6 +99,8 @@ func (a *Agent) Request(ctx context.Context, method string, params json.RawMessa
 		return a.newSession(ctx, params)
 	case "session/prompt":
 		return a.prompt(ctx, params)
+	case "session/load":
+		return a.loadSession(ctx, params)
 	default:
 		return nil, Errorf(CodeMethodNotFound, "method not found: %s", method)
 	}
@@ -165,10 +167,10 @@ func (a *Agent) initialize(raw json.RawMessage) (any, error) {
 
 // agentCapabilities is deliberately the smallest honest set.
 //
-// loadSession stays false until the replay path exists (#703): claiming it
-// obliges us to replay a whole conversation as session/update notifications
-// before answering, and an agent that claims it and does not do it leaves an
-// editor showing an empty transcript for a conversation that has one.
+// loadSession is true because the replay exists (#703): the conversation's
+// stored `session/update` notifications are re-emitted before the response.
+// The capability is a promise about ordering as much as ability, which is why
+// it was false until the drain was written.
 //
 // `image` is true because the prompt path carries images to the API, which has
 // taken them since before this adapter existed. `embeddedContext` stays false:
@@ -177,7 +179,7 @@ func (a *Agent) initialize(raw json.RawMessage) (any, error) {
 // about a machine the agent cannot see.
 func agentCapabilities() map[string]any {
 	return map[string]any{
-		"loadSession": false,
+		"loadSession": true,
 		"promptCapabilities": map[string]any{
 			"image":           true,
 			"audio":           false,

--- a/cli/internal/acp/agent_test.go
+++ b/cli/internal/acp/agent_test.go
@@ -123,8 +123,12 @@ func TestInitializeDoesNotClaimCapabilitiesItCannotHonour(t *testing.T) {
 	if !ok {
 		t.Fatalf("agentCapabilities missing: %v", result)
 	}
-	if caps["loadSession"] != false {
-		t.Errorf("loadSession = %v, want false until #703 builds the replay", caps["loadSession"])
+	// loadSession is a promise about ordering as much as ability: claiming it
+	// obliges the agent to replay the whole conversation as session/update
+	// notifications BEFORE answering. It went true with #703, which built the
+	// replay — see load_test.go.
+	if caps["loadSession"] != true {
+		t.Errorf("loadSession = %v, want true", caps["loadSession"])
 	}
 	prompt := caps["promptCapabilities"].(map[string]any)
 	if prompt["image"] != true {
@@ -254,7 +258,9 @@ func TestAuthenticateRejectsAnUnknownMethod(t *testing.T) {
 func TestSessionMethodsAreNotFoundYet(t *testing.T) {
 	a := newTestAgent(&fakeAuth{available: true})
 
-	for _, method := range []string{"session/load", "session/cancel"} {
+	// session/cancel is a notification, not a request — an editor never sends
+	// it with an id, and answering one would be the bug.
+	for _, method := range []string{"session/cancel"} {
 		_, rpcErr := request(t, a, method, map[string]any{})
 		if rpcErr == nil || rpcErr.Code != CodeMethodNotFound {
 			t.Errorf("%s: want method-not-found, got %v", method, rpcErr)

--- a/cli/internal/acp/load.go
+++ b/cli/internal/acp/load.go
@@ -1,0 +1,88 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type loadSessionParams struct {
+	SessionID string `json:"sessionId"`
+}
+
+// loadSession reopens a conversation this process did not start.
+//
+// This is the reason ADR 0015 gives for reaching past a local agent at all:
+// the work outlives the editor. Close the laptop mid-turn, reopen tomorrow,
+// and the transcript is still there — because it was never in the editor, or
+// in this process. It is also why the ACP session id is the conversation id
+// (#699): an editor hands back an id from last week, and a minted one would
+// resolve to a map that died with the process that made it.
+//
+// ACP requires the whole conversation to be replayed as `session/update`
+// notifications **before** this responds. Two details make that true rather
+// than nearly true:
+//
+//   - The replay is a drain, not a follow: it reads what is stored and stops.
+//     Waiting for live events would hold the response open for as long as the
+//     conversation stays interesting.
+//   - The notifications are written before the response because the handler
+//     writes them before it returns, and the connection serialises writes. We
+//     answered a `session/load` early once already, on the other side of this
+//     protocol — gemini's floating replay cost us #657/#661. Being the agent
+//     rather than the client is no reason to repeat it.
+func (a *Agent) loadSession(ctx context.Context, raw json.RawMessage) (any, error) {
+	var params loadSessionParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, Errorf(CodeInvalidParams, "session/load: %s", err)
+		}
+	}
+
+	if err := a.requireReady(); err != nil {
+		return nil, err
+	}
+	if params.SessionID == "" {
+		return nil, Errorf(CodeInvalidParams, "session/load: no sessionId")
+	}
+
+	conv, err := a.api.Conversation(ctx, params.SessionID)
+	if err != nil {
+		return nil, Errorf(CodeInvalidParams,
+			"could not open session %q on %s: %s", params.SessionID, a.auth.Describe(), err)
+	}
+
+	if !conv.ACP {
+		return nil, Errorf(CodeInvalidParams,
+			"session %q ran on the %s runtime, which does not speak ACP — its transcript "+
+				"is in the web UI", conv.ID, conv.Runtime)
+	}
+
+	sess := Session{ID: conv.ID, Agent: AgentRef{Runtime: conv.Runtime, ACP: true}}
+	a.sessions.put(sess)
+
+	replayed := 0
+	err = a.api.Replay(ctx, conv.ID, func(ev Event) (bool, error) {
+		if ev.Kind == "output" && ev.Stream == "acp" {
+			a.forwardUpdate(sess, ev.Data)
+			replayed++
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, Errorf(CodeInternalError,
+			"could not replay session %q: %s", conv.ID, err)
+	}
+
+	// A conversation whose sandbox was reclaimed replays in full while the
+	// agent inside remembers none of it (#649). The transcript above is real;
+	// the continuity is not, and this adapter has no honest way to say so in
+	// the protocol — inventing an agent message to explain it would be worse
+	// than the log line.
+	a.log.Info("session loaded",
+		"sessionId", conv.ID,
+		"runtime", conv.Runtime,
+		"status", conv.Status,
+		"updates_replayed", replayed)
+
+	return nil, nil
+}

--- a/cli/internal/acp/load_test.go
+++ b/cli/internal/acp/load_test.go
@@ -1,0 +1,195 @@
+package acp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// loadAgent returns an agent that has handshaked but opened nothing — the
+// state a freshly spawned process is in when an editor hands back a session id
+// from yesterday.
+func loadAgent(t *testing.T, api *fakeAPI) (*Agent, *fakeNotifier) {
+	t.Helper()
+
+	a := NewAgent(&fakeAuth{available: true}, api, "researcher", discardLogger())
+	if _, rpcErr := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion}); rpcErr != nil {
+		t.Fatalf("initialize failed: %v", rpcErr)
+	}
+	n := &fakeNotifier{}
+	a.SetNotifier(n)
+	return a, n
+}
+
+func acpConversation() ConversationRef {
+	return ConversationRef{ID: "conv-9", Runtime: "claude", Status: "idle", ACP: true}
+}
+
+// The whole pitch: the work outlived the editor. A process that never saw this
+// conversation can still put it back on screen.
+func TestLoadReplaysTheTranscriptOfAConversationThisProcessNeverOpened(t *testing.T) {
+	api := &fakeAPI{
+		conversation: acpConversation(),
+		replay: []Event{
+			{Kind: "output", Stream: "acp", Data: acpLine("sprite-session", "first")},
+			{Kind: "output", Stream: "acp", Data: acpLine("sprite-session", "second")},
+		},
+	}
+	a, notifier := loadAgent(t, api)
+
+	if _, rpcErr := request(t, a, "session/load", map[string]any{"sessionId": "conv-9"}); rpcErr != nil {
+		t.Fatalf("session/load failed: %v", rpcErr)
+	}
+
+	if len(notifier.methods) != 2 {
+		t.Fatalf("replayed %d updates, want 2", len(notifier.methods))
+	}
+	for _, m := range notifier.methods {
+		if m != "session/update" {
+			t.Errorf("replayed a %s, want session/update", m)
+		}
+	}
+}
+
+// ACP requires the replay to precede the response. We have already been on the
+// receiving end of the opposite (#657: gemini answered `session/load` and
+// replayed afterwards, so the client double-rendered a turn).
+func TestLoadReplaysBeforeItAnswers(t *testing.T) {
+	api := &fakeAPI{
+		conversation: acpConversation(),
+		replay: []Event{
+			{Kind: "output", Stream: "acp", Data: acpLine("sprite-session", "first")},
+		},
+	}
+	a, notifier := loadAgent(t, api)
+
+	// Recorded at the moment the handler returns: everything the editor is
+	// owed must already have been written.
+	request(t, a, "session/load", map[string]any{"sessionId": "conv-9"})
+
+	if notifier.rawCalls != 1 {
+		t.Errorf("the response was produced with %d updates sent, want 1 — a client "+
+			"that renders on the response would show an empty transcript", notifier.rawCalls)
+	}
+}
+
+// A loaded session is a session: the next prompt continues the same
+// conversation rather than opening a new one.
+func TestLoadedSessionIsPromptable(t *testing.T) {
+	api := &fakeAPI{
+		conversation: acpConversation(),
+		events:       []Event{stageEvent("turn", "done", `{"stop_reason":"end_turn"}`)},
+	}
+	a, _ := loadAgent(t, api)
+
+	request(t, a, "session/load", map[string]any{"sessionId": "conv-9"})
+
+	result, rpcErr := request(t, a, "session/prompt", textPrompt("conv-9", "carry on"))
+	if rpcErr != nil {
+		t.Fatalf("prompting a loaded session failed: %v", rpcErr)
+	}
+	if result["stopReason"] != "end_turn" {
+		t.Errorf("stopReason = %v, want end_turn", result["stopReason"])
+	}
+	if len(api.prompts) != 1 || api.prompts[0].convID != "conv-9" {
+		t.Errorf("prompts = %+v, want one for conv-9", api.prompts)
+	}
+	if len(api.created) != 0 {
+		t.Errorf("loading a session created a conversation: %v", api.created)
+	}
+}
+
+func TestLoadRefusesAConversationWhoseRuntimeIsNotOnACP(t *testing.T) {
+	api := &fakeAPI{
+		conversation: ConversationRef{ID: "conv-9", Runtime: "gemini", Status: "idle", ACP: false},
+		replay:       []Event{{Kind: "output", Stream: "acp", Data: acpLine("s", "hi")}},
+	}
+	a, notifier := loadAgent(t, api)
+
+	_, rpcErr := request(t, a, "session/load", map[string]any{"sessionId": "conv-9"})
+	if rpcErr == nil {
+		t.Fatal("loaded a conversation whose transcript is not protocol")
+	}
+	if !strings.Contains(rpcErr.Message, "gemini") {
+		t.Errorf("message = %q, want it to name the runtime", rpcErr.Message)
+	}
+	if notifier.rawCalls != 0 {
+		t.Errorf("replayed %d updates for a conversation it refused", notifier.rawCalls)
+	}
+}
+
+func TestLoadReportsAConversationThatIsNotThere(t *testing.T) {
+	api := &fakeAPI{conversationErr: errors.New("http 404")}
+	a, _ := loadAgent(t, api)
+
+	_, rpcErr := request(t, a, "session/load", map[string]any{"sessionId": "conv-gone"})
+	if rpcErr == nil {
+		t.Fatal("loaded a session that does not exist")
+	}
+	for _, want := range []string{"conv-gone", "example.test"} {
+		if !strings.Contains(rpcErr.Message, want) {
+			t.Errorf("message = %q, want it to mention %q", rpcErr.Message, want)
+		}
+	}
+}
+
+func TestLoadWithoutASessionIDIsRefused(t *testing.T) {
+	api := &fakeAPI{conversation: acpConversation()}
+	a, _ := loadAgent(t, api)
+
+	_, rpcErr := request(t, a, "session/load", map[string]any{})
+	if rpcErr == nil || rpcErr.Code != CodeInvalidParams {
+		t.Fatalf("want invalid params, got %v", rpcErr)
+	}
+}
+
+// A failed replay must not leave the editor believing it has the transcript.
+func TestLoadReportsAFailedReplay(t *testing.T) {
+	api := &fakeAPI{conversation: acpConversation(), replayErr: errors.New("stream HTTP 500")}
+	a, _ := loadAgent(t, api)
+
+	_, rpcErr := request(t, a, "session/load", map[string]any{"sessionId": "conv-9"})
+	if rpcErr == nil {
+		t.Fatal("a failed replay answered as though the transcript had been sent")
+	}
+}
+
+// The replayed updates go out under our session id, like live ones — the
+// sprite's own id means nothing to the editor (#649).
+func TestReplayedUpdatesCarryOurSessionID(t *testing.T) {
+	api := &fakeAPI{
+		conversation: acpConversation(),
+		replay:       []Event{{Kind: "output", Stream: "acp", Data: acpLine("sprite-session", "hi")}},
+	}
+	a, notifier := loadAgent(t, api)
+
+	request(t, a, "session/load", map[string]any{"sessionId": "conv-9"})
+
+	if got := notifier.params[0]["sessionId"]; got != "conv-9" {
+		t.Errorf("sessionId = %v, want conv-9", got)
+	}
+}
+
+// Loading is a read: it must not require the --agent that opening a new
+// session does, because the conversation already knows which agent it belongs
+// to.
+func TestLoadNeedsNoConfiguredAgent(t *testing.T) {
+	api := &fakeAPI{conversation: acpConversation()}
+	a := NewAgent(&fakeAuth{available: true}, api, "", discardLogger())
+	request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+	a.SetNotifier(&fakeNotifier{})
+
+	if _, rpcErr := request(t, a, "session/load", map[string]any{"sessionId": "conv-9"}); rpcErr != nil {
+		t.Fatalf("session/load required an agent it did not need: %v", rpcErr)
+	}
+}
+
+func TestLoadBeforeInitializeIsRefused(t *testing.T) {
+	api := &fakeAPI{conversation: acpConversation()}
+	a := NewAgent(&fakeAuth{available: true}, api, "researcher", discardLogger())
+
+	_, rpcErr := request(t, a, "session/load", map[string]any{"sessionId": "conv-9"})
+	if rpcErr == nil || rpcErr.Code != CodeInvalidRequest {
+		t.Fatalf("want an invalid-request error, got %v", rpcErr)
+	}
+}

--- a/cli/internal/acp/session.go
+++ b/cli/internal/acp/session.go
@@ -28,6 +28,24 @@ type API interface {
 	// Interrupt stops the running turn. A conversation with no turn running is
 	// not an error — see cancel.
 	Interrupt(ctx context.Context, convID string) error
+	// Conversation looks up a conversation the adapter did not open, which is
+	// what `session/load` is: an editor handing back an id from last week.
+	Conversation(ctx context.Context, convID string) (ConversationRef, error)
+	// Replay drains the conversation's stored ACP events from the beginning,
+	// oldest first, and closes. Unlike Follow it does not wait for more.
+	Replay(ctx context.Context, convID string, fn EventFunc) error
+}
+
+// ConversationRef is what the adapter needs to know about a conversation it is
+// being asked to reopen.
+type ConversationRef struct {
+	ID      string
+	Runtime string
+	Status  string
+	// ACP reports whether this conversation's output was stored as protocol.
+	// A legacy-runtime conversation has a transcript, but not one this adapter
+	// can replay — see #702.
+	ACP bool
 }
 
 // AgentRef is what the adapter needs to know about a Fountain agent.

--- a/cli/internal/acp/session_test.go
+++ b/cli/internal/acp/session_test.go
@@ -37,6 +37,12 @@ type fakeAPI struct {
 	// at the moment a real one would arrive.
 	followBlock   chan struct{}
 	followStarted chan struct{}
+
+	// load path
+	conversation    ConversationRef
+	conversationErr error
+	replay          []Event
+	replayErr       error
 }
 
 type sentPrompt struct {
@@ -105,6 +111,29 @@ func (f *fakeAPI) Follow(_ context.Context, _, lastEventID string, fn EventFunc)
 		return f.followErr
 	}
 	for _, ev := range f.events {
+		stop, err := fn(ev)
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (f *fakeAPI) Conversation(context.Context, string) (ConversationRef, error) {
+	if f.conversationErr != nil {
+		return ConversationRef{}, f.conversationErr
+	}
+	return f.conversation, nil
+}
+
+func (f *fakeAPI) Replay(_ context.Context, _ string, fn EventFunc) error {
+	if f.replayErr != nil {
+		return f.replayErr
+	}
+	for _, ev := range f.replay {
 		stop, err := fn(ev)
 		if err != nil {
 			return err

--- a/cli/internal/cmd/acp.go
+++ b/cli/internal/cmd/acp.go
@@ -197,6 +197,75 @@ func (f fountainAPI) CreateConversation(_ context.Context, agentID string) (stri
 	return id, nil
 }
 
+func (f fountainAPI) Conversation(_ context.Context, convID string) (acp.ConversationRef, error) {
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := api.New(f.opts).Get("/conversations/"+convID, &resp); err != nil {
+		return acp.ConversationRef{}, err
+	}
+	acpOK, _ := resp.Data["acp"].(bool)
+	return acp.ConversationRef{
+		ID:      output.ToString(resp.Data["id"]),
+		Runtime: output.ToString(resp.Data["runtime"]),
+		Status:  output.ToString(resp.Data["status"]),
+		ACP:     acpOK,
+	}, nil
+}
+
+// Replay drains everything the conversation has stored on the `acp` stream and
+// closes, oldest first.
+//
+// `wait=false` is what makes it a drain: the server replays the history and
+// ends the response instead of holding the connection open (#398's sibling —
+// the same endpoint, the opposite need). `Last-Event-ID: 0` starts at the
+// beginning, which is exactly what `session/load` is for.
+func (f fountainAPI) Replay(ctx context.Context, convID string, fn acp.EventFunc) error {
+	req, err := api.New(f.opts).NewStreamRequest(ctx,
+		"/conversations/"+convID+"/stream?streams=acp&wait=false", "0")
+	if err != nil {
+		return err
+	}
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("replay HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	// The trailing blank line makes the final event parse even when the body
+	// did not end with one.
+	events, _ := sse.Feed(string(body) + "\n\n")
+	for _, ev := range events {
+		data, ok := ev.Data.(map[string]any)
+		if !ok {
+			continue
+		}
+		stop, err := fn(acp.Event{
+			Kind:   output.ToString(data["kind"]),
+			Stream: output.ToString(data["stream"]),
+			Data:   output.ToString(data["data"]),
+			Stage:  output.ToString(data["stage"]),
+			State:  output.ToString(data["state"]),
+		})
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+	}
+	return nil
+}
+
 // Interrupt stops the running turn. A 409 means the turn had already ended —
 // the normal outcome of a cancel that raced the agent finishing — and is not
 // reported as a failure.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -158,8 +158,14 @@ after 60 seconds, and the adapter reconnects and resumes from where it left
 off, so a long silence is never mistaken for a finished turn. Cancelling in the
 editor stops the turn.
 
-Status: in progress. Reopening a closed session (`session/load`) is still being
-built ([tracker](https://github.com/BinaryBourbon/fountain/issues/709)).
+Close the editor and reopen it later and the conversation comes back — the
+transcript is replayed from the server, and the next prompt continues the same
+conversation. The work does not live in the editor, which is the reason to run
+an agent here rather than as a local subprocess.
+
+One caveat worth knowing: if the sandbox was reclaimed while you were away, the
+transcript still replays in full but the agent's own memory of it is gone
+([#649](https://github.com/BinaryBourbon/fountain/issues/649)).
 
 ## Apply manifests
 


### PR DESCRIPTION
Closes #703. The last of gate 2 for **ADR 0015**, tracked by #709. Stacked on
#714.

This is the reason the ADR gives for reaching past a local agent at all: **the
work outlives the editor.** Close the laptop mid-turn, reopen tomorrow, and the
conversation is still there — because it was never in the editor, or in this
process.

It also cashes in #699's choice to make the ACP session id the conversation id.
An editor hands back an id from last week; a minted one would resolve to a map
that died with the process that made it.

## The replay precedes the response, and that is the whole spec

`session/load` **MUST** re-emit the conversation as `session/update`
notifications before it answers. We have been on the receiving end of the
opposite: gemini answers first and replays afterwards, which double-rendered a
turn and cost us #657 and #661. Being the agent this time is no reason to
repeat it.

So the notifications are written before the handler returns, and the test
asserts the count *at the moment it does* — a client that renders on the
response would otherwise show an empty transcript for a conversation that has
one.

The replay is a drain, not a follow: `?streams=acp&wait=false` with
`Last-Event-ID: 0`. Waiting for live events would hold the response open for as
long as the conversation stayed interesting.

`loadSession` flips to true here rather than in #710, because the capability is
a promise about ordering as much as ability.

## A conversation this process never opened needs its own lookup

`GET /api/conversations/:id` gained the same derived `acp` boolean the agents
endpoint got in #711. A legacy-runtime conversation has a transcript, but not
one stored as protocol — it is refused by name rather than replayed as nothing.

Loading requires no `--agent`: the conversation already knows which agent it
belongs to, and demanding one would refuse to reopen a conversation the editor
is entitled to see.

## What this cannot fix

A conversation whose sandbox was reclaimed replays **in full** while the agent
inside remembers none of it (#649). The transcript is real; the continuity is
not. There is no honest way to say that in the protocol — inventing an agent
message to explain it would be worse than the log line — so the docs say it
instead, and the load logs the conversation's status.

## Tests

Ten cases covering the ordering guarantee, the refusals (unknown conversation,
non-ACP runtime, failed replay), that a loaded session is promptable and does
not create a second conversation, and that replayed updates carry our session
id rather than the sprite's. Elixir side asserts `acp` true/false through the
real controller. `go test ./... && go vet ./...` green, `-race` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
