### PR TITLE
fix: the acp stream was dropped from every filtered replay

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -856,16 +856,28 @@ defmodule Fountain.Conversations do
   defp apply_limit(query, limit) when is_integer(limit) and limit > 0,
     do: from(e in query, limit: ^limit)
 
-  # `streams` is a list of allowed stream identifiers. We accept the
-  # three values that show up in log_events: `"stdout"`, `"stderr"`, and
-  # `"stage"` (the synthetic name we give to `kind: "stage"` events,
-  # which don't have a real `stream` column value). `nil`/empty list =
+  # `streams` is a list of allowed stream identifiers: any value of the
+  # `stream` column, plus `"stage"`, the synthetic name for `kind: "stage"`
+  # events (which have no `stream` value of their own). `nil`/empty list =
   # no filter.
+  #
+  # There is deliberately **no allow-list of stream names**. There used to be
+  # one — `["stdout", "stderr"]`, written when those were the only two — and
+  # when ACP added a third (`"acp"`, one stored `session/update` per line) the
+  # filter silently answered "nothing" for it: an unrecognised name fell to a
+  # `where: false`. A name we do not know is now simply a name no row has,
+  # which returns nothing on its own without a list to keep in step.
+  #
+  # `event_in_streams?/2` is the same rule for an event already in hand. The
+  # two must agree — see the test that runs one table through both. They did
+  # not agree before, and the gap was invisible in exactly the way that hurts:
+  # live events matched, replayed ones did not, so a filtered stream returned
+  # a conversation's future and none of its past.
   defp apply_streams_filter(query, nil), do: query
   defp apply_streams_filter(query, []), do: query
 
   defp apply_streams_filter(query, streams) when is_list(streams) do
-    real_streams = Enum.filter(streams, &(&1 in ["stdout", "stderr"]))
+    real_streams = Enum.reject(streams, &(&1 == "stage"))
     include_stage? = "stage" in streams
 
     cond do
@@ -876,14 +888,28 @@ defmodule Fountain.Conversations do
       include_stage? ->
         from e in query, where: e.kind == "stage"
 
-      real_streams != [] ->
-        from e in query, where: e.stream in ^real_streams
-
       true ->
-        # All values were unknown; return nothing rather than everything.
-        from e in query, where: false
+        from e in query, where: e.stream in ^real_streams
     end
   end
+
+  @doc """
+  Whether one already-loaded event belongs to a `?streams=` selection.
+
+  The in-memory half of `apply_streams_filter/2`, used for events arriving
+  live over PubSub, where there is no query to add a `where` to. It lives here
+  rather than in the controller so the two halves of one rule sit together and
+  are tested together.
+  """
+  @spec event_in_streams?(LogEvent.t(), [String.t()] | nil) :: boolean()
+  def event_in_streams?(_ev, nil), do: true
+  def event_in_streams?(_ev, []), do: true
+  def event_in_streams?(%LogEvent{kind: "stage"}, streams), do: "stage" in streams
+
+  def event_in_streams?(%LogEvent{stream: s}, streams) when is_binary(s),
+    do: s in streams
+
+  def event_in_streams?(_ev, _streams), do: false
 
   @doc """
   Sum the byte sizes of persisted output events for a turn, by stream.

--- a/apps/fountain/lib/fountain/conversations/log_event.ex
+++ b/apps/fountain/lib/fountain/conversations/log_event.ex
@@ -6,6 +6,8 @@ defmodule Fountain.Conversations.LogEvent do
 
   @foreign_key_type :binary_id
 
+  @type t :: %__MODULE__{}
+
   @kinds ~w(output stage)
   # `acp` rows hold Agent Client Protocol `session/update` notifications, one
   # per line, exactly as `stdout` rows hold raw runtime output — what is on disk

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -598,17 +598,11 @@ defmodule FountainWeb.ConversationController do
     end)
   end
 
-  # Match a freshly-broadcast event against the same allow-list the
-  # historical replay used.
-  defp event_in_streams?(_ev, nil), do: true
-
-  defp event_in_streams?(%LogEvent{kind: "stage"}, streams),
-    do: "stage" in streams
-
-  defp event_in_streams?(%LogEvent{stream: s}, streams) when is_binary(s),
-    do: s in streams
-
-  defp event_in_streams?(_ev, _streams), do: false
+  # Match a freshly-broadcast event against the same rule the historical
+  # replay uses — literally the same function now. This used to be a second
+  # copy that had drifted from the query filter, so `?streams=acp` matched
+  # live events and no replayed ones.
+  defp event_in_streams?(ev, streams), do: Conversations.event_in_streams?(ev, streams)
 
   defp sse_loop(conn, last_id, streams, monitor_ref) do
     receive do

--- a/apps/fountain/test/fountain/conversations/stream_filter_test.exs
+++ b/apps/fountain/test/fountain/conversations/stream_filter_test.exs
@@ -1,0 +1,124 @@
+defmodule Fountain.Conversations.StreamFilterTest do
+  @moduledoc """
+  `?streams=` has two implementations and they must agree.
+
+  One filters a query (history, `_unsafe_list_log_events/3`); the other filters
+  an event already in hand (live, over PubSub). They disagreed for as long as
+  the `acp` stream existed: the query half carried an allow-list of
+  `["stdout", "stderr"]` written before ACP, so a filtered request answered
+  with a conversation's future and none of its past.
+
+  Nothing caught it because each half was plausible on its own, and the two
+  are only comparable when you run one table through both — which is what this
+  file does.
+  """
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+
+  setup do
+    user = insert_verified_user()
+    conv = insert_conversation(user_id: user.id)
+    {:ok, conv: conv}
+  end
+
+  describe "history and live agree" do
+    test "for every stream name we store", %{conv: conv} do
+      events = %{
+        "acp" => insert_log_event(conv, %{stream: "acp", data: ~s({"method":"session/update"})}),
+        "stdout" => insert_log_event(conv, %{stream: "stdout"}),
+        "stderr" => insert_log_event(conv, %{stream: "stderr"}),
+        "stage" =>
+          insert_log_event(conv, %{kind: "stage", stream: "", stage: "turn", state: "done"})
+      }
+
+      selections = [
+        ["acp"],
+        ["stage"],
+        ["acp", "stage"],
+        ["stdout", "stderr"],
+        ["acp", "stdout", "stderr", "stage"],
+        ["nonsense"],
+        nil
+      ]
+
+      for streams <- selections, {name, event} <- events do
+        from_history =
+          conv.id
+          |> Conversations._unsafe_list_log_events(0, streams: streams)
+          |> Enum.any?(&(&1.id == event.id))
+
+        from_live = Conversations.event_in_streams?(event, streams)
+
+        assert from_history == from_live,
+               "#{name} event: history says #{from_history}, live says #{from_live} " <>
+                 "for streams=#{inspect(streams)}"
+      end
+    end
+  end
+
+  describe "the acp stream" do
+    # The regression. `session/load` replays a conversation by asking for
+    # exactly this, so an empty answer means an editor reopens to a blank
+    # transcript for a conversation that has one (#703).
+    test "is replayed when asked for by name", %{conv: conv} do
+      acp = insert_log_event(conv, %{stream: "acp", data: ~s({"method":"session/update"})})
+      insert_log_event(conv, %{stream: "stdout"})
+
+      ids =
+        conv.id
+        |> Conversations._unsafe_list_log_events(0, streams: ["acp"])
+        |> Enum.map(& &1.id)
+
+      assert ids == [acp.id]
+    end
+
+    # What a reconnect mid-turn asks for: the updates it missed, plus the
+    # stage event that ends the turn. Dropping the `acp` half loses exactly
+    # the output produced while the connection was down.
+    test "is replayed alongside stage events", %{conv: conv} do
+      acp = insert_log_event(conv, %{stream: "acp"})
+      stage = insert_log_event(conv, %{kind: "stage", stream: "", stage: "turn", state: "done"})
+      insert_log_event(conv, %{stream: "stdout"})
+
+      ids =
+        conv.id
+        |> Conversations._unsafe_list_log_events(0, streams: ["acp", "stage"])
+        |> Enum.map(& &1.id)
+
+      assert ids == [acp.id, stage.id]
+    end
+  end
+
+  describe "unknown names" do
+    # No allow-list any more, so this holds by construction rather than by a
+    # list someone has to remember to extend: a name no row carries matches no
+    # row.
+    test "match nothing rather than everything", %{conv: conv} do
+      insert_log_event(conv, %{stream: "acp"})
+      insert_log_event(conv, %{stream: "stdout"})
+
+      assert Conversations._unsafe_list_log_events(conv.id, 0, streams: ["not-a-stream"]) == []
+    end
+
+    test "do not suppress the names alongside them", %{conv: conv} do
+      acp = insert_log_event(conv, %{stream: "acp"})
+
+      ids =
+        conv.id
+        |> Conversations._unsafe_list_log_events(0, streams: ["not-a-stream", "acp"])
+        |> Enum.map(& &1.id)
+
+      assert ids == [acp.id]
+    end
+  end
+
+  describe "no filter" do
+    test "returns everything", %{conv: conv} do
+      for stream <- ~w(acp stdout stderr), do: insert_log_event(conv, %{stream: stream})
+
+      assert length(Conversations._unsafe_list_log_events(conv.id, 0, streams: nil)) == 3
+      assert length(Conversations._unsafe_list_log_events(conv.id, 0, streams: [])) == 3
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
@@ -125,6 +125,7 @@ defmodule FountainWeb.SseStreamTest do
     setup %{conv: conv} do
       insert_log_event(conv, %{kind: "output", stream: "stdout", data: "on-stdout"})
       insert_log_event(conv, %{kind: "output", stream: "stderr", data: "on-stderr"})
+      insert_log_event(conv, %{kind: "output", stream: "acp", data: "on-acp"})
       insert_log_event(conv, %{kind: "stage", stream: "", stage: "provision", state: "done"})
       :ok
     end
@@ -151,6 +152,29 @@ defmodule FountainWeb.SseStreamTest do
       refute conn.resp_body =~ "on-stdout"
       assert conn.resp_body =~ "on-stderr"
       assert conn.resp_body =~ "event: stage"
+    end
+
+    # These three existed for stdout/stderr/stage, which is exactly why the
+    # `acp` stream could be dropped from every filtered replay without a test
+    # noticing. `fountain acp` asks for `acp,stage` on every reconnect and
+    # `acp` alone on every `session/load`.
+    test "the acp stream replays when asked for by name", %{raw_key: key, conv: conv} do
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false&streams=acp")
+
+      assert conn.resp_body =~ "on-acp"
+      refute conn.resp_body =~ "on-stdout"
+      refute conn.resp_body =~ "event: stage"
+    end
+
+    test "acp combines with stage, which is what a protocol client asks for", %{
+      raw_key: key,
+      conv: conv
+    } do
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false&streams=acp,stage")
+
+      assert conn.resp_body =~ "on-acp"
+      assert conn.resp_body =~ "event: stage"
+      refute conn.resp_body =~ "on-stdout"
     end
   end
 


### PR DESCRIPTION
Found by the live smoke of #703 (PR #715), not by a test: `session/load`
against a real conversation holding 31 stored updates replayed **zero** of
them.

```console
$ curl ".../stream?streams=acp&wait=false"      # nothing
$ curl ".../stream?wait=false" | jq -r .stream | sort | uniq -c
  31 acp
  14 stage
```

## The bug

`?streams=` has two implementations. The live one matches an event already in
hand; the history one builds a `where` clause. The history one carried an
allow-list:

```elixir
real_streams = Enum.filter(streams, &(&1 in ["stdout", "stderr"]))
# …
true -> from e in query, where: false   # "all values were unknown"
```

Written when those were the only two streams. When ACP added a third in #647,
a filtered request began answering with a conversation's **future and none of
its past** — live events matched, replayed ones did not.

## What it broke, this week

- **`session/load` replayed nothing** (#703). An editor reopening a
  conversation saw a blank transcript for a conversation that has one — the
  exact failure `loadSession: true` is a promise against.
- **A reconnect mid-turn lost what it missed** (#704). `fountain acp` resumes
  with `Last-Event-ID` and `streams=acp,stage`; the catch-up replay dropped
  every `acp` line, so output produced while the connection was down never
  reached the editor. The turn carried on afterwards, which is what made it
  invisible.

Neither showed up in tests: the Go tests fake the API, and the Elixir
filter tests covered `stdout`, `stderr` and `stage` — the three names the
allow-list happened to know.

## The fix

Stop keeping a list. `"stage"` is the synthetic name for `kind: "stage"`
events; every other value filters on the `stream` column. An unknown name
matches no row because no row carries it, so "return nothing rather than
everything" survives without a list anyone has to remember to extend.

The two halves are one function now — the controller delegates to
`Conversations.event_in_streams?/2`.

## The test that was missing

`stream_filter_test.exs` runs one table of (event, selection) pairs through
**both** halves and asserts they agree. That is the shape of test this needed:
each half was plausible on its own, and they are only comparable together.

Reverted against the old code, 4 of its 6 cases fail. The HTTP-level filter
tests gained `acp` and `acp,stage` — the two selections a protocol client
actually sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
