### PR TITLE
docs: the event stream is an interface, so document what it carries (#707)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -443,7 +443,15 @@ defmodule FountainWeb.ConversationController do
     description:
       "Server-Sent Events stream of the conversation's log events. The `Last-Event-ID` " <>
         "request header resumes from a known event id; missed events are replayed before " <>
-        "the live tail begins. Keep-alive heartbeats every 15s as `: heartbeat` comments.",
+        "the live tail begins. Keep-alive heartbeats every 15s as `: heartbeat` comments.\n\n" <>
+        "Each message carries the event id in `id:`, the event's `kind` in `event:` " <>
+        "(`output` or `stage`), and a JSON object in `data:` with `kind`, `stream`, " <>
+        "`data`, `stage`, `state`, `turn_id` and `ts`. The `data` field is a string: raw " <>
+        "output for an `output` event, JSON-encoded metadata for a `stage` one.\n\n" <>
+        "**This shape is an interface, not an implementation detail.** Two clients render " <>
+        "from it — the web UI and `fountain acp`, the Agent Client Protocol adapter an " <>
+        "editor spawns — so changing an event's shape or a stream's meaning breaks a " <>
+        "surface outside this repo. See decisions/0015.",
     parameters: [
       conversation_id: [in: :path, type: :string, required: true],
       "Last-Event-ID": [
@@ -455,14 +463,27 @@ defmodule FountainWeb.ConversationController do
             "Missing or unparseable values are treated as 0."
       ],
       # Both load-bearing in the bundled SKILL.md files and undocumented here
-      # until now.
+      # until now. The values are enumerated from LogEvent.streams/0 by a guard
+      # test, because this list has already gone stale once: `acp` shipped in
+      # #647 and the description still said "stdout, stderr, stage" while the
+      # query filter silently dropped it (#716).
       streams: [
         in: :query,
         type: :string,
         required: false,
         description:
-          "Comma-separated subset of `stdout`, `stderr`, `stage`. " <>
-            "Omitted or empty means all three."
+          "Comma-separated subset of `stdout`, `stderr`, `acp` and `stage`. " <>
+            "Omitted or empty means everything.\n\n" <>
+            "- `stdout` / `stderr` — the runtime process's own output, byte for byte.\n" <>
+            "- `acp` — one Agent Client Protocol `session/update` notification per line, " <>
+            "stored exactly as the runtime's adapter emitted it. This is what a protocol " <>
+            "client forwards to an editor, so it is a compatibility surface (decisions/0015). " <>
+            "Only conversations whose runtime speaks ACP have it — see the conversation's " <>
+            "`acp` field.\n" <>
+            "- `stage` — lifecycle events (`provision`, `setup`, `turn`, `reattach`, " <>
+            "`sandbox`, `terminate`) with a `state` and JSON metadata. The terminal " <>
+            "`turn`/`done` carries the turn's `stop_reason`.\n\n" <>
+            "A name no event carries selects nothing; it is not an error."
       ],
       wait: [
         in: :query,

--- a/apps/fountain/test/fountain_web/api_spec_test.exs
+++ b/apps/fountain/test/fountain_web/api_spec_test.exs
@@ -146,6 +146,51 @@ defmodule FountainWeb.ApiSpecTest do
     end
   end
 
+  # The event stream stopped being an implementation detail when a second
+  # client started rendering from it: `fountain acp` forwards its `acp` events
+  # to an editor (decisions/0015). Its shape and its stream names are now a
+  # published contract, and this is the part of the contract a reader relies on
+  # to know what to ask for.
+  #
+  # It has already gone stale once in the worst way: `acp` shipped in #647,
+  # the documented values still said "stdout, stderr, stage", and the query
+  # filter dropped the name entirely, so `session/load` replayed nothing
+  # (#716). A doc string is not enough on its own — this ties it to
+  # `LogEvent.streams/0`, which is where the real list lives.
+  describe "the stream endpoint documents what it streams (issue #707)" do
+    setup do
+      op = ApiSpec.spec().paths["/api/conversations/{conversation_id}/stream"].get
+      param = Enum.find(op.parameters, &(&1.name == :streams))
+
+      assert param, "the `streams` query parameter is undocumented"
+      %{op: op, description: param.description}
+    end
+
+    test "every real stream name is named", %{description: description} do
+      for stream <- Fountain.Conversations.LogEvent.streams() do
+        assert description =~ "`#{stream}`",
+               "the `streams` parameter does not mention `#{stream}` — a client cannot " <>
+                 "ask for a stream it has never been told about"
+      end
+    end
+
+    test "the synthetic stage name is named too", %{description: description} do
+      assert description =~ "`stage`"
+    end
+
+    test "the acp stream's contract is stated, not just its name", %{description: description} do
+      assert description =~ "session/update",
+             "a client forwarding these lines needs to know they are ACP notifications"
+    end
+
+    test "the event envelope is described", %{op: op} do
+      for field <- ~w(kind stream data stage state turn_id ts) do
+        assert op.description =~ "`#{field}`",
+               "the SSE payload's `#{field}` field is undocumented"
+      end
+    end
+  end
+
   defp open_api_path(path) do
     path
     |> String.split("/")


### PR DESCRIPTION
Closes #707. Gate 3 of **ADR 0015**, tracked by #709.

ADR 0015 predicted this: once a second client renders from the event stream, it
"stops being an implementation detail of `show.ex` and becomes an interface,
with the compatibility obligations of one". `fountain acp` forwards `acp`
events to an editor, so that second client now exists.

## A correction to the issue as I filed it

I wrote that `?streams=` "appears **nowhere** in the OpenAPI spec". Wrong — the
API-parity campaign (#531) documented `streams` and `wait`.

What was actually wrong is subtler and worse: the documented values were
`stdout, stderr, stage`, written before ACP existed. So the one stream two
clients depend on was missing from the description *and* silently dropped by
the query filter (#716). The docs and the code were stale in the same
direction, which is exactly why neither contradicted the other.

## What is documented now

- **Every stream name**, what it carries, and that an unknown name selects
  nothing rather than erroring.
- **The `acp` stream's contract** — one `session/update` notification per line,
  stored exactly as the runtime's adapter emitted it, and only present for
  runtimes that speak ACP (pointing at the conversation's `acp` field).
- **The SSE envelope**: the `event:` names and the seven fields of the `data:`
  object, including that `data` is a *string* — raw output for `output`,
  JSON-encoded metadata for `stage`.
- **That the shape is a compatibility surface**, stated in the operation
  description, where someone about to change it will read it.

## The guard is the part that lasts

Four tests tie the description to `LogEvent.streams/0` — the list the schema
already validates against — so a fifth stream cannot ship documented as three,
and the `acp` contract cannot be reduced to a bare name. Reverted to the
pre-ACP description, four of them fail.

That is the same shape of fix as #716: stop maintaining a second copy of a list
by hand, and tie the copy that remains to the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
