### PR TITLE
docs: an editor page for ACP, and 0015 stops saying nothing is built (#706)

### DIFF
--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -46,6 +46,7 @@ defmodule Fountain.Docs do
     {"Integrations",
      [
        {"Overview", "integrations/index.md"},
+       {"Editors (ACP)", "integrations/editors.md"},
        {"GitHub OAuth", "integrations/github-oauth.md"},
        {"Stripe", "integrations/stripe.md"},
        {"Sentry", "integrations/sentry.md"},

--- a/decisions/0015-fountain-as-an-acp-agent.md
+++ b/decisions/0015-fountain-as-an-acp-agent.md
@@ -1,10 +1,23 @@
 # 0015 — Fountain as an ACP agent, reachable from a code editor
 
-**Status:** Proposed — **nothing described here is built.** No ACP code exists
-in this repo. This is the second of two ADRs about the Agent Client Protocol
-and covers the opposite direction from
-[0014](0014-agent-client-protocol.md); the PR that builds each gate removes
-its caveat.
+**Status:** Accepted — **gates 1–3 are built.** `fountain acp` exists in
+`cli/internal/acp`, and an editor can open a conversation on a Fountain agent,
+prompt it, watch it stream, cancel it, and reopen it later
+([#709](https://github.com/BinaryBourbon/fountain/issues/709): gate 1 in
+#710/#711/#712, gate 2 in #713/#714/#715, gate 3 in #718 and the PR carrying
+this line). **Gate 4 — permission forwarding — is not built** and remains
+blocked on #643; the *Consequences* section below states what it needs first.
+
+This is the second of two ADRs about the Agent Client Protocol and covers the
+opposite direction from [0014](0014-agent-client-protocol.md).
+
+What the build changed about the design as written, all recorded in the gates
+below: the ACP session id **is** the conversation id rather than a minted one,
+because an editor must be able to hand back an id from last week; the sandbox
+paths in `tool_call.locations` are removed rather than labelled, because the
+protocol has no way to say "this path is on another machine"; and the adapter
+turned out to be a forwarder rather than a translator, which is the best case
+this ADR hoped for from 0014 and the reason it stayed small.
 
 ## Context
 
@@ -198,15 +211,36 @@ land in `cli/`.**
 
 ### Gates
 
-1. **Transcript-only prototype, one runtime.** `fountain acp` renders a live
-   remote conversation in a real editor: message chunks, thoughts, tool calls
-   with status. No `fs/*`, no `terminal/*`. Proves the shape end to end.
-2. **Session lifecycle.** `session/load`, `session/cancel`, correct stop
-   reasons, and survival across a dropped SSE connection — reattaching to a
-   turn that kept running is the entire pitch, so it is a gate, not a polish
-   item.
-3. **Auth and distribution.** `authMethods`, editor config snippets, docs.
-4. **Permission forwarding** — blocked on 0014 gate 3. See below.
+1. ~~**Transcript-only prototype, one runtime.**~~ **Built.** `fountain acp`
+   renders a live remote conversation: message chunks, thoughts, tool calls
+   with status. No `fs/*`, no `terminal/*`. Verified against prod, not only in
+   tests — the run returned a tool call and a real stop reason.
+2. ~~**Session lifecycle.**~~ **Built.** `session/load`, `session/cancel`,
+   stop reasons taken from the sandbox's own adapter, and survival across a
+   dropped SSE connection. Verified live: a cancel answered a blocked prompt
+   with `cancelled` in 0.1s, and a load replayed 31 updates before responding.
+3. ~~**Auth and distribution.**~~ **Built.** `authMethods`, the editor page in
+   `docs/integrations/editors.md`, and the event stream documented as the
+   interface it now is (#707).
+4. **Permission forwarding** — not built, blocked on 0014 gate 3 (#643). See
+   below.
+
+**Two things found by running gates 1–3 against production, which the tests
+could not see.** Both are worth keeping here because they are properties of
+this design, not accidents. The filtered *replay* of the event stream had
+never included the `acp` stream, so `session/load` returned an empty
+transcript and every mid-turn reconnect silently dropped what it missed
+(#716) — a proxy that forwards stored events depends on the store's filter as
+much as on the protocol. And a lost wake race leaves a conversation pointing
+at a sandbox it just terminated (#717), which this adapter reproduces on every
+session because `session/new` and the first `session/prompt` arrive a second
+apart.
+
+**On the remote transport, which this gate said to revisit:** ACP's own
+introduction still documents it as work in progress, and nothing in the build
+argued for waiting. The local process kept earning its place — it is where
+`fountain auth login`'s credentials already are, and where the instance and
+profile are chosen.
 
 ## Consequences
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -131,41 +131,13 @@ the protocol and nothing else; diagnostics go to stderr, which is where to look
 first when an editor reports a problem.
 
 `--agent` names the Fountain agent that sessions run: the protocol has no field
-for it, so it is configured on the command line. Add one editor entry per agent
-you want to reach. Each session the editor opens creates its own conversation
-for that agent.
+for it, so it is configured on the command line, one editor entry per agent.
+Credentials are the ones `fountain auth login` already saved, and `--profile`
+selects the instance.
 
-It authenticates with the same credentials as every other command
-(`FOUNTAIN_API_KEY`, then the active profile), so `fountain auth login` is the
-only setup step. `--profile` selects the instance.
-
-Agents whose runtime does not speak ACP are refused when the editor opens a
-session, with the runtime named — today that is `gemini`. Use those from the web
-UI or `fountain run`.
-
-**What it is not:** a way for a remote agent to edit your local files. The agent
-works inside a Fountain sandbox, on a checkout that is not yours, and this
-integration declares no filesystem or terminal access to your editor at all.
-
-Tool calls name files in the sandbox, so those paths are deliberately not sent
-as editor-clickable locations — clicking one would open the wrong file on your
-machine, or nothing. The file a tool touched is still named in the tool call
-itself, and the full paths travel under `_meta.fountain.sandboxLocations` for
-clients that know what to do with a remote path.
-
-A turn survives a dropped connection: the server closes an idle SSE stream
-after 60 seconds, and the adapter reconnects and resumes from where it left
-off, so a long silence is never mistaken for a finished turn. Cancelling in the
-editor stops the turn.
-
-Close the editor and reopen it later and the conversation comes back — the
-transcript is replayed from the server, and the next prompt continues the same
-conversation. The work does not live in the editor, which is the reason to run
-an agent here rather than as a local subprocess.
-
-One caveat worth knowing: if the sandbox was reclaimed while you were away, the
-transcript still replays in full but the agent's own memory of it is gone
-([#649](https://github.com/BinaryBourbon/fountain/issues/649)).
+**[Editors (ACP)](integrations/editors.md)** has the setup, the editor config
+snippets, and the limits worth knowing before you start — chief among them that
+the agent works on a sandbox's files, not the ones open in your editor.
 
 ## Apply manifests
 

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -1,0 +1,157 @@
+# Editors (Agent Client Protocol)
+
+Fountain speaks the [Agent Client Protocol](https://agentclientprotocol.com)
+(ACP), so an ACP-capable editor can drive a conversation running on a Fountain
+agent: prompt it, watch it think and call tools, cancel it, close the editor,
+and reopen the conversation later.
+
+The editor spawns `fountain acp` as a subprocess and talks JSON-RPC to it over
+the pipe. That process talks HTTP and SSE to your Fountain instance.
+
+```
+  editor  ──spawns──▶  fountain acp  ──HTTPS──▶  Fountain  ──ACP──▶  sandbox
+   (ACP over stdio)                                                  (the agent)
+```
+
+## What this is, and is not
+
+It is a **control surface for a remote conversation**. The agent runs in a
+Fountain sandbox, on a checkout the sandbox made, on a machine that is not
+yours.
+
+It is **not** a way for the agent to edit the files open in your editor. The
+integration declares no filesystem or terminal access, and the file paths a
+tool call reports are paths inside the sandbox — they are deliberately not sent
+as clickable locations, because clicking one would open the wrong file on your
+machine or nothing at all. They travel under
+`_meta.fountain.sandboxLocations` instead.
+
+Why reach for this rather than a local agent, then:
+
+- **The work outlives the editor.** Close the laptop mid-turn; the turn keeps
+  running. Reopen and the transcript is replayed from the server.
+- **The unit is a Fountain agent** — an environment, vault overrides, skills,
+  MCP servers and inference credentials that never touch your machine.
+- **The same conversation is open in the web UI**, for you or a teammate,
+  while it runs.
+
+## Setup
+
+1. Install the CLI and log in:
+
+    ```bash
+    brew install BinaryBourbon/tap/fountain
+    fountain auth login
+    ```
+
+    For a self-hosted instance, point at it first — the CLI defaults to the
+    hosted one:
+
+    ```bash
+    FOUNTAIN_BASE_URL=https://fountain.example.com fountain auth login
+    ```
+
+2. Pick an agent. `fountain agent list` shows yours; the editor entry names one
+   agent, so add one entry per agent you want to reach.
+
+3. Configure your editor (below), and start a new thread with it.
+
+### Zed
+
+In `settings.json` (`zed: open settings`):
+
+```json
+{
+  "agent_servers": {
+    "Fountain: researcher": {
+      "type": "custom",
+      "command": "fountain",
+      "args": ["acp", "--agent", "researcher"],
+      "env": {}
+    }
+  }
+}
+```
+
+Use the agent's name or id in `--args`. To reach a non-default instance or
+profile, add `"--profile", "staging"` to `args`, or set `FOUNTAIN_BASE_URL` in
+`env`.
+
+### Any other ACP client
+
+There is nothing Zed-specific in the adapter. Whatever your client calls it,
+the agent command is:
+
+```bash
+fountain acp --agent <name-or-id>
+```
+
+spoken to over stdin/stdout. [Buzz](https://github.com/block/buzz) is
+ACP-native and should work the same way, though its configuration format for a
+custom agent is not something we have verified — if you get it working, a note
+in an issue would be welcome.
+
+## What you get
+
+| ACP | What happens |
+|---|---|
+| `initialize` | Capability handshake. Protocol version 1 |
+| `authenticate` | Uses the credentials `fountain auth login` saved. No second login |
+| `session/new` | Creates a conversation for the configured agent |
+| `session/prompt` | Runs a turn; messages, thoughts and tool calls stream back as they happen |
+| `session/cancel` | Interrupts the running turn |
+| `session/load` | Replays the conversation into a freshly opened editor |
+
+Images in a prompt are supported. A dropped connection is not a lost turn: the
+server closes an idle stream after 60 seconds and the adapter reconnects and
+resumes from where it left off.
+
+## Limits, stated rather than discovered
+
+- **No access to your local files**, as above.
+- **Agents on the `gemini` runtime are refused** when the editor opens a
+  session, by name. Gemini is not on ACP yet
+  ([#659](https://github.com/BinaryBourbon/fountain/issues/659)); use those
+  agents from the web UI or `fountain run`.
+- **Permission prompts are not forwarded yet.** Agents currently run with their
+  own permission handling, so an editor will not be asked to approve a tool
+  call ([#643](https://github.com/BinaryBourbon/fountain/issues/643),
+  [#708](https://github.com/BinaryBourbon/fountain/issues/708)).
+- **A reclaimed sandbox loses the agent's memory.** If a conversation's sandbox
+  was reclaimed while you were away, `session/load` still replays the full
+  transcript, but the agent itself does not remember it
+  ([#649](https://github.com/BinaryBourbon/fountain/issues/649)).
+
+## When something goes wrong
+
+`fountain acp` writes the protocol to stdout and **everything else to stderr**,
+which is where your editor's agent-server log will show it. Start there.
+
+```bash
+# what the editor runs, with more detail
+fountain acp --agent researcher --log-level debug
+```
+
+Errors are written to be readable inside an editor rather than in a terminal:
+
+| Message | Meaning |
+|---|---|
+| `no Fountain agent configured` | The entry has no `--agent` |
+| `agent "x" runs the gemini runtime, which does not speak ACP` | See the limits above |
+| `credentials for … were rejected` | Run `fountain auth login`. The message names the instance it tried, which is usually the surprise |
+| `could not resolve agent "x" on …` | Wrong name, or the right name on a different instance |
+
+Running the binary by hand is a fair diagnostic — it will sit waiting for
+JSON-RPC on stdin, which tells you the process starts and finds its
+credentials.
+
+## How it works
+
+Two ADRs cover the design:
+[0014](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0014-agent-client-protocol.md)
+made Fountain an ACP *client* of the coding agents it runs in sandboxes;
+[0015](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0015-fountain-as-an-acp-agent.md)
+makes it an ACP *agent* for editors. Together they make Fountain a proxy: the
+same block vocabulary arrives from a sandbox on one side and leaves for an
+editor on the other, so the adapter forwards updates rather than translating
+them, and no runtime's output format is parsed twice.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -12,6 +12,14 @@ provider side, which env vars result, and how to verify it works.
 | [Stripe](stripe.md) | Optional | `BILLING_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID` | No billing. Correct for most self-hosted instances — leave the gate off |
 | [Sentry](sentry.md) | Optional | `SENTRY_DSN`, `SENTRY_ENVIRONMENT` | No error tracking; the SDK is inert and nothing leaves the instance |
 
+## The integration with nothing to configure
+
+[**Editors**](editors.md) are the one integration an operator does not set up.
+An ACP-capable editor — Zed and friends — spawns `fountain acp` locally and
+talks to your instance with the credentials the developer already has. There is
+no env var, no server-side switch, and nothing for you to run: it works against
+any instance the CLI can reach.
+
 The sandbox providers — Sprites, E2B, Daytona — have
 [a section of their own](sandbox-contract.md): one contract, three
 implementations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - Adding a provider: integrations/adding-a-sandbox-provider.md
   - Integrations:
       - Overview: integrations/index.md
+      - Editors (ACP): integrations/editors.md
       - GitHub OAuth: integrations/github-oauth.md
       - Stripe: integrations/stripe.md
       - Sentry: integrations/sentry.md


### PR DESCRIPTION
Closes #706. Gate 3 of **ADR 0015**, tracked by #709. Sibling of #718.

The adapter has worked since gate 1. What was missing was any way for someone
who has never seen this repo to find it, configure it, and know what it will
not do.

## `docs/integrations/editors.md`

- **Setup**, including the self-hosted case (`FOUNTAIN_BASE_URL` before
  `fountain auth login` — the trap the CLI page already warns about).
- **The Zed snippet**, checked against Zed's own docs rather than written from
  memory:

    ```json
    {
      "agent_servers": {
        "Fountain: researcher": {
          "type": "custom",
          "command": "fountain",
          "args": ["acp", "--agent", "researcher"],
          "env": {}
        }
      }
    }
    ```

- **The generic invocation** for any other ACP client, since nothing in the
  adapter is Zed-specific.
- **What each method does**, so the table of capabilities is not something you
  infer from behaviour.
- **A troubleshooting table keyed by the exact error strings** the adapter
  emits. Those messages were written to be read inside an editor by someone
  who cannot see a 401; the docs quote them verbatim so a search lands here.

**The limits are stated rather than discovered:** no access to local files;
sandbox paths deliberately not sent as clickable locations; gemini agents
refused by name (#659); permission prompts not forwarded yet (#643/#708); and a
reclaimed sandbox replaying a transcript the agent no longer remembers (#649).

**Buzz** is named as ACP-native with an honest caveat — I could not verify its
custom-agent configuration format, so the page says exactly that and asks for a
note, rather than shipping a snippet I invented.

`docs/cli.md` loses the duplicate and points here. Two copies of the same
limits drift, which is the failure this campaign has paid for twice today
(#716, and the `streams` description in #718).

## ADR 0015's status caveat comes off

Required by the rule in CLAUDE.md, and overdue by three gates. It now names
gates 1–3 as built with their PRs and gate 4 as explicitly not, and records:

- **what the build changed about the design** — the ACP session id *is* the
  conversation id; sandbox locations are removed rather than labelled; the
  adapter forwards rather than translates (0014's best case, and why this
  stayed small);
- **the two production defects gates 1–3 surfaced** (#716, #717), because both
  are properties of this design rather than accidents — a proxy that forwards
  stored events depends on the store's filter as much as on the protocol;
- **the answer to the question gate 3 was told to revisit**: ACP's remote
  transport is still documented as WIP, and the local process keeps earning its
  place, because that is where credentials and instance selection already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
