### PR TITLE
fix: report agentInfo and the session's model, so clients accept the agent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,17 @@ jobs:
           CGO_ENABLED: "0"
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          # Stamped into the binary so `fountain --version` and the ACP
+          # handshake's `agentInfo` report what someone actually installed.
+          # A tag push gives GITHUB_REF_NAME; a manual dispatch names the tag.
+          VERSION: ${{ inputs.tag || github.ref_name }}
         working-directory: cli
         run: |
           set -euxo pipefail
           mkdir -p ../dist
-          go build -trimpath -ldflags "-s -w" -o "../dist/${{ matrix.artifact }}" ./cmd/fountain
+          go build -trimpath \
+            -ldflags "-s -w -X github.com/BinaryBourbon/fountain/cli/internal/cmd.Version=${VERSION}" \
+            -o "../dist/${{ matrix.artifact }}" ./cmd/fountain
           file "../dist/${{ matrix.artifact }}"
           du -h "../dist/${{ matrix.artifact }}"
 

--- a/cli/internal/acp/agent.go
+++ b/cli/internal/acp/agent.go
@@ -58,6 +58,10 @@ type Agent struct {
 	// on one machine fight over it.
 	agentTarget string
 
+	// version is what `agentInfo` reports. Injected rather than read from a
+	// constant here so the protocol layer does not depend on the CLI package.
+	version string
+
 	sessions *sessions
 
 	mu            sync.Mutex
@@ -68,12 +72,13 @@ type Agent struct {
 }
 
 // NewAgent returns an agent bound to a credential source, the Fountain API,
-// and the agent sessions open against.
-func NewAgent(auth Auth, api API, agentTarget string, log *slog.Logger) *Agent {
+// the agent sessions open against, and the version it reports as `agentInfo`.
+func NewAgent(auth Auth, api API, agentTarget, version string, log *slog.Logger) *Agent {
 	return &Agent{
 		auth:        auth,
 		api:         api,
 		agentTarget: agentTarget,
+		version:     version,
 		sessions:    newSessions(),
 		log:         log,
 	}
@@ -160,9 +165,25 @@ func (a *Agent) initialize(raw json.RawMessage) (any, error) {
 
 	return map[string]any{
 		"protocolVersion":   negotiated,
+		"agentInfo":         agentInfo(a.version),
 		"agentCapabilities": agentCapabilities(),
 		"authMethods":       authMethods(authenticated),
 	}, nil
+}
+
+// agentInfo names the implementation. The spec says an agent SHOULD send it
+// and that it becomes required in a future version — and a client that does
+// not get it has nothing to call us but "unknown", which is what it then shows
+// its user when anything goes wrong.
+func agentInfo(version string) map[string]any {
+	if version == "" {
+		version = "dev"
+	}
+	return map[string]any{
+		"name":    "fountain",
+		"title":   "Fountain",
+		"version": version,
+	}
 }
 
 // agentCapabilities is deliberately the smallest honest set.

--- a/cli/internal/acp/agent_info_test.go
+++ b/cli/internal/acp/agent_info_test.go
@@ -1,0 +1,140 @@
+package acp
+
+import (
+	"strings"
+	"testing"
+)
+
+// Buzz refused an agent with "unknown reported no models. Check that the CLI
+// is installed and signed in" — a true sentence about a different problem. Two
+// fields were missing: `agentInfo` (so the client had nothing to call us but
+// "unknown") and a session model list (so it concluded there was nothing to
+// run). Both are things the spec says an agent SHOULD send and we did not.
+func TestInitializeIdentifiesTheAgent(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, &fakeAPI{}, "", "v0.9.0", discardLogger())
+
+	result, rpcErr := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+	if rpcErr != nil {
+		t.Fatalf("initialize failed: %v", rpcErr)
+	}
+
+	info, ok := result["agentInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("no agentInfo in the initialize response: %v", result)
+	}
+	if info["name"] != "fountain" {
+		t.Errorf("agentInfo.name = %v, want fountain", info["name"])
+	}
+	if info["version"] != "v0.9.0" {
+		t.Errorf("agentInfo.version = %v, want the build's version", info["version"])
+	}
+}
+
+// A source build has no stamped version. Reporting an empty string is worse
+// than reporting "dev": a client showing "Fountain " with a blank version has
+// been told something confusing rather than something honest.
+func TestAgentInfoVersionFallsBackToDev(t *testing.T) {
+	a := NewAgent(&fakeAuth{available: true}, &fakeAPI{}, "", "", discardLogger())
+
+	result, _ := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
+
+	info := result["agentInfo"].(map[string]any)
+	if info["version"] != "dev" {
+		t.Errorf("agentInfo.version = %v, want dev for an unstamped build", info["version"])
+	}
+}
+
+func TestNewSessionReportsTheAgentsModel(t *testing.T) {
+	api := &fakeAPI{
+		ref:    AgentRef{ID: "a1", Name: "philosoraptor", Runtime: "claude", Model: "anthropic/claude-sonnet-4-6", ACP: true},
+		convID: "conv-1",
+	}
+	a := sessionAgent(t, api, "philosoraptor")
+
+	result, rpcErr := request(t, a, "session/new", map[string]any{})
+	if rpcErr != nil {
+		t.Fatalf("session/new failed: %v", rpcErr)
+	}
+
+	models, ok := result["models"].(map[string]any)
+	if !ok {
+		t.Fatalf("session/new reported no models: %v", result)
+	}
+	if models["currentModelId"] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("currentModelId = %v, want the agent's model", models["currentModelId"])
+	}
+
+	available, ok := models["availableModels"].([]map[string]any)
+	if !ok || len(available) != 1 {
+		t.Fatalf("availableModels = %v, want exactly the agent's model", models["availableModels"])
+	}
+	if available[0]["modelId"] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("availableModels[0].modelId = %v", available[0]["modelId"])
+	}
+	// The description is where a user learns why there is only one and where
+	// to change it — the picker itself cannot.
+	if !strings.Contains(available[0]["description"].(string), "philosoraptor") {
+		t.Errorf("description = %v, want it to name the agent", available[0]["description"])
+	}
+}
+
+// An agent with no model set runs the runtime's default. An empty list would
+// read as "this agent cannot run anything", which is how we got here.
+func TestASessionAlwaysReportsAtLeastOneModel(t *testing.T) {
+	api := &fakeAPI{
+		ref:    AgentRef{ID: "a1", Name: "no-model", Runtime: "claude", ACP: true},
+		convID: "conv-1",
+	}
+	a := sessionAgent(t, api, "no-model")
+
+	result, _ := request(t, a, "session/new", map[string]any{})
+
+	models := result["models"].(map[string]any)
+	if models["currentModelId"] != "default" {
+		t.Errorf("currentModelId = %v, want a stand-in rather than empty", models["currentModelId"])
+	}
+	if len(models["availableModels"].([]map[string]any)) != 1 {
+		t.Error("an agent with no model configured reported an empty model list")
+	}
+}
+
+// A reopened session has to look the same to the client as a fresh one, or the
+// model picker disappears on reload.
+func TestLoadedSessionReportsItsModelToo(t *testing.T) {
+	api := &fakeAPI{
+		conversation: ConversationRef{
+			ID: "conv-9", Runtime: "claude", Status: "idle", ACP: true,
+			Agent: "philosoraptor", Model: "anthropic/claude-sonnet-4-6",
+		},
+	}
+	a, _ := loadAgent(t, api)
+
+	result, rpcErr := request(t, a, "session/load", map[string]any{"sessionId": "conv-9"})
+	if rpcErr != nil {
+		t.Fatalf("session/load failed: %v", rpcErr)
+	}
+
+	models, ok := result["models"].(map[string]any)
+	if !ok {
+		t.Fatalf("session/load reported no models: %v", result)
+	}
+	if models["currentModelId"] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("currentModelId = %v, want the conversation's agent's model", models["currentModelId"])
+	}
+}
+
+// Switching models would mean editing the Fountain agent, which every other
+// conversation on it shares. Saying so beats accepting a change we would not
+// make.
+func TestSetModelIsNotOffered(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef(), convID: "conv-1"}
+	a := sessionAgent(t, api, "researcher")
+	request(t, a, "session/new", map[string]any{})
+
+	_, rpcErr := request(t, a, "session/set_model", map[string]any{
+		"sessionId": "conv-1", "modelId": "anthropic/claude-opus-4-7",
+	})
+	if rpcErr == nil || rpcErr.Code != CodeMethodNotFound {
+		t.Fatalf("want method-not-found for session/set_model, got %v", rpcErr)
+	}
+}

--- a/cli/internal/acp/agent_test.go
+++ b/cli/internal/acp/agent_test.go
@@ -26,7 +26,7 @@ func (f *fakeAuth) Describe() string { return "https://example.test (profile def
 // newTestAgent builds an agent with no Fountain agent configured — enough for
 // the handshake tests. The session tests build their own with an API.
 func newTestAgent(auth Auth) *Agent {
-	return NewAgent(auth, &fakeAPI{}, "", discardLogger())
+	return NewAgent(auth, &fakeAPI{}, "", "test", discardLogger())
 }
 
 func request(t *testing.T, a *Agent, method string, params any) (map[string]any, *Error) {

--- a/cli/internal/acp/cancel_test.go
+++ b/cli/internal/acp/cancel_test.go
@@ -60,7 +60,7 @@ func TestCancelReachesAPromptThatIsStillRunning(t *testing.T) {
 		events:        []Event{stageEvent("turn", "interrupted", `{}`)},
 	}
 
-	a := NewAgent(&fakeAuth{available: true}, api, "researcher", discardLogger())
+	a := NewAgent(&fakeAuth{available: true}, api, "researcher", "test", discardLogger())
 	client := newTestClient(t, a)
 	defer client.close()
 

--- a/cli/internal/acp/jsonrpc.go
+++ b/cli/internal/acp/jsonrpc.go
@@ -160,8 +160,18 @@ func (c *Conn) dispatch(ctx context.Context, h Handler, line string) {
 	case len(msg.ID) == 0:
 		h.Notify(ctx, msg.Method, msg.Params)
 
+	case isHandshake(msg.Method):
+		// The handshake runs in order, on this goroutine. A client is supposed
+		// to await each response before sending the next, and every one does —
+		// but a pipelined `initialize` + `session/new` would otherwise race
+		// and fail with "initialize must come first", which is a confusing
+		// thing to tell someone whose client did nothing wrong. These calls
+		// are local and fast; nothing is gained by running them concurrently.
+		result, err := h.Request(ctx, msg.Method, msg.Params)
+		c.respond(msg, result, err)
+
 	default:
-		// Each request runs on its own goroutine because `session/prompt`
+		// Everything else runs on its own goroutine because `session/prompt`
 		// blocks for the whole turn — minutes, sometimes — and a connection
 		// that stopped reading during it would be deaf to exactly the messages
 		// a developer sends when a turn is taking too long: `session/cancel`
@@ -232,6 +242,13 @@ func (c *Conn) write(v any) {
 	if _, err := c.out.Write(append(encoded, '\n')); err != nil {
 		c.log.Error("failed to write to client", "err", err)
 	}
+}
+
+// isHandshake reports whether a method establishes the connection rather than
+// doing work on it. These are ordered against each other by the protocol, so
+// they are answered in the order they arrive.
+func isHandshake(method string) bool {
+	return method == "initialize" || method == "authenticate"
 }
 
 func truncate(s string, n int) string {

--- a/cli/internal/acp/load.go
+++ b/cli/internal/acp/load.go
@@ -57,7 +57,10 @@ func (a *Agent) loadSession(ctx context.Context, raw json.RawMessage) (any, erro
 				"is in the web UI", conv.ID, conv.Runtime)
 	}
 
-	sess := Session{ID: conv.ID, Agent: AgentRef{Runtime: conv.Runtime, ACP: true}}
+	sess := Session{
+		ID:    conv.ID,
+		Agent: AgentRef{Name: conv.Agent, Runtime: conv.Runtime, Model: conv.Model, ACP: true},
+	}
 	a.sessions.put(sess)
 
 	replayed := 0
@@ -84,5 +87,5 @@ func (a *Agent) loadSession(ctx context.Context, raw json.RawMessage) (any, erro
 		"status", conv.Status,
 		"updates_replayed", replayed)
 
-	return nil, nil
+	return map[string]any{"models": modelState(sess.Agent)}, nil
 }

--- a/cli/internal/acp/load_test.go
+++ b/cli/internal/acp/load_test.go
@@ -12,7 +12,7 @@ import (
 func loadAgent(t *testing.T, api *fakeAPI) (*Agent, *fakeNotifier) {
 	t.Helper()
 
-	a := NewAgent(&fakeAuth{available: true}, api, "researcher", discardLogger())
+	a := NewAgent(&fakeAuth{available: true}, api, "researcher", "test", discardLogger())
 	if _, rpcErr := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion}); rpcErr != nil {
 		t.Fatalf("initialize failed: %v", rpcErr)
 	}
@@ -175,7 +175,7 @@ func TestReplayedUpdatesCarryOurSessionID(t *testing.T) {
 // to.
 func TestLoadNeedsNoConfiguredAgent(t *testing.T) {
 	api := &fakeAPI{conversation: acpConversation()}
-	a := NewAgent(&fakeAuth{available: true}, api, "", discardLogger())
+	a := NewAgent(&fakeAuth{available: true}, api, "", "test", discardLogger())
 	request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
 	a.SetNotifier(&fakeNotifier{})
 
@@ -186,7 +186,7 @@ func TestLoadNeedsNoConfiguredAgent(t *testing.T) {
 
 func TestLoadBeforeInitializeIsRefused(t *testing.T) {
 	api := &fakeAPI{conversation: acpConversation()}
-	a := NewAgent(&fakeAuth{available: true}, api, "researcher", discardLogger())
+	a := NewAgent(&fakeAuth{available: true}, api, "researcher", "test", discardLogger())
 
 	_, rpcErr := request(t, a, "session/load", map[string]any{"sessionId": "conv-9"})
 	if rpcErr == nil || rpcErr.Code != CodeInvalidRequest {

--- a/cli/internal/acp/session.go
+++ b/cli/internal/acp/session.go
@@ -42,6 +42,10 @@ type ConversationRef struct {
 	ID      string
 	Runtime string
 	Status  string
+	// Agent and Model describe what this conversation runs, for the model
+	// state a reopened session reports.
+	Agent string
+	Model string
 	// ACP reports whether this conversation's output was stored as protocol.
 	// A legacy-runtime conversation has a transcript, but not one this adapter
 	// can replay — see #702.
@@ -53,6 +57,10 @@ type AgentRef struct {
 	ID      string
 	Name    string
 	Runtime string
+	// Model is the agent's canonical provider/model id, e.g.
+	// "anthropic/claude-sonnet-4-6". Reported to the client as the session's
+	// current model — see modelState.
+	Model string
 	// ACP reports whether the runtime speaks the protocol. The server derives
 	// it (GET /api/agents/:id) precisely so this file does not carry a list of
 	// runtime names that goes stale the day a held-back runtime is converted.
@@ -157,9 +165,44 @@ func (a *Agent) newSession(ctx context.Context, raw json.RawMessage) (any, error
 
 	sess := Session{ID: convID, Agent: ref}
 	a.sessions.put(sess)
-	a.log.Info("session opened", "sessionId", sess.ID, "agent", ref.Name, "runtime", ref.Runtime)
+	a.log.Info("session opened",
+		"sessionId", sess.ID, "agent", ref.Name, "runtime", ref.Runtime, "model", ref.Model)
 
-	return map[string]any{"sessionId": sess.ID}, nil
+	return map[string]any{
+		"sessionId": sess.ID,
+		"models":    modelState(ref),
+	}, nil
+}
+
+// modelState reports the session's model.
+//
+// A Fountain agent's model is part of the agent, chosen once and shared by
+// every conversation it runs — so the list has exactly one entry and it is
+// also the current one. That is not a placeholder: switching models here would
+// mean editing the agent, which would silently change what every other
+// conversation on it runs, and `session/set_model` is not implemented for that
+// reason.
+//
+// Reporting it at all matters because clients use this list to decide the
+// agent is usable: Buzz refuses an agent that reports no models, with a
+// message about the CLI not being signed in — a true statement about a
+// different problem.
+func modelState(ref AgentRef) map[string]any {
+	model := ref.Model
+	if model == "" {
+		// An agent with no model set runs the runtime's own default. Saying so
+		// beats reporting an empty list, which reads as "no models available".
+		model = "default"
+	}
+
+	return map[string]any{
+		"currentModelId": model,
+		"availableModels": []map[string]any{{
+			"modelId":     model,
+			"name":        model,
+			"description": "Configured on the Fountain agent \"" + ref.Name + "\". Change it on the agent, not here.",
+		}},
+	}
 }
 
 // requireReady is the gate the session methods share: a client that has not

--- a/cli/internal/acp/session_test.go
+++ b/cli/internal/acp/session_test.go
@@ -154,7 +154,7 @@ func acpAgentRef() AgentRef {
 func sessionAgent(t *testing.T, api *fakeAPI, target string) *Agent {
 	t.Helper()
 
-	a := NewAgent(&fakeAuth{available: true}, api, target, discardLogger())
+	a := NewAgent(&fakeAuth{available: true}, api, target, "test", discardLogger())
 	if _, rpcErr := request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion}); rpcErr != nil {
 		t.Fatalf("initialize failed: %v", rpcErr)
 	}
@@ -268,7 +268,7 @@ func TestNewSessionReportsAFailedConversationStart(t *testing.T) {
 // A client that skips the handshake gets told which step it missed, rather
 // than an error from three layers down.
 func TestNewSessionBeforeInitializeIsRefused(t *testing.T) {
-	a := NewAgent(&fakeAuth{available: true}, &fakeAPI{ref: acpAgentRef()}, "researcher", discardLogger())
+	a := NewAgent(&fakeAuth{available: true}, &fakeAPI{ref: acpAgentRef()}, "researcher", "test", discardLogger())
 
 	_, rpcErr := request(t, a, "session/new", map[string]any{})
 	if rpcErr == nil || rpcErr.Code != CodeInvalidRequest {
@@ -281,7 +281,7 @@ func TestNewSessionBeforeInitializeIsRefused(t *testing.T) {
 
 func TestNewSessionWithoutCredentialsIsRefused(t *testing.T) {
 	api := &fakeAPI{ref: acpAgentRef()}
-	a := NewAgent(&fakeAuth{available: false}, api, "researcher", discardLogger())
+	a := NewAgent(&fakeAuth{available: false}, api, "researcher", "test", discardLogger())
 	request(t, a, "initialize", map[string]any{"protocolVersion": ProtocolVersion})
 
 	_, rpcErr := request(t, a, "session/new", map[string]any{})

--- a/cli/internal/cmd/acp.go
+++ b/cli/internal/cmd/acp.go
@@ -67,7 +67,7 @@ func runACP() error {
 	defer stop()
 
 	opts := activeOpts()
-	agent := acp.NewAgent(cliAuth{opts: opts}, fountainAPI{opts: opts, log: log}, acpAgent, log)
+	agent := acp.NewAgent(cliAuth{opts: opts}, fountainAPI{opts: opts, log: log}, acpAgent, Version, log)
 	conn := acp.NewConn(os.Stdin, os.Stdout, log)
 	// The connection is how a turn's updates reach the editor while the turn
 	// is still running; without it `session/prompt` would block in silence and
@@ -176,6 +176,7 @@ func agentRef(data map[string]any) acp.AgentRef {
 		ID:      output.ToString(data["id"]),
 		Name:    output.ToString(data["name"]),
 		Runtime: output.ToString(data["runtime"]),
+		Model:   output.ToString(data["model"]),
 		ACP:     acpOK,
 	}
 }
@@ -205,12 +206,27 @@ func (f fountainAPI) Conversation(_ context.Context, convID string) (acp.Convers
 		return acp.ConversationRef{}, err
 	}
 	acpOK, _ := resp.Data["acp"].(bool)
-	return acp.ConversationRef{
+	ref := acp.ConversationRef{
 		ID:      output.ToString(resp.Data["id"]),
 		Runtime: output.ToString(resp.Data["runtime"]),
 		Status:  output.ToString(resp.Data["status"]),
 		ACP:     acpOK,
-	}, nil
+	}
+
+	// The conversation knows its agent by id only, and a reopened session
+	// still owes the client a model. Best-effort: an agent deleted since the
+	// conversation ran leaves the model unreported rather than failing a load
+	// that would otherwise work.
+	if agentID := output.ToString(resp.Data["agent_id"]); agentID != "" {
+		if agent, err := f.Agent(context.Background(), agentID); err == nil {
+			ref.Agent = agent.Name
+			ref.Model = agent.Model
+		} else {
+			f.log.Info("could not read the conversation's agent", "agent_id", agentID, "err", err)
+		}
+	}
+
+	return ref, nil
 }
 
 // Replay drains everything the conversation has stored on the `acp` stream and

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -9,9 +9,18 @@ import (
 
 var profileFlag string
 
+// Version is stamped at build time by release.yml:
+//
+//	go build -ldflags "-X .../internal/cmd.Version=v0.9.0"
+//
+// A source build says "dev", which is the honest answer and the one an editor
+// shows when it reports which agent it is talking to.
+var Version = "dev"
+
 var rootCmd = &cobra.Command{
-	Use:   "fountain",
-	Short: "Fountain CLI",
+	Use:     "fountain",
+	Version: Version,
+	Short:   "Fountain CLI",
 	Long: `Fountain CLI.
 
 Credentials are read from FOUNTAIN_API_KEY env var or ~/.fountain/credentials.


### PR DESCRIPTION
Buzz refuses to add a Fountain agent:

> unknown reported no models. Check that the CLI is installed and signed in, then reopen this screen.

Both halves of that sentence are ours, and neither is about being signed in.

## "unknown"

`initialize` carried no `agentInfo`. The spec says an agent **SHOULD** send it
and that it becomes required in a later version. A client that never learns our
name has nothing to call us — so it says "unknown", and then reports every
later problem under that name.

```json
"agentInfo": {"name": "fountain", "title": "Fountain", "version": "v0.9.0"}
```

## "no models"

`session/new` reported no model state, and clients use that list to decide an
agent can run anything at all. An empty one reads as "nothing to run here".

```json
"models": {
  "currentModelId": "anthropic/claude-sonnet-4-6",
  "availableModels": [{
    "modelId": "anthropic/claude-sonnet-4-6",
    "name": "anthropic/claude-sonnet-4-6",
    "description": "Configured on the Fountain agent \"philosoraptor\". Change it on the agent, not here."
  }]
}
```

**One entry is the honest shape, not a stub.** A Fountain agent's model belongs
to the agent and is shared by every conversation on it. `session/set_model`
stays unimplemented because switching here would silently change what every
other conversation on that agent runs — and the description says where to
change it instead. A reopened session reports the same state, so the picker
does not vanish on reload.

## The version had nowhere to come from

Which is also why `fountain --version` did not exist. `internal/cmd.Version` is
now stamped by `release.yml`'s ldflags from the tag, defaults to `dev` for a
source build, and feeds both the flag and `agentInfo.version`.

## One thing found while reproducing it

Piping `initialize` and `session/new` in together answered *"initialize must
come first"* — #701 put every request on its own goroutine, so a client that
pipelines the handshake loses the race. A well-behaved client waits, so this
was never going to bite a real editor, but the failure message blames the
client for our scheduling. The handshake methods are now answered in order on
the read goroutine; they are local and fast, so nothing is lost.

## Verified live

Against prod, with a client that awaits each response:

```
initialize → {"name": "fountain", "title": "Fountain", "version": "v0.9.1-test"}
session/new → sessionId b03db416-…, currentModelId anthropic/claude-sonnet-4-6
```

Tests cover both fields, the `dev` fallback, the no-model-configured case, the
reopened session, and that `session/set_model` is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)