### PR TITLE
feat: a sandbox reports its own URL, and Sprites URLs are public

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -58,8 +58,14 @@ defmodule Fountain.Conversations.ConversationServer do
   @doc """
   Send another prompt. If the conversation's GenServer is gone (e.g. server
   restart), transparently wake the conversation — provision a fresh sprite
-  and queue this prompt as the first turn of the new sandbox. claude
-  `--resume` preserves the chat via the persisted runtime_session_id.
+  and queue this prompt as the first turn of the new sandbox.
+
+  The persisted `runtime_session_id` is what the next turn resumes by
+  (`session/resume` under ACP). Note that it only carries the conversation
+  while the *sandbox* survives: a runtime session lives in the sandbox
+  filesystem, so a wake that provisions a fresh sprite resumes against a
+  session that is not there — see #649. `log_events` still render the whole
+  transcript, which is what makes that failure quiet.
   """
   def send_prompt(conv_id, prompt, images \\ [], opts \\ []) do
     result =
@@ -576,7 +582,11 @@ defmodule Fountain.Conversations.ConversationServer do
 
         {state, conv} = rotate_callback_api_key(state, conv)
 
-        sprite_env = build_sprite_env(state, agent, env, secrets)
+        # Looked up once, here, because it is stable for the sandbox's life and
+        # the agent needs it in its environment before the first turn runs.
+        sandbox_url = record_sandbox_url(sandbox, handle)
+
+        sprite_env = build_sprite_env(state, agent, env, secrets, sandbox_url)
 
         write_runtime_config(handle, state.runtime_module, agent)
         Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
@@ -925,9 +935,9 @@ defmodule Fountain.Conversations.ConversationServer do
     )
   end
 
-  defp build_sprite_env(state, agent, env, secrets) do
+  defp build_sprite_env(state, agent, env, secrets, sandbox_url \\ nil) do
     state
-    |> do_build_sprite_env(agent, env, secrets)
+    |> do_build_sprite_env(agent, env, secrets, sandbox_url)
     |> tap(fn sprite_env ->
       # Register before anything can log. Provisioning writes output from its
       # very first step, and the secrets are already in the sprite by then.
@@ -935,10 +945,11 @@ defmodule Fountain.Conversations.ConversationServer do
     end)
   end
 
-  defp do_build_sprite_env(state, agent, env, secrets) do
+  defp do_build_sprite_env(state, agent, env, secrets, sandbox_url) do
     (state.runtime_module.default_env(agent, state.inference_credentials) || []) ++
       fountain_callback_env(state.callback_token) ++
       conversation_env(state.conversation_id) ++
+      sandbox_url_env(sandbox_url) ++
       otel_propagation_env() ++
       git_author_env() ++
       if(env,
@@ -946,6 +957,42 @@ defmodule Fountain.Conversations.ConversationServer do
         else: []
       ) ++
       Enum.map(secrets, fn {k, v} -> {k, v} end)
+  end
+
+  # The sandbox's own HTTP endpoint, so an agent asked "what's the URL?" can
+  # answer. Without it the agent has no way to know: the platform assigns the
+  # URL outside the sandbox, and inside it the hostname is just "sprite".
+  #
+  # `SANDBOX_URL` rather than `SPRITE_URL` because the value is provider-
+  # neutral; a provider that has no such endpoint simply sets nothing, and an
+  # unset variable is the honest answer to "no URL".
+  defp sandbox_url_env(nil), do: []
+  defp sandbox_url_env(url) when is_binary(url), do: [{"SANDBOX_URL", url}]
+
+  # Best-effort, and deliberately not fatal: a sandbox with no reportable URL
+  # is still a working sandbox. Stored on the row so the API and the UI can
+  # show it without a provider round trip.
+  defp record_sandbox_url(sandbox, handle) do
+    case Fountain.Sandbox.public_url(handle) do
+      {:ok, url} ->
+        meta = Map.put(sandbox.provider_meta || %{}, "public_url", url)
+        {:ok, _} = Conversations.update_sandbox(sandbox, %{provider_meta: meta})
+        url
+
+      {:error, :unsupported} ->
+        nil
+
+      {:error, reason} ->
+        Logger.warning("could not read the sandbox URL for #{handle.name}: #{inspect(reason)}")
+        nil
+    end
+  rescue
+    # The URL is a convenience; provisioning is not. An adapter that raises
+    # here — a provider SDK surprise, a probe against a sandbox that has not
+    # settled — must not cost the user their conversation.
+    error ->
+      Logger.warning("sandbox URL lookup raised for #{handle.name}: #{inspect(error)}")
+      nil
   end
 
   # Inject the current conversation ID so the bundled fountain skill can
@@ -1855,8 +1902,14 @@ defmodule Fountain.Conversations.ConversationServer do
       case state.runtime_session_id do
         nil ->
           # Generate one and persist immediately so a server restart can resume.
-          # claude uses --session-id <X> verbatim, so this is the value claude
-          # will know us by; turn 2+ will pass --resume <X>.
+          # Under ACP this value is a placeholder, not an identity: the spec
+          # makes the *agent* mint the session id, so `session/new` proposes
+          # nothing and the id that comes back overwrites this one (see the
+          # `{:acp, ref, {:session, id}}` handler). What the row still buys is
+          # the `mode` decision above — a persisted id means "a turn has
+          # happened", which is the only thing gemini's legacy `--resume`
+          # needs, since `Gemini.build_command/5` ignores the id and re-enters
+          # the most recent conversation in the workspace.
           new_id = Ecto.UUID.generate()
           {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: new_id})
           new_id
@@ -1865,11 +1918,15 @@ defmodule Fountain.Conversations.ConversationServer do
           existing
       end
 
-    # 0014 gate 2: when the agent has opted in and its runtime is one gate 1
-    # cleared, the turn spawns an ACP adapter instead of the CLI. Everything
-    # about the turn — the prompt, the images, the session id, the mode —
-    # travels over the protocol rather than in argv, so `build_command/5` is
-    # not consulted at all on this path.
+    # 0014: a supported runtime spawns an ACP adapter instead of the CLI, and
+    # everything about the turn — the prompt, the images, the session id, the
+    # mode — travels over the protocol rather than in argv, so
+    # `build_command/5` is not consulted at all on this path. There is no
+    # opt-in left to check: gate 4 deleted the legacy spawn path for claude,
+    # codex and opencode along with the per-agent flag, so `acp?` is a
+    # property of `conv.runtime` alone. The `else` branch survives for gemini,
+    # the one runtime held back (#659), and for it the CLI is not a fallback —
+    # it is the only path.
     {cmd, args, build_opts} =
       if acp? do
         {c, a} = Fountain.Runtimes.ACP.command(conv.runtime)

--- a/apps/fountain/lib/fountain/sandbox.ex
+++ b/apps/fountain/lib/fountain/sandbox.ex
@@ -86,8 +86,12 @@ defmodule Fountain.Sandbox do
     * `:checkpoint` — checkpoint create/restore currently usable
     * `:attach` — detachable sessions with replay-from-start
     * `:tty` — PTY allocation on spawn
+    * `:public_url` — the platform gives each sandbox an HTTP endpoint, and
+      the adapter can report it (and make it reachable without a platform
+      credential). Agents serve from inside the sandbox and need to be able to
+      tell a human where to look
   """
-  @type capability :: :suspend | :network_policy | :checkpoint | :attach | :tty
+  @type capability :: :suspend | :network_policy | :checkpoint | :attach | :tty | :public_url
 
   @typedoc """
   The provider-neutral error taxonomy.
@@ -190,6 +194,17 @@ defmodule Fountain.Sandbox do
 
   @doc "Apply a deny-capable egress policy. `allow: []` must deny all egress."
   @callback apply_network_policy(Handle.t(), NetworkPolicy.t()) :: :ok | {:error, error()}
+
+  @doc """
+  The sandbox's HTTP endpoint, or `{:error, :unsupported}` where the platform
+  has no such concept.
+
+  Adapters that advertise `:public_url` must return a URL a browser can open.
+  Everything else returns `{:error, :unsupported}` rather than a guess: a URL
+  that does not resolve is worse than none, because the agent will hand it to
+  a human who then blames the service they were told to visit.
+  """
+  @callback public_url(Handle.t()) :: {:ok, String.t()} | {:error, :unsupported | error()}
 
   @doc "Checkpoint the sandbox filesystem; returns the durable checkpoint id."
   @callback create_checkpoint(Handle.t(), keyword()) ::
@@ -294,6 +309,17 @@ defmodule Fountain.Sandbox do
   @doc "Destroy a sandbox."
   @spec destroy(Handle.t()) :: :ok | {:error, error()}
   def destroy(%Handle{} = handle), do: adapter(handle).destroy(handle)
+
+  @doc """
+  The sandbox's HTTP endpoint.
+
+  `{:error, :unsupported}` when the provider has none — callers treat that as
+  "no URL to report", not as a failure. It is deliberately outside the shared
+  error taxonomy: every other error means something went wrong, and this one
+  means the question does not apply.
+  """
+  @spec public_url(Handle.t()) :: {:ok, String.t()} | {:error, :unsupported | error()}
+  def public_url(%Handle{} = handle), do: adapter(handle).public_url(handle)
 
   @doc "Explicitly park a sandbox."
   @spec suspend(Handle.t()) :: :ok | {:error, error()}

--- a/apps/fountain/lib/fountain/sandbox/daytona.ex
+++ b/apps/fountain/lib/fountain/sandbox/daytona.ex
@@ -76,6 +76,12 @@ defmodule Fountain.Sandbox.Daytona do
   end
 
   @impl true
+  # Daytona exposes per-port hostnames rather than one sandbox URL, and nothing here
+  # asks it to open a port yet. Reporting a guess would send someone to an
+  # address that does not answer, which is worse than reporting nothing.
+  def public_url(%Handle{}), do: {:error, :unsupported}
+
+  @impl true
   def get(%Handle{name: name}) do
     case Api.get_sandbox(name) do
       {:ok, info} -> {:ok, %{status: normalize_state(info), raw: info}}

--- a/apps/fountain/lib/fountain/sandbox/e2b.ex
+++ b/apps/fountain/lib/fountain/sandbox/e2b.ex
@@ -85,6 +85,12 @@ defmodule Fountain.Sandbox.E2B do
   end
 
   @impl true
+  # E2B exposes per-port hostnames rather than one sandbox URL, and nothing here
+  # asks it to open a port yet. Reporting a guess would send someone to an
+  # address that does not answer, which is worse than reporting nothing.
+  def public_url(%Handle{}), do: {:error, :unsupported}
+
+  @impl true
   def get(%Handle{name: name}) do
     case Api.find_by_name(name) do
       {:ok, nil} -> {:error, :not_found}

--- a/apps/fountain/lib/fountain/sandbox/sprites.ex
+++ b/apps/fountain/lib/fountain/sandbox/sprites.ex
@@ -36,7 +36,9 @@ defmodule Fountain.Sandbox.Sprites do
 
   @impl true
   def capabilities do
-    MapSet.new([:suspend, :network_policy, :attach, :tty] ++ checkpoint_capabilities())
+    MapSet.new(
+      [:suspend, :network_policy, :attach, :tty, :public_url] ++ checkpoint_capabilities()
+    )
   end
 
   defp checkpoint_capabilities do
@@ -58,6 +60,7 @@ defmodule Fountain.Sandbox.Sprites do
 
     case Sprites.create(client, name, opts) do
       {:ok, %Sprites.Sprite{} = sprite} ->
+        open_url(sprite)
         {:ok, wrap(sprite)}
 
       # The sprite already exists — adopt it. Names are unique per token and
@@ -68,6 +71,44 @@ defmodule Fountain.Sandbox.Sprites do
 
       {:error, reason} ->
         {:error, Errors.normalize(reason)}
+    end
+  end
+
+  @impl true
+  @spec public_url(Handle.t()) :: {:ok, String.t()} | {:error, :unsupported | term()}
+  def public_url(%Handle{} = handle) do
+    client = Client.get!()
+
+    case Sprites.get_sprite(client, handle.name) do
+      {:ok, %{"url" => url}} when is_binary(url) and url != "" -> {:ok, url}
+      {:ok, _no_url} -> {:error, :unsupported}
+      {:error, reason} -> {:error, Errors.normalize(reason)}
+    end
+  end
+
+  # Sprites hands every sandbox a URL, but `url_settings.auth` defaults to
+  # `sprite` — reachable only with a platform credential, which the person the
+  # agent is talking to does not have. An agent that starts a web server is
+  # doing it for a human to open, so the URL is made public at create time.
+  #
+  # Best-effort by design: a sandbox that provisions but cannot be made public
+  # is still a working sandbox, and failing the whole conversation over the
+  # URL setting would trade a large capability for a small one. The log line
+  # is what makes the degraded case visible.
+  defp open_url(sprite) do
+    if Application.get_env(:fountain, :sprites_public_urls, true) do
+      case Sprites.update_url_settings(sprite, %{auth: "public"}) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning(
+            "sprites: could not make #{sprite.name}'s URL public " <>
+              "(#{inspect(reason)}); it will only be reachable with a platform token"
+          )
+
+          :ok
+      end
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -58,7 +58,12 @@ defmodule FountainWeb.ConversationJSON do
     %{
       id: s.id,
       sprite_name: s.sprite_name,
-      status: s.status
+      status: s.status,
+      # The sandbox's own HTTP endpoint, for providers that give it one. Read
+      # from the row rather than the provider so listing conversations stays a
+      # single query; null means the provider has no such concept (or the
+      # sandbox predates the field).
+      url: s.provider_meta["public_url"]
     }
   end
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -23,6 +23,14 @@ defmodule FountainWeb.Schemas do
         status: %Schema{
           type: :string,
           enum: ~w(pending starting ready suspended terminated failed)
+        },
+        url: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "The sandbox's own HTTP endpoint, where a service the agent starts " <>
+              "is reachable. Null for providers that expose no such URL. The " <>
+              "same value is available inside the sandbox as `SANDBOX_URL`."
         }
       },
       required: [:id, :sprite_name, :status]

--- a/apps/fountain/test/fountain/conversations/sandbox_url_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_url_test.exs
@@ -1,0 +1,91 @@
+defmodule Fountain.Conversations.SandboxURLTest do
+  @moduledoc """
+  An agent asked "what is your URL?" has to be able to answer.
+
+  It cannot work it out from inside: the platform assigns the endpoint outside
+  the sandbox, and in there the hostname is just `sprite`. So the URL has to
+  arrive as environment, and it has to be stored where the API can show it
+  without a provider round trip.
+  """
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+  alias Fountain.Sandbox
+
+  setup do
+    Fountain.Sandbox.Fake.reset()
+    user = insert_verified_user()
+    {:ok, user: user}
+  end
+
+  describe "the provider contract" do
+    # The Fake is not in the configured provider list (it is a test double, not
+    # a deployment target), so this goes through the adapter directly — the
+    # facade's dispatch is covered by the providers below.
+    test "an adapter that advertises :public_url reports one" do
+      alias Fountain.Sandbox.Fake
+
+      name = "url-test-#{System.unique_integer([:positive])}"
+      {:ok, handle} = Fake.create(name, [])
+
+      assert MapSet.member?(Fake.capabilities(), :public_url)
+      assert {:ok, "https://url-test-" <> _} = Fake.public_url(handle)
+    end
+
+    # The two providers that expose per-port hostnames rather than one sandbox
+    # URL say so, instead of returning something that looks like an address.
+    test "e2b and daytona report :unsupported rather than guessing" do
+      for provider <- [:e2b, :daytona] do
+        handle = Sandbox.build_handle(provider, "whatever")
+
+        refute Sandbox.supports?(provider, :public_url)
+        assert {:error, :unsupported} = Sandbox.public_url(handle)
+      end
+    end
+  end
+
+  describe "the sandbox row" do
+    test "carries the URL so the API can show it without asking the provider", %{user: user} do
+      sandbox = insert_sandbox(user_id: user.id)
+
+      {:ok, updated} =
+        Conversations.update_sandbox(sandbox, %{
+          provider_meta: Map.put(sandbox.provider_meta || %{}, "public_url", "https://x.example")
+        })
+
+      assert updated.provider_meta["public_url"] == "https://x.example"
+    end
+
+    # A sandbox that predates the field, or one on a provider with no URL, must
+    # render as null rather than blowing up the serializer.
+    test "renders as null when there is none", %{user: user} do
+      sandbox = insert_sandbox(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, sandbox_id: sandbox.id)
+
+      rendered =
+        FountainWeb.ConversationJSON.show(%{
+          conversation: Fountain.Repo.preload(conv, :sandbox)
+        })
+
+      assert rendered.data.sandbox.url == nil
+    end
+
+    test "renders the URL when the row has one", %{user: user} do
+      sandbox = insert_sandbox(user_id: user.id)
+
+      {:ok, _} =
+        Conversations.update_sandbox(sandbox, %{
+          provider_meta: %{"public_url" => "https://y.test"}
+        })
+
+      conv = insert_conversation(user_id: user.id, sandbox_id: sandbox.id)
+
+      rendered =
+        FountainWeb.ConversationJSON.show(%{
+          conversation: Fountain.Repo.preload(conv, :sandbox)
+        })
+
+      assert rendered.data.sandbox.url == "https://y.test"
+    end
+  end
+end

--- a/apps/fountain/test/fountain/sandbox/sprites_test.exs
+++ b/apps/fountain/test/fountain/sandbox/sprites_test.exs
@@ -43,8 +43,73 @@ defmodule Fountain.Sandbox.SpritesTest do
     test "wraps a created sprite in a handle" do
       stub_client()
       stub(Sprites, :create, fn _client, @name, [] -> {:ok, %Sprites.Sprite{name: @name}} end)
+      stub(Sprites, :update_url_settings, fn _sprite, _settings -> :ok end)
 
       assert {:ok, %Handle{provider: :sprites, name: @name}} = Adapter.create(@name, [])
+    end
+
+    # Sprites' URLs default to `auth: sprite` — reachable only with a platform
+    # credential, which is not what an agent serving a page for a human needs.
+    test "opens the sprite's URL to the public" do
+      stub_client()
+      stub(Sprites, :create, fn _client, @name, [] -> {:ok, %Sprites.Sprite{name: @name}} end)
+
+      test_pid = self()
+
+      stub(Sprites, :update_url_settings, fn _sprite, settings ->
+        send(test_pid, {:url_settings, settings})
+        :ok
+      end)
+
+      assert {:ok, %Handle{}} = Adapter.create(@name, [])
+      assert_receive {:url_settings, %{auth: "public"}}
+    end
+
+    # A sandbox that provisions but cannot be made public is still a working
+    # sandbox; trading the whole conversation for the URL setting would be the
+    # wrong bargain.
+    test "a failed url-settings call does not fail the create" do
+      stub_client()
+      stub(Sprites, :create, fn _client, @name, [] -> {:ok, %Sprites.Sprite{name: @name}} end)
+      stub(Sprites, :update_url_settings, fn _sprite, _settings -> {:error, :boom} end)
+
+      assert {:ok, %Handle{provider: :sprites, name: @name}} = Adapter.create(@name, [])
+    end
+
+    test "leaves the URL alone when public URLs are switched off" do
+      stub_client()
+      stub(Sprites, :create, fn _client, @name, [] -> {:ok, %Sprites.Sprite{name: @name}} end)
+
+      stub(Sprites, :update_url_settings, fn _sprite, _settings ->
+        flunk("should not be called")
+      end)
+
+      Application.put_env(:fountain, :sprites_public_urls, false)
+      on_exit(fn -> Application.delete_env(:fountain, :sprites_public_urls) end)
+
+      assert {:ok, %Handle{}} = Adapter.create(@name, [])
+    end
+  end
+
+  describe "public_url/1" do
+    test "reports the URL the platform assigned" do
+      stub_client()
+
+      stub(Sprites, :get_sprite, fn _client, @name ->
+        {:ok, %{"name" => @name, "url" => "https://#{@name}-abc12.sprites.app"}}
+      end)
+
+      assert {:ok, "https://" <> _} = Adapter.public_url(%Handle{provider: :sprites, name: @name})
+    end
+
+    # A sprite with no url field is not an error to shout about — it is a
+    # platform that did not give this sandbox an endpoint.
+    test "a sprite with no url is unsupported, not a failure" do
+      stub_client()
+      stub(Sprites, :get_sprite, fn _client, @name -> {:ok, %{"name" => @name}} end)
+
+      assert {:error, :unsupported} =
+               Adapter.public_url(%Handle{provider: :sprites, name: @name})
     end
 
     test "adopts on 409 — the name already exists" do

--- a/apps/fountain/test/support/fake_sandbox.ex
+++ b/apps/fountain/test/support/fake_sandbox.ex
@@ -57,7 +57,7 @@ defmodule Fountain.Sandbox.Fake do
   def provider, do: :fake
 
   @impl true
-  def capabilities, do: MapSet.new([:suspend, :network_policy, :attach])
+  def capabilities, do: MapSet.new([:suspend, :network_policy, :attach, :public_url])
 
   @impl true
   def build_handle(name) when is_binary(name), do: %Handle{provider: :fake, name: name}
@@ -71,6 +71,18 @@ defmodule Fountain.Sandbox.Fake do
     end)
 
     {:ok, build_handle(name)}
+  end
+
+  @impl true
+  # The Fake advertises :public_url so the conformance suite exercises the
+  # capability without a network. Like a real adapter it looks the sandbox up
+  # first, so asking about one that does not exist is not-found rather than a
+  # confidently wrong URL.
+  def public_url(%Handle{name: name}) do
+    case Agent.get(@registry, &Map.get(&1, name)) do
+      nil -> {:error, :not_found}
+      _ -> {:ok, "https://#{name}.fake.test"}
+    end
   end
 
   @impl true

--- a/apps/fountain/test/support/sandbox_conformance_case.ex
+++ b/apps/fountain/test/support/sandbox_conformance_case.ex
@@ -82,8 +82,36 @@ defmodule Fountain.SandboxConformanceCase.Identity do
           caps = @adapter.capabilities()
           assert %MapSet{} = caps
 
-          known = MapSet.new([:suspend, :network_policy, :checkpoint, :attach, :tty])
+          known = MapSet.new([:suspend, :network_policy, :checkpoint, :attach, :tty, :public_url])
           assert MapSet.subset?(caps, known)
+        end
+
+        # The capability is a promise about the answer, not just about the
+        # function existing: an adapter that advertises :public_url must return
+        # a URL, and one that does not must say :unsupported rather than
+        # inventing an address a human would then be sent to.
+        test "public_url/1 agrees with the advertised capability" do
+          name = "conformance-url-#{System.unique_integer([:positive])}"
+          {:ok, handle} = @adapter.create(name, [])
+          on_exit(fn -> @adapter.destroy(handle) end)
+
+          case @adapter.public_url(handle) do
+            {:ok, url} ->
+              assert MapSet.member?(@adapter.capabilities(), :public_url),
+                     "returned a URL without advertising :public_url"
+
+              assert String.starts_with?(url, "http"),
+                     "public_url must be openable, got: #{inspect(url)}"
+
+            {:error, :unsupported} ->
+              refute MapSet.member?(@adapter.capabilities(), :public_url),
+                     "advertises :public_url but answers :unsupported"
+
+            {:error, _other} ->
+              # A provider that is reachable but has no sandbox by that name is
+              # allowed to fail; the capability claim is what is under test.
+              :ok
+          end
         end
       end
     end

--- a/docs/integrations/sandbox-contract.md
+++ b/docs/integrations/sandbox-contract.md
@@ -42,7 +42,8 @@ every conversation fails at provision time.
 ## What the contract guarantees
 
 - **Capabilities are honest.** Adapters advertise what they can actually do
-  (`:suspend`, `:network_policy`, `:attach`, `:tty`, `:checkpoint`), and the
+  (`:suspend`, `:network_policy`, `:attach`, `:tty`, `:checkpoint`,
+  `:public_url`), and the
   lifecycle degrades accordingly: a provider without `:suspend` destroys on
   idle rather than faking a park — agent memory lives on the sandbox disk,
   and resume-with-a-fresh-disk would be silent data loss.
@@ -54,6 +55,20 @@ every conversation fails at provision time.
   destroyed on a flaky network call.
 - **Network policy means what it says.** For a `limited` environment,
   `allow: []` is deny-all on every provider, never a no-op.
+- **A sandbox URL is real or absent, never a guess.** Providers that give a
+  sandbox its own HTTP endpoint advertise `:public_url`; the URL is stored on
+  the sandbox row, returned as `sandbox.url` on the conversation API, and set
+  inside the sandbox as **`SANDBOX_URL`** so an agent asked "where is it
+  running?" can answer. Providers that expose per-port hostnames instead
+  report `:unsupported` rather than an address that would not resolve.
+
+  On Sprites the endpoint defaults to requiring a platform credential, so
+  Fountain opens it (`url_settings.auth = "public"`) when the sandbox is
+  created — an agent serving a page is doing it for a human who has no such
+  credential. **Anything an agent serves is therefore reachable by anyone with
+  the URL.** Set `config :fountain, :sprites_public_urls, false` to keep the
+  default instead; sandboxes then keep their URLs but only a token holder can
+  open them.
 
 ## Where to go next
 


### PR DESCRIPTION
An agent asked *"you're serving something — what's the URL?"* could not answer.
It has no way to know: the platform assigns the endpoint outside the sandbox,
and inside it the hostname is just `sprite`.

## It was never wired up

Verified rather than assumed:

- The API returns it — for one of tonight's sprites:
  ```json
  {"name":"fountain-50e06232-02d4542b",
   "url":"https://fountain-50e06232-02d4542b-bagzz.sprites.app",
   "url_settings":{"auth":"sprite","private_access":"admins"}}
  ```
- The SDK drops it: `Sprites.Sprite.new/3` keeps `id`, `status`, `config`,
  `environment` — no `url`.
- `sandboxes` has no column for it, and a live probe inside a sandbox found no
  URL in the environment at all.
- `git log -S` across all history: this repo has never exported one. The single
  historical `url_settings` use was `up.ex`'s self-deploy path, deleted in May.

So this is a missing feature, not a regression.

## What lands

- **A `:public_url` capability and `public_url/1` callback.** Sprites advertises
  it; E2B and Daytona expose per-port hostnames rather than one sandbox URL and
  answer `{:error, :unsupported}`. A URL that does not resolve is worse than
  none — the agent hands it to a human who then blames the service they were
  told to visit. `:unsupported` sits outside the shared error taxonomy
  deliberately: every other error means something went wrong; this one means
  the question does not apply.
- **Stored on the sandbox row** (`provider_meta.public_url`) and returned as
  `sandbox.url`, so the API and UI show it without a provider round trip.
- **`SANDBOX_URL` in the sandbox environment** — the piece the agent actually
  needs. Provider-neutral name, and a provider without an endpoint sets
  nothing, because an unset variable is the honest answer.
- **Sprites URLs are opened at create time** (`url_settings.auth = "public"`),
  because the default requires a platform credential the human does not have.

## The security-relevant bit, stated plainly

**Anything an agent serves is now reachable by anyone with the URL.** That is
the intent, and it is documented in `sandbox-contract.md` right next to
`config :fountain, :sprites_public_urls, false`, which restores the old
default (URLs still exist; only a token holder can open them).

## Two deliberate degradations

A sandbox is worth more than a URL, so a failed `update_url_settings` logs and
continues, and the provisioning-time lookup rescues. The second one is not
theoretical: adding the lookup without it turned 68 conversation tests red,
because a provider call that raises during provisioning takes the conversation
with it.

## Tests

Conformance gains a case tying the capability to the answer (advertise → returns a
URL; otherwise `:unsupported`), the Fake looks the sandbox up like a real
adapter, and the Sprites adapter tests cover public-by-default, the config
switch, and the failure path. Full suite green: 2,783 tests, 0 failures;
credo, dialyzer and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)