### PR TITLE
docs: roll the changelog for v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,33 @@ upgrade, is in
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-08-15
+
+### Upgrade notes
+
+- **Sprites sandboxes now expose their HTTP endpoint publicly.** Every
+  sprite already had a URL; it required a platform credential to open,
+  which meant a web service an agent started could not be reached by the
+  person who asked for it. Fountain now sets `url_settings.auth =
+  "public"` when it creates a sandbox, so **anything an agent serves is
+  reachable by anyone who has the URL** (a name plus a random suffix,
+  not guessable, but not secret either). Set
+  `config :fountain, :sprites_public_urls, false` to keep the previous
+  behaviour: sandboxes keep their URLs, and only a token holder can open
+  them. E2B and Daytona are unaffected — they expose per-port hostnames
+  rather than one sandbox URL, and report no URL at all.
+
+### Added
+
+- **A sandbox can tell you where it is running.** Agents asked "what's
+  the URL?" had no way to answer: the platform assigns the endpoint
+  outside the sandbox, and inside it the hostname is just `sprite`. The
+  URL is now stored on the sandbox, returned as `sandbox.url` on the
+  conversation API, and set inside the sandbox as **`SANDBOX_URL`**.
+  Providers that have no such endpoint report `:unsupported` rather than
+  a guess — a URL that does not resolve is worse than none, because the
+  agent hands it to a human who then blames the service.
+
 ## [0.9.1] — 2026-08-15
 
 ### Fixed


### PR DESCRIPTION
Rolls the release for #725.

**A minor, not a patch**, on one line in the policy at the top of the file: patch releases are "always safe to take", and this one changes exposure. Every Sprites sandbox's HTTP endpoint becomes publicly reachable, so anything an agent serves is reachable by anyone holding the URL. That belongs in **Upgrade notes** — with `config :fountain, :sprites_public_urls, false` right there for anyone who wants the old behaviour — and a minor bump is what forces that section to exist.

The Added entry leads with the symptom rather than the capability, because the thing people actually hit is an agent that cannot tell them where it is running.

After this merges: Actions → Release bump → `minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)