### PR TITLE
fix: per-entry secrets for `fountain acp` belong in a vault, not an environment

### DIFF
--- a/cli/internal/cmd/acp.go
+++ b/cli/internal/cmd/acp.go
@@ -24,6 +24,7 @@ import (
 var (
 	acpLogLevel string
 	acpAgent    string
+	acpVault    string
 )
 
 func init() {
@@ -40,6 +41,12 @@ else; diagnostics go to stderr.
 for it, so it is configured here. Point one editor entry at each agent you
 want to reach.
 
+--vault attaches a vault to every conversation this process opens. Vault
+values override the agent's environment, so this is where per-entry secrets
+belong — an identity the agent posts under, for instance. Two entries pointing
+at the same agent with different vaults stay separate; the same secret in a
+shared environment would not.
+
 What it is, and is not: a control surface for a conversation running in a
 Fountain sandbox — watch it, steer it, interrupt it. It has no access to the
 files open in your editor, and the paths it reports are inside the sandbox,
@@ -47,6 +54,7 @@ not on your machine.`,
 		RunE: func(cmd *cobra.Command, args []string) error { return runACP() },
 	}
 	acpCmd.Flags().StringVar(&acpAgent, "agent", "", "Fountain agent name or id to open sessions against")
+	acpCmd.Flags().StringVar(&acpVault, "vault", "", "vault name or id to attach to each session's conversation")
 	acpCmd.Flags().StringVar(&acpLogLevel, "log-level", "info", "stderr log level: debug, info, warn, error")
 	rootCmd.AddCommand(acpCmd)
 }
@@ -67,7 +75,13 @@ func runACP() error {
 	defer stop()
 
 	opts := activeOpts()
-	agent := acp.NewAgent(cliAuth{opts: opts}, fountainAPI{opts: opts, log: log}, acpAgent, Version, log)
+	agent := acp.NewAgent(
+		cliAuth{opts: opts},
+		fountainAPI{opts: opts, log: log, vault: acpVault},
+		acpAgent,
+		Version,
+		log,
+	)
 	conn := acp.NewConn(os.Stdin, os.Stdout, log)
 	// The connection is how a turn's updates reach the editor while the turn
 	// is still running; without it `session/prompt` would block in silence and
@@ -136,8 +150,9 @@ func (a cliAuth) Describe() string {
 // here: a failure inside a session method is a JSON-RPC error the editor
 // renders, not a reason to kill a process the editor is talking to.
 type fountainAPI struct {
-	opts credentials.Opts
-	log  *slog.Logger
+	opts  credentials.Opts
+	log   *slog.Logger
+	vault string
 }
 
 func (f fountainAPI) Agent(_ context.Context, target string) (acp.AgentRef, error) {
@@ -185,10 +200,24 @@ func (f fountainAPI) CreateConversation(_ context.Context, agentID string) (stri
 	var resp struct {
 		Data map[string]any `json:"data"`
 	}
+	body := map[string]any{"agent_id": agentID}
+
+	// A vault carries the secrets that belong to this entry rather than to the
+	// agent — its values win over the environment's on key collision, which is
+	// the point: two editor entries on one agent can hold different
+	// credentials without either leaking into the other.
+	if f.vault != "" {
+		vaultID, err := f.vaultID()
+		if err != nil {
+			return "", err
+		}
+		body["vault_id"] = vaultID
+	}
+
 	// No prompt: the conversation is created empty and the editor's first
 	// `session/prompt` becomes turn 1. Provisioning starts server-side either
 	// way, so the sandbox is warming while the developer types.
-	if err := api.New(f.opts).Post("/conversations", map[string]any{"agent_id": agentID}, &resp); err != nil {
+	if err := api.New(f.opts).Post("/conversations", body, &resp); err != nil {
 		return "", err
 	}
 	id := output.ToString(resp.Data["id"])
@@ -292,6 +321,26 @@ func (f fountainAPI) Interrupt(_ context.Context, convID string) error {
 		return nil
 	}
 	return err
+}
+
+// vaultID resolves --vault, which may be a name or an id.
+func (f fountainAPI) vaultID() (string, error) {
+	if isUUID(f.vault) {
+		return f.vault, nil
+	}
+
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := api.New(f.opts).Get("/vaults", &resp); err != nil {
+		return "", err
+	}
+	for _, v := range resp.Data {
+		if output.ToString(v["name"]) == f.vault {
+			return output.ToString(v["id"]), nil
+		}
+	}
+	return "", fmt.Errorf("no vault named %q", f.vault)
 }
 
 func (f fountainAPI) StreamHead(_ context.Context, convID string) (string, error) {

--- a/cli/internal/cmd/acp_test.go
+++ b/cli/internal/cmd/acp_test.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -162,3 +164,76 @@ func TestFollowStopsWhenTheContextIsCancelled(t *testing.T) {
 // Compile-time proof that the CLI's own follow and the ACP adapter's are the
 // same loop. If they ever diverge, #398 has two places to come back.
 var _ stream.Opener = streamOpener(nil)
+
+// #725's fallout: an identity put in an *environment* is shared by every agent
+// on it, so a second Buzz agent published under the first one's name. A vault
+// is the per-entry primitive — its values win on collision — so this asserts
+// the flag actually reaches the conversation that gets created.
+func TestCreateConversationAttachesTheVault(t *testing.T) {
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/vaults":
+			_, _ = w.Write([]byte(`{"data":[{"id":"11111111-2222-3333-4444-555555555555","name":"buzz-philo"}]}`))
+		case "/api/conversations":
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"data":{"id":"conv-1"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+	api.vault = "buzz-philo"
+
+	id, err := api.CreateConversation(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if id != "conv-1" {
+		t.Errorf("conversation id = %q", id)
+	}
+	if body["vault_id"] != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("vault_id = %v, want the resolved vault", body["vault_id"])
+	}
+}
+
+// Without the flag the request must not carry a vault at all — an empty string
+// would be a request to attach a vault named "", not a request for none.
+func TestCreateConversationOmitsTheVaultWhenUnset(t *testing.T) {
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"id":"conv-1"}}`))
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+
+	if _, err := api.CreateConversation(context.Background(), "agent-1"); err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if _, present := body["vault_id"]; present {
+		t.Errorf("vault_id was sent without --vault: %v", body["vault_id"])
+	}
+}
+
+func TestUnknownVaultNameIsReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+	api.vault = "not-a-vault"
+
+	_, err := api.CreateConversation(context.Background(), "agent-1")
+	if err == nil || !strings.Contains(err.Error(), "not-a-vault") {
+		t.Fatalf("want an error naming the vault, got %v", err)
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,7 +121,7 @@ fountain conv stream <conversation-id>
 ## Editor integration (ACP)
 
 ```bash
-fountain acp --agent <name-or-id> [--log-level debug]
+fountain acp --agent <name-or-id> [--vault <name-or-id>] [--log-level debug]
 ```
 
 Speaks the [Agent Client Protocol](https://agentclientprotocol.com) on stdio, so

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -77,6 +77,22 @@ Use the agent's name or id in `--args`. To reach a non-default instance or
 profile, add `"--profile", "staging"` to `args`, or set `FOUNTAIN_BASE_URL` in
 `env`.
 
+### Per-entry secrets
+
+`--vault <name-or-id>` attaches a [vault](../primitives.md#vault) to every
+conversation the entry opens. Vault values override the agent's environment, so
+this is where a secret that belongs to *this entry* goes — an identity the
+agent posts under, a token scoped to one workspace.
+
+```json
+"args": ["acp", "--agent", "researcher", "--vault", "researcher-identity"]
+```
+
+The distinction matters as soon as there are two entries. An environment is
+shared by every agent attached to it, so a credential put there is used by all
+of them; a vault is attached per conversation, so two entries stay separate
+even when they point at the same agent.
+
 ### Any other ACP client
 
 There is nothing Zed-specific in the adapter. Whatever your client calls it,


### PR DESCRIPTION
Found in use: a second Buzz agent's replies arrived in the channel under the
**first** agent's identity.

## Cause — a primitive mismatch, and my setup caused it

To let a sandbox publish to Buzz, I put an agent's Nostr identity
(`BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`) into a Fountain **environment**. An
environment is shared by every agent attached to it — `philosoraptor` and
`ideator` share one — so the second agent's sandbox published as the first.
Fountain did what it was told; the identity was in the wrong place.

(I checked `agent_count` before doing it and read **1** — because at that
moment I had temporarily moved `philosoraptor` off that environment, so the
count I saw was the *other* agent. The check was right; the moment I ran it
was wrong.)

Mitigated already: those three secrets are deleted from the shared
environment, so nothing is publishing under a borrowed identity. `GITHUB_TOKEN`
was left in place, so both agents still provision.

## Fix

Vaults are the primitive for this and already do the hard part — attached per
conversation, values win on key collision. What was missing is that the ACP
adapter creates the conversation itself and had no way to attach one.

```json
"args": ["acp", "--agent", "researcher", "--vault", "researcher-identity"]
```

Each editor entry carries the secrets that belong to *it*, and two entries on
the same agent stay separate. The name resolves like `--agent` does; an unknown
name is reported by name rather than silently dropped.

Unset sends no `vault_id` at all — an empty string would ask the server to
attach a vault named `""`, which is a different request, and there is a test
for exactly that.

## Docs

The environment-versus-vault distinction is stated on the editors page at the
point where someone configures a second entry, because that is where it bites:

> An environment is shared by every agent attached to it, so a credential put
> there is used by all of them; a vault is attached per conversation, so two
> entries stay separate even when they point at the same agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)