### PR TITLE
fix: the CLI renders ACP conversations (#723)

### DIFF
--- a/cli/internal/cmd/acp_render_test.go
+++ b/cli/internal/cmd/acp_render_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// #723: since ACP became the only path for claude, codex and opencode, a
+// conversation's output *is* the protocol — and the CLI rendered it as
+// stream-json, which produced the empty string for every line. `fountain run`
+// printed a turn starting and finishing with nothing in between, and
+// `fountain conv stream` printed nothing at all.
+func acpEvent(update string) map[string]any {
+	return map[string]any{
+		"kind":   "output",
+		"stream": "acp",
+		"stage":  "turn",
+		"data":   `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s","update":` + update + `}}` + "\n",
+	}
+}
+
+func TestAgentTextIsRendered(t *testing.T) {
+	out := formatOutput(acpEvent(`{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello from the agent"}}`))
+
+	if !strings.Contains(out, "hello from the agent") {
+		t.Errorf("agent text missing from %q", out)
+	}
+}
+
+// The regression in one assertion: the whole reason the command looked broken.
+func TestAnACPTurnIsNotSilent(t *testing.T) {
+	if got := formatOutput(acpEvent(`{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"x"}}`)); got == "" {
+		t.Fatal("an ACP conversation rendered as the empty string")
+	}
+}
+
+func TestToolCallsAreShown(t *testing.T) {
+	out := formatOutput(acpEvent(`{"sessionUpdate":"tool_call","toolCallId":"t1","title":"Edit lib/foo.ex","kind":"edit","status":"pending"}`))
+
+	if !strings.Contains(out, "Edit lib/foo.ex") {
+		t.Errorf("tool title missing from %q", out)
+	}
+}
+
+// A tool call with no title still has to render something a human can read,
+// or the turn shows an empty pair of brackets.
+func TestAToolCallWithoutATitleFallsBackToItsKind(t *testing.T) {
+	out := formatOutput(acpEvent(`{"sessionUpdate":"tool_call","toolCallId":"t1","kind":"execute","status":"pending"}`))
+
+	if !strings.Contains(out, "execute") {
+		t.Errorf("want the kind as a fallback, got %q", out)
+	}
+}
+
+// In-flight updates carry progress, not outcome. A line per `in_progress`
+// would bury the agent's own words.
+func TestOnlyTerminalToolStatusesPrint(t *testing.T) {
+	inFlight := formatOutput(acpEvent(`{"sessionUpdate":"tool_call_update","toolCallId":"t1","status":"in_progress"}`))
+	if inFlight != "" {
+		t.Errorf("in-flight tool update printed %q", inFlight)
+	}
+
+	done := formatOutput(acpEvent(`{"sessionUpdate":"tool_call_update","toolCallId":"t1","status":"completed"}`))
+	if !strings.Contains(done, "completed") {
+		t.Errorf("completed tool update missing from %q", done)
+	}
+
+	failed := formatOutput(acpEvent(`{"sessionUpdate":"tool_call_update","toolCallId":"t1","status":"failed"}`))
+	if !strings.Contains(failed, "failed") {
+		t.Errorf("failed tool update missing from %q", failed)
+	}
+}
+
+// Thinking is dimmed rather than dropped: on a long tool-heavy turn it is
+// often the only output, and a silent terminal reads as a hung agent.
+func TestThoughtsAreDimmedNotDropped(t *testing.T) {
+	out := formatOutput(acpEvent(`{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"considering"}}`))
+
+	if !strings.Contains(out, "considering") {
+		t.Errorf("thought missing from %q", out)
+	}
+	if !strings.Contains(out, "\x1b[2m") {
+		t.Errorf("thought was not dimmed: %q", out)
+	}
+}
+
+// Variants a terminal has nothing useful to do with must not print noise —
+// a usage_update per turn is not something anyone asked to read.
+func TestBookkeepingUpdatesPrintNothing(t *testing.T) {
+	for _, kind := range []string{"usage_update", "available_commands_update", "plan"} {
+		if got := formatOutput(acpEvent(`{"sessionUpdate":"` + kind + `"}`)); got != "" {
+			t.Errorf("%s printed %q, want nothing", kind, got)
+		}
+	}
+}
+
+// A line that is not JSON-RPC is somebody else's diagnostic on a pipe that
+// should carry only protocol. Skipped, never crashed on.
+func TestGarbageOnTheACPStreamIsSkipped(t *testing.T) {
+	out := formatOutput(map[string]any{
+		"kind": "output", "stream": "acp", "stage": "turn",
+		"data": "npm warn deprecated foo@1.0.0\n",
+	})
+
+	if out != "" {
+		t.Errorf("non-protocol line rendered as %q", out)
+	}
+}
+
+// The other streams must keep behaving exactly as they did — stderr in red,
+// provisioning output raw, stream-json parsed.
+func TestOtherStreamsAreUnchanged(t *testing.T) {
+	stderr := formatOutput(map[string]any{"kind": "output", "stream": "stderr", "data": "boom"})
+	if !strings.Contains(stderr, "boom") || !strings.Contains(stderr, "\x1b[31m") {
+		t.Errorf("stderr rendering changed: %q", stderr)
+	}
+
+	setup := formatOutput(map[string]any{
+		"kind": "output", "stream": "stdout", "stage": "setup", "data": "installing",
+	})
+	if !strings.Contains(setup, "installing") {
+		t.Errorf("setup output rendering changed: %q", setup)
+	}
+
+	legacy := formatOutput(map[string]any{
+		"kind": "output", "stream": "stdout", "stage": "turn",
+		"data": `{"type":"assistant","message":{"content":[{"type":"text","text":"legacy"}]}}`,
+	})
+	if !strings.Contains(legacy, "legacy") {
+		t.Errorf("stream-json rendering changed: %q", legacy)
+	}
+}

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -490,6 +490,21 @@ func formatOutput(data map[string]any) string {
 	if raw == "" {
 		return ""
 	}
+	// ACP conversations store the protocol itself, one `session/update` per
+	// line. Since #674 made ACP the only path for claude, codex and opencode,
+	// this is what a turn's output *is* — and rendering it as stream-json
+	// produced nothing at all, so `fountain run` printed a turn starting and
+	// finishing with silence in between (#723).
+	if stream == "acp" {
+		var b strings.Builder
+		for _, line := range strings.Split(raw, "\n") {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			b.WriteString(formatACPLine(line))
+		}
+		return b.String()
+	}
 	// Only turn output is runtime stream-JSON. The setup script and the
 	// provisioning stages (packages, network, clone) log raw text under
 	// their own stage — formatStreamJSONLine returns "" for anything that
@@ -514,6 +529,72 @@ func formatOutput(data map[string]any) string {
 
 // formatStreamJSONLine renders a single line from the assistant/user/result
 // JSON Lines stream. Mirrors conv.ex's format_stream_json_line/1.
+// formatACPLine renders one stored `session/update` for a human.
+//
+// This is not the dialect parser ADR 0015 forbids in `cli/`: ACP is the
+// protocol every supported runtime now speaks, not a vendor's format, and the
+// alternative is a CLI that shows nothing. The rendering deliberately matches
+// the stream-json path above — assistant text plain, tool calls in cyan — so
+// a gemini conversation and a claude one read the same in a terminal.
+func formatACPLine(line string) string {
+	var msg struct {
+		Method string `json:"method"`
+		Params struct {
+			Update map[string]any `json:"update"`
+		} `json:"params"`
+	}
+	if json.Unmarshal([]byte(line), &msg) != nil || msg.Method != "session/update" {
+		return ""
+	}
+
+	update := msg.Params.Update
+	kind, _ := update["sessionUpdate"].(string)
+
+	switch kind {
+	case "agent_message_chunk":
+		return acpContentText(update)
+
+	case "agent_thought_chunk":
+		// Thinking is dimmed rather than dropped: it is often the only output
+		// a long tool-heavy turn produces, and a silent terminal reads as a
+		// hung agent.
+		if text := acpContentText(update); text != "" {
+			return "\x1b[2m" + text + "\x1b[0m"
+		}
+
+	case "tool_call":
+		title, _ := update["title"].(string)
+		if title == "" {
+			title, _ = update["kind"].(string)
+		}
+		return "\n\x1b[36m[" + title + "]\x1b[0m\n"
+
+	case "tool_call_update":
+		// Only terminal statuses: in-flight updates carry progress, and a line
+		// per `in_progress` would bury the agent's own words.
+		status, _ := update["status"].(string)
+		switch status {
+		case "failed":
+			return "\x1b[31m  ✗ " + status + "\x1b[0m\n"
+		case "completed", "cancelled":
+			return "\x1b[2m  ✓ " + status + "\x1b[0m\n"
+		}
+	}
+
+	return ""
+}
+
+// acpContentText pulls the text out of an update's `content` block, which ACP
+// shapes as `{"type": "text", "text": "..."}`.
+func acpContentText(update map[string]any) string {
+	content, ok := update["content"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	text, _ := content["text"].(string)
+	return text
+}
+
 func formatStreamJSONLine(line string) string {
 	var msg map[string]any
 	if json.Unmarshal([]byte(line), &msg) != nil {


### PR DESCRIPTION
Closes #723.

Since #674 made ACP the only path for claude, codex and opencode, a turn's
output **is** the protocol — and `formatOutput` handed every line to the
stream-json parser, which returns `""` for anything that is not claude's own
format. `fountain run` printed a turn starting and finishing with silence in
between, on the default runtime path.

## Before / after, same command, live turn

```
▸ turn: started                          ▸ turn: started
▸ turn done (exit_code=)                 The user is asking me to reply with…   ← dimmed
                                         RENDER-OK
                                         [Terminal]
                                           ✓ completed
                                         Done!
                                         ▸ turn done (exit_code=)
```

## Choices

Rendering matches the stream-json path so both read the same in a terminal:
agent text plain, tool calls in cyan, **thoughts dimmed rather than dropped**
(on a long tool-heavy turn they are often the only output, and a silent
terminal reads as a hung agent), and **terminal tool statuses only** — a line
per `in_progress` would bury the agent's own words. `usage_update` and friends
print nothing.

This is not the dialect parser ADR 0015 forbids in `cli/`: ACP is the protocol
every supported runtime speaks, not a vendor's format, and the alternative is a
CLI that shows nothing.

## A correction to the issue as I filed it

I claimed `fountain conv stream <id>` prints nothing for a finished
conversation and called it the same bug. **It isn't.** That command seeds from
the stream head and tails live, deliberately, because replaying history ended
the follow on a *prior* turn's terminal event (#398). An empty tail of a
finished conversation is the design working as intended.

So the real bug was only ever the live path. If showing a finished
conversation's transcript from the CLI is wanted, that is a separate feature
(a `--replay` flag, say) and a separate decision — worth an issue rather than
smuggling it in here.

## Tests

Nine cases, including the regression in one assertion ("an ACP turn is not
silent"), the fallbacks, the noise that must stay quiet, and a guard that the
other three streams — stderr red, provisioning raw, stream-json parsed — render
exactly as they did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)