### PR TITLE
fix: a lost wake race no longer points a conversation at a dead sandbox (#717)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1394,13 +1394,30 @@ defmodule Fountain.Conversations do
                  user_id: conv.user_id
                })
              end
-           ),
-         _ <- mark_old_sandbox_terminated(conv.sandbox_id),
-         {:ok, conv} <-
-           update_conversation(conv, %{sandbox_id: new_sandbox.id, status: "pending"}) do
+           ) do
+      # The row is repointed *after* the server starts, not before (#717).
+      #
+      # The old order repointed first, so a wake that then lost the start race
+      # left the conversation pointing at the sandbox it had just terminated,
+      # while the winner ran on a different one — a conversation that reads as
+      # terminated in the API and the UI while it is happily serving turns, and
+      # an orphan `ready` row nothing references. `fountain acp` reproduced it
+      # on every session, because `session/new` and the first prompt arrive a
+      # second apart and the prompt takes this path before the registry has the
+      # new server.
+      #
+      # Deferring leaves a much smaller window — between the server starting
+      # and the row being updated — in which the row still names the old
+      # sandbox. That one is transient and self-correcting; the old one was
+      # permanent.
       case start_conversation_server(conv, new_sandbox.id, runtime_module, initial_prompt) do
-        {:ok, _} = ok ->
-          ok
+        {:ok, _} ->
+          _ = mark_old_sandbox_terminated(conv.sandbox_id)
+
+          {:ok, conv} =
+            update_conversation(conv, %{sandbox_id: new_sandbox.id, status: "pending"})
+
+          {:ok, _unsafe_get_conversation!(conv.id)}
 
         {:error, {:already_started, winner_pid}} ->
           # Lost a concurrent wake of the same conversation. The winner's
@@ -1410,6 +1427,9 @@ defmodule Fountain.Conversations do
           # themselves out by double-clicking (#330). Clean up our own row and
           # hand the prompt to the winner, which drops it if a turn is already
           # running — exactly right for a double-click.
+          #
+          # The conversation is left alone: the winner owns it, and it is the
+          # winner's sandbox the row should name.
           _ = mark_old_sandbox_terminated(new_sandbox.id)
 
           if is_binary(initial_prompt) and initial_prompt != "" do
@@ -1419,6 +1439,10 @@ defmodule Fountain.Conversations do
           {:ok, _unsafe_get_conversation!(conv.id)}
 
         {:error, _} = err ->
+          # Nothing ever ran on this sandbox. Retiring it keeps a failed wake
+          # from holding a quota slot until the reaper's next pass — the same
+          # reasoning as the branch above.
+          _ = mark_old_sandbox_terminated(new_sandbox.id)
           err
       end
     end

--- a/apps/fountain/test/fountain/conversations/wake_race_test.exs
+++ b/apps/fountain/test/fountain/conversations/wake_race_test.exs
@@ -1,0 +1,139 @@
+defmodule Fountain.Conversations.WakeRaceTest do
+  @moduledoc """
+  Waking a dormant conversation races: two prompts a second apart, a Horde
+  registry that has not caught up, and both callers decide to provision.
+
+  The loser used to leave the conversation pointing at the sandbox it had just
+  terminated (#717) — because the row was repointed *before* the server was
+  started, and the losing branch cleaned up its row without undoing that. The
+  conversation then read as `terminated` through the API and the UI while the
+  winner served turns on a different sandbox, and prod accumulated orphan
+  `ready` rows nothing referenced.
+
+  These pin each branch: what the row points at, and what is left holding a
+  quota slot.
+  """
+  use Fountain.DataCase, async: false
+
+  use Mimic
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.ConversationServer
+
+  setup :set_mimic_global
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    old_sandbox = insert_sandbox(user_id: user.id, status: "terminated")
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent_id: agent.id,
+        sandbox_id: old_sandbox.id,
+        status: "idle"
+      )
+
+    {:ok, user: user, agent: agent, conv: conv, old_sandbox: old_sandbox}
+  end
+
+  defp sandbox_of(conv_id) do
+    conv_id |> Conversations._unsafe_get_conversation!() |> Fountain.Repo.preload(:sandbox)
+  end
+
+  defp sandbox_ids do
+    Fountain.Conversations.Sandbox |> Fountain.Repo.all() |> MapSet.new(& &1.id)
+  end
+
+  # Only the rows this wake created — the factory makes its own, and counting
+  # those was how the first version of this test failed against a working fix.
+  defp sandboxes_created_since(before) do
+    Fountain.Conversations.Sandbox
+    |> Fountain.Repo.all()
+    |> Enum.reject(&MapSet.member?(before, &1.id))
+  end
+
+  describe "when the wake wins the race" do
+    test "the conversation points at the new sandbox", %{conv: conv, old_sandbox: old} do
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+      end)
+
+      stub(ConversationServer, :queue_initial_prompt, fn _pid, _prompt -> :ok end)
+
+      {:ok, _} = Conversations.wake_conversation(conv.id, "hello")
+
+      woken = sandbox_of(conv.id)
+      refute woken.sandbox_id == old.id, "the row still names the retired sandbox"
+      assert woken.sandbox.status != "terminated", "the row names a terminated sandbox"
+    end
+  end
+
+  describe "when the wake loses the race" do
+    setup do
+      winner = spawn(fn -> Process.sleep(:infinity) end)
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:error, {:already_started, winner}}
+      end)
+
+      stub(ConversationServer, :queue_initial_prompt, fn _pid, _prompt -> :ok end)
+
+      {:ok, winner: winner}
+    end
+
+    # The regression. The winner owns the conversation; the loser must not
+    # repoint the row at a sandbox it is about to terminate.
+    test "the conversation is left pointing where it was", %{conv: conv, old_sandbox: old} do
+      {:ok, _} = Conversations.wake_conversation(conv.id, "hello")
+
+      assert sandbox_of(conv.id).sandbox_id == old.id,
+             "the loser repointed the conversation at its own sandbox"
+    end
+
+    test "the loser's own sandbox is retired rather than left holding a quota slot", %{
+      conv: conv
+    } do
+      before = sandbox_ids()
+
+      {:ok, _} = Conversations.wake_conversation(conv.id, "hello")
+
+      created = sandboxes_created_since(before)
+      assert created != [], "expected the loser to have created a sandbox row"
+
+      for sandbox <- created do
+        assert sandbox.status == "terminated",
+               "a losing wake left #{sandbox.sprite_name} in #{sandbox.status}"
+      end
+    end
+
+    test "the prompt is handed to the winner", %{conv: conv, winner: winner} do
+      test_pid = self()
+
+      stub(ConversationServer, :queue_initial_prompt, fn pid, prompt ->
+        send(test_pid, {:queued, pid, prompt})
+        :ok
+      end)
+
+      {:ok, _} = Conversations.wake_conversation(conv.id, "hello")
+
+      assert_receive {:queued, ^winner, "hello"}
+    end
+  end
+
+  describe "when the start fails outright" do
+    test "the unused sandbox does not keep a quota slot", %{conv: conv} do
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec -> {:error, :boom} end)
+
+      before = sandbox_ids()
+
+      assert {:error, :boom} = Conversations.wake_conversation(conv.id, "hello")
+
+      for sandbox <- sandboxes_created_since(before) do
+        assert sandbox.status == "terminated",
+               "a failed wake left #{sandbox.sprite_name} in #{sandbox.status}"
+      end
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1905,11 +1905,30 @@ defmodule Fountain.ConversationsContextTest do
         :ok
       end)
 
+      before = Fountain.Repo.all(Fountain.Conversations.Sandbox) |> MapSet.new(& &1.id)
+
       assert {:ok, _conv} = Conversations.wake_conversation(conv.id, "hi")
 
-      # No slot held: the old sandbox was retired by the wake, and the row the
-      # loser created for itself is terminated, not pending.
-      assert Fountain.Quotas.active_sandbox_count(user.id) == 0
+      # The row the loser created for itself is terminated, not pending —
+      # which is what #330 is about: a double-click must not strand a quota
+      # slot until the reaper's next pass.
+      created =
+        Fountain.Conversations.Sandbox
+        |> Fountain.Repo.all()
+        |> Enum.reject(&MapSet.member?(before, &1.id))
+
+      assert created != []
+
+      for sandbox <- created do
+        assert sandbox.status == "terminated"
+      end
+
+      # The conversation's *existing* sandbox is deliberately left alone now
+      # (#717). The loser does not know what the winner is running on, and
+      # `wake_conversation`'s reuse arm starts a server against exactly this
+      # sandbox — so retiring it here could terminate the one the winner is
+      # using. The winner retires it if it provisioned a replacement.
+      assert Fountain.Quotas.active_sandbox_count(user.id) == 1
     end
 
     test "the loser forwards its prompt to the winner" do


### PR DESCRIPTION
Closes #717.

`create_fresh_sandbox_and_start/4` repointed `conv.sandbox_id` at its new
sandbox **before** starting the server. When the start then lost the race, the
losing branch cleaned up its own row but never undid the repoint — leaving the
conversation naming a sandbox it had just terminated, while the winner served
turns on a different one.

## What that looked like

- A conversation that reads `terminated` through the API and the UI while it is
  happily answering.
- An orphan `ready` sandbox nothing references. **Prod is carrying 204 of those
  out of 506 rows.**
- A quota slot consumed twice, since both rows count.

`fountain acp` reproduced it on *every* session, which is how it surfaced:
`session/new` and the first `session/prompt` land about a second apart, so the
prompt takes the wake path before Horde's registry has the server that is
already starting.

## The fix is ordering

The row is repointed only after the server actually starts. The losing branch
then has nothing to undo — it retires its own sandbox and leaves the
conversation to the winner, which is the process that knows which sandbox it is
running. A plain start failure now retires its unused sandbox too, for the same
quota reason the already-started branch already carried.

Deferring is what makes the loser correct without needing to know the winner's
sandbox id, which it cannot: by the time it loses, its own write would already
have overwritten it.

**Remaining window:** between the server starting and the row being updated,
the row still names the old sandbox. That is transient and self-correcting; the
old one was permanent. Called out in a comment so the next reader does not
"fix" it by moving the update back.

## Tests

Five, one per branch — what the row points at and what is left holding a quota
slot. Reverted to the old order, two fail.

The first version of the test failed against the *working* fix, because it
counted a sandbox the factory creates; it now diffs the rows created by the
wake itself. Worth mentioning because the wrong version would have "passed"
by accident in the other direction.

Full conversation suites green (324 tests); credo, dialyzer and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)