### PR TITLE
fix: a refused model is visible on every surface, not just stderr (#724)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1282,6 +1282,27 @@ defmodule Fountain.Conversations.ConversationServer do
     {:noreply, %{new_state | stream_tracer: tracer}}
   end
 
+  # The runtime refused the agent's model. Published as a stage event so it
+  # reaches every surface — the conversation view, the API, the CLI and an
+  # editor's log — rather than only the `stderr` stream, which is the one
+  # thing a protocol client filters out (#724). The turn continues on the
+  # runtime's default, which is the peer's call and the right one mid-turn;
+  # what changes here is that nobody has to guess which model answered.
+  def handle_info(
+        {:acp, ref, {:model_rejected, requested, detail}},
+        %{current_command_ref: ref} = state
+      ) do
+    Logger.warning("conv #{state.conversation_id}: runtime refused model #{requested}: #{detail}")
+
+    publish_stage(state.conversation_id, "model", "failed", %{
+      requested: requested,
+      detail: detail,
+      using: "the runtime's default for this turn"
+    })
+
+    {:noreply, state}
+  end
+
   # `session/new` chose an id. Persisted immediately, exactly as the legacy path
   # persists one before spawning: it is what the next turn resumes by, and a
   # server restart between here and the end of the turn must not lose it.

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -76,6 +76,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
   @type payload ::
           {:lines, stream :: String.t(), data :: String.t()}
           | {:session, String.t()}
+          | {:model_rejected, requested :: String.t(), detail :: String.t()}
           | {:handshake_ms, non_neg_integer(), method :: String.t()}
           | {:done, stop_reason :: String.t()}
           | {:failed, term()}
@@ -237,13 +238,16 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   # A model we could not pin is not worth failing a turn over — but it is worth
   # the tenant seeing, because the alternative is their agent quietly running a
-  # model they did not choose. It lands in the transcript as ordinary output.
+  # model they did not choose.
+  #
+  # Reported upward rather than written to `stderr` (#724). stderr is the one
+  # stream every protocol client filters out: `?streams=acp,stage` drops it,
+  # and `fountain acp` treats it as the adapter's own noise. So the warning was
+  # invisible to exactly the surfaces that had no other way to know — the
+  # server turns this into a stage event, which every surface renders.
   defp handle_message({:error_response, _id, error}, %State{phase: :setting_model} = state) do
     state
-    |> persist("stderr", [
-      "fountain: could not select model #{state.model} over ACP (#{inspect(error)}); ",
-      "the runtime's default is in use for this turn\n"
-    ])
+    |> report_model_rejected(error)
     |> send_prompt()
   end
 
@@ -590,6 +594,18 @@ defmodule Fountain.Runtimes.ACP.Peer do
       {:error, reason} -> fail(state, {:acp_write_failed, reason})
     end
   end
+
+  defp report_model_rejected(state, error) do
+    report(state, {:model_rejected, state.model, error_detail(error)})
+    state
+  end
+
+  # Adapters put the useful sentence in different places: claude's is under
+  # `data.details` ("Invalid value for config option model: …"), while the
+  # top-level `message` is a generic "Internal error". Prefer the specific one.
+  defp error_detail(%{"data" => %{"details" => details}}) when is_binary(details), do: details
+  defp error_detail(%{"message" => message}) when is_binary(message), do: message
+  defp error_detail(other), do: inspect(other)
 
   defp persist(state, stream, iodata) do
     report(state, {:lines, stream, IO.iodata_to_binary(iodata)})

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -195,6 +195,8 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       pid: pid,
       ref: ref
     } do
+      prompt_id = drive_to_prompt(pid, ref)
+
       send(pid, {:acp, ref, {:model_rejected, "claude-sonnet-4-6", "Invalid value for model"}})
 
       # handle_info is async; a sync call flushes the mailbox so the read below
@@ -214,6 +216,12 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       # And the turn is still alive: a model we could not pin is not worth
       # failing a turn over.
       assert Process.alive?(pid)
+
+      # Finish it. A test that leaves a turn in flight leaves a live peer and a
+      # busy server behind, and the neighbours in this file are timing
+      # sensitive enough to have earned `settle/1`.
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
     end
 
     test "the stop reason ends the turn and closes stdin", %{conv: conv, pid: pid, ref: ref} do

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -186,6 +186,36 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert event.data =~ "the answer"
     end
 
+    # #724: the refusal used to go to `stderr`, the one stream a protocol
+    # client filters out — so an editor (and anyone reading `?streams=acp,stage`)
+    # had no way to know the agent was answering on a different model than the
+    # one configured. A stage event reaches every surface.
+    test "a refused model becomes a stage event, and the turn continues", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      send(pid, {:acp, ref, {:model_rejected, "claude-sonnet-4-6", "Invalid value for model"}})
+
+      # handle_info is async; a sync call flushes the mailbox so the read below
+      # sees the event rather than racing it.
+      _ = :sys.get_state(pid)
+
+      stage =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.find(&(&1.kind == "stage" and &1.stage == "model"))
+
+      assert stage, "the refusal never reached the transcript as a stage event"
+      assert stage.state == "failed"
+      assert stage.data =~ "claude-sonnet-4-6"
+      assert stage.data =~ "Invalid value for model"
+
+      # And the turn is still alive: a model we could not pin is not worth
+      # failing a turn over.
+      assert Process.alive?(pid)
+    end
+
     test "the stop reason ends the turn and closes stdin", %{conv: conv, pid: pid, ref: ref} do
       prompt_id = drive_to_prompt(pid, ref)
 

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -556,8 +556,11 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
         }) <> "\n"
       )
 
-      assert_receive {:acp, _ref, {:lines, "stderr", msg}}
-      assert msg =~ "could not select model"
+      # Reported as a structured event, not an stderr line: stderr is the one
+      # stream `?streams=acp,stage` and `fountain acp` both drop, so the
+      # warning was invisible to protocol clients (#724).
+      assert_receive {:acp, _ref, {:model_rejected, "not-a-real-model", detail}}
+      assert detail =~ "Invalid value for config option model"
 
       # The turn still runs.
       assert %{"method" => "session/prompt"} = next_write()

--- a/cli/internal/acp/prompt.go
+++ b/cli/internal/acp/prompt.go
@@ -128,7 +128,17 @@ func (a *Agent) followTurn(ctx context.Context, sess Session, head string) (any,
 		case ev.Kind == "stage":
 			out, terminal := classifyStage(ev)
 			if !terminal {
-				a.log.Debug("stage", "stage", ev.Stage, "state", ev.State)
+				// A refused model is the one non-terminal stage worth raising:
+				// the turn continues on the runtime's default, so the editor
+				// would otherwise have no way to know a different model
+				// answered (#724).
+				if ev.Stage == "model" && ev.State == "failed" {
+					meta := decodeMeta(ev.Data)
+					a.log.Warn("the runtime refused the agent's model; its default is in use",
+						"requested", meta["requested"], "detail", meta["detail"])
+				} else {
+					a.log.Debug("stage", "stage", ev.Stage, "state", ev.State)
+				}
 				return false, nil
 			}
 			outcome = out

--- a/cli/internal/acp/prompt_test.go
+++ b/cli/internal/acp/prompt_test.go
@@ -330,3 +330,29 @@ func TestSpriteRequestsAreNotForwardedAsUpdates(t *testing.T) {
 		t.Errorf("forwarded %d messages that were not updates, want 0", notifier.rawCalls)
 	}
 }
+
+// #724: a refused model does not end the turn — the runtime answers on its
+// default — so the stage must not be treated as terminal. It is surfaced in
+// the adapter's log instead, which is where an editor's agent-server output
+// goes.
+func TestARefusedModelDoesNotEndTheTurn(t *testing.T) {
+	api := &fakeAPI{
+		events: []Event{
+			stageEvent("model", "failed", `{"requested":"claude-sonnet-4-6","detail":"Invalid value"}`),
+			{Kind: "output", Stream: "acp", Data: acpLine("sprite-session", "answered anyway")},
+			stageEvent("turn", "done", `{"stop_reason":"end_turn"}`),
+		},
+	}
+	a, notifier := promptAgent(t, api)
+
+	result, rpcErr := request(t, a, "session/prompt", textPrompt("conv-1", "go"))
+	if rpcErr != nil {
+		t.Fatalf("a refused model failed the turn: %v", rpcErr)
+	}
+	if result["stopReason"] != "end_turn" {
+		t.Errorf("stopReason = %v, want end_turn", result["stopReason"])
+	}
+	if len(notifier.methods) != 1 {
+		t.Errorf("forwarded %d updates, want the one that came after the refusal", len(notifier.methods))
+	}
+}


### PR DESCRIPTION
Closes #724.

When the runtime rejects the agent's model, the turn continues on the runtime's
default. That is the right call mid-turn and is unchanged here. What was wrong
is that the only notice went to **stderr** — precisely the stream a protocol
client filters out. `?streams=acp,stage` drops it and `fountain acp` treats it
as the adapter's own noise, so the surface with no other way to know was the one
that never heard.

Your `philosoraptor` has been answering on the runtime's default all evening,
and the only trace was a red line in `fountain run`.

## What changes

The peer reports `{:model_rejected, requested, detail}` upward; the server
publishes a `model`/`failed` stage event:

```json
{"requested": "claude-sonnet-4-6",
 "detail": "Invalid value for config option model: claude-sonnet-4-6",
 "using": "the runtime's default for this turn"}
```

Stage events reach the conversation view, the API, the CLI and — via a warning
the adapter now raises for this one non-terminal stage — an editor's agent log.

`detail` prefers the adapter's specific sentence over its generic one: claude
puts "Invalid value for config option model: …" under `data.details` while
`message` says only "Internal error".

## What it deliberately does not do

Decide *which* model should have been sent. `Model.id/1` strips the provider
prefix and the adapter validates what is left; whether Fountain should map onto
what the adapter advertises in `configOptions` is a separate question that
needs a live adapter to answer honestly. This makes the failure impossible to
miss; choosing the right value is its own change.

## Tests

- The peer reports the structured event rather than an stderr line (the
  existing test updated, with the reason in a comment).
- The server turns it into a `model`/`failed` stage event **and the turn stays
  alive** — a model we cannot pin is not worth failing a turn over.
- Go: the stage is not terminal, the updates after it still arrive, and the
  turn's own stop reason is what comes back.

Full suite green: 2,789 tests; credo, dialyzer, format clean; `go test ./...`
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)