### PR TITLE
docs: roll the changelog for v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,36 @@ upgrade, is in
 
 ## [Unreleased]
 
+## [0.10.2] — 2026-08-15
+
+### Fixed
+
+- **The CLI shows agent output again.** Since ACP became the only path
+  for claude, codex and opencode, `fountain run` printed a turn starting
+  and finishing with nothing in between: the renderer only understood
+  claude's own stream-json, so every protocol line rendered as empty.
+  Agent text, tool calls and thinking now appear, matching how the
+  legacy path always looked (#723).
+
+- **A lost wake race no longer strands a conversation on a dead
+  sandbox.** Waking a dormant conversation repointed it at its new
+  sandbox *before* the server started; when the start lost the race, the
+  loser terminated its own row without undoing that, leaving the
+  conversation naming a sandbox it had just retired while the winner
+  served turns on another. Visible as a conversation that reads
+  `terminated` through the API while it answers normally, an orphan
+  sandbox nothing references, and a quota slot spent twice. The row is
+  now repointed only after the server starts — which also means a loser
+  can no longer retire the sandbox a winner is reusing (#717).
+
+- **A model the runtime refuses is no longer invisible.** The turn still
+  continues on the runtime's default, but the notice went only to
+  `stderr` — the one stream `?streams=acp,stage` drops and `fountain
+  acp` treats as noise, so an editor never heard. It is now a
+  `model`/`failed` stage event carrying the requested model and the
+  runtime's own explanation, which the conversation view, the API, the
+  CLI and an editor's log all receive (#724).
+
 ## [0.10.1] — 2026-08-15
 
 ### Added


### PR DESCRIPTION
Rolls the three fixes from tonight's bug pass: #723, #717, #724.

A patch — no behaviour anyone was relying on changes, no migrations.

All three were **silently wrong rather than loudly broken**, which is why each entry leads with the symptom someone would actually notice:

- a CLI that printed a turn starting and finishing with nothing in between;
- a conversation that reads `terminated` through the API while answering normally, plus an orphan sandbox and a quota slot spent twice;
- an agent quietly answering on a model nobody chose.

After this merges: Actions → Release bump → `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)