### PR TITLE
docs: 0016's status stops listing built things as missing

### DIFF
--- a/decisions/0016-governance-as-an-acp-proxy.md
+++ b/decisions/0016-governance-as-an-acp-proxy.md
@@ -1,9 +1,15 @@
 # 0016 — Governance as an ACP proxy
 
-**Status:** Proposed — **nothing described here is built.** No ACP code, no
-policy engine, no sandbox abstraction and no inference proxy exist in this
-repo. This ADR records a product shape and the gates that decide whether we
-take it; the PR that builds each gate removes its caveat.
+**Status:** Proposed — **the governance layer described here is not built.**
+No policy engine and no inference proxy exist in this repo. Two things this
+ADR originally listed as missing have since landed: ACP is built, and is the
+only path to the agent for claude, codex and opencode
+([0014](0014-agent-client-protocol.md) gates 1–4); and the sandbox
+abstraction is `Fountain.Sandbox`
+([0018](0018-sandbox-provider-abstraction.md)). What remains unbuilt is the
+*answering* — Fountain still observes a turn it cannot intervene in. This ADR
+records a product shape and the gates that decide whether we take it; the PR
+that builds each gate removes its caveat.
 
 This is the third ACP ADR and the only one that is about what Fountain *is*.
 [0014](0014-agent-client-protocol.md) proposes Fountain as an ACP client of


### PR DESCRIPTION
Jake's commit, carried verbatim onto a branch — it was made directly on `main`,
which the repo does not accept (CLAUDE.md: everything goes through a PR and the
CI gate).

ADR 0016's status block claimed "**nothing described here is built.** No ACP
code, no policy engine, no sandbox abstraction and no inference proxy exist in
this repo." Two of those four are now false:

- **ACP is built** and is the only path to the agent for claude, codex and
  opencode (0014 gates 1–4).
- **The sandbox abstraction is `Fountain.Sandbox`** (ADR 0018).

What remains unbuilt is the part the ADR is actually about — the *answering*.
Fountain still observes a turn it cannot intervene in, and there is no policy
engine and no inference proxy. The status now says exactly that.

This is the stale-ADR defect CLAUDE.md's decisions rule exists to prevent: a
document that describes shipped behaviour as missing misleads the next reader
as surely as one that describes unbuilt behaviour as existing.

**Worth a follow-up, not smuggled in here:** since tonight, the other direction
is built too — ADR 0015 gates 1–3, so an editor can drive a conversation
(#709). 0016's framing of "the front door" now has two doors built, and its
status could say so in a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)