### PR TITLE
feat(buzz): BuzzIdentity primitive + hosted buzz-acp Harness (ADR 0020 gate 2, increment 1)

### DIFF
--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -1,0 +1,224 @@
+defmodule Fountain.Buzz do
+  @moduledoc """
+  Context for Buzz identities and the environment a hosted `buzz-acp` runs with
+  (ADR 0020, Phase 1 — tracker #735 / gate #736).
+
+  A Buzz identity binds a Nostr keypair (in a vault) to a Fountain agent. This
+  context owns the tenant-scoped CRUD for those bindings and the one function
+  that turns a binding into a launch spec for `Fountain.Buzz.Harness`:
+  `harness_launch/2` mints a scoped API key for the owner, decrypts the vault's
+  `BUZZ_*` secrets **server-side**, and assembles the full process environment.
+
+  The nsec never leaves the server: it goes from the vault into the harness
+  process env, and the harness's ACP child (`fountain acp`) authenticates to
+  this instance with the freshly-minted key — no human credentials file, and
+  nothing about the identity travels into the sandbox.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Fountain.{Accounts, Audit, Crypto, Repo, Vaults}
+  alias Fountain.Buzz.BuzzIdentity
+
+  # ── identities (tenant-scoped) ─────────────────────────────────────────────
+
+  @doc "WARNING: lookup by id without owner check. Admin/internal/supervisor use only."
+  def _unsafe_get_identity(id), do: Repo.get(BuzzIdentity, id)
+
+  @doc "List every enabled identity across tenants. System sweep only (the boot supervisor)."
+  def _unsafe_list_enabled_identities do
+    Repo.all(from i in BuzzIdentity, where: i.enabled == true)
+  end
+
+  @doc "List identities scoped to a user."
+  def list_identities(user_id) when is_binary(user_id) do
+    Repo.all(
+      from i in BuzzIdentity,
+        where: i.user_id == ^user_id,
+        order_by: [desc: i.inserted_at, desc: i.id]
+    )
+  end
+
+  @doc "Fetch one identity scoped to a user. Returns nil if missing or not owned."
+  def get_identity(id, user_id) when is_binary(id) and is_binary(user_id) do
+    Repo.get_by(BuzzIdentity, id: id, user_id: user_id)
+  end
+
+  @doc """
+  Create a Buzz identity. `attrs` must carry `user_id`, `agent_id`, `vault_id`,
+  `name` and `relay_url`. Records `buzz_identity.created`.
+  """
+  def create_identity(attrs, opts \\ []) do
+    %BuzzIdentity{}
+    |> BuzzIdentity.changeset(attrs)
+    |> Repo.insert()
+    |> audited("buzz_identity.created", opts)
+  end
+
+  @doc "Update a Buzz identity. Records `buzz_identity.updated`."
+  def update_identity(%BuzzIdentity{} = identity, attrs, opts \\ []) do
+    identity
+    |> BuzzIdentity.changeset(attrs)
+    |> Repo.update()
+    |> audited("buzz_identity.updated", opts)
+  end
+
+  @doc "Delete a Buzz identity. Records `buzz_identity.deleted`."
+  def delete_identity(%BuzzIdentity{} = identity, opts \\ []) do
+    identity
+    |> Repo.delete()
+    |> audited("buzz_identity.deleted", opts)
+  end
+
+  defp audited({:ok, %BuzzIdentity{} = identity} = ok, action, opts) do
+    Audit.record(%{
+      user_id: identity.user_id,
+      action: action,
+      resource_type: "buzz_identity",
+      resource_id: identity.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      # Name and the *public* key identify which binding changed without
+      # recording the secret — the nsec is never in this trail (ADR 0013).
+      metadata: %{"name" => identity.name, "pubkey" => identity.pubkey}
+    })
+
+    ok
+  end
+
+  defp audited(other, _action, _opts), do: other
+
+  # ── launch spec for the harness ────────────────────────────────────────────
+
+  @typedoc """
+  A `Fountain.Buzz.Harness` launch spec: the command, args, env, and the id of
+  the API key minted for this run (so the caller/harness can revoke it on stop).
+
+  * `:command` — path to the `buzz-acp` binary
+  * `:args`    — argv (empty; `buzz-acp` is configured entirely by env)
+  * `:env`     — `[{name, value}]` for the port
+  * `:api_key_id` — the minted key's id, scoped to the owner, revoke on teardown
+  """
+  @type launch :: %{
+          command: String.t(),
+          args: [String.t()],
+          env: [{String.t(), String.t()}],
+          api_key_id: String.t()
+        }
+
+  @doc """
+  Build the launch spec for a hosted `buzz-acp` bound to `identity`.
+
+  Mints a `["sprite"]`-scoped API key for the owning user (the resource surface a
+  sandbox-adjacent process needs, without key management), decrypts the vault's
+  `BUZZ_PRIVATE_KEY` / `BUZZ_AUTH_TAG` / `BUZZ_RELAY_URL` server-side, and lays
+  out the environment: the Buzz identity vars, the `BUZZ_ACP_*` wiring that
+  points the harness's ACP child at `fountain acp --agent … --vault …`, and the
+  `FOUNTAIN_*` vars that let that child authenticate back to this instance.
+
+  Options:
+  * `:buzz_acp_path` — path to the binary (defaults to app env `:buzz_acp_path`)
+  * `:base_url`      — this instance's base URL for the ACP child
+                       (defaults to app env `:public_base_url`)
+  * `:fountain_bin`  — path to the `fountain` CLI in the harness image
+                       (defaults to app env `:fountain_cli_path`, else `"fountain"`)
+  * `:agents`        — `BUZZ_ACP_AGENTS` pool size (default 1; the desktop's 10 is
+                       a desktop assumption)
+  * `:actor` / `:request_ip` — attribution for the minted key's audit row
+
+  Returns `{:ok, launch}` or `{:error, reason}`. The agent and vault referenced
+  by the identity must exist; a caller that has already established ownership of
+  the identity may call this — the mint is scoped to `identity.user_id`.
+  """
+  @spec harness_launch(BuzzIdentity.t(), keyword()) :: {:ok, launch()} | {:error, term()}
+  def harness_launch(%BuzzIdentity{} = identity, opts \\ []) do
+    command = opts[:buzz_acp_path] || Application.get_env(:fountain, :buzz_acp_path)
+    base_url = opts[:base_url] || Application.get_env(:fountain, :public_base_url)
+
+    fountain_bin =
+      opts[:fountain_bin] || Application.get_env(:fountain, :fountain_cli_path) || "fountain"
+
+    agents = opts[:agents] || 1
+
+    cond do
+      is_nil(command) ->
+        {:error, :no_buzz_acp_path}
+
+      is_nil(base_url) ->
+        {:error, :no_base_url}
+
+      true ->
+        with {:ok, dek} <- Crypto.load_tenant_key(identity.user_id),
+             {:ok, vault} <- fetch_vault(identity),
+             {:ok, {key, raw}} <- mint_key(identity, opts) do
+          vault_env = Vaults.decrypted_env(vault, dek)
+
+          env =
+            vault_env
+            |> buzz_identity_env(identity)
+            |> Map.merge(acp_wiring_env(identity, fountain_bin, agents))
+            |> Map.merge(fountain_child_env(raw, base_url))
+            |> Enum.map(fn {k, v} -> {to_string(k), to_string(v)} end)
+
+          {:ok, %{command: command, args: [], env: env, api_key_id: key.id}}
+        end
+    end
+  end
+
+  @doc """
+  Revoke the API key a launch minted. Called when a harness stops so a
+  one-conversation credential does not become standing access. Scoped to the
+  identity's owner. Returns `{:ok, key}` or `{:error, :not_found}`.
+  """
+  def revoke_launch_key(%BuzzIdentity{} = identity, api_key_id, opts \\ []) do
+    Accounts.revoke_api_key(identity.user_id, api_key_id, opts)
+  end
+
+  defp fetch_vault(%BuzzIdentity{vault_id: vault_id, user_id: user_id}) do
+    # Ownership: the identity is tenant-owned and its vault_id is a same-tenant
+    # FK, so a scoped fetch confirms it rather than trusting the pointer.
+    case Vaults.get_vault(vault_id, user_id) do
+      nil -> {:error, :vault_not_found}
+      vault -> {:ok, vault}
+    end
+  end
+
+  defp mint_key(%BuzzIdentity{} = identity, opts) do
+    name = "buzz-acp:#{identity.name}"
+
+    Accounts.create_api_key(identity.user_id, name,
+      scopes: ["sprite"],
+      actor: Keyword.get(opts, :actor, "system:buzz_harness"),
+      request_ip: Keyword.get(opts, :request_ip)
+    )
+  end
+
+  # The vault provides BUZZ_PRIVATE_KEY / BUZZ_AUTH_TAG (and may provide
+  # BUZZ_RELAY_URL); the identity row is authoritative for the relay, so it wins.
+  defp buzz_identity_env(vault_env, %BuzzIdentity{} = identity) do
+    vault_env
+    |> Map.put("BUZZ_RELAY_URL", identity.relay_url)
+    |> maybe_put("BUZZ_ACP_DISPLAY_NAME", identity.display_name)
+  end
+
+  # Point the harness's ACP child at this Fountain agent + vault, and keep the
+  # pool to one (the desktop's 10 is not our assumption).
+  defp acp_wiring_env(%BuzzIdentity{} = identity, fountain_bin, agents) do
+    args = "acp,--agent,#{identity.agent_id},--vault,#{identity.vault_id}"
+
+    %{
+      "BUZZ_ACP_AGENT_COMMAND" => fountain_bin,
+      "BUZZ_ACP_AGENT_ARGS" => args,
+      "BUZZ_ACP_AGENTS" => Integer.to_string(agents)
+    }
+  end
+
+  # The ACP child authenticates back to this instance with the minted key.
+  defp fountain_child_env(raw_key, base_url) do
+    %{"FOUNTAIN_API_KEY" => raw_key, "FOUNTAIN_BASE_URL" => base_url}
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/apps/fountain/lib/fountain/buzz/buzz_identity.ex
+++ b/apps/fountain/lib/fountain/buzz/buzz_identity.ex
@@ -1,0 +1,88 @@
+defmodule Fountain.Buzz.BuzzIdentity do
+  @moduledoc """
+  A Buzz identity: the binding that lets Fountain host a Buzz agent's Nostr
+  presence off the user's desktop (ADR 0020, Phase 1).
+
+  It points a Nostr keypair — held as `BUZZ_PRIVATE_KEY` / `BUZZ_AUTH_TAG` in the
+  referenced **vault**, never in this row — at a Fountain **agent**. A hosted
+  `buzz-acp` supervised per identity runs that agent as its ACP child, so the
+  agent keeps a body on the relay even when the laptop that created it is closed.
+
+  The public key is stored (it is public); the secret is not. Deleting the user,
+  the agent, or the vault cascades the identity away — a harness with no agent to
+  run or no key to sign with is not a state worth keeping.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Fountain.Accounts.User
+  alias Fountain.Agents.Agent
+  alias Fountain.Vaults.Vault
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{}
+
+  schema "buzz_identities" do
+    field :name, :string
+    field :relay_url, :string
+    field :pubkey, :string
+    field :display_name, :string
+    field :enabled, :boolean, default: true
+
+    belongs_to :user, User
+    belongs_to :agent, Agent
+    belongs_to :vault, Vault
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @castable [
+    :name,
+    :relay_url,
+    :pubkey,
+    :display_name,
+    :enabled,
+    :user_id,
+    :agent_id,
+    :vault_id
+  ]
+
+  def changeset(identity, attrs) do
+    identity
+    |> cast(attrs, @castable)
+    |> validate_required([:name, :relay_url, :user_id, :agent_id, :vault_id])
+    |> validate_length(:name, min: 1, max: 200)
+    |> validate_relay_url()
+    |> validate_pubkey()
+    |> unique_constraint(:name, name: :buzz_identities_user_id_name_index)
+    |> unique_constraint(:pubkey, name: :buzz_identities_user_id_pubkey_index)
+    |> foreign_key_constraint(:agent_id)
+    |> foreign_key_constraint(:vault_id)
+  end
+
+  # `buzz-acp` connects over a WebSocket, so the relay URL must be ws(s). A
+  # http(s) URL is what the `buzz` CLI wants and a common paste error; reject it
+  # here rather than letting the harness fail opaquely at connect time.
+  defp validate_relay_url(changeset) do
+    validate_change(changeset, :relay_url, fn :relay_url, url ->
+      if String.starts_with?(url, "ws://") or String.starts_with?(url, "wss://") do
+        []
+      else
+        [relay_url: "must be a ws:// or wss:// URL"]
+      end
+    end)
+  end
+
+  # A Nostr pubkey is 64 lowercase hex chars. NULL is allowed (not yet resolved).
+  defp validate_pubkey(changeset) do
+    validate_change(changeset, :pubkey, fn :pubkey, pubkey ->
+      if is_nil(pubkey) or pubkey =~ ~r/\A[0-9a-f]{64}\z/ do
+        []
+      else
+        [pubkey: "must be 64 lowercase hex characters"]
+      end
+    end)
+  end
+end

--- a/apps/fountain/lib/fountain/buzz/harness.ex
+++ b/apps/fountain/lib/fountain/buzz/harness.ex
@@ -1,0 +1,154 @@
+defmodule Fountain.Buzz.Harness do
+  @moduledoc """
+  A supervised `buzz-acp` process — one per Buzz identity (ADR 0020, Phase 1).
+
+  This GenServer owns the OS process lifecycle and nothing else: it opens
+  `buzz-acp` as an Erlang port, watches for its exit, restarts it with a bounded
+  backoff, and on shutdown closes the port and runs an `:on_stop` callback (where
+  the supervisor revokes the launch's API key). All the tenant-aware work —
+  minting the key, decrypting the vault, building the env — happens in
+  `Fountain.Buzz.harness_launch/2` *before* this process starts, so the harness
+  holds no repo and does no per-tenant query. That split is deliberate: it keeps
+  this the one place that reasons about a foreign long-lived binary, and it makes
+  the process testable against a fake `buzz-acp` with no database at all.
+
+  `buzz-acp` is the first external OS process the Fountain OTP app manages; the
+  restart/backoff and process-group teardown here are the cost of that.
+
+  Start it with the launch spec fields plus lifecycle options:
+
+      Fountain.Buzz.Harness.start_link(
+        command: launch.command,
+        args: launch.args,
+        env: launch.env,                 # [{name, value}] — strings
+        on_stop: fn -> Buzz.revoke_launch_key(identity, launch.api_key_id) end,
+        restart_backoff_ms: 1_000,
+        label: identity.id               # for log lines only
+      )
+  """
+  use GenServer
+
+  require Logger
+
+  @default_backoff_ms 1_000
+
+  # ── API ────────────────────────────────────────────────────────────────────
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
+  end
+
+  @doc "How many times the port has been (re)opened, including the first. For tests/telemetry."
+  def starts_count(server), do: GenServer.call(server, :starts_count)
+
+  @doc "Whether a port is currently open."
+  def running?(server), do: GenServer.call(server, :running?)
+
+  # ── GenServer ───────────────────────────────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    state = %{
+      command: Keyword.fetch!(opts, :command),
+      args: Keyword.get(opts, :args, []),
+      env: Keyword.get(opts, :env, []),
+      on_stop: Keyword.get(opts, :on_stop),
+      backoff_ms: Keyword.get(opts, :restart_backoff_ms, @default_backoff_ms),
+      label: Keyword.get(opts, :label, "buzz-acp"),
+      port: nil,
+      starts: 0
+    }
+
+    {:ok, open(state)}
+  end
+
+  @impl true
+  def handle_call(:starts_count, _from, state), do: {:reply, state.starts, state}
+
+  def handle_call(:running?, _from, state), do: {:reply, state.port != nil, state}
+
+  @impl true
+  def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
+    Logger.warning("buzz-acp exited: label=#{state.label} status=#{status} — restarting")
+    Process.send_after(self(), :reopen, state.backoff_ms)
+    {:noreply, %{state | port: nil}}
+  end
+
+  # A late message from a port we already replaced or closed. Ignore it.
+  def handle_info({_stale_port, {:exit_status, _status}}, state), do: {:noreply, state}
+
+  def handle_info({port, {:data, _data}}, %{port: port} = state) do
+    # buzz-acp writes protocol/diagnostics to its own stdio toward its ACP
+    # child, not to us; anything arriving here is noise. Increment 2 wires
+    # captured output to log_events — for now, drop it.
+    {:noreply, state}
+  end
+
+  def handle_info(:reopen, %{port: nil} = state), do: {:noreply, open(state)}
+
+  # Already reopened (a manual restart raced the timer). Nothing to do.
+  def handle_info(:reopen, state), do: {:noreply, state}
+
+  # The port process died without an exit_status frame (rare). Treat as an exit.
+  def handle_info({:EXIT, port, _reason}, %{port: port} = state) do
+    Process.send_after(self(), :reopen, state.backoff_ms)
+    {:noreply, %{state | port: nil}}
+  end
+
+  def handle_info({:EXIT, _other, _reason}, state), do: {:noreply, state}
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    close(state.port)
+    run_on_stop(state.on_stop)
+    :ok
+  end
+
+  # ── internals ────────────────────────────────────────────────────────────────
+
+  defp open(state) do
+    port =
+      Port.open({:spawn_executable, state.command}, [
+        :binary,
+        :exit_status,
+        :hide,
+        {:args, state.args},
+        {:env, charlist_env(state.env)}
+      ])
+
+    %{state | port: port, starts: state.starts + 1}
+  end
+
+  defp close(nil), do: :ok
+
+  # Closing a spawn_executable port terminates its OS process. Reliable teardown
+  # of the ACP *child* (`fountain acp` beneath `buzz-acp`) needs a process-group
+  # kill, which in turn needs the port spawned in its own session — that arrives
+  # with the real binary in increment 2. For now, close the port.
+  defp close(port) do
+    Port.close(port)
+    :ok
+  rescue
+    # Port already closed between the exit frame and here.
+    ArgumentError -> :ok
+  end
+
+  defp run_on_stop(nil), do: :ok
+  defp run_on_stop(fun) when is_function(fun, 0), do: safe_run(fun)
+  defp run_on_stop({m, f, a}), do: safe_run(fn -> apply(m, f, a) end)
+
+  defp safe_run(fun) do
+    fun.()
+    :ok
+  rescue
+    e -> Logger.error("buzz-acp on_stop failed: #{inspect(e)}")
+  end
+
+  defp charlist_env(env) do
+    Enum.map(env, fn {k, v} -> {to_charlist(k), to_charlist(v)} end)
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260816120000_create_buzz_identities.exs
+++ b/apps/fountain/priv/repo/migrations/20260816120000_create_buzz_identities.exs
@@ -1,0 +1,49 @@
+defmodule Fountain.Repo.Migrations.CreateBuzzIdentities do
+  use Ecto.Migration
+
+  # A Buzz identity is the fifth-and-a-half thing: not one of the four
+  # primitives, but the binding that lets Fountain host a Buzz agent's Nostr
+  # presence (ADR 0020). It points a Nostr keypair (held as vault secrets, not
+  # here) at a Fountain agent, so a hosted `buzz-acp` can run the agent off the
+  # user's desktop. The nsec never lives in this row — only the public identity
+  # and the pointers do; `BUZZ_PRIVATE_KEY` / `BUZZ_AUTH_TAG` stay in the vault,
+  # decrypted server-side at harness start.
+  def change do
+    create table(:buzz_identities, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+
+      # The Fountain agent this identity drives, and the vault carrying its
+      # BUZZ_* secrets. Nilifying rather than cascading on delete would leave a
+      # harness with no agent to run or no key to sign with, so both cascade the
+      # identity away with their target.
+      add :agent_id, references(:agents, type: :binary_id, on_delete: :delete_all), null: false
+      add :vault_id, references(:vaults, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :name, :string, null: false
+      add :relay_url, :string, null: false
+      # The Nostr public key (hex). The public half of the identity — safe to
+      # store, and the natural uniqueness key per tenant.
+      add :pubkey, :string
+      add :display_name, :string
+
+      # Whether the boot sweep should stand a harness up for this identity.
+      add :enabled, :boolean, null: false, default: true
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:buzz_identities, [:user_id])
+
+    create unique_index(:buzz_identities, [:user_id, :name],
+             name: "buzz_identities_user_id_name_index"
+           )
+
+    # A pubkey is one identity per tenant when known; NULL pubkeys (not yet
+    # resolved from the key) don't collide.
+    create unique_index(:buzz_identities, [:user_id, :pubkey],
+             where: "pubkey IS NOT NULL",
+             name: "buzz_identities_user_id_pubkey_index"
+           )
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -23,7 +23,7 @@ defmodule Fountain.AuditGuardrailTest do
 
   use Fountain.DataCase, async: true
 
-  alias Fountain.{Agents, Audit, Conversations, Environments, InferenceCredentials, Vaults}
+  alias Fountain.{Agents, Audit, Buzz, Conversations, Environments, InferenceCredentials, Vaults}
 
   # {label, fun/1 taking the user, expected action}
   #
@@ -59,7 +59,10 @@ defmodule Fountain.AuditGuardrailTest do
     {"vault secret delete", &__MODULE__.do_vault_secret_delete/1, "vault.secret.delete"},
     {"password reset", &__MODULE__.do_password_reset/1, "auth.password.reset"},
     {"password change", &__MODULE__.do_password_change/1, "auth.password.changed"},
-    {"email verification", &__MODULE__.do_verify_email/1, "auth.email.verified"}
+    {"email verification", &__MODULE__.do_verify_email/1, "auth.email.verified"},
+    {"buzz identity create", &__MODULE__.do_buzz_create/1, "buzz_identity.created"},
+    {"buzz identity update", &__MODULE__.do_buzz_update/1, "buzz_identity.updated"},
+    {"buzz identity delete", &__MODULE__.do_buzz_delete/1, "buzz_identity.deleted"}
   ]
 
   # Documented non-coverage. Mirrors the `Fountain.Audit` moduledoc; if the two
@@ -168,6 +171,28 @@ defmodule Fountain.AuditGuardrailTest do
 
   def do_vault_delete(user) do
     {:ok, _} = Vaults.delete_vault(insert_vault(user_id: user.id))
+  end
+
+  def do_buzz_create(user), do: {:ok, _} = Buzz.create_identity(buzz_attrs(user))
+
+  def do_buzz_update(user) do
+    {:ok, i} = Buzz.create_identity(buzz_attrs(user))
+    {:ok, _} = Buzz.update_identity(i, %{"display_name" => "x"})
+  end
+
+  def do_buzz_delete(user) do
+    {:ok, i} = Buzz.create_identity(buzz_attrs(user))
+    {:ok, _} = Buzz.delete_identity(i)
+  end
+
+  defp buzz_attrs(user) do
+    %{
+      "user_id" => user.id,
+      "agent_id" => insert_agent(user_id: user.id).id,
+      "vault_id" => insert_vault(user_id: user.id).id,
+      "name" => "buzz-#{System.unique_integer([:positive])}",
+      "relay_url" => "wss://relay.test"
+    }
   end
 
   def do_key_create(user), do: {:ok, {_, _}} = Fountain.Accounts.create_api_key(user.id, "guard")

--- a/apps/fountain/test/fountain/buzz/harness_test.exs
+++ b/apps/fountain/test/fountain/buzz/harness_test.exs
@@ -1,0 +1,83 @@
+defmodule Fountain.Buzz.HarnessTest do
+  # async: false — writes a fake executable to a tmp dir and spawns OS processes.
+  use ExUnit.Case, async: false
+
+  alias Fountain.Buzz.Harness
+
+  # A fake `buzz-acp`: writes its invocation marker to a file (so the test can
+  # prove the port opened with the right env) and then behaves as the scenario
+  # asks — either sleep forever, or exit after a beat to exercise restart.
+  defp write_fake(dir, name, body) do
+    path = Path.join(dir, name)
+    File.write!(path, "#!/bin/sh\n" <> body)
+    File.chmod!(path, 0o755)
+    path
+  end
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "buzz-harness-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf(dir) end)
+    %{dir: dir}
+  end
+
+  test "opens the port with the given env and stays running", %{dir: dir} do
+    marker = Path.join(dir, "marker")
+    # Record BUZZ_RELAY_URL so we can prove env made it through, then idle.
+    cmd = write_fake(dir, "buzz-acp", "printf '%s' \"$BUZZ_RELAY_URL\" > #{marker}\nsleep 30\n")
+
+    pid =
+      start_supervised!(
+        {Harness, command: cmd, env: [{"BUZZ_RELAY_URL", "wss://relay.example"}], label: "t"}
+      )
+
+    assert Harness.running?(pid)
+    assert Harness.starts_count(pid) == 1
+
+    wait_until(fn -> File.exists?(marker) end)
+    assert File.read!(marker) == "wss://relay.example"
+  end
+
+  test "restarts the process when it exits, with backoff", %{dir: dir} do
+    counter = Path.join(dir, "count")
+    # Append a line each launch, then exit immediately — forces restarts.
+    cmd = write_fake(dir, "buzz-acp", "echo x >> #{counter}\nexit 0\n")
+
+    pid =
+      start_supervised!({Harness, command: cmd, env: [], restart_backoff_ms: 20, label: "t"})
+
+    # Three launches means at least two restarts happened after the first exit.
+    wait_until(fn ->
+      File.exists?(counter) and length(File.stream!(counter) |> Enum.to_list()) >= 3
+    end)
+
+    assert Harness.starts_count(pid) >= 3
+  end
+
+  test "runs the on_stop callback and closes the port on shutdown", %{dir: dir} do
+    cmd = write_fake(dir, "buzz-acp", "sleep 30\n")
+    test_pid = self()
+
+    pid =
+      start_supervised!(
+        {Harness, command: cmd, env: [], label: "t", on_stop: fn -> send(test_pid, :stopped) end}
+      )
+
+    assert Harness.running?(pid)
+    :ok = stop_supervised(Harness)
+
+    assert_receive :stopped, 2_000
+  end
+
+  defp wait_until(fun, tries \\ 200)
+  defp wait_until(_fun, 0), do: flunk("condition not met in time")
+
+  defp wait_until(fun, tries) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(10)
+      wait_until(fun, tries - 1)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/buzz_test.exs
+++ b/apps/fountain/test/fountain/buzz_test.exs
@@ -1,0 +1,195 @@
+defmodule Fountain.BuzzTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.{Accounts, Buzz, Crypto, Vaults}
+  alias Fountain.Buzz.BuzzIdentity
+
+  describe "identities (tenant scoping)" do
+    test "create/get/list are scoped to the owner" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      identity = insert_buzz_identity(%{"user_id" => user.id, "name" => "philo"})
+
+      assert %BuzzIdentity{name: "philo"} = Buzz.get_identity(identity.id, user.id)
+      assert Buzz.get_identity(identity.id, other.id) == nil
+      assert [%BuzzIdentity{id: id}] = Buzz.list_identities(user.id)
+      assert id == identity.id
+      assert Buzz.list_identities(other.id) == []
+    end
+
+    test "name is unique per tenant but not across tenants" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      insert_buzz_identity(%{"user_id" => user.id, "name" => "dup"})
+
+      assert {:error, changeset} =
+               Buzz.create_identity(%{
+                 "user_id" => user.id,
+                 "agent_id" => insert_agent(%{"user_id" => user.id}).id,
+                 "vault_id" => insert_vault(%{"user_id" => user.id}).id,
+                 "name" => "dup",
+                 "relay_url" => "wss://relay.test"
+               })
+
+      assert %{name: _} = errors_on(changeset)
+
+      # Same name under a different tenant is fine.
+      assert %BuzzIdentity{} = insert_buzz_identity(%{"user_id" => other.id, "name" => "dup"})
+    end
+
+    test "rejects a non-ws relay url and a malformed pubkey" do
+      user = insert_verified_user()
+
+      base = %{
+        "user_id" => user.id,
+        "agent_id" => insert_agent(%{"user_id" => user.id}).id,
+        "vault_id" => insert_vault(%{"user_id" => user.id}).id,
+        "name" => "bad"
+      }
+
+      assert {:error, cs} = Buzz.create_identity(Map.put(base, "relay_url", "https://relay.test"))
+      assert %{relay_url: _} = errors_on(cs)
+
+      assert {:error, cs2} =
+               Buzz.create_identity(
+                 base
+                 |> Map.put("relay_url", "wss://relay.test")
+                 |> Map.put("pubkey", "NOTHEX")
+               )
+
+      assert %{pubkey: _} = errors_on(cs2)
+    end
+
+    test "mutations leave an audit trail" do
+      user = insert_verified_user()
+      identity = insert_buzz_identity(%{"user_id" => user.id})
+
+      {:ok, _} = Buzz.update_identity(identity, %{"display_name" => "Philo"})
+      {:ok, _} = Buzz.delete_identity(identity)
+
+      actions =
+        Fountain.Audit.list_recent_for_user(user.id, 200)
+        |> Enum.map(& &1.action)
+
+      assert "buzz_identity.created" in actions
+      assert "buzz_identity.updated" in actions
+      assert "buzz_identity.deleted" in actions
+    end
+
+    test "_unsafe_list_enabled_identities returns only enabled ones, across tenants" do
+      a = insert_buzz_identity(%{"enabled" => true})
+      b = insert_buzz_identity(%{"enabled" => true})
+      _disabled = insert_buzz_identity(%{"enabled" => false})
+
+      ids = Buzz._unsafe_list_enabled_identities() |> Enum.map(& &1.id) |> MapSet.new()
+      assert MapSet.member?(ids, a.id)
+      assert MapSet.member?(ids, b.id)
+      refute Enum.any?(Buzz._unsafe_list_enabled_identities(), &(&1.enabled == false))
+    end
+  end
+
+  describe "harness_launch/2" do
+    setup do
+      user = insert_verified_user()
+      agent = insert_agent(%{"user_id" => user.id})
+      vault = insert_vault(%{"user_id" => user.id})
+
+      # BUZZ_* secrets live in the vault, decrypted server-side by the launch.
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+
+      {:ok, _} =
+        Vaults.upsert_secret(vault, %{"key" => "BUZZ_PRIVATE_KEY", "value" => "nsec1secret"}, dek)
+
+      {:ok, _} =
+        Vaults.upsert_secret(
+          vault,
+          %{"key" => "BUZZ_AUTH_TAG", "value" => "[\"auth\",\"owner\"]"},
+          dek
+        )
+
+      identity =
+        insert_buzz_identity(%{
+          "user_id" => user.id,
+          "agent_id" => agent.id,
+          "vault_id" => vault.id,
+          "name" => "philo",
+          "relay_url" => "wss://relay.example",
+          "display_name" => "Philo"
+        })
+
+      %{user: user, agent: agent, vault: vault, identity: identity}
+    end
+
+    test "assembles the env: vault secrets, ACP wiring, and a minted FOUNTAIN_API_KEY",
+         %{identity: identity, agent: agent, vault: vault, user: user} do
+      assert {:ok, launch} =
+               Buzz.harness_launch(identity,
+                 buzz_acp_path: "/opt/buzz-acp",
+                 base_url: "https://fountain.example",
+                 fountain_bin: "/usr/local/bin/fountain"
+               )
+
+      env = Map.new(launch.env)
+
+      # From the vault, decrypted here — never from the identity row.
+      assert env["BUZZ_PRIVATE_KEY"] == "nsec1secret"
+      assert env["BUZZ_AUTH_TAG"] == "[\"auth\",\"owner\"]"
+
+      # Identity is authoritative for the relay and display name.
+      assert env["BUZZ_RELAY_URL"] == "wss://relay.example"
+      assert env["BUZZ_ACP_DISPLAY_NAME"] == "Philo"
+
+      # ACP child points at this agent + vault, pool of one.
+      assert env["BUZZ_ACP_AGENT_COMMAND"] == "/usr/local/bin/fountain"
+      assert env["BUZZ_ACP_AGENT_ARGS"] == "acp,--agent,#{agent.id},--vault,#{vault.id}"
+      assert env["BUZZ_ACP_AGENTS"] == "1"
+
+      # The child authenticates back with a freshly minted key.
+      assert env["FOUNTAIN_BASE_URL"] == "https://fountain.example"
+      assert String.starts_with?(env["FOUNTAIN_API_KEY"], "ftn_")
+
+      # That key is real, sprite-scoped, and owned by the identity's user.
+      assert {:ok, ^user, key} = Accounts.authenticate_api_key(env["FOUNTAIN_API_KEY"])
+      assert key.scopes == ["sprite"]
+
+      # The launch reports the key id so the caller can revoke it on stop.
+      assert launch.api_key_id == key.id
+      assert launch.command == "/opt/buzz-acp"
+    end
+
+    test "the identity's relay_url overrides a BUZZ_RELAY_URL in the vault",
+         %{identity: identity, vault: vault, user: user} do
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+
+      {:ok, _} =
+        Vaults.upsert_secret(vault, %{"key" => "BUZZ_RELAY_URL", "value" => "wss://stale"}, dek)
+
+      assert {:ok, launch} =
+               Buzz.harness_launch(identity,
+                 buzz_acp_path: "/opt/buzz-acp",
+                 base_url: "https://f.example"
+               )
+
+      assert Map.new(launch.env)["BUZZ_RELAY_URL"] == "wss://relay.example"
+    end
+
+    test "revoke_launch_key revokes the minted key", %{identity: identity} do
+      {:ok, launch} =
+        Buzz.harness_launch(identity,
+          buzz_acp_path: "/opt/buzz-acp",
+          base_url: "https://f.example"
+        )
+
+      assert {:ok, revoked} = Buzz.revoke_launch_key(identity, launch.api_key_id)
+      assert revoked.revoked_at != nil
+    end
+
+    test "errors when the binary path or base url is missing", %{identity: identity} do
+      assert {:error, :no_buzz_acp_path} =
+               Buzz.harness_launch(identity, base_url: "https://f.example")
+
+      assert {:error, :no_base_url} =
+               Buzz.harness_launch(identity, buzz_acp_path: "/opt/buzz-acp")
+    end
+  end
+end

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -97,6 +97,36 @@ defmodule Fountain.Factory do
     vault
   end
 
+  # ── buzz identities ─────────────────────────────────────────────────────────
+
+  def insert_buzz_identity(overrides \\ %{}) do
+    overrides = to_string_map(overrides)
+
+    user_id =
+      Map.get_lazy(overrides, "user_id", fn -> insert_verified_user().id end)
+
+    agent_id =
+      Map.get_lazy(overrides, "agent_id", fn -> insert_agent(%{"user_id" => user_id}).id end)
+
+    vault_id =
+      Map.get_lazy(overrides, "vault_id", fn -> insert_vault(%{"user_id" => user_id}).id end)
+
+    attrs =
+      Map.merge(
+        %{
+          "user_id" => user_id,
+          "agent_id" => agent_id,
+          "vault_id" => vault_id,
+          "name" => "buzz-#{uniq()}",
+          "relay_url" => "wss://relay.test"
+        },
+        overrides
+      )
+
+    {:ok, identity} = Fountain.Buzz.create_identity(attrs)
+    identity
+  end
+
   def insert_vault_secret(vault, overrides \\ %{}) do
     attrs =
       %{"key" => "TEST_KEY_#{uniq()}", "value" => "test-value-#{uniq()}"}


### PR DESCRIPTION
First increment of gate 2 (#736) — the hosted-harness supervisor from ADR 0020. Establishes the Buzz identity as **its own tenant-owned primitive** (Jake's call) and the process that runs `buzz-acp` per identity, off the user's desktop.

## What's here
- **`Fountain.Buzz.BuzzIdentity` + migration** — binds a Nostr keypair (held in a **vault**, never in this row) to a Fountain agent. Cascades on user/agent/vault delete; validates ws:// relay + 64-hex pubkey; unique name and pubkey per tenant.
- **`Fountain.Buzz` context** — tenant-scoped CRUD (audited; guardrail entries added), plus `harness_launch/2`: mints a `["sprite"]`-scoped API key for the owner, decrypts the vault's `BUZZ_*` secrets **server-side**, and assembles the process env — `BUZZ_*` identity vars, `BUZZ_ACP_*` wiring pointing the ACP child at `fountain acp --agent … --vault …`, and `FOUNTAIN_API_KEY`/`FOUNTAIN_BASE_URL` so that child authenticates back. The nsec never enters the sandbox; the identity's `relay_url` wins over any vault copy.
- **`Fountain.Buzz.Harness`** — a thin GenServer owning the `buzz-acp` OS Port: open, watch exit, restart with bounded backoff, close + run `on_stop` (key revocation) on shutdown. Deliberately holds no repo and does no per-tenant query — all DB work is in `harness_launch/2` before start, which keeps it testable against a fake binary.

## What's NOT here (increment 2)
Not wired into the app supervision tree; no real `buzz-acp` binary in the release image; process-group teardown of the ACP child and captured-output → `log_events` are deferred (noted in code). This PR is the primitive + the unit-testable process, nothing running in prod.

## Testing
End-to-end against a fake `buzz-acp` shell script (spawn, env passthrough, restart-on-exit, on_stop/teardown) plus context tenant-scoping, validation, and audit. **42 tests, 0 failures** locally; format / credo --strict / compile --warnings-as-errors clean.

Refs #735 #736. ADR: `decisions/0020-buzz-as-a-client-of-the-acp-gateway.md`.