### PR TITLE
feat(buzz): Horde supervisor + Manager + boot sweep for hosted harnesses (ADR 0020 gate 2, increment 2a)

### DIFF
--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -60,6 +60,23 @@ defmodule Fountain.Application do
              max_restarts: 100,
              max_seconds: 10
            ]},
+          # Hosted buzz-acp harnesses (ADR 0020, gate #736). Same Horde shape as
+          # the conversation tree: one harness per Buzz identity, addressable
+          # cluster-wide, surviving node loss. The BootSweep stands the enabled
+          # ones up after both are ready, and is inert until a `buzz-acp` binary
+          # path is configured (increment 2b), so this adds nothing at runtime on
+          # an instance that has not opted in.
+          {Horde.Registry, [name: Fountain.BuzzRegistry, keys: :unique, members: :auto]},
+          {Horde.DynamicSupervisor,
+           [
+             name: Fountain.BuzzSupervisor,
+             strategy: :one_for_one,
+             distribution_strategy: Horde.UniformDistribution,
+             members: :auto,
+             max_restarts: 100,
+             max_seconds: 10
+           ]},
+          Fountain.Buzz.BootSweep,
           FountainWeb.Endpoint
         ]
 

--- a/apps/fountain/lib/fountain/buzz/boot_sweep.ex
+++ b/apps/fountain/lib/fountain/buzz/boot_sweep.ex
@@ -1,0 +1,71 @@
+defmodule Fountain.Buzz.BootSweep do
+  @moduledoc """
+  Starts a harness for every enabled Buzz identity at boot (ADR 0020, gate #736).
+
+  Mirrors `Fountain.Conversations.Rehydrator`: on start it sweeps the enabled
+  identities and asks `Fountain.Buzz.Manager` to stand each one up. The sweep is a
+  no-op unless `:buzz_acp_path` is configured — until the binary ships in the
+  image (increment 2b) there is nothing to run, so this stays inert in dev, in
+  test, and on any instance that has not opted in.
+
+  Cluster safety comes from the registry, not from leader election: two nodes
+  sweeping at once both call `Manager.start_harness/2`, and the second gets the
+  first's pid back (the registry key is unique), so a double sweep converges to
+  one harness per identity rather than two. The credential a losing race minted
+  is revoked by `Manager`, not leaked.
+  """
+  use GenServer
+
+  require Logger
+
+  alias Fountain.Buzz
+  alias Fountain.Buzz.Manager
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc "Whether the sweep is enabled — i.e. a `buzz-acp` binary path is configured."
+  def enabled?, do: Application.get_env(:fountain, :buzz_acp_path) != nil
+
+  @doc """
+  Start a harness for every enabled identity. Safe to call repeatedly
+  (`Manager.start_harness/2` is idempotent). Returns the count started or found.
+  """
+  def run do
+    # ownership: a system-level sweep across all tenants (like the rehydrator),
+    # not a user-facing request — every identity's own user_id scopes the mint
+    # and vault decrypt that `Manager.start_harness/2` performs downstream.
+    Buzz._unsafe_list_enabled_identities()
+    |> Enum.map(&start_one/1)
+    |> Enum.count(&(&1 == :ok))
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok, opts, {:continue, :sweep}}
+  end
+
+  @impl true
+  def handle_continue(:sweep, state) do
+    if enabled?() do
+      count = run()
+      Logger.info("buzz boot sweep: started/verified #{count} harness(es)")
+    else
+      Logger.debug("buzz boot sweep: skipped (no :buzz_acp_path configured)")
+    end
+
+    {:noreply, state}
+  end
+
+  defp start_one(identity) do
+    case Manager.start_harness(identity, actor: "system:buzz_boot_sweep") do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("buzz boot sweep: identity=#{identity.id} failed: #{inspect(reason)}")
+        :error
+    end
+  end
+end

--- a/apps/fountain/lib/fountain/buzz/manager.ex
+++ b/apps/fountain/lib/fountain/buzz/manager.ex
@@ -1,0 +1,123 @@
+defmodule Fountain.Buzz.Manager do
+  @moduledoc """
+  Starts and stops hosted `buzz-acp` harnesses, one per Buzz identity, across the
+  cluster (ADR 0020, Phase 1 — gate #736, increment 2).
+
+  A harness is a `Fountain.Buzz.Harness` process registered in
+  `Fountain.BuzzRegistry` under its identity id and supervised by
+  `Fountain.BuzzSupervisor` (a `Horde.DynamicSupervisor`), so exactly one runs
+  per identity cluster-wide and it survives a node loss the same way a
+  `ConversationServer` does.
+
+  This module is the seam between the tenant-aware context and the process tree:
+  it calls `Fountain.Buzz.harness_launch/2` (which mints the API key and decrypts
+  the vault) and hands the resulting spec to the supervisor. It also owns the one
+  correctness subtlety that split introduces — a launch mints a credential
+  *before* the supervisor can say whether a harness already exists, so every path
+  that does not end in a running harness revokes the key it minted, or a race
+  would leak standing credentials.
+  """
+
+  require Logger
+
+  alias Fountain.Buzz
+  alias Fountain.Buzz.{BuzzIdentity, Harness}
+
+  @registry Fountain.BuzzRegistry
+  @supervisor Fountain.BuzzSupervisor
+
+  @doc "The via-tuple a harness for `identity_id` is registered under."
+  def via(identity_id), do: {:via, Horde.Registry, {@registry, identity_id}}
+
+  @doc "The harness pid for `identity_id`, or nil if none is running."
+  def whereis(identity_id) do
+    case Horde.Registry.lookup(@registry, identity_id) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+
+  @doc "Whether a harness is running for `identity_id` (anywhere in the cluster)."
+  def running?(identity_id), do: whereis(identity_id) != nil
+
+  @doc """
+  Ensure a harness is running for `identity`. Idempotent: if one already runs,
+  returns it without minting a credential. Otherwise mints the launch's API key,
+  builds the env, and starts the supervised harness.
+
+  `opts` are forwarded to `Fountain.Buzz.harness_launch/2` (`:buzz_acp_path`,
+  `:base_url`, `:agents`, attribution). Returns `{:ok, pid}` or `{:error, reason}`.
+  """
+  @spec start_harness(BuzzIdentity.t(), keyword()) :: {:ok, pid()} | {:error, term()}
+  def start_harness(%BuzzIdentity{} = identity, opts \\ []) do
+    case whereis(identity.id) do
+      pid when is_pid(pid) ->
+        {:ok, pid}
+
+      nil ->
+        with {:ok, launch} <- Buzz.harness_launch(identity, opts) do
+          start_child(identity, launch)
+        end
+    end
+  end
+
+  @doc """
+  Stop the harness for `identity_id` if one is running. The harness's own
+  `terminate` revokes its launch key. Returns `:ok` whether or not one was found.
+  """
+  def stop_harness(identity_id) do
+    case whereis(identity_id) do
+      nil -> :ok
+      pid -> Horde.DynamicSupervisor.terminate_child(@supervisor, pid)
+    end
+  end
+
+  defp start_child(%BuzzIdentity{} = identity, launch) do
+    child = %{
+      id: identity.id,
+      start: {Harness, :start_link, [harness_opts(identity, launch)]},
+      # The harness restarts its own port; if the harness process itself dies we
+      # want Horde to bring it back, but a deliberate stop is terminal.
+      restart: :transient,
+      type: :worker,
+      shutdown: 10_000
+    }
+
+    case Horde.DynamicSupervisor.start_child(@supervisor, child) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, {:already_started, pid}} ->
+        # Another node won the race between our `whereis` and this call. The key
+        # we just minted has no harness to own it — revoke it rather than leak it.
+        revoke_orphaned_key(identity, launch)
+        {:ok, pid}
+
+      {:error, reason} = err ->
+        revoke_orphaned_key(identity, launch)
+
+        Logger.error(
+          "buzz harness failed to start: identity=#{identity.id} reason=#{inspect(reason)}"
+        )
+
+        err
+    end
+  end
+
+  defp harness_opts(%BuzzIdentity{} = identity, launch) do
+    [
+      name: via(identity.id),
+      command: launch.command,
+      args: launch.args,
+      env: launch.env,
+      label: identity.id,
+      on_stop: fn -> Buzz.revoke_launch_key(identity, launch.api_key_id) end
+    ]
+  end
+
+  defp revoke_orphaned_key(%BuzzIdentity{} = identity, launch) do
+    Buzz.revoke_launch_key(identity, launch.api_key_id)
+  rescue
+    e -> Logger.error("failed to revoke orphaned buzz launch key: #{inspect(e)}")
+  end
+end

--- a/apps/fountain/test/fountain/buzz/boot_sweep_test.exs
+++ b/apps/fountain/test/fountain/buzz/boot_sweep_test.exs
@@ -1,0 +1,78 @@
+defmodule Fountain.Buzz.BootSweepTest do
+  # async: false — sets application env and starts real harnesses under the
+  # global Horde supervisor.
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Buzz.{BootSweep, Manager}
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "buzz-sweep-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    fake = Path.join(dir, "buzz-acp")
+    File.write!(fake, "#!/bin/sh\nsleep 30\n")
+    File.chmod!(fake, 0o755)
+
+    prev_path = Application.get_env(:fountain, :buzz_acp_path)
+    prev_url = Application.get_env(:fountain, :public_base_url)
+
+    on_exit(fn ->
+      restore(:buzz_acp_path, prev_path)
+      restore(:public_base_url, prev_url)
+
+      for {_, pid, _, _} <- Horde.DynamicSupervisor.which_children(Fountain.BuzzSupervisor),
+          is_pid(pid) do
+        Horde.DynamicSupervisor.terminate_child(Fountain.BuzzSupervisor, pid)
+      end
+
+      File.rm_rf(dir)
+    end)
+
+    %{fake: fake}
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:fountain, key)
+  defp restore(key, val), do: Application.put_env(:fountain, key, val)
+
+  test "enabled? follows the :buzz_acp_path config" do
+    Application.delete_env(:fountain, :buzz_acp_path)
+    refute BootSweep.enabled?()
+
+    Application.put_env(:fountain, :buzz_acp_path, "/some/path")
+    assert BootSweep.enabled?()
+  end
+
+  test "run starts a harness for each enabled identity and skips disabled ones", %{fake: fake} do
+    Application.put_env(:fountain, :buzz_acp_path, fake)
+    Application.put_env(:fountain, :public_base_url, "https://fountain.test")
+
+    a = insert_buzz_identity(%{"enabled" => true})
+    b = insert_buzz_identity(%{"enabled" => true})
+    disabled = insert_buzz_identity(%{"enabled" => false})
+
+    started = BootSweep.run()
+    assert started >= 2
+
+    assert Manager.running?(a.id)
+    assert Manager.running?(b.id)
+    refute Manager.running?(disabled.id)
+  end
+
+  test "run is idempotent — a second sweep does not double-start" do
+    fake = Path.join(System.tmp_dir!(), "buzz-acp-#{System.unique_integer([:positive])}")
+    File.write!(fake, "#!/bin/sh\nsleep 30\n")
+    File.chmod!(fake, 0o755)
+    on_exit(fn -> File.rm(fake) end)
+
+    Application.put_env(:fountain, :buzz_acp_path, fake)
+    Application.put_env(:fountain, :public_base_url, "https://fountain.test")
+
+    identity = insert_buzz_identity(%{"enabled" => true})
+
+    BootSweep.run()
+    pid = Manager.whereis(identity.id)
+    assert is_pid(pid)
+
+    BootSweep.run()
+    assert Manager.whereis(identity.id) == pid
+  end
+end

--- a/apps/fountain/test/fountain/buzz/manager_test.exs
+++ b/apps/fountain/test/fountain/buzz/manager_test.exs
@@ -1,0 +1,96 @@
+defmodule Fountain.Buzz.ManagerTest do
+  # async: false — starts real harness processes under the global Horde
+  # supervisor, and DataCase gives shared-mode DB so their terminate-time key
+  # revocation reaches this connection.
+  use Fountain.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Fountain.Accounts.ApiKey
+  alias Fountain.Buzz.Manager
+  alias Fountain.Repo
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "buzz-mgr-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    fake = Path.join(dir, "buzz-acp")
+    File.write!(fake, "#!/bin/sh\nsleep 30\n")
+    File.chmod!(fake, 0o755)
+
+    on_exit(fn ->
+      # Tear down every harness this test left running (no prod harnesses exist
+      # under this supervisor in the test node) before the tmp dir goes away.
+      for {_, pid, _, _} <- Horde.DynamicSupervisor.which_children(Fountain.BuzzSupervisor),
+          is_pid(pid) do
+        Horde.DynamicSupervisor.terminate_child(Fountain.BuzzSupervisor, pid)
+      end
+
+      File.rm_rf(dir)
+    end)
+
+    %{fake: fake}
+  end
+
+  defp launch_opts(fake), do: [buzz_acp_path: fake, base_url: "https://fountain.test"]
+
+  defp active_key_count(user_id) do
+    Repo.one(
+      from k in ApiKey,
+        where: k.user_id == ^user_id and is_nil(k.revoked_at) and like(k.name, "buzz-acp:%"),
+        select: count(k.id)
+    )
+  end
+
+  test "start_harness stands a harness up and registers it", %{fake: fake} do
+    identity = insert_buzz_identity()
+
+    assert {:ok, pid} = Manager.start_harness(identity, launch_opts(fake))
+    assert is_pid(pid)
+    assert Manager.running?(identity.id)
+    assert Manager.whereis(identity.id) == pid
+    assert active_key_count(identity.user_id) == 1
+
+    Manager.stop_harness(identity.id)
+  end
+
+  test "start_harness is idempotent and mints no second credential", %{fake: fake} do
+    identity = insert_buzz_identity()
+
+    assert {:ok, pid} = Manager.start_harness(identity, launch_opts(fake))
+    assert {:ok, ^pid} = Manager.start_harness(identity, launch_opts(fake))
+    # The second call short-circuits on `whereis` before minting anything.
+    assert active_key_count(identity.user_id) == 1
+
+    Manager.stop_harness(identity.id)
+  end
+
+  test "stop_harness terminates the harness and revokes its launch key", %{fake: fake} do
+    identity = insert_buzz_identity()
+
+    {:ok, _pid} = Manager.start_harness(identity, launch_opts(fake))
+    assert active_key_count(identity.user_id) == 1
+
+    :ok = Manager.stop_harness(identity.id)
+
+    refute Manager.running?(identity.id)
+    # terminate_child is synchronous, so the harness's on_stop (key revoke) has run.
+    assert active_key_count(identity.user_id) == 0
+  end
+
+  test "stop_harness is a no-op when nothing is running" do
+    identity = insert_buzz_identity()
+    assert Manager.stop_harness(identity.id) == :ok
+    refute Manager.running?(identity.id)
+  end
+
+  test "start_harness surfaces a launch error and leaks no key", %{fake: _fake} do
+    identity = insert_buzz_identity()
+
+    # No binary path and none in config → harness_launch refuses before minting.
+    assert {:error, :no_buzz_acp_path} =
+             Manager.start_harness(identity, base_url: "https://fountain.test")
+
+    assert active_key_count(identity.user_id) == 0
+    refute Manager.running?(identity.id)
+  end
+end


### PR DESCRIPTION
Increment 2a of gate 2 (#736): wires the `Harness` from #739 into the app so hosted `buzz-acp` processes are supervised for real — one per Buzz identity, cluster-wide. Pure Elixir; no binary and no infra yet (that's 2b).

## What's here
- **App supervision tree** — `Fountain.BuzzRegistry` (Horde.Registry) + `Fountain.BuzzSupervisor` (Horde.DynamicSupervisor), the same shape as the conversation tree: one harness per identity, addressable across the cluster, surviving node loss.
- **`Fountain.Buzz.Manager`** — `start_harness/2`, `stop_harness/1`, `via/1`, `whereis/1`, `running?/1`. `start_harness/2` is idempotent (short-circuits on the registry before minting) and closes the one correctness gap the mint-before-supervise split creates: on a lost start-race or a start error it **revokes the key it just minted**, so a race never leaks a standing credential.
- **`Fountain.Buzz.BootSweep`** — stands up every enabled identity at boot, **guarded on `:buzz_acp_path`** so it is completely inert until the binary ships (2b). Cluster-safe via the unique registry rather than leader election — a double sweep converges to one harness per identity.

## Runtime impact today: none
No `buzz-acp` binary in the image and no `:buzz_acp_path` configured, so `BootSweep` no-ops on every current instance. The registry/supervisor are cheap idle processes (same as the conversation Horde pair). This PR is the wiring; nothing runs until 2b.

## Testing
End to end against a fake `buzz-acp`: start/stop/idempotency/no-credential-leak through the real Horde supervisor, plus the `enabled?` config gate and sweep-starts-enabled/skips-disabled. **50 tests in the buzz suite, 0 failures**; credo --strict / format / compile --warnings-as-errors clean.

Refs #735 #736. ADR: `decisions/0020-buzz-as-a-client-of-the-acp-gateway.md`.

### Next (2b)
Unpack the pinned `buzz-acp` (desktop-v0.5.14, `usr/bin/buzz-acp`, x86-64) into the release image, set `:buzz_acp_path` + `:public_base_url` in `runtime.exs`, add process-group teardown of the ACP child, stream captured output to `log_events`, verify presence survives sandbox suspend. **Caveat: the Fountain image must build amd64.**