### PR TITLE
feat(buzz): bake buzz-acp + fountain CLI into the image (ADR 0020 gate 2, increment 2b-i)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #     generation here — fail-fast at boot if it's missing rather than
 #     silently invalidate cookie sessions on every restart.
 
-FROM hexpm/elixir:1.19.2-erlang-28.3-debian-bookworm-20260505-slim AS build
+FROM hexpm/elixir:1.19.2-erlang-28.3-debian-trixie-20260610-slim AS build
 
 ENV MIX_ENV=prod
 
@@ -63,8 +63,45 @@ RUN mix compile \
  && mix release fountain_server
 
 # ---
+# The `fountain` Go CLI. It is the ACP *child* a hosted buzz-acp harness drives
+# (ADR 0020): buzz-acp runs `fountain acp`, which talks HTTP/SSE back to this
+# same server. Built for the image's target arch (both amd64 and arm64).
 
-FROM debian:bookworm-slim AS runtime
+FROM golang:1.25-bookworm AS gocli
+WORKDIR /src
+COPY cli/go.mod cli/go.sum ./
+RUN go mod download
+COPY cli/ ./
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-amd64}" \
+      go build -trimpath -o /out/fountain ./cmd/fountain
+
+# ---
+# The hosted Buzz harness binary. block/buzz publishes an amd64 .deb only, so
+# this is baked on amd64 and skipped on arm64 — an arm64 image simply has no
+# buzz-acp, and runtime.exs leaves :buzz_acp_path unset there (the BootSweep is
+# inert). Pin is deliberate: a moved tag under an agent's key is not something
+# we want to float. Bump BUZZ_VERSION consciously.
+
+FROM debian:bookworm-slim AS buzzacp
+ARG TARGETARCH
+ARG BUZZ_VERSION=0.5.14
+RUN apt-get update -y \
+ && apt-get install -y --no-install-recommends curl ca-certificates dpkg \
+ && mkdir -p /out \
+ && if [ "${TARGETARCH:-amd64}" = "amd64" ]; then \
+      curl -fsSL -o /tmp/buzz.deb \
+        "https://github.com/block/buzz/releases/download/desktop-v${BUZZ_VERSION}/Buzz_${BUZZ_VERSION}_amd64.deb" \
+      && dpkg-deb -x /tmp/buzz.deb /tmp/x \
+      && install -m 0755 /tmp/x/usr/bin/buzz-acp /out/buzz-acp ; \
+    else \
+      echo "buzz-acp: no ${TARGETARCH} build published upstream; skipping bake" ; \
+    fi \
+ && rm -rf /var/lib/apt/lists/* /tmp/buzz.deb /tmp/x
+
+# ---
+
+FROM debian:trixie-slim AS runtime
 
 # Git SHA of the source commit, surfaced in-app under the sidebar email
 # popup so we can confirm at-a-glance which build is running (and that
@@ -88,6 +125,22 @@ RUN apt-get update -y \
 WORKDIR /app
 
 COPY --chown=fountain:fountain --from=build /app/_build/prod/rel/fountain_server ./
+
+# Hosted Buzz harness binaries (ADR 0020). The `fountain` CLI is the harness's
+# ACP child; buzz-acp is present only on amd64 (see the buzzacp stage). Copying
+# an empty /out on arm64 is a no-op, so :buzz_acp_path stays unset there.
+COPY --from=gocli /out/fountain /usr/local/bin/fountain
+COPY --from=buzzacp /out/ /usr/local/lib/fountain-buzz/
+
+ARG TARGETARCH
+# Fail the build now if a baked binary will not run in this image, rather than
+# at the first harness start. The CLI must run on every arch; buzz-acp only
+# where it was baked.
+RUN /usr/local/bin/fountain --version >/dev/null 2>&1 \
+ && if [ -x /usr/local/lib/fountain-buzz/buzz-acp ]; then \
+      /usr/local/lib/fountain-buzz/buzz-acp --help >/dev/null 2>&1 \
+        || { echo "buzz-acp is present but will not run in this image" >&2; exit 1; } ; \
+    fi
 
 EXPOSE 4000
 

--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -119,7 +119,7 @@ defmodule Fountain.Buzz do
   Options:
   * `:buzz_acp_path` — path to the binary (defaults to app env `:buzz_acp_path`)
   * `:base_url`      — this instance's base URL for the ACP child
-                       (defaults to app env `:public_base_url`)
+                       (defaults to app env `:buzz_acp_base_url`)
   * `:fountain_bin`  — path to the `fountain` CLI in the harness image
                        (defaults to app env `:fountain_cli_path`, else `"fountain"`)
   * `:agents`        — `BUZZ_ACP_AGENTS` pool size (default 1; the desktop's 10 is
@@ -133,7 +133,7 @@ defmodule Fountain.Buzz do
   @spec harness_launch(BuzzIdentity.t(), keyword()) :: {:ok, launch()} | {:error, term()}
   def harness_launch(%BuzzIdentity{} = identity, opts \\ []) do
     command = opts[:buzz_acp_path] || Application.get_env(:fountain, :buzz_acp_path)
-    base_url = opts[:base_url] || Application.get_env(:fountain, :public_base_url)
+    base_url = opts[:base_url] || Application.get_env(:fountain, :buzz_acp_base_url)
 
     fountain_bin =
       opts[:fountain_bin] || Application.get_env(:fountain, :fountain_cli_path) || "fountain"

--- a/apps/fountain/test/fountain/buzz/boot_sweep_test.exs
+++ b/apps/fountain/test/fountain/buzz/boot_sweep_test.exs
@@ -13,11 +13,11 @@ defmodule Fountain.Buzz.BootSweepTest do
     File.chmod!(fake, 0o755)
 
     prev_path = Application.get_env(:fountain, :buzz_acp_path)
-    prev_url = Application.get_env(:fountain, :public_base_url)
+    prev_url = Application.get_env(:fountain, :buzz_acp_base_url)
 
     on_exit(fn ->
       restore(:buzz_acp_path, prev_path)
-      restore(:public_base_url, prev_url)
+      restore(:buzz_acp_base_url, prev_url)
 
       for {_, pid, _, _} <- Horde.DynamicSupervisor.which_children(Fountain.BuzzSupervisor),
           is_pid(pid) do
@@ -43,7 +43,7 @@ defmodule Fountain.Buzz.BootSweepTest do
 
   test "run starts a harness for each enabled identity and skips disabled ones", %{fake: fake} do
     Application.put_env(:fountain, :buzz_acp_path, fake)
-    Application.put_env(:fountain, :public_base_url, "https://fountain.test")
+    Application.put_env(:fountain, :buzz_acp_base_url, "https://fountain.test")
 
     a = insert_buzz_identity(%{"enabled" => true})
     b = insert_buzz_identity(%{"enabled" => true})
@@ -64,7 +64,7 @@ defmodule Fountain.Buzz.BootSweepTest do
     on_exit(fn -> File.rm(fake) end)
 
     Application.put_env(:fountain, :buzz_acp_path, fake)
-    Application.put_env(:fountain, :public_base_url, "https://fountain.test")
+    Application.put_env(:fountain, :buzz_acp_base_url, "https://fountain.test")
 
     identity = insert_buzz_identity(%{"enabled" => true})
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -927,7 +927,9 @@ if config_env() == :prod do
     config :fountain, :buzz_acp_path, buzz_acp_path
   end
 
-  config :fountain, :fountain_cli_path, System.get_env("FOUNTAIN_CLI_PATH", "/usr/local/bin/fountain")
+  config :fountain,
+         :fountain_cli_path,
+         System.get_env("FOUNTAIN_CLI_PATH", "/usr/local/bin/fountain")
 
   config :fountain,
          :buzz_acp_base_url,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -911,3 +911,26 @@ if config_env() == :prod and server? do
     otlp_endpoint: otel_endpoint,
     otlp_headers: otel_headers
 end
+
+# Hosted Buzz harnesses (ADR 0020, gate #736). The `buzz-acp` binary is baked
+# into the amd64 image only and the `fountain` CLI into both; point config at
+# them here so `Fountain.Buzz.BootSweep` can stand up enabled identities. On an
+# arch without buzz-acp the path stays unset and the sweep is inert.
+#
+# The harness's ACP child (`fountain acp`) talks back to THIS server, so its
+# base URL defaults to the loopback endpoint — no egress, no TLS, no dependence
+# on PUBLIC_URL resolving inside the pod. Override with BUZZ_ACP_BASE_URL.
+if config_env() == :prod do
+  buzz_acp_path = "/usr/local/lib/fountain-buzz/buzz-acp"
+
+  if File.exists?(buzz_acp_path) do
+    config :fountain, :buzz_acp_path, buzz_acp_path
+  end
+
+  config :fountain, :fountain_cli_path, System.get_env("FOUNTAIN_CLI_PATH", "/usr/local/bin/fountain")
+
+  config :fountain,
+         :buzz_acp_base_url,
+         System.get_env("BUZZ_ACP_BASE_URL") ||
+           "http://127.0.0.1:#{System.get_env("PORT", "4000")}"
+end

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,3 +150,19 @@ default**: spans are exported only when `OTEL_EXPORTER_OTLP_ENDPOINT`,
 also honours its own standard variables, which take precedence — set
 `OTEL_TRACES_EXPORTER=otlp` or `=none` to force export on or off regardless
 of the above.
+
+## Hosted Buzz agents
+
+Fountain can host a [Buzz](https://github.com/block/buzz) agent's `buzz-acp`
+harness (ADR 0020), so a Buzz agent keeps a body on its relay without a running
+desktop. The harness binary is baked into the amd64 image; these tune where it
+runs and how its ACP child reaches back. Operators rarely set them — the
+defaults are correct for the packaged image.
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `BUZZ_ACP_BASE_URL` | the loopback endpoint (`http://127.0.0.1:$PORT`) | — | Base URL the harness's ACP child (`fountain acp`) uses to reach this instance. Defaults to loopback so harness traffic never leaves the pod; override only to point the child at a different Fountain endpoint |
+| `FOUNTAIN_CLI_PATH` | `/usr/local/bin/fountain` | — | Path to the `fountain` CLI the harness runs as its ACP child. The image bakes it at the default; override only for a non-standard layout |
+
+There is no `buzz-acp` binary in the arm64 image (upstream publishes none), so
+on an arm64 node the harness path stays unset and no Buzz harness starts there.


### PR DESCRIPTION
Makes `BootSweep` able to actually start hosted harnesses: the binaries now ship in the release image and `runtime.exs` points config at them. Part of #736 / #735.

## ⚠️ Needs a maintainer's eyes: this bumps the base image bookworm → trixie
A build-time smoke I added caught that **the shipped `buzz-acp` requires glibc 2.38+, and `debian:bookworm-slim` (our current runtime base) ships glibc 2.36 — so buzz-acp will not run there.** `debian:trixie-slim` (glibc 2.41) runs it. So both the build image (`hexpm/elixir:…-debian-trixie-…`) and the runtime base move to trixie. This affects **every deploy's runtime**, not just Buzz — hence the explicit callout. I validated the full release still builds and boots on trixie (below), but this is your call to merge.

## What's here
- **Dockerfile**
  - `gocli` stage — builds the `fountain` Go CLI (the harness's ACP child) for the target arch, amd64 + arm64.
  - `buzzacp` stage — unpacks `usr/bin/buzz-acp` from the pinned `.deb` (desktop-v0.5.14). **amd64-only** (upstream ships no arm64 build); on arm64 nothing is baked and `:buzz_acp_path` stays unset, so `BootSweep` is inert there.
  - runtime stage copies both in and **smokes them at build time** (`fountain --version`, `buzz-acp --help`) — a broken bake fails the image build, not the first harness start.
  - base images bumped bookworm → trixie (build + runtime) for the glibc reason above.
- **config/runtime.exs** (prod) — sets `:buzz_acp_path` (only if the binary exists → arm64 no-op), `:fountain_cli_path`, and `:buzz_acp_base_url` (defaults to the loopback endpoint; the ACP child talks to this same server, so no egress/TLS).
- **buzz.ex** — config key `:public_base_url` → `:buzz_acp_base_url` for clarity.

## Validation (local)
- Full **arm64** image builds on trixie; release ERTS loads and `runtime.exs` evaluates (reaches app-level config, well past any platform/NIF concern); `fountain` CLI runs in the image; buzz-acp correctly **absent** on arm64.
- **buzz-acp runs on `debian:trixie-slim`** and **fails on `debian:bookworm-slim`** (isolated test) — the evidence for the base bump.
- The amd64 bake + its build-time smoke run natively on CI's amd64 build; CI does not build the Docker image on PRs, so the on-merge build.yml is where the amd64 image (with buzz-acp) is first produced — worth watching that run after merge.

## Deployment note
Buzz harnesses run only on **amd64** nodes (no arm64 buzz-acp upstream). If the cluster is mixed, a follow-up adds node affinity; if it's amd64, this is a non-issue.

## Next (2b-ii)
ACP-child process-group teardown (spawn the port in its own session), captured `buzz-acp` output → `log_events`, and presence-survives-suspend verification.

Refs #735 #736. ADR: `decisions/0020-buzz-as-a-client-of-the-acp-gateway.md`.