### PR TITLE
feat(buzz): image bakes our own buzz-acp for both arches (#743)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,9 @@ jobs:
         with:
           ref: ${{ env.SRC_SHA }}
 
+      - name: Read buzz-acp pin
+        run: echo "BUZZ_ACP_VERSION=$(tr -d '[:space:]' < buzz-acp.version)" >> "$GITHUB_ENV"
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -156,6 +159,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             BUILD_SHA=${{ env.SRC_SHA }}
+            BUZZ_ACP_VERSION=${{ env.BUZZ_ACP_VERSION }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ env.SRC_SHA }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,10 @@ jobs:
         id: sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Read buzz-acp pin
+        id: buzzver
+        run: echo "version=$(tr -d '[:space:]' < buzz-acp.version)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -247,6 +251,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             BUILD_SHA=${{ steps.sha.outputs.sha }}
+            BUZZ_ACP_VERSION=${{ steps.buzzver.outputs.version }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.sha.outputs.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,27 +77,27 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-amd64}" \
       go build -trimpath -o /out/fountain ./cmd/fountain
 
 # ---
-# The hosted Buzz harness binary. block/buzz publishes an amd64 .deb only, so
-# this is baked on amd64 and skipped on arm64 — an arm64 image simply has no
-# buzz-acp, and runtime.exs leaves :buzz_acp_path unset there (the BootSweep is
-# inert). Pin is deliberate: a moved tag under an agent's key is not something
-# we want to float. Bump BUZZ_VERSION consciously.
+# The hosted Buzz harness binary. block/buzz publishes an amd64 .deb only, and
+# our cluster is arm64 (ADR 0020, #743), so we build buzz-acp ourselves for both
+# arches from the block/buzz source and publish it as a Fountain release asset
+# (`.github/workflows/buzz-acp-publish.yml`). Here we just download the
+# arch-matched binary and verify its checksum — no compile in the image build.
+# The pin lives in buzz-acp.version and is passed as BUZZ_ACP_VERSION by the
+# build workflow; the default below keeps a local `docker build` working.
 
-FROM debian:bookworm-slim AS buzzacp
+FROM debian:trixie-slim AS buzzacp
 ARG TARGETARCH
-ARG BUZZ_VERSION=0.5.14
+ARG BUZZ_ACP_VERSION=0.5.14
 RUN apt-get update -y \
- && apt-get install -y --no-install-recommends curl ca-certificates dpkg \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
  && mkdir -p /out \
- && if [ "${TARGETARCH:-amd64}" = "amd64" ]; then \
-      curl -fsSL -o /tmp/buzz.deb \
-        "https://github.com/block/buzz/releases/download/desktop-v${BUZZ_VERSION}/Buzz_${BUZZ_VERSION}_amd64.deb" \
-      && dpkg-deb -x /tmp/buzz.deb /tmp/x \
-      && install -m 0755 /tmp/x/usr/bin/buzz-acp /out/buzz-acp ; \
-    else \
-      echo "buzz-acp: no ${TARGETARCH} build published upstream; skipping bake" ; \
-    fi \
- && rm -rf /var/lib/apt/lists/* /tmp/buzz.deb /tmp/x
+ && base="https://github.com/BinaryBourbon/fountain/releases/download/buzz-acp-v${BUZZ_ACP_VERSION}" \
+ && asset="buzz-acp-linux-${TARGETARCH:-amd64}" \
+ && curl -fsSL -o /out/buzz-acp "${base}/${asset}" \
+ && curl -fsSL -o /tmp/sha "${base}/${asset}.sha256" \
+ && echo "$(cat /tmp/sha)  /out/buzz-acp" | sha256sum -c - \
+ && chmod 0755 /out/buzz-acp \
+ && rm -rf /var/lib/apt/lists/* /tmp/sha
 
 # ---
 
@@ -127,20 +127,15 @@ WORKDIR /app
 COPY --chown=fountain:fountain --from=build /app/_build/prod/rel/fountain_server ./
 
 # Hosted Buzz harness binaries (ADR 0020). The `fountain` CLI is the harness's
-# ACP child; buzz-acp is present only on amd64 (see the buzzacp stage). Copying
-# an empty /out on arm64 is a no-op, so :buzz_acp_path stays unset there.
+# ACP child; buzz-acp is our own build (see the buzzacp stage) for both arches.
 COPY --from=gocli /out/fountain /usr/local/bin/fountain
-COPY --from=buzzacp /out/ /usr/local/lib/fountain-buzz/
+COPY --from=buzzacp /out/buzz-acp /usr/local/lib/fountain-buzz/buzz-acp
 
-ARG TARGETARCH
 # Fail the build now if a baked binary will not run in this image, rather than
-# at the first harness start. The CLI must run on every arch; buzz-acp only
-# where it was baked.
+# at the first harness start.
 RUN /usr/local/bin/fountain --version >/dev/null 2>&1 \
- && if [ -x /usr/local/lib/fountain-buzz/buzz-acp ]; then \
-      /usr/local/lib/fountain-buzz/buzz-acp --help >/dev/null 2>&1 \
-        || { echo "buzz-acp is present but will not run in this image" >&2; exit 1; } ; \
-    fi
+ && /usr/local/lib/fountain-buzz/buzz-acp --help >/dev/null 2>&1 \
+      || { echo "a baked binary will not run in this image" >&2; exit 1; }
 
 EXPOSE 4000
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,14 +155,14 @@ of the above.
 
 Fountain can host a [Buzz](https://github.com/block/buzz) agent's `buzz-acp`
 harness (ADR 0020), so a Buzz agent keeps a body on its relay without a running
-desktop. The harness binary is baked into the amd64 image; these tune where it
-runs and how its ACP child reaches back. Operators rarely set them — the
-defaults are correct for the packaged image.
+desktop. The harness binary is baked into the image for both amd64 and arm64;
+these tune where it runs and how its ACP child reaches back. Operators rarely
+set them — the defaults are correct for the packaged image.
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|
 | `BUZZ_ACP_BASE_URL` | the loopback endpoint (`http://127.0.0.1:$PORT`) | — | Base URL the harness's ACP child (`fountain acp`) uses to reach this instance. Defaults to loopback so harness traffic never leaves the pod; override only to point the child at a different Fountain endpoint |
 | `FOUNTAIN_CLI_PATH` | `/usr/local/bin/fountain` | — | Path to the `fountain` CLI the harness runs as its ACP child. The image bakes it at the default; override only for a non-standard layout |
 
-There is no `buzz-acp` binary in the arm64 image (upstream publishes none), so
-on an arm64 node the harness path stays unset and no Buzz harness starts there.
+Upstream publishes `buzz-acp` for amd64 only, so Fountain builds it for both
+architectures from source and bakes it in (see `.github/workflows/buzz-acp-publish.yml`).


### PR DESCRIPTION
Step 2 of 2 for #743 (step 1 = the publish workflow, #744, merged). The image now bakes a **runnable buzz-acp on arm64** — the thing the prod cluster actually needs.

## What changed
- **Dockerfile** `buzzacp` stage now downloads our own **arch-matched** binary from the `buzz-acp-v<version>` release and **verifies its sha256**, instead of unpacking upstream's amd64-only `.deb`. No compile in the image build; buzz-acp is now present on **both** amd64 and arm64, so the runtime smoke and `:buzz_acp_path` apply everywhere.
- **build.yml / release.yml** read `buzz-acp.version` and pass `BUZZ_ACP_VERSION` as a build-arg, so the pin is a single source of truth.
- **docs/configuration.md** — both-arch availability.

## Verified locally against the real release (`buzz-acp-v0.5.14`, published by #744)
- arm64 `buzzacp` stage downloads `buzz-acp-linux-arm64` + `.sha256` and the checksum check passes (`/out/buzz-acp: OK`).
- **Full arm64 image builds**, the build-time smoke (`fountain --version` + `buzz-acp --help`) passes, and `buzz-acp --help` runs inside the built image (`"ACP harness that bridges Buzz events to AI agents"`).

## After merge
`build.yml` builds the multi-arch image with this Dockerfile; the arm64 image (the deployed one) now carries a runnable buzz-acp, so `BootSweep` can start harnesses on the prod nodes. That on-merge `build.yml` run is the last thing to watch.

One maintenance note: the Dockerfile's default `ARG BUZZ_ACP_VERSION=0.5.14` should track `buzz-acp.version`; the CI build passes the real value, so the default only matters for a bare local `docker build`. A small guard test could enforce the two stay in sync (follow-up).

Refs #735 #736 #743. ADR: `decisions/0020-buzz-as-a-client-of-the-acp-gateway.md`.