### PR TITLE
fix(buzz): reap buzz-acp on stop via a port middleman — no more orphans (#736)

### DIFF
--- a/apps/fountain/lib/fountain/buzz/harness.ex
+++ b/apps/fountain/lib/fountain/buzz/harness.ex
@@ -54,6 +54,13 @@ defmodule Fountain.Buzz.Harness do
       command: Keyword.fetch!(opts, :command),
       args: Keyword.get(opts, :args, []),
       env: Keyword.get(opts, :env, []),
+      # The port middleman that ties buzz-acp's lifetime to the port and reaps it
+      # on close (see priv/buzz-acp-launch.sh). Without it, buzz-acp closes its
+      # stdio to us, the port reports a false EOF, and we leak a still-live
+      # process that stays on the relay. `nil` spawns the command directly (only
+      # for callers that do not need teardown — real harnesses always set it).
+      launcher: Keyword.get(opts, :launcher),
+      shell: Keyword.get(opts, :shell, "/bin/sh"),
       on_stop: Keyword.get(opts, :on_stop),
       backoff_ms: Keyword.get(opts, :restart_backoff_ms, @default_backoff_ms),
       label: Keyword.get(opts, :label, "buzz-acp"),
@@ -111,24 +118,33 @@ defmodule Fountain.Buzz.Harness do
   # ── internals ────────────────────────────────────────────────────────────────
 
   defp open(state) do
+    {exec, args} = spawn_argv(state)
+
     port =
-      Port.open({:spawn_executable, state.command}, [
+      Port.open({:spawn_executable, exec}, [
         :binary,
         :exit_status,
         :hide,
-        {:args, state.args},
+        {:args, args},
         {:env, charlist_env(state.env)}
       ])
 
     %{state | port: port, starts: state.starts + 1}
   end
 
+  # Through the launcher (`/bin/sh <launcher> <command> <args…>`) so buzz-acp is
+  # reaped on port close; direct only when no launcher is configured.
+  defp spawn_argv(%{launcher: nil} = state), do: {state.command, state.args}
+
+  defp spawn_argv(%{launcher: launcher, shell: shell} = state),
+    do: {shell, [launcher, state.command | state.args]}
+
   defp close(nil), do: :ok
 
-  # Closing a spawn_executable port terminates its OS process. Reliable teardown
-  # of the ACP *child* (`fountain acp` beneath `buzz-acp`) needs a process-group
-  # kill, which in turn needs the port spawned in its own session — that arrives
-  # with the real binary in increment 2. For now, close the port.
+  # Closing the port EOFs the launcher's held pipe, which TERMs buzz-acp (and,
+  # if it will not go, KILLs it) and reaps its `fountain acp` child — see
+  # priv/buzz-acp-launch.sh. Without the launcher this only closes the pipe and
+  # a bare buzz-acp would be orphaned.
   defp close(port) do
     Port.close(port)
     :ok

--- a/apps/fountain/lib/fountain/buzz/manager.ex
+++ b/apps/fountain/lib/fountain/buzz/manager.ex
@@ -110,9 +110,18 @@ defmodule Fountain.Buzz.Manager do
       command: launch.command,
       args: launch.args,
       env: launch.env,
+      launcher: launcher_path(),
       label: identity.id,
       on_stop: fn -> Buzz.revoke_launch_key(identity, launch.api_key_id) end
     ]
+  end
+
+  # The port middleman that reaps buzz-acp on stop (priv/buzz-acp-launch.sh,
+  # shipped in the release). Config can override the path; the app-dir default
+  # resolves in dev, test and the release alike.
+  defp launcher_path do
+    Application.get_env(:fountain, :buzz_acp_launcher) ||
+      Application.app_dir(:fountain, "priv/buzz-acp-launch.sh")
   end
 
   defp revoke_orphaned_key(%BuzzIdentity{} = identity, launch) do

--- a/apps/fountain/priv/buzz-acp-launch.sh
+++ b/apps/fountain/priv/buzz-acp-launch.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Port middleman for a hosted buzz-acp (Fountain ADR 0020 / gate #736; harness.ex).
+#
+# Why this exists: buzz-acp does not use its stdio to talk to the BEAM (it drives
+# `fountain acp` over its own pipes and closes ours), so a bare spawn_executable
+# port saw a false EOF and the harness restarted a still-live buzz-acp — leaking
+# orphaned processes that stayed on the relay (the agent "online" after stop).
+#
+# This wrapper:
+#   * holds the BEAM's stdin open (fd 3) regardless of what buzz-acp does, so the
+#     port delivers exactly one true exit_status — when buzz-acp actually exits;
+#   * on Port.close (BEAM closes the port), TERMs buzz-acp, and if it does not go
+#     within the grace window, KILLs it — never orphaning it. buzz-acp SIGTERM-
+#     cleans its own `fountain acp` child, and that child exits on stdio EOF if
+#     buzz-acp is killed outright.
+
+# A backgrounded `&` command has its stdin redirected to /dev/null, which would
+# EOF the closer immediately; dup the real port pipe to fd 3 first.
+exec 3<&0
+
+"$@" &
+child=$!
+
+{
+  cat <&3 >/dev/null 2>&1        # blocks until the BEAM closes the port
+  kill -TERM "$child" 2>/dev/null
+  i=0
+  while kill -0 "$child" 2>/dev/null && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  kill -KILL "$child" 2>/dev/null
+} &
+closer=$!
+
+wait "$child"
+status=$?
+
+kill -TERM "$closer" 2>/dev/null
+exit "$status"

--- a/apps/fountain/test/fountain/buzz/harness_test.exs
+++ b/apps/fountain/test/fountain/buzz/harness_test.exs
@@ -1,12 +1,13 @@
 defmodule Fountain.Buzz.HarnessTest do
-  # async: false — writes a fake executable to a tmp dir and spawns OS processes.
+  # async: false — writes fake executables and spawns OS processes.
   use ExUnit.Case, async: false
 
   alias Fountain.Buzz.Harness
 
-  # A fake `buzz-acp`: writes its invocation marker to a file (so the test can
-  # prove the port opened with the right env) and then behaves as the scenario
-  # asks — either sleep forever, or exit after a beat to exercise restart.
+  # The real port middleman, shipped in priv. Every harness spawns through it,
+  # so the tests exercise the exact teardown path production uses.
+  @launcher Path.expand("../../../priv/buzz-acp-launch.sh", __DIR__)
+
   defp write_fake(dir, name, body) do
     path = Path.join(dir, name)
     File.write!(path, "#!/bin/sh\n" <> body)
@@ -14,39 +15,38 @@ defmodule Fountain.Buzz.HarnessTest do
     path
   end
 
+  defp alive?(pid), do: match?({_, 0}, System.cmd("sh", ["-c", "kill -0 #{pid} 2>/dev/null"]))
+
   setup do
+    assert File.exists?(@launcher), "launcher missing at #{@launcher}"
     dir = Path.join(System.tmp_dir!(), "buzz-harness-#{System.unique_integer([:positive])}")
     File.mkdir_p!(dir)
     on_exit(fn -> File.rm_rf(dir) end)
     %{dir: dir}
   end
 
+  defp start(opts) do
+    start_supervised!({Harness, Keyword.put_new(opts, :launcher, @launcher)})
+  end
+
   test "opens the port with the given env and stays running", %{dir: dir} do
     marker = Path.join(dir, "marker")
-    # Record BUZZ_RELAY_URL so we can prove env made it through, then idle.
     cmd = write_fake(dir, "buzz-acp", "printf '%s' \"$BUZZ_RELAY_URL\" > #{marker}\nsleep 30\n")
 
-    pid =
-      start_supervised!(
-        {Harness, command: cmd, env: [{"BUZZ_RELAY_URL", "wss://relay.example"}], label: "t"}
-      )
+    pid = start(command: cmd, env: [{"BUZZ_RELAY_URL", "wss://relay.example"}], label: "t")
 
     assert Harness.running?(pid)
     assert Harness.starts_count(pid) == 1
-
     wait_until(fn -> File.exists?(marker) end)
     assert File.read!(marker) == "wss://relay.example"
   end
 
-  test "restarts the process when it exits, with backoff", %{dir: dir} do
+  test "restarts the process when it really exits, with backoff", %{dir: dir} do
     counter = Path.join(dir, "count")
-    # Append a line each launch, then exit immediately — forces restarts.
     cmd = write_fake(dir, "buzz-acp", "echo x >> #{counter}\nexit 0\n")
 
-    pid =
-      start_supervised!({Harness, command: cmd, env: [], restart_backoff_ms: 20, label: "t"})
+    pid = start(command: cmd, restart_backoff_ms: 20, label: "t")
 
-    # Three launches means at least two restarts happened after the first exit.
     wait_until(fn ->
       File.exists?(counter) and length(File.stream!(counter) |> Enum.to_list()) >= 3
     end)
@@ -54,18 +54,49 @@ defmodule Fountain.Buzz.HarnessTest do
     assert Harness.starts_count(pid) >= 3
   end
 
-  test "runs the on_stop callback and closes the port on shutdown", %{dir: dir} do
+  # The bug this whole change exists to fix (#736): buzz-acp closes its stdio to
+  # the BEAM, which a bare port reads as a false exit and restarts — leaking a
+  # still-live process. Through the launcher the port stays open, so no restart.
+  test "does NOT restart when the child merely closes its stdio", %{dir: dir} do
+    # Close stdin/stdout/stderr toward the port, then keep running.
+    cmd = write_fake(dir, "buzz-acp", "exec 0<&- 1>&- 2>&-\nsleep 30\n")
+
+    pid = start(command: cmd, restart_backoff_ms: 20, label: "t")
+
+    Process.sleep(700)
+    assert Harness.running?(pid)
+    assert Harness.starts_count(pid) == 1, "the harness restarted a still-live child"
+  end
+
+  # The other half of the fix: on shutdown the OS process must actually die, not
+  # orphan onto the relay. The fake closes its stdio (like the real one) so only
+  # the launcher's teardown can reap it.
+  test "reaps the child OS process on shutdown", %{dir: dir} do
+    pidfile = Path.join(dir, "childpid")
+    cmd = write_fake(dir, "buzz-acp", "echo $$ > #{pidfile}\nexec 0<&- 1>&- 2>&-\nsleep 300\n")
+
+    start(command: cmd, label: "t")
+    wait_until(fn -> File.exists?(pidfile) end)
+    child = File.read!(pidfile) |> String.trim() |> String.to_integer()
+    assert alive?(child)
+
+    :ok = stop_supervised(Harness)
+
+    reaped =
+      Enum.reduce_while(1..80, false, fn _, _ ->
+        Process.sleep(100)
+        if alive?(child), do: {:cont, false}, else: {:halt, true}
+      end)
+
+    assert reaped, "child OS process #{child} survived shutdown (leaked)"
+  end
+
+  test "runs the on_stop callback on shutdown", %{dir: dir} do
     cmd = write_fake(dir, "buzz-acp", "sleep 30\n")
     test_pid = self()
 
-    pid =
-      start_supervised!(
-        {Harness, command: cmd, env: [], label: "t", on_stop: fn -> send(test_pid, :stopped) end}
-      )
-
-    assert Harness.running?(pid)
+    start(command: cmd, label: "t", on_stop: fn -> send(test_pid, :stopped) end)
     :ok = stop_supervised(Harness)
-
     assert_receive :stopped, 2_000
   end
 
@@ -73,11 +104,12 @@ defmodule Fountain.Buzz.HarnessTest do
   defp wait_until(_fun, 0), do: flunk("condition not met in time")
 
   defp wait_until(fun, tries) do
-    if fun.() do
-      :ok
-    else
-      Process.sleep(10)
-      wait_until(fun, tries - 1)
-    end
+    if fun.(),
+      do: :ok,
+      else:
+        (
+          Process.sleep(10)
+          wait_until(fun, tries - 1)
+        )
   end
 end


### PR DESCRIPTION
First piece of gate 2b-ii, and a **real bug the prod smoke caught**: stopping a hosted harness left buzz-acp **running and online on the relay** (processes even hopped across deploys).

## Two failure modes, one cause
buzz-acp doesn't use its stdio to talk to the BEAM — it drives `fountain acp` over its own pipes and closes ours. So:
1. **False restart:** a bare `spawn_executable` port read that stdio-close as EOF and the harness restarted a **still-live** buzz-acp → duplicates.
2. **Orphan on stop:** `Port.close` closed the pipe but never killed buzz-acp → it kept running (agent stays online).

## Fix: a port middleman (`priv/buzz-acp-launch.sh`)
The harness now spawns buzz-acp through a small launcher that:
- holds the BEAM's stdin open (dup'd to fd 3) regardless of buzz-acp's own stdio, so the port delivers **exactly one true `exit_status`** — never a false restart; and
- on `Port.close`, **TERMs buzz-acp, escalating to KILL** after a grace window, so it is reaped rather than orphaned. buzz-acp SIGTERM-cleans its own `fountain acp` child; that child exits on stdio EOF even if buzz-acp is killed outright.

Ships in the release `priv` (resolved via `Application.app_dir`, overridable with `:buzz_acp_launcher`), spawned via `/bin/sh` so there's no exec-bit dependence. No Dockerfile/runtime.exs change.

## Validation
- Two regression tests pin the failure modes: **no restart when the child closes its stdio**, and **child OS process reaped on shutdown**.
- The launcher's teardown is confirmed under **dash on arm64 `debian:trixie-slim`** (the exact prod shell + arch): child alive while the port is open, reaped on close.
- 52 buzz tests, 0 failures; format / credo --strict / compile --warnings-as-errors clean.

## After merge
Re-run the prod smoke (create a BuzzIdentity, start + stop a harness) and confirm **zero leaked buzz-acp** after stop — the exact thing that failed before.

Still to come in 2b-ii: captured buzz-acp output → `log_events`, and presence-survives-suspend. Refs #735 #736.