### PR TITLE
feat(buzz): surface buzz-acp output on the Logger (#736)

### DIFF
--- a/apps/fountain/lib/fountain/buzz/harness.ex
+++ b/apps/fountain/lib/fountain/buzz/harness.ex
@@ -31,6 +31,9 @@ defmodule Fountain.Buzz.Harness do
   require Logger
 
   @default_backoff_ms 1_000
+  # Line-frame buzz-acp's output at the port so a single log line is bounded and
+  # a chatty process cannot deliver one unbounded binary.
+  @max_line 4_096
 
   # ── API ────────────────────────────────────────────────────────────────────
 
@@ -86,10 +89,18 @@ defmodule Fountain.Buzz.Harness do
   # A late message from a port we already replaced or closed. Ignore it.
   def handle_info({_stale_port, {:exit_status, _status}}, state), do: {:noreply, state}
 
-  def handle_info({port, {:data, _data}}, %{port: port} = state) do
-    # buzz-acp writes protocol/diagnostics to its own stdio toward its ACP
-    # child, not to us; anything arriving here is noise. Increment 2 wires
-    # captured output to log_events — for now, drop it.
+  # buzz-acp's own stdout/stderr (its relay/handshake diagnostics) flow through
+  # the launcher to this port. Surface them on the Elixir Logger tagged with the
+  # identity, so `kubectl logs` shows why a harness is (or isn't) connected — the
+  # thing the first prod smoke could not see. Not log_events: those are
+  # conversation-scoped, and a harness is identity-scoped.
+  def handle_info({port, {:data, {:eol, line}}}, %{port: port} = state) do
+    log_line(state.label, line)
+    {:noreply, state}
+  end
+
+  def handle_info({port, {:data, {:noeol, chunk}}}, %{port: port} = state) do
+    log_line(state.label, chunk)
     {:noreply, state}
   end
 
@@ -125,11 +136,18 @@ defmodule Fountain.Buzz.Harness do
         :binary,
         :exit_status,
         :hide,
+        {:line, @max_line},
         {:args, args},
         {:env, charlist_env(state.env)}
       ])
 
     %{state | port: port, starts: state.starts + 1}
+  end
+
+  defp log_line(_label, ""), do: :ok
+
+  defp log_line(label, line) do
+    Logger.info("[buzz-acp #{label}] #{line}")
   end
 
   # Through the launcher (`/bin/sh <launcher> <command> <args…>`) so buzz-acp is

--- a/apps/fountain/test/fountain/buzz/harness_test.exs
+++ b/apps/fountain/test/fountain/buzz/harness_test.exs
@@ -91,6 +91,27 @@ defmodule Fountain.Buzz.HarnessTest do
     assert reaped, "child OS process #{child} survived shutdown (leaked)"
   end
 
+  test "surfaces buzz-acp output on the Logger, tagged with the label", %{dir: dir} do
+    import ExUnit.CaptureLog
+
+    cmd = write_fake(dir, "buzz-acp", "echo 'connected to relay'\nsleep 30\n")
+
+    # Test config filters :info at the primary level; prod logs at :info. Lower
+    # the level for this test so the info line is dispatched to the capture.
+    prev = Logger.level()
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: prev) end)
+
+    log =
+      capture_log(fn ->
+        start(command: cmd, label: "philo-xyz")
+        Process.sleep(400)
+      end)
+
+    assert log =~ "[buzz-acp philo-xyz]"
+    assert log =~ "connected to relay"
+  end
+
   test "runs the on_stop callback on shutdown", %{dir: dir} do
     cmd = write_fake(dir, "buzz-acp", "sleep 30\n")
     test_pid = self()


### PR DESCRIPTION
Second 2b-ii piece — operability. The harness **dropped** buzz-acp's port output, so its relay/handshake diagnostics were invisible in-pod. That's exactly why the first prod smoke couldn't see whether the harness had connected.

buzz-acp's own stdout/stderr flow through the launcher (#746) to the port. This line-frames them (bounded at 4 KB/line via `{:line, 4096}`) and logs each at `:info`, tagged with the identity label:

```
[buzz-acp <identity-id>] connected to relay wss://buzz.inevitable.fyi
[buzz-acp <identity-id>] presence set to online
```

so `kubectl logs` shows why a harness is (or isn't) on the relay.

Deliberately **not** `log_events` — those are conversation-scoped, and a harness is identity-scoped; the Logger (→ kubectl logs / Sentry breadcrumbs) is the right home for harness diagnostics.

Test: a fake that echoes a line is asserted to reach the Logger (lowering the primary level, since test config filters `:info`). 53 buzz tests, 0 failures; format / credo --strict / compile --warnings-as-errors clean.

Refs #735 #736.

---
FYI — **the #746 leak fix is proven in prod**: re-ran the smoke on `sha-184693d`, harness stayed at exactly 1 process while running (no duplication) and reaped to **0 on stop** (the failure that leaked orphans before). This PR makes that kind of check visible in the logs instead of requiring `/proc` spelunking.