### PR TITLE
ci(buzz): publish the buzz CLI alongside buzz-acp (gate 3, #737)

### DIFF
--- a/.github/workflows/buzz-acp-publish.yml
+++ b/.github/workflows/buzz-acp-publish.yml
@@ -56,19 +56,23 @@ jobs:
           cd buzz
           rustup show
 
-      - name: Build buzz-acp
+      - name: Build binaries
         run: |
           cd buzz
-          cargo build --release -p buzz-acp
-          strip target/release/buzz-acp
+          # buzz-acp: the hosted harness (gate 2). buzz: the CLI our server-side
+          # MCP tools shell out to for signed publishes (gate 3, #737).
+          cargo build --release -p buzz-acp -p buzz-cli
+          strip target/release/buzz-acp target/release/buzz
 
-      - name: Stage artifact + checksum
+      - name: Stage artifacts + checksums
         run: |
           mkdir -p dist
-          cp buzz/target/release/buzz-acp "dist/buzz-acp-linux-${{ matrix.arch }}"
-          ( cd dist && sha256sum "buzz-acp-linux-${{ matrix.arch }}" | cut -d' ' -f1 \
-              > "buzz-acp-linux-${{ matrix.arch }}.sha256" )
-          file "dist/buzz-acp-linux-${{ matrix.arch }}"
+          for bin in buzz-acp buzz; do
+            cp "buzz/target/release/${bin}" "dist/${bin}-linux-${{ matrix.arch }}"
+            ( cd dist && sha256sum "${bin}-linux-${{ matrix.arch }}" | cut -d' ' -f1 \
+                > "${bin}-linux-${{ matrix.arch }}.sha256" )
+            file "dist/${bin}-linux-${{ matrix.arch }}"
+          done
 
       - name: Upload to the buzz-acp release
         env:
@@ -80,10 +84,12 @@ jobs:
           if ! gh release view "$tag" >/dev/null 2>&1; then
             gh release create "$tag" \
               --title "buzz-acp v${VERSION}" \
-              --notes "buzz-acp built from block/buzz \`desktop-v${VERSION}\` for linux/amd64 and linux/arm64. See ADR 0020 / #743. Upstream is Apache-2.0." \
+              --notes "buzz-acp and buzz built from block/buzz \`desktop-v${VERSION}\` for linux/amd64 and linux/arm64. See ADR 0020 / #743 / #737. Upstream is Apache-2.0." \
               || true
           fi
           gh release upload "$tag" \
             "dist/buzz-acp-linux-${{ matrix.arch }}" \
             "dist/buzz-acp-linux-${{ matrix.arch }}.sha256" \
+            "dist/buzz-linux-${{ matrix.arch }}" \
+            "dist/buzz-linux-${{ matrix.arch }}.sha256" \
             --clobber


### PR DESCRIPTION
Gate 3 (the reply path, #737) — step 1 of the tooling. Decided: the Fountain-hosted MCP `buzz_*` tools **shell out to the `buzz` CLI** with the nsec held server-side (reuses Buzz's proven NIP-01/NIP-98/schnorr signing; lowest crypto-bug risk).

This extends the existing publish workflow to build and publish **`buzz`** from the same block/buzz source + pin as buzz-acp, for both arches, to the same `buzz-acp-v<version>` release. A follow-up bakes it into the image (mirrors #745).

Small, mechanical, mirrors the buzz-acp publish path. After merge I'll dispatch the workflow to add `buzz-linux-{amd64,arm64}` to the release, then open the bake PR.

Refs #735 #737.