### PR TITLE
feat(buzz): bake the buzz CLI into the image (gate 3, #737)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,15 +88,19 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-amd64}" \
 FROM debian:trixie-slim AS buzzacp
 ARG TARGETARCH
 ARG BUZZ_ACP_VERSION=0.5.14
+# buzz-acp: the hosted harness (gate 2). buzz: the CLI the server-side MCP tools
+# shell out to for signed publishes (gate 3, #737). Both from our own release.
 RUN apt-get update -y \
  && apt-get install -y --no-install-recommends curl ca-certificates \
  && mkdir -p /out \
  && base="https://github.com/BinaryBourbon/fountain/releases/download/buzz-acp-v${BUZZ_ACP_VERSION}" \
- && asset="buzz-acp-linux-${TARGETARCH:-amd64}" \
- && curl -fsSL -o /out/buzz-acp "${base}/${asset}" \
- && curl -fsSL -o /tmp/sha "${base}/${asset}.sha256" \
- && echo "$(cat /tmp/sha)  /out/buzz-acp" | sha256sum -c - \
- && chmod 0755 /out/buzz-acp \
+ && for bin in buzz-acp buzz; do \
+      asset="${bin}-linux-${TARGETARCH:-amd64}" \
+      && curl -fsSL -o "/out/${bin}" "${base}/${asset}" \
+      && curl -fsSL -o /tmp/sha "${base}/${asset}.sha256" \
+      && echo "$(cat /tmp/sha)  /out/${bin}" | sha256sum -c - \
+      && chmod 0755 "/out/${bin}" ; \
+    done \
  && rm -rf /var/lib/apt/lists/* /tmp/sha
 
 # ---
@@ -126,15 +130,18 @@ WORKDIR /app
 
 COPY --chown=fountain:fountain --from=build /app/_build/prod/rel/fountain_server ./
 
-# Hosted Buzz harness binaries (ADR 0020). The `fountain` CLI is the harness's
-# ACP child; buzz-acp is our own build (see the buzzacp stage) for both arches.
+# Hosted Buzz binaries (ADR 0020, #737). The `fountain` CLI is the harness's ACP
+# child; buzz-acp is the harness; buzz is the CLI the server-side MCP tools shell
+# out to for signed publishes. All our own builds (see the stages) for both arches.
 COPY --from=gocli /out/fountain /usr/local/bin/fountain
 COPY --from=buzzacp /out/buzz-acp /usr/local/lib/fountain-buzz/buzz-acp
+COPY --from=buzzacp /out/buzz /usr/local/lib/fountain-buzz/buzz
 
 # Fail the build now if a baked binary will not run in this image, rather than
-# at the first harness start.
+# at the first harness start or publish.
 RUN /usr/local/bin/fountain --version >/dev/null 2>&1 \
  && /usr/local/lib/fountain-buzz/buzz-acp --help >/dev/null 2>&1 \
+ && /usr/local/lib/fountain-buzz/buzz --help >/dev/null 2>&1 \
       || { echo "a baked binary will not run in this image" >&2; exit 1; }
 
 EXPOSE 4000


### PR DESCRIPTION
Gate 3, step 2 — follow-up to #748 (which publishes `buzz`). The image now bakes the `buzz` CLI so the upcoming server-side MCP tools can shell out to it for signed publishes (nsec held server-side, never in the sandbox).

- The `buzzacp` Dockerfile stage downloads **both** `buzz-acp` and `buzz` for the target arch (checksum-verified) from our `buzz-acp-v<version>` release.
- The runtime stage copies `buzz` to `/usr/local/lib/fountain-buzz/buzz` and smokes it (`buzz --help`) at build time.

Validated locally on arm64: both binaries download with verified checksums (`buzz-acp: OK`, `buzz: OK`), and `buzz --help` runs on `debian:trixie-slim`.

After this, gate 3's remaining work is the big one: the **Fountain-hosted HTTP MCP server** (`buzz_send_message` + `buzz_react`) that resolves the nsec server-side and shells out to this baked `buzz`, wired into `session/new` for Buzz-driven conversations, with a base-prompt override. Refs #735 #737.