### PR TITLE
feat(buzz): MCP tool layer for the reply path (#737)

### DIFF
--- a/apps/fountain/lib/fountain/buzz/mcp.ex
+++ b/apps/fountain/lib/fountain/buzz/mcp.ex
@@ -148,6 +148,9 @@ defmodule Fountain.Buzz.Mcp do
     end
   end
 
+  # sobelow_skip ["CI.System"] — no shell: System.cmd execs `bin` directly with
+  # `argv` as a list, so message content (an argv element) cannot inject a
+  # command. `bin` is a config path, and the credentials travel in `env`.
   defp default_exec(bin, argv, env) do
     System.cmd(bin, argv, env: env, stderr_to_stdout: true)
   end

--- a/apps/fountain/lib/fountain/buzz/mcp.ex
+++ b/apps/fountain/lib/fountain/buzz/mcp.ex
@@ -1,0 +1,185 @@
+defmodule Fountain.Buzz.Mcp do
+  @moduledoc """
+  Server-side MCP tools that let a hosted Buzz agent post to its channel
+  (ADR 0020 Phase 2, gate #737 — the reply path).
+
+  buzz-acp never publishes the agent's reply, and Fountain deliberately keeps the
+  agent's Nostr key out of the sandbox. So instead of the sandbox running the
+  `buzz` CLI, Fountain exposes `buzz_*` tools over MCP: the sandboxed agent calls
+  a tool, and Fountain — holding the key server-side — signs and publishes on its
+  behalf by shelling out to the baked `buzz` CLI. Every post is a tool call
+  Fountain can see and audit; the nsec never leaves the server.
+
+  This module is the pure protocol/tool layer: it handles a JSON-RPC request map
+  against a `ctx` and returns a response map. The transport (an HTTP endpoint)
+  and the `ctx` construction (resolving a conversation to its Buzz identity and
+  decrypting the key) live above it, so the tool logic is testable without a
+  network or a real key.
+
+  `ctx` fields:
+    * `:env`     — `[{name, value}]` the `BUZZ_*` credentials for the `buzz` CLI
+    * `:buzz_bin` — path to the baked `buzz` binary
+    * `:exec`    — `(bin, args, env) -> {output, exit_status}` (default `System.cmd`),
+                   injectable for tests
+    * `:audit`   — optional `(tool_name, args) -> any` called after a successful
+                   publish, for the audit trail
+  """
+
+  # The MCP protocol revision we implement (Streamable HTTP transport).
+  @protocol_version "2025-06-18"
+  @server_info %{name: "fountain-buzz", version: "1"}
+
+  @doc "The tool catalogue advertised by `tools/list`."
+  def tools do
+    [
+      %{
+        name: "buzz_send_message",
+        description:
+          "Post a message to a Buzz channel as this agent. Use this to reply — " <>
+            "the agent's own text is not published anywhere else. Returns the " <>
+            "published event id.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            channel: %{type: "string", description: "Channel UUID to post in"},
+            content: %{type: "string", description: "Message text (markdown, @mentions)"},
+            reply_to: %{
+              type: "string",
+              description: "Optional event id (64-hex) to reply to, creating a thread"
+            }
+          },
+          required: ["channel", "content"]
+        }
+      },
+      %{
+        name: "buzz_react",
+        description: "Add an emoji reaction to a Buzz event (message) as this agent.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            event: %{type: "string", description: "Event id (64-hex) to react to"},
+            emoji: %{type: "string", description: "Emoji, e.g. 👍"}
+          },
+          required: ["event", "emoji"]
+        }
+      }
+    ]
+  end
+
+  @doc """
+  Handle one JSON-RPC 2.0 request map against `ctx`.
+
+  Returns a response map to send back, or `:noreply` for a notification (a
+  request with no `id`), which per JSON-RPC gets no response.
+  """
+  def handle(%{"method" => method} = req, ctx) do
+    id = Map.get(req, "id")
+
+    cond do
+      is_nil(id) and String.starts_with?(method, "notifications/") ->
+        :noreply
+
+      true ->
+        dispatch(method, id, Map.get(req, "params", %{}), ctx)
+    end
+  end
+
+  defp dispatch("initialize", id, _params, _ctx) do
+    result(id, %{
+      protocolVersion: @protocol_version,
+      capabilities: %{tools: %{}},
+      serverInfo: @server_info
+    })
+  end
+
+  defp dispatch("ping", id, _params, _ctx), do: result(id, %{})
+
+  defp dispatch("tools/list", id, _params, _ctx), do: result(id, %{tools: tools()})
+
+  defp dispatch("tools/call", id, %{"name" => name} = params, ctx) do
+    call_tool(id, name, Map.get(params, "arguments", %{}), ctx)
+  end
+
+  defp dispatch(_unknown, nil, _params, _ctx), do: :noreply
+
+  defp dispatch(method, id, _params, _ctx) do
+    error(id, -32_601, "method not found: #{method}")
+  end
+
+  # ── tools ──────────────────────────────────────────────────────────────────
+
+  defp call_tool(id, "buzz_send_message", args, ctx) do
+    with {:ok, channel} <- require_arg(args, "channel"),
+         {:ok, content} <- require_arg(args, "content") do
+      argv =
+        ["messages", "send", "--channel", channel, "--content", content] ++
+          optional(args, "reply_to", "--reply-to")
+
+      run(id, "buzz_send_message", args, argv, ctx)
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, "buzz_react", args, ctx) do
+    with {:ok, event} <- require_arg(args, "event"),
+         {:ok, emoji} <- require_arg(args, "emoji") do
+      run(id, "buzz_react", args, ["reactions", "add", "--event", event, "--emoji", emoji], ctx)
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, name, _args, _ctx), do: tool_error(id, "unknown tool: #{name}")
+
+  # Shell out to the baked `buzz` with the BUZZ_* creds in the environment (never
+  # in argv). No shell is involved — args are passed as a list, so message
+  # content cannot inject a command.
+  defp run(id, tool, args, argv, ctx) do
+    exec = Map.get(ctx, :exec, &default_exec/3)
+
+    case exec.(ctx.buzz_bin, argv, ctx.env) do
+      {output, 0} ->
+        maybe_audit(ctx, tool, args)
+        result(id, %{content: [text(output)], isError: false})
+
+      {output, status} ->
+        result(id, %{content: [text("buzz exited #{status}: #{output}")], isError: true})
+    end
+  end
+
+  defp default_exec(bin, argv, env) do
+    System.cmd(bin, argv, env: env, stderr_to_stdout: true)
+  end
+
+  defp maybe_audit(%{audit: audit}, tool, args) when is_function(audit, 2), do: audit.(tool, args)
+  defp maybe_audit(_ctx, _tool, _args), do: :ok
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  defp require_arg(args, key) do
+    case Map.get(args, key) do
+      v when is_binary(v) and v != "" -> {:ok, v}
+      _ -> {:error, "missing required argument: #{key}"}
+    end
+  end
+
+  defp optional(args, key, flag) do
+    case Map.get(args, key) do
+      v when is_binary(v) and v != "" -> [flag, v]
+      _ -> []
+    end
+  end
+
+  defp text(str), do: %{type: "text", text: to_string(str)}
+
+  defp result(id, result), do: %{"jsonrpc" => "2.0", "id" => id, "result" => result}
+
+  defp error(id, code, message),
+    do: %{"jsonrpc" => "2.0", "id" => id, "error" => %{"code" => code, "message" => message}}
+
+  # A tool-level failure is a successful JSON-RPC response carrying isError, per
+  # MCP — the model sees it and can recover, rather than the call itself failing.
+  defp tool_error(id, message),
+    do: result(id, %{content: [text(message)], isError: true})
+end

--- a/apps/fountain/test/fountain/buzz/mcp_test.exs
+++ b/apps/fountain/test/fountain/buzz/mcp_test.exs
@@ -1,0 +1,136 @@
+defmodule Fountain.Buzz.McpTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Buzz.Mcp
+
+  # A ctx whose exec records the call and returns a canned result, so the tool
+  # logic is tested without a real `buzz` binary or key.
+  defp ctx(result \\ {~s({"accepted":true,"event_id":"abc"}), 0}) do
+    test = self()
+
+    %{
+      buzz_bin: "/fake/buzz",
+      env: [{"BUZZ_PRIVATE_KEY", "nsec1secret"}, {"BUZZ_RELAY_URL", "https://relay"}],
+      exec: fn bin, argv, env ->
+        send(test, {:exec, bin, argv, env})
+        result
+      end,
+      audit: fn tool, args -> send(test, {:audit, tool, args}) end
+    }
+  end
+
+  describe "protocol" do
+    test "initialize advertises tools capability and protocol version" do
+      resp = Mcp.handle(%{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize"}, ctx())
+      assert resp["id"] == 1
+      assert resp["result"].capabilities.tools == %{}
+      assert is_binary(resp["result"].protocolVersion)
+      assert resp["result"].serverInfo.name == "fountain-buzz"
+    end
+
+    test "tools/list returns send_message and react" do
+      resp = Mcp.handle(%{"id" => 2, "method" => "tools/list"}, ctx())
+      names = Enum.map(resp["result"].tools, & &1.name)
+      assert "buzz_send_message" in names
+      assert "buzz_react" in names
+    end
+
+    test "a notification gets no reply" do
+      assert Mcp.handle(%{"method" => "notifications/initialized"}, ctx()) == :noreply
+    end
+
+    test "an unknown method is a JSON-RPC method-not-found error" do
+      resp = Mcp.handle(%{"id" => 9, "method" => "does/not/exist"}, ctx())
+      assert resp["error"]["code"] == -32_601
+    end
+  end
+
+  describe "buzz_send_message" do
+    test "shells out with channel + content, credentials in env not argv" do
+      req = %{
+        "id" => 3,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "buzz_send_message",
+          "arguments" => %{"channel" => "chan-1", "content" => "hello there"}
+        }
+      }
+
+      resp = Mcp.handle(req, ctx())
+
+      assert_received {:exec, "/fake/buzz", argv, env}
+      assert argv == ["messages", "send", "--channel", "chan-1", "--content", "hello there"]
+      # The nsec travels in the environment, never in the argv the process list shows.
+      assert {"BUZZ_PRIVATE_KEY", "nsec1secret"} in env
+      refute Enum.any?(argv, &String.contains?(&1, "nsec1"))
+
+      assert resp["result"].isError == false
+      assert [%{type: "text", text: out}] = resp["result"].content
+      assert out =~ "accepted"
+      assert_received {:audit, "buzz_send_message", _}
+    end
+
+    test "threads a reply when reply_to is given" do
+      req = %{
+        "id" => 4,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "buzz_send_message",
+          "arguments" => %{"channel" => "c", "content" => "re", "reply_to" => "evt-1"}
+        }
+      }
+
+      Mcp.handle(req, ctx())
+      assert_received {:exec, _, argv, _}
+      assert Enum.chunk_every(argv, 1) |> List.flatten() |> Enum.member?("--reply-to")
+      assert "evt-1" in argv
+    end
+
+    test "missing content is a tool error, not a crash, and does not shell out" do
+      req = %{
+        "id" => 5,
+        "method" => "tools/call",
+        "params" => %{"name" => "buzz_send_message", "arguments" => %{"channel" => "c"}}
+      }
+
+      resp = Mcp.handle(req, ctx())
+      assert resp["result"].isError == true
+      refute_received {:exec, _, _, _}
+    end
+
+    test "a nonzero buzz exit surfaces as a tool error carrying the output" do
+      req = %{
+        "id" => 6,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "buzz_send_message",
+          "arguments" => %{"channel" => "c", "content" => "x"}
+        }
+      }
+
+      resp = Mcp.handle(req, ctx({"relay error 403", 3}))
+      assert resp["result"].isError == true
+      assert [%{text: out}] = resp["result"].content
+      assert out =~ "403"
+      # A failed publish must not audit.
+      refute_received {:audit, _, _}
+    end
+  end
+
+  describe "buzz_react" do
+    test "shells out with event + emoji" do
+      req = %{
+        "id" => 7,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "buzz_react",
+          "arguments" => %{"event" => "evt-9", "emoji" => "👍"}
+        }
+      }
+
+      resp = Mcp.handle(req, ctx())
+      assert_received {:exec, _, ["reactions", "add", "--event", "evt-9", "--emoji", "👍"], _}
+      assert resp["result"].isError == false
+    end
+  end
+end


### PR DESCRIPTION
Gate 3b, step 1 — the protocol/tool core of the Fountain-hosted MCP server. Transport (HTTP endpoint) and wiring (inject into `session/new` + base-prompt override) follow in the next PRs.

## What's here
`Fountain.Buzz.Mcp` handles JSON-RPC 2.0 — `initialize`, `tools/list`, `tools/call`, `ping`, notifications — and executes the two first-cut tools:
- **`buzz_send_message`** (channel, content, optional reply_to) — the agent's reply
- **`buzz_react`** (event, emoji)

It runs them by shelling out to the baked `buzz` CLI (#749) with the `BUZZ_*` credentials **in the environment, never in argv**, and no shell (args as a list), so message content can't inject a command. A failed publish surfaces as an MCP `isError` result — the model sees it and can recover — and does **not** audit; a successful one calls the ctx audit hook.

## Design
Pure and injectable: `ctx.exec` defaults to `System.cmd` but tests supply a fake, so the tool logic is covered without a real key or `buzz` binary. The nsec resolution and HTTP transport live above this layer (next PRs), keeping the tools testable in isolation.

**The nsec never leaves the server** — that's the whole point of the reply path: the sandbox calls a tool, Fountain signs and publishes.

9 tests (incl. credentials-in-env-not-argv, missing-arg is a tool error not a crash, failed-publish doesn't audit). Format / credo --strict / compile --warnings-as-errors clean.

## Next
3b-2: the `POST /api/mcp/buzz/:conversation_id` Streamable-HTTP endpoint (resolves conv → BuzzIdentity → vault → nsec, builds ctx). 3b-3: inject into `session/new` for Buzz-driven conversations + base-prompt override. Then live test against a sprite. Refs #735 #737.