### PR TITLE
feat(buzz): HTTP MCP endpoint for the reply path (#737)

### DIFF
--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -45,6 +45,16 @@ defmodule Fountain.Buzz do
   end
 
   @doc """
+  Fetch the identity that drives a given vault, scoped to a user. This is how
+  a Buzz-driven conversation is recognised: the hosted harness runs
+  `fountain acp --agent … --vault <vault>`, so its conversations carry that
+  vault. Returns nil if the vault is not a Buzz identity vault (or not owned).
+  """
+  def get_identity_by_vault(vault_id, user_id) when is_binary(vault_id) and is_binary(user_id) do
+    Repo.get_by(BuzzIdentity, vault_id: vault_id, user_id: user_id)
+  end
+
+  @doc """
   Create a Buzz identity. `attrs` must carry `user_id`, `agent_id`, `vault_id`,
   `name` and `relay_url`. Records `buzz_identity.created`.
   """

--- a/apps/fountain/lib/fountain_web/controllers/buzz_mcp_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_mcp_controller.ex
@@ -1,0 +1,90 @@
+defmodule FountainWeb.BuzzMcpController do
+  @moduledoc """
+  The MCP endpoint a hosted Buzz agent's sandbox calls to post to its channel
+  (ADR 0020 Phase 2, gate #737). Streamable-HTTP transport: one JSON-RPC message
+  per POST, a JSON response back (or 202 for a notification).
+
+  The sandbox authenticates with its sprite token (already in it, so no new
+  secret leaves the server). This controller verifies the conversation is
+  Buzz-driven, resolves the agent's Nostr key **server-side** from the identity's
+  vault, and hands `Fountain.Buzz.Mcp` a context that shells out to the baked
+  `buzz` CLI — the nsec never enters the sandbox.
+  """
+  use FountainWeb, :controller
+
+  alias Fountain.{Audit, Buzz, Conversations, Crypto, Vaults}
+  alias Fountain.Buzz.Mcp
+
+  @default_buzz_bin "/usr/local/lib/fountain-buzz/buzz"
+
+  def handle(conn, %{"conversation_id" => conv_id}) do
+    user = conn.assigns.current_user
+
+    case build_ctx(conv_id, user) do
+      {:ok, ctx} ->
+        case Mcp.handle(conn.body_params, ctx) do
+          :noreply -> send_resp(conn, 202, "")
+          resp -> json(conn, resp)
+        end
+
+      {:error, status, message} ->
+        conn |> put_status(status) |> json(%{error: message})
+    end
+  end
+
+  # Resolve conversation → Buzz identity → vault → nsec, all scoped to the caller.
+  defp build_ctx(conv_id, user) do
+    with %Conversations.Conversation{} = conv <- get_conv(conv_id, user),
+         %Buzz.BuzzIdentity{} = identity <- get_identity(conv, user),
+         %Vaults.Vault{} = vault <- get_vault(identity, user),
+         {:ok, dek} <- Crypto.load_tenant_key(user.id) do
+      env =
+        vault
+        |> Vaults.decrypted_env(dek)
+        |> Enum.filter(fn {k, _} -> String.starts_with?(k, "BUZZ_") end)
+
+      {:ok, %{buzz_bin: buzz_bin(), env: env, audit: audit_fn(identity, user)}}
+    else
+      {:error, _, _} = err -> err
+      :no_conv -> {:error, 404, "conversation not found"}
+      :not_buzz -> {:error, 404, "not a buzz conversation"}
+      :no_vault -> {:error, 404, "buzz vault not found"}
+      _ -> {:error, 500, "could not resolve the buzz identity"}
+    end
+  end
+
+  defp get_conv(conv_id, user),
+    do: Conversations.get_conversation(conv_id, user.id) || :no_conv
+
+  defp get_identity(%{vault_id: nil}, _user), do: :not_buzz
+
+  defp get_identity(%{vault_id: vault_id}, user),
+    do: Buzz.get_identity_by_vault(vault_id, user.id) || :not_buzz
+
+  defp get_vault(%Buzz.BuzzIdentity{vault_id: vault_id}, user),
+    do: Vaults.get_vault(vault_id, user.id) || :no_vault
+
+  # The publish is an effect, not a tenant-state mutation, so it is audited here
+  # rather than in a context. Records what happened and where — never the message
+  # content (ADR 0013).
+  defp audit_fn(identity, user) do
+    fn tool, args ->
+      Audit.record(%{
+        user_id: user.id,
+        action: "buzz.published",
+        resource_type: "buzz_identity",
+        resource_id: identity.id,
+        actor: "sprite",
+        metadata:
+          %{"tool" => tool}
+          |> put_present("channel", args["channel"])
+          |> put_present("event", args["event"])
+      })
+    end
+  end
+
+  defp put_present(map, _k, nil), do: map
+  defp put_present(map, k, v), do: Map.put(map, k, v)
+
+  defp buzz_bin, do: Application.get_env(:fountain, :buzz_cli_bin, @default_buzz_bin)
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -285,6 +285,11 @@ defmodule FountainWeb.Router do
     # The tenant's own trail (#526). Cross-tenant listing is an admin concern.
     get "/audit", AuditController, :index
 
+    # MCP tools a hosted Buzz agent's sandbox calls to post to its channel
+    # (ADR 0020, #737). One JSON-RPC message per POST; the nsec is resolved
+    # server-side and never enters the sandbox.
+    post "/mcp/buzz/:conversation_id", BuzzMcpController, :handle
+
     resources "/environments", EnvironmentController, except: [:new, :edit] do
       resources "/secrets", SecretController, only: [:index, :create, :delete]
     end

--- a/apps/fountain/test/fountain_web/api_spec_test.exs
+++ b/apps/fountain/test/fountain_web/api_spec_test.exs
@@ -54,7 +54,11 @@ defmodule FountainWeb.ApiSpecTest do
       {"/api/stripe/webhook", :post},
       # A browser-session route that happens to live under /api/ — CSRF-
       # protected, session-authenticated, and driven by the theme toggle.
-      {"/api/settings/theme", :patch}
+      {"/api/settings/theme", :patch},
+      # A JSON-RPC 2.0 (MCP) endpoint, not a REST operation: its body is a
+      # polymorphic MCP message, and its caller is a sandboxed agent's MCP
+      # client, which discovers tools via `tools/list`, not our OpenAPI spec.
+      {"/api/mcp/buzz/{conversation_id}", :post}
     ]
 
     setup do

--- a/apps/fountain/test/fountain_web/controllers/buzz_mcp_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/buzz_mcp_controller_test.exs
@@ -1,0 +1,115 @@
+defmodule FountainWeb.BuzzMcpControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.{Crypto, Vaults}
+
+  setup do
+    user = insert_verified_user()
+    {_rec, raw_key} = insert_api_key(user)
+    %{user: user, raw_key: raw_key}
+  end
+
+  # A conversation whose vault is a BuzzIdentity vault → a "buzz-driven" conv.
+  defp buzz_conversation(user) do
+    agent = insert_agent(user_id: user.id)
+    vault = insert_vault(user_id: user.id)
+    {:ok, dek} = Crypto.load_tenant_key(user.id)
+
+    {:ok, _} =
+      Vaults.upsert_secret(vault, %{"key" => "BUZZ_PRIVATE_KEY", "value" => "nsec1x"}, dek)
+
+    insert_buzz_identity(%{"user_id" => user.id, "agent_id" => agent.id, "vault_id" => vault.id})
+    insert_conversation(user_id: user.id, agent_id: agent.id, vault_id: vault.id)
+  end
+
+  defp rpc(conn, raw_key, conv_id, body) do
+    conn
+    |> authed_with_key(raw_key)
+    |> put_req_header("content-type", "application/json")
+    |> post("/api/mcp/buzz/#{conv_id}", body)
+  end
+
+  test "initialize on a buzz conversation returns the server info", %{
+    conn: conn,
+    user: user,
+    raw_key: raw_key
+  } do
+    conv = buzz_conversation(user)
+    conn = rpc(conn, raw_key, conv.id, %{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize"})
+
+    body = json_response(conn, 200)
+    assert body["result"]["serverInfo"]["name"] == "fountain-buzz"
+  end
+
+  test "tools/list advertises the reply tools", %{conn: conn, user: user, raw_key: raw_key} do
+    conv = buzz_conversation(user)
+    conn = rpc(conn, raw_key, conv.id, %{"id" => 2, "method" => "tools/list"})
+
+    names = json_response(conn, 200)["result"]["tools"] |> Enum.map(& &1["name"])
+    assert "buzz_send_message" in names
+    assert "buzz_react" in names
+  end
+
+  test "tools/call shells out to the configured buzz and audits", %{
+    conn: conn,
+    user: user,
+    raw_key: raw_key
+  } do
+    # Point the controller at a fake `buzz` that echoes JSON, so the full path
+    # (controller → Mcp → System.cmd) runs without the real binary.
+    dir = Path.join(System.tmp_dir!(), "buzzbin-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    fake = Path.join(dir, "buzz")
+    File.write!(fake, "#!/bin/sh\necho '{\"accepted\":true,\"event_id\":\"e1\"}'\n")
+    File.chmod!(fake, 0o755)
+    prev = Application.get_env(:fountain, :buzz_cli_bin)
+    Application.put_env(:fountain, :buzz_cli_bin, fake)
+
+    on_exit(fn ->
+      if prev,
+        do: Application.put_env(:fountain, :buzz_cli_bin, prev),
+        else: Application.delete_env(:fountain, :buzz_cli_bin)
+
+      File.rm_rf(dir)
+    end)
+
+    conv = buzz_conversation(user)
+
+    body = %{
+      "id" => 3,
+      "method" => "tools/call",
+      "params" => %{
+        "name" => "buzz_send_message",
+        "arguments" => %{"channel" => "chan-1", "content" => "hi from the agent"}
+      }
+    }
+
+    conn = rpc(conn, raw_key, conv.id, body)
+    result = json_response(conn, 200)["result"]
+    assert result["isError"] == false
+    assert [%{"type" => "text", "text" => out}] = result["content"]
+    assert out =~ "accepted"
+
+    actions = Fountain.Audit.list_recent_for_user(user.id, 50) |> Enum.map(& &1.action)
+    assert "buzz.published" in actions
+  end
+
+  test "a notification gets 202 and no body", %{conn: conn, user: user, raw_key: raw_key} do
+    conv = buzz_conversation(user)
+    conn = rpc(conn, raw_key, conv.id, %{"method" => "notifications/initialized"})
+    assert response(conn, 202) == ""
+  end
+
+  test "a non-buzz conversation is 404", %{conn: conn, user: user, raw_key: raw_key} do
+    plain = insert_conversation(user_id: user.id)
+    conn = rpc(conn, raw_key, plain.id, %{"id" => 1, "method" => "initialize"})
+    assert json_response(conn, 404)["error"] =~ "buzz"
+  end
+
+  test "another tenant's conversation is 404 (tenant scoping)", %{conn: conn, raw_key: raw_key} do
+    other = insert_verified_user()
+    conv = buzz_conversation(other)
+    conn = rpc(conn, raw_key, conv.id, %{"id" => 1, "method" => "initialize"})
+    assert json_response(conn, 404)
+  end
+end


### PR DESCRIPTION
Gate 3b, step 2 — the transport. `POST /api/mcp/buzz/:conversation_id` (Streamable HTTP) is where a hosted Buzz agent's sandbox calls the `buzz_*` tools from #750.

## How it works
- The sandbox authenticates with **its sprite token** (already in it → no new secret leaves the server).
- The controller verifies the conversation is **Buzz-driven** — recognised by its vault (the harness runs `fountain acp --agent … --vault`, so its conversations carry that vault) — and tenant-scopes everything.
- It resolves the agent's Nostr key **server-side** from the identity's vault and hands `Fountain.Buzz.Mcp` a ctx that shells out to the baked `buzz` CLI. **The nsec never enters the sandbox.**
- One JSON-RPC message per POST → JSON response (or `202` for a notification).
- A successful post audits `buzz.published` (actor `sprite`) with the tool + channel/event — never the message content (ADR 0013).

## Tested end to end
Controller → Mcp → `System.cmd` against a fake `buzz`: initialize, tools/list, a real tools/call that audits, notification → 202, non-buzz conversation → 404, cross-tenant → 404. 38 buzz tests, 0 failures; format / credo --strict / sobelow / compile --warnings-as-errors clean.

## Next
3b-3: inject this MCP server into `session/new` for Buzz-driven conversations (with the sprite token as the auth header) + the base-prompt override that tells the model to use the tools. Then the live sprite test. Refs #735 #737.