### PR TITLE
feat(buzz): give the sandboxed agent the reply tools (#737)

### DIFF
--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -17,7 +17,7 @@ defmodule Fountain.Buzz do
 
   import Ecto.Query, only: [from: 2]
 
-  alias Fountain.{Accounts, Audit, Crypto, Repo, Vaults}
+  alias Fountain.{Accounts, Audit, Conversations, Crypto, Repo, Vaults}
   alias Fountain.Buzz.BuzzIdentity
 
   # ── identities (tenant-scoped) ─────────────────────────────────────────────
@@ -52,6 +52,44 @@ defmodule Fountain.Buzz do
   """
   def get_identity_by_vault(vault_id, user_id) when is_binary(vault_id) and is_binary(user_id) do
     Repo.get_by(BuzzIdentity, vault_id: vault_id, user_id: user_id)
+  end
+
+  @doc """
+  The MCP server entries to inject into a conversation's `session/new` so the
+  sandboxed agent can post to its channel (gate #737). Returns `[]` unless the
+  conversation is Buzz-driven (its vault belongs to a BuzzIdentity); otherwise a
+  one-element list pointing the agent's MCP client at Fountain's buzz endpoint,
+  authenticated with the conversation's own sprite `token`.
+
+  Ownership: a system-level call from `ConversationServer`, which established
+  ownership of the conversation at provision; the `_unsafe_` fetch is scoped
+  again by the `get_identity_by_vault` that follows.
+  """
+  def conversation_mcp_servers(conversation_id, token)
+      when is_binary(conversation_id) and is_binary(token) and token != "" do
+    with %Conversations.Conversation{vault_id: vid, user_id: uid}
+         when is_binary(vid) <- fetch_conv(conversation_id),
+         %BuzzIdentity{} <- get_identity_by_vault(vid, uid) do
+      [
+        %{
+          name: "fountain-buzz",
+          type: "http",
+          url: Fountain.PublicUrl.base() <> "/api/mcp/buzz/" <> conversation_id,
+          headers: [%{name: "Authorization", value: "Bearer " <> token}]
+        }
+      ]
+    else
+      _ -> []
+    end
+  end
+
+  def conversation_mcp_servers(_conversation_id, _token), do: []
+
+  # A malformed id must yield [] (no tools), not a crash — the cast raises.
+  defp fetch_conv(conversation_id) do
+    Conversations._unsafe_get_conversation(conversation_id)
+  rescue
+    Ecto.Query.CastError -> nil
   end
 
   @doc """
@@ -219,13 +257,21 @@ defmodule Fountain.Buzz do
     %{
       "BUZZ_ACP_AGENT_COMMAND" => fountain_bin,
       "BUZZ_ACP_AGENT_ARGS" => args,
-      "BUZZ_ACP_AGENTS" => Integer.to_string(agents)
+      "BUZZ_ACP_AGENTS" => Integer.to_string(agents),
+      # Steer the model to the Fountain-hosted buzz_* MCP tools (which sign
+      # server-side) instead of a `buzz` CLI it has no key for (#737).
+      "BUZZ_ACP_BASE_PROMPT_FILE" => base_prompt_file()
     }
   end
 
   # The ACP child authenticates back to this instance with the minted key.
   defp fountain_child_env(raw_key, base_url) do
     %{"FOUNTAIN_API_KEY" => raw_key, "FOUNTAIN_BASE_URL" => base_url}
+  end
+
+  defp base_prompt_file do
+    Application.get_env(:fountain, :buzz_base_prompt_file) ||
+      Application.app_dir(:fountain, "priv/buzz-base-prompt.md")
   end
 
   defp maybe_put(map, _key, nil), do: map

--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -87,6 +87,9 @@ defmodule Fountain.Buzz do
 
   # A malformed id must yield [] (no tools), not a crash — the cast raises.
   defp fetch_conv(conversation_id) do
+    # ownership: system-level call from ConversationServer, which owns the
+    # conversation; the identity fetched next is re-scoped by user_id, and the
+    # result only ever authorises publishing under that same tenant's key.
     Conversations._unsafe_get_conversation(conversation_id)
   rescue
     Ecto.Query.CastError -> nil

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1771,6 +1771,16 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
+  # The Buzz reply tools (#737), injected into `session/new` only for a
+  # Buzz-driven conversation and only once a callback token has been minted —
+  # `Fountain.Buzz` decides both. `[]` for every other conversation.
+  defp buzz_mcp_servers(%{callback_token: token, conversation_id: conv_id})
+       when is_binary(token) and is_binary(conv_id) do
+    Fountain.Buzz.conversation_mcp_servers(conv_id, token)
+  end
+
+  defp buzz_mcp_servers(_state), do: []
+
   # How long a sprite's callback key stays valid.
   #
   # This is a backstop, not the primary control: the key is revoked at
@@ -2055,7 +2065,9 @@ defmodule Fountain.Conversations.ConversationServer do
                   start_acp_peer(command, prompt, mode, runtime_session_id,
                     cwd: cwd,
                     images: images,
-                    mcp_servers: Fountain.Runtimes.ACP.mcp_servers(agent),
+                    mcp_servers:
+                      Fountain.Runtimes.ACP.mcp_servers(agent) ++
+                        buzz_mcp_servers(state),
                     model: agent && Fountain.Runtimes.Model.id(agent.model)
                   )
                 else

--- a/apps/fountain/priv/buzz-base-prompt.md
+++ b/apps/fountain/priv/buzz-base-prompt.md
@@ -1,0 +1,15 @@
+# Posting to the channel
+
+You are an agent in a Buzz channel. Nothing you say is published automatically —
+the only way your words reach the channel is by calling a tool.
+
+- To reply, call **buzz_send_message** with the channel id and your message. To
+  reply in a thread, also pass the id of the message you are replying to.
+- To acknowledge or react, call **buzz_react** with the event id and an emoji.
+
+Do not try to run a shell or a `buzz` command line: you hold no credentials and
+have no network to the relay. The tools above are the only way to publish; they
+sign and send on your behalf.
+
+The channel id, and the id of the message you are replying to, are in the
+`[Context]` and `[Buzz event: …]` sections of your prompt. Keep replies concise.

--- a/apps/fountain/test/fountain/buzz_test.exs
+++ b/apps/fountain/test/fountain/buzz_test.exs
@@ -88,6 +88,39 @@ defmodule Fountain.BuzzTest do
     end
   end
 
+  describe "conversation_mcp_servers/2" do
+    test "returns the buzz MCP entry for a Buzz-driven conversation" do
+      user = insert_verified_user()
+      agent = insert_agent(%{"user_id" => user.id})
+      vault = insert_vault(%{"user_id" => user.id})
+
+      insert_buzz_identity(%{
+        "user_id" => user.id,
+        "agent_id" => agent.id,
+        "vault_id" => vault.id
+      })
+
+      conv = insert_conversation(user_id: user.id, agent_id: agent.id, vault_id: vault.id)
+
+      assert [entry] = Buzz.conversation_mcp_servers(conv.id, "sprite-tok")
+      assert entry.name == "fountain-buzz"
+      assert entry.type == "http"
+      assert entry.url =~ "/api/mcp/buzz/#{conv.id}"
+      assert [%{name: "Authorization", value: "Bearer sprite-tok"}] = entry.headers
+    end
+
+    test "returns [] for a non-Buzz conversation" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      assert Buzz.conversation_mcp_servers(conv.id, "tok") == []
+    end
+
+    test "returns [] for an unknown conversation or blank token" do
+      assert Buzz.conversation_mcp_servers("00000000-0000-0000-0000-000000000000", "tok") == []
+      assert Buzz.conversation_mcp_servers("x", "") == []
+    end
+  end
+
   describe "harness_launch/2" do
     setup do
       user = insert_verified_user()
@@ -143,6 +176,7 @@ defmodule Fountain.BuzzTest do
       assert env["BUZZ_ACP_AGENT_COMMAND"] == "/usr/local/bin/fountain"
       assert env["BUZZ_ACP_AGENT_ARGS"] == "acp,--agent,#{agent.id},--vault,#{vault.id}"
       assert env["BUZZ_ACP_AGENTS"] == "1"
+      assert env["BUZZ_ACP_BASE_PROMPT_FILE"] =~ "buzz-base-prompt.md"
 
       # The child authenticates back with a freshly minted key.
       assert env["FOUNTAIN_BASE_URL"] == "https://fountain.example"


### PR DESCRIPTION
Gate 3b, step 3 — the last wiring. This connects the tool layer (#750) and endpoint (#751) to the agent: inject the buzz MCP server into a Buzz-driven conversation's `session/new`, and steer the model to use it.

## What's here
- **`Fountain.Buzz.conversation_mcp_servers/2`** — returns the buzz MCP entry (`type: http`, `url: <public>/api/mcp/buzz/<conv>`, `Authorization: <sprite token>`) when the conversation's vault belongs to a BuzzIdentity; `[]` otherwise. A malformed id yields `[]`, not a crash.
- **`ConversationServer`** appends it to the ACP `mcp_servers` at `session/new`, only once a callback token is minted — so a normal (non-Buzz) conversation is completely unaffected (`[]`).
- **`harness_launch`** sets `BUZZ_ACP_BASE_PROMPT_FILE` → `priv/buzz-base-prompt.md`, which tells the model to call `buzz_send_message` / `buzz_react` (Fountain signs server-side) instead of a `buzz` CLI it has no key for.

## The chain is now complete
```
sandbox agent → buzz_* MCP tool → POST /api/mcp/buzz/<conv> → server-side signed publish → channel
```
with the nsec never leaving the server.

71 buzz + 265 conversation-server tests, 0 failures (the hot-path injection is guarded and covered); format / credo / sobelow / warnings-as-errors clean.

## Next: live verification
Once this deploys, drive a real Buzz-driven conversation and confirm the hosted agent actually **posts to the channel** via the tool — the end-to-end proof of the whole reply path. Refs #735 #737.