### PR TITLE
feat(buzz): REST API for hosted Buzz agents (#738)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
@@ -1,0 +1,117 @@
+defmodule FountainWeb.BuzzAgentController do
+  @moduledoc """
+  Provision and manage hosted Buzz agents over the API (ADR 0020 Phase 3, #738).
+
+  This is the Fountain-side surface the `buzz-backend-fountain` remote-agents
+  provider calls: `create` maps onto a provider `deploy` (idempotent on the
+  Nostr pubkey), and `delete` tears the hosted agent down. The Nostr secret key
+  is accepted on `create` and stored server-side in the identity's vault; it is
+  never returned and never enters a sandbox.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Buzz
+  alias Fountain.Buzz.{BuzzIdentity, Manager}
+  alias Fountain.Vaults
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Buzz"])
+
+  operation(:index,
+    summary: "List hosted Buzz agents",
+    responses: [ok: {"Buzz agents", "application/json", Schemas.BuzzIdentityListResponse}]
+  )
+
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    json(conn, %{data: Enum.map(Buzz.list_identities(user.id), &identity_json/1)})
+  end
+
+  operation(:create,
+    summary: "Provision (or converge on) a hosted Buzz agent",
+    request_body: {"Provision attributes", "application/json", Schemas.BuzzProvisionRequest},
+    responses: [
+      created: {"Buzz agent", "application/json", Schemas.BuzzIdentityResponse},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
+    ]
+  )
+
+  def create(conn, params) do
+    user = conn.assigns.current_user
+
+    attrs =
+      Map.take(params, ~w(name relay_url agent_id pubkey private_key_nsec auth_tag display_name))
+
+    case Buzz.provision_identity(user.id, attrs, actor: "api") do
+      {:ok, %BuzzIdentity{} = identity} ->
+        # Best-effort eager start so a provider `deploy` sees it running; the
+        # boot sweep also stands enabled identities up, so this is not load-bearing.
+        _ = Manager.start_harness(identity)
+
+        conn
+        |> put_status(:created)
+        |> json(%{data: identity_json(identity)})
+
+      {:error, {:missing, fields}} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "missing required fields: #{Enum.join(fields, ", ")}"})
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "could not provision the buzz agent"})
+    end
+  end
+
+  operation(:delete,
+    summary: "Tear down a hosted Buzz agent",
+    parameters: [id: [in: :path, type: :string, description: "Buzz agent id"]],
+    responses: [
+      no_content: "Deleted",
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case Buzz.get_identity(id, user.id) do
+      %BuzzIdentity{} = identity ->
+        Manager.stop_harness(identity.id)
+        {:ok, _} = Buzz.delete_identity(identity, actor: "api")
+        delete_vault(identity, user.id)
+        send_resp(conn, :no_content, "")
+
+      nil ->
+        conn |> put_status(:not_found) |> json(%{error: "not found"})
+    end
+  end
+
+  defp delete_vault(%BuzzIdentity{vault_id: vault_id}, user_id) do
+    case Vaults.get_vault(vault_id, user_id) do
+      %Vaults.Vault{} = vault -> Vaults.delete_vault(vault, actor: "api")
+      _ -> :ok
+    end
+  end
+
+  defp identity_json(%BuzzIdentity{} = i) do
+    %{
+      id: i.id,
+      name: i.name,
+      display_name: i.display_name,
+      relay_url: i.relay_url,
+      pubkey: i.pubkey,
+      agent_id: i.agent_id,
+      vault_id: i.vault_id,
+      enabled: i.enabled,
+      inserted_at: i.inserted_at,
+      updated_at: i.updated_at
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -300,6 +300,10 @@ defmodule FountainWeb.Router do
 
     resources "/agents", AgentController, except: [:new, :edit]
 
+    # Hosted Buzz agents (ADR 0020, #738). `create` is the Fountain side of a
+    # remote-agents provider deploy — idempotent on the Nostr pubkey.
+    resources "/buzz/agents", BuzzAgentController, only: [:index, :create, :delete]
+
     # Bulk apply for compiled fountain.yml manifests (`fountain apply`).
     post "/apply", ApplyController, :create
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -355,6 +355,66 @@ defmodule FountainWeb.Schemas do
 
   list_response(AgentListResponse, of: Agent)
 
+  defmodule BuzzIdentity do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "BuzzIdentity",
+      description:
+        "A hosted Buzz agent: a Nostr identity (key held server-side in a vault) " <>
+          "bound to a Fountain agent. Its harness runs on the gateway (ADR 0020).",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        name: %Schema{type: :string},
+        display_name: %Schema{type: :string, nullable: true},
+        relay_url: %Schema{type: :string, description: "wss:// relay URL"},
+        pubkey: %Schema{type: :string, description: "Nostr public key (hex)", nullable: true},
+        agent_id: %Schema{type: :string, format: :uuid},
+        vault_id: %Schema{type: :string, format: :uuid},
+        enabled: %Schema{type: :boolean},
+        inserted_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :name, :agent_id, :vault_id, :enabled]
+    })
+  end
+
+  defmodule BuzzProvisionRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "BuzzProvisionRequest",
+      description:
+        "Provision (or converge on) a hosted Buzz agent. The Nostr secret key is " <>
+          "accepted here and stored server-side in the identity's vault; it is never " <>
+          "returned and never enters a sandbox. Idempotent on `pubkey`.",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, minLength: 1, maxLength: 200},
+        relay_url: %Schema{type: :string, description: "wss:// relay URL"},
+        agent_id: %Schema{type: :string, format: :uuid, description: "The Fountain agent to run"},
+        pubkey: %Schema{
+          type: :string,
+          description: "Nostr public key (hex) — the convergence key"
+        },
+        private_key_nsec: %Schema{
+          type: :string,
+          description: "Nostr secret key (nsec/hex). Stored, never returned"
+        },
+        auth_tag: %Schema{type: :string, description: "NIP-OA owner attestation tag (JSON array)"},
+        display_name: %Schema{type: :string, nullable: true}
+      },
+      required: [:name, :relay_url, :agent_id, :pubkey, :private_key_nsec, :auth_tag]
+    })
+  end
+
+  item_response(BuzzIdentityResponse, of: BuzzIdentity)
+
+  list_response(BuzzIdentityListResponse, of: BuzzIdentity)
+
   defmodule AgentRequest do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
@@ -1,0 +1,114 @@
+defmodule FountainWeb.BuzzAgentControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.{Crypto, Vaults}
+
+  setup do
+    user = insert_verified_user()
+    {_rec, raw_key} = insert_api_key(user)
+    agent = insert_agent(user_id: user.id)
+    %{user: user, raw_key: raw_key, agent: agent}
+  end
+
+  defp params(agent) do
+    %{
+      "name" => "philo",
+      "relay_url" => "wss://relay.example",
+      "agent_id" => agent.id,
+      "pubkey" => String.duplicate("a", 64),
+      "private_key_nsec" => "nsec1secret",
+      "auth_tag" => ~s(["auth","owner"])
+    }
+  end
+
+  test "POST provisions a hosted Buzz agent and never returns the nsec", %{
+    conn: conn,
+    user: user,
+    raw_key: raw_key,
+    agent: agent
+  } do
+    conn =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", params(agent))
+
+    data = json_response(conn, 201)["data"]
+    assert data["name"] == "philo"
+    assert data["enabled"] == true
+    assert data["agent_id"] == agent.id
+    refute json_response(conn, 201) |> inspect() =~ "nsec1secret"
+
+    # The key landed in the vault, server-side.
+    {:ok, dek} = Crypto.load_tenant_key(user.id)
+    vault = Vaults.get_vault(data["vault_id"], user.id)
+    assert Vaults.decrypted_env(vault, dek)["BUZZ_PRIVATE_KEY"] == "nsec1secret"
+  end
+
+  test "POST is idempotent on the pubkey (converge)", %{
+    conn: conn,
+    raw_key: raw_key,
+    agent: agent
+  } do
+    first =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", params(agent))
+      |> json_response(201)
+
+    second =
+      build_conn()
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", params(agent))
+      |> json_response(201)
+
+    assert first["data"]["id"] == second["data"]["id"]
+  end
+
+  test "GET lists the tenant's Buzz agents", %{conn: conn, raw_key: raw_key, agent: agent} do
+    build_conn()
+    |> authed_with_key(raw_key)
+    |> put_req_header("content-type", "application/json")
+    |> post("/api/buzz/agents", params(agent))
+
+    data = conn |> authed_with_key(raw_key) |> get("/api/buzz/agents") |> json_response(200)
+    assert Enum.any?(data["data"], &(&1["name"] == "philo"))
+  end
+
+  test "DELETE tears it down (identity and vault gone)", %{
+    conn: conn,
+    user: user,
+    raw_key: raw_key,
+    agent: agent
+  } do
+    created =
+      build_conn()
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", params(agent))
+      |> json_response(201)
+
+    id = created["data"]["id"]
+    vault_id = created["data"]["vault_id"]
+
+    conn |> authed_with_key(raw_key) |> delete("/api/buzz/agents/#{id}") |> response(204)
+
+    assert Fountain.Buzz.get_identity(id, user.id) == nil
+    assert Vaults.get_vault(vault_id, user.id) == nil
+  end
+
+  test "missing required fields is a 422", %{conn: conn, raw_key: raw_key, agent: agent} do
+    bad = Map.delete(params(agent), "private_key_nsec")
+
+    conn =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", bad)
+
+    # OpenApiSpex CastAndValidate rejects the missing required field before the action.
+    assert conn.status in [422, 400]
+  end
+end


### PR DESCRIPTION
Gate 4, step 2 — the API surface over `provision_identity/2` (#753). This is what the `buzz-backend-fountain` provider (and any Fountain-native caller) uses to stand up and tear down a hosted Buzz agent.

## Endpoints (`/api/buzz/agents`)
- **POST** — provision / converge (idempotent on the Nostr pubkey). The nsec is accepted, **stored server-side in the identity's vault, and never returned**. Best-effort eager harness start so a provider `deploy` sees it running.
- **GET** — list the tenant's hosted agents.
- **DELETE /:id** — stop the harness, delete the identity and its vault.

OpenApiSpex-spec'd (`BuzzIdentity` + `BuzzProvisionRequest` schemas) so the #571 route-parity guard passes and the spec validates.

17 tests: provision, converge (same id, no dup), list, delete (identity + vault gone), missing-field → 422, and **the response never contains the nsec**. Format / full `mix credo` / sobelow / `openapi.spec.json` validate all clean.

## Next: the provider binary
`buzz-backend-fountain` in `cli/` — `info` (protocol_version 1 + config_schema) and `deploy` (maps the remote-agents payload onto `POST /api/buzz/agents`, refusing no-owner and relay-mesh per the spec). Then conformance to block/buzz's [L1]/[L2] checklist. Refs #735 #738.