### PR TITLE
fix(buzz): set BUZZ_ACP_RELAY_OBSERVER so the desktop's ACP activity panel populates

### DIFF
--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -362,7 +362,12 @@ defmodule Fountain.Buzz do
       "BUZZ_ACP_AGENTS" => Integer.to_string(agents),
       # Steer the model to the Fountain-hosted buzz_* MCP tools (which sign
       # server-side) instead of a `buzz` CLI it has no key for (#737).
-      "BUZZ_ACP_BASE_PROMPT_FILE" => base_prompt_file()
+      "BUZZ_ACP_BASE_PROMPT_FILE" => base_prompt_file(),
+      # Mirror every ACP frame as NIP-44 kind-24200 telemetry encrypted to the
+      # owner, so the Buzz desktop's "ACP activity" panel shows the agent's work.
+      # The desktop sets this when it spawns buzz-acp itself; a gateway-hosted
+      # harness must too, or the panel stays empty.
+      "BUZZ_ACP_RELAY_OBSERVER" => "true"
     }
   end
 

--- a/apps/fountain/test/fountain/buzz_test.exs
+++ b/apps/fountain/test/fountain/buzz_test.exs
@@ -242,6 +242,7 @@ defmodule Fountain.BuzzTest do
       assert env["BUZZ_ACP_AGENT_ARGS"] == "acp,--agent,#{agent.id},--vault,#{vault.id}"
       assert env["BUZZ_ACP_AGENTS"] == "1"
       assert env["BUZZ_ACP_BASE_PROMPT_FILE"] =~ "buzz-base-prompt.md"
+      assert env["BUZZ_ACP_RELAY_OBSERVER"] == "true"
 
       # The child authenticates back with a freshly minted key.
       assert env["FOUNTAIN_BASE_URL"] == "https://fountain.example"


### PR DESCRIPTION
Found by the live desktop test (a deployed agent worked and replied, but Buzz's **ACP activity panel stayed empty**).

That panel is fed by buzz-acp's observer stream: with `BUZZ_ACP_RELAY_OBSERVER=true`, buzz-acp mirrors every ACP frame as NIP-44-encrypted kind-24200 telemetry to the owner, which the desktop decrypts and renders as "the agent's work." Buzz's desktop sets this when it spawns buzz-acp locally — a **gateway-hosted** harness must set it too, or the panel has nothing to show.

One line in the harness env, plus a test assertion. After this deploys, re-mention the agent and the activity panel should populate.

Refs #735 #736.