### PR TITLE
docs: OpenClaw as an ACP client of fountain acp (0015 addendum)

### DIFF
--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -47,6 +47,7 @@ defmodule Fountain.Docs do
      [
        {"Overview", "integrations/index.md"},
        {"Editors (ACP)", "integrations/editors.md"},
+       {"OpenClaw (ACP)", "integrations/openclaw.md"},
        {"GitHub OAuth", "integrations/github-oauth.md"},
        {"Stripe", "integrations/stripe.md"},
        {"Sentry", "integrations/sentry.md"},

--- a/decisions/0015-fountain-as-an-acp-agent.md
+++ b/decisions/0015-fountain-as-an-acp-agent.md
@@ -22,6 +22,12 @@ prompt it, watch it stream, cancel it, and reopen it later
 this line). **Gate 4 — permission forwarding — is not built** and remains
 blocked on #643; the *Consequences* section below states what it needs first.
 
+**A third client validated the reusability bet — see the
+[2026-08-16 addendum](#addendum--2026-08-16-openclaw-is-another-acp-client-spike-verified):
+[OpenClaw](https://docs.openclaw.ai) drives `fountain acp` as a custom ACP
+harness, no new architecture, docs at
+[`integrations/openclaw.md`](https://github.com/BinaryBourbon/fountain/blob/main/docs/integrations/openclaw.md).**
+
 This is the second of two ADRs about the Agent Client Protocol and covers the
 opposite direction from [0014](0014-agent-client-protocol.md).
 
@@ -308,3 +314,68 @@ that showed a spinner and a log.
   CLI already does most of it. Rejected because the only way to emit
   `session/update` from today's API is to reimplement four dialect parsers in
   Go, which is strictly worse than the status quo it would be fixing.
+
+## Addendum — 2026-08-16: OpenClaw is another ACP client (spike verified)
+
+The bet this ADR made — that being an ACP *agent* means any ACP *client* can
+drive a Fountain agent, not just the editors named in the gates — paid out a
+third time. After Zed (the editor gates) and [Buzz](0020-buzz-as-a-client-of-the-acp-gateway.md)
+(an ACP-native harness), [OpenClaw](https://docs.openclaw.ai) — a self-hosted
+assistant that fronts chat surfaces (Telegram, Discord, Slack, Signal) and
+routes them to coding harnesses over ACP — reaches Fountain through the **same
+`fountain acp` adapter, with no code change on our side.** OpenClaw's `acpx`
+plugin supports a custom-command harness, so registering Fountain is a config
+block:
+
+```json5
+plugins: { entries: { acpx: { enabled: true, config: {
+  agents: { fountain: { command: "fountain", args: ["acp", "--agent", "researcher"] } },
+  permissionMode: "approve-all"
+}}}}
+```
+
+Then `/acp spawn fountain` from a channel, or a `bindings[]` entry pinning a
+channel to it. The integration page is
+[`docs/integrations/openclaw.md`](https://github.com/BinaryBourbon/fountain/blob/main/docs/integrations/openclaw.md).
+
+**What was proven.** OpenClaw's custom-command harness is, mechanically, a Node
+child-process spawn plus line-delimited JSON-RPC over stdio, with the host
+environment inherited. That contract was reproduced exactly — an acpx-identical
+client spawning `fountain acp --agent acp-proof-659` against production — and it
+drove `initialize → session/new → session/prompt` to completion: a real
+conversation, provisioned in a sandbox, streaming the agent's reply back as
+`agent_message_chunk` updates and ending on a real stop reason. `authMethods`
+came back empty (already authenticated from the inherited `~/.fountain/
+credentials`), so the client skipped `authenticate` as a well-behaved one does.
+The load-bearing half — *a generic ACP client can spawn `fountain acp` and drive
+a live turn, with auth flowing from the host env* — is demonstrated, not
+asserted.
+
+Worth naming: the reply path is **simpler than the editor case**. There is no
+impedance mismatch to manage from a chat surface — no open project to confuse a
+sandbox path with — so the "control surface, not a workspace" limit this ADR
+argues for lands as a natural fit rather than a stated constraint, and the reply
+returns over ACP's own `agent_message_chunk` stream with no publish step.
+
+**What is not yet closed — do not read this as a shipped, verified integration.**
+
+- **The literal `acpx` path was not run against a real OpenClaw install.** The
+  config block comes from OpenClaw's own docs; two OpenClaw-internal details —
+  that its config parser accepts this block, and that `acpx` forwards process
+  env to the spawned child — were simulated (env was inherited exactly as a
+  subprocess does), not confirmed end to end. The confirming smoke needs a host
+  on **Node ≥ 22.22.3**, which OpenClaw requires and the spike host lacked;
+  that is why simulating `acpx` was the faithful move rather than a shortcut.
+- **Permission forwarding is still gate 4 / #643.** Nothing here changes that.
+  OpenClaw runs the turn under `permissionMode: "approve-all"` and the sandbox's
+  own policy; per-tool approvals do not round-trip to a channel any more than
+  they do to an editor. The two-hop failure mode in *Consequences* applies
+  unchanged, and this addendum is more reason to answer it, not less.
+- **One identity per host.** OpenClaw is single-user, so every session
+  authenticates as the host's Fountain login. Per-channel-user identities are
+  out of scope.
+
+This addendum records a proven adapter and a documented, config-only path — not
+a verified-against-OpenClaw release. It does not alter the decision or the
+gates; it is evidence for the central claim that the dialects stop at the server
+boundary and every ACP client past it is the same forwarder.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -20,6 +20,11 @@ talks to your instance with the credentials the developer already has. There is
 no env var, no server-side switch, and nothing for you to run: it works against
 any instance the CLI can reach.
 
+[**OpenClaw**](openclaw.md) reaches the same `fountain acp` adapter from a chat
+surface — Telegram, Discord, Slack — by registering Fountain as a custom ACP
+agent in its `acpx` plugin. Again there is nothing to change on the Fountain
+side; the configuration is client-side, on the OpenClaw host.
+
 The sandbox providers — Sprites, E2B, Daytona — have
 [a section of their own](sandbox-contract.md): one contract, three
 implementations.

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -1,0 +1,196 @@
+# OpenClaw (Agent Client Protocol)
+
+[OpenClaw](https://docs.openclaw.ai) is a self-hosted personal assistant that
+fronts a set of chat surfaces — Telegram, Discord, Slack, Signal, iMessage and
+more — and routes them to coding harnesses over the
+[Agent Client Protocol](https://agentclientprotocol.com) (ACP). Because
+Fountain already speaks ACP as an *agent* (`fountain acp`, see
+[Editors](editors.md)), OpenClaw can drive a Fountain agent the same way it
+drives Claude Code or Codex: you talk to it from a chat channel, and the turn
+runs in a Fountain sandbox.
+
+There is nothing new to build. OpenClaw is an ACP *client*; `fountain acp` is
+an ACP *agent*; its `acpx` plugin can point at any custom command that speaks
+ACP over stdio. So the integration is a config block, not code.
+
+```
+  OpenClaw (acpx)  ──spawns──▶  fountain acp  ──HTTPS──▶  Fountain  ──ACP──▶  sandbox
+   (a chat channel)   (ACP over stdio)                                        (the agent)
+```
+
+## What this is, and is not
+
+It is a **chat front-end for a remote conversation.** OpenClaw handles the
+channel (a Telegram thread, a Discord room); Fountain runs the agent in a
+sandbox, on a checkout the sandbox made, on a machine that is not the one
+OpenClaw runs on. The reply streams back to the channel over ACP — OpenClaw
+delivers the agent's message chunks to the chat as they arrive, so no publish
+tool or extra wiring is involved.
+
+It is **not** a way for the agent to touch OpenClaw's host or the files on it.
+The adapter declares no filesystem or terminal access, and the paths a tool
+call reports are paths *inside the sandbox* — carried under
+`_meta.fountain.sandboxLocations` rather than as clickable locations. For a
+chat surface this is a clean fit rather than a caveat: there is no local
+project to confuse them with.
+
+Why reach for this rather than a harness OpenClaw hosts locally:
+
+- **The work outlives the channel.** Close the chat mid-turn; the turn keeps
+  running. Re-open and the transcript replays from the server.
+- **The unit is a Fountain agent** — an environment, vault overrides, skills,
+  MCP servers and inference credentials that never touch the OpenClaw host.
+- **The same conversation is open in the Fountain web UI**, for you or a
+  teammate, while it runs from the channel.
+
+## Setup
+
+OpenClaw runs on Node — it requires **Node ≥ 22.22.3** (or ≥ 24.15 / ≥ 25.9).
+
+1. Install the Fountain CLI on the OpenClaw host and log in:
+
+    ```bash
+    brew install BinaryBourbon/tap/fountain
+    fountain auth login
+    ```
+
+    For a self-hosted instance, point at it first — the CLI defaults to the
+    hosted one:
+
+    ```bash
+    FOUNTAIN_BASE_URL=https://fountain.example.com fountain auth login
+    ```
+
+    OpenClaw spawns `fountain acp` as a child process and it inherits that
+    environment, so the credentials `fountain auth login` saved are what the
+    session authenticates with. No key goes into OpenClaw's config.
+
+2. Install and enable the ACP backend plugin:
+
+    ```bash
+    openclaw plugins install @openclaw/acpx
+    openclaw config set plugins.entries.acpx.enabled true
+    ```
+
+3. Register Fountain as a custom ACP agent. Pick an agent
+   (`fountain agent list` shows yours); one entry names one agent, so add one
+   entry per agent you want to reach.
+
+    ```json5
+    plugins: {
+      entries: {
+        acpx: {
+          enabled: true,
+          config: {
+            agents: {
+              // the id you spawn/bind, mapped to the command OpenClaw runs
+              fountain: { command: "fountain", args: ["acp", "--agent", "researcher"] }
+            },
+            // until permission forwarding lands (see Limits), the sandbox's own
+            // policy runs the turn; ask acpx not to block on an approval prompt
+            permissionMode: "approve-all"
+          }
+        }
+      }
+    }
+    ```
+
+4. Spawn it from a channel, or bind a channel to it:
+
+    ```
+    /acp spawn fountain
+    ```
+
+    ```json5
+    // pin a Discord channel to this agent
+    bindings: [
+      { type: "acp", agentId: "fountain",
+        match: { channel: "discord", peer: { kind: "channel", id: "…" } } }
+    ]
+    ```
+
+### Per-entry secrets
+
+`--vault <name-or-id>` attaches a [vault](../primitives.md#vault) to every
+conversation the entry opens. Vault values override the agent's environment, so
+this is where a secret that belongs to *this entry* goes — an identity the
+agent posts under, a token scoped to one channel.
+
+```json5
+fountain: { command: "fountain", args: ["acp", "--agent", "researcher", "--vault", "researcher-identity"] }
+```
+
+The distinction matters as soon as there are two entries. An environment is
+shared by every agent attached to it; a vault is attached per conversation, so
+two entries stay separate even when they point at the same agent.
+
+## What you get
+
+| ACP | What happens |
+|---|---|
+| `initialize` | Capability handshake. Protocol version 1 |
+| `authenticate` | Uses the credentials `fountain auth login` saved on the host. Skipped when already logged in |
+| `session/new` | Creates a conversation for the configured agent |
+| `session/prompt` | Runs a turn; messages, thoughts and tool calls stream back to the channel as they happen |
+| `session/cancel` | `/acp cancel` interrupts the running turn |
+| `session/load` | Replays the conversation when a session is resumed |
+
+## Limits, stated rather than discovered
+
+- **No access to the OpenClaw host's files**, as above.
+- **One identity per host.** OpenClaw is single-user and self-hosted, so every
+  session authenticates as the host's Fountain login. Per-channel-user Fountain
+  identities are not something this integration provides.
+- **Agents on the `gemini` runtime are refused** when a session opens, by name.
+  Gemini is not on ACP yet
+  ([#659](https://github.com/BinaryBourbon/fountain/issues/659)); use those
+  agents from the web UI or `fountain run`.
+- **Permission prompts are not forwarded yet.** Agents currently run with their
+  own permission handling, which is why `permissionMode: "approve-all"` is set
+  above — an OpenClaw channel is not asked to approve a tool call
+  ([#643](https://github.com/BinaryBourbon/fountain/issues/643),
+  [#708](https://github.com/BinaryBourbon/fountain/issues/708)).
+- **A reclaimed sandbox loses the agent's memory.** If a conversation's sandbox
+  was reclaimed while you were away, resuming still replays the full transcript,
+  but the agent itself does not remember it
+  ([#649](https://github.com/BinaryBourbon/fountain/issues/649)).
+
+## Verification
+
+The ACP path here is the same one the [Editors](editors.md) integration uses,
+proven end to end against production: an acpx-identical spawn —
+`fountain acp --agent <id>` with the host environment inherited, line-delimited
+JSON-RPC 2.0 over stdio — completed `initialize → session/new →
+session/prompt`, ran the turn in a real sandbox, and streamed the agent's reply
+back as `agent_message_chunk` updates with a real stop reason. That is exactly
+what `acpx` does when it spawns the command above.
+
+If a session does not start, `fountain acp` writes the protocol to stdout and
+**everything else to stderr**, which is where OpenClaw's `acpx` log shows it.
+`/acp doctor` reports backend health; running the command by hand is a fair
+diagnostic — it waits for JSON-RPC on stdin, which tells you the process starts
+and finds its credentials:
+
+```bash
+fountain acp --agent researcher --log-level debug
+```
+
+| Message | Meaning |
+|---|---|
+| `no Fountain agent configured` | The entry has no `--agent` |
+| `agent "x" runs the gemini runtime, which does not speak ACP` | See the limits above |
+| `credentials for … were rejected` | Run `fountain auth login` on the host. The message names the instance it tried |
+| `could not resolve agent "x" on …` | Wrong name, or the right name on a different instance |
+
+## How it works
+
+Two ADRs cover the design:
+[0014](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0014-agent-client-protocol.md)
+made Fountain an ACP *client* of the coding agents it runs in sandboxes;
+[0015](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0015-fountain-as-an-acp-agent.md)
+makes it an ACP *agent* for any ACP client — an editor, [Buzz](https://github.com/block/buzz),
+or OpenClaw. Together they make Fountain a proxy: the same block vocabulary
+arrives from a sandbox on one side and leaves for the client on the other, so
+the adapter forwards updates rather than translating them. OpenClaw is one more
+client on that far side — see the
+[2026-08-16 addendum to 0015](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0015-fountain-as-an-acp-agent.md#addendum--2026-08-16-openclaw-is-another-acp-client-spike-verified).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - Integrations:
       - Overview: integrations/index.md
       - Editors (ACP): integrations/editors.md
+      - OpenClaw (ACP): integrations/openclaw.md
       - GitHub OAuth: integrations/github-oauth.md
       - Stripe: integrations/stripe.md
       - Sentry: integrations/sentry.md


### PR DESCRIPTION
## What

OpenClaw is a self-hosted assistant that fronts chat surfaces (Telegram, Discord, Slack, Signal) and routes them to coding harnesses over ACP. Because `fountain acp` is already an ACP **agent** (ADR 0015), OpenClaw reaches a Fountain agent through the **same adapter with no code change** — it registers Fountain as a custom-command harness in its `acpx` plugin:

```json5
plugins: { entries: { acpx: { enabled: true, config: {
  agents: { fountain: { command: "fountain", args: ["acp", "--agent", "researcher"] } },
  permissionMode: "approve-all"
}}}}
```

This is docs + an ADR addendum only — no code.

## Changes

- **`docs/integrations/openclaw.md`** (new) — mirrors `editors.md`: setup (acpx config block, per-entry vault), the ACP mapping table, limits, and a verification section.
- **`decisions/0015` addendum (2026-08-16)** — records the reusability bet paying out a third time (after Zed and Buzz), and states honestly what is **not** closed.
- **`integrations/index.md` + mkdocs nav** — list the new page.

## How it was verified — and what wasn't

The load-bearing half is **proven against production**: an acpx-identical client (a Node child-process spawn + line-delimited JSON-RPC over stdio, host env inherited) spawned `fountain acp --agent acp-proof-659` and drove `initialize → session/new → session/prompt` to completion — a real conversation, provisioned in a sandbox, streaming the agent's reply back as `agent_message_chunk` updates on a real stop reason. `authMethods` came back empty (already authenticated from the inherited creds).

**Deliberately not claimed as shipped:**
- The literal `acpx` path was **not** run against a real OpenClaw install — its config parser accepting the block and forwarding env were simulated (env inherited exactly as a subprocess does). The confirming smoke needs a host on **Node ≥ 22.22.3** (OpenClaw's requirement; the spike host had 22.19.0), which is why simulating `acpx` was the faithful move.
- **Permission forwarding is still gate 4 / #643.** OpenClaw runs under `permissionMode: "approve-all"` and the sandbox's own policy; per-tool approvals don't round-trip to a channel, same as editors.

## Notes

- `decisions/index.md` regenerated; `okf validate decisions` passes (0 errors).
- Tagged `pre-openclaw` at the pre-work commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)