### PR TITLE
fix(acp): accept session/set_config_option instead of rejecting it

### DIFF
--- a/cli/internal/acp/agent.go
+++ b/cli/internal/acp/agent.go
@@ -106,9 +106,51 @@ func (a *Agent) Request(ctx context.Context, method string, params json.RawMessa
 		return a.prompt(ctx, params)
 	case "session/load":
 		return a.loadSession(ctx, params)
+	case "session/set_config_option":
+		return a.setConfigOption(params)
 	default:
 		return nil, Errorf(CodeMethodNotFound, "method not found: %s", method)
 	}
+}
+
+type setConfigOptionParams struct {
+	SessionID string          `json:"sessionId"`
+	ConfigID  string          `json:"configId"`
+	Value     json.RawMessage `json:"value"`
+}
+
+// setConfigOption accepts a client's request to change a session config option
+// — but does not apply it. Every option a Fountain conversation has, its model
+// above all, is a property of the *agent*: chosen once, server-side, and shared
+// by every conversation the agent runs. Changing it here would silently edit
+// the agent, which is why `session/set_model` is absent too (see modelState).
+//
+// The method exists rather than returning "method not found" because some ACP
+// clients set the model at session start and treat a rejection as fatal —
+// OpenClaw's acpx pushes its own model over `session/set_config_option` and
+// aborts the whole turn on a -32601 here (found standing up the gateway round
+// trip). So the request is acknowledged and the unchanged state reported back,
+// leaving the agent's configuration authoritative.
+func (a *Agent) setConfigOption(raw json.RawMessage) (any, error) {
+	var params setConfigOptionParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, Errorf(CodeInvalidParams, "session/set_config_option: %s", err)
+		}
+	}
+
+	sess, ok := a.sessions.get(params.SessionID)
+	if !ok {
+		return nil, Errorf(CodeInvalidParams, "unknown session %q", params.SessionID)
+	}
+
+	a.log.Info("ignoring client session config change",
+		"sessionId", params.SessionID,
+		"configId", params.ConfigID,
+		"value", string(params.Value),
+		"why", "session options are properties of the Fountain agent, not the conversation")
+
+	return map[string]any{"configOptions": configOptions(sess.Agent)}, nil
 }
 
 // Notify handles client notifications.

--- a/cli/internal/acp/session.go
+++ b/cli/internal/acp/session.go
@@ -205,6 +205,24 @@ func modelState(ref AgentRef) map[string]any {
 	}
 }
 
+// configOptions reports a session's settable options as an ACP config-option
+// list, echoed back from setConfigOption so a client that pushed one sees the
+// resulting state. A Fountain agent exposes exactly one option, its model, and
+// it is fixed — chosen on the agent, shared by every conversation — so the list
+// has a single entry that is also the current value. See setConfigOption for
+// why the set is accepted but never applied.
+func configOptions(ref AgentRef) []map[string]any {
+	model := ref.Model
+	if model == "" {
+		model = "default"
+	}
+	return []map[string]any{{
+		"configId": "model", "id": "model", "name": "Model",
+		"currentValue": model, "value": model,
+		"options": []map[string]any{{"optionId": model, "id": model, "name": model}},
+	}}
+}
+
 // requireReady is the gate the session methods share: a client that has not
 // handshaked, or has no working credentials, gets a protocol error naming
 // which of the two it is rather than an authorization failure from three

--- a/cli/internal/acp/session_test.go
+++ b/cli/internal/acp/session_test.go
@@ -328,3 +328,52 @@ func TestTwoSessionsAreTrackedIndependently(t *testing.T) {
 		}
 	}
 }
+
+func TestSetConfigOptionIsAcceptedRatherThanRejected(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef(), convID: "conv-9"}
+	a := sessionAgent(t, api, "researcher")
+
+	if _, rpcErr := request(t, a, "session/new", map[string]any{}); rpcErr != nil {
+		t.Fatalf("session/new failed: %v", rpcErr)
+	}
+
+	// A client that pushes a model at session start — as OpenClaw's acpx does —
+	// must not get "method not found". Rejecting it makes acpx abort the whole
+	// turn; the method is implemented so the request is accepted.
+	result, rpcErr := request(t, a, "session/set_config_option", map[string]any{
+		"sessionId": "conv-9",
+		"configId":  "model",
+		"value":     "anthropic/claude-something-else",
+	})
+	if rpcErr != nil {
+		t.Fatalf("set_config_option returned an error: %v", rpcErr)
+	}
+
+	// The push is accepted but not applied: the agent's model is authoritative,
+	// so the echoed option still reports the agent's own value (here "default",
+	// since the test ref sets no model), never the client's.
+	opts, ok := result["configOptions"].([]map[string]any)
+	if !ok || len(opts) == 0 {
+		t.Fatalf("configOptions = %#v, want a non-empty list", result["configOptions"])
+	}
+	if got := opts[0]["currentValue"]; got != "default" {
+		t.Errorf("model currentValue = %v, want the agent's value \"default\" (the client's push must not apply)", got)
+	}
+}
+
+func TestSetConfigOptionOnAnUnknownSessionIsRefused(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef(), convID: "conv-9"}
+	a := sessionAgent(t, api, "researcher")
+
+	_, rpcErr := request(t, a, "session/set_config_option", map[string]any{
+		"sessionId": "nope",
+		"configId":  "model",
+		"value":     "x",
+	})
+	if rpcErr == nil {
+		t.Fatal("expected an error for an unknown session")
+	}
+	if rpcErr.Code != CodeInvalidParams {
+		t.Errorf("code = %d, want CodeInvalidParams (%d)", rpcErr.Code, CodeInvalidParams)
+	}
+}


### PR DESCRIPTION
## The bug

`fountain acp` returned `-32601` (method not found) for `session/set_config_option`. Editors that never call it (Zed) were unaffected, but ACP clients that set the session **model at spawn** — **OpenClaw's acpx pushes its own model this way** — treat the rejection as fatal and abort the whole turn. The result: `session/new` succeeds (a Fountain conversation is created) and then nothing runs.

Found while standing up the OpenClaw ACP gateway round trip (follow-up to #757/#758). The gateway routes `channel → brain → sessions_spawn → acpx → fountain acp`, and it died here:

```
AcpRuntimeError: Agent rejected session/set_config_option for "model"=...: method not found (ACP -32601)
→ "The ACP harness session failed to initialize … the task never ran."
```

## The fix

Implement `session/set_config_option` as **accept-but-do-not-apply**. A Fountain agent's model (and every option) is a property of the *agent* — chosen server-side, shared by every conversation it runs — so changing it per-session would silently edit the agent. That's the same reason `session/set_model` is deliberately absent (see `modelState`). The request is acknowledged and the unchanged config echoed back, leaving the agent's configuration authoritative.

## Verification

Against the **real acpx binary (v0.11.2)**:

```
acpx --agent "fountain acp --agent <acp-agent>" --model <advertised-model> exec "…"
```

- **before:** dies on `-32601`
- **after:** completes a full turn (`FINAL-FIX-OK` streamed back)

Plus two unit tests: the method is accepted (not method-not-found) and the pushed value is **not** applied (the agent's model stays authoritative); an unknown session is refused with `CodeInvalidParams`.

## Scope / what this does *not* claim

This fixes the specific interop bug. The **full OpenClaw brain-mediated gateway round trip is not green yet** — after this fix, acpx goes on to sync *further* session controls (`thinking`, `fast`) and eventually hits an acpx-internal `ACP_BACKEND_UNSUPPORTED_CONTROL` for model-sync onto a custom harness. That's OpenClaw/acpx-side behavior, not a `fountain acp` defect, and is out of scope here. The direct-acpx path and the "conversation is created via ACP" wiring are both proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)