### PR TITLE
docs: Buzz integration page + in-app diagram rendering

### DIFF
--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -48,6 +48,7 @@ defmodule Fountain.Docs do
        {"Overview", "integrations/index.md"},
        {"Editors (ACP)", "integrations/editors.md"},
        {"OpenClaw (ACP)", "integrations/openclaw.md"},
+       {"Buzz (Nostr)", "integrations/buzz.md"},
        {"GitHub OAuth", "integrations/github-oauth.md"},
        {"Stripe", "integrations/stripe.md"},
        {"Sentry", "integrations/sentry.md"},

--- a/apps/fountain/lib/fountain_web/controllers/docs_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/docs_controller.ex
@@ -21,7 +21,7 @@ defmodule FountainWeb.DocsController do
           nav: Fountain.Docs.nav(),
           slug: slug,
           title: page.title,
-          body_html: FountainWeb.Markdown.to_html(page.body)
+          body_html: FountainWeb.Markdown.to_trusted_html(page.body)
         )
 
       :error ->

--- a/apps/fountain/lib/fountain_web/live/help_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/help_live/show.ex
@@ -51,9 +51,10 @@ defmodule FountainWeb.HelpLive.Show do
     end
   end
 
-  # Help topics are repo-controlled markdown, but rendering through the same
-  # sanitizing pipeline as agent output keeps one code path (#323).
-  defp render_markdown(text), do: FountainWeb.Markdown.to_html(text)
+  # Help topics are repo-controlled markdown (the trusted corpus), so they
+  # render through the trusted path — same scrubbing as agent output (#323),
+  # plus a sanitized <svg>/<figure> subset so authored diagrams draw.
+  defp render_markdown(text), do: FountainWeb.Markdown.to_trusted_html(text)
 
   @impl true
   def render(assigns) do

--- a/apps/fountain/lib/fountain_web/markdown.ex
+++ b/apps/fountain/lib/fountain_web/markdown.ex
@@ -33,7 +33,7 @@ defmodule FountainWeb.Markdown do
   nothing else.
   """
   def to_html(text) when is_binary(text) do
-    render(text, allow_svg: false)
+    render(text, &sanitize/1)
   end
 
   def to_html(_), do: ""
@@ -51,55 +51,67 @@ defmodule FountainWeb.Markdown do
   user-supplied markdown here; use `to_html/1` for that.
   """
   def to_trusted_html(text) when is_binary(text) do
-    render(text, allow_svg: true)
+    render(text, &sanitize_trusted/1)
   end
 
   def to_trusted_html(_), do: ""
 
-  defp render(text, opts) do
-    allow_svg = Keyword.fetch!(opts, :allow_svg)
-
+  # `sanitizer` is `&sanitize/1` (untrusted) or `&sanitize_trusted/1` (the docs
+  # corpus). It is passed as a direct function capture, and each sanitizer
+  # recurses through its own direct capture — threading the mode as a parameter
+  # instead defeats Dialyzer's success typing of the recursive AST walk.
+  defp render(text, sanitizer) do
     case Earmark.as_ast(text, smartypants: false) do
-      {:ok, ast, _warnings} -> transform(ast, allow_svg)
-      {:error, ast, _warnings} -> transform(ast, allow_svg)
+      {:ok, ast, _warnings} -> emit(ast, sanitizer)
+      {:error, ast, _warnings} -> emit(ast, sanitizer)
     end
   end
 
-  defp transform(ast, allow_svg) do
-    ast
-    |> sanitize(allow_svg)
-    |> Earmark.transform(compact_output: true)
-  end
+  defp emit(ast, sanitizer), do: ast |> sanitizer.() |> Earmark.transform(compact_output: true)
 
-  defp sanitize(nodes, allow_svg) when is_list(nodes),
-    do: Enum.map(nodes, &sanitize(&1, allow_svg))
+  # --- untrusted: every raw-HTML block is neutralized to text (#323) ---
 
-  # A block-level `<figure>`/`<svg>` in the trusted corpus is kept as real
-  # markup — scrubbed of the script-bearing subset — so the diagram renders.
-  # Its verbatim children are raw source strings; Transform emits a kept
-  # verbatim node into the DOM unescaped, which is the whole point here.
-  defp sanitize({tag, attrs, children, %{verbatim: true} = meta}, true)
-       when tag in ~w(figure svg) do
-    {tag, drop_event_attrs(attrs), Enum.map(children, &scrub_svg/1), meta}
-  end
+  defp sanitize(nodes) when is_list(nodes), do: Enum.map(nodes, &sanitize/1)
 
-  # Every other block-level raw HTML — and all of it on the untrusted path —
-  # is re-serialized to a plain string so Transform escapes it as text.
-  defp sanitize({_tag, _attrs, _children, %{verbatim: true}} = node, _allow_svg),
-    do: reserialize(node)
+  # Block-level raw HTML. Re-serialized to a plain string so Transform
+  # escapes it as text instead of emitting it verbatim into the DOM.
+  defp sanitize({_tag, _attrs, _children, %{verbatim: true}} = node), do: reserialize(node)
 
-  defp sanitize({"a", attrs, children, meta}, allow_svg),
-    do:
-      {"a", filter_url(attrs, "href", ~w(http https mailto)), sanitize(children, allow_svg), meta}
+  defp sanitize({"a", attrs, children, meta}),
+    do: {"a", filter_url(attrs, "href", ~w(http https mailto)), sanitize(children), meta}
 
-  defp sanitize({"img", attrs, children, meta}, allow_svg),
-    do: {"img", filter_url(attrs, "src", ~w(http https)), sanitize(children, allow_svg), meta}
+  defp sanitize({"img", attrs, children, meta}),
+    do: {"img", filter_url(attrs, "src", ~w(http https)), sanitize(children), meta}
 
-  defp sanitize({tag, attrs, children, meta}, allow_svg),
-    do: {tag, attrs, sanitize(children, allow_svg), meta}
+  defp sanitize({tag, attrs, children, meta}), do: {tag, attrs, sanitize(children), meta}
 
   # Text nodes (escaped by Transform) and comment nodes.
-  defp sanitize(other, _allow_svg), do: other
+  defp sanitize(other), do: other
+
+  # --- trusted docs corpus: identical, except a <figure>/<svg> block is kept
+  # as real markup after scrubbing its script-bearing subset ---
+
+  defp sanitize_trusted(nodes) when is_list(nodes), do: Enum.map(nodes, &sanitize_trusted/1)
+
+  # The one difference from `sanitize/1`: a verbatim figure/svg is kept (its raw
+  # source strings scrubbed) so Transform emits the diagram into the DOM.
+  defp sanitize_trusted({tag, attrs, children, %{verbatim: true} = meta})
+       when tag in ~w(figure svg),
+       do: {tag, drop_event_attrs(attrs), Enum.map(children, &scrub_svg/1), meta}
+
+  defp sanitize_trusted({_tag, _attrs, _children, %{verbatim: true}} = node),
+    do: reserialize(node)
+
+  defp sanitize_trusted({"a", attrs, children, meta}),
+    do: {"a", filter_url(attrs, "href", ~w(http https mailto)), sanitize_trusted(children), meta}
+
+  defp sanitize_trusted({"img", attrs, children, meta}),
+    do: {"img", filter_url(attrs, "src", ~w(http https)), sanitize_trusted(children), meta}
+
+  defp sanitize_trusted({tag, attrs, children, meta}),
+    do: {tag, attrs, sanitize_trusted(children), meta}
+
+  defp sanitize_trusted(other), do: other
 
   # Belt-and-suspenders scrub of an authored SVG block: the corpus is trusted,
   # but the executable surface is removed anyway so a bad paste can't become

--- a/apps/fountain/lib/fountain_web/markdown.ex
+++ b/apps/fountain/lib/fountain_web/markdown.ex
@@ -33,36 +33,101 @@ defmodule FountainWeb.Markdown do
   nothing else.
   """
   def to_html(text) when is_binary(text) do
-    case Earmark.as_ast(text, smartypants: false) do
-      {:ok, ast, _warnings} -> render(ast)
-      {:error, ast, _warnings} -> render(ast)
-    end
+    render(text, allow_svg: false)
   end
 
   def to_html(_), do: ""
 
-  defp render(ast) do
+  @doc """
+  Renders **trusted** markdown (the in-repo docs corpus, compiled from
+  `docs/*.md` and reviewed in a PR) exactly like `to_html/1`, with one
+  addition: a `<figure>`/`<svg>` block is kept as real markup so hand-authored
+  diagrams render, after scrubbing the script-bearing subset (`<script>`,
+  `<style>`, `<foreignObject>`, `on*` handlers, and `javascript:`/`data:`/
+  `vbscript:` URLs). Everything else — every other raw-HTML block — is still
+  neutralized to text, and the untrusted `to_html/1` path is untouched.
+
+  This is only ever fed authored documentation. Never pass agent- or
+  user-supplied markdown here; use `to_html/1` for that.
+  """
+  def to_trusted_html(text) when is_binary(text) do
+    render(text, allow_svg: true)
+  end
+
+  def to_trusted_html(_), do: ""
+
+  defp render(text, opts) do
+    allow_svg = Keyword.fetch!(opts, :allow_svg)
+
+    case Earmark.as_ast(text, smartypants: false) do
+      {:ok, ast, _warnings} -> transform(ast, allow_svg)
+      {:error, ast, _warnings} -> transform(ast, allow_svg)
+    end
+  end
+
+  defp transform(ast, allow_svg) do
     ast
-    |> sanitize()
+    |> sanitize(allow_svg)
     |> Earmark.transform(compact_output: true)
   end
 
-  defp sanitize(nodes) when is_list(nodes), do: Enum.map(nodes, &sanitize/1)
+  defp sanitize(nodes, allow_svg) when is_list(nodes),
+    do: Enum.map(nodes, &sanitize(&1, allow_svg))
 
-  # Block-level raw HTML. Re-serialized to a plain string so Transform
-  # escapes it as text instead of emitting it verbatim into the DOM.
-  defp sanitize({_tag, _attrs, _children, %{verbatim: true}} = node), do: reserialize(node)
+  # A block-level `<figure>`/`<svg>` in the trusted corpus is kept as real
+  # markup — scrubbed of the script-bearing subset — so the diagram renders.
+  # Its verbatim children are raw source strings; Transform emits a kept
+  # verbatim node into the DOM unescaped, which is the whole point here.
+  defp sanitize({tag, attrs, children, %{verbatim: true} = meta}, true)
+       when tag in ~w(figure svg) do
+    {tag, drop_event_attrs(attrs), Enum.map(children, &scrub_svg/1), meta}
+  end
 
-  defp sanitize({"a", attrs, children, meta}),
-    do: {"a", filter_url(attrs, "href", ~w(http https mailto)), sanitize(children), meta}
+  # Every other block-level raw HTML — and all of it on the untrusted path —
+  # is re-serialized to a plain string so Transform escapes it as text.
+  defp sanitize({_tag, _attrs, _children, %{verbatim: true}} = node, _allow_svg),
+    do: reserialize(node)
 
-  defp sanitize({"img", attrs, children, meta}),
-    do: {"img", filter_url(attrs, "src", ~w(http https)), sanitize(children), meta}
+  defp sanitize({"a", attrs, children, meta}, allow_svg),
+    do:
+      {"a", filter_url(attrs, "href", ~w(http https mailto)), sanitize(children, allow_svg), meta}
 
-  defp sanitize({tag, attrs, children, meta}), do: {tag, attrs, sanitize(children), meta}
+  defp sanitize({"img", attrs, children, meta}, allow_svg),
+    do: {"img", filter_url(attrs, "src", ~w(http https)), sanitize(children, allow_svg), meta}
+
+  defp sanitize({tag, attrs, children, meta}, allow_svg),
+    do: {tag, attrs, sanitize(children, allow_svg), meta}
 
   # Text nodes (escaped by Transform) and comment nodes.
-  defp sanitize(other), do: other
+  defp sanitize(other, _allow_svg), do: other
+
+  # Belt-and-suspenders scrub of an authored SVG block: the corpus is trusted,
+  # but the executable surface is removed anyway so a bad paste can't become
+  # live script. Element removals run before the on*/URL passes so their
+  # contents cannot re-introduce a handler.
+  defp scrub_svg(str) when is_binary(str) do
+    str
+    |> drop_elements(~w(script style foreignObject))
+    |> String.replace(~r/\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/i, "")
+    |> String.replace(
+      ~r/(href|xlink:href|src)\s*=\s*("(?:javascript|data|vbscript):[^"]*"|'(?:javascript|data|vbscript):[^']*')/i,
+      ""
+    )
+  end
+
+  defp scrub_svg(other), do: other
+
+  defp drop_elements(str, tags) do
+    Enum.reduce(tags, str, fn tag, acc ->
+      acc
+      |> String.replace(~r/<#{tag}\b[^>]*>.*?<\/#{tag}\s*>/is, "")
+      |> String.replace(~r/<#{tag}\b[^>]*\/?>/is, "")
+    end)
+  end
+
+  defp drop_event_attrs(attrs) do
+    Enum.reject(attrs, fn {k, _v} -> String.match?(k, ~r/^on[a-z]+$/i) end)
+  end
 
   # Verbatim children are the raw source lines as strings; nested markup
   # arrives inside those strings, so joining them reconstructs the block.

--- a/apps/fountain/test/fountain_web/markdown_test.exs
+++ b/apps/fountain/test/fountain_web/markdown_test.exs
@@ -137,4 +137,66 @@ defmodule FountainWeb.MarkdownTest do
       assert Markdown.to_html(123) == ""
     end
   end
+
+  describe "to_trusted_html/1 — the docs corpus keeps a sanitized SVG subset" do
+    test "a clean figure/svg block renders as real markup, not escaped text" do
+      md = ~s|intro
+
+<figure>
+<svg viewBox="0 0 10 10"><rect fill="#b3760f"/><text fill="currentColor">hi</text></svg>
+<figcaption>cap</figcaption>
+</figure>
+
+end|
+      html = Markdown.to_trusted_html(md)
+
+      assert html =~ ~s|<svg viewBox="0 0 10 10">|
+      assert html =~ ~s|<rect fill="#b3760f"/>|
+      assert html =~ "<figcaption>cap</figcaption>"
+      refute html =~ "&lt;svg"
+    end
+
+    test "script, style and foreignObject are stripped from a trusted svg" do
+      md =
+        ~s|<figure><svg><script>alert(1)</script><style>x{}</style><foreignObject><b>y</b></foreignObject><rect/></svg></figure>|
+
+      html = Markdown.to_trusted_html(md)
+
+      refute html =~ "<script"
+      refute html =~ "<style"
+      refute html =~ "foreignObject"
+      assert html =~ "<rect/>"
+    end
+
+    test "event handlers and javascript/data URLs are stripped from a trusted svg" do
+      md =
+        ~s|<figure><svg onload="steal()"><a xlink:href="javascript:alert(1)">x</a><image href="data:text/html,evil"/></svg></figure>|
+
+      html = Markdown.to_trusted_html(md)
+
+      refute html =~ "onload"
+      refute html =~ "javascript:"
+      refute html =~ "data:text/html"
+      assert html =~ "<svg>"
+    end
+
+    test "raw HTML that is not a figure/svg is still neutralized on the trusted path" do
+      html = Markdown.to_trusted_html("para\n\n<img src=x onerror=alert(1)>\n\nend")
+
+      refute html =~ "onerror=alert"
+      assert html =~ "&lt;img"
+    end
+
+    test "the untrusted path never renders svg, even the same clean block" do
+      md = ~s|<figure><svg><rect fill="#000"/></svg></figure>|
+      html = Markdown.to_html(md)
+
+      refute html =~ "<svg>"
+      assert html =~ "&lt;svg&gt;"
+    end
+
+    test "non-binary input renders as empty" do
+      assert Markdown.to_trusted_html(nil) == ""
+    end
+  end
 end

--- a/docs/integrations/buzz.md
+++ b/docs/integrations/buzz.md
@@ -1,0 +1,263 @@
+# Buzz (hosted agents on Nostr)
+
+[Buzz](https://github.com/block/buzz) is a Nostr-based agent workspace: an agent
+is a Nostr identity that lives in relay-based group channels. On the desktop,
+that agent's "body" — the coding agent that reads mentions and replies — runs on
+your laptop, and stops when the laptop does.
+
+Fountain **hosts the body**. You bind a Buzz identity (its Nostr key) to a
+Fountain agent, and Fountain runs a `buzz-acp` harness for it on the gateway:
+the identity keeps a presence on the relay, listens for mentions, and answers
+from a sandbox — whether or not any laptop is open. The agent's Nostr key stays
+inside Fountain and is used to sign; the sandbox never holds it.
+
+<figure>
+<svg viewBox="0 0 720 232" role="img" aria-label="Buzz on Fountain map: the owner's Buzz desktop provisions an identity into Fountain; Fountain speaks Nostr to the relay as the agent, drives the coding agent in a sandbox over ACP, and the sandbox asks Fountain to publish through an MCP tool. The agent's key lives in a Fountain vault." style="max-width:100%;height:auto">
+  <defs>
+    <marker id="bz-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+  </defs>
+  <g fill="none" stroke="currentColor" stroke-width="1.4">
+    <rect x="14" y="92" width="150" height="48" rx="8"/>
+    <rect x="286" y="92" width="150" height="48" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="556" y="92" width="150" height="48" rx="8" stroke="#8a93a3"/>
+    <rect x="286" y="16" width="150" height="44" rx="8" stroke="#c98a2b"/>
+    <rect x="300" y="176" width="122" height="40" rx="8" stroke="#cf5563"/>
+  </g>
+  <g font-family="ui-monospace, Menlo, monospace" text-anchor="middle">
+    <text x="89" y="112" fill="currentColor" font-size="12.5" font-weight="600">Owner</text>
+    <text x="89" y="129" fill="currentColor" font-size="10.5" opacity=".7">Buzz desktop</text>
+    <text x="361" y="112" fill="#2f8fb3" font-size="12.5" font-weight="700">Fountain</text>
+    <text x="361" y="129" fill="currentColor" font-size="10.5" opacity=".7">harness · signer · vault</text>
+    <text x="631" y="112" fill="currentColor" font-size="12.5" font-weight="600">Sandbox</text>
+    <text x="631" y="129" fill="currentColor" font-size="10.5" opacity=".7">the coding agent</text>
+    <text x="361" y="35" fill="#c98a2b" font-size="12" font-weight="700">Nostr relay</text>
+    <text x="361" y="50" fill="currentColor" font-size="10" opacity=".7">channels + presence</text>
+    <text x="361" y="201" fill="#cf5563" font-size="11" font-weight="600">the agent's key</text>
+    <text x="361" y="211" fill="currentColor" font-size="9.5" opacity=".7">in a vault</text>
+  </g>
+  <g font-family="ui-monospace, Menlo, monospace" font-size="10.5">
+    <!-- owner -> fountain: provision (setup) -->
+    <line x1="164" y1="108" x2="284" y2="108" stroke="currentColor" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#bz-a)"/>
+    <text x="224" y="101" fill="currentColor" text-anchor="middle" opacity=".85">provision</text>
+    <!-- fountain <-> relay -->
+    <line x1="361" y1="92" x2="361" y2="62" stroke="#c98a2b" stroke-width="1.8" marker-end="url(#bz-a)" marker-start="url(#bz-a)"/>
+    <text x="446" y="78" fill="#c98a2b" text-anchor="start">Nostr · WS</text>
+    <!-- fountain -> sandbox: ACP -->
+    <line x1="436" y1="108" x2="554" y2="108" stroke="#2f8fb3" stroke-width="1.8" marker-end="url(#bz-a)"/>
+    <text x="495" y="101" fill="#2f8fb3" text-anchor="middle">ACP</text>
+    <!-- sandbox -> fountain: MCP publish -->
+    <line x1="554" y1="126" x2="438" y2="126" stroke="#2f8fb3" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#bz-a)"/>
+    <text x="496" y="139" fill="currentColor" text-anchor="middle" opacity=".85">MCP · publish</text>
+    <!-- fountain -> key -->
+    <line x1="361" y1="140" x2="361" y2="174" stroke="#cf5563" stroke-width="1.4" marker-end="url(#bz-a)"/>
+  </g>
+</svg>
+<figcaption><b>Four parties, and Fountain in the middle.</b> The owner provisions once; then Fountain speaks Nostr to the relay <em>as the agent</em>, drives the coding agent in a sandbox over ACP, and the sandbox asks Fountain to publish through an MCP tool — it never touches the relay or the key itself.</figcaption>
+</figure>
+
+## What this is
+
+A Buzz agent on Fountain is a **`BuzzIdentity`**: a Nostr keypair bound to one of
+your Fountain agents. Fountain supervises exactly one `buzz-acp` harness per
+identity (cluster-wide, surviving a node loss), and that harness runs the bound
+Fountain agent as its ACP child. So the unit you get is a normal Fountain
+agent — its environment, vault overrides, skills, MCP servers and inference
+credentials — wearing a Nostr identity on a relay.
+
+It is **not** a way to run arbitrary code on the relay, and the sandbox is
+deliberately untrusted with respect to the identity: it can *ask* to publish, but
+Fountain signs and sends.
+
+## Set it up
+
+You need a Nostr secret key (`nsec…` or hex), the relay URL, and an
+owner attestation (a Buzz `auth_tag` or a launch owner pubkey) so the relay
+knows who stands behind the agent. There are two ways in.
+
+### From the Buzz desktop (the provider)
+
+Fountain ships a Buzz **remote-agents provider**, `buzz-backend-fountain`. The
+Buzz desktop discovers it by name and hands it a one-shot deploy; it stands up
+the hosted agent on your Fountain instance and returns.
+
+- Its settings ask only **which Fountain agent** to run as
+  (`{ "agent": "<name-or-id>" }`) — a non-secret selector.
+- Fountain credentials are **ambient**: `FOUNTAIN_API_KEY` / `FOUNTAIN_BASE_URL`
+  from the environment or the `fountain` CLI creds file. The provider refuses to
+  carry a secret in its config, so your Fountain key never rides in the Buzz
+  deploy payload.
+- It refuses to deploy an agent with **no owner** (no `auth_tag` and no launch
+  owner pubkey), and refuses the `relay-mesh` substrate.
+
+Deploy is **idempotent on the agent's Nostr pubkey**, so re-deploying the same
+identity converges rather than duplicating.
+
+### From the API
+
+```bash
+curl -X POST https://fountain.example.com/api/buzz/agents \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "night-owl",
+    "agent": "researcher",
+    "relay_url": "wss://relay.example.com",
+    "pubkey": "<64-hex nostr pubkey>",
+    "private_key_nsec": "nsec1…",
+    "auth_tag": "<owner attestation>"
+  }'
+```
+
+- `POST /api/buzz/agents` provisions (or converges on) the identity and starts
+  its harness. **`GET`** lists yours; **`DELETE /api/buzz/agents/:id`** stops the
+  harness and destroys the identity *and its backing vault*.
+- Any valid tenant API key may provision — there is no separate scope gate.
+- The `private_key_nsec` is **accepted here and stored server-side; it is never
+  returned and never enters a sandbox.** The response carries only the identity's
+  public fields (id, name, relay, pubkey, `agent_id`, `vault_id`, `enabled`).
+- The relay URL must be `ws://` or `wss://`, and the pubkey 64 lowercase hex — a
+  common `https://` paste is rejected up front.
+
+## Where the key lives
+
+<figure>
+<svg viewBox="0 0 720 196" role="img" aria-label="Key custody: the Nostr secret key is stored in a per-identity Fountain vault. To publish, the sandbox calls an MCP tool with no key; Fountain reads the key from the vault, signs, and sends to the relay. The sandbox never holds the key or the relay connection." style="max-width:100%;height:auto">
+  <defs>
+    <marker id="bz-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+  </defs>
+  <g fill="none" stroke="currentColor" stroke-width="1.4">
+    <rect x="14" y="70" width="150" height="52" rx="8" stroke="#8a93a3"/>
+    <rect x="286" y="70" width="150" height="52" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="286" y="150" width="150" height="38" rx="8" stroke="#cf5563"/>
+    <rect x="556" y="70" width="150" height="52" rx="8" stroke="#c98a2b"/>
+  </g>
+  <g font-family="ui-monospace, Menlo, monospace" text-anchor="middle">
+    <text x="89" y="92" fill="currentColor" font-size="12" font-weight="600">Sandbox</text>
+    <text x="89" y="109" fill="currentColor" font-size="10" opacity=".7">holds no key</text>
+    <text x="361" y="92" fill="#2f8fb3" font-size="12" font-weight="700">Fountain</text>
+    <text x="361" y="109" fill="currentColor" font-size="10" opacity=".7">reads key · signs</text>
+    <text x="361" y="167" fill="#cf5563" font-size="11" font-weight="600">Vault</text>
+    <text x="361" y="180" fill="currentColor" font-size="9.5" opacity=".7">BUZZ_PRIVATE_KEY</text>
+    <text x="631" y="92" fill="#c98a2b" font-size="12" font-weight="700">Relay</text>
+    <text x="631" y="109" fill="currentColor" font-size="10" opacity=".7">signed event</text>
+  </g>
+  <g font-family="ui-monospace, Menlo, monospace" font-size="10.5">
+    <line x1="164" y1="90" x2="284" y2="90" stroke="#2f8fb3" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#bz-b)"/>
+    <text x="224" y="83" fill="currentColor" text-anchor="middle" opacity=".85">buzz_send_message</text>
+    <text x="224" y="105" fill="currentColor" text-anchor="middle" opacity=".6">(no key)</text>
+    <line x1="361" y1="150" x2="361" y2="122" stroke="#cf5563" stroke-width="1.4" marker-end="url(#bz-b)"/>
+    <text x="371" y="140" fill="#cf5563" text-anchor="start">read + sign</text>
+    <line x1="436" y1="90" x2="554" y2="90" stroke="#c98a2b" stroke-width="1.8" marker-end="url(#bz-b)"/>
+    <text x="495" y="83" fill="#c98a2b" text-anchor="middle">publish</text>
+  </g>
+</svg>
+<figcaption><b>The sandbox asks; Fountain signs.</b> The Nostr secret lives in a per-identity vault (as <code>BUZZ_PRIVATE_KEY</code>), never in a table row, never returned by the API, never in a sandbox. A publish is a tool call carrying no key; Fountain reads the key, signs, and sends. The identity can be provisioned, run, and destroyed without the key ever leaving the server.</figcaption>
+</figure>
+
+## A turn
+
+When someone mentions the agent, Fountain wakes a sandbox and drives the turn
+over ACP. The agent thinks and, to reply, calls a Fountain-hosted **MCP tool** —
+it holds no relay connection and no key, so this is the only way it can publish.
+While the turn runs, Fountain mirrors every ACP frame back to the owner's Buzz
+desktop as encrypted telemetry, so you can watch the work from where you created
+the agent.
+
+<figure>
+<svg viewBox="0 0 720 226" role="img" aria-label="A turn: a mention arrives from the relay to Fountain; Fountain wakes the sandbox over ACP; the agent reads and plans; it calls buzz_send_message over MCP; Fountain signs with the vault key and publishes the reply to the relay. In parallel Fountain mirrors ACP activity to the owner's desktop as encrypted telemetry." style="max-width:100%;height:auto">
+  <defs>
+    <marker id="bz-c" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+  </defs>
+  <g font-family="ui-monospace, Menlo, monospace" font-size="11" fill="currentColor">
+    <text x="60" y="24" text-anchor="middle" fill="#c98a2b" font-weight="700">Relay</text>
+    <text x="270" y="24" text-anchor="middle" fill="#2f8fb3" font-weight="700">Fountain</text>
+    <text x="530" y="24" text-anchor="middle" font-weight="700">Sandbox</text>
+    <text x="670" y="24" text-anchor="middle" opacity=".8">Owner</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1" stroke-dasharray="2 4" opacity=".5">
+    <line x1="60" y1="34" x2="60" y2="214"/>
+    <line x1="270" y1="34" x2="270" y2="214"/>
+    <line x1="530" y1="34" x2="530" y2="214"/>
+    <line x1="670" y1="34" x2="670" y2="214"/>
+  </g>
+  <g font-family="ui-monospace, Menlo, monospace" font-size="10">
+    <!-- mention -->
+    <line x1="60" y1="56" x2="266" y2="56" stroke="#c98a2b" stroke-width="1.6" marker-end="url(#bz-c)"/>
+    <text x="163" y="49" text-anchor="middle" fill="#c98a2b">@mention</text>
+    <!-- wake + ACP -->
+    <line x1="270" y1="86" x2="526" y2="86" stroke="#2f8fb3" stroke-width="1.6" marker-end="url(#bz-c)"/>
+    <text x="398" y="79" text-anchor="middle" fill="#2f8fb3">wake · ACP</text>
+    <!-- observer to owner -->
+    <line x1="270" y1="114" x2="666" y2="114" stroke="#8a93a3" stroke-width="1.3" stroke-dasharray="1.5 3" marker-end="url(#bz-c)"/>
+    <text x="470" y="107" text-anchor="middle" fill="currentColor" opacity=".7">observe · encrypted telemetry</text>
+    <!-- think -->
+    <rect x="470" y="126" width="120" height="22" rx="5" fill="none" stroke="currentColor" opacity=".8"/>
+    <text x="530" y="141" text-anchor="middle" fill="currentColor" opacity=".85">reads · plans</text>
+    <!-- tool call -->
+    <line x1="530" y1="166" x2="274" y2="166" stroke="#2f8fb3" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#bz-c)"/>
+    <text x="402" y="159" text-anchor="middle" fill="currentColor">buzz_send_message · MCP</text>
+    <!-- sign + publish -->
+    <line x1="270" y1="194" x2="64" y2="194" stroke="#c98a2b" stroke-width="1.6" marker-end="url(#bz-c)"/>
+    <text x="167" y="187" text-anchor="middle" fill="#cf5563">sign (vault key)</text>
+    <text x="167" y="208" text-anchor="middle" fill="#c98a2b">reply published</text>
+  </g>
+</svg>
+<figcaption><b>In over ACP, out over a signed publish.</b> Note the asymmetry that defines the integration: <code>buzz-acp</code> never publishes the agent's own text — the reply only reaches the channel because the agent chose to call <code>buzz_send_message</code>, which Fountain signs and sends. If the model doesn't call the tool, nothing is posted.</figcaption>
+</figure>
+
+## The two publish tools
+
+The sandbox reaches exactly two Fountain-hosted MCP tools, over
+`POST /api/mcp/buzz/:conversation_id` (authenticated by the conversation's own
+sandbox token):
+
+| Tool | Does |
+|---|---|
+| `buzz_send_message` | Post to a channel (`channel`, `content`, optional `reply_to`) |
+| `buzz_react` | React to an event (`event`, `emoji`) |
+
+A base prompt tells the agent the truth about its position — that it holds no
+credentials and no relay connection, and that these tools are the only way to
+publish. Each publish is recorded in the [audit trail](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0013-audit-trail.md)
+as `buzz.published` — the tool and channel, never the message content.
+
+## Limits, stated rather than discovered
+
+- **A reply only happens if the agent calls the tool.** `buzz-acp` does not
+  publish the agent's ACP text; the MCP tool is the whole outbound path.
+- **Two tools, no more.** `buzz_send_message` and `buzz_react` — there is no
+  memory, thread-reading or message-history tool today.
+- **One identity per name/key.** Each identity gets one vault (`buzz:<name>`),
+  unique per `(user, name)` and per `(user, pubkey)`; convergence is by pubkey.
+- **Publishes are audited, not policy-gated.** The trail records that a publish
+  happened; there is no per-publish approval or allow/deny gate in this path.
+- **Permission prompts are auto-answered.** The harness answers a runtime
+  permission request with "allow once" — Buzz is not a human approval surface.
+- **The runtime is the Fountain agent's.** A Buzz agent runs whatever runtime
+  its bound Fountain agent is configured for; there is no Buzz-specific pin.
+
+## For operators
+
+The integration **self-enables** on any production image that ships the
+`buzz-acp` binary (the Dockerfile builds it for amd64 and arm64 and bakes it in);
+if the binary is present, the boot sweep stands up every enabled identity, and if
+it is absent the feature is simply inert. There is no separate on/off flag.
+
+Two settings, both optional (see the
+[configuration reference](../configuration.md)):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `BUZZ_ACP_BASE_URL` | loopback `http://127.0.0.1:$PORT` | Where the harness's ACP child reaches this instance. Loopback keeps harness traffic inside the pod |
+| `FOUNTAIN_CLI_PATH` | `/usr/local/bin/fountain` | The `fountain` binary the harness runs as its ACP agent |
+
+## How it works
+
+The design is [ADR 0020](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0020-buzz-as-a-client-of-the-acp-gateway.md):
+Buzz participates by being an **ACP client** of Fountain. `buzz-acp` holds the
+relay connection and drives the bound Fountain agent through
+[`fountain acp`](editors.md) over stdio; the reply path routes back through a
+Fountain-hosted MCP tool that signs with the vaulted key. Because every inbound
+turn arrives through the ACP-agent door, the conversation, its log events, its
+lifecycle and its audit trail all apply for free — the same machinery every
+other Fountain surface uses.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -25,6 +25,12 @@ surface — Telegram, Discord, Slack — by registering Fountain as a custom ACP
 agent in its `acpx` plugin. Again there is nothing to change on the Fountain
 side; the configuration is client-side, on the OpenClaw host.
 
+[**Buzz**](buzz.md) is the other direction: Fountain *hosts* a Buzz agent —
+a Nostr identity that lives on a relay — running its coding agent in a sandbox
+and holding its signing key in a vault. Provision one from the Buzz desktop or
+`POST /api/buzz/agents`; it self-enables on any image that ships the `buzz-acp`
+binary.
+
 The sandbox providers — Sprites, E2B, Daytona — have
 [a section of their own](sandbox-contract.md): one contract, three
 implementations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
       - Overview: integrations/index.md
       - Editors (ACP): integrations/editors.md
       - OpenClaw (ACP): integrations/openclaw.md
+      - Buzz (Nostr): integrations/buzz.md
       - GitHub OAuth: integrations/github-oauth.md
       - Stripe: integrations/stripe.md
       - Sentry: integrations/sentry.md


### PR DESCRIPTION
## What

Adds `docs/integrations/buzz.md` — a user-facing page for the **Buzz-on-Fountain** integration — to the embedded /docs site, and teaches the docs renderer to draw inline diagrams.

### The Buzz page

Fountain hosts a Buzz agent: a Nostr identity whose coding-agent "body" runs in a Fountain sandbox, with its signing key held server-side in a vault. The page covers: the concept + a map, provisioning (Buzz desktop provider **or** `POST /api/buzz/agents`), the key-custody model, how a turn flows (ACP in → agent thinks → `buzz_send_message` MCP tool → Fountain signs → relay, plus the observer back-channel), the two publish tools, limits, and the operator surface.

**Accuracy note:** grounded in the code, *not* ADR 0020's stale "nothing is built" status (the integration shipped across Phases 1–3 in merged PRs). It deliberately does **not** claim PDP/governance gating or `mem`/thread tools — those remain unbuilt. (Worth a separate follow-up to refresh ADR 0020's status block.)

### The renderer change (why it's here)

The embedded /docs renders through `FountainWeb.Markdown`, which **escapes all raw HTML** — the #323 XSS defense for agent output — so an inline `<svg>` came out as visible `&lt;svg&gt;` text, not a drawing. To carry the diagrams in-app:

- New `to_trusted_html/1`, used **only** by the in-repo docs corpus (`/docs`, `/help`). It keeps a `<figure>`/`<svg>` block as real markup after scrubbing the script-bearing subset: `<script>`, `<style>`, `<foreignObject>`, `on*` handlers, and `javascript:`/`data:`/`vbscript:` URLs.
- The untrusted `to_html/1` path (conversation / agent output) is **unchanged** — verified by a test that the same clean `<svg>` still escapes there.
- Diagrams are self-contained (inline presentation attributes + `currentColor`), so they theme correctly without the artifact's CSS.

## Verification

- New renderer tests (6): clean SVG renders raw; `<script>`/`<style>`/`<foreignObject>` stripped; `on*`/`javascript:`/`data:` stripped; non-figure raw HTML still neutralized on the trusted path; untrusted path never renders SVG. `mix test markdown_test` → 26/0.
- `DocsTest` 13/0 (nav mirror + link integrity; page registered in `Fountain.Docs` `@nav` + `mkdocs.yml` + integrations index).
- End-to-end render of the page: 3 SVG blocks emitted raw, **0 escaped leaks**, relative `.md` links rewritten to `/docs/...`.
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` (renderer) all clean.

The full-color 7-diagram walkthrough still lives in the standalone artifact; this page carries self-contained versions of the map, key-custody, and turn diagrams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)