### PR TITLE
docs: heading ids on the trusted markdown path so #anchor links resolve (#765)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Fixed
+
+- **In-app docs anchor links land on their section.** `/docs` and `/help`
+  headings now carry GFM-style ids, so the docs' `#anchor` cross-links
+  (e.g. `/docs/architecture#the-secrets-model`) scroll to the heading
+  instead of the top of the page, matching the public MkDocs site (#765).
+
 ### Changed
 
 - **Markdown rendering moved from Earmark to MDEx.** Earmark is retired

--- a/apps/fountain/lib/fountain_web/markdown.ex
+++ b/apps/fountain/lib/fountain_web/markdown.ex
@@ -35,7 +35,7 @@ defmodule FountainWeb.Markdown do
   link/image URLs removed.
   """
   def to_html(text) when is_binary(text) do
-    render(text, &sanitize/1, unsafe: false, escape: true)
+    render(text, &sanitize/1, [], unsafe: false, escape: true)
   end
 
   def to_html(_), do: ""
@@ -55,7 +55,11 @@ defmodule FountainWeb.Markdown do
   def to_trusted_html(text) when is_binary(text) do
     # `unsafe: true` is what lets the kept figure/svg block through; every
     # other raw-HTML node has already been turned into text by the walk.
-    render(text, &sanitize_trusted/1, unsafe: true)
+    # `header_id_prefix` gives every heading a GFM-style id (plus GitHub's
+    # empty self-link) so the docs' `#anchor` cross-links resolve in-app the
+    # way they do on the MkDocs site (#765). Trusted path only: ids on agent
+    # output would be surface with no reader.
+    render(text, &sanitize_trusted/1, [header_id_prefix: ""], unsafe: true)
   end
 
   def to_trusted_html(_), do: ""
@@ -64,11 +68,13 @@ defmodule FountainWeb.Markdown do
   # corpus). Each recurses through its own direct capture rather than
   # threading the mode as a parameter, which keeps Dialyzer's success typing of
   # the recursive walk intact.
-  defp render(text, sanitizer, render_opts) do
-    case MDEx.parse_document(text, extension: @extension) do
+  defp render(text, sanitizer, extra_extensions, render_opts) do
+    extension = @extension ++ extra_extensions
+
+    case MDEx.parse_document(text, extension: extension) do
       {:ok, %Document{nodes: nodes} = doc} ->
         MDEx.to_html!(%{doc | nodes: sanitizer.(nodes)},
-          extension: @extension,
+          extension: extension,
           render: render_opts
         )
 

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -71,6 +71,28 @@ defmodule Fountain.DocsTest do
       end
     end
 
+    # The rendered target must carry the anchor as a heading id — MDEx emits
+    # them on the trusted path (#765). MkDocs slugs the same headings for the
+    # public site; the two differ only for *duplicate* headings (comrak
+    # `-1`, python-markdown `_1`), so avoid linking to those.
+    test "every internal /docs anchor link targets a heading on that page" do
+      rendered =
+        Map.new(Docs.slugs(), fn slug ->
+          {:ok, %{body: body}} = Docs.get(slug)
+          {slug, FountainWeb.Markdown.to_trusted_html(body)}
+        end)
+
+      for {slug, _html} <- rendered,
+          {:ok, %{body: body}} = Docs.get(slug),
+          [_, target, anchor] <- Regex.scan(~r{\]\(/docs(/[^)#]+)?#([^)]+)\)}, body) do
+        target_slug = String.trim_leading(target, "/")
+        target_html = Map.fetch!(rendered, if(target == "", do: slug, else: target_slug))
+
+        assert target_html =~ ~s( id="#{anchor}"),
+               "#{inspect(slug)} links to /docs/#{target_slug}##{anchor}, but that page has no heading with that id"
+      end
+    end
+
     test "the changelog page carries the repo-root CHANGELOG" do
       {:ok, %{body: body}} = Docs.get("changelog")
       assert body =~ "Keep a Changelog"

--- a/apps/fountain/test/fountain_web/markdown_test.exs
+++ b/apps/fountain/test/fountain_web/markdown_test.exs
@@ -208,12 +208,25 @@ end|
       assert html =~ "&lt;img"
     end
 
+    test "headings carry GFM-style ids so #anchor links resolve" do
+      html = Markdown.to_trusted_html("## Back up `MASTER_SECRETS_KEY`\n\n## Crons: alerting")
+      assert html =~ ~s(<h2 id="back-up-master_secrets_key">)
+      assert html =~ ~s(<h2 id="crons-alerting">)
+      # comrak also emits GitHub's self-link inside the heading; it is empty
+      # and invisible, but pin its shape so a change shows up here.
+      assert html =~ ~s(<a href="#crons-alerting" aria-label="Link to heading 'Crons: alerting'")
+    end
+
+    test "the untrusted path emits no heading ids" do
+      refute Markdown.to_html("## Title") =~ "id="
+    end
+
     test "an HTML comment block is dropped on the trusted path too" do
       html =
         Markdown.to_trusted_html("<!-- The changelog lives in the repo root -->\n\n# Changelog")
 
       refute html =~ "changelog lives"
-      assert html =~ "<h1>Changelog</h1>"
+      assert html =~ ~s(<h1 id="changelog">Changelog)
     end
 
     test "the untrusted path never renders svg, even the same clean block" do


### PR DESCRIPTION
Closes #765.

## What

`/docs` and `/help` headings now carry GFM-style ids, so the docs' `#anchor` cross-links (e.g. `/docs/architecture#the-secrets-model`) scroll to the section instead of the top of the page — the same as on the MkDocs site.

- `FountainWeb.Markdown.to_trusted_html/1` renders with comrak's `header_id_prefix: ""`. Trusted path only; the untrusted agent-output path emits no ids (pinned by a test).
- comrak also emits GitHub's empty self-link inside each heading (`<a href="#slug" aria-label="Link to heading '…'" class="anchor"></a>`); it is invisible with no styling and matches what GitHub renders. Its shape is pinned in a test so a change shows up rather than slipping by.

## Slug parity

Checked every anchor the docs currently link to against the live MkDocs site (`back-up-master_secrets_key`, `crons-alerting-when-a-scheduled-job-stops-running`, `running-migrations-in-a-job`, `the-secrets-model`, `vault`, `upgrade-gone-wrong` …) — comrak's slugs are identical. The one known divergence is *duplicate* headings (comrak `-1`, python-markdown `_1`); no doc links to one, and the new test's comment says to avoid it.

## Guard

`docs_test.exs` gains "every internal /docs anchor link targets a heading on that page": renders every page and asserts each `/docs/...#anchor` link resolves to an `id` on the rendered target (the sibling of the existing page-exists check). Verified it fails when the option is removed.

`mix precommit` clean (format, credo, sobelow, dialyzer, 2855 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)