### PR TITLE
fix(acp): set_config_option reply advertises no config-option list — OpenClaw gateway round trip green (#760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ upgrade, is in
 
 ### Fixed
 
+- **`fountain acp` no longer trips OpenClaw's session-control sync.** The
+  `session/set_config_option` reply advertised a config-option list, and
+  acpx narrows the controls it will push to whatever that list says — so the
+  next control (`thinking`) failed with "does not advertise config option"
+  and the gateway turn died. The reply now carries no list (Fountain has no
+  per-session options; the agent's model is authoritative) and says
+  `_meta.fountain.applied: false`. The full OpenClaw gateway round trip —
+  brain → `sessions_spawn` → acpx → `fountain acp` → sandbox → reply — is
+  green against the real acpx 0.11.2 (#760).
+
 - **In-app docs anchor links land on their section.** `/docs` and `/help`
   headings now carry GFM-style ids, so the docs' `#anchor` cross-links
   (e.g. `/docs/architecture#the-secrets-model`) scroll to the heading

--- a/cli/internal/acp/agent.go
+++ b/cli/internal/acp/agent.go
@@ -120,17 +120,28 @@ type setConfigOptionParams struct {
 }
 
 // setConfigOption accepts a client's request to change a session config option
-// — but does not apply it. Every option a Fountain conversation has, its model
-// above all, is a property of the *agent*: chosen once, server-side, and shared
-// by every conversation the agent runs. Changing it here would silently edit
-// the agent, which is why `session/set_model` is absent too (see modelState).
+// — but does not apply it, and does not pretend to. Every option a Fountain
+// conversation has, its model above all, is a property of the *agent*: chosen
+// once, server-side, and shared by every conversation the agent runs. Changing
+// it here would silently edit the agent, which is why `session/set_model` is
+// absent too (see modelState) and why `session/new` advertises no
+// `configOptions`: there is nothing a client can set.
 //
 // The method exists rather than returning "method not found" because some ACP
-// clients set the model at session start and treat a rejection as fatal —
-// OpenClaw's acpx pushes its own model over `session/set_config_option` and
-// aborts the whole turn on a -32601 here (found standing up the gateway round
-// trip). So the request is acknowledged and the unchanged state reported back,
-// leaving the agent's configuration authoritative.
+// clients push session controls at spawn and treat any rejection as fatal.
+// OpenClaw's acpx pushes the model its brain chose over
+// `session/set_config_option` (and, derived from that model, a `thinking`
+// level) and aborts the whole turn on a -32601 here — found standing up the
+// gateway round trip (#759, #760).
+//
+// The reply carries no `configOptions` list, deliberately. acpx narrows the
+// set of controls it will send to whatever list the last reply advertised
+// (`applyConfigOptionsToState` → `resolveSupportedConfigOptionId`), so echoing
+// the honest list — empty, or the fixed model alone — makes the *next* control
+// (`thinking`) fail with "does not advertise config option" and the turn dies
+// anyway. Saying nothing keeps acpx in its "not advertised, try it" mode, every
+// push lands here, and the agent's configuration stays authoritative. The
+// `_meta` block says so in as many words for a client that reads it.
 func (a *Agent) setConfigOption(raw json.RawMessage) (any, error) {
 	var params setConfigOptionParams
 	if len(raw) > 0 {
@@ -139,8 +150,7 @@ func (a *Agent) setConfigOption(raw json.RawMessage) (any, error) {
 		}
 	}
 
-	sess, ok := a.sessions.get(params.SessionID)
-	if !ok {
+	if _, ok := a.sessions.get(params.SessionID); !ok {
 		return nil, Errorf(CodeInvalidParams, "unknown session %q", params.SessionID)
 	}
 
@@ -150,7 +160,15 @@ func (a *Agent) setConfigOption(raw json.RawMessage) (any, error) {
 		"value", string(params.Value),
 		"why", "session options are properties of the Fountain agent, not the conversation")
 
-	return map[string]any{"configOptions": configOptions(sess.Agent)}, nil
+	return map[string]any{
+		"_meta": map[string]any{
+			"fountain": map[string]any{
+				"applied":  false,
+				"configId": params.ConfigID,
+				"reason":   "session options are properties of the Fountain agent; change them on the agent",
+			},
+		},
+	}, nil
 }
 
 // Notify handles client notifications.

--- a/cli/internal/acp/session.go
+++ b/cli/internal/acp/session.go
@@ -205,24 +205,6 @@ func modelState(ref AgentRef) map[string]any {
 	}
 }
 
-// configOptions reports a session's settable options as an ACP config-option
-// list, echoed back from setConfigOption so a client that pushed one sees the
-// resulting state. A Fountain agent exposes exactly one option, its model, and
-// it is fixed — chosen on the agent, shared by every conversation — so the list
-// has a single entry that is also the current value. See setConfigOption for
-// why the set is accepted but never applied.
-func configOptions(ref AgentRef) []map[string]any {
-	model := ref.Model
-	if model == "" {
-		model = "default"
-	}
-	return []map[string]any{{
-		"configId": "model", "id": "model", "name": "Model",
-		"currentValue": model, "value": model,
-		"options": []map[string]any{{"optionId": model, "id": model, "name": model}},
-	}}
-}
-
 // requireReady is the gate the session methods share: a client that has not
 // handshaked, or has no working credentials, gets a protocol error naming
 // which of the two it is rather than an authorization failure from three

--- a/cli/internal/acp/session_test.go
+++ b/cli/internal/acp/session_test.go
@@ -349,15 +349,23 @@ func TestSetConfigOptionIsAcceptedRatherThanRejected(t *testing.T) {
 		t.Fatalf("set_config_option returned an error: %v", rpcErr)
 	}
 
-	// The push is accepted but not applied: the agent's model is authoritative,
-	// so the echoed option still reports the agent's own value (here "default",
-	// since the test ref sets no model), never the client's.
-	opts, ok := result["configOptions"].([]map[string]any)
-	if !ok || len(opts) == 0 {
-		t.Fatalf("configOptions = %#v, want a non-empty list", result["configOptions"])
+	// The push is accepted but not applied: the agent's model is authoritative.
+	// The reply says so in _meta and — deliberately — advertises no
+	// configOptions list: acpx narrows the controls it will send to whatever
+	// list the last reply carried, so an honest empty (or model-only) list makes
+	// its next control fail with "does not advertise config option 'thinking'"
+	// and the turn dies anyway (#760).
+	if _, present := result["configOptions"]; present {
+		t.Errorf("configOptions = %#v, want the key absent (a list, even an honest one, makes acpx abort the next control)", result["configOptions"])
 	}
-	if got := opts[0]["currentValue"]; got != "default" {
-		t.Errorf("model currentValue = %v, want the agent's value \"default\" (the client's push must not apply)", got)
+	meta, _ := result["_meta"].(map[string]any)
+	fountainMeta, _ := meta["fountain"].(map[string]any)
+	if got := fountainMeta["applied"]; got != false {
+		t.Errorf("_meta.fountain.applied = %v, want false", got)
+	}
+	sess, _ := a.sessions.get("conv-9")
+	if sess.Agent.Model != "" {
+		t.Errorf("agent model = %q after the push, want unchanged (empty in this fixture)", sess.Agent.Model)
 	}
 }
 

--- a/decisions/0015-fountain-as-an-acp-agent.md
+++ b/decisions/0015-fountain-as-an-acp-agent.md
@@ -373,14 +373,43 @@ ships. Node ≥ 22.22.3 was the only gate, and Node 24.19.0 cleared it; simulati
 `acpx` beforehand was the faithful move, and running the real binary confirmed
 it rather than overturning it.
 
-**What is still open — do not read this as a shipped, gateway-verified integration.**
+**Update — 2026-08-16 (later): the gateway round trip is green.** A live
+`--dev` gateway daemon (OpenClaw 2026.7.1, acpx 0.11.2) ran
+`openclaw agent` → OpenClaw's own brain → `sessions_spawn(runtime: "acp",
+agentId: "fountain")` → acpx → `fountain acp` → sandbox → reply relayed back,
+against production. Two things had to change in the adapter, both about
+**session controls OpenClaw pushes at spawn** — its brain sends the model it
+chose (`anthropic/claude-haiku-4-5-…`) as a `sessions_spawn` argument, OpenClaw
+derives a `thinking` level from it, and acpx delivers both over
+`session/set_config_option`, treating any rejection as fatal:
 
-- **The full OpenClaw *gateway* path was not exercised end to end.** The smoke
-  drove the acpx engine directly (escape hatch and config file); it did not run a
-  turn through a live gateway daemon via `sessions_spawn` with channel delivery.
-  That wrapper is a thin OpenClaw-owned layer over the exact engine and config
-  schema verified above — but it is not the same as a green
-  channel-to-reply round trip, and a channel binding remains unproven.
+- [#759](https://github.com/BinaryBourbon/fountain/pull/759) implemented the
+  method as accept-but-do-not-apply (the agent's model is authoritative — the
+  same reason `session/set_model` is absent).
+- [#760](https://github.com/BinaryBourbon/fountain/issues/760): that reply must
+  **not** carry a `configOptions` list. acpx narrows the controls it will send
+  to whatever list the last reply advertised, so the honest list — empty, or the
+  fixed model alone — makes the *next* control fail with "does not advertise
+  config option 'thinking'" and the turn dies anyway. `fountain acp` therefore
+  advertises no session config options at all (`session/new` never did) and
+  answers `set_config_option` with `_meta.fountain.applied: false`. Advertising
+  `thinking`/`fast` to satisfy the check was considered and rejected: a
+  Fountain agent has neither, and saying otherwise is the "describes unbuilt
+  behaviour" failure this repo's guidance forbids.
+
+One cost is OpenClaw's, and stays: a `mode: "run"` spawn ensures the acpx
+session twice (spawn init, then turn) and one-shot acpx answers each with a
+fresh `session/new`, so every gateway spawn opens **two** Fountain
+conversations and prompts one; the orphan sits `pending` with a provisioned
+sandbox until the idle reaper parks it. Documented on the integration page;
+worth an upstream report, not an adapter workaround.
+
+**What is still open.**
+
+- **A channel binding remains unproven.** The round trip above was driven from
+  `openclaw agent` (the CLI front door to the gateway); a Telegram/Discord
+  binding is the same gateway path with a delivery step on the end, and has not
+  been run.
 - **Permission forwarding is still gate 4 / #643.** Nothing here changes that.
   OpenClaw runs the turn under `permissionMode: "approve-all"` and the sandbox's
   own policy; per-tool approvals do not round-trip to a channel any more than
@@ -390,8 +419,8 @@ it rather than overturning it.
   authenticates as the host's Fountain login. Per-channel-user identities are
   out of scope.
 
-This addendum records a proven adapter and a config-only path now verified
-against the real acpx binary — but not a full gateway-daemon round trip, and not
-permission forwarding. It does not alter the decision or the gates; it is
+This addendum records a proven adapter, a config-only path verified against
+the real acpx binary, and a green gateway-daemon round trip — but not a channel
+binding, and not permission forwarding. It does not alter the decision or the gates; it is
 evidence for the central claim that the dialects stop at the server boundary and
 every ACP client past it is the same forwarder.

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -134,6 +134,7 @@ two entries stay separate even when they point at the same agent.
 | `session/prompt` | Runs a turn; messages, thoughts and tool calls stream back to the channel as they happen |
 | `session/cancel` | `/acp cancel` interrupts the running turn |
 | `session/load` | Replays the conversation when a session is resumed |
+| `session/set_config_option` | Accepted, not applied. OpenClaw pushes the model its brain chose (and a `thinking` level derived from it) at every spawn; a Fountain agent's model is set on the agent, so the push is acknowledged and ignored, and the reply's `_meta.fountain.applied: false` says so |
 
 ## Limits, stated rather than discovered
 
@@ -150,6 +151,16 @@ two entries stay separate even when they point at the same agent.
   above — an OpenClaw channel is not asked to approve a tool call
   ([#643](https://github.com/BinaryBourbon/fountain/issues/643),
   [#708](https://github.com/BinaryBourbon/fountain/issues/708)).
+- **A gateway spawn opens two conversations, and uses one.** OpenClaw's
+  `sessions_spawn(runtime: "acp", mode: "run")` asks acpx to ensure the session
+  twice — once when the spawn is initialised, once when the turn runs — and in
+  one-shot mode acpx answers each with a fresh `session/new`. On Fountain that
+  is two conversations per spawn, each with a provisioned sandbox; the first is
+  never prompted and sits `pending` until the idle reaper parks it. This is
+  OpenClaw/acpx behaviour, not something the adapter can prevent
+  ([#760](https://github.com/BinaryBourbon/fountain/issues/760)). Sessions
+  bound to a channel thread (`mode: "session"`) reuse their record and do not
+  pay this.
 - **A reclaimed sandbox loses the agent's memory.** If a conversation's sandbox
   was reclaimed while you were away, resuming still replays the full transcript,
   but the agent itself does not remember it
@@ -164,6 +175,14 @@ JSON-RPC 2.0 over stdio — completed `initialize → session/new →
 session/prompt`, ran the turn in a real sandbox, and streamed the agent's reply
 back as `agent_message_chunk` updates with a real stop reason. That is exactly
 what `acpx` does when it spawns the command above.
+
+The full gateway round trip is also proven: `openclaw agent` (OpenClaw's own
+brain) → `sessions_spawn(runtime: "acp", agentId: "fountain")` → acpx →
+`fountain acp` → sandbox → the reply relayed back through the gateway, against
+the real acpx (0.11.2) and OpenClaw (2026.7.1) — with the brain pushing its
+model and a `thinking` level at the harness on the way, which is the case that
+used to abort the turn ([#759](https://github.com/BinaryBourbon/fountain/issues/759),
+[#760](https://github.com/BinaryBourbon/fountain/issues/760)).
 
 If a session does not start, `fountain acp` writes the protocol to stdout and
 **everything else to stderr**, which is where OpenClaw's `acpx` log shows it.


### PR DESCRIPTION
Closes #760.

## The answers to the issue's questions (all three, decided here)

**1. Should `fountain acp` advertise `configOptions` (`thinking`, `fast`)?** No. A Fountain agent has one fixed model and no per-session thinking/fast, so advertising them is describing behaviour that does not exist. And it would not even help — see the mechanism below.

**2. Is there an acpx/OpenClaw config to disable control sync?** No. Read from source (acpx 0.11.2 TS via source maps, OpenClaw 2026.7.1 dist): the controls come from `sessions_spawn`'s `model` argument — which OpenClaw's **brain passes on its own** (haiku did, on most calls, with its resolved id `anthropic/claude-haiku-4-5-20251001`) — plus a `thinking` level OpenClaw derives from that model (`resolveThinkingDefault` → `"off"`), plus an optional timeout. Removing `model` from the fountain `agents.list[]` entry does not stop it (tested), because the brain supplies it. There is no knob.

**3. Upstream-worthy?** Yes, two things (draft below) — but the blocking part was **ours**.

## The actual mechanism

acpx narrows the set of controls it will send to whatever `configOptions` list the *last reply* advertised (`applyConfigOptionsToState` → `resolveSupportedConfigOptionId`), and OpenClaw does the same with `configOptionKeys` from `getCapabilities`. Fountain's `session/new` advertises nothing (→ "not advertised, try it"), but the #759 `set_config_option` reply echoed a model-only list — in a shape the ACP SDK drops as invalid (no `type: "select"`, `optionId` instead of `value`), so acpx saw **`[]`** and the next control died with `does not advertise config option 'thinking'. Supported config options: none.` (reproduced live before the fix). An honest `[model]` list fails the same way one step later on `thinking`. So the only reply that keeps a control-pushing client working is one that advertises no list at all.

## The change

`session/set_config_option` still accepts-and-does-not-apply (agent config authoritative, as #759), but the reply is now `{ "_meta": { "fountain": { "applied": false, "configId": …, "reason": … } } }` — no `configOptions`. The unused `configOptions()` helper is gone. Test asserts the key is absent, `_meta.applied=false`, and the agent's model is unchanged.

## Verified live — the gateway round trip is green

Live `openclaw --dev gateway` (2026.7.1, acpx 0.11.2, Node 24): `openclaw agent --agent fountain` → brain → `sessions_spawn(runtime:"acp", agentId:"fountain", model:"anthropic/claude-haiku-4-5-20251001")` → acpx → `fountain acp --agent acp-proof-659` → prod sandbox → **`GATEWAY-C-OK`** relayed back (child session `done`, Fountain conversation `44874eb4…` idle with 1 completed turn titled `GATEWAY-C-OK`). The `fountain acp` trace on a second run shows the pushes landing (`configId=model`, `configId=thinking value="off"`) and being ignored. Same config, pre-fix binary: `does not advertise config option 'thinking'` (Test A/B in the session).

## Found on the way — OpenClaw's, documented, not worked around

A `mode: "run"` spawn calls acpx `ensureSession` **twice** (spawn init, then turn), and one-shot acpx answers each with a fresh `session/new` → **two Fountain conversations per spawn, one never prompted** (pending, sandbox provisioned, until the idle reaper parks it). Documented in "Limits" on the OpenClaw page and in the ADR addendum.

## Draft upstream reports (not filed — say the word)

- **OpenClaw**: `applyManagerRuntimeControls` pushes a `thinking` level it *derived* (default `"off"`) as a hard requirement; a harness that advertises neither `thinking` nor `effort` should get best-effort skip (as `timeout` already does), at least for the default value. Same for pushing OpenClaw's own `provider/model` ref at a custom harness whose advertised models do not include it.
- **acpx**: one-shot `ensureSession` creates a new backend session on every call; when OpenClaw ensures at init and again at turn, the first session is orphaned.

## Files
- `cli/internal/acp/agent.go`, `session.go`, `session_test.go`
- `docs/integrations/openclaw.md` — `set_config_option` row, gateway proof, the two-sessions limit
- `decisions/0015` addendum — gateway round trip green; open list trimmed to channel binding + #643 (`okf validate` clean)
- `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)