### PR TITLE
ci(build): docs/ and CHANGELOG.md changes build the image — they are in it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,11 +66,18 @@ jobs:
 
       - name: Skip paths that never affect the OCI image
         id: filter
-        # The old push-trigger paths-ignore list (k8s/**, deploy/**, docs/**,
-        # decisions/**, **/*.md — deploy/ is the portable self-hosting
+        # The old push-trigger paths-ignore list (k8s/**, deploy/**,
+        # decisions/**, root-level *.md — deploy/ is the portable self-hosting
         # manifests, never part of the image), re-implemented as a diff from
         # the newest first-parent ancestor whose image EXISTS in the registry
-        # (#414) — not HEAD^. Diffing one commit back assumed every ancestor
+        # (#414) — not HEAD^.
+        #
+        # docs/** and CHANGELOG.md are NOT on the list, deliberately: since
+        # the in-app docs site, Fountain.Docs embeds both at compile time, so
+        # a docs-only commit changes the image. With them ignored, prod's
+        # /docs sat on the previous code commit's copy until the next code
+        # change happened to ship (found at v0.11.0: the changelog and the
+        # OpenClaw page went stale on prod while the release image had them). Diffing one commit back assumed every ancestor
         # got built; a cancelled CI run plus a docs-only follow-up broke that
         # assumption, and the follow-up's one-commit diff reported "nothing
         # image-affecting" while the cancelled commit's code sat un-built.
@@ -101,8 +108,12 @@ jobs:
           fi
 
           echo "diffing against newest built ancestor ${base:0:7}"
-          if git diff --name-only "${base}" HEAD \
-              | grep -qvE '^(k8s|deploy|docs|decisions)/|\.md$'; then
+          changed="$(git diff --name-only "${base}" HEAD)"
+          # Anything outside the ignore list, or CHANGELOG.md itself (a
+          # root-level .md that IS in the image), means a build.
+          if [ -n "${changed}" ] && printf '%s\n' "${changed}" \
+               | grep -qvE '^(k8s|deploy|decisions)/|^[^/]*\.md$' \
+             || printf '%s\n' "${changed}" | grep -qx 'CHANGELOG.md'; then
             echo "image-affecting changes since ${base:0:7} — building"
             echo "build=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
Found while verifying the v0.11.0 release.

## Symptom
Prod pods stayed on `sha-6b7669c` (#767) after #768 (changelog) and #769 (OpenClaw docs) merged: `publish-manifests` for `b52aa4d` logged `manifest tree b52aa4d pins image …:sha-6b7669c…` because build.yml's gate decided "only ignored paths changed" — `docs/**` and `*.md` were on its never-affects-the-image list. But `Fountain.Docs` embeds `docs/` and `CHANGELOG.md` at compile time for `/docs`, so those commits *do* change the image. Prod's `/docs/integrations/openclaw` and `/docs/changelog` were stale while the v0.11.0 release image (built unconditionally by release.yml) had them.

## Change
Ignore list becomes `k8s/`, `deploy/`, `decisions/`, and **root-level** `*.md` except `CHANGELOG.md`. Table-tested the shell condition:

| changed | old | new |
|---|---|---|
| `docs/integrations/openclaw.md` | skip | **build** |
| `CHANGELOG.md` | skip | **build** |
| `README.md` | skip | skip |
| `k8s/…`, `deploy/…` | skip | skip |
| `decisions/0015.md README.md` | skip | skip |
| `cli/README.md` | skip | build (fail-safe, rare) |
| `apps/…/x.ex` | build | build |

Plus an empty-diff guard. `publish-manifests.yml` needs no change (it pins the newest ancestor whose image exists; the fix is that the image now exists).

Immediate remediation for prod was a manual `build.yml` dispatch on main (`a4cdd2c`, the v0.11.0 tree) — in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)