### PR TITLE
fix(acp): a turn in flight across a deploy no longer hangs on reattach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Fixed
+
+- **An ACP turn in flight across a deploy no longer hangs.** Every deploy
+  restarts every `ConversationServer`; the agent in the sandbox keeps running
+  and the server reattached to its session — but on the ACP path it reattached
+  with no peer, so nobody answered the agent's `session/request_permission`
+  and nobody saw the `session/prompt` response. The turn sat `running` until
+  the user prompted again (which interrupts it) or the sandbox hit its
+  lifetime ceiling. The peer now records the prompt's JSON-RPC id on the turn
+  and a reattach starts a peer in attach mode that resumes exactly that
+  request; a turn whose prompt was never sent is orphaned cleanly instead of
+  left to hang. Replayed output is de-duplicated by content: sprites replays
+  the last 16 KiB of the session, not the whole buffer, so the byte-count
+  skip could not apply.
+
 ## [0.11.0] — 2026-08-16
 
 Fountain can now **host a Buzz agent** — a Nostr identity whose coding-agent

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -930,6 +930,27 @@ defmodule Fountain.Conversations do
     |> Map.new()
   end
 
+  @doc """
+  The most recent persisted output lines of one stream for a turn, as a set.
+
+  Feeds the ACP reattach path: sprites replays the tail of the session buffer
+  (measured at 16 KiB), and the peer re-encodes protocol lines so a byte count
+  cannot align the replay with what is already stored — content can. `limit`
+  rows is comfortably more than 16 KiB of `session/update` lines.
+  """
+  def _unsafe_recent_output_lines(conversation_id, turn_id, stream, limit \\ 400) do
+    from(e in LogEvent,
+      where:
+        e.conversation_id == ^conversation_id and e.turn_id == ^turn_id and
+          e.kind == "output" and e.stream == ^stream,
+      order_by: [desc: e.id],
+      limit: ^limit,
+      select: e.data
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
   # ── high-level lifecycle ──────────────────────────────────────────────────────────
 
   alias Fountain.Agents

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -273,6 +273,11 @@ defmodule Fountain.Conversations.ConversationServer do
       # Bytes of replayed output to drop on reattach, keyed by stream.
       # Empty map outside a reattach window. See attempt_session_attach.
       replay_skip: %{},
+      # ACP reattach: the `acp` lines already persisted for the in-flight
+      # turn, so the sprite's replayed tail is not written twice. Consumed as
+      # matches arrive and cleared on a timer; empty outside a reattach
+      # window. See attempt_session_attach.
+      replay_dedup: MapSet.new(),
       # Per-tenant DEK + decrypted inference credentials. Loaded in
       # handle_continue(:provision) once the conversation row tells us the
       # owning user_id; held for the conversation lifetime; dropped on
@@ -864,23 +869,45 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp attempt_session_attach(state, running_turn, [session | _]) do
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    acp? = Fountain.Runtimes.ACP.enabled?(conv.runtime)
+
     case Fountain.Sandbox.attach(state.handle, session.id, owner: self(), stdin: true) do
+      {:ok, idle_command} when acp? and is_nil(running_turn.acp_prompt_id) ->
+        # The previous peer died before it wrote `session/prompt` (or the turn
+        # predates the column). The adapter is sitting idle in its handshake
+        # with nothing to answer, and no peer can pick that up: the ids it
+        # would need are gone with the process. Stop it — otherwise it lingers
+        # as a session the next reattach could bind to — and orphan the turn.
+        Fountain.Sandbox.stop_command(idle_command)
+        mark_orphan(state, running_turn, "acp_prompt_not_sent")
+        state
+
       {:ok, command} ->
-        # sprites replays the session's buffered output before live-tailing.
-        # Count the bytes we already persisted for this turn so the
-        # stdout/stderr handlers can drop the replayed prefix.
+        # sprites replays the tail of the session's buffered output before
+        # live-tailing. On the legacy path, count the bytes we already
+        # persisted for this turn so the stdout/stderr handlers can drop the
+        # replayed prefix. On the ACP path the peer re-encodes protocol lines
+        # so byte counts do not line up; the replayed lines are matched by
+        # content instead (`replay_dedup`).
         replay_skip =
-          Conversations._unsafe_output_bytes_by_stream(state.conversation_id, running_turn.id)
+          if acp?,
+            do: %{},
+            else:
+              Conversations._unsafe_output_bytes_by_stream(
+                state.conversation_id,
+                running_turn.id
+              )
 
         publish_stage(state.conversation_id, "reattach", "done", %{
           outcome: "session_attached",
           session_id: session.id,
           turn_id: running_turn.id,
           turn_number: running_turn.turn_number,
-          replay_skip_bytes: replay_skip
+          replay_skip_bytes: replay_skip,
+          acp_prompt_id: running_turn.acp_prompt_id
         })
 
-        conv = Conversations._unsafe_get_conversation!(state.conversation_id)
         {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
 
         # turn_metrics stays nil on purpose, so this turn contributes no
@@ -888,7 +915,7 @@ defmodule Fountain.Conversations.ConversationServer do
         # monotonic time isn't comparable across a restart, and measuring
         # from the row's started_at would fold the whole deploy gap into the
         # histogram. A missing sample beats a wrong one.
-        %{
+        state = %{
           state
           | current_command: command,
             current_command_ref: command.ref,
@@ -896,11 +923,50 @@ defmodule Fountain.Conversations.ConversationServer do
             replay_skip: replay_skip
         }
 
+        if acp?, do: reattach_acp_peer(state, running_turn, conv), else: state
+
       {:error, reason} ->
         Logger.warning("attach_session failed: #{inspect(reason)}")
         mark_orphan(state, running_turn, "attach_failed")
         state
     end
+  end
+
+  @replay_dedup_ttl_ms 10_000
+
+  # An ACP turn is only alive while something answers the agent: a
+  # `session/request_permission` left unanswered blocks it forever, and the
+  # `session/prompt` response is the only thing that ends it — the adapter
+  # keeps running until stdin closes. Before this, a reattached ACP turn had
+  # its stdout logged raw and no peer, so every turn in flight across a deploy
+  # hung until the user prompted again (which interrupts it) or the sandbox
+  # hit its lifetime ceiling.
+  #
+  # No tracer: the turn span belongs to a previous BEAM lifetime.
+  defp reattach_acp_peer(state, running_turn, conv) do
+    {:ok, peer} =
+      Fountain.Runtimes.ACP.Peer.start(
+        owner: self(),
+        command: state.current_command,
+        ref: state.current_command_ref,
+        prompt: running_turn.prompt,
+        mode: :continue,
+        session_id: conv.runtime_session_id,
+        attach: running_turn.acp_prompt_id
+      )
+
+    dedup =
+      Conversations._unsafe_recent_output_lines(state.conversation_id, running_turn.id, "acp")
+
+    Process.send_after(self(), :clear_replay_dedup, @replay_dedup_ttl_ms)
+
+    %{
+      state
+      | acp_peer: peer,
+        acp_peer_mon: Process.monitor(peer),
+        stream_tracer: nil,
+        replay_dedup: dedup
+    }
   end
 
   defp mark_orphan(state, running_turn, why) do
@@ -1267,19 +1333,13 @@ defmodule Fountain.Conversations.ConversationServer do
   # the log budget, the redaction pass and the replay skip. A peer writing rows
   # itself would bypass all three.
   def handle_info({:acp, ref, {:lines, stream, data}}, %{current_command_ref: ref} = state) do
-    new_state = log_with_replay_skip(state, stream, data)
-
-    # Each "acp" report is one session/update line; the tracer turns tool_call
-    # / tool_call_update into child spans. Peer-relayed lines never replay (a
-    # peer lives for exactly one turn), so no replay-suffix arithmetic here.
-    tracer =
-      if stream == "acp" do
-        Fountain.Runtimes.ACP.Tracer.handle_line(new_state.stream_tracer, data)
-      else
-        new_state.stream_tracer
-      end
-
-    {:noreply, %{new_state | stream_tracer: tracer}}
+    if stream == "acp" and MapSet.member?(state.replay_dedup, data) do
+      # A replayed line we already hold (ACP reattach). Each persisted line
+      # suppresses at most one arrival, so a legitimate later repeat survives.
+      {:noreply, %{state | replay_dedup: MapSet.delete(state.replay_dedup, data)}}
+    else
+      {:noreply, persist_acp_lines(state, stream, data)}
+    end
   end
 
   # The runtime refused the agent's model. Published as a stage event so it
@@ -1310,6 +1370,15 @@ defmodule Fountain.Conversations.ConversationServer do
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: id})
     {:noreply, %{state | runtime_session_id: id}}
+  end
+
+  # The peer wrote `session/prompt` under this JSON-RPC id. Persisted at once:
+  # it is what a reattach after a restart needs to tell the prompt's answer
+  # from the replayed handshake, and a turn without it cannot be resumed at
+  # all — see `reattach_acp_peer/3`.
+  def handle_info({:acp, ref, {:prompt_sent, id}}, %{current_command_ref: ref} = state) do
+    {:ok, turn} = Conversations._unsafe_update_turn(state.current_turn, %{acp_prompt_id: id})
+    {:noreply, %{state | current_turn: turn}}
   end
 
   # The number gate 2 exists to produce: what a turn pays for `initialize` plus
@@ -1484,6 +1553,12 @@ defmodule Fountain.Conversations.ConversationServer do
   def handle_info({:error, _ref, reason}, state) do
     Logger.error("sprite command error: #{inspect(reason)}")
     {:noreply, state}
+  end
+
+  # The ACP reattach window is over; anything still in the set is a persisted
+  # line the replay did not repeat, and must not suppress a genuine repeat.
+  def handle_info(:clear_replay_dedup, state) do
+    {:noreply, %{state | replay_dedup: MapSet.new()}}
   end
 
   # ── sandbox lifetime ──────────────────────────────────────────────────────
@@ -2340,6 +2415,26 @@ defmodule Fountain.Conversations.ConversationServer do
       :ok -> Fountain.Sandbox.close_stdin(command)
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  # Persistence for peer-relayed lines: the log budget, redaction and the
+  # legacy replay skip all live on this path; the tracer reads protocol lines
+  # from the peer's reports, never raw chunks.
+  defp persist_acp_lines(state, stream, data) do
+    new_state = log_with_replay_skip(state, stream, data)
+
+    # Each "acp" report is one session/update line; the tracer turns tool_call
+    # / tool_call_update into child spans. Peer-relayed lines carry no byte
+    # replay-suffix arithmetic: a fresh peer's lines never replay, and an
+    # attached peer's replayed lines were matched by content before this.
+    tracer =
+      if stream == "acp" do
+        Fountain.Runtimes.ACP.Tracer.handle_line(new_state.stream_tracer, data)
+      else
+        new_state.stream_tracer
+      end
+
+    %{new_state | stream_tracer: tracer}
   end
 
   defp start_acp_peer(command, prompt, mode, runtime_session_id, opts) do

--- a/apps/fountain/lib/fountain/conversations/turn.ex
+++ b/apps/fountain/lib/fountain/conversations/turn.ex
@@ -16,6 +16,9 @@ defmodule Fountain.Conversations.Turn do
     field :exit_code, :integer
     field :started_at, :utc_datetime
     field :ended_at, :utc_datetime
+    # JSON-RPC id of the ACP `session/prompt` in flight; nil on the legacy
+    # path and until the peer has written the prompt. See the migration.
+    field :acp_prompt_id, :integer
     belongs_to :conversation, Conversation
     has_many :images, TurnImage, preload_order: [asc: :position]
     timestamps(type: :utc_datetime, updated_at: false)
@@ -32,6 +35,7 @@ defmodule Fountain.Conversations.Turn do
       :exit_code,
       :started_at,
       :ended_at,
+      :acp_prompt_id,
       :conversation_id
     ])
     |> validate_required([:turn_number, :prompt, :status, :conversation_id])

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -52,6 +52,29 @@ defmodule Fountain.Runtimes.ACP.Peer do
   version, and discovering at runtime that this build cannot resume is better
   handled by taking the expensive path than by failing the turn.
 
+  ## Reattaching after a restart
+
+  A deploy restarts every `ConversationServer`, and with it every peer — but
+  the adapter in the sprite is a detachable session that keeps running,
+  mid-turn, with a `session/prompt` still outstanding. `attach: prompt_id`
+  starts a peer for that turn without a handshake: it joins the stream already
+  in flight, answers the agent's requests (a `session/request_permission`
+  nobody answers is a turn that never ends), and closes the turn on the
+  response to `prompt_id`. Everything else in the replayed prefix — the
+  handshake responses, a model rejection the previous peer already reported —
+  is history and is dropped rather than re-acted-on.
+
+  The prompt id has to come from the caller because it is the only way to
+  tell the prompt's answer from a replayed handshake response; the peer
+  reports `{:prompt_sent, id}` the moment it writes the prompt so the server
+  can persist it for exactly this purpose. Without it a reattached turn cannot
+  be resumed at all, and the caller orphans it instead.
+
+  Sprites replays the **tail** of the session buffer (measured: one 16 KiB
+  chunk, starting mid-line — not from the beginning), so an attached peer
+  drops the partial first line and the server de-duplicates the replayed
+  lines it already holds by content, not by byte count.
+
   ## What it sends back
 
   Everything goes to the owner as `{:acp, ref, payload}` so the server can keep
@@ -76,6 +99,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
   @type payload ::
           {:lines, stream :: String.t(), data :: String.t()}
           | {:session, String.t()}
+          | {:prompt_sent, pos_integer()}
           | {:model_rejected, requested :: String.t(), detail :: String.t()}
           | {:handshake_ms, non_neg_integer(), method :: String.t()}
           | {:done, stop_reason :: String.t()}
@@ -109,7 +133,12 @@ defmodule Fountain.Runtimes.ACP.Peer do
       replay_until_ms: nil,
       capabilities: %{},
       auth_methods: [],
-      authenticated?: false
+      authenticated?: false,
+      # `attach: prompt_id` mode: joined a turn already in flight, so replayed
+      # responses to ids we never sent are expected, and the first chunk may
+      # start mid-line.
+      attached?: false,
+      drop_partial_line?: false
     ]
   end
 
@@ -120,6 +149,11 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   Required opts: `:owner`, `:command`, `:ref`, `:prompt`, `:mode`,
   `:session_id`, `:cwd`.
+
+  `attach: prompt_id` skips the handshake and resumes a turn whose
+  `session/prompt` (with that JSON-RPC id) is already outstanding on the
+  attached command — see the moduledoc. `:session_id` must be the live
+  session's id so `cancel/1` still works.
   """
   def start(opts), do: GenServer.start(__MODULE__, opts)
 
@@ -158,7 +192,21 @@ defmodule Fountain.Runtimes.ACP.Peer do
       started_mono: System.monotonic_time(:millisecond)
     }
 
-    {:ok, state, {:continue, :initialize}}
+    case Keyword.get(opts, :attach) do
+      nil ->
+        {:ok, state, {:continue, :initialize}}
+
+      prompt_id when is_integer(prompt_id) ->
+        {:ok,
+         %{
+           state
+           | phase: :prompting,
+             pending: %{prompt_id => :prompt},
+             next_id: prompt_id + 1,
+             attached?: true,
+             drop_partial_line?: true
+         }}
+    end
   end
 
   @impl true
@@ -168,6 +216,24 @@ defmodule Fountain.Runtimes.ACP.Peer do
   end
 
   @impl true
+  def handle_cast({:stdout, data}, %State{drop_partial_line?: true} = state) do
+    # The replay starts wherever the sprite's buffer happens to start, which is
+    # mid-line unless we are lucky. A fragment that does not open a JSON object
+    # can only be the tail of a line we cannot parse: drop through its newline.
+    # A chunk with no newline yet is the same fragment still arriving.
+    cond do
+      String.starts_with?(data, "{") ->
+        handle_cast({:stdout, data}, %{state | drop_partial_line?: false})
+
+      String.contains?(data, "\n") ->
+        [_partial, rest] = String.split(data, "\n", parts: 2)
+        handle_cast({:stdout, rest}, %{state | drop_partial_line?: false})
+
+      true ->
+        {:noreply, state}
+    end
+  end
+
   def handle_cast({:stdout, data}, state) do
     {messages, buffer} = Protocol.feed(state.buffer, data)
 
@@ -227,6 +293,10 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   defp handle_message({:response, id, result}, state) do
     case pop_pending(state, id) do
+      {nil, %State{attached?: true} = state} ->
+        # A replayed answer to the previous peer's handshake. Expected.
+        state
+
       {nil, state} ->
         Logger.warning("acp peer: response to unknown request #{inspect(id)}")
         state
@@ -250,6 +320,14 @@ defmodule Fountain.Runtimes.ACP.Peer do
     |> report_model_rejected(error)
     |> send_prompt()
   end
+
+  # Attached mid-turn: an error for an id we never sent is a replay of one the
+  # previous peer already handled — a `session/set_config_option` refusal is the
+  # common one, and it was reported as a stage event at the time. Only the
+  # prompt's own error can fail this turn.
+  defp handle_message({:error_response, id, _error}, %State{attached?: true} = state)
+       when not is_map_key(state.pending, id),
+       do: state
 
   # Backstop for an agent that advertises no auth method at `initialize` and
   # then refuses anyway. The eager path above covers everything measured; this
@@ -550,7 +628,12 @@ defmodule Fountain.Runtimes.ACP.Peer do
       prompt: [%{type: "text", text: state.prompt} | image_blocks(state.images)]
     }
 
-    send_request(%{state | phase: :prompting}, :prompt, "session/prompt", params)
+    id = state.next_id
+    state = send_request(%{state | phase: :prompting}, :prompt, "session/prompt", params)
+
+    # Reported after the write so the server never persists an id for a prompt
+    # that did not go out. Reattach reads it back — see the moduledoc.
+    if state.phase == :failed, do: state, else: tap(state, &report(&1, {:prompt_sent, id}))
   end
 
   # ACP carries images in the prompt itself, so the legacy dance — write the

--- a/apps/fountain/priv/repo/migrations/20260817000000_add_acp_prompt_id_to_turns.exs
+++ b/apps/fountain/priv/repo/migrations/20260817000000_add_acp_prompt_id_to_turns.exs
@@ -1,0 +1,14 @@
+defmodule Fountain.Repo.Migrations.AddAcpPromptIdToTurns do
+  use Ecto.Migration
+
+  # The JSON-RPC id of the `session/prompt` request in flight for an ACP turn.
+  # Set the moment the peer writes the prompt; read by the reattach path after
+  # a BEAM restart, which needs it to tell the prompt's answer apart from the
+  # replayed handshake responses. NULL means the prompt was never sent (or the
+  # turn predates this column) — the turn cannot be resumed and is orphaned.
+  def change do
+    alter table(:turns) do
+      add :acp_prompt_id, :integer
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -163,6 +163,17 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert Conversations._unsafe_get_conversation!(conv.id).runtime_session_id == "sess_1"
     end
 
+    test "persists the prompt's JSON-RPC id so a restart can resume the turn", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.acp_prompt_id == prompt_id
+    end
+
     test "protocol chatter never reaches the transcript", %{conv: conv, pid: pid, ref: ref} do
       drive_to_prompt(pid, ref)
 
@@ -422,6 +433,175 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       settle(pid)
 
       refute_receive {:fs_write, "/tmp/aod_turn_" <> _}, 100
+    end
+  end
+
+  describe "reattach — a deploy lands mid-turn" do
+    # Every deploy restarts every ConversationServer; the adapter in the sprite
+    # is a detachable session and keeps running. Before this describe existed
+    # the reattach path re-hooked the command and logged its stdout raw: no
+    # peer, so nobody answered `session/request_permission` and nobody saw the
+    # `session/prompt` response. Every ACP turn in flight across a deploy hung
+    # until the user prompted again (interrupting it) or the sandbox hit its
+    # lifetime ceiling — 8 such turns were found stuck in production the day
+    # this was written, one of them 15 hours in.
+
+    # A conversation with a `ready` sandbox and a `running` turn, which is
+    # exactly what the server finds after a restart. `attach` hands back a
+    # command with our ref; every stdin write reaches the test process.
+    defp reattach_fixture(prompt_id) do
+      user = insert_verified_user()
+      agent = acp_agent(user)
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      conv =
+        insert_conversation(
+          agent: agent,
+          user_id: user.id,
+          sandbox: sandbox,
+          status: "running",
+          runtime_session_id: "sess_live"
+        )
+
+      turn =
+        insert_turn(conv, %{
+          status: "running",
+          prompt: "long task",
+          started_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          acp_prompt_id: prompt_id
+        })
+
+      stub_happy_sprite()
+      test = self()
+      ref = make_ref()
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :list_sessions, fn _h ->
+        {:ok, [%Fountain.Sandbox.Session{id: "9350"}]}
+      end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :attach, fn _h, "9350", _opts ->
+        {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
+      end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _c, data ->
+        send(test, {:wrote, IO.iodata_to_binary(data)})
+        :ok
+      end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _c ->
+        send(test, :stdin_closed)
+        :ok
+      end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :stop_command, fn _c ->
+        send(test, :command_stopped)
+        :ok
+      end)
+
+      {conv, turn, ref}
+    end
+
+    defp start_reattached(conv) do
+      {pid, _mon, :alive} = start_server(conv)
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      pid
+    end
+
+    defp raw_update(update) do
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "method" => "session/update",
+        "params" => %{"sessionId" => "sess_live", "update" => update}
+      }) <> "\n"
+    end
+
+    test "a peer joins the running turn: permission answered, prompt response ends it", %{} do
+      {conv, turn, ref} = reattach_fixture(4)
+      pid = start_reattached(conv)
+
+      assert is_pid(:sys.get_state(pid).acp_peer)
+      # Attach mode is silent on start: no initialize, no second prompt.
+      refute_receive {:wrote, _}, 100
+
+      # The sprite replays a mid-line tail, then live-tails. Here the agent
+      # asks permission mid-tool-call — the exact frame found at the end of the
+      # hung production turn.
+      send(pid, {:stdout, %{ref: ref}, ~s(le":"tail-of-a-replayed-line"}}}\n)})
+
+      send(
+        pid,
+        {:stdout, %{ref: ref},
+         Jason.encode!(%{
+           "jsonrpc" => "2.0",
+           "id" => 5,
+           "method" => "session/request_permission",
+           "params" => %{"options" => [%{"optionId" => "allow", "kind" => "allow_once"}]}
+         }) <> "\n"}
+      )
+
+      assert_receive {:wrote, answer}, 1_000
+
+      assert %{"id" => 5, "result" => %{"outcome" => %{"optionId" => "allow"}}} =
+               Jason.decode!(answer)
+
+      reply(pid, ref, 4, %{"stopReason" => "end_turn"})
+
+      assert_receive :stdin_closed, 1_000
+      assert Fountain.Repo.reload!(turn).status == "completed"
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+      assert :sys.get_state(pid).current_command == nil
+    end
+
+    test "replayed lines already persisted are not written twice; new ones are", %{} do
+      {conv, turn, ref} = reattach_fixture(4)
+
+      already = raw_update(%{"sessionUpdate" => "usage_update", "used" => 100})
+
+      # What the previous peer persisted for this turn: the peer's own
+      # re-encoding of the line, which is what a fresh peer produces again.
+      {:notification, "session/update", params} =
+        Fountain.Runtimes.ACP.Protocol.classify_line(String.trim_trailing(already, "\n"))
+
+      Conversations.log!(%{
+        conversation_id: conv.id,
+        turn_id: turn.id,
+        kind: "output",
+        stream: "acp",
+        stage: "turn",
+        data:
+          IO.iodata_to_binary(
+            Fountain.Runtimes.ACP.Protocol.notification("session/update", params)
+          )
+      })
+
+      pid = start_reattached(conv)
+      fresh = raw_update(%{"sessionUpdate" => "usage_update", "used" => 250})
+
+      # The replay repeats the persisted line and brings one the old server
+      # never saw (emitted during the deploy gap).
+      send(pid, {:stdout, %{ref: ref}, already <> fresh})
+      settle(pid)
+
+      acp = Enum.filter(Conversations._unsafe_list_log_events(conv.id), &(&1.stream == "acp"))
+      assert Enum.count(acp, &(&1.data =~ ~s("used":100))) == 1
+      assert Enum.count(acp, &(&1.data =~ ~s("used":250))) == 1
+    end
+
+    test "a turn whose prompt was never sent is orphaned and its adapter stopped", %{} do
+      # The previous peer died mid-handshake: the adapter is idle waiting for a
+      # prompt no peer can now write. Nothing to resume — end it cleanly rather
+      # than leave a session the next reattach would bind to.
+      {conv, turn, _ref} = reattach_fixture(nil)
+      pid = start_reattached(conv)
+
+      assert_receive :command_stopped, 1_000
+      assert :sys.get_state(pid).acp_peer == nil
+      assert :sys.get_state(pid).current_command == nil
+      assert Fountain.Repo.reload!(turn).status == "interrupted"
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      stages = Enum.filter(Conversations._unsafe_list_log_events(conv.id), &(&1.kind == "stage"))
+      assert Enum.any?(stages, &(&1.stage == "reattach" and &1.data =~ "acp_prompt_not_sent"))
     end
   end
 

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -109,9 +109,15 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
 
       assert_receive {:acp, _ref, {:session, "sess_abc"}}
 
-      assert %{"method" => "session/prompt", "params" => prompt_params} = next_write()
+      assert %{"method" => "session/prompt", "id" => prompt_id, "params" => prompt_params} =
+               next_write()
+
       assert prompt_params["sessionId"] == "sess_abc"
       assert [%{"type" => "text", "text" => "do the thing"}] = prompt_params["prompt"]
+
+      # The id is reported the moment the prompt is on the wire: it is what a
+      # reattach after a restart resumes the turn by.
+      assert_receive {:acp, _ref, {:prompt_sent, ^prompt_id}}
     end
 
     test "a session response with no id fails the turn rather than prompting blind", ctx do
@@ -728,6 +734,119 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
 
       send_response(pid, set_id, %{})
       assert %{"method" => "session/prompt"} = next_write()
+    end
+  end
+
+  describe "attach — resuming a turn already in flight" do
+    # A deploy restarts the peer while the adapter, a detachable session in the
+    # sprite, keeps running with `session/prompt` outstanding. The new peer is
+    # handed the prompt's id and joins the stream: no handshake, replayed
+    # history ignored, live requests answered, the prompt's answer ends it.
+
+    defp attached_peer(ctx, prompt_id \\ 4) do
+      start_peer(ctx, mode: :continue, session_id: "sess_live", attach: prompt_id)
+    end
+
+    test "writes nothing on start — no initialize, no session call, no second prompt", ctx do
+      pid = attached_peer(ctx)
+      _ = :sys.get_state(pid)
+      refute_receive {:wrote, _}, 100
+    end
+
+    test "the replayed handshake — responses and a model refusal — is ignored", ctx do
+      pid = attached_peer(ctx, 4)
+
+      # initialize, session/resume, then the set_config_option the previous
+      # peer already reported as a `model failed` stage event.
+      send_response(pid, 1, %{"agentCapabilities" => caps()})
+      send_response(pid, 2, %{"configOptions" => [%{"id" => "model"}]})
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => 3,
+          "error" => %{"code" => -32_603, "data" => %{"details" => "Invalid value"}}
+        }) <> "\n"
+      )
+
+      _ = :sys.get_state(pid)
+      refute_received {:acp, _, {:failed, _}}
+      refute_received {:acp, _, {:done, _}}
+      refute_received {:acp, _, {:model_rejected, _, _}}
+    end
+
+    test "a live permission request is answered — the reason the turn used to hang", ctx do
+      pid = attached_peer(ctx)
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => 5,
+          "method" => "session/request_permission",
+          "params" => %{"options" => [%{"optionId" => "allow", "kind" => "allow_once"}]}
+        }) <> "\n"
+      )
+
+      assert %{"id" => 5, "result" => %{"outcome" => %{"optionId" => "allow"}}} = next_write()
+    end
+
+    test "updates are relayed for persistence", ctx do
+      pid = attached_peer(ctx)
+      Peer.stdout(pid, update_line(%{"sessionUpdate" => "agent_message_chunk"}))
+      assert_receive {:acp, _ref, {:lines, "acp", line}}
+      assert line =~ "agent_message_chunk"
+    end
+
+    test "the response to the prompt id ends the turn; an error to it fails the turn", ctx do
+      pid = attached_peer(ctx, 4)
+      send_response(pid, 4, %{"stopReason" => "end_turn"})
+      assert_receive {:acp, _ref, {:done, "end_turn"}}
+
+      pid2 = attached_peer(ctx, 7)
+
+      Peer.stdout(
+        pid2,
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => 7, "error" => %{"message" => "gone"}}) <>
+          "\n"
+      )
+
+      assert_receive {:acp, _ref, {:failed, {:acp_error, :prompt, %{"message" => "gone"}}}}
+    end
+
+    test "cancel still reaches the agent, addressed to the live session", ctx do
+      pid = attached_peer(ctx)
+      Peer.cancel(pid)
+
+      assert %{"method" => "session/cancel", "params" => %{"sessionId" => "sess_live"}} =
+               next_write()
+    end
+
+    test "the replay's partial first line is dropped, not persisted as noise", ctx do
+      # Sprites replays the tail of its buffer, which starts wherever it starts.
+      pid = attached_peer(ctx)
+      good = update_line(%{"sessionUpdate" => "usage_update", "used" => 1})
+      Peer.stdout(pid, ~s(le":"garbage"}}}\n) <> good)
+
+      assert_receive {:acp, _ref, {:lines, "acp", line}}
+      assert line =~ "usage_update"
+      refute_receive {:acp, _ref, {:lines, "stdout", _}}, 100
+    end
+
+    test "a first chunk that opens a JSON line is kept whole", ctx do
+      pid = attached_peer(ctx)
+      Peer.stdout(pid, update_line(%{"sessionUpdate" => "usage_update", "used" => 2}))
+      assert_receive {:acp, _ref, {:lines, "acp", line}}
+      assert line =~ ~s("used":2)
+    end
+
+    test "a first fragment with no newline yet is held until the line boundary arrives", ctx do
+      pid = attached_peer(ctx)
+      Peer.stdout(pid, "tail-of-a-line")
+      Peer.stdout(pid, "-still-going\n" <> update_line(%{"sessionUpdate" => "usage_update"}))
+      assert_receive {:acp, _ref, {:lines, "acp", _}}
+      refute_receive {:acp, _ref, {:lines, "stdout", _}}, 100
     end
   end
 end

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -189,6 +189,24 @@ That is the shape we already run, with the protocol swapped in underneath it:
 | process exit ends the turn | the `session/prompt` response ends it; exit is the backstop |
 | idle sprite reclaimed at 60m, any sprite at 24h | unchanged |
 
+> **Addendum, 2026-08-16 — the connection is scoped to the turn, but the
+> server is not.** Every deploy restarts every `ConversationServer`, and the
+> adapter in the sprite is a detachable session that keeps running with
+> `session/prompt` outstanding. The reattach path (`attempt_session_attach`)
+> re-hooked the command and logged its stdout raw — no peer — so nobody
+> answered `session/request_permission` and nobody saw the prompt response;
+> with 24 deploys in a day, every ACP turn in flight across one hung until the
+> user prompted again or the sandbox hit its 24h ceiling (eight found stuck in
+> production, one 15 hours in). Two things now hold: the peer reports the
+> prompt's JSON-RPC id and the server persists it on the turn
+> (`turns.acp_prompt_id`), and a reattach starts a peer with `attach:
+> prompt_id` that resumes exactly that request — no handshake, replayed
+> handshake ignored, live requests answered. A turn without the id (the peer
+> died mid-handshake) is orphaned and its adapter stopped rather than left to
+> hang. Sprites replays only the last 16 KiB of the session, mid-line, so
+> replayed lines are de-duplicated by content, not by the byte count the
+> legacy path still uses.
+
 **The rule that keeps this from eroding one optimisation at a time: no ACP
 state may become a reason to keep a sandbox alive.** A connection may be
 scoped to the turn (v1) or, if per-turn `initialize` proves too slow, to the


### PR DESCRIPTION
## The bug

https://fountain.inevitable.fyi/conversations/1d239529-fef7-4889-b191-64522eed8de3 turn 9: running fine, then at 09:47:39 a deploy restarted the server. `reattach done (session_attached)` — and from then on the events are raw `stdout` JSON-RPC lines, not parsed `acp`. The last one is a `session/request_permission` (id 5) that **nobody answered**. The turn sat `running` until Jake typed "still cookin?" at 09:55, which interrupted it.

`attempt_session_attach/3` re-hooked `current_command` but never started an `ACP.Peer`. On the ACP path that means: no answer to the agent's permission requests, and no one watching for the `session/prompt` response — the adapter stays alive until stdin closes, so the turn can never end on its own. Every ACP turn in flight across a deploy hung. There were 24 deploys today; **8 conversations are currently stuck `running` on turn 1 for 9–15h** (`0b27cb55`, `aa5e71b7`, `9177a4b0`, `c3076541`, `a1c96369`, `115bc934`, `a7351976`, `d8074bc5`), several with a `ready` sandbox billing to the ceiling. Those will be orphaned cleanly (turn `interrupted`, adapter stopped) on the first reattach after this ships, because their turns have no `acp_prompt_id`.

## The fix

- **Peer** reports `{:prompt_sent, id}` after writing `session/prompt`; the server persists it (`turns.acp_prompt_id`, new nullable column).
- **Reattach** on an ACP runtime starts a peer with `attach: prompt_id`: no handshake, replayed handshake responses/errors ignored (a replayed `set_config_option` refusal must not fail the turn), live `session/request_permission` answered, response to `prompt_id` ends the turn (error to it fails it), `cancel/1` still works.
- **No id → orphan.** The old peer died mid-handshake; the adapter is idle waiting for a prompt nobody can now write. `stop_command` + `mark_orphan("acp_prompt_not_sent")` — otherwise it lingers as the session the *next* reattach binds to.
- **Replay dedup by content, not bytes.** Both hung turns show the replay is **one 16384-byte chunk starting mid-line** — sprites replays the last 16 KiB, not the buffer from the start. The byte-count `replay_skip` (102,619 here) would have swallowed the replay *and* ~86 KB of live output. On the ACP path the peer drops the partial first line and the server drops `acp` lines matching the turn's last 400 persisted lines (each match consumed once; set cleared after 10s). The legacy path keeps its byte skip — see follow-up.

ADR 0014 gets a dated addendum under *Session lifetime*: the connection is scoped to the turn, but the server isn't.

## Tests

- `peer_test.exs`: 8 attach-mode tests + `prompt_sent` reported. All 8 fail against the old peer.
- `conversation_server_acp_test.exs`: prompt id persisted; a full reattach (partial replay line, live permission request answered, prompt response → `completed`/`idle`/stdin closed); replayed-line dedup (persisted line written once, new line written); no-id → `interrupted`, `stop_command`, `idle`. All 4 fail against the old server.
- `mix precommit` green: 2868 tests, 0 failures; credo/dialyzer/sobelow clean.

## Follow-ups (not in this PR)

- The **legacy path's byte-count `replay_skip` over-skips** for the same reason (replay is a 16 KiB tail, skip is total persisted bytes) — silently drops live output after a reattach on gemini-legacy turns. Needs the same content-aware treatment against raw bytes.
- `attempt_session_attach` binds to `[session | _]` — with more than one lingering session it can attach to the wrong one.
- `c3076541` shows two `provision started/done` pairs on one conversation with no reattach — looks like a duplicate-server race, separate from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
