### PR TITLE
fix(buzz): resolve a harness's launch in the child start, not in the Horde spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ upgrade, is in
 
 ### Fixed
 
+- **A hosted Buzz harness survives deploys and version bumps.** Horde replays
+  a harness's child spec on every deploy, and the spec carried the launch:
+  the launcher path (`/app/lib/fountain-<version>/priv/buzz-acp-launch.sh`,
+  stale after the next version bump — the harness crash-looped on `No such
+  file`) and the minted `FOUNTAIN_API_KEY` (revoked by the old node's
+  `terminate/2`, then replayed by the new one). The spec now carries only the
+  identity id; the launch — key, env, launcher — is resolved by the child's
+  start on whichever node runs it. **One-time step after upgrading:** a
+  harness started before this fix keeps its old spec until it is stopped and
+  started once (disable and re-enable the Buzz agent).
 - **An ACP turn in flight across a deploy no longer hangs.** Every deploy
   restarts every `ConversationServer`; the agent in the sandbox keeps running
   and the server reattached to its session — but on the ACP path it reattached

--- a/apps/fountain/lib/fountain/buzz/manager.ex
+++ b/apps/fountain/lib/fountain/buzz/manager.ex
@@ -11,11 +11,28 @@ defmodule Fountain.Buzz.Manager do
 
   This module is the seam between the tenant-aware context and the process tree:
   it calls `Fountain.Buzz.harness_launch/2` (which mints the API key and decrypts
-  the vault) and hands the resulting spec to the supervisor. It also owns the one
-  correctness subtlety that split introduces — a launch mints a credential
-  *before* the supervisor can say whether a harness already exists, so every path
-  that does not end in a running harness revokes the key it minted, or a race
-  would leak standing credentials.
+  the vault) and hands the resulting spec to the supervisor.
+
+  ## The child spec carries the identity id and nothing else
+
+  Horde stores every child spec in a CRDT and **replays it** — on a node loss,
+  on a rebalance, and on every deploy, when the old node's supervisor terminates
+  the harness and the new node's starts it again from the stored spec. So
+  anything resolved at `start_harness/2` time and put in the spec is frozen at
+  that moment, for the life of the identity. Two things bit (2026-08-16, the
+  FizzTheShark identity): the launcher path
+  (`/app/lib/fountain-<version>/priv/buzz-acp-launch.sh`) went stale on the next
+  version bump and the harness crash-looped on `No such file` after every
+  restart; and the minted `FOUNTAIN_API_KEY` was **revoked by the old node's
+  `terminate/2`** and then replayed by the new node, so a harness that did start
+  drove `fountain acp` with a dead credential. The `ConversationServer` learned
+  the same lesson about its initial prompt.
+
+  So the spec is `{Manager, :start_harness_link, [identity_id, opts]}` and the
+  launch — identity re-read, vault decrypted, key minted, launcher path resolved
+  — happens inside that function, on whichever node is starting the child, every
+  time it starts. `opts` are the config overrides only (`:buzz_acp_path`,
+  `:base_url`, `:agents`, `:actor`); they are safe to store.
   """
 
   require Logger
@@ -42,22 +59,50 @@ defmodule Fountain.Buzz.Manager do
 
   @doc """
   Ensure a harness is running for `identity`. Idempotent: if one already runs,
-  returns it without minting a credential. Otherwise mints the launch's API key,
-  builds the env, and starts the supervised harness.
+  returns it without minting a credential. Otherwise starts the supervised
+  harness, whose start resolves the launch (mints the API key, decrypts the
+  vault, builds the env) — see the moduledoc for why that happens in the child
+  and not here.
 
   `opts` are forwarded to `Fountain.Buzz.harness_launch/2` (`:buzz_acp_path`,
-  `:base_url`, `:agents`, attribution). Returns `{:ok, pid}` or `{:error, reason}`.
+  `:base_url`, `:agents`, attribution) and stored in the child spec, so they must
+  not carry anything that goes stale. Returns `{:ok, pid}` or `{:error, reason}`;
+  a launch error (`:no_buzz_acp_path`, `:vault_not_found`, …) surfaces here.
   """
   @spec start_harness(BuzzIdentity.t(), keyword()) :: {:ok, pid()} | {:error, term()}
   def start_harness(%BuzzIdentity{} = identity, opts \\ []) do
     case whereis(identity.id) do
-      pid when is_pid(pid) ->
-        {:ok, pid}
+      pid when is_pid(pid) -> {:ok, pid}
+      nil -> start_child(identity, opts)
+    end
+  end
 
-      nil ->
+  @doc false
+  # The child's start function. Runs under `Fountain.BuzzSupervisor` on whichever
+  # node is starting this child — first start, restart after a crash, or Horde
+  # replaying the spec after a deploy — so everything here is resolved fresh
+  # each time. `:ignore` drops the spec for an identity that no longer exists or
+  # is disabled; Horde would otherwise carry it forever.
+  def start_harness_link(identity_id, opts) do
+    # ownership: a supervisor start has no requester; the identity was
+    # tenant-scoped when it was enabled, and every launch is scoped to its
+    # user_id inside harness_launch/2.
+    case Buzz._unsafe_get_identity(identity_id) do
+      %BuzzIdentity{enabled: true} = identity ->
         with {:ok, launch} <- Buzz.harness_launch(identity, opts) do
-          start_child(identity, launch)
+          case Harness.start_link(harness_opts(identity, launch)) do
+            {:ok, pid} ->
+              {:ok, pid}
+
+            other ->
+              # The key was minted for a harness that never came up.
+              revoke_orphaned_key(identity, launch)
+              other
+          end
         end
+
+      _ ->
+        :ignore
     end
   end
 
@@ -72,10 +117,10 @@ defmodule Fountain.Buzz.Manager do
     end
   end
 
-  defp start_child(%BuzzIdentity{} = identity, launch) do
+  defp start_child(%BuzzIdentity{} = identity, opts) do
     child = %{
       id: identity.id,
-      start: {Harness, :start_link, [harness_opts(identity, launch)]},
+      start: {__MODULE__, :start_harness_link, [identity.id, opts]},
       # The harness restarts its own port; if the harness process itself dies we
       # want Horde to bring it back, but a deliberate stop is terminal.
       restart: :transient,
@@ -87,15 +132,15 @@ defmodule Fountain.Buzz.Manager do
       {:ok, pid} ->
         {:ok, pid}
 
+      # Another node won the race between our `whereis` and this call. Nothing
+      # was minted on this side: the launch lives in the child's start.
       {:error, {:already_started, pid}} ->
-        # Another node won the race between our `whereis` and this call. The key
-        # we just minted has no harness to own it — revoke it rather than leak it.
-        revoke_orphaned_key(identity, launch)
         {:ok, pid}
 
-      {:error, reason} = err ->
-        revoke_orphaned_key(identity, launch)
+      :ignore ->
+        {:error, :identity_not_enabled}
 
+      {:error, reason} = err ->
         Logger.error(
           "buzz harness failed to start: identity=#{identity.id} reason=#{inspect(reason)}"
         )

--- a/apps/fountain/test/fountain/buzz/manager_test.exs
+++ b/apps/fountain/test/fountain/buzz/manager_test.exs
@@ -33,6 +33,13 @@ defmodule Fountain.Buzz.ManagerTest do
 
   defp launch_opts(fake), do: [buzz_acp_path: fake, base_url: "https://fountain.test"]
 
+  defp active_keys(user_id) do
+    Repo.all(
+      from k in ApiKey,
+        where: k.user_id == ^user_id and is_nil(k.revoked_at) and like(k.name, "buzz-acp:%")
+    )
+  end
+
   defp active_key_count(user_id) do
     Repo.one(
       from k in ApiKey,
@@ -92,5 +99,66 @@ defmodule Fountain.Buzz.ManagerTest do
 
     assert active_key_count(identity.user_id) == 0
     refute Manager.running?(identity.id)
+  end
+
+  describe "the launch is resolved by the child's start, not frozen in the spec" do
+    # Horde replays a stored child spec on every deploy, node loss and rebalance.
+    # If the spec carried the launch, a replay would reuse a launcher path from a
+    # previous release and an API key the old node revoked in terminate/2 —
+    # which is exactly what took the FizzTheShark harness down on 2026-08-16.
+    # `start_harness_link/2` is what the spec invokes; calling it directly is
+    # calling it the way Horde does.
+
+    test "each start mints its own key and a stop revokes only that one", %{fake: fake} do
+      identity = insert_buzz_identity()
+
+      assert {:ok, pid1} = Manager.start_harness_link(identity.id, launch_opts(fake))
+      assert active_key_count(identity.user_id) == 1
+      [key1] = active_keys(identity.user_id)
+
+      # The old node going away: terminate runs, the key is revoked.
+      GenServer.stop(pid1)
+      assert active_key_count(identity.user_id) == 0
+
+      # The new node replaying the same spec: a fresh key, not the dead one.
+      assert {:ok, pid2} = Manager.start_harness_link(identity.id, launch_opts(fake))
+      assert [key2] = active_keys(identity.user_id)
+      refute key2.id == key1.id
+      GenServer.stop(pid2)
+    end
+
+    test "the launcher path is read at start, so a version bump cannot strand it", %{
+      fake: fake
+    } do
+      identity = insert_buzz_identity()
+      dir = Path.dirname(fake)
+      old = Path.join(dir, "old-launch.sh")
+      new = Path.join(dir, "new-launch.sh")
+      for l <- [old, new], do: File.write!(l, "#!/bin/sh\nexec \"$@\"\n") && File.chmod!(l, 0o755)
+
+      Application.put_env(:fountain, :buzz_acp_launcher, old)
+      on_exit(fn -> Application.delete_env(:fountain, :buzz_acp_launcher) end)
+
+      assert {:ok, pid1} = Manager.start_harness_link(identity.id, launch_opts(fake))
+      assert :sys.get_state(pid1).launcher == old
+      GenServer.stop(pid1)
+
+      # "The next release": the launcher lives somewhere else now.
+      Application.put_env(:fountain, :buzz_acp_launcher, new)
+      assert {:ok, pid2} = Manager.start_harness_link(identity.id, launch_opts(fake))
+      assert :sys.get_state(pid2).launcher == new
+      GenServer.stop(pid2)
+    end
+
+    test "an identity that was disabled or deleted is dropped, not restarted forever", %{
+      fake: fake
+    } do
+      identity = insert_buzz_identity()
+      {:ok, _} = Fountain.Buzz.update_identity(identity, %{enabled: false}, actor: "system:test")
+      assert :ignore = Manager.start_harness_link(identity.id, launch_opts(fake))
+      assert active_key_count(identity.user_id) == 0
+
+      assert :ignore = Manager.start_harness_link(Ecto.UUID.generate(), launch_opts(fake))
+    end
   end
 end


### PR DESCRIPTION
## What's wrong

FizzTheShark (a Fountain-hosted Buzz identity, `614f1a0e…`) is "online" but never answers. Pod logs:

```
/bin/sh: 0: cannot open /app/lib/fountain-0.10.2/priv/buzz-acp-launch.sh: No such file
buzz-acp exited: label=614f1a0e-… status=2 — restarting
```

— every second, on the 0.11.0 image. The harness was started at 09:32Z when prod ran 0.10.2; Horde stores the child spec in its CRDT and replays it across every rolling deploy, so the launcher path resolved *then* has been replayed ever since, and went stale the moment the version bumped.

Second, quieter defect in the same shape: the spec also carried the minted `FOUNTAIN_API_KEY`. The old node's `terminate/2` revokes it, then the new node replays the spec with the dead key — so even without a version bump a moved harness drives `fountain acp` with a revoked credential.

## The fix

The Horde spec is now `{Manager, :start_harness_link, [identity_id, opts]}` — identity id and config overrides only. `start_harness_link/2` re-reads the identity, calls `Buzz.harness_launch/2` (mint, decrypt, env), resolves the launcher path, and starts the `Harness`, on whichever node starts the child, every time (first start, crash restart, deploy replay). `:ignore` for a disabled/deleted identity so Horde drops the spec instead of carrying it forever. `start_child` no longer mints anything, so the pre-mint race handling goes away.

Same lesson `ConversationServer` documents for its initial prompt ("deliberately not a start_link argument").

## Tests

`manager_test.exs`: each start via the spec's MFA mints its own key and a stop revokes only that one (the replay scenario); the launcher path is read at start (changes between two starts); disabled/deleted identity → `:ignore`, no key minted. `mix precommit` green.

## Rollout note

A harness started before this fix keeps its old spec until it is stopped and started once — I'll do that for FizzTheShark right after this deploys (disable/enable, or `Manager.stop_harness` + `start_harness` in a release eval). Noted in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
