### PR TITLE
chore(buzz-acp): point the fork pin at #776

### DIFF
--- a/.github/workflows/buzz-acp-publish.yml
+++ b/.github/workflows/buzz-acp-publish.yml
@@ -11,8 +11,8 @@ name: Publish buzz-acp
 #
 # buzz-acp.source (optional, `owner/repo@ref`) overrides WHERE the source comes
 # from — a fork carrying a change upstream has not merged yet (block/buzz#6088,
-# #774). When it is present the version is only the release name; delete the
-# file and set the version back to an upstream tag once the change ships.
+# #774). When it is present the version is only the release name. **#776 says
+# when it is safe to delete the file and repin to an upstream tag, and how.**
 
 on:
   workflow_dispatch:
@@ -45,7 +45,7 @@ jobs:
           version="$(tr -d '[:space:]' < buzz-acp.version)"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           if [ -s buzz-acp.source ]; then
-            source="$(tr -d '[:space:]' < buzz-acp.source)"
+            source="$(grep -v '^#' buzz-acp.source | tr -d '[:space:]')"
             echo "repository=${source%@*}" >> "$GITHUB_OUTPUT"
             echo "ref=${source##*@}" >> "$GITHUB_OUTPUT"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ upgrade, is in
   — `buzz-acp`, on every hosted deploy — lands back on the same conversation
   and sandbox. The hosted `buzz-acp` is built from a fork carrying the
   upstream change that sends the channel id (block/buzz#6088;
-  `buzz-acp.source`) until it merges.
+  `buzz-acp.source`) until it merges — #776 tracks the repin.
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-amd64}" \
 # The pin lives in buzz-acp.version and is passed as BUZZ_ACP_VERSION by the
 # build workflow; the default below keeps a local `docker build` working.
 # (buzz-acp.source may point the publish workflow at a fork — the version is
-# then only the release name; see that workflow.)
+# then only the release name; see that workflow. #776 tracks repinning to
+# upstream once block/buzz#6088 ships.)
 
 FROM debian:trixie-slim AS buzzacp
 ARG TARGETARCH

--- a/buzz-acp.source
+++ b/buzz-acp.source
@@ -1,1 +1,2 @@
+# Fork pin — see #776 for when and how to remove. Format: owner/repo@ref
 jhgaylor/buzz@83eda69a99fad02bc3cdf60d61ad14e56a41447e


### PR DESCRIPTION
Comments in `buzz-acp.source`, the publish workflow, the Dockerfile and the CHANGELOG now reference #776, which says when it is safe to drop the fork pin (block/buzz#6088 shipped in a desktop tag) and how. The workflow's reader ignores comment lines in `buzz-acp.source`; the pinned sha is unchanged, so no rebuild.

Note: this touches `buzz-acp.source`, which re-triggers `Publish buzz-acp` on merge — it re-uploads the same assets with `--clobber`. Harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)