### PR TITLE
fix(buzz): a harness that loses a Horde name conflict stops instead of running unregistered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ upgrade, is in
 
 ### Fixed
 
+- **Two hosted harnesses for one Buzz identity no longer both run.** When two
+  nodes ran the boot sweep before the cluster formed, both registered a
+  harness and Horde told the loser to exit — but the harness traps exits and
+  swallowed the `:name_conflict` message, so two `buzz-acp` processes
+  answered the same channel and raced one conversation (`conversation_busy`
+  on every second prompt). The loser now stops: port closed, buzz-acp
+  reaped, its launch key revoked.
 - **A hosted Buzz harness survives deploys and version bumps.** Horde replays
   a harness's child spec on every deploy, and the spec carried the launch:
   the launcher path (`/app/lib/fountain-<version>/priv/buzz-acp-launch.sh`,

--- a/apps/fountain/lib/fountain/buzz/harness.ex
+++ b/apps/fountain/lib/fountain/buzz/harness.ex
@@ -115,7 +115,29 @@ defmodule Fountain.Buzz.Harness do
     {:noreply, %{state | port: nil}}
   end
 
-  def handle_info({:EXIT, _other, _reason}, state), do: {:noreply, state}
+  # Horde.Registry found two harnesses registered under one identity — two
+  # nodes each ran the boot sweep before the cluster formed — and named this
+  # one the loser with `Process.exit(pid, {:name_conflict, …})`. Because this
+  # process traps exits, that arrives as a message, not a kill; the old
+  # catch-all below swallowed it and the loser lived on unregistered, so two
+  # `buzz-acp` processes answered the same channel and raced one conversation
+  # (`conversation_busy` on every second prompt, 2026-08-17). Stop, so
+  # `terminate/2` closes the port, reaps buzz-acp and revokes this launch's key.
+  # `{:shutdown, _}` is a clean reason: `:transient` does not restart it.
+  def handle_info({:EXIT, _from, {:name_conflict, _key, _registry, winner}}, state) do
+    Logger.warning(
+      "buzz harness #{state.label}: duplicate of #{inspect(winner)} — stopping this one"
+    )
+
+    {:stop, {:shutdown, :name_conflict}, state}
+  end
+
+  # Any other linked exit: a :normal one is noise; anything else is a reason
+  # to go down through terminate/2 rather than to keep running blind, exactly
+  # as ConversationServer treats it. Nothing but the port and the supervisor
+  # links to a harness today, so in practice this clause is a backstop.
+  def handle_info({:EXIT, _other, :normal}, state), do: {:noreply, state}
+  def handle_info({:EXIT, _other, reason}, state), do: {:stop, reason, state}
 
   def handle_info(_msg, state), do: {:noreply, state}
 

--- a/apps/fountain/test/fountain/buzz/harness_test.exs
+++ b/apps/fountain/test/fountain/buzz/harness_test.exs
@@ -112,6 +112,43 @@ defmodule Fountain.Buzz.HarnessTest do
     assert log =~ "connected to relay"
   end
 
+  # 2026-08-17: two pods ran the boot sweep before the cluster formed, both
+  # registered a harness for FizzTheShark, and the Horde loser ignored the
+  # name-conflict exit — two buzz-acp processes answered one channel.
+  test "a Horde name-conflict exit stops the loser: port reaped, on_stop run", %{dir: dir} do
+    pidfile = Path.join(dir, "childpid")
+    cmd = write_fake(dir, "buzz-acp", "echo $$ > #{pidfile}\nsleep 300\n")
+    test_pid = self()
+
+    pid = start(command: cmd, label: "t", on_stop: fn -> send(test_pid, :stopped) end)
+    wait_until(fn -> File.exists?(pidfile) end)
+    child = File.read!(pidfile) |> String.trim() |> String.to_integer()
+    ref = Process.monitor(pid)
+
+    # What Horde.Registry sends the losing process (registry_impl.ex).
+    Process.exit(pid, {:name_conflict, {"identity-id", nil}, Fountain.BuzzRegistry, self()})
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :name_conflict}}, 2_000
+    assert_receive :stopped, 2_000
+
+    reaped =
+      Enum.reduce_while(1..80, false, fn _, _ ->
+        Process.sleep(100)
+        if alive?(child), do: {:cont, false}, else: {:halt, true}
+      end)
+
+    assert reaped, "the loser's buzz-acp #{child} survived (leaked)"
+  end
+
+  test "a :normal linked exit is ignored — the harness keeps running", %{dir: dir} do
+    cmd = write_fake(dir, "buzz-acp", "sleep 30\n")
+    pid = start(command: cmd, label: "t")
+    # What a linked helper that exits normally would deliver to a trapping process.
+    send(pid, {:EXIT, self(), :normal})
+    _ = :sys.get_state(pid)
+    assert Process.alive?(pid)
+  end
+
   test "runs the on_stop callback on shutdown", %{dir: dir} do
     cmd = write_fake(dir, "buzz-acp", "sleep 30\n")
     test_pid = self()


### PR DESCRIPTION
## What happened

Fizz's DM showed "turn errors" while still working. Pod logs: two `fountain acp` children — one per pod — opened the **same** session at 03:39:13 (`resumed=true` on both), then one of every pair of prompts failed `http 400: conversation_busy` and buzz-acp retried with backoff (which is why it "also worked"). `Horde.DynamicSupervisor.which_children(Fountain.BuzzSupervisor)` showed two children for the identity; the registry showed one.

Cause: both pods ran `BootSweep` before the cluster formed, each registered its harness locally, and on CRDT merge Horde sent the loser `Process.exit(pid, {:name_conflict, …})`. `Harness` traps exits, and `handle_info({:EXIT, _other, _reason}, state)` ignored it — the loser kept running unregistered. `ConversationServer` handles the same message by stopping.

## Fix

- `{:EXIT, _, {:name_conflict, _, _, winner}}` → `{:stop, {:shutdown, :name_conflict}}` — `terminate/2` closes the port, the launcher reaps buzz-acp, the launch key is revoked; `:transient` does not restart it.
- Any other non-`:normal` linked exit stops the harness (backstop, mirrors ConversationServer); `:normal` stays ignored.

Prod: I terminated the unregistered duplicate by hand right away (`terminate_child` on the non-registered pid; its key `01c2d3c6` revoked at 03:42:38); one harness is running now. This PR keeps it from recurring on the next deploy where both pods boot inside the cluster-formation window.

## Tests

`harness_test.exs`: a name-conflict exit stops the loser with `{:shutdown, :name_conflict}`, runs `on_stop`, and the fake buzz-acp is reaped; a `:normal` linked exit is ignored. `mix precommit` 2878/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
