### PR TITLE
chore(buzz-acp): repin the fork to the DCO-signed commit of block/buzz#6088

### DIFF
--- a/buzz-acp.source
+++ b/buzz-acp.source
@@ -1,2 +1,2 @@
 # Fork pin — see #776 for when and how to remove. Format: owner/repo@ref
-jhgaylor/buzz@af535a64b241c4b806db1809714f73b57236a707
+jhgaylor/buzz@9390060f0908dfd29e5dd1a2d4a481a2fe81819c

--- a/buzz-acp.source
+++ b/buzz-acp.source
@@ -1,2 +1,2 @@
 # Fork pin — see #776 for when and how to remove. Format: owner/repo@ref
-jhgaylor/buzz@83eda69a99fad02bc3cdf60d61ad14e56a41447e
+jhgaylor/buzz@af535a64b241c4b806db1809714f73b57236a707


### PR DESCRIPTION
Follows the fork pin through the DCO fix on block/buzz#6088. The PR's original commit was amended with `Signed-off-by` (`83eda69a` → `af535a64`, identical tree), and a second commit `9390060` adds the reviewer-requested README docs for `BUZZ_ACP_STATE_DIR` / `--no-resume-sessions`. The old sha is unreachable from any branch on the fork, so the pin moves before GitHub can GC it. #776 still tracks the eventual repin to upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)