### PR TITLE
test(acp): settle/1 tolerates a peer that stopped between the alive check and the sync

### DIFF
--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -66,9 +66,23 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
   # casts it to the peer, the peer acts and reports back, and the server acts on
   # the report. Syncing only the server would assert against a state one hop
   # behind, which is what made these tests pass alone and fail together.
+  #
+  # The peer is stopped by the server the moment it reports `{:done, _}`, so
+  # between reading `acp_peer` and syncing on it the peer may already be gone
+  # (a `noproc` exit from `:sys.get_state/1`, seen in CI on 2026-08-17). That
+  # is the state we wanted anyway — the report was handled — so a dead peer
+  # is not a failure here.
   defp settle(pid) do
     peer = :sys.get_state(pid).acp_peer
-    if is_pid(peer) and Process.alive?(peer), do: :sys.get_state(peer)
+
+    if is_pid(peer) do
+      try do
+        _ = :sys.get_state(peer)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+
     _ = :sys.get_state(pid)
     :ok
   end

--- a/buzz-acp.source
+++ b/buzz-acp.source
@@ -1,2 +1,2 @@
 # Fork pin — see #776 for when and how to remove. Format: owner/repo@ref
-jhgaylor/buzz@af535a64b241c4b806db1809714f73b57236a707
+jhgaylor/buzz@9390060f0908dfd29e5dd1a2d4a481a2fe81819c

--- a/buzz-acp.source
+++ b/buzz-acp.source
@@ -1,2 +1,2 @@
 # Fork pin — see #776 for when and how to remove. Format: owner/repo@ref
-jhgaylor/buzz@83eda69a99fad02bc3cdf60d61ad14e56a41447e
+jhgaylor/buzz@af535a64b241c4b806db1809714f73b57236a707


### PR DESCRIPTION
Flake seen on #780's partition 2: `the conversation accepts another prompt afterwards` — `settle/1` read `acp_peer`, checked `Process.alive?`, and the peer stopped (server stops it on `{:done, _}`) before `:sys.get_state` → `noproc`. A dead peer at that point IS the settled state. Catch the exit. 22/22 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)