### PR TITLE
feat(conversations): per-launch environment override — environment_id on create, --environment on acp/run, Buzz passthrough (#783)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ upgrade, is in
 - **Per-launch environment override (#783).** A conversation may be provisioned
   from an environment other than its agent's: `environment_id` on
   `POST /api/conversations`, `--environment` on `fountain acp` and
-  `fountain run`, and `environment_id` on the hosted-Buzz provision request
-  (the identity's harness passes it through). One agent config can now run
+  `fountain run`, `environment_id` on the hosted-Buzz provision request
+  (the identity's harness passes it through), and an optional `environment`
+  selector in the `buzz-backend-fountain` provider's settings. One agent config can now run
   under N environments — a "fountain engineer" and a "buzz engineer" no longer
   need to be two agents. The override is pinned to the conversation across
   wakes and is part of the `channel_id` resume key. Agents get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ upgrade, is in
 
 ### Added
 
+- **Per-launch environment override (#783).** A conversation may be provisioned
+  from an environment other than its agent's: `environment_id` on
+  `POST /api/conversations`, `--environment` on `fountain acp` and
+  `fountain run`, and `environment_id` on the hosted-Buzz provision request
+  (the identity's harness passes it through). One agent config can now run
+  under N environments — a "fountain engineer" and a "buzz engineer" no longer
+  need to be two agents. The override is pinned to the conversation across
+  wakes and is part of the `channel_id` resume key. Agents get
+  `allowed_environment_ids`, the same shape as `allowed_vault_ids`, to scope
+  which environments may stand in for a reviewed one; the agent's own always
+  passes.
+
 - **Channel-bound conversations (#774).** `POST /api/conversations` accepts
   an opaque `channel_id`; when set, the latest live conversation for the same
   agent, vault and channel is resumed (200, `meta.resumed: true`) instead of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ fountain/                  umbrella root
 
 | Primitive | Purpose |
 |---|---|
-| **Environment** | Baseline set of encrypted env vars + runtime config (packages, repos, scripts) attached to an agent |
+| **Environment** | Baseline set of encrypted env vars + runtime config (packages, repos, scripts) attached to an agent. A conversation may name a different one at launch (`environment_id`; scoped by `agent.allowed_environment_ids`) — the agent's is the default, not the only choice |
 | **Vault** | Free-floating bag of env-var overrides. Vault values **win on key collision** when merged with an environment at sprite spawn time |
 | **Agent** | A named, re-runnable agent config — model, runtime, skills, MCP servers, optional environment |
 | **Conversation** | A single run of an agent inside a Sprites sandbox. Has turns, log events, and a status lifecycle |

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -34,6 +34,11 @@ defmodule Fountain.Agents.Agent do
     # on env-var collision, so an attached vault can override reviewed
     # agent config — this is the lever that scopes who can do that.
     field :allowed_vault_ids, {:array, :binary_id}
+    # Environments a conversation may launch this agent under instead of its
+    # own (#783). Same shape: nil = any tenant environment, [] = none,
+    # non-empty = allowlist. An override *replaces* the reviewed environment
+    # wholesale, so it is scoped the same way a vault override is.
+    field :allowed_environment_ids, {:array, :binary_id}
     field :avatar_media_type, :string
     field :conversation_count, :integer, virtual: true, default: 0
     belongs_to :user, User
@@ -56,6 +61,7 @@ defmodule Fountain.Agents.Agent do
       :mcp_servers,
       :metadata,
       :allowed_vault_ids,
+      :allowed_environment_ids,
       :user_id,
       :environment_id
     ])

--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -17,7 +17,7 @@ defmodule Fountain.Buzz do
 
   import Ecto.Query, only: [from: 2]
 
-  alias Fountain.{Accounts, Audit, Conversations, Crypto, Repo, Vaults}
+  alias Fountain.{Accounts, Audit, Conversations, Crypto, Environments, Repo, Vaults}
   alias Fountain.Buzz.BuzzIdentity
 
   # ── identities (tenant-scoped) ─────────────────────────────────────────────
@@ -72,11 +72,17 @@ defmodule Fountain.Buzz do
   partial run.
 
   `params` (string-keyed): `"name"`, `"relay_url"`, `"agent_id"`, `"pubkey"`,
-  `"private_key_nsec"`, `"auth_tag"` (required); `"display_name"` (optional).
+  `"private_key_nsec"`, `"auth_tag"` (required); `"display_name"` and
+  `"environment_id"` (optional). The environment, when named, must be owned by
+  `user_id` — a foreign or unknown id is `{:error, :environment_not_found}` —
+  and becomes the baseline every conversation this identity opens is
+  provisioned from instead of the agent's own (#783). Re-provisioning without
+  it clears a previously set one: the provider's `deploy` is the whole truth.
   Returns `{:ok, %BuzzIdentity{}}` or `{:error, reason}`.
   """
   def provision_identity(user_id, params, opts \\ []) when is_binary(user_id) do
     with {:ok, fields} <- validate_provision(params),
+         :ok <- check_environment(fields.environment_id, user_id),
          {:ok, dek} <- Crypto.load_tenant_key(user_id),
          {:ok, vault} <- ensure_vault(user_id, fields, dek, opts),
          :ok <- write_buzz_secrets(vault, fields, dek, opts) do
@@ -98,7 +104,8 @@ defmodule Fountain.Buzz do
          pubkey: params["pubkey"],
          nsec: params["private_key_nsec"],
          auth_tag: params["auth_tag"],
-         display_name: params["display_name"]
+         display_name: params["display_name"],
+         environment_id: presence(params["environment_id"])
        }}
     else
       {:error, {:missing, missing}}
@@ -106,6 +113,19 @@ defmodule Fountain.Buzz do
   end
 
   defp blank?(v), do: is_nil(v) or v == ""
+
+  defp presence(v), do: if(blank?(v), do: nil, else: v)
+
+  # Scoped fetch: the environment's secrets materialise in this identity's
+  # sandboxes, so a pointer at another tenant's must never be stored.
+  defp check_environment(nil, _user_id), do: :ok
+
+  defp check_environment(id, user_id) do
+    case Environments.get_environment(id, user_id) do
+      nil -> {:error, :environment_not_found}
+      _env -> :ok
+    end
+  end
 
   # One vault per identity, named for it. Reused on re-provision.
   defp ensure_vault(user_id, fields, _dek, opts) do
@@ -140,6 +160,7 @@ defmodule Fountain.Buzz do
       "user_id" => user_id,
       "agent_id" => fields.agent_id,
       "vault_id" => vault.id,
+      "environment_id" => fields.environment_id,
       "name" => fields.name,
       "relay_url" => fields.relay_url,
       "pubkey" => fields.pubkey,
@@ -263,7 +284,8 @@ defmodule Fountain.Buzz do
   sandbox-adjacent process needs, without key management), decrypts the vault's
   `BUZZ_PRIVATE_KEY` / `BUZZ_AUTH_TAG` / `BUZZ_RELAY_URL` server-side, and lays
   out the environment: the Buzz identity vars, the `BUZZ_ACP_*` wiring that
-  points the harness's ACP child at `fountain acp --agent … --vault …`, and the
+  points the harness's ACP child at `fountain acp --agent … --vault …
+  [--environment …]`, and the
   `FOUNTAIN_*` vars that let that child authenticate back to this instance.
 
   Options:
@@ -351,10 +373,16 @@ defmodule Fountain.Buzz do
     |> maybe_put("BUZZ_ACP_DISPLAY_NAME", identity.display_name)
   end
 
-  # Point the harness's ACP child at this Fountain agent + vault, and keep the
-  # pool to one (the desktop's 10 is not our assumption).
+  # Point the harness's ACP child at this Fountain agent + vault (+ environment
+  # override, #783), and keep the pool to one (the desktop's 10 is not our
+  # assumption).
   defp acp_wiring_env(%BuzzIdentity{} = identity, fountain_bin, agents) do
-    args = "acp,--agent,#{identity.agent_id},--vault,#{identity.vault_id}"
+    args =
+      ["acp", "--agent", identity.agent_id, "--vault", identity.vault_id]
+      |> Kernel.++(
+        if identity.environment_id, do: ["--environment", identity.environment_id], else: []
+      )
+      |> Enum.join(",")
 
     %{
       "BUZZ_ACP_AGENT_COMMAND" => fountain_bin,

--- a/apps/fountain/lib/fountain/buzz/buzz_identity.ex
+++ b/apps/fountain/lib/fountain/buzz/buzz_identity.ex
@@ -11,12 +11,19 @@ defmodule Fountain.Buzz.BuzzIdentity do
   The public key is stored (it is public); the secret is not. Deleting the user,
   the agent, or the vault cascades the identity away — a harness with no agent to
   run or no key to sign with is not a state worth keeping.
+
+  An identity may also name an **environment** (#783): the baseline its
+  conversations are provisioned from instead of the agent's own, so one agent
+  config can run under N environments — one per identity. Optional; nil means
+  the agent's environment, and deleting the environment nilifies rather than
+  cascades, because losing an override is not losing the identity.
   """
   use Ecto.Schema
   import Ecto.Changeset
 
   alias Fountain.Accounts.User
   alias Fountain.Agents.Agent
+  alias Fountain.Environments.Environment
   alias Fountain.Vaults.Vault
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -34,6 +41,7 @@ defmodule Fountain.Buzz.BuzzIdentity do
     belongs_to :user, User
     belongs_to :agent, Agent
     belongs_to :vault, Vault
+    belongs_to :environment, Environment
 
     timestamps(type: :utc_datetime)
   end
@@ -46,7 +54,8 @@ defmodule Fountain.Buzz.BuzzIdentity do
     :enabled,
     :user_id,
     :agent_id,
-    :vault_id
+    :vault_id,
+    :environment_id
   ]
 
   def changeset(identity, attrs) do
@@ -60,6 +69,7 @@ defmodule Fountain.Buzz.BuzzIdentity do
     |> unique_constraint(:pubkey, name: :buzz_identities_user_id_pubkey_index)
     |> foreign_key_constraint(:agent_id)
     |> foreign_key_constraint(:vault_id)
+    |> foreign_key_constraint(:environment_id)
   end
 
   # `buzz-acp` connects over a WebSocket, so the relay URL must be ws(s). A

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -966,8 +966,8 @@ defmodule Fountain.Conversations do
   the same sandbox and workspace, rather than opening a fresh one per restart.
 
   Resumes the **latest live** conversation for the same user + agent + vault
-  + channel — `terminated` and `failed` ones are past resuming, so a new one
-  is opened and becomes the binding. Returns `{:ok, conv, :resumed}` or
+  + environment override + channel — `terminated` and `failed` ones are past
+  resuming, so a new one is opened and becomes the binding. Returns `{:ok, conv, :resumed}` or
   `{:ok, conv, :created}`; without a `channel_id` it always creates.
 
   Two concurrent first calls for one channel can both create; the next call
@@ -982,8 +982,9 @@ defmodule Fountain.Conversations do
       )
       when is_binary(channel_id) and channel_id != "" do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent) do
-      case find_channel_conversation(user_id, agent.id, vault_id, channel_id) do
+         {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
+         {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent) do
+      case find_channel_conversation(user_id, agent.id, vault_id, env_id, channel_id) do
         %Conversation{} = conv ->
           {:ok, conv, :resumed}
 
@@ -999,8 +1000,10 @@ defmodule Fountain.Conversations do
 
   # The newest conversation still worth resuming for this binding. `vault_id`
   # is part of the key: two entries on one agent with different vaults are
-  # different identities (#727) and must not share a conversation.
-  defp find_channel_conversation(user_id, agent_id, vault_id, channel_id) do
+  # different identities (#727) and must not share a conversation. So is the
+  # environment override (#783): an identity that switches environments must
+  # not resume a conversation provisioned from the old one.
+  defp find_channel_conversation(user_id, agent_id, vault_id, env_id, channel_id) do
     from(c in Conversation,
       where:
         c.user_id == ^user_id and c.agent_id == ^agent_id and c.channel_id == ^channel_id and
@@ -1009,11 +1012,15 @@ defmodule Fountain.Conversations do
       limit: 1
     )
     |> where_vault(vault_id)
+    |> where_environment(env_id)
     |> Repo.one()
   end
 
   defp where_vault(query, nil), do: from(c in query, where: is_nil(c.vault_id))
   defp where_vault(query, vault_id), do: from(c in query, where: c.vault_id == ^vault_id)
+
+  defp where_environment(query, nil), do: from(c in query, where: is_nil(c.environment_id))
+  defp where_environment(query, id), do: from(c in query, where: c.environment_id == ^id)
 
   @doc """
   Create a new sandbox + conversation pair, start a ConversationServer
@@ -1025,6 +1032,8 @@ defmodule Fountain.Conversations do
     - `prompt`                — optional first prompt (sends turn 1 immediately)
     - `sprite_name`           — optional override; defaults to "fountain-<short-user-id>-<short-id>"
     - `vault_id`              — optional vault whose secrets override the env's
+    - `environment_id`        — optional environment to provision from instead of the
+                                agent's own (#783); subject to `agent.allowed_environment_ids`
     - `source`                — optional; one of "ui", "api", "agent" (default "api")
     - `parent_conversation_id` — optional; UUID of the conversation that spawned this one
   """
@@ -1033,6 +1042,7 @@ defmodule Fountain.Conversations do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
+         {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
          {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Accounts.check_not_suspended(user_id),
          :ok <- Fountain.Billing.check_active(user_id),
@@ -1043,7 +1053,7 @@ defmodule Fountain.Conversations do
          {:ok, sandbox} <-
            Fountain.Quotas.with_sandbox_reservation(user_id, fn ->
              create_sandbox(%{
-               environment_id: agent.environment_id,
+               environment_id: env_id || agent.environment_id,
                sprite_name:
                  attrs["sprite_name"] || "fountain-#{tenant_prefix(user_id)}-#{short_id()}",
                status: "pending",
@@ -1056,6 +1066,7 @@ defmodule Fountain.Conversations do
              sandbox_id: sandbox.id,
              agent_id: agent.id,
              vault_id: vault_id,
+             environment_id: env_id,
              user_id: user_id,
              runtime: agent.runtime,
              status: "pending",
@@ -1223,6 +1234,35 @@ defmodule Fountain.Conversations do
 
   defp check_vault_allowed(vault_id, %Agents.Agent{allowed_vault_ids: allowed}) do
     if vault_id in allowed, do: :ok, else: {:error, :vault_not_allowed}
+  end
+
+  # A per-launch environment override (#783): the conversation is provisioned
+  # from this environment instead of the agent's own, and stays pinned to it
+  # across wakes. Resolved exactly like the vault — a scoped fetch (a foreign
+  # id reads as not found, so it cannot be probed) behind the agent's allowlist.
+  defp resolve_environment_id(nil, _user_id, _agent), do: {:ok, nil}
+  defp resolve_environment_id("", _user_id, _agent), do: {:ok, nil}
+
+  defp resolve_environment_id(id, user_id, agent) when is_binary(id) and is_binary(user_id) do
+    with :ok <- check_environment_allowed(id, agent) do
+      case Fountain.Environments.get_environment(id, user_id) do
+        nil -> {:error, :environment_not_found}
+        env -> {:ok, env.id}
+      end
+    end
+  end
+
+  # An override replaces the reviewed environment wholesale, so it is scoped
+  # the same way as a vault: nil = any tenant environment, [] = none, a
+  # non-empty list is an allowlist. Default nil is deliberate — a caller who
+  # can attach a vault can already override every key, so a stricter default
+  # here would guard nothing (#783). Naming the agent's own environment is not
+  # an override, so it passes regardless of the list.
+  defp check_environment_allowed(_id, %Agents.Agent{allowed_environment_ids: nil}), do: :ok
+  defp check_environment_allowed(id, %Agents.Agent{environment_id: id}), do: :ok
+
+  defp check_environment_allowed(id, %Agents.Agent{allowed_environment_ids: allowed}) do
+    if id in allowed, do: :ok, else: {:error, :environment_not_allowed}
   end
 
   @doc """
@@ -1468,7 +1508,7 @@ defmodule Fountain.Conversations do
              [exclude: conv.sandbox_id],
              fn ->
                create_sandbox(%{
-                 environment_id: agent.environment_id,
+                 environment_id: conv.environment_id || agent.environment_id,
                  sprite_name: "fountain-#{tenant_prefix(conv.user_id)}-#{short_id()}",
                  status: "pending",
                  provider: Atom.to_string(provider),

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -5,6 +5,7 @@ defmodule Fountain.Conversations.Conversation do
   alias Fountain.Accounts.User
   alias Fountain.Agents.Agent
   alias Fountain.Conversations.{Sandbox, Turn}
+  alias Fountain.Environments.Environment
   alias Fountain.Vaults.Vault
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -44,6 +45,12 @@ defmodule Fountain.Conversations.Conversation do
     belongs_to :sandbox, Sandbox
     belongs_to :agent, Agent
     belongs_to :vault, Vault
+    # Per-launch environment override (#783). nil means "the agent's
+    # environment" — resolved at provision, so a conversation whose agent
+    # later changes environments follows the agent, as before. Set, it is the
+    # baseline this conversation's sandboxes are provisioned from instead,
+    # every time (a wake provisions a fresh sandbox from it too).
+    belongs_to :environment, Environment
 
     belongs_to :parent_conversation, __MODULE__,
       foreign_key: :parent_conversation_id,
@@ -73,6 +80,7 @@ defmodule Fountain.Conversations.Conversation do
       :sandbox_id,
       :agent_id,
       :vault_id,
+      :environment_id,
       :channel_id
     ])
     |> validate_required([:runtime, :status, :sandbox_id, :user_id])
@@ -82,6 +90,7 @@ defmodule Fountain.Conversations.Conversation do
     |> foreign_key_constraint(:sandbox_id)
     |> foreign_key_constraint(:agent_id)
     |> foreign_key_constraint(:vault_id)
+    |> foreign_key_constraint(:environment_id)
     |> foreign_key_constraint(:parent_conversation_id)
   end
 end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -420,16 +420,21 @@ defmodule Fountain.Conversations.ConversationServer do
       Logger.warning("conv #{conv.id}: agent #{conv.agent_id} is gone; provisioning without it")
     end
 
-    # Scoped by the conversation's owner even though create/update_agent
-    # already validates ownership: a cross-tenant environment_id that
-    # predates that check (or slips in through a future path) must not
-    # materialise another tenant's secrets or checkpoint here.
+    # The conversation's own override wins over the agent's environment (#783);
+    # nil falls back to the agent's, resolved fresh each provision.
+    #
+    # Scoped by the conversation's owner even though create/update_agent and
+    # start_conversation already validate ownership: a cross-tenant
+    # environment_id that predates that check (or slips in through a future
+    # path) must not materialise another tenant's secrets or checkpoint here.
+    env_id = conv.environment_id || (agent && agent.environment_id)
+
     env =
-      if agent && agent.environment_id do
-        case Environments.get_environment(agent.environment_id, conv.user_id) do
+      if env_id do
+        case Environments.get_environment(env_id, conv.user_id) do
           nil ->
             Logger.warning(
-              "Agent #{agent.id} references environment #{agent.environment_id} " <>
+              "conv #{conv.id}: environment #{env_id} " <>
                 "not owned by user #{conv.user_id}; provisioning without it"
             )
 

--- a/apps/fountain/lib/fountain/exports.ex
+++ b/apps/fountain/lib/fountain/exports.ex
@@ -345,6 +345,7 @@ defmodule Fountain.Exports do
         "mcp_servers" => agent.mcp_servers,
         "metadata" => agent.metadata,
         "allowed_vault_ids" => agent.allowed_vault_ids,
+        "allowed_environment_ids" => agent.allowed_environment_ids,
         "environment_id" => agent.environment_id,
         "created_at" => agent.inserted_at,
         "updated_at" => agent.updated_at
@@ -432,6 +433,7 @@ defmodule Fountain.Exports do
         "source" => conv.source,
         "agent_id" => conv.agent_id,
         "vault_id" => conv.vault_id,
+        "environment_id" => conv.environment_id,
         "parent_conversation_id" => conv.parent_conversation_id,
         "created_at" => conv.inserted_at,
         "updated_at" => conv.updated_at,

--- a/apps/fountain/lib/fountain_web/controllers/agent_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_json.ex
@@ -26,6 +26,7 @@ defmodule FountainWeb.AgentJSON do
       mcp_servers: a.mcp_servers,
       metadata: a.metadata,
       allowed_vault_ids: a.allowed_vault_ids,
+      allowed_environment_ids: a.allowed_environment_ids,
       conversation_count: a.conversation_count,
       avatar_media_type: a.avatar_media_type,
       inserted_at: a.inserted_at,

--- a/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
@@ -45,7 +45,10 @@ defmodule FountainWeb.BuzzAgentController do
     user = conn.assigns.current_user
 
     attrs =
-      Map.take(params, ~w(name relay_url agent_id pubkey private_key_nsec auth_tag display_name))
+      Map.take(
+        params,
+        ~w(name relay_url agent_id pubkey private_key_nsec auth_tag display_name environment_id)
+      )
 
     case Buzz.provision_identity(user.id, attrs, actor: "api") do
       {:ok, %BuzzIdentity{} = identity} ->
@@ -61,6 +64,11 @@ defmodule FountainWeb.BuzzAgentController do
         conn
         |> put_status(:unprocessable_entity)
         |> json(%{error: "missing required fields: #{Enum.join(fields, ", ")}"})
+
+      # 404 like every other unknown-or-foreign environment id, so the response
+      # cannot be used to probe which ids exist.
+      {:error, :environment_not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "environment_not_found"})
 
       {:error, _reason} ->
         conn
@@ -109,6 +117,7 @@ defmodule FountainWeb.BuzzAgentController do
       pubkey: i.pubkey,
       agent_id: i.agent_id,
       vault_id: i.vault_id,
+      environment_id: i.environment_id,
       enabled: i.enabled,
       inserted_at: i.inserted_at,
       updated_at: i.updated_at

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -34,6 +34,7 @@ defmodule FountainWeb.ConversationJSON do
       sandbox: sandbox_data(c.sandbox),
       agent_id: c.agent_id,
       vault_id: c.vault_id,
+      environment_id: c.environment_id,
       runtime: c.runtime,
       # Derived, never stored — the same signal as on an agent (#702). A
       # protocol client asks before reopening a conversation, because a

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -36,6 +36,22 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # Same two shapes for a per-launch environment override (#783).
+  def call(conn, {:error, :environment_not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> json(%{error: "environment_not_found"})
+  end
+
+  def call(conn, {:error, :environment_not_allowed}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "environment_not_allowed",
+      message: "environment is not in the agent's allowed_environment_ids"
+    })
+  end
+
   # An unknown or cross-tenant parent conversation. 404 rather than 403 so the
   # caller cannot use the response to probe which conversation ids exist.
   def call(conn, {:error, :parent_not_found}) do

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -56,6 +56,12 @@ defmodule FountainWeb.Schemas do
         sandbox: %Schema{oneOf: [Sandbox], nullable: true},
         agent_id: %Schema{type: :string, format: :uuid, nullable: true},
         vault_id: %Schema{type: :string, format: :uuid, nullable: true},
+        environment_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "Per-launch environment override; null means the agent's environment."
+        },
         runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
         acp: %Schema{
           type: :boolean,
@@ -168,6 +174,17 @@ defmodule FountainWeb.Schemas do
           description:
             "Optional vault whose secrets override the environment's baseline at sprite spawn. " <>
               "Must satisfy the agent's allowed_vault_ids when that allowlist is set."
+        },
+        environment_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Optional environment to provision from instead of the agent's own; the " <>
+              "conversation stays pinned to it across wakes. Must be owned by the caller " <>
+              "(404 otherwise) and satisfy the agent's allowed_environment_ids when that " <>
+              "allowlist is set (422 environment_not_allowed). Part of the channel_id " <>
+              "resume key."
         },
         prompt: %Schema{type: :string, description: "Optional first turn prompt."},
         images: %Schema{
@@ -347,6 +364,16 @@ defmodule FountainWeb.Schemas do
               "a non-empty list is an allowlist. Vault values override the agent's " <>
               "environment on key collision, so this scopes who can override reviewed config."
         },
+        allowed_environment_ids: %Schema{
+          type: :array,
+          items: %Schema{type: :string, format: :uuid},
+          nullable: true,
+          description:
+            "Environments a conversation may launch this agent under instead of its own " <>
+              "(environment_id on create). Same shape as allowed_vault_ids: null (default) " <>
+              "allows any environment the tenant owns; an empty list forbids overriding; " <>
+              "a non-empty list is an allowlist. The agent's own environment always passes."
+        },
         conversation_count: %Schema{
           type: :integer,
           description: "Conversations started from this agent."
@@ -388,6 +415,14 @@ defmodule FountainWeb.Schemas do
         pubkey: %Schema{type: :string, description: "Nostr public key (hex)", nullable: true},
         agent_id: %Schema{type: :string, format: :uuid},
         vault_id: %Schema{type: :string, format: :uuid},
+        environment_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Environment this identity's conversations are provisioned from instead of " <>
+              "the agent's own; null means the agent's."
+        },
         enabled: %Schema{type: :boolean},
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
@@ -420,7 +455,18 @@ defmodule FountainWeb.Schemas do
           description: "Nostr secret key (nsec/hex). Stored, never returned"
         },
         auth_tag: %Schema{type: :string, description: "NIP-OA owner attestation tag (JSON array)"},
-        display_name: %Schema{type: :string, nullable: true}
+        display_name: %Schema{type: :string, nullable: true},
+        environment_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Optional environment to provision this identity's conversations from instead " <>
+              "of the agent's own — one agent config, one environment per identity. Must be " <>
+              "owned by the caller (404 otherwise) and, when the agent sets " <>
+              "allowed_environment_ids, on that list (checked at conversation start). " <>
+              "Omitted on a re-provision clears a previously set one."
+        }
       },
       required: [:name, :relay_url, :agent_id, :pubkey, :private_key_nsec, :auth_tag]
     })
@@ -529,6 +575,16 @@ defmodule FountainWeb.Schemas do
             "Sandbox backend override; null inherits the instance default " <>
               "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
         },
+        allowed_environment_ids: %Schema{
+          type: :array,
+          items: %Schema{type: :string, format: :uuid},
+          nullable: true,
+          description:
+            "Environments a conversation may launch this agent under instead of its own " <>
+              "(environment_id on create). Same shape as allowed_vault_ids: null (default) " <>
+              "allows any environment the tenant owns; an empty list forbids overriding; " <>
+              "a non-empty list is an allowlist. The agent's own environment always passes."
+        },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         skills: %Schema{
           type: :array,
@@ -625,6 +681,16 @@ defmodule FountainWeb.Schemas do
             }
           },
           additionalProperties: true
+        },
+        allowed_environment_ids: %Schema{
+          type: :array,
+          items: %Schema{type: :string, format: :uuid},
+          nullable: true,
+          description:
+            "Environments a conversation may launch this agent under instead of its own " <>
+              "(environment_id on create). Same shape as allowed_vault_ids: null (default) " <>
+              "allows any environment the tenant owns; an empty list forbids overriding; " <>
+              "a non-empty list is an allowlist. The agent's own environment always passes."
         },
         repositories: %Schema{type: :array, items: Repository},
         metadata: %Schema{type: :object, additionalProperties: true},

--- a/apps/fountain/priv/repo/migrations/20260817020000_add_per_launch_environment.exs
+++ b/apps/fountain/priv/repo/migrations/20260817020000_add_per_launch_environment.exs
@@ -1,0 +1,29 @@
+defmodule Fountain.Repo.Migrations.AddPerLaunchEnvironment do
+  @moduledoc """
+  A conversation's environment becomes a per-launch choice that defaults to
+  the agent's (#783): the conversation carries an optional override, a Buzz
+  identity can name one for every conversation it opens, and the agent gets an
+  allowlist mirroring `allowed_vault_ids` to scope who may override.
+
+  All three are `nilify_all` on environment delete — losing the override falls
+  back to the agent's environment; it never orphans a row.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:conversations) do
+      add :environment_id, references(:environments, type: :binary_id, on_delete: :nilify_all)
+    end
+
+    alter table(:buzz_identities) do
+      add :environment_id, references(:environments, type: :binary_id, on_delete: :nilify_all)
+    end
+
+    alter table(:agents) do
+      add :allowed_environment_ids, {:array, :binary_id}, null: true
+    end
+
+    create index(:conversations, [:environment_id])
+    create index(:buzz_identities, [:environment_id])
+  end
+end

--- a/apps/fountain/test/fountain/buzz_test.exs
+++ b/apps/fountain/test/fountain/buzz_test.exs
@@ -184,6 +184,42 @@ defmodule Fountain.BuzzTest do
 
       assert "private_key_nsec" in missing
     end
+
+    # #783: an identity may name the environment its conversations launch
+    # under, so one agent config runs under one environment per identity.
+    test "stores an environment override, and a re-provision without one clears it", %{
+      user: user,
+      params: params
+    } do
+      env = insert_env(user_id: user.id)
+
+      assert {:ok, identity} =
+               Buzz.provision_identity(user.id, Map.put(params, "environment_id", env.id))
+
+      assert identity.environment_id == env.id
+
+      # The provider's deploy is the whole truth: omitting it is "none".
+      assert {:ok, again} = Buzz.provision_identity(user.id, params)
+      assert again.id == identity.id
+      assert is_nil(again.environment_id)
+    end
+
+    test "a foreign or unknown environment_id is not stored", %{user: user, params: params} do
+      other = insert_verified_user()
+      foreign = insert_env(user_id: other.id)
+
+      assert {:error, :environment_not_found} =
+               Buzz.provision_identity(user.id, Map.put(params, "environment_id", foreign.id))
+
+      assert {:error, :environment_not_found} =
+               Buzz.provision_identity(
+                 user.id,
+                 Map.put(params, "environment_id", Ecto.UUID.generate())
+               )
+
+      # And nothing was half-created on the way to the refusal.
+      assert Buzz.list_identities(user.id) == []
+    end
   end
 
   describe "harness_launch/2" do
@@ -255,6 +291,24 @@ defmodule Fountain.BuzzTest do
       # The launch reports the key id so the caller can revoke it on stop.
       assert launch.api_key_id == key.id
       assert launch.command == "/opt/buzz-acp"
+    end
+
+    # #783: the override reaches the ACP child as --environment, so every
+    # conversation the harness opens is provisioned from it.
+    test "an environment override is passed to the ACP child",
+         %{identity: identity, agent: agent, vault: vault, user: user} do
+      env = insert_env(user_id: user.id)
+      {:ok, identity} = Buzz.update_identity(identity, %{"environment_id" => env.id})
+
+      assert {:ok, launch} =
+               Buzz.harness_launch(identity,
+                 buzz_acp_path: "/opt/buzz-acp",
+                 base_url: "https://fountain.example",
+                 fountain_bin: "fountain"
+               )
+
+      assert Map.new(launch.env)["BUZZ_ACP_AGENT_ARGS"] ==
+               "acp,--agent,#{agent.id},--vault,#{vault.id},--environment,#{env.id}"
     end
 
     test "the identity's relay_url overrides a BUZZ_RELAY_URL in the vault",

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
 
   use Fountain.ConversationServerCase
 
-  alias Fountain.Accounts
+  alias Fountain.{Accounts, Environments}
   alias Fountain.Repo
 
   setup do
@@ -133,6 +133,79 @@ defmodule Fountain.Conversations.ConversationServerTest do
       assert turn.prompt == "first prompt"
 
       GenServer.stop(pid)
+    end
+  end
+
+  describe "provisioning — per-launch environment override (#783)" do
+    # The observable difference between two environments at provision is which
+    # checkpoint is restored, so that is what the assertion reads.
+    test "the conversation's environment_id is provisioned from, not the agent's", %{
+      user: user,
+      env: agent_env
+    } do
+      {:ok, _} = Environments.update_environment(agent_env, %{"checkpoint_id" => "cp_agent"})
+      override = insert_env(user_id: user.id, checkpoint_id: "cp_override")
+
+      agent = insert_agent(user_id: user.id, environment_id: agent_env.id, runtime: "gemini")
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox_id: sandbox.id,
+          environment_id: override.id,
+          status: "pending"
+        )
+
+      stub_happy_sprite()
+      test_pid = self()
+
+      Mimic.stub(Fountain.Conversations.Provisioning, :restore_checkpoint, fn _s, id ->
+        send(test_pid, {:restore_checkpoint, id})
+        :ok
+      end)
+
+      {pid, _ref, :alive} = start_server(conv)
+
+      assert_received {:restore_checkpoint, "cp_override"}
+      refute_received {:restore_checkpoint, "cp_agent"}
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
+      GenServer.stop(pid)
+    end
+
+    test "a cross-tenant environment_id on the conversation is not materialised", %{
+      user: attacker,
+      conv: conv,
+      sandbox: sandbox
+    } do
+      victim = insert_verified_user()
+      victim_env = insert_env(user_id: victim.id, checkpoint_id: "cp_victim")
+
+      # Inserted through the bare changeset — start_conversation refuses this,
+      # so only a row that bypassed it could carry a foreign id.
+      {:ok, conv} =
+        conv
+        |> Fountain.Conversations.Conversation.changeset(%{"environment_id" => victim_env.id})
+        |> Repo.update()
+
+      stub_happy_sprite()
+      test_pid = self()
+
+      Mimic.stub(Fountain.Conversations.Provisioning, :restore_checkpoint, fn _s, id ->
+        send(test_pid, {:restore_checkpoint, id})
+        :ok
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          {pid, _ref, :alive} = start_server(conv)
+          refute_received {:restore_checkpoint, "cp_victim"}
+          assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
+          GenServer.stop(pid)
+        end)
+
+      assert log =~ "not owned by user #{attacker.id}"
     end
   end
 

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -2,7 +2,7 @@ defmodule Fountain.ConversationsContextTest do
   use Fountain.DataCase, async: true
   use Mimic
 
-  alias Fountain.Conversations
+  alias Fountain.{Agents, Conversations}
   alias Fountain.Conversations.{Conversation, LogEvent, Sandbox, Turn}
 
   # ────────────────────────────────────────────────────────────────────────────
@@ -1625,6 +1625,145 @@ defmodule Fountain.ConversationsContextTest do
       attrs = %{"agent_id" => agent.id, "user_id" => user.id}
       assert {:ok, conv} = Conversations.start_conversation(attrs)
       assert is_nil(conv.vault_id)
+    end
+  end
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # start_conversation/2 — per-launch environment override (#783)
+  # ────────────────────────────────────────────────────────────────────────────
+
+  describe "start_conversation/2 environment_id override" do
+    setup do
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
+
+      user = insert_verified_user()
+      agent_env = insert_env(user_id: user.id)
+      other_env = insert_env(user_id: user.id)
+      agent = insert_agent(user_id: user.id, environment_id: agent_env.id)
+      %{user: user, agent: agent, agent_env: agent_env, other_env: other_env}
+    end
+
+    test "pins the conversation and its sandbox to the named environment", ctx do
+      attrs = %{
+        "agent_id" => ctx.agent.id,
+        "user_id" => ctx.user.id,
+        "environment_id" => ctx.other_env.id
+      }
+
+      assert {:ok, conv} = Conversations.start_conversation(attrs)
+      assert conv.environment_id == ctx.other_env.id
+
+      assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).environment_id ==
+               ctx.other_env.id
+    end
+
+    test "nil and blank mean the agent's environment", ctx do
+      for value <- [nil, ""] do
+        attrs = %{
+          "agent_id" => ctx.agent.id,
+          "user_id" => ctx.user.id,
+          "environment_id" => value
+        }
+
+        assert {:ok, conv} = Conversations.start_conversation(attrs)
+        assert is_nil(conv.environment_id)
+
+        assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).environment_id ==
+                 ctx.agent_env.id
+      end
+    end
+
+    test "a foreign environment reads as not found — same as an unknown id", ctx do
+      stranger = insert_verified_user()
+      foreign = insert_env(user_id: stranger.id)
+
+      for id <- [foreign.id, Ecto.UUID.generate()] do
+        attrs = %{"agent_id" => ctx.agent.id, "user_id" => ctx.user.id, "environment_id" => id}
+        assert {:error, :environment_not_found} = Conversations.start_conversation(attrs)
+      end
+    end
+
+    test "allowed_environment_ids: a listed environment passes, an unlisted one is refused",
+         ctx do
+      third = insert_env(user_id: ctx.user.id)
+
+      {:ok, agent} =
+        Agents.update_agent(ctx.agent, %{allowed_environment_ids: [ctx.other_env.id]})
+
+      ok = %{
+        "agent_id" => agent.id,
+        "user_id" => ctx.user.id,
+        "environment_id" => ctx.other_env.id
+      }
+
+      assert {:ok, conv} = Conversations.start_conversation(ok)
+      assert conv.environment_id == ctx.other_env.id
+
+      refused = %{"agent_id" => agent.id, "user_id" => ctx.user.id, "environment_id" => third.id}
+      assert {:error, :environment_not_allowed} = Conversations.start_conversation(refused)
+    end
+
+    test "an empty allowlist forbids every override but still permits the agent's own", ctx do
+      {:ok, agent} = Agents.update_agent(ctx.agent, %{allowed_environment_ids: []})
+
+      refused = %{
+        "agent_id" => agent.id,
+        "user_id" => ctx.user.id,
+        "environment_id" => ctx.other_env.id
+      }
+
+      assert {:error, :environment_not_allowed} = Conversations.start_conversation(refused)
+
+      # Naming the agent's own environment is not an override — it is pinned
+      # (a later change of the agent's environment does not move it), but it
+      # needs no allowlist entry.
+      own = %{
+        "agent_id" => agent.id,
+        "user_id" => ctx.user.id,
+        "environment_id" => ctx.agent_env.id
+      }
+
+      assert {:ok, conv} = Conversations.start_conversation(own)
+      assert conv.environment_id == ctx.agent_env.id
+    end
+
+    test "the allowlist is checked before the fetch, so a foreign id is refused not probed",
+         ctx do
+      stranger = insert_verified_user()
+      foreign = insert_env(user_id: stranger.id)
+      {:ok, agent} = Agents.update_agent(ctx.agent, %{allowed_environment_ids: []})
+
+      attrs = %{"agent_id" => agent.id, "user_id" => ctx.user.id, "environment_id" => foreign.id}
+      assert {:error, :environment_not_allowed} = Conversations.start_conversation(attrs)
+    end
+
+    test "channel resume keys on the override: a different environment is a different binding",
+         ctx do
+      base = %{"agent_id" => ctx.agent.id, "user_id" => ctx.user.id, "channel_id" => "chan-783"}
+
+      assert {:ok, first, :created} =
+               Conversations.start_or_resume_conversation(
+                 Map.put(base, "environment_id", ctx.other_env.id)
+               )
+
+      # Same channel, same environment: resumed.
+      assert {:ok, again, :resumed} =
+               Conversations.start_or_resume_conversation(
+                 Map.put(base, "environment_id", ctx.other_env.id)
+               )
+
+      assert again.id == first.id
+
+      # Same channel, no override: a fresh conversation, not the pinned one.
+      assert {:ok, plain, :created} = Conversations.start_or_resume_conversation(base)
+      refute plain.id == first.id
+      assert is_nil(plain.environment_id)
+
+      # And the plain one is now what a plain launch resumes.
+      assert {:ok, resumed, :resumed} = Conversations.start_or_resume_conversation(base)
+      assert resumed.id == plain.id
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
@@ -168,6 +168,30 @@ defmodule FountainWeb.AgentControllerTest do
       body = json_response(conn, 201)
       assert body["data"]["environment_id"] == env.id
     end
+
+    # #783: the allowlist that scopes per-launch environment overrides round-trips.
+    test "accepts and reports allowed_environment_ids", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      env = insert_env(user_id: user.id)
+
+      payload = %{
+        name: "with-env-allowlist",
+        model: "anthropic/claude-sonnet-4-6",
+        runtime: "claude",
+        allowed_environment_ids: [env.id]
+      }
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/agents", payload)
+        |> json_response(201)
+
+      assert body["data"]["allowed_environment_ids"] == [env.id]
+    end
   end
 
   describe "PUT /api/agents/:id" do

--- a/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
@@ -99,6 +99,41 @@ defmodule FountainWeb.BuzzAgentControllerTest do
     assert Vaults.get_vault(vault_id, user.id) == nil
   end
 
+  # #783: an identity may name the environment its conversations launch under.
+  test "POST stores an environment override and echoes it", %{
+    conn: conn,
+    user: user,
+    raw_key: raw_key,
+    agent: agent
+  } do
+    env = insert_env(user_id: user.id)
+
+    conn =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", Map.put(params(agent), "environment_id", env.id))
+
+    assert json_response(conn, 201)["data"]["environment_id"] == env.id
+  end
+
+  test "POST with a foreign environment_id is a 404, and nothing is provisioned", %{
+    conn: conn,
+    raw_key: raw_key,
+    agent: agent
+  } do
+    foreign = insert_env(user_id: insert_verified_user().id)
+
+    conn =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", Map.put(params(agent), "environment_id", foreign.id))
+
+    assert json_response(conn, 404)["error"] == "environment_not_found"
+    assert Fountain.Buzz.list_identities(agent.user_id) == []
+  end
+
   test "missing required fields is a 422", %{conn: conn, raw_key: raw_key, agent: agent} do
     bad = Map.delete(params(agent), "private_key_nsec")
 

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -896,6 +896,73 @@ defmodule FountainWeb.ConversationControllerTest do
     end
   end
 
+  describe "POST /api/conversations with environment_id (#783)" do
+    setup %{user: user} do
+      stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+      agent_env = insert_env(user_id: user.id)
+      other_env = insert_env(user_id: user.id)
+      agent = insert_agent(user_id: user.id, environment_id: agent_env.id)
+      %{agent: agent, other_env: other_env}
+    end
+
+    test "provisions from the named environment and reports it", %{
+      conn: conn,
+      raw_key: raw_key,
+      agent: agent,
+      other_env: other_env
+    } do
+      body = %{"agent_id" => agent.id, "environment_id" => other_env.id}
+
+      data =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations", body)
+        |> json_response(201)
+        |> Map.fetch!("data")
+
+      assert data["environment_id"] == other_env.id
+    end
+
+    test "a foreign environment is a 404 — indistinguishable from an unknown one", %{
+      conn: conn,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      foreign = insert_env(user_id: insert_verified_user().id)
+
+      for id <- [foreign.id, Ecto.UUID.generate()] do
+        assert conn
+               |> authed_with_key(raw_key)
+               |> post_json("/api/conversations", %{
+                 "agent_id" => agent.id,
+                 "environment_id" => id
+               })
+               |> json_response(404)
+               |> Map.fetch!("error") == "environment_not_found"
+      end
+    end
+
+    test "an environment outside the agent's allowlist is a 422 environment_not_allowed", %{
+      conn: conn,
+      raw_key: raw_key,
+      agent: agent,
+      other_env: other_env
+    } do
+      {:ok, agent} = Fountain.Agents.update_agent(agent, %{allowed_environment_ids: []})
+
+      resp =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations", %{
+          "agent_id" => agent.id,
+          "environment_id" => other_env.id
+        })
+        |> json_response(422)
+
+      assert resp["error"] == "environment_not_allowed"
+    end
+  end
+
   describe "POST /api/conversations with channel_id (#774)" do
     # A client that forgets its sessions — a restarted buzz-acp — must land back
     # on the same conversation, and so the same sandbox, rather than opening a

--- a/cli/internal/backend/backend.go
+++ b/cli/internal/backend/backend.go
@@ -79,6 +79,8 @@ type DeployResponse struct {
 type Fountain interface {
 	// ResolveAgent maps a user-supplied agent name or id to its id.
 	ResolveAgent(nameOrID string) (string, error)
+	// ResolveEnvironment maps a user-supplied environment name or id to its id.
+	ResolveEnvironment(nameOrID string) (string, error)
 	// Provision creates or converges a hosted Buzz agent, returning its id.
 	Provision(body ProvisionBody) (string, error)
 }
@@ -92,12 +94,16 @@ type ProvisionBody struct {
 	PrivateKeyNsec string `json:"private_key_nsec"`
 	AuthTag        string `json:"auth_tag"`
 	DisplayName    string `json:"display_name,omitempty"`
+	// Optional per-identity environment override (#783): the environment this
+	// identity's conversations are provisioned from instead of the agent's own.
+	EnvironmentID string `json:"environment_id,omitempty"`
 }
 
 // Info returns the provider descriptor. config_schema is the desktop's settings
-// form: only a non-secret selector (which Fountain agent to run as). Credentials
-// are deliberately NOT here — the desktop rejects a provider_config key named
-// like a secret, so Fountain auth is ambient (env / the fountain CLI creds).
+// form: non-secret selectors only — which Fountain agent to run as, and
+// optionally which environment to run it under. Credentials are deliberately
+// NOT here — the desktop rejects a provider_config key named like a secret, so
+// Fountain auth is ambient (env / the fountain CLI creds).
 func Info() InfoResponse {
 	schema := json.RawMessage(`{
   "type": "object",
@@ -106,6 +112,11 @@ func Info() InfoResponse {
       "type": "string",
       "title": "Fountain agent",
       "description": "Name or id of the Fountain agent this Buzz identity runs as."
+    },
+    "environment": {
+      "type": "string",
+      "title": "Fountain environment (optional)",
+      "description": "Name or id of a Fountain environment to provision this identity's conversations from, instead of the agent's own. Leave blank to use the agent's."
     }
   },
   "required": ["agent"]
@@ -140,14 +151,25 @@ func Deploy(req Request, f Fountain) DeployResponse {
 		return fail(fmt.Sprintf("could not derive the agent pubkey from its key: %v", err))
 	}
 
-	agentSel, err := providerAgent(req.ProviderConfig)
+	cfg, err := providerConfig(req.ProviderConfig)
 	if err != nil {
 		return fail(err.Error())
 	}
 
-	agentID, err := f.ResolveAgent(agentSel)
+	agentID, err := f.ResolveAgent(cfg.Agent)
 	if err != nil {
-		return fail(fmt.Sprintf("no such Fountain agent %q: %v", agentSel, err))
+		return fail(fmt.Sprintf("no such Fountain agent %q: %v", cfg.Agent, err))
+	}
+
+	// The environment selector is optional; blank means the agent's own. A
+	// selector that names nothing is a refusal, not a silent fallback — the
+	// user asked for a specific baseline and would otherwise get another.
+	envID := ""
+	if cfg.Environment != "" {
+		envID, err = f.ResolveEnvironment(cfg.Environment)
+		if err != nil {
+			return fail(fmt.Sprintf("no such Fountain environment %q: %v", cfg.Environment, err))
+		}
 	}
 
 	id, err := f.Provision(ProvisionBody{
@@ -158,6 +180,7 @@ func Deploy(req Request, f Fountain) DeployResponse {
 		PrivateKeyNsec: req.Agent.PrivateKeyNsec,
 		AuthTag:        req.Agent.AuthTag,
 		DisplayName:    req.Agent.Name,
+		EnvironmentID:  envID,
 	})
 	if err != nil {
 		return fail(fmt.Sprintf("provisioning failed: %v", err))
@@ -189,17 +212,24 @@ func derivePubkey(key string) (string, error) {
 	return nostr.GetPublicKey(sk)
 }
 
-func providerAgent(raw json.RawMessage) (string, error) {
-	var cfg struct {
-		Agent string `json:"agent"`
-	}
+// providerConfigFields is the desktop's provider_config as this provider reads
+// it — the two selectors from Info's config_schema, trimmed.
+type providerConfigFields struct {
+	Agent       string `json:"agent"`
+	Environment string `json:"environment"`
+}
+
+func providerConfig(raw json.RawMessage) (providerConfigFields, error) {
+	var cfg providerConfigFields
 	if len(raw) > 0 {
 		_ = json.Unmarshal(raw, &cfg)
 	}
-	if strings.TrimSpace(cfg.Agent) == "" {
-		return "", fmt.Errorf("no Fountain agent configured — set the `agent` field")
+	cfg.Agent = strings.TrimSpace(cfg.Agent)
+	cfg.Environment = strings.TrimSpace(cfg.Environment)
+	if cfg.Agent == "" {
+		return cfg, fmt.Errorf("no Fountain agent configured — set the `agent` field")
 	}
-	return cfg.Agent, nil
+	return cfg, nil
 }
 
 func fail(msg string) DeployResponse { return DeployResponse{OK: false, Error: msg} }

--- a/cli/internal/backend/backend_test.go
+++ b/cli/internal/backend/backend_test.go
@@ -2,18 +2,33 @@ package backend
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
 
+var errNoEnv = errors.New("no environment named \"nope\"")
+
 // fakeFountain records calls and returns canned results.
 type fakeFountain struct {
-	resolveTo  string
-	resolveErr error
-	gotBody    ProvisionBody
-	provID     string
-	provErr    error
-	provably   bool
+	resolveTo     string
+	resolveErr    error
+	resolveEnvTo  string
+	resolveEnvErr error
+	gotBody       ProvisionBody
+	provID        string
+	provErr       error
+	provably      bool
+}
+
+func (f *fakeFountain) ResolveEnvironment(sel string) (string, error) {
+	if f.resolveEnvErr != nil {
+		return "", f.resolveEnvErr
+	}
+	if f.resolveEnvTo != "" {
+		return f.resolveEnvTo, nil
+	}
+	return sel, nil
 }
 
 func (f *fakeFountain) ResolveAgent(sel string) (string, error) {
@@ -81,6 +96,39 @@ func TestDeployProvisionsWithDerivedPubkey(t *testing.T) {
 	}
 	if f.gotBody.PrivateKeyNsec != testNsec {
 		t.Fatalf("the nsec must pass through to Fountain, which holds it server-side")
+	}
+}
+
+// #783: the optional environment selector resolves and rides as environment_id;
+// blank means "the agent's own" and sends nothing.
+func TestDeployPassesTheEnvironmentSelector(t *testing.T) {
+	f := &fakeFountain{resolveTo: "agent-uuid", resolveEnvTo: "env-uuid"}
+	resp := Deploy(deployReq(`{"agent":"my-agent","environment":"buzz-env"}`), f)
+	if !resp.OK {
+		t.Fatalf("deploy failed: %+v", resp)
+	}
+	if f.gotBody.EnvironmentID != "env-uuid" {
+		t.Fatalf("environment_id = %q, want the resolved environment", f.gotBody.EnvironmentID)
+	}
+
+	f = &fakeFountain{resolveTo: "agent-uuid"}
+	resp = Deploy(deployReq(`{"agent":"my-agent","environment":"  "}`), f)
+	if !resp.OK || f.gotBody.EnvironmentID != "" {
+		t.Fatalf("a blank environment must send none: %+v / %q", resp, f.gotBody.EnvironmentID)
+	}
+	if b, _ := json.Marshal(f.gotBody); strings.Contains(string(b), "environment_id") {
+		t.Fatalf("environment_id must be omitted when unset: %s", b)
+	}
+}
+
+func TestDeployRefusesAnUnknownEnvironment(t *testing.T) {
+	f := &fakeFountain{resolveTo: "agent-uuid", resolveEnvErr: errNoEnv}
+	resp := Deploy(deployReq(`{"agent":"my-agent","environment":"nope"}`), f)
+	if resp.OK || !strings.Contains(resp.Error, "nope") {
+		t.Fatalf("want an in-band refusal naming the environment, got %+v", resp)
+	}
+	if f.provably {
+		t.Fatalf("must not provision when the environment does not resolve")
 	}
 }
 

--- a/cli/internal/backend/fountain.go
+++ b/cli/internal/backend/fountain.go
@@ -38,6 +38,26 @@ func (a *apiFountain) ResolveAgent(sel string) (string, error) {
 	return "", fmt.Errorf("no agent named %q", sel)
 }
 
+func (a *apiFountain) ResolveEnvironment(sel string) (string, error) {
+	if uuidRe.MatchString(sel) {
+		return sel, nil
+	}
+
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := a.c.Get("/environments", &resp); err != nil {
+		return "", err
+	}
+
+	for _, env := range resp.Data {
+		if fmt.Sprint(env["name"]) == sel {
+			return fmt.Sprint(env["id"]), nil
+		}
+	}
+	return "", fmt.Errorf("no environment named %q", sel)
+}
+
 func (a *apiFountain) Provision(body ProvisionBody) (string, error) {
 	var out struct {
 		Data struct {

--- a/cli/internal/cmd/acp.go
+++ b/cli/internal/cmd/acp.go
@@ -22,9 +22,10 @@ import (
 )
 
 var (
-	acpLogLevel string
-	acpAgent    string
-	acpVault    string
+	acpLogLevel    string
+	acpAgent       string
+	acpVault       string
+	acpEnvironment string
 )
 
 func init() {
@@ -47,6 +48,11 @@ belong — an identity the agent posts under, for instance. Two entries pointing
 at the same agent with different vaults stay separate; the same secret in a
 shared environment would not.
 
+--environment provisions every conversation this process opens from that
+environment instead of the agent's own. One agent config can then run under
+several environments — one entry per environment — without duplicating the
+agent. The vault still wins over it on key collision.
+
 What it is, and is not: a control surface for a conversation running in a
 Fountain sandbox — watch it, steer it, interrupt it. It has no access to the
 files open in your editor, and the paths it reports are inside the sandbox,
@@ -55,6 +61,7 @@ not on your machine.`,
 	}
 	acpCmd.Flags().StringVar(&acpAgent, "agent", "", "Fountain agent name or id to open sessions against")
 	acpCmd.Flags().StringVar(&acpVault, "vault", "", "vault name or id to attach to each session's conversation")
+	acpCmd.Flags().StringVar(&acpEnvironment, "environment", "", "environment name or id to provision each session's conversation from, instead of the agent's own")
 	acpCmd.Flags().StringVar(&acpLogLevel, "log-level", "info", "stderr log level: debug, info, warn, error")
 	rootCmd.AddCommand(acpCmd)
 }
@@ -77,7 +84,7 @@ func runACP() error {
 	opts := activeOpts()
 	agent := acp.NewAgent(
 		cliAuth{opts: opts},
-		fountainAPI{opts: opts, log: log, vault: acpVault},
+		fountainAPI{opts: opts, log: log, vault: acpVault, environment: acpEnvironment},
 		acpAgent,
 		Version,
 		log,
@@ -150,9 +157,10 @@ func (a cliAuth) Describe() string {
 // here: a failure inside a session method is a JSON-RPC error the editor
 // renders, not a reason to kill a process the editor is talking to.
 type fountainAPI struct {
-	opts  credentials.Opts
-	log   *slog.Logger
-	vault string
+	opts        credentials.Opts
+	log         *slog.Logger
+	vault       string
+	environment string
 }
 
 func (f fountainAPI) Agent(_ context.Context, target string) (acp.AgentRef, error) {
@@ -221,6 +229,17 @@ func (f fountainAPI) CreateConversation(_ context.Context, agentID, channelID st
 			return "", false, err
 		}
 		body["vault_id"] = vaultID
+	}
+
+	// An environment override is the baseline the sandbox is provisioned from
+	// instead of the agent's own (#783). Same omit-when-unset rule as the
+	// vault: an empty string would name an environment called "".
+	if f.environment != "" {
+		envID, err := f.environmentID()
+		if err != nil {
+			return "", false, err
+		}
+		body["environment_id"] = envID
 	}
 
 	// No prompt: the conversation is created empty and the editor's first
@@ -351,6 +370,25 @@ func (f fountainAPI) vaultID() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no vault named %q", f.vault)
+}
+
+func (f fountainAPI) environmentID() (string, error) {
+	if isUUID(f.environment) {
+		return f.environment, nil
+	}
+
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := api.New(f.opts).Get("/environments", &resp); err != nil {
+		return "", err
+	}
+	for _, e := range resp.Data {
+		if output.ToString(e["name"]) == f.environment {
+			return output.ToString(e["id"]), nil
+		}
+	}
+	return "", fmt.Errorf("no environment named %q", f.environment)
 }
 
 func (f fountainAPI) StreamHead(_ context.Context, convID string) (string, error) {

--- a/cli/internal/cmd/acp_test.go
+++ b/cli/internal/cmd/acp_test.go
@@ -223,6 +223,57 @@ func TestCreateConversationOmitsTheVaultWhenUnset(t *testing.T) {
 	}
 }
 
+// #783: --environment resolves by name and rides as `environment_id`, so one
+// agent config can be launched under a different environment per entry.
+func TestCreateConversationAttachesTheEnvironment(t *testing.T) {
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/environments":
+			_, _ = w.Write([]byte(`{"data":[{"id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","name":"buzz-env"}]}`))
+		case "/api/conversations":
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"data":{"id":"conv-1"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+	api.environment = "buzz-env"
+
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", ""); err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if body["environment_id"] != "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" {
+		t.Errorf("environment_id = %v, want the resolved environment", body["environment_id"])
+	}
+}
+
+// Same omit rule as the vault: no flag, no key.
+func TestCreateConversationOmitsTheEnvironmentWhenUnset(t *testing.T) {
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"id":"conv-1"}}`))
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", ""); err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if _, present := body["environment_id"]; present {
+		t.Errorf("environment_id was sent without --environment: %v", body["environment_id"])
+	}
+}
+
 // #774: the channel key rides as `channel_id`, and a 200 with
 // `meta.resumed: true` comes back as resumed.
 func TestCreateConversationSendsTheChannelKeyAndReadsResumed(t *testing.T) {
@@ -269,6 +320,21 @@ func TestCreateConversationOmitsTheChannelKeyWhenEmpty(t *testing.T) {
 	}
 	if _, present := body["channel_id"]; present {
 		t.Errorf("channel_id was sent without a key: %v", body["channel_id"])
+	}
+}
+
+func TestUnknownEnvironmentNameIsReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+	api.environment = "not-an-env"
+
+	_, _, err := api.CreateConversation(context.Background(), "agent-1", "")
+	if err == nil || !strings.Contains(err.Error(), "not-an-env") {
+		t.Fatalf("want an error naming the environment, got %v", err)
 	}
 }
 

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -83,6 +83,7 @@ func init() {
 	}
 	runCmd.Flags().StringP("prompt", "p", "", "prompt text (required)")
 	runCmd.Flags().String("vault", "", "vault name or id")
+	runCmd.Flags().String("environment", "", "environment name or id to provision from, instead of the agent's own")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -267,11 +268,15 @@ func runAgent(cmd *cobra.Command, target string) error {
 		Fatal("missing -p <prompt>")
 	}
 	vault, _ := cmd.Flags().GetString("vault")
+	environment, _ := cmd.Flags().GetString("environment")
 
 	agentID := resolveAgentID(target)
 	body := map[string]any{"agent_id": agentID, "prompt": prompt}
 	if vault != "" {
 		body["vault_id"] = resolveVaultID(vault)
+	}
+	if environment != "" {
+		body["environment_id"] = resolveEnvironmentID(environment)
 	}
 
 	c := activeClient()

--- a/cli/internal/cmd/env.go
+++ b/cli/internal/cmd/env.go
@@ -68,3 +68,25 @@ func envShow(id string) error {
 	envResp.Data["secrets"] = secResp.Data
 	return output.PrintJSON(envResp.Data)
 }
+
+// resolveEnvironmentID accepts a UUID or an environment name and returns the id,
+// exactly as resolveVaultID does for vaults. Fatal on an unknown name.
+func resolveEnvironmentID(target string) string {
+	if isUUID(target) {
+		return target
+	}
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/environments", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	for _, e := range resp.Data {
+		if output.ToString(e["name"]) == target {
+			return output.ToString(e["id"])
+		}
+	}
+	Fatalf("no environment named %q", target)
+	return ""
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,9 +93,13 @@ fountain conv delete <id>
 ```bash
 fountain run <agent-name-or-id> -p "Audit the auth module"
 fountain run <agent-name-or-id> -p "Run the test suite" --vault staging-creds
+fountain run <agent-name-or-id> -p "Run the test suite" --environment staging
 ```
 
 `run` creates a conversation and streams until the turn reaches a terminal state.
+`--vault` layers a vault's secrets over the agent's environment (vault wins on
+collision); `--environment` provisions from that environment instead of the
+agent's own.
 
 ### Long-running turns
 
@@ -121,7 +125,7 @@ fountain conv stream <conversation-id>
 ## Editor integration (ACP)
 
 ```bash
-fountain acp --agent <name-or-id> [--vault <name-or-id>] [--log-level debug]
+fountain acp --agent <name-or-id> [--vault <name-or-id>] [--environment <name-or-id>] [--log-level debug]
 ```
 
 Speaks the [Agent Client Protocol](https://agentclientprotocol.com) on stdio, so

--- a/docs/integrations/buzz.md
+++ b/docs/integrations/buzz.md
@@ -80,8 +80,12 @@ Fountain ships a Buzz **remote-agents provider**, `buzz-backend-fountain`. The
 Buzz desktop discovers it by name and hands it a one-shot deploy; it stands up
 the hosted agent on your Fountain instance and returns.
 
-- Its settings ask only **which Fountain agent** to run as
-  (`{ "agent": "<name-or-id>" }`) — a non-secret selector.
+- Its settings ask **which Fountain agent** to run as
+  (`{ "agent": "<name-or-id>" }`) and, optionally, **which environment** to run
+  it under (`"environment": "<name-or-id>"`) — non-secret selectors. The
+  environment stands in for the agent's own at provision, so one Fountain agent
+  can back several Buzz identities each with a different baseline; leave it
+  blank to use the agent's.
 - Fountain credentials are **ambient**: `FOUNTAIN_API_KEY` / `FOUNTAIN_BASE_URL`
   from the environment or the `fountain` CLI creds file. The provider refuses to
   carry a secret in its config, so your Fountain key never rides in the Buzz
@@ -100,7 +104,8 @@ curl -X POST https://fountain.example.com/api/buzz/agents \
   -H "Content-Type: application/json" \
   -d '{
     "name": "night-owl",
-    "agent": "researcher",
+    "agent_id": "<fountain agent uuid>",
+    "environment_id": "<optional environment uuid — instead of the agent's own>",
     "relay_url": "wss://relay.example.com",
     "pubkey": "<64-hex nostr pubkey>",
     "private_key_nsec": "nsec1…",
@@ -114,7 +119,11 @@ curl -X POST https://fountain.example.com/api/buzz/agents \
 - Any valid tenant API key may provision — there is no separate scope gate.
 - The `private_key_nsec` is **accepted here and stored server-side; it is never
   returned and never enters a sandbox.** The response carries only the identity's
-  public fields (id, name, relay, pubkey, `agent_id`, `vault_id`, `enabled`).
+  public fields (id, name, relay, pubkey, `agent_id`, `vault_id`,
+  `environment_id`, `enabled`).
+- `environment_id` is optional and must be yours (404 otherwise); it is the
+  environment the identity's conversations are provisioned from instead of the
+  agent's own, and re-provisioning without it clears it.
 - The relay URL must be `ws://` or `wss://`, and the pubkey 64 lowercase hex — a
   common `https://` paste is rejected up front.
 

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -93,6 +93,16 @@ shared by every agent attached to it, so a credential put there is used by all
 of them; a vault is attached per conversation, so two entries stay separate
 even when they point at the same agent.
 
+### Per-entry environments
+
+`--environment <name-or-id>` provisions every conversation the entry opens from
+that [environment](../primitives.md#environment) instead of the agent's own.
+Use it when one agent config should run under several baselines — the same
+"engineer" against a `fountain` environment in one entry and a `buzz`
+environment in another — without duplicating the agent. The vault, if any,
+still wins over it on key collision, and an agent can restrict which
+environments may stand in for its own via `allowed_environment_ids`.
+
 ### Any other ACP client
 
 There is nothing Zed-specific in the adapter. Whatever your client calls it,

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -157,6 +157,16 @@ The distinction matters as soon as there are two entries. An environment is
 shared by every agent attached to it; a vault is attached per conversation, so
 two entries stay separate even when they point at the same agent.
 
+### Per-entry environments
+
+`--environment <name-or-id>` provisions every conversation the entry opens from
+that [environment](../primitives.md#environment) instead of the agent's own.
+Use it when one agent config should run under several baselines — the same
+"engineer" against a `fountain` environment in one entry and a `buzz`
+environment in another — without duplicating the agent. The vault, if any,
+still wins over it on key collision, and an agent can restrict which
+environments may stand in for its own via `allowed_environment_ids`.
+
 ## What you get
 
 | ACP | What happens |

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -99,7 +99,7 @@ spec:
 
 A **Conversation** is a running session of an Agent inside a sandboxed VM. It starts with one prompt and can continue over multiple turns:
 
-1. POST to `/api/conversations` with `agent_id` (and optional `vault_id`, `prompt`, `images`)
+1. POST to `/api/conversations` with `agent_id` (and optional `vault_id`, `environment_id` — an environment to provision from instead of the agent's own — `prompt`, `images`)
 2. Fountain resolves the full env-var set and spawns a Sprites sandbox
 3. The agent runs; log events stream in real time over SSE (`GET /api/conversations/:id/stream`)
 4. Follow-up prompts go to `POST /api/conversations/:id/prompts`; a running turn can be interrupted (`POST .../interrupt`) and the whole conversation ended early (`POST .../terminate`)


### PR DESCRIPTION
Closes #783.

## What

A conversation may now be provisioned from an environment other than its agent's, per launch:

| Surface | Change |
|---|---|
| `POST /api/conversations` | `environment_id` (optional). 404 `environment_not_found` for a foreign/unknown id; 422 `environment_not_allowed` when outside the agent's allowlist. Echoed on the conversation. |
| `fountain acp` / `fountain run` | `--environment <name-or-id>`, resolved like `--vault`. Omitted when unset. |
| `POST /api/buzz/agents` | `environment_id` (optional, ownership-checked, 404 otherwise). Stored on the identity; the harness passes `--environment` to its ACP child. Re-provision without it clears it. |
| `buzz-backend-fountain` | Optional `environment` selector in the provider config_schema; deploy resolves it and passes `environment_id`. |
| Agent | `allowed_environment_ids` — same nil / `[]` / allowlist shape as `allowed_vault_ids`; the agent's own environment always passes. API + export only, like `allowed_vault_ids`. |
| Conversation | `environment_id` (nullable FK, `nilify_all`). Pinned across wakes; `ConversationServer` resolves `conv.environment_id \|\| agent.environment_id`, still scoped by the conversation's owner. |
| Channel resume | The override is part of the `channel_id` resume key, so switching environments never resumes a conversation provisioned from the old one. |

## Why the authz shape

An override replaces the reviewed environment wholesale, which is the same concern #136 raised for vaults, so it gets the same lever. Nil default is deliberate: anyone who can attach a vault can already override every key, so a stricter default here would guard nothing.

## Not in this PR

- The new-conversation LiveView form has no environment picker (matches `allowed_vault_ids`, which is API-only). Cheap to add if wanted.
- `Buzz.provision_identity` still doesn't ownership-check `agent_id` (pre-existing; a foreign agent id fails at conversation start under the minted key). Left alone — worth its own small fix.

## Verification

- `mix precommit` gate locally: format, credo --strict, sobelow, dialyzer, full suite **2896 tests, 0 failures**; OpenAPI spec generates and validates; `go vet` + `go test ./...` in `cli/`.
- New tests were checked against a reverted fix: the ConversationServer override test and the harness `--environment` test both fail without their change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)