### PR TITLE
fix: a lost reuse wake race drops the prompt instead of handing it off (#667)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1303,7 +1303,23 @@ defmodule Fountain.Conversations do
           with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
                :ok <- Fountain.Billing.check_active(conv.user_id),
                {:ok, _} <- wake_suspended_sandbox(conv.user_id, sandbox_id) do
-            start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt)
+            case start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt) do
+              {:error, {:already_started, winner_pid}} ->
+                # Lost a concurrent wake of the same conversation to another
+                # caller reusing the same sandbox. Mirrors the handoff in
+                # create_fresh_sandbox_and_start/4 (#330), but reuse provisions
+                # no row of its own, so there is nothing here to clean up —
+                # just hand the prompt to the winner, which drops it if a turn
+                # is already running.
+                if is_binary(initial_prompt) and initial_prompt != "" do
+                  ConversationServer.queue_initial_prompt(winner_pid, initial_prompt)
+                end
+
+                {:ok, _unsafe_get_conversation!(conv.id)}
+
+              other ->
+                other
+            end
           end
 
         :create_new ->

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1194,6 +1194,41 @@ defmodule Fountain.ConversationsContextTest do
       assert {:ok, _conv} = Conversations.wake_conversation(conv.id)
     end
 
+    test "a reuse that loses the start race hands the prompt to the winner (#667)" do
+      # Two concurrent wakes of the same suspended/ready sandbox: the loser
+      # used to get the raw {:error, {:already_started, pid}} back from
+      # start_conversation_server, so the prompt was silently dropped instead
+      # of reaching the winner's server.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite-race")
+      {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      winner = spawn(fn -> Process.sleep(:infinity) end)
+      test_pid = self()
+
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+        {:ok, %{status: :running, raw: %{name: "test-sprite-race"}}}
+      end)
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
+        {:error, {:already_started, winner}}
+      end)
+
+      stub(Fountain.Conversations.ConversationServer, :queue_initial_prompt, fn pid, prompt ->
+        send(test_pid, {:queued, pid, prompt})
+        :ok
+      end)
+
+      assert {:ok, woken} = Conversations.wake_conversation(conv.id, "hello")
+      assert_receive {:queued, ^winner, "hello"}
+
+      # Reuse touches no row — the conversation still names the sandbox it
+      # started with.
+      assert woken.sandbox_id == sandbox.id
+    end
+
     test "waking a suspended sandbox flips it to ready and stamps the clock" do
       # The core of decisions/0017: the parked sprite is reused, re-added to
       # the quota, and the max-lifetime ceiling restarts from the wake.


### PR DESCRIPTION
## Summary
Closes #667.

`wake_conversation/2`'s reuse arm called `start_conversation_server/4` and returned its result as-is. When a wake lost a concurrent start race, that meant returning the raw `{:error, {:already_started, pid}}` to the caller — the prompt was never delivered anywhere.

The fresh-sandbox arm (`create_fresh_sandbox_and_start/4`) already handles exactly this race (#330): on `{:error, {:already_started, winner_pid}}` it queues the prompt to the winner and returns `{:ok, conv}`. This mirrors that handoff in the reuse arm. No row cleanup is needed here (unlike the fresh arm), since reuse provisions no sandbox row of its own.

## Test plan
- [x] Added `wake_conversation/2 a reuse that loses the start race hands the prompt to the winner (#667)` in `apps/fountain/test/fountain/conversations_context_test.exs`, mirroring the existing race coverage in `wake_race_test.exs` but for the reuse arm.
- [x] `mix test apps/fountain/test/fountain/conversations_context_test.exs apps/fountain/test/fountain/conversations/wake_race_test.exs` — 163 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `MIX_ENV=dev mix compile --warnings-as-errors`
- [x] `mix credo --strict` — no issues