### PR TITLE
chore(buzz-acp): repin the fork to carry block/buzz#6101 (owner commands with mention text)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Fixed
+
+- **Owner control commands (`!rotate`, `!cancel`, `!shutdown`) now work from
+  the Buzz Desktop composer.** The hosted `buzz-acp` required the message body
+  to be *exactly* the command, but Desktop renders the `@Name` mention into the
+  body, so `@Fountain Maintainer !rotate` reached the agent as an ordinary
+  prompt and a bare `!rotate` was dropped for lacking the `p` tag. The fork pin
+  moves to a build carrying block/buzz#6101 (`buzz-acp-v0.5.14-fountain.2`),
+  which matches the command with mention text around it. #776 still tracks
+  the repin to upstream — it now waits on #6101 as well as #6088.
+
 ## [0.12.0] — 2026-08-17
 
 One agent config, many baselines: a conversation can now be provisioned from

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-amd64}" \
 
 FROM debian:trixie-slim AS buzzacp
 ARG TARGETARCH
-ARG BUZZ_ACP_VERSION=0.5.14-fountain.1
+ARG BUZZ_ACP_VERSION=0.5.14-fountain.2
 # buzz-acp: the hosted harness (gate 2). buzz: the CLI the server-side MCP tools
 # shell out to for signed publishes (gate 3, #737). Both from our own release.
 RUN apt-get update -y \

--- a/buzz-acp.source
+++ b/buzz-acp.source
@@ -1,2 +1,2 @@
 # Fork pin — see #776 for when and how to remove. Format: owner/repo@ref
-jhgaylor/buzz@9390060f0908dfd29e5dd1a2d4a481a2fe81819c
+jhgaylor/buzz@0bb9e5af7713ca6946b6eb5a332d817897024a31

--- a/buzz-acp.version
+++ b/buzz-acp.version
@@ -1,1 +1,1 @@
-0.5.14-fountain.1
+0.5.14-fountain.2


### PR DESCRIPTION
## Summary

Bumps the hosted `buzz-acp` fork pin so `!rotate` / `!cancel` / `!shutdown` work from the Buzz Desktop composer.

- `buzz-acp.source` → `jhgaylor/buzz@0bb9e5af` — the `fountain-pin` branch on the fork: the two block/buzz#6088 commits already pinned (`9390060`) plus block/buzz#6101 (`is_owner_control_command` tolerates the `@Name` / `nostr:` mention text Desktop renders into the body).
- `buzz-acp.version` → `0.5.14-fountain.2` (and the `Dockerfile` default `ARG`), so the image downloads a fresh `buzz-acp-v0.5.14-fountain.2` release instead of a clobbered `fountain.1` asset.
- CHANGELOG entry under Unreleased.

Observed on prod: `@Fountain Maintainer !rotate` reached the agent as a prompt ("Not sure what `!rotate` should do here"), and bare `!rotate`/`!shutdown` were dropped. Upstream issues: block/buzz#6014, block/buzz#6051.

#776 (repin to upstream) now also waits on block/buzz#6101.

## Rollout note

Merging touches `buzz-acp.source`/`.version`, so `buzz-acp-publish.yml` and (after CI) `build.yml` run concurrently. If the image build races ahead of the release upload it fails on the download step — re-run `build.yml` (`workflow_dispatch`) once `buzz-acp-v0.5.14-fountain.2` has both arches.

## Test plan

- [ ] `buzz-acp-publish` publishes `buzz-acp-v0.5.14-fountain.2` with amd64 + arm64 assets
- [ ] `build.yml` succeeds and Flux rolls the pods
- [ ] From Desktop as owner: `@Fountain Maintainer !rotate` — no conversational reply, harness log shows the rotate

🤖 Generated with [Claude Code](https://claude.com/claude-code)