### PR TITLE
fix(billing): suspend-aware usage metering — parked time no longer inflates sandbox-minutes (#665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ upgrade, is in
   `BUZZ_ACP_DISPLAY_NAME` becomes the advertised name. #776 now waits on #6097
   too. (#790)
 
+- **Suspend-aware usage metering: parked sandbox time no longer inflates
+  sandbox-minutes (#665).** A sandbox that suspended and later terminated
+  billed its entire parked interval as run time. New `sandbox_suspended` /
+  `sandbox_resumed` usage events now bracket each parked span, and the
+  `usage_summary`/`usage_summaries` roll-up subtracts it from the
+  `sandbox_terminated` `duration_ms` — including the case where a parked
+  sandbox is torn down (account deletion, tenant reap) without ever waking
+  again, closed against the terminated event itself. A `suspended → ready`
+  wake still emits no second `sandbox_provisioned`. Understated minutes for a
+  sandbox that stays suspended forever (no `sandbox_terminated` at all) are
+  unchanged — see decisions/0017.
+
 - **`!shutdown` no longer restart-loops a hosted harness.** The supervisor
   restarts `buzz-acp` on any exit and the fresh process replayed the same
   `!shutdown` from its subscription backlog — five exits per command before

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -205,6 +205,36 @@ defmodule Fountain.Conversations do
     )
   end
 
+  # `suspended → ready`: the wake side of a park/wake cycle (0017). No
+  # sandbox_provisioned here — the provision was already recorded before the
+  # sandbox parked (see above) — but the parked interval needs a start and an
+  # end of its own so the duration roll-up can subtract it from
+  # sandbox_terminated's duration_ms instead of billing parked time (#665).
+  defp record_sandbox_usage("suspended", %Sandbox{status: "ready"} = sandbox) do
+    Fountain.Billing.record_usage(
+      sandbox.user_id,
+      "sandbox_resumed",
+      sandbox.id,
+      "sandbox",
+      %{"sprite_name" => sandbox.sprite_name, "provider" => sandbox.provider}
+    )
+  end
+
+  # `ready → suspended`: the sandbox is parked, not destroyed, and stops
+  # billing compute from here (0017). Paired with sandbox_resumed (or, for a
+  # sandbox that never wakes again, with sandbox_terminated) so the duration
+  # roll-up can tell parked time apart from run time (#665).
+  defp record_sandbox_usage(was, %Sandbox{status: "suspended"} = sandbox)
+       when was not in @billable_terminal do
+    Fountain.Billing.record_usage(
+      sandbox.user_id,
+      "sandbox_suspended",
+      sandbox.id,
+      "sandbox",
+      %{"sprite_name" => sandbox.sprite_name, "provider" => sandbox.provider}
+    )
+  end
+
   defp record_sandbox_usage(was, %Sandbox{status: status} = sandbox)
        when status in @billable_terminal and was not in @billable_terminal do
     # A sandbox that dies before reaching "ready" never emitted

--- a/decisions/0017-suspend-idle-sandboxes.md
+++ b/decisions/0017-suspend-idle-sandboxes.md
@@ -72,13 +72,15 @@ destroyed the moment it is woken.
   being ignorable — or a sprites.dev account-level sprite cap starts binding —
   a retention bound for `suspended` rows is the knob to add, with the #649
   caveat attached.
-- **Usage metering blurs at the edges, in both directions.** A sandbox that
-  suspends and later terminates includes its parked time in the
-  `sandbox_terminated` `duration_ms`; one that stays suspended forever emits
-  no `sandbox_terminated` at all, so billed sandbox-minutes understate. The ee
-  usage-event vocabulary is closed and suspend-aware metering was not worth
-  new event types while the cost is treated as zero. A `suspended → ready`
-  wake deliberately emits no second `sandbox_provisioned`.
+- **Usage metering blurs at the edges, in both directions — half-fixed by
+  #665.** `sandbox_suspended`/`sandbox_resumed` events now bracket each parked
+  interval, and the `usage_summary`/`usage_summaries` roll-up subtracts that
+  interval (or, for a sandbox torn down while still parked, the span up to
+  its `sandbox_terminated`) from `duration_ms`, so the overstating direction
+  is corrected. The understating direction stands: a sandbox that stays
+  suspended forever still emits no `sandbox_terminated`, so its time never
+  enters `sandbox_minutes` at all. A `suspended → ready` wake still
+  deliberately emits no second `sandbox_provisioned`.
 - **A rolling deploy has a one-time loss window.** An old node waking a
   suspended row does not recognise the status, provisions a fresh sprite, and
   the parked disk is destroyed by the reaper. Old nodes cannot *write*

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -1522,7 +1522,10 @@ defmodule Fountain.Billing do
     diverge for exactly the accounts where provisioning is failing.
   - `:turns` — count of `turn_started` events
   - `:sandbox_minutes` — total wall-clock sandbox time in minutes, derived
-    from `duration_ms` metadata on `sandbox_terminated` events
+    from `duration_ms` metadata on `sandbox_terminated` events, minus any
+    parked interval bracketed by `sandbox_suspended`/`sandbox_resumed` (or, for
+    a sandbox that parks and is torn down without ever waking again,
+    `sandbox_suspended` paired with the terminated event itself) (#665).
   """
   @spec usage_summary(binary(), DateTime.t(), DateTime.t()) ::
           %{conversations: non_neg_integer(), turns: non_neg_integer(), sandbox_minutes: float()}
@@ -1541,18 +1544,7 @@ defmodule Fountain.Billing do
 
     turns = Enum.count(events, &(&1.event_type == "turn_started"))
 
-    sandbox_minutes =
-      events
-      |> Enum.filter(&(&1.event_type == "sandbox_terminated"))
-      |> Enum.reduce(0.0, fn ev, acc ->
-        ms =
-          get_in(ev.metadata, ["duration_ms"]) ||
-            get_in(ev.metadata, [:duration_ms]) || 0
-
-        acc + ms / 60_000.0
-      end)
-
-    %{conversations: conversations, turns: turns, sandbox_minutes: sandbox_minutes}
+    %{conversations: conversations, turns: turns, sandbox_minutes: sandbox_minutes(events)}
   end
 
   @doc """
@@ -1566,42 +1558,108 @@ defmodule Fountain.Billing do
   def usage_summaries(%DateTime{} = period_start, %DateTime{} = period_end) do
     empty = %{conversations: 0, turns: 0, sandbox_minutes: 0.0}
 
+    counted =
+      from(e in UsageEvent,
+        where:
+          e.inserted_at >= ^period_start and e.inserted_at < ^period_end and
+            e.event_type in ["sandbox_provisioned", "sandbox_provision_failed", "turn_started"],
+        group_by: [e.user_id, e.event_type],
+        select: {e.user_id, e.event_type, count(e.id)}
+      )
+      |> Repo.all()
+      |> Enum.reduce(%{}, fn {user_id, type, count}, acc ->
+        summary = Map.get(acc, user_id, empty)
+
+        summary =
+          case type do
+            "sandbox_provisioned" ->
+              %{summary | conversations: summary.conversations + count}
+
+            "sandbox_provision_failed" ->
+              %{summary | conversations: summary.conversations + count}
+
+            "turn_started" ->
+              %{summary | turns: count}
+          end
+
+        Map.put(acc, user_id, summary)
+      end)
+
+    # Separate pass, in its own (still single) query: pairing suspend/resume
+    # intervals against a sandbox's terminated duration (#665) needs the raw
+    # per-sandbox event timeline, which a `sum(duration_ms)` aggregate throws
+    # away. These three event types are a small slice of `usage_events`
+    # compared to `turn_started`, so pulling their rows is cheap next to the
+    # one-query-per-admin-refresh constraint above.
     from(e in UsageEvent,
-      where: e.inserted_at >= ^period_start and e.inserted_at < ^period_end,
-      group_by: [e.user_id, e.event_type],
-      select:
-        {e.user_id, e.event_type, count(e.id),
-         sum(coalesce(fragment("(? ->> 'duration_ms')::numeric", e.metadata), 0))}
+      where:
+        e.inserted_at >= ^period_start and e.inserted_at < ^period_end and
+          e.event_type in ["sandbox_suspended", "sandbox_resumed", "sandbox_terminated"]
     )
     |> Repo.all()
-    |> Enum.reduce(%{}, fn {user_id, type, count, duration_ms}, acc ->
+    |> Enum.group_by(& &1.user_id)
+    |> Enum.reduce(counted, fn {user_id, user_events}, acc ->
       summary = Map.get(acc, user_id, empty)
-
-      summary =
-        case type do
-          "sandbox_provisioned" ->
-            %{summary | conversations: summary.conversations + count}
-
-          "sandbox_provision_failed" ->
-            %{summary | conversations: summary.conversations + count}
-
-          "turn_started" ->
-            %{summary | turns: count}
-
-          "sandbox_terminated" ->
-            %{summary | sandbox_minutes: to_minutes(duration_ms)}
-
-          _ ->
-            summary
-        end
-
-      Map.put(acc, user_id, summary)
+      Map.put(acc, user_id, %{summary | sandbox_minutes: sandbox_minutes(user_events)})
     end)
   end
 
-  defp to_minutes(nil), do: 0.0
-  defp to_minutes(%Decimal{} = ms), do: Decimal.to_float(ms) / 60_000.0
-  defp to_minutes(ms) when is_number(ms), do: ms / 60_000.0
+  # Shared by usage_summary/3 (one user's events) and usage_summaries/2 (one
+  # user's slice of the all-users pull) — sums sandbox_terminated's
+  # duration_ms, minus whatever of that span was parked rather than running.
+  defp sandbox_minutes(events) do
+    parked_ms_by_sandbox = parked_ms_by_sandbox(events)
+
+    events
+    |> Enum.filter(&(&1.event_type == "sandbox_terminated"))
+    |> Enum.reduce(0.0, fn ev, acc ->
+      ms =
+        get_in(ev.metadata, ["duration_ms"]) ||
+          get_in(ev.metadata, [:duration_ms]) || 0
+
+      parked_ms = Map.get(parked_ms_by_sandbox, ev.resource_id, 0)
+      acc + max(ms - parked_ms, 0) / 60_000.0
+    end)
+  end
+
+  # A sandbox's parked time, in milliseconds, keyed by resource_id (the
+  # sandbox id). Pairs each `sandbox_suspended` with the `sandbox_resumed` (or,
+  # failing that, the `sandbox_terminated`) that closes it, in event order —
+  # a `sandbox_suspended` with neither in this event set is still parked as of
+  # `period_end` and contributes nothing yet, matching `sandbox_terminated`'s
+  # own absence from the minutes total until it fires.
+  defp parked_ms_by_sandbox(events) do
+    events
+    |> Enum.filter(
+      &(&1.event_type in ["sandbox_suspended", "sandbox_resumed", "sandbox_terminated"])
+    )
+    |> Enum.group_by(& &1.resource_id)
+    |> Map.new(fn {resource_id, resource_events} ->
+      parked_ms =
+        resource_events
+        |> Enum.sort_by(& &1.inserted_at, DateTime)
+        |> sum_parked_intervals()
+
+      {resource_id, parked_ms}
+    end)
+  end
+
+  defp sum_parked_intervals(sorted_events) do
+    {total_ms, _suspended_since} =
+      Enum.reduce(sorted_events, {0, nil}, fn
+        %{event_type: "sandbox_suspended", inserted_at: at}, {total_ms, nil} ->
+          {total_ms, at}
+
+        %{event_type: type, inserted_at: at}, {total_ms, since}
+        when type in ["sandbox_resumed", "sandbox_terminated"] and not is_nil(since) ->
+          {total_ms + DateTime.diff(at, since, :millisecond), nil}
+
+        _event, acc ->
+          acc
+      end)
+
+    total_ms
+  end
 
   # ─── Admin billing overview (#286) ──────────────────────────────────────────
 

--- a/ee/lib/fountain/billing/usage_event.ex
+++ b/ee/lib/fountain/billing/usage_event.ex
@@ -26,7 +26,8 @@ defmodule Fountain.Billing.UsageEvent do
     field :inserted_at, :utc_datetime
   end
 
-  @valid_event_types ~w(sandbox_provisioned sandbox_provision_failed turn_started sandbox_terminated)
+  @valid_event_types ~w(sandbox_provisioned sandbox_provision_failed turn_started sandbox_terminated
+                         sandbox_suspended sandbox_resumed)
 
   def changeset(usage_event, attrs) do
     usage_event

--- a/ee/test/fountain/billing_test.exs
+++ b/ee/test/fountain/billing_test.exs
@@ -509,6 +509,126 @@ defmodule Fountain.BillingTest do
     end
   end
 
+  describe "usage_summary/3 — suspend-aware sandbox_minutes (#665)" do
+    @period_start ~U[2026-05-01 00:00:00Z]
+    @period_end ~U[2026-06-01 00:00:00Z]
+    @sandbox_id Ecto.UUID.generate()
+
+    setup do
+      {:ok, user: insert_verified_user()}
+    end
+
+    test "subtracts a closed suspend/resume interval from the terminated duration", %{
+      user: user
+    } do
+      # Alive 12:00 -> 13:00 (1h = 3_600_000ms), parked 12:20 -> 12:50 (30min).
+      # Net run time: 30 minutes.
+      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, @sandbox_id)
+      insert_event(user, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, @sandbox_id)
+
+      insert_event(
+        user,
+        "sandbox_terminated",
+        ~U[2026-05-10 13:00:00Z],
+        %{"duration_ms" => 3_600_000},
+        @sandbox_id
+      )
+
+      summary = Billing.usage_summary(user.id, @period_start, @period_end)
+
+      assert summary.sandbox_minutes == 30.0
+    end
+
+    test "closes a dangling suspend against the terminated event itself", %{user: user} do
+      # A sandbox that parks and is torn down (account deletion, tenant reap)
+      # without ever waking again: no sandbox_resumed at all. The whole parked
+      # span (12:20 -> 13:00, 40 minutes) must come off the hour.
+      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, @sandbox_id)
+
+      insert_event(
+        user,
+        "sandbox_terminated",
+        ~U[2026-05-10 13:00:00Z],
+        %{"duration_ms" => 3_600_000},
+        @sandbox_id
+      )
+
+      summary = Billing.usage_summary(user.id, @period_start, @period_end)
+
+      assert summary.sandbox_minutes == 20.0
+    end
+
+    test "sums multiple park cycles on the same sandbox", %{user: user} do
+      # Two separate suspend/resume cycles of 10 minutes each = 20 minutes
+      # parked out of the hour.
+      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:10:00Z], %{}, @sandbox_id)
+      insert_event(user, "sandbox_resumed", ~U[2026-05-10 12:20:00Z], %{}, @sandbox_id)
+      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:40:00Z], %{}, @sandbox_id)
+      insert_event(user, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, @sandbox_id)
+
+      insert_event(
+        user,
+        "sandbox_terminated",
+        ~U[2026-05-10 13:00:00Z],
+        %{"duration_ms" => 3_600_000},
+        @sandbox_id
+      )
+
+      summary = Billing.usage_summary(user.id, @period_start, @period_end)
+
+      assert summary.sandbox_minutes == 40.0
+    end
+
+    test "never goes negative when parked time would exceed the recorded duration", %{
+      user: user
+    } do
+      insert_event(user, "sandbox_suspended", ~U[2026-05-10 11:00:00Z], %{}, @sandbox_id)
+
+      insert_event(
+        user,
+        "sandbox_terminated",
+        ~U[2026-05-10 13:00:00Z],
+        %{"duration_ms" => 60_000},
+        @sandbox_id
+      )
+
+      summary = Billing.usage_summary(user.id, @period_start, @period_end)
+
+      assert summary.sandbox_minutes == 0.0
+    end
+
+    test "keys parked intervals per sandbox — one sandbox's suspend does not bleed into another's",
+         %{user: user} do
+      other_sandbox_id = Ecto.UUID.generate()
+
+      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, other_sandbox_id)
+      insert_event(user, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, other_sandbox_id)
+
+      insert_event(
+        user,
+        "sandbox_terminated",
+        ~U[2026-05-10 13:00:00Z],
+        %{"duration_ms" => 3_600_000},
+        @sandbox_id
+      )
+
+      summary = Billing.usage_summary(user.id, @period_start, @period_end)
+
+      # The suspend/resume pair belongs to a different sandbox; the terminated
+      # sandbox's full hour still counts.
+      assert summary.sandbox_minutes == 60.0
+    end
+
+    test "a suspend still parked at period end (no resume, no terminated event) contributes nothing",
+         %{user: user} do
+      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, @sandbox_id)
+
+      summary = Billing.usage_summary(user.id, @period_start, @period_end)
+
+      assert summary.sandbox_minutes == 0.0
+    end
+  end
+
   describe "sync_subscription/1 — trial_end nil branch" do
     setup do
       user = insert_verified_user()
@@ -697,13 +817,14 @@ defmodule Fountain.BillingTest do
     Ecto.Changeset.change(user, stripe_customer_id: customer_id) |> Repo.update!()
   end
 
-  defp insert_event(user, event_type, inserted_at, metadata \\ %{}) do
+  defp insert_event(user, event_type, inserted_at, metadata \\ %{}, resource_id \\ nil) do
     %UsageEvent{}
     |> UsageEvent.changeset(%{
       user_id: user.id,
       event_type: event_type,
       inserted_at: inserted_at,
-      metadata: metadata
+      metadata: metadata,
+      resource_id: resource_id
     })
     |> Repo.insert!()
   end
@@ -970,6 +1091,40 @@ defmodule Fountain.BillingTest do
       summaries = Billing.usage_summaries(DateTime.add(now, -1, :day), DateTime.add(now, 1, :day))
 
       assert summaries[a.id].conversations == 2
+    end
+
+    test "subtracts parked time per sandbox, per user (#665)" do
+      a = insert_verified_user()
+      b = insert_verified_user()
+      sandbox_a = Ecto.UUID.generate()
+      sandbox_b = Ecto.UUID.generate()
+
+      # a: alive an hour, parked 30 of those minutes -> nets 30.
+      insert_event(a, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, sandbox_a)
+      insert_event(a, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, sandbox_a)
+
+      insert_event(
+        a,
+        "sandbox_terminated",
+        ~U[2026-05-10 13:00:00Z],
+        %{"duration_ms" => 3_600_000},
+        sandbox_a
+      )
+
+      # b: alive an hour, never suspended -> nets the full 60.
+      insert_event(
+        b,
+        "sandbox_terminated",
+        ~U[2026-05-10 13:00:00Z],
+        %{"duration_ms" => 3_600_000},
+        sandbox_b
+      )
+
+      summaries =
+        Billing.usage_summaries(~U[2026-05-01 00:00:00Z], ~U[2026-06-01 00:00:00Z])
+
+      assert summaries[a.id].sandbox_minutes == 30.0
+      assert summaries[b.id].sandbox_minutes == 60.0
     end
   end
 

--- a/ee/test/fountain/usage_metering_test.exs
+++ b/ee/test/fountain/usage_metering_test.exs
@@ -85,6 +85,55 @@ defmodule Fountain.UsageMeteringTest do
     end
   end
 
+  describe "sandbox_suspended / sandbox_resumed (#665)" do
+    test "sandbox_suspended is emitted when a ready sandbox parks" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+
+      assert [event] = events_for(user.id, "sandbox_suspended")
+      assert event.resource_id == sandbox.id
+      assert event.resource_type == "sandbox"
+    end
+
+    test "sandbox_resumed is emitted when a suspended sandbox wakes" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      {:ok, parked} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+      {:ok, _} = Conversations.update_sandbox(parked, %{status: "ready"})
+
+      assert [event] = events_for(user.id, "sandbox_resumed")
+      assert event.resource_id == sandbox.id
+    end
+
+    test "a full park/wake/terminate cycle emits exactly one of each" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      {:ok, parked} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+      {:ok, woken} = Conversations.update_sandbox(parked, %{status: "ready"})
+      {:ok, _} = Conversations.update_sandbox(woken, %{status: "terminated"})
+
+      assert length(events_for(user.id, "sandbox_suspended")) == 1
+      assert length(events_for(user.id, "sandbox_resumed")) == 1
+      assert length(events_for(user.id, "sandbox_terminated")) == 1
+    end
+
+    test "a sandbox torn down while still parked emits sandbox_suspended with no matching resume" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      {:ok, parked} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+      {:ok, _} = Conversations.update_sandbox(parked, %{status: "terminated"})
+
+      assert length(events_for(user.id, "sandbox_suspended")) == 1
+      assert events_for(user.id, "sandbox_resumed") == []
+      assert [_] = events_for(user.id, "sandbox_terminated")
+    end
+  end
+
   describe "sandbox_terminated" do
     test "is emitted with a duration when a sandbox is terminated" do
       user = insert_verified_user()


### PR DESCRIPTION
## Summary

Closes #665.

decisions/0017 (suspend idle sandboxes) accepted that usage metering would blur at the edges "in both directions" because the ee usage-event vocabulary was closed: a sandbox that suspends and later terminates includes all of its parked time in `sandbox_terminated`'s `duration_ms`, overstating sandbox-minutes.

This adds `sandbox_suspended`/`sandbox_resumed` event types and makes the duration roll-up subtract parked intervals, fixing the overstating direction:

- `Conversations.record_sandbox_usage/2` (the choke point every sandbox status write already goes through) now emits `sandbox_suspended` on `ready → suspended` and `sandbox_resumed` on `suspended → ready` — no `sandbox_provisioned` re-emission, matching the existing wake behavior.
- `Billing.usage_summary/3` and `Billing.usage_summaries/2` pair each sandbox's `sandbox_suspended`/`sandbox_resumed` events (by `resource_id`, in timestamp order) and subtract the parked span from that sandbox's `sandbox_terminated` `duration_ms`. A sandbox torn down while still parked (account deletion, tenant reap) has no `sandbox_resumed` — the dangling `sandbox_suspended` is closed against the `sandbox_terminated` event itself instead of left unaccounted for.
- `usage_summaries/2` keeps its one-query-per-refresh shape for `conversations`/`turns`; the parked-interval math runs over a second, separate query scoped to just the three sandbox lifecycle event types (small next to `turn_started` volume), so the "no query per user" property the admin view depends on still holds.
- decisions/0017's "Accepted costs" section is updated to reflect the fix. The other blur direction (a sandbox suspended forever emits no `sandbox_terminated` at all, so its time never enters `sandbox_minutes`) is unchanged and called out as such — that's a structurally different problem than this issue asked for.

## Test plan

- [x] New tests in `ee/test/fountain/usage_metering_test.exs`: `sandbox_suspended`/`sandbox_resumed` emit on the right transitions (ready→suspended, suspended→ready, full park/wake/terminate cycle, and a parked sandbox torn down with no resume).
- [x] New tests in `ee/test/fountain/billing_test.exs`: closed suspend/resume interval subtracted; dangling suspend closed against `sandbox_terminated`; multiple park cycles summed; never goes negative; parked intervals keyed per-sandbox (one sandbox's suspend doesn't bleed into another's minutes); a suspend still parked at period end contributes nothing yet. Mirrored coverage for `usage_summaries/2`'s per-user aggregation.
- [x] `mix test` (full suite, both apps/fountain and ee/test) — 2908 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict` — no issues
- [x] `scripts/sobelow.sh` — clean
