### PR TITLE
fix(buzz): honor the desktop's respond_to policy on a hosted harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ upgrade, is in
   control commands created before it started (block/buzz#6104). The pin moves
   to `buzz-acp-v0.5.14-fountain.3` for both changes.
 
+- **A hosted Buzz agent now honors the desktop's "respond to" policy — anyone
+  (or an allowlist) can `@`-mention it, not just its owner.** `buzz-acp` takes
+  its inbound author gate from `BUZZ_ACP_RESPOND_TO` and defaults to
+  `owner-only`; the desktop sets that when it spawns the harness itself, but the
+  Fountain-hosted harness never got it, so every hosted agent silently dropped
+  mentions from anyone but the owner whatever the record said. The
+  `buzz-backend-fountain` provider now forwards the desktop's `respond_to` /
+  `respond_to_allowlist`, `POST /api/buzz/agents` accepts and stores them on the
+  identity, and the launch sets `BUZZ_ACP_RESPOND_TO` (and the allowlist var in
+  `allowlist` mode). A converging deploy that changes a launch-relevant field
+  (the gate, the environment override, relay, display name or agent) now
+  restarts the running harness so it takes effect — previously a re-deploy onto
+  a running harness was a no-op. Rebuild the provider binary to pick this up.
+  (#790)
+
 - **Owner control commands (`!rotate`, `!cancel`, `!shutdown`) now work from
   the Buzz Desktop composer.** The hosted `buzz-acp` required the message body
   to be *exactly* the command, but Desktop renders the `@Name` mention into the

--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -78,6 +78,13 @@ defmodule Fountain.Buzz do
   and becomes the baseline every conversation this identity opens is
   provisioned from instead of the agent's own (#783). Re-provisioning without
   it clears a previously set one: the provider's `deploy` is the whole truth.
+
+  `"respond_to"` and `"respond_to_allowlist"` (optional, #790) are the harness's
+  inbound author gate — one of `owner-only` / `allowlist` / `anyone` / `nobody`
+  and the 64-hex pubkeys admitted in `allowlist` mode. Omitted means
+  `owner-only` with an empty list, again because the deploy is the whole truth;
+  `allowlist` with no pubkeys is `{:error, %Ecto.Changeset{}}` rather than a
+  harness that refuses to start.
   Returns `{:ok, %BuzzIdentity{}}` or `{:error, reason}`.
   """
   def provision_identity(user_id, params, opts \\ []) when is_binary(user_id) do
@@ -105,7 +112,9 @@ defmodule Fountain.Buzz do
          nsec: params["private_key_nsec"],
          auth_tag: params["auth_tag"],
          display_name: params["display_name"],
-         environment_id: presence(params["environment_id"])
+         environment_id: presence(params["environment_id"]),
+         respond_to: presence(params["respond_to"]) || "owner-only",
+         respond_to_allowlist: allowlist(params["respond_to_allowlist"])
        }}
     else
       {:error, {:missing, missing}}
@@ -115,6 +124,22 @@ defmodule Fountain.Buzz do
   defp blank?(v), do: is_nil(v) or v == ""
 
   defp presence(v), do: if(blank?(v), do: nil, else: v)
+
+  # Normalise the allowlist the way buzz-acp does: trim, lowercase, dedupe. A
+  # non-list is left as-is so the changeset reports it instead of a crash.
+  defp allowlist(nil), do: []
+
+  defp allowlist(list) when is_list(list) do
+    list
+    |> Enum.map(fn
+      v when is_binary(v) -> v |> String.trim() |> String.downcase()
+      v -> v
+    end)
+    |> Enum.reject(&blank?/1)
+    |> Enum.uniq()
+  end
+
+  defp allowlist(other), do: other
 
   # Scoped fetch: the environment's secrets materialise in this identity's
   # sandboxes, so a pointer at another tenant's must never be stored.
@@ -165,6 +190,8 @@ defmodule Fountain.Buzz do
       "relay_url" => fields.relay_url,
       "pubkey" => fields.pubkey,
       "display_name" => fields.display_name,
+      "respond_to" => fields.respond_to,
+      "respond_to_allowlist" => fields.respond_to_allowlist,
       "enabled" => true
     }
 
@@ -172,6 +199,22 @@ defmodule Fountain.Buzz do
       %BuzzIdentity{} = existing -> update_identity(existing, attrs, opts)
       nil -> create_identity(attrs, opts)
     end
+  end
+
+  # Every identity field that ends up in the harness env or the ACP child's argv.
+  @launch_fields ~w(agent_id relay_url display_name environment_id respond_to respond_to_allowlist)a
+
+  @doc """
+  Whether a re-provision changed anything the running harness was launched
+  with — the relay, the display name, the agent, the environment override, or
+  the author gate (#790). `harness_launch/2` reads these from the identity row
+  at start, so a change only takes effect on a restart; the controller uses
+  this to decide whether a converging deploy must bounce the harness. Vault
+  secrets are not compared: a rotated key is the owner's `!rotate` to apply.
+  """
+  @spec launch_config_changed?(BuzzIdentity.t(), BuzzIdentity.t()) :: boolean()
+  def launch_config_changed?(%BuzzIdentity{} = before, %BuzzIdentity{} = after_) do
+    Enum.any?(@launch_fields, &(Map.get(before, &1) != Map.get(after_, &1)))
   end
 
   @doc """
@@ -283,9 +326,10 @@ defmodule Fountain.Buzz do
   Mints a `["sprite"]`-scoped API key for the owning user (the resource surface a
   sandbox-adjacent process needs, without key management), decrypts the vault's
   `BUZZ_PRIVATE_KEY` / `BUZZ_AUTH_TAG` / `BUZZ_RELAY_URL` server-side, and lays
-  out the environment: the Buzz identity vars, the `BUZZ_ACP_*` wiring that
-  points the harness's ACP child at `fountain acp --agent … --vault …
-  [--environment …]`, and the
+  out the environment: the Buzz identity vars, the inbound author gate
+  (`BUZZ_ACP_RESPOND_TO` and, in allowlist mode, `BUZZ_ACP_RESPOND_TO_ALLOWLIST`,
+  #790), the `BUZZ_ACP_*` wiring that points the harness's ACP child at
+  `fountain acp --agent … --vault … [--environment …]`, and the
   `FOUNTAIN_*` vars that let that child authenticate back to this instance.
 
   Options:
@@ -367,11 +411,24 @@ defmodule Fountain.Buzz do
 
   # The vault provides BUZZ_PRIVATE_KEY / BUZZ_AUTH_TAG (and may provide
   # BUZZ_RELAY_URL); the identity row is authoritative for the relay, so it wins.
+  # The author gate is the identity's too: without BUZZ_ACP_RESPOND_TO the
+  # harness defaults to owner-only whatever the desktop's record says (#790).
   defp buzz_identity_env(vault_env, %BuzzIdentity{} = identity) do
     vault_env
     |> Map.put("BUZZ_RELAY_URL", identity.relay_url)
     |> maybe_put("BUZZ_ACP_DISPLAY_NAME", identity.display_name)
+    |> Map.put("BUZZ_ACP_RESPOND_TO", identity.respond_to || "owner-only")
+    |> maybe_put_allowlist(identity)
   end
+
+  # buzz-acp warns and ignores the allowlist var outside allowlist mode; only
+  # set it where it means something.
+  defp maybe_put_allowlist(env, %BuzzIdentity{respond_to: "allowlist", respond_to_allowlist: list})
+       when is_list(list) and list != [] do
+    Map.put(env, "BUZZ_ACP_RESPOND_TO_ALLOWLIST", Enum.join(list, ","))
+  end
+
+  defp maybe_put_allowlist(env, _identity), do: env
 
   # Point the harness's ACP child at this Fountain agent + vault (+ environment
   # override, #783), and keep the pool to one (the desktop's 10 is not our

--- a/apps/fountain/lib/fountain/buzz/buzz_identity.ex
+++ b/apps/fountain/lib/fountain/buzz/buzz_identity.ex
@@ -17,6 +17,14 @@ defmodule Fountain.Buzz.BuzzIdentity do
   config can run under N environments — one per identity. Optional; nil means
   the agent's environment, and deleting the environment nilifies rather than
   cascades, because losing an override is not losing the identity.
+
+  It also carries the harness's **inbound author gate** (#790): `respond_to` is
+  one of `buzz-acp`'s `--respond-to` modes and `respond_to_allowlist` the
+  pubkeys admitted in `allowlist` mode. These become `BUZZ_ACP_RESPOND_TO` /
+  `BUZZ_ACP_RESPOND_TO_ALLOWLIST` in the harness env — the same translation the
+  desktop performs when it spawns `buzz-acp` itself. The default is `owner-only`,
+  which is also the harness's own default, so an identity that never set a
+  policy behaves as before.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -31,12 +39,19 @@ defmodule Fountain.Buzz.BuzzIdentity do
 
   @type t :: %__MODULE__{}
 
+  @respond_to_modes ~w(owner-only allowlist anyone nobody)
+
+  @doc "The `buzz-acp` `--respond-to` modes an identity may carry."
+  def respond_to_modes, do: @respond_to_modes
+
   schema "buzz_identities" do
     field :name, :string
     field :relay_url, :string
     field :pubkey, :string
     field :display_name, :string
     field :enabled, :boolean, default: true
+    field :respond_to, :string, default: "owner-only"
+    field :respond_to_allowlist, {:array, :string}, default: []
 
     belongs_to :user, User
     belongs_to :agent, Agent
@@ -52,6 +67,8 @@ defmodule Fountain.Buzz.BuzzIdentity do
     :pubkey,
     :display_name,
     :enabled,
+    :respond_to,
+    :respond_to_allowlist,
     :user_id,
     :agent_id,
     :vault_id,
@@ -65,6 +82,8 @@ defmodule Fountain.Buzz.BuzzIdentity do
     |> validate_length(:name, min: 1, max: 200)
     |> validate_relay_url()
     |> validate_pubkey()
+    |> validate_inclusion(:respond_to, @respond_to_modes)
+    |> validate_respond_to_allowlist()
     |> unique_constraint(:name, name: :buzz_identities_user_id_name_index)
     |> unique_constraint(:pubkey, name: :buzz_identities_user_id_pubkey_index)
     |> foreign_key_constraint(:agent_id)
@@ -81,6 +100,30 @@ defmodule Fountain.Buzz.BuzzIdentity do
         []
       else
         [relay_url: "must be a ws:// or wss:// URL"]
+      end
+    end)
+  end
+
+  # The allowlist is only meaningful in `allowlist` mode, where buzz-acp refuses
+  # to start without at least one entry — catch that here rather than in a
+  # crash loop. Every entry is a 64-hex pubkey, as buzz-acp validates them.
+  defp validate_respond_to_allowlist(changeset) do
+    mode = get_field(changeset, :respond_to)
+    list = get_field(changeset, :respond_to_allowlist) || []
+
+    changeset
+    |> validate_change(:respond_to_allowlist, fn :respond_to_allowlist, entries ->
+      if Enum.all?(entries, &(&1 =~ ~r/\A[0-9a-f]{64}\z/)) do
+        []
+      else
+        [respond_to_allowlist: "every entry must be a 64 lowercase hex pubkey"]
+      end
+    end)
+    |> then(fn cs ->
+      if mode == "allowlist" and list == [] do
+        add_error(cs, :respond_to_allowlist, "must name at least one pubkey in allowlist mode")
+      else
+        cs
       end
     end)
   end

--- a/apps/fountain/lib/fountain/buzz/manager.ex
+++ b/apps/fountain/lib/fountain/buzz/manager.ex
@@ -117,6 +117,35 @@ defmodule Fountain.Buzz.Manager do
     end
   end
 
+  @doc """
+  Bounce the harness for `identity` so a launch resolved from the *current*
+  identity row takes effect — a converging deploy that changed the author gate,
+  the environment override, the relay or the display name (#790). Stops any
+  running harness (its `terminate` revokes the old key), waits for the registry
+  to drop it, then starts afresh. When none was running this is just
+  `start_harness/2`. Returns what `start_harness/2` returns.
+  """
+  @spec restart_harness(BuzzIdentity.t(), keyword()) :: {:ok, pid()} | {:error, term()}
+  def restart_harness(%BuzzIdentity{} = identity, opts \\ []) do
+    :ok = stop_harness(identity.id)
+    await_unregistered(identity.id, 50)
+    start_harness(identity, opts)
+  end
+
+  # `terminate_child` is synchronous, but the registry learns of the exit by
+  # monitor; give it a moment so `start_harness`'s `whereis` does not hand back
+  # the dead pid.
+  defp await_unregistered(_identity_id, 0), do: :ok
+
+  defp await_unregistered(identity_id, tries) do
+    if running?(identity_id) do
+      Process.sleep(20)
+      await_unregistered(identity_id, tries - 1)
+    else
+      :ok
+    end
+  end
+
   defp start_child(%BuzzIdentity{} = identity, opts) do
     child = %{
       id: identity.id,

--- a/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
@@ -47,14 +47,21 @@ defmodule FountainWeb.BuzzAgentController do
     attrs =
       Map.take(
         params,
-        ~w(name relay_url agent_id pubkey private_key_nsec auth_tag display_name environment_id)
+        ~w(name relay_url agent_id pubkey private_key_nsec auth_tag display_name environment_id
+           respond_to respond_to_allowlist)
       )
+
+    # A converging deploy may change what the harness was launched with; the
+    # identity as it was before tells us whether the running one must bounce.
+    before = Buzz.get_identity_by_pubkey(params["pubkey"] || "", user.id)
 
     case Buzz.provision_identity(user.id, attrs, actor: "api") do
       {:ok, %BuzzIdentity{} = identity} ->
         # Best-effort eager start so a provider `deploy` sees it running; the
         # boot sweep also stands enabled identities up, so this is not load-bearing.
-        _ = Manager.start_harness(identity)
+        # When the deploy changed a launch-relevant field (author gate, environment,
+        # relay, name — #790) the harness restarts so the new env takes effect.
+        _ = ensure_harness(before, identity)
 
         conn
         |> put_status(:created)
@@ -69,6 +76,14 @@ defmodule FountainWeb.BuzzAgentController do
       # cannot be used to probe which ids exist.
       {:error, :environment_not_found} ->
         conn |> put_status(:not_found) |> json(%{error: "environment_not_found"})
+
+      # Field errors — an empty allowlist in allowlist mode, a malformed pubkey —
+      # so a provider deploy can say *why* it was refused, not a bare 422.
+      {:error, %Ecto.Changeset{} = changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> put_view(json: FountainWeb.ChangesetJSON)
+        |> render(:error, changeset: changeset)
 
       {:error, _reason} ->
         conn
@@ -101,6 +116,14 @@ defmodule FountainWeb.BuzzAgentController do
     end
   end
 
+  defp ensure_harness(%BuzzIdentity{} = before, %BuzzIdentity{} = identity) do
+    if Buzz.launch_config_changed?(before, identity),
+      do: Manager.restart_harness(identity),
+      else: Manager.start_harness(identity)
+  end
+
+  defp ensure_harness(nil, %BuzzIdentity{} = identity), do: Manager.start_harness(identity)
+
   defp delete_vault(%BuzzIdentity{vault_id: vault_id}, user_id) do
     case Vaults.get_vault(vault_id, user_id) do
       %Vaults.Vault{} = vault -> Vaults.delete_vault(vault, actor: "api")
@@ -118,6 +141,8 @@ defmodule FountainWeb.BuzzAgentController do
       agent_id: i.agent_id,
       vault_id: i.vault_id,
       environment_id: i.environment_id,
+      respond_to: i.respond_to,
+      respond_to_allowlist: i.respond_to_allowlist,
       enabled: i.enabled,
       inserted_at: i.inserted_at,
       updated_at: i.updated_at

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -431,6 +431,16 @@ defmodule FountainWeb.Schemas do
             "Environment this identity's conversations are provisioned from instead of " <>
               "the agent's own; null means the agent's."
         },
+        respond_to: %Schema{
+          type: :string,
+          enum: ~w(owner-only allowlist anyone nobody),
+          description: "The harness's inbound author gate (buzz-acp --respond-to)."
+        },
+        respond_to_allowlist: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "64-hex pubkeys admitted in allowlist mode."
+        },
         enabled: %Schema{type: :boolean},
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
@@ -474,6 +484,23 @@ defmodule FountainWeb.Schemas do
               "owned by the caller (404 otherwise) and, when the agent sets " <>
               "allowed_environment_ids, on that list (checked at conversation start). " <>
               "Omitted on a re-provision clears a previously set one."
+        },
+        respond_to: %Schema{
+          type: :string,
+          enum: ~w(owner-only allowlist anyone nobody),
+          nullable: true,
+          description:
+            "Who may @-mention the agent and fire a turn — buzz-acp's --respond-to mode, " <>
+              "set as BUZZ_ACP_RESPOND_TO on the hosted harness. Omitted means owner-only. " <>
+              "A re-provision that changes it restarts a running harness."
+        },
+        respond_to_allowlist: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          nullable: true,
+          description:
+            "64-hex pubkeys admitted in allowlist mode (BUZZ_ACP_RESPOND_TO_ALLOWLIST). " <>
+              "Required non-empty when respond_to is allowlist; ignored otherwise."
         }
       },
       required: [:name, :relay_url, :agent_id, :pubkey, :private_key_nsec, :auth_tag]

--- a/apps/fountain/priv/repo/migrations/20260817030000_add_respond_to_to_buzz_identities.exs
+++ b/apps/fountain/priv/repo/migrations/20260817030000_add_respond_to_to_buzz_identities.exs
@@ -1,0 +1,18 @@
+defmodule Fountain.Repo.Migrations.AddRespondToToBuzzIdentities do
+  @moduledoc """
+  The inbound author gate a hosted `buzz-acp` runs with (#790): who may
+  @-mention the agent and fire a turn. `respond_to` is one of buzz-acp's
+  `--respond-to` modes (`owner-only`, `allowlist`, `anyone`, `nobody`) and
+  `respond_to_allowlist` the 64-hex pubkeys admitted in `allowlist` mode. The
+  desktop already sends both on every provider deploy; until now the hosted
+  harness silently ran at the `owner-only` default whatever the record said.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:buzz_identities) do
+      add :respond_to, :string, null: false, default: "owner-only"
+      add :respond_to_allowlist, {:array, :string}, null: false, default: []
+    end
+  end
+end

--- a/apps/fountain/test/fountain/buzz/manager_test.exs
+++ b/apps/fountain/test/fountain/buzz/manager_test.exs
@@ -84,6 +84,39 @@ defmodule Fountain.Buzz.ManagerTest do
     assert active_key_count(identity.user_id) == 0
   end
 
+  # #790: a converging deploy that changes the author gate (or any launch field)
+  # must bounce the harness — a running one keeps the env it started with.
+  test "restart_harness bounces a running harness onto a fresh launch", %{fake: fake} do
+    identity = insert_buzz_identity()
+
+    {:ok, old_pid} = Manager.start_harness(identity, launch_opts(fake))
+    [old_key] = active_keys(identity.user_id)
+
+    {:ok, identity} = Fountain.Buzz.update_identity(identity, %{"respond_to" => "anyone"})
+    assert {:ok, new_pid} = Manager.restart_harness(identity, launch_opts(fake))
+
+    assert is_pid(new_pid)
+    assert new_pid != old_pid
+    refute Process.alive?(old_pid)
+    assert Manager.whereis(identity.id) == new_pid
+
+    # The old launch key was revoked by the stop; exactly one fresh key is live.
+    assert [new_key] = active_keys(identity.user_id)
+    assert new_key.id != old_key.id
+
+    Manager.stop_harness(identity.id)
+  end
+
+  test "restart_harness with nothing running is just a start", %{fake: fake} do
+    identity = insert_buzz_identity()
+
+    assert {:ok, pid} = Manager.restart_harness(identity, launch_opts(fake))
+    assert Manager.whereis(identity.id) == pid
+    assert active_key_count(identity.user_id) == 1
+
+    Manager.stop_harness(identity.id)
+  end
+
   test "stop_harness is a no-op when nothing is running" do
     identity = insert_buzz_identity()
     assert Manager.stop_harness(identity.id) == :ok

--- a/apps/fountain/test/fountain/buzz_test.exs
+++ b/apps/fountain/test/fountain/buzz_test.exs
@@ -204,6 +204,54 @@ defmodule Fountain.BuzzTest do
       assert is_nil(again.environment_id)
     end
 
+    # #790: the author gate the desktop sends rides onto the identity, and an
+    # omission means owner-only — the deploy is the whole truth.
+    test "stores the author gate, defaulting to owner-only", %{user: user, params: params} do
+      pk = String.duplicate("b", 64)
+
+      assert {:ok, identity} =
+               Buzz.provision_identity(
+                 user.id,
+                 Map.merge(params, %{
+                   "respond_to" => "allowlist",
+                   "respond_to_allowlist" => [" " <> String.upcase(pk) <> " ", pk, ""]
+                 })
+               )
+
+      assert identity.respond_to == "allowlist"
+      # trimmed, lowercased, deduped
+      assert identity.respond_to_allowlist == [pk]
+
+      assert {:ok, again} = Buzz.provision_identity(user.id, params)
+      assert again.id == identity.id
+      assert again.respond_to == "owner-only"
+      assert again.respond_to_allowlist == []
+    end
+
+    test "allowlist mode with no pubkeys, an unknown mode, or a bad pubkey is refused",
+         %{user: user, params: params} do
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Buzz.provision_identity(user.id, Map.put(params, "respond_to", "allowlist"))
+
+      assert %{respond_to_allowlist: [_]} = errors_on(cs)
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Buzz.provision_identity(user.id, Map.put(params, "respond_to", "everyone"))
+
+      assert %{respond_to: [_]} = errors_on(cs)
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Buzz.provision_identity(
+                 user.id,
+                 Map.merge(params, %{
+                   "respond_to" => "allowlist",
+                   "respond_to_allowlist" => ["npub1notahexkey"]
+                 })
+               )
+
+      assert %{respond_to_allowlist: [_]} = errors_on(cs)
+    end
+
     test "a foreign or unknown environment_id is not stored", %{user: user, params: params} do
       other = insert_verified_user()
       foreign = insert_env(user_id: other.id)
@@ -309,6 +357,52 @@ defmodule Fountain.BuzzTest do
 
       assert Map.new(launch.env)["BUZZ_ACP_AGENT_ARGS"] ==
                "acp,--agent,#{agent.id},--vault,#{vault.id},--environment,#{env.id}"
+    end
+
+    # #790: without BUZZ_ACP_RESPOND_TO the harness runs owner-only whatever the
+    # desktop's record says; the identity's gate must reach the env.
+    test "the author gate is set on the harness env",
+         %{identity: identity} do
+      opts = [buzz_acp_path: "/opt/buzz-acp", base_url: "https://f.example"]
+
+      assert {:ok, launch} = Buzz.harness_launch(identity, opts)
+      env = Map.new(launch.env)
+      assert env["BUZZ_ACP_RESPOND_TO"] == "owner-only"
+      refute Map.has_key?(env, "BUZZ_ACP_RESPOND_TO_ALLOWLIST")
+
+      {:ok, identity} = Buzz.update_identity(identity, %{"respond_to" => "anyone"})
+      assert {:ok, launch} = Buzz.harness_launch(identity, opts)
+      assert Map.new(launch.env)["BUZZ_ACP_RESPOND_TO"] == "anyone"
+
+      a = String.duplicate("a", 64)
+      b = String.duplicate("b", 64)
+
+      {:ok, identity} =
+        Buzz.update_identity(identity, %{
+          "respond_to" => "allowlist",
+          "respond_to_allowlist" => [a, b]
+        })
+
+      assert {:ok, launch} = Buzz.harness_launch(identity, opts)
+      env = Map.new(launch.env)
+      assert env["BUZZ_ACP_RESPOND_TO"] == "allowlist"
+      assert env["BUZZ_ACP_RESPOND_TO_ALLOWLIST"] == "#{a},#{b}"
+    end
+
+    test "launch_config_changed? spots the fields a running harness was launched with",
+         %{identity: identity, user: user} do
+      refute Buzz.launch_config_changed?(identity, identity)
+
+      {:ok, gated} = Buzz.update_identity(identity, %{"respond_to" => "anyone"})
+      assert Buzz.launch_config_changed?(identity, gated)
+
+      env = insert_env(user_id: user.id)
+      {:ok, moved} = Buzz.update_identity(identity, %{"environment_id" => env.id})
+      assert Buzz.launch_config_changed?(identity, moved)
+
+      # A field the harness never reads at launch is not a reason to bounce it.
+      {:ok, disabled} = Buzz.update_identity(identity, %{"enabled" => false})
+      refute Buzz.launch_config_changed?(identity, disabled)
     end
 
     test "the identity's relay_url overrides a BUZZ_RELAY_URL in the vault",

--- a/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
@@ -134,6 +134,55 @@ defmodule FountainWeb.BuzzAgentControllerTest do
     assert Fountain.Buzz.list_identities(agent.user_id) == []
   end
 
+  # #790: the provider passes the desktop's author gate through; it is stored,
+  # echoed, and an omission on re-provision means owner-only.
+  test "POST stores the author gate and echoes it", %{conn: conn, raw_key: raw_key, agent: agent} do
+    pk = String.duplicate("b", 64)
+
+    data =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post(
+        "/api/buzz/agents",
+        Map.merge(params(agent), %{
+          "respond_to" => "allowlist",
+          "respond_to_allowlist" => [pk]
+        })
+      )
+      |> json_response(201)
+      |> Map.fetch!("data")
+
+    assert data["respond_to"] == "allowlist"
+    assert data["respond_to_allowlist"] == [pk]
+
+    again =
+      build_conn()
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", params(agent))
+      |> json_response(201)
+      |> Map.fetch!("data")
+
+    assert again["id"] == data["id"]
+    assert again["respond_to"] == "owner-only"
+    assert again["respond_to_allowlist"] == []
+  end
+
+  test "POST with allowlist mode and no pubkeys is a 422 naming the field", %{
+    conn: conn,
+    raw_key: raw_key,
+    agent: agent
+  } do
+    conn =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", Map.put(params(agent), "respond_to", "allowlist"))
+
+    assert %{"errors" => %{"respond_to_allowlist" => [_]}} = json_response(conn, 422)
+  end
+
   test "missing required fields is a 422", %{conn: conn, raw_key: raw_key, agent: agent} do
     bad = Map.delete(params(agent), "private_key_nsec")
 

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -30,6 +30,7 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
 
   alias Fountain.Accounts.User
   alias Fountain.Agents.Agent
+  alias Fountain.Buzz.BuzzIdentity
   alias Fountain.Conversations.{Conversation, LogEvent, Sandbox, Turn}
   alias Fountain.Environments.Environment
   alias Fountain.Exports.Export
@@ -61,6 +62,8 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.AvatarRequest, "media_type"} => {Images, :valid_media_types},
     {FountainWeb.Schemas.ImageInput, "media_type"} => {Images, :valid_media_types},
     {FountainWeb.Schemas.BillingResponse, "data.status"} => {User, :subscription_statuses},
+    {FountainWeb.Schemas.BuzzIdentity, "respond_to"} => {BuzzIdentity, :respond_to_modes},
+    {FountainWeb.Schemas.BuzzProvisionRequest, "respond_to"} => {BuzzIdentity, :respond_to_modes},
     {FountainWeb.Schemas.Conversation, "status"} => {Conversation, :statuses},
     {FountainWeb.Schemas.Conversation, "source"} => {Conversation, :sources},
     {FountainWeb.Schemas.ConversationTreeNode, "status"} => {Conversation, :statuses},

--- a/cli/internal/backend/backend.go
+++ b/cli/internal/backend/backend.go
@@ -48,6 +48,12 @@ type AgentPayload struct {
 	AuthTag        string `json:"auth_tag"`
 	Provider       string `json:"provider"`
 	Launch         Launch `json:"launch"`
+	// The inbound author gate the desktop projects from the agent record —
+	// buzz-acp's --respond-to mode and its allowlist. Fountain sets these on the
+	// hosted harness; dropping them here left every hosted agent owner-only
+	// whatever the record said (#790).
+	RespondTo          string   `json:"respond_to"`
+	RespondToAllowlist []string `json:"respond_to_allowlist"`
 }
 
 // Launch is the normative launch block; we read only the owner attestation.
@@ -97,6 +103,10 @@ type ProvisionBody struct {
 	// Optional per-identity environment override (#783): the environment this
 	// identity's conversations are provisioned from instead of the agent's own.
 	EnvironmentID string `json:"environment_id,omitempty"`
+	// The harness's inbound author gate (#790). Omitted when the desktop sent
+	// none, so Fountain applies its own owner-only default.
+	RespondTo          string   `json:"respond_to,omitempty"`
+	RespondToAllowlist []string `json:"respond_to_allowlist,omitempty"`
 }
 
 // Info returns the provider descriptor. config_schema is the desktop's settings
@@ -181,6 +191,10 @@ func Deploy(req Request, f Fountain) DeployResponse {
 		AuthTag:        req.Agent.AuthTag,
 		DisplayName:    req.Agent.Name,
 		EnvironmentID:  envID,
+		// Pass the author gate through verbatim; Fountain validates the mode and
+		// the pubkeys and refuses an allowlist with nothing on it.
+		RespondTo:          strings.TrimSpace(req.Agent.RespondTo),
+		RespondToAllowlist: trimmedList(req.Agent.RespondToAllowlist),
 	})
 	if err != nil {
 		return fail(fmt.Sprintf("provisioning failed: %v", err))
@@ -230,6 +244,18 @@ func providerConfig(raw json.RawMessage) (providerConfigFields, error) {
 		return cfg, fmt.Errorf("no Fountain agent configured — set the `agent` field")
 	}
 	return cfg, nil
+}
+
+// trimmedList drops blank entries; nil when nothing remains so the field is
+// omitted from the provision body rather than sent as [].
+func trimmedList(in []string) []string {
+	var out []string
+	for _, v := range in {
+		if v = strings.TrimSpace(v); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func fail(msg string) DeployResponse { return DeployResponse{OK: false, Error: msg} }

--- a/cli/internal/backend/backend_test.go
+++ b/cli/internal/backend/backend_test.go
@@ -121,6 +121,53 @@ func TestDeployPassesTheEnvironmentSelector(t *testing.T) {
 	}
 }
 
+// #790: the desktop's respond_to / respond_to_allowlist ride through to
+// Fountain, which sets them on the hosted harness. Dropping them left every
+// hosted agent owner-only whatever the desktop's record said.
+func TestDeployPassesTheAuthorGate(t *testing.T) {
+	f := &fakeFountain{}
+	req := deployReq(`{"agent":"my-agent"}`)
+	req.Agent.RespondTo = "allowlist"
+	req.Agent.RespondToAllowlist = []string{" " + testPub + " ", ""}
+	resp := Deploy(req, f)
+	if !resp.OK {
+		t.Fatalf("deploy failed: %+v", resp)
+	}
+	if f.gotBody.RespondTo != "allowlist" {
+		t.Fatalf("respond_to = %q, want allowlist", f.gotBody.RespondTo)
+	}
+	if len(f.gotBody.RespondToAllowlist) != 1 || f.gotBody.RespondToAllowlist[0] != testPub {
+		t.Fatalf("respond_to_allowlist = %v, want the trimmed pubkey only", f.gotBody.RespondToAllowlist)
+	}
+
+	// An older desktop that sends neither must not invent a mode: Fountain
+	// applies its own owner-only default, so the fields are omitted.
+	f = &fakeFountain{}
+	resp = Deploy(deployReq(`{"agent":"my-agent"}`), f)
+	if !resp.OK {
+		t.Fatalf("deploy failed: %+v", resp)
+	}
+	b, _ := json.Marshal(f.gotBody)
+	if strings.Contains(string(b), "respond_to") {
+		t.Fatalf("respond_to fields must be omitted when the desktop sent none: %s", b)
+	}
+}
+
+// The wire shape the desktop actually sends: both fields at the top level of
+// "agent", next to the legacy bookkeeping fields, not inside launch.
+func TestRequestDecodesTheAuthorGate(t *testing.T) {
+	raw := `{"op":"deploy","agent":{"name":"philo","relay_url":"wss://r","private_key_nsec":"x",` +
+		`"auth_tag":"t","respond_to":"anyone","respond_to_allowlist":["` + testPub + `"],` +
+		`"launch":{"owner_pubkey":"o"}},"provider_config":{"agent":"a"}}`
+	var req Request
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.Agent.RespondTo != "anyone" || len(req.Agent.RespondToAllowlist) != 1 {
+		t.Fatalf("author gate not decoded: %+v", req.Agent)
+	}
+}
+
 func TestDeployRefusesAnUnknownEnvironment(t *testing.T) {
 	f := &fakeFountain{resolveTo: "agent-uuid", resolveEnvErr: errNoEnv}
 	resp := Deploy(deployReq(`{"agent":"my-agent","environment":"nope"}`), f)

--- a/docs/integrations/buzz.md
+++ b/docs/integrations/buzz.md
@@ -109,7 +109,9 @@ curl -X POST https://fountain.example.com/api/buzz/agents \
     "relay_url": "wss://relay.example.com",
     "pubkey": "<64-hex nostr pubkey>",
     "private_key_nsec": "nsec1…",
-    "auth_tag": "<owner attestation>"
+    "auth_tag": "<owner attestation>",
+    "respond_to": "anyone",
+    "respond_to_allowlist": []
   }'
 ```
 
@@ -124,6 +126,20 @@ curl -X POST https://fountain.example.com/api/buzz/agents \
 - `environment_id` is optional and must be yours (404 otherwise); it is the
   environment the identity's conversations are provisioned from instead of the
   agent's own, and re-provisioning without it clears it.
+- `respond_to` / `respond_to_allowlist` are the harness's **inbound author
+  gate** — who may `@`-mention the agent and fire a turn. `respond_to` is one of
+  `buzz-acp`'s modes (`owner-only`, `allowlist`, `anyone`, `nobody`) and the
+  allowlist the 64-hex pubkeys admitted in `allowlist` mode (required non-empty
+  there). Omitted means `owner-only`. Fountain sets these on the hosted harness
+  as `BUZZ_ACP_RESPOND_TO` / `BUZZ_ACP_RESPOND_TO_ALLOWLIST` — the same
+  translation the Buzz desktop performs for a harness it spawns itself, so the
+  policy the desktop shows on the agent record is the one the hosted harness
+  runs. Note that inside a DM the harness admits only the owner and same-owner
+  siblings whatever the mode; that is `buzz-acp`'s rule, not Fountain's.
+- A re-provision that changes anything the harness was launched with — the
+  author gate, the environment override, the relay URL, the display name or the
+  agent — **restarts the running harness** so the new launch takes effect. A
+  re-provision that changes nothing leaves it running.
 - The relay URL must be `ws://` or `wss://`, and the pubkey 64 lowercase hex — a
   common `https://` paste is rejected up front.
 
@@ -240,6 +256,10 @@ as `buzz.published` — the tool and channel, never the message content.
   unique per `(user, name)` and per `(user, pubkey)`; convergence is by pubkey.
 - **Publishes are audited, not policy-gated.** The trail records that a publish
   happened; there is no per-publish approval or allow/deny gate in this path.
+- **Who may talk to it is the desktop's call.** The provider forwards the
+  agent record's `respond_to` policy on every deploy; change it on the desktop
+  and re-deploy, and the hosted harness restarts with the new gate. There is no
+  Fountain-side override.
 - **Permission prompts are auto-answered.** The harness answers a runtime
   permission request with "allow once" — Buzz is not a human approval surface.
 - **The runtime is the Fountain agent's.** A Buzz agent runs whatever runtime


### PR DESCRIPTION
Closes #790.

## Problem

A Buzz agent hosted on Fountain whose desktop record says **respond to: anyone** still ignores every `@`-mention from anyone but its owner. `buzz-acp` reads its inbound author gate from `BUZZ_ACP_RESPOND_TO` (default `owner-only`); the desktop sets that when it spawns the harness itself, but the Fountain-hosted harness never got it. The desktop already sends `respond_to` / `respond_to_allowlist` at the top level of every provider deploy payload — the provider dropped them on decode, the API didn't accept them, and the launch never emitted the var.

## Change

- **Provider** (`cli/internal/backend`): `AgentPayload` decodes both fields; `ProvisionBody` forwards them (`omitempty`, so an older desktop that sends neither leaves Fountain's default in force).
- **API / schema**: `POST /api/buzz/agents` accepts and stores `respond_to` (one of `owner-only|allowlist|anyone|nobody`, default `owner-only`) and `respond_to_allowlist` (trimmed, lowercased, deduped 64-hex pubkeys). `allowlist` with no pubkeys is a field-level 422 (via `ChangesetJSON`) rather than a harness that refuses to start. Migration adds the two columns with server defaults. Echoed in identity JSON; OpenAPI enums registered in the enum guardrail as derived from `BuzzIdentity.respond_to_modes/0`.
- **Launch env**: `harness_launch/2` sets `BUZZ_ACP_RESPOND_TO` always and `BUZZ_ACP_RESPOND_TO_ALLOWLIST` in allowlist mode.
- **Restart on change**: `Buzz.launch_config_changed?/2` + `Manager.restart_harness/2`. A converging deploy that changes a launch-relevant field (gate, environment override, relay, display name, agent) bounces the running harness; an unchanged re-deploy leaves it alone. This also fixes the pre-existing gap where re-deploying with a new `environment_id` (#783) was a no-op on a running harness.
- Docs (`docs/integrations/buzz.md`) + CHANGELOG.

## Tests

- Go: author gate passes through, blank entries trimmed, fields omitted when unset, wire shape decodes.
- Elixir: provision stores/defaults/normalises; refusals for empty allowlist / unknown mode / bad pubkey; env carries the gate; `launch_config_changed?`; `restart_harness` bounces onto a fresh pid + key; controller stores/echoes and 422s. Full suite green locally (2904 tests), `mix precommit` checks pass.

## Rollout

Server: auto-deploys on merge (build → publish-manifests → Flux). The provider binary on each desktop must be rebuilt (`go build ./cmd/buzz-backend-fountain`) and the agent re-deployed from the desktop once for the policy to reach the hosted harness.