### PR TITLE
chore(buzz-acp): repin to fountain.4 — publish the kind:10100 directory entry (block/buzz#6097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ upgrade, is in
 
 ### Fixed
 
+- **A hosted Buzz agent now shows up in other people's `@`-mention
+  autocomplete.** Buzz Desktop admits a non-owned agent to autocomplete only if
+  the relay carries a kind:10100 directory entry for it saying which channels
+  it listens in and whom it answers — and nothing published one, so even with
+  `respond_to: anyone` a hosted agent was mentionable by its owner alone (the
+  owner's desktop knows it locally). The pin moves to
+  `buzz-acp-v0.5.14-fountain.4`, carrying block/buzz#6097: the harness
+  publishes that entry at startup and again on every membership change, from
+  the channels it actually subscribes to and its real author gate. Fountain's
+  `BUZZ_ACP_DISPLAY_NAME` becomes the advertised name. #776 now waits on #6097
+  too. (#790)
+
 - **`!shutdown` no longer restart-loops a hosted harness.** The supervisor
   restarts `buzz-acp` on any exit and the fresh process replayed the same
   `!shutdown` from its subscription backlog — five exits per command before

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-amd64}" \
 
 FROM debian:trixie-slim AS buzzacp
 ARG TARGETARCH
-ARG BUZZ_ACP_VERSION=0.5.14-fountain.3
+ARG BUZZ_ACP_VERSION=0.5.14-fountain.4
 # buzz-acp: the hosted harness (gate 2). buzz: the CLI the server-side MCP tools
 # shell out to for signed publishes (gate 3, #737). Both from our own release.
 RUN apt-get update -y \

--- a/buzz-acp.source
+++ b/buzz-acp.source
@@ -1,2 +1,2 @@
 # Fork pin — see #776 for when and how to remove. Format: owner/repo@ref
-jhgaylor/buzz@f98c2a7f2d0882d632d0f03a67e2cb687101ccd4
+jhgaylor/buzz@5bbad010f234ac71533f1afd120f44b75d9117dd

--- a/buzz-acp.version
+++ b/buzz-acp.version
@@ -1,1 +1,1 @@
-0.5.14-fountain.3
+0.5.14-fountain.4


### PR DESCRIPTION
Follow-up to #791 / #790.

## Problem

After #791 the hosted harness runs with the desktop's `respond_to` policy, but a second account still doesn't see the agent in `@`-mention autocomplete. Buzz Desktop (and mobile) admit a **non-owned** agent to autocomplete only if the relay carries a **kind:10100 agent-directory entry** for it whose `channel_ids` include the current channel and whose `respond_to` admits the viewer (`agentAutocompleteEligibility.ts`). Nothing in block/buzz publishes that entry today (upstream issues #3809/#3971/#5363), so a hosted agent is mentionable by its owner alone — the owner's desktop knows it as a *managed* agent and skips the directory check.

## Change

- Fork branch `jhgaylor/buzz@fountain-pin` now carries block/buzz#6097 (cherry-picked as `5bbad010f`): `buzz-acp` publishes the kind:10100 entry at startup and republishes on membership changes, from the channels it actually subscribes to plus its real author gate (allowlist only in allowlist mode). `BUZZ_ACP_DISPLAY_NAME` — which Fountain already sets — becomes the advertised name. Opt-out: `BUZZ_ACP_NO_PUBLISH_DIRECTORY`.
- `buzz-acp.source` → `jhgaylor/buzz@5bbad010f`, `buzz-acp.version` → `0.5.14-fountain.4`, Dockerfile default ARG, CHANGELOG. #776's repin condition gains #6097.

Verified on the fork: `cargo test -p buzz-acp` 797 passed, clippy `-D warnings` clean, fmt clean.

## Rollout

- [ ] `Publish buzz-acp` → release `buzz-acp-v0.5.14-fountain.4` (both arches) — dispatched from this branch before merge so the image build finds it
- [ ] merge → CI → `build` → Flux
- [ ] Prod: hosted harnesses restart on deploy and publish their entries; a second account sees `@TV Guide` in `#eras`