### PR TITLE
feat(buzz): set who may @-mention a hosted agent after deploy — PATCH /api/buzz/agents/:id + fountain buzz agents set-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ upgrade, is in
 
 ### Added
 
+- **`fountain buzz agents set-access` / `PATCH /api/buzz/agents/:id`.** Change
+  who may `@`-mention a hosted Buzz agent (`--respond-to owner-only | allowlist
+  | anyone | nobody`, `--allowlist <hex,…>`) after it is deployed; the harness
+  restarts with the new gate. The Buzz desktop refuses to change access on a
+  provider agent it has already deployed, so without this the only way to open
+  an agent up was a re-create under a new key. `fountain buzz agents list`
+  shows the current gate per agent. A later desktop deploy still sends the
+  desktop's record as the whole truth. (#790)
+
 - **`!rotate` from a Buzz channel opens a new conversation.** The channel-bound
   resume (#774) meant a rotated harness's next `session/new` landed straight
   back on the same conversation, so rotation did nothing on a hosted agent.

--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -277,6 +277,41 @@ defmodule Fountain.Buzz do
     |> audited("buzz_identity.updated", opts)
   end
 
+  @doc """
+  Change an identity's inbound author gate without a full re-provision (#790):
+  `params` (string-keyed) may carry `"respond_to"` and `"respond_to_allowlist"`,
+  validated and normalised exactly as `provision_identity/3` does. Nothing else
+  on the identity changes. Records `buzz_identity.updated`. The caller restarts
+  the harness (`Fountain.Buzz.Manager.restart_harness/2`) when
+  `launch_config_changed?/2` says so — this function only persists.
+
+  This is the operator's knob for the desktop's `respond_to` when the desktop
+  cannot resend it (it refuses to change access on an already-deployed
+  provider agent). Note a later provider deploy sends the desktop's record as
+  the whole truth and will overwrite what is set here.
+  """
+  def update_access(%BuzzIdentity{} = identity, params, opts \\ []) when is_map(params) do
+    attrs =
+      %{}
+      |> maybe_attr("respond_to", presence(params["respond_to"]))
+      |> maybe_attr(
+        "respond_to_allowlist",
+        if(Map.has_key?(params, "respond_to_allowlist"),
+          do: allowlist(params["respond_to_allowlist"]),
+          else: nil
+        )
+      )
+
+    if attrs == %{} do
+      {:error, :nothing_to_update}
+    else
+      update_identity(identity, attrs, opts)
+    end
+  end
+
+  defp maybe_attr(attrs, _key, nil), do: attrs
+  defp maybe_attr(attrs, key, value), do: Map.put(attrs, key, value)
+
   @doc "Delete a Buzz identity. Records `buzz_identity.deleted`."
   def delete_identity(%BuzzIdentity{} = identity, opts \\ []) do
     identity

--- a/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
@@ -92,6 +92,49 @@ defmodule FountainWeb.BuzzAgentController do
     end
   end
 
+  operation(:update,
+    summary: "Change who may talk to a hosted Buzz agent",
+    parameters: [id: [in: :path, type: :string, description: "Buzz agent id"]],
+    request_body: {"Access attributes", "application/json", Schemas.BuzzAccessUpdateRequest},
+    responses: [
+      ok: {"Buzz agent", "application/json", Schemas.BuzzIdentityResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
+    ]
+  )
+
+  # The operator's knob for the inbound author gate (#790): sets `respond_to`
+  # / `respond_to_allowlist` on the identity and restarts its harness so the
+  # new gate is live. Exists because the desktop refuses to change access on a
+  # provider agent it has already deployed, so the record's policy cannot be
+  # resent from there.
+  def update(conn, %{"id" => id} = params) do
+    user = conn.assigns.current_user
+
+    with %BuzzIdentity{} = identity <- Buzz.get_identity(id, user.id),
+         {:ok, %BuzzIdentity{} = updated} <-
+           Buzz.update_access(identity, Map.take(params, ~w(respond_to respond_to_allowlist)),
+             actor: "api"
+           ) do
+      if Buzz.launch_config_changed?(identity, updated), do: Manager.restart_harness(updated)
+      json(conn, %{data: identity_json(updated)})
+    else
+      nil ->
+        conn |> put_status(:not_found) |> json(%{error: "not found"})
+
+      {:error, :nothing_to_update} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "nothing to update: send respond_to and/or respond_to_allowlist"})
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> put_view(json: FountainWeb.ChangesetJSON)
+        |> render(:error, changeset: changeset)
+    end
+  end
+
   operation(:delete,
     summary: "Tear down a hosted Buzz agent",
     parameters: [id: [in: :path, type: :string, description: "Buzz agent id"]],

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -302,7 +302,7 @@ defmodule FountainWeb.Router do
 
     # Hosted Buzz agents (ADR 0020, #738). `create` is the Fountain side of a
     # remote-agents provider deploy — idempotent on the Nostr pubkey.
-    resources "/buzz/agents", BuzzAgentController, only: [:index, :create, :delete]
+    resources "/buzz/agents", BuzzAgentController, only: [:index, :create, :update, :delete]
 
     # Bulk apply for compiled fountain.yml manifests (`fountain apply`).
     post "/apply", ApplyController, :create

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -507,6 +507,34 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule BuzzAccessUpdateRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "BuzzAccessUpdateRequest",
+      description:
+        "Change who may @-mention a hosted Buzz agent. Sets buzz-acp's inbound author " <>
+          "gate on the identity and restarts its harness. At least one field is required. " <>
+          "A later provider deploy from the desktop resends the desktop's record and " <>
+          "overwrites this.",
+      type: :object,
+      properties: %{
+        respond_to: %Schema{
+          type: :string,
+          enum: ~w(owner-only allowlist anyone nobody),
+          nullable: true
+        },
+        respond_to_allowlist: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          nullable: true,
+          description: "64-hex pubkeys; required non-empty when respond_to is allowlist."
+        }
+      }
+    })
+  end
+
   item_response(BuzzIdentityResponse, of: BuzzIdentity)
 
   list_response(BuzzIdentityListResponse, of: BuzzIdentity)

--- a/apps/fountain/test/fountain/buzz_test.exs
+++ b/apps/fountain/test/fountain/buzz_test.exs
@@ -252,6 +252,35 @@ defmodule Fountain.BuzzTest do
       assert %{respond_to_allowlist: [_]} = errors_on(cs)
     end
 
+    test "update_access changes only the gate, and refuses an empty or invalid change",
+         %{user: user, params: params} do
+      {:ok, identity} = Buzz.provision_identity(user.id, params)
+      pk = String.duplicate("c", 64)
+
+      assert {:ok, updated} =
+               Buzz.update_access(identity, %{
+                 "respond_to" => "allowlist",
+                 "respond_to_allowlist" => [String.upcase(pk)]
+               })
+
+      assert updated.respond_to == "allowlist"
+      assert updated.respond_to_allowlist == [pk]
+      assert updated.name == identity.name
+      assert updated.environment_id == identity.environment_id
+
+      # Only the fields sent change: mode alone keeps the list.
+      assert {:ok, again} = Buzz.update_access(updated, %{"respond_to" => "anyone"})
+      assert again.respond_to_allowlist == [pk]
+
+      assert {:error, :nothing_to_update} = Buzz.update_access(again, %{})
+
+      assert {:error, %Ecto.Changeset{}} =
+               Buzz.update_access(again, %{
+                 "respond_to" => "allowlist",
+                 "respond_to_allowlist" => []
+               })
+    end
+
     test "a foreign or unknown environment_id is not stored", %{user: user, params: params} do
       other = insert_verified_user()
       foreign = insert_env(user_id: other.id)

--- a/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
@@ -183,6 +183,55 @@ defmodule FountainWeb.BuzzAgentControllerTest do
     assert %{"errors" => %{"respond_to_allowlist" => [_]}} = json_response(conn, 422)
   end
 
+  # #790: the operator's knob when the desktop cannot resend the policy.
+  test "PATCH changes the author gate and echoes it; foreign ids are 404", %{
+    conn: conn,
+    raw_key: raw_key,
+    agent: agent
+  } do
+    id =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", params(agent))
+      |> json_response(201)
+      |> get_in(["data", "id"])
+
+    data =
+      build_conn()
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> patch("/api/buzz/agents/#{id}", %{"respond_to" => "anyone"})
+      |> json_response(200)
+      |> Map.fetch!("data")
+
+    assert data["id"] == id
+    assert data["respond_to"] == "anyone"
+
+    assert %{"error" => _} =
+             build_conn()
+             |> authed_with_key(raw_key)
+             |> put_req_header("content-type", "application/json")
+             |> patch("/api/buzz/agents/#{id}", %{})
+             |> json_response(422)
+
+    assert %{"errors" => %{"respond_to_allowlist" => [_]}} =
+             build_conn()
+             |> authed_with_key(raw_key)
+             |> put_req_header("content-type", "application/json")
+             |> patch("/api/buzz/agents/#{id}", %{"respond_to" => "allowlist"})
+             |> json_response(422)
+
+    other = insert_verified_user()
+    {_rec, other_key} = insert_api_key(other)
+
+    assert build_conn()
+           |> authed_with_key(other_key)
+           |> put_req_header("content-type", "application/json")
+           |> patch("/api/buzz/agents/#{id}", %{"respond_to" => "anyone"})
+           |> json_response(404)
+  end
+
   test "missing required fields is a 422", %{conn: conn, raw_key: raw_key, agent: agent} do
     bad = Map.delete(params(agent), "private_key_nsec")
 

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -64,6 +64,8 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.BillingResponse, "data.status"} => {User, :subscription_statuses},
     {FountainWeb.Schemas.BuzzIdentity, "respond_to"} => {BuzzIdentity, :respond_to_modes},
     {FountainWeb.Schemas.BuzzProvisionRequest, "respond_to"} => {BuzzIdentity, :respond_to_modes},
+    {FountainWeb.Schemas.BuzzAccessUpdateRequest, "respond_to"} =>
+      {BuzzIdentity, :respond_to_modes},
     {FountainWeb.Schemas.Conversation, "status"} => {Conversation, :statuses},
     {FountainWeb.Schemas.Conversation, "source"} => {Conversation, :sources},
     {FountainWeb.Schemas.ConversationTreeNode, "status"} => {Conversation, :statuses},

--- a/cli/internal/api/api.go
+++ b/cli/internal/api/api.go
@@ -125,6 +125,11 @@ func (c *Client) Put(path string, body, out any) error {
 	return c.do(http.MethodPut, path, body, out)
 }
 
+// Patch performs PATCH /api<path> with a JSON body.
+func (c *Client) Patch(path string, body, out any) error {
+	return c.do(http.MethodPatch, path, body, out)
+}
+
 // Delete performs DELETE /api<path>.
 func (c *Client) Delete(path string, out any) error {
 	return c.do(http.MethodDelete, path, nil, out)

--- a/cli/internal/cmd/buzz.go
+++ b/cli/internal/cmd/buzz.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/api"
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// buzzRespondToModes are buzz-acp's --respond-to modes, as the server's
+// BuzzIdentity.respond_to_modes/0 accepts them.
+var buzzRespondToModes = []string{"owner-only", "allowlist", "anyone", "nobody"}
+
+func init() {
+	buzzCmd := &cobra.Command{
+		Use:   "buzz",
+		Short: "Hosted Buzz agents (docs/integrations/buzz.md)",
+	}
+	agentsCmd := &cobra.Command{
+		Use:   "agents",
+		Short: "Manage hosted Buzz agents",
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List hosted Buzz agents",
+		RunE:  func(cmd *cobra.Command, args []string) error { return buzzAgentsList(cmd) },
+	}
+	listCmd.Flags().Bool("json", false, "output JSON")
+
+	// The operator's knob for who may @-mention a hosted agent (#790). The
+	// desktop cannot resend its respond_to for a provider agent it has already
+	// deployed, so this is how the policy changes after the fact.
+	setAccessCmd := &cobra.Command{
+		Use:   "set-access <name-or-id>",
+		Short: "Change who may @-mention a hosted Buzz agent (restarts its harness)",
+		Long: `Set buzz-acp's inbound author gate on a hosted Buzz agent and restart its
+harness so it takes effect.
+
+  --respond-to  owner-only | allowlist | anyone | nobody
+  --allowlist   comma-separated 64-hex pubkeys (allowlist mode; required non-empty there)
+
+Note: a later provider deploy from the Buzz desktop resends the desktop's own
+record for the agent and overwrites what is set here.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error { return buzzAgentsSetAccess(cmd, args[0]) },
+	}
+	setAccessCmd.Flags().String("respond-to", "", "owner-only | allowlist | anyone | nobody")
+	setAccessCmd.Flags().String("allowlist", "", "comma-separated 64-hex pubkeys admitted in allowlist mode")
+
+	agentsCmd.AddCommand(listCmd, setAccessCmd)
+	buzzCmd.AddCommand(agentsCmd)
+	rootCmd.AddCommand(buzzCmd)
+}
+
+func buzzAgentsList(cmd *cobra.Command) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/buzz/agents", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	if jsonOut {
+		return output.PrintJSON(resp.Data)
+	}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, a := range resp.Data {
+		rows = append(rows, []string{
+			output.ToString(a["name"]),
+			output.ShortID(output.ToString(a["id"])),
+			buzzAccessLabel(a),
+			output.Truncate(output.ToString(a["pubkey"]), 16),
+			output.ToString(a["enabled"]),
+		})
+	}
+	output.Table([]string{"name", "id", "respond_to", "pubkey", "enabled"}, rows)
+	return nil
+}
+
+// buzzAccessLabel renders the gate the way an operator thinks about it:
+// "allowlist(2)" rather than a bare mode next to a separate column.
+func buzzAccessLabel(a map[string]any) string {
+	mode := output.ToString(a["respond_to"])
+	if mode != "allowlist" {
+		return mode
+	}
+	n := 0
+	if list, ok := a["respond_to_allowlist"].([]any); ok {
+		n = len(list)
+	}
+	return fmt.Sprintf("allowlist(%d)", n)
+}
+
+// buzzAccessBody validates the flags client-side so a typo is a usage error
+// here rather than a 422 there, and builds the PATCH body. Only flags that
+// were set are sent: mode alone keeps the server's allowlist.
+func buzzAccessBody(respondTo, allowlist string, allowlistSet bool) (map[string]any, error) {
+	body := map[string]any{}
+	if respondTo != "" {
+		ok := false
+		for _, m := range buzzRespondToModes {
+			if m == respondTo {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return nil, fmt.Errorf("--respond-to must be one of %s", strings.Join(buzzRespondToModes, ", "))
+		}
+		body["respond_to"] = respondTo
+	}
+	if allowlistSet {
+		var pks []string
+		for _, pk := range strings.Split(allowlist, ",") {
+			if pk = strings.TrimSpace(pk); pk != "" {
+				pks = append(pks, pk)
+			}
+		}
+		if pks == nil {
+			pks = []string{}
+		}
+		body["respond_to_allowlist"] = pks
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("nothing to change: pass --respond-to and/or --allowlist")
+	}
+	return body, nil
+}
+
+func buzzAgentsSetAccess(cmd *cobra.Command, target string) error {
+	respondTo, _ := cmd.Flags().GetString("respond-to")
+	allowlist, _ := cmd.Flags().GetString("allowlist")
+	body, err := buzzAccessBody(respondTo, allowlist, cmd.Flags().Changed("allowlist"))
+	if err != nil {
+		Fatal(err.Error())
+	}
+	c := activeClient()
+	id := resolveBuzzAgentID(target)
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := c.Patch("/buzz/agents/"+id, body, &resp); err != nil {
+		if api.StatusCode(err) == 404 {
+			Fatal("not found")
+		}
+		Fatal(err.Error())
+	}
+	fmt.Printf("buzz agent  ~  %s  respond_to=%s\n", output.ToString(resp.Data["name"]), buzzAccessLabel(resp.Data))
+	return nil
+}
+
+func resolveBuzzAgentID(target string) string {
+	if isUUID(target) {
+		return target
+	}
+	c := activeClient()
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get("/buzz/agents", &resp); err != nil {
+		Fatal(err.Error())
+	}
+	for _, a := range resp.Data {
+		if output.ToString(a["name"]) == target || output.ToString(a["display_name"]) == target {
+			return output.ToString(a["id"])
+		}
+	}
+	Fatalf("no hosted Buzz agent named %q", target)
+	return ""
+}

--- a/cli/internal/cmd/buzz_test.go
+++ b/cli/internal/cmd/buzz_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import "testing"
+
+func TestBuzzAccessBody(t *testing.T) {
+	body, err := buzzAccessBody("anyone", "", false)
+	if err != nil || body["respond_to"] != "anyone" {
+		t.Fatalf("mode alone: %v %v", body, err)
+	}
+	if _, has := body["respond_to_allowlist"]; has {
+		t.Fatalf("an unset --allowlist must not be sent (it would clear the server's list): %v", body)
+	}
+
+	body, err = buzzAccessBody("allowlist", " aa , bb,, ", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := body["respond_to_allowlist"].([]string); len(got) != 2 || got[0] != "aa" || got[1] != "bb" {
+		t.Fatalf("allowlist not split/trimmed: %v", got)
+	}
+
+	// An explicit empty --allowlist sends [] so the server can clear it (or
+	// refuse it in allowlist mode) — that is a decision, not an omission.
+	body, _ = buzzAccessBody("", "", true)
+	if got := body["respond_to_allowlist"].([]string); len(got) != 0 {
+		t.Fatalf("empty --allowlist must send []: %v", got)
+	}
+
+	if _, err := buzzAccessBody("everyone", "", false); err == nil {
+		t.Fatal("an unknown mode must be a usage error, not a 422")
+	}
+	if _, err := buzzAccessBody("", "", false); err == nil {
+		t.Fatal("no flags must be a usage error")
+	}
+}
+
+func TestBuzzAccessLabel(t *testing.T) {
+	if got := buzzAccessLabel(map[string]any{"respond_to": "anyone"}); got != "anyone" {
+		t.Fatal(got)
+	}
+	if got := buzzAccessLabel(map[string]any{"respond_to": "allowlist", "respond_to_allowlist": []any{"a", "b"}}); got != "allowlist(2)" {
+		t.Fatal(got)
+	}
+}

--- a/cli/internal/cmd/docs_test.go
+++ b/cli/internal/cmd/docs_test.go
@@ -42,7 +42,7 @@ func TestNoDocumentedCommandIsInvented(t *testing.T) {
 		real["fountain "+strings.Join(path, " ")] = true
 	})
 	// Group commands are legitimate to mention on their own.
-	for _, g := range []string{"agent", "auth", "conv", "env", "keys", "vault"} {
+	for _, g := range []string{"agent", "auth", "conv", "env", "keys", "vault", "buzz", "buzz agents"} {
 		real["fountain "+g] = true
 	}
 
@@ -71,8 +71,12 @@ func TestNoDocumentedCommandIsInvented(t *testing.T) {
 			continue
 		}
 
-		// Longest match first: `fountain vault set-secret` before `fountain vault`.
+		// Longest match first: `fountain buzz agents list` before
+		// `fountain vault set-secret` before `fountain vault`.
 		var candidates []string
+		if len(fields) >= 4 && isCommandWord(fields[2]) && isCommandWord(fields[3]) {
+			candidates = append(candidates, strings.Join(fields[:4], " "))
+		}
 		if len(fields) >= 3 && isCommandWord(fields[2]) {
 			candidates = append(candidates, strings.Join(fields[:3], " "))
 		}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,6 +74,25 @@ fountain vault set-secret <id-or-name> <key> <value>
 fountain vault delete-secret <id-or-name> <key>
 ```
 
+## Hosted Buzz agents
+
+The one knob a hosted [Buzz](integrations/buzz.md) agent needs after it is
+deployed: who may `@`-mention it. The Buzz desktop refuses to change access on
+a provider agent it has already deployed, so this is where the policy changes.
+Setting it restarts the agent's harness so the new gate is live.
+
+```bash
+fountain buzz agents list [--json]
+fountain buzz agents set-access <name-or-id> --respond-to anyone
+fountain buzz agents set-access <name-or-id> --respond-to allowlist --allowlist <hex>,<hex>
+fountain buzz agents set-access <name-or-id> --respond-to owner-only
+```
+
+`--respond-to` is one of `owner-only`, `allowlist`, `anyone`, `nobody`
+(`buzz-acp`'s own modes). Only the flags you pass change; `--respond-to` alone
+keeps the stored allowlist. Note that a later provider deploy from the desktop
+resends the desktop's own record and overwrites what is set here.
+
 ## Conversations
 
 ```bash

--- a/docs/integrations/buzz.md
+++ b/docs/integrations/buzz.md
@@ -136,6 +136,11 @@ curl -X POST https://fountain.example.com/api/buzz/agents \
   policy the desktop shows on the agent record is the one the hosted harness
   runs. Note that inside a DM the harness admits only the owner and same-owner
   siblings whatever the mode; that is `buzz-acp`'s rule, not Fountain's.
+- After the fact, `PATCH /api/buzz/agents/:id` with `respond_to` /
+  `respond_to_allowlist` — or `fountain buzz agents set-access <name> --respond-to
+  anyone` — changes the gate and restarts the harness. That is the knob to use
+  once the desktop has deployed the agent: it refuses to change access on a
+  provider agent it already deployed. A later desktop deploy overwrites it.
 - A re-provision that changes anything the harness was launched with — the
   author gate, the environment override, the relay URL, the display name or the
   agent — **restarts the running harness** so the new launch takes effect. A


### PR DESCRIPTION
Follow-up to #791/#792 (#790).

## Why

Once the desktop has deployed a Buzz agent to Fountain, its access policy is frozen: the desktop refuses to change `respond_to` on a provider agent it already deployed (`agent_models_update.rs`: "Stop or recreate the provider agent first") and never clears the deploy marker, so the only way to open an agent up was to re-create it under a new key. We need a repeatable operator path — "let everyone talk to Fountain Maintainer" today, other agents tomorrow.

## Change

- **`Buzz.update_access/3`** — sets `respond_to` / `respond_to_allowlist` only (same validation/normalisation as provision); `{:error, :nothing_to_update}` on an empty change.
- **`PATCH /api/buzz/agents/:id`** — tenant-scoped; restarts the harness via `Manager.restart_harness/2` when the launch config changed; field errors via `ChangesetJSON`; foreign/unknown id → 404. OpenAPI `BuzzAccessUpdateRequest` (enum registered in the guardrail).
- **CLI** — `fountain buzz agents list` and `fountain buzz agents set-access <name|id> --respond-to <mode> [--allowlist a,b]`. Client-side mode validation; only flags you pass are sent (mode alone keeps the stored allowlist; explicit empty `--allowlist` sends `[]`). `api.Client.Patch`. `docs/cli.md`; the docs↔commands invariant test now matches three-level commands.
- Docs (`docs/integrations/buzz.md`) + CHANGELOG. Caveat documented: a later desktop deploy resends the desktop's record and overwrites this.

## Tests

Context (only the gate changes; empty/invalid refused), controller (200/echo, 422 empty, 422 field error, 404 foreign), Go (`buzzAccessBody`, label, docs invariants). Full suite + precommit gates green locally.