### PR TITLE
docs: a fountain acp reference page, and "Operating a hosted agent" on the Buzz page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ upgrade, is in
 
 ### Added
 
+- **Docs: a [`fountain acp` reference](https://binarybourbon.github.io/fountain/integrations/acp/)
+  and an "Operating a hosted agent" section on the Buzz page.** The three ACP
+  clients (editors, OpenClaw, Buzz) now point at one page for the adapter's
+  protocol surface, `_meta` extensions (`channelId`, `freshSession`), what
+  streams back and what is ignored. The Buzz page gains the day-2 material:
+  who may talk to an agent and how to change it, how other people's clients
+  discover it (the kind:10100 entry), what a re-deploy restarts, the owner
+  control commands, where to look, and a symptom table.
+
 - **`fountain buzz agents set-access` / `PATCH /api/buzz/agents/:id`.** Change
   who may `@`-mention a hosted Buzz agent (`--respond-to owner-only | allowlist
   | anyone | nobody`, `--allowlist <hex,…>`) after it is deployed; the harness

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -46,6 +46,7 @@ defmodule Fountain.Docs do
     {"Integrations",
      [
        {"Overview", "integrations/index.md"},
+       {"fountain acp (reference)", "integrations/acp.md"},
        {"Editors (ACP)", "integrations/editors.md"},
        {"OpenClaw (ACP)", "integrations/openclaw.md"},
        {"Buzz (Nostr)", "integrations/buzz.md"},

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -158,7 +158,8 @@ for it, so it is configured on the command line, one editor entry per agent.
 Credentials are the ones `fountain auth login` already saved, and `--profile`
 selects the instance.
 
-**[Editors (ACP)](integrations/editors.md)** has the setup, the editor config
+**[`fountain acp` (reference)](integrations/acp.md)** documents the protocol
+surface and flags in full; **[Editors (ACP)](integrations/editors.md)** has the setup, the editor config
 snippets, and the limits worth knowing before you start — chief among them that
 the agent works on a sandbox's files, not the ones open in your editor.
 

--- a/docs/integrations/acp.md
+++ b/docs/integrations/acp.md
@@ -1,0 +1,146 @@
+# `fountain acp` — the ACP agent reference
+
+`fountain acp` is the one process every ACP client of Fountain spawns:
+[editors](editors.md) (Zed and friends), [OpenClaw](openclaw.md), and the
+[Buzz](buzz.md) harness all speak the
+[Agent Client Protocol](https://agentclientprotocol.com) to it over stdio, and
+it drives a conversation running in a Fountain sandbox. Those three pages cover
+*setting up the client*; this page is the reference for the adapter itself —
+what it accepts, what it does with it, and what it deliberately ignores — so
+they do not each restate it.
+
+**What it is, and is not.** A control surface for a conversation that runs on
+your Fountain instance: open it, prompt it, watch it, interrupt it, reopen it
+tomorrow. It has no access to the machine it runs on beyond its own stdio and
+the CLI's credentials. Every path it reports is inside the sandbox.
+
+## Invocation
+
+```bash
+fountain acp --agent <name-or-id> [--vault <name-or-id>] [--environment <name-or-id>] [--log-level debug]
+```
+
+| Flag | Meaning |
+|---|---|
+| `--agent` | **Required in practice.** The Fountain agent every session runs. ACP has no field for it, so it is configured per process — one client entry per agent you want to reach. |
+| `--vault` | A vault attached to every conversation this process opens. Vault values override the agent's environment, so this is where per-entry secrets belong — an identity the agent posts under, for instance. Two entries on the same agent with different vaults stay separate. |
+| `--environment` | Provision every conversation from this environment instead of the agent's own — one agent config under several environments, one entry each. The vault still wins on key collision. When the agent sets `allowed_environment_ids`, the environment must be on that list. |
+| `--log-level` | stderr verbosity: `debug`, `info` (default), `warn`, `error`. |
+| `--profile` | Which saved CLI credentials to use (global flag). |
+
+**Credentials** are the CLI's: `FOUNTAIN_API_KEY` / `FOUNTAIN_BASE_URL` in the
+environment, else the profile `fountain auth login` saved. There is no login
+inside the protocol — `authenticate` verifies what the CLI already holds and
+its one advertised method just says "run `fountain auth login`". A hosted
+Buzz harness gets a freshly minted, sprite-scoped key in its environment for
+exactly this reason.
+
+**stdout is the protocol and nothing else; diagnostics go to stderr.** That is
+where your client's agent-server log will show them, and the first place to
+look when something is wrong.
+
+## The protocol surface
+
+Protocol version **1**, negotiated down to the client's if lower. `agentInfo`
+is `fountain` with the CLI's version.
+
+| Method | What Fountain does |
+|---|---|
+| `initialize` | Capability handshake. The client's own capabilities (`fs`, terminals) are logged and unused — this agent works on a sandbox filesystem, not yours. |
+| `authenticate` | Verifies the CLI's saved credentials against the instance. Advertised only when none are held. |
+| `session/new` | Resolves `--agent`, refuses an agent whose runtime does not speak ACP (today: `gemini`, [#659](https://github.com/BinaryBourbon/fountain/issues/659)), and opens a conversation. **The ACP session id *is* the conversation id** — see below. Responds with the agent's model as the single available model. |
+| `session/prompt` | Sends the turn (text and images; other blocks are dropped with a warning, an all-unusable prompt is refused) and streams the conversation's ACP output back as `session/update` notifications until the turn ends. |
+| `session/cancel` | Interrupts the running turn. |
+| `session/load` | Reopens a conversation this process did not start: the stored `session/update` history is replayed **before** the response, as the spec requires. |
+| `session/set_model` | Not implemented. The model belongs to the Fountain agent; changing it here would change every conversation on that agent. |
+| `session/request_permission` (agent → client) | Not forwarded yet — sandboxed runtimes run under their own permission mode ([#643](https://github.com/BinaryBourbon/fountain/issues/643), [#708](https://github.com/BinaryBourbon/fountain/issues/708)). |
+
+Advertised capabilities: `loadSession: true`; prompt `image: true`,
+`audio: false`, `embeddedContext: false` (the client may not inline a local
+file — that would be context about a machine the agent cannot see).
+
+`cwd` and `mcpServers` on `session/new` are logged and ignored: the sandbox
+clones its own checkout, and a Fountain agent carries its own MCP configuration
+to the sandbox. Fountain may *add* MCP servers of its own to a session — the
+Buzz publish tools are injected this way — but never the client's.
+
+### The session id is the conversation id
+
+`session/new` returns the Fountain conversation id as the ACP `sessionId`
+([ADR 0015](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0015-fountain-as-an-acp-agent.md),
+[#699](https://github.com/BinaryBourbon/fountain/issues/699)). That is what
+makes `session/load` work across processes and days: an editor hands back an id
+from last week and it resolves to a real conversation, not to a map that died
+with the process that minted it. It is also why the same id shows up in the web
+UI, `fountain conv`, and the audit trail.
+
+### What streams back
+
+The sandbox runtime already speaks ACP to Fountain
+([ADR 0014](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0014-agent-client-protocol.md)),
+so the adapter is a proxy, not a translator: `agent_message_chunk`,
+`agent_thought_chunk`, `tool_call`, `tool_call_update` and friends are
+forwarded as they arrive, with the `sessionId` rewritten to yours. Two
+adjustments, both about the machine boundary:
+
+- **`tool_call.locations` are moved to `_meta["fountain.sandboxLocations"]`.**
+  They name files in the sandbox; left in place an editor would open (or fail
+  to open) paths on your machine.
+- **Stop reasons come from the sandbox** (`end_turn`, `refusal`, `cancelled`,
+  …). What the sandbox has no vocabulary for — it never provisioned, it was
+  reclaimed mid-turn, the conversation was terminated — is reported as a
+  JSON-RPC error rather than dressed up as "the agent finished".
+
+A dropped SSE connection is not a lost turn: the server closes an idle stream
+after 60 s and the adapter reconnects and resumes from where it left off.
+
+### `_meta` extensions on `session/new`
+
+Out-of-band fields a chat harness sends; anything else in `_meta` is ignored.
+
+| Field | Meaning |
+|---|---|
+| `channelId` | Names the external channel this session serves. With it, `session/new` **resumes** the conversation already bound to that channel for this user + agent + vault (same conversation, same sandbox, same runtime session — a fresh ACP id from the client's side), so a harness that forgets its sessions on restart lands back where it was ([#774](https://github.com/BinaryBourbon/fountain/issues/774)). Without it every `session/new` is a new conversation. |
+| `freshSession` | With `channelId`: skip the resume this once — unbind the current conversation (it keeps running and is retired like any other idle one) and open a new one as the binding. This is what a Buzz owner's `!rotate` turns into ([#788](https://github.com/BinaryBourbon/fountain/pull/788)). Ignored without `channelId`. |
+
+The same knobs exist on the API as `channel_id` / `fresh` on
+`POST /api/conversations`.
+
+## Lifecycle, sandboxes, and what survives
+
+- **A turn ends when the conversation says so** — the terminal `turn` stage
+  event, with its stop reason — not when output goes quiet.
+- **An idle sandbox is suspended, not lost.** The next prompt resumes it. A
+  sandbox reclaimed at its maximum lifetime, or one that fails to reattach, is
+  reported as an error on the turn that hit it; prompt again to provision a
+  fresh one. The transcript is untouched either way — `session/load` replays
+  it — but the agent's own working memory in the sandbox is gone
+  ([#649](https://github.com/BinaryBourbon/fountain/issues/649)).
+- **Closing the client does not stop anything.** The conversation is on the
+  server; the process is a window onto it. Reopen with `session/load`, or from
+  the web UI, or `fountain conv`.
+
+## When something goes wrong
+
+Start with stderr (`--log-level debug` if the default is not enough). Errors
+are worded for a reader inside an editor rather than a terminal:
+
+| Message | Meaning |
+|---|---|
+| `no Fountain agent configured` | The entry has no `--agent`. |
+| `agent "x" runs the gemini runtime, which does not speak ACP` | Use that agent from the web UI or `fountain run`. |
+| `credentials for … were rejected` | Run `fountain auth login`. The message names the instance it tried, which is usually the surprise. |
+| `could not resolve agent "x" on …` | Wrong name, or the right name on a different instance. |
+| `the sandbox never started: …` | Provisioning failed — the reason is the sandbox provider's. |
+| `could not reattach to the sandbox — prompt again to provision a fresh one` | The sandbox was reclaimed; the transcript survives. |
+
+Running the binary by hand is a fair diagnostic — it sits waiting for JSON-RPC
+on stdin, which proves the process starts and finds its credentials.
+
+## Where it is used
+
+| Client | Who spawns it | Page |
+|---|---|---|
+| Zed and other ACP editors | The editor, from its agent-server config | [Editors](editors.md) |
+| OpenClaw (Telegram, Discord, Slack) | The `acpx` plugin on the OpenClaw host | [OpenClaw](openclaw.md) |
+| Buzz (Nostr) | `buzz-acp`, supervised **by Fountain itself** on the gateway, one per hosted identity | [Buzz](buzz.md) |

--- a/docs/integrations/buzz.md
+++ b/docs/integrations/buzz.md
@@ -270,6 +270,104 @@ as `buzz.published` — the tool and channel, never the message content.
 - **The runtime is the Fountain agent's.** A Buzz agent runs whatever runtime
   its bound Fountain agent is configured for; there is no Buzz-specific pin.
 
+## Operating a hosted agent
+
+Everything after `deploy`. The desktop's picture of a hosted agent is the
+record it deployed; Fountain's is the identity it runs. They agree at deploy
+time and can drift afterwards, and this section is about which side owns what.
+
+### Who may talk to it
+
+The harness's inbound author gate — `buzz-acp`'s `respond_to` — decides whose
+`@`-mention fires a turn: `owner-only` (the default), `allowlist` (owner plus
+named pubkeys), `anyone`, or `nobody`. Inside a DM only the owner and same-owner
+siblings ever get through, whatever the mode; that is `buzz-acp`'s rule.
+
+- **At deploy** the desktop sends its record's `respond_to` /
+  `respond_to_allowlist`; the provider forwards them and the harness starts
+  with them.
+- **Afterwards** the desktop refuses to change access on a provider agent it
+  has already deployed ("Stop or recreate the provider agent first"). Change it
+  here instead — it restarts the harness so the new gate is live in seconds:
+
+    ```bash
+    fountain buzz agents list
+    fountain buzz agents set-access "TV Guide" --respond-to anyone
+    fountain buzz agents set-access "TV Guide" --respond-to allowlist --allowlist <hex>,<hex>
+    ```
+
+    (`PATCH /api/buzz/agents/:id` underneath.)
+
+- **A later desktop deploy overwrites it.** `deploy` is the whole truth of the
+  record, so pressing *Start* on the desktop for an agent whose record still
+  says `owner-only` sends `owner-only` — and Fountain will faithfully apply it
+  and restart. Until the desktop can edit access on a deployed provider agent,
+  treat `set-access` as the source of truth and avoid re-deploying from the
+  desktop for hosted agents you have opened up.
+
+### How other people find it
+
+Being *allowed* to answer someone is not the same as *appearing* in their
+composer. Buzz Desktop and mobile only offer a non-owned agent in `@`-mention
+autocomplete when the relay carries a **kind:10100 directory entry** for it,
+authored by the agent, saying which channels it listens in and whom it answers.
+The hosted harness publishes that entry at startup and again on every channel
+membership change, from the channels it actually subscribes to and its real
+`respond_to` (allowlist pubkeys only in allowlist mode). So the two are always
+consistent: an agent is offered exactly where it would answer.
+
+Clients cache the directory; someone who does not see a freshly opened agent
+in autocomplete should restart their desktop app. The owner never needed the
+entry — their desktop knows the agent locally — which is why "only I can
+mention it" is the symptom of a missing or `owner-only` entry.
+
+### What a re-deploy does
+
+Deploy is idempotent on the pubkey. A re-deploy that changes something the
+harness was launched with — `respond_to`, the environment override, the relay
+URL, the display name, the agent — restarts the harness; one that changes
+nothing leaves it running. Vault secrets are refreshed either way but a
+rotated key is not applied to a running harness; that is what `!rotate` is for.
+
+### Owner control commands
+
+Three commands the **owner** can send by mentioning the agent, and only the
+owner (verified through the NIP-OA attestation, not the display name):
+
+| Command | Effect |
+|---|---|
+| `@Agent !rotate` | Ends the channel's current conversation and opens a fresh one on the next mention — a clean slate without a redeploy. |
+| `@Agent !cancel` | Interrupts the running turn. |
+| `@Agent !shutdown` | Exits the harness. Fountain restarts it (the identity is still enabled), so this is a restart, not a stop — `DELETE /api/buzz/agents/:id` is the stop. |
+
+Commands created before the harness started are ignored, so a restart does not
+replay them.
+
+### Where to look
+
+- **The harness's own log** is in the Fountain server log, prefixed
+  `[buzz-acp <identity id>]`. The startup line reports the effective
+  `respond_to`; `published agent directory entry (kind 10100) channels=N`
+  confirms the directory entry.
+- **The desktop's ACP activity panel** shows the agent's work in flight —
+  the harness mirrors every ACP frame to the owner as encrypted telemetry.
+- **The conversation** is a normal Fountain conversation: web UI,
+  `fountain conv`, and the audit trail (`buzz.published` for every publish).
+- **The version** of `buzz-acp` an image ships is `buzz-acp.version` in the
+  repo (a `-fountain.N` suffix means a fork build carrying upstream fixes not
+  yet released; `buzz-acp.source` names the ref).
+
+### When something goes wrong
+
+| Symptom | Usually |
+|---|---|
+| Only the owner can `@`-mention it | The gate is `owner-only`. `fountain buzz agents list`, then `set-access`. |
+| The gate is right but others don't see it in autocomplete | Their client's cached directory. Restart the desktop app; confirm the `published agent directory entry` log line. |
+| It answers, but not in a DM | By design — DMs are owner-only in `buzz-acp`. |
+| It answered before a re-deploy and not after | The deploy sent a different `respond_to` (see "a later desktop deploy overwrites it"). |
+| `!rotate` / `!shutdown` do nothing | Sent by someone other than the attested owner, or by an older harness (fixed in `0.5.14-fountain.2`+). |
+| It went quiet after a deploy | Watch the harness log for the startup line; a crash loop names its reason there. Every deploy restarts every harness. |
+
 ## For operators
 
 The integration **self-enables** on any production image that ships the
@@ -290,7 +388,7 @@ Two settings, both optional (see the
 The design is [ADR 0020](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0020-buzz-as-a-client-of-the-acp-gateway.md):
 Buzz participates by being an **ACP client** of Fountain. `buzz-acp` holds the
 relay connection and drives the bound Fountain agent through
-[`fountain acp`](editors.md) over stdio; the reply path routes back through a
+[`fountain acp`](acp.md) over stdio; the reply path routes back through a
 Fountain-hosted MCP tool that signs with the vaulted key. Because every inbound
 turn arrives through the ACP-agent door, the conversation, its log events, its
 lifecycle and its audit trail all apply for free — the same machinery every

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -119,6 +119,11 @@ in an issue would be welcome.
 
 ## What you get
 
+The adapter's full protocol surface — every method, the `_meta` extensions
+chat harnesses use, what is forwarded and what is deliberately ignored — is on
+the [`fountain acp` reference](acp.md). The short version:
+
+
 | ACP | What happens |
 |---|---|
 | `initialize` | Capability handshake. Protocol version 1 |

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -14,6 +14,10 @@ provider side, which env vars result, and how to verify it works.
 
 ## The integration with nothing to configure
 
+All three ACP clients below spawn the same adapter; its protocol surface,
+`_meta` extensions and failure modes are on one page,
+[**`fountain acp` (reference)**](acp.md), so the client pages only cover setup.
+
 [**Editors**](editors.md) are the one integration an operator does not set up.
 An ACP-capable editor — Zed and friends — spawns `fountain acp` locally and
 talks to your instance with the credentials the developer already has. There is

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - Adding a provider: integrations/adding-a-sandbox-provider.md
   - Integrations:
       - Overview: integrations/index.md
+      - fountain acp (reference): integrations/acp.md
       - Editors (ACP): integrations/editors.md
       - OpenClaw (ACP): integrations/openclaw.md
       - Buzz (Nostr): integrations/buzz.md


### PR DESCRIPTION
Follow-up to #791/#792/#794 (#790).

- **New: [`docs/integrations/acp.md`](https://github.com/BinaryBourbon/fountain/blob/docs/acp-and-buzz-operating/docs/integrations/acp.md)** — the `fountain acp` reference every ACP client page can point at instead of restating: invocation/flags, credentials, the protocol surface method by method, session id = conversation id, what streams back (and the `locations` → `_meta["fountain.sandboxLocations"]` move), the `_meta` extensions (`channelId`, `freshSession`), lifecycle/what survives, error table, where it's used. Nav entry under Integrations; linked from Editors, the integrations overview, Buzz "How it works", and `docs/cli.md`.
- **Buzz page: new "Operating a hosted agent"** — who may talk to it (`set-access`, and that the desktop refuses access edits on deployed provider agents and a later desktop deploy overwrites the server-side value), how other people's clients discover it (kind:10100 entry, cache/restart), what a re-deploy restarts, owner control commands (`!rotate` / `!cancel` / `!shutdown`), where to look, symptom table.
- CHANGELOG.

`mkdocs build --strict` passes locally; the CLI docs invariant test passes.