### PR TITLE
fix(claude): fall back to the api key when the org disallows the oauth token (#655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -438,6 +438,21 @@ upgrade, is in
 
 ### Fixed
 
+- **A Claude OAuth token the org disallows now falls back to the Anthropic
+  API key instead of failing every turn (#655).** `Fountain.Runtimes.Claude`
+  picks the OAuth token over the API key when both are on file — it bills a
+  subscription instead of metered usage — but an org that disables Claude
+  Code's subscription access rejected every turn with no way out short of a
+  human noticing and swapping credentials by hand, even though a working API
+  key sat in the same row. The ACP peer now recognizes Claude's
+  `oauth_org_not_allowed` error kind on the `session/prompt` call
+  specifically (session setup failing the same way is a different problem),
+  and `ConversationServer` swaps the OAuth token for the API key in the
+  running server's env for the rest of the conversation — the failed turn
+  says so plainly, and the next prompt succeeds without editing anything. A
+  fresh conversation still tries OAuth first, so a policy that later reverts
+  self-heals instead of staying pinned to a credential this fix disabled.
+
 - **Team page: a teammate stayed named after its agent, not its first
   message.** The first turn's auto-generated conversation title (a summary
   like "Elixir Tic Tac Toe Game Development") is what #807 shows as the

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1583,6 +1583,66 @@ defmodule Fountain.Conversations.ConversationServer do
      })}
   end
 
+  # #655: the org has refused this account's Claude OAuth token. Left alone,
+  # every further turn on this conversation would fail the exact same way —
+  # nothing about the token changes between attempts — while the Anthropic
+  # API key sitting in the same `inference_credentials` row would work. Swap
+  # it in for the rest of this server's life (not just a silent retry of this
+  # one turn, so the failure and the fix are both visible in the transcript)
+  # rather than leave the tenant to rediscover the swap by hand. Scoped to
+  # this running conversation on purpose: a fresh conversation tries OAuth
+  # again, so a policy that later reverts self-heals instead of staying
+  # pinned to a credential this fix disabled.
+  def handle_info(
+        {:acp, ref, {:failed, {:oauth_org_not_allowed, detail}}},
+        %{current_command_ref: ref, runtime_module: Fountain.Runtimes.Claude} = state
+      ) do
+    Logger.warning("conv #{state.conversation_id}: Claude OAuth token refused by org: #{detail}")
+
+    fallback_env =
+      Fountain.Runtimes.Claude.fall_back_to_api_key(state.sprite_env, state.inference_credentials)
+
+    switched? = fallback_env != state.sprite_env
+
+    # The API key was never in the sprite env before now, so `build_sprite_env`
+    # never registered it for redaction — do it here, or the very value this
+    # fix injects prints in plaintext into `log_events`. Registered as a union
+    # with the outgoing env, not a replacement: the refused OAuth token is
+    # still sitting in the sprite's `/home/sprite/.env` until a wake rewrites
+    # it, so it stays worth scrubbing.
+    Fountain.Conversations.Redaction.put(
+      state.conversation_id,
+      state.sprite_env ++ fallback_env
+    )
+
+    state = %{
+      state
+      | sprite_env: fallback_env,
+        inference_credentials: Map.delete(state.inference_credentials, :claude_code_oauth_token)
+    }
+
+    message =
+      if switched? do
+        "Your organization has disabled Claude subscription (OAuth) access for Claude Code. " <>
+          "Switched to the Anthropic API key on this account for the rest of this " <>
+          "conversation — send your prompt again."
+      else
+        "Your organization has disabled Claude subscription (OAuth) access for Claude Code, " <>
+          "and no Anthropic API key is on file for this account. Add one in Settings, then " <>
+          "try again."
+      end
+
+    {:noreply,
+     finish_acp_turn(
+       state,
+       "failed",
+       %{"error" => message, "acp.oauth_org_not_allowed" => true},
+       %{
+         reason: message
+       }
+     )}
+  end
+
   def handle_info({:acp, ref, {:failed, reason}}, %{current_command_ref: ref} = state) do
     Logger.error("conv #{state.conversation_id}: acp peer failed: #{inspect(reason)}")
 

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -335,19 +335,31 @@ defmodule Fountain.Runtimes.ACP.Peer do
   defp handle_message({:error_response, id, error}, state) do
     {tag, state} = pop_pending(state, id)
 
-    if session_setup?(tag) and auth_error?(error) and not state.authenticated? and
-         auth_method(state) do
-      method = auth_method(state)
-      Logger.info("acp peer: #{tag} needs authentication; retrying with #{method}")
+    cond do
+      session_setup?(tag) and auth_error?(error) and not state.authenticated? and
+          auth_method(state) ->
+        method = auth_method(state)
+        Logger.info("acp peer: #{tag} needs authentication; retrying with #{method}")
 
-      send_request(
-        %{state | authenticated?: true},
-        :authenticate,
-        "authenticate",
-        %{methodId: method}
-      )
-    else
-      fail(state, {:acp_error, tag, error})
+        send_request(
+          %{state | authenticated?: true},
+          :authenticate,
+          "authenticate",
+          %{methodId: method}
+        )
+
+      # Claude's own error kind for "the Anthropic org owning this OAuth token
+      # has disabled subscription (Claude Code) access" (#655). It arrives
+      # over ACP as a generic JSON-RPC -32603 "Internal error" — nothing in
+      # `code` marks it, so the kind has to be found in the error body's text
+      # rather than read off a field. Scoped to the `:prompt` call: session
+      # setup can fail for unrelated reasons, and the auth-retry clause above
+      # already owns those.
+      tag == :prompt and oauth_org_not_allowed?(error) ->
+        fail(state, {:oauth_org_not_allowed, error_detail(error)})
+
+      true ->
+        fail(state, {:acp_error, tag, error})
     end
   end
 
@@ -483,6 +495,14 @@ defmodule Fountain.Runtimes.ACP.Peer do
     do: String.contains?(String.downcase(message), "auth")
 
   defp auth_error?(_), do: false
+
+  # inspect/1 rather than pattern-matching a specific key: the adapter's exact
+  # placement of the kind (top-level, `data.details`, `data.kind`, ...) has
+  # not been pinned down against a live org-disallowed account, and a
+  # substring search over the whole payload is total — it cannot raise on a
+  # shape we did not anticipate, unlike a `get_in` chain would.
+  defp oauth_org_not_allowed?(error),
+    do: error |> inspect() |> String.contains?("oauth_org_not_allowed")
 
   # Prefer a method naming an API key in its `_meta`: that is what an agent
   # offers for "there is a key in the environment, use it", as against an

--- a/apps/fountain/lib/fountain/runtimes/claude.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude.ex
@@ -97,4 +97,30 @@ defmodule Fountain.Runtimes.Claude do
   end
 
   def write_config(_handle, _agent), do: :ok
+
+  @doc """
+  Swaps `CLAUDE_CODE_OAUTH_TOKEN` for `ANTHROPIC_API_KEY` in an already-built
+  env list — what a live turn asks for after the org has refused the OAuth
+  token (#655). Left as-is (still carrying the doomed OAuth token) when no
+  API key is on file: the caller decides what to tell the tenant when there
+  is nothing to fall back to.
+
+  Deliberately not folded into `default_env/2` as a "skip oauth" flag: that
+  function runs at provisioning, before any turn has been attempted, so it
+  has no way to know the token is bad. This is reached only after the specific
+  ACP failure that says so.
+  """
+  @spec fall_back_to_api_key([{String.t(), String.t()}], %{atom() => String.t()}) ::
+          [{String.t(), String.t()}]
+  def fall_back_to_api_key(env, inference_credentials) do
+    case Map.get(inference_credentials, :anthropic_api_key) do
+      key when is_binary(key) and key != "" ->
+        env
+        |> Enum.reject(fn {k, _v} -> k == "CLAUDE_CODE_OAUTH_TOKEN" end)
+        |> List.keystore("ANTHROPIC_API_KEY", 0, {"ANTHROPIC_API_KEY", key})
+
+      _ ->
+        env
+    end
+  end
 end

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -19,8 +19,33 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
   # Starts a server whose turn speaks ACP, with the sprite side wired to this
   # process: every byte written to stdin arrives as `{:wrote, line}`, and the
   # command's ref is ours so tests can feed stdout back.
-  defp start_acp_turn(conv) do
+  #
+  # `credentials` overrides `stub_happy_sprite/1`'s empty
+  # `InferenceCredentials.decrypted_for_user/2` stub — set after, since
+  # `stub_happy_sprite/1` would otherwise clobber it back to `%{}`.
+  #
+  # `runtime` matches `start_server/2`'s own default (`FakeRuntime`) so every
+  # existing call site is unaffected; a test asserting on real runtime-module
+  # behaviour (credential env mapping, #655) passes the real module — `conv`'s
+  # `runtime` string alone is not enough, since `state.runtime_module` is
+  # this arg, independent of it (see `start_server/2`).
+  defp start_acp_turn(conv, credentials \\ %{}, runtime \\ Fountain.Test.FakeRuntime) do
     stub_happy_sprite()
+
+    Mimic.stub(Fountain.InferenceCredentials, :decrypted_for_user, fn _u, _k ->
+      {:ok, credentials}
+    end)
+
+    # Turn 1 fires title generation, which is a live HTTPS call to the model
+    # provider. Every other test here leaves `credentials` empty, so it used to
+    # bail at `:no_credentials` before reaching the network — the moment a test
+    # supplies a key-shaped credential it dials out for real. Nothing in this
+    # file asserts on titles, so stub the boundary rather than let an offline
+    # or egress-restricted runner decide how long the call takes to fail.
+    Mimic.stub(Fountain.Conversations.TitleGenerator, :generate, fn _prompt, _creds ->
+      {:error, :stubbed_in_test}
+    end)
+
     test = self()
     ref = make_ref()
 
@@ -39,7 +64,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       :ok
     end)
 
-    {pid, _mon, :alive} = start_server(conv, initial_prompt: "first")
+    {pid, _mon, :alive} = start_server(conv, initial_prompt: "first", runtime: runtime)
 
     # Unconditional teardown. A test that fails an assertion would otherwise
     # skip its own `GenServer.stop`, leaving a server running into the next
@@ -341,6 +366,112 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert [turn] = Conversations._unsafe_list_turns(conv.id)
       assert turn.status == "failed"
       assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+    end
+  end
+
+  describe "org-disallowed oauth (#655)" do
+    setup do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+      {:ok, conv: conv}
+    end
+
+    defp oauth_error_reply(pid, ref, id) do
+      line =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "error" => %{
+            "code" => -32_603,
+            "message" => "Internal error",
+            "data" => %{
+              "details" =>
+                "oauth_org_not_allowed: Your organization has disabled Claude subscription access"
+            }
+          }
+        }) <> "\n"
+
+      send(pid, {:stdout, %{ref: ref}, line})
+      settle(pid)
+    end
+
+    defp failed_turn_stage(conv_id) do
+      conv_id
+      |> Conversations._unsafe_list_log_events()
+      |> Enum.find(&(&1.kind == "stage" and &1.stage == "turn" and &1.state == "failed"))
+    end
+
+    test "falls back to the api key for the rest of the conversation, when one is on file", %{
+      conv: conv
+    } do
+      {pid, ref} =
+        start_acp_turn(
+          conv,
+          %{claude_code_oauth_token: "oauth-token", anthropic_api_key: "api-key"},
+          Fountain.Runtimes.Claude
+        )
+
+      # Drain turn 1's own spawn message — otherwise the `assert_receive` below
+      # would match this stale one (still carrying the doomed oauth token)
+      # rather than turn 2's fresh spawn.
+      assert_receive {:spawned, _cmd, _args, _turn_1_opts}
+
+      prompt_id = drive_to_prompt(pid, ref)
+      oauth_error_reply(pid, ref, prompt_id)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "failed"
+
+      stage = failed_turn_stage(conv.id)
+      assert stage.data =~ "Switched to the Anthropic API key"
+
+      # The conversation is usable again — the next turn spawns with the
+      # fallback credential, not the one the org already refused.
+      assert :ok = GenServer.call(pid, {:send_prompt, "again", []})
+      assert_receive {:spawned, _cmd, _args, opts}
+
+      env = Keyword.fetch!(opts, :env)
+      assert {"ANTHROPIC_API_KEY", "api-key"} in env
+      refute List.keymember?(env, "CLAUDE_CODE_OAUTH_TOKEN", 0)
+    end
+
+    test "the swapped-in api key is registered for output redaction", %{conv: conv} do
+      # Only `build_sprite_env/5` registers secrets with the redaction table,
+      # and the fallback never goes through it — so without an explicit
+      # registration the one credential this fix puts into the sandbox is the
+      # one credential that would print in plaintext into `log_events`. The
+      # refused OAuth token stays registered too: it is still in the sprite's
+      # `.env` on disk until a wake rewrites the file.
+      {pid, ref} =
+        start_acp_turn(
+          conv,
+          %{
+            claude_code_oauth_token: "oauth-token-long-enough",
+            anthropic_api_key: "api-key-long-enough"
+          },
+          Fountain.Runtimes.Claude
+        )
+
+      prompt_id = drive_to_prompt(pid, ref)
+      oauth_error_reply(pid, ref, prompt_id)
+
+      registered = Fountain.Conversations.Redaction.lookup(conv.id)
+      assert "api-key-long-enough" in registered
+      assert "oauth-token-long-enough" in registered
+    end
+
+    test "says so plainly when there is no api key to fall back to", %{conv: conv} do
+      {pid, ref} =
+        start_acp_turn(conv, %{claude_code_oauth_token: "oauth-token"}, Fountain.Runtimes.Claude)
+
+      prompt_id = drive_to_prompt(pid, ref)
+      oauth_error_reply(pid, ref, prompt_id)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "failed"
+
+      stage = failed_turn_stage(conv.id)
+      assert stage.data =~ "no Anthropic API key is on file"
     end
   end
 

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -378,6 +378,54 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       assert_receive {:acp, _ref, {:failed, {:acp_error, :initialize, %{"message" => "bad key"}}}}
     end
 
+    test "an org-disallowed oauth error at the prompt is distinguished from a generic error (#655)",
+         ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+      %{"id" => prompt_id} = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => prompt_id,
+          "error" => %{
+            "code" => -32_603,
+            "message" => "Internal error",
+            "data" => %{
+              "details" =>
+                "oauth_org_not_allowed: Your organization has disabled Claude subscription access"
+            }
+          }
+        }) <> "\n"
+      )
+
+      assert_receive {:acp, _ref, {:failed, {:oauth_org_not_allowed, detail}}}
+      assert detail =~ "oauth_org_not_allowed"
+    end
+
+    test "the same error kind at session setup is not special-cased — only the prompt call is",
+         ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => init_id,
+          "error" => %{"code" => -32_603, "message" => "oauth_org_not_allowed"}
+        }) <> "\n"
+      )
+
+      assert_receive {:acp, _ref,
+                      {:failed,
+                       {:acp_error, :initialize, %{"message" => "oauth_org_not_allowed"}}}}
+    end
+
     test "a stdin write failure fails the turn rather than exiting the peer", ctx do
       # #603: the SDK write is a bare GenServer.call underneath, and the command
       # process stops :normal the moment the runtime's exit frame arrives. The

--- a/apps/fountain/test/fountain/runtimes/claude_test.exs
+++ b/apps/fountain/test/fountain/runtimes/claude_test.exs
@@ -51,4 +51,56 @@ defmodule Fountain.Runtimes.ClaudeTest do
     assert_receive {:wrote, "/home/sprite/.claude/settings.json", settings}
     assert %{"enableAllProjectMcpServers" => true} = Jason.decode!(settings)
   end
+
+  describe "default_env/2" do
+    test "prefers the oauth token over the api key" do
+      env =
+        Claude.default_env(nil, %{
+          claude_code_oauth_token: "oauth-token",
+          anthropic_api_key: "api-key"
+        })
+
+      assert env == [{"CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"}]
+    end
+
+    test "falls back to the api key when there is no oauth token" do
+      env = Claude.default_env(nil, %{anthropic_api_key: "api-key"})
+
+      assert env == [{"ANTHROPIC_API_KEY", "api-key"}]
+    end
+
+    test "is empty when neither credential is on file" do
+      assert Claude.default_env(nil, %{}) == []
+    end
+  end
+
+  describe "fall_back_to_api_key/2 (#655)" do
+    test "swaps the oauth token for the api key when one is on file" do
+      env = [{"CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"}, {"OTHER_VAR", "x"}]
+
+      result = Claude.fall_back_to_api_key(env, %{anthropic_api_key: "api-key"})
+
+      assert {"ANTHROPIC_API_KEY", "api-key"} in result
+      refute List.keymember?(result, "CLAUDE_CODE_OAUTH_TOKEN", 0)
+      assert {"OTHER_VAR", "x"} in result
+    end
+
+    test "leaves the env untouched when no api key is on file" do
+      env = [{"CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"}]
+
+      assert Claude.fall_back_to_api_key(env, %{}) == env
+    end
+
+    test "does not duplicate an api key entry the env already carries" do
+      env = [
+        {"CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"},
+        {"ANTHROPIC_API_KEY", "stale-key"}
+      ]
+
+      result = Claude.fall_back_to_api_key(env, %{anthropic_api_key: "fresh-key"})
+
+      assert Enum.count(result, fn {k, _v} -> k == "ANTHROPIC_API_KEY" end) == 1
+      assert {"ANTHROPIC_API_KEY", "fresh-key"} in result
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes #655.

`Fountain.Runtimes.Claude.default_env/2` deliberately picks the OAuth token over the API key when both are on file — it bills a subscription instead of metered usage. But when the Anthropic org that owns the OAuth token has disabled Claude subscription access for Claude Code, every turn refuses with `oauth_org_not_allowed`, and there was no way out short of a human noticing and swapping credentials by hand — even though the API key sitting in the same `inference_credentials` row would have worked.

I went with the issue's "fall back on this specific error" option, since it's the one that actually unblocks a tenant without them touching anything:

- **`Fountain.Runtimes.ACP.Peer`** recognizes Claude's `oauth_org_not_allowed` error kind (a generic JSON-RPC `-32603` on the wire — the kind lives in the error body's text, not `code`, so detection is a substring search over the whole payload rather than a `get_in` on a specific key I haven't seen pinned down against a live org-disallowed account). Scoped to the `:prompt` call specifically — a session-setup call failing the same shape is a different, pre-existing problem the auth-retry path above it already owns.
- **`Fountain.Runtimes.Claude.fall_back_to_api_key/2`** swaps `CLAUDE_CODE_OAUTH_TOKEN` for `ANTHROPIC_API_KEY` in an already-built env list. Kept out of `default_env/2` on purpose — that function runs at provisioning, before any turn has been attempted, so it has no way to know the token is bad.
- **`ConversationServer`** applies the swap to the running server's `sprite_env`/`inference_credentials` for the rest of the conversation, not just a silent retry of the one failed turn — so both the failure and the fix are visible in the transcript (the turn's stage event says plainly what happened and what changed, or that there's no API key to fall back to). Every ACP turn is a fresh spawn reusing `state.sprite_env` (confirmed by reading the turn-spawn path), so this is enough for the very next prompt to succeed with no respawn/retry surgery needed.
- Scoped to the running conversation, deliberately not persisted to the credentials row: a fresh conversation tries OAuth again, so an org policy that later reverts self-heals instead of staying pinned to a credential this fix disabled.

## Test plan

- [x] `Fountain.Runtimes.ACP.PeerTest`: the `oauth_org_not_allowed` error at `session/prompt` is reported as a distinct `{:oauth_org_not_allowed, detail}` failure reason; the same error kind at session setup is *not* special-cased (only `:prompt` is).
- [x] `Fountain.Runtimes.ClaudeTest`: `fall_back_to_api_key/2` — swaps when an API key is on file, leaves the env untouched when there isn't one, doesn't duplicate an existing `ANTHROPIC_API_KEY` entry.
- [x] `Fountain.Conversations.ConversationServerACPTest` (real `ConversationServer` + real ACP peer, driven end-to-end over stdout): when an API key is on file, the failed turn's stage event says so, and the *next* turn's real spawn carries `ANTHROPIC_API_KEY` with `CLAUDE_CODE_OAUTH_TOKEN` gone; when there's no API key on file, the failure message says so instead of silently repeating.
- [x] `mix test` (full suite) — 2929 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict` — no issues
- [x] `scripts/sobelow.sh` — clean
