### PR TITLE
fix(conversations): a transient provider error no longer retires a live sandbox (#799)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ upgrade, is in
 
 ### Fixed
 
+- **A transient sandbox-provider error no longer retires a live sandbox.**
+  Both places that probe a sprite before reusing it — the reattach a
+  `ConversationServer` runs when it starts against a `ready` row, and the
+  wake path's probe — now give the sandbox up only on a definitive
+  not-found. Anything else (DNS, timeouts, 5xx, a credential problem) leaves
+  the row exactly as it was: reattach stops and the next prompt tries again;
+  a wake answers `503 sandbox_probe_failed` with `Retry-After`. On 2026-08-18
+  a 70-second cluster DNS outage during a Horde failover ran reattach for
+  nine live sandboxes at once, every probe answered `nxdomain`, and all nine
+  rows were marked `failed` — which is exactly what the reaper's destroy
+  pass keys on; one of them held a completed turn and a live ACP session.
+  The `reattach failed` stage event now carries `retryable`. (#799)
+
 - **A hosted Buzz agent now shows up in other people's `@`-mention
   autocomplete.** Buzz Desktop admits a non-owned agent to autocomplete only if
   the relay carries a kind:10100 directory entry for it saying which channels

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1438,20 +1438,22 @@ defmodule Fountain.Conversations do
       {:error, :not_found} ->
         :create_new
 
-      {:error, reason} when status == "suspended" ->
-        # A transient probe failure must not cost the parked disk: falling
-        # to :create_new retires this row, and the reaper then destroys the
+      {:error, reason} ->
+        # A transient probe failure must not cost the disk: falling to
+        # :create_new retires this row, and the reaper then destroys the
         # still-live sprite — with the agent's memory on it. Only a
-        # definitive not-found gives up the suspended sandbox; anything
-        # else fails the wake retryably.
+        # definitive not-found gives up the sandbox; anything else fails the
+        # wake retryably (503 + Retry-After at the API).
+        #
+        # This clause was `suspended`-only until #799: a `ready` row is the
+        # same parked disk once its server is gone (a deploy, a crash, a
+        # partition), and the 2026-08-18 incident showed the provider going
+        # unreachable for 70 s with nine `ready` rows behind it.
         Logger.warning(
-          "sprite probe failed for suspended sandbox #{sandbox_id}: #{inspect(reason)}"
+          "sprite probe failed for #{status} sandbox #{sandbox_id}: #{inspect(reason)}"
         )
 
         {:error, :sprite_probe_failed}
-
-      _ ->
-        :create_new
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -818,12 +818,18 @@ defmodule Fountain.Conversations.ConversationServer do
 
         {:noreply, new_state}
 
-      {:error, reason} ->
+      {:error, :not_found} ->
+        # The provider says the sandbox is gone. That is the one answer that
+        # justifies retiring the row: the disk no longer exists, so the next
+        # prompt must provision fresh.
         Logger.warning(
-          "reattach failed for sprite #{sandbox.sprite_name}: #{inspect(reason)} — marking sandbox failed"
+          "reattach failed for sprite #{sandbox.sprite_name}: not found — marking sandbox failed"
         )
 
-        publish_stage(state.conversation_id, "reattach", "failed", %{reason: inspect(reason)})
+        publish_stage(state.conversation_id, "reattach", "failed", %{
+          reason: "not_found",
+          retryable: false
+        })
 
         {:ok, _} =
           Conversations.update_sandbox(sandbox, %{
@@ -833,6 +839,32 @@ defmodule Fountain.Conversations.ConversationServer do
 
         # Don't mark the conversation failed — the user can still send a
         # prompt and auto-wake will spin a fresh sandbox.
+        {:stop, :normal, state}
+
+      {:error, reason} ->
+        # Anything else — a transport error, a timeout, a 5xx, a credential
+        # problem — says nothing about the sandbox, only about our ability to
+        # reach the provider right now. The row is left exactly as it was and
+        # the server stops; the next prompt takes the same reattach path again.
+        #
+        # This arm used to mark the row `failed` too. On 2026-08-18 a 70-second
+        # DNS outage did exactly that to nine live sandboxes at once (a Horde
+        # failover re-ran reattach for every conversation on the partitioned
+        # pod, and every probe answered nxdomain), and `SandboxReaper`'s
+        # destroy pass would have taken the sprites — one of them holding a
+        # completed turn and a live ACP session — an hour later (#799). A
+        # transient failure must not become a destroyed disk; the same rule
+        # `probe_sandbox/4` applies on the wake path.
+        Logger.warning(
+          "reattach failed for sprite #{sandbox.sprite_name}: #{inspect(reason)} — " <>
+            "transient; sandbox row left untouched"
+        )
+
+        publish_stage(state.conversation_id, "reattach", "failed", %{
+          reason: inspect(reason),
+          retryable: true
+        })
+
         {:stop, :normal, state}
     end
   end

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -122,6 +122,20 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # The wake path could not reach the sandbox provider to check whether the
+  # conversation's sandbox is still there (#799). Nothing was changed — the
+  # row is deliberately left as it was rather than retired on a transport
+  # error — so the caller should simply retry, same as :provisioning.
+  def call(conn, {:error, :sprite_probe_failed}) do
+    conn
+    |> put_resp_header("retry-after", "10")
+    |> put_status(:service_unavailable)
+    |> json(%{
+      error: "sandbox_probe_failed",
+      message: "could not reach the sandbox provider to wake the conversation; retry shortly"
+    })
+  end
+
   # Prompting a terminated conversation. 410 rather than 404: the id was
   # real, the resource is gone for good, and the caller should stop retrying.
   def call(conn, {:error, :gone}) do

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -1409,6 +1409,14 @@ defmodule FountainWeb.ConversationsLive.Show do
         {:noreply,
          put_flash(socket, :error, "The conversation is still provisioning — try again shortly.")}
 
+      {:error, :sprite_probe_failed} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Couldn't reach the sandbox provider to wake the conversation — try again shortly."
+         )}
+
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Couldn't send: #{inspect(reason)}")}
     end

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -455,6 +455,86 @@ defmodule Fountain.Conversations.ConversationServerTest do
     end
   end
 
+  describe "reattach — failure paths (#799)" do
+    # A `ready` sandbox routes the server down the reattach branch: probe the
+    # sprite, then re-arm. Only a definitive not-found may retire the row —
+    # on 2026-08-18 a 70 s DNS outage during a Horde failover ran this path
+    # for nine live sandboxes at once, every probe answered nxdomain, and the
+    # old error arm marked all nine `failed`, which is what the reaper's
+    # destroy pass keys on.
+    setup %{sandbox: sandbox, conv: conv} do
+      {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      {:ok, conv} = Conversations.update_conversation(conv, %{status: "idle"})
+      {:ok, sandbox: sandbox, conv: conv}
+    end
+
+    defp reattach_stage(conv_id) do
+      conv_id
+      |> Conversations._unsafe_list_log_events()
+      |> Enum.find(&(&1.kind == "stage" and &1.stage == "reattach" and &1.state == "failed"))
+    end
+
+    test "a transient probe failure leaves the sandbox row untouched", %{
+      conv: conv,
+      sandbox: sandbox
+    } do
+      stub_happy_sprite()
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+        {:error, {:unavailable, %Req.TransportError{reason: :nxdomain}}}
+      end)
+
+      # The whole point: the disk is still there, so nothing may route it to
+      # the reaper's destroy pass.
+      Mimic.reject(&Fountain.Sandbox.Sprites.destroy/1)
+
+      {_pid, ref, _} = start_server(conv)
+      assert :normal = assert_stopped(ref)
+
+      reloaded = Conversations._unsafe_get_sandbox!(sandbox.id)
+      assert reloaded.status == "ready"
+      assert is_nil(reloaded.terminated_at)
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      # The operator can still see it happened, and that it will be retried.
+      assert %{data: data} = reattach_stage(conv.id)
+      assert %{"retryable" => true, "reason" => reason} = Jason.decode!(data)
+      assert reason =~ "nxdomain"
+    end
+
+    test "a 5xx from the provider is transient too", %{conv: conv, sandbox: sandbox} do
+      stub_happy_sprite()
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+        {:error, {:unavailable, {:http, 503, %{}}}}
+      end)
+
+      {_pid, ref, _} = start_server(conv)
+      assert :normal = assert_stopped(ref)
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
+    end
+
+    test "a definitive not-found retires the sandbox so the next prompt provisions fresh", %{
+      conv: conv,
+      sandbox: sandbox
+    } do
+      stub_happy_sprite()
+      Mimic.stub(Fountain.Sandbox.Sprites, :get, fn _handle -> {:error, :not_found} end)
+
+      {_pid, ref, _} = start_server(conv)
+      assert :normal = assert_stopped(ref)
+
+      reloaded = Conversations._unsafe_get_sandbox!(sandbox.id)
+      assert reloaded.status == "failed"
+      refute is_nil(reloaded.terminated_at)
+      # The conversation itself is not failed — the user can still prompt it.
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      assert %{data: data} = reattach_stage(conv.id)
+      assert %{"retryable" => false, "reason" => "not_found"} = Jason.decode!(data)
+    end
+  end
+
   describe "turn lifecycle on a running server" do
     defp start_with_turn(conv) do
       stub_happy_sprite()

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1295,6 +1295,30 @@ defmodule Fountain.ConversationsContextTest do
       assert Repo.reload(sandbox).status == "suspended"
     end
 
+    test "a transient sprite probe failure does not give up a ready sandbox either (#799)" do
+      # A `ready` row whose server is gone (deploy, crash, partition) is the
+      # same parked disk as a suspended one. Until #799 only `suspended` was
+      # protected; a `ready` row fell to :create_new, was marked terminated,
+      # and the reaper destroyed a sprite that was fine.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite-blip-ready")
+      {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+        {:error, {:unavailable, %Req.TransportError{reason: :nxdomain}}}
+      end)
+
+      reject(&Horde.DynamicSupervisor.start_child/2)
+
+      assert {:error, :sprite_probe_failed} = Conversations.wake_conversation(conv.id)
+      reloaded = Repo.reload(sandbox)
+      assert reloaded.status == "ready"
+      assert is_nil(reloaded.terminated_at)
+      assert Repo.reload(conv).sandbox_id == sandbox.id
+    end
+
     test "a definitively gone sprite retires the suspended sandbox and provisions fresh" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)

--- a/apps/fountain/test/fountain_web/controllers/fallback_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/fallback_controller_test.exs
@@ -48,6 +48,17 @@ defmodule FountainWeb.FallbackControllerTest do
     end
   end
 
+  describe "{:error, :sprite_probe_failed} → 503 (#799)" do
+    test "a wake that could not reach the sandbox provider is retryable, not a 422", %{
+      conn: conn
+    } do
+      conn = FountainWeb.FallbackController.call(conn, {:error, :sprite_probe_failed})
+      assert conn.status == 503
+      assert get_resp_header(conn, "retry-after") == ["10"]
+      assert %{"error" => "sandbox_probe_failed"} = Jason.decode!(conn.resp_body)
+    end
+  end
+
   describe "{:error, :not_found} → 404" do
     test "GET /api/agents/:id with a nonexistent UUID returns 404 with error body", %{conn: conn} do
       user = insert_verified_user()

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -427,8 +427,15 @@ func handleStageEvent(data map[string]any) (bool, error) {
 
 	case stage == "reattach" && state == "failed":
 		// The server stops after this (conversation_server.ex); no more
-		// events are coming. The conversation itself stays promptable —
-		// the next prompt auto-wakes a fresh sandbox.
+		// events are coming. The conversation itself stays promptable.
+		// Since #799 the event says which kind of failure it was: a
+		// transient one (provider unreachable) left the sandbox as it was
+		// and the next prompt reattaches again; a definitive not-found
+		// retired it and the next prompt provisions fresh.
+		if innerDataString(data, "retryable") == "true" {
+			fmt.Fprintf(os.Stderr, "▸ reattach failed (%s) — the sandbox is untouched; prompt again to retry\n", innerDataString(data, "reason"))
+			return true, errReattachFailed
+		}
 		fmt.Fprintf(os.Stderr, "▸ reattach failed — prompt again to provision a fresh sandbox\n")
 		return true, errReattachFailed
 

--- a/cli/internal/cmd/conv_test.go
+++ b/cli/internal/cmd/conv_test.go
@@ -92,6 +92,15 @@ func TestHandleStageEvent(t *testing.T) {
 			wantErr:  errReattachFailed,
 		},
 		{
+			// #799: a transient failure leaves the sandbox untouched. Still
+			// terminal for the stream — the server stopped — and still an
+			// error exit, but the message tells the caller to just retry.
+			name:     "transient reattach failure is terminal and fails",
+			data:     map[string]any{"stage": "reattach", "state": "failed", "data": `{"reason":"{:unavailable, :nxdomain}","retryable":true}`},
+			terminal: true,
+			wantErr:  errReattachFailed,
+		},
+		{
 			// The server falls back to cold provisioning after a failed
 			// checkpoint restore — the stream must keep going.
 			name:     "checkpoint restore failed is not terminal (cold provision follows)",

--- a/cli/internal/cmd/stream.go
+++ b/cli/internal/cmd/stream.go
@@ -25,7 +25,7 @@ var (
 	// success for a crashed agent or a sandbox that never came up.
 	errTurnFailed      = errors.New("turn failed")
 	errProvisionFailed = errors.New("provisioning failed — the sandbox never started")
-	errReattachFailed  = errors.New("reattach failed — the sandbox was marked failed")
+	errReattachFailed  = errors.New("reattach failed — the sandbox could not be re-armed")
 	errSandboxExpired  = errors.New("sandbox hit its max lifetime")
 )
 


### PR DESCRIPTION
Closes #799.

## What

Two places probe a sprite before reusing it — the reattach a `ConversationServer` runs when it starts against a `ready` row, and `probe_sandbox/4` on the wake path. Both now give the sandbox up **only on a definitive `:not_found`**. Anything else (transport error, timeout, 5xx, credential problem) says nothing about the sandbox, only about our ability to reach the provider right now, so the row is left untouched:

- reattach publishes `reattach failed {retryable: true, reason}` and stops; the next prompt reattaches again.
- a wake returns `{:error, :sprite_probe_failed}` → API `503 sandbox_probe_failed` + `Retry-After: 10` (it used to fall through to the 422 catch-all), LiveView "try again shortly" flash. The wake-path clause was `suspended`-only; a `ready` row whose server is gone is the same parked disk.
- CLI: the `reattach failed` line reads the new `retryable` field and says "the sandbox is untouched; prompt again to retry" instead of "prompt again to provision a fresh sandbox".

## Why

2026-08-18 07:18 UTC: a 70 s cluster DNS outage during a Horde failover ran reattach for nine live sandboxes at once, every probe answered `nxdomain`, and the old error arm marked all nine rows `failed` — exactly what `SandboxReaper`'s destroy pass keys on. One held a completed turn and a live ACP session; the repair was a one-row UPDATE and a wake, which came back `session_attached`. Full timeline in #799.

## Tests

- `conversation_server_test.exs` — new `reattach — failure paths (#799)` block: transient (`nxdomain`) leaves the row `ready`/no `terminated_at` and never calls `destroy`; 5xx likewise; `:not_found` still retires it and the conversation stays `idle`. Stage event carries `retryable`.
- `conversations_context_test.exs` — a transient probe on a `ready` sandbox returns `:sprite_probe_failed`, row and `sandbox_id` unchanged, no `start_child`.
- `fallback_controller_test.exs` — `:sprite_probe_failed` → 503 + Retry-After.
- `cli/internal/cmd/conv_test.go` — transient reattach event.

All new tests verified failing against the pre-fix code (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)