### PR TITLE
fix(conversations): a wake onto a fresh sandbox starts a new runtime session (#778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,18 @@ upgrade, is in
   pass keys on; one of them held a completed turn and a live ACP session.
   The `reattach failed` stage event now carries `retryable`. (#799)
 
+- **A conversation whose sandbox is gone works again on the next prompt.**
+  When a wake provisions a fresh sandbox — the old one hit the 24 h ceiling,
+  or was retired as failed — the server now clears `runtime_session_id` and
+  publishes a `session` stage event (`event: reset, reason: fresh_sandbox`),
+  so the next turn is `session/new` on the new disk. It used to keep the old
+  id and run `session/resume` against a disk that had never seen the
+  session, which failed `-32002 Resource not found` on that prompt and on
+  every prompt after it, until the conversation was terminated. The agent's
+  in-context memory is still lost when its sandbox is — that has not
+  changed — but the conversation, its transcript and its title carry over,
+  and the transcript says why the agent does not remember. (#778)
+
 - **A hosted Buzz agent now shows up in other people's `@`-mention
   autocomplete.** Buzz Desktop admits a non-owned agent to autocomplete only if
   the relay carries a kind:10100 directory entry for it saying which channels

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1334,9 +1334,12 @@ defmodule Fountain.Conversations do
      server will go through reattach mode and pick up any running
      detachable session.
   2. Otherwise, provision a fresh sprite, mark the old sandbox
-     terminated, and start the server pointing at the new sandbox.
-     `claude --resume` keeps the chat via the persisted
-     `runtime_session_id`.
+     terminated, and start the server pointing at the new sandbox. The
+     runtime session does not follow — it lived on the old disk — so the
+     server clears `runtime_session_id` once the fresh sprite is up and the
+     next turn starts a new one (#778). The Fountain conversation, its
+     transcript and its title carry over; the agent's in-context memory
+     does not.
 
   Returns `{:error, :gone}` if the conversation is in a terminal status
   (`terminated`, `failed`) — those don't auto-resume.

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -63,9 +63,10 @@ defmodule Fountain.Conversations.ConversationServer do
   The persisted `runtime_session_id` is what the next turn resumes by
   (`session/resume` under ACP). Note that it only carries the conversation
   while the *sandbox* survives: a runtime session lives in the sandbox
-  filesystem, so a wake that provisions a fresh sprite resumes against a
-  session that is not there — see #649. `log_events` still render the whole
-  transcript, which is what makes that failure quiet.
+  filesystem, so a wake that provisions a fresh sprite cannot resume it. The
+  server clears the id when it provisions fresh (#778, `forget_runtime_session`)
+  and the next turn starts a new session on the new disk; `log_events` still
+  render the whole transcript.
   """
   def send_prompt(conv_id, prompt, images \\ [], opts \\ []) do
     result =
@@ -612,6 +613,8 @@ defmodule Fountain.Conversations.ConversationServer do
           # conversations on this env can warm-start from it. Async so it
           # doesn't block the user's first turn.
           maybe_create_checkpoint_async(handle, env)
+
+          state = forget_runtime_session(state, conv)
 
           # Dated from the sandbox row, not from now, so the absolute lifetime
           # ceiling survives a restart and a reattach rather than resetting.
@@ -1845,6 +1848,33 @@ defmodule Fountain.Conversations.ConversationServer do
   defp redact(_present), do: "[REDACTED]"
 
   # ── helpers ───────────────────────────────────────────────────────────────
+
+  # A runtime session lives in the sandbox filesystem, so it cannot follow the
+  # conversation onto a freshly provisioned one. Until #778 a wake that took
+  # the `:create_new` arm kept the old id, the next turn ran in `:continue`
+  # mode, and the ACP peer's `session/resume` failed `-32002 Resource not
+  # found` against a disk that had never seen the session — on every prompt,
+  # until the conversation was terminated. Clearing it here makes the next
+  # turn `:run` → `session/new`: the same conversation, transcript and title,
+  # a new runtime session on the new disk. The agent's in-context memory is
+  # lost either way; the difference is a working turn instead of a failing
+  # one, and a stage event that says so.
+  #
+  # Done inside the server rather than by the wake caller: the caller's row
+  # update races this server's own read of the row in handle_continue.
+  defp forget_runtime_session(%{runtime_session_id: nil} = state, _conv), do: state
+
+  defp forget_runtime_session(state, conv) do
+    {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: nil})
+
+    publish_stage(state.conversation_id, "session", "done", %{
+      event: "reset",
+      reason: "fresh_sandbox",
+      detail: "the previous runtime session lived on a sandbox that no longer exists"
+    })
+
+    %{state | runtime_session_id: nil}
+  end
 
   # The row's provider decides where the sandbox is created; adopt-on-
   # already-exists is the adapter's job.

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -1430,6 +1430,7 @@ defmodule FountainWeb.ConversationsLive.Show do
   defp stage_icon("clone"), do: "&#129319;"
   defp stage_icon("turn"), do: "&#128172;"
   defp stage_icon("reattach"), do: "&#128268;"
+  defp stage_icon("session"), do: "&#128260;"
   defp stage_icon("sandbox"), do: "&#128164;"
   defp stage_icon("terminate"), do: "&#128721;"
   defp stage_icon(_), do: "&bull;"

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -319,9 +319,23 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
     test "resumes by the persisted id rather than guessing" do
       # The hazard 0014 names: gemini's `--resume` and codex's `--last` re-enter
       # "the most recent conversation in the workspace". ACP names the session.
+      #
+      # On the sandbox that minted the id: a `ready` row routes the server
+      # through reattach, which is what a second turn after a server restart
+      # looks like. (This test used to start from a `pending` sandbox with a
+      # prior id — a fresh provision — which is the #778 shape and now,
+      # correctly, does not resume; see the describe below.)
       user = insert_verified_user()
-      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
-      {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: "sess_prior"})
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      conv =
+        insert_conversation(
+          agent: acp_agent(user),
+          user_id: user.id,
+          sandbox: sandbox,
+          status: "idle",
+          runtime_session_id: "sess_prior"
+        )
 
       {pid, ref} = start_acp_turn(conv)
 
@@ -331,6 +345,71 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       decoded = next_write()
       assert decoded["method"] == "session/resume"
       assert decoded["params"]["sessionId"] == "sess_prior"
+    end
+  end
+
+  describe "a wake onto a fresh sandbox (#778)" do
+    test "starts a new runtime session instead of resuming one the disk never saw" do
+      # The conversation's previous sandbox is gone (ceiling destroy, failed
+      # probe, …) and the wake took the :create_new arm: a `pending` row and
+      # a fresh provision, but the row still names the session that lived on
+      # the old disk. Resuming it fails `-32002 Resource not found` on every
+      # prompt until the conversation is terminated. The server must forget
+      # the id when it provisions fresh, so the next turn is `session/new`.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      conv =
+        insert_conversation(
+          agent: acp_agent(user),
+          user_id: user.id,
+          sandbox: sandbox,
+          status: "idle",
+          runtime_session_id: "sess_on_the_old_disk"
+        )
+
+      {pid, ref} = start_acp_turn(conv)
+
+      %{"id" => init_id} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => @caps})
+
+      decoded = next_write()
+      assert decoded["method"] == "session/new"
+      refute Map.has_key?(decoded["params"], "sessionId")
+
+      # The stale id is gone from the row (the turn start persists a fresh
+      # placeholder, which `session/new` overwrites below), and the transcript
+      # says why the agent's memory did not follow.
+      refute Conversations._unsafe_get_conversation!(conv.id).runtime_session_id ==
+               "sess_on_the_old_disk"
+
+      assert %{data: data} =
+               conv.id
+               |> Conversations._unsafe_list_log_events()
+               |> Enum.find(&(&1.kind == "stage" and &1.stage == "session"))
+
+      assert %{"event" => "reset", "reason" => "fresh_sandbox"} = Jason.decode!(data)
+
+      # And the id the agent mints on the new disk is what the next turn
+      # resumes by — the same round trip as a brand-new conversation.
+      reply(pid, ref, decoded["id"], %{"sessionId" => "sess_new_disk"})
+
+      assert Conversations._unsafe_get_conversation!(conv.id).runtime_session_id ==
+               "sess_new_disk"
+    end
+
+    test "a conversation that never had a session does not get a spurious reset event" do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+
+      {pid, ref} = start_acp_turn(conv)
+      %{"id" => init_id} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => @caps})
+      %{"method" => "session/new"} = next_write()
+
+      refute conv.id
+             |> Conversations._unsafe_list_log_events()
+             |> Enum.any?(&(&1.kind == "stage" and &1.stage == "session"))
     end
   end
 

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -548,6 +548,15 @@ where the legacy path fails on an id it guessed.
 > connection stays correct on 0017's terms too: nothing is attached between
 > turns, whether the sandbox is parked or destroyed.
 
+> **Correction, 2026-08-18 (#778).** The *loud* failure is gone too. A
+> `ConversationServer` that provisions a fresh sandbox now clears
+> `runtime_session_id` (`forget_runtime_session/2`) and publishes a `session`
+> stage event (`event: reset, reason: fresh_sandbox`), so the next turn is
+> `session/new` on the new disk rather than a `session/resume` that fails
+> `-32002` on every prompt until the conversation is terminated. The agent's
+> memory is still lost when its sandbox is — that is unchanged — but the
+> conversation keeps working and the transcript says why.
+
 ### Gate 3 — permissions — **not built**
 
 Implement `session/request_permission` against the conversation LiveView: a


### PR DESCRIPTION
Closes #778.

## What

`ConversationServer` now clears `runtime_session_id` when it **provisions fresh** (`forget_runtime_session/2` in `do_fresh_provision_inner`) and publishes a `session` stage event (`state: done, event: reset, reason: fresh_sandbox`). The next turn is therefore mode `:run` → `session/new` on the new disk instead of `:continue` → `session/resume` against a session that lived on the old one, which failed `-32002 Resource not found` on that prompt and every prompt after it until the conversation was terminated.

Done inside the server rather than at the wake caller: the caller's row repoint races the server's own read of the row in `handle_continue(:provision)`.

## What does not change

The agent's in-context memory is still lost when its sandbox is (24 h ceiling, or a retired-as-failed row). The Fountain conversation, transcript and title carry over. ADR 0014 gets a dated correction under *The reclaim finding*; the CLI prints `▸ session: done` for the new event and the LiveView gets an icon.

## Tests

- `conversation_server_acp_test.exs`: the existing "turn 2 resumes by the persisted id" test started from a `pending` sandbox with a prior id — exactly the #778 shape — so it was asserting the bug. It now starts from a `ready` sandbox (reattach path) and still asserts `session/resume`. New describe *a wake onto a fresh sandbox (#778)*: pending sandbox + prior id → `session/new` with no `sessionId`, stale id gone from the row, `session`/`reset` stage event present, and the newly minted id is what gets persisted. Plus: a conversation that never had a session gets no spurious reset event.
- Verified failing against the pre-fix code. Full suite: 2921 tests, 0 failures.

Related: #799 / #801 (the incident that made this one bite), #779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)