### PR TITLE
fix(conversations): a prompt that finds a pending sandbox waits for its server instead of racing it (#800)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,20 @@ upgrade, is in
   changed — but the conversation, its transcript and its title carry over,
   and the transcript says why the agent does not remember. (#778)
 
+- **A conversation's first prompt no longer races its own creation into a
+  second sandbox.** `session/new` (`POST /api/conversations`) starts the
+  server through Horde, which may place it on another pod; the first prompt
+  arrives ~30 ms later, and if it lands on a pod whose registry has not yet
+  synced it saw a `pending` sandbox, missed the server, and took the
+  fresh-provision arm — two servers, two sprites, ~21 s of provisioning
+  each, a Horde name conflict that killed the loser after the fact, and an
+  orphan `ready` sandbox row per occurrence. A prompt that finds a `pending`
+  or `starting` row now waits for the registry to catch up
+  (`ConversationServer.await_registered/2`, `:conversation_registry_settle_ms`,
+  3 s by default) and hands the prompt to the server it finds; only if none
+  appears — the provision died with its BEAM — does it provision fresh.
+  (#800)
+
 - **A hosted Buzz agent now shows up in other people's `@`-mention
   autocomplete.** Buzz Desktop admits a non-owned agent to autocomplete only if
   the relay carries a kind:10100 directory entry for it saying which channels

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1384,6 +1384,31 @@ defmodule Fountain.Conversations do
             end
           end
 
+        {:provisioning, sandbox_id} ->
+          # The row says a server is (or was) provisioning this sandbox. The
+          # registry may simply not have caught up with a server started on
+          # another node — `session/new` and the first prompt arrive ~30 ms
+          # apart and can land on different pods — so wait for it before
+          # concluding it is dead. If it turns up, hand it the prompt exactly
+          # as the `already_started` branches do; if it does not, the
+          # provision died with its BEAM and a fresh one is right (#800).
+          case ConversationServer.await_registered(conv.id) do
+            {:ok, pid} ->
+              Logger.info(
+                "conv #{conv.id}: server for pending sandbox #{sandbox_id} " <>
+                  "appeared during the registry settle window; handing off the prompt"
+              )
+
+              if is_binary(initial_prompt) and initial_prompt != "" do
+                ConversationServer.queue_initial_prompt(pid, initial_prompt)
+              end
+
+              {:ok, _unsafe_get_conversation!(conv.id)}
+
+            :timeout ->
+              create_fresh_sandbox_and_start(conv, agent, runtime_module, initial_prompt)
+          end
+
         :create_new ->
           create_fresh_sandbox_and_start(conv, agent, runtime_module, initial_prompt)
 
@@ -1406,6 +1431,11 @@ defmodule Fountain.Conversations do
       %{status: status, sprite_name: name} = sandbox
       when status in ["ready", "suspended"] and is_binary(name) ->
         probe_reusable_sandbox(sandbox, sandbox_id)
+
+      # A provision is in flight — or was, in a BEAM that is gone. The
+      # caller waits for the registry before deciding which (#800).
+      %{status: status} when status in ["pending", "starting"] ->
+        {:provisioning, sandbox_id}
 
       _ ->
         :create_new
@@ -1611,6 +1641,12 @@ defmodule Fountain.Conversations do
       # and the row being updated — in which the row still names the old
       # sandbox. That one is transient and self-correcting; the old one was
       # permanent.
+      #
+      # #800 closed the other half: a prompt that finds a `pending` row now
+      # waits for the registry (`ConversationServer.await_registered/2`)
+      # before coming here, so the first server — often on another pod, and
+      # so invisible to this node's registry for a beat — is found and
+      # handed the prompt instead of being raced by a second provision.
       case start_conversation_server(conv, new_sandbox.id, runtime_module, initial_prompt) do
         {:ok, _} ->
           _ = mark_old_sandbox_terminated(conv.sandbox_id)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -55,6 +55,49 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
+  @registry_settle_ms 3_000
+  @registry_poll_ms 50
+
+  @doc """
+  `whereis/1`, but willing to wait for the registry to catch up.
+
+  Horde's registry is a CRDT: a server started on another node is visible
+  here only once the delta has synced, which is milliseconds normally and
+  longer under load. A caller that already knows a server *should* exist —
+  the conversation's sandbox row is `pending`, so someone is provisioning it —
+  polls for up to `:conversation_registry_settle_ms` (#{@registry_settle_ms} ms by
+  default) before concluding there is none. Returns `{:ok, pid}` or `:timeout`.
+
+  This is what keeps a `session/new` + first-prompt pair from provisioning
+  two sprites for one conversation when the two requests land on different
+  pods (#800): the prompt used to see a `pending` row, miss the registry, and
+  take the `:create_new` arm while the first server was still 20 s from
+  finishing.
+  """
+  def await_registered(conv_id, timeout_ms \\ nil) do
+    timeout_ms =
+      timeout_ms ||
+        Application.get_env(:fountain, :conversation_registry_settle_ms, @registry_settle_ms)
+
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_await_registered(conv_id, deadline)
+  end
+
+  defp do_await_registered(conv_id, deadline) do
+    case whereis(conv_id) do
+      pid when is_pid(pid) ->
+        {:ok, pid}
+
+      nil ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          :timeout
+        else
+          Process.sleep(@registry_poll_ms)
+          do_await_registered(conv_id, deadline)
+        end
+    end
+  end
+
   @doc """
   Send another prompt. If the conversation's GenServer is gone (e.g. server
   restart), transparently wake the conversation — provision a fresh sprite

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -1359,7 +1359,9 @@ defmodule Fountain.ConversationsContextTest do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)
 
-      # sandbox remains "pending" (not "ready"), so maybe_reuse_sandbox hits the _ -> :create_new branch
+      # A `pending` sandbox with no server anywhere: the provision died with
+      # its BEAM. After the registry settle window (#800) the wake gives up
+      # waiting and provisions fresh.
       sandbox = insert_sandbox(user_id: user.id)
       conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
 
@@ -1367,7 +1369,57 @@ defmodule Fountain.ConversationsContextTest do
         {:ok, spawn(fn -> :ok end)}
       end)
 
-      assert {:ok, _conv} = Conversations.wake_conversation(conv.id)
+      assert {:ok, woken} = Conversations.wake_conversation(conv.id)
+      assert woken.sandbox_id != sandbox.id
+    end
+
+    test "a pending sandbox whose server appears during the settle window is handed the prompt, not raced (#800)" do
+      # `session/new` (POST /api/conversations) starts the server via Horde,
+      # which may place it on another pod; the first prompt arrives ~30 ms
+      # later on this pod, sees a `pending` row and — before #800 — missed
+      # the registry and took :create_new: two servers, two sprites, ~21 s of
+      # provisioning each, and a name conflict that killed the loser after
+      # the fact, leaving an orphan `ready` row. The prompt path now waits
+      # for the registry to catch up and hands the prompt to the server it
+      # finds.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      test = self()
+
+      # A stand-in for the first server: registers under the conversation's
+      # name a beat after the wake starts looking, then relays the prompt
+      # cast it receives.
+      late_server =
+        spawn_link(fn ->
+          Process.sleep(40)
+          {:ok, _} = Horde.Registry.register(Fountain.ConversationRegistry, conv.id, nil)
+          send(test, :registered)
+
+          receive do
+            {:"$gen_cast", {:initial_prompt, prompt, images}} ->
+              send(test, {:handed_off, prompt, images})
+          end
+        end)
+
+      # No second server, no second sandbox.
+      reject(&Horde.DynamicSupervisor.start_child/2)
+
+      assert {:ok, woken} = Conversations.wake_conversation(conv.id, "hello")
+      assert_receive :registered
+      assert_receive {:handed_off, "hello", []}, 500
+
+      assert woken.sandbox_id == sandbox.id
+      assert Repo.reload(sandbox).status == "pending"
+
+      assert Repo.aggregate(
+               from(s in Fountain.Conversations.Sandbox, where: s.user_id == ^user.id),
+               :count
+             ) == 1
+
+      Process.exit(late_server, :kill)
     end
 
     test "returns {:ok, conv} when old sandbox is already terminated (mark_old_sandbox_terminated no-op)" do

--- a/config/test.exs
+++ b/config/test.exs
@@ -57,6 +57,9 @@ config :fountain, :funnel_poller_enabled, false
 # without changing the retry logic under test.
 config :fountain, :retry_base_ms, 1
 
+# The registry settle window (#800) is a real-time wait; keep tests brisk.
+config :fountain, :conversation_registry_settle_ms, 150
+
 config :logger, level: :warning
 config :phoenix, :plug_init_mode, :runtime
 config :phoenix, sort_verified_routes_query_params: true


### PR DESCRIPTION
Closes #800.

## What

`maybe_reuse_sandbox/1` returns `{:provisioning, sandbox_id}` for a `pending`/`starting` row, and `wake_conversation/2` then waits for the Horde registry to catch up — `ConversationServer.await_registered/2`, polling `whereis/1` every 50 ms for up to `:conversation_registry_settle_ms` (3 s default, 150 ms in test) — before deciding:

- a server turns up → hand it the prompt (`queue_initial_prompt/3`), same as the existing `already_started` branches; no new row, no new sprite.
- none appears → the provision died with its BEAM; provision fresh, exactly as before.

## Why

`session/new` (`POST /api/conversations`) starts the server through Horde, which may place it on another pod; the first prompt arrives ~30 ms later on the pod buzz-acp talks to, sees a `pending` row, misses the not-yet-synced registry, and took `:create_new`. On `4faea53d…` this morning: two servers, two sprites, ~21 s of provisioning each, a `:name_conflict` that killed the loser only after its `handle_continue(:provision)` returned, and an orphan `ready` row + `cold` sprite left over. #717 fixed the repoint ordering; this closes the second-provision half.

Not done here: making `POST /api/conversations` block until the local registry sees the child. The wait on the prompt path is where the harm was, and it also covers a third pod.

## Tests

- `conversations_context_test.exs`: a stand-in server registers under the conversation's name 40 ms after the wake starts looking; the wake hands it the prompt, `start_child` is rejected, `sandbox_id` and the row are unchanged, one sandbox row total. Fails without the fix.
- The existing "pending sandbox → fresh" test now also asserts the new `sandbox_id`, i.e. the timeout arm still provisions.
- Full suite: 2920 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)