### PR TITLE
feat(team): name a teammate and pick its environment and vault when adding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ upgrade, is in
 
 ### Added
 
+- **Team page: name a teammate, pick its environment and vault when adding
+  it.** The add dialog is a small form now — agent, an optional name, the
+  environment its computer is set up from (the agent's own by default) and
+  an optional vault — instead of a bare list with Add buttons. Nothing new
+  is stored: the name is the conversation's `title`, the other two are the
+  per-launch environment override and `vault_id` every conversation already
+  has, so `Team.add_teammate/4` takes them as attrs and the pickers only
+  offer what the agent's allowlists permit. A named teammate shows its name
+  in the roster, the thread header, the composer and the tab title, with
+  the agent's name beside it; a fresh conversation opened when the old one
+  is past resuming inherits all three, so a teammate keeps its identity when
+  its computer is replaced. `POST /api/conversations` accepts `title` too.
+
 - **Team page (`/team`): your agents as teammates, one conversation each,
   laid out like a messaging app.** The roster on the left, the selected
   teammate's thread on the right, Enter to send. Adding an agent to the team

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1125,6 +1125,7 @@ defmodule Fountain.Conversations do
                                 agent's own (#783); subject to `agent.allowed_environment_ids`
     - `source`                — optional; one of "ui", "api", "agent" (default "api")
     - `parent_conversation_id` — optional; UUID of the conversation that spawned this one
+    - `title`                 — optional display title (the team page names a teammate with it)
   """
   def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts \\ [])
       when is_binary(user_id) do
@@ -1161,7 +1162,8 @@ defmodule Fountain.Conversations do
              status: "pending",
              source: attrs["source"] || "api",
              parent_conversation_id: parent_id,
-             channel_id: attrs["channel_id"]
+             channel_id: attrs["channel_id"],
+             title: attrs["title"]
            }) do
       # Recorded here rather than in either branch below: both of them return
       # {:ok, conv}. The row exists and the sandbox reservation is spent even

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -85,6 +85,7 @@ defmodule Fountain.Conversations.Conversation do
     ])
     |> validate_required([:runtime, :status, :sandbox_id, :user_id])
     |> validate_length(:channel_id, max: 255)
+    |> validate_length(:title, max: 120)
     |> validate_inclusion(:status, @statuses)
     |> validate_inclusion(:source, @sources)
     |> foreign_key_constraint(:sandbox_id)

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -18,6 +18,13 @@ defmodule Fountain.Team do
   on every conversation this agent had under it, so the rows stay in the
   user's history (`/conversations`) but leave the team.
 
+  A teammate can be given a name of its own, an environment and a vault when
+  it is added. None of these is a new column: the name is the conversation's
+  `title`, the other two are the per-launch `environment_id` override (#783)
+  and `vault_id` every conversation already carries. They belong to the
+  teammate, not the computer, so a fresh conversation opened when the old one
+  is past resuming inherits all three.
+
   Every function is tenant-scoped by `user_id`; the `_unsafe_` reads inside
   are legitimate because they follow the scoped fetch in the same function.
   """
@@ -36,10 +43,12 @@ defmodule Fountain.Team do
   One entry per agent on the team, most recently active first.
 
   Each entry is `%{agent: %Agent{}, conversation: %Conversation{}, last_turn:
-  %Turn{} | nil}` — the conversation is the newest live one for that agent,
-  or, when none is live, the newest terminated/failed one (so the last
-  transcript still shows). The conversation carries `turn_count` and
-  `last_active_at`; `last_turn` is what the list previews.
+  %Turn{} | nil, name: String.t()}` — the conversation is the newest live one
+  for that agent, or, when none is live, the newest terminated/failed one (so
+  the last transcript still shows). The conversation carries `turn_count` and
+  `last_active_at`; `last_turn` is what the list previews; `name` is what the
+  teammate is called — the conversation's title when it was given one at add
+  time, else the agent's name.
   """
   def list_teammates(user_id) when is_binary(user_id) do
     convs =
@@ -52,9 +61,20 @@ defmodule Fountain.Team do
     last_turns = last_turns_by_conversation(Enum.map(convs, & &1.id))
 
     convs
-    |> Enum.map(&%{agent: &1.agent, conversation: &1, last_turn: Map.get(last_turns, &1.id)})
+    |> Enum.map(
+      &%{
+        agent: &1.agent,
+        conversation: &1,
+        last_turn: Map.get(last_turns, &1.id),
+        name: teammate_name(&1)
+      }
+    )
     |> Enum.sort_by(& &1.conversation.last_active_at, {:desc, DateTime})
   end
+
+  @doc "What the teammate is called: the conversation's title, else the agent's name."
+  def teammate_name(%Conversation{title: title}) when is_binary(title) and title != "", do: title
+  def teammate_name(%Conversation{agent: %{name: name}}), do: name
 
   # The newest turn of each conversation in one query (DISTINCT ON). The ids
   # come from the tenant-scoped listing above, which is what scopes this.
@@ -89,18 +109,40 @@ defmodule Fountain.Team do
   @doc """
   Add `agent_id` to the team: open its conversation (and so its sandbox).
 
-  Idempotent — an agent already on the team gets its existing conversation
-  back and nothing is recorded, since nothing changed. Returns `{:ok, conv}`
-  or the `start_conversation/2` error (`:not_found`, `:subscription_required`,
-  `{:sandbox_quota_exceeded, _}`, ...). `opts` is audit attribution.
+  `attrs` is optional and string-keyed: `"name"` (what the teammate is
+  called; blank means the agent's name), `"environment_id"` (provision from
+  this environment instead of the agent's own) and `"vault_id"` (layer this
+  vault's secrets on top). The two ids go through the same checks as any
+  launch — owned by the user, and on the agent's allowlist when it has one —
+  so the errors are `start_conversation/2`'s: `:environment_not_found`,
+  `:environment_not_allowed`, `:vault_not_found`, `:vault_not_allowed`.
+
+  Idempotent — an agent already on the team gets its existing live
+  conversation back, `attrs` ignored, and nothing is recorded, since nothing
+  changed. Returns `{:ok, conv}` or the `start_conversation/2` error
+  (`:not_found`, `:subscription_required`, `{:sandbox_quota_exceeded, _}`,
+  ...). `opts` is audit attribution.
   """
-  def add_teammate(user_id, agent_id, opts \\ [])
-      when is_binary(user_id) and is_binary(agent_id) do
+  def add_teammate(user_id, agent_id, attrs \\ %{}, opts \\ [])
+      when is_binary(user_id) and is_binary(agent_id) and is_map(attrs) and is_list(opts) do
+    case get_teammate(user_id, agent_id) do
+      %{conversation: conv} ->
+        if live?(conv), do: {:ok, conv}, else: open_teammate(user_id, agent_id, attrs, opts)
+
+      nil ->
+        open_teammate(user_id, agent_id, attrs, opts)
+    end
+  end
+
+  defp open_teammate(user_id, agent_id, attrs, opts) do
     attrs = %{
       "agent_id" => agent_id,
       "user_id" => user_id,
       "channel_id" => @channel,
-      "source" => "ui"
+      "source" => "ui",
+      "title" => blank_to_nil(attrs["name"]),
+      "environment_id" => blank_to_nil(attrs["environment_id"]),
+      "vault_id" => blank_to_nil(attrs["vault_id"])
     }
 
     case Conversations.start_or_resume_conversation(attrs, opts) do
@@ -115,6 +157,41 @@ defmodule Fountain.Team do
         err
     end
   end
+
+  defp blank_to_nil(nil), do: nil
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  @doc """
+  The environments and vaults a teammate built on `agent` may be given at add
+  time: `%{environments: [%Environment{}], vaults: [%Vault{}]}`.
+
+  Both lists are the user's own, narrowed by the agent's allowlists the way
+  `start_conversation/2` will enforce them (nil = all, `[]` = none, a list =
+  those). The agent's own environment is always offered — naming it is not an
+  override — and is what a blank pick means.
+  """
+  def addable_options(user_id, %Agents.Agent{} = agent) when is_binary(user_id) do
+    %{
+      environments:
+        user_id
+        |> Fountain.Environments.list_environments()
+        |> Enum.filter(&allowed?(&1.id, agent.allowed_environment_ids, agent.environment_id)),
+      vaults:
+        user_id
+        |> Fountain.Vaults.list_vaults()
+        |> Enum.filter(&allowed?(&1.id, agent.allowed_vault_ids, nil))
+    }
+  end
+
+  defp allowed?(_id, nil, _own), do: true
+  defp allowed?(id, _allowed, id), do: true
+  defp allowed?(id, allowed, _own), do: id in allowed
 
   @doc """
   Remove `agent_id` from the team.
@@ -172,11 +249,11 @@ defmodule Fountain.Team do
         if live?(conv) do
           case ConversationServer.send_prompt(conv.id, text, images, opts) do
             :ok -> {:ok, Conversations.get_conversation(conv.id, user_id) || conv}
-            {:error, :gone} -> start_fresh(user_id, agent_id, text, images, opts)
+            {:error, :gone} -> start_fresh(user_id, agent_id, conv, text, images, opts)
             {:error, _} = err -> err
           end
         else
-          start_fresh(user_id, agent_id, text, images, opts)
+          start_fresh(user_id, agent_id, conv, text, images, opts)
         end
     end
   end
@@ -184,8 +261,9 @@ defmodule Fountain.Team do
   # A new conversation under the team binding, seeded with the message. Not
   # `start_or_resume`: we are here precisely because the bound conversation
   # cannot be resumed, and `find_channel_conversation` would agree — but
-  # saying so directly keeps the intent readable.
-  defp start_fresh(user_id, agent_id, text, images, opts) do
+  # saying so directly keeps the intent readable. The name, environment and
+  # vault are the teammate's, not the dead computer's, so they carry over.
+  defp start_fresh(user_id, agent_id, %Conversation{} = prev, text, images, opts) do
     Conversations.start_conversation(
       %{
         "agent_id" => agent_id,
@@ -193,7 +271,10 @@ defmodule Fountain.Team do
         "channel_id" => @channel,
         "source" => "ui",
         "prompt" => text,
-        "images" => images
+        "images" => images,
+        "title" => prev.title,
+        "environment_id" => prev.environment_id,
+        "vault_id" => prev.vault_id
       },
       opts
     )

--- a/apps/fountain/lib/fountain_web/live/team_live.ex
+++ b/apps/fountain/lib/fountain_web/live/team_live.ex
@@ -23,6 +23,8 @@ defmodule FountainWeb.TeamLive do
   alias Fountain.{Conversations, Team}
   alias Fountain.Conversations.{ConversationServer, LogEvent}
 
+  @empty_add_form %{"agent_id" => nil, "name" => "", "environment_id" => "", "vault_id" => ""}
+
   @impl true
   def mount(params, _session, socket) do
     user_id = socket.assigns.current_user.id
@@ -43,6 +45,8 @@ defmodule FountainWeb.TeamLive do
       |> assign(:turns_by_id, %{})
       |> assign(:prompt, "")
       |> assign(:picker_open, false)
+      |> assign(:add_form, @empty_add_form)
+      |> assign(:add_options, %{environments: [], vaults: []})
 
     # `/team` with no teammate named lands on the most recently active one,
     # the way a messaging app opens on the top thread; `/team/:agent_id` is
@@ -87,7 +91,7 @@ defmodule FountainWeb.TeamLive do
     |> assign(:turns_by_id, load_turns(conv.id))
     |> assign(:prompt, "")
     |> assign(:teammates, mark_read_locally(socket.assigns.teammates, conv.id))
-    |> assign(:page_title, "#{teammate.agent.name} · Team")
+    |> assign(:page_title, "#{teammate.name} · Team")
   end
 
   defp load_turns(conv_id) do
@@ -246,18 +250,30 @@ defmodule FountainWeb.TeamLive do
   end
 
   def handle_event("open_picker", _, socket) do
+    agents = Team.list_addable_agents(socket.assigns.user_id)
+    first = List.first(agents)
+
     {:noreply,
      socket
-     |> assign(:addable_agents, Team.list_addable_agents(socket.assigns.user_id))
-     |> assign(:picker_open, true)}
+     |> assign(:addable_agents, agents)
+     |> assign(:picker_open, true)
+     |> set_add_form(%{@empty_add_form | "agent_id" => first && first.id})}
   end
 
   def handle_event("close_picker", _, socket), do: {:noreply, assign(socket, :picker_open, false)}
 
-  def handle_event("add_teammate", %{"agent_id" => agent_id}, socket) do
-    user_id = socket.assigns.user_id
+  # The picker form as it is typed into. A change of agent re-derives the
+  # environment and vault choices from that agent's allowlists.
+  def handle_event("validate_add", %{"add" => params}, socket) do
+    {:noreply, set_add_form(socket, Map.merge(socket.assigns.add_form, params))}
+  end
 
-    case Team.add_teammate(user_id, agent_id, FountainWeb.Audited.attribution(socket)) do
+  def handle_event("add_teammate", %{"add" => %{"agent_id" => agent_id} = params}, socket)
+      when is_binary(agent_id) and agent_id != "" do
+    user_id = socket.assigns.user_id
+    attrs = Map.take(params, ["name", "environment_id", "vault_id"])
+
+    case Team.add_teammate(user_id, agent_id, attrs, FountainWeb.Audited.attribution(socket)) do
       {:ok, conv} ->
         Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv.id}")
 
@@ -272,6 +288,8 @@ defmodule FountainWeb.TeamLive do
         {:noreply, socket |> assign(:picker_open, false) |> flash_error(reason)}
     end
   end
+
+  def handle_event("add_teammate", _params, socket), do: {:noreply, socket}
 
   def handle_event("remove_teammate", %{"agent_id" => agent_id}, socket) do
     user_id = socket.assigns.user_id
@@ -370,6 +388,31 @@ defmodule FountainWeb.TeamLive do
     end
   end
 
+  # Keep the form and its option lists in step: the environment and vault
+  # choices belong to the agent picked, and a pick that the new agent does not
+  # offer falls back to the default (blank).
+  defp set_add_form(socket, form) do
+    agent = Enum.find(socket.assigns.addable_agents, &(&1.id == form["agent_id"]))
+
+    options =
+      if agent,
+        do: Team.addable_options(socket.assigns.user_id, agent),
+        else: %{environments: [], vaults: []}
+
+    form =
+      form
+      |> Map.update("environment_id", "", &keep_if_offered(&1, options.environments))
+      |> Map.update("vault_id", "", &keep_if_offered(&1, options.vaults))
+
+    socket
+    |> assign(:add_form, form)
+    |> assign(:add_options, options)
+  end
+
+  defp keep_if_offered(id, offered) do
+    if Enum.any?(offered, &(&1.id == id)), do: id, else: ""
+  end
+
   defp flash_error(socket, :busy),
     do: put_flash(socket, :error, "They're still working on the last message")
 
@@ -377,6 +420,17 @@ defmodule FountainWeb.TeamLive do
     do: put_flash(socket, :error, "Their computer is still starting — try again shortly")
 
   defp flash_error(socket, :not_found), do: put_flash(socket, :error, "Agent not found")
+
+  defp flash_error(socket, :environment_not_found),
+    do: put_flash(socket, :error, "Environment not found")
+
+  defp flash_error(socket, :environment_not_allowed),
+    do: put_flash(socket, :error, "That agent may not use that environment")
+
+  defp flash_error(socket, :vault_not_found), do: put_flash(socket, :error, "Vault not found")
+
+  defp flash_error(socket, :vault_not_allowed),
+    do: put_flash(socket, :error, "That agent may not use that vault")
 
   defp flash_error(socket, :subscription_required) do
     socket
@@ -517,13 +571,13 @@ defmodule FountainWeb.TeamLive do
               <div class="text-sm">
                 <%= case @selected.conversation.status do %>
                   <% "pending" -> %>
-                    Starting <span class="font-medium text-zinc-600">{@selected.agent.name}</span>'s
+                    Starting <span class="font-medium text-zinc-600">{@selected.name}</span>'s
                     computer&hellip;
                   <% "failed" -> %>
-                    <span class="font-medium text-zinc-600">{@selected.agent.name}</span>'s computer
+                    <span class="font-medium text-zinc-600">{@selected.name}</span>'s computer
                     failed to start — a message tries a new one.
                   <% _ -> %>
-                    Say hello to <span class="font-medium text-zinc-600">{@selected.agent.name}</span>.
+                    Say hello to <span class="font-medium text-zinc-600">{@selected.name}</span>.
                 <% end %>
               </div>
               <div class="text-xs">
@@ -554,7 +608,7 @@ defmodule FountainWeb.TeamLive do
               id={"team-prompt-#{@selected.conversation.id}"}
               name="prompt"
               rows="1"
-              placeholder={"Message #{@selected.agent.name}…"}
+              placeholder={"Message #{@selected.name}…"}
               phx-hook="SubmitOnEnter"
               autofocus
               class="flex-1 resize-none rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-0)] px-4 py-2 text-sm leading-6 max-h-40 focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)]"
@@ -574,7 +628,12 @@ defmodule FountainWeb.TeamLive do
         <% end %>
       </section>
 
-      <.agent_picker :if={@picker_open} agents={@addable_agents} />
+      <.agent_picker
+        :if={@picker_open}
+        agents={@addable_agents}
+        form={@add_form}
+        options={@add_options}
+      />
     </div>
     """
   end
@@ -607,7 +666,7 @@ defmodule FountainWeb.TeamLive do
       <div class="relative shrink-0">
         <div class="size-11 rounded-full overflow-hidden flex items-center justify-center text-sm font-semibold bg-zinc-200 text-zinc-700">
           <img :if={@avatar_url} src={@avatar_url} class="w-full h-full object-cover" alt="" />
-          <span :if={is_nil(@avatar_url)}>{initials(@teammate.agent.name)}</span>
+          <span :if={is_nil(@avatar_url)}>{initials(@teammate.name)}</span>
         </div>
         <span
           class={["absolute bottom-0 right-0 size-3 rounded-full ring-2 ring-white", @dot]}
@@ -616,7 +675,7 @@ defmodule FountainWeb.TeamLive do
       </div>
       <div class="flex-1 min-w-0">
         <div class="flex items-baseline justify-between gap-2">
-          <span class="font-medium truncate">{@teammate.agent.name}</span>
+          <span class="font-medium truncate">{@teammate.name}</span>
           <span class={[
             "text-[11px] shrink-0",
             @selected && "text-blue-100",
@@ -672,8 +731,11 @@ defmodule FountainWeb.TeamLive do
         &lsaquo; Team
       </button>
       <div class="min-w-0 flex-1">
-        <div class="font-semibold truncate">{@teammate.agent.name}</div>
+        <div class="font-semibold truncate">{@teammate.name}</div>
         <div class="flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)] whitespace-nowrap min-w-0">
+          <span :if={@teammate.name != @teammate.agent.name} class="truncate">
+            {@teammate.agent.name} &middot;
+          </span>
           <span class={["size-2 rounded-full shrink-0", @dot]} />
           <span class="truncate">{@presence_label}</span>
           <span
@@ -704,7 +766,7 @@ defmodule FountainWeb.TeamLive do
           type="button"
           phx-click="remove_teammate"
           phx-value-agent_id={@teammate.agent.id}
-          data-confirm={"Remove #{@teammate.agent.name} from the team? Their computer is shut down; the conversation stays in your history."}
+          data-confirm={"Remove #{@teammate.name} from the team? Their computer is shut down; the conversation stays in your history."}
           class="rounded-md border border-rose-200 text-rose-700 px-2.5 py-1 hover:bg-rose-50"
         >
           Remove
@@ -715,8 +777,25 @@ defmodule FountainWeb.TeamLive do
   end
 
   attr :agents, :list, required: true
+  attr :form, :map, required: true
+  attr :options, :map, required: true
 
   defp agent_picker(assigns) do
+    agent = Enum.find(assigns.agents, &(&1.id == assigns.form["agent_id"]))
+
+    own_env =
+      agent && agent.environment_id &&
+        Enum.find(assigns.options.environments, &(&1.id == agent.environment_id))
+
+    assigns =
+      assign(assigns,
+        agent: agent,
+        own_env: own_env,
+        # The agent's own environment is the blank pick, not a row of its own.
+        other_envs:
+          Enum.reject(assigns.options.environments, &(agent && &1.id == agent.environment_id))
+      )
+
     ~H"""
     <div id="add-teammate" class="relative z-50">
       <div
@@ -752,25 +831,130 @@ defmodule FountainWeb.TeamLive do
               Every agent you have is already on the team.
               <.link navigate={~p"/agents/new"} class="underline not-italic">Create another</.link>
             </div>
-            <ul :if={@agents != []} class="divide-y divide-[var(--color-border)]" role="list">
-              <li :for={a <- @agents} class="py-2 flex items-center justify-between gap-3">
-                <div class="min-w-0">
-                  <div class="font-medium truncate">{a.name}</div>
-                  <div class="text-xs text-[var(--color-text-muted)] truncate">
-                    {a.runtime} &middot; {a.model}
-                  </div>
-                </div>
+            <form
+              :if={@agents != []}
+              id="add-teammate-form"
+              phx-change="validate_add"
+              phx-submit="add_teammate"
+              class="space-y-4"
+            >
+              <div class="space-y-1">
+                <label
+                  for="add-agent"
+                  class="block text-xs font-medium text-[var(--color-text-secondary)]"
+                >
+                  Agent
+                </label>
+                <select
+                  id="add-agent"
+                  name="add[agent_id]"
+                  class="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-0)] px-3 py-2 text-sm"
+                >
+                  <option :for={a <- @agents} value={a.id} selected={@form["agent_id"] == a.id}>
+                    {a.name} ({a.runtime} &middot; {a.model})
+                  </option>
+                </select>
+              </div>
+
+              <div class="space-y-1">
+                <label
+                  for="add-name"
+                  class="block text-xs font-medium text-[var(--color-text-secondary)]"
+                >
+                  Name <span class="font-normal text-[var(--color-text-muted)]">(optional)</span>
+                </label>
+                <input
+                  id="add-name"
+                  type="text"
+                  name="add[name]"
+                  value={@form["name"]}
+                  maxlength="120"
+                  placeholder={(@agent && @agent.name) || "Teammate"}
+                  autocomplete="off"
+                  class="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-0)] px-3 py-2 text-sm"
+                />
+                <p class="text-xs text-[var(--color-text-muted)]">
+                  How they show up on the team. Blank uses the agent's name.
+                </p>
+              </div>
+
+              <div :if={@other_envs != []} class="space-y-1">
+                <label
+                  for="add-environment"
+                  class="block text-xs font-medium text-[var(--color-text-secondary)]"
+                >
+                  Environment
+                </label>
+                <select
+                  id="add-environment"
+                  name="add[environment_id]"
+                  class="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-0)] px-3 py-2 text-sm"
+                >
+                  <option value="" selected={@form["environment_id"] in [nil, ""]}>
+                    <%= if @own_env do %>
+                      Agent's default ({@own_env.name})
+                    <% else %>
+                      Agent's default
+                    <% end %>
+                  </option>
+                  <option
+                    :for={e <- @other_envs}
+                    value={e.id}
+                    selected={@form["environment_id"] == e.id}
+                  >
+                    {e.name}
+                  </option>
+                </select>
+                <p class="text-xs text-[var(--color-text-muted)]">
+                  Their computer is set up from this environment instead of the agent's own.
+                </p>
+              </div>
+
+              <div :if={@options.vaults != []} class="space-y-1">
+                <label
+                  for="add-vault"
+                  class="block text-xs font-medium text-[var(--color-text-secondary)]"
+                >
+                  Vault <span class="font-normal text-[var(--color-text-muted)]">(optional)</span>
+                </label>
+                <select
+                  id="add-vault"
+                  name="add[vault_id]"
+                  class="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-0)] px-3 py-2 text-sm"
+                >
+                  <option value="" selected={@form["vault_id"] in [nil, ""]}>
+                    &#8212; none &#8212;
+                  </option>
+                  <option
+                    :for={v <- @options.vaults}
+                    value={v.id}
+                    selected={@form["vault_id"] == v.id}
+                  >
+                    {v.name}
+                  </option>
+                </select>
+                <p class="text-xs text-[var(--color-text-muted)]">
+                  Layered on top of the environment's secrets. Vault values win on key collision.
+                </p>
+              </div>
+
+              <div class="flex justify-end gap-2 pt-1">
                 <button
                   type="button"
-                  phx-click="add_teammate"
-                  phx-value-agent_id={a.id}
-                  phx-disable-with="Adding…"
-                  class="shrink-0 rounded-md px-3 py-1 text-xs font-medium bg-[var(--color-brand)] text-white hover:bg-[var(--color-brand-hover)]"
+                  phx-click="close_picker"
+                  class="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]"
                 >
-                  Add
+                  Cancel
                 </button>
-              </li>
-            </ul>
+                <button
+                  type="submit"
+                  phx-disable-with="Adding…"
+                  class="rounded-md px-3 py-1.5 text-sm font-medium bg-[var(--color-brand)] text-white hover:bg-[var(--color-brand-hover)]"
+                >
+                  Add to team
+                </button>
+              </div>
+            </form>
           </div>
         </div>
       </div>

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -187,6 +187,12 @@ defmodule FountainWeb.Schemas do
               "resume key."
         },
         prompt: %Schema{type: :string, description: "Optional first turn prompt."},
+        title: %Schema{
+          type: :string,
+          nullable: true,
+          maxLength: 120,
+          description: "Optional display title. The team page names a teammate with it."
+        },
         images: %Schema{
           type: :array,
           items: ImageInput,

--- a/apps/fountain/test/fountain/team_test.exs
+++ b/apps/fountain/test/fountain/team_test.exs
@@ -67,13 +67,13 @@ defmodule Fountain.TeamTest do
     end
   end
 
-  describe "add_teammate/3" do
+  describe "add_teammate/4" do
     test "opens a channel-bound conversation and records the membership" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)
       inert_start_child()
 
-      assert {:ok, conv} = Team.add_teammate(user.id, agent.id, actor: "ui")
+      assert {:ok, conv} = Team.add_teammate(user.id, agent.id, %{}, actor: "ui")
       assert conv.channel_id == Team.channel()
       assert conv.agent_id == agent.id
       assert [%{agent: %{id: id}}] = Team.list_teammates(user.id)
@@ -102,6 +102,126 @@ defmodule Fountain.TeamTest do
       agent = insert_agent(user_id: other.id)
 
       assert {:error, :not_found} = Team.add_teammate(user.id, agent.id)
+    end
+
+    test "a name, an environment and a vault land on the conversation" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id, name: "Ada")
+      env = insert_env(user_id: user.id, name: "staging")
+      vault = insert_vault(user_id: user.id, name: "ada-keys")
+      inert_start_child()
+
+      assert {:ok, conv} =
+               Team.add_teammate(user.id, agent.id, %{
+                 "name" => "  Ada (staging)  ",
+                 "environment_id" => env.id,
+                 "vault_id" => vault.id
+               })
+
+      assert conv.title == "Ada (staging)"
+      assert conv.environment_id == env.id
+      assert conv.vault_id == vault.id
+      # The sandbox was provisioned from the override, not the agent's own.
+      assert Repo.reload(conv.sandbox).environment_id == env.id
+
+      assert [%{name: "Ada (staging)", agent: %{name: "Ada"}}] = Team.list_teammates(user.id)
+    end
+
+    test "a blank name means the agent's name; blank ids mean the defaults" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id, name: "Ada")
+      inert_start_child()
+
+      assert {:ok, conv} =
+               Team.add_teammate(user.id, agent.id, %{
+                 "name" => "   ",
+                 "environment_id" => "",
+                 "vault_id" => ""
+               })
+
+      assert conv.title == nil
+      assert conv.environment_id == nil
+      assert conv.vault_id == nil
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+    end
+
+    test "the agent's allowlists gate the environment and the vault" do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id)
+      vault = insert_vault(user_id: user.id)
+
+      agent =
+        insert_agent(user_id: user.id, allowed_environment_ids: [], allowed_vault_ids: [])
+
+      assert {:error, :environment_not_allowed} =
+               Team.add_teammate(user.id, agent.id, %{"environment_id" => env.id})
+
+      assert {:error, :vault_not_allowed} =
+               Team.add_teammate(user.id, agent.id, %{"vault_id" => vault.id})
+
+      assert Team.list_teammates(user.id) == []
+    end
+
+    test "another tenant's environment or vault reads as not found" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      env = insert_env(user_id: other.id)
+      vault = insert_vault(user_id: other.id)
+
+      assert {:error, :environment_not_found} =
+               Team.add_teammate(user.id, agent.id, %{"environment_id" => env.id})
+
+      assert {:error, :vault_not_found} =
+               Team.add_teammate(user.id, agent.id, %{"vault_id" => vault.id})
+    end
+
+    test "an agent already on the team keeps its conversation, whatever the new attrs" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      vault = insert_vault(user_id: user.id)
+      inert_start_child()
+
+      {:ok, first} = Team.add_teammate(user.id, agent.id, %{"name" => "One"})
+
+      assert {:ok, again} =
+               Team.add_teammate(user.id, agent.id, %{"name" => "Two", "vault_id" => vault.id})
+
+      assert again.id == first.id
+      assert [%{name: "One"}] = Team.list_teammates(user.id)
+    end
+  end
+
+  describe "addable_options/2" do
+    test "the user's environments and vaults, narrowed by the agent's allowlists" do
+      user = insert_verified_user()
+      own = insert_env(user_id: user.id, name: "own")
+      allowed = insert_env(user_id: user.id, name: "allowed")
+      _other = insert_env(user_id: user.id, name: "other")
+      _foreign = insert_env(user_id: insert_verified_user().id, name: "foreign")
+      v1 = insert_vault(user_id: user.id, name: "v1")
+      _v2 = insert_vault(user_id: user.id, name: "v2")
+
+      open = insert_agent(user_id: user.id, environment_id: own.id)
+      assert %{environments: envs, vaults: vaults} = Team.addable_options(user.id, open)
+      assert envs |> Enum.map(& &1.name) |> Enum.sort() == ["allowed", "other", "own"]
+      assert vaults |> Enum.map(& &1.name) |> Enum.sort() == ["v1", "v2"]
+
+      narrow =
+        insert_agent(
+          user_id: user.id,
+          environment_id: own.id,
+          allowed_environment_ids: [allowed.id],
+          allowed_vault_ids: [v1.id]
+        )
+
+      assert %{environments: envs, vaults: vaults} = Team.addable_options(user.id, narrow)
+      # The agent's own environment is always offered — naming it is not an override.
+      assert envs |> Enum.map(& &1.name) |> Enum.sort() == ["allowed", "own"]
+      assert Enum.map(vaults, & &1.name) == ["v1"]
+
+      closed = insert_agent(user_id: user.id, allowed_environment_ids: [], allowed_vault_ids: [])
+      assert %{environments: [], vaults: []} = Team.addable_options(user.id, closed)
     end
   end
 
@@ -169,6 +289,30 @@ defmodule Fountain.TeamTest do
 
       assert agent_id == ada.id
       assert conv_id == fresh.id
+    end
+
+    test "a fresh conversation inherits the teammate's name, environment and vault" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      env = insert_env(user_id: user.id)
+      vault = insert_vault(user_id: user.id)
+
+      _dead =
+        insert_teammate_conv(user, ada,
+          status: "terminated",
+          title: "Ada (staging)",
+          environment_id: env.id,
+          vault_id: vault.id
+        )
+
+      inert_start_child()
+
+      assert {:ok, fresh} = Team.send_message(user.id, ada.id, "are you there?")
+      assert fresh.title == "Ada (staging)"
+      assert fresh.environment_id == env.id
+      assert fresh.vault_id == vault.id
+      assert Repo.reload(fresh.sandbox).environment_id == env.id
+      assert [%{name: "Ada (staging)"}] = Team.list_teammates(user.id)
     end
 
     test "a server that answers :gone also gets a fresh conversation" do

--- a/apps/fountain/test/fountain_web/live/team_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/team_live_test.exs
@@ -58,8 +58,60 @@ defmodule FountainWeb.TeamLiveTest do
 
       assert html =~ "Add a teammate"
       assert html =~ "Ada"
-      # Linus is on the team already: exactly one Add button, and it is Ada's.
-      assert [_one] = Regex.scan(~r/phx-click="add_teammate"/, html)
+      # Linus is on the team already: the agent select offers only Ada.
+      assert [_one] = Regex.scan(~r/<option[^>]*value="[0-9a-f-]{36}"[^>]*>\s*Ada/, html)
+      refute html =~ ~r/<option[^>]*>\s*Linus/
+    end
+
+    test "the picker offers the environments and vaults the chosen agent may use", %{
+      conn: conn
+    } do
+      user = insert_verified_user()
+      own = insert_env(user_id: user.id, name: "own-env")
+      allowed = insert_env(user_id: user.id, name: "allowed-env")
+      _other = insert_env(user_id: user.id, name: "other-env")
+      v1 = insert_vault(user_id: user.id, name: "vault-one")
+      _v2 = insert_vault(user_id: user.id, name: "vault-two")
+
+      narrow =
+        insert_agent(
+          user_id: user.id,
+          name: "Narrow",
+          environment_id: own.id,
+          allowed_environment_ids: [allowed.id],
+          allowed_vault_ids: [v1.id]
+        )
+
+      _open = insert_agent(user_id: user.id, name: "Open")
+      conn = login_user(conn, user)
+
+      {:ok, view, _html} = live(conn, ~p"/team")
+      view |> element("#add-teammate-button") |> render_click()
+
+      html =
+        view
+        |> form("#add-teammate-form", %{"add" => %{"agent_id" => narrow.id}})
+        |> render_change()
+
+      # Own environment is the blank default; only the allowlisted other one is a row.
+      assert html =~ "Agent&#39;s default (own-env)"
+      assert html =~ "allowed-env"
+      refute html =~ "other-env"
+      assert html =~ "vault-one"
+      refute html =~ "vault-two"
+    end
+
+    test "the picker without vaults or other environments shows neither select", %{conn: conn} do
+      user = insert_verified_user()
+      insert_agent(user_id: user.id, name: "Ada")
+      conn = login_user(conn, user)
+
+      {:ok, view, _html} = live(conn, ~p"/team")
+      html = view |> element("#add-teammate-button") |> render_click()
+
+      assert html =~ "add[name]"
+      refute html =~ "add[environment_id]"
+      refute html =~ "add[vault_id]"
     end
   end
 
@@ -258,13 +310,67 @@ defmodule FountainWeb.TeamLiveMutationsTest do
     view |> element("#add-teammate-button") |> render_click()
 
     view
-    |> element("button[phx-click=add_teammate][phx-value-agent_id='#{ada.id}']")
-    |> render_click()
+    |> form("#add-teammate-form", %{"add" => %{"agent_id" => ada.id}})
+    |> render_submit()
 
     assert_patch(view, ~p"/team/#{ada.id}")
     assert has_element?(view, "#teammate-#{ada.id}")
-    assert [%{agent: %{id: id}}] = Team.list_teammates(user.id)
+    assert [%{agent: %{id: id}, name: "Ada"}] = Team.list_teammates(user.id)
     assert id == ada.id
+  end
+
+  test "adding a teammate with a name, environment and vault shows the name everywhere", %{
+    conn: conn
+  } do
+    user = insert_verified_user()
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    env = insert_env(user_id: user.id, name: "staging")
+    vault = insert_vault(user_id: user.id, name: "ada-keys")
+    conn = login_user(conn, user)
+
+    {:ok, view, _html} = live(conn, ~p"/team")
+    view |> element("#add-teammate-button") |> render_click()
+
+    view
+    |> form("#add-teammate-form", %{
+      "add" => %{
+        "agent_id" => ada.id,
+        "name" => "Ada (staging)",
+        "environment_id" => env.id,
+        "vault_id" => vault.id
+      }
+    })
+    |> render_submit()
+
+    assert_patch(view, ~p"/team/#{ada.id}")
+    html = render(view)
+    assert html =~ "Ada (staging)"
+    assert html =~ "Message Ada (staging)…"
+    assert page_title(view) =~ "Ada (staging) · Team"
+
+    assert [%{conversation: conv, name: "Ada (staging)"}] = Team.list_teammates(user.id)
+    assert conv.environment_id == env.id
+    assert conv.vault_id == vault.id
+  end
+
+  test "an environment the agent may not use is refused with a flash", %{conn: conn} do
+    user = insert_verified_user()
+    env = insert_env(user_id: user.id, name: "forbidden")
+    ada = insert_agent(user_id: user.id, name: "Ada", allowed_environment_ids: [])
+    conn = login_user(conn, user)
+
+    {:ok, view, _html} = live(conn, ~p"/team")
+    view |> element("#add-teammate-button") |> render_click()
+
+    # The picker never offers it, so this is a hand-built submit — the guard
+    # is the context's, not the form's.
+    html =
+      render_submit(view, "add_teammate", %{
+        "add" => %{"agent_id" => ada.id, "environment_id" => env.id}
+      })
+
+    assert html =~ "may not use that environment"
+    assert Team.list_teammates(user.id) == []
   end
 
   test "sending a message hands it to the conversation server and clears the box", %{conn: conn} do

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -141,6 +141,14 @@ conversation and unbinds the agent's conversations from the channel; the
 rows stay in the ordinary conversation list. "Details" on a thread opens the
 full conversation view (stages, tool calls, raw output).
 
+When you add a teammate you can give it a name of its own, pick the
+environment its computer is set up from, and attach a vault. These are the
+conversation's `title`, its per-launch environment override and its
+`vault_id` — nothing new — and the environment and vault pickers only offer
+what the agent's `allowed_environment_ids` / `allowed_vault_ids` allow. They
+belong to the teammate, not the computer: a fresh conversation opened after
+the old one is terminated inherits all three.
+
 ---
 
 ## Substitution


### PR DESCRIPTION
## Summary

- The add-teammate dialog on `/team` is a form: agent, optional **name**, **environment** (agent's own by default), optional **vault**.
- No new schema: name → `conversation.title`; environment/vault → the per-launch `environment_id` override (#783) and `vault_id`. `Team.add_teammate/4` passes them to `start_or_resume_conversation`, so the same ownership + allowlist checks apply; `Team.addable_options/2` narrows the pickers to what the agent's `allowed_environment_ids` / `allowed_vault_ids` permit.
- A fresh conversation opened when the old one is past resuming now inherits title, environment and vault (previously the vault was silently dropped).
- Teammate `name` shows in roster, thread header (agent name beside it when different), composer, remove confirm, tab title.
- `start_conversation/2` accepts `title` (documented in the OpenAPI create schema); docs + changelog updated.

## Test plan

- [x] `test/fountain/team_test.exs` — attrs land on the conversation + sandbox, blanks mean defaults, allowlists gate, foreign ids read not-found, idempotent add ignores attrs, `addable_options/2`, fresh conversation inherits (proven to fail with the carry-over removed)
- [x] `test/fountain_web/live/team_live_test.exs` — picker offers only allowed env/vault, hides selects when there's nothing to pick, add via form with name/env/vault shows the name everywhere, hand-built forbidden submit flashes
- [x] credo --strict, format, dialyzer, api_spec + docs guard tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)