### PR TITLE
feat(team): schedules — a cron that runs a teammate with a prompt, in its thread or on a one-off computer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ upgrade, is in
   the agent's name beside it; a fresh conversation opened when the old one
   is past resuming inherits all three, so a teammate keeps its identity when
   its computer is replaced. `POST /api/conversations` accepts `title` too.
+- **Team schedules: a cron that runs a teammate with a prompt.** "Schedules"
+  in a `/team` thread header: a cron expression (UTC), a prompt, and where
+  it runs. By default the prompt goes into the teammate's own conversation
+  as a message from you; **Run in a one-off computer** opens a fresh
+  conversation on a new sandbox per run — same agent, environment and vault
+  as the teammate — and leaves the thread alone. Pause/resume, edit, "Run
+  now", delete; the row shows the next run, the last run (linked) and the
+  last error. Removing the teammate deletes its schedules. Under the hood a
+  `team_schedules` table (`Fountain.Team.Schedules`), a minute tick
+  (`Fountain.Workers.TeamScheduler`, Oban Cron) that claims what is due
+  with a compare-and-swap on `next_run_at` and enqueues one
+  `Fountain.Workers.TeamScheduleRun` per firing (new `schedules` queue; a
+  busy teammate is snoozed for up to 30 minutes). Audited as
+  `team.schedule.created` / `.updated` / `.deleted` / `.fired`, runs as
+  `system:team_scheduler`.
 
 - **Team page (`/team`): your agents as teammates, one conversation each,
   laid out like a messaging app.** The roster on the left, the selected

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -16,7 +16,9 @@ defmodule Fountain.Team do
 
   Removing a teammate terminates the live conversation and clears the binding
   on every conversation this agent had under it, so the rows stay in the
-  user's history (`/conversations`) but leave the team.
+  user's history (`/conversations`) but leave the team. Its schedules
+  (`Fountain.Team.Schedules` — a cron that runs the teammate with a prompt)
+  are deleted with it.
 
   A teammate can be given a name of its own, an environment and a vault when
   it is added. None of these is a new column: the name is the conversation's
@@ -220,6 +222,13 @@ defmodule Fountain.Team do
             ),
             set: [channel_id: nil]
           )
+
+        # The teammate's schedules go with it: they name this teammate, and a
+        # schedule that fires "not on the team" every morning is a defect,
+        # not a record. Covered by the membership event, not per row.
+        # ownership: the scoped get_teammate above found this agent for user_id;
+        # the delete is bounded by the same user_id + agent_id.
+        _ = Fountain.Team.Schedules._unsafe_delete_for_teammate(user_id, agent_id)
 
         record(user_id, "team.member.removed", conv, opts)
         :ok

--- a/apps/fountain/lib/fountain/team/schedule.ex
+++ b/apps/fountain/lib/fountain/team/schedule.ex
@@ -1,0 +1,116 @@
+defmodule Fountain.Team.Schedule do
+  @moduledoc """
+  A scheduled prompt for a teammate: on a cron, send `prompt` to the agent.
+
+  `one_off` decides *where* it runs. `false` (the default) sends the prompt
+  into the teammate's own conversation — the one `/team` shows — as if the
+  user had typed it, so the reply lands in the thread and the agent's
+  working memory. `true` opens a fresh conversation on a new computer for
+  each run, using the same agent, environment and vault the teammate has,
+  and leaves the teammate's thread alone; the run shows up in
+  `/conversations` like any other.
+
+  `cron` is a five-field expression in UTC (`Oban.Cron.Expression` is the
+  parser, so `@daily`-style names work too; `@reboot` does not — a schedule
+  needs a next time). `next_run_at` is derived from it and is what the
+  ticker polls; the context recomputes it whenever the cron changes or the
+  schedule is re-enabled.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Fountain.Accounts.User
+  alias Fountain.Agents.Agent
+  alias Fountain.Conversations.Conversation
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "team_schedules" do
+    field :name, :string
+    field :cron, :string
+    field :prompt, :string
+    field :one_off, :boolean, default: false
+    field :enabled, :boolean, default: true
+    field :next_run_at, :utc_datetime
+    field :last_run_at, :utc_datetime
+    field :last_error, :string
+
+    belongs_to :user, User
+    belongs_to :agent, Agent
+    belongs_to :last_conversation, Conversation
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc "The user-editable fields."
+  def changeset(schedule, attrs) do
+    schedule
+    |> cast(attrs, [:name, :cron, :prompt, :one_off, :enabled, :agent_id, :user_id])
+    |> validate_required([:cron, :prompt, :agent_id, :user_id])
+    |> update_change(:name, &blank_to_nil/1)
+    |> update_change(:cron, &String.trim/1)
+    |> validate_length(:name, max: 120)
+    |> validate_length(:prompt, min: 1, max: 20_000)
+    |> validate_cron()
+    |> foreign_key_constraint(:agent_id)
+    |> foreign_key_constraint(:user_id)
+  end
+
+  @doc "The fields a run writes; not user-editable."
+  def run_changeset(schedule, attrs) do
+    schedule
+    |> cast(attrs, [:next_run_at, :last_run_at, :last_error, :last_conversation_id])
+    |> update_change(:last_error, &truncate_error/1)
+  end
+
+  @doc """
+  Parses `cron`. `{:ok, expr}` for a usable expression, `{:error, message}`
+  for anything else — including `@reboot`, which has no next time.
+  """
+  def parse_cron(cron) when is_binary(cron) do
+    case Oban.Cron.Expression.parse(String.trim(cron)) do
+      {:ok, %{reboot?: true}} -> {:error, "@reboot is not a schedule"}
+      {:ok, expr} -> {:ok, expr}
+      {:error, %ArgumentError{message: message}} -> {:error, message}
+    end
+  end
+
+  def parse_cron(_), do: {:error, "is not a valid cron expression"}
+
+  @doc "The next time `cron` fires strictly after `from` (UTC)."
+  def next_run_at(cron, from \\ DateTime.utc_now()) do
+    with {:ok, expr} <- parse_cron(cron) do
+      case Oban.Cron.Expression.next_at(expr, from) do
+        %DateTime{} = at -> {:ok, DateTime.truncate(at, :second)}
+        :unknown -> {:error, "has no next run"}
+      end
+    end
+  end
+
+  defp validate_cron(changeset) do
+    case fetch_change(changeset, :cron) do
+      {:ok, cron} ->
+        case parse_cron(cron) do
+          {:ok, _} -> changeset
+          {:error, message} -> add_error(changeset, :cron, message)
+        end
+
+      :error ->
+        changeset
+    end
+  end
+
+  defp blank_to_nil(nil), do: nil
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  # A `:string` column; an inspected error term can be long.
+  defp truncate_error(nil), do: nil
+  defp truncate_error(msg) when is_binary(msg), do: String.slice(msg, 0, 250)
+end

--- a/apps/fountain/lib/fountain/team/schedules.ex
+++ b/apps/fountain/lib/fountain/team/schedules.ex
@@ -1,0 +1,315 @@
+defmodule Fountain.Team.Schedules do
+  @moduledoc """
+  Scheduled prompts for teammates — a cron that runs a team member with a
+  given prompt.
+
+  A schedule belongs to a teammate (a user + agent on the team) and says
+  what to send and when. Two ways to run, chosen per schedule:
+
+    * **in the teammate's conversation** (`one_off: false`) — the prompt
+      goes through `Fountain.Team.send_message/5`, so it lands in the same
+      thread `/team` shows, wakes the teammate's computer if it is parked,
+      and replaces it if it is gone, exactly as a typed message would;
+    * **on a one-off computer** (`one_off: true`) — each run opens a fresh
+      conversation with the same agent, environment and vault the teammate
+      was added with, seeded with the prompt. The teammate's own thread is
+      untouched; the run is an ordinary conversation in `/conversations`.
+
+  Firing is two Oban pieces: `Fountain.Workers.TeamScheduler` ticks every
+  minute, claims what is due (`_unsafe_claim_due/1` — a compare-and-swap on
+  `next_run_at`, so a claim happens once however many tickers run) and
+  enqueues one `Fountain.Workers.TeamScheduleRun` per claim, which calls
+  `run_schedule/2`. Everything a run leaves is on the row: `last_run_at`,
+  `last_conversation_id`, `last_error`.
+
+  Times are UTC: the app has no time-zone database, and a schedule that says
+  `0 9 * * 1-5` means 09:00 UTC. The UI says so.
+
+  Every user-facing function is tenant-scoped by `user_id`; the `_unsafe_`
+  ones are for the workers.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Fountain.{Agents, Audit, Conversations, Repo, Team}
+  alias Fountain.Team.Schedule
+
+  @actor "system:team_scheduler"
+
+  @doc "The audit actor a run fires as."
+  def actor, do: @actor
+
+  @doc "Every schedule of `user_id`, soonest next run first, agent preloaded."
+  def list_schedules(user_id) when is_binary(user_id) do
+    from(s in Schedule,
+      where: s.user_id == ^user_id,
+      order_by: [asc_nulls_last: s.next_run_at, asc: s.inserted_at],
+      preload: [:agent]
+    )
+    |> Repo.all()
+  end
+
+  @doc "The schedules of one teammate."
+  def list_schedules(user_id, agent_id) when is_binary(user_id) and is_binary(agent_id) do
+    from(s in Schedule,
+      where: s.user_id == ^user_id and s.agent_id == ^agent_id,
+      order_by: [asc_nulls_last: s.next_run_at, asc: s.inserted_at],
+      preload: [:agent]
+    )
+    |> Repo.all()
+  end
+
+  @doc "One schedule, tenant-scoped; nil when not the user's."
+  def get_schedule(id, user_id) when is_binary(id) and is_binary(user_id) do
+    Repo.one(from(s in Schedule, where: s.id == ^id and s.user_id == ^user_id, preload: [:agent]))
+  end
+
+  @doc "For the run worker, which acts as the system: no tenant scope."
+  def _unsafe_get_schedule(id) when is_binary(id) do
+    Repo.get(Schedule, id) |> Repo.preload(:agent)
+  end
+
+  @doc """
+  Create a schedule for the teammate on `attrs["agent_id"]`.
+
+  `attrs` is string-keyed: `"agent_id"`, `"cron"`, `"prompt"`, and
+  optionally `"name"`, `"one_off"`, `"enabled"`. The agent must be the
+  user's — `{:error, :not_found}` otherwise; it need not be on the team yet
+  (a one-off schedule runs without a teammate; an in-thread one fails each
+  run with "not on the team" until it is). `next_run_at` is computed here.
+  Audited as `team.schedule.created`; `opts` is attribution.
+  """
+  def create_schedule(user_id, attrs, opts \\ []) when is_binary(user_id) and is_map(attrs) do
+    with %Agents.Agent{} = agent <-
+           Agents.get_agent(attrs["agent_id"] || "", user_id) || {:error, :not_found} do
+      attrs = attrs |> Map.put("user_id", user_id) |> Map.put("agent_id", agent.id)
+
+      %Schedule{}
+      |> Schedule.changeset(attrs)
+      |> put_next_run_at()
+      |> Repo.insert()
+      |> case do
+        {:ok, schedule} ->
+          schedule = Repo.preload(schedule, :agent)
+          record("team.schedule.created", schedule, opts, describe(schedule))
+          {:ok, schedule}
+
+        {:error, _} = err ->
+          err
+      end
+    end
+  end
+
+  @doc """
+  Update a schedule's user-editable fields. A changed cron or a re-enable
+  recomputes `next_run_at` and clears `last_error`. Audited as
+  `team.schedule.updated` with the changed field names.
+  """
+  def update_schedule(%Schedule{} = schedule, attrs, opts \\ []) when is_map(attrs) do
+    changeset = Schedule.changeset(schedule, attrs)
+
+    changeset =
+      if Ecto.Changeset.changed?(changeset, :cron) or
+           Ecto.Changeset.get_change(changeset, :enabled) == true,
+         do: changeset |> put_next_run_at() |> Ecto.Changeset.put_change(:last_error, nil),
+         else: changeset
+
+    case Repo.update(changeset) do
+      {:ok, updated} ->
+        updated = Repo.preload(updated, :agent, force: true)
+
+        if changeset.changes != %{},
+          do: record("team.schedule.updated", updated, opts, Audit.changed_fields(changeset))
+
+        {:ok, updated}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc "Delete a schedule. Audited as `team.schedule.deleted`."
+  def delete_schedule(%Schedule{} = schedule, opts \\ []) do
+    with {:ok, deleted} <- Repo.delete(schedule) do
+      record("team.schedule.deleted", deleted, opts, describe(schedule))
+      {:ok, deleted}
+    end
+  end
+
+  @doc """
+  Delete every schedule of one teammate — what removing the teammate does.
+  Nothing is recorded per row: the `team.member.removed` event covers it,
+  and the schedules cannot outlive the teammate they belong to.
+  """
+  def _unsafe_delete_for_teammate(user_id, agent_id)
+      when is_binary(user_id) and is_binary(agent_id) do
+    {n, _} =
+      Repo.delete_all(
+        from(s in Schedule, where: s.user_id == ^user_id and s.agent_id == ^agent_id)
+      )
+
+    n
+  end
+
+  @doc """
+  Run the schedule now — from the worker on its cron, or from the UI's "Run
+  now". Returns `{:ok, conv}` with the conversation the prompt went to, or
+  the `Team.send_message/5` / `Conversations.start_conversation/2` error
+  unchanged (`:busy`, `:provisioning`, `:not_found`, `{:sandbox_quota_exceeded, _}`,
+  ...). Either way `last_run_at` is stamped, and `last_conversation_id` /
+  `last_error` say how it went; the caller decides whether an error is worth
+  retrying (the worker snoozes on `:busy` and `:provisioning`).
+
+  `opts` is audit attribution: `Fountain.Workers.TeamScheduleRun` passes
+  `actor: "system:team_scheduler"`, the UI passes the socket's. Recorded as
+  `team.schedule.fired` on top of the conversation events underneath.
+  """
+  def run_schedule(%Schedule{} = schedule, opts \\ []) do
+    result =
+      if schedule.one_off,
+        do: run_one_off(schedule, opts),
+        else: Team.send_message(schedule.user_id, schedule.agent_id, schedule.prompt, [], opts)
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    run_attrs =
+      case result do
+        {:ok, conv} -> %{last_run_at: now, last_conversation_id: conv.id, last_error: nil}
+        {:error, reason} -> %{last_run_at: now, last_error: describe_error(reason)}
+      end
+
+    {:ok, _} = schedule |> Schedule.run_changeset(run_attrs) |> Repo.update()
+
+    record(
+      "team.schedule.fired",
+      schedule,
+      opts,
+      Map.merge(describe(schedule), %{
+        "outcome" => if(match?({:ok, _}, result), do: "ok", else: run_attrs.last_error),
+        "conversation_id" =>
+          case result do
+            {:ok, conv} -> conv.id
+            _ -> nil
+          end
+      })
+    )
+
+    result
+  end
+
+  # A fresh conversation with what the teammate has: its agent, and the
+  # environment override and vault its current team conversation carries.
+  # Off the team, the agent's own defaults apply — that is what "same
+  # environment and vault" means when there is no teammate to copy.
+  defp run_one_off(%Schedule{} = schedule, opts) do
+    {env_id, vault_id} =
+      case Team.get_teammate(schedule.user_id, schedule.agent_id) do
+        %{conversation: conv} -> {conv.environment_id, conv.vault_id}
+        nil -> {nil, nil}
+      end
+
+    Conversations.start_conversation(
+      %{
+        "agent_id" => schedule.agent_id,
+        "user_id" => schedule.user_id,
+        "prompt" => schedule.prompt,
+        "source" => "ui",
+        "environment_id" => env_id,
+        "vault_id" => vault_id
+      },
+      opts
+    )
+  end
+
+  @doc """
+  Claim every enabled schedule due at `now`: advance its `next_run_at` past
+  `now` and return it. The advance is a compare-and-swap on the old
+  `next_run_at`, so two tickers racing on one row claim it once. Rows whose
+  cron no longer parses (it cannot — the changeset checks — but a row is
+  data) are disabled with an error rather than claimed forever.
+  """
+  def _unsafe_claim_due(now \\ DateTime.utc_now()) do
+    now = DateTime.truncate(now, :second)
+
+    from(s in Schedule,
+      where: s.enabled and not is_nil(s.next_run_at) and s.next_run_at <= ^now,
+      order_by: [asc: s.next_run_at],
+      preload: [:agent]
+    )
+    |> Repo.all()
+    |> Enum.filter(&claim(&1, now))
+  end
+
+  defp claim(%Schedule{} = schedule, now) do
+    case Schedule.next_run_at(schedule.cron, now) do
+      {:ok, next} ->
+        {n, _} =
+          Repo.update_all(
+            from(s in Schedule,
+              where: s.id == ^schedule.id and s.next_run_at == ^schedule.next_run_at
+            ),
+            set: [next_run_at: next]
+          )
+
+        n == 1
+
+      {:error, message} ->
+        {_n, _} =
+          Repo.update_all(from(s in Schedule, where: s.id == ^schedule.id),
+            set: [enabled: false, last_error: "disabled: cron #{message}"]
+          )
+
+        false
+    end
+  end
+
+  # ── helpers ───────────────────────────────────────────────────────────────
+
+  defp put_next_run_at(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+
+  defp put_next_run_at(changeset) do
+    cron = Ecto.Changeset.get_field(changeset, :cron)
+
+    case Schedule.next_run_at(cron) do
+      {:ok, next} -> Ecto.Changeset.put_change(changeset, :next_run_at, next)
+      {:error, message} -> Ecto.Changeset.add_error(changeset, :cron, message)
+    end
+  end
+
+  # What a run's failure reads as on the row and in the UI. Never the prompt.
+  def describe_error(:busy), do: "teammate was busy"
+  def describe_error(:provisioning), do: "teammate's computer was still starting"
+  def describe_error(:not_found), do: "agent is not on the team"
+  def describe_error(:subscription_required), do: "subscription inactive"
+
+  def describe_error({:sandbox_quota_exceeded, %{count: c, limit: l}}),
+    do: "sandbox quota: #{c}/#{l}"
+
+  def describe_error(%Ecto.Changeset{}), do: "could not open a conversation"
+  def describe_error(other), do: inspect(other) |> String.slice(0, 250)
+
+  # Names and shapes, never the prompt: it is the tenant's content.
+  defp describe(%Schedule{} = s) do
+    %{
+      "name" => s.name,
+      "agent_id" => s.agent_id,
+      "agent_name" => s.agent && s.agent.name,
+      "cron" => s.cron,
+      "one_off" => s.one_off,
+      "enabled" => s.enabled,
+      "prompt_bytes" => byte_size(s.prompt || "")
+    }
+  end
+
+  defp record(action, %Schedule{} = schedule, opts, metadata) do
+    Audit.record(%{
+      user_id: schedule.user_id,
+      action: action,
+      resource_type: "team_schedule",
+      resource_id: schedule.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: metadata
+    })
+  end
+end

--- a/apps/fountain/lib/fountain/workers/team_schedule_run.ex
+++ b/apps/fountain/lib/fountain/workers/team_schedule_run.ex
@@ -1,0 +1,65 @@
+defmodule Fountain.Workers.TeamScheduleRun do
+  @moduledoc """
+  One firing of one team schedule: `Fountain.Team.Schedules.run_schedule/2`
+  as a job, so it retries sensibly and never blocks the ticker.
+
+  A teammate that is busy (`:busy`) or whose computer is still starting
+  (`:provisioning`) is worth waiting for: the job snoozes and tries again,
+  for up to `@wait_for` after the scheduled time, then gives up with the
+  error on the row — the next scheduled run is a better use of the prompt
+  than a stale one delivered an hour late. Every other error is final for
+  this firing: it is on the schedule's `last_error`, and retrying `:not_found`
+  or a quota error seconds later would not change it.
+
+  Idempotent per `{schedule_id, fired_at}` — the unique clause below — so a
+  ticker that is retried cannot enqueue the same firing twice.
+  """
+
+  use Oban.Worker,
+    queue: :schedules,
+    max_attempts: 3,
+    unique: [keys: [:schedule_id, :fired_at], period: 3600]
+
+  require Logger
+
+  alias Fountain.Team.Schedules
+
+  # How long a firing waits for a busy teammate before it is dropped.
+  @wait_for 30 * 60
+  @snooze 30
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"schedule_id" => id} = args}) do
+    case Schedules._unsafe_get_schedule(id) do
+      nil ->
+        :ok
+
+      %{enabled: false} ->
+        :ok
+
+      schedule ->
+        # The schedule is the system's to run — the tenant set it up — so
+        # the actor is the worker; the row already carries the user.
+        case Schedules.run_schedule(schedule, actor: Schedules.actor()) do
+          {:ok, _conv} ->
+            :ok
+
+          {:error, reason} when reason in [:busy, :provisioning] ->
+            if stale?(args), do: :ok, else: {:snooze, @snooze}
+
+          {:error, reason} ->
+            Logger.info("team_schedule_run: #{id} did not run: #{inspect(reason)}")
+            :ok
+        end
+    end
+  end
+
+  defp stale?(%{"fired_at" => fired_at}) do
+    case DateTime.from_iso8601(fired_at) do
+      {:ok, at, _} -> DateTime.diff(DateTime.utc_now(), at, :second) > @wait_for
+      _ -> true
+    end
+  end
+
+  defp stale?(_), do: false
+end

--- a/apps/fountain/lib/fountain/workers/team_scheduler.ex
+++ b/apps/fountain/lib/fountain/workers/team_scheduler.ex
@@ -1,0 +1,37 @@
+defmodule Fountain.Workers.TeamScheduler do
+  @moduledoc """
+  The minute tick for team schedules (`Fountain.Team.Schedules`).
+
+  Runs from Oban's Cron plugin every minute — once across the cluster, since
+  the plugin elects a leader — claims what is due and enqueues one
+  `Fountain.Workers.TeamScheduleRun` per claim. The claim advances
+  `next_run_at` first, so a tick that dies after claiming loses at most the
+  runs it had claimed but not enqueued; it never fires one twice. The runs
+  are separate jobs so one slow or failing schedule cannot hold the others,
+  and so a busy teammate can be retried with a snooze.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 1
+
+  require Logger
+
+  alias Fountain.Team.Schedules
+  alias Fountain.Workers.TeamScheduleRun
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{} = job) do
+    now = job.scheduled_at || DateTime.utc_now()
+    fired_at = now |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+
+    due = Schedules._unsafe_claim_due(now)
+
+    Enum.each(due, fn schedule ->
+      %{"schedule_id" => schedule.id, "fired_at" => fired_at}
+      |> TeamScheduleRun.new()
+      |> Oban.insert()
+    end)
+
+    if due != [], do: Logger.info("team_scheduler: fired #{length(due)} schedule(s)")
+    :ok
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/team_live.ex
+++ b/apps/fountain/lib/fountain_web/live/team_live.ex
@@ -22,6 +22,7 @@ defmodule FountainWeb.TeamLive do
 
   alias Fountain.{Conversations, Team}
   alias Fountain.Conversations.{ConversationServer, LogEvent}
+  alias Fountain.Team.{Schedule, Schedules}
 
   @empty_add_form %{"agent_id" => nil, "name" => "", "environment_id" => "", "vault_id" => ""}
 
@@ -47,6 +48,10 @@ defmodule FountainWeb.TeamLive do
       |> assign(:picker_open, false)
       |> assign(:add_form, @empty_add_form)
       |> assign(:add_options, %{environments: [], vaults: []})
+      |> assign(:schedules_open, false)
+      |> assign(:schedules, [])
+      |> assign(:schedule_form, nil)
+      |> assign(:editing_schedule, nil)
 
     # `/team` with no teammate named lands on the most recently active one,
     # the way a messaging app opens on the top thread; `/team/:agent_id` is
@@ -92,6 +97,10 @@ defmodule FountainWeb.TeamLive do
     |> assign(:prompt, "")
     |> assign(:teammates, mark_read_locally(socket.assigns.teammates, conv.id))
     |> assign(:page_title, "#{teammate.name} · Team")
+    |> assign(:schedules, Schedules.list_schedules(user_id, teammate.agent.id))
+    |> assign(:schedules_open, false)
+    |> assign(:schedule_form, nil)
+    |> assign(:editing_schedule, nil)
   end
 
   defp load_turns(conv_id) do
@@ -236,7 +245,7 @@ defmodule FountainWeb.TeamLive do
   # Read-only for a lapsed subscription (#505, ADR 0006): viewing stays open,
   # the events that create spend do not. Interrupt and remove still work —
   # they stop spend.
-  @spend_events ~w(send update_prompt add_teammate open_picker)
+  @spend_events ~w(send update_prompt add_teammate open_picker run_schedule)
 
   @impl true
   def handle_event(event, _params, %{assigns: %{subscription_active: false}} = socket)
@@ -320,6 +329,112 @@ defmodule FountainWeb.TeamLive do
   end
 
   # Mobile: back from the thread to the roster.
+  # ── schedules: a cron that runs this teammate with a prompt ────────────────
+
+  def handle_event("open_schedules", _, %{assigns: %{selected: %{} = selected}} = socket) do
+    {:noreply,
+     socket
+     |> assign(:schedules, Schedules.list_schedules(socket.assigns.user_id, selected.agent.id))
+     |> assign(:schedules_open, true)
+     |> assign(:editing_schedule, nil)
+     |> assign(:schedule_form, new_schedule_form())}
+  end
+
+  def handle_event("open_schedules", _, socket), do: {:noreply, socket}
+
+  def handle_event("close_schedules", _, socket) do
+    {:noreply,
+     socket
+     |> assign(:schedules_open, false)
+     |> assign(:editing_schedule, nil)
+     |> assign(:schedule_form, nil)}
+  end
+
+  def handle_event("validate_schedule", %{"schedule" => params}, socket) do
+    base = socket.assigns.editing_schedule || %Schedule{}
+    changeset = base |> Schedule.changeset(params) |> Map.put(:action, :validate)
+    {:noreply, assign(socket, :schedule_form, to_form(changeset, as: :schedule))}
+  end
+
+  def handle_event("save_schedule", %{"schedule" => params}, socket) do
+    %{user_id: user_id, selected: selected} = socket.assigns
+    attribution = FountainWeb.Audited.attribution(socket)
+
+    result =
+      case socket.assigns.editing_schedule do
+        nil ->
+          Schedules.create_schedule(
+            user_id,
+            Map.put(params, "agent_id", selected.agent.id),
+            attribution
+          )
+
+        %Schedule{} = schedule ->
+          Schedules.update_schedule(schedule, params, attribution)
+      end
+
+    case result do
+      {:ok, _schedule} ->
+        {:noreply,
+         socket
+         |> assign(:schedules, Schedules.list_schedules(user_id, selected.agent.id))
+         |> assign(:editing_schedule, nil)
+         |> assign(:schedule_form, new_schedule_form())
+         |> put_flash(:info, "Schedule saved")}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :schedule_form, to_form(changeset, as: :schedule))}
+
+      {:error, reason} ->
+        {:noreply, flash_error(socket, reason)}
+    end
+  end
+
+  def handle_event("edit_schedule", %{"id" => id}, socket) do
+    case Schedules.get_schedule(id, socket.assigns.user_id) do
+      nil ->
+        {:noreply, socket}
+
+      schedule ->
+        {:noreply,
+         socket
+         |> assign(:editing_schedule, schedule)
+         |> assign(:schedule_form, to_form(Schedule.changeset(schedule, %{}), as: :schedule))}
+    end
+  end
+
+  def handle_event("cancel_edit_schedule", _, socket) do
+    {:noreply,
+     socket
+     |> assign(:editing_schedule, nil)
+     |> assign(:schedule_form, new_schedule_form())}
+  end
+
+  def handle_event("toggle_schedule", %{"id" => id}, socket) do
+    with_schedule(socket, id, fn schedule ->
+      Schedules.update_schedule(
+        schedule,
+        %{"enabled" => !schedule.enabled},
+        FountainWeb.Audited.attribution(socket)
+      )
+    end)
+  end
+
+  def handle_event("delete_schedule", %{"id" => id}, socket) do
+    with_schedule(socket, id, fn schedule ->
+      Schedules.delete_schedule(schedule, FountainWeb.Audited.attribution(socket))
+    end)
+  end
+
+  def handle_event("run_schedule", %{"id" => id}, socket) do
+    with_schedule(socket, id, fn schedule ->
+      case Schedules.run_schedule(schedule, FountainWeb.Audited.attribution(socket)) do
+        {:ok, conv} -> {:ok, conv}
+        {:error, _} = err -> err
+      end
+    end)
+  end
+
   def handle_event("deselect", _, socket) do
     {:noreply,
      socket
@@ -411,6 +526,61 @@ defmodule FountainWeb.TeamLive do
 
   defp keep_if_offered(id, offered) do
     if Enum.any?(offered, &(&1.id == id)), do: id, else: ""
+  end
+
+  defp new_schedule_form do
+    to_form(Schedule.changeset(%Schedule{}, %{}), as: :schedule)
+  end
+
+  # Fetch the schedule tenant-scoped, act on it, refresh the list; the
+  # teammate stays selected. A run that opened or fed a conversation also
+  # refreshes the roster, since the thread may have a new turn or a new
+  # computer.
+  defp with_schedule(socket, id, fun) do
+    %{user_id: user_id, selected: selected} = socket.assigns
+
+    case Schedules.get_schedule(id, user_id) do
+      nil ->
+        {:noreply, socket}
+
+      schedule ->
+        socket =
+          case fun.(schedule) do
+            {:ok, %Fountain.Conversations.Conversation{} = conv} ->
+              Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv.id}")
+
+              socket
+              |> put_flash(:info, "Sent — running now")
+              |> refresh_teammates()
+              |> reselect_after_run(conv)
+
+            {:ok, _} ->
+              socket
+
+            {:error, reason} ->
+              flash_error(socket, reason)
+          end
+
+        agent_id = (selected && selected.agent.id) || schedule.agent_id
+        {:noreply, assign(socket, :schedules, Schedules.list_schedules(user_id, agent_id))}
+    end
+  end
+
+  # A run into the teammate's thread may have replaced its computer; follow
+  # the current conversation the way send_message does. A one-off run is
+  # its own conversation and leaves the thread alone.
+  defp reselect_after_run(socket, conv) do
+    case socket.assigns.selected do
+      %{agent: %{id: agent_id}, conversation: %{id: prev_id}} when prev_id != conv.id ->
+        case Enum.find(socket.assigns.teammates, &(&1.agent.id == agent_id)) do
+          %{conversation: %{id: ^prev_id}} -> socket
+          nil -> socket
+          teammate -> socket |> select_teammate(teammate) |> assign(:schedules_open, true)
+        end
+
+      _ ->
+        socket
+    end
   end
 
   defp flash_error(socket, :busy),
@@ -555,7 +725,7 @@ defmodule FountainWeb.TeamLive do
         </div>
 
         <%= if @selected do %>
-          <.thread_header teammate={@selected} />
+          <.thread_header teammate={@selected} schedule_count={length(@schedules)} />
 
           <div
             id={"team-thread-#{@selected.conversation.id}"}
@@ -633,6 +803,14 @@ defmodule FountainWeb.TeamLive do
         agents={@addable_agents}
         form={@add_form}
         options={@add_options}
+      />
+      <.schedules_panel
+        :if={@schedules_open && @selected}
+        teammate={@selected}
+        schedules={@schedules}
+        form={@schedule_form}
+        editing={@editing_schedule}
+        subscription_active={@subscription_active}
       />
     </div>
     """
@@ -714,6 +892,7 @@ defmodule FountainWeb.TeamLive do
   end
 
   attr :teammate, :map, required: true
+  attr :schedule_count, :integer, default: 0
 
   defp thread_header(assigns) do
     conv = assigns.teammate.conversation
@@ -754,6 +933,15 @@ defmodule FountainWeb.TeamLive do
           class="rounded-md border border-[var(--color-border)] px-2.5 py-1 hover:bg-[var(--color-bg-2)]"
         >
           Interrupt
+        </button>
+        <button
+          id="open-schedules-button"
+          type="button"
+          phx-click="open_schedules"
+          class="rounded-md border border-[var(--color-border)] px-2.5 py-1 hover:bg-[var(--color-bg-2)]"
+          title="Scheduled prompts: run this teammate on a cron"
+        >
+          Schedules<span :if={@schedule_count > 0} class="ml-1 text-[var(--color-text-muted)]">{@schedule_count}</span>
         </button>
         <.link
           navigate={~p"/conversations/#{@conv.id}"}
@@ -961,4 +1149,281 @@ defmodule FountainWeb.TeamLive do
     </div>
     """
   end
+
+  # ── schedules panel ─────────────────────────────────────────────────────────
+
+  attr :teammate, :map, required: true
+  attr :schedules, :list, required: true
+  attr :form, :any, required: true
+  attr :editing, :any, default: nil
+  attr :subscription_active, :boolean, default: true
+
+  defp schedules_panel(assigns) do
+    ~H"""
+    <div id="team-schedules" class="relative z-50">
+      <div
+        class="fixed inset-0 bg-black/50 backdrop-blur-sm"
+        phx-click="close_schedules"
+        aria-hidden="true"
+      />
+      <div
+        class="fixed inset-0 overflow-y-auto flex items-start sm:items-center justify-center p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="team-schedules-title"
+        phx-window-keydown="close_schedules"
+        phx-key="escape"
+      >
+        <div class="relative w-full max-w-2xl rounded-xl shadow-xl bg-[var(--color-bg-1)] border border-[var(--color-border)]">
+          <div class="flex items-center justify-between px-6 py-4 border-b border-[var(--color-border)]">
+            <h2 id="team-schedules-title" class="text-base font-semibold">
+              Schedules · {@teammate.name}
+            </h2>
+            <button
+              type="button"
+              phx-click="close_schedules"
+              aria-label="Close"
+              class="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)]"
+            >
+              &times;
+            </button>
+          </div>
+
+          <div class="px-6 py-4 text-sm space-y-5 max-h-[80vh] overflow-y-auto">
+            <p class="text-[var(--color-text-secondary)]">
+              A schedule sends {@teammate.name} a prompt on a cron. By default it goes into
+              this conversation, like a message from you; a schedule set to run on a
+              <span class="font-medium">one-off computer</span>
+              opens a fresh conversation for each run instead — same agent, environment and vault —
+              and leaves this thread alone. Times are UTC.
+            </p>
+
+            <div :if={@schedules == []} class="text-[var(--color-text-muted)] italic">
+              No schedules yet.
+            </div>
+
+            <ul :if={@schedules != []} class="divide-y divide-[var(--color-border)]" role="list">
+              <li
+                :for={s <- @schedules}
+                id={"schedule-#{s.id}"}
+                class={["py-3 flex items-start justify-between gap-3", !s.enabled && "opacity-60"]}
+              >
+                <div class="min-w-0 space-y-0.5">
+                  <div class="flex items-center gap-2 min-w-0">
+                    <span class="font-medium truncate">{s.name || s.cron}</span>
+                    <span class="shrink-0 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide bg-[var(--color-bg-2)] text-[var(--color-text-secondary)]">
+                      {if s.one_off, do: "one-off computer", else: "in thread"}
+                    </span>
+                    <span
+                      :if={!s.enabled}
+                      class="shrink-0 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide bg-amber-100 text-amber-800"
+                    >
+                      paused
+                    </span>
+                  </div>
+                  <div class="text-xs text-[var(--color-text-secondary)] font-mono">{s.cron}</div>
+                  <div class="text-xs text-[var(--color-text-muted)] truncate" title={s.prompt}>
+                    {s.prompt}
+                  </div>
+                  <div class="text-xs text-[var(--color-text-muted)]">
+                    <span :if={s.enabled && s.next_run_at}>
+                      next {format_run_time(s.next_run_at)}
+                    </span>
+                    <span :if={s.last_run_at}>
+                      &middot; last {format_run_time(s.last_run_at)}
+                      <.link
+                        :if={s.last_conversation_id && is_nil(s.last_error)}
+                        navigate={~p"/conversations/#{s.last_conversation_id}"}
+                        class="underline"
+                      >
+                        view
+                      </.link>
+                      <span :if={s.last_error} class="text-rose-600">— {s.last_error}</span>
+                    </span>
+                  </div>
+                </div>
+                <div class="flex items-center gap-1.5 shrink-0 text-xs">
+                  <button
+                    :if={@subscription_active}
+                    type="button"
+                    phx-click="run_schedule"
+                    phx-value-id={s.id}
+                    phx-disable-with="…"
+                    class="rounded-md border border-[var(--color-border)] px-2 py-1 hover:bg-[var(--color-bg-2)]"
+                    title="Run this prompt now"
+                  >
+                    Run now
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="toggle_schedule"
+                    phx-value-id={s.id}
+                    class="rounded-md border border-[var(--color-border)] px-2 py-1 hover:bg-[var(--color-bg-2)]"
+                  >
+                    {if s.enabled, do: "Pause", else: "Resume"}
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="edit_schedule"
+                    phx-value-id={s.id}
+                    class="rounded-md border border-[var(--color-border)] px-2 py-1 hover:bg-[var(--color-bg-2)]"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="delete_schedule"
+                    phx-value-id={s.id}
+                    data-confirm="Delete this schedule?"
+                    class="rounded-md border border-rose-200 text-rose-700 px-2 py-1 hover:bg-rose-50"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </li>
+            </ul>
+
+            <.form
+              :if={@form}
+              for={@form}
+              id="schedule-form"
+              phx-change="validate_schedule"
+              phx-submit="save_schedule"
+              class="rounded-lg border border-[var(--color-border)] p-4 space-y-3 bg-[var(--color-bg-0)]"
+            >
+              <div class="font-medium">
+                {if @editing, do: "Edit schedule", else: "New schedule"}
+              </div>
+
+              <div class="grid sm:grid-cols-2 gap-3">
+                <label class="block">
+                  <span class="text-xs text-[var(--color-text-secondary)]">Name (optional)</span>
+                  <input
+                    type="text"
+                    name={@form[:name].name}
+                    value={@form[:name].value}
+                    placeholder="Morning standup"
+                    class="mt-1 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-1)] px-3 py-1.5 text-sm"
+                  />
+                  <.schedule_errors field={@form[:name]} />
+                </label>
+                <label class="block">
+                  <span class="text-xs text-[var(--color-text-secondary)]">
+                    Cron (UTC) — <span class="font-mono">min hour day month weekday</span>
+                  </span>
+                  <input
+                    type="text"
+                    name={@form[:cron].name}
+                    value={@form[:cron].value}
+                    list="cron-presets"
+                    placeholder="0 9 * * 1-5"
+                    required
+                    class="mt-1 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-1)] px-3 py-1.5 text-sm font-mono"
+                  />
+                  <datalist id="cron-presets">
+                    <option value="0 * * * *">every hour</option>
+                    <option value="0 9 * * *">daily at 09:00 UTC</option>
+                    <option value="0 9 * * 1-5">weekdays at 09:00 UTC</option>
+                    <option value="0 9 * * 1">Mondays at 09:00 UTC</option>
+                    <option value="0 0 1 * *">first of the month</option>
+                  </datalist>
+                  <.schedule_errors field={@form[:cron]} />
+                </label>
+              </div>
+
+              <label class="block">
+                <span class="text-xs text-[var(--color-text-secondary)]">Prompt</span>
+                <textarea
+                  name={@form[:prompt].name}
+                  rows="3"
+                  required
+                  placeholder={"What should #{@teammate.name} do each time?"}
+                  class="mt-1 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-1)] px-3 py-1.5 text-sm"
+                >{@form[:prompt].value}</textarea>
+                <.schedule_errors field={@form[:prompt]} />
+              </label>
+
+              <label class="flex items-start gap-2">
+                <input type="hidden" name={@form[:one_off].name} value="false" />
+                <input
+                  type="checkbox"
+                  name={@form[:one_off].name}
+                  value="true"
+                  checked={truthy?(@form[:one_off].value)}
+                  class="mt-0.5 rounded border-[var(--color-border)]"
+                />
+                <span>
+                  <span class="font-medium">Run in a one-off computer</span>
+                  <span class="block text-xs text-[var(--color-text-secondary)]">
+                    Each run opens a fresh conversation on a new computer with the same agent,
+                    environment and vault, instead of messaging {@teammate.name} here.
+                  </span>
+                </span>
+              </label>
+
+              <label :if={@editing} class="flex items-center gap-2">
+                <input type="hidden" name={@form[:enabled].name} value="false" />
+                <input
+                  type="checkbox"
+                  name={@form[:enabled].name}
+                  value="true"
+                  checked={truthy?(@form[:enabled].value)}
+                  class="rounded border-[var(--color-border)]"
+                />
+                <span>Enabled</span>
+              </label>
+
+              <div class="flex items-center gap-2 pt-1">
+                <button
+                  type="submit"
+                  phx-disable-with="Saving…"
+                  class="rounded-md px-3 py-1.5 text-sm font-medium bg-[var(--color-brand)] text-white hover:bg-[var(--color-brand-hover)]"
+                >
+                  {if @editing, do: "Save changes", else: "Add schedule"}
+                </button>
+                <button
+                  :if={@editing}
+                  type="button"
+                  phx-click="cancel_edit_schedule"
+                  class="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]"
+                >
+                  Cancel
+                </button>
+              </div>
+            </.form>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :field, Phoenix.HTML.FormField, required: true
+
+  defp schedule_errors(assigns) do
+    errors =
+      if Phoenix.Component.used_input?(assigns.field),
+        do: Enum.map(assigns.field.errors, &format_error/1),
+        else: []
+
+    assigns = assign(assigns, :errors, errors)
+
+    ~H"""
+    <p :for={msg <- @errors} class="mt-1 text-xs text-rose-600">{msg}</p>
+    """
+  end
+
+  # Changeset errors carry `%{count}`-style placeholders; fill them in.
+  defp format_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", to_string(value))
+    end)
+  end
+
+  defp truthy?(true), do: true
+  defp truthy?("true"), do: true
+  defp truthy?(_), do: false
+
+  defp format_run_time(%DateTime{} = dt), do: Calendar.strftime(dt, "%b %-d %H:%M UTC")
+  defp format_run_time(_), do: ""
 end

--- a/apps/fountain/priv/repo/migrations/20260818100000_create_team_schedules.exs
+++ b/apps/fountain/priv/repo/migrations/20260818100000_create_team_schedules.exs
@@ -1,0 +1,38 @@
+defmodule Fountain.Repo.Migrations.CreateTeamSchedules do
+  @moduledoc """
+  Scheduled prompts for teammates: a cron expression, a prompt, and whether
+  it runs in the teammate's own conversation or on a one-off computer.
+
+  Belongs to the user and the agent — deleting either takes the schedule
+  with it. `last_conversation_id` is a pointer to the last run's
+  conversation and only nilifies on delete; the run history is the
+  conversations themselves.
+  """
+  use Ecto.Migration
+
+  def change do
+    create table(:team_schedules, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+      add :agent_id, references(:agents, type: :binary_id, on_delete: :delete_all), null: false
+      add :name, :string
+      add :cron, :string, null: false
+      add :prompt, :text, null: false
+      add :one_off, :boolean, null: false, default: false
+      add :enabled, :boolean, null: false, default: true
+      add :next_run_at, :utc_datetime
+      add :last_run_at, :utc_datetime
+      add :last_error, :string
+
+      add :last_conversation_id,
+          references(:conversations, type: :binary_id, on_delete: :nilify_all)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:team_schedules, [:user_id])
+    create index(:team_schedules, [:agent_id])
+    # The ticker's query: enabled rows whose next run has come.
+    create index(:team_schedules, [:next_run_at], where: "enabled")
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -67,7 +67,13 @@ defmodule Fountain.AuditGuardrailTest do
     # Team membership: a teammate is a channel-bound conversation, so add also
     # leaves conversation.created underneath; these are the team-side events.
     {"team member add", &__MODULE__.do_team_add/1, "team.member.added"},
-    {"team member remove", &__MODULE__.do_team_remove/1, "team.member.removed"}
+    {"team member remove", &__MODULE__.do_team_remove/1, "team.member.removed"},
+    # Team schedules: a cron that runs a teammate with a prompt. A run leaves
+    # conversation events underneath; `.fired` is the schedule-side record.
+    {"team schedule create", &__MODULE__.do_schedule_create/1, "team.schedule.created"},
+    {"team schedule update", &__MODULE__.do_schedule_update/1, "team.schedule.updated"},
+    {"team schedule delete", &__MODULE__.do_schedule_delete/1, "team.schedule.deleted"},
+    {"team schedule run", &__MODULE__.do_schedule_run/1, "team.schedule.fired"}
   ]
 
   # Documented non-coverage. Mirrors the `Fountain.Audit` moduledoc; if the two
@@ -245,6 +251,35 @@ defmodule Fountain.AuditGuardrailTest do
     )
 
     :ok = Fountain.Team.remove_teammate(user.id, agent.id)
+  end
+
+  defp insert_schedule(user) do
+    agent = insert_agent(user_id: user.id)
+
+    {:ok, s} =
+      Fountain.Team.Schedules.create_schedule(user.id, %{
+        "agent_id" => agent.id,
+        "cron" => "0 9 * * *",
+        "prompt" => "hello"
+      })
+
+    s
+  end
+
+  def do_schedule_create(user), do: insert_schedule(user)
+
+  def do_schedule_update(user),
+    do:
+      {:ok, _} =
+        Fountain.Team.Schedules.update_schedule(insert_schedule(user), %{"cron" => "@hourly"})
+
+  def do_schedule_delete(user),
+    do: {:ok, _} = Fountain.Team.Schedules.delete_schedule(insert_schedule(user))
+
+  def do_schedule_run(user) do
+    # Off the team, so the in-thread run fails fast — the firing is what
+    # must be recorded, however it went.
+    {:error, :not_found} = Fountain.Team.Schedules.run_schedule(insert_schedule(user))
   end
 
   def do_role_change(user), do: {:ok, _} = Fountain.Accounts.update_user_role(user, "admin")

--- a/apps/fountain/test/fountain/team/schedules_test.exs
+++ b/apps/fountain/test/fountain/team/schedules_test.exs
@@ -1,0 +1,332 @@
+defmodule Fountain.Team.SchedulesTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Audit, Conversations, Team}
+  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Team.{Schedule, Schedules}
+
+  defp insert_teammate_conv(user, agent, overrides \\ %{}) do
+    insert_conversation(
+      Map.merge(
+        %{user_id: user.id, agent: agent, status: "idle", channel_id: Team.channel()},
+        Map.new(overrides)
+      )
+    )
+  end
+
+  defp inert_start_child do
+    stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+      {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+    end)
+  end
+
+  defp schedule_events(user_id) do
+    user_id
+    |> Audit.list_recent_for_user()
+    |> Enum.filter(&String.starts_with?(&1.action, "team.schedule."))
+  end
+
+  defp create!(user, agent, overrides \\ %{}) do
+    attrs =
+      Map.merge(
+        %{"agent_id" => agent.id, "cron" => "0 9 * * *", "prompt" => "standup please"},
+        Map.new(overrides)
+      )
+
+    {:ok, s} = Schedules.create_schedule(user.id, attrs)
+    s
+  end
+
+  describe "create_schedule/3" do
+    test "stores the schedule with a computed next run and records it" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id, name: "Ada")
+
+      assert {:ok, %Schedule{} = s} =
+               Schedules.create_schedule(user.id, %{
+                 "agent_id" => agent.id,
+                 "name" => "  Standup ",
+                 "cron" => " 0 9 * * 1-5 ",
+                 "prompt" => "What's on today?",
+                 "one_off" => "true"
+               })
+
+      assert s.name == "Standup"
+      assert s.cron == "0 9 * * 1-5"
+      assert s.one_off
+      assert s.enabled
+      assert %DateTime{} = s.next_run_at
+      assert DateTime.compare(s.next_run_at, DateTime.utc_now()) == :gt
+      assert s.next_run_at.hour == 9 and s.next_run_at.minute == 0
+      assert s.agent.id == agent.id
+
+      assert [%{action: "team.schedule.created", metadata: meta}] = schedule_events(user.id)
+
+      assert meta["cron"] == "0 9 * * 1-5"
+      assert meta["one_off"] == true
+      refute Map.has_key?(meta, "prompt")
+    end
+
+    test "rejects a bad cron, @reboot, and a blank prompt" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      assert {:error, cs} =
+               Schedules.create_schedule(user.id, %{
+                 "agent_id" => agent.id,
+                 "cron" => "every day",
+                 "prompt" => "x"
+               })
+
+      assert {_, _} = cs.errors[:cron]
+
+      assert {:error, cs} =
+               Schedules.create_schedule(user.id, %{
+                 "agent_id" => agent.id,
+                 "cron" => "@reboot",
+                 "prompt" => "x"
+               })
+
+      assert {"@reboot is not a schedule", _} = cs.errors[:cron]
+
+      assert {:error, cs} =
+               Schedules.create_schedule(user.id, %{
+                 "agent_id" => agent.id,
+                 "cron" => "@daily",
+                 "prompt" => ""
+               })
+
+      assert cs.errors[:prompt]
+      assert schedule_events(user.id) == []
+    end
+
+    test "refuses another tenant's agent" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      agent = insert_agent(user_id: other.id)
+
+      assert {:error, :not_found} =
+               Schedules.create_schedule(user.id, %{
+                 "agent_id" => agent.id,
+                 "cron" => "@daily",
+                 "prompt" => "x"
+               })
+    end
+  end
+
+  describe "list/get" do
+    test "tenant-scoped, and per teammate" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      linus = insert_agent(user_id: user.id)
+      s1 = create!(user, ada)
+      _s2 = create!(user, linus)
+      _s3 = create!(other, insert_agent(user_id: other.id))
+
+      assert length(Schedules.list_schedules(user.id)) == 2
+      assert [%{id: id}] = Schedules.list_schedules(user.id, ada.id)
+      assert id == s1.id
+      assert Schedules.get_schedule(s1.id, user.id).id == s1.id
+      assert Schedules.get_schedule(s1.id, other.id) == nil
+    end
+  end
+
+  describe "update_schedule/3" do
+    test "a new cron recomputes next_run_at and clears last_error; records the fields" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      s = create!(user, agent)
+
+      {:ok, s} = s |> Schedule.run_changeset(%{last_error: "boom"}) |> Repo.update()
+
+      assert {:ok, updated} = Schedules.update_schedule(s, %{"cron" => "30 14 * * *"})
+      assert updated.next_run_at.hour == 14 and updated.next_run_at.minute == 30
+      assert updated.last_error == nil
+
+      assert [%{action: "team.schedule.updated", metadata: %{"changed" => changed}} | _] =
+               schedule_events(user.id)
+
+      assert "cron" in changed
+    end
+
+    test "a no-op update records nothing" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      s = create!(user, agent)
+      before = length(schedule_events(user.id))
+
+      assert {:ok, _} = Schedules.update_schedule(s, %{"cron" => s.cron})
+      assert length(schedule_events(user.id)) == before
+    end
+  end
+
+  describe "delete_schedule/2" do
+    test "deletes and records" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      s = create!(user, agent)
+
+      assert {:ok, _} = Schedules.delete_schedule(s)
+      assert Schedules.get_schedule(s.id, user.id) == nil
+      assert [%{action: "team.schedule.deleted"} | _] = schedule_events(user.id)
+    end
+
+    test "removing the teammate takes its schedules with it" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      linus = insert_agent(user_id: user.id)
+      insert_teammate_conv(user, ada)
+      insert_teammate_conv(user, linus)
+      create!(user, ada)
+      keep = create!(user, linus)
+
+      :ok = Team.remove_teammate(user.id, ada.id)
+
+      assert [%{id: id}] = Schedules.list_schedules(user.id)
+      assert id == keep.id
+    end
+  end
+
+  describe "run_schedule/2 — in the teammate's thread" do
+    test "sends the prompt through the conversation server and stamps the row" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      conv = insert_teammate_conv(user, ada)
+      s = create!(user, ada, %{"prompt" => "standup please"})
+      test_pid = self()
+
+      stub(ConversationServer, :send_prompt, fn id, text, images, opts ->
+        send(test_pid, {:sent, id, text, images, opts[:actor]})
+        :ok
+      end)
+
+      assert {:ok, %{id: conv_id}} = Schedules.run_schedule(s, actor: Schedules.actor())
+      assert conv_id == conv.id
+      assert_received {:sent, ^conv_id, "standup please", [], "system:team_scheduler"}
+
+      s = Schedules.get_schedule(s.id, user.id)
+      assert %DateTime{} = s.last_run_at
+      assert s.last_conversation_id == conv.id
+      assert s.last_error == nil
+
+      assert Enum.any?(
+               Audit.list_recent_for_user(user.id),
+               &(&1.action == "team.schedule.fired" and &1.metadata["outcome"] == "ok" and
+                   &1.actor == "system:team_scheduler")
+             )
+    end
+
+    test "an error is returned unchanged and lands on the row" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      insert_teammate_conv(user, ada, status: "running")
+      s = create!(user, ada)
+      stub(ConversationServer, :send_prompt, fn _id, _text, _images, _opts -> {:error, :busy} end)
+
+      assert {:error, :busy} = Schedules.run_schedule(s)
+
+      s = Schedules.get_schedule(s.id, user.id)
+      assert s.last_error == "teammate was busy"
+      assert s.last_conversation_id == nil
+    end
+
+    test "an agent not on the team cannot be messaged in-thread" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      s = create!(user, ada)
+
+      assert {:error, :not_found} = Schedules.run_schedule(s)
+      assert Schedules.get_schedule(s.id, user.id).last_error == "agent is not on the team"
+    end
+  end
+
+  describe "run_schedule/2 — on a one-off computer" do
+    test "opens a fresh, unbound conversation with the teammate's environment and vault" do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id)
+      vault = insert_vault(user_id: user.id)
+      ada = insert_agent(user_id: user.id)
+      team_conv = insert_teammate_conv(user, ada, environment_id: env.id, vault_id: vault.id)
+      s = create!(user, ada, %{"one_off" => true, "prompt" => "nightly report"})
+      inert_start_child()
+
+      # The teammate's thread must not be touched.
+      stub(ConversationServer, :send_prompt, fn _, _, _, _ -> flunk("in-thread send") end)
+
+      assert {:ok, conv} = Schedules.run_schedule(s, actor: Schedules.actor())
+      refute conv.id == team_conv.id
+      assert conv.channel_id == nil
+      assert conv.agent_id == ada.id
+      assert conv.environment_id == env.id
+      assert conv.vault_id == vault.id
+      assert conv.source == "ui"
+
+      # Still one teammate, still the same thread.
+      assert [%{conversation: %{id: id}}] = Team.list_teammates(user.id)
+      assert id == team_conv.id
+
+      assert Schedules.get_schedule(s.id, user.id).last_conversation_id == conv.id
+    end
+
+    test "works off the team too, with the agent's own defaults" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      s = create!(user, ada, %{"one_off" => true})
+      inert_start_child()
+
+      assert {:ok, conv} = Schedules.run_schedule(s)
+      assert conv.environment_id == nil and conv.vault_id == nil
+      assert Team.list_teammates(user.id) == []
+    end
+  end
+
+  describe "_unsafe_claim_due/1" do
+    test "claims what is due, advances it, and skips the rest" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      due = create!(user, ada, %{"cron" => "0 9 * * *"})
+      paused = create!(user, ada, %{"cron" => "0 9 * * *"})
+      {:ok, paused} = Schedules.update_schedule(paused, %{"enabled" => false})
+      later = create!(user, ada, %{"cron" => "0 9 * * *"})
+
+      past = DateTime.utc_now() |> DateTime.add(-120, :second) |> DateTime.truncate(:second)
+
+      for s <- [due, paused] do
+        {:ok, _} = s |> Schedule.run_changeset(%{next_run_at: past}) |> Repo.update()
+      end
+
+      now = DateTime.utc_now()
+      assert [%Schedule{id: id}] = Schedules._unsafe_claim_due(now)
+      assert id == due.id
+
+      advanced = Schedules.get_schedule(due.id, user.id)
+      assert DateTime.compare(advanced.next_run_at, now) == :gt
+      assert Schedules.get_schedule(later.id, user.id).next_run_at == later.next_run_at
+      refute Schedules.get_schedule(paused.id, user.id).enabled
+
+      # Claimed once: the same tick again finds nothing.
+      assert Schedules._unsafe_claim_due(now) == []
+    end
+  end
+
+  test "deleting the agent deletes the schedule" do
+    user = insert_verified_user()
+    ada = insert_agent(user_id: user.id)
+    s = create!(user, ada)
+    {:ok, _} = Fountain.Agents.delete_agent(ada)
+    assert Schedules.get_schedule(s.id, user.id) == nil
+  end
+
+  test "Conversations still list the one-off runs" do
+    # Sanity on the shape the UI links to: the run's conversation is an
+    # ordinary row for the user.
+    user = insert_verified_user()
+    ada = insert_agent(user_id: user.id)
+    s = create!(user, ada, %{"one_off" => true})
+    inert_start_child()
+    {:ok, conv} = Schedules.run_schedule(s)
+    assert Conversations.get_conversation(conv.id, user.id)
+  end
+end

--- a/apps/fountain/test/fountain/workers/team_scheduler_test.exs
+++ b/apps/fountain/test/fountain/workers/team_scheduler_test.exs
@@ -1,0 +1,125 @@
+defmodule Fountain.Workers.TeamSchedulerTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Team
+  alias Fountain.Team.{Schedule, Schedules}
+  alias Fountain.Workers.{TeamScheduler, TeamScheduleRun}
+
+  defp create!(user, agent, overrides \\ %{}) do
+    attrs =
+      Map.merge(
+        %{"agent_id" => agent.id, "cron" => "0 9 * * *", "prompt" => "hi"},
+        Map.new(overrides)
+      )
+
+    {:ok, s} = Schedules.create_schedule(user.id, attrs)
+    s
+  end
+
+  defp make_due(schedule) do
+    past = DateTime.utc_now() |> DateTime.add(-90, :second) |> DateTime.truncate(:second)
+    {:ok, s} = schedule |> Schedule.run_changeset(%{next_run_at: past}) |> Repo.update()
+    s
+  end
+
+  describe "TeamScheduler" do
+    test "enqueues one run per due schedule and nothing for the rest" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      due = create!(user, ada) |> make_due()
+      _later = create!(user, ada)
+
+      assert :ok = perform_job(TeamScheduler, %{})
+
+      assert [job] = all_enqueued(worker: TeamScheduleRun)
+      assert job.args["schedule_id"] == due.id
+      assert is_binary(job.args["fired_at"])
+
+      # The claim advanced it, so a second tick is quiet.
+      assert :ok = perform_job(TeamScheduler, %{})
+      assert length(all_enqueued(worker: TeamScheduleRun)) == 1
+    end
+  end
+
+  describe "TeamScheduleRun" do
+    test "runs the schedule as the system" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: ada,
+          status: "idle",
+          channel_id: Team.channel()
+        )
+
+      s = create!(user, ada)
+      test_pid = self()
+
+      stub(ConversationServer, :send_prompt, fn id, _text, _images, opts ->
+        send(test_pid, {:sent, id, opts[:actor]})
+        :ok
+      end)
+
+      fired_at = DateTime.utc_now() |> DateTime.to_iso8601()
+
+      assert :ok = perform_job(TeamScheduleRun, %{"schedule_id" => s.id, "fired_at" => fired_at})
+      conv_id = conv.id
+      assert_received {:sent, ^conv_id, "system:team_scheduler"}
+    end
+
+    test "snoozes on a busy teammate, gives up once the firing is stale" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+
+      insert_conversation(
+        user_id: user.id,
+        agent: ada,
+        status: "running",
+        channel_id: Team.channel()
+      )
+
+      s = create!(user, ada)
+      stub(ConversationServer, :send_prompt, fn _, _, _, _ -> {:error, :busy} end)
+
+      fresh = DateTime.utc_now() |> DateTime.to_iso8601()
+
+      assert {:snooze, 30} =
+               perform_job(TeamScheduleRun, %{"schedule_id" => s.id, "fired_at" => fresh})
+
+      stale = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.to_iso8601()
+      assert :ok = perform_job(TeamScheduleRun, %{"schedule_id" => s.id, "fired_at" => stale})
+      assert Schedules.get_schedule(s.id, user.id).last_error == "teammate was busy"
+    end
+
+    test "a deleted or paused schedule is a no-op" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      s = create!(user, ada)
+      {:ok, s} = Schedules.update_schedule(s, %{"enabled" => false})
+      stub(ConversationServer, :send_prompt, fn _, _, _, _ -> flunk("ran a paused schedule") end)
+
+      fired_at = DateTime.utc_now() |> DateTime.to_iso8601()
+      assert :ok = perform_job(TeamScheduleRun, %{"schedule_id" => s.id, "fired_at" => fired_at})
+
+      assert :ok =
+               perform_job(TeamScheduleRun, %{
+                 "schedule_id" => Ecto.UUID.generate(),
+                 "fired_at" => fired_at
+               })
+    end
+
+    test "other errors are final for the firing and land on the row" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      s = create!(user, ada)
+
+      fired_at = DateTime.utc_now() |> DateTime.to_iso8601()
+      assert :ok = perform_job(TeamScheduleRun, %{"schedule_id" => s.id, "fired_at" => fired_at})
+      assert Schedules.get_schedule(s.id, user.id).last_error == "agent is not on the team"
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/team_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/team_live_test.exs
@@ -421,3 +421,158 @@ defmodule FountainWeb.TeamLiveMutationsTest do
     assert render(view) =~ "No one on the team yet"
   end
 end
+
+# Schedules: a cron that runs a teammate with a prompt, from the thread
+# header. Create/pause/delete need no server; "Run now" does, so this is
+# also a global-Mimic, async: false module.
+defmodule FountainWeb.TeamLiveSchedulesTest do
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Team
+  alias Fountain.Team.Schedules
+
+  setup :set_mimic_global
+
+  defp insert_teammate_conv(user, agent, overrides \\ %{}) do
+    insert_conversation(
+      Map.merge(
+        %{user_id: user.id, agent: agent, status: "idle", channel_id: Team.channel()},
+        Map.new(overrides)
+      )
+    )
+  end
+
+  defp open_panel(conn, user, agent) do
+    conn = login_user(conn, user)
+    {:ok, view, _html} = live(conn, ~p"/team/#{agent.id}")
+    view |> element("#open-schedules-button") |> render_click()
+    view
+  end
+
+  test "creating a schedule from the panel, and a bad cron is refused inline", %{conn: conn} do
+    user = insert_verified_user()
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    insert_teammate_conv(user, ada)
+
+    view = open_panel(conn, user, ada)
+    assert has_element?(view, "#team-schedules", "No schedules yet")
+
+    html =
+      view
+      |> form("#schedule-form", %{
+        "schedule" => %{"cron" => "not a cron", "prompt" => "hi", "one_off" => "false"}
+      })
+      |> render_submit()
+
+    assert html =~ "cron"
+    assert Schedules.list_schedules(user.id) == []
+
+    html =
+      view
+      |> form("#schedule-form", %{
+        "schedule" => %{
+          "name" => "Standup",
+          "cron" => "0 9 * * 1-5",
+          "prompt" => "What's on today?",
+          "one_off" => "true"
+        }
+      })
+      |> render_submit()
+
+    assert html =~ "Schedule saved"
+
+    assert [%{name: "Standup", cron: "0 9 * * 1-5", one_off: true, agent_id: agent_id}] =
+             Schedules.list_schedules(user.id)
+
+    assert agent_id == ada.id
+    assert has_element?(view, "#team-schedules li", "Standup")
+    assert has_element?(view, "#team-schedules li", "one-off computer")
+    # The header counts it.
+    assert has_element?(view, "#open-schedules-button", "1")
+  end
+
+  test "pause, edit and delete", %{conn: conn} do
+    user = insert_verified_user()
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    insert_teammate_conv(user, ada)
+
+    {:ok, s} =
+      Schedules.create_schedule(user.id, %{
+        "agent_id" => ada.id,
+        "cron" => "@hourly",
+        "prompt" => "ping"
+      })
+
+    view = open_panel(conn, user, ada)
+
+    view |> element("#schedule-#{s.id} button", "Pause") |> render_click()
+    refute Schedules.get_schedule(s.id, user.id).enabled
+    assert has_element?(view, "#schedule-#{s.id}", "paused")
+
+    view |> element("#schedule-#{s.id} button", "Edit") |> render_click()
+
+    view
+    |> form("#schedule-form", %{
+      "schedule" => %{"cron" => "30 8 * * *", "prompt" => "ping", "enabled" => "true"}
+    })
+    |> render_submit()
+
+    updated = Schedules.get_schedule(s.id, user.id)
+    assert updated.cron == "30 8 * * *" and updated.enabled
+
+    view |> element("#schedule-#{s.id} button", "Delete") |> render_click()
+    assert Schedules.list_schedules(user.id) == []
+    assert has_element?(view, "#team-schedules", "No schedules yet")
+  end
+
+  test "Run now sends the prompt into the thread", %{conn: conn} do
+    user = insert_verified_user()
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    conv = insert_teammate_conv(user, ada)
+
+    {:ok, s} =
+      Schedules.create_schedule(user.id, %{
+        "agent_id" => ada.id,
+        "cron" => "@daily",
+        "prompt" => "nightly report"
+      })
+
+    test_pid = self()
+
+    stub(ConversationServer, :send_prompt, fn id, text, _images, _opts ->
+      send(test_pid, {:sent, id, text})
+      :ok
+    end)
+
+    view = open_panel(conn, user, ada)
+    view |> element("#schedule-#{s.id} button", "Run now") |> render_click()
+
+    conv_id = conv.id
+    assert_received {:sent, ^conv_id, "nightly report"}
+    assert Schedules.get_schedule(s.id, user.id).last_conversation_id == conv.id
+    assert has_element?(view, "#schedule-#{s.id}", "last")
+  end
+
+  test "another tenant's schedule id is ignored", %{conn: conn} do
+    user = insert_verified_user()
+    other = insert_verified_user()
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    insert_teammate_conv(user, ada)
+    theirs = insert_agent(user_id: other.id)
+
+    {:ok, s} =
+      Schedules.create_schedule(other.id, %{
+        "agent_id" => theirs.id,
+        "cron" => "@daily",
+        "prompt" => "x"
+      })
+
+    view = open_panel(conn, user, ada)
+    render_click(view, "delete_schedule", %{"id" => s.id})
+    assert Schedules.get_schedule(s.id, other.id)
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,7 @@ config :fountain, Oban,
   # exports is its own queue so a user-requested data export is never stuck
   # behind a maintenance sweep; concurrency 1 because each job reads every row
   # an account owns and two at once doubles that memory.
-  queues: [maintenance: 1, billing: 5, exports: 1, mailer: 5],
+  queues: [maintenance: 1, billing: 5, exports: 1, mailer: 5, schedules: 5],
   plugins: [
     # Oban's own job-table pruning: completed jobs older than 7 days.
     {Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60},
@@ -29,7 +29,11 @@ config :fountain, Oban,
        # 48h grace inside the sweep means Stripe's webhook retries always get
        # the first shot; daily is fast enough for a backstop. The worker
        # no-ops when billing is disabled.
-       {"53 6 * * *", Fountain.Workers.TrialSweeper}
+       {"53 6 * * *", Fountain.Workers.TrialSweeper},
+       # Every minute: the tick for user-defined team schedules. Cheap — one
+       # indexed query, usually empty — and a minute is the cron grain the
+       # schedules are written in.
+       {"* * * * *", Fountain.Workers.TeamScheduler}
      ]}
   ]
 

--- a/decisions/0013-audit-trail.md
+++ b/decisions/0013-audit-trail.md
@@ -94,7 +94,8 @@ for the sandbox privilege-escalation fix make them distinguishable.
 
 `system:<worker>` names are snake_case and match the module doing the work:
 `conversation_server`, `sandbox_reaper`, `retention_pruner`, `release_task`,
-`provisioning`, `account_export`, `unverified_pruner`, `verify_lifecycle`, and
+`provisioning`, `account_export`, `unverified_pruner`, `verify_lifecycle`,
+`team_scheduler`, and
 in `ee/` the billing sources `webhook`, `stripe`, `local`, `trial_sweeper`.
 
 Two rules keep the list from fraying:

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -148,6 +148,18 @@ conversation's `title`, its per-launch environment override and its
 what the agent's `allowed_environment_ids` / `allowed_vault_ids` allow. They
 belong to the teammate, not the computer: a fresh conversation opened after
 the old one is terminated inherits all three.
+**Schedules.** "Schedules" in a thread's header sets up a cron that runs
+the teammate with a prompt — `0 9 * * 1-5` and "What's on today?", say.
+Cron times are UTC. By default the prompt goes into the teammate's own
+conversation, as if you had typed it, so the reply lands in the thread and
+the teammate's working memory. Tick **Run in a one-off computer** and each
+run opens a fresh conversation on a new sandbox instead — the same agent,
+environment and vault the teammate was added with — leaving the thread
+alone; the run shows up in the conversation list like any other, and the
+schedule keeps a link to its last one. A schedule can be paused, edited,
+run on demand ("Run now") and deleted; the last error, if a run could not
+be delivered (the teammate was busy for half an hour, the sandbox quota was
+full), shows on the schedule. Removing the teammate deletes its schedules.
 
 ---
 


### PR DESCRIPTION
## What

A **Schedules** panel in the `/team` thread header: a cron expression (UTC), a prompt, and where it runs.

- **In the thread** (default): the prompt goes into the teammate's own conversation via `Team.send_message/5`, exactly as a typed message — reply lands in the thread and the agent's working memory; wakes a parked computer, replaces a dead one.
- **Run in a one-off computer**: each run opens a fresh conversation on a new sandbox with the **same agent, environment and vault** the teammate carries, and leaves the thread alone. Shows up in `/conversations`; the schedule links to its last run.
- Pause/resume, edit, **Run now**, delete; next run, last run and last error on each row. Removing the teammate deletes its schedules; deleting the agent cascades.

## How

- `team_schedules` table + `Fountain.Team.Schedule` / `Fountain.Team.Schedules` (tenant-scoped; `next_run_at` derived with `Oban.Cron.Expression`, which is already a dep — no new deps).
- `Fountain.Workers.TeamScheduler` on the Oban Cron plugin every minute (leader-elected, once per cluster): claims due rows with a compare-and-swap on `next_run_at`, so a firing happens once however many tickers run, and enqueues one `Fountain.Workers.TeamScheduleRun` per claim (new `schedules` queue, unique per `{schedule_id, fired_at}`). A busy/provisioning teammate snoozes 30 s at a time for up to 30 min, then the firing is dropped with the error on the row; other errors are final for that firing.
- Audit: `team.schedule.created/.updated/.deleted/.fired`, runs as `system:team_scheduler` (added to ADR 0013's worker list); guardrail entries added.
- Docs: `docs/primitives.md` team section, CHANGELOG.

## Verified

- `mix precommit` green locally (2988 tests, 0 failures; credo/dialyzer/sobelow clean).
- Live in a dev server via headless Chrome: panel opens, a bad cron is refused inline (`incorrect number of fields in expression`), a valid schedule saves and lists with its next run; the Oban tick ran on schedule.

## Not in this PR (follow-ups)

- REST/CLI surface for schedules (API-parity campaign shape).
- Time zones other than UTC (no tz database in the app).
- Cron presets are a `<datalist>`, not a picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)