### PR TITLE
fix(team): a teammate keeps its agent's name — no generated summary over a team conversation's title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,15 @@ upgrade, is in
 
 ### Fixed
 
+- **Team page: a teammate stayed named after its agent, not its first
+  message.** The first turn's auto-generated conversation title (a summary
+  like "Elixir Tic Tac Toe Game Development") is what #807 shows as the
+  teammate's name when one was given — and it was being generated over team
+  conversations too, so every teammate got renamed after its first message.
+  Title generation now skips team-bound conversations (their title is only
+  ever the given name), and a migration clears the summaries already
+  stamped on them, so the roster shows the agent's name again.
+
 - **A transient sandbox-provider error no longer retires a live sandbox.**
   Both places that probe a sprite before reusing it — the reattach a
   `ConversationServer` runs when it starts against a `ready` row, and the

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2080,7 +2080,11 @@ defmodule Fountain.Conversations.ConversationServer do
     end
 
     # On the first turn, asynchronously generate a short title for the sidebar.
-    if turn.turn_number == 1 do
+    # Not for a teammate's conversation: there the title is the name the user
+    # gave the teammate when adding it (or nothing, and the agent's name
+    # shows), and a generated summary would rename the teammate on the team
+    # page after its first message (#807).
+    if turn.turn_number == 1 and conv.channel_id != Fountain.Team.channel() do
       conv_id = state.conversation_id
       creds = state.inference_credentials
 

--- a/apps/fountain/priv/repo/migrations/20260818120000_clear_generated_titles_on_team_conversations.exs
+++ b/apps/fountain/priv/repo/migrations/20260818120000_clear_generated_titles_on_team_conversations.exs
@@ -1,0 +1,21 @@
+defmodule Fountain.Repo.Migrations.ClearGeneratedTitlesOnTeamConversations do
+  @moduledoc """
+  A teammate's conversation title is the teammate's given name (#807) — but
+  until now the first turn's auto-generated summary overwrote it, so the team
+  page showed "Elixir Tic Tac Toe Game Development" where it should have
+  shown the agent. Generation is now skipped for team-bound conversations;
+  this clears what was already stamped. Every title on a team conversation at
+  this point is a generated summary: naming a teammate shipped in the same
+  hour, and no name was given through it before this migration.
+
+  Not reversible in the sense of restoring the summaries — they were never
+  wanted there.
+  """
+  use Ecto.Migration
+
+  def up do
+    execute("UPDATE conversations SET title = NULL WHERE channel_id = 'fountain:team'")
+  end
+
+  def down, do: :ok
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -575,6 +575,44 @@ defmodule Fountain.Conversations.ConversationServerTest do
       GenServer.stop(pid)
     end
 
+    test "the first turn generates a title — except on a teammate's conversation (#807)",
+         %{conv: conv, user: user, agent: agent} do
+      test = self()
+
+      Mimic.stub(Fountain.Conversations.TitleGenerator, :generate, fn prompt, _creds ->
+        send(test, {:title_requested, prompt})
+        {:ok, "A Generated Summary"}
+      end)
+
+      # An ordinary conversation: the sidebar gets a title.
+      {pid, ref} = start_with_turn(conv)
+      send(pid, {:exit, %{ref: ref}, 0})
+      _ = :sys.get_state(pid)
+      assert_receive {:title_requested, "first"}, 1_000
+      GenServer.stop(pid)
+
+      # A teammate's conversation: its title is the teammate's name, so no
+      # summary is generated over it.
+      team_sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      team_conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox_id: team_sandbox.id,
+          status: "pending",
+          channel_id: Fountain.Team.channel(),
+          title: "Ada"
+        )
+
+      {pid, ref} = start_with_turn(team_conv)
+      send(pid, {:exit, %{ref: ref}, 0})
+      _ = :sys.get_state(pid)
+      refute_receive {:title_requested, _}, 300
+      assert Conversations._unsafe_get_conversation!(team_conv.id).title == "Ada"
+      GenServer.stop(pid)
+    end
+
     test "a non-zero exit marks the turn failed but keeps the conversation usable", %{conv: conv} do
       {pid, ref} = start_with_turn(conv)
 

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -31,6 +31,7 @@ Mimic.copy(Stripe.Subscription)
 Mimic.copy(Stripe.Invoice)
 
 Mimic.copy(Fountain.Conversations.ConversationServer)
+Mimic.copy(Fountain.Conversations.TitleGenerator)
 Mimic.copy(Fountain.Conversations.Provisioning)
 Mimic.copy(Fountain.SandboxSkills)
 Mimic.copy(Fountain.Accounts)


### PR DESCRIPTION
## Problem

Since #807 the team page shows the conversation title as the teammate's name (when one was given at add time). But the first turn's `TitleGenerator` was still writing its summary over team-bound conversations, so every teammate got renamed after its first message. In prod right now: `homelab-builder` shows as "Elixir Tic Tac Toe Game Development", `philosoraptor` as "Language Processing and Assistance Capabilities", `captain-picard` as "Fountain Agents Combat Interdimensional Spaghetti".

## Fix

- `ConversationServer.kick_turn`: skip title generation when `conv.channel_id == Fountain.Team.channel()` — a team conversation's title is only ever the name the user gave the teammate.
- Migration `ClearGeneratedTitlesOnTeamConversations`: `title = NULL` on every `fountain:team` conversation. Safe: every title on one at this point is a generated summary (the naming feature shipped in the same hour and none was given through it), so the roster falls back to the agent's name.
- Test: first turn on an ordinary conversation requests a title; on a team conversation it does not and the given title survives (verified the test fails with the guard removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)