### PR TITLE
feat(api): the team over the API — /api/team, one SSE stream for the whole team, opt-in CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,6 +195,12 @@ STRIPE_PRICE_MONTHLY_CENTS=
 # own host is always included.
 # CHECK_ORIGIN_EXTRA=
 
+# Browser origins allowed to call /api with a bearer token from another site
+# (comma-separated exact origins, or *). Off when unset. This is what a
+# standalone client such as the team app needs; cookies are never allowed
+# across origins regardless.
+# API_CORS_ORIGINS=https://team.example.com
+
 # ── Clustering (multi-replica only) ──────────────────────────────────────────
 
 # DNS name polled for Erlang peer discovery — a headless service in k8s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ upgrade, is in
 
 ### Added
 
+- **The team over the API: `/api/team`, plus one SSE stream for the whole
+  team and opt-in CORS.** `GET /api/team` (roster with name, presence,
+  unread, preview), `POST /api/team` (add, with name/environment/vault),
+  `GET`/`DELETE /api/team/:agent_id`, `POST /api/team/:agent_id/messages`
+  and `GET /api/team/stream` — every teammate's events on one connection,
+  labelled with `conversation_id`/`agent_id`, plus a `team` event when the
+  roster changes so the client re-lists. Each route wraps `Fountain.Team`,
+  so a standalone client gets the `/team` page's exact semantics (idempotent
+  add, wake-or-replace on message, terminate-and-unbind on remove) rather
+  than rebuilding them over `/api/conversations`. Presence and the roster
+  preview moved into `FountainWeb.TeamPresenter`, shared by the page and the
+  JSON. `API_CORS_ORIGINS` (off by default) lets a browser client on another
+  origin call `/api` with a bearer key; cookies never cross origins.
+
 - **Team page: name a teammate, pick its environment and vault when adding
   it.** The add dialog is a small form now — agent, an optional name, the
   environment its computer is set up from (the agent's own by default) and

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -42,6 +42,21 @@ defmodule Fountain.Team do
   def channel, do: @channel
 
   @doc """
+  Subscribe the caller to `{:team_changed, user_id}`, broadcast whenever the
+  roster's membership changes — a teammate added or removed, or a fresh
+  conversation opened for one — so a client following the team knows to
+  re-list and to follow the new conversation. Per-conversation events keep
+  riding `conv:<id>`.
+  """
+  def subscribe(user_id) when is_binary(user_id),
+    do: Phoenix.PubSub.subscribe(Fountain.PubSub, topic(user_id))
+
+  defp topic(user_id), do: "team:#{user_id}"
+
+  defp broadcast_changed(user_id),
+    do: Phoenix.PubSub.broadcast(Fountain.PubSub, topic(user_id), {:team_changed, user_id})
+
+  @doc """
   One entry per agent on the team, most recently active first.
 
   Each entry is `%{agent: %Agent{}, conversation: %Conversation{}, last_turn:
@@ -123,7 +138,8 @@ defmodule Fountain.Team do
   conversation back, `attrs` ignored, and nothing is recorded, since nothing
   changed. Returns `{:ok, conv}` or the `start_conversation/2` error
   (`:not_found`, `:subscription_required`, `{:sandbox_quota_exceeded, _}`,
-  ...). `opts` is audit attribution.
+  ...). `opts` is audit attribution, plus an optional `:source` (`"ui"` or
+  `"api"`, default `"ui"`) recorded on the conversation.
   """
   def add_teammate(user_id, agent_id, attrs \\ %{}, opts \\ [])
       when is_binary(user_id) and is_binary(agent_id) and is_map(attrs) and is_list(opts) do
@@ -141,7 +157,7 @@ defmodule Fountain.Team do
       "agent_id" => agent_id,
       "user_id" => user_id,
       "channel_id" => @channel,
-      "source" => "ui",
+      "source" => Keyword.get(opts, :source, "ui"),
       "title" => blank_to_nil(attrs["name"]),
       "environment_id" => blank_to_nil(attrs["environment_id"]),
       "vault_id" => blank_to_nil(attrs["vault_id"])
@@ -150,6 +166,7 @@ defmodule Fountain.Team do
     case Conversations.start_or_resume_conversation(attrs, opts) do
       {:ok, conv, :created} ->
         record(user_id, "team.member.added", conv, opts)
+        broadcast_changed(user_id)
         {:ok, conv}
 
       {:ok, conv, :resumed} ->
@@ -231,6 +248,7 @@ defmodule Fountain.Team do
         _ = Fountain.Team.Schedules._unsafe_delete_for_teammate(user_id, agent_id)
 
         record(user_id, "team.member.removed", conv, opts)
+        broadcast_changed(user_id)
         :ok
     end
   end
@@ -273,20 +291,24 @@ defmodule Fountain.Team do
   # saying so directly keeps the intent readable. The name, environment and
   # vault are the teammate's, not the dead computer's, so they carry over.
   defp start_fresh(user_id, agent_id, %Conversation{} = prev, text, images, opts) do
-    Conversations.start_conversation(
-      %{
-        "agent_id" => agent_id,
-        "user_id" => user_id,
-        "channel_id" => @channel,
-        "source" => "ui",
-        "prompt" => text,
-        "images" => images,
-        "title" => prev.title,
-        "environment_id" => prev.environment_id,
-        "vault_id" => prev.vault_id
-      },
-      opts
-    )
+    result =
+      Conversations.start_conversation(
+        %{
+          "agent_id" => agent_id,
+          "user_id" => user_id,
+          "channel_id" => @channel,
+          "source" => Keyword.get(opts, :source, "ui"),
+          "prompt" => text,
+          "images" => images,
+          "title" => prev.title,
+          "environment_id" => prev.environment_id,
+          "vault_id" => prev.vault_id
+        },
+        opts
+      )
+
+    with {:ok, _} <- result, do: broadcast_changed(user_id)
+    result
   end
 
   @doc "Agents of `user_id` that are not on the team yet — the add picker."

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -1,0 +1,307 @@
+defmodule FountainWeb.TeamController do
+  @moduledoc """
+  The team over the API: the same roster `/team` shows, for a client that
+  is not this web app (#810).
+
+  Every action is a thin wrapper over `Fountain.Team`; nothing here decides
+  anything the LiveView does not. `stream/2` is the one addition — one SSE
+  connection carrying every teammate's events plus a `team` event when the
+  roster changes, so a client follows the whole team on a single socket
+  instead of one per conversation.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.{Conversations, Team}
+  alias Fountain.Conversations.LogEvent
+  alias FountainWeb.{Audited, Schemas}
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Team"])
+
+  operation(:index,
+    summary: "List the team",
+    description:
+      "One entry per agent on the team, most recently active first: the agent, its " <>
+        "current conversation (the newest live one, or the newest finished one when " <>
+        "none is live), presence, unread state and the roster preview. A teammate is a " <>
+        "conversation bound to the reserved channel `fountain:team`.",
+    responses: [ok: {"Team", "application/json", Schemas.TeammateListResponse}]
+  )
+
+  def index(conn, _params) do
+    render(conn, :index, teammates: Team.list_teammates(conn.assigns.current_user.id))
+  end
+
+  operation(:show,
+    summary: "Show one teammate",
+    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Teammate", "application/json", Schemas.TeammateResponse},
+      not_found: {"Not on the team", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"agent_id" => agent_id}) do
+    case Team.get_teammate(conn.assigns.current_user.id, agent_id) do
+      nil -> {:error, :not_found}
+      teammate -> render(conn, :show, teammate: teammate)
+    end
+  end
+
+  operation(:create,
+    summary: "Add an agent to the team",
+    description:
+      "Opens the agent's team conversation — which provisions its sandbox — with an " <>
+        "optional name (the conversation title), environment (provision from it instead " <>
+        "of the agent's own; must satisfy `allowed_environment_ids`) and vault (must " <>
+        "satisfy `allowed_vault_ids`). 201 with the teammate; 200 when the agent was " <>
+        "already on the team (its live conversation is returned, the attributes ignored).",
+    request_body: {"Add attributes", "application/json", Schemas.TeamAddRequest},
+    responses: [
+      created: {"Teammate", "application/json", Schemas.TeammateResponse},
+      ok: {"Teammate (already on the team)", "application/json", Schemas.TeammateResponse},
+      not_found: {"Unknown agent, environment or vault", "application/json", Schemas.Error},
+      unprocessable_entity: {"Not allowed by the agent", "application/json", Schemas.Error}
+    ]
+  )
+
+  def create(conn, %{"agent_id" => agent_id} = params) do
+    user = conn.assigns.current_user
+    already? = Team.get_teammate(user.id, agent_id) != nil
+    attrs = Map.take(params, ["name", "environment_id", "vault_id"])
+    opts = [source: "api"] ++ Audited.attribution(conn)
+
+    with {:ok, _conv} <- Team.add_teammate(user.id, agent_id, attrs, opts),
+         %{} = teammate <- Team.get_teammate(user.id, agent_id) || {:error, :not_found} do
+      conn
+      |> put_status(if(already?, do: :ok, else: :created))
+      |> render(:show, teammate: teammate)
+    end
+  end
+
+  operation(:delete,
+    summary: "Remove an agent from the team",
+    description:
+      "Terminates the live conversation (its sandbox goes with it) and unbinds every " <>
+        "conversation the agent had under the team channel; the rows stay in " <>
+        "`GET /api/conversations`.",
+    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Removed",
+      not_found: {"Not on the team", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"agent_id" => agent_id}) do
+    user = conn.assigns.current_user
+
+    with :ok <- Team.remove_teammate(user.id, agent_id, Audited.attribution(conn)) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  operation(:message,
+    summary: "Message a teammate",
+    description:
+      "A turn on the teammate's conversation. A parked or reaped sandbox wakes; a " <>
+        "conversation past resuming is replaced by a fresh one under the same binding, " <>
+        "seeded with this message, so the response names the conversation the message " <>
+        "went to. 400 `conversation_busy` while the previous turn is still running " <>
+        "(the same shape as `POST /api/conversations/:id/prompts`), 503 while the " <>
+        "computer is still starting.",
+    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    request_body: {"Message", "application/json", Schemas.TeamMessageRequest},
+    responses: [
+      accepted: {"Queued", "application/json", Schemas.TeamMessageResponse},
+      not_found: {"Not on the team", "application/json", Schemas.Error},
+      bad_request: {"A turn is still running", "application/json", Schemas.Error}
+    ]
+  )
+
+  def message(conn, %{"agent_id" => agent_id, "prompt" => prompt} = params) do
+    user = conn.assigns.current_user
+
+    with {:ok, images} <- FountainWeb.PromptImages.decode(params["images"]),
+         opts = [source: "api"] ++ Audited.attribution(conn),
+         {:ok, conv} <- Team.send_message(user.id, agent_id, prompt, images, opts) do
+      conn
+      |> put_status(:accepted)
+      |> json(%{status: "queued", conversation_id: conv.id})
+    else
+      {:error, :busy} -> {:error, "conversation_busy"}
+      {:error, _} = err -> err
+    end
+  end
+
+  # ── stream ──────────────────────────────────────────────────────────────────
+
+  operation(:stream,
+    summary: "Stream the whole team's events (SSE)",
+    description:
+      "One `text/event-stream` carrying the log events of every teammate's " <>
+        "conversation, each payload the shape of `GET /api/conversations/:id/stream` " <>
+        "plus `conversation_id` and `agent_id`. A `team` event (data `{reason: changed}`) " <>
+        "is sent when the roster changes — a teammate added or removed, or a " <>
+        "fresh conversation opened for one — and the stream follows the new " <>
+        "conversation on its own; the client re-lists. `Last-Event-ID` (a log event " <>
+        "id) replays what was missed on each teammate's conversation. Heartbeats " <>
+        "every 15s; closes after 60s idle so the client reconnects.",
+    parameters: [
+      streams: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Comma-separated stream allow-list (`stdout,stderr,acp,stage,...`)."
+      ]
+    ],
+    responses: [
+      ok: {"SSE stream", "text/event-stream", %OpenApiSpex.Schema{type: :string}}
+    ]
+  )
+
+  @default_heartbeat_ms 15_000
+  @default_idle_timeout_ms 60_000
+
+  defp heartbeat_ms,
+    do: Application.get_env(:fountain, :sse_heartbeat_ms, @default_heartbeat_ms)
+
+  defp idle_timeout_ms,
+    do: Application.get_env(:fountain, :sse_idle_timeout_ms, @default_idle_timeout_ms)
+
+  def stream(conn, params) do
+    user_id = conn.assigns.current_user.id
+    last_event_id = conn |> get_req_header("last-event-id") |> List.first() |> parse_id()
+    streams = parse_streams(params["streams"])
+
+    Team.subscribe(user_id)
+    followed = follow_team(user_id, %{})
+
+    conn =
+      conn
+      |> put_resp_header("content-type", "text/event-stream")
+      |> put_resp_header("cache-control", "no-cache")
+      |> put_resp_header("connection", "keep-alive")
+      |> send_chunked(200)
+
+    case replay(conn, followed, last_event_id, streams) do
+      {:ok, conn, last_id} ->
+        Process.send_after(self(), :heartbeat, heartbeat_ms())
+
+        sse_loop(conn, %{user_id: user_id, followed: followed, last_id: last_id, streams: streams})
+
+      {:closed, conn, _} ->
+        conn
+    end
+  end
+
+  # Subscribe to every teammate's conversation not yet followed. Returns the
+  # map conversation_id → agent_id the loop labels events with. Topics are
+  # never unsubscribed: a removed teammate's conversation stops publishing.
+  defp follow_team(user_id, followed) do
+    user_id
+    |> Team.list_teammates()
+    |> Enum.reduce(followed, fn %{conversation: conv, agent: agent}, acc ->
+      unless Map.has_key?(acc, conv.id) do
+        Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv.id}")
+      end
+
+      Map.put(acc, conv.id, agent.id)
+    end)
+  end
+
+  defp replay(conn, _followed, 0, _streams), do: {:ok, conn, 0}
+
+  defp replay(conn, followed, after_id, streams) do
+    # Ownership: `followed` came from the tenant-scoped Team.list_teammates.
+    followed
+    |> Enum.flat_map(fn {conv_id, _agent_id} ->
+      Conversations._unsafe_list_log_events(conv_id, after_id, streams: streams)
+    end)
+    |> Enum.sort_by(& &1.id)
+    |> Enum.reduce_while({:ok, conn, after_id}, fn ev, {:ok, acc, last_id} ->
+      case write_event(acc, ev, followed) do
+        {:ok, c} -> {:cont, {:ok, c, max(ev.id, last_id)}}
+        {:error, _} -> {:halt, {:closed, acc, last_id}}
+      end
+    end)
+  end
+
+  defp sse_loop(conn, state) do
+    receive do
+      {:log_event, %LogEvent{id: ev_id} = ev} when ev_id > state.last_id ->
+        if Conversations.event_in_streams?(ev, state.streams) do
+          case write_event(conn, ev, state.followed) do
+            {:ok, conn} -> sse_loop(conn, %{state | last_id: ev_id})
+            {:error, _} -> conn
+          end
+        else
+          sse_loop(conn, %{state | last_id: ev_id})
+        end
+
+      {:log_event, _stale} ->
+        sse_loop(conn, state)
+
+      {:team_changed, _} ->
+        followed = follow_team(state.user_id, state.followed)
+
+        case Plug.Conn.chunk(
+               conn,
+               "event: team\ndata: #{Jason.encode!(%{reason: "changed"})}\n\n"
+             ) do
+          {:ok, conn} -> sse_loop(conn, %{state | followed: followed})
+          {:error, _} -> conn
+        end
+
+      :heartbeat ->
+        case Plug.Conn.chunk(conn, ": heartbeat\n\n") do
+          {:ok, conn} ->
+            Process.send_after(self(), :heartbeat, heartbeat_ms())
+            sse_loop(conn, state)
+
+          {:error, _} ->
+            conn
+        end
+    after
+      idle_timeout_ms() -> conn
+    end
+  end
+
+  # Field-for-field the per-conversation stream's payload, plus the two ids a
+  # client needs to route the event to a roster row.
+  defp write_event(conn, %LogEvent{} = ev, followed) do
+    payload =
+      Jason.encode!(%{
+        conversation_id: ev.conversation_id,
+        agent_id: Map.get(followed, ev.conversation_id),
+        kind: ev.kind,
+        stream: ev.stream,
+        data: ev.data,
+        stage: ev.stage,
+        state: ev.state,
+        turn_id: ev.turn_id,
+        ts: ev.inserted_at
+      })
+
+    Plug.Conn.chunk(conn, "id: #{ev.id}\nevent: #{ev.kind}\ndata: #{payload}\n\n")
+  end
+
+  defp parse_id(nil), do: 0
+  defp parse_id(""), do: 0
+
+  defp parse_id(s) do
+    case Integer.parse(s) do
+      {n, _} -> n
+      :error -> 0
+    end
+  end
+
+  defp parse_streams(nil), do: nil
+  defp parse_streams(""), do: nil
+
+  defp parse_streams(s) when is_binary(s),
+    do: s |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+end

--- a/apps/fountain/lib/fountain_web/controllers/team_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_json.ex
@@ -1,0 +1,37 @@
+defmodule FountainWeb.TeamJSON do
+  @moduledoc false
+
+  alias FountainWeb.{AgentJSON, ConversationJSON, TeamPresenter}
+
+  def index(%{teammates: teammates}), do: %{data: Enum.map(teammates, &data/1)}
+  def show(%{teammate: teammate}), do: %{data: data(teammate)}
+
+  @doc "One roster entry: the agent, its current conversation, and what the roster line shows."
+  def data(%{agent: agent, conversation: conv, last_turn: last_turn, name: name} = teammate) do
+    %{
+      agent_id: agent.id,
+      name: name,
+      agent: AgentJSON.data(agent),
+      conversation: ConversationJSON.data(conv),
+      presence: TeamPresenter.presence(conv),
+      unread: Fountain.Conversations.unread?(conv),
+      last_turn: last_turn && turn_summary(last_turn),
+      preview: preview(TeamPresenter.preview(teammate))
+    }
+  end
+
+  defp turn_summary(turn) do
+    %{
+      id: turn.id,
+      turn_number: turn.turn_number,
+      prompt: turn.prompt,
+      status: turn.status,
+      inserted_at: turn.inserted_at
+    }
+  end
+
+  defp preview(nil), do: nil
+  defp preview(:typing), do: %{kind: "typing", text: nil}
+  defp preview({:you, text}), do: %{kind: "you", text: text}
+  defp preview({:them, text}), do: %{kind: "them", text: text}
+end

--- a/apps/fountain/lib/fountain_web/endpoint.ex
+++ b/apps/fountain/lib/fountain_web/endpoint.ex
@@ -111,6 +111,9 @@ defmodule FountainWeb.Endpoint do
   # from a trusted proxy — see the plug's moduledoc for why that check cannot be
   # left to RemoteIp.
   plug FountainWeb.Plugs.ClientIp
+  # CORS for /api, off unless API_CORS_ORIGINS is set. Before the router so a
+  # preflight from an allowed origin is answered instead of 404ing.
+  plug FountainWeb.Plugs.Cors
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 

--- a/apps/fountain/lib/fountain_web/live/team_live.ex
+++ b/apps/fountain/lib/fountain_web/live/team_live.ex
@@ -17,8 +17,8 @@ defmodule FountainWeb.TeamLive do
   """
   use FountainWeb, :live_view
 
-  import FountainWeb.ConversationsLive.Chat,
-    only: [chat_view: 1, chat_assistant_reply: 2, agent_glyph: 1]
+  import FountainWeb.ConversationsLive.Chat, only: [chat_view: 1, agent_glyph: 1]
+  alias FountainWeb.TeamPresenter
 
   alias Fountain.{Conversations, Team}
   alias Fountain.Conversations.{ConversationServer, LogEvent}
@@ -116,22 +116,7 @@ defmodule FountainWeb.TeamLive do
   defp load_teammates(user_id) do
     user_id
     |> Team.list_teammates()
-    |> Enum.map(&Map.put(&1, :preview, preview_for(&1)))
-  end
-
-  defp preview_for(%{last_turn: nil}), do: nil
-
-  defp preview_for(%{last_turn: %{status: status}}) when status in ["pending", "running"],
-    do: :typing
-
-  defp preview_for(%{last_turn: turn, conversation: conv}) do
-    # Ownership: `turn` belongs to a conversation from the scoped listing.
-    reply =
-      turn.id
-      |> Conversations._unsafe_list_turn_log_events()
-      |> chat_assistant_reply(conv.runtime)
-
-    if reply == "", do: {:you, turn.prompt}, else: {:them, reply}
+    |> Enum.map(&Map.put(&1, :preview, TeamPresenter.preview(&1)))
   end
 
   defp subscribe_teammate(%{conversation: conv}) do
@@ -621,20 +606,19 @@ defmodule FountainWeb.TeamLive do
 
   # ── presence ────────────────────────────────────────────────────────────────
 
-  # What the teammate's computer is doing, from the conversation and sandbox
-  # rows. `{label, dot_class}`.
-  defp presence(%{status: "running"}), do: {"working", "bg-emerald-500 animate-pulse"}
-  defp presence(%{status: "pending"}), do: {"starting computer", "bg-amber-400 animate-pulse"}
+  # The presence label and its dot, from the shared presenter's state.
+  defp presence(conv) do
+    %{state: state, label: label} = TeamPresenter.presence(conv)
+    {label, presence_dot(state)}
+  end
 
-  defp presence(%{status: "idle", sandbox: %{status: s}}) when s in ["ready", "starting"],
-    do: {"online", "bg-emerald-500"}
-
-  defp presence(%{status: "idle", sandbox: %{status: "suspended"}}),
-    do: {"asleep · wakes on message", "bg-zinc-400"}
-
-  defp presence(%{status: "idle"}), do: {"away · wakes on message", "bg-zinc-400"}
-  defp presence(%{status: "failed"}), do: {"offline · failed", "bg-rose-500"}
-  defp presence(_), do: {"offline · new computer on message", "bg-zinc-300"}
+  defp presence_dot("working"), do: "bg-emerald-500 animate-pulse"
+  defp presence_dot("starting"), do: "bg-amber-400 animate-pulse"
+  defp presence_dot("online"), do: "bg-emerald-500"
+  defp presence_dot("asleep"), do: "bg-zinc-400"
+  defp presence_dot("away"), do: "bg-zinc-400"
+  defp presence_dot("failed"), do: "bg-rose-500"
+  defp presence_dot(_), do: "bg-zinc-300"
 
   defp avatar_url(%{id: id, avatar_media_type: mt}) when is_binary(mt), do: "/agents/#{id}/avatar"
   defp avatar_url(_), do: nil

--- a/apps/fountain/lib/fountain_web/plugs/cors.ex
+++ b/apps/fountain/lib/fountain_web/plugs/cors.ex
@@ -1,0 +1,70 @@
+defmodule FountainWeb.Plugs.Cors do
+  @moduledoc """
+  CORS for `/api/*`, for a browser client on another origin — the standalone
+  team app (#810) is the first.
+
+  Off by default: with no configured origins the plug does nothing, and the
+  API stays same-origin + non-browser clients only, as it always was. Set
+  `API_CORS_ORIGINS` (comma-separated, exact origins such as
+  `https://team.example.com`, or `*`) to allow browsers there to call the API
+  with a bearer token. No cookies are ever allowed across origins
+  (`Access-Control-Allow-Credentials` is never sent), so a session cannot be
+  ridden from an allowed origin — only an explicitly presented API key works,
+  which is the point.
+
+  A preflight (`OPTIONS` with `Access-Control-Request-Method`) from an allowed
+  origin is answered here with 204 and never reaches the router, which would
+  otherwise 404 it before any header could be set.
+  """
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @allowed_methods "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+  @allowed_headers "authorization, content-type, last-event-id, accept"
+  @exposed_headers "retry-after, x-request-id"
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(%Plug.Conn{path_info: ["api" | _]} = conn, _opts) do
+    with [origin] <- get_req_header(conn, "origin"),
+         true <- allowed?(origin, origins()) do
+      conn = put_cors_headers(conn, origin)
+
+      if preflight?(conn) do
+        conn |> send_resp(204, "") |> halt()
+      else
+        conn
+      end
+    else
+      _ -> conn
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  defp origins, do: Application.get_env(:fountain, :api_cors_origins, [])
+
+  defp allowed?(_origin, []), do: false
+  defp allowed?(origin, allowed), do: "*" in allowed or origin in allowed
+
+  defp preflight?(%Plug.Conn{method: "OPTIONS"} = conn),
+    do: get_req_header(conn, "access-control-request-method") != []
+
+  defp preflight?(_conn), do: false
+
+  # The origin is echoed, never `*`: `*` with a bearer-token client is fine
+  # today, but echoing keeps the response cacheable per origin (`Vary`) and
+  # means a future credentialed mode does not need a rewrite.
+  defp put_cors_headers(conn, origin) do
+    conn
+    |> put_resp_header("access-control-allow-origin", origin)
+    |> put_resp_header("access-control-allow-methods", @allowed_methods)
+    |> put_resp_header("access-control-allow-headers", @allowed_headers)
+    |> put_resp_header("access-control-expose-headers", @exposed_headers)
+    |> put_resp_header("access-control-max-age", "600")
+    |> put_resp_header("vary", "origin")
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -279,6 +279,15 @@ defmodule FountainWeb.Router do
     delete "/inference-credentials/:provider", InferenceCredentialController, :delete
   end
 
+  # The team's SSE stream (#810). Declared before the JSON team routes so
+  # `/team/stream` is not swallowed by `/team/:agent_id`; no `:accepts_json`
+  # for the same reason as the conversation stream below.
+  scope "/api", FountainWeb do
+    pipe_through :api
+
+    get "/team/stream", TeamController, :stream, as: :team_stream
+  end
+
   scope "/api", FountainWeb do
     pipe_through [:accepts_json, :api]
 
@@ -306,6 +315,14 @@ defmodule FountainWeb.Router do
 
     # Bulk apply for compiled fountain.yml manifests (`fountain apply`).
     post "/apply", ApplyController, :create
+
+    # The team (#810): the roster `/team` shows, for clients that are not this
+    # web app. Every action wraps Fountain.Team.
+    get "/team", TeamController, :index
+    post "/team", TeamController, :create
+    get "/team/:agent_id", TeamController, :show
+    delete "/team/:agent_id", TeamController, :delete
+    post "/team/:agent_id/messages", TeamController, :message
 
     resources "/conversations", ConversationController, only: [:index, :show, :create, :delete] do
       post "/prompts", ConversationController, :prompt, as: :prompt

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1590,6 +1590,137 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule Teammate do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Teammate",
+      description:
+        "One agent on the team: the agent, its current team conversation (the newest " <>
+          "live one, else the newest finished one), and what the roster shows for it.",
+      type: :object,
+      properties: %{
+        agent_id: %Schema{type: :string, format: :uuid},
+        name: %Schema{
+          type: :string,
+          description:
+            "What the teammate is called: the conversation's title, else the agent's name."
+        },
+        agent: Agent,
+        conversation: Conversation,
+        presence: %Schema{
+          type: :object,
+          properties: %{
+            state: %Schema{
+              type: :string,
+              enum: ~w(working starting online asleep away failed offline)
+            },
+            label: %Schema{type: :string}
+          },
+          required: [:state, :label]
+        },
+        unread: %Schema{type: :boolean},
+        last_turn: %Schema{
+          type: :object,
+          nullable: true,
+          properties: %{
+            id: %Schema{type: :string, format: :uuid},
+            turn_number: %Schema{type: :integer},
+            prompt: %Schema{type: :string},
+            status: %Schema{type: :string},
+            inserted_at: %Schema{type: :string, format: :"date-time"}
+          }
+        },
+        preview: %Schema{
+          type: :object,
+          nullable: true,
+          description:
+            "The roster line: `you` (the last prompt, no reply yet), `them` (the last " <>
+              "reply), or `typing` (a turn is in flight). Null with no messages.",
+          properties: %{
+            kind: %Schema{type: :string, enum: ~w(you them typing)},
+            text: %Schema{type: :string, nullable: true}
+          }
+        }
+      },
+      required: [:agent_id, :name, :agent, :conversation, :presence, :unread]
+    })
+  end
+
+  item_response(TeammateResponse, of: Teammate)
+  list_response(TeammateListResponse, of: Teammate)
+
+  defmodule TeamAddRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeamAddRequest",
+      type: :object,
+      properties: %{
+        agent_id: %Schema{type: :string, format: :uuid},
+        name: %Schema{
+          type: :string,
+          nullable: true,
+          maxLength: 120,
+          description: "What to call the teammate. Blank means the agent's name."
+        },
+        environment_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Provision the teammate's computer from this environment instead of the " <>
+              "agent's own. Must satisfy the agent's allowed_environment_ids."
+        },
+        vault_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "Layer this vault's secrets on top. Must satisfy allowed_vault_ids."
+        }
+      },
+      required: [:agent_id]
+    })
+  end
+
+  defmodule TeamMessageRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeamMessageRequest",
+      type: :object,
+      properties: %{
+        prompt: %Schema{type: :string},
+        images: %Schema{type: :array, items: ImageInput, nullable: true}
+      },
+      required: [:prompt]
+    })
+  end
+
+  defmodule TeamMessageResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeamMessageResponse",
+      type: :object,
+      properties: %{
+        status: %Schema{type: :string, enum: ["queued"]},
+        conversation_id: %Schema{
+          type: :string,
+          format: :uuid,
+          description:
+            "The conversation the message went to — a fresh one when the teammate's " <>
+              "previous conversation was past resuming."
+        }
+      },
+      required: [:status, :conversation_id]
+    })
+  end
+
   defmodule Error do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1612,10 +1612,7 @@ defmodule FountainWeb.Schemas do
         presence: %Schema{
           type: :object,
           properties: %{
-            state: %Schema{
-              type: :string,
-              enum: ~w(working starting online asleep away failed offline)
-            },
+            state: %Schema{type: :string, enum: FountainWeb.TeamPresenter.presence_states()},
             label: %Schema{type: :string}
           },
           required: [:state, :label]
@@ -1639,7 +1636,7 @@ defmodule FountainWeb.Schemas do
             "The roster line: `you` (the last prompt, no reply yet), `them` (the last " <>
               "reply), or `typing` (a turn is in flight). Null with no messages.",
           properties: %{
-            kind: %Schema{type: :string, enum: ~w(you them typing)},
+            kind: %Schema{type: :string, enum: FountainWeb.TeamPresenter.preview_kinds()},
             text: %Schema{type: :string, nullable: true}
           }
         }
@@ -1708,7 +1705,7 @@ defmodule FountainWeb.Schemas do
       title: "TeamMessageResponse",
       type: :object,
       properties: %{
-        status: %Schema{type: :string, enum: ["queued"]},
+        status: %Schema{type: :string, example: "queued"},
         conversation_id: %Schema{
           type: :string,
           format: :uuid,

--- a/apps/fountain/lib/fountain_web/team_presenter.ex
+++ b/apps/fountain/lib/fountain_web/team_presenter.ex
@@ -1,0 +1,62 @@
+defmodule FountainWeb.TeamPresenter do
+  @moduledoc """
+  What a teammate looks like from the outside — presence and the roster
+  preview — computed once, for both the `/team` LiveView and `/api/team`.
+
+  Both are views over `Fountain.Team.list_teammates/1`; the presence reads
+  the conversation and sandbox rows, the preview reads the last turn's
+  events through the same parser the chat bubbles use, so the roster line
+  and the thread agree on what the teammate last said.
+  """
+
+  import FountainWeb.ConversationsLive.Chat, only: [chat_assistant_reply: 2]
+
+  alias Fountain.Conversations
+
+  @typedoc "`state` is the vocabulary a client switches on; `label` is what a human reads."
+  @type presence :: %{state: String.t(), label: String.t()}
+
+  @doc """
+  What the teammate's computer is doing, from the conversation and its
+  sandbox. States: `working`, `starting`, `online`, `asleep`, `away`,
+  `failed`, `offline`.
+  """
+  @spec presence(map()) :: presence()
+  def presence(%{status: "running"}), do: %{state: "working", label: "working"}
+
+  def presence(%{status: "pending"}),
+    do: %{state: "starting", label: "starting computer"}
+
+  def presence(%{status: "idle", sandbox: %{status: s}}) when s in ["ready", "starting"],
+    do: %{state: "online", label: "online"}
+
+  def presence(%{status: "idle", sandbox: %{status: "suspended"}}),
+    do: %{state: "asleep", label: "asleep · wakes on message"}
+
+  def presence(%{status: "idle"}), do: %{state: "away", label: "away · wakes on message"}
+  def presence(%{status: "failed"}), do: %{state: "failed", label: "offline · failed"}
+  def presence(_), do: %{state: "offline", label: "offline · new computer on message"}
+
+  @doc """
+  The roster's one-line preview of a teammate's thread: `nil` when there are
+  no messages, `:typing` while a turn is in flight, else `{:you, prompt}` or
+  `{:them, reply}` for the last turn. One query per teammate (the last
+  turn's events) — cheap for a team-sized list.
+  """
+  @spec preview(map()) :: nil | :typing | {:you | :them, String.t()}
+  def preview(%{last_turn: nil}), do: nil
+
+  def preview(%{last_turn: %{status: status}}) when status in ["pending", "running"],
+    do: :typing
+
+  def preview(%{last_turn: turn, conversation: conv}) do
+    # Ownership: `turn` belongs to a conversation from the tenant-scoped
+    # Team.list_teammates that built this entry.
+    reply =
+      turn.id
+      |> Conversations._unsafe_list_turn_log_events()
+      |> chat_assistant_reply(conv.runtime)
+
+    if reply == "", do: {:you, turn.prompt}, else: {:them, reply}
+  end
+end

--- a/apps/fountain/lib/fountain_web/team_presenter.ex
+++ b/apps/fountain/lib/fountain_web/team_presenter.ex
@@ -16,6 +16,15 @@ defmodule FountainWeb.TeamPresenter do
   @typedoc "`state` is the vocabulary a client switches on; `label` is what a human reads."
   @type presence :: %{state: String.t(), label: String.t()}
 
+  @presence_states ~w(working starting online asleep away failed offline)
+  @preview_kinds ~w(you them typing)
+
+  @doc "Every `state` `presence/1` can answer — the wire enum."
+  def presence_states, do: @presence_states
+
+  @doc "Every `kind` the JSON preview can carry — the wire enum."
+  def preview_kinds, do: @preview_kinds
+
   @doc """
   What the teammate's computer is doing, from the conversation and its
   sandbox. States: `working`, `starting`, `online`, `asleep`, `away`,

--- a/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
@@ -1,0 +1,262 @@
+defmodule FountainWeb.TeamControllerTest do
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.{Audit, Repo, Team}
+  alias Fountain.Conversations.ConversationServer
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    {:ok, user: user, raw_key: raw_key}
+  end
+
+  defp insert_teammate_conv(user, agent, overrides \\ %{}) do
+    insert_conversation(
+      Map.merge(
+        %{user_id: user.id, agent: agent, status: "idle", channel_id: Team.channel()},
+        Map.new(overrides)
+      )
+    )
+  end
+
+  defp inert_start_child do
+    stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+      {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+    end)
+  end
+
+  describe "GET /api/team" do
+    test "lists the roster with name, presence, preview and unread", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada, title: "Ada (staging)")
+      insert_turn(conv, prompt: "hello there", status: "completed")
+      # Someone else's team is not ours; an unbound conversation is not a teammate.
+      insert_teammate_conv(insert_verified_user(), insert_agent())
+      insert_conversation(user_id: user.id, agent: insert_agent(user_id: user.id))
+
+      body = conn |> authed_with_key(key) |> get("/api/team") |> json_response(200)
+
+      assert [entry] = body["data"]
+      assert entry["agent_id"] == ada.id
+      assert entry["name"] == "Ada (staging)"
+      assert entry["agent"]["name"] == "Ada"
+      assert entry["conversation"]["id"] == conv.id
+      assert entry["conversation"]["channel_id"] == "fountain:team"
+      assert entry["presence"]["state"] == "away"
+      assert entry["preview"] == %{"kind" => "you", "text" => "hello there"}
+      assert entry["last_turn"]["prompt"] == "hello there"
+      assert is_boolean(entry["unread"])
+    end
+
+    test "is empty with no team", %{conn: conn, raw_key: key} do
+      assert %{"data" => []} =
+               conn |> authed_with_key(key) |> get("/api/team") |> json_response(200)
+    end
+
+    test "401 without a key", %{conn: conn} do
+      assert conn |> get("/api/team") |> json_response(401)
+    end
+  end
+
+  describe "GET /api/team/:agent_id" do
+    test "one teammate, or 404 when the agent is not on the team", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      insert_teammate_conv(user, ada)
+      loner = insert_agent(user_id: user.id)
+
+      assert %{"data" => %{"agent_id" => id}} =
+               conn |> authed_with_key(key) |> get("/api/team/#{ada.id}") |> json_response(200)
+
+      assert id == ada.id
+      assert conn |> authed_with_key(key) |> get("/api/team/#{loner.id}") |> json_response(404)
+    end
+  end
+
+  describe "POST /api/team" do
+    test "adds the agent with a name, environment and vault; 201 with the teammate", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      env = insert_env(user_id: user.id, name: "staging")
+      vault = insert_vault(user_id: user.id)
+      inert_start_child()
+
+      resp =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/team", %{
+          agent_id: ada.id,
+          name: "Ada (staging)",
+          environment_id: env.id,
+          vault_id: vault.id
+        })
+
+      body = json_response(resp, 201)
+      assert body["data"]["name"] == "Ada (staging)"
+      assert body["data"]["conversation"]["environment_id"] == env.id
+      assert body["data"]["conversation"]["vault_id"] == vault.id
+      assert body["data"]["conversation"]["source"] == "api"
+
+      actions = user.id |> Audit.list_recent_for_user(20) |> Enum.map(& &1.action)
+      assert "team.member.added" in actions
+    end
+
+    test "200 when the agent is already on the team", %{conn: conn, user: user, raw_key: key} do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/team", %{agent_id: ada.id, name: "ignored"})
+        |> json_response(200)
+
+      assert body["data"]["conversation"]["id"] == conv.id
+      assert body["data"]["name"] == "Ada"
+    end
+
+    test "404 for another tenant's agent, environment or vault", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      other = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+
+      assert conn
+             |> authed_with_key(key)
+             |> post_json("/api/team", %{agent_id: insert_agent(user_id: other.id).id})
+             |> json_response(404)
+
+      assert %{"error" => "environment_not_found"} =
+               conn
+               |> authed_with_key(key)
+               |> post_json("/api/team", %{
+                 agent_id: ada.id,
+                 environment_id: insert_env(user_id: other.id).id
+               })
+               |> json_response(404)
+
+      assert %{"error" => "vault_not_found"} =
+               conn
+               |> authed_with_key(key)
+               |> post_json("/api/team", %{
+                 agent_id: ada.id,
+                 vault_id: insert_vault(user_id: other.id).id
+               })
+               |> json_response(404)
+    end
+
+    test "422 when the agent's allowlist forbids the environment", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      env = insert_env(user_id: user.id)
+      ada = insert_agent(user_id: user.id, allowed_environment_ids: [])
+
+      assert %{"error" => "environment_not_allowed"} =
+               conn
+               |> authed_with_key(key)
+               |> post_json("/api/team", %{agent_id: ada.id, environment_id: env.id})
+               |> json_response(422)
+
+      assert Team.list_teammates(user.id) == []
+    end
+  end
+
+  describe "DELETE /api/team/:agent_id" do
+    test "removes the teammate; 404 when not on the team", %{conn: conn, user: user, raw_key: key} do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada)
+
+      resp = conn |> authed_with_key(key) |> delete("/api/team/#{ada.id}")
+      assert response(resp, 204)
+      assert Team.list_teammates(user.id) == []
+      assert Repo.reload(conv).channel_id == nil
+
+      assert conn |> authed_with_key(key) |> delete("/api/team/#{ada.id}") |> json_response(404)
+    end
+  end
+
+  describe "POST /api/team/:agent_id/messages" do
+    test "hands the prompt to the conversation server; 202 with the conversation", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada)
+      test_pid = self()
+
+      stub(ConversationServer, :send_prompt, fn id, text, images, opts ->
+        send(test_pid, {:sent, id, text, images, opts[:actor]})
+        :ok
+      end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/team/#{ada.id}/messages", %{prompt: "hello"})
+        |> json_response(202)
+
+      assert body == %{"status" => "queued", "conversation_id" => conv.id}
+      conv_id = conv.id
+      assert_received {:sent, ^conv_id, "hello", [], "api"}
+    end
+
+    test "400 conversation_busy while the teammate is busy, 404 when not on the team", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      insert_teammate_conv(user, ada, status: "running")
+      stub(ConversationServer, :send_prompt, fn _id, _text, _images, _opts -> {:error, :busy} end)
+
+      assert %{"error" => "conversation_busy"} =
+               conn
+               |> authed_with_key(key)
+               |> post_json("/api/team/#{ada.id}/messages", %{prompt: "hurry"})
+               |> json_response(400)
+
+      loner = insert_agent(user_id: user.id)
+
+      assert conn
+             |> authed_with_key(key)
+             |> post_json("/api/team/#{loner.id}/messages", %{prompt: "hi"})
+             |> json_response(404)
+    end
+
+    test "a terminated teammate gets a fresh conversation, named in the response", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      dead = insert_teammate_conv(user, ada, status: "terminated", title: "Ada (staging)")
+      inert_start_child()
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/team/#{ada.id}/messages", %{prompt: "are you there?"})
+        |> json_response(202)
+
+      refute body["conversation_id"] == dead.id
+      assert [%{conversation: %{id: id}, name: "Ada (staging)"}] = Team.list_teammates(user.id)
+      assert id == body["conversation_id"]
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
@@ -1,0 +1,190 @@
+defmodule FountainWeb.TeamStreamTest do
+  @moduledoc """
+  `GET /api/team/stream`: every teammate's events on one connection, labelled
+  with the conversation and agent, plus the `team` event and follow-on
+  subscription when the roster changes. Same fast-loop technique as
+  `SseStreamTest`.
+  """
+
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.ConnTest, only: [build_conn: 0]
+
+  alias Fountain.Team
+
+  @endpoint FountainWeb.Endpoint
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+
+    previous = {
+      Application.get_env(:fountain, :sse_heartbeat_ms),
+      Application.get_env(:fountain, :sse_idle_timeout_ms)
+    }
+
+    on_exit(fn ->
+      {hb, idle} = previous
+
+      if hb,
+        do: Application.put_env(:fountain, :sse_heartbeat_ms, hb),
+        else: Application.delete_env(:fountain, :sse_heartbeat_ms)
+
+      if idle,
+        do: Application.put_env(:fountain, :sse_idle_timeout_ms, idle),
+        else: Application.delete_env(:fountain, :sse_idle_timeout_ms)
+    end)
+
+    Application.put_env(:fountain, :sse_heartbeat_ms, 60_000)
+    Application.put_env(:fountain, :sse_idle_timeout_ms, 800)
+
+    Ecto.Adapters.SQL.Sandbox.mode(Fountain.Repo, {:shared, self()})
+
+    {:ok, user: user, raw_key: raw_key}
+  end
+
+  defp insert_teammate_conv(user, agent, overrides \\ %{}) do
+    insert_conversation(
+      Map.merge(
+        %{user_id: user.id, agent: agent, status: "idle", channel_id: Team.channel()},
+        Map.new(overrides)
+      )
+    )
+  end
+
+  defp publish(conv, attrs) do
+    ev = insert_log_event(conv, attrs)
+    Phoenix.PubSub.broadcast(Fountain.PubSub, "conv:#{conv.id}", {:log_event, ev})
+    ev
+  end
+
+  defp stream_async(raw_key, headers \\ []) do
+    parent = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+
+      conn =
+        Enum.reduce(headers, authed_with_key(build_conn(), raw_key), fn {k, v}, c ->
+          Plug.Conn.put_req_header(c, k, v)
+        end)
+
+      Phoenix.ConnTest.dispatch(conn, @endpoint, :get, "/api/team/stream")
+    end)
+  end
+
+  test "events from every teammate arrive on one connection, labelled", %{
+    user: user,
+    raw_key: key
+  } do
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    linus = insert_agent(user_id: user.id, name: "Linus")
+    ada_conv = insert_teammate_conv(user, ada)
+    linus_conv = insert_teammate_conv(user, linus)
+    # Not on the team: must not be streamed.
+    other_conv = insert_conversation(user_id: user.id, agent: insert_agent(user_id: user.id))
+
+    task = stream_async(key)
+    Process.sleep(300)
+
+    publish(ada_conv, %{kind: "output", stream: "acp", data: "from-ada"})
+    publish(linus_conv, %{kind: "output", stream: "acp", data: "from-linus"})
+    publish(other_conv, %{kind: "output", stream: "acp", data: "not-on-team"})
+
+    conn = Task.await(task, 5_000)
+    assert conn.status == 200
+    assert Plug.Conn.get_resp_header(conn, "content-type") |> hd() =~ "text/event-stream"
+
+    body = conn.resp_body
+    assert body =~ "from-ada"
+    assert body =~ "from-linus"
+    refute body =~ "not-on-team"
+
+    # Each payload names its conversation and agent so a client can route it.
+    [ada_payload] = Regex.run(~r/data: (\{[^\n]*from-ada[^\n]*\})/, body, capture: :all_but_first)
+    decoded = Jason.decode!(ada_payload)
+    assert decoded["conversation_id"] == ada_conv.id
+    assert decoded["agent_id"] == ada.id
+    assert decoded["kind"] == "output"
+  end
+
+  test "Last-Event-ID replays what was missed across the team", %{user: user, raw_key: key} do
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    linus = insert_agent(user_id: user.id, name: "Linus")
+    ada_conv = insert_teammate_conv(user, ada)
+    linus_conv = insert_teammate_conv(user, linus)
+
+    seen = insert_log_event(ada_conv, %{kind: "output", stream: "acp", data: "already-seen"})
+    insert_log_event(linus_conv, %{kind: "output", stream: "acp", data: "missed-linus"})
+    insert_log_event(ada_conv, %{kind: "output", stream: "acp", data: "missed-ada"})
+
+    conn = stream_async(key, [{"last-event-id", to_string(seen.id)}]) |> Task.await(5_000)
+
+    refute conn.resp_body =~ "already-seen"
+    assert conn.resp_body =~ "missed-linus"
+    assert conn.resp_body =~ "missed-ada"
+  end
+
+  test "a roster change sends a `team` event and follows the new conversation", %{
+    user: user,
+    raw_key: key
+  } do
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    insert_teammate_conv(user, ada)
+    linus = insert_agent(user_id: user.id, name: "Linus")
+
+    task = stream_async(key)
+    Process.sleep(300)
+
+    # Linus joins after the stream connected: the roster broadcast makes the
+    # stream re-list and subscribe, so his first event still arrives.
+    linus_conv = insert_teammate_conv(user, linus)
+    Phoenix.PubSub.broadcast(Fountain.PubSub, "team:#{user.id}", {:team_changed, user.id})
+    Process.sleep(200)
+    publish(linus_conv, %{kind: "output", stream: "acp", data: "from-new-linus"})
+
+    conn = Task.await(task, 5_000)
+    assert conn.resp_body =~ "event: team\ndata: {\"reason\":\"changed\"}"
+    assert conn.resp_body =~ "from-new-linus"
+  end
+
+  test "Team.add_teammate and remove_teammate broadcast the roster change", %{user: user} do
+    Team.subscribe(user.id)
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    insert_teammate_conv(user, ada)
+
+    :ok = Team.remove_teammate(user.id, ada.id)
+    assert_receive {:team_changed, _}
+  end
+
+  test "the streams filter applies to replay and to the live tail", %{user: user, raw_key: key} do
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    conv = insert_teammate_conv(user, ada)
+    marker = insert_log_event(conv, %{kind: "output", stream: "stdout", data: "before"})
+    insert_log_event(conv, %{kind: "output", stream: "stdout", data: "replayed-stdout"})
+    insert_log_event(conv, %{kind: "output", stream: "acp", data: "replayed-acp"})
+
+    parent = self()
+
+    task =
+      Task.async(fn ->
+        Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+
+        build_conn()
+        |> authed_with_key(key)
+        |> Plug.Conn.put_req_header("last-event-id", to_string(marker.id))
+        |> Phoenix.ConnTest.dispatch(@endpoint, :get, "/api/team/stream?streams=acp")
+      end)
+
+    Process.sleep(300)
+    publish(conv, %{kind: "output", stream: "stdout", data: "live-stdout"})
+    publish(conv, %{kind: "output", stream: "acp", data: "live-acp"})
+
+    conn = Task.await(task, 5_000)
+    assert conn.resp_body =~ "replayed-acp"
+    assert conn.resp_body =~ "live-acp"
+    refute conn.resp_body =~ "replayed-stdout"
+    refute conn.resp_body =~ "live-stdout"
+    refute conn.resp_body =~ "before"
+  end
+end

--- a/apps/fountain/test/fountain_web/plugs/cors_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/cors_test.exs
@@ -1,0 +1,114 @@
+defmodule FountainWeb.Plugs.CorsTest do
+  use FountainWeb.ConnCase, async: false
+
+  alias FountainWeb.Plugs.Cors
+
+  setup do
+    previous = Application.get_env(:fountain, :api_cors_origins)
+
+    on_exit(fn ->
+      if previous,
+        do: Application.put_env(:fountain, :api_cors_origins, previous),
+        else: Application.delete_env(:fountain, :api_cors_origins)
+    end)
+
+    :ok
+  end
+
+  defp call(conn), do: Cors.call(conn, Cors.init([]))
+
+  test "does nothing when no origins are configured", %{conn: conn} do
+    Application.put_env(:fountain, :api_cors_origins, [])
+
+    conn =
+      conn
+      |> Map.put(:path_info, ["api", "team"])
+      |> put_req_header("origin", "https://team.example.com")
+      |> call()
+
+    assert get_resp_header(conn, "access-control-allow-origin") == []
+    refute conn.halted
+  end
+
+  test "echoes an allowed origin and never allows credentials", %{conn: conn} do
+    Application.put_env(:fountain, :api_cors_origins, ["https://team.example.com"])
+
+    conn =
+      conn
+      |> Map.put(:path_info, ["api", "team"])
+      |> put_req_header("origin", "https://team.example.com")
+      |> call()
+
+    assert get_resp_header(conn, "access-control-allow-origin") == ["https://team.example.com"]
+    assert get_resp_header(conn, "access-control-allow-credentials") == []
+    assert get_resp_header(conn, "vary") == ["origin"]
+    refute conn.halted
+  end
+
+  test "ignores an origin that is not allowed", %{conn: conn} do
+    Application.put_env(:fountain, :api_cors_origins, ["https://team.example.com"])
+
+    conn =
+      conn
+      |> Map.put(:path_info, ["api", "team"])
+      |> put_req_header("origin", "https://evil.example.com")
+      |> call()
+
+    assert get_resp_header(conn, "access-control-allow-origin") == []
+  end
+
+  test "`*` allows any origin, still by echo", %{conn: conn} do
+    Application.put_env(:fountain, :api_cors_origins, ["*"])
+
+    conn =
+      conn
+      |> Map.put(:path_info, ["api", "team"])
+      |> put_req_header("origin", "https://anywhere.example.com")
+      |> call()
+
+    assert get_resp_header(conn, "access-control-allow-origin") == [
+             "https://anywhere.example.com"
+           ]
+  end
+
+  test "answers a preflight from an allowed origin with 204 and halts", %{conn: conn} do
+    Application.put_env(:fountain, :api_cors_origins, ["https://team.example.com"])
+
+    conn =
+      %{conn | method: "OPTIONS"}
+      |> Map.put(:path_info, ["api", "team"])
+      |> put_req_header("origin", "https://team.example.com")
+      |> put_req_header("access-control-request-method", "POST")
+      |> call()
+
+    assert conn.halted
+    assert conn.status == 204
+    assert hd(get_resp_header(conn, "access-control-allow-headers")) =~ "authorization"
+    assert hd(get_resp_header(conn, "access-control-allow-headers")) =~ "last-event-id"
+  end
+
+  test "leaves non-/api paths alone", %{conn: conn} do
+    Application.put_env(:fountain, :api_cors_origins, ["*"])
+
+    conn =
+      conn
+      |> Map.put(:path_info, ["dashboard"])
+      |> put_req_header("origin", "https://team.example.com")
+      |> call()
+
+    assert get_resp_header(conn, "access-control-allow-origin") == []
+  end
+
+  test "end to end: a preflight against the endpoint is answered before auth", %{conn: conn} do
+    Application.put_env(:fountain, :api_cors_origins, ["https://team.example.com"])
+
+    conn =
+      conn
+      |> put_req_header("origin", "https://team.example.com")
+      |> put_req_header("access-control-request-method", "GET")
+      |> options("/api/team")
+
+    assert conn.status == 204
+    assert get_resp_header(conn, "access-control-allow-origin") == ["https://team.example.com"]
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -80,7 +80,10 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.ManifestResource, "kind"} => {Manifest, :kinds},
     {FountainWeb.Schemas.OnboardingResponse, "data.state"} => {Accounts, :onboarding_states},
     {FountainWeb.Schemas.Sandbox, "status"} => {Sandbox, :statuses},
-    {FountainWeb.Schemas.Turn, "status"} => {Turn, :statuses}
+    {FountainWeb.Schemas.Turn, "status"} => {Turn, :statuses},
+    {FountainWeb.Schemas.Teammate, "presence.state"} =>
+      {FountainWeb.TeamPresenter, :presence_states},
+    {FountainWeb.Schemas.Teammate, "preview.kind"} => {FountainWeb.TeamPresenter, :preview_kinds}
   }
 
   # Enums with no domain list behind them. Each entry needs a reason: the

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -936,3 +936,15 @@ if config_env() == :prod do
          System.get_env("BUZZ_ACP_BASE_URL") ||
            "http://127.0.0.1:#{System.get_env("PORT", "4000")}"
 end
+
+# ── CORS for /api ─────────────────────────────────────────────────────────
+#
+# Browser clients on other origins (the standalone team app, #809). Empty —
+# the default — leaves CORS off. See FountainWeb.Plugs.Cors. Read in every
+# env so a dev server can allow its Vite origin the same way prod does.
+config :fountain,
+       :api_cors_origins,
+       "API_CORS_ORIGINS"
+       |> System.get_env("")
+       |> String.split(",", trim: true)
+       |> Enum.map(&String.trim/1)

--- a/docs/api.md
+++ b/docs/api.md
@@ -234,6 +234,55 @@ Since sub-conversations are created over the API (`X-Fountain-Parent-Conversatio
 
 Page by passing the previous response's `meta.next_cursor` as `after`; keep going while `meta.has_more` is true. `limit` defaults to 100 and caps at 1000. The `id` is the same value the SSE route uses as `Last-Event-ID`, so a client can drain history as JSON and then attach the stream from where it left off.
 
+## Team
+
+The roster [`/team`](primitives.md#the-team-page-agents-as-teammates) shows, for
+clients that are not this web app. A teammate is a conversation bound to the
+reserved channel `fountain:team`; every route here wraps the same
+`Fountain.Team` the page uses, so a standalone client gets the page's exact
+semantics — add is idempotent, a message wakes a parked computer or opens a
+fresh conversation when the old one is past resuming, remove terminates and
+unbinds — without reimplementing them over `/api/conversations`.
+
+```
+GET    /api/team                    # roster: agent, conversation, presence, unread, preview
+POST   /api/team                    # add (agent_id; optional name, environment_id, vault_id)
+GET    /api/team/:agent_id
+DELETE /api/team/:agent_id          # remove: terminate the live conversation, unbind history
+POST   /api/team/:agent_id/messages # a turn (prompt; optional images) → {conversation_id}
+GET    /api/team/stream             # SSE: every teammate's events on one connection
+```
+
+`POST /api/team` answers `201` with the teammate, or `200` when the agent was
+already on the team (its live conversation, the attributes ignored). `name`
+becomes the conversation's `title`; `environment_id` and `vault_id` go through
+the agent's `allowed_environment_ids` / `allowed_vault_ids` exactly as on
+`POST /api/conversations` (`404` unknown or foreign, `422` not allowed).
+
+Each roster entry carries `name` (title, else the agent's name), the full
+`agent` and `conversation` objects, `presence` (`state` in `working`,
+`starting`, `online`, `asleep`, `away`, `failed`, `offline`, plus a human
+`label`), `unread`, `last_turn`, and `preview` — `{kind: "you"|"them"|"typing",
+text}` or null with no messages.
+
+`/messages` returns `202 {status: "queued", conversation_id}`; the id is the
+conversation the message went to, which is a new one when the teammate's
+previous conversation was terminated. `400 conversation_busy` while the last
+turn is still running, `503` while the computer is starting.
+
+`/stream` is one `text/event-stream` for the whole team: each event is the
+per-conversation stream's payload plus `conversation_id` and `agent_id`, so a
+client routes it to a roster row without a socket per teammate. A `team`
+event (`{"reason":"changed"}`) is sent when the roster changes — a teammate
+added or removed, or a fresh conversation opened for one — and the stream
+starts following the new conversation itself; the client re-lists. It honours
+`Last-Event-ID` (replayed across every teammate) and `?streams=`, heartbeats
+every 15 s and closes after 60 s idle so the client reconnects.
+
+Browser clients on another origin need `API_CORS_ORIGINS` set on the server
+(see [configuration](configuration.md)); a bearer key is the only credential
+that crosses origins.
+
 ## Admin
 
 For operator accounts (`role: "admin"`) holding a `full`-scoped key. Every action mirrors the admin UI, including its refusals, and records the same privilege-trail event.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,6 +118,7 @@ The identity rendered on `/terms` and `/privacy` — the operator's, not the Fou
 |---|---|---|---|
 | `TRUSTED_PROXIES` | — | behind a proxy | Comma-separated CIDRs stepped over when resolving the client IP from `X-Forwarded-For`. Without it, per-IP rate limits collapse into one bucket keyed on the proxy; over-broad, it lets a client spoof past rate limiting |
 | `CHECK_ORIGIN_EXTRA` | — | — | Comma-separated extra origins allowed to open a LiveView websocket. Your own host is always included |
+| `API_CORS_ORIGINS` | — | — | Comma-separated browser origins (or `*`) allowed to call `/api` with a bearer key from another site — what a standalone client such as the team app needs. Off when unset; cookies never cross origins regardless |
 
 ## Clustering
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -120,6 +120,12 @@ spec:
             # unverified-account pruner (#258).
             - name: UNVERIFIED_PRUNE_EXEMPT
               value: jhgaylor
+            # The standalone team app (jhgaylor/fountain-team, #810) is a
+            # static site on GitHub Pages behind jakegaylor.com; a browser
+            # there calls /api with a pasted API key. Only that origin, and
+            # only bearer keys — the plug never lets a session cookie cross.
+            - name: API_CORS_ORIGINS
+              value: https://jakegaylor.com
             # SANDBOX_IDLE_TIMEOUT_MINUTES is back at the stock 60m default.
             # The 240m override (#664) existed because idle reclaim used to
             # destroy the sandbox — and the agent's working memory — while a


### PR DESCRIPTION
Part of #810.

## Summary

- **`/api/team`**: `GET` roster (agent, conversation, presence, unread, last turn, preview), `POST` add with optional `name` / `environment_id` / `vault_id` (201, or 200 if already on the team), `GET`/`DELETE /:agent_id`, `POST /:agent_id/messages` → `202 {conversation_id}` (a fresh one when the old was past resuming). All wrap `Fountain.Team`, so remove still unbinds and `team.member.*` is still audited — neither is reachable over `/api/conversations`.
- **`GET /api/team/stream`**: one SSE connection for every teammate's events (payload + `conversation_id`, `agent_id`), a `team` event on roster changes (`Team` now broadcasts on `team:<user_id>`), `Last-Event-ID` replay across the team, `?streams=` filter. Route declared before `/team/:agent_id`.
- **`FountainWeb.TeamPresenter`**: presence + preview shared by the LiveView and the JSON.
- **`FountainWeb.Plugs.Cors`** + `API_CORS_ORIGINS` (off by default): preflight + origin echo for `/api`, never allow-credentials.
- Docs (`api.md`, `configuration.md`, `.env.example`), OpenAPI schemas, changelog.

## Test plan

- [x] `team_controller_test.exs` — roster shape/tenancy, show/404, add 201/200/404/422 + audit + source=api, delete 204/404 + unbind, messages 202/400 busy/404/fresh-conversation
- [x] `team_stream_test.exs` — multi-teammate labelled events, non-team excluded, Last-Event-ID across the team, `team` event + follow-on subscribe, broadcast from `Team`, streams filter on replay and live tail
- [x] `plugs/cors_test.exs` — off by default, echo, deny, `*`, preflight 204 + halt, non-/api untouched, end-to-end preflight before auth
- [x] existing team/live/API/spec/docs/guardrail/SSE tests, credo --strict, format, dialyzer, sobelow

🤖 Generated with [Claude Code](https://claude.com/claude-code)