### PR TITLE
fix(api): the team stream sends a first byte before anything else

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -187,6 +187,17 @@ defmodule FountainWeb.TeamController do
       |> put_resp_header("connection", "keep-alive")
       |> send_chunked(200)
 
+    # A first byte straight away. A proxy that buffers a chunked response
+    # until data flows (Cloudflare does) would otherwise hold the headers
+    # back until the first heartbeat, 15 s later, and a browser client that
+    # shows "connected" when the response opens would sit on "reconnecting"
+    # for that long on every connect.
+    conn =
+      case Plug.Conn.chunk(conn, ": connected\n\n") do
+        {:ok, conn} -> conn
+        {:error, _} -> conn
+      end
+
     case replay(conn, followed, last_event_id, streams) do
       {:ok, conn, last_id} ->
         Process.send_after(self(), :heartbeat, heartbeat_ms())

--- a/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
@@ -108,6 +108,15 @@ defmodule FountainWeb.TeamStreamTest do
     assert decoded["kind"] == "output"
   end
 
+  test "the first byte is a comment, sent before any event or heartbeat", %{
+    user: user,
+    raw_key: key
+  } do
+    insert_teammate_conv(user, insert_agent(user_id: user.id))
+    conn = stream_async(key) |> Task.await(5_000)
+    assert String.starts_with?(conn.resp_body, ": connected\n\n")
+  end
+
   test "Last-Event-ID replays what was missed across the team", %{user: user, raw_key: key} do
     ada = insert_agent(user_id: user.id, name: "Ada")
     linus = insert_agent(user_id: user.id, name: "Linus")


### PR DESCRIPTION
Part of #810. Cloudflare buffers a chunked response until data flows, so the hosted team app (jakegaylor.com/fountain-team) saw the stream open only at the first heartbeat (~15 s) and showed 'reconnecting' until then. Send a `: connected` SSE comment right after the headers. Test asserts it is the first byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)