### PR TITLE
feat(api): blocks over the API, and every conversation on one SSE stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ upgrade, is in
 
 ### Added
 
+- **Blocks over the API, and every conversation on one stream.**
+  `?blocks=true` on `GET /api/conversations/:id/events`, on its `/stream`
+  and on the new `GET /api/events/stream` adds `blocks` to each event — its
+  `data` parsed server-side into the text / thinking / tool_use /
+  tool_result / init / result / error / raw blocks a transcript renders,
+  the same parse the web UI uses (`Fountain.Conversations.Blocks`, with
+  `LegacyBlocks` moved out of the LiveView into `Fountain.Runtimes`), so a
+  client on another origin never re-implements a runtime's dialect (ADR
+  0014 applied to the wire). `GET /api/events/stream` carries every
+  unfinished conversation of the caller on one SSE connection, labelled with
+  `conversation_id`, plus a debounced `conversations` event when the list
+  changes. Groundwork for the standalone conversation UI (#813).
+
 - **The team over the API: `/api/team`, plus one SSE stream for the whole
   team and opt-in CORS.** `GET /api/team` (roster with name, presence,
   unread, preview), `POST /api/team` (add, with name/environment/vault),

--- a/apps/fountain/lib/fountain/conversations/blocks.ex
+++ b/apps/fountain/lib/fountain/conversations/blocks.ex
@@ -1,0 +1,73 @@
+defmodule Fountain.Conversations.Blocks do
+  @moduledoc """
+  A log event's `data`, as the structured blocks a client renders — the one
+  seam between what the runtime wrote and what a transcript shows.
+
+  Keyed on the event's *stream*, not the conversation's runtime: the `acp`
+  stream is parsed by `Fountain.Runtimes.ACP.Blocks`, the legacy `stdout`
+  dialects by `Fountain.Runtimes.LegacyBlocks` for the runtime that wrote
+  them. The per-agent ACP flag can flip between turns, and the turns before
+  it flipped must keep rendering through the parser that produced them
+  (0014, #642).
+
+  This used to live in the LiveView (`ConversationsLive.Chat.blocks_for/2`).
+  It moved here so the API can serve blocks too (`?blocks=true` on
+  `/events` and the streams) and a client on another origin never re-parses a
+  vendor dialect — ADR 0014's principle applied to the wire, not just to the
+  render path.
+
+  ## Block shapes
+
+  Maps with a `:kind` atom; the rest is per kind. `to_json/1` is the wire
+  form: `kind` as a string, `error?` as `error`, nothing else renamed.
+
+  | kind | fields |
+  |---|---|
+  | `:text`, `:thinking` | `body` |
+  | `:tool_use` | `id`, `name`, `summary`, `body` (the input) |
+  | `:tool_result` | `tool_id`, `body`, `error?` |
+  | `:init` | `summary`, `body` |
+  | `:result` | `body`, `raw` |
+  | `:error` | `body` |
+  | `:raw` | `body`, `summary` |
+
+  A `tool_result` is paired to its `tool_use` on `tool_id`; that is the
+  client's pass (`pair_tool_results` in the LiveView, the same in the SPA),
+  because the two arrive as separate events.
+  """
+
+  alias Fountain.Runtimes.{ACP, LegacyBlocks}
+
+  @kinds ~w(text thinking tool_use tool_result init result error raw)
+
+  @doc "Every `kind` a block can have — the wire enum."
+  def kinds, do: @kinds
+
+  @doc "The blocks one log event's data holds, for `runtime`'s dialect when it is a legacy stdout row."
+  @spec for_event(map(), String.t() | nil) :: [map()]
+  def for_event(%{stream: "acp", data: data}, _runtime) when is_binary(data) do
+    data
+    |> String.split("\n", trim: true)
+    |> Enum.flat_map(&ACP.Blocks.from_line/1)
+  end
+
+  def for_event(%{data: data}, runtime) when is_binary(data) do
+    data
+    |> String.split("\n", trim: true)
+    |> Enum.flat_map(&LegacyBlocks.from_line(&1, runtime))
+  end
+
+  def for_event(_, _), do: []
+
+  @doc "The wire form of a block: string `kind`, `error` for `error?`, everything else as is."
+  @spec to_json(map()) :: map()
+  def to_json(%{kind: kind} = block) do
+    block
+    |> Map.new(fn
+      {:kind, k} -> {"kind", Atom.to_string(k)}
+      {:error?, v} -> {"error", v}
+      {k, v} -> {Atom.to_string(k), v}
+    end)
+    |> Map.put("kind", Atom.to_string(kind))
+  end
+end

--- a/apps/fountain/lib/fountain/runtimes/legacy_blocks.ex
+++ b/apps/fountain/lib/fountain/runtimes/legacy_blocks.ex
@@ -1,4 +1,4 @@
-defmodule FountainWeb.ConversationsLive.LegacyBlocks do
+defmodule Fountain.Runtimes.LegacyBlocks do
   @moduledoc """
   Translate stored legacy-dialect stdout lines into the block maps the
   conversation view renders.

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -164,6 +164,16 @@ defmodule FountainWeb.ConversationController do
         type: :integer,
         required: false,
         description: "Page size, 1..#{@max_event_limit}. Defaults to #{@default_event_limit}."
+      ],
+      blocks: [
+        in: :query,
+        type: :boolean,
+        required: false,
+        description:
+          "Add `blocks` to each event: its `data` parsed server-side into the " <>
+            "structured blocks a transcript renders (text, thinking, tool_use, " <>
+            "tool_result, init, result, error, raw) — the same parse the web UI uses, " <>
+            "so no client re-implements a runtime's dialect. Defaults to false."
       ]
     ],
     responses: [
@@ -179,10 +189,11 @@ defmodule FountainWeb.ConversationController do
       nil ->
         {:error, :not_found}
 
-      _ ->
+      conv ->
         limit = parse_limit(params["limit"])
         after_id = parse_after(params["after"])
         streams = parse_streams_param(params["streams"])
+        blocks_runtime = if parse_bool_param(params["blocks"], false), do: conv.runtime
 
         # Ownership: established by the scoped get_conversation above.
         # One extra row decides has_more without a second count query.
@@ -194,7 +205,12 @@ defmodule FountainWeb.ConversationController do
 
         {page, has_more?} = split_page(events, limit)
 
-        render(conn, :events, events: page, has_more: has_more?, limit: limit)
+        render(conn, :events,
+          events: page,
+          has_more: has_more?,
+          limit: limit,
+          blocks_runtime: blocks_runtime
+        )
     end
   end
 
@@ -502,6 +518,15 @@ defmodule FountainWeb.ConversationController do
           "`false`/`0` drains the buffered events and closes immediately, " <>
             "rather than holding the connection open for the live tail. " <>
             "Defaults to true."
+      ],
+      blocks: [
+        in: :query,
+        type: :boolean,
+        required: false,
+        description:
+          "Add `blocks` to each event payload — its `data` parsed server-side into " <>
+            "the structured blocks a transcript renders, as on `/events?blocks=true`. " <>
+            "Defaults to false."
       ]
     ],
     responses: [
@@ -529,7 +554,7 @@ defmodule FountainWeb.ConversationController do
       nil ->
         {:error, :not_found}
 
-      _ ->
+      conv ->
         last_event_id =
           conn
           |> get_req_header("last-event-id")
@@ -538,6 +563,7 @@ defmodule FountainWeb.ConversationController do
 
         streams = parse_streams_param(params["streams"])
         wait? = parse_bool_param(params["wait"], true)
+        blocks_runtime = if parse_bool_param(params["blocks"], false), do: conv.runtime
 
         if wait? do
           Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{id}")
@@ -567,11 +593,11 @@ defmodule FountainWeb.ConversationController do
           |> send_chunked(200)
 
         # Replay buffered events the client missed.
-        {status, conn, last_id} = replay(conn, id, last_event_id, streams)
+        {status, conn, last_id} = replay(conn, id, last_event_id, streams, blocks_runtime)
 
         if wait? and status == :ok do
           Process.send_after(self(), :heartbeat, heartbeat_ms())
-          sse_loop(conn, last_id, streams, monitor_ref)
+          sse_loop(conn, last_id, streams, monitor_ref, blocks_runtime)
         else
           # `?wait=false` → close immediately after replay. Useful when
           # the caller already knows the conversation is finished and
@@ -616,12 +642,12 @@ defmodule FountainWeb.ConversationController do
   # closed tab, an EventSource reconnect against a long backlog), not an
   # error. This used to `throw` the chunk error with no catch anywhere in
   # the module, producing a crash report and a Sentry event per disconnect.
-  defp replay(conn, conv_id, after_id, streams) do
+  defp replay(conn, conv_id, after_id, streams, blocks_runtime) do
     # Ownership: only called from stream/2, after its scoped get_conversation.
     conv_id
     |> Conversations._unsafe_list_log_events(after_id, streams: streams)
     |> Enum.reduce_while({:ok, conn, after_id}, fn ev, {:ok, acc_conn, last_id} ->
-      case write_event(acc_conn, ev) do
+      case write_event(acc_conn, ev, blocks_runtime) do
         {:ok, c} -> {:cont, {:ok, c, ev.id}}
         {:error, _} -> {:halt, {:closed, acc_conn, last_id}}
       end
@@ -634,28 +660,28 @@ defmodule FountainWeb.ConversationController do
   # live events and no replayed ones.
   defp event_in_streams?(ev, streams), do: Conversations.event_in_streams?(ev, streams)
 
-  defp sse_loop(conn, last_id, streams, monitor_ref) do
+  defp sse_loop(conn, last_id, streams, monitor_ref, blocks_runtime) do
     receive do
       {:log_event, %LogEvent{id: ev_id} = ev} when ev_id > last_id ->
         cond do
           not event_in_streams?(ev, streams) ->
-            sse_loop(conn, ev_id, streams, monitor_ref)
+            sse_loop(conn, ev_id, streams, monitor_ref, blocks_runtime)
 
           true ->
-            case write_event(conn, ev) do
-              {:ok, conn} -> sse_loop(conn, ev_id, streams, monitor_ref)
+            case write_event(conn, ev, blocks_runtime) do
+              {:ok, conn} -> sse_loop(conn, ev_id, streams, monitor_ref, blocks_runtime)
               {:error, _} -> conn
             end
         end
 
       {:log_event, _stale} ->
-        sse_loop(conn, last_id, streams, monitor_ref)
+        sse_loop(conn, last_id, streams, monitor_ref, blocks_runtime)
 
       :heartbeat ->
         case Plug.Conn.chunk(conn, ": heartbeat\n\n") do
           {:ok, conn} ->
             Process.send_after(self(), :heartbeat, heartbeat_ms())
-            sse_loop(conn, last_id, streams, monitor_ref)
+            sse_loop(conn, last_id, streams, monitor_ref, blocks_runtime)
 
           {:error, _} ->
             conn
@@ -709,7 +735,9 @@ defmodule FountainWeb.ConversationController do
     end
   end
 
-  defp write_event(conn, %LogEvent{} = ev) do
+  # `blocks_runtime` nil means no blocks; a runtime string means "add the
+  # server-parsed blocks for this event, for that runtime's legacy dialect".
+  defp write_event(conn, %LogEvent{} = ev, blocks_runtime) do
     payload =
       %{
         kind: ev.kind,
@@ -720,6 +748,7 @@ defmodule FountainWeb.ConversationController do
         turn_id: ev.turn_id,
         ts: ev.inserted_at
       }
+      |> FountainWeb.ConversationJSON.put_blocks(ev, blocks_runtime)
       |> Jason.encode!()
 
     chunk = "id: #{ev.id}\nevent: #{ev.kind}\ndata: #{payload}\n\n"

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -10,9 +10,11 @@ defmodule FountainWeb.ConversationJSON do
   def show(%{conversation: conv}), do: %{data: data(conv)}
   def turns(%{turns: turns}), do: %{data: Enum.map(turns, &turn_data/1)}
 
-  def events(%{events: events, has_more: has_more?, limit: limit}) do
+  def events(%{events: events, has_more: has_more?, limit: limit} = assigns) do
+    blocks_runtime = Map.get(assigns, :blocks_runtime)
+
     %{
-      data: Enum.map(events, &log_event_data/1),
+      data: Enum.map(events, &(&1 |> log_event_data() |> put_blocks(&1, blocks_runtime))),
       meta: %{
         limit: limit,
         has_more: has_more?,
@@ -91,6 +93,24 @@ defmodule FountainWeb.ConversationJSON do
       ts: e.inserted_at
     }
   end
+
+  @doc """
+  Add `blocks` — the event's data parsed into the blocks a transcript renders
+  — to an event's JSON when a runtime is given; unchanged when nil. Output
+  events only: a stage event has no dialect to parse, and gets `[]`.
+  """
+  def put_blocks(json, _event, nil), do: json
+
+  def put_blocks(json, %LogEvent{kind: "output"} = ev, runtime) do
+    blocks =
+      ev
+      |> Fountain.Conversations.Blocks.for_event(runtime)
+      |> Enum.map(&Fountain.Conversations.Blocks.to_json/1)
+
+    Map.put(json, :blocks, blocks)
+  end
+
+  def put_blocks(json, _event, _runtime), do: Map.put(json, :blocks, [])
 
   defp event_id(%LogEvent{id: id}), do: id
   defp event_id(nil), do: nil

--- a/apps/fountain/lib/fountain_web/controllers/events_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/events_controller.ex
@@ -1,0 +1,228 @@
+defmodule FountainWeb.EventsController do
+  @moduledoc """
+  `GET /api/events/stream`: every conversation of the caller on one SSE
+  connection (#813) — what a client that shows a conversation list with live
+  status and unread dots needs, instead of one socket per conversation.
+
+  Same loop shape as `TeamController.stream/2`: subscribe to each followed
+  conversation's `conv:<id>` topic and to the user's `sidebar:<id>` topic;
+  the latter is pinged on every change to the list (a conversation created,
+  titled, read, deleted — and once per output chunk from ConversationServer),
+  so it is debounced here into one `conversations` event and one re-follow
+  pass per quiet second at most.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.LogEvent
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Conversations"])
+
+  operation(:stream,
+    summary: "Stream every conversation's events (SSE)",
+    description:
+      "One `text/event-stream` carrying the log events of every conversation the " <>
+        "caller owns that is not finished, each payload the shape of " <>
+        "`GET /api/conversations/:id/stream` plus `conversation_id`. A `conversations` " <>
+        "event (data `{reason: changed}`) is sent, debounced, when the list changes — " <>
+        "created, titled, read, deleted, finished — and the stream follows a new " <>
+        "conversation on its own; the client re-lists. `Last-Event-ID` replays what was " <>
+        "missed across every followed conversation. `?streams=` filters as elsewhere; " <>
+        "`?blocks=true` adds server-parsed blocks. Heartbeats every 15 s; closes after " <>
+        "60 s idle so the client reconnects. The first byte is a `: connected` comment.",
+    parameters: [
+      streams: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Comma-separated stream allow-list (`stdout,stderr,acp,stage`)."
+      ],
+      blocks: [
+        in: :query,
+        type: :boolean,
+        required: false,
+        description: "Add `blocks` to each event payload. Defaults to false."
+      ]
+    ],
+    responses: [
+      ok: {"SSE stream", "text/event-stream", %OpenApiSpex.Schema{type: :string}}
+    ]
+  )
+
+  @default_heartbeat_ms 15_000
+  @default_idle_timeout_ms 60_000
+  @refollow_debounce_ms 1_000
+
+  defp heartbeat_ms,
+    do: Application.get_env(:fountain, :sse_heartbeat_ms, @default_heartbeat_ms)
+
+  defp idle_timeout_ms,
+    do: Application.get_env(:fountain, :sse_idle_timeout_ms, @default_idle_timeout_ms)
+
+  def stream(conn, params) do
+    user_id = conn.assigns.current_user.id
+    last_event_id = conn |> get_req_header("last-event-id") |> List.first() |> parse_id()
+    streams = parse_streams(params["streams"])
+    blocks? = params["blocks"] in [true, "true", "1"]
+
+    Phoenix.PubSub.subscribe(Fountain.PubSub, "sidebar:#{user_id}")
+    followed = follow(user_id, %{})
+
+    conn =
+      conn
+      |> put_resp_header("content-type", "text/event-stream")
+      |> put_resp_header("cache-control", "no-cache")
+      |> put_resp_header("connection", "keep-alive")
+      |> send_chunked(200)
+
+    # A first byte straight away — a buffering proxy (Cloudflare) would
+    # otherwise hold the headers until the first heartbeat.
+    conn =
+      case Plug.Conn.chunk(conn, ": connected\n\n") do
+        {:ok, conn} -> conn
+        {:error, _} -> conn
+      end
+
+    state = %{
+      user_id: user_id,
+      followed: followed,
+      last_id: last_event_id,
+      streams: streams,
+      blocks?: blocks?,
+      refollow_pending?: false
+    }
+
+    case replay(conn, state) do
+      {:ok, conn, last_id} ->
+        Process.send_after(self(), :heartbeat, heartbeat_ms())
+        sse_loop(conn, %{state | last_id: last_id})
+
+      {:closed, conn, _} ->
+        conn
+    end
+  end
+
+  # conversation_id → runtime for every conversation still worth following.
+  # Finished ones publish nothing; a conversation that finishes while
+  # followed simply goes quiet. Never unsubscribed — the process ends with
+  # the request.
+  defp follow(user_id, followed) do
+    user_id
+    |> Conversations.list_conversations()
+    |> Enum.reject(&(&1.status in ["terminated", "failed"]))
+    |> Enum.reduce(followed, fn conv, acc ->
+      unless Map.has_key?(acc, conv.id) do
+        Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv.id}")
+      end
+
+      Map.put(acc, conv.id, conv.runtime)
+    end)
+  end
+
+  defp replay(conn, %{last_id: 0}), do: {:ok, conn, 0}
+
+  defp replay(conn, state) do
+    # Ownership: `followed` came from the tenant-scoped list_conversations.
+    state.followed
+    |> Enum.flat_map(fn {conv_id, _runtime} ->
+      Conversations._unsafe_list_log_events(conv_id, state.last_id, streams: state.streams)
+    end)
+    |> Enum.sort_by(& &1.id)
+    |> Enum.reduce_while({:ok, conn, state.last_id}, fn ev, {:ok, acc, last_id} ->
+      case write_event(acc, ev, state) do
+        {:ok, c} -> {:cont, {:ok, c, max(ev.id, last_id)}}
+        {:error, _} -> {:halt, {:closed, acc, last_id}}
+      end
+    end)
+  end
+
+  defp sse_loop(conn, state) do
+    receive do
+      {:log_event, %LogEvent{id: ev_id} = ev} when ev_id > state.last_id ->
+        if Conversations.event_in_streams?(ev, state.streams) do
+          case write_event(conn, ev, state) do
+            {:ok, conn} -> sse_loop(conn, %{state | last_id: ev_id})
+            {:error, _} -> conn
+          end
+        else
+          sse_loop(conn, %{state | last_id: ev_id})
+        end
+
+      {:log_event, _stale} ->
+        sse_loop(conn, state)
+
+      {:sidebar_update, _} ->
+        # Coalesce the burst: one refollow + one `conversations` event per
+        # quiet second, however many pings arrived.
+        if state.refollow_pending? do
+          sse_loop(conn, state)
+        else
+          Process.send_after(self(), :refollow, @refollow_debounce_ms)
+          sse_loop(conn, %{state | refollow_pending?: true})
+        end
+
+      :refollow ->
+        followed = follow(state.user_id, state.followed)
+        chunk = "event: conversations\ndata: #{Jason.encode!(%{reason: "changed"})}\n\n"
+
+        case Plug.Conn.chunk(conn, chunk) do
+          {:ok, conn} -> sse_loop(conn, %{state | followed: followed, refollow_pending?: false})
+          {:error, _} -> conn
+        end
+
+      :heartbeat ->
+        case Plug.Conn.chunk(conn, ": heartbeat\n\n") do
+          {:ok, conn} ->
+            Process.send_after(self(), :heartbeat, heartbeat_ms())
+            sse_loop(conn, state)
+
+          {:error, _} ->
+            conn
+        end
+    after
+      idle_timeout_ms() -> conn
+    end
+  end
+
+  defp write_event(conn, %LogEvent{} = ev, state) do
+    runtime = if state.blocks?, do: Map.get(state.followed, ev.conversation_id)
+
+    payload =
+      %{
+        conversation_id: ev.conversation_id,
+        kind: ev.kind,
+        stream: ev.stream,
+        data: ev.data,
+        stage: ev.stage,
+        state: ev.state,
+        duration_ms: ev.duration_ms,
+        turn_id: ev.turn_id,
+        ts: ev.inserted_at
+      }
+      |> FountainWeb.ConversationJSON.put_blocks(ev, runtime)
+      |> Jason.encode!()
+
+    Plug.Conn.chunk(conn, "id: #{ev.id}\nevent: #{ev.kind}\ndata: #{payload}\n\n")
+  end
+
+  defp parse_id(nil), do: 0
+  defp parse_id(""), do: 0
+
+  defp parse_id(s) do
+    case Integer.parse(s) do
+      {n, _} -> n
+      :error -> 0
+    end
+  end
+
+  defp parse_streams(nil), do: nil
+  defp parse_streams(""), do: nil
+
+  defp parse_streams(s) when is_binary(s),
+    do: s |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+end

--- a/apps/fountain/lib/fountain_web/live/conversations_live/chat.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/chat.ex
@@ -217,32 +217,12 @@ defmodule FountainWeb.ConversationsLive.Chat do
 
   # ── event → blocks ──────────────────────────────────────────────
 
-  # Splits an event's `data` (which may be a stream-json chunk with N
-  # lines) into a flat list of structured blocks. Each block is a map
-  # with at least `:kind`, plus kind-specific fields.
-  # ACP rows carry a specified protocol rather than a vendor's dialect, so the
-  # translation lives on the server in `Fountain.Runtimes.ACP.Blocks` — with its
-  # own tests, and outside the render path where a point release becomes a
-  # rendering bug. That relocation is the point of 0014; this clause is the
-  # seam, and it is deliberately the only ACP knowledge in this module.
-  #
-  # Keyed on the event's stream, not the conversation's runtime: the per-agent
-  # flag can flip between turns, and the turns before it flipped must keep
-  # rendering through the parser that produced them.
-  def blocks_for(%{stream: "acp", data: data}, _runtime) when is_binary(data) do
-    data
-    |> String.split("\n", trim: true)
-    |> Enum.flat_map(&Fountain.Runtimes.ACP.Blocks.from_line/1)
-  end
-
-  # Legacy stdout rows: gemini's live dialect (#659) and pre-ACP history for
-  # the converted runtimes. The parsers live in `LegacyBlocks`, out of the
-  # render path, with their own tests — this clause is the whole seam (#642).
-  def blocks_for(%{data: data}, runtime) when is_binary(data) do
-    data
-    |> String.split("\n", trim: true)
-    |> Enum.flat_map(&FountainWeb.ConversationsLive.LegacyBlocks.from_line(&1, runtime))
-  end
-
-  def blocks_for(_, _), do: []
+  @doc """
+  The blocks one log event's data holds. Delegates to
+  `Fountain.Conversations.Blocks.for_event/2` — the parsers live in the
+  runtimes namespace with their own tests, and the API serves the same
+  blocks (`?blocks=true`), so this LiveView and a client on another origin
+  render one transcript from one parse.
+  """
+  def blocks_for(event, runtime), do: Fountain.Conversations.Blocks.for_event(event, runtime)
 end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -286,6 +286,8 @@ defmodule FountainWeb.Router do
     pipe_through :api
 
     get "/team/stream", TeamController, :stream, as: :team_stream
+    # Every conversation of the caller on one connection (#813).
+    get "/events/stream", EventsController, :stream, as: :events_stream
   end
 
   scope "/api", FountainWeb do

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -994,6 +994,38 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule Block do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Block",
+      description:
+        "One structured piece of a log event's output — the same parse the web UI " <>
+          "renders (`Fountain.Conversations.Blocks`). `kind` decides the other fields: " <>
+          "`text`/`thinking` carry `body`; `tool_use` carries `id`, `name`, `summary`, " <>
+          "`body` (the input); `tool_result` carries `tool_id`, `body`, `error` and pairs " <>
+          "with the `tool_use` of the same id; `init` carries `summary`, `body`; `result` " <>
+          "carries `body`, `raw`; `error` carries `body`; `raw` carries `body`, `summary`.",
+      type: :object,
+      properties: %{
+        kind: %Schema{
+          type: :string,
+          enum: Fountain.Conversations.Blocks.kinds()
+        },
+        body: %Schema{type: :string, nullable: true},
+        summary: %Schema{type: :string, nullable: true},
+        id: %Schema{type: :string, nullable: true},
+        name: %Schema{type: :string, nullable: true},
+        tool_id: %Schema{type: :string, nullable: true},
+        error: %Schema{type: :boolean, nullable: true},
+        raw: %Schema{type: :string, nullable: true}
+      },
+      required: [:kind],
+      additionalProperties: true
+    })
+  end
+
   defmodule LogEvent do
     @moduledoc false
     require OpenApiSpex
@@ -1022,7 +1054,14 @@ defmodule FountainWeb.Schemas do
         state: %Schema{type: :string, enum: ~w(started done failed interrupted), nullable: true},
         duration_ms: %Schema{type: :integer, nullable: true},
         turn_id: %Schema{type: :string, format: :uuid, nullable: true},
-        ts: %Schema{type: :string, format: :"date-time"}
+        ts: %Schema{type: :string, format: :"date-time"},
+        blocks: %Schema{
+          type: :array,
+          items: Block,
+          description:
+            "Only with `?blocks=true`: `data` parsed server-side into the blocks a " <>
+              "transcript renders. Empty for non-output events."
+        }
       },
       required: [:id, :kind, :ts]
     })

--- a/apps/fountain/test/fountain/conversations/blocks_test.exs
+++ b/apps/fountain/test/fountain/conversations/blocks_test.exs
@@ -1,0 +1,70 @@
+defmodule Fountain.Conversations.BlocksTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Conversations.Blocks
+
+  defp acp(update) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{"sessionId" => "s", "update" => update}
+    })
+  end
+
+  test "an acp row parses through ACP.Blocks whatever the runtime" do
+    ev = %{
+      kind: "output",
+      stream: "acp",
+      data:
+        acp(%{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => "hi"}
+        })
+    }
+
+    assert [%{kind: :text, body: "hi"}] = Blocks.for_event(ev, "gemini")
+  end
+
+  test "a stdout row parses through the runtime's legacy dialect" do
+    ev = %{
+      kind: "output",
+      stream: "stdout",
+      data:
+        Jason.encode!(%{
+          "type" => "assistant",
+          "message" => %{"content" => [%{"type" => "text", "text" => "old style"}]}
+        })
+    }
+
+    assert [%{kind: :text, body: "old style"}] = Blocks.for_event(ev, "claude")
+    assert [%{kind: :raw}] = Blocks.for_event(ev, "unknown-runtime")
+  end
+
+  test "no data, no blocks" do
+    assert [] = Blocks.for_event(%{kind: "stage", stream: nil, data: nil}, "claude")
+  end
+
+  test "to_json stringifies the kind and renames error?" do
+    assert %{"kind" => "tool_result", "tool_id" => "t1", "body" => "x", "error" => true} =
+             Blocks.to_json(%{kind: :tool_result, tool_id: "t1", body: "x", error?: true})
+
+    assert %{"kind" => "text", "body" => "b"} = Blocks.to_json(%{kind: :text, body: "b"})
+  end
+
+  test "every kind the parsers emit is in kinds/0" do
+    ev = %{
+      kind: "output",
+      stream: "acp",
+      data:
+        acp(%{
+          "sessionUpdate" => "tool_call",
+          "toolCallId" => "c",
+          "title" => "Read"
+        })
+    }
+
+    for b <- Blocks.for_event(ev, "claude") do
+      assert Atom.to_string(b.kind) in Blocks.kinds()
+    end
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/legacy_blocks_test.exs
+++ b/apps/fountain/test/fountain/runtimes/legacy_blocks_test.exs
@@ -1,7 +1,7 @@
-defmodule FountainWeb.ConversationsLive.LegacyBlocksTest do
+defmodule Fountain.Runtimes.LegacyBlocksTest do
   use ExUnit.Case, async: true
 
-  alias FountainWeb.ConversationsLive.LegacyBlocks
+  alias Fountain.Runtimes.LegacyBlocks
 
   # First tests these parsers have ever had: they spent their whole life as
   # private clauses of a LiveView (#642). Gemini's dialect is live; the other

--- a/apps/fountain/test/fountain_web/controllers/events_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/events_stream_test.exs
@@ -1,0 +1,221 @@
+defmodule FountainWeb.EventsStreamTest do
+  @moduledoc """
+  `GET /api/events/stream` — every conversation on one connection — and the
+  `?blocks=true` read-model on `/events` and the per-conversation stream.
+  Same fast-loop technique as `SseStreamTest`.
+  """
+
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.ConnTest, only: [build_conn: 0, get: 2, json_response: 2]
+
+  @endpoint FountainWeb.Endpoint
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+
+    previous = {
+      Application.get_env(:fountain, :sse_heartbeat_ms),
+      Application.get_env(:fountain, :sse_idle_timeout_ms)
+    }
+
+    on_exit(fn ->
+      {hb, idle} = previous
+
+      if hb,
+        do: Application.put_env(:fountain, :sse_heartbeat_ms, hb),
+        else: Application.delete_env(:fountain, :sse_heartbeat_ms)
+
+      if idle,
+        do: Application.put_env(:fountain, :sse_idle_timeout_ms, idle),
+        else: Application.delete_env(:fountain, :sse_idle_timeout_ms)
+    end)
+
+    Application.put_env(:fountain, :sse_heartbeat_ms, 60_000)
+    Application.put_env(:fountain, :sse_idle_timeout_ms, 1_500)
+
+    Ecto.Adapters.SQL.Sandbox.mode(Fountain.Repo, {:shared, self()})
+
+    {:ok, user: user, raw_key: raw_key}
+  end
+
+  defp acp_text(text) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{
+        "sessionId" => "s",
+        "update" => %{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => text}
+        }
+      }
+    })
+  end
+
+  defp publish(conv, attrs) do
+    ev = insert_log_event(conv, attrs)
+    Phoenix.PubSub.broadcast(Fountain.PubSub, "conv:#{conv.id}", {:log_event, ev})
+    ev
+  end
+
+  defp stream_async(raw_key, path, headers \\ []) do
+    parent = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, parent, self())
+
+      conn =
+        Enum.reduce(headers, authed_with_key(build_conn(), raw_key), fn {k, v}, c ->
+          Plug.Conn.put_req_header(c, k, v)
+        end)
+
+      Phoenix.ConnTest.dispatch(conn, @endpoint, :get, path)
+    end)
+  end
+
+  describe "GET /api/events/stream" do
+    test "events from every live conversation, labelled; finished and foreign ones excluded", %{
+      user: user,
+      raw_key: key
+    } do
+      a = insert_conversation(user_id: user.id, status: "idle")
+      b = insert_conversation(user_id: user.id, status: "running")
+      dead = insert_conversation(user_id: user.id, status: "terminated")
+      foreign = insert_conversation(user_id: insert_verified_user().id, status: "idle")
+
+      task = stream_async(key, "/api/events/stream")
+      Process.sleep(300)
+
+      publish(a, %{kind: "output", stream: "acp", data: "from-a"})
+      publish(b, %{kind: "output", stream: "acp", data: "from-b"})
+      publish(dead, %{kind: "output", stream: "acp", data: "from-dead"})
+      publish(foreign, %{kind: "output", stream: "acp", data: "from-foreign"})
+
+      conn = Task.await(task, 5_000)
+      assert conn.status == 200
+      assert String.starts_with?(conn.resp_body, ": connected\n\n")
+      assert conn.resp_body =~ "from-a"
+      assert conn.resp_body =~ "from-b"
+      refute conn.resp_body =~ "from-dead"
+      refute conn.resp_body =~ "from-foreign"
+
+      [payload] =
+        Regex.run(~r/data: (\{[^\n]*from-a[^\n]*\})/, conn.resp_body, capture: :all_but_first)
+
+      assert Jason.decode!(payload)["conversation_id"] == a.id
+    end
+
+    test "Last-Event-ID replays what was missed across conversations", %{user: user, raw_key: key} do
+      a = insert_conversation(user_id: user.id, status: "idle")
+      b = insert_conversation(user_id: user.id, status: "idle")
+      seen = insert_log_event(a, %{kind: "output", stream: "acp", data: "seen"})
+      insert_log_event(b, %{kind: "output", stream: "acp", data: "missed-b"})
+      insert_log_event(a, %{kind: "output", stream: "acp", data: "missed-a"})
+
+      conn =
+        stream_async(key, "/api/events/stream", [{"last-event-id", to_string(seen.id)}])
+        |> Task.await(5_000)
+
+      refute conn.resp_body =~ "\"seen\""
+      assert conn.resp_body =~ "missed-b"
+      assert conn.resp_body =~ "missed-a"
+    end
+
+    test "a sidebar ping becomes one debounced `conversations` event and follows new ones", %{
+      user: user,
+      raw_key: key
+    } do
+      insert_conversation(user_id: user.id, status: "idle")
+
+      task = stream_async(key, "/api/events/stream")
+      Process.sleep(300)
+
+      new = insert_conversation(user_id: user.id, status: "idle")
+
+      for _ <- 1..5,
+          do:
+            Phoenix.PubSub.broadcast(
+              Fountain.PubSub,
+              "sidebar:#{user.id}",
+              {:sidebar_update, user.id}
+            )
+
+      # Past the 1 s debounce: the refollow ran, the new conversation is subscribed.
+      Process.sleep(1_300)
+      publish(new, %{kind: "output", stream: "acp", data: "from-new"})
+
+      conn = Task.await(task, 6_000)
+      assert length(Regex.scan(~r/event: conversations\n/, conn.resp_body)) == 1
+      assert conn.resp_body =~ "from-new"
+    end
+
+    test "?blocks=true adds the server-parsed blocks per event", %{user: user, raw_key: key} do
+      a = insert_conversation(user_id: user.id, status: "idle")
+      marker = insert_log_event(a, %{kind: "output", stream: "stdout", data: "m"})
+      insert_log_event(a, %{kind: "output", stream: "acp", data: acp_text("hello")})
+
+      conn =
+        stream_async(key, "/api/events/stream?blocks=true&streams=acp", [
+          {"last-event-id", to_string(marker.id)}
+        ])
+        |> Task.await(5_000)
+
+      [payload] =
+        Regex.run(~r/data: (\{[^\n]*hello[^\n]*\})/, conn.resp_body, capture: :all_but_first)
+
+      assert %{"blocks" => [%{"kind" => "text", "body" => "hello"}]} = Jason.decode!(payload)
+    end
+  end
+
+  describe "?blocks=true on the per-conversation surfaces" do
+    test "GET /events adds blocks for output events and [] for stage events", %{
+      user: user,
+      raw_key: key
+    } do
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: insert_agent(user_id: user.id, runtime: "claude")
+        )
+
+      insert_log_event(conv, %{kind: "output", stream: "acp", data: acp_text("hi")})
+      insert_log_event(conv, %{kind: "stage", stream: "", stage: "turn", state: "done"})
+
+      body =
+        build_conn()
+        |> authed_with_key(key)
+        |> get("/api/conversations/#{conv.id}/events?blocks=true")
+        |> json_response(200)
+
+      assert [%{"blocks" => [%{"kind" => "text", "body" => "hi"}]}, %{"blocks" => []}] =
+               body["data"]
+
+      # Without the flag the field is absent, so existing clients see the same rows.
+      plain =
+        build_conn()
+        |> authed_with_key(key)
+        |> get("/api/conversations/#{conv.id}/events")
+        |> json_response(200)
+
+      refute Map.has_key?(hd(plain["data"]), "blocks")
+    end
+
+    test "the per-conversation stream adds blocks with ?blocks=true", %{user: user, raw_key: key} do
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: insert_agent(user_id: user.id, runtime: "claude")
+        )
+
+      insert_log_event(conv, %{kind: "output", stream: "acp", data: acp_text("streamed")})
+
+      conn =
+        stream_async(key, "/api/conversations/#{conv.id}/stream?wait=false&blocks=true")
+        |> Task.await(5_000)
+
+      assert conn.resp_body =~ ~s("blocks":[{"body":"streamed","kind":"text"}])
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -83,7 +83,8 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.Turn, "status"} => {Turn, :statuses},
     {FountainWeb.Schemas.Teammate, "presence.state"} =>
       {FountainWeb.TeamPresenter, :presence_states},
-    {FountainWeb.Schemas.Teammate, "preview.kind"} => {FountainWeb.TeamPresenter, :preview_kinds}
+    {FountainWeb.Schemas.Teammate, "preview.kind"} => {FountainWeb.TeamPresenter, :preview_kinds},
+    {FountainWeb.Schemas.Block, "kind"} => {Fountain.Conversations.Blocks, :kinds}
   }
 
   # Enums with no domain list behind them. Each entry needs a reason: the

--- a/docs/api.md
+++ b/docs/api.md
@@ -234,6 +234,41 @@ Since sub-conversations are created over the API (`X-Fountain-Parent-Conversatio
 
 Page by passing the previous response's `meta.next_cursor` as `after`; keep going while `meta.has_more` is true. `limit` defaults to 100 and caps at 1000. The `id` is the same value the SSE route uses as `Last-Event-ID`, so a client can drain history as JSON and then attach the stream from where it left off.
 
+`?blocks=true` — on `/events`, on `/stream` and on `/api/events/stream` — adds
+`blocks` to every event: its `data` parsed server-side into the structured
+blocks a transcript renders, the same parse the web UI uses
+(`Fountain.Conversations.Blocks`). A client never re-implements a runtime's
+dialect (ADR 0014, applied to the wire). Kinds and their fields:
+
+| kind | fields |
+|---|---|
+| `text`, `thinking` | `body` |
+| `tool_use` | `id`, `name`, `summary`, `body` (the input) |
+| `tool_result` | `tool_id`, `body`, `error` — pair it with the `tool_use` of the same id |
+| `init` | `summary`, `body` |
+| `result` | `body`, `raw` |
+| `error` | `body` |
+| `raw` | `body`, `summary` — an unrecognised line, shown rather than dropped |
+
+Non-output events carry `blocks: []`; without the flag the field is absent.
+
+### Every conversation on one stream
+
+```
+GET /api/events/stream          # SSE (?streams=  ?blocks=true)
+```
+
+One `text/event-stream` for every conversation the caller owns that is not
+finished — what a conversation list with live status and unread dots needs
+instead of a socket per conversation. Each event is the per-conversation
+stream's payload plus `conversation_id`. A `conversations` event
+(`{"reason":"changed"}`) is sent, debounced to one per second, when the list
+changes (created, titled, read, deleted, finished); the stream follows a new
+conversation on its own and the client re-lists. `Last-Event-ID` replays what
+was missed across every followed conversation; the first byte is a
+`: connected` comment; heartbeats every 15 s; closes after 60 s idle so the
+client reconnects.
+
 ## Team
 
 The roster [`/team`](primitives.md#the-team-page-agents-as-teammates) shows, for


### PR DESCRIPTION
Part of #813 (standalone conversation UI).

## Summary
- **`Fountain.Conversations.Blocks`**: the block parse (acp → `ACP.Blocks`, legacy stdout → `LegacyBlocks`, now `Fountain.Runtimes.LegacyBlocks`) out of the LiveView; `Chat.blocks_for/2` delegates. `to_json/1` wire form, `kinds/0` enum (schema + guardrail wired).
- **`?blocks=true`** on `GET /api/conversations/:id/events`, its `/stream`, and the new user-wide stream — `blocks` per event, `[]` for non-output rows, absent without the flag.
- **`GET /api/events/stream`**: every unfinished conversation of the caller on one SSE connection (`conversation_id` on each payload), debounced `conversations` event on list changes (sidebar pings), Last-Event-ID replay across the set, `: connected` first byte.
- Docs (`api.md`), OpenAPI (`Block` schema, params), changelog.

## Test plan
- [x] `blocks_test.exs` (acp/legacy/none/to_json/kinds), `events_stream_test.exs` (multi-conversation labelled, finished+foreign excluded, Last-Event-ID, debounced `conversations` + follow-on subscribe, blocks on the user stream, `/events?blocks=true`, per-conversation stream `?blocks=true`, no field without the flag)
- [x] moved `legacy_blocks_test.exs`, LiveView/team/SSE/API/spec/guardrail/docs tests, credo, format, dialyzer

🤖 Generated with [Claude Code](https://claude.com/claude-code)