### PR TITLE
feat(api): GET /api/catalog and POST /api/avatars/generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ upgrade, is in
 
 ### Added
 
+- **`GET /api/catalog` and `POST /api/avatars/generate`.** The vocabulary the
+  agent and environment forms are built from — runtimes and model
+  suggestions per runtime, sandbox providers usable on the instance and the
+  default, the package managers provisioning installs, the avatar
+  generator's bases and moods — and the generator itself over the API, so
+  the standalone conversations app can carry the agents / environments /
+  vaults pages without hard-coding any of it (#815).
+
+### Fixed
+
+- **The environment form offers only the package managers provisioning
+  installs (`apt`, `npm`).** pip, cargo, gem and go were offered, stored and
+  never installed; an environment that already carries one of those keys
+  still shows it (#815).
+
 - **Blocks over the API, and every conversation on one stream.**
   `?blocks=true` on `GET /api/conversations/:id/events`, on its `/stream`
   and on the new `GET /api/events/stream` adds `blocks` to each event — its

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -234,6 +234,15 @@ defmodule Fountain.Conversations.Provisioning do
 
   def build_package_commands(_), do: []
 
+  @package_managers ~w(apt npm)
+
+  @doc """
+  The package managers `install_packages/4` acts on. An environment's
+  `packages` map may carry other keys (the form used to offer pip, cargo, gem
+  and go); they are stored and ignored — nothing installs them (#815).
+  """
+  def package_managers, do: @package_managers
+
   @doc false
   def build_apt_commands([]), do: []
 

--- a/apps/fountain/lib/fountain_web/controllers/avatar_generate_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/avatar_generate_controller.ex
@@ -1,0 +1,74 @@
+defmodule FountainWeb.AvatarGenerateController do
+  @moduledoc """
+  `POST /api/avatars/generate`: the agent form's "generate an avatar" over the
+  API (#815). Same generator as the web form (`Fountain.AvatarGenerator`,
+  OpenAI Images with the tenant's own OpenAI credential); returns the PNG as
+  base64 for the client to preview and then attach with
+  `PUT /api/agents/:id/avatar` — generation is not tied to an agent, so a
+  client can generate before the agent exists, as the form does.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.AvatarGenerator
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Agents"])
+
+  operation(:create,
+    summary: "Generate an avatar image",
+    description:
+      "Generates a square PNG avatar with the tenant's OpenAI credential from a `base` " <>
+        "and a `mood` (`GET /api/catalog` lists both). Returns base64 `data` and " <>
+        "`media_type` in the shape `PUT /api/agents/:id/avatar` accepts. 422 " <>
+        "`no_openai_key` when the tenant has no OpenAI credential; 502 when the " <>
+        "provider refused.",
+    request_body: {"Base and mood", "application/json", Schemas.AvatarGenerateRequest},
+    responses: [
+      ok: {"Generated image", "application/json", Schemas.AvatarGenerateResponse},
+      unprocessable_entity:
+        {"No OpenAI credential, or unknown base/mood", "application/json", Schemas.Error},
+      bad_gateway: {"The image provider refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def create(conn, %{"base" => base, "mood" => mood}) do
+    user = conn.assigns.current_user
+
+    with :ok <- check_choice(base, AvatarGenerator.bases(), "base"),
+         :ok <- check_choice(mood, AvatarGenerator.moods(), "mood") do
+      case AvatarGenerator.generate(user.id, base, mood) do
+        {:ok, png} ->
+          json(conn, %{data: %{data: Base.encode64(png), media_type: "image/png"}})
+
+        {:error, :no_openai_key} ->
+          conn
+          |> put_status(:unprocessable_entity)
+          |> json(%{
+            error: "no_openai_key",
+            message: "Add an OpenAI credential under inference credentials to generate avatars."
+          })
+
+        {:error, reason} ->
+          conn
+          |> put_status(:bad_gateway)
+          |> json(%{error: "avatar_generation_failed", message: to_string_reason(reason)})
+      end
+    end
+  end
+
+  defp check_choice(value, allowed, field) do
+    if value in allowed do
+      :ok
+    else
+      {:error, "unknown #{field}: #{inspect(value)} (one of #{Enum.join(allowed, ", ")})"}
+    end
+  end
+
+  defp to_string_reason(reason) when is_binary(reason), do: reason
+  defp to_string_reason(reason), do: inspect(reason)
+end

--- a/apps/fountain/lib/fountain_web/controllers/catalog_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/catalog_controller.ex
@@ -1,0 +1,53 @@
+defmodule FountainWeb.CatalogController do
+  @moduledoc """
+  `GET /api/catalog`: the instance's vocabulary a client needs to build the
+  agent and environment forms — runtimes and their model suggestions,
+  the sandbox providers usable here and the default, the package managers
+  an environment accepts, the avatar generator's bases and moods (#815).
+
+  Everything here is already public through the forms; this is the same
+  lists over the API so a client on another origin does not hard-code them
+  and drift from the server.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Agents.Agent
+  alias Fountain.Runtimes.Model
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  tags(["Catalog"])
+
+  operation(:show,
+    summary: "The instance's form vocabulary",
+    description:
+      "Runtimes with model suggestions per runtime (suggestions, not an allowlist — " <>
+        "any `provider/model` under a known provider is accepted), sandbox providers " <>
+        "usable on this instance and the default, package managers an environment " <>
+        "accepts, and the avatar generator's bases and moods.",
+    responses: [ok: {"Catalog", "application/json", Schemas.CatalogResponse}]
+  )
+
+  def show(conn, _params) do
+    runtimes = Agent.runtimes()
+
+    json(conn, %{
+      data: %{
+        runtimes: runtimes,
+        models: Map.new(runtimes, &{&1, Model.suggestions(&1)}),
+        model_providers: Model.providers(),
+        sandbox_providers: %{
+          enabled: Enum.map(Fountain.Sandbox.enabled_providers(), &Atom.to_string/1),
+          default: Atom.to_string(Fountain.Sandbox.default_provider())
+        },
+        package_managers: Fountain.Conversations.Provisioning.package_managers(),
+        avatar: %{
+          bases: Fountain.AvatarGenerator.bases(),
+          moods: Fountain.AvatarGenerator.moods()
+        }
+      }
+    })
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -5,7 +5,10 @@ defmodule FountainWeb.EnvironmentsLive.Form do
   alias Fountain.{Crypto, Environments}
   alias Fountain.Environments.Environment
 
-  @supported_managers ~w(apt npm pip cargo gem go)
+  # Only what provisioning installs (#815). pip/cargo/gem/go used to be
+  # offered here and were stored but never installed; an environment that
+  # already has such a key still shows it, so nothing disappears silently.
+  @supported_managers Fountain.Conversations.Provisioning.package_managers()
 
   @impl true
   def mount(params, _session, socket) do

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -310,6 +310,10 @@ defmodule FountainWeb.Router do
     end
 
     resources "/agents", AgentController, except: [:new, :edit]
+    # The form vocabulary and the avatar generator, for clients that build
+    # the agent/environment forms elsewhere (#815).
+    get "/catalog", CatalogController, :show
+    post "/avatars/generate", AvatarGenerateController, :create
 
     # Hosted Buzz agents (ADR 0020, #738). `create` is the Fountain side of a
     # remote-agents provider deploy — idempotent on the Nostr pubkey.

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1757,6 +1757,90 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule CatalogResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "CatalogResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            runtimes: %Schema{type: :array, items: %Schema{type: :string}},
+            models: %Schema{
+              type: :object,
+              additionalProperties: %Schema{type: :array, items: %Schema{type: :string}},
+              description:
+                "Suggested `provider/model` ids per runtime. Suggestions, not an allowlist."
+            },
+            model_providers: %Schema{type: :array, items: %Schema{type: :string}},
+            sandbox_providers: %Schema{
+              type: :object,
+              properties: %{
+                enabled: %Schema{type: :array, items: %Schema{type: :string}},
+                default: %Schema{type: :string}
+              },
+              required: [:enabled, :default]
+            },
+            package_managers: %Schema{
+              type: :array,
+              items: %Schema{type: :string},
+              description: "The managers provisioning installs from an environment's `packages`."
+            },
+            avatar: %Schema{
+              type: :object,
+              properties: %{
+                bases: %Schema{type: :array, items: %Schema{type: :string}},
+                moods: %Schema{type: :array, items: %Schema{type: :string}}
+              },
+              required: [:bases, :moods]
+            }
+          },
+          required: [:runtimes, :models, :sandbox_providers, :package_managers, :avatar]
+        }
+      },
+      required: [:data]
+    })
+  end
+
+  defmodule AvatarGenerateRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AvatarGenerateRequest",
+      type: :object,
+      properties: %{
+        base: %Schema{type: :string, description: "One of `GET /api/catalog` `avatar.bases`."},
+        mood: %Schema{type: :string, description: "One of `GET /api/catalog` `avatar.moods`."}
+      },
+      required: [:base, :mood]
+    })
+  end
+
+  defmodule AvatarGenerateResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AvatarGenerateResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            data: %Schema{type: :string, description: "Base64 PNG bytes."},
+            media_type: %Schema{type: :string, example: "image/png"}
+          },
+          required: [:data, :media_type]
+        }
+      },
+      required: [:data]
+    })
+  end
+
   defmodule Error do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/avatar_generate_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/avatar_generate_controller_test.exs
@@ -1,0 +1,62 @@
+defmodule FountainWeb.AvatarGenerateControllerTest do
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.AvatarGenerator
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    {:ok, user: user, raw_key: raw_key}
+  end
+
+  test "returns the generated PNG as base64", %{conn: conn, user: user, raw_key: key} do
+    user_id = user.id
+
+    stub(AvatarGenerator, :generate, fn ^user_id, "robot", "goofy" ->
+      {:ok, <<137, 80, 78, 71>>}
+    end)
+
+    body =
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/avatars/generate", %{base: "robot", mood: "goofy"})
+      |> json_response(200)
+
+    assert body["data"]["media_type"] == "image/png"
+    assert Base.decode64!(body["data"]["data"]) == <<137, 80, 78, 71>>
+  end
+
+  test "422 without an OpenAI credential; 502 when the provider refuses", %{
+    conn: conn,
+    raw_key: key
+  } do
+    stub(AvatarGenerator, :generate, fn _, _, _ -> {:error, :no_openai_key} end)
+
+    assert %{"error" => "no_openai_key"} =
+             conn
+             |> authed_with_key(key)
+             |> post_json("/api/avatars/generate", %{base: "robot", mood: "goofy"})
+             |> json_response(422)
+
+    stub(AvatarGenerator, :generate, fn _, _, _ -> {:error, "rate limited"} end)
+
+    assert %{"error" => "avatar_generation_failed", "message" => "rate limited"} =
+             conn
+             |> authed_with_key(key)
+             |> post_json("/api/avatars/generate", %{base: "robot", mood: "goofy"})
+             |> json_response(502)
+  end
+
+  test "an unknown base or mood is refused before any call", %{conn: conn, raw_key: key} do
+    reject(&AvatarGenerator.generate/3)
+
+    resp =
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/avatars/generate", %{base: "dragon", mood: "goofy"})
+
+    assert resp.status == 400
+    assert json_response(resp, 400)["error"] =~ "unknown base"
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/catalog_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/catalog_controller_test.exs
@@ -1,0 +1,31 @@
+defmodule FountainWeb.CatalogControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    {:ok, raw_key: raw_key}
+  end
+
+  test "GET /api/catalog lists the form vocabulary", %{conn: conn, raw_key: key} do
+    body = conn |> authed_with_key(key) |> get("/api/catalog") |> json_response(200)
+    data = body["data"]
+
+    assert data["runtimes"] == Fountain.Agents.Agent.runtimes()
+    assert data["models"]["claude"] == Fountain.Runtimes.Model.suggestions("claude")
+    assert Enum.all?(data["models"]["opencode"], &String.contains?(&1, "/"))
+    assert data["model_providers"] == Fountain.Runtimes.Model.providers()
+    assert is_list(data["sandbox_providers"]["enabled"])
+    assert data["sandbox_providers"]["default"] in Fountain.Sandbox.known_providers()
+    assert data["package_managers"] == ["apt", "npm"]
+
+    assert data["avatar"] == %{
+             "bases" => ~w(robot human alien),
+             "moods" => ~w(serious casual goofy)
+           }
+  end
+
+  test "401 without a key", %{conn: conn} do
+    assert conn |> get("/api/catalog") |> json_response(401)
+  end
+end

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -11,6 +11,7 @@ end
 # facade); the raw SDK copies below it exist only for the adapter's own unit
 # tests and the full-stack provisioning/checkpoint pins.
 Mimic.copy(Fountain.Sandbox.Sprites)
+Mimic.copy(Fountain.AvatarGenerator)
 Mimic.copy(Fountain.Sandbox.Sprites.Client)
 Mimic.copy(Fountain.Sandbox.Daytona.LogStream)
 Mimic.copy(Sprites)

--- a/docs/api.md
+++ b/docs/api.md
@@ -142,6 +142,21 @@ Avatars accept `image/png`, `image/jpeg`, `image/gif`, `image/webp`, up to 5 MB.
 
 Agent objects carry `conversation_count`; environments carry `secret_count` and `agent_count`; vaults carry `secret_count`. They are on both the list and single-resource reads, so "is this environment in use / safe to delete" is one request.
 
+## Catalog
+
+```
+GET  /api/catalog             # runtimes, model suggestions per runtime, sandbox providers, package managers, avatar bases/moods
+POST /api/avatars/generate    # {base, mood} → {data (base64 PNG), media_type}; attach with PUT /api/agents/:id/avatar
+```
+
+The vocabulary the agent and environment forms are built from, so a client
+elsewhere does not hard-code it. Model lists are suggestions, not an
+allowlist — any `provider/model` under a known provider is accepted.
+`package_managers` is what provisioning actually installs from an
+environment's `packages` (`apt`, `npm`); other keys are stored and ignored.
+Avatar generation uses the tenant's own OpenAI credential (`422
+no_openai_key` without one).
+
 ## Environments
 
 ```


### PR DESCRIPTION
Part of #815 (agents/environments/vaults in the standalone conversations app).

- `GET /api/catalog`: runtimes, model suggestions per runtime, `model_providers`, sandbox providers (enabled + default), package managers, avatar bases/moods.
- `POST /api/avatars/generate {base, mood}` → base64 PNG (422 `no_openai_key`, 502 on provider refusal, 400 on unknown base/mood) — the form's generator over the API.
- `Provisioning.package_managers/0` (`apt`, `npm`) is now what the environment form offers; pip/cargo/gem/go were never installed. Existing keys still show.
- Docs (`api.md`), OpenAPI schemas, changelog, tests (catalog shape; generate ok/422/502/400 with `AvatarGenerator` mimicked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)