### PR TITLE
docs(buzz): update_access is harness-side only — the desktop's 30177 policy is what clients trust (#820)

### DIFF
--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -285,10 +285,21 @@ defmodule Fountain.Buzz do
   the harness (`Fountain.Buzz.Manager.restart_harness/2`) when
   `launch_config_changed?/2` says so — this function only persists.
 
-  This is the operator's knob for the desktop's `respond_to` when the desktop
-  cannot resend it (it refuses to change access on an already-deployed
-  provider agent). Note a later provider deploy sends the desktop's record as
-  the whole truth and will overwrite what is set here.
+  This changes only what the *harness accepts* — the `BUZZ_ACP_RESPOND_TO`
+  gate and the kind-10100 profile buzz-acp publishes. It does not change what
+  other relay users' clients believe (#820): Buzz Desktop deploys a provider
+  agent with an owner-signed kind-30177 policy event, and Desktop ≥ 0.5.17
+  builds its agent directory from that event and ignores the 10100 when one
+  exists. So widening access here from `owner-only` to `anyone` lets the
+  harness answer, but a Desktop ≥ 0.5.17 user still cannot @-mention the agent
+  (no autocomplete entry, and a free-typed `@name` sends no `p` tag) until the
+  owner's desktop republishes the 30177 with the same access — the desktop UI
+  refuses to change access on an already-deployed provider agent, so today that
+  means editing the desktop's `managed-agents.json` and restarting, or
+  recreating the agent. Keep both sides in agreement.
+
+  A later provider deploy sends the desktop's record as the whole truth and
+  will overwrite what is set here.
   """
   def update_access(%BuzzIdentity{} = identity, params, opts \\ []) when is_map(params) do
     attrs =

--- a/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
@@ -107,7 +107,10 @@ defmodule FountainWeb.BuzzAgentController do
   # / `respond_to_allowlist` on the identity and restarts its harness so the
   # new gate is live. Exists because the desktop refuses to change access on a
   # provider agent it has already deployed, so the record's policy cannot be
-  # resent from there.
+  # resent from there. Harness-side only: the desktop's owner-signed kind-30177
+  # policy is what other users' clients (Desktop >= 0.5.17) trust for
+  # mentionability, and this does not touch it — see `Buzz.update_access/3`
+  # and #820.
   def update(conn, %{"id" => id} = params) do
     user = conn.assigns.current_user
 


### PR DESCRIPTION
Closes the docstring half of #820.

`Fountain.Buzz.update_access/3` described itself as "the operator's knob for the desktop's `respond_to`". It only changes what the harness accepts (`BUZZ_ACP_RESPOND_TO` + the kind-10100 profile). Buzz Desktop ≥ 0.5.17 (block/buzz #6086) builds its agent directory from the desktop's owner-signed kind-30177 policy and ignores the 10100, so an agent widened to `anyone` here is still un-mentionable for those users until the owner's desktop republishes 30177. The docstring and the controller comment now say so, and how to bring the desktop side along.

Docs only. Leaves open the #820 questions about warning on divergence and the upstream buzz change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)