### PR TITLE
feat(integrations): Hermes Agent plugin — Fountain agents as Hermes tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,11 @@ jobs:
         working-directory: cli
         run: go vet ./...
 
+      # The Hermes plugin (integrations/hermes) is stdlib Python; its tests
+      # run against an in-process fake Fountain and need nothing installed.
+      - name: Hermes plugin tests
+        run: python3 -m unittest discover -s integrations/hermes/tests -v
+
       # `gofmt -l` prints offending files and exits 0, so the failure has to
       # come from the emptiness check — print the list first so the log says
       # which files to run gofmt on.

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ aod.yml
 # mkdocs build output
 site/
 priv/plts/
+
+# Python (integrations/hermes)
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ upgrade, is in
 
 ### Added
 
+- **Hermes Agent plugin** (`integrations/hermes/`). Fountain agents as tools
+  inside [Hermes Agent](https://github.com/NousResearch/hermes-agent):
+  `fountain_agents`, `fountain_run`, `fountain_send`, `fountain_wait`,
+  `fountain_status`, `fountain_conversations`, `fountain_terminate`, plus a
+  `fountain` skill and a `/fountain` slash command. Delegation over the HTTP
+  API — a Hermes turn hands a task to a named Fountain agent, the work runs in
+  a Fountain sandbox, the answer comes back as the tool result; multi-turn
+  via `fountain_send`, bounded waits with a resumable cursor so a long turn
+  never trips Hermes's tool deadline. Reads the log feed as blocks
+  (`?blocks=true`), so it never learns a runtime dialect. Stdlib Python, no
+  dependencies; credentials resolve like the CLI (`FOUNTAIN_API_KEY`,
+  in-sandbox `FOUNTAIN_TOKEN`, `~/.fountain/credentials`). Install with
+  `hermes plugins install BinaryBourbon/fountain/integrations/hermes/fountain
+  --enable`. Docs: `docs/integrations/hermes.md`; tests run in CI.
 - **"Sign in with Fountain" for the browser apps — Fountain as an OAuth 2.0
   authorization server (ADR 0021).** `GET /oauth/authorize` (consent page
   behind the session; a signed-out user logs in — password or GitHub — and

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -49,6 +49,7 @@ defmodule Fountain.Docs do
        {"fountain acp (reference)", "integrations/acp.md"},
        {"Editors (ACP)", "integrations/editors.md"},
        {"OpenClaw (ACP)", "integrations/openclaw.md"},
+       {"Hermes Agent (plugin)", "integrations/hermes.md"},
        {"Buzz (Nostr)", "integrations/buzz.md"},
        {"GitHub OAuth", "integrations/github-oauth.md"},
        {"Stripe", "integrations/stripe.md"},

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -1,0 +1,136 @@
+# Hermes Agent
+
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) is Nous Research's
+self-hosted agent — a CLI, a TUI, and a gateway that fronts Telegram, Discord,
+Slack and the rest — with a plugin system for adding tools. Fountain ships a
+Hermes plugin that turns every Fountain agent on your account into something
+Hermes can delegate to: Hermes calls `fountain_run`, Fountain provisions a
+sandbox for that agent, the work runs there, and the answer comes back as the
+tool result.
+
+```
+  Hermes (CLI / TUI / gateway)  ──HTTPS──▶  Fountain  ──▶  sandbox: the Fountain agent
+    fountain_run(agent, prompt)              /api/*         (its environment, vault, runtime)
+```
+
+It is **delegation, not a model provider.** Hermes keeps its own model and its
+own loop; a Fountain agent is a contractor it hands a task to and hears back
+from. (Hermes's `copilot-acp` provider — an ACP agent used *as the LLM* — would
+also accept `fountain acp`, but it opens a fresh session per model call, which
+for Fountain means a sandbox per Hermes turn. The plugin is the intended path.)
+
+Why reach for it:
+
+- **The work runs off the Hermes host**, in a sandbox with the agent's own
+  environment (packages, cloned repos, network policy) and secrets that never
+  touch the machine Hermes runs on.
+- **The unit is a Fountain agent** the user already named and configured; the
+  Hermes model just picks one by name.
+- **Conversations are multi-turn and durable.** Hermes gets a
+  `conversation_id`, can follow up in the same sandbox, and the same
+  conversation is open in the Fountain web UI while it runs.
+- **Fan-out is a loop of tool calls**, not orchestration code.
+
+## Setup
+
+1. Credentials. On the Hermes host either export a key —
+
+    ```bash
+    export FOUNTAIN_API_KEY=fk_…                       # from Settings → API keys, or the CLI
+    export FOUNTAIN_BASE_URL=https://fountain.example  # only for a self-hosted instance
+    ```
+
+    — or install the CLI and log in; the plugin reads `~/.fountain/credentials`
+    exactly as the CLI does (`FOUNTAIN_PROFILE` selects a profile):
+
+    ```bash
+    brew install BinaryBourbon/tap/fountain
+    fountain auth login
+    ```
+
+    Inside a Fountain sandbox nothing is needed: the plugin picks up the
+    conversation-scoped `FOUNTAIN_TOKEN` and marks the conversations it starts
+    as children of the one it is running in.
+
+2. Install and enable the plugin:
+
+    ```bash
+    hermes plugins install BinaryBourbon/fountain/integrations/hermes/fountain --enable
+    ```
+
+    From a checkout of this repo, a symlink does the same:
+    `ln -s "$PWD/integrations/hermes/fountain" ~/.hermes/plugins/fountain &&
+    hermes plugins enable fountain`.
+
+3. Check it:
+
+    ```
+    hermes plugins doctor ~/.hermes/plugins/fountain    # 7 tool(s) registered
+    hermes                                              # then, in the session:
+    /fountain whoami
+    /fountain agents
+    ```
+
+    The tools are on for the CLI and TUI by default. If you have saved an
+    explicit toolset list with `hermes tools`, tick **Fountain** there.
+
+Optional settings live under `plugins.entries.fountain.settings` in Hermes's
+`config.yaml` and win over the environment: `base_url`, `api_key`, `profile`,
+and `default_timeout_seconds` (see Long turns).
+
+## What Hermes gets
+
+| Tool | Does |
+|---|---|
+| `fountain_agents` | list the account's agents (name, runtime, model) |
+| `fountain_run` | start a conversation with an agent — a fresh sandbox — and wait for the answer; `vault` / `environment` pick per-run overrides; `wait: false` returns the id at once |
+| `fountain_send` | a follow-up turn in the same conversation; the agent remembers the earlier turns and the sandbox keeps its files |
+| `fountain_wait` | keep waiting on the current turn and collect what arrived since the last look |
+| `fountain_status` | lifecycle status and turns, no waiting |
+| `fountain_conversations` | the live conversations on the account |
+| `fountain_terminate` | end a conversation and destroy its sandbox |
+
+Every result carries the conversation's `url`, so the transcript is one click
+away in the Fountain UI. The answer itself is the agent's text — Fountain
+serves the log feed pre-parsed into blocks (`?blocks=true`, ADR 0014), so the
+plugin never learns a runtime's dialect; a claude, codex, gemini or opencode
+agent all come back the same way.
+
+Two extras: a `fountain` skill (`skill_view("fountain:fountain")`) that tells the
+Hermes model *when* to delegate and how to brief an agent, and a `/fountain`
+slash command (`agents`, `run <agent> <prompt>`, `send`, `wait`, `status`,
+`conversations`, `terminate`, `whoami`) for driving it by hand from any Hermes
+surface.
+
+## Long turns
+
+A Fountain turn can run for many minutes; Hermes deadlines a tool call at 420 s
+by default (`timeouts.tools.sequential_call`). The plugin never sits inside one
+call for the life of a turn: `fountain_run`, `fountain_send` and `fountain_wait`
+return after `timeout_seconds` (default 300, from `default_timeout_seconds`)
+with `done: false` and the output so far, and the model calls `fountain_wait`
+to continue — the cursor is remembered, so each call returns only new text.
+The skill spells this out; a turn is finished when `done` is `true` and
+`turn_state` says `done`, `failed` (with a `reason`) or `interrupted`.
+
+Provisioning is inside the first wait: a cold sandbox is typically 20–90 s
+before the agent's first token, depending on the sandbox provider and the
+environment's setup script.
+
+## Limits
+
+- **No permission prompts.** A Fountain agent runs under the sandbox's own
+  policy; there is nothing to approve from Hermes. (Forwarding permission
+  requests to a client is #643 and lands for `fountain acp` clients first —
+  this plugin polls the log feed and is unaffected either way.)
+- **Text only, one direction.** The plugin returns the agent's text and the
+  names of the tools it used; files it wrote stay in the sandbox (push them
+  from the environment's repo, or ask the agent to print them). Images in
+  prompts are not passed through.
+- **Agents are chosen, not managed.** Creating or editing agents, environments
+  and vaults is the web UI, the CLI or `fountain apply`; the plugin lists and
+  runs what exists.
+
+The plugin source and its tests are at
+[`integrations/hermes/`](https://github.com/BinaryBourbon/fountain/tree/main/integrations/hermes)
+in the Fountain repo.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -29,6 +29,13 @@ surface — Telegram, Discord, Slack — by registering Fountain as a custom ACP
 agent in its `acpx` plugin. Again there is nothing to change on the Fountain
 side; the configuration is client-side, on the OpenClaw host.
 
+[**Hermes Agent**](hermes.md) is a client of the HTTP API rather than of
+`fountain acp`: a Hermes plugin (shipped in this repo under
+`integrations/hermes/`) gives Hermes `fountain_run` and friends, so its model
+delegates a task to a named Fountain agent and reads the answer back. Nothing
+to configure server-side; the plugin authenticates with an API key or the
+CLI's saved login.
+
 [**Buzz**](buzz.md) is the other direction: Fountain *hosts* a Buzz agent —
 a Nostr identity that lives on a relay — running its coding agent in a sandbox
 and holding its signing key in a vault. Provision one from the Buzz desktop or

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,45 @@
+# Fountain plugin for Hermes Agent
+
+Run [Fountain](https://github.com/BinaryBourbon/fountain) agents as tools from
+[Hermes Agent](https://github.com/NousResearch/hermes-agent). Hermes gets
+`fountain_run` and friends; the work runs in a Fountain sandbox.
+
+The user-facing page is [`docs/integrations/hermes.md`](../../docs/integrations/hermes.md).
+This directory is the plugin itself plus its tests.
+
+```
+integrations/hermes/
+├── fountain/                 the plugin — install this directory
+│   ├── plugin.yaml           manifest (v2): tools, config_schema
+│   ├── __init__.py           register(ctx): tools, skill, /fountain command
+│   ├── client.py             stdlib HTTP client + credential resolution
+│   ├── tools.py              handlers; follows a turn through /events?blocks=true
+│   ├── schemas.py            tool schemas (what the model sees)
+│   └── skills/fountain/SKILL.md
+└── tests/                    unittest, against an in-process fake Fountain
+```
+
+## Install
+
+```bash
+hermes plugins install BinaryBourbon/fountain/integrations/hermes/fountain --enable
+# or, from a checkout:
+ln -s "$PWD/integrations/hermes/fountain" ~/.hermes/plugins/fountain && hermes plugins enable fountain
+```
+
+Credentials resolve like the `fountain` CLI: `FOUNTAIN_API_KEY` (or the
+in-sandbox `FOUNTAIN_TOKEN`), then `~/.fountain/credentials` (written by
+`fountain auth login`). `FOUNTAIN_BASE_URL` points at a self-hosted instance.
+Both can also be pinned in Hermes config under
+`plugins.entries.fountain.settings` (`base_url`, `api_key`, `profile`,
+`default_timeout_seconds`).
+
+## Test
+
+```bash
+python3 -m unittest discover -s integrations/hermes/tests -v   # from the repo root
+hermes plugins doctor integrations/hermes/fountain              # with a Hermes checkout
+```
+
+No dependencies: the plugin and its tests are stdlib Python ≥ 3.9 (Hermes
+itself needs 3.11).

--- a/integrations/hermes/fountain/__init__.py
+++ b/integrations/hermes/fountain/__init__.py
@@ -1,0 +1,171 @@
+"""Hermes plugin: Fountain agents as tools.
+
+Registers seven tools (`fountain_agents`, `fountain_run`, `fountain_send`,
+`fountain_wait`, `fountain_status`, `fountain_conversations`,
+`fountain_terminate`), a `fountain:fountain` skill that explains when to reach
+for them, and a `/fountain` slash command for humans.
+
+Install: symlink or copy this directory to `~/.hermes/plugins/fountain/`, or
+`hermes plugins install BinaryBourbon/fountain/integrations/hermes/fountain --enable`.
+Configure with `FOUNTAIN_API_KEY` (+ `FOUNTAIN_BASE_URL` for a self-hosted
+instance), `fountain auth login`, or `plugins.entries.fountain.settings.*`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+from pathlib import Path
+
+from . import schemas
+from .client import FountainClient, FountainError, resolve_settings
+from .tools import FountainTools
+
+logger = logging.getLogger(__name__)
+
+TOOLSET = "fountain"
+
+_HELP = """/fountain — Fountain agents from Hermes
+  /fountain agents [search]            list agents
+  /fountain run <agent> <prompt…>      start a conversation and wait for the answer
+  /fountain send <conversation_id> <prompt…>
+  /fountain wait <conversation_id>
+  /fountain status <conversation_id>
+  /fountain conversations              live conversations
+  /fountain terminate <conversation_id>
+  /fountain whoami                     which instance and key source are in use"""
+
+
+def _settings(ctx) -> dict:
+    def get(key: str, default=None):
+        try:
+            val = ctx.get_config(key, default=default)
+        except Exception:  # config access is best-effort — env/credentials still work
+            return default
+        return default if val is None else val
+
+    return {
+        "base_url": str(get("base_url", "") or ""),
+        "api_key": str(get("api_key", "") or ""),
+        "profile": str(get("profile", "") or ""),
+        "default_timeout_seconds": get("default_timeout_seconds", 300),
+    }
+
+
+def register(ctx):
+    settings = _settings(ctx)
+
+    def resolve() -> tuple[str, str]:
+        return resolve_settings(
+            base_url=settings["base_url"], api_key=settings["api_key"], profile=settings["profile"]
+        )
+
+    def client_factory() -> FountainClient:
+        base_url, api_key = resolve()
+        return FountainClient(base_url, api_key)
+
+    def configured() -> bool:
+        _, key = resolve()
+        return bool(key)
+
+    try:
+        default_timeout = float(settings["default_timeout_seconds"] or 300)
+    except (TypeError, ValueError):
+        default_timeout = 300.0
+
+    tools = FountainTools(client_factory, default_timeout=default_timeout)
+
+    handlers = {
+        "fountain_agents": tools.agents,
+        "fountain_run": tools.run,
+        "fountain_send": tools.send,
+        "fountain_wait": tools.wait,
+        "fountain_status": tools.status,
+        "fountain_conversations": tools.conversations,
+        "fountain_terminate": tools.terminate,
+    }
+    for schema in schemas.ALL:
+        ctx.register_tool(
+            name=schema["name"],
+            toolset=TOOLSET,
+            schema=schema,
+            handler=handlers[schema["name"]],
+            check_fn=configured,
+            emoji="⛲",
+        )
+
+    skill_md = Path(__file__).parent / "skills" / "fountain" / "SKILL.md"
+    if skill_md.exists():
+        try:
+            ctx.register_skill("fountain", skill_md, description="Delegating work to Fountain agents")
+        except Exception as exc:  # older Hermes without register_skill
+            logger.debug("fountain plugin: register_skill unavailable: %s", exc)
+
+    def slash(raw_args: str) -> str:
+        return _slash(raw_args, tools, resolve)
+
+    try:
+        ctx.register_command(
+            "fountain",
+            slash,
+            description="Run and inspect Fountain agents",
+            args_hint="agents | run <agent> <prompt> | send <id> <prompt> | wait <id> | status <id> | conversations | terminate <id>",
+        )
+    except Exception as exc:
+        logger.debug("fountain plugin: register_command unavailable: %s", exc)
+
+
+def _slash(raw_args: str, tools: FountainTools, resolve) -> str:
+    try:
+        parts = shlex.split(raw_args or "")
+    except ValueError:
+        parts = (raw_args or "").split()
+    if not parts or parts[0] in ("help", "-h", "--help"):
+        return _HELP
+    cmd, rest = parts[0], parts[1:]
+
+    if cmd == "whoami":
+        base_url, key = resolve()
+        return f"instance: {base_url}\napi key: {'configured' if key else 'MISSING'}"
+    if cmd == "agents":
+        return _pretty(tools.agents({"search": " ".join(rest) or None}))
+    if cmd == "run":
+        if len(rest) < 2:
+            return "usage: /fountain run <agent> <prompt…>"
+        return _pretty(tools.run({"agent": rest[0], "prompt": " ".join(rest[1:])}))
+    if cmd == "send":
+        if len(rest) < 2:
+            return "usage: /fountain send <conversation_id> <prompt…>"
+        return _pretty(tools.send({"conversation_id": rest[0], "prompt": " ".join(rest[1:])}))
+    if cmd == "wait":
+        if not rest:
+            return "usage: /fountain wait <conversation_id>"
+        return _pretty(tools.wait({"conversation_id": rest[0]}))
+    if cmd == "status":
+        if not rest:
+            return "usage: /fountain status <conversation_id>"
+        return _pretty(tools.status({"conversation_id": rest[0]}))
+    if cmd in ("conversations", "convs", "ls"):
+        return _pretty(tools.conversations({}))
+    if cmd == "terminate":
+        if not rest:
+            return "usage: /fountain terminate <conversation_id>"
+        return _pretty(tools.terminate({"conversation_id": rest[0]}))
+    return f"unknown subcommand {cmd!r}\n\n{_HELP}"
+
+
+def _pretty(result_json: str) -> str:
+    try:
+        data = json.loads(result_json)
+    except ValueError:
+        return result_json
+    if isinstance(data, dict) and "error" in data:
+        return f"error: {data['error']}"
+    if isinstance(data, dict) and "output" in data:
+        head = {k: v for k, v in data.items() if k != "output"}
+        return json.dumps(head, indent=2, default=str) + "\n\n" + (data.get("output") or "(no output)")
+    return json.dumps(data, indent=2, default=str)
+
+
+__all__ = ["register", "FountainClient", "FountainError", "FountainTools"]

--- a/integrations/hermes/fountain/client.py
+++ b/integrations/hermes/fountain/client.py
@@ -1,0 +1,260 @@
+"""A small Fountain API client — stdlib only, so the plugin has no pip dependencies.
+
+Credential resolution mirrors the `fountain` CLI (cli/internal/config):
+
+  api_key:  plugin setting → FOUNTAIN_API_KEY → FOUNTAIN_TOKEN → ~/.fountain/credentials
+  base_url: plugin setting → FOUNTAIN_BASE_URL → ~/.fountain/credentials → hosted default
+
+`FOUNTAIN_TOKEN` is what a Fountain sandbox exports for the agent inside it, so a
+Hermes running *in* a Fountain sandbox delegates with the conversation-scoped
+token it already has, and the spawned conversations are attributed as children
+of it via `X-Fountain-Parent-Conversation-Id` (`FOUNTAIN_CONVERSATION_ID`).
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_BASE_URL = "https://fountain.inevitable.fyi"
+USER_AGENT = "hermes-fountain-plugin/0.1.0"
+
+
+class FountainError(Exception):
+    """An API call failed. `status` is the HTTP status (0 for transport errors)."""
+
+    def __init__(self, message: str, status: int = 0, body: Any = None):
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def _credentials_path() -> Path:
+    override = os.environ.get("FOUNTAIN_CREDENTIALS_FILE", "").strip()
+    if override:
+        return Path(override)
+    return Path.home() / ".fountain" / "credentials"
+
+
+def _read_credentials(profile: str) -> dict[str, str]:
+    path = _credentials_path()
+    if not path.is_file():
+        return {}
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(path)
+    except configparser.Error:
+        return {}
+    if not parser.has_section(profile):
+        return {}
+    # `fountain auth login` writes values quoted (`api_key = "fk_…"`); tolerate both.
+    return {k: _unquote(v) for k, v in parser.items(profile)}
+
+
+def _unquote(value: str) -> str:
+    v = (value or "").strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in "\"'":
+        v = v[1:-1]
+    return v.strip()
+
+
+def resolve_settings(
+    *,
+    base_url: str = "",
+    api_key: str = "",
+    profile: str = "",
+) -> tuple[str, str]:
+    """Return `(base_url, api_key)`; `api_key` is "" when nothing is configured."""
+    profile = profile or os.environ.get("FOUNTAIN_PROFILE", "").strip() or "default"
+    creds: dict[str, str] | None = None
+
+    key = (api_key or "").strip() or os.environ.get("FOUNTAIN_API_KEY", "").strip() or os.environ.get(
+        "FOUNTAIN_TOKEN", ""
+    ).strip()
+    if not key:
+        creds = _read_credentials(profile)
+        key = creds.get("api_key", "")
+
+    url = (base_url or "").strip() or os.environ.get("FOUNTAIN_BASE_URL", "").strip()
+    if not url:
+        if creds is None:
+            creds = _read_credentials(profile)
+        url = creds.get("base_url", "") or DEFAULT_BASE_URL
+
+    return url.rstrip("/"), key
+
+
+class FountainClient:
+    def __init__(self, base_url: str, api_key: str, *, timeout: float = 30.0):
+        if not api_key:
+            raise FountainError(
+                "No Fountain API key. Set FOUNTAIN_API_KEY, run `fountain auth login`, "
+                "or set plugins.entries.fountain.settings.api_key in Hermes config."
+            )
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+        self.parent_conversation_id = os.environ.get("FOUNTAIN_CONVERSATION_ID", "").strip()
+
+    # ── transport ──────────────────────────────────────────────────────────
+
+    def request(self, method: str, path: str, *, params: dict | None = None, body: dict | None = None) -> Any:
+        url = self.base_url + path
+        if params:
+            clean = {k: v for k, v in params.items() if v is not None and v != ""}
+            if clean:
+                url += "?" + urllib.parse.urlencode(clean)
+        data = None
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        }
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        if self.parent_conversation_id:
+            headers["X-Fountain-Parent-Conversation-Id"] = self.parent_conversation_id
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read()
+        except urllib.error.HTTPError as exc:
+            raw = exc.read()
+            parsed = _maybe_json(raw)
+            raise FountainError(_describe_http_error(exc.code, parsed, url), status=exc.code, body=parsed) from None
+        except (urllib.error.URLError, OSError, TimeoutError) as exc:
+            raise FountainError(f"{method} {url} failed: {exc}") from None
+        return _maybe_json(raw) if raw else None
+
+    # ── agents ─────────────────────────────────────────────────────────────
+
+    def list_agents(self, search: str | None = None) -> list[dict]:
+        out = self.request("GET", "/api/agents", params={"search": search})
+        return list((out or {}).get("data") or [])
+
+    def resolve_agent(self, name_or_id: str) -> dict:
+        """Find an agent by id, then by exact name (case-insensitive), then unique prefix."""
+        wanted = (name_or_id or "").strip()
+        if not wanted:
+            raise FountainError("agent is required (a Fountain agent name or id)")
+        agents = self.list_agents()
+        for a in agents:
+            if a.get("id") == wanted:
+                return a
+        exact = [a for a in agents if (a.get("name") or "").lower() == wanted.lower()]
+        if len(exact) == 1:
+            return exact[0]
+        prefix = [a for a in agents if (a.get("name") or "").lower().startswith(wanted.lower())]
+        if len(prefix) == 1:
+            return prefix[0]
+        names = ", ".join(sorted(a.get("name") or "?" for a in agents)) or "(none)"
+        raise FountainError(f"No agent named {wanted!r}. Agents on this account: {names}")
+
+    # ── conversations ──────────────────────────────────────────────────────
+
+    def create_conversation(
+        self,
+        agent_id: str,
+        prompt: str,
+        *,
+        vault_id: str | None = None,
+        environment_id: str | None = None,
+    ) -> dict:
+        body: dict[str, Any] = {"agent_id": agent_id, "prompt": prompt}
+        if vault_id:
+            body["vault_id"] = vault_id
+        if environment_id:
+            body["environment_id"] = environment_id
+        out = self.request("POST", "/api/conversations", body=body)
+        return (out or {}).get("data") or {}
+
+    def get_conversation(self, conversation_id: str) -> dict:
+        out = self.request("GET", f"/api/conversations/{conversation_id}")
+        return (out or {}).get("data") or {}
+
+    def list_conversations(self, roots_only: bool = True) -> list[dict]:
+        out = self.request(
+            "GET", "/api/conversations", params={"roots_only": "true" if roots_only else None}
+        )
+        return list((out or {}).get("data") or [])
+
+    def list_turns(self, conversation_id: str) -> list[dict]:
+        out = self.request("GET", f"/api/conversations/{conversation_id}/turns")
+        return list((out or {}).get("data") or [])
+
+    def send_prompt(self, conversation_id: str, prompt: str) -> dict:
+        return self.request("POST", f"/api/conversations/{conversation_id}/prompts", body={"prompt": prompt}) or {}
+
+    def interrupt(self, conversation_id: str) -> Any:
+        return self.request("POST", f"/api/conversations/{conversation_id}/interrupt")
+
+    def terminate(self, conversation_id: str) -> Any:
+        return self.request("POST", f"/api/conversations/{conversation_id}/terminate")
+
+    def events(self, conversation_id: str, *, after: int = 0, limit: int = 1000) -> tuple[list[dict], int | None, bool]:
+        """One page of log events after `after`, with blocks. Returns (events, next_cursor, has_more)."""
+        out = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/events",
+            params={"after": after, "limit": limit, "blocks": "true"},
+        )
+        out = out or {}
+        meta = out.get("meta") or {}
+        return list(out.get("data") or []), meta.get("next_cursor"), bool(meta.get("has_more"))
+
+    def resolve_vault(self, name_or_id: str | None) -> str | None:
+        return self._resolve_named("/api/vaults", "vault", name_or_id)
+
+    def resolve_environment(self, name_or_id: str | None) -> str | None:
+        return self._resolve_named("/api/environments", "environment", name_or_id)
+
+    def _resolve_named(self, path: str, what: str, name_or_id: str | None) -> str | None:
+        wanted = (name_or_id or "").strip()
+        if not wanted:
+            return None
+        items = list((self.request("GET", path) or {}).get("data") or [])
+        for it in items:
+            if it.get("id") == wanted:
+                return wanted
+        exact = [it for it in items if (it.get("name") or "").lower() == wanted.lower()]
+        if len(exact) == 1:
+            return exact[0]["id"]
+        names = ", ".join(sorted(it.get("name") or "?" for it in items)) or "(none)"
+        raise FountainError(f"No {what} named {wanted!r}. Available: {names}")
+
+
+def _maybe_json(raw: bytes) -> Any:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return raw.decode("utf-8", "replace")
+
+
+def _describe_http_error(status: int, parsed: Any, url: str) -> str:
+    detail = ""
+    if isinstance(parsed, dict):
+        err = parsed.get("error") or parsed.get("errors") or parsed.get("message")
+        if err:
+            detail = err if isinstance(err, str) else json.dumps(err)
+    elif isinstance(parsed, str) and parsed.strip():
+        detail = parsed.strip()[:300]
+    hints = {
+        401: "unauthorized — check the API key",
+        402: "payment required — the account has no active subscription",
+        404: "not found — wrong id, or it belongs to another account",
+        409: "conflict",
+        422: "rejected",
+        429: "rate limited — retry shortly",
+    }
+    hint = hints.get(status, "")
+    parts = [f"HTTP {status}", hint, detail, f"({url})"]
+    return " ".join(p for p in parts if p)

--- a/integrations/hermes/fountain/plugin.yaml
+++ b/integrations/hermes/fountain/plugin.yaml
@@ -1,0 +1,34 @@
+name: fountain
+version: 0.1.0
+manifest_version: 2
+api_version: 1
+description: Run Fountain agents — sandboxed coding agents on a Fountain instance — as tools from Hermes.
+author: BinaryBourbon
+license: MIT
+homepage: https://github.com/BinaryBourbon/fountain
+tags: [fountain, delegation, sandbox, agents]
+provides_tools:
+  - fountain_agents
+  - fountain_run
+  - fountain_send
+  - fountain_wait
+  - fountain_status
+  - fountain_conversations
+  - fountain_terminate
+config_schema:
+  base_url:
+    type: str
+    default: ""
+    description: Fountain instance URL. Falls back to FOUNTAIN_BASE_URL, then ~/.fountain/credentials, then https://fountain.inevitable.fyi.
+  api_key:
+    type: str
+    default: ""
+    description: Fountain API key. Falls back to FOUNTAIN_API_KEY / FOUNTAIN_TOKEN, then ~/.fountain/credentials.
+  profile:
+    type: str
+    default: ""
+    description: Profile in ~/.fountain/credentials to read when no key is configured (default "default", or FOUNTAIN_PROFILE).
+  default_timeout_seconds:
+    type: int
+    default: 300
+    description: How long fountain_run / fountain_send / fountain_wait block for a turn before returning `done=false` (keep it under Hermes's tool deadline, 420s by default).

--- a/integrations/hermes/fountain/schemas.py
+++ b/integrations/hermes/fountain/schemas.py
@@ -1,0 +1,145 @@
+"""Tool schemas — what the Hermes model sees."""
+
+_CONV_ID = {
+    "type": "string",
+    "description": "The Fountain conversation id (returned by fountain_run).",
+}
+_TIMEOUT = {
+    "type": "integer",
+    "description": (
+        "Seconds to wait for the turn before returning with done=false. "
+        "Defaults to the plugin's default_timeout_seconds (300). Keep it under Hermes's tool deadline; "
+        "call fountain_wait to keep waiting."
+    ),
+}
+_WAIT = {
+    "type": "boolean",
+    "description": "Wait for the turn to finish (default true). false returns immediately with the conversation id.",
+    "default": True,
+}
+
+FOUNTAIN_AGENTS = {
+    "name": "fountain_agents",
+    "description": (
+        "List the Fountain agents on the configured account — each is a named, sandboxed coding agent "
+        "(runtime + model + environment) you can run with fountain_run. Call this first when the user "
+        "names an agent you have not seen, or asks what agents exist."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "search": {"type": "string", "description": "Optional substring filter on agent name."},
+        },
+    },
+}
+
+FOUNTAIN_RUN = {
+    "name": "fountain_run",
+    "description": (
+        "Delegate a task to a Fountain agent. Provisions a fresh sandbox for that agent, sends the prompt "
+        "as turn 1, and (by default) waits for the agent's answer. Use it to hand off work that should run "
+        "in an isolated sandbox with its own credentials — a code change in a repo the agent's environment "
+        "clones, a long investigation, or fanning a task out across several agents (call it once per agent "
+        "with wait=false, then fountain_wait each). Returns the conversation_id (keep it: fountain_send "
+        "continues the same conversation, and the sandbox remembers everything so far) plus the agent's "
+        "output. If done=false the turn is still running — call fountain_wait."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "agent": {"type": "string", "description": "Fountain agent name or id (see fountain_agents)."},
+            "prompt": {"type": "string", "description": "The task for the agent. Be complete: it has no other context."},
+            "vault": {
+                "type": "string",
+                "description": "Optional vault name or id whose secrets override the environment's for this conversation.",
+            },
+            "environment": {
+                "type": "string",
+                "description": "Optional environment name or id to provision from instead of the agent's default (must be allowed on the agent).",
+            },
+            "wait": _WAIT,
+            "timeout_seconds": _TIMEOUT,
+        },
+        "required": ["agent", "prompt"],
+    },
+}
+
+FOUNTAIN_SEND = {
+    "name": "fountain_send",
+    "description": (
+        "Send a follow-up prompt to an existing Fountain conversation (turn 2+). The agent's session "
+        "resumes in the same sandbox with everything from earlier turns. Waits for the answer by default."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conversation_id": _CONV_ID,
+            "prompt": {"type": "string", "description": "The follow-up prompt."},
+            "wait": _WAIT,
+            "timeout_seconds": _TIMEOUT,
+        },
+        "required": ["conversation_id", "prompt"],
+    },
+}
+
+FOUNTAIN_WAIT = {
+    "name": "fountain_wait",
+    "description": (
+        "Keep waiting on a Fountain conversation's current turn and collect its output. Call this after "
+        "fountain_run / fountain_send returned done=false, or after starting with wait=false. Returns the "
+        "text the agent produced since you last looked, and done=true once the turn finished."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"conversation_id": _CONV_ID, "timeout_seconds": _TIMEOUT},
+        "required": ["conversation_id"],
+    },
+}
+
+FOUNTAIN_STATUS = {
+    "name": "fountain_status",
+    "description": (
+        "Show a Fountain conversation: lifecycle status (pending, running, idle, failed, terminated), "
+        "runtime, and its turns with their statuses. Cheap; does not wait."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"conversation_id": _CONV_ID},
+        "required": ["conversation_id"],
+    },
+}
+
+FOUNTAIN_CONVERSATIONS = {
+    "name": "fountain_conversations",
+    "description": "List the account's Fountain conversations (most recent first), by default only ones that are still alive.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "active_only": {"type": "boolean", "description": "Hide failed/terminated conversations (default true).", "default": True},
+            "limit": {"type": "integer", "description": "Max conversations to return (default 20).", "default": 20},
+        },
+    },
+}
+
+FOUNTAIN_TERMINATE = {
+    "name": "fountain_terminate",
+    "description": (
+        "End a Fountain conversation and destroy its sandbox. Do this when the delegated work is finished "
+        "and no follow-up is expected; idle conversations are also reclaimed by Fountain on their own."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"conversation_id": _CONV_ID},
+        "required": ["conversation_id"],
+    },
+}
+
+ALL = [
+    FOUNTAIN_AGENTS,
+    FOUNTAIN_RUN,
+    FOUNTAIN_SEND,
+    FOUNTAIN_WAIT,
+    FOUNTAIN_STATUS,
+    FOUNTAIN_CONVERSATIONS,
+    FOUNTAIN_TERMINATE,
+]

--- a/integrations/hermes/fountain/skills/fountain/SKILL.md
+++ b/integrations/hermes/fountain/skills/fountain/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: fountain
+description: Delegate work to Fountain agents — sandboxed coding agents (claude/codex/gemini/opencode) that each run in their own per-conversation sandbox on a Fountain instance. Use when the user asks to spin up an agent on Fountain, hand a task to a named agent, fan a task out across several agents, or continue a Fountain conversation. The fountain_* tools are the interface; this skill is the operating model.
+---
+
+# Fountain from Hermes
+
+You have `fountain_*` tools. Each call talks to a Fountain instance on the
+user's behalf; the work runs **there**, in a sandbox Fountain provisions, not
+on this machine.
+
+## Mental model
+
+| Primitive | What it is |
+|---|---|
+| **Agent** | a named runtime config: runtime (claude/codex/gemini/opencode), model, system prompt, an environment (packages, repos, secrets, network policy), optional skills and MCP servers |
+| **Conversation** | one running instance of an agent in a fresh sandbox; multi-turn; the sandbox keeps state between turns until it is terminated or reclaimed |
+| **Turn** | one prompt and everything the agent did in response |
+| **Vault** | a bag of secret overrides picked per conversation (wins over the environment on key collision) |
+
+The user chooses *which* agent by name; you do not configure agents from here.
+
+## Workflow
+
+1. `fountain_agents` — once per session, or when the user names an agent you
+   have not seen. Match by name; pass the name (or id) to `fountain_run`.
+2. `fountain_run(agent, prompt)` — write the prompt as if briefing a contractor
+   with **no other context**: the goal, the repo/paths if the environment
+   clones one, what "done" looks like, and what to report back. It provisions
+   a sandbox (typically 30–90 s) and waits for the answer.
+3. Read `output`. If `done` is `false`, the turn is still running: call
+   `fountain_wait(conversation_id)` — repeat until `done`. Do not re-run the
+   task.
+4. Follow-ups go to the **same** conversation with `fountain_send` — the agent
+   remembers the earlier turns and the sandbox still has its files.
+5. When the delegated work is finished and no follow-up is expected,
+   `fountain_terminate`. Idle conversations are reclaimed anyway; terminating
+   just frees the sandbox sooner.
+
+### Fan-out
+
+Start each with `wait: false`, then `fountain_wait` each conversation id in
+turn:
+
+```
+fountain_run(agent="reviewer", prompt="Audit auth/ …", wait=false)  → conv A
+fountain_run(agent="reviewer", prompt="Audit billing/ …", wait=false) → conv B
+fountain_wait(A); fountain_wait(B)
+```
+
+### Long turns
+
+Every blocking call returns after `timeout_seconds` (default 300) with
+`done=false` and the output so far. Keep waiting with `fountain_wait`; the
+cursor is remembered, so you only see new text. Never assume a turn failed
+because a wait returned — check `done` / `turn_state`.
+
+## Reporting back
+
+Relay the agent's `output` faithfully — it is the deliverable — and include
+the conversation `url` so the user can open the transcript in Fountain. Say
+which agent ran and whether the turn finished (`turn_state: done`), failed
+(`failed`, with `reason`) or was interrupted.
+
+## Errors you may see
+
+- `No agent named …` — list agents; the user probably meant a different name.
+- `HTTP 401` — the API key is wrong or missing (`FOUNTAIN_API_KEY`, or
+  `fountain auth login`).
+- `HTTP 402` — the account has no active subscription on that instance.
+- `HTTP 404` on a conversation — wrong id, or it belongs to another account.
+- `conversation_busy` — a turn is already running; `fountain_wait` first.

--- a/integrations/hermes/fountain/tools.py
+++ b/integrations/hermes/fountain/tools.py
@@ -1,0 +1,401 @@
+"""Tool handlers: run a Fountain agent, wait for its turn, read the answer.
+
+A Fountain conversation is a sandbox running an agent; a turn is one prompt and
+everything the agent did in response. Fountain's log feed (`/events?blocks=true`)
+is the read-model these handlers consume: `output` rows carry server-parsed
+`blocks` (`text`, `tool_use`, ...), and `stage` rows mark the turn lifecycle
+(`turn/started`, `turn/done`, `turn/failed`, `turn/interrupted`).
+
+Waiting is bounded: every blocking tool returns after `timeout_seconds` with
+`done: false` and whatever text has arrived, and `fountain_wait` picks up where
+it left off. Hermes deadlines a tool call at 420s by default (see
+`timeouts.tools.sequential_call`), so the plugin never sits inside one call for
+the whole life of a long turn.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any, Callable
+
+from .client import FountainClient, FountainError
+
+TERMINAL_TURN_STATES = ("done", "failed", "interrupted")
+TERMINAL_CONVERSATION_STATUSES = ("failed", "terminated")
+POLL_INTERVAL_S = 2.0
+MAX_OUTPUT_CHARS = 60_000
+
+
+class TurnTracker:
+    """Per-conversation cursor into the log feed, and the turn currently being followed."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state: dict[str, dict[str, Any]] = {}
+
+    def get(self, conversation_id: str) -> dict[str, Any]:
+        with self._lock:
+            return self._state.setdefault(
+                conversation_id,
+                {
+                    "cursor": 0,  # last event id consumed
+                    "turn_number": None,  # the turn being followed
+                    "turn_id": None,
+                    "started": False,
+                    "state": None,  # terminal turn state once seen
+                    "exit_code": None,
+                    "reason": None,
+                    "text": [],  # accumulated answer fragments
+                    "tools": [],  # tool names used, for the summary
+                    "break_before_text": False,
+                },
+            )
+
+    def follow(self, conversation_id: str, turn_number: int) -> dict[str, Any]:
+        st = self.get(conversation_id)
+        with self._lock:
+            st.update(
+                {
+                    "turn_number": turn_number,
+                    "turn_id": None,
+                    "started": False,
+                    "state": None,
+                    "exit_code": None,
+                    "reason": None,
+                    "text": [],
+                    "tools": [],
+                    "break_before_text": False,
+                }
+            )
+        return st
+
+    def forget(self, conversation_id: str) -> None:
+        with self._lock:
+            self._state.pop(conversation_id, None)
+
+
+class FountainTools:
+    def __init__(
+        self,
+        client_factory: Callable[[], FountainClient],
+        *,
+        default_timeout: float = 300.0,
+        poll_interval: float = POLL_INTERVAL_S,
+        sleep: Callable[[float], None] = time.sleep,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._client_factory = client_factory
+        self.default_timeout = default_timeout
+        self.poll_interval = poll_interval
+        self._sleep = sleep
+        self._clock = clock
+        self.tracker = TurnTracker()
+
+    # ── handlers (each returns a JSON string, never raises) ────────────────
+
+    def agents(self, args: dict, **_: Any) -> str:
+        return self._guard(lambda: self._agents(args))
+
+    def run(self, args: dict, **_: Any) -> str:
+        return self._guard(lambda: self._run(args))
+
+    def send(self, args: dict, **_: Any) -> str:
+        return self._guard(lambda: self._send(args))
+
+    def wait(self, args: dict, **_: Any) -> str:
+        return self._guard(lambda: self._wait(args))
+
+    def status(self, args: dict, **_: Any) -> str:
+        return self._guard(lambda: self._status(args))
+
+    def conversations(self, args: dict, **_: Any) -> str:
+        return self._guard(lambda: self._conversations(args))
+
+    def terminate(self, args: dict, **_: Any) -> str:
+        return self._guard(lambda: self._terminate(args))
+
+    # ── implementations ────────────────────────────────────────────────────
+
+    def _agents(self, args: dict) -> dict:
+        client = self._client_factory()
+        agents = client.list_agents(search=(args.get("search") or None))
+        return {
+            "agents": [
+                {
+                    "id": a.get("id"),
+                    "name": a.get("name"),
+                    "runtime": a.get("runtime"),
+                    "model": a.get("model"),
+                    "description": a.get("description"),
+                    "environment_id": a.get("environment_id"),
+                }
+                for a in agents
+            ],
+            "count": len(agents),
+        }
+
+    def _run(self, args: dict) -> dict:
+        prompt = _required(args, "prompt")
+        client = self._client_factory()
+        agent = client.resolve_agent(_required(args, "agent"))
+        vault_id = client.resolve_vault(args.get("vault"))
+        environment_id = client.resolve_environment(args.get("environment"))
+        conv = client.create_conversation(
+            agent["id"], prompt, vault_id=vault_id, environment_id=environment_id
+        )
+        conv_id = conv.get("id")
+        if not conv_id:
+            raise FountainError(f"POST /api/conversations returned no id: {conv!r}")
+        self.tracker.follow(conv_id, 1)
+        base = {
+            "conversation_id": conv_id,
+            "agent": {"id": agent.get("id"), "name": agent.get("name"), "runtime": agent.get("runtime")},
+            "turn_number": 1,
+            "url": f"{client.base_url}/conversations/{conv_id}",
+        }
+        if args.get("wait") is False:
+            return {**base, "status": conv.get("status"), "done": False,
+                    "note": "Not waiting. Call fountain_wait with this conversation_id to collect the answer."}
+        return {**base, **self._follow(client, conv_id, self._timeout(args))}
+
+    def _send(self, args: dict) -> dict:
+        conv_id = _required(args, "conversation_id")
+        prompt = _required(args, "prompt")
+        client = self._client_factory()
+        turns = client.list_turns(conv_id)
+        next_turn = 1 + max((int(t.get("turn_number") or 0) for t in turns), default=0)
+        client.send_prompt(conv_id, prompt)
+        self.tracker.follow(conv_id, next_turn)
+        base = {"conversation_id": conv_id, "turn_number": next_turn,
+                "url": f"{client.base_url}/conversations/{conv_id}"}
+        if args.get("wait") is False:
+            return {**base, "status": "queued", "done": False,
+                    "note": "Not waiting. Call fountain_wait with this conversation_id to collect the answer."}
+        return {**base, **self._follow(client, conv_id, self._timeout(args))}
+
+    def _wait(self, args: dict) -> dict:
+        conv_id = _required(args, "conversation_id")
+        client = self._client_factory()
+        st = self.tracker.get(conv_id)
+        if st["turn_number"] is None:
+            # A conversation this process did not start: follow its latest turn.
+            turns = client.list_turns(conv_id)
+            latest = max((int(t.get("turn_number") or 0) for t in turns), default=0)
+            if latest == 0:
+                return {"conversation_id": conv_id, "done": False, "status": "no_turns",
+                        "output": "", "note": "This conversation has no turns yet."}
+            self.tracker.follow(conv_id, latest)
+        return {"conversation_id": conv_id, "turn_number": st["turn_number"],
+                "url": f"{client.base_url}/conversations/{conv_id}",
+                **self._follow(client, conv_id, self._timeout(args))}
+
+    def _status(self, args: dict) -> dict:
+        conv_id = _required(args, "conversation_id")
+        client = self._client_factory()
+        conv = client.get_conversation(conv_id)
+        turns = client.list_turns(conv_id)
+        return {
+            "conversation": _conversation_summary(conv, client.base_url),
+            "turns": [
+                {k: t.get(k) for k in ("turn_number", "status", "exit_code", "started_at", "ended_at")}
+                | {"prompt": _clip(t.get("prompt") or "", 200)}
+                for t in turns
+            ],
+        }
+
+    def _conversations(self, args: dict) -> dict:
+        client = self._client_factory()
+        convs = client.list_conversations(roots_only=True)
+        active_only = args.get("active_only", True)
+        if active_only:
+            convs = [c for c in convs if c.get("status") not in TERMINAL_CONVERSATION_STATUSES]
+        limit = int(args.get("limit") or 20)
+        convs = convs[:limit]
+        return {"conversations": [_conversation_summary(c, client.base_url) for c in convs],
+                "count": len(convs)}
+
+    def _terminate(self, args: dict) -> dict:
+        conv_id = _required(args, "conversation_id")
+        client = self._client_factory()
+        client.terminate(conv_id)
+        self.tracker.forget(conv_id)
+        return {"conversation_id": conv_id, "status": "terminated"}
+
+    # ── following a turn ───────────────────────────────────────────────────
+
+    def _follow(self, client: FountainClient, conv_id: str, timeout: float) -> dict:
+        """Poll the log feed until the followed turn ends or `timeout` elapses."""
+        st = self.tracker.get(conv_id)
+        deadline = self._clock() + timeout
+        conv_status = None
+        while True:
+            self._consume(client, conv_id, st)
+            if st["state"] in TERMINAL_TURN_STATES:
+                break
+            conv = client.get_conversation(conv_id)
+            conv_status = conv.get("status")
+            if conv_status in TERMINAL_CONVERSATION_STATUSES:
+                # One more drain so a failure written just before the status flip is not lost.
+                self._consume(client, conv_id, st)
+                break
+            if self._clock() >= deadline:
+                break
+            self._sleep(self.poll_interval)
+
+        # Report the status as of the end of the wait, not the last poll's.
+        conv_status = (client.get_conversation(conv_id) or {}).get("status") or conv_status
+        output = "".join(st["text"]).strip()
+        done = st["state"] in TERMINAL_TURN_STATES or conv_status in TERMINAL_CONVERSATION_STATUSES
+        result: dict[str, Any] = {
+            "done": done,
+            "turn_state": st["state"],
+            "output": _clip(output, MAX_OUTPUT_CHARS),
+            "tools_used": sorted(set(st["tools"])),
+        }
+        if conv_status:
+            result["status"] = conv_status
+        if st["exit_code"] is not None:
+            result["exit_code"] = st["exit_code"]
+        if st["reason"]:
+            result["reason"] = st["reason"]
+        if not done:
+            result["note"] = (
+                "The turn is still running. Call fountain_wait with this conversation_id "
+                "to keep waiting; the output so far is above."
+            )
+        return result
+
+    def _consume(self, client: FountainClient, conv_id: str, st: dict[str, Any]) -> None:
+        """Drain new events into the tracker state."""
+        while True:
+            events, next_cursor, has_more = client.events(conv_id, after=st["cursor"])
+            for ev in events:
+                self._apply(ev, st)
+            if next_cursor:
+                st["cursor"] = next_cursor
+            if not has_more or not events:
+                return
+
+    def _apply(self, ev: dict, st: dict[str, Any]) -> None:
+        kind = ev.get("kind")
+        if kind == "stage":
+            if ev.get("stage") != "turn":
+                return
+            meta = _parse_json(ev.get("data")) or {}
+            if meta.get("turn_number") != st["turn_number"] and not (
+                st["turn_id"] and meta.get("turn_id") == st["turn_id"]
+            ):
+                return
+            state = ev.get("state")
+            if state == "started":
+                st["started"] = True
+                st["turn_id"] = meta.get("turn_id") or st["turn_id"]
+            elif state in TERMINAL_TURN_STATES:
+                st["state"] = state
+                st["turn_id"] = st["turn_id"] or meta.get("turn_id")
+                if meta.get("exit_code") is not None:
+                    st["exit_code"] = meta.get("exit_code")
+                if meta.get("reason"):
+                    st["reason"] = meta.get("reason")
+            return
+
+        if kind != "output":
+            return
+        turn_id = ev.get("turn_id")
+        if st["turn_id"] and turn_id and turn_id != st["turn_id"]:
+            return
+        if not st["started"] and not st["turn_id"]:
+            # Output from before our turn started (history of an older turn).
+            return
+        blocks = ev.get("blocks") or []
+        # ACP streams text as chunks of one message, so chunks join with
+        # nothing; a legacy stdout row is a whole message, so rows join as
+        # paragraphs. Either way, text that follows a tool call (or any other
+        # non-text block) is a new message and gets a paragraph break.
+        acp = ev.get("stream") == "acp"
+        for block in blocks:
+            bkind = block.get("kind")
+            if bkind == "text":
+                body = block.get("body") or ""
+                if body:
+                    if st["text"] and (not acp or st.get("break_before_text")) and not st["text"][-1].endswith("\n"):
+                        st["text"].append("\n\n")
+                    st["text"].append(body)
+                    st["break_before_text"] = False
+                continue
+            if bkind in ("thinking", "raw", "init"):
+                continue
+            st["break_before_text"] = True
+            if bkind == "tool_use":
+                name = block.get("name")
+                if name:
+                    st["tools"].append(name)
+            elif bkind == "result" and not st["text"]:
+                body = block.get("body") or ""
+                if body:
+                    st["text"].append(body)
+            elif bkind == "error":
+                body = block.get("body") or ""
+                if body:
+                    st["text"].append(f"\n[error] {body}\n")
+
+    # ── helpers ────────────────────────────────────────────────────────────
+
+    def _timeout(self, args: dict) -> float:
+        raw = args.get("timeout_seconds")
+        try:
+            t = float(raw) if raw is not None else self.default_timeout
+        except (TypeError, ValueError):
+            t = self.default_timeout
+        return max(1.0, t)
+
+    @staticmethod
+    def _guard(fn: Callable[[], dict]) -> str:
+        try:
+            return json.dumps(fn(), ensure_ascii=False, default=str)
+        except FountainError as exc:
+            return json.dumps({"error": str(exc)})
+        except Exception as exc:  # a tool handler must never raise
+            return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+
+
+def _required(args: dict, key: str) -> str:
+    val = args.get(key)
+    if val is None or (isinstance(val, str) and not val.strip()):
+        raise FountainError(f"{key} is required")
+    return str(val).strip() if isinstance(val, str) else val
+
+
+def _parse_json(raw: Any) -> Any:
+    if isinstance(raw, (dict, list)):
+        return raw
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError:
+        return None
+
+
+def _clip(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    head = limit // 2
+    tail = limit - head
+    return text[:head] + f"\n…[{len(text) - limit} chars elided]…\n" + text[-tail:]
+
+
+def _conversation_summary(c: dict, base_url: str) -> dict:
+    return {
+        "id": c.get("id"),
+        "title": c.get("title"),
+        "status": c.get("status"),
+        "agent_id": c.get("agent_id"),
+        "runtime": c.get("runtime"),
+        "turn_count": c.get("turn_count"),
+        "last_active_at": c.get("last_active_at"),
+        "unread": c.get("unread"),
+        "url": f"{base_url}/conversations/{c.get('id')}",
+    }

--- a/integrations/hermes/tests/fake_fountain.py
+++ b/integrations/hermes/tests/fake_fountain.py
@@ -1,0 +1,206 @@
+"""A scripted in-process Fountain for the plugin tests.
+
+Serves the slice of the API the plugin uses. Tests append log events and flip
+statuses between polls to script a turn; the server never sleeps.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+TOKEN = "fk_test_token"
+
+
+class State:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.agents = [
+            {"id": "a-1", "name": "reviewer", "runtime": "claude", "model": "opus", "description": "reviews"},
+            {"id": "a-2", "name": "Builder", "runtime": "codex", "model": "gpt-5", "description": None},
+            {"id": "a-3", "name": "builder-two", "runtime": "codex", "model": "gpt-5", "description": None},
+        ]
+        self.vaults = [{"id": "v-1", "name": "prod-keys"}]
+        self.environments = [{"id": "e-1", "name": "py312"}]
+        self.conversations: dict[str, dict] = {}
+        self.turns: dict[str, list[dict]] = {}
+        self.events: dict[str, list[dict]] = {}
+        self.requests: list[tuple[str, str, dict | None, dict]] = []
+        self.next_conv = 1
+        self.next_event = 1
+        # Called (with the state) at the start of every GET so a test can
+        # advance the script per poll.
+        self.on_poll = None
+
+    # ── scripting helpers ─────────────────────────────────────────────────
+
+    def add_event(self, conv_id: str, **ev) -> int:
+        with self.lock:
+            eid = self.next_event
+            self.next_event += 1
+            row = {"id": eid, "kind": ev.get("kind", "output"), "stream": ev.get("stream"),
+                   "data": ev.get("data", ""), "stage": ev.get("stage"), "state": ev.get("state"),
+                   "turn_id": ev.get("turn_id"), "ts": "2026-08-19T00:00:00Z"}
+            if "blocks" in ev:
+                row["blocks"] = ev["blocks"]
+            elif row["kind"] == "output":
+                row["blocks"] = []
+            self.events.setdefault(conv_id, []).append(row)
+            return eid
+
+    def stage(self, conv_id: str, state: str, turn_number: int, turn_id: str, **meta) -> int:
+        return self.add_event(conv_id, kind="stage", stage="turn", state=state,
+                              data=json.dumps({"turn_id": turn_id, "turn_number": turn_number, **meta}))
+
+    def text(self, conv_id: str, turn_id: str, body: str, stream: str = "acp") -> int:
+        return self.add_event(conv_id, kind="output", stream=stream, turn_id=turn_id,
+                              blocks=[{"kind": "text", "body": body}])
+
+    def tool(self, conv_id: str, turn_id: str, name: str) -> int:
+        return self.add_event(conv_id, kind="output", stream="acp", turn_id=turn_id,
+                              blocks=[{"kind": "tool_use", "id": "t1", "name": name, "summary": name, "body": {}}])
+
+    def set_status(self, conv_id: str, status: str) -> None:
+        with self.lock:
+            self.conversations[conv_id]["status"] = status
+
+    def add_turn(self, conv_id: str, prompt: str) -> dict:
+        with self.lock:
+            turns = self.turns.setdefault(conv_id, [])
+            turn = {"id": f"t-{conv_id}-{len(turns) + 1}", "turn_number": len(turns) + 1,
+                    "prompt": prompt, "status": "pending", "exit_code": None,
+                    "started_at": None, "ended_at": None}
+            turns.append(turn)
+            self.conversations[conv_id]["turn_count"] = len(turns)
+            return turn
+
+
+class Handler(BaseHTTPRequestHandler):
+    state: State  # set by the server factory
+
+    def log_message(self, *_):  # silence
+        pass
+
+    def _send(self, code: int, body) -> None:
+        raw = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _auth(self) -> bool:
+        if self.headers.get("Authorization") != f"Bearer {TOKEN}":
+            self._send(401, {"error": "unauthorized"})
+            return False
+        return True
+
+    def _body(self) -> dict | None:
+        n = int(self.headers.get("Content-Length") or 0)
+        if not n:
+            return None
+        return json.loads(self.rfile.read(n))
+
+    def do_GET(self):
+        st = self.state
+        if not self._auth():
+            return
+        url = urlparse(self.path)
+        q = {k: v[0] for k, v in parse_qs(url.query).items()}
+        st.requests.append(("GET", url.path, None, dict(self.headers)))
+        if st.on_poll:
+            st.on_poll(st)
+        parts = url.path.strip("/").split("/")
+        if url.path == "/api/agents":
+            agents = st.agents
+            if q.get("search"):
+                agents = [a for a in agents if q["search"].lower() in a["name"].lower()]
+            return self._send(200, {"data": agents})
+        if url.path == "/api/vaults":
+            return self._send(200, {"data": st.vaults})
+        if url.path == "/api/environments":
+            return self._send(200, {"data": st.environments})
+        if url.path == "/api/conversations":
+            return self._send(200, {"data": list(st.conversations.values())})
+        if len(parts) >= 3 and parts[1] == "conversations":
+            conv = st.conversations.get(parts[2])
+            if not conv:
+                return self._send(404, {"error": "not_found"})
+            if len(parts) == 3:
+                return self._send(200, {"data": conv})
+            if parts[3] == "turns":
+                return self._send(200, {"data": st.turns.get(parts[2], [])})
+            if parts[3] == "events":
+                after = int(q.get("after") or 0)
+                limit = int(q.get("limit") or 100)
+                rows = [e for e in st.events.get(parts[2], []) if e["id"] > after]
+                page, more = rows[:limit], len(rows) > limit
+                out = []
+                for e in page:
+                    e = dict(e)
+                    if q.get("blocks") != "true":
+                        e.pop("blocks", None)
+                    out.append(e)
+                return self._send(200, {"data": out, "meta": {"limit": limit, "has_more": more,
+                                                              "next_cursor": page[-1]["id"] if page else None}})
+        return self._send(404, {"error": "not_found"})
+
+    def do_POST(self):
+        st = self.state
+        if not self._auth():
+            return
+        url = urlparse(self.path)
+        body = self._body()
+        st.requests.append(("POST", url.path, body, dict(self.headers)))
+        parts = url.path.strip("/").split("/")
+        if url.path == "/api/conversations":
+            agent = next((a for a in st.agents if a["id"] == body.get("agent_id")), None)
+            if not agent:
+                return self._send(404, {"error": "not_found"})
+            with st.lock:
+                cid = f"c-{st.next_conv}"
+                st.next_conv += 1
+                st.conversations[cid] = {"id": cid, "title": None, "status": "pending", "agent_id": agent["id"],
+                                         "vault_id": body.get("vault_id"), "environment_id": body.get("environment_id"),
+                                         "runtime": agent["runtime"], "turn_count": 0}
+            if body.get("prompt"):
+                st.add_turn(cid, body["prompt"])
+            return self._send(201, {"data": st.conversations[cid]})
+        if len(parts) == 4 and parts[1] == "conversations":
+            conv = st.conversations.get(parts[2])
+            if not conv:
+                return self._send(404, {"error": "not_found"})
+            if parts[3] == "prompts":
+                if conv["status"] == "running":
+                    return self._send(409, {"error": "conversation_busy"})
+                st.add_turn(parts[2], body["prompt"])
+                return self._send(200, {"status": "queued"})
+            if parts[3] == "terminate":
+                st.set_status(parts[2], "terminated")
+                return self._send(200, {"data": conv})
+            if parts[3] == "interrupt":
+                return self._send(200, {"data": conv})
+        return self._send(404, {"error": "not_found"})
+
+
+class FakeFountain:
+    def __init__(self) -> None:
+        self.state = State()
+        handler = type("BoundHandler", (Handler,), {"state": self.state})
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self) -> "FakeFountain":
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+
+    @property
+    def base_url(self) -> str:
+        host, port = self.server.server_address[:2]
+        return f"http://{host}:{port}"

--- a/integrations/hermes/tests/test_plugin.py
+++ b/integrations/hermes/tests/test_plugin.py
@@ -1,0 +1,401 @@
+"""Tests for the Hermes Fountain plugin. Run from the repo root:
+
+    python3 -m unittest discover -s integrations/hermes/tests -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))  # so `fountain` imports as a package
+sys.path.insert(0, str(HERE))
+
+import fountain as plugin  # noqa: E402
+from fountain.client import FountainClient, FountainError, resolve_settings  # noqa: E402
+from fountain.tools import FountainTools  # noqa: E402
+from fake_fountain import TOKEN, FakeFountain  # noqa: E402
+
+
+class FakeClock:
+    """A clock the test advances; `sleep` advances it and runs a per-tick script."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.ticks = 0
+        self.on_tick = None
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+        self.ticks += 1
+        if self.on_tick:
+            self.on_tick(self.ticks)
+
+
+def make_tools(fake: FakeFountain, clock: FakeClock, **kw) -> FountainTools:
+    return FountainTools(
+        lambda: FountainClient(fake.base_url, TOKEN),
+        default_timeout=kw.pop("default_timeout", 300),
+        poll_interval=1.0,
+        sleep=clock.sleep,
+        clock=clock,
+        **kw,
+    )
+
+
+def script_turn(st, conv_id: str, turn_number: int, chunks, tools=(), state="done", exit_code=0):
+    """Emit a whole turn's events at once."""
+    turn = st.turns[conv_id][turn_number - 1]
+    st.set_status(conv_id, "running")
+    st.stage(conv_id, "started", turn_number, turn["id"], mode="acp")
+    for name in tools:
+        st.tool(conv_id, turn["id"], name)
+    for c in chunks:
+        st.text(conv_id, turn["id"], c)
+    st.stage(conv_id, state, turn_number, turn["id"], exit_code=exit_code)
+    st.set_status(conv_id, "idle")
+
+
+class SettingsTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.creds = Path(self.tmp.name) / "credentials"
+        self.creds.write_text('[default]\napi_key = "from_file"\nbase_url = "https://file.example"\n\n[work]\napi_key = work_key\n')
+        self.env = mock.patch.dict(os.environ, {"FOUNTAIN_CREDENTIALS_FILE": str(self.creds)}, clear=False)
+        self.env.start()
+        for k in ("FOUNTAIN_API_KEY", "FOUNTAIN_TOKEN", "FOUNTAIN_BASE_URL", "FOUNTAIN_PROFILE"):
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        self.env.stop()
+        self.tmp.cleanup()
+
+    def test_credentials_file_is_the_fallback(self):
+        self.assertEqual(resolve_settings(), ("https://file.example", "from_file"))
+
+    def test_env_beats_file_and_settings_beat_env(self):
+        os.environ["FOUNTAIN_API_KEY"] = "from_env"
+        os.environ["FOUNTAIN_BASE_URL"] = "https://env.example/"
+        self.assertEqual(resolve_settings(), ("https://env.example", "from_env"))
+        self.assertEqual(resolve_settings(api_key="cfg", base_url="https://cfg.example"), ("https://cfg.example", "cfg"))
+
+    def test_fountain_token_is_the_in_sandbox_name(self):
+        os.environ["FOUNTAIN_TOKEN"] = "sandbox_token"
+        _, key = resolve_settings()
+        self.assertEqual(key, "sandbox_token")
+
+    def test_profile_selects_a_section(self):
+        _, key = resolve_settings(profile="work")
+        self.assertEqual(key, "work_key")
+        os.environ["FOUNTAIN_PROFILE"] = "work"
+        self.assertEqual(resolve_settings()[1], "work_key")
+
+    def test_no_key_anywhere(self):
+        self.creds.unlink()
+        self.assertEqual(resolve_settings(), ("https://fountain.inevitable.fyi", ""))
+        with self.assertRaises(FountainError):
+            FountainClient("https://x", "")
+
+
+class ClientTests(unittest.TestCase):
+    def test_agent_resolution(self):
+        with FakeFountain() as fake:
+            c = FountainClient(fake.base_url, TOKEN)
+            self.assertEqual(c.resolve_agent("a-2")["name"], "Builder")
+            self.assertEqual(c.resolve_agent("REVIEWER")["id"], "a-1")
+            self.assertEqual(c.resolve_agent("builder")["id"], "a-2")  # exact (ci) beats prefix
+            self.assertEqual(c.resolve_agent("builder-t")["id"], "a-3")  # unique prefix
+            with self.assertRaises(FountainError) as cm:
+                c.resolve_agent("nope")
+            self.assertIn("Builder, builder-two, reviewer", str(cm.exception))
+
+    def test_http_errors_become_fountain_errors(self):
+        with FakeFountain() as fake:
+            c = FountainClient(fake.base_url, "wrong")
+            with self.assertRaises(FountainError) as cm:
+                c.list_agents()
+            self.assertEqual(cm.exception.status, 401)
+            self.assertIn("unauthorized", str(cm.exception))
+            c = FountainClient(fake.base_url, TOKEN)
+            with self.assertRaises(FountainError) as cm:
+                c.get_conversation("missing")
+            self.assertEqual(cm.exception.status, 404)
+
+    def test_parent_conversation_header_when_inside_a_sandbox(self):
+        with FakeFountain() as fake, mock.patch.dict(os.environ, {"FOUNTAIN_CONVERSATION_ID": "parent-1"}):
+            FountainClient(fake.base_url, TOKEN).list_agents()
+            _, _, _, headers = fake.state.requests[-1]
+            self.assertEqual(headers.get("X-Fountain-Parent-Conversation-Id"), "parent-1")
+
+
+class RunTests(unittest.TestCase):
+    def test_run_waits_for_the_turn_and_concatenates_acp_chunks(self):
+        with FakeFountain() as fake:
+            st = fake.state
+            clock = FakeClock()
+            tools = make_tools(fake, clock)
+
+            def on_tick(n):
+                if n == 2:  # sandbox comes up, agent works, turn ends
+                    script_turn(st, "c-1", 1, ["Hello", ", ", "world."], tools=["read_file", "terminal"])
+
+            clock.on_tick = on_tick
+            out = json.loads(tools.run({"agent": "reviewer", "prompt": "say hi", "vault": "prod-keys"}))
+            self.assertNotIn("error", out)
+            self.assertEqual(out["conversation_id"], "c-1")
+            self.assertTrue(out["done"])
+            self.assertEqual(out["turn_state"], "done")
+            self.assertEqual(out["output"], "Hello, world.")
+            self.assertEqual(out["tools_used"], ["read_file", "terminal"])
+            self.assertEqual(out["exit_code"], 0)
+            self.assertEqual(out["agent"]["name"], "reviewer")
+            self.assertEqual(out["url"], f"{fake.base_url}/conversations/c-1")
+            create = next(b for m, p, b, _ in st.requests if m == "POST" and p == "/api/conversations")
+            self.assertEqual(create, {"agent_id": "a-1", "prompt": "say hi", "vault_id": "v-1"})
+
+    def test_acp_text_after_a_tool_call_starts_a_new_paragraph(self):
+        with FakeFountain() as fake:
+            st = fake.state
+            clock = FakeClock()
+            tools = make_tools(fake, clock)
+
+            def on_tick(n):
+                if n == 1:
+                    turn = st.turns["c-1"][0]
+                    st.set_status("c-1", "running")
+                    st.stage("c-1", "started", 1, turn["id"])
+                    st.text("c-1", turn["id"], "smoke ")
+                    st.text("c-1", turn["id"], "ok")
+                    st.tool("c-1", turn["id"], "Terminal")
+                    st.add_event("c-1", kind="output", stream="acp", turn_id=turn["id"],
+                                 blocks=[{"kind": "tool_result", "tool_id": "t1", "body": "Linux", "error": False}])
+                    st.text("c-1", turn["id"], "The kernel ")
+                    st.text("c-1", turn["id"], "is Linux.")
+                    st.stage("c-1", "done", 1, turn["id"], exit_code=0)
+                    st.set_status("c-1", "idle")
+
+            clock.on_tick = on_tick
+            out = json.loads(tools.run({"agent": "reviewer", "prompt": "x"}))
+            self.assertEqual(out["output"], "smoke ok\n\nThe kernel is Linux.")
+            self.assertEqual(out["tools_used"], ["Terminal"])
+
+    def test_legacy_stdout_text_blocks_are_paragraphs(self):
+        with FakeFountain() as fake:
+            st = fake.state
+            clock = FakeClock()
+            tools = make_tools(fake, clock)
+
+            def on_tick(n):
+                if n == 1:
+                    turn = st.turns["c-1"][0]
+                    st.set_status("c-1", "running")
+                    st.stage("c-1", "started", 1, turn["id"])
+                    st.text("c-1", turn["id"], "first message", stream="stdout")
+                    st.text("c-1", turn["id"], "second message", stream="stdout")
+                    st.stage("c-1", "done", 1, turn["id"], exit_code=0)
+                    st.set_status("c-1", "idle")
+
+            clock.on_tick = on_tick
+            out = json.loads(tools.run({"agent": "reviewer", "prompt": "x"}))
+            self.assertEqual(out["output"], "first message\n\nsecond message")
+
+    def test_timeout_returns_partial_and_wait_resumes_from_the_cursor(self):
+        with FakeFountain() as fake:
+            st = fake.state
+            clock = FakeClock()
+            tools = make_tools(fake, clock)
+
+            def on_tick(n):
+                if n == 1:
+                    turn = st.turns["c-1"][0]
+                    st.set_status("c-1", "running")
+                    st.stage("c-1", "started", 1, turn["id"])
+                    st.text("c-1", turn["id"], "part one. ")
+
+            clock.on_tick = on_tick
+            out = json.loads(tools.run({"agent": "reviewer", "prompt": "x", "timeout_seconds": 3}))
+            self.assertFalse(out["done"])
+            self.assertEqual(out["status"], "running")
+            self.assertEqual(out["output"], "part one.")
+            self.assertIn("fountain_wait", out["note"])
+            self.assertLessEqual(clock.now, 4)
+
+            turn = st.turns["c-1"][0]
+            st.text("c-1", turn["id"], "part two.")
+            st.stage("c-1", "done", 1, turn["id"], exit_code=0)
+            st.set_status("c-1", "idle")
+            clock.on_tick = None
+            out2 = json.loads(tools.wait({"conversation_id": "c-1"}))
+            self.assertTrue(out2["done"])
+            self.assertEqual(out2["output"], "part one. part two.")
+
+    def test_send_follows_only_the_new_turn(self):
+        with FakeFountain() as fake:
+            st = fake.state
+            clock = FakeClock()
+            tools = make_tools(fake, clock)
+            clock.on_tick = lambda n: script_turn(st, "c-1", 1, ["answer one"]) if n == 1 else None
+            out = json.loads(tools.run({"agent": "Builder", "prompt": "one"}))
+            self.assertEqual(out["output"], "answer one")
+
+            def on_tick2(n):
+                if n == 1:
+                    script_turn(st, "c-1", 2, ["answer two"], tools=["write_file"])
+
+            clock.ticks = 0
+            clock.on_tick = on_tick2
+            out2 = json.loads(tools.send({"conversation_id": "c-1", "prompt": "two"}))
+            self.assertEqual(out2["turn_number"], 2)
+            self.assertEqual(out2["output"], "answer two")
+            self.assertEqual(out2["tools_used"], ["write_file"])
+            self.assertTrue(out2["done"])
+
+    def test_wait_on_a_conversation_this_process_did_not_start(self):
+        with FakeFountain() as fake:
+            st = fake.state
+            clock = FakeClock()
+            # Another client created it and ran turn 1; turn 2 is in flight.
+            other = FountainClient(fake.base_url, TOKEN)
+            conv = other.create_conversation("a-1", "one")
+            script_turn(st, conv["id"], 1, ["old answer"])
+            st.add_turn(conv["id"], "two")
+            turn2 = st.turns[conv["id"]][1]
+            st.set_status(conv["id"], "running")
+            st.stage(conv["id"], "started", 2, turn2["id"])
+            st.text(conv["id"], turn2["id"], "new answer")
+            st.stage(conv["id"], "done", 2, turn2["id"], exit_code=0)
+            st.set_status(conv["id"], "idle")
+
+            tools = make_tools(fake, clock)
+            out = json.loads(tools.wait({"conversation_id": conv["id"]}))
+            self.assertTrue(out["done"])
+            self.assertEqual(out["turn_number"], 2)
+            self.assertEqual(out["output"], "new answer")
+
+    def test_failed_turn_and_failed_conversation(self):
+        with FakeFountain() as fake:
+            st = fake.state
+            clock = FakeClock()
+            tools = make_tools(fake, clock)
+
+            def on_tick(n):
+                if n == 1:
+                    turn = st.turns["c-1"][0]
+                    st.set_status("c-1", "running")
+                    st.stage("c-1", "started", 1, turn["id"])
+                    st.stage("c-1", "failed", 1, turn["id"], reason="sprite connection lost")
+                    st.set_status("c-1", "failed")
+
+            clock.on_tick = on_tick
+            out = json.loads(tools.run({"agent": "reviewer", "prompt": "x"}))
+            self.assertTrue(out["done"])
+            self.assertEqual(out["turn_state"], "failed")
+            self.assertEqual(out["reason"], "sprite connection lost")
+            self.assertEqual(out["status"], "failed")
+
+        with FakeFountain() as fake:  # provisioning fails before any turn stage
+            st = fake.state
+            clock = FakeClock()
+            tools = make_tools(fake, clock)
+            clock.on_tick = lambda n: st.set_status("c-1", "failed") if n == 1 else None
+            out = json.loads(tools.run({"agent": "reviewer", "prompt": "x"}))
+            self.assertTrue(out["done"])
+            self.assertIsNone(out["turn_state"])
+            self.assertEqual(out["status"], "failed")
+
+    def test_no_wait_and_status_and_terminate(self):
+        with FakeFountain() as fake:
+            st = fake.state
+            clock = FakeClock()
+            tools = make_tools(fake, clock)
+            out = json.loads(tools.run({"agent": "reviewer", "prompt": "x", "wait": False}))
+            self.assertFalse(out["done"])
+            self.assertEqual(clock.ticks, 0)
+            status = json.loads(tools.status({"conversation_id": "c-1"}))
+            self.assertEqual(status["conversation"]["status"], "pending")
+            self.assertEqual(status["turns"][0]["prompt"], "x")
+            convs = json.loads(tools.conversations({}))
+            self.assertEqual(convs["count"], 1)
+            term = json.loads(tools.terminate({"conversation_id": "c-1"}))
+            self.assertEqual(term["status"], "terminated")
+            self.assertEqual(st.conversations["c-1"]["status"], "terminated")
+            self.assertEqual(json.loads(tools.conversations({}))["count"], 0)
+
+    def test_errors_are_json_not_exceptions(self):
+        with FakeFountain() as fake:
+            tools = make_tools(fake, FakeClock())
+            self.assertIn("agent is required", json.loads(tools.run({"prompt": "x"}))["error"])
+            self.assertIn("No agent named", json.loads(tools.run({"agent": "zzz", "prompt": "x"}))["error"])
+            self.assertIn("HTTP 404", json.loads(tools.status({"conversation_id": "nope"}))["error"])
+            self.assertIn("No vault named", json.loads(tools.run({"agent": "reviewer", "prompt": "x", "vault": "zz"}))["error"])
+        # transport failure (server gone)
+        tools = FountainTools(lambda: FountainClient("http://127.0.0.1:9", TOKEN))
+        self.assertIn("failed", json.loads(tools.agents({}))["error"])
+
+
+class FakeCtx:
+    def __init__(self, config=None):
+        self.config = config or {}
+        self.tools = {}
+        self.skills = {}
+        self.commands = {}
+
+    def get_config(self, key, default=None):
+        return self.config.get(key, default)
+
+    def register_tool(self, *, name, toolset, schema, handler, check_fn=None, requires_env=None,
+                      is_async=False, description="", emoji="", override=False):
+        self.tools[name] = {"toolset": toolset, "schema": schema, "handler": handler, "check_fn": check_fn}
+
+    def register_skill(self, name, path, description="", frontmatter=None):
+        self.skills[name] = Path(path)
+
+    def register_command(self, name, handler, description="", args_hint=""):
+        self.commands[name] = handler
+
+
+class RegisterTests(unittest.TestCase):
+    def test_register_wires_tools_skill_and_command(self):
+        with FakeFountain() as fake:
+            ctx = FakeCtx({"base_url": fake.base_url, "api_key": TOKEN})
+            plugin.register(ctx)
+            self.assertEqual(
+                sorted(ctx.tools),
+                ["fountain_agents", "fountain_conversations", "fountain_run", "fountain_send",
+                 "fountain_status", "fountain_terminate", "fountain_wait"],
+            )
+            for name, entry in ctx.tools.items():
+                self.assertEqual(entry["toolset"], "fountain")
+                self.assertEqual(entry["schema"]["name"], name)
+                self.assertTrue(entry["check_fn"]())
+            self.assertTrue(ctx.skills["fountain"].is_file())
+            out = json.loads(ctx.tools["fountain_agents"]["handler"]({"search": "build"}))
+            self.assertEqual([a["name"] for a in out["agents"]], ["Builder", "builder-two"])
+            self.assertIn("reviewer", ctx.commands["fountain"]("agents"))
+            self.assertIn("instance:", ctx.commands["fountain"]("whoami"))
+            self.assertIn("usage:", ctx.commands["fountain"]("run"))
+            self.assertIn("/fountain", ctx.commands["fountain"](""))
+
+    def test_tools_hidden_without_a_key(self):
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
+            os.environ, {"FOUNTAIN_CREDENTIALS_FILE": str(Path(tmp) / "none")}
+        ):
+            for k in ("FOUNTAIN_API_KEY", "FOUNTAIN_TOKEN"):
+                os.environ.pop(k, None)
+            ctx = FakeCtx()
+            plugin.register(ctx)
+            self.assertFalse(ctx.tools["fountain_run"]["check_fn"]())
+            self.assertIn("No Fountain API key", json.loads(ctx.tools["fountain_run"]["handler"]({"agent": "a", "prompt": "b"}))["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - fountain acp (reference): integrations/acp.md
       - Editors (ACP): integrations/editors.md
       - OpenClaw (ACP): integrations/openclaw.md
+      - Hermes Agent (plugin): integrations/hermes.md
       - Buzz (Nostr): integrations/buzz.md
       - GitHub OAuth: integrations/github-oauth.md
       - Stripe: integrations/stripe.md


### PR DESCRIPTION
## What

A Hermes Agent plugin, shipped in this repo at `integrations/hermes/fountain/`, that gives Hermes seven `fountain_*` tools (list agents, run, send a follow-up, wait, status, list conversations, terminate), a `fountain` skill, and a `/fountain` slash command. Hermes delegates a task to a named Fountain agent; the work runs in a Fountain sandbox; the answer comes back as the tool result.

```
hermes plugins install BinaryBourbon/fountain/integrations/hermes/fountain --enable
```

## Why the plugin and not `copilot-acp`

Hermes's `copilot-acp` provider treats an ACP agent as the LLM behind Hermes's own loop and would accept `fountain acp` — but it opens a fresh process + `session/new` per model call, i.e. a Fountain sandbox per Hermes turn, and asks the agent to emit `<tool_call>` blocks. Wrong shape. Delegation over the HTTP API is what Fountain is for.

## How it works

- Follows a turn through `GET /events?blocks=true`: `text` blocks are the answer (ACP chunks join as one message; a paragraph break after any tool call), `stage` rows `turn/started|done|failed|interrupted` end it. No runtime dialect in the plugin.
- Bounded, resumable waits: default 300 s (Hermes deadlines a tool call at 420 s), returns `done=false` + text so far, `fountain_wait` continues from the remembered cursor. Fan-out is `wait=false` × N then `fountain_wait` each.
- Credentials like the CLI: settings → `FOUNTAIN_API_KEY` → in-sandbox `FOUNTAIN_TOKEN` → `~/.fountain/credentials`; inside a sandbox, spawned conversations get `X-Fountain-Parent-Conversation-Id`.
- Stdlib Python, no deps. 19 tests against an in-process fake Fountain, run in the `checks` CI job.

## Verified

- `hermes plugins doctor integrations/hermes/fountain` → 7 tools registered, no warnings; the `fountain` toolset resolves for the CLI platform by default.
- Live against fountain.inevitable.fyi with `acp-proof-659`: run returned in 24 s (`hermes plugin smoke ok` + `uname`), follow-up turn in 9 s recalled turn 1, `fountain_status` / `fountain_terminate` fine.
- `mix test apps/fountain/test/fountain/docs_test.exs` (nav mirror), `mkdocs build --strict`, `mix format --check-formatted`.

Docs: `docs/integrations/hermes.md`, both navs, integrations index, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
