### PR TITLE
feat(api): team schedules over the API (#825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ upgrade, is in
 
 ### Added
 
+- **Team schedules over the API** (#825). `GET /api/team/schedules`, and
+  `GET|POST /api/team/:agent_id/schedules`, `GET|PATCH|DELETE
+  /api/team/:agent_id/schedules/:id`, `POST .../:id/run` — the routines the
+  team page offers, for standalone clients, wrapping `Fountain.Team.Schedules`
+  under the same tenant scoping and audit attribution as the rest of
+  `/api/team`. The team stream sends a `schedule` event when a schedule is
+  created, updated, deleted or fired, so a client re-lists rather than polls.
+
 - **Hermes Agent plugin** (`integrations/hermes/`). Fountain agents as tools
   inside [Hermes Agent](https://github.com/NousResearch/hermes-agent):
   `fountain_agents`, `fountain_run`, `fountain_send`, `fountain_wait`,

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -57,6 +57,20 @@ defmodule Fountain.Team do
     do: Phoenix.PubSub.broadcast(Fountain.PubSub, topic(user_id), {:team_changed, user_id})
 
   @doc """
+  Broadcast `{:team_schedules_changed, user_id}` on the team topic — a
+  schedule was created, updated, deleted or fired (#825). Same subscribers
+  as `subscribe/1`; the API stream turns it into a `schedule` event so a
+  client re-lists its routines. Called by `Fountain.Team.Schedules`.
+  """
+  def broadcast_schedules_changed(user_id) when is_binary(user_id),
+    do:
+      Phoenix.PubSub.broadcast(
+        Fountain.PubSub,
+        topic(user_id),
+        {:team_schedules_changed, user_id}
+      )
+
+  @doc """
   One entry per agent on the team, most recently active first.
 
   Each entry is `%{agent: %Agent{}, conversation: %Conversation{}, last_turn:

--- a/apps/fountain/lib/fountain/team/schedules.ex
+++ b/apps/fountain/lib/fountain/team/schedules.ex
@@ -92,6 +92,7 @@ defmodule Fountain.Team.Schedules do
         {:ok, schedule} ->
           schedule = Repo.preload(schedule, :agent)
           record("team.schedule.created", schedule, opts, describe(schedule))
+          Team.broadcast_schedules_changed(schedule.user_id)
           {:ok, schedule}
 
         {:error, _} = err ->
@@ -118,8 +119,10 @@ defmodule Fountain.Team.Schedules do
       {:ok, updated} ->
         updated = Repo.preload(updated, :agent, force: true)
 
-        if changeset.changes != %{},
-          do: record("team.schedule.updated", updated, opts, Audit.changed_fields(changeset))
+        if changeset.changes != %{} do
+          record("team.schedule.updated", updated, opts, Audit.changed_fields(changeset))
+          Team.broadcast_schedules_changed(updated.user_id)
+        end
 
         {:ok, updated}
 
@@ -132,6 +135,7 @@ defmodule Fountain.Team.Schedules do
   def delete_schedule(%Schedule{} = schedule, opts \\ []) do
     with {:ok, deleted} <- Repo.delete(schedule) do
       record("team.schedule.deleted", deleted, opts, describe(schedule))
+      Team.broadcast_schedules_changed(deleted.user_id)
       {:ok, deleted}
     end
   end
@@ -148,6 +152,7 @@ defmodule Fountain.Team.Schedules do
         from(s in Schedule, where: s.user_id == ^user_id and s.agent_id == ^agent_id)
       )
 
+    if n > 0, do: Team.broadcast_schedules_changed(user_id)
     n
   end
 
@@ -179,6 +184,7 @@ defmodule Fountain.Team.Schedules do
       end
 
     {:ok, _} = schedule |> Schedule.run_changeset(run_attrs) |> Repo.update()
+    Team.broadcast_schedules_changed(schedule.user_id)
 
     record(
       "team.schedule.fired",

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -147,7 +147,9 @@ defmodule FountainWeb.TeamController do
         "plus `conversation_id` and `agent_id`. A `team` event (data `{reason: changed}`) " <>
         "is sent when the roster changes — a teammate added or removed, or a " <>
         "fresh conversation opened for one — and the stream follows the new " <>
-        "conversation on its own; the client re-lists. `Last-Event-ID` (a log event " <>
+        "conversation on its own; the client re-lists. A `schedule` event (same " <>
+        "data) is sent when a team schedule is created, updated, deleted or fired " <>
+        "(#825); the client re-lists `/api/team/schedules`. `Last-Event-ID` (a log event " <>
         "id) replays what was missed on each teammate's conversation. Heartbeats " <>
         "every 15s; closes after 60s idle so the client reconnects.",
     parameters: [
@@ -264,6 +266,19 @@ defmodule FountainWeb.TeamController do
                "event: team\ndata: #{Jason.encode!(%{reason: "changed"})}\n\n"
              ) do
           {:ok, conn} -> sse_loop(conn, %{state | followed: followed})
+          {:error, _} -> conn
+        end
+
+      # A schedule was created, updated, deleted or fired (#825): the client
+      # re-lists `/api/team/schedules`. Nothing to follow — a run's
+      # conversation is either a teammate's (already followed, or announced by
+      # `team`) or a one-off outside the team.
+      {:team_schedules_changed, _} ->
+        case Plug.Conn.chunk(
+               conn,
+               "event: schedule\ndata: #{Jason.encode!(%{reason: "changed"})}\n\n"
+             ) do
+          {:ok, conn} -> sse_loop(conn, state)
           {:error, _} -> conn
         end
 

--- a/apps/fountain/lib/fountain_web/controllers/team_schedule_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_schedule_controller.ex
@@ -1,0 +1,181 @@
+defmodule FountainWeb.TeamScheduleController do
+  @moduledoc """
+  Team schedules over the API (#825): the routines `/team` offers — a cron
+  that runs a teammate with a prompt, in its thread or on a one-off computer
+  — for a client that is not this web app.
+
+  Every action is a thin wrapper over `Fountain.Team.Schedules`, under the
+  same tenant scoping and audit attribution as the rest of `/api/team`. The
+  `:agent_id` in the path is part of the identity: a schedule reached under
+  another agent's path is a 404, the same as one that is not the caller's.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Team.Schedules
+  alias FountainWeb.{Audited, Schemas}
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Team"])
+
+  @agent_id_param [agent_id: [in: :path, type: :string, required: true]]
+  @id_params @agent_id_param ++ [id: [in: :path, type: :string, required: true]]
+
+  operation(:index_all,
+    summary: "List every schedule of the caller",
+    description:
+      "Every team schedule the caller owns, across teammates, soonest next run " <>
+        "first. Times are UTC: `cron` is a five-field expression evaluated in UTC.",
+    responses: [ok: {"Schedules", "application/json", Schemas.TeamScheduleListResponse}]
+  )
+
+  def index_all(conn, _params) do
+    render(conn, :index, schedules: Schedules.list_schedules(conn.assigns.current_user.id))
+  end
+
+  operation(:index,
+    summary: "List one teammate's schedules",
+    parameters: @agent_id_param,
+    responses: [ok: {"Schedules", "application/json", Schemas.TeamScheduleListResponse}]
+  )
+
+  def index(conn, %{"agent_id" => agent_id}) do
+    render(conn, :index,
+      schedules: Schedules.list_schedules(conn.assigns.current_user.id, agent_id)
+    )
+  end
+
+  operation(:show,
+    summary: "Show one schedule",
+    parameters: @id_params,
+    responses: [
+      ok: {"Schedule", "application/json", Schemas.TeamScheduleResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"agent_id" => agent_id, "id" => id}) do
+    with {:ok, schedule} <- fetch(conn, agent_id, id) do
+      render(conn, :show, schedule: schedule)
+    end
+  end
+
+  operation(:create,
+    summary: "Create a schedule for a teammate",
+    description:
+      "`cron` is five fields in UTC (`0 9 * * 1-5` is 09:00 UTC on weekdays; " <>
+        "`@daily`-style names work, `@reboot` does not). `one_off: false` (the " <>
+        "default) sends the prompt into the teammate's own conversation as a typed " <>
+        "message would; `one_off: true` opens a fresh conversation on a new computer " <>
+        "each run, with the teammate's agent, environment and vault. The agent must be " <>
+        "the caller's; it need not be on the team yet (an in-thread schedule then " <>
+        "fails each run with `agent is not on the team` until it is). Audited as " <>
+        "`team.schedule.created`.",
+    parameters: @agent_id_param,
+    request_body: {"Schedule attributes", "application/json", Schemas.TeamScheduleCreateRequest},
+    responses: [
+      created: {"Schedule", "application/json", Schemas.TeamScheduleResponse},
+      not_found: {"Unknown agent", "application/json", Schemas.Error},
+      unprocessable_entity: {"Validation errors", "application/json", Schemas.Error}
+    ]
+  )
+
+  def create(conn, %{"agent_id" => agent_id} = params) do
+    user = conn.assigns.current_user
+
+    attrs =
+      params
+      |> Map.take(["name", "cron", "prompt", "one_off", "enabled"])
+      |> Map.put("agent_id", agent_id)
+
+    with {:ok, schedule} <- Schedules.create_schedule(user.id, attrs, Audited.attribution(conn)) do
+      conn
+      |> put_status(:created)
+      |> render(:show, schedule: schedule)
+    end
+  end
+
+  operation(:update,
+    summary: "Update a schedule",
+    description:
+      "Any of `name`, `cron`, `prompt`, `one_off`, `enabled`. A changed cron or a " <>
+        "re-enable recomputes `next_run_at` and clears `last_error`. Audited as " <>
+        "`team.schedule.updated` with the changed field names.",
+    parameters: @id_params,
+    request_body: {"Schedule attributes", "application/json", Schemas.TeamScheduleUpdateRequest},
+    responses: [
+      ok: {"Schedule", "application/json", Schemas.TeamScheduleResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Validation errors", "application/json", Schemas.Error}
+    ]
+  )
+
+  def update(conn, %{"agent_id" => agent_id, "id" => id} = params) do
+    attrs = Map.take(params, ["name", "cron", "prompt", "one_off", "enabled"])
+
+    with {:ok, schedule} <- fetch(conn, agent_id, id),
+         {:ok, updated} <- Schedules.update_schedule(schedule, attrs, Audited.attribution(conn)) do
+      render(conn, :show, schedule: updated)
+    end
+  end
+
+  operation(:delete,
+    summary: "Delete a schedule",
+    parameters: @id_params,
+    responses: [
+      no_content: "Deleted",
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"agent_id" => agent_id, "id" => id}) do
+    with {:ok, schedule} <- fetch(conn, agent_id, id),
+         {:ok, _} <- Schedules.delete_schedule(schedule, Audited.attribution(conn)) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  operation(:run,
+    summary: "Run a schedule now",
+    description:
+      "The same path as the page's \"Run now\": the prompt goes where the schedule " <>
+        "says (the teammate's thread, or a one-off computer) and `last_run_at`, " <>
+        "`last_conversation_id` and `last_error` are stamped either way. The cron " <>
+        "is untouched. 400 `conversation_busy` while the teammate's previous turn is " <>
+        "still running, 503 while its computer is still starting, 404 when an " <>
+        "in-thread schedule's agent is not on the team; the sandbox quota and " <>
+        "subscription refusals are the same as `POST /api/conversations`. Audited as " <>
+        "`team.schedule.fired`.",
+    parameters: @id_params,
+    responses: [
+      accepted: {"Queued", "application/json", Schemas.TeamMessageResponse},
+      not_found: {"Not found, or not on the team", "application/json", Schemas.Error},
+      bad_request: {"A turn is still running", "application/json", Schemas.Error}
+    ]
+  )
+
+  def run(conn, %{"agent_id" => agent_id, "id" => id}) do
+    with {:ok, schedule} <- fetch(conn, agent_id, id),
+         {:ok, conv} <- Schedules.run_schedule(schedule, Audited.attribution(conn)) do
+      conn
+      |> put_status(:accepted)
+      |> json(%{status: "queued", conversation_id: conv.id})
+    else
+      {:error, :busy} -> {:error, "conversation_busy"}
+      {:error, _} = err -> err
+    end
+  end
+
+  # Tenant-scoped, and the path's agent must be the schedule's: a schedule
+  # is addressed by (agent, id), so a mismatch is as much a 404 as another
+  # tenant's row.
+  defp fetch(conn, agent_id, id) do
+    case Schedules.get_schedule(id, conn.assigns.current_user.id) do
+      %{agent_id: ^agent_id} = schedule -> {:ok, schedule}
+      _ -> {:error, :not_found}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/team_schedule_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_schedule_json.ex
@@ -1,0 +1,27 @@
+defmodule FountainWeb.TeamScheduleJSON do
+  @moduledoc false
+
+  alias Fountain.Team.Schedule
+
+  def index(%{schedules: schedules}), do: %{data: Enum.map(schedules, &data/1)}
+  def show(%{schedule: schedule}), do: %{data: data(schedule)}
+
+  @doc "One schedule, every column the page shows; the prompt is the tenant's and is returned in full."
+  def data(%Schedule{} = s) do
+    %{
+      id: s.id,
+      agent_id: s.agent_id,
+      name: s.name,
+      cron: s.cron,
+      prompt: s.prompt,
+      one_off: s.one_off,
+      enabled: s.enabled,
+      next_run_at: s.next_run_at,
+      last_run_at: s.last_run_at,
+      last_conversation_id: s.last_conversation_id,
+      last_error: s.last_error,
+      inserted_at: s.inserted_at,
+      updated_at: s.updated_at
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -349,9 +349,19 @@ defmodule FountainWeb.Router do
     # web app. Every action wraps Fountain.Team.
     get "/team", TeamController, :index
     post "/team", TeamController, :create
+    # Before `/team/:agent_id`, or "schedules" would be read as an agent id.
+    get "/team/schedules", TeamScheduleController, :index_all
     get "/team/:agent_id", TeamController, :show
     delete "/team/:agent_id", TeamController, :delete
     post "/team/:agent_id/messages", TeamController, :message
+
+    # Team schedules (#825): the routines `/team` offers, per teammate.
+    get "/team/:agent_id/schedules", TeamScheduleController, :index
+    post "/team/:agent_id/schedules", TeamScheduleController, :create
+    get "/team/:agent_id/schedules/:id", TeamScheduleController, :show
+    patch "/team/:agent_id/schedules/:id", TeamScheduleController, :update
+    delete "/team/:agent_id/schedules/:id", TeamScheduleController, :delete
+    post "/team/:agent_id/schedules/:id/run", TeamScheduleController, :run
 
     resources "/conversations", ConversationController, only: [:index, :show, :create, :delete] do
       post "/prompts", ConversationController, :prompt, as: :prompt

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1757,6 +1757,97 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule TeamSchedule do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeamSchedule",
+      description:
+        "A scheduled prompt for a teammate: on `cron` (five fields, UTC), send `prompt` " <>
+          "to the agent — into its team conversation, or (`one_off`) on a fresh computer.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        agent_id: %Schema{type: :string, format: :uuid},
+        name: %Schema{type: :string, nullable: true, maxLength: 120},
+        cron: %Schema{type: :string, example: "0 9 * * 1-5"},
+        prompt: %Schema{type: :string},
+        one_off: %Schema{
+          type: :boolean,
+          description:
+            "false: the prompt goes into the teammate's own conversation. true: each " <>
+              "run opens a fresh conversation with the teammate's agent, environment and vault."
+        },
+        enabled: %Schema{type: :boolean},
+        next_run_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          nullable: true,
+          description: "The next fire time (UTC); null while disabled."
+        },
+        last_run_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        last_conversation_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "The conversation the last run went to; null when it failed or never ran."
+        },
+        last_error: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "Why the last run did not go out (`teammate was busy`, ...); null after a good run."
+        },
+        inserted_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :agent_id, :cron, :prompt, :one_off, :enabled]
+    })
+  end
+
+  item_response(TeamScheduleResponse, of: TeamSchedule)
+  list_response(TeamScheduleListResponse, of: TeamSchedule)
+
+  defmodule TeamScheduleCreateRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeamScheduleCreateRequest",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, nullable: true, maxLength: 120},
+        cron: %Schema{
+          type: :string,
+          description: "Five fields, UTC. `@daily`-style names work; `@reboot` does not.",
+          example: "0 9 * * 1-5"
+        },
+        prompt: %Schema{type: :string, minLength: 1, maxLength: 20_000},
+        one_off: %Schema{type: :boolean, default: false},
+        enabled: %Schema{type: :boolean, default: true}
+      },
+      required: [:cron, :prompt]
+    })
+  end
+
+  defmodule TeamScheduleUpdateRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeamScheduleUpdateRequest",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, nullable: true, maxLength: 120},
+        cron: %Schema{type: :string, example: "0 9 * * 1-5"},
+        prompt: %Schema{type: :string, minLength: 1, maxLength: 20_000},
+        one_off: %Schema{type: :boolean},
+        enabled: %Schema{type: :boolean}
+      }
+    })
+  end
+
   defmodule CatalogResponse do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/team_schedule_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_schedule_controller_test.exs
@@ -1,0 +1,269 @@
+defmodule FountainWeb.TeamScheduleControllerTest do
+  @moduledoc """
+  Team schedules over the API (#825): `/api/team/schedules` and
+  `/api/team/:agent_id/schedules[/:id[/run]]`, tenant-scoped, audited with
+  the request's attribution, broadcasting `schedule` on the team topic.
+  """
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.{Audit, Team}
+  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Team.Schedules
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    agent = insert_agent(user_id: user.id, name: "Ada")
+    {:ok, user: user, raw_key: raw_key, agent: agent}
+  end
+
+  defp insert_teammate_conv(user, agent, overrides \\ %{}) do
+    insert_conversation(
+      Map.merge(
+        %{user_id: user.id, agent: agent, status: "idle", channel_id: Team.channel()},
+        Map.new(overrides)
+      )
+    )
+  end
+
+  defp create!(user, agent, overrides \\ %{}) do
+    {:ok, s} =
+      Schedules.create_schedule(
+        user.id,
+        Map.merge(
+          %{"agent_id" => agent.id, "cron" => "0 9 * * *", "prompt" => "standup please"},
+          Map.new(overrides)
+        )
+      )
+
+    s
+  end
+
+  defp schedule_events(user_id) do
+    user_id
+    |> Audit.list_recent_for_user()
+    |> Enum.filter(&String.starts_with?(&1.action, "team.schedule."))
+  end
+
+  describe "GET /api/team/schedules" do
+    test "lists every schedule of the caller across teammates, never another tenant's", %{
+      conn: conn,
+      user: user,
+      raw_key: key,
+      agent: ada
+    } do
+      linus = insert_agent(user_id: user.id, name: "Linus")
+      a = create!(user, ada, %{"name" => "Standup"})
+      b = create!(user, linus, %{"cron" => "0 18 * * *"})
+      other = insert_verified_user()
+      create!(other, insert_agent(user_id: other.id))
+
+      body = conn |> authed_with_key(key) |> get("/api/team/schedules") |> json_response(200)
+
+      assert body["data"] |> Enum.map(& &1["id"]) |> Enum.sort() == Enum.sort([a.id, b.id])
+      entry = Enum.find(body["data"], &(&1["id"] == a.id))
+      assert entry["agent_id"] == ada.id
+      assert entry["name"] == "Standup"
+      assert entry["cron"] == "0 9 * * *"
+      assert entry["prompt"] == "standup please"
+      assert entry["one_off"] == false
+      assert entry["enabled"] == true
+      assert is_binary(entry["next_run_at"])
+      assert entry["last_run_at"] == nil
+      assert entry["last_error"] == nil
+    end
+
+    test "401 without a key", %{conn: conn} do
+      assert conn |> get("/api/team/schedules") |> json_response(401)
+    end
+  end
+
+  describe "GET /api/team/:agent_id/schedules" do
+    test "one teammate's schedules only", %{conn: conn, user: user, raw_key: key, agent: ada} do
+      linus = insert_agent(user_id: user.id, name: "Linus")
+      a = create!(user, ada)
+      create!(user, linus)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/team/#{ada.id}/schedules")
+        |> json_response(200)
+
+      assert [%{"id" => id}] = body["data"]
+      assert id == a.id
+    end
+  end
+
+  describe "POST /api/team/:agent_id/schedules" do
+    test "creates with the request's attribution; 201 with the schedule", %{
+      conn: conn,
+      user: user,
+      raw_key: key,
+      agent: ada
+    } do
+      Team.subscribe(user.id)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/team/#{ada.id}/schedules", %{
+          name: "Standup",
+          cron: "0 9 * * 1-5",
+          prompt: "What's on today?",
+          one_off: true
+        })
+        |> json_response(201)
+
+      assert %{"id" => id, "agent_id" => agent_id, "one_off" => true, "enabled" => true} =
+               body["data"]
+
+      assert agent_id == ada.id
+      assert %{name: "Standup", cron: "0 9 * * 1-5"} = Schedules.get_schedule(id, user.id)
+      assert_receive {:team_schedules_changed, _}
+
+      assert [%{action: "team.schedule.created", actor: "api"} = ev] = schedule_events(user.id)
+      assert ev.metadata["prompt_bytes"] == byte_size("What's on today?")
+      refute Map.has_key?(ev.metadata, "prompt")
+    end
+
+    test "422 with errors on a bad cron; 404 for another tenant's agent", %{
+      conn: conn,
+      raw_key: key,
+      agent: ada
+    } do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/team/#{ada.id}/schedules", %{cron: "not a cron", prompt: "x"})
+        |> json_response(422)
+
+      assert body["errors"]["cron"]
+
+      foreign = insert_agent(user_id: insert_verified_user().id)
+
+      assert conn
+             |> authed_with_key(key)
+             |> post_json("/api/team/#{foreign.id}/schedules", %{cron: "0 9 * * *", prompt: "x"})
+             |> json_response(404)
+    end
+  end
+
+  describe "GET/PATCH/DELETE /api/team/:agent_id/schedules/:id" do
+    test "show, update and delete, scoped to the tenant and the path's agent", %{
+      conn: conn,
+      user: user,
+      raw_key: key,
+      agent: ada
+    } do
+      s = create!(user, ada)
+      linus = insert_agent(user_id: user.id, name: "Linus")
+      path = "/api/team/#{ada.id}/schedules/#{s.id}"
+
+      assert %{"data" => %{"id" => id}} =
+               conn |> authed_with_key(key) |> get(path) |> json_response(200)
+
+      assert id == s.id
+
+      # The same row under another agent's path is not found.
+      assert conn
+             |> authed_with_key(key)
+             |> get("/api/team/#{linus.id}/schedules/#{s.id}")
+             |> json_response(404)
+
+      # Another tenant cannot see it at all.
+      {_k, other_key} = insert_api_key(insert_verified_user())
+      assert conn |> authed_with_key(other_key) |> get(path) |> json_response(404)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> patch_json(path, %{enabled: false, name: "Paused"})
+        |> json_response(200)
+
+      assert body["data"]["enabled"] == false
+      assert body["data"]["name"] == "Paused"
+
+      assert %{actor: "api"} =
+               Enum.find(schedule_events(user.id), &(&1.action == "team.schedule.updated"))
+
+      assert conn |> authed_with_key(key) |> delete(path) |> response(204)
+      assert Schedules.get_schedule(s.id, user.id) == nil
+      assert Enum.any?(schedule_events(user.id), &(&1.action == "team.schedule.deleted"))
+      assert conn |> authed_with_key(key) |> get(path) |> json_response(404)
+    end
+
+    test "422 on an invalid update", %{conn: conn, user: user, raw_key: key, agent: ada} do
+      s = create!(user, ada)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> patch_json("/api/team/#{ada.id}/schedules/#{s.id}", %{cron: "@reboot"})
+        |> json_response(422)
+
+      assert body["errors"]["cron"]
+    end
+  end
+
+  describe "POST /api/team/:agent_id/schedules/:id/run" do
+    test "runs now through the teammate's thread; 202 with the conversation", %{
+      conn: conn,
+      user: user,
+      raw_key: key,
+      agent: ada
+    } do
+      conv = insert_teammate_conv(user, ada)
+      s = create!(user, ada, %{"prompt" => "standup please"})
+      test_pid = self()
+
+      stub(ConversationServer, :send_prompt, fn id, text, _images, opts ->
+        send(test_pid, {:sent, id, text, opts[:actor]})
+        :ok
+      end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/team/#{ada.id}/schedules/#{s.id}/run", %{})
+        |> json_response(202)
+
+      assert body == %{"status" => "queued", "conversation_id" => conv.id}
+      assert_received {:sent, conv_id, "standup please", "api"}
+      assert conv_id == conv.id
+
+      s = Schedules.get_schedule(s.id, user.id)
+      assert %DateTime{} = s.last_run_at
+      assert s.last_conversation_id == conv.id
+      assert Enum.any?(schedule_events(user.id), &(&1.action == "team.schedule.fired"))
+    end
+
+    test "400 conversation_busy while a turn is running; 404 off the team", %{
+      conn: conn,
+      user: user,
+      raw_key: key,
+      agent: ada
+    } do
+      insert_teammate_conv(user, ada, status: "running")
+      s = create!(user, ada)
+      stub(ConversationServer, :send_prompt, fn _id, _text, _images, _opts -> {:error, :busy} end)
+
+      assert %{"error" => "conversation_busy"} =
+               conn
+               |> authed_with_key(key)
+               |> post_json("/api/team/#{ada.id}/schedules/#{s.id}/run", %{})
+               |> json_response(400)
+
+      assert Schedules.get_schedule(s.id, user.id).last_error == "teammate was busy"
+
+      loner = insert_agent(user_id: user.id, name: "Loner")
+      s2 = create!(user, loner)
+
+      assert conn
+             |> authed_with_key(key)
+             |> post_json("/api/team/#{loner.id}/schedules/#{s2.id}/run", %{})
+             |> json_response(404)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
@@ -157,6 +157,24 @@ defmodule FountainWeb.TeamStreamTest do
     assert conn.resp_body =~ "from-new-linus"
   end
 
+  test "a schedule change sends a `schedule` event (#825)", %{user: user, raw_key: key} do
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    insert_teammate_conv(user, ada)
+
+    task = stream_async(key)
+    Process.sleep(300)
+
+    {:ok, _} =
+      Fountain.Team.Schedules.create_schedule(user.id, %{
+        "agent_id" => ada.id,
+        "cron" => "0 9 * * *",
+        "prompt" => "standup"
+      })
+
+    conn = Task.await(task, 5_000)
+    assert conn.resp_body =~ "event: schedule\ndata: {\"reason\":\"changed\"}"
+  end
+
   test "Team.add_teammate and remove_teammate broadcast the roster change", %{user: user} do
     Team.subscribe(user.id)
     ada = insert_agent(user_id: user.id, name: "Ada")

--- a/apps/fountain/test/support/conn_case.ex
+++ b/apps/fountain/test/support/conn_case.ex
@@ -69,6 +69,12 @@ defmodule FountainWeb.ConnCase do
     |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :put, path, Jason.encode!(payload))
   end
 
+  def patch_json(conn, path, payload) do
+    conn
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Phoenix.ConnTest.dispatch(FountainWeb.Endpoint, :patch, path, Jason.encode!(payload))
+  end
+
   @doc """
   DELETE with a JSON body — account deletion takes a typed confirmation, so
   the body matters on a verb that usually has none.

--- a/docs/api.md
+++ b/docs/api.md
@@ -349,6 +349,45 @@ starts following the new conversation itself; the client re-lists. It honours
 `Last-Event-ID` (replayed across every teammate) and `?streams=`, heartbeats
 every 15 s and closes after 60 s idle so the client reconnects.
 
+### Schedules
+
+The routines the team page offers — a cron that runs a teammate with a
+prompt, either in its own thread or on a one-off computer — over the API.
+Every route wraps `Fountain.Team.Schedules`, so a standalone client gets the
+page's exact semantics.
+
+```
+GET    /api/team/schedules                       # every schedule of the caller, soonest first
+GET    /api/team/:agent_id/schedules
+POST   /api/team/:agent_id/schedules             # cron (5 fields, UTC), prompt; optional name, one_off, enabled
+GET    /api/team/:agent_id/schedules/:id
+PATCH  /api/team/:agent_id/schedules/:id
+DELETE /api/team/:agent_id/schedules/:id
+POST   /api/team/:agent_id/schedules/:id/run     # run now → 202 {status: "queued", conversation_id}
+```
+
+A schedule carries `id`, `agent_id`, `name`, `cron`, `prompt`, `one_off`,
+`enabled`, `next_run_at`, `last_run_at`, `last_conversation_id` and
+`last_error`. `cron` is evaluated in UTC (`0 9 * * 1-5` is 09:00 UTC on
+weekdays; `@daily`-style names work, `@reboot` does not). `one_off: false`
+(the default) sends the prompt into the teammate's own conversation as a
+typed message would; `one_off: true` opens a fresh conversation on a new
+computer each run, with the teammate's agent, environment and vault. The
+agent must be the caller's; it need not be on the team yet. A schedule is
+addressed by `(agent_id, id)`: the same row under another agent's path is a
+`404`, like another tenant's.
+
+`/run` takes the same path as the page's "Run now" and answers like
+`/messages`: `400 conversation_busy` while the teammate's previous turn is
+still running, `503` while its computer is starting, `404` when an in-thread
+schedule's agent is not on the team; `last_run_at` / `last_error` are stamped
+either way. Creates, updates, deletes and runs are audited
+(`team.schedule.*`) with the request's attribution.
+
+The team stream sends a `schedule` event (`{"reason":"changed"}`) whenever a
+schedule is created, updated, deleted or fired — by the API, the page or the
+scheduler — so a client re-lists rather than polls.
+
 Browser clients on another origin need `API_CORS_ORIGINS` set on the server
 (see [configuration](configuration.md)); a bearer key is the only credential
 that crosses origins.


### PR DESCRIPTION
## Summary

Closes #825.

- `GET /api/team/schedules`, `GET|POST /api/team/:agent_id/schedules`, `GET|PATCH|DELETE /api/team/:agent_id/schedules/:id`, `POST .../:id/run` — thin wrappers over `Fountain.Team.Schedules` (same functions the `/team` LiveView calls), tenant-scoped, `Audited.attribution(conn)`.
- A schedule is addressed by `(agent_id, id)`: the same row under another agent's path is a 404, like another tenant's.
- `/run` answers like `/messages`: `202 {status: "queued", conversation_id}`, `400 conversation_busy`, `503 provisioning`, `404` when an in-thread schedule's agent is not on the team; quota/subscription errors through the fallback as everywhere else.
- `Fountain.Team.broadcast_schedules_changed/1` on the team topic from create/update/delete/fire (and the remove-teammate cascade); `/api/team/stream` sends `event: schedule` `{"reason":"changed"}` so a client re-lists.
- OpenAPI schemas (`TeamSchedule`, create/update requests), docs/api.md "Schedules" section, CHANGELOG.

## Test plan

- [x] `team_schedule_controller_test.exs`: list-all / per-agent / show / create (201, audit actor `api`, prompt not in metadata) / 422 bad cron / 404 foreign agent / path-agent mismatch 404 / cross-tenant 404 / update / delete / run 202 / run busy 400 / run off-team 404
- [x] `team_stream_test.exs`: a schedule create sends `event: schedule`
- [x] `mix test apps/fountain/test/fountain_web apps/fountain/test/fountain/team …` → 1211 tests, 0 failures; format + credo --strict clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)