### PR TITLE
feat(api): token usage per turn and per conversation (#827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ upgrade, is in
   `/api/team`. The team stream sends a `schedule` event when a schedule is
   created, updated, deleted or fired, so a client re-lists rather than polls.
 
+- **Token usage per turn and per conversation** (#827). The figure the
+  runtime reports on the ACP `session/prompt` response is stored on the turn
+  (`turns.usage`: input, output, cache read/write) and summed on the
+  conversation (`usage_total`); `GET /api/conversations/:id/turns`,
+  conversation objects and `/api/team` roster entries (per teammate, across
+  every conversation it has had on the team) carry it. Recorded once per turn,
+  never from the live `usage_update`s. Turns before this release have
+  `usage: null`.
+
 - **Hermes Agent plugin** (`integrations/hermes/`). Fountain agents as tools
   inside [Hermes Agent](https://github.com/NousResearch/hermes-agent):
   `fountain_agents`, `fountain_run`, `fountain_send`, `fountain_wait`,

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -804,6 +804,38 @@ defmodule Fountain.Conversations do
     |> Repo.update()
   end
 
+  @doc """
+  Record a turn's end-of-turn token usage (#827): stamp `usage` on the turn
+  and add its `input` / `output` to the conversation's running sums, in one
+  transaction. `usage` is the normalised map `Fountain.Runtimes.ACP.Usage`
+  produces (`%{"input" => n, "output" => n, ...}`); nil records nothing.
+
+  Once per turn, by the ConversationServer when the `session/prompt`
+  response arrives — never from the live `usage_update`s, whose meaning
+  differs per runtime (a per-call delta, a thread total, a per-step figure).
+  A second call for the same turn would double-count the conversation, so
+  it refuses when the turn already carries a usage.
+  """
+  def _unsafe_record_turn_usage(%Turn{}, nil), do: :ok
+  def _unsafe_record_turn_usage(%Turn{usage: %{}}, _usage), do: {:error, :already_recorded}
+
+  def _unsafe_record_turn_usage(%Turn{} = turn, %{} = usage) do
+    input = Map.get(usage, "input", 0)
+    output = Map.get(usage, "output", 0)
+
+    Repo.transaction(fn ->
+      {:ok, updated} = turn |> Turn.changeset(%{usage: usage}) |> Repo.update()
+
+      {1, _} =
+        Repo.update_all(
+          from(c in Conversation, where: c.id == ^turn.conversation_id),
+          inc: [usage_input_tokens: input, usage_output_tokens: output]
+        )
+
+      updated
+    end)
+  end
+
   # ── log events ──────────────────────────────────────────────────────────────────────────
 
   @doc """

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -36,6 +36,11 @@ defmodule Fountain.Conversations.Conversation do
     # to (a Buzz channel id via ACP `session/new` `_meta.channelId`, #774).
     # `start_or_resume_conversation/2` resumes by it. Opaque to Fountain.
     field :channel_id, :string
+    # Running sums of the turns' `usage.input` / `usage.output` (#827), kept
+    # by `Conversations._unsafe_record_turn_usage/2` as each turn ends. Not
+    # in `changeset/2`: nothing user-facing writes them.
+    field :usage_input_tokens, :integer, default: 0
+    field :usage_output_tokens, :integer, default: 0
 
     # Populated by list_conversations_by_activity/1 — not persisted.
     field :turn_count, :integer, virtual: true, default: 0

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1489,8 +1489,13 @@ defmodule Fountain.Conversations.ConversationServer do
   # The turn's first terminator: `session/prompt` answered with a stop reason.
   # Closing stdin here is what makes the adapter exit, and clearing the command
   # ref is what makes that exit a no-op instead of a second ending.
-  def handle_info({:acp, ref, {:done, stop_reason}}, %{current_command_ref: ref} = state) do
+  #
+  # `usage` is the turn's end-of-turn token figure (#827), recorded once here
+  # — the response is the only place the runtime reports it — before the turn
+  # row is closed. nil records nothing.
+  def handle_info({:acp, ref, {:done, stop_reason, usage}}, %{current_command_ref: ref} = state) do
     status = if stop_reason in ["refusal", "cancelled"], do: "failed", else: "completed"
+    record_turn_usage(state, usage)
 
     {:noreply,
      finish_acp_turn(state, status, %{"stop_reason" => stop_reason}, %{
@@ -2467,6 +2472,20 @@ defmodule Fountain.Conversations.ConversationServer do
   # opens with can't be mistaken for a first token (its real one arrived in
   # a previous BEAM lifetime).
   defp maybe_emit_first_output(state), do: state
+
+  defp record_turn_usage(%{current_turn: %{} = turn}, %{} = usage) do
+    case Conversations._unsafe_record_turn_usage(turn, usage) do
+      {:ok, _} ->
+        :ok
+
+      other ->
+        Logger.warning(
+          "conv #{turn.conversation_id}: turn #{turn.id} usage not recorded: #{inspect(other)}"
+        )
+    end
+  end
+
+  defp record_turn_usage(_state, _usage), do: :ok
 
   defp emit_turn_completed(%{turn_metrics: nil}, _status), do: :ok
 

--- a/apps/fountain/lib/fountain/conversations/turn.ex
+++ b/apps/fountain/lib/fountain/conversations/turn.ex
@@ -19,6 +19,12 @@ defmodule Fountain.Conversations.Turn do
     # JSON-RPC id of the ACP `session/prompt` in flight; nil on the legacy
     # path and until the peer has written the prompt. See the migration.
     field :acp_prompt_id, :integer
+    # The turn's token usage as the runtime reported it when the turn ended
+    # (#827): `%{"input" => n, "output" => n, "cache_read" => n?,
+    # "cache_write" => n?}`. Written once by `Conversations._unsafe_record_turn_usage/2`,
+    # never summed from the live `usage_update`s (their meaning differs per
+    # runtime). nil when the runtime reported nothing.
+    field :usage, :map
     belongs_to :conversation, Conversation
     has_many :images, TurnImage, preload_order: [asc: :position]
     timestamps(type: :utc_datetime, updated_at: false)
@@ -36,6 +42,7 @@ defmodule Fountain.Conversations.Turn do
       :started_at,
       :ended_at,
       :acp_prompt_id,
+      :usage,
       :conversation_id
     ])
     |> validate_required([:turn_number, :prompt, :status, :conversation_id])

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -88,7 +88,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
   require Logger
 
   alias Fountain.Runtimes.ACP
-  alias Fountain.Runtimes.ACP.Protocol
+  alias Fountain.Runtimes.ACP.{Protocol, Usage}
 
   # How long the replay has to stay quiet before we believe it is over, and how
   # long we will wait for that in total. See `handle_response(:load_session, …)`.
@@ -102,7 +102,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
           | {:prompt_sent, pos_integer()}
           | {:model_rejected, requested :: String.t(), detail :: String.t()}
           | {:handshake_ms, non_neg_integer(), method :: String.t()}
-          | {:done, stop_reason :: String.t()}
+          | {:done, stop_reason :: String.t(), usage :: map() | nil}
           | {:failed, term()}
 
   defmodule State do
@@ -464,9 +464,12 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # Authenticated; open (or reopen) the session.
   defp handle_response(:authenticate, _result, state), do: start_session(state)
 
+  # The turn's usage rides along with the stop reason (#827): it is the one
+  # end-of-turn figure the runtime reports, and the response is the only place
+  # it appears. nil when the runtime reports none.
   defp handle_response(:prompt, result, state) do
     stop = Map.get(result, "stopReason") || "end_turn"
-    report(state, {:done, stop})
+    report(state, {:done, stop, Usage.from_prompt_result(result)})
     %{state | phase: :done}
   end
 

--- a/apps/fountain/lib/fountain/runtimes/acp/usage.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/usage.ex
@@ -1,0 +1,65 @@
+defmodule Fountain.Runtimes.ACP.Usage do
+  @moduledoc """
+  The end-of-turn token figure, normalised from a `session/prompt` response
+  (#827).
+
+  Two places a runtime puts it, tried in order:
+
+    * `usage` — the (unstable, as of protocol v1) `Usage` object:
+      `inputTokens`, `outputTokens`, `cachedReadTokens`, `cachedWriteTokens`,
+      `totalTokens`, `thoughtTokens`. claude-agent-acp ≥ 0.6x fills it with
+      the turn's accumulated API usage (reset when the turn starts) and
+      codex-acp with the thread's last token count;
+    * `_meta.inputTokens` / `_meta.outputTokens` — where an adapter put it
+      before the field had a name.
+
+  The result is Fountain's shape, string-keyed for the jsonb column:
+  `%{"input" => n, "output" => n}` plus `"cache_read"` / `"cache_write"`
+  when reported. `nil` when the response carries neither — a turn without a
+  usage, not a zero one.
+
+  Deliberately *not* derived from the `usage_update` notifications that
+  stream during a turn: those are context-window occupancy (`used` / `size`)
+  and a cumulative session `cost`, and what they mean per update differs by
+  runtime. The one figure recorded per turn is the one the runtime reports
+  when the turn ends.
+  """
+
+  @type t :: %{required(String.t()) => non_neg_integer()}
+
+  @doc "The turn's usage from a `session/prompt` result, or nil."
+  @spec from_prompt_result(map() | nil) :: t() | nil
+  def from_prompt_result(%{"usage" => %{} = usage}), do: normalize(usage)
+  def from_prompt_result(%{"_meta" => %{} = meta}), do: normalize(meta)
+  def from_prompt_result(_), do: nil
+
+  defp normalize(source) do
+    input = count(source["inputTokens"])
+    output = count(source["outputTokens"])
+
+    if is_nil(input) and is_nil(output) do
+      nil
+    else
+      %{"input" => input || 0, "output" => output || 0}
+      |> put_present("cache_read", count(source["cachedReadTokens"]))
+      |> put_present("cache_write", count(source["cachedWriteTokens"]))
+    end
+  end
+
+  # An adapter that reports a float or a numeric string still counts;
+  # anything else (a negative, a bool, an object) is "not reported".
+  defp count(n) when is_integer(n) and n >= 0, do: n
+  defp count(n) when is_float(n) and n >= 0, do: trunc(n)
+
+  defp count(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, ""} when n >= 0 -> n
+      _ -> nil
+    end
+  end
+
+  defp count(_), do: nil
+
+  defp put_present(map, _key, nil), do: map
+  defp put_present(map, key, value), do: Map.put(map, key, value)
+end

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -74,7 +74,7 @@ defmodule Fountain.Team do
   One entry per agent on the team, most recently active first.
 
   Each entry is `%{agent: %Agent{}, conversation: %Conversation{}, last_turn:
-  %Turn{} | nil, name: String.t()}` — the conversation is the newest live one
+  %Turn{} | nil, name: String.t(), usage_total: %{input: n, output: n}}` — the conversation is the newest live one
   for that agent, or, when none is live, the newest terminated/failed one (so
   the last transcript still shows). The conversation carries `turn_count` and
   `last_active_at`; `last_turn` is what the list previews; `name` is what the
@@ -82,25 +82,38 @@ defmodule Fountain.Team do
   time, else the agent's name.
   """
   def list_teammates(user_id) when is_binary(user_id) do
-    convs =
+    groups =
       user_id
       |> Conversations.list_channel_conversations(@channel)
       |> Enum.reject(&is_nil(&1.agent))
       |> Enum.group_by(& &1.agent_id)
-      |> Enum.map(fn {_agent_id, convs} -> pick_current(convs) end)
+      |> Enum.map(fn {_agent_id, convs} -> {pick_current(convs), usage_total(convs)} end)
 
-    last_turns = last_turns_by_conversation(Enum.map(convs, & &1.id))
+    last_turns = last_turns_by_conversation(Enum.map(groups, fn {conv, _} -> conv.id end))
 
-    convs
-    |> Enum.map(
-      &%{
-        agent: &1.agent,
-        conversation: &1,
-        last_turn: Map.get(last_turns, &1.id),
-        name: teammate_name(&1)
+    groups
+    |> Enum.map(fn {conv, usage_total} ->
+      %{
+        agent: conv.agent,
+        conversation: conv,
+        last_turn: Map.get(last_turns, conv.id),
+        name: teammate_name(conv),
+        usage_total: usage_total
       }
-    )
+    end)
     |> Enum.sort_by(& &1.conversation.last_active_at, {:desc, DateTime})
+  end
+
+  # The teammate's tokens across every conversation it has had under the
+  # channel (#827) — a replaced conversation's turns still count for the
+  # teammate, even though the roster shows only the current one.
+  defp usage_total(convs) do
+    Enum.reduce(convs, %{input: 0, output: 0}, fn c, acc ->
+      %{
+        input: acc.input + (c.usage_input_tokens || 0),
+        output: acc.output + (c.usage_output_tokens || 0)
+      }
+    end)
   end
 
   @doc "What the teammate is called: the conversation's title, else the agent's name."

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -53,6 +53,8 @@ defmodule FountainWeb.ConversationJSON do
       # Served rather than left to each client: the rule has three cases and
       # the nil ones are easy to get backwards.
       unread: Fountain.Conversations.unread?(c),
+      # Running sums of the turns' usage (#827); zeros until a turn reports one.
+      usage_total: %{input: c.usage_input_tokens || 0, output: c.usage_output_tokens || 0},
       inserted_at: c.inserted_at,
       updated_at: c.updated_at
     }
@@ -125,7 +127,20 @@ defmodule FountainWeb.ConversationJSON do
       started_at: t.started_at,
       ended_at: t.ended_at,
       inserted_at: t.inserted_at,
-      image_count: length(t.images || [])
+      image_count: length(t.images || []),
+      # The end-of-turn figure as the runtime reported it (#827); null when
+      # it reported none or the turn predates the column.
+      usage: t.usage && usage_data(t.usage)
     }
   end
+
+  @doc "A turn's stored usage as the wire object: `input`, `output`, and the cache fields when present."
+  def usage_data(%{} = u) do
+    %{input: u["input"] || 0, output: u["output"] || 0}
+    |> put_present(:cache_read, u["cache_read"])
+    |> put_present(:cache_write, u["cache_write"])
+  end
+
+  defp put_present(map, _k, nil), do: map
+  defp put_present(map, k, v), do: Map.put(map, k, v)
 end

--- a/apps/fountain/lib/fountain_web/controllers/team_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_json.ex
@@ -15,6 +15,8 @@ defmodule FountainWeb.TeamJSON do
       conversation: ConversationJSON.data(conv),
       presence: TeamPresenter.presence(conv),
       unread: Fountain.Conversations.unread?(conv),
+      # Across every conversation the agent has had on the team (#827).
+      usage_total: teammate.usage_total,
       last_turn: last_turn && turn_summary(last_turn),
       preview: preview(TeamPresenter.preview(teammate))
     }
@@ -26,7 +28,8 @@ defmodule FountainWeb.TeamJSON do
       turn_number: turn.turn_number,
       prompt: turn.prompt,
       status: turn.status,
-      inserted_at: turn.inserted_at
+      inserted_at: turn.inserted_at,
+      usage: turn.usage && ConversationJSON.usage_data(turn.usage)
     }
   end
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -37,6 +37,43 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule TurnUsage do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TurnUsage",
+      description:
+        "The turn's token usage as the runtime reported it when the turn ended " <>
+          "(the ACP `session/prompt` response's `usage`). The cache fields appear " <>
+          "only when the runtime reports them.",
+      type: :object,
+      properties: %{
+        input: %Schema{type: :integer, minimum: 0},
+        output: %Schema{type: :integer, minimum: 0},
+        cache_read: %Schema{type: :integer, minimum: 0, nullable: true},
+        cache_write: %Schema{type: :integer, minimum: 0, nullable: true}
+      },
+      required: [:input, :output]
+    })
+  end
+
+  defmodule UsageTotal do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "UsageTotal",
+      description: "Running sums of `input` and `output` over the turns that reported a usage.",
+      type: :object,
+      properties: %{
+        input: %Schema{type: :integer, minimum: 0},
+        output: %Schema{type: :integer, minimum: 0}
+      },
+      required: [:input, :output]
+    })
+  end
+
   defmodule Conversation do
     @moduledoc false
     require OpenApiSpex
@@ -104,6 +141,7 @@ defmodule FountainWeb.Schemas do
           type: :boolean,
           description: "last_active_at is later than last_read_at (true if never read)."
         },
+        usage_total: UsageTotal,
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
@@ -280,6 +318,13 @@ defmodule FountainWeb.Schemas do
         image_count: %Schema{
           type: :integer,
           description: "Number of images attached to this turn."
+        },
+        usage: %Schema{
+          oneOf: [TurnUsage],
+          nullable: true,
+          description:
+            "The end-of-turn token figure; null while the turn runs, when the runtime " <>
+              "reported none, or on turns that predate the field."
         }
       },
       required: [:id, :turn_number, :prompt, :status]
@@ -1657,6 +1702,12 @@ defmodule FountainWeb.Schemas do
           required: [:state, :label]
         },
         unread: %Schema{type: :boolean},
+        usage_total: %Schema{
+          allOf: [UsageTotal],
+          description:
+            "Summed over every conversation this agent has had under the team " <>
+              "channel, not just the current one — the per-teammate figure."
+        },
         last_turn: %Schema{
           type: :object,
           nullable: true,
@@ -1665,7 +1716,8 @@ defmodule FountainWeb.Schemas do
             turn_number: %Schema{type: :integer},
             prompt: %Schema{type: :string},
             status: %Schema{type: :string},
-            inserted_at: %Schema{type: :string, format: :"date-time"}
+            inserted_at: %Schema{type: :string, format: :"date-time"},
+            usage: %Schema{oneOf: [TurnUsage], nullable: true}
           }
         },
         preview: %Schema{

--- a/apps/fountain/priv/repo/migrations/20260819100000_add_token_usage.exs
+++ b/apps/fountain/priv/repo/migrations/20260819100000_add_token_usage.exs
@@ -1,0 +1,24 @@
+defmodule Fountain.Repo.Migrations.AddTokenUsage do
+  @moduledoc """
+  Token usage per turn and per conversation (#827).
+
+  `turns.usage` is the end-of-turn figure as the runtime reports it on the
+  ACP `session/prompt` response — `{"input", "output", "cache_read",
+  "cache_write"}` — null for turns that predate this or whose runtime does
+  not report one. The two conversation columns are running sums of `input`
+  and `output` over the conversation's turns, kept by the context as each
+  turn ends, so a list never has to aggregate turns.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:turns) do
+      add :usage, :map
+    end
+
+    alter table(:conversations) do
+      add :usage_input_tokens, :bigint, null: false, default: 0
+      add :usage_output_tokens, :bigint, null: false, default: 0
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -249,6 +249,35 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
     end
 
+    test "the response's usage lands on the turn and the conversation's sums (#827)", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+
+      reply(pid, ref, prompt_id, %{
+        "stopReason" => "end_turn",
+        "usage" => %{"inputTokens" => 100, "outputTokens" => 25, "totalTokens" => 125}
+      })
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "completed"
+      assert turn.usage == %{"input" => 100, "output" => 25}
+
+      conv = Conversations._unsafe_get_conversation!(conv.id)
+      assert conv.usage_input_tokens == 100
+      assert conv.usage_output_tokens == 25
+    end
+
+    test "a response without usage leaves the turn's usage nil", %{conv: conv, pid: pid, ref: ref} do
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      assert [%{usage: nil}] = Conversations._unsafe_list_turns(conv.id)
+      assert %{usage_input_tokens: 0} = Conversations._unsafe_get_conversation!(conv.id)
+    end
+
     test "the stop reason ends the turn and closes stdin", %{conv: conv, pid: pid, ref: ref} do
       prompt_id = drive_to_prompt(pid, ref)
 

--- a/apps/fountain/test/fountain/conversations/turn_usage_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_usage_test.exs
@@ -1,0 +1,48 @@
+defmodule Fountain.Conversations.TurnUsageTest do
+  @moduledoc "`Conversations._unsafe_record_turn_usage/2` (#827): once per turn, summed on the conversation."
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+
+  setup do
+    user = insert_verified_user()
+    conv = insert_conversation(user_id: user.id, agent: insert_agent(user_id: user.id))
+    {:ok, user: user, conv: conv}
+  end
+
+  test "stamps the turn and adds to the conversation's running sums", %{conv: conv} do
+    t1 = insert_turn(conv, prompt: "one", status: "completed")
+    t2 = insert_turn(conv, prompt: "two", status: "completed", turn_number: 2)
+
+    assert {:ok, %{usage: %{"input" => 100, "output" => 20}}} =
+             Conversations._unsafe_record_turn_usage(t1, %{"input" => 100, "output" => 20})
+
+    assert {:ok, _} =
+             Conversations._unsafe_record_turn_usage(t2, %{
+               "input" => 50,
+               "output" => 5,
+               "cache_read" => 40
+             })
+
+    conv = Conversations._unsafe_get_conversation!(conv.id)
+    assert conv.usage_input_tokens == 150
+    assert conv.usage_output_tokens == 25
+
+    assert Conversations._unsafe_list_turns(conv.id) |> Enum.map(& &1.usage) == [
+             %{"input" => 100, "output" => 20},
+             %{"input" => 50, "output" => 5, "cache_read" => 40}
+           ]
+  end
+
+  test "nil records nothing; a second figure for the same turn is refused", %{conv: conv} do
+    t = insert_turn(conv, prompt: "one", status: "completed")
+    assert :ok = Conversations._unsafe_record_turn_usage(t, nil)
+    assert {:ok, t} = Conversations._unsafe_record_turn_usage(t, %{"input" => 1, "output" => 1})
+
+    assert {:error, :already_recorded} =
+             Conversations._unsafe_record_turn_usage(t, %{"input" => 1, "output" => 1})
+
+    assert %{usage_input_tokens: 1, usage_output_tokens: 1} =
+             Conversations._unsafe_get_conversation!(conv.id)
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -330,7 +330,36 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
 
       send_response(pid, prompt_id, %{"stopReason" => "end_turn"})
 
-      assert_receive {:acp, _ref, {:done, "end_turn"}}
+      assert_receive {:acp, _ref, {:done, "end_turn", nil}}
+    end
+
+    test "the response's usage rides along, normalised (#827)", ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+      %{"id" => prompt_id} = next_write()
+
+      send_response(pid, prompt_id, %{
+        "stopReason" => "end_turn",
+        "usage" => %{
+          "inputTokens" => 1200,
+          "outputTokens" => 340,
+          "cachedReadTokens" => 900,
+          "cachedWriteTokens" => 0,
+          "totalTokens" => 2440
+        }
+      })
+
+      assert_receive {:acp, _ref,
+                      {:done, "end_turn",
+                       %{
+                         "input" => 1200,
+                         "output" => 340,
+                         "cache_read" => 900,
+                         "cache_write" => 0
+                       }}}
     end
 
     test "an error response fails the turn", ctx do
@@ -772,7 +801,7 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
 
       _ = :sys.get_state(pid)
       refute_received {:acp, _, {:failed, _}}
-      refute_received {:acp, _, {:done, _}}
+      refute_received {:acp, _, {:done, _, _}}
       refute_received {:acp, _, {:model_rejected, _, _}}
     end
 
@@ -802,7 +831,7 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
     test "the response to the prompt id ends the turn; an error to it fails the turn", ctx do
       pid = attached_peer(ctx, 4)
       send_response(pid, 4, %{"stopReason" => "end_turn"})
-      assert_receive {:acp, _ref, {:done, "end_turn"}}
+      assert_receive {:acp, _ref, {:done, "end_turn", nil}}
 
       pid2 = attached_peer(ctx, 7)
 

--- a/apps/fountain/test/fountain/runtimes/acp/usage_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/usage_test.exs
@@ -1,0 +1,36 @@
+defmodule Fountain.Runtimes.ACP.UsageTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Runtimes.ACP.Usage
+
+  test "the `usage` object, with the cache fields when present" do
+    assert Usage.from_prompt_result(%{
+             "stopReason" => "end_turn",
+             "usage" => %{
+               "inputTokens" => 10,
+               "outputTokens" => 4,
+               "cachedReadTokens" => 8,
+               "cachedWriteTokens" => nil,
+               "totalTokens" => 22
+             }
+           }) == %{"input" => 10, "output" => 4, "cache_read" => 8}
+  end
+
+  test "falls back to _meta.inputTokens / outputTokens" do
+    assert Usage.from_prompt_result(%{"_meta" => %{"inputTokens" => 3, "outputTokens" => "7"}}) ==
+             %{"input" => 3, "output" => 7}
+  end
+
+  test "nil when nothing is reported, or nothing usable" do
+    assert Usage.from_prompt_result(%{"stopReason" => "end_turn"}) == nil
+    assert Usage.from_prompt_result(%{"_meta" => %{"other" => 1}}) == nil
+    assert Usage.from_prompt_result(%{"usage" => %{"inputTokens" => -1}}) == nil
+    assert Usage.from_prompt_result(%{"usage" => %{"inputTokens" => true}}) == nil
+    assert Usage.from_prompt_result(nil) == nil
+  end
+
+  test "one side missing counts as zero for that side" do
+    assert Usage.from_prompt_result(%{"usage" => %{"outputTokens" => 5.0}}) ==
+             %{"input" => 0, "output" => 5}
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -112,6 +112,42 @@ defmodule FountainWeb.ConversationControllerTest do
       assert turn.id in ids
     end
 
+    test "carries each turn's usage and the conversation's usage_total (#827)", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+      t1 = insert_turn(conv, status: "completed")
+      insert_turn(conv, status: "completed")
+
+      {:ok, _} =
+        Fountain.Conversations._unsafe_record_turn_usage(t1, %{
+          "input" => 120,
+          "output" => 30,
+          "cache_read" => 100
+        })
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations/#{conv.id}/turns")
+        |> json_response(200)
+
+      assert [
+               %{"usage" => %{"input" => 120, "output" => 30, "cache_read" => 100}},
+               %{"usage" => nil}
+             ] = body["data"]
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations/#{conv.id}")
+        |> json_response(200)
+
+      assert body["data"]["usage_total"] == %{"input" => 120, "output" => 30}
+    end
+
     test "returns 200 with an empty list when there are no turns", %{
       conn: conn,
       user: user,

--- a/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
@@ -53,6 +53,32 @@ defmodule FountainWeb.TeamControllerTest do
       assert is_boolean(entry["unread"])
     end
 
+    test "usage_total sums every conversation the agent had on the team (#827)", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      old = insert_teammate_conv(user, ada, status: "terminated")
+      current = insert_teammate_conv(user, ada)
+      t_old = insert_turn(old, prompt: "before", status: "completed")
+      t_new = insert_turn(current, prompt: "now", status: "completed")
+
+      {:ok, _} =
+        Fountain.Conversations._unsafe_record_turn_usage(t_old, %{"input" => 10, "output" => 1})
+
+      {:ok, _} =
+        Fountain.Conversations._unsafe_record_turn_usage(t_new, %{"input" => 5, "output" => 2})
+
+      body = conn |> authed_with_key(key) |> get("/api/team") |> json_response(200)
+
+      assert [entry] = body["data"]
+      assert entry["conversation"]["id"] == current.id
+      assert entry["conversation"]["usage_total"] == %{"input" => 5, "output" => 2}
+      assert entry["usage_total"] == %{"input" => 15, "output" => 3}
+      assert entry["last_turn"]["usage"] == %{"input" => 5, "output" => 2}
+    end
+
     test "is empty with no team", %{conn: conn, raw_key: key} do
       assert %{"data" => []} =
                conn |> authed_with_key(key) |> get("/api/team") |> json_response(200)

--- a/docs/api.md
+++ b/docs/api.md
@@ -251,6 +251,17 @@ Turns carry `image_count`; the image endpoint takes a zero-based `position` into
 
 Conversation objects carry `title`, `turn_count`, `last_active_at`, `last_read_at` and a computed `unread` alongside the lifecycle fields. `unread` is true when `last_active_at` is later than `last_read_at` (and for a conversation never read); `POST /api/conversations/:id/read` clears it.
 
+**Token usage.** Each turn carries `usage` — `{input, output, cache_read?,
+cache_write?}` — the figure the runtime reports when the turn ends (the ACP
+`session/prompt` response's `usage`; claude-agent-acp and codex-acp report
+it), or `null` while the turn runs, when the runtime reported none, or on
+turns that predate the field. It is recorded once per turn and never summed
+from the `usage_update` notifications that stream during a turn (those are
+context-window occupancy and mean different things per runtime). Each
+conversation carries `usage_total: {input, output}`, a running sum over its
+turns; a `/api/team` roster entry carries `usage_total` summed over every
+conversation the agent has had on the team.
+
 `/tree` returns every conversation in the same spawn tree — ancestors and descendants, flat, each with a `parent_id`:
 
 ```json


### PR DESCRIPTION
## Summary

Closes #827.

- **Source**: the ACP `session/prompt` response's `usage` (`inputTokens`, `outputTokens`, `cachedReadTokens`, `cachedWriteTokens`; `_meta.inputTokens|outputTokens` as a fallback). Verified against `@agentclientprotocol/claude-agent-acp` 0.66.0 (`sessionUsage(session)` — per-turn accumulated API usage, reset on turn activation) and codex-acp. Never summed from `usage_update` (context-window occupancy + cumulative cost; per-runtime meaning), per the issue.
- `Fountain.Runtimes.ACP.Usage.from_prompt_result/1` normalises to `%{"input", "output", "cache_read"?, "cache_write"?}`; the peer's report becomes `{:done, stop_reason, usage | nil}`.
- `Conversations._unsafe_record_turn_usage/2`: stamps `turns.usage` and `inc:`s `conversations.usage_input_tokens/usage_output_tokens` in one transaction; refuses a second figure for the same turn.
- Migration `20260819100000_add_token_usage` (nullable jsonb on turns; two `bigint default 0` on conversations).
- Wire: `usage` on turns (`/turns`, team `last_turn`), `usage_total {input, output}` on conversation objects, `usage_total` on `/api/team` entries summed across every conversation the agent has had on the team. OpenAPI `TurnUsage` / `UsageTotal`, docs/api.md, CHANGELOG.

## Test plan

- [x] `usage_test.exs` (normalisation), `peer_test.exs` (usage rides the `:done` report), `conversation_server_acp_test.exs` (lands on the turn + conversation sums; nil when absent), `turn_usage_test.exs` (context: sums, refuse double-record), controller tests for `/turns`, `GET /conversations/:id`, `/api/team`
- [x] `mix test` → 3067 tests, 0 failures; format, credo --strict, compile --warnings-as-errors clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)