### PR TITLE
feat(api): GET /api/search across a user's conversations and turns (#826)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ upgrade, is in
 
 ### Added
 
+- **`GET /api/search`** (#826). Full-text search across the caller's
+  conversation titles, turn prompts and assistant replies, with `kind`,
+  ids and a plain-text snippet per hit; `websearch` syntax, `limit`/`offset`,
+  `agent_id`/`conversation_id`/`since`/`kinds` filters. Replies come from a
+  new `turns.reply_text`, materialised when a turn ends from the same block
+  parse the transcript uses (never tool noise); turns that ended before this
+  release are searchable by prompt until
+  `Fountain.Release.backfill_turn_replies/0` runs once on the server.
+
 - **Team schedules over the API** (#825). `GET /api/team/schedules`, and
   `GET|POST /api/team/:agent_id/schedules`, `GET|PATCH|DELETE
   /api/team/:agent_id/schedules/:id`, `POST .../:id/run` — the routines the

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -11,7 +11,7 @@ defmodule Fountain.Conversations do
   require Logger
 
   alias Fountain.Audit
-  alias Fountain.Conversations.{Conversation, LogEvent, Sandbox, Turn, TurnImage}
+  alias Fountain.Conversations.{Blocks, Conversation, LogEvent, Sandbox, Turn, TurnImage}
   alias Fountain.Repo
 
   # ── on the _unsafe_ prefix ────────────────────────────────────────────────
@@ -798,9 +798,20 @@ defmodule Fountain.Conversations do
     end
   end
 
+  @doc """
+  Update a turn's row. When the update ends the turn — its status becomes
+  `completed`, `failed` or `interrupted` — the assistant's text for the
+  turn is materialised into `reply_text` in the same write (#826): every
+  turn ending goes through here, from the ConversationServer's six endings
+  to the orphan sweep, so search coverage is by construction rather than
+  by each ending remembering. A turn that already carries a `reply_text`
+  keeps it.
+  """
   def _unsafe_update_turn(%Turn{} = turn, attrs) do
-    turn
-    |> Turn.changeset(attrs)
+    changeset = Turn.changeset(turn, attrs)
+
+    changeset
+    |> maybe_put_reply_text(turn)
     |> Repo.update()
   end
 
@@ -834,6 +845,63 @@ defmodule Fountain.Conversations do
 
       updated
     end)
+  end
+
+  @terminal_turn_statuses ~w(completed failed interrupted)
+
+  defp maybe_put_reply_text(%Ecto.Changeset{valid?: false} = changeset, _turn), do: changeset
+
+  defp maybe_put_reply_text(changeset, %Turn{reply_text: nil} = turn) do
+    case Ecto.Changeset.get_change(changeset, :status) do
+      status when status in @terminal_turn_statuses ->
+        Ecto.Changeset.put_change(changeset, :reply_text, _unsafe_turn_reply_text(turn))
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp maybe_put_reply_text(changeset, _turn), do: changeset
+
+  @doc """
+  Materialise `reply_text` on every ended turn that has none — the one-time
+  backfill for turns that predate the column (`Fountain.Release.backfill_turn_replies/0`).
+  Returns the number of turns written; a turn with no assistant text is
+  left null and visited again next run (there are few, and re-parsing them
+  is cheap). No tenant scope: a system sweep.
+  """
+  def _unsafe_backfill_reply_texts do
+    from(t in Turn,
+      where: t.status in ^@terminal_turn_statuses and is_nil(t.reply_text),
+      order_by: [asc: t.inserted_at]
+    )
+    |> Repo.all()
+    |> Enum.reduce(0, fn turn, n ->
+      case _unsafe_turn_reply_text(turn) do
+        nil ->
+          n
+
+        text ->
+          {:ok, _} = turn |> Turn.changeset(%{reply_text: text}) |> Repo.update()
+          n + 1
+      end
+    end)
+  end
+
+  @doc """
+  The assistant's text for `turn`, from its events through the same parse
+  the transcript uses (`Blocks.assistant_text/2`); nil when there is none.
+  Reads the conversation's runtime for the legacy dialects. Without tenant
+  scope: the caller holds the turn.
+  """
+  def _unsafe_turn_reply_text(%Turn{} = turn) do
+    runtime =
+      Repo.one(from c in Conversation, where: c.id == ^turn.conversation_id, select: c.runtime)
+
+    case turn.id |> _unsafe_list_turn_log_events() |> Blocks.assistant_text(runtime) do
+      "" -> nil
+      text -> text
+    end
   end
 
   # ── log events ──────────────────────────────────────────────────────────────────────────

--- a/apps/fountain/lib/fountain/conversations/blocks.ex
+++ b/apps/fountain/lib/fountain/conversations/blocks.ex
@@ -59,6 +59,27 @@ defmodule Fountain.Conversations.Blocks do
 
   def for_event(_, _), do: []
 
+  @doc """
+  The assistant's text across `events` — every `:text` block of each output
+  event, joined, trimmed — for `runtime`'s dialect on legacy rows. What a
+  chat bubble shows for a turn's reply, what the roster previews, and what
+  `Fountain.Search` indexes (`turns.reply_text`). `""` when there is none.
+  """
+  @spec assistant_text([map()], String.t() | nil) :: String.t()
+  def assistant_text(events, runtime) do
+    events
+    |> Enum.filter(
+      &(&1.kind == "output" and &1.stream in ["stdout", "acp"] and is_binary(&1.data))
+    )
+    |> Enum.flat_map(&for_event(&1, runtime))
+    |> Enum.flat_map(fn
+      %{kind: :text, body: t} when is_binary(t) -> [t]
+      _ -> []
+    end)
+    |> Enum.join("")
+    |> String.trim()
+  end
+
   @doc "The wire form of a block: string `kind`, `error` for `error?`, everything else as is."
   @spec to_json(map()) :: map()
   def to_json(%{kind: kind} = block) do

--- a/apps/fountain/lib/fountain/conversations/turn.ex
+++ b/apps/fountain/lib/fountain/conversations/turn.ex
@@ -25,6 +25,11 @@ defmodule Fountain.Conversations.Turn do
     # never summed from the live `usage_update`s (their meaning differs per
     # runtime). nil when the runtime reported nothing.
     field :usage, :map
+    # The assistant's text for the turn — its events' `text` blocks, joined —
+    # materialised by `Conversations._unsafe_update_turn/2` when the turn
+    # ends, for `Fountain.Search` (#826). nil while the turn runs and on
+    # turns that predate the column (see `Fountain.Release.backfill_turn_replies/0`).
+    field :reply_text, :string
     belongs_to :conversation, Conversation
     has_many :images, TurnImage, preload_order: [asc: :position]
     timestamps(type: :utc_datetime, updated_at: false)
@@ -43,6 +48,7 @@ defmodule Fountain.Conversations.Turn do
       :ended_at,
       :acp_prompt_id,
       :usage,
+      :reply_text,
       :conversation_id
     ])
     |> validate_required([:turn_number, :prompt, :status, :conversation_id])

--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -153,6 +153,30 @@ defmodule Fountain.Release do
   end
 
   @doc """
+  Materialise `turns.reply_text` for every ended turn that has none (#826):
+  the assistant's text of each, through the same parse the transcript uses,
+  so `GET /api/search` covers replies from before the column existed. Turns
+  ending after the migration are written as they end. Idempotent; prints a
+  count. Runs beside the live server:
+
+      PHX_SERVER=false METRICS_PORT=0 bin/fountain_server eval 'Fountain.Release.backfill_turn_replies()'
+  """
+  def backfill_turn_replies do
+    load_app()
+
+    for repo <- repos() do
+      # ownership: a system-level sweep over every tenant's ended turns,
+      # run by an operator beside the release — the same footing as migrate/0.
+      {:ok, n, _} =
+        Ecto.Migrator.with_repo(repo, fn _repo ->
+          Fountain.Conversations._unsafe_backfill_reply_texts()
+        end)
+
+      IO.puts("backfilled reply_text on #{n} turn(s)")
+    end
+  end
+
+  @doc """
   Gives accounts without a trial clock a status and a trial end date.
 
   Two cohorts land here, both of which the gate would otherwise handle badly

--- a/apps/fountain/lib/fountain/search.ex
+++ b/apps/fountain/lib/fountain/search.ex
@@ -1,0 +1,258 @@
+defmodule Fountain.Search do
+  @moduledoc """
+  Full-text search across a user's conversations (#826): titles, turn
+  prompts and assistant replies, for a client's command palette — "jump to
+  the message".
+
+  Postgres full-text, `simple` config (no stemming, no stop words: an
+  identifier or a code fragment matches as itself, and so does text in any
+  language), `websearch_to_tsquery` syntax (`quoted phrases`, `-excluded`,
+  `or`). Three sources, one shape:
+
+    * `title` — a conversation's title (`Conversations.title`);
+    * `prompt` — a turn's prompt;
+    * `reply` — a turn's assistant text, from `turns.reply_text`, which is
+      materialised when the turn ends (`Conversations._unsafe_update_turn/2`).
+      A turn in flight is not searchable by its reply until it ends; turns
+      that ended before the column existed need
+      `Fountain.Release.backfill_turn_replies/0`.
+
+  Every source is scoped by `user_id` in the query itself; there is no
+  unscoped entry point. Hits are ranked (`ts_rank`, then newest first) and
+  paged with `limit` / `offset` — one query per source, merged here, so a
+  page costs three indexed lookups; fine at the sizes a tenant has.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Fountain.Conversations.{Conversation, Turn}
+  alias Fountain.Repo
+
+  @default_limit 20
+  @max_limit 100
+  @snippet_words 32
+  @kinds ~w(title prompt reply)
+
+  @typedoc "One hit; `turn_id` is nil for a `title` hit."
+  @type hit :: %{
+          kind: String.t(),
+          conversation_id: String.t(),
+          agent_id: String.t() | nil,
+          turn_id: String.t() | nil,
+          turn_number: non_neg_integer() | nil,
+          snippet: String.t(),
+          ts: DateTime.t(),
+          rank: float()
+        }
+
+  @doc "Every `kind` a hit can have — the wire enum."
+  def kinds, do: @kinds
+
+  @doc "The page-size cap."
+  def max_limit, do: @max_limit
+
+  @doc """
+  Search `user_id`'s conversations for `q`.
+
+  Options: `:limit` (default #{@default_limit}, capped at #{@max_limit}),
+  `:offset` (default 0), `:agent_id`, `:conversation_id`, `:since` (a
+  `DateTime`; hits at or after it), `:kinds` (a subset of `#{inspect(@kinds)}`).
+
+  Returns `%{hits: [hit], has_more: boolean, limit: n, offset: n}`. A blank
+  query, or one with no searchable term (`"-only"`), matches nothing.
+  """
+  @spec search(String.t(), String.t(), keyword()) :: %{
+          hits: [hit()],
+          has_more: boolean(),
+          limit: pos_integer(),
+          offset: non_neg_integer()
+        }
+  def search(user_id, q, opts \\ []) when is_binary(user_id) and is_binary(q) do
+    limit = opts |> Keyword.get(:limit, @default_limit) |> clamp(1, @max_limit)
+    offset = opts |> Keyword.get(:offset, 0) |> max(0)
+    kinds = Keyword.get(opts, :kinds) || @kinds
+    q = String.trim(q)
+
+    hits =
+      if q == "" or not positive_term?(q) do
+        []
+      else
+        # Each source returns at most one page past the offset; the merge
+        # below re-ranks across sources and re-applies the window.
+        take = offset + limit + 1
+
+        kinds
+        |> Enum.flat_map(fn
+          "title" -> title_hits(user_id, q, take, opts)
+          "prompt" -> turn_hits(user_id, q, :prompt, take, opts)
+          "reply" -> turn_hits(user_id, q, :reply_text, take, opts)
+          _ -> []
+        end)
+        |> Enum.sort_by(&{-&1.rank, DateTime.to_unix(&1.ts, :microsecond) * -1, &1.kind})
+        |> Enum.drop(offset)
+        |> Enum.take(limit + 1)
+      end
+
+    %{
+      hits: Enum.take(hits, limit),
+      has_more: length(hits) > limit,
+      limit: limit,
+      offset: offset
+    }
+  end
+
+  # ── sources ─────────────────────────────────────────────────────────────
+
+  defp title_hits(user_id, q, take, opts) do
+    from(c in Conversation,
+      where: c.user_id == ^user_id and not is_nil(c.title),
+      where:
+        fragment(
+          "to_tsvector('simple', coalesce(?, '')) @@ websearch_to_tsquery('simple', ?)",
+          c.title,
+          ^q
+        ),
+      select: %{
+        kind: "title",
+        conversation_id: c.id,
+        agent_id: c.agent_id,
+        turn_id: nil,
+        turn_number: nil,
+        snippet:
+          fragment(
+            "ts_headline('simple', ?, websearch_to_tsquery('simple', ?), ?)",
+            c.title,
+            ^q,
+            ^headline_opts()
+          ),
+        ts: c.inserted_at,
+        rank:
+          fragment(
+            "ts_rank(to_tsvector('simple', coalesce(?, '')), websearch_to_tsquery('simple', ?))",
+            c.title,
+            ^q
+          )
+      },
+      order_by: [
+        desc:
+          fragment(
+            "ts_rank(to_tsvector('simple', coalesce(?, '')), websearch_to_tsquery('simple', ?))",
+            c.title,
+            ^q
+          ),
+        desc: c.inserted_at
+      ],
+      limit: ^take
+    )
+    |> filter_conversation(opts)
+    |> filter_since(:c, opts)
+    |> Repo.all()
+  end
+
+  defp turn_hits(user_id, q, field, take, opts) do
+    kind = if field == :prompt, do: "prompt", else: "reply"
+
+    from(t in Turn,
+      join: c in Conversation,
+      on: c.id == t.conversation_id,
+      as: :conv,
+      where: c.user_id == ^user_id,
+      where:
+        fragment(
+          "to_tsvector('simple', coalesce(?, '')) @@ websearch_to_tsquery('simple', ?)",
+          field(t, ^field),
+          ^q
+        ),
+      select: %{
+        kind: ^kind,
+        conversation_id: c.id,
+        agent_id: c.agent_id,
+        turn_id: t.id,
+        turn_number: t.turn_number,
+        snippet:
+          fragment(
+            "ts_headline('simple', ?, websearch_to_tsquery('simple', ?), ?)",
+            field(t, ^field),
+            ^q,
+            ^headline_opts()
+          ),
+        ts: t.inserted_at,
+        rank:
+          fragment(
+            "ts_rank(to_tsvector('simple', coalesce(?, '')), websearch_to_tsquery('simple', ?))",
+            field(t, ^field),
+            ^q
+          )
+      },
+      order_by: [
+        desc:
+          fragment(
+            "ts_rank(to_tsvector('simple', coalesce(?, '')), websearch_to_tsquery('simple', ?))",
+            field(t, ^field),
+            ^q
+          ),
+        desc: t.inserted_at
+      ],
+      limit: ^take
+    )
+    |> filter_conversation(opts)
+    |> filter_since(:t, opts)
+    |> Repo.all()
+  end
+
+  # ── filters ─────────────────────────────────────────────────────────────
+
+  # `agent_id` / `conversation_id` are on the conversation row; on the turn
+  # queries that is the joined `:conv` binding, on the title query the root.
+  defp filter_conversation(query, opts) do
+    query
+    |> maybe_where(:agent_id, opts[:agent_id])
+    |> maybe_where(:conversation_id, opts[:conversation_id])
+  end
+
+  defp maybe_where(query, _field, nil), do: query
+  defp maybe_where(query, _field, ""), do: query
+
+  defp maybe_where(query, :agent_id, id) do
+    if has_named_binding?(query, :conv),
+      do: where(query, [conv: c], c.agent_id == ^id),
+      else: where(query, [c], c.agent_id == ^id)
+  end
+
+  defp maybe_where(query, :conversation_id, id) do
+    if has_named_binding?(query, :conv),
+      do: where(query, [conv: c], c.id == ^id),
+      else: where(query, [c], c.id == ^id)
+  end
+
+  defp filter_since(query, _binding, opts) do
+    case opts[:since] do
+      %DateTime{} = since ->
+        where(query, [row], row.inserted_at >= ^since)
+
+      _ ->
+        query
+    end
+  end
+
+  # ── helpers ─────────────────────────────────────────────────────────────
+
+  # Plain text, one fragment, no markup: a client renders the snippet as
+  # text; anything it wants highlighted it finds with the query it sent.
+  defp headline_opts,
+    do:
+      ~s(StartSel="", StopSel="", MaxFragments=1, MaxWords=#{@snippet_words}, ) <>
+        ~s(MinWords=#{div(@snippet_words, 2)}, FragmentDelimiter=" … ")
+
+  # `-foo` alone is `!foo` to Postgres, which matches every row that lacks
+  # it — the whole tenant. A search box means "find", so a query with only
+  # exclusions finds nothing.
+  defp positive_term?(q) do
+    q
+    |> String.split()
+    |> Enum.any?(&(not String.starts_with?(&1, "-") and String.downcase(&1) != "or"))
+  end
+
+  defp clamp(n, lo, hi) when is_integer(n), do: n |> max(lo) |> min(hi)
+  defp clamp(_, lo, _hi), do: lo
+end

--- a/apps/fountain/lib/fountain_web/controllers/search_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/search_controller.ex
@@ -1,0 +1,137 @@
+defmodule FountainWeb.SearchController do
+  @moduledoc """
+  `GET /api/search` (#826): full-text search across the caller's
+  conversations — titles, prompts, replies — for a client's command palette.
+  A thin wrapper over `Fountain.Search`, which scopes every source by the
+  caller in the query itself.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Search
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Search"])
+
+  operation(:index,
+    summary: "Search conversations, prompts and replies",
+    description:
+      "Full-text search over the caller's conversation titles, turn prompts and " <>
+        "assistant replies (`kind`: `title`, `prompt`, `reply`), ranked, newest first " <>
+        "among equals. Postgres `websearch` syntax: `\"quoted phrase\"`, `-excluded`, " <>
+        "`or`; matching is exact-token (no stemming), so identifiers and code " <>
+        "fragments match as themselves. Each hit names the conversation, agent and " <>
+        "turn to jump to, with a plain-text `snippet` (no markup) and the turn's " <>
+        "(or conversation's) creation time as `ts`. A reply is searchable once its " <>
+        "turn ends. Page with `limit` / `offset` while `meta.has_more`.",
+    parameters: [
+      q: [in: :query, type: :string, required: true, description: "The search text."],
+      limit: [
+        in: :query,
+        type: %OpenApiSpex.Schema{type: :integer, minimum: 1, maximum: Search.max_limit()},
+        required: false,
+        description: "Page size; default 20, max #{Search.max_limit()}."
+      ],
+      offset: [
+        in: :query,
+        type: %OpenApiSpex.Schema{type: :integer, minimum: 0},
+        required: false,
+        description: "Hits to skip; default 0."
+      ],
+      agent_id: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Only this agent's conversations."
+      ],
+      conversation_id: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Only this conversation."
+      ],
+      since: [
+        in: :query,
+        type: %OpenApiSpex.Schema{type: :string, format: :"date-time"},
+        required: false,
+        description: "Only hits whose `ts` is at or after this instant (RFC 3339)."
+      ],
+      kinds: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Comma-separated subset of `title,prompt,reply`; default all."
+      ]
+    ],
+    responses: [
+      ok: {"Hits", "application/json", Schemas.SearchResponse},
+      bad_request: {"Blank `q`", "application/json", Schemas.Error},
+      unprocessable_entity:
+        {"Missing `q`, or a malformed parameter", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index(conn, params) do
+    user = conn.assigns.current_user
+
+    with {:ok, q} <- fetch_q(params),
+         {:ok, since} <- parse_since(params["since"]) do
+      result =
+        Search.search(user.id, q,
+          limit: parse_int(params["limit"], 20),
+          offset: parse_int(params["offset"], 0),
+          agent_id: params["agent_id"],
+          conversation_id: params["conversation_id"],
+          since: since,
+          kinds: parse_kinds(params["kinds"])
+        )
+
+      render(conn, :index, result: result)
+    end
+  end
+
+  defp fetch_q(%{"q" => q}) when is_binary(q) do
+    case String.trim(q) do
+      "" -> {:error, "q_required"}
+      trimmed -> {:ok, trimmed}
+    end
+  end
+
+  defp fetch_q(_), do: {:error, "q_required"}
+
+  # `replace_params: false` leaves query params as strings; the spec has
+  # already validated the shape, so a parse failure here is only the default.
+  defp parse_int(nil, default), do: default
+  defp parse_int(n, _default) when is_integer(n), do: n
+
+  defp parse_int(s, default) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, ""} -> n
+      _ -> default
+    end
+  end
+
+  defp parse_since(nil), do: {:ok, nil}
+  defp parse_since(%DateTime{} = dt), do: {:ok, dt}
+
+  defp parse_since(s) when is_binary(s) do
+    case DateTime.from_iso8601(s) do
+      {:ok, dt, _offset} -> {:ok, dt}
+      _ -> {:error, "invalid_since"}
+    end
+  end
+
+  defp parse_kinds(nil), do: nil
+  defp parse_kinds(""), do: nil
+
+  defp parse_kinds(s) when is_binary(s) do
+    kinds = s |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+    # An unknown kind is ignored rather than refused: `Fountain.Search`
+    # returns nothing for it, which is the honest answer.
+    Enum.filter(kinds, &(&1 in Search.kinds()))
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/search_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/search_json.ex
@@ -1,0 +1,22 @@
+defmodule FountainWeb.SearchJSON do
+  @moduledoc false
+
+  def index(%{result: %{hits: hits, has_more: has_more, limit: limit, offset: offset}}) do
+    %{
+      data: Enum.map(hits, &hit/1),
+      meta: %{limit: limit, offset: offset, has_more: has_more}
+    }
+  end
+
+  defp hit(h) do
+    %{
+      kind: h.kind,
+      conversation_id: h.conversation_id,
+      agent_id: h.agent_id,
+      turn_id: h.turn_id,
+      turn_number: h.turn_number,
+      snippet: h.snippet,
+      ts: h.ts
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/conversations_live/chat.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/chat.ex
@@ -200,20 +200,11 @@ defmodule FountainWeb.ConversationsLive.Chat do
   # Walk this turn's events and pull out every `:text` block from each
   # runtime's stream-json. Joined so multi-message turns (claude can
   # emit several assistant messages, gemini streams deltas) read as
-  # one contiguous reply.
-  def chat_assistant_reply(events, runtime) do
-    events
-    |> Enum.filter(
-      &(&1.kind == "output" and &1.stream in ["stdout", "acp"] and is_binary(&1.data))
-    )
-    |> Enum.flat_map(&blocks_for(&1, runtime))
-    |> Enum.flat_map(fn
-      %{kind: :text, body: t} when is_binary(t) -> [t]
-      _ -> []
-    end)
-    |> Enum.join("")
-    |> String.trim()
-  end
+  # one contiguous reply. The walk lives in the context (it is also what
+  # `turns.reply_text` is materialised from, #826); this is the render path's
+  # name for it.
+  def chat_assistant_reply(events, runtime),
+    do: Fountain.Conversations.Blocks.assistant_text(events, runtime)
 
   # ── event → blocks ──────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -319,6 +319,9 @@ defmodule FountainWeb.Router do
     # The tenant's own trail (#526). Cross-tenant listing is an admin concern.
     get "/audit", AuditController, :index
 
+    # Full-text search across the caller's conversations (#826).
+    get "/search", SearchController, :index
+
     # MCP tools a hosted Buzz agent's sandbox calls to post to its channel
     # (ADR 0020, #737). One JSON-RPC message per POST; the nsec is resolved
     # server-side and never enters the sandbox.

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1900,6 +1900,62 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule SearchHit do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SearchHit",
+      description: "One search hit: what matched, and where to jump.",
+      type: :object,
+      properties: %{
+        kind: %Schema{type: :string, enum: Fountain.Search.kinds()},
+        conversation_id: %Schema{type: :string, format: :uuid},
+        agent_id: %Schema{type: :string, format: :uuid, nullable: true},
+        turn_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "The turn (prompt / reply hits); null for a title hit."
+        },
+        turn_number: %Schema{type: :integer, nullable: true},
+        snippet: %Schema{
+          type: :string,
+          description: "The best-matching fragment, plain text — no markup to escape."
+        },
+        ts: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "The turn's creation time, or the conversation's for a title hit."
+        }
+      },
+      required: [:kind, :conversation_id, :snippet, :ts]
+    })
+  end
+
+  defmodule SearchResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SearchResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{type: :array, items: SearchHit},
+        meta: %Schema{
+          type: :object,
+          properties: %{
+            limit: %Schema{type: :integer},
+            offset: %Schema{type: :integer},
+            has_more: %Schema{type: :boolean}
+          },
+          required: [:limit, :offset, :has_more]
+        }
+      },
+      required: [:data, :meta]
+    })
+  end
+
   defmodule CatalogResponse do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/priv/repo/migrations/20260819110000_add_search.exs
+++ b/apps/fountain/priv/repo/migrations/20260819110000_add_search.exs
@@ -1,0 +1,51 @@
+defmodule Fountain.Repo.Migrations.AddSearch do
+  @moduledoc """
+  `GET /api/search` (#826): full-text search over conversation titles, turn
+  prompts and assistant replies.
+
+  `turns.reply_text` is the assistant's text for the turn — the `text`
+  blocks of its log events, joined — materialised when the turn ends by
+  `Fountain.Conversations._unsafe_update_turn/2`, so search reads a column
+  and never re-parses `log_events` (and never indexes tool noise). Turns
+  that ended before this migration have it null until
+  `Fountain.Release.backfill_turn_replies/0` runs; the search covers their
+  prompts either way.
+
+  The three GIN indexes are on the exact expressions `Fountain.Search`
+  queries; the search config is `simple` (no stemming, no stop words) so a
+  hit is a hit for an identifier or a code fragment as much as for prose,
+  and so a query in any language matches its own text.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:turns) do
+      add :reply_text, :text
+    end
+
+    execute("""
+    CREATE INDEX turns_prompt_search_idx ON turns
+      USING gin (to_tsvector('simple', coalesce(prompt, '')))
+    """)
+
+    execute("""
+    CREATE INDEX turns_reply_search_idx ON turns
+      USING gin (to_tsvector('simple', coalesce(reply_text, '')))
+    """)
+
+    execute("""
+    CREATE INDEX conversations_title_search_idx ON conversations
+      USING gin (to_tsvector('simple', coalesce(title, '')))
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX IF EXISTS conversations_title_search_idx")
+    execute("DROP INDEX IF EXISTS turns_reply_search_idx")
+    execute("DROP INDEX IF EXISTS turns_prompt_search_idx")
+
+    alter table(:turns) do
+      remove :reply_text
+    end
+  end
+end

--- a/apps/fountain/test/fountain/search_test.exs
+++ b/apps/fountain/test/fountain/search_test.exs
@@ -1,0 +1,206 @@
+defmodule Fountain.SearchTest do
+  @moduledoc "`Fountain.Search` (#826) and the `reply_text` materialisation it reads."
+  use Fountain.DataCase, async: true
+
+  alias Fountain.{Conversations, Search}
+
+  defp acp_text(text) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{
+        "sessionId" => "s",
+        "update" => %{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => text}
+        }
+      }
+    })
+  end
+
+  defp acp_tool(name) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{
+        "sessionId" => "s",
+        "update" => %{
+          "sessionUpdate" => "tool_call",
+          "toolCallId" => "t1",
+          "title" => name,
+          "status" => "pending"
+        }
+      }
+    })
+  end
+
+  # A turn that ran and ended, with an ACP reply.
+  defp finished_turn(conv, prompt, reply, opts \\ []) do
+    turn = insert_turn(conv, prompt: prompt, status: "running")
+
+    if reply do
+      insert_log_event(conv, %{turn_id: turn.id, stream: "acp", data: acp_text(reply)})
+    end
+
+    insert_log_event(conv, %{turn_id: turn.id, stream: "acp", data: acp_tool("Bash zebra")})
+
+    {:ok, turn} =
+      Conversations._unsafe_update_turn(turn, %{
+        status: Keyword.get(opts, :status, "completed"),
+        ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    turn
+  end
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, runtime: "claude")
+    conv = insert_conversation(user_id: user.id, agent: agent, title: "Refactor the billing gate")
+    {:ok, user: user, agent: agent, conv: conv}
+  end
+
+  describe "reply_text materialisation" do
+    test "ending a turn writes the assistant text, not tool noise", %{conv: conv} do
+      turn = finished_turn(conv, "hello", "The gate lives in Billing.Gate.")
+      assert turn.reply_text == "The gate lives in Billing.Gate."
+
+      # A turn with no text ends with reply_text nil, and a non-ending
+      # update leaves reply_text alone.
+      silent = finished_turn(conv, "quiet", nil, status: "failed")
+      assert silent.reply_text == nil
+
+      running = insert_turn(conv, prompt: "still going", status: "running")
+      insert_log_event(conv, %{turn_id: running.id, stream: "acp", data: acp_text("partial")})
+      {:ok, running} = Conversations._unsafe_update_turn(running, %{acp_prompt_id: 4})
+      assert running.reply_text == nil
+    end
+
+    test "the backfill fills ended turns that have none, once", %{conv: conv} do
+      turn = insert_turn(conv, prompt: "old", status: "completed")
+      insert_log_event(conv, %{turn_id: turn.id, stream: "acp", data: acp_text("from before")})
+      insert_turn(conv, prompt: "running", status: "running")
+
+      assert 1 == Conversations._unsafe_backfill_reply_texts()
+      assert 0 == Conversations._unsafe_backfill_reply_texts()
+
+      assert Repo.reload!(turn).reply_text == "from before"
+      assert [%{kind: "reply"}] = Search.search(conv.user_id, "before").hits
+    end
+  end
+
+  describe "search/3" do
+    test "hits across titles, prompts and replies, tenant-scoped, ranked", %{
+      user: user,
+      agent: agent,
+      conv: conv
+    } do
+      t1 =
+        finished_turn(
+          conv,
+          "where does the billing gate live?",
+          "In the Gate plug, under Billing."
+        )
+
+      other_conv = insert_conversation(user_id: user.id, agent: agent, title: "Unrelated")
+      t2 = finished_turn(other_conv, "rename Gate to Toll", "done, Gate is now Toll")
+
+      # Another tenant's identical text never appears.
+      stranger = insert_verified_user()
+
+      s_conv =
+        insert_conversation(
+          user_id: stranger.id,
+          agent: insert_agent(user_id: stranger.id),
+          title: "billing gate"
+        )
+
+      finished_turn(s_conv, "billing gate", "billing gate")
+
+      %{hits: hits, has_more: false} = Search.search(user.id, "gate")
+
+      assert Enum.map(hits, &{&1.kind, &1.conversation_id, &1.turn_id}) |> Enum.sort() ==
+               Enum.sort([
+                 {"title", conv.id, nil},
+                 {"prompt", conv.id, t1.id},
+                 {"reply", conv.id, t1.id},
+                 {"prompt", other_conv.id, t2.id},
+                 {"reply", other_conv.id, t2.id}
+               ])
+
+      title = Enum.find(hits, &(&1.kind == "title"))
+      assert title.snippet == "Refactor the billing gate"
+      assert title.agent_id == agent.id
+      assert %DateTime{} = title.ts
+
+      reply = Enum.find(hits, &(&1.kind == "reply" and &1.turn_id == t1.id))
+      assert reply.snippet =~ "Gate plug"
+      assert reply.turn_number == t1.turn_number
+    end
+
+    test "tool noise is not searchable", %{user: user, conv: conv} do
+      finished_turn(conv, "hello", "plain reply")
+      assert Search.search(user.id, "zebra").hits == []
+    end
+
+    test "filters: agent_id, conversation_id, since, kinds", %{
+      user: user,
+      agent: agent,
+      conv: conv
+    } do
+      finished_turn(conv, "alpha one", "alpha reply")
+      other_agent = insert_agent(user_id: user.id)
+      other = insert_conversation(user_id: user.id, agent: other_agent, title: "alpha two")
+      finished_turn(other, "alpha three", nil)
+
+      assert Search.search(user.id, "alpha", agent_id: agent.id).hits
+             |> Enum.all?(&(&1.conversation_id == conv.id))
+
+      assert Search.search(user.id, "alpha", conversation_id: other.id).hits
+             |> Enum.map(& &1.kind)
+             |> Enum.sort() == ["prompt", "title"]
+
+      assert Search.search(user.id, "alpha", kinds: ["reply"]).hits |> Enum.map(& &1.kind) ==
+               ["reply"]
+
+      future = DateTime.add(DateTime.utc_now(), 3600, :second)
+      assert Search.search(user.id, "alpha", since: future).hits == []
+      past = DateTime.add(DateTime.utc_now(), -3600, :second)
+      assert length(Search.search(user.id, "alpha", since: past).hits) == 4
+    end
+
+    test "paging with limit and offset, has_more", %{user: user, conv: conv} do
+      for i <- 1..5, do: finished_turn(conv, "needle #{i}", nil)
+
+      page1 = Search.search(user.id, "needle", limit: 2)
+      assert length(page1.hits) == 2
+      assert page1.has_more
+      page3 = Search.search(user.id, "needle", limit: 2, offset: 4)
+      assert length(page3.hits) == 1
+      refute page3.has_more
+
+      all = Search.search(user.id, "needle", limit: 100).hits |> Enum.map(& &1.turn_id)
+
+      paged =
+        Enum.flat_map(0..2, fn p ->
+          Search.search(user.id, "needle", limit: 2, offset: p * 2).hits
+        end)
+        |> Enum.map(& &1.turn_id)
+
+      assert paged == all
+    end
+
+    test "websearch syntax and blank queries", %{user: user, conv: conv} do
+      finished_turn(conv, "deploy the api tonight", nil)
+      finished_turn(conv, "deploy the docs tomorrow", nil)
+
+      assert Search.search(user.id, "\"deploy the api\"").hits |> length() == 1
+      assert Search.search(user.id, "deploy -docs").hits |> length() == 1
+      assert Search.search(user.id, "api or docs").hits |> length() == 2
+      assert Search.search(user.id, "   ").hits == []
+      assert Search.search(user.id, "-only").hits == []
+      assert Search.search(user.id, "needle", limit: 0).limit == 1
+      assert Search.search(user.id, "needle", limit: 10_000).limit == Search.max_limit()
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/search_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/search_controller_test.exs
@@ -1,0 +1,133 @@
+defmodule FountainWeb.SearchControllerTest do
+  @moduledoc "`GET /api/search` (#826)."
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Conversations
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    agent = insert_agent(user_id: user.id, runtime: "claude")
+    conv = insert_conversation(user_id: user.id, agent: agent, title: "Rotate the vault key")
+    {:ok, user: user, raw_key: raw_key, agent: agent, conv: conv}
+  end
+
+  defp acp_text(text) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{
+        "sessionId" => "s",
+        "update" => %{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => text}
+        }
+      }
+    })
+  end
+
+  defp finished_turn(conv, prompt, reply) do
+    turn = insert_turn(conv, prompt: prompt, status: "running")
+    insert_log_event(conv, %{turn_id: turn.id, stream: "acp", data: acp_text(reply)})
+
+    {:ok, turn} =
+      Conversations._unsafe_update_turn(turn, %{
+        status: "completed",
+        ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    turn
+  end
+
+  test "hits with kind, ids, snippet and ts; meta paging", %{
+    conn: conn,
+    raw_key: key,
+    conv: conv,
+    agent: agent
+  } do
+    turn = finished_turn(conv, "how do I rotate the key?", "Use `fountain vault rotate`.")
+
+    body =
+      conn
+      |> authed_with_key(key)
+      |> get("/api/search", q: "rotate", limit: 2)
+      |> json_response(200)
+
+    assert body["meta"] == %{"limit" => 2, "offset" => 0, "has_more" => true}
+    assert length(body["data"]) == 2
+
+    body =
+      conn
+      |> authed_with_key(key)
+      |> get("/api/search", q: "rotate", limit: 10)
+      |> json_response(200)
+
+    assert body["meta"]["has_more"] == false
+    kinds = body["data"] |> Enum.map(& &1["kind"]) |> Enum.sort()
+    assert kinds == ["prompt", "reply", "title"]
+
+    reply = Enum.find(body["data"], &(&1["kind"] == "reply"))
+    assert reply["conversation_id"] == conv.id
+    assert reply["agent_id"] == agent.id
+    assert reply["turn_id"] == turn.id
+    assert reply["turn_number"] == turn.turn_number
+    assert reply["snippet"] =~ "vault rotate"
+    assert {:ok, _, _} = DateTime.from_iso8601(reply["ts"])
+
+    title = Enum.find(body["data"], &(&1["kind"] == "title"))
+    assert title["turn_id"] == nil
+  end
+
+  test "filters and kinds pass through", %{conn: conn, raw_key: key, conv: conv, user: user} do
+    finished_turn(conv, "rotate now", "rotated")
+    other = insert_conversation(user_id: user.id, agent: insert_agent(user_id: user.id))
+    finished_turn(other, "rotate later", "rotated")
+
+    body =
+      conn
+      |> authed_with_key(key)
+      |> get("/api/search", q: "rotate", conversation_id: other.id, kinds: "prompt")
+      |> json_response(200)
+
+    assert [%{"kind" => "prompt", "conversation_id" => id}] = body["data"]
+    assert id == other.id
+
+    future = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.to_iso8601()
+
+    assert %{"data" => []} =
+             conn
+             |> authed_with_key(key)
+             |> get("/api/search", q: "rotate", since: future)
+             |> json_response(200)
+  end
+
+  test "never crosses tenants", %{conn: conn, conv: conv} do
+    finished_turn(conv, "rotate the secret", "rotated")
+    {_k, other_key} = insert_api_key(insert_verified_user())
+
+    assert %{"data" => []} =
+             conn
+             |> authed_with_key(other_key)
+             |> get("/api/search", q: "rotate")
+             |> json_response(200)
+  end
+
+  test "422 without q or with a bad since (the spec); 400 on a blank q", %{
+    conn: conn,
+    raw_key: key
+  } do
+    assert conn |> authed_with_key(key) |> get("/api/search") |> json_response(422)
+
+    assert %{"error" => "q_required"} =
+             conn |> authed_with_key(key) |> get("/api/search", q: "  ") |> json_response(400)
+
+    assert conn
+           |> authed_with_key(key)
+           |> get("/api/search", q: "x", since: "yesterday")
+           |> json_response(422)
+  end
+
+  test "401 without a key", %{conn: conn} do
+    assert conn |> get("/api/search", q: "x") |> json_response(401)
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -84,7 +84,8 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.Teammate, "presence.state"} =>
       {FountainWeb.TeamPresenter, :presence_states},
     {FountainWeb.Schemas.Teammate, "preview.kind"} => {FountainWeb.TeamPresenter, :preview_kinds},
-    {FountainWeb.Schemas.Block, "kind"} => {Fountain.Conversations.Blocks, :kinds}
+    {FountainWeb.Schemas.Block, "kind"} => {Fountain.Conversations.Blocks, :kinds},
+    {FountainWeb.Schemas.SearchHit, "kind"} => {Fountain.Search, :kinds}
   }
 
   # Enums with no domain list behind them. Each entry needs a reason: the

--- a/docs/api.md
+++ b/docs/api.md
@@ -315,6 +315,38 @@ was missed across every followed conversation; the first byte is a
 `: connected` comment; heartbeats every 15 s; closes after 60 s idle so the
 client reconnects.
 
+## Search
+
+Full-text search across the caller's conversations, for a command palette
+("jump to the message"):
+
+```
+GET /api/search?q=<text>[&limit=20][&offset=0][&agent_id=][&conversation_id=][&since=][&kinds=title,prompt,reply]
+```
+
+```json
+{"data": [{"kind": "reply", "conversation_id": "…", "agent_id": "…", "turn_id": "…",
+           "turn_number": 3, "snippet": "… the gate lives in the billing plug …",
+           "ts": "2026-08-19T02:00:00Z"}],
+ "meta": {"limit": 20, "offset": 0, "has_more": false}}
+```
+
+Three sources, one shape: `title` (a conversation's title; `turn_id` null),
+`prompt` (a turn's prompt) and `reply` (a turn's assistant text — the `text`
+blocks of its events, materialised when the turn ends, so a turn in flight is
+searchable by its prompt but not yet by its reply). Postgres full-text with
+`websearch` syntax — `"quoted phrase"`, `-excluded`, `or` — and exact-token
+matching (no stemming), so identifiers and code fragments match as
+themselves. Hits are ranked, newest first among equals; `snippet` is plain
+text with no markup; `ts` is the turn's (or the conversation's) creation
+time. `limit` caps at 100. Every source is scoped to the caller in the query
+itself; nothing is indexed across tenants. Rate-limited with the rest of
+`/api`.
+
+Turns that ended before the `reply_text` column existed are searchable by
+prompt only until the one-time backfill runs on the server:
+`bin/fountain_server eval 'Fountain.Release.backfill_turn_replies()'`.
+
 ## Team
 
 The roster [`/team`](primitives.md#the-team-page-agents-as-teammates) shows, for


### PR DESCRIPTION
## Summary

Closes #826.

- `GET /api/search?q=&limit=&offset=&agent_id=&conversation_id=&since=&kinds=` → `{data: [{kind: title|prompt|reply, conversation_id, agent_id, turn_id, turn_number, snippet, ts}], meta: {limit, offset, has_more}}`.
- `Fountain.Search`: three Postgres FTS queries (`simple` config — exact tokens, so identifiers/code match as themselves; `websearch_to_tsquery` syntax), each scoped by `user_id` in the query itself, merged and re-ranked (`ts_rank`, then newest). Snippets via `ts_headline`, plain text, no markup. A query with only exclusions (`-foo`) finds nothing rather than the whole tenant.
- **Replies**: new `turns.reply_text`, materialised in `Conversations._unsafe_update_turn/2` on any transition to `completed|failed|interrupted` — every turn ending goes through it (the server's six endings, the orphan sweep), so coverage is by construction. Text comes from `Blocks.assistant_text/2` (extracted from `ConversationsLive.Chat.chat_assistant_reply/2`, which now delegates), i.e. the same parse the transcript, `?blocks=true` and the roster preview use — tool noise is never indexed.
- Migration `20260819110000_add_search`: the column + three GIN expression indexes matching the query expressions.
- `Fountain.Release.backfill_turn_replies/0` for turns that ended before the column (prod: 1,174 turns; searchable by prompt until it runs). Documented in CHANGELOG + docs/api.md "Search".
- OpenAPI `SearchHit`/`SearchResponse`; enum guardrail entry for `SearchHit.kind`.

## Test plan

- [x] `search_test.exs`: materialisation on end (not on other updates, not tool noise), backfill idempotence, cross-source hits + tenant isolation, filters, paging/has_more consistency, websearch syntax, blank/negative-only queries, limit clamp
- [x] `search_controller_test.exs`: shape, meta, filters/kinds/since, cross-tenant, 422/400/401
- [x] `mix test` → 3068 tests, 0 failures; format, credo --strict, sobelow, compile --warnings-as-errors clean

## Notes

- Postgres's `simple` parser tokenises `Billing.Gate` as one host-like token, so `gate` won't hit it but `Billing.Gate` will — inherent to PG FTS, documented as exact-token matching.
- Post-merge: run `PHX_SERVER=false METRICS_PORT=0 bin/fountain_server eval 'Fountain.Release.backfill_turn_replies()'` in a prod pod once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)