### PR TITLE
feat(api): rename a teammate and list its history (#831, #832)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ upgrade, is in
 
 ### Added
 
+- **Rename a teammate and list its history over the API** (#831, #832).
+  `PATCH /api/team/:agent_id {name}` renames (null/blank → the agent's name;
+  audited `team.renamed`; the name carries onto the next fresh conversation),
+  `GET /api/team/:agent_id/conversations` lists every conversation the agent
+  has had on the team newest first with the live one flagged `current`, and
+  `GET /api/conversations` takes `agent_id`, `channel_id` and `status`
+  filters.
+
 - **`GET /api/search`** (#826). Full-text search across the caller's
   conversation titles, turn prompts and assistant replies, with `kind`,
   ids and a plain-text snippet per hit; `websearch` syntax, `limit`/`offset`,

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -512,6 +512,12 @@ defmodule Fountain.Conversations do
   `parent_conversation_id`). Useful for hiding agent-spawned sub-conversations
   from the index when the user only wants to see top-level sessions.
 
+  Further filters (#832), all combinable: `agent_id: id`, `channel_id:
+  "fountain:team"` (the *bound* channel — a conversation unbound by
+  `Fountain.Team.remove_teammate/3` no longer matches; a teammate's full
+  history is `Team.list_teammate_conversations/2`), and `status: [..]` (a
+  list of conversation statuses). Unpaged, like the list always was.
+
   Populates the `last_active_at` virtual field using `kind: "output"` log
   events only — stage events (reconnects, lifecycle) are excluded so
   reconnects don't produce false unread indicators.
@@ -527,6 +533,21 @@ defmodule Fountain.Conversations do
       else
         base
       end
+
+    query =
+      Enum.reduce(opts, query, fn
+        {:agent_id, id}, q when is_binary(id) and id != "" ->
+          where(q, [conv: c], c.agent_id == ^id)
+
+        {:channel_id, id}, q when is_binary(id) and id != "" ->
+          where(q, [conv: c], c.channel_id == ^id)
+
+        {:status, [_ | _] = statuses}, q ->
+          where(q, [conv: c], c.status in ^statuses)
+
+        _, q ->
+          q
+      end)
 
     Repo.all(query)
     |> Repo.preload([:agent, turns: first_turn_query()])

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -338,6 +338,65 @@ defmodule Fountain.Team do
     result
   end
 
+  @doc """
+  Rename the teammate for `agent_id` (#831): `name` becomes its current
+  conversation's title — what the roster shows and what `start_fresh/6`
+  carries onto the next conversation when this one is past resuming. Blank
+  or nil clears it, so the teammate reads as its agent's name again.
+  `{:error, :not_found}` when the agent is not on the team; a changeset
+  error when the name is too long. Audited as `team.renamed` (the field,
+  never the value); broadcasts the roster change.
+  """
+  def rename_teammate(user_id, agent_id, name, opts \\ [])
+      when is_binary(user_id) and is_binary(agent_id) do
+    case get_teammate(user_id, agent_id) do
+      nil ->
+        {:error, :not_found}
+
+      %{conversation: conv} ->
+        title = blank_to_nil(name)
+
+        # Ownership: `conv` came from the tenant-scoped get_teammate above.
+        case Conversations.update_conversation(conv, %{"title" => title}) do
+          {:ok, updated} ->
+            if updated.title != conv.title do
+              record(user_id, "team.renamed", updated, opts, %{
+                "fields" => ["name"],
+                "cleared" => is_nil(title)
+              })
+
+              broadcast_changed(user_id)
+            end
+
+            {:ok, updated}
+
+          {:error, _} = err ->
+            err
+        end
+    end
+  end
+
+  @doc """
+  Every conversation `agent_id` has had on the team (#832): the current one
+  first (`live?/1`, else the newest), then the retired ones newest first — a previous computer's thread, still bound to the channel until the
+  teammate is removed. `[]` when the agent is not on the team.
+  """
+  def list_teammate_conversations(user_id, agent_id)
+      when is_binary(user_id) and is_binary(agent_id) do
+    case user_id
+         |> Conversations.list_channel_conversations(@channel)
+         |> Enum.filter(&(&1.agent_id == agent_id)) do
+      [] ->
+        []
+
+      convs ->
+        # The current one first, whatever its age — the roster's pick — then
+        # the rest as listed (newest first).
+        current = pick_current(convs)
+        [current | Enum.reject(convs, &(&1.id == current.id))]
+    end
+  end
+
   @doc "Agents of `user_id` that are not on the team yet — the add picker."
   def list_addable_agents(user_id) when is_binary(user_id) do
     on_team = user_id |> list_teammates() |> MapSet.new(& &1.agent.id)
@@ -351,7 +410,7 @@ defmodule Fountain.Team do
   # conversation events (`conversation.created`, `.terminated`) still fire
   # underneath where they apply, and describe the sandbox side of the same
   # action; these describe the team side.
-  defp record(user_id, action, %Conversation{} = conv, opts) do
+  defp record(user_id, action, %Conversation{} = conv, opts, extra \\ %{}) do
     Audit.record(%{
       user_id: user_id,
       action: action,
@@ -359,10 +418,14 @@ defmodule Fountain.Team do
       resource_id: conv.id,
       actor: Keyword.get(opts, :actor, "self"),
       request_ip: Keyword.get(opts, :request_ip),
-      metadata: %{
-        "agent_id" => conv.agent_id,
-        "agent_name" => conv.agent && conv.agent.name
-      }
+      metadata:
+        Map.merge(
+          %{
+            "agent_id" => conv.agent_id,
+            "agent_name" => conv.agent && conv.agent.name
+          },
+          extra
+        )
     })
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -25,10 +25,33 @@ defmodule FountainWeb.ConversationController do
         description:
           "Exclude sub-conversations (those with a `parent_conversation_id`), " <>
             "leaving only top-level sessions. Defaults to false."
+      ],
+      agent_id: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Only this agent's conversations (#832)."
+      ],
+      channel_id: [
+        in: :query,
+        type: :string,
+        required: false,
+        description:
+          "Only conversations bound to this channel — `fountain:team` for the team's. " <>
+            "A conversation unbound by removing its teammate no longer matches; a " <>
+            "teammate's full history is `GET /api/team/:agent_id/conversations`."
+      ],
+      status: [
+        in: :query,
+        type: :string,
+        required: false,
+        description:
+          "Comma-separated statuses to keep (`idle,terminated`); 400 on a value outside the vocabulary."
       ]
     ],
     responses: [
-      ok: {"Conversations", "application/json", Schemas.ConversationListResponse}
+      ok: {"Conversations", "application/json", Schemas.ConversationListResponse},
+      bad_request: {"Unknown status", "application/json", Schemas.Error}
     ]
   )
 
@@ -36,9 +59,31 @@ defmodule FountainWeb.ConversationController do
     user = conn.assigns.current_user
     roots_only = parse_bool_param(params["roots_only"], false)
 
-    render(conn, :index,
-      conversations: Conversations.list_conversations(user.id, roots_only: roots_only)
-    )
+    with {:ok, statuses} <- parse_statuses(params["status"]) do
+      render(conn, :index,
+        conversations:
+          Conversations.list_conversations(user.id,
+            roots_only: roots_only,
+            agent_id: params["agent_id"],
+            channel_id: params["channel_id"],
+            status: statuses
+          )
+      )
+    end
+  end
+
+  # A status the vocabulary does not have is a 400, not a silent "match
+  # nothing" (or worse, "match everything"): a client that typos `terminted`
+  # should find out.
+  defp parse_statuses(nil), do: {:ok, []}
+  defp parse_statuses(""), do: {:ok, []}
+
+  defp parse_statuses(s) when is_binary(s) do
+    statuses = s |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+
+    if Enum.all?(statuses, &(&1 in Fountain.Conversations.Conversation.statuses())),
+      do: {:ok, statuses},
+      else: {:error, "invalid_status"}
   end
 
   operation(:read,

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -83,6 +83,62 @@ defmodule FountainWeb.TeamController do
     end
   end
 
+  operation(:update,
+    summary: "Rename a teammate",
+    description:
+      "Sets what the teammate is called — its conversation's title (#831). `name` " <>
+        "null or blank goes back to the agent's name. The name carries over to the " <>
+        "fresh conversation opened when this one is past resuming. Audited as " <>
+        "`team.renamed`; the stream sends `team` so clients re-list.",
+    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    request_body: {"Rename", "application/json", Schemas.TeamRenameRequest},
+    responses: [
+      ok: {"Teammate", "application/json", Schemas.TeammateResponse},
+      not_found: {"Not on the team", "application/json", Schemas.Error},
+      unprocessable_entity: {"Name too long", "application/json", Schemas.Error}
+    ]
+  )
+
+  def update(conn, %{"agent_id" => agent_id} = params) do
+    user = conn.assigns.current_user
+
+    with {:ok, _conv} <-
+           Team.rename_teammate(user.id, agent_id, params["name"], Audited.attribution(conn)),
+         %{} = teammate <- Team.get_teammate(user.id, agent_id) || {:error, :not_found} do
+      render(conn, :show, teammate: teammate)
+    end
+  end
+
+  operation(:conversations,
+    summary: "List a teammate's conversations",
+    description:
+      "Every conversation the agent has had on the team, newest first (#832): the " <>
+        "current one flagged `current: true`, the retired ones — a previous computer's " <>
+        "thread, read-only — behind it. Each is a full conversation object; read a " <>
+        "retired thread with `GET /api/conversations/:id/events`. 404 when the agent is " <>
+        "not on the team.",
+    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Conversations", "application/json", Schemas.TeammateConversationListResponse},
+      not_found: {"Not on the team", "application/json", Schemas.Error}
+    ]
+  )
+
+  def conversations(conn, %{"agent_id" => agent_id}) do
+    user = conn.assigns.current_user
+
+    case Team.get_teammate(user.id, agent_id) do
+      nil ->
+        {:error, :not_found}
+
+      %{conversation: current} ->
+        render(conn, :conversations,
+          conversations: Team.list_teammate_conversations(user.id, agent_id),
+          current_id: current.id
+        )
+    end
+  end
+
   operation(:delete,
     summary: "Remove an agent from the team",
     description:

--- a/apps/fountain/lib/fountain_web/controllers/team_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_json.ex
@@ -6,6 +6,15 @@ defmodule FountainWeb.TeamJSON do
   def index(%{teammates: teammates}), do: %{data: Enum.map(teammates, &data/1)}
   def show(%{teammate: teammate}), do: %{data: data(teammate)}
 
+  def conversations(%{conversations: convs, current_id: current_id}) do
+    %{
+      data:
+        Enum.map(convs, fn conv ->
+          conv |> ConversationJSON.data() |> Map.put(:current, conv.id == current_id)
+        end)
+    }
+  end
+
   @doc "One roster entry: the agent, its current conversation, and what the roster line shows."
   def data(%{agent: agent, conversation: conv, last_turn: last_turn, name: name} = teammate) do
     %{

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -355,8 +355,11 @@ defmodule FountainWeb.Router do
     # Before `/team/:agent_id`, or "schedules" would be read as an agent id.
     get "/team/schedules", TeamScheduleController, :index_all
     get "/team/:agent_id", TeamController, :show
+    patch "/team/:agent_id", TeamController, :update
     delete "/team/:agent_id", TeamController, :delete
     post "/team/:agent_id/messages", TeamController, :message
+    # The teammate's history (#832): every conversation it has had on the team.
+    get "/team/:agent_id/conversations", TeamController, :conversations
 
     # Team schedules (#825): the routines `/team` offers, per teammate.
     get "/team/:agent_id/schedules", TeamScheduleController, :index

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1773,6 +1773,44 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule TeamRenameRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeamRenameRequest",
+      type: :object,
+      properties: %{
+        name: %Schema{
+          type: :string,
+          nullable: true,
+          maxLength: 120,
+          description: "What to call the teammate. Null or blank means the agent's name."
+        }
+      }
+    })
+  end
+
+  defmodule TeammateConversation do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeammateConversation",
+      description: "A conversation object plus `current`: whether it is the teammate's live one.",
+      allOf: [
+        Conversation,
+        %Schema{
+          type: :object,
+          properties: %{current: %Schema{type: :boolean}},
+          required: [:current]
+        }
+      ]
+    })
+  end
+
+  list_response(TeammateConversationListResponse, of: TeammateConversation)
+
   defmodule TeamMessageRequest do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -68,6 +68,7 @@ defmodule Fountain.AuditGuardrailTest do
     # leaves conversation.created underneath; these are the team-side events.
     {"team member add", &__MODULE__.do_team_add/1, "team.member.added"},
     {"team member remove", &__MODULE__.do_team_remove/1, "team.member.removed"},
+    {"team member rename", &__MODULE__.do_team_rename/1, "team.renamed"},
     # Team schedules: a cron that runs a teammate with a prompt. A run leaves
     # conversation events underneath; `.fired` is the schedule-side record.
     {"team schedule create", &__MODULE__.do_schedule_create/1, "team.schedule.created"},
@@ -238,6 +239,19 @@ defmodule Fountain.AuditGuardrailTest do
     end)
 
     {:ok, _} = Fountain.Team.add_teammate(user.id, agent.id)
+  end
+
+  def do_team_rename(user) do
+    agent = insert_agent(user_id: user.id)
+
+    insert_conversation(
+      user_id: user.id,
+      agent: agent,
+      status: "idle",
+      channel_id: Fountain.Team.channel()
+    )
+
+    {:ok, _} = Fountain.Team.rename_teammate(user.id, agent.id, "Renamed")
   end
 
   def do_team_remove(user) do

--- a/apps/fountain/test/fountain/team_test.exs
+++ b/apps/fountain/test/fountain/team_test.exs
@@ -342,6 +342,77 @@ defmodule Fountain.TeamTest do
     end
   end
 
+  describe "rename_teammate/4 (#831)" do
+    test "sets the current conversation's title, audits the field, broadcasts" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada)
+      Team.subscribe(user.id)
+
+      assert {:ok, %{title: "Ada (staging)"}} =
+               Team.rename_teammate(user.id, ada.id, "  Ada (staging) ", actor: "api")
+
+      assert Repo.reload(conv).title == "Ada (staging)"
+      assert [%{name: "Ada (staging)"}] = Team.list_teammates(user.id)
+      assert_receive {:team_changed, _}
+
+      assert [ev] =
+               Enum.filter(Audit.list_recent_for_user(user.id), &(&1.action == "team.renamed"))
+
+      assert ev.actor == "api"
+      assert ev.metadata["fields"] == ["name"]
+      assert ev.metadata["cleared"] == false
+      refute inspect(ev.metadata) =~ "staging"
+    end
+
+    test "blank clears the name back to the agent's; an unchanged name records nothing" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      insert_teammate_conv(user, ada, title: "Old")
+
+      assert {:ok, %{title: nil}} = Team.rename_teammate(user.id, ada.id, "  ")
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+
+      assert {:ok, _} = Team.rename_teammate(user.id, ada.id, nil)
+
+      assert [%{metadata: %{"cleared" => true}}] =
+               Enum.filter(Audit.list_recent_for_user(user.id), &(&1.action == "team.renamed"))
+    end
+
+    test "the renamed title carries onto a fresh conversation; off the team is not found" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      dead = insert_teammate_conv(user, ada, status: "terminated")
+      assert {:ok, _} = Team.rename_teammate(user.id, ada.id, "Renamed")
+      assert Repo.reload(dead).title == "Renamed"
+
+      inert_start_child()
+      assert {:ok, fresh} = Team.send_message(user.id, ada.id, "hi")
+      assert fresh.title == "Renamed"
+
+      loner = insert_agent(user_id: user.id)
+      assert {:error, :not_found} = Team.rename_teammate(user.id, loner.id, "x")
+
+      assert {:error, %Ecto.Changeset{}} =
+               Team.rename_teammate(user.id, ada.id, String.duplicate("x", 121))
+    end
+  end
+
+  describe "list_teammate_conversations/2 (#832)" do
+    test "every conversation the agent had on the team, newest first; none off the team" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      old = insert_teammate_conv(user, ada, status: "terminated")
+      current = insert_teammate_conv(user, ada)
+      _unbound = insert_conversation(user_id: user.id, agent: ada)
+      _other = insert_teammate_conv(user, insert_agent(user_id: user.id))
+
+      ids = user.id |> Team.list_teammate_conversations(ada.id) |> Enum.map(& &1.id)
+      assert ids == [current.id, old.id]
+      assert Team.list_teammate_conversations(user.id, insert_agent(user_id: user.id).id) == []
+    end
+  end
+
   describe "list_addable_agents/1" do
     test "the user's agents not yet on the team" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -37,6 +37,55 @@ defmodule FountainWeb.ConversationControllerTest do
       refute other_conv.id in ids
     end
 
+    test "filters by agent_id, channel_id and status (#832)", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      ada = insert_agent(user_id: user.id)
+      linus = insert_agent(user_id: user.id)
+
+      team_idle =
+        insert_conversation(
+          user_id: user.id,
+          agent: ada,
+          channel_id: "fountain:team",
+          status: "idle"
+        )
+
+      team_dead =
+        insert_conversation(
+          user_id: user.id,
+          agent: ada,
+          channel_id: "fountain:team",
+          status: "terminated"
+        )
+
+      plain = insert_conversation(user_id: user.id, agent: linus, status: "idle")
+
+      ids = fn query ->
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations", query)
+        |> json_response(200)
+        |> Map.fetch!("data")
+        |> Enum.map(& &1["id"])
+        |> Enum.sort()
+      end
+
+      assert ids.(agent_id: ada.id) == Enum.sort([team_idle.id, team_dead.id])
+      assert ids.(channel_id: "fountain:team") == Enum.sort([team_idle.id, team_dead.id])
+      assert ids.(agent_id: ada.id, status: "terminated") == [team_dead.id]
+      assert ids.(status: "idle,terminated") == Enum.sort([team_idle.id, team_dead.id, plain.id])
+      assert ids.(agent_id: linus.id, channel_id: "fountain:team") == []
+
+      assert %{"error" => "invalid_status"} =
+               conn
+               |> authed_with_key(raw_key)
+               |> get("/api/conversations", status: "terminted")
+               |> json_response(400)
+    end
+
     test "returns 401 without authentication", %{conn: conn} do
       conn = get(conn, "/api/conversations")
       assert json_response(conn, 401)

--- a/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
@@ -202,6 +202,82 @@ defmodule FountainWeb.TeamControllerTest do
     end
   end
 
+  describe "PATCH /api/team/:agent_id (#831)" do
+    test "renames; blank clears; 404 off the team; 422 too long", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      insert_teammate_conv(user, ada)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> patch_json("/api/team/#{ada.id}", %{name: "Ada (staging)"})
+        |> json_response(200)
+
+      assert body["data"]["name"] == "Ada (staging)"
+      assert body["data"]["conversation"]["title"] == "Ada (staging)"
+
+      assert [%{actor: "api"}] =
+               Enum.filter(Audit.list_recent_for_user(user.id), &(&1.action == "team.renamed"))
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> patch_json("/api/team/#{ada.id}", %{name: nil})
+        |> json_response(200)
+
+      assert body["data"]["name"] == "Ada"
+
+      loner = insert_agent(user_id: user.id)
+
+      assert conn
+             |> authed_with_key(key)
+             |> patch_json("/api/team/#{loner.id}", %{name: "x"})
+             |> json_response(404)
+
+      assert conn
+             |> authed_with_key(key)
+             |> patch_json("/api/team/#{ada.id}", %{name: String.duplicate("x", 121)})
+             |> json_response(422)
+    end
+  end
+
+  describe "GET /api/team/:agent_id/conversations (#832)" do
+    test "the teammate's history newest first, the live one flagged; 404 off the team", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      old = insert_teammate_conv(user, ada, status: "terminated")
+      current = insert_teammate_conv(user, ada)
+      insert_conversation(user_id: user.id, agent: ada)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/team/#{ada.id}/conversations")
+        |> json_response(200)
+
+      assert Enum.map(body["data"], &{&1["id"], &1["current"]}) == [
+               {current.id, true},
+               {old.id, false}
+             ]
+
+      assert hd(body["data"])["channel_id"] == "fountain:team"
+
+      loner = insert_agent(user_id: user.id)
+
+      assert conn
+             |> authed_with_key(key)
+             |> get("/api/team/#{loner.id}/conversations")
+             |> json_response(404)
+    end
+  end
+
   describe "DELETE /api/team/:agent_id" do
     test "removes the teammate; 404 when not on the team", %{conn: conn, user: user, raw_key: key} do
       ada = insert_agent(user_id: user.id, name: "Ada")

--- a/docs/api.md
+++ b/docs/api.md
@@ -232,7 +232,7 @@ Resources are upserted by name in a fixed order (environments, then vaults, then
 Conversations are multi-turn: create one with an initial prompt, then keep prompting it.
 
 ```
-GET    /api/conversations                  # list (?roots_only=true hides sub-conversations)
+GET    /api/conversations                  # list (?roots_only=true; ?agent_id= ?channel_id= ?status=idle,terminated)
 POST   /api/conversations                  # start (agent_id; optional vault_id, prompt, images)
 GET    /api/conversations/:id
 DELETE /api/conversations/:id
@@ -248,6 +248,12 @@ GET    /api/conversations/:id/turns/:turn_id/images/:position   # image bytes
 ```
 
 Turns carry `image_count`; the image endpoint takes a zero-based `position` into that count and returns the raw bytes with the stored media type. Anything that does not resolve — unknown conversation, a turn from a different conversation, an absent position, a stored media type that is not an image — is a `404`, so it is not a probe for ids.
+
+The list takes `agent_id`, `channel_id` (the *bound* channel — `fountain:team`
+for the team; a conversation unbound by removing its teammate no longer
+matches, so a teammate's full history is `GET /api/team/:agent_id/conversations`)
+and `status` (comma-separated; `400 invalid_status` on a value outside the
+vocabulary), all combinable with `roots_only`. The list is unpaged.
 
 Conversation objects carry `title`, `turn_count`, `last_active_at`, `last_read_at` and a computed `unread` alongside the lifecycle fields. `unread` is true when `last_active_at` is later than `last_read_at` (and for a conversation never read); `POST /api/conversations/:id/read` clears it.
 
@@ -361,10 +367,21 @@ unbinds — without reimplementing them over `/api/conversations`.
 GET    /api/team                    # roster: agent, conversation, presence, unread, preview
 POST   /api/team                    # add (agent_id; optional name, environment_id, vault_id)
 GET    /api/team/:agent_id
+PATCH  /api/team/:agent_id          # rename ({name}; null or blank → the agent's name)
 DELETE /api/team/:agent_id          # remove: terminate the live conversation, unbind history
 POST   /api/team/:agent_id/messages # a turn (prompt; optional images) → {conversation_id}
+GET    /api/team/:agent_id/conversations  # history: every conversation on the team, newest first, `current` flagged
 GET    /api/team/stream             # SSE: every teammate's events on one connection
 ```
+
+`PATCH /api/team/:agent_id` sets what the teammate is called — its
+conversation's `title` — and the name carries onto the fresh conversation
+opened when that one is past resuming; `team.renamed` is audited and the
+stream sends `team`. `GET /api/team/:agent_id/conversations` is the
+teammate's history: a retired conversation (a previous computer's thread)
+stays bound to the team channel until the teammate is removed, so it is
+listed behind the current one with `current: false`; read it with
+`GET /api/conversations/:id/events`.
 
 `POST /api/team` answers `201` with the teammate, or `200` when the agent was
 already on the team (its live conversation, the attributes ignored). `name`


### PR DESCRIPTION
## Summary

Closes #831, closes #832.

- **`PATCH /api/team/:agent_id {name}`** → `Team.rename_teammate/4`: sets the current team conversation's `title` (null/blank → back to the agent's name), audited `team.renamed` with `fields: ["name"]` / `cleared` (never the value), broadcasts `team_changed` so the stream sends `team`. `start_fresh/6` already carries `prev.title`, so a rename is what the next fresh conversation inherits (tested).
- **`GET /api/team/:agent_id/conversations`** → `Team.list_teammate_conversations/2` (the issue's preferred option): every conversation the agent has had on the team — retired ones stay channel-bound until the teammate is removed — current first and flagged `current: true`, the rest newest first. 404 off the team.
- **`GET /api/conversations?agent_id=&channel_id=&status=`** — cheap, combinable filters on the existing list (`channel_id` is the *bound* channel, documented); `400 invalid_status` on an unknown status rather than silently matching nothing/everything. Left unpaged, as the list always was — `limit`/`after` would be a separate change.
- OpenAPI (`TeamRenameRequest`, `TeammateConversation`), audit guardrail entry, docs/api.md, CHANGELOG.

## Test plan

- [x] `team_test.exs`: rename sets title/audits/broadcasts; blank clears; unchanged records nothing; carries onto fresh conversation; not_found / too-long; history ordering + off-team empty
- [x] `team_controller_test.exs`: PATCH 200/404/422; history list with `current` flags; 404
- [x] `conversation_controller_test.exs`: agent_id / channel_id / status filters, 400 on typo
- [x] `mix test` → 3097 tests, 0 failures; format, credo --strict, warnings-as-errors clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)