### PR TITLE
feat(team): presence and roster fields for runner-backed teammates (#834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ upgrade, is in
 
 ### Added
 
+- **Runner-backed teammates on the team surface** (#834). Presence tells
+  "asleep" from "the machine is off": a teammate on a self-hosted runner whose
+  daemon is not connected is `machine_offline` (a message answers `503
+  runner_offline` rather than waking it; a scheduled run waits for it). The
+  sandbox object carries `provider` and, on a runner, `runner: {id, name,
+  hostname, online, path}` — where it runs — and a runner connecting or
+  dropping sends a `team` event on `/api/team/stream` and refreshes `/team`.
+
 - **Rename a teammate and list its history over the API** (#831, #832).
   `PATCH /api/team/:agent_id {name}` renames (null/blank → the agent's name;
   audited `team.renamed`; the name carries onto the next fresh conversation),

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1635,6 +1635,12 @@ defmodule Fountain.Conversations do
       {:error, :not_found} ->
         :create_new
 
+      # The machine behind a runner-backed sandbox is not connected (#834):
+      # the same protect-the-disk rule as below, named, so the caller can say
+      # "the machine is off" rather than "the provider is unreachable".
+      {:error, {:unavailable, :runner_offline}} ->
+        {:error, :runner_offline}
+
       {:error, reason} ->
         # A transient probe failure must not cost the disk: falling to
         # :create_new retires this row, and the reaper then destroys the

--- a/apps/fountain/lib/fountain/runners.ex
+++ b/apps/fountain/lib/fountain/runners.ex
@@ -168,6 +168,71 @@ defmodule Fountain.Runners do
     end
   end
 
+  # ── presence broadcasts ────────────────────────────────────────────────────
+
+  @doc """
+  Subscribe to `{:runner_online, runner_id}` / `{:runner_offline, runner_id}`
+  for `user_id`'s runners — sent by the connection process as it registers
+  and as it goes away (#834). A roster of runner-backed teammates re-reads
+  presence on either rather than polling.
+  """
+  def subscribe(user_id) when is_binary(user_id),
+    do: Phoenix.PubSub.subscribe(Fountain.PubSub, topic(user_id))
+
+  @doc false
+  def broadcast_presence(user_id, runner_id, state)
+      when is_binary(user_id) and is_binary(runner_id) and state in [:online, :offline] do
+    Phoenix.PubSub.broadcast(Fountain.PubSub, topic(user_id), {:"runner_#{state}", runner_id})
+  end
+
+  defp topic(user_id), do: "runners:#{user_id}"
+
+  # ── sandboxes on runners ───────────────────────────────────────────────────
+
+  @doc """
+  What a runner-backed sandbox sits on (#834): `%{runner: %Runner{} | nil,
+  online: boolean, path: String.t() | nil}` — the row (nil when the runner
+  was forgotten), whether its connection is up right now, and the sandbox
+  directory on that machine (`<root>/<name>`, the daemon's layout; nil when
+  the row does not know its root). `nil` for any other provider. Ownership:
+  the sandbox row carries its `user_id`, and the runner is fetched under it.
+  """
+  @spec for_sandbox(map() | nil) ::
+          %{runner: Runner.t() | nil, online: boolean(), path: String.t() | nil} | nil
+  def for_sandbox(%{provider: "runner", sprite_name: name, user_id: user_id})
+      when is_binary(name) do
+    case parse_sandbox_name(name) do
+      {:ok, runner_id} ->
+        runner = get_runner(runner_id, user_id)
+
+        %{
+          runner: runner,
+          online: online?(runner_id),
+          path: runner && runner.root && Path.join(runner.root, name)
+        }
+
+      :error ->
+        nil
+    end
+  end
+
+  def for_sandbox(_), do: nil
+
+  @doc """
+  Whether the machine behind a runner-backed sandbox is connected right now;
+  `true` for every other provider (a hosted sandbox has no machine to be
+  off). Registry only — no query — so presence can ask per roster row.
+  """
+  @spec sandbox_online?(map() | nil) :: boolean()
+  def sandbox_online?(%{provider: "runner", sprite_name: name}) when is_binary(name) do
+    case parse_sandbox_name(name) do
+      {:ok, runner_id} -> online?(runner_id)
+      :error -> true
+    end
+  end
+
+  def sandbox_online?(_), do: true
+
   # ── sandbox names ──────────────────────────────────────────────────────────
 
   @doc """

--- a/apps/fountain/lib/fountain/runners.ex
+++ b/apps/fountain/lib/fountain/runners.ex
@@ -180,10 +180,13 @@ defmodule Fountain.Runners do
     do: Phoenix.PubSub.subscribe(Fountain.PubSub, topic(user_id))
 
   @doc false
-  def broadcast_presence(user_id, runner_id, state)
-      when is_binary(user_id) and is_binary(runner_id) and state in [:online, :offline] do
-    Phoenix.PubSub.broadcast(Fountain.PubSub, topic(user_id), {:"runner_#{state}", runner_id})
-  end
+  def broadcast_presence(user_id, runner_id, :online)
+      when is_binary(user_id) and is_binary(runner_id),
+      do: Phoenix.PubSub.broadcast(Fountain.PubSub, topic(user_id), {:runner_online, runner_id})
+
+  def broadcast_presence(user_id, runner_id, :offline)
+      when is_binary(user_id) and is_binary(runner_id),
+      do: Phoenix.PubSub.broadcast(Fountain.PubSub, topic(user_id), {:runner_offline, runner_id})
 
   defp topic(user_id), do: "runners:#{user_id}"
 

--- a/apps/fountain/lib/fountain/runners/connection.ex
+++ b/apps/fountain/lib/fountain/runners/connection.ex
@@ -107,6 +107,7 @@ defmodule Fountain.Runners.Connection do
       {:ok, _} ->
         Process.send_after(self(), :heartbeat, @heartbeat_ms)
         Logger.info("runner #{init[:name]} (#{runner_id}) connected for user #{user_id}")
+        Runners.broadcast_presence(user_id, runner_id, :online)
 
         {:ok,
          %{
@@ -217,6 +218,15 @@ defmodule Fountain.Runners.Connection do
   @impl WebSock
   def terminate(reason, state) do
     Logger.info("runner #{state[:name]} (#{state.runner_id}) disconnected: #{inspect(reason)}")
+
+    # Only a registered connection was ever "online"; the 4409 duplicate
+    # above never was, and has no user_id in its state. Unregister before
+    # broadcasting so a subscriber that asks `online?/1` on receipt sees the
+    # truth rather than racing the registry's own DOWN handling.
+    if state[:user_id] do
+      Horde.Registry.unregister(Runners.registry(), {:runner, state.runner_id})
+      Runners.broadcast_presence(state.user_id, state.runner_id, :offline)
+    end
 
     Enum.each(state.pending, fn {_id, {from, ref, _sub}} ->
       send(from, {:runner_reply, ref, {:error, {:unavailable, :runner_disconnected}}})

--- a/apps/fountain/lib/fountain/team/schedules.ex
+++ b/apps/fountain/lib/fountain/team/schedules.ex
@@ -287,6 +287,8 @@ defmodule Fountain.Team.Schedules do
   def describe_error(:provisioning), do: "teammate's computer was still starting"
   def describe_error(:not_found), do: "agent is not on the team"
   def describe_error(:subscription_required), do: "subscription inactive"
+  def describe_error(:runner_offline), do: "teammate's machine is offline"
+  def describe_error(:sprite_probe_failed), do: "could not reach the sandbox provider"
 
   def describe_error({:sandbox_quota_exceeded, %{count: c, limit: l}}),
     do: "sandbox quota: #{c}/#{l}"

--- a/apps/fountain/lib/fountain/workers/team_schedule_run.ex
+++ b/apps/fountain/lib/fountain/workers/team_schedule_run.ex
@@ -3,8 +3,9 @@ defmodule Fountain.Workers.TeamScheduleRun do
   One firing of one team schedule: `Fountain.Team.Schedules.run_schedule/2`
   as a job, so it retries sensibly and never blocks the ticker.
 
-  A teammate that is busy (`:busy`) or whose computer is still starting
-  (`:provisioning`) is worth waiting for: the job snoozes and tries again,
+  A teammate that is busy (`:busy`), whose computer is still starting
+  (`:provisioning`) or whose own machine is off (`:runner_offline`) is worth
+  waiting for: the job snoozes and tries again,
   for up to `@wait_for` after the scheduled time, then gives up with the
   error on the row — the next scheduled run is a better use of the prompt
   than a stale one delivered an hour late. Every other error is final for
@@ -44,7 +45,9 @@ defmodule Fountain.Workers.TeamScheduleRun do
           {:ok, _conv} ->
             :ok
 
-          {:error, reason} when reason in [:busy, :provisioning] ->
+          # A runner-backed teammate whose machine is off (#834) is the
+          # same wait: it may come back within the window.
+          {:error, reason} when reason in [:busy, :provisioning, :runner_offline] ->
             if stale?(args), do: :ok, else: {:snooze, @snooze}
 
           {:error, reason} ->

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -69,15 +69,32 @@ defmodule FountainWeb.ConversationJSON do
       id: s.id,
       sprite_name: s.sprite_name,
       status: s.status,
+      provider: s.provider,
       # The sandbox's own HTTP endpoint, for providers that give it one. Read
       # from the row rather than the provider so listing conversations stays a
       # single query; null means the provider has no such concept (or the
       # sandbox predates the field).
-      url: s.provider_meta["public_url"]
+      url: s.provider_meta["public_url"],
+      # Where a runner-backed sandbox lives (#834): the machine and the
+      # directory, so a client says "on mac-mini · ~/…" without parsing the
+      # name. Null for hosted providers.
+      runner: runner_data(Fountain.Runners.for_sandbox(s))
     }
   end
 
   defp sandbox_data(_), do: nil
+
+  defp runner_data(nil), do: nil
+
+  defp runner_data(%{runner: runner, online: online, path: path}) do
+    %{
+      id: runner && runner.id,
+      name: runner && runner.name,
+      hostname: runner && runner.hostname,
+      online: online,
+      path: path
+    }
+  end
 
   # Field-for-field the SSE payload, plus `id` (the pagination cursor and the
   # SSE `Last-Event-ID`) and `duration_ms`, which stage events carry and the

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -150,6 +150,20 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # A runner-backed sandbox whose machine is not connected (#834). Same
+  # shape as the probe failure — nothing was changed, retry — but named, so
+  # a client can say "the machine is off" and the retry hint is honest: it
+  # comes back when the runner reconnects, not in ten seconds.
+  def call(conn, {:error, :runner_offline}) do
+    conn
+    |> put_resp_header("retry-after", "30")
+    |> put_status(:service_unavailable)
+    |> json(%{
+      error: "runner_offline",
+      message: "the teammate's machine is offline; it wakes when the runner reconnects"
+    })
+  end
+
   # Prompting a terminated conversation. 410 rather than 404: the id was
   # real, the resource is gone for good, and the caller should stop retrying.
   def call(conn, {:error, :gone}) do

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -202,7 +202,8 @@ defmodule FountainWeb.TeamController do
         "conversation, each payload the shape of `GET /api/conversations/:id/stream` " <>
         "plus `conversation_id` and `agent_id`. A `team` event (data `{reason: changed}`) " <>
         "is sent when the roster changes — a teammate added or removed, or a " <>
-        "fresh conversation opened for one — and the stream follows the new " <>
+        "fresh conversation opened for one, or a self-hosted runner connecting or " <>
+        "dropping (presence changes for the teammates on it) — and the stream follows the new " <>
         "conversation on its own; the client re-lists. A `schedule` event (same " <>
         "data) is sent when a team schedule is created, updated, deleted or fired " <>
         "(#825); the client re-lists `/api/team/schedules`. `Last-Event-ID` (a log event " <>
@@ -236,6 +237,9 @@ defmodule FountainWeb.TeamController do
     streams = parse_streams(params["streams"])
 
     Team.subscribe(user_id)
+    # A runner going offline or online changes presence for every teammate
+    # on that machine (#834); the roster must not poll to notice.
+    Fountain.Runners.subscribe(user_id)
     followed = follow_team(user_id, %{})
 
     conn =
@@ -322,6 +326,17 @@ defmodule FountainWeb.TeamController do
                "event: team\ndata: #{Jason.encode!(%{reason: "changed"})}\n\n"
              ) do
           {:ok, conn} -> sse_loop(conn, %{state | followed: followed})
+          {:error, _} -> conn
+        end
+
+      # A runner connected or dropped (#834): presence changed for the
+      # teammates on it; the same re-list as a roster change.
+      {runner_event, _runner_id} when runner_event in [:runner_online, :runner_offline] ->
+        case Plug.Conn.chunk(
+               conn,
+               "event: team\ndata: #{Jason.encode!(%{reason: "changed"})}\n\n"
+             ) do
+          {:ok, conn} -> sse_loop(conn, state)
           {:error, _} -> conn
         end
 

--- a/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
+++ b/apps/fountain/lib/fountain_web/live/conversations_live/show.ex
@@ -1187,6 +1187,14 @@ defmodule FountainWeb.ConversationsLive.Show do
            "Couldn't reach the sandbox provider to wake the conversation — try again shortly."
          )}
 
+      {:error, :runner_offline} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "This conversation's machine is offline — it wakes when the runner reconnects."
+         )}
+
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Couldn't send: #{inspect(reason)}")}
     end

--- a/apps/fountain/lib/fountain_web/live/team_live.ex
+++ b/apps/fountain/lib/fountain_web/live/team_live.ex
@@ -33,6 +33,7 @@ defmodule FountainWeb.TeamLive do
 
     if connected?(socket) do
       Enum.each(teammates, &subscribe_teammate/1)
+      Fountain.Runners.subscribe(user_id)
     end
 
     socket =
@@ -148,6 +149,12 @@ defmodule FountainWeb.TeamLive do
 
     {:noreply, socket}
   end
+
+  # A runner connected or dropped (#834): presence changed for the teammates
+  # on that machine.
+  def handle_info({runner_event, _id}, socket)
+      when runner_event in [:runner_online, :runner_offline],
+      do: {:noreply, refresh_teammates(socket)}
 
   def handle_info(_msg, socket), do: {:noreply, socket}
 
@@ -617,6 +624,7 @@ defmodule FountainWeb.TeamLive do
   defp presence_dot("online"), do: "bg-emerald-500"
   defp presence_dot("asleep"), do: "bg-zinc-400"
   defp presence_dot("away"), do: "bg-zinc-400"
+  defp presence_dot("machine_offline"), do: "bg-amber-600"
   defp presence_dot("failed"), do: "bg-rose-500"
   defp presence_dot(_), do: "bg-zinc-300"
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -31,6 +31,34 @@ defmodule FountainWeb.Schemas do
             "The sandbox's own HTTP endpoint, where a service the agent starts " <>
               "is reachable. Null for providers that expose no such URL. The " <>
               "same value is available inside the sandbox as `SANDBOX_URL`."
+        },
+        provider: %Schema{
+          type: :string,
+          enum: ~w(sprites e2b daytona runner),
+          description: "The sandbox backend this row lives on."
+        },
+        runner: %Schema{
+          type: :object,
+          nullable: true,
+          description:
+            "For `provider: runner` — the user's own machine the sandbox lives on, " <>
+              "and its directory there (#834). Null for hosted providers; the inner " <>
+              "fields are null when the runner row was forgotten.",
+          properties: %{
+            id: %Schema{type: :string, format: :uuid, nullable: true},
+            name: %Schema{type: :string, nullable: true},
+            hostname: %Schema{type: :string, nullable: true},
+            online: %Schema{
+              type: :boolean,
+              description: "Whether the runner daemon is connected right now."
+            },
+            path: %Schema{
+              type: :string,
+              nullable: true,
+              description: "The sandbox directory on the machine (`<root>/<name>`)."
+            }
+          },
+          required: [:online]
         }
       },
       required: [:id, :sprite_name, :status]

--- a/apps/fountain/lib/fountain_web/team_presenter.ex
+++ b/apps/fountain/lib/fountain_web/team_presenter.ex
@@ -16,7 +16,7 @@ defmodule FountainWeb.TeamPresenter do
   @typedoc "`state` is the vocabulary a client switches on; `label` is what a human reads."
   @type presence :: %{state: String.t(), label: String.t()}
 
-  @presence_states ~w(working starting online asleep away failed offline)
+  @presence_states ~w(working starting online asleep away machine_offline failed offline)
   @preview_kinds ~w(you them typing)
 
   @doc "Every `state` `presence/1` can answer — the wire enum."
@@ -36,15 +36,29 @@ defmodule FountainWeb.TeamPresenter do
   def presence(%{status: "pending"}),
     do: %{state: "starting", label: "starting computer"}
 
-  def presence(%{status: "idle", sandbox: %{status: s}}) when s in ["ready", "starting"],
+  # A teammate on the user's own machine whose runner is not connected
+  # (#834): not asleep — a message cannot wake it — and not gone either; the
+  # directory is intact and it comes back when the daemon reconnects.
+  def presence(%{status: "idle", sandbox: %{provider: "runner"} = sandbox} = conv) do
+    if Fountain.Runners.sandbox_online?(sandbox),
+      do: hosted_presence(conv),
+      else: %{
+        state: "machine_offline",
+        label: "machine offline · wakes when the runner reconnects"
+      }
+  end
+
+  def presence(conv), do: hosted_presence(conv)
+
+  defp hosted_presence(%{status: "idle", sandbox: %{status: s}}) when s in ["ready", "starting"],
     do: %{state: "online", label: "online"}
 
-  def presence(%{status: "idle", sandbox: %{status: "suspended"}}),
+  defp hosted_presence(%{status: "idle", sandbox: %{status: "suspended"}}),
     do: %{state: "asleep", label: "asleep · wakes on message"}
 
-  def presence(%{status: "idle"}), do: %{state: "away", label: "away · wakes on message"}
-  def presence(%{status: "failed"}), do: %{state: "failed", label: "offline · failed"}
-  def presence(_), do: %{state: "offline", label: "offline · new computer on message"}
+  defp hosted_presence(%{status: "idle"}), do: %{state: "away", label: "away · wakes on message"}
+  defp hosted_presence(%{status: "failed"}), do: %{state: "failed", label: "offline · failed"}
+  defp hosted_presence(_), do: %{state: "offline", label: "offline · new computer on message"}
 
   @doc """
   The roster's one-line preview of a teammate's thread: `nil` when there are

--- a/apps/fountain/test/fountain/runners_test.exs
+++ b/apps/fountain/test/fountain/runners_test.exs
@@ -77,6 +77,58 @@ defmodule Fountain.RunnersTest do
     end
   end
 
+  describe "presence for the team surface (#834)" do
+    test "for_sandbox/1 and sandbox_online?/1 describe a runner-backed sandbox" do
+      user = insert_verified_user()
+
+      {:ok, runner} =
+        Runners.register(user.id, %{
+          "name" => "mini",
+          "hostname" => "mac-mini",
+          "root" => "/Users/j/.fountain/sandboxes"
+        })
+
+      name = Runners.sandbox_name_for(runner.id)
+
+      sandbox =
+        insert_sandbox(user_id: user.id, sprite_name: name, provider: "runner", status: "ready")
+
+      hosted = insert_sandbox(user_id: user.id, status: "ready")
+
+      assert %{runner: %{id: rid, name: "mini", hostname: "mac-mini"}, online: false, path: path} =
+               Runners.for_sandbox(sandbox)
+
+      assert rid == runner.id
+      assert path == "/Users/j/.fountain/sandboxes/" <> name
+      refute Runners.sandbox_online?(sandbox)
+      assert Runners.for_sandbox(hosted) == nil
+      assert Runners.sandbox_online?(hosted)
+
+      {:ok, daemon} = FakeDaemon.start(runner.id, user.id, name: "mini")
+      assert %{online: true} = Runners.for_sandbox(sandbox)
+      assert Runners.sandbox_online?(sandbox)
+      FakeDaemon.stop(daemon)
+
+      # A forgotten runner: the name still routes, the row is gone.
+      {:ok, _} = Runners.delete_runner(runner)
+      assert %{runner: nil, online: false, path: nil} = Runners.for_sandbox(sandbox)
+    end
+
+    test "a connection coming and going broadcasts runner_online / runner_offline" do
+      user = insert_verified_user()
+      {:ok, runner} = Runners.register(user.id, %{"name" => "mini"})
+      Runners.subscribe(user.id)
+
+      {:ok, daemon} = FakeDaemon.start(runner.id, user.id, name: "mini")
+      assert_receive {:runner_online, id}
+      assert id == runner.id
+
+      FakeDaemon.stop(daemon)
+      assert_receive {:runner_offline, ^id}
+      refute Runners.online?(runner)
+    end
+  end
+
   describe "online status and placement" do
     test "a runner is online exactly while a connection is registered" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
@@ -89,6 +89,84 @@ defmodule FountainWeb.TeamControllerTest do
     end
   end
 
+  describe "runner-backed teammates (#834)" do
+    test "presence is machine_offline while the runner is down, and the sandbox names the machine",
+         %{
+           conn: conn,
+           user: user,
+           raw_key: key
+         } do
+      {:ok, runner} =
+        Fountain.Runners.register(user.id, %{
+          "name" => "mini",
+          "hostname" => "mac-mini.local",
+          "root" => "/Users/j/sandboxes"
+        })
+
+      name = Fountain.Runners.sandbox_name_for(runner.id)
+
+      sandbox =
+        insert_sandbox(user_id: user.id, sprite_name: name, provider: "runner", status: "ready")
+
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      insert_teammate_conv(user, ada, sandbox_id: sandbox.id)
+
+      [entry] =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/team")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert entry["presence"]["state"] == "machine_offline"
+      assert entry["presence"]["label"] =~ "machine offline"
+
+      assert %{
+               "provider" => "runner",
+               "runner" => %{
+                 "name" => "mini",
+                 "hostname" => "mac-mini.local",
+                 "online" => false,
+                 "path" => "/Users/j/sandboxes/" <> ^name
+               }
+             } = entry["conversation"]["sandbox"]
+
+      {:ok, daemon} = Fountain.Runners.FakeDaemon.start(runner.id, user.id, name: "mini")
+
+      [entry] =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/team")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert entry["presence"]["state"] == "online"
+      assert entry["conversation"]["sandbox"]["runner"]["online"] == true
+      Fountain.Runners.FakeDaemon.stop(daemon)
+    end
+
+    test "a hosted sandbox carries provider and a null runner", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      sandbox = insert_sandbox(user_id: user.id, status: "suspended")
+      insert_teammate_conv(user, ada, sandbox_id: sandbox.id)
+
+      [entry] =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/team")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert entry["presence"]["state"] == "asleep"
+      assert entry["conversation"]["sandbox"]["provider"] == "sprites"
+      assert entry["conversation"]["sandbox"]["runner"] == nil
+    end
+  end
+
   describe "GET /api/team/:agent_id" do
     test "one teammate, or 404 when the agent is not on the team", %{
       conn: conn,

--- a/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
@@ -175,6 +175,21 @@ defmodule FountainWeb.TeamStreamTest do
     assert conn.resp_body =~ "event: schedule\ndata: {\"reason\":\"changed\"}"
   end
 
+  test "a runner connecting or dropping sends a `team` event (#834)", %{user: user, raw_key: key} do
+    ada = insert_agent(user_id: user.id, name: "Ada")
+    insert_teammate_conv(user, ada)
+    {:ok, runner} = Fountain.Runners.register(user.id, %{"name" => "mini"})
+
+    task = stream_async(key)
+    Process.sleep(300)
+    {:ok, daemon} = Fountain.Runners.FakeDaemon.start(runner.id, user.id, name: "mini")
+    Process.sleep(100)
+    Fountain.Runners.FakeDaemon.stop(daemon)
+
+    conn = Task.await(task, 5_000)
+    assert conn.resp_body =~ "event: team\ndata: {\"reason\":\"changed\"}"
+  end
+
   test "Team.add_teammate and remove_teammate broadcast the roster change", %{user: user} do
     Team.subscribe(user.id)
     ada = insert_agent(user_id: user.id, name: "Ada")

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -51,6 +51,7 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.AgentRequest, "runtime"} => {Agent, :runtimes},
     {FountainWeb.Schemas.AgentUpdate, "runtime"} => {Agent, :runtimes},
     {FountainWeb.Schemas.Agent, "sandbox_provider"} => {Fountain.Sandbox, :known_providers},
+    {FountainWeb.Schemas.Sandbox, "provider"} => {Fountain.Sandbox, :known_providers},
     {FountainWeb.Schemas.AgentRequest, "sandbox_provider"} =>
       {Fountain.Sandbox, :known_providers},
     {FountainWeb.Schemas.AgentUpdate, "sandbox_provider"} => {Fountain.Sandbox, :known_providers},

--- a/apps/fountain/test/support/fake_runner_daemon.ex
+++ b/apps/fountain/test/support/fake_runner_daemon.ex
@@ -101,12 +101,16 @@ defmodule Fountain.Runners.FakeDaemon do
     end
   end
 
-  @doc "Disconnect: the socket process exits normally, the daemon is killed."
+  @doc """
+  Disconnect: the socket process stops through `terminate/2` — as Bandit
+  runs a WebSock handler's on close — so the offline broadcast and the
+  pending-reply failures fire as they do live; the daemon is killed.
+  """
   def stop(%{socket: socket, daemon: daemon}) do
     Process.unlink(socket)
     Process.unlink(daemon)
     ref = Process.monitor(socket)
-    Process.exit(socket, :shutdown)
+    if Process.alive?(socket), do: GenServer.stop(socket, :shutdown, 1_000)
 
     receive do
       {:DOWN, ^ref, :process, _, _} -> :ok

--- a/docs/api.md
+++ b/docs/api.md
@@ -391,21 +391,28 @@ the agent's `allowed_environment_ids` / `allowed_vault_ids` exactly as on
 
 Each roster entry carries `name` (title, else the agent's name), the full
 `agent` and `conversation` objects, `presence` (`state` in `working`,
-`starting`, `online`, `asleep`, `away`, `failed`, `offline`, plus a human
-`label`), `unread`, `last_turn`, and `preview` — `{kind: "you"|"them"|"typing",
-text}` or null with no messages.
+`starting`, `online`, `asleep`, `away`, `machine_offline`, `failed`, `offline`,
+plus a human `label`), `unread`, `last_turn`, and `preview` — `{kind:
+"you"|"them"|"typing", text}` or null with no messages. `machine_offline` is
+a teammate on a [self-hosted runner](integrations/runners.md) whose machine
+is not connected: a message cannot wake it (`503 runner_offline`), it comes
+back when the daemon reconnects. The conversation's `sandbox` carries
+`provider` and, on a runner, `runner: {id, name, hostname, online, path}`.
 
 `/messages` returns `202 {status: "queued", conversation_id}`; the id is the
 conversation the message went to, which is a new one when the teammate's
 previous conversation was terminated. `400 conversation_busy` while the last
-turn is still running, `503` while the computer is starting.
+turn is still running, `503 provisioning` while the computer is starting,
+`503 runner_offline` while a runner-backed teammate's machine is off.
 
 `/stream` is one `text/event-stream` for the whole team: each event is the
 per-conversation stream's payload plus `conversation_id` and `agent_id`, so a
 client routes it to a roster row without a socket per teammate. A `team`
 event (`{"reason":"changed"}`) is sent when the roster changes — a teammate
-added or removed, or a fresh conversation opened for one — and the stream
-starts following the new conversation itself; the client re-lists. It honours
+added or removed, a fresh conversation opened for one, or a self-hosted
+runner connecting or dropping (presence changes for the teammates on it) —
+and the stream starts following the new conversation itself; the client
+re-lists. It honours
 `Last-Event-ID` (replayed across every teammate) and `?streams=`, heartbeats
 every 15 s and closes after 60 s idle so the client reconnects.
 

--- a/docs/integrations/runners.md
+++ b/docs/integrations/runners.md
@@ -92,6 +92,23 @@ shared across sandboxes, as they do inside a single Linux sandbox).
 | Listing | The union over the runners **online right now**. An offline runner's sandboxes are not in the view, which the reaper already treats as "skip, converge later" — it only destroys names it sees |
 | Network policy, TTY, checkpoints, public URL | Not advertised |
 
+## On the team page and API
+
+A teammate whose sandbox lives on a runner shows where it runs: the roster
+entry's (and every conversation object's) `sandbox` carries `provider`
+(`sprites|e2b|daytona|runner`) and, for runners, `runner: {id, name,
+hostname, online, path}` — the machine and the sandbox directory on it, so a
+client can say "on mac-mini · ~/…" without parsing the sandbox name.
+Presence tells "asleep" from "the machine is off": while the runner is not
+connected the teammate is `machine_offline` ("machine offline · wakes when
+the runner reconnects") rather than `asleep`/`away`, because a message
+cannot wake it — `POST /api/team/:agent_id/messages` (and `POST
+/api/conversations/:id/prompts`) answer `503 runner_offline` with
+`Retry-After` until the daemon is back, the same shape as `provisioning`. A
+scheduled run on such a teammate waits the same way a busy one does. A
+runner connecting or dropping sends a `team` event on `/api/team/stream`, so
+a roster notices the machine came back without polling.
+
 ## Configuration
 
 | Variable | Default | Effect |


### PR DESCRIPTION
## Summary

Closes #834 (follow-up to #833).

1. **Presence.** `TeamPresenter.presence/1` answers `machine_offline` ("machine offline · wakes when the runner reconnects") for an idle teammate whose sandbox is on a runner that is not connected — registry lookup only (`Runners.sandbox_online?/1`), no query per row. Everything else falls through to the hosted rules unchanged. `Conversations` wake path maps `{:unavailable, :runner_offline}` → `{:error, :runner_offline}` (the same protect-the-disk rule as `sprite_probe_failed`, named), FallbackController answers `503 runner_offline` + `Retry-After`, documented beside `provisioning`; `TeamScheduleRun` snoozes on it like `:busy`; `Schedules.describe_error/1` and the conversation LiveView flash know it.
2. **Where it runs.** `sandbox.provider` on every conversation object; for runners `sandbox.runner {id, name, hostname, online, path}` via new `Runners.for_sandbox/1` (`<root>/<name>` — the daemon's layout, so no RPC). OpenAPI + enum guardrail entry for `Sandbox.provider`.
3. **Stream.** `Runners.Connection` broadcasts `{:runner_online|:runner_offline, id}` on `runners:<user_id>` (`Runners.subscribe/1`); it unregisters from Horde *before* the offline broadcast so a subscriber asking `online?/1` on receipt sees the truth. `/api/team/stream` emits `team` on either; `/team` LiveView re-reads presence. `FakeDaemon.stop/1` now stops through `terminate/2` (as Bandit does on close) so the offline path is exercised by the existing fake.

Not in scope (still "not built" per ADR 0022): per-agent runner pinning / `runner_id` on `POST /api/team`.

## Test plan

- [x] `runners_test.exs`: `for_sandbox/1` (row, online, path; forgotten runner; hosted → nil), `sandbox_online?/1`, online/offline broadcasts
- [x] `team_controller_test.exs`: `machine_offline` → `online` across a FakeDaemon start, `sandbox.provider/runner` fields; hosted sandbox → `asleep`, `runner: null`
- [x] `team_stream_test.exs`: runner connect/drop sends `event: team`
- [x] `mix test` → 3147 tests, 0 failures; format, credo --strict, warnings-as-errors clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)