### PR TITLE
fix(acp/claude): make MCP servers actually work — provision into the sandbox (#837)

### DIFF
--- a/apps/fountain/lib/fountain/runtimes/claude.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude.ex
@@ -38,6 +38,18 @@ defmodule Fountain.Runtimes.Claude do
     end
   end
 
-  # MCP servers travel in `session/new`'s `mcpServers` param (#636); nothing
-  # MCP-shaped to prepare in the sandbox.
+  # MCP servers travel in `session/new`'s `mcpServers` param (#636), so there is
+  # nothing to provision into the sandbox for them.
+  #
+  # KNOWN BROKEN (#837): `claude-agent-acp` (0.66–0.70) receives a correct,
+  # non-empty `mcpServers` from us in `session/new` and never launches the
+  # stdio servers — reproduced standalone, so it is upstream of Fountain, not
+  # an emit bug on our side (`test/fountain/runtimes/acp/peer_mcp_test.exs`
+  # pins that we emit it). And unlike Gemini — whose `write_config/2` below
+  # provisions MCP into `~/.gemini/settings.json` because gemini-cli reads it
+  # — the Claude Agent SDK driving `claude` here does **not** pick up
+  # sandbox-provisioned MCP config either: `.claude.json` (global and project)
+  # and `~/.claude/settings.json` were all measured and none launched the
+  # server. So there is no `write_config/2` here to add — the fix is upstream.
+  # See #837.
 end

--- a/apps/fountain/lib/fountain/runtimes/claude.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude.ex
@@ -5,14 +5,39 @@ defmodule Fountain.Runtimes.Claude do
   Turns speak ACP through the pinned `claude-agent-acp` adapter
   (`Fountain.Runtimes.ACP`); the CLI argv builder that used to live here went
   with the legacy spawn path. What remains is the half ADR 0014 deliberately
-  kept: how credentials and skills get into the sandbox.
+  kept: how credentials, skills and MCP servers get into the sandbox.
 
   The adapter runs on the Claude Agent SDK, which reads the same skills tree
   as the CLI (`/home/sprite/.claude/skills`, verified live 2026-08-10) and
   honours the same credential env vars.
+
+  ## MCP servers are provisioned, not delivered over ACP (#837)
+
+  ACP defines a session-scoped channel for MCP servers (`session/new`'s
+  `mcpServers`), and `Fountain.Runtimes.ACP.Peer` sends the agent's servers
+  there correctly (pinned by `peer_mcp_test.exs`). But `claude-agent-acp`
+  (measured on 0.66–0.70) never launches stdio servers passed that way —
+  reproduced standalone, upstream bug
+  [agentclientprotocol/claude-agent-acp#883]. Until that is fixed, the
+  session-scoped path delivers nothing.
+
+  So `write_config/2` provisions the servers into the sandbox instead, as a
+  project `.mcp.json` plus `enableAllProjectMcpServers` in
+  `~/.claude/settings.json` — which the CLI loads via its `settingSources`.
+  This path is verified working end-to-end (2026-08-19): the model calls
+  `mcp__<server>__*` tools and gets results. It works on every provider (all
+  share `HOME=/home/sprite`), and the `${VAR}` refs are already resolved
+  because the caller hands us the substituted agent.
+
+  When the upstream bug is fixed, the session-scoped path will start working
+  too; at that point drop this provisioning to avoid double-registration
+  (cf. the same lesson in `Fountain.Runtimes.Gemini`).
   """
 
   @behaviour Fountain.Runtimes
+
+  @mcp_config "/home/sprite/.mcp.json"
+  @settings "/home/sprite/.claude/settings.json"
 
   @impl true
   def skills_root, do: "/home/sprite/.claude/skills"
@@ -38,18 +63,38 @@ defmodule Fountain.Runtimes.Claude do
     end
   end
 
-  # MCP servers travel in `session/new`'s `mcpServers` param (#636), so there is
-  # nothing to provision into the sandbox for them.
-  #
-  # KNOWN BROKEN (#837): `claude-agent-acp` (0.66–0.70) receives a correct,
-  # non-empty `mcpServers` from us in `session/new` and never launches the
-  # stdio servers — reproduced standalone, so it is upstream of Fountain, not
-  # an emit bug on our side (`test/fountain/runtimes/acp/peer_mcp_test.exs`
-  # pins that we emit it). And unlike Gemini — whose `write_config/2` below
-  # provisions MCP into `~/.gemini/settings.json` because gemini-cli reads it
-  # — the Claude Agent SDK driving `claude` here does **not** pick up
-  # sandbox-provisioned MCP config either: `.claude.json` (global and project)
-  # and `~/.claude/settings.json` were all measured and none launched the
-  # server. So there is no `write_config/2` here to add — the fix is upstream.
-  # See #837.
+  @doc """
+  Provision the agent's MCP servers into the sandbox (see the moduledoc for
+  why this, not the ACP session-scoped channel). No servers → nothing written.
+  """
+  @impl true
+  def write_config(_handle, nil), do: :ok
+  def write_config(_handle, %{mcp_servers: m}) when m == %{} or is_nil(m), do: :ok
+
+  def write_config(handle, %{mcp_servers: mcp_servers}) when is_map(mcp_servers) do
+    # Project-scope config the CLI reads via settingSources; `mcp_servers` is
+    # already the Claude-Code shape (`%{name => %{"command"/"args"/"env"...}}`)
+    # with `${VAR}` refs resolved by the caller.
+    :ok =
+      Fountain.Sandbox.write_file(
+        handle,
+        @mcp_config,
+        Jason.encode!(%{"mcpServers" => mcp_servers}, pretty: true)
+      )
+
+    # Pre-approve the project's servers so the first turn does not stall on an
+    # approval the sandbox has no human to answer. (Fountain's ACP peer also
+    # auto-allows `session/request_permission`, but that only fires mid-turn;
+    # pre-approval keeps the server connected from session start.)
+    :ok =
+      Fountain.Sandbox.write_file(
+        handle,
+        @settings,
+        Jason.encode!(%{"enableAllProjectMcpServers" => true}, pretty: true)
+      )
+
+    :ok
+  end
+
+  def write_config(_handle, _agent), do: :ok
 end

--- a/apps/fountain/test/fountain/runtimes/acp/peer_mcp_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_mcp_test.exs
@@ -1,0 +1,88 @@
+defmodule Fountain.Runtimes.ACP.PeerMcpTest do
+  @moduledoc """
+  The ACP peer must deliver the agent's configured MCP servers to the agent in
+  `session/new` (and on resume). This is the Fountain half of #837: it proves
+  Fountain emits a correct, non-empty `mcpServers` on the wire — the drop that
+  bug tracks is downstream, in the agent adapter (`claude-agent-acp`), which
+  receives this and fails to launch stdio servers. Keep this green so a
+  regression on *our* side is caught separately from the upstream issue.
+  """
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Fountain.Runtimes.ACP.Peer
+
+  setup :set_mimic_global
+
+  setup do
+    test = self()
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _command, data ->
+      send(test, {:wrote, IO.iodata_to_binary(data)})
+      :ok
+    end)
+
+    {:ok, ref: make_ref(), command: %Fountain.Sandbox.Command{provider: :sprites, ref: :fake}}
+  end
+
+  @fs %{name: "fs", command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "."]}
+
+  defp start(ctx, opts) do
+    {:ok, pid} =
+      Peer.start(
+        Keyword.merge(
+          [
+            owner: self(),
+            command: ctx.command,
+            ref: ctx.ref,
+            prompt: "hi",
+            mode: :run,
+            session_id: nil,
+            cwd: "/home/sprite",
+            images: [],
+            mcp_servers: [@fs]
+          ],
+          opts
+        )
+      )
+
+    pid
+  end
+
+  defp write, do: assert_receive({:wrote, l}, 1_000) && Jason.decode!(l)
+
+  defp ack_init(pid) do
+    %{"id" => id, "method" => "initialize"} = write()
+
+    Peer.stdout(
+      pid,
+      Jason.encode!(%{"jsonrpc" => "2.0", "id" => id, "result" => %{"agentCapabilities" => %{}}}) <>
+        "\n"
+    )
+  end
+
+  test "session/new carries the configured MCP servers", ctx do
+    pid = start(ctx, mode: :run)
+    ack_init(pid)
+
+    frame = write()
+    assert frame["method"] == "session/new"
+
+    assert frame["params"]["mcpServers"] == [
+             %{
+               "name" => "fs",
+               "command" => "npx",
+               "args" => ["-y", "@modelcontextprotocol/server-filesystem", "."]
+             }
+           ]
+  end
+
+  test "an agent with no MCP servers sends an empty list, not a missing key", ctx do
+    pid = start(ctx, mode: :run, mcp_servers: [])
+    ack_init(pid)
+
+    frame = write()
+    assert frame["method"] == "session/new"
+    assert frame["params"]["mcpServers"] == []
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/claude_test.exs
+++ b/apps/fountain/test/fountain/runtimes/claude_test.exs
@@ -1,0 +1,54 @@
+defmodule Fountain.Runtimes.ClaudeTest do
+  @moduledoc """
+  MCP servers are provisioned into the sandbox (project `.mcp.json` + an
+  auto-approve setting) because the ACP session-scoped channel is broken
+  upstream (#837). This pins the provisioning shape.
+  """
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Fountain.Runtimes.Claude
+  alias Fountain.Sandbox
+
+  setup :set_mimic_from_context
+
+  setup do
+    Mimic.copy(Fountain.Sandbox)
+    handle = %Sandbox.Handle{provider: :fake, name: "sb"}
+    {:ok, handle: handle}
+  end
+
+  test "no MCP servers writes nothing", %{handle: handle} do
+    Mimic.reject(&Sandbox.write_file/3)
+    Mimic.reject(&Sandbox.write_file/4)
+    assert Claude.write_config(handle, %{mcp_servers: %{}}) == :ok
+    assert Claude.write_config(handle, %{mcp_servers: nil}) == :ok
+    assert Claude.write_config(handle, nil) == :ok
+  end
+
+  test "MCP servers are written as project .mcp.json plus an auto-approve setting", %{
+    handle: handle
+  } do
+    test = self()
+
+    Mimic.stub(Fountain.Sandbox, :write_file, fn _h, path, body ->
+      send(test, {:wrote, path, body})
+      :ok
+    end)
+
+    mcp = %{
+      "fs" => %{
+        "command" => "npx",
+        "args" => ["-y", "@modelcontextprotocol/server-filesystem", "."]
+      }
+    }
+
+    assert Claude.write_config(handle, %{mcp_servers: mcp}) == :ok
+
+    assert_receive {:wrote, "/home/sprite/.mcp.json", mcp_json}
+    assert %{"mcpServers" => %{"fs" => %{"command" => "npx"}}} = Jason.decode!(mcp_json)
+
+    assert_receive {:wrote, "/home/sprite/.claude/settings.json", settings}
+    assert %{"enableAllProjectMcpServers" => true} = Jason.decode!(settings)
+  end
+end


### PR DESCRIPTION
Resolves #837. Claude agents' configured MCP servers never reached the model — on **any** provider. Root-caused as an upstream bug, then fixed with a sandbox-provisioning path proven end-to-end.

## Root cause (upstream)

- **Fountain emits correct ACP.** `Fountain.Runtimes.ACP.Peer` sends `session/new` with a correct, non-empty `mcpServers` (captured on the wire; pinned by `peer_mcp_test.exs`).
- **`claude-agent-acp` drops it.** Driven standalone (no Fountain), fresh `$HOME`, real token, on **0.66.0 and 0.70.0**: the stdio server is never launched (package never fetched, no process), agent reports MCP-ABSENT, Claude Code shows `pendingMcpServers: []`. Filed/corroborated upstream: **agentclientprotocol/claude-agent-acp#883**.

## Fix (Fountain-side, works today)

`Fountain.Runtimes.Claude.write_config/2` provisions the agent's MCP servers into the sandbox as a project **`.mcp.json`** plus **`enableAllProjectMcpServers`** in `~/.claude/settings.json`, which the CLI loads via its `settingSources` — bypassing the broken ACP-native delivery.

**Verified working end-to-end (2026-08-19)** on a live runner through a full Fountain turn: the model calls `mcp__fs__list_directory` and gets a real directory listing. My earlier standalone probes wrongly suggested no workaround existed — they couldn't answer the `session/request_permission` that Fountain's ACP peer auto-allows, which is what approves the project server.

Properties:
- Works on **every provider** (all share `HOME=/home/sprite`), not just the runner.
- `${VAR}` refs are already resolved (the caller hands `write_config/2` the substituted agent).
- No servers → nothing written.

## Changes

- `Fountain.Runtimes.Claude.write_config/2` — the provisioning fix, with a moduledoc explaining why (and that it should be dropped once upstream #883 lands, to avoid double-registration — same lesson as `Fountain.Runtimes.Gemini`).
- `apps/fountain/test/fountain/runtimes/claude_test.exs` — pins the provisioning shape.
- `apps/fountain/test/fountain/runtimes/acp/peer_mcp_test.exs` — pins that we still emit a correct session-scoped `mcpServers`, so the ACP-native path lights up automatically when upstream is fixed.

## Note on the consolidation idea

This is the *opposite* of consolidating onto ACP — we provision more, not less — but it's the only thing that works today. When upstream #883 is fixed, the session-scoped path starts working with no Fountain change, and this provisioning can be removed; that's the consolidation payoff, gated on the adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)