### PR TITLE
fix(team): a pending conversation on a ready sandbox is online, not "starting computer"

### DIFF
--- a/apps/fountain/lib/fountain_web/team_presenter.ex
+++ b/apps/fountain/lib/fountain_web/team_presenter.ex
@@ -33,6 +33,13 @@ defmodule FountainWeb.TeamPresenter do
   @spec presence(map()) :: presence()
   def presence(%{status: "running"}), do: %{state: "working", label: "working"}
 
+  # A conversation opened without a prompt (POST /api/team, the team page's
+  # add) stays `pending` until its first turn, but its computer may well be
+  # up by then: read the sandbox, or a client keeps saying "starting" for a
+  # teammate Fountain itself shows as waiting for a turn.
+  def presence(%{status: "pending", sandbox: %{status: "ready"}}),
+    do: %{state: "online", label: "ready · waiting for a turn"}
+
   def presence(%{status: "pending"}),
     do: %{state: "starting", label: "starting computer"}
 

--- a/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
@@ -145,6 +145,31 @@ defmodule FountainWeb.TeamControllerTest do
       Fountain.Runners.FakeDaemon.stop(daemon)
     end
 
+    test "a pending conversation on a ready sandbox is online, not starting", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      ready = insert_sandbox(user_id: user.id, status: "ready")
+      insert_teammate_conv(user, ada, status: "pending", sandbox_id: ready.id)
+
+      bob = insert_agent(user_id: user.id, name: "Bob")
+      starting = insert_sandbox(user_id: user.id, status: "starting")
+      insert_teammate_conv(user, bob, status: "pending", sandbox_id: starting.id)
+
+      entries =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/team")
+        |> json_response(200)
+        |> Map.fetch!("data")
+        |> Map.new(&{&1["agent"]["name"], &1["presence"]})
+
+      assert %{"state" => "online", "label" => "ready · waiting for a turn"} = entries["Ada"]
+      assert %{"state" => "starting"} = entries["Bob"]
+    end
+
     test "a hosted sandbox carries provider and a null runner", %{
       conn: conn,
       user: user,


### PR DESCRIPTION
## What

`TeamPresenter.presence/1` mapped `status: "pending"` to `starting` / "starting computer" unconditionally. A conversation opened without a prompt (`POST /api/team`, the team page's add) stays `pending` until its first turn — so once its sandbox was `ready`, `/team` and `GET /api/team` kept saying the computer was starting while the conversation page showed it waiting for a turn. fountain-team inherited that: a freshly added teammate sat on "Starting their computer…" until a message was sent (the client now compensates by reading `sandbox.status`, but the presenter is the right place).

Now: `pending` + `sandbox.status == "ready"` → `online`, label "ready · waiting for a turn". `pending` on a sandbox still provisioning stays `starting`.

## Testing

- New controller test: two pending teammates, one on a ready sandbox (→ online / "ready · waiting for a turn"), one on a starting sandbox (→ starting). `mix test test/fountain_web/controllers/team_controller_test.exs` — 18 tests, 0 failures.
- `mix format` clean.

Client side: jhgaylor/fountain-team (ready splash + title affordance) ships with a compensating read of `sandbox.status` so it works before and after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)