### PR TITLE
feat(team): a fresh conversation on the same computer — POST /api/team/:agent_id/conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ upgrade, is in
 
 ### Added
 
+- **A fresh conversation on the same computer.** `POST
+  /api/team/:agent_id/conversations` retires the teammate's current
+  conversation (it stays in its history, past resuming) and opens a new one
+  on the **same sandbox**: the next message starts a fresh runtime session on
+  the same disk — files, clones and installed tools intact — instead of
+  provisioning a new computer. Nothing is interrupted (400 `conversation_busy`
+  mid-turn; 503 `provisioning` while the computer is starting); when the
+  computer is gone a new one is provisioned, as adding does. Audited
+  `team.conversation.rotated`; the stream sends `team`. Underneath,
+  `ConversationServer.release_conversation/2` ends a conversation without
+  touching its sandbox, and terminating or deleting a retired thread no
+  longer reaches the sandbox its successor is running on.
+
 - **Runner-backed teammates on the team surface** (#834). Presence tells
   "asleep" from "the machine is off": a teammate on a self-hosted runner whose
   daemon is not connected is `machine_offline` (a message answers `503

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -51,6 +51,26 @@ defmodule Fountain.Conversations do
   def _unsafe_get_sandbox!(id), do: Repo.get!(Sandbox, id)
 
   @doc """
+  Whether a conversation other than `conv_id` still holds `sandbox_id` — one
+  that is not `terminated`/`failed`. A sandbox normally has one conversation;
+  it gets a second when a teammate starts a fresh conversation on the same
+  computer (`ConversationServer.release_conversation/2`, `Fountain.Team`),
+  and from then on the retired thread's lifecycle must not reach the disk
+  its successor is running on. `_unsafe_`: callers have established
+  ownership of `conv_id` already (a GenServer, or a scoped fetch before it).
+  """
+  def _unsafe_sandbox_held_by_other?(sandbox_id, conv_id)
+      when is_binary(sandbox_id) and is_binary(conv_id) do
+    Repo.exists?(
+      from(c in Conversation,
+        where:
+          c.sandbox_id == ^sandbox_id and c.id != ^conv_id and
+            c.status not in ["terminated", "failed"]
+      )
+    )
+  end
+
+  @doc """
   Load any tenant's conversation for the admin support view (#446).
 
   Returns the conversation with owner/agent/sandbox preloaded plus turn and

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -216,7 +216,11 @@ defmodule Fountain.Conversations.ConversationServer do
               now = DateTime.utc_now() |> DateTime.truncate(:second)
               {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
 
-              if conv.sandbox_id do
+              # A sandbox handed on to a successor conversation
+              # (`release_conversation/2`) is that conversation's computer now;
+              # terminating the retired thread must not take it down.
+              if is_binary(conv.sandbox_id) and
+                   not Conversations._unsafe_sandbox_held_by_other?(conv.sandbox_id, conv.id) do
                 sb = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
 
                 if sb.status not in ["terminated", "failed"] do
@@ -232,6 +236,44 @@ defmodule Fountain.Conversations.ConversationServer do
       end
 
     audit_lifecycle(conv_id, "conversation.terminated", result, opts)
+    result
+  end
+
+  @doc """
+  End the conversation but keep its computer: the conversation goes
+  `terminated` (past resuming, its transcript intact), the sandbox row and
+  the sprite behind it are left exactly as they are, and this server stops
+  holding them. The callback key this server minted is revoked on the way
+  out (`terminate/2`), so nothing on the sandbox can act as the retired
+  conversation.
+
+  This is how a teammate starts a fresh conversation on the same computer
+  (`Fountain.Team.open_fresh_conversation/3`): the successor conversation
+  takes the `sandbox_id`, and its first prompt reattaches through the
+  ordinary wake path — a new runtime session on the same disk.
+
+  `{:error, :busy}` while a turn is running; nothing is interrupted. With no
+  server alive the row alone is marked, the same as `terminate_conversation/2`.
+  Audited as `conversation.released` unless `audit: false`.
+  """
+  def release_conversation(conv_id, opts \\ []) do
+    result =
+      case whereis(conv_id) do
+        nil ->
+          case Conversations._unsafe_get_conversation(conv_id) do
+            nil ->
+              {:error, :not_running}
+
+            conv ->
+              {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+              :ok
+          end
+
+        pid ->
+          call_server(pid, :release_conv)
+      end
+
+    audit_lifecycle(conv_id, "conversation.released", result, opts)
     result
   end
 
@@ -1335,6 +1377,23 @@ defmodule Fountain.Conversations.ConversationServer do
     {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
     publish_stage(state.conversation_id, "terminate", "done")
     {:stop, :normal, :ok, state}
+  end
+
+  # End the conversation, keep the sandbox — see release_conversation/2. A
+  # running turn is refused rather than interrupted: the caller decides
+  # whether to cut the agent off. `handle: nil` on the way out so no stop
+  # path (terminate/2 included) touches the sprite; the sandbox row is not
+  # written at all — it stays `ready`, a parked disk with no server, exactly
+  # what the wake path expects when the successor's first prompt arrives.
+  def handle_call(:release_conv, _from, %{current_turn: turn} = state) when not is_nil(turn) do
+    {:reply, {:error, :busy}, state}
+  end
+
+  def handle_call(:release_conv, _from, state) do
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+    publish_stage(state.conversation_id, "terminate", "done", %{event: "released"})
+    {:stop, :normal, :ok, %{state | handle: nil}}
   end
 
   # Catch-all: an unmatched call must not die with a FunctionClauseError at

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -14,6 +14,12 @@ defmodule Fountain.Team do
   a fresh one under the same binding — the agent gets a new computer, and the
   team list keeps showing the same teammate.
 
+  A teammate can also start over without losing its computer:
+  `open_fresh_conversation/3` retires the current conversation (it stays in
+  the teammate's history, past resuming) and opens a new one on the same
+  sandbox — the next message runs a fresh runtime session on the same disk,
+  the files and installed tools still there.
+
   Removing a teammate terminates the live conversation and clears the binding
   on every conversation this agent had under it, so the rows stay in the
   user's history (`/conversations`) but leave the team. Its schedules
@@ -374,6 +380,146 @@ defmodule Fountain.Team do
             err
         end
     end
+  end
+
+  @doc """
+  Open a fresh conversation for the teammate on its current computer.
+
+  The current conversation is released — `terminated`, past resuming, listed
+  behind the new one in `list_teammate_conversations/2` — and a new one is
+  opened under the same binding, carrying the teammate's name, environment
+  and vault, and pointing at the **same sandbox**: the agent's next message
+  wakes it through the ordinary reattach path and starts a new runtime
+  session there, so the context is fresh but the disk is not. Nothing is
+  provisioned, and the sandbox is not touched at all (a parked one stays
+  parked until that message).
+
+  When the computer is gone — the sandbox `terminated` or `failed`, or the
+  current conversation already past resuming — there is nothing to keep, and
+  the new conversation is opened the way `add_teammate/4` opens one: a fresh
+  sandbox, provisioning now. Either way the caller gets the conversation that
+  is current from here on.
+
+  Returns `{:ok, conv}`; `{:error, :not_found}` off the team; `{:error,
+  :busy}` while a turn is running (nothing is interrupted — interrupt first);
+  `{:error, :provisioning}` while the computer is still starting; else the
+  `start_conversation/2` errors on the fallback path. Audited as
+  `team.conversation.rotated` (with `conversation.created` underneath);
+  broadcasts the roster change, so a client following the stream re-lists
+  and follows the new conversation.
+  """
+  def open_fresh_conversation(user_id, agent_id, opts \\ [])
+      when is_binary(user_id) and is_binary(agent_id) and is_list(opts) do
+    case get_teammate(user_id, agent_id) do
+      nil ->
+        {:error, :not_found}
+
+      %{conversation: conv} ->
+        # Ownership: `conv` (and its preloaded sandbox) came from the
+        # tenant-scoped get_teammate above.
+        with :ok <- releasable(conv) do
+          rotate(user_id, agent_id, conv, opts)
+        end
+    end
+  end
+
+  # A computer mid-provision cannot change hands: the server holding it is
+  # inside the provision and will mark the row ready or failed on its own.
+  defp releasable(%Conversation{sandbox: %{status: s}}) when s in ["pending", "starting"],
+    do: {:error, :provisioning}
+
+  defp releasable(_conv), do: :ok
+
+  defp rotate(user_id, agent_id, %Conversation{} = prev, opts) do
+    keep? = live?(prev) and reusable_sandbox?(prev.sandbox)
+
+    # Release the live one first (a running turn refuses here, before anything
+    # is created); a conversation already past resuming has nothing to release.
+    # `audit: false`: the rotation below is what the user asked for.
+    release =
+      if live?(prev),
+        do: ConversationServer.release_conversation(prev.id, audit: false),
+        else: :ok
+
+    result =
+      case release do
+        :ok when keep? -> open_on_sandbox(user_id, agent_id, prev, opts)
+        :ok -> open_on_new_sandbox(user_id, agent_id, prev, opts)
+        {:error, _} = err -> err
+      end
+
+    with {:ok, conv} <- result do
+      record(user_id, "team.conversation.rotated", conv, opts, %{
+        "previous_conversation_id" => prev.id,
+        "computer_kept" => keep?
+      })
+
+      broadcast_changed(user_id)
+    end
+
+    result
+  end
+
+  defp reusable_sandbox?(%{status: s}) when s in ["ready", "suspended"], do: true
+  defp reusable_sandbox?(_sandbox), do: false
+
+  # The same sandbox, a new conversation row: `idle` with no server, which is
+  # exactly what a parked teammate looks like — `ConversationServer.send_prompt/4`
+  # finds no server, `Conversations.wake_conversation/2` probes the sandbox and
+  # reattaches. The runtime session id is left nil on purpose: that is the
+  # fresh start. `runtime` is snapshotted from the agent as start_conversation
+  # does, so a later change of the agent's runtime does not rewrite history.
+  defp open_on_sandbox(user_id, agent_id, %Conversation{} = prev, opts) do
+    agent = Agents.get_agent(agent_id, user_id)
+
+    attrs = %{
+      sandbox_id: prev.sandbox_id,
+      agent_id: agent_id,
+      vault_id: prev.vault_id,
+      environment_id: prev.environment_id,
+      user_id: user_id,
+      runtime: (agent && agent.runtime) || prev.runtime,
+      status: "idle",
+      source: Keyword.get(opts, :source, "ui"),
+      channel_id: @channel,
+      title: prev.title
+    }
+
+    with {:ok, conv} <- Conversations.create_conversation(attrs) do
+      Audit.record(%{
+        user_id: user_id,
+        action: "conversation.created",
+        resource_type: "conversation",
+        resource_id: conv.id,
+        actor: Keyword.get(opts, :actor, "self"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{
+          "agent_id" => agent_id,
+          "agent_name" => agent && agent.name,
+          "source" => conv.source,
+          "with_prompt" => false,
+          "sandbox_reused_from" => prev.id
+        }
+      })
+
+      {:ok, Conversations.get_conversation(conv.id, user_id) || conv}
+    end
+  end
+
+  # The computer is gone: a new one, provisioning now — what add_teammate does.
+  defp open_on_new_sandbox(user_id, agent_id, %Conversation{} = prev, opts) do
+    Conversations.start_conversation(
+      %{
+        "agent_id" => agent_id,
+        "user_id" => user_id,
+        "channel_id" => @channel,
+        "source" => Keyword.get(opts, :source, "ui"),
+        "title" => prev.title,
+        "environment_id" => prev.environment_id,
+        "vault_id" => prev.vault_id
+      },
+      opts
+    )
   end
 
   @doc """

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -139,6 +139,42 @@ defmodule FountainWeb.TeamController do
     end
   end
 
+  operation(:fresh_conversation,
+    summary: "Open a fresh conversation on the teammate's computer",
+    description:
+      "Retires the teammate's current conversation — it stays in its history, past " <>
+        "resuming — and opens a new one on the **same sandbox**: the next message starts " <>
+        "a fresh runtime session on the same disk, files and installed tools intact. " <>
+        "Nothing is provisioned and nothing is interrupted: 400 `conversation_busy` " <>
+        "while a turn is running (interrupt first), 503 `provisioning` while the " <>
+        "computer is still starting. When the computer is gone (sandbox terminated or " <>
+        "failed, or the conversation already past resuming) a new sandbox is " <>
+        "provisioned instead, as `POST /api/team` does. 201 with the teammate and its " <>
+        "new conversation; the stream sends `team`. Audited as `team.conversation.rotated`.",
+    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    responses: [
+      created: {"Teammate", "application/json", Schemas.TeammateResponse},
+      not_found: {"Not on the team", "application/json", Schemas.Error},
+      bad_request: {"A turn is still running", "application/json", Schemas.Error},
+      service_unavailable: {"The computer is still starting", "application/json", Schemas.Error}
+    ]
+  )
+
+  def fresh_conversation(conn, %{"agent_id" => agent_id}) do
+    user = conn.assigns.current_user
+    opts = [source: "api"] ++ Audited.attribution(conn)
+
+    with {:ok, _conv} <- Team.open_fresh_conversation(user.id, agent_id, opts),
+         %{} = teammate <- Team.get_teammate(user.id, agent_id) || {:error, :not_found} do
+      conn
+      |> put_status(:created)
+      |> render(:show, teammate: teammate)
+    else
+      {:error, :busy} -> {:error, "conversation_busy"}
+      {:error, _} = err -> err
+    end
+  end
+
   operation(:delete,
     summary: "Remove an agent from the team",
     description:

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -380,6 +380,8 @@ defmodule FountainWeb.Router do
     post "/team/:agent_id/messages", TeamController, :message
     # The teammate's history (#832): every conversation it has had on the team.
     get "/team/:agent_id/conversations", TeamController, :conversations
+    # A fresh conversation on the same computer; the current one is retired.
+    post "/team/:agent_id/conversations", TeamController, :fresh_conversation
 
     # Team schedules (#825): the routines `/team` offers, per teammate.
     get "/team/:agent_id/schedules", TeamScheduleController, :index

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -69,6 +69,7 @@ defmodule Fountain.AuditGuardrailTest do
     {"team member add", &__MODULE__.do_team_add/1, "team.member.added"},
     {"team member remove", &__MODULE__.do_team_remove/1, "team.member.removed"},
     {"team member rename", &__MODULE__.do_team_rename/1, "team.renamed"},
+    {"team conversation rotate", &__MODULE__.do_team_rotate/1, "team.conversation.rotated"},
     # Team schedules: a cron that runs a teammate with a prompt. A run leaves
     # conversation events underneath; `.fired` is the schedule-side record.
     {"team schedule create", &__MODULE__.do_schedule_create/1, "team.schedule.created"},
@@ -265,6 +266,21 @@ defmodule Fountain.AuditGuardrailTest do
     )
 
     {:ok, _} = Fountain.Team.rename_teammate(user.id, agent.id, "Renamed")
+  end
+
+  def do_team_rotate(user) do
+    agent = insert_agent(user_id: user.id)
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+    insert_conversation(
+      user_id: user.id,
+      agent: agent,
+      sandbox: sandbox,
+      status: "idle",
+      channel_id: Fountain.Team.channel()
+    )
+
+    {:ok, _} = Fountain.Team.open_fresh_conversation(user.id, agent.id)
   end
 
   def do_team_remove(user) do

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -938,6 +938,89 @@ defmodule Fountain.Conversations.ConversationServerTest do
     end
   end
 
+  describe "release_conversation/2 — end the conversation, keep the computer" do
+    test "a live server stops without destroying the sprite; the rows say so",
+         %{conv: conv, sandbox: sandbox} do
+      stub_happy_sprite()
+      test = self()
+      Mimic.stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> send(test, :destroyed) && :ok end)
+
+      {pid, ref, :alive} = start_server(conv)
+      key_id = Conversations._unsafe_get_conversation!(conv.id).callback_api_key_id
+
+      # The harness's servers are outside Horde, so the client function would
+      # not find this one; the call is what release_conversation/2 makes.
+      assert :ok = GenServer.call(pid, :release_conv)
+      assert_stopped(ref)
+
+      refute_received :destroyed
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "terminated"
+      # The sandbox row is untouched: ready, no terminated_at — a parked disk.
+      reloaded = Conversations._unsafe_get_sandbox!(sandbox.id)
+      assert reloaded.status == "ready"
+      refute reloaded.terminated_at
+      # The retired conversation's credential does not outlive it.
+      assert Repo.get(Accounts.ApiKey, key_id).revoked_at
+      # The stage event names what happened so a client can tell it from a terminate.
+      assert Enum.any?(
+               Conversations._unsafe_list_log_events(conv.id),
+               &(&1.kind == "stage" and &1.stage == "terminate" and &1.state == "done" and
+                   &1.data =~ "released")
+             )
+    end
+
+    test "refuses while a turn is running and interrupts nothing", %{conv: conv, sandbox: sandbox} do
+      stub_happy_sprite()
+      ref = make_ref()
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
+      end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _cmd, _data -> :ok end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _cmd -> :ok end)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "first")
+
+      assert {:error, :busy} = GenServer.call(pid, :release_conv)
+      assert Process.alive?(pid)
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "running"
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
+      assert [%{status: "running"}] = Conversations._unsafe_list_turns(conv.id)
+
+      GenServer.stop(pid)
+    end
+
+    test "with no server, marks the conversation alone", %{conv: conv, sandbox: sandbox} do
+      {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+
+      assert :ok = ConversationServer.release_conversation(conv.id)
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "terminated"
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
+
+      assert {:error, :not_running} =
+               ConversationServer.release_conversation(Ecto.UUID.generate())
+    end
+
+    test "terminating the retired conversation later leaves its successor's sandbox alone",
+         %{conv: conv, sandbox: sandbox, user: user, agent: agent} do
+      {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      assert :ok = ConversationServer.release_conversation(conv.id)
+
+      successor =
+        insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      # A terminate (or a delete, which cascades through it) of the old thread.
+      assert :ok = ConversationServer.terminate_conversation(conv.id)
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
+
+      # Once the successor is past resuming too, the sandbox goes with it.
+      {:ok, _} = Conversations.update_conversation(successor, %{status: "terminated"})
+      assert :ok = ConversationServer.terminate_conversation(conv.id)
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "terminated"
+    end
+  end
+
   describe "interrupt/1 and send_prompt/3 with no running server" do
     test "interrupt reports not_running", %{conv: conv} do
       assert {:error, :not_running} = ConversationServer.interrupt(conv.id)

--- a/apps/fountain/test/fountain/team_test.exs
+++ b/apps/fountain/test/fountain/team_test.exs
@@ -398,6 +398,161 @@ defmodule Fountain.TeamTest do
     end
   end
 
+  describe "open_fresh_conversation/3" do
+    test "retires the current conversation and opens a new one on the same sandbox" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      env = insert_env(user_id: user.id)
+      vault = insert_vault(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      prev =
+        insert_teammate_conv(user, ada,
+          sandbox: sandbox,
+          status: "idle",
+          title: "Ada (staging)",
+          environment_id: env.id,
+          vault_id: vault.id,
+          runtime_session_id: "sess-old"
+        )
+
+      Team.subscribe(user.id)
+
+      assert {:ok, fresh} = Team.open_fresh_conversation(user.id, ada.id, actor: "ui")
+
+      # A new conversation, same computer, fresh session, the teammate's attributes.
+      refute fresh.id == prev.id
+      assert fresh.sandbox_id == sandbox.id
+      assert fresh.status == "idle"
+      assert fresh.runtime_session_id == nil
+      assert fresh.channel_id == Team.channel()
+      assert fresh.title == "Ada (staging)"
+      assert fresh.environment_id == env.id
+      assert fresh.vault_id == vault.id
+      assert fresh.runtime == ada.runtime
+
+      # The old one is past resuming; the sandbox row was not touched.
+      assert Repo.reload(prev).status == "terminated"
+      assert Repo.reload(sandbox).status == "ready"
+      refute Repo.reload(sandbox).terminated_at
+
+      # The roster follows the new one; history lists both, the new one first.
+      assert [%{conversation: %{id: id}, name: "Ada (staging)"}] = Team.list_teammates(user.id)
+      assert id == fresh.id
+
+      assert [fresh.id, prev.id] ==
+               user.id |> Team.list_teammate_conversations(ada.id) |> Enum.map(& &1.id)
+
+      assert_received {:team_changed, _}
+
+      actions = user.id |> Audit.list_recent_for_user(20) |> Enum.map(& &1.action)
+      assert "team.conversation.rotated" in actions
+      assert "conversation.created" in actions
+    end
+
+    test "a parked computer is kept too, and stays parked" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, status: "suspended")
+      insert_teammate_conv(user, ada, sandbox: sandbox, status: "idle")
+
+      assert {:ok, fresh} = Team.open_fresh_conversation(user.id, ada.id)
+      assert fresh.sandbox_id == sandbox.id
+      assert Repo.reload(sandbox).status == "suspended"
+    end
+
+    test "releases through the server when one is running; a running turn refuses" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      prev = insert_teammate_conv(user, ada, sandbox: sandbox, status: "running")
+      test_pid = self()
+
+      stub(ConversationServer, :release_conversation, fn id, opts ->
+        send(test_pid, {:released, id, opts})
+        {:error, :busy}
+      end)
+
+      assert {:error, :busy} = Team.open_fresh_conversation(user.id, ada.id)
+      assert_received {:released, id, opts}
+      assert id == prev.id
+      assert opts[:audit] == false
+
+      # Nothing was created or recorded.
+      assert [prev.id] ==
+               user.id |> Team.list_teammate_conversations(ada.id) |> Enum.map(& &1.id)
+
+      actions = user.id |> Audit.list_recent_for_user(20) |> Enum.map(& &1.action)
+      refute "team.conversation.rotated" in actions
+    end
+
+    test "a computer still starting cannot change hands" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+
+      for status <- ["pending", "starting"] do
+        agent = insert_agent(user_id: user.id)
+        sandbox = insert_sandbox(user_id: user.id, status: status)
+        insert_teammate_conv(user, agent, sandbox: sandbox, status: "pending")
+        assert {:error, :provisioning} = Team.open_fresh_conversation(user.id, agent.id)
+      end
+
+      _ = ada
+    end
+
+    test "a gone computer means a new one, provisioning now, with the teammate's attributes" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      env = insert_env(user_id: user.id)
+      dead_sandbox = insert_sandbox(user_id: user.id, status: "terminated")
+
+      prev =
+        insert_teammate_conv(user, ada,
+          sandbox: dead_sandbox,
+          status: "idle",
+          title: "Ada (staging)",
+          environment_id: env.id
+        )
+
+      inert_start_child()
+
+      assert {:ok, fresh} = Team.open_fresh_conversation(user.id, ada.id)
+      refute fresh.id == prev.id
+      refute fresh.sandbox_id == dead_sandbox.id
+      assert fresh.title == "Ada (staging)"
+      assert fresh.environment_id == env.id
+      assert Repo.reload(prev).status == "terminated"
+
+      actions = user.id |> Audit.list_recent_for_user(20) |> Enum.map(& &1.action)
+      assert "team.conversation.rotated" in actions
+    end
+
+    test "a conversation already past resuming is replaced the same way" do
+      user = insert_verified_user()
+      ada = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      prev = insert_teammate_conv(user, ada, sandbox: sandbox, status: "terminated")
+      inert_start_child()
+
+      assert {:ok, fresh} = Team.open_fresh_conversation(user.id, ada.id)
+      refute fresh.id == prev.id
+      # Not reused: a terminated conversation's sandbox is not the teammate's
+      # computer any more, whatever the row says.
+      refute fresh.sandbox_id == sandbox.id
+    end
+
+    test "not on the team → :not_found; another tenant's teammate too" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      theirs = insert_agent(user_id: other.id)
+      insert_teammate_conv(other, theirs)
+
+      assert {:error, :not_found} = Team.open_fresh_conversation(user.id, agent.id)
+      assert {:error, :not_found} = Team.open_fresh_conversation(user.id, theirs.id)
+    end
+  end
+
   describe "list_teammate_conversations/2 (#832)" do
     test "every conversation the agent had on the team, newest first; none off the team" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
@@ -356,6 +356,84 @@ defmodule FountainWeb.TeamControllerTest do
     end
   end
 
+  describe "POST /api/team/:agent_id/conversations" do
+    test "opens a fresh conversation on the same computer; the old one is retired", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      prev = insert_teammate_conv(user, ada, sandbox: sandbox, title: "Ada (staging)")
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/team/#{ada.id}/conversations")
+        |> json_response(201)
+
+      entry = body["data"]
+      assert entry["agent_id"] == ada.id
+      assert entry["name"] == "Ada (staging)"
+      refute entry["conversation"]["id"] == prev.id
+      assert entry["conversation"]["sandbox_id"] == sandbox.id
+      assert entry["conversation"]["status"] == "idle"
+      # Same computer, no server yet: online, wakes on the next message.
+      assert entry["presence"]["state"] == "online"
+
+      assert Repo.reload(prev).status == "terminated"
+      assert Repo.reload(sandbox).status == "ready"
+
+      history =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/team/#{ada.id}/conversations")
+        |> json_response(200)
+
+      assert Enum.map(history["data"], &{&1["id"], &1["current"]}) == [
+               {entry["conversation"]["id"], true},
+               {prev.id, false}
+             ]
+
+      assert Enum.any?(Audit.list_recent_for_user(user.id, 20), fn e ->
+               e.action == "team.conversation.rotated" and e.actor == "api" and
+                 e.metadata["previous_conversation_id"] == prev.id and
+                 e.metadata["computer_kept"] == true
+             end)
+    end
+
+    test "400 conversation_busy while a turn runs; 503 while the computer starts; 404 off the team",
+         %{conn: conn, user: user, raw_key: key} do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      insert_teammate_conv(user, ada, sandbox: sandbox, status: "running")
+      stub(ConversationServer, :release_conversation, fn _id, _opts -> {:error, :busy} end)
+
+      assert %{"error" => "conversation_busy"} =
+               conn
+               |> authed_with_key(key)
+               |> post("/api/team/#{ada.id}/conversations")
+               |> json_response(400)
+
+      linus = insert_agent(user_id: user.id, name: "Linus")
+      starting = insert_sandbox(user_id: user.id, status: "starting")
+      insert_teammate_conv(user, linus, sandbox: starting, status: "pending")
+
+      assert %{"error" => "provisioning"} =
+               conn
+               |> authed_with_key(key)
+               |> post("/api/team/#{linus.id}/conversations")
+               |> json_response(503)
+
+      loner = insert_agent(user_id: user.id)
+
+      assert conn
+             |> authed_with_key(key)
+             |> post("/api/team/#{loner.id}/conversations")
+             |> json_response(404)
+    end
+  end
+
   describe "DELETE /api/team/:agent_id" do
     test "removes the teammate; 404 when not on the team", %{conn: conn, user: user, raw_key: key} do
       ada = insert_agent(user_id: user.id, name: "Ada")

--- a/docs/api.md
+++ b/docs/api.md
@@ -383,6 +383,23 @@ stays bound to the team channel until the teammate is removed, so it is
 listed behind the current one with `current: false`; read it with
 `GET /api/conversations/:id/events`.
 
+`POST /api/team/:agent_id/conversations` starts the teammate over without
+losing its computer: the current conversation is retired — `terminated`,
+listed behind the new one with `current: false` — and a new conversation is
+opened under the binding, carrying the name, environment and vault and
+pointing at the **same sandbox**. Nothing is provisioned or interrupted: the
+next message wakes that sandbox through the ordinary reattach path and
+starts a fresh runtime session on it, so the agent's context is new but its
+files, clones and installed tools are where it left them. `201` with the
+teammate and its new conversation; `400 conversation_busy` while a turn is
+running (interrupt first), `503 provisioning` while the computer is still
+starting. When the computer is gone (sandbox `terminated`/`failed`, or the
+conversation already past resuming) a new sandbox is provisioned instead,
+exactly as `POST /api/team` would. Audited as `team.conversation.rotated`;
+the stream sends `team`. To retire the thread *and* the computer, the old
+way still works: `POST /api/conversations/:id/terminate` on the current
+conversation, and the next message opens a fresh one on a new sandbox.
+
 `POST /api/team` answers `201` with the teammate, or `200` when the agent was
 already on the team (its live conversation, the attributes ignored). `name`
 becomes the conversation's `title`; `environment_id` and `vault_id` go through


### PR DESCRIPTION
## Summary

A teammate could only start over by terminating its conversation, which took the sandbox with it: the next message provisioned a new computer and everything on the old disk was gone. This adds a way to retire the thread while the computer stays.

- **`ConversationServer.release_conversation/2`** — end the conversation, leave the sandbox row and sprite untouched, stop holding them (callback key revoked on exit). `{:error, :busy}` mid-turn; nothing is interrupted.
- **`Team.open_fresh_conversation/3`** — release the current conversation and open a new one under the team binding pointing at the **same `sandbox_id`** (`idle`, no server, nil runtime session). The next message wakes it through the ordinary reattach path and starts a fresh runtime session on the same disk. When the computer is gone (sandbox terminated/failed, or the conversation already past resuming) it falls back to provisioning a new one, as `add_teammate` does. Audited `team.conversation.rotated`; broadcasts `team`.
- **Safety** — terminating or deleting a retired thread no longer flips a sandbox that a live successor conversation holds (`Conversations._unsafe_sandbox_held_by_other?/2`); otherwise deleting an old thread from the UI would have let the reaper destroy the live computer.
- **`POST /api/team/:agent_id/conversations`** → 201 with the teammate; 400 `conversation_busy`; 503 `provisioning`; 404. OpenAPI op, `docs/api.md`, CHANGELOG.

Client side: BinaryBourbon/fountain-team (the "Start a fresh thread" action). Deploy this first; the client's default action 404s on an older server.

## Test plan

- [x] `mix test` — 3165 tests, 0 failures (new: Team context ×7, ConversationServer ×4, controller ×2, audit guardrail entry)
- [x] `mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors`
- [ ] Manual against a real provider: fresh thread → send a message → the same sprite reattaches with a new session; the retired thread reads in History

🤖 Generated with [Claude Code](https://claude.com/claude-code)
