### PR TITLE
feat(onboarding): ask for Anthropic only; collect other providers' keys when a model first needs them (#841)

### DIFF
--- a/apps/fountain/lib/fountain/inference_credentials.ex
+++ b/apps/fountain/lib/fountain/inference_credentials.ex
@@ -146,6 +146,42 @@ defmodule Fountain.InferenceCredentials do
   end
 
   @doc """
+  The credentials that let a model's provider run: a model `provider/id`
+  names a provider; any one of these credentials serves it. Unknown
+  providers (a local model, a gateway) need none — Fountain cannot know.
+
+      iex> credentials_for_provider("anthropic")
+      [:anthropic_api_key, :claude_code_oauth_token]
+  """
+  @spec credentials_for_provider(String.t() | nil) :: [atom()]
+  def credentials_for_provider("anthropic"), do: [:anthropic_api_key, :claude_code_oauth_token]
+  def credentials_for_provider("openai"), do: [:openai_api_key]
+  def credentials_for_provider("google"), do: [:gemini_api_key]
+  def credentials_for_provider(_), do: []
+
+  @doc """
+  What a model would be missing on this account: `nil` when one of the
+  credentials its provider accepts is set (or the provider needs none),
+  else `{provider, credentials}` — the provider's name and the credentials
+  that would do. The onboarding wizard asks only for Anthropic; this is how
+  the agent form and the API ask for the rest the first time a model needs
+  them, rather than failing inside the sandbox.
+  """
+  @spec missing_for_model(binary(), String.t() | nil) :: nil | {String.t(), [atom()]}
+  def missing_for_model(user_id, model) when is_binary(user_id) do
+    provider = Fountain.Runtimes.Model.provider(model)
+
+    case credentials_for_provider(provider) do
+      [] ->
+        nil
+
+      accepted ->
+        status = status_for_user(user_id)
+        if Enum.any?(accepted, &Map.get(status, &1, false)), do: nil, else: {provider, accepted}
+    end
+  end
+
+  @doc """
   Returns a map `%{provider => boolean}` of which providers the user has set.
   Cheap — does not decrypt; just checks for non-nil ciphertext.
   """

--- a/apps/fountain/lib/fountain_web/inference_credential_save.ex
+++ b/apps/fountain/lib/fountain_web/inference_credential_save.ex
@@ -1,0 +1,76 @@
+defmodule FountainWeb.InferenceCredentialSave do
+  @moduledoc """
+  Validate-then-persist an inference credential from a LiveView, with the
+  messages the user sees. One place for the three doors that collect keys
+  (onboarding, the credentials page, the agent form's just-in-time prompt),
+  so every one validates against the provider first and audits the save
+  with the socket's attribution (#546).
+  """
+
+  alias Fountain.Crypto
+  alias Fountain.InferenceCredentials
+  alias Fountain.InferenceCredentials.Validator
+
+  @type outcome :: {:ok, String.t()} | {:error, String.t()}
+
+  @doc "Validate `value` against `provider`, persist it for the socket's user, and say what happened."
+  @spec save(Phoenix.LiveView.Socket.t(), atom(), String.t() | nil) :: outcome
+  def save(socket, provider, value) do
+    value = String.trim(value || "")
+
+    if value == "" do
+      {:error, "Paste a value before saving."}
+    else
+      case Validator.validate(provider, value) do
+        :ok ->
+          case persist(socket, provider, value) do
+            {:ok, _} -> {:ok, "Saved and validated."}
+            {:error, reason} -> {:error, "Could not save: #{inspect(reason)}"}
+          end
+
+        {:error, :invalid, %{status: status}} ->
+          {:error,
+           "Provider rejected the credential (HTTP #{status}). Check that you copied the full token."}
+
+        {:error, :timeout} ->
+          {:error, "Validation timed out. Try again."}
+
+        {:error, reason} ->
+          {:error, "Could not reach provider (#{inspect(reason)})."}
+      end
+    end
+  end
+
+  defp persist(socket, provider, value) do
+    user_id = socket.assigns.user_id
+
+    with {:ok, dek} <- Crypto.load_tenant_key(user_id) do
+      InferenceCredentials.put_credential(
+        user_id,
+        dek,
+        provider,
+        value,
+        FountainWeb.Audited.attribution(socket)
+      )
+    end
+  end
+
+  @doc "Human names for the providers and credentials the forms talk about."
+  @spec label(atom() | String.t()) :: String.t()
+  def label(:anthropic_api_key), do: "Anthropic API key"
+  def label(:claude_code_oauth_token), do: "Claude OAuth token"
+  def label(:openai_api_key), do: "OpenAI API key"
+  def label(:gemini_api_key), do: "Gemini API key"
+  def label("anthropic"), do: "Anthropic"
+  def label("openai"), do: "OpenAI"
+  def label("google"), do: "Google"
+  def label(other), do: to_string(other)
+
+  @doc "Where to get one."
+  @spec source(atom()) :: String.t()
+  def source(:anthropic_api_key), do: "console.anthropic.com"
+  def source(:claude_code_oauth_token), do: "`claude setup-token`"
+  def source(:openai_api_key), do: "platform.openai.com/api-keys"
+  def source(:gemini_api_key), do: "aistudio.google.com/apikey"
+  def source(_), do: ""
+end

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -2,7 +2,7 @@ defmodule FountainWeb.AgentsLive.Form do
   @moduledoc false
   use FountainWeb, :live_view
 
-  alias Fountain.{Agents, AvatarGenerator, Environments}
+  alias Fountain.{Agents, AvatarGenerator, Environments, InferenceCredentials}
   alias Fountain.Agents.Agent
   alias Fountain.Runtimes.Model
 
@@ -16,6 +16,14 @@ defmodule FountainWeb.AgentsLive.Form do
      socket
      |> assign(:page_title, page_title(action))
      |> assign(:user_id, user_id)
+     |> assign(
+       :missing_credential,
+       InferenceCredentials.missing_for_model(
+         user_id,
+         agent.model || "anthropic/claude-sonnet-4-6"
+       )
+     )
+     |> assign(:credential_message, nil)
      |> assign(:envs, envs)
      |> assign(:sandbox_providers, Fountain.Sandbox.enabled_providers())
      |> assign(:action, action)
@@ -117,7 +125,35 @@ defmodule FountainWeb.AgentsLive.Form do
      socket
      |> assign(:form, params)
      |> assign(:skills, skills)
-     |> assign(:mcp_servers, mcp_servers)}
+     |> assign(:mcp_servers, mcp_servers)
+     |> assign(
+       :missing_credential,
+       InferenceCredentials.missing_for_model(socket.assigns.user_id, params["model"])
+     )}
+  end
+
+  # The model needs a provider this account has no credential for: collect
+  # it right here, the first time it matters (#841), rather than after a
+  # conversation fails to start inside the sandbox.
+  def handle_event("save_credential", %{"provider" => provider_str, "value" => value}, socket) do
+    provider = String.to_existing_atom(provider_str)
+
+    case FountainWeb.InferenceCredentialSave.save(socket, provider, value) do
+      {:ok, msg} ->
+        {:noreply,
+         socket
+         |> assign(:credential_message, {:info, msg})
+         |> assign(
+           :missing_credential,
+           InferenceCredentials.missing_for_model(
+             socket.assigns.user_id,
+             socket.assigns.form["model"]
+           )
+         )}
+
+      {:error, msg} ->
+        {:noreply, assign(socket, :credential_message, {:error, msg})}
+    end
   end
 
   def handle_event("add_skill", _, socket) do
@@ -573,6 +609,11 @@ defmodule FountainWeb.AgentsLive.Form do
         >
           Not one of the models Fountain lists — it will be passed to the runtime as-is.
         </p>
+        <.missing_credential_card
+          :if={@missing_credential}
+          missing={@missing_credential}
+          message={@credential_message}
+        />
 
         <div :if={length(@sandbox_providers) > 1} class="space-y-1">
           <label class="block text-sm font-medium text-zinc-700">Sandbox provider</label>
@@ -1026,6 +1067,52 @@ defmodule FountainWeb.AgentsLive.Form do
     <p :if={Map.has_key?(@errors, @field)} class="text-rose-600 text-xs">
       {Map.get(@errors, @field)}
     </p>
+    """
+  end
+
+  attr :missing, :any, required: true
+  attr :message, :any, required: true
+
+  defp missing_credential_card(assigns) do
+    {provider, accepted} = assigns.missing
+    assigns = assign(assigns, provider: provider, accepted: accepted, first: hd(accepted))
+
+    ~H"""
+    <div class="rounded-md border border-amber-300 bg-amber-50 p-3 space-y-2">
+      <p class="text-sm text-amber-900">
+        <span class="font-medium">
+          No {FountainWeb.InferenceCredentialSave.label(@provider)} credential on this account yet.
+        </span>
+        The agent saves fine, but its conversations cannot start until one is set. Paste it here and it is validated and saved <span :if={
+          length(@accepted) > 1
+        }>
+          (a {Enum.map_join(tl(@accepted), " or ", &FountainWeb.InferenceCredentialSave.label/1)} works too — Settings → Inference credentials)
+        </span>:
+      </p>
+      <form phx-submit="save_credential" class="flex gap-2">
+        <input type="hidden" name="provider" value={Atom.to_string(@first)} />
+        <input
+          type="password"
+          name="value"
+          placeholder={"#{FountainWeb.InferenceCredentialSave.label(@first)} · from #{FountainWeb.InferenceCredentialSave.source(@first)}"}
+          autocomplete="off"
+          class="flex-1 rounded-md border border-amber-300 bg-white px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-amber-500"
+        />
+        <button
+          type="submit"
+          class="rounded-md bg-zinc-900 text-white px-3 py-1.5 text-xs font-medium hover:bg-zinc-700"
+        >
+          Save key
+        </button>
+      </form>
+      <%= case @message do %>
+        <% nil -> %>
+        <% {:info, msg} -> %>
+          <p class="text-xs text-emerald-700">{msg}</p>
+        <% {:error, msg} -> %>
+          <p class="text-xs text-rose-700">{msg}</p>
+      <% end %>
+    </div>
     """
   end
 end

--- a/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
+++ b/apps/fountain/lib/fountain_web/live/onboarding_live/wizard.ex
@@ -2,8 +2,7 @@ defmodule FountainWeb.OnboardingLive.Wizard do
   @moduledoc false
   use FountainWeb, :live_view
 
-  alias Fountain.{Accounts, Agents, Crypto, Environments, InferenceCredentials}
-  alias Fountain.InferenceCredentials.Validator
+  alias Fountain.{Accounts, Agents, Environments, InferenceCredentials}
 
   # ADR 0008 inserted "inference" as the new first step. Old step_1/2/3
   # shifted to step_2/3/4. Migration 20260510210001 bumps existing user
@@ -52,6 +51,7 @@ defmodule FountainWeb.OnboardingLive.Wizard do
     |> assign(:environments, Environments.list_environments(user.id))
     |> assign(:agents, Agents.list_agents(user.id, []))
     |> assign(:inference_providers, @inference_providers)
+    |> assign(:show_all_providers, false)
     |> assign(:inference_status, InferenceCredentials.status_for_user(user.id))
     |> assign(:inference_messages, %{})
   end
@@ -61,56 +61,24 @@ defmodule FountainWeb.OnboardingLive.Wizard do
   @impl true
   def handle_event("save_credential", %{"provider" => provider_str, "value" => value}, socket) do
     provider = String.to_existing_atom(provider_str)
-    value = String.trim(value || "")
 
-    if value == "" do
-      {:noreply, put_inference_message(socket, provider, :error, "Paste a value before saving.")}
-    else
-      case Validator.validate(provider, value) do
-        :ok ->
-          case persist_credential(socket, provider, value) do
-            {:ok, _} ->
-              {:noreply,
-               socket
-               |> assign(
-                 :inference_status,
-                 InferenceCredentials.status_for_user(socket.assigns.user_id)
-               )
-               |> put_inference_message(provider, :info, "Saved and validated.")}
+    case FountainWeb.InferenceCredentialSave.save(socket, provider, value) do
+      {:ok, msg} ->
+        {:noreply,
+         socket
+         |> assign(
+           :inference_status,
+           InferenceCredentials.status_for_user(socket.assigns.user_id)
+         )
+         |> put_inference_message(provider, :info, msg)}
 
-            {:error, reason} ->
-              {:noreply,
-               put_inference_message(
-                 socket,
-                 provider,
-                 :error,
-                 "Could not save: #{inspect(reason)}"
-               )}
-          end
-
-        {:error, :invalid, %{status: status}} ->
-          {:noreply,
-           put_inference_message(
-             socket,
-             provider,
-             :error,
-             "Provider rejected the credential (HTTP #{status}). Check that you copied the full token."
-           )}
-
-        {:error, :timeout} ->
-          {:noreply,
-           put_inference_message(socket, provider, :error, "Validation timed out. Try again.")}
-
-        {:error, reason} ->
-          {:noreply,
-           put_inference_message(
-             socket,
-             provider,
-             :error,
-             "Could not reach provider (#{inspect(reason)})."
-           )}
-      end
+      {:error, msg} ->
+        {:noreply, put_inference_message(socket, provider, :error, msg)}
     end
+  end
+
+  def handle_event("show_all_providers", _params, socket) do
+    {:noreply, assign(socket, :show_all_providers, true)}
   end
 
   def handle_event("continue_from_inference", _params, socket) do
@@ -183,24 +151,6 @@ defmodule FountainWeb.OnboardingLive.Wizard do
     {:noreply, socket |> assign(:user, user) |> push_navigate(to: ~p"/onboarding/#{next_step}")}
   end
 
-  # Takes the socket rather than a bare user_id so the credential save made
-  # during onboarding is attributed like every other one. This was the surface
-  # #546 found unaudited: the same context function, reached through a third
-  # door that nobody had added a recording call to.
-  defp persist_credential(socket, provider, value) do
-    user_id = socket.assigns.user_id
-
-    with {:ok, dek} <- Crypto.load_tenant_key(user_id) do
-      InferenceCredentials.put_credential(
-        user_id,
-        dek,
-        provider,
-        value,
-        FountainWeb.Audited.attribution(socket)
-      )
-    end
-  end
-
   defp put_inference_message(socket, provider, kind, msg) do
     update(socket, :inference_messages, fn map -> Map.put(map, provider, {kind, msg}) end)
   end
@@ -232,6 +182,7 @@ defmodule FountainWeb.OnboardingLive.Wizard do
             <% "step_1" -> %>
               <.step_inference
                 providers={@inference_providers}
+                show_all={@show_all_providers}
                 status={@inference_status}
                 messages={@inference_messages}
                 any_set?={Enum.any?(@inference_status, fn {_, set?} -> set? end)}
@@ -306,23 +257,41 @@ defmodule FountainWeb.OnboardingLive.Wizard do
   end
 
   attr :providers, :list, required: true
+  attr :show_all, :boolean, required: true
   attr :status, :map, required: true
   attr :messages, :map, required: true
   attr :any_set?, :boolean, required: true
 
+  # Anthropic first (#841): one key is all a Claude teammate needs, and every
+  # other provider is asked for the first time a model actually needs it —
+  # the agent form prompts inline. The rest stay one click away here for
+  # people who arrive with an OpenAI or Gemini key, or a Claude OAuth token.
   defp step_inference(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :visible_providers,
+        if(assigns.show_all,
+          do: assigns.providers,
+          else:
+            Enum.filter(assigns.providers, fn {p, _, _} ->
+              p == :anthropic_api_key or Map.get(assigns.status, p, false)
+            end)
+        )
+      )
+
     ~H"""
     <div class="space-y-5">
       <div>
-        <h2 class="text-lg font-semibold">Step 1: Connect a provider</h2>
+        <h2 class="text-lg font-semibold">Step 1: Connect Anthropic</h2>
         <p class="mt-1 text-sm text-zinc-500">
-          Bring your own inference token. Sandboxes call providers directly with these — Fountain never sees your traffic and you pay providers directly. Set at least one to continue. You can add or change these anytime from Settings.
+          Paste an Anthropic API key — that is all a Claude agent needs. Sandboxes call the provider directly with it; Fountain never sees your traffic and you pay the provider. Other providers are asked for the first time an agent needs them, and you can add or change any of them from Settings.
         </p>
       </div>
 
       <div class="space-y-3">
         <div
-          :for={{provider, label, source} <- @providers}
+          :for={{provider, label, source} <- @visible_providers}
           class="rounded-md border border-zinc-200 p-3 space-y-2"
         >
           <div class="flex items-center justify-between">
@@ -367,6 +336,15 @@ defmodule FountainWeb.OnboardingLive.Wizard do
           <% end %>
         </div>
       </div>
+
+      <button
+        :if={!@show_all}
+        type="button"
+        phx-click="show_all_providers"
+        class="text-sm text-zinc-600 underline underline-offset-2 hover:text-zinc-900"
+      >
+        Using a Claude OAuth token, OpenAI or Gemini instead?
+      </button>
 
       <button
         phx-click="continue_from_inference"

--- a/apps/fountain/test/fountain/inference_credentials_test.exs
+++ b/apps/fountain/test/fountain/inference_credentials_test.exs
@@ -24,6 +24,39 @@ defmodule Fountain.InferenceCredentialsTest do
     end
   end
 
+  describe "credentials_for_provider/1 and missing_for_model/2" do
+    test "names the credentials a model's provider accepts" do
+      assert InferenceCredentials.credentials_for_provider("anthropic") ==
+               [:anthropic_api_key, :claude_code_oauth_token]
+
+      assert InferenceCredentials.credentials_for_provider("openai") == [:openai_api_key]
+      assert InferenceCredentials.credentials_for_provider("google") == [:gemini_api_key]
+      assert InferenceCredentials.credentials_for_provider("ollama") == []
+      assert InferenceCredentials.credentials_for_provider(nil) == []
+    end
+
+    test "missing until any accepted credential is set; unknown providers need none", %{
+      user: user,
+      dek: dek
+    } do
+      assert InferenceCredentials.missing_for_model(user.id, "anthropic/claude-sonnet-5") ==
+               {"anthropic", [:anthropic_api_key, :claude_code_oauth_token]}
+
+      assert InferenceCredentials.missing_for_model(user.id, "openai/gpt-5") ==
+               {"openai", [:openai_api_key]}
+
+      assert InferenceCredentials.missing_for_model(user.id, "ollama/llama3") == nil
+      assert InferenceCredentials.missing_for_model(user.id, nil) == nil
+
+      # the OAuth token counts for Anthropic models too
+      {:ok, _} =
+        InferenceCredentials.put_credential(user.id, dek, :claude_code_oauth_token, "sk-ant-oat")
+
+      assert InferenceCredentials.missing_for_model(user.id, "anthropic/claude-sonnet-5") == nil
+      assert InferenceCredentials.missing_for_model(user.id, "openai/gpt-5") != nil
+    end
+  end
+
   describe "get_for_user/1" do
     test "returns nil for a user with no credentials", %{user: user} do
       assert nil == InferenceCredentials.get_for_user(user.id)

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -73,6 +73,59 @@ defmodule FountainWeb.AgentsLive.IndexTest do
       assert path =~ "/auth/login"
     end
 
+    # Onboarding asks for Anthropic only; the first model that needs another
+    # provider is where its key is collected.
+    test "prompts for the provider's key when the chosen model has none on the account", %{
+      conn: conn
+    } do
+      user = insert_verified_user()
+      {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+
+      {:ok, _} =
+        Fountain.InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, "sk-ant")
+
+      conn = login_user(conn, user)
+
+      {:ok, view, html} = live(conn, ~p"/agents/new")
+      # default model is Anthropic → nothing to ask
+      refute html =~ "No OpenAI API key"
+      refute html =~ "credential on this account yet"
+
+      html =
+        view
+        |> element("form[phx-change=validate]")
+        |> render_change(%{
+          "agent" => %{"name" => "x", "runtime" => "codex", "model" => "openai/gpt-5"}
+        })
+
+      assert html =~ "No OpenAI credential on this account yet"
+      assert html =~ ~s(value="openai_api_key")
+
+      # back to an Anthropic model: the card goes away
+      html =
+        view
+        |> element("form[phx-change=validate]")
+        |> render_change(%{
+          "agent" => %{
+            "name" => "x",
+            "runtime" => "claude",
+            "model" => "anthropic/claude-sonnet-5"
+          }
+        })
+
+      refute html =~ "credential on this account yet"
+
+      # a model from a provider Fountain doesn't know needs nothing
+      html =
+        view
+        |> element("form[phx-change=validate]")
+        |> render_change(%{
+          "agent" => %{"name" => "x", "runtime" => "opencode", "model" => "ollama/llama3"}
+        })
+
+      refute html =~ "credential on this account yet"
+    end
+
     # #554: the model field was a bare text input, so nothing in the UI said
     # what a valid value looked like until the sprite failed at spawn time.
     test "model field offers the curated models for the selected runtime", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/live/onboarding_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/onboarding_live_test.exs
@@ -20,7 +20,7 @@ defmodule FountainWeb.OnboardingLiveTest do
 
       {:ok, _lv, html} = live(conn, ~p"/onboarding/step_1")
       assert html =~ "Step 1"
-      assert html =~ "Connect a provider"
+      assert html =~ "Connect Anthropic"
     end
 
     test "unauthenticated user is redirected to login", %{conn: conn} do
@@ -74,12 +74,34 @@ defmodule FountainWeb.OnboardingLiveTest do
       %{lv: lv, user: user}
     end
 
-    test "renders all four provider forms", %{lv: lv} do
+    test "asks for Anthropic first; the other providers are one click away", %{lv: lv} do
       html = render(lv)
-      assert html =~ "Anthropic"
-      assert html =~ "Claude OAuth"
-      assert html =~ "OpenAI"
-      assert html =~ "Gemini"
+      assert html =~ "Connect Anthropic"
+      assert html =~ ~s(value="anthropic_api_key")
+      refute html =~ ~s(value="openai_api_key")
+      refute html =~ ~s(value="gemini_api_key")
+      refute html =~ ~s(value="claude_code_oauth_token")
+
+      html =
+        lv
+        |> element("button", "Using a Claude OAuth token, OpenAI or Gemini instead?")
+        |> render_click()
+
+      assert html =~ ~s(value="claude_code_oauth_token")
+      assert html =~ ~s(value="openai_api_key")
+      assert html =~ ~s(value="gemini_api_key")
+    end
+
+    test "a provider already set shows even before the disclosure", %{user: user} do
+      {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+
+      {:ok, _} =
+        Fountain.InferenceCredentials.put_credential(user.id, dek, :openai_api_key, "sk-test")
+
+      conn = login_user(Phoenix.ConnTest.build_conn(), user)
+      {:ok, _lv, html} = live(conn, ~p"/onboarding/step_1")
+      assert html =~ ~s(value="openai_api_key")
+      refute html =~ ~s(value="gemini_api_key")
     end
 
     test "Continue is disabled until at least one provider is set", %{lv: lv} do


### PR DESCRIPTION
Closes #841.

## What

- **Onboarding step 1 asks for Anthropic only** — "Connect Anthropic", one key; "Using a Claude OAuth token, OpenAI or Gemini instead?" reveals the rest, and a provider already set stays visible. Gate unchanged (any one credential continues).
- **Just-in-time collection elsewhere**: `InferenceCredentials.credentials_for_provider/1` + `missing_for_model/2`; the **agent form** shows an inline card when the chosen model's provider has no credential on the account ("No OpenAI credential on this account yet … paste it here"), validates + saves in place, and disappears when the model changes back or the key lands. Unknown providers ask for nothing.
- `FountainWeb.InferenceCredentialSave` — the one validate-then-persist-with-attribution path for LiveViews collecting a key (onboarding refactored onto it; the agent form is the second caller).

## Testing

Context, wizard and agent-form tests added (see commit); `mix test` on the three files: 62 tests, 0 failures. `mix format` clean.

Client side: jhgaylor/fountain-team's brain picker already marks providers without a key; a follow-up will collect the key inline there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)