### PR TITLE
feat(support): POST /api/support/reports — "Report a problem" with context, forwarded to the operator (#843)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,10 @@ EMAIL_FROM=noreply@fountain.example.com
 # Optional: where "contact support" in account emails (suspension, deletion)
 # points. Unset, the emails say "contact support" with no address.
 # SUPPORT_EMAIL=support@example.com
+# Where "Report a problem" reports are forwarded besides SUPPORT_EMAIL: a
+# GitHub issue in this repo, created with this token (issues:write). Optional.
+# SUPPORT_GITHUB_REPO=owner/repo
+# SUPPORT_GITHUB_TOKEN=
 
 # ── Authentication ───────────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain/support.ex
+++ b/apps/fountain/lib/fountain/support.ex
@@ -1,0 +1,140 @@
+defmodule Fountain.Support do
+  @moduledoc """
+  Problem reports from users, filed from a client with the context the client
+  had (#843). The report is stored, audited, and forwarded to the operator
+  out of band — email to `SUPPORT_EMAIL`, a GitHub issue when
+  `SUPPORT_GITHUB_REPO` + `SUPPORT_GITHUB_TOKEN` are set — by
+  `Fountain.Workers.SupportForward`, so a slow or broken forwarder never
+  fails the user's request.
+
+  Tenant-scoped like everything else: a user sees only their own reports.
+  The screenshot is bytes on the row (5 MB max), never in the audit trail
+  or the forwarded mail body beyond "attached".
+  """
+  import Ecto.Query
+
+  alias Fountain.{Audit, Repo}
+  alias Fountain.Support.Report
+
+  @doc """
+  File a report. `attrs` is the API body: `category`, `message`, optional
+  `context` (map), `client` (a client name/version), `screenshot`
+  (`%{"data" => base64, "media_type" => ...}`). Audited as
+  `support.report.created` (category, client, context keys, sizes — never
+  the message). Enqueues the forwarder.
+  """
+  @spec create_report(binary(), map(), keyword()) :: {:ok, Report.t()} | {:error, term()}
+  def create_report(user_id, attrs, opts \\ []) when is_binary(user_id) and is_map(attrs) do
+    with {:ok, shot} <- decode_screenshot(attrs["screenshot"]) do
+      attrs =
+        attrs
+        |> Map.take(["category", "message", "context", "client"])
+        |> Map.put("user_id", user_id)
+        |> Map.merge(shot)
+
+      %Report{}
+      |> Report.changeset(attrs)
+      |> Repo.insert()
+      |> case do
+        {:ok, report} ->
+          record("support.report.created", report, opts, describe(report))
+          enqueue_forward(report)
+          {:ok, report}
+
+        {:error, _} = err ->
+          err
+      end
+    end
+  end
+
+  @doc "The caller's reports, newest first."
+  @spec list_reports(binary()) :: [Report.t()]
+  def list_reports(user_id) when is_binary(user_id) do
+    Repo.all(from(r in Report, where: r.user_id == ^user_id, order_by: [desc: r.inserted_at]))
+  end
+
+  @spec get_report(binary(), binary()) :: Report.t() | nil
+  def get_report(id, user_id) when is_binary(id) and is_binary(user_id) do
+    Repo.get_by(Report, id: id, user_id: user_id)
+  end
+
+  @doc false
+  def _unsafe_get_report(id) when is_binary(id), do: Repo.get(Report, id)
+
+  @doc false
+  def mark_forwarded(%Report{} = report, attrs) do
+    report |> Report.forward_changeset(attrs) |> Repo.update()
+  end
+
+  @doc "Where reports go: the configured targets, for the forwarder and the docs."
+  @spec targets() :: %{email: String.t() | nil, github: {String.t(), String.t()} | nil}
+  def targets do
+    email =
+      case Application.get_env(:fountain, :support_email) do
+        e when is_binary(e) and e != "" -> e
+        _ -> nil
+      end
+
+    github =
+      case {Application.get_env(:fountain, :support_github_repo),
+            Application.get_env(:fountain, :support_github_token)} do
+        {repo, token} when is_binary(repo) and repo != "" and is_binary(token) and token != "" ->
+          {repo, token}
+
+        _ ->
+          nil
+      end
+
+    %{email: email, github: github}
+  end
+
+  defp enqueue_forward(%Report{id: id}) do
+    %{"report_id" => id}
+    |> Fountain.Workers.SupportForward.new()
+    |> Oban.insert()
+    |> case do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        require Logger
+        Logger.warning("support report #{id}: could not enqueue forward: #{inspect(reason)}")
+    end
+  end
+
+  defp decode_screenshot(nil), do: {:ok, %{}}
+
+  defp decode_screenshot(%{} = shot) do
+    case FountainWeb.PromptImages.decode([shot]) do
+      {:ok, [%{media_type: mt, data: data}]} ->
+        {:ok, %{"screenshot" => data, "screenshot_media_type" => mt}}
+
+      {:error, msg} ->
+        {:error, {:screenshot, msg}}
+    end
+  end
+
+  defp decode_screenshot(_), do: {:error, {:screenshot, "screenshot must be an object"}}
+
+  defp describe(%Report{} = r) do
+    %{
+      "category" => r.category,
+      "client" => r.client,
+      "message_bytes" => byte_size(r.message || ""),
+      "context_keys" => r.context |> Map.keys() |> Enum.sort(),
+      "screenshot" => is_binary(r.screenshot)
+    }
+  end
+
+  defp record(action, %Report{} = report, opts, metadata) do
+    Audit.record(%{
+      user_id: report.user_id,
+      action: action,
+      resource_type: "support_report",
+      resource_id: report.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: metadata
+    })
+  end
+end

--- a/apps/fountain/lib/fountain/support/report.ex
+++ b/apps/fountain/lib/fountain/support/report.ex
@@ -1,0 +1,105 @@
+defmodule Fountain.Support.Report do
+  @moduledoc """
+  A problem report a user filed from a client — the "Report a problem" button
+  in fountain-team, or `POST /api/support/reports` from anything else. Carries
+  what the client knew at the time (conversation, agent, sandbox, presence,
+  recent events, app version) so triage starts with the facts, and an optional
+  screenshot. Forwarded to the operator by `Fountain.Workers.SupportForward`.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @categories ~w(bug stuck question idea other)
+  @statuses ~w(new forwarded failed)
+  @max_message 20_000
+  @max_context_bytes 64 * 1024
+  @max_screenshot 5 * 1024 * 1024
+  @image_types ~w(image/png image/jpeg image/gif image/webp)
+
+  schema "support_reports" do
+    belongs_to :user, Fountain.Accounts.User
+    field :category, :string
+    field :message, :string
+    field :context, :map, default: %{}
+    field :client, :string
+    field :screenshot, :binary, redact: true
+    field :screenshot_media_type, :string
+    field :status, :string, default: "new"
+    field :forwarded_at, :utc_datetime
+    field :external_url, :string
+    field :forward_error, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def categories, do: @categories
+
+  def changeset(report, attrs) do
+    report
+    |> cast(attrs, [
+      :user_id,
+      :category,
+      :message,
+      :context,
+      :client,
+      :screenshot,
+      :screenshot_media_type
+    ])
+    |> update_change(:message, &String.trim/1)
+    |> validate_required([:user_id, :category, :message])
+    |> validate_inclusion(:category, @categories)
+    |> validate_length(:message, min: 1, max: @max_message)
+    |> validate_length(:client, max: 200)
+    |> validate_context()
+    |> validate_screenshot()
+  end
+
+  def forward_changeset(report, attrs) do
+    report
+    |> cast(attrs, [:status, :forwarded_at, :external_url, :forward_error])
+    |> validate_inclusion(:status, @statuses)
+  end
+
+  defp validate_context(cs) do
+    case get_change(cs, :context) do
+      nil ->
+        cs
+
+      ctx when is_map(ctx) ->
+        if byte_size(Jason.encode!(ctx)) > @max_context_bytes,
+          do: add_error(cs, :context, "is too large (64 KB max)"),
+          else: cs
+
+      _ ->
+        add_error(cs, :context, "must be an object")
+    end
+  end
+
+  defp validate_screenshot(cs) do
+    case {get_field(cs, :screenshot), get_field(cs, :screenshot_media_type)} do
+      {nil, _} ->
+        put_change(cs, :screenshot_media_type, nil)
+
+      {bin, mt} when is_binary(bin) ->
+        cs
+        |> then(fn c ->
+          if byte_size(bin) > @max_screenshot,
+            do: add_error(c, :screenshot, "exceeds the 5 MB limit"),
+            else: c
+        end)
+        |> then(fn c ->
+          if mt in @image_types,
+            do: c,
+            else:
+              add_error(
+                c,
+                :screenshot_media_type,
+                "must be one of #{Enum.join(@image_types, ", ")}"
+              )
+        end)
+    end
+  end
+end

--- a/apps/fountain/lib/fountain/support/report.ex
+++ b/apps/fountain/lib/fountain/support/report.ex
@@ -19,6 +19,8 @@ defmodule Fountain.Support.Report do
   @max_screenshot 5 * 1024 * 1024
   @image_types ~w(image/png image/jpeg image/gif image/webp)
 
+  @type t :: %__MODULE__{}
+
   schema "support_reports" do
     belongs_to :user, Fountain.Accounts.User
     field :category, :string

--- a/apps/fountain/lib/fountain/support/report.ex
+++ b/apps/fountain/lib/fountain/support/report.ex
@@ -38,6 +38,7 @@ defmodule Fountain.Support.Report do
   end
 
   def categories, do: @categories
+  def statuses, do: @statuses
 
   def changeset(report, attrs) do
     report

--- a/apps/fountain/lib/fountain/workers/support_forward.ex
+++ b/apps/fountain/lib/fountain/workers/support_forward.ex
@@ -1,0 +1,168 @@
+defmodule Fountain.Workers.SupportForward do
+  @moduledoc """
+  Deliver one support report to the operator: a GitHub issue when
+  `SUPPORT_GITHUB_REPO` + `SUPPORT_GITHUB_TOKEN` are configured, and/or an
+  email to `SUPPORT_EMAIL`. Either target succeeding marks the report
+  `forwarded` (with the issue URL when there is one); neither configured is
+  not an error — the report is still on the row for `GET /api/support/reports`
+  and the admin to read — and the job completes. A transport failure retries
+  (three attempts), then the row carries `forward_error`.
+  """
+  use Oban.Worker, queue: :mailer, max_attempts: 3, unique: [keys: [:report_id], period: 3600]
+
+  require Logger
+  import Swoosh.Email
+
+  alias Fountain.{Accounts, Mailer, Support}
+  alias Fountain.Support.Report
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"report_id" => id}}) do
+    case Support._unsafe_get_report(id) do
+      nil ->
+        :ok
+
+      %Report{status: "forwarded"} ->
+        :ok
+
+      %Report{} = report ->
+        targets = Support.targets()
+        user = report.user_id && Accounts.get_user(report.user_id)
+
+        results = [
+          targets.github && github(report, user, targets.github),
+          targets.email && email(report, user, targets.email)
+        ]
+
+        outcomes = Enum.reject(results, &is_nil/1)
+
+        url =
+          Enum.find_value(outcomes, fn
+            {:ok, u} -> u
+            _ -> nil
+          end)
+
+        errors = for {:error, e} <- outcomes, do: e
+
+        cond do
+          outcomes == [] ->
+            # nothing configured: the row is the inbox
+            {:ok, _} = Support.mark_forwarded(report, %{status: "forwarded", forwarded_at: now()})
+            :ok
+
+          Enum.any?(outcomes, &match?({:ok, _}, &1)) ->
+            {:ok, _} =
+              Support.mark_forwarded(report, %{
+                status: "forwarded",
+                forwarded_at: now(),
+                external_url: url,
+                forward_error: if(errors == [], do: nil, else: Enum.join(errors, "; "))
+              })
+
+            :ok
+
+          true ->
+            msg = Enum.join(errors, "; ")
+            {:ok, _} = Support.mark_forwarded(report, %{status: "failed", forward_error: msg})
+            {:error, msg}
+        end
+    end
+  end
+
+  # ── targets ───────────────────────────────────────────────────────────────
+
+  @doc false
+  def github(%Report{} = r, user, {repo, token}, request \\ &Req.post/2) do
+    title = "[#{r.category}] #{first_line(r.message)}"
+    body = issue_body(r, user)
+
+    case request.("https://api.github.com/repos/#{repo}/issues",
+           json: %{title: title, body: body, labels: ["support", r.category]},
+           headers: [
+             {"authorization", "Bearer #{token}"},
+             {"accept", "application/vnd.github+json"},
+             {"x-github-api-version", "2022-11-28"}
+           ],
+           receive_timeout: 15_000
+         ) do
+      {:ok, %Req.Response{status: 201, body: %{"html_url" => url}}} -> {:ok, url}
+      {:ok, %Req.Response{status: status}} -> {:error, "github #{status}"}
+      {:error, reason} -> {:error, "github: #{inspect(reason)}"}
+    end
+  rescue
+    e -> {:error, "github: #{Exception.message(e)}"}
+  end
+
+  @doc false
+  def email(%Report{} = r, user, to) do
+    mail =
+      new()
+      |> from(Fountain.Emails.UserEmails.from_address())
+      |> to(to)
+      |> subject("[Fountain support] [#{r.category}] #{first_line(r.message)}")
+      |> text_body(issue_body(r, user))
+      |> maybe_attach(r)
+
+    case Mailer.deliver(mail) do
+      {:ok, _} -> {:ok, nil}
+      {:error, reason} -> {:error, "email: #{inspect(reason)}"}
+    end
+  end
+
+  defp maybe_attach(mail, %Report{screenshot: bin, screenshot_media_type: mt})
+       when is_binary(bin) do
+    ext = mt |> String.split("/") |> List.last()
+
+    attachment(
+      mail,
+      Swoosh.Attachment.new({:data, bin}, filename: "screenshot.#{ext}", content_type: mt)
+    )
+  end
+
+  defp maybe_attach(mail, _), do: mail
+
+  @doc false
+  def issue_body(%Report{} = r, user) do
+    base = Fountain.PublicUrl.base()
+    who = if user, do: "#{user.email} (`#{user.id}`)", else: "(account deleted)"
+    ctx = r.context || %{}
+
+    """
+    **From:** #{who}
+    **Client:** #{r.client || "—"} · **Filed:** #{r.inserted_at} · **Report:** `#{r.id}`
+    **Category:** #{r.category}
+
+    #{r.message}
+
+    ---
+    #{context_lines(ctx, base)}
+    <details><summary>Full context</summary>
+
+    ```json
+    #{Jason.encode!(ctx, pretty: true)}
+    ```
+    </details>
+    #{if is_binary(r.screenshot), do: "\nScreenshot: attached to the report (#{r.screenshot_media_type}).", else: ""}
+    """
+  end
+
+  defp context_lines(ctx, base) do
+    [
+      ctx["conversation_id"] &&
+        "**Conversation:** #{base}/conversations/#{ctx["conversation_id"]} (`#{ctx["conversation_id"]}`)",
+      ctx["agent_id"] &&
+        "**Agent:** #{ctx["agent_name"] || ""} `#{ctx["agent_id"]}` · #{ctx["runtime"] || ""} #{ctx["model"] || ""}",
+      ctx["sandbox"] && "**Sandbox:** `#{inspect(ctx["sandbox"])}`",
+      ctx["presence"] && "**Presence:** #{inspect(ctx["presence"])}",
+      ctx["url"] && "**Page:** #{ctx["url"]}"
+    ]
+    |> Enum.reject(&(&1 in [nil, false]))
+    |> Enum.join("\n")
+  end
+
+  defp first_line(message) do
+    message |> String.split("\n", parts: 2) |> hd() |> String.slice(0, 90)
+  end
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+end

--- a/apps/fountain/lib/fountain_web/controllers/support_report_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/support_report_controller.ex
@@ -1,0 +1,70 @@
+defmodule FountainWeb.SupportReportController do
+  @moduledoc """
+  Problem reports over the API (#843): what the "Report a problem" button in a
+  client files. The report is stored with the context the client had and
+  forwarded to the operator out of band; the caller gets an id to quote.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Support
+  alias FountainWeb.{Audited, Schemas}
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Support"])
+
+  operation(:create,
+    summary: "File a problem report",
+    description:
+      "Stores the report with whatever `context` the client attaches (conversation, " <>
+        "agent, sandbox, presence, recent events, app version — the facts triage needs; " <>
+        "never secrets) and forwards it to the operator: a GitHub issue when the instance " <>
+        "configures `SUPPORT_GITHUB_REPO`, and/or mail to `SUPPORT_EMAIL`. Forwarding is " <>
+        "asynchronous; `status` is `new` until it lands. Audited as `support.report.created` " <>
+        "(category, sizes and context keys — not the message).",
+    request_body: {"Report", "application/json", Schemas.SupportReportCreateRequest},
+    responses: [
+      created: {"Report", "application/json", Schemas.SupportReportResponse},
+      unprocessable_entity: {"Validation errors", "application/json", Schemas.Error}
+    ]
+  )
+
+  def create(conn, params) do
+    user = conn.assigns.current_user
+
+    with {:ok, report} <- Support.create_report(user.id, params, Audited.attribution(conn)) do
+      conn
+      |> put_status(:created)
+      |> render(:show, report: report)
+    end
+  end
+
+  operation(:index,
+    summary: "List the caller's reports",
+    description: "Newest first, with forwarding status and the issue URL when one was created.",
+    responses: [ok: {"Reports", "application/json", Schemas.SupportReportListResponse}]
+  )
+
+  def index(conn, _params) do
+    render(conn, :index, reports: Support.list_reports(conn.assigns.current_user.id))
+  end
+
+  operation(:show,
+    summary: "Show one report",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Report", "application/json", Schemas.SupportReportResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"id" => id}) do
+    case Support.get_report(id, conn.assigns.current_user.id) do
+      nil -> {:error, :not_found}
+      report -> render(conn, :show, report: report)
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/support_report_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/support_report_json.ex
@@ -1,0 +1,26 @@
+defmodule FountainWeb.SupportReportJSON do
+  @moduledoc false
+
+  alias Fountain.Support.Report
+
+  def index(%{reports: reports}), do: %{data: Enum.map(reports, &data/1)}
+  def show(%{report: report}), do: %{data: data(report)}
+
+  @doc "One report; the screenshot is reported by presence and type, never inlined."
+  def data(%Report{} = r) do
+    %{
+      id: r.id,
+      category: r.category,
+      message: r.message,
+      context: r.context,
+      client: r.client,
+      has_screenshot: is_binary(r.screenshot),
+      screenshot_media_type: r.screenshot_media_type,
+      status: r.status,
+      forwarded_at: r.forwarded_at,
+      external_url: r.external_url,
+      forward_error: r.forward_error,
+      inserted_at: r.inserted_at
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -391,6 +391,11 @@ defmodule FountainWeb.Router do
     delete "/team/:agent_id/schedules/:id", TeamScheduleController, :delete
     post "/team/:agent_id/schedules/:id/run", TeamScheduleController, :run
 
+    # Problem reports (#843): "Report a problem" from a client; forwarded to the operator.
+    post "/support/reports", SupportReportController, :create
+    get "/support/reports", SupportReportController, :index
+    get "/support/reports/:id", SupportReportController, :show
+
     resources "/conversations", ConversationController, only: [:index, :show, :create, :delete] do
       post "/prompts", ConversationController, :prompt, as: :prompt
       post "/interrupt", ConversationController, :interrupt, as: :interrupt

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1966,6 +1966,102 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule SupportReport do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SupportReport",
+      description:
+        "A problem report a client filed, with the context it had and where it was forwarded.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        category: %Schema{type: :string, enum: ["bug", "stuck", "question", "idea", "other"]},
+        message: %Schema{type: :string},
+        context: %Schema{type: :object, additionalProperties: true},
+        client: %Schema{type: :string, nullable: true},
+        has_screenshot: %Schema{type: :boolean},
+        screenshot_media_type: %Schema{type: :string, nullable: true},
+        status: %Schema{type: :string, enum: ["new", "forwarded", "failed"]},
+        forwarded_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        external_url: %Schema{
+          type: :string,
+          nullable: true,
+          description: "The GitHub issue, when one was created."
+        },
+        forward_error: %Schema{type: :string, nullable: true},
+        inserted_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :category, :message, :status, :inserted_at]
+    })
+  end
+
+  defmodule SupportReportResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SupportReportResponse",
+      type: :object,
+      properties: %{data: SupportReport},
+      required: [:data]
+    })
+  end
+
+  defmodule SupportReportListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SupportReportListResponse",
+      type: :object,
+      properties: %{data: %Schema{type: :array, items: SupportReport}},
+      required: [:data]
+    })
+  end
+
+  defmodule SupportReportCreateRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SupportReportCreateRequest",
+      type: :object,
+      properties: %{
+        category: %Schema{type: :string, enum: ["bug", "stuck", "question", "idea", "other"]},
+        message: %Schema{type: :string, minLength: 1, maxLength: 20_000},
+        context: %Schema{
+          type: :object,
+          additionalProperties: true,
+          description:
+            "What the client knew: conversation_id, agent_id/agent_name/runtime/model, sandbox, " <>
+              "presence, recent events, url, app version. 64 KB max. Never secrets.",
+          nullable: true
+        },
+        client: %Schema{
+          type: :string,
+          maxLength: 200,
+          nullable: true,
+          example: "fountain-team 2026-08-19 a1db945"
+        },
+        screenshot: %Schema{
+          type: :object,
+          nullable: true,
+          properties: %{
+            data: %Schema{type: :string, description: "base64"},
+            media_type: %Schema{
+              type: :string,
+              enum: ["image/png", "image/jpeg", "image/gif", "image/webp"]
+            }
+          },
+          required: [:data, :media_type]
+        }
+      },
+      required: [:category, :message]
+    })
+  end
+
   defmodule SearchHit do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1977,13 +1977,13 @@ defmodule FountainWeb.Schemas do
       type: :object,
       properties: %{
         id: %Schema{type: :string, format: :uuid},
-        category: %Schema{type: :string, enum: ["bug", "stuck", "question", "idea", "other"]},
+        category: %Schema{type: :string, enum: Fountain.Support.Report.categories()},
         message: %Schema{type: :string},
         context: %Schema{type: :object, additionalProperties: true},
         client: %Schema{type: :string, nullable: true},
         has_screenshot: %Schema{type: :boolean},
         screenshot_media_type: %Schema{type: :string, nullable: true},
-        status: %Schema{type: :string, enum: ["new", "forwarded", "failed"]},
+        status: %Schema{type: :string, enum: Fountain.Support.Report.statuses()},
         forwarded_at: %Schema{type: :string, format: :"date-time", nullable: true},
         external_url: %Schema{
           type: :string,
@@ -1997,29 +1997,8 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule SupportReportResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "SupportReportResponse",
-      type: :object,
-      properties: %{data: SupportReport},
-      required: [:data]
-    })
-  end
-
-  defmodule SupportReportListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "SupportReportListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: SupportReport}},
-      required: [:data]
-    })
-  end
+  item_response(SupportReportResponse, of: SupportReport)
+  list_response(SupportReportListResponse, of: SupportReport)
 
   defmodule SupportReportCreateRequest do
     @moduledoc false
@@ -2029,7 +2008,7 @@ defmodule FountainWeb.Schemas do
       title: "SupportReportCreateRequest",
       type: :object,
       properties: %{
-        category: %Schema{type: :string, enum: ["bug", "stuck", "question", "idea", "other"]},
+        category: %Schema{type: :string, enum: Fountain.Support.Report.categories()},
         message: %Schema{type: :string, minLength: 1, maxLength: 20_000},
         context: %Schema{
           type: :object,

--- a/apps/fountain/priv/repo/migrations/20260819130000_create_support_reports.exs
+++ b/apps/fountain/priv/repo/migrations/20260819130000_create_support_reports.exs
@@ -1,0 +1,27 @@
+defmodule Fountain.Repo.Migrations.CreateSupportReports do
+  use Ecto.Migration
+
+  def change do
+    create table(:support_reports, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+      add :category, :string, null: false
+      add :message, :text, null: false
+      # what the client knew when the report was filed: conversation, agent,
+      # sandbox, presence, last events, app version, URL — never secrets
+      add :context, :map, null: false, default: %{}
+      add :client, :string
+      add :screenshot, :binary
+      add :screenshot_media_type, :string
+      add :status, :string, null: false, default: "new"
+      add :forwarded_at, :utc_datetime
+      add :external_url, :string
+      add :forward_error, :text
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:support_reports, [:user_id])
+    create index(:support_reports, [:status, :inserted_at])
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -76,6 +76,7 @@ defmodule Fountain.AuditGuardrailTest do
     {"team schedule update", &__MODULE__.do_schedule_update/1, "team.schedule.updated"},
     {"team schedule delete", &__MODULE__.do_schedule_delete/1, "team.schedule.deleted"},
     {"team schedule run", &__MODULE__.do_schedule_run/1, "team.schedule.fired"},
+    {"support report create", &__MODULE__.do_support_create/1, "support.report.created"},
     {"runner register", &__MODULE__.do_runner_register/1, "runner.registered"},
     {"runner delete", &__MODULE__.do_runner_delete/1, "runner.deleted"}
   ]
@@ -308,6 +309,15 @@ defmodule Fountain.AuditGuardrailTest do
 
     s
   end
+
+  def do_support_create(user),
+    do:
+      {:ok, _} =
+        Fountain.Support.create_report(user.id, %{
+          "category" => "bug",
+          "message" => "it broke",
+          "context" => %{"conversation_id" => "x"}
+        })
 
   def do_schedule_create(user), do: insert_schedule(user)
 

--- a/apps/fountain/test/fountain/support_test.exs
+++ b/apps/fountain/test/fountain/support_test.exs
@@ -1,0 +1,143 @@
+defmodule Fountain.SupportTest do
+  use Fountain.DataCase, async: true
+  import Swoosh.TestAssertions
+
+  alias Fountain.Support
+  alias Fountain.Support.Report
+  alias Fountain.Workers.SupportForward
+
+  setup do
+    %{user: insert_verified_user()}
+  end
+
+  describe "create_report/3" do
+    test "stores the report, audits keys not content, enqueues the forwarder", %{user: user} do
+      ctx = %{"conversation_id" => "c1", "agent_name" => "coo", "url" => "https://x/#/team/a"}
+
+      assert {:ok, %Report{} = r} =
+               Support.create_report(user.id, %{
+                 "category" => "stuck",
+                 "message" => "  teammate says starting forever  ",
+                 "context" => ctx,
+                 "client" => "fountain-team test"
+               })
+
+      assert r.message == "teammate says starting forever"
+      assert r.status == "new"
+      assert r.context == ctx
+      assert_enqueued(worker: SupportForward, args: %{"report_id" => r.id})
+
+      event =
+        user.id
+        |> Fountain.Audit.list_for_user()
+        |> Enum.find(&(&1.action == "support.report.created"))
+
+      assert event
+      assert event.metadata["category"] == "stuck"
+      assert event.metadata["context_keys"] == ["agent_name", "conversation_id", "url"]
+      refute Jason.encode!(event.metadata) =~ "starting forever"
+    end
+
+    test "decodes a screenshot and refuses a bad one", %{user: user} do
+      png = Base.encode64("not really a png but bytes")
+
+      assert {:ok, %Report{screenshot: bin, screenshot_media_type: "image/png"}} =
+               Support.create_report(user.id, %{
+                 "category" => "bug",
+                 "message" => "see attached",
+                 "screenshot" => %{"data" => png, "media_type" => "image/png"}
+               })
+
+      assert is_binary(bin)
+
+      assert {:error, {:screenshot, _}} =
+               Support.create_report(user.id, %{
+                 "category" => "bug",
+                 "message" => "see attached",
+                 "screenshot" => %{"data" => png, "media_type" => "image/svg+xml"}
+               })
+    end
+
+    test "validates category and message", %{user: user} do
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Support.create_report(user.id, %{"category" => "rant", "message" => ""})
+
+      assert %{category: _, message: _} = errors_on(cs)
+    end
+
+    test "reports are tenant-scoped", %{user: user} do
+      other = insert_verified_user()
+
+      {:ok, r} =
+        Support.create_report(user.id, %{"category" => "idea", "message" => "more pizza"})
+
+      assert [%Report{id: id}] = Support.list_reports(user.id)
+      assert id == r.id
+      assert Support.list_reports(other.id) == []
+      assert Support.get_report(r.id, other.id) == nil
+    end
+  end
+
+  describe "SupportForward" do
+    test "with nothing configured the report is marked forwarded (the row is the inbox)", %{
+      user: user
+    } do
+      {:ok, r} = Support.create_report(user.id, %{"category" => "bug", "message" => "x"})
+      assert :ok = perform_job(SupportForward, %{"report_id" => r.id})
+
+      assert %Report{status: "forwarded", forwarded_at: %DateTime{}} =
+               Support.get_report(r.id, user.id)
+    end
+
+    test "a GitHub target creates an issue with the context and records its URL", %{user: user} do
+      {:ok, r} =
+        Support.create_report(user.id, %{
+          "category" => "bug",
+          "message" => "first line\nmore detail",
+          "context" => %{"conversation_id" => "c1", "agent_name" => "coo", "agent_id" => "a1"}
+        })
+
+      request = fn url, opts ->
+        send(self(), {:github, url, opts})
+
+        {:ok,
+         %Req.Response{status: 201, body: %{"html_url" => "https://github.com/o/r/issues/7"}}}
+      end
+
+      assert {:ok, "https://github.com/o/r/issues/7"} =
+               SupportForward.github(r, user, {"o/r", "tok"}, request)
+
+      assert_received {:github, "https://api.github.com/repos/o/r/issues", opts}
+      assert opts[:json].title == "[bug] first line"
+      assert opts[:json].body =~ "coo"
+      assert opts[:json].body =~ "/conversations/c1"
+      assert opts[:json].body =~ user.email
+      assert {"authorization", "Bearer tok"} in opts[:headers]
+    end
+
+    test "a GitHub failure is reported, not raised", %{user: user} do
+      {:ok, r} = Support.create_report(user.id, %{"category" => "bug", "message" => "x"})
+      request = fn _url, _opts -> {:ok, %Req.Response{status: 401, body: %{}}} end
+      assert {:error, "github 401"} = SupportForward.github(r, user, {"o/r", "bad"}, request)
+    end
+
+    test "the email carries the body and the screenshot as an attachment", %{user: user} do
+      png = Base.encode64("bytes")
+
+      {:ok, r} =
+        Support.create_report(user.id, %{
+          "category" => "stuck",
+          "message" => "stuck at starting",
+          "screenshot" => %{"data" => png, "media_type" => "image/png"}
+        })
+
+      assert {:ok, nil} = SupportForward.email(r, user, "support@example.com")
+
+      assert_email_sent(fn mail ->
+        assert mail.subject =~ "[stuck] stuck at starting"
+        assert [%Swoosh.Attachment{filename: "screenshot.png"}] = mail.attachments
+        assert mail.text_body =~ user.email
+      end)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/support_report_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/support_report_controller_test.exs
@@ -1,0 +1,93 @@
+defmodule FountainWeb.SupportReportControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    {:ok, user: user, raw_key: raw_key}
+  end
+
+  describe "POST /api/support/reports" do
+    test "files a report with context and returns it", %{conn: conn, raw_key: key} do
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/support/reports", %{
+          "category" => "stuck",
+          "message" => "Koda sits at starting",
+          "context" => %{"conversation_id" => "c1", "agent_name" => "Koda"},
+          "client" => "fountain-team test"
+        })
+        |> json_response(201)
+
+      assert %{
+               "data" => %{
+                 "id" => id,
+                 "category" => "stuck",
+                 "message" => "Koda sits at starting",
+                 "context" => %{"conversation_id" => "c1"},
+                 "status" => "new",
+                 "has_screenshot" => false
+               }
+             } = body
+
+      assert %{"data" => [%{"id" => ^id}]} =
+               conn |> authed_with_key(key) |> get("/api/support/reports") |> json_response(200)
+
+      assert %{"data" => %{"id" => ^id}} =
+               conn
+               |> authed_with_key(key)
+               |> get("/api/support/reports/#{id}")
+               |> json_response(200)
+    end
+
+    test "rejects a bad category or an empty message", %{conn: conn, raw_key: key} do
+      # the OpenAPI cast rejects the enum before the context sees it
+      assert %{"errors" => [%{"source" => %{"pointer" => "/category"}}]} =
+               conn
+               |> authed_with_key(key)
+               |> post_json("/api/support/reports", %{"category" => "rant", "message" => "x"})
+               |> json_response(422)
+
+      assert %{"errors" => [%{"source" => %{"pointer" => "/message"}}]} =
+               conn
+               |> authed_with_key(key)
+               |> post_json("/api/support/reports", %{"category" => "bug", "message" => ""})
+               |> json_response(422)
+
+      # and a changeset error for what the schema cannot express (a huge context)
+      big = %{"blob" => String.duplicate("x", 70 * 1024)}
+
+      assert %{"errors" => %{"context" => [_]}} =
+               conn
+               |> authed_with_key(key)
+               |> post_json("/api/support/reports", %{
+                 "category" => "bug",
+                 "message" => "x",
+                 "context" => big
+               })
+               |> json_response(422)
+    end
+
+    test "another tenant cannot read it", %{conn: conn, raw_key: key} do
+      %{"data" => %{"id" => id}} =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/support/reports", %{"category" => "bug", "message" => "mine"})
+        |> json_response(201)
+
+      {_k, other_key} = insert_api_key(insert_verified_user())
+
+      conn
+      |> authed_with_key(other_key)
+      |> get("/api/support/reports/#{id}")
+      |> json_response(404)
+    end
+
+    test "requires auth", %{conn: conn} do
+      conn
+      |> post_json("/api/support/reports", %{"category" => "bug", "message" => "x"})
+      |> json_response(401)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -86,7 +86,13 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
       {FountainWeb.TeamPresenter, :presence_states},
     {FountainWeb.Schemas.Teammate, "preview.kind"} => {FountainWeb.TeamPresenter, :preview_kinds},
     {FountainWeb.Schemas.Block, "kind"} => {Fountain.Conversations.Blocks, :kinds},
-    {FountainWeb.Schemas.SearchHit, "kind"} => {Fountain.Search, :kinds}
+    {FountainWeb.Schemas.SearchHit, "kind"} => {Fountain.Search, :kinds},
+    {FountainWeb.Schemas.SupportReport, "category"} => {Fountain.Support.Report, :categories},
+    {FountainWeb.Schemas.SupportReport, "status"} => {Fountain.Support.Report, :statuses},
+    {FountainWeb.Schemas.SupportReportCreateRequest, "category"} =>
+      {Fountain.Support.Report, :categories},
+    {FountainWeb.Schemas.SupportReportCreateRequest, "screenshot.media_type"} =>
+      {Fountain.Images, :valid_media_types}
   }
 
   # Enums with no domain list behind them. Each entry needs a reason: the

--- a/apps/fountain/test/fountain_web/schema_wrappers_test.exs
+++ b/apps/fountain/test/fountain_web/schema_wrappers_test.exs
@@ -94,11 +94,13 @@ defmodule FountainWeb.SchemaWrappersTest do
     Schemas.VaultListResponse,
     Schemas.VaultResponse,
     Schemas.VaultSecretListResponse,
-    Schemas.VaultSecretResponse
+    Schemas.VaultSecretResponse,
+    Schemas.SupportReportResponse,
+    Schemas.SupportReportListResponse
   ]
 
-  test "all 22 generated envelopes exist and keep the envelope invariants" do
-    assert length(@generated) == 22
+  test "all 24 generated envelopes exist and keep the envelope invariants" do
+    assert length(@generated) == 24
 
     for mod <- @generated do
       assert Code.ensure_loaded?(mod), "#{inspect(mod)} was not defined"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -629,6 +629,12 @@ if config_env() == :prod do
   # "reply to this email" would point somewhere replies go to die.
   config :fountain, :support_email, System.get_env("SUPPORT_EMAIL")
 
+  # Optional (#843): where "Report a problem" reports are forwarded besides
+  # SUPPORT_EMAIL — a GitHub issue in this repo, created with this token
+  # (needs `issues:write`). Unset, reports stay on the row and in the mail.
+  config :fountain, :support_github_repo, System.get_env("SUPPORT_GITHUB_REPO")
+  config :fountain, :support_github_token, System.get_env("SUPPORT_GITHUB_TOKEN")
+
   # "" counts as unset for the adapter choice (#396): docker-compose.yml passes
   # `${RESEND_API_KEY:-}` / `${SMTP_HOST:-}` / `${SMTP_USERNAME:-}`, which
   # deliver present-but-empty variables — and "" is truthy, so a blank

--- a/docs/api.md
+++ b/docs/api.md
@@ -476,6 +476,34 @@ Browser clients on another origin need `API_CORS_ORIGINS` set on the server
 (see [configuration](configuration.md)); a bearer key is the only credential
 that crosses origins.
 
+## Support
+
+"Report a problem" from a client (#843): the report is stored with whatever
+context the client attaches — conversation, agent, sandbox, presence, recent
+events, app version, page URL; the facts triage needs, never secrets — and
+forwarded to the operator out of band.
+
+```
+POST   /api/support/reports         # {category, message, context?, client?, screenshot?} → 201 the report
+GET    /api/support/reports         # the caller's reports, newest first
+GET    /api/support/reports/:id
+```
+
+`category` is one of `bug`, `stuck`, `question`, `idea`, `other`; `message`
+up to 20 KB; `context` an object up to 64 KB; `client` a name/version
+string; `screenshot` the same `{data: base64, media_type}` shape prompt
+images use (png/jpeg/gif/webp, 5 MB). The response carries `status` (`new`
+→ `forwarded` or `failed`), `forwarded_at`, `external_url` (the GitHub issue
+when one was created) and `forward_error`; the screenshot is reported by
+presence, never inlined. Audited as `support.report.created` with category,
+sizes and context keys — not the message.
+
+Forwarding is an Oban job: a GitHub issue when the instance sets
+`SUPPORT_GITHUB_REPO` + `SUPPORT_GITHUB_TOKEN` (issues:write; labelled
+`support` and the category), and/or mail to `SUPPORT_EMAIL` with the
+screenshot attached. Neither configured is fine — the rows are the inbox.
+Rate-limited with the rest of `/api`.
+
 ## Admin
 
 For operator accounts (`role: "admin"`) holding a `full`-scoped key. Every action mirrors the admin UI, including its refusals, and records the same privilege-trail event.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,9 @@ signup with no visible error. See [Email](self-hosting.md#email).
 | `SMTP_TLS` | `always` | — | STARTTLS by default; `never` for a relay on a trusted network that does not offer it |
 | `EMAIL_DELIVERY` | — | one of three | `none` deliberately disables email. Accounts then self-verify at registration (ADR 0011), but password-reset email cannot be delivered, so a forgotten password is unrecoverable in this mode |
 | `EMAIL_FROM` | — | when mail is on | The From address. Required whenever a real delivery provider is configured — a prod instance refuses to boot without it, since mail from an unverified domain is rejected anyway. Unused under `EMAIL_DELIVERY=none` |
-| `SUPPORT_EMAIL` | — | — | Where "contact support" in account emails (suspension, deletion) points. Unset, the copy names no address |
+| `SUPPORT_EMAIL` | — | — | Where "contact support" in account emails (suspension, deletion) points, and where `POST /api/support/reports` reports are mailed. Unset, the copy names no address and reports are not mailed |
+| `SUPPORT_GITHUB_REPO` | — | — | `owner/repo`: each support report also becomes a GitHub issue there (labels `support` + category). Needs `SUPPORT_GITHUB_TOKEN` |
+| `SUPPORT_GITHUB_TOKEN` | — | — | A token with `issues:write` on `SUPPORT_GITHUB_REPO` |
 
 ## Authentication
 


### PR DESCRIPTION
Closes #843.

## What
- **`Fountain.Support`** + `support_reports`: category, message, free-form `context` (≤64 KB), client name/version, optional screenshot (prompt-image shape/limits). Tenant-scoped reads. Audited `support.report.created` (category, sizes, context keys — not the message); guardrail entry.
- **`Workers.SupportForward`** (Oban): GitHub issue when `SUPPORT_GITHUB_REPO`+`SUPPORT_GITHUB_TOKEN` (labels `support`+category; body with conversation link/agent/sandbox/presence/page + full context JSON), and/or mail to `SUPPORT_EMAIL` with the screenshot attached. Either success → `forwarded` (+ issue URL); none configured → rows are the inbox; transport failure retries ×3 then `forward_error`.
- **`POST/GET /api/support/reports(/:id)`** with OpenAPI schemas; docs (`api.md` Support section, `configuration.md`, `.env.example`).

## Why this shape
A Support teammate per team or a skill per agent would spend the user's sandbox/tokens and lack the client's state; the client has everything triage needs. A hosted Support teammate can sit on top of this endpoint later.

## Testing
65 tests green across context/worker/controller/spec/guardrail; credo + format clean. Migration `20260819130000_create_support_reports`.

Client side: fountain-team "Report a problem…" (team menu / row menu) ships next against this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)