### PR TITLE
fix(agents): deliver the system prompt to the runtime (#848)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -685,6 +685,7 @@ defmodule Fountain.Conversations.ConversationServer do
         sprite_env = build_sprite_env(state, agent, env, secrets, sandbox_url)
 
         write_runtime_config(handle, state.runtime_module, agent)
+        write_instructions(handle, runtime, agent)
         Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
 
         with :ok <-
@@ -877,6 +878,9 @@ defmodule Fountain.Conversations.ConversationServer do
         # Refresh the .env file in case secrets/env_vars were edited
         # between the original provision and this reattach.
         Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
+        # Same for the agent's system prompt: an edit reaches the existing
+        # computer on its next wake (#848).
+        write_instructions(handle, conv.runtime || (agent && agent.runtime) || "claude", agent)
 
         # Normally the wake path already flipped suspended → ready under the
         # quota reservation; this covers the reaper parking the row mid-wake.
@@ -1267,6 +1271,23 @@ defmodule Fountain.Conversations.ConversationServer do
 
     if function_exported?(runtime_module, :write_config, 2) do
       runtime_module.write_config(handle, agent)
+    end
+  end
+
+  # The agent's `system` prompt, into the runtime's user-level instructions
+  # file (#848). Best-effort: a sandbox that refuses the write still runs,
+  # on the CLI's default persona, and says so in the log.
+  defp write_instructions(handle, runtime, agent) do
+    case Fountain.Runtimes.Instructions.write(handle, runtime, agent) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "could not write agent instructions for #{inspect(agent && agent.name)} (#{runtime}): #{inspect(reason)}"
+        )
+
+        :ok
     end
   end
 

--- a/apps/fountain/lib/fountain/runtimes/instructions.ex
+++ b/apps/fountain/lib/fountain/runtimes/instructions.ex
@@ -1,0 +1,79 @@
+defmodule Fountain.Runtimes.Instructions do
+  @moduledoc """
+  Deliver the agent's `system` prompt to the runtime (#848).
+
+  `agents.system` was stored, edited, exported and rendered in every form —
+  and never reached a sandbox: the ACP `session/new` / `session/prompt`
+  carry `cwd`, `mcpServers` and the user's text, nothing else, and no
+  runtime module wrote it anywhere. Every agent ran on its CLI's default
+  persona.
+
+  Each runtime reads a user-level instructions file at session start; that
+  file is the one place all of them honour without flags, and it survives
+  suspend/resume on the sandbox disk. Written at provision and rewritten at
+  every reattach, so an edit to the agent's prompt lands on its existing
+  computer the next time it wakes. An empty/blank prompt removes nothing and
+  writes nothing — the CLI's default stands, as before.
+
+  | runtime  | file                                 |
+  |----------|--------------------------------------|
+  | claude   | `~/.claude/CLAUDE.md`                |
+  | codex    | `~/.codex/AGENTS.md`                 |
+  | opencode | `~/.config/opencode/AGENTS.md`       |
+  | gemini   | `~/.gemini/GEMINI.md`                |
+
+  The file carries a short header so a human (or the agent) reading it knows
+  where it came from, then the prompt verbatim.
+  """
+
+  @home "/home/sprite"
+
+  @paths %{
+    "claude" => "#{@home}/.claude/CLAUDE.md",
+    "codex" => "#{@home}/.codex/AGENTS.md",
+    "opencode" => "#{@home}/.config/opencode/AGENTS.md",
+    "gemini" => "#{@home}/.gemini/GEMINI.md"
+  }
+
+  @doc "The user-level instructions file the runtime reads, or nil for a runtime we do not know."
+  @spec path(String.t() | nil) :: String.t() | nil
+  def path(runtime), do: Map.get(@paths, runtime)
+
+  @doc """
+  Write the agent's system prompt for the runtime into the sandbox. Returns
+  `:ok` when written or when there was nothing to write; `{:error, reason}`
+  when the sandbox refused the write (the caller logs and carries on — a
+  missing persona is not a reason to fail a provision).
+  """
+  @spec write(Fountain.Sandbox.Handle.t(), String.t() | nil, map() | nil) ::
+          :ok | {:error, term()}
+  def write(_handle, _runtime, nil), do: :ok
+
+  def write(handle, runtime, %{system: system} = agent) do
+    with path when is_binary(path) <- path(runtime),
+         prompt when is_binary(prompt) <- blank_to_nil(system) do
+      Fountain.Sandbox.write_file(handle, path, render(agent, prompt))
+    else
+      _ -> :ok
+    end
+  end
+
+  def write(_handle, _runtime, _agent), do: :ok
+
+  @doc false
+  def render(agent, prompt) do
+    name = Map.get(agent, :name) || "agent"
+
+    """
+    <!-- Written by Fountain from the agent "#{name}" (its `system` prompt). Edit the agent in Fountain, not this file: it is rewritten when the computer is provisioned or reattached. -->
+
+    #{String.trim_trailing(prompt)}
+    """
+  end
+
+  defp blank_to_nil(nil), do: nil
+
+  defp blank_to_nil(s) when is_binary(s) do
+    if String.trim(s) == "", do: nil, else: s
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/instructions_test.exs
+++ b/apps/fountain/test/fountain/runtimes/instructions_test.exs
@@ -1,0 +1,49 @@
+defmodule Fountain.Runtimes.InstructionsTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Fountain.Runtimes.Instructions
+
+  setup :verify_on_exit!
+
+  @handle %Fountain.Sandbox.Handle{provider: :sprites, name: "fountain-test"}
+
+  test "each ACP runtime has a user-level instructions file; unknown runtimes none" do
+    assert Instructions.path("claude") == "/home/sprite/.claude/CLAUDE.md"
+    assert Instructions.path("codex") == "/home/sprite/.codex/AGENTS.md"
+    assert Instructions.path("opencode") == "/home/sprite/.config/opencode/AGENTS.md"
+    assert Instructions.path("gemini") == "/home/sprite/.gemini/GEMINI.md"
+    assert Instructions.path("nope") == nil
+  end
+
+  test "writes the prompt verbatim, with a provenance header, to the runtime's file" do
+    expect(Fountain.Sandbox.Sprites, :write_file, fn @handle,
+                                                     "/home/sprite/.claude/CLAUDE.md",
+                                                     body,
+                                                     _opts ->
+      assert body =~ ~s(agent "team-lead")
+      assert body =~ "You are team-lead, Jake's single point of contact."
+      assert String.ends_with?(body, "contact.\n")
+      :ok
+    end)
+
+    assert :ok =
+             Instructions.write(@handle, "claude", %{
+               name: "team-lead",
+               system: "You are team-lead, Jake's single point of contact.\n\n"
+             })
+  end
+
+  test "a blank or missing prompt writes nothing" do
+    reject(&Fountain.Sandbox.Sprites.write_file/4)
+    assert :ok = Instructions.write(@handle, "claude", %{name: "x", system: "   \n"})
+    assert :ok = Instructions.write(@handle, "claude", %{name: "x", system: nil})
+    assert :ok = Instructions.write(@handle, "claude", nil)
+    assert :ok = Instructions.write(@handle, "unknown-runtime", %{name: "x", system: "hi"})
+  end
+
+  test "a refused write is reported, not raised" do
+    expect(Fountain.Sandbox.Sprites, :write_file, fn _h, _p, _b, _o -> {:error, :boom} end)
+    assert {:error, :boom} = Instructions.write(@handle, "codex", %{name: "x", system: "hi"})
+  end
+end

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -67,7 +67,7 @@ An **Agent** is a named, re-runnable configuration for an AI coding assistant:
   the CLI as-is, so a model released since your Fountain version still works.
 - **`runtime`** - one of `claude`, `codex`, `gemini`, `opencode`
 - **`environment`** - optional Environment to attach
-- **`system`** / **`description`** - system prompt and human-readable description
+- **`system`** / **`description`** - system prompt and human-readable description. The system prompt is written into the runtime's user-level instructions file on the agent's computer at provision and again at every reattach (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.config/opencode/AGENTS.md`, `~/.gemini/GEMINI.md`), so an edit reaches an existing computer the next time it wakes
 - **`skills`** - each entry is either inline (`{name, content}` — a full SKILL.md written to the sandbox) or GitHub-sourced (`{source: "owner/repo"}` — installed via the skills.sh CLI)
 - **`mcp_servers`** - MCP server definitions, with `${VAR}` substitution in their env
 - **`metadata`** - free-form map for callers' own bookkeeping


### PR DESCRIPTION
Closes #848.

`agents.system` was stored and shown everywhere but **never delivered**: nothing under `lib/fountain` reads it except exports/forms, and ACP `session/new`/`prompt` carry only cwd, mcpServers and the user's text. Every agent ran as its CLI's default persona.

**Fix:** `Fountain.Runtimes.Instructions` writes the prompt (with a provenance header) to the runtime's user-level instructions file — `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.config/opencode/AGENTS.md`, `~/.gemini/GEMINI.md` — at provision **and** at reattach (an edit reaches an existing computer on its next wake). Blank → no write; refused write → logged, not fatal. docs/primitives.md updated.

Tests: 4 new (paths, body, no-ops, refusal); conversations/runtimes suites 434 green; credo clean; dialyzer shows only the pre-existing `feature_flags.ex` guard warning from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)