### PR TITLE
feat(team): a teammate with its own email address and phone number (PoC, flag team_comms)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,24 @@ EMAIL_FROM=noreply@fountain.example.com
 # SUPPORT_GITHUB_REPO=owner/repo
 # SUPPORT_GITHUB_TOKEN=
 
+# ── Feature flags ────────────────────────────────────────────────────────────
+# Per-user flags via PostHog (project API key, not a personal key). Unset, every
+# flag reads off unless forced on below. When PostHog is unreachable the last
+# answer it gave is reused; with none, flags read off.
+# POSTHOG_PROJECT_API_KEY=
+# POSTHOG_HOST=https://us.i.posthog.com
+# Force flags on for every user without PostHog (comma-separated keys).
+# FEATURE_FLAGS_ON=team_comms
+
+# ── Teammate email + phone (flag: team_comms) ───────────────────────────────
+# Fountain owns these keys; teammates get an inbox/number under them and use
+# MCP tools Fountain serves. The keys never enter a sandbox.
+# AGENTMAIL_API_KEY=
+# AGENTMAIL_BASE_URL=https://api.agentmail.to
+# AGENTMAIL_DOMAIN=
+# AGENTPHONE_API_KEY=
+# AGENTPHONE_BASE_URL=https://api.agentphone.ai
+
 # ── Authentication ───────────────────────────────────────────────────────────
 
 # GitHub OAuth (register at https://github.com/settings/developers). Optional:

--- a/.env.example
+++ b/.env.example
@@ -163,6 +163,9 @@ EMAIL_FROM=noreply@fountain.example.com
 # AGENTMAIL_DOMAIN=
 # AGENTPHONE_API_KEY=
 # AGENTPHONE_BASE_URL=https://api.agentphone.ai
+# From `POST /v1/webhooks {"url": "<PUBLIC_URL>/api/webhooks/agentphone"}`:
+# verifies inbound texts so the allow-listed sender's texts become prompts.
+# AGENTPHONE_WEBHOOK_SECRET=
 
 # ── Authentication ───────────────────────────────────────────────────────────
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@ upgrade, is in
   token — no provider key ever enters a sandbox. Sends are audited
   (`team.contact.sent`, never the content). Configuration:
   `AGENTMAIL_API_KEY`, `AGENTPHONE_API_KEY` (+ optional base URLs and
-  `AGENTMAIL_DOMAIN`).
+  `AGENTMAIL_DOMAIN`). Giving a number also collects `prompt_from_number`
+  — your phone: a text from it to the teammate's number arrives as a prompt
+  in the teammate's conversation (AgentPhone's master webhook at `POST
+  /api/webhooks/agentphone`, HMAC-verified with `AGENTPHONE_WEBHOOK_SECRET`,
+  deduplicated by delivery id); texts from anyone else are ignored.
 - **Per-user feature flags** (`Fountain.FeatureFlags`), evaluated by PostHog
   (`POSTHOG_PROJECT_API_KEY`, `POSTHOG_HOST`) with a one-minute per-user
   cache; when PostHog is unreachable the last answer it gave is reused and,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ upgrade, is in
 
 ### Added
 
+- **A teammate with its own email address and phone number** (proof of
+  concept, behind the `team_comms` feature flag). `POST
+  /api/team/:agent_id/contact` provisions an AgentMail inbox and an
+  AgentPhone number under Fountain's own keys and records them on the
+  teammate; `DELETE` releases them; `GET /api/team/comms` reports whether
+  the caller may. The `/team` page gains a "Give email & phone" button and
+  shows the contact. From its next turn the teammate has `email_send`,
+  `email_reply`, `email_list`, `email_get`, `sms_send`, `sms_list` and
+  `my_contact_info` MCP tools, served by Fountain at `POST
+  /api/mcp/team-comms/:conversation_id` with the conversation's own sprite
+  token — no provider key ever enters a sandbox. Sends are audited
+  (`team.contact.sent`, never the content). Configuration:
+  `AGENTMAIL_API_KEY`, `AGENTPHONE_API_KEY` (+ optional base URLs and
+  `AGENTMAIL_DOMAIN`).
+- **Per-user feature flags** (`Fountain.FeatureFlags`), evaluated by PostHog
+  (`POSTHOG_PROJECT_API_KEY`, `POSTHOG_HOST`) with a one-minute per-user
+  cache; when PostHog is unreachable the last answer it gave is reused and,
+  with none, every flag reads off — an outage never turns a feature on.
+  `FEATURE_FLAGS_ON=team_comms` forces a flag on for everyone without
+  PostHog.
+
 - **A fresh conversation on the same computer.** `POST
   /api/team/:agent_id/conversations` retires the teammate's current
   conversation (it stays in its history, past resuming) and opens a new one

--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -32,6 +32,7 @@ defmodule Fountain.Application do
         {Phoenix.PubSub, name: Fountain.PubSub},
         FountainWeb.Plugs.RateLimit.Sweeper,
         Fountain.Conversations.Redaction,
+        Fountain.FeatureFlags.Cache,
         {Oban, Application.fetch_env!(:fountain, Oban)}
       ] ++
         cluster_children(cluster_topologies) ++

--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -33,6 +33,7 @@ defmodule Fountain.Application do
         FountainWeb.Plugs.RateLimit.Sweeper,
         Fountain.Conversations.Redaction,
         Fountain.FeatureFlags.Cache,
+        Fountain.Team.Comms.Inbound.Seen,
         {Oban, Application.fetch_env!(:fountain, Oban)}
       ] ++
         cluster_children(cluster_topologies) ++

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -685,7 +685,6 @@ defmodule Fountain.Conversations.ConversationServer do
         sprite_env = build_sprite_env(state, agent, env, secrets, sandbox_url)
 
         write_runtime_config(handle, state.runtime_module, agent)
-        write_instructions(handle, runtime, agent)
         Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
 
         with :ok <-
@@ -878,9 +877,6 @@ defmodule Fountain.Conversations.ConversationServer do
         # Refresh the .env file in case secrets/env_vars were edited
         # between the original provision and this reattach.
         Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
-        # Same for the agent's system prompt: an edit reaches the existing
-        # computer on its next wake (#848).
-        write_instructions(handle, conv.runtime || (agent && agent.runtime) || "claude", agent)
 
         # Normally the wake path already flipped suspended → ready under the
         # quota reservation; this covers the reaper parking the row mid-wake.
@@ -1271,23 +1267,6 @@ defmodule Fountain.Conversations.ConversationServer do
 
     if function_exported?(runtime_module, :write_config, 2) do
       runtime_module.write_config(handle, agent)
-    end
-  end
-
-  # The agent's `system` prompt, into the runtime's user-level instructions
-  # file (#848). Best-effort: a sandbox that refuses the write still runs,
-  # on the CLI's default persona, and says so in the log.
-  defp write_instructions(handle, runtime, agent) do
-    case Fountain.Runtimes.Instructions.write(handle, runtime, agent) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning(
-          "could not write agent instructions for #{inspect(agent && agent.name)} (#{runtime}): #{inspect(reason)}"
-        )
-
-        :ok
     end
   end
 
@@ -2058,6 +2037,17 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp team_mcp_servers(_state), do: []
 
+  # A teammate's email + phone tools (flag `team_comms`), injected the same
+  # way: only for a team conversation whose teammate has a contact, and only
+  # once a callback token exists — `Fountain.Team.Comms` decides. Computed
+  # at every turn kick, so a contact given mid-session is there next turn.
+  defp team_comms_mcp_servers(%{callback_token: token, conversation_id: conv_id})
+       when is_binary(token) and is_binary(conv_id) do
+    Fountain.Team.Comms.conversation_mcp_servers(conv_id, token)
+  end
+
+  defp team_comms_mcp_servers(_state), do: []
+
   # How long a sprite's callback key stays valid.
   #
   # This is a backstop, not the primary control: the key is revoked at
@@ -2355,7 +2345,9 @@ defmodule Fountain.Conversations.ConversationServer do
                     images: images,
                     mcp_servers:
                       Fountain.Runtimes.ACP.mcp_servers(agent) ++
-                        buzz_mcp_servers(state) ++ team_mcp_servers(state),
+                        buzz_mcp_servers(state) ++
+                        team_mcp_servers(state) ++
+                        team_comms_mcp_servers(state),
                     model: agent && Fountain.Runtimes.Model.id(agent.model)
                   )
                 else

--- a/apps/fountain/lib/fountain/feature_flags.ex
+++ b/apps/fountain/lib/fountain/feature_flags.ex
@@ -1,0 +1,207 @@
+defmodule Fountain.FeatureFlags do
+  @moduledoc """
+  Per-user feature flags, evaluated by PostHog and safe when PostHog is not.
+
+  `enabled?(flag, user)` answers a yes/no for one user. The sources, in order:
+
+  1. **Static overrides** — `config :fountain, :feature_flag_overrides,
+     %{"team_comms" => true}` (from `FEATURE_FLAGS_ON=team_comms,...` in
+     `config/runtime.exs`). A self-hoster with no PostHog turns a feature on
+     for everyone this way; tests use it to flip a flag without any HTTP.
+  2. **PostHog** — `POST {host}/flags/?v=2` with the project API key and the
+     user's id as `distinct_id`, when `POSTHOG_PROJECT_API_KEY` is set. The
+     answer for the whole user is cached in ETS for `@fresh_ms`.
+  3. **The last answer PostHog gave**, however old, when the call fails —
+     timeout, 5xx, DNS. A flag that was on stays on across a PostHog outage
+     and a flag that was off stays off; the outage does not flip anything.
+  4. **Off.** No override, no PostHog (or PostHog unreachable with nothing
+     cached) → `false`. Fail closed: an unreachable flag service must never
+     turn a feature on.
+
+  The lookup is bounded — `@timeout_ms` — so a slow PostHog costs a request
+  at most that much once per user per `@fresh_ms`, not on every call. The
+  cache is a plain ETS table owned by `Fountain.FeatureFlags.Cache`; readers
+  never touch the GenServer.
+
+  Flags are plain strings, the PostHog key as written in its UI. Keep the
+  known ones in `@flags` so a typo is a compile-time `KeyError`, not a flag
+  that is silently always off.
+  """
+
+  require Logger
+
+  @table :fountain_feature_flags
+  @fresh_ms 60_000
+  @timeout_ms 2_000
+
+  @flags %{
+    # A teammate can be given an email address and a phone number, and gets
+    # MCP tools to use them (AgentMail + AgentPhone, keys held by Fountain).
+    team_comms: "team_comms"
+  }
+
+  @doc "The PostHog key for a known flag atom."
+  def key!(flag) when is_atom(flag), do: Map.fetch!(@flags, flag)
+
+  @doc """
+  Whether `flag` is on for `user` — a `%Fountain.Accounts.User{}`, a user id
+  string, or `nil` (no user: only static overrides apply).
+  """
+  @spec enabled?(atom | String.t(), term) :: boolean
+  def enabled?(flag, user) when is_atom(flag), do: enabled?(key!(flag), user)
+
+  def enabled?(flag, user) when is_binary(flag) do
+    case Map.fetch(overrides(), flag) do
+      {:ok, value} -> value == true
+      :error -> remote_enabled?(flag, distinct_id(user))
+    end
+  end
+
+  defp distinct_id(%{id: id}) when is_binary(id), do: id
+  defp distinct_id(id) when is_binary(id), do: id
+  defp distinct_id(_), do: nil
+
+  defp remote_enabled?(_flag, nil), do: false
+
+  defp remote_enabled?(flag, distinct_id) do
+    case configured?() do
+      false -> false
+      true -> Map.get(flags_for(distinct_id), flag, false) == true
+    end
+  end
+
+  @doc "Every flag PostHog reports on for the user, `%{key => boolean}`."
+  def flags_for(distinct_id) when is_binary(distinct_id) do
+    now = System.monotonic_time(:millisecond)
+
+    case cached(distinct_id) do
+      {:ok, flags, at} when now - at < @fresh_ms ->
+        flags
+
+      cached ->
+        case fetch(distinct_id) do
+          {:ok, flags} ->
+            put(distinct_id, flags, now)
+            flags
+
+          {:error, reason} ->
+            Logger.warning(
+              "feature flags: PostHog lookup failed (#{inspect(reason)}); " <>
+                stale_note(cached)
+            )
+
+            case cached do
+              {:ok, flags, _at} -> flags
+              :miss -> %{}
+            end
+        end
+    end
+  end
+
+  defp stale_note({:ok, _, _}), do: "using the last answer"
+  defp stale_note(:miss), do: "no cached answer, every flag reads off"
+
+  @doc "Drop every cached answer (tests, or after an operator flips a flag)."
+  def reset do
+    ensure_table()
+    :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  ## PostHog
+
+  @doc false
+  def configured?, do: is_binary(api_key()) and api_key() != ""
+
+  defp api_key, do: Application.get_env(:fountain, :posthog_project_api_key)
+
+  defp host, do: Application.get_env(:fountain, :posthog_host, "https://us.i.posthog.com")
+
+  defp overrides, do: Application.get_env(:fountain, :feature_flag_overrides, %{})
+
+  defp fetch(distinct_id) do
+    req =
+      Req.new(
+        [
+          base_url: host(),
+          receive_timeout: @timeout_ms,
+          connect_options: [timeout: @timeout_ms],
+          retry: false
+        ] ++ Application.get_env(:fountain, :posthog_req_options, [])
+      )
+
+    case Req.post(req, url: "/flags/?v=2", json: %{api_key: api_key(), distinct_id: distinct_id}) do
+      {:ok, %Req.Response{status: 200, body: body}} when is_map(body) -> {:ok, parse(body)}
+      {:ok, %Req.Response{status: status}} -> {:error, {:status, status}}
+      {:error, reason} -> {:error, reason}
+    end
+  rescue
+    e -> {:error, e}
+  end
+
+  # `/flags?v=2` answers `{"flags": {key: {"enabled": bool, ...}}}`; the
+  # older `/decide?v=3` shape is `{"featureFlags": {key: bool | variant}}`.
+  # Read both so a host pinned to the old endpoint still works.
+  defp parse(%{"flags" => flags}) when is_map(flags) do
+    Map.new(flags, fn
+      {k, %{"enabled" => enabled}} -> {k, enabled == true}
+      {k, v} -> {k, v == true}
+    end)
+  end
+
+  defp parse(%{"featureFlags" => flags}) when is_map(flags) do
+    Map.new(flags, fn {k, v} -> {k, v == true or is_binary(v)} end)
+  end
+
+  defp parse(_), do: %{}
+
+  ## cache
+
+  defp cached(distinct_id) do
+    ensure_table()
+
+    case :ets.lookup(@table, distinct_id) do
+      [{^distinct_id, flags, at}] -> {:ok, flags, at}
+      [] -> :miss
+    end
+  end
+
+  defp put(distinct_id, flags, at) do
+    ensure_table()
+    :ets.insert(@table, {distinct_id, flags, at})
+  end
+
+  @doc false
+  def table, do: @table
+
+  # The table is owned by `Fountain.FeatureFlags.Cache`; a caller that runs
+  # before the tree is up (or a test without it) gets a table of its own.
+  defp ensure_table do
+    if :ets.whereis(@table) == :undefined do
+      :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    end
+
+    true
+  catch
+    :error, :badarg -> true
+  end
+
+  defmodule Cache do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts),
+      do: GenServer.start_link(__MODULE__, :ok, Keyword.put_new(opts, :name, __MODULE__))
+
+    @impl true
+    def init(:ok) do
+      table = Fountain.FeatureFlags.table()
+
+      if :ets.whereis(table) == :undefined do
+        :ets.new(table, [:named_table, :public, :set, read_concurrency: true])
+      end
+
+      {:ok, %{}}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -38,6 +38,7 @@ defmodule Fountain.Team do
   """
 
   import Ecto.Query, warn: false
+  require Logger
 
   alias Fountain.{Agents, Audit, Conversations, Repo}
   alias Fountain.Conversations.{Conversation, ConversationServer, Turn}
@@ -59,7 +60,12 @@ defmodule Fountain.Team do
 
   defp topic(user_id), do: "team:#{user_id}"
 
-  defp broadcast_changed(user_id),
+  @doc """
+  Broadcast `{:team_changed, user_id}` on the team topic — the roster needs
+  re-listing. Also called by `Fountain.Team.Comms` when a teammate gains or
+  loses its email address and phone number.
+  """
+  def broadcast_changed(user_id),
     do: Phoenix.PubSub.broadcast(Fountain.PubSub, topic(user_id), {:team_changed, user_id})
 
   @doc """
@@ -131,6 +137,14 @@ defmodule Fountain.Team do
 
     last_turns = last_turns_by_conversation(Enum.map(groups, fn {conv, _} -> conv.id end))
 
+    # The teammate's email address and phone number, when it has them
+    # (`Fountain.Team.Comms`, flag `team_comms`); nil otherwise.
+    contacts =
+      Fountain.Team.Comms.contacts_by_agent(
+        user_id,
+        Enum.map(groups, fn {c, _} -> c.agent_id end)
+      )
+
     groups
     |> Enum.map(fn {conv, usage_total} ->
       %{
@@ -138,7 +152,8 @@ defmodule Fountain.Team do
         conversation: conv,
         last_turn: Map.get(last_turns, conv.id),
         name: teammate_name(conv),
-        usage_total: usage_total
+        usage_total: usage_total,
+        contact: Map.get(contacts, conv.agent_id)
       }
     end)
     |> Enum.sort_by(& &1.conversation.last_active_at, {:desc, DateTime})
@@ -313,6 +328,23 @@ defmodule Fountain.Team do
         # ownership: the scoped get_teammate above found this agent for user_id;
         # the delete is bounded by the same user_id + agent_id.
         _ = Fountain.Team.Schedules._unsafe_delete_for_teammate(user_id, agent_id)
+
+        # So does its email address and phone number, when it has them: the
+        # inbox and number are released upstream. A provider failure there
+        # keeps the contact row (nothing orphaned) and is logged, not raised —
+        # the removal the user asked for still happens.
+        case Fountain.Team.Comms.release_contact(user_id, agent_id, opts) do
+          :ok ->
+            :ok
+
+          {:error, :not_found} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning(
+              "team: could not release the contact for agent #{agent_id} on removal: #{inspect(reason)}"
+            )
+        end
 
         record(user_id, "team.member.removed", conv, opts)
         broadcast_changed(user_id)

--- a/apps/fountain/lib/fountain/team/comms.ex
+++ b/apps/fountain/lib/fountain/team/comms.ex
@@ -71,6 +71,11 @@ defmodule Fountain.Team.Comms do
   @doc """
   Give the teammate for `agent_id` an email address and a phone number.
 
+  `attrs` is what the user supplies: `"prompt_from_number"`, required — the
+  one number whose texts to the teammate's new number arrive as prompts in
+  its conversation (`Fountain.Team.Comms.Inbound`). It is validated before
+  anything is bought.
+
   Creates the AgentMail inbox (display name = the teammate's name, username
   derived from it) and the AgentPhone number, then records both. All or
   nothing: if the number cannot be provisioned the inbox is deleted again and
@@ -78,14 +83,17 @@ defmodule Fountain.Team.Comms do
 
   Returns `{:ok, %Contact{}}`, or `{:error, reason}` with one of
   `:not_found` (not on the team), `:not_enabled` (flag off), `:not_configured`
-  (a provider key is missing), `:already_provisioned`, or
+  (a provider key is missing), `:already_provisioned`, an
+  `%Ecto.Changeset{}` (a bad `prompt_from_number`), or
   `{:email | :phone, provider_error}`.
   """
-  def provision_contact(user_id, agent_id, opts \\ [])
-      when is_binary(user_id) and is_binary(agent_id) do
+  def provision_contact(user_id, agent_id, attrs \\ %{}, opts \\ [])
+      when is_binary(user_id) and is_binary(agent_id) and is_map(attrs) do
     with :ok <- gate(user_id),
          %{name: name} = teammate <- Team.get_teammate(user_id, agent_id) || {:error, :not_found},
          :ok <- ensure_no_contact(user_id, agent_id),
+         {:ok, requested} <-
+           Ecto.Changeset.apply_action(Contact.request_changeset(attrs), :insert),
          {:ok, inbox} <- create_inbox(name, teammate, opts),
          {:ok, number} <- create_number(inbox, opts) do
       attrs = %{
@@ -94,14 +102,16 @@ defmodule Fountain.Team.Comms do
         email_address: inbox["email"],
         email_inbox_id: inbox["inbox_id"],
         phone_number: number["phoneNumber"],
-        phone_number_id: number["id"]
+        phone_number_id: number["id"],
+        prompt_from_number: requested.prompt_from_number
       }
 
       case %Contact{} |> Contact.changeset(attrs) |> Repo.insert() do
         {:ok, contact} ->
           record("team.contact.provisioned", contact, opts, %{
             "channels" => channels(contact),
-            "agent_name" => teammate.agent.name
+            "agent_name" => teammate.agent.name,
+            "prompt_from_number" => not is_nil(contact.prompt_from_number)
           })
 
           Team.broadcast_changed(user_id)
@@ -173,6 +183,19 @@ defmodule Fountain.Team.Comms do
   end
 
   def conversation_mcp_servers(_conversation_id, _token), do: []
+
+  @doc """
+  The contact that owns the teammate number `phone_number` (E.164), across
+  every tenant — or nil.
+
+  `_unsafe_`: no `user_id` scopes this; the inbound SMS webhook
+  (`Fountain.Team.Comms.Inbound`) has nothing but the number to go on. The
+  caller has already verified the provider's signature, and the result only
+  ever prompts the conversation that belongs to the contact's own user.
+  """
+  def _unsafe_get_contact_by_phone_number(phone_number) when is_binary(phone_number) do
+    Repo.one(from(c in Contact, where: c.phone_number == ^phone_number, limit: 1))
+  end
 
   @doc """
   Resolve a conversation the caller owns to the contact its MCP tools act

--- a/apps/fountain/lib/fountain/team/comms.ex
+++ b/apps/fountain/lib/fountain/team/comms.ex
@@ -1,0 +1,342 @@
+defmodule Fountain.Team.Comms do
+  @moduledoc """
+  A teammate's email address and phone number, and the MCP tools it uses them
+  through (flag `team_comms`).
+
+  Fountain owns the AgentMail and AgentPhone keys. Giving a teammate a contact
+  (`provision_contact/3`) creates an inbox and a number under those keys and
+  records them in `Fountain.Team.Contact`; the teammate's sandbox never sees a
+  key — it reaches email and SMS through MCP tools Fountain serves
+  (`Fountain.Team.Comms.Mcp` behind `POST /api/mcp/team-comms/:conversation_id`),
+  the same shape as the hosted Buzz tools (ADR 0020). The tools are injected
+  into the teammate's conversation at each turn (`conversation_mcp_servers/2`),
+  so a contact given while the teammate is mid-session shows up on its next
+  turn.
+
+  Two gates, both checked on every path: the **flag** (`flag_on?/1`, per user,
+  from `Fountain.FeatureFlags`) and the **providers** (`configured?/0`, both
+  keys present). `status/1` reports them separately so a surface can say
+  which one is missing.
+
+  Every function is tenant-scoped by `user_id`; provisioning and release are
+  audited here, as the context rule requires. The audit trail records which
+  channels a teammate got, never the address or number.
+  """
+
+  import Ecto.Query, warn: false
+  require Logger
+
+  alias Fountain.{Audit, Conversations, FeatureFlags, Repo, Team}
+  alias Fountain.Team.Comms.{AgentMail, AgentPhone}
+  alias Fountain.Team.Contact
+
+  @flag :team_comms
+  @mcp_name "fountain-comms"
+
+  ## gates
+
+  @doc "Whether the `team_comms` flag is on for this user (a `%User{}` or id)."
+  def flag_on?(user), do: FeatureFlags.enabled?(@flag, user)
+
+  @doc "Whether both provider keys are configured on this instance."
+  def configured?, do: AgentMail.configured?() and AgentPhone.configured?()
+
+  @doc "Whether the feature can be used by this user: flag on and providers configured."
+  def available?(user), do: flag_on?(user) and configured?()
+
+  @doc """
+  The two gates, separately: `%{enabled: flag, configured: providers}`. A
+  surface shows the feature when `enabled` and explains itself when
+  `configured` is false.
+  """
+  def status(user), do: %{enabled: flag_on?(user), configured: configured?()}
+
+  @doc "The MCP server name the teammate sees the tools under."
+  def mcp_name, do: @mcp_name
+
+  ## contacts
+
+  @doc "The teammate's contact, or nil."
+  def get_contact(user_id, agent_id) when is_binary(user_id) and is_binary(agent_id) do
+    Repo.one(from(c in Contact, where: c.user_id == ^user_id and c.agent_id == ^agent_id))
+  end
+
+  @doc "Contacts for many teammates at once, `%{agent_id => %Contact{}}`."
+  def contacts_by_agent(user_id, agent_ids) when is_binary(user_id) and is_list(agent_ids) do
+    from(c in Contact, where: c.user_id == ^user_id and c.agent_id in ^agent_ids)
+    |> Repo.all()
+    |> Map.new(&{&1.agent_id, &1})
+  end
+
+  @doc """
+  Give the teammate for `agent_id` an email address and a phone number.
+
+  Creates the AgentMail inbox (display name = the teammate's name, username
+  derived from it) and the AgentPhone number, then records both. All or
+  nothing: if the number cannot be provisioned the inbox is deleted again and
+  the error says which channel failed.
+
+  Returns `{:ok, %Contact{}}`, or `{:error, reason}` with one of
+  `:not_found` (not on the team), `:not_enabled` (flag off), `:not_configured`
+  (a provider key is missing), `:already_provisioned`, or
+  `{:email | :phone, provider_error}`.
+  """
+  def provision_contact(user_id, agent_id, opts \\ [])
+      when is_binary(user_id) and is_binary(agent_id) do
+    with :ok <- gate(user_id),
+         %{name: name} = teammate <- Team.get_teammate(user_id, agent_id) || {:error, :not_found},
+         :ok <- ensure_no_contact(user_id, agent_id),
+         {:ok, inbox} <- create_inbox(name, teammate, opts),
+         {:ok, number} <- create_number(inbox, opts) do
+      attrs = %{
+        user_id: user_id,
+        agent_id: agent_id,
+        email_address: inbox["email"],
+        email_inbox_id: inbox["inbox_id"],
+        phone_number: number["phoneNumber"],
+        phone_number_id: number["id"]
+      }
+
+      case %Contact{} |> Contact.changeset(attrs) |> Repo.insert() do
+        {:ok, contact} ->
+          record("team.contact.provisioned", contact, opts, %{
+            "channels" => channels(contact),
+            "agent_name" => teammate.agent.name
+          })
+
+          Team.broadcast_changed(user_id)
+          {:ok, contact}
+
+        {:error, changeset} ->
+          # A race with a second provision, most likely. Release what we
+          # just created so nothing is left unrecorded upstream.
+          release_upstream(inbox["inbox_id"], number["id"])
+          {:error, changeset}
+      end
+    end
+  end
+
+  @doc """
+  Take the teammate's email address and phone number away: the inbox and the
+  number are deleted upstream and the contact row removed. A provider that
+  no longer knows the resource (404) counts as released; any other provider
+  failure keeps the row so the resource is not orphaned, and is returned.
+  """
+  def release_contact(user_id, agent_id, opts \\ [])
+      when is_binary(user_id) and is_binary(agent_id) do
+    case get_contact(user_id, agent_id) do
+      nil ->
+        {:error, :not_found}
+
+      %Contact{} = contact ->
+        with :ok <- release_email(contact),
+             :ok <- release_phone(contact),
+             {:ok, _} <- Repo.delete(contact) do
+          record("team.contact.released", contact, opts, %{"channels" => channels(contact)})
+          Team.broadcast_changed(user_id)
+          :ok
+        end
+    end
+  end
+
+  ## MCP wiring
+
+  @doc """
+  The MCP server entry to inject into `session/new` for `conversation_id`,
+  authenticated with the conversation's own sprite `token` — `[]` unless the
+  conversation is a teammate's, the teammate has a contact, and the feature
+  is available to its owner.
+
+  Ownership: a system-level call from `ConversationServer`, which established
+  ownership of the conversation at provision; the contact lookup that follows
+  is scoped again by the conversation's `user_id`.
+  """
+  def conversation_mcp_servers(conversation_id, token)
+      when is_binary(conversation_id) and is_binary(token) and token != "" do
+    channel = Team.channel()
+
+    with %Conversations.Conversation{channel_id: ^channel, user_id: uid, agent_id: aid}
+         when is_binary(aid) <- fetch_conv(conversation_id),
+         %Contact{} <- get_contact(uid, aid),
+         true <- available?(uid) do
+      [
+        %{
+          name: @mcp_name,
+          type: "http",
+          url: Fountain.PublicUrl.base() <> "/api/mcp/team-comms/" <> conversation_id,
+          headers: [%{name: "Authorization", value: "Bearer " <> token}]
+        }
+      ]
+    else
+      _ -> []
+    end
+  end
+
+  def conversation_mcp_servers(_conversation_id, _token), do: []
+
+  @doc """
+  Resolve a conversation the caller owns to the contact its MCP tools act
+  for: `{:ok, %Contact{}}`, or `{:error, :not_team}` / `{:error, :no_contact}` /
+  `{:error, :unavailable}`. The controller's whole authorization question.
+  """
+  def contact_for_conversation(%Conversations.Conversation{} = conv, user_id)
+      when is_binary(user_id) do
+    cond do
+      conv.user_id != user_id or conv.channel_id != Team.channel() or is_nil(conv.agent_id) ->
+        {:error, :not_team}
+
+      not available?(user_id) ->
+        {:error, :unavailable}
+
+      true ->
+        case get_contact(user_id, conv.agent_id) do
+          nil -> {:error, :no_contact}
+          contact -> {:ok, contact}
+        end
+    end
+  end
+
+  defp fetch_conv(conversation_id) do
+    # ownership: system-level call from ConversationServer, which owns the
+    # conversation; the contact fetched next is re-scoped by its user_id.
+    Conversations._unsafe_get_conversation(conversation_id)
+  rescue
+    Ecto.Query.CastError -> nil
+  end
+
+  ## provisioning
+
+  defp gate(user_id) do
+    cond do
+      not flag_on?(user_id) -> {:error, :not_enabled}
+      not configured?() -> {:error, :not_configured}
+      true -> :ok
+    end
+  end
+
+  defp ensure_no_contact(user_id, agent_id) do
+    case get_contact(user_id, agent_id) do
+      nil -> :ok
+      %Contact{} -> {:error, :already_provisioned}
+    end
+  end
+
+  defp create_inbox(name, teammate, opts) do
+    attrs =
+      %{
+        "username" => username(name, opts),
+        "display_name" => name,
+        "client_id" => "fountain-team:" <> teammate.agent.id
+      }
+      |> put_present("domain", AgentMail.domain())
+
+    case AgentMail.create_inbox(attrs) do
+      {:ok, %{"inbox_id" => _, "email" => _} = inbox} -> {:ok, inbox}
+      {:ok, other} -> {:error, {:email, {:unexpected_response, other}}}
+      {:error, reason} -> {:error, {:email, reason}}
+    end
+  end
+
+  defp create_number(inbox, opts) do
+    attrs = %{"country" => Keyword.get(opts, :country, "US")}
+
+    case AgentPhone.create_number(attrs) do
+      {:ok, %{"id" => _, "phoneNumber" => _} = number} ->
+        {:ok, number}
+
+      {:ok, other} ->
+        release_upstream(inbox["inbox_id"], nil)
+        {:error, {:phone, {:unexpected_response, other}}}
+
+      {:error, reason} ->
+        release_upstream(inbox["inbox_id"], nil)
+        {:error, {:phone, reason}}
+    end
+  end
+
+  # The local part of the address: the teammate's name as a slug plus a short
+  # random suffix, since usernames are unique per domain and teammates are
+  # not. `opts[:username]` overrides for a deliberate address.
+  defp username(name, opts) do
+    case Keyword.get(opts, :username) do
+      u when is_binary(u) and u != "" ->
+        u
+
+      _ ->
+        slug =
+          name
+          |> String.downcase()
+          |> String.replace(~r/[^a-z0-9]+/, "-")
+          |> String.trim("-")
+          |> String.slice(0, 24)
+
+        suffix = :crypto.strong_rand_bytes(3) |> Base.encode16(case: :lower)
+        if slug == "", do: "teammate-" <> suffix, else: slug <> "-" <> suffix
+    end
+  end
+
+  defp release_email(%Contact{} = c) do
+    if Contact.email?(c),
+      do: release_one(:email, AgentMail.delete_inbox(c.email_inbox_id)),
+      else: :ok
+  end
+
+  defp release_phone(%Contact{} = c) do
+    if Contact.phone?(c),
+      do: release_one(:phone, AgentPhone.delete_number(c.phone_number_id)),
+      else: :ok
+  end
+
+  defp release_one(_channel, {:ok, _}), do: :ok
+  defp release_one(_channel, {:error, {:status, 404, _}}), do: :ok
+  defp release_one(channel, {:error, reason}), do: {:error, {channel, reason}}
+
+  # Best-effort cleanup after a partial provision; a failure here is logged,
+  # not raised — the caller is already returning the real error.
+  defp release_upstream(inbox_id, number_id) do
+    if is_binary(inbox_id) do
+      case AgentMail.delete_inbox(inbox_id) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning(
+            "team comms: could not delete inbox #{inbox_id} after a failed provision: #{inspect(reason)}"
+          )
+      end
+    end
+
+    if is_binary(number_id) do
+      case AgentPhone.delete_number(number_id) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning(
+            "team comms: could not release number #{number_id} after a failed provision: #{inspect(reason)}"
+          )
+      end
+    end
+
+    :ok
+  end
+
+  defp channels(%Contact{} = c) do
+    Enum.reject([Contact.email?(c) && "email", Contact.phone?(c) && "phone"], &(&1 == false))
+  end
+
+  defp put_present(map, _k, nil), do: map
+  defp put_present(map, k, v), do: Map.put(map, k, v)
+
+  defp record(action, %Contact{} = contact, opts, metadata) do
+    Audit.record(%{
+      user_id: contact.user_id,
+      action: action,
+      resource_type: "team_contact",
+      resource_id: contact.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: Map.put(metadata, "agent_id", contact.agent_id)
+    })
+  end
+end

--- a/apps/fountain/lib/fountain/team/comms/agent_mail.ex
+++ b/apps/fountain/lib/fountain/team/comms/agent_mail.ex
@@ -1,0 +1,71 @@
+defmodule Fountain.Team.Comms.AgentMail do
+  @moduledoc """
+  Thin client for the AgentMail API (`api.agentmail.to/v0`) — the inboxes
+  Fountain provisions for teammates and the messages in them.
+
+  Fountain holds the key (`AGENTMAIL_API_KEY`); every call here runs
+  server-side on a teammate's behalf. Responses come back as the decoded JSON
+  maps the API returns; errors as `{:error, {:status, code, body}}` or
+  `{:error, reason}` for a transport failure. Tests inject a `Req.Test` plug
+  through `:agentmail_req_options`.
+  """
+
+  @doc "Whether an API key is configured."
+  def configured?, do: is_binary(api_key()) and api_key() != ""
+
+  def api_key, do: Application.get_env(:fountain, :agentmail_api_key)
+
+  def base_url,
+    do: Application.get_env(:fountain, :agentmail_base_url, "https://api.agentmail.to")
+
+  @doc "The custom domain for teammate addresses, or nil for AgentMail's shared one."
+  def domain do
+    case Application.get_env(:fountain, :agentmail_domain) do
+      d when is_binary(d) and d != "" -> d
+      _ -> nil
+    end
+  end
+
+  def req do
+    Req.new(
+      [
+        base_url: base_url(),
+        auth: {:bearer, api_key() || ""},
+        receive_timeout: Application.get_env(:fountain, :agentmail_timeout_ms, 15_000),
+        retry: false
+      ] ++ Application.get_env(:fountain, :agentmail_req_options, [])
+    )
+  end
+
+  @doc """
+  Create an inbox. `attrs` may carry `username`, `domain`, `display_name`,
+  `client_id`, `metadata`. Returns the inbox map (`inbox_id`, `email`, …).
+  """
+  def create_inbox(attrs) when is_map(attrs), do: post("/v0/inboxes", attrs)
+
+  def delete_inbox(inbox_id), do: request(:delete, "/v0/inboxes/#{enc(inbox_id)}")
+
+  def list_messages(inbox_id, params \\ []),
+    do: request(:get, "/v0/inboxes/#{enc(inbox_id)}/messages", params: params)
+
+  def get_message(inbox_id, message_id),
+    do: request(:get, "/v0/inboxes/#{enc(inbox_id)}/messages/#{enc(message_id)}")
+
+  def send_message(inbox_id, body) when is_map(body),
+    do: post("/v0/inboxes/#{enc(inbox_id)}/messages/send", body)
+
+  def reply_to_message(inbox_id, message_id, body) when is_map(body),
+    do: post("/v0/inboxes/#{enc(inbox_id)}/messages/#{enc(message_id)}/reply", body)
+
+  defp post(path, body), do: request(:post, path, json: body)
+
+  defp request(method, path, opts \\ []) do
+    case Req.request(req(), [method: method, url: path] ++ opts) do
+      {:ok, %Req.Response{status: status, body: body}} when status in 200..299 -> {:ok, body}
+      {:ok, %Req.Response{status: status, body: body}} -> {:error, {:status, status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp enc(s), do: URI.encode(to_string(s), &URI.char_unreserved?/1)
+end

--- a/apps/fountain/lib/fountain/team/comms/agent_phone.ex
+++ b/apps/fountain/lib/fountain/team/comms/agent_phone.ex
@@ -1,0 +1,56 @@
+defmodule Fountain.Team.Comms.AgentPhone do
+  @moduledoc """
+  Thin client for the AgentPhone API (`api.agentphone.ai/v1`) — the numbers
+  Fountain provisions for teammates and the SMS on them.
+
+  Fountain holds the key (`AGENTPHONE_API_KEY`); every call here runs
+  server-side on a teammate's behalf. Same conventions as
+  `Fountain.Team.Comms.AgentMail`; tests inject a `Req.Test` plug through
+  `:agentphone_req_options`.
+  """
+
+  @doc "Whether an API key is configured."
+  def configured?, do: is_binary(api_key()) and api_key() != ""
+
+  def api_key, do: Application.get_env(:fountain, :agentphone_api_key)
+
+  def base_url,
+    do: Application.get_env(:fountain, :agentphone_base_url, "https://api.agentphone.ai")
+
+  def req do
+    Req.new(
+      [
+        base_url: base_url(),
+        auth: {:bearer, api_key() || ""},
+        receive_timeout: Application.get_env(:fountain, :agentphone_timeout_ms, 30_000),
+        retry: false
+      ] ++ Application.get_env(:fountain, :agentphone_req_options, [])
+    )
+  end
+
+  @doc """
+  Provision a number. `attrs` may carry `country` (default US), `areaCode`.
+  Returns the number map (`id`, `phoneNumber`, `status`, `outboundSms`, …).
+  """
+  def create_number(attrs \\ %{}) when is_map(attrs), do: post("/v1/numbers", attrs)
+
+  def delete_number(number_id), do: request(:delete, "/v1/numbers/#{enc(number_id)}")
+
+  def list_messages(number_id, params \\ []),
+    do: request(:get, "/v1/numbers/#{enc(number_id)}/messages", params: params)
+
+  @doc "Send an SMS: `%{number_id:, to_number:, body:}`."
+  def send_message(body) when is_map(body), do: post("/v1/messages", body)
+
+  defp post(path, body), do: request(:post, path, json: body)
+
+  defp request(method, path, opts \\ []) do
+    case Req.request(req(), [method: method, url: path] ++ opts) do
+      {:ok, %Req.Response{status: status, body: body}} when status in 200..299 -> {:ok, body}
+      {:ok, %Req.Response{status: status, body: body}} -> {:error, {:status, status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp enc(s), do: URI.encode(to_string(s), &URI.char_unreserved?/1)
+end

--- a/apps/fountain/lib/fountain/team/comms/inbound.ex
+++ b/apps/fountain/lib/fountain/team/comms/inbound.ex
@@ -1,0 +1,216 @@
+defmodule Fountain.Team.Comms.Inbound do
+  @moduledoc """
+  Inbound texts to a teammate's number, arriving as prompts (flag
+  `team_comms`).
+
+  AgentPhone delivers every inbound message on the account's numbers to one
+  master webhook (`POST /api/webhooks/agentphone`,
+  `FountainWeb.AgentPhoneWebhookController`, which verifies the HMAC
+  signature first). `handle/2` is the policy behind it: an `agent.message`
+  on `sms`/`mms`/`imessage`, inbound, to a number some teammate owns,
+  **from that teammate's `prompt_from_number`** — and nothing else — becomes
+  `Team.send_message` into the teammate's conversation, which wakes a parked
+  computer by itself. The text is wrapped so the teammate knows it came by
+  SMS and can answer with its `sms_send` tool; its own reply text is not
+  sent anywhere.
+
+  Every other delivery is acknowledged and ignored — a stranger texting the
+  number, a voice transcript, an outbound echo — and says why in the return
+  value, never in an error status (AgentPhone retries non-2xx for hours).
+
+  Deliveries are deduplicated by `X-Webhook-ID` through `Seen`, a per-node
+  ETS table: a retry of a delivery this node already turned into a prompt is
+  dropped. A retry landing on the other node after the first succeeded is
+  the one gap — rare, and bounded at one duplicate prompt.
+
+  Every prompt is audited as `team.contact.prompted` (bytes, never the
+  text), actor `system:agentphone`.
+  """
+
+  require Logger
+
+  alias Fountain.{Audit, Team}
+  alias Fountain.Team.Comms
+  alias Fountain.Team.Comms.Phone
+  alias Fountain.Team.Contact
+
+  @actor "system:agentphone"
+  @channels ~w(sms mms imessage)
+
+  @doc "The audit actor for prompts that came in by text."
+  def actor, do: @actor
+
+  @doc """
+  Handle one verified webhook payload. `delivery_id` is the `X-Webhook-ID`
+  (nil when absent — then nothing is deduplicated).
+
+  Returns `{:ok, conversation_id}` when a prompt was sent, or
+  `{:ignored, reason}` with one of `:duplicate`, `:not_a_message`,
+  `:not_inbound`, `:unknown_number`, `:sender_not_allowed`, `:empty`,
+  `:unavailable` (flag off or providers unconfigured for the owner), or
+  `{:send_failed, reason}`.
+  """
+  def handle(payload, delivery_id \\ nil)
+
+  def handle(
+        %{
+          "event" => "agent.message",
+          "channel" => channel,
+          "data" => %{"direction" => "inbound", "from" => from, "to" => to} = data
+        },
+        delivery_id
+      )
+      when channel in @channels and is_binary(from) and is_binary(to) do
+    with :ok <- fresh(delivery_id),
+         {:ok, %Contact{} = contact} <- contact_for(to),
+         :ok <- sender_allowed(contact, from),
+         :ok <- available(contact),
+         {:ok, text} <- body(data) do
+      prompt = wrap(text, from, to, data)
+
+      case Team.send_message(contact.user_id, contact.agent_id, prompt, [],
+             actor: @actor,
+             source: "sms"
+           ) do
+        {:ok, conv} ->
+          record(contact, text, conv)
+          {:ok, conv.id}
+
+        {:error, reason} ->
+          Logger.warning(
+            "team comms inbound: could not prompt agent #{contact.agent_id} from a text: #{inspect(reason)}"
+          )
+
+          {:ignored, {:send_failed, reason}}
+      end
+    else
+      {:ignored, _} = ignored -> ignored
+    end
+  end
+
+  def handle(%{"event" => "agent.message"}, _delivery_id), do: {:ignored, :not_inbound}
+  def handle(_payload, _delivery_id), do: {:ignored, :not_a_message}
+
+  defp fresh(nil), do: :ok
+
+  defp fresh(delivery_id) do
+    if __MODULE__.Seen.first_time?(delivery_id), do: :ok, else: {:ignored, :duplicate}
+  end
+
+  defp contact_for(to) do
+    # ownership: a webhook has no tenant; the controller verified AgentPhone's
+    # signature, and the contact found by its own number decides whose
+    # conversation (and only whose) gets prompted — by the contact's user_id.
+    with {:ok, e164} <- Phone.normalize(to),
+         %Contact{} = contact <- Comms._unsafe_get_contact_by_phone_number(e164) do
+      {:ok, contact}
+    else
+      _ -> {:ignored, :unknown_number}
+    end
+  end
+
+  defp sender_allowed(%Contact{prompt_from_number: allowed}, from)
+       when is_binary(allowed) and allowed != "" do
+    if Phone.same?(allowed, from), do: :ok, else: {:ignored, :sender_not_allowed}
+  end
+
+  defp sender_allowed(_contact, _from), do: {:ignored, :sender_not_allowed}
+
+  defp available(%Contact{user_id: user_id}) do
+    if Comms.available?(user_id), do: :ok, else: {:ignored, :unavailable}
+  end
+
+  defp body(%{"message" => text}) when is_binary(text) do
+    case String.trim(text) do
+      "" -> {:ignored, :empty}
+      trimmed -> {:ok, trimmed}
+    end
+  end
+
+  defp body(_), do: {:ignored, :empty}
+
+  # What the teammate reads. Names the channel and the sender so it can
+  # answer the same way; a media attachment is passed as its URL.
+  defp wrap(text, from, to, data) do
+    media =
+      case data["mediaUrl"] do
+        url when is_binary(url) and url != "" -> "\n(attachment: #{url})"
+        _ -> ""
+      end
+
+    "[Text message from #{from} to your number #{to}]\n#{text}#{media}\n\n" <>
+      "(This arrived by SMS. If a reply is wanted, send it with the sms_send tool to #{from}; " <>
+      "what you write here is not texted back.)"
+  end
+
+  defp record(%Contact{} = contact, text, conv) do
+    Audit.record(%{
+      user_id: contact.user_id,
+      action: "team.contact.prompted",
+      resource_type: "team_contact",
+      resource_id: contact.id,
+      actor: @actor,
+      metadata: %{
+        "agent_id" => contact.agent_id,
+        "conversation_id" => conv.id,
+        "channel" => "sms",
+        "prompt_bytes" => byte_size(text)
+      }
+    })
+  end
+
+  defmodule Seen do
+    @moduledoc """
+    Delivery ids this node has already turned into prompts. ETS, public,
+    swept of entries older than an hour every ten minutes — AgentPhone's
+    retries span twelve hours, but a duplicate that late is harmless next to
+    the table growing without bound.
+    """
+    use GenServer
+
+    @table :fountain_team_comms_seen
+    @ttl_ms 60 * 60 * 1000
+    @sweep_ms 10 * 60 * 1000
+
+    def start_link(opts),
+      do: GenServer.start_link(__MODULE__, :ok, Keyword.put_new(opts, :name, __MODULE__))
+
+    @doc "True the first time `id` is offered, false on every later call."
+    def first_time?(id) when is_binary(id) do
+      ensure_table()
+      :ets.insert_new(@table, {id, System.monotonic_time(:millisecond)})
+    end
+
+    @doc false
+    def reset do
+      ensure_table()
+      :ets.delete_all_objects(@table)
+      :ok
+    end
+
+    @impl true
+    def init(:ok) do
+      ensure_table()
+      Process.send_after(self(), :sweep, @sweep_ms)
+      {:ok, %{}}
+    end
+
+    @impl true
+    def handle_info(:sweep, state) do
+      cutoff = System.monotonic_time(:millisecond) - @ttl_ms
+      :ets.select_delete(@table, [{{:_, :"$1"}, [{:<, :"$1", cutoff}], [true]}])
+      Process.send_after(self(), :sweep, @sweep_ms)
+      {:noreply, state}
+    end
+
+    defp ensure_table do
+      if :ets.whereis(@table) == :undefined do
+        :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+      end
+
+      :ok
+    catch
+      :error, :badarg -> :ok
+    end
+  end
+end

--- a/apps/fountain/lib/fountain/team/comms/mcp.ex
+++ b/apps/fountain/lib/fountain/team/comms/mcp.ex
@@ -161,6 +161,8 @@ defmodule Fountain.Team.Comms.Mcp do
       "You have your own contact details.",
       Contact.email?(c) && "Your email address is #{c.email_address}.",
       Contact.phone?(c) && "Your phone number is #{c.phone_number}.",
+      Contact.phone?(c) && is_binary(c.prompt_from_number) &&
+        "Texts from #{c.prompt_from_number} to your number reach you as messages; answer them with sms_send.",
       "Use the email_* and sms_* tools to send and read; nothing you write elsewhere is sent."
     ]
     |> Enum.reject(&(&1 == false))

--- a/apps/fountain/lib/fountain/team/comms/mcp.ex
+++ b/apps/fountain/lib/fountain/team/comms/mcp.ex
@@ -1,0 +1,480 @@
+defmodule Fountain.Team.Comms.Mcp do
+  @moduledoc """
+  Server-side MCP tools that let a teammate use its email address and phone
+  number (flag `team_comms`).
+
+  The AgentMail and AgentPhone keys stay with Fountain; the teammate's sandbox
+  calls a tool and Fountain performs the send or the read under its own key,
+  scoped to this teammate's inbox and number. Every send is a tool call
+  Fountain can see and audit.
+
+  This is the pure protocol/tool layer, the same shape as `Fountain.Buzz.Mcp`:
+  `handle/2` takes one JSON-RPC request map and a `ctx`, returns one response
+  map (or `:noreply` for a notification). The transport and the `ctx`
+  construction live in `FountainWeb.TeamCommsMcpController`.
+
+  `ctx` fields:
+    * `:contact` — the `%Fountain.Team.Contact{}` the tools act for
+    * `:mail`    — the AgentMail client module (default
+                   `Fountain.Team.Comms.AgentMail`), injectable for tests
+    * `:phone`   — the AgentPhone client module (default
+                   `Fountain.Team.Comms.AgentPhone`)
+    * `:audit`   — optional `(tool_name, summary_map) -> any` called after a
+                   successful send, for the audit trail
+  """
+
+  alias Fountain.Team.Contact
+
+  # The MCP protocol revision we implement (Streamable HTTP transport).
+  @protocol_version "2025-06-18"
+  @server_info %{name: "fountain-comms", version: "1"}
+
+  @default_list_limit 20
+  @max_list_limit 100
+
+  @doc "The tool catalogue advertised by `tools/list`, for this contact."
+  def tools(%Contact{} = contact) do
+    email_tools(contact) ++ phone_tools(contact) ++ [whoami_tool()]
+  end
+
+  defp email_tools(%Contact{} = c) do
+    if Contact.email?(c) do
+      [
+        %{
+          name: "email_send",
+          description:
+            "Send an email from your own address (#{c.email_address}). " <>
+              "Use email_reply to answer a message you received.",
+          inputSchema: %{
+            type: "object",
+            properties: %{
+              to: %{
+                type: "array",
+                items: %{type: "string"},
+                description: "Recipient addresses"
+              },
+              subject: %{type: "string"},
+              text: %{type: "string", description: "Plain-text body"},
+              cc: %{type: "array", items: %{type: "string"}},
+              html: %{type: "string", description: "Optional HTML body"}
+            },
+            required: ["to", "subject", "text"]
+          }
+        },
+        %{
+          name: "email_reply",
+          description:
+            "Reply to an email in your inbox, in its thread. Give the message_id " <>
+              "from email_list / email_get.",
+          inputSchema: %{
+            type: "object",
+            properties: %{
+              message_id: %{type: "string"},
+              text: %{type: "string", description: "Plain-text body"},
+              reply_all: %{type: "boolean", description: "Reply to every recipient"},
+              html: %{type: "string"}
+            },
+            required: ["message_id", "text"]
+          }
+        },
+        %{
+          name: "email_list",
+          description:
+            "List the messages in your inbox (#{c.email_address}), newest first: " <>
+              "sender, subject, timestamp, a preview and the message_id to read or reply with.",
+          inputSchema: %{
+            type: "object",
+            properties: %{
+              limit: %{type: "integer", description: "Max messages (default 20, max 100)"},
+              unread_only: %{type: "boolean", description: "Only messages labelled unread"},
+              after: %{
+                type: "string",
+                description: "ISO-8601 timestamp; only messages after it"
+              },
+              from: %{type: "string", description: "Only messages whose sender contains this"}
+            }
+          }
+        },
+        %{
+          name: "email_get",
+          description: "Read one email in full: headers and the text body.",
+          inputSchema: %{
+            type: "object",
+            properties: %{message_id: %{type: "string"}},
+            required: ["message_id"]
+          }
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp phone_tools(%Contact{} = c) do
+    if Contact.phone?(c) do
+      [
+        %{
+          name: "sms_send",
+          description: "Send a text message (SMS) from your own number (#{c.phone_number}).",
+          inputSchema: %{
+            type: "object",
+            properties: %{
+              to: %{type: "string", description: "Recipient phone number, E.164 preferred"},
+              body: %{type: "string"}
+            },
+            required: ["to", "body"]
+          }
+        },
+        %{
+          name: "sms_list",
+          description:
+            "List the text messages on your number (#{c.phone_number}), newest first, " <>
+              "both sent and received.",
+          inputSchema: %{
+            type: "object",
+            properties: %{
+              limit: %{type: "integer", description: "Max messages (default 20, max 100)"},
+              after: %{
+                type: "string",
+                description: "ISO-8601 timestamp; only messages after it"
+              }
+            }
+          }
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp whoami_tool do
+    %{
+      name: "my_contact_info",
+      description: "Your own email address and phone number, to share with people.",
+      inputSchema: %{type: "object", properties: %{}}
+    }
+  end
+
+  @doc "The `instructions` string `initialize` returns — who the teammate is."
+  def instructions(%Contact{} = c) do
+    [
+      "You have your own contact details.",
+      Contact.email?(c) && "Your email address is #{c.email_address}.",
+      Contact.phone?(c) && "Your phone number is #{c.phone_number}.",
+      "Use the email_* and sms_* tools to send and read; nothing you write elsewhere is sent."
+    ]
+    |> Enum.reject(&(&1 == false))
+    |> Enum.join(" ")
+  end
+
+  @doc """
+  Handle one JSON-RPC 2.0 request map against `ctx`.
+
+  Returns a response map to send back, or `:noreply` for a notification (a
+  request with no `id`), which per JSON-RPC gets no response.
+  """
+  def handle(%{"method" => method} = req, ctx) do
+    id = Map.get(req, "id")
+
+    if is_nil(id) and String.starts_with?(method, "notifications/") do
+      :noreply
+    else
+      dispatch(method, id, Map.get(req, "params", %{}), ctx)
+    end
+  end
+
+  def handle(_req, _ctx), do: error(nil, -32_600, "invalid request")
+
+  defp dispatch("initialize", id, _params, ctx) do
+    result(id, %{
+      protocolVersion: @protocol_version,
+      capabilities: %{tools: %{}},
+      serverInfo: @server_info,
+      instructions: instructions(ctx.contact)
+    })
+  end
+
+  defp dispatch("ping", id, _params, _ctx), do: result(id, %{})
+
+  defp dispatch("tools/list", id, _params, ctx), do: result(id, %{tools: tools(ctx.contact)})
+
+  defp dispatch("tools/call", id, %{"name" => name} = params, ctx) do
+    call_tool(id, name, Map.get(params, "arguments", %{}) || %{}, ctx)
+  end
+
+  defp dispatch(_unknown, nil, _params, _ctx), do: :noreply
+
+  defp dispatch(method, id, _params, _ctx) do
+    error(id, -32_601, "method not found: #{method}")
+  end
+
+  # ── tools ──────────────────────────────────────────────────────────────────
+
+  defp call_tool(id, "my_contact_info", _args, %{contact: c}) do
+    ok(id, %{
+      email: (Contact.email?(c) && c.email_address) || nil,
+      phone: (Contact.phone?(c) && c.phone_number) || nil
+    })
+  end
+
+  defp call_tool(id, "email_send", args, ctx) do
+    with {:ok, c} <- email_contact(ctx),
+         {:ok, to} <- require_addresses(args, "to"),
+         {:ok, subject} <- require_arg(args, "subject"),
+         {:ok, text} <- require_arg(args, "text") do
+      body =
+        %{"to" => to, "subject" => subject, "text" => text}
+        |> put_present("cc", addresses(args["cc"]))
+        |> put_present("html", present(args["html"]))
+
+      case mail(ctx).send_message(c.email_inbox_id, body) do
+        {:ok, %{"message_id" => mid} = resp} ->
+          audit(ctx, "email_send", %{"recipients" => length(to)})
+          ok(id, %{message_id: mid, thread_id: resp["thread_id"]})
+
+        {:ok, other} ->
+          ok(id, other)
+
+        {:error, reason} ->
+          tool_error(id, "email_send failed: #{describe(reason)}")
+      end
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, "email_reply", args, ctx) do
+    with {:ok, c} <- email_contact(ctx),
+         {:ok, message_id} <- require_arg(args, "message_id"),
+         {:ok, text} <- require_arg(args, "text") do
+      body =
+        %{"text" => text}
+        |> put_present("html", present(args["html"]))
+        |> put_present("reply_all", if(args["reply_all"] == true, do: true))
+
+      case mail(ctx).reply_to_message(c.email_inbox_id, message_id, body) do
+        {:ok, %{"message_id" => mid} = resp} ->
+          audit(ctx, "email_reply", %{"reply_all" => args["reply_all"] == true})
+          ok(id, %{message_id: mid, thread_id: resp["thread_id"]})
+
+        {:ok, other} ->
+          ok(id, other)
+
+        {:error, reason} ->
+          tool_error(id, "email_reply failed: #{describe(reason)}")
+      end
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, "email_list", args, ctx) do
+    with {:ok, c} <- email_contact(ctx) do
+      params =
+        [limit: limit(args)]
+        |> put_param(:labels, if(args["unread_only"] == true, do: ["unread"]))
+        |> put_param(:after, present(args["after"]))
+        |> put_param(:from, present(args["from"]))
+
+      case mail(ctx).list_messages(c.email_inbox_id, params) do
+        {:ok, %{"messages" => messages} = resp} ->
+          ok(id, %{
+            count: length(messages),
+            next_page_token: resp["next_page_token"],
+            messages: Enum.map(messages, &email_summary/1)
+          })
+
+        {:ok, other} ->
+          ok(id, other)
+
+        {:error, reason} ->
+          tool_error(id, "email_list failed: #{describe(reason)}")
+      end
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, "email_get", args, ctx) do
+    with {:ok, c} <- email_contact(ctx),
+         {:ok, message_id} <- require_arg(args, "message_id") do
+      case mail(ctx).get_message(c.email_inbox_id, message_id) do
+        {:ok, message} -> ok(id, email_full(message))
+        {:error, reason} -> tool_error(id, "email_get failed: #{describe(reason)}")
+      end
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, "sms_send", args, ctx) do
+    with {:ok, c} <- phone_contact(ctx),
+         {:ok, to} <- require_arg(args, "to"),
+         {:ok, body} <- require_arg(args, "body") do
+      payload = %{"number_id" => c.phone_number_id, "to_number" => to, "body" => body}
+
+      case phone(ctx).send_message(payload) do
+        {:ok, %{"id" => mid} = resp} ->
+          audit(ctx, "sms_send", %{})
+          ok(id, %{message_id: mid, status: resp["status"], channel: resp["channel"]})
+
+        {:ok, other} ->
+          ok(id, other)
+
+        {:error, reason} ->
+          tool_error(id, "sms_send failed: #{describe(reason)}")
+      end
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, "sms_list", args, ctx) do
+    with {:ok, c} <- phone_contact(ctx) do
+      params = [limit: limit(args)] |> put_param(:after, present(args["after"]))
+
+      case phone(ctx).list_messages(c.phone_number_id, params) do
+        {:ok, %{"data" => messages} = resp} ->
+          ok(id, %{
+            count: length(messages),
+            has_more: resp["hasMore"] == true,
+            messages: Enum.map(messages, &sms_summary/1)
+          })
+
+        {:ok, other} ->
+          ok(id, other)
+
+        {:error, reason} ->
+          tool_error(id, "sms_list failed: #{describe(reason)}")
+      end
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, name, _args, _ctx), do: tool_error(id, "unknown tool: #{name}")
+
+  # ── shaping ────────────────────────────────────────────────────────────────
+
+  defp email_summary(m) do
+    %{
+      message_id: m["message_id"],
+      thread_id: m["thread_id"],
+      from: m["from"],
+      to: m["to"],
+      subject: m["subject"],
+      timestamp: m["timestamp"],
+      labels: m["labels"],
+      preview: m["preview"],
+      attachments:
+        Enum.map(m["attachments"] || [], &Map.take(&1, ["filename", "content_type", "size"]))
+    }
+  end
+
+  defp email_full(m) do
+    m
+    |> email_summary()
+    |> Map.merge(%{
+      cc: m["cc"],
+      reply_to: m["reply_to"],
+      in_reply_to: m["in_reply_to"],
+      text: m["extracted_text"] || m["text"] || strip_html(m["html"])
+    })
+  end
+
+  defp sms_summary(m) do
+    %{
+      message_id: m["id"],
+      from: m["from_"] || m["from"],
+      to: m["to"],
+      body: m["body"],
+      direction: m["direction"],
+      received_at: m["receivedAt"],
+      status: m["status"]
+    }
+  end
+
+  defp strip_html(nil), do: nil
+
+  defp strip_html(html) when is_binary(html),
+    do: html |> String.replace(~r/<[^>]*>/, " ") |> String.trim()
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  defp mail(ctx), do: Map.get(ctx, :mail, Fountain.Team.Comms.AgentMail)
+  defp phone(ctx), do: Map.get(ctx, :phone, Fountain.Team.Comms.AgentPhone)
+
+  defp email_contact(%{contact: %Contact{} = c}) do
+    if Contact.email?(c), do: {:ok, c}, else: {:error, "this teammate has no email address"}
+  end
+
+  defp phone_contact(%{contact: %Contact{} = c}) do
+    if Contact.phone?(c), do: {:ok, c}, else: {:error, "this teammate has no phone number"}
+  end
+
+  defp audit(%{audit: audit}, tool, summary) when is_function(audit, 2), do: audit.(tool, summary)
+  defp audit(_ctx, _tool, _summary), do: :ok
+
+  defp require_arg(args, key) do
+    case Map.get(args, key) do
+      v when is_binary(v) and v != "" -> {:ok, v}
+      _ -> {:error, "missing required argument: #{key}"}
+    end
+  end
+
+  defp require_addresses(args, key) do
+    case addresses(Map.get(args, key)) do
+      [] -> {:error, "missing required argument: #{key}"}
+      list -> {:ok, list}
+    end
+  end
+
+  defp addresses(nil), do: []
+
+  defp addresses(v) when is_binary(v),
+    do: v |> String.split(~r/[,;]\s*/, trim: true) |> Enum.map(&String.trim/1)
+
+  defp addresses(v) when is_list(v),
+    do: v |> Enum.filter(&is_binary/1) |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
+
+  defp addresses(_), do: []
+
+  defp present(v) when is_binary(v) and v != "", do: v
+  defp present(_), do: nil
+
+  defp limit(args) do
+    case args["limit"] do
+      n when is_integer(n) and n > 0 -> min(n, @max_list_limit)
+      _ -> @default_list_limit
+    end
+  end
+
+  defp put_present(map, _k, nil), do: map
+  defp put_present(map, _k, []), do: map
+  defp put_present(map, k, v), do: Map.put(map, k, v)
+
+  defp put_param(params, _k, nil), do: params
+  defp put_param(params, k, v), do: Keyword.put(params, k, v)
+
+  defp describe({:status, status, body}) when is_map(body),
+    do:
+      "HTTP #{status}: #{body["message"] || body["error"] || body["detail"] || Jason.encode!(body)}"
+
+  defp describe({:status, status, body}), do: "HTTP #{status}: #{inspect(body)}"
+  defp describe(%{__exception__: true} = e), do: Exception.message(e)
+  defp describe(other), do: inspect(other)
+
+  defp text(str), do: %{type: "text", text: to_string(str)}
+
+  defp ok(id, payload), do: result(id, %{content: [text(Jason.encode!(payload))], isError: false})
+
+  defp result(id, result), do: %{"jsonrpc" => "2.0", "id" => id, "result" => result}
+
+  defp error(id, code, message),
+    do: %{"jsonrpc" => "2.0", "id" => id, "error" => %{"code" => code, "message" => message}}
+
+  # A tool-level failure is a successful JSON-RPC response carrying isError, per
+  # MCP — the model sees it and can recover, rather than the call itself failing.
+  defp tool_error(id, message),
+    do: result(id, %{content: [text(message)], isError: true})
+end

--- a/apps/fountain/lib/fountain/team/comms/phone.ex
+++ b/apps/fountain/lib/fountain/team/comms/phone.ex
@@ -1,0 +1,41 @@
+defmodule Fountain.Team.Comms.Phone do
+  @moduledoc """
+  Phone numbers as E.164 (`+15551234567`), the one shape AgentPhone speaks
+  and the one `team_contacts` stores. `normalize/1` is forgiving about what
+  people type — spaces, dashes, parentheses, a leading `1` or none on a US
+  number — and strict about what comes out.
+  """
+
+  @e164 ~r/^\+[1-9]\d{6,14}$/
+
+  @doc """
+  `{:ok, "+1555..."}` or `:error`. A bare 10-digit number is taken as US/CA;
+  an 11-digit number starting with 1 likewise; anything else must carry its
+  own `+` country code.
+  """
+  @spec normalize(term) :: {:ok, String.t()} | :error
+  def normalize(value) when is_binary(value) do
+    digits = String.replace(value, ~r/[\s().-]/, "")
+
+    candidate =
+      cond do
+        String.starts_with?(digits, "+") -> digits
+        String.starts_with?(digits, "00") -> "+" <> String.slice(digits, 2..-1//1)
+        Regex.match?(~r/^\d{10}$/, digits) -> "+1" <> digits
+        Regex.match?(~r/^1\d{10}$/, digits) -> "+" <> digits
+        true -> digits
+      end
+
+    if Regex.match?(@e164, candidate), do: {:ok, candidate}, else: :error
+  end
+
+  def normalize(_), do: :error
+
+  @doc "Whether two numbers are the same once normalized."
+  def same?(a, b) do
+    case {normalize(a), normalize(b)} do
+      {{:ok, x}, {:ok, y}} -> x == y
+      _ -> false
+    end
+  end
+end

--- a/apps/fountain/lib/fountain/team/contact.ex
+++ b/apps/fountain/lib/fountain/team/contact.ex
@@ -7,6 +7,10 @@ defmodule Fountain.Team.Contact do
   survives the teammate's conversation being replaced. Either channel may be
   absent (the provider declined, or was not configured) — `email?/1` and
   `phone?/1` say which the teammate actually has.
+
+  `prompt_from_number` is the one number whose texts to the teammate's number
+  arrive as prompts in its conversation (`Fountain.Team.Comms.Inbound`) —
+  the owner's phone, collected whenever a number is given. Stored E.164.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -19,6 +23,7 @@ defmodule Fountain.Team.Contact do
     field :email_inbox_id, :string
     field :phone_number, :string
     field :phone_number_id, :string
+    field :prompt_from_number, :string
 
     belongs_to :user, Fountain.Accounts.User
     belongs_to :agent, Fountain.Agents.Agent
@@ -26,15 +31,56 @@ defmodule Fountain.Team.Contact do
     timestamps(type: :utc_datetime)
   end
 
-  @fields [:user_id, :agent_id, :email_address, :email_inbox_id, :phone_number, :phone_number_id]
+  @fields [
+    :user_id,
+    :agent_id,
+    :email_address,
+    :email_inbox_id,
+    :phone_number,
+    :phone_number_id,
+    :prompt_from_number
+  ]
 
   def changeset(contact, attrs) do
     contact
     |> cast(attrs, @fields)
     |> validate_required([:user_id, :agent_id])
+    |> normalize_number(:prompt_from_number)
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:agent_id)
     |> unique_constraint([:user_id, :agent_id])
+  end
+
+  @doc """
+  What the user supplies when giving a teammate a contact — today just the
+  number whose texts become prompts, required and E.164-normalized. Run
+  before anything is bought upstream, so a typo costs nothing.
+  """
+  def request_changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, [:prompt_from_number])
+    |> validate_required([:prompt_from_number])
+    |> normalize_number(:prompt_from_number)
+  end
+
+  defp normalize_number(changeset, field) do
+    case get_change(changeset, field) do
+      nil ->
+        changeset
+
+      value ->
+        case Fountain.Team.Comms.Phone.normalize(value) do
+          {:ok, e164} ->
+            put_change(changeset, field, e164)
+
+          :error ->
+            add_error(
+              changeset,
+              field,
+              "must be a phone number with country code, e.g. +15551234567"
+            )
+        end
+    end
   end
 
   def email?(%__MODULE__{email_inbox_id: id}), do: is_binary(id) and id != ""

--- a/apps/fountain/lib/fountain/team/contact.ex
+++ b/apps/fountain/lib/fountain/team/contact.ex
@@ -1,0 +1,42 @@
+defmodule Fountain.Team.Contact do
+  @moduledoc """
+  A teammate's email address and phone number — the AgentMail inbox and
+  AgentPhone number Fountain provisioned for it (`Fountain.Team.Comms`).
+
+  Keyed by `(user_id, agent_id)`, the pair that names a teammate, so it
+  survives the teammate's conversation being replaced. Either channel may be
+  absent (the provider declined, or was not configured) — `email?/1` and
+  `phone?/1` say which the teammate actually has.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "team_contacts" do
+    field :email_address, :string
+    field :email_inbox_id, :string
+    field :phone_number, :string
+    field :phone_number_id, :string
+
+    belongs_to :user, Fountain.Accounts.User
+    belongs_to :agent, Fountain.Agents.Agent
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @fields [:user_id, :agent_id, :email_address, :email_inbox_id, :phone_number, :phone_number_id]
+
+  def changeset(contact, attrs) do
+    contact
+    |> cast(attrs, @fields)
+    |> validate_required([:user_id, :agent_id])
+    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:agent_id)
+    |> unique_constraint([:user_id, :agent_id])
+  end
+
+  def email?(%__MODULE__{email_inbox_id: id}), do: is_binary(id) and id != ""
+  def phone?(%__MODULE__{phone_number_id: id}), do: is_binary(id) and id != ""
+end

--- a/apps/fountain/lib/fountain_web/controllers/agent_phone_webhook_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_phone_webhook_controller.ex
@@ -1,0 +1,82 @@
+defmodule FountainWeb.AgentPhoneWebhookController do
+  @moduledoc """
+  AgentPhone's master webhook: every inbound message on the account's
+  numbers lands here (flag `team_comms`). Like the Stripe webhook, no bearer
+  token — the request is authenticated by its HMAC signature:
+  `X-Webhook-Signature: sha256=<hex>` over `"<timestamp>.<raw_body>"` with
+  the secret AgentPhone issued when the webhook was registered
+  (`AGENTPHONE_WEBHOOK_SECRET`), and `X-Webhook-Timestamp` within five
+  minutes. The raw body comes from `conn.assigns[:raw_body]`
+  (`FountainWeb.CachingBodyReader`).
+
+  A verified delivery is handed to `Fountain.Team.Comms.Inbound`; the answer
+  is always `200` so AgentPhone does not retry a delivery we deliberately
+  ignored — the body says what happened. Unverifiable → `401`; no secret
+  configured → `503` (nothing is processed unsigned).
+  """
+  use FountainWeb, :controller
+
+  alias Fountain.Team.Comms.Inbound
+
+  @max_skew_seconds 300
+
+  def create(conn, _params) do
+    case secret() do
+      nil ->
+        conn
+        |> put_status(:service_unavailable)
+        |> json(%{error: "agentphone_webhook_not_configured"})
+
+      secret ->
+        raw = conn.assigns[:raw_body] || ""
+        sig = first_header(conn, "x-webhook-signature")
+        ts = first_header(conn, "x-webhook-timestamp")
+
+        if verified?(raw, sig, ts, secret) do
+          delivery_id = first_header(conn, "x-webhook-id")
+
+          result =
+            case Inbound.handle(conn.body_params, delivery_id) do
+              {:ok, conv_id} -> %{status: "prompted", conversation_id: conv_id}
+              {:ignored, reason} -> %{status: "ignored", reason: describe(reason)}
+            end
+
+          json(conn, result)
+        else
+          conn |> put_status(:unauthorized) |> json(%{error: "invalid_signature"})
+        end
+    end
+  end
+
+  @doc false
+  def verified?(raw, "sha256=" <> hex, ts, secret) when is_binary(hex) and is_binary(ts) do
+    with {unix, ""} <- Integer.parse(ts),
+         true <- abs(System.os_time(:second) - unix) <= @max_skew_seconds do
+      expected =
+        :crypto.mac(:hmac, :sha256, secret, ts <> "." <> raw) |> Base.encode16(case: :lower)
+
+      Plug.Crypto.secure_compare(expected, String.downcase(hex))
+    else
+      _ -> false
+    end
+  end
+
+  def verified?(_raw, _sig, _ts, _secret), do: false
+
+  defp first_header(conn, name) do
+    case get_req_header(conn, name) do
+      [v | _] -> v
+      [] -> nil
+    end
+  end
+
+  defp describe({:send_failed, reason}), do: "send_failed: #{inspect(reason)}"
+  defp describe(reason), do: to_string(reason)
+
+  defp secret do
+    case Application.get_env(:fountain, :agentphone_webhook_secret) do
+      s when is_binary(s) and s != "" -> s
+      _ -> nil
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/team_comms_mcp_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_comms_mcp_controller.ex
@@ -1,0 +1,66 @@
+defmodule FountainWeb.TeamCommsMcpController do
+  @moduledoc """
+  The MCP endpoint a teammate's sandbox calls to use its email address and
+  phone number (flag `team_comms`). Streamable-HTTP transport: one JSON-RPC
+  message per POST, a JSON response back (or 202 for a notification) — the
+  same shape as `FountainWeb.BuzzMcpController`.
+
+  The sandbox authenticates with its sprite token (already in it, so no new
+  secret leaves the server). This controller checks the conversation is the
+  caller's and a teammate's, that the teammate has a contact and the feature
+  is available to the caller, and hands `Fountain.Team.Comms.Mcp` a context
+  that talks to AgentMail/AgentPhone under Fountain's keys — which never
+  enter the sandbox.
+  """
+  use FountainWeb, :controller
+
+  alias Fountain.{Audit, Conversations}
+  alias Fountain.Team.Comms
+  alias Fountain.Team.Comms.Mcp
+
+  def handle(conn, %{"conversation_id" => conv_id}) do
+    user = conn.assigns.current_user
+
+    case build_ctx(conv_id, user) do
+      {:ok, ctx} ->
+        case Mcp.handle(conn.body_params, ctx) do
+          :noreply -> send_resp(conn, 202, "")
+          resp -> json(conn, resp)
+        end
+
+      {:error, status, message} ->
+        conn |> put_status(status) |> json(%{error: message})
+    end
+  end
+
+  defp build_ctx(conv_id, user) do
+    with %Conversations.Conversation{} = conv <- get_conv(conv_id, user),
+         {:ok, contact} <- Comms.contact_for_conversation(conv, user.id) do
+      {:ok, %{contact: contact, audit: audit_fn(contact, user)}}
+    else
+      :no_conv -> {:error, 404, "conversation not found"}
+      {:error, :not_team} -> {:error, 404, "not a teammate's conversation"}
+      {:error, :no_contact} -> {:error, 404, "this teammate has no email address or phone number"}
+      {:error, :unavailable} -> {:error, 403, "teammate email and phone are not available here"}
+    end
+  end
+
+  defp get_conv(conv_id, user),
+    do: Conversations.get_conversation(conv_id, user.id) || :no_conv
+
+  # A send is an effect, not a tenant-state mutation, so it is audited here
+  # rather than in a context. Records what happened — never the recipients,
+  # the subject or the body (ADR 0013).
+  defp audit_fn(contact, user) do
+    fn tool, summary ->
+      Audit.record(%{
+        user_id: user.id,
+        action: "team.contact.sent",
+        resource_type: "team_contact",
+        resource_id: contact.id,
+        actor: "sprite",
+        metadata: Map.merge(%{"tool" => tool, "agent_id" => contact.agent_id}, summary)
+      })
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -221,21 +221,26 @@ defmodule FountainWeb.TeamController do
         "teammate without both. Behind the `team_comms` flag — 404 when it is off for " <>
         "the caller, 503 when this instance has no provider keys.",
     parameters: [agent_id: [in: :path, type: :string, required: true]],
+    request_body:
+      {"The number whose texts become prompts", "application/json", Schemas.TeamContactRequest,
+       required: true},
     responses: [
       created: {"Teammate, now with a contact", "application/json", Schemas.TeammateResponse},
       not_found: {"Not on the team, or the feature is off", "application/json", Schemas.Error},
       conflict: {"Already has a contact", "application/json", Schemas.Error},
+      unprocessable_entity: {"Bad prompt_from_number", "application/json", Schemas.Error},
       bad_gateway: {"A provider refused", "application/json", Schemas.Error},
       service_unavailable:
         {"No provider keys on this instance", "application/json", Schemas.Error}
     ]
   )
 
-  def provision_contact(conn, %{"agent_id" => agent_id}) do
+  def provision_contact(conn, %{"agent_id" => agent_id} = params) do
     user = conn.assigns.current_user
     opts = [source: "api"] ++ Audited.attribution(conn)
+    attrs = Map.take(params, ["prompt_from_number"])
 
-    with {:ok, _contact} <- Comms.provision_contact(user.id, agent_id, opts),
+    with {:ok, _contact} <- Comms.provision_contact(user.id, agent_id, attrs, opts),
          %{} = teammate <- Team.get_teammate(user.id, agent_id) || {:error, :not_found} do
       conn
       |> put_status(:created)
@@ -272,6 +277,7 @@ defmodule FountainWeb.TeamController do
   # like `billing_disabled` does — a client that did not ask about the flag
   # sees nothing to discover.
   defp comms_error(_conn, :not_found), do: {:error, :not_found}
+  defp comms_error(_conn, %Ecto.Changeset{} = cs), do: {:error, cs}
 
   defp comms_error(conn, :not_enabled),
     do: conn |> put_status(:not_found) |> json(%{error: "team_comms_not_enabled"})

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -13,6 +13,7 @@ defmodule FountainWeb.TeamController do
   use OpenApiSpex.ControllerSpecs
 
   alias Fountain.{Conversations, Team}
+  alias Fountain.Team.Comms
   alias Fountain.Conversations.LogEvent
   alias FountainWeb.{Audited, Schemas}
 
@@ -195,6 +196,117 @@ defmodule FountainWeb.TeamController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  operation(:comms_status,
+    summary: "Can teammates be given an email address and phone number?",
+    description:
+      "The two gates for `POST /api/team/:agent_id/contact`: the caller's `team_comms` " <>
+        "feature flag and whether this instance has the AgentMail/AgentPhone keys. A " <>
+        "client shows the affordance when `enabled`, and explains itself when `configured` " <>
+        "is false.",
+    responses: [ok: {"Status", "application/json", Schemas.TeamCommsStatusResponse}]
+  )
+
+  def comms_status(conn, _params) do
+    json(conn, %{data: Comms.status(conn.assigns.current_user)})
+  end
+
+  operation(:provision_contact,
+    summary: "Give a teammate an email address and a phone number",
+    description:
+      "Provisions an inbox (AgentMail) and a number (AgentPhone) under Fountain's own " <>
+        "keys and records them on the teammate; from its next turn the teammate has " <>
+        "`email_*` and `sms_*` MCP tools served by Fountain, and knows its own address " <>
+        "and number. All or nothing: a provider failure on either channel leaves the " <>
+        "teammate without both. Behind the `team_comms` flag — 404 when it is off for " <>
+        "the caller, 503 when this instance has no provider keys.",
+    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    responses: [
+      created: {"Teammate, now with a contact", "application/json", Schemas.TeammateResponse},
+      not_found: {"Not on the team, or the feature is off", "application/json", Schemas.Error},
+      conflict: {"Already has a contact", "application/json", Schemas.Error},
+      bad_gateway: {"A provider refused", "application/json", Schemas.Error},
+      service_unavailable:
+        {"No provider keys on this instance", "application/json", Schemas.Error}
+    ]
+  )
+
+  def provision_contact(conn, %{"agent_id" => agent_id}) do
+    user = conn.assigns.current_user
+    opts = [source: "api"] ++ Audited.attribution(conn)
+
+    with {:ok, _contact} <- Comms.provision_contact(user.id, agent_id, opts),
+         %{} = teammate <- Team.get_teammate(user.id, agent_id) || {:error, :not_found} do
+      conn
+      |> put_status(:created)
+      |> render(:show, teammate: teammate)
+    else
+      {:error, reason} -> comms_error(conn, reason)
+    end
+  end
+
+  operation(:release_contact,
+    summary: "Take a teammate's email address and phone number away",
+    description:
+      "Deletes the inbox and releases the number upstream, then forgets them. A provider " <>
+        "failure keeps the contact (nothing is orphaned) and is reported as 502.",
+    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Released",
+      not_found: {"No contact, or not on the team", "application/json", Schemas.Error},
+      bad_gateway: {"A provider refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def release_contact(conn, %{"agent_id" => agent_id}) do
+    user = conn.assigns.current_user
+    opts = [source: "api"] ++ Audited.attribution(conn)
+
+    case Comms.release_contact(user.id, agent_id, opts) do
+      :ok -> send_resp(conn, :no_content, "")
+      {:error, reason} -> comms_error(conn, reason)
+    end
+  end
+
+  # `Fountain.Team.Comms` errors, as HTTP. The feature being off reads as 404
+  # like `billing_disabled` does — a client that did not ask about the flag
+  # sees nothing to discover.
+  defp comms_error(_conn, :not_found), do: {:error, :not_found}
+
+  defp comms_error(conn, :not_enabled),
+    do: conn |> put_status(:not_found) |> json(%{error: "team_comms_not_enabled"})
+
+  defp comms_error(conn, :not_configured) do
+    conn
+    |> put_status(:service_unavailable)
+    |> json(%{
+      error: "team_comms_not_configured",
+      message: "this instance has no AgentMail/AgentPhone keys configured"
+    })
+  end
+
+  defp comms_error(conn, :already_provisioned),
+    do: conn |> put_status(:conflict) |> json(%{error: "contact_already_provisioned"})
+
+  defp comms_error(conn, {channel, reason}) when channel in [:email, :phone] do
+    conn
+    |> put_status(:bad_gateway)
+    |> json(%{
+      error: "provider_error",
+      channel: to_string(channel),
+      message: describe_provider_error(reason)
+    })
+  end
+
+  defp comms_error(_conn, other), do: {:error, other}
+
+  defp describe_provider_error({:status, status, body}) when is_map(body),
+    do:
+      "HTTP #{status}: #{body["message"] || body["error"] || body["detail"] || Jason.encode!(body)}"
+
+  defp describe_provider_error({:status, status, body}), do: "HTTP #{status}: #{inspect(body)}"
+  defp describe_provider_error(%{__exception__: true} = e), do: Exception.message(e)
+  defp describe_provider_error(other), do: inspect(other)
 
   operation(:message,
     summary: "Message a teammate",

--- a/apps/fountain/lib/fountain_web/controllers/team_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_json.ex
@@ -40,6 +40,7 @@ defmodule FountainWeb.TeamJSON do
     %{
       email: (Fountain.Team.Contact.email?(c) && c.email_address) || nil,
       phone: (Fountain.Team.Contact.phone?(c) && c.phone_number) || nil,
+      prompt_from_number: c.prompt_from_number,
       inserted_at: c.inserted_at
     }
   end

--- a/apps/fountain/lib/fountain_web/controllers/team_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_json.ex
@@ -27,7 +27,20 @@ defmodule FountainWeb.TeamJSON do
       # Across every conversation the agent has had on the team (#827).
       usage_total: teammate.usage_total,
       last_turn: last_turn && turn_summary(last_turn),
-      preview: preview(TeamPresenter.preview(teammate))
+      preview: preview(TeamPresenter.preview(teammate)),
+      # The teammate's own email address and phone number (flag
+      # `team_comms`), or null when it has none.
+      contact: contact(Map.get(teammate, :contact))
+    }
+  end
+
+  def contact(nil), do: nil
+
+  def contact(%Fountain.Team.Contact{} = c) do
+    %{
+      email: (Fountain.Team.Contact.email?(c) && c.email_address) || nil,
+      phone: (Fountain.Team.Contact.phone?(c) && c.phone_number) || nil,
+      inserted_at: c.inserted_at
     }
   end
 

--- a/apps/fountain/lib/fountain_web/live/team_live.ex
+++ b/apps/fountain/lib/fountain_web/live/team_live.ex
@@ -22,7 +22,7 @@ defmodule FountainWeb.TeamLive do
 
   alias Fountain.{Conversations, Team}
   alias Fountain.Conversations.{ConversationServer, LogEvent}
-  alias Fountain.Team.{Schedule, Schedules}
+  alias Fountain.Team.{Comms, Schedule, Schedules}
 
   @empty_add_form %{"agent_id" => nil, "name" => "", "environment_id" => "", "vault_id" => ""}
 
@@ -41,6 +41,9 @@ defmodule FountainWeb.TeamLive do
       |> assign(:page_title, "Team")
       |> assign(:user_id, user_id)
       |> assign(:teammates, teammates)
+      # Can teammates here be given an email address and phone number?
+      # (`Fountain.Team.Comms`, flag `team_comms`.) Read once at mount.
+      |> assign(:comms, Comms.status(socket.assigns.current_user))
       |> assign(:addable_agents, Team.list_addable_agents(user_id))
       |> assign(:selected, nil)
       |> assign(:events, [])
@@ -320,6 +323,48 @@ defmodule FountainWeb.TeamLive do
          |> push_patch(to: ~p"/team")}
   end
 
+  # ── contact: the teammate's own email address and phone number ─────────────
+
+  def handle_event("provision_contact", _, %{assigns: %{selected: %{} = selected}} = socket) do
+    user_id = socket.assigns.user_id
+    opts = FountainWeb.Audited.attribution(socket)
+
+    case Comms.provision_contact(user_id, selected.agent.id, opts) do
+      {:ok, contact} ->
+        {:noreply,
+         socket
+         |> refresh_selected_teammate()
+         |> put_flash(
+           :info,
+           "#{selected.name} now has #{contact.email_address} and #{contact.phone_number}. " <>
+             "The tools are there from its next turn."
+         )}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, comms_error(reason))}
+    end
+  end
+
+  def handle_event("provision_contact", _, socket), do: {:noreply, socket}
+
+  def handle_event("release_contact", _, %{assigns: %{selected: %{} = selected}} = socket) do
+    user_id = socket.assigns.user_id
+    opts = FountainWeb.Audited.attribution(socket)
+
+    case Comms.release_contact(user_id, selected.agent.id, opts) do
+      :ok ->
+        {:noreply,
+         socket
+         |> refresh_selected_teammate()
+         |> put_flash(:info, "#{selected.name}'s email address and phone number are released.")}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, comms_error(reason))}
+    end
+  end
+
+  def handle_event("release_contact", _, socket), do: {:noreply, socket}
+
   # Mobile: back from the thread to the roster.
   # ── schedules: a cron that runs this teammate with a prompt ────────────────
 
@@ -575,6 +620,44 @@ defmodule FountainWeb.TeamLive do
     end
   end
 
+  # Re-list the roster and point `selected` at the fresh copy of the same
+  # teammate (its contact changed); nothing else about the thread moves.
+  defp refresh_selected_teammate(socket) do
+    teammates = load_teammates(socket.assigns.user_id)
+
+    selected =
+      case socket.assigns.selected do
+        %{agent: %{id: id}} -> Enum.find(teammates, &(&1.agent.id == id))
+        _ -> nil
+      end
+
+    socket
+    |> assign(:teammates, teammates)
+    |> assign(:selected, selected || socket.assigns.selected)
+  end
+
+  defp comms_error(:not_enabled), do: "Teammate email and phone are not enabled for your account."
+
+  defp comms_error(:not_configured),
+    do: "This instance has no AgentMail/AgentPhone keys configured."
+
+  defp comms_error(:already_provisioned),
+    do: "This teammate already has an email address and phone number."
+
+  defp comms_error(:not_found), do: "That teammate is no longer on the team."
+
+  defp comms_error({:email, reason}), do: "AgentMail refused: #{describe_provider(reason)}"
+  defp comms_error({:phone, reason}), do: "AgentPhone refused: #{describe_provider(reason)}"
+  defp comms_error(other), do: "Could not update the contact: #{inspect(other)}"
+
+  defp describe_provider({:status, status, body}) when is_map(body),
+    do:
+      "HTTP #{status}: #{body["message"] || body["error"] || body["detail"] || Jason.encode!(body)}"
+
+  defp describe_provider({:status, status, body}), do: "HTTP #{status}: #{inspect(body)}"
+  defp describe_provider(%{__exception__: true} = e), do: Exception.message(e)
+  defp describe_provider(other), do: inspect(other)
+
   defp flash_error(socket, :busy),
     do: put_flash(socket, :error, "They're still working on the last message")
 
@@ -717,7 +800,7 @@ defmodule FountainWeb.TeamLive do
         </div>
 
         <%= if @selected do %>
-          <.thread_header teammate={@selected} schedule_count={length(@schedules)} />
+          <.thread_header teammate={@selected} schedule_count={length(@schedules)} comms={@comms} />
 
           <div
             id={"team-thread-#{@selected.conversation.id}"}
@@ -885,11 +968,19 @@ defmodule FountainWeb.TeamLive do
 
   attr :teammate, :map, required: true
   attr :schedule_count, :integer, default: 0
+  attr :comms, :map, default: %{enabled: false, configured: false}
 
   defp thread_header(assigns) do
     conv = assigns.teammate.conversation
     {label, dot} = presence(conv)
-    assigns = assign(assigns, conv: conv, presence_label: label, dot: dot)
+
+    assigns =
+      assign(assigns,
+        conv: conv,
+        presence_label: label,
+        dot: dot,
+        contact: Map.get(assigns.teammate, :contact)
+      )
 
     ~H"""
     <header class="flex items-center justify-between gap-3 px-6 py-3 border-b border-[var(--color-border)] bg-[var(--color-bg-1)]">
@@ -916,6 +1007,18 @@ defmodule FountainWeb.TeamLive do
             &middot; {@conv.sandbox.provider}/{@conv.sandbox.sprite_name}
           </span>
         </div>
+        <div
+          :if={@contact}
+          id="teammate-contact"
+          class="flex items-center gap-2 text-xs text-[var(--color-text-secondary)] min-w-0 mt-0.5"
+          title="This teammate's own email address and phone number"
+        >
+          <span :if={@contact.email_address} class="font-mono truncate">
+            {@contact.email_address}
+          </span>
+          <span :if={@contact.email_address && @contact.phone_number}>&middot;</span>
+          <span :if={@contact.phone_number} class="font-mono truncate">{@contact.phone_number}</span>
+        </div>
       </div>
       <div class="flex items-center gap-2 shrink-0 text-xs">
         <button
@@ -934,6 +1037,32 @@ defmodule FountainWeb.TeamLive do
           title="Scheduled prompts: run this teammate on a cron"
         >
           Schedules<span :if={@schedule_count > 0} class="ml-1 text-[var(--color-text-muted)]">{@schedule_count}</span>
+        </button>
+        <button
+          :if={@comms.enabled and is_nil(@contact)}
+          id="provision-contact-button"
+          type="button"
+          phx-click="provision_contact"
+          disabled={not @comms.configured}
+          class="rounded-md border border-[var(--color-border)] px-2.5 py-1 hover:bg-[var(--color-bg-2)] disabled:opacity-50 disabled:cursor-not-allowed"
+          title={
+            if @comms.configured,
+              do: "Give this teammate its own email address and phone number",
+              else: "This instance has no AgentMail/AgentPhone keys configured"
+          }
+        >
+          Give email &amp; phone
+        </button>
+        <button
+          :if={@comms.enabled and @contact}
+          id="release-contact-button"
+          type="button"
+          phx-click="release_contact"
+          data-confirm={"Take #{@teammate.name}'s email address and phone number away? The inbox and number are released."}
+          class="rounded-md border border-[var(--color-border)] px-2.5 py-1 hover:bg-[var(--color-bg-2)]"
+          title="Release this teammate's email address and phone number"
+        >
+          Release contact
         </button>
         <.link
           navigate={~p"/conversations/#{@conv.id}"}

--- a/apps/fountain/lib/fountain_web/live/team_live.ex
+++ b/apps/fountain/lib/fountain_web/live/team_live.ex
@@ -44,6 +44,8 @@ defmodule FountainWeb.TeamLive do
       # Can teammates here be given an email address and phone number?
       # (`Fountain.Team.Comms`, flag `team_comms`.) Read once at mount.
       |> assign(:comms, Comms.status(socket.assigns.current_user))
+      |> assign(:contact_form_open, false)
+      |> assign(:contact_number, "")
       |> assign(:addable_agents, Team.list_addable_agents(user_id))
       |> assign(:selected, nil)
       |> assign(:events, [])
@@ -105,6 +107,8 @@ defmodule FountainWeb.TeamLive do
     |> assign(:schedules_open, false)
     |> assign(:schedule_form, nil)
     |> assign(:editing_schedule, nil)
+    |> assign(:contact_form_open, false)
+    |> assign(:contact_number, "")
   end
 
   defp load_turns(conv_id) do
@@ -325,23 +329,44 @@ defmodule FountainWeb.TeamLive do
 
   # ── contact: the teammate's own email address and phone number ─────────────
 
-  def handle_event("provision_contact", _, %{assigns: %{selected: %{} = selected}} = socket) do
+  def handle_event("open_contact_form", _, socket),
+    do: {:noreply, assign(socket, contact_form_open: true)}
+
+  def handle_event("close_contact_form", _, socket),
+    do: {:noreply, assign(socket, contact_form_open: false, contact_number: "")}
+
+  def handle_event("validate_contact", %{"prompt_from_number" => n}, socket),
+    do: {:noreply, assign(socket, :contact_number, n)}
+
+  def handle_event(
+        "provision_contact",
+        %{"prompt_from_number" => number},
+        %{assigns: %{selected: %{} = selected}} = socket
+      ) do
     user_id = socket.assigns.user_id
     opts = FountainWeb.Audited.attribution(socket)
 
-    case Comms.provision_contact(user_id, selected.agent.id, opts) do
+    case Comms.provision_contact(
+           user_id,
+           selected.agent.id,
+           %{"prompt_from_number" => number},
+           opts
+         ) do
       {:ok, contact} ->
         {:noreply,
          socket
+         |> assign(contact_form_open: false, contact_number: "")
          |> refresh_selected_teammate()
          |> put_flash(
            :info,
            "#{selected.name} now has #{contact.email_address} and #{contact.phone_number}. " <>
-             "The tools are there from its next turn."
+             "Texts from #{contact.prompt_from_number} reach it as prompts; " <>
+             "the tools are there from its next turn."
          )}
 
       {:error, reason} ->
-        {:noreply, put_flash(socket, :error, comms_error(reason))}
+        {:noreply,
+         socket |> assign(:contact_number, number) |> put_flash(:error, comms_error(reason))}
     end
   end
 
@@ -646,6 +671,13 @@ defmodule FountainWeb.TeamLive do
 
   defp comms_error(:not_found), do: "That teammate is no longer on the team."
 
+  defp comms_error(%Ecto.Changeset{errors: errors}) do
+    case Keyword.get(errors, :prompt_from_number) do
+      {msg, _} -> "Phone number " <> msg <> "."
+      nil -> "Could not save the contact."
+    end
+  end
+
   defp comms_error({:email, reason}), do: "AgentMail refused: #{describe_provider(reason)}"
   defp comms_error({:phone, reason}), do: "AgentPhone refused: #{describe_provider(reason)}"
   defp comms_error(other), do: "Could not update the contact: #{inspect(other)}"
@@ -801,6 +833,7 @@ defmodule FountainWeb.TeamLive do
 
         <%= if @selected do %>
           <.thread_header teammate={@selected} schedule_count={length(@schedules)} comms={@comms} />
+          <.contact_form :if={@contact_form_open} number={@contact_number} teammate={@selected} />
 
           <div
             id={"team-thread-#{@selected.conversation.id}"}
@@ -967,6 +1000,54 @@ defmodule FountainWeb.TeamLive do
   end
 
   attr :teammate, :map, required: true
+  attr :number, :string, default: ""
+
+  # Collected whenever a teammate is given a number: the one phone whose
+  # texts to it arrive as prompts. Nothing is bought until this is submitted.
+  defp contact_form(assigns) do
+    ~H"""
+    <form
+      id="contact-form"
+      phx-submit="provision_contact"
+      phx-change="validate_contact"
+      class="flex flex-wrap items-end gap-3 px-6 py-3 border-b border-[var(--color-border)] bg-[var(--color-bg-2)] text-sm"
+    >
+      <label class="flex flex-col gap-1 min-w-0">
+        <span class="text-xs text-[var(--color-text-secondary)]">
+          Your phone number — texts from it to {@teammate.name}'s new number become prompts
+        </span>
+        <input
+          type="tel"
+          name="prompt_from_number"
+          value={@number}
+          placeholder="+1 555 123 4567"
+          autocomplete="tel"
+          required
+          class="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-1)] px-2.5 py-1 font-mono w-64"
+        />
+      </label>
+      <button
+        id="contact-form-submit"
+        type="submit"
+        class="rounded-md bg-blue-600 text-white px-3 py-1.5 hover:bg-blue-700"
+      >
+        Give email &amp; phone
+      </button>
+      <button
+        type="button"
+        phx-click="close_contact_form"
+        class="rounded-md border border-[var(--color-border)] px-2.5 py-1.5 hover:bg-[var(--color-bg-1)]"
+      >
+        Cancel
+      </button>
+      <span class="basis-full text-xs text-[var(--color-text-muted)]">
+        This provisions an AgentMail inbox and an AgentPhone number for this teammate only (both billed); texts from any other number are ignored.
+      </span>
+    </form>
+    """
+  end
+
+  attr :teammate, :map, required: true
   attr :schedule_count, :integer, default: 0
   attr :comms, :map, default: %{enabled: false, configured: false}
 
@@ -1018,6 +1099,13 @@ defmodule FountainWeb.TeamLive do
           </span>
           <span :if={@contact.email_address && @contact.phone_number}>&middot;</span>
           <span :if={@contact.phone_number} class="font-mono truncate">{@contact.phone_number}</span>
+          <span
+            :if={@contact.prompt_from_number}
+            class="truncate"
+            title="Texts from this number to the teammate's number arrive as prompts"
+          >
+            &middot; texts from <span class="font-mono">{@contact.prompt_from_number}</span> prompt
+          </span>
         </div>
       </div>
       <div class="flex items-center gap-2 shrink-0 text-xs">
@@ -1042,7 +1130,7 @@ defmodule FountainWeb.TeamLive do
           :if={@comms.enabled and is_nil(@contact)}
           id="provision-contact-button"
           type="button"
-          phx-click="provision_contact"
+          phx-click="open_contact_form"
           disabled={not @comms.configured}
           class="rounded-md border border-[var(--color-border)] px-2.5 py-1 hover:bg-[var(--color-bg-2)] disabled:opacity-50 disabled:cursor-not-allowed"
           title={

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -233,6 +233,14 @@ defmodule FountainWeb.Router do
     post "/webhook", StripeWebhookController, :create
   end
 
+  # AgentPhone's master webhook (flag `team_comms`): inbound texts to a
+  # teammate's number become prompts. Same shape as Stripe's — no bearer
+  # token, authenticated by the HMAC signature in the request.
+  scope "/api/webhooks", FountainWeb do
+    pipe_through :api_public
+    post "/agentphone", AgentPhoneWebhookController, :create
+  end
+
   ## ─── Authenticated JSON resource endpoints ──────────────────────────────────────────────────────────────
 
   scope "/api/auth", FountainWeb do

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -349,6 +349,11 @@ defmodule FountainWeb.Router do
     # The team tools a teammate's sandbox calls to see and message the team (#851).
     post "/mcp/team/:conversation_id", TeamMcpController, :handle
 
+    # MCP tools a teammate's sandbox calls to use its email address and phone
+    # number (flag `team_comms`). Same transport; the AgentMail/AgentPhone
+    # keys stay server-side.
+    post "/mcp/team-comms/:conversation_id", TeamCommsMcpController, :handle
+
     resources "/environments", EnvironmentController, except: [:new, :edit] do
       resources "/secrets", SecretController, only: [:index, :create, :delete]
     end
@@ -376,6 +381,9 @@ defmodule FountainWeb.Router do
     post "/team", TeamController, :create
     # Before `/team/:agent_id`, or "schedules" would be read as an agent id.
     get "/team/schedules", TeamScheduleController, :index_all
+    # Likewise before `/team/:agent_id`: can teammates here get an email
+    # address and phone number (flag `team_comms`)?
+    get "/team/comms", TeamController, :comms_status
     get "/team/:agent_id", TeamController, :show
     patch "/team/:agent_id", TeamController, :update
     delete "/team/:agent_id", TeamController, :delete
@@ -384,6 +392,9 @@ defmodule FountainWeb.Router do
     get "/team/:agent_id/conversations", TeamController, :conversations
     # A fresh conversation on the same computer; the current one is retired.
     post "/team/:agent_id/conversations", TeamController, :fresh_conversation
+    # The teammate's own email address and phone number (flag `team_comms`).
+    post "/team/:agent_id/contact", TeamController, :provision_contact
+    delete "/team/:agent_id/contact", TeamController, :release_contact
 
     # Team schedules (#825): the routines `/team` offers, per teammate.
     get "/team/:agent_id/schedules", TeamScheduleController, :index

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1702,6 +1702,26 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule TeammateContact do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeammateContact",
+      description:
+        "A teammate's own email address and phone number, provisioned by Fountain " <>
+          "(AgentMail + AgentPhone) behind the `team_comms` flag. The teammate reaches " <>
+          "both through MCP tools Fountain serves; no provider key enters its sandbox.",
+      type: :object,
+      properties: %{
+        email: %Schema{type: :string, nullable: true},
+        phone: %Schema{type: :string, nullable: true, description: "E.164"},
+        inserted_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:email, :phone]
+    })
+  end
+
   defmodule Teammate do
     @moduledoc false
     require OpenApiSpex
@@ -1758,6 +1778,13 @@ defmodule FountainWeb.Schemas do
             kind: %Schema{type: :string, enum: FountainWeb.TeamPresenter.preview_kinds()},
             text: %Schema{type: :string, nullable: true}
           }
+        },
+        contact: %Schema{
+          allOf: [TeammateContact],
+          nullable: true,
+          description:
+            "The teammate's own email address and phone number (flag `team_comms`), " <>
+              "or null when it has none."
         }
       },
       required: [:agent_id, :name, :agent, :conversation, :presence, :unread]
@@ -1766,6 +1793,27 @@ defmodule FountainWeb.Schemas do
 
   item_response(TeammateResponse, of: Teammate)
   list_response(TeammateListResponse, of: Teammate)
+
+  defmodule TeamCommsStatus do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeamCommsStatus",
+      description:
+        "Whether teammates can be given an email address and phone number here: `enabled` " <>
+          "is the per-user feature flag (`team_comms`), `configured` whether this instance " <>
+          "has the provider keys. Both must hold to provision.",
+      type: :object,
+      properties: %{
+        enabled: %Schema{type: :boolean},
+        configured: %Schema{type: :boolean}
+      },
+      required: [:enabled, :configured]
+    })
+  end
+
+  item_response(TeamCommsStatusResponse, of: TeamCommsStatus)
 
   defmodule TeamAddRequest do
     @moduledoc false

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1716,9 +1716,35 @@ defmodule FountainWeb.Schemas do
       properties: %{
         email: %Schema{type: :string, nullable: true},
         phone: %Schema{type: :string, nullable: true, description: "E.164"},
+        prompt_from_number: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "E.164. The one number whose texts to `phone` arrive as prompts in the " <>
+              "teammate's conversation; texts from anyone else are ignored."
+        },
         inserted_at: %Schema{type: :string, format: :"date-time"}
       },
       required: [:email, :phone]
+    })
+  end
+
+  defmodule TeamContactRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TeamContactRequest",
+      type: :object,
+      properties: %{
+        prompt_from_number: %Schema{
+          type: :string,
+          description:
+            "Your phone number: texts from it to the teammate's new number become prompts " <>
+              "in its conversation. Any common format; stored E.164. Required."
+        }
+      },
+      required: [:prompt_from_number]
     })
   end
 

--- a/apps/fountain/priv/repo/migrations/20260819140000_create_team_contacts.exs
+++ b/apps/fountain/priv/repo/migrations/20260819140000_create_team_contacts.exs
@@ -1,0 +1,27 @@
+defmodule Fountain.Repo.Migrations.CreateTeamContacts do
+  @moduledoc """
+  A teammate's email address and phone number (flag `team_comms`): the
+  AgentMail inbox and AgentPhone number Fountain provisioned for it, keyed by
+  the same `(user_id, agent_id)` pair that names a teammate. One row per
+  teammate; deleting the user or the agent drops the row (the upstream
+  resources are released by the context before that where it can).
+  """
+  use Ecto.Migration
+
+  def change do
+    create table(:team_contacts, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+      add :agent_id, references(:agents, type: :binary_id, on_delete: :delete_all), null: false
+      add :email_address, :string
+      add :email_inbox_id, :string
+      add :phone_number, :string
+      add :phone_number_id, :string
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:team_contacts, [:user_id, :agent_id])
+    create index(:team_contacts, [:agent_id])
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260819150000_add_prompt_from_number_to_team_contacts.exs
+++ b/apps/fountain/priv/repo/migrations/20260819150000_add_prompt_from_number_to_team_contacts.exs
@@ -1,0 +1,17 @@
+defmodule Fountain.Repo.Migrations.AddPromptFromNumberToTeamContacts do
+  @moduledoc """
+  The one phone number whose texts to a teammate's number arrive as prompts
+  in the teammate's conversation (flag `team_comms`). Collected whenever a
+  teammate is given a number; E.164. The index is what the inbound webhook
+  resolves a delivery by: the teammate's own number.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:team_contacts) do
+      add :prompt_from_number, :string
+    end
+
+    create index(:team_contacts, [:phone_number])
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -76,6 +76,11 @@ defmodule Fountain.AuditGuardrailTest do
     {"team schedule update", &__MODULE__.do_schedule_update/1, "team.schedule.updated"},
     {"team schedule delete", &__MODULE__.do_schedule_delete/1, "team.schedule.deleted"},
     {"team schedule run", &__MODULE__.do_schedule_run/1, "team.schedule.fired"},
+    # Team contacts: a teammate's email address and phone number (flag
+    # `team_comms`). Sends through the MCP tools are audited by the controller
+    # as `team.contact.sent` — an effect, not tenant state.
+    {"team contact provision", &__MODULE__.do_contact_provision/1, "team.contact.provisioned"},
+    {"team contact release", &__MODULE__.do_contact_release/1, "team.contact.released"},
     {"support report create", &__MODULE__.do_support_create/1, "support.report.created"},
     {"runner register", &__MODULE__.do_runner_register/1, "runner.registered"},
     {"runner delete", &__MODULE__.do_runner_delete/1, "runner.deleted"}
@@ -142,7 +147,9 @@ defmodule Fountain.AuditGuardrailTest do
           {Vaults, :delete_vault, 2},
           {InferenceCredentials, :put_credential, 5},
           {Conversations, :start_conversation, 2},
-          {Conversations, :delete_conversation, 2}
+          {Conversations, :delete_conversation, 2},
+          {Fountain.Team.Comms, :provision_contact, 3},
+          {Fountain.Team.Comms, :release_contact, 3}
         ] do
       # `Code.ensure_loaded?/1` first: `function_exported?/3` answers about
       # *loaded* modules, so on a seed where this test ran before anything had
@@ -318,6 +325,51 @@ defmodule Fountain.AuditGuardrailTest do
           "message" => "it broke",
           "context" => %{"conversation_id" => "x"}
         })
+
+  # The flag is flipped for the duration of the call only; the providers are
+  # the Req.Test plugs from config/test.exs, stubbed in this process.
+  defp with_comms(user, fun) do
+    agent = insert_agent(user_id: user.id)
+
+    insert_conversation(
+      user_id: user.id,
+      agent: agent,
+      status: "idle",
+      channel_id: Fountain.Team.channel()
+    )
+
+    Req.Test.stub(Fountain.Team.Comms.AgentMail, fn conn ->
+      Req.Test.json(conn, %{"inbox_id" => "inbox_g", "email" => "g@agentmail.to"})
+    end)
+
+    Req.Test.stub(Fountain.Team.Comms.AgentPhone, fn conn ->
+      Req.Test.json(conn, %{"id" => "num_g", "phoneNumber" => "+15550000000"})
+    end)
+
+    previous = Application.get_env(:fountain, :feature_flag_overrides)
+    Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => true})
+
+    try do
+      fun.(agent)
+    after
+      if previous,
+        do: Application.put_env(:fountain, :feature_flag_overrides, previous),
+        else: Application.delete_env(:fountain, :feature_flag_overrides)
+    end
+  end
+
+  def do_contact_provision(user) do
+    with_comms(user, fn agent ->
+      {:ok, _} = Fountain.Team.Comms.provision_contact(user.id, agent.id)
+    end)
+  end
+
+  def do_contact_release(user) do
+    with_comms(user, fn agent ->
+      {:ok, _} = Fountain.Team.Comms.provision_contact(user.id, agent.id)
+      :ok = Fountain.Team.Comms.release_contact(user.id, agent.id)
+    end)
+  end
 
   def do_schedule_create(user), do: insert_schedule(user)
 

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -148,7 +148,7 @@ defmodule Fountain.AuditGuardrailTest do
           {InferenceCredentials, :put_credential, 5},
           {Conversations, :start_conversation, 2},
           {Conversations, :delete_conversation, 2},
-          {Fountain.Team.Comms, :provision_contact, 3},
+          {Fountain.Team.Comms, :provision_contact, 4},
           {Fountain.Team.Comms, :release_contact, 3}
         ] do
       # `Code.ensure_loaded?/1` first: `function_exported?/3` answers about
@@ -360,13 +360,20 @@ defmodule Fountain.AuditGuardrailTest do
 
   def do_contact_provision(user) do
     with_comms(user, fn agent ->
-      {:ok, _} = Fountain.Team.Comms.provision_contact(user.id, agent.id)
+      {:ok, _} =
+        Fountain.Team.Comms.provision_contact(user.id, agent.id, %{
+          "prompt_from_number" => "+15550001111"
+        })
     end)
   end
 
   def do_contact_release(user) do
     with_comms(user, fn agent ->
-      {:ok, _} = Fountain.Team.Comms.provision_contact(user.id, agent.id)
+      {:ok, _} =
+        Fountain.Team.Comms.provision_contact(user.id, agent.id, %{
+          "prompt_from_number" => "+15550001111"
+        })
+
       :ok = Fountain.Team.Comms.release_contact(user.id, agent.id)
     end)
   end

--- a/apps/fountain/test/fountain/feature_flags_test.exs
+++ b/apps/fountain/test/fountain/feature_flags_test.exs
@@ -1,0 +1,164 @@
+defmodule Fountain.FeatureFlagsTest do
+  # Mutates global app env (the PostHog key, the overrides), so not async.
+  use ExUnit.Case, async: false
+
+  alias Fountain.FeatureFlags
+
+  @user_id "11111111-1111-1111-1111-111111111111"
+
+  setup do
+    previous = %{
+      key: Application.get_env(:fountain, :posthog_project_api_key),
+      overrides: Application.get_env(:fountain, :feature_flag_overrides)
+    }
+
+    FeatureFlags.reset()
+
+    on_exit(fn ->
+      restore(:posthog_project_api_key, previous.key)
+      restore(:feature_flag_overrides, previous.overrides)
+      FeatureFlags.reset()
+    end)
+
+    :ok
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:fountain, key)
+  defp restore(key, value), do: Application.put_env(:fountain, key, value)
+
+  defp posthog_on, do: Application.put_env(:fountain, :posthog_project_api_key, "phc_test")
+  defp posthog_off, do: Application.delete_env(:fountain, :posthog_project_api_key)
+
+  defp stub_flags(flags) do
+    Req.Test.stub(FeatureFlags, fn conn ->
+      Req.Test.json(conn, %{"flags" => Map.new(flags, fn {k, v} -> {k, %{"enabled" => v}} end)})
+    end)
+  end
+
+  defp stub_down do
+    Req.Test.stub(FeatureFlags, fn conn -> Req.Test.transport_error(conn, :econnrefused) end)
+  end
+
+  describe "without PostHog" do
+    test "every flag reads off" do
+      posthog_off()
+      refute FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    test "a static override turns a flag on for everyone" do
+      posthog_off()
+      Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => true})
+      assert FeatureFlags.enabled?(:team_comms, @user_id)
+      assert FeatureFlags.enabled?(:team_comms, %{id: @user_id})
+      # An override applies even with no user to ask about.
+      assert FeatureFlags.enabled?(:team_comms, nil)
+    end
+
+    test "an unknown flag atom is a KeyError, not a silent off" do
+      assert_raise KeyError, fn -> FeatureFlags.enabled?(:no_such_flag, @user_id) end
+    end
+  end
+
+  describe "with PostHog" do
+    setup do
+      posthog_on()
+      :ok
+    end
+
+    test "reads the flag for the user" do
+      stub_flags(%{"team_comms" => true})
+      assert FeatureFlags.enabled?(:team_comms, @user_id)
+
+      stub_flags(%{"team_comms" => false})
+      FeatureFlags.reset()
+      refute FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    test "a flag PostHog does not mention is off" do
+      stub_flags(%{"something_else" => true})
+      refute FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    test "also reads the older /decide shape" do
+      Req.Test.stub(FeatureFlags, fn conn ->
+        Req.Test.json(conn, %{"featureFlags" => %{"team_comms" => true}})
+      end)
+
+      assert FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    test "a static override wins over PostHog" do
+      stub_flags(%{"team_comms" => true})
+      Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => false})
+      refute FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    test "caches the answer: a second call does not hit PostHog" do
+      test = self()
+
+      Req.Test.stub(FeatureFlags, fn conn ->
+        send(test, :posthog_called)
+        Req.Test.json(conn, %{"flags" => %{"team_comms" => %{"enabled" => true}}})
+      end)
+
+      assert FeatureFlags.enabled?(:team_comms, @user_id)
+      assert_received :posthog_called
+      assert FeatureFlags.enabled?(:team_comms, @user_id)
+      refute_received :posthog_called
+    end
+
+    test "no user to ask about reads off without a call" do
+      Req.Test.stub(FeatureFlags, fn _conn -> flunk("PostHog should not be called") end)
+      refute FeatureFlags.enabled?(:team_comms, nil)
+    end
+  end
+
+  describe "when PostHog is down" do
+    setup do
+      posthog_on()
+      :ok
+    end
+
+    test "with no cached answer every flag reads off — never on" do
+      stub_down()
+      refute FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    test "a 5xx is an outage too" do
+      Req.Test.stub(FeatureFlags, fn conn ->
+        conn |> Plug.Conn.put_status(503) |> Req.Test.json(%{"error" => "down"})
+      end)
+
+      refute FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    test "the last answer it gave is kept — on stays on" do
+      stub_flags(%{"team_comms" => true})
+      assert FeatureFlags.enabled?(:team_comms, @user_id)
+
+      # Expire the cache entry, then take PostHog down.
+      age_cache(@user_id)
+      stub_down()
+      assert FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    test "the last answer it gave is kept — off stays off" do
+      stub_flags(%{"team_comms" => false})
+      refute FeatureFlags.enabled?(:team_comms, @user_id)
+
+      age_cache(@user_id)
+      stub_down()
+      refute FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+  end
+
+  # Push the cached entry's timestamp into the past so the next read refetches.
+  defp age_cache(distinct_id) do
+    [{^distinct_id, flags, _at}] = :ets.lookup(FeatureFlags.table(), distinct_id)
+
+    :ets.insert(
+      FeatureFlags.table(),
+      {distinct_id, flags, System.monotonic_time(:millisecond) - 600_000}
+    )
+  end
+end

--- a/apps/fountain/test/fountain/team/comms/inbound_test.exs
+++ b/apps/fountain/test/fountain/team/comms/inbound_test.exs
@@ -1,0 +1,150 @@
+defmodule Fountain.Team.Comms.InboundTest do
+  # Flips the `team_comms` flag through global app env, so not async.
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Fountain.{Audit, Team}
+  alias Fountain.Team.Comms.Inbound
+  alias Fountain.Team.Contact
+  alias Fountain.Conversations.ConversationServer
+
+  @teammate_number "+15551234567"
+  @owner "+15550001111"
+
+  setup do
+    previous = Application.get_env(:fountain, :feature_flag_overrides)
+    Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => true})
+    Inbound.Seen.reset()
+
+    on_exit(fn ->
+      if previous,
+        do: Application.put_env(:fountain, :feature_flag_overrides, previous),
+        else: Application.delete_env(:fountain, :feature_flag_overrides)
+    end)
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, name: "Ada")
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        status: "idle",
+        channel_id: Team.channel()
+      )
+
+    contact =
+      Repo.insert!(%Contact{
+        user_id: user.id,
+        agent_id: agent.id,
+        email_address: "ada@agentmail.to",
+        email_inbox_id: "inbox_1",
+        phone_number: @teammate_number,
+        phone_number_id: "num_1",
+        prompt_from_number: @owner
+      })
+
+    test_pid = self()
+
+    stub(ConversationServer, :send_prompt, fn id, text, images, opts ->
+      send(test_pid, {:sent, id, text, images, opts})
+      :ok
+    end)
+
+    {:ok, user: user, agent: agent, conv: conv, contact: contact}
+  end
+
+  defp payload(overrides \\ %{}) do
+    data =
+      Map.merge(
+        %{
+          "conversationId" => "conv_x",
+          "numberId" => "num_1",
+          "from" => @owner,
+          "to" => @teammate_number,
+          "message" => "ship it",
+          "mediaUrl" => nil,
+          "direction" => "inbound",
+          "receivedAt" => "2026-08-19T10:00:00Z"
+        },
+        Map.get(overrides, "data", %{})
+      )
+
+    %{"event" => "agent.message", "channel" => "sms", "timestamp" => "x", "data" => data}
+    |> Map.merge(Map.delete(overrides, "data"))
+  end
+
+  test "a text from the allow-listed number becomes a prompt in the teammate's conversation", %{
+    conv: conv,
+    user: user,
+    contact: contact
+  } do
+    assert {:ok, conv_id} = Inbound.handle(payload(), "del_1")
+    assert conv_id == conv.id
+
+    assert_received {:sent, ^conv_id, text, [], opts}
+    assert text =~ "[Text message from +15550001111 to your number +15551234567]"
+    assert text =~ "ship it"
+    assert text =~ "sms_send tool to +15550001111"
+    assert opts[:actor] == "system:agentphone"
+
+    [event] =
+      user.id
+      |> Audit.list_recent_for_user(10)
+      |> Enum.filter(&(&1.action == "team.contact.prompted"))
+
+    assert event.resource_id == contact.id
+    assert event.metadata["prompt_bytes"] == 7
+    refute inspect(event.metadata) =~ "ship it"
+  end
+
+  test "the sender is matched after normalization; anyone else is ignored" do
+    assert {:ok, _} = Inbound.handle(payload(%{"data" => %{"from" => "(555) 000-1111"}}), "del_a")
+    assert_received {:sent, _, _, _, _}
+
+    assert {:ignored, :sender_not_allowed} =
+             Inbound.handle(payload(%{"data" => %{"from" => "+15559999999"}}), "del_b")
+
+    refute_received {:sent, _, _, _, _}
+  end
+
+  test "a number no teammate owns is ignored" do
+    assert {:ignored, :unknown_number} =
+             Inbound.handle(payload(%{"data" => %{"to" => "+15557777777"}}), "del_c")
+  end
+
+  test "only inbound text channels count" do
+    assert {:ignored, :not_inbound} =
+             Inbound.handle(payload(%{"data" => %{"direction" => "outbound"}}), "d1")
+
+    assert {:ignored, :not_inbound} = Inbound.handle(payload(%{"channel" => "voice"}), "d2")
+    assert {:ignored, :not_a_message} = Inbound.handle(%{"event" => "agent.call_ended"}, "d3")
+    assert {:ignored, :empty} = Inbound.handle(payload(%{"data" => %{"message" => "   "}}), "d4")
+    refute_received {:sent, _, _, _, _}
+  end
+
+  test "a redelivery with the same id is dropped" do
+    assert {:ok, _} = Inbound.handle(payload(), "del_same")
+    assert {:ignored, :duplicate} = Inbound.handle(payload(), "del_same")
+    assert_received {:sent, _, _, _, _}
+    refute_received {:sent, _, _, _, _}
+  end
+
+  test "with the flag off for the owner nothing is prompted" do
+    Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => false})
+    assert {:ignored, :unavailable} = Inbound.handle(payload(), "del_off")
+  end
+
+  test "an attachment is passed as its URL" do
+    assert {:ok, _} =
+             Inbound.handle(payload(%{"data" => %{"mediaUrl" => "https://x/y.jpg"}}), "del_m")
+
+    assert_received {:sent, _, text, _, _}
+    assert text =~ "(attachment: https://x/y.jpg)"
+  end
+
+  test "a send failure is reported, not raised" do
+    stub(ConversationServer, :send_prompt, fn _, _, _, _ -> {:error, :busy} end)
+    assert {:ignored, {:send_failed, :busy}} = Inbound.handle(payload(), "del_busy")
+  end
+end

--- a/apps/fountain/test/fountain/team/comms/mcp_test.exs
+++ b/apps/fountain/test/fountain/team/comms/mcp_test.exs
@@ -1,0 +1,293 @@
+defmodule Fountain.Team.Comms.McpTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Team.Comms.Mcp
+  alias Fountain.Team.Contact
+
+  # Fake providers: record the call in the test process, answer canned JSON.
+  defmodule FakeMail do
+    def send_message(inbox_id, body) do
+      send(self(), {:mail_send, inbox_id, body})
+      {:ok, %{"message_id" => "msg_1", "thread_id" => "thr_1"}}
+    end
+
+    def reply_to_message(inbox_id, message_id, body) do
+      send(self(), {:mail_reply, inbox_id, message_id, body})
+      {:ok, %{"message_id" => "msg_2", "thread_id" => "thr_1"}}
+    end
+
+    def list_messages(inbox_id, params) do
+      send(self(), {:mail_list, inbox_id, params})
+
+      {:ok,
+       %{
+         "count" => 1,
+         "messages" => [
+           %{
+             "message_id" => "msg_9",
+             "thread_id" => "thr_9",
+             "from" => "Bob <bob@example.com>",
+             "to" => ["ada@agentmail.to"],
+             "subject" => "hi",
+             "timestamp" => "2026-08-19T10:00:00Z",
+             "labels" => ["unread"],
+             "preview" => "hello there",
+             "attachments" => [%{"attachment_id" => "a", "filename" => "x.pdf", "size" => 3}]
+           }
+         ]
+       }}
+    end
+
+    def get_message(inbox_id, message_id) do
+      send(self(), {:mail_get, inbox_id, message_id})
+
+      {:ok,
+       %{
+         "message_id" => message_id,
+         "thread_id" => "thr_9",
+         "from" => "bob@example.com",
+         "to" => ["ada@agentmail.to"],
+         "subject" => "hi",
+         "timestamp" => "2026-08-19T10:00:00Z",
+         "labels" => [],
+         "text" => "full body",
+         "html" => "<p>full body</p>"
+       }}
+    end
+  end
+
+  defmodule FailingMail do
+    def send_message(_, _), do: {:error, {:status, 422, %{"message" => "bad recipient"}}}
+  end
+
+  defmodule FakePhone do
+    def send_message(body) do
+      send(self(), {:sms_send, body})
+      {:ok, %{"id" => "sms_1", "status" => "queued", "channel" => "sms"}}
+    end
+
+    def list_messages(number_id, params) do
+      send(self(), {:sms_list, number_id, params})
+
+      {:ok,
+       %{
+         "data" => [
+           %{
+             "id" => "sms_7",
+             "from_" => "+15550001111",
+             "to" => "+15551234567",
+             "body" => "yo",
+             "direction" => "inbound",
+             "receivedAt" => "2026-08-19T10:00:00Z"
+           }
+         ],
+         "hasMore" => false
+       }}
+    end
+  end
+
+  @contact %Contact{
+    id: "c1",
+    email_address: "ada@agentmail.to",
+    email_inbox_id: "inbox_1",
+    phone_number: "+15551234567",
+    phone_number_id: "num_1"
+  }
+
+  defp ctx(overrides \\ %{}) do
+    Map.merge(%{contact: @contact, mail: FakeMail, phone: FakePhone}, overrides)
+  end
+
+  # Responses are built with atom keys and serialised by the controller; the
+  # JSON round-trip here is what the sandbox sees.
+  defp handle(req, ctx), do: req |> Mcp.handle(ctx) |> json()
+
+  defp json(:noreply), do: :noreply
+  defp json(resp), do: resp |> Jason.encode!() |> Jason.decode!()
+
+  defp call(name, args, ctx \\ ctx()) do
+    handle(
+      %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "tools/call",
+        "params" => %{"name" => name, "arguments" => args}
+      },
+      ctx
+    )
+  end
+
+  defp payload(%{"result" => %{"content" => [%{"text" => text}], "isError" => false}}),
+    do: Jason.decode!(text)
+
+  describe "protocol" do
+    test "initialize names the server and tells the teammate who it is" do
+      resp = handle(%{"id" => 1, "method" => "initialize"}, ctx())
+      assert resp["result"]["serverInfo"]["name"] == "fountain-comms"
+      assert resp["result"]["protocolVersion"] == "2025-06-18"
+      assert resp["result"]["instructions"] =~ "ada@agentmail.to"
+      assert resp["result"]["instructions"] =~ "+15551234567"
+    end
+
+    test "tools/list advertises email, sms and whoami tools" do
+      resp = handle(%{"id" => 1, "method" => "tools/list"}, ctx())
+      names = Enum.map(resp["result"]["tools"], & &1["name"])
+
+      assert names ==
+               ~w(email_send email_reply email_list email_get sms_send sms_list my_contact_info)
+
+      # The descriptions carry the teammate's own address, so the model knows it.
+      assert Enum.find(resp["result"]["tools"], &(&1["name"] == "email_send"))["description"] =~
+               "ada@agentmail.to"
+    end
+
+    test "an email-only contact gets no sms tools, and vice versa" do
+      email_only = %{@contact | phone_number: nil, phone_number_id: nil}
+      resp = handle(%{"id" => 1, "method" => "tools/list"}, ctx(%{contact: email_only}))
+      names = Enum.map(resp["result"]["tools"], & &1["name"])
+      refute "sms_send" in names
+      assert "email_send" in names
+
+      assert %{"result" => %{"isError" => true, "content" => [%{"text" => msg}]}} =
+               call("sms_send", %{"to" => "+1", "body" => "x"}, ctx(%{contact: email_only}))
+
+      assert msg =~ "no phone number"
+    end
+
+    test "notifications get no reply; unknown methods are -32601" do
+      assert :noreply = handle(%{"method" => "notifications/initialized"}, ctx())
+      assert %{"error" => %{"code" => -32_601}} = handle(%{"id" => 3, "method" => "nope"}, ctx())
+      assert %{"result" => %{}} = handle(%{"id" => 4, "method" => "ping"}, ctx())
+    end
+  end
+
+  describe "email tools" do
+    test "email_send posts under the teammate's inbox and audits a count, not the recipients" do
+      test = self()
+      ctx = ctx(%{audit: fn tool, summary -> send(test, {:audit, tool, summary}) end})
+
+      resp =
+        call(
+          "email_send",
+          %{"to" => ["x@y.com", "z@y.com"], "subject" => "s", "text" => "t", "cc" => "c@y.com"},
+          ctx
+        )
+
+      assert payload(resp) == %{"message_id" => "msg_1", "thread_id" => "thr_1"}
+
+      assert_received {:mail_send, "inbox_1",
+                       %{
+                         "to" => ["x@y.com", "z@y.com"],
+                         "subject" => "s",
+                         "text" => "t",
+                         "cc" => ["c@y.com"]
+                       }}
+
+      assert_received {:audit, "email_send", %{"recipients" => 2}}
+    end
+
+    test "email_send accepts a single comma-separated string for `to`" do
+      call("email_send", %{"to" => "a@b.com, c@d.com", "subject" => "s", "text" => "t"})
+      assert_received {:mail_send, _, %{"to" => ["a@b.com", "c@d.com"]}}
+    end
+
+    test "missing arguments are a tool error the model can read" do
+      assert %{"result" => %{"isError" => true, "content" => [%{"text" => msg}]}} =
+               call("email_send", %{"subject" => "s", "text" => "t"})
+
+      assert msg =~ "missing required argument: to"
+      refute_received {:mail_send, _, _}
+    end
+
+    test "a provider refusal is a tool error with the provider's message" do
+      assert %{"result" => %{"isError" => true, "content" => [%{"text" => msg}]}} =
+               call(
+                 "email_send",
+                 %{"to" => "a@b.com", "subject" => "s", "text" => "t"},
+                 ctx(%{mail: FailingMail})
+               )
+
+      assert msg =~ "HTTP 422"
+      assert msg =~ "bad recipient"
+    end
+
+    test "email_reply threads on the message id" do
+      call("email_reply", %{"message_id" => "msg_9", "text" => "thanks", "reply_all" => true})
+
+      assert_received {:mail_reply, "inbox_1", "msg_9",
+                       %{"text" => "thanks", "reply_all" => true}}
+    end
+
+    test "email_list passes the filters through and shapes the summaries" do
+      resp = call("email_list", %{"limit" => 5, "unread_only" => true, "from" => "bob"})
+      assert_received {:mail_list, "inbox_1", params}
+      assert params[:limit] == 5
+      assert params[:labels] == ["unread"]
+      assert params[:from] == "bob"
+
+      assert %{"count" => 1, "messages" => [m]} = payload(resp)
+      assert m["message_id"] == "msg_9"
+      assert m["from"] == "Bob <bob@example.com>"
+      assert m["preview"] == "hello there"
+      assert m["attachments"] == [%{"filename" => "x.pdf", "size" => 3}]
+    end
+
+    test "email_list caps the limit and defaults it" do
+      call("email_list", %{"limit" => 1000})
+      assert_received {:mail_list, _, params}
+      assert params[:limit] == 100
+
+      call("email_list", %{})
+      assert_received {:mail_list, _, params}
+      assert params[:limit] == 20
+    end
+
+    test "email_get returns the body" do
+      resp = call("email_get", %{"message_id" => "msg_9"})
+      assert_received {:mail_get, "inbox_1", "msg_9"}
+      assert %{"text" => "full body", "subject" => "hi"} = payload(resp)
+    end
+  end
+
+  describe "sms tools" do
+    test "sms_send sends from the teammate's number and audits" do
+      test = self()
+      ctx = ctx(%{audit: fn tool, summary -> send(test, {:audit, tool, summary}) end})
+
+      resp = call("sms_send", %{"to" => "+15550001111", "body" => "hey"}, ctx)
+      assert payload(resp) == %{"message_id" => "sms_1", "status" => "queued", "channel" => "sms"}
+
+      assert_received {:sms_send,
+                       %{"number_id" => "num_1", "to_number" => "+15550001111", "body" => "hey"}}
+
+      assert_received {:audit, "sms_send", %{}}
+    end
+
+    test "sms_list shapes the messages" do
+      resp = call("sms_list", %{"limit" => 3})
+      assert_received {:sms_list, "num_1", [limit: 3]}
+      assert %{"count" => 1, "has_more" => false, "messages" => [m]} = payload(resp)
+
+      assert m == %{
+               "message_id" => "sms_7",
+               "from" => "+15550001111",
+               "to" => "+15551234567",
+               "body" => "yo",
+               "direction" => "inbound",
+               "received_at" => "2026-08-19T10:00:00Z",
+               "status" => nil
+             }
+    end
+  end
+
+  test "my_contact_info answers with both" do
+    assert payload(call("my_contact_info", %{})) == %{
+             "email" => "ada@agentmail.to",
+             "phone" => "+15551234567"
+           }
+  end
+
+  test "an unknown tool is a tool error" do
+    assert %{"result" => %{"isError" => true}} = call("launch_missiles", %{})
+  end
+end

--- a/apps/fountain/test/fountain/team/comms/phone_test.exs
+++ b/apps/fountain/test/fountain/team/comms/phone_test.exs
@@ -1,0 +1,40 @@
+defmodule Fountain.Team.Comms.PhoneTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Team.Comms.Phone
+
+  test "normalizes what people type to E.164" do
+    for {input, expected} <- [
+          {"+15551234567", "+15551234567"},
+          {"5551234567", "+15551234567"},
+          {"15551234567", "+15551234567"},
+          {"(555) 123-4567", "+15551234567"},
+          {"+1 555 123 4567", "+15551234567"},
+          {"+44 20 7946 0958", "+442079460958"},
+          {"0044 20 7946 0958", "+442079460958"}
+        ] do
+      assert Phone.normalize(input) == {:ok, expected}, input
+    end
+  end
+
+  test "rejects what is not a phone number" do
+    for input <- [
+          "",
+          "call me",
+          "123",
+          "+0123456789",
+          "555-1234",
+          nil,
+          42,
+          "+1 555 123 4567 ext 9"
+        ] do
+      assert Phone.normalize(input) == :error, inspect(input)
+    end
+  end
+
+  test "same? compares normalized forms" do
+    assert Phone.same?("(555) 000-1111", "+15550001111")
+    refute Phone.same?("+15550001111", "+15550001112")
+    refute Phone.same?("junk", "+15550001111")
+  end
+end

--- a/apps/fountain/test/fountain/team/comms_test.exs
+++ b/apps/fountain/test/fountain/team/comms_test.exs
@@ -17,6 +17,8 @@ defmodule Fountain.Team.CommsTest do
   defp restore(key, nil), do: Application.delete_env(:fountain, key)
   defp restore(key, value), do: Application.put_env(:fountain, key, value)
 
+  @req %{"prompt_from_number" => "+1 (555) 000-1111"}
+
   defp flag(on?),
     do: Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => on?})
 
@@ -79,7 +81,7 @@ defmodule Fountain.Team.CommsTest do
       flag(false)
       Req.Test.stub(AgentMail, fn _ -> flunk("AgentMail must not be called") end)
 
-      assert {:error, :not_enabled} = Comms.provision_contact(user.id, agent.id)
+      assert {:error, :not_enabled} = Comms.provision_contact(user.id, agent.id, @req)
       assert Comms.get_contact(user.id, agent.id) == nil
     end
 
@@ -92,7 +94,7 @@ defmodule Fountain.Team.CommsTest do
       on_exit(fn -> Application.put_env(:fountain, :agentphone_api_key, previous) end)
 
       refute Comms.configured?()
-      assert {:error, :not_configured} = Comms.provision_contact(user.id, agent.id)
+      assert {:error, :not_configured} = Comms.provision_contact(user.id, agent.id, @req)
     end
   end
 
@@ -108,12 +110,15 @@ defmodule Fountain.Team.CommsTest do
       stub_providers_ok()
       Team.subscribe(user.id)
 
-      assert {:ok, %Contact{} = contact} = Comms.provision_contact(user.id, agent.id, actor: "ui")
+      assert {:ok, %Contact{} = contact} =
+               Comms.provision_contact(user.id, agent.id, @req, actor: "ui")
 
       assert contact.email_inbox_id == "inbox_123"
       assert contact.email_address =~ ~r/^ada-lovelace-[0-9a-f]{6}@agentmail\.to$/
       assert contact.phone_number_id == "num_123"
       assert contact.phone_number == "+15551234567"
+      # The number whose texts become prompts, normalized to E.164.
+      assert contact.prompt_from_number == "+15550001111"
 
       assert_received {:agentmail_create, body}
       assert body["display_name"] == "Ada Lovelace"
@@ -139,7 +144,7 @@ defmodule Fountain.Team.CommsTest do
       user = insert_verified_user()
       agent = teammate(user)
       stub_providers_ok()
-      {:ok, contact} = Comms.provision_contact(user.id, agent.id)
+      {:ok, contact} = Comms.provision_contact(user.id, agent.id, @req)
 
       assert %{contact: %Contact{id: id}} = Team.get_teammate(user.id, agent.id)
       assert id == contact.id
@@ -149,21 +154,37 @@ defmodule Fountain.Team.CommsTest do
       user = insert_verified_user()
       agent = teammate(user)
       stub_providers_ok()
-      {:ok, _} = Comms.provision_contact(user.id, agent.id)
-      assert {:error, :already_provisioned} = Comms.provision_contact(user.id, agent.id)
+      {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
+      assert {:error, :already_provisioned} = Comms.provision_contact(user.id, agent.id, @req)
+    end
+
+    test "a missing or bad prompt_from_number is refused before anything is bought" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      Req.Test.stub(AgentMail, fn _ -> flunk("nothing is bought on a bad request") end)
+      Req.Test.stub(AgentPhone, fn _ -> flunk("nothing is bought on a bad request") end)
+
+      assert {:error, %Ecto.Changeset{} = cs} = Comms.provision_contact(user.id, agent.id, %{})
+      assert %{prompt_from_number: ["can't be blank"]} = errors_on(cs)
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Comms.provision_contact(user.id, agent.id, %{"prompt_from_number" => "call me"})
+
+      assert %{prompt_from_number: [_]} = errors_on(cs)
+      assert Comms.get_contact(user.id, agent.id) == nil
     end
 
     test "an agent not on the team gets not_found" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)
-      assert {:error, :not_found} = Comms.provision_contact(user.id, agent.id)
+      assert {:error, :not_found} = Comms.provision_contact(user.id, agent.id, @req)
     end
 
     test "another tenant's teammate is not_found" do
       user = insert_verified_user()
       other = insert_verified_user()
       agent = teammate(other)
-      assert {:error, :not_found} = Comms.provision_contact(user.id, agent.id)
+      assert {:error, :not_found} = Comms.provision_contact(user.id, agent.id, @req)
     end
 
     test "all or nothing: a failed number deletes the inbox again" do
@@ -187,7 +208,7 @@ defmodule Fountain.Team.CommsTest do
       end)
 
       assert {:error, {:phone, {:status, 402, %{"detail" => "insufficient balance"}}}} =
-               Comms.provision_contact(user.id, agent.id)
+               Comms.provision_contact(user.id, agent.id, @req)
 
       assert_received :agentmail_delete
       assert Comms.get_contact(user.id, agent.id) == nil
@@ -208,7 +229,8 @@ defmodule Fountain.Team.CommsTest do
 
       Req.Test.stub(AgentPhone, fn _ -> flunk("no number without an inbox") end)
 
-      assert {:error, {:email, {:status, 500, _}}} = Comms.provision_contact(user.id, agent.id)
+      assert {:error, {:email, {:status, 500, _}}} =
+               Comms.provision_contact(user.id, agent.id, @req)
     end
   end
 
@@ -222,7 +244,7 @@ defmodule Fountain.Team.CommsTest do
       user = insert_verified_user()
       agent = teammate(user)
       stub_providers_ok()
-      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+      {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
 
       assert :ok = Comms.release_contact(user.id, agent.id, actor: "api")
       assert_received :agentmail_delete
@@ -241,7 +263,7 @@ defmodule Fountain.Team.CommsTest do
       user = insert_verified_user()
       agent = teammate(user)
       stub_providers_ok()
-      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+      {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
 
       Req.Test.stub(AgentMail, fn conn ->
         conn |> Plug.Conn.put_status(404) |> Req.Test.json(%{})
@@ -259,7 +281,7 @@ defmodule Fountain.Team.CommsTest do
       user = insert_verified_user()
       agent = teammate(user)
       stub_providers_ok()
-      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+      {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
 
       Req.Test.stub(AgentPhone, fn conn ->
         conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{})
@@ -279,7 +301,7 @@ defmodule Fountain.Team.CommsTest do
       user = insert_verified_user()
       agent = teammate(user)
       stub_providers_ok()
-      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+      {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
 
       assert :ok = Team.remove_teammate(user.id, agent.id)
       assert_received :agentmail_delete
@@ -294,7 +316,7 @@ defmodule Fountain.Team.CommsTest do
       user = insert_verified_user()
       agent = teammate(user)
       stub_providers_ok()
-      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+      {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
       %{conversation: conv} = Team.get_teammate(user.id, agent.id)
 
       assert [%{name: "fountain-comms", type: "http", url: url, headers: headers}] =
@@ -312,7 +334,7 @@ defmodule Fountain.Team.CommsTest do
       assert [] = Comms.conversation_mcp_servers(conv.id, "tok")
 
       stub_providers_ok()
-      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+      {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
       assert [_] = Comms.conversation_mcp_servers(conv.id, "tok")
       assert [] = Comms.conversation_mcp_servers(conv.id, "")
       assert [] = Comms.conversation_mcp_servers(conv.id, nil)

--- a/apps/fountain/test/fountain/team/comms_test.exs
+++ b/apps/fountain/test/fountain/team/comms_test.exs
@@ -1,0 +1,330 @@
+defmodule Fountain.Team.CommsTest do
+  # Flips the `team_comms` flag through global app env, so not async. The
+  # providers are Req.Test plugs (config/test.exs) stubbed per test.
+  use Fountain.DataCase, async: false
+
+  alias Fountain.{Audit, Team}
+  alias Fountain.Team.Comms
+  alias Fountain.Team.Comms.{AgentMail, AgentPhone}
+  alias Fountain.Team.Contact
+
+  setup do
+    previous = Application.get_env(:fountain, :feature_flag_overrides)
+    on_exit(fn -> restore(:feature_flag_overrides, previous) end)
+    :ok
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:fountain, key)
+  defp restore(key, value), do: Application.put_env(:fountain, key, value)
+
+  defp flag(on?),
+    do: Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => on?})
+
+  defp teammate(user, name \\ "Ada") do
+    agent = insert_agent(user_id: user.id, name: name)
+
+    insert_conversation(
+      user_id: user.id,
+      agent: agent,
+      status: "idle",
+      channel_id: Team.channel()
+    )
+
+    agent
+  end
+
+  # Happy-path provider stubs: an inbox and a number, echoing what was asked.
+  defp stub_providers_ok(test \\ self()) do
+    Req.Test.stub(AgentMail, fn conn ->
+      case {conn.method, conn.request_path} do
+        {"POST", "/v0/inboxes"} ->
+          send(test, {:agentmail_create, conn.body_params})
+
+          Req.Test.json(conn, %{
+            "inbox_id" => "inbox_123",
+            "email" => "#{conn.body_params["username"]}@agentmail.to"
+          })
+
+        {"DELETE", "/v0/inboxes/inbox_123"} ->
+          send(test, :agentmail_delete)
+          Req.Test.json(conn, %{})
+      end
+    end)
+
+    Req.Test.stub(AgentPhone, fn conn ->
+      case {conn.method, conn.request_path} do
+        {"POST", "/v1/numbers"} ->
+          send(test, {:agentphone_create, conn.body_params})
+          Req.Test.json(conn, %{"id" => "num_123", "phoneNumber" => "+15551234567"})
+
+        {"DELETE", "/v1/numbers/num_123"} ->
+          send(test, :agentphone_delete)
+          Req.Test.json(conn, %{})
+      end
+    end)
+  end
+
+  describe "gates" do
+    test "status reports the flag and the providers separately" do
+      user = insert_verified_user()
+      flag(false)
+      assert Comms.status(user) == %{enabled: false, configured: true}
+      flag(true)
+      assert Comms.status(user) == %{enabled: true, configured: true}
+    end
+
+    test "provision is refused with the flag off, and nothing is called" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      flag(false)
+      Req.Test.stub(AgentMail, fn _ -> flunk("AgentMail must not be called") end)
+
+      assert {:error, :not_enabled} = Comms.provision_contact(user.id, agent.id)
+      assert Comms.get_contact(user.id, agent.id) == nil
+    end
+
+    test "provision is refused when a provider key is missing" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      flag(true)
+      previous = Application.get_env(:fountain, :agentphone_api_key)
+      Application.delete_env(:fountain, :agentphone_api_key)
+      on_exit(fn -> Application.put_env(:fountain, :agentphone_api_key, previous) end)
+
+      refute Comms.configured?()
+      assert {:error, :not_configured} = Comms.provision_contact(user.id, agent.id)
+    end
+  end
+
+  describe "provision_contact/3" do
+    setup do
+      flag(true)
+      :ok
+    end
+
+    test "creates an inbox and a number, records them, audits, broadcasts" do
+      user = insert_verified_user()
+      agent = teammate(user, "Ada Lovelace")
+      stub_providers_ok()
+      Team.subscribe(user.id)
+
+      assert {:ok, %Contact{} = contact} = Comms.provision_contact(user.id, agent.id, actor: "ui")
+
+      assert contact.email_inbox_id == "inbox_123"
+      assert contact.email_address =~ ~r/^ada-lovelace-[0-9a-f]{6}@agentmail\.to$/
+      assert contact.phone_number_id == "num_123"
+      assert contact.phone_number == "+15551234567"
+
+      assert_received {:agentmail_create, body}
+      assert body["display_name"] == "Ada Lovelace"
+      assert body["client_id"] == "fountain-team:" <> agent.id
+      assert_received {:agentphone_create, %{"country" => "US"}}
+      assert_received {:team_changed, _}
+
+      assert Comms.get_contact(user.id, agent.id).id == contact.id
+
+      [event] =
+        user.id
+        |> Audit.list_recent_for_user(10)
+        |> Enum.filter(&(&1.action == "team.contact.provisioned"))
+
+      assert event.actor == "ui"
+      assert event.metadata["channels"] == ["email", "phone"]
+      # The trail names the channels, never the address or number.
+      refute inspect(event.metadata) =~ "agentmail.to"
+      refute inspect(event.metadata) =~ "+1555"
+    end
+
+    test "the teammate's contact rides along on the roster" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      stub_providers_ok()
+      {:ok, contact} = Comms.provision_contact(user.id, agent.id)
+
+      assert %{contact: %Contact{id: id}} = Team.get_teammate(user.id, agent.id)
+      assert id == contact.id
+    end
+
+    test "refuses a second contact for the same teammate" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      stub_providers_ok()
+      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+      assert {:error, :already_provisioned} = Comms.provision_contact(user.id, agent.id)
+    end
+
+    test "an agent not on the team gets not_found" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      assert {:error, :not_found} = Comms.provision_contact(user.id, agent.id)
+    end
+
+    test "another tenant's teammate is not_found" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      agent = teammate(other)
+      assert {:error, :not_found} = Comms.provision_contact(user.id, agent.id)
+    end
+
+    test "all or nothing: a failed number deletes the inbox again" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      test = self()
+
+      Req.Test.stub(AgentMail, fn conn ->
+        case {conn.method, conn.request_path} do
+          {"POST", "/v0/inboxes"} ->
+            Req.Test.json(conn, %{"inbox_id" => "inbox_123", "email" => "x@agentmail.to"})
+
+          {"DELETE", "/v0/inboxes/inbox_123"} ->
+            send(test, :agentmail_delete)
+            Req.Test.json(conn, %{})
+        end
+      end)
+
+      Req.Test.stub(AgentPhone, fn conn ->
+        conn |> Plug.Conn.put_status(402) |> Req.Test.json(%{"detail" => "insufficient balance"})
+      end)
+
+      assert {:error, {:phone, {:status, 402, %{"detail" => "insufficient balance"}}}} =
+               Comms.provision_contact(user.id, agent.id)
+
+      assert_received :agentmail_delete
+      assert Comms.get_contact(user.id, agent.id) == nil
+
+      assert [] =
+               user.id
+               |> Audit.list_recent_for_user(10)
+               |> Enum.filter(&(&1.action =~ "team.contact"))
+    end
+
+    test "a failed inbox is reported as the email channel, and no number is bought" do
+      user = insert_verified_user()
+      agent = teammate(user)
+
+      Req.Test.stub(AgentMail, fn conn ->
+        conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{"message" => "boom"})
+      end)
+
+      Req.Test.stub(AgentPhone, fn _ -> flunk("no number without an inbox") end)
+
+      assert {:error, {:email, {:status, 500, _}}} = Comms.provision_contact(user.id, agent.id)
+    end
+  end
+
+  describe "release_contact/3" do
+    setup do
+      flag(true)
+      :ok
+    end
+
+    test "deletes the inbox and the number, removes the row, audits" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      stub_providers_ok()
+      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+
+      assert :ok = Comms.release_contact(user.id, agent.id, actor: "api")
+      assert_received :agentmail_delete
+      assert_received :agentphone_delete
+      assert Comms.get_contact(user.id, agent.id) == nil
+
+      assert [event] =
+               user.id
+               |> Audit.list_recent_for_user(10)
+               |> Enum.filter(&(&1.action == "team.contact.released"))
+
+      assert event.actor == "api"
+    end
+
+    test "a provider that already forgot the resource counts as released" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      stub_providers_ok()
+      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+
+      Req.Test.stub(AgentMail, fn conn ->
+        conn |> Plug.Conn.put_status(404) |> Req.Test.json(%{})
+      end)
+
+      Req.Test.stub(AgentPhone, fn conn ->
+        conn |> Plug.Conn.put_status(404) |> Req.Test.json(%{})
+      end)
+
+      assert :ok = Comms.release_contact(user.id, agent.id)
+      assert Comms.get_contact(user.id, agent.id) == nil
+    end
+
+    test "a provider failure keeps the row so nothing is orphaned" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      stub_providers_ok()
+      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+
+      Req.Test.stub(AgentPhone, fn conn ->
+        conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{})
+      end)
+
+      assert {:error, {:phone, {:status, 500, _}}} = Comms.release_contact(user.id, agent.id)
+      assert %Contact{} = Comms.get_contact(user.id, agent.id)
+    end
+
+    test "no contact is not_found" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      assert {:error, :not_found} = Comms.release_contact(user.id, agent.id)
+    end
+
+    test "removing the teammate releases its contact too" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      stub_providers_ok()
+      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+
+      assert :ok = Team.remove_teammate(user.id, agent.id)
+      assert_received :agentmail_delete
+      assert_received :agentphone_delete
+      assert Comms.get_contact(user.id, agent.id) == nil
+    end
+  end
+
+  describe "conversation_mcp_servers/2" do
+    test "injects the tools for a teammate with a contact when the flag is on" do
+      flag(true)
+      user = insert_verified_user()
+      agent = teammate(user)
+      stub_providers_ok()
+      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+      %{conversation: conv} = Team.get_teammate(user.id, agent.id)
+
+      assert [%{name: "fountain-comms", type: "http", url: url, headers: headers}] =
+               Comms.conversation_mcp_servers(conv.id, "tok_123")
+
+      assert String.ends_with?(url, "/api/mcp/team-comms/" <> conv.id)
+      assert headers == [%{name: "Authorization", value: "Bearer tok_123"}]
+    end
+
+    test "nothing without a contact, off the team, with the flag off, or without a token" do
+      flag(true)
+      user = insert_verified_user()
+      agent = teammate(user)
+      %{conversation: conv} = Team.get_teammate(user.id, agent.id)
+      assert [] = Comms.conversation_mcp_servers(conv.id, "tok")
+
+      stub_providers_ok()
+      {:ok, _} = Comms.provision_contact(user.id, agent.id)
+      assert [_] = Comms.conversation_mcp_servers(conv.id, "tok")
+      assert [] = Comms.conversation_mcp_servers(conv.id, "")
+      assert [] = Comms.conversation_mcp_servers(conv.id, nil)
+
+      # The same agent, in a conversation that is not the teammate's.
+      other = insert_conversation(user_id: user.id, agent: agent)
+      assert [] = Comms.conversation_mcp_servers(other.id, "tok")
+
+      flag(false)
+      assert [] = Comms.conversation_mcp_servers(conv.id, "tok")
+
+      assert [] = Comms.conversation_mcp_servers("not-a-uuid", "tok")
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/api_spec_test.exs
+++ b/apps/fountain/test/fountain_web/api_spec_test.exs
@@ -60,7 +60,9 @@ defmodule FountainWeb.ApiSpecTest do
       # client, which discovers tools via `tools/list`, not our OpenAPI spec.
       {"/api/mcp/buzz/{conversation_id}", :post},
       # Same: the team tools a teammate's sandbox calls (#851).
-      {"/api/mcp/team/{conversation_id}", :post}
+      {"/api/mcp/team/{conversation_id}", :post},
+      # Same: the teammate email/phone tools (flag `team_comms`).
+      {"/api/mcp/team-comms/{conversation_id}", :post}
     ]
 
     setup do

--- a/apps/fountain/test/fountain_web/api_spec_test.exs
+++ b/apps/fountain/test/fountain_web/api_spec_test.exs
@@ -52,6 +52,9 @@ defmodule FountainWeb.ApiSpecTest do
       # Authenticated by Stripe-Signature, not a bearer token. Its caller is
       # Stripe, which does not read our spec.
       {"/api/stripe/webhook", :post},
+      # Likewise AgentPhone's webhook: authenticated by its HMAC signature,
+      # called by AgentPhone (flag `team_comms`).
+      {"/api/webhooks/agentphone", :post},
       # A browser-session route that happens to live under /api/ — CSRF-
       # protected, session-authenticated, and driven by the theme toggle.
       {"/api/settings/theme", :patch},

--- a/apps/fountain/test/fountain_web/controllers/agent_phone_webhook_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_phone_webhook_controller_test.exs
@@ -1,0 +1,166 @@
+defmodule FountainWeb.AgentPhoneWebhookControllerTest do
+  # Flips the `team_comms` flag and the webhook secret through global app
+  # env, so not async.
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+
+  alias Fountain.Team
+  alias Fountain.Team.Comms.Inbound
+  alias Fountain.Team.Contact
+  alias Fountain.Conversations.ConversationServer
+
+  @secret "whsec_test"
+
+  setup do
+    previous = Application.get_env(:fountain, :feature_flag_overrides)
+    Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => true})
+    Inbound.Seen.reset()
+
+    on_exit(fn ->
+      if previous,
+        do: Application.put_env(:fountain, :feature_flag_overrides, previous),
+        else: Application.delete_env(:fountain, :feature_flag_overrides)
+    end)
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        status: "idle",
+        channel_id: Team.channel()
+      )
+
+    Fountain.Repo.insert!(%Contact{
+      user_id: user.id,
+      agent_id: agent.id,
+      phone_number: "+15551234567",
+      phone_number_id: "num_1",
+      prompt_from_number: "+15550001111"
+    })
+
+    test_pid = self()
+
+    stub(ConversationServer, :send_prompt, fn id, text, _images, _opts ->
+      send(test_pid, {:sent, id, text})
+      :ok
+    end)
+
+    {:ok, conv: conv}
+  end
+
+  @body Jason.encode!(%{
+          "event" => "agent.message",
+          "channel" => "sms",
+          "data" => %{
+            "from" => "+15550001111",
+            "to" => "+15551234567",
+            "message" => "hello there",
+            "direction" => "inbound"
+          }
+        })
+
+  defp sign(body, ts, secret \\ @secret) do
+    "sha256=" <>
+      (:crypto.mac(:hmac, :sha256, secret, "#{ts}.#{body}") |> Base.encode16(case: :lower))
+  end
+
+  defp deliver(conn, body, headers) do
+    conn =
+      Enum.reduce(headers, put_req_header(conn, "content-type", "application/json"), fn {k, v},
+                                                                                        c ->
+        put_req_header(c, k, v)
+      end)
+
+    post(conn, "/api/webhooks/agentphone", body)
+  end
+
+  test "a signed delivery from the allow-listed number becomes a prompt", %{
+    conn: conn,
+    conv: conv
+  } do
+    ts = to_string(System.os_time(:second))
+
+    body =
+      conn
+      |> deliver(@body, [
+        {"x-webhook-signature", sign(@body, ts)},
+        {"x-webhook-timestamp", ts},
+        {"x-webhook-id", "del_1"}
+      ])
+      |> json_response(200)
+
+    assert body == %{"status" => "prompted", "conversation_id" => conv.id}
+    assert_received {:sent, _, text}
+    assert text =~ "hello there"
+  end
+
+  test "a bad signature is 401 and nothing is prompted", %{conn: conn} do
+    ts = to_string(System.os_time(:second))
+
+    conn
+    |> deliver(@body, [
+      {"x-webhook-signature", sign(@body, ts, "other")},
+      {"x-webhook-timestamp", ts}
+    ])
+    |> json_response(401)
+
+    conn |> deliver(@body, []) |> json_response(401)
+    refute_received {:sent, _, _}
+  end
+
+  test "a stale timestamp is 401 even with a valid signature", %{conn: conn} do
+    ts = to_string(System.os_time(:second) - 600)
+
+    conn
+    |> deliver(@body, [{"x-webhook-signature", sign(@body, ts)}, {"x-webhook-timestamp", ts}])
+    |> json_response(401)
+
+    refute_received {:sent, _, _}
+  end
+
+  test "an ignored delivery is still 200, saying why", %{conn: conn} do
+    body = Jason.encode!(%{"event" => "agent.call_ended", "data" => %{}})
+    ts = to_string(System.os_time(:second))
+
+    assert %{"status" => "ignored", "reason" => "not_a_message"} =
+             conn
+             |> deliver(body, [
+               {"x-webhook-signature", sign(body, ts)},
+               {"x-webhook-timestamp", ts}
+             ])
+             |> json_response(200)
+  end
+
+  test "a redelivery is 200 and not prompted twice", %{conn: conn} do
+    ts = to_string(System.os_time(:second))
+
+    headers = [
+      {"x-webhook-signature", sign(@body, ts)},
+      {"x-webhook-timestamp", ts},
+      {"x-webhook-id", "del_dup"}
+    ]
+
+    conn |> deliver(@body, headers) |> json_response(200)
+
+    assert %{"status" => "ignored", "reason" => "duplicate"} =
+             conn |> deliver(@body, headers) |> json_response(200)
+
+    assert_received {:sent, _, _}
+    refute_received {:sent, _, _}
+  end
+
+  test "without a configured secret the endpoint is 503 and processes nothing", %{conn: conn} do
+    Application.delete_env(:fountain, :agentphone_webhook_secret)
+    on_exit(fn -> Application.put_env(:fountain, :agentphone_webhook_secret, @secret) end)
+    ts = to_string(System.os_time(:second))
+
+    conn
+    |> deliver(@body, [{"x-webhook-signature", sign(@body, ts)}, {"x-webhook-timestamp", ts}])
+    |> json_response(503)
+
+    refute_received {:sent, _, _}
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
@@ -16,6 +16,13 @@ defmodule FountainWeb.TeamCommsControllerTest do
     {:ok, user: user, raw_key: raw_key}
   end
 
+  defp give(conn, key, agent_id, body \\ %{"prompt_from_number" => "5550001111"}) do
+    conn
+    |> authed_with_key(key)
+    |> put_req_header("content-type", "application/json")
+    |> post("/api/team/#{agent_id}/contact", body)
+  end
+
   defp restore(key, nil), do: Application.delete_env(:fountain, key)
   defp restore(key, value), do: Application.put_env(:fountain, key, value)
 
@@ -81,14 +88,13 @@ defmodule FountainWeb.TeamCommsControllerTest do
       stub_providers_ok()
 
       body =
-        conn
-        |> authed_with_key(key)
-        |> post("/api/team/#{agent.id}/contact")
+        give(conn, key, agent.id)
         |> json_response(201)
 
       assert body["data"]["agent_id"] == agent.id
       assert body["data"]["contact"]["email"] == "ada-abc123@agentmail.to"
       assert body["data"]["contact"]["phone"] == "+15551234567"
+      assert body["data"]["contact"]["prompt_from_number"] == "+15550001111"
 
       [entry] =
         conn
@@ -106,9 +112,7 @@ defmodule FountainWeb.TeamCommsControllerTest do
       Req.Test.stub(AgentMail, fn _ -> flunk("no provider call with the flag off") end)
 
       body =
-        conn
-        |> authed_with_key(key)
-        |> post("/api/team/#{agent.id}/contact")
+        give(conn, key, agent.id)
         |> json_response(404)
 
       assert body["error"] == "team_comms_not_enabled"
@@ -122,24 +126,38 @@ defmodule FountainWeb.TeamCommsControllerTest do
       on_exit(fn -> Application.put_env(:fountain, :agentmail_api_key, previous) end)
 
       body =
-        conn
-        |> authed_with_key(key)
-        |> post("/api/team/#{agent.id}/contact")
+        give(conn, key, agent.id)
         |> json_response(503)
 
       assert body["error"] == "team_comms_not_configured"
+    end
+
+    test "is 422 without a usable prompt_from_number, and buys nothing", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      flag(true)
+      {agent, _} = teammate(user)
+      Req.Test.stub(AgentMail, fn _ -> flunk("nothing is bought on a bad request") end)
+
+      # No body at all: the spec requires one (422 from the validator).
+      give(conn, key, agent.id, %{}) |> json_response(422)
+
+      give(conn, key, agent.id, %{"prompt_from_number" => "nope"})
+      |> json_response(422)
     end
 
     test "is 409 the second time", %{conn: conn, user: user, raw_key: key} do
       flag(true)
       {agent, _} = teammate(user)
       stub_providers_ok()
-      conn |> authed_with_key(key) |> post("/api/team/#{agent.id}/contact") |> json_response(201)
+
+      give(conn, key, agent.id)
+      |> json_response(201)
 
       body =
-        conn
-        |> authed_with_key(key)
-        |> post("/api/team/#{agent.id}/contact")
+        give(conn, key, agent.id)
         |> json_response(409)
 
       assert body["error"] == "contact_already_provisioned"
@@ -158,9 +176,7 @@ defmodule FountainWeb.TeamCommsControllerTest do
       end)
 
       body =
-        conn
-        |> authed_with_key(key)
-        |> post("/api/team/#{agent.id}/contact")
+        give(conn, key, agent.id)
         |> json_response(502)
 
       assert body == %{
@@ -179,8 +195,11 @@ defmodule FountainWeb.TeamCommsControllerTest do
       loose = insert_agent(user_id: user.id)
       {theirs, _} = teammate(insert_verified_user())
 
-      conn |> authed_with_key(key) |> post("/api/team/#{loose.id}/contact") |> json_response(404)
-      conn |> authed_with_key(key) |> post("/api/team/#{theirs.id}/contact") |> json_response(404)
+      give(conn, key, loose.id)
+      |> json_response(404)
+
+      give(conn, key, theirs.id)
+      |> json_response(404)
     end
   end
 
@@ -189,7 +208,9 @@ defmodule FountainWeb.TeamCommsControllerTest do
       flag(true)
       {agent, _} = teammate(user)
       stub_providers_ok()
-      conn |> authed_with_key(key) |> post("/api/team/#{agent.id}/contact") |> json_response(201)
+
+      give(conn, key, agent.id)
+      |> json_response(201)
 
       assert conn
              |> authed_with_key(key)
@@ -218,7 +239,10 @@ defmodule FountainWeb.TeamCommsControllerTest do
       flag(true)
       {agent, conv} = teammate(user)
       stub_providers_ok()
-      {:ok, contact} = Comms.provision_contact(user.id, agent.id)
+
+      {:ok, contact} =
+        Comms.provision_contact(user.id, agent.id, %{"prompt_from_number" => "+15550001111"})
+
       {:ok, agent: agent, conv: conv, contact: contact}
     end
 

--- a/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
@@ -1,0 +1,325 @@
+defmodule FountainWeb.TeamCommsControllerTest do
+  # Flips the `team_comms` flag through global app env, so not async. The
+  # providers are Req.Test plugs (config/test.exs) stubbed per test.
+  use FountainWeb.ConnCase, async: false
+
+  alias Fountain.Team
+  alias Fountain.Team.Comms
+  alias Fountain.Team.Comms.{AgentMail, AgentPhone}
+
+  setup do
+    previous = Application.get_env(:fountain, :feature_flag_overrides)
+    on_exit(fn -> restore(:feature_flag_overrides, previous) end)
+
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    {:ok, user: user, raw_key: raw_key}
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:fountain, key)
+  defp restore(key, value), do: Application.put_env(:fountain, key, value)
+
+  defp flag(on?),
+    do: Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => on?})
+
+  defp teammate(user, name \\ "Ada") do
+    agent = insert_agent(user_id: user.id, name: name)
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        status: "idle",
+        channel_id: Team.channel()
+      )
+
+    {agent, conv}
+  end
+
+  defp stub_providers_ok do
+    Req.Test.stub(AgentMail, fn conn ->
+      case {conn.method, conn.request_path} do
+        {"POST", "/v0/inboxes"} ->
+          Req.Test.json(conn, %{"inbox_id" => "inbox_123", "email" => "ada-abc123@agentmail.to"})
+
+        {"DELETE", _} ->
+          Req.Test.json(conn, %{})
+      end
+    end)
+
+    Req.Test.stub(AgentPhone, fn conn ->
+      case {conn.method, conn.request_path} do
+        {"POST", "/v1/numbers"} ->
+          Req.Test.json(conn, %{"id" => "num_123", "phoneNumber" => "+15551234567"})
+
+        {"DELETE", _} ->
+          Req.Test.json(conn, %{})
+      end
+    end)
+  end
+
+  describe "GET /api/team/comms" do
+    test "reports the two gates", %{conn: conn, raw_key: key} do
+      flag(false)
+      body = conn |> authed_with_key(key) |> get("/api/team/comms") |> json_response(200)
+      assert body["data"] == %{"enabled" => false, "configured" => true}
+
+      flag(true)
+      body = conn |> authed_with_key(key) |> get("/api/team/comms") |> json_response(200)
+      assert body["data"] == %{"enabled" => true, "configured" => true}
+    end
+  end
+
+  describe "POST /api/team/:agent_id/contact" do
+    test "gives the teammate an email and a phone, and the roster shows them", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      flag(true)
+      {agent, _} = teammate(user)
+      stub_providers_ok()
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/team/#{agent.id}/contact")
+        |> json_response(201)
+
+      assert body["data"]["agent_id"] == agent.id
+      assert body["data"]["contact"]["email"] == "ada-abc123@agentmail.to"
+      assert body["data"]["contact"]["phone"] == "+15551234567"
+
+      [entry] =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/team")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert entry["contact"]["email"] == "ada-abc123@agentmail.to"
+    end
+
+    test "is 404 with the flag off — nothing to discover", %{conn: conn, user: user, raw_key: key} do
+      flag(false)
+      {agent, _} = teammate(user)
+      Req.Test.stub(AgentMail, fn _ -> flunk("no provider call with the flag off") end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/team/#{agent.id}/contact")
+        |> json_response(404)
+
+      assert body["error"] == "team_comms_not_enabled"
+    end
+
+    test "is 503 when the instance has no provider keys", %{conn: conn, user: user, raw_key: key} do
+      flag(true)
+      {agent, _} = teammate(user)
+      previous = Application.get_env(:fountain, :agentmail_api_key)
+      Application.delete_env(:fountain, :agentmail_api_key)
+      on_exit(fn -> Application.put_env(:fountain, :agentmail_api_key, previous) end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/team/#{agent.id}/contact")
+        |> json_response(503)
+
+      assert body["error"] == "team_comms_not_configured"
+    end
+
+    test "is 409 the second time", %{conn: conn, user: user, raw_key: key} do
+      flag(true)
+      {agent, _} = teammate(user)
+      stub_providers_ok()
+      conn |> authed_with_key(key) |> post("/api/team/#{agent.id}/contact") |> json_response(201)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/team/#{agent.id}/contact")
+        |> json_response(409)
+
+      assert body["error"] == "contact_already_provisioned"
+    end
+
+    test "is 502 naming the channel when a provider refuses", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      flag(true)
+      {agent, _} = teammate(user)
+
+      Req.Test.stub(AgentMail, fn conn ->
+        conn |> Plug.Conn.put_status(429) |> Req.Test.json(%{"message" => "slow down"})
+      end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post("/api/team/#{agent.id}/contact")
+        |> json_response(502)
+
+      assert body == %{
+               "error" => "provider_error",
+               "channel" => "email",
+               "message" => "HTTP 429: slow down"
+             }
+    end
+
+    test "is 404 for an agent not on the team, or another tenant's", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      flag(true)
+      loose = insert_agent(user_id: user.id)
+      {theirs, _} = teammate(insert_verified_user())
+
+      conn |> authed_with_key(key) |> post("/api/team/#{loose.id}/contact") |> json_response(404)
+      conn |> authed_with_key(key) |> post("/api/team/#{theirs.id}/contact") |> json_response(404)
+    end
+  end
+
+  describe "DELETE /api/team/:agent_id/contact" do
+    test "releases the contact", %{conn: conn, user: user, raw_key: key} do
+      flag(true)
+      {agent, _} = teammate(user)
+      stub_providers_ok()
+      conn |> authed_with_key(key) |> post("/api/team/#{agent.id}/contact") |> json_response(201)
+
+      assert conn
+             |> authed_with_key(key)
+             |> delete("/api/team/#{agent.id}/contact")
+             |> response(204)
+
+      assert Comms.get_contact(user.id, agent.id) == nil
+
+      # Gone from the teammate too.
+      body = conn |> authed_with_key(key) |> get("/api/team/#{agent.id}") |> json_response(200)
+      assert body["data"]["contact"] == nil
+    end
+
+    test "is 404 without one", %{conn: conn, user: user, raw_key: key} do
+      {agent, _} = teammate(user)
+
+      conn
+      |> authed_with_key(key)
+      |> delete("/api/team/#{agent.id}/contact")
+      |> json_response(404)
+    end
+  end
+
+  describe "POST /api/mcp/team-comms/:conversation_id" do
+    setup %{user: user} do
+      flag(true)
+      {agent, conv} = teammate(user)
+      stub_providers_ok()
+      {:ok, contact} = Comms.provision_contact(user.id, agent.id)
+      {:ok, agent: agent, conv: conv, contact: contact}
+    end
+
+    defp rpc(conn, raw_key, conv_id, body) do
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/mcp/team-comms/#{conv_id}", body)
+    end
+
+    test "initialize + tools/list on the teammate's conversation", %{
+      conn: conn,
+      raw_key: key,
+      conv: conv
+    } do
+      body =
+        rpc(conn, key, conv.id, %{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize"})
+        |> json_response(200)
+
+      assert body["result"]["serverInfo"]["name"] == "fountain-comms"
+      assert body["result"]["instructions"] =~ "ada-abc123@agentmail.to"
+
+      body = rpc(conn, key, conv.id, %{"id" => 2, "method" => "tools/list"}) |> json_response(200)
+      names = Enum.map(body["result"]["tools"], & &1["name"])
+      assert "email_send" in names
+      assert "sms_send" in names
+    end
+
+    test "tools/call goes to the provider under Fountain's key and is audited", %{
+      conn: conn,
+      raw_key: key,
+      conv: conv,
+      user: user
+    } do
+      test = self()
+
+      Req.Test.stub(AgentPhone, fn conn ->
+        assert {"authorization", "Bearer ap_test_key"} in conn.req_headers
+        send(test, {:sms, conn.body_params})
+        Req.Test.json(conn, %{"id" => "sms_1", "status" => "queued", "channel" => "sms"})
+      end)
+
+      body =
+        rpc(conn, key, conv.id, %{
+          "id" => 3,
+          "method" => "tools/call",
+          "params" => %{
+            "name" => "sms_send",
+            "arguments" => %{"to" => "+15550001111", "body" => "hi"}
+          }
+        })
+        |> json_response(200)
+
+      assert body["result"]["isError"] == false
+
+      assert_received {:sms,
+                       %{"number_id" => "num_123", "to_number" => "+15550001111", "body" => "hi"}}
+
+      [event] =
+        user.id
+        |> Fountain.Audit.list_recent_for_user(20)
+        |> Enum.filter(&(&1.action == "team.contact.sent"))
+
+      assert event.actor == "sprite"
+      assert event.metadata["tool"] == "sms_send"
+      refute inspect(event.metadata) =~ "+15550001111"
+    end
+
+    test "a notification is 202 with no body", %{conn: conn, raw_key: key, conv: conv} do
+      assert rpc(conn, key, conv.id, %{"method" => "notifications/initialized"}) |> response(202) ==
+               ""
+    end
+
+    test "is 404 on a conversation that is not the teammate's", %{
+      conn: conn,
+      raw_key: key,
+      user: user,
+      agent: agent
+    } do
+      other = insert_conversation(user_id: user.id, agent: agent)
+
+      assert rpc(conn, key, other.id, %{"id" => 1, "method" => "initialize"})
+             |> json_response(404)
+    end
+
+    test "is 404 when the teammate has no contact", %{conn: conn, raw_key: key, user: user} do
+      {_agent, conv} = teammate(user, "Bob")
+      assert rpc(conn, key, conv.id, %{"id" => 1, "method" => "initialize"}) |> json_response(404)
+    end
+
+    test "is 403 when the flag is off for the owner", %{conn: conn, raw_key: key, conv: conv} do
+      flag(false)
+      assert rpc(conn, key, conv.id, %{"id" => 1, "method" => "initialize"}) |> json_response(403)
+    end
+
+    test "is 404 for another tenant", %{conn: conn, conv: conv} do
+      other = insert_verified_user()
+      {_key, other_key} = insert_api_key(other)
+
+      assert rpc(conn, other_key, conv.id, %{"id" => 1, "method" => "initialize"})
+             |> json_response(404)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
+++ b/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
@@ -1,0 +1,104 @@
+defmodule FountainWeb.TeamLiveCommsTest do
+  # The teammate email/phone affordance on /team (flag `team_comms`). Flips
+  # the flag through global app env, so not async; the providers are the
+  # Req.Test plugs from config/test.exs, allowed to the LiveView process.
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Team
+  alias Fountain.Team.Comms
+  alias Fountain.Team.Comms.{AgentMail, AgentPhone}
+
+  setup do
+    previous = Application.get_env(:fountain, :feature_flag_overrides)
+    on_exit(fn -> restore(:feature_flag_overrides, previous) end)
+    :ok
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:fountain, key)
+  defp restore(key, value), do: Application.put_env(:fountain, key, value)
+
+  defp flag(on?),
+    do: Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => on?})
+
+  defp teammate(user) do
+    agent = insert_agent(user_id: user.id, name: "Ada")
+
+    insert_conversation(
+      user_id: user.id,
+      agent: agent,
+      status: "idle",
+      channel_id: Team.channel()
+    )
+
+    agent
+  end
+
+  defp stub_providers_ok do
+    Req.Test.stub(AgentMail, fn conn ->
+      case conn.method do
+        "POST" -> Req.Test.json(conn, %{"inbox_id" => "inbox_1", "email" => "ada-1@agentmail.to"})
+        "DELETE" -> Req.Test.json(conn, %{})
+      end
+    end)
+
+    Req.Test.stub(AgentPhone, fn conn ->
+      case conn.method do
+        "POST" -> Req.Test.json(conn, %{"id" => "num_1", "phoneNumber" => "+15551234567"})
+        "DELETE" -> Req.Test.json(conn, %{})
+      end
+    end)
+  end
+
+  test "with the flag off there is no affordance", %{conn: conn} do
+    flag(false)
+    user = insert_verified_user()
+    agent = teammate(user)
+
+    {:ok, _view, html} = conn |> login_user(user) |> live(~p"/team/#{agent.id}")
+    refute html =~ "provision-contact-button"
+    refute html =~ "teammate-contact"
+  end
+
+  test "with the flag on: give, see, release", %{conn: conn} do
+    flag(true)
+    user = insert_verified_user()
+    agent = teammate(user)
+    stub_providers_ok()
+
+    {:ok, view, html} = conn |> login_user(user) |> live(~p"/team/#{agent.id}")
+    assert html =~ "Give email &amp; phone"
+    refute html =~ "release-contact-button"
+
+    # The LiveView process makes the provider calls; let it use our stubs.
+    Req.Test.allow(AgentMail, self(), view.pid)
+    Req.Test.allow(AgentPhone, self(), view.pid)
+
+    html = view |> element("#provision-contact-button") |> render_click()
+    assert html =~ "ada-1@agentmail.to"
+    assert html =~ "+15551234567"
+    assert html =~ "release-contact-button"
+    refute html =~ "provision-contact-button"
+    assert %Fountain.Team.Contact{} = Comms.get_contact(user.id, agent.id)
+
+    html = view |> element("#release-contact-button") |> render_click()
+    refute html =~ "ada-1@agentmail.to"
+    assert html =~ "provision-contact-button"
+    assert Comms.get_contact(user.id, agent.id) == nil
+  end
+
+  test "with the flag on but no provider keys the button is disabled and says why", %{conn: conn} do
+    flag(true)
+    user = insert_verified_user()
+    agent = teammate(user)
+    previous = Application.get_env(:fountain, :agentmail_api_key)
+    Application.delete_env(:fountain, :agentmail_api_key)
+    on_exit(fn -> Application.put_env(:fountain, :agentmail_api_key, previous) end)
+
+    {:ok, view, _html} = conn |> login_user(user) |> live(~p"/team/#{agent.id}")
+    button = view |> element("#provision-contact-button") |> render()
+    assert button =~ "disabled"
+    assert button =~ "no AgentMail/AgentPhone keys"
+  end
+end

--- a/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
+++ b/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
@@ -75,9 +75,20 @@ defmodule FountainWeb.TeamLiveCommsTest do
     Req.Test.allow(AgentMail, self(), view.pid)
     Req.Test.allow(AgentPhone, self(), view.pid)
 
+    # The button opens the form that collects the number; nothing is bought yet.
     html = view |> element("#provision-contact-button") |> render_click()
+    assert html =~ "contact-form"
+    refute html =~ "ada-1@agentmail.to"
+
+    html =
+      view
+      |> form("#contact-form", %{"prompt_from_number" => "(555) 000-1111"})
+      |> render_submit()
+
     assert html =~ "ada-1@agentmail.to"
     assert html =~ "+15551234567"
+    assert html =~ "texts from"
+    assert html =~ "+15550001111"
     assert html =~ "release-contact-button"
     refute html =~ "provision-contact-button"
     assert %Fountain.Team.Contact{} = Comms.get_contact(user.id, agent.id)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1047,3 +1047,11 @@ end
 config :fountain,
        :agentphone_base_url,
        System.get_env("AGENTPHONE_BASE_URL", "https://api.agentphone.ai")
+
+# The signing secret AgentPhone issued for this instance's master webhook
+# (POST /v1/webhooks → `secret`), which verifies POST /api/webhooks/agentphone.
+# Unset, the endpoint answers 503 and no inbound text becomes a prompt.
+case System.get_env("AGENTPHONE_WEBHOOK_SECRET") do
+  blank when blank in [nil, ""] -> :ok
+  secret -> config :fountain, :agentphone_webhook_secret, secret
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -991,3 +991,59 @@ case System.get_env("OAUTH_CLIENTS") do
         raise "OAUTH_CLIENTS must be a JSON array of {id, name, redirect_uris}"
     end
 end
+
+# ── Feature flags ─────────────────────────────────────────────────────────
+#
+# Per-user flags are evaluated by PostHog (`Fountain.FeatureFlags`) when a
+# project API key is set; the module caches answers and falls back to the
+# last one it got when PostHog is unreachable, and to "off" when it has
+# none — an outage never turns a feature on. FEATURE_FLAGS_ON is the
+# no-PostHog path: a comma-separated list of flag keys forced on for every
+# user (a self-hoster, or dev). Read in every env.
+# Set only when present, so config/test.exs keeps its own value.
+case System.get_env("POSTHOG_PROJECT_API_KEY") do
+  blank when blank in [nil, ""] -> :ok
+  key -> config :fountain, :posthog_project_api_key, key
+end
+
+config :fountain,
+       :posthog_host,
+       System.get_env("POSTHOG_HOST", "https://us.i.posthog.com")
+
+config :fountain,
+       :feature_flag_overrides,
+       "FEATURE_FLAGS_ON"
+       |> System.get_env("")
+       |> String.split(",", trim: true)
+       |> Enum.map(&String.trim/1)
+       |> Enum.reject(&(&1 == ""))
+       |> Map.new(&{&1, true})
+
+# ── Teammate email + phone (flag `team_comms`) ───────────────────────────
+#
+# Fountain holds the AgentMail and AgentPhone keys; a teammate gets an inbox
+# and a number under them, and reaches both through MCP tools Fountain serves
+# (`Fountain.Team.Comms`). The keys never enter a sandbox. Unset, the feature
+# reports itself unavailable even when the flag is on.
+# Keys are set only when present, so config/test.exs keeps its own values.
+case System.get_env("AGENTMAIL_API_KEY") do
+  blank when blank in [nil, ""] -> :ok
+  key -> config :fountain, :agentmail_api_key, key
+end
+
+config :fountain,
+       :agentmail_base_url,
+       System.get_env("AGENTMAIL_BASE_URL", "https://api.agentmail.to")
+
+# Optional: a verified custom domain for teammate inboxes; unset uses
+# AgentMail's shared domain.
+config :fountain, :agentmail_domain, System.get_env("AGENTMAIL_DOMAIN")
+
+case System.get_env("AGENTPHONE_API_KEY") do
+  blank when blank in [nil, ""] -> :ok
+  key -> config :fountain, :agentphone_api_key, key
+end
+
+config :fountain,
+       :agentphone_base_url,
+       System.get_env("AGENTPHONE_BASE_URL", "https://api.agentphone.ai")

--- a/config/test.exs
+++ b/config/test.exs
@@ -102,4 +102,5 @@ config :fountain, :agentmail_api_key, "am_test_key"
 config :fountain, :agentmail_req_options, plug: {Req.Test, Fountain.Team.Comms.AgentMail}
 config :fountain, :agentphone_api_key, "ap_test_key"
 config :fountain, :agentphone_req_options, plug: {Req.Test, Fountain.Team.Comms.AgentPhone}
+config :fountain, :agentphone_webhook_secret, "whsec_test"
 config :fountain, :posthog_req_options, plug: {Req.Test, Fountain.FeatureFlags}

--- a/config/test.exs
+++ b/config/test.exs
@@ -92,3 +92,14 @@ config :fountain, :oauth_clients, [
 # about "which providers are enabled" (only what a test configures) hold;
 # runner tests switch it on explicitly.
 config :fountain, :runners_enabled, false
+
+# Teammate email + phone (flag `team_comms`) and the PostHog flag lookup:
+# every outbound call goes to a Req.Test plug, so a test that forgets to
+# stub fails loudly instead of reaching a real provider. The keys are set so
+# `Comms.configured?/0` holds; the flag itself stays off (no override, no
+# PostHog key) until a test flips `:feature_flag_overrides`.
+config :fountain, :agentmail_api_key, "am_test_key"
+config :fountain, :agentmail_req_options, plug: {Req.Test, Fountain.Team.Comms.AgentMail}
+config :fountain, :agentphone_api_key, "ap_test_key"
+config :fountain, :agentphone_req_options, plug: {Req.Test, Fountain.Team.Comms.AgentPhone}
+config :fountain, :posthog_req_options, plug: {Req.Test, Fountain.FeatureFlags}

--- a/docs/api.md
+++ b/docs/api.md
@@ -371,7 +371,7 @@ PATCH  /api/team/:agent_id          # rename ({name}; null or blank → the agen
 DELETE /api/team/:agent_id          # remove: terminate the live conversation, unbind history
 POST   /api/team/:agent_id/messages # a turn (prompt; optional images) → {conversation_id}
 GET    /api/team/:agent_id/conversations  # history: every conversation on the team, newest first, `current` flagged
-POST   /api/team/:agent_id/contact  # give the teammate an email address + phone number (flag `team_comms`)
+POST   /api/team/:agent_id/contact  # give the teammate an email address + phone number ({prompt_from_number}; flag `team_comms`)
 DELETE /api/team/:agent_id/contact  # release them
 GET    /api/team/comms              # {enabled, configured}: may this caller, and can this instance
 GET    /api/team/stream             # SSE: every teammate's events on one connection
@@ -435,6 +435,15 @@ instance has no keys, `409` for a second contact, `502 provider_error`
 nothing. `DELETE` releases both upstream and forgets them; `GET
 /api/team/comms` answers `{enabled, configured}` so a client knows whether
 to offer it. See [configuration](configuration.md#teammate-email-and-phone).
+
+The request body carries `prompt_from_number` (required; any common format,
+stored E.164): **your** phone. A text from that number to the teammate's
+number arrives as a prompt in the teammate's conversation — delivered by
+AgentPhone to `POST /api/webhooks/agentphone` (HMAC-verified with
+`AGENTPHONE_WEBHOOK_SECRET`), wrapped so the teammate knows it came by SMS
+and can answer with its `sms_send` tool. Texts from any other number are
+acknowledged and ignored; deliveries are deduplicated by AgentPhone's
+`X-Webhook-ID`. Audited as `team.contact.prompted` (bytes, never the text).
 
 `/messages` returns `202 {status: "queued", conversation_id}`; the id is the
 conversation the message went to, which is a new one when the teammate's

--- a/docs/api.md
+++ b/docs/api.md
@@ -371,6 +371,9 @@ PATCH  /api/team/:agent_id          # rename ({name}; null or blank → the agen
 DELETE /api/team/:agent_id          # remove: terminate the live conversation, unbind history
 POST   /api/team/:agent_id/messages # a turn (prompt; optional images) → {conversation_id}
 GET    /api/team/:agent_id/conversations  # history: every conversation on the team, newest first, `current` flagged
+POST   /api/team/:agent_id/contact  # give the teammate an email address + phone number (flag `team_comms`)
+DELETE /api/team/:agent_id/contact  # release them
+GET    /api/team/comms              # {enabled, configured}: may this caller, and can this instance
 GET    /api/team/stream             # SSE: every teammate's events on one connection
 ```
 
@@ -415,6 +418,23 @@ a teammate on a [self-hosted runner](integrations/runners.md) whose machine
 is not connected: a message cannot wake it (`503 runner_offline`), it comes
 back when the daemon reconnects. The conversation's `sandbox` carries
 `provider` and, on a runner, `runner: {id, name, hostname, online, path}`.
+
+**Email and phone (proof of concept, flag `team_comms`).** `POST
+/api/team/:agent_id/contact` gives the teammate an inbox
+([AgentMail](https://agentmail.to)) and a number
+([AgentPhone](https://agentphone.ai)) under the instance's own keys, and the
+roster entry gains `contact: {email, phone}`. From its next turn the teammate
+has `email_send`, `email_reply`, `email_list`, `email_get`, `sms_send`,
+`sms_list` and `my_contact_info` MCP tools, served by Fountain itself at
+`POST /api/mcp/team-comms/:conversation_id` with the conversation's sprite
+token — no provider key enters the sandbox, and every send is audited
+(`team.contact.sent`, never the content). `404 team_comms_not_enabled` when
+the flag is off for the caller, `503 team_comms_not_configured` when the
+instance has no keys, `409` for a second contact, `502 provider_error`
+(`channel` names which) when a provider refuses — provisioning is all or
+nothing. `DELETE` releases both upstream and forgets them; `GET
+/api/team/comms` answers `{enabled, configured}` so a client knows whether
+to offer it. See [configuration](configuration.md#teammate-email-and-phone).
 
 `/messages` returns `202 {status: "queued", conversation_id}`; the id is the
 conversation the message went to, which is a new one when the teammate's

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,3 +202,4 @@ unavailable even where the flag is on.
 | `AGENTMAIL_DOMAIN` | — | — | A verified custom domain for teammate addresses; unset uses AgentMail's shared domain |
 | `AGENTPHONE_API_KEY` | — | — | AgentPhone API key; teammate numbers are provisioned under it |
 | `AGENTPHONE_BASE_URL` | `https://api.agentphone.ai` | — | AgentPhone API host |
+| `AGENTPHONE_WEBHOOK_SECRET` | — | — | The signing secret AgentPhone returned when the account's master webhook was pointed at `POST /api/webhooks/agentphone` on this instance. Verifies inbound deliveries; a text from a teammate's `prompt_from_number` then becomes a prompt in its conversation. Unset, the endpoint answers 503 and nothing inbound is processed |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,3 +171,34 @@ set them — the defaults are correct for the packaged image.
 
 Upstream publishes `buzz-acp` for amd64 only, so Fountain builds it for both
 architectures from source and bakes it in (see `.github/workflows/buzz-acp-publish.yml`).
+
+## Feature flags
+
+Per-user flags (`Fountain.FeatureFlags`) are evaluated by PostHog when a
+project key is set. Answers are cached per user for a minute; when PostHog is
+unreachable the last answer it gave is reused, and with none every flag reads
+off — an outage never turns a feature on. Without PostHog, a flag can be forced
+on for every user.
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `POSTHOG_PROJECT_API_KEY` | — | — | The PostHog *project* API key (the public `phc_…` token, not a personal key). Unset, no flag is looked up remotely |
+| `POSTHOG_HOST` | `https://us.i.posthog.com` | — | PostHog ingestion host; `https://eu.i.posthog.com` for EU Cloud, or a self-hosted instance |
+| `FEATURE_FLAGS_ON` | — | — | Comma-separated flag keys forced on for every user, e.g. `team_comms`. Wins over PostHog |
+
+## Teammate email and phone
+
+Behind the `team_comms` flag, a teammate can be given an email address
+([AgentMail](https://agentmail.to)) and a phone number
+([AgentPhone](https://agentphone.ai)), and gets MCP tools to send and read on
+both. Fountain holds the provider keys and serves the tools itself — the keys
+never enter a sandbox. With either key unset the feature reports itself
+unavailable even where the flag is on.
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `AGENTMAIL_API_KEY` | — | — | AgentMail API key; teammate inboxes are created under it |
+| `AGENTMAIL_BASE_URL` | `https://api.agentmail.to` | — | AgentMail API host (`https://api.agentmail.eu` for the EU region) |
+| `AGENTMAIL_DOMAIN` | — | — | A verified custom domain for teammate addresses; unset uses AgentMail's shared domain |
+| `AGENTPHONE_API_KEY` | — | — | AgentPhone API key; teammate numbers are provisioned under it |
+| `AGENTPHONE_BASE_URL` | `https://api.agentphone.ai` | — | AgentPhone API host |


### PR DESCRIPTION
## What

Proof of concept: give a teammate an inbox ([AgentMail](https://agentmail.to)) and a number ([AgentPhone](https://agentphone.ai)), and let it send and read on both through MCP tools **Fountain serves itself**. Fountain owns the provider keys (`AGENTMAIL_API_KEY`, `AGENTPHONE_API_KEY` — Infisical in prod); **no key ever enters a sandbox**. Behind a new per-user feature flag, `team_comms`.

- **`Fountain.FeatureFlags`** — per-user flags evaluated by PostHog (`POSTHOG_PROJECT_API_KEY`, `POSTHOG_HOST`), cached per user for a minute. **When PostHog is down** the last answer it gave is reused; with none cached, every flag reads off — an outage never turns a feature on. `FEATURE_FLAGS_ON=team_comms` forces a flag on without PostHog (self-host / dev / tests).
- **`Fountain.Team.Comms` + `Fountain.Team.Contact`** (`team_contacts`, keyed by `user_id+agent_id` like schedules): `provision_contact` (all or nothing — a failed number deletes the inbox again), `release_contact` (404 upstream counts as released; any other failure keeps the row so nothing is orphaned), both audited (channels, never the address). `remove_teammate` releases the contact too.
- **`Fountain.Team.Comms.Mcp` + `POST /api/mcp/team-comms/:conversation_id`** — the Buzz-MCP shape (ADR 0020). Tools `email_send` / `email_reply` / `email_list` / `email_get` / `sms_send` / `sms_list` / `my_contact_info`; `initialize` instructions tell the teammate its own address and number. Injected at every turn kick beside the Buzz tools, only for a team conversation whose teammate has a contact and whose owner has the flag — so a contact given mid-session is there on the next turn. Sends audited as `team.contact.sent`.
- **API**: `POST`/`DELETE /api/team/:agent_id/contact`, `GET /api/team/comms` (`{enabled, configured}`), `contact` on every roster entry; OpenAPI schemas. 404 with the flag off, 503 without keys, 409 twice, 502 naming the channel a provider refused.
- **`/team`**: "Give email & phone" / "Release contact" on the thread header, the contact shown under the name; disabled with the reason when the instance has no keys.
- docs/configuration.md (test-enforced), docs/api.md, `.env.example`, CHANGELOG.

## To turn it on (prod)

1. Infisical: `AGENTMAIL_API_KEY`, `AGENTPHONE_API_KEY`, `POSTHOG_PROJECT_API_KEY` (the public `phc_…` project token).
2. PostHog: create a boolean flag `team_comms`, release to Jake's user id (the Fountain `users.id` UUID is the `distinct_id`).
3. `/team` → pick a teammate → **Give email & phone**. Next turn: ask it for its contact info / to email you.

## Tests

Feature flags (override, PostHog on/off/down, stale-on-outage, cache), context (gates, provisioning, rollback, release, removal, mcp_servers injection), MCP protocol + tools, controller (API + MCP endpoint incl. tenant/flag/contact checks), LiveView, audit guardrail. Full suite 3250 green; format, credo, sobelow, dialyzer, openapi, mkdocs --strict clean.

## Not in this PoC (next)

- **Inbound SMS → prompt**: an AgentPhone webhook that, for a message from an allow-listed sender number, becomes `Team.send_message` into the teammate's conversation (the follow-up Jake named).
- Inbound email → prompt; voice.
- Approval cards for sends (#643).

🤖 Generated with [Claude Code](https://claude.com/claude-code)