### PR TITLE
feat(team): teammates that know each other — the fountain-team MCP — and a bundled /create-team skill (#851)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2051,6 +2051,13 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp buzz_mcp_servers(_state), do: []
 
+  # The team tools (#851), for conversations on the team channel.
+  defp team_mcp_servers(%{callback_token: token, conversation_id: conv_id})
+       when is_binary(token) and is_binary(conv_id),
+       do: Fountain.Team.conversation_mcp_servers(conv_id, token)
+
+  defp team_mcp_servers(_state), do: []
+
   # How long a sprite's callback key stays valid.
   #
   # This is a backstop, not the primary control: the key is revoked at
@@ -2348,7 +2355,7 @@ defmodule Fountain.Conversations.ConversationServer do
                     images: images,
                     mcp_servers:
                       Fountain.Runtimes.ACP.mcp_servers(agent) ++
-                        buzz_mcp_servers(state),
+                        buzz_mcp_servers(state) ++ team_mcp_servers(state),
                     model: agent && Fountain.Runtimes.Model.id(agent.model)
                   )
                 else

--- a/apps/fountain/lib/fountain/sandbox_skills.ex
+++ b/apps/fountain/lib/fountain/sandbox_skills.ex
@@ -32,6 +32,9 @@ defmodule Fountain.SandboxSkills do
 
   @bundle_root "sprite_skills"
   @fountain_skill_name "fountain"
+  # Every sandbox gets these, in this order: the API skill, then the team
+  # set-up Q&A (#851) — so a first teammate can answer "/create-team".
+  @bundled_skills [@fountain_skill_name, "create-team"]
 
   @doc """
   Mount `skills` (a list of inline/github maps) on the sandbox behind
@@ -49,7 +52,7 @@ defmodule Fountain.SandboxSkills do
     skills_root = runtime_module.skills_root()
     sh_agent = runtime_module.skills_sh_agent()
 
-    all = [fountain_inline_skill() | normalize(skills || [])]
+    all = bundled_inline_skills() ++ normalize(skills || [])
 
     {inline, github} =
       Enum.split_with(all, fn s -> is_binary(s["content"]) end)
@@ -77,11 +80,10 @@ defmodule Fountain.SandboxSkills do
   # priv_dir and a module attribute; no user input.
   # sobelow_skip ["Traversal.FileModule"] — fixed path assembled from
   # priv_dir and a module attribute; no user input.
-  defp fountain_inline_skill do
-    %{
-      "name" => @fountain_skill_name,
-      "content" => File.read!(Path.join([priv_dir(), @fountain_skill_name, "SKILL.md"]))
-    }
+  defp bundled_inline_skills do
+    Enum.map(@bundled_skills, fn name ->
+      %{"name" => name, "content" => File.read!(Path.join([priv_dir(), name, "SKILL.md"]))}
+    end)
   end
 
   defp write_inline_skills(_handle, _root, []), do: :ok

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -77,6 +77,40 @@ defmodule Fountain.Team do
       )
 
   @doc """
+  The MCP server a team conversation's turns carry (#851): `fountain-team`,
+  served by Fountain at `/api/mcp/team/:conversation_id`, authenticated with
+  the sandbox's own token. Only conversations on the team channel get it —
+  the tools are "the team", and a conversation outside it has no team.
+  """
+  def conversation_mcp_servers(conversation_id, token)
+      when is_binary(conversation_id) and is_binary(token) and token != "" do
+    case fetch_conv(conversation_id) do
+      %Conversation{channel_id: @channel} ->
+        [
+          %{
+            name: Fountain.Team.Mcp.mcp_name(),
+            type: "http",
+            url: Fountain.PublicUrl.base() <> "/api/mcp/team/" <> conversation_id,
+            headers: [%{name: "Authorization", value: "Bearer " <> token}]
+          }
+        ]
+
+      _ ->
+        []
+    end
+  end
+
+  def conversation_mcp_servers(_conversation_id, _token), do: []
+
+  # ownership: system-level call from ConversationServer, which owns the
+  # conversation; the tools re-scope every read/write by the token's user.
+  defp fetch_conv(conversation_id) do
+    Conversations._unsafe_get_conversation(conversation_id)
+  rescue
+    Ecto.Query.CastError -> nil
+  end
+
+  @doc """
   One entry per agent on the team, most recently active first.
 
   Each entry is `%{agent: %Agent{}, conversation: %Conversation{}, last_turn:

--- a/apps/fountain/lib/fountain/team/mcp.ex
+++ b/apps/fountain/lib/fountain/team/mcp.ex
@@ -1,0 +1,333 @@
+defmodule Fountain.Team.Mcp do
+  @moduledoc """
+  Teammates that know each other (#851): MCP tools Fountain serves to every
+  conversation on the team channel, so an agent can see who else is on the
+  team and message them — "send this to the engineer" becomes
+  `get_teammate("engineer")` → `send_to_teammate(id, text)`, and
+  `read_teammate` fetches the reply.
+
+  Same shape as the Buzz tools (ADR 0020): a pure JSON-RPC/tool layer over a
+  `ctx`, served by `FountainWeb.TeamMcpController` at
+  `POST /api/mcp/team/:conversation_id`, injected into each turn by
+  `Fountain.Team.conversation_mcp_servers/2`. The sandbox authenticates with
+  the per-conversation token it already holds; every call is tenant-scoped
+  through `Fountain.Team` and a message lands in the teammate's thread exactly
+  as one typed on the team page would — the receiver sees who sent it.
+
+  `ctx`: `:user_id`, `:self` (the calling teammate's roster entry or nil),
+  `:actor` / `:request_ip` for audit.
+  """
+
+  alias Fountain.{Conversations, Team}
+  alias FountainWeb.TeamPresenter
+
+  @protocol_version "2025-06-18"
+  @server_info %{name: "fountain-team", version: "1"}
+  @mcp_name "fountain-team"
+
+  def mcp_name, do: @mcp_name
+
+  @doc "The tool catalogue advertised by `tools/list`."
+  def tools do
+    [
+      %{
+        name: "list_teammates",
+        description:
+          "Everyone on the team: name, agent id, what they are for, and what they are doing " <>
+            "right now (presence). Start here when asked to involve a teammate.",
+        inputSchema: %{type: "object", properties: %{}}
+      },
+      %{
+        name: "get_teammate",
+        description:
+          "Find one teammate by name, role or description — 'the engineer', 'steward', " <>
+            "'whoever handles support'. Returns the best match with its agent id and " <>
+            "presence, or the candidates when it is ambiguous.",
+        inputSchema: %{
+          type: "object",
+          properties: %{query: %{type: "string", description: "A name, role or keyword"}},
+          required: ["query"]
+        }
+      },
+      %{
+        name: "send_to_teammate",
+        description:
+          "Send a message to a teammate's thread. They get it like a message typed to them, " <>
+            "prefixed with who it is from. Returns their conversation id; poll read_teammate " <>
+            "for the reply. Fails with busy/starting when they cannot take it yet — wait and retry.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            teammate: %{type: "string", description: "Agent id, or a name/role to resolve"},
+            message: %{
+              type: "string",
+              description: "What to say — goal, constraints, what 'done' looks like"
+            }
+          },
+          required: ["teammate", "message"]
+        }
+      },
+      %{
+        name: "read_teammate",
+        description:
+          "A teammate's recent turns: each prompt and their reply text, newest last, with " <>
+            "status. Use after send_to_teammate to collect the answer.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            teammate: %{type: "string", description: "Agent id, or a name/role to resolve"},
+            limit: %{type: "integer", description: "How many recent turns (default 5, max 20)"}
+          },
+          required: ["teammate"]
+        }
+      }
+    ]
+  end
+
+  @doc "Handle one JSON-RPC 2.0 request map against `ctx`; `:noreply` for notifications."
+  def handle(%{"method" => method} = req, ctx) do
+    id = Map.get(req, "id")
+
+    if is_nil(id) and String.starts_with?(method, "notifications/"),
+      do: :noreply,
+      else: dispatch(method, id, Map.get(req, "params", %{}), ctx)
+  end
+
+  def handle(_req, _ctx), do: error(nil, -32_600, "invalid request")
+
+  defp dispatch("initialize", id, _params, _ctx) do
+    result(id, %{
+      protocolVersion: @protocol_version,
+      capabilities: %{tools: %{}},
+      serverInfo: @server_info
+    })
+  end
+
+  defp dispatch("ping", id, _params, _ctx), do: result(id, %{})
+  defp dispatch("tools/list", id, _params, _ctx), do: result(id, %{tools: tools()})
+
+  defp dispatch("tools/call", id, %{"name" => name} = params, ctx),
+    do: call_tool(id, name, Map.get(params, "arguments", %{}), ctx)
+
+  defp dispatch(_unknown, nil, _params, _ctx), do: :noreply
+  defp dispatch(method, id, _params, _ctx), do: error(id, -32_601, "method not found: #{method}")
+
+  # ── tools ──────────────────────────────────────────────────────────────────
+
+  defp call_tool(id, "list_teammates", _args, ctx) do
+    rows = ctx.user_id |> Team.list_teammates() |> Enum.map(&summary(&1, ctx))
+    result(id, %{content: [json(rows)], isError: false})
+  end
+
+  defp call_tool(id, "get_teammate", args, ctx) do
+    with {:ok, q} <- require_arg(args, "query") do
+      case resolve(ctx.user_id, q) do
+        {:ok, t} ->
+          result(id, %{content: [json(summary(t, ctx))], isError: false})
+
+        {:ambiguous, ts} ->
+          result(id, %{
+            content: [json(%{ambiguous: Enum.map(ts, &summary(&1, ctx))})],
+            isError: false
+          })
+
+        :none ->
+          tool_error(id, "no teammate matches #{inspect(q)}; call list_teammates")
+      end
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, "send_to_teammate", args, ctx) do
+    with {:ok, who} <- require_arg(args, "teammate"),
+         {:ok, message} <- require_arg(args, "message"),
+         {:ok, t} <- resolve_one(ctx.user_id, who),
+         :ok <- not_self(t, ctx) do
+      text = from_line(ctx) <> message
+
+      case Team.send_message(ctx.user_id, t.agent.id, text, [], audit_opts(ctx)) do
+        {:ok, conv} ->
+          result(id, %{
+            content: [
+              json(%{
+                sent: true,
+                teammate: t.name,
+                agent_id: t.agent.id,
+                conversation_id: conv.id
+              })
+            ],
+            isError: false
+          })
+
+        {:error, :busy} ->
+          tool_error(
+            id,
+            "#{t.name} is busy with another turn — wait for it to finish (read_teammate) and retry"
+          )
+
+        {:error, :provisioning} ->
+          tool_error(id, "#{t.name}'s computer is still starting — retry in ~30s")
+
+        {:error, :runner_offline} ->
+          tool_error(
+            id,
+            "#{t.name}'s machine is offline — nothing can reach them until its runner reconnects"
+          )
+
+        {:error, other} ->
+          tool_error(id, "could not send to #{t.name}: #{inspect(other)}")
+      end
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, "read_teammate", args, ctx) do
+    with {:ok, who} <- require_arg(args, "teammate"),
+         {:ok, t} <- resolve_one(ctx.user_id, who) do
+      limit = args |> Map.get("limit", 5) |> clamp(1, 20)
+      conv = t.conversation
+
+      # ownership: `t` came from resolve_one → Team.list_teammates(ctx.user_id),
+      # a tenant-scoped read; the conversation is that teammate's.
+      turns =
+        conv.id
+        |> Conversations._unsafe_list_turns()
+        |> Enum.take(-limit)
+        |> Enum.map(fn turn ->
+          %{
+            turn: turn.turn_number,
+            status: turn.status,
+            at: turn.inserted_at,
+            prompt: String.slice(turn.prompt || "", 0, 2000),
+            reply: String.slice(turn.reply_text || "", 0, 6000)
+          }
+        end)
+
+      result(id, %{
+        content: [
+          json(%{teammate: t.name, conversation_id: conv.id, presence: presence(t), turns: turns})
+        ],
+        isError: false
+      })
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
+  defp call_tool(id, name, _args, _ctx), do: tool_error(id, "unknown tool: #{name}")
+
+  # ── resolving "the engineer" ───────────────────────────────────────────────
+
+  @doc false
+  def resolve(user_id, query) do
+    rows = Team.list_teammates(user_id)
+    q = String.downcase(String.trim(query))
+
+    exact =
+      Enum.filter(rows, fn t ->
+        t.agent.id == query or String.downcase(t.name) == q or String.downcase(t.agent.name) == q
+      end)
+
+    case exact do
+      [t] ->
+        {:ok, t}
+
+      [_ | _] = ts ->
+        {:ambiguous, ts}
+
+      [] ->
+        words =
+          q
+          |> String.split(~r/[^a-z0-9]+/, trim: true)
+          |> Enum.reject(&(&1 in ~w(the a an our my)))
+
+        scored =
+          rows
+          |> Enum.map(fn t -> {score(t, q, words), t} end)
+          |> Enum.filter(fn {s, _} -> s > 0 end)
+          |> Enum.sort_by(fn {s, _} -> -s end)
+
+        case scored do
+          [] -> :none
+          [{_, t}] -> {:ok, t}
+          [{s1, t1}, {s2, _} | _] when s1 >= s2 * 2 -> {:ok, t1}
+          many -> {:ambiguous, many |> Enum.take(3) |> Enum.map(&elem(&1, 1))}
+        end
+    end
+  end
+
+  defp score(t, q, words) do
+    hay = String.downcase("#{t.name} #{t.agent.name} #{t.agent.description || ""}")
+    name = String.downcase("#{t.name} #{t.agent.name}")
+
+    base = if q != "" and String.contains?(name, q), do: 10, else: 0
+
+    Enum.reduce(words, base, fn w, acc ->
+      cond do
+        String.contains?(name, w) -> acc + 4
+        String.contains?(hay, w) -> acc + 1
+        true -> acc
+      end
+    end)
+  end
+
+  defp resolve_one(user_id, who) do
+    case resolve(user_id, who) do
+      {:ok, t} -> {:ok, t}
+      {:ambiguous, ts} -> {:error, "ambiguous: #{Enum.map_join(ts, ", ", & &1.name)} — say which"}
+      :none -> {:error, "no teammate matches #{inspect(who)}; call list_teammates"}
+    end
+  end
+
+  defp not_self(%{agent: %{id: id}}, %{self: %{agent: %{id: id}}}),
+    do: {:error, "that is you — pick another teammate"}
+
+  defp not_self(_t, _ctx), do: :ok
+
+  # ── shapes ─────────────────────────────────────────────────────────────────
+
+  defp summary(t, ctx) do
+    %{
+      name: t.name,
+      agent_id: t.agent.id,
+      agent_name: t.agent.name,
+      about: t.agent.description || "",
+      runtime: t.agent.runtime,
+      model: t.agent.model,
+      presence: presence(t),
+      conversation_id: t.conversation.id,
+      is_you: match?(%{self: %{agent: %{id: id}}} when id == t.agent.id, ctx)
+    }
+  end
+
+  defp presence(t), do: t.conversation |> TeamPresenter.presence() |> Map.get(:state)
+
+  defp from_line(%{self: %{name: name}}) when is_binary(name),
+    do: "[From your teammate #{name}, via the team] "
+
+  defp from_line(_), do: "[From a teammate, via the team] "
+
+  defp audit_opts(ctx),
+    do: [actor: Map.get(ctx, :actor, "sprite"), request_ip: Map.get(ctx, :request_ip)]
+
+  defp require_arg(args, key) do
+    case Map.get(args, key) do
+      v when is_binary(v) and v != "" -> {:ok, v}
+      _ -> {:error, "missing required argument: #{key}"}
+    end
+  end
+
+  defp clamp(n, lo, hi) when is_integer(n), do: n |> max(lo) |> min(hi)
+  defp clamp(_, lo, _), do: lo
+
+  defp json(v), do: %{type: "text", text: Jason.encode!(v)}
+  defp result(id, r), do: %{"jsonrpc" => "2.0", "id" => id, "result" => r}
+
+  defp tool_error(id, msg),
+    do: result(id, %{content: [%{type: "text", text: msg}], isError: true})
+
+  defp error(id, code, message),
+    do: %{"jsonrpc" => "2.0", "id" => id, "error" => %{"code" => code, "message" => message}}
+end

--- a/apps/fountain/lib/fountain_web/controllers/team_mcp_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_mcp_controller.ex
@@ -1,0 +1,50 @@
+defmodule FountainWeb.TeamMcpController do
+  @moduledoc """
+  The MCP endpoint a teammate's sandbox calls to see and message the rest of
+  the team (#851). Streamable-HTTP: one JSON-RPC message per POST. The
+  sandbox authenticates with its per-conversation token; the conversation in
+  the path must be the caller's and on the team channel, which is what makes
+  the tools "the team" and not "any conversation I can name".
+  """
+  use FountainWeb, :controller
+
+  alias Fountain.{Conversations, Team}
+  alias Fountain.Team.Mcp
+
+  def handle(conn, %{"conversation_id" => conv_id}) do
+    user = conn.assigns.current_user
+
+    case build_ctx(conn, conv_id, user) do
+      {:ok, ctx} ->
+        case Mcp.handle(conn.body_params, ctx) do
+          :noreply -> send_resp(conn, 202, "")
+          resp -> json(conn, resp)
+        end
+
+      {:error, status, message} ->
+        conn |> put_status(status) |> json(%{error: message})
+    end
+  end
+
+  defp build_ctx(conn, conv_id, user) do
+    case Conversations.get_conversation(conv_id, user.id) do
+      %Conversations.Conversation{channel_id: ch} = conv ->
+        if ch == Team.channel() do
+          self = conv.agent_id && Team.get_teammate(user.id, conv.agent_id)
+
+          {:ok,
+           Map.merge(
+             %{user_id: user.id, self: self},
+             Map.new(FountainWeb.Audited.attribution(conn))
+           )}
+        else
+          {:error, 404, "not a team conversation"}
+        end
+
+      nil ->
+        {:error, 404, "conversation not found"}
+    end
+  rescue
+    Ecto.Query.CastError -> {:error, 404, "conversation not found"}
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -346,6 +346,8 @@ defmodule FountainWeb.Router do
     # (ADR 0020, #737). One JSON-RPC message per POST; the nsec is resolved
     # server-side and never enters the sandbox.
     post "/mcp/buzz/:conversation_id", BuzzMcpController, :handle
+    # The team tools a teammate's sandbox calls to see and message the team (#851).
+    post "/mcp/team/:conversation_id", TeamMcpController, :handle
 
     resources "/environments", EnvironmentController, except: [:new, :edit] do
       resources "/secrets", SecretController, only: [:index, :create, :delete]

--- a/apps/fountain/priv/sprite_skills/create-team/SKILL.md
+++ b/apps/fountain/priv/sprite_skills/create-team/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: create-team
+description: Set up the user's Fountain team through a short Q&A — use when the user says "/create-team", "help me set up my team", "I want a few agents for X", or when you are the only teammate and they ask what the team should look like. Asks what they want done, proposes a roster (names, brains, one-line roles), creates the agents and adds them to the team over the Fountain API with `FOUNTAIN_BASE_URL` + `FOUNTAIN_TOKEN`, and explains how to talk to them.
+---
+
+# /create-team — a team in five questions
+
+You are a teammate on a Fountain team, and the user wants more teammates. A
+teammate is an **agent** (name, brain = `provider/model` + runtime, a short
+description, a system prompt) that is **on the team** (`POST /api/team`):
+its own computer, one ongoing conversation with the user, reachable from the
+team page and from other teammates through the `fountain-team` tools.
+
+Keep it conversational: one question at a time, sensible defaults offered
+in the question so "yes" is a complete answer, never more than five
+questions before you propose something. The API is at `$FOUNTAIN_BASE_URL`
+(under `/api`) with bearer `$FOUNTAIN_TOKEN`; use `curl -s` + `jq`.
+
+## 1. Ask (at most five)
+
+1. **What should the team get done?** (one sentence; examples: "maintain my
+   repos and triage issues", "research + write for my newsletter", "keep my
+   homelab healthy")
+2. **Which repos / services are in scope?** — URLs or names. Note which need
+   a token (private repos, deploy targets).
+3. **How many teammates, roughly?** Offer a shape based on #1: usually 2–5.
+   A *lead/gateway* that knows everyone is worth it past three.
+4. **Any brain preference?** Default: the team's default brain for
+   engineers is Claude Sonnet; Opus for the lead or anything that spans
+   repos. Check what the account can run: `GET /api/catalog` (models per
+   runtime) and `GET /api/account/inference-credentials` (which providers
+   have a key). Never propose a provider without a key.
+5. **Names?** Offer role names (`repo-maintainer`, `issue-triager`) or a
+   themed set if they'd like; names must be unique per account.
+
+## 2. Propose, then confirm
+
+Show a table: name · brain · what they do (one line) · first thing you'd
+send them. Ask "create these?" — adjust on feedback. Do not create anything
+before a yes.
+
+## 3. Create (after the yes)
+
+For each teammate, in order:
+
+```bash
+B="$FOUNTAIN_BASE_URL/api"; H=(-H "Authorization: Bearer $FOUNTAIN_TOKEN" -H "content-type: application/json")
+AGENT=$(curl -s "${H[@]}" -X POST "$B/agents" -d @- <<JSON | jq -r '.data.id'
+{"name":"<name>","model":"<provider/model>","runtime":"<claude|codex|opencode>",
+ "description":"<one line>",
+ "system":"You are <name>, a teammate on the user's team. Your role: <one line>. You have your own computer; do the work there and report back in chat — concise, concrete, no filler. <repo/scope specifics>"}
+JSON
+)
+curl -s "${H[@]}" -X POST "$B/team" -d "{\"agent_id\":\"$AGENT\"}" | jq -r '.data.name + " → " + .data.presence.label'
+```
+
+Runtime follows the brain: `anthropic/*` → `claude`, `openai/*` → `codex`,
+anything else → `opencode`. If a teammate needs an environment (a repo
+mounted, a token, packages), say so and point at Fountain's Environments
+page or `fountain apply` — do not invent secrets; the user supplies them.
+
+Optional, when the team has a recurring job (triage, a daily report):
+`POST $B/team/<agent_id>/schedules {"name","cron","prompt"}` (five-field
+cron, UTC).
+
+## 4. Hand over
+
+Reply with the roster as created (name, presence), who to message for what,
+and one concrete first message for each. Mention that teammates can reach
+each other (`fountain-team` tools: list_teammates, get_teammate,
+send_to_teammate, read_teammate) and that everything — brain, role, name —
+is editable later from the team page. If you created a lead/gateway, say
+"send your asks to <lead> from now on."
+
+## Rules
+
+- One question at a time; stop asking as soon as you can propose.
+- Never create before a confirmation; never delete or rename anything.
+- Never paste tokens into prompts, descriptions or messages.
+- If `POST /api/agents` fails with a name conflict, add a short suffix and
+  say so; if with a missing-credential error, say which provider needs a key
+  and where (Account → Inference credentials).

--- a/apps/fountain/test/fountain/team/mcp_test.exs
+++ b/apps/fountain/test/fountain/team/mcp_test.exs
@@ -1,0 +1,166 @@
+defmodule Fountain.Team.McpTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Team
+  alias Fountain.Team.Mcp
+
+  setup :verify_on_exit!
+
+  setup do
+    user = insert_verified_user()
+
+    eng =
+      insert_agent(
+        user_id: user.id,
+        name: "fountain-maintainer",
+        description: "Maintains BinaryBourbon/fountain — the engineer for the server"
+      )
+
+    steward =
+      insert_agent(
+        user_id: user.id,
+        name: "home-cloud-steward",
+        description: "Keeps the k8s estate repo"
+      )
+
+    lead =
+      insert_agent(user_id: user.id, name: "team-lead", description: "Jake's gateway to the team")
+
+    for a <- [eng, steward, lead] do
+      insert_conversation(%{
+        user_id: user.id,
+        agent: a,
+        status: "idle",
+        channel_id: Team.channel()
+      })
+    end
+
+    self_entry = Team.get_teammate(user.id, lead.id)
+    ctx = %{user_id: user.id, self: self_entry, actor: "sprite", request_ip: nil}
+    %{user: user, eng: eng, steward: steward, lead: lead, ctx: ctx}
+  end
+
+  defp call(ctx, name, args \\ %{}) do
+    Mcp.handle(
+      %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "tools/call",
+        "params" => %{"name" => name, "arguments" => args}
+      },
+      ctx
+    )
+  end
+
+  defp payload(resp), do: resp["result"].content |> hd() |> Map.fetch!(:text) |> Jason.decode!()
+
+  test "initialize / tools/list advertise the four tools" do
+    resp =
+      Mcp.handle(%{"jsonrpc" => "2.0", "id" => 1, "method" => "tools/list"}, %{
+        user_id: "x",
+        self: nil
+      })
+
+    assert Enum.map(resp["result"].tools, & &1.name) ==
+             ~w(list_teammates get_teammate send_to_teammate read_teammate)
+
+    assert :noreply =
+             Mcp.handle(%{"jsonrpc" => "2.0", "method" => "notifications/initialized"}, %{})
+  end
+
+  test "list_teammates names everyone, marks the caller", %{ctx: ctx} do
+    rows = ctx |> call("list_teammates") |> payload()
+
+    assert Enum.map(rows, & &1["name"]) |> Enum.sort() ==
+             ~w(fountain-maintainer home-cloud-steward team-lead)
+
+    assert Enum.find(rows, & &1["is_you"])["name"] == "team-lead"
+    assert Enum.all?(rows, &(&1["presence"] in ~w(online asleep away offline starting working)))
+  end
+
+  test "get_teammate resolves a role word, an exact name, and says when it cannot", %{
+    ctx: ctx,
+    eng: eng
+  } do
+    assert payload(call(ctx, "get_teammate", %{"query" => "the engineer"}))["agent_id"] == eng.id
+
+    assert payload(call(ctx, "get_teammate", %{"query" => "home-cloud-steward"}))["name"] ==
+             "home-cloud-steward"
+
+    assert payload(call(ctx, "get_teammate", %{"query" => "maintainer"}))["agent_id"] == eng.id
+    resp = call(ctx, "get_teammate", %{"query" => "zzz nobody"})
+    assert resp["result"].isError
+  end
+
+  test "send_to_teammate hands the message to their conversation with a from-line; not to yourself",
+       %{ctx: ctx, eng: eng} do
+    test_pid = self()
+
+    stub(ConversationServer, :send_prompt, fn id, text, images, opts ->
+      send(test_pid, {:sent, id, text, images, opts[:actor]})
+      :ok
+    end)
+
+    resp =
+      call(ctx, "send_to_teammate", %{
+        "teammate" => "engineer",
+        "message" => "please bump the version"
+      })
+
+    refute resp["result"].isError
+    assert payload(resp)["agent_id"] == eng.id
+
+    assert_received {:sent, _id,
+                     "[From your teammate team-lead, via the team] please bump the version", [],
+                     "sprite"}
+
+    resp = call(ctx, "send_to_teammate", %{"teammate" => "team-lead", "message" => "hi me"})
+    assert resp["result"].isError
+  end
+
+  test "send_to_teammate reports busy instead of failing silently", %{ctx: ctx} do
+    stub(ConversationServer, :send_prompt, fn _id, _text, _images, _opts -> {:error, :busy} end)
+    resp = call(ctx, "send_to_teammate", %{"teammate" => "steward", "message" => "x"})
+    assert resp["result"].isError
+    assert hd(resp["result"].content).text =~ "busy"
+  end
+
+  test "read_teammate returns recent turns with prompt, reply and status", %{
+    ctx: ctx,
+    eng: eng,
+    user: user
+  } do
+    conv = Team.get_teammate(user.id, eng.id).conversation
+
+    insert_turn(conv, %{
+      turn_number: 1,
+      prompt: "hello",
+      status: "completed",
+      reply_text: "hi there"
+    })
+
+    insert_turn(conv, %{turn_number: 2, prompt: "bump it", status: "running"})
+
+    p = payload(call(ctx, "read_teammate", %{"teammate" => "fountain-maintainer", "limit" => 5}))
+    assert p["teammate"] == "fountain-maintainer"
+
+    assert [
+             %{"turn" => 1, "reply" => "hi there", "status" => "completed"},
+             %{"turn" => 2, "status" => "running"}
+           ] = p["turns"]
+  end
+
+  test "conversation_mcp_servers is only for team conversations", %{user: user, eng: eng} do
+    conv = Team.get_teammate(user.id, eng.id).conversation
+
+    assert [%{name: "fountain-team", type: "http", url: url}] =
+             Team.conversation_mcp_servers(conv.id, "tok")
+
+    assert url =~ "/api/mcp/team/#{conv.id}"
+    other = insert_conversation(%{user_id: user.id, agent: eng, status: "idle"})
+    assert Team.conversation_mcp_servers(other.id, "tok") == []
+    assert Team.conversation_mcp_servers("not-a-uuid", "tok") == []
+  end
+end

--- a/apps/fountain/test/fountain_web/api_spec_test.exs
+++ b/apps/fountain/test/fountain_web/api_spec_test.exs
@@ -58,7 +58,9 @@ defmodule FountainWeb.ApiSpecTest do
       # A JSON-RPC 2.0 (MCP) endpoint, not a REST operation: its body is a
       # polymorphic MCP message, and its caller is a sandboxed agent's MCP
       # client, which discovers tools via `tools/list`, not our OpenAPI spec.
-      {"/api/mcp/buzz/{conversation_id}", :post}
+      {"/api/mcp/buzz/{conversation_id}", :post},
+      # Same: the team tools a teammate's sandbox calls (#851).
+      {"/api/mcp/team/{conversation_id}", :post}
     ]
 
     setup do

--- a/apps/fountain/test/fountain_web/controllers/team_mcp_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_mcp_controller_test.exs
@@ -1,0 +1,79 @@
+defmodule FountainWeb.TeamMcpControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.Team
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    agent = insert_agent(user_id: user.id, name: "team-lead")
+
+    conv =
+      insert_conversation(%{
+        user_id: user.id,
+        agent: agent,
+        status: "idle",
+        channel_id: Team.channel()
+      })
+
+    {:ok, user: user, raw_key: raw_key, conv: conv, agent: agent}
+  end
+
+  test "serves tools/list for the caller's team conversation", %{
+    conn: conn,
+    raw_key: key,
+    conv: conv
+  } do
+    body =
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/mcp/team/#{conv.id}", %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "tools/list"
+      })
+      |> json_response(200)
+
+    assert Enum.map(body["result"]["tools"], & &1["name"]) |> Enum.member?("send_to_teammate")
+  end
+
+  test "a conversation off the team channel, or another tenant's, gets 404", %{
+    conn: conn,
+    raw_key: key,
+    user: user,
+    agent: agent
+  } do
+    plain = insert_conversation(%{user_id: user.id, agent: agent, status: "idle"})
+
+    conn
+    |> authed_with_key(key)
+    |> post_json("/api/mcp/team/#{plain.id}", %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "method" => "tools/list"
+    })
+    |> json_response(404)
+
+    other = insert_verified_user()
+    {_k, other_key} = insert_api_key(other)
+
+    conn
+    |> authed_with_key(other_key)
+    |> post_json("/api/mcp/team/#{plain.id}", %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "method" => "tools/list"
+    })
+    |> json_response(404)
+  end
+
+  test "a notification gets 202 and no body", %{conn: conn, raw_key: key, conv: conv} do
+    conn
+    |> authed_with_key(key)
+    |> post_json("/api/mcp/team/#{conv.id}", %{
+      "jsonrpc" => "2.0",
+      "method" => "notifications/initialized"
+    })
+    |> response(202)
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -422,6 +422,16 @@ previous conversation was terminated. `400 conversation_busy` while the last
 turn is still running, `503 provisioning` while the computer is starting,
 `503 runner_offline` while a runner-backed teammate's machine is off.
 
+**Teammates know each other.** Every conversation on the team channel carries
+an MCP server, `fountain-team`, served by Fountain at
+`POST /api/mcp/team/:conversation_id` and authenticated with the sandbox's
+own token: `list_teammates`, `get_teammate` (by name, role or keyword —
+"the engineer"), `send_to_teammate` (lands in their thread prefixed with who
+sent it; busy/starting/machine-offline come back as tool errors to retry)
+and `read_teammate` (recent prompts and replies). So "send this to the
+steward" inside one teammate's turn is two tool calls, and the exchange is
+visible in both threads on the team page.
+
 `/stream` is one `text/event-stream` for the whole team: each event is the
 per-conversation stream's payload plus `conversation_id` and `agent_id`, so a
 client routes it to a roster row without a socket per teammate. A `team`

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -68,7 +68,7 @@ An **Agent** is a named, re-runnable configuration for an AI coding assistant:
 - **`runtime`** - one of `claude`, `codex`, `gemini`, `opencode`
 - **`environment`** - optional Environment to attach
 - **`system`** / **`description`** - system prompt and human-readable description. The system prompt is written into the runtime's user-level instructions file on the agent's computer at provision and again at every reattach (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.config/opencode/AGENTS.md`, `~/.gemini/GEMINI.md`), so an edit reaches an existing computer the next time it wakes
-- **`skills`** - each entry is either inline (`{name, content}` — a full SKILL.md written to the sandbox) or GitHub-sourced (`{source: "owner/repo"}` — installed via the skills.sh CLI)
+- **`skills`** - each entry is either inline (`{name, content}` — a full SKILL.md written to the sandbox) or GitHub-sourced (`{source: "owner/repo"}` — installed via the skills.sh CLI). Two skills are bundled into every sandbox regardless: `fountain` (the API, for spawning sub-conversations) and `create-team` (a Q&A that sets up the user's team — a first teammate answers "/create-team")
 - **`mcp_servers`** - MCP server definitions, with `${VAR}` substitution in their env
 - **`metadata`** - free-form map for callers' own bookkeeping
 


### PR DESCRIPTION
Closes #851.

**fountain-team MCP** — served at `POST /api/mcp/team/:conversation_id` with the sandbox's own token, injected into every team-channel conversation's turns (beside the Buzz tools). `list_teammates` · `get_teammate` ("the engineer" → name/agent/description match, ambiguity reported) · `send_to_teammate` (lands in their thread as a typed message, prefixed with who sent it; busy/starting/machine-offline are retryable tool errors; not to yourself) · `read_teammate` (recent prompts + replies + status). Off-channel or foreign conversations 404.

**/create-team** — a second bundled skill in every sandbox: ≤5-question Q&A → proposed roster → on yes, `POST /api/agents` + `POST /api/team` per teammate (+ optional schedule) → hand-over. Brains checked against `/api/catalog` + the account's credentials.

Docs: api.md (Team), primitives.md (skills). Tests as in the commit; credo + dialyzer clean.

Client side (fountain-team): a tip nudging a new team to tell its first teammate `/create-team` follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)