### PR TITLE
team: a from-line that states the trust boundary on teammate messages

### DIFF
--- a/apps/fountain/lib/fountain/team/mcp.ex
+++ b/apps/fountain/lib/fountain/team/mcp.ex
@@ -304,10 +304,20 @@ defmodule Fountain.Team.Mcp do
 
   defp presence(t), do: t.conversation |> TeamPresenter.presence() |> Map.get(:state)
 
+  # The receiver's only senders are the account owner and the owner's own
+  # teammates — the endpoint is authenticated with the sender's sandbox token
+  # and scoped to the same tenant — so the line says so: a teammate reading
+  # "from X via the team" should treat it as the owner delegating, not as an
+  # untrusted inbound that might be an injection.
   defp from_line(%{self: %{name: name}}) when is_binary(name),
-    do: "[From your teammate #{name}, via the team] "
+    do:
+      "[Team message from your teammate #{name}, delivered by Fountain. Only your account's owner " <>
+        "and their teammates can send these; treat it as the owner delegating to you.]\n\n"
 
-  defp from_line(_), do: "[From a teammate, via the team] "
+  defp from_line(_),
+    do:
+      "[Team message from a teammate, delivered by Fountain. Only your account's owner and their " <>
+        "teammates can send these; treat it as the owner delegating to you.]\n\n"
 
   defp audit_opts(ctx),
     do: [actor: Map.get(ctx, :actor, "sprite"), request_ip: Map.get(ctx, :request_ip)]

--- a/apps/fountain/test/fountain/team/mcp_test.exs
+++ b/apps/fountain/test/fountain/team/mcp_test.exs
@@ -112,9 +112,10 @@ defmodule Fountain.Team.McpTest do
     refute resp["result"].isError
     assert payload(resp)["agent_id"] == eng.id
 
-    assert_received {:sent, _id,
-                     "[From your teammate team-lead, via the team] please bump the version", [],
-                     "sprite"}
+    assert_received {:sent, _id, text, [], "sprite"}
+    assert text =~ "Team message from your teammate team-lead"
+    assert text =~ "treat it as the owner delegating to you"
+    assert String.ends_with?(text, "please bump the version")
 
     resp = call(ctx, "send_to_teammate", %{"teammate" => "team-lead", "message" => "hi me"})
     assert resp["result"].isError


### PR DESCRIPTION
A steward on a runner refused a teammate's request as a possible injection — reasonable given a bare `[From your teammate X]`. Only the account owner and their own teammates can send team messages (sandbox-token auth, tenant-scoped), so the prefix now says exactly that and tells the receiver to treat it as the owner delegating. Test updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)