### PR TITLE
fix(team): AgentMail client_id without a colon; provider refusals are 424, not 502

### DIFF
--- a/apps/fountain/lib/fountain/team/comms.ex
+++ b/apps/fountain/lib/fountain/team/comms.ex
@@ -249,7 +249,8 @@ defmodule Fountain.Team.Comms do
       %{
         "username" => username(name, opts),
         "display_name" => name,
-        "client_id" => "fountain-team:" <> teammate.agent.id
+        # AgentMail client ids allow only [A-Za-z0-9._~-]; no colon.
+        "client_id" => "fountain-team." <> teammate.agent.id
       }
       |> put_present("domain", AgentMail.domain())
 

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -254,12 +254,12 @@ defmodule FountainWeb.TeamController do
     summary: "Take a teammate's email address and phone number away",
     description:
       "Deletes the inbox and releases the number upstream, then forgets them. A provider " <>
-        "failure keeps the contact (nothing is orphaned) and is reported as 502.",
+        "failure keeps the contact (nothing is orphaned) and is reported as 424.",
     parameters: [agent_id: [in: :path, type: :string, required: true]],
     responses: [
       no_content: "Released",
       not_found: {"No contact, or not on the team", "application/json", Schemas.Error},
-      bad_gateway: {"A provider refused", "application/json", Schemas.Error}
+      failed_dependency: {"A provider refused", "application/json", Schemas.Error}
     ]
   )
 
@@ -294,9 +294,11 @@ defmodule FountainWeb.TeamController do
   defp comms_error(conn, :already_provisioned),
     do: conn |> put_status(:conflict) |> json(%{error: "contact_already_provisioned"})
 
+  # 424, not 502: Cloudflare swaps an origin 502's body for its own error
+  # page, which would hide which provider refused and why.
   defp comms_error(conn, {channel, reason}) when channel in [:email, :phone] do
     conn
-    |> put_status(:bad_gateway)
+    |> put_status(:failed_dependency)
     |> json(%{
       error: "provider_error",
       channel: to_string(channel),

--- a/apps/fountain/test/fountain/team/comms_test.exs
+++ b/apps/fountain/test/fountain/team/comms_test.exs
@@ -122,7 +122,7 @@ defmodule Fountain.Team.CommsTest do
 
       assert_received {:agentmail_create, body}
       assert body["display_name"] == "Ada Lovelace"
-      assert body["client_id"] == "fountain-team:" <> agent.id
+      assert body["client_id"] == "fountain-team." <> agent.id
       assert_received {:agentphone_create, %{"country" => "US"}}
       assert_received {:team_changed, _}
 

--- a/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
@@ -163,7 +163,7 @@ defmodule FountainWeb.TeamCommsControllerTest do
       assert body["error"] == "contact_already_provisioned"
     end
 
-    test "is 502 naming the channel when a provider refuses", %{
+    test "is 424 naming the channel when a provider refuses", %{
       conn: conn,
       user: user,
       raw_key: key
@@ -177,7 +177,7 @@ defmodule FountainWeb.TeamCommsControllerTest do
 
       body =
         give(conn, key, agent.id)
-        |> json_response(502)
+        |> json_response(424)
 
       assert body == %{
                "error" => "provider_error",

--- a/docs/api.md
+++ b/docs/api.md
@@ -430,7 +430,7 @@ has `email_send`, `email_reply`, `email_list`, `email_get`, `sms_send`,
 token — no provider key enters the sandbox, and every send is audited
 (`team.contact.sent`, never the content). `404 team_comms_not_enabled` when
 the flag is off for the caller, `503 team_comms_not_configured` when the
-instance has no keys, `409` for a second contact, `502 provider_error`
+instance has no keys, `409` for a second contact, `424 provider_error`
 (`channel` names which) when a provider refuses — provisioning is all or
 nothing. `DELETE` releases both upstream and forgets them; `GET
 /api/team/comms` answers `{enabled, configured}` so a client knows whether


### PR DESCRIPTION
Found on the first prod smoke of #850.

- AgentMail rejects client ids outside `[A-Za-z0-9._~-]` — the colon in `fountain-team:<agent_id>` made every inbox creation a 400 ("Request validation failed"). Now `fountain-team.<agent_id>`.
- The 502 that reported it arrived as Cloudflare's own "error code: 502" page — the proxy replaces an origin 502 body — so the provider's reason was invisible from outside. `provider_error` is now **424 Failed Dependency**, which Cloudflare passes through. Docs/spec/tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)