### PR TITLE
team: wait_for_teammate — block for a teammate's reply instead of polling

### DIFF
--- a/apps/fountain/lib/fountain/team/mcp.ex
+++ b/apps/fountain/lib/fountain/team/mcp.ex
@@ -25,6 +25,12 @@ defmodule Fountain.Team.Mcp do
   @server_info %{name: "fountain-team", version: "1"}
   @mcp_name "fountain-team"
 
+  # wait_for_teammate: server-side poll, capped under the tunnel's idle limit.
+  @default_wait 60
+  @max_wait 90
+  @poll_ms 2_000
+  @terminal ~w(completed failed cancelled)
+
   def mcp_name, do: @mcp_name
 
   @doc "The tool catalogue advertised by `tools/list`."
@@ -277,11 +283,6 @@ defmodule Fountain.Team.Mcp do
   end
 
   defp call_tool(id, name, _args, _ctx), do: tool_error(id, "unknown tool: #{name}")
-
-  @default_wait 60
-  @max_wait 90
-  @poll_ms 2_000
-  @terminal ~w(completed failed cancelled)
 
   # ownership: the conversation id came from a teammate entry resolved through
   # Team.list_teammates(ctx.user_id) — a tenant-scoped read.

--- a/apps/fountain/lib/fountain/team/mcp.ex
+++ b/apps/fountain/lib/fountain/team/mcp.ex
@@ -68,6 +68,30 @@ defmodule Fountain.Team.Mcp do
         }
       },
       %{
+        name: "wait_for_teammate",
+        description:
+          "Block until a teammate's turn finishes, then return it (prompt, reply, status). Waits " <>
+            "up to timeout_seconds (default 60, max 90) — if it returns timed_out: true, just call " <>
+            "it again; do not end your own turn to wait. Pass since_turn (the `turn` number " <>
+            "send_to_teammate returned, minus one) to wait for that specific reply; without it, " <>
+            "waits for their latest turn.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            teammate: %{type: "string", description: "Agent id, or a name/role to resolve"},
+            since_turn: %{
+              type: "integer",
+              description: "Wait for a terminal turn numbered above this"
+            },
+            timeout_seconds: %{
+              type: "integer",
+              description: "How long to block (default 60, max 90)"
+            }
+          },
+          required: ["teammate"]
+        }
+      },
+      %{
         name: "read_teammate",
         description:
           "A teammate's recent turns: each prompt and their reply text, newest last, with " <>
@@ -154,7 +178,10 @@ defmodule Fountain.Team.Mcp do
                 sent: true,
                 teammate: t.name,
                 agent_id: t.agent.id,
-                conversation_id: conv.id
+                conversation_id: conv.id,
+                turn: conv.turn_count,
+                hint:
+                  "call wait_for_teammate with since_turn = #{max(conv.turn_count - 1, 0)} to block for the reply"
               })
             ],
             isError: false
@@ -216,7 +243,79 @@ defmodule Fountain.Team.Mcp do
     end
   end
 
+  defp call_tool(id, "wait_for_teammate", args, ctx) do
+    with {:ok, who} <- require_arg(args, "teammate"),
+         {:ok, t} <- resolve_one(ctx.user_id, who) do
+      since = Map.get(args, "since_turn")
+      timeout = args |> Map.get("timeout_seconds", @default_wait) |> clamp(1, @max_wait)
+      deadline = System.monotonic_time(:millisecond) + timeout * 1000
+
+      case wait_loop(t.conversation.id, since, deadline, ctx) do
+        {:ok, turn} ->
+          result(id, %{
+            content: [json(%{teammate: t.name, done: true, turn: turn_summary(turn)})],
+            isError: false
+          })
+
+        {:timeout, latest} ->
+          result(id, %{
+            content: [
+              json(%{
+                teammate: t.name,
+                timed_out: true,
+                waited_seconds: timeout,
+                latest_turn: latest && turn_summary(latest),
+                hint: "still working — call wait_for_teammate again"
+              })
+            ],
+            isError: false
+          })
+      end
+    else
+      {:error, msg} -> tool_error(id, msg)
+    end
+  end
+
   defp call_tool(id, name, _args, _ctx), do: tool_error(id, "unknown tool: #{name}")
+
+  @default_wait 60
+  @max_wait 90
+  @poll_ms 2_000
+  @terminal ~w(completed failed cancelled)
+
+  # ownership: the conversation id came from a teammate entry resolved through
+  # Team.list_teammates(ctx.user_id) — a tenant-scoped read.
+  defp wait_loop(conv_id, since, deadline, ctx) do
+    turns = Conversations._unsafe_list_turns(conv_id)
+
+    candidate =
+      case since do
+        n when is_integer(n) -> Enum.find(turns, &(&1.turn_number > n and &1.status in @terminal))
+        _ -> turns |> List.last() |> then(fn t -> if t && t.status in @terminal, do: t end)
+      end
+
+    cond do
+      candidate ->
+        {:ok, candidate}
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        {:timeout, List.last(turns)}
+
+      true ->
+        (Map.get(ctx, :sleep) || (&Process.sleep/1)).(@poll_ms)
+        wait_loop(conv_id, since, deadline, ctx)
+    end
+  end
+
+  defp turn_summary(turn) do
+    %{
+      turn: turn.turn_number,
+      status: turn.status,
+      at: turn.inserted_at,
+      prompt: String.slice(turn.prompt || "", 0, 2000),
+      reply: String.slice(turn.reply_text || "", 0, 6000)
+    }
+  end
 
   # ── resolving "the engineer" ───────────────────────────────────────────────
 

--- a/apps/fountain/priv/sprite_skills/create-team/SKILL.md
+++ b/apps/fountain/priv/sprite_skills/create-team/SKILL.md
@@ -68,7 +68,7 @@ cron, UTC).
 Reply with the roster as created (name, presence), who to message for what,
 and one concrete first message for each. Mention that teammates can reach
 each other (`fountain-team` tools: list_teammates, get_teammate,
-send_to_teammate, read_teammate) and that everything — brain, role, name —
+send_to_teammate, wait_for_teammate, read_teammate) and that everything — brain, role, name —
 is editable later from the team page. If you created a lead/gateway, say
 "send your asks to <lead> from now on."
 

--- a/apps/fountain/test/fountain/team/mcp_test.exs
+++ b/apps/fountain/test/fountain/team/mcp_test.exs
@@ -56,7 +56,7 @@ defmodule Fountain.Team.McpTest do
 
   defp payload(resp), do: resp["result"].content |> hd() |> Map.fetch!(:text) |> Jason.decode!()
 
-  test "initialize / tools/list advertise the four tools" do
+  test "initialize / tools/list advertise the five tools" do
     resp =
       Mcp.handle(%{"jsonrpc" => "2.0", "id" => 1, "method" => "tools/list"}, %{
         user_id: "x",
@@ -64,7 +64,7 @@ defmodule Fountain.Team.McpTest do
       })
 
     assert Enum.map(resp["result"].tools, & &1.name) ==
-             ~w(list_teammates get_teammate send_to_teammate read_teammate)
+             ~w(list_teammates get_teammate send_to_teammate wait_for_teammate read_teammate)
 
     assert :noreply =
              Mcp.handle(%{"jsonrpc" => "2.0", "method" => "notifications/initialized"}, %{})
@@ -151,6 +151,95 @@ defmodule Fountain.Team.McpTest do
              %{"turn" => 1, "reply" => "hi there", "status" => "completed"},
              %{"turn" => 2, "status" => "running"}
            ] = p["turns"]
+  end
+
+  test "tools/list includes wait_for_teammate" do
+    resp =
+      Mcp.handle(%{"jsonrpc" => "2.0", "id" => 1, "method" => "tools/list"}, %{
+        user_id: "x",
+        self: nil
+      })
+
+    assert "wait_for_teammate" in Enum.map(resp["result"].tools, & &1.name)
+  end
+
+  test "wait_for_teammate returns immediately when the latest turn is terminal", %{
+    ctx: ctx,
+    eng: eng,
+    user: user
+  } do
+    conv = Team.get_teammate(user.id, eng.id).conversation
+
+    insert_turn(conv, %{
+      turn_number: 1,
+      prompt: "hello",
+      status: "completed",
+      reply_text: "hi there"
+    })
+
+    p =
+      payload(call(ctx, "wait_for_teammate", %{"teammate" => "engineer", "timeout_seconds" => 5}))
+
+    assert p["done"] == true
+    assert p["turn"]["reply"] == "hi there"
+  end
+
+  test "wait_for_teammate waits for the turn after since_turn, and times out honestly", %{
+    ctx: ctx,
+    eng: eng,
+    user: user
+  } do
+    conv = Team.get_teammate(user.id, eng.id).conversation
+
+    insert_turn(conv, %{
+      turn_number: 1,
+      prompt: "old",
+      status: "completed",
+      reply_text: "old reply"
+    })
+
+    running = insert_turn(conv, %{turn_number: 2, prompt: "new", status: "running"})
+    ticks = :counters.new(1, [])
+
+    sleep = fn _ms ->
+      :counters.add(ticks, 1, 1)
+
+      if :counters.get(ticks, 1) == 2 do
+        {:ok, _} =
+          Fountain.Repo.update(
+            Ecto.Changeset.change(running, status: "completed", reply_text: "new reply")
+          )
+      end
+
+      :ok
+    end
+
+    p =
+      payload(
+        call(Map.put(ctx, :sleep, sleep), "wait_for_teammate", %{
+          "teammate" => "engineer",
+          "since_turn" => 1,
+          "timeout_seconds" => 30
+        })
+      )
+
+    assert p["done"] == true
+    assert p["turn"]["turn"] == 2
+    assert p["turn"]["reply"] == "new reply"
+
+    insert_turn(conv, %{turn_number: 3, prompt: "stuck", status: "running"})
+
+    p =
+      payload(
+        call(Map.put(ctx, :sleep, fn _ -> :ok end), "wait_for_teammate", %{
+          "teammate" => "engineer",
+          "since_turn" => 2,
+          "timeout_seconds" => 1
+        })
+      )
+
+    assert p["timed_out"] == true
+    assert p["latest_turn"]["turn"] == 3
   end
 
   test "conversation_mcp_servers is only for team conversations", %{user: user, eng: eng} do

--- a/docs/api.md
+++ b/docs/api.md
@@ -456,8 +456,11 @@ an MCP server, `fountain-team`, served by Fountain at
 `POST /api/mcp/team/:conversation_id` and authenticated with the sandbox's
 own token: `list_teammates`, `get_teammate` (by name, role or keyword —
 "the engineer"), `send_to_teammate` (lands in their thread prefixed with who
-sent it; busy/starting/machine-offline come back as tool errors to retry)
-and `read_teammate` (recent prompts and replies). So "send this to the
+sent it and a note that only the owner and their teammates can send such
+messages; busy/starting/machine-offline come back as tool errors to retry;
+returns the turn it created), `wait_for_teammate` (blocks up to 90 s for
+the reply — `since_turn` pins it to a specific turn; `timed_out: true` means
+call again) and `read_teammate` (recent prompts and replies). So "send this to the
 steward" inside one teammate's turn is two tool calls, and the exchange is
 visible in both threads on the team page.
 


### PR DESCRIPTION
New `fountain-team` tool: `wait_for_teammate(teammate, since_turn?, timeout_seconds?)` blocks server-side (2 s poll, default 60 s, max 90 s — under the tunnel's idle limit) until the teammate's latest turn — or the first terminal turn after `since_turn` — is done, and returns prompt/reply/status; on timeout returns `timed_out: true` + the latest turn, and the caller calls again. `send_to_teammate` now returns the turn it created and the `since_turn` to pass. Motivated by team-lead ending its turn to "wake up later" (nothing wakes it).

Tests (immediate, loop, timeout) green; credo + dialyzer clean; docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)