### PR TITLE
ci: skip the main re-run when the merged PR already tested this exact tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,90 @@ permissions:
 # third of the tests, so no partition's coverage means anything on its own.
 # Hence the `coverage` job: partitions export, it merges, and the 85% threshold
 # is enforced once against the union (see mix.exs / coverage.exs).
+#
+# On main, most of that is a re-run. PRs are squash-merged after a rebase, so
+# the commit that lands on main usually has the *same tree* as the PR head —
+# the exact tree the PR's CI run already passed (a rebased head contains
+# main's tip, so the merge ref GitHub tested was the head itself). 10 of 12
+# recent main commits were like that, and each spent ~10 minutes re-proving
+# it before build.yml was allowed to start. The `already-tested` job checks
+# for that case and, when it holds, lets every other job skip; the run still
+# concludes `success`, which is all build.yml's workflow_run gate asks. Any
+# doubt — no associated PR, a differing tree, no successful PR run, an API
+# hiccup — falls through to the full run, never to a skip.
 jobs:
+  already-tested:
+    name: Skip the re-run when a PR already tested this exact tree
+    # Push-to-main only. On pull_request this job is skipped, its outputs are
+    # empty, and the `!= 'true'` tests below let everything run as before.
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+
+    outputs:
+      skip: ${{ steps.probe.outputs.skip }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: Compare this tree with the tested PR head
+        id: probe
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Never fails: every branch of this script ends in a decision, and the
+        # decision on any error is "run the full CI".
+        run: |
+          set -u
+          skip=false
+          tree="$(git rev-parse 'HEAD^{tree}')"
+          echo "main tree: ${tree}"
+
+          heads="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+                     --jq '.[] | select(.merged_at != null) | .head.sha' 2>/dev/null || true)"
+          if [ -z "${heads}" ]; then
+            echo "no merged PR is associated with ${GITHUB_SHA:0:7} — running the full CI"
+          fi
+
+          for head in ${heads}; do
+            if ! git fetch --quiet --depth=1 origin "${head}" 2>/dev/null; then
+              echo "PR head ${head:0:7} could not be fetched"
+              continue
+            fi
+            head_tree="$(git rev-parse "${head}^{tree}")"
+            if [ "${head_tree}" != "${tree}" ]; then
+              echo "PR head ${head:0:7} has tree ${head_tree:0:7} — differs; the merge produced a tree no PR run tested"
+              continue
+            fi
+            # A completed, successful CI run on that head, triggered by the PR.
+            # `status=success` excludes the cancelled runs that PR
+            # cancel-in-progress leaves behind.
+            run_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${head}&event=pull_request&status=success&per_page=50" \
+                        --jq '[.workflow_runs[] | select(.name == "CI")] | first | .id // empty' 2>/dev/null || true)"
+            if [ -z "${run_id}" ]; then
+              echo "PR head ${head:0:7} has the same tree but no successful pull_request CI run"
+              continue
+            fi
+            echo "PR head ${head:0:7} has the same tree and CI run ${run_id} passed on it — skipping the re-run"
+            echo "tested by https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}" >> "$GITHUB_STEP_SUMMARY"
+            skip=true
+            break
+          done
+
+          echo "skip=${skip}" >> "$GITHUB_OUTPUT"
+
   test:
     name: Build and Test (partition ${{ matrix.partition }})
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    needs: already-tested
+    # `!cancelled()` rather than the implicit success(): on pull_request the
+    # gate job is skipped, and a skipped `needs` would skip this job too.
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true' }}
 
     permissions:
       contents: read
@@ -176,6 +255,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: test
+    # Still "after a green suite" — but spelled out, because test is skipped
+    # (not failed) on the already-tested path and must not drag this along.
+    if: ${{ !cancelled() && needs.test.result == 'success' }}
 
     permissions:
       contents: read
@@ -254,6 +336,8 @@ jobs:
     name: Static analysis and release checks
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    needs: already-tested
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true' }}
 
     permissions:
       contents: read
@@ -489,6 +573,8 @@ jobs:
     name: Compose fresh-clone check
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    needs: already-tested
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true' }}
 
     permissions:
       contents: read
@@ -517,6 +603,8 @@ jobs:
     name: Compose boots the pinned image
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: already-tested
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true' }}
 
     permissions:
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,13 @@ wrap `record/1` in a way that makes it blocking for the user.
 11. Release boot check — builds a prod release, probes `/health` and `/health/ready`, runs a release task beside the live server
 12. `mix openapi.spec.json` + `jq empty` (OpenAPI spec validates)
 
+On `main` the run usually short-circuits: the `already-tested` job compares
+the pushed commit's tree with the head of the merged PR and, when they are
+identical and that head has a successful `pull_request` CI run, every other
+job is skipped and `build.yml` starts straight away (the run still concludes
+`success`, which is its gate). A rebased squash-merge is that case; anything
+else — a tree that differs, no PR, no green run — gets the full run.
+
 ### Coverage
 
 Coverage uses Elixir's built-in cover, not ExCoveralls — ExCoveralls cannot


### PR DESCRIPTION
## Why

Every push to `main` re-runs the full CI (~9–12 min: three test partitions, coverage merge, static analysis, release boot, compose checks) before `build.yml` is allowed to start. But PRs here are squash-merged after a rebase, so the commit that lands on `main` is usually **byte-identical in tree** to the PR head that already passed CI — 10 of the last 12 main commits (#854, #853, #850, #852, #849, #844, #842, #839, #838, #836; the exceptions were #840 and #835). Merge→prod was paying ~10 minutes to re-prove a tree it had already green-lit.

## What

A new first job on `main`, `already-tested`:

1. takes the pushed commit's tree (`HEAD^{tree}`);
2. looks up the merged PR associated with the commit, fetches its head, compares trees;
3. if identical **and** that head has a successful `pull_request` CI run, outputs `skip=true`.

Every other job is `needs: already-tested` + `if: !cancelled() && skip != 'true'`, so on that path they all skip, the run concludes `success`, and `build.yml`'s `workflow_run` gate fires straight away. `coverage` is additionally pinned to `needs.test.result == 'success'` so a skipped suite doesn't drag it along.

Any doubt falls through to the full run: no associated PR, a differing tree (a non-rebased merge produced a tree nobody tested), no green run on that head, or an API error — the script never fails, it just answers `skip=false`. `pull_request` runs are unchanged (the gate job is skipped there; its empty output reads as "run everything").

Why the same-tree test is sound: a squash whose tree equals the PR head's tree means the head was rebased onto the exact parent, so the merge ref GitHub tested for the PR *was* the head — the same tree, not merely an equivalent one.

## Verified

- Dry-ran the gate script locally: `c072ea4` (#854) → same tree as head `e0c…`, run 32271790407 passed → `skip=true`; `9462597` (#840) → tree differs → `skip=false`.
- This PR's own CI run exercises the pull_request path (gate skipped, full suite runs). The push-to-main path can only be observed after merge — watch the first `main` run: expect `already-tested` ≈ 20 s, everything else skipped, then `build` starts within a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)