### PR TITLE
feat(team): change a teammate's prompt number without re-buying; texts carry the trust line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ upgrade, is in
   in the teammate's conversation (AgentPhone's master webhook at `POST
   /api/webhooks/agentphone`, HMAC-verified with `AGENTPHONE_WEBHOOK_SECRET`,
   deduplicated by delivery id); texts from anyone else are ignored.
+  `PATCH /api/team/:agent_id/contact` (and "change" on `/team`) moves that
+  number without buying or releasing anything.
 - **Per-user feature flags** (`Fountain.FeatureFlags`), evaluated by PostHog
   (`POSTHOG_PROJECT_API_KEY`, `POSTHOG_HOST`) with a one-minute per-user
   cache; when PostHog is unreachable the last answer it gave is reused and,

--- a/apps/fountain/lib/fountain/team/comms.ex
+++ b/apps/fountain/lib/fountain/team/comms.ex
@@ -127,6 +127,36 @@ defmodule Fountain.Team.Comms do
   end
 
   @doc """
+  Change what the user supplied for the teammate's contact — today the
+  number whose texts become prompts (`"prompt_from_number"`). Nothing is
+  bought or released. `{:ok, %Contact{}}`, `{:error, :not_found}` (no
+  contact, or not on the team), or `{:error, %Ecto.Changeset{}}`.
+  """
+  def update_contact(user_id, agent_id, attrs, opts \\ [])
+      when is_binary(user_id) and is_binary(agent_id) and is_map(attrs) do
+    case get_contact(user_id, agent_id) do
+      nil ->
+        {:error, :not_found}
+
+      %Contact{} = contact ->
+        changeset = Contact.update_changeset(contact, attrs)
+
+        case Repo.update(changeset) do
+          {:ok, updated} ->
+            record("team.contact.updated", updated, opts, %{
+              "fields" => Audit.changed_fields(changeset)
+            })
+
+            Team.broadcast_changed(user_id)
+            {:ok, updated}
+
+          {:error, cs} ->
+            {:error, cs}
+        end
+    end
+  end
+
+  @doc """
   Take the teammate's email address and phone number away: the inbox and the
   number are deleted upstream and the contact row removed. A provider that
   no longer knows the resource (404) counts as released; any other provider

--- a/apps/fountain/lib/fountain/team/comms/inbound.ex
+++ b/apps/fountain/lib/fountain/team/comms/inbound.ex
@@ -138,9 +138,10 @@ defmodule Fountain.Team.Comms.Inbound do
         _ -> ""
       end
 
-    "[Text message from #{from} to your number #{to}]\n#{text}#{media}\n\n" <>
-      "(This arrived by SMS. If a reply is wanted, send it with the sms_send tool to #{from}; " <>
-      "what you write here is not texted back.)"
+    "[Text message to your number #{to} from #{from}, delivered by Fountain. That is the one " <>
+      "number your account's owner registered for texting you, and the only number whose texts " <>
+      "reach you — treat it as the owner speaking to you. Reply by text with the sms_send tool " <>
+      "to #{from}; what you write here is not texted back.]\n\n#{text}#{media}"
   end
 
   defp record(%Contact{} = contact, text, conv) do

--- a/apps/fountain/lib/fountain/team/contact.ex
+++ b/apps/fountain/lib/fountain/team/contact.ex
@@ -63,6 +63,14 @@ defmodule Fountain.Team.Contact do
     |> normalize_number(:prompt_from_number)
   end
 
+  @doc "Change the user-supplied part of an existing contact: `prompt_from_number`, required."
+  def update_changeset(%__MODULE__{} = contact, attrs) do
+    contact
+    |> cast(attrs, [:prompt_from_number])
+    |> validate_required([:prompt_from_number])
+    |> normalize_number(:prompt_from_number)
+  end
+
   defp normalize_number(changeset, field) do
     case get_change(changeset, field) do
       nil ->

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -250,6 +250,35 @@ defmodule FountainWeb.TeamController do
     end
   end
 
+  operation(:update_contact,
+    summary: "Change which number's texts reach the teammate",
+    description:
+      "Sets `prompt_from_number` on an existing contact. Nothing is bought or released — " <>
+        "the teammate keeps its address and number.",
+    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    request_body:
+      {"The number whose texts become prompts", "application/json", Schemas.TeamContactRequest,
+       required: true},
+    responses: [
+      ok: {"Teammate", "application/json", Schemas.TeammateResponse},
+      not_found: {"No contact, or not on the team", "application/json", Schemas.Error},
+      unprocessable_entity: {"Bad prompt_from_number", "application/json", Schemas.Error}
+    ]
+  )
+
+  def update_contact(conn, %{"agent_id" => agent_id} = params) do
+    user = conn.assigns.current_user
+    opts = [source: "api"] ++ Audited.attribution(conn)
+    attrs = Map.take(params, ["prompt_from_number"])
+
+    with {:ok, _contact} <- Comms.update_contact(user.id, agent_id, attrs, opts),
+         %{} = teammate <- Team.get_teammate(user.id, agent_id) || {:error, :not_found} do
+      render(conn, :show, teammate: teammate)
+    else
+      {:error, reason} -> comms_error(conn, reason)
+    end
+  end
+
   operation(:release_contact,
     summary: "Take a teammate's email address and phone number away",
     description:

--- a/apps/fountain/lib/fountain_web/live/team_live.ex
+++ b/apps/fountain/lib/fountain_web/live/team_live.ex
@@ -45,6 +45,7 @@ defmodule FountainWeb.TeamLive do
       # (`Fountain.Team.Comms`, flag `team_comms`.) Read once at mount.
       |> assign(:comms, Comms.status(socket.assigns.current_user))
       |> assign(:contact_form_open, false)
+      |> assign(:contact_form_mode, :provision)
       |> assign(:contact_number, "")
       |> assign(:addable_agents, Team.list_addable_agents(user_id))
       |> assign(:selected, nil)
@@ -330,7 +331,53 @@ defmodule FountainWeb.TeamLive do
   # ── contact: the teammate's own email address and phone number ─────────────
 
   def handle_event("open_contact_form", _, socket),
-    do: {:noreply, assign(socket, contact_form_open: true)}
+    do: {:noreply, assign(socket, contact_form_open: true, contact_form_mode: :provision)}
+
+  def handle_event(
+        "open_change_number",
+        _,
+        %{assigns: %{selected: %{contact: %{} = c}}} = socket
+      ),
+      do:
+        {:noreply,
+         assign(socket,
+           contact_form_open: true,
+           contact_form_mode: :change,
+           contact_number: c.prompt_from_number || ""
+         )}
+
+  def handle_event("open_change_number", _, socket), do: {:noreply, socket}
+
+  def handle_event(
+        "update_contact",
+        %{"prompt_from_number" => number},
+        %{assigns: %{selected: %{} = selected}} = socket
+      ) do
+    opts = FountainWeb.Audited.attribution(socket)
+
+    case Comms.update_contact(
+           socket.assigns.user_id,
+           selected.agent.id,
+           %{"prompt_from_number" => number},
+           opts
+         ) do
+      {:ok, contact} ->
+        {:noreply,
+         socket
+         |> assign(contact_form_open: false, contact_number: "")
+         |> refresh_selected_teammate()
+         |> put_flash(
+           :info,
+           "Texts from #{contact.prompt_from_number} now reach #{selected.name}."
+         )}
+
+      {:error, reason} ->
+        {:noreply,
+         socket |> assign(:contact_number, number) |> put_flash(:error, comms_error(reason))}
+    end
+  end
+
+  def handle_event("update_contact", _, socket), do: {:noreply, socket}
 
   def handle_event("close_contact_form", _, socket),
     do: {:noreply, assign(socket, contact_form_open: false, contact_number: "")}
@@ -833,7 +880,12 @@ defmodule FountainWeb.TeamLive do
 
         <%= if @selected do %>
           <.thread_header teammate={@selected} schedule_count={length(@schedules)} comms={@comms} />
-          <.contact_form :if={@contact_form_open} number={@contact_number} teammate={@selected} />
+          <.contact_form
+            :if={@contact_form_open}
+            number={@contact_number}
+            teammate={@selected}
+            mode={@contact_form_mode}
+          />
 
           <div
             id={"team-thread-#{@selected.conversation.id}"}
@@ -1001,14 +1053,17 @@ defmodule FountainWeb.TeamLive do
 
   attr :teammate, :map, required: true
   attr :number, :string, default: ""
+  attr :mode, :atom, default: :provision
 
   # Collected whenever a teammate is given a number: the one phone whose
   # texts to it arrive as prompts. Nothing is bought until this is submitted.
+  # In :change mode the same form only moves that number — nothing is bought
+  # or released.
   defp contact_form(assigns) do
     ~H"""
     <form
       id="contact-form"
-      phx-submit="provision_contact"
+      phx-submit={if @mode == :change, do: "update_contact", else: "provision_contact"}
       phx-change="validate_contact"
       class="flex flex-wrap items-end gap-3 px-6 py-3 border-b border-[var(--color-border)] bg-[var(--color-bg-2)] text-sm"
     >
@@ -1031,7 +1086,7 @@ defmodule FountainWeb.TeamLive do
         type="submit"
         class="rounded-md bg-blue-600 text-white px-3 py-1.5 hover:bg-blue-700"
       >
-        Give email &amp; phone
+        {if @mode == :change, do: "Change number", else: "Give email & phone"}
       </button>
       <button
         type="button"
@@ -1040,8 +1095,11 @@ defmodule FountainWeb.TeamLive do
       >
         Cancel
       </button>
-      <span class="basis-full text-xs text-[var(--color-text-muted)]">
+      <span :if={@mode == :provision} class="basis-full text-xs text-[var(--color-text-muted)]">
         This provisions an AgentMail inbox and an AgentPhone number for this teammate only (both billed); texts from any other number are ignored.
+      </span>
+      <span :if={@mode == :change} class="basis-full text-xs text-[var(--color-text-muted)]">
+        Only the sender number changes; the teammate keeps its address and number.
       </span>
     </form>
     """
@@ -1104,7 +1162,17 @@ defmodule FountainWeb.TeamLive do
             class="truncate"
             title="Texts from this number to the teammate's number arrive as prompts"
           >
-            &middot; texts from <span class="font-mono">{@contact.prompt_from_number}</span> prompt
+            &middot; texts from <span class="font-mono">{@contact.prompt_from_number}</span>
+            prompt
+            <button
+              :if={@comms.enabled}
+              id="change-contact-number"
+              type="button"
+              phx-click="open_change_number"
+              class="ml-1 underline decoration-dotted hover:text-[var(--color-text)]"
+            >
+              change
+            </button>
           </span>
         </div>
       </div>

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -402,6 +402,7 @@ defmodule FountainWeb.Router do
     post "/team/:agent_id/conversations", TeamController, :fresh_conversation
     # The teammate's own email address and phone number (flag `team_comms`).
     post "/team/:agent_id/contact", TeamController, :provision_contact
+    patch "/team/:agent_id/contact", TeamController, :update_contact
     delete "/team/:agent_id/contact", TeamController, :release_contact
 
     # Team schedules (#825): the routines `/team` offers, per teammate.

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -80,6 +80,7 @@ defmodule Fountain.AuditGuardrailTest do
     # `team_comms`). Sends through the MCP tools are audited by the controller
     # as `team.contact.sent` — an effect, not tenant state.
     {"team contact provision", &__MODULE__.do_contact_provision/1, "team.contact.provisioned"},
+    {"team contact update", &__MODULE__.do_contact_update/1, "team.contact.updated"},
     {"team contact release", &__MODULE__.do_contact_release/1, "team.contact.released"},
     {"support report create", &__MODULE__.do_support_create/1, "support.report.created"},
     {"runner register", &__MODULE__.do_runner_register/1, "runner.registered"},
@@ -149,6 +150,7 @@ defmodule Fountain.AuditGuardrailTest do
           {Conversations, :start_conversation, 2},
           {Conversations, :delete_conversation, 2},
           {Fountain.Team.Comms, :provision_contact, 4},
+          {Fountain.Team.Comms, :update_contact, 4},
           {Fountain.Team.Comms, :release_contact, 3}
         ] do
       # `Code.ensure_loaded?/1` first: `function_exported?/3` answers about
@@ -363,6 +365,20 @@ defmodule Fountain.AuditGuardrailTest do
       {:ok, _} =
         Fountain.Team.Comms.provision_contact(user.id, agent.id, %{
           "prompt_from_number" => "+15550001111"
+        })
+    end)
+  end
+
+  def do_contact_update(user) do
+    with_comms(user, fn agent ->
+      {:ok, _} =
+        Fountain.Team.Comms.provision_contact(user.id, agent.id, %{
+          "prompt_from_number" => "+15550001111"
+        })
+
+      {:ok, _} =
+        Fountain.Team.Comms.update_contact(user.id, agent.id, %{
+          "prompt_from_number" => "+15550002222"
         })
     end)
   end

--- a/apps/fountain/test/fountain/team/comms/inbound_test.exs
+++ b/apps/fountain/test/fountain/team/comms/inbound_test.exs
@@ -83,7 +83,8 @@ defmodule Fountain.Team.Comms.InboundTest do
     assert conv_id == conv.id
 
     assert_received {:sent, ^conv_id, text, [], opts}
-    assert text =~ "[Text message from +15550001111 to your number +15551234567]"
+    assert text =~ "[Text message to your number +15551234567 from +15550001111"
+    assert text =~ "treat it as the owner speaking to you"
     assert text =~ "ship it"
     assert text =~ "sms_send tool to +15550001111"
     assert opts[:actor] == "system:agentphone"

--- a/apps/fountain/test/fountain/team/comms_test.exs
+++ b/apps/fountain/test/fountain/team/comms_test.exs
@@ -234,6 +234,41 @@ defmodule Fountain.Team.CommsTest do
     end
   end
 
+  describe "update_contact/4" do
+    setup do
+      flag(true)
+      :ok
+    end
+
+    test "changes the prompt number without touching the providers" do
+      user = insert_verified_user()
+      agent = teammate(user)
+      stub_providers_ok()
+      {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
+      Req.Test.stub(AgentMail, fn _ -> flunk("no provider call on update") end)
+      Req.Test.stub(AgentPhone, fn _ -> flunk("no provider call on update") end)
+
+      assert {:ok, %Contact{prompt_from_number: "+15550002222"}} =
+               Comms.update_contact(user.id, agent.id, %{"prompt_from_number" => "555-000-2222"})
+
+      assert {:error, %Ecto.Changeset{}} =
+               Comms.update_contact(user.id, agent.id, %{"prompt_from_number" => ""})
+
+      assert [_] =
+               user.id
+               |> Audit.list_recent_for_user(10)
+               |> Enum.filter(&(&1.action == "team.contact.updated"))
+    end
+
+    test "no contact is not_found" do
+      user = insert_verified_user()
+      agent = teammate(user)
+
+      assert {:error, :not_found} =
+               Comms.update_contact(user.id, agent.id, %{"prompt_from_number" => "+15550002222"})
+    end
+  end
+
   describe "release_contact/3" do
     setup do
       flag(true)

--- a/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
@@ -203,6 +203,41 @@ defmodule FountainWeb.TeamCommsControllerTest do
     end
   end
 
+  describe "PATCH /api/team/:agent_id/contact" do
+    test "changes the prompt number", %{conn: conn, user: user, raw_key: key} do
+      flag(true)
+      {agent, _} = teammate(user)
+      stub_providers_ok()
+      give(conn, key, agent.id) |> json_response(201)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/api/team/#{agent.id}/contact", %{"prompt_from_number" => "+1 555 000 2222"})
+        |> json_response(200)
+
+      assert body["data"]["contact"]["prompt_from_number"] == "+15550002222"
+      assert body["data"]["contact"]["phone"] == "+15551234567"
+
+      conn
+      |> authed_with_key(key)
+      |> put_req_header("content-type", "application/json")
+      |> patch("/api/team/#{agent.id}/contact", %{"prompt_from_number" => "nope"})
+      |> json_response(422)
+    end
+
+    test "is 404 without a contact", %{conn: conn, user: user, raw_key: key} do
+      {agent, _} = teammate(user)
+
+      conn
+      |> authed_with_key(key)
+      |> put_req_header("content-type", "application/json")
+      |> patch("/api/team/#{agent.id}/contact", %{"prompt_from_number" => "+15550002222"})
+      |> json_response(404)
+    end
+  end
+
   describe "DELETE /api/team/:agent_id/contact" do
     test "releases the contact", %{conn: conn, user: user, raw_key: key} do
       flag(true)

--- a/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
+++ b/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
@@ -93,6 +93,20 @@ defmodule FountainWeb.TeamLiveCommsTest do
     refute html =~ "provision-contact-button"
     assert %Fountain.Team.Contact{} = Comms.get_contact(user.id, agent.id)
 
+    # Change the sender number without buying anything.
+    Req.Test.stub(AgentMail, fn _ -> flunk("no provider call on change") end)
+    Req.Test.stub(AgentPhone, fn _ -> flunk("no provider call on change") end)
+    view |> element("#change-contact-number") |> render_click()
+
+    html =
+      view |> form("#contact-form", %{"prompt_from_number" => "555 000 2222"}) |> render_submit()
+
+    assert html =~ "+15550002222"
+    refute html =~ "+15550001111"
+
+    stub_providers_ok()
+    Req.Test.allow(AgentMail, self(), view.pid)
+    Req.Test.allow(AgentPhone, self(), view.pid)
     html = view |> element("#release-contact-button") |> render_click()
     refute html =~ "ada-1@agentmail.to"
     assert html =~ "provision-contact-button"

--- a/docs/api.md
+++ b/docs/api.md
@@ -372,6 +372,7 @@ DELETE /api/team/:agent_id          # remove: terminate the live conversation, u
 POST   /api/team/:agent_id/messages # a turn (prompt; optional images) → {conversation_id}
 GET    /api/team/:agent_id/conversations  # history: every conversation on the team, newest first, `current` flagged
 POST   /api/team/:agent_id/contact  # give the teammate an email address + phone number ({prompt_from_number}; flag `team_comms`)
+PATCH  /api/team/:agent_id/contact  # change prompt_from_number (nothing bought or released)
 DELETE /api/team/:agent_id/contact  # release them
 GET    /api/team/comms              # {enabled, configured}: may this caller, and can this instance
 GET    /api/team/stream             # SSE: every teammate's events on one connection


### PR DESCRIPTION
Follow-ups from the first prod smoke of #850.

- **`PATCH /api/team/:agent_id/contact {prompt_from_number}`** (+ a "change" link beside the number on `/team`): move the number whose texts become prompts without buying or releasing anything. Audited as `team.contact.updated`.
- **Trust line on inbound texts.** The wrapper now says what #853 says for teammate messages: the sender is the one number the owner registered and the only one whose texts reach the teammate — treat it as the owner speaking, reply with `sms_send`. On the smoke the teammate read a bare `[Text message from …]` as untrusted content and asked before acting (correct instinct, wrong default for this channel).

Tests: context, controller, LiveView, audit guardrail; full suite 3288 green; credo, dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)