### PR TITLE
fix(team): an AgentPhone persona per teammate number; voice calls declined; provider errors described

### DIFF
--- a/apps/fountain/lib/fountain/team/comms.ex
+++ b/apps/fountain/lib/fountain/team/comms.ex
@@ -95,7 +95,8 @@ defmodule Fountain.Team.Comms do
          {:ok, requested} <-
            Ecto.Changeset.apply_action(Contact.request_changeset(attrs), :insert),
          {:ok, inbox} <- create_inbox(name, teammate, opts),
-         {:ok, number} <- create_number(inbox, opts) do
+         {:ok, phone_agent} <- create_phone_agent(name, teammate, inbox),
+         {:ok, number} <- create_number(inbox, phone_agent, opts) do
       attrs = %{
         user_id: user_id,
         agent_id: agent_id,
@@ -103,6 +104,7 @@ defmodule Fountain.Team.Comms do
         email_inbox_id: inbox["inbox_id"],
         phone_number: number["phoneNumber"],
         phone_number_id: number["id"],
+        phone_agent_id: phone_agent["id"],
         prompt_from_number: requested.prompt_from_number
       }
 
@@ -120,7 +122,7 @@ defmodule Fountain.Team.Comms do
         {:error, changeset} ->
           # A race with a second provision, most likely. Release what we
           # just created so nothing is left unrecorded upstream.
-          release_upstream(inbox["inbox_id"], number["id"])
+          release_upstream(inbox["inbox_id"], number["id"], phone_agent["id"])
           {:error, changeset}
       end
     end
@@ -291,19 +293,45 @@ defmodule Fountain.Team.Comms do
     end
   end
 
-  defp create_number(inbox, opts) do
-    attrs = %{"country" => Keyword.get(opts, :country, "US")}
+  # AgentPhone sends only from a number attached to one of its "agents", so
+  # each teammate number gets a persona of its own. Webhook voice mode: a
+  # call reaches our master webhook, which declines it — nothing of
+  # AgentPhone's own LLM answers on a teammate's behalf.
+  defp create_phone_agent(name, teammate, inbox) do
+    attrs = %{
+      "name" => name,
+      "description" => "Fountain teammate #{teammate.agent.name} (#{teammate.agent.id})",
+      "voiceMode" => "webhook",
+      "enableMessaging" => true
+    }
+
+    case AgentPhone.create_agent(attrs) do
+      {:ok, %{"id" => _} = agent} ->
+        {:ok, agent}
+
+      {:ok, other} ->
+        release_upstream(inbox["inbox_id"], nil, nil)
+        {:error, {:phone, {:unexpected_response, other}}}
+
+      {:error, reason} ->
+        release_upstream(inbox["inbox_id"], nil, nil)
+        {:error, {:phone, reason}}
+    end
+  end
+
+  defp create_number(inbox, phone_agent, opts) do
+    attrs = %{"country" => Keyword.get(opts, :country, "US"), "agentId" => phone_agent["id"]}
 
     case AgentPhone.create_number(attrs) do
       {:ok, %{"id" => _, "phoneNumber" => _} = number} ->
         {:ok, number}
 
       {:ok, other} ->
-        release_upstream(inbox["inbox_id"], nil)
+        release_upstream(inbox["inbox_id"], nil, phone_agent["id"])
         {:error, {:phone, {:unexpected_response, other}}}
 
       {:error, reason} ->
-        release_upstream(inbox["inbox_id"], nil)
+        release_upstream(inbox["inbox_id"], nil, phone_agent["id"])
         {:error, {:phone, reason}}
     end
   end
@@ -336,9 +364,18 @@ defmodule Fountain.Team.Comms do
   end
 
   defp release_phone(%Contact{} = c) do
-    if Contact.phone?(c),
-      do: release_one(:phone, AgentPhone.delete_number(c.phone_number_id)),
-      else: :ok
+    number =
+      if Contact.phone?(c),
+        do: release_one(:phone, AgentPhone.delete_number(c.phone_number_id)),
+        else: :ok
+
+    # The persona goes with the number; a missing one (older contacts, or
+    # already gone) is nothing to report.
+    with :ok <- number do
+      if is_binary(c.phone_agent_id) and c.phone_agent_id != "",
+        do: release_one(:phone, AgentPhone.delete_agent(c.phone_agent_id)),
+        else: :ok
+    end
   end
 
   defp release_one(_channel, {:ok, _}), do: :ok
@@ -347,7 +384,7 @@ defmodule Fountain.Team.Comms do
 
   # Best-effort cleanup after a partial provision; a failure here is logged,
   # not raised — the caller is already returning the real error.
-  defp release_upstream(inbox_id, number_id) do
+  defp release_upstream(inbox_id, number_id, phone_agent_id) do
     if is_binary(inbox_id) do
       case AgentMail.delete_inbox(inbox_id) do
         {:ok, _} ->
@@ -368,6 +405,18 @@ defmodule Fountain.Team.Comms do
         {:error, reason} ->
           Logger.warning(
             "team comms: could not release number #{number_id} after a failed provision: #{inspect(reason)}"
+          )
+      end
+    end
+
+    if is_binary(phone_agent_id) do
+      case AgentPhone.delete_agent(phone_agent_id) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning(
+            "team comms: could not delete phone agent #{phone_agent_id} after a failed provision: #{inspect(reason)}"
           )
       end
     end

--- a/apps/fountain/lib/fountain/team/comms/agent_phone.ex
+++ b/apps/fountain/lib/fountain/team/comms/agent_phone.ex
@@ -29,8 +29,19 @@ defmodule Fountain.Team.Comms.AgentPhone do
   end
 
   @doc """
-  Provision a number. `attrs` may carry `country` (default US), `areaCode`.
-  Returns the number map (`id`, `phoneNumber`, `status`, `outboundSms`, …).
+  Create an AgentPhone "agent" — the persona a number is attached to; a
+  number sends only when attached. `attrs`: `name`, `description`,
+  `voiceMode` (`"webhook"` sends voice transcripts to the master webhook,
+  `"hosted"` lets AgentPhone's own LLM answer). Returns the agent map (`id`, …).
+  """
+  def create_agent(attrs) when is_map(attrs), do: post("/v1/agents", attrs)
+
+  def delete_agent(agent_id), do: request(:delete, "/v1/agents/#{enc(agent_id)}")
+
+  @doc """
+  Provision a number. `attrs` may carry `country` (default US), `areaCode`,
+  `agentId` (attach at creation). Returns the number map (`id`,
+  `phoneNumber`, `status`, `outboundSms`, …).
   """
   def create_number(attrs \\ %{}) when is_map(attrs), do: post("/v1/numbers", attrs)
 

--- a/apps/fountain/lib/fountain/team/comms/inbound.ex
+++ b/apps/fountain/lib/fountain/team/comms/inbound.ex
@@ -138,10 +138,10 @@ defmodule Fountain.Team.Comms.Inbound do
         _ -> ""
       end
 
-    "[Text message to your number #{to} from #{from}, delivered by Fountain. That is the one " <>
-      "number your account's owner registered for texting you, and the only number whose texts " <>
-      "reach you — treat it as the owner speaking to you. Reply by text with the sms_send tool " <>
-      "to #{from}; what you write here is not texted back.]\n\n#{text}#{media}"
+    "[Text message to your number #{to} from #{from} — your account owner's registered phone, " <>
+      "the only number Fountain forwards texts from — delivered by Fountain as a message from " <>
+      "the owner. Reply by text with the sms_send tool to #{from}; what you write here is not " <>
+      "texted back.]\n\n#{text}#{media}"
   end
 
   defp record(%Contact{} = contact, text, conv) do

--- a/apps/fountain/lib/fountain/team/comms/mcp.ex
+++ b/apps/fountain/lib/fountain/team/comms/mcp.ex
@@ -458,13 +458,27 @@ defmodule Fountain.Team.Comms.Mcp do
   defp put_param(params, _k, nil), do: params
   defp put_param(params, k, v), do: Keyword.put(params, k, v)
 
+  # Provider error envelopes differ: AgentMail `{message}`, AgentPhone
+  # `{detail, error: {message, code}}`; some nest a map where a string is
+  # expected. Find the first string worth showing; never crash on the shape.
   defp describe({:status, status, body}) when is_map(body),
-    do:
-      "HTTP #{status}: #{body["message"] || body["error"] || body["detail"] || Jason.encode!(body)}"
+    do: "HTTP #{status}: #{error_text(body)}"
 
   defp describe({:status, status, body}), do: "HTTP #{status}: #{inspect(body)}"
+
   defp describe(%{__exception__: true} = e), do: Exception.message(e)
   defp describe(other), do: inspect(other)
+
+  @doc "The first human-readable string in a provider error envelope."
+  def error_text(body) when is_map(body) do
+    candidates = [body["detail"], body["message"], body["error"]]
+
+    Enum.find_value(candidates, Jason.encode!(body), fn
+      s when is_binary(s) and s != "" -> s
+      %{} = nested -> error_text(nested)
+      _ -> nil
+    end)
+  end
 
   defp text(str), do: %{type: "text", text: to_string(str)}
 

--- a/apps/fountain/lib/fountain/team/contact.ex
+++ b/apps/fountain/lib/fountain/team/contact.ex
@@ -23,6 +23,9 @@ defmodule Fountain.Team.Contact do
     field :email_inbox_id, :string
     field :phone_number, :string
     field :phone_number_id, :string
+    # The AgentPhone "agent" (persona) the number is attached to — AgentPhone
+    # only sends from an attached number. Ours, created per teammate.
+    field :phone_agent_id, :string
     field :prompt_from_number, :string
 
     belongs_to :user, Fountain.Accounts.User
@@ -38,6 +41,7 @@ defmodule Fountain.Team.Contact do
     :email_inbox_id,
     :phone_number,
     :phone_number_id,
+    :phone_agent_id,
     :prompt_from_number
   ]
 

--- a/apps/fountain/lib/fountain_web/controllers/agent_phone_webhook_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_phone_webhook_controller.ex
@@ -36,9 +36,18 @@ defmodule FountainWeb.AgentPhoneWebhookController do
           delivery_id = first_header(conn, "x-webhook-id")
 
           result =
-            case Inbound.handle(conn.body_params, delivery_id) do
-              {:ok, conv_id} -> %{status: "prompted", conversation_id: conv_id}
-              {:ignored, reason} -> %{status: "ignored", reason: describe(reason)}
+            case conn.body_params do
+              # A voice event wants a spoken reply; a teammate's number does
+              # not take calls (voiceMode "webhook", see Comms), so say so
+              # and hang up rather than leaving the caller in silence.
+              %{"event" => "agent.message", "channel" => "voice"} ->
+                %{text: "This number only receives text messages. Goodbye.", hangup: true}
+
+              payload ->
+                case Inbound.handle(payload, delivery_id) do
+                  {:ok, conv_id} -> %{status: "prompted", conversation_id: conv_id}
+                  {:ignored, reason} -> %{status: "ignored", reason: describe(reason)}
+                end
             end
 
           json(conn, result)

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -338,8 +338,7 @@ defmodule FountainWeb.TeamController do
   defp comms_error(_conn, other), do: {:error, other}
 
   defp describe_provider_error({:status, status, body}) when is_map(body),
-    do:
-      "HTTP #{status}: #{body["message"] || body["error"] || body["detail"] || Jason.encode!(body)}"
+    do: "HTTP #{status}: #{Fountain.Team.Comms.Mcp.error_text(body)}"
 
   defp describe_provider_error({:status, status, body}), do: "HTTP #{status}: #{inspect(body)}"
   defp describe_provider_error(%{__exception__: true} = e), do: Exception.message(e)

--- a/apps/fountain/lib/fountain_web/live/team_live.ex
+++ b/apps/fountain/lib/fountain_web/live/team_live.ex
@@ -730,8 +730,7 @@ defmodule FountainWeb.TeamLive do
   defp comms_error(other), do: "Could not update the contact: #{inspect(other)}"
 
   defp describe_provider({:status, status, body}) when is_map(body),
-    do:
-      "HTTP #{status}: #{body["message"] || body["error"] || body["detail"] || Jason.encode!(body)}"
+    do: "HTTP #{status}: #{Fountain.Team.Comms.Mcp.error_text(body)}"
 
   defp describe_provider({:status, status, body}), do: "HTTP #{status}: #{inspect(body)}"
   defp describe_provider(%{__exception__: true} = e), do: Exception.message(e)

--- a/apps/fountain/priv/repo/migrations/20260819170000_add_phone_agent_id_to_team_contacts.exs
+++ b/apps/fountain/priv/repo/migrations/20260819170000_add_phone_agent_id_to_team_contacts.exs
@@ -1,0 +1,14 @@
+defmodule Fountain.Repo.Migrations.AddPhoneAgentIdToTeamContacts do
+  @moduledoc """
+  AgentPhone only sends from a number that is attached to one of its
+  "agents" (a persona record); Fountain creates one per teammate number and
+  remembers it here so release can delete it again.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:team_contacts) do
+      add :phone_agent_id, :string
+    end
+  end
+end

--- a/apps/fountain/test/fountain/team/comms/inbound_test.exs
+++ b/apps/fountain/test/fountain/team/comms/inbound_test.exs
@@ -84,7 +84,7 @@ defmodule Fountain.Team.Comms.InboundTest do
 
     assert_received {:sent, ^conv_id, text, [], opts}
     assert text =~ "[Text message to your number +15551234567 from +15550001111"
-    assert text =~ "treat it as the owner speaking to you"
+    assert text =~ "as a message from the owner"
     assert text =~ "ship it"
     assert text =~ "sms_send tool to +15550001111"
     assert opts[:actor] == "system:agentphone"

--- a/apps/fountain/test/fountain/team/comms/mcp_test.exs
+++ b/apps/fountain/test/fountain/team/comms/mcp_test.exs
@@ -60,6 +60,21 @@ defmodule Fountain.Team.Comms.McpTest do
     def send_message(_, _), do: {:error, {:status, 422, %{"message" => "bad recipient"}}}
   end
 
+  # AgentPhone's envelope nests the message under "error".
+  defmodule FailingPhone do
+    def send_message(_),
+      do:
+        {:error,
+         {:status, 400,
+          %{
+            "detail" => "Number is not assigned to an agent yet",
+            "error" => %{
+              "message" => "Number is not assigned to an agent yet",
+              "code" => "HTTP_400"
+            }
+          }}}
+  end
+
   defmodule FakePhone do
     def send_message(body) do
       send(self(), {:sms_send, body})
@@ -250,6 +265,17 @@ defmodule Fountain.Team.Comms.McpTest do
   end
 
   describe "sms tools" do
+    test "a nested provider error envelope is described, not crashed on" do
+      assert %{"result" => %{"isError" => true, "content" => [%{"text" => msg}]}} =
+               call(
+                 "sms_send",
+                 %{"to" => "+15550001111", "body" => "hey"},
+                 ctx(%{phone: FailingPhone})
+               )
+
+      assert msg =~ "HTTP 400: Number is not assigned to an agent yet"
+    end
+
     test "sms_send sends from the teammate's number and audits" do
       test = self()
       ctx = ctx(%{audit: fn tool, summary -> send(test, {:audit, tool, summary}) end})

--- a/apps/fountain/test/fountain/team/comms_test.exs
+++ b/apps/fountain/test/fountain/team/comms_test.exs
@@ -55,12 +55,20 @@ defmodule Fountain.Team.CommsTest do
 
     Req.Test.stub(AgentPhone, fn conn ->
       case {conn.method, conn.request_path} do
+        {"POST", "/v1/agents"} ->
+          send(test, {:agentphone_create_agent, conn.body_params})
+          Req.Test.json(conn, %{"id" => "agt_123", "name" => conn.body_params["name"]})
+
         {"POST", "/v1/numbers"} ->
           send(test, {:agentphone_create, conn.body_params})
           Req.Test.json(conn, %{"id" => "num_123", "phoneNumber" => "+15551234567"})
 
         {"DELETE", "/v1/numbers/num_123"} ->
           send(test, :agentphone_delete)
+          Req.Test.json(conn, %{})
+
+        {"DELETE", "/v1/agents/agt_123"} ->
+          send(test, :agentphone_delete_agent)
           Req.Test.json(conn, %{})
       end
     end)
@@ -123,7 +131,12 @@ defmodule Fountain.Team.CommsTest do
       assert_received {:agentmail_create, body}
       assert body["display_name"] == "Ada Lovelace"
       assert body["client_id"] == "fountain-team." <> agent.id
-      assert_received {:agentphone_create, %{"country" => "US"}}
+      # A persona per teammate number, and the number attached to it.
+      assert_received {:agentphone_create_agent,
+                       %{"name" => "Ada Lovelace", "voiceMode" => "webhook"}}
+
+      assert_received {:agentphone_create, %{"country" => "US", "agentId" => "agt_123"}}
+      assert contact.phone_agent_id == "agt_123"
       assert_received {:team_changed, _}
 
       assert Comms.get_contact(user.id, agent.id).id == contact.id
@@ -204,13 +217,27 @@ defmodule Fountain.Team.CommsTest do
       end)
 
       Req.Test.stub(AgentPhone, fn conn ->
-        conn |> Plug.Conn.put_status(402) |> Req.Test.json(%{"detail" => "insufficient balance"})
+        case {conn.method, conn.request_path} do
+          {"POST", "/v1/agents"} ->
+            Req.Test.json(conn, %{"id" => "agt_123"})
+
+          {"DELETE", "/v1/agents/agt_123"} ->
+            send(test, :agentphone_delete_agent)
+            Req.Test.json(conn, %{})
+
+          _ ->
+            conn
+            |> Plug.Conn.put_status(402)
+            |> Req.Test.json(%{"detail" => "insufficient balance"})
+        end
       end)
 
       assert {:error, {:phone, {:status, 402, %{"detail" => "insufficient balance"}}}} =
                Comms.provision_contact(user.id, agent.id, @req)
 
+      # The inbox and the persona are both undone.
       assert_received :agentmail_delete
+      assert_received :agentphone_delete_agent
       assert Comms.get_contact(user.id, agent.id) == nil
 
       assert [] =
@@ -284,6 +311,7 @@ defmodule Fountain.Team.CommsTest do
       assert :ok = Comms.release_contact(user.id, agent.id, actor: "api")
       assert_received :agentmail_delete
       assert_received :agentphone_delete
+      assert_received :agentphone_delete_agent
       assert Comms.get_contact(user.id, agent.id) == nil
 
       assert [event] =

--- a/apps/fountain/test/fountain_web/controllers/agent_phone_webhook_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_phone_webhook_controller_test.exs
@@ -134,6 +134,33 @@ defmodule FountainWeb.AgentPhoneWebhookControllerTest do
              |> json_response(200)
   end
 
+  test "a voice event is declined with a spoken line and a hangup", %{conn: conn} do
+    body =
+      Jason.encode!(%{
+        "event" => "agent.message",
+        "channel" => "voice",
+        "data" => %{
+          "from" => "+15550001111",
+          "to" => "+15551234567",
+          "transcript" => "hello?",
+          "direction" => "inbound"
+        }
+      })
+
+    ts = to_string(System.os_time(:second))
+
+    assert %{"text" => text, "hangup" => true} =
+             conn
+             |> deliver(body, [
+               {"x-webhook-signature", sign(body, ts)},
+               {"x-webhook-timestamp", ts}
+             ])
+             |> json_response(200)
+
+    assert text =~ "text messages"
+    refute_received {:sent, _, _}
+  end
+
   test "a redelivery is 200 and not prompted twice", %{conn: conn} do
     ts = to_string(System.os_time(:second))
 

--- a/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
@@ -56,6 +56,9 @@ defmodule FountainWeb.TeamCommsControllerTest do
 
     Req.Test.stub(AgentPhone, fn conn ->
       case {conn.method, conn.request_path} do
+        {"POST", "/v1/agents"} ->
+          Req.Test.json(conn, %{"id" => "agt_123"})
+
         {"POST", "/v1/numbers"} ->
           Req.Test.json(conn, %{"id" => "num_123", "phoneNumber" => "+15551234567"})
 

--- a/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
+++ b/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
@@ -44,9 +44,10 @@ defmodule FountainWeb.TeamLiveCommsTest do
     end)
 
     Req.Test.stub(AgentPhone, fn conn ->
-      case conn.method do
-        "POST" -> Req.Test.json(conn, %{"id" => "num_1", "phoneNumber" => "+15551234567"})
-        "DELETE" -> Req.Test.json(conn, %{})
+      case {conn.method, conn.request_path} do
+        {"POST", "/v1/agents"} -> Req.Test.json(conn, %{"id" => "agt_1"})
+        {"POST", _} -> Req.Test.json(conn, %{"id" => "num_1", "phoneNumber" => "+15551234567"})
+        {"DELETE", _} -> Req.Test.json(conn, %{})
       end
     end)
   end


### PR DESCRIPTION
From the prod smoke of #850/#857: the teammate's first `sms_send` failed twice over.

- **AgentPhone sends only from a number attached to one of its "agents"** (personas). Provisioning now creates one per teammate (`voiceMode: webhook`, messaging on) and attaches the number at creation; release deletes both; a failed provision undoes the persona too. New column `team_contacts.phone_agent_id`.
- **The error envelope crashed `describe/1`** — AgentPhone returns `{detail, error: {message, code}}`, a map where a string was expected, so the teammate saw `Internal Server Error` instead of the reason. `Mcp.error_text/1` walks the envelope; used by the tool error, the API 424 and the LiveView flash.
- **Voice calls to a teammate's number** are answered with a spoken decline + hangup via the master webhook (webhook voice mode), not silence.
- Inbound wrapper reads as delivery metadata rather than arguing for trust.

Tests updated (stubs carry the agent routes; nested-envelope test; voice test). Full suite green; credo, dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)