### PR TITLE
feat(team): SMS opt-in consent on the contact form; STOP/START/HELP honoured inbound (A2P/10DLC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ upgrade, is in
   /api/webhooks/agentphone`, HMAC-verified with `AGENTPHONE_WEBHOOK_SECRET`,
   deduplicated by delivery id); texts from anyone else are ignored.
   `PATCH /api/team/:agent_id/contact` (and "change" on `/team`) moves that
-  number without buying or releasing anything.
+  number without buying or releasing anything. The form carries the SMS
+  opt-in statement (frequency, rates, STOP/HELP, privacy + terms), and
+  `STOP`/`START`/`HELP` from the registered number are honoured in the
+  inbound path (`contact.prompt_opted_out_at`).
 - **Per-user feature flags** (`Fountain.FeatureFlags`), evaluated by PostHog
   (`POSTHOG_PROJECT_API_KEY`, `POSTHOG_HOST`) with a one-minute per-user
   cache; when PostHog is unreachable the last answer it gave is reused and,

--- a/apps/fountain/lib/fountain/team/comms.ex
+++ b/apps/fountain/lib/fountain/team/comms.ex
@@ -159,6 +159,27 @@ defmodule Fountain.Team.Comms do
   end
 
   @doc """
+  Record the registered number's SMS opt-out (`true`: it texted STOP) or
+  opt-in (`false`: START). Nothing is bought or released; while opted out
+  its texts are not prompts. Audited as `team.contact.opted_out` /
+  `team.contact.opted_in`.
+  """
+  def set_opt_out(%Contact{} = contact, opted_out?, opts \\ []) when is_boolean(opted_out?) do
+    at = if opted_out?, do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+    case contact |> Ecto.Changeset.change(prompt_opted_out_at: at) |> Repo.update() do
+      {:ok, updated} ->
+        action = if opted_out?, do: "team.contact.opted_out", else: "team.contact.opted_in"
+        record(action, updated, opts, %{})
+        Team.broadcast_changed(updated.user_id)
+        {:ok, updated}
+
+      {:error, cs} ->
+        {:error, cs}
+    end
+  end
+
+  @doc """
   Take the teammate's email address and phone number away: the inbox and the
   number are deleted upstream and the contact row removed. A provider that
   no longer knows the resource (404) counts as released; any other provider

--- a/apps/fountain/lib/fountain/team/comms/inbound.ex
+++ b/apps/fountain/lib/fountain/team/comms/inbound.ex
@@ -25,6 +25,15 @@ defmodule Fountain.Team.Comms.Inbound do
 
   Every prompt is audited as `team.contact.prompted` (bytes, never the
   text), actor `system:agentphone`.
+
+  **Opt-out keywords (A2P/10DLC).** From the registered number, a text that
+  is exactly `STOP` (or `STOPALL`, `UNSUBSCRIBE`, `CANCEL`, `END`, `QUIT`)
+  is not a prompt: it sets the contact's `prompt_opted_out_at`, and until
+  `START` (`UNSTOP`, `YES`) arrives — or the number is changed, which is new
+  consent — that number's texts are acknowledged and dropped. `HELP`
+  (`INFO`) is answered with a short help text. Each keyword gets a one-line
+  confirmation texted back from the teammate's number, best-effort (the
+  carrier may also answer STOP itself).
   """
 
   require Logger
@@ -36,6 +45,9 @@ defmodule Fountain.Team.Comms.Inbound do
 
   @actor "system:agentphone"
   @channels ~w(sms mms imessage)
+  @stop_words ~w(STOP STOPALL UNSUBSCRIBE CANCEL END QUIT)
+  @start_words ~w(START UNSTOP YES)
+  @help_words ~w(HELP INFO)
 
   @doc "The audit actor for prompts that came in by text."
   def actor, do: @actor
@@ -64,6 +76,8 @@ defmodule Fountain.Team.Comms.Inbound do
     with :ok <- fresh(delivery_id),
          {:ok, %Contact{} = contact} <- contact_for(to),
          :ok <- sender_allowed(contact, from),
+         :prompt <- keyword(contact, data, from),
+         :ok <- not_opted_out(contact),
          :ok <- available(contact),
          {:ok, text} <- body(data) do
       prompt = wrap(text, from, to, data)
@@ -85,6 +99,7 @@ defmodule Fountain.Team.Comms.Inbound do
       end
     else
       {:ignored, _} = ignored -> ignored
+      {:handled, _} = handled -> handled
     end
   end
 
@@ -115,6 +130,88 @@ defmodule Fountain.Team.Comms.Inbound do
   end
 
   defp sender_allowed(_contact, _from), do: {:ignored, :sender_not_allowed}
+
+  # STOP / START / HELP from the registered number are handled here, never
+  # forwarded. Returns `:prompt` for an ordinary text.
+  defp keyword(%Contact{} = contact, data, from) do
+    word = data |> Map.get("message", "") |> to_string() |> String.trim() |> String.upcase()
+
+    cond do
+      word in @stop_words ->
+        {:ok, updated} = Comms.set_opt_out(contact, true, actor: @actor)
+
+        confirm(
+          updated,
+          from,
+          "You've opted out: texts from this number no longer reach #{teammate_name(updated)} via Fountain. Reply START to resume."
+        )
+
+        {:handled, :opted_out}
+
+      word in @start_words ->
+        {:ok, updated} = Comms.set_opt_out(contact, false, actor: @actor)
+
+        confirm(
+          updated,
+          from,
+          "You're opted in: texts from this number reach #{teammate_name(updated)} via Fountain again. Reply STOP to opt out, HELP for help."
+        )
+
+        {:handled, :opted_in}
+
+      word in @help_words ->
+        confirm(
+          contact,
+          from,
+          "Fountain: texts from this number are forwarded to your teammate #{teammate_name(contact)} (#{contact.phone_number}). Msg & data rates may apply. Reply STOP to opt out. Help: #{help_url()}"
+        )
+
+        {:handled, :help}
+
+      true ->
+        :prompt
+    end
+  end
+
+  defp not_opted_out(%Contact{} = c) do
+    if Contact.opted_out?(c), do: {:ignored, :opted_out}, else: :ok
+  end
+
+  # Best-effort confirmation from the teammate's own number; a refusal
+  # (A2P registration pending, say) is logged and changes nothing.
+  defp confirm(%Contact{} = c, to, body) do
+    if Contact.phone?(c) do
+      case Comms.AgentPhone.send_message(%{
+             "number_id" => c.phone_number_id,
+             "to_number" => to,
+             "body" => body
+           }) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.info(
+            "team comms inbound: could not text a keyword confirmation: #{inspect(reason)}"
+          )
+      end
+    end
+
+    :ok
+  end
+
+  defp teammate_name(%Contact{user_id: uid, agent_id: aid}) do
+    case Team.get_teammate(uid, aid) do
+      %{name: name} -> name
+      _ -> "your teammate"
+    end
+  end
+
+  defp help_url do
+    case Application.get_env(:fountain, :support_email) do
+      email when is_binary(email) and email != "" -> email
+      _ -> Fountain.PublicUrl.base()
+    end
+  end
 
   defp available(%Contact{user_id: user_id}) do
     if Comms.available?(user_id), do: :ok, else: {:ignored, :unavailable}

--- a/apps/fountain/lib/fountain/team/contact.ex
+++ b/apps/fountain/lib/fountain/team/contact.ex
@@ -27,6 +27,9 @@ defmodule Fountain.Team.Contact do
     # only sends from an attached number. Ours, created per teammate.
     field :phone_agent_id, :string
     field :prompt_from_number, :string
+    # Set when the registered number texted STOP; cleared by START or by a
+    # fresh number (new consent). While set, its texts are not prompts.
+    field :prompt_opted_out_at, :utc_datetime
 
     belongs_to :user, Fountain.Accounts.User
     belongs_to :agent, Fountain.Agents.Agent
@@ -42,7 +45,8 @@ defmodule Fountain.Team.Contact do
     :phone_number,
     :phone_number_id,
     :phone_agent_id,
-    :prompt_from_number
+    :prompt_from_number,
+    :prompt_opted_out_at
   ]
 
   def changeset(contact, attrs) do
@@ -67,13 +71,20 @@ defmodule Fountain.Team.Contact do
     |> normalize_number(:prompt_from_number)
   end
 
-  @doc "Change the user-supplied part of an existing contact: `prompt_from_number`, required."
+  @doc """
+  Change the user-supplied part of an existing contact: `prompt_from_number`,
+  required. Entering a number is consent again, so a standing STOP is cleared.
+  """
   def update_changeset(%__MODULE__{} = contact, attrs) do
     contact
     |> cast(attrs, [:prompt_from_number])
     |> validate_required([:prompt_from_number])
     |> normalize_number(:prompt_from_number)
+    |> put_change(:prompt_opted_out_at, nil)
   end
+
+  @doc "Whether the registered number has opted out (texted STOP)."
+  def opted_out?(%__MODULE__{prompt_opted_out_at: at}), do: not is_nil(at)
 
   defp normalize_number(changeset, field) do
     case get_change(changeset, field) do

--- a/apps/fountain/lib/fountain_web/controllers/agent_phone_webhook_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_phone_webhook_controller.ex
@@ -46,6 +46,7 @@ defmodule FountainWeb.AgentPhoneWebhookController do
               payload ->
                 case Inbound.handle(payload, delivery_id) do
                   {:ok, conv_id} -> %{status: "prompted", conversation_id: conv_id}
+                  {:handled, what} -> %{status: "handled", reason: to_string(what)}
                   {:ignored, reason} -> %{status: "ignored", reason: describe(reason)}
                 end
             end

--- a/apps/fountain/lib/fountain_web/controllers/team_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_json.ex
@@ -41,6 +41,7 @@ defmodule FountainWeb.TeamJSON do
       email: (Fountain.Team.Contact.email?(c) && c.email_address) || nil,
       phone: (Fountain.Team.Contact.phone?(c) && c.phone_number) || nil,
       prompt_from_number: c.prompt_from_number,
+      prompt_opted_out_at: c.prompt_opted_out_at,
       inserted_at: c.inserted_at
     }
   end

--- a/apps/fountain/lib/fountain_web/live/team_live.ex
+++ b/apps/fountain/lib/fountain_web/live/team_live.ex
@@ -1083,9 +1083,10 @@ defmodule FountainWeb.TeamLive do
       <button
         id="contact-form-submit"
         type="submit"
-        class="rounded-md bg-blue-600 text-white px-3 py-1.5 hover:bg-blue-700"
+        disabled={String.trim(@number) == ""}
+        class="rounded-md bg-blue-600 text-white px-3 py-1.5 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        {if @mode == :change, do: "Change number", else: "Give email & phone"}
+        {if @mode == :change, do: "Agree & change number", else: "Agree & give email & phone"}
       </button>
       <button
         type="button"
@@ -1094,6 +1095,14 @@ defmodule FountainWeb.TeamLive do
       >
         Cancel
       </button>
+      <p id="sms-consent" class="basis-full text-sm text-[var(--color-text-secondary)] max-w-prose">
+        By entering your number you agree to receive text messages from Fountain — your
+        teammate's replies and occasional notifications — at this number. Message frequency
+        varies. Msg &amp; data rates may apply. Reply <span class="font-mono">STOP</span>
+        to opt out at any time, <span class="font-mono">HELP</span>
+        for help. <.link href={~p"/privacy"} target="_blank" class="underline">Privacy Policy</.link>
+        &middot; <.link href={~p"/terms"} target="_blank" class="underline">Terms</.link>
+      </p>
       <span :if={@mode == :provision} class="basis-full text-xs text-[var(--color-text-muted)]">
         This provisions an AgentMail inbox and an AgentPhone number for this teammate only (both billed); texts from any other number are ignored.
       </span>
@@ -1162,7 +1171,9 @@ defmodule FountainWeb.TeamLive do
             title="Texts from this number to the teammate's number arrive as prompts"
           >
             &middot; texts from <span class="font-mono">{@contact.prompt_from_number}</span>
-            prompt
+            {if @contact.prompt_opted_out_at,
+              do: "paused (STOP received; text START to resume)",
+              else: "prompt"}
             <button
               :if={@comms.enabled}
               id="change-contact-number"

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1723,6 +1723,14 @@ defmodule FountainWeb.Schemas do
             "E.164. The one number whose texts to `phone` arrive as prompts in the " <>
               "teammate's conversation; texts from anyone else are ignored."
         },
+        prompt_opted_out_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          nullable: true,
+          description:
+            "Set when `prompt_from_number` texted STOP: its texts are dropped until it texts " <>
+              "START, or until the number is changed (new consent)."
+        },
         inserted_at: %Schema{type: :string, format: :"date-time"}
       },
       required: [:email, :phone]

--- a/apps/fountain/priv/repo/migrations/20260819180000_add_prompt_opted_out_at_to_team_contacts.exs
+++ b/apps/fountain/priv/repo/migrations/20260819180000_add_prompt_opted_out_at_to_team_contacts.exs
@@ -1,0 +1,14 @@
+defmodule Fountain.Repo.Migrations.AddPromptOptedOutAtToTeamContacts do
+  @moduledoc """
+  SMS opt-out (A2P/10DLC): when the registered number texts STOP, the
+  teammate stops receiving its texts as prompts until START, or until the
+  number is changed (fresh consent). Nothing is released.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:team_contacts) do
+      add :prompt_opted_out_at, :utc_datetime
+    end
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -81,6 +81,8 @@ defmodule Fountain.AuditGuardrailTest do
     # as `team.contact.sent` — an effect, not tenant state.
     {"team contact provision", &__MODULE__.do_contact_provision/1, "team.contact.provisioned"},
     {"team contact update", &__MODULE__.do_contact_update/1, "team.contact.updated"},
+    {"team contact opt-out", &__MODULE__.do_contact_opt_out/1, "team.contact.opted_out"},
+    {"team contact opt-in", &__MODULE__.do_contact_opt_in/1, "team.contact.opted_in"},
     {"team contact release", &__MODULE__.do_contact_release/1, "team.contact.released"},
     {"support report create", &__MODULE__.do_support_create/1, "support.report.created"},
     {"runner register", &__MODULE__.do_runner_register/1, "runner.registered"},
@@ -151,6 +153,7 @@ defmodule Fountain.AuditGuardrailTest do
           {Conversations, :delete_conversation, 2},
           {Fountain.Team.Comms, :provision_contact, 4},
           {Fountain.Team.Comms, :update_contact, 4},
+          {Fountain.Team.Comms, :set_opt_out, 3},
           {Fountain.Team.Comms, :release_contact, 3}
         ] do
       # `Code.ensure_loaded?/1` first: `function_exported?/3` answers about
@@ -380,6 +383,28 @@ defmodule Fountain.AuditGuardrailTest do
         Fountain.Team.Comms.update_contact(user.id, agent.id, %{
           "prompt_from_number" => "+15550002222"
         })
+    end)
+  end
+
+  def do_contact_opt_out(user) do
+    with_comms(user, fn agent ->
+      {:ok, c} =
+        Fountain.Team.Comms.provision_contact(user.id, agent.id, %{
+          "prompt_from_number" => "+15550001111"
+        })
+
+      {:ok, _} = Fountain.Team.Comms.set_opt_out(c, true)
+    end)
+  end
+
+  def do_contact_opt_in(user) do
+    with_comms(user, fn agent ->
+      {:ok, c} =
+        Fountain.Team.Comms.provision_contact(user.id, agent.id, %{
+          "prompt_from_number" => "+15550001111"
+        })
+
+      {:ok, _} = Fountain.Team.Comms.set_opt_out(c, false)
     end)
   end
 

--- a/apps/fountain/test/fountain/team/comms/inbound_test.exs
+++ b/apps/fountain/test/fountain/team/comms/inbound_test.exs
@@ -144,6 +144,101 @@ defmodule Fountain.Team.Comms.InboundTest do
     assert text =~ "(attachment: https://x/y.jpg)"
   end
 
+  describe "STOP / START / HELP from the registered number" do
+    setup do
+      # Keyword confirmations are texted back best-effort through AgentPhone.
+      test = self()
+
+      Req.Test.stub(Fountain.Team.Comms.AgentPhone, fn conn ->
+        send(test, {:confirm_sms, conn.body_params})
+        Req.Test.json(conn, %{"id" => "sms_c", "status" => "queued"})
+      end)
+
+      :ok
+    end
+
+    test "STOP opts the number out: no prompt, later texts dropped, audited", %{
+      user: user,
+      contact: contact
+    } do
+      assert {:handled, :opted_out} =
+               Inbound.handle(payload(%{"data" => %{"message" => " stop "}}), "k1")
+
+      refute_received {:sent, _, _, _, _}
+
+      assert_received {:confirm_sms,
+                       %{"number_id" => "num_1", "to_number" => @owner, "body" => body}}
+
+      assert body =~ "opted out"
+      assert body =~ "START"
+
+      assert %Contact{prompt_opted_out_at: %DateTime{}} = Fountain.Repo.get!(Contact, contact.id)
+
+      assert {:ignored, :opted_out} = Inbound.handle(payload(), "k2")
+      refute_received {:sent, _, _, _, _}
+
+      assert [_] =
+               user.id
+               |> Audit.list_recent_for_user(10)
+               |> Enum.filter(&(&1.action == "team.contact.opted_out"))
+    end
+
+    test "START opts back in", %{contact: contact} do
+      {:handled, :opted_out} = Inbound.handle(payload(%{"data" => %{"message" => "STOP"}}), "k3")
+
+      assert {:handled, :opted_in} =
+               Inbound.handle(payload(%{"data" => %{"message" => "START"}}), "k4")
+
+      assert %Contact{prompt_opted_out_at: nil} = Fountain.Repo.get!(Contact, contact.id)
+      assert {:ok, _} = Inbound.handle(payload(), "k5")
+      assert_received {:sent, _, _, _, _}
+    end
+
+    test "HELP is answered, not forwarded" do
+      assert {:handled, :help} =
+               Inbound.handle(payload(%{"data" => %{"message" => "help"}}), "k6")
+
+      assert_received {:confirm_sms, %{"body" => body}}
+      assert body =~ "STOP to opt out"
+      refute_received {:sent, _, _, _, _}
+    end
+
+    test "a keyword from a stranger is just ignored" do
+      assert {:ignored, :sender_not_allowed} =
+               Inbound.handle(
+                 payload(%{"data" => %{"from" => "+15559999999", "message" => "STOP"}}),
+                 "k7"
+               )
+
+      refute_received {:confirm_sms, _}
+    end
+
+    test "changing the number is new consent: the opt-out clears", %{
+      user: user,
+      agent: agent,
+      contact: _
+    } do
+      {:handled, :opted_out} = Inbound.handle(payload(%{"data" => %{"message" => "STOP"}}), "k8")
+      Application.put_env(:fountain, :feature_flag_overrides, %{"team_comms" => true})
+
+      assert {:ok, %Contact{prompt_opted_out_at: nil}} =
+               Fountain.Team.Comms.update_contact(user.id, agent.id, %{
+                 "prompt_from_number" => @owner
+               })
+    end
+
+    test "a refused confirmation changes nothing" do
+      Req.Test.stub(Fountain.Team.Comms.AgentPhone, fn conn ->
+        conn
+        |> Plug.Conn.put_status(403)
+        |> Req.Test.json(%{"detail" => "A2P registration required"})
+      end)
+
+      assert {:handled, :opted_out} =
+               Inbound.handle(payload(%{"data" => %{"message" => "STOP"}}), "k9")
+    end
+  end
+
   test "a send failure is reported, not raised" do
     stub(ConversationServer, :send_prompt, fn _, _, _, _ -> {:error, :busy} end)
     assert {:ignored, {:send_failed, :busy}} = Inbound.handle(payload(), "del_busy")

--- a/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
+++ b/apps/fountain/test/fountain_web/live/team_live_comms_test.exs
@@ -80,6 +80,14 @@ defmodule FountainWeb.TeamLiveCommsTest do
     html = view |> element("#provision-contact-button") |> render_click()
     assert html =~ "contact-form"
     refute html =~ "ada-1@agentmail.to"
+    # The SMS opt-in copy an A2P reviewer looks for, with the legal links.
+    assert html =~ "agree to receive text messages from Fountain"
+    assert html =~ "Msg &amp; data rates may apply"
+    assert html =~ "STOP"
+    assert html =~ "HELP"
+    assert html =~ ~s(href="/privacy")
+    assert html =~ ~s(href="/terms")
+    assert html =~ "Agree &amp; give email &amp; phone"
 
     html =
       view

--- a/docs/api.md
+++ b/docs/api.md
@@ -445,6 +445,11 @@ AgentPhone to `POST /api/webhooks/agentphone` (HMAC-verified with
 and can answer with its `sms_send` tool. Texts from any other number are
 acknowledged and ignored; deliveries are deduplicated by AgentPhone's
 `X-Webhook-ID`. Audited as `team.contact.prompted` (bytes, never the text).
+`STOP` (or `UNSUBSCRIBE`, `CANCEL`, `END`, `QUIT`) from that number opts it
+out — `contact.prompt_opted_out_at` is set and its texts are dropped until
+`START`, or until the number is changed (new consent); `HELP` is answered.
+Each keyword gets a confirmation texted back from the teammate's number,
+best-effort.
 
 `/messages` returns `202 {status: "queued", conversation_id}`; the id is the
 conversation the message went to, which is a new one when the teammate's


### PR DESCRIPTION
For the A2P 10DLC registration: the number-entry form is the opt-in, and it now says so.

- **Consent statement** on the `/team` form (provision and change): what the texts are, "Message frequency varies. Msg & data rates may apply. Reply STOP to opt out at any time, HELP for help.", links to Privacy Policy and Terms; submit reads **Agree & give email & phone** / **Agree & change number**, disabled until a number is entered. Nothing is bought before the user submits.
- **STOP / START / HELP** from the registered number are honoured in the inbound path (never forwarded as prompts): STOP sets `contact.prompt_opted_out_at` and its texts are dropped until START, or until the number is changed (new consent); HELP is answered. Each gets a confirmation texted back from the teammate's number, best-effort. Audited as `team.contact.opted_out` / `opted_in`; `prompt_opted_out_at` in the API; `/team` shows "paused (STOP received; text START to resume)".

The standalone team app's dialog gets the same copy in its PR. Tests for keywords, opt-out gating, new-consent clearing, consent copy; full suite green; credo, dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)