### PR TITLE
oauth: register the dns-desk client

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -37,5 +37,10 @@ config :fountain, :oauth_clients, [
     id: "fountain-conversations",
     name: "Fountain Conversations",
     redirect_uris: ["http://localhost:5173/", "http://localhost:5174/"]
+  },
+  %{
+    id: "dns-desk",
+    name: "DNS Desk",
+    redirect_uris: ["http://localhost:5173/", "http://localhost:5174/"]
   }
 ]

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -129,7 +129,7 @@ spec:
             # The same apps may "Sign in with Fountain" (OAuth code + PKCE,
             # #818). Redirect URIs are exact.
             - name: OAUTH_CLIENTS
-              value: '[{"id":"fountain-conversations","name":"Fountain Conversations","redirect_uris":["https://jakegaylor.com/fountain-conversations/"]},{"id":"fountain-team","name":"Fountain Team","redirect_uris":["https://jakegaylor.com/fountain-team/"]}]'
+              value: '[{"id":"fountain-conversations","name":"Fountain Conversations","redirect_uris":["https://jakegaylor.com/fountain-conversations/"]},{"id":"fountain-team","name":"Fountain Team","redirect_uris":["https://jakegaylor.com/fountain-team/"]},{"id":"dns-desk","name":"DNS Desk","redirect_uris":["https://jakegaylor.com/dns-desk/"]}]'
             # SANDBOX_IDLE_TIMEOUT_MINUTES is back at the stock 60m default.
             # The 240m override (#664) existed because idle reclaim used to
             # destroy the sandbox — and the agent's working memory — while a


### PR DESCRIPTION
DNS Desk ([jhgaylor/dns-desk](https://github.com/jhgaylor/dns-desk)) is the next standalone app on the API — a dedicated DNS operator for Cloudflare zones: free-text request → plan as a diff → approve → apply, with the desk running as a teammate.

This registers its OAuth client (code + PKCE, #818 / ADR 0021) in prod (`k8s/deployment.yaml`) and dev (`config/dev.exs`). Redirect URI `https://jakegaylor.com/dns-desk/` (GitHub Pages, same origin already in `API_CORS_ORIGINS` — no CORS change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)