### PR TITLE
fix(agents): re-wire system-prompt delivery lost in #850's merge

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -685,6 +685,7 @@ defmodule Fountain.Conversations.ConversationServer do
         sprite_env = build_sprite_env(state, agent, env, secrets, sandbox_url)
 
         write_runtime_config(handle, state.runtime_module, agent)
+        write_instructions(handle, runtime, agent)
         Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
 
         with :ok <-
@@ -877,6 +878,9 @@ defmodule Fountain.Conversations.ConversationServer do
         # Refresh the .env file in case secrets/env_vars were edited
         # between the original provision and this reattach.
         Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
+        # Same for the agent's system prompt: an edit reaches the existing
+        # computer on its next wake (#848).
+        write_instructions(handle, conv.runtime || (agent && agent.runtime) || "claude", agent)
 
         # Normally the wake path already flipped suspended → ready under the
         # quota reservation; this covers the reaper parking the row mid-wake.
@@ -1267,6 +1271,23 @@ defmodule Fountain.Conversations.ConversationServer do
 
     if function_exported?(runtime_module, :write_config, 2) do
       runtime_module.write_config(handle, agent)
+    end
+  end
+
+  # The agent's `system` prompt, into the runtime's user-level instructions
+  # file (#848). Best-effort: a sandbox that refuses the write still runs,
+  # on the CLI's default persona, and says so in the log.
+  defp write_instructions(handle, runtime, agent) do
+    case Fountain.Runtimes.Instructions.write(handle, runtime, agent) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "could not write agent instructions for #{inspect(agent && agent.name)} (#{runtime}): #{inspect(reason)}"
+        )
+
+        :ok
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_instructions_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_instructions_test.exs
@@ -1,0 +1,86 @@
+defmodule Fountain.Conversations.ConversationServerInstructionsTest do
+  @moduledoc """
+  The agent's `system` prompt must reach the sandbox (#848).
+
+  #849 wired `Fountain.Runtimes.Instructions.write/3` into provision and
+  reattach; #850 — branched before #849 landed — removed both call sites in
+  its squash-merge and nothing failed, because the only tests were
+  module-level. Every agent provisioned after that ran on the CLI's default
+  persona. These tests pin the *wiring*: a provision (and a reattach) of an
+  agent with a `system` prompt must write the runtime's user-level
+  instructions file into the sandbox.
+  """
+
+  use Fountain.ConversationServerCase
+
+  @prompt "You are Desk, a dedicated operator. Never mutate without an approved plan."
+
+  setup do
+    user = insert_verified_user()
+    env = insert_env(user_id: user.id)
+
+    agent =
+      insert_agent(
+        user_id: user.id,
+        environment_id: env.id,
+        runtime: "gemini",
+        system: @prompt
+      )
+
+    {:ok, user: user, agent: agent}
+  end
+
+  defp capture_writes do
+    test = self()
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :write_file, fn _handle, path, data, _opts ->
+      send(test, {:wrote, path, data})
+      :ok
+    end)
+  end
+
+  defp assert_instructions_written do
+    path = Fountain.Runtimes.Instructions.path("gemini")
+    assert is_binary(path)
+
+    assert_receive {:wrote, ^path, data}, 2_000
+    assert data =~ @prompt
+    assert data =~ "Written by Fountain"
+  end
+
+  test "a fresh provision writes the runtime's instructions file", %{user: user, agent: agent} do
+    sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        sandbox_id: sandbox.id,
+        status: "pending"
+      )
+
+    stub_happy_sprite()
+    capture_writes()
+
+    {pid, _ref, :alive} = start_server(conv)
+    assert_instructions_written()
+    GenServer.stop(pid)
+  end
+
+  test "a reattach rewrites it, so an edited prompt reaches the existing computer", %{
+    user: user,
+    agent: agent
+  } do
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+    conv =
+      insert_conversation(user_id: user.id, agent: agent, sandbox_id: sandbox.id, status: "idle")
+
+    stub_happy_sprite()
+    capture_writes()
+
+    {pid, _ref, :alive} = start_server(conv)
+    assert_instructions_written()
+    GenServer.stop(pid)
+  end
+end


### PR DESCRIPTION
The #848 bug is back on prod: **#850's squash-merge removed #849's call sites** (`write_instructions/3` in fresh provision + reattach) — #850 was branched before #849 landed and the textual merge kept #850's side. `Fountain.Runtimes.Instructions` survived untouched; nothing calls it, so no warning is logged and every agent since this morning runs on the CLI's default persona.

Found live while standing up DNS Desk: a freshly-hired agent answered "I don't have zones to see — I'm a coding assistant"; its sandbox had no `~/.claude/CLAUDE.md` (probed from inside), while the app logs showed a clean provision.

- Restores the two call sites + the `write_instructions/3` helper, verbatim from #849.
- Adds `conversation_server_instructions_test.exs`: **wiring** tests (the #849 tests were module-level only, which is why CI stayed green through the unwiring). Verified by reverting the fix: 2/2 fail on current main, pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)