### PR TITLE
k8s: admit the demo-suite origins (CORS + OAuth clients)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -120,16 +120,17 @@ spec:
             # unverified-account pruner (#258).
             - name: UNVERIFIED_PRUNE_EXEMPT
               value: jhgaylor
-            # The standalone team app (jhgaylor/fountain-team, #810) is a
-            # static site on GitHub Pages behind jakegaylor.com; a browser
-            # there calls /api with a pasted API key. Only that origin, and
-            # only bearer keys — the plug never lets a session cookie cross.
+            # Browser clients on other origins call /api with a bearer key
+            # (never a cookie — the plug refuses credentials cross-origin):
+            # the jakegaylor.com apps (fountain-team #810 and siblings) and
+            # the demo suite on *.inevitable.fyi (one exact origin per app;
+            # the landing page demos.inevitable.fyi makes no API calls).
             - name: API_CORS_ORIGINS
-              value: https://jakegaylor.com
+              value: https://jakegaylor.com,https://arena.inevitable.fyi,https://tables.inevitable.fyi,https://reposage.inevitable.fyi,https://watchtower.inevitable.fyi,https://mission.inevitable.fyi,https://briefs.inevitable.fyi
             # The same apps may "Sign in with Fountain" (OAuth code + PKCE,
             # #818). Redirect URIs are exact.
             - name: OAUTH_CLIENTS
-              value: '[{"id":"fountain-conversations","name":"Fountain Conversations","redirect_uris":["https://jakegaylor.com/fountain-conversations/"]},{"id":"fountain-team","name":"Fountain Team","redirect_uris":["https://jakegaylor.com/fountain-team/"]},{"id":"dns-desk","name":"DNS Desk","redirect_uris":["https://jakegaylor.com/dns-desk/"]}]'
+              value: '[{"id":"fountain-conversations","name":"Fountain Conversations","redirect_uris":["https://jakegaylor.com/fountain-conversations/"]},{"id":"fountain-team","name":"Fountain Team","redirect_uris":["https://jakegaylor.com/fountain-team/"]},{"id":"dns-desk","name":"DNS Desk","redirect_uris":["https://jakegaylor.com/dns-desk/"]},{"id":"arena","name":"Arena","redirect_uris":["https://arena.inevitable.fyi/"]},{"id":"table-talk","name":"Table Talk","redirect_uris":["https://tables.inevitable.fyi/"]},{"id":"repo-sage","name":"Repo Sage","redirect_uris":["https://reposage.inevitable.fyi/"]},{"id":"watchtower","name":"Watchtower","redirect_uris":["https://watchtower.inevitable.fyi/"]},{"id":"mission-control","name":"Mission Control","redirect_uris":["https://mission.inevitable.fyi/"]},{"id":"briefing-room","name":"Briefing Room","redirect_uris":["https://briefs.inevitable.fyi/"]}]'
             # SANDBOX_IDLE_TIMEOUT_MINUTES is back at the stock 60m default.
             # The 240m override (#664) existed because idle reclaim used to
             # destroy the sandbox — and the agent's working memory — while a


### PR DESCRIPTION
Six new browser apps (the Fountain demo suite — arena/tables/reposage/watchtower/mission/briefs.inevitable.fyi, indexed at demos.inevitable.fyi) call /api cross-origin with bearer keys and sign in via OAuth code+PKCE. This adds their exact origins to `API_CORS_ORIGINS` and their public clients to `OAUTH_CLIENTS`, same shape as dns-desk (#818). Config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)