### PR TITLE
api: first_prompt on conversation JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ upgrade, is in
 
 ### Added
 
+- **`first_prompt` on conversation JSON.** `GET /api/conversations` and
+  `GET /api/conversations/:id` carry the first turn's prompt, so a client
+  can title an untitled conversation the way the web sidebar does without
+  a `/turns` call per row. Null until the first turn exists.
+
 - **A teammate with its own email address and phone number** (proof of
   concept, behind the `team_comms` feature flag). `POST
   /api/team/:agent_id/contact` provisions an AgentMail inbox and an

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -606,7 +606,9 @@ defmodule Fountain.Conversations do
   def get_conversation_with_activity(id, user_id) when is_binary(user_id) do
     case Repo.one(from(c in annotated_query(user_id), where: c.id == ^id)) do
       nil -> nil
-      conv -> Repo.preload(conv, [:sandbox, :agent, :vault])
+      # The first turn rides along, as it does on the list: `first_prompt` in
+      # the JSON is what a client titles an untitled conversation with.
+      conv -> Repo.preload(conv, [:sandbox, :agent, :vault, turns: first_turn_query()])
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -32,6 +32,11 @@ defmodule FountainWeb.ConversationJSON do
     %{
       id: c.id,
       title: c.title,
+      # The first turn's prompt, for clients that title an untitled
+      # conversation the way the console's sidebar did. Only served where the
+      # first turn was preloaded (index and show); null elsewhere and for a
+      # conversation that has no turn yet.
+      first_prompt: first_prompt(c),
       sandbox_id: c.sandbox_id,
       sandbox: sandbox_data(c.sandbox),
       agent_id: c.agent_id,
@@ -59,6 +64,9 @@ defmodule FountainWeb.ConversationJSON do
       updated_at: c.updated_at
     }
   end
+
+  defp first_prompt(%Conversation{turns: [%Turn{turn_number: 1, prompt: prompt} | _]}), do: prompt
+  defp first_prompt(_), do: nil
 
   defp tree_node(%{id: id, source: source, status: status, parent_id: parent_id}) do
     %{id: id, source: source, status: status, parent_id: parent_id}

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -151,6 +151,14 @@ defmodule FountainWeb.Schemas do
             "The external channel key this conversation is bound to, if it was created with one."
         },
         turn_count: %Schema{type: :integer},
+        first_prompt: %Schema{
+          type: :string,
+          nullable: true,
+          readOnly: true,
+          description:
+            "The first turn's prompt — what to title an untitled conversation " <>
+              "with. Null until the first turn exists."
+        },
         last_active_at: %Schema{
           type: :string,
           format: :"date-time",

--- a/apps/fountain/test/fountain_web/controllers/conversation_read_model_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_read_model_test.exs
@@ -60,6 +60,37 @@ defmodule FountainWeb.ConversationReadModelTest do
       assert json["last_active_at"]
     end
 
+    test "index and show carry the first turn's prompt; null before it exists", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      titled = insert_conversation(user_id: user.id)
+      insert_turn(titled, prompt: "Fix the flaky test in CI")
+      insert_turn(titled, turn_number: 2, prompt: "Now the other one")
+      fresh = insert_conversation(user_id: user.id)
+
+      by_id =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations")
+        |> json_response(200)
+        |> Map.fetch!("data")
+        |> Map.new(&{&1["id"], &1})
+
+      assert by_id[titled.id]["first_prompt"] == "Fix the flaky test in CI"
+      assert by_id[fresh.id]["first_prompt"] == nil
+
+      json =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/conversations/#{titled.id}")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert json["first_prompt"] == "Fix the flaky test in CI"
+    end
+
     test "a read conversation reports unread false", %{conn: conn, user: user, key: key} do
       conv = insert_conversation(user_id: user.id)
       :ok = Conversations.mark_read(conv.id, user.id)


### PR DESCRIPTION
## Summary
- `GET /api/conversations` and `GET /api/conversations/:id` now carry `first_prompt` — the first turn's prompt, null until it exists.
- `show` preloads the first turn (index already did); the JSON helper returns null when turns were not preloaded (team roster etc.), never raises.
- OpenAPI schema + a read-model test.

## Why
The standalone conversations client (jhgaylor/fountain-conversations) is being brought to parity with the LiveView UI before that UI is retired from core. The sidebar/index title an untitled conversation with its first prompt; without this field the client needs one `/turns` call per row.

## Test plan
- [x] `mix test` on the conversation/team controller tests (105, 0 failures)
- [x] compile --warnings-as-errors, credo --strict clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)