### PR TITLE
apps: one place that knows where the browser apps live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ upgrade, is in
 
 ### Added
 
+- **`Fountain.Apps` — one place that knows where the browser apps live.**
+  Conversations and the team roster are standalone single-page apps on the
+  API; `CONVERSATIONS_APP_URL` and `TEAM_APP_URL` say where (defaulting to
+  the builds hosted at jakegaylor.com, which work against any Fountain that
+  admits the origin in `API_CORS_ORIGINS`; `""` means this deployment has no
+  such app). `GET /api/catalog` now reports them as `apps`, and the links
+  that leave Fountain — a forwarded support report, the Hermes plugin's
+  `url` — point at the app rather than at a console route.
+
 - **`first_prompt` on conversation JSON.** `GET /api/conversations` and
   `GET /api/conversations/:id` carry the first turn's prompt, so a client
   can title an untitled conversation the way the web sidebar does without

--- a/apps/fountain/lib/fountain/apps.ex
+++ b/apps/fountain/lib/fountain/apps.ex
@@ -1,0 +1,85 @@
+defmodule Fountain.Apps do
+  @moduledoc """
+  Where the browser apps that sit on Fountain's API live.
+
+  Fountain's own UI is a console — accounts, keys, agents, environments,
+  vaults, audit, admin. Watching an agent work and messaging a teammate are
+  separate single-page apps on their own origins, talking to `/api` with a
+  bearer key (ADR 0021 gave them "Sign in with Fountain"). This module is the
+  one place that knows their URLs, so the console's links, an email's
+  "open it" and a forwarded support report all agree.
+
+  Both default to the apps hosted at jakegaylor.com. They are ordinary static
+  builds with **no server of their own**: the reader types their Fountain's
+  URL in, so the hosted build works against a self-hosted Fountain as soon as
+  that server admits the origin:
+
+      API_CORS_ORIGINS=https://jakegaylor.com
+
+  A deployment that would rather host its own copy points `CONVERSATIONS_APP_URL`
+  and `TEAM_APP_URL` at it (and admits *that* origin instead). Setting either
+  to an empty string says "this deployment has no such app": the console stops
+  linking to it, and the retired in-app routes redirect to the dashboard
+  rather than off-site.
+  """
+
+  @conversations "https://jakegaylor.com/fountain-conversations/"
+  @team "https://jakegaylor.com/fountain-team/"
+
+  @doc "The conversations app's base URL, or nil where the deployment has none."
+  @spec conversations() :: String.t() | nil
+  def conversations, do: get(:conversations_app_url, @conversations)
+
+  @doc "The team app's base URL, or nil where the deployment has none."
+  @spec team() :: String.t() | nil
+  def team, do: get(:team_app_url, @team)
+
+  @doc """
+  A deep link into the conversations app, or nil when there is no app.
+
+  The app routes on the fragment, so a conversation is `#/c/<id>` and its raw
+  log `#/c/<id>/logs`.
+
+      iex> Fountain.Apps.conversation_url("abc")
+      "https://jakegaylor.com/fountain-conversations/#/c/abc"
+  """
+  @spec conversation_url(String.t(), keyword()) :: String.t() | nil
+  def conversation_url(id, opts \\ []) when is_binary(id) do
+    case conversations() do
+      nil -> nil
+      base -> base <> "#/c/" <> id <> if(opts[:logs], do: "/logs", else: "")
+    end
+  end
+
+  @doc "The conversations app's new-conversation screen, or nil."
+  @spec new_conversation_url() :: String.t() | nil
+  def new_conversation_url do
+    case conversations() do
+      nil -> nil
+      base -> base <> "#/new"
+    end
+  end
+
+  @doc """
+  A deep link to one teammate in the team app, or the roster when no id is
+  given. nil where the deployment has no team app.
+  """
+  @spec team_url(String.t() | nil) :: String.t() | nil
+  def team_url(agent_id \\ nil) do
+    case {team(), agent_id} do
+      {nil, _} -> nil
+      {base, nil} -> base
+      {base, id} -> base <> "#/team/" <> id
+    end
+  end
+
+  # An unset key takes the default; an explicitly empty one means "none", which
+  # is how a deployment turns a link off rather than pointing it somewhere wrong.
+  defp get(key, default) do
+    case Application.get_env(:fountain, key, default) do
+      nil -> nil
+      "" -> nil
+      value when is_binary(value) -> String.trim_trailing(value, "/") <> "/"
+    end
+  end
+end

--- a/apps/fountain/lib/fountain/workers/support_forward.ex
+++ b/apps/fountain/lib/fountain/workers/support_forward.ex
@@ -149,7 +149,7 @@ defmodule Fountain.Workers.SupportForward do
   defp context_lines(ctx, base) do
     [
       ctx["conversation_id"] &&
-        "**Conversation:** #{base}/conversations/#{ctx["conversation_id"]} (`#{ctx["conversation_id"]}`)",
+        "**Conversation:** #{conversation_link(ctx["conversation_id"], base)} (`#{ctx["conversation_id"]}`)",
       ctx["agent_id"] &&
         "**Agent:** #{ctx["agent_name"] || ""} `#{ctx["agent_id"]}` · #{ctx["runtime"] || ""} #{ctx["model"] || ""}",
       ctx["sandbox"] && "**Sandbox:** `#{inspect(ctx["sandbox"])}`",
@@ -158,6 +158,12 @@ defmodule Fountain.Workers.SupportForward do
     ]
     |> Enum.reject(&(&1 in [nil, false]))
     |> Enum.join("\n")
+  end
+
+  # The transcript lives in the conversations app, not in Fountain's console;
+  # a deployment without one gets the API URL, which is at least fetchable.
+  defp conversation_link(id, base) do
+    Fountain.Apps.conversation_url(id) || "#{base}/api/conversations/#{id}"
   end
 
   defp first_line(message) do

--- a/apps/fountain/lib/fountain_web/controllers/catalog_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/catalog_controller.ex
@@ -3,7 +3,8 @@ defmodule FountainWeb.CatalogController do
   `GET /api/catalog`: the instance's vocabulary a client needs to build the
   agent and environment forms — runtimes and their model suggestions,
   the sandbox providers usable here and the default, the package managers
-  an environment accepts, the avatar generator's bases and moods (#815).
+  an environment accepts, the avatar generator's bases and moods (#815),
+  and where this instance's browser apps live (#866).
 
   Everything here is already public through the forms; this is the same
   lists over the API so a client on another origin does not hard-code them
@@ -26,7 +27,8 @@ defmodule FountainWeb.CatalogController do
       "Runtimes with model suggestions per runtime (suggestions, not an allowlist — " <>
         "any `provider/model` under a known provider is accepted), sandbox providers " <>
         "usable on this instance and the default, package managers an environment " <>
-        "accepts, and the avatar generator's bases and moods.",
+        "accepts, the avatar generator's bases and moods, and the URLs of the " <>
+        "browser apps this instance sends people to for conversations and the team.",
     responses: [ok: {"Catalog", "application/json", Schemas.CatalogResponse}]
   )
 
@@ -46,6 +48,12 @@ defmodule FountainWeb.CatalogController do
         avatar: %{
           bases: Fountain.AvatarGenerator.bases(),
           moods: Fountain.AvatarGenerator.moods()
+        },
+        # Where a human is sent to watch a conversation or message a teammate.
+        # Null for an app this deployment does not have.
+        apps: %{
+          conversations: Fountain.Apps.conversations(),
+          team: Fountain.Apps.team()
         }
       }
     })

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -2226,9 +2226,27 @@ defmodule FountainWeb.Schemas do
                 moods: %Schema{type: :array, items: %Schema{type: :string}}
               },
               required: [:bases, :moods]
+            },
+            apps: %Schema{
+              type: :object,
+              description:
+                "Where this instance sends a human to watch a conversation or " <>
+                  "message a teammate. Null for an app this deployment does not have.",
+              properties: %{
+                conversations: %Schema{type: :string, nullable: true},
+                team: %Schema{type: :string, nullable: true}
+              },
+              required: [:conversations, :team]
             }
           },
-          required: [:runtimes, :models, :sandbox_providers, :package_managers, :avatar]
+          required: [
+            :runtimes,
+            :models,
+            :sandbox_providers,
+            :package_managers,
+            :avatar,
+            :apps
+          ]
         }
       },
       required: [:data]

--- a/apps/fountain/test/fountain/apps_test.exs
+++ b/apps/fountain/test/fountain/apps_test.exs
@@ -1,0 +1,74 @@
+defmodule Fountain.AppsTest do
+  @moduledoc """
+  The one place that knows where the browser apps live (#866). Every link
+  that leaves the console — an email, a forwarded support report, a retired
+  route's redirect — reads it from here, so they cannot drift apart.
+  """
+
+  use ExUnit.Case, async: false
+
+  doctest Fountain.Apps
+
+  alias Fountain.Apps
+
+  setup do
+    original = {
+      Application.fetch_env(:fountain, :conversations_app_url),
+      Application.fetch_env(:fountain, :team_app_url)
+    }
+
+    on_exit(fn ->
+      case original do
+        {{:ok, c}, {:ok, t}} ->
+          Application.put_env(:fountain, :conversations_app_url, c)
+          Application.put_env(:fountain, :team_app_url, t)
+
+        _ ->
+          Application.delete_env(:fountain, :conversations_app_url)
+          Application.delete_env(:fountain, :team_app_url)
+      end
+    end)
+
+    :ok
+  end
+
+  test "defaults to the hosted apps" do
+    Application.delete_env(:fountain, :conversations_app_url)
+    Application.delete_env(:fountain, :team_app_url)
+
+    assert Apps.conversations() == "https://jakegaylor.com/fountain-conversations/"
+    assert Apps.team() == "https://jakegaylor.com/fountain-team/"
+  end
+
+  test "a configured URL wins, with exactly one trailing slash either way" do
+    Application.put_env(:fountain, :conversations_app_url, "https://apps.example.com/convs")
+    Application.put_env(:fountain, :team_app_url, "https://apps.example.com/team/")
+
+    assert Apps.conversations() == "https://apps.example.com/convs/"
+    assert Apps.team() == "https://apps.example.com/team/"
+    assert Apps.conversation_url("c1") == "https://apps.example.com/convs/#/c/c1"
+  end
+
+  test "an empty string means this deployment has no such app" do
+    Application.put_env(:fountain, :conversations_app_url, "")
+    Application.put_env(:fountain, :team_app_url, "")
+
+    assert Apps.conversations() == nil
+    assert Apps.team() == nil
+    assert Apps.conversation_url("c1") == nil
+    assert Apps.new_conversation_url() == nil
+    assert Apps.team_url() == nil
+    assert Apps.team_url("a1") == nil
+  end
+
+  test "deep links follow the apps' own hash routes" do
+    Application.put_env(:fountain, :conversations_app_url, "https://x.test/c/")
+    Application.put_env(:fountain, :team_app_url, "https://x.test/t/")
+
+    assert Apps.conversation_url("abc") == "https://x.test/c/#/c/abc"
+    assert Apps.conversation_url("abc", logs: true) == "https://x.test/c/#/c/abc/logs"
+    assert Apps.new_conversation_url() == "https://x.test/c/#/new"
+    assert Apps.team_url() == "https://x.test/t/"
+    assert Apps.team_url("agent-1") == "https://x.test/t/#/team/agent-1"
+  end
+end

--- a/apps/fountain/test/fountain/support_test.exs
+++ b/apps/fountain/test/fountain/support_test.exs
@@ -110,7 +110,9 @@ defmodule Fountain.SupportTest do
       assert_received {:github, "https://api.github.com/repos/o/r/issues", opts}
       assert opts[:json].title == "[bug] first line"
       assert opts[:json].body =~ "coo"
-      assert opts[:json].body =~ "/conversations/c1"
+      # The transcript link goes to the conversations app, not to a console
+      # route that no longer exists (#866).
+      assert opts[:json].body =~ Fountain.Apps.conversation_url("c1")
       assert opts[:json].body =~ user.email
       assert {"authorization", "Bearer tok"} in opts[:headers]
     end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -971,6 +971,21 @@ config :fountain,
        |> String.split(",", trim: true)
        |> Enum.map(&String.trim/1)
 
+# ── The browser apps on top of the API ────────────────────────────────────
+#
+# Fountain's own UI is a console; conversations and the team roster are
+# separate single-page apps (Fountain.Apps). Both default to the builds
+# hosted at jakegaylor.com, which work against any Fountain the reader types
+# in — provided this server admits that origin in API_CORS_ORIGINS. Point
+# these at your own deployment instead, or set one to "" to say this
+# deployment has no such app.
+for {key, env} <- [conversations_app_url: "CONVERSATIONS_APP_URL", team_app_url: "TEAM_APP_URL"] do
+  case System.get_env(env) do
+    nil -> :ok
+    value -> config :fountain, key, String.trim(value)
+  end
+end
+
 # ── OAuth clients ─────────────────────────────────────────────────────────
 #
 # The public browser apps allowed to sign in with Fountain (#818), as JSON:

--- a/docs/api.md
+++ b/docs/api.md
@@ -165,7 +165,7 @@ Agent objects carry `conversation_count`; environments carry `secret_count` and 
 ## Catalog
 
 ```
-GET  /api/catalog             # runtimes, model suggestions per runtime, sandbox providers, package managers, avatar bases/moods
+GET  /api/catalog             # runtimes, model suggestions per runtime, sandbox providers, package managers, avatar bases/moods, app URLs
 POST /api/avatars/generate    # {base, mood} → {data (base64 PNG), media_type}; attach with PUT /api/agents/:id/avatar
 ```
 
@@ -176,6 +176,14 @@ allowlist — any `provider/model` under a known provider is accepted.
 environment's `packages` (`apt`, `npm`); other keys are stored and ignored.
 Avatar generation uses the tenant's own OpenAI credential (`422
 no_openai_key` without one).
+
+`apps` is where this instance sends a human to *read* something — the
+standalone [conversations](https://github.com/jhgaylor/fountain-conversations)
+and [team](https://github.com/jhgaylor/fountain-team) apps, which route on the
+fragment (`…/#/c/<conversation_id>`, `…/#/team/<agent_id>`). Either is null
+where the deployment has no such app. Use it instead of composing a URL
+against the API host: Fountain's own UI is a console and does not serve
+transcripts.
 
 ## Environments
 

--- a/integrations/hermes/fountain/tools.py
+++ b/integrations/hermes/fountain/tools.py
@@ -16,11 +16,15 @@ the whole life of a long turn.
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 from typing import Any, Callable
 
 from .client import FountainClient, FountainError
+
+# The standalone conversations app Fountain sends people to for a transcript.
+DEFAULT_APP_URL = "https://jakegaylor.com/fountain-conversations/"
 
 TERMINAL_TURN_STATES = ("done", "failed", "interrupted")
 TERMINAL_CONVERSATION_STATUSES = ("failed", "terminated")
@@ -153,7 +157,7 @@ class FountainTools:
             "conversation_id": conv_id,
             "agent": {"id": agent.get("id"), "name": agent.get("name"), "runtime": agent.get("runtime")},
             "turn_number": 1,
-            "url": f"{client.base_url}/conversations/{conv_id}",
+            "url": conversation_url(conv_id, client.base_url),
         }
         if args.get("wait") is False:
             return {**base, "status": conv.get("status"), "done": False,
@@ -169,7 +173,7 @@ class FountainTools:
         client.send_prompt(conv_id, prompt)
         self.tracker.follow(conv_id, next_turn)
         base = {"conversation_id": conv_id, "turn_number": next_turn,
-                "url": f"{client.base_url}/conversations/{conv_id}"}
+                "url": conversation_url(conv_id, client.base_url)}
         if args.get("wait") is False:
             return {**base, "status": "queued", "done": False,
                     "note": "Not waiting. Call fountain_wait with this conversation_id to collect the answer."}
@@ -188,7 +192,7 @@ class FountainTools:
                         "output": "", "note": "This conversation has no turns yet."}
             self.tracker.follow(conv_id, latest)
         return {"conversation_id": conv_id, "turn_number": st["turn_number"],
-                "url": f"{client.base_url}/conversations/{conv_id}",
+                "url": conversation_url(conv_id, client.base_url),
                 **self._follow(client, conv_id, self._timeout(args))}
 
     def _status(self, args: dict) -> dict:
@@ -387,6 +391,20 @@ def _clip(text: str, limit: int) -> str:
     return text[:head] + f"\n…[{len(text) - limit} chars elided]…\n" + text[-tail:]
 
 
+def conversation_url(conv_id: str, base_url: str) -> str:
+    """Where a human reads this conversation.
+
+    Fountain's own UI is a console; the transcript lives in the standalone
+    conversations app, which routes on the fragment. `FOUNTAIN_APP_URL`
+    points at a different deployment of it (or at "" to fall back to the
+    API URL, which is at least fetchable).
+    """
+    app = os.environ.get("FOUNTAIN_APP_URL", DEFAULT_APP_URL).strip()
+    if not app:
+        return f"{base_url}/api/conversations/{conv_id}"
+    return f"{app.rstrip('/')}/#/c/{conv_id}"
+
+
 def _conversation_summary(c: dict, base_url: str) -> dict:
     return {
         "id": c.get("id"),
@@ -397,5 +415,5 @@ def _conversation_summary(c: dict, base_url: str) -> dict:
         "turn_count": c.get("turn_count"),
         "last_active_at": c.get("last_active_at"),
         "unread": c.get("unread"),
-        "url": f"{base_url}/conversations/{c.get('id')}",
+        "url": conversation_url(str(c.get("id")), base_url),
     }

--- a/integrations/hermes/tests/test_plugin.py
+++ b/integrations/hermes/tests/test_plugin.py
@@ -158,7 +158,7 @@ class RunTests(unittest.TestCase):
             self.assertEqual(out["tools_used"], ["read_file", "terminal"])
             self.assertEqual(out["exit_code"], 0)
             self.assertEqual(out["agent"]["name"], "reviewer")
-            self.assertEqual(out["url"], f"{fake.base_url}/conversations/c-1")
+            self.assertEqual(out["url"], "https://jakegaylor.com/fountain-conversations/#/c/c-1")
             create = next(b for m, p, b, _ in st.requests if m == "POST" and p == "/api/conversations")
             self.assertEqual(create, {"agent_id": "a-1", "prompt": "say hi", "vault_id": "v-1"})
 


### PR DESCRIPTION
## Why
`fountain-conversations` and `fountain-team` are the UI now; Fountain's own pages are becoming a console. Several links still point at console routes that are about to be retired — a forwarded support report's **Conversation:** line, the Hermes plugin's `url` field.

## What
- `Fountain.Apps` — `conversations/0`, `team/0`, `conversation_url/2`, `new_conversation_url/0`, `team_url/1`. Configured by `CONVERSATIONS_APP_URL` / `TEAM_APP_URL`.
  - Default: the hosted builds at jakegaylor.com. They're static and take the reader's own Fountain URL as input, so the default works for a **self-hosted** server too — it just has to admit `https://jakegaylor.com` in `API_CORS_ORIGINS`.
  - `""` means "this deployment has no such app": every link turns off rather than pointing somewhere wrong.
- `GET /api/catalog` gains `apps: {conversations, team}` so clients discover it instead of composing URLs against the API host.
- `SupportForward` and the Hermes plugin link into the app (`…/#/c/<id>`).

No routes change here; this is the seam the removal PR builds on.

## Test plan
- [x] `mix test` on apps / support / catalog (14 tests + doctest, 0 failures)
- [x] `python3 -m pytest integrations/hermes/tests` — 19 passed
- [x] `mix format`, compile with warnings-as-errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)