### PR TITLE
docs: tell a self-hoster where the conversation UI went

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,23 @@ upgrade, is in
     that used it; the bearer route (`/api/conversations/:id/turns/:id/images/:n`)
     is unchanged.
 
+  **Upgrade notes — self-hosted.** `/conversations` and `/team` now send a
+  browser to the hosted apps at `https://jakegaylor.com`. They are static
+  builds that take *your* Fountain's URL as input, so they work against your
+  server — but only once it admits that origin:
+
+  ```
+  API_CORS_ORIGINS=https://jakegaylor.com          # add to what you already set
+  ```
+
+  Add `https://jakegaylor.com/fountain-conversations/` and
+  `.../fountain-team/` to `OAUTH_CLIENTS` too if you want "Sign in with
+  Fountain" rather than pasting an API key. Prefer to host your own copies?
+  Point `CONVERSATIONS_APP_URL` / `TEAM_APP_URL` at them. Prefer neither? Set
+  both to `""`: the console stops offering them and the old paths land on the
+  dashboard instead of sending anyone off-site. Nothing about the API
+  changes — a deployment driven by the CLI or `/api` is unaffected either way.
+
 ### Added
 
 - **`Fountain.Apps` — one place that knows where the browser apps live.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Fountain
 
-Fountain is a **multi-tenant API and UI** for managing agents, repos, secrets, and conversations. It's for people who want to create sandboxed coding agent instances with preconfigured sets of env vars, MCP servers, skills, repos, and packages.
+Fountain is a **multi-tenant API** for managing agents, repos, secrets, and conversations, with an operator console over it and standalone apps for watching an agent work. It's for people who want to create sandboxed coding agent instances with preconfigured sets of env vars, MCP servers, skills, repos, and packages.
 
 !!! tip "In a hurry?"
     Install the CLI and point it at a Fountain instance:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -52,6 +52,33 @@ login. With the compose defaults (`EMAIL_DELIVERY=none`,
 being the first, is promoted to admin, recorded in the admin audit trail
 like any other role grant (ADR 0011).
 
+### Watching an agent work
+
+Fountain's own UI is a console — the account, its keys, and the agents,
+environments and vaults a conversation runs on. Watching a conversation turn
+by turn, and messaging an agent as a teammate, are separate single-page apps
+that talk to your `/api`:
+
+| | |
+|---|---|
+| [Conversations](https://jakegaylor.com/fountain-conversations/) | start a run, watch it, steer it, read the raw log |
+| [Team](https://jakegaylor.com/fountain-team/) | your agents as teammates, one thread each |
+
+They are static builds with no server of their own: you type your Fountain's
+URL in, so the hosted copies above work against your deployment as soon as it
+admits the origin —
+
+```bash
+echo "API_CORS_ORIGINS=https://jakegaylor.com" >> .env
+```
+
+— and, if you would rather click "Sign in with Fountain" than paste an API
+key, register them in `OAUTH_CLIENTS` (see the
+[configuration reference](configuration.md)). The console links to whatever
+`CONVERSATIONS_APP_URL` and `TEAM_APP_URL` say, so pointing those at your own
+build of either repo works the same way; setting them to `""` tells the
+console this deployment has neither, and it stops offering them.
+
 Then close registration so nobody else can join:
 
 ```bash


### PR DESCRIPTION
## Why
#869 made the web UI a console and said so in the changelog — without saying what an operator has to *do*. On upgrade, `/conversations` starts sending a browser to a static app on another origin, and that app can't call their server until it admits the origin. One line, but not one they can guess.

## What
- **Upgrade notes** on the changelog entry: the `API_CORS_ORIGINS` line, the `OAUTH_CLIENTS` option, and the three ways to answer it — use the hosted builds, point `CONVERSATIONS_APP_URL`/`TEAM_APP_URL` at your own, or set them to `""` and have the console stop offering them. Plus the reassurance that matters: nothing about the API changes, so a CLI/API-driven deployment is unaffected.
- **`docs/self-hosting.md`** gains a "Watching an agent work" section right after first login, where someone actually hits the question.
- **`docs/index.md`** no longer opens with "a multi-tenant API **and UI**".

## Test plan
- [x] `mkdocs build --strict` — clean
- [x] `mix test apps/fountain/test/fountain/docs_test.exs` — the nav-drift guard still passes (prose-only edits, no nav change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)