### PR TITLE
feat(agui): Fountain speaks AG-UI, so an OpenBot coworker can be a Fountain agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,19 @@ upgrade, is in
 
 ### Added
 
+- **Fountain speaks AG-UI.** `POST /api/agui/:agent_id` answers the
+  [AG-UI](https://github.com/ag-ui-protocol/ag-ui) protocol's `RunAgentInput`
+  with its SSE event stream, so any AG-UI host registers a Fountain agent with
+  a URL and a bearer token — CopilotKit's
+  [OpenBot](https://copilotkit.ai/openbot), where a coworker *is* an AG-UI
+  endpoint, is the host it was built against. The host's thread binds to one
+  conversation (`agui:<threadId>`), so one channel is one sandbox and the
+  agent's memory stays where it lives rather than being replayed as a
+  transcript each turn. Tool use and lifecycle stages relay as AG-UI thinking
+  events; no AG-UI *tool call* is emitted, because a Fountain agent runs its
+  tools in its own sandbox and already has the result. See
+  [OpenBot (AG-UI)](https://binarybourbon.github.io/fountain/integrations/openbot/).
+
 - **Usage on the console's dashboard.** A "This month" row — conversations,
   turns, sandbox time, and tokens in/out — on the same calendar the billing
   page uses (`Billing.current_month_range/0`, promoted out of two identical

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1164,6 +1164,24 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  The id of a conversation's newest log event, or `0` when it has none.
+
+  A cursor for "everything from here on", which is what a caller about to
+  prompt a live conversation needs: the events its own turn produces, without
+  the ones a previous turn already wrote. Ownership rides on the conversation —
+  reach it through a tenant-scoped fetch first.
+  """
+  @spec _unsafe_latest_log_event_id(String.t()) :: integer()
+  def _unsafe_latest_log_event_id(conversation_id) when is_binary(conversation_id) do
+    from(e in LogEvent,
+      where: e.conversation_id == ^conversation_id,
+      select: max(e.id)
+    )
+    |> Repo.one()
+    |> Kernel.||(0)
+  end
+
+  @doc """
   List a conversation's log events after `after_id`, oldest first.
 
   Options:

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -51,6 +51,7 @@ defmodule Fountain.Docs do
        {"Editors (ACP)", "integrations/editors.md"},
        {"OpenClaw (ACP)", "integrations/openclaw.md"},
        {"Hermes Agent (plugin)", "integrations/hermes.md"},
+       {"OpenBot (AG-UI)", "integrations/openbot.md"},
        {"Buzz (Nostr)", "integrations/buzz.md"},
        {"GitHub OAuth", "integrations/github-oauth.md"},
        {"Stripe", "integrations/stripe.md"},

--- a/apps/fountain/lib/fountain_web/controllers/agui_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agui_controller.ex
@@ -1,0 +1,548 @@
+defmodule FountainWeb.AguiController do
+  @moduledoc """
+  A Fountain agent answering as an [AG-UI](https://github.com/ag-ui-protocol/ag-ui)
+  endpoint.
+
+  `POST /api/agui/:agent_id` takes the protocol's `RunAgentInput` and answers
+  with its SSE event stream, so an AG-UI host can register a Fountain agent
+  knowing nothing about Fountain's own API — one URL and a bearer token. The
+  host this was built against is CopilotKit's OpenBot, where a "Bot" is exactly
+  that: an endpoint speaking AG-UI. See `docs/integrations/openbot.md`.
+
+  ## The thread is the conversation
+
+  An AG-UI host holds the transcript and replays the whole message list on every
+  run, expecting the endpoint to keep no memory of its own. A Fountain
+  conversation is the opposite: the sandbox holds the context, and feeding it
+  back its own transcript each turn would be both wrong and expensive.
+
+  So the thread is *mapped* to a conversation rather than replayed into one.
+  `threadId` becomes the channel binding `agui:<threadId>` — the same mechanism
+  the team page resumes on (#774) — and only the newest user message of each run
+  is sent as a prompt. The first run on a thread opens the conversation; every
+  later run prompts the one already bound. A host that starts a new thread gets
+  a new sandbox, which is what starting a new channel should mean.
+
+  The standing role (the host's `system`/`developer` messages) rides along with
+  the first prompt only. Editing it afterwards reaches new threads, not the
+  sandbox that already booted with it.
+
+  ## One run is one turn
+
+  `RUN_STARTED` goes out immediately, then the turn's log events are translated
+  as they arrive, then `RUN_FINISHED` when the turn ends (`RUN_ERROR` if it
+  failed). `text` blocks stream as the assistant's message. Everything else the
+  turn does — `thinking`, `tool_use`, `tool_result`, and the lifecycle stages,
+  because provisioning a fresh sandbox takes a minute and silence reads as a
+  hang — streams as AG-UI *thinking* events, which a host renders as reasoning.
+
+  Nothing here is emitted as an AG-UI **tool call**. On this protocol a tool call
+  means "host, run this and send me the result", and that is not what happened: a
+  Fountain agent ran its own tool, inside its own sandbox, and already has the
+  result. Reporting it as a call would ask the host to execute something twice
+  and leave the run waiting for a result it will never be sent. Bridging the
+  host's tools *into* the sandbox is the other half of the integration and is
+  deliberately not in this one.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{Blocks, ConversationServer, LogEvent}
+  alias FountainWeb.Audited
+
+  action_fallback FountainWeb.FallbackController
+
+  tags(["Integrations"])
+
+  @run_input %OpenApiSpex.Schema{
+    type: :object,
+    title: "RunAgentInput",
+    description:
+      "The AG-UI run envelope, as the protocol defines it. Extra fields are accepted " <>
+        "and ignored: only `threadId`, `runId` and `messages` are read.",
+    properties: %{
+      threadId: %OpenApiSpex.Schema{
+        type: :string,
+        description: "The host's thread. Bound to one Fountain conversation as `agui:<threadId>`."
+      },
+      runId: %OpenApiSpex.Schema{type: :string, description: "This run. Echoed in the events."},
+      messages: %OpenApiSpex.Schema{
+        type: :array,
+        items: %OpenApiSpex.Schema{type: :object},
+        description:
+          "The thread so far. The newest `user` message becomes the prompt; " <>
+            "`system`/`developer` messages become the standing role of a new conversation."
+      },
+      tools: %OpenApiSpex.Schema{
+        type: :array,
+        items: %OpenApiSpex.Schema{type: :object},
+        description: "Accepted and ignored — see the module doc on why no tool call is emitted."
+      },
+      state: %OpenApiSpex.Schema{type: :object},
+      context: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :object}},
+      forwardedProps: %OpenApiSpex.Schema{type: :object}
+    },
+    required: [:threadId, :runId, :messages]
+  }
+
+  operation(:run,
+    summary: "Run an agent over AG-UI (SSE)",
+    description:
+      "Answers a `RunAgentInput` with the AG-UI event stream: `RUN_STARTED`, the turn's " <>
+        "output as `TEXT_MESSAGE_*` and `THINKING_*` events, then `RUN_FINISHED` or " <>
+        "`RUN_ERROR`. Each SSE message is `data: {\"type\": ...}`, as the reference " <>
+        "encoder writes it.\n\n" <>
+        "`threadId` binds to a conversation (`agui:<threadId>`): the first run opens one, " <>
+        "later runs prompt it. Only the newest user message is sent — the agent's memory " <>
+        "lives in its sandbox, not in the replayed transcript.\n\n" <>
+        "Errors before the stream opens are ordinary JSON responses (404 for an unknown " <>
+        "agent, 402 without a subscription); once it is open, failure arrives as `RUN_ERROR`.",
+    parameters: [
+      agent_id: [in: :path, type: :string, required: true, description: "The agent to run."],
+      activity: [
+        in: :query,
+        type: :string,
+        required: false,
+        description:
+          "`off` streams the reply text only. Default `thinking`: tool use and lifecycle " <>
+            "stages are relayed as AG-UI thinking events too, which is also what keeps a " <>
+            "host's stall watchdog fed while a sandbox provisions."
+      ]
+    ],
+    request_body: {"AG-UI run input", "application/json", @run_input},
+    responses: [
+      ok: {"AG-UI event stream", "text/event-stream", %OpenApiSpex.Schema{type: :string}},
+      bad_request: {"Malformed run input", "application/json", FountainWeb.Schemas.Error},
+      not_found: {"No such agent", "application/json", FountainWeb.Schemas.Error}
+    ]
+  )
+
+  def run(conn, %{"agent_id" => agent_id} = params) do
+    user = conn.assigns.current_user
+
+    with {:ok, thread_id} <- require_string(params["threadId"], "threadId"),
+         {:ok, run_id} <- require_string(params["runId"], "runId"),
+         messages = List.wrap(params["messages"]),
+         {:ok, prompt} <- last_user_message(messages),
+         {:ok, conv, since} <- open(conn, agent_id, user, thread_id, prompt, messages) do
+      stream(conn, conv, thread_id, run_id, since, params)
+    end
+  end
+
+  ## ─── Opening the conversation ─────────────────────────────────────────────
+
+  # Bind, prompt, and hand back the log-event id everything after which belongs
+  # to this run. Subscription happens before the prompt is sent, and the caller
+  # replays from `since` anyway, so no event can fall between the two.
+  defp open(conn, agent_id, user, thread_id, prompt, messages) do
+    attrs = %{
+      "agent_id" => agent_id,
+      "user_id" => user.id,
+      "channel_id" => channel_id(thread_id),
+      "source" => "api",
+      "prompt" => first_prompt(standing_role(messages), prompt)
+    }
+
+    case Conversations.start_or_resume_conversation(attrs, Audited.attribution(conn)) do
+      {:ok, conv, :created} ->
+        subscribe(conv.id)
+        # A conversation opened by this request has no earlier events to skip.
+        {:ok, conv, 0}
+
+      {:ok, conv, :resumed} ->
+        subscribe(conv.id)
+
+        # Ownership: established by start_or_resume_conversation directly
+        # above, which resolves the conversation scoped by user_id.
+        since = Conversations._unsafe_latest_log_event_id(conv.id)
+
+        case ConversationServer.send_prompt(conv.id, prompt, [], Audited.attribution(conn)) do
+          :ok -> {:ok, conv, since}
+          {:error, :busy} -> {:error, "conversation_busy"}
+          {:error, _} = err -> err
+        end
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp subscribe(conv_id), do: Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv_id}")
+
+  @doc """
+  The channel a host's thread binds to.
+
+  Namespaced because a channel id is a shared vocabulary — `fountain:team` is
+  the team page's — and a bare thread id from someone else's product must not
+  be able to collide with one of ours.
+  """
+  @spec channel_id(String.t()) :: String.t()
+  def channel_id(thread_id), do: "agui:" <> thread_id
+
+  @doc """
+  The prompt a brand-new conversation opens with: the standing role, then the
+  message.
+
+  The host re-sends its role on every run. It is only of use on the first,
+  where it is what the sandbox boots knowing; afterwards the agent has it, and
+  repeating it every turn would be noise in the transcript and tokens on the
+  bill. The cost is that editing a role in the host reaches new threads, not
+  the sandbox that already booted with it.
+  """
+  @spec first_prompt(String.t(), String.t()) :: String.t()
+  def first_prompt("", prompt), do: prompt
+  def first_prompt(role, prompt), do: role <> "\n\n" <> prompt
+
+  defp standing_role(messages) do
+    messages
+    |> Enum.filter(&(is_map(&1) and &1["role"] in ["system", "developer"]))
+    |> Enum.map(&content_text/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n\n")
+  end
+
+  defp last_user_message(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find(&(is_map(&1) and &1["role"] == "user"))
+    |> case do
+      nil -> {:error, "no user message in this run"}
+      message -> non_empty(content_text(message), "the newest user message has no text")
+    end
+  end
+
+  defp non_empty("", reason), do: {:error, reason}
+  defp non_empty(text, _reason), do: {:ok, text}
+
+  # AG-UI carries message content as a string. Multi-part content is not in the
+  # 0.0.57 schema but costs two lines to survive, and a host that sends it would
+  # otherwise look to the user like an agent that ignored them.
+  defp content_text(%{"content" => content}) when is_binary(content), do: content
+
+  defp content_text(%{"content" => parts}) when is_list(parts) do
+    Enum.map_join(parts, "", fn
+      %{"text" => text} when is_binary(text) -> text
+      text when is_binary(text) -> text
+      _ -> ""
+    end)
+  end
+
+  defp content_text(_), do: ""
+
+  defp require_string(value, _field) when is_binary(value) and value != "", do: {:ok, value}
+  defp require_string(_value, field), do: {:error, "#{field} is required"}
+
+  ## ─── The stream ───────────────────────────────────────────────────────────
+
+  @default_heartbeat_ms 15_000
+  @default_quiet_timeout_ms 600_000
+
+  defp heartbeat_ms, do: Application.get_env(:fountain, :sse_heartbeat_ms, @default_heartbeat_ms)
+
+  # How long the conversation may produce nothing at all before the run is
+  # abandoned. Not a ceiling on the turn: any log event resets it, and a working
+  # agent emits them constantly. It is the backstop for a conversation that
+  # stops existing without saying so.
+  defp quiet_timeout_ms,
+    do: Application.get_env(:fountain, :agui_quiet_timeout_ms, @default_quiet_timeout_ms)
+
+  defp stream(conn, conv, thread_id, run_id, since, params) do
+    # Best-effort, exactly as in the log stream: no server means a conversation
+    # that is idle or already finished, which the replay below still covers.
+    monitor_ref =
+      case ConversationServer.whereis(conv.id) do
+        pid when is_pid(pid) -> Process.monitor(pid)
+        _ -> nil
+      end
+
+    conn =
+      conn
+      |> put_resp_header("content-type", "text/event-stream")
+      |> put_resp_header("cache-control", "no-cache")
+      |> put_resp_header("connection", "keep-alive")
+      |> send_chunked(200)
+
+    state = %{
+      conn: conn,
+      conv_id: conv.id,
+      runtime: conv.runtime,
+      thread_id: thread_id,
+      run_id: run_id,
+      last_id: since,
+      turn_id: nil,
+      text_id: nil,
+      thinking?: false,
+      seq: 0,
+      activity?: params["activity"] != "off",
+      monitor_ref: monitor_ref,
+      deadline: now_ms() + quiet_timeout_ms()
+    }
+
+    case emit(state, "RUN_STARTED", %{threadId: thread_id, runId: run_id}) do
+      {:ok, state} ->
+        Process.send_after(self(), :heartbeat, heartbeat_ms())
+
+        case replay(state, since) do
+          {:ok, state} -> loop(state)
+          {_halted, state} -> state.conn
+        end
+
+      {:closed, state} ->
+        state.conn
+    end
+  end
+
+  # Events written between the prompt and the subscription — for a fresh
+  # conversation, everything provisioning has done so far.
+  defp replay(state, since) do
+    # Ownership: the conversation was resolved scoped by user_id in open/6,
+    # which is the only caller path into this stream.
+    state.conv_id
+    |> Conversations._unsafe_list_log_events(since)
+    |> Enum.reduce_while({:ok, state}, fn ev, {:ok, state} ->
+      case handle_event(%{state | last_id: ev.id}, ev) do
+        {:ok, state} -> {:cont, {:ok, state}}
+        halted -> {:halt, halted}
+      end
+    end)
+  end
+
+  defp loop(state) do
+    case receive_next(state) do
+      {:event, %LogEvent{id: id} = ev} ->
+        case handle_event(%{state | last_id: id, deadline: now_ms() + quiet_timeout_ms()}, ev) do
+          {:ok, state} -> loop(state)
+          {_halted, state} -> state.conn
+        end
+
+      :stale ->
+        loop(state)
+
+      :heartbeat ->
+        # A comment, not an event: it keeps the connection (and a host's
+        # silence watchdog) alive without appearing in the protocol.
+        case Plug.Conn.chunk(state.conn, ": heartbeat\n\n") do
+          {:ok, conn} ->
+            Process.send_after(self(), :heartbeat, heartbeat_ms())
+            loop(%{state | conn: conn})
+
+          {:error, _} ->
+            state.conn
+        end
+
+      {:server_down, reason} ->
+        {_, state} =
+          fail(state, "the conversation stopped running (#{inspect(reason)}) — retry to resume")
+
+        state.conn
+
+      :quiet ->
+        {_, state} = fail(state, "the conversation went quiet; nothing arrived for the timeout")
+        state.conn
+    end
+  end
+
+  defp receive_next(state) do
+    ref = state.monitor_ref
+
+    receive do
+      {:log_event, %LogEvent{id: id} = ev} when id > state.last_id -> {:event, ev}
+      {:log_event, _stale} -> :stale
+      :heartbeat -> :heartbeat
+      {:DOWN, ^ref, :process, _pid, reason} when is_reference(ref) -> {:server_down, reason}
+    after
+      max(state.deadline - now_ms(), 0) -> :quiet
+    end
+  end
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  ## ─── Log events → AG-UI events ────────────────────────────────────────────
+
+  # The turn this run is waiting for. A conversation can only run one at a
+  # time, so the first `started` after our cursor is ours.
+  defp handle_event(%{turn_id: nil} = state, %LogEvent{stage: "turn", state: "started"} = ev) do
+    case meta(ev)["turn_id"] do
+      turn_id when is_binary(turn_id) -> {:ok, %{state | turn_id: turn_id}}
+      _ -> {:ok, state}
+    end
+  end
+
+  defp handle_event(%{turn_id: turn_id} = state, %LogEvent{stage: "turn", state: state_name} = ev)
+       when is_binary(turn_id) and state_name in ~w(done failed interrupted) do
+    if meta(ev)["turn_id"] == turn_id do
+      finish(state, state_name, meta(ev))
+    else
+      {:ok, state}
+    end
+  end
+
+  defp handle_event(%{turn_id: turn_id} = state, %LogEvent{kind: "output", turn_id: turn_id} = ev)
+       when is_binary(turn_id) do
+    ev
+    |> Blocks.for_event(state.runtime)
+    |> Enum.reduce_while({:ok, state}, fn block, {:ok, state} ->
+      case apply_block(state, block) do
+        {:ok, state} -> {:cont, {:ok, state}}
+        halted -> {:halt, halted}
+      end
+    end)
+  end
+
+  # A stage that failed before any turn started — provisioning died, the
+  # sandbox never came up. Nothing else will arrive, so end the run rather than
+  # wait out the quiet timeout.
+  defp handle_event(%{turn_id: nil} = state, %LogEvent{kind: "stage", state: "failed"} = ev) do
+    reason = meta(ev)["reason"] || meta(ev)["message"] || "no reason given"
+    fail(state, "#{ev.stage} failed: #{reason}")
+  end
+
+  # Everything else — provision/setup/sandbox progress — is worth showing while
+  # a first run waits for its sandbox, and worth nothing after that.
+  defp handle_event(%{turn_id: nil} = state, %LogEvent{kind: "stage"} = ev) do
+    activity(state, "#{ev.stage}: #{ev.state}\n")
+  end
+
+  defp handle_event(state, _ev), do: {:ok, state}
+
+  defp meta(%LogEvent{data: data}) when is_binary(data) do
+    case Jason.decode(data) do
+      {:ok, %{} = decoded} -> decoded
+      _ -> %{}
+    end
+  end
+
+  defp meta(_ev), do: %{}
+
+  defp apply_block(state, %{kind: :text, body: body}) when is_binary(body) and body != "",
+    do: write(state, :text, body)
+
+  defp apply_block(state, %{kind: :thinking, body: body}) when is_binary(body) and body != "",
+    do: activity(state, body)
+
+  defp apply_block(state, %{kind: :tool_use} = block),
+    do: activity(state, "→ #{block[:name] || "tool"}#{summary(block)}\n")
+
+  defp apply_block(state, %{kind: :tool_result, error?: true}), do: activity(state, "← failed\n")
+  defp apply_block(state, %{kind: :tool_result}), do: activity(state, "← ok\n")
+
+  defp apply_block(state, %{kind: :error, body: body}) when is_binary(body) and body != "",
+    do: activity(state, "error: #{body}\n")
+
+  defp apply_block(state, _block), do: {:ok, state}
+
+  defp summary(%{summary: summary}) when is_binary(summary) and summary != "", do: " #{summary}"
+  defp summary(_block), do: ""
+
+  ## ─── Emitting ─────────────────────────────────────────────────────────────
+
+  # Text goes to the assistant message; everything else to the thinking region.
+  # The two cannot be open at once, so each opens by closing the other.
+  defp write(state, :text, delta) do
+    with {:ok, state} <- close_thinking(state),
+         {:ok, state} <- open_text(state) do
+      emit(state, "TEXT_MESSAGE_CONTENT", %{messageId: state.text_id, delta: delta})
+    end
+  end
+
+  defp write(state, :thinking, delta) do
+    with {:ok, state} <- close_text(state),
+         {:ok, state} <- open_thinking(state) do
+      emit(state, "THINKING_TEXT_MESSAGE_CONTENT", %{delta: delta})
+    end
+  end
+
+  defp activity(%{activity?: false} = state, _delta), do: {:ok, state}
+  defp activity(state, delta), do: write(state, :thinking, delta)
+
+  defp open_text(%{text_id: nil} = state) do
+    message_id = "msg_#{state.run_id}_#{state.seq}"
+
+    with {:ok, state} <-
+           emit(state, "TEXT_MESSAGE_START", %{messageId: message_id, role: "assistant"}) do
+      {:ok, %{state | text_id: message_id, seq: state.seq + 1}}
+    end
+  end
+
+  defp open_text(state), do: {:ok, state}
+
+  defp close_text(%{text_id: nil} = state), do: {:ok, state}
+
+  defp close_text(state) do
+    with {:ok, state} <- emit(state, "TEXT_MESSAGE_END", %{messageId: state.text_id}) do
+      {:ok, %{state | text_id: nil}}
+    end
+  end
+
+  defp open_thinking(%{thinking?: false} = state) do
+    with {:ok, state} <- emit(state, "THINKING_START", %{}),
+         {:ok, state} <- emit(state, "THINKING_TEXT_MESSAGE_START", %{}) do
+      {:ok, %{state | thinking?: true}}
+    end
+  end
+
+  defp open_thinking(state), do: {:ok, state}
+
+  defp close_thinking(%{thinking?: false} = state), do: {:ok, state}
+
+  defp close_thinking(state) do
+    with {:ok, state} <- emit(state, "THINKING_TEXT_MESSAGE_END", %{}),
+         {:ok, state} <- emit(state, "THINKING_END", %{}) do
+      {:ok, %{state | thinking?: false}}
+    end
+  end
+
+  defp finish(state, "failed", meta) do
+    fail(state, meta["reason"] || "the turn failed")
+  end
+
+  defp finish(state, state_name, meta) do
+    with {:ok, state} <- interrupted_note(state, state_name),
+         {:ok, state} <- close_text(state),
+         {:ok, state} <- close_thinking(state),
+         {:ok, state} <-
+           emit(state, "RUN_FINISHED", %{
+             threadId: state.thread_id,
+             runId: state.run_id,
+             result: %{
+               conversationId: state.conv_id,
+               turnId: state.turn_id,
+               stopReason: stop_reason(meta)
+             }
+           }) do
+      {:done, state}
+    end
+  end
+
+  defp interrupted_note(state, "interrupted"), do: activity(state, "\n(interrupted)\n")
+  defp interrupted_note(state, _state_name), do: {:ok, state}
+
+  defp stop_reason(meta), do: meta["stop_reason"] || meta["reason"]
+
+  # RUN_ERROR is terminal for the protocol, so both channels close first: a
+  # host that renders a half-open message would keep it spinning forever.
+  defp fail(state, message) do
+    with {:ok, state} <- close_text(state),
+         {:ok, state} <- close_thinking(state),
+         {:ok, state} <- emit(state, "RUN_ERROR", %{message: message}) do
+      {:done, state}
+    end
+  end
+
+  # One SSE message per event, the type inside the JSON — the shape the
+  # reference AG-UI encoder writes and every client parses.
+  defp emit(state, type, fields) do
+    payload = fields |> Map.put(:type, type) |> Jason.encode!()
+
+    case Plug.Conn.chunk(state.conn, "data: #{payload}\n\n") do
+      {:ok, conn} ->
+        {:ok, %{state | conn: conn}}
+
+      # The host hung up mid-run. Routine (a closed tab, an abandoned run), and
+      # nothing is left to say to a socket that is gone.
+      {:error, _reason} ->
+        {:closed, state}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -463,6 +463,12 @@ defmodule FountainWeb.Router do
 
     get "/conversations/:conversation_id/stream", ConversationController, :stream,
       as: :conversation_stream
+
+    # AG-UI. Here rather than in the JSON scope for the same reason:
+    # the request body is JSON but the *response* is an event stream, and an
+    # AG-UI client sends `Accept: text/event-stream`, which `:accepts_json`
+    # would refuse with 406 before the action ran.
+    post "/agui/:agent_id", AguiController, :run, as: :agui_run
   end
 
   # Operator surface (#527). Three gates in order: :api authenticates the key,

--- a/apps/fountain/test/fountain_web/controllers/agui_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agui_controller_test.exs
@@ -1,0 +1,640 @@
+defmodule FountainWeb.AguiControllerTest do
+  @moduledoc """
+  The AG-UI endpoint: what a host sends, what it gets back, and what it must
+  never get back.
+
+  The stream is driven entirely through replay — the turn's log events are
+  written while the request is inside `send_prompt`, so the run completes
+  synchronously and the assertions are about the emitted protocol rather than
+  about timing. The quiet timeout is dropped to a fraction of a second so a
+  test that never ends a turn fails in milliseconds instead of hanging out the
+  real ten minutes.
+  """
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.ConversationServer
+  alias FountainWeb.AguiController
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    agent = insert_agent(user_id: user.id)
+
+    previous = Application.get_env(:fountain, :agui_quiet_timeout_ms)
+    Application.put_env(:fountain, :agui_quiet_timeout_ms, 250)
+
+    on_exit(fn ->
+      if previous,
+        do: Application.put_env(:fountain, :agui_quiet_timeout_ms, previous),
+        else: Application.delete_env(:fountain, :agui_quiet_timeout_ms)
+    end)
+
+    Ecto.Adapters.SQL.Sandbox.mode(Fountain.Repo, {:shared, self()})
+
+    # No live server: the stream's monitor is best-effort and every turn in
+    # here is played by the stub below, not by a real ConversationServer.
+    stub(ConversationServer, :whereis, fn _id -> nil end)
+
+    {:ok, user: user, raw_key: raw_key, agent: agent}
+  end
+
+  ## ─── Helpers ──────────────────────────────────────────────────────────────
+
+  defp bound_conversation(user, agent, thread_id) do
+    insert_conversation(
+      user_id: user.id,
+      agent: agent,
+      channel_id: AguiController.channel_id(thread_id),
+      status: "idle"
+    )
+  end
+
+  defp run(conn, raw_key, agent_id, body, query \\ "") do
+    conn
+    |> authed_with_key(raw_key)
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("accept", "text/event-stream")
+    |> post("/api/agui/#{agent_id}#{query}", Jason.encode!(body))
+  end
+
+  defp input(thread_id, text, extra \\ []) do
+    %{
+      "threadId" => thread_id,
+      "runId" => "run-1",
+      "messages" => Keyword.get(extra, :messages, [%{"role" => "user", "content" => text}]),
+      "tools" => [],
+      "context" => [],
+      "state" => %{},
+      "forwardedProps" => %{}
+    }
+  end
+
+  # One SSE message per AG-UI event, `data:` only — heartbeat comments and
+  # blank separators drop out here, as they do in any client's parser.
+  defp events(conn) do
+    conn.resp_body
+    |> String.split("\n\n", trim: true)
+    |> Enum.flat_map(fn message ->
+      case String.trim_leading(message) do
+        "data: " <> json -> [Jason.decode!(json)]
+        _ -> []
+      end
+    end)
+  end
+
+  defp types(conn), do: conn |> events() |> Enum.map(& &1["type"])
+
+  defp text(conn) do
+    conn
+    |> events()
+    |> Enum.filter(&(&1["type"] == "TEXT_MESSAGE_CONTENT"))
+    |> Enum.map_join("", & &1["delta"])
+  end
+
+  defp thinking(conn) do
+    conn
+    |> events()
+    |> Enum.filter(&(&1["type"] == "THINKING_TEXT_MESSAGE_CONTENT"))
+    |> Enum.map_join("", & &1["delta"])
+  end
+
+  # A stored ACP line, exactly as the adapter writes one.
+  defp acp(update) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{"sessionId" => "sess-1", "update" => update}
+    })
+  end
+
+  defp chunk(text),
+    do: %{
+      "sessionUpdate" => "agent_message_chunk",
+      "content" => %{"type" => "text", "text" => text}
+    }
+
+  defp thought(text),
+    do: %{
+      "sessionUpdate" => "agent_thought_chunk",
+      "content" => %{"type" => "text", "text" => text}
+    }
+
+  defp tool_call(id, title),
+    do: %{
+      "sessionUpdate" => "tool_call",
+      "toolCallId" => id,
+      "title" => title,
+      "kind" => "execute"
+    }
+
+  defp tool_done(id, status),
+    do: %{"sessionUpdate" => "tool_call_update", "toolCallId" => id, "status" => status}
+
+  # An agent pinned to the runner provider with no runner connected refuses
+  # before anything is allocated, which is the cheapest observable proof that a
+  # run took the *create* path rather than resuming something. Enabledness is
+  # global application env — off in test config — which is why this module is
+  # `async: false`.
+  defp agent_that_cannot_provision(user) do
+    previous = Application.get_env(:fountain, :runners_enabled)
+    Application.put_env(:fountain, :runners_enabled, true)
+    on_exit(fn -> Application.put_env(:fountain, :runners_enabled, previous) end)
+
+    insert_agent(user_id: user.id, sandbox_provider: "runner")
+  end
+
+  # Write the turn the way production does: a `turn`/`started` stage, the
+  # runtime's output rows, then a terminal stage.
+  defp play_turn(conv, updates, ending \\ {"done", %{}}) do
+    turn = insert_turn(conv, status: "running")
+
+    Conversations.publish_stage(conv.id, "turn", "started", %{
+      turn_id: turn.id,
+      turn_number: turn.turn_number
+    })
+
+    for update <- updates do
+      event =
+        insert_log_event(conv,
+          kind: "output",
+          stream: "acp",
+          turn_id: turn.id,
+          data: acp(update)
+        )
+
+      Phoenix.PubSub.broadcast(Fountain.PubSub, "conv:#{conv.id}", {:log_event, event})
+    end
+
+    {state, meta} = ending
+    Conversations.publish_stage(conv.id, "turn", state, Map.put(meta, :turn_id, turn.id))
+    turn
+  end
+
+  ## ─── The happy path ───────────────────────────────────────────────────────
+
+  describe "POST /api/agui/:agent_id" do
+    test "streams a turn's text as one assistant message", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn conv_id, _prompt, [], _opts ->
+        assert conv_id == conv.id
+        play_turn(conv, [chunk("4"), chunk(", obviously")])
+        :ok
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "what is 2 + 2?"))
+
+      assert conn.status == 200
+
+      assert types(conn) == [
+               "RUN_STARTED",
+               "TEXT_MESSAGE_START",
+               "TEXT_MESSAGE_CONTENT",
+               "TEXT_MESSAGE_CONTENT",
+               "TEXT_MESSAGE_END",
+               "RUN_FINISHED"
+             ]
+
+      assert text(conn) == "4, obviously"
+
+      [started | _] = events(conn)
+      assert started["threadId"] == "t1"
+      assert started["runId"] == "run-1"
+    end
+
+    test "answers as an event stream, not JSON", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+        play_turn(conv, [chunk("hi")])
+        :ok
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "hello"))
+
+      assert ["text/event-stream" <> _] = get_resp_header(conn, "content-type")
+    end
+
+    # The whole design in one assertion: the host replays its transcript, and
+    # only the newest user message reaches the sandbox that already lived
+    # through the rest of it.
+    test "prompts with the newest user message only, not the replayed transcript", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, prompt, [], _opts ->
+        assert prompt == "and the one after that?"
+        play_turn(conv, [chunk("ok")])
+        :ok
+      end)
+
+      messages = [
+        %{"role" => "system", "content" => "You are Ada, Staff Engineer."},
+        %{"role" => "user", "content" => "the first question"},
+        %{"role" => "assistant", "content" => "the first answer"},
+        %{"role" => "user", "content" => "and the one after that?"}
+      ]
+
+      conn = run(conn, raw_key, agent.id, input("t1", nil, messages: messages))
+
+      assert "RUN_FINISHED" in types(conn)
+    end
+
+    test "binds the thread to one conversation, so a second run resumes it", %{
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, 2, fn conv_id, _prompt, [], _opts ->
+        assert conv_id == conv.id
+        play_turn(conv, [chunk("same sandbox")])
+        :ok
+      end)
+
+      for _run <- 1..2 do
+        conn = run(build_conn(), raw_key, agent.id, input("t1", "again"))
+        assert text(conn) == "same sandbox"
+      end
+    end
+
+    # A run on an unbound thread has to *open* a conversation, and opening one
+    # provisions a sandbox. The agent here is pinned to the runner provider
+    # with no runner connected, which refuses before anything is allocated
+    # (see runners/placement_test.exs) — so the create path is observable
+    # without a sandbox existing anywhere.
+    test "a different thread opens its own conversation rather than resuming another's", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = agent_that_cannot_provision(user)
+      _bound = bound_conversation(user, agent, "t1")
+
+      reject(&ConversationServer.send_prompt/4)
+
+      conn = run(conn, raw_key, agent.id, input("t2", "hello"))
+
+      assert json_response(conn, 409)["error"] == "no_runner_online"
+    end
+  end
+
+  ## ─── Everything that is not the reply ─────────────────────────────────────
+
+  describe "activity" do
+    test "relays thinking and tool use as AG-UI thinking events", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+        play_turn(conv, [
+          thought("let me look"),
+          tool_call("c1", "Bash"),
+          tool_done("c1", "completed"),
+          chunk("done")
+        ])
+
+        :ok
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "look at the repo"))
+
+      assert thinking(conn) =~ "let me look"
+      assert thinking(conn) =~ "→ Bash"
+      assert thinking(conn) =~ "← ok"
+      assert text(conn) == "done"
+
+      # The thinking region opens and closes exactly once, and is closed
+      # before the assistant message starts.
+      assert Enum.count(types(conn), &(&1 == "THINKING_START")) == 1
+      assert Enum.count(types(conn), &(&1 == "THINKING_END")) == 1
+
+      thinking_end = Enum.find_index(types(conn), &(&1 == "THINKING_END"))
+      text_start = Enum.find_index(types(conn), &(&1 == "TEXT_MESSAGE_START"))
+      assert thinking_end < text_start
+    end
+
+    test "a failed tool says so", %{conn: conn, user: user, agent: agent, raw_key: raw_key} do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+        play_turn(conv, [tool_call("c1", "Bash"), tool_done("c1", "failed"), chunk("hm")])
+        :ok
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "try it"))
+
+      assert thinking(conn) =~ "← failed"
+    end
+
+    test "?activity=off streams the reply and nothing else", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+        play_turn(conv, [thought("noise"), tool_call("c1", "Bash"), chunk("signal")])
+        :ok
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "hello"), "?activity=off")
+
+      assert text(conn) == "signal"
+      refute "THINKING_START" in types(conn)
+      refute "THINKING_TEXT_MESSAGE_CONTENT" in types(conn)
+    end
+
+    # Interleaving is where a half-open message would leave a host spinning:
+    # each channel has to be closed before the other opens.
+    test "text and thinking never overlap", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+        play_turn(conv, [chunk("first"), thought("wait"), chunk("second")])
+        :ok
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "hello"))
+
+      assert types(conn) == [
+               "RUN_STARTED",
+               "TEXT_MESSAGE_START",
+               "TEXT_MESSAGE_CONTENT",
+               "TEXT_MESSAGE_END",
+               "THINKING_START",
+               "THINKING_TEXT_MESSAGE_START",
+               "THINKING_TEXT_MESSAGE_CONTENT",
+               "THINKING_TEXT_MESSAGE_END",
+               "THINKING_END",
+               "TEXT_MESSAGE_START",
+               "TEXT_MESSAGE_CONTENT",
+               "TEXT_MESSAGE_END",
+               "RUN_FINISHED"
+             ]
+
+      # Two messages, two ids: a host that reopened the first would concatenate
+      # the reply into the wrong bubble.
+      ids =
+        conn
+        |> events()
+        |> Enum.filter(&(&1["type"] == "TEXT_MESSAGE_START"))
+        |> Enum.map(& &1["messageId"])
+
+      assert length(Enum.uniq(ids)) == 2
+    end
+  end
+
+  ## ─── Failure ──────────────────────────────────────────────────────────────
+
+  describe "failure" do
+    test "a failed turn ends the run with RUN_ERROR, not RUN_FINISHED", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+        play_turn(conv, [chunk("half an ans")], {"failed", %{reason: "sprite connection lost"}})
+        :ok
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "hello"))
+
+      types = types(conn)
+      assert "RUN_ERROR" in types
+      refute "RUN_FINISHED" in types
+
+      # The half-written message is closed first. A host holding an open
+      # message renders a reply that never stops arriving.
+      assert Enum.find_index(types, &(&1 == "TEXT_MESSAGE_END")) <
+               Enum.find_index(types, &(&1 == "RUN_ERROR"))
+
+      error = conn |> events() |> List.last()
+      assert error["message"] =~ "sprite connection lost"
+    end
+
+    test "an interrupted turn still finishes the run", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+        play_turn(conv, [chunk("as far as I got")], {"interrupted", %{}})
+        :ok
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "hello"))
+
+      assert "RUN_FINISHED" in types(conn)
+      assert thinking(conn) =~ "interrupted"
+    end
+
+    test "another turn's output is not attributed to this run", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+        stranger = insert_turn(conv, status: "running")
+
+        insert_log_event(conv,
+          kind: "output",
+          stream: "acp",
+          turn_id: stranger.id,
+          data: acp(chunk("someone else's answer"))
+        )
+
+        play_turn(conv, [chunk("mine")])
+        :ok
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "hello"))
+
+      assert text(conn) == "mine"
+      refute text(conn) =~ "someone else"
+    end
+
+    test "a busy conversation is refused before the stream opens", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      _conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+        {:error, :busy}
+      end)
+
+      conn = run(conn, raw_key, agent.id, input("t1", "hello"))
+
+      assert json_response(conn, 400)["error"] == "conversation_busy"
+    end
+  end
+
+  ## ─── The envelope ─────────────────────────────────────────────────────────
+
+  describe "run input" do
+    test "400 without a threadId", %{conn: conn, agent: agent, raw_key: raw_key} do
+      body = %{"runId" => "run-1", "messages" => [%{"role" => "user", "content" => "hi"}]}
+
+      conn = run(conn, raw_key, agent.id, body)
+
+      assert json_response(conn, 400)["error"] =~ "threadId"
+    end
+
+    test "400 without a runId", %{conn: conn, agent: agent, raw_key: raw_key} do
+      body = %{"threadId" => "t1", "messages" => [%{"role" => "user", "content" => "hi"}]}
+
+      conn = run(conn, raw_key, agent.id, body)
+
+      assert json_response(conn, 400)["error"] =~ "runId"
+    end
+
+    test "400 when no message in the run came from a user", %{
+      conn: conn,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      body = %{
+        "threadId" => "t1",
+        "runId" => "run-1",
+        "messages" => [%{"role" => "assistant", "content" => "hello?"}]
+      }
+
+      conn = run(conn, raw_key, agent.id, body)
+
+      assert json_response(conn, 400)["error"] =~ "user message"
+    end
+
+    test "multi-part content is read rather than ignored", %{
+      conn: conn,
+      user: user,
+      agent: agent,
+      raw_key: raw_key
+    } do
+      conv = bound_conversation(user, agent, "t1")
+
+      expect(ConversationServer, :send_prompt, fn _id, prompt, [], _opts ->
+        assert prompt == "look at this"
+        play_turn(conv, [chunk("ok")])
+        :ok
+      end)
+
+      messages = [
+        %{
+          "role" => "user",
+          "content" => [
+            %{"type" => "text", "text" => "look at "},
+            %{"type" => "text", "text" => "this"}
+          ]
+        }
+      ]
+
+      conn = run(conn, raw_key, agent.id, input("t1", nil, messages: messages))
+
+      assert "RUN_FINISHED" in types(conn)
+    end
+  end
+
+  ## ─── Who may run what ─────────────────────────────────────────────────────
+
+  describe "auth" do
+    test "401 without a key", %{conn: conn, agent: agent} do
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/agui/#{agent.id}", Jason.encode!(input("t1", "hello")))
+
+      assert conn.status == 401
+    end
+
+    test "404 for an agent that does not exist", %{conn: conn, raw_key: raw_key} do
+      conn = run(conn, raw_key, Ecto.UUID.generate(), input("t1", "hello"))
+
+      assert json_response(conn, 404)
+    end
+
+    test "404 for another tenant's agent", %{conn: conn, raw_key: raw_key} do
+      stranger = insert_verified_user()
+      their_agent = insert_agent(user_id: stranger.id)
+
+      conn = run(conn, raw_key, their_agent.id, input("t1", "hello"))
+
+      assert json_response(conn, 404)
+    end
+
+    # The binding is per tenant as well: two users' threads can share an id
+    # (a host mints them, not us) without sharing a sandbox.
+    test "another tenant's thread of the same name is not resumed", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      stranger = insert_verified_user()
+      their_agent = insert_agent(user_id: stranger.id)
+      _theirs = bound_conversation(stranger, their_agent, "t1")
+
+      ours = agent_that_cannot_provision(user)
+
+      reject(&ConversationServer.send_prompt/4)
+
+      conn = run(conn, raw_key, ours.id, input("t1", "hello"))
+
+      # We have no conversation on `t1`, so this opens one (and fails for want
+      # of a runner) rather than walking into theirs.
+      assert json_response(conn, 409)["error"] == "no_runner_online"
+    end
+  end
+
+  ## ─── The two rules a host depends on ──────────────────────────────────────
+
+  describe "thread mapping" do
+    test "channel ids are namespaced, so a host's thread cannot collide with ours" do
+      assert AguiController.channel_id("t1") == "agui:t1"
+      refute AguiController.channel_id("fountain:team") == "fountain:team"
+    end
+
+    test "the standing role opens a new conversation and is not repeated after" do
+      assert AguiController.first_prompt("", "hello") == "hello"
+      assert AguiController.first_prompt("You are Ada.", "hello") == "You are Ada.\n\nhello"
+    end
+  end
+end

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -36,6 +36,13 @@ delegates a task to a named Fountain agent and reads the answer back. Nothing
 to configure server-side; the plugin authenticates with an API key or the
 CLI's saved login.
 
+[**OpenBot**](openbot.md) needs no plugin at all, only a URL: Fountain answers
+[AG-UI](https://github.com/ag-ui-protocol/ag-ui) at `POST /api/agui/:agent_id`,
+and CopilotKit's OpenBot — or any other AG-UI host — registers a Fountain agent
+as a coworker with a channel of its own. One channel binds to one conversation,
+so the sandbox is the memory rather than the replayed transcript. Nothing to
+configure server-side; the coworker holds an API key.
+
 [**Buzz**](buzz.md) is the other direction: Fountain *hosts* a Buzz agent —
 a Nostr identity that lives on a relay — running its coding agent in a sandbox
 and holding its signing key in a vault. Provision one from the Buzz desktop or

--- a/docs/integrations/openbot.md
+++ b/docs/integrations/openbot.md
@@ -1,0 +1,204 @@
+# OpenBot (AG-UI)
+
+[OpenBot](https://copilotkit.ai/openbot) is CopilotKit's self-hosted agent
+platform: channels, a coworker roster, an audit trail, and a browser computer
+per bot. A "Bot" there is not a framework or an SDK — it is **any HTTP endpoint
+speaking [AG-UI](https://github.com/ag-ui-protocol/ag-ui)**, the open protocol
+for agent-to-user interaction.
+
+Fountain speaks it. `POST /api/agui/:agent_id` takes AG-UI's `RunAgentInput`
+and answers with its SSE event stream, so a Fountain agent arrives in OpenBot
+as a coworker with a channel of its own — no plugin, no sidecar, no code on the
+OpenBot host.
+
+```
+  OpenBot (channels, roster, audit)  ──HTTPS──▶  Fountain            ──▶  sandbox: the Fountain agent
+    one channel = one thread                     POST /api/agui/:id       (its environment, vault, runtime)
+    ◀── SSE: RUN_STARTED, TEXT_MESSAGE_*, THINKING_*, RUN_FINISHED
+```
+
+The endpoint is not OpenBot-specific. Any AG-UI host — a hand-written client,
+another product built on the protocol — registers a Fountain agent the same
+way; OpenBot is simply the host it was built and verified against.
+
+## Set it up
+
+You need two things from Fountain: the agent's id, and an API key.
+
+```bash
+fountain agents list                 # the id
+fountain auth api-keys create openbot
+```
+
+In OpenBot, open `/agents`, create a coworker, and fill in:
+
+| Field | Value |
+|---|---|
+| Name / Title | Whatever the coworker should be called |
+| Role description | The standing role — see below |
+| AG-UI endpoint | `https://your-fountain/api/agui/<agent_id>` |
+| Authorization header | `Authorization` / `Bearer ftn_...` |
+
+OpenBot's **Test connection** button runs a real AG-UI run against the endpoint
+before saving it, so a typo, a dead host or a wrong key is named at the form
+rather than in a channel. It provisions a sandbox to answer, and that sandbox
+counts against your concurrency quota until it idles out.
+
+Running both on one laptop, OpenBot refuses a loopback endpoint unless its
+`.env` has `AGENT_COMPUTER_ALLOW_PRIVATE_HOSTS=true` — the same target check
+that governs browser navigation. It ships set for local development.
+
+Declaring the coworker in a tenant package works too:
+
+```yaml
+agents:
+  - id: ada
+    name: Ada
+    title: Fountain Agent
+    role_description: Runs in its own sandbox.
+    type: remote-ag-ui
+    endpoint: https://your-fountain/api/agui/<agent_id>
+```
+
+## One channel is one conversation is one sandbox
+
+This is the part worth understanding, because the two products disagree about
+where an agent's memory lives and the endpoint resolves it in Fountain's
+favour.
+
+An AG-UI host holds the transcript. It replays the entire message list on every
+run and expects the endpoint to be stateless. A Fountain conversation is the
+opposite: the sandbox holds the context — the agent's files, its shell history,
+what it worked out last turn — and replaying the transcript into it each turn
+would feed the agent its own words back.
+
+So the thread is **mapped**, not replayed. OpenBot mints a stable thread id per
+channel; that becomes the channel binding `agui:<threadId>`, and only the
+newest user message of each run is sent as a prompt. The first run on a thread
+opens a conversation, and every later run prompts the one already bound.
+
+The consequences are all the ones you would want:
+
+- Starting a new channel in OpenBot starts a new sandbox.
+- Two channels with the same coworker are two sandboxes that know nothing of
+  each other.
+- A channel picks up where it left off, including after the sandbox has idled
+  out and been suspended — the next message wakes it.
+- The binding is per tenant, so two accounts whose hosts happen to mint the
+  same thread id never share anything.
+
+The conversations show up in Fountain like any others, with `channel_id`
+`agui:<threadId>`:
+
+```bash
+fountain conversations list --channel "agui:<threadId>"
+```
+
+### The standing role
+
+OpenBot sends a coworker's title and role description as an AG-UI system
+message on every run. Fountain delivers it **once**, with the first prompt of a
+new conversation, because after that the agent has it and repeating it every
+turn is noise in the transcript and tokens on the bill.
+
+The cost of that choice: editing a role in OpenBot reaches new channels, not
+the sandbox that already booted with the old one. Start a new channel to apply
+a rewritten role.
+
+An agent's own system prompt still applies, and is the better place for
+anything that should hold for every surface.
+
+## What comes back
+
+| Fountain | AG-UI |
+|---|---|
+| `text` blocks | `TEXT_MESSAGE_START` / `CONTENT` / `END` |
+| `thinking` blocks | `THINKING_*` |
+| `tool_use` / `tool_result` | `THINKING_*` — one line per call (`→ Terminal`, `← ok`) |
+| `provision`, `setup`, … stages | `THINKING_*` — `provision: started` |
+| `turn`/`done` | `RUN_FINISHED` |
+| `turn`/`failed` | `RUN_ERROR`, carrying the reason |
+
+`?activity=off` on the endpoint drops everything but the reply text.
+
+**No AG-UI tool call is ever emitted**, and that is deliberate. On this
+protocol a tool call means *host, run this and send me the result*: the run
+ends, the host executes it, and a second run carries the result back. A
+Fountain agent ran its own tool, inside its own sandbox, and already has the
+result. Reporting it as a call would ask the host to execute something twice
+and leave the run waiting for a result that is never coming. Tool activity is
+reported as reasoning instead, which no host tries to execute.
+
+The other side of that coin: **OpenBot's governance does not reach inside a
+Fountain sandbox.** Its boundary is the gateway that every browser, file and
+MCP tool call passes through, and a Fountain agent's `bash` never goes near it,
+so `/admin/audit` and `/admin/boundaries` have nothing to say about what the
+agent did. A Fountain agent is governed by Fountain — its own audit trail, its
+environment, its vault, its sandbox provider. Register one as a coworker in the
+knowledge that you are trusting Fountain's boundary, not OpenBot's.
+
+Bridging OpenBot's tools *into* the sandbox — so its computer, components and
+MCP grants are things a Fountain agent can call and OpenBot can refuse — is the
+other half of this integration and is not built.
+
+## Timing, and a watchdog to know about
+
+OpenBot ends a turn whose stream has been silent for `AGENT_STALL_TIMEOUT_MS`
+(a minute by default). It measures silence, not duration: a turn may run for an
+hour as long as events keep arriving.
+
+Provisioning a fresh sandbox takes longer than a minute on some providers, and
+a first run would otherwise be killed mid-provision. Two things keep it alive:
+the lifecycle stages stream as thinking events, and the endpoint writes an SSE
+heartbeat comment every 15 seconds. Both are bytes on the wire, which is what
+the watchdog counts.
+
+Whether a host *renders* thinking events is its own business — OpenBot's
+channel view (CopilotKit 1.67.1) does not show them, so a first run looks quiet
+even though the connection is healthy. Subsequent runs on a warm sandbox answer
+in a couple of seconds.
+
+If a Fountain error arrives before the stream opens — an unknown agent, no
+subscription, the sandbox quota — it is an ordinary JSON response with a
+status, and OpenBot shows it in the channel. Once the stream is open, failure
+arrives as `RUN_ERROR`.
+
+## Model credentials
+
+The agent needs a model credential, as it does on every other surface: add one
+at `/account/inference-credentials` (an Anthropic API key or Claude Code OAuth
+token, an OpenAI key, a Gemini key). Without it the sandbox spawns, the ACP
+session initialises, and the turn fails with `Authentication required` — a
+`RUN_ERROR` in the channel that names it.
+
+Fountain has no platform-level model key on purpose
+([ADR 0008](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0008-byo-inference-credentials.md)).
+
+## What it does not do yet
+
+- **No tool bridge**, as above.
+- **One key, one tenant.** The bot's stored key is a Fountain API key, so every
+  OpenBot user in a deployment reaches Fountain as the account that owns it.
+  OpenBot's own `actor.id` does not travel.
+- **No approvals.** OpenBot can hand control to a person mid-run; a Fountain
+  agent asking permission for a tool call has nowhere to ask
+  ([#643](https://github.com/BinaryBourbon/fountain/issues/643)).
+- **Attachments** on an OpenBot message are not forwarded; the prompt is text.
+
+## Verify it
+
+Against a running instance, with `curl`:
+
+```bash
+curl -N -X POST "https://your-fountain/api/agui/<agent_id>" \
+  -H "Authorization: Bearer ftn_..." \
+  -H "content-type: application/json" \
+  -H "accept: text/event-stream" \
+  -d '{"threadId":"probe-1","runId":"run-1",
+       "messages":[{"role":"user","content":"Say hello in five words."}],
+       "tools":[],"context":[],"state":{},"forwardedProps":{}}'
+```
+
+A healthy run is `RUN_STARTED`, some `TEXT_MESSAGE_*`, then `RUN_FINISHED`.
+Each SSE message is `data: {"type": ...}` — the type is inside the JSON, which
+is what the reference AG-UI encoder writes and every client parses.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Editors (ACP): integrations/editors.md
       - OpenClaw (ACP): integrations/openclaw.md
       - Hermes Agent (plugin): integrations/hermes.md
+      - OpenBot (AG-UI): integrations/openbot.md
       - Buzz (Nostr): integrations/buzz.md
       - GitHub OAuth: integrations/github-oauth.md
       - Stripe: integrations/stripe.md

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -246,6 +246,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/agui/{agent_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run an agent over AG-UI (SSE)
+         * @description Answers a `RunAgentInput` with the AG-UI event stream: `RUN_STARTED`, the turn's output as `TEXT_MESSAGE_*` and `THINKING_*` events, then `RUN_FINISHED` or `RUN_ERROR`. Each SSE message is `data: {"type": ...}`, as the reference encoder writes it.
+         *
+         *     `threadId` binds to a conversation (`agui:<threadId>`): the first run opens one, later runs prompt it. Only the newest user message is sent — the agent's memory lives in its sandbox, not in the replayed transcript.
+         *
+         *     Errors before the stream opens are ordinary JSON responses (404 for an unknown agent, 402 without a subscription); once it is open, failure arrives as `RUN_ERROR`.
+         */
+        post: operations["FountainWeb.AguiController.run"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/environments/{environment_id}/secrets": {
         parameters: {
             query?: never;
@@ -2533,6 +2557,23 @@ export interface components {
             /** Format: uuid */
             vault_id?: string | null;
         };
+        /**
+         * RunAgentInput
+         * @description The AG-UI run envelope, as the protocol defines it. Extra fields are accepted and ignored: only `threadId`, `runId` and `messages` are read.
+         */
+        RunAgentInput: {
+            context?: Record<string, never>[];
+            forwardedProps?: Record<string, never>;
+            /** @description The thread so far. The newest `user` message becomes the prompt; `system`/`developer` messages become the standing role of a new conversation. */
+            messages: Record<string, never>[];
+            /** @description This run. Echoed in the events. */
+            runId: string;
+            state?: Record<string, never>;
+            /** @description The host's thread. Bound to one Fountain conversation as `agui:<threadId>`. */
+            threadId: string;
+            /** @description Accepted and ignored — see the module doc on why no tool call is emitted. */
+            tools?: Record<string, never>[];
+        };
         /** EnvironmentListResponse */
         EnvironmentListResponse: {
             data: components["schemas"]["Environment"][];
@@ -3876,6 +3917,67 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+        };
+    };
+    "FountainWeb.AguiController.run": {
+        parameters: {
+            query?: {
+                /** @description `off` streams the reply text only. Default `thinking`: tool use and lifecycle stages are relayed as AG-UI thinking events too, which is also what keeps a host's stall watchdog fed while a sandbox provisions. */
+                activity?: string;
+            };
+            header?: never;
+            path: {
+                /** @description The agent to run. */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description AG-UI run input */
+        requestBody?: {
+            content: {
+                "application/json": {
+                    context?: Record<string, never>[];
+                    forwardedProps?: Record<string, never>;
+                    /** @description The thread so far. The newest `user` message becomes the prompt; `system`/`developer` messages become the standing role of a new conversation. */
+                    messages: Record<string, never>[];
+                    /** @description This run. Echoed in the events. */
+                    runId: string;
+                    state?: Record<string, never>;
+                    /** @description The host's thread. Bound to one Fountain conversation as `agui:<threadId>`. */
+                    threadId: string;
+                    /** @description Accepted and ignored — see the module doc on why no tool call is emitted. */
+                    tools?: Record<string, never>[];
+                };
+            };
+        };
+        responses: {
+            /** @description AG-UI event stream */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": string;
+                };
+            };
+            /** @description Malformed run input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No such agent */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };


### PR DESCRIPTION
`POST /api/agui/:agent_id` takes the [AG-UI](https://github.com/ag-ui-protocol/ag-ui) protocol's `RunAgentInput` and answers with its SSE event stream, so a Fountain agent arrives in an AG-UI host as a first-class agent — a URL and a bearer token, nothing else.

The host this was built and verified against is CopilotKit's [OpenBot](https://copilotkit.ai/openbot), launched this month, where a "Bot" *is* an AG-UI endpoint: register one at `/agents` and it becomes a coworker with a channel of its own.

```
  OpenBot (channels, roster, audit)  ──HTTPS──▶  Fountain           ──▶  sandbox: the Fountain agent
    one channel = one thread                     POST /api/agui/:id      (its environment, vault, runtime)
    ◀── SSE: RUN_STARTED, TEXT_MESSAGE_*, THINKING_*, RUN_FINISHED
```

Native rather than a sidecar, for the same reason `fountain acp` is a command and not a service: a host needs a reachable address, and a hosted instance already is one. The Hermes plugin (#824) is a plugin because Hermes needs in-process Python; this needs a URL.

## The decision worth reviewing: where the memory lives

An AG-UI host holds the transcript. It replays the whole message list on every run and expects the endpoint to be stateless. A Fountain conversation is the opposite — the sandbox holds the context — and replaying the transcript into it each turn would feed the agent its own words back.

So the thread is **mapped, not replayed**: `threadId` becomes the channel binding `agui:<threadId>` (the mechanism #774 added for the team page), and only the newest user message of each run is sent as a prompt.

- One channel is one conversation is one sandbox.
- A new channel is a new sandbox; two channels on one coworker know nothing of each other.
- A channel picks up where it left off, waking a suspended sandbox.
- The binding is per tenant, so two accounts whose hosts mint the same thread id share nothing.
- A `failed` conversation is skipped, so a channel self-heals onto a fresh sandbox after a partition — at the cost of that sandbox's memory.

The standing role (the host's system messages, re-sent every run) is delivered **once**, with the first prompt of a new conversation. Editing a role reaches new channels, not the sandbox that already booted with it; that trade is documented on the page.

## No AG-UI tool call is ever emitted

On this protocol a tool call means *host, run this and send me the result*: the run ends, the host executes it, and a second run carries the result back. A Fountain agent ran its own tool, in its own sandbox, and already has the result — reporting it as a call would ask the host to execute it a second time and leave the run waiting for a result that is never coming.

Tool use, thinking and the lifecycle stages relay as AG-UI **thinking** events instead, which no host tries to execute, and which (with a 15s heartbeat comment) keep a host's silence watchdog fed while a sandbox provisions — OpenBot's default gives a Bot 60s, and a cold provision can exceed it.

The corollary is stated plainly in the docs: **OpenBot's gateway governs the tools it runs, and a Fountain agent's `bash` never passes it.** `/admin/audit` and `/admin/boundaries` have nothing to say about what the agent did in its sandbox. A Fountain agent is governed by Fountain. Bridging the host's tools *into* the sandbox — so its computer, components and MCP grants become things the agent can call and OpenBot can refuse — is the other half of this integration and is deliberately not here.

## Verified end to end, locally

| | |
|---|---|
| Real `@ag-ui/client` `HttpAgent` (runs CopilotKit's protocol verifier) | clean stream, no ordering violations |
| OpenBot's own `POST /api/agents/test-connection` | `{"ok":true}` with the full event list |
| Coworker registered at `/agents`, channel driven in the browser | real replies |
| `sw_vers -productVersion` → `15.5` | ran on the host via `fountain runner` |
| Second message in the same channel | resumed the same sandbox, recalled the first command |
| Third message after restarting the Fountain server | woke and answered |

Two findings from that run, both in the docs:

- **OpenBot's channel view (CopilotKit 1.67.1) does not render thinking events.** They still do their other job — bytes on the wire keep the watchdog fed — but a cold first run looks quiet rather than showing `provision: started`.
- **The sandbox quota bites early.** Every connection test and every channel is a sandbox; at 5 concurrent the next run gets a 429, which OpenBot renders in the channel verbatim. That is the pre-stream JSON error path working as intended.

## Also in here

`Conversations._unsafe_latest_log_event_id/1` — the "everything from here on" cursor a caller about to prompt a *live* conversation needs, so a previous turn's trailing events are not attributed to this run.

## Checks

`mix format`, `credo --strict`, `sobelow`, `dialyzer` (0 errors), `mkdocs build --strict`, OpenAPI spec generation, and the full suite (3326 tests, 0 failures). 23 new tests cover the translation, the thread binding, tenant isolation, turn locking, interleaving, and every failure shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
