### PR TITLE
The tokens tile counted a rounding error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ upgrade, is in
 
 ### Fixed
 
+- **The dashboard's token total counted only fresh input.** A coding agent
+  re-reads its context every turn, so nearly everything it consumes arrives
+  as a cached read: a month of real work on the hosted instance was 1.5k
+  `input` against 41M `cache_read`. The tile said "1.5k in" for 44M tokens.
+  `Conversations.token_usage/3` now reports all four keys the runtimes send
+  and `total_input/1` sums the three that went into the model; the tile shows
+  that, and names the split on hover.
+
 - **A runtime reporting a malformed usage figure no longer breaks recording
   it.** `turns.usage` is stored as the runtime sent it, but the conversation
   counters it increments are bigints: a string or an object where a number

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -525,22 +525,55 @@ defmodule Fountain.Conversations do
     |> Repo.preload([:sandbox, :agent, :vault])
   end
 
+  @typedoc """
+  A period's tokens, as the runtimes reported them. `cache_read` and
+  `cache_write` are prompt-cache traffic; see `total_input/1`.
+  """
+  @type token_usage :: %{
+          input: non_neg_integer(),
+          cache_read: non_neg_integer(),
+          cache_write: non_neg_integer(),
+          output: non_neg_integer()
+        }
+
+  @token_keys [:input, :cache_read, :cache_write, :output]
+
+  # Only a JSON number is cast. `usage` is whatever the runtime reported and
+  # nothing validates its shape on the way in, so one row with a string where
+  # a number belongs would otherwise take the whole page down with it.
+  defmacrop token_sum(usage, key) do
+    quote do
+      fragment(
+        "CASE WHEN jsonb_typeof(?->?) = 'number' THEN (?->>?)::bigint ELSE 0 END",
+        unquote(usage),
+        unquote(key),
+        unquote(usage),
+        unquote(key)
+      )
+    end
+  end
+
   @doc """
   What this tenant's agents spent, in tokens, over a period.
 
   Summed from `turns.usage` — the figure the runtime reported when the turn
-  ended, which is also what `conversations.usage_input_tokens/_output_tokens`
-  are incremented by. Reading the turns rather than the conversation counters
-  is what makes a period possible: the counters are lifetime totals, and a
+  ended. Reading the turns rather than `conversations.usage_input_tokens` is
+  what makes a period possible: those counters are lifetime totals, and a
   conversation started in March is still accruing in April.
+
+  **All four keys, not two.** A coding agent re-reads its context every turn,
+  so nearly everything it consumes arrives as `cache_read`: a month of real
+  work on this instance was 1.5k `input` against 41M `cache_read`. Reporting
+  `input` alone as "what went in" understates it by four orders of magnitude,
+  which is worse than not reporting it at all. Callers get the breakdown and
+  decide how to present it; `total_input/1` is the sum for the common case.
 
   Tokens are the tenant's own inference spend — Fountain runs on their key
   (ADR 0008) and never bills for them — so this is reported, not charged.
   Turns from before the usage column existed, and runtimes that report no
   usage, contribute nothing rather than a guess.
   """
-  @spec token_usage(binary(), DateTime.t(), DateTime.t()) ::
-          %{input: non_neg_integer(), output: non_neg_integer()}
+  @spec token_usage(binary(), DateTime.t(), DateTime.t()) :: token_usage()
   def token_usage(user_id, %DateTime{} = from, %DateTime{} = to) when is_binary(user_id) do
     # The sum happens in Postgres: a busy month is tens of thousands of turns,
     # and this runs on a page load.
@@ -556,30 +589,29 @@ defmodule Fountain.Conversations do
         where: c.user_id == ^user_id and t.inserted_at >= ^from and t.inserted_at <= ^to,
         where: not is_nil(t.usage),
         select: %{
-          input:
-            sum(
-              fragment(
-                "CASE WHEN jsonb_typeof(?->'input') = 'number' THEN (?->>'input')::bigint ELSE 0 END",
-                t.usage,
-                t.usage
-              )
-            ),
-          output:
-            sum(
-              fragment(
-                "CASE WHEN jsonb_typeof(?->'output') = 'number' THEN (?->>'output')::bigint ELSE 0 END",
-                t.usage,
-                t.usage
-              )
-            )
+          input: sum(token_sum(t.usage, "input")),
+          cache_read: sum(token_sum(t.usage, "cache_read")),
+          cache_write: sum(token_sum(t.usage, "cache_write")),
+          output: sum(token_sum(t.usage, "output"))
         }
       )
 
     case Repo.one(query) do
-      %{input: input, output: output} -> %{input: to_count(input), output: to_count(output)}
-      _ -> %{input: 0, output: 0}
+      %{} = row -> Map.new(@token_keys, &{&1, to_count(Map.get(row, &1))})
+      _ -> empty_token_usage()
     end
   end
+
+  @doc """
+  Everything the model read: fresh input plus what it wrote to and read from
+  the prompt cache. The cached reads dominate, and leaving them out is what
+  made the first version of this metric wrong.
+  """
+  @spec total_input(token_usage()) :: non_neg_integer()
+  def total_input(%{input: input, cache_read: read, cache_write: write}),
+    do: input + read + write
+
+  defp empty_token_usage, do: Map.new(@token_keys, &{&1, 0})
 
   # Postgres sums bigints as `numeric`, which arrives as a Decimal. The
   # callers of this want an integer they can format, and the spec says so.

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -154,8 +154,8 @@ defmodule FountainWeb.DashboardLive.Index do
           <.metric
             label="Tokens"
             value={format_tokens(@tokens)}
-            sub={if @tokens.input > 0 or @tokens.output > 0, do: "in / out"}
-            hint="On your own inference key — Fountain never bills for these."
+            sub={token_sub(@tokens)}
+            hint={token_hint(@tokens)}
           />
         </div>
         <p :if={@usage.turns == 0} class="mt-2 text-xs text-[var(--color-text-muted)]">
@@ -363,11 +363,37 @@ defmodule FountainWeb.DashboardLive.Index do
 
   defp format_minutes(_), do: "—"
 
-  # Two numbers in one tile: what went up, what came back.
-  defp format_tokens(%{input: 0, output: 0}), do: "—"
+  # Two numbers in one tile: what went in, what came back. "In" is every
+  # token the model read — a coding agent re-reads its context every turn, so
+  # nearly all of it arrives as cached reads, and `input` alone reads as
+  # nothing at all.
+  defp format_tokens(tokens) do
+    case {Conversations.total_input(tokens), tokens.output} do
+      {0, 0} -> "—"
+      {input, output} -> "#{compact(input)} / #{compact(output)}"
+    end
+  end
 
-  defp format_tokens(%{input: input, output: output}),
-    do: "#{compact(input)} / #{compact(output)}"
+  defp token_sub(tokens) do
+    if Conversations.total_input(tokens) > 0 or tokens.output > 0, do: "in / out"
+  end
+
+  # The breakdown belongs somewhere, and a tile is not it — but a reader who
+  # wonders why "in" is so large deserves the answer on hover.
+  defp token_hint(tokens) do
+    cached = tokens.cache_read + tokens.cache_write
+
+    base =
+      "On your own inference key — Fountain never bills for these."
+
+    if cached > 0 do
+      base <>
+        " In includes #{format_count(cached)} read from or written to the prompt cache," <>
+        " and #{format_count(tokens.input)} fresh."
+    else
+      base
+    end
+  end
 
   defp compact(n) when n >= 1_000_000, do: "#{Float.round(n / 1_000_000, 1)}M"
   defp compact(n) when n >= 1_000, do: "#{Float.round(n / 1_000, 1)}k"

--- a/apps/fountain/test/fountain/conversations_usage_test.exs
+++ b/apps/fountain/test/fountain/conversations_usage_test.exs
@@ -42,7 +42,40 @@ defmodule Fountain.ConversationsUsageTest do
 
       from = DateTime.add(now, -86_400, :second)
 
-      assert Conversations.token_usage(user.id, from, now) == %{input: 105, output: 21}
+      assert Conversations.token_usage(user.id, from, now) ==
+               %{input: 105, cache_read: 0, cache_write: 0, output: 21}
+    end
+
+    # The bug this metric shipped with: a coding agent re-reads its context
+    # every turn, so nearly everything it consumes arrives as `cache_read`.
+    # Prod's first month was 1.5k input against 41M cache_read — reporting
+    # `input` alone as "what went in" was wrong by four orders of magnitude.
+    test "counts the prompt cache, which is where nearly all the input is", %{user: user} do
+      conv = insert_conversation(user_id: user.id)
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      at = DateTime.add(now, -60, :second)
+
+      turn_with_usage(
+        conv,
+        %{
+          "input" => 1_471,
+          "cache_read" => 41_317_595,
+          "cache_write" => 3_120_406,
+          "output" => 545_912
+        },
+        at
+      )
+
+      usage = Conversations.token_usage(user.id, DateTime.add(now, -86_400, :second), now)
+
+      assert usage == %{
+               input: 1_471,
+               cache_read: 41_317_595,
+               cache_write: 3_120_406,
+               output: 545_912
+             }
+
+      assert Conversations.total_input(usage) == 44_439_472
     end
 
     test "no turns, and turns that reported no usage, are zero not nil", %{user: user} do
@@ -51,7 +84,8 @@ defmodule Fountain.ConversationsUsageTest do
       now = DateTime.utc_now()
       from = DateTime.add(now, -86_400, :second)
 
-      assert Conversations.token_usage(user.id, from, now) == %{input: 0, output: 0}
+      assert Conversations.token_usage(user.id, from, now) ==
+               %{input: 0, cache_read: 0, cache_write: 0, output: 0}
     end
 
     test "a usage map missing a key contributes nothing for it", %{user: user} do
@@ -59,7 +93,7 @@ defmodule Fountain.ConversationsUsageTest do
       now = DateTime.utc_now() |> DateTime.truncate(:second)
       turn_with_usage(conv, %{"input" => 50}, DateTime.add(now, -60, :second))
 
-      assert %{input: 50, output: 0} =
+      assert %{input: 50, cache_read: 0, cache_write: 0, output: 0} =
                Conversations.token_usage(user.id, DateTime.add(now, -86_400, :second), now)
     end
 
@@ -74,7 +108,7 @@ defmodule Fountain.ConversationsUsageTest do
       turn_with_usage(conv, %{"input" => 10, "output" => 2}, at)
 
       assert Conversations.token_usage(user.id, DateTime.add(now, -86_400, :second), now) ==
-               %{input: 10, output: 2}
+               %{input: 10, cache_read: 0, cache_write: 0, output: 2}
     end
 
     # The same nonsense, on the write side: it used to raise inside the

--- a/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
@@ -166,6 +166,32 @@ defmodule FountainWeb.DashboardLiveTest do
       assert html =~ "1.5k / 250"
     end
 
+    # The tile shipped reading `input` alone, which for a coding agent is a
+    # rounding error next to its cached reads.
+    test "the tokens tile counts the prompt cache, not just fresh input", %{
+      conn: conn,
+      user: user
+    } do
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv)
+
+      {:ok, _} =
+        Fountain.Conversations._unsafe_record_turn_usage(turn, %{
+          "input" => 1_471,
+          "cache_read" => 41_317_595,
+          "cache_write" => 3_120_406,
+          "output" => 545_912
+        })
+
+      {:ok, _lv, html} = live(conn, ~p"/dashboard")
+
+      # 1,471 + 41,317,595 + 3,120,406 = 44,439,472 in; 545,912 out.
+      assert html =~ "44.4M / 545.9k"
+      refute html =~ "1.5k / 545.9k"
+      # …and the breakdown is on hover rather than lost.
+      assert html =~ "read from or written to the prompt cache"
+    end
+
     test "an account that has done nothing this month says so", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/dashboard")
 


### PR DESCRIPTION
## The bug
I shipped #871 an hour ago with the tokens tile reading the `input` key alone. A coding agent re-reads its context every turn, so nearly everything it consumes arrives as a **cached read**. This month on the hosted instance:

| key | tokens |
|---|---|
| `input` | 1,471 |
| `cache_read` | 41,317,595 |
| `cache_write` | 3,120,406 |
| `output` | 545,912 |

The tile said **"1.5k in"** for 44.4M tokens. Wrong by four orders of magnitude, and worse than not reporting it at all — someone reading it would conclude their agents barely read anything.

## The fix
- `token_usage/3` reports **all four keys** the runtimes actually send, not two.
- `total_input/1` sums the three that went into the model. That's what the tile shows: `44.4M / 545.9k`.
- The split is named on hover — *"In includes 44,438,001 read from or written to the prompt cache, and 1,471 fresh"* — so a reader who wonders why "in" is so large gets the answer without the tile carrying four numbers.

## How I found it
By computing the number the *deployed* page would show against production data, rather than trusting my seeded fixture — which happened to contain no cache keys at all, so the tests and the screenshot both looked right.

## Related, not fixed here
`conversations.usage_input_tokens` is incremented by `input` only, so `usage_total.input` on the conversations API has the same blind spot. That's a documented API field with existing consumers; changing what it means is a separate decision, not a drive-by. Flagging it rather than quietly altering it.

## Test plan
- [x] `mix test` — 3,225 tests, 0 failures
- [x] New: the real prod figures as a fixture, asserting all four keys and `total_input/1` = 44,439,472; and a dashboard test pinning the tile at `44.4M / 545.9k`, refuting `1.5k / 545.9k`, and asserting the hover text
- [x] `EXPLAIN ANALYZE` on prod for the largest tenant: **0.993 ms** (was 0.738 ms with two keys)
- [x] format, credo --strict, sobelow, dialyzer — each verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)