### PR TITLE
Promote the account menu into the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ upgrade, is in
 
 ### Changed
 
+- **The console's sidebar shows where you can go.** Account, API keys,
+  inference keys, runners, billing, security, the audit log and admin were in
+  a popup behind the user's email address; they are sections now. A
+  destination you cannot see is one you do not know you have — and the
+  conversation list that used to own that space is gone, so there was room.
+  What stays at the bottom is what is not a destination: who you are, sign
+  out, the theme toggle, and the build version a bug report quotes.
+
 - **Fountain's web UI is a console.** The conversation pages
   (`/conversations`, `/conversations/new`, `/conversations/:id`,
   `/conversations/:id/logs`), the team page (`/team`) and the onboarding

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -13,15 +13,8 @@ defmodule FountainWeb.Layouts do
   embed_templates "layouts/*"
 
   def app(assigns) do
-    footer_open =
-      Enum.any?(
-        ["/api-keys", "/account", "/audit", "/help", "/admin"],
-        &String.starts_with?(assigns[:current_path] || "", &1)
-      )
-
     assigns =
       assign(assigns,
-        footer_open: footer_open,
         conversations_app: Fountain.Apps.conversations(),
         team_app: Fountain.Apps.team()
       )
@@ -69,117 +62,114 @@ defmodule FountainWeb.Layouts do
             </label>
           </div>
 
-          <%!-- Primary nav: the primitives a conversation runs on --%>
-          <nav class="px-2 pt-2 pb-1 text-sm space-y-0.5 shrink-0" aria-label="Primary navigation">
-            <.nav_link href={~p"/dashboard"} label="Dashboard" current={@current_path} />
-            <.nav_link href={~p"/agents"} label="Agents" current={@current_path} />
-            <.nav_link href={~p"/environments"} label="Environments" current={@current_path} />
-            <.nav_link href={~p"/vaults"} label="Vaults" current={@current_path} />
-          </nav>
+          <%!-- Everything you can go to. The conversation list used to own
+                this space and scroll; now the destinations do, so a short
+                viewport scrolls the nav rather than pushing the footer off. --%>
+          <div class="flex-1 min-h-0 overflow-y-auto">
+            <nav class="px-2 pt-2 pb-1 text-sm space-y-0.5" aria-label="Primary navigation">
+              <.nav_link href={~p"/dashboard"} label="Dashboard" current={@current_path} />
+              <.nav_link href={~p"/agents"} label="Agents" current={@current_path} />
+              <.nav_link href={~p"/environments"} label="Environments" current={@current_path} />
+              <.nav_link href={~p"/vaults"} label="Vaults" current={@current_path} />
+            </nav>
 
-          <%!-- The apps on top of the API. External: they are their own
-                origins, and a deployment may have neither. --%>
-          <div
-            :if={@conversations_app || @team_app}
-            class="border-t border-[var(--color-border)] px-2 py-1.5 space-y-0.5 shrink-0"
-          >
-            <p class="px-3 pt-1 pb-0.5 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] font-medium">
-              Apps
-            </p>
-            <.app_link :if={@conversations_app} href={@conversations_app} label="Conversations" />
-            <.app_link :if={@team_app} href={@team_app} label="Team" />
+            <%!-- The apps on top of the API. External: they are their own
+                  origins, and a deployment may have neither. --%>
+            <div
+              :if={@conversations_app || @team_app}
+              class="border-t border-[var(--color-border)] px-2 py-1.5 space-y-0.5"
+            >
+              <.nav_heading>Apps</.nav_heading>
+              <.app_link :if={@conversations_app} href={@conversations_app} label="Conversations" />
+              <.app_link :if={@team_app} href={@team_app} label="Team" />
+            </div>
+
+            <%!-- Promoted out of the popup behind the email address: these are
+                  destinations, and a destination you cannot see is one you do
+                  not know you have. --%>
+            <div class="border-t border-[var(--color-border)] px-2 py-1.5 space-y-0.5">
+              <.nav_heading>Account</.nav_heading>
+              <.nav_link href={~p"/account"} label="Account" current={@current_path} exact />
+              <.nav_link href={~p"/api-keys"} label="API keys" current={@current_path} />
+              <.nav_link
+                href={~p"/account/inference-credentials"}
+                label="Inference keys"
+                current={@current_path}
+              />
+              <.nav_link href={~p"/account/runners"} label="Runners" current={@current_path} />
+              <.nav_link
+                :if={Fountain.Billing.enabled?()}
+                href={~p"/account/billing"}
+                label="Billing"
+                current={@current_path}
+              />
+              <.nav_link href={~p"/account/security"} label="Security" current={@current_path} />
+            </div>
+
+            <div class="border-t border-[var(--color-border)] px-2 py-1.5 space-y-0.5">
+              <.nav_link href={~p"/audit"} label="Audit log" current={@current_path} />
+              <.nav_link href={~p"/help"} label="Help" current={@current_path} />
+              <.nav_link
+                :if={assigns[:current_user] && assigns.current_user.role == "admin"}
+                href={~p"/admin"}
+                label="Admin"
+                current={@current_path}
+              />
+            </div>
           </div>
 
-          <div class="flex-1 min-h-0" />
-
-          <%!-- Sidebar footer: click username to reveal settings --%>
-          <div class="border-t border-[var(--color-border)] shrink-0 flex items-start">
-            <details class="flex-1 min-w-0 group" open={@footer_open}>
-              <summary class="
-                flex items-center gap-2 px-3 py-2.5
-                cursor-pointer select-none
-                list-none [&::-webkit-details-marker]:hidden
-                hover:bg-[var(--color-bg-2)] transition-colors
-              ">
-                <span
-                  :if={assigns[:current_user]}
-                  class="flex-1 min-w-0 text-xs font-medium text-[var(--color-text-primary)] truncate"
-                >
-                  {assigns.current_user.email}
-                </span>
+          <%!-- Who you are, and the things that are not destinations. --%>
+          <div class="border-t border-[var(--color-border)] shrink-0 px-2 py-2 space-y-1">
+            <div class="flex items-center gap-1">
+              <span
+                :if={assigns[:current_user]}
+                class="flex-1 min-w-0 px-1 text-xs font-medium text-[var(--color-text-primary)] truncate"
+                title={assigns.current_user.email}
+              >
+                {assigns.current_user.email}
+              </span>
+              <button
+                id="theme-toggle"
+                phx-hook="ThemeToggle"
+                type="button"
+                aria-label="Toggle dark mode"
+                class="shrink-0 rounded-md p-1.5 text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+              >
                 <svg
-                  class="size-3.5 shrink-0 text-[var(--color-text-muted)] -rotate-90 group-open:rotate-0 transition-transform duration-150"
+                  id="theme-icon-moon"
+                  class="size-4"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path d="M17.293 13.293A8 8 0 0 1 6.707 2.707a8.001 8.001 0 1 0 10.586 10.586z" />
+                </svg>
+                <svg
+                  id="theme-icon-sun"
+                  class="size-4 hidden"
                   viewBox="0 0 20 20"
                   fill="currentColor"
                   aria-hidden="true"
                 >
                   <path
                     fill-rule="evenodd"
-                    d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+                    d="M10 2a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1Zm4 8a4 4 0 1 1-8 0 4 4 0 0 1 8 0Zm-.464 4.95.707.707a1 1 0 0 0 1.414-1.414l-.707-.707a1 1 0 0 0-1.414 1.414Zm2.12-10.607a1 1 0 0 1 0 1.414l-.706.707a1 1 0 1 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 0ZM17 11a1 1 0 1 0 0-2h-1a1 1 0 1 1 0 2h1Zm-7 4a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1ZM5.05 6.464A1 1 0 1 0 6.465 5.05l-.708-.707a1 1 0 0 0-1.414 1.414l.707.707Zm1.414 8.486-.707.707a1 1 0 0 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 1.414ZM4 11a1 1 0 1 0 0-2H3a1 1 0 0 0 0 2h1Z"
                     clip-rule="evenodd"
                   />
                 </svg>
-              </summary>
-              <div class="px-2 pt-0.5 pb-2 space-y-0.5 border-t border-[var(--color-border)]">
-                <.nav_link href={~p"/account"} label="Account" current={@current_path} exact />
-                <.nav_link href={~p"/api-keys"} label="API Keys" current={@current_path} />
-                <.nav_link href={~p"/account/runners"} label="Runners" current={@current_path} />
-                <.nav_link
-                  :if={Fountain.Billing.enabled?()}
-                  href={~p"/account/billing"}
-                  label="Billing"
-                  current={@current_path}
-                />
-                <.nav_link href={~p"/account/security"} label="Security" current={@current_path} />
-                <.nav_link href={~p"/audit"} label="Audit log" current={@current_path} />
-                <.nav_link href={~p"/help"} label="Help" current={@current_path} />
-                <.nav_link
-                  :if={assigns[:current_user] && assigns.current_user.role == "admin"}
-                  href={~p"/admin"}
-                  label="Admin"
-                  current={@current_path}
-                />
-                <a
-                  href={~p"/auth/logout"}
-                  class="block rounded-md px-3 py-1 text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)] transition-colors"
-                >
-                  Sign out
-                </a>
-                <p class="px-3 pt-2 text-[10px] font-mono text-[var(--color-text-muted)] select-text">
-                  {build_version()}
-                </p>
-              </div>
-            </details>
-            <button
-              id="theme-toggle"
-              phx-hook="ThemeToggle"
-              type="button"
-              aria-label="Toggle dark mode"
-              class="shrink-0 mt-1 mr-1.5 rounded-md p-1.5 text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-            >
-              <svg
-                id="theme-icon-moon"
-                class="size-4"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
+              </button>
+            </div>
+            <div class="flex items-baseline justify-between gap-2 px-1">
+              <a
+                href={~p"/auth/logout"}
+                class="text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
               >
-                <path d="M17.293 13.293A8 8 0 0 1 6.707 2.707a8.001 8.001 0 1 0 10.586 10.586z" />
-              </svg>
-              <svg
-                id="theme-icon-sun"
-                class="size-4 hidden"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M10 2a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1Zm4 8a4 4 0 1 1-8 0 4 4 0 0 1 8 0Zm-.464 4.95.707.707a1 1 0 0 0 1.414-1.414l-.707-.707a1 1 0 0 0-1.414 1.414Zm2.12-10.607a1 1 0 0 1 0 1.414l-.706.707a1 1 0 1 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 0ZM17 11a1 1 0 1 0 0-2h-1a1 1 0 1 1 0 2h1Zm-7 4a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1ZM5.05 6.464A1 1 0 1 0 6.465 5.05l-.708-.707a1 1 0 0 0-1.414 1.414l.707.707Zm1.414 8.486-.707.707a1 1 0 0 1-1.414-1.414l.707-.707a1 1 0 0 1 1.414 1.414ZM4 11a1 1 0 1 0 0-2H3a1 1 0 0 0 0 2h1Z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </button>
+                Sign out
+              </a>
+              <span class="text-[10px] font-mono text-[var(--color-text-muted)] select-text truncate">
+                {build_version()}
+              </span>
+            </div>
           </div>
         </aside>
 
@@ -220,6 +210,16 @@ defmodule FountainWeb.Layouts do
     vsn = :fountain |> Application.spec(:vsn) |> to_string()
     sha = "FOUNTAIN_BUILD_SHA" |> System.get_env("dev") |> String.slice(0, 7)
     "v#{vsn} · #{sha}"
+  end
+
+  slot :inner_block, required: true
+
+  defp nav_heading(assigns) do
+    ~H"""
+    <p class="px-3 pt-1 pb-0.5 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] font-medium">
+      {render_slot(@inner_block)}
+    </p>
+    """
   end
 
   attr :href, :string, required: true

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -158,7 +158,11 @@ defmodule FountainWeb.DashboardLive.Index do
             hint={token_hint(@tokens)}
           />
         </div>
-        <p :if={@usage.turns == 0} class="mt-2 text-xs text-[var(--color-text-muted)]">
+        <%!-- Only when every tile is empty. Usage events are best-effort
+              (`Billing.record_usage/5` swallows its failures), so an instance
+              can have turns and tokens with no events behind them — and
+              "nothing yet" above four populated tiles reads as a bug. --%>
+        <p :if={nothing_this_month?(assigns)} class="mt-2 text-xs text-[var(--color-text-muted)]">
           Nothing yet this month.
         </p>
       </section>
@@ -207,6 +211,12 @@ defmodule FountainWeb.DashboardLive.Index do
   end
 
   defp maybe_complete_onboarding(_user, _has_credential?, _agents), do: :ok
+
+  defp nothing_this_month?(assigns) do
+    assigns.usage.conversations == 0 and assigns.usage.turns == 0 and
+      assigns.usage.sandbox_minutes == 0 and Conversations.total_input(assigns.tokens) == 0 and
+      assigns.tokens.output == 0
+  end
 
   defp ready?(assigns) do
     assigns.has_credential? and assigns.agent_count > 0 and

--- a/apps/fountain/test/fountain_web/live/console_nav_test.exs
+++ b/apps/fountain/test/fountain_web/live/console_nav_test.exs
@@ -1,0 +1,88 @@
+defmodule FountainWeb.ConsoleNavTest do
+  @moduledoc """
+  The console's sidebar (#875).
+
+  Account, API keys, inference keys, runners, billing, security, the audit log
+  and admin used to live in a popup behind the user's email address. A
+  destination you cannot see is one you do not know you have, so they are
+  sections now — and being sections, they are assertable.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, conn: login_user(conn, user), user: user}
+  end
+
+  test "every destination is in the sidebar itself, not behind a disclosure", %{conn: conn} do
+    {:ok, _lv, html} = live(conn, ~p"/dashboard")
+
+    for path <- [
+          ~p"/dashboard",
+          ~p"/agents",
+          ~p"/environments",
+          ~p"/vaults",
+          ~p"/account",
+          ~p"/api-keys",
+          ~p"/account/inference-credentials",
+          ~p"/account/runners",
+          ~p"/account/security",
+          ~p"/audit",
+          ~p"/help",
+          ~p"/auth/logout"
+        ] do
+      assert html =~ ~s|href="#{path}"|, "#{path} is missing from the sidebar"
+    end
+  end
+
+  test "the email is shown but is no longer a control", %{conn: conn, user: user} do
+    {:ok, lv, html} = live(conn, ~p"/dashboard")
+
+    assert html =~ user.email
+    # The old popup was a <details><summary>; nothing in the sidebar opens now.
+    assert lv |> element("#app-sidebar summary") |> has_element?() == false
+  end
+
+  test "the build version is still reachable — it is what a bug report quotes", %{conn: conn} do
+    {:ok, _lv, html} = live(conn, ~p"/dashboard")
+
+    vsn = :fountain |> Application.spec(:vsn) |> to_string()
+    assert html =~ "v#{vsn}"
+  end
+
+  describe "what a deployment does not have, it does not offer" do
+    test "admin only for an admin", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/dashboard")
+      refute html =~ ~s|href="/admin"|
+
+      admin = insert_verified_user(role: "admin")
+      {:ok, _lv, html} = live(login_user(build_conn(), admin), ~p"/dashboard")
+      assert html =~ ~s|href="/admin"|
+    end
+
+    test "billing only when billing is on", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/dashboard")
+
+      if Fountain.Billing.enabled?() do
+        assert html =~ ~s|href="/account/billing"|
+      else
+        refute html =~ ~s|href="/account/billing"|
+      end
+    end
+  end
+
+  test "the current page is marked, wherever in the sidebar it lives", %{conn: conn} do
+    # `exact` on /account matters: /account/security must not light both up.
+    {:ok, _lv, html} = live(conn, ~p"/account/security")
+
+    assert [_ | _] =
+             Regex.scan(~r|<a[^>]+href="/account/security"[^>]*class="([^"]*)"|, html)
+             |> Enum.filter(fn [_, class] -> class =~ "font-medium" end)
+
+    refute Regex.scan(~r|<a[^>]+href="/account"[^>]*class="([^"]*)"|, html)
+           |> Enum.any?(fn [_, class] -> class =~ "font-medium" end)
+  end
+end

--- a/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
@@ -201,6 +201,20 @@ defmodule FountainWeb.DashboardLiveTest do
       refute html =~ "0 / 0"
     end
 
+    # Usage events are best-effort, so turns can exist with no events behind
+    # them. "Nothing yet" over a populated tile reads as a bug.
+    test "it does not say nothing while a tile says something", %{conn: conn, user: user} do
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv)
+
+      {:ok, _} =
+        Fountain.Conversations._unsafe_record_turn_usage(turn, %{"input" => 10, "output" => 2})
+
+      {:ok, _lv, html} = live(conn, ~p"/dashboard")
+
+      refute html =~ "Nothing yet this month."
+    end
+
     test "the billing link is there only when billing is on", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/dashboard")
 


### PR DESCRIPTION
## Why
Account, API keys, runners, billing, security, the audit log and admin were behind a `<details>` you opened by clicking your own email address. A destination you can't see is one you don't know you have — and the conversation list that used to fill that column is gone (#869), so there's room.

## Before / after

```
BEFORE                          AFTER
Dashboard                       Dashboard
Agents                          Agents
Environments                    Environments
Vaults                          Vaults
── APPS ──                      ── APPS ──
Conversations ↗                 Conversations ↗
Team ↗                          Team ↗
                                ── ACCOUNT ──
(empty space)                   Account
                                API keys
                                Inference keys
                                Runners
                                Billing
                                Security
                                ──────────
                                Audit log
                                Help
                                Admin
▸ you@example.com  ← click me   you@example.com      ☾
                                Sign out    v0.12.0 · sha
```

**Inference keys** joins the list: it had a page and no way to reach it except the dashboard checklist.

**What stays at the bottom** is what isn't a destination — who you are, sign out, the theme toggle, and the build version a bug report quotes. The nav column scrolls rather than pushing the footer off a short viewport, which the conversation list used to handle.

## Also in here
`"Nothing yet this month."` now requires *every* tile to be empty, not just the turn count. `Billing.record_usage/5` is best-effort by contract, so an instance can have turns and tokens with no usage events behind them — and that line sitting over four populated tiles reads as a bug. I hit exactly this on the dev console.

## Test plan
- [x] `mix test` — 3,232 tests, 0 failures
- [x] New `console_nav_test.exs` (6): every destination present as an `href`, the email is no longer a control (no `<details><summary>` left in the sidebar), the build version survives, admin/billing appear only when they should, and the current page is marked
- [x] **Verified the `exact` test isn't vacuous** by removing `exact` from the `/account` link — it fails, then passes again restored
- [x] Rendered in a browser; sidebar reads Dashboard/Agents/Environments/Vaults · APPS · ACCOUNT · Audit log/Help · identity footer
- [x] format, credo --strict, sobelow, dialyzer — each verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)