### PR TITLE
A TypeScript SDK: fountain.run(prompt, {agent, environment, vault})

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,6 +461,33 @@ jobs:
       - name: Hermes plugin tests
         run: python3 -m unittest discover -s integrations/hermes/tests -v
 
+      # The TypeScript SDK (sdk/typescript). Node runs the .ts sources
+      # directly, so `npm test` needs nothing but the dev dependency on tsc —
+      # which is also what enforces `erasableSyntaxOnly`, the setting that
+      # keeps those sources runnable without a build step.
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: SDK install
+        working-directory: sdk/typescript
+        run: npm ci
+
+      - name: SDK typecheck
+        working-directory: sdk/typescript
+        run: npm run typecheck
+
+      - name: SDK tests
+        working-directory: sdk/typescript
+        run: npm test
+
+      - name: SDK build
+        working-directory: sdk/typescript
+        run: npm run build
+
       # `gofmt -l` prints offending files and exits 0, so the failure has to
       # come from the emptiness check — print the list first so the log says
       # which files to run gofmt on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Added
+
+- **A TypeScript SDK** (`sdk/typescript`; not yet published to npm). Running
+  an agent is one call — `fountain.run(prompt, { agent, vault, environment })` —
+  which opens a conversation, follows the turn and hands back the answer, the
+  tools used and a URL a human can watch. The handle it returns can be awaited,
+  iterated for lifecycle events, or read as a text stream; `resume(id).send(...)`
+  continues in the same sandbox. Every integration that has ever talked to
+  Fountain wrote this wrapper first (the Hermes plugin, `fountain run`, the
+  bundled skill); this is that wrapper, once, with the turn-following rules and
+  the mid-turn reconnect in one place. Zero runtime dependencies, Node 20.19+.
+  Documented at `docs/sdk.md`.
+
 ### Fixed
 
 - **The dashboard's token total counted only fresh input.** A coding agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ upgrade, is in
   the mid-turn reconnect in one place. Zero runtime dependencies, Node 20.19+.
   Documented at `docs/sdk.md`.
 
+  The SDK also defines what it runs: `fountain.agents`, `fountain.environments`
+  and `fountain.vaults` each have `list`/`get`/`create`/`update`/`delete` taking
+  a name or an id, and the two latter carry `secrets.set`/`setAll`/`list`/
+  `delete`. `AgentInput` is the whole agent definition as one type — runtime,
+  model, system prompt, skills, MCP servers, sandbox provider and the two
+  allowlists — so `docs/sdk.md` can show a complete definition on one screen
+  instead of describing it. Payloads keep the API's own key names, so one
+  definition reads identically in the SDK, the REST API and a `fountain.yml`.
+
 ### Fixed
 
 - **The dashboard's token total counted only fresh input.** A coding agent

--- a/README.md
+++ b/README.md
@@ -14,17 +14,34 @@ docker compose up -d
 Prefer Kubernetes? A portable baseline — plain manifests, `kubectl apply -k`,
 no operators assumed — lives in [`deploy/k8s/`](deploy/k8s/).
 
-## Three surfaces
+## Four surfaces
 
-Every public feature lives on all three:
+Every public feature lives on the first three; the SDK wraps the verbs most
+code actually reaches for.
 
 | Surface | Use it when |
 |---|---|
 | **Web UI** (`/dashboard`) | Getting started, debugging conversations, managing resources visually |
 | **REST API** (`/api/*`) | Scripting, CI/CD pipelines, integrating Fountain into your own tools |
 | **CLI** (`fountain`) | Local workflows, manifest-driven `apply`, shell scripting |
+| **TypeScript SDK** (`sdk/typescript`) | Running an agent from your own code: `fountain.run(prompt, { agent, vault })` |
 
-The CLI is a convenience wrapper over the REST API. Everything the CLI does, you can do with `curl`.
+The CLI and the SDK are convenience wrappers over the REST API. Everything they do, you can do with `curl`.
+
+```ts
+import { Fountain } from "fountain-sdk";
+
+const run = await new Fountain().run("Upgrade us to Phoenix 1.8 and open a PR", {
+  agent: "reposage",
+  vault: "github-bot",   // the token lands in the sandbox, never in the prompt
+});
+
+console.log(run.text, run.url);
+```
+
+The sandbox is still there afterwards: `fountain.resume(run.conversationId).send("...")`
+continues on the same machine, with the same checkout and the same session.
+See [`sdk/typescript/`](sdk/typescript/) or the [SDK docs](https://binarybourbon.github.io/fountain/sdk/).
 
 ## Get started with the CLI
 

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -60,6 +60,7 @@ defmodule Fountain.Docs do
     {"The four primitives", "primitives.md"},
     {"CLI reference", "cli.md"},
     {"API reference", "api.md"},
+    {"TypeScript SDK", "sdk.md"},
     {"LLM integration", "llm-integration.md"},
     {"Changelog", "changelog.md"}
   ]

--- a/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
@@ -67,6 +67,7 @@ defmodule FountainWeb.LlmsController do
     - [OpenAPI 3 spec](#{base}/api/openapi.json): machine-readable contract
     - [Swagger UI](#{base}/api/docs): interactive try-it, click "Authorize" to set your bearer token
     - [Endpoint summary](#{base}/help/api): summary table and response envelope
+    - [TypeScript SDK](https://github.com/BinaryBourbon/fountain/tree/main/sdk/typescript): `fountain.run(prompt, {agent, vault})` over the conversation endpoints; awaitable, streamable, resumable
 
     ## For LLMs
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,12 @@
 
 Fountain exposes a REST API. All endpoints are under `/api/` and return JSON.
 
+!!! tip "Writing a script, not an integration?"
+
+    The [TypeScript SDK](sdk.md) is one call — `fountain.run(prompt, { agent, vault })` —
+    over the conversation endpoints below. Reach for the raw API when you need
+    a surface the SDK does not wrap, or a language it is not written in.
+
 The authoritative, always-current reference is the served OpenAPI spec:
 
 - `GET /api/openapi.json` - OpenAPI 3.1 spec, generated from the code (public, no auth)

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,144 @@
+# TypeScript SDK
+
+The REST API describes machinery: conversations, turns, log events, blocks. The
+SDK describes the job.
+
+```ts
+import { Fountain } from "fountain-sdk";
+
+const fountain = new Fountain();
+
+const run = await fountain.run("Upgrade us to Phoenix 1.8 and open a PR", {
+  agent: "reposage",
+  vault: "github-bot",   // the token lands in the sandbox, never in the prompt
+});
+
+console.log(run.text);   // what the agent said
+console.log(run.url);    // where a human can watch it happen
+```
+
+The source lives in [`sdk/typescript/`](https://github.com/BinaryBourbon/fountain/tree/main/sdk/typescript).
+It has no runtime dependencies and needs Node 20.19 or newer.
+
+!!! note "Not on npm yet"
+
+    The package is not yet published. Until it is, build it from a checkout —
+    `cd sdk/typescript && npm install && npm run build && npm link` — and
+    `npm link fountain-sdk` in the project that wants it.
+
+## What the second argument is for
+
+The first argument is a prompt, which every LLM SDK has. The second is the part
+that is Fountain:
+
+| | what it does |
+|---|---|
+| `agent` | which named agent config to run — its runtime, model, skills and MCP servers |
+| `environment` | which baseline to provision the sandbox from: packages, cloned repos, setup scripts |
+| `vault` | which secrets to attach at spawn. They win over the environment's on a key collision |
+
+A vault's values are decrypted into the sandbox's environment when the sandbox
+spawns. They are not in the prompt, not in the model's context and not in the
+log feed the SDK reads. Swapping `vault: "github-bot"` for
+`vault: "github-readonly"` changes what the agent is able to do without
+changing a word of the task.
+
+See [the four primitives](primitives.md) for what each one is.
+
+## Credentials
+
+`new Fountain()` resolves exactly as the [CLI](cli.md) does, so a script
+inherits whatever already works in your terminal:
+
+```
+apiKey:  option → FOUNTAIN_API_KEY → FOUNTAIN_TOKEN → ~/.fountain/credentials
+baseUrl: option → FOUNTAIN_BASE_URL → ~/.fountain/credentials → hosted
+```
+
+`FOUNTAIN_TOKEN` is the conversation-scoped token a Fountain sandbox exports
+for the agent inside it. An agent that imports this SDK therefore delegates
+with the credential it already holds, and the conversations it opens are
+recorded as its children — fan-out needs no extra configuration.
+
+## Awaiting, streaming, or neither
+
+`run()` starts the work and returns a handle. There is no second request behind
+any of these — they are three views of one run.
+
+```ts
+// the finished answer
+const result = await fountain.run(prompt, { agent: "reposage" });
+
+// the words, as they arrive
+const run = fountain.run(prompt, { agent: "reposage" });
+for await (const chunk of run.textStream) process.stdout.write(chunk);
+
+// everything: lifecycle, tools, thinking, raw events
+for await (const event of run) {
+  if (event.type === "tool") console.log("→", event.name);
+}
+
+// fan out: nothing is awaited, so every sandbox provisions at once
+const results = await Promise.all(agents.map((agent) => fountain.run(prompt, { agent })));
+```
+
+A turn that **fails** is a result, not an exception — check `result.state`
+(`done`, `failed`, `interrupted`, `timeout`). Only a transport failure, a
+rejected request or a timeout throws.
+
+## Follow-ups
+
+```ts
+const first = await fountain.run("Find every N+1 query in this repo", { agent: "reposage" });
+const second = await fountain.resume(first.conversationId).send("Fix the worst three.");
+```
+
+The second turn costs one prompt. The sandbox is the same machine, the checkout
+is where the first turn left it, and the agent's session still holds what it
+learned. A [suspended](operations.md) sandbox wakes for it.
+
+## Timeouts
+
+`run()` waits as long as the turn takes; agent work legitimately runs for
+hours. `timeoutMs` stops the *waiting* — never the agent:
+
+```ts
+try {
+  await fountain.run(prompt, { agent: "reposage", timeoutMs: 5 * 60_000 });
+} catch (error) {
+  if (error instanceof TimeoutError) {
+    console.log(error.partialText);
+    await fountain.resume(error.conversationId).send("status?");
+  }
+}
+```
+
+`run.interrupt()` asks the agent to stop the turn and leaves the sandbox up;
+`run.terminate()` tears the sandbox down.
+
+## Everything else
+
+The SDK wraps the verbs worth wrapping. The rest of the API — environments,
+secrets, audit, schedules, the team, API keys — is one call away with the same
+auth and error handling:
+
+```ts
+await fountain.request("GET", "/api/audit", { query: { limit: 50 } });
+```
+
+The [API reference](api.md) and the generated `GET /api/openapi.json` cover
+those.
+
+## Other languages
+
+There is no SDK for your language yet, but there are two worked references for
+the part that is easy to get wrong — following a turn through the log feed:
+
+- **Python** — the [Hermes plugin](integrations/hermes.md)'s `tools.py`, which
+  polls `/events?blocks=true`.
+- **Go** — the [`fountain` CLI](cli.md)'s `fountain run`, which streams SSE.
+
+Both implement the same rules the TypeScript SDK does: keep only your own
+turn's events, keep only `text` blocks, join ACP chunks with nothing and legacy
+rows as paragraphs, start a new paragraph after a tool call, and resume from
+the last event id when a connection drops mid-turn.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -43,6 +43,14 @@ log feed the SDK reads. Swapping `vault: "github-bot"` for
 `vault: "github-readonly"` changes what the agent is able to do without
 changing a word of the task.
 
+There is a second layer under that, and it is worth knowing about because it
+changes what you can safely let an agent do: Fountain redacts every value of 8
+bytes or more that it placed in the sandbox's environment out of the
+conversation's output, on the single write path every log event goes through.
+An `env`, a `set -x`, a `cat .env`, or an agent simply asked to print its token
+persists as `[REDACTED]`. The secret reaches the process that needs it and not
+the transcript, the database, or this SDK.
+
 See [the four primitives](primitives.md) for what each one is.
 
 ## Credentials
@@ -86,6 +94,94 @@ A turn that **fails** is a result, not an exception — check `result.state`
 (`done`, `failed`, `interrupted`, `timeout`). Only a transport failure, a
 rejected request or a timeout throws.
 
+## A whole definition, in code
+
+`run()` names an agent. This is where the agent comes from — and the point of
+showing it whole is that the vocabulary is small enough to fit on one screen.
+
+```ts
+const environment = await fountain.environments.create({
+  name: "fountain-ci",
+  packages: { apt: ["ripgrep"] },
+  env_vars: { MIX_ENV: "test" },
+  repositories: [
+    { url: "https://github.com/BinaryBourbon/fountain", mount_path: "/work/fountain" },
+  ],
+  setup_script: "cd /work/fountain && mix deps.get",
+  networking_type: "limited",
+  networking_config: { allowed_hosts: ["github.com", "hex.pm", "api.anthropic.com"] },
+});
+
+const vault = await fountain.vaults.create({ name: "github-bot" });
+await fountain.vaults.secrets.set("github-bot", "GITHUB_TOKEN", process.env.GITHUB_TOKEN!);
+
+const agent = await fountain.agents.create({
+  name: "reposage",
+  runtime: "claude",
+  model: "anthropic/claude-sonnet-5",
+  description: "Reads a repository and answers questions about it",
+  system: "You are a careful reader of other people's code.",
+  environment_id: environment.id,
+  skills: [
+    { source: "obra/superpowers", ref: "v2.1.0" },
+    { name: "house-style", content: "# House style\n\nPrefer small diffs." },
+  ],
+  mcp_servers: { linear: { command: "npx", args: ["-y", "linear-mcp"] } },
+  allowed_vault_ids: [vault.id],
+});
+
+// ...and now the one-liner at the top of this page has something to run.
+await fountain.run("Find every N+1 query and open a PR", {
+  agent: "reposage",
+  vault: "github-bot",
+});
+```
+
+That is an [environment](primitives.md), a [vault](primitives.md) and an
+[agent](primitives.md) — three of the four primitives — and then a
+conversation, which is the fourth.
+
+The fields that are not self-evident:
+
+| Field | What it decides |
+|---|---|
+| `runtime` | `claude`, `codex`, `gemini` or `opencode`. `model`'s provider must match it |
+| `model` | canonical `provider/model_id`. Not checked against a list, so a model released today works today |
+| `system` | the agent's system prompt |
+| `skills` | either `{ source, ref? }` (installed from GitHub) or `{ name, content }` (written into the sandbox verbatim) — exactly one shape per entry |
+| `sandbox_provider` | `sprites`, `e2b`, `daytona` or `runner`; `null` takes the instance default |
+| `allowed_vault_ids` | which vaults a conversation may attach. `null` allows any, `[]` forbids all, a list is an allowlist. Since vault values override the environment, this is what scopes who can override reviewed config |
+| `allowed_environment_ids` | same shape, for launching the agent under a different environment |
+
+Every collection reads the same way:
+
+```ts
+await fountain.agents.list();                                  // or .list("search")
+await fountain.agents.get("reposage");                         // by name or id
+await fountain.agents.update("reposage", { model: "anthropic/claude-opus-5" });
+await fountain.agents.delete("reposage");
+```
+
+`environments` and `vaults` have the same five verbs, plus `secrets`:
+
+```ts
+await fountain.environments.secrets.set("fountain-ci", "HEX_API_KEY", "…");
+await fountain.vaults.secrets.setAll("github-bot", { GITHUB_TOKEN: "…", GITHUB_USER: "bot" });
+await fountain.vaults.secrets.list("github-bot");    // keys only — never values
+await fountain.vaults.secrets.delete("github-bot", "GITHUB_USER");
+```
+
+Secret values are write-only. `list` returns the keys and nothing else: the SDK
+can put a credential into a sandbox and cannot read it back out.
+
+!!! note "Why `environment_id` and not `environmentId`"
+
+    Resource payloads use the API's own key names, so one definition reads
+    identically in the SDK, in the [REST API](api.md) and in a `fountain.yml`
+    manifest, and this page doubles as the API reference. Options that control
+    the SDK's own behaviour — `timeoutMs`, `signal` — are camelCase, because
+    those are not data.
+
 ## Follow-ups
 
 ```ts
@@ -118,9 +214,9 @@ try {
 
 ## Everything else
 
-The SDK wraps the verbs worth wrapping. The rest of the API — environments,
-secrets, audit, schedules, the team, API keys — is one call away with the same
-auth and error handling:
+The SDK wraps the verbs worth wrapping. The rest of the API — audit, schedules,
+the team, API keys, conversations' images and trees — is one call away with the
+same auth and error handling:
 
 ```ts
 await fountain.request("GET", "/api/audit", { query: { limit: 50 } });

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - The four primitives: primitives.md
   - CLI reference: cli.md
   - API reference: api.md
+  - TypeScript SDK: sdk.md
   - LLM integration: llm-integration.md
   - Changelog: changelog.md
 

--- a/sdk/typescript/.gitignore
+++ b/sdk/typescript/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,0 +1,248 @@
+# fountain-sdk
+
+Give an agent a computer, your repos and your credentials — in one call.
+
+```ts
+import { Fountain } from "fountain-sdk";
+
+const fountain = new Fountain();
+
+const run = await fountain.run("Upgrade us to Phoenix 1.8 and open a PR", {
+  agent: "reposage",
+  vault: "github-bot",   // the token lands in the sandbox, never in the prompt
+});
+
+console.log(run.text);   // what the agent said
+console.log(run.url);    // where a human can watch it happen
+```
+
+That is the whole thing. The agent ran on a real machine with your repository
+cloned and your GitHub token attached at spawn time, and the machine is still
+there when you want to ask it something else.
+
+## Why not just call a model?
+
+A model API takes a prompt and returns tokens. To make it do work you supply
+the computer, the checkout, the tools and the secrets — and you keep supplying
+them, on every call, because nothing persists between them.
+
+Fountain's unit is not a message. It is **a sandbox with an agent in it**:
+
+| | model API | `fountain.run()` |
+|---|---|---|
+| where it runs | your process | an isolated sandbox, provisioned per run |
+| your repo | you paste it in | already cloned, from the **environment** |
+| your secrets | in the prompt, or in your process | attached at spawn from a **vault**, never in the transcript |
+| the next question | resend the whole context | `resume(id).send("...")` — same machine, same session |
+| watching it | your logs | `run.url`, a live transcript |
+
+`vault` is the argument to look at. Its values are decrypted into the sandbox's
+environment when the sandbox spawns; they are never part of the prompt, never
+in the model's context, and never in the log feed this SDK reads. Swapping
+`vault: "github-bot"` for `vault: "github-readonly"` changes what the agent can
+do without changing a word of the task.
+
+## What it replaces
+
+Every integration that ever talked to Fountain wrote the same wrapper first —
+open a conversation, send the prompt, follow the log feed, decide when the turn
+is over, glue the text back together. This is that wrapper, once:
+
+<details>
+<summary>The same run, by hand</summary>
+
+```bash
+# 1. find the agent, the vault, the environment (three listings, by name)
+curl -sH "$AUTH" $BASE/api/agents | jq -r '.data[] | select(.name=="reposage") | .id'
+curl -sH "$AUTH" $BASE/api/vaults | jq -r '.data[] | select(.name=="github-bot") | .id'
+
+# 2. open the conversation
+CONV=$(curl -sH "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"agent_id":"...","vault_id":"...","prompt":"Upgrade us to Phoenix 1.8"}' \
+  $BASE/api/conversations | jq -r .data.id)
+
+# 3. follow the feed — and now the real work starts:
+#    - page /events?blocks=true&after=N until has_more is false
+#    - keep only events whose turn_id is *your* turn's
+#    - keep only `text` blocks; `tool_use` is not the answer, `thinking` is not either
+#    - join acp chunks with nothing, stdout rows with a blank line,
+#      and start a new paragraph after any tool call
+#    - stop on stage/turn/done — or failed, or interrupted
+#    - and when the connection drops mid-turn, resume from the last event id
+#      or you will either miss output or replay it twice
+curl -sH "$AUTH" "$BASE/api/conversations/$CONV/stream?blocks=true" | ...
+```
+
+</details>
+
+Those rules are not incidental complexity you could skip — get the paragraph
+rule wrong and every transcript reads as one run-on sentence; get the cursor
+wrong and a deploy mid-turn silently drops the answer. They are in here, with
+tests.
+
+## Install
+
+**Not on npm yet.** Until it is published, install it from a checkout:
+
+```bash
+cd sdk/typescript && npm install && npm run build && npm link
+npm link fountain-sdk            # in the project that wants it
+```
+
+Once published, it will be `npm install fountain-sdk`.
+
+Node 20.19+ (native `fetch` and ESM). No runtime dependencies.
+
+## Credentials
+
+`new Fountain()` resolves the same way the `fountain` CLI does, so a script
+inherits whatever already works in your terminal:
+
+```
+apiKey:  option → FOUNTAIN_API_KEY → FOUNTAIN_TOKEN → ~/.fountain/credentials
+baseUrl: option → FOUNTAIN_BASE_URL → ~/.fountain/credentials → hosted
+```
+
+```ts
+new Fountain({ apiKey: process.env.FOUNTAIN_API_KEY, baseUrl: "https://fountain.internal" });
+new Fountain({ profile: "work" });   // a profile from ~/.fountain/credentials
+```
+
+`FOUNTAIN_TOKEN` is what a Fountain sandbox exports for the agent running
+inside it. An agent that imports this SDK therefore delegates with the token it
+already has, and the conversations it starts are recorded as its children — no
+extra configuration to fan work out.
+
+## Waiting, or not
+
+`run()` starts the work and hands back a handle. What you do with the handle
+decides how much of the run you see; there is no second request behind any of
+these.
+
+```ts
+// await it — the finished answer
+const result = await fountain.run(prompt, { agent: "reposage" });
+
+// stream the words
+const run = fountain.run(prompt, { agent: "reposage" });
+for await (const chunk of run.textStream) process.stdout.write(chunk);
+const result = await run;                      // same run, now finished
+
+// or watch everything: tools, thinking, lifecycle
+for await (const event of run) {
+  if (event.type === "tool") console.log("→", event.name);
+  if (event.type === "text") process.stdout.write(event.text);
+}
+
+// or don't wait at all — fan out, collect later
+const runs = agents.map((agent) => fountain.run(prompt, { agent }));
+const results = await Promise.all(runs);
+```
+
+A `RunResult` is:
+
+```ts
+{
+  conversationId: string;   // keep it — the sandbox is still there
+  url: string;              // where a human watches
+  turnNumber: number;
+  text: string;             // the answer, tool noise removed
+  toolsUsed: string[];
+  state: "done" | "failed" | "interrupted" | "timeout";
+  exitCode: number | null;
+  reason: string | null;    // stop_reason, or why it failed
+  status: string | null;    // the conversation's status
+}
+```
+
+A turn that **fails** is a result, not an exception — the agent ran and has
+something to say about it. Check `state`. Only a transport failure, a rejected
+request or a timeout throws.
+
+## Follow-ups
+
+```ts
+const first = await fountain.run("Find every N+1 query in this repo", { agent: "reposage" });
+
+const second = await fountain.resume(first.conversationId).send("Fix the worst three.");
+```
+
+The second turn costs one prompt. The sandbox is the same machine, the checkout
+is where the first turn left it, and the agent's session still holds everything
+it learned — this is the part a stateless API cannot do at any price.
+
+## Timeouts and cancellation
+
+By default `run()` waits as long as the turn takes; agent work legitimately
+runs for hours.
+
+```ts
+try {
+  await fountain.run(prompt, { agent: "reposage", timeoutMs: 5 * 60_000 });
+} catch (error) {
+  if (error instanceof TimeoutError) {
+    // The turn did not stop — only the waiting did.
+    console.log(error.partialText);
+    const rest = await fountain.resume(error.conversationId).send("status?");
+  }
+}
+```
+
+- `timeoutMs` — stop waiting, throw `TimeoutError`. The agent keeps working.
+- `signal` — an `AbortSignal` that stops the waiting, same deal.
+- `run.interrupt()` — ask the agent to stop the turn. The sandbox stays up.
+- `run.terminate()` — tear the sandbox down. Nothing resumes after this.
+
+## Errors
+
+Every failure is a `FountainError` with `status`, `code` and `body`:
+
+| class | when |
+|---|---|
+| `AuthError` | 401, or no key configured at all |
+| `SubscriptionRequiredError` | 402 — carries `upgradeUrl` |
+| `NotFoundError` | 404 — wrong id, or it belongs to another account |
+| `ValidationError` | 422 |
+| `RateLimitError` | 429 |
+| `TimeoutError` | the SDK stopped waiting — carries `conversationId` and `partialText` |
+| `ResolutionError` | a name matched no agent/vault/environment, or matched several |
+
+A `ResolutionError` names what the account actually has, so a typo is a
+one-line fix rather than a trip to the console.
+
+## The rest of the API
+
+The verbs above are the ones worth wrapping. Everything else Fountain exposes —
+61 paths and counting: environments, secrets, audit, schedules, the team, API
+keys — is one call away, with the same auth, retries and error mapping:
+
+```ts
+await fountain.request("GET", "/api/audit", { query: { limit: 50 } });
+await fountain.request("POST", "/api/vaults", { body: { name: "staging" } });
+```
+
+`GET /api/openapi.json` is the generated, always-current spec for those.
+
+## Names, not ids
+
+`agent`, `vault` and `environment` all take a name or an id. Names resolve
+against the account (exact match first, then a unique prefix) and the listings
+are memoized per client. A UUID in a script tells the next reader nothing;
+`vault: "github-bot"` tells them everything.
+
+## Development
+
+```bash
+npm install
+npm test          # node --test, against an in-process fake Fountain
+npm run typecheck
+npm run build
+```
+
+The tests run a fake Fountain over real HTTP and real SSE, including the parts
+that are easy to get wrong: a connection that dies mid-turn, output belonging
+to another turn, and the two different ways runtimes chunk their text.
+
+## License
+
+MIT, same as Fountain.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -42,6 +42,14 @@ in the model's context, and never in the log feed this SDK reads. Swapping
 `vault: "github-bot"` for `vault: "github-readonly"` changes what the agent can
 do without changing a word of the task.
 
+There is a second layer under that, and it is worth knowing about because it
+changes what you can safely let an agent do: Fountain redacts every value of 8
+bytes or more that it placed in the sandbox's environment out of the
+conversation's output, on the single write path every log event goes through.
+An `env`, a `set -x`, a `cat .env`, or an agent simply asked to print its token
+persists as `[REDACTED]`. The secret reaches the process that needs it and not
+the transcript, the database, or this SDK.
+
 ## What it replaces
 
 Every integration that ever talked to Fountain wrote the same wrapper first —
@@ -159,6 +167,65 @@ A turn that **fails** is a result, not an exception — the agent ran and has
 something to say about it. Check `state`. Only a transport failure, a rejected
 request or a timeout throws.
 
+## Defining what you run
+
+`run()` names an agent; this is where the agent comes from. The whole
+vocabulary fits on one screen:
+
+```ts
+const environment = await fountain.environments.create({
+  name: "fountain-ci",
+  packages: { apt: ["ripgrep"] },
+  env_vars: { MIX_ENV: "test" },
+  repositories: [
+    { url: "https://github.com/BinaryBourbon/fountain", mount_path: "/work/fountain" },
+  ],
+  setup_script: "cd /work/fountain && mix deps.get",
+  networking_type: "limited",
+  networking_config: { allowed_hosts: ["github.com", "hex.pm", "api.anthropic.com"] },
+});
+
+const vault = await fountain.vaults.create({ name: "github-bot" });
+await fountain.vaults.secrets.set("github-bot", "GITHUB_TOKEN", process.env.GITHUB_TOKEN!);
+
+const agent = await fountain.agents.create({
+  name: "reposage",
+  runtime: "claude",
+  model: "anthropic/claude-sonnet-5",
+  system: "You are a careful reader of other people's code.",
+  environment_id: environment.id,
+  skills: [
+    { source: "obra/superpowers", ref: "v2.1.0" },
+    { name: "house-style", content: "# House style\n\nPrefer small diffs." },
+  ],
+  mcp_servers: { linear: { command: "npx", args: ["-y", "linear-mcp"] } },
+  allowed_vault_ids: [vault.id],   // this agent may attach that vault, and no other
+});
+
+await fountain.run("Find every N+1 query and open a PR", {
+  agent: "reposage",
+  vault: "github-bot",
+});
+```
+
+`agents`, `environments` and `vaults` all have the same five verbs — `list`,
+`get`, `create`, `update`, `delete` — and take a name or an id:
+
+```ts
+await fountain.agents.update("reposage", { model: "anthropic/claude-opus-5" });
+await fountain.environments.secrets.set("fountain-ci", "HEX_API_KEY", "…");
+await fountain.vaults.secrets.list("github-bot");   // keys only — never values
+await fountain.vaults.secrets.delete("github-bot", "GITHUB_USER");
+```
+
+Secret values are write-only. `list` returns keys and nothing else: the SDK can
+put a credential into a sandbox and cannot read it back out.
+
+**Why `environment_id` and not `environmentId`.** Resource payloads use the
+API's own key names, so one definition reads identically in the SDK, in the
+REST API and in a `fountain.yml` manifest. Options that control the SDK's own
+behaviour — `timeoutMs`, `signal` — are camelCase, because those are not data.
+
 ## Follow-ups
 
 ```ts
@@ -213,8 +280,8 @@ one-line fix rather than a trip to the console.
 ## The rest of the API
 
 The verbs above are the ones worth wrapping. Everything else Fountain exposes —
-61 paths and counting: environments, secrets, audit, schedules, the team, API
-keys — is one call away, with the same auth, retries and error mapping:
+61 paths and counting: audit, schedules, the team, API keys, conversation trees
+and images — is one call away, with the same auth and error mapping:
 
 ```ts
 await fountain.request("GET", "/api/audit", { query: { limit: 50 } });

--- a/sdk/typescript/examples/define.ts
+++ b/sdk/typescript/examples/define.ts
@@ -1,0 +1,61 @@
+/**
+ * Define an environment, a vault and an agent — then run the thing you just
+ * defined. Deletes all three on the way out.
+ *
+ *   FOUNTAIN_API_KEY=... node examples/define.ts
+ */
+import { Fountain } from "../src/index.ts";
+
+const fountain = new Fountain();
+const suffix = process.argv[2] ?? "demo";
+const names = {
+  environment: `sdk-${suffix}-env`,
+  vault: `sdk-${suffix}-vault`,
+  agent: `sdk-${suffix}-agent`,
+};
+
+let conversationId: string | null = null;
+
+try {
+  const environment = await fountain.environments.create({
+    name: names.environment,
+    env_vars: { GREETING: "hello from the environment" },
+  });
+
+  await fountain.vaults.create({ name: names.vault });
+  // A vault value is decrypted into the sandbox at spawn. It is never in the
+  // prompt, so the agent can use it without the model ever seeing it.
+  await fountain.vaults.secrets.set(names.vault, "DEMO_TOKEN", "s3cr3t-abc123");
+
+  const agent = await fountain.agents.create({
+    name: names.agent,
+    runtime: "claude",
+    model: "anthropic/claude-haiku-4-5",
+    description: "Created by the Fountain SDK's define example",
+    system: "You answer in one short line.",
+    environment_id: environment.id,
+    allowed_vault_ids: [(await fountain.vaults.get(names.vault)).id],
+  });
+
+  console.log(`defined ${agent.name} (${agent.runtime}, ${agent.model})`);
+
+  // Deliberately ask it to print the secret. Fountain redacts any value of 8
+  // bytes or more that it placed in the sandbox's environment, on the single
+  // write path every log event goes through — so the plaintext never reaches
+  // Postgres or this stream, however the agent was asked.
+  const run = await fountain.run(
+    "Print $GREETING and $DEMO_TOKEN, then say how many characters $DEMO_TOKEN has.",
+    { agent: names.agent, vault: names.vault },
+  );
+  conversationId = run.conversationId;
+
+  console.log(run.text);
+  console.log("\n^ the values come back [REDACTED]; the character count proves they arrived");
+  console.log(`${run.state} · ${run.url}`);
+} finally {
+  if (conversationId) await fountain.resume(conversationId).terminate().catch(() => {});
+  await fountain.agents.delete(names.agent).catch(() => {});
+  await fountain.vaults.delete(names.vault).catch(() => {});
+  await fountain.environments.delete(names.environment).catch(() => {});
+  console.log("cleaned up");
+}

--- a/sdk/typescript/examples/fanout.ts
+++ b/sdk/typescript/examples/fanout.ts
@@ -1,0 +1,30 @@
+/**
+ * The same question to several agents at once. Each gets its own sandbox.
+ *
+ *   FOUNTAIN_API_KEY=... node examples/fanout.ts "<prompt>" <agent> <agent> ...
+ */
+import { Fountain } from "../src/index.ts";
+
+const [prompt = "In one sentence: what is this repository for?", ...agents] = process.argv.slice(2);
+const roster = agents.length ? agents : ["smoke-runner"];
+
+const fountain = new Fountain();
+
+// Nothing is awaited yet, so all of them are provisioning at once.
+const runs = roster.map((agent) => fountain.run(prompt, { agent, timeoutMs: 10 * 60_000 }));
+
+const results = await Promise.allSettled(runs);
+
+for (const [index, result] of results.entries()) {
+  const agent = roster[index];
+  if (result.status === "rejected") {
+    console.log(`\n## ${agent}\n(failed: ${result.reason})`);
+    continue;
+  }
+  console.log(`\n## ${agent}\n${result.value.text}\n→ ${result.value.url}`);
+}
+
+// Sandboxes are cheap but not free; hand them back.
+await Promise.allSettled(
+  runs.map(async (run) => fountain.resume(await run.conversationId).terminate()),
+);

--- a/sdk/typescript/examples/run.ts
+++ b/sdk/typescript/examples/run.ts
@@ -1,0 +1,15 @@
+/**
+ * The whole SDK in ten lines.
+ *
+ *   FOUNTAIN_API_KEY=... node examples/run.ts "<agent>" "<prompt>"
+ */
+import { Fountain } from "../src/index.ts";
+
+const [agent = "smoke-runner", prompt = "Reply with the kernel name and nothing else."] =
+  process.argv.slice(2);
+
+const fountain = new Fountain();
+const run = await fountain.run(prompt, { agent });
+
+console.log(run.text);
+console.log(`\n${run.state} · ${run.toolsUsed.join(", ") || "no tools"} · ${run.url}`);

--- a/sdk/typescript/examples/stream.ts
+++ b/sdk/typescript/examples/stream.ts
@@ -1,0 +1,42 @@
+/**
+ * Watch a turn as it happens, then keep the conversation going.
+ *
+ *   FOUNTAIN_API_KEY=... node examples/stream.ts "<agent>"
+ */
+import { Fountain } from "../src/index.ts";
+
+const agent = process.argv[2] ?? "smoke-runner";
+const fountain = new Fountain();
+
+const run = fountain.run("List the files in the repo root, then say how many there are.", {
+  agent,
+  // A vault's secrets are attached when the sandbox spawns — not sent here.
+  // vault: "github-bot",
+});
+
+console.log(`watch: ${await run.url}\n`);
+
+for await (const event of run) {
+  switch (event.type) {
+    case "turn-start":
+      console.log("· the agent picked up the turn");
+      break;
+    case "tool":
+      console.log(`· ${event.name}`);
+      break;
+    case "text":
+      process.stdout.write(event.text);
+      break;
+    case "turn-end":
+      console.log(`\n· ${event.state}`);
+      break;
+  }
+}
+
+const first = await run;
+
+// The sandbox is still up, and the agent still knows what it just did.
+const second = await fountain.resume(first.conversationId).send("Which of those is the largest?");
+console.log(`\n${second.text}`);
+
+await fountain.resume(first.conversationId).terminate();

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "fountain-sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fountain-sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=20.19"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "fountain-sdk",
+  "version": "0.1.0",
+  "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
+  "license": "MIT",
+  "type": "module",
+  "engines": { "node": ">=20.19" },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BinaryBourbon/fountain.git",
+    "directory": "sdk/typescript"
+  },
+  "homepage": "https://github.com/BinaryBourbon/fountain/tree/main/sdk/typescript",
+  "keywords": ["fountain", "agent", "sandbox", "coding-agent", "acp", "sdk"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test test/*.test.ts",
+    "prepublishOnly": "npm run typecheck && npm test && npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,179 @@
+import { HttpClient, type FetchLike, type RequestOptions } from "./http.ts";
+import { resolveConfig, type ConfigOptions, type ResolvedConfig } from "./config.ts";
+import { Resolver } from "./resolve.ts";
+import { Run, type RunOptions } from "./run.ts";
+import { Conversation } from "./conversation.ts";
+import type { Agent, Conversation as ConversationRecord, NamedResource } from "./types.ts";
+
+export interface FountainOptions extends ConfigOptions {
+  /** Swap the fetch implementation — a test server, a proxy, an instrumented one. */
+  fetch?: FetchLike;
+  /** Timeout for ordinary API calls, in ms. Streams are never timed out. */
+  timeoutMs?: number;
+}
+
+export interface RunConfig extends RunOptions {
+  /** The agent to run, by name or id. */
+  agent: string;
+  /**
+   * A vault of secrets, by name or id. Its values win over the environment's
+   * on a key collision, and they are attached when the sandbox spawns — the
+   * prompt never carries them.
+   */
+  vault?: string;
+  /** An environment to provision from instead of the agent's own, by name or id. */
+  environment?: string;
+  /** Display title for the conversation. */
+  title?: string;
+  /** Images to attach to the first prompt, as the API's `ImageInput` shape. */
+  images?: unknown[];
+  /**
+   * Bind the conversation to an external channel. A second run with the same
+   * channel, agent and vault continues that conversation instead of opening a
+   * new one — how a chat harness keeps one thread on one sandbox.
+   */
+  channelId?: string;
+  /** With `channelId`: open a new conversation anyway. */
+  fresh?: boolean;
+  /** Override the generated sandbox name. */
+  spriteName?: string;
+}
+
+/**
+ * A Fountain client.
+ *
+ * ```ts
+ * const fountain = new Fountain();
+ * const run = await fountain.run("Upgrade us to Phoenix 1.8 and open a PR", {
+ *   agent: "reposage",
+ *   vault: "github-bot",
+ * });
+ * console.log(run.text, run.url);
+ * ```
+ *
+ * Credentials resolve the way the `fountain` CLI resolves them, so a script
+ * inherits whatever already works in your terminal. See `resolveConfig`.
+ */
+export class Fountain {
+  /** The raw HTTP client. Every endpoint this SDK does not wrap is still here. */
+  readonly api: HttpClient;
+  readonly config: ResolvedConfig;
+
+  private readonly resolver: Resolver;
+
+  constructor(options: FountainOptions = {}) {
+    this.config = resolveConfig(options);
+    this.api = new HttpClient(this.config, {
+      fetch: options.fetch,
+      timeoutMs: options.timeoutMs,
+    });
+    this.resolver = new Resolver(this.api);
+  }
+
+  /**
+   * Run an agent on a prompt in a fresh sandbox.
+   *
+   * Returns immediately with a handle: `await` it for the finished answer,
+   * `for await` it for events as they land, or read `.textStream`. The work
+   * starts either way.
+   */
+  run(prompt: string, config: RunConfig): Run {
+    const options: RunOptions = {
+      timeoutMs: config.timeoutMs,
+      signal: config.signal,
+      collectEvents: config.collectEvents,
+    };
+
+    return new Run(
+      this.api,
+      {
+        start: async () => {
+          const [agent, vaultId, environmentId] = await Promise.all([
+            this.resolver.resolve("/api/agents", "agent", config.agent),
+            this.resolver.resolveId("/api/vaults", "vault", config.vault),
+            this.resolver.resolveId("/api/environments", "environment", config.environment),
+          ]);
+
+          const body: Record<string, unknown> = { agent_id: agent.id };
+          if (prompt) body.prompt = prompt;
+          if (vaultId) body.vault_id = vaultId;
+          if (environmentId) body.environment_id = environmentId;
+          if (config.title) body.title = config.title;
+          if (config.images?.length) body.images = config.images;
+          if (config.channelId) body.channel_id = config.channelId;
+          if (config.fresh) body.fresh = true;
+          if (config.spriteName) body.sprite_name = config.spriteName;
+
+          const conversation = await this.api.data<ConversationRecord>(
+            "POST",
+            "/api/conversations",
+            { body },
+          );
+
+          // `channel_id` may have resumed an existing conversation, in which
+          // case this prompt is not turn 1. Ask, rather than assume.
+          const turnNumber = config.channelId ? await this.nextTurnNumber(conversation.id) : 1;
+          return { conversation, turnNumber, after: 0 };
+        },
+      },
+      options,
+    );
+  }
+
+  /**
+   * Pick a conversation back up. The sandbox is still there and so is the
+   * agent's session — `send` costs one prompt, not a re-explanation.
+   */
+  resume(conversationId: string): Conversation {
+    return new Conversation(this.api, conversationId);
+  }
+
+  /** The agents on this account. */
+  async agents(search?: string): Promise<Agent[]> {
+    return this.api.list<Agent>("/api/agents", { query: { search } });
+  }
+
+  /** One agent, by name or id. */
+  async agent(nameOrId: string): Promise<Agent> {
+    return (await this.resolver.resolve("/api/agents", "agent", nameOrId)) as Agent;
+  }
+
+  /** The vaults on this account. */
+  async vaults(): Promise<NamedResource[]> {
+    return this.api.list<NamedResource>("/api/vaults");
+  }
+
+  /** The environments on this account. */
+  async environments(): Promise<NamedResource[]> {
+    return this.api.list<NamedResource>("/api/environments");
+  }
+
+  /** The account's conversations, newest first. */
+  async conversations(opts: { rootsOnly?: boolean } = {}): Promise<ConversationRecord[]> {
+    return this.api.list<ConversationRecord>("/api/conversations", {
+      query: { roots_only: opts.rootsOnly === false ? undefined : "true" },
+    });
+  }
+
+  /** Who this key belongs to. The cheapest way to check a key works. */
+  async me(): Promise<Record<string, unknown>> {
+    return this.api.request<Record<string, unknown>>("GET", "/api/auth/me");
+  }
+
+  /** Forget the memoized agent/vault/environment listings. */
+  refresh(): void {
+    this.resolver.clear();
+  }
+
+  /** Shorthand for `api.request`, for endpoints this SDK does not wrap. */
+  request<T = unknown>(method: string, path: string, options?: RequestOptions): Promise<T> {
+    return this.api.request<T>(method, path, options);
+  }
+
+  private async nextTurnNumber(conversationId: string): Promise<number> {
+    const turns = await this.api.list<{ turn_number?: number }>(
+      `/api/conversations/${conversationId}/turns`,
+    );
+    return turns.reduce((max, t) => Math.max(max, Number(t.turn_number) || 0), 0) + 1;
+  }
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -3,7 +3,8 @@ import { resolveConfig, type ConfigOptions, type ResolvedConfig } from "./config
 import { Resolver } from "./resolve.ts";
 import { Run, type RunOptions } from "./run.ts";
 import { Conversation } from "./conversation.ts";
-import type { Agent, Conversation as ConversationRecord, NamedResource } from "./types.ts";
+import { Agents, Environments, Vaults } from "./resources.ts";
+import type { Conversation as ConversationRecord } from "./types.ts";
 
 export interface FountainOptions extends ConfigOptions {
   /** Swap the fetch implementation — a test server, a proxy, an instrumented one. */
@@ -59,6 +60,13 @@ export class Fountain {
   readonly api: HttpClient;
   readonly config: ResolvedConfig;
 
+  /** Define, read, change and delete agents. */
+  readonly agents: Agents;
+  /** Environments and their secrets. */
+  readonly environments: Environments;
+  /** Vaults and their secrets. */
+  readonly vaults: Vaults;
+
   private readonly resolver: Resolver;
 
   constructor(options: FountainOptions = {}) {
@@ -68,6 +76,9 @@ export class Fountain {
       timeoutMs: options.timeoutMs,
     });
     this.resolver = new Resolver(this.api);
+    this.agents = new Agents(this.api, this.resolver);
+    this.environments = new Environments(this.api, this.resolver);
+    this.vaults = new Vaults(this.api, this.resolver);
   }
 
   /**
@@ -126,26 +137,6 @@ export class Fountain {
    */
   resume(conversationId: string): Conversation {
     return new Conversation(this.api, conversationId);
-  }
-
-  /** The agents on this account. */
-  async agents(search?: string): Promise<Agent[]> {
-    return this.api.list<Agent>("/api/agents", { query: { search } });
-  }
-
-  /** One agent, by name or id. */
-  async agent(nameOrId: string): Promise<Agent> {
-    return (await this.resolver.resolve("/api/agents", "agent", nameOrId)) as Agent;
-  }
-
-  /** The vaults on this account. */
-  async vaults(): Promise<NamedResource[]> {
-    return this.api.list<NamedResource>("/api/vaults");
-  }
-
-  /** The environments on this account. */
-  async environments(): Promise<NamedResource[]> {
-    return this.api.list<NamedResource>("/api/environments");
   }
 
   /** The account's conversations, newest first. */

--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -1,0 +1,107 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+
+export const DEFAULT_BASE_URL = "https://fountain.inevitable.fyi";
+
+/** Where a human reads a transcript. Fountain's own UI is a console (see CLAUDE.md). */
+export const DEFAULT_APP_URL = "https://jakegaylor.com/fountain-conversations/";
+
+export interface ResolvedConfig {
+  baseUrl: string;
+  apiKey: string;
+  appUrl: string;
+  /** Set when running inside a Fountain sandbox; stamps spawned conversations as children. */
+  parentConversationId: string | undefined;
+}
+
+export interface ConfigOptions {
+  /** Bearer token. Falls back to the environment, then `~/.fountain/credentials`. */
+  apiKey?: string;
+  /** Your Fountain deployment. Defaults to the hosted one. */
+  baseUrl?: string;
+  /** Credentials-file profile. Defaults to `$FOUNTAIN_PROFILE` or `default`. */
+  profile?: string;
+  /** Base of the conversations app, for `run.url`. `""` falls back to the API URL. */
+  appUrl?: string;
+}
+
+function unquote(value: string): string {
+  const v = (value ?? "").trim();
+  if (v.length >= 2 && v[0] === v[v.length - 1] && (v[0] === '"' || v[0] === "'")) {
+    return v.slice(1, -1).trim();
+  }
+  return v;
+}
+
+/**
+ * Read one profile out of the INI-ish file `fountain auth login` writes.
+ * Absent or unreadable is not an error — it just contributes nothing.
+ */
+function readCredentials(profile: string): Record<string, string> {
+  const override = (process.env.FOUNTAIN_CREDENTIALS_FILE ?? "").trim();
+  const path = override || join(homedir(), ".fountain", "credentials");
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return {};
+  }
+
+  const out: Record<string, string> = {};
+  let section = "";
+  for (const line of raw.split("\n")) {
+    const text = line.trim();
+    if (!text || text.startsWith("#") || text.startsWith(";")) continue;
+    if (text.startsWith("[") && text.endsWith("]")) {
+      section = text.slice(1, -1).trim();
+      continue;
+    }
+    if (section !== profile) continue;
+    const eq = text.indexOf("=");
+    if (eq === -1) continue;
+    out[text.slice(0, eq).trim()] = unquote(text.slice(eq + 1));
+  }
+  return out;
+}
+
+const env = (name: string): string => (process.env[name] ?? "").trim();
+
+/**
+ * Resolve credentials the way the `fountain` CLI does, so a script inherits
+ * whatever already works in the terminal:
+ *
+ *   apiKey:  option → FOUNTAIN_API_KEY → FOUNTAIN_TOKEN → ~/.fountain/credentials
+ *   baseUrl: option → FOUNTAIN_BASE_URL → ~/.fountain/credentials → hosted
+ *
+ * `FOUNTAIN_TOKEN` is what a Fountain sandbox exports for the agent inside it,
+ * so an agent that reaches for this SDK delegates with the conversation-scoped
+ * token it already has — and the conversations it starts are recorded as its
+ * children.
+ */
+export function resolveConfig(options: ConfigOptions = {}): ResolvedConfig {
+  const profile = (options.profile ?? "").trim() || env("FOUNTAIN_PROFILE") || "default";
+  let creds: Record<string, string> | undefined;
+  const credentials = (): Record<string, string> => (creds ??= readCredentials(profile));
+
+  let apiKey = (options.apiKey ?? "").trim() || env("FOUNTAIN_API_KEY") || env("FOUNTAIN_TOKEN");
+  if (!apiKey) apiKey = credentials().api_key ?? "";
+
+  let baseUrl = (options.baseUrl ?? "").trim() || env("FOUNTAIN_BASE_URL");
+  if (!baseUrl) baseUrl = credentials().base_url || DEFAULT_BASE_URL;
+
+  const appUrl = options.appUrl !== undefined ? options.appUrl.trim() : env("FOUNTAIN_APP_URL") || DEFAULT_APP_URL;
+
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    apiKey,
+    appUrl: appUrl.replace(/\/+$/, ""),
+    parentConversationId: env("FOUNTAIN_CONVERSATION_ID") || undefined,
+  };
+}
+
+/** The URL a human opens to watch this conversation. */
+export function conversationUrl(conversationId: string, config: ResolvedConfig): string {
+  if (!config.appUrl) return `${config.baseUrl}/api/conversations/${conversationId}`;
+  return `${config.appUrl}/#/c/${conversationId}`;
+}

--- a/sdk/typescript/src/conversation.ts
+++ b/sdk/typescript/src/conversation.ts
@@ -1,0 +1,151 @@
+import type { HttpClient } from "./http.ts";
+import type { Conversation as ConversationRecord, LogEvent, Turn } from "./types.ts";
+import { Run, type RunOptions } from "./run.ts";
+import { streamEvents, type StreamOptions } from "./sse.ts";
+import { conversationUrl } from "./config.ts";
+
+export interface SendOptions extends RunOptions {
+  /** Images to attach to the prompt, as the API's `ImageInput` shape. */
+  images?: unknown[];
+}
+
+/**
+ * A conversation you already have — the sandbox is still there, and so is
+ * everything the agent learned in it.
+ *
+ * This is the piece no stateless agent API has. `resume(id).send(...)` costs
+ * one prompt, not a re-explanation of the whole task, because the machine, the
+ * checkout and the session are exactly where the last turn left them.
+ */
+export class Conversation {
+  readonly id: string;
+
+  private readonly http: HttpClient;
+  /** Where the log feed has been read to, so a follow-up skips the history. */
+  private cursor: number;
+
+  constructor(http: HttpClient, id: string, cursor = 0) {
+    this.http = http;
+    this.id = id;
+    this.cursor = cursor;
+  }
+
+  /** Where a human watches this conversation. */
+  get url(): string {
+    return conversationUrl(this.id, this.http.config);
+  }
+
+  /** The conversation record: status, agent, turn count. */
+  async get(): Promise<ConversationRecord> {
+    return this.http.data<ConversationRecord>("GET", `/api/conversations/${this.id}`);
+  }
+
+  async status(): Promise<ConversationRecord["status"]> {
+    return (await this.get()).status;
+  }
+
+  async turns(): Promise<Turn[]> {
+    return this.http.list<Turn>(`/api/conversations/${this.id}/turns`);
+  }
+
+  /** Send the next turn. Returns a `Run` — await it, or stream it. */
+  send(prompt: string, options: SendOptions = {}): Run {
+    const body: Record<string, unknown> = { prompt };
+    if (options.images?.length) body.images = options.images;
+
+    const run = new Run(
+      this.http,
+      {
+        start: async () => {
+          // The cursor and the turn number both have to be taken *before* the
+          // prompt goes in, or we race the events it produces.
+          const after = this.cursor > 0 ? this.cursor : await this.discoverCursor();
+          const turnNumber = (await this.lastTurnNumber()) + 1;
+          await this.http.request("POST", `/api/conversations/${this.id}/prompts`, { body });
+          const conversation = await this.get();
+          return { conversation, turnNumber, after };
+        },
+      },
+      options,
+    );
+
+    // Keep the conversation's cursor moving as the run consumes the feed, so
+    // the next send starts where this one stopped.
+    void run
+      .finally(() => {
+        if (run.cursor > this.cursor) this.cursor = run.cursor;
+      })
+      .catch(() => {});
+
+    return run;
+  }
+
+  /** Ask the agent to stop the turn it is on. The sandbox stays up. */
+  async interrupt(): Promise<void> {
+    await this.http.request("POST", `/api/conversations/${this.id}/interrupt`);
+  }
+
+  /** Tear the sandbox down. Nothing resumes after this. */
+  async terminate(): Promise<void> {
+    await this.http.request("POST", `/api/conversations/${this.id}/terminate`);
+  }
+
+  /** Delete the conversation and its history. */
+  async delete(): Promise<void> {
+    await this.http.request("DELETE", `/api/conversations/${this.id}`);
+  }
+
+  /**
+   * The raw log feed, reconnecting on its own. Everything, from `after`
+   * onwards, of every turn — `run`/`send` is the filtered view of this.
+   */
+  events(options: StreamOptions = {}): AsyncIterable<LogEvent> {
+    return streamEvents(this.http, this.id, options);
+  }
+
+  /** One page of the log feed as JSON, for a client that would rather poll. */
+  async eventPage(after = 0, limit = 1000): Promise<{ events: LogEvent[]; nextCursor: number; hasMore: boolean }> {
+    const out = await this.http.request<{ data?: LogEvent[]; meta?: Record<string, unknown> }>(
+      "GET",
+      `/api/conversations/${this.id}/events`,
+      { query: { after, limit, blocks: "true" } },
+    );
+    const meta = out?.meta ?? {};
+    return {
+      events: out?.data ?? [],
+      nextCursor: typeof meta.next_cursor === "number" ? meta.next_cursor : after,
+      hasMore: Boolean(meta.has_more),
+    };
+  }
+
+  private async lastTurnNumber(): Promise<number> {
+    const turns = await this.turns();
+    return turns.reduce((max, turn) => Math.max(max, Number(turn.turn_number) || 0), 0);
+  }
+
+  /**
+   * Find the end of the log feed cheaply.
+   *
+   * A cold `resume().send()` has no cursor, and starting from 0 would replay
+   * every event of every earlier turn before reaching ours. Draining the
+   * `stage` stream (`wait=false`) is a few rows for even a long conversation,
+   * and its ids are the same global ids the full feed uses.
+   */
+  private async discoverCursor(): Promise<number> {
+    let last = 0;
+    try {
+      for await (const event of streamEvents(this.http, this.id, {
+        streams: "stage",
+        wait: false,
+        maxRetries: 0,
+      })) {
+        if (typeof event.id === "number" && event.id > last) last = event.id;
+      }
+    } catch {
+      // Not worth failing a send over; 0 replays, which is correct if noisy.
+      return 0;
+    }
+    this.cursor = last;
+    return last;
+  }
+}

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,0 +1,122 @@
+/**
+ * Every failure the SDK raises is a `FountainError` or a subclass of one, so a
+ * caller can `catch (e) { if (e instanceof FountainError) ... }` and get the
+ * status, the machine-readable code and the parsed body without reaching for
+ * the response object.
+ */
+export class FountainError extends Error {
+  /** HTTP status, or 0 for a transport-level failure. */
+  readonly status: number;
+  /** The API's `error` field when it sent one (`subscription_required`, ...). */
+  readonly code: string | undefined;
+  /** The parsed response body, whatever shape it had. */
+  readonly body: unknown;
+
+  constructor(
+    message: string,
+    opts: { status?: number; code?: string; body?: unknown; cause?: unknown } = {},
+  ) {
+    super(message, opts.cause !== undefined ? { cause: opts.cause } : undefined);
+    this.name = new.target.name;
+    this.status = opts.status ?? 0;
+    this.code = opts.code;
+    this.body = opts.body;
+  }
+}
+
+/** No API key, or the key was rejected (401). */
+export class AuthError extends FountainError {}
+
+/** The account has no active subscription (402). `upgradeUrl` is where to fix it. */
+export class SubscriptionRequiredError extends FountainError {
+  readonly upgradeUrl: string | undefined;
+  constructor(message: string, opts: ConstructorParameters<typeof FountainError>[1] = {}) {
+    super(message, opts);
+    const body = opts.body as Record<string, unknown> | undefined;
+    this.upgradeUrl =
+      body && typeof body === "object" && typeof body.upgrade_url === "string"
+        ? body.upgrade_url
+        : undefined;
+  }
+}
+
+/** Wrong id, or it belongs to another account — Fountain does not distinguish (404). */
+export class NotFoundError extends FountainError {}
+
+/** The request was well-formed but rejected (422). */
+export class ValidationError extends FountainError {}
+
+/** Too many requests (429). */
+export class RateLimitError extends FountainError {}
+
+/**
+ * `run`/`send` gave up waiting. The turn is still running in the sandbox —
+ * `fountain.resume(conversationId)` picks it back up.
+ */
+export class TimeoutError extends FountainError {
+  readonly conversationId: string;
+  /** Whatever the agent had said by the deadline. */
+  readonly partialText: string;
+  constructor(message: string, conversationId: string, partialText: string) {
+    super(message);
+    this.conversationId = conversationId;
+    this.partialText = partialText;
+  }
+}
+
+/** A name that matched no agent/vault/environment, or matched more than one. */
+export class ResolutionError extends FountainError {}
+
+const HINTS: Record<number, string> = {
+  400: "bad request",
+  401: "unauthorized — check the API key",
+  402: "payment required — the account has no active subscription",
+  403: "forbidden — the key may lack the scope for this call",
+  404: "not found — wrong id, or it belongs to another account",
+  409: "conflict",
+  422: "rejected",
+  429: "rate limited — retry shortly",
+};
+
+/** Map an HTTP failure onto the right error class, with a message worth reading. */
+export function errorForStatus(
+  status: number,
+  body: unknown,
+  method: string,
+  url: string,
+): FountainError {
+  let detail = "";
+  let code: string | undefined;
+  if (body && typeof body === "object") {
+    const b = body as Record<string, unknown>;
+    const err = b.error ?? b.errors ?? b.message;
+    if (typeof err === "string") {
+      detail = err;
+      code = typeof b.error === "string" ? b.error : undefined;
+    } else if (err !== undefined) {
+      detail = JSON.stringify(err);
+    }
+  } else if (typeof body === "string" && body.trim()) {
+    detail = body.trim().slice(0, 300);
+  }
+
+  const message = [`HTTP ${status}`, HINTS[status], detail, `(${method} ${url})`]
+    .filter(Boolean)
+    .join(" ");
+  const opts = { status, code, body };
+
+  switch (status) {
+    case 401:
+      return new AuthError(message, opts);
+    case 402:
+      return new SubscriptionRequiredError(message, opts);
+    case 404:
+      return new NotFoundError(message, opts);
+    case 422:
+      return new ValidationError(message, opts);
+    case 429:
+      return new RateLimitError(message, opts);
+    default:
+      return new FountainError(message, opts);
+  }
+}

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -1,0 +1,135 @@
+import { AuthError, FountainError, errorForStatus } from "./errors.ts";
+import type { ResolvedConfig } from "./config.ts";
+
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+export interface RequestOptions {
+  query?: Record<string, string | number | boolean | undefined | null>;
+  body?: unknown;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+  /** Per-request timeout. Defaults to the client's. `0` disables it. */
+  timeoutMs?: number;
+  accept?: string;
+}
+
+export const USER_AGENT = "fountain-sdk-js/0.1.0";
+
+/**
+ * The thin layer everything else is built on: one bearer token, JSON in and
+ * out, and errors that say which call failed. `Fountain#api` exposes it
+ * directly so a caller is never blocked by a verb this SDK did not wrap.
+ */
+export class HttpClient {
+  readonly config: ResolvedConfig;
+  private readonly fetchImpl: FetchLike;
+  private readonly defaultTimeoutMs: number;
+
+  constructor(config: ResolvedConfig, opts: { fetch?: FetchLike; timeoutMs?: number } = {}) {
+    this.config = config;
+    this.fetchImpl = opts.fetch ?? ((input, init) => globalThis.fetch(input, init));
+    this.defaultTimeoutMs = opts.timeoutMs ?? 30_000;
+  }
+
+  get baseUrl(): string {
+    return this.config.baseUrl;
+  }
+
+  url(path: string, query?: RequestOptions["query"]): string {
+    const url = new URL(path.startsWith("http") ? path : this.config.baseUrl + path);
+    for (const [key, value] of Object.entries(query ?? {})) {
+      if (value === undefined || value === null || value === "") continue;
+      url.searchParams.set(key, String(value));
+    }
+    return url.toString();
+  }
+
+  headers(extra?: Record<string, string>): Record<string, string> {
+    if (!this.config.apiKey) {
+      throw new AuthError(
+        "No Fountain API key. Pass `apiKey`, set FOUNTAIN_API_KEY, or run `fountain auth login`.",
+      );
+    }
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.config.apiKey}`,
+      Accept: "application/json",
+      "User-Agent": USER_AGENT,
+      ...extra,
+    };
+    // Attribute conversations started from inside a sandbox to their parent.
+    if (this.config.parentConversationId) {
+      headers["X-Fountain-Parent-Conversation-Id"] = this.config.parentConversationId;
+    }
+    return headers;
+  }
+
+  /** Send a request and return the parsed body. Non-2xx throws. */
+  async request<T = unknown>(method: string, path: string, opts: RequestOptions = {}): Promise<T> {
+    const response = await this.raw(method, path, opts);
+    const text = await response.text();
+    const parsed = text ? safeJson(text) : null;
+    if (!response.ok) {
+      throw errorForStatus(response.status, parsed, method, this.url(path, opts.query));
+    }
+    return parsed as T;
+  }
+
+  /** Send a request and return the `Response` — for SSE and image bytes. */
+  async raw(method: string, path: string, opts: RequestOptions = {}): Promise<Response> {
+    const url = this.url(path, opts.query);
+    const headers = this.headers(opts.headers);
+    if (opts.accept) headers.Accept = opts.accept;
+
+    let body: string | undefined;
+    if (opts.body !== undefined) {
+      body = JSON.stringify(opts.body);
+      headers["Content-Type"] = "application/json";
+    }
+
+    const timeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
+    const signal = withTimeout(opts.signal, timeoutMs);
+
+    try {
+      return await this.fetchImpl(url, { method, headers, body, signal });
+    } catch (cause) {
+      if (opts.signal?.aborted) {
+        throw new FountainError(`${method} ${url} was aborted`, { cause });
+      }
+      throw new FountainError(`${method} ${url} failed: ${describe(cause)}`, { cause });
+    }
+  }
+
+  /** `{data: T}` is the envelope every collection and show action uses. */
+  async data<T>(method: string, path: string, opts: RequestOptions = {}): Promise<T> {
+    const out = await this.request<{ data?: T }>(method, path, opts);
+    return (out?.data ?? null) as T;
+  }
+
+  async list<T>(path: string, opts: RequestOptions = {}): Promise<T[]> {
+    return (await this.data<T[]>("GET", path, opts)) ?? [];
+  }
+}
+
+function safeJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function describe(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  return String(cause);
+}
+
+/**
+ * Compose the caller's signal with a deadline. `AbortSignal.any` keeps the
+ * caller's abort reason intact, which is what makes `run({ signal })` report
+ * "aborted" rather than "timed out".
+ */
+function withTimeout(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal | undefined {
+  if (!timeoutMs || timeoutMs <= 0) return signal;
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -2,6 +2,7 @@ export { Fountain, type FountainOptions, type RunConfig } from "./client.ts";
 export { Run, type RunOptions } from "./run.ts";
 export { Conversation, type SendOptions } from "./conversation.ts";
 export { HttpClient, type FetchLike, type RequestOptions } from "./http.ts";
+export { Agents, Environments, Vaults } from "./resources.ts";
 export {
   resolveConfig,
   conversationUrl,
@@ -24,15 +25,26 @@ export {
 } from "./errors.ts";
 export type {
   Agent,
+  AgentInput,
   Block,
   Conversation as ConversationRecord,
   ConversationStatus,
+  Environment,
+  EnvironmentInput,
   LogEvent,
   NamedResource,
+  NetworkingType,
+  Repository,
+  Runtime,
   RunEvent,
   RunResult,
+  SandboxProvider,
+  Secret,
+  SkillInput,
   Turn,
   TurnState,
+  Vault,
+  VaultInput,
 } from "./types.ts";
 
 import { Fountain } from "./client.ts";

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,39 @@
+export { Fountain, type FountainOptions, type RunConfig } from "./client.ts";
+export { Run, type RunOptions } from "./run.ts";
+export { Conversation, type SendOptions } from "./conversation.ts";
+export { HttpClient, type FetchLike, type RequestOptions } from "./http.ts";
+export {
+  resolveConfig,
+  conversationUrl,
+  DEFAULT_BASE_URL,
+  DEFAULT_APP_URL,
+  type ConfigOptions,
+  type ResolvedConfig,
+} from "./config.ts";
+export { streamEvents, parseSse, type StreamOptions, type SseMessage } from "./sse.ts";
+export { TurnFollower } from "./turn.ts";
+export {
+  FountainError,
+  AuthError,
+  SubscriptionRequiredError,
+  NotFoundError,
+  ValidationError,
+  RateLimitError,
+  TimeoutError,
+  ResolutionError,
+} from "./errors.ts";
+export type {
+  Agent,
+  Block,
+  Conversation as ConversationRecord,
+  ConversationStatus,
+  LogEvent,
+  NamedResource,
+  RunEvent,
+  RunResult,
+  Turn,
+  TurnState,
+} from "./types.ts";
+
+import { Fountain } from "./client.ts";
+export default Fountain;

--- a/sdk/typescript/src/queue.ts
+++ b/sdk/typescript/src/queue.ts
@@ -1,0 +1,68 @@
+/**
+ * A push source that many consumers can read as an async iterable.
+ *
+ * Everything a run produces goes through one of these. Late subscribers get
+ * the whole history first, which is what lets `await run` and
+ * `for await (run)` be the same run: the promise path is just another
+ * consumer, and it does not race the streaming one for events.
+ */
+export class Broadcast<T> {
+  private readonly buffer: T[] = [];
+  private readonly waiters = new Set<() => void>();
+  private closed = false;
+  private failure: unknown = null;
+
+  push(value: T): void {
+    if (this.closed) return;
+    this.buffer.push(value);
+    this.wake();
+  }
+
+  close(error?: unknown): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (error !== undefined) this.failure = error;
+    this.wake();
+  }
+
+  private wake(): void {
+    for (const waiter of [...this.waiters]) waiter();
+    this.waiters.clear();
+  }
+
+  private wait(): Promise<void> {
+    return new Promise((resolve) => this.waiters.add(resolve));
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<T> {
+    let index = 0;
+    while (true) {
+      while (index < this.buffer.length) {
+        yield this.buffer[index++] as T;
+      }
+      if (this.closed) {
+        if (this.failure !== null) throw this.failure;
+        return;
+      }
+      await this.wait();
+    }
+  }
+}
+
+/** A promise whose settlement is triggered from elsewhere. */
+export function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  // Nobody may have attached a handler yet; the Run surfaces this failure on
+  // whichever path the caller actually awaits.
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}

--- a/sdk/typescript/src/resolve.ts
+++ b/sdk/typescript/src/resolve.ts
@@ -26,9 +26,14 @@ export class Resolver {
     this.http = http;
   }
 
-  /** Drop the memoized listings — call after creating an agent elsewhere. */
+  /** Drop every memoized listing. */
   clear(): void {
     this.cache.clear();
+  }
+
+  /** Drop one memoized listing — after a create, rename or delete. */
+  forget(path: string): void {
+    this.cache.delete(path);
   }
 
   list(path: string): Promise<Named[]> {

--- a/sdk/typescript/src/resolve.ts
+++ b/sdk/typescript/src/resolve.ts
@@ -1,0 +1,105 @@
+import type { HttpClient } from "./http.ts";
+import { ResolutionError } from "./errors.ts";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface Named {
+  id: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Turns `{ agent: "reposage" }` into an id.
+ *
+ * Names, not ids, are the point: a script that reads `vault: "github-bot"` says
+ * what it does, and a UUID in a README kills the demo. Resolution is exact
+ * (case-insensitive) first, then a unique prefix, and a miss lists what the
+ * account actually has — the error a caller can act on without opening the
+ * console.
+ */
+export class Resolver {
+  private readonly cache = new Map<string, Promise<Named[]>>();
+  private readonly http: HttpClient;
+
+  constructor(http: HttpClient) {
+    this.http = http;
+  }
+
+  /** Drop the memoized listings — call after creating an agent elsewhere. */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  list(path: string): Promise<Named[]> {
+    let pending = this.cache.get(path);
+    if (!pending) {
+      pending = this.http.list<Named>(path).catch((error) => {
+        // A failed listing must not be remembered as an empty account.
+        this.cache.delete(path);
+        throw error;
+      });
+      this.cache.set(path, pending);
+    }
+    return pending;
+  }
+
+  async resolve(path: string, what: string, nameOrId: string): Promise<Named> {
+    const wanted = (nameOrId ?? "").trim();
+    if (!wanted) throw new ResolutionError(`${what} is required (a name or id)`);
+
+    // An id needs no listing — and an account with hundreds of agents should
+    // not pay for one on every call.
+    if (UUID.test(wanted)) {
+      const known = (await this.peek(path))?.find((item) => item.id === wanted);
+      return known ?? { id: wanted };
+    }
+
+    const items = await this.list(path);
+    const byId = items.find((item) => item.id === wanted);
+    if (byId) return byId;
+
+    const lower = wanted.toLowerCase();
+    const exact = items.filter((item) => (item.name ?? "").toLowerCase() === lower);
+    if (exact.length === 1) return exact[0] as Named;
+    if (exact.length > 1) {
+      throw new ResolutionError(
+        `More than one ${what} is named ${JSON.stringify(wanted)}. Use the id: ` +
+          exact.map((item) => item.id).join(", "),
+      );
+    }
+
+    const prefix = items.filter((item) => (item.name ?? "").toLowerCase().startsWith(lower));
+    if (prefix.length === 1) return prefix[0] as Named;
+    if (prefix.length > 1) {
+      throw new ResolutionError(
+        `${JSON.stringify(wanted)} matches more than one ${what}: ` +
+          prefix.map((item) => item.name ?? item.id).join(", "),
+      );
+    }
+
+    throw new ResolutionError(
+      `No ${what} named ${JSON.stringify(wanted)}. On this account: ${describe(items)}`,
+    );
+  }
+
+  async resolveId(path: string, what: string, nameOrId?: string | null): Promise<string | undefined> {
+    if (!nameOrId) return undefined;
+    return (await this.resolve(path, what, nameOrId)).id;
+  }
+
+  /** The cached listing if we already have one; never fetches. */
+  private async peek(path: string): Promise<Named[] | null> {
+    const pending = this.cache.get(path);
+    if (!pending) return null;
+    return pending.catch(() => null);
+  }
+}
+
+function describe(items: Named[]): string {
+  const names = items
+    .map((item) => item.name ?? item.id)
+    .filter(Boolean)
+    .sort();
+  return names.length ? names.join(", ") : "(none)";
+}

--- a/sdk/typescript/src/resources.ts
+++ b/sdk/typescript/src/resources.ts
@@ -1,0 +1,155 @@
+import type { HttpClient } from "./http.ts";
+import type { Resolver } from "./resolve.ts";
+import type {
+  Agent,
+  AgentInput,
+  Environment,
+  EnvironmentInput,
+  Secret,
+  Vault,
+  VaultInput,
+} from "./types.ts";
+
+/**
+ * Payloads here use the API's own key names (`environment_id`, `mcp_servers`,
+ * `allowed_vault_ids`) rather than camelCase. That is a choice, not an
+ * oversight: an agent definition is the same object in the REST API, in a
+ * `fountain.yml` manifest and here, so one definition reads identically in all
+ * three and the API reference doubles as the SDK reference. Options that
+ * control the SDK's own behaviour — `timeoutMs`, `signal` — are camelCase,
+ * because those are not data.
+ */
+
+/** List, read, define, change and delete one kind of thing. */
+class Collection<T extends { id: string }, Input> {
+  protected readonly http: HttpClient;
+  protected readonly resolver: Resolver;
+  protected readonly path: string;
+  protected readonly what: string;
+
+  constructor(http: HttpClient, resolver: Resolver, path: string, what: string) {
+    this.http = http;
+    this.resolver = resolver;
+    this.path = path;
+    this.what = what;
+  }
+
+  /** Everything on the account. */
+  async list(search?: string): Promise<T[]> {
+    return this.http.list<T>(this.path, { query: { search } });
+  }
+
+  /** One of them, by name or id. */
+  async get(nameOrId: string): Promise<T> {
+    const { id } = await this.resolver.resolve(this.path, this.what, nameOrId);
+    return this.http.data<T>("GET", `${this.path}/${id}`);
+  }
+
+  /** Define a new one. */
+  async create(input: Input): Promise<T> {
+    const created = await this.http.data<T>("POST", this.path, { body: input });
+    // A new name has to be findable by the next `run({ agent: "…" })`.
+    this.resolver.forget(this.path);
+    return created;
+  }
+
+  /** Change one. Only the fields you pass are touched. */
+  async update(nameOrId: string, patch: Partial<Input>): Promise<T> {
+    const { id } = await this.resolver.resolve(this.path, this.what, nameOrId);
+    const updated = await this.http.data<T>("PATCH", `${this.path}/${id}`, { body: patch });
+    // The patch may have renamed it.
+    this.resolver.forget(this.path);
+    return updated;
+  }
+
+  /** Delete one. */
+  async delete(nameOrId: string): Promise<void> {
+    const { id } = await this.resolver.resolve(this.path, this.what, nameOrId);
+    await this.http.request("DELETE", `${this.path}/${id}`);
+    this.resolver.forget(this.path);
+  }
+}
+
+/**
+ * Secrets on an environment or a vault.
+ *
+ * Values are write-only: `list` returns keys, never what they are worth. That
+ * is the whole point — the SDK can put a credential into a sandbox and can
+ * never read it back out.
+ */
+class Secrets {
+  private readonly http: HttpClient;
+  private readonly resolver: Resolver;
+  private readonly parentPath: string;
+  private readonly what: string;
+
+  constructor(http: HttpClient, resolver: Resolver, parentPath: string, what: string) {
+    this.http = http;
+    this.resolver = resolver;
+    this.parentPath = parentPath;
+    this.what = what;
+  }
+
+  /** The keys stored here. Never the values. */
+  async list(parent: string): Promise<Secret[]> {
+    return this.http.list<Secret>(`${await this.parentId(parent)}/secrets`);
+  }
+
+  /** Store a secret, or replace one with the same key. */
+  async set(parent: string, key: string, value: string): Promise<Secret> {
+    return this.http.data<Secret>("POST", `${await this.parentId(parent)}/secrets`, {
+      body: { key, value },
+    });
+  }
+
+  /** Store several at once. */
+  async setAll(parent: string, secrets: Record<string, string>): Promise<Secret[]> {
+    const base = await this.parentId(parent);
+    const out: Secret[] = [];
+    // Serially: these are audited writes, and a partial failure should say
+    // which key it stopped on rather than leave a scattered half-write.
+    for (const [key, value] of Object.entries(secrets)) {
+      out.push(
+        await this.http.data<Secret>("POST", `${base}/secrets`, { body: { key, value } }),
+      );
+    }
+    return out;
+  }
+
+  /** Remove one, by key. */
+  async delete(parent: string, key: string): Promise<void> {
+    await this.http.request("DELETE", `${await this.parentId(parent)}/secrets/${encodeURIComponent(key)}`);
+  }
+
+  private async parentId(nameOrId: string): Promise<string> {
+    const { id } = await this.resolver.resolve(this.parentPath, this.what, nameOrId);
+    return `${this.parentPath}/${id}`;
+  }
+}
+
+/** The agents on this account. */
+export class Agents extends Collection<Agent, AgentInput> {
+  constructor(http: HttpClient, resolver: Resolver) {
+    super(http, resolver, "/api/agents", "agent");
+  }
+}
+
+/** The environments on this account, and their secrets. */
+export class Environments extends Collection<Environment, EnvironmentInput> {
+  readonly secrets: Secrets;
+
+  constructor(http: HttpClient, resolver: Resolver) {
+    super(http, resolver, "/api/environments", "environment");
+    this.secrets = new Secrets(http, resolver, this.path, this.what);
+  }
+}
+
+/** The vaults on this account, and their secrets. */
+export class Vaults extends Collection<Vault, VaultInput> {
+  readonly secrets: Secrets;
+
+  constructor(http: HttpClient, resolver: Resolver) {
+    super(http, resolver, "/api/vaults", "vault");
+    this.secrets = new Secrets(http, resolver, this.path, this.what);
+  }
+}

--- a/sdk/typescript/src/run.ts
+++ b/sdk/typescript/src/run.ts
@@ -145,6 +145,7 @@ export class Run implements Promise<RunResult>, AsyncIterable<RunEvent> {
       ? AbortSignal.any([options.signal, this.abort.signal])
       : this.abort.signal;
 
+    let failure: { reason: string | null } | null = null;
     let timedOut = false;
     const timeoutMs = options.timeoutMs ?? 0;
     const timer =
@@ -165,8 +166,19 @@ export class Run implements Promise<RunResult>, AsyncIterable<RunEvent> {
         for (const out of follower.apply(event)) this.events.push(out);
         if (follower.finished) break;
 
-        // The sandbox died, or someone tore it down: no turn event is coming.
-        if (isConversationOver(event)) break;
+        // A stage that can mean the conversation is over. Which stages those
+        // are is not a list worth hard-coding — `provision/failed` stops the
+        // server, `setup/failed` may not, and `sandbox/done` is a suspend
+        // (resumable) or a reclaim (not) depending on a field. So ask the
+        // conversation instead of guessing: if it is terminal, no turn event
+        // is ever coming and waiting for one hangs forever.
+        if (mayEndConversation(event)) {
+          const status = await this.currentStatus(conversation);
+          if (status && TERMINAL_CONVERSATION_STATUSES.has(status)) {
+            failure = { reason: stageReason(event) };
+            break;
+          }
+        }
       }
     } finally {
       if (timer) clearTimeout(timer);
@@ -183,8 +195,10 @@ export class Run implements Promise<RunResult>, AsyncIterable<RunEvent> {
 
     const status = await this.currentStatus(conversation);
     if (!follower.finished) {
-      // Aborted, or the stream ended with the conversation. Report what there is.
-      this.events.push({ type: "turn-end", state: "timeout", exitCode: null, reason: null });
+      // The conversation died under the turn, or the caller stopped waiting.
+      // Either way say so, rather than reporting an empty answer as normal.
+      const state = failure ? "failed" : "timeout";
+      this.events.push({ type: "turn-end", state, exitCode: null, reason: failure?.reason ?? null });
     }
 
     const result: RunResult = {
@@ -193,9 +207,9 @@ export class Run implements Promise<RunResult>, AsyncIterable<RunEvent> {
       turnNumber,
       text: follower.text,
       toolsUsed: follower.toolsUsed,
-      state: follower.state ?? "timeout",
+      state: follower.state ?? (failure ? "failed" : "timeout"),
       exitCode: follower.exitCode,
-      reason: follower.reason,
+      reason: follower.reason ?? failure?.reason ?? null,
       status,
     };
     if (options.collectEvents) result.events = collected;
@@ -221,14 +235,35 @@ export class Run implements Promise<RunResult>, AsyncIterable<RunEvent> {
   }
 }
 
-/** A `sandbox`/`terminate` stage event that means no turn event will arrive. */
-function isConversationOver(event: LogEvent): boolean {
+/**
+ * Stage events worth checking the conversation's status over.
+ *
+ * `state` is a closed vocabulary — started/done/failed/interrupted — so a
+ * destroyed sandbox and a parked one are both `sandbox`/`done`, told apart by
+ * a field in the payload. Rather than encode that, treat every one of these as
+ * "go and ask" and let the conversation's own status decide.
+ */
+function mayEndConversation(event: LogEvent): boolean {
   if (event.kind !== "stage") return false;
-  if (event.stage === "terminate") return true;
-  if (event.stage === "sandbox" && event.state && TERMINAL_CONVERSATION_STATUSES.has(event.state)) {
-    return true;
+  if (event.stage === "turn") return false; // the follower owns the turn's own fate
+  return event.state === "failed" || event.stage === "terminate" || event.stage === "sandbox";
+}
+
+/** Why a stage said it ended, when it said. */
+function stageReason(event: LogEvent): string | null {
+  let meta: unknown = event.data;
+  if (typeof meta === "string") {
+    try {
+      meta = JSON.parse(meta);
+    } catch {
+      return null;
+    }
   }
-  return false;
+  if (!meta || typeof meta !== "object") return null;
+  const record = meta as Record<string, unknown>;
+  const reason = record.message ?? record.reason;
+  const label = typeof reason === "string" && reason ? reason : null;
+  return label ? `${event.stage}/${event.state}: ${label}` : `${event.stage}/${event.state}`;
 }
 
 /** Mark a promise as handled without changing what it settles to. */

--- a/sdk/typescript/src/run.ts
+++ b/sdk/typescript/src/run.ts
@@ -1,0 +1,238 @@
+import type { HttpClient } from "./http.ts";
+import type { Conversation, LogEvent, RunEvent, RunResult } from "./types.ts";
+import { TurnFollower } from "./turn.ts";
+import { streamEvents } from "./sse.ts";
+import { Broadcast, deferred } from "./queue.ts";
+import { conversationUrl } from "./config.ts";
+import { TimeoutError } from "./errors.ts";
+
+const TERMINAL_CONVERSATION_STATUSES = new Set(["failed", "terminated"]);
+
+export interface RunPlan {
+  /** Open the conversation (a fresh `run`), or reuse one (`send`). */
+  start(): Promise<{ conversation: Conversation; turnNumber: number; after: number }>;
+}
+
+export interface RunOptions {
+  /** Stop waiting after this many ms and throw `TimeoutError`. `0` (default) waits. */
+  timeoutMs?: number;
+  /** Abort the run's own waiting. The turn keeps going in the sandbox. */
+  signal?: AbortSignal;
+  /** Keep every log event on the result. Off by default — a long turn is a lot of rows. */
+  collectEvents?: boolean;
+}
+
+/**
+ * A turn in flight.
+ *
+ * The work starts as soon as you call `run()`; what you do with this object
+ * decides how much of it you see. `await` it for the answer, iterate it for
+ * events as they land, or read `.textStream` for just the words. All three
+ * read the same underlying run — there is no second request behind them.
+ */
+export class Run implements Promise<RunResult>, AsyncIterable<RunEvent> {
+  readonly [Symbol.toStringTag]: string = "Run";
+
+  /** The conversation this turn runs in. Resolves as soon as it exists. */
+  readonly conversationId: Promise<string>;
+  /** Where a human watches it. Resolves with `conversationId`. */
+  readonly url: Promise<string>;
+  /** The full conversation record, once opened. */
+  readonly conversation: Promise<Conversation>;
+
+  private readonly http: HttpClient;
+  private readonly events = new Broadcast<RunEvent>();
+  private readonly completion: Promise<RunResult>;
+  private readonly opened = deferred<Conversation>();
+  private readonly abort = new AbortController();
+  private lastEventId = 0;
+  private conversationIdValue: string | null = null;
+
+  constructor(http: HttpClient, plan: RunPlan, options: RunOptions = {}) {
+    this.http = http;
+    this.conversation = this.opened.promise;
+    this.conversationId = hushed(this.conversation.then((c) => c.id));
+    this.url = hushed(this.conversation.then((c) => conversationUrl(c.id, http.config)));
+    this.completion = this.execute(plan, options);
+    // A caller may only ever iterate, or only ever read `conversationId`. None
+    // of these derived promises may crash the process for want of a handler —
+    // the failure still arrives on whichever one is actually awaited.
+    hushed(this.completion);
+  }
+
+  then<A = RunResult, B = never>(
+    onfulfilled?: ((value: RunResult) => A | PromiseLike<A>) | null,
+    onrejected?: ((reason: unknown) => B | PromiseLike<B>) | null,
+  ): Promise<A | B> {
+    return this.completion.then(onfulfilled, onrejected);
+  }
+
+  catch<B = never>(onrejected?: ((reason: unknown) => B | PromiseLike<B>) | null): Promise<RunResult | B> {
+    return this.completion.catch(onrejected);
+  }
+
+  finally(onfinally?: (() => void) | null): Promise<RunResult> {
+    return this.completion.finally(onfinally);
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<RunEvent> {
+    return this.events[Symbol.asyncIterator]();
+  }
+
+  /** Just the words, as they arrive. */
+  get textStream(): AsyncIterable<string> {
+    const events = this.events;
+    return {
+      async *[Symbol.asyncIterator]() {
+        for await (const event of events) {
+          if (event.type === "text") yield event.text;
+        }
+      },
+    };
+  }
+
+  /** Stop waiting. The turn keeps running in the sandbox; `interrupt()` stops that. */
+  cancel(): void {
+    this.abort.abort();
+  }
+
+  /** Ask the agent to stop the turn it is on. The sandbox stays up. */
+  async interrupt(): Promise<void> {
+    const id = await this.conversationId;
+    await this.http.request("POST", `/api/conversations/${id}/interrupt`);
+  }
+
+  /** Tear the sandbox down. Nothing resumes after this. */
+  async terminate(): Promise<void> {
+    const id = await this.conversationId;
+    await this.http.request("POST", `/api/conversations/${id}/terminate`);
+  }
+
+  /** The cursor to resume the log feed from — how a follow-up turn skips history. */
+  get cursor(): number {
+    return this.lastEventId;
+  }
+
+  private async execute(plan: RunPlan, options: RunOptions): Promise<RunResult> {
+    try {
+      const { conversation, turnNumber, after } = await plan.start();
+      this.conversationIdValue = conversation.id;
+      this.lastEventId = after;
+      this.opened.resolve(conversation);
+      const url = conversationUrl(conversation.id, this.http.config);
+      this.events.push({ type: "conversation", conversationId: conversation.id, conversation, url });
+
+      const result = await this.follow(conversation, turnNumber, after, options, url);
+      this.events.close();
+      return result;
+    } catch (error) {
+      this.opened.reject(error);
+      this.events.close(error);
+      throw error;
+    }
+  }
+
+  private async follow(
+    conversation: Conversation,
+    turnNumber: number,
+    after: number,
+    options: RunOptions,
+    url: string,
+  ): Promise<RunResult> {
+    const follower = new TurnFollower(turnNumber);
+    const collected: LogEvent[] = [];
+    const signal = options.signal
+      ? AbortSignal.any([options.signal, this.abort.signal])
+      : this.abort.signal;
+
+    let timedOut = false;
+    const timeoutMs = options.timeoutMs ?? 0;
+    const timer =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            timedOut = true;
+            this.abort.abort();
+          }, timeoutMs)
+        : null;
+    timer?.unref?.();
+
+    try {
+      for await (const event of streamEvents(this.http, conversation.id, { after, signal })) {
+        if (typeof event.id === "number" && event.id > this.lastEventId) this.lastEventId = event.id;
+        if (options.collectEvents) collected.push(event);
+        this.events.push({ type: "event", event });
+
+        for (const out of follower.apply(event)) this.events.push(out);
+        if (follower.finished) break;
+
+        // The sandbox died, or someone tore it down: no turn event is coming.
+        if (isConversationOver(event)) break;
+      }
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+
+    if (timedOut) {
+      throw new TimeoutError(
+        `Timed out after ${timeoutMs}ms waiting for turn ${turnNumber}. ` +
+          `The turn is still running — resume conversation ${conversation.id}.`,
+        conversation.id,
+        follower.text,
+      );
+    }
+
+    const status = await this.currentStatus(conversation);
+    if (!follower.finished) {
+      // Aborted, or the stream ended with the conversation. Report what there is.
+      this.events.push({ type: "turn-end", state: "timeout", exitCode: null, reason: null });
+    }
+
+    const result: RunResult = {
+      conversationId: conversation.id,
+      url,
+      turnNumber,
+      text: follower.text,
+      toolsUsed: follower.toolsUsed,
+      state: follower.state ?? "timeout",
+      exitCode: follower.exitCode,
+      reason: follower.reason,
+      status,
+    };
+    if (options.collectEvents) result.events = collected;
+    return result;
+  }
+
+  /** The status as of the end of the wait, not as of the last event. */
+  private async currentStatus(conversation: Conversation): Promise<Conversation["status"] | null> {
+    try {
+      const fresh = await this.http.data<Conversation>(
+        "GET",
+        `/api/conversations/${conversation.id}`,
+      );
+      return fresh?.status ?? conversation.status ?? null;
+    } catch {
+      return conversation.status ?? null;
+    }
+  }
+
+  /** The id, once known — for internal callers that already awaited the open. */
+  get id(): string | null {
+    return this.conversationIdValue;
+  }
+}
+
+/** A `sandbox`/`terminate` stage event that means no turn event will arrive. */
+function isConversationOver(event: LogEvent): boolean {
+  if (event.kind !== "stage") return false;
+  if (event.stage === "terminate") return true;
+  if (event.stage === "sandbox" && event.state && TERMINAL_CONVERSATION_STATUSES.has(event.state)) {
+    return true;
+  }
+  return false;
+}
+
+/** Mark a promise as handled without changing what it settles to. */
+function hushed<T>(promise: Promise<T>): Promise<T> {
+  promise.catch(() => {});
+  return promise;
+}

--- a/sdk/typescript/src/sse.ts
+++ b/sdk/typescript/src/sse.ts
@@ -1,0 +1,220 @@
+import type { HttpClient } from "./http.ts";
+import type { LogEvent } from "./types.ts";
+import { FountainError, errorForStatus } from "./errors.ts";
+
+/** One `id:`/`event:`/`data:` message off the wire. */
+export interface SseMessage {
+  id: string | null;
+  event: string;
+  data: string;
+}
+
+/** Split a byte stream into SSE messages. Comments (`: heartbeat`) are dropped. */
+export async function* parseSse(body: ReadableStream<Uint8Array>): AsyncGenerator<SseMessage> {
+  const decoder = new TextDecoder();
+  const reader = body.getReader();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let split: number;
+      // A message ends at a blank line; \r\n is legal and Fountain sends \n.
+      while ((split = indexOfBoundary(buffer)) !== -1) {
+        const { chunk, length } = boundaryAt(buffer, split);
+        buffer = buffer.slice(split + length);
+        const message = parseChunk(chunk);
+        if (message) yield message;
+      }
+    }
+  } finally {
+    // A consumer that breaks out mid-turn must not leave the socket open.
+    try {
+      await reader.cancel();
+    } catch {
+      // Already closed, or the peer went away first.
+    }
+    reader.releaseLock();
+  }
+
+  const tail = parseChunk(buffer);
+  if (tail) yield tail;
+}
+
+function indexOfBoundary(buffer: string): number {
+  const lf = buffer.indexOf("\n\n");
+  const crlf = buffer.indexOf("\r\n\r\n");
+  if (lf === -1) return crlf;
+  if (crlf === -1) return lf;
+  return Math.min(lf, crlf);
+}
+
+function boundaryAt(buffer: string, index: number): { chunk: string; length: number } {
+  const isCrlf = buffer.startsWith("\r\n\r\n", index);
+  return { chunk: buffer.slice(0, index), length: isCrlf ? 4 : 2 };
+}
+
+function parseChunk(chunk: string): SseMessage | null {
+  let id: string | null = null;
+  let event = "message";
+  const data: string[] = [];
+
+  for (const rawLine of chunk.split("\n")) {
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (!line || line.startsWith(":")) continue; // heartbeat comment
+    const colon = line.indexOf(":");
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? "" : line.slice(colon + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+
+    if (field === "id") id = value;
+    else if (field === "event") event = value;
+    else if (field === "data") data.push(value);
+  }
+
+  if (!data.length && id === null) return null;
+  return { id, event, data: data.join("\n") };
+}
+
+export interface StreamOptions {
+  /** Resume after this event id. `0` replays the conversation from the start. */
+  after?: number;
+  signal?: AbortSignal;
+  /** How long one connection may sit idle before it is retried. */
+  idleTimeoutMs?: number;
+  /** Give up reconnecting after this many consecutive failures. */
+  maxRetries?: number;
+  /** Wait between reconnects, in ms. Exposed so tests do not sleep. */
+  retryDelayMs?: number;
+  /** Comma-separated subset of `stdout`, `stderr`, `acp`, `stage`. */
+  streams?: string;
+  /** `false` drains the buffered events and closes instead of tailing live. */
+  wait?: boolean;
+}
+
+/**
+ * The conversation's log feed as an async iterable of `LogEvent`, reconnecting
+ * on its own.
+ *
+ * The reconnect is not decoration. A Fountain deploy, a sandbox wake or an
+ * ordinary proxy timeout will end an SSE connection mid-turn; without a cursor
+ * the next connection either replays what the caller already saw or misses
+ * what arrived in the gap. `Last-Event-ID` is Fountain's answer — the server
+ * replays buffered events after that id, then tails live — so this loop tracks
+ * the last id it yielded and resumes there. A caller never sees the seam.
+ */
+export async function* streamEvents(
+  http: HttpClient,
+  conversationId: string,
+  opts: StreamOptions = {},
+): AsyncGenerator<LogEvent> {
+  let lastId = opts.after ?? 0;
+  let attempt = 0;
+  const maxRetries = opts.maxRetries ?? 5;
+  const retryDelayMs = opts.retryDelayMs ?? 500;
+
+  while (true) {
+    let response: Response;
+    try {
+      response = await http.raw("GET", `/api/conversations/${conversationId}/stream`, {
+        query: {
+          blocks: "true",
+          streams: opts.streams,
+          wait: opts.wait === false ? "false" : undefined,
+        },
+        headers: lastId > 0 ? { "Last-Event-ID": String(lastId) } : {},
+        accept: "text/event-stream",
+        signal: opts.signal,
+        // The stream is meant to be held open; a request timeout would kill it.
+        timeoutMs: 0,
+      });
+    } catch (error) {
+      if (opts.signal?.aborted) return;
+      if (++attempt > maxRetries) throw error;
+      await delay(retryDelayMs * attempt, opts.signal);
+      continue;
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      // 4xx will not fix itself: a bad key or a conversation this account
+      // cannot see returns the same answer however many times we ask.
+      if (response.status < 500 || ++attempt > maxRetries) {
+        throw errorForStatus(response.status, text ? safeJson(text) : null, "GET", `stream ${conversationId}`);
+      }
+      await delay(retryDelayMs * attempt, opts.signal);
+      continue;
+    }
+
+    if (!response.body) {
+      throw new FountainError("SSE response had no body");
+    }
+
+    attempt = 0;
+    try {
+      for await (const message of parseSse(response.body)) {
+        if (opts.signal?.aborted) return;
+        const id = Number(message.id);
+        if (Number.isFinite(id) && id > 0) lastId = id;
+        const event = decodeEvent(message);
+        if (event) yield event;
+      }
+    } catch (error) {
+      if (opts.signal?.aborted) return;
+      if (++attempt > maxRetries) throw error;
+      await delay(retryDelayMs * attempt, opts.signal);
+      continue;
+    }
+
+    // A drain closes on purpose; there is nothing to reconnect to.
+    if (opts.wait === false) return;
+
+    // The connection ended. Fountain closes an idle stream after 60s, which is
+    // normal for a conversation between turns — reconnect from the cursor.
+    if (opts.signal?.aborted) return;
+    if (++attempt > maxRetries) return;
+    await delay(retryDelayMs, opts.signal);
+  }
+}
+
+function decodeEvent(message: SseMessage): LogEvent | null {
+  if (!message.data) return null;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(message.data);
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== "object") return null;
+  const event = payload as LogEvent;
+  const id = Number(message.id);
+  if (Number.isFinite(id) && id > 0) event.id = id;
+  if (!event.kind) event.kind = message.event;
+  return event;
+}
+
+function safeJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve();
+    const timer = setTimeout(done, ms);
+    // Never hold the process open on a retry sleep.
+    timer.unref?.();
+    function done() {
+      signal?.removeEventListener("abort", done);
+      clearTimeout(timer);
+      resolve();
+    }
+    signal?.addEventListener("abort", done, { once: true });
+  });
+}

--- a/sdk/typescript/src/turn.ts
+++ b/sdk/typescript/src/turn.ts
@@ -1,0 +1,175 @@
+import type { Block, LogEvent, RunEvent, TurnState } from "./types.ts";
+
+const TERMINAL_TURN_STATES = new Set(["done", "failed", "interrupted"]);
+
+/**
+ * Folds the log feed into one turn's answer.
+ *
+ * The feed carries every turn of the conversation and every stream of each
+ * turn, so "what did the agent just say" is a filtering problem, not a
+ * concatenation one. This class is the filter:
+ *
+ *   - a `stage`/`turn` event opens and closes the turn we are following, and
+ *     is the only thing that says how it ended;
+ *   - `output` events carry server-parsed `blocks`; only `text` is the answer,
+ *     `tool_use` is noise worth naming, `thinking` is neither;
+ *   - text that follows a tool call is a new message, so it gets a paragraph
+ *     break — the rule that stops a transcript reading as one run-on sentence.
+ *
+ * The joining rules are ported from the Hermes plugin, which learned them
+ * against real runtimes: ACP streams one message as chunks that join with
+ * nothing, while a legacy stdout row is a whole message and joins as a
+ * paragraph.
+ */
+export class TurnFollower {
+  readonly turnNumber: number;
+  turnId: string | null = null;
+  started = false;
+  state: TurnState | null = null;
+  exitCode: number | null = null;
+  reason: string | null = null;
+
+  private readonly chunks: string[] = [];
+  private readonly tools: string[] = [];
+  private breakBeforeText = false;
+
+  constructor(turnNumber: number, turnId: string | null = null) {
+    this.turnNumber = turnNumber;
+    this.turnId = turnId;
+  }
+
+  get text(): string {
+    return this.chunks.join("").trim();
+  }
+
+  get toolsUsed(): string[] {
+    return [...this.tools];
+  }
+
+  get finished(): boolean {
+    return this.state !== null;
+  }
+
+  /** Fold one event in, and report what a streaming caller should be told. */
+  apply(event: LogEvent): RunEvent[] {
+    if (event.kind === "stage") return this.applyStage(event);
+    if (event.kind !== "output") return [];
+    return this.applyOutput(event);
+  }
+
+  private applyStage(event: LogEvent): RunEvent[] {
+    if (event.stage !== "turn") return [];
+    const meta = parseJson(event.data) ?? {};
+    if (!this.matchesTurn(meta)) return [];
+
+    if (event.state === "started") {
+      this.started = true;
+      this.turnId = asString(meta.turn_id) ?? this.turnId;
+      return [{ type: "turn-start", turnNumber: this.turnNumber, turnId: this.turnId }];
+    }
+
+    if (event.state && TERMINAL_TURN_STATES.has(event.state)) {
+      this.state = event.state as TurnState;
+      this.turnId = this.turnId ?? asString(meta.turn_id);
+      if (typeof meta.exit_code === "number") this.exitCode = meta.exit_code;
+      const reason = asString(meta.reason) ?? asString(meta.stop_reason);
+      if (reason) this.reason = reason;
+      return [
+        { type: "turn-end", state: this.state, exitCode: this.exitCode, reason: this.reason },
+      ];
+    }
+
+    return [];
+  }
+
+  private matchesTurn(meta: Record<string, unknown>): boolean {
+    if (this.turnId && asString(meta.turn_id) === this.turnId) return true;
+    return meta.turn_number === this.turnNumber;
+  }
+
+  private applyOutput(event: LogEvent): RunEvent[] {
+    const turnId = asString(event.turn_id);
+    // A different turn's output — history, or a turn someone else started.
+    if (this.turnId && turnId && turnId !== this.turnId) return [];
+    // Output from before our turn opened is the tail of an older one.
+    if (!this.started && !this.turnId) return [];
+
+    const acp = event.stream === "acp";
+    const out: RunEvent[] = [];
+
+    for (const block of event.blocks ?? []) {
+      out.push({ type: "block", block, event });
+      out.push(...this.applyBlock(block, acp));
+    }
+    return out;
+  }
+
+  private applyBlock(block: Block, acp: boolean): RunEvent[] {
+    const body = block.body ?? "";
+
+    if (block.kind === "text") {
+      if (!body) return [];
+      const prefix = this.paragraphBreak(acp);
+      if (prefix) this.chunks.push(prefix);
+      this.chunks.push(body);
+      this.breakBeforeText = false;
+      return [{ type: "text", text: prefix + body }];
+    }
+
+    if (block.kind === "thinking") {
+      return body ? [{ type: "thinking", text: body }] : [];
+    }
+
+    // `raw` and `init` are transport bookkeeping: not output, and not a break.
+    if (block.kind === "raw" || block.kind === "init") return [];
+
+    this.breakBeforeText = true;
+
+    if (block.kind === "tool_use") {
+      const name = asString(block.name);
+      if (!name) return [];
+      if (!this.tools.includes(name)) this.tools.push(name);
+      return [{ type: "tool", name, block }];
+    }
+
+    // A `result` block is the answer only when the runtime said nothing else.
+    if (block.kind === "result" && !this.chunks.length && body) {
+      this.chunks.push(body);
+      return [{ type: "text", text: body }];
+    }
+
+    if (block.kind === "error" && body) {
+      const text = `\n[error] ${body}\n`;
+      this.chunks.push(text);
+      return [{ type: "text", text }];
+    }
+
+    return [];
+  }
+
+  /**
+   * ACP chunks are pieces of one message and join with nothing; anything after
+   * a tool call is a new message. A legacy row is a whole message either way.
+   */
+  private paragraphBreak(acp: boolean): string {
+    if (!this.chunks.length) return "";
+    if (acp && !this.breakBeforeText) return "";
+    const last = this.chunks[this.chunks.length - 1] ?? "";
+    return last.endsWith("\n") ? "" : "\n\n";
+  }
+}
+
+function parseJson(raw: unknown): Record<string, unknown> | null {
+  if (raw && typeof raw === "object") return raw as Record<string, unknown>;
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value ? value : null;
+}

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,0 +1,121 @@
+/**
+ * The wire shapes this SDK depends on. They are a subset: Fountain's REST API
+ * returns more fields than these, and the objects are passed through, so
+ * anything not named here is still on the value at runtime.
+ */
+
+/** A named, re-runnable agent config — runtime, model, skills, environment. */
+export interface Agent {
+  id: string;
+  name: string;
+  runtime?: string;
+  model?: string;
+  description?: string | null;
+  environment_id?: string | null;
+  [key: string]: unknown;
+}
+
+/** A named bag of things an agent can be given: an environment or a vault. */
+export interface NamedResource {
+  id: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export type ConversationStatus =
+  | "provisioning"
+  | "running"
+  | "idle"
+  | "suspended"
+  | "failed"
+  | "terminated"
+  | (string & {});
+
+/** One run of an agent inside a sandbox. */
+export interface Conversation {
+  id: string;
+  status: ConversationStatus;
+  agent_id?: string;
+  title?: string | null;
+  runtime?: string;
+  turn_count?: number;
+  last_active_at?: string | null;
+  [key: string]: unknown;
+}
+
+/** One prompt and everything the agent did in response. */
+export interface Turn {
+  turn_number: number;
+  status?: string;
+  prompt?: string;
+  exit_code?: number | null;
+  started_at?: string | null;
+  ended_at?: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * A server-parsed piece of an agent's output. `?blocks=true` is what makes the
+ * log feed portable: no client re-parses a runtime's dialect.
+ */
+export interface Block {
+  kind: "text" | "thinking" | "tool_use" | "result" | "error" | "raw" | "init" | (string & {});
+  body?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+/** One row of the conversation's log feed. */
+export interface LogEvent {
+  id: number;
+  kind: "output" | "stage" | (string & {});
+  /** `stdout`, `stderr`, `acp` or `stage`. */
+  stream?: string;
+  /** Raw output for an `output` event; JSON-encoded metadata for a `stage` one. */
+  data?: string;
+  /** `provision`, `setup`, `turn`, `reattach`, `sandbox`, `terminate`. */
+  stage?: string;
+  state?: string;
+  turn_id?: string | null;
+  ts?: string;
+  blocks?: Block[];
+  [key: string]: unknown;
+}
+
+/** How a turn ended. `timeout` means the SDK stopped waiting, not that the agent stopped. */
+export type TurnState = "done" | "failed" | "interrupted" | "timeout";
+
+/** What the agent streams back while it works. */
+export type RunEvent =
+  | { type: "conversation"; conversationId: string; conversation: Conversation; url: string }
+  | { type: "turn-start"; turnNumber: number; turnId: string | null }
+  | { type: "text"; text: string }
+  | { type: "thinking"; text: string }
+  | { type: "tool"; name: string; block: Block }
+  | { type: "block"; block: Block; event: LogEvent }
+  | { type: "event"; event: LogEvent }
+  | { type: "turn-end"; state: TurnState; exitCode: number | null; reason: string | null };
+
+/** The finished turn. */
+export interface RunResult {
+  /** The conversation the turn ran in. Keep it: the sandbox is still there. */
+  conversationId: string;
+  /** Where a human watches it. */
+  url: string;
+  /** Which turn this was — 1 for a fresh `run`, 2+ for a `send`. */
+  turnNumber: number;
+  /** Everything the agent said, tool noise removed. */
+  text: string;
+  /** Tool names the agent used, in the order it first used each. */
+  toolsUsed: string[];
+  /** How the turn ended. */
+  state: TurnState;
+  /** The runtime's exit code when it reported one. */
+  exitCode: number | null;
+  /** Why it stopped, when the runtime said (`stop_reason`, a failure message). */
+  reason: string | null;
+  /** The conversation's status when the turn ended. */
+  status: ConversationStatus | null;
+  /** Every log event consumed, when `collectEvents` was set. */
+  events?: LogEvent[];
+}

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -4,18 +4,129 @@
  * anything not named here is still on the value at runtime.
  */
 
-/** A named, re-runnable agent config — runtime, model, skills, environment. */
-export interface Agent {
+/** The agent runtimes Fountain can start. */
+export type Runtime = "claude" | "codex" | "gemini" | "opencode";
+
+/** Sandbox backends. `null` on an agent means "the instance default". */
+export type SandboxProvider = "sprites" | "e2b" | "daytona" | "runner";
+
+/**
+ * A skill given to an agent — either written into the sandbox verbatim, or
+ * installed from GitHub. Exactly one of `content` or `source` per entry.
+ */
+export type SkillInput =
+  | { name: string; content: string; source?: never; ref?: never }
+  | { source: string; ref?: string; name?: string; content?: never };
+
+/** A repository the environment clones into the sandbox before the agent starts. */
+export interface Repository {
+  url: string;
+  mount_path: string;
+}
+
+/**
+ * An agent definition: everything that decides how a run behaves, before the
+ * prompt. This is the same vocabulary as the REST API and a `fountain.yml`
+ * manifest — deliberately, so one definition reads the same in all three.
+ */
+export interface AgentInput {
+  name: string;
+  /** Canonical `provider/model_id`, e.g. `anthropic/claude-sonnet-5`. */
+  model: string;
+  runtime: Runtime;
+  description?: string;
+  /** The agent's system prompt. */
+  system?: string;
+  /** Sandbox backend override; `null` inherits the instance default. */
+  sandbox_provider?: SandboxProvider | null;
+  /** The environment this agent runs in by default. */
+  environment_id?: string | null;
+  skills?: SkillInput[];
+  /** MCP servers, in the runtime's own config shape. */
+  mcp_servers?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  /**
+   * Vaults a conversation may attach. `null` (default) allows any the account
+   * owns, `[]` forbids all of them, a list is an allowlist. Vault values
+   * override the environment on a key collision, so this is what scopes who
+   * can override reviewed config.
+   */
+  allowed_vault_ids?: string[] | null;
+  /** Environments a conversation may launch under instead of this agent's own. */
+  allowed_environment_ids?: string[] | null;
+}
+
+/** A named, re-runnable agent config, as the API returns it. */
+export interface Agent extends Partial<AgentInput> {
   id: string;
   name: string;
-  runtime?: string;
-  model?: string;
-  description?: string | null;
-  environment_id?: string | null;
+  /** Whether the runtime speaks the Agent Client Protocol. Derived, never stored. */
+  acp?: boolean;
+  conversation_count?: number;
+  avatar_media_type?: string | null;
+  inserted_at?: string;
+  updated_at?: string;
   [key: string]: unknown;
 }
 
-/** A named bag of things an agent can be given: an environment or a vault. */
+/** Egress policy. `limited` with no `allowed_hosts` denies everything. */
+export type NetworkingType = "unrestricted" | "limited";
+
+/** The sandbox an agent runs in, before any conversation exists. */
+export interface EnvironmentInput {
+  name: string;
+  /** Packages to install, keyed by manager (`apt`, `npm`, ...). */
+  packages?: Record<string, unknown>;
+  /** Non-secret environment variables. Secrets go through `secrets.set`. */
+  env_vars?: Record<string, string>;
+  setup_script?: string;
+  networking_type?: NetworkingType;
+  networking_config?: { allowed_hosts?: string[] } & Record<string, unknown>;
+  repositories?: Repository[];
+  metadata?: Record<string, unknown>;
+}
+
+/** An environment, as the API returns it. */
+export interface Environment extends Partial<EnvironmentInput> {
+  id: string;
+  name: string;
+  secret_count?: number;
+  /** Agents referencing this environment — 0 means it is safe to delete. */
+  agent_count?: number;
+  inserted_at?: string;
+  updated_at?: string;
+  [key: string]: unknown;
+}
+
+/** A free-floating bag of env-var overrides, picked per conversation. */
+export interface VaultInput {
+  name: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** A vault, as the API returns it. */
+export interface Vault extends Partial<VaultInput> {
+  id: string;
+  name: string;
+  secret_count?: number;
+  inserted_at?: string;
+  updated_at?: string;
+  [key: string]: unknown;
+}
+
+/** A stored secret. Values are write-only — the API never returns them. */
+export interface Secret {
+  id: string;
+  key: string;
+  environment_id?: string;
+  vault_id?: string;
+  inserted_at?: string;
+  updated_at?: string;
+  [key: string]: unknown;
+}
+
+/** A named thing an agent can be given: an environment or a vault. */
 export interface NamedResource {
   id: string;
   name: string;

--- a/sdk/typescript/test/config.test.ts
+++ b/sdk/typescript/test/config.test.ts
@@ -1,0 +1,102 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveConfig, conversationUrl, DEFAULT_BASE_URL } from "../src/config.ts";
+
+const VARS = [
+  "FOUNTAIN_API_KEY",
+  "FOUNTAIN_TOKEN",
+  "FOUNTAIN_BASE_URL",
+  "FOUNTAIN_PROFILE",
+  "FOUNTAIN_APP_URL",
+  "FOUNTAIN_CONVERSATION_ID",
+  "FOUNTAIN_CREDENTIALS_FILE",
+];
+
+let saved: Record<string, string | undefined> = {};
+let dir: string;
+
+beforeEach(() => {
+  saved = Object.fromEntries(VARS.map((name) => [name, process.env[name]]));
+  for (const name of VARS) delete process.env[name];
+  dir = mkdtempSync(join(tmpdir(), "fountain-sdk-"));
+});
+
+afterEach(() => {
+  for (const [name, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function credentials(contents: string): string {
+  const path = join(dir, "credentials");
+  writeFileSync(path, contents);
+  process.env.FOUNTAIN_CREDENTIALS_FILE = path;
+  return path;
+}
+
+describe("resolveConfig", () => {
+  test("an explicit option beats everything", () => {
+    process.env.FOUNTAIN_API_KEY = "from-env";
+    const config = resolveConfig({ apiKey: "explicit", baseUrl: "https://self.hosted/" });
+    assert.equal(config.apiKey, "explicit");
+    assert.equal(config.baseUrl, "https://self.hosted", "trailing slash is trimmed");
+  });
+
+  test("FOUNTAIN_TOKEN is the in-sandbox fallback", () => {
+    process.env.FOUNTAIN_TOKEN = "sandbox-token";
+    assert.equal(resolveConfig().apiKey, "sandbox-token");
+  });
+
+  test("FOUNTAIN_API_KEY wins over FOUNTAIN_TOKEN", () => {
+    process.env.FOUNTAIN_TOKEN = "sandbox-token";
+    process.env.FOUNTAIN_API_KEY = "my-key";
+    assert.equal(resolveConfig().apiKey, "my-key");
+  });
+
+  test("reads the profile the CLI wrote, quotes and all", () => {
+    credentials('[default]\napi_key = "fk_default"\nbase_url = "https://one.example"\n\n[work]\napi_key = fk_work\nbase_url = https://two.example\n');
+    const fallback = resolveConfig();
+    assert.equal(fallback.apiKey, "fk_default");
+    assert.equal(fallback.baseUrl, "https://one.example");
+
+    const work = resolveConfig({ profile: "work" });
+    assert.equal(work.apiKey, "fk_work");
+    assert.equal(work.baseUrl, "https://two.example");
+  });
+
+  test("an unknown profile contributes nothing, and is not an error", () => {
+    credentials("[default]\napi_key = fk_default\n");
+    const config = resolveConfig({ profile: "nope" });
+    assert.equal(config.apiKey, "");
+    assert.equal(config.baseUrl, DEFAULT_BASE_URL);
+  });
+
+  test("a missing credentials file is not an error", () => {
+    process.env.FOUNTAIN_CREDENTIALS_FILE = join(dir, "does-not-exist");
+    assert.equal(resolveConfig().apiKey, "");
+  });
+
+  test("running inside a sandbox records the parent conversation", () => {
+    process.env.FOUNTAIN_CONVERSATION_ID = "conv-parent";
+    assert.equal(resolveConfig().parentConversationId, "conv-parent");
+    delete process.env.FOUNTAIN_CONVERSATION_ID;
+    assert.equal(resolveConfig().parentConversationId, undefined);
+  });
+});
+
+describe("conversationUrl", () => {
+  test("points at the conversations app", () => {
+    const config = resolveConfig({ appUrl: "https://app.example/c/" });
+    assert.equal(conversationUrl("abc", config), "https://app.example/c/#/c/abc");
+  });
+
+  test("a deployment with no app falls back to something fetchable", () => {
+    const config = resolveConfig({ baseUrl: "https://self.hosted", appUrl: "" });
+    assert.equal(conversationUrl("abc", config), "https://self.hosted/api/conversations/abc");
+  });
+});

--- a/sdk/typescript/test/resources.test.ts
+++ b/sdk/typescript/test/resources.test.ts
@@ -1,0 +1,171 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { FakeFountain } from "./server.ts";
+import { Fountain, type AgentInput } from "../src/index.ts";
+import { NotFoundError, ValidationError } from "../src/errors.ts";
+
+let fake: FakeFountain;
+let baseUrl: string;
+
+const client = (): Fountain => new Fountain({ baseUrl, apiKey: "fk_test" });
+
+before(async () => {
+  fake = new FakeFountain();
+  baseUrl = await fake.start();
+});
+
+after(async () => {
+  await fake.stop();
+});
+
+beforeEach(() => {
+  fake.agents = [
+    { id: "11111111-1111-1111-1111-111111111111", name: "reposage", runtime: "claude", model: "opus" },
+  ];
+  fake.vaults = [{ id: "aaaaaaaa-1111-1111-1111-111111111111", name: "github-bot" }];
+  fake.environments = [{ id: "bbbbbbbb-1111-1111-1111-111111111111", name: "monorepo" }];
+  fake.secrets.clear();
+  fake.requests.length = 0;
+});
+
+/** The definition the docs show — every field an agent has, in one object. */
+const DEFINITION: AgentInput = {
+  name: "reposage",
+  runtime: "claude",
+  model: "anthropic/claude-sonnet-5",
+  description: "Reads a repository and answers questions about it",
+  system: "You are a careful reader of other people's code.",
+  environment_id: "bbbbbbbb-1111-1111-1111-111111111111",
+  sandbox_provider: null,
+  skills: [
+    { source: "obra/superpowers", ref: "v2.1.0" },
+    { name: "house-style", content: "# House style\n\nPrefer small diffs." },
+  ],
+  mcp_servers: { linear: { command: "npx", args: ["-y", "linear-mcp"] } },
+  allowed_vault_ids: ["aaaaaaaa-1111-1111-1111-111111111111"],
+  allowed_environment_ids: null,
+  metadata: { team: "platform" },
+};
+
+describe("agents", () => {
+  test("a whole definition goes to the wire flat, and comes back", async () => {
+    const created = await client().agents.create({ ...DEFINITION, name: "newcomer" });
+
+    assert.equal(created.name, "newcomer");
+    assert.equal(created.runtime, "claude");
+
+    const post = fake.requests.find((r) => r.method === "POST" && r.path === "/api/agents");
+    // Flat attributes — not wrapped under an `agent` key, which the server rejects.
+    assert.deepEqual(post?.body, { ...DEFINITION, name: "newcomer" });
+  });
+
+  test("a name is usable the moment it exists", async () => {
+    const fountain = client();
+    // Warm the resolver's memo so the create has something stale to invalidate.
+    await fountain.agents.list();
+
+    await fountain.agents.create({ ...DEFINITION, name: "brand-new" });
+    const found = await fountain.agents.get("brand-new");
+    assert.equal(found.name, "brand-new");
+  });
+
+  test("update touches only what it is given", async () => {
+    const fountain = client();
+    const updated = await fountain.agents.update("reposage", { model: "anthropic/claude-opus-5" });
+
+    assert.equal(updated.model, "anthropic/claude-opus-5");
+    assert.equal(updated.runtime, "claude", "untouched fields survive");
+
+    const patch = fake.requests.find((r) => r.method === "PATCH");
+    assert.deepEqual(patch?.body, { model: "anthropic/claude-opus-5" });
+    assert.match(String(patch?.path), /^\/api\/agents\/11111111-/, "resolved the name to an id");
+  });
+
+  test("a rename is visible to the next lookup", async () => {
+    const fountain = client();
+    await fountain.agents.get("reposage");
+    await fountain.agents.update("reposage", { name: "repo-sage" });
+
+    const found = await fountain.agents.get("repo-sage");
+    assert.equal(found.name, "repo-sage");
+  });
+
+  test("delete removes it, and the account listing agrees", async () => {
+    const fountain = client();
+    await fountain.agents.delete("reposage");
+    assert.deepEqual(await fountain.agents.list(), []);
+  });
+
+  test("a definition without a name is rejected by the API, not the SDK", async () => {
+    await assert.rejects(
+      () => client().agents.create({ runtime: "claude", model: "anthropic/x" } as AgentInput),
+      (error: unknown) => {
+        assert.ok(error instanceof ValidationError);
+        assert.equal(error.status, 422);
+        return true;
+      },
+    );
+  });
+});
+
+describe("environments and their secrets", () => {
+  test("create an environment with repos and an egress allowlist", async () => {
+    const env = await client().environments.create({
+      name: "monorepo-ci",
+      packages: { apt: ["ripgrep"] },
+      env_vars: { CI: "true" },
+      setup_script: "mix deps.get",
+      networking_type: "limited",
+      networking_config: { allowed_hosts: ["github.com", "hex.pm"] },
+      repositories: [{ url: "https://github.com/BinaryBourbon/fountain", mount_path: "/work" }],
+    });
+
+    assert.equal(env.name, "monorepo-ci");
+    const post = fake.requests.find((r) => r.method === "POST" && r.path === "/api/environments");
+    assert.equal((post?.body as Record<string, unknown>).networking_type, "limited");
+  });
+
+  test("a secret goes in by name and never comes back out", async () => {
+    const fountain = client();
+    await fountain.environments.secrets.set("monorepo", "HEX_API_KEY", "super-secret");
+
+    const listed = await fountain.environments.secrets.list("monorepo");
+    assert.deepEqual(listed.map((s) => s.key), ["HEX_API_KEY"]);
+    // The whole point: the SDK can put a credential in and cannot read it back.
+    assert.equal(JSON.stringify(listed).includes("super-secret"), false);
+  });
+
+  test("setAll stores several, and delete takes the key", async () => {
+    const fountain = client();
+    await fountain.vaults.secrets.setAll("github-bot", {
+      GITHUB_TOKEN: "ghp_x",
+      GITHUB_USER: "bot",
+    });
+    assert.equal((await fountain.vaults.secrets.list("github-bot")).length, 2);
+
+    await fountain.vaults.secrets.delete("github-bot", "GITHUB_USER");
+    assert.deepEqual(
+      (await fountain.vaults.secrets.list("github-bot")).map((s) => s.key),
+      ["GITHUB_TOKEN"],
+    );
+
+    const del = fake.requests.find((r) => r.method === "DELETE");
+    assert.match(String(del?.path), /\/secrets\/GITHUB_USER$/, "the key is the path segment");
+  });
+
+  test("secrets on something that does not exist say so", async () => {
+    await assert.rejects(
+      () => client().vaults.secrets.set("aaaaaaaa-0000-0000-0000-000000000000", "K", "v"),
+      NotFoundError,
+    );
+  });
+});
+
+describe("vaults", () => {
+  test("create and read back", async () => {
+    const fountain = client();
+    const vault = await fountain.vaults.create({ name: "staging", description: "staging creds" });
+    assert.equal(vault.name, "staging");
+    assert.equal((await fountain.vaults.get("staging")).description, "staging creds");
+  });
+});

--- a/sdk/typescript/test/run.test.ts
+++ b/sdk/typescript/test/run.test.ts
@@ -1,0 +1,342 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { FakeFountain } from "./server.ts";
+import { Fountain } from "../src/index.ts";
+import {
+  NotFoundError,
+  ResolutionError,
+  SubscriptionRequiredError,
+  TimeoutError,
+} from "../src/errors.ts";
+
+let fake: FakeFountain;
+let baseUrl: string;
+
+const client = (): Fountain =>
+  new Fountain({ baseUrl, apiKey: "fk_test", appUrl: "https://app.example/fountain" });
+
+before(async () => {
+  fake = new FakeFountain();
+  baseUrl = await fake.start();
+});
+
+after(async () => {
+  await fake.stop();
+});
+
+beforeEach(() => {
+  fake.conversations.clear();
+  fake.requests.length = 0;
+  fake.onTurn = null;
+  fake.dieAfterEvents = null;
+  fake.failNextWith = null;
+});
+
+describe("run", () => {
+  test("resolves names, opens a conversation and returns the answer", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.scriptTurn(conversation.id, {
+        turnNumber,
+        turnId: "t1",
+        tools: ["Bash", "Edit"],
+        text: ["Opened ", "PR #12."],
+      });
+    };
+
+    const run = await client().run("upgrade phoenix", {
+      agent: "reposage",
+      vault: "github-bot",
+      environment: "monorepo",
+    });
+
+    assert.equal(run.text, "Opened PR #12.");
+    assert.deepEqual(run.toolsUsed, ["Bash", "Edit"]);
+    assert.equal(run.state, "done");
+    assert.equal(run.turnNumber, 1);
+    assert.equal(run.reason, "end_turn");
+    assert.equal(run.url, `https://app.example/fountain/#/c/${run.conversationId}`);
+
+    // The names went to the wire as ids, and the prompt carried no secret.
+    const create = fake.requests.find((r) => r.method === "POST" && r.path === "/api/conversations");
+    assert.deepEqual(create?.body, {
+      agent_id: "11111111-1111-1111-1111-111111111111",
+      prompt: "upgrade phoenix",
+      vault_id: "aaaaaaaa-1111-1111-1111-111111111111",
+      environment_id: "bbbbbbbb-1111-1111-1111-111111111111",
+    });
+  });
+
+  test("an unknown agent name names the ones that exist", async () => {
+    await assert.rejects(
+      async () => {
+        await client().run("hi", { agent: "repossage" });
+      },
+      (error: unknown) => {
+        assert.ok(error instanceof ResolutionError);
+        assert.match(error.message, /No agent named "repossage"/);
+        assert.match(error.message, /reporter, reposage/);
+        return true;
+      },
+    );
+  });
+
+  test("an agent id is used as-is, without listing the account", async () => {
+    fake.onTurn = (c, n) => fake.scriptTurn(c.id, { turnNumber: n, turnId: "t1", text: ["ok"] });
+    const run = await client().run("hi", { agent: "11111111-1111-1111-1111-111111111111" });
+    assert.equal(run.text, "ok");
+    assert.equal(fake.requests.filter((r) => r.path === "/api/agents").length, 0);
+  });
+
+  test("streams text while the turn runs, and awaits the same run", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.scriptTurn(conversation.id, {
+        turnNumber,
+        turnId: "t1",
+        text: ["Look", "ing at ", "the repo."],
+      });
+    };
+
+    const run = client().run("look", { agent: "reposage" });
+    const chunks: string[] = [];
+    for await (const chunk of run.textStream) chunks.push(chunk);
+
+    assert.deepEqual(chunks, ["Look", "ing at ", "the repo."]);
+    const result = await run;
+    assert.equal(result.text, "Looking at the repo.");
+  });
+
+  test("iterating yields lifecycle events in order", async () => {
+    fake.onTurn = (c, n) =>
+      fake.scriptTurn(c.id, { turnNumber: n, turnId: "t1", tools: ["Read"], text: ["done"] });
+
+    const run = client().run("go", { agent: "reposage" });
+    const types: string[] = [];
+    for await (const event of run) {
+      if (event.type === "event" || event.type === "block") continue;
+      types.push(event.type);
+    }
+    assert.deepEqual(types, ["conversation", "turn-start", "tool", "text", "turn-end"]);
+  });
+
+  test("a failed turn is a result, not an exception", async () => {
+    fake.onTurn = (c, n) =>
+      fake.scriptTurn(c.id, { turnNumber: n, turnId: "t1", text: ["boom"], state: "failed" });
+
+    const run = await client().run("go", { agent: "reposage" });
+    assert.equal(run.state, "failed");
+    assert.equal(run.text, "boom");
+  });
+
+  test("output from another turn is not this turn's answer", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      // A turn that was already running when we attached.
+      fake.emit(conversation.id, {
+        kind: "output",
+        stream: "acp",
+        turn_id: "older",
+        blocks: [{ kind: "text", body: "leftovers from turn 0" }],
+      });
+      fake.scriptTurn(conversation.id, { turnNumber, turnId: "t1", text: ["mine"] });
+    };
+
+    const run = await client().run("go", { agent: "reposage" });
+    assert.equal(run.text, "mine");
+  });
+
+  test("a stdout runtime joins rows as paragraphs, acp joins chunks", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.scriptTurn(conversation.id, {
+        turnNumber,
+        turnId: "t1",
+        text: ["first line", "second line"],
+        stream: "stdout",
+      });
+    };
+    const legacy = await client().run("go", { agent: "reposage" });
+    assert.equal(legacy.text, "first line\n\nsecond line");
+  });
+
+  test("text after a tool call starts a new paragraph", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      const turnId = "t1";
+      fake.emit(conversation.id, {
+        kind: "stage",
+        stage: "turn",
+        state: "started",
+        stream: "stage",
+        data: JSON.stringify({ turn_number: turnNumber, turn_id: turnId }),
+      });
+      fake.emit(conversation.id, {
+        kind: "output",
+        stream: "acp",
+        turn_id: turnId,
+        blocks: [{ kind: "text", body: "Reading it." }],
+      });
+      fake.emit(conversation.id, {
+        kind: "output",
+        stream: "acp",
+        turn_id: turnId,
+        blocks: [{ kind: "tool_use", name: "Read" }],
+      });
+      fake.emit(conversation.id, {
+        kind: "output",
+        stream: "acp",
+        turn_id: turnId,
+        blocks: [{ kind: "text", body: "It's a Phoenix app." }],
+      });
+      fake.emit(conversation.id, {
+        kind: "stage",
+        stage: "turn",
+        state: "done",
+        stream: "stage",
+        data: JSON.stringify({ turn_number: turnNumber, turn_id: turnId }),
+      });
+    };
+
+    const run = await client().run("go", { agent: "reposage" });
+    assert.equal(run.text, "Reading it.\n\nIt's a Phoenix app.");
+  });
+
+  test("a dead connection mid-turn resumes from the last event id", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.scriptTurn(conversation.id, {
+        turnNumber,
+        turnId: "t1",
+        text: ["one ", "two ", "three"],
+      });
+    };
+    // Kill the first connection after the turn-start and the first chunk.
+    fake.dieAfterEvents = 2;
+
+    const run = await client().run("go", { agent: "reposage" });
+
+    assert.equal(run.text, "one two three");
+    const streams = fake.requests.filter((r) => r.path.endsWith("/stream"));
+    assert.equal(streams.length, 2, "should have reconnected exactly once");
+    // It resumed at the last event it actually saw — not at 0, which would
+    // have replayed "one " and doubled it in the answer.
+    const secondEventId = fake.conversations.get(run.conversationId)?.events[1]?.id;
+    assert.equal(streams[1]?.headers["last-event-id"], String(secondEventId));
+  });
+
+  test("timing out says where the work still is", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.emit(conversation.id, {
+        kind: "stage",
+        stage: "turn",
+        state: "started",
+        stream: "stage",
+        data: JSON.stringify({ turn_number: turnNumber, turn_id: "t1" }),
+      });
+      fake.emit(conversation.id, {
+        kind: "output",
+        stream: "acp",
+        turn_id: "t1",
+        blocks: [{ kind: "text", body: "thinking..." }],
+      });
+      // ...and never finishes.
+    };
+
+    await assert.rejects(
+      async () => {
+        await client().run("go", { agent: "reposage", timeoutMs: 150 });
+      },
+      (error: unknown) => {
+        assert.ok(error instanceof TimeoutError);
+        assert.equal(error.partialText, "thinking...");
+        assert.match(error.message, /still running/);
+        assert.ok(error.conversationId.startsWith("conv-"));
+        return true;
+      },
+    );
+  });
+
+  test("a torn-down sandbox ends the wait instead of hanging", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.emit(conversation.id, {
+        kind: "stage",
+        stage: "turn",
+        state: "started",
+        stream: "stage",
+        data: JSON.stringify({ turn_number: turnNumber, turn_id: "t1" }),
+      });
+      fake.emit(conversation.id, { kind: "stage", stage: "terminate", state: "done", stream: "stage" });
+    };
+
+    const run = await client().run("go", { agent: "reposage", timeoutMs: 2_000 });
+    assert.equal(run.state, "timeout");
+    assert.equal(run.text, "");
+  });
+});
+
+describe("resume and send", () => {
+  test("a follow-up is turn 2 in the same sandbox", async () => {
+    fake.onTurn = (c, n) => fake.scriptTurn(c.id, { turnNumber: n, turnId: `t${n}`, text: [`answer ${n}`] });
+
+    const fountain = client();
+    const first = await fountain.run("first", { agent: "reposage" });
+    const second = await fountain.resume(first.conversationId).send("second");
+
+    assert.equal(second.turnNumber, 2);
+    assert.equal(second.text, "answer 2");
+    assert.equal(second.conversationId, first.conversationId);
+  });
+
+  test("a cold resume skips the earlier turns' events", async () => {
+    fake.onTurn = (c, n) => fake.scriptTurn(c.id, { turnNumber: n, turnId: `t${n}`, text: [`answer ${n}`] });
+
+    const first = await client().run("first", { agent: "reposage" });
+    fake.requests.length = 0;
+
+    // A different process entirely: no memory of where the feed got to.
+    const second = await client().resume(first.conversationId).send("second");
+    assert.equal(second.text, "answer 2");
+
+    const streams = fake.requests.filter((r) => r.path.endsWith("/stream"));
+    const drain = streams.find((r) => r.method === "GET");
+    assert.ok(drain, "should have drained the stage stream to find the cursor");
+    const live = streams.at(-1);
+    assert.ok(Number(live?.headers["last-event-id"]) > 0, "the live stream resumes past the history");
+  });
+});
+
+describe("errors", () => {
+  test("402 carries the upgrade url", async () => {
+    fake.failNextWith = { status: 402, body: { error: "subscription_required", upgrade_url: "/account/billing" } };
+    await assert.rejects(
+      async () => {
+        await client().run("go", { agent: "11111111-1111-1111-1111-111111111111" });
+      },
+      (error: unknown) => {
+        assert.ok(error instanceof SubscriptionRequiredError);
+        assert.equal(error.status, 402);
+        assert.equal(error.code, "subscription_required");
+        assert.equal(error.upgradeUrl, "/account/billing");
+        return true;
+      },
+    );
+  });
+
+  test("a conversation that is not ours is a NotFoundError", async () => {
+    await assert.rejects(
+      () => client().resume("conv-nope").get(),
+      (error: unknown) => {
+        assert.ok(error instanceof NotFoundError);
+        assert.match(error.message, /wrong id, or it belongs to another account/);
+        return true;
+      },
+    );
+  });
+
+  test("a missing key fails before any request", async () => {
+    const bare = new Fountain({ baseUrl, apiKey: "", profile: "no-such-profile" });
+    await assert.rejects(() => bare.me(), /No Fountain API key/);
+  });
+});
+
+describe("escape hatch", () => {
+  test("api reaches endpoints the SDK does not wrap", async () => {
+    const me = await client().request<{ data: { email: string } }>("GET", "/api/auth/me");
+    assert.equal(me.data.email, "test@example.com");
+  });
+});

--- a/sdk/typescript/test/run.test.ts
+++ b/sdk/typescript/test/run.test.ts
@@ -251,6 +251,38 @@ describe("run", () => {
     );
   });
 
+  test("a conversation that dies under the turn ends the wait, with the reason", async () => {
+    // provision/failed is the real shape: the server stops, so no turn event
+    // is ever coming. Waiting for one would hang forever.
+    fake.onTurn = (conversation) => {
+      fake.failConversation(conversation.id, "provision deadline exceeded");
+    };
+
+    const run = await client().run("go", { agent: "reposage" });
+    assert.equal(run.state, "failed");
+    assert.equal(run.status, "failed");
+    assert.match(String(run.reason), /provision deadline exceeded/);
+  });
+
+  test("a failure stage on a conversation that is still alive is not the end", async () => {
+    // setup/failed does not necessarily stop the conversation, which is why
+    // the SDK asks for the status rather than trusting the stage name.
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.emit(conversation.id, {
+        kind: "stage",
+        stage: "setup",
+        state: "failed",
+        stream: "stage",
+        data: JSON.stringify({ exit_code: 1 }),
+      });
+      fake.scriptTurn(conversation.id, { turnNumber, turnId: "t1", text: ["carried on anyway"] });
+    };
+
+    const run = await client().run("go", { agent: "reposage", timeoutMs: 5_000 });
+    assert.equal(run.state, "done");
+    assert.equal(run.text, "carried on anyway");
+  });
+
   test("a torn-down sandbox ends the wait instead of hanging", async () => {
     fake.onTurn = (conversation, turnNumber) => {
       fake.emit(conversation.id, {
@@ -260,11 +292,13 @@ describe("run", () => {
         stream: "stage",
         data: JSON.stringify({ turn_number: turnNumber, turn_id: "t1" }),
       });
+      conversation.status = "terminated";
       fake.emit(conversation.id, { kind: "stage", stage: "terminate", state: "done", stream: "stage" });
     };
 
     const run = await client().run("go", { agent: "reposage", timeoutMs: 2_000 });
-    assert.equal(run.state, "timeout");
+    assert.equal(run.state, "failed");
+    assert.equal(run.status, "terminated");
     assert.equal(run.text, "");
   });
 });

--- a/sdk/typescript/test/server.ts
+++ b/sdk/typescript/test/server.ts
@@ -36,12 +36,16 @@ export interface FakeConversation {
 }
 
 export class FakeFountain {
-  readonly agents = [
+  agents: Record<string, unknown>[] = [
     { id: "11111111-1111-1111-1111-111111111111", name: "reposage", runtime: "claude", model: "opus" },
     { id: "22222222-2222-2222-2222-222222222222", name: "reporter", runtime: "codex", model: "gpt" },
   ];
-  readonly vaults = [{ id: "aaaaaaaa-1111-1111-1111-111111111111", name: "github-bot" }];
-  readonly environments = [{ id: "bbbbbbbb-1111-1111-1111-111111111111", name: "monorepo" }];
+  vaults: Record<string, unknown>[] = [{ id: "aaaaaaaa-1111-1111-1111-111111111111", name: "github-bot" }];
+  environments: Record<string, unknown>[] = [
+    { id: "bbbbbbbb-1111-1111-1111-111111111111", name: "monorepo" },
+  ];
+  /** Secrets by `${collection}:${parentId}` → key → value. Never read back out. */
+  readonly secrets = new Map<string, Map<string, string>>();
 
   readonly conversations = new Map<string, FakeConversation>();
   /** Every request the SDK made, for assertions about the wire. */
@@ -154,10 +158,19 @@ export class FakeFountain {
 
     const path = url.pathname;
 
-    if (path === "/api/agents") return json(res, 200, { data: this.agents });
-    if (path === "/api/vaults") return json(res, 200, { data: this.vaults });
-    if (path === "/api/environments") return json(res, 200, { data: this.environments });
     if (path === "/api/auth/me") return json(res, 200, { data: { email: "test@example.com" } });
+
+    const collection = /^\/api\/(agents|vaults|environments)(?:\/([^/]+))?(?:\/(secrets)(?:\/(.+))?)?$/.exec(path);
+    if (collection) {
+      return this.collection(req, res, {
+        name: collection[1] as "agents" | "vaults" | "environments",
+        id: collection[2],
+        secrets: collection[3] === "secrets",
+        key: collection[4],
+        body,
+        search: url.searchParams.get("search"),
+      });
+    }
 
     if (path === "/api/conversations" && req.method === "POST") {
       return json(res, 201, { data: this.createConversation(body as Record<string, unknown>) });
@@ -188,6 +201,84 @@ export class FakeFountain {
     }
 
     json(res, 404, { error: "no route" });
+  }
+
+  /** The agent/vault/environment endpoints, including their secrets. */
+  private collection(
+    req: IncomingMessage,
+    res: ServerResponse,
+    q: {
+      name: "agents" | "vaults" | "environments";
+      id?: string | undefined;
+      secrets: boolean;
+      key?: string | undefined;
+      body: unknown;
+      search: string | null;
+    },
+  ): void {
+    const items = this[q.name];
+    const method = req.method ?? "GET";
+    const singular = { agents: "agent", vaults: "vault", environments: "environment" }[q.name];
+
+    if (!q.id) {
+      if (method === "GET") {
+        const data = q.search
+          ? items.filter((item) => String(item.name ?? "").includes(q.search as string))
+          : items;
+        return json(res, 200, { data });
+      }
+      if (method === "POST") {
+        const attrs = (q.body ?? {}) as Record<string, unknown>;
+        if (!attrs.name) return json(res, 422, { error: "name is required" });
+        // The API takes attributes flat, not wrapped under a resource key —
+        // asserted here so a wrapped payload fails loudly.
+        if (attrs[singular]) return json(res, 422, { error: `unexpected ${singular} wrapper` });
+        const created = { id: `${q.name}-${items.length + 1}`, ...attrs };
+        items.push(created);
+        return json(res, 201, { data: created });
+      }
+      return json(res, 405, { error: "method not allowed" });
+    }
+
+    const index = items.findIndex((item) => item.id === q.id);
+    if (index === -1) return json(res, 404, { error: "not found" });
+    const item = items[index] as Record<string, unknown>;
+
+    if (q.secrets) {
+      const bag = this.secrets.get(`${q.name}:${q.id}`) ?? new Map<string, string>();
+      this.secrets.set(`${q.name}:${q.id}`, bag);
+
+      if (method === "GET") {
+        // Keys only, never values.
+        return json(res, 200, {
+          data: [...bag.keys()].map((key) => ({ id: `sec-${key}`, key })),
+        });
+      }
+      if (method === "POST") {
+        const attrs = (q.body ?? {}) as Record<string, unknown>;
+        if (typeof attrs.key !== "string" || typeof attrs.value !== "string") {
+          return json(res, 422, { error: "key and value are required" });
+        }
+        bag.set(attrs.key, attrs.value);
+        return json(res, 201, { data: { id: `sec-${attrs.key}`, key: attrs.key } });
+      }
+      if (method === "DELETE" && q.key) {
+        if (!bag.delete(decodeURIComponent(q.key))) return json(res, 404, { error: "not found" });
+        return json(res, 204, null);
+      }
+      return json(res, 405, { error: "method not allowed" });
+    }
+
+    if (method === "GET") return json(res, 200, { data: item });
+    if (method === "PATCH") {
+      Object.assign(item, (q.body ?? {}) as Record<string, unknown>);
+      return json(res, 200, { data: item });
+    }
+    if (method === "DELETE") {
+      items.splice(index, 1);
+      return json(res, 204, null);
+    }
+    return json(res, 405, { error: "method not allowed" });
   }
 
   private createConversation(body: Record<string, unknown>): FakeConversation {

--- a/sdk/typescript/test/server.ts
+++ b/sdk/typescript/test/server.ts
@@ -1,0 +1,291 @@
+/**
+ * A fake Fountain, in process.
+ *
+ * The SDK's job is to turn a log feed into an answer, so the tests need a
+ * server that can hand out a feed on demand — including the awkward parts: a
+ * connection that dies mid-turn, output belonging to somebody else's turn, an
+ * ACP runtime that streams a sentence as five chunks.
+ */
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export interface FakeEvent {
+  kind: "output" | "stage";
+  stream?: string;
+  data?: string;
+  stage?: string;
+  state?: string;
+  turn_id?: string | null;
+  blocks?: unknown[];
+}
+
+interface StoredEvent extends FakeEvent {
+  id: number;
+}
+
+export interface FakeConversation {
+  id: string;
+  status: string;
+  agent_id: string;
+  vault_id?: string | null;
+  environment_id?: string | null;
+  title?: string | null;
+  turn_count: number;
+  events: StoredEvent[];
+  turns: { turn_number: number; status: string }[];
+}
+
+export class FakeFountain {
+  readonly agents = [
+    { id: "11111111-1111-1111-1111-111111111111", name: "reposage", runtime: "claude", model: "opus" },
+    { id: "22222222-2222-2222-2222-222222222222", name: "reporter", runtime: "codex", model: "gpt" },
+  ];
+  readonly vaults = [{ id: "aaaaaaaa-1111-1111-1111-111111111111", name: "github-bot" }];
+  readonly environments = [{ id: "bbbbbbbb-1111-1111-1111-111111111111", name: "monorepo" }];
+
+  readonly conversations = new Map<string, FakeConversation>();
+  /** Every request the SDK made, for assertions about the wire. */
+  readonly requests: { method: string; path: string; body: unknown; headers: NodeJS.Dict<string | string[]> }[] = [];
+
+  /** Called when a conversation opens or a prompt lands; script the turn here. */
+  onTurn: ((conversation: FakeConversation, turnNumber: number) => void) | null = null;
+  /** Force the next N SSE connections to die after this many events. */
+  dieAfterEvents: number | null = null;
+  /** Status to answer the next request with, instead of doing the work. */
+  failNextWith: { status: number; body: unknown } | null = null;
+
+  private nextEventId = 1;
+  private nextConversation = 1;
+  private readonly listeners = new Map<string, Set<() => void>>();
+  private server: Server | null = null;
+  private readonly openResponses = new Set<ServerResponse>();
+
+  async start(): Promise<string> {
+    this.server = createServer((req, res) => void this.handle(req, res));
+    await new Promise<void>((resolve) => this.server!.listen(0, "127.0.0.1", resolve));
+    const { port } = this.server!.address() as AddressInfo;
+    return `http://127.0.0.1:${port}`;
+  }
+
+  async stop(): Promise<void> {
+    for (const res of this.openResponses) res.destroy();
+    this.openResponses.clear();
+    await new Promise<void>((resolve) => this.server?.close(() => resolve()));
+    this.server = null;
+  }
+
+  /** Append an event to a conversation's feed and wake every open stream. */
+  emit(conversationId: string, event: FakeEvent): StoredEvent {
+    const conversation = this.conversations.get(conversationId);
+    if (!conversation) throw new Error(`no conversation ${conversationId}`);
+    const stored: StoredEvent = { ...event, id: this.nextEventId++ };
+    conversation.events.push(stored);
+    for (const wake of this.listeners.get(conversationId) ?? []) wake();
+    return stored;
+  }
+
+  /** The whole shape of one agent turn: start, some output, done. */
+  scriptTurn(
+    conversationId: string,
+    opts: { turnNumber: number; turnId: string; text?: string[]; tools?: string[]; state?: string; stream?: string },
+  ): void {
+    const turnId = opts.turnId;
+    const stream = opts.stream ?? "acp";
+    this.emit(conversationId, {
+      kind: "stage",
+      stage: "turn",
+      state: "started",
+      stream: "stage",
+      data: JSON.stringify({ turn_number: opts.turnNumber, turn_id: turnId }),
+    });
+    for (const tool of opts.tools ?? []) {
+      this.emit(conversationId, {
+        kind: "output",
+        stream,
+        turn_id: turnId,
+        blocks: [{ kind: "tool_use", name: tool }],
+      });
+    }
+    for (const text of opts.text ?? []) {
+      this.emit(conversationId, {
+        kind: "output",
+        stream,
+        turn_id: turnId,
+        blocks: [{ kind: "text", body: text }],
+      });
+    }
+    this.emit(conversationId, {
+      kind: "stage",
+      stage: "turn",
+      state: opts.state ?? "done",
+      stream: "stage",
+      data: JSON.stringify({ turn_number: opts.turnNumber, turn_id: turnId, stop_reason: "end_turn" }),
+    });
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const body = await readBody(req);
+    this.requests.push({ method: req.method ?? "GET", path: url.pathname, body, headers: req.headers });
+
+    if (this.failNextWith) {
+      const failure = this.failNextWith;
+      this.failNextWith = null;
+      return json(res, failure.status, failure.body);
+    }
+
+    if (!(req.headers.authorization ?? "").startsWith("Bearer ")) {
+      return json(res, 401, { error: "unauthorized" });
+    }
+
+    const path = url.pathname;
+
+    if (path === "/api/agents") return json(res, 200, { data: this.agents });
+    if (path === "/api/vaults") return json(res, 200, { data: this.vaults });
+    if (path === "/api/environments") return json(res, 200, { data: this.environments });
+    if (path === "/api/auth/me") return json(res, 200, { data: { email: "test@example.com" } });
+
+    if (path === "/api/conversations" && req.method === "POST") {
+      return json(res, 201, { data: this.createConversation(body as Record<string, unknown>) });
+    }
+    if (path === "/api/conversations" && req.method === "GET") {
+      return json(res, 200, { data: [...this.conversations.values()].map(summary) });
+    }
+
+    const match = /^\/api\/conversations\/([^/]+)(\/.*)?$/.exec(path);
+    if (match) {
+      const conversation = this.conversations.get(match[1] as string);
+      if (!conversation) return json(res, 404, { error: "not found" });
+      const rest = match[2] ?? "";
+
+      if (rest === "" && req.method === "GET") return json(res, 200, { data: summary(conversation) });
+      if (rest === "/turns") return json(res, 200, { data: conversation.turns });
+      if (rest === "/prompts" && req.method === "POST") {
+        const turnNumber = conversation.turns.length + 1;
+        conversation.turns.push({ turn_number: turnNumber, status: "running" });
+        conversation.turn_count = turnNumber;
+        json(res, 202, { status: "queued" });
+        this.onTurn?.(conversation, turnNumber);
+        return;
+      }
+      if (rest === "/interrupt" || rest === "/terminate") return json(res, 200, { status: "ok" });
+      if (rest === "/events") return this.eventPage(res, conversation, url);
+      if (rest === "/stream") return this.stream(req, res, conversation, url);
+    }
+
+    json(res, 404, { error: "no route" });
+  }
+
+  private createConversation(body: Record<string, unknown>): FakeConversation {
+    const id = `conv-${this.nextConversation++}`;
+    const conversation: FakeConversation = {
+      id,
+      status: "running",
+      agent_id: String(body.agent_id ?? ""),
+      vault_id: (body.vault_id as string) ?? null,
+      environment_id: (body.environment_id as string) ?? null,
+      title: (body.title as string) ?? null,
+      turn_count: 0,
+      events: [],
+      turns: [],
+    };
+    this.conversations.set(id, conversation);
+    if (body.prompt) {
+      conversation.turns.push({ turn_number: 1, status: "running" });
+      conversation.turn_count = 1;
+      // The real server starts the turn asynchronously; so does this one, or
+      // the SDK would never exercise its replay path.
+      setTimeout(() => this.onTurn?.(conversation, 1), 1);
+    }
+    return conversation;
+  }
+
+  private eventPage(res: ServerResponse, conversation: FakeConversation, url: URL): void {
+    const after = Number(url.searchParams.get("after") ?? 0) || 0;
+    const events = conversation.events.filter((event) => event.id > after);
+    json(res, 200, {
+      data: events,
+      meta: { next_cursor: events.at(-1)?.id ?? after, has_more: false },
+    });
+  }
+
+  private stream(req: IncomingMessage, res: ServerResponse, conversation: FakeConversation, url: URL): void {
+    const streams = (url.searchParams.get("streams") ?? "").split(",").filter(Boolean);
+    const waitForMore = url.searchParams.get("wait") !== "false";
+    let cursor = Number(req.headers["last-event-id"] ?? 0) || 0;
+    let written = 0;
+    let dead = false;
+
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    this.openResponses.add(res);
+
+    const flush = (): void => {
+      if (dead) return;
+      for (const event of conversation.events) {
+        if (event.id <= cursor) continue;
+        if (streams.length && !streams.includes(event.stream ?? "")) {
+          cursor = event.id;
+          continue;
+        }
+        res.write(`id: ${event.id}\nevent: ${event.kind}\ndata: ${JSON.stringify(event)}\n\n`);
+        cursor = event.id;
+        written++;
+        if (this.dieAfterEvents !== null && written >= this.dieAfterEvents) {
+          // A deploy, a proxy timeout, a sandbox wake: the connection just ends.
+          this.dieAfterEvents = null;
+          dead = true;
+          cleanup();
+          // Let the bytes reach the client, *then* drop the socket — a real
+          // connection death loses the future, not the past.
+          setImmediate(() => res.destroy());
+          return;
+        }
+      }
+      if (!waitForMore) {
+        dead = true;
+        cleanup();
+        res.end();
+      }
+    };
+
+    const listeners = this.listeners.get(conversation.id) ?? new Set<() => void>();
+    listeners.add(flush);
+    this.listeners.set(conversation.id, listeners);
+
+    const cleanup = (): void => {
+      listeners.delete(flush);
+      this.openResponses.delete(res);
+    };
+    res.on("close", cleanup);
+
+    flush();
+  }
+}
+
+function summary(conversation: FakeConversation): Record<string, unknown> {
+  const { events, turns, ...rest } = conversation;
+  void events;
+  void turns;
+  return rest;
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) });
+  res.end(payload);
+}
+
+async function readBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  if (!chunks.length) return null;
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    return null;
+  }
+}

--- a/sdk/typescript/test/server.ts
+++ b/sdk/typescript/test/server.ts
@@ -74,6 +74,20 @@ export class FakeFountain {
     this.server = null;
   }
 
+  /** Fail a conversation the way a provisioning failure does. */
+  failConversation(conversationId: string, reason: string): void {
+    const conversation = this.conversations.get(conversationId);
+    if (!conversation) throw new Error(`no conversation ${conversationId}`);
+    conversation.status = "failed";
+    this.emit(conversationId, {
+      kind: "stage",
+      stage: "provision",
+      state: "failed",
+      stream: "stage",
+      data: JSON.stringify({ reason }),
+    });
+  }
+
   /** Append an event to a conversation's feed and wake every open stream. */
   emit(conversationId: string, event: FakeEvent): StoredEvent {
     const conversation = this.conversations.get(conversationId);

--- a/sdk/typescript/test/sse.test.ts
+++ b/sdk/typescript/test/sse.test.ts
@@ -1,0 +1,134 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { parseSse } from "../src/sse.ts";
+import { TurnFollower } from "../src/turn.ts";
+import type { LogEvent } from "../src/types.ts";
+
+/** Feed a body to the parser in exactly the chunks given, TCP-style. */
+function bodyOf(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+async function collect(chunks: string[]) {
+  const out = [];
+  for await (const message of parseSse(bodyOf(chunks))) out.push(message);
+  return out;
+}
+
+describe("parseSse", () => {
+  test("reads id, event and data", async () => {
+    const messages = await collect(['id: 7\nevent: output\ndata: {"kind":"output"}\n\n']);
+    assert.deepEqual(messages, [{ id: "7", event: "output", data: '{"kind":"output"}' }]);
+  });
+
+  test("a message split across packets is still one message", async () => {
+    // The failure this guards against is not hypothetical: Fountain's replay
+    // buffer cuts at a byte count, so a message arriving in two pieces is the
+    // normal case, not the edge one.
+    const messages = await collect(["id: 1\neve", "nt: output\ndata: {\"a\":", '1}\n\n']);
+    assert.equal(messages.length, 1);
+    assert.deepEqual(messages[0], { id: "1", event: "output", data: '{"a":1}' });
+  });
+
+  test("heartbeat comments are not messages", async () => {
+    const messages = await collect([": heartbeat\n\n", "id: 2\nevent: stage\ndata: {}\n\n"]);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0]?.id, "2");
+  });
+
+  test("multi-line data joins with newlines", async () => {
+    const messages = await collect(["data: one\ndata: two\n\n"]);
+    assert.equal(messages[0]?.data, "one\ntwo");
+  });
+
+  test("CRLF framing works too", async () => {
+    const messages = await collect(["id: 3\r\nevent: output\r\ndata: hi\r\n\r\n"]);
+    assert.deepEqual(messages[0], { id: "3", event: "output", data: "hi" });
+  });
+
+  test("a final message with no trailing blank line is not dropped", async () => {
+    const messages = await collect(["id: 9\nevent: stage\ndata: {}"]);
+    assert.equal(messages[0]?.id, "9");
+  });
+});
+
+const stage = (state: string, meta: Record<string, unknown>): LogEvent => ({
+  id: 1,
+  kind: "stage",
+  stage: "turn",
+  state,
+  data: JSON.stringify(meta),
+});
+
+const output = (blocks: unknown[], turnId: string, stream = "acp"): LogEvent => ({
+  id: 2,
+  kind: "output",
+  stream,
+  turn_id: turnId,
+  blocks: blocks as LogEvent["blocks"],
+});
+
+describe("TurnFollower", () => {
+  test("ignores a different turn's lifecycle", () => {
+    const follower = new TurnFollower(2);
+    follower.apply(stage("started", { turn_number: 1, turn_id: "t1" }));
+    assert.equal(follower.started, false);
+    follower.apply(stage("done", { turn_number: 1, turn_id: "t1" }));
+    assert.equal(follower.finished, false);
+  });
+
+  test("thinking is reported but is not the answer", () => {
+    const follower = new TurnFollower(1);
+    follower.apply(stage("started", { turn_number: 1, turn_id: "t1" }));
+    const events = follower.apply(output([{ kind: "thinking", body: "hmm" }], "t1"));
+    assert.ok(events.some((e) => e.type === "thinking"));
+    assert.equal(follower.text, "");
+  });
+
+  test("a result block is the answer only when nothing else was said", () => {
+    const follower = new TurnFollower(1);
+    follower.apply(stage("started", { turn_number: 1, turn_id: "t1" }));
+    follower.apply(output([{ kind: "result", body: "exit 0" }], "t1"));
+    assert.equal(follower.text, "exit 0");
+
+    const chatty = new TurnFollower(1);
+    chatty.apply(stage("started", { turn_number: 1, turn_id: "t1" }));
+    chatty.apply(output([{ kind: "text", body: "All set." }], "t1"));
+    chatty.apply(output([{ kind: "result", body: "exit 0" }], "t1"));
+    assert.equal(chatty.text, "All set.");
+  });
+
+  test("a tool is recorded once, in first-use order", () => {
+    const follower = new TurnFollower(1);
+    follower.apply(stage("started", { turn_number: 1, turn_id: "t1" }));
+    follower.apply(output([{ kind: "tool_use", name: "Bash" }], "t1"));
+    follower.apply(output([{ kind: "tool_use", name: "Read" }], "t1"));
+    follower.apply(output([{ kind: "tool_use", name: "Bash" }], "t1"));
+    assert.deepEqual(follower.toolsUsed, ["Bash", "Read"]);
+  });
+
+  test("the terminal stage carries how it ended", () => {
+    const follower = new TurnFollower(1);
+    follower.apply(stage("started", { turn_number: 1, turn_id: "t1" }));
+    follower.apply(stage("failed", { turn_number: 1, turn_id: "t1", exit_code: 2, reason: "oom" }));
+    assert.equal(follower.state, "failed");
+    assert.equal(follower.exitCode, 2);
+    assert.equal(follower.reason, "oom");
+  });
+
+  test("matches on turn_id once known, even if the turn number drifts", () => {
+    const follower = new TurnFollower(3);
+    follower.apply(stage("started", { turn_number: 3, turn_id: "t3" }));
+    follower.apply(output([{ kind: "text", body: "hi" }], "t3"));
+    // A resumed sandbox renumbering its turns must not orphan the follower.
+    follower.apply(stage("done", { turn_number: 99, turn_id: "t3" }));
+    assert.equal(follower.state, "done");
+    assert.equal(follower.text, "hi");
+  });
+});

--- a/sdk/typescript/tsconfig.build.json
+++ b/sdk/typescript/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src/**/*.ts"]
+}

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -9,6 +9,8 @@
     "exactOptionalPropertyTypes": false,
     "verbatimModuleSyntax": true,
     "erasableSyntaxOnly": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
     "skipLibCheck": true,

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "examples/**/*.ts"]
+}


### PR DESCRIPTION
The REST API describes machinery — conversations, turns, log events, blocks. Every integration that has ever talked to it wrote the same wrapper first to get back to the job:

- `integrations/hermes/fountain/tools.py` — `fountain_run(agent, prompt, vault, environment, …)`
- `cli/internal/cmd/conv.go:77` — *"`run` is a top-level shortcut: create + stream until done"*
- the bundled skill, the same thing in shell

Three implementations of one function is the tell that the function is the product surface and REST is the transport. This is that function, once.

```ts
import { Fountain } from "fountain-sdk";

const run = await new Fountain().run("Upgrade us to Phoenix 1.8 and open a PR", {
  agent: "reposage",
  vault: "github-bot",   // the token lands in the sandbox, never in the prompt
});

console.log(run.text, run.url);
```

## The design calls worth arguing about

**The second argument is the pitch.** `fountain.run(prompt, …)` alone looks exactly like `anthropic.messages.create()` and explains nothing. `{ agent, environment, vault }` is the part that is Fountain, so it is what you read first. `vault` is the differentiator no model API has: the secret is attached at spawn, so it is not in the prompt, not in the model's context, and not in the log feed the SDK reads.

**A handle, not a string.** `run()` returns something you can `await` (the answer), `for await` (lifecycle events), or read as `.textStream` (the words) — three views of one run, no second request behind any of them. `resume(id).send()` continues in the same sandbox with the same checkout and session.

**Names, not ids.** `agent`/`vault`/`environment` take either; resolution is exact then unique-prefix, and a miss names what the account actually has. A UUID in a README kills the demo.

**Two things that look like polish and are not:**

- The turn-following rules — keep only your own turn's events, keep `text` blocks, join `acp` chunks with nothing and `stdout` rows as paragraphs, break after a tool call — are ported from the Hermes plugin, which learned them against real runtimes. Get them wrong and every transcript reads as one run-on sentence.
- The SSE reader resumes from the last event id when a connection dies. A deploy, a sandbox wake or a proxy timeout ends a stream mid-turn; without the cursor the reconnect either replays output or loses it. #772 is what that costs in production. There is a test that kills the connection mid-turn and asserts the resume header.

## Verification

Not just the fake server:

- **Live run** against `fountain.inevitable.fyi` — 28s, streamed, tool call detected, clean text, correct transcript URL.
- **Cold resume** — a brand-new client, no memory of the first run, sent turn 2 into the same sandbox in 4.8s and got an answer that depended on turn 1 (`uname -a && echo READY`). Both sandboxes terminated afterwards.
- **39 tests** against an in-process fake Fountain over real HTTP and real SSE. Three defects surfaced during the writing and were fixed in the SDK rather than the tests: unhandled rejections on derived promises, a retry that counted one failure twice, and a body left open when a consumer breaks mid-turn.

## Also in here

- `docs/sdk.md`, nav mirrored in `mkdocs.yml` and `docs.ex` (`docs_test` green, `mkdocs build --strict` exits 0).
- A pointer at the top of `docs/api.md` for people who land on the endpoint list first, and an `llms.txt` entry so an agent writing a script finds the SDK before it finds `curl`.
- CI steps in the `checks` job beside the Go and Hermes ones: install, typecheck, test, build.

## Not done, deliberately

- **Not published to npm.** The package name `fountain-sdk` is free, but publishing is your call — the docs say "not on npm yet" and give the `npm link` path instead of claiming an install that would 404.
- **No generated OpenAPI layer.** `fountain.request(method, path, opts)` is the escape hatch for the other ~55 paths today; generating types from `/api/openapi.json` into `fountain.api.*` is the natural next step, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)