### PR TITLE
A guided tour: an agent that opens a pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ upgrade, is in
   `conversation.history()`, `fountain.catalog()`, `fountain.search()` and
   `fountain.events()`.
 
+- **A guided tour** (`docs/tour.md`): an agent that clones a repository, opens
+  a pull request, and then amends the same PR on a follow-up turn thirteen
+  seconds later because the sandbox is still up. Every number and output on the
+  page came from running it; `sdk/typescript/examples/pull-request.ts` is the
+  same thing runnable.
+
   Errors are now keyed on the server's `error` code rather than the status,
   because that is how every app branches: `ConversationBusyError` (a 400),
   `QuotaExceededError` (a 429, carrying `activeSandboxes`/`limit`),
@@ -46,6 +52,13 @@ upgrade, is in
   exists. Generating it immediately found one: see below.
 
 ### Fixed
+
+- **`Repository` declared neither `secret_key` nor `ref`.**
+  `Provisioning.clone_https/4` reads both — `secret_key` names the secret the
+  clone authenticates with, `ref` picks a branch — so a private repository
+  could not be expressed by a client generated from the spec. Without
+  `secret_key` the clone fails *inside the sandbox*: provisioning continues,
+  and the agent opens on an empty directory.
 
 - **`AgentRequest` did not declare `allowed_environment_ids`.** `AgentUpdate`
   declared it and `Agent.changeset/2` has cast it since the allowlist shipped,

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -61,6 +61,7 @@ defmodule Fountain.Docs do
     {"CLI reference", "cli.md"},
     {"API reference", "api.md"},
     {"TypeScript SDK", "sdk.md"},
+    {"Guided tour — opening a PR", "tour.md"},
     {"LLM integration", "llm-integration.md"},
     {"Changelog", "changelog.md"}
   ]

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -808,7 +808,25 @@ defmodule FountainWeb.Schemas do
       type: :object,
       properties: %{
         url: %Schema{type: :string, format: :uri, pattern: "^https://"},
-        mount_path: %Schema{type: :string, pattern: "^/"}
+        mount_path: %Schema{type: :string, pattern: "^/"},
+        # Both are read by `Provisioning.clone_https/4` and neither was
+        # declared, so a private repository could not be expressed by a client
+        # generated from this spec — and an unauthenticated clone of one fails
+        # inside the sandbox rather than at the API.
+        secret_key: %Schema{
+          type: :string,
+          description:
+            "Name of a secret — on the environment or on a vault attached at launch — " <>
+              "holding a token to clone with. The clone uses it as HTTPS " <>
+              "`x-access-token` auth. Required for a private repository; omit it for a " <>
+              "public one."
+        },
+        ref: %Schema{
+          type: :string,
+          description:
+            "Optional branch or tag to clone (`git clone -b`). Without it the default " <>
+              "branch is cloned."
+        }
       },
       required: [:url, :mount_path]
     })

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -1,0 +1,193 @@
+# A guided tour: an agent that opens a pull request
+
+By the end of this page you will have an agent that clones your repository,
+makes a change, and opens a pull request — and you will be able to ask it for a
+revision that lands on the same PR seconds later, because the computer it
+worked on is still running.
+
+It is about forty lines. Every number and every output below came from actually
+running it.
+
+## What you need
+
+- A Fountain API key (Account → API keys, or `fountain auth login`).
+- A repository you are willing to let an agent push a branch to.
+- A GitHub token that can push to it. A
+  [fine-grained token](https://github.com/settings/personal-access-tokens)
+  scoped to that one repository is the right thing here — the agent gets a real
+  credential, so give it the smallest one that works.
+
+```bash
+npm install fountain-sdk   # see the SDK page: not on npm yet, build from the repo
+```
+
+```ts
+import { Fountain } from "fountain-sdk";
+
+const fountain = new Fountain();          // FOUNTAIN_API_KEY
+const REPO = "https://github.com/you/your-app";
+```
+
+## 1. The computer
+
+An [environment](primitives.md) is the machine the agent gets, described once
+and reused. Here it is a checkout of your repository:
+
+```ts
+const environment = await fountain.environments.create({
+  name: "tour-workspace",
+  repositories: [
+    {
+      url: REPO,
+      mount_path: "/work/app",
+      secret_key: "GITHUB_TOKEN",   // ← see the warning below
+    },
+  ],
+  setup_script: "cd /work/app && npm install",
+});
+```
+
+!!! warning "A private repository needs `secret_key`"
+
+    `secret_key` names the secret the clone authenticates with. Leave it out on
+    a **private** repository and the clone fails inside the sandbox — the
+    conversation still starts, and your agent opens on an empty directory and
+    tells you it cannot find the repo. Writing this page cost one wasted run to
+    exactly that. A public repository does not need it.
+
+## 2. The credential
+
+A [vault](primitives.md) is a bag of secrets chosen per run. Its values are
+decrypted into the sandbox when the sandbox spawns — they are never in the
+prompt, never in the model's context, and never in the log feed:
+
+```ts
+const vault = await fountain.vaults.create({ name: "tour-github" });
+
+await fountain.vaults.secrets.set("tour-github", "GITHUB_TOKEN", process.env.GITHUB_TOKEN!);
+await fountain.vaults.secrets.set("tour-github", "GH_TOKEN", process.env.GITHUB_TOKEN!);
+```
+
+Two keys because two things need it: `GITHUB_TOKEN` is what the clone reads
+(the `secret_key` above), and `gh` looks for `GH_TOKEN` when the agent opens
+the PR.
+
+You cannot read either one back — `secrets.list()` returns keys and nothing
+else. And if the agent prints the token, Fountain redacts it out of the
+transcript before it is stored.
+
+## 3. The agent
+
+The system prompt is where you say how the work should be done. Be specific
+about the repository path and about what "done" means:
+
+```ts
+const agent = await fountain.agents.create({
+  name: "tour-contributor",
+  runtime: "claude",
+  model: "anthropic/claude-sonnet-5",
+  description: "Opens small pull requests",
+  system:
+    "You work in /work/app, a git repository. Make the smallest change that " +
+    "satisfies the request, commit on a new branch, push, and open a pull " +
+    "request with `gh`. Report the PR url and nothing else.",
+  environment_id: environment.id,
+  allowed_vault_ids: [vault.id],   // this agent may attach that vault, and no other
+});
+```
+
+## 4. The run
+
+```ts
+const run = fountain.run(
+  "Add a --version flag that prints 0.1.0 and exits. " +
+    "Update the README. Then open a pull request.",
+  { agent: "tour-contributor", vault: "tour-github" },
+);
+
+for await (const event of run) {
+  if (event.type === "tool") console.log("·", event.name);
+}
+
+const result = await run;
+console.log(result.text);
+```
+
+```text
+· Terminal
+· Read File
+· Read File
+· Edit
+· Edit
+· Terminal
+· Terminal
+· Terminal
+· Terminal
+· Terminal
+https://github.com/you/your-app/pull/1
+```
+
+Forty-three seconds, most of it provisioning. The pull request is real: a
+`--version` branch, two files changed, ten lines added.
+
+If you would rather not watch, drop the loop — `await fountain.run(...)` gives
+you the same result. If you would rather not wait at all, don't await it: hand
+`run.conversationId` to whatever polls later.
+
+## 5. The follow-up, which is the point
+
+Ask for a revision:
+
+```ts
+const revision = await fountain
+  .resume(result.conversationId)
+  .send("Also accept -v as an alias for --version, and push it to the same PR.");
+```
+
+```text
+turn 2 | done | +13s
+https://github.com/you/your-app/pull/1
+```
+
+**Thirteen seconds, and the same PR.** Nothing was re-cloned, nothing was
+re-explained, no second branch appeared. The sandbox is still up, the checkout
+is on the branch the first turn made, `gh` is still authenticated, and the
+agent's session still holds what it did and why. That is the difference between
+an agent that has a computer and an agent that has a context window.
+
+## 6. Clean up
+
+```ts
+await fountain.resume(result.conversationId).terminate();   // the sandbox
+await fountain.agents.delete("tour-contributor");
+await fountain.vaults.delete("tour-github");                // the credential first, in real code
+await fountain.environments.delete("tour-workspace");
+```
+
+In a script that can fail, delete the vault in a `finally` — a credential
+should not outlive the run that needed it.
+
+## What you just built
+
+| Piece | What it decided |
+|---|---|
+| Environment | which repository, cloned where, and what to run before the agent starts |
+| Vault | which credential the sandbox gets, without it entering the prompt |
+| Agent | the runtime, the model, and the standing instructions |
+| Conversation | this run, and everything you can still ask it |
+
+Swapping any one of them changes the job without touching the others: a
+read-only token turns the same agent into one that can only report, and a
+second environment points it at a different repository.
+
+## Making it yours
+
+- **Run it from CI.** The same forty lines work in an action; the agent needs
+  no checkout on the runner, because the checkout is in the sandbox.
+- **Make it a teammate.** `fountain.team.add("tour-contributor")` gives it a
+  durable thread and a cron routine — "every Monday, open a PR bumping the
+  dependencies" is `team.schedules.create`. See the [SDK page](sdk.md#the-team).
+- **Fan it out.** `fountain.run()` per repository, awaited together; each gets
+  its own sandbox.
+- **Narrow the allowlist.** `allowed_vault_ids` is what stops this agent
+  attaching a vault someone else set up.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
   - CLI reference: cli.md
   - API reference: api.md
   - TypeScript SDK: sdk.md
+  - Guided tour — opening a PR: tour.md
   - LLM integration: llm-integration.md
   - Changelog: changelog.md
 

--- a/sdk/typescript/examples/pull-request.ts
+++ b/sdk/typescript/examples/pull-request.ts
@@ -1,0 +1,74 @@
+/**
+ * The guided tour, runnable: an agent that clones a repo, makes a change and
+ * opens a pull request — then a follow-up that amends the same PR.
+ *
+ *   FOUNTAIN_API_KEY=... GITHUB_TOKEN=... node examples/pull-request.ts \
+ *     https://github.com/you/your-app
+ *
+ * Use a fine-grained token scoped to that one repository: the agent gets a
+ * real credential. Everything created here is deleted on the way out.
+ *
+ * Full walkthrough: docs/tour.md
+ */
+import { Fountain } from "../src/node.ts";
+
+const repo = process.argv[2];
+const token = process.env.GITHUB_TOKEN;
+if (!repo || !token) {
+  console.error("usage: GITHUB_TOKEN=… node examples/pull-request.ts <https repo url>");
+  process.exit(1);
+}
+
+const fountain = new Fountain();
+const names = { environment: "tour-workspace", vault: "tour-github", agent: "tour-contributor" };
+let conversationId: string | null = null;
+
+try {
+  const environment = await fountain.environments.create({
+    name: names.environment,
+    // `secret_key` names the secret the clone authenticates with. A private
+    // repo without it fails to clone *inside the sandbox*: the conversation
+    // starts anyway and the agent finds an empty directory.
+    repositories: [{ url: repo, mount_path: "/work/app", secret_key: "GITHUB_TOKEN" }],
+  });
+
+  const vault = await fountain.vaults.create({ name: names.vault });
+  await fountain.vaults.secrets.set(names.vault, "GITHUB_TOKEN", token); // the clone reads this
+  await fountain.vaults.secrets.set(names.vault, "GH_TOKEN", token); // `gh` reads this
+
+  await fountain.agents.create({
+    name: names.agent,
+    runtime: "claude",
+    model: "anthropic/claude-sonnet-5",
+    system:
+      "You work in /work/app, a git repository. Make the smallest change that " +
+      "satisfies the request, commit on a new branch, push, and open a pull request " +
+      "with `gh`. Report the PR url and nothing else.",
+    environment_id: environment.id,
+    allowed_vault_ids: [vault.id],
+  });
+
+  const run = fountain.run(
+    "Add a --version flag that prints 0.1.0 and exits. Update the README. Then open a pull request.",
+    { agent: names.agent, vault: names.vault, timeoutMs: 15 * 60_000 },
+  );
+  for await (const event of run) {
+    if (event.type === "tool") console.log("·", event.name);
+  }
+  const result = await run;
+  conversationId = result.conversationId;
+  console.log(`\n${result.text}\n`);
+
+  // The sandbox is still up, on the branch the first turn made.
+  const revision = await fountain
+    .resume(result.conversationId)
+    .send("Also accept -v as an alias for --version, and push it to the same PR.");
+  console.log(`turn ${revision.turnNumber}: ${revision.text}`);
+} finally {
+  // The credential goes first, whatever happened above.
+  await fountain.vaults.delete(names.vault).catch(() => {});
+  if (conversationId) await fountain.resume(conversationId).terminate().catch(() => {});
+  await fountain.agents.delete(names.agent).catch(() => {});
+  await fountain.environments.delete(names.environment).catch(() => {});
+  console.log("cleaned up");
+}

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1971,6 +1971,10 @@ export interface components {
         /** Repository */
         Repository: {
             mount_path: string;
+            /** @description Optional branch or tag to clone (`git clone -b`). Without it the default branch is cloned. */
+            ref?: string;
+            /** @description Name of a secret — on the environment or on a vault attached at launch — holding a token to clone with. The clone uses it as HTTPS `x-access-token` auth. Required for a private repository; omit it for a public one. */
+            secret_key?: string;
             /** Format: uri */
             url: string;
         };


### PR DESCRIPTION
The docs had reference material and no narrative — nothing that walks from an empty account to a thing that did work. `docs/tour.md` is that page, and it ends where the value actually is.

## What it walks through

Environment (the repo, cloned) → vault (the token, never in the prompt) → agent (runtime, model, standing instructions) → run → **follow-up**. About forty lines.

The payoff is step 5:

```
turn 2 | done | +13s
https://github.com/you/your-app/pull/1
```

Thirteen seconds, same PR, second commit. Nothing re-cloned, nothing re-explained, no second branch. *"That is the difference between an agent that has a computer and an agent that has a context window."*

## Every number on the page is real

Run against production, not written from imagination:

- private repo cloned into a sandbox, `--version` added to a small CLI, README updated, branch pushed, PR opened — **43s**, most of it provisioning
- `resume(id).send(...)` adding a `-v` alias as a second commit on the same PR — **13s**
- the tool list in the page (`Terminal`, `Read File`, `Edit`, …) is the actual sequence

Everything created for it is deleted: agents, vaults, environments, both conversations, and the scratch repo.

## The wasted run that became a warning box, and a spec fix

The first attempt failed: the agent opened on an empty directory. `Repository` declares only `url` and `mount_path`, but `Provisioning.clone_https/4` reads two more — `secret_key` (which secret the clone authenticates with) and `ref` (which branch). A private repository could not be expressed by a client generated from the spec.

Worse, omitting `secret_key` doesn't fail the request: the clone fails *inside the sandbox*, provisioning continues, and your agent tells you it can't find your repo. That's now a warning box on the page, and both fields are declared in the schema.

## One thing worth chasing, deliberately not fixed here

That failed clone published **`clone/done`**, while the logged output plainly read `fatal: could not read Username for 'https://github.com'`. `clone_https/4` does check the exit code (`if code == 0, do: :ok, else: {:error, …}`), so the sandbox exec appears to have reported `0` for a command that exited non-zero. If that generalises it is a nasty class of silent failure — but it needs a focused repro before anyone changes anything, and I didn't want to guess at it inside a docs PR.

## Also

`sdk/typescript/examples/pull-request.ts` — the same tour, runnable. Nav mirrored in `mkdocs.yml` and `docs.ex`; `docs_test` and `mkdocs build --strict` both green.

Note: this branch touches only my files. There is in-progress work in the same checkout (adding `lumis` syntax highlighting to the docs renderer) that I left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)