### PR TITLE
Bake the highlighter's parsers into the image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,3 +236,33 @@ jobs:
             --tag "${IMAGE}:sha-${SHA}" \
             $(printf "${IMAGE}@sha256:%s " *)
           docker buildx imagetools inspect "${IMAGE}:sha-${SHA}"
+
+      # The docs highlighter loads tree-sitter parsers from disk. They are
+      # baked in by the Dockerfile because the deployment is read-only with no
+      # egress — and when they are missing nothing fails, the code just renders
+      # plain (#879 shipped exactly that). Nothing in the test suite can see
+      # inside the image, so the image itself is asked, offline and read-only,
+      # the way the pods run it.
+      - name: The image can highlight code
+        env:
+          SHA: ${{ env.SRC_SHA }}
+        run: |
+          set -euo pipefail
+          docker pull "${IMAGE}:sha-${SHA}"
+          out=$(docker run --rm --read-only --network none --tmpfs /tmp \
+            -e MASTER_SECRETS_KEY="$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=')" \
+            -e SECRET_KEY_BASE="$(openssl rand -base64 48 | tr -d '\n')" \
+            -e DATABASE_URL="postgres://u:p@127.0.0.1:5432/none" \
+            -e PHX_HOST=example.test -e PUBLIC_URL="https://example.test" \
+            -e RESEND_API_KEY=re_dummy -e EMAIL_FROM="fountain@example.test" \
+            "${IMAGE}:sha-${SHA}" /app/bin/fountain_server eval '
+              {:ok, _} = Application.ensure_all_started(:lumis)
+              html = FountainWeb.Markdown.to_trusted_html("```ts\nconst x = 1;\n```")
+              IO.puts("spans=#{length(Regex.scan(~r/<span style="color/, html))}")
+            ')
+          echo "$out"
+          spans=$(printf '%s' "$out" | sed -n 's/^spans=//p')
+          if [ "${spans:-0}" -lt 1 ]; then
+            echo "::error::the image rendered a ts fence with no highlighting — are the Lumis parsers baked in?"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,11 @@ upgrade, is in
   fenced code is syntax highlighted (Lumis, `github_dark_high_contrast`,
   whose background matches the console's `--color-code-bg`), as it already was
   on the published MkDocs site, and admonitions — which arrive as blockquotes —
-  no longer render in italics wrapped in typographic quote marks.
+  no longer render in italics wrapped in typographic quote marks. The
+  highlighter's tree-sitter parsers are baked into the image at build time:
+  it otherwise fetches them from a CDN on first use and caches them on disk,
+  and the deployment has neither the egress nor a writable filesystem, so a
+  self-hosted instance would render every fence plain.
 
 - **`Repository` declared neither `secret_key` nor `ref`.**
   `Provisioning.clone_https/4` reads both — `secret_key` names the secret the

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,20 @@ COPY ee ./ee
 COPY docs ./docs
 COPY CHANGELOG.md ./
 
+# Lumis downloads a language's tree-sitter parser on first use and caches it
+# under its own priv/. The deployment runs read-only (deployment.yaml sets
+# `readOnlyRootFilesystem: true`), so at runtime that download can neither
+# happen nor be kept, and every fenced block in /docs and /help renders
+# unhighlighted — how #879 shipped. Caching the parsers here, before the
+# release is assembled, puts them in `deps/lumis/priv/lumis`, which `mix
+# release` copies in like any other dependency's priv. `{:ok, _}` is the point:
+# a parser that cannot be fetched fails the build rather than the page.
+# `elixir -e` rather than `mix run`: any mix task here evaluates
+# config/runtime.exs, which demands MASTER_SECRETS_KEY and the rest of the
+# production environment that does not exist during a build. Prepending the
+# compiled ebin paths gives the same code without the config.
 RUN mix compile \
+ && elixir -e 'Enum.each(Path.wildcard("_build/prod/lib/*/ebin"), &Code.prepend_path/1); {:ok, _} = Application.ensure_all_started(:lumis); {:ok, _} = Lumis.Languages.cache(FountainWeb.Markdown.languages())' \
  && mix release fountain_server
 
 # ---

--- a/apps/fountain/lib/fountain_web/markdown.ex
+++ b/apps/fountain/lib/fountain_web/markdown.ex
@@ -35,6 +35,28 @@ defmodule FountainWeb.Markdown do
   # a highlighted block sits on the same ground as the log viewer's.
   @theme "github_dark_high_contrast"
 
+  # Lumis fetches a language's tree-sitter parser from a CDN the first time it
+  # sees one and caches it under its own `priv/`. A release can do neither: the
+  # deployment runs with `readOnlyRootFilesystem: true`, so the first request
+  # for a highlighted block fails to load the parser and the code renders
+  # plain — which is exactly what shipped in #879 and reached production.
+  #
+  # So the parsers are baked into the image instead: the Dockerfile caches this
+  # list into `deps/lumis/priv/lumis` before `mix release`, which copies it in
+  # like any other dependency's priv. Nothing is fetched at runtime.
+  #
+  # `markdown_test.exs` fails if the docs corpus grows a fence in a language
+  # this list does not name — a highlighter that quietly degrades is worse than
+  # one that is off, because nobody notices.
+  @languages ~w(bash typescript json json5 yaml elixir ini)
+
+  @doc """
+  The languages whose parsers are baked into the image — see `@languages`.
+
+  Called by the Dockerfile, before `mix release`.
+  """
+  def languages, do: @languages
+
   @doc """
   Renders untrusted markdown to HTML with raw HTML neutralized and unsafe
   link/image URLs removed.

--- a/apps/fountain/test/fountain_web/markdown_test.exs
+++ b/apps/fountain/test/fountain_web/markdown_test.exs
@@ -296,4 +296,51 @@ end|
       refute html =~ "style=\"color:"
     end
   end
+
+  describe "the baked parser list" do
+    @root Path.expand("../../../..", __DIR__)
+
+    test "every language name is one Lumis knows, by id" do
+      ids = MapSet.new(Lumis.available_languages(), & &1.id)
+
+      for name <- Markdown.languages() do
+        assert MapSet.member?(ids, name),
+               "#{name} is not a Lumis language id — the Dockerfile's cache step would fail the build"
+      end
+    end
+
+    test "covers every language the docs corpus and in-app help fence" do
+      # The parsers ship in the image (see `@languages` in FountainWeb.Markdown);
+      # a fence in a language that is not baked renders unhighlighted in
+      # production and nowhere else, which is how it goes unnoticed.
+      baked = MapSet.new(Markdown.languages())
+      by_alias = Map.new(Lumis.available_languages(), &{&1.id, &1.id})
+
+      aliases =
+        for l <- Lumis.available_languages(), a <- l.aliases, into: by_alias, do: {a, l.id}
+
+      for {file, info} <- fenced_languages(), info not in ~w(text txt plain plaintext) do
+        id = Map.get(aliases, info, info)
+
+        assert MapSet.member?(baked, id),
+               "#{file} fences ```#{info} (#{id}), which is not in FountainWeb.Markdown.languages()"
+      end
+    end
+
+    defp fenced_languages do
+      [
+        Path.wildcard(Path.join(@root, "docs/**/*.md")),
+        Path.wildcard(Path.join(@root, "apps/fountain/priv/help/**/*.md")),
+        [Path.join(@root, "CHANGELOG.md")]
+      ]
+      |> List.flatten()
+      |> Enum.filter(&File.exists?/1)
+      |> Enum.flat_map(fn file ->
+        ~r/^\s*```([a-zA-Z0-9_+-]+)\s*$/m
+        |> Regex.scan(File.read!(file))
+        |> Enum.map(fn [_, info] -> {Path.relative_to(file, @root), info} end)
+      end)
+      |> Enum.uniq()
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #879, which turned on syntax highlighting for `/docs` and `/help`
and then didn't highlight anything in production.

## What happened

Lumis fetches a language's tree-sitter parser from a CDN the first time it sees
one, and caches it on disk under its own `priv/`. The deployment runs with
`readOnlyRootFilesystem: true` and no egress to that CDN, so the fetch failed,
`highlight_code/1`'s error clause returned the block untouched, and prod served
plain code. Nothing errored — the page just looked like it did before:

```
$ curl -s https://fountain.inevitable.fyi/docs/sdk | grep -c '<span style="color'
0
```

Confirmed from inside a pod: `Lumis.Languages.load("typescript")` →
`{:error, :failed_to_load_parser}`, and `/app/lib/lumis-0.7.0/priv/lumis` did
not exist. A self-hosted instance behind a firewall would have behaved the same
way, permanently.

## The fix

Bake the parsers in. The Dockerfile caches the seven languages the corpus
fences into `deps/lumis/priv/lumis` before `mix release`, which copies them into
the release like any other dependency's priv — 5.9 MB, nothing fetched at
runtime. Matching on `{:ok, _}` means a parser that can't be fetched fails the
build instead of the page.

It runs `elixir -e` rather than `mix run` because any mix task evaluates
`config/runtime.exs`, which demands `MASTER_SECRETS_KEY` and the rest of a
production environment that doesn't exist during a build.

## Two guardrails

Both halves of this failed silently, so both get one:

- **`markdown_test.exs`** fails if the docs corpus grows a fence in a language
  the baked list doesn't name. Proven by dropping `yaml` from the list:
  `docs/cli.md fences ```yaml (yaml), which is not in FountainWeb.Markdown.languages()`.
- **`build.yml`** asks the built image to highlight a `ts` fence — offline and
  read-only, the way the pods run it — and fails the build at zero colour
  spans. No test in the suite can see inside the image, which is exactly how
  the first attempt reached prod.

## Verification

Built the image locally and ran it under `--read-only --network none`:

| | colour spans | class |
|---|---|---|
| shipped image (`sha-e635242`) | 0 | `language-ts` |
| this branch | 7 | `language-typescript` |

Full local gate green apart from one unrelated full-suite flake in
`conversation_server_test.exs:434` (`sprite command error: :closed`), which
passes on its own both with and without this branch's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)