### PR TITLE
The image build cannot read a doc snippet it was never given

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,12 +52,18 @@ COPY apps ./apps
 # email — decisions/0010). Mix SILENTLY skips missing elixirc_paths dirs:
 # without this COPY the release still builds but is missing those modules.
 COPY ee ./ee
-# Fountain.Docs embeds docs/ (and the CHANGELOG.md its changelog page
-# includes) at compile time to serve them at /docs — without these the
-# compile fails on File.read!. This is also the only way the content
+# Fountain.Docs embeds docs/ at compile time to serve it at /docs — without
+# it the compile fails on File.read!. This is also the only way the content
 # ships: the release never contains docs/ as files.
+#
+# Every path a page snippet-includes (`--8<-- "…"`) has to be here too, and
+# those paths reach outside docs/: the changelog page includes CHANGELOG.md,
+# and the tour page includes the SDK example it is written from. A missing one
+# is not a broken link, it is a failed image build — `docs_test.exs` checks
+# this list against the snippets so the failure lands in CI instead.
 COPY docs ./docs
 COPY CHANGELOG.md ./
+COPY sdk/typescript/examples ./sdk/typescript/examples
 
 RUN mix compile \
  && mix release fountain_server

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -16,6 +16,54 @@ defmodule Fountain.DocsTest do
   alias Fountain.Docs.Compiler
 
   @mkdocs_yml Path.expand("../../../../mkdocs.yml", __DIR__)
+  @repo_root Path.expand("../../../..", __DIR__)
+  @dockerfile Path.join(@repo_root, "Dockerfile")
+
+  describe "snippet includes ↔ Dockerfile" do
+    @doc """
+    `Fountain.Docs` inlines `--8<-- "path"` at *compile time*, reading from the
+    repo root. Inside the image that root is whatever the Dockerfile COPYed, so
+    a snippet pointing outside it does not degrade — `mix release` dies on
+    `File.read!` and no image is produced at all. That is a silent failure in
+    the worst place: CI is green, the PR merges, and the deploy simply never
+    happens. It has happened once (docs/tour.md including the SDK example).
+    """
+    test "every snippet path is copied into the image" do
+      copied =
+        @dockerfile
+        |> File.read!()
+        |> then(&Regex.scan(~r/^COPY\s+(?!--)(\S+)\s+\S+$/m, &1))
+        |> Enum.map(fn [_, source] -> source end)
+
+      for {page, path} <- snippet_paths() do
+        assert File.exists?(Path.join(@repo_root, path)),
+               "#{page} includes #{path}, which does not exist"
+
+        assert Enum.any?(copied, &covers?(&1, path)),
+               """
+               #{page} includes #{path}, which the Dockerfile does not COPY into
+               the build stage. The docs are embedded at compile time, so this
+               does not break a link — it breaks `mix release`, and no image is
+               built. Add a COPY for it beside `COPY docs ./docs`.
+               """
+      end
+    end
+
+    defp snippet_paths do
+      Path.join(@repo_root, "docs/**/*.md")
+      |> Path.wildcard()
+      |> Enum.flat_map(fn file ->
+        ~r/^--8<--\s+"([^"]+)"\s*$/m
+        |> Regex.scan(File.read!(file))
+        |> Enum.map(fn [_, path] -> {Path.relative_to(file, @repo_root), path} end)
+      end)
+    end
+
+    # `COPY docs ./docs` covers `docs/x.md`; `COPY CHANGELOG.md ./` covers itself.
+    defp covers?(source, path) do
+      path == source or String.starts_with?(path, source <> "/")
+    end
+  end
 
   describe "nav ↔ mkdocs.yml" do
     test "matches the nav: section of mkdocs.yml exactly, order included" do


### PR DESCRIPTION
**`main` has not produced an image since `f037c92`.** The `build` job fails and `publish-manifests` skips, so nothing has deployed. This unbreaks it.

## What happened

`Fountain.Docs` inlines `--8<-- "…"` at **compile time**, reading from the repo root. `docs/tour.md` includes `sdk/typescript/examples/pull-request.ts` so the page and the tested example can't drift. The Dockerfile doesn't COPY `sdk/`, so inside the build stage that path doesn't exist:

```
== Compilation error in file lib/fountain/docs.ex ==
** (File.Error) could not read file "/app/sdk/typescript/examples/pull-request.ts": no such file or directory
```

`mix compile` dies, no image is built, the deploy silently never happens.

## Why nothing caught it

CI is green — at the repo root the file is right there. The release boot check builds a release too, and also passes, for the same reason: it runs in a checkout, not in the image's context. The only place the difference shows up is the Docker build, which runs *after* merge.

That is a bad shape for a failure: green PR, clean merge, and the only symptom is that prod quietly stays on the old image.

## The fix, and the guard

One `COPY` beside `COPY docs ./docs`. The comment there already warned about this for `CHANGELOG.md`; it now states the rule instead of the instance.

The guard is the actual point. `docs_test.exs` now scans every `--8<--` in `docs/**/*.md`, resolves it, and asserts the Dockerfile COPYs a path covering it:

```
docs/tour.md includes sdk/typescript/examples/pull-request.ts, which the Dockerfile
does not COPY into the build stage. The docs are embedded at compile time, so this
does not break a link — it breaks `mix release`, and no image is built.
```

Verified by deleting the COPY and watching the test fail with exactly that.

## Provenance

`f037c92` was mine, and it went to `main` as a **direct push** — the shared checkout had been switched to `main` between my previous commit and that one, and I didn't re-check the branch. That is what put a broken commit on `main` without review. Flagged in the close comment on #878; repeating it here because this PR is the consequence.