### PR TITLE
The tour's snippet was not in the image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,13 @@ COPY ee ./ee
 # ships: the release never contains docs/ as files.
 COPY docs ./docs
 COPY CHANGELOG.md ./
+# A docs page can pull a file in with `--8<--` (docs/tour.md includes the SDK
+# example verbatim, so the page cannot drift from the script that produced its
+# output). Those paths are read at compile time from the repo root, so every
+# one of them has to be here too — docs_test.exs checks this list against the
+# snippet paths the corpus actually uses, because the failure is a compile
+# error inside `docker build` and nowhere else.
+COPY sdk/typescript/examples ./sdk/typescript/examples
 
 # Lumis downloads a language's tree-sitter parser on first use and caches it
 # under its own priv/. The deployment runs read-only (deployment.yaml sets

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -152,6 +152,54 @@ defmodule Fountain.DocsTest do
     end
   end
 
+  describe "snippet includes vs the image build" do
+    @root Path.expand("../../../..", __DIR__)
+
+    test "every `--8<--` path is copied into the Dockerfile's build stage" do
+      # A snippet is read from the repo root at compile time, so a page that
+      # includes a file the image never copies fails `mix compile` inside
+      # `docker build` — green CI, no image, nothing deployed (docs/tour.md
+      # including the SDK example did exactly that). The suite cannot run a
+      # docker build, but it can check the two lists agree.
+      copied = dockerfile_build_sources()
+
+      for path <- snippet_paths() do
+        assert Enum.any?(copied, &(&1 == path or String.starts_with?(path, &1 <> "/"))),
+               """
+               docs/ includes #{path} with `--8<--`, but the Dockerfile's build stage
+               does not copy it. Add a COPY for it beside `COPY docs ./docs`, or the
+               image build fails on File.read! while CI stays green.
+               """
+      end
+    end
+
+    defp snippet_paths do
+      Path.join(@root, "docs/**/*.md")
+      |> Path.wildcard()
+      |> Enum.flat_map(fn file ->
+        ~r/^\s*--8<--\s+"([^"]+)"\s*$/m
+        |> Regex.scan(File.read!(file))
+        |> Enum.map(fn [_, path] -> path end)
+      end)
+      |> Enum.uniq()
+    end
+
+    # The COPY sources of the `AS build` stage, which is the only one that
+    # compiles Elixir. Sources are repo-relative; the destination is dropped.
+    defp dockerfile_build_sources do
+      @root
+      |> Path.join("Dockerfile")
+      |> File.read!()
+      |> String.split(~r/^FROM /m)
+      |> Enum.find(&String.starts_with?(&1, "hexpm/elixir"))
+      |> String.split("\n")
+      |> Enum.filter(&String.starts_with?(&1, "COPY "))
+      |> Enum.flat_map(fn line ->
+        line |> String.split() |> Enum.drop(1) |> Enum.drop(-1)
+      end)
+    end
+  end
+
   # A deliberately narrow parser for the two shapes mkdocs.yml's nav uses:
   # `- Title: file.md` entries at two indent levels and `- Title:` section
   # headers. Anything it doesn't recognize fails the test, which is the point —


### PR DESCRIPTION
**Every image build on `main` has failed since f037c92**, so nothing has
deployed — including #883's parser fix.

`docs/tour.md` now includes `sdk/typescript/examples/pull-request.ts` verbatim
via `--8<--`. Snippets are expanded at compile time from the repo root, and the
Dockerfile's build stage copies `docs/` and `CHANGELOG.md` but not `sdk/`:

```
> [build 13/13] RUN mix compile && ...:
== Compilation error in file lib/fountain/docs.ex ==
** (File.Error) could not read file "/app/sdk/typescript/examples/pull-request.ts"
```

CI never saw it — the suite compiles from a full checkout, where the file is
present. Only `docker build` has the narrowed context.

## The fix

`COPY sdk/typescript/examples ./sdk/typescript/examples`, plus a check in
`docs_test.exs` that the two lists agree: for every `--8<--` path in the corpus,
assert the Dockerfile's build stage copies it (exact file or parent directory).
Deleting the new COPY line fails that test naming the exact path — which is the
point, since the real failure is a compile error inside a build nobody watches,
with a green PR gate above it.

## Verification

Built the image from this tree and ran it `--read-only --network none`:

- compiles (the tour page embeds the script: `tour_has_script=true`)
- still highlights: `spans=5` on a `ts` fence

🤖 Generated with [Claude Code](https://claude.com/claude-code)