### PR TITLE
One Integrations section held two unrelated jobs

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -16,6 +16,13 @@ jobs:
 
     permissions:
       contents: read
+      # gitleaks-action resolves the scan range from the event payload's
+      # `before`..`after` when it can. A force-pushed rebase leaves `before`
+      # unreachable, and it falls back to GET /pulls/:n/commits — which 403s
+      # without this, crashing the action before it scans a single byte. The
+      # failure reads as "Detect secrets: fail" with no finding attached, so
+      # it looks like a leak when it is the opposite: nothing was scanned.
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -44,29 +44,32 @@ defmodule Fountain.Docs do
        {"Self-hosted runners", "integrations/runners.md"},
        {"Adding a provider", "integrations/adding-a-sandbox-provider.md"}
      ]},
-    {"Integrations",
+    {"Services Fountain uses",
      [
        {"Overview", "integrations/index.md"},
-       {"fountain acp (reference)", "integrations/acp.md"},
-       {"Editors (ACP)", "integrations/editors.md"},
-       {"OpenClaw (ACP)", "integrations/openclaw.md"},
-       {"Hermes Agent (plugin)", "integrations/hermes.md"},
-       {"OpenBot (AG-UI)", "integrations/openbot.md"},
-       {"Buzz (Nostr)", "integrations/buzz.md"},
+       {"Mail", "integrations/mail.md"},
        {"GitHub OAuth", "integrations/github-oauth.md"},
        {"Stripe", "integrations/stripe.md"},
-       {"Sentry", "integrations/sentry.md"},
-       {"Mail", "integrations/mail.md"}
+       {"Sentry", "integrations/sentry.md"}
      ]},
     {"The four primitives", "primitives.md"},
     {"CLI reference", "cli.md"},
     {"API reference", "api.md"},
     {"TypeScript SDK", "sdk.md"},
     {"Guided tour — opening a PR", "tour.md"},
-    {"LLM integration", "llm-integration.md"},
+    {"Plugging into Fountain",
+     [
+       {"Overview", "integrations/clients.md"},
+       {"fountain acp (reference)", "integrations/acp.md"},
+       {"Editors (ACP)", "integrations/editors.md"},
+       {"OpenClaw (ACP)", "integrations/openclaw.md"},
+       {"Hermes Agent (plugin)", "integrations/hermes.md"},
+       {"OpenBot (AG-UI)", "integrations/openbot.md"},
+       {"Buzz (Nostr)", "integrations/buzz.md"},
+       {"LLM integration", "llm-integration.md"}
+     ]},
     {"Changelog", "changelog.md"}
   ]
-
   # docs/changelog.md pulls the repo-root CHANGELOG.md in via a snippet.
   @external_resource Path.join(@root, "CHANGELOG.md")
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,3 +31,5 @@ Running Claude instances with worktrees locally and shuffling MCP configurations
 - [**CLI reference**](cli.md) - `fountain` command surface
 - [**API reference**](api.md) - REST endpoints and auth
 - [**LLM integration**](llm-integration.md) - connect any agentic IDE via `/skill`
+- [**Plugging into Fountain**](integrations/clients.md) - editors, chat surfaces, plugins, SDKs
+- [**Services Fountain uses**](integrations/index.md) - what an operator configures: sandboxes, mail, OAuth, billing, errors

--- a/docs/integrations/clients.md
+++ b/docs/integrations/clients.md
@@ -1,0 +1,66 @@
+# Overview
+
+Fountain is a server. This section is everything that drives it from the
+outside: an editor, a chat surface, a plugin host, a relay, your own code.
+
+None of it is set up by the operator. There is no env var, no server-side
+switch and nothing to run — each of these authenticates as an ordinary user,
+with an API key or the CLI's saved login, and works against any instance it
+can reach. If you are looking for the services Fountain itself needs
+configured — sandboxes, mail, OAuth, billing, error tracking — those are in
+[Services Fountain uses](index.md).
+
+| Client | Talks over | Set up on |
+|---|---|---|
+| [Editors](editors.md) | [`fountain acp`](acp.md) | The developer's machine |
+| [OpenClaw](openclaw.md) | [`fountain acp`](acp.md) | The OpenClaw host |
+| [Hermes Agent](hermes.md) | HTTP API, via a plugin | The Hermes host |
+| [OpenBot](openbot.md) | [AG-UI](https://github.com/ag-ui-protocol/ag-ui) over HTTP | The OpenBot host |
+| [Buzz](buzz.md) | Nostr relay, hosted by Fountain | The Buzz desktop, or `POST /api/buzz/agents` |
+| [Agentic IDEs](../llm-integration.md) | `/skill` + discovery endpoints | The IDE |
+| Your own code | [HTTP API](../api.md), [TypeScript SDK](../sdk.md), [CLI](../cli.md) | Wherever you like |
+
+## Over ACP
+
+The first three of those spawn the same adapter. Its protocol surface, `_meta`
+extensions and failure modes are on one page —
+[**`fountain acp` (reference)**](acp.md) — so the client pages below only cover
+setup.
+
+[**Editors**](editors.md): an ACP-capable editor — Zed and friends — spawns
+`fountain acp` locally and talks to your instance with the credentials the
+developer already has.
+
+[**OpenClaw**](openclaw.md) reaches the same adapter from a chat surface —
+Telegram, Discord, Slack — by registering Fountain as a custom ACP agent in its
+`acpx` plugin. The configuration is client-side, on the OpenClaw host.
+
+## Over the API
+
+[**Hermes Agent**](hermes.md) is a client of the HTTP API rather than of
+`fountain acp`: a Hermes plugin (shipped in this repo under
+`integrations/hermes/`) gives Hermes `fountain_run` and friends, so its model
+delegates a task to a named Fountain agent and reads the answer back. The
+plugin authenticates with an API key or the CLI's saved login.
+
+[**OpenBot**](openbot.md) needs no plugin at all, only a URL: Fountain answers
+[AG-UI](https://github.com/ag-ui-protocol/ag-ui) at `POST /api/agui/:agent_id`,
+and CopilotKit's OpenBot — or any other AG-UI host — registers a Fountain agent
+as a coworker with a channel of its own. One channel binds to one conversation,
+so the sandbox is the memory rather than the replayed transcript. The coworker
+holds an API key.
+
+Everything that plugin does is available directly — see the
+[API reference](../api.md), the [TypeScript SDK](../sdk.md) and the
+[CLI reference](../cli.md). [LLM integration](../llm-integration.md) covers the
+discovery endpoints that let an agentic IDE learn the whole surface from one
+fetch.
+
+## The other direction
+
+[**Buzz**](buzz.md) inverts the arrangement: Fountain *hosts* a Buzz agent — a
+Nostr identity that lives on a relay — running its coding agent in a sandbox
+and holding its signing key in a vault. Nobody drives Fountain here; Fountain
+shows up on the relay and answers. Provision one from the Buzz desktop or
+`POST /api/buzz/agents`; it self-enables on any image that ships the
+`buzz-acp` binary.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,10 +1,16 @@
-# Integrations
+# Overview
 
-Every external service a Fountain instance can talk to, what it is for, and
-what breaks without it. One page per integration covers what to create on the
-provider side, which env vars result, and how to verify it works.
+The external services a Fountain instance talks to in order to run: where a
+sandbox is provisioned, how mail goes out, who signs users in, whether spend is
+metered, where errors land. These are the operator's business — one page per
+service covers what to create on the provider side, which env vars result, and
+how to verify it works.
 
-| Integration | Required? | Env vars | Without it |
+This is the *outbound* half. For the tools that talk **to** a running Fountain
+— editors, chat surfaces, plugins, SDKs — see
+[Plugging into Fountain](clients.md); nothing there needs an env var here.
+
+| Service | Required? | Env vars | Without it |
 |---|---|---|---|
 | [A sandbox provider](sandbox-contract.md) | **Yes — one of four** | `SPRITES_TOKEN` *or* `E2B_API_KEY` *or* `DAYTONA_API_KEY` (or users' own machines via [`fountain runner`](runners.md), no credential), plus `SANDBOX_PROVIDER` to pick the default | The app boots, but every conversation fails at provision time |
 | [Mail](mail.md) | **A decision, yes** | `RESEND_API_KEY` *or* `SMTP_*` *or* `EMAIL_DELIVERY=none`, `EMAIL_FROM` | Production refuses to boot with none of the three set |
@@ -12,48 +18,11 @@ provider side, which env vars result, and how to verify it works.
 | [Stripe](stripe.md) | Optional | `BILLING_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID` | No billing. Correct for most self-hosted instances — leave the gate off |
 | [Sentry](sentry.md) | Optional | `SENTRY_DSN`, `SENTRY_ENVIRONMENT` | No error tracking; the SDK is inert and nothing leaves the instance |
 
-## The integration with nothing to configure
+The sandbox providers — Sprites, E2B, Daytona, and users' own machines — have
+[a section of their own](sandbox-contract.md): one contract, four
+implementations. The row above is the short version.
 
-All three ACP clients below spawn the same adapter; its protocol surface,
-`_meta` extensions and failure modes are on one page,
-[**`fountain acp` (reference)**](acp.md), so the client pages only cover setup.
-
-[**Editors**](editors.md) are the one integration an operator does not set up.
-An ACP-capable editor — Zed and friends — spawns `fountain acp` locally and
-talks to your instance with the credentials the developer already has. There is
-no env var, no server-side switch, and nothing for you to run: it works against
-any instance the CLI can reach.
-
-[**OpenClaw**](openclaw.md) reaches the same `fountain acp` adapter from a chat
-surface — Telegram, Discord, Slack — by registering Fountain as a custom ACP
-agent in its `acpx` plugin. Again there is nothing to change on the Fountain
-side; the configuration is client-side, on the OpenClaw host.
-
-[**Hermes Agent**](hermes.md) is a client of the HTTP API rather than of
-`fountain acp`: a Hermes plugin (shipped in this repo under
-`integrations/hermes/`) gives Hermes `fountain_run` and friends, so its model
-delegates a task to a named Fountain agent and reads the answer back. Nothing
-to configure server-side; the plugin authenticates with an API key or the
-CLI's saved login.
-
-[**OpenBot**](openbot.md) needs no plugin at all, only a URL: Fountain answers
-[AG-UI](https://github.com/ag-ui-protocol/ag-ui) at `POST /api/agui/:agent_id`,
-and CopilotKit's OpenBot — or any other AG-UI host — registers a Fountain agent
-as a coworker with a channel of its own. One channel binds to one conversation,
-so the sandbox is the memory rather than the replayed transcript. Nothing to
-configure server-side; the coworker holds an API key.
-
-[**Buzz**](buzz.md) is the other direction: Fountain *hosts* a Buzz agent —
-a Nostr identity that lives on a relay — running its coding agent in a sandbox
-and holding its signing key in a vault. Provision one from the Buzz desktop or
-`POST /api/buzz/agents`; it self-enables on any image that ships the `buzz-acp`
-binary.
-
-The sandbox providers — Sprites, E2B, Daytona — have
-[a section of their own](sandbox-contract.md): one contract, three
-implementations.
-
-## The integration you do not configure
+## The service you do not configure
 
 **Inference providers — Anthropic, OpenAI, Gemini — are not set up by the
 operator.** There is no platform-level API key: each user brings their own

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,26 +72,27 @@ nav:
       - Daytona: integrations/daytona.md
       - Self-hosted runners: integrations/runners.md
       - Adding a provider: integrations/adding-a-sandbox-provider.md
-  - Integrations:
+  - Services Fountain uses:
       - Overview: integrations/index.md
+      - Mail: integrations/mail.md
+      - GitHub OAuth: integrations/github-oauth.md
+      - Stripe: integrations/stripe.md
+      - Sentry: integrations/sentry.md
+  - The four primitives: primitives.md
+  - CLI reference: cli.md
+  - API reference: api.md
+  - TypeScript SDK: sdk.md
+  - Guided tour — opening a PR: tour.md
+  - Plugging into Fountain:
+      - Overview: integrations/clients.md
       - fountain acp (reference): integrations/acp.md
       - Editors (ACP): integrations/editors.md
       - OpenClaw (ACP): integrations/openclaw.md
       - Hermes Agent (plugin): integrations/hermes.md
       - OpenBot (AG-UI): integrations/openbot.md
       - Buzz (Nostr): integrations/buzz.md
-      - GitHub OAuth: integrations/github-oauth.md
-      - Stripe: integrations/stripe.md
-      - Sentry: integrations/sentry.md
-      - Mail: integrations/mail.md
-  - The four primitives: primitives.md
-  - CLI reference: cli.md
-  - API reference: api.md
-  - TypeScript SDK: sdk.md
-  - Guided tour — opening a PR: tour.md
-  - LLM integration: llm-integration.md
+      - LLM integration: llm-integration.md
   - Changelog: changelog.md
-
 extra:
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
The `Integrations` section merged the services an operator has to configure before Fountain runs — Mail, GitHub OAuth, Stripe, Sentry — with the tools that drive a *running* Fountain from outside: editors, OpenClaw, Hermes, Buzz. Two audiences, opposite directions, one list. The overview page had to keep announcing which kind you were looking at ("the integration with nothing to configure", "the integration you do not configure"), which is the tell.

## Split by direction

Each half now sits next to its audience rather than in one alphabetical-ish pile:

| Section | Where | Pages |
|---|---|---|
| **Services Fountain uses** | after Sandbox providers, in the operator run | Overview, Mail, GitHub OAuth, Stripe, Sentry |
| **Plugging into Fountain** | after CLI / API / SDK, in the builder run | Overview, `fountain acp` (reference), Editors, OpenClaw, Hermes, Buzz, LLM integration |

`LLM integration` was floating loose at the top level and plainly belongs in the second group.

`docs/integrations/index.md` becomes the services overview — the required/env-vars/without-it table plus the BYO-inference note. New `docs/integrations/clients.md` is the clients overview: a client/transport/set-up-on table, then the ACP group, the API group, and Buzz as the inversion (nobody drives Fountain there; Fountain shows up on a relay and answers). Home links both.

## Two deliberate non-changes

**File paths do not move.** Everything stays under `docs/integrations/`, so every published URL and every existing cross-link still resolves. `mkdocs.yml` has no redirects plugin, so a move would silently break external links and `/docs/<slug>`. The nav labels no longer match the directory name; matching them up is a follow-up that needs `mkdocs-redirects` first.

**Sandbox providers keeps its own section** rather than folding into the services one — seven pages and a contract earn a heading. The services overview links to it and keeps the one-line row.

## Verification

- `mkdocs build --strict` — exit 0
- `mix test test/fountain/docs_test.exs test/fountain_web/controllers/docs_controller_test.exs` — 22 tests, 0 failures. The nav is mirrored in `Fountain.Docs.@nav` and `docs_test.exs` diffs it against `mkdocs.yml`, so both moved together.
- `mix format --check-formatted` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Two follow-on commits

**Rebased onto #873 (AG-UI / OpenBot).** That PR added `integrations/openbot.md` into the very section being split, so the conflict was substantive rather than textual: a new *client* page had landed in the old merged list. It now sits in **Plugging into Fountain**, and its paragraph moved from the services overview into `clients.md` — in the "Over the API" group, since AG-UI is a URL-and-token integration like Hermes rather than an ACP one.

**`Secret scanning reported a leak it never looked for`.** The force-pushed rebase turned `Detect secrets` red with no finding attached. gitleaks-action resolves its range from the payload's `before`..`after`; a rebase leaves `before` unreachable, so it fell back to `GET /pulls/:n/commits`, got a 403 against `permissions: contents: read`, and died inside `ScanPullRequest` before scanning a byte (`x-ratelimit-used: 1` — its first call). A red secret scanner reads as "there's a credential in this diff"; here it meant nothing had been examined. Granting `pull-requests: read` closes that fallback path. Latent since the workflow was written — every prior PR resolved its range locally.

Verified independently with gitleaks 8.30.0 over the same range: `no leaks found`, exit 0.
