### PR TITLE
An orphaned `sleep` held CI's pipe open for five minutes a run

### DIFF
--- a/apps/fountain/test/fountain/buzz/harness_test.exs
+++ b/apps/fountain/test/fountain/buzz/harness_test.exs
@@ -8,6 +8,14 @@ defmodule Fountain.Buzz.HarnessTest do
   # so the tests exercise the exact teardown path production uses.
   @launcher Path.expand("../../../priv/buzz-acp-launch.sh", __DIR__)
 
+  # A fake that blocks must `exec` its last command, never background it behind
+  # the shell. The launcher TERMs the pid this script reports, which is the
+  # shell's; a plain `sleep 300` is the shell's *child* and `sh` does not
+  # forward the signal, so it orphans onto init still holding the stdio it
+  # inherited from the BEAM. `mix test | tee` (scripts/test-partition.sh) then
+  # cannot see EOF until that sleep expires — five silent minutes on the CI
+  # critical path, with every assertion green, because the pid the test watches
+  # really did die. `exec` makes the reported pid the process that blocks.
   defp write_fake(dir, name, body) do
     path = Path.join(dir, name)
     File.write!(path, "#!/bin/sh\n" <> body)
@@ -73,7 +81,9 @@ defmodule Fountain.Buzz.HarnessTest do
   # the launcher's teardown can reap it.
   test "reaps the child OS process on shutdown", %{dir: dir} do
     pidfile = Path.join(dir, "childpid")
-    cmd = write_fake(dir, "buzz-acp", "echo $$ > #{pidfile}\nexec 0<&- 1>&- 2>&-\nsleep 300\n")
+
+    cmd =
+      write_fake(dir, "buzz-acp", "echo $$ > #{pidfile}\nexec 0<&- 1>&- 2>&-\nexec sleep 300\n")
 
     start(command: cmd, label: "t")
     wait_until(fn -> File.exists?(pidfile) end)
@@ -117,7 +127,7 @@ defmodule Fountain.Buzz.HarnessTest do
   # name-conflict exit — two buzz-acp processes answered one channel.
   test "a Horde name-conflict exit stops the loser: port reaped, on_stop run", %{dir: dir} do
     pidfile = Path.join(dir, "childpid")
-    cmd = write_fake(dir, "buzz-acp", "echo $$ > #{pidfile}\nsleep 300\n")
+    cmd = write_fake(dir, "buzz-acp", "echo $$ > #{pidfile}\nexec sleep 300\n")
     test_pid = self()
 
     pid = start(command: cmd, label: "t", on_stop: fn -> send(test_pid, :stopped) end)


### PR DESCRIPTION
PR CI doubled on 2026-08-17 — a 4m02s median became 7m53s, and it has sat near 8m30s since:

```
08-16  n=34  median=4m02s
08-17  n=11  median=7m53s   ← cliff
08-21  n= 6  median=8m26s
```

The suite is not the cause. ExUnit reports 88–138s per partition, balanced and unchanged. One partition simply stops for 4–5 minutes *after* the run finishes — after `mix test` prints its last coverage line, with the BEAM already exited:

```
Run "mix test.coverage" once all exports complete
  ← 261 SECONDS OF NOTHING →
partition 3/3: 1060 tests, coverage exported
```

## What is actually happening

`scripts/test-partition.sh` pipes `mix test` into `tee`, and `tee` waits for the last writer to close the pipe — not for the BEAM. Caught live, mid-stall:

```
tee    74388  fd 0  PIPE 0xd1b2…  ->0x3104fe39ec74118
sleep  75337  fd 2  PIPE 0x3104…  ->0xd1b214f00b0e6f3c   ppid 1
sleep  75343  fd 2  PIPE 0x3104…  ->0xd1b214f00b0e6f3c   ppid 1
```

Two orphaned `sleep 300` processes holding the write end. The fake `buzz-acp` in `harness_test.exs` is a shell that runs `sleep 300` as a *child*. The launcher TERMs the pid the fake reports — the shell's — and `sh` does not forward the signal, so the `sleep` orphans onto init still holding the stderr it inherited from the BEAM. `tee` cannot see EOF until it expires. 300s is exactly the stall, less however far into the run the sleep started.

## The fix

`exec sleep 300` makes the reported pid the process that actually blocks, so the launcher's TERM lands on it. Both fakes get it — the pre-existing one leaked too, harmlessly, because it closes stdio first.

**The assertions never had a chance to catch this.** Both tests watch the pid in the pidfile, and both are right that it dies. It is the grandchild that survives, and nothing in the suite looks at it. Four days green.

## Measured

Partition 3 on `main`, same machine and database:

| | wall | tests | result |
|---|---|---|---|
| baseline | **5m55.91s** | 82.6s | 1060 tests, 0 failures |
| with fix | **1m24.49s** | 77.3s | 1060 tests, 0 failures |

Bisected to #780, which added the second fake:

| commit | wall | tests |
|---|---|---|
| `f0d0d53` (#777, parent) | 1m13s | 66.0s |
| `4a508a1` (#780) | 5m40s / 5m49s | 63.0s / 64.1s |

This should take PR CI back to ~4m and merge→deployed to roughly 6 minutes on the fast path.

## Left for a follow-up

- **`test-partition.sh` turns this class of bug into a silent hang** rather than a failure. Any leaked stdio-holding grandchild costs minutes with every check green. Redirecting to the log file instead of piping, or putting a timeout around the pipeline, would make the next one visible.
- **`buzz-acp-launch.sh` still TERMs a pid, not a process group.** Production is fine — a real `buzz-acp` SIGTERM-cleans its own child, and the fake was simply a worse citizen than the real thing. Hardening the launcher against a child that ignores TERM is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)