### PR TITLE
The bot messenger everyone is cloning, minus the half that is hard

### DIFF
--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -57,6 +57,12 @@ defmodule Fountain.Docs do
     {"API reference", "api.md"},
     {"TypeScript SDK", "sdk.md"},
     {"Guided tour — opening a PR", "tour.md"},
+    {"Build a chat app",
+     [
+       {"The shape everyone is cloning", "build/index.md"},
+       {"A team chat, end to end", "build/team-chat.md"},
+       {"What each piece does", "build/pieces.md"}
+     ]},
     {"Plugging into Fountain",
      [
        {"Overview", "integrations/clients.md"},

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -1,0 +1,123 @@
+# The shape everyone is cloning
+
+The app on your timeline this month is the same app. A messaging client where
+the contacts are bots: a roster down the left, a thread on the right, a **+**
+that makes a new one with a name, a face and a one-line brief, and a settings
+panel where you connect it to GitHub or Notion so it can actually do
+something. Grok Bot shipped that shape; the clones arrived within weeks, and
+most of them are good.
+
+The front end is a weekend. What takes longer is the half nobody screenshots.
+
+## What a bot needs that a chat UI does not give it
+
+A bubble is text. A teammate is a process on a machine, and the machine is the
+product:
+
+| Behind the bubble | What it actually means |
+|---|---|
+| a computer | a filesystem, a shell, a package manager, a network |
+| credentials | a GitHub token that works — not in the prompt, not in the transcript |
+| memory | the second message costs a sentence, not a re-explanation of the first |
+| isolation | one bot's token and files on a machine that is not the one serving your app |
+| a lifecycle | something starts that machine, parks it while nobody is typing, wakes it |
+| tenancy | the second person who signs in does not see the first one's bots |
+| a clock | "every weekday at nine" |
+
+None of that is chat. All of it is what separates a bot that answers from a
+bot that does the thing.
+
+## The two usual answers
+
+**Run the agent on the user's own machine.** The app becomes a front end for a
+process on your laptop: your Node, your keys in a dotfile, your working
+directory. It is the fastest thing to build and it is genuinely lovely for one
+person. It is also why the README starts with `git clone` — everybody who wants
+a bot installs the whole stack, the bots stop when the lid closes, and "share
+it with my team" has no answer.
+
+**Take an endpoint.** Bring your own agent: a URL that speaks
+[ACP](../integrations/acp.md), or an OpenAI-compatible chat completion, or a
+framework's own protocol. Better — the app can now run anywhere — but it has
+moved the hard part rather than solved it. Somebody still has to host that
+runtime, give it a filesystem, put credentials in it, keep its memory between
+calls, and stop one tenant reading another's. A chat-completions endpoint is
+stateless and has no shell. An ACP endpoint has one only if you built it one.
+
+Either way, the part that gets skipped is the part that costs money and pages
+you at night.
+
+## The third answer
+
+Make the runtime an HTTP API that somebody else operates.
+
+```
+  A. the agent runs on the user's machine
+     browser ──▶ local daemon ──▶ agent process ──▶ ~/.config, ~/code, your keys
+                 one person, one laptop, asleep when the lid closes
+
+  B. bring your own endpoint
+     browser ──▶ your server ──▶ https://someones-agent/…
+                 stateless: no shell, no files, nothing remembered
+                 unless you also built and now operate that
+
+  C. the runtime is an API                            ← this section
+     browser ──▶ Fountain ──▶ a sandbox per teammate: shell, checkout,
+     static files             secrets, memory that survives the message
+```
+
+Fountain is C. `POST /api/team` hires a teammate and gives it a computer;
+`POST /api/team/:id/messages` says something to it; one SSE connection carries
+what every teammate is doing. Your app is static files and a bearer token.
+
+## What you write, and what you stop writing
+
+| You write | Fountain does |
+|---|---|
+| the roster, the thread, the composer | provisions and holds a sandbox per teammate |
+| what a bot is called, and what it looks like | starts `claude` / `codex` / `gemini` / `opencode` in it |
+| which connectors you offer | encrypts the tokens, injects them at spawn, redacts them from output |
+| your own sign-in, or none | accounts, API keys, OAuth, per-user isolation, quota, audit |
+| what a routine is for | runs it on a cron |
+| how a thread should look | parses each runtime's dialect into blocks you can render |
+
+The second column is the one that has an on-call rotation.
+
+## It already exists, twice
+
+Two apps are built on this API and are open source. Neither has a
+backend — both are static files talking to Fountain with a key the person
+pasted in, or a "Sign in with Fountain" token.
+
+- **[fountain-team](https://github.com/jhgaylor/fountain-team)** — the one this
+  section walks through: roster, threads, queued messages while a teammate is
+  busy, images, notifications, routines, ⌘K search, connectors, a live
+  activity feed. A few thousand lines of React and no server of its own.
+- **[fountain-conversations](https://github.com/jhgaylor/fountain-conversations)**
+  — the same API from the other end: one conversation, in detail.
+
+Fountain's own console does not do chat at all. It manages agents, secrets and
+audit; the chat surfaces are these apps, on the public API, with no privileged
+access. Whatever they do, your clone can do.
+
+## Two things the clones do not have
+
+**The teammates know each other.** Every conversation on the team channel is
+handed an MCP server by Fountain itself, so a teammate can list the others,
+find "the engineer", send them a message and wait for the reply — and the
+exchange shows up in both threads. See [Team](../api.md#team).
+
+**A teammate is not locked to your app.** The same agent answers over
+[ACP](../integrations/acp.md) in an editor, over
+[AG-UI](../integrations/openbot.md) from another agent platform, over
+[Nostr](../integrations/buzz.md), and — where the instance enables it — from
+its own email address and phone number. Each surface binds its own durable
+thread through the same mechanism your app uses, so your UI is one door onto
+something that exists whether or not the tab is open.
+
+## Next
+
+- [**A team chat, end to end**](team-chat.md) — the whole app in SDK calls:
+  hire, message, stream, render, connect, schedule, ship.
+- [**What each piece does**](pieces.md) — which primitive is doing what, and
+  what happens between Enter and the first word of the reply.

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -4,8 +4,8 @@ The app on your timeline this month is the same app. A messaging client where
 the contacts are bots: a roster down the left, a thread on the right, a **+**
 that makes a new one with a name, a face and a one-line brief, and a settings
 panel where you connect it to GitHub or Notion so it can actually do
-something. Grok Bot shipped that shape; the clones arrived within weeks, and
-most of them are good.
+something. Grok Bot shipped that shape, the clones are everywhere, and most of
+them are good.
 
 The front end is a weekend. What takes longer is the half nobody screenshots.
 

--- a/docs/build/pieces.md
+++ b/docs/build/pieces.md
@@ -1,0 +1,165 @@
+# What each piece does
+
+A chat app has three nouns: a contact, a thread, a message. Fountain has
+[four primitives](../primitives.md). They line up, and knowing which is which
+is most of what you need to reason about the app you are building.
+
+| In your UI | In Fountain | What it decides |
+|---|---|---|
+| the contact | **Agent** | which model and runtime answer, what the system prompt says, which skills and MCP servers exist |
+| the thread | **Conversation** | one standing session, bound to the reserved channel `fountain:team` |
+| the computer behind it | its **sandbox** | the filesystem, the shell, the network, the memory |
+| what it is allowed to touch | **Environment** + **Vault** | packages, cloned repos, setup script, and the encrypted values injected at spawn |
+| a message | a **turn** | one prompt and everything the agent did about it |
+
+There is no fifth primitive for the team. A teammate *is* a conversation with
+a channel binding, which is why anything you can do to a conversation you can
+do to a teammate.
+
+```
+   Agent  "watchtower"                 the definition. Cheap. Reusable.
+     │      runtime, model, system prompt, skills, mcp_servers
+     │
+     ├── Environment "watchtower-env"  the machine's shape: apt packages,
+     │     repos to clone, setup script, encrypted secrets
+     │
+     └── Conversation ─ channel: fountain:team      ← the thread
+           │  turns 1..n, a log feed, a status
+           └── Sandbox                              ← the computer
+                 Debian, a shell, the repos, the secrets as real env vars,
+                 the runtime's session on disk
+```
+
+## The channel binding is the whole trick
+
+`channel_id` is what makes one agent equal one durable thread. Sending to a
+channel that already has a live conversation continues it; there is no
+"create or find" dance in your app, and no table of your own mapping rows to
+conversation ids.
+
+The team is a reserved channel, `fountain:team`. Any other string is yours:
+
+```ts
+// a Slack channel, a Telegram chat, a row in your own product
+await fountain.run(text, { agent: "watchtower", channelId: `slack:${channel}` });
+```
+
+Same behaviour, same sandbox-per-thread, without the team API at all. This is
+how [AG-UI](../integrations/openbot.md) binds one coworker channel to one
+conversation, and how [Buzz](../integrations/buzz.md) binds a Nostr thread.
+
+## What happens between Enter and the first word
+
+```
+  your app                     Fountain                       the sandbox
+  ────────                     ────────                       ───────────
+  POST /team/:id/messages ───▶ a turn in flight?  ─ yes ─▶ 400 conversation_busy
+                               computer starting? ─ yes ─▶ 503 provisioning
+                                     │ no
+  ◀─── 202 {conversation_id}         │
+       everything else arrives       ▼
+       on the stream           wake it, or provision ─────▶ stage: reattach
+                                     │                      stage: provision
+                                     │                      stage: setup
+                                     │                      env + vault become
+                                     ▼                      real env vars here
+                               prompt the runtime ────────▶ claude / codex / …
+                                                                    │  ndjson
+  SSE /api/team/stream ◀── redact ◀── persist ◀───────────────────── ┘
+       stage: turn/started            every value Fountain
+       …                              put in that machine,
+       stage: turn/done               8 bytes or longer
+```
+
+Three things in that picture are worth carrying around:
+
+**The response is 202, not the answer.** `POST /messages` queues a turn and
+returns the conversation id. Everything after that arrives on the stream. An
+app that awaits a reply is really awaiting stream events — which is what the
+SDK's `Run` handle does for you.
+
+**Secrets enter at spawn, not at prompt.** The environment's values and the
+vault's are merged (the vault wins on a key collision) and handed to the
+sandbox as environment variables. They are not in the prompt, so they are not
+in the model's context, so they cannot be argued out of the model by a clever
+message.
+
+**Redaction is on the write path.** Every value of 8 bytes or more that
+Fountain put into that sandbox is scrubbed out of persisted output. Not
+best-effort in the client, not a rule the agent is asked to follow — the
+single path every log event takes. `env`, `set -x` and `cat .env` all persist
+as `[REDACTED]`. It is why a browser app can offer a "connect GitHub" button
+without you having to think very hard about the transcript.
+
+## The computer's day
+
+The sandbox is the piece that has no equivalent in a stateless agent API, and
+its lifecycle is the thing to design your empty states around.
+
+```
+  sandbox:  pending ──▶ starting ──▶ ready ──────────────▶ suspended
+  presence: starting   starting     online / working       asleep
+                                       │      ▲                │
+                                       │      └── next message ┘
+                                       │          wakes it, memory intact
+                                       │
+                                       │  24 h running (default)
+                                       ▼
+                                   terminated — the thread stays readable and
+                                   resumable; the next turn starts a new
+                                   computer, and a new memory
+```
+
+`ready` becomes `suspended` after 60 minutes with no turn (default).
+
+Suspension is free and invisible: the disk survives, so the runtime's session
+survives, so message five does not need to re-explain messages one through
+four. That is the difference between a bot you chat with and a colleague you
+leave a note for.
+
+The ceiling is not. A sandbox destroyed at the max-lifetime bound loses the
+disk; the stored transcript is intact and the conversation is still resumable,
+but the agent's own memory of it is gone. Both bounds are configurable
+(`SANDBOX_IDLE_TIMEOUT_MINUTES`, `SANDBOX_MAX_LIFETIME_HOURS`), and
+`freshConversation()` is the deliberate version of the same thing: a new
+session, on the *same* disk.
+
+## Who reads what
+
+The two feeds a client uses are different on purpose.
+
+| | `/api/team/stream` | `/api/conversations/:id/events` |
+|---|---|---|
+| covers | every teammate | one thread |
+| carries | raw events + `conversation_id`, `agent_id` | events, and `blocks` on request |
+| answers | *something happened, to whom* | *what was said* |
+| you use it for | roster, typing dots, notifications, unread | rendering the thread |
+
+A team UI wants both: one long-lived connection for the roster, and a read of
+the open thread's feed. `blocks` is what keeps the second one from becoming a
+parser — the server folds each runtime's dialect into `text`, `thinking`,
+`tool_use`, `tool_result`, `init`, `result`, `error`, `raw`, and your renderer
+handles eight kinds instead of four vendor formats.
+
+## Where the multi-tenancy is
+
+Every route is scoped to the key that called it. Agents, conversations,
+secrets, search, audit — a key sees its own account and nothing else, and the
+scoping lives in the queries rather than in each controller. For your app that
+means the second person to sign in gets their own roster, their own computers
+and their own quota without you writing a line about it — and that a browser
+app holding one person's key cannot be talked into reaching anyone else's
+teammates.
+
+What you do not get for free is *sharing*. A teammate belongs to an account.
+A shared team room across several people is your product's problem — the usual
+answer being one Fountain account for the team, with your app in front of it.
+
+## Where to look next
+
+- [The four primitives](../primitives.md) — the same objects, described on
+  their own terms.
+- [Architecture](../architecture.md) — what runs, and what breaks when a
+  dependency is down.
+- [Operations](../operations.md) — what to do when a computer is stuck.
+- [A team chat, end to end](team-chat.md) — the code.

--- a/docs/build/team-chat.md
+++ b/docs/build/team-chat.md
@@ -1,0 +1,399 @@
+# A team chat, end to end
+
+Everything below is the [TypeScript SDK](../sdk.md) against a live instance,
+in the order you would write it. It is the same sequence
+[fountain-team](https://github.com/jhgaylor/fountain-team) performs — that app
+predates the SDK and calls `fetch` directly, so its hand-written API client is
+roughly what the SDK now wraps.
+
+Nothing here needs a server of your own. The whole app is static files and a
+bearer token.
+
+## 1. A client
+
+```ts
+import { Fountain } from "fountain-sdk";
+
+const fountain = new Fountain({
+  baseUrl: "https://fountain.example.com",   // your instance
+  apiKey,                                     // pasted once, or an OAuth token
+});
+
+const me = await fountain.me();               // the cheapest check that a key works
+```
+
+In Node the arguments are optional — credentials resolve from the environment
+and `~/.fountain/credentials` exactly as the [CLI](../cli.md)'s do. In a
+browser you pass what the person gave you, and the server has to allow your
+origin (`API_CORS_ORIGINS`). See [shipping it](#10-shipping-it).
+
+## 2. Hire a teammate
+
+The **+** in these apps asks nothing. A name from a list, a sensible brain, a
+one-line brief, and the roster has a new row a second later. That is two calls:
+an [agent](../primitives.md#agent), and the agent put on the team.
+
+```ts
+const catalog = await fountain.catalog();          // this deployment's vocabulary
+const model = catalog.models.claude?.[0] ?? "anthropic/claude-sonnet-5";
+
+const agent = await fountain.agents.create({
+  name: "watchtower",
+  runtime: "claude",
+  model,
+  description: "Keeps an eye on the fleet",
+  system: "You are Watchtower. You watch things and report only what changed.",
+});
+
+const teammate = await fountain.team.add(agent.name, { name: "Watchtower" });
+
+teammate.conversation.id;      // the thread
+teammate.presence.state;       // "starting" — a computer is being provisioned
+```
+
+`catalog()` is what stops the model dropdown going stale: the runtimes, the
+suggested `provider/model` ids and the avatar vocabulary come from the server,
+not from a list in your bundle.
+
+Adding is idempotent, so the **+** does not need to know whether this agent is
+already on the team. It is also the moment a machine appears: `team.add` opens
+the teammate's standing conversation, and that provisions its sandbox.
+
+!!! note "The face"
+
+    If the account holds an OpenAI credential, Fountain will draw one:
+
+    ```ts
+    const image = await fountain.request<{ data: string; media_type: string }>(
+      "POST",
+      "/api/avatars/generate",
+      { body: { base: catalog.avatar.bases[0], mood: catalog.avatar.moods[0] } },
+    );
+    await fountain.request("PUT", `/api/agents/${agent.id}/avatar`, { body: image });
+    ```
+
+    Reading it back needs the bearer key, so an `<img src>` straight at the
+    URL will 401. Fetch the bytes and hand the element an object URL:
+
+    ```ts
+    const response = await fountain.api.raw("GET", `/api/agents/${agent.id}/avatar`);
+    element.src = URL.createObjectURL(await response.blob());
+    ```
+
+## 3. The roster
+
+```ts
+const roster = await fountain.team.list();
+
+for (const teammate of roster) {
+  render({
+    name: teammate.name,                       // its title, else the agent's name
+    status: teammate.presence.label,           // "working", "asleep · wakes on message"…
+    line: teammate.preview?.text ?? "",        // the last thing said, either way
+    who: teammate.preview?.kind,               // "you" | "them" | "typing"
+    bold: teammate.unread,
+    tokens: teammate.usage_total,              // summed over every thread it has had
+  });
+}
+```
+
+One call fills a roster row completely — nothing here is assembled from three
+endpoints and a guess. `presence.state` is the enum behind the label:
+`working`, `starting`, `online`, `asleep`, `away`, `machine_offline`,
+`failed`, `offline`. `asleep` is a teammate whose computer has been
+[parked](../primitives.md#conversation) for want of anything to do; it wakes
+on the next message with its memory intact, and your UI does not have to do
+anything about it beyond saying so.
+
+## 4. Say something
+
+```ts
+const run = fountain.team.message("watchtower", "Any disks over 80%?");
+
+for await (const chunk of run.textStream) appendToBubble(chunk);
+
+const result = await run;
+if (result.state !== "done") markFailed(result.reason);   // failed, interrupted, timeout
+```
+
+`message()` hands back the same `Run` handle `fountain.run()` does. You can
+await it for the finished reply, iterate `textStream` for the words as they
+land, iterate the run itself for tool calls and thinking, or drop it entirely
+and let the team stream in the next section carry the answer to whichever
+component is showing that thread.
+
+A turn that fails is a result, not an exception: check `state`. Only a
+transport failure or a rejected request throws, which is what §7 is about.
+
+## 5. One connection for the whole app
+
+A chat app needs to know what everyone is doing, not just the thread that is
+open. That is one endpoint, not one socket per teammate:
+
+```ts
+for await (const event of fountain.team.stream({ streams: ["stage"] })) {
+  // A `team` or `schedule` notice: the roster or the routines changed.
+  if (!event.agent_id) {
+    void refreshRoster();
+    continue;
+  }
+
+  if (event.stage === "turn") {
+    if (event.state === "started") setTyping(event.agent_id, true);
+    if (event.state === "done") {
+      setTyping(event.agent_id, false);
+      void reloadThread(event.conversation_id!);
+      notifyIfNotLooking(event.agent_id);
+    }
+  }
+}
+```
+
+Every payload is a conversation's log event plus `conversation_id` and
+`agent_id`, so it routes to a roster row without a lookup. The iterator
+reconnects from its own last event id, which means a Fountain deploy, a proxy
+timeout or a laptop lid does not lose events — and your reconnect logic is the
+`for await` you already wrote.
+
+The stages worth knowing are the ones a UI shows while nothing is being said
+yet — `provision`, `setup` and `reattach`, then `turn`, then `terminate` —
+each with a `state` of `started`, `done`, `failed` or `interrupted`.
+
+!!! note "The team stream carries raw events"
+
+    `/api/team/stream` takes `streams` and nothing else — no `blocks` — so it
+    is a notification channel: *something happened, to whom*. Read the
+    transcript itself from the conversation's own feed, which does parse
+    blocks. That is the next section.
+
+## 6. Open a thread
+
+Three calls. The third is the one that stops your app shouting about messages
+the person is currently reading.
+
+```ts
+const conversation = fountain.resume(conversationId);
+
+const [turns, events] = await Promise.all([
+  conversation.turns(),                                  // the prompts, in order
+  conversation.history({ streams: ["acp", "stdout"] }),   // paged to the end for you
+]);
+
+await conversation.markRead();
+```
+
+Each turn is a pair of bubbles: what was said, and everything the agent did
+about it. Group the feed by `turn_id` and you have both:
+
+```ts
+import type { Block, LogEvent, Turn } from "fountain-sdk";
+
+function bubbles(turns: Turn[], events: LogEvent[]) {
+  const byTurn = new Map<string, Block[]>();
+  for (const event of events) {
+    if (!event.turn_id) continue;
+    const blocks = byTurn.get(event.turn_id) ?? [];
+    blocks.push(...(event.blocks ?? []));
+    byTurn.set(event.turn_id, blocks);
+  }
+
+  return turns.flatMap((turn) => [
+    { from: "you" as const, text: turn.prompt },
+    { from: "them" as const, parts: fold(byTurn.get(turn.id) ?? []) },
+  ]);
+}
+```
+
+And a reply is a handful of blocks, folded the way a chat bubble wants them —
+adjacent prose joined, a run of tool calls collapsed into one line you can
+expand:
+
+```ts
+type Part = { kind: "text" | "thinking" | "tools"; body: string; tools: string[] };
+
+function fold(blocks: Block[]): Part[] {
+  const out: Part[] = [];
+  for (const block of blocks) {
+    const last = out.at(-1);
+    if (block.kind === "text" || block.kind === "thinking") {
+      if (last?.kind === block.kind) last.body += block.body ?? "";
+      else out.push({ kind: block.kind, body: block.body ?? "", tools: [] });
+    } else if (block.kind === "tool_use") {
+      if (last?.kind === "tools") last.tools.push(block.name ?? "a tool");
+      else out.push({ kind: "tools", body: "", tools: [block.name ?? "a tool"] });
+    }
+  }
+  return out;
+}
+```
+
+That is the entire transcript renderer, and the reason it fits on a screen is
+`blocks`. The log feed holds whatever dialect the runtime speaks — ACP
+`session/update` notifications for `claude`, `codex` and `opencode`, plain
+stdout for others — and `?blocks=true`, which `history()` sets for you, parses
+it server-side into `text`, `thinking`, `tool_use`, `tool_result`, `init`,
+`result`, `error` and `raw`. fountain-team shipped a 200-line port of
+Fountain's own ACP parser before this existed. Do not repeat that.
+
+## 7. The things a messaging app is judged on
+
+**Busy.** A teammate is one computer running one turn. A message sent
+mid-turn is refused, and the right answer is not an error toast:
+
+```ts
+import { ConversationBusyError } from "fountain-sdk";
+
+try {
+  await fountain.team.message("watchtower", text);
+} catch (error) {
+  if (error instanceof ConversationBusyError) queue.push(text);   // send it at turn-end
+  else throw error;
+}
+```
+
+Queue locally, flush on the `turn`/`done` event from §5, and several queued
+notes go as one turn. Branch on `error.code`, never on the status — see the
+[error table](../sdk.md#errors).
+
+**Stop.** Interrupt ends the turn and keeps the computer; terminate takes the
+computer down.
+
+```ts
+const conversation = await fountain.team.conversation("watchtower");
+await conversation.interrupt();
+```
+
+**Images.** Base64 in, on the same call:
+
+```ts
+await fountain.team.message("watchtower", "What is wrong with this graph?", {
+  images: [{ data: base64, media_type: "image/png" }],
+});
+```
+
+**Search.** Across every conversation the key can see, prompts and replies:
+
+```ts
+const hits = await fountain.search("disk usage");
+// { conversation_id, agent_id, turn_id, turn_number, kind: "title"|"prompt"|"reply", snippet }
+```
+
+`turn_number` is what lets a ⌘K hit open the thread scrolled to the right
+bubble.
+
+**A clean slate.** A long thread eventually wants a fresh start without losing
+the machine it was working on:
+
+```ts
+await fountain.team.freshConversation("watchtower");  // same computer, new session
+const past = await fountain.team.history("watchtower"); // the retired threads
+```
+
+The old thread is retired and stays readable; the next message starts a new
+runtime session on the same disk, so the agent's context is new but its
+clones, installs and files are where it left them.
+
+## 8. Give a teammate an app to use
+
+This is the part the clones call connectors, and it is where a hosted runtime
+stops being a convenience. A connector is an MCP server the teammate's runtime
+talks to, and it usually needs a real credential.
+
+The credential does not go in the agent config. It goes in the teammate's
+[environment](../primitives.md#environment) as a secret, and the server
+definition refers to it by name:
+
+```ts
+const environment = await fountain.environments.create({ name: "watchtower-env" });
+await fountain.agents.update("watchtower", { environment_id: environment.id });
+
+await fountain.environments.secrets.set(environment.name, "GITHUB_TOKEN", token);
+
+await fountain.agents.update("watchtower", {
+  mcp_servers: {
+    github: {
+      type: "http",
+      url: "https://api.githubcopilot.com/mcp/",
+      headers: { Authorization: "Bearer ${GITHUB_TOKEN}" },
+    },
+  },
+});
+```
+
+`${GITHUB_TOKEN}` is resolved by [substitution](../primitives.md#substitution)
+when the computer is set up. Three things follow, and they are the reason this
+is not just a nicer way to store a string:
+
+- The token is never in a prompt, a model's context, or the log feed your app
+  reads.
+- Fountain **redacts every environment value of 8 bytes or more out of the
+  conversation's output**, on the single write path every log event takes. An
+  agent asked to print its token persists `[REDACTED]`.
+- Secret values are write-only. `secrets.list()` returns keys. Your app can
+  give a teammate a credential and cannot read it back — which is exactly what
+  you want to be able to tell someone pasting a GitHub token into a web page.
+
+A connector applies when the computer is next set up, not to the machine
+already running.
+
+## 9. Routines
+
+Cron, per teammate, server-side. Nothing in your app has to be awake.
+
+```ts
+await fountain.team.schedules.create("watchtower", {
+  cron: "0 9 * * 1-5",                       // five fields, UTC
+  prompt: "Check disk usage and say only what changed.",
+  name: "Morning sweep",
+});
+
+const routines = await fountain.team.schedules.list();          // the whole team's
+await fountain.team.schedules.run("watchtower", routines[0].id);  // "Run now"
+```
+
+By default the prompt lands in the teammate's own thread, as though you had
+typed it, so the reply is in the conversation and in the agent's working
+memory. `one_off: true` gives each run a fresh conversation on a new computer
+instead, leaving the thread alone. The `schedule` notice on the team stream
+tells your UI to re-list.
+
+## 10. Shipping it
+
+Static hosting. The only server-side facts are on the Fountain instance:
+
+| What | Why |
+|---|---|
+| `API_CORS_ORIGINS` | a browser calling another origin's API is a CORS request; off by default, and it only ever admits a presented bearer key — cookies never cross origins |
+| `OAUTH_CLIENTS` | to offer **Sign in with Fountain** instead of asking for a pasted key |
+
+[Sign in with Fountain](../api.md#sign-in-with-fountain-oauth-20-for-browser-apps)
+is OAuth 2.0 authorization code + PKCE, and the token it returns *is* an API
+key: it lists and revokes under Account → API keys, and signing out revokes
+it. That is the whole authentication story for an app with no backend.
+
+## The whole thing, runnable
+
+The roster row, the event router and the transcript folder above are one file
+in this repo:
+[`sdk/typescript/examples/chat.ts`](https://github.com/BinaryBourbon/fountain/blob/main/sdk/typescript/examples/chat.ts).
+It hires a temporary teammate, prints the roster, sends a message, renders the
+thread out of blocks and cleans up after itself:
+
+```bash
+cd sdk/typescript && npm install
+FOUNTAIN_API_KEY=ftn_… node examples/chat.ts
+```
+
+CI typechecks it against the SDK on every push, which is the only reason this
+page can promise the code on it compiles.
+[`examples/team.ts`](https://github.com/BinaryBourbon/fountain/blob/main/sdk/typescript/examples/team.ts)
+is the smaller version — hire, say two things, watch the stream.
+
+## Where this goes next
+
+- [**What each piece does**](pieces.md) — what happens between Enter and the
+  first word, and which primitive is responsible for what.
+- [**TypeScript SDK**](../sdk.md) — the full surface, including everything
+  outside the team.
+- [**API reference**](../api.md#team) — the routes underneath, for a language
+  the SDK does not cover yet.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,5 +31,6 @@ Running Claude instances with worktrees locally and shuffling MCP configurations
 - [**CLI reference**](cli.md) - `fountain` command surface
 - [**API reference**](api.md) - REST endpoints and auth
 - [**LLM integration**](llm-integration.md) - connect any agentic IDE via `/skill`
+- [**Build a chat app**](build/index.md) - the bot-messenger everyone is cloning, on an API that brings the runtimes
 - [**Plugging into Fountain**](integrations/clients.md) - editors, chat surfaces, plugins, SDKs
 - [**Services Fountain uses**](integrations/index.md) - what an operator configures: sandboxes, mail, OAuth, billing, errors

--- a/docs/integrations/clients.md
+++ b/docs/integrations/clients.md
@@ -52,7 +52,10 @@ holds an API key.
 
 Everything that plugin does is available directly — see the
 [API reference](../api.md), the [TypeScript SDK](../sdk.md) and the
-[CLI reference](../cli.md). [LLM integration](../llm-integration.md) covers the
+[CLI reference](../cli.md). If what you are building is a chat surface of your
+own — the roster-and-threads app currently being cloned everywhere —
+[**Build a chat app**](../build/index.md) walks the whole thing through in SDK
+calls. [LLM integration](../llm-integration.md) covers the
 discovery endpoints that let an agentic IDE learn the whole surface from one
 fetch.
 

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -36,7 +36,7 @@ Why reach for it:
 1. Credentials. On the Hermes host either export a key —
 
     ```bash
-    export FOUNTAIN_API_KEY=fk_…                       # from Settings → API keys, or the CLI
+    export FOUNTAIN_API_KEY=ftn_…                       # from Settings → API keys, or the CLI
     export FOUNTAIN_BASE_URL=https://fountain.example  # only for a self-hosted instance
     ```
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -199,6 +199,10 @@ console.log(reply.text);
 `message()` returns the same `Run` handle `run()` does: await it, iterate it,
 or ignore it and let the stream below carry the answer to your UI.
 
+An entire messaging client on these verbs — roster, threads, connectors,
+routines, and what each piece is doing — is
+[**Build a chat app**](build/index.md).
+
 ```ts
 await fountain.team.list();                       // the roster, with unread counts
 await fountain.team.rename("watchtower", "Eyes"); // null restores the agent's name

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,10 @@ nav:
   - API reference: api.md
   - TypeScript SDK: sdk.md
   - Guided tour — opening a PR: tour.md
+  - Build a chat app:
+      - The shape everyone is cloning: build/index.md
+      - A team chat, end to end: build/team-chat.md
+      - What each piece does: build/pieces.md
   - Plugging into Fountain:
       - Overview: integrations/clients.md
       - fountain acp (reference): integrations/acp.md

--- a/sdk/typescript/examples/chat.ts
+++ b/sdk/typescript/examples/chat.ts
@@ -1,0 +1,168 @@
+/**
+ * The data layer of a messaging client for your team, in one file.
+ *
+ *   FOUNTAIN_API_KEY=... node examples/chat.ts
+ *
+ * Every piece here is what a roster-and-threads UI actually needs: a roster
+ * row, a live router for the team's one connection, and a transcript folded
+ * out of server-parsed blocks. The docs walk through it at
+ * https://binarybourbon.github.io/fountain/build/team-chat/ — this file is the
+ * copy CI typechecks, so the page cannot drift from the SDK.
+ *
+ * Creates a temporary agent and removes everything on the way out.
+ */
+import { Fountain } from "../src/node.ts";
+import type { Block, LogEvent, TeamEvent, Teammate, Turn } from "../src/index.ts";
+
+// ── what a roster row shows ──────────────────────────────────────────────────
+
+interface RosterRow {
+  agentId: string;
+  name: string;
+  status: string;
+  line: string;
+  who: "you" | "them" | "typing" | undefined;
+  unread: boolean;
+}
+
+/** One `team.list()` call fills a row completely. */
+function rosterRow(teammate: Teammate): RosterRow {
+  return {
+    agentId: teammate.agent_id,
+    name: teammate.name,
+    status: teammate.presence.label,
+    line: teammate.preview?.text ?? "",
+    who: teammate.preview?.kind,
+    unread: teammate.unread,
+  };
+}
+
+// ── the transcript ───────────────────────────────────────────────────────────
+
+type Part = { kind: "text" | "thinking" | "tools"; body: string; tools: string[] };
+type Bubble = { from: "you"; text: string } | { from: "them"; parts: Part[] };
+
+/**
+ * A reply as a chat bubble wants it: adjacent prose joined, a run of tool
+ * calls collapsed into one line.
+ *
+ * The blocks come from the server (`?blocks=true`, which `history()` sets),
+ * so this never parses a runtime's own dialect.
+ */
+function fold(blocks: Block[]): Part[] {
+  const out: Part[] = [];
+  for (const block of blocks) {
+    const last = out.at(-1);
+    if (block.kind === "text" || block.kind === "thinking") {
+      if (last?.kind === block.kind) last.body += block.body ?? "";
+      else out.push({ kind: block.kind, body: block.body ?? "", tools: [] });
+    } else if (block.kind === "tool_use") {
+      if (last?.kind === "tools") last.tools.push(block.name ?? "a tool");
+      else out.push({ kind: "tools", body: "", tools: [block.name ?? "a tool"] });
+    }
+  }
+  return out;
+}
+
+/** Each turn is a pair of bubbles: what was said, and what was done about it. */
+function bubbles(turns: Turn[], events: LogEvent[]): Bubble[] {
+  const byTurn = new Map<string, Block[]>();
+  for (const event of events) {
+    if (!event.turn_id) continue;
+    const blocks = byTurn.get(event.turn_id) ?? [];
+    blocks.push(...(event.blocks ?? []));
+    byTurn.set(event.turn_id, blocks);
+  }
+
+  return turns.flatMap((turn): Bubble[] => [
+    { from: "you", text: turn.prompt },
+    { from: "them", parts: fold(byTurn.get(turn.id) ?? []) },
+  ]);
+}
+
+// ── the one connection ───────────────────────────────────────────────────────
+
+interface Handlers {
+  rosterChanged(): void;
+  typing(agentId: string, on: boolean): void;
+  replied(agentId: string, conversationId: string): void;
+}
+
+/**
+ * Route the whole team's events. Payloads carry `conversation_id` and
+ * `agent_id`, so a row is found without a lookup; an event with neither is a
+ * `team` or `schedule` notice telling the client to re-list.
+ */
+function route(event: TeamEvent, on: Handlers): void {
+  if (!event.agent_id) return on.rosterChanged();
+  if (event.stage !== "turn") return;
+  if (event.state === "started") on.typing(event.agent_id, true);
+  if (event.state === "done") {
+    on.typing(event.agent_id, false);
+    if (event.conversation_id) on.replied(event.agent_id, event.conversation_id);
+  }
+}
+
+// ── exercise all of it against a live instance ───────────────────────────────
+
+const fountain = new Fountain();
+const name = `sdk-chat-${process.argv[2] ?? "demo"}`;
+let conversationId: string | null = null;
+
+try {
+  // The form vocabulary, so a "new teammate" dialog is never a stale list.
+  const catalog = await fountain.catalog();
+  const model = catalog.models.claude?.[0] ?? "anthropic/claude-haiku-4-5";
+
+  await fountain.agents.create({
+    name,
+    runtime: "claude",
+    model,
+    description: "Created by the Fountain SDK's chat example",
+    system: "You answer in one very short line.",
+  });
+  await fountain.team.add(name, { name: "Watchtower" });
+
+  const stop = new AbortController();
+  const watching = (async () => {
+    for await (const event of fountain.team.stream({ streams: ["stage"], signal: stop.signal })) {
+      route(event, {
+        rosterChanged: () => console.log("  · roster changed — re-list"),
+        typing: (_agentId, on) => console.log(`  · ${on ? "typing…" : "done"}`),
+        replied: (_agentId, id) => console.log(`  · reply in ${id}`),
+      });
+    }
+  })();
+
+  for (const row of (await fountain.team.list()).map(rosterRow)) {
+    console.log(`${row.unread ? "●" : " "} ${row.name} — ${row.status}  ${row.line}`);
+  }
+
+  const reply = await fountain.team.message(name, "Reply with just the word PONG.");
+  conversationId = reply.conversationId;
+
+  stop.abort();
+  await watching;
+
+  // What the UI does when someone opens the thread.
+  const conversation = fountain.resume(conversationId);
+  const [turns, events] = await Promise.all([
+    conversation.turns(),
+    conversation.history({ streams: ["acp", "stdout"] }),
+  ]);
+  await conversation.markRead();
+
+  for (const bubble of bubbles(turns, events)) {
+    if (bubble.from === "you") console.log(`you  › ${bubble.text}`);
+    else
+      for (const part of bubble.parts) {
+        if (part.kind === "tools") console.log(`them › [ran ${part.tools.join(", ")}]`);
+        else console.log(`them › ${part.body.trim()}`);
+      }
+  }
+} finally {
+  await fountain.team.remove(name).catch(() => {});
+  if (conversationId) await fountain.resume(conversationId).terminate().catch(() => {});
+  await fountain.agents.delete(name).catch(() => {});
+  console.log("cleaned up");
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -41,6 +41,7 @@ export type {
   LogEvent,
   NamedResource,
   Stream,
+  TeamEvent,
   Repository,
   Runtime,
   RunEvent,

--- a/sdk/typescript/src/schemas.ts
+++ b/sdk/typescript/src/schemas.ts
@@ -15,6 +15,9 @@ import type { components } from "./generated/openapi.ts";
 
 type S = components["schemas"];
 
+/** `T` with `K` made optional — for fields the API defaults and the generator does not. */
+type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
 // ── the four primitives ──────────────────────────────────────────────────────
 
 /** A named, re-runnable agent config — runtime, model, skills, environment. */
@@ -56,7 +59,12 @@ export type Teammate = S["Teammate"];
 export type TeamAddInput = S["TeamAddRequest"];
 /** A cron that runs a teammate with a prompt. */
 export type Schedule = S["TeamSchedule"];
-export type ScheduleInput = S["TeamScheduleCreateRequest"];
+/**
+ * Creating one. `enabled` and `one_off` are optional on the wire — the server
+ * defaults them to `true` and `false` — but the generator marks a property
+ * that carries a default as required, so they are relaxed back here.
+ */
+export type ScheduleInput = Optional<S["TeamScheduleCreateRequest"], "enabled" | "one_off">;
 export type SchedulePatch = S["TeamScheduleUpdateRequest"];
 export type TeamCommsStatus = S["TeamCommsStatus"];
 export type TeammateContact = S["TeammateContact"];

--- a/sdk/typescript/src/team.ts
+++ b/sdk/typescript/src/team.ts
@@ -6,13 +6,13 @@ import { streamPath, type StreamRequest } from "./sse.ts";
 import type {
   ConversationRecord,
   ImageInput,
-  LogEvent,
   Schedule,
   ScheduleInput,
   SchedulePatch,
   Stream,
   TeamAddInput,
   TeamCommsStatus,
+  TeamEvent,
   Teammate,
 } from "./types.ts";
 
@@ -162,13 +162,16 @@ export class Team {
    * it out of N per-conversation streams is what the apps did before this
    * endpoint existed. Reconnects from the last event id on its own.
    *
+   * Each payload is a conversation event plus `conversation_id` and
+   * `agent_id`, so a roster row can be found without a socket per teammate.
+   *
    * Note that this endpoint carries raw events only — it takes no `blocks`
    * parameter, so a client rendering a transcript from it either parses the
    * runtime's dialect itself or reads the conversation's own feed, which does
    * support blocks. Use it as a notification channel and fetch detail per
    * conversation.
    */
-  stream(options: StreamRequest = {}): AsyncIterable<LogEvent> {
+  stream(options: StreamRequest = {}): AsyncIterable<TeamEvent> {
     // No `blocks` here: the endpoint does not accept it and the spec
     // validator rejects unknown query parameters.
     return streamPath(this.http, "/api/team/stream", normalizeStreams(options));

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -58,6 +58,17 @@ export type SkillInput =
   | { name: string; content: string; source?: never; ref?: never }
   | { source: string; ref?: string; name?: string; content?: never };
 
+/**
+ * A log event off `/api/team/stream`, which multiplexes every teammate's
+ * conversation onto one connection and labels each payload with the two ids a
+ * roster routes on. Both are absent on a single-conversation stream, and on
+ * the `team` / `schedule` notices the same endpoint interleaves.
+ */
+export interface TeamEvent extends LogEvent {
+  conversation_id?: string;
+  agent_id?: string;
+}
+
 /** The log-event streams a conversation carries. */
 export type Stream = "stdout" | "stderr" | "acp" | "stage";
 


### PR DESCRIPTION
The app being cloned everywhere this month is a roster of bots and a thread each. The front end is a weekend; the machine behind each bot is not — and the usual answers either run the agent on the user's own laptop or ask for an endpoint that somebody still has to host, credential, isolate and keep memory for. That is precisely what this API already is, and the docs never said so.

### A new nav section, "Build a chat app"

| Page | What it does |
|---|---|
| `docs/build/index.md` | The story: what a bot needs that a chat UI does not give it, the two usual architectures and what each costs, and the third answer — with a diagram comparing all three. Ends on the two things the clones structurally cannot have (teammates that can message each other; a teammate reachable from an editor, AG-UI, Nostr or its own phone number). |
| `docs/build/team-chat.md` | The whole app in SDK calls, in the order you would write it: client, hire, roster, say something, one stream for everyone, open a thread, busy/interrupt/images/search/fresh start, connectors, routines, shipping it. |
| `docs/build/pieces.md` | The roles: chat noun → Fountain primitive, why `channel_id` is the whole trick, what happens between Enter and the first word, the computer's lifecycle, and which of the two feeds answers which question. |

Three ASCII diagrams in the house style (the architecture comparison, the message sequence, the sandbox lifecycle), plus the primitive tree.

### The code on those pages is real

Every TypeScript snippet is also `sdk/typescript/examples/chat.ts` — a runnable script that hires a temporary teammate, prints the roster, sends a message, renders the thread out of blocks and cleans up. It sits in `examples/`, which `npm run typecheck` covers in CI, so the page cannot drift from the SDK.

Writing it turned up two SDK defects:

- **`team.stream()` yielded `LogEvent`**, which declares neither `conversation_id` nor `agent_id` — the two ids `/api/team/stream` adds to every payload, and the only reason a team UI can route an event to a roster row without a lookup. It now yields a `TeamEvent`.
- **`schedules.create({ cron, prompt })` did not typecheck**, including the example already on `docs/sdk.md`. The spec has `enabled` and `one_off` optional; `openapi-typescript` marks a property carrying a default as required. Relaxed in the hand-written layer, which is where that kind of thing belongs.

Also corrects `fk_` → `ftn_` in the Hermes page's API key example.

### Checks

- `mkdocs build --strict` clean; cross-page anchors verified against the built site
- `docs_test.exs` green (the `mkdocs.yml` ↔ `docs.ex` nav mirror)
- SDK: `npm run typecheck`, 65 tests, `npm run build` all green
- `mix format --check-formatted`, `mix credo --strict` on the changed Elixir file

🤖 Generated with [Claude Code](https://claude.com/claude-code)