### PR TITLE
The nav was written twice and only checked by a test that looked unrelated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,12 +342,21 @@ See `.env.example` for the full list. Key ones for local dev:
 in-app manual at `/docs` — the same markdown is embedded at compile time by
 `Fountain.Docs`. Three guardrails trip people who only edit markdown:
 
-- **The nav is mirrored in code.** `mkdocs.yml` `nav:` and `@nav` in
-  `apps/fountain/lib/fountain/docs.ex` must list the same pages in the same
-  order; `apps/fountain/test/fountain/docs_test.exs` fails on any drift. Adding,
-  renaming or moving a page means editing both. (This has broken docs-only PRs
-  more than once — the failing test is in *partition 3* of CI, not the Docs
-  workflow, so it looks unrelated.)
+- **The nav lives only in `mkdocs.yml`.** `Fountain.Docs` parses that file's
+  `nav:` block at compile time, so adding, renaming or moving a page is a
+  one-file change. It used to be mirrored in `@nav` in
+  `apps/fountain/lib/fountain/docs.ex` with a drift test, which is exactly how
+  docs-only PRs kept going red in *partition 3* of CI, looking unrelated to
+  the docs. Keep to the two line shapes the parser reads — `  - Title: x.md`,
+  and a `  - Section:` header with six-space-indented children — because a
+  line it cannot read raises at compile time rather than being skipped.
+- **Anything `Fountain.Docs` reads at compile time must be `COPY`d into the
+  Docker build stage.** The release image contains no `docs/`, only strings
+  baked out of it, so a file outside the `COPY` list does not degrade to a
+  broken link: `mix release` dies, no image is built, CI stays green and the
+  deploy silently never happens (#884). `docs_test.exs` asserts the module's
+  `@external_resource` list against the Dockerfile, so adding a new
+  compile-time read fails there first.
 - **`mkdocs build --strict`** is what CI runs; a broken relative link or a page
   not in the nav is an error. Run it locally (`pip install -r
   docs/requirements.txt`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,14 @@ COPY ee ./ee
 # it the compile fails on File.read!. This is also the only way the content
 # ships: the release never contains docs/ as files.
 #
-# Every path a page snippet-includes (`--8<-- "…"`) has to be here too, and
-# those paths reach outside docs/: the changelog page includes CHANGELOG.md,
-# and the tour page includes the SDK example it is written from. A missing one
-# is not a broken link, it is a failed image build — `docs_test.exs` checks
-# this list against the snippets so the failure lands in CI instead.
+# Every file Fountain.Docs reads at compile time has to be here too, and those
+# paths reach outside docs/: the nav is parsed from mkdocs.yml, the changelog
+# page snippet-includes CHANGELOG.md, and the tour page includes the SDK
+# example it is written from. A missing one is not a broken link, it is a
+# failed image build — `docs_test.exs` checks this list against the module's
+# @external_resource attributes so the failure lands in CI instead.
 COPY docs ./docs
+COPY mkdocs.yml ./
 COPY CHANGELOG.md ./
 COPY sdk/typescript/examples ./sdk/typescript/examples
 

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -14,11 +14,20 @@ defmodule Fountain.Docs do
   This is distinct from `Fountain.Help`, the curated in-app help under
   `priv/help/` — that stays as it is; `/docs` is the full public manual.
 
-  `@nav` mirrors the `nav:` section of `mkdocs.yml`; `docs_test.exs` parses
-  that file and fails on any drift, in either direction. The MkDocs dialect
-  the preprocessing covers is deliberately small (snippet includes,
-  admonitions, relative `.md` links) — if a doc page starts using an extension
-  beyond that, check the page at `/docs`, don't assume.
+  The nav is **read from `mkdocs.yml` at compile time**, not mirrored here.
+  It used to be a hand-maintained copy that `docs_test.exs` diffed against the
+  real file, and the diff is what people hit: adding a page to `mkdocs.yml`
+  without editing this module failed a test in CI partition 3, which looks
+  entirely unrelated to the docs. Adding a page to `mkdocs.yml` is now the
+  whole change.
+
+  Because `mkdocs.yml` is read at compile time it is also an
+  `@external_resource`, which means it must be COPYed into the Docker build
+  stage — see the note on the `@external_resource` list below.
+
+  The MkDocs dialect the preprocessing covers is deliberately small (snippet
+  includes, admonitions, relative `.md` links) — if a doc page starts using an
+  extension beyond that, check the page at `/docs`, don't assume.
   """
 
   alias Fountain.Docs.Compiler
@@ -26,56 +35,22 @@ defmodule Fountain.Docs do
   @root Path.expand("../../../..", __DIR__)
   @docs_dir Path.join(@root, "docs")
 
-  # Mirrors mkdocs.yml `nav:` — {title, file} or {section_title, [{title, file}]}.
-  @nav [
-    {"Home", "index.md"},
-    {"Setup", "setup.md"},
-    {"Self-hosting", "self-hosting.md"},
-    {"Architecture", "architecture.md"},
-    {"Operations", "operations.md"},
-    {"Configuration reference", "configuration.md"},
-    {"Sandbox providers",
-     [
-       {"The contract", "integrations/sandbox-contract.md"},
-       {"Sprites", "integrations/sprites.md"},
-       {"Sprites transport reference", "integrations/sprites-contract.md"},
-       {"E2B", "integrations/e2b.md"},
-       {"Daytona", "integrations/daytona.md"},
-       {"Self-hosted runners", "integrations/runners.md"},
-       {"Adding a provider", "integrations/adding-a-sandbox-provider.md"}
-     ]},
-    {"Services Fountain uses",
-     [
-       {"Overview", "integrations/index.md"},
-       {"Mail", "integrations/mail.md"},
-       {"GitHub OAuth", "integrations/github-oauth.md"},
-       {"Stripe", "integrations/stripe.md"},
-       {"Sentry", "integrations/sentry.md"}
-     ]},
-    {"The four primitives", "primitives.md"},
-    {"CLI reference", "cli.md"},
-    {"API reference", "api.md"},
-    {"TypeScript SDK", "sdk.md"},
-    {"Guided tour — opening a PR", "tour.md"},
-    {"Build a chat app",
-     [
-       {"The shape everyone is cloning", "build/index.md"},
-       {"A team chat, end to end", "build/team-chat.md"},
-       {"What each piece does", "build/pieces.md"}
-     ]},
-    {"Plugging into Fountain",
-     [
-       {"Overview", "integrations/clients.md"},
-       {"fountain acp (reference)", "integrations/acp.md"},
-       {"Editors (ACP)", "integrations/editors.md"},
-       {"OpenClaw (ACP)", "integrations/openclaw.md"},
-       {"Hermes Agent (plugin)", "integrations/hermes.md"},
-       {"OpenBot (AG-UI)", "integrations/openbot.md"},
-       {"Buzz (Nostr)", "integrations/buzz.md"},
-       {"LLM integration", "llm-integration.md"}
-     ]},
-    {"Changelog", "changelog.md"}
-  ]
+  @mkdocs_yml Path.join(@root, "mkdocs.yml")
+
+  # The nav, parsed from mkdocs.yml itself. `{title, file}` for a page,
+  # `{section_title, [{title, file}]}` for a section — the same shape the
+  # hand-maintained copy had, minus the maintaining.
+  @nav @mkdocs_yml |> File.read!() |> Compiler.parse_nav()
+
+  # Everything read at compile time is listed here, so an edit recompiles the
+  # module in dev — AND so `docs_test.exs` can assert the Dockerfile COPYs it
+  # into the build stage. That second job is the load-bearing one: the release
+  # image never contains these files, only the strings baked out of them, so a
+  # path outside what the Dockerfile COPYs does not degrade to a broken link.
+  # It kills `mix release`, no image is produced, CI stays green, and the
+  # deploy silently never happens (#884).
+  @external_resource @mkdocs_yml
+
   # docs/changelog.md pulls the repo-root CHANGELOG.md in via a snippet.
   @external_resource Path.join(@root, "CHANGELOG.md")
 
@@ -107,11 +82,16 @@ defmodule Fountain.Docs do
   @spec slugs() :: [String.t()]
   def slugs, do: Map.keys(@pages)
 
+  @doc """
+  The compiled nav in *source* shape — `{title, file}` rather than
+  `{title, slug}` — so tests can check the pages mkdocs.yml names against
+  what is on disk. This is what the module actually embedded, not a re-read
+  of the file.
+  """
+  @spec nav_source() :: [{String.t(), String.t() | [{String.t(), String.t()}]}]
+  def nav_source, do: @nav
+
   @doc "Fetch a page by slug: `{:ok, %{title: ..., body: markdown}}` or `:error`."
   @spec get(String.t()) :: {:ok, %{title: String.t(), body: String.t()}} | :error
   def get(slug) when is_binary(slug), do: Map.fetch(@pages, slug)
-
-  @doc "The nav source as `{title, file}` pairs — for the mkdocs.yml sync test."
-  @spec nav_source() :: [{String.t(), String.t() | [{String.t(), String.t()}]}]
-  def nav_source, do: @nav
 end

--- a/apps/fountain/lib/fountain/docs/compiler.ex
+++ b/apps/fountain/lib/fountain/docs/compiler.ex
@@ -19,6 +19,73 @@ defmodule Fountain.Docs.Compiler do
     end
   end
 
+  @doc """
+  Parses the `nav:` block of `mkdocs.yml` into the shape `Fountain.Docs`
+  serves: `{title, file}` for a page and `{section_title, [{title, file}, ...]}`
+  for a section, in document order.
+
+  Deliberately not a YAML parser, and it does not need to be — the nav is a
+  hand-written two-level list, and this reads the two line shapes it can take.
+  What matters is the failure mode: a line it does not recognise **raises**
+  rather than being skipped. A page silently missing from `/docs` is exactly
+  the bug this parser exists to make impossible, so being unable to parse the
+  nav has to fail the compile, not shrink the site.
+
+  This replaced a hand-maintained copy of the nav in `Fountain.Docs`. Adding a
+  page to `mkdocs.yml` is now the whole change.
+  """
+  @spec parse_nav(String.t()) :: [{String.t(), String.t() | [{String.t(), String.t()}]}]
+  def parse_nav(yaml) do
+    case String.split(yaml, ~r/^nav:\n/m, parts: 2) do
+      [_before, block] -> block |> nav_lines() |> Enum.reduce([], &nav_entry/2) |> finish_nav()
+      _ -> raise ArgumentError, "mkdocs.yml has no `nav:` block"
+    end
+  end
+
+  # The block runs until the first line that is neither blank nor indented —
+  # the next top-level key. Comments inside it are ignored rather than fatal.
+  defp nav_lines(block) do
+    block
+    |> String.split("\n")
+    |> Enum.take_while(&(&1 == "" or String.starts_with?(&1, " ")))
+    |> Enum.reject(&(String.trim(&1) == "" or String.starts_with?(String.trim(&1), "#")))
+  end
+
+  defp nav_entry(line, acc) do
+    case Regex.run(~r/^(\s+)- ([^:]+):\s*(\S+)?\s*$/, line) do
+      # `  - Setup: setup.md` — a top-level page.
+      [_, indent, title, file] when byte_size(indent) == 2 ->
+        [{title, file} | acc]
+
+      # `  - Sandbox providers:` — a section header; its children follow.
+      [_, indent, title] when byte_size(indent) == 2 ->
+        [{title, []} | acc]
+
+      # `      - Sprites: integrations/sprites.md` — a child of the section
+      # currently being built.
+      [_, indent, title, file] when byte_size(indent) > 2 ->
+        case acc do
+          [{section, children} | rest] when is_list(children) ->
+            [{section, [{title, file} | children]} | rest]
+
+          _ ->
+            raise ArgumentError, "indented nav entry with no section above it: #{inspect(line)}"
+        end
+
+      _ ->
+        raise ArgumentError, "unparsed mkdocs.yml nav line: #{inspect(line)}"
+    end
+  end
+
+  defp finish_nav(acc) do
+    acc
+    |> Enum.map(fn
+      {section, children} when is_list(children) -> {section, Enum.reverse(children)}
+      entry -> entry
+    end)
+    |> Enum.reverse()
+  end
+
   @doc "Flattens a nav (sections one level deep) to `{title, file}` pairs in order."
   @spec flat_pages(list()) :: [{String.t(), String.t()}]
   def flat_pages(nav) do

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -15,7 +15,6 @@ defmodule Fountain.DocsTest do
   alias Fountain.Docs
   alias Fountain.Docs.Compiler
 
-  @mkdocs_yml Path.expand("../../../../mkdocs.yml", __DIR__)
   @repo_root Path.expand("../../../..", __DIR__)
   @dockerfile Path.join(@repo_root, "Dockerfile")
 
@@ -49,6 +48,49 @@ defmodule Fountain.DocsTest do
       end
     end
 
+    @doc """
+    The generalisation of the test above. Snippets are found by scanning
+    markdown; this one asks the module itself what it read, so a *new kind* of
+    compile-time dependency is covered without anyone remembering to extend a
+    scanner. `mkdocs.yml` is the case that motivated it — the nav is parsed
+    from it at compile time, and nothing about a snippet scan would ever have
+    noticed it was missing from the Dockerfile.
+    """
+    test "every file Fountain.Docs reads at compile time is copied into the image" do
+      copied = dockerfile_copies()
+
+      for path <- external_resources() do
+        assert File.exists?(Path.join(@repo_root, path)),
+               "Fountain.Docs reads #{path}, which does not exist"
+
+        assert Enum.any?(copied, &covers?(&1, path)),
+               """
+               Fountain.Docs reads #{path} at compile time, and the Dockerfile
+               does not COPY it into the build stage. This does not break a
+               link — it breaks `mix release`, so no image is built, CI stays
+               green and the deploy never happens. Add a COPY for it beside
+               `COPY docs ./docs`.
+               """
+      end
+    end
+
+    defp external_resources do
+      :attributes
+      |> Fountain.Docs.__info__()
+      |> Keyword.get_values(:external_resource)
+      |> List.flatten()
+      |> Enum.map(&to_string/1)
+      |> Enum.map(&Path.relative_to(&1, @repo_root))
+      |> Enum.uniq()
+    end
+
+    defp dockerfile_copies do
+      @dockerfile
+      |> File.read!()
+      |> then(&Regex.scan(~r/^COPY\s+(?!--)(\S+)\s+\S+$/m, &1))
+      |> Enum.map(fn [_, source] -> source end)
+    end
+
     defp snippet_paths do
       Path.join(@repo_root, "docs/**/*.md")
       |> Path.wildcard()
@@ -65,9 +107,99 @@ defmodule Fountain.DocsTest do
     end
   end
 
-  describe "nav ↔ mkdocs.yml" do
-    test "matches the nav: section of mkdocs.yml exactly, order included" do
-      assert Docs.nav_source() == mkdocs_nav()
+  describe "nav ← mkdocs.yml" do
+    @doc """
+    The nav is parsed from mkdocs.yml rather than mirrored in Elixir, so there
+    is no longer a drift test to write — drift is unrepresentable. What is
+    worth pinning is the parser's contract, and above all that it REFUSES a
+    line it does not understand. Silently dropping one would quietly shrink
+    /docs, which is the failure this whole arrangement exists to prevent.
+    """
+    test "parses the real mkdocs.yml into pages and one-level sections" do
+      nav = Docs.nav_source()
+
+      assert {"Home", "index.md"} in nav
+      assert {"Setup", "setup.md"} in nav
+
+      assert {"Sandbox providers", children} =
+               Enum.find(nav, &match?({"Sandbox providers", _}, &1))
+
+      assert {"Sprites", "integrations/sprites.md"} in children
+    end
+
+    test "keeps mkdocs.yml's order" do
+      titles = Enum.map(Docs.nav_source(), &elem(&1, 0))
+      assert Enum.take(titles, 3) == ["Home", "Setup", "Self-hosting"]
+      assert List.last(titles) == "Changelog"
+    end
+
+    test "a page and a section are told apart by indentation" do
+      yaml = """
+      nav:
+        - Home: index.md
+        - Section:
+            - Child: a/b.md
+        - Tail: t.md
+      """
+
+      assert Compiler.parse_nav(yaml) == [
+               {"Home", "index.md"},
+               {"Section", [{"Child", "a/b.md"}]},
+               {"Tail", "t.md"}
+             ]
+    end
+
+    test "blank lines and comments inside the block are ignored" do
+      yaml = """
+      nav:
+        # a comment
+        - Home: index.md
+
+        - Tail: t.md
+      extra:
+      """
+
+      assert Compiler.parse_nav(yaml) == [{"Home", "index.md"}, {"Tail", "t.md"}]
+    end
+
+    test "the block ends at the next top-level key" do
+      yaml = """
+      nav:
+        - Home: index.md
+      extra:
+        - Not: a/page.md
+      """
+
+      assert Compiler.parse_nav(yaml) == [{"Home", "index.md"}]
+    end
+
+    test "an unparsable nav line raises rather than being dropped" do
+      yaml = "nav:\n  - Home: index.md\n  this is not a nav entry\n"
+
+      assert_raise ArgumentError, ~r/unparsed mkdocs.yml nav line/, fn ->
+        Compiler.parse_nav(yaml)
+      end
+    end
+
+    test "an indented entry with no section above it raises" do
+      yaml = "nav:\n      - Orphan: a/b.md\n"
+
+      assert_raise ArgumentError, ~r/no section above it/, fn ->
+        Compiler.parse_nav(yaml)
+      end
+    end
+
+    test "a file with no nav: block raises" do
+      assert_raise ArgumentError, ~r/no `nav:` block/, fn ->
+        Compiler.parse_nav("site_name: Fountain\n")
+      end
+    end
+
+    test "every page the nav names exists on disk" do
+      for {_title, file} <- Compiler.flat_pages(Docs.nav_source()) do
+        assert File.exists?(Path.join([@repo_root, "docs", file])),
+               "mkdocs.yml nav lists #{file}, which does not exist"
+      end
     end
   end
 
@@ -204,33 +336,4 @@ defmodule Fountain.DocsTest do
   # `- Title: file.md` entries at two indent levels and `- Title:` section
   # headers. Anything it doesn't recognize fails the test, which is the point —
   # a new nav shape needs a decision here, not silent skipping.
-  defp mkdocs_nav do
-    [_before, nav_block] = @mkdocs_yml |> File.read!() |> String.split(~r/^nav:\n/m, parts: 2)
-
-    nav_block
-    |> String.split("\n")
-    |> Enum.take_while(&(&1 == "" or String.starts_with?(&1, " ")))
-    |> Enum.reject(&(String.trim(&1) == ""))
-    |> Enum.reduce([], fn line, acc ->
-      case Regex.run(~r/^(\s+)- ([^:]+):\s*(\S+)?\s*$/, line) do
-        [_, indent, title, file] when byte_size(indent) == 2 ->
-          [{title, file} | acc]
-
-        [_, indent, title] when byte_size(indent) == 2 ->
-          [{title, []} | acc]
-
-        [_, indent, title, file] when byte_size(indent) > 2 ->
-          [{section, children} | rest] = acc
-          [{section, [{title, file} | children]} | rest]
-
-        _ ->
-          flunk("unparsed mkdocs.yml nav line: #{inspect(line)}")
-      end
-    end)
-    |> Enum.map(fn
-      {section, children} when is_list(children) -> {section, Enum.reverse(children)}
-      entry -> entry
-    end)
-    |> Enum.reverse()
-  end
 end

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,12 +51,20 @@ markdown_extensions:
   - toc:
       permalink: true
 
-# ── Adding or renaming a page? Two places must change together ─────────────
-# The app serves these same pages at /docs and mirrors this nav in
-# apps/fountain/lib/fountain/docs.ex (`@nav`). docs_test.exs diffs the two and
-# CI fails on any drift — a new entry here without one there is the usual way
-# a docs-only PR goes red. Also: `mkdocs build --strict` fails on a broken
-# relative link, and docs/cli.md is diffed against the real CLI command tree.
+# ── This nav is the only copy ──────────────────────────────────────────────
+# The app serves these same pages at /docs and PARSES this block at compile
+# time (Fountain.Docs, via Compiler.parse_nav/1), so adding or renaming a page
+# is a one-file change. It used to be mirrored in @nav in
+# apps/fountain/lib/fountain/docs.ex with a test diffing the two, which is how
+# docs-only PRs kept going red in CI partition 3.
+#
+# A line this file's parser cannot read raises at compile time rather than
+# being skipped — a page silently missing from /docs is the failure being
+# prevented. Keep to the two shapes below: `  - Title: file.md` for a page and
+# a `  - Section:` header with six-space-indented children.
+#
+# Also: `mkdocs build --strict` fails on a broken relative link, and
+# docs/cli.md is diffed against the real CLI command tree.
 nav:
   - Home: index.md
   - Setup: setup.md


### PR DESCRIPTION
Adding a docs page meant editing `mkdocs.yml`, then editing `@nav` in `apps/fountain/lib/fountain/docs.ex` to say the same thing again. A test diffed the two and failed on drift — in **CI partition 3**, where the Elixir suite lives, so a docs-only PR went red pointing at something that looks nothing like docs. `CLAUDE.md` warned about it in as many words: *"this has broken docs-only PRs more than once."*

`Fountain.Docs` now parses the `nav:` block out of `mkdocs.yml` at compile time. Drift isn't fixed, it's **unrepresentable** — the 44-line copy is gone and adding a page is a one-file change.

## The parser refuses rather than skips

`Compiler.parse_nav/1` is deliberately not a YAML parser — no new dependency. The nav is a hand-written two-level list and this reads the two line shapes it takes.

What matters is the failure mode: **a line it doesn't recognise raises.** A page silently missing from `/docs` is the exact bug this exists to prevent, so failing to parse has to fail the compile, not quietly shrink the site.

## The trap this opens, and the guard for it

Reading `mkdocs.yml` at compile time makes it an `@external_resource`. The release image contains none of these files — only the strings baked out of them — so a compile-time read of a path the Dockerfile doesn't `COPY` **does not degrade to a broken link**. `mix release` dies inside the image, no image is produced, CI stays green, and the deploy silently never happens.

That's **#884**, three commits ago.

So: `COPY mkdocs.yml ./`, plus a test that closes the *class* of bug rather than this one instance. The old check scanned markdown for `--8<--` snippet paths and would never have noticed `mkdocs.yml`. The new one asks the module what it actually read — every `@external_resource` must be covered by a Dockerfile `COPY` — so the next compile-time dependency anyone adds is checked without remembering to extend a scanner.

**Verified by reverting.** With `COPY mkdocs.yml ./` removed:

```
1) test every file Fountain.Docs reads at compile time is copied into the image
   Fountain.Docs reads mkdocs.yml at compile time, and the Dockerfile
   does not COPY it into the build stage. This does not break a
   link — it breaks `mix release`, so no image is built, CI stays
   green and the deploy never happens.
```

Restored and re-verified green.

## Stale guidance removed

The header comment in `mkdocs.yml` ("Two places must change together") and the docs guardrails in `CLAUDE.md` both documented the old requirement. Left alone, they'd send the next person to edit a file that no longer needs editing.

## Verification

| Check | Result |
|---|---|
| Full suite | 6 doctests, 3 properties, **3274 tests, 0 failures** |
| Docs tests | 31 tests, 0 failures (was 22 — 9 new) |
| `mix format --check-formatted` | clean |
| `mix credo --strict` | 537 files, no issues |
| `mkdocs build --strict` | exit 0 |
| Dockerfile guard | fails when the COPY is removed, passes when restored |

Run against an isolated database (`DATABASE_URL` → `fountain_test_navwt`) because another session is working in a parallel worktree and we share one `fountain_test`.

**Incidental proof it works:** this branch was cut after #893 landed a whole new "Build a chat app" section, which had dutifully added its three pages to the hand-maintained `@nav`. The parser picked all three up with nothing done by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
