### PR TITLE
Six test partitions, because the slowest one is the wall-clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,20 @@ permissions:
 # and 55 of 198 modules are `async: false` for real reasons (Application.put_env
 # in the config tests, set_mimic_global in 13 files, the ETS rate-limit table).
 # No runner size crosses that floor; only separate OS processes do, because
-# separate partitions are separate BEAMs. Split three ways the serial tail
-# falls from 111.6s to roughly a third of it, and each partition gets its own
-# Postgres rather than 2,423 tests sharing one 20-connection pool.
+# separate partitions are separate BEAMs. Splitting N ways drops the serial
+# tail to roughly 1/N of it, and each partition gets its own Postgres rather
+# than the whole suite sharing one 20-connection pool.
+#
+# #894 took it from three to six, because this matrix is the critical path for
+# every commit: the slowest partition plus the serial coverage gate IS the
+# wall-clock of CI. At three, the slowest partition was ~5m of a ~5m54s run.
+# The limit is that ~60s of each job is fixed cost that does not divide
+# (Postgres container init dominates), so the marginal win shrinks: six roughly
+# halves the test work for two more jobs' worth of that cost, and eight would
+# buy only ~30s beyond six. Shrink the 60s before adding a seventh.
 #
 # The cost is that each partition instruments every module while exercising a
-# third of the tests, so no partition's coverage means anything on its own.
+# fraction of the tests, so no partition's coverage means anything on its own.
 # Hence the `coverage` job: partitions export, it merges, and the 85% threshold
 # is enforced once against the union (see mix.exs / coverage.exs).
 #
@@ -213,7 +221,7 @@ jobs:
       contents: read
 
     strategy:
-      # Each partition is an independent verdict and all three are wanted: a
+      # Each partition is an independent verdict and all six are wanted: a
       # cancelled sibling would leave the coverage merge without its export and
       # turn one test failure into two unrelated-looking ones.
       fail-fast: false
@@ -221,7 +229,15 @@ jobs:
         # The single source of truth for how many partitions there are — the
         # `--partitions` argument below is `strategy.job-total`, so adding an
         # entry here is the whole change.
-        partition: [1, 2, 3]
+        #
+        # Six, not three, because this matrix is the critical path for every
+        # commit: the slowest partition plus the serial coverage gate IS the
+        # wall-clock of CI, and at three the slowest was ~5m. Each job carries
+        # ~60s of fixed cost (Postgres container init dominates) that does not
+        # divide, so the win shrinks as the count grows — six roughly halves
+        # the test work while paying that cost twice more, and eight would buy
+        # only ~30s beyond it. Attack the 60s before adding a seventh.
+        partition: [1, 2, 3, 4, 5, 6]
 
     outputs:
       # Same value from every partition, so which one wins the race to set it
@@ -265,10 +281,10 @@ jobs:
       # deliberately-narrow restore-keys below: a cache whose contents depend
       # on who got there first is the failure mode being avoided.
       #
-      # The three partitions DO share a key, and that is not the same race:
+      # The partitions DO share a key, and that is not the same race:
       # they compile one identical :test tree and differ only in which test
       # files they load, so whichever wins the save has saved the same archive
-      # the others would have. Giving each partition its own key would triple
+      # the others would have. Giving each partition its own key would multiply
       # the storage for identical content and stop them warming each other.
       - name: Restore deps cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
@@ -325,7 +341,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # The 85% gate, enforced once against all three partitions' data. It is a
+  # The 85% gate, enforced once against every partition's data. It is a
   # separate job because there is nowhere else it can live: no partition can
   # see the others' coverage, and ExCoveralls — which this replaced in #620 —
   # had no way to merge across machines at all. Elixir's built-in cover does,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ wrap `record/1` in a way that makes it blocking for the user.
 7. `MIX_ENV=dev mix dialyzer`
 8. Go CLI checks: `go test ./...` and `go vet ./...` in `cli/`
 9. `mix ecto.create && mix ecto.migrate`
-10. The test suite, as three partitions in three parallel jobs (`scripts/test-partition.sh`), plus a `coverage` job that merges their exports with `mix test.coverage` and enforces the 85% threshold
+10. The test suite, as six partitions in six parallel jobs (`scripts/test-partition.sh`), plus a `coverage` job that merges their exports with `mix test.coverage` and enforces the 85% threshold
 11. Release boot check — builds a prod release, probes `/health` and `/health/ready`, runs a release task beside the live server
 12. `mix openapi.spec.json` + `jq empty` (OpenAPI spec validates)
 
@@ -256,8 +256,8 @@ else — a tree that differs, no PR, no green run — gets the full run.
 ### Coverage
 
 Coverage uses Elixir's built-in cover, not ExCoveralls — ExCoveralls cannot
-merge results across machines, and since #620 the suite runs as three
-partitions on three of them. Settings live in `coverage.exs` at the repo root
+merge results across machines, and since #620 the suite runs as six
+partitions on six of them (three until #894). Settings live in `coverage.exs` at the repo root
 (read by both mix.exs files): `summary: [threshold: 85]` and `:ignore_modules`,
 which replaced `coveralls.json`'s `minimum_coverage` and `skip_files`.
 

--- a/mix.exs
+++ b/mix.exs
@@ -12,8 +12,8 @@ defmodule Fountain.Umbrella.MixProject do
       aliases: aliases(),
       # Built-in cover rather than ExCoveralls (#620): ExCoveralls has no way
       # to merge results from separate machines, and the suite is now run as
-      # three partitions in three CI jobs, each of which instruments every
-      # module while exercising a third of the tests. `mix test --partitions`
+      # six partitions in six CI jobs, each of which instruments every
+      # module while exercising a sixth of the tests. `mix test --partitions`
       # exports a .coverdata per partition and `mix test.coverage` merges them
       # here, at the umbrella root, where the 85% threshold is enforced once
       # against the union. Dropping the threshold per partition instead would


### PR DESCRIPTION
First of three changes aimed at commit → prod latency. This one is a matrix entry.

## Why this is the lever

The test matrix is the critical path for **every** commit — the slowest partition plus the serial coverage gate *is* CI's wall-clock. Everything else finishes beside it with room to spare (static analysis 3m04s, compose checks 26s).

Measured on #892's run:

```
partition 1   303s job / 241s test step
partition 2   245s     / 188s
partition 3   276s     / 213s
coverage gate  51s, serial after the slowest
                              → critical path 5m54s
```

642s of test work over three jobs. Six jobs is ~107s each, putting the critical path near **3m48s**.

## Why six and not more

~60s of every partition job is fixed cost that does not divide: Postgres container init is 20–28s of it, the rest is checkout, Elixir setup, cache restores, and the compile each partition does regardless. Six pays that twice more to halve the work. Eight would buy only ~30s beyond six. The 60s is the thing to attack before a seventh partition.

## Verified locally

The three new partitions are non-empty — the risk this change actually carries, since `test-partition.sh` refuses to pass a partition that runs zero tests:

```
partition 4/6: 675 tests, coverage exported
partition 5/6: 456 tests, coverage exported
partition 6/6: 577 tests, coverage exported
```

260 test files spread over 6 partitions, so there is plenty of granularity.

`--partitions` is `strategy.job-total` and the coverage job reads the count from the partitions themselves, so the matrix entry really is the whole change. Comments in `ci.yml`, `mix.exs` and `CLAUDE.md` that said "three" are updated.

## Cost

+~4 runner-minutes per CI run (two more jobs' worth of the fixed 60s). Public repo, so the minutes are free; the trade is deliberate — latency is the goal, minutes are secondary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)