### PR TITLE
Write the build pages like a person

### DIFF
--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -1,18 +1,16 @@
 # The shape everyone is cloning
 
-The app on your timeline this month is the same app. A messaging client where
-the contacts are bots: a roster down the left, a thread on the right, a **+**
-that makes a new one with a name, a face and a one-line brief, and a settings
-panel where you connect it to GitHub or Notion so it can actually do
-something. Grok Bot shipped that shape, the clones are everywhere, and most of
-them are good.
+The same app keeps turning up: a messaging client whose contacts are bots.
+Roster on the left, thread on the right, a **+** that makes a new bot out of a
+name and a one-line brief, and a settings panel for connecting it to GitHub or
+Notion. Grok Bot shipped that shape and the clones are everywhere.
 
-The front end is a weekend. What takes longer is the half nobody screenshots.
+The front end is a weekend of work. The machinery under it is not.
 
 ## What a bot needs that a chat UI does not give it
 
-A bubble is text. A teammate is a process on a machine, and the machine is the
-product:
+A useful teammate is a process running on a machine, so something has to
+supply the machine:
 
 | Behind the bubble | What it actually means |
 |---|---|
@@ -24,28 +22,24 @@ product:
 | tenancy | the second person who signs in does not see the first one's bots |
 | a clock | "every weekday at nine" |
 
-None of that is chat. All of it is what separates a bot that answers from a
-bot that does the thing.
-
 ## The two usual answers
 
 **Run the agent on the user's own machine.** The app becomes a front end for a
 process on your laptop: your Node, your keys in a dotfile, your working
-directory. It is the fastest thing to build and it is genuinely lovely for one
-person. It is also why the README starts with `git clone` — everybody who wants
-a bot installs the whole stack, the bots stop when the lid closes, and "share
-it with my team" has no answer.
+directory. Nothing is quicker to build, and for one person it works well. The
+cost shows up in the README, which starts with `git clone`: everyone who wants
+a bot installs the whole stack, the bots stop when the lid closes, and sharing
+them with a team has no answer.
 
-**Take an endpoint.** Bring your own agent: a URL that speaks
+**Take an endpoint.** Bring your own agent: a URL speaking
 [ACP](../integrations/acp.md), or an OpenAI-compatible chat completion, or a
-framework's own protocol. Better — the app can now run anywhere — but it has
-moved the hard part rather than solved it. Somebody still has to host that
-runtime, give it a filesystem, put credentials in it, keep its memory between
-calls, and stop one tenant reading another's. A chat-completions endpoint is
-stateless and has no shell. An ACP endpoint has one only if you built it one.
+framework's own protocol. The app can run anywhere now, but the hard part has
+moved rather than gone. Somebody still hosts that runtime, gives it a
+filesystem, puts credentials in it, keeps its memory between calls and stops
+one tenant reading another's. A chat-completions endpoint is stateless and has
+no shell. An ACP endpoint has one only if you built it one.
 
-Either way, the part that gets skipped is the part that costs money and pages
-you at night.
+Both leave the same gap.
 
 ## The third answer
 
@@ -66,9 +60,10 @@ Make the runtime an HTTP API that somebody else operates.
      static files             secrets, memory that survives the message
 ```
 
-Fountain is C. `POST /api/team` hires a teammate and gives it a computer;
-`POST /api/team/:id/messages` says something to it; one SSE connection carries
-what every teammate is doing. Your app is static files and a bearer token.
+Fountain is that third shape. `POST /api/team` hires a teammate and gives it a
+computer, `POST /api/team/:id/messages` says something to it, and one SSE
+connection carries what every teammate is doing. Your app is static files and
+a bearer token.
 
 ## What you write, and what you stop writing
 
@@ -81,43 +76,43 @@ what every teammate is doing. Your app is static files and a bearer token.
 | what a routine is for | runs it on a cron |
 | how a thread should look | parses each runtime's dialect into blocks you can render |
 
-The second column is the one that has an on-call rotation.
+Only one of those columns has an on-call rotation.
 
 ## It already exists, twice
 
-Two apps are built on this API and are open source. Neither has a
-backend — both are static files talking to Fountain with a key the person
-pasted in, or a "Sign in with Fountain" token.
+Two apps are built on this API, both open source and both without a backend
+of their own: static files talking to Fountain with a key the person pasted
+in, or a "Sign in with Fountain" token.
 
-- **[fountain-team](https://github.com/jhgaylor/fountain-team)** — the one this
-  section walks through: roster, threads, queued messages while a teammate is
-  busy, images, notifications, routines, ⌘K search, connectors, a live
-  activity feed. A few thousand lines of React and no server of its own.
+- **[fountain-team](https://github.com/jhgaylor/fountain-team)** is the one
+  this section walks through: roster, threads, queued messages while a
+  teammate is busy, images, notifications, routines, ⌘K search, connectors, a
+  live activity feed. A few thousand lines of React.
 - **[fountain-conversations](https://github.com/jhgaylor/fountain-conversations)**
-  — the same API from the other end: one conversation, in detail.
+  takes the same API from the other end, showing one conversation in detail.
 
-Fountain's own console does not do chat at all. It manages agents, secrets and
-audit; the chat surfaces are these apps, on the public API, with no privileged
-access. Whatever they do, your clone can do.
+Fountain's own console has no chat in it. It manages agents, secrets and
+audit. The chat surfaces are these two apps, running on the public API with no
+privileged access to it.
 
 ## Two things the clones do not have
 
-**The teammates know each other.** Every conversation on the team channel is
-handed an MCP server by Fountain itself, so a teammate can list the others,
-find "the engineer", send them a message and wait for the reply — and the
-exchange shows up in both threads. See [Team](../api.md#team).
+**The teammates know each other.** Fountain hands every conversation on the
+team channel an MCP server, so a teammate can list the others, find "the
+engineer", send one of them a message and wait for the reply. The exchange
+shows up in both threads. See [Team](../api.md#team).
 
 **A teammate is not locked to your app.** The same agent answers over
 [ACP](../integrations/acp.md) in an editor, over
 [AG-UI](../integrations/openbot.md) from another agent platform, over
-[Nostr](../integrations/buzz.md), and — where the instance enables it — from
-its own email address and phone number. Each surface binds its own durable
-thread through the same mechanism your app uses, so your UI is one door onto
+[Nostr](../integrations/buzz.md), and, where the instance enables it, from its
+own email address and phone number. Each of those surfaces binds its own
+durable thread through the mechanism your app uses. Your UI is one door onto
 something that exists whether or not the tab is open.
 
 ## Next
 
-- [**A team chat, end to end**](team-chat.md) — the whole app in SDK calls:
-  hire, message, stream, render, connect, schedule, ship.
-- [**What each piece does**](pieces.md) — which primitive is doing what, and
-  what happens between Enter and the first word of the reply.
+- [**A team chat, end to end**](team-chat.md) walks the whole app through in
+  SDK calls: hire, message, stream, render, connect, schedule, ship.
+- [**What each piece does**](pieces.md) covers which primitive is responsible
+  for what, and what happens between Enter and the first word of the reply.

--- a/docs/build/pieces.md
+++ b/docs/build/pieces.md
@@ -1,8 +1,7 @@
 # What each piece does
 
 A chat app has three nouns: a contact, a thread, a message. Fountain has
-[four primitives](../primitives.md). They line up, and knowing which is which
-is most of what you need to reason about the app you are building.
+[four primitives](../primitives.md), and they line up.
 
 | In your UI | In Fountain | What it decides |
 |---|---|---|
@@ -13,8 +12,8 @@ is most of what you need to reason about the app you are building.
 | a message | a **turn** | one prompt and everything the agent did about it |
 
 There is no fifth primitive for the team. A teammate *is* a conversation with
-a channel binding, which is why anything you can do to a conversation you can
-do to a teammate.
+a channel binding, so anything you can do to a conversation you can do to a
+teammate.
 
 ```
    Agent  "watchtower"                 the definition. Cheap. Reusable.
@@ -30,12 +29,11 @@ do to a teammate.
                  the runtime's session on disk
 ```
 
-## The channel binding is the whole trick
+## One agent, one durable thread
 
-`channel_id` is what makes one agent equal one durable thread. Sending to a
-channel that already has a live conversation continues it; there is no
-"create or find" dance in your app, and no table of your own mapping rows to
-conversation ids.
+`channel_id` is what arranges that. Sending to a channel that already has a
+live conversation continues it, so your app needs no "create or find" dance
+and no table of its own mapping rows to conversation ids.
 
 The team is a reserved channel, `fountain:team`. Any other string is yours:
 
@@ -44,9 +42,10 @@ The team is a reserved channel, `fountain:team`. Any other string is yours:
 await fountain.run(text, { agent: "watchtower", channelId: `slack:${channel}` });
 ```
 
-Same behaviour, same sandbox-per-thread, without the team API at all. This is
-how [AG-UI](../integrations/openbot.md) binds one coworker channel to one
-conversation, and how [Buzz](../integrations/buzz.md) binds a Nostr thread.
+Same behaviour, same sandbox per thread, without the team API at all.
+[AG-UI](../integrations/openbot.md) binds one coworker channel to one
+conversation this way, and [Buzz](../integrations/buzz.md) binds a Nostr
+thread.
 
 ## What happens between Enter and the first word
 
@@ -71,30 +70,28 @@ conversation, and how [Buzz](../integrations/buzz.md) binds a Nostr thread.
        stage: turn/done               8 bytes or longer
 ```
 
-Three things in that picture are worth carrying around:
-
-**The response is 202, not the answer.** `POST /messages` queues a turn and
-returns the conversation id. Everything after that arrives on the stream. An
-app that awaits a reply is really awaiting stream events — which is what the
-SDK's `Run` handle does for you.
+**The 202 is not the answer.** `POST /messages` queues a turn and returns the
+conversation id. Everything after that arrives on the stream, so an app
+awaiting a reply is really awaiting stream events. The SDK's `Run` handle does
+that waiting for you.
 
 **Secrets enter at spawn, not at prompt.** The environment's values and the
 vault's are merged (the vault wins on a key collision) and handed to the
-sandbox as environment variables. They are not in the prompt, so they are not
-in the model's context, so they cannot be argued out of the model by a clever
-message.
+sandbox as environment variables. Since they never reach the prompt, they
+never reach the model's context, and no clever message can talk the model into
+revealing them.
 
 **Redaction is on the write path.** Every value of 8 bytes or more that
-Fountain put into that sandbox is scrubbed out of persisted output. Not
-best-effort in the client, not a rule the agent is asked to follow — the
-single path every log event takes. `env`, `set -x` and `cat .env` all persist
-as `[REDACTED]`. It is why a browser app can offer a "connect GitHub" button
-without you having to think very hard about the transcript.
+Fountain put into that sandbox is scrubbed out of persisted output. The
+scrubbing happens on the single path every log event takes, rather than in the
+client or as a rule the agent is asked to follow, so `env`, `set -x` and
+`cat .env` all persist as `[REDACTED]`. A browser app can therefore offer a
+"connect GitHub" button without much thought about the transcript.
 
 ## The computer's day
 
-The sandbox is the piece that has no equivalent in a stateless agent API, and
-its lifecycle is the thing to design your empty states around.
+The sandbox has no equivalent in a stateless agent API, and its lifecycle is
+what your empty states should be designed around.
 
 ```
   sandbox:  pending ──▶ starting ──▶ ready ──────────────▶ suspended
@@ -112,17 +109,15 @@ its lifecycle is the thing to design your empty states around.
 
 `ready` becomes `suspended` after 60 minutes with no turn (default).
 
-Suspension is free and invisible: the disk survives, so the runtime's session
-survives, so message five does not need to re-explain messages one through
-four. That is the difference between a bot you chat with and a colleague you
-leave a note for.
+Suspension is free and invisible. The disk survives, which keeps the runtime's
+session alive, so message five never re-explains messages one through four.
 
-The ceiling is not. A sandbox destroyed at the max-lifetime bound loses the
-disk; the stored transcript is intact and the conversation is still resumable,
-but the agent's own memory of it is gone. Both bounds are configurable
-(`SANDBOX_IDLE_TIMEOUT_MINUTES`, `SANDBOX_MAX_LIFETIME_HOURS`), and
-`freshConversation()` is the deliberate version of the same thing: a new
-session, on the *same* disk.
+The ceiling costs you that. A sandbox destroyed at the max-lifetime bound
+loses its disk; the stored transcript is intact and the conversation still
+resumes, but the agent's own memory of it is gone. Both bounds are
+configurable (`SANDBOX_IDLE_TIMEOUT_MINUTES`, `SANDBOX_MAX_LIFETIME_HOURS`),
+and `freshConversation()` is the deliberate version of the same thing: a new
+session on the *same* disk.
 
 ## Who reads what
 
@@ -136,30 +131,31 @@ The two feeds a client uses are different on purpose.
 | you use it for | roster, typing dots, notifications, unread | rendering the thread |
 
 A team UI wants both: one long-lived connection for the roster, and a read of
-the open thread's feed. `blocks` is what keeps the second one from becoming a
-parser — the server folds each runtime's dialect into `text`, `thinking`,
-`tool_use`, `tool_result`, `init`, `result`, `error`, `raw`, and your renderer
-handles eight kinds instead of four vendor formats.
+the open thread's feed. `blocks` keeps the second one from becoming a parser.
+The server folds each runtime's dialect into `text`, `thinking`, `tool_use`,
+`tool_result`, `init`, `result`, `error` and `raw`, so your renderer handles
+eight kinds instead of four vendor formats.
 
 ## Where the multi-tenancy is
 
-Every route is scoped to the key that called it. Agents, conversations,
-secrets, search, audit — a key sees its own account and nothing else, and the
-scoping lives in the queries rather than in each controller. For your app that
-means the second person to sign in gets their own roster, their own computers
-and their own quota without you writing a line about it — and that a browser
-app holding one person's key cannot be talked into reaching anyone else's
-teammates.
+Every route is scoped to the key that called it. Across agents,
+conversations, secrets, search and audit, a key sees its own account and
+nothing else, and the scoping lives in the queries rather than in each
+controller. So the second person to sign in gets their own roster, their own
+computers and their own quota without you writing a line about it, and a
+browser app holding one person's key cannot be talked into reaching anyone
+else's teammates.
 
-What you do not get for free is *sharing*. A teammate belongs to an account.
-A shared team room across several people is your product's problem — the usual
-answer being one Fountain account for the team, with your app in front of it.
+*Sharing* is the part you do not get for free. A teammate belongs to an
+account, so a shared team room across several people remains your product's
+problem. The usual answer is one Fountain account for the team, with your app
+in front of it.
 
 ## Where to look next
 
-- [The four primitives](../primitives.md) — the same objects, described on
-  their own terms.
-- [Architecture](../architecture.md) — what runs, and what breaks when a
+- [The four primitives](../primitives.md) describes the same objects on their
+  own terms.
+- [Architecture](../architecture.md) covers what runs, and what breaks when a
   dependency is down.
-- [Operations](../operations.md) — what to do when a computer is stuck.
-- [A team chat, end to end](team-chat.md) — the code.
+- [Operations](../operations.md) is what to read when a computer is stuck.
+- [A team chat, end to end](team-chat.md) is the code.

--- a/docs/build/team-chat.md
+++ b/docs/build/team-chat.md
@@ -1,8 +1,8 @@
 # A team chat, end to end
 
 Everything below is the [TypeScript SDK](../sdk.md) against a live instance,
-in the order you would write it. It is the same sequence
-[fountain-team](https://github.com/jhgaylor/fountain-team) performs — that app
+in the order you would write it. It follows the same sequence
+[fountain-team](https://github.com/jhgaylor/fountain-team) performs. That app
 predates the SDK and calls `fetch` directly, so its hand-written API client is
 roughly what the SDK now wraps.
 
@@ -22,16 +22,17 @@ const fountain = new Fountain({
 const me = await fountain.me();               // the cheapest check that a key works
 ```
 
-In Node the arguments are optional — credentials resolve from the environment
-and `~/.fountain/credentials` exactly as the [CLI](../cli.md)'s do. In a
-browser you pass what the person gave you, and the server has to allow your
-origin (`API_CORS_ORIGINS`). See [shipping it](#10-shipping-it).
+In Node the arguments are optional, because credentials resolve from the
+environment and `~/.fountain/credentials` exactly as the [CLI](../cli.md)'s
+do. In a browser you pass what the person gave you, and the server has to
+allow your origin (`API_CORS_ORIGINS`). See [shipping it](#10-shipping-it).
 
 ## 2. Hire a teammate
 
 The **+** in these apps asks nothing. A name from a list, a sensible brain, a
-one-line brief, and the roster has a new row a second later. That is two calls:
-an [agent](../primitives.md#agent), and the agent put on the team.
+one-line brief, and the roster has a new row a second later. Two calls do it:
+one to define an [agent](../primitives.md#agent), one to put that agent on the
+team.
 
 ```ts
 const catalog = await fountain.catalog();          // this deployment's vocabulary
@@ -56,8 +57,8 @@ suggested `provider/model` ids and the avatar vocabulary come from the server,
 not from a list in your bundle.
 
 Adding is idempotent, so the **+** does not need to know whether this agent is
-already on the team. It is also the moment a machine appears: `team.add` opens
-the teammate's standing conversation, and that provisions its sandbox.
+already on the team. A machine appears at this point too: `team.add` opens the
+teammate's standing conversation, which provisions its sandbox.
 
 !!! note "The face"
 
@@ -97,13 +98,13 @@ for (const teammate of roster) {
 }
 ```
 
-One call fills a roster row completely — nothing here is assembled from three
-endpoints and a guess. `presence.state` is the enum behind the label:
-`working`, `starting`, `online`, `asleep`, `away`, `machine_offline`,
-`failed`, `offline`. `asleep` is a teammate whose computer has been
-[parked](../primitives.md#conversation) for want of anything to do; it wakes
-on the next message with its memory intact, and your UI does not have to do
-anything about it beyond saying so.
+One call fills a roster row completely, with nothing assembled from three
+endpoints and a guess. Behind the label, `presence.state` is an enum:
+`working`, `starting`, `online`, `asleep`, `away`, `machine_offline`, `failed`
+and `offline`. A teammate reads as `asleep` when its computer has been
+[parked](../primitives.md#conversation) for want of anything to do. It wakes
+on the next message with its memory intact, so your UI need do nothing about
+it beyond saying so.
 
 ## 4. Say something
 
@@ -128,7 +129,7 @@ transport failure or a rejected request throws, which is what §7 is about.
 ## 5. One connection for the whole app
 
 A chat app needs to know what everyone is doing, not just the thread that is
-open. That is one endpoint, not one socket per teammate:
+open. One endpoint covers that, rather than one socket per teammate:
 
 ```ts
 for await (const event of fountain.team.stream({ streams: ["stage"] })) {
@@ -151,20 +152,20 @@ for await (const event of fountain.team.stream({ streams: ["stage"] })) {
 
 Every payload is a conversation's log event plus `conversation_id` and
 `agent_id`, so it routes to a roster row without a lookup. The iterator
-reconnects from its own last event id, which means a Fountain deploy, a proxy
-timeout or a laptop lid does not lose events — and your reconnect logic is the
-`for await` you already wrote.
+reconnects from its own last event id, so a Fountain deploy, a proxy timeout
+or a laptop lid loses no events, and your reconnect logic is the `for await`
+you already wrote.
 
 The stages worth knowing are the ones a UI shows while nothing is being said
-yet — `provision`, `setup` and `reattach`, then `turn`, then `terminate` —
-each with a `state` of `started`, `done`, `failed` or `interrupted`.
+yet: `provision`, `setup` and `reattach`, then `turn`, then `terminate`. Each
+carries a `state` of `started`, `done`, `failed` or `interrupted`.
 
 !!! note "The team stream carries raw events"
 
-    `/api/team/stream` takes `streams` and nothing else — no `blocks` — so it
-    is a notification channel: *something happened, to whom*. Read the
-    transcript itself from the conversation's own feed, which does parse
-    blocks. That is the next section.
+    `/api/team/stream` takes `streams` and nothing else, with no `blocks`, so
+    treat it as a notification channel: *something happened, to whom*. Read
+    the transcript itself from the conversation's own feed, which does parse
+    blocks. The next section covers that.
 
 ## 6. Open a thread
 
@@ -204,9 +205,9 @@ function bubbles(turns: Turn[], events: LogEvent[]) {
 }
 ```
 
-And a reply is a handful of blocks, folded the way a chat bubble wants them —
-adjacent prose joined, a run of tool calls collapsed into one line you can
-expand:
+A reply is a handful of blocks, folded the way a chat bubble wants them.
+Adjacent prose joins up, and a run of tool calls collapses into one line you
+can expand:
 
 ```ts
 type Part = { kind: "text" | "thinking" | "tools"; body: string; tools: string[] };
@@ -227,13 +228,14 @@ function fold(blocks: Block[]): Part[] {
 }
 ```
 
-That is the entire transcript renderer, and the reason it fits on a screen is
-`blocks`. The log feed holds whatever dialect the runtime speaks — ACP
-`session/update` notifications for `claude`, `codex` and `opencode`, plain
-stdout for others — and `?blocks=true`, which `history()` sets for you, parses
-it server-side into `text`, `thinking`, `tool_use`, `tool_result`, `init`,
-`result`, `error` and `raw`. fountain-team shipped a 200-line port of
-Fountain's own ACP parser before this existed. Do not repeat that.
+Those two functions are the entire transcript renderer, and they fit on a
+screen because of `blocks`. The log feed holds whatever dialect the runtime
+speaks: ACP `session/update` notifications for `claude`, `codex` and
+`opencode`, plain stdout for the rest. Adding `?blocks=true`, which
+`history()` sets for you, parses that server-side into `text`, `thinking`,
+`tool_use`, `tool_result`, `init`, `result`, `error` and `raw`. fountain-team
+shipped a 200-line port of Fountain's own ACP parser before this existed. Do
+not repeat that.
 
 ## 7. The things a messaging app is judged on
 
@@ -252,8 +254,8 @@ try {
 ```
 
 Queue locally, flush on the `turn`/`done` event from §5, and several queued
-notes go as one turn. Branch on `error.code`, never on the status — see the
-[error table](../sdk.md#errors).
+notes go as one turn. Branch on `error.code` rather than on the status; the
+[error table](../sdk.md#errors) has the rest.
 
 **Stop.** Interrupt ends the turn and keeps the computer; terminate takes the
 computer down.
@@ -295,8 +297,8 @@ clones, installs and files are where it left them.
 
 ## 8. Give a teammate an app to use
 
-This is the part the clones call connectors, and it is where a hosted runtime
-stops being a convenience. A connector is an MCP server the teammate's runtime
+The clones call this part connectors, and it is where a hosted runtime stops
+being a mere convenience. A connector is an MCP server the teammate's runtime
 talks to, and it usually needs a real credential.
 
 The credential does not go in the agent config. It goes in the teammate's
@@ -320,18 +322,18 @@ await fountain.agents.update("watchtower", {
 });
 ```
 
-`${GITHUB_TOKEN}` is resolved by [substitution](../primitives.md#substitution)
-when the computer is set up. Three things follow, and they are the reason this
-is not just a nicer way to store a string:
+[Substitution](../primitives.md#substitution) resolves `${GITHUB_TOKEN}` when
+the computer is set up. Three things follow, and together they are why this is
+more than a nicer way to store a string:
 
-- The token is never in a prompt, a model's context, or the log feed your app
-  reads.
+- The token never appears in a prompt, a model's context, or the log feed your
+  app reads.
 - Fountain **redacts every environment value of 8 bytes or more out of the
   conversation's output**, on the single write path every log event takes. An
   agent asked to print its token persists `[REDACTED]`.
 - Secret values are write-only. `secrets.list()` returns keys. Your app can
-  give a teammate a credential and cannot read it back — which is exactly what
-  you want to be able to tell someone pasting a GitHub token into a web page.
+  give a teammate a credential and can never read it back, which is a useful
+  thing to be able to tell someone pasting a GitHub token into a web page.
 
 A connector applies when the computer is next set up, not to the machine
 already running.
@@ -369,7 +371,7 @@ Static hosting. The only server-side facts are on the Fountain instance:
 [Sign in with Fountain](../api.md#sign-in-with-fountain-oauth-20-for-browser-apps)
 is OAuth 2.0 authorization code + PKCE, and the token it returns *is* an API
 key: it lists and revokes under Account → API keys, and signing out revokes
-it. That is the whole authentication story for an app with no backend.
+it. For an app with no backend, that is the whole authentication story.
 
 ## The whole thing, runnable
 
@@ -385,15 +387,15 @@ FOUNTAIN_API_KEY=ftn_… node examples/chat.ts
 ```
 
 CI typechecks it against the SDK on every push, which is the only reason this
-page can promise the code on it compiles.
+page can promise that the code on it compiles.
 [`examples/team.ts`](https://github.com/BinaryBourbon/fountain/blob/main/sdk/typescript/examples/team.ts)
-is the smaller version — hire, say two things, watch the stream.
+is the smaller version: hire, say two things, watch the stream.
 
 ## Where this goes next
 
-- [**What each piece does**](pieces.md) — what happens between Enter and the
-  first word, and which primitive is responsible for what.
-- [**TypeScript SDK**](../sdk.md) — the full surface, including everything
+- [**What each piece does**](pieces.md) covers what happens between Enter and
+  the first word, and which primitive is responsible for what.
+- [**TypeScript SDK**](../sdk.md) has the full surface, including everything
   outside the team.
-- [**API reference**](../api.md#team) — the routes underneath, for a language
-  the SDK does not cover yet.
+- [**API reference**](../api.md#team) documents the routes underneath, for a
+  language the SDK does not cover yet.


### PR DESCRIPTION
Prose only. No page changed what it claims, and no code or nav moved (`mkdocs.yml` and `docs.ex` are untouched).

The section I shipped in #893 read as machine output. Measured before:

| | em-dashes in prose | "That is / It is / This is" openers |
|---|---|---|
| `build/index.md` | 11 | 2 |
| `build/team-chat.md` | 17 | 8 |
| `build/pieces.md` | 10 | 3 |

After: **0, 0, and 1** (the survivor being an ordinary "This is the quickest thing to build").

### What actually changed

**Em-dashes.** Nearly all of them were standing in for a period, a colon or a comma. `Better — the app can now run anywhere — but it has moved the hard part` became `The app can run anywhere now, but the hard part has moved rather than gone.`

**Restating sentences, cut rather than reworded.** A table would make a point and then a sentence would make it again:

> | a clock | "every weekday at nine" |
>
> None of that is chat. All of it is what separates a bot that answers from a bot that does the thing.

Also gone: "Either way, the part that gets skipped is the part that costs money and pages you at night", "Whatever they do, your clone can do", and "That is the difference between a bot you chat with and a colleague you leave a note for."

**The "so X, so Y" chains and negation triads.** `They are not in the prompt, so they are not in the model's context, so they cannot be argued out of the model by a clever message` → `Since they never reach the prompt, they never reach the model's context, and no clever message can talk the model into revealing them.`

**Listy framing.** "Three things in that picture are worth carrying around." was deleted; the three bolded paragraphs under it stand on their own.

### What I deliberately kept

Two closers that carry the argument instead of repeating it: "Only one of those columns has an on-call rotation" after the write/don't-write table, and "Your UI is one door onto something that exists whether or not the tab is open." The complaint was volume, not existence, and a doc with no voice at all is its own problem.

`mkdocs build --strict` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)