### PR TITLE
The image should not claim to be a commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,8 +168,20 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
+          # No BUILD_SHA here, deliberately. Baking the commit into the
+          # image made two builds of the *same tree* different artifacts,
+          # which is what stops a main-line image from being reusable: an
+          # image built from tree T is correct for every commit with tree T,
+          # and it should not claim to be one of them. k8s/deployment.yaml
+          # carries FOUNTAIN_BUILD_SHA instead and publish-manifests.yml pins
+          # it to the commit actually being deployed — a pod env wins over the
+          # image's ENV, so the footer and the Sentry release still name a real
+          # commit on main.
+          #
+          # release.yml still passes BUILD_SHA: a tagged release image is
+          # pulled by self-hosters who never see our deployment.yaml, so it has
+          # to describe itself.
           build-args: |
-            BUILD_SHA=${{ env.SRC_SHA }}
             BUZZ_ACP_VERSION=${{ env.BUZZ_ACP_VERSION }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/.github/workflows/publish-manifests.yml
+++ b/.github/workflows/publish-manifests.yml
@@ -153,10 +153,16 @@ jobs:
         run: |
           set -euo pipefail
           image=""
+          image_sha=""
           for candidate in $(git rev-list --first-parent -n 50 "${SRC_SHA}"); do
             if docker manifest inspect \
                  "ghcr.io/binarybourbon/fountain:sha-${candidate}" > /dev/null 2>&1; then
               image="ghcr.io/binarybourbon/fountain:sha-${candidate}"
+              # The commit the IMAGE was built from, which is not always
+              # SRC_SHA: on a manifest-only push this walk lands on an
+              # ancestor. FOUNTAIN_BUILD_SHA must name what is running, not
+              # the tree that triggered the publish.
+              image_sha="${candidate}"
               break
             fi
           done
@@ -171,11 +177,13 @@ jobs:
             echo "sha=${SRC_SHA}"
             echo "short=${SRC_SHA:0:7}"
             echo "image=${image}"
+            echo "image_sha=${image_sha}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Pin the image tag in the working tree
+      - name: Pin the image tag and build sha in the working tree
         env:
           IMAGE: ${{ steps.tag.outputs.image }}
+          IMAGE_SHA: ${{ steps.tag.outputs.image_sha }}
         run: |
           set -euo pipefail
           sed -i -E \
@@ -186,6 +194,31 @@ jobs:
           # matching the regex, the old tag would otherwise ship silently.
           grep -qF "${IMAGE}" k8s/deployment.yaml || {
             echo "image pin substitution failed: ${IMAGE} not found in k8s/deployment.yaml" >&2
+            exit 1
+          }
+
+          # FOUNTAIN_BUILD_SHA is not baked into the image any more (build.yml),
+          # so this pin is the only thing that tells a running pod which commit
+          # it is — it reaches the console footer and the Sentry release. Same
+          # verify-or-fail shape as the image tag above: shipping the
+          # placeholder would misattribute every error to a commit that does
+          # not exist. `n` moves to the line after the name, so this cannot
+          # rewrite some other env's value.
+          # awk rather than sed: rewriting the line *after* a match needs
+          # GNU sed's `{n;s}`, which BSD sed rejects, so it could not be tried
+          # outside CI. This runs the same everywhere and counts what it did —
+          # exactly one substitution, or the publish fails.
+          awk -v sha="${IMAGE_SHA}" '
+            /- name: FOUNTAIN_BUILD_SHA/ {
+              print; if (getline <= 0) { exit 1 }
+              n += sub(/value: "[0-9a-f]+"/, "value: \"" sha "\"")
+            }
+            { print }
+            END { if (n != 1) { print "expected 1 pin, made " n+0 > "/dev/stderr"; exit 1 } }
+          ' k8s/deployment.yaml > k8s/deployment.yaml.pinned
+          mv k8s/deployment.yaml.pinned k8s/deployment.yaml
+          grep -qF "value: \"${IMAGE_SHA}\"" k8s/deployment.yaml || {
+            echo "FOUNTAIN_BUILD_SHA pin failed: ${IMAGE_SHA} not found in k8s/deployment.yaml" >&2
             exit 1
           }
           git diff --stat k8s/deployment.yaml

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -202,10 +202,12 @@ defmodule FountainWeb.Layouts do
   end
 
   # Deployment marker shown under the sidebar email popup. Combines the
-  # umbrella app version with the short git SHA the Docker image was
-  # built from. `FOUNTAIN_BUILD_SHA` is set in the runtime image via a
-  # docker build-arg wired up in .github/workflows/build.yml; local dev
-  # falls back to "dev".
+  # umbrella app version with the short git SHA this deployment is running.
+  # `FOUNTAIN_BUILD_SHA` comes from one of two places: a tagged release image
+  # bakes it in as a docker build-arg (release.yml), while a main-line image
+  # deliberately does not — that image is reusable across commits with the
+  # same tree, so k8s/deployment.yaml carries the value and
+  # publish-manifests.yml pins it per deploy. Local dev falls back to "dev".
   defp build_version do
     vsn = :fountain |> Application.spec(:vsn) |> to_string()
     sha = "FOUNTAIN_BUILD_SHA" |> System.get_env("dev") |> String.slice(0, 7)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ Only needed for more than one replica — see
 | `METRICS_PORT` | `9568` in prod, off elsewhere | — | The private Prometheus listener (`/metrics`, `/health`). `""` or `0` disables it. Keep it off the public internet |
 | `SENTRY_DSN` | — | — | Error tracking. Unset, the SDK is inert and nothing leaves the instance. Accepts sentry.io or any Sentry-API-compatible endpoint (GlitchTip) |
 | `SENTRY_ENVIRONMENT` | the build env | — | Environment tag on reported errors |
-| `FOUNTAIN_BUILD_SHA` | set by the image build | — | Correlates errors and traces with deploys; also shown in the app footer |
+| `FOUNTAIN_BUILD_SHA` | set by the image build (release images) or by the deployment (main-line images) | — | Correlates errors and traces with deploys; also shown in the app footer |
 | `OTEL_SERVICE_NAME` | `fountain` | — | Service name on exported traces |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `HONEYCOMB_ENDPOINT` | — | OTLP (HTTP/protobuf) trace export target |
 | `OTEL_EXPORTER_OTLP_HEADERS` | — | — | `key=val,key=val` headers on trace export |

--- a/docs/integrations/sentry.md
+++ b/docs/integrations/sentry.md
@@ -16,7 +16,7 @@ stack — and take its DSN.
 |---|---|---|
 | `SENTRY_DSN` | — | Turns reporting on. Crashes — including ones that never touch a web request — are reported with stack traces, grouped, rate-limited to 20 events/minute |
 | `SENTRY_ENVIRONMENT` | the build env | Environment tag on events |
-| `FOUNTAIN_BUILD_SHA` | set by the image build | Correlates events with releases: "this started with `sha-…`" |
+| `FOUNTAIN_BUILD_SHA` | set by the image build (release images) or by the deployment (main-line images) | Correlates events with releases: "this started with `sha-…`" |
 
 Reporting is deliberately conservative: `send_default_pii` is off, so
 cookies, user IPs and request bodies are not attached — this app holds tenant

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -45,6 +45,20 @@ spec:
             - name: erldist
               containerPort: 9100
           env:
+            # Which commit this pod is running. Not baked into the image:
+            # build.yml stopped passing BUILD_SHA so that an image built from
+            # a tree is reusable for any commit with that tree, and this env
+            # (which wins over the image's ENV) names the commit actually
+            # deployed. publish-manifests.yml rewrites the value in the
+            # artifact next to the image tag, and fails if it cannot — the
+            # literal below is whatever was last committed here and is not
+            # what runs, exactly like the image line above.
+            #
+            # It reaches the footer (FountainWeb.Layouts) and, more
+            # importantly, the Sentry release (config/runtime.exs) — so a
+            # wrong value here misattributes every error to the wrong commit.
+            - name: FOUNTAIN_BUILD_SHA
+              value: "0000000000000000000000000000000000000000"
             # --- Erlang clustering (required for >1 replica) ---
             # Pod IP via the downward API; RELEASE_NODE interpolates it
             # below. Must be declared before any env that references


### PR DESCRIPTION
Second of three changes aimed at commit → prod latency. This one buys nothing on its own — it is the prerequisite that makes the third safe.

## The problem

`Dockerfile:136` takes `ARG BUILD_SHA` → `ENV FOUNTAIN_BUILD_SHA`, and `build.yml` passes the commit sha. That makes two builds of the **same tree** different artifacts, which is exactly what stops a main-line image from being reusable. An image built from tree `T` is correct for *every* commit whose tree is `T`; it should not assert that it is one particular one.

This matters because `FOUNTAIN_BUILD_SHA` is not decoration:

- the console footer — `FountainWeb.Layouts.build_version/0`
- **the Sentry release** — `config/runtime.exs:330`

Reusing a PR-built image without fixing this would tag every production error with a commit that isn't on `main`.

## The change

| where | before | after |
|---|---|---|
| `build.yml` | passes `BUILD_SHA` | doesn't; labels still record the building commit |
| `k8s/deployment.yaml` | — | carries `FOUNTAIN_BUILD_SHA` (pod env wins over image `ENV`) |
| `publish-manifests.yml` | pins the image tag | pins the sha too, same verify-or-fail |
| `release.yml` | passes `BUILD_SHA` | **unchanged** |

Releases stay self-describing: a tagged image is pulled by self-hosters who never see our `deployment.yaml`. `deploy/k8s/` therefore needs no change — it already pins `v0.12.0`.

## Two details that were easy to get wrong

**It pins `image_sha`, not `SRC_SHA`.** The image pin is the newest first-parent ancestor whose image actually exists in the registry, which on a manifest-only push is an *ancestor*. Pinning `SRC_SHA` would have produced a pod reporting a commit whose code it is not running — a worse lie than the one being fixed.

**`awk`, not `sed`.** Rewriting the line *after* a match needs GNU sed's `{n;s}`, which BSD sed rejects — so it could not be exercised outside CI. The awk counts its substitutions and fails the publish on anything but exactly one.

Verified locally against the real manifest:

```
happy path      → exactly one line changed, YAML still valid
env var missing → "expected 1 pin, made 0", exit 1
kubectl kustomize k8s        → OK
kubectl kustomize deploy/k8s → OK
```

## Risk

This is the deploy path. The failure mode if the pin silently no-ops is a pod reporting `0000000…` in the footer and as its Sentry release — loud rather than subtle, and the verify step turns it into a failed publish instead. Worth watching the first deploy after merge regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)