### PR TITLE
The coverage gate rendered 129MB of HTML nobody read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,28 +425,6 @@ jobs:
       # itself compiles nothing, but Mix runs loadpaths underneath it and will
       # build the whole dependency tree into an empty _build first. Measured on
       # a 10-core machine: 3.7s warm, 38.5s cold.
-      - name: Restore deps cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
-        with:
-          path: deps
-          key: ${{ runner.os }}-mix-test-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-test-
-
-      - name: Restore build cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
-        with:
-          path: _build
-          key: ${{ runner.os }}-build-test-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-test-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      # Back into the directory the partitions wrote them from, which is where
-      # `mix test.coverage` looks: it merges every *.coverdata under the
-      # umbrella's children.
       - name: Download coverage exports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -473,8 +451,23 @@ jobs:
           total=$(cat apps/fountain/cover/*.tests | awk '{s += $1} END {print s + 0}')
           echo "merging ${#exports[@]} partitions covering $total tests"
 
+      # Not `mix test.coverage`: ~90% of that task's time is rendering an
+      # HTML report — 530 files, 129MB — that this job never opens, since all
+      # it does is assert a threshold and exit. The script computes the same
+      # number from the same coverage.exs (verified identical, 85.46% both, on
+      # the same six exports), and prints the least-covered modules so a
+      # failure still says where to look.
+      #
+      # `elixir`, not `mix run`: the script reads .coverdata and coverage.exs
+      # and touches nothing else, so it needs no deps, no _build and no
+      # compile. Through `mix run` this step spent most of its time
+      # recompiling the app for a script that never calls it ("Compiling 10
+      # files" for a 12s step). That is also why this job no longer restores
+      # the deps/build caches or runs deps.get.
+      #
+      # Run `mix test.coverage` locally for the full table and the HTML.
       - name: Enforce the coverage threshold
-        run: mix test.coverage
+        run: elixir scripts/coverage-gate.exs
 
   checks:
     name: Static analysis and release checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ wrap `record/1` in a way that makes it blocking for the user.
 7. `MIX_ENV=dev mix dialyzer`
 8. Go CLI checks: `go test ./...` and `go vet ./...` in `cli/`
 9. `mix ecto.create && mix ecto.migrate`
-10. The test suite, as six partitions in six parallel jobs (`scripts/test-partition.sh`), plus a `coverage` job that merges their exports with `mix test.coverage` and enforces the 85% threshold
+10. The test suite, as six partitions in six parallel jobs (`scripts/test-partition.sh`), plus a `coverage` job that merges their exports with `scripts/coverage-gate.exs` and enforces the 85% threshold
 11. Release boot check — builds a prod release, probes `/health` and `/health/ready`, runs a release task beside the live server
 12. `mix openapi.spec.json` + `jq empty` (OpenAPI spec validates)
 
@@ -264,6 +264,14 @@ which replaced `coveralls.json`'s `minimum_coverage` and `skip_files`.
 `:ignore_modules` matches **module names**, not source paths — a bare atom for
 one module, a regex against `inspect(module)` for what used to be a
 directory entry. Locally, `mix test --cover` reports and gates in one step.
+
+CI enforces the threshold with `scripts/coverage-gate.exs`, not
+`mix test.coverage`: ~90% of that task's time is rendering an HTML report the
+job never opens. The script reads the same `coverage.exs` and was verified to
+produce the identical total (85.46% on the same six exports). Run
+`mix test.coverage` locally when you want the per-module table or the HTML —
+and re-verify the two agree when bumping Elixir, since the script depends on
+`:cover` semantics the pin currently freezes.
 
 Run `mix precommit` locally before pushing — it covers the core gate (compile with warnings-as-errors, unused deps, format, `credo --strict`, sobelow, dialyzer, tests). CI additionally runs hex.audit, the Go CLI checks, the release boot check, and OpenAPI validation.
 

--- a/scripts/coverage-gate.exs
+++ b/scripts/coverage-gate.exs
@@ -1,0 +1,112 @@
+# Enforces the coverage threshold across the partitions' exports.
+#
+# This is `mix test.coverage` minus the part CI cannot use. That task spends
+# roughly 90% of its time rendering an HTML report — 530 files and 129MB on
+# this repo, ~17s of the coverage job — and nothing reads it: the job asserts a
+# threshold and exits. Measured on the same six exports:
+#
+#     mix test.coverage    85.46%   7.4s wall / 18.7s user   (+129MB of HTML)
+#     this script          85.46%   3.6s
+#
+# The number is identical, and that is the whole basis for using this instead.
+# Two details of `:cover` have to be handled to make it so, and getting either
+# wrong moves the total by percentage points rather than failing loudly:
+#
+#   * `:cover.analyse(mod, :coverage, :line)` returns one entry per *clause*,
+#     so a line with several clauses appears several times. A line counts once,
+#     and counts as covered if ANY clause on it ran. Summing the entries
+#     instead reported 81.32% against the real 85.46% — under the threshold,
+#     failing a build that should pass.
+#   * Line 0 is module-level bookkeeping, not executable, and is dropped.
+#
+# It reads coverage.exs, so `:ignore_modules` and the threshold stay in the one
+# place `mix test.coverage` and `mix test --cover` already read them from.
+#
+# Run it as `elixir scripts/coverage-gate.exs`, not through `mix run`. It reads
+# .coverdata and coverage.exs and touches nothing else — no deps, no _build, no
+# app modules — so mix has nothing to contribute and a great deal to do first:
+# through `mix run` the step recompiled the app ("Compiling 10 files") for a
+# script that never calls it, which was most of its 12s in CI.
+#
+# Elixir is pinned (.tool-versions), so these semantics cannot drift without a
+# deliberate bump. WHEN BUMPING ELIXIR, re-run `mix test.coverage` on the same
+# exports and check the totals still agree.
+
+opts = "coverage.exs" |> Code.eval_file() |> elem(0)
+ignore = Keyword.get(opts, :ignore_modules, [])
+threshold = opts |> Keyword.get(:summary, []) |> Keyword.get(:threshold, 90)
+
+exports = Path.wildcard("apps/fountain/cover/*.coverdata")
+
+if exports == [] do
+  IO.puts(:stderr, "no .coverdata under apps/fountain/cover — nothing was merged")
+  System.halt(1)
+end
+
+ignored? = fn mod ->
+  name = inspect(mod)
+
+  Enum.any?(ignore, fn
+    %Regex{} = re -> Regex.match?(re, name)
+    atom when is_atom(atom) -> atom == mod
+    _ -> false
+  end)
+end
+
+{:ok, _} = :cover.start()
+for f <- exports, do: :ok = :cover.import(String.to_charlist(f))
+
+per_module =
+  :cover.imported_modules()
+  |> Enum.reject(ignored?)
+  |> Enum.map(fn mod ->
+    {covered, total} =
+      case :cover.analyse(mod, :coverage, :line) do
+        {:ok, lines} ->
+          lines
+          |> Enum.reject(fn {{_mod, line}, _} -> line == 0 end)
+          |> Enum.reduce(%{}, fn {{_mod, line}, {c, _n}}, seen ->
+            Map.update(seen, line, c > 0, &(&1 or c > 0))
+          end)
+          |> Enum.reduce({0, 0}, fn {_line, covered?}, {c, t} ->
+            {c + if(covered?, do: 1, else: 0), t + 1}
+          end)
+
+        _ ->
+          {0, 0}
+      end
+
+    {mod, covered, total}
+  end)
+
+{covered, total} =
+  Enum.reduce(per_module, {0, 0}, fn {_m, c, t}, {a, b} -> {a + c, b + t} end)
+
+pct = if total > 0, do: covered * 100 / total, else: 100.0
+
+# The table is gone with the HTML, so name the modules a failure would point at.
+worst =
+  per_module
+  |> Enum.filter(fn {_m, _c, t} -> t > 0 end)
+  |> Enum.sort_by(fn {_m, c, t} -> c / t end)
+  |> Enum.take(15)
+
+IO.puts(
+  "coverage: #{Float.round(pct, 2)}% (#{covered}/#{total} lines, #{length(per_module)} modules, threshold #{threshold}%)"
+)
+
+IO.puts("merged #{length(exports)} export(s): #{Enum.map_join(exports, ", ", &Path.basename/1)}")
+IO.puts("\nleast covered:")
+
+for {mod, c, t} <- worst do
+  IO.puts(
+    "  #{String.pad_leading(Float.to_string(Float.round(c * 100 / t, 1)), 6)}%  #{inspect(mod)} (#{c}/#{t})"
+  )
+end
+
+if pct < threshold do
+  IO.puts(:stderr, "\ncoverage #{Float.round(pct, 2)}% is below the #{threshold}% threshold")
+  System.halt(1)
+end
+
+IO.puts("\ncoverage gate passed")


### PR DESCRIPTION
The `coverage` job is a **barrier** — every partition must finish before it starts, and nothing runs alongside it — so its 39s is 39s of CI wall-clock. About 17s of that is `mix test.coverage`, and ~90% of *that* is rendering an HTML report: **530 files, 129MB**, into a directory that dies with the runner. The job's only output is a threshold verdict.

## The swap

`scripts/coverage-gate.exs` computes the same number from the same `coverage.exs`, without the report:

| | total | time |
|---|---|---|
| `mix test.coverage` | **85.46%** | 7.4s wall / 18.7s user, +129MB HTML |
| `scripts/coverage-gate.exs` | **85.46%** | 3.6s |

## Why the equality needs stating carefully

That the two agree is the entire argument for this change, so it is worth recording how easily they don't. `:cover.analyse(mod, :coverage, :line)` returns **one entry per clause**, so a line with several clauses appears several times. Summing the entries gives **81.32%** against the real 85.46% — not a rounding difference, but *below the 85% threshold*: a gate that fails builds it should pass.

The rules that make it match:
- a line counts **once**, and counts as covered if **any** clause on it ran
- **line 0** is module-level bookkeeping, not executable, and is dropped

## Both failure paths are exercised

A gate that cannot fail is worse than no gate:

```
threshold raised to 99%  → exit 1, "coverage 85.46% is below the 99% threshold"
no .coverdata present    → exit 1, "nothing was merged"   (not "100% of nothing")
```

## What is lost, and what replaces it

The per-module table goes with the HTML, so the script prints the **fifteen least-covered modules** — a failure still says where to look:

```
coverage: 85.46% (8913/10430 lines, 530 modules, threshold 85%)
least covered:
     0.0%  Mix.Tasks.Fountain.VerifyLifecycle (0/203)
     7.1%  Fountain.Sandbox.E2B.Errors (1/14)
    15.4%  Fountain.Sandbox.Daytona.Errors (2/13)
    ...
```

`mix test.coverage` still works locally for the full table and the HTML.

## Drift

The script leans on `:cover` semantics rather than Elixir's private summary code. Elixir is pinned in `.tool-versions` (1.19.2-otp-28), so those cannot change without a deliberate bump — the script's header and CLAUDE.md both say to re-verify the totals agree when bumping.

Expected: coverage job **39s → ~25s**, all of it off the serial tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)