### PR TITLE
docs: a concepts tree, and a front door that starts with the tutorial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
 
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
+      docs_touched: ${{ steps.filter.outputs.docs_touched }}
       cli_docs: ${{ steps.filter.outputs.cli_docs }}
 
     steps:
@@ -168,25 +169,26 @@ jobs:
           decide() {
             echo "docs_only=$1" >> "$GITHUB_OUTPUT"
             echo "cli_docs=$2" >> "$GITHUB_OUTPUT"
+            echo "docs_touched=$3" >> "$GITHUB_OUTPUT"
             exit 0
           }
 
           if ! git fetch --no-tags --quiet origin \
                "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}" 2>/dev/null; then
             echo "could not fetch base ${GITHUB_BASE_REF} — running the full CI"
-            decide false false
+            decide false false true
           fi
 
           base="$(git merge-base "refs/remotes/origin/${GITHUB_BASE_REF}" HEAD 2>/dev/null || true)"
           if [ -z "${base}" ]; then
             echo "no merge base with ${GITHUB_BASE_REF} — running the full CI"
-            decide false false
+            decide false false true
           fi
 
           changed="$(git diff --name-only "${base}" HEAD 2>/dev/null || true)"
           if [ -z "${changed}" ]; then
             echo "empty diff against ${base:0:7} — running the full CI"
-            decide false false
+            decide false false true
           fi
 
           echo "changed against ${base:0:7}:"
@@ -197,15 +199,24 @@ jobs:
             cli_docs=true
           fi
 
+          # Whether ANY docs path moved, independent of whether the diff is
+          # docs-ONLY. A mixed PR takes the `checks` path, which had no strict
+          # build, so `mkdocs build --strict` ran on neither branch of the gate
+          # and a broken link surfaced on main after the merge.
+          docs_touched=false
+          if printf '%s\n' "${changed}" | grep -qE '^docs/|^mkdocs\.yml$'; then
+            docs_touched=true
+          fi
+
           # grep -qv succeeds when ANY line falls outside the allowlist, so
           # the negation is "every changed path is a docs path".
           if printf '%s\n' "${changed}" | grep -qvE '^docs/|^mkdocs\.yml$'; then
             echo "non-docs paths changed — running the full CI"
-            decide false "${cli_docs}"
+            decide false "${cli_docs}" "${docs_touched}"
           fi
 
           echo "docs-only — running the docs job instead of the Elixir suite"
-          decide true "${cli_docs}"
+          decide true "${cli_docs}" false
 
   test:
     name: Build and Test (partition ${{ matrix.partition }})
@@ -719,6 +730,25 @@ jobs:
         working-directory: sdk/typescript
         run: npx --yes esbuild dist/index.js --bundle --platform=browser --format=esm --outfile=/dev/null
 
+      # The complement of the `docs` job. That job carries the strict build for
+      # a docs-ONLY diff; this carries it for a diff that touches docs AND
+      # code, which took neither branch before and so went unchecked until
+      # docs.yml ran on main. The two jobs are mutually exclusive by the same
+      # docs_only gate, so neither the cache argument nor the "one set or the
+      # other, never both" claim in the `docs` job comment changes.
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: ${{ needs.changes.outputs.docs_touched == 'true' }}
+        with:
+          python-version: '3.12'
+
+      - name: Install MkDocs
+        if: ${{ needs.changes.outputs.docs_touched == 'true' }}
+        run: pip install -r docs/requirements.txt
+
+      - name: Build the site strictly
+        if: ${{ needs.changes.outputs.docs_touched == 'true' }}
+        run: mkdocs build --strict
+
   compose-fresh-clone:
     name: Compose fresh-clone check
     runs-on: ubuntu-24.04
@@ -892,7 +922,7 @@ jobs:
       - name: Set up database
         run: mix ecto.create --quiet && mix ecto.migrate --quiet
 
-      # docs_test.exs: the mkdocs.yml <-> @nav mirror, the snippet-to-Dockerfile
+      # docs_test.exs: the mkdocs.yml nav parser, the snippet-to-Dockerfile
       # COPY coverage, the MkDocs-dialect preprocessing and every internal
       # /docs link. docs_controller_test.exs: that the pages actually serve.
       - name: Docs tests

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -129,8 +129,22 @@ defmodule Fountain.DocsTest do
 
     test "keeps mkdocs.yml's order" do
       titles = Enum.map(Docs.nav_source(), &elem(&1, 0))
-      assert Enum.take(titles, 3) == ["Home", "Setup", "Self-hosting"]
+      assert Enum.take(titles, 3) == ["Home", "Guided tour — opening a PR", "Concepts"]
       assert List.last(titles) == "Changelog"
+    end
+
+    # The tutorial sits second and the concepts tree third, ahead of every
+    # reference page. It was position 15 of 34 and unlinked from the home page,
+    # so a newcomer met three reference pages before the lesson.
+    test "the tutorial and the concepts tree come before reference" do
+      titles = Enum.map(Docs.nav_source(), &elem(&1, 0))
+
+      tour = Enum.find_index(titles, &(&1 == "Guided tour — opening a PR"))
+      concepts = Enum.find_index(titles, &(&1 == "Concepts"))
+      reference = Enum.find_index(titles, &(&1 == "Reference"))
+
+      assert tour < concepts
+      assert concepts < reference
     end
 
     test "a page and a section are told apart by indentation" do

--- a/docs-redesign/00-diataxis-working-note.md
+++ b/docs-redesign/00-diataxis-working-note.md
@@ -1,0 +1,129 @@
+# Working note: the mode test I will apply to Fountain pages
+
+Read in full at diataxis.fr. Pages used here are `/start-here/`, `/tutorials/`,
+`/how-to-guides/`, `/reference/`, `/explanation/`, `/tutorials-how-to/`,
+`/reference-explanation/`, `/compass/`, `/map/`, `/how-to-use-diataxis/`,
+`/quality/`, `/application/`, `/foundations/`.
+
+## What the framework actually claims
+
+Diátaxis is not a list of four content types. It is a two-axis map of a craft,
+and the four modes fall out of the axes rather than being chosen
+(`/foundations/`). The axes are action versus cognition, and acquisition versus
+application. Two binary axes give four quadrants, which is why the framework
+insists there are four and not three or five.
+
+The tool for deciding is the compass, not the map (`/compass/`). The map is
+reference, so it cannot tell you what to do. The compass is a two-question
+decision table.
+
+| If the content | and serves the user's | then it must belong to |
+|---|---|---|
+| informs action | acquisition of skill | a tutorial |
+| informs action | application of skill | a how-to guide |
+| informs cognition | application of skill | reference |
+| informs cognition | acquisition of skill | explanation |
+
+## The test I will use on a Fountain page
+
+The compass asks two questions. Both are hard to answer honestly on a page you
+wrote yourself, because a writer always believes the page informs action and
+always believes the reader is working. So I am going to answer them through
+four proxy questions that have observable answers.
+
+**1. Who chose the goal.** Read the page's first paragraph. If the page told
+the reader what they are about to accomplish, the page chose the goal, and the
+reader is at study. If the reader arrived already knowing what they wanted and
+the page's job is to hand it to them, the reader is at work. This is the
+acquisition/application axis, and for Fountain it is the load-bearing one,
+because tutorial/how-to conflation is the single most common failure in
+software docs (`/tutorials-how-to/`).
+
+**2. What the reader's hands are doing.** If the page only makes sense with the
+reader's hands on a keyboard mid-task, it informs action. If the reader could
+usefully read it on a train with no terminal open, it informs cognition. The
+source's own version of this is that explanation is the only mode it might make
+sense to read in the bath (`/explanation/`).
+
+**3. Whether the page is allowed to fork.** A tutorial follows a single line
+and offers no alternatives, because choices are cognitive load that break the
+learning experience (`/tutorials/`, "Ignore options and alternatives"). A
+how-to forks constantly, because the real world forks (`/tutorials-how-to/`).
+Reference is a flat description of the machinery and does not sequence at all.
+Explanation must consider alternatives, because weighing them is its job
+(`/explanation/`, "Admit opinion and perspective"). So counting the branches in
+a page is a fast way to catch a mislabelled one.
+
+**4. What breaks if the page is wrong.** If a wrong page makes a competent
+reader ship something broken, it was serving work, so it is reference or
+how-to, and it owes accuracy. If a wrong page makes a newcomer conclude they
+cannot use the product, it was serving study, so it is a tutorial or
+explanation, and it owes confidence. Diátaxis's clothing analogy in `/quality/`
+separates these as functional quality against deep quality.
+
+Applied in order, questions 1 and 2 give the quadrant. Questions 3 and 4 are
+the audit, used to catch a page whose declared mode and actual behaviour
+disagree.
+
+### The Fountain-specific tie-breaker
+
+Fountain has four pages that all look like ordered steps with shell commands.
+`setup.md`, `tour.md`, `self-hosting.md`'s quick start and
+`build/team-chat.md`. Question 1 separates them cleanly.
+
+- `tour.md` and `build/team-chat.md` announce the destination in their own
+  first paragraph. The reader did not arrive wanting to open a pull request
+  from an agent, the page proposed it. Tutorials.
+- `setup.md` is read by someone who already decided to contribute to Fountain
+  and needs a working checkout. How-to.
+- `self-hosting.md`'s quick start is read by someone who already decided to
+  self-host. How-to.
+
+## The specific failure when two modes share a page
+
+The general answer is blur (`/map/`, "Blur"), and the general consequence is
+that writing style and content migrate into inappropriate places. That is true
+but not actionable. Three specific failures matter for Fountain, in order of
+how much damage they are doing today.
+
+**The page loses its stopping condition, and then nobody can tell whether it is
+finished.** Each mode is bounded by something different. A tutorial is bounded
+by what the learner must encounter. A how-to is bounded by the user's goal. A
+reference page is bounded by the machinery itself, which is the only bound that
+is externally checkable. Explanation is the one mode with no natural bound, and
+`/explanation/` says so directly, recommending you invent a why-question to
+serve as a prompt. Put two of these on one page and the page inherits the
+weakest bound. `docs/primitives.md` is the live example. Its Conversation
+section describes a status enum, which is bounded by the code, and also
+discusses suspension policy, which is bounded by nothing, and the section has
+grown to whatever the last writer felt like adding. A contributor adding a
+fifth status cannot tell whether they owe one edit or three.
+
+**Reference stops being consultable and explanation never gets to develop.**
+`/reference-explanation/` states the damage as symmetric. Interleaving hurts
+the reference, which is "interrupted and obscured by digressions", and hurts
+the explanation, which "is not allowed to develop appropriately and do its own
+work". On `docs/primitives.md` the `model` field's reference entry carries nine
+lines of prose arguing why a provider outside the allowed set is rejected at
+write time. That argument is good, and it is longer than the entire
+Substitution section, and it is unfindable by anyone who wants it, because it
+is filed under a field name.
+
+**Edits stop being local, so maintenance cost rises superlinearly.**
+`/tutorials/` observes that tutorial revisions cascade through the whole story
+because the end-to-end journey must keep making sense, where changes elsewhere
+in documentation can be made discretely. A page that is part tutorial inherits
+the cascade for its whole length. Fountain feels this already. Every change to
+the conversation lifecycle currently touches `primitives.md`, `architecture.md`
+and `build/pieces.md`, because all three narrate the same sequence at different
+altitudes.
+
+## One caution about acting on this
+
+`/how-to-use-diataxis/` is explicit that Diátaxis is a guide rather than a
+plan, that you should not create empty four-way structures, and that structure
+should emerge from repeated small improvements rather than be imposed. The nav
+tree in deliverable 1 is therefore not proposed as a build order. It is the
+shape 34 existing pages settle into once each one is made to do a single job,
+and it is accompanied by an ordered list of individually mergeable moves. No
+step in that list creates an empty section.

--- a/docs-redesign/01-reference-site-study.md
+++ b/docs-redesign/01-reference-site-study.md
@@ -1,0 +1,685 @@
+# Phase 2: what the reference sites actually do
+
+Every pattern below is given a short name in **bold**, so the later
+deliverables can cite it. Every claim is from a page I fetched and read.
+Anything I could not verify is marked "unverified".
+
+---
+
+## Temporal
+
+Question. How do they teach four primitives to readers with no prior model,
+how is the concepts tree separated from the how-to tree, and how does each
+concept page justify the primitive's existence.
+
+Pages read: `docs.temporal.io/llms.txt`, `/temporal.md`, `/workflows.md`,
+`/activities.md`, `/evaluate/understanding-temporal`,
+`/develop/typescript/llms.txt`.
+
+### The two trees are the same topic list, twice
+
+`docs.temporal.io/llms.txt` is the whole information architecture in one file.
+The top section is **Core Primitives**, whose children are Activities, Child
+Workflows, Data conversion, Event History, Namespace, Nexus, Temporal Service,
+Visibility, Workers, Workflow, Workflow message passing. A later section is
+**SDK Development Guides**, one per language, each at
+`/develop/<language>/llms.txt`.
+
+Fetch `/develop/typescript/llms.txt` and the child list is Activities, Best
+Practices, Client, Nexus, Platform, Workers, Workflows. The same nouns. So a
+reader who learned "Activity" from `/activities.md` finds the how-to at
+`/develop/typescript/activities/basics.md`, by substitution rather than by
+search.
+
+**Pattern: mirrored topic trees.** One topic vocabulary, instantiated once as
+explanation and once per language as how-to. Reference lives in a third tree
+(`/references/`, `/cli/`) and troubleshooting in a fourth
+(`/troubleshooting/`). Note that the top-level sections are named for what they
+contain in reader language, not "Explanation" and "How-to guides".
+
+### How a concept page justifies the primitive
+
+`/activities.md` does four things in its first screen, in this order.
+
+1. Defines the thing in one sentence in terms the reader already has. An
+   Activity is "a normal function or method that executes a single,
+   well-defined action".
+2. Gives four recognizable jobs it is for, phrased as work the reader has
+   already done. Single write operations, batches of similar writes, read then
+   write, a read that should be memoized.
+3. States the failure that the primitive exists to survive. If an Activity
+   Execution fails, a future attempt starts from the initial state unless the
+   code checkpoints with heartbeat details.
+4. Says when you do not need it. "If you only want to execute one Activity
+   Function, then you don't need to use a Workflow."
+
+**Pattern: justify-by-failure.** The primitive is motivated by naming what
+breaks without it, not by listing its features. **Pattern: the negative
+boundary.** Every concept page states a case where the reader should use
+something else.
+
+### Disambiguating an overloaded noun
+
+`/workflows.md` opens by conceding the word is overloaded. "In day-to-day
+conversations, the term Workflow might refer to Workflow Type, a Workflow
+Definition, or a Workflow Execution." It then numbers the three senses and
+defines each. There is also a standalone `/glossary.md` in the Concepts
+section.
+
+**Pattern: noun disambiguation up front.** Directly relevant to Fountain, which
+overloads "environment", "agent" and "fountain" worse than Temporal overloads
+"workflow".
+
+### The entry page routes into all four modes
+
+`/temporal.md` ends with a **Next steps** list whose five items are a tutorial
+(Quickstarts), how-to (Developer guides), reference-adjacent (Temporal Cloud),
+and two explanations (architecture, Understanding Temporal). The reader is
+handed the mode, not just the link.
+
+**Pattern: mode-labelled next steps.**
+
+---
+
+## Stripe
+
+Question. How does a conceptual page end in runnable code without becoming a
+tutorial.
+
+Page read: `docs.stripe.com/payments/payment-intents` ("The Payment Intents
+API"), in full.
+
+The page contains four `curl` blocks and is not a tutorial. The mechanism is
+mechanical and copyable.
+
+### Every snippet is the same stem with one parameter changed
+
+Block 1 is the base object.
+
+```
+curl https://api.stripe.com/v1/payment_intents -u "sk_test_..." \
+  -d amount=1099 -d currency=usd
+```
+
+Blocks 2, 3 and 4 are that exact request with exactly one line added.
+`-d setup_future_usage=off_session`, then
+`-d "statement_descriptor_suffix=Custom descriptor"`, then
+`-d "metadata[order_id]=6735"`.
+
+**Pattern: one-parameter variations on a fixed stem.** This is what prevents
+the page becoming a tutorial. A tutorial's steps are ordered and cumulative, so
+step 4 fails if you skipped step 2. These four blocks are independent and
+substitutable. Any one of them runs on its own, and none of them advances a
+state machine. Diátaxis licenses exactly this in `/reference/`, "Provide
+examples", as illustration that avoids becoming instruction.
+
+### The page explicitly refuses the tutorial and names its address
+
+The Creating a PaymentIntent section's first sentence is "To get started, see
+the accept a payment guide." The page then shows the object rather than the
+build sequence. It closes with a **See also** list of four how-to guides
+(Accept a payment online, in an iOS app, in an Android app, Set up future
+payments).
+
+**Pattern: hand off the sequence by name.** The conceptual page does not
+compress the tutorial into a smaller tutorial. It says where the tutorial is,
+in its first paragraph, and again at the end.
+
+### Judgment goes in prose blocks, never in a numbered step
+
+Between the code blocks the page carries **Best practices** (create the object
+as soon as you know the amount, reuse it if checkout resumes, supply an
+idempotency key) and repeated **Caution** admonitions (do not log the client
+secret, do not store PII in metadata). These are the sentences that would be
+steps in a tutorial. Here they are standing advice with no position in a
+sequence.
+
+### The advantage list is the justification
+
+The page's second paragraph is four bullets. Automatic authentication handling,
+no double charges, no idempotency key issues, support for SCA. Three of the
+four are named failures avoided, which is Temporal's justify-by-failure
+arriving independently at a second site.
+
+---
+
+## Fly.io
+
+Question. How is reference organized for a CLI-first user with the API as the
+escape hatch, and what exactly is the voice.
+
+Pages read: `fly.io/docs/` (nav), `/docs/flyctl/`, `/docs/machines/`,
+`/docs/machines/overview/`, `/docs/flyctl/machine-run/`.
+
+### Resource-first, with the same four-shape inside each resource
+
+The nav is organized by resource, not by mode. `/docs/machines/`,
+`/docs/volumes/`, `/docs/networking/`, `/docs/monitoring/`, `/docs/mpg/`,
+`/docs/security/`. Inside a resource the same sub-shape repeats.
+
+| Slot | Machines | Volumes |
+|---|---|---|
+| explanation | `/docs/machines/overview/` | `/docs/volumes/overview/` |
+| state reference | `/docs/machines/machine-states/` | `/docs/volumes/volume-states/` |
+| how-to | `/docs/machines/guides-examples/...` | `/docs/volumes/volume-manage/` |
+| CLI reference | `/docs/machines/flyctl/fly-machine-run/` | |
+| API reference | `/docs/machines/api/` | |
+
+**Pattern: the state machine is its own reference page.** Fly gives Machine
+states and Volume states dedicated URLs rather than a section inside the
+overview. Fountain's Conversation status lifecycle is currently four lines
+inside an explanation page.
+
+`/docs/reference/` exists as a separate top-level bucket, and it holds only the
+platform-wide reference that no single resource owns. Configuration, regions,
+health checks, fly-proxy, architecture, autoscaling.
+
+### The CLI is indexed twice, by task and by command
+
+`/docs/flyctl/` groups commands under task headings, not alphabetically. "Using
+your Fly.io Account", "Working with Apps", "Viewing and monitoring an App",
+"Configuring networking and certificates". Each entry is a human goal followed
+by the exact command, in the form "Deploy An App: `fly deploy`". The same
+command pages are also reachable inside the resource section.
+
+Each command page itself (`/docs/flyctl/machine-run/`) is austere and
+generated. Title, one-line summary, Usage, Options, Global options. No prose,
+no voice, no examples. All ~60 flags in one block.
+
+**Pattern: task-grouped command index over a generated command reference.** The
+human organization is in the index. The command pages are machine output.
+
+### The API is the escape hatch, and the concept page is the join
+
+`/docs/machines/` is a three-item hub that names both surfaces and their
+relationship in the deck. Machines are controlled "with a simple REST API or
+flyctl commands". Its three children are the concept intro, the Machines API,
+and the flyctl commands.
+
+Then `/docs/machines/overview/` does the actual joining. Every lifecycle
+transition names both surfaces in the same sentence. "You create a Fly Machine
+with a Create Machine request, or with `fly machine run`." "you stop it with a
+Stop Machine request, or `fly machine stop`." "Send a Delete Machine request,
+or use `fly machine destroy`."
+
+**Pattern: the concept page is the CLI/API join table.** The two reference
+trees stay separate and neutral. The mapping between them lives in the
+explanation, once, in prose, where it does not have to be maintained in two
+generated files.
+
+The same page also routes readers away twice. "For most applications, most of
+the time, you don't need to be picky! ... Fly Launch does all that for you."
+And `/docs/machines/` closes with "On the other hand, try Fly Launch if you
+prefer easy app-wide configuration". That is Temporal's negative boundary
+again, from a third site.
+
+### The voice, concretely
+
+Verbatim markers from `/docs/machines/overview/`, so this can be imitated or
+rejected on evidence rather than vibes.
+
+- Second person and contractions throughout. "If you've launched an app on
+  Fly.io, you're already using Fly Machines."
+- Editorializing exclamation inside technical prose. "you don't need to be
+  picky!"
+- Self-deprecation about their own product's ergonomics. "Here, we're going to
+  scale Machines directly, in a fiddly way."
+- Slang intensifier as a definition. "The big Fly Machine trick is: starting up
+  super fast; like, 'in response to an HTTP request from a user' fast."
+- A programming in-joke inside a lifecycle list. Step 3 ends "if you want to do
+  that, GOTO 2."
+- Anthropomorphized objects. "You're tired of the Fly Machine, and want it to
+  go away permanently."
+- Hedged numbers instead of precise ones. "this can take some time, maybe low
+  double digit seconds."
+- Real terminal output pasted verbatim, including the machine-generated app
+  name `flyctl-interactive-shells-g1b7jg6wpdbq0i8b8yrl4q9rlqu5pm-502673` and a
+  raw IPv6 address.
+- Direct encouragement. "Go ahead and try it!"
+
+**The voice is confined to explanation.** `/docs/flyctl/machine-run/` has none
+of it. That split is the part worth copying regardless of what you think of the
+jokes.
+
+---
+
+## Tailscale
+
+Question. How does the "how it works" explainer do marketing work while staying
+honest technical writing.
+
+Page read: `tailscale.com/blog/how-tailscale-works` (Avery Pennarun, 20 March
+2020), in full.
+
+### The marketing is structural, not adjectival
+
+The page never claims Tailscale is good. It builds the reader's existing
+solution, lets it fail, rebuilds it better, lets that fail, and repeats. The
+sequence is hub-and-spoke, then multi-hub, then mesh, then Tailscale.
+
+Each stage is steelmanned before it is knocked down. On multi-hub: "But we can
+do it, right? It's only about 5 times as much work as one hub, which is not
+that much work." Only then does it enumerate what actually breaks. Nodes cannot
+find each other, user devices rarely have static IPs, you cannot open a
+firewall port in a cafe, and compliance auditing has nowhere to sit.
+
+**Pattern: build the reader's status quo, then break it.** The product arrives
+as the answer to a problem the reader has just watched accumulate, so no
+adjective is needed.
+
+### The honesty is specific and costly
+
+- It gives away the implementation. "you should be able to build your own
+  Tailscale replacement… except you don't have to, since our node software is
+  open source and we have a flexible free plan." The commercial reason not to
+  reimplement is stated plainly rather than hidden behind vagueness.
+- It credits the component it did not build, by exact variant. "the userspace
+  Go variant, wireguard-go".
+- It admits its own complexity instead of smoothing it. "This is where things
+  get a bit hairy."
+- It names the case where the good path does not work. "Some especially cruel
+  networks block UDP entirely, or are otherwise so strict that they simply
+  cannot be traversed using STUN and ICE." The DERP relay fallback is then
+  introduced as a concession, not a feature.
+- It corrects an inaccuracy in its own diagram, in a parenthetical, quoting
+  their designer on why London is missing from a map.
+- It defers rather than pads. NAT traversal gets a one-paragraph summary and a
+  link to a teammate's dedicated post.
+- It is dated and bylined, so a 2020 claim reads as a 2020 claim.
+
+**Pattern: concede the failure case in the same breath as the feature.**
+**Pattern: date and sign explanation.** Explanation is the one mode allowed
+opinion (`diataxis.fr/explanation/`), and a byline is what makes an opinion
+attributable rather than corporate.
+
+---
+
+## WorkOS
+
+Question. Reverse-engineer the template behind the per-provider setup guides.
+
+Pages read: `workos.com/docs/integrations/okta-saml` and
+`workos.com/docs/integrations/azure-ad-saml`, in full, diffed against each
+other.
+
+### The template, field by field, in order
+
+1. **Breadcrumb** `Integrations`.
+2. **H1** `<Provider> <Protocol>`, with the vendor's rename in parentheses when
+   there is one. "Entra ID SAML (formerly Azure AD)".
+3. **Deck**, one sentence, same skeleton both times. "Learn how to configure a
+   connection to `<Provider>` via `<Protocol>`."
+4. **On this page** auto-generated TOC.
+5. **Introduction.** Opens with boilerplate that is near-identical across
+   guides. "Each SSO Identity Provider requires specific information to create
+   and configure a new Connection. And often, the information required to
+   create a Connection will differ by Identity Provider." Then exactly one
+   variable sentence naming what this provider needs. Okta needs three items,
+   Entra needs one.
+6. **What WorkOS provides.** The constant half of the exchange. Each field gets
+   a definition sentence that is identical across guides ("The ACS URL is the
+   location an Identity Provider redirects its authentication response to"),
+   followed by a per-provider translation sentence ("the ACS URL will need to
+   be set as the 'Single Sign-On URL'" for Okta, "as the 'Reply URL (Assertion
+   Consumer Service URL)'" for Entra).
+7. **What you'll need.** The variable half, coming from the customer's IdP,
+   with a note that it normally arrives from the customer's IT team.
+8. **Numbered steps.** Titles are reused across guides wherever the work is the
+   same. Both guides have `1 Log in`, `2 Select or create your application`,
+   `3 Initial SAML Application Setup`, `4 Configure SAML Application`. They
+   diverge only at step 5.
+9. **Optional steps marked in the heading.** "Role Assignment (optional)",
+   present in both.
+10. **Forward skips.** "move to Step 4" (Okta), "move to Step 7" (Entra), so
+    the guide serves both the create-new and already-exists reader.
+11. **Screenshot per UI step.**
+
+### Why the fortieth guide is cheap
+
+The genuinely new content per provider is three things. The provider's own UI
+label for each of about three WorkOS-side fields, the click path through their
+admin console, and the screenshots. Everything conceptual is boilerplate that
+is written once and pasted.
+
+**Pattern: constant-half / variable-half.** The guide is explicitly a
+translation table between a fixed set of your-side terms and one vendor's
+labels for them. This is the single most transferable idea in Phase 2.
+
+**Pattern: shared step titles.** Reusing `1 Log in` verbatim across forty
+guides is not laziness. It means a reader who has done one guide can skim the
+next, and it means the writer knows which steps they are allowed to invent.
+
+**Pattern: the vendor rename goes in the title.** Catalogs outlive vendor
+branding, and a reader searching "Azure AD" must land on the Entra page.
+
+---
+
+## Sentry and Supabase
+
+Question. How do they handle the same task documented once per platform without
+it reading as copy-paste.
+
+Pages read: `docs.sentry.io/platforms/javascript/guides/react/`,
+`docs.sentry.io/platforms/python/guides/django/`,
+`supabase.com/docs/guides/auth/server-side/nextjs`,
+`supabase.com/docs/guides/auth/quickstarts/react-native`.
+
+### Sentry: one URL per platform, one templated body underneath
+
+The React and Django pages have a byte-identical skeleton. Deck ("Learn how to
+set up Sentry in your `<X>`, capture your first errors and traces, and view
+them in Sentry"), Prerequisites, Install, Configure, Initialize the Sentry SDK,
+Verify.
+
+The "Want to learn more about these features?" block is word-for-word the same
+on both pages for the features they share.
+
+What varies is small and mechanical. The package manager tabs (npm/yarn/pnpm
+against pip/uv/poetry), the install command, the file the SDK is initialized in
+(`instrument.js` against `settings.py`), and the version rows in Prerequisites.
+
+The mechanism is visible in the fetched source. The code blocks contain
+`___PUBLIC_DSN___` and paired `___PRODUCT_OPTION_START___ performance` /
+`___PRODUCT_OPTION_END___ performance` markers. So the snippet is a single
+templated artifact, filled at render time with the signed-in reader's real DSN
+and toggled by the on-page feature picker.
+
+**Pattern: token-substituted snippets.** The code is not written per platform,
+it is generated from one source with slots.
+
+**Pattern: capability-driven feature picker.** React offers Error Monitoring,
+Tracing, Session Replay, Logs, User Feedback. Django offers Error Monitoring,
+Tracing, Profiling, Logs, Metrics. The picker enumerates what this platform
+actually supports, which turns "unsupported here" from missing prose into a
+visibly absent option.
+
+**Pattern: the wrong-page interceptor.** Near the top of the React page, before
+Install, sits a block headed "Using React Server Components or a React
+framework?" that routes to Next.js, Remix and Gatsby, and then states what the
+current page is for. "This guide is for client-side React applications (SPAs)
+built with tools like Vite or custom bundler configurations."
+
+### Supabase: two different answers depending on the mode
+
+Supabase does both things, and the split is not arbitrary.
+
+`/guides/auth/quickstarts/react-native` is a **tutorial**, and it gets a
+dedicated URL per framework. Numbered steps 1 to N, one concrete path, a "View
+source" link to a real repo.
+
+`/guides/auth/server-side/nextjs` is a **how-to plus explanation**, and it is
+one page with an in-page framework switcher listing Next.js, SvelteKit, Astro,
+Remix, Nuxt, React Router, Express, Hono and TanStack Start. The
+framework-invariant prose is written once. The three-way comparison of
+`getClaims` against `getUser` against `getSession`, and the reason a Next.js
+Server Component needs a proxy to write cookies, appear once and are shared by
+all nine frameworks.
+
+**This is the correct rule, and it falls straight out of Diátaxis.** A tutorial
+must be concrete, single-line, and must not offer alternatives
+(`diataxis.fr/tutorials/`), so it duplicates per framework. Explanation is
+about a topic rather than a tool and must weigh alternatives, so it is shared.
+A how-to may fork, so a switcher is fine.
+
+Both sites also inject the reader's live project values into the snippets.
+Sentry's `___PUBLIC_DSN___`, Supabase's "Project URL" and "Publishable key"
+fields, which render as "No project found" when signed out.
+
+### Where they disagree, and which side to take
+
+Sentry gives every platform its own URL. Supabase gives its how-tos one URL and
+a switcher. The tradeoff is real. Per-URL wins on deep linking, on search
+landing, on per-platform ownership, and on being able to say "read
+`/platforms/python/guides/django/`" in a support reply. Switcher wins on
+never letting the shared prose drift.
+
+**Take Supabase's split, not either extreme.** Duplicate the URL when the page
+is a tutorial or when the content is genuinely mostly different. Share the URL
+with a switcher when the only difference is the code block. For Fountain the
+practical consequence is that the four runtimes (`claude`, `codex`, `gemini`,
+`opencode`) should be a switcher on shared pages, not four page trees, because
+almost everything about them is identical and the divergences are small enough
+to name inline.
+
+---
+
+## Segment
+
+Question. What does catalog UX need once there are hundreds of entries.
+
+Pages read: `segment.com/docs/connections/destinations/catalog/`,
+`segment.com/docs/connections/destinations/catalog/actions-slack/`.
+
+### Measured shape
+
+I extracted the catalog index and counted. 1021 entry lines resolving to 495
+distinct strings, across roughly 45 function categories ("A/B Testing",
+"Advertising", "Analytics", and so on). So each destination is listed under
+about two categories on average.
+
+**Pattern: cross-listing is mandatory at scale.** Segment does not file each
+entry once. AB Smartly appears under both A/B Testing and Analytics. AdQuick
+appears under both Advertising and Analytics. A single home starts mis-filing
+entries long before 495, because vendors do not respect your taxonomy.
+
+**Pattern: one vendor is not one entry.** The unit is one integration. Slack
+has two entries, Optimizely five, TikTok five, LinkedIn three, Facebook three.
+
+**Pattern: status and variant live in the entry title.** Names carry inline
+suffixes so a scanner can disambiguate without clicking. `Beta`, `(Actions)`,
+`Cloud Mode`, `Web Mode`, `(Classic)`. "Optimizely Web" and "Optimizely Full
+Stack" and "Optimizely Data Platform (Beta)" are visibly three things in the
+list itself.
+
+**Pattern: two views over one dataset.** At the very top of the categorized
+catalog sits "Want a simpler list? Check out the list of all destinations." The
+categorized view answers "what should I use for analytics". The flat view
+answers "do you support X". Neither view can answer both, and at this scale
+both questions are common.
+
+### The entry page template
+
+From the Slack (Actions) page, in order.
+
+1. H1 `<Vendor> (<Variant>) Destination`.
+2. **Destination Info** box, hoisted above all prose. What call types it
+   accepts, and the exact identifier string to use in the API. Machine facts
+   first.
+3. **Version disambiguation callout.** "Additional versions of this destination
+   are available… See below for information about other versions of the Slack
+   destination", linking to Slack (Classic).
+4. One-sentence vendor description, clearly vendor-supplied.
+5. **Benefits of X vs Y**, present only when variants exist.
+6. **Getting started**, numbered click path.
+7. **Important differences from the classic destination**, the gotcha section.
+   Here it is a single line about handlebars against Slack's formatting syntax.
+8. **Available Actions**, with a generated
+   `Property name | Type | Required | Description` table per action.
+9. **Migration from**.
+
+The generated property tables are why the entry is cheap. They come from the
+destination's own schema, not from prose.
+
+---
+
+## Modal
+
+Question. How do they build the mental model for remote sandboxed execution.
+
+Pages read: `modal.com/docs/guide`, `modal.com/docs/guide/sandbox`.
+
+This is the closest analogue to Fountain in the whole set, and the Sandboxes
+page is worth treating as the target for Fountain's Conversation page.
+
+### The page declares its own mode in its first sentence
+
+"This page is a high-level guide to Sandboxes, secure containers for executing
+untrusted user or agent code on Modal. For reference documentation on the
+`modal.Sandbox` interface, see this page."
+
+**Pattern: state the mode and link the twin.** Two sentences that make
+reference/explanation blur structurally impossible. The reader who wanted the
+other mode leaves in three seconds instead of scrolling.
+
+### The primitive is introduced as a contrast with the known one
+
+"In addition to the Function interface, Modal has a direct interface for
+defining containers at runtime and securely running arbitrary code inside
+them."
+
+The reader already knows Functions. Sandboxes are defined by what they add.
+
+### The H2 is literally the reader's two questions
+
+"What are Sandboxes and why should I use them?" is answered with a list of
+recognizable jobs rather than a definition. Execute code generated by a
+language model. Create isolated environments for running untrusted code. Check
+out a git repository and run a command against it, like a test suite, or
+`npm lint`. Run containers with arbitrary dependencies and setup scripts.
+
+Three of those four are literally what a Fountain Conversation does.
+
+### The lifecycle is events, each with a paragraph saying what exists yet
+
+Created, Scheduled, Started, Ready, Finished. Each gets a paragraph that
+answers three things. What exists now, what does not exist yet, and what you
+are allowed to do at this state.
+
+- Created. "the Sandbox object exists and has an ID, but no compute resources
+  have been allocated yet."
+- Started. "At this point you can begin executing commands inside the Sandbox
+  with `sandbox.exec(...)`. Network tunnels and volume mounts are active."
+- Ready. Conditional, and says so. "If readiness probes are enabled… If
+  readiness probes are not configured, this event is skipped."
+- Finished. Enumerates all five ways it can happen. The entrypoint exited, it
+  was terminated from the dashboard, `sandbox.terminate()`, the timeout or idle
+  timeout was reached, or out of memory.
+
+**Pattern: per-state paragraph, not a diagram.** A state diagram tells you the
+edges. It does not tell you what you may call, which is the question a reader
+actually has.
+
+**Pattern: enumerate every exit.** The Finished paragraph does not say "for
+various reasons".
+
+### Defaults are stated with their override in the same sentence
+
+"Sandboxes have a default maximum lifetime of 5 minutes. You can change this by
+passing a timeout of up to 24 hours to the `Sandbox.create(...)` function."
+
+Value, unit, ceiling, and the exact parameter, in two sentences.
+
+### The intro page's voice, for contrast with Fly
+
+`modal.com/docs/guide` is terse and mostly claim-then-stop, with one flourish.
+"Take a breath of fresh air and feel how good it tastes with no YAML in it." It
+then shows a complete 25-line runnable example, followed by "That's it!" and
+the exact command to run it. Multi-language tabs (Python, async Python,
+JavaScript, Go) rather than four page trees, which is Supabase's switcher
+arriving independently.
+
+---
+
+## HashiCorp Vault
+
+Question. What does "vault" already mean to a developer who has used their
+product, and where does that prior collide with Fountain's Vault.
+
+Pages read: `developer.hashicorp.com/vault/docs/what-is-vault`,
+`developer.hashicorp.com/vault/docs/concepts/seal`.
+
+### What the word already means
+
+1. **A deployed server or cluster, not a data object.** It has storage backends
+   with an HA support column (Integrated, File system, External, In-memory).
+   You install it, run it, and operate it.
+2. **Singular and central.** The opening sentence is "centralized, well-audited
+   privileged access and secret management". There is one Vault per
+   environment. You do not make many small ones.
+3. **Sealed by default.** "When you start a Vault server, it starts in a sealed
+   state. In this state, Vault can access the physical storage, but it cannot
+   decrypt any of the data on it." Unsealing is an operational ritual, with
+   Shamir shares and a quorum threshold.
+4. **Dynamic, leased, revocable credentials.** The headline capability is
+   database secret plugins that "manage dynamic credentials".
+5. **Path-mounted, policy-governed.** "Clients interact with secrets and
+   encryption operations based on resource paths mounted in Vault", authorized
+   against policies set on that path.
+6. **Audited unconditionally.** "Vault audits all activity, regardless of
+   whether authentication or authorization succeeds".
+7. **The system of record.** If it is in Vault, it is authoritative.
+
+### Where the prior collides with Fountain's Vault
+
+| Reader's prior from HashiCorp | Fountain's actual Vault |
+|---|---|
+| One central server you deploy and operate | Many small rows in Postgres, created freely per customer or per environment |
+| The authoritative store | A patch layer. The Environment is the baseline; the Vault is the exception |
+| Dynamic, leased, short-lived credentials | Static key/value written once, never rotated, never revoked, never returned |
+| Sealed/unsealed operational state | No state. There is nothing to unseal |
+| Path mounts and per-path policy | A flat key/value bag, scoped only by tenant and by `allowed_vault_ids` |
+| Precedence is not a concept | Precedence is the whole point. Vault values win on key collision |
+
+**The prior actively inverts the most important fact.** A HashiCorp user reads
+"Vault" and assumes it is the base of truth. In Fountain the Environment is the
+base and the Vault overrides it. Getting that backwards produces exactly the
+wrong mental model of the merge, which is the one thing a reader must get right
+to use vaults at all.
+
+**Two dangerous silent assumptions.** That putting a credential in a Fountain
+Vault gets it rotation and revocation, and that a Fountain Vault is audited at
+read time the way HashiCorp's is. Neither is true, and neither is currently
+denied anywhere in Fountain's docs.
+
+**One thing that does transfer, and should be leaned on.** The envelope
+encryption chain is the same shape. HashiCorp goes unseal key to root key to
+keyring to data. Fountain goes `MASTER_SECRETS_KEY` to per-tenant DEK to secret
+value. A reader with the HashiCorp prior will understand Fountain's crypto
+immediately, so that is the place to say "yes, like Vault", right after saying
+"no, not like Vault" about everything else.
+
+---
+
+## Where the sites disagree, and the side I take
+
+**1. Top-level nav: four Diátaxis buckets, or reader-language sections.**
+
+Nobody in this set uses the four Diátaxis words at top level. Temporal uses
+Core Primitives / SDK Development Guides / References / Guides / Best Practices
+/ Troubleshooting. Fly uses resources. Modal uses Guide / Reference / Examples.
+
+Take reader-language sections, with one mode per section. Diátaxis licenses
+this itself. `diataxis.fr/explanation/` says explanation "doesn't need to be
+called Explanation" and offers Discussion, Background, Conceptual guides,
+Topics as alternatives. The discipline is that a section contains exactly one
+mode, not that it is named after it.
+
+**2. Resource-first (Fly) or mode-first (Temporal).**
+
+Fly repeats the whole four-mode shape inside every resource, which is right
+when you have twelve resources of comparable weight. Temporal keeps one
+concepts tree and mirrors its topic names into the how-to trees, which is right
+when a small number of primitives are referenced everywhere.
+
+Take Temporal. Fountain has four primitives and a growing catalog. Replicating
+overview / states / guides / CLI / API under each of Environment, Vault, Agent
+and Conversation would produce twenty near-empty pages, which is the empty
+structure `diataxis.fr/how-to-use-diataxis/` explicitly warns against. Borrow
+exactly one thing from Fly, the state machine as its own reference page.
+
+**3. Per-platform URLs (Sentry) or one page with a switcher (Supabase).**
+
+Take Supabase's split, as argued above. Tutorial duplicates, how-to and
+explanation share with a switcher.
+
+**4. How much voice belongs in docs.**
+
+Fly is chatty everywhere in explanation. Modal is terse with one joke per page.
+Stripe and Temporal are neutral throughout. Tailscale is chatty but signed and
+dated.
+
+Take Modal's calibration with Tailscale's honesty, and take Fly's *split*
+rather than Fly's register. Voice lives in explanation only. Reference pages
+get none. The deciding argument is Fly's own site. `/docs/machines/overview/`
+contains "GOTO 2" and `/docs/flyctl/machine-run/` contains sixty flags and no
+adjectives, and both are correct.

--- a/docs-redesign/02-audit.md
+++ b/docs-redesign/02-audit.md
@@ -270,11 +270,19 @@ These are addressed in deliverable 4.
 
 Both are in `CLAUDE.md` and both are real gates, not conventions.
 
-1. **The nav is mirrored in code.** `mkdocs.yml` `nav:` and `@nav` in
-   `apps/fountain/lib/fountain/docs.ex` must list the same pages in the same
-   order, and `apps/fountain/test/fountain/docs_test.exs` fails on drift. Every
-   move, split and rename in deliverable 1 is a two-file edit, and the failing
-   test surfaces in CI partition 3 where it looks unrelated.
+1. **The nav lives only in `mkdocs.yml`, and its parser is strict.**
+   `Fountain.Docs` parses that file's `nav:` at compile time
+   (`docs.ex:43`), so there is nothing to mirror. Two real constraints remain.
+   The parser handles **one level of sections only** and raises on a line it
+   cannot read, so a nested sub-section fails the build. And
+   `docs_test.exs` renders every page and asserts each `](/docs/x#anchor)`
+   target is a real heading, so renaming a heading breaks its inbound links.
+
+   Note. `/Users/jake/CLAUDE.md`'s copy of the contributor guide still
+   describes a hand-mirrored `@nav`. The version on `main` was already
+   corrected. The stale copy is what the nav tree in deliverable 1 was
+   originally written against, and its "every nav edit is two files" claim is
+   wrong.
 2. **`docs/cli.md` is diffed against the CLI, by hardcoded path.** I read
    `cli/internal/cmd/docs_test.go`. `readCLIDoc` opens
    `../../../docs/cli.md` and nothing else. `TestEveryCommandIsDocumented`

--- a/docs-redesign/02-audit.md
+++ b/docs-redesign/02-audit.md
@@ -1,0 +1,289 @@
+# Phase 3: audit of the current docs
+
+Crawled `https://fountain.inevitable.fyi/docs` and the `docs/` source tree they
+are built from. The two agree, so the source is the audit target.
+
+**Correction to the brief's scope.** The brief names seven pages (index, setup,
+architecture, primitives, cli, api, llm-integration). The live site has 34,
+plus a `changelog`. The extra 27 are `self-hosting`, `operations`,
+`configuration`, `sdk`, `tour`, three `build/*` pages, and nineteen
+`integrations/*` pages. Most of the findings below are about those 27.
+
+## Mode classification, all 34 pages
+
+Mode column is what the page *is*, not what it is filed as. "Jobs" counts the
+distinct Diátaxis modes doing real work on the page.
+
+| Page | Lines | Actual mode(s) | Jobs |
+|---|---|---|---|
+| `index.md` | 36 | hub, with explanation in "Why Fountain?" | 2 |
+| `setup.md` | 109 | how-to | 1 |
+| `self-hosting.md` | 393 | how-to x8, reference x2, explanation x1 | 3 |
+| `architecture.md` | 187 | explanation, with a nav list and a lifecycle narration | 2 |
+| `operations.md` | 290 | how-to x7 | 1 |
+| `configuration.md` | 207 | reference | 1 |
+| `primitives.md` | 178 | explanation, reference, how-to | 3 |
+| `cli.md` | 279 | reference, with how-to prose | 2 |
+| `api.md` | 629 | reference | 1 |
+| `sdk.md` | 374 | how-to, reference, explanation | 3 |
+| `tour.md` | 208 | tutorial | 1 |
+| `llm-integration.md` | 65 | how-to, reference, roadmap | 3 |
+| `build/index.md` | 118 | explanation | 1 |
+| `build/team-chat.md` | 401 | tutorial | 1 |
+| `build/pieces.md` | 161 | explanation | 1 |
+| `integrations/index.md` | 39 | reference table, explanation | 2 |
+| `integrations/clients.md` | 69 | hub | 1 |
+| `integrations/sandbox-contract.md` | 82 | explanation, reference | 2 |
+| `integrations/sprites.md` | 49 | how-to, reference | 2 |
+| `integrations/e2b.md` | 52 | how-to, reference | 2 |
+| `integrations/daytona.md` | 50 | how-to, reference | 2 |
+| `integrations/runners.md` | 146 | how-to, reference, explanation | 3 |
+| `integrations/adding-a-sandbox-provider.md` | 133 | how-to | 1 |
+| `integrations/sprites-contract.md` | 168 | reference | 1 |
+| `integrations/acp.md` | 146 | reference | 1 |
+| `integrations/editors.md` | 188 | how-to, explanation, reference | 3 |
+| `integrations/openclaw.md` | 271 | how-to, explanation, reference | 3 |
+| `integrations/hermes.md` | 136 | how-to, reference | 2 |
+| `integrations/openbot.md` | 204 | how-to, explanation, reference | 3 |
+| `integrations/buzz.md` | 395 | how-to, explanation, reference, ops runbook | 4 |
+| `integrations/mail.md` | 61 | how-to, reference | 2 |
+| `integrations/github-oauth.md` | 47 | how-to, reference | 2 |
+| `integrations/stripe.md` | 111 | how-to, reference | 2 |
+| `integrations/sentry.md` | 46 | how-to, reference | 2 |
+| `changelog.md` | 5 | reference (include) | 1 |
+
+**13 of 34 pages do exactly one job. 21 do two or more.** Six do three or more.
+
+## Where pages do two jobs at once
+
+### `primitives.md`, the worst case
+
+Section-by-section, by line range.
+
+| Section | Lines | Doing |
+|---|---|---|
+| Environment (7 to 33) | 27 | reference (field list), explanation (networking semantics), example |
+| Vault (34 to 54) | 21 | explanation (the merge rule), reference, how-to ("Typical uses") |
+| Agent (55 to 97) | 43 | reference, plus a 9-line explanation buried inside one bullet |
+| Conversation (98 to 118) | 21 | how-to (a 5-step API sequence), explanation (the suspend admonition) |
+| Status lifecycle (119 to 127) | 9 | reference |
+| The team (128 to 168) | 41 | explanation, how-to (Schedules), reference |
+| Substitution (169 to 178) | 10 | reference |
+
+Two specific defects follow from this.
+
+**The `model` field's explanation is longer than the Substitution section and
+is unfindable.** Lines 57 to 65 argue why a provider outside `anthropic`,
+`openai`, `google` is rejected at write time, and why the model id itself is
+not validated. That is good, load-bearing explanation. It is filed under a
+field name inside a bullet list, so nobody who wants "why can't I use my own
+provider" will ever find it.
+
+**"The team: agents as teammates" is 41 lines, 23% of the page, about a
+different application.** It explains a channel binding, then documents the
+schedules feature of the team app in prose, including cron syntax and the
+one-off-computer toggle. Per `diataxis.fr/explanation/`, "Keep explanation
+closely bounded"; this section has absorbed a how-to for a product that ships
+from a different repo.
+
+### The other multi-job pages, briefly
+
+- **`self-hosting.md`, 393 lines.** Contains at least eight distinct how-tos
+  (deploy, upgrade, configure a database, run migrations in a Job, take
+  backups, configure email, change sandbox lifetime, turn on billing, put it on
+  the internet, wire observability, deploy to Kubernetes), plus a reference
+  (health endpoints), plus a "Known gaps" explanation. Every one of these has a
+  different reader arriving at a different moment. Bounded by nothing.
+- **`operations.md`, 290 lines.** Seven runbooks on one page. Correct mode,
+  wrong granularity. An operator with a stuck conversation at 3am is scrolling
+  past a Postgres restore drill.
+- **`buzz.md`, 395 lines.** The single largest integration page, doing setup,
+  concept, protocol reference, and an operator runbook ("Operating a hosted
+  agent", "When something goes wrong").
+- **`sdk.md`.** "What the second argument is for" and "Awaiting, streaming, or
+  neither" are explanation sections inside a how-to page. They are also the two
+  best-written sections on the page, which is the `diataxis.fr` observation
+  that trapped explanation is good writing in the wrong place.
+- **`llm-integration.md`.** Ships a JSON config block for an MCP server under
+  the heading "MCP server (coming soon)". The block looks copy-pasteable. This
+  violates the repo's own rule in `CLAUDE.md`, which says documents must not
+  describe unbuilt behavior as existing.
+
+### The writers have already invented an explanation template
+
+Three integration pages independently grew the same two headings.
+`editors.md` and `openclaw.md` both have "What this is, and is not", and
+`editors.md`, `openclaw.md` and `buzz.md` all have "Limits, stated rather than
+discovered". `openbot.md` has "What it does not do yet".
+
+This is evidence, not coincidence. Writers keep needing a place to put the
+negative boundary and the honest limits, and with no explanation section
+available they are embedding one inside every how-to. That heading pair should
+be promoted into the template rather than reinvented per page.
+
+## Confirming or refuting the four known gaps
+
+### 1. "No concepts tree separate from task pages". CONFIRMED
+
+There is no explanation section. Explanation exists and is substantial, and it
+is scattered across at least nine locations.
+
+`architecture.md` (whole page), `build/index.md` (whole page),
+`build/pieces.md` (whole page), `primitives.md` (interleaved),
+`integrations/sandbox-contract.md` ("What the contract guarantees"),
+`integrations/index.md` ("The service you do not configure", which is a
+first-rate ADR summary buried under a table of env vars), `sdk.md` (two
+sections), and the "What this is, and is not" / "Limits" sections on four
+client pages.
+
+Consequence, using Temporal's shape as the comparison. A reader who wants to
+understand Fountain before using it has no door. `docs/index.md`'s "Get
+started" list offers Local setup, Architecture, Primitives deep-dive, CLI, API,
+LLM integration, Build a chat app, Plugging into Fountain, Services. Two of
+those nine are explanation, and they are second and third in a list that reads
+as a task list.
+
+### 2. "MCP servers, skills, repos and packages have no catalog". CONFIRMED, and worse than stated
+
+`grep` across `docs/` finds `skills` mentioned on 12 pages and documented
+nowhere. The complete public documentation of the skills capability is one
+bullet inside the Agent primitive, `primitives.md` line 71. That bullet also
+reveals that **two skills are injected into every sandbox in the world**,
+`fountain` and `create-team`, and that `create-team` is triggered by a user
+typing `/create-team`. Neither has a page. A user cannot find out what
+`/create-team` will ask them.
+
+`mcp_servers` is the same. One bullet, one YAML example using
+`@modelcontextprotocol/server-github`, and `${VAR}` substitution in its env.
+There is no page for that server or any other, no list of what works, no
+statement of which transports are supported.
+
+`packages` and `repos` are worse still. They appear only as the words "packages
+to install, repos to clone, a setup script" in one line of the Environment
+section, plus a `packages: {python: "3.12"}` example. What package managers
+exist is discoverable only by calling `GET /api/catalog`, which
+`api.md` line 174 says returns "package managers" among other things.
+
+**There is a machine-readable catalog and no human-readable one.**
+`GET /api/catalog` returns runtimes, model suggestions per runtime, sandbox
+providers, package managers, avatar bases and moods, and app URLs. That is the
+data a catalog index page would render, and it renders for agents only.
+
+### 3. "'Why Fountain?' motivates via an earlier personal repo". CONFIRMED
+
+`docs/index.md`, whole section, three sentences. It names
+`jhgaylor/aod-ex` and describes Fountain as that project's core rebuilt for
+multi-tenancy.
+
+Two separate problems. The reader's problem appears only in a subordinate
+clause ("Running Claude instances with worktrees locally and shuffling MCP
+configurations and skill setups by hand is painful"), and the paragraph's
+actual subject is repository lineage, which is of interest to about four
+people. Compare Tailscale, which spends roughly a third of a long page inside
+the reader's current setup before naming the product, and Temporal's
+`/temporal.md`, which never mentions its own history.
+
+The marketing site at `fountain.inevitable.fyi` already does this job properly.
+Its second paragraph is "Manual configuration doesn't scale. New teammates
+spend afternoons reverse-engineering setup instead of writing code. API keys
+expire mid-sprint with no single source of truth. Parallel tasks with different
+credentials mean maintaining separate local checkouts." That is three concrete
+failures of the reader's status quo. The docs index has the weaker version of a
+paragraph the marketing site already wrote well.
+
+### 4. "The guided tour lives on marketing rather than the docs index". REFUTED, and the real defect is worse
+
+Verified by fetching both. The tour is **not on the marketing site**. I fetched
+`https://fountain.inevitable.fyi/` and the rendered text contains no tour, no
+walkthrough, and no link matching `tour`.
+
+The tour is at `docs/tour.md`, 208 lines, served at `/docs/tour`, titled "A
+guided tour: an agent that opens a pull request". It is the best page in the
+repository. It is a clean tutorial with an announced destination, six numbered
+stages, a real observable result, a cleanup step, a "What you just built"
+recap, and the whole thing repeated as one copyable script.
+
+The actual defects are these.
+
+- **It is not linked from `docs/index.md`.** The "Get started" list has nine
+  entries and the tutorial is not among them.
+- **It sits at position 15 of 34 in the `mkdocs.yml` nav**, below the CLI
+  reference, the API reference and the TypeScript SDK. A newcomer meets three
+  reference pages before the lesson.
+- **The second tutorial has the same problem.** `build/team-chat.md`, 401
+  lines, is also a real tutorial and is also absent from the index.
+
+So Fountain has two good tutorials and no visible way in. Per
+`diataxis.fr/tutorials-how-to/`, tutorial/how-to conflation is harmful "because
+it risks getting in the way of those newcomers whom we hope to turn into
+committed users". Fountain has not conflated them. It has hidden them.
+
+## What a reader cannot currently find
+
+Six gaps beyond the four above, each stated as the question that has no page.
+
+1. **"My conversation failed. Now what?"** `operations.md` is operator-facing
+   and assumes `kubectl` and Flux. Four client pages have their own "When
+   something goes wrong" sections. There is no user-facing troubleshooting
+   door.
+2. **"What are all the conversation statuses and what can I do in each?"**
+   Nine lines inside `primitives.md`, as an ASCII arrow diagram plus one
+   sentence about `terminated`. It says nothing about what operations are legal
+   in each state. Compare Modal's Sandbox lifecycle, which gives each state a
+   paragraph, and Fly, which gives Machine states its own page.
+3. **"What does this word mean?"** No glossary. Fountain overloads at least
+   five terms. "Environment" is a primitive, a map of env vars, and a
+   deployment tier. "Agent" is a primitive, the coding agent running in the
+   sandbox, and the ACP role. "Computer" is used throughout the team docs for
+   the sandbox and is defined nowhere. "Sandbox", "sprite", "runner" and
+   "machine" all appear. "Fountain" is the product, the CLI binary, and a skill
+   injected into every sandbox.
+4. **"Which runtime should I pick?"** Four runtimes exist. The differences are
+   scattered across the `model` bullet in `primitives.md`, `acp.md` ("ACP is
+   the ONLY path for claude/codex/opencode"), and `configuration.md`. No
+   comparison exists.
+5. **"How does the secret actually get into my sandbox?"** The pieces exist in
+   three places. `architecture.md`'s "The secrets model", the Vault merge rule
+   in `primitives.md`, and the Substitution table. Nothing joins the chain from
+   `MASTER_SECRETS_KEY` through the per-tenant DEK through the environment plus
+   vault merge through `${VAR}` substitution to the process environment.
+6. **"Why is there a console and also two separate apps?"** This is a real
+   architectural decision with real consequences for anyone building against
+   Fountain, and it is documented only in `CLAUDE.md`, which is a contributor
+   file, plus a redirect note. `docs/` never states it.
+
+## Cross-cutting style findings
+
+Measured across the 34 pages.
+
+- **682 em dashes, in 32 of 34 files.** `api.md` alone has 61,
+  `architecture.md` 32, `primitives.md` 12.
+- **Colon-introduced lists are the default construction.** 19 in
+  `primitives.md`, 12 in `api.md`, 10 in `cli.md`, 8 in `architecture.md`.
+- **Trailing explanatory clauses are pervasive**, and they are where the
+  explanation hides. The `model` bullet is one 60-word sentence with three
+  subordinate clauses after the claim.
+
+These are addressed in deliverable 4.
+
+## Two structural facts that constrain any redesign
+
+Both are in `CLAUDE.md` and both are real gates, not conventions.
+
+1. **The nav is mirrored in code.** `mkdocs.yml` `nav:` and `@nav` in
+   `apps/fountain/lib/fountain/docs.ex` must list the same pages in the same
+   order, and `apps/fountain/test/fountain/docs_test.exs` fails on drift. Every
+   move, split and rename in deliverable 1 is a two-file edit, and the failing
+   test surfaces in CI partition 3 where it looks unrelated.
+2. **`docs/cli.md` is diffed against the CLI, by hardcoded path.** I read
+   `cli/internal/cmd/docs_test.go`. `readCLIDoc` opens
+   `../../../docs/cli.md` and nothing else. `TestEveryCommandIsDocumented`
+   walks the real Cobra tree and fails if any command string is absent from
+   that one file. `TestNoDocumentedCommandIsInvented` scans only fenced code
+   blocks in that file and fails on any invented command.
+
+   Consequence for this redesign. The CLI reference **must stay as one file at
+   `docs/cli.md`**, or `readCLIDoc` must be changed to concatenate a directory
+   before any split happens. This is the only proposal in deliverable 1 that
+   carries a code change outside `docs/` and `docs.ex`, and it is called out
+   there.

--- a/docs-redesign/03-nav-tree.md
+++ b/docs-redesign/03-nav-tree.md
@@ -1,0 +1,243 @@
+# Deliverable 1: proposed nav tree
+
+Every entry is labelled with its Diátaxis mode and its disposition.
+**KEEP**, **MOVE**, **SPLIT**, **MERGE**, **NEW**, **DELETE**.
+
+Section names are in reader language rather than Diátaxis vocabulary, following
+Temporal's `docs.temporal.io/llms.txt`, which uses Core Primitives, SDK
+Development Guides, References, Guides, Troubleshooting. `diataxis.fr/explanation/`
+licenses this directly, listing Discussion, Background, Conceptual guides and
+Topics as acceptable names for explanation. The discipline being enforced is
+one mode per section, not the naming.
+
+---
+
+## The tree
+
+### Start here
+
+| Page | Mode | Disposition |
+|---|---|---|
+| `index.md`, Fountain | hub | **KEEP**, rewritten. Nine undifferentiated links become four mode-labelled doors, following Temporal `/temporal.md`'s "Next steps" |
+| `start/what-fountain-is.md` | Explanation | **NEW**. Replaces `index.md`'s "Why Fountain?". Built on Tailscale's status-quo-then-break shape |
+| `tutorials/first-agent.md`, An agent that opens a pull request | **Tutorial** | **MOVE** from `tour.md`, unchanged in content, promoted to position 2 |
+| `start/install.md`, Install the CLI and sign in | How-to | **NEW**. Extracted from `cli.md` "Install" plus "Authentication" |
+
+The tutorial appears here and in Tutorials. One page, two nav positions.
+`diataxis.fr/map/` is explicit that a user "may enter the documentation
+anywhere", so a single canonical order is not required.
+
+### Concepts
+
+Everything in this section is explanation. Nothing in it contains a numbered
+step or a complete field list.
+
+| Page | Mode | Disposition |
+|---|---|---|
+| `concepts/index.md`, The four primitives | Explanation | **SPLIT** from `primitives.md`. Becomes a hub. Full rewrite in deliverable 5 |
+| `concepts/environment.md` | Explanation | **SPLIT** from `primitives.md` lines 7 to 33 |
+| `concepts/vault.md` | Explanation | **SPLIT** from `primitives.md` lines 34 to 54, plus the HashiCorp collision section. Rewrite in deliverable 5 |
+| `concepts/agent.md` | Explanation | **SPLIT** from `primitives.md` lines 55 to 97. The 9-line `model` argument becomes prose under its own heading |
+| `concepts/conversation.md` | Explanation | **SPLIT** from `primitives.md` lines 98 to 118 |
+| `concepts/how-a-conversation-runs.md` | Explanation | **MERGE** of `architecture.md` "A conversation's life" and `build/pieces.md` "What happens between Enter and the first word" and "The computer's day" |
+| `concepts/secrets.md`, Where a secret comes from | Explanation | **NEW**. Joins `architecture.md` "The secrets model", the vault merge rule, and `${VAR}` substitution into one chain. Audit gap 5 |
+| `concepts/sandboxes.md` | Explanation | **SPLIT** from `integrations/sandbox-contract.md`, explanation half only |
+| `concepts/inference-credentials.md`, Why you bring your own | Explanation | **MOVE** from `integrations/index.md` "The service you do not configure" |
+| `concepts/teammates.md`, Agents as teammates | Explanation | **SPLIT** from `primitives.md` lines 128 to 168, explanation half only |
+| `concepts/surfaces.md`, The console, the apps, and the API | Explanation | **NEW**. Audit gap 6. Currently only in `CLAUDE.md` |
+| `concepts/architecture.md` | Explanation | **MOVE** from `architecture.md`, minus the two merged sections and the "Where to look" nav list |
+| `concepts/why-a-chat-app-needs-this.md` | Explanation | **MOVE** from `build/index.md`. Genuinely good explanation currently filed under a tutorial section |
+
+### Tutorials
+
+| Page | Mode | Disposition |
+|---|---|---|
+| `tutorials/first-agent.md` | **Tutorial** | Same page as in Start here |
+| `tutorials/team-chat.md` | **Tutorial** | **MOVE** from `build/team-chat.md` |
+
+Two tutorials is the right number. `diataxis.fr/tutorials/` is blunt that they
+"can consume a remarkable amount of effort and time" and that revisions
+"cascade through the entire story". Adding a third is a maintenance commitment,
+not a page.
+
+### Guides
+
+Everything here is how-to, and every title starts with a verb, per
+`diataxis.fr/how-to-guides/`, "Pay attention to naming".
+
+#### Run agents
+
+| Page | Mode | Disposition |
+|---|---|---|
+| `guides/give-an-agent-a-repo.md` | How-to | **NEW**. Extracted from `tour.md` stage 1 and `cli.md` "Apply manifests" |
+| `guides/override-credentials-with-a-vault.md` | How-to | **MOVE** from `primitives.md` Vault "Typical uses", expanded |
+| `guides/interrupt-resume-end.md` | How-to | **NEW**. From `primitives.md` Conversation steps 4 and 5, and `api.md` |
+| `guides/schedule-a-teammate.md` | How-to | **SPLIT** from `primitives.md` "Schedules" |
+| `guides/stream-a-conversation.md` | How-to | **SPLIT** from `sdk.md` "Awaiting, streaming, or neither" |
+
+#### Operate an instance
+
+`self-hosting.md` (393 lines) and `operations.md` (290 lines) become nine
+pages. Each has one reader arriving at one moment.
+
+| Page | Mode | Disposition |
+|---|---|---|
+| `guides/operate/deploy.md` | How-to | **SPLIT** from `self-hosting.md` "Quick start" |
+| `guides/operate/put-it-on-the-internet.md` | How-to | **SPLIT** from `self-hosting.md` |
+| `guides/operate/database.md` | How-to | **SPLIT** from `self-hosting.md` "Database" and "Running migrations in a Job" |
+| `guides/operate/back-up-and-restore.md` | How-to | **MERGE** of `self-hosting.md` "Backups" and `operations.md` "Backup and restore" including the restore drill |
+| `guides/operate/upgrade.md` | How-to | **MERGE** of `self-hosting.md` "Versioning and upgrades" and `operations.md` "Upgrade gone wrong" |
+| `guides/operate/turn-on-billing.md` | How-to | **SPLIT** from `self-hosting.md` "Billing" |
+| `guides/operate/set-sandbox-lifetimes.md` | How-to | **SPLIT** from `self-hosting.md` "Sandbox lifetime" |
+| `guides/operate/observability.md` | How-to | **MERGE** of `self-hosting.md` "Observability" and `operations.md` "Pods restarting or not ready" |
+| `guides/operate/run-a-release-task.md` | How-to | **SPLIT** from `operations.md` |
+| `guides/operate/kubernetes.md` | How-to | **SPLIT** from `self-hosting.md` "Kubernetes" |
+
+#### Contribute
+
+| Page | Mode | Disposition |
+|---|---|---|
+| `guides/contribute/set-up-a-workstation.md` | How-to | **MOVE** from `setup.md` |
+| `guides/contribute/add-a-sandbox-provider.md` | How-to | **MOVE** from `integrations/adding-a-sandbox-provider.md` |
+| `guides/contribute/write-a-catalog-entry.md` | How-to | **NEW**. The template from deliverable 3, as an executable guide |
+
+### Catalog
+
+New top-level section. Six sub-catalogs, one entry template (deliverable 3).
+
+| Page | Mode | Disposition |
+|---|---|---|
+| `catalog/index.md` | Reference index | **NEW** |
+| `catalog/sandboxes/index.md` | Reference index | **NEW** |
+| `catalog/sandboxes/sprites.md` | Catalog entry | **MOVE** from `integrations/sprites.md`, refiled to template |
+| `catalog/sandboxes/e2b.md` | Catalog entry | **MOVE** from `integrations/e2b.md` |
+| `catalog/sandboxes/daytona.md` | Catalog entry | **MOVE** from `integrations/daytona.md` |
+| `catalog/sandboxes/self-hosted-runner.md` | Catalog entry | **MOVE** from `integrations/runners.md`, explanation half to `concepts/sandboxes.md`, wire protocol to Reference |
+| `catalog/clients/index.md` | Reference index | **MOVE** from `integrations/clients.md` |
+| `catalog/clients/editors.md` | Catalog entry | **MOVE** from `integrations/editors.md` |
+| `catalog/clients/openclaw.md` | Catalog entry | **MOVE** from `integrations/openclaw.md` |
+| `catalog/clients/hermes.md` | Catalog entry | **MOVE** from `integrations/hermes.md` |
+| `catalog/clients/openbot.md` | Catalog entry | **MOVE** from `integrations/openbot.md` |
+| `catalog/clients/buzz.md` | Catalog entry | **MOVE** from `integrations/buzz.md`, runbook half to Troubleshooting |
+| `catalog/clients/agentic-ides.md` | Catalog entry | **SPLIT** from `llm-integration.md` |
+| `catalog/services/index.md` | Reference index | **MOVE** from `integrations/index.md`, minus the inference-credentials essay |
+| `catalog/services/mail.md` | Catalog entry | **MOVE** from `integrations/mail.md` |
+| `catalog/services/github-oauth.md` | Catalog entry | **MOVE** from `integrations/github-oauth.md` |
+| `catalog/services/stripe.md` | Catalog entry | **MOVE** from `integrations/stripe.md` |
+| `catalog/services/sentry.md` | Catalog entry | **MOVE** from `integrations/sentry.md` |
+| `catalog/runtimes/index.md` | Reference index | **NEW**. Audit gap 4 |
+| `catalog/runtimes/{claude,codex,gemini,opencode}.md` | Catalog entry x4 | **NEW** |
+| `catalog/mcp-servers/index.md` | Reference index | **NEW**. Known gap 2 |
+| `catalog/mcp-servers/*.md` | Catalog entry | **NEW**. Start with the ones actually in use |
+| `catalog/skills/index.md` | Reference index | **NEW**. Known gap 2 |
+| `catalog/skills/fountain.md` | Catalog entry | **NEW**. Injected into every sandbox and documented nowhere |
+| `catalog/skills/create-team.md` | Catalog entry | **NEW**. Same, and it owns the `/create-team` command |
+
+### Reference
+
+Austere and neutral, per `diataxis.fr/reference/`. No voice, no
+recommendations, no numbered procedures.
+
+| Page | Mode | Disposition |
+|---|---|---|
+| `cli.md` | Reference | **KEEP AT THIS PATH**. See the constraint below |
+| `api.md` | Reference | **KEEP** |
+| `sdk-reference.md` | Reference | **SPLIT** from `sdk.md`, reference half |
+| `configuration.md` | Reference | **KEEP** |
+| `reference/conversation-states.md` | Reference | **NEW**. Promoted out of `primitives.md`. Fly gives Machine states and Volume states their own pages |
+| `reference/acp.md` | Reference | **MOVE** from `integrations/acp.md` |
+| `reference/sprites-transport.md` | Reference | **MOVE** from `integrations/sprites-contract.md` |
+| `reference/sandbox-contract.md` | Reference | **SPLIT** from `integrations/sandbox-contract.md`, reference half |
+| `reference/runner-protocol.md` | Reference | **SPLIT** from `integrations/runners.md` "The wire protocol" |
+| `reference/discovery-endpoints.md` | Reference | **SPLIT** from `llm-integration.md` "Discovery endpoints" |
+| `reference/glossary.md` | Reference | **NEW**. Audit gap 3. Temporal keeps `/glossary.md` in its Concepts section |
+| `changelog.md` | Reference | **KEEP** |
+
+### Troubleshooting
+
+New top-level section, one problem per page, titled as the symptom the reader
+observes. Temporal keeps `/troubleshooting/` as a peer of its other trees.
+
+| Page | Mode | Disposition |
+|---|---|---|
+| `troubleshooting/index.md` | hub | **NEW** |
+| `troubleshooting/conversation-stuck-or-failed.md` | How-to | **MOVE** from `operations.md` |
+| `troubleshooting/nobody-can-log-in.md` | How-to | **MOVE** from `operations.md` |
+| `troubleshooting/sandbox-errors.md` | How-to | **MERGE** of `operations.md` "Sprites errors" and the four scattered "When something goes wrong" sections on `acp.md`, `editors.md`, `openclaw.md`, `buzz.md`, `openbot.md` |
+| `troubleshooting/setup-problems.md` | How-to | **MOVE** from `setup.md` "Troubleshooting" |
+
+---
+
+## What gets deleted
+
+| Page or section | Why |
+|---|---|
+| `index.md` "Why Fountain?" | Motivates by repository lineage. Replaced by `start/what-fountain-is.md` |
+| `llm-integration.md` "MCP server (coming soon)" | Documents unbuilt behavior with a copy-pasteable config block. Violates `CLAUDE.md`'s own rule. Restore it in the PR that ships the server |
+| `architecture.md` "Where to look" | A nav list inside a page. The nav is the nav |
+| `build/pieces.md` | Fully absorbed by `concepts/how-a-conversation-runs.md` and `concepts/surfaces.md`. Its "Where the multi-tenancy is" section moves to `concepts/architecture.md` |
+| `integrations/index.md` as a page | Becomes `catalog/services/index.md`. Its essay moves to `concepts/inference-credentials.md` |
+| `sdk.md` as a single page | Splits into a Guides entry and `sdk-reference.md` |
+
+Nothing else is deleted. Every one of the 34 current pages survives as content.
+
+## Summary of movement
+
+| | Count |
+|---|---|
+| Pages today | 34 |
+| Kept at their path | 5 |
+| Moved | 19 |
+| Split into two or more | 8 source pages, producing 31 |
+| Merged | 6 source sections into 3 |
+| Written new | 24, of which 11 are catalog scaffolding |
+| Deleted outright | 1 page, 3 sections |
+| Pages after | roughly 88, of which about 35 are catalog entries |
+
+The page count roughly doubles. That is the point. `diataxis.fr/how-to-guides/`
+argues the list of how-to guides "helps frame the picture of what your product
+can actually do", and Fountain currently hides ten runbooks inside two pages.
+
+## Ordered sequence of individually mergeable steps
+
+`diataxis.fr/how-to-use-diataxis/` is explicit that this tree should not be
+built as a plan, that empty structures are "horrible", and that structure
+should emerge from small improvements. So the tree above is the destination,
+and this is the order. Every step is one PR that leaves the docs better and
+passes `mkdocs build --strict` and `docs_test.exs` on its own.
+
+1. **Link the two tutorials from `index.md` and move `tour.md` to nav position
+   2.** One file, two lines, plus the `docs.ex` mirror. Fixes the highest-value
+   defect in the audit and creates no new structure.
+2. **Rewrite `index.md`'s "Why Fountain?" as `start/what-fountain-is.md`.** One
+   new page, one deletion.
+3. **Delete the "coming soon" MCP config block.** Zero new pages.
+4. **Split `primitives.md`.** One hub plus four children plus
+   `reference/conversation-states.md`. This is deliverable 5 and it is the
+   first step that creates a section, and the section arrives full.
+5. **Add `reference/glossary.md`.** Cheap, and every later page can link into
+   it.
+6. **Split `operations.md` into Troubleshooting.** Creates the second section,
+   also full on arrival.
+7. **Split `self-hosting.md` into `guides/operate/`.**
+8. **Refile the existing 19 integration pages onto the catalog template**, one
+   page per PR, starting with `mail`, `github-oauth`, `sentry` and `stripe`,
+   which are already closest to it.
+9. **Add the two empty catalogs last**, `mcp-servers` and `skills`, each
+   arriving with at least three real entries. Never ship the index alone.
+
+Steps 1 through 3 are half a day and are worth doing regardless of whether the
+rest of this is adopted.
+
+## Two constraints that carry code changes
+
+**`docs/cli.md` cannot move or split** until
+`cli/internal/cmd/docs_test.go`'s `readCLIDoc` is changed. It opens
+`../../../docs/cli.md` by hardcoded path and nothing else, and both tests in
+that file scan only that string. The fix is small, which is to walk a directory
+and concatenate, but it is a Go change and belongs in its own PR before step 8.
+
+**Every nav edit is two files.** `mkdocs.yml` `nav:` and `@nav` in
+`apps/fountain/lib/fountain/docs.ex`, in the same order, or
+`apps/fountain/test/fountain/docs_test.exs` fails in CI partition 3 where it
+reads as unrelated.

--- a/docs-redesign/03-nav-tree.md
+++ b/docs-redesign/03-nav-tree.md
@@ -237,7 +237,9 @@ rest of this is adopted.
 that file scan only that string. The fix is small, which is to walk a directory
 and concatenate, but it is a Go change and belongs in its own PR before step 8.
 
-**Every nav edit is two files.** `mkdocs.yml` `nav:` and `@nav` in
-`apps/fountain/lib/fountain/docs.ex`, in the same order, or
-`apps/fountain/test/fountain/docs_test.exs` fails in CI partition 3 where it
-reads as unrelated.
+**Sections are one level deep, and that is enforced by a raise.** The
+`mkdocs.yml` nav parser in `Fountain.Docs` reads exactly two line shapes, and
+anything else raises at compile time. So `Guides > Operate > page` is not
+representable. The Guides sub-groupings above must flatten into sibling
+sections, for example `Guides: run agents` and `Guides: operate`, or become
+in-page headings on a hub.

--- a/docs-redesign/04-page-templates.md
+++ b/docs-redesign/04-page-templates.md
@@ -1,0 +1,334 @@
+# Deliverable 2: a page template per mode
+
+Four skeletons. Each heading carries a one-line note saying what belongs under
+it, and a citation for why the slot exists.
+
+Two rules apply to all four.
+
+**Declare the mode in the first two sentences and link the twin.** Modal's
+`modal.com/docs/guide/sandbox` opens "This page is a high-level guide to
+Sandboxes… For reference documentation on the `modal.Sandbox` interface, see
+this page." Two sentences make mode blur structurally impossible, because the
+reader who wanted the other mode leaves immediately.
+
+**A page owes exactly one mode.** If a section will not fit under any heading
+in its template, that section belongs on a different page. That is the test,
+not a guideline.
+
+---
+
+## Tutorial
+
+Fountain should have two of these and no more.
+`diataxis.fr/tutorials/` warns that tutorial revisions "cascade through the
+entire story", which makes each one a standing maintenance commitment.
+
+```markdown
+# <A concrete thing we will build together>
+
+<!-- Title names the artifact, not the skill. "An agent that opens a pull
+     request", never "Learning Fountain" or "Getting started with agents". -->
+
+In this tutorial we will <build X>. Along the way we will meet
+<primitive>, <primitive> and <primitive>.
+
+<!-- diataxis.fr/tutorials/, "Show the learner where they'll be going".
+     Never "you will learn", which the source calls presumptuous and a very
+     poor pattern. First person plural throughout; the source calls it the
+     affirmation that "we are in this together". -->
+
+## What you need
+
+<!-- Exactly the prerequisites this tutorial uses, with versions. No optional
+     items, no "you may also want". Every line here is something the reader
+     must have before step 1, and the tutorial fails without it. -->
+
+## 1. <The first concrete result>
+
+<!-- One command or one action. Show it. -->
+
+<!-- Then the expected output, verbatim, in a block. diataxis.fr/tutorials/,
+     "Maintain a narrative of the expected". Paste real output including ids
+     and timestamps, the way fly.io/docs/machines/overview/ pastes a real
+     machine id and a raw IPv6 address. -->
+
+You will see <specific string>. That means <what it means>.
+
+<!-- diataxis.fr/tutorials/, "Point out what the learner should notice".
+     One sentence. Not an explanation of the mechanism. -->
+
+If you do not see <specific string>, <the one likely cause>.
+
+<!-- Only for failures you have actually observed. A speculative failure mode
+     costs confidence and buys nothing. -->
+
+## 2. <The next concrete result>
+
+<!-- Repeat. Every step produces something the reader can see.
+     diataxis.fr/tutorials/, "Deliver visible results early and often". -->
+
+## N. Clean up
+
+<!-- Non-negotiable. The tutorial must be repeatable, and Fountain's steps
+     provision billable sandboxes. diataxis.fr/tutorials/, "Encourage and
+     permit repetition". -->
+
+## What you just built
+
+<!-- Name the artifact and name the primitives that appeared, linking each to
+     its Concepts page. This is the only place a tutorial links outward.
+     diataxis.fr/tutorials/, "Describe (and admire, in a mild way) what your
+     learner has accomplished". -->
+
+## The whole thing, in one script
+
+<!-- Every command from steps 1 to N, contiguous, copyable. tour.md already
+     does this and it is the best single feature of that page. It is also how
+     the tutorial gets tested. -->
+
+## Making it yours
+
+<!-- Two or three one-line pointers to how-to guides. Not variations on the
+     tutorial. -->
+```
+
+**Prohibited in a tutorial.** Alternatives, options, `--flags` the reader is
+invited to choose between, "you could also", explanation of why beyond one
+clause, and any sentence beginning "Note that". `diataxis.fr/tutorials/`,
+"Ignore options and alternatives" and "Ruthlessly minimise explanation".
+
+---
+
+## How-to guide
+
+The most common mode in Fountain and the one with the most pages after the
+split. Title always starts with a verb.
+`diataxis.fr/how-to-guides/`, "Pay attention to naming", grades
+"How to integrate application performance monitoring" as good, "Integrating
+application performance monitoring" as bad, and the bare noun phrase as very
+bad.
+
+```markdown
+# <Verb> <object>
+
+<!-- "Rotate the master secrets key", not "Key rotation", not "Rotating keys". -->
+
+This guide shows you how to <goal>, when <the situation the reader is in>.
+
+<!-- diataxis.fr/how-to-guides/, "This guide shows you how to…". The second
+     clause is the entry condition. A reader in a different situation should
+     be able to leave on this sentence. -->
+
+<!-- If a sibling guide covers the adjacent situation, route here, before the
+     first step. This is Sentry's wrong-page interceptor, at
+     docs.sentry.io/platforms/javascript/guides/react/, which routes Next.js,
+     Remix and Gatsby readers away before Install. -->
+
+## Before you start
+
+<!-- Preconditions as a checkable list. State access level, which surface
+     (console, CLI, API), and anything irreversible ahead. -->
+
+## <Verb the first sub-goal>
+
+<!-- Headings are sub-goals, not tool names. Not "Use the vault API", but
+     "Attach the vault to one run". diataxis.fr/how-to-guides/ is emphatic
+     that guides are "about goals, projects and problems, not about tools",
+     and that tools appear as "incidental bit-players". -->
+
+<!-- Conditional imperatives where the path forks. "If you want x, do y. To
+     achieve w, do z." A how-to may fork; a tutorial may not. -->
+
+<!-- Judgment goes here, in prose, not as a step. Stripe's
+     docs.stripe.com/payments/payment-intents keeps its recommendations in a
+     Best practices block and its warnings in Caution admonitions, both
+     outside the numbered flow. -->
+
+## Verify it worked
+
+<!-- One observable check with its expected output. Every Fountain services
+     page already ends with a "Verify" section; promote it into the template.
+     Without this the guide cannot tell the reader they are done. -->
+
+## If it did not work
+
+<!-- Observed failures only, as symptom then cause then fix. Link to the
+     Troubleshooting page rather than growing a runbook here. -->
+
+## Related
+
+<!-- Links to the reference this guide skipped, and to adjacent guides.
+     diataxis.fr/how-to-guides/, "Refer to the x reference guide for a full
+     list of options". A how-to must not become complete. -->
+```
+
+**Prohibited in a how-to.** Complete option lists, teaching, background,
+history, and any sentence explaining why the system is designed this way.
+`diataxis.fr/how-to-guides/`, "no digression, explanation, teaching".
+
+---
+
+## Reference
+
+Austere. `diataxis.fr/reference/` calls neutral description "the key
+imperative" and says reference should be "austere and uncompromising". This is
+the one mode that gets no voice at all. Fly.io demonstrates the split on its
+own site, where `fly.io/docs/machines/overview/` contains a GOTO joke and
+`fly.io/docs/flyctl/machine-run/` contains sixty flags and no adjectives.
+
+```markdown
+# <The thing, named exactly as the machinery names it>
+
+<!-- The page title is the identifier. "Conversation states", "fountain acp",
+     "Configuration". Not "Understanding conversation states". -->
+
+<one sentence stating what this describes, and one linking the explanation>
+
+<!-- Modal's two-sentence mode declaration, inverted. Reference points at its
+     explanation twin; explanation points at its reference twin. -->
+
+## <Structural division that matches the code>
+
+<!-- diataxis.fr/reference/, "Respect the structure of the machinery". The
+     page's sections mirror the module, the command tree, the router, or the
+     state enum. Not a division the writer invented. For Fountain this means
+     configuration groups match config file sections, API groups match router
+     scopes, and CLI groups match the Cobra tree. -->
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+
+<!-- Tables over prose wherever the data is tabular. Same column order on
+     every reference page in the site. diataxis.fr/reference/, "Adopt standard
+     patterns", which says reference is useful when it is consistent and that
+     it is "definitely not" the place for varied style. -->
+
+<!-- Where a default exists, state value, unit, ceiling and the exact override
+     in one place. Modal does this in two sentences: "Sandboxes have a default
+     maximum lifetime of 5 minutes. You can change this by passing a timeout of
+     up to 24 hours to the Sandbox.create(...) function." -->
+
+### Example
+
+<!-- One minimal example per non-obvious entry. diataxis.fr/reference/,
+     "Provide examples", explicitly licenses illustration in reference.
+     Follow Stripe's rule from docs.stripe.com/payments/payment-intents: every
+     example is the same base call with exactly one thing changed, never a
+     cumulative sequence. Independent and substitutable, so no example depends
+     on a previous one. -->
+
+## Warnings
+
+<!-- diataxis.fr/reference/, "Provide warnings where appropriate": "You must
+     use a. You must not apply b unless c. Never d." Constraints, not advice.
+     "Never call an _unsafe_ function as the first fetch in a user-facing
+     request" belongs here. "We recommend" does not. -->
+```
+
+**Prohibited in reference.** Recommendations, rationale, numbered procedures,
+second person exhortation, and any sentence that would change if the product's
+strategy changed rather than its code.
+
+**Generate what can be generated.** `docs/api.md` is 629 hand-written lines
+alongside an OpenAPI spec that CI already validates, and `docs/cli.md` is 279
+hand-written lines alongside a Cobra tree that a Go test already walks.
+`diataxis.fr/reference/` notes that generated reference is "a powerful way of
+ensuring that it remains faithfully accurate to the code". Fly generates its
+command pages and hand-writes only the task-grouped index at
+`fly.io/docs/flyctl/`. Fountain should do the same.
+
+---
+
+## Explanation
+
+The mode Fountain is missing entirely. Its distinguishing property is that it
+has no natural boundary, so `diataxis.fr/explanation/` recommends inventing a
+why-question as a prompt and drawing a line.
+
+```markdown
+# About <topic>
+
+<!-- The source says you should be able to place an implicit "about" in front
+     of every explanation title. Use it explicitly where it reads well.
+     "Where a secret comes from", "Why you bring your own inference
+     credentials", "The console, the apps, and the API". Never a verb, never
+     a bare primitive name without framing. -->
+
+<one sentence stating this page explains rather than instructs, and linking
+the how-to and the reference for the same subject>
+
+## <The reader's current situation>
+
+<!-- Start where the reader already is, and let it fail. Tailscale's
+     tailscale.com/blog/how-tailscale-works builds hub-and-spoke, steelmans it
+     ("But we can do it, right? It's only about 5 times as much work as one
+     hub, which is not that much work"), then enumerates the four specific
+     things that break. The product is not named until the reader has watched
+     the problem accumulate. -->
+
+## What it is
+
+<!-- One sentence in terms the reader already has, then a contrast with the
+     sibling they already know. Modal introduces Sandboxes as "In addition to
+     the Function interface…" and Temporal introduces Activities as "a normal
+     function or method". -->
+
+## Why it exists
+
+<!-- Name the failure the thing prevents, not the features it has. Temporal's
+     docs.temporal.io/activities.md states what happens when an Activity fails
+     without checkpointing. Stripe's Payment Intents advantages list is three
+     avoided failures out of four bullets. -->
+
+## What it is not
+
+<!-- Mandatory on every Fountain explanation page. Three of the current client
+     pages independently grew a "What this is, and is not" heading, and four
+     grew "Limits, stated rather than discovered". Those writers were right and
+     the template should stop making them reinvent it.
+
+     Where a term collides with a well-known product, this section names the
+     collision. Fountain's Vault against HashiCorp Vault is the worst case and
+     is worked in deliverable 5. -->
+
+## When to use something else
+
+<!-- The negative boundary, present on Temporal, Modal and Fly independently.
+     Temporal: "If you only want to execute one Activity Function, then you
+     don't need to use a Workflow." Fly: "For most applications, most of the
+     time, you don't need to be picky!" -->
+
+## How it works
+
+<!-- The mechanism, at explanation altitude. Prose and a diagram, not a field
+     table. Where the mechanism has two surfaces, name both in the same
+     sentence, which is Fly's join-table move: "You create a Fly Machine with a
+     Create Machine request, or with fly machine run." Doing this here is what
+     lets the CLI reference and the API reference stay separate and neutral. -->
+
+## What we chose not to do
+
+<!-- diataxis.fr/explanation/ is the one mode that admits opinion and
+     perspective, and says explanation "must consider alternatives,
+     counter-examples or multiple different approaches". Fountain has ADRs
+     already; this section is where an ADR's reasoning becomes readable, with a
+     link to the decision record. -->
+
+## Where to go next
+
+<!-- Mode-labelled links, following docs.temporal.io/temporal.md's Next steps,
+     which routes to a tutorial, a how-to and two explanations and says which
+     is which. -->
+```
+
+**Prohibited in explanation.** Numbered procedures, complete field lists, and
+copy-pasteable setup. `diataxis.fr/explanation/`, "Keep explanation closely
+bounded", warns that explanation "tends to absorb other things" and that
+letting instruction creep in both interferes with the explanation and removes
+the instruction from view in the correct place.
+
+**Sign and date explanation pages.** Tailscale's post carries a byline and 20
+March 2020. Explanation is the only mode allowed opinion, and a byline is what
+makes an opinion attributable rather than institutional. It also lets a reader
+discount a stale claim, which matters on a page like `concepts/surfaces.md`
+whose subject changed twice this year.

--- a/docs-redesign/05-catalog-template.md
+++ b/docs-redesign/05-catalog-template.md
@@ -1,0 +1,332 @@
+# Deliverable 3: the integration catalog
+
+Designed so the fortieth entry costs almost nothing. The governing idea is
+WorkOS's constant-half / variable-half split, verified by diffing
+`workos.com/docs/integrations/okta-saml` against
+`workos.com/docs/integrations/azure-ad-saml`. Their guides are a translation
+table between a fixed set of WorkOS-side terms and one vendor's labels for
+them, wrapped in boilerplate that is identical across guides.
+
+Fountain's version of that fixed set is the sandbox contract, the client
+protocols, and the four primitives. Those are the constant half. A catalog
+entry supplies only the variable half.
+
+---
+
+## The six catalogs and what a row means
+
+| Catalog | Entry unit | Today | Growth |
+|---|---|---|---|
+| Sandbox providers | one backend implementing `Fountain.Sandbox` | 4 | slow, single digits |
+| Clients | one thing that drives Fountain from outside | 7 | slow |
+| Services | one external service Fountain calls to run | 4 | slow |
+| Runtimes | one coding-agent CLI | 4 | slow |
+| MCP servers | one server, one transport | 0 | fast, hundreds |
+| Skills | one skill | 2, both undocumented | fast, hundreds |
+
+Segment's rule applies to the last two. At
+`segment.com/docs/connections/destinations/catalog/` I counted 1021 entry
+listings resolving to 495 distinct names across roughly 45 categories, so each
+destination is cross-listed under about two categories. **One vendor is not one
+entry.** Slack has two Segment destinations, Optimizely five, TikTok five. For
+Fountain that means one MCP server offered over both stdio and HTTP is two
+entries if their setup differs, and one entry with a transport switcher if it
+does not.
+
+---
+
+## Front matter, which is the whole point
+
+Every entry carries YAML front matter. The index pages, the badges, the
+filtering and the sort all read from it. Nothing about an entry is derived from
+its prose.
+
+```yaml
+---
+title: Sprites
+catalog: sandboxes          # sandboxes | clients | services | runtimes | mcp-servers | skills
+slug: sprites
+categories: [sandbox, hosted]   # cross-listing; an entry may appear under several
+status: ga                  # ga | beta | experimental | deprecated | community
+maintainer: fountain        # fountain | vendor | community
+also_known_as: []           # former names, so search finds the rename
+direction: outbound         # outbound (Fountain calls it) | inbound (it calls Fountain)
+protocol: sprites-http      # the wire format, verbatim
+requires_config: true       # does the operator set env vars for this
+env_vars: [SPRITES_TOKEN]   # exact names, so the config reference can back-link
+capabilities: [exec, sessions, checkpoints, network-policy, suspend]
+since: "0.1.0"
+verified_against: "0.12.0"  # the last Fountain version this entry was checked on
+---
+```
+
+Four of these fields do disproportionate work.
+
+`also_known_as` handles vendor renames. WorkOS titles its page "Entra ID SAML
+(formerly Azure AD)" precisely because catalogs outlive branding and a reader
+searching the old name must land.
+
+`status` renders as an inline badge in the entry title on the index, which is
+Segment's move. `Beta`, `(Actions)`, `Cloud Mode` and `(Classic)` appear in the
+name text itself, so a scanner disambiguates two same-vendor entries without
+clicking either.
+
+`capabilities` is what makes filtering possible later without rewriting
+anything, and it is what a comparison table renders from.
+
+`verified_against` is the honesty field. `CLAUDE.md` already forbids describing
+unbuilt behavior as existing. A catalog of forty entries drifts, and a stated
+verification version is cheaper than pretending it does not.
+
+---
+
+## The entry template
+
+```markdown
+---
+<front matter as above>
+---
+
+# <Name> <(Variant)>
+
+<!-- Title is the name plus the disambiguating variant, exactly as Segment
+     does. "Sprites", "Slack (stdio)", "Entra ID SAML (formerly Azure AD)". -->
+
+> <One sentence, from the vendor, saying what the thing is.>
+
+<!-- Vendor-supplied and clearly so. Segment does exactly this on
+     segment.com/docs/connections/destinations/catalog/actions-slack/ and
+     nobody is confused about who wrote it. -->
+
+## At a glance
+
+<!-- Rendered from front matter. The writer types none of it. This is
+     Segment's "Destination Info" box, hoisted above all prose: machine facts
+     before sentences. -->
+
+| | |
+|---|---|
+| Status | GA |
+| Maintained by | Fountain |
+| Protocol | `sprites-http` |
+| Env vars | `SPRITES_TOKEN` |
+| Capabilities | exec, sessions, checkpoints, network policy, suspend |
+| Verified against | 0.12.0 |
+
+<!-- If other entries exist for the same vendor, a disambiguation callout goes
+     here, linking siblings. Segment: "Additional versions of this destination
+     are available… See below for information about other versions." -->
+
+## Why you would pick this one
+
+<!-- Two to four sentences. The only genuinely editorial part of the page, and
+     it exists because the index cannot answer "which" from badges alone.
+     Compare against the sibling entries by name. -->
+
+## What Fountain provides
+
+<!-- The constant half. Boilerplate, near-identical across every entry in this
+     catalog, with the provider name substituted. This is WorkOS's "What WorkOS
+     provides".
+
+     Sandbox providers: the six advertised capabilities (:suspend,
+       :network_policy, :attach, :tty, :checkpoint, :public_url) and the
+       error taxonomy, each defined once in the boilerplate.
+     Clients: the conversation, the API key, the stream.
+     Services: the callback URL, the webhook path, the sender identity.
+
+     Each item gets a fixed definition sentence, then one per-entry sentence
+     translating it into this vendor's vocabulary. That translation pair is the
+     mechanism that makes the fortieth entry cheap. -->
+
+## What you will need
+
+<!-- The variable half. Exactly what comes from the vendor's side, with where
+     to get it. WorkOS's "What you'll need", including its note that the value
+     normally arrives from someone else's team. -->
+
+## Set it up
+
+<!-- Numbered steps with fixed titles reused across the catalog wherever the
+     work is the same. WorkOS reuses "1 Log in", "2 Select or create your
+     application", "3 Initial SAML Application Setup" verbatim across
+     providers, and diverges only where the work genuinely diverges.
+
+     Fountain's reusable step titles, per catalog:
+       services:      1 Create it on the provider  2 Set the env vars  3 Restart
+       sandboxes:     1 Get a token  2 Build the image  3 Point Fountain at it
+       clients:       1 Get an API key  2 Configure the client  3 Name an agent
+       mcp-servers:   1 Add it to the agent  2 Supply its credentials
+       skills:        1 Add it to the agent
+
+     A reader who has done one entry can skim the next. A writer knows which
+     steps they are allowed to invent. -->
+
+## Verify
+
+<!-- One command, one expected output. Four of Fountain's existing service
+     pages already end this way; the template makes it universal. Non-optional:
+     an entry with no verification step cannot tell a reader they are done. -->
+
+## How the contract maps
+
+<!-- Sandbox providers only. The existing e2b.md, daytona.md and runners.md all
+     have this section already and it is the best thing about them. Table of
+     contract operation against this provider's call. -->
+
+## Limits
+
+<!-- Mandatory. Titled "Limits", not "Known issues", and stated rather than
+     discovered. Three existing client pages independently invented the heading
+     "Limits, stated rather than discovered", which is evidence the section is
+     needed and evidence writers will invent it if the template omits it.
+
+     Tailscale's rule applies: concede the failure case in the same breath as
+     the feature. "Some especially cruel networks block UDP entirely" arrives
+     immediately before the relay fallback, not in an appendix. -->
+
+## Troubleshooting
+
+<!-- Symptom, cause, fix. Three entries maximum. Anything longer moves to the
+     Troubleshooting section and this becomes a link. This cap is what keeps
+     buzz.md from happening again; it reached 395 lines partly by growing an
+     operator runbook in place. -->
+
+## Related
+
+<!-- Sibling entries in the same catalog, the concept page for the capability,
+     and the reference for the protocol. -->
+```
+
+### Which sections are optional
+
+Required on every entry. Front matter, title, vendor sentence, At a glance,
+What you will need, Set it up, Verify, Limits, Related.
+
+Optional. Why you would pick this one (omit when the catalog has fewer than
+three entries), How the contract maps (sandbox providers only), Troubleshooting
+(omit when there is nothing observed, never fill it speculatively).
+
+### Cost of the fortieth entry
+
+Front matter is roughly twelve lines of fact the author already knows. At a
+glance is generated. What Fountain provides is boilerplate with a name
+substituted. Set it up reuses three of its step titles. That leaves the vendor
+sentence, Why you would pick this one, What you will need, the click path, the
+Verify command, and Limits. Call it forty lines of genuinely new writing on a
+page of about a hundred and forty.
+
+---
+
+## The catalog index page
+
+Two views over one dataset, which is Segment's arrangement. The categorized
+view answers "what should I use for X". The flat view answers "do you support
+X". Neither view answers both, and both questions are common.
+
+### `catalog/index.md`
+
+Six cards, one per sub-catalog, each showing its entry count and its three
+newest entries. Nothing else. This page exists to route, and a router that
+tries to also be a list becomes neither.
+
+### `catalog/<name>/index.md`
+
+```markdown
+# <Catalog name>
+
+<One sentence saying what an entry in this catalog is.>
+
+<!-- Do this literally. "A sandbox provider is a backend that Fountain
+     provisions computers on." Without it, a reader cannot tell why
+     self-hosted runners are in this list and Sprites' transport reference is
+     not. -->
+
+<Two sentences on how to choose, linking the concept page.>
+
+## All <n> <things>
+
+<!-- The flat view, first, always. Table sorted by name, generated entirely
+     from front matter. -->
+
+| Name | Status | Protocol | Env vars | Capabilities |
+|---|---|---|---|---|
+
+<!-- Enough per row to decide without clicking. Segment's badges are in the
+     name text for the same reason. -->
+
+## By category
+
+<!-- The categorized view, second. Entries cross-list, so an entry appears
+     under every category in its front matter, not under one home.
+     Segment cross-lists at an average of about two categories per
+     destination, and it is necessary well before their scale, because vendors
+     do not respect your taxonomy. -->
+
+### <Category>
+
+- **<Name>** `<status>`. <the vendor sentence, truncated>
+
+## Not here yet
+
+<!-- What the catalog deliberately excludes, and how to request or contribute
+     one. Links to guides/contribute/write-a-catalog-entry.md.
+
+     This section is why an empty-ish catalog is honest rather than
+     embarrassing, and diataxis.fr/how-to-use-diataxis/ warns against shipping
+     empty structures. Never ship an index with fewer than three entries. -->
+```
+
+---
+
+## When search and filtering become necessary
+
+The threshold is not a raw count, it is two structural events. Both are
+observable in the source.
+
+**Filtering becomes necessary when a single category's list stops fitting on
+one screen.** That is about 25 entries in one category. Below it, the browser's
+own find is faster than any widget you can build. Above it, the reader is
+scrolling a list they cannot see the shape of, and the categorized view has
+stopped doing its job.
+
+**Search over entry metadata becomes necessary when the total exceeds about
+40.** Below 40 the flat table is one long screen and site-wide search is
+adequate. Above it, readers stop arriving with a name and start arriving with a
+requirement, and full-text search over prose answers the wrong question. What
+they need is a query against `capabilities`, `protocol` and `status`, which is
+why those are front matter fields rather than sentences.
+
+**Cross-listing becomes necessary before either.** At about 15 entries the
+first entry appears that legitimately belongs in two categories, and filing it
+in one is a lie. Segment's ~495 destinations across ~45 categories with ~1021
+listings is the mature version of a problem that starts small.
+
+### Where each Fountain catalog lands
+
+| Catalog | Entries now | Needs cross-listing | Needs filtering | Needs search |
+|---|---|---|---|---|
+| Sandbox providers | 4 | no | no | no |
+| Clients | 7 | at ~15 | no | no |
+| Services | 4 | no | no | no |
+| Runtimes | 4 | no | no | no |
+| MCP servers | 0 | immediately | at ~25 in one category | at ~40 |
+| Skills | 2 | immediately | at ~25 in one category | at ~40 |
+
+So four of six catalogs never need any of it, and the two that do are the two
+that do not exist yet. Build them with front matter from entry one, and the
+filtering is a rendering change rather than a migration.
+
+### One thing Fountain already has and does not use
+
+`GET /api/catalog` returns runtimes, model suggestions per runtime, sandbox
+providers, package managers, avatar bases and moods, and app URLs. Fountain
+already publishes a machine-readable catalog and no human-readable one. The
+index pages above should render from the same source wherever the data
+overlaps, so the two cannot disagree, which is the argument
+`diataxis.fr/reference/` makes for generated reference.
+
+MkDocs Material with `plugins: [search]` is already configured in
+`mkdocs.yml`, so site-wide search exists today. The gap is catalog-scoped
+filtering, and nothing above needs building until the MCP-server catalog passes
+25 entries in a category.

--- a/docs-redesign/06-voice-and-style.md
+++ b/docs-redesign/06-voice-and-style.md
@@ -1,0 +1,249 @@
+# Deliverable 4: voice and style
+
+One page. Every rule is enforceable by a reader with the text in front of them,
+and most are enforceable by CI.
+
+## The register, chosen deliberately
+
+Fly.io and Modal sit at opposite ends of a range and both work.
+`fly.io/docs/machines/overview/` contains "you don't need to be picky!", "in a
+fiddly way", and a numbered list whose step 3 ends "if you want to do that,
+GOTO 2". `modal.com/docs/guide` is terse and claim-then-stop with one joke per
+page.
+
+**Take Modal's calibration and Tailscale's honesty. Reject Fly's register.**
+The reason is not taste. Fountain's audience is infrastructure-literate
+developers with no prior model for a managed agent control plane, and the
+jokes cost reading budget the reader needs for the model. Fly can afford them
+because every reader already knows what a VM is.
+
+**Take Fly's split, which is the part that matters.** Voice lives in
+explanation only. Reference gets none. Fly's own site proves the split works,
+because `/docs/machines/overview/` and `/docs/flyctl/machine-run/` are written
+by the same organisation in two registers and both are correct.
+
+| Mode | Register |
+|---|---|
+| Tutorial | First person plural, warm, confident. "We will create an agent." |
+| How-to | Second person, imperative, no adjectives. "Set `SPRITES_TOKEN`." |
+| Reference | No person. Declarative statements about the machinery. |
+| Explanation | First person plural, allowed opinion, signed and dated. |
+
+---
+
+## The three named rules
+
+### 1. No em dashes
+
+Not `—`, not `–`, not ` - ` used as one.
+
+The current docs contain **682 em dashes across 32 of 34 files**. `api.md` has
+61, `architecture.md` 32, `primitives.md` 12.
+
+The reason is not typographic preference. An em dash is a hinge that lets a
+sentence continue after it has finished, and it is where Fountain's explanation
+has been hiding. `primitives.md` reads "`runtime` — one of `claude`, `codex`,
+`gemini`, `opencode`", where the dash stands in for a verb nobody chose.
+Removing the dash forces the choice, and the choice is usually a table cell or
+a new sentence.
+
+Replace with one of four things.
+
+| Was | Becomes |
+|---|---|
+| A definition after a term | A table row, or a colon-free sentence |
+| A parenthetical aside | Parentheses, or a separate sentence |
+| A pause before a conclusion | A full stop |
+| A list gloss | A sub-bullet |
+
+Before.
+
+> The system prompt is written into the runtime's user-level instructions file
+> on the agent's computer at provision and again at every reattach
+> (`~/.claude/CLAUDE.md`, ...) — so an edit reaches an existing computer the
+> next time it wakes
+
+After.
+
+> The system prompt is written into the runtime's user-level instructions file
+> at provision and again at every reattach. An edit therefore reaches an
+> existing computer the next time it wakes.
+
+CI check. `grep -n '—\|–' docs/` returns nothing.
+
+### 2. Colons do not introduce lists
+
+The list's lead-in ends with a full stop.
+
+The current docs use colon-introduced lists as the default construction. 19 in
+`primitives.md`, 12 in `api.md`, 10 in `cli.md`, 8 in `architecture.md`.
+
+The reason is that a colon makes the lead-in a fragment, and a fragment cannot
+be wrong. "An Environment is a named, reusable baseline for a coding agent:"
+asserts nothing that can be checked. Ending it with a full stop forces a
+complete claim, and the claim is then either true or false against the code.
+
+Before.
+
+> An **Environment** is a named, reusable baseline for a coding agent:
+>
+> - Encrypted secrets ...
+> - Plain env vars ...
+
+After.
+
+> An Environment holds four kinds of thing.
+>
+> - Encrypted secrets ...
+> - Plain env vars ...
+
+The count in the lead-in is a free correctness check. If the list grows to five
+and the sentence still says four, the diff is visibly wrong.
+
+Colons remain correct in three places. Inside code, in YAML and JSON, and after
+a label in a definition list or admonition title.
+
+CI check. No line matching `:$` immediately followed by a line starting `- ` or
+`1. ` or `|`, outside fenced blocks.
+
+### 3. A sentence states a claim and stops
+
+No trailing explanatory clause. If the explanation matters, it is the next
+sentence. If it does not matter, it is deleted.
+
+This is the rule that actually changes the docs, and it is the one the other
+two exist to enforce, because em dashes and colons are how trailing clauses
+attach.
+
+Before, from `primitives.md`, one 60-word sentence.
+
+> A provider outside that set is rejected at write time: there is no credential
+> for it, so the sandbox would have started with no inference key at all. The
+> model id itself is *not* checked against a list — the agent form suggests
+> current models, but anything you type is passed to the CLI as-is, so a model
+> released since your Fountain version still works.
+
+After, five sentences, same facts, no dashes, no colons.
+
+> A provider outside that set is rejected at write time. Fountain holds no
+> credential for it, so the sandbox would start with no inference key.
+>
+> The model id itself is not checked against a list. The agent form suggests
+> current models, and anything you type is passed to the CLI unchanged. A model
+> released after your Fountain version still works.
+
+Three consequences worth naming, because writers resist this rule.
+
+- Sentences get shorter and the paragraph gets longer. That is the trade, and
+  it is the right one for a reader building a model.
+- Causal words move to the front of their own sentence. "so", "because" and
+  "which means" start sentences now.
+- Some clauses turn out to have been carrying nothing. Delete those.
+
+Diátaxis makes the same point from the other end. `diataxis.fr/reference/`
+calls neutral description "the hardest thing to do" precisely because
+explaining and opining are the natural way to write, and a trailing clause is
+where both leak in.
+
+---
+
+## Rules that follow from the templates
+
+**Verb-first how-to titles.** "Rotate the master secrets key", never "Key
+rotation" and never "Rotating keys". `diataxis.fr/how-to-guides/` grades the
+three forms explicitly and the bare noun phrase is "very bad".
+
+**Explanation titles take an implicit "about".** "Where a secret comes from",
+"Why you bring your own inference credentials". Never a verb.
+
+**Reference titles are identifiers.** "Conversation states", not
+"Understanding conversation states".
+
+**State the mode in the first two sentences and link the twin.** Modal's
+`modal.com/docs/guide/sandbox` does it in two sentences and it is the cheapest
+structural fix available.
+
+**State defaults with their override in the same place.** Value, unit,
+ceiling, exact parameter. Modal's version is "a default maximum lifetime of 5
+minutes. You can change this by passing a timeout of up to 24 hours to the
+`Sandbox.create(...)` function."
+
+**Paste real output, including ids.** Fly pastes a real machine id and a raw
+IPv6 address in `/docs/machines/overview/`. Invented output teaches readers to
+distrust output.
+
+**Concede the failure case in the same breath as the feature.** Tailscale
+introduces its relay fallback immediately after admitting "some especially
+cruel networks block UDP entirely".
+
+**Never describe unbuilt behavior as existing.** Already the repo's rule in
+`CLAUDE.md`, and currently violated by the "MCP server (coming soon)" config
+block on `llm-integration.md`.
+
+---
+
+## Terminology, fixed
+
+Fountain overloads five terms. Pick one meaning each, use it everywhere, and
+put the collisions in `reference/glossary.md`.
+
+| Term | Means, in docs | Never means |
+|---|---|---|
+| Environment | the primitive | a deployment tier, or a map of env vars |
+| environment variables | the values in a process | the Environment primitive |
+| deployment | dev, staging, production | anything else |
+| Agent | the primitive, the stored config | the running process |
+| runtime | the coding-agent CLI (`claude`, `codex`, `gemini`, `opencode`) | |
+| Conversation | the primitive, one run | the transcript |
+| sandbox | the isolated machine a conversation runs in | |
+| computer | nothing. Do not use it | the sandbox |
+| Sprites, E2B, Daytona, runner | the four sandbox providers by name | a generic sandbox |
+| Fountain | the product | the CLI binary, or the injected skill |
+| `fountain` | the CLI binary, always in code font | |
+| the `fountain` skill | the skill injected into every sandbox, always with "skill" | |
+
+"Computer" is currently used throughout the team documentation for the sandbox
+and is defined nowhere. It is a friendly word in a product surface and a
+liability in reference. Delete it from docs and keep it in the UI if it earns
+its place there.
+
+## The Vault rule
+
+Because of HashiCorp, the word "vault" carries a prior that inverts Fountain's
+meaning. `developer.hashicorp.com/vault/docs/what-is-vault` establishes Vault
+as the singular, central, authoritative store of dynamic leased credentials.
+Fountain's Vault is a plural, small, static override layer that wins over the
+Environment.
+
+**Every page that introduces a Fountain Vault for the first time states the
+collision before it states the feature.** The wording is worked in deliverable
+5. Never write "Vault" unqualified in a heading where a newcomer meets it
+first.
+
+---
+
+## What CI can enforce today
+
+A `scripts/docs-style.sh` running on `docs/**/*.md`, outside fenced blocks.
+
+1. No `—` or `–`.
+2. No line ending in `:` immediately followed by a list item.
+3. No sentence longer than 40 words. A warning, not a failure. It catches the
+   trailing-clause rule without trying to parse grammar.
+4. Every `docs/**/*.md` has a `mode:` key in its front matter, one of
+   `tutorial`, `how-to`, `reference`, `explanation`, `hub`, `catalog-entry`.
+5. Every page whose `mode:` is `catalog-entry` carries the full front matter
+   set from deliverable 3.
+6. Forbidden word list. "computer" outside code, "simply", "just", "easy",
+   "obviously", "coming soon".
+
+Rules 1, 2 and 6 are grep. Rule 4 is what makes the whole redesign hold,
+because a page that declares its mode can be audited against its template by
+anyone, including a reviewer who has never read Diátaxis.
+
+## What this style sheet does not claim
+
+Diátaxis is explicit in `diataxis.fr/quality/` that it addresses deep quality
+and cannot deliver functional quality. Accuracy, completeness and consistency
+come from the craft, not from the rules above. These rules make bad writing
+visible. They do not make writing good.

--- a/docs-redesign/07-primitives-rewrite.md
+++ b/docs-redesign/07-primitives-rewrite.md
@@ -1,0 +1,401 @@
+# Deliverable 5: `primitives.md` rewritten end to end
+
+Worked example. The before is `docs/primitives.md` at `b4e3314`, 178 lines. The
+after is `concepts/index.md` plus four children, and this document gives two of
+them in full, the hub and `concepts/vault.md`. Vault is included because the
+hub alone cannot demonstrate the HashiCorp collision, which is the single
+largest comprehension risk in Fountain's vocabulary.
+
+Every structural decision is numbered and traced at the end.
+
+---
+
+## Before, as a section map
+
+The full text is at `docs/primitives.md`. What matters is the job mix.
+
+| Section | Lines | Modes present |
+|---|---|---|
+| Environment | 27 | reference, explanation, example |
+| Vault | 21 | explanation, reference, how-to |
+| Agent | 43 | reference, plus 9 lines of buried explanation |
+| Conversation | 21 | how-to (a 5-step API sequence), explanation |
+| Status lifecycle | 9 | reference |
+| The team: agents as teammates | 41 | explanation, how-to, reference |
+| Substitution | 10 | reference |
+
+Four of seven sections do three jobs. The team section is 23% of a page about
+primitives and is about a different application. The page contains 12 em
+dashes and 19 colon-introduced lists.
+
+The specific damage, in the terms of the working note. The page has inherited
+the weakest stopping condition it contains, so nobody can tell when it is
+finished. A contributor adding a fifth conversation status cannot tell whether
+they owe one edit or three.
+
+---
+
+## After, page 1 of 5
+
+### `docs/concepts/index.md`
+
+```markdown
+---
+mode: explanation
+title: The four primitives
+---
+
+# The four primitives
+
+This page explains what Fountain's four objects are and why there are four of
+them. For the fields on each one, see the [API reference](../api.md). For
+building something with them, start with
+[An agent that opens a pull request](../tutorials/first-agent.md).
+
+## The problem the four primitives divide up
+
+To run a coding agent on a machine that is not yours, four things have to be
+decided, and they change on four different schedules.
+
+What the machine has on it changes rarely. Python 3.12, a checkout of your
+repo, a setup script. You decide it once for a team and leave it alone.
+
+Which credentials the agent runs with changes constantly. A staging database
+URL today, a customer's API key tomorrow, a rotated token an hour from now.
+
+How the agent behaves changes occasionally. Which model, which runtime, which
+skills, which MCP servers, what its system prompt says.
+
+What it is doing right now changes every few seconds.
+
+Put all four in one object and every credential rotation edits the machine
+image, and every prompt edits the credentials. Fountain splits them into four
+objects on purpose, and the split is the product.
+
+| Primitive | Answers | Changes |
+|---|---|---|
+| [Environment](environment.md) | what is on the machine | rarely |
+| [Vault](vault.md) | which credentials this run uses | constantly |
+| [Agent](agent.md) | how the agent behaves | occasionally |
+| [Conversation](conversation.md) | what it is doing right now | continuously |
+
+## How they compose
+
+An Agent names an Environment. A Conversation runs an Agent, and may name a
+different Environment and attach a Vault for that run alone.
+
+```
+Environment  ──▶  Agent  ──▶  Conversation
+     ▲                             │
+     └── overridden per run ───────┤
+                                   │
+Vault ──────── attached per run ───┘
+```
+
+At the moment a Conversation starts, Fountain merges the Environment's secrets
+with the Vault's secrets and hands the result to the sandbox as environment
+variables. **The Vault wins on key collision.** That one rule is why the split
+into four is usable rather than merely tidy, and it is explained in
+[About vaults](vault.md).
+
+## What Fountain does not have
+
+There is no fifth primitive, and two things that look like one are not.
+
+A **team** is not an object. A teammate is a Conversation bound to the reserved
+channel `fountain:team`. See [Agents as teammates](teammates.md).
+
+A **sandbox** is not an object you create. It is provisioned when a
+Conversation starts and reclaimed when it ends. See
+[About sandboxes](sandboxes.md).
+
+## Where to go next
+
+- Learn by doing.
+  [An agent that opens a pull request](../tutorials/first-agent.md) is a
+  tutorial that uses all four in about fifteen minutes.
+- Understand one primitive.
+  [Environment](environment.md), [Vault](vault.md), [Agent](agent.md),
+  [Conversation](conversation.md).
+- Understand the machinery.
+  [How a conversation runs](how-a-conversation-runs.md) follows a prompt from
+  the API call to the first token.
+- Look something up. The [API reference](../api.md) has every field, and
+  [Conversation states](../reference/conversation-states.md) has the state
+  table.
+
+---
+*Written 2026-08-21 against Fountain 0.12.0.*
+```
+
+---
+
+## After, page 2 of 5
+
+### `docs/concepts/vault.md`
+
+```markdown
+---
+mode: explanation
+title: About vaults
+---
+
+# About vaults
+
+This page explains what a Fountain Vault is, why it exists, and why it is not
+the thing its name suggests. To attach one to a run, see
+[Override credentials with a vault](../guides/override-credentials-with-a-vault.md).
+For fields, see the [API reference](../api.md#vaults).
+
+## If you have used HashiCorp Vault, read this first
+
+The names collide and the meanings are close to opposite. Getting this
+backwards produces exactly the wrong model of how credentials reach a sandbox.
+
+| HashiCorp Vault | Fountain Vault |
+|---|---|
+| One central server you deploy, cluster and unseal | A small record in Fountain's database. You make as many as you like |
+| The authoritative store. If it is in Vault, it is true | A patch layer. The Environment is the baseline and the Vault overrides it |
+| Issues dynamic, leased, revocable credentials | Holds static values you wrote. No leases, no rotation, no revocation |
+| Sealed until an operator unseals it | No state. There is nothing to unseal |
+| Path mounts, per-path policy | A flat key and value bag, scoped to your tenant |
+| Precedence is not a concept | Precedence is the entire point |
+
+One thing does carry over. Both encrypt with an envelope. HashiCorp goes unseal
+key, then root key, then keyring, then data. Fountain goes `MASTER_SECRETS_KEY`,
+then a per-tenant data encryption key, then the value. If you understood
+theirs, you understand [ours](secrets.md).
+
+## What a vault is
+
+A Vault is a named bag of environment variables that layers over an
+Environment for one run.
+
+It is free-floating. It belongs to no Agent and no Environment, it can be
+attached to any conversation your Agent's `allowed_vault_ids` permits, and the
+same Vault can be attached to conversations of different Agents at the same
+time.
+
+## Why it exists
+
+Without vaults, changing one credential means editing the Environment, and the
+Environment is shared. Three consequences follow, and all three are things
+teams actually do.
+
+Running the same Agent against staging and production would need two
+Environments that are identical except for one URL, and they would drift.
+
+Giving a contractor's agent a scoped token would mean either widening the
+shared Environment or cloning it.
+
+Rotating one key would touch every agent using that Environment, whether or not
+they use the key.
+
+A Vault makes each of those a one-line attachment on a single run, and leaves
+the Environment alone.
+
+## The merge rule
+
+When a Conversation starts, Fountain builds the environment variable set in one
+direction.
+
+```
+environment secrets  ──merge──▶  vault secrets  ──▶  the sandbox
+                                      ▲
+                              wins on collision
+```
+
+The Vault wins. If the Environment sets `DATABASE_URL` and the attached Vault
+also sets `DATABASE_URL`, the process sees the Vault's value.
+
+The merge happens once, at spawn. Editing a Vault does not reach a running
+sandbox.
+
+Keys that only the Environment sets survive. A Vault is a patch and not a
+replacement.
+
+## What a vault is not
+
+**Not rotation.** A value you put in a Vault stays there until you change it.
+Fountain does not expire it, does not renew it, and does not tell the agent it
+went stale.
+
+**Not revocation.** Removing a Vault from an Agent's `allowed_vault_ids` stops
+future conversations attaching it. A sandbox that is already running keeps the
+value it was given, because the value is in a process's environment on a
+machine.
+
+**Not a read audit.** Fountain audits the mutation when a secret is written, by
+key and by size. It does not record that an agent read one, because the read
+happens inside the sandbox.
+
+**Not returnable.** Values are write-only. Listing a Vault returns keys and
+timestamps. There is no endpoint that gives you a value back, including for
+you, including as the owner.
+
+## When to use something else
+
+Use an **Environment** for anything the whole team shares that is not a
+credential. Feature flags, endpoints and package versions belong in
+`env_vars`, which is returned by the API as written.
+
+Use **inference credentials** for model API keys. Those are per-user, entered
+at `/account/inference-credentials`, and never go in a Vault. See
+[Why you bring your own inference credentials](inference-credentials.md).
+
+Use **nothing** when the value is not secret and not per-run. A Vault holding
+one non-secret is a Vault someone will later assume is secret.
+
+## What we chose not to do
+
+We considered per-key precedence, so a specific Environment key could refuse to
+be overridden. We rejected it. A merge rule that holds always is worth more
+than a merge rule that is more expressive, because the reader has to hold it in
+their head at the moment they are debugging a wrong credential, which is
+usually at a bad time.
+
+We also considered making the Vault the baseline and the Environment the
+override, which would have matched the HashiCorp prior. We rejected it because
+the thing that changes rarely should be the base.
+
+## Where to go next
+
+- [Override credentials with a vault](../guides/override-credentials-with-a-vault.md),
+  a how-to.
+- [Where a secret comes from](secrets.md), the full chain from
+  `MASTER_SECRETS_KEY` to the process.
+- [About environments](environment.md), the other half of the merge.
+- [API reference](../api.md#vaults), every field.
+
+---
+*Written 2026-08-21 against Fountain 0.12.0.*
+```
+
+---
+
+## Pages 3 to 5, and what left the page
+
+`concepts/environment.md`, `concepts/agent.md` and `concepts/conversation.md`
+follow the same template and are not reproduced here. What matters for the
+audit is that nothing was lost. Every line of the old page has a destination.
+
+| Old content | Went to | Because |
+|---|---|---|
+| Environment field bullets | `api.md`, existing Environments section | Reference belongs in reference |
+| Environment networking semantics | `concepts/environment.md`, "How it works" | Explanation |
+| Environment YAML example | `concepts/environment.md`, one example | Illustration is licensed in explanation |
+| Vault merge rule | `concepts/vault.md`, "The merge rule" | The most important sentence on the page, promoted to a heading |
+| Vault "Typical uses" | `guides/override-credentials-with-a-vault.md` | It was a how-to in three words |
+| Agent field bullets | `api.md` | Reference |
+| The 9-line `model` argument | `concepts/agent.md`, "Why the provider is checked and the model id is not" | Findable under a question, not a field name |
+| Agent skills bullet | `concepts/agent.md` plus `catalog/skills/` | The bundled `fountain` and `create-team` skills get pages |
+| Agent `mcp_servers` bullet | `concepts/agent.md` plus `catalog/mcp-servers/` | Same |
+| Conversation 5-step sequence | `guides/interrupt-resume-end.md` and the tutorial | It was a how-to inside an explanation |
+| Suspend and destroy admonition | `concepts/conversation.md`, "How it works" | Explanation, expanded to Modal's per-state depth |
+| `SANDBOX_IDLE_TIMEOUT_MINUTES`, `SANDBOX_MAX_LIFETIME_HOURS` | `configuration.md` | Reference |
+| Status lifecycle diagram | `reference/conversation-states.md` | Its own page, with a row per state |
+| "The team", 41 lines | `concepts/teammates.md` and `guides/schedule-a-teammate.md` | Explanation and how-to, separated |
+| Substitution table | `api.md` plus `concepts/secrets.md` | Reference, with the chain explained once |
+
+---
+
+## Every structural decision, traced
+
+**1. The hub opens with the reader's problem, not a definition.**
+`tailscale.com/blog/how-tailscale-works` builds hub-and-spoke, steelmans it,
+then enumerates what breaks, and never uses an adjective to sell. The four
+paragraphs about change rates are Fountain's version. The old page opened
+"Everything in Fountain is built from four concepts", which asserts the
+conclusion and skips the argument.
+
+**2. The four primitives are motivated by four different change rates, and by
+what breaks if you merge them.** This is Temporal's justify-by-failure, from
+`docs.temporal.io/activities.md`, where the primitive is motivated by naming
+what fails without it. Also Stripe's, where three of the four Payment Intents
+advantages at `docs.stripe.com/payments/payment-intents` are avoided failures.
+The old page listed features.
+
+**3. The comparison table has a "Changes" column.** That column is the
+argument, compressed. `diataxis.fr/explanation/` says explanation "joins things
+together"; a table whose only columns are name and definition joins nothing.
+
+**4. The composition diagram is on the hub and nowhere else.** Fly.io's
+`fly.io/docs/machines/` is a three-item hub whose job is entirely to route, and
+`/docs/machines/overview/` does the explaining. Splitting hub from explanation
+is what stops the hub growing to 178 lines again.
+
+**5. "What Fountain does not have" is a required section.** Temporal, Modal and
+Fly all independently carry a negative boundary. Temporal, "If you only want to
+execute one Activity Function, then you don't need to use a Workflow." Modal,
+routing readers to Functions. Fly, "For most applications, most of the time,
+you don't need to be picky!" Fountain needs it more than any of them, because
+"is a team a fifth primitive" is a real question the old page half-answered in
+its 41-line team section.
+
+**6. "Where to go next" labels the mode of each link.**
+`docs.temporal.io/temporal.md` ends with five Next steps that route to a
+tutorial, a how-to and two explanations, and say which is which. The old page
+had no exits at all, which is why `tour.md` went unlinked.
+
+**7. Vault opens with the HashiCorp collision, before the definition.**
+`developer.hashicorp.com/vault/docs/what-is-vault` and
+`/vault/docs/concepts/seal` establish a prior that is not merely different from
+Fountain's but inverted on the one fact that matters, which is which layer is
+authoritative. Temporal's noun-disambiguation move at
+`docs.temporal.io/workflows.md` ("the term Workflow might refer to Workflow
+Type, a Workflow Definition, or a Workflow Execution") is the same instinct
+applied to an internal collision. Fountain's collision is external and worse.
+
+**8. The collision table ends by naming what does transfer.** Both products
+use envelope encryption in the same shape. Saying "no, not like Vault" six
+times and then "yes, exactly like Vault" once gives the reader something to
+keep, and it is the same move Tailscale makes when it credits `wireguard-go` by
+exact variant instead of claiming the mechanism.
+
+**9. "The merge rule" is its own H2 with a diagram.** It was the fourth
+sentence of a 21-line section, introduced by a colon. It is the one fact a
+reader must have to use vaults at all.
+
+**10. "What a vault is not" enumerates four negatives, each stating the
+mechanism.** Modal's Finished state at `modal.com/docs/guide/sandbox`
+enumerates all five ways a sandbox can stop rather than saying "for various
+reasons". The revocation entry here does the same thing, explaining that a
+running sandbox keeps its value because the value is already in a process's
+environment. The audit found that a HashiCorp reader will silently assume
+rotation and revocation, and no current page denies it.
+
+**11. "What we chose not to do" is present.** `diataxis.fr/explanation/` is the
+only mode that admits opinion and says explanation "must consider alternatives,
+counter-examples or multiple different approaches". Fountain writes ADRs
+already, so the reasoning exists; this section is where it becomes readable.
+
+**12. The page is dated and stamped with a version.**
+`tailscale.com/blog/how-tailscale-works` carries a byline and 20 March 2020, so
+a 2020 claim reads as one. Explanation is the mode most likely to go quietly
+stale, because unlike reference nothing in CI compares it to the code.
+
+**13. Every code fence on these pages is illustration, and none is a step.**
+Stripe's rule from `docs.stripe.com/payments/payment-intents`, where four
+`curl` blocks are the same base request with exactly one parameter changed, so
+no block depends on a previous one. The old Conversation section's five
+numbered steps failed this test, which is why they left for a how-to.
+
+**14. The status lifecycle became its own reference page.** Fly gives
+`/docs/machines/machine-states/` and `/docs/volumes/volume-states/` dedicated
+URLs rather than sections inside an overview. The new page follows Modal's
+depth rather than Fly's, giving each state a row that says what exists, what
+does not exist yet, and which operations are legal, because a diagram tells you
+the edges and not what you may call.
+
+**15. The team section left entirely.**
+`diataxis.fr/explanation/`, "Keep explanation closely bounded", warns that
+explanation absorbs other things and that letting instruction creep in both
+interferes with the explanation and removes the instruction from view in its
+correct place. Forty-one lines of another application's cron feature is the
+textbook case.
+
+**16. No em dashes, no colon-introduced lists, no trailing clauses.** The old
+page has 12 and 19 of the first two. The rewrite has none. The third rule is
+what turned the `model` bullet from one 60-word sentence into five sentences
+under a findable heading, which is the whole argument for the rule in
+deliverable 4.

--- a/docs-redesign/README.md
+++ b/docs-redesign/README.md
@@ -1,0 +1,49 @@
+# Fountain docs: IA redesign and writing standards
+
+Working documents, not yet a docs PR. Nothing under `docs/` has been changed.
+
+| File | What it is |
+|---|---|
+| [00-diataxis-working-note.md](00-diataxis-working-note.md) | Phase 1. The mode test I apply to a Fountain page, and the specific failure when two modes share one |
+| [01-reference-site-study.md](01-reference-site-study.md) | Phase 2. Nine sites, named patterns with URLs, and the four places they disagree |
+| [02-audit.md](02-audit.md) | Phase 3. All 34 live pages classified, the four known gaps confirmed or refuted, six more found |
+| [03-nav-tree.md](03-nav-tree.md) | Deliverable 1. Proposed tree, every page labelled and traced, plus a nine-step merge order |
+| [04-page-templates.md](04-page-templates.md) | Deliverable 2. One markdown skeleton per mode |
+| [05-catalog-template.md](05-catalog-template.md) | Deliverable 3. Catalog entry template, index design, and the search and filtering thresholds |
+| [06-voice-and-style.md](06-voice-and-style.md) | Deliverable 4. One page, with the CI checks |
+| [07-primitives-rewrite.md](07-primitives-rewrite.md) | Deliverable 5. `primitives.md` before and after, with sixteen traced decisions |
+
+## Sources read in full
+
+Diátaxis. `/start-here/`, `/tutorials/`, `/how-to-guides/`, `/reference/`,
+`/explanation/`, `/tutorials-how-to/`, `/reference-explanation/`, `/compass/`,
+`/map/`, `/how-to-use-diataxis/`, `/quality/`, `/application/`,
+`/foundations/`.
+
+Reference sites. `docs.temporal.io` (llms.txt, temporal, workflows, activities,
+develop/typescript), `docs.stripe.com/payments/payment-intents`, `fly.io/docs`
+(nav, flyctl, machines, machines/overview, flyctl/machine-run),
+`tailscale.com/blog/how-tailscale-works`, `workos.com/docs/integrations`
+(okta-saml, azure-ad-saml), `docs.sentry.io/platforms` (javascript/react,
+python/django), `supabase.com/docs/guides/auth` (server-side/nextjs,
+quickstarts/react-native), `segment.com/docs/connections/destinations`
+(catalog, actions-slack), `modal.com/docs/guide` (guide, sandbox),
+`developer.hashicorp.com/vault/docs` (what-is-vault, concepts/seal).
+
+Fountain. All 34 pages under `docs/`, `mkdocs.yml`,
+`cli/internal/cmd/docs_test.go`, `fountain.inevitable.fyi/docs`, and
+`fountain.inevitable.fyi`.
+
+## Flagged as unverified
+
+Nothing in these documents is asserted from memory. Two things are worth
+knowing about the evidence.
+
+`diataxis.fr/complex-hierarchies/` and `diataxis.fr/needs/` both return 404.
+The content those URLs used to hold is covered by `/map/` and `/foundations/`,
+which I read instead.
+
+Segment's counts (1021 listings, 495 distinct names, roughly 45 categories) are
+mine, computed from the rendered catalog index text. They are the right order
+of magnitude rather than Segment's official figure, which is not published on
+that page.

--- a/docs/api.md
+++ b/docs/api.md
@@ -369,7 +369,7 @@ prompt only until the one-time backfill runs on the server:
 
 ## Team
 
-The roster [`/team`](primitives.md#the-team-agents-as-teammates) shows, for
+The roster [`/team`](concepts/teammates.md) shows, for
 clients that are not this web app. A teammate is a conversation bound to the
 reserved channel `fountain:team`; every route here wraps the same
 `Fountain.Team` the page uses, so a standalone client gets the page's exact

--- a/docs/build/team-chat.md
+++ b/docs/build/team-chat.md
@@ -31,7 +31,7 @@ allow your origin (`API_CORS_ORIGINS`). See [shipping it](#10-shipping-it).
 
 The **+** in these apps asks nothing. A name from a list, a sensible brain, a
 one-line brief, and the roster has a new row a second later. Two calls do it:
-one to define an [agent](../primitives.md#agent), one to put that agent on the
+one to define an [agent](../concepts/agent.md), one to put that agent on the
 team.
 
 ```ts
@@ -102,7 +102,7 @@ One call fills a roster row completely, with nothing assembled from three
 endpoints and a guess. Behind the label, `presence.state` is an enum:
 `working`, `starting`, `online`, `asleep`, `away`, `machine_offline`, `failed`
 and `offline`. A teammate reads as `asleep` when its computer has been
-[parked](../primitives.md#conversation) for want of anything to do. It wakes
+[parked](../concepts/conversation.md) for want of anything to do. It wakes
 on the next message with its memory intact, so your UI need do nothing about
 it beyond saying so.
 
@@ -302,7 +302,7 @@ being a mere convenience. A connector is an MCP server the teammate's runtime
 talks to, and it usually needs a real credential.
 
 The credential does not go in the agent config. It goes in the teammate's
-[environment](../primitives.md#environment) as a secret, and the server
+[environment](../concepts/environment.md) as a secret, and the server
 definition refers to it by name:
 
 ```ts

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -1,0 +1,131 @@
+# About agents
+
+This page explains what an Agent is and which of its fields carry decisions
+rather than settings. For every field, see the
+[API reference](../api.md).
+
+## What an agent is
+
+An Agent is a named, re-runnable configuration for a coding agent. It is
+config, not a process. Nothing runs until a [Conversation](conversation.md)
+runs it.
+
+An Agent decides seven things.
+
+- **`model`**, as `provider/model-id`, for example
+  `anthropic/claude-sonnet-4-6`.
+- **`runtime`**, one of `claude`, `codex`, `gemini` or `opencode`.
+- **`environment`**, an optional [Environment](environment.md) to provision
+  from.
+- **`system`** and **`description`**, the system prompt and a human-readable
+  summary.
+- **`skills`**, either inline or sourced from GitHub.
+- **`mcp_servers`**, MCP server definitions with `${VAR}` substitution in their
+  env.
+- **`metadata`**, a free-form map for your own bookkeeping.
+
+## Why it exists
+
+An Agent is the thing you name and hand to someone else.
+
+Without it, every run would carry its own model choice, prompt and tool
+configuration, and two people asking the same agent for the same thing would
+get different behavior. The Agent is the unit that makes a run repeatable and
+the unit a teammate is built from. See
+[agents as teammates](teammates.md).
+
+## Why the provider is checked and the model id is not
+
+This trips people up, and the asymmetry is deliberate.
+
+The provider must match the runtime. `anthropic` for `claude`, `openai` for
+`codex`, `google` for `gemini`. `opencode` is multi-provider and takes any of
+the three, using the prefix to pick which API key to export.
+
+A provider outside that set is rejected at write time. Fountain holds no
+credential for it, so a sandbox provisioned that way would start with no
+inference key at all and fail on the first turn with an error that pointed
+nowhere useful. Rejecting at write time turns a confusing runtime failure into
+a clear form error.
+
+The model id itself is not checked against a list. The agent form suggests
+current models, and whatever you type is passed to the runtime's CLI unchanged.
+A model released after your Fountain version still works. Validating the id
+would mean shipping a list that goes stale between releases, and the cost of a
+stale allowlist is worse than the cost of a typo.
+
+## How the system prompt reaches the machine
+
+The system prompt is written into the runtime's user-level instructions file on
+the agent's sandbox, at provision and again at every reattach.
+
+| Runtime | File |
+|---|---|
+| `claude` | `~/.claude/CLAUDE.md` |
+| `codex` | `~/.codex/AGENTS.md` |
+| `opencode` | `~/.config/opencode/AGENTS.md` |
+| `gemini` | `~/.gemini/GEMINI.md` |
+
+Because it is rewritten on reattach, editing an Agent's system prompt reaches
+an existing sandbox the next time that sandbox wakes. It does not reach a turn
+that is already in flight.
+
+## Skills and MCP servers
+
+Each `skills` entry is either inline or GitHub-sourced. An inline entry is
+`{name, content}` and writes a full `SKILL.md` into the sandbox. A GitHub entry
+is `{source: "owner/repo"}` and is installed with the skills.sh CLI.
+
+Two skills are bundled into every sandbox regardless of what an Agent asks
+for.
+
+- **`fountain`** gives the agent Fountain's own API, so it can spawn
+  sub-conversations.
+- **`create-team`** is a question-and-answer flow that sets up the user's team.
+  A first teammate runs it when someone answers `/create-team`.
+
+`mcp_servers` entries support `${VAR}` substitution in their `env`, resolved
+from the merged environment and vault secrets at spawn time.
+
+```yaml
+apiVersion: fountain.dev/v1
+kind: Agent
+metadata:
+  name: researcher
+spec:
+  model: anthropic/claude-sonnet-4-6
+  runtime: claude
+  environment: python-data-env
+  skills:
+    - source: BinaryBourbon/fountain-api-skill
+  mcp_servers:
+    github:
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      env:
+        GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PAT}"
+```
+
+`${GITHUB_PAT}` resolves from the merged environment and vault secrets. See
+[substitution](../api.md).
+
+## What an agent is not
+
+**Not a running process.** An Agent that has never been run has no sandbox, no
+memory and no cost.
+
+**Not a hard scope.** `allowed_environment_ids` and `allowed_vault_ids` bound
+which Environments and Vaults a launch may name. They are the Agent's own
+allowlists rather than a tenancy boundary. Tenancy is enforced separately, on
+every query.
+
+**Not the ACP sense of "agent".** In the Agent Client Protocol, "agent" means
+the process an editor spawns. See
+[`fountain acp`](../integrations/acp.md).
+
+## Where to go next
+
+- [About conversations](conversation.md), which run an Agent.
+- [Agents as teammates](teammates.md), which is one Conversation per Agent.
+- [About environments](environment.md), which an Agent names.
+- [Glossary](../reference/glossary.md), for the three senses of "agent".

--- a/docs/concepts/conversation.md
+++ b/docs/concepts/conversation.md
@@ -1,0 +1,110 @@
+# About conversations
+
+This page explains what a Conversation is and what happens to its sandbox over
+time. For the state table, see
+[Conversation states](../reference/conversation-states.md). For the endpoints,
+see the [API reference](../api.md).
+
+## What a conversation is
+
+A Conversation is one run of an [Agent](agent.md) inside a sandboxed machine.
+
+It starts with a prompt and continues over turns. It has a transcript, a stream
+of log events, and a status. It is the only primitive that costs money while it
+exists, because it is the only one with a machine attached.
+
+## Why it exists
+
+The other three primitives are configuration and could have been one object
+with three sections. The Conversation is why they are not.
+
+A Conversation is the point where the three are resolved together into a
+running machine. It picks an Agent, may override that Agent's Environment, and
+may attach a Vault, and it does all three at launch rather than at
+configuration time. That is what lets one Agent serve staging and production,
+one Environment serve twenty agents, and one Vault be borrowed by any of them.
+
+## How it works
+
+Launching a Conversation resolves the full environment variable set and asks a
+sandbox provider for a machine.
+
+```
+POST /api/conversations
+        |
+        v
+resolve agent -> environment (or the per-launch override)
+        |
+        v
+merge environment secrets with vault secrets   (vault wins)
+        |
+        v
+provision a sandbox, write skills and the system prompt
+        |
+        v
+run the turn, stream log events over SSE
+```
+
+A follow-up prompt runs another turn on the same machine. A running turn can be
+interrupted, and the whole conversation can be ended early.
+
+Log events stream in real time over
+`GET /api/conversations/:id/stream`. Add `?blocks=true` and the server does the
+runtime-dialect parsing, so a client never has to.
+
+## The sandbox does not live forever, and that is two rules
+
+Both bounds act on the sandbox. Neither ends the Conversation, which stays
+resumable either way.
+
+**Idle suspends.** After 60 minutes with no turn activity, by default, the
+sandbox is suspended. It scales to zero and costs nothing while parked. The
+next prompt wakes it with the agent's memory intact, because the runtime keeps
+its session on the sandbox's disk and a suspended sandbox keeps its disk.
+
+**A ceiling destroys.** At 24 hours of continuous running, by default, the
+sandbox is destroyed. Disk and all. The stored transcript survives and the
+conversation stays resumable, but the next turn starts a fresh runtime session,
+so the agent answers without the earlier ones. Expect to restate context after
+a ceiling reclaim.
+
+The difference matters. Suspend keeps the agent's memory. The ceiling does not.
+
+Self-hosters can widen or disable both with
+`SANDBOX_IDLE_TIMEOUT_MINUTES` and `SANDBOX_MAX_LIFETIME_HOURS`, where `0`
+disables. See the
+[configuration reference](../configuration.md).
+
+Not every sandbox provider can suspend. A provider that does not advertise the
+capability destroys on idle rather than faking a park, because resuming with a
+fresh disk would be silent loss of the agent's memory. See
+[the sandbox contract](../integrations/sandbox-contract.md).
+
+## What a conversation is not
+
+**Not the transcript.** The transcript is stored and outlives the sandbox. The
+Conversation is the run.
+
+**Not a chat session in a UI.** Fountain's own console does not render
+conversations. Watching one work happens in the
+[conversations app](https://github.com/jhgaylor/fountain-conversations),
+which is a separate application on `/api`.
+
+**Not a sandbox you manage.** You never create, name or address a sandbox. It
+is provisioned when the Conversation starts and reclaimed on the rules above.
+
+## When to use something else
+
+Use a [teammate](teammates.md) when you want one ongoing thread with an agent
+rather than a run per task. A teammate is still a Conversation, bound to a
+reserved channel.
+
+Use a schedule when the run should happen without you. See the
+[API reference](../api.md).
+
+## Where to go next
+
+- [Conversation states](../reference/conversation-states.md), the state table.
+- [Agents as teammates](teammates.md).
+- [Architecture](../architecture.md), for what runs where.
+- [The guided tour](../tour.md), which runs one end to end.

--- a/docs/concepts/environment.md
+++ b/docs/concepts/environment.md
@@ -1,0 +1,114 @@
+# About environments
+
+This page explains what an Environment is and why it is separate from the
+other three primitives. For every field, see the
+[API reference](../api.md). To bootstrap one, see the
+[guided tour](../tour.md).
+
+## What an environment is
+
+An Environment is the machine an agent wakes up on, described as data.
+
+It holds four kinds of thing.
+
+- **Encrypted secrets.** Key and value pairs, encrypted per tenant with
+  AES-256-GCM. They are write-only. Once stored, the API never returns a value,
+  and listing gives you keys and timestamps.
+- **Plain environment variables.** A non-secret `env_vars` map for values that
+  are not sensitive, such as feature flags and endpoints. The API returns these
+  as written, so anything sensitive belongs in secrets instead.
+- **Runtime config.** Packages to install, repos to clone, and a setup script
+  to run.
+- **A networking policy.** `networking_type` is `unrestricted` or `limited`.
+
+## Why it exists
+
+The contents of a machine change on a different schedule from everything else
+about an agent.
+
+Python 3.12, a checkout of your service repo and a `mise install` step are
+decided once for a team and then left alone for months. Which credentials a
+particular run uses can change hourly. Which model an agent runs is revisited
+every few weeks.
+
+If those lived in one object, rotating a token would edit the machine image and
+every agent sharing it would need a new one. Splitting them means many agents
+can share one Environment, and a single run can still deviate from it without
+anyone editing the shared thing.
+
+## How it works
+
+An Environment attaches to an Agent when the Agent is created, and that is the
+Agent's default.
+
+It is not the only choice. A Conversation may name a different
+`environment_id` at launch, scoped by the Agent's `allowed_environment_ids`. So
+the same Agent can be provisioned from a heavier image for one task and a
+minimal one for another.
+
+At spawn, the Environment's secrets are merged with any attached Vault's
+secrets, and the result becomes the process environment inside the sandbox.
+The Vault wins on key collision. See [About vaults](vault.md).
+
+```yaml
+apiVersion: fountain.dev/v1
+kind: Environment
+metadata:
+  name: python-data-env
+spec:
+  packages:
+    python: "3.12"
+  networking_type: limited
+  secrets:
+    - key: OPENAI_API_KEY
+      value: sk-...
+```
+
+### The networking policy is not symmetric
+
+`unrestricted` is a no-op. Sprites sandboxes are open by default, so setting it
+changes nothing.
+
+`limited` restricts egress to the domains in
+`networking_config.allowed_hosts`, which is the only `networking_config` key
+honored today.
+
+Under `limited` with no `allowed_hosts`, nothing is allowlisted. That is
+deny-all, and it is deliberate rather than a bug. An empty allowlist that
+silently meant "allow everything" would be the worst possible default for a
+policy whose purpose is restriction.
+
+## What an environment is not
+
+**Not a deployment tier.** "Environment" in Fountain never means dev, staging
+or production. Those are things you might build with Environments and Vaults,
+not something Fountain models.
+
+**Not a container image.** Fountain does not build or store images. An
+Environment is a recipe the sandbox provider applies at provision time, so two
+conversations from the same Environment install their packages independently.
+
+**Not a secret store you can read.** Values go in and never come out. If you
+need to know what a secret is, you need the source you got it from, not
+Fountain.
+
+## When to use something else
+
+Use a [Vault](vault.md) when the value changes per run, per customer or per
+credential rotation.
+
+Use `env_vars` rather than `secrets` when the value is not sensitive. The API
+returns `env_vars` as written, and a non-secret filed as a secret is a value
+nobody can ever read back to check.
+
+Use [inference credentials](../integrations/index.md) for model API keys.
+Those are per-user and are never set by an operator or stored in an
+Environment.
+
+## Where to go next
+
+- [About vaults](vault.md), the other half of the merge.
+- [About agents](agent.md), which names an Environment.
+- [The guided tour](../tour.md), which builds one in its first step.
+- [Configuration reference](../configuration.md), for the instance-level
+  sandbox settings.

--- a/docs/concepts/teammates.md
+++ b/docs/concepts/teammates.md
@@ -1,0 +1,99 @@
+# Agents as teammates
+
+This page explains what a teammate is and why it is not a fifth primitive. For
+the endpoints, see the [API reference](../api.md).
+
+## What a teammate is
+
+A teammate is an [Agent](agent.md) with one ongoing
+[Conversation](conversation.md), bound to the reserved channel
+`fountain:team`.
+
+That is the whole mechanism. There is no team table and no teammate record. The
+binding is the same one a Buzz channel uses through `channel_id`, pointed at a
+reserved name.
+
+The [team app](https://github.com/jhgaylor/fountain-team) lays those
+conversations out like a messaging app, with the roster on the left and one
+thread on the right, on `/api/team`.
+
+## Why it works this way
+
+A teammate needs exactly the properties a Conversation already has.
+
+It needs to persist across messages, which a Conversation does. It needs a
+machine that remembers what it did, which a suspended sandbox keeps on disk. It
+needs to survive being idle overnight and wake on the next message, which
+suspend and resume already do.
+
+Adding a fifth primitive would have meant a second lifecycle to keep correct,
+and every sandbox reclamation rule would have needed a teammate variant.
+Binding a Conversation to a channel needed none of that.
+
+## How it behaves
+
+Adding an Agent to the team opens its conversation, which provisions the
+sandbox.
+
+A message is a follow-up turn on that conversation. A suspended or reclaimed
+sandbox wakes on the next message as usual.
+
+A terminated conversation is replaced by a fresh one under the same binding, so
+the teammate stays reachable. Removing a teammate terminates the live
+conversation and unbinds the Agent's conversations from the channel. The rows
+stay in the ordinary conversation list.
+
+"Details" on a thread opens the full transcript in the
+[conversations app](https://github.com/jhgaylor/fountain-conversations),
+with stages, tool calls and raw output.
+
+## Three fields that look new and are not
+
+When you add a teammate you can give it a name of its own, pick the Environment
+its sandbox is built from, and attach a Vault.
+
+None of that is new. They are the conversation's `title`, its per-launch
+environment override, and its `vault_id`. The pickers only offer what the
+Agent's `allowed_environment_ids` and `allowed_vault_ids` allow.
+
+They belong to the teammate rather than to the sandbox. A fresh conversation
+opened after the old one is terminated inherits all three.
+
+## Schedules
+
+A schedule is a cron that runs a teammate with a prompt. Cron times are UTC.
+
+By default the prompt goes into the teammate's own conversation, as if you had
+typed it, so the reply lands in the thread and in the teammate's working
+memory.
+
+Ticking **Run in a one-off computer** changes that. Each run opens a fresh
+conversation on a new sandbox, using the same Agent, Environment and Vault the
+teammate was added with, and leaves the thread alone. The run appears in the
+conversation list like any other, and the schedule keeps a link to its last
+one.
+
+A schedule can be paused, edited, run on demand and deleted. If a run could not
+be delivered, because the teammate was busy for half an hour or the sandbox
+quota was full, the last error shows on the schedule.
+
+Removing a teammate deletes its schedules.
+
+## What a teammate is not
+
+**Not a primitive.** Nothing in the API creates a teammate. You bind a
+conversation to a channel.
+
+**Not a shared inbox.** One Agent has one team conversation. Two people
+messaging the same teammate are talking to the same thread and the same
+machine.
+
+**Not persistent memory.** The teammate's memory is the sandbox's disk. A
+sandbox destroyed at the max-lifetime ceiling takes it, and the thread survives
+without it. See [About conversations](conversation.md).
+
+## Where to go next
+
+- [About conversations](conversation.md), for the lifecycle underneath.
+- [About agents](agent.md).
+- [API reference](../api.md), for the team endpoints and schedules.

--- a/docs/concepts/vault.md
+++ b/docs/concepts/vault.md
@@ -1,0 +1,134 @@
+# About vaults
+
+This page explains what a Fountain Vault is, why it exists, and why it is not
+the thing its name suggests. For every field, see the
+[API reference](../api.md). For the commands, see the
+[CLI reference](../cli.md).
+
+## If you have used HashiCorp Vault, read this first
+
+The names collide and the meanings are close to opposite. Getting this
+backwards produces exactly the wrong model of how a credential reaches a
+sandbox, so it is worth thirty seconds.
+
+| HashiCorp Vault | Fountain Vault |
+|---|---|
+| One central server you deploy, cluster and unseal | A small record in Fountain's database. Make as many as you like |
+| The authoritative store. If it is in Vault, it is true | A patch layer. The Environment is the baseline and the Vault overrides it |
+| Issues dynamic, leased, revocable credentials | Holds static values you wrote. No leases, no rotation, no revocation |
+| Sealed until an operator unseals it | No state. There is nothing to unseal |
+| Path mounts and per-path policy | A flat key and value bag, scoped to your tenant |
+| Precedence is not a concept | Precedence is the entire point |
+
+One thing does carry over. Both encrypt with an envelope. HashiCorp goes unseal
+key, then root key, then keyring, then data. Fountain goes
+`MASTER_SECRETS_KEY`, then a per-tenant data encryption key, then the value. If
+you understood theirs, you already understand
+[ours](../architecture.md).
+
+## What a vault is
+
+A Vault is a named bag of environment variable overrides that layers over an
+Environment for one run.
+
+It is free-floating. It belongs to no Agent and no Environment. It can be
+attached to any conversation the Agent's `allowed_vault_ids` permits, and the
+same Vault can be attached to conversations of different Agents at the same
+time.
+
+```yaml
+apiVersion: fountain.dev/v1
+kind: Vault
+metadata:
+  name: staging-creds
+spec:
+  secrets:
+    - key: DATABASE_URL
+      value: postgres://staging-host/mydb
+```
+
+## Why it exists
+
+Without vaults, changing one credential means editing the Environment, and the
+Environment is shared. Three consequences follow, and teams hit all three.
+
+Running one Agent against staging and production would need two Environments
+that are identical except for one URL. They would drift.
+
+Giving a contractor's agent a scoped token would mean either widening the
+shared Environment or cloning it.
+
+Rotating one key would touch every agent using that Environment, whether or not
+they use the key.
+
+A Vault makes each of those a one-line attachment on a single run and leaves
+the shared thing alone.
+
+## The merge rule
+
+When a Conversation starts, Fountain builds the environment variable set in one
+direction.
+
+```
+environment secrets  --merge-->  vault secrets  -->  the sandbox
+                                       ^
+                               wins on collision
+```
+
+The Vault wins. If the Environment sets `DATABASE_URL` and the attached Vault
+also sets `DATABASE_URL`, the process sees the Vault's value.
+
+The merge happens once, at spawn. Editing a Vault does not reach a sandbox that
+is already running.
+
+Keys that only the Environment sets survive untouched. A Vault is a patch, not
+a replacement.
+
+## What a vault is not
+
+**Not rotation.** A value you put in a Vault stays there until you change it.
+Fountain does not expire it, does not renew it and does not tell an agent that
+it went stale.
+
+**Not revocation.** Removing a Vault from an Agent's `allowed_vault_ids` stops
+future conversations attaching it. A sandbox that is already running keeps the
+value it was given, because by then the value is in a process's environment on
+a machine.
+
+**Not a read audit.** Fountain audits the mutation when a secret is written, by
+key and by size. It does not record that an agent read one, because the read
+happens inside the sandbox.
+
+**Not returnable.** Values are write-only. Listing a Vault returns keys and
+timestamps. There is no endpoint that gives you a value back, including as the
+owner.
+
+## When to use something else
+
+Use an [Environment](environment.md) for anything the whole team shares that
+changes rarely.
+
+Use `env_vars` on an Environment for values that are not sensitive. A Vault
+holding one non-secret is a Vault someone will later assume is secret.
+
+Use [inference credentials](../integrations/index.md) for model API keys.
+Those are per-user, entered in the running app, and never belong in a Vault.
+
+## What we chose not to do
+
+We considered per-key precedence, so a specific Environment key could refuse to
+be overridden by a Vault. We rejected it. A merge rule that holds always is
+worth more than a merge rule that is more expressive, because the reader has to
+hold it in their head at the moment they are debugging a wrong credential,
+which is usually a bad moment.
+
+We also considered making the Vault the baseline and the Environment the
+override, which would have matched the HashiCorp prior. We rejected it because
+the thing that changes rarely should be the base.
+
+## Where to go next
+
+- [About environments](environment.md), the other half of the merge.
+- [About agents](agent.md), which decides which vaults are attachable.
+- [Architecture](../architecture.md), for the full encryption chain.
+- [CLI reference](../cli.md), for `fountain vault`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,10 @@
 # Fountain
 
-Fountain is a **multi-tenant API** for managing agents, repos, secrets, and conversations, with an operator console over it and standalone apps for watching an agent work. It's for people who want to create sandboxed coding agent instances with preconfigured sets of env vars, MCP servers, skills, repos, and packages.
+Fountain is a **multi-tenant API** for managing agents, repos, secrets and
+conversations, with an operator console over it and standalone apps for
+watching an agent work. It is for people who want sandboxed coding agent
+instances with preconfigured sets of env vars, MCP servers, skills, repos and
+packages.
 
 !!! tip "In a hurry?"
     Install the CLI and point it at a Fountain instance:
@@ -10,27 +14,74 @@ Fountain is a **multi-tenant API** for managing agents, repos, secrets, and conv
     fountain apply -f agent-specs
     ```
 
-## Why Fountain?
+## The problem
 
-Running Claude instances with worktrees locally and shuffling MCP configurations and skill setups by hand is painful. [`jhgaylor/aod-ex`](https://github.com/jhgaylor/aod-ex) solves this for a single tenant; Fountain takes that core and rebuilds it around multi-tenant use.
+Running coding agents on your own machine works until there is more than one of
+you.
 
-## The four primitives
+Setup does not travel. A new engineer spends an afternoon reverse-engineering
+which MCP servers, skills and env vars the last person had, because the
+configuration lives in a laptop rather than anywhere shared.
 
-| Primitive | What it is |
-|---|---|
-| [**Environment**](primitives.md#environment) | Baseline set of encrypted env vars + runtime config |
-| [**Vault**](primitives.md#vault) | Free-floating bag of env-var overrides that layer on top of an environment |
-| [**Agent**](primitives.md#agent) | A named, re-runnable agent config with model, skills, MCP servers |
-| [**Conversation**](primitives.md#conversation) | A single run of an agent inside a sandboxed VM with streaming logs |
+Credentials drift. There is no single source of truth for a key, so the wrong
+`.env` silently breaks an agent and nobody finds out until a run fails
+strangely.
 
-## Get started
+Parallel work forces duplication. Two tasks needing different credentials means
+two checkouts, two configurations, and two things to keep in sync.
 
-- [**Local setup**](setup.md) - bootstrap a workstation in ~10 minutes
-- [**Architecture**](architecture.md) - what runs, what it talks to, what breaks when a dependency is down
-- [**Primitives deep-dive**](primitives.md) - understand the data model
-- [**CLI reference**](cli.md) - `fountain` command surface
-- [**API reference**](api.md) - REST endpoints and auth
-- [**LLM integration**](llm-integration.md) - connect any agentic IDE via `/skill`
-- [**Build a chat app**](build/index.md) - the bot-messenger everyone is cloning, on an API that brings the runtimes
-- [**Plugging into Fountain**](integrations/clients.md) - editors, chat surfaces, plugins, SDKs
-- [**Services Fountain uses**](integrations/index.md) - what an operator configures: sandboxes, mail, OAuth, billing, errors
+Sandboxing is nobody's afternoon project. Giving an agent a machine that is
+isolated, disposable and cheap when idle is real infrastructure work, and it is
+not the work you were trying to do.
+
+Fountain makes the configuration an API object, the credentials a layered
+merge, and the machine something that is provisioned per run and reclaimed when
+it goes quiet.
+
+## Start here
+
+- **[The guided tour](tour.md)** builds an agent that clones a repo, makes a
+  change and opens a pull request, then takes a revision that lands on the same
+  PR. About forty lines. Start here if you have not used Fountain.
+- **[The four primitives](primitives.md)** explains the data model and why it
+  is split four ways.
+
+## Understand it
+
+- [The four primitives](primitives.md), and one page each for
+  [Environment](concepts/environment.md),
+  [Vault](concepts/vault.md),
+  [Agent](concepts/agent.md) and
+  [Conversation](concepts/conversation.md)
+- [Agents as teammates](concepts/teammates.md), why a teammate is not a fifth
+  primitive
+- [Architecture](architecture.md), what runs, what it talks to, and what breaks
+  when a dependency is down
+- [Why a bot needs more than a chat UI](build/index.md), the case for the API
+  underneath
+
+## Build with it
+
+- [The guided tour](tour.md), an agent that opens a pull request
+- [Build a chat app](build/team-chat.md), a roster-and-threads app end to end
+- [Plugging into Fountain](integrations/clients.md), editors, chat surfaces,
+  plugins and SDKs
+- [LLM integration](llm-integration.md), connect any agentic IDE through
+  `/skill`
+
+## Run it
+
+- [Local setup](setup.md), bootstrap a workstation in about ten minutes
+- [Self-hosting](self-hosting.md), run your own instance
+- [Operations](operations.md), runbooks for when something is wrong
+- [Services Fountain uses](integrations/index.md), sandboxes, mail, OAuth,
+  billing and errors
+
+## Look it up
+
+- [CLI reference](cli.md), the `fountain` command surface
+- [API reference](api.md), REST endpoints and auth
+- [TypeScript SDK](sdk.md)
+- [Configuration reference](configuration.md), every environment variable
+- [Conversation states](reference/conversation-states.md)
+- [Glossary](reference/glossary.md), including the five overloaded words

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -79,7 +79,7 @@ profile, add `"--profile", "staging"` to `args`, or set `FOUNTAIN_BASE_URL` in
 
 ### Per-entry secrets
 
-`--vault <name-or-id>` attaches a [vault](../primitives.md#vault) to every
+`--vault <name-or-id>` attaches a [vault](../concepts/vault.md) to every
 conversation the entry opens. Vault values override the agent's environment, so
 this is where a secret that belongs to *this entry* goes — an identity the
 agent posts under, a token scoped to one workspace.
@@ -96,7 +96,7 @@ even when they point at the same agent.
 ### Per-entry environments
 
 `--environment <name-or-id>` provisions every conversation the entry opens from
-that [environment](../primitives.md#environment) instead of the agent's own.
+that [environment](../concepts/environment.md) instead of the agent's own.
 Use it when one agent config should run under several baselines — the same
 "engineer" against a `fountain` environment in one entry and a `buzz`
 environment in another — without duplicating the agent. The vault, if any,

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -144,7 +144,7 @@ OpenClaw runs on Node — it requires **Node ≥ 22.22.3** (or ≥ 24.15 / ≥ 2
 
 ### Per-entry secrets
 
-`--vault <name-or-id>` attaches a [vault](../primitives.md#vault) to every
+`--vault <name-or-id>` attaches a [vault](../concepts/vault.md) to every
 conversation the entry opens. Vault values override the agent's environment, so
 this is where a secret that belongs to *this entry* goes — an identity the
 agent posts under, a token scoped to one channel.
@@ -160,7 +160,7 @@ two entries stay separate even when they point at the same agent.
 ### Per-entry environments
 
 `--environment <name-or-id>` provisions every conversation the entry opens from
-that [environment](../primitives.md#environment) instead of the agent's own.
+that [environment](../concepts/environment.md) instead of the agent's own.
 Use it when one agent config should run under several baselines — the same
 "engineer" against a `fountain` environment in one entry and a `buzz`
 environment in another — without duplicating the agent. The vault, if any,

--- a/docs/llm-integration.md
+++ b/docs/llm-integration.md
@@ -30,24 +30,12 @@ curl $FOUNTAIN_URL/llms.txt
 curl $FOUNTAIN_URL/llms-full.txt
 ```
 
-## MCP server (coming soon)
+## There is no first-party MCP server
 
-Fountain will ship a first-party MCP server exposing all four primitives as tools:
-
-```json
-{
-  "mcpServers": {
-    "fountain": {
-      "command": "npx",
-      "args": ["-y", "@fountain/mcp-server"],
-      "env": {
-        "FOUNTAIN_API_KEY": "ftn_your_api_key",
-        "FOUNTAIN_BASE_URL": "https://your-fountain.example.com"
-      }
-    }
-  }
-}
-```
+**Not built.** A first-party MCP server exposing the four primitives as tools
+has been discussed and does not exist. There is no package to install and no
+config block that will work. Use the `/skill` file above, which gives an
+agentic IDE the whole API surface in one fetch.
 
 ## Using the API from an agent
 

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -1,178 +1,93 @@
 # The four primitives
 
-Everything in Fountain is built from four concepts.
+This page explains what Fountain's four objects are and why there are four of
+them. For the fields on each one, see the [API reference](api.md). To build
+something with them, start with the [guided tour](tour.md).
 
----
+## The problem the four primitives divide up
 
-## Environment
+To run a coding agent on a machine that is not yours, four things have to be
+decided, and they change on four different schedules.
 
-An **Environment** is a named, reusable baseline for a coding agent:
+What the machine has on it changes rarely. Python 3.12, a checkout of your
+repo, a setup script. You decide it once for a team and leave it alone for
+months.
 
-- **Encrypted secrets** - key/value env vars, encrypted per-tenant with AES-256-GCM. Write-only: once stored, the API never returns a value (listing returns keys and timestamps only).
-- **Plain env vars** - a non-secret `env_vars` map for values that aren't sensitive (feature flags, endpoints). Returned by the API as-is; put anything sensitive in secrets instead.
-- **Runtime config** - packages to install, repos to clone, a setup script
-- **Networking policy** - `networking_type: unrestricted` or `limited`. Sprites are open by default, so `unrestricted` is a no-op. `limited` restricts egress to the domains in `networking_config.allowed_hosts` (the only `networking_config` key honored today); under `limited` with no `allowed_hosts`, nothing is allowlisted.
+Which credentials the agent runs with changes constantly. A staging database
+URL today, a customer's API key tomorrow, a rotated token an hour from now.
 
-Environments attach to Agents at creation time. Many agents can share one environment.
+How the agent behaves changes occasionally. Which model, which runtime, which
+skills, which MCP servers, what its system prompt says.
 
-```yaml
-apiVersion: fountain.dev/v1
-kind: Environment
-metadata:
-  name: python-data-env
-spec:
-  packages:
-    python: "3.12"
-  networking_type: limited
-  secrets:
-    - key: OPENAI_API_KEY
-      value: sk-...   # encrypted at rest, never returned by the API
-```
+What it is doing right now changes every few seconds.
 
----
+Put all four in one object and every credential rotation edits the machine
+image, and every prompt edits the credentials. Fountain splits them into four
+objects on purpose, and the split is the product.
 
-## Vault
+| Primitive | Answers | Changes |
+|---|---|---|
+| [Environment](concepts/environment.md) | what is on the machine | rarely |
+| [Vault](concepts/vault.md) | which credentials this run uses | constantly |
+| [Agent](concepts/agent.md) | how the agent behaves | occasionally |
+| [Conversation](concepts/conversation.md) | what it is doing right now | continuously |
 
-A **Vault** is a free-floating bag of env-var overrides.
+## How they compose
 
-**Key rule: vault values win on key collision.** When Fountain materializes env vars for a conversation, it merges `environment secrets -> vault secrets`. The vault always takes precedence.
-
-Typical uses: per-customer API keys, staging vs. production credentials, temporary overrides.
-
-```yaml
-apiVersion: fountain.dev/v1
-kind: Vault
-metadata:
-  name: staging-creds
-spec:
-  secrets:
-    - key: DATABASE_URL
-      value: postgres://staging-host/mydb
-```
-
----
-
-## Agent
-
-An **Agent** is a named, re-runnable configuration for an AI coding assistant:
-
-- **`model`** - `provider/model-id` (e.g. `anthropic/claude-sonnet-4-6`), passed
-  to the runtime's CLI. The provider must match the runtime: `anthropic` for
-  `claude`, `openai` for `codex`, `google` for `gemini`. `opencode` is
-  multi-provider and takes any of the three — it uses the prefix to pick which
-  API key to export. A provider outside that set is rejected at write time:
-  there is no credential for it, so the sandbox would have started with no
-  inference key at all. The model id itself is *not* checked against a list —
-  the agent form suggests current models, but anything you type is passed to
-  the CLI as-is, so a model released since your Fountain version still works.
-- **`runtime`** - one of `claude`, `codex`, `gemini`, `opencode`
-- **`environment`** - optional Environment to attach
-- **`system`** / **`description`** - system prompt and human-readable description. The system prompt is written into the runtime's user-level instructions file on the agent's computer at provision and again at every reattach (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.config/opencode/AGENTS.md`, `~/.gemini/GEMINI.md`), so an edit reaches an existing computer the next time it wakes
-- **`skills`** - each entry is either inline (`{name, content}` — a full SKILL.md written to the sandbox) or GitHub-sourced (`{source: "owner/repo"}` — installed via the skills.sh CLI). Two skills are bundled into every sandbox regardless: `fountain` (the API, for spawning sub-conversations) and `create-team` (a Q&A that sets up the user's team — a first teammate answers "/create-team")
-- **`mcp_servers`** - MCP server definitions, with `${VAR}` substitution in their env
-- **`metadata`** - free-form map for callers' own bookkeeping
-
-```yaml
-apiVersion: fountain.dev/v1
-kind: Agent
-metadata:
-  name: researcher
-spec:
-  model: anthropic/claude-sonnet-4-6
-  runtime: claude
-  environment: python-data-env
-  skills:
-    - source: BinaryBourbon/fountain-api-skill
-  mcp_servers:
-    github:
-      command: npx
-      args: ["-y", "@modelcontextprotocol/server-github"]
-      env:
-        GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PAT}"
-```
-
-`${GITHUB_PAT}` is a substitution reference resolved from the merged env + vault secrets at spawn time.
-
----
-
-## Conversation
-
-A **Conversation** is a running session of an Agent inside a sandboxed VM. It starts with one prompt and can continue over multiple turns:
-
-1. POST to `/api/conversations` with `agent_id` (and optional `vault_id`, `environment_id` — an environment to provision from instead of the agent's own — `prompt`, `images`)
-2. Fountain resolves the full env-var set and spawns a Sprites sandbox
-3. The agent runs; log events stream in real time over SSE (`GET /api/conversations/:id/stream`)
-4. Follow-up prompts go to `POST /api/conversations/:id/prompts`; a running turn can be interrupted (`POST .../interrupt`) and the whole conversation ended early (`POST .../terminate`)
-5. After 60 minutes with no turn activity (default) the sandbox is **suspended**: it scales to zero, costs nothing while parked, and the next prompt wakes it with the agent's memory intact. At 24 hours of continuous running (default) it is **destroyed** — the ceiling for a conversation that never stops being busy.
-
-Neither bound ends the conversation — it stays resumable either way. Self-hosters can widen or disable both bounds with `SANDBOX_IDLE_TIMEOUT_MINUTES` and `SANDBOX_MAX_LIFETIME_HOURS` (`0` disables).
-
-!!! note "Suspend keeps the agent's memory; the max-lifetime ceiling does not"
-
-    The runtime keeps its session on the sandbox's disk. A suspended sandbox
-    keeps that disk, so waking it resumes the agent right where it left off.
-    A sandbox that hits the max-lifetime ceiling is destroyed, disk and all:
-    the stored transcript survives and the conversation stays resumable, but
-    the next turn starts a fresh session and the agent answers without the
-    earlier ones. Expect to restate context after a ceiling reclaim.
-
-### Status lifecycle
+An Agent names an Environment. A Conversation runs an Agent, and may name a
+different Environment and attach a Vault for that run alone.
 
 ```
-pending -> running -> idle -> running   (idle between turns; a follow-up prompt resumes it)
-                    -> failed
+ Environment  ----->  Agent  ----->  Conversation
+      ^                                   |
+      +---- overridden per run -----------+
+                                          |
+ Vault  ------------ attached per run ----+
 ```
 
-Any non-terminal state can move to `terminated` via `POST /api/conversations/:id/terminate`.
-
-### The team: agents as teammates
-
-The [team app](https://github.com/jhgaylor/fountain-team) lays conversations
-out like a messaging app — the roster on the left, one thread on the right —
-on `/api/team`, and treats each agent as a teammate with **one** ongoing
-conversation. There is no fifth primitive
-behind it: a teammate *is* a Conversation, bound to the reserved channel
-`fountain:team` the same way a Buzz channel binds one through `channel_id`.
-Adding an agent to the team opens that conversation, which provisions the
-agent its own sandbox — its computer. A message is a follow-up turn on it; a
-suspended or reaped sandbox wakes on the next message as usual, and a
-terminated conversation is replaced by a fresh one under the same binding,
-so the teammate stays reachable. Removing a teammate terminates the live
-conversation and unbinds the agent's conversations from the channel; the
-rows stay in the ordinary conversation list. "Details" on a thread opens the
-full transcript in the
-[conversations app](https://github.com/jhgaylor/fountain-conversations)
-(stages, tool calls, raw output).
-
-When you add a teammate you can give it a name of its own, pick the
-environment its computer is set up from, and attach a vault. These are the
-conversation's `title`, its per-launch environment override and its
-`vault_id` — nothing new — and the environment and vault pickers only offer
-what the agent's `allowed_environment_ids` / `allowed_vault_ids` allow. They
-belong to the teammate, not the computer: a fresh conversation opened after
-the old one is terminated inherits all three.
-**Schedules.** "Schedules" in a thread's header sets up a cron that runs
-the teammate with a prompt — `0 9 * * 1-5` and "What's on today?", say.
-Cron times are UTC. By default the prompt goes into the teammate's own
-conversation, as if you had typed it, so the reply lands in the thread and
-the teammate's working memory. Tick **Run in a one-off computer** and each
-run opens a fresh conversation on a new sandbox instead — the same agent,
-environment and vault the teammate was added with — leaving the thread
-alone; the run shows up in the conversation list like any other, and the
-schedule keeps a link to its last one. A schedule can be paused, edited,
-run on demand ("Run now") and deleted; the last error, if a run could not
-be delivered (the teammate was busy for half an hour, the sandbox quota was
-full), shows on the schedule. Removing the teammate deletes its schedules.
-
----
+At the moment a Conversation starts, Fountain merges the Environment's secrets
+with the Vault's secrets and hands the result to the sandbox as environment
+variables. **The Vault wins on key collision.** That one rule is why the split
+into four is usable rather than merely tidy, and it is set out in
+[About vaults](concepts/vault.md).
 
 ## Substitution
 
-All string values in Agent configs support `${VAR}` interpolation:
+All string values in Agent configs support `${VAR}` interpolation, resolved
+from the merged environment and vault secrets at spawn time.
 
 | Syntax | Result |
 |---|---|
-| `${VAR}` | Value of `VAR` from the merged env map |
-| `$$` | Literal `$` |
+| `${VAR}` | The value of `VAR` from the merged map |
+| `$$` | A literal `$` |
 
-Substitution is recursive (works inside maps and lists) and fail-complete - all missing variables are reported at once.
+Substitution is recursive, so it works inside maps and lists. It is also
+fail-complete. Every missing variable is reported at once rather than one per
+attempt.
+
+## What Fountain does not have
+
+There is no fifth primitive, and two things that look like one are not.
+
+A **team** is not an object. A teammate is a Conversation bound to the reserved
+channel `fountain:team`. See
+[Agents as teammates](concepts/teammates.md).
+
+A **sandbox** is not an object you create. It is provisioned when a
+Conversation starts and reclaimed when it ends. See
+[About conversations](concepts/conversation.md).
+
+## Where to go next
+
+- **Learn by doing.** The [guided tour](tour.md) uses all four to open a pull
+  request, in about forty lines.
+- **Understand one primitive.**
+  [Environment](concepts/environment.md),
+  [Vault](concepts/vault.md),
+  [Agent](concepts/agent.md),
+  [Conversation](concepts/conversation.md).
+- **Understand the machinery.** [Architecture](architecture.md) follows a
+  prompt from the API call to the first token.
+- **Look something up.** The [API reference](api.md) has every field,
+  [Conversation states](reference/conversation-states.md) has the state table,
+  and the [glossary](reference/glossary.md) has the overloaded words.

--- a/docs/reference/conversation-states.md
+++ b/docs/reference/conversation-states.md
@@ -1,0 +1,68 @@
+# Conversation states
+
+The status values a conversation takes, what exists in each, and which
+operations are legal. For what a conversation is, see
+[About conversations](../concepts/conversation.md).
+
+## Transitions
+
+```
+pending ---> running <---> idle
+   |            |            |
+   |            v            |
+   +--------> failed <-------+
+
+any non-terminal state ---> terminated
+```
+
+`idle` returns to `running` when a follow-up prompt arrives. Any non-terminal
+state moves to `terminated` through
+`POST /api/conversations/:id/terminate`.
+
+## The states
+
+| Status | What exists | What you can do | Terminal |
+|---|---|---|---|
+| `pending` | The conversation row and its resolved environment variable set. No sandbox yet | Terminate | No |
+| `running` | A sandbox, and a turn in flight | Interrupt the turn, stream events, terminate | No |
+| `idle` | A sandbox, no turn in flight. The sandbox may be live or suspended | Send a follow-up prompt, stream events, terminate | No |
+| `failed` | The transcript and log events. The sandbox may already be gone | Read the transcript. Launch a new conversation | Yes |
+| `terminated` | The transcript and log events | Read the transcript | Yes |
+
+## The sandbox is not the status
+
+A conversation's status describes the run. It does not tell you whether a
+machine is currently powered on.
+
+An `idle` conversation may have a live sandbox, a suspended one, or none at
+all, depending on how long it has been idle and what the provider supports.
+
+| Sandbox event | Trigger | Effect on status | Agent memory |
+|---|---|---|---|
+| Suspend | Idle for `SANDBOX_IDLE_TIMEOUT_MINUTES`, default 60 | None. Stays `idle` | Kept. The disk survives |
+| Wake | The next prompt | `idle` to `running` | Kept |
+| Destroy on ceiling | Running for `SANDBOX_MAX_LIFETIME_HOURS`, default 24 | None. Stays resumable | Lost. The next turn starts a fresh runtime session |
+| Destroy on idle | Idle, on a provider without the `:suspend` capability | None | Lost |
+
+Both bounds are set per instance. `0` disables either. See the
+[configuration reference](../configuration.md).
+
+## Warnings
+
+A conversation in `failed` or `terminated` cannot be resumed. Launch a new one.
+
+An interrupt applies to the turn in flight, not to the conversation. The
+conversation returns to `idle` and remains usable.
+
+Terminating is not reversible, and it destroys the sandbox along with the
+agent's working memory. The transcript is kept.
+
+A sandbox reclaimed at the max-lifetime ceiling leaves the conversation
+resumable and the agent without its earlier context. Restate what matters on
+the next turn.
+
+## Where to go next
+
+- [About conversations](../concepts/conversation.md).
+- [API reference](../api.md), for the endpoints that cause each transition.
+- [Configuration reference](../configuration.md), for the two timeouts.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,85 @@
+# Glossary
+
+Terms Fountain uses, and the five that are overloaded. Where a word has more
+than one sense, the senses are listed and the docs pick one.
+
+## The overloaded words
+
+### Agent
+
+Three senses. The docs mean the first.
+
+1. **The primitive.** A named, re-runnable configuration. See
+   [About agents](../concepts/agent.md).
+2. **The coding agent.** The process running inside the sandbox, which is
+   Claude Code, Codex, Gemini CLI or opencode. The docs call this the
+   **runtime**.
+3. **The ACP role.** In the Agent Client Protocol, the process an editor
+   spawns. The docs call this `fountain acp`. See
+   [`fountain acp`](../integrations/acp.md).
+
+### Environment
+
+Three senses. The docs mean the first.
+
+1. **The primitive.** See [About environments](../concepts/environment.md).
+2. **Environment variables.** The values in a process. The docs always say
+   "environment variables" in full.
+3. **A deployment tier.** Dev, staging, production. The docs say
+   **deployment** for this and never "environment".
+
+### Fountain
+
+Three senses, distinguished by formatting.
+
+1. **Fountain**, unstyled, is the product.
+2. **`fountain`**, in code font, is the CLI binary.
+3. **the `fountain` skill** is the skill injected into every sandbox, which
+   gives an agent Fountain's own API. Always written with the word "skill".
+
+### Vault
+
+Two senses, and they are close to opposite. The docs mean the first.
+
+1. **The primitive.** A small, static, per-run override layer that wins on key
+   collision. See [About vaults](../concepts/vault.md).
+2. **HashiCorp Vault.** A central server issuing dynamic leased credentials.
+   Unrelated to Fountain's Vault beyond the shape of the encryption. The
+   collision is set out on the Vault page.
+
+### Computer
+
+Used in the team and conversations apps for the machine a teammate works on.
+The docs say **sandbox**.
+
+## The rest
+
+| Term | Means |
+|---|---|
+| **ACP** | Agent Client Protocol. How editors and chat surfaces drive Fountain. See [`fountain acp`](../integrations/acp.md) |
+| **AG-UI** | The protocol OpenBot and other coworker hosts speak. See [OpenBot](../integrations/openbot.md) |
+| **Conversation** | One run of an Agent in a sandbox. See [About conversations](../concepts/conversation.md) |
+| **DEK** | Data encryption key. Derived per tenant from `MASTER_SECRETS_KEY` and used to encrypt that tenant's secrets |
+| **Inference credentials** | A user's own model provider keys, entered in the running app. Never set by an operator. See [Services Fountain uses](../integrations/index.md) |
+| **Log event** | One entry in a conversation's stream. Delivered over SSE, optionally pre-parsed with `?blocks=true` |
+| **MCP server** | A Model Context Protocol server an Agent gives its runtime. Declared in `mcp_servers` |
+| **Reaper** | The background sweep that suspends idle sandboxes and destroys ones past the ceiling |
+| **Runner** | A machine you own, running `fountain runner`, acting as a sandbox provider. See [Self-hosted runners](../integrations/runners.md) |
+| **Runtime** | The coding-agent CLI a sandbox runs. One of `claude`, `codex`, `gemini`, `opencode` |
+| **Sandbox** | The isolated machine one Conversation runs in. Provisioned at launch, reclaimed on the lifetime rules |
+| **Sandbox provider** | A backend Fountain provisions sandboxes on. Sprites, E2B, Daytona, or a self-hosted runner. See [the sandbox contract](../integrations/sandbox-contract.md) |
+| **Skill** | A `SKILL.md` written into the sandbox, inline or sourced from GitHub |
+| **Sprite** | One sandbox on the Sprites provider. Not a Fountain concept. See [Sprites](../integrations/sprites.md) |
+| **Substitution** | `${VAR}` interpolation in Agent config, resolved from the merged secrets at spawn |
+| **Suspend** | Scaling a sandbox to zero while keeping its disk, so the agent's memory survives |
+| **Teammate** | An Agent with one ongoing Conversation on the reserved channel `fountain:team`. Not a primitive. See [Agents as teammates](../concepts/teammates.md) |
+| **Turn** | One prompt and the work that follows it, inside a Conversation |
+
+## Two things that sound like primitives and are not
+
+A **team** is not an object. See
+[Agents as teammates](../concepts/teammates.md).
+
+A **sandbox** is not an object you create. It is provisioned when a
+Conversation starts and reclaimed when it ends. See
+[About conversations](../concepts/conversation.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,9 +67,17 @@ markdown_extensions:
 # docs/cli.md is diffed against the real CLI command tree.
 nav:
   - Home: index.md
+  - Guided tour — opening a PR: tour.md
+  - Concepts:
+      - The four primitives: primitives.md
+      - Environment: concepts/environment.md
+      - Vault: concepts/vault.md
+      - Agent: concepts/agent.md
+      - Conversation: concepts/conversation.md
+      - Agents as teammates: concepts/teammates.md
+      - Architecture: architecture.md
   - Setup: setup.md
   - Self-hosting: self-hosting.md
-  - Architecture: architecture.md
   - Operations: operations.md
   - Configuration reference: configuration.md
   - Sandbox providers:
@@ -86,11 +94,12 @@ nav:
       - GitHub OAuth: integrations/github-oauth.md
       - Stripe: integrations/stripe.md
       - Sentry: integrations/sentry.md
-  - The four primitives: primitives.md
-  - CLI reference: cli.md
-  - API reference: api.md
-  - TypeScript SDK: sdk.md
-  - Guided tour — opening a PR: tour.md
+  - Reference:
+      - CLI: cli.md
+      - API: api.md
+      - TypeScript SDK: sdk.md
+      - Conversation states: reference/conversation-states.md
+      - Glossary: reference/glossary.md
   - Build a chat app:
       - The shape everyone is cloning: build/index.md
       - A team chat, end to end: build/team-chat.md


### PR DESCRIPTION
Redesigns the docs information architecture around Diátaxis, and ships the
first four steps of it. The research, audit and full plan are in
`docs-redesign/` so the rest can land incrementally.

## What was wrong

I crawled all 34 live pages and classified each by Diátaxis mode.
**13 do exactly one job. 21 do two or more; six do three or more.**

Four specific defects motivated this PR.

**The tutorial was hidden.** `tour.md` is the best page in the repo, and it
sat at nav position 15 of 34, below the CLI, API and SDK references, and was
not linked from `docs/index.md` at all. (The brief I was working from said it
lived on marketing instead. It does not. I fetched `fountain.inevitable.fyi`
and there is no tour there. It was simply unreachable.) `build/team-chat.md`,
the second tutorial, had the same problem.

**No concepts tree existed.** Explanation was scattered across nine locations,
including inside `integrations/index.md` under a table of env vars. Three
client pages had independently grown a `What this is, and is not` heading and
four had grown `Limits, stated rather than discovered`, which is writers
reinventing a template that had nowhere to live.

**`primitives.md` did three jobs in seven sections.** Four of its seven
sections mixed reference, explanation and how-to. The nine-line argument for
why a model provider is validated and a model id is not was buried inside a
bullet under a field name. The team section was 41 lines, 23% of a page about
primitives, documenting another application's cron feature.

**`llm-integration.md` advertised software that does not exist**, with a
copy-pasteable `@fountain/mcp-server` config block under a "coming soon"
heading. `CLAUDE.md` forbids exactly this.

## What this PR changes

**Nav.** The tutorial moves to position 2. A `Concepts` section comes third,
ahead of every reference page. The four reference pages group under
`Reference`.

**`docs/index.md`** replaces "Why Fountain?", which motivated the product by
citing an earlier personal repo, with four concrete failures of the reader's
current setup. The nine undifferentiated links become five mode-labelled
groups: Start here, Understand it, Build with it, Run it, Look it up.

**`primitives.md`** becomes a hub that argues why there are four objects (they
change on four different schedules) rather than listing their fields. **The
path does not move**, so inbound links survive. The six pages that linked to
its anchors are repointed.

**New: `docs/concepts/`** with `environment`, `vault`, `agent`, `conversation`
and `teammates`.

**New: `docs/reference/conversation-states.md`.** Each status gets a row saying
what exists, what you can do, and whether the agent's memory survives. The old
version was an ASCII arrow diagram that told you the edges but not what you
could call.

**New: `docs/reference/glossary.md`**, fixing five overloaded words. "Agent"
has three senses, "environment" three, "fountain" three, "vault" two, and
"computer" is used throughout the team docs for the sandbox and defined
nowhere.

`concepts/vault.md` opens with the HashiCorp collision before the definition.
Their Vault is a central, authoritative issuer of dynamic leased credentials.
Ours is a small static patch layer that wins on key collision. The prior
inverts the one fact a reader must have to use vaults at all, and nothing in
the docs currently denies that Fountain vaults rotate or revoke.

## What is deliberately not here

`self-hosting.md` (393 lines, ~8 how-tos) and `operations.md` (290 lines, 7
runbooks) still need splitting. The catalog for MCP servers and skills does
not exist yet; note that two skills, `fountain` and `create-team`, are injected
into **every** sandbox and are documented in a single bullet. And the
site-wide style pass is untouched: there are 682 em dashes across 32 of 34
files. `docs-redesign/03-nav-tree.md` has the ordered, individually-mergeable
sequence.

## Verification

- `mkdocs build --strict`, clean
- `docs_test.exs` and `docs_controller_test.exs`, 32 tests 0 failures,
  including the checks that every internal `/docs` link resolves and every
  `#anchor` targets a real heading
- `go test ./internal/cmd/` for the CLI docs diff, passing
- `mix format --check-formatted`, clean

One test change. `docs_test.exs`'s nav-order assertion pinned
`["Home", "Setup", "Self-hosting"]`, so it is updated, and a new test asserts
the tutorial and concepts tree stay ahead of Reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Second commit: a hole in the docs gate

`056cd36` is separable. Revert it alone if you would rather handle this
another way.

`mkdocs build --strict` lived only in the `docs` job, gated on
`docs_only == 'true'`. The `checks` job, which handles everything else, had no
strict build. **A PR that changes docs *and* code therefore took neither
branch, and the strict build did not run at all** — docs.yml on main was the
first gate that saw it.

That is precisely the failure the `docs` job's own comment says it exists to
prevent:

> `mkdocs build --strict` never ran on a pull request at all before this job
> existed [...] so a broken relative link or a page missing from the nav passed
> CI and failed after the merge, on main, where nobody was looking.

The job closed the docs-only case and left the mixed case open. I found it by
walking into it: this PR touches `docs/`, `mkdocs.yml` and a test file, so its
first run showed `Docs: skipping` and nothing built the site.

The fix adds a `docs_touched` output to `changes`, meaning "any docs path
moved" rather than "only docs paths moved", and runs the strict build in
`checks` when it is set. The two jobs stay mutually exclusive, so the shared
deps-cache argument in the `docs` job's comment is unaffected. The three error
branches of the classifier decide `true`, preserving the existing "on any
error, run more rather than less" direction.

It would have caught a real regression in this very PR. Splitting
`primitives.md` broke eight `primitives.md#anchor` links across `api.md`,
`build/team-chat.md`, `editors.md` and `openclaw.md`. `docs_test.exs` catches
those for the in-app renderer, but the MkDocs site's own link check would not
have run.
