### PR TITLE
docs: split self-hosting and operations into task-scoped pages

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ Scheduled work, all times UTC:
 
 One replica needs none of this. With more than one, replicas must form an
 Erlang cluster — `CLUSTER_DNS_QUERY` pointed at a headless service
-([`k8s/` shows the wiring](self-hosting.md#kubernetes)):
+([`k8s/` shows the wiring](guides/operate/kubernetes.md)):
 
 - The conversation registry places each conversation server on exactly one
   node and finds it from any node.
@@ -72,10 +72,10 @@ the key is half of that sentence.
 
 | Dependency | Needed for | When it is down |
 |---|---|---|
-| **Postgres** | Everything | `GET /health/ready` returns 503 and load balancers drain the instance; the app stays up and does not restart — restarting does not fix Postgres, so [the restart check deliberately checks nothing](self-hosting.md#health-endpoints). Recovery is automatic. A replica *booting* against a down database fails instead, because migrations run at boot |
+| **Postgres** | Everything | `GET /health/ready` returns 503 and load balancers drain the instance; the app stays up and does not restart — restarting does not fix Postgres, so [the restart check deliberately checks nothing](guides/operate/observability.md#health-endpoints). Recovery is automatic. A replica *booting* against a down database fails instead, because migrations run at boot |
 | **sprites.dev** | Conversations | New provisions and wakes fail — bounded retries with backoff, then the conversation is marked `failed` (or left resumable, if it was a wake). Everything else keeps serving: sign-in, dashboards, agent/environment/vault management, past logs. Deliberately excluded from the readiness check — a third party's uptime does not belong on the serving path |
 | **Stripe** | Billing — optional, `BILLING_ENABLED` | Checkout and the billing portal fail with a visible error; the billing page itself still renders from local state. Webhooks are redelivered by Stripe until acknowledged. Trial expiry is enforced against the local clock, so an outage delays revenue rather than opening the gate |
-| **Mail** (Resend or SMTP) | Signup verification, password reset | Both dead-end while the provider is down. Escape hatch: `Fountain.Release.verify_email/1` — see [Email](self-hosting.md#email). (`EMAIL_DELIVERY=none` is different: accounts self-verify, ADR 0011) |
+| **Mail** (Resend or SMTP) | Signup verification, password reset | Both dead-end while the provider is down. Escape hatch: `Fountain.Release.verify_email/1` — see [Email](guides/operate/email.md). (`EMAIL_DELIVERY=none` is different: accounts self-verify, ADR 0011) |
 | **GitHub OAuth** | The OAuth login button — optional | Only that button. Email/password auth is unaffected |
 | **Sentry** | Error reporting — optional | Inert without a DSN; nothing depends on it |
 | **Object storage** | Database backups — ops layer | The application never touches object storage; it exists only in a deployment's backup pipeline |
@@ -96,7 +96,7 @@ The blast radius follows from the layout:
 
 - **A database backup cannot decrypt itself.** Restoring secrets requires the
   same `MASTER_SECRETS_KEY` the backup was written under —
-  [keep it separate from the backups](self-hosting.md#back-up-master_secrets_key).
+  [keep it separate from the backups](guides/operate/back-up-and-restore.md#back-up-master_secrets_key).
 - Losing or changing the master key makes every stored secret unrecoverable.
   Nothing else is lost — accounts, configs and history are plain rows.
 - An attacker with only database access holds ciphertext and wrapped keys, not
@@ -146,7 +146,7 @@ strings shown in the UI, the SSE stream and the log rows, each with a state of
    memory. If the sprite is gone, the conversation re-provisions from step 2 —
    Fountain's transcript survives, the agent's session does not (#649).
 6. **`sandbox`** — the lifetime bounds. Every server checks its
-   [bounds](self-hosting.md#sandbox-lifetime) each minute, and they do
+   [bounds](guides/operate/sandbox-lifetime.md) each minute, and they do
    different things: crossing the **idle timeout** *suspends* — the server
    stops, the sprite stays (it scales itself to zero) and the sandbox parks in
    `suspended`, to be woken with everything intact by the next prompt.
@@ -182,6 +182,6 @@ level — what to run and what the output means — is [Operations](operations.m
 | UI down, `GET /health/ready` returns 503 | Postgres |
 | Container restarts in a loop at boot | Migrations cannot reach Postgres — boot fails before anything listens |
 | Streaming dead for some viewers, fine for others, multiple replicas | Erlang clustering — `CLUSTER_DNS_QUERY` |
-| Signups never complete | Mail delivery — see [Email](self-hosting.md#email) |
+| Signups never complete | Mail delivery — see [Email](guides/operate/email.md) |
 | `402 subscription_required` on a self-hosted instance | `BILLING_ENABLED` should be `false` |
-| Sandbox suspends between prompts, work resumes on the next one | Working as designed — [lifecycle bounds](self-hosting.md#sandbox-lifetime) |
+| Sandbox suspends between prompts, work resumes on the next one | Working as designed — [lifecycle bounds](guides/operate/sandbox-lifetime.md) |

--- a/docs/build/pieces.md
+++ b/docs/build/pieces.md
@@ -157,5 +157,5 @@ in front of it.
   own terms.
 - [Architecture](../architecture.md) covers what runs, and what breaks when a
   dependency is down.
-- [Operations](../operations.md) is what to read when a computer is stuck.
+- [Troubleshooting](../troubleshooting/index.md) is what to read when a sandbox is stuck.
 - [A team chat, end to end](team-chat.md) is the code.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ an error message.
 | `DATABASE_SSL_VERIFY` | off | — | Unset, the connection is encrypted but the server certificate is **not** verified. `true` verifies it, against the OS trust store unless a CA file is given |
 | `DATABASE_SSL_CA_FILE` | OS trust store | — | CA bundle used when `DATABASE_SSL_VERIFY=true` |
 | `POOL_SIZE` | `10` | — | Database connection pool size |
-| `MIGRATE_ON_BOOT` | `true` | — | Whether a booting release runs pending migrations before it serves. `false` (also `0`, `no`) makes the pod only serve, for the deployment that runs migrations once in a Job — see [migrations in a Job](self-hosting.md#running-migrations-in-a-job). `bin/migrate` always migrates, whatever this is set to. **Nothing checks that the Job ran**: a pod that skips migrations against an un-migrated database boots and then fails on the first query |
+| `MIGRATE_ON_BOOT` | `true` | — | Whether a booting release runs pending migrations before it serves. `false` (also `0`, `no`) makes the pod only serve, for the deployment that runs migrations once in a Job — see [migrations in a Job](guides/operate/database.md#running-migrations-in-a-job). `bin/migrate` always migrates, whatever this is set to. **Nothing checks that the Job ran**: a pod that skips migrations against an un-migrated database boots and then fails on the first query |
 
 ## Sandboxes
 
@@ -53,7 +53,7 @@ an error message.
 | `DAYTONA_API_KEY` | — | for the `daytona` provider | [Daytona](https://daytona.io) API key. Its presence enables the provider |
 | `DAYTONA_API_URL` | `https://app.daytona.io/api` | — | Repoints the Daytona API (self-hosted Daytona) |
 | `DAYTONA_SNAPSHOT` | org default | — | Snapshot (image) new Daytona sandboxes are created from; must be registered with the organization. The default image lacks the agent CLIs — build one from `images/daytona/` for real use |
-| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long and the sandbox is reclaimed — the conversation stays [resumable](self-hosting.md#sandbox-lifetime). `0` disables the bound; boot refuses anything that is not a non-negative integer |
+| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long and the sandbox is reclaimed — the conversation stays [resumable](guides/operate/sandbox-lifetime.md). `0` disables the bound; boot refuses anything that is not a non-negative integer |
 | `SANDBOX_MAX_LIFETIME_HOURS` | `24` | — | Absolute sandbox age ceiling, regardless of activity. Same `0`-disables and boot-refusal rules |
 | `LOG_OUTPUT_BUDGET_MB` | `50` | — | Durable log volume per conversation. Once a conversation has persisted this much sandbox output, one truncation marker is written and further output is discarded (retention bounds age; this bounds rate). Same `0`-disables and boot-refusal rules |
 
@@ -71,7 +71,7 @@ an error message.
 
 Production **refuses to boot** unless exactly one of the three delivery
 options is configured — a silently discarded verification email dead-ends
-signup with no visible error. See [Email](self-hosting.md#email).
+signup with no visible error. See [Email](guides/operate/email.md).
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|

--- a/docs/guides/operate/back-up-and-restore.md
+++ b/docs/guides/operate/back-up-and-restore.md
@@ -1,0 +1,115 @@
+# Back up and restore
+
+This guide shows you how to take backups, prove they work, and restore one for
+real.
+
+A backup here is two things. A `pg_dump` of Postgres **and the
+`MASTER_SECRETS_KEY` it was written under**. The key wraps every tenant's
+encryption key, so a dump restored without it has secrets that nothing will
+ever decrypt. Treat "which key was live when this was taken" as part of a
+backup's identity.
+
+## Back up `MASTER_SECRETS_KEY`
+
+Every environment and vault secret is encrypted with a per-tenant key that is
+itself wrapped with `MASTER_SECRETS_KEY`. **Lose it and every stored secret is
+unrecoverable. Change it and the same is true.**
+
+It is not stored in the database, by design, so a database backup alone does
+not protect you.
+
+Keep it somewhere separate from your database backups, and treat rotating it as
+a migration rather than a config change.
+
+## Take backups
+
+**Compose.** The bundled service, off unless you opt in.
+
+```bash
+docker compose --profile backup up -d
+```
+
+Dumps land in the `backup_data` volume and are pruned after
+`BACKUP_RETENTION_DAYS` (default 14). `BACKUP_INTERVAL_SECONDS` sets the
+cadence.
+
+**That volume is on the same host as the database.** It protects against bad
+migrations and fat fingers, not a dead machine. Copy dumps off-host on a
+schedule.
+
+**Kubernetes.** `deploy/k8s/backup-cronjob.yaml` is the same discipline against
+any S3-compatible bucket. Dump, size-check, upload, verify, then prune. It is
+commented out of the kustomization until you create its secret, and setup is at
+the top of the file.
+
+## Run the restore drill
+
+A backup nobody has restored is a hypothesis. Periodically, and always before
+an upgrade, restore the newest dump into a scratch database and look at it.
+
+Compose:
+
+```bash
+docker compose --profile backup exec backup ls -lh /backups
+docker compose exec postgres createdb -U postgres fountain_drill
+docker compose --profile backup exec backup \
+  pg_restore --no-owner -d "dbname=fountain_drill" /backups/fountain-<ts>.dump
+
+# Does it hold what production holds?
+docker compose exec postgres psql -U postgres -d fountain_drill -c \
+  "SELECT (SELECT count(*) FROM users) AS users,
+          (SELECT count(*) FROM conversations) AS conversations,
+          (SELECT max(inserted_at) FROM audit_events) AS newest_audit_row"
+
+docker compose exec postgres dropdb -U postgres fountain_drill
+```
+
+Kubernetes. Fetch the dump from the bucket and do the same against a scratch
+database on your Postgres:
+
+```bash
+aws s3 cp s3://<bucket>/pg_dump/fountain-<ts>.dump .
+createdb -h <host> -U <user> fountain_drill
+pg_restore --no-owner -h <host> -U <user> -d fountain_drill fountain-<ts>.dump
+```
+
+The drill passes when the counts look like production and the newest rows are
+from the night of the dump. It does not pass merely because `pg_restore` exited
+zero.
+
+## Restore for real
+
+Stop the app first so nothing writes mid-restore (`docker compose stop app`, or
+scale the deployment to zero), then replace the live database and start the app
+again.
+
+```bash
+pg_restore --clean --if-exists --no-owner -d "$DATABASE_URL" fountain-<ts>.dump
+```
+
+Two rules decide whether this works.
+
+- The restored data decrypts only under the `MASTER_SECRETS_KEY` that was live
+  when the dump was taken. If you rotated the key since, you need the old one.
+- If the restore crosses an upgrade boundary, run the image version that
+  matches the dump. See [Upgrade an instance](upgrade.md).
+
+## Know the job still runs
+
+A backup job that quietly stops is the classic way backups rot.
+
+The Kubernetes CronJob has the
+[Sentry Crons check-in](../../integrations/sentry.md#crons-alerting-when-a-scheduled-job-stops-running)
+built in. Set `SENTRY_DSN` and arm the monitor's schedule.
+
+On compose, check the service's log line dates.
+
+```bash
+docker compose --profile backup logs backup | tail -5
+```
+
+## Related
+
+- [Upgrade an instance](upgrade.md), the moment a backup earns its keep.
+- [Connect a database](database.md).
+- [Observability](observability.md), for the staleness alert on the backup job.

--- a/docs/guides/operate/billing.md
+++ b/docs/guides/operate/billing.md
@@ -1,0 +1,49 @@
+# Turn on billing
+
+This guide shows you how to enable the subscription gate, and why you probably
+should not.
+
+## Leave it off unless you are running Fountain commercially
+
+Billing is off by default (`BILLING_ENABLED=false`), and the compose file also
+pins it off.
+
+The subscription gate exists for the hosted service. On your own instance it is
+a lock with no key. Leave it off unless you are running Fountain commercially
+and have configured Stripe.
+
+With billing disabled, accounts carry no subscription status and no trial
+clock. Nothing billing-shaped appears in the UI, the admin panel, or the API.
+
+## Enable it
+
+Set `BILLING_ENABLED=true` and configure Stripe. The
+[Stripe integration guide](../../integrations/stripe.md) covers
+`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID` and the
+provider-side setup.
+
+## Start the clocks on existing accounts
+
+Accounts created while billing was off have no trial to measure, and they
+**fail closed** at the subscription gate the moment you enable it. Start their
+trial clocks explicitly.
+
+```bash
+# See who would be affected, change nothing:
+bin/fountain_server eval 'Fountain.Release.expire_legacy_trials(dry_run: true)'
+
+# Mark them trialing with 14 days from now:
+bin/fountain_server eval 'Fountain.Release.expire_legacy_trials(days: 14)'
+```
+
+Run the dry run first. It reports without changing anything.
+
+## Verify it worked
+
+Sign in as a non-admin account and confirm it can still reach a gated action.
+An account that is locked out here is one the backfill missed.
+
+## Related
+
+- [Stripe integration guide](../../integrations/stripe.md).
+- [Run a release task](run-a-release-task.md).

--- a/docs/guides/operate/database.md
+++ b/docs/guides/operate/database.md
@@ -1,0 +1,71 @@
+# Connect a database
+
+This guide shows you how to point Fountain at a Postgres you manage, turn on
+TLS verification, and move migrations out of boot into an explicit step.
+
+## Before you start
+
+Fountain needs Postgres 16 or newer. The compose file runs one for you, and
+this guide is for replacing it with a managed database or running migrations
+separately.
+
+## Point it at your database
+
+`DATABASE_URL` is the connection. The app runs its migrations at boot, so
+upgrading is `docker compose pull && docker compose up -d`.
+
+`DATABASE_SSL` defaults to on, and the compose file sets it to `false` because
+a stock `postgres` image does not serve TLS. If you point Fountain at a managed
+database, remove that line.
+
+To verify the server certificate rather than merely encrypt to it:
+
+```bash
+DATABASE_SSL_VERIFY=true
+# optional, otherwise the OS trust store is used
+DATABASE_SSL_CA_FILE=/etc/ssl/certs/rds-ca.pem
+```
+
+## Running migrations in a Job
+
+Migrating at boot is right for one replica and is not the only shape. Set
+`MIGRATE_ON_BOOT=false` and the release starts without migrating. Run the
+migration entrypoint yourself, once, before the new version serves.
+
+```bash
+bin/migrate     # in the image; equivalent to
+                # bin/fountain_server eval 'Fountain.Release.migrate()'
+```
+
+`bin/migrate` ignores `MIGRATE_ON_BOOT`. It is the thing you run *to* migrate.
+In Kubernetes that is a Job ordered before the rollout, and
+[`deploy/k8s/README.md`](https://github.com/BinaryBourbon/fountain/blob/main/deploy/k8s/README.md)
+has the manifest.
+
+Three things are worth knowing before you turn it off.
+
+- **Nothing verifies the Job ran.** A pod with the switch off boots happily
+  against an un-migrated database and fails on the first query that needs the
+  new column. Ordering the Job ahead of the rollout is your job, not the app's.
+- **You do not need this to run several replicas.** Boot migrations are
+  serialized by a Postgres advisory lock, taken before `schema_migrations` is
+  touched, so even the first boot against an empty database does not race.
+- **What it buys you** is migrations as an explicitly reviewable step, app pods
+  that can run with a database role that cannot `ALTER`, and faster pod starts
+  on scale-up.
+
+## Verify it worked
+
+```bash
+curl -sS localhost:4000/health/ready
+# {"checks":{"database":"ok"},"status":"ok"}
+```
+
+A 503 here means this instance cannot reach its database.
+
+## Related
+
+- [Back up and restore](back-up-and-restore.md).
+- [Upgrade an instance](upgrade.md).
+- [Configuration reference](../../configuration.md), for every `DATABASE_*`
+  variable.

--- a/docs/guides/operate/deploy.md
+++ b/docs/guides/operate/deploy.md
@@ -1,0 +1,122 @@
+# Deploy an instance
+
+This guide shows you how to get a Fountain instance running with Docker
+Compose, register the first account, and close registration behind you.
+
+For a development environment on your own machine, see [Setup](../../setup.md).
+That is a different thing, and this guide assumes you want an instance that
+stays up.
+
+## Before you start
+
+You need Postgres 16 or newer, which the compose file runs for you, and a
+sandbox provider token. See [Self-hosting](../../self-hosting.md) for what each
+provider needs.
+
+## Bring it up
+
+```bash
+git clone https://github.com/BinaryBourbon/fountain
+cd fountain
+
+cp .env.compose.example .env
+echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')" >> .env
+echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" >> .env
+# add your SPRITES_TOKEN to .env
+
+docker compose up -d
+```
+
+Back up `MASTER_SECRETS_KEY` now, before you have data. It is not in the
+database, so a database backup alone does not protect you. See
+[Back up and restore](back-up-and-restore.md).
+
+The variables that shape a deployment are explained as they come up across
+these guides. The complete list, including the deploy-level ones the compose
+file never mentions, is the
+[configuration reference](../../configuration.md).
+
+## Register the first account
+
+Open <http://localhost:4000> and register. That is the whole first login.
+
+With the compose defaults (`EMAIL_DELIVERY=none`, `FIRST_USER_ADMIN=true`) your
+account self-verifies at registration and, being the first, is promoted to
+admin. The grant is recorded in the admin audit trail like any other role
+change (ADR 0011).
+
+Register **before** exposing the instance to a network you do not trust. While
+no admin exists, the first verified account gets the role.
+
+Prefer the manual path? Set `FIRST_USER_ADMIN=false` and use a release task
+instead. See [Run a release task](run-a-release-task.md).
+
+```bash
+docker compose exec app bin/fountain_server eval \
+  'Fountain.Release.promote_admin("you@example.com")'
+```
+
+## Point the apps at it
+
+Fountain's own UI is a console, covering the account, its keys, and the agents,
+environments and vaults a conversation runs on. Watching a conversation turn by
+turn, and messaging an agent as a teammate, are separate single-page apps that
+talk to your `/api`.
+
+| | |
+|---|---|
+| [Conversations](https://jakegaylor.com/fountain-conversations/) | start a run, watch it, steer it, read the raw log |
+| [Team](https://jakegaylor.com/fountain-team/) | your agents as teammates, one thread each |
+
+They are static builds with no server of their own. You type your Fountain's
+URL in, so the hosted copies above work against your deployment as soon as it
+admits the origin.
+
+```bash
+echo "API_CORS_ORIGINS=https://jakegaylor.com" >> .env
+```
+
+If you would rather click "Sign in with Fountain" than paste an API key,
+register them in `OAUTH_CLIENTS`. See the
+[configuration reference](../../configuration.md).
+
+The console links to whatever `CONVERSATIONS_APP_URL` and `TEAM_APP_URL` say,
+so pointing those at your own build of either repo works the same way. Setting
+them to `""` tells the console this deployment has neither, and it stops
+offering them.
+
+## Close registration
+
+```bash
+echo "REGISTRATION_ENABLED=false" >> .env
+docker compose up -d
+```
+
+Registration is open by default, and an instance on the public internet with
+registration open will be found.
+
+## Verify it worked
+
+```bash
+curl -sS localhost:4000/health/ready
+# {"checks":{"database":"ok"},"status":"ok"}
+```
+
+Then sign in and create a conversation. A run that reaches its first turn
+proves the database, the secrets key and the sandbox provider are all wired.
+
+## If it did not work
+
+If provisioning fails but the app serves, the sandbox provider is the usual
+cause. See [Sandbox errors](../../troubleshooting/sandbox-errors.md).
+
+If the container never starts listening, migrations cannot reach the database.
+See [Pods restarting or not ready](../../troubleshooting/pods-restarting.md).
+
+## Related
+
+- [Put it on the internet](put-it-on-the-internet.md), the next step.
+- [Back up and restore](back-up-and-restore.md).
+- [Configuration reference](../../configuration.md).
+- [Architecture](../../architecture.md), for what runs and what breaks when a
+  dependency is down.

--- a/docs/guides/operate/email.md
+++ b/docs/guides/operate/email.md
@@ -1,0 +1,51 @@
+# Configure email
+
+This guide shows you how to pick a mail setting, which is a decision Fountain
+requires rather than an optional extra.
+
+Fountain refuses to start in production without one, because a silently
+discarded verification email dead-ends signup with no visible error.
+
+## Pick one of three
+
+| Setting | Effect |
+|---|---|
+| `RESEND_API_KEY` | Delivery via Resend |
+| `SMTP_HOST` (plus `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`) | Any SMTP server. Port defaults to 587 with STARTTLS. Omit the username for an unauthenticated relay |
+| `EMAIL_DELIVERY=none` | No email. Accounts self-verify at registration (ADR 0011) |
+
+`EMAIL_FROM` sets the sender in the first two modes.
+
+## What each choice costs you
+
+Password reset also needs working mail. With `EMAIL_DELIVERY=none` the only
+route back into a locked-out account is the database.
+
+That is the trade the mode's boot notice warns about, and it is usually the
+right trade for a single-operator instance where you can run a release task.
+
+Provider-side setup, including domain verification and what each mode means for
+signup, is in the [mail integration guide](../../integrations/mail.md).
+
+## Verify it worked
+
+Register a throwaway account and watch for the verification mail. If it does
+not arrive, verify the account by hand and treat that as a failing mail setup
+rather than a fix.
+
+```bash
+docker compose exec app bin/fountain_server eval \
+  'Fountain.Release.verify_email("them@example.com")'
+```
+
+## If it did not work
+
+An unverified sending domain (SPF, DKIM, DMARC) is accepted by the provider and
+then rejected or spam-foldered downstream. See
+[Nobody can log in](../../troubleshooting/nobody-can-log-in.md).
+
+## Related
+
+- [Mail integration guide](../../integrations/mail.md), for provider setup.
+- [Run a release task](run-a-release-task.md), for `verify_email/1`.
+- [Nobody can log in](../../troubleshooting/nobody-can-log-in.md).

--- a/docs/guides/operate/kubernetes.md
+++ b/docs/guides/operate/kubernetes.md
@@ -1,0 +1,52 @@
+# Deploy on Kubernetes
+
+This guide shows you which manifests to apply, and which to read but not apply.
+
+## Use `deploy/k8s/`
+
+A portable baseline lives in
+[`deploy/k8s/`](https://github.com/BinaryBourbon/fountain/tree/main/deploy/k8s).
+Plain manifests applied with `kubectl apply -k`, with no operators or CRDs
+assumed.
+
+You bring a Postgres, an ingress controller, and the `fountain-secrets` Secret.
+Its README walks through the rest, and the probe and scaling reasoning is
+commented inline in the manifests.
+
+## Do not apply `k8s/`
+
+`k8s/` in this repository is a different thing. It is the maintainer's own
+cluster, with CNPG, Traefik, cert-manager, Infisical, Flux, Longhorn and
+personal hostnames.
+
+It is worth reading, because it shows the full Erlang-clustering wiring for
+running more than one replica. It is not worth applying.
+
+## Two things to decide
+
+**Migrations.** Boot migrations are safe with several replicas, serialized by a
+Postgres advisory lock. If you would rather run them as an explicit Job, see
+[Running migrations in a Job](database.md#running-migrations-in-a-job).
+
+**Backups.** `deploy/k8s/backup-cronjob.yaml` is commented out of the
+kustomization until you create its secret. See
+[Back up and restore](back-up-and-restore.md).
+
+## Verify it worked
+
+```bash
+kubectl rollout status deployment/fountain -n fountain
+kubectl exec -n fountain deploy/fountain -- curl -sS localhost:4000/health/ready
+```
+
+## If it did not work
+
+See [Pods restarting or not ready](../../troubleshooting/pods-restarting.md).
+Most "kubernetes is broken" symptoms here are the probe layout working as
+designed.
+
+## Related
+
+- [Wire up observability](observability.md), for the PrometheusRule.
+- [Back up and restore](back-up-and-restore.md).
+- [Architecture](../../architecture.md), for the clustering picture.

--- a/docs/guides/operate/observability.md
+++ b/docs/guides/operate/observability.md
@@ -1,0 +1,75 @@
+# Wire up observability
+
+This guide shows you how to scrape metrics, import the shipped dashboard and
+alerts, and point health checks at the right endpoints.
+
+## Metrics
+
+The app serves Prometheus metrics on port 9568, which the compose file does not
+publish. Add a port mapping if you are scraping it, and keep it off the public
+internet. It enumerates routes, request rates and database timings.
+
+You do not have to start from a blank scrape. The repo ships an observability
+pack built from running the hosted instance.
+
+- **Alerts**, `deploy/k8s/prometheusrule.yaml`. Error rate, unhandled
+  exceptions, pool saturation, provisioning failures, and staleness watches for
+  the optional backup CronJob, each commented with what it means and what to
+  do. Needs the PrometheusRule CRD, and is commented out of the kustomization
+  until you enable it.
+- **A starter dashboard**, `deploy/grafana/fountain-dashboard.json`, built only
+  from metrics the app actually exports. Import it into Grafana and pick your
+  Prometheus datasource. On compose, point any Prometheus at the metrics port
+  and import the same file.
+
+## Logs
+
+Logs go to stdout.
+
+```bash
+docker compose logs -f app
+```
+
+## Error tracking
+
+Error tracking is off unless you opt in. Set `SENTRY_DSN` and crashes are
+reported with stack traces, grouped, and correlated with releases, including
+the ones that never touch a web request.
+
+The endpoint can be sentry.io or anything Sentry-API-compatible, such as
+GlitchTip for a fully self-hosted stack. Unset, nothing ever leaves your
+instance.
+
+Setup and the Crons pattern for backup-job alerting are in the
+[Sentry integration guide](../../integrations/sentry.md).
+
+## Health endpoints
+
+Two, because restarting a container and taking it out of a load balancer are
+different decisions.
+
+| | |
+|---|---|
+| `GET /health` | Always 200 while the app is running. Checks nothing. Point a **restart** check here. If it consulted the database, a Postgres blip would restart every container at once, which does not fix Postgres |
+| `GET /health/ready` | 200 when this instance can serve, 503 when it cannot reach its database. Point **load balancer** and deploy gates here |
+
+```bash
+curl -sS localhost:4000/health/ready
+# {"checks":{"database":"ok"},"status":"ok"}
+```
+
+Both are public and unauthenticated, and report `ok` or `error` per check with
+no further detail. A failing check does not describe your database to whoever
+asked.
+
+A healthy check takes about 2ms. An unreachable database takes a few seconds to
+give up, so give the check a timeout above one second if your platform defaults
+lower.
+
+## Related
+
+- [Sentry integration guide](../../integrations/sentry.md).
+- [Pods restarting or not ready](../../troubleshooting/pods-restarting.md),
+  where the probe layout is explained as symptoms.
+- [Architecture](../../architecture.md), for which component owns which
+  symptom.

--- a/docs/guides/operate/put-it-on-the-internet.md
+++ b/docs/guides/operate/put-it-on-the-internet.md
@@ -1,0 +1,63 @@
+# Put it on the internet
+
+This guide shows you how to expose an instance safely, once it runs locally.
+
+The compose file publishes port 4000 with no TLS. Terminate TLS in front of it
+with Caddy, nginx, or a tunnel.
+
+## Before you start
+
+Register your own account first. While no admin exists, the first verified
+account gets the role, so an open instance with no admin is an instance anyone
+can take.
+
+## Set three variables
+
+- `PUBLIC_URL`, the external URL with scheme included. It builds verification
+  links and is passed to every sandbox.
+- `TRUSTED_PROXIES`, your proxy's address range. Without it, per-IP rate limits
+  all collapse into one bucket keyed on the proxy.
+- `REGISTRATION_ENABLED=false`, or set `REGISTRATION_ALLOWED_EMAIL_DOMAINS`.
+
+Registration is open by default. An instance on the public internet with
+registration open will be found.
+
+## What an https PUBLIC_URL switches on
+
+An `https://` `PUBLIC_URL` also enables HTTPS redirection, HSTS (one year,
+including subdomains, not preloaded) and the `secure` flag on the session
+cookie.
+
+All three are derived from the scheme rather than set separately, because none
+of them can be on for an `http://` instance. A cookie marked secure is never
+sent back, and the redirect would point at a port serving nothing.
+
+If you terminate TLS in front of Fountain, make sure your proxy sets
+`X-Forwarded-Proto`. The redirect uses it, and without it every request looks
+like plain http and loops.
+
+`CHECK_ORIGIN_EXTRA` adds origins allowed to open a LiveView websocket, as a
+comma-separated list. Your own host is always included, so add to this only for
+something like a preview environment on a different domain.
+
+## Verify it worked
+
+```bash
+curl -sSI https://your-fountain.example.com/health/ready | head -1
+```
+
+Then sign in through the public URL. A redirect loop in the browser means the
+proxy is not setting `X-Forwarded-Proto`.
+
+## If it did not work
+
+See [Pods restarting or not ready](../../troubleshooting/pods-restarting.md)
+for the probe-versus-redirect interaction, which is the other common surprise
+here. `/health` and `/health/ready` are exempt from the https redirect
+precisely because probes hit the pod over plain http.
+
+## Related
+
+- [Deploy an instance](deploy.md).
+- [Observability](observability.md), including the health endpoints.
+- [Configuration reference](../../configuration.md).

--- a/docs/guides/operate/run-a-release-task.md
+++ b/docs/guides/operate/run-a-release-task.md
@@ -1,0 +1,52 @@
+# Run a release task
+
+This guide shows you how to run an operator action that touches data. Every one
+of them goes through the same invocation pattern.
+
+## The pattern
+
+Compose:
+
+```bash
+docker compose exec app bin/fountain_server eval \
+  'Fountain.Release.verify_email("you@example.com")'
+```
+
+Kubernetes:
+
+```bash
+kubectl exec -n fountain deploy/fountain -- \
+  sh -c "PHX_SERVER=false bin/fountain_server eval 'Fountain.Release.verify_email(\"you@example.com\")'"
+```
+
+`eval` starts only the database connection, never the app, so a task cannot
+compete with the running server for ports, background jobs, or conversation
+processes. `PHX_SERVER=false` makes that explicit in an environment where the
+container sets it `true`. Include it and the pattern is always safe to paste.
+
+## The tasks
+
+| Task | What it does |
+|---|---|
+| `Fountain.Release.verify_email("a@b.c")` | Mark an account's email verified without sending anything. The escape hatch for a broken mail provider. `EMAIL_DELIVERY=none` self-verifies at registration since ADR 0011 |
+| `Fountain.Release.promote_admin("a@b.c")` | Grant the admin role, recorded in the admin audit trail with a system actor. The manual alternative to `FIRST_USER_ADMIN=true` (ADR 0011) |
+| `Fountain.Release.expire_legacy_trials(dry_run: true)` | Report, then without `dry_run` backfill, trial end dates on legacy `trialing` accounts that have none |
+| `Fountain.Release.migrate()` | Run pending migrations by hand, which is what `bin/migrate` runs. They already run at every boot unless `MIGRATE_ON_BOOT=false`, in which case this, in a Job before the rollout, is how they run at all. Never skipped by that switch |
+| `Fountain.Release.rollback(Fountain.Repo, version)` | Roll migrations back to a version. Last resort, and read [Upgrade an instance](upgrade.md) before reaching for it |
+
+## Warnings
+
+`rollback/2` is for surgically reversing a migration you understand. Reversing
+an arbitrary release's migrations is not something to attempt on production
+data.
+
+`expire_legacy_trials/1` changes account state. Run it with `dry_run: true`
+first and read the report.
+
+## Related
+
+- [Upgrade an instance](upgrade.md).
+- [Turn on billing](billing.md), which is where `expire_legacy_trials/1`
+  matters.
+- [Nobody can log in](../../troubleshooting/nobody-can-log-in.md), which is
+  where `verify_email/1` matters.

--- a/docs/guides/operate/sandbox-lifetime.md
+++ b/docs/guides/operate/sandbox-lifetime.md
@@ -1,0 +1,59 @@
+# Change sandbox lifetimes
+
+This guide shows you how to widen, narrow or disable the two bounds that
+reclaim a sandbox, and what each one costs.
+
+## The two bounds
+
+They do different things, and the difference matters more than the numbers.
+
+| Setting | Default | |
+|---|---|---|
+| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | No turn activity for this long and the sandbox is **suspended**. The sprite stays, scaled to zero, and the next prompt wakes it with the agent's memory intact |
+| `SANDBOX_MAX_LIFETIME_HOURS` | `24` | Ceiling on a continuous run, from creation or the last wake. Crossing it **destroys** the sprite, the backstop for a conversation that never stops being busy |
+
+Set either to `0` to disable it. A value that is not a non-negative integer
+refuses to boot rather than quietly disabling the bound.
+
+## Which one you can be aggressive with
+
+Neither bound ends the conversation. It stays resumable either way.
+
+The idle bound is free to be aggressive, because suspension loses nothing.
+
+The max-lifetime ceiling is not. The runtime session lives on the destroyed
+disk, so after a ceiling reclaim the next prompt provisions fresh and the agent
+starts without its memory of the earlier turns. Expect users to restate context
+after one.
+
+Suspended sandboxes are never aged out. Their sprites persist at the provider
+until the conversation is terminated or the account deleted.
+
+## Not every provider can suspend
+
+A provider that does not advertise the `:suspend` capability destroys on idle
+rather than faking a park, because resuming with a fresh disk would be silent
+loss of the agent's memory. See
+[the sandbox contract](../../integrations/sandbox-contract.md).
+
+So on such a provider, lowering the idle timeout is not free. It has the cost
+of the ceiling.
+
+## Verify it worked
+
+The reaper logs one summary line per run, hourly at :07.
+
+```bash
+kubectl logs -n fountain -l app=fountain --since=2h | grep 'reaper:'
+# reaper: released=0 parked=1 expired=0 destroyed=2 untracked=102 live=114
+```
+
+`parked` is the reaper suspending idle sandboxes, which is reversible
+bookkeeping rather than a teardown.
+
+## Related
+
+- [About conversations](../../concepts/conversation.md), for what suspend and
+  destroy mean to a user.
+- [Conversation states](../../reference/conversation-states.md).
+- [Configuration reference](../../configuration.md).

--- a/docs/guides/operate/upgrade.md
+++ b/docs/guides/operate/upgrade.md
@@ -1,0 +1,106 @@
+# Upgrade an instance
+
+This guide shows you how to move an instance to a newer Fountain release, and
+what to do when an upgrade goes wrong.
+
+## Before you start
+
+Take a backup. An upgrade is the one moment where the supported path back
+depends on having one. See [Back up and restore](back-up-and-restore.md).
+
+Read **Upgrade notes** in the [changelog](../../changelog.md) before a minor
+bump.
+
+## How versions work
+
+Fountain follows [SemVer](https://semver.org/), pre-1.0. A patch release
+(`v0.3.0` to `v0.3.1`) is always safe to take. A minor release (`v0.3` to
+`v0.4`) may include breaking changes, and calls them out under **Upgrade
+notes** in the changelog.
+
+Each release publishes the server image to `ghcr.io/binarybourbon/fountain`
+under two tags, alongside the tags that track development.
+
+| Tag | Moves? | Use it for |
+|---|---|---|
+| `vX.Y.Z` | Never | Pinning a known version, the recommended default |
+| `vX.Y` | To the newest patch in the line | Taking patches automatically without risking a breaking minor |
+| `latest` | On every merge to `main` | Nothing you keep running, because it moves under you |
+| `sha-<commit>` | Never | Reproducing exactly what a given commit built |
+
+Releases v0.2.1 and earlier predate image tagging and exist only as `sha-`
+tags.
+
+## Take a new version
+
+The compose file reads `FOUNTAIN_IMAGE_TAG` from `.env`, and
+`.env.compose.example` ships it set to a pinned release, so a fresh install is
+pinned by construction. Even with the variable unset, the compose file falls
+back to a pinned release rather than `latest`.
+
+Upgrading is editing that value, then pulling.
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+Migrations run automatically at boot, idempotently, serialized by a Postgres
+advisory lock. Rolling replicas do not race each other, and there are no manual
+migration steps unless a release's upgrade notes say otherwise. A migration
+that builds an index concurrently opts out of that lock by design, and such
+migrations are written to be safe to re-run.
+
+If you have moved migrations into a Job with `MIGRATE_ON_BOOT=false`, running
+the Job is the upgrade step. See
+[Running migrations in a Job](database.md#running-migrations-in-a-job).
+
+## Match the CLI to the server
+
+The CLI and the server are cut from the same tag, so matching versions are the
+tested pairing.
+
+The CLI's built-in default `base_url` is the hosted instance
+(`https://fountain.inevitable.fyi`), not yours. Point it at your instance
+before exporting an API key, otherwise the first unconfigured command sends
+that key to the hosted domain.
+
+```bash
+FOUNTAIN_BASE_URL=https://your-fountain.example.com fountain auth login
+```
+
+`auth login` records the URL in the saved profile, so this is a one-time step.
+
+## Watch a deploy land
+
+```bash
+kubectl rollout status deployment/fountain -n fountain   # k8s
+docker compose logs -f app                               # compose
+```
+
+A rollout that never completes is usually the startup probe failing, meaning
+migrations that cannot finish, or a readiness probe failing against a database
+problem that predates the deploy. See
+[Pods restarting or not ready](../../troubleshooting/pods-restarting.md).
+
+## When an upgrade goes wrong
+
+The rules, in order of preference.
+
+1. **Roll forward.** Pin `vX.Y.Z` tags, read **Upgrade notes** before a minor
+   bump, and fix forward when something breaks.
+2. **Downgrading is not supported once a newer version's migrations have
+   run.** The supported path back is restoring the pre-upgrade database backup
+   and running the previous image, accepting the loss of writes since the
+   backup. This is why a backup taken before every upgrade is cheap insurance.
+3. `Fountain.Release.rollback/2` exists for surgically reversing a migration
+   you understand. Reversing an arbitrary release's migrations is not something
+   to attempt on production data.
+
+If a restore crosses an upgrade boundary, run the image version that matches
+the dump.
+
+## Related
+
+- [Back up and restore](back-up-and-restore.md).
+- [Run a release task](run-a-release-task.md), for `rollback/2` and `migrate/0`.
+- [Changelog](../../changelog.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,8 +72,10 @@ it goes quiet.
 ## Run it
 
 - [Local setup](setup.md), bootstrap a workstation in about ten minutes
-- [Self-hosting](self-hosting.md), run your own instance
-- [Operations](operations.md), runbooks for when something is wrong
+- [Self-hosting](self-hosting.md), what you need and which guide to read
+- [Deploy an instance](guides/operate/deploy.md), the first one to read
+- [Troubleshooting](troubleshooting/index.md), start from the symptom
+- [Operations](operations.md), running one day to day
 - [Services Fountain uses](integrations/index.md), sandboxes, mail, OAuth,
   billing and errors
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,290 +1,33 @@
 # Operations
 
-What to do when something is wrong with a running instance.
-[Architecture](architecture.md) tells you which component owns a symptom;
-this page is the action level — what to run, and what the output means.
+Running an instance day to day.
+
+[Architecture](architecture.md) tells you which component owns a symptom. These
+pages are the action level, meaning what to run and what the output means.
 Commands are shown for both deploy paths where they differ.
 
----
+## When something is wrong
 
-## Running a release task
+Start from the symptom in [Troubleshooting](troubleshooting/index.md).
 
-Every operator action that touches data goes through one invocation pattern.
-Compose:
-
-```bash
-docker compose exec app bin/fountain_server eval \
-  'Fountain.Release.verify_email("you@example.com")'
-```
-
-Kubernetes:
-
-```bash
-kubectl exec -n fountain deploy/fountain -- \
-  sh -c "PHX_SERVER=false bin/fountain_server eval 'Fountain.Release.verify_email(\"you@example.com\")'"
-```
-
-`eval` starts only the database connection, never the app — a task cannot
-compete with the running server for ports, background jobs, or conversation
-processes. `PHX_SERVER=false` makes that explicit in an environment where the
-container sets it `true`; include it and the pattern is always safe to paste.
-
-The tasks:
-
-| Task | What it does |
+| You see | Read |
 |---|---|
-| `Fountain.Release.verify_email("a@b.c")` | Mark an account's email verified without sending anything — the escape hatch for a broken mail provider (`EMAIL_DELIVERY=none` self-verifies at registration since ADR 0011) |
-| `Fountain.Release.promote_admin("a@b.c")` | Grant the admin role, recorded in the admin audit trail with a system actor. The manual alternative to `FIRST_USER_ADMIN=true` (ADR 0011) |
-| `Fountain.Release.expire_legacy_trials(dry_run: true)` | Report (then, without `dry_run`, backfill) trial end dates on legacy `trialing` accounts that have none |
-| `Fountain.Release.migrate()` | Run pending migrations by hand — what `bin/migrate` runs. They already run at every boot unless `MIGRATE_ON_BOOT=false`, in which case this (in a Job, before the rollout) is how they run at all. Never skipped by that switch |
-| `Fountain.Release.rollback(Fountain.Repo, version)` | Roll migrations back to a version. Last resort — see [Upgrade gone wrong](#upgrade-gone-wrong) before reaching for it |
+| A conversation sits in `running` with no output, or went `failed` | [A conversation is stuck or failed](troubleshooting/conversation-stuck-or-failed.md) |
+| Provisioning fails while everything else is healthy | [Sandbox errors](troubleshooting/sandbox-errors.md) |
+| Pods restart, or sit NotReady | [Pods restarting or not ready](troubleshooting/pods-restarting.md) |
+| Registration completes but nobody gets past "check your email" | [Nobody can log in](troubleshooting/nobody-can-log-in.md) |
 
----
+## Routine work
 
-## A conversation is stuck or failed
+- [Run a release task](guides/operate/run-a-release-task.md), the invocation
+  pattern every operator action uses, and the five tasks
+- [Back up and restore](guides/operate/back-up-and-restore.md), including the
+  restore drill
+- [Upgrade an instance](guides/operate/upgrade.md), and what to do when one
+  goes wrong
+- [Wire up observability](guides/operate/observability.md), metrics, alerts,
+  logs and the health endpoints
 
-Open the conversation's log view. Provisioning progress is recorded as stage
-events — `provision`, `checkpoint_restore`, `packages`, `network`, `clone`,
-`setup`, `turn` — and the failing step names itself, with the exit code in
-the event data.
+## Standing it up in the first place
 
-- **`packages`, `clone` or `setup` failed** — almost always the environment's
-  own configuration: a package that does not exist, a repository the token
-  cannot reach, a setup script exiting non-zero. Fix the environment and
-  prompt again.
-- **`provision` failed outright** — the sprite could not be created: the
-  Sprites platform is unhealthy, `SPRITES_TOKEN` is invalid, or the user is
-  at their concurrent-sandbox quota. See [Sprites errors](#sprites-errors).
-- **Stuck with no failure** — a conversation `running` with no events
-  arriving usually means the sprite-side process died and the exit was
-  missed. Interrupt it, or just send another prompt — waking reattaches to
-  the existing sprite when it still exists:
-
-    ```bash
-    fountain conv show <conv-id>          # turn status, sandbox name
-    fountain conv interrupt <conv-id>     # stop the in-flight turn, keep the sandbox
-    fountain conv terminate <conv-id>     # destroy the sprite, end the conversation
-    ```
-
-What the statuses mean: `failed` and `terminated` are the two terminal
-states — a further prompt is refused. `idle` with a *suspended* sandbox is
-the normal resting state, not an error: the sprite is parked at sprites.dev,
-scaled to zero, and the next prompt wakes it with the agent's memory intact.
-`idle` with a *terminated* sandbox is what the max-lifetime ceiling (or an
-explicit reap) leaves behind: the next prompt provisions fresh, the stored
-transcript is unaffected, but the agent starts a fresh session — see the note
-under [Primitives → Conversation](primitives.md).
-
-**Quota knock-on:** a crash mid-provision leaves a `pending`/`starting`
-sandbox row that counts against the user's quota (default 5 concurrent).
-The reaper runs hourly at :07 and releases rows stuck longer than 60
-minutes; an admin can raise a user's cap from `/admin` immediately. The
-reaper logs one summary line per run:
-
-```bash
-kubectl logs -n fountain -l app=fountain --since=2h | grep 'reaper:'
-# reaper: released=0 parked=1 expired=0 destroyed=2 untracked=102 live=114
-```
-
-(`parked` is the reaper suspending idle server-less sandboxes — reversible
-bookkeeping, not a teardown.)
-
----
-
-## Pods restarting or not ready
-
-The probe layout is deliberate, and most "kubernetes is broken" symptoms are
-it working as designed:
-
-- **Liveness checks nothing but the process.** A restart does not fix
-  Postgres, so `/health` always answers 200 while the BEAM runs.
-- **Readiness checks Postgres.** A pod that cannot reach its database
-  answers 503 on `/health/ready`, is drained from the Service without being
-  killed, and recovers on its own — **NotReady during a database blip with
-  no restarts is the system behaving correctly.** Answering that 503 takes
-  ~3 seconds, so give external checks a timeout above that.
-- **The startup probe holds the others off for up to 150 seconds** because
-  migrations run at boot, before the listener opens. A slow migration is not
-  a dead pod.
-
-Failure modes that are real:
-
-- **Boot loop** — migrations cannot reach the database at all. The container
-  fails before anything listens; check `DATABASE_URL` and the database
-  itself.
-- **A 301 where a probe expected 200** — on an `https://` instance every
-  path redirects http to https *except* `/health` and `/health/ready`, which
-  are exempt precisely because probes hit the pod over plain http. A check
-  pointed at any other path scores the redirect as a failure. Point checks
-  at the two health endpoints only.
-- **Redirect loop in the browser** — the proxy in front is not setting
-  `X-Forwarded-Proto`, so every request looks like http and gets redirected
-  to itself. Fix the proxy header.
-
----
-
-## Nobody can log in
-
-Work down the chain:
-
-1. **Did the verification email go anywhere?** Note the symptom: the password
-   is accepted and the session is real, but it never leaves the "check your
-   email" page, so this reads as a broken app rather than a refused login. An
-   instance with `EMAIL_DELIVERY=none` sends nothing — that is the compose
-   default. Verify by hand:
-
-    ```bash
-    docker compose exec app bin/fountain_server eval \
-      'Fountain.Release.verify_email("them@example.com")'
-    ```
-
-2. **Mail configured but not arriving** — an unverified sending domain (SPF,
-   DKIM, DMARC) is accepted by the provider and then rejected or spam-foldered
-   downstream. See the [mail integration guide](integrations/mail.md).
-3. **OAuth still works when mail does not.** GitHub sign-ins arrive already
-   verified. Conversely, a GitHub outage breaks only the button — password
-   auth is unaffected.
-4. **Password reset needs working mail.** With `EMAIL_DELIVERY=none` a
-   locked-out password account has no self-serve route back; that is the
-   trade-off the mode's boot notice warns about.
-5. **429 responses** — the API rate limit is 600 requests/minute per IP. If
-   *everyone* is rate-limited at once behind a proxy, `TRUSTED_PROXIES` is
-   unset and every client is sharing the proxy's bucket.
-
----
-
-## Sprites errors
-
-What the retries already cover: transient Sprites failures (5xx, 429,
-timeouts) on the provisioning path are tried up to three times (two retries)
-with exponential backoff, each call bounded by `SPRITES_TIMEOUT_MS` (default
-30s). You only
-see a failure after that has been exhausted.
-
-What a 4xx means — these are deliberately **not** retried:
-
-- **401/403** — `SPRITES_TOKEN` is invalid, revoked, or missing. Check this
-  first; it fails every conversation while everything else looks healthy.
-- **409 on create** — already handled: the existing sprite is adopted, not
-  an error you will see.
-
-During a Sprites outage: new conversations and wakes fail (a fresh provision
-marks the conversation `failed`; a wake leaves it resumable for later),
-while sign-in, dashboards, configuration and past logs keep serving. The
-readiness probe deliberately excludes Sprites — a third party's uptime does
-not belong on the serving path — so do not expect pods to go NotReady over
-it. If you scrape metrics, provisioning failures show as
-`fountain_stage_count{stage="provision", status="failed"}` (and completions
-as `status="done"`).
-
----
-
-## Backup and restore
-
-A backup here is two things: a `pg_dump` of Postgres **and the
-`MASTER_SECRETS_KEY` it was written under**. The key wraps every tenant's
-encryption key; a dump restored without it has secrets that nothing will
-ever decrypt. Store the key separately from the dumps, and treat "which key
-was live when this was taken" as part of a backup's identity.
-
-Taking them:
-
-- **Compose** — the bundled service, opt-in:
-  `docker compose --profile backup up -d`. Nightly `pg_dump` into the
-  `backup_data` volume, pruned after 14 days
-  ([details](self-hosting.md#backups)).
-- **Kubernetes** — `deploy/k8s/backup-cronjob.yaml`, nightly to any
-  S3-compatible bucket, commented out of the kustomization until you create
-  its secret. Setup is at the top of the file.
-
-### The restore drill
-
-A backup nobody has restored is a hypothesis. Periodically — and always
-before an upgrade — restore the newest dump into a scratch database and look
-at it. Compose:
-
-```bash
-docker compose --profile backup exec backup ls -lh /backups
-docker compose exec postgres createdb -U postgres fountain_drill
-docker compose --profile backup exec backup \
-  pg_restore --no-owner -d "dbname=fountain_drill" /backups/fountain-<ts>.dump
-
-# Does it hold what production holds?
-docker compose exec postgres psql -U postgres -d fountain_drill -c \
-  "SELECT (SELECT count(*) FROM users) AS users,
-          (SELECT count(*) FROM conversations) AS conversations,
-          (SELECT max(inserted_at) FROM audit_events) AS newest_audit_row"
-
-docker compose exec postgres dropdb -U postgres fountain_drill
-```
-
-Kubernetes: fetch the dump from the bucket and do the same against a scratch
-database on your Postgres:
-
-```bash
-aws s3 cp s3://<bucket>/pg_dump/fountain-<ts>.dump .
-createdb -h <host> -U <user> fountain_drill
-pg_restore --no-owner -h <host> -U <user> -d fountain_drill fountain-<ts>.dump
-```
-
-The drill passes when the counts look like production and the newest rows
-are from the night of the dump — not when `pg_restore` merely exits zero.
-
-### Restoring for real
-
-Stop the app first so nothing writes mid-restore (`docker compose stop app`,
-or scale the deployment to zero), then replace the live database and start
-the app again:
-
-```bash
-pg_restore --clean --if-exists --no-owner -d "$DATABASE_URL" fountain-<ts>.dump
-```
-
-Two rules that decide whether this works:
-
-- The restored data decrypts only under the `MASTER_SECRETS_KEY` that was
-  live when the dump was taken. If you rotated the key since, you need the
-  old one.
-- If the restore crosses an upgrade boundary, run the image version that
-  matches the dump — see [Upgrade gone wrong](#upgrade-gone-wrong).
-
-### Knowing the job still runs
-
-A backup job that quietly stops is the classic way backups rot. The
-Kubernetes CronJob has the [Sentry Crons
-check-in](integrations/sentry.md#crons-alerting-when-a-scheduled-job-stops-running)
-built in — set `SENTRY_DSN` and arm the monitor's schedule. On compose,
-check the service's log line dates:
-
-```bash
-docker compose --profile backup logs backup | tail -5
-```
-
----
-
-## Upgrade gone wrong
-
-The rules, in order of preference:
-
-1. **Roll forward.** Pin `vX.Y.Z` tags, read **Upgrade notes** in the
-   [changelog](changelog.md) before a minor bump, and fix forward when
-   something breaks.
-2. **Downgrading is not supported once a newer version's migrations have
-   run.** The supported path back is restoring the pre-upgrade database
-   backup and running the previous image — accepting the loss of writes
-   since the backup. This is why a backup taken before every upgrade is
-   cheap insurance.
-3. `Fountain.Release.rollback/2` exists for surgically reversing a migration
-   you understand. Reversing an arbitrary release's migrations is not
-   something to attempt on production data.
-
-Watching a deploy land:
-
-```bash
-kubectl rollout status deployment/fountain -n fountain   # k8s
-docker compose logs -f app                               # compose
-```
-
-A rollout that never completes is usually the startup probe failing —
-migrations that cannot finish — or a readiness probe failing against a
-database problem that predates the deploy.
+See [Self-hosting](self-hosting.md).

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -262,7 +262,7 @@ const second = await fountain.resume(first.conversationId).send("Fix the worst t
 
 The second turn costs one prompt. The sandbox is the same machine, the checkout
 is where the first turn left it, and the agent's session still holds what it
-learned. A [suspended](operations.md) sandbox wakes for it.
+learned. A [suspended](reference/conversation-states.md) sandbox wakes for it.
 
 ## Timeouts
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -2,392 +2,71 @@
 
 Running your own Fountain instance.
 
-For a development environment on your own machine, see [Setup](setup.md) — that
-is a different thing, and this page assumes you want an instance that stays up.
+For a development environment on your own machine, see [Setup](setup.md). That
+is a different thing, and this section assumes you want an instance that stays
+up.
+
+Start with [Deploy an instance](guides/operate/deploy.md).
 
 ## What you need
 
 | | |
 |---|---|
-| **Postgres 16+** | The compose file below runs one for you |
-| **A sandbox provider** | [sprites.dev](https://sprites.dev) by default; [E2B](integrations/e2b.md) and [Daytona](integrations/daytona.md) are hosted alternatives, and users can bring their own machines with [`fountain runner`](integrations/runners.md) (no credential). The app boots without one, but every conversation fails |
-| **A mail provider** | Resend or any SMTP server. Optional — see [Email](#email) |
+| **Postgres 16+** | The compose file runs one for you |
+| **A sandbox provider** | [sprites.dev](https://sprites.dev) by default. [E2B](integrations/e2b.md) and [Daytona](integrations/daytona.md) are hosted alternatives, and users can bring their own machines with [`fountain runner`](integrations/runners.md), which needs no credential. The app boots without one, but every conversation fails |
+| **A mail provider** | Resend or any SMTP server. See [Configure email](guides/operate/email.md), which is a decision rather than an optional extra |
 
-Sandboxes run on one of three backends, all hosted services — a Fountain
-instance is not fully self-contained (self-hosted Daytona comes closest):
+Sandboxes run on one of three backends, all hosted services. A Fountain
+instance is not fully self-contained, and self-hosted Daytona comes closest.
 
 | Provider | Enabled by | Idle behavior | Notes |
 |---|---|---|---|
-| **Sprites** (default) | `SPRITES_TOKEN` | Parks — scales to zero on its own | The reference backend |
-| **E2B** | `E2B_API_KEY` | Parks — explicit pause (filesystem + memory snapshot) | Needs a template built from `images/e2b/`; see [E2B](integrations/e2b.md) |
-| **Daytona** | `DAYTONA_API_KEY` | Parks — explicit stop (disk preserved; archives when long-parked) | Self-hostable via `DAYTONA_API_URL`; see [Daytona](integrations/daytona.md) |
+| **Sprites** (default) | `SPRITES_TOKEN` | Parks, scaling to zero on its own | The reference backend |
+| **E2B** | `E2B_API_KEY` | Parks with an explicit pause, snapshotting filesystem and memory | Needs a template built from `images/e2b/`. See [E2B](integrations/e2b.md) |
+| **Daytona** | `DAYTONA_API_KEY` | Parks with an explicit stop, preserving disk, archiving when long-parked | Self-hostable via `DAYTONA_API_URL`. See [Daytona](integrations/daytona.md) |
 
-`SANDBOX_PROVIDER` picks the default for new sandboxes; an agent can pin a
+`SANDBOX_PROVIDER` picks the default for new sandboxes. An agent can pin a
 provider, and existing sandboxes always stay where they were created.
 
 For what each piece of the system does and what breaks when a dependency is
 down, see [Architecture](architecture.md).
 
-## Quick start
+## The guides
 
-```bash
-git clone https://github.com/BinaryBourbon/fountain
-cd fountain
+**Standing it up.**
 
-cp .env.compose.example .env
-echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')" >> .env
-echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" >> .env
-# add your SPRITES_TOKEN to .env
+- [Deploy an instance](guides/operate/deploy.md)
+- [Put it on the internet](guides/operate/put-it-on-the-internet.md)
+- [Connect a database](guides/operate/database.md)
+- [Deploy on Kubernetes](guides/operate/kubernetes.md)
 
-docker compose up -d
-```
+**Decisions it forces.**
 
-This page explains the variables that shape a deployment as they come up; the
-complete list — including the deploy-level ones the compose file never
-mentions — is the [configuration reference](configuration.md).
+- [Configure email](guides/operate/email.md)
+- [Change sandbox lifetimes](guides/operate/sandbox-lifetime.md)
+- [Turn on billing](guides/operate/billing.md)
 
-Then open <http://localhost:4000> and register — that's the whole first
-login. With the compose defaults (`EMAIL_DELIVERY=none`,
-`FIRST_USER_ADMIN=true`) your account self-verifies at registration and,
-being the first, is promoted to admin, recorded in the admin audit trail
-like any other role grant (ADR 0011).
+**Keeping it up.**
 
-### Watching an agent work
+- [Back up and restore](guides/operate/back-up-and-restore.md)
+- [Upgrade an instance](guides/operate/upgrade.md)
+- [Wire up observability](guides/operate/observability.md)
+- [Run a release task](guides/operate/run-a-release-task.md)
 
-Fountain's own UI is a console — the account, its keys, and the agents,
-environments and vaults a conversation runs on. Watching a conversation turn
-by turn, and messaging an agent as a teammate, are separate single-page apps
-that talk to your `/api`:
-
-| | |
-|---|---|
-| [Conversations](https://jakegaylor.com/fountain-conversations/) | start a run, watch it, steer it, read the raw log |
-| [Team](https://jakegaylor.com/fountain-team/) | your agents as teammates, one thread each |
-
-They are static builds with no server of their own: you type your Fountain's
-URL in, so the hosted copies above work against your deployment as soon as it
-admits the origin —
-
-```bash
-echo "API_CORS_ORIGINS=https://jakegaylor.com" >> .env
-```
-
-— and, if you would rather click "Sign in with Fountain" than paste an API
-key, register them in `OAUTH_CLIENTS` (see the
-[configuration reference](configuration.md)). The console links to whatever
-`CONVERSATIONS_APP_URL` and `TEAM_APP_URL` say, so pointing those at your own
-build of either repo works the same way; setting them to `""` tells the
-console this deployment has neither, and it stops offering them.
-
-Then close registration so nobody else can join:
-
-```bash
-echo "REGISTRATION_ENABLED=false" >> .env
-docker compose up -d
-```
-
-Register **before** exposing the instance to a network you don't trust:
-while no admin exists, the first verified account gets the role. Prefer the
-manual path? Set `FIRST_USER_ADMIN=false` and use `Fountain.Release`
-tasks — see [operations](operations.md):
-
-```bash
-docker compose exec app bin/fountain_server eval \
-  'Fountain.Release.promote_admin("you@example.com")'
-```
-
-## Versioning and upgrades
-
-Fountain follows [SemVer](https://semver.org/), pre-1.0: a patch release
-(`v0.3.0` → `v0.3.1`) is always safe to take; a minor release (`v0.3` → `v0.4`)
-may include breaking changes, and calls them out under **Upgrade notes** in the
-[changelog](changelog.md).
-
-Each release publishes the server image to `ghcr.io/binarybourbon/fountain`
-under two tags, alongside the tags that track development:
-
-| Tag | Moves? | Use it for |
-|---|---|---|
-| `vX.Y.Z` | Never | Pinning a known version — the recommended default |
-| `vX.Y` | To the newest patch in the line | Taking patches automatically without risking a breaking minor |
-| `latest` | On every merge to `main` | Nothing you keep running — it moves under you |
-| `sha-<commit>` | Never | Reproducing exactly what a given commit built |
-
-Releases v0.2.1 and earlier predate image tagging and exist only as `sha-`
-tags.
-
-The compose file reads `FOUNTAIN_IMAGE_TAG` from `.env`, and
-`.env.compose.example` ships it set to a pinned release — so the quick start
-above is pinned by construction. Even with the variable unset, the compose
-file falls back to a pinned release rather than `latest`.
-
-Upgrading is editing that value, then `docker compose pull && docker compose
-up -d`. Migrations run automatically at boot — idempotently, serialized by a
-Postgres advisory lock — so rolling replicas do not race each other, and there
-are no manual migration steps unless a release's upgrade notes say otherwise.
-(A migration that builds an index concurrently opts out of that lock by
-design; such migrations are written to be safe to re-run. And if you have
-moved migrations into a Job with `MIGRATE_ON_BOOT=false`, running the Job is
-the upgrade step — see [Running migrations in a
-Job](#running-migrations-in-a-job).) Downgrading is
-not supported once a newer version's migrations have run; restore from a
-backup instead.
-
-The CLI and the server are cut from the same tag, so matching versions are the
-tested pairing.
-
-The CLI's built-in default `base_url` is the hosted instance
-(`https://fountain.inevitable.fyi`), not yours. Point it at your instance
-before exporting an API key — otherwise the first unconfigured command sends
-that key to the hosted domain:
-
-```bash
-FOUNTAIN_BASE_URL=https://your-fountain.example.com fountain auth login
-```
-
-`auth login` records the URL in the saved profile, so this is a one-time step.
-
-## Back up `MASTER_SECRETS_KEY`
-
-Every environment and vault secret is encrypted with a per-tenant key that is
-itself wrapped with `MASTER_SECRETS_KEY`. **Lose it and every stored secret is
-unrecoverable; change it and the same is true.** It is not stored in the
-database, by design — so a database backup alone does not protect you.
-
-Keep it somewhere separate from your database backups, and treat rotating it as
-a migration rather than a config change.
-
-## Database
-
-The app runs its migrations at boot, so upgrading is `docker compose pull &&
-docker compose up -d`.
-
-`DATABASE_SSL` defaults to on and the compose file sets it to `false`, because a
-stock `postgres` image does not serve TLS. If you point Fountain at a managed
-database, remove that line. To verify the server certificate rather than merely
-encrypt to it:
-
-```bash
-DATABASE_SSL_VERIFY=true
-# optional, otherwise the OS trust store is used
-DATABASE_SSL_CA_FILE=/etc/ssl/certs/rds-ca.pem
-```
-
-### Running migrations in a Job
-
-Migrating at boot is right for one replica and is not the only shape. Set
-`MIGRATE_ON_BOOT=false` and the release starts without migrating; run the
-migration entrypoint yourself, once, before the new version serves:
-
-```bash
-bin/migrate     # in the image; equivalent to
-                # bin/fountain_server eval 'Fountain.Release.migrate()'
-```
-
-`bin/migrate` ignores `MIGRATE_ON_BOOT` — it is the thing you run *to*
-migrate. In Kubernetes that is a Job ordered before the rollout;
-[`deploy/k8s/README.md`](https://github.com/BinaryBourbon/fountain/blob/main/deploy/k8s/README.md)
-has the manifest.
-
-Worth knowing before you turn it off:
-
-- **Nothing verifies the Job ran.** A pod with the switch off boots happily
-  against an un-migrated database and fails on the first query that needs the
-  new column. Ordering the Job ahead of the rollout is your job, not the
-  app's.
-- **You do not need this to run several replicas.** Boot migrations are
-  serialized by a Postgres advisory lock — taken before `schema_migrations`
-  is touched, so even the first boot against an empty database does not race.
-- **What it buys you** is migrations as an explicitly reviewable step, app
-  pods that can run with a database role that cannot `ALTER`, and faster pod
-  starts on scale-up.
-
-### Backups
-
-The compose file ships a nightly `pg_dump` service, off unless you opt in:
-
-```bash
-docker compose --profile backup up -d
-```
-
-Dumps land in the `backup_data` volume and are pruned after
-`BACKUP_RETENTION_DAYS` (default 14; `BACKUP_INTERVAL_SECONDS` sets the
-cadence). **That volume is on the same host as the database** — it protects
-against bad migrations and fat fingers, not a dead machine. Copy dumps
-off-host on a schedule, and remember the standing rule: a database backup
-alone cannot decrypt itself — it pairs with the
-[`MASTER_SECRETS_KEY` you backed up separately](#back-up-master_secrets_key).
-
-On Kubernetes, `deploy/k8s/backup-cronjob.yaml` is the same discipline
-against any S3-compatible bucket — dump, size-check, upload, verify, then
-prune — commented out of the kustomization until you create its secret.
-
-Restoring, and proving you can, is in
-[Operations](operations.md#backup-and-restore). A backup nobody has restored
-is a hypothesis.
-
-## Email
-
-Fountain refuses to start in production without a mail setting, because a
-silently discarded verification email dead-ends signup with no visible error.
-Pick one:
-
-| Setting | Effect |
-|---|---|
-| `RESEND_API_KEY` | Delivery via Resend |
-| `SMTP_HOST` (+ `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`) | Any SMTP server. Port defaults to 587 with STARTTLS; omit the username for an unauthenticated relay |
-| `EMAIL_DELIVERY=none` | No email. Accounts self-verify at registration (ADR 0011) |
-
-Password reset also needs working mail. With `EMAIL_DELIVERY=none` the only
-route back into a locked-out account is the database. Provider-side setup —
-domain verification, SMTP details, what each mode means for signup — is in
-the [mail integration guide](integrations/mail.md).
-
-## Sandbox lifetime
-
-Two bounds, doing different things:
-
-| Setting | Default | |
-|---|---|---|
-| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | No turn activity for this long and the sandbox is **suspended** — the sprite stays, scaled to zero, and the next prompt wakes it with the agent's memory intact |
-| `SANDBOX_MAX_LIFETIME_HOURS` | `24` | Ceiling on a continuous run (from creation or the last wake). Crossing it **destroys** the sprite — the backstop for a conversation that never stops being busy |
-
-Set either to `0` to disable it. A value that is not a non-negative integer
-refuses to boot rather than quietly disabling the bound.
-
-Neither bound ends the conversation; it stays resumable either way. The idle
-bound is free to be aggressive — suspension loses nothing. The max-lifetime
-ceiling is not: the runtime session lives on the destroyed disk, so after a
-ceiling reclaim the next prompt provisions fresh and the agent starts without
-its memory of the earlier turns. Suspended sandboxes are never aged out —
-their sprites persist at sprites.dev until the conversation is terminated or
-the account deleted.
-
-## Billing
-
-Billing is off by default (`BILLING_ENABLED=false`; the compose file also pins
-it). The subscription gate exists for the hosted service; on your own instance
-it is a lock with no key. Leave it off
-unless you are running Fountain commercially and have configured Stripe — the
-[Stripe integration guide](integrations/stripe.md) covers that setup.
-
-With billing disabled, accounts carry no subscription status and no trial
-clock — nothing billing-shaped appears in the UI, the admin panel, or the API.
-If you later enable billing on an existing instance, those accounts have no
-trial to measure and **fail closed** at the subscription gate. Start their
-trial clocks explicitly with the release task:
-
-```bash
-# See who would be affected, change nothing:
-bin/fountain_server eval 'Fountain.Release.expire_legacy_trials(dry_run: true)'
-
-# Mark them trialing with 14 days from now:
-bin/fountain_server eval 'Fountain.Release.expire_legacy_trials(days: 14)'
-```
-
-## Putting it on the internet
-
-The compose file publishes port 4000 with no TLS. Terminate TLS in front of it
-with Caddy, nginx, or a tunnel, and then:
-
-- set `PUBLIC_URL` to the external URL, scheme included — it builds verification
-  links and is passed to every sandbox
-- set `TRUSTED_PROXIES` to your proxy's address range, or per-IP rate limits will
-  all collapse into one bucket keyed on the proxy
-- close registration, or set `REGISTRATION_ALLOWED_EMAIL_DOMAINS`
-
-An `https://` `PUBLIC_URL` also switches on HTTPS redirection, HSTS (one year,
-including subdomains — not preloaded) and the `secure` flag on the session
-cookie. All three are derived from the scheme rather than set separately,
-because none of them can be on for an `http://` instance: a cookie marked
-secure is never sent back, and the redirect would point at a port serving
-nothing. If you terminate TLS in front of Fountain, make sure your proxy sets
-`X-Forwarded-Proto` — the redirect uses it, and without it every request looks
-like plain http and loops.
-
-`CHECK_ORIGIN_EXTRA` adds origins allowed to open a LiveView websocket, as a
-comma-separated list. Your own host is always included; add to this only for
-something like a preview environment on a different domain.
-
-Registration is open by default. An instance on the public internet with
-registration open will be found.
-
-## Observability
-
-The app serves Prometheus metrics on port 9568, which the compose file does not
-publish. Add a port mapping if you are scraping it, and keep it off the public
-internet — it enumerates routes, request rates and database timings.
-
-You do not have to start from a blank scrape. The repo ships an observability
-pack built from running the hosted instance:
-
-- **Alerts** — `deploy/k8s/prometheusrule.yaml`: error rate, unhandled
-  exceptions, pool saturation, provisioning failures, and staleness watches
-  for the optional backup CronJob, each commented with what it means and what
-  to do. Needs the PrometheusRule CRD; commented out of the kustomization
-  until you enable it.
-- **A starter dashboard** — `deploy/grafana/fountain-dashboard.json`, built
-  only from metrics the app actually exports. Import it into Grafana and pick
-  your Prometheus datasource; on compose, point any Prometheus at the metrics
-  port and import the same file.
-
-Logs go to stdout: `docker compose logs -f app`.
-
-Error tracking is off unless you opt in: set `SENTRY_DSN` and crashes —
-including the ones that never touch a web request — are reported with stack
-traces, grouped, and correlated with releases. The endpoint can be sentry.io
-or anything Sentry-API-compatible (GlitchTip, for a fully self-hosted stack).
-Unset, nothing ever leaves your instance. Setup and the Crons pattern for
-backup-job alerting are in the [Sentry integration guide](integrations/sentry.md).
-
-### Health endpoints
-
-Two, because restarting a container and taking it out of a load balancer are
-different decisions:
-
-| | |
-|---|---|
-| `GET /health` | Always 200 while the app is running. Checks nothing. Point a **restart** check here — if it consulted the database, a Postgres blip would restart every container at once, which does not fix Postgres |
-| `GET /health/ready` | 200 when this instance can serve, 503 when it cannot reach its database. Point **load balancer** and deploy gates here |
-
-```bash
-curl -sS localhost:4000/health/ready
-# {"checks":{"database":"ok"},"status":"ok"}
-```
-
-Both are public and unauthenticated, and report `ok`/`error` per check with no
-further detail — a failing check does not describe your database to whoever
-asked.
-
-A healthy check takes about 2ms; an unreachable database takes a few seconds to
-give up, so give the check a timeout above one second if your platform defaults
-lower.
-
-## Kubernetes
-
-A portable baseline lives in
-[`deploy/k8s/`](https://github.com/BinaryBourbon/fountain/tree/main/deploy/k8s)
-— plain manifests applied with `kubectl apply -k`, no operators or CRDs
-assumed. You bring a Postgres, an ingress controller, and the
-`fountain-secrets` Secret; its README walks through the rest, and the probe
-and scaling reasoning is commented inline in the manifests.
-
-`k8s/` in this repository is a different thing: the maintainer's own cluster
-(CNPG, Traefik, cert-manager, Infisical, Flux, Longhorn, personal hostnames).
-It is worth reading — it shows the full Erlang-clustering wiring for running
-more than one replica — and is not worth applying.
+When something is wrong, start from
+[Troubleshooting](troubleshooting/index.md).
 
 ## Licence
 
-Fountain is MIT licensed — running your own instance is explicitly fine,
+Fountain is MIT licensed. Running your own instance is explicitly fine,
 including commercially.
 
 ## Known gaps
 
-Being straight about what self-hosting does not yet include:
+Being straight about what self-hosting does not yet include.
 
-- **Sandbox backends are hosted dependencies** — Sprites, E2B and Daytona
-  are all services (self-hosted Daytona narrows this). The contract a new
-  backend must satisfy is executable — `Fountain.Sandbox` plus its
-  conformance suite — and written down in
+- **Sandbox backends are hosted dependencies.** Sprites, E2B and Daytona are
+  all services, and self-hosted Daytona narrows this. The contract a new
+  backend must satisfy is executable, `Fountain.Sandbox` plus its conformance
+  suite, and written down in
   [the sandbox contract](integrations/sandbox-contract.md).

--- a/docs/troubleshooting/conversation-stuck-or-failed.md
+++ b/docs/troubleshooting/conversation-stuck-or-failed.md
@@ -1,0 +1,76 @@
+# A conversation is stuck or failed
+
+This guide shows you how to find which step failed and what to do about it.
+
+## Read the stage events
+
+Open the conversation's log view. Provisioning progress is recorded as stage
+events, `provision`, `checkpoint_restore`, `packages`, `network`, `clone`,
+`setup`, `turn`. The failing step names itself, with the exit code in the event
+data.
+
+**`packages`, `clone` or `setup` failed.** Almost always the environment's own
+configuration. A package that does not exist, a repository the token cannot
+reach, a setup script exiting non-zero. Fix the environment and prompt again.
+
+**`provision` failed outright.** The sandbox could not be created. The provider
+is unhealthy, the token is invalid, or the user is at their concurrent-sandbox
+quota. See [Sandbox errors](sandbox-errors.md).
+
+**Stuck with no failure.** A conversation `running` with no events arriving
+usually means the sandbox-side process died and the exit was missed. Interrupt
+it, or just send another prompt, because waking reattaches to the existing
+sandbox when it still exists.
+
+```bash
+fountain conv show <conv-id>          # turn status, sandbox name
+fountain conv interrupt <conv-id>     # stop the in-flight turn, keep the sandbox
+fountain conv terminate <conv-id>     # destroy the sandbox, end the conversation
+```
+
+## What the statuses mean
+
+`failed` and `terminated` are the two terminal states, and a further prompt is
+refused.
+
+`idle` with a *suspended* sandbox is the normal resting state rather than an
+error. The sandbox is parked, scaled to zero, and the next prompt wakes it with
+the agent's memory intact.
+
+`idle` with a *destroyed* sandbox is what the max-lifetime ceiling, or an
+explicit reap, leaves behind. The next prompt provisions fresh and the stored
+transcript is unaffected, but the agent starts a fresh session. See
+[About conversations](../concepts/conversation.md) and the full table in
+[Conversation states](../reference/conversation-states.md).
+
+## Quota knock-on
+
+A crash mid-provision leaves a `pending` or `starting` sandbox row that counts
+against the user's quota, default 5 concurrent.
+
+The reaper runs hourly at :07 and releases rows stuck longer than 60 minutes.
+An admin can raise a user's cap from `/admin` immediately.
+
+The reaper logs one summary line per run.
+
+```bash
+kubectl logs -n fountain -l app=fountain --since=2h | grep 'reaper:'
+# reaper: released=0 parked=1 expired=0 destroyed=2 untracked=102 live=114
+```
+
+`parked` is the reaper suspending idle sandboxes, which is reversible
+bookkeeping rather than a teardown.
+
+## One trap worth knowing
+
+On the default provider, a failed setup script or clone can record as
+successful, because the exec transport reports exit code 0 for every command
+([#880](https://github.com/BinaryBourbon/fountain/issues/880), open). Read the
+logged output rather than trusting the stage status when a conversation starts
+in a state you did not expect.
+
+## Related
+
+- [Sandbox errors](sandbox-errors.md).
+- [Conversation states](../reference/conversation-states.md).
+- [Change sandbox lifetimes](../guides/operate/sandbox-lifetime.md).

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -1,0 +1,37 @@
+# Troubleshooting
+
+Start from the symptom you can see. Each page names the symptom, what causes
+it, and what to run.
+
+[Architecture](../architecture.md) tells you which component owns a symptom.
+These pages are the action level, meaning what to run and what the output
+means. Commands are shown for both deploy paths where they differ.
+
+## By symptom
+
+| You see | Read |
+|---|---|
+| A conversation sits in `running` with no output, or went `failed` | [A conversation is stuck or failed](conversation-stuck-or-failed.md) |
+| Provisioning fails while everything else is healthy | [Sandbox errors](sandbox-errors.md) |
+| Pods restart, or sit NotReady | [Pods restarting or not ready](pods-restarting.md) |
+| Registration completes but nobody gets past "check your email" | [Nobody can log in](nobody-can-log-in.md) |
+| Everyone is rate-limited at once | [Nobody can log in](nobody-can-log-in.md) |
+| A rollout never completes | [Upgrade an instance](../guides/operate/upgrade.md) |
+| A restore is needed | [Back up and restore](../guides/operate/back-up-and-restore.md) |
+
+## Client-side problems
+
+If the failure is in something driving Fountain rather than in Fountain, the
+client's own page carries its failure modes.
+
+- [`fountain acp`](../integrations/acp.md), the adapter editors and chat
+  surfaces spawn.
+- [Editors](../integrations/editors.md).
+- [OpenClaw](../integrations/openclaw.md).
+- [OpenBot](../integrations/openbot.md).
+- [Buzz](../integrations/buzz.md).
+
+## Setting up a workstation
+
+Problems with a local development checkout are in
+[Setup](../setup.md), not here.

--- a/docs/troubleshooting/nobody-can-log-in.md
+++ b/docs/troubleshooting/nobody-can-log-in.md
@@ -1,0 +1,58 @@
+# Nobody can log in
+
+This guide shows you how to work down the chain from the most common cause to
+the least.
+
+Note the symptom, because it misleads. The password is accepted and the session
+is real, but it never leaves the "check your email" page, so this reads as a
+broken app rather than a refused login.
+
+## 1. Did the verification email go anywhere?
+
+An instance with `EMAIL_DELIVERY=none` sends nothing, and that is the compose
+default.
+
+Verify an account by hand.
+
+```bash
+docker compose exec app bin/fountain_server eval \
+  'Fountain.Release.verify_email("them@example.com")'
+```
+
+If that unblocks the account, the problem is mail. See
+[Configure email](../guides/operate/email.md).
+
+## 2. Mail configured but not arriving
+
+An unverified sending domain (SPF, DKIM, DMARC) is accepted by the provider and
+then rejected or spam-foldered downstream. See the
+[mail integration guide](../integrations/mail.md).
+
+## 3. OAuth still works when mail does not
+
+GitHub sign-ins arrive already verified, so they are a way back in while mail
+is broken.
+
+Conversely, a GitHub outage breaks only the button. Password auth is
+unaffected.
+
+## 4. Password reset needs working mail
+
+With `EMAIL_DELIVERY=none` a locked-out password account has no self-serve
+route back. That is the trade-off the mode's boot notice warns about, and the
+only route is a release task.
+
+## 5. 429 responses
+
+The API rate limit is 600 requests per minute per IP.
+
+If *everyone* is rate-limited at once behind a proxy, `TRUSTED_PROXIES` is
+unset and every client is sharing the proxy's bucket. See
+[Put it on the internet](../guides/operate/put-it-on-the-internet.md).
+
+## Related
+
+- [Configure email](../guides/operate/email.md).
+- [Run a release task](../guides/operate/run-a-release-task.md), for
+  `verify_email/1` and `promote_admin/1`.
+- [Mail integration guide](../integrations/mail.md).

--- a/docs/troubleshooting/pods-restarting.md
+++ b/docs/troubleshooting/pods-restarting.md
@@ -1,0 +1,50 @@
+# Pods restarting or not ready
+
+This guide shows you how to tell the probe layout working as designed from a
+real failure.
+
+Most "kubernetes is broken" symptoms here are the first thing.
+
+## What is working as designed
+
+**Liveness checks nothing but the process.** A restart does not fix Postgres,
+so `/health` always answers 200 while the BEAM runs.
+
+**Readiness checks Postgres.** A pod that cannot reach its database answers 503
+on `/health/ready`, is drained from the Service without being killed, and
+recovers on its own. **NotReady during a database blip with no restarts is the
+system behaving correctly.** Answering that 503 takes about 3 seconds, so give
+external checks a timeout above that.
+
+**The startup probe holds the others off for up to 150 seconds**, because
+migrations run at boot, before the listener opens. A slow migration is not a
+dead pod.
+
+## Failure modes that are real
+
+**Boot loop.** Migrations cannot reach the database at all. The container fails
+before anything listens. Check `DATABASE_URL` and the database itself. See
+[Connect a database](../guides/operate/database.md).
+
+**A 301 where a probe expected 200.** On an `https://` instance every path
+redirects http to https *except* `/health` and `/health/ready`, which are
+exempt precisely because probes hit the pod over plain http. A check pointed at
+any other path scores the redirect as a failure. Point checks at the two health
+endpoints only.
+
+**Redirect loop in the browser.** The proxy in front is not setting
+`X-Forwarded-Proto`, so every request looks like http and gets redirected to
+itself. Fix the proxy header. See
+[Put it on the internet](../guides/operate/put-it-on-the-internet.md).
+
+**A rollout that never completes.** Usually the startup probe failing, meaning
+migrations that cannot finish, or a readiness probe failing against a database
+problem that predates the deploy. See
+[Upgrade an instance](../guides/operate/upgrade.md).
+
+## Related
+
+- [Wire up observability](../guides/operate/observability.md), for what each
+  health endpoint is for.
+- [Deploy on Kubernetes](../guides/operate/kubernetes.md).
+- [Architecture](../architecture.md), for which component owns which symptom.

--- a/docs/troubleshooting/sandbox-errors.md
+++ b/docs/troubleshooting/sandbox-errors.md
@@ -1,0 +1,57 @@
+# Sandbox errors
+
+This guide shows you how to read a provisioning failure, and what the retries
+have already tried on your behalf.
+
+The examples below are the Sprites path, which is the default. The shape is the
+same on other providers, because every adapter normalizes provider errors into
+one taxonomy. See
+[the sandbox contract](../integrations/sandbox-contract.md).
+
+## What the retries already cover
+
+Transient failures on the provisioning path (5xx, 429, timeouts) are tried up
+to three times, meaning two retries, with exponential backoff. Each call is
+bounded by `SPRITES_TIMEOUT_MS`, default 30s.
+
+You only see a failure after that has been exhausted.
+
+## What a 4xx means
+
+These are deliberately **not** retried.
+
+- **401 or 403.** The provider token is invalid, revoked, or missing. Check
+  this first, because it fails every conversation while everything else looks
+  healthy.
+- **409 on create.** Already handled. The existing sandbox is adopted, so this
+  is not an error you will see.
+
+## During a provider outage
+
+New conversations and wakes fail. A fresh provision marks the conversation
+`failed`, and a wake leaves it resumable for later.
+
+Sign-in, dashboards, configuration and past logs keep serving.
+
+The readiness probe deliberately excludes the sandbox provider, because a third
+party's uptime does not belong on the serving path. Do not expect pods to go
+NotReady over it.
+
+If you scrape metrics, provisioning failures show as
+`fountain_stage_count{stage="provision", status="failed"}`, and completions as
+`status="done"`.
+
+## Quota, not outage
+
+A user at their concurrent-sandbox quota, default 5, sees provisioning fail
+while the provider is perfectly healthy. Crashed provisions leave rows that
+count until the reaper releases them, hourly at :07. See
+[A conversation is stuck or failed](conversation-stuck-or-failed.md).
+
+## Related
+
+- [A conversation is stuck or failed](conversation-stuck-or-failed.md).
+- [The sandbox contract](../integrations/sandbox-contract.md), for the shared
+  error taxonomy.
+- [Wire up observability](../guides/operate/observability.md), for the
+  provisioning-failure alert.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,8 +77,26 @@ nav:
       - Agents as teammates: concepts/teammates.md
       - Architecture: architecture.md
   - Setup: setup.md
-  - Self-hosting: self-hosting.md
-  - Operations: operations.md
+  - Run an instance:
+      - Self-hosting: self-hosting.md
+      - Deploy an instance: guides/operate/deploy.md
+      - Put it on the internet: guides/operate/put-it-on-the-internet.md
+      - Connect a database: guides/operate/database.md
+      - Deploy on Kubernetes: guides/operate/kubernetes.md
+      - Configure email: guides/operate/email.md
+      - Change sandbox lifetimes: guides/operate/sandbox-lifetime.md
+      - Turn on billing: guides/operate/billing.md
+      - Back up and restore: guides/operate/back-up-and-restore.md
+      - Upgrade an instance: guides/operate/upgrade.md
+      - Wire up observability: guides/operate/observability.md
+      - Run a release task: guides/operate/run-a-release-task.md
+      - Operations overview: operations.md
+  - Troubleshooting:
+      - Overview: troubleshooting/index.md
+      - A conversation is stuck or failed: troubleshooting/conversation-stuck-or-failed.md
+      - Sandbox errors: troubleshooting/sandbox-errors.md
+      - Pods restarting or not ready: troubleshooting/pods-restarting.md
+      - Nobody can log in: troubleshooting/nobody-can-log-in.md
   - Configuration reference: configuration.md
   - Sandbox providers:
       - The contract: integrations/sandbox-contract.md


### PR DESCRIPTION
Closes #904. Closes #905. Part of #903.

## Why

`self-hosting.md` was 393 lines holding at least ten how-tos plus a reference
plus an explanation. `operations.md` was 290 lines holding seven runbooks.

Both are the correct Diátaxis mode and the wrong granularity. A how-to is
bounded by the user's goal, so a page holding ten goals is bounded by nothing,
which is how they reached that length. An operator with a stuck conversation
at 3am was scrolling past a Postgres restore drill to reach it.

## What changed

**Eleven operator guides** under `guides/operate/`: deploy, put it on the
internet, connect a database, Kubernetes, configure email, change sandbox
lifetimes, turn on billing, back up and restore, upgrade, observability, run a
release task.

**Five troubleshooting pages**, titled as the symptom the reader observes,
with an index that is a symptom table.

**Both originals keep their paths as hubs.** That is load-bearing:
`self-hosting.md` has 11 inbound links, and `README.md` plus two source
comments point at the path. It is where a self-hoster lands from GitHub.

`upgrade.md` merges self-hosting's "Versioning and upgrades" with operations'
"Upgrade gone wrong", and `back-up-and-restore.md` merges self-hosting's
"Backups" and "Back up `MASTER_SECRETS_KEY`" with operations' "Backup and
restore" and its drill. Those pairs were describing one job from two pages.

## There was no user-facing troubleshooting door

`operations.md` is operator-facing and assumes `kubectl` and Flux. Meanwhile
five client pages had independently grown their own "When something goes
wrong" sections (`acp.md`, `editors.md`, `openclaw.md`, `openbot.md`,
`buzz.md`). A developer whose conversation failed had nowhere to start.
`troubleshooting/index.md` now routes to both.

## Anchors

Eight inbound anchors are repointed: `#backups`, `#kubernetes`,
`#health-endpoints`, `#email` ×2, `#back-up-master_secrets_key`,
`#sandbox-lifetime` ×2, `#running-migrations-in-a-job`.

`docs_test.exs` renders every page and asserts each `](/docs/x#anchor)` target
is a real heading, so a missed repoint fails CI rather than shipping. This is
also the first PR where the strict MkDocs build actually runs, thanks to the
`docs_touched` gate from #901.

Two weak links improved while passing through: `sdk.md`'s "suspended sandbox"
pointed at `operations.md` and now points at the state table;
`build/pieces.md` pointed a stuck sandbox at `operations.md` and now points at
troubleshooting.

## One factual addition

`troubleshooting/conversation-stuck-or-failed.md` notes that the default
provider reports exit code 0 for every command, so a failed clone or setup
script records as successful. I checked #880 is still open before writing it.
That is the single most confusing thing about reading a failed conversation
and it was documented nowhere.

Everything else moves close to verbatim. New prose is the per-page opener, the
Verify sections, and the routing.

## Verification

- `mkdocs build --strict`, clean
- `docs_test.exs` + `docs_controller_test.exs`, 32 tests 0 failures
- No em dashes or colon-introduced lists in the new pages, per #911

393 + 290 lines become 1,198 across 18 pages. The growth is openers, verify
steps and cross-links, which is the point: `diataxis.fr/how-to-guides/` argues
the list of guides "helps frame the picture of what your product can actually
do", and ten runbooks hidden inside two pages framed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
