### PR TITLE
docs: the three missing explanation pages

### DIFF
--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -1,0 +1,107 @@
+# About sandboxes
+
+This page explains what a sandbox is, why Fountain does not let you create one,
+and what changes when you switch providers. For the executable contract a
+backend must meet, see
+[the sandbox contract](../integrations/sandbox-contract.md). To pick and
+configure one, see [Self-hosting](../self-hosting.md).
+
+## What a sandbox is
+
+A sandbox is the isolated machine one [conversation](conversation.md) runs in.
+
+It is not a primitive. You never create, name or address one. It is provisioned
+when a conversation starts and reclaimed when the conversation goes quiet or
+runs too long.
+
+That is deliberate. A sandbox you could create independently would be a
+resource you could leak, and the thing that makes agent infrastructure
+expensive is machines nobody remembered to turn off.
+
+## Why the lifecycle is attached to the conversation
+
+Tie the machine to the run and three problems solve themselves.
+
+Reclamation has an owner. When the conversation is idle, the machine is idle,
+and there is no separate bookkeeping to get wrong.
+
+Cost has a shape a user recognises. "This conversation cost something" is
+legible in a way "you have 14 sandboxes" is not.
+
+Memory has somewhere to live. The runtime keeps its session on the sandbox's
+disk, so suspending and waking is the same thing as pausing and resuming the
+conversation. See [About conversations](conversation.md).
+
+## One seam, four backends
+
+Every backend plugs into the same seam, `Fountain.Sandbox`. The contract is
+executable rather than described. The behaviour specifies callbacks,
+capabilities and an error taxonomy, and a conformance suite every adapter must
+pass covers replay-from-start attach, total `write_stdin`, exactly one terminal
+frame per command, and that `allow: []` means deny-all.
+
+| Provider | What it is | Suspend |
+|---|---|---|
+| [Sprites](../integrations/sprites.md) | The original backend and the instance default | Parks implicitly, scaling to zero on its own, disk preserved |
+| [E2B](../integrations/e2b.md) | Hosted | Explicit pause, snapshotting filesystem **and memory** |
+| [Daytona](../integrations/daytona.md) | Hosted, self-hostable | Explicit stop, disk preserved, archiving when long-parked |
+| [Self-hosted runner](../integrations/runners.md) | `fountain runner` on a machine the **user** owns | Stops processes, directory stays |
+
+## Capabilities are honest, and that has consequences
+
+An adapter advertises what it can actually do (`:suspend`, `:network_policy`,
+`:attach`, `:tty`, `:checkpoint`, `:public_url`), and the lifecycle degrades
+accordingly rather than pretending.
+
+A provider without `:suspend` **destroys on idle** rather than faking a park.
+Resuming with a fresh disk would be silent loss of the agent's memory, which is
+worse than an honest teardown.
+
+So the idle timeout does not mean the same thing everywhere. On Sprites it
+costs nothing. On a provider without suspend it costs the agent's working
+memory. See
+[Change sandbox lifetimes](../guides/operate/sandbox-lifetime.md).
+
+Three other consequences worth knowing.
+
+**A runner has no isolation.** It runs in trusted mode on a machine the user
+owns, with no egress policy. It is a way to use hardware you already have, not
+a security boundary.
+
+**TTY is Sprites-only.**
+
+**Existing sandboxes never move.** A parked disk lives where it was written, so
+waking never crosses providers, and switching the instance default only affects
+new sandboxes.
+
+## Anything an agent serves may be public
+
+Providers that give a sandbox its own HTTP endpoint advertise `:public_url`,
+and the URL is set inside the sandbox as `SANDBOX_URL` so an agent asked "where
+is it running?" can answer.
+
+On Sprites that endpoint defaults to requiring a platform credential, and
+Fountain opens it, because an agent serving a page is doing it for a human who
+has no such credential.
+
+**So anything an agent serves is reachable by anyone with the URL.** Set
+`config :fountain, :sprites_public_urls, false` to keep the default instead.
+Sandboxes then keep their URLs and only a token holder can open them.
+
+## Not a container you can hand us
+
+Fountain does not build or store images. A provider applies your
+[environment](environment.md) as a recipe at provision time, so two
+conversations from the same environment install their packages independently.
+
+That costs provisioning time and buys not having a registry, a build pipeline,
+or a garbage-collection problem.
+
+## Where to go next
+
+- [The sandbox contract](../integrations/sandbox-contract.md), the executable
+  version of this page.
+- [About conversations](conversation.md), whose lifecycle this follows.
+- [Change sandbox lifetimes](../guides/operate/sandbox-lifetime.md).
+- [Adding a provider](../integrations/adding-a-sandbox-provider.md), if you
+  want a fifth.

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -1,0 +1,160 @@
+# Where a secret comes from
+
+This page explains the whole chain, from the key on the server to the string an
+agent's process reads. To put a value somewhere, see
+[About environments](environment.md) and [About vaults](vault.md). For the
+operator side, see
+[Back up and restore](../guides/operate/back-up-and-restore.md).
+
+## Four hops
+
+A secret you type into Fountain is transformed four times before an agent sees
+it.
+
+```
+MASTER_SECRETS_KEY          (the platform key, never in the database)
+        |  wraps
+        v
+per-tenant DEK              (one per user, stored wrapped)
+        |  encrypts
+        v
+the stored value            (AES-256-GCM, at rest)
+        |  merged at spawn
+        v
+environment + vault         (vault wins on collision)
+        |  ${VAR} substitution
+        v
+the process environment     (inside the sandbox)
+```
+
+Each hop exists for a different reason, and knowing which one you are looking
+at is usually the difference between a five-minute problem and an afternoon.
+
+## Hop 1: the master key wraps a per-tenant key
+
+Every tenant has a data encryption key, a DEK. The DEK is what actually
+encrypts that tenant's values.
+
+The DEK is not stored in the clear. It is stored wrapped with AES-256-GCM under
+`MASTER_SECRETS_KEY`, in `user_data_keys.wrapped_key`.
+
+`MASTER_SECRETS_KEY` is a 32-byte binary, base64url-encoded, set at runtime.
+**It is deliberately not in the database.** That is the whole point of the
+arrangement, and it is also why a database backup on its own is useless. See
+[Back up and restore](../guides/operate/back-up-and-restore.md).
+
+In dev and test a deterministic key is derived from a fixed phrase. Production
+refuses to boot without a real one.
+
+If this shape feels familiar, it is the same one HashiCorp Vault uses. Unseal
+key wraps root key wraps keyring wraps data. That analogy holds here, unlike
+almost everything else about the word "vault". See
+[About vaults](vault.md).
+
+## Hop 2: the DEK encrypts the value
+
+The DEK's lifecycle is short and explicit.
+
+1. At user creation, generate a DEK, wrap it, store it.
+2. At conversation start, load the tenant key and unwrap the DEK.
+3. While the conversation runs, the unwrapped DEK is held in the conversation
+   process's own state, and every encrypt and decrypt is passed it explicitly.
+4. When the conversation ends, the DEK is dropped from that state.
+
+Passing the DEK explicitly rather than looking it up is what makes tenant
+isolation a property of the call rather than a convention. A function that
+needs a DEK cannot accidentally use somebody else's.
+
+Values are write-only from the outside. Listing a vault or an environment
+returns keys and timestamps. There is no endpoint that returns a value, for
+anyone, including the owner.
+
+## Hop 3: environment and vault merge
+
+At the moment a conversation starts, Fountain resolves the full set.
+
+```
+environment secrets  --merge-->  vault secrets  -->  the sandbox
+                                       ^
+                               wins on collision
+```
+
+The merge happens once, at spawn. Editing either afterwards does not reach a
+sandbox that is already running.
+
+A conversation may name a different environment than its agent's default, and
+may attach a vault, and both are scoped by the agent's
+`allowed_environment_ids` and `allowed_vault_ids`.
+
+Non-secret `env_vars` from the environment are merged in too. They are stored
+and returned in the clear, so the distinction between `env_vars` and `secrets`
+is about who can read the value back, not about who can use it.
+
+## Hop 4: substitution, then the process
+
+Agent config strings support `${VAR}` interpolation, resolved against the
+merged map. This is how an MCP server declaration gets a credential without the
+credential being written into the agent.
+
+```yaml
+mcp_servers:
+  github:
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PAT}"
+```
+
+Substitution is recursive, so it reaches inside maps and lists, and it is
+fail-complete. Every missing variable is reported at once rather than one per
+attempt, because the alternative is fixing a config one name at a time.
+
+`$$` is a literal `$`.
+
+## What the chain does not do
+
+**No rotation.** Nothing expires a value or tells an agent it went stale.
+
+**No revocation of a live process.** Removing a vault from an agent's
+allowlist stops future conversations attaching it. A sandbox already running
+keeps what it was given, because by then the value is in a process's
+environment on a machine.
+
+**No read audit.** Fountain audits the write, by key and by size, never by
+value. It cannot audit the read, because the read happens inside the sandbox.
+
+**No protection against the agent.** Anything in the merged map is readable by
+the code running in that sandbox, which is the point of putting it there. Scope
+the credential, do not scope the agent.
+
+## Hop 5, which is really a hop back: output is scrubbed
+
+Everything a sandbox writes to stdout or stderr is persisted verbatim into
+`log_events` and streamed over SSE. That table has none of the envelope
+encryption above, and it outlives the conversation.
+
+So an `env`, a `set -x`, a `cat .env` in a setup script, or an agent that
+simply prints its environment would write plaintext credentials into Postgres.
+Fountain removes every known secret value from output before it is stored.
+
+Two consequences worth knowing.
+
+**A smoke test that echoes a secret prints `[REDACTED]`.** That is the system
+working. Ask for a character count instead if you need to confirm a value
+arrived.
+
+**There is a length floor of 8 bytes.** Sandbox environments hold plenty of
+short non-secrets, such as `true`, `1`, a port or a region, and redacting those
+would turn logs into noise while protecting nothing. The case this misses is a
+deliberately short password. Do not use one.
+
+The values live in a registry that the single log writer consults, rather than
+being passed to each caller, because the scrubber this replaced was applied on
+the HTTPS clone path and not the SSH one. Redaction a caller has to remember
+will eventually be forgotten by a new caller.
+
+## Where to go next
+
+- [About environments](environment.md), the baseline half of the merge.
+- [About vaults](vault.md), the override half.
+- [Back up and restore](../guides/operate/back-up-and-restore.md), because
+  hop 1 decides what a backup is worth.
+- [Architecture](../architecture.md), for where each piece runs.

--- a/docs/concepts/surfaces.md
+++ b/docs/concepts/surfaces.md
@@ -1,0 +1,100 @@
+# The console, the apps, and the API
+
+This page explains why Fountain's own UI does not show you an agent working,
+and where that happens instead. For connecting your own client, see
+[Plugging into Fountain](../integrations/clients.md).
+
+## Three surfaces, on purpose
+
+| Surface | What it is | Where it runs |
+|---|---|---|
+| The console | Fountain's own browser UI | The Fountain server |
+| The apps | Conversations and Team | Their own origins, on `/api` |
+| The API | REST, SSE, plus the CLI and SDK over it | Anywhere |
+
+## The console is an operator console
+
+Fountain's own UI covers the dashboard, agents, environments, vaults, audit,
+API keys, account and admin.
+
+It is deliberately not an interactive application. You configure things in it.
+You do not watch an agent work in it.
+
+## Watching an agent work is a different application
+
+Two single-page apps sit on `/api`, each on its own origin with its own OAuth
+client.
+
+| App | What it does |
+|---|---|
+| [Conversations](https://github.com/jhgaylor/fountain-conversations) | start a run, watch it, steer it, read the raw log |
+| [Team](https://github.com/jhgaylor/fountain-team) | agents as teammates, one thread each |
+
+They replaced in-app LiveViews. `/conversations`, `/conversations/new`,
+`/conversations/:id`, `/conversations/:id/logs`, `/team` and `/team/:agent_id`
+now redirect rather than 404, because links to them are in sent emails, in
+filed support issues, in agents' skills and in people's bookmarks. `/onboarding`
+goes to the dashboard, whose checklist replaced the wizard.
+
+The redirect is a 302 rather than a 301, deliberately. A permanent redirect
+would be cached in browsers past any future change of mind.
+
+## Why split them
+
+**A conversation UI is a real-time application and a console is not.** Turn
+streaming, tool-call rendering, steering a run mid-turn and interrupting it are
+a different engineering problem from a form that writes a row. Putting both in
+one LiveView meant every change to either risked the other.
+
+**The apps are static builds with no server.** You type your Fountain's URL in.
+That means one hosted build works against every deployment, including yours,
+as soon as the server admits the origin.
+
+```
+API_CORS_ORIGINS=https://jakegaylor.com
+```
+
+**It forces the API to be complete.** If the only way to watch a conversation
+is over `/api`, then `/api` has everything a client needs, and anyone building
+their own client is on equal footing with the first-party one. `?blocks=true`
+on the event streams exists for exactly this reason. The server does the
+runtime-dialect parsing so no client re-implements it.
+
+That last point is the real argument. A console that could do things the API
+could not would quietly make the API second-class.
+
+## What this means for you
+
+**Building a conversation-facing feature?** It goes in the app, not in
+Fountain. The server's job is to serve it.
+
+**Self-hosting?** The hosted apps work against your instance once you set
+`API_CORS_ORIGINS`. If you would rather host your own build, point
+`CONVERSATIONS_APP_URL` and `TEAM_APP_URL` at it. Setting either to an empty
+string tells the console this deployment has no such app, and it stops
+offering it. See [Deploy an instance](../guides/operate/deploy.md).
+
+**Writing something that links a human to a transcript?** Read the URL from
+the one place that knows it. The console's links, an email's "open it", a
+forwarded support report and `/api/catalog` all agree because they all ask the
+same module.
+
+## What this is not
+
+**Not a microservice split.** There is one server and one database. The apps
+are static files with no backend of their own.
+
+**Not a plugin system.** The apps are ordinary API clients with no special
+access. Yours would have the same.
+
+**Not permanent for the console.** The console keeps whatever a human needs
+that is not a conversation. That boundary can move, and the redirects exist so
+it can move without breaking links.
+
+## Where to go next
+
+- [Plugging into Fountain](../integrations/clients.md), for editors, chat
+  surfaces, plugins and SDKs.
+- [Build a chat app](../build/index.md), the case for the API underneath.
+- [API reference](../api.md).
+- [Agents as teammates](teammates.md), which is what the Team app renders.

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,11 @@ it goes quiet.
   [Conversation](concepts/conversation.md)
 - [Agents as teammates](concepts/teammates.md), why a teammate is not a fifth
   primitive
+- [Where a secret comes from](concepts/secrets.md), the chain from the master
+  key to the agent's process
+- [About sandboxes](concepts/sandboxes.md), the machine a conversation runs on
+- [The console, the apps, and the API](concepts/surfaces.md), why watching an
+  agent work happens somewhere else
 - [Architecture](architecture.md), what runs, what it talks to, and what breaks
   when a dependency is down
 - [Why a bot needs more than a chat UI](build/index.md), the case for the API

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -86,7 +86,10 @@ Conversation starts and reclaimed when it ends. See
   [Vault](concepts/vault.md),
   [Agent](concepts/agent.md),
   [Conversation](concepts/conversation.md).
-- **Understand the machinery.** [Architecture](architecture.md) follows a
+- **Understand the machinery.**
+  [Where a secret comes from](concepts/secrets.md) follows a value from the
+  master key to the process. [About sandboxes](concepts/sandboxes.md) covers
+  the machine a run happens on. [Architecture](architecture.md) follows a
   prompt from the API call to the first token.
 - **Look something up.** The [API reference](api.md) has every field,
   [Conversation states](reference/conversation-states.md) has the state table,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,9 @@ nav:
       - Agent: concepts/agent.md
       - Conversation: concepts/conversation.md
       - Agents as teammates: concepts/teammates.md
+      - Where a secret comes from: concepts/secrets.md
+      - About sandboxes: concepts/sandboxes.md
+      - The console, the apps, and the API: concepts/surfaces.md
       - Architecture: architecture.md
   - Setup: setup.md
   - Run an instance:


### PR DESCRIPTION
Closes #910. Part of #903.

Completes the concepts tree #901 started. Three pages, each answering a
question that had no page, only fragments scattered across others.

## Where a secret comes from

The chain existed in three places (`architecture.md`'s secrets model, the
vault merge rule, the substitution table) and nothing joined them. This
follows one value through five hops.

```
MASTER_SECRETS_KEY -> per-tenant DEK -> stored value
   -> environment + vault merge (vault wins) -> ${VAR} -> the process
```

The fifth hop is the one that was documented nowhere public and that surprises
people: **output is scrubbed**, so a smoke test that echoes a secret prints
`[REDACTED]`. That is the system working, and the fix is to ask for a
character count.

The page states the 8-byte floor and names the case it misses, a deliberately
short password. `Redaction`'s own moduledoc is honest about that gap
("worth knowing about"), and the docs should be too. It also explains why the
values live in a registry rather than being passed per-caller: the scrubber
this replaced was applied on the HTTPS clone path and not the SSH one.

## The console, the apps, and the API

Why Fountain's own UI does not show you an agent working was documented only
in `CLAUDE.md`, which is a contributor file. `docs/` never stated it, despite
it being a decision anyone building against Fountain runs into immediately.

Three reasons, and the third is the real one: if the only way to watch a
conversation is over `/api`, then `/api` has everything a client needs, and
anyone building their own is on equal footing with the first-party one. A
console that could do things the API could not would quietly make the API
second-class.

Includes the practical consequences — build conversation features in the app,
set `API_CORS_ORIGINS` when self-hosting, read app URLs from the one module
that knows them — and a "what this is not" section, since "microservices" and
"plugin system" are both wrong readings.

## About sandboxes

The explanation half of `integrations/sandbox-contract.md`, which was mixing
explanation and reference on one page. Leads with why you cannot create a
sandbox, since that is the first question, and why tying the machine to the
run solves reclamation, cost legibility and where memory lives.

Spells out something the contract page states as a capability list but not as
a consequence: **the idle timeout does not cost the same on every provider.**
On Sprites it costs nothing. On a provider without `:suspend` it destroys, and
the agent loses its working memory. Also surfaces that anything an agent
serves over `SANDBOX_URL` is reachable by anyone with the URL, and the config
that changes it.

## Verification

Every claim checked against source, not memory:

| Claim | Source |
|---|---|
| DEK lifecycle, wrap algorithm, master key format | `fountain/crypto.ex` |
| 8-byte floor, registry rationale, the short-password gap | `conversations/redaction.ex` |
| App URLs, `API_CORS_ORIGINS`, empty-string semantics | `fountain/apps.ex` |
| 302 not 301, which paths redirect and why | `moved_controller.ex` |
| Capability list, suspend semantics per provider | `integrations/sandbox-contract.md` |

- `mkdocs build --strict`, clean
- `docs_test.exs` + `docs_controller_test.exs`, 32 tests 0 failures
- No em dashes or colon-introduced lists, per #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)
