### PR TITLE
docs: a catalog, starting with runtimes and skills

### DIFF
--- a/docs/catalog/index.md
+++ b/docs/catalog/index.md
@@ -1,0 +1,37 @@
+# Catalog
+
+The things you can plug into an agent, and the things Fountain plugs into.
+
+Each entry follows the same shape, so once you have read one you can skim the
+rest.
+
+## Pick an agent's parts
+
+| Catalog | An entry is | Count |
+|---|---|---|
+| [Runtimes](runtimes/index.md) | one coding-agent CLI a sandbox can run | 4 |
+| [Skills](skills/index.md) | one `SKILL.md` written into the sandbox | 2 bundled, plus anything on GitHub |
+
+## Elsewhere in these docs
+
+Two catalogs predate this section and keep their own pages for now.
+
+**[Sandbox providers](../integrations/sandbox-contract.md).** Where a
+conversation's machine comes from. Sprites, E2B, Daytona, or a machine you own
+through `fountain runner`.
+
+**[Services Fountain uses](../integrations/index.md).** What an operator
+configures. Mail, GitHub OAuth, Stripe, Sentry.
+
+**[Plugging into Fountain](../integrations/clients.md).** What drives Fountain
+from outside. Editors, chat surfaces, plugin hosts, relays, your own code.
+
+## What is not here yet
+
+**MCP servers.** `mcp_servers` is a first-class Agent field and there is no
+list of what works. Tracked in
+[#908](https://github.com/BinaryBourbon/fountain/issues/908), and it needs a
+decision about what "supported" means before it can be written honestly.
+
+If you want an entry that does not exist, open an issue. The entry template is
+in `docs-redesign/05-catalog-template.md` in the repository.

--- a/docs/catalog/runtimes/claude.md
+++ b/docs/catalog/runtimes/claude.md
@@ -1,0 +1,61 @@
+# claude
+
+> Anthropic's Claude Code CLI, running headless inside the sandbox.
+
+## At a glance
+
+| | |
+|---|---|
+| Provider | `anthropic` |
+| Multi-provider | No |
+| Transport | ACP, through the pinned `claude-agent-acp` adapter |
+| Skills root | `/home/sprite/.claude/skills` |
+| skills.sh agent | `claude-code` |
+| System prompt | `~/.claude/CLAUDE.md` |
+| Credential | An Anthropic API key or a Claude Code OAuth token |
+
+## Why you would pick this one
+
+It is the default and the most exercised path. Editor integration, the
+permission flow and the block format all developed against it first.
+
+Pick [opencode](opencode.md) instead if you want one agent definition that can
+switch providers.
+
+## Set it up
+
+```yaml
+apiVersion: fountain.dev/v1
+kind: Agent
+metadata:
+  name: researcher
+spec:
+  runtime: claude
+  model: anthropic/claude-sonnet-4-6
+```
+
+The model must carry the `anthropic/` prefix. Anything else is rejected when
+you save the agent.
+
+Add your Anthropic key at `/account/inference-credentials` in the running app.
+An operator cannot set one for you. See
+[Services Fountain uses](../../integrations/index.md).
+
+## Verify
+
+Run a conversation and ask it what model it is. A turn that reaches output at
+all proves the credential, the runtime and the sandbox.
+
+## Limits
+
+**MCP servers are provisioned rather than passed per session.** Session-scoped
+MCP delivery is broken upstream in `claude-agent-acp`, so Fountain writes
+`.mcp.json` into the sandbox and enables project servers instead. The effect is
+the same and the mechanism is different, which matters if you are debugging why
+a raw ACP probe behaves differently from Fountain.
+
+## Related
+
+- [About agents](../../concepts/agent.md)
+- [`fountain acp`](../../integrations/acp.md)
+- [Runtimes](index.md)

--- a/docs/catalog/runtimes/codex.md
+++ b/docs/catalog/runtimes/codex.md
@@ -1,0 +1,53 @@
+# codex
+
+> OpenAI's Codex CLI, running headless inside the sandbox.
+
+## At a glance
+
+| | |
+|---|---|
+| Provider | `openai` |
+| Multi-provider | No |
+| Transport | ACP, through the pinned `codex-acp` adapter |
+| Skills root | `/home/sprite/.codex/skills` |
+| skills.sh agent | `codex` |
+| System prompt | `~/.codex/AGENTS.md` |
+| Credential | An OpenAI API key |
+
+## Why you would pick this one
+
+You want an OpenAI model doing the work, or you are comparing two runtimes on
+the same task.
+
+## Set it up
+
+```yaml
+apiVersion: fountain.dev/v1
+kind: Agent
+metadata:
+  name: reviewer
+spec:
+  runtime: codex
+  model: openai/gpt-5-codex
+```
+
+The model must carry the `openai/` prefix.
+
+Add your OpenAI key at `/account/inference-credentials` in the running app.
+
+## Verify
+
+Run a conversation. A turn that reaches output proves the credential and the
+adapter.
+
+## Limits
+
+The CLI takes the bare model id, so Fountain strips the `openai/` prefix before
+invoking it. That is invisible in normal use and worth knowing if you are
+reading a spawn command in the logs.
+
+## Related
+
+- [About agents](../../concepts/agent.md)
+- [`fountain acp`](../../integrations/acp.md)
+- [Runtimes](index.md)

--- a/docs/catalog/runtimes/gemini.md
+++ b/docs/catalog/runtimes/gemini.md
@@ -1,0 +1,57 @@
+# gemini
+
+> Google's Gemini CLI. The only runtime not on ACP.
+
+## At a glance
+
+| | |
+|---|---|
+| Provider | `google` |
+| Multi-provider | No |
+| Transport | **Legacy**, a line-delimited `stream-json` the worker tails |
+| Skills root | `/tmp/.gemini/skills` |
+| skills.sh agent | `gemini-cli` |
+| System prompt | `~/.gemini/GEMINI.md` |
+| Credential | A Gemini API key, exported as `GEMINI_API_KEY` |
+
+## Why you would pick this one
+
+You specifically want a Gemini model. That is the whole case.
+
+If you do not, prefer [claude](claude.md), [codex](codex.md) or
+[opencode](opencode.md), all of which are on ACP.
+
+## Set it up
+
+```yaml
+apiVersion: fountain.dev/v1
+kind: Agent
+metadata:
+  name: gemini-agent
+spec:
+  runtime: gemini
+  model: google/gemini-2.5-pro
+```
+
+Add your Gemini key at `/account/inference-credentials`.
+
+## Verify
+
+Run a conversation. Output arriving at all proves the credential and the
+legacy stream parser.
+
+## Limits
+
+**Not on ACP.** The other three runtimes speak the Agent Client Protocol, which
+is what carries editor integration and the shared block format. Gemini uses the
+older path, so it does not get those.
+
+**Sessions are the CLI's, not Fountain's.** Gemini manages its own session
+state, and `--resume` re-enters the most recent conversation in the workspace,
+so Fountain does not pass a session id. One workspace holds one resumable
+session.
+
+## Related
+
+- [About agents](../../concepts/agent.md)
+- [Runtimes](index.md)

--- a/docs/catalog/runtimes/index.md
+++ b/docs/catalog/runtimes/index.md
@@ -1,0 +1,75 @@
+# Runtimes
+
+A runtime is the coding-agent CLI a sandbox runs. It is one field on an
+[Agent](../../concepts/agent.md), and it decides which provider's credential
+that agent needs, how skills land on disk, and where the system prompt is
+written.
+
+## All four
+
+| Runtime | Provider | Transport | Multi-provider |
+|---|---|---|---|
+| [claude](claude.md) | `anthropic` | ACP | No |
+| [codex](codex.md) | `openai` | ACP | No |
+| [opencode](opencode.md) | any of the three | ACP | **Yes** |
+| [gemini](gemini.md) | `google` | legacy stream | No |
+
+## How to choose
+
+**Pick the runtime whose provider you have a key for.** This is the constraint
+that decides it most of the time. Inference credentials are per-user, entered
+in the running app, and Fountain can export keys for exactly three providers.
+See [Services Fountain uses](../../integrations/index.md).
+
+**Pick `opencode` if you want one agent definition to work across providers.**
+It is the only multi-provider runtime. It takes the canonical
+`provider/model-id` string verbatim and reads the prefix to decide which key to
+export.
+
+**Avoid `gemini` unless you specifically want it.** It is the only runtime not
+on ACP, so it does not get the editor integration, the permission plumbing or
+the shared block format the other three share.
+
+## The rule that catches people
+
+`model` is stored as `provider/model-id`, and **the provider half is validated
+while the model id is not.**
+
+The provider must match the runtime. A mismatch is rejected when you save the
+agent, because Fountain holds no credential for the wrong provider and the
+sandbox would start with no inference key at all.
+
+The model id is passed to the CLI unchanged. A model released after your
+Fountain version still works, and a typo reaches the CLI and fails there.
+
+## Suggested models
+
+These are suggestions the agent form offers, not an allowlist.
+
+| Provider | Suggested |
+|---|---|
+| `anthropic` | `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
+| `openai` | `gpt-5-codex`, `gpt-5` |
+| `google` | `gemini-2.5-pro`, `gemini-2.5-flash` |
+
+`GET /api/catalog` returns this list per runtime, so a client can render the
+current set rather than hard-coding one.
+
+## Where skills and prompts land
+
+Each runtime has its own on-disk layout, which is why the same skill list
+produces different paths.
+
+| Runtime | Skills root | skills.sh agent | System prompt |
+|---|---|---|---|
+| `claude` | `/home/sprite/.claude/skills` | `claude-code` | `~/.claude/CLAUDE.md` |
+| `codex` | `/home/sprite/.codex/skills` | `codex` | `~/.codex/AGENTS.md` |
+| `opencode` | `/tmp/.config/opencode/skills` | `opencode` | `~/.config/opencode/AGENTS.md` |
+| `gemini` | `/tmp/.gemini/skills` | `gemini-cli` | `~/.gemini/GEMINI.md` |
+
+## Related
+
+- [About agents](../../concepts/agent.md), where `runtime` is set.
+- [Skills](../skills/index.md).
+- [`fountain acp`](../../integrations/acp.md), the adapter three of the four
+  speak through.

--- a/docs/catalog/runtimes/opencode.md
+++ b/docs/catalog/runtimes/opencode.md
@@ -1,0 +1,59 @@
+# opencode
+
+> The opencode CLI. The only runtime that can reach more than one provider.
+
+## At a glance
+
+| | |
+|---|---|
+| Provider | `anthropic`, `openai` or `google` |
+| Multi-provider | **Yes** |
+| Transport | ACP, through opencode's own `acp` subcommand |
+| Skills root | `/tmp/.config/opencode/skills` |
+| skills.sh agent | `opencode` |
+| System prompt | `~/.config/opencode/AGENTS.md` |
+| Credential | Whichever provider the model prefix names |
+
+## Why you would pick this one
+
+It is the only runtime where changing provider is a one-line edit to `model`
+rather than a different agent.
+
+It takes the canonical `provider/model-id` string verbatim and reads the prefix
+to decide which API key to export into the sandbox.
+
+## Set it up
+
+```yaml
+apiVersion: fountain.dev/v1
+kind: Agent
+metadata:
+  name: portable
+spec:
+  runtime: opencode
+  model: anthropic/claude-sonnet-4-6   # or openai/... or google/...
+```
+
+Add a key for whichever provider you name, at
+`/account/inference-credentials`.
+
+## Verify
+
+Run a conversation, then change `model` to a different provider and run
+another. Both working is the thing this runtime is for.
+
+## Limits
+
+**The provider set is closed at three.** `anthropic`, `openai` and `google` are
+the only prefixes Fountain can export a credential for, so a fourth is rejected
+when you save the agent rather than failing as an auth error inside the
+sandbox.
+
+**A provider you have no key for fails at the turn, not at save time.** The
+prefix is validated, the presence of your credential is not.
+
+## Related
+
+- [About agents](../../concepts/agent.md)
+- [`fountain acp`](../../integrations/acp.md)
+- [Runtimes](index.md)

--- a/docs/catalog/skills/create-team.md
+++ b/docs/catalog/skills/create-team.md
@@ -1,0 +1,75 @@
+# create-team
+
+> A five-question conversation that proposes a roster of teammates, creates
+> them, and hands them over.
+
+## At a glance
+
+| | |
+|---|---|
+| Bundled | Yes, in every sandbox |
+| Declared by | Nobody. It is always present |
+| Source | `apps/fountain/priv/sprite_skills/create-team/SKILL.md` |
+| Triggered by | `/create-team`, or asking a teammate to help set up a team |
+
+## What happens when you run it
+
+Say `/create-team` to any teammate, or ask it what the team should look like.
+
+**It asks at most five questions**, one at a time, with a default offered in
+each so "yes" is a complete answer.
+
+1. What should the team get done?
+2. Which repos or services are in scope, and which need a token?
+3. How many teammates, roughly? Usually two to five, and a lead is worth it
+   past three.
+4. Any brain preference? It checks `GET /api/catalog` for models and your
+   inference credentials for which providers you actually have a key for, and
+   will not propose one you cannot run.
+5. What names? Role names such as `repo-maintainer`, or a themed set.
+
+**Then it proposes.** A table of name, brain, one-line role, and the first
+thing it would send each teammate.
+
+**It creates nothing before you say yes.**
+
+**Then it hands over.** The roster as created, who to message for what, one
+concrete first message each, and a note that teammates can reach each other.
+
+## What it creates
+
+For each teammate, an [Agent](../../concepts/agent.md) and then a
+[team membership](../../concepts/teammates.md), which opens that agent's one
+ongoing conversation and provisions its sandbox.
+
+Everything it sets is editable afterwards from the team app. Brain, role and
+name are not decisions you are stuck with.
+
+## Its own rules
+
+The skill constrains itself in four ways worth knowing, because they are the
+difference between a helpful flow and a destructive one.
+
+- One question at a time, and it stops asking as soon as it can propose.
+- Never create before a confirmation. Never delete or rename anything.
+- Never paste tokens into prompts, descriptions or messages.
+- On a name conflict it adds a suffix and says so. On a missing credential it
+  names the provider and where to add the key.
+
+## Limits
+
+**It only adds.** It will not remove a teammate, rename one, or reorganise an
+existing team.
+
+**It needs inference credentials already in place.** It checks first and tells
+you what is missing rather than creating agents that cannot run.
+
+**Every teammate it creates provisions a sandbox.** A roster of five is five
+machines. See
+[Change sandbox lifetimes](../../guides/operate/sandbox-lifetime.md).
+
+## Related
+
+- [Agents as teammates](../../concepts/teammates.md), what it is building.
+- [About agents](../../concepts/agent.md).
+- [Skills](index.md).

--- a/docs/catalog/skills/fountain.md
+++ b/docs/catalog/skills/fountain.md
@@ -1,0 +1,61 @@
+# fountain
+
+> Lets an agent spawn and stream more Fountain conversations from inside its
+> own sandbox.
+
+## At a glance
+
+| | |
+|---|---|
+| Bundled | Yes, in every sandbox |
+| Declared by | Nobody. It is always prepended |
+| Source | `apps/fountain/priv/sprite_skills/fountain/SKILL.md` |
+| Reads | `FOUNTAIN_BASE_URL`, `FOUNTAIN_TOKEN`, `FOUNTAIN_CONVERSATION_ID` |
+
+## What it gives the agent
+
+Fountain's own API, from the inside. An agent that has it can fan work out
+across other agents and collect the answers.
+
+Two patterns are written out in the skill. Fan out N conversations in parallel
+and gather their results, and drive a single sub-conversation over multiple
+turns.
+
+This is what makes "delegate to another agent" work when a user asks for it.
+
+## The credential it uses
+
+`FOUNTAIN_TOKEN` is a **per-conversation key scoped to this conversation's
+owner**, not a long-lived admin token.
+
+Fountain rotates it on every fresh provision and every reattach, for example
+after a deploy or a BEAM restart, revoking the previous value. A request that
+returns 401 with `"reason": "api_key_revoked"` means the agent cached a stale
+copy and should re-read the variable from its environment.
+
+## Provenance is automatic
+
+`FOUNTAIN_CONVERSATION_ID` is always in the sandbox's environment. A
+`POST /api/conversations` that includes
+`X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID` records the
+parent, so an operator can reconstruct the whole spawn chain.
+
+## Limits
+
+**Spawned agents have the same skill.** Nothing stops recursion, so the skill
+tells the agent to cap depth itself with a `MAX_DEPTH` check. A runaway fan-out
+is a real way to spend money.
+
+**Every conversation is a real sandbox.** The skill is explicit that orphaned
+conversations run until the idle timeout, and that the agent should terminate
+promptly. See
+[Change sandbox lifetimes](../../guides/operate/sandbox-lifetime.md).
+
+**The bare `/conversations` path is not the API.** It redirects to the login
+page for non-browser requests. The API is under `/api`.
+
+## Related
+
+- [API reference](../../api.md), the same surface from outside.
+- [Skills](index.md).
+- [About conversations](../../concepts/conversation.md).

--- a/docs/catalog/skills/index.md
+++ b/docs/catalog/skills/index.md
@@ -1,0 +1,73 @@
+# Skills
+
+A skill is a `SKILL.md` written into the sandbox, which the runtime reads to
+learn a capability. Skills are declared on an [Agent](../../concepts/agent.md).
+
+## Bundled in every sandbox
+
+These two are written into **every** sandbox, whatever an agent declares.
+
+| Skill | What it does |
+|---|---|
+| [fountain](fountain.md) | Gives the agent Fountain's own API, so it can spawn and stream sub-conversations |
+| [create-team](create-team.md) | A five-question flow that builds the user's team. Answering `/create-team` runs it |
+
+## Declaring your own
+
+Two forms, and they behave differently.
+
+**Inline.** The whole file, written directly to
+`<skills_root>/<name>/SKILL.md`.
+
+```yaml
+skills:
+  - name: house-style
+    content: |
+      ---
+      name: house-style
+      description: Our commit message and PR conventions.
+      ---
+      # House style
+      ...
+```
+
+**From GitHub.** Installed on the sandbox with the
+[skills.sh](https://skills.sh) CLI.
+
+```yaml
+skills:
+  - source: BinaryBourbon/fountain-api-skill
+    ref: v1.2.0        # optional: a tag, branch or sha
+    name: fountain-api # optional: rename on install
+```
+
+Without a `ref`, the repository's default branch is resolved **at spawn time**.
+Two conversations from the same agent, a week apart, can install different
+code. Pin a `ref` for anything you depend on.
+
+## Two things about how they land
+
+**Skills mount before the network policy locks the sandbox down.** GitHub
+installs need npm and github.com, so they happen first. A `limited` environment
+that allowlists neither still gets its skills, and this ordering is why.
+
+**GitHub installs run before inline writes.** The install is a blocking exec,
+which doubles as the readiness gate the file-write path needs anyway.
+
+## The path depends on the runtime
+
+Each runtime declares its own skills root and its own skills.sh agent name, so
+the same declaration lands in a different place depending on `runtime`. See
+[Runtimes](../runtimes/index.md) for the table.
+
+## Not here yet
+
+There is no catalog of third-party skills. Anything on GitHub that ships a
+`SKILL.md` works, and Fountain does not curate a list.
+
+## Related
+
+- [About agents](../../concepts/agent.md), where `skills` is declared.
+- [Runtimes](../runtimes/index.md), for where a skill lands on disk.
+- [Agents as teammates](../../concepts/teammates.md), which
+  [create-team](create-team.md) builds.

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -128,4 +128,6 @@ the process an editor spawns. See
 - [About conversations](conversation.md), which run an Agent.
 - [Agents as teammates](teammates.md), which is one Conversation per Agent.
 - [About environments](environment.md), which an Agent names.
+- [Runtimes](../catalog/runtimes/index.md), all four compared.
+- [Skills](../catalog/skills/index.md), including the two every sandbox gets.
 - [Glossary](../reference/glossary.md), for the three senses of "agent".

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ it goes quiet.
 
 ## Look it up
 
+- [Catalog](catalog/index.md), runtimes and skills
 - [CLI reference](cli.md), the `fountain` command surface
 - [API reference](api.md), REST endpoints and auth
 - [TypeScript SDK](sdk.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,16 @@ nav:
       - Pods restarting or not ready: troubleshooting/pods-restarting.md
       - Nobody can log in: troubleshooting/nobody-can-log-in.md
   - Configuration reference: configuration.md
+  - Catalog:
+      - Overview: catalog/index.md
+      - Runtimes: catalog/runtimes/index.md
+      - claude: catalog/runtimes/claude.md
+      - codex: catalog/runtimes/codex.md
+      - opencode: catalog/runtimes/opencode.md
+      - gemini: catalog/runtimes/gemini.md
+      - Skills: catalog/skills/index.md
+      - fountain (skill): catalog/skills/fountain.md
+      - create-team (skill): catalog/skills/create-team.md
   - Sandbox providers:
       - The contract: integrations/sandbox-contract.md
       - Sprites: integrations/sprites.md


### PR DESCRIPTION
Closes #909. Closes #907. Part of #903 and #906.

Two catalogs that had **no pages at all**, built on the entry template in
`docs-redesign/05-catalog-template.md`. The 19 existing `integrations/` pages
are not refiled here; that is the rest of #906 and is mechanical.

## Runtimes

Four exist and nothing compared them. The differences were spread across the
Agent concept page, `integrations/acp.md` and `configuration.md`, so choosing
one meant assembling it yourself.

| Runtime | Provider | Transport | Multi-provider |
|---|---|---|---|
| claude | `anthropic` | ACP | No |
| codex | `openai` | ACP | No |
| opencode | any of the three | ACP | **Yes** |
| gemini | `google` | legacy stream | No |

The index carries the rule that catches people: **the provider half of `model`
is validated and the model id half is not.** That asymmetry is deliberate, and
`runtimes/model.ex` explains why in a comment nobody reading the docs would
find. A model released after your deploy has to work the day it ships.

`gemini` gets an honest entry. It is the only runtime not on ACP, so it does
not get editor integration or the shared block format, and its own page says to
prefer one of the other three unless you specifically want Gemini.

## Skills

`skills` is named as a capability on 12 pages and was documented in one bullet.

**Two skills are written into every sandbox and had no documentation
anywhere.**

- **`fountain`** gives an agent Fountain's own API, so it can spawn and stream
  sub-conversations. This is what makes "delegate to another agent" work.
- **`create-team`** owns the user-typed `/create-team`.

A user could not previously discover that `/create-team` exists, what it asks,
or that it will not create anything before a confirmation. Its page now walks
the five questions and lists the four rules the skill holds itself to, since
those are the difference between a helpful flow and a destructive one.

Both entries carry the limits that matter. The `fountain` skill is recursive
(spawned agents have it too, so depth needs capping) and every conversation is
a real sandbox. `create-team` only adds, never renames or deletes, and needs
inference credentials in place first.

## Two ordering facts promoted out of a moduledoc

**Skills mount before the network policy locks the sandbox down**, because
GitHub installs need npm and github.com. A `limited` environment that
allowlists neither still gets its skills, and that is why.

**A GitHub skill without a `ref` resolves the default branch at spawn time.**
Two conversations from the same agent, a week apart, can install different
code. Pin a `ref` for anything you depend on.

## A note on the nav parser

Writing this, the parser raised on `- "Runtime: claude": path`. That is the
parser working as intended: it refuses a line it cannot read rather than
silently dropping a page from `/docs`. Titles renamed to drop the colon.

## Verification

Facts checked against `runtimes/model.ex`, the four runtime modules,
`sandbox_skills.ex`, and both `SKILL.md` files.

- `mkdocs build --strict`, clean
- `docs_test.exs` + `docs_controller_test.exs`, 32 tests 0 failures
- No em dashes or colon-introduced lists, per #911

## Still open

**#908, MCP servers.** Deliberately not attempted. `mcp_servers` is a
first-class Agent field with no list of what works anywhere in the repo, and
writing one honestly needs a decision about what "supported" means. The
catalog index says so and links the issue rather than pretending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
