### PR TITLE
cli: let the CLI reference live in a directory

### DIFF
--- a/cli/internal/cmd/docs_test.go
+++ b/cli/internal/cmd/docs_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -125,13 +126,39 @@ func walkCommands(c *cobra.Command, path []string, fn func([]string)) {
 	}
 }
 
+// The CLI reference is docs/cli.md today. It is allowed to become a directory
+// of per-command pages without this test having to change again: both
+// docs/cli.md and every .md under docs/cli/ are concatenated, so a split moves
+// prose between files the scanners already read.
+//
+// The old version hardcoded docs/cli.md and nothing else, which made the page
+// unsplittable — the reference could not be reorganised without the parity
+// tests going red for a reason unrelated to the CLI.
 func readCLIDoc(t *testing.T) string {
 	t.Helper()
 	// cli/internal/cmd -> repo root
-	path := filepath.Join("..", "..", "..", "docs", "cli.md")
-	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Skipf("docs/cli.md not readable from here (%v); skipping", err)
+	root := filepath.Join("..", "..", "..", "docs")
+
+	var parts []string
+	if b, err := os.ReadFile(filepath.Join(root, "cli.md")); err == nil {
+		parts = append(parts, string(b))
 	}
-	return string(b)
+
+	matches, err := filepath.Glob(filepath.Join(root, "cli", "*.md"))
+	if err != nil {
+		t.Fatalf("globbing docs/cli/: %v", err)
+	}
+	sort.Strings(matches)
+	for _, m := range matches {
+		b, err := os.ReadFile(m)
+		if err != nil {
+			t.Fatalf("reading %s: %v", m, err)
+		}
+		parts = append(parts, string(b))
+	}
+
+	if len(parts) == 0 {
+		t.Skip("no CLI reference found at docs/cli.md or docs/cli/*.md; skipping")
+	}
+	return strings.Join(parts, "\n")
 }


### PR DESCRIPTION
Unblocks #912. Part of #903.

## The blocker

`readCLIDoc` opened `docs/cli.md` by hardcoded path and nothing else, so both
parity tests scanned exactly one file.

```go
path := filepath.Join("..", "..", "..", "docs", "cli.md")
```

That made the page unsplittable. `docs/cli.md` is 279 hand-written lines
alongside a Cobra tree this test already walks, and #912 wants it generated
per-command — but the reference could not be reorganised at all without these
tests going red for a reason unrelated to the CLI.

## The change

`readCLIDoc` now concatenates `docs/cli.md` and every `docs/cli/*.md`, sorted,
so a future split moves prose between files the scanners already read.

**No docs change here.** This only removes the blocker, so #912 can be done as
its own reviewable piece.

## Verified in both directions

The tests stay green either way, so green proves nothing on its own. I checked
the directory path is actually load-bearing:

**Positive.** Moved the `fountain keys` block out of `docs/cli.md` into
`docs/cli/keys.md`, so those three commands appeared **zero** times in
`cli.md`. Both parity tests still passed.

**Negative.** Hid the directory and re-ran:

```
--- FAIL: TestEveryCommandIsDocumented (0.00s)
    docs_test.go:32: docs/cli.md does not mention:
          fountain keys create
          fountain keys list
          fountain keys revoke
```

Both scratch changes reverted. Only the Go change remains, and `docs/cli.md`
is byte-identical to `main`.

- `go test ./internal/cmd/` passes
- `go vet ./...` clean
- `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
