### PR TITLE
docs: a style checker with a ratchet, and the first two pages cleaned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,6 +820,10 @@ jobs:
         if: ${{ needs.changes.outputs.docs_touched == 'true' }}
         run: pip install -r docs/requirements.txt
 
+      - name: Docs style
+        if: ${{ needs.changes.outputs.docs_touched == 'true' }}
+        run: python3 scripts/docs-style.py
+
       - name: Build the site strictly
         if: ${{ needs.changes.outputs.docs_touched == 'true' }}
         run: mkdocs build --strict
@@ -1040,6 +1044,12 @@ jobs:
       # /docs link. docs_controller_test.exs: that the pages actually serve.
       - name: Docs tests
         run: mix test apps/fountain/test/fountain/docs_test.exs apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
+
+      # The style sheet in docs-redesign/06-voice-and-style.md, enforced. It
+      # skips the backlog in scripts/docs-style-allow.txt, so a file NOT on
+      # that list is checked and every new page is covered by default.
+      - name: Docs style
+        run: python3 scripts/docs-style.py
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,12 @@ in-app manual at `/docs` — the same markdown is embedded at compile time by
 - **`mkdocs build --strict`** is what CI runs; a broken relative link or a page
   not in the nav is an error. Run it locally (`pip install -r
   docs/requirements.txt`).
+- **`python3 scripts/docs-style.py`** enforces the style sheet
+  (`docs-redesign/06-voice-and-style.md`): no em dashes, no colon-introduced
+  lists, no "simply"/"obviously"/"coming soon". It skips the backlog in
+  `scripts/docs-style-allow.txt`, so a file **not** on that list is checked and
+  every new page is covered by default. Cleaning a page means deleting its
+  line; the list only shrinks (#911).
 - **`docs/cli.md` is diffed against the CLI.** `cli/internal/cmd/docs_test.go`
   fails if a command exists that the page does not mention, or the page
   mentions one that does not exist. Add a CLI command → add it to `docs/cli.md`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 # CLI reference
 
 The `fountain` binary manages Fountain resources from the terminal or CI scripts.
-It is a convenience wrapper over the REST API — everything here can be done with
+It is a convenience wrapper over the REST API. Everything here can be done with
 `curl`.
 
 This page tracks the real command tree. If a command is not listed here it does
@@ -135,7 +135,7 @@ conversation, rather than reporting success. Widen the wait with
 FOUNTAIN_STREAM_IDLE_TIMEOUT=7200 fountain run researcher -p "large refactor"
 ```
 
-Disconnecting loses nothing — reattach at any time:
+Disconnecting loses nothing. Reattach at any time:
 
 ```bash
 fountain conv stream <conversation-id>
@@ -149,7 +149,7 @@ fountain acp --agent <name-or-id> [--vault <name-or-id>] [--environment <name-or
 
 Speaks the [Agent Client Protocol](https://agentclientprotocol.com) on stdio, so
 an ACP-capable editor can drive a Fountain conversation. You do not run this
-yourself — the editor spawns it and talks JSON-RPC over the pipe. stdout carries
+yourself. The editor spawns it and talks JSON-RPC over the pipe. stdout carries
 the protocol and nothing else; diagnostics go to stderr, which is where to look
 first when an editor reports a problem.
 
@@ -160,8 +160,8 @@ selects the instance.
 
 **[`fountain acp` (reference)](integrations/acp.md)** documents the protocol
 surface and flags in full; **[Editors (ACP)](integrations/editors.md)** has the setup, the editor config
-snippets, and the limits worth knowing before you start — chief among them that
-the agent works on a sandbox's files, not the ones open in your editor.
+snippets, and the limits worth knowing before you start. Chief among them is
+that the agent works on a sandbox's files, not the ones open in your editor.
 
 ## Self-hosted runner
 
@@ -175,8 +175,8 @@ whose `sandbox_provider` is `runner`: each sandbox is a directory under
 `--root` (default `~/.fountain/runners/<name>/sandboxes`), the agent's
 processes run on this machine as you with `HOME` pointed at that directory,
 and idle sandboxes park by stopping their processes with the directory left
-in place. Trusted mode — no VM or egress policy — so run it on a machine you
-would hand a capable colleague a shell on. Needs a full-scope key. Names are
+in place. Trusted mode, with no VM and no egress policy, so run it on a machine
+you would hand a capable colleague a shell on. Needs a full-scope key. Names are
 unique per account (default: the hostname); reconnects with backoff. See the
 [runners guide](integrations/runners.md).
 
@@ -188,23 +188,23 @@ fountain apply -f path/to/directory/          # walks all *.yml / *.yaml files
 fountain apply -f dir/ --var REGION=eu-west-1 # ${VAR} substitution, repeatable
 ```
 
-Apply is idempotent — create if new, update if changed. Supported kinds:
-`Environment`, `Vault`, `Agent`.
+Apply is idempotent, creating if new and updating if changed. The supported
+kinds are `Environment`, `Vault` and `Agent`.
 
-`--var`/`${VAR}` substitution applies to `spec.secrets` values only — a
+`--var`/`${VAR}` substitution applies to `spec.secrets` values only. A
 `${VAR}` anywhere else in the document (a `setup_script`, a name) is
 transmitted literally.
 
 The CLI compiles every document into a single manifest and sends it to
 `POST /api/apply` in one request; the server reconciles environments, then
-vaults, then agents, and resolves agent `environment:` name references —
+vaults, then agents, and resolves agent `environment:` name references,
 including environments that already exist on the server. Against older servers
 without `/api/apply`, the CLI falls back to per-resource calls.
 
 ### Secret references
 
 `spec.secrets` values can reference a secret manager instead of holding
-plaintext — this is what makes manifests committable to git. A value starting
+plaintext. That is what makes manifests committable to git. A value starting
 with one of these schemes is resolved client-side at apply time by shelling
 out to the manager's own CLI (which must be installed and authenticated):
 
@@ -270,7 +270,7 @@ FOUNTAIN_API_KEY=ftn_... FOUNTAIN_BASE_URL=https://other.example.com fountain ag
 ```
 
 Resolution order for both the key and the URL is: environment variable, then the
-active profile in the credentials file, then — for the URL only — the built-in
+active profile in the credentials file, then (for the URL only) the built-in
 default `https://fountain.inevitable.fyi`.
 
 **Self-hosting?** That built-in default is the hosted instance, not yours. Run

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -132,7 +132,7 @@ Everything a sandbox writes to stdout or stderr is persisted verbatim into
 encryption above, and it outlives the conversation.
 
 So an `env`, a `set -x`, a `cat .env` in a setup script, or an agent that
-simply prints its environment would write plaintext credentials into Postgres.
+prints its own environment would write plaintext credentials into Postgres.
 Fountain removes every known secret value from output before it is stored.
 
 Two consequences worth knowing.

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -1,8 +1,8 @@
 # A guided tour: an agent that opens a pull request
 
 By the end of this page you will have an agent that clones your repository,
-makes a change, and opens a pull request — and you will be able to ask it for a
-revision that lands on the same PR seconds later, because the computer it
+makes a change, and opens a pull request. You will then be able to ask it for
+a revision that lands on the same PR seconds later, because the computer it
 worked on is still running.
 
 It is about forty lines. Every number and every output below came from actually
@@ -14,7 +14,7 @@ running it.
 - A repository you are willing to let an agent push a branch to.
 - A GitHub token that can push to it. A
   [fine-grained token](https://github.com/settings/personal-access-tokens)
-  scoped to that one repository is the right thing here — the agent gets a real
+  scoped to that one repository is the right thing here. The agent gets a real
   credential, so give it the smallest one that works.
 
 ```bash
@@ -50,7 +50,7 @@ const environment = await fountain.environments.create({
 !!! warning "A private repository needs `secret_key`"
 
     `secret_key` names the secret the clone authenticates with. Leave it out on
-    a **private** repository and the clone fails inside the sandbox — the
+    a **private** repository and the clone fails inside the sandbox. The
     conversation still starts, and your agent opens on an empty directory and
     tells you it cannot find the repo. Writing this page cost one wasted run to
     exactly that. A public repository does not need it.
@@ -58,8 +58,8 @@ const environment = await fountain.environments.create({
 ## 2. The credential
 
 A [vault](primitives.md) is a bag of secrets chosen per run. Its values are
-decrypted into the sandbox when the sandbox spawns — they are never in the
-prompt, never in the model's context, and never in the log feed:
+decrypted into the sandbox when the sandbox spawns. They are never in the
+prompt, never in the model's context, and never in the log feed.
 
 ```ts
 const vault = await fountain.vaults.create({ name: "tour-github" });
@@ -72,7 +72,7 @@ Two keys because two things need it: `GITHUB_TOKEN` is what the clone reads
 (the `secret_key` above), and `gh` looks for `GH_TOKEN` when the agent opens
 the PR.
 
-You cannot read either one back — `secrets.list()` returns keys and nothing
+You cannot read either one back. `secrets.list()` returns keys and nothing
 else. And if the agent prints the token, Fountain redacts it out of the
 transcript before it is stored.
 
@@ -130,7 +130,7 @@ https://github.com/you/your-app/pull/1
 Forty-three seconds, most of it provisioning. The pull request is real: a
 `--version` branch, two files changed, ten lines added.
 
-If you would rather not watch, drop the loop — `await fountain.run(...)` gives
+If you would rather not watch, drop the loop. `await fountain.run(...)` gives
 you the same result. If you would rather not wait at all, don't await it: hand
 `run.conversationId` to whatever polls later.
 
@@ -164,7 +164,7 @@ await fountain.vaults.delete("tour-github");                // the credential fi
 await fountain.environments.delete("tour-workspace");
 ```
 
-In a script that can fail, delete the vault in a `finally` — a credential
+In a script that can fail, delete the vault in a `finally`. A credential
 should not outlive the run that needed it.
 
 ## What you just built
@@ -183,7 +183,7 @@ second environment points it at a different repository.
 ## The whole thing, in one script
 
 Everything above, in one file you can copy and run. It is not a transcription
-of the steps — it is `sdk/typescript/examples/pull-request.ts`, included here
+of the steps. It is `sdk/typescript/examples/pull-request.ts`, included here
 verbatim, which is the same file that produced every output on this page.
 
 ```ts title="pull-request.ts"
@@ -200,7 +200,7 @@ FOUNTAIN_API_KEY=…  GITHUB_TOKEN=…  REPO_URL=https://github.com/you/your-app
 - **Run it from CI.** The same forty lines work in an action; the agent needs
   no checkout on the runner, because the checkout is in the sandbox.
 - **Make it a teammate.** `fountain.team.add("tour-contributor")` gives it a
-  durable thread and a cron routine — "every Monday, open a PR bumping the
+  durable thread and a cron routine, so "every Monday, open a PR bumping the
   dependencies" is `team.schedules.create`. See the [SDK page](sdk.md#the-team).
 - **Fan it out.** `fountain.run()` per repository, awaited together; each gets
   its own sandbox.

--- a/scripts/docs-style-allow.txt
+++ b/scripts/docs-style-allow.txt
@@ -1,0 +1,40 @@
+# The pre-existing style backlog, tracked by #911.
+#
+# Files listed here are SKIPPED by scripts/docs-style.py. This list is only
+# ever meant to shrink: clean a page, delete its line, and the checker starts
+# guarding it. A file NOT listed here is checked, so every new page is covered
+# by default and the cleanup can land one page at a time without leaving CI
+# red in between.
+#
+# The checker fails if a line here names a file that no longer exists, so a
+# rename cannot quietly re-exempt a page.
+docs/api.md
+docs/architecture.md
+docs/build/index.md
+docs/build/team-chat.md
+docs/configuration.md
+docs/integrations/acp.md
+docs/integrations/adding-a-sandbox-provider.md
+docs/integrations/buzz.md
+docs/integrations/clients.md
+docs/integrations/daytona.md
+docs/integrations/e2b.md
+docs/integrations/editors.md
+docs/integrations/github-oauth.md
+docs/integrations/hermes.md
+docs/integrations/index.md
+docs/integrations/mail.md
+docs/integrations/openbot.md
+docs/integrations/openclaw.md
+docs/integrations/runners.md
+docs/integrations/sandbox-contract.md
+docs/integrations/sentry.md
+docs/integrations/sprites-contract.md
+docs/integrations/sprites.md
+docs/integrations/stripe.md
+docs/llm-integration.md
+docs/sdk.md
+docs/superpowers/plans/2026-05-10-phase-3-foundation.md
+docs/superpowers/plans/2026-05-11-ci-checks.md
+docs/superpowers/plans/2026-05-13-conversation-titles.md
+docs/superpowers/specs/2026-05-11-ci-checks-design.md

--- a/scripts/docs-style.py
+++ b/scripts/docs-style.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Enforce the docs style sheet on docs/**/*.md.
+
+Three rules, all from docs-redesign/06-voice-and-style.md:
+
+  1. No em or en dashes. An em dash is a hinge that lets a sentence continue
+     after it has finished, and it is where explanation hides. Removing it
+     forces the writer to choose a table row, a parenthesis or a full stop.
+  2. Colons do not introduce lists. A colon makes the lead-in a fragment, and
+     a fragment asserts nothing that can be checked against the code. Ending
+     it with a full stop forces a complete claim.
+  3. A small forbidden-word list. "simply" and "just" tell a stuck reader the
+     thing they are stuck on is easy; "coming soon" describes unbuilt
+     behaviour as if it existed, which CLAUDE.md already forbids.
+
+Code fences and inline code spans are exempt, because they quote the world
+rather than describe it.
+
+THE RATCHET. Files listed in scripts/docs-style-allow.txt are skipped. That
+list is the pre-existing backlog (#911) and is only ever meant to shrink. A
+file NOT on the list is checked, so anything new is covered by default and
+the cleanup can land page by page without leaving CI red in between.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs"
+ALLOW = ROOT / "scripts" / "docs-style-allow.txt"
+
+FORBIDDEN = ["simply", "coming soon", "obviously"]
+LIST_ITEM = re.compile(r"^\s*(?:[-*+]\s|\d+\.\s)")
+
+
+def load_allowlist():
+    if not ALLOW.exists():
+        return set()
+    out = set()
+    for line in ALLOW.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            out.add(line)
+    return out
+
+
+def strip_code(lines):
+    """Blank out fenced blocks and inline code spans, keeping line numbers."""
+    out = []
+    in_fence = False
+    for line in lines:
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            out.append("")
+            continue
+        if in_fence or line.startswith("    ") and not LIST_ITEM.match(line):
+            out.append("")
+            continue
+        out.append(re.sub(r"`[^`]*`", "", line))
+    return out
+
+
+def check(path, rel):
+    raw = path.read_text().splitlines()
+    text = strip_code(raw)
+    problems = []
+
+    for i, line in enumerate(text, 1):
+        for ch, name in (("—", "em dash"), ("–", "en dash")):
+            if ch in line:
+                problems.append((i, f"{name}: {raw[i - 1].strip()[:90]}"))
+
+        low = line.lower()
+        for word in FORBIDDEN:
+            if re.search(rf"\b{re.escape(word)}\b", low):
+                problems.append((i, f'forbidden phrase "{word}"'))
+
+    for i in range(len(text) - 1):
+        line = text[i].rstrip()
+        if not line.endswith(":") or line.endswith("::"):
+            continue
+        nxt = i + 1
+        while nxt < len(text) and not text[nxt].strip():
+            nxt += 1
+        if nxt < len(text) and LIST_ITEM.match(text[nxt]):
+            problems.append((i + 1, f"colon introduces a list: {line.strip()[:90]}"))
+
+    return [(rel, ln, msg) for ln, msg in problems]
+
+
+def main():
+    allow = load_allowlist()
+    failures = []
+    checked = 0
+
+    for path in sorted(DOCS.rglob("*.md")):
+        rel = str(path.relative_to(ROOT))
+        if rel in allow:
+            continue
+        checked += 1
+        failures.extend(check(path, rel))
+
+    stale = sorted(a for a in allow if not (ROOT / a).exists())
+    for a in stale:
+        print(f"allowlist names a file that no longer exists: {a}", file=sys.stderr)
+
+    if failures:
+        print(f"docs style: {len(failures)} problem(s) in {checked} checked file(s)\n")
+        for rel, ln, msg in failures:
+            print(f"  {rel}:{ln}: {msg}")
+        print(
+            "\nSee docs-redesign/06-voice-and-style.md. If this is a page from the "
+            "pre-existing backlog (#911), it belongs in scripts/docs-style-allow.txt "
+            "until it is cleaned."
+        )
+        return 1
+
+    if stale:
+        return 1
+
+    print(f"docs style: clean ({checked} files checked, {len(allow)} on the backlog)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of #911 and #903.

## Why this is not one big diff

**889 em dashes across 29 files.** A blind replacement would mangle prose: an
em dash stands in for a comma, a parenthesis, a full stop or a restructure, and
only a reader can tell which. A 29-file mechanical diff is also not reviewable.

So this ships the enforcement plus a worked example, and leaves the backlog to
be cleared page by page.

## The checker

`scripts/docs-style.py` enforces three rules from
`docs-redesign/06-voice-and-style.md`:

1. **No em or en dashes.** An em dash is a hinge that lets a sentence continue
   after it has finished, and it is where explanation hides. Removing it forces
   the writer to choose a table row, a parenthesis or a full stop.
2. **Colons do not introduce lists.** A colon makes the lead-in a fragment, and
   a fragment asserts nothing that can be checked against the code.
3. **A short forbidden-phrase list.** "simply" and "obviously" tell a stuck
   reader the thing they are stuck on is easy. "coming soon" describes unbuilt
   behaviour as if it existed, which `CLAUDE.md` already forbids.

Fenced blocks and inline code spans are exempt, because they quote the world
rather than describe it. Stdlib only, so it runs before the Python setup step.

## The ratchet

`scripts/docs-style-allow.txt` lists the 30 pages still on the backlog, and the
checker skips them.

**A file NOT on that list is checked**, so every new page is covered by default
and each cleanup PR just deletes a line. The list only shrinks.

The checker also fails on an allowlist entry naming a file that no longer
exists, so a rename cannot quietly re-exempt a page.

## Two pages cleaned

Chosen for traffic rather than ease.

- **`tour.md`**, the tutorial at nav position 2, the first thing a newcomer
  reads. 9 sites.
- **`cli.md`**, the most-linked reference. 10 sites.

Each was a judgment call, not a substitution. For example:

> before: `Apply is idempotent — create if new, update if changed. Supported kinds: ...`
> after: `Apply is idempotent, creating if new and updating if changed. The supported kinds are ...`

That one fixed both rules at once, which is typical: the colon and the dash
tend to travel together.

## Wired into both CI paths

The docs-only `docs` job and the `docs_touched` path in `checks`, so it cannot
be skipped the way the strict build was before #901.

## Verified in both directions

A passing check proves nothing if the rules never fire.

- Injected an em dash into a checked page:
  `docs/troubleshooting/index.md:39: em dash: A sentence with an em dash — like this.`
- Injected a colon-introduced list:
  `docs/troubleshooting/index.md:39: colon introduces a list: Pick one of these:`
- Reverted both.
- `go test ./internal/cmd/` still passes after the `cli.md` edits, since that
  page is diffed against the real command tree.

Plus `mkdocs build --strict` and `docs_test.exs` (32 tests, 0 failures).

## What is left

30 files on the backlog, biggest first: `api.md` (61 sites),
`architecture.md` (32), then the `integrations/` pages. Each is now a
one-file PR that deletes one line from the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
