### PR TITLE
ci: stop persisting checkout credentials in the build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,11 @@ jobs:
           # Full history: the diff below walks ancestry for the newest
           # commit whose image actually exists.
           fetch-depth: 0
+          # Nothing after checkout needs the token: the filter step runs only
+          # local git (rev-list, diff) and the registry probe carries its own
+          # auth. Leaving it behind writes a push-capable credential into
+          # .git/config that every later step inherits.
+          persist-credentials: false
 
       - name: Skip paths that never affect the OCI image
         id: filter
@@ -147,6 +152,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           ref: ${{ env.SRC_SHA }}
+          # This job runs no authenticated git operation — GHCR gets an
+          # explicit token below — so the image build and everything it
+          # executes should not inherit one from .git/config.
+          persist-credentials: false
 
       - name: Read buzz-acp pin
         run: echo "BUZZ_ACP_VERSION=$(tr -d '[:space:]' < buzz-acp.version)" >> "$GITHUB_ENV"


### PR DESCRIPTION
`actions/checkout` writes the job token into `.git/config` as an http extraheader by default, where it stays readable by every subsequent step. In `build.yml` that hands the image build — and anything it executes, including dependency code pulled during the Docker build — a push-capable credential it never asks for.

Neither job needs it after checkout:

- **`decide`** (`build.yml:60`) — the filter step runs only local `git rev-list` and `git diff` over the history `fetch-depth: 0` already fetched. No network git.
- **`build`** (`build.yml:152`) — logs in to GHCR with an explicit `secrets.GITHUB_TOKEN` passed to `docker/login-action`. No git operation at all.

I grepped the workflow for `git`/`gh` invocations to confirm; the only two hits are the local `rev-list`/`diff` above. Checkout itself still authenticates normally — `persist-credentials: false` only stops it leaving the token behind afterwards.

### Relationship to #887

This is the change #887 described but did not contain: that PR's commit was empty (`gh pr view 887 --json files` returned `[]`, and `persist-credentials` appeared nowhere in its head tree), so it was closed rather than merged.

### `release.yml` is the precedent

Worth noting for reviewers: `release.yml` already does this on 4 of its 5 checkouts. The fifth is the Homebrew tap checkout, which takes `HOMEBREW_TAP_TOKEN` and pushes the formula commit — the legitimate exception that shows the rule.

The workflows still checking out with the default are `ci.yml` (8), `publish-manifests.yml` (2), `buzz-acp-publish.yml` (2), `decisions.yml`, `docs.yml`, `release-bump.yml` and `secrets-scan.yml`. Each needs the same per-job "does anything here use the token?" check rather than a blanket sweep — `release-bump.yml` in particular pushes. Left for follow-up to keep this reviewable.

### Verification

`build.yml` is not exercised by PR CI, so this one gets its proof on `main`: the next `build` run should log in to GHCR and push as usual. The failure mode if I've misjudged a step's needs would be an auth error in that run, not a silent bad image.