### PR TITLE
chore(cli): move the Go pins to 1.26, matching the image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         required: true
 
 env:
-  GO_VERSION: "1.25.0"
+  GO_VERSION: "1.26.0"
 
 permissions:
   contents: read

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,7 +17,7 @@ cross-compiles cleanly with stdlib tooling.
 
 ## Build
 
-Requires Go 1.25+.
+Requires Go 1.26+.
 
 ```sh
 cd cli

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/BinaryBourbon/fountain/cli
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/coder/websocket v1.8.12


### PR DESCRIPTION
#821 bumped the Dockerfile's `gocli` stage to `golang:1.26-bookworm`, but three other Go pins stayed at 1.25. The toolchain building the CLI then depended on which door it came through:

| Pin | Was | Builds |
|---|---|---|
| `Dockerfile:91` | **1.26** (#821) | the CLI inside the release image |
| `cli/go.mod:3` | 1.25.0 | CI — `ci.yml` uses `go-version-file: cli/go.mod` |
| `release.yml:19` `GO_VERSION` | 1.25.0 | the published `fountain-{linux,darwin}-{amd64,arm64}` assets |
| `cli/README.md:20` | 1.25+ | what a contributor installs |

So CI was testing at 1.25 what the image shipped at 1.26, and the release binaries people actually `brew install` were built with neither. This aligns all four on 1.26.

### Verified, not assumed

Bumping the `go` directive changes the **language version**, not just the toolchain — a 1.26 toolchain running in 1.25 language mode is a different thing from what this PR produces. So it was re-checked with the directive in place, in `golang:1.26-bookworm` (go1.26.7):

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — **12 packages ok**, 0 failures
- `go mod tidy` — no drift in `go.mod` or `go.sum`
- cross-compile of all four release targets — linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 all produce binaries

The `gocli` Docker stage itself was also built for both arches, and the resulting binary runs (`fountain version`, with `acp`/`run`/`runner` present).

### Note on the go directive

`go 1.26.0` is a *minimum*. Anyone on Go 1.21+ with the default `GOTOOLCHAIN` setting auto-downloads 1.26 as needed, so this doesn't strand contributors on older toolchains — but it does mean a `GOTOOLCHAIN=local` environment below 1.26 will now refuse to build, which is the intended signal given the image requires it.