### PR TITLE
docs: the three MCP servers Fountain hosts

### DIFF
--- a/docs/catalog/index.md
+++ b/docs/catalog/index.md
@@ -11,6 +11,7 @@ rest.
 |---|---|---|
 | [Runtimes](runtimes/index.md) | one coding-agent CLI a sandbox can run | 4 |
 | [Skills](skills/index.md) | one `SKILL.md` written into the sandbox | 2 bundled, plus anything on GitHub |
+| [MCP servers](mcp-servers/index.md) | one server giving the runtime tools | 3 hosted, plus anything you declare |
 
 ## Elsewhere in these docs
 
@@ -28,10 +29,11 @@ from outside. Editors, chat surfaces, plugin hosts, relays, your own code.
 
 ## What is not here yet
 
-**MCP servers.** `mcp_servers` is a first-class Agent field and there is no
-list of what works. Tracked in
+**A list of third-party MCP servers.** Fountain hosts three of its own and
+those are documented, but there is no curated list of which external servers
+work. Tracked in
 [#908](https://github.com/BinaryBourbon/fountain/issues/908), and it needs a
-decision about what "supported" means before it can be written honestly.
+decision about what "supported" would mean before such a list could be honest.
 
 If you want an entry that does not exist, open an issue. The entry template is
 in `docs-redesign/05-catalog-template.md` in the repository.

--- a/docs/catalog/mcp-servers/fountain-buzz.md
+++ b/docs/catalog/mcp-servers/fountain-buzz.md
@@ -1,0 +1,54 @@
+# fountain-buzz
+
+> Lets a hosted Buzz agent publish its reply to a Nostr channel.
+
+## At a glance
+
+| | |
+|---|---|
+| Hosted by | Fountain |
+| Declared by | Nobody. Injected automatically |
+| Injected when | The conversation's vault holds a Buzz identity, and a callback token exists |
+| Endpoint | `POST /api/mcp/buzz/:conversation_id` |
+| Auth | The sandbox's own per-conversation callback token |
+
+## Why it exists
+
+A Buzz agent's reply has to be signed with its Nostr key to appear on the
+relay.
+
+The key lives in a [vault](../../concepts/vault.md), and it stays on Fountain's
+side. The agent asks Fountain to publish, and Fountain signs. That is what
+these tools are.
+
+The consequence worth stating plainly: **the agent's own text is not published
+anywhere else.** An agent that writes a beautiful answer and does not call
+`buzz_send_message` has said nothing on the relay. This is the single most
+common way a hosted Buzz agent appears broken.
+
+## The tools
+
+| Tool | What it does |
+|---|---|
+| `buzz_send_message` | Post to a channel as this agent. Takes `channel` and `content`, plus an optional `reply_to` event id to start a thread. Returns the published event id |
+| `buzz_react` | Add an emoji reaction to an event as this agent |
+
+`content` is markdown and may carry `@mentions`.
+
+## Limits
+
+**No identity, no tools.** A conversation whose vault holds no Buzz identity
+gets an empty list rather than tools that fail. That is deliberate, and it is
+also the first thing to check when an agent will not reply.
+
+**Publishing is the agent's job.** Nothing publishes on its behalf if it
+forgets.
+
+**Event ids are 64-hex.** `reply_to` and `buzz_react`'s `event` both take one,
+not a channel id.
+
+## Related
+
+- [Buzz](../../integrations/buzz.md), the full hosted-agent guide.
+- [About vaults](../../concepts/vault.md), where the signing key lives.
+- [MCP servers](index.md).

--- a/docs/catalog/mcp-servers/fountain-comms.md
+++ b/docs/catalog/mcp-servers/fountain-comms.md
@@ -1,0 +1,71 @@
+# fountain-comms
+
+> Gives a teammate its own email address and phone number, without giving it
+> the keys.
+
+## At a glance
+
+| | |
+|---|---|
+| Hosted by | Fountain |
+| Declared by | Nobody. Injected automatically |
+| Injected when | The teammate has a contact, and the `team_comms` flag is on |
+| Endpoint | `POST /api/mcp/team-comms/:conversation_id` |
+| Auth | The sandbox's own per-conversation callback token |
+| Status | Behind a feature flag |
+
+## Why it exists this way
+
+A teammate that can email people needs a mail credential. Putting one in the
+sandbox would mean any agent that prints its environment has leaked the ability
+to send mail as you.
+
+So the credential does not go there. **Fountain owns the AgentMail and
+AgentPhone keys.** Giving a teammate a contact creates an inbox and a number
+under those keys, and the teammate reaches them only through these tools. The
+sandbox never sees a key.
+
+This is the same shape as [fountain-buzz](fountain-buzz.md), and the reasoning
+generalises. When an agent needs a capability that a credential would grant,
+serving the capability beats shipping the credential.
+
+## The tools
+
+Email tools appear only if the contact has an address, and SMS tools only if it
+has a number. `my_contact_info` is always there.
+
+| Tool | What it does |
+|---|---|
+| `email_send` | Send from the teammate's own address |
+| `email_reply` | Answer a message it received. Prefer this over `email_send` for replies |
+| `email_list` | Messages on its address |
+| `email_get` | One message in full |
+| `sms_send` | Send a text from its own number |
+| `sms_list` | Texts on its number, newest first, sent and received |
+| `my_contact_info` | Its own address and number, to share with people |
+
+## A contact granted mid-session works on the next turn
+
+Injection is recomputed at every turn kick rather than at provision. Give a
+working teammate a contact and it can send mail on its next reply, with no
+restart and no new sandbox.
+
+## Limits
+
+**Behind a flag.** `team_comms` gates the whole thing. With the flag off the
+tools are absent, not merely inert.
+
+**Teammates only.** A conversation that is not a teammate's gets nothing.
+
+**One identity per teammate.** The address and number belong to the teammate,
+so a fresh conversation under the same binding keeps them.
+
+**Fountain sees the traffic.** The mail and messages pass through Fountain's
+provider accounts, which is the cost of the sandbox not holding keys. If that
+is the wrong trade for your data, do not grant a contact.
+
+## Related
+
+- [Agents as teammates](../../concepts/teammates.md).
+- [fountain-buzz](fountain-buzz.md), the same pattern for Nostr.
+- [MCP servers](index.md).

--- a/docs/catalog/mcp-servers/fountain-team.md
+++ b/docs/catalog/mcp-servers/fountain-team.md
@@ -1,0 +1,67 @@
+# fountain-team
+
+> Lets a teammate see who else is on the team and message them.
+
+## At a glance
+
+| | |
+|---|---|
+| Hosted by | Fountain |
+| Declared by | Nobody. Injected automatically |
+| Injected when | The conversation is a teammate's, on the `fountain:team` channel |
+| Endpoint | `POST /api/mcp/team/:conversation_id` |
+| Auth | The sandbox's own per-conversation callback token |
+
+## Why it exists
+
+A team where the members cannot reach each other is a list, not a team.
+
+With these tools, "send this to the engineer" becomes `get_teammate("engineer")`
+then `send_to_teammate(id, text)`, and the reply comes back through
+`read_teammate`. A lead teammate can route work without a human relaying it.
+
+## The tools
+
+| Tool | What it does |
+|---|---|
+| `list_teammates` | Everyone on the team, with name, agent id, purpose and current presence. The place to start |
+| `get_teammate` | Resolve one by name, role or description. "the engineer", "whoever handles support". Returns the best match, or the candidates when ambiguous |
+| `send_to_teammate` | Send to a teammate's thread. They receive it like a typed message, prefixed with who it is from. Returns their conversation id |
+| `wait_for_teammate` | Block until their turn finishes, then return prompt, reply and status |
+| `read_teammate` | Their recent turns, newest last, with status. Use after `send_to_teammate` to collect the answer |
+
+A message sent this way lands in the receiving teammate's thread exactly as one
+typed on the team page would, and the receiver sees who sent it. There is no
+back channel.
+
+## Two things that catch agents out
+
+**`send_to_teammate` can fail with `busy` or `starting`.** A teammate mid-turn,
+or one whose sandbox is still provisioning, cannot take a message yet. Wait and
+retry.
+
+**`wait_for_teammate` blocks for at most 90 seconds**, default 60. If it
+returns `timed_out: true`, call it again. The important part is what the tool
+description tells the agent explicitly: *do not end your own turn to wait*.
+Ending the turn is how a delegation gets silently dropped.
+
+Pass `since_turn` to wait for one specific reply rather than the latest turn.
+
+## Limits
+
+**Team conversations only.** A conversation not bound to the team channel gets
+no tools at all, not an empty roster.
+
+**No credential reaches the sandbox.** The tools run on Fountain's side, and
+every call is tenant-scoped, so a teammate cannot reach another account's
+roster whatever it sends.
+
+**Presence is a point-in-time answer.** A teammate idle when you listed may be
+busy when you send.
+
+## Related
+
+- [Agents as teammates](../../concepts/teammates.md), what this operates on.
+- [MCP servers](index.md).
+- [create-team](../skills/create-team.md), which builds the roster these tools
+  read.

--- a/docs/catalog/mcp-servers/index.md
+++ b/docs/catalog/mcp-servers/index.md
@@ -1,0 +1,87 @@
+# MCP servers
+
+An MCP server gives a runtime tools it did not ship with. Fountain deals with
+two kinds, and they work differently enough to be worth separating.
+
+**Servers Fountain hosts.** Three of them, listed below. Nobody declares these
+and no operator configures them. Fountain injects them into a conversation when
+that conversation qualifies.
+
+**Servers you declare.** Anything else, through the `mcp_servers` field on an
+[Agent](../../concepts/agent.md). Fountain passes the declaration through and
+does not curate a list.
+
+## The three Fountain hosts
+
+| Server | Injected when | Tools |
+|---|---|---|
+| [fountain-team](fountain-team.md) | the conversation is a teammate's | `list_teammates`, `get_teammate`, `send_to_teammate`, `wait_for_teammate`, `read_teammate` |
+| [fountain-buzz](fountain-buzz.md) | the conversation's vault holds a Buzz identity | `buzz_send_message`, `buzz_react` |
+| [fountain-comms](fountain-comms.md) | the teammate has a contact, behind flag `team_comms` | `email_send`, `email_reply`, `email_list`, `email_get`, `sms_send`, `sms_list`, `my_contact_info` |
+
+Three properties are shared by all three, and each one is load-bearing.
+
+**The sandbox never holds the credential.** This is the whole point.
+`fountain-comms` is the clearest case: Fountain owns the AgentMail and
+AgentPhone keys, and the teammate reaches email and SMS purely through tools.
+No provider key enters the sandbox, so an agent that leaks its environment
+leaks nothing that can send mail.
+
+**They authenticate with the token the sandbox already has.** Each is served
+over HTTP at a per-conversation URL, and the sandbox presents its
+per-conversation callback token. There is no second credential to manage, and
+the token is scoped to that conversation's owner.
+
+**Injection is recomputed every turn.** A capability granted mid-session
+appears on the next turn rather than at the next provision. Give a teammate a
+contact while it is working and it can send mail on its next reply.
+
+Every call is tenant-scoped, and a message sent through a tool lands in the
+receiving teammate's thread exactly as one typed on the team page would, with
+the sender attributed.
+
+## Declaring your own
+
+`mcp_servers` on an Agent takes a map of server definitions, with `${VAR}`
+substitution in their `env` resolved from the merged environment and vault
+secrets at spawn time.
+
+```yaml
+mcp_servers:
+  github:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PAT}"
+```
+
+The credential comes from a [vault](../../concepts/vault.md) rather than being
+written into the agent. See
+[Where a secret comes from](../../concepts/secrets.md).
+
+Note the difference from the hosted servers above. A server you declare runs
+**inside** the sandbox and holds a real credential there. A server Fountain
+hosts runs outside it and holds nothing.
+
+### One runtime does this differently
+
+On `claude`, session-scoped MCP delivery is broken upstream, so Fountain
+provisions `.mcp.json` into the sandbox and enables project servers instead of
+passing them per session. The effect is the same. The mechanism matters only if
+you are debugging why a raw ACP probe behaves differently from Fountain. See
+[claude](../runtimes/claude.md).
+
+## No catalog of third-party servers
+
+Fountain does not maintain a list of which MCP servers work, and this page is
+not one.
+
+Any server the runtime can launch will run. Whether it is a good idea is
+between you and its author.
+
+## Related
+
+- [About agents](../../concepts/agent.md), where `mcp_servers` is declared.
+- [Agents as teammates](../../concepts/teammates.md), which
+  [fountain-team](fountain-team.md) serves.
+- [Where a secret comes from](../../concepts/secrets.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,10 @@ nav:
       - Skills: catalog/skills/index.md
       - fountain (skill): catalog/skills/fountain.md
       - create-team (skill): catalog/skills/create-team.md
+      - MCP servers: catalog/mcp-servers/index.md
+      - fountain-team: catalog/mcp-servers/fountain-team.md
+      - fountain-buzz: catalog/mcp-servers/fountain-buzz.md
+      - fountain-comms: catalog/mcp-servers/fountain-comms.md
   - Sandbox providers:
       - The contract: integrations/sandbox-contract.md
       - Sprites: integrations/sprites.md


### PR DESCRIPTION
Part of #908 and #903.

## The issue was half wrong, and I was the one who wrote it

I filed #908 saying MCP servers needed a product decision. Investigating it
while doing #915, **half of it needed no decision at all.**

Fountain *hosts* three MCP servers and injects them into a conversation
automatically. Nobody declares them, no operator configures them, and none
were documented anywhere.

| Server | Injected when | Tools |
|---|---|---|
| `fountain-team` | the conversation is a teammate's | `list_teammates`, `get_teammate`, `send_to_teammate`, `wait_for_teammate`, `read_teammate` |
| `fountain-buzz` | the conversation's vault holds a Buzz identity | `buzz_send_message`, `buzz_react` |
| `fountain-comms` | the teammate has a contact, behind flag `team_comms` | 7 email and SMS tools |

A user could not previously discover that their teammate has
`send_to_teammate` at all.

## Three shared properties, stated once

Each is load-bearing, so the index carries them rather than repeating per
entry.

**The sandbox never holds the credential.** `fountain-comms` is the clearest
case: Fountain owns the AgentMail and AgentPhone keys, and the teammate reaches
mail and SMS purely through tools. An agent that leaks its environment leaks
nothing that can send mail. The reasoning generalises, and the page says so:
when an agent needs a capability a credential would grant, serving the
capability beats shipping the credential.

**They authenticate with the per-conversation callback token the sandbox
already has.** No second credential to manage.

**Injection is recomputed every turn.** Grant a working teammate a contact and
it can send mail on its next reply, with no restart.

## Two traps that were told to agents and not to humans

The tool descriptions warn the model about both. Nothing told the person
debugging it.

- `send_to_teammate` fails with `busy` or `starting` when the teammate is
  mid-turn or still provisioning. Wait and retry.
- `wait_for_teammate` blocks for 90 seconds maximum. On `timed_out: true` you
  call it again — **do not end your own turn to wait**, which is how a
  delegation gets silently dropped.

And one for Buzz that is the most common way a hosted agent looks broken:
**the agent's own text is not published anywhere else.** An agent that writes a
good answer and never calls `buzz_send_message` has said nothing on the relay.

## The absence is now a decision, not a gap

The index states plainly that Fountain keeps no list of third-party MCP
servers, and links #908. Any server the runtime can launch will run; whether it
is a good idea is between you and its author.

That half of #908 stays open pending a definition of "supported".

## Verification

Facts checked against `team/mcp.ex`, `buzz/mcp.ex`, `team/comms/mcp.ex` and the
injection guards in `conversation_server.ex`.

- `mkdocs build --strict`, clean
- `docs_test.exs` + `docs_controller_test.exs`, 32 tests 0 failures
- Style rules checked by hand. `scripts/docs-style.py` lands with #917 and will
  guard these pages from then on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
