### PR TITLE
docs: clean architecture.md, the biggest style-backlog page

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,22 +1,22 @@
 # Architecture
 
 This page is the system view: what processes exist, what they talk to, and what
-breaks when each dependency is down. For the domain objects — agents,
-environments, vaults, conversations — see [The four primitives](primitives.md).
+breaks when each dependency is down. For the domain objects (agents,
+environments, vaults, conversations) see [The four primitives](primitives.md).
 
 ---
 
 ## The runtime shape
 
 Fountain is **one OTP release**, `fountain_server`. Everything below runs
-inside a single BEAM instance — there are no separate worker deployments or
+inside a single BEAM instance. There are no separate worker deployments and no
 sidecars, and scaling out means running more replicas of the same image.
 
 | Piece | Job |
 |---|---|
 | **Phoenix endpoint** | The one public listener: the operator console, the REST API, and SSE streaming, all on the same port |
 | **Conversation server** | One process per active conversation. Owns the sandbox: provisions it, spawns turns in it, streams output back, enforces lifecycle bounds. Holds the decrypted tenant key in memory for the duration. Registered cluster-wide, so exactly one exists per conversation no matter how many replicas run |
-| **Rehydrator** | Runs once at boot. Finds conversations that were live before the restart and restarts their servers, which reattach to the still-running sprite — a deploy does not kill running work |
+| **Rehydrator** | Runs once at boot. Finds conversations that were live before the restart and restarts their servers, which reattach to the still-running sprite, so a deploy does not kill running work |
 | **Oban** | Background jobs (billing syncs, lifecycle emails, account exports on the `exports` queue) and the cron schedule below |
 | **Metrics listener** | A second, private HTTP listener on `METRICS_PORT` (default 9568 in production, disabled elsewhere) serving `/metrics` and `/health`. Deliberately separate from the public endpoint, so an ingress rule can never accidentally expose it |
 
@@ -25,14 +25,15 @@ Scheduled work, all times UTC:
 | Schedule | Job | What it does |
 |---|---|---|
 | Hourly at :07 | Sandbox reaper | Reconciles sandbox rows against sprites.dev: frees rows stuck mid-provision, expires abandoned sandboxes, destroys sprites whose row is already terminal, reports untracked sprites |
-| 04:23 daily | Retention pruner | Deletes rows past retention — log events and Stripe events after 90 days, audit events after 365, usage events after 400, revoked API keys after 30 |
+| 04:23 daily | Retention pruner | Deletes rows past retention. Log events and Stripe events after 90 days, audit events after 365, usage events after 400, revoked API keys after 30 |
 | 05:41 daily | Unverified-account pruner | Deletes accounts that never verified their email, after 30 days, through the full deletion path (Stripe, sprites, audit) |
 
 ### Clustering
 
 One replica needs none of this. With more than one, replicas must form an
-Erlang cluster — `CLUSTER_DNS_QUERY` pointed at a headless service
-([`k8s/` shows the wiring](guides/operate/kubernetes.md)):
+Erlang cluster, with `CLUSTER_DNS_QUERY` pointed at a headless service.
+[`k8s/` shows the wiring](guides/operate/kubernetes.md). Two things depend on
+it.
 
 - The conversation registry places each conversation server on exactly one
   node and finds it from any node.
@@ -51,10 +52,11 @@ on one node only.
 
 **Postgres is the only durable store.** Users, agent and environment configs,
 encrypted secrets, conversations, turns, log output, the audit trail, the job
-queue, uploaded images — all rows. Sprites are disposable by design: output is
-persisted as it streams, so destroying a sandbox loses nothing that mattered.
+queue, uploaded images are all rows. Sandboxes are disposable by design, and
+output is persisted as it streams, so destroying one loses nothing that
+mattered.
 
-What is *not* durable, deliberately:
+Two things are deliberately *not* durable.
 
 - Per-node in-memory tables: rate-limit counters and the log-redaction
   registry. Rebuilt empty at boot.
@@ -62,9 +64,9 @@ What is *not* durable, deliberately:
   and the sandbox's callback token live only in that conversation's process
   and die with it.
 
-Consequence: a complete backup is **Postgres plus `MASTER_SECRETS_KEY`** —
-nothing else holds state. The [secrets model](#the-secrets-model) below is why
-the key is half of that sentence.
+A complete backup is therefore **Postgres plus `MASTER_SECRETS_KEY`**. Nothing
+else holds state. The [secrets model](#the-secrets-model) below is why the key
+is half of that sentence.
 
 ---
 
@@ -72,33 +74,33 @@ the key is half of that sentence.
 
 | Dependency | Needed for | When it is down |
 |---|---|---|
-| **Postgres** | Everything | `GET /health/ready` returns 503 and load balancers drain the instance; the app stays up and does not restart — restarting does not fix Postgres, so [the restart check deliberately checks nothing](guides/operate/observability.md#health-endpoints). Recovery is automatic. A replica *booting* against a down database fails instead, because migrations run at boot |
-| **sprites.dev** | Conversations | New provisions and wakes fail — bounded retries with backoff, then the conversation is marked `failed` (or left resumable, if it was a wake). Everything else keeps serving: sign-in, dashboards, agent/environment/vault management, past logs. Deliberately excluded from the readiness check — a third party's uptime does not belong on the serving path |
-| **Stripe** | Billing — optional, `BILLING_ENABLED` | Checkout and the billing portal fail with a visible error; the billing page itself still renders from local state. Webhooks are redelivered by Stripe until acknowledged. Trial expiry is enforced against the local clock, so an outage delays revenue rather than opening the gate |
-| **Mail** (Resend or SMTP) | Signup verification, password reset | Both dead-end while the provider is down. Escape hatch: `Fountain.Release.verify_email/1` — see [Email](guides/operate/email.md). (`EMAIL_DELIVERY=none` is different: accounts self-verify, ADR 0011) |
-| **GitHub OAuth** | The OAuth login button — optional | Only that button. Email/password auth is unaffected |
-| **Sentry** | Error reporting — optional | Inert without a DSN; nothing depends on it |
-| **Object storage** | Database backups — ops layer | The application never touches object storage; it exists only in a deployment's backup pipeline |
+| **Postgres** | Everything | `GET /health/ready` returns 503 and load balancers drain the instance; the app stays up and does not restart, because restarting does not fix Postgres, so [the restart check deliberately checks nothing](guides/operate/observability.md#health-endpoints). Recovery is automatic. A replica *booting* against a down database fails instead, because migrations run at boot |
+| **sprites.dev** | Conversations | New provisions and wakes fail after bounded retries with backoff, then the conversation is marked `failed`, or left resumable if it was a wake. Everything else keeps serving, including sign-in, dashboards, agent/environment/vault management and past logs. Deliberately excluded from the readiness check, because a third party's uptime does not belong on the serving path |
+| **Stripe** | Billing (optional, `BILLING_ENABLED`) | Checkout and the billing portal fail with a visible error; the billing page itself still renders from local state. Webhooks are redelivered by Stripe until acknowledged. Trial expiry is enforced against the local clock, so an outage delays revenue rather than opening the gate |
+| **Mail** (Resend or SMTP) | Signup verification, password reset | Both dead-end while the provider is down. The escape hatch is `Fountain.Release.verify_email/1`. See [Email](guides/operate/email.md). (`EMAIL_DELIVERY=none` is different, because accounts self-verify, ADR 0011) |
+| **GitHub OAuth** | The OAuth login button (optional) | Only that button. Email/password auth is unaffected |
+| **Sentry** | Error reporting (optional) | Inert without a DSN, and nothing depends on it |
+| **Object storage** | Database backups (ops layer) | The application never touches object storage, and it exists only in a deployment's backup pipeline |
 | **Inference providers** | Turns | Credentials are per-user, stored by Fountain but consumed *inside* the sandbox. An Anthropic or OpenAI outage fails turns, not Fountain |
 
 ---
 
 ## The secrets model
 
-Envelope encryption, two layers:
+Envelope encryption, in two layers.
 
 1. Each tenant has a **data encryption key** (DEK). Every environment and
    vault secret is encrypted with it, AES-256-GCM.
-2. The DEK itself is stored **wrapped** by `MASTER_SECRETS_KEY` — an
+2. The DEK itself is stored **wrapped** by `MASTER_SECRETS_KEY`, an
    environment variable, never written to the database.
 
-The blast radius follows from the layout:
+Three consequences follow from that layout.
 
 - **A database backup cannot decrypt itself.** Restoring secrets requires the
-  same `MASTER_SECRETS_KEY` the backup was written under —
+  same `MASTER_SECRETS_KEY` the backup was written under, so
   [keep it separate from the backups](guides/operate/back-up-and-restore.md#back-up-master_secrets_key).
 - Losing or changing the master key makes every stored secret unrecoverable.
-  Nothing else is lost — accounts, configs and history are plain rows.
+  Nothing else is lost, because accounts, configs and history are plain rows.
 - An attacker with only database access holds ciphertext and wrapped keys, not
   values.
 
@@ -118,8 +120,8 @@ Progress is recorded as **stage events**. The stage names below are the exact
 strings shown in the UI, the SSE stream and the log rows, each with a state of
 `started`, `done`, `failed` or `interrupted`.
 
-1. **Gates.** A prompt arrives — `POST /api/conversations`, or a client on it. In order:
-   the agent must exist *and belong to you* (every query in the system is
+1. **Gates.** A prompt arrives, through `POST /api/conversations` or a client
+   on it. In order, the agent must exist *and belong to you* (every query in the system is
    tenant-scoped); the vault must be on the agent's allowlist; the
    subscription gate, when billing is enabled (`402` otherwise); the
    concurrent-sandbox quota (default 5 per user).
@@ -127,35 +129,35 @@ strings shown in the UI, the SSE stream and the log rows, each with a state of
    a conversation server starts. It creates the sprite, mounts skills, mints a
    scoped, expiring API key the sandbox uses to call back into Fountain,
    assembles the env, and writes it into the sprite. Then either
-   **`checkpoint_restore`** — a warm start from an environment checkpoint,
-   skipping the rest — or the cold pipeline: **`packages` → `network` →
+   **`checkpoint_restore`**, a warm start from an environment checkpoint that
+   skips the rest, or the cold pipeline **`packages` → `network` →
    `clone` → `setup`**. The sandbox is now `ready`. Any failed step destroys
    the sprite and marks sandbox and conversation `failed`.
 3. **`turn`.** The runtime (claude, codex, gemini, opencode) is spawned inside
    the sprite. Its output flows back to the server, is redacted, persisted as
-   log events, and broadcast — the LiveView and the SSE endpoint
+   log events, and broadcast. The LiveView and the SSE endpoint
    (`GET /api/conversations/:id/stream`, resumable via `Last-Event-ID`) are
-   both just subscribers to the same feed.
+   both subscribers to the same feed.
 4. **Idle.** The turn exits and the conversation goes `idle`, sandbox still
    warm. A follow-up prompt starts the next turn immediately.
-5. **`reattach`.** If the server is gone — a deploy, a node loss — but the
-   sprite survived, the next prompt (or the boot-time rehydrator) reattaches:
-   verify the sprite still exists, rewrite its env, pick a still-running
-   turn's session back up where it left off. The runtime's session lives on
+5. **`reattach`.** If the server is gone (a deploy, a node loss) but the
+   sprite survived, the next prompt or the boot-time rehydrator reattaches. It
+   verifies the sprite still exists, rewrites its env, and picks a
+   still-running turn's session back up where it left off. The runtime's session lives on
    the sprite's disk, so reattaching to the *same* sprite keeps the agent's
-   memory. If the sprite is gone, the conversation re-provisions from step 2 —
-   Fountain's transcript survives, the agent's session does not (#649).
-6. **`sandbox`** — the lifetime bounds. Every server checks its
-   [bounds](guides/operate/sandbox-lifetime.md) each minute, and they do
-   different things: crossing the **idle timeout** *suspends* — the server
-   stops, the sprite stays (it scales itself to zero) and the sandbox parks in
+   memory. If the sprite is gone, the conversation re-provisions from step 2.
+   Fountain's transcript survives and the agent's session does not (#649).
+6. **`sandbox`**, the lifetime bounds. Every server checks its
+   [bounds](guides/operate/sandbox-lifetime.md) each minute, and the two do
+   different things. Crossing the **idle timeout** *suspends*. The server
+   stops, the sprite stays and scales itself to zero, and the sandbox parks in
    `suspended`, to be woken with everything intact by the next prompt.
    Crossing the **max lifetime** *destroys* the sprite and marks the sandbox
    `terminated`; the conversation goes back to `idle`, resumable at the #649
    price. The hourly reaper applies the same split to anything a crashed
    server left behind.
 7. **`terminate`.** An explicit `POST .../terminate` destroys the sprite and
-   marks the conversation `terminated` — one of the two terminal states,
+   marks the conversation `terminated`, one of the two terminal states
    alongside `failed`.
 
 The two status vocabularies, side by side:
@@ -173,15 +175,16 @@ what a max-lifetime reclaim leaves behind).
 
 ## Where to look
 
-The point of this page: given a symptom, predict the component. The action
-level — what to run and what the output means — is [Operations](operations.md).
+The point of this page is that a symptom should predict a component. The
+action level, meaning what to run and what the output means, is
+[Operations](operations.md).
 
 | Symptom | Look at |
 |---|---|
 | Conversation stuck or `failed` during startup | The stage events in its log view name the failing step. `packages`, `clone` and `setup` failures are usually the environment's own config; `provision` failing outright is sprites.dev or the sandbox quota |
 | UI down, `GET /health/ready` returns 503 | Postgres |
-| Container restarts in a loop at boot | Migrations cannot reach Postgres — boot fails before anything listens |
-| Streaming dead for some viewers, fine for others, multiple replicas | Erlang clustering — `CLUSTER_DNS_QUERY` |
-| Signups never complete | Mail delivery — see [Email](guides/operate/email.md) |
+| Container restarts in a loop at boot | Migrations cannot reach Postgres, so boot fails before anything listens |
+| Streaming dead for some viewers, fine for others, multiple replicas | Erlang clustering, via `CLUSTER_DNS_QUERY` |
+| Signups never complete | Mail delivery. See [Email](guides/operate/email.md) |
 | `402 subscription_required` on a self-hosted instance | `BILLING_ENABLED` should be `false` |
-| Sandbox suspends between prompts, work resumes on the next one | Working as designed — [lifecycle bounds](guides/operate/sandbox-lifetime.md) |
+| Sandbox suspends between prompts, work resumes on the next one | Working as designed. See [lifecycle bounds](guides/operate/sandbox-lifetime.md) |

--- a/scripts/docs-style-allow.txt
+++ b/scripts/docs-style-allow.txt
@@ -9,7 +9,6 @@
 # The checker fails if a line here names a file that no longer exists, so a
 # rename cannot quietly re-exempt a page.
 docs/api.md
-docs/architecture.md
 docs/build/index.md
 docs/build/team-chat.md
 docs/configuration.md


### PR DESCRIPTION
Part of #911 and #903. Follows #917, which added the checker and the ratchet.

`architecture.md` had **32 em dashes and 4 colon-introduced lists**, the
largest single page on the backlog after `api.md`. It is off the manifest now,
so the checker guards it.

## 28 edits, each a judgment call

The recurring patterns are worth naming, because they are what the rest of the
backlog will look like.

**A dash carrying a *because* becomes one.**

> before: `the app stays up and does not restart — restarting does not fix Postgres`
> after: `the app stays up and does not restart, because restarting does not fix Postgres`

The causal link was implied by punctuation. Now it is stated, and a reader who
disagrees can say so.

**A dash carrying a parenthetical becomes parentheses.**

> before: `| **Stripe** | Billing — optional, `BILLING_ENABLED` |`
> after: `| **Stripe** | Billing (optional, `BILLING_ENABLED`) |`

**A colon-introduced list gains a counted lead-in.**

> before: `What is *not* durable, deliberately:`
> after: `Two things are deliberately *not* durable.`

The count is a free correctness check. If the list grows to three and the
sentence still says two, the diff is visibly wrong. That is the argument for
the rule, and this page is where it pays.

## Two sentences changed meaning slightly, for the better

Both in the lifecycle section, where a dash was doing the work of an "or" and
the reader had to guess which branch a clause belonged to:

> before: `either **checkpoint_restore** — a warm start ..., skipping the rest — or the cold pipeline: ...`
> after: `either **checkpoint_restore**, a warm start ... that skips the rest, or the cold pipeline ...`

Same for step 5, where `If the server is gone — a deploy, a node loss — but the
sprite survived` reads as three clauses of equal weight and is actually one
condition with an aside.

## Verification

- `scripts/docs-style.py`: clean, 49 files checked, 29 on the backlog
- `mkdocs build --strict`: clean
- `docs_test.exs`: 25 tests, 0 failures

The 49 includes the MCP pages from #920, which I had only checked by hand
before the checker existed. They pass.

## Note on the flake you may see

#917 hit an unrelated flake in `conversations_wake_test.exs` on a docs-only
diff. Filed as #921 with a diagnosis and three options. It is a wall-clock race
in the test, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
