### PR TITLE
docs: api.md and configuration.md cleaned, plus two false positives fixed in the checker

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,17 +4,17 @@ Fountain exposes a REST API. All endpoints are under `/api/` and return JSON.
 
 !!! tip "Writing a script, not an integration?"
 
-    The [TypeScript SDK](sdk.md) is one call — `fountain.run(prompt, { agent, vault })` —
+    The [TypeScript SDK](sdk.md) is one call, `fountain.run(prompt, { agent, vault })`,
     over the conversation endpoints below. Reach for the raw API when you need
     a surface the SDK does not wrap, or a language it is not written in.
 
-The authoritative, always-current reference is the served OpenAPI spec:
+The authoritative, always-current reference is the served OpenAPI spec.
 
 - `GET /api/openapi.json` - OpenAPI 3.1 spec, generated from the code (public, no auth)
 - `GET /api/docs` - Swagger UI over the same spec
 
 The endpoint listings below are a convenience summary of that spec. Every
-`/api/` endpoint is in it, including the auth surface — a test walks the router
+`/api/` endpoint is in it, including the auth surface. A test walks the router
 and fails if a route is added without one, so a generated client covers the
 whole API and not just the parts someone remembered to document.
 
@@ -36,18 +36,18 @@ POST   /api/auth/api-keys          # create a key (plaintext returned once)
 DELETE /api/auth/api-keys/:id      # revoke a key
 ```
 
-**Registration and account recovery** (no auth — the emailed token authenticates the completion):
+**Registration and account recovery** (no auth, because the emailed token authenticates the completion):
 
 ```
 POST   /api/auth/register          # {email, password}
 POST   /api/auth/resend-verification
 POST   /api/auth/verify            # {token} -> activate the account
-POST   /api/auth/forgot            # {email} — always 200, never reveals whether it exists
+POST   /api/auth/forgot            # {email}. Always 200, never reveals whether it exists
 POST   /api/auth/reset             # {token, password}
-POST   /api/auth/email/confirm     # {token} — completes a pending email change
+POST   /api/auth/email/confirm     # {token}. Completes a pending email change
 ```
 
-The verification and reset emails keep linking to the browser pages; these endpoints accept the same tokens, so a CLI can prompt "paste the code from your email" and never open a browser. `verify` is idempotent (an already-verified account is a 200) and issues no session — mint a key at `POST /api/auth/token` once the account is live. Token failures are `422` with `error` of `invalid_token` or `expired`.
+The verification and reset emails keep linking to the browser pages; these endpoints accept the same tokens, so a CLI can prompt "paste the code from your email" and never open a browser. `verify` is idempotent (an already-verified account is a 200) and issues no session, so mint a key at `POST /api/auth/token` once the account is live. Token failures are `422` with `error` of `invalid_token` or `expired`.
 
 Completing a reset or an email change bumps `session_version`, which signs out every existing session.
 
@@ -55,12 +55,12 @@ Completing a reset or an email change bumps `session_version`, which signs out e
 
 ```
 POST   /api/auth/password          # {current_password, new_password}
-POST   /api/auth/email             # {new_email, current_password} — sends a confirmation link
+POST   /api/auth/email             # {new_email, current_password}. Sends a confirmation link
 ```
 
-Changing the password signs out browser sessions (`session_version` bumps) but does **not** revoke API keys — they are separate credentials with their own expiries. The response says so explicitly (`sessions_invalidated`, `api_keys_revoked`); if you are rotating because something leaked, revoke keys yourself with `DELETE /api/auth/api-keys/:id`.
+Changing the password signs out browser sessions (`session_version` bumps) but does **not** revoke API keys, which are separate credentials with their own expiries. The response says so explicitly (`sessions_invalidated`, `api_keys_revoked`); if you are rotating because something leaked, revoke keys yourself with `DELETE /api/auth/api-keys/:id`.
 
-The email endpoint answers identically whether or not the address is free — it is not an availability oracle — and the address only changes when the emailed token is submitted to `POST /api/auth/email/confirm`.
+The email endpoint answers identically whether or not the address is free, so it is not an availability oracle. The address only changes when the emailed token is submitted to `POST /api/auth/email/confirm`.
 
 **Session cookie:** Obtained via OAuth at `/auth/oauth/:provider` or email/password login. Used by Fountain's own console.
 
@@ -101,9 +101,9 @@ POST   /api/account/billing/portal    # Stripe Billing Portal URL
 POST   /api/account/billing/checkout  # Stripe Checkout URL
 ```
 
-Stripe requires a browser to finish, so the URL is the deliverable — mint it here, open it there. Return URLs are server-chosen; a caller-supplied one would be an open redirect.
+Stripe requires a browser to finish, so the URL is the deliverable. Mint it here, open it there. Return URLs are server-chosen; a caller-supplied one would be an open redirect.
 
-`checkout` refuses with `409 subscription_exists` when Stripe already holds a live subscription (Checkout on top of one creates a duplicate) — use the portal instead. Both refuse a comped account with `422`, and answer `502` rather than guessing when Stripe is unreachable. On an instance with billing disabled all three are `404` with `"billing": "disabled"`.
+`checkout` refuses with `409 subscription_exists` when Stripe already holds a live subscription (Checkout on top of one creates a duplicate), so use the portal instead. Both refuse a comped account with `422`, and answer `502` rather than guessing when Stripe is unreachable. On an instance with billing disabled all three are `404` with `"billing": "disabled"`.
 
 ### Data export and deletion
 
@@ -112,16 +112,16 @@ POST   /api/account/exports              # 202 with a pending export; 429 + Retr
 GET    /api/account/exports              # status (zero- or one-element list)
 GET    /api/account/exports/:id
 GET    /api/account/exports/:id/download # gzipped JSON
-DELETE /api/account                      # {"confirm": "<your account email>"} — irreversible
+DELETE /api/account                      # {"confirm": "<your account email>"}. Irreversible
 ```
 
 Exports build asynchronously; the API has no PubSub, so poll `GET /api/account/exports` until `downloadable` is true. At most one export exists per account and one request per hour.
 
-Deleting the account cancels billing, destroys sandboxes and removes every resource **and the tenant encryption key**. It requires the confirmation body — the API equivalent of the UI's typed-email gate — and a `full`-scoped key.
+Deleting the account cancels billing, destroys sandboxes and removes every resource **and the tenant encryption key**. It requires the confirmation body, the API equivalent of the UI's typed-email gate, and a `full`-scoped key.
 
 ## Inference credentials
 
-Conversations run on your own provider tokens (BYO — Fountain never sees your inference traffic), so a new account cannot start a conversation until at least one is set.
+Conversations run on your own provider tokens, and Fountain never sees your inference traffic, so a new account cannot start a conversation until at least one is set.
 
 ```
 GET    /api/account/inference-credentials             # per-provider set/not-set
@@ -136,17 +136,17 @@ Providers: `anthropic_api_key`, `claude_code_oauth_token`, `openai_api_key`, `ge
 | Status | Meaning |
 |---|---|
 | `200` | Stored (encrypted under your tenant key) |
-| `422` | `invalid` — the provider rejected it (`provider_status` carries the upstream code); or a blank value; or an unknown provider |
-| `502` | `network` — the provider was unreachable from this instance |
-| `504` | `timeout` — the provider did not answer in time |
+| `422` | `invalid`. The provider rejected it (`provider_status` carries the upstream code), or the value was blank, or the provider is unknown |
+| `502` | `network`. The provider was unreachable from this instance |
+| `504` | `timeout`. The provider did not answer in time |
 
 Send `{"validate": false}` to store a credential without the ping.
 
-Values are **write-only** — these endpoints report only whether a provider is set. They require a `full`-scoped key: the per-conversation token a sandbox holds cannot read or replace the account's credentials.
+Values are **write-only**, so these endpoints report only whether a provider is set. They require a `full`-scoped key, because the per-conversation token a sandbox holds cannot read or replace the account's credentials.
 
 ## Rate limiting
 
-Requests are rate-limited per client IP (authenticated or not — the limiter does not key by API key). On limit hit: `429 Too Many Requests` with `Retry-After` header.
+Requests are rate-limited per client IP, authenticated or not, because the limiter does not key by API key. On a limit hit you get `429 Too Many Requests` with a `Retry-After` header.
 
 ## Agents
 
@@ -177,19 +177,19 @@ POST /api/avatars/generate    # {base, mood} → {data (base64 PNG), media_type}
 
 The vocabulary the agent and environment forms are built from, so a client
 elsewhere does not hard-code it. Model lists are suggestions, not an
-allowlist — any `provider/model` under a known provider is accepted.
+allowlist, and any `provider/model` under a known provider is accepted.
 `package_managers` is what provisioning actually installs from an
 environment's `packages` (`apt`, `npm`); other keys are stored and ignored.
 Avatar generation uses the tenant's own OpenAI credential (`422
 no_openai_key` without one).
 
-`apps` is where this instance sends a human to *read* something — the
+`apps` is where this instance sends a human to *read* something, meaning the
 standalone [conversations](https://github.com/jhgaylor/fountain-conversations)
 and [team](https://github.com/jhgaylor/fountain-team) apps, which route on the
 fragment (`…/#/c/<conversation_id>`, `…/#/team/<agent_id>`). Either is null
 where the deployment has no such app. Use it instead of composing a URL
-against the API host: Fountain's own UI is a console and does not serve
-transcripts.
+against the API host, because Fountain's own UI is a console and does not
+serve transcripts.
 
 ## Environments
 
@@ -227,7 +227,7 @@ The same write-only rule applies to vault secret values.
 POST   /api/apply                # apply a compiled manifest in one request
 ```
 
-Takes the compiled form of a `fountain.yml` manifest — this is what `fountain apply` sends:
+Takes the compiled form of a `fountain.yml` manifest, which is what `fountain apply` sends.
 
 ```json
 {
@@ -239,7 +239,7 @@ Takes the compiled form of a `fountain.yml` manifest — this is what `fountain 
 }
 ```
 
-Resources are upserted by name in a fixed order (environments, then vaults, then agents), so an agent's `spec.environment` name reference resolves against environments in the same manifest **or** environments that already exist. Application is best-effort per resource: the response is always `200` with a per-resource result — `action` of `created`, `updated`, or `error` (with changeset-style `errors`), plus per-key secret outcomes. Secret values are never echoed back.
+Resources are upserted by name in a fixed order (environments, then vaults, then agents), so an agent's `spec.environment` name reference resolves against environments in the same manifest **or** environments that already exist. Application is best-effort per resource: the response is always `200` with a per-resource result, carrying an `action` of `created`, `updated`, or `error` (with changeset-style `errors`), plus per-key secret outcomes. Secret values are never echoed back.
 
 ## Conversations
 
@@ -261,9 +261,9 @@ GET    /api/conversations/:id/stream       # SSE log stream (?streams=stdout,std
 GET    /api/conversations/:id/turns/:turn_id/images/:position   # image bytes
 ```
 
-Turns carry `image_count`; the image endpoint takes a zero-based `position` into that count and returns the raw bytes with the stored media type. Anything that does not resolve — unknown conversation, a turn from a different conversation, an absent position, a stored media type that is not an image — is a `404`, so it is not a probe for ids.
+Turns carry `image_count`; the image endpoint takes a zero-based `position` into that count and returns the raw bytes with the stored media type. Anything that does not resolve is a `404`, so it is not a probe for ids. That covers an unknown conversation, a turn from a different conversation, an absent position, and a stored media type that is not an image.
 
-The list takes `agent_id`, `channel_id` (the *bound* channel — `fountain:team`
+The list takes `agent_id`, `channel_id` (the *bound* channel, `fountain:team`
 for the team; a conversation unbound by removing its teammate no longer
 matches, so a teammate's full history is `GET /api/team/:agent_id/conversations`)
 and `status` (comma-separated; `400 invalid_status` on a value outside the
@@ -271,8 +271,8 @@ vocabulary), all combinable with `roots_only`. The list is unpaged.
 
 Conversation objects carry `title`, `turn_count`, `last_active_at`, `last_read_at` and a computed `unread` alongside the lifecycle fields. `unread` is true when `last_active_at` is later than `last_read_at` (and for a conversation never read); `POST /api/conversations/:id/read` clears it.
 
-**Token usage.** Each turn carries `usage` — `{input, output, cache_read?,
-cache_write?}` — the figure the runtime reports when the turn ends (the ACP
+**Token usage.** Each turn carries `usage`, as `{input, output, cache_read?,
+cache_write?}`, the figure the runtime reports when the turn ends (the ACP
 `session/prompt` response's `usage`; claude-agent-acp and codex-acp report
 it), or `null` while the turn runs, when the runtime reported none, or on
 turns that predate the field. It is recorded once per turn and never summed
@@ -282,7 +282,7 @@ conversation carries `usage_total: {input, output}`, a running sum over its
 turns; a `/api/team` roster entry carries `usage_total` summed over every
 conversation the agent has had on the team.
 
-`/tree` returns every conversation in the same spawn tree — ancestors and descendants, flat, each with a `parent_id`:
+`/tree` returns every conversation in the same spawn tree. Ancestors and descendants, flat, each with a `parent_id`.
 
 ```json
 {"data": [{"id": "…", "source": "ui", "status": "idle", "parent_id": null},
@@ -291,7 +291,7 @@ conversation the agent has had on the team.
 
 Since sub-conversations are created over the API (`X-Fountain-Parent-Conversation-Id`), this is how an agent that fanned out enumerates what it started without keeping its own bookkeeping.
 
-`/events` is the read-model for the log feed and `/stream` is the tail. The JSON endpoint returns the same rows the stream sends — `kind`, `stream`, `data`, `stage`, `state`, `duration_ms`, `turn_id`, `ts` — plus each event's `id`, oldest first:
+`/events` is the read-model for the log feed and `/stream` is the tail. The JSON endpoint returns the same rows the stream sends (`kind`, `stream`, `data`, `stage`, `state`, `duration_ms`, `turn_id`, `ts`) plus each event's `id`, oldest first.
 
 ```json
 {"data": [{"id": 41, "kind": "output", "stream": "stdout", "data": "...", "ts": "..."}],
@@ -300,7 +300,7 @@ Since sub-conversations are created over the API (`X-Fountain-Parent-Conversatio
 
 Page by passing the previous response's `meta.next_cursor` as `after`; keep going while `meta.has_more` is true. `limit` defaults to 100 and caps at 1000. The `id` is the same value the SSE route uses as `Last-Event-ID`, so a client can drain history as JSON and then attach the stream from where it left off.
 
-`?blocks=true` — on `/events`, on `/stream` and on `/api/events/stream` — adds
+`?blocks=true`, available on `/events`, on `/stream` and on `/api/events/stream`, adds
 `blocks` to every event: its `data` parsed server-side into the structured
 blocks a transcript renders, the same parse the conversations app uses
 (`Fountain.Conversations.Blocks`). A client never re-implements a runtime's
@@ -310,11 +310,11 @@ dialect (ADR 0014, applied to the wire). Kinds and their fields:
 |---|---|
 | `text`, `thinking` | `body` |
 | `tool_use` | `id`, `name`, `summary`, `body` (the input) |
-| `tool_result` | `tool_id`, `body`, `error` — pair it with the `tool_use` of the same id |
+| `tool_result` | `tool_id`, `body`, `error`. Pair it with the `tool_use` of the same id |
 | `init` | `summary`, `body` |
 | `result` | `body`, `raw` |
 | `error` | `body` |
-| `raw` | `body`, `summary` — an unrecognised line, shown rather than dropped |
+| `raw` | `body`, `summary`. An unrecognised line, shown rather than dropped |
 
 Non-output events carry `blocks: []`; without the flag the field is absent.
 
@@ -325,7 +325,7 @@ GET /api/events/stream          # SSE (?streams=  ?blocks=true)
 ```
 
 One `text/event-stream` for every conversation the caller owns that is not
-finished — what a conversation list with live status and unread dots needs
+finished, which is what a conversation list with live status and unread dots needs
 instead of a socket per conversation. Each event is the per-conversation
 stream's payload plus `conversation_id`. A `conversations` event
 (`{"reason":"changed"}`) is sent, debounced to one per second, when the list
@@ -352,10 +352,10 @@ GET /api/search?q=<text>[&limit=20][&offset=0][&agent_id=][&conversation_id=][&s
 ```
 
 Three sources, one shape: `title` (a conversation's title; `turn_id` null),
-`prompt` (a turn's prompt) and `reply` (a turn's assistant text — the `text`
+`prompt` (a turn's prompt) and `reply` (a turn's assistant text, the `text`
 blocks of its events, materialised when the turn ends, so a turn in flight is
 searchable by its prompt but not yet by its reply). Postgres full-text with
-`websearch` syntax — `"quoted phrase"`, `-excluded`, `or` — and exact-token
+`websearch` syntax (`"quoted phrase"`, `-excluded`, `or`) and exact-token
 matching (no stemming), so identifiers and code fragments match as
 themselves. Hits are ranked, newest first among equals; `snippet` is plain
 text with no markup; `ts` is the turn's (or the conversation's) creation
@@ -373,9 +373,9 @@ The roster [`/team`](concepts/teammates.md) shows, for
 clients that are not this web app. A teammate is a conversation bound to the
 reserved channel `fountain:team`; every route here wraps the same
 `Fountain.Team` the page uses, so a standalone client gets the page's exact
-semantics — add is idempotent, a message wakes a parked computer or opens a
+semantics, where add is idempotent, a message wakes a parked computer or opens a
 fresh conversation when the old one is past resuming, remove terminates and
-unbinds — without reimplementing them over `/api/conversations`.
+unbinds, without reimplementing them over `/api/conversations`.
 
 ```
 GET    /api/team                    # roster: agent, conversation, presence, unread, preview
@@ -392,8 +392,8 @@ GET    /api/team/comms              # {enabled, configured}: may this caller, an
 GET    /api/team/stream             # SSE: every teammate's events on one connection
 ```
 
-`PATCH /api/team/:agent_id` sets what the teammate is called — its
-conversation's `title` — and the name carries onto the fresh conversation
+`PATCH /api/team/:agent_id` sets what the teammate is called, which is its
+conversation's `title`. The name carries onto the fresh conversation
 opened when that one is past resuming; `team.renamed` is audited and the
 stream sends `team`. `GET /api/team/:agent_id/conversations` is the
 teammate's history: a retired conversation (a previous computer's thread)
@@ -402,8 +402,9 @@ listed behind the current one with `current: false`; read it with
 `GET /api/conversations/:id/events`.
 
 `POST /api/team/:agent_id/conversations` starts the teammate over without
-losing its computer: the current conversation is retired — `terminated`,
-listed behind the new one with `current: false` — and a new conversation is
+losing its computer. The current conversation is retired, meaning
+`terminated` and listed behind the new one with `current: false`, and a new
+conversation is
 opened under the binding, carrying the name, environment and vault and
 pointing at the **same sandbox**. Nothing is provisioned or interrupted: the
 next message wakes that sandbox through the ordinary reattach path and
@@ -427,7 +428,7 @@ the agent's `allowed_environment_ids` / `allowed_vault_ids` exactly as on
 Each roster entry carries `name` (title, else the agent's name), the full
 `agent` and `conversation` objects, `presence` (`state` in `working`,
 `starting`, `online`, `asleep`, `away`, `machine_offline`, `failed`, `offline`,
-plus a human `label`), `unread`, `last_turn`, and `preview` — `{kind:
+plus a human `label`), `unread`, `last_turn`, and `preview`, as `{kind:
 "you"|"them"|"typing", text}` or null with no messages. `machine_offline` is
 a teammate on a [self-hosted runner](integrations/runners.md) whose machine
 is not connected: a message cannot wake it (`503 runner_offline`), it comes
@@ -442,25 +443,25 @@ roster entry gains `contact: {email, phone}`. From its next turn the teammate
 has `email_send`, `email_reply`, `email_list`, `email_get`, `sms_send`,
 `sms_list` and `my_contact_info` MCP tools, served by Fountain itself at
 `POST /api/mcp/team-comms/:conversation_id` with the conversation's sprite
-token — no provider key enters the sandbox, and every send is audited
+token, so no provider key enters the sandbox, and every send is audited
 (`team.contact.sent`, never the content). `404 team_comms_not_enabled` when
 the flag is off for the caller, `503 team_comms_not_configured` when the
 instance has no keys, `409` for a second contact, `424 provider_error`
-(`channel` names which) when a provider refuses — provisioning is all or
+(`channel` names which) when a provider refuses, because provisioning is all or
 nothing. `DELETE` releases both upstream and forgets them; `GET
 /api/team/comms` answers `{enabled, configured}` so a client knows whether
 to offer it. See [configuration](configuration.md#teammate-email-and-phone).
 
 The request body carries `prompt_from_number` (required; any common format,
 stored E.164): **your** phone. A text from that number to the teammate's
-number arrives as a prompt in the teammate's conversation — delivered by
+number arrives as a prompt in the teammate's conversation, delivered by
 AgentPhone to `POST /api/webhooks/agentphone` (HMAC-verified with
 `AGENTPHONE_WEBHOOK_SECRET`), wrapped so the teammate knows it came by SMS
 and can answer with its `sms_send` tool. Texts from any other number are
 acknowledged and ignored; deliveries are deduplicated by AgentPhone's
 `X-Webhook-ID`. Audited as `team.contact.prompted` (bytes, never the text).
 `STOP` (or `UNSUBSCRIBE`, `CANCEL`, `END`, `QUIT`) from that number opts it
-out — `contact.prompt_opted_out_at` is set and its texts are dropped until
+out. `contact.prompt_opted_out_at` is set and its texts are dropped until
 `START`, or until the number is changed (new consent); `HELP` is answered.
 Each keyword gets a confirmation texted back from the teammate's number,
 best-effort.
@@ -474,12 +475,12 @@ turn is still running, `503 provisioning` while the computer is starting,
 **Teammates know each other.** Every conversation on the team channel carries
 an MCP server, `fountain-team`, served by Fountain at
 `POST /api/mcp/team/:conversation_id` and authenticated with the sandbox's
-own token: `list_teammates`, `get_teammate` (by name, role or keyword —
+own token: `list_teammates`, `get_teammate` (by name, role or keyword, and
 "the engineer"), `send_to_teammate` (lands in their thread prefixed with who
 sent it and a note that only the owner and their teammates can send such
 messages; busy/starting/machine-offline come back as tool errors to retry;
 returns the turn it created), `wait_for_teammate` (blocks up to 90 s for
-the reply — `since_turn` pins it to a specific turn; `timed_out: true` means
+the reply. `since_turn` pins it to a specific turn, and `timed_out: true` means
 call again) and `read_teammate` (recent prompts and replies). So "send this to the
 steward" inside one teammate's turn is two tool calls, and the exchange is
 visible in both threads on the team page.
@@ -487,9 +488,9 @@ visible in both threads on the team page.
 `/stream` is one `text/event-stream` for the whole team: each event is the
 per-conversation stream's payload plus `conversation_id` and `agent_id`, so a
 client routes it to a roster row without a socket per teammate. A `team`
-event (`{"reason":"changed"}`) is sent when the roster changes — a teammate
+event (`{"reason":"changed"}`) is sent when the roster changes, such as a teammate
 added or removed, a fresh conversation opened for one, or a self-hosted
-runner connecting or dropping (presence changes for the teammates on it) —
+runner connecting or dropping (presence changes for the teammates on it), so
 and the stream starts following the new conversation itself; the client
 re-lists. It honours
 `Last-Event-ID` (replayed across every teammate) and `?streams=`, heartbeats
@@ -497,8 +498,9 @@ every 15 s and closes after 60 s idle so the client reconnects.
 
 ### Schedules
 
-The routines the team page offers — a cron that runs a teammate with a
-prompt, either in its own thread or on a one-off computer — over the API.
+The routines the team page offers, over the API. A routine is a cron that
+runs a teammate with a prompt, either in its own thread or on a one-off
+computer.
 Every route wraps `Fountain.Team.Schedules`, so a standalone client gets the
 page's exact semantics.
 
@@ -531,8 +533,8 @@ either way. Creates, updates, deletes and runs are audited
 (`team.schedule.*`) with the request's attribution.
 
 The team stream sends a `schedule` event (`{"reason":"changed"}`) whenever a
-schedule is created, updated, deleted or fired — by the API, the page or the
-scheduler — so a client re-lists rather than polls.
+schedule is created, updated, deleted or fired, whether by the API, the page
+or the scheduler, so a client re-lists rather than polls.
 
 Browser clients on another origin need `API_CORS_ORIGINS` set on the server
 (see [configuration](configuration.md)); a bearer key is the only credential
@@ -541,8 +543,9 @@ that crosses origins.
 ## Support
 
 "Report a problem" from a client (#843): the report is stored with whatever
-context the client attaches — conversation, agent, sandbox, presence, recent
-events, app version, page URL; the facts triage needs, never secrets — and
+context the client attaches. That is conversation, agent, sandbox, presence,
+recent events, app version and page URL, the facts triage needs and never
+secrets, and
 forwarded to the operator out of band.
 
 ```
@@ -558,12 +561,12 @@ images use (png/jpeg/gif/webp, 5 MB). The response carries `status` (`new`
 → `forwarded` or `failed`), `forwarded_at`, `external_url` (the GitHub issue
 when one was created) and `forward_error`; the screenshot is reported by
 presence, never inlined. Audited as `support.report.created` with category,
-sizes and context keys — not the message.
+sizes and context keys, never the message.
 
 Forwarding is an Oban job: a GitHub issue when the instance sets
 `SUPPORT_GITHUB_REPO` + `SUPPORT_GITHUB_TOKEN` (issues:write; labelled
 `support` and the category), and/or mail to `SUPPORT_EMAIL` with the
-screenshot attached. Neither configured is fine — the rows are the inbox.
+screenshot attached. Neither configured is fine, because the rows are the inbox.
 Rate-limited with the rest of `/api`.
 
 ## Admin
@@ -586,7 +589,7 @@ GET    /api/admin/audit                     # cross-tenant audit events
 GET    /api/admin/events                    # the privilege trail: who did what to whom
 ```
 
-Refusals: you cannot suspend, delete, or change the role of your own account (use another admin, or `DELETE /api/account` for self-deletion). Billing actions — extend-trial, comp, resync-stripe — are `404` with `"billing": "disabled"` on an instance without billing. Cross-tenant reads are metadata only; prompt and output content never cross a tenant boundary, whatever the role.
+Refusals: you cannot suspend, delete, or change the role of your own account (use another admin, or `DELETE /api/account` for self-deletion). Billing actions (extend-trial, comp, resync-stripe) are `404` with `"billing": "disabled"` on an instance without billing. Cross-tenant reads are metadata only; prompt and output content never cross a tenant boundary, whatever the role.
 
 ## Audit
 
@@ -600,7 +603,7 @@ Page backwards with `meta.next_cursor` as `before`; `limit` defaults to 100 and 
 
 Only this tenant's events are visible.
 
-The `/audit` page in the browser takes the same `action_prefix`, `resource_type`, `since` and `until` filters (as `?action=`, `?resource=`, `?since=`, `?until=`) and runs them through the same query, so a filtered view is a shareable link. It shows the newest 200 matches and does not page — use this endpoint to walk the whole trail.
+The `/audit` page in the browser takes the same `action_prefix`, `resource_type`, `since` and `until` filters (as `?action=`, `?resource=`, `?since=`, `?until=`) and runs them through the same query, so a filtered view is a shareable link. It shows the newest 200 matches and does not page, so use this endpoint to walk the whole trail.
 
 ## Error responses
 
@@ -615,7 +618,7 @@ The `/audit` page in the browser takes the same `action_prefix`, `resource_type`
 | `402` | Active subscription required (`subscription_required`, includes `upgrade_url`) |
 | `403` | Wrong tenant |
 | `404` | Not found |
-| `410` | Conversation terminated (`conversation_terminated`) — stop retrying |
+| `410` | Conversation terminated (`conversation_terminated`). Stop retrying |
 | `422` | Validation error |
 | `429` | Rate limited |
 | `500` | Internal error |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,14 +1,14 @@
 # Configuration reference
 
 Every environment variable the server reads at runtime, grouped by concern.
-Variables are read at boot — changing one means restarting the app.
+Variables are read at boot, so changing one means restarting the app.
 
 This list is complete by construction: a test fails the build when
 `config/runtime.exs` reads a variable that is not documented on this page, so
 the reference cannot silently drift from the code.
 
 A few variables **refuse to boot on an invalid value** rather than falling
-back to a default — noted per row. That is deliberate: a typo that silently
+back to a default, noted per row. That is deliberate, because a typo that silently
 disabled a bound or a key would otherwise surface as a bill or a breach, not
 an error message.
 
@@ -21,7 +21,7 @@ an error message.
 | `DATABASE_URL` | — | prod | Postgres connection string. Boot fails without it |
 | `SECRET_KEY_BASE` | — | prod (serving) | Signs and encrypts session cookies and tokens. Generate: `openssl rand -base64 48` |
 | `MASTER_SECRETS_KEY` | — | prod | Wraps every tenant's data-encryption key ([the secrets model](architecture.md#the-secrets-model)). 32 bytes, url-safe base64, no padding: `openssl rand 32 \| base64 \| tr '+/' '-_' \| tr -d '='`. **Lose it and every stored secret is unrecoverable.** Boot refuses a malformed value |
-| `PUBLIC_URL` | — | prod | The externally visible base URL, scheme included. A prod instance refuses to boot without it (or the deprecated `FOUNTAIN_DOMAIN`) — the old `http://localhost:4000` fallback silently put localhost links in every verification email. Builds every link that leaves the app (verification and reset emails, `llms.txt`) and is passed to every sandbox as `FOUNTAIN_BASE_URL`. An `https://` value also switches on HTTPS redirection, HSTS, and the secure cookie flag — all derived from the scheme |
+| `PUBLIC_URL` | — | prod | The externally visible base URL, scheme included. A prod instance refuses to boot without it (or the deprecated `FOUNTAIN_DOMAIN`), because the old `http://localhost:4000` fallback silently put localhost links in every verification email. Builds every link that leaves the app (verification and reset emails, `llms.txt`) and is passed to every sandbox as `FOUNTAIN_BASE_URL`. An `https://` value also switches on HTTPS redirection, HSTS, and the secure cookie flag, all derived from the scheme |
 | `PHX_HOST` | host of `PUBLIC_URL` | — | Bare host for the endpoint URL and the LiveView origin check. Set only if it differs from `PUBLIC_URL`'s host |
 | `FOUNTAIN_DOMAIN` | — | deprecated | The old combined variable; still honoured as a fallback for both of the above. Prefer `PUBLIC_URL` / `PHX_HOST` |
 | `PHX_SERVER` | `true` in the shipped image | — | `1`/`true`/`yes` starts the web listener. Release tasks run with `PHX_SERVER=false … eval '…'` to boot the app without binding the port |
@@ -35,25 +35,25 @@ an error message.
 | `DATABASE_SSL_VERIFY` | off | — | Unset, the connection is encrypted but the server certificate is **not** verified. `true` verifies it, against the OS trust store unless a CA file is given |
 | `DATABASE_SSL_CA_FILE` | OS trust store | — | CA bundle used when `DATABASE_SSL_VERIFY=true` |
 | `POOL_SIZE` | `10` | — | Database connection pool size |
-| `MIGRATE_ON_BOOT` | `true` | — | Whether a booting release runs pending migrations before it serves. `false` (also `0`, `no`) makes the pod only serve, for the deployment that runs migrations once in a Job — see [migrations in a Job](guides/operate/database.md#running-migrations-in-a-job). `bin/migrate` always migrates, whatever this is set to. **Nothing checks that the Job ran**: a pod that skips migrations against an un-migrated database boots and then fails on the first query |
+| `MIGRATE_ON_BOOT` | `true` | — | Whether a booting release runs pending migrations before it serves. `false` (also `0`, `no`) makes the pod only serve, for the deployment that runs migrations once in a Job. See [migrations in a Job](guides/operate/database.md#running-migrations-in-a-job). `bin/migrate` always migrates, whatever this is set to. **Nothing checks that the Job ran**: a pod that skips migrations against an un-migrated database boots and then fails on the first query |
 
 ## Sandboxes
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|
-| `SPRITES_TOKEN` | — | for conversations | Platform token for [sprites.dev](https://sprites.dev). The app boots without it, but every conversation fails. Never expose it to tenants — it pays for every sandbox |
+| `SPRITES_TOKEN` | — | for conversations | Platform token for [sprites.dev](https://sprites.dev). The app boots without it, but every conversation fails. Never expose it to tenants, because it pays for every sandbox |
 | `SPRITES_BASE_URL` | `https://api.sprites.dev` | — | Repoints the sandbox API. Anything else must implement the same contract; there is no bundled alternative |
 | `SPRITES_TIMEOUT_MS` | `30000` | — | Bounds every HTTP call to the Sprites API. Long-running commands (package installs, clones) set their own per-call timeouts. Boot refuses a non-positive value |
 | `SANDBOX_PROVIDER` | `sprites` | — | Which backend newly-created sandboxes run on: `sprites`, `e2b`, `daytona`, or `runner`. A hosted provider is enabled by the presence of its credential; boot refuses an explicit default whose credential is missing. Existing sandboxes stay on the provider they were created on |
 | `SANDBOX_RUNNERS_ENABLED` | `true` | — | [Self-hosted runners](integrations/runners.md) need no credential; `false` hides the `runner` provider and refuses `fountain runner` connections |
 | `E2B_API_KEY` | — | for the `e2b` provider | [E2B](https://e2b.dev) API key. Its presence enables the provider |
 | `E2B_BASE_URL` | `https://api.e2b.app` | — | Repoints the E2B control plane |
-| `E2B_TEMPLATE` | `base` | — | Template new E2B sandboxes are created from. The stock `base` template lacks the agent CLIs — build one from `images/e2b/` for real use |
+| `E2B_TEMPLATE` | `base` | — | Template new E2B sandboxes are created from. The stock `base` template lacks the agent CLIs, so build one from `images/e2b/` for real use |
 | `E2B_USER` | `sprite` | — | In-guest user envd runs commands as. `images/e2b/` templates create `sprite`; set to `user` when pointing at the stock `base` template |
 | `DAYTONA_API_KEY` | — | for the `daytona` provider | [Daytona](https://daytona.io) API key. Its presence enables the provider |
 | `DAYTONA_API_URL` | `https://app.daytona.io/api` | — | Repoints the Daytona API (self-hosted Daytona) |
-| `DAYTONA_SNAPSHOT` | org default | — | Snapshot (image) new Daytona sandboxes are created from; must be registered with the organization. The default image lacks the agent CLIs — build one from `images/daytona/` for real use |
-| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long and the sandbox is reclaimed — the conversation stays [resumable](guides/operate/sandbox-lifetime.md). `0` disables the bound; boot refuses anything that is not a non-negative integer |
+| `DAYTONA_SNAPSHOT` | org default | — | Snapshot (image) new Daytona sandboxes are created from; must be registered with the organization. The default image lacks the agent CLIs, so build one from `images/daytona/` for real use |
+| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long and the sandbox is reclaimed, and the conversation stays [resumable](guides/operate/sandbox-lifetime.md). `0` disables the bound; boot refuses anything that is not a non-negative integer |
 | `SANDBOX_MAX_LIFETIME_HOURS` | `24` | — | Absolute sandbox age ceiling, regardless of activity. Same `0`-disables and boot-refusal rules |
 | `LOG_OUTPUT_BUDGET_MB` | `50` | — | Durable log volume per conversation. Once a conversation has persisted this much sandbox output, one truncation marker is written and further output is discarded (retention bounds age; this bounds rate). Same `0`-disables and boot-refusal rules |
 
@@ -63,14 +63,14 @@ an error message.
 |---|---|---|---|
 | `REGISTRATION_ENABLED` | `true` | — | `false` closes signup entirely. An open instance on the public internet will be found |
 | `REGISTRATION_ALLOWED_EMAIL_DOMAINS` | any | — | Comma-separated list; signups outside these domains are refused. Empty means no restriction |
-| `UNVERIFIED_PRUNE_AFTER_DAYS` | `30` | — | Accounts that never verified their email are deleted after this many days — they can sign in but reach nothing, so they are rows, not users. `0` disables the sweep |
+| `UNVERIFIED_PRUNE_AFTER_DAYS` | `30` | — | Accounts that never verified their email are deleted after this many days. They can sign in but reach nothing, so they are rows rather than users. `0` disables the sweep |
 | `UNVERIFIED_PRUNE_EXEMPT` | — | — | Comma-separated email substrings never pruned (operator or test accounts that deliberately stay unverified) |
-| `FIRST_USER_ADMIN` | `false` | — | `true`: while the instance has no admin, the first account to become verified is promoted to admin, audit-recorded (ADR 0011). Leave off on a multi-tenant deployment — it hands admin to whoever verifies first |
+| `FIRST_USER_ADMIN` | `false` | — | `true`: while the instance has no admin, the first account to become verified is promoted to admin, audit-recorded (ADR 0011). Leave off on a multi-tenant deployment, because it hands admin to whoever verifies first |
 
 ## Email
 
 Production **refuses to boot** unless exactly one of the three delivery
-options is configured — a silently discarded verification email dead-ends
+options is configured, because a silently discarded verification email dead-ends
 signup with no visible error. See [Email](guides/operate/email.md).
 
 | Variable | Default | Required | Effect |
@@ -82,7 +82,7 @@ signup with no visible error. See [Email](guides/operate/email.md).
 | `SMTP_PASSWORD` | — | — | |
 | `SMTP_TLS` | `always` | — | STARTTLS by default; `never` for a relay on a trusted network that does not offer it |
 | `EMAIL_DELIVERY` | — | one of three | `none` deliberately disables email. Accounts then self-verify at registration (ADR 0011), but password-reset email cannot be delivered, so a forgotten password is unrecoverable in this mode |
-| `EMAIL_FROM` | — | when mail is on | The From address. Required whenever a real delivery provider is configured — a prod instance refuses to boot without it, since mail from an unverified domain is rejected anyway. Unused under `EMAIL_DELIVERY=none` |
+| `EMAIL_FROM` | — | when mail is on | The From address. Required whenever a real delivery provider is configured, and a prod instance refuses to boot without it, since mail from an unverified domain is rejected anyway. Unused under `EMAIL_DELIVERY=none` |
 | `SUPPORT_EMAIL` | — | — | Where "contact support" in account emails (suspension, deletion) points, and where `POST /api/support/reports` reports are mailed. Unset, the copy names no address and reports are not mailed |
 | `SUPPORT_GITHUB_REPO` | — | — | `owner/repo`: each support report also becomes a GitHub issue there (labels `support` + category). Needs `SUPPORT_GITHUB_TOKEN` |
 | `SUPPORT_GITHUB_TOKEN` | — | — | A token with `issues:write` on `SUPPORT_GITHUB_REPO` |
@@ -98,7 +98,7 @@ signup with no visible error. See [Email](guides/operate/email.md).
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|
-| `BILLING_ENABLED` | `false` | — | The subscription gate. Off by default — on a self-hosted instance it is a lock with no key. Set `true` only if you run Fountain commercially with Stripe configured |
+| `BILLING_ENABLED` | `false` | — | The subscription gate. Off by default, because on a self-hosted instance it is a lock with no key. Set `true` only if you run Fountain commercially with Stripe configured |
 | `STRIPE_SECRET_KEY` | — | for billing | Stripe API key |
 | `STRIPE_WEBHOOK_SECRET` | — | for billing | Verifies `POST /api/stripe/webhook` signatures |
 | `STRIPE_PRICE_ID` | — | for checkout | The subscription price surfaced by Checkout. Unset with billing enabled, signups get a purely local 14-day trial and a logged warning |
@@ -106,7 +106,7 @@ signup with no visible error. See [Email](guides/operate/email.md).
 
 ## Legal pages
 
-The identity rendered on `/terms` and `/privacy` — the operator's, not the Fountain project's. Set all four or none: a partial set refuses to boot. With none set, the pages return 404 and their links disappear from signup and the footer — unless billing is enabled, in which case the pages stay up with loud `{{...}}` placeholders until you configure them (an instance charging money should publish terms).
+The identity rendered on `/terms` and `/privacy`, meaning the operator's rather than the Fountain project's. Set all four or none, because a partial set refuses to boot. With none set, the pages return 404 and their links disappear from signup and the footer, unless billing is enabled, in which case the pages stay up with loud `{{...}}` placeholders until you configure them (an instance charging money should publish terms).
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|
@@ -121,20 +121,20 @@ The identity rendered on `/terms` and `/privacy` — the operator's, not the Fou
 |---|---|---|---|
 | `TRUSTED_PROXIES` | — | behind a proxy | Comma-separated CIDRs stepped over when resolving the client IP from `X-Forwarded-For`. Without it, per-IP rate limits collapse into one bucket keyed on the proxy; over-broad, it lets a client spoof past rate limiting |
 | `CHECK_ORIGIN_EXTRA` | — | — | Comma-separated extra origins allowed to open a LiveView websocket. Your own host is always included |
-| `OAUTH_CLIENTS` | — | — | JSON array of `{id, name, redirect_uris}` — the browser apps allowed to "Sign in with Fountain" (OAuth code + PKCE, public clients; `decisions/0021`). Redirect URIs match exactly. Unset means none |
-| `API_CORS_ORIGINS` | — | — | Comma-separated browser origins (or `*`) allowed to call `/api` with a bearer key from another site — what a standalone client such as the team app needs. Off when unset; cookies never cross origins regardless |
+| `OAUTH_CLIENTS` | — | — | JSON array of `{id, name, redirect_uris}`, naming the browser apps allowed to "Sign in with Fountain" (OAuth code + PKCE, public clients; `decisions/0021`). Redirect URIs match exactly. Unset means none |
+| `API_CORS_ORIGINS` | — | — | Comma-separated browser origins (or `*`) allowed to call `/api` with a bearer key from another site, which is what a standalone client such as the team app needs. Off when unset; cookies never cross origins regardless |
 | `CONVERSATIONS_APP_URL` | `https://jakegaylor.com/fountain-conversations/` | — | Where the console sends people to watch a conversation. The default is a static build that takes *your* Fountain's URL as input, so it works for a self-hosted server as soon as `API_CORS_ORIGINS` admits `https://jakegaylor.com`. Point it at your own copy instead, or set it to `""` to say this deployment has no such app |
 | `TEAM_APP_URL` | `https://jakegaylor.com/fountain-team/` | — | The same, for the team roster |
 
 ## Clustering
 
-Only needed for more than one replica — see
+Only needed for more than one replica. See
 [Clustering](architecture.md#clustering) for what breaks without it.
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|
 | `CLUSTER_DNS_QUERY` | — | multi-replica | DNS name polled for peer discovery (a headless service in Kubernetes). Empty or unset, clustering is off |
-| `RELEASE_NAME` | set by the release | — | Node basename used in peer discovery; must match what each node registered as. The release tooling sets it — override only if you know why |
+| `RELEASE_NAME` | set by the release | — | Node basename used in peer discovery; must match what each node registered as. The release tooling sets it, so override only if you know why |
 | `DNS_CLUSTER_QUERY` | — | — | A second, separate discovery mechanism (Phoenix's `DNSCluster`). Leave unset when using `CLUSTER_DNS_QUERY` |
 
 ## Observability
@@ -154,7 +154,7 @@ Only needed for more than one replica — see
 Trace export is configured only in production while serving, and is **off by
 default**: spans are exported only when `OTEL_EXPORTER_OTLP_ENDPOINT`,
 `HONEYCOMB_ENDPOINT` or `HONEYCOMB_API_KEY` is explicitly set. The OTel SDK
-also honours its own standard variables, which take precedence — set
+also honours its own standard variables, which take precedence. Set
 `OTEL_TRACES_EXPORTER=otlp` or `=none` to force export on or off regardless
 of the above.
 
@@ -164,7 +164,7 @@ Fountain can host a [Buzz](https://github.com/block/buzz) agent's `buzz-acp`
 harness (ADR 0020), so a Buzz agent keeps a body on its relay without a running
 desktop. The harness binary is baked into the image for both amd64 and arm64;
 these tune where it runs and how its ACP child reaches back. Operators rarely
-set them — the defaults are correct for the packaged image.
+set them, because the defaults are correct for the packaged image.
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|
@@ -179,7 +179,7 @@ architectures from source and bakes it in (see `.github/workflows/buzz-acp-publi
 Per-user flags (`Fountain.FeatureFlags`) are evaluated by PostHog when a
 project key is set. Answers are cached per user for a minute; when PostHog is
 unreachable the last answer it gave is reused, and with none every flag reads
-off — an outage never turns a feature on. Without PostHog, a flag can be forced
+off, so an outage never turns a feature on. Without PostHog, a flag can be forced
 on for every user.
 
 | Variable | Default | Required | Effect |
@@ -193,7 +193,7 @@ on for every user.
 Behind the `team_comms` flag, a teammate can be given an email address
 ([AgentMail](https://agentmail.to)) and a phone number
 ([AgentPhone](https://agentphone.ai)), and gets MCP tools to send and read on
-both. Fountain holds the provider keys and serves the tools itself — the keys
+both. Fountain holds the provider keys and serves the tools itself, so the keys
 never enter a sandbox. With either key unset the feature reports itself
 unavailable even where the flag is on.
 

--- a/docs/integrations/platform-requirements.md
+++ b/docs/integrations/platform-requirements.md
@@ -19,7 +19,7 @@ correcting it is cheaper for us than working around it.
 
 An agent turn runs for minutes or hours. It streams output a human is
 watching in real time, it takes input mid-flight, and the filesystem it
-leaves behind **is the agent's memory** — the next turn resumes on that disk.
+leaves behind **is the agent's memory**, because the next turn resumes on that disk.
 Our control plane redeploys underneath running turns and has to rejoin them,
 and our reaper destroys sandboxes based on what a provider's API says exists.
 
@@ -52,7 +52,7 @@ code works. We would rather delete it.
 ### exit-truth
 
 **We need** exactly one terminal event per command, carrying the process's
-actual exit code — on the streaming path as well as the blocking one — and
+actual exit code, on the streaming path as well as the blocking one, and
 distinguishable from a transport failure that ended the stream early.
 
 **Because** a setup script that fails silently produces a sandbox that looks
@@ -79,8 +79,8 @@ Our own contract specifies replay-from-byte-zero purely because no platform
 offers a cursor; callers then de-duplicate by counting bytes already
 persisted per stream.
 
-**Acceptance:** attach to a running session twice — once from byte zero, once
-from a cursor — and the concatenated output is byte-identical to an
+**Acceptance:** attach to a running session twice, once from byte zero and
+once from a cursor, and the concatenated output is byte-identical to an
 uninterrupted read.
 
 ### detached-sessions
@@ -104,7 +104,7 @@ credential or a slow region never produces one of them.
 **Because** a parked sandbox's disk is the agent's memory. Our reaper
 reconciles the provider's listing against our database and destroys what the
 provider says is untracked. If a blip reads as absence, we delete a
-customer's work. This is not hypothetical — a control-plane partition on our
+customer's work. This is not hypothetical. A control-plane partition on our
 side once made nine live sandboxes look absent, and the next sweep destroyed
 them.
 
@@ -133,7 +133,7 @@ sandbox when the name is taken instead of minting a second one.
 
 **Because** idempotence under retry is the whole game for a control plane.
 With server-assigned identity, a timed-out create leaves an orphan we are
-paying for and cannot address — so we end up maintaining a second naming
+paying for and cannot address, so we end up maintaining a second naming
 system in provider metadata and reconciling the duplicates our own retries
 produced.
 
@@ -143,7 +143,7 @@ two identical handles.
 ### park-not-expire
 
 **We need** a pause or stop that keeps the filesystem at storage-only cost,
-with no TTL that destroys — and where a TTL is unavoidable, expiry must park
+with no TTL that destroys. Where a TTL is unavoidable, expiry must park
 rather than kill.
 
 **Because** our cost model is "park everything idle", and the disk being
@@ -184,7 +184,7 @@ fails to connect, including DNS and raw IP.
 ### url-or-nothing
 
 **We need** one HTTP endpoint per sandbox that a browser can open without a
-platform credential, reported by the API — or a clear statement that the
+platform credential, reported by the API, or a clear statement that the
 platform has no such concept.
 
 **Because** agents build things and then need to show a human. "Where is it
@@ -203,26 +203,26 @@ several entries are probably already stale.
 
 | Requirement | [Sprites](sprites.md) | [E2B](e2b.md) | [Daytona](daytona.md) | [Runner](runners.md) |
 |---|---|---|---|---|
-| exit-truth | No — exec reports 0 regardless | Yes | No — no exit code on session-command records | Yes |
-| replay-cursor | Partial — replays the last 16 KiB, starting mid-line | No — journaling shim + tail replayer | Yes — journal replays from byte zero | Yes |
-| detached-sessions | Yes | No — emulated by the adapter | Yes | Yes |
-| absence-definitive | Undocumented | Undocumented | Undocumented | Yes — every offline shape is transient by construction |
-| stdin-total | Yes | Yes | No — the FIFO EOFs after every write, and has no close | Yes |
-| named-create | Yes | No — names emulated via metadata | Yes | Yes |
-| park-not-expire | Yes — scales to zero | Partial — pause preserves the disk, but a TTL runs underneath | Yes — stop, then archive to object storage | Yes |
-| honest-listing | Yes — continuation tokens | Not measured | Not measured | Yes |
-| egress-deny | Partial — translated fail-open | Yes | Yes, but tier-gated | No — by design; the machine is the user's |
-| url-or-nothing | Yes | No — per-port hostnames only | No | No |
+| exit-truth | No, exec reports 0 regardless | Yes | No, no exit code on session-command records | Yes |
+| replay-cursor | Partial, replays the last 16 KiB starting mid-line | No, journaling shim plus tail replayer | Yes, journal replays from byte zero | Yes |
+| detached-sessions | Yes | No, emulated by the adapter | Yes | Yes |
+| absence-definitive | Undocumented | Undocumented | Undocumented | Yes, every offline shape is transient by construction |
+| stdin-total | Yes | Yes | No, the FIFO EOFs after every write and has no close | Yes |
+| named-create | Yes | No, names emulated via metadata | Yes | Yes |
+| park-not-expire | Yes, scales to zero | Partial, pause preserves the disk but a TTL runs underneath | Yes, stop then archive to object storage | Yes |
+| honest-listing | Yes, continuation tokens | Not measured | Not measured | Yes |
+| egress-deny | Partial, translated fail-open | Yes | Yes, but tier-gated | No, by design, since the machine is the user's |
+| url-or-nothing | Yes | No, per-port hostnames only | No | No |
 
 The fourth backend is our own daemon ([self-hosted
-runner](runners.md)) — worth reading as an existence proof rather than a
+runner](runners.md)), worth reading as an existence proof rather than a
 comparison. It meets nearly all of this because we wrote both ends, which is
 the only reason we know the list is implementable rather than merely
 desirable.
 
 ## The rule underneath all ten
 
-!!! note "Advertise or refuse — never pretend"
+!!! note "Advertise or refuse, never pretend"
 
     An orchestrator can degrade gracefully around a missing capability. It
     cannot degrade around a capability that is claimed and then quietly does
@@ -234,7 +234,7 @@ to an operator. A guessed preview URL is a support ticket for someone else's
 product.
 
 The whole abstraction rests on this: each adapter declares a capability set,
-and the lifecycle changes shape accordingly — a backend that cannot park gets
+and the lifecycle changes shape accordingly, so a backend that cannot park gets
 destroy-on-idle rather than a fake park. That only works if "I don't support
 this" is an answer the platform's API is willing to give.
 
@@ -243,7 +243,7 @@ this" is an answer the platform's API is willing to give.
 Naming the non-asks is half of making this a conversation rather than a wish
 list.
 
-- **A common wire format.** REST, gRPC, WebSocket, a vendor SDK — we write
+- **A common wire format.** REST, gRPC, WebSocket, a vendor SDK, because we write
   the adapter. This page is about semantics, not shapes.
 - **Images or provisioning.** We ship our own image per platform,
   deliberately, so that no provisioning logic is provider-specific.
@@ -265,8 +265,9 @@ cares about. A genuinely neutral contract needs another kind of customer in
 the room.
 
 The capability vocabulary is also doing more work than it should.
-`:suspend` currently means three different promises across our backends —
-scale-to-zero, an explicit pause, and stopping processes in a directory — and
+`:suspend` currently means three different promises across our backends,
+namely scale-to-zero, an explicit pause, and stopping processes in a
+directory, and
 they are not equivalent. If any of this became a shared specification, that
 word would need splitting first.
 
@@ -276,5 +277,5 @@ word would need splitting first.
 checklist: an in-memory reference adapter passes it in full, and it pins
 every semantic above, including the byte-exact replay test. The practical
 route for a platform team is [adding a
-provider](adding-a-sandbox-provider.md) — its verification ladder exists
+provider](adding-a-sandbox-provider.md), whose verification ladder exists
 because each rung caught something the previous one passed.

--- a/scripts/docs-style-allow.txt
+++ b/scripts/docs-style-allow.txt
@@ -10,7 +10,6 @@
 # rename cannot quietly re-exempt a page.
 docs/build/index.md
 docs/build/team-chat.md
-docs/configuration.md
 docs/integrations/acp.md
 docs/integrations/adding-a-sandbox-provider.md
 docs/integrations/buzz.md
@@ -32,7 +31,3 @@ docs/integrations/sprites.md
 docs/integrations/stripe.md
 docs/llm-integration.md
 docs/sdk.md
-docs/superpowers/plans/2026-05-10-phase-3-foundation.md
-docs/superpowers/plans/2026-05-11-ci-checks.md
-docs/superpowers/plans/2026-05-13-conversation-titles.md
-docs/superpowers/specs/2026-05-11-ci-checks-design.md

--- a/scripts/docs-style-allow.txt
+++ b/scripts/docs-style-allow.txt
@@ -8,7 +8,6 @@
 #
 # The checker fails if a line here names a file that no longer exists, so a
 # rename cannot quietly re-exempt a page.
-docs/api.md
 docs/build/index.md
 docs/build/team-chat.md
 docs/configuration.md

--- a/scripts/docs-style.py
+++ b/scripts/docs-style.py
@@ -16,6 +16,17 @@ Three rules, all from docs-redesign/06-voice-and-style.md:
 Code fences and inline code spans are exempt, because they quote the world
 rather than describe it.
 
+TWO EXEMPTIONS THE FIRST DRAFT OF THIS SCRIPT GOT WRONG.
+
+A table cell whose whole content is a dash is a placeholder meaning "none",
+not a hinge in a sentence. `configuration.md` has 84 of them in its
+default column. Forcing those to "n/a" would make the table worse, and the
+rule exists to stop a dash carrying a clause, which a lone cell cannot do.
+
+`docs/superpowers/` is internal planning material, not in the nav and not
+served at /docs or on the site. Style rules for published pages should not
+apply to a historical artifact nobody reads.
+
 THE RATCHET. Files listed in scripts/docs-style-allow.txt are skipped. That
 list is the pre-existing backlog (#911) and is only ever meant to shrink. A
 file NOT on the list is checked, so anything new is covered by default and
@@ -32,6 +43,13 @@ ALLOW = ROOT / "scripts" / "docs-style-allow.txt"
 
 FORBIDDEN = ["simply", "coming soon", "obviously"]
 LIST_ITEM = re.compile(r"^\s*(?:[-*+]\s|\d+\.\s)")
+
+# Not in the nav, not served, not published. Historical planning material.
+EXCLUDED_DIRS = ("docs/superpowers/",)
+
+# A table cell holding nothing but a dash: `| — |`, `|—|`, and the row-start
+# and row-end variants. This is a placeholder for "none", not prose.
+PLACEHOLDER_CELL = re.compile(r"\|\s*[—–]\s*(?=\|)")
 
 
 def load_allowlist():
@@ -67,8 +85,11 @@ def check(path, rel):
     problems = []
 
     for i, line in enumerate(text, 1):
+        # Drop placeholder cells before looking for prose dashes, so
+        # `| VAR | — | prod | ... — ... |` still reports the prose one.
+        prose = PLACEHOLDER_CELL.sub("|", line) if line.lstrip().startswith("|") else line
         for ch, name in (("—", "em dash"), ("–", "en dash")):
-            if ch in line:
+            if ch in prose:
                 problems.append((i, f"{name}: {raw[i - 1].strip()[:90]}"))
 
         low = line.lower()
@@ -96,7 +117,7 @@ def main():
 
     for path in sorted(DOCS.rglob("*.md")):
         rel = str(path.relative_to(ROOT))
-        if rel in allow:
+        if rel in allow or rel.startswith(EXCLUDED_DIRS):
             continue
         checked += 1
         failures.extend(check(path, rel))


### PR DESCRIPTION
Part of #911 and #903. Three commits, each separable.

## 1. `api.md`, 57 sites

The largest count of any page. Mostly a reference, so most dashes were
definitional asides in table cells and endpoint notes.

> `| `502` | `network` — the provider was unreachable |`
> `| `502` | `network`. The provider was unreachable |`

Two places changed shape rather than punctuation, because the sentence was
carrying too much. The image endpoint's `Anything that does not resolve — A,
B, C, D — is a 404` now leads with the rule and lists the cases after it.

## 2. The checker was wrong, so the checker changed

`configuration.md` reported **93 violations. 84 were `| — |` table cells**
meaning "no default".

That is a placeholder, not the prose hinge the rule exists to catch. Rewriting
84 cells to "n/a" would have made the reference tables worse while fixing
nothing, and leaving the file parked forever would have hidden the flaw.

Two narrow exemptions:

- **A table cell whose entire content is a dash.** The regex requires the cell
  to hold nothing else, so `| VAR | — | prod | ...text — text |` still reports
  the prose dash at the end. Verified with a planted line carrying both.
- **`docs/superpowers/`**, internal planning material that is not in the nav,
  not served at `/docs`, and not on the site. Excluded by scope rather than by
  the ratchet, since it will never be "cleaned".

93 reported became 23 real, all fixed here.

## 3. `platform-requirements.md`, from #922

#922 landed between #917 (the checker) and #923, adding a page **written
before the rule existed**. Its own PR predated the checker, so nothing flagged
it, and the first run to see the combined tree is main's.

23 sites, mostly the capability matrix where a cell reads `No — exec reports 0
regardless`. A comma carries that better in a table cell anyway.

**No claim is changed.** This is punctuation only, on someone else's page, so
it is worth saying explicitly that the argument, the acceptance criteria and
the matrix verdicts are untouched.

### A gap in the ratchet, stated plainly

A page can be authored against a rule that does not exist yet and merge before
any run sees both. The ratchet catches it on the *next* PR rather than the one
that introduced it.

The cost is one follow-up commit. The alternative is blocking every open PR on
a rebase whenever a rule lands, which is worse.

## Backlog

| | Files | Real violations |
|---|---|---|
| Start (#917) | 32 | 560 |
| After this | 23 | ~330 |

Four of the nine files removed came off through the scope fix rather than
editing. The rest are `integrations/*`, averaging ~15 sites each.

## Verification

- `scripts/docs-style.py`: clean, 52 files checked
- Negative control planted in both directions (placeholder ignored, prose dash
  on the same line caught)
- `mkdocs build --strict`: clean
- `docs_test.exs`: 25 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
