### PR TITLE
docs: clean sdk.md and the five small provider and service pages

### DIFF
--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -29,13 +29,13 @@ daytona snapshot create fountain --dockerfile Dockerfile
 
 | Fountain operation | Daytona mechanics |
 |---|---|
-| Name-keyed create/adopt | Native — sandboxes are name-addressable in API paths; a conflicting create adopts when a follow-up get succeeds |
+| Name-keyed create/adopt | Native. Sandboxes are name-addressable in API paths, and a conflicting create adopts when a follow-up get succeeds |
 | Suspend / resume | `stop` preserves the whole disk; `start` resumes it. Long-parked sandboxes auto-archive to object storage (still startable, slower) so they stop consuming disk quota |
-| TTL | None — sandboxes are created with `ttlMinutes: 0` and `autoStopInterval: 0`; Fountain's own lifecycle owns suspension. No heartbeat needed |
+| TTL | None. Sandboxes are created with `ttlMinutes: 0` and `autoStopInterval: 0`, and Fountain's own lifecycle owns suspension. No heartbeat needed |
 | Exec | One-shot toolbox `process/execute` with cwd/env/timeout |
-| Streaming / reattach | Daemon-side sessions journal output server-side, and the log websocket **replays from byte zero before following** — reattach is the same stream opened again. The daemon publishes no exit code and its follow stream is unreliable at both ends, so the adapter's shim writes an exit sentinel and the stream reconnects with a byte-exact skip |
-| Stdin | The daemon FIFO EOFs after every write, so stdin-consuming commands read from a `tail -f`-fed file; writes append via one-shot execs and `close_stdin` kills the tail — a real EOF |
-| Network policy | `networkBlockAll` + `domainAllowList` per sandbox, updatable on a running sandbox — genuinely default-deny, so `allow: []` needs no translation |
+| Streaming / reattach | Daemon-side sessions journal output server-side, and the log websocket **replays from byte zero before following**, so reattach is the same stream opened again. The daemon publishes no exit code and its follow stream is unreliable at both ends, so the adapter's shim writes an exit sentinel and the stream reconnects with a byte-exact skip |
+| Stdin | The daemon FIFO EOFs after every write, so stdin-consuming commands read from a `tail -f`-fed file; writes append via one-shot execs, and `close_stdin` kills the tail for a real EOF |
+| Network policy | `networkBlockAll` + `domainAllowList` per sandbox, updatable on a running sandbox. Genuinely default-deny, so `allow: []` needs no translation |
 | Checkpoints | Not supported (`:checkpoint` is not advertised) |
 
 ## Operational notes
@@ -44,7 +44,7 @@ daytona snapshot create fountain --dockerfile Dockerfile
   entries; a `limited` environment with a longer allowlist will be rejected
   by the API.
 - **Org tiers**: lower tiers restrict egress by default and may not honor
-  overrides — check the organization's network settings if `limited`
+  overrides, so check the organization's network settings if `limited`
   environments behave unexpectedly.
 - **Reaper**: reconciliation lists `fountain`-labeled sandboxes only; other
   sandboxes in the organization are never touched.

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -24,9 +24,9 @@ cd images/e2b
 e2b template build --name fountain --dockerfile e2b.Dockerfile
 ```
 
-It recreates the sandbox shape the provisioning pipeline assumes — a
+It recreates the sandbox shape the provisioning pipeline assumes, meaning a
 `sprite` user with passwordless sudo, `/home/sprite`, node/npm/bun/git and
-the four agent CLIs — so no per-provider provisioning code exists.
+the four agent CLIs, so no per-provider provisioning code exists.
 
 ## How the contract maps
 
@@ -35,9 +35,9 @@ the four agent CLIs — so no per-provider provisioning code exists.
 | Name-keyed create/adopt | E2B assigns ids; the minted name rides in sandbox `metadata` and lookups filter on it server-side. A create race leaves a duplicate the reaper converges |
 | Suspend / resume | Real calls: `pause` snapshots filesystem + memory (retained indefinitely, storage-only cost); `connect` restores. The idle bound genuinely parks |
 | TTL | Every running E2B sandbox has one. Live commands heartbeat it, and sandboxes are created with `autoPause: true`, so a missed heartbeat pauses (state preserved) rather than kills. Operations that find the sandbox auto-paused resume it first |
-| Exec / streaming | envd (the in-sandbox daemon) over Connect-RPC with the JSON codec — plain HTTPS, no gRPC |
+| Exec / streaming | envd (the in-sandbox daemon) over Connect-RPC with the JSON codec, which is plain HTTPS and not gRPC |
 | Reattach after a deploy | envd does not replay a reconnected process's output, so detachable commands run under a journaling shim (`tee` to `/tmp/fountain/<tag>.*`); reattach replays the journal from byte zero via a `tail` streamer and reads the real exit code from the shim's exit file |
-| Network policy | Native default-deny: `denyOut 0.0.0.0/0` plus the allowlist, updatable on a running sandbox — the provision-open-then-lock flow works unchanged |
+| Network policy | Native default-deny: `denyOut 0.0.0.0/0` plus the allowlist, updatable on a running sandbox, so the provision-open-then-lock flow works unchanged |
 | Checkpoints | Not supported (`:checkpoint` is not advertised) |
 
 ## Operational notes

--- a/docs/integrations/github-oauth.md
+++ b/docs/integrations/github-oauth.md
@@ -22,7 +22,7 @@ The requested scope is `user:email`.
 | `GITHUB_OAUTH_CLIENT_ID` | From the OAuth app |
 | `GITHUB_OAUTH_CLIENT_SECRET` | From the OAuth app |
 
-The button only renders when `GITHUB_OAUTH_CLIENT_ID` is set — an
+The button only renders when `GITHUB_OAUTH_CLIENT_ID` is set, so an
 unconfigured instance shows plain email + password auth, with no dead-end
 GitHub button.
 
@@ -30,10 +30,10 @@ GitHub button.
 
 - **Only a GitHub-verified email is accepted.** Fountain checks the address's
   `verified` flag with GitHub rather than trusting the primary email, because
-  sign-ins link to existing accounts by email — an unverified address set to
+  sign-ins link to existing accounts by email, so an unverified address set to
   someone else's email must not attach to their account. An unverified email
   is refused with a message telling the user to confirm it on GitHub first.
-- OAuth signups arrive with their email already verified — no verification
+- OAuth signups arrive with their email already verified, so no verification
   email is sent, so OAuth works fine on an instance with
   `EMAIL_DELIVERY=none`.
 - `REGISTRATION_ENABLED=false` and `REGISTRATION_ALLOWED_EMAIL_DOMAINS` apply

--- a/docs/integrations/sentry.md
+++ b/docs/integrations/sentry.md
@@ -1,46 +1,46 @@
 # Sentry
 
 **Optional, and inert until you opt in.** With no DSN set, the SDK is
-configured but does nothing — no account, no events, nothing leaves your
+configured but does nothing. No account, no events, nothing leaves your
 instance.
 
 ## Provider side
 
 Create a project (platform: Elixir) on [sentry.io](https://sentry.io) or any
-Sentry-API-compatible endpoint — GlitchTip works, for a fully self-hosted
-stack — and take its DSN.
+Sentry-API-compatible endpoint, such as GlitchTip for a fully self-hosted
+stack, and take its DSN.
 
 ## Env vars
 
 | Variable | Default | Effect |
 |---|---|---|
-| `SENTRY_DSN` | — | Turns reporting on. Crashes — including ones that never touch a web request — are reported with stack traces, grouped, rate-limited to 20 events/minute |
+| `SENTRY_DSN` | — | Turns reporting on. Crashes, including ones that never touch a web request, are reported with stack traces, grouped, rate-limited to 20 events/minute |
 | `SENTRY_ENVIRONMENT` | the build env | Environment tag on events |
 | `FOUNTAIN_BUILD_SHA` | set by the image build (release images) or by the deployment (main-line images) | Correlates events with releases: "this started with `sha-…`" |
 
 Reporting is deliberately conservative: `send_default_pii` is off, so
-cookies, user IPs and request bodies are not attached — this app holds tenant
+cookies, user IPs and request bodies are not attached, because this app holds tenant
 secrets, and nothing the SDK gathers on its own should ride along.
 
 ## Crons: alerting when a scheduled job stops running
 
 Sentry Monitors (Crons) catch the failure mode Prometheus alerts often miss:
 a backup job that silently stops being scheduled. The pattern Fountain's own
-deployment uses for its nightly `pg_dump`, reusable for any scheduled job:
+deployment uses for its nightly `pg_dump` is reusable for any scheduled job.
 
 - After the job **verifiably succeeds** (upload confirmed, not merely
-  attempted), ping the check-in URL derived from the DSN:
+  attempted), ping the check-in URL derived from the DSN.
 
     ```
     curl -fsS -m 10 "https://<sentry-host>/api/<project-id>/cron/<monitor-slug>/<public-key>/?status=ok"
     ```
 
 - The monitor is auto-created on the first check-in. Then set its schedule
-  and a grace period in the Sentry UI — that arms the alert for *missed*
+  and a grace period in the Sentry UI, which arms the alert for *missed*
   runs, which is the point.
 - Keep it best-effort: a Sentry outage must never fail a successful backup.
 
 ## Verify
 
-Set the DSN, restart, and cause any error — it appears in the project within
+Set the DSN, restart, and cause any error. It appears in the project within
 seconds, tagged with environment and release. Unset it and nothing does.

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -6,8 +6,8 @@
 needs at least one provider credential, and with none configured every
 conversation fails at provision time.
 
-The exact API surface Fountain consumes — and what a compatible replacement
-behind `SPRITES_BASE_URL` would have to provide — is written down in
+The exact API surface Fountain consumes, and what a compatible replacement
+behind `SPRITES_BASE_URL` would have to provide, is written down in
 [the Sprites transport reference](sprites-contract.md).
 
 ## Provider side
@@ -19,16 +19,16 @@ provider-side setup.
 
 | Variable | Default | Effect |
 |---|---|---|
-| `SPRITES_TOKEN` | — | The platform token. Not checked at boot: the app starts without it, and the first conversation fails at provision time instead |
-| `SPRITES_BASE_URL` | `https://api.sprites.dev` | Repoints the Sprites API. Anything else must implement the same transport — [E2B](e2b.md) and [Daytona](daytona.md) are separate providers, not `SPRITES_BASE_URL` replacements |
+| `SPRITES_TOKEN` | — | The platform token. Not checked at boot, so the app starts without it and the first conversation fails at provision time instead |
+| `SPRITES_BASE_URL` | `https://api.sprites.dev` | Repoints the Sprites API. Anything else must implement the same transport. [E2B](e2b.md) and [Daytona](daytona.md) are separate providers rather than `SPRITES_BASE_URL` replacements |
 | `SPRITES_TIMEOUT_MS` | `30000` | Bounds every HTTP call to the Sprites API. Long-running commands (package installs, clones) set their own per-call timeouts. Boot refuses a non-positive value |
 
 ## The cost model
 
 **One platform token pays for every Sprites sandbox.** Fountain provisions
 all tenants' Sprites sandboxes with `SPRITES_TOKEN` and the bill lands on that token's
-account — on the hosted instance, subscription pricing recovers it; on yours,
-you are the one paying. Two consequences:
+account. On the hosted instance subscription pricing recovers it, and on yours
+you are the one paying. Two consequences follow.
 
 - Every signup that can start a conversation can spend your money. Close
   registration, or restrict it, before putting an instance on the internet.
@@ -37,13 +37,13 @@ you are the one paying. Two consequences:
   provisioning begins, because that is when they start being paid for.
 
 The token is never surfaced to tenants, the admin UI, or the sandboxes
-themselves — a sprite receives only a scoped, expiring token whose sole
+themselves. A sprite receives only a scoped, expiring token whose sole
 audience is your Fountain instance's own API.
 
 ## Verify
 
 Start a conversation. Provisioning progress streams as stage events; a bad or
 missing token surfaces as the `provision` stage failing, visible in the
-conversation's log view. A Sprites outage does not affect anything else —
+conversation's log view. A Sprites outage does not affect anything else,
 sign-in, dashboards and configuration keep working, and the health endpoints
 deliberately do not consult Sprites.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -22,8 +22,8 @@ It has no runtime dependencies and needs Node 20.19 or newer.
 
 !!! note "Not on npm yet"
 
-    The package is not yet published. Until it is, build it from a checkout —
-    `cd sdk/typescript && npm install && npm run build && npm link` — and
+    The package is not yet published. Until it is, build it from a checkout
+    with `cd sdk/typescript && npm install && npm run build && npm link`, and
     `npm link fountain-sdk` in the project that wants it.
 
 ## What the second argument is for
@@ -33,7 +33,7 @@ that is Fountain:
 
 | | what it does |
 |---|---|
-| `agent` | which named agent config to run — its runtime, model, skills and MCP servers |
+| `agent` | which named agent config to run, meaning its runtime, model, skills and MCP servers |
 | `environment` | which baseline to provision the sandbox from: packages, cloned repos, setup scripts |
 | `vault` | which secrets to attach at spawn. They win over the environment's on a key collision |
 
@@ -47,7 +47,7 @@ There is a second layer under that, and it is worth knowing about because it
 changes what you can safely let an agent do: Fountain redacts every value of 8
 bytes or more that it placed in the sandbox's environment out of the
 conversation's output, on the single write path every log event goes through.
-An `env`, a `set -x`, a `cat .env`, or an agent simply asked to print its token
+An `env`, a `set -x`, a `cat .env`, or an agent asked outright to print its token
 persists as `[REDACTED]`. The secret reaches the process that needs it and not
 the transcript, the database, or this SDK.
 
@@ -66,12 +66,12 @@ baseUrl: option → FOUNTAIN_BASE_URL → ~/.fountain/credentials → hosted
 `FOUNTAIN_TOKEN` is the conversation-scoped token a Fountain sandbox exports
 for the agent inside it. An agent that imports this SDK therefore delegates
 with the credential it already holds, and the conversations it opens are
-recorded as its children — fan-out needs no extra configuration.
+recorded as its children, so fan-out needs no extra configuration.
 
 ## Awaiting, streaming, or neither
 
 `run()` starts the work and returns a handle. There is no second request behind
-any of these — they are three views of one run.
+any of these, because they are three views of one run.
 
 ```ts
 // the finished answer
@@ -90,13 +90,13 @@ for await (const event of run) {
 const results = await Promise.all(agents.map((agent) => fountain.run(prompt, { agent })));
 ```
 
-A turn that **fails** is a result, not an exception — check `result.state`
+A turn that **fails** is a result rather than an exception, so check `result.state`
 (`done`, `failed`, `interrupted`, `timeout`). Only a transport failure, a
 rejected request or a timeout throws.
 
 ## A whole definition, in code
 
-`run()` names an agent. This is where the agent comes from — and the point of
+`run()` names an agent. This is where the agent comes from, and the point of
 showing it whole is that the vocabulary is small enough to fit on one screen.
 
 ```ts
@@ -138,7 +138,7 @@ await fountain.run("Find every N+1 query and open a PR", {
 ```
 
 That is an [environment](primitives.md), a [vault](primitives.md) and an
-[agent](primitives.md) — three of the four primitives — and then a
+[agent](primitives.md), three of the four primitives, and then a
 conversation, which is the fourth.
 
 The fields that are not self-evident:
@@ -148,7 +148,7 @@ The fields that are not self-evident:
 | `runtime` | `claude`, `codex`, `gemini` or `opencode`. `model`'s provider must match it |
 | `model` | canonical `provider/model_id`. Not checked against a list, so a model released today works today |
 | `system` | the agent's system prompt |
-| `skills` | either `{ source, ref? }` (installed from GitHub) or `{ name, content }` (written into the sandbox verbatim) — exactly one shape per entry |
+| `skills` | either `{ source, ref? }` (installed from GitHub) or `{ name, content }` (written into the sandbox verbatim). Exactly one shape per entry |
 | `sandbox_provider` | `sprites`, `e2b`, `daytona` or `runner`; `null` takes the instance default |
 | `allowed_vault_ids` | which vaults a conversation may attach. `null` allows any, `[]` forbids all, a list is an allowlist. Since vault values override the environment, this is what scopes who can override reviewed config |
 | `allowed_environment_ids` | same shape, for launching the agent under a different environment |
@@ -167,7 +167,7 @@ await fountain.agents.delete("reposage");
 ```ts
 await fountain.environments.secrets.set("fountain-ci", "HEX_API_KEY", "…");
 await fountain.vaults.secrets.setAll("github-bot", { GITHUB_TOKEN: "…", GITHUB_USER: "bot" });
-await fountain.vaults.secrets.list("github-bot");    // keys only — never values
+await fountain.vaults.secrets.list("github-bot");    // keys only, never values
 await fountain.vaults.secrets.delete("github-bot", "GITHUB_USER");
 ```
 
@@ -179,15 +179,16 @@ can put a credential into a sandbox and cannot read it back out.
     Resource payloads use the API's own key names, so one definition reads
     identically in the SDK, in the [REST API](api.md) and in a `fountain.yml`
     manifest, and this page doubles as the API reference. Options that control
-    the SDK's own behaviour — `timeoutMs`, `signal` — are camelCase, because
+    the SDK's own behaviour (`timeoutMs`, `signal`) are camelCase, because
     those are not data.
 
 ## The team
 
 Ten of the eleven applications built on Fountain talk to `/api/team`, and some
 of them never touch `/api/conversations` at all. The reason is that a teammate
-is a *durable* thing — one agent, one long-running sandbox, one thread you keep
-messaging — where a conversation is something you open and close.
+is a *durable* thing, meaning one agent, one long-running sandbox and one
+thread you keep messaging, where a conversation is something you open and
+close.
 
 ```ts
 await fountain.team.add("watchtower", { name: "Watchtower" });
@@ -199,8 +200,8 @@ console.log(reply.text);
 `message()` returns the same `Run` handle `run()` does: await it, iterate it,
 or ignore it and let the stream below carry the answer to your UI.
 
-An entire messaging client on these verbs — roster, threads, connectors,
-routines, and what each piece is doing — is
+An entire messaging client on these verbs, covering roster, threads,
+connectors, routines and what each piece is doing, is
 [**Build a chat app**](build/index.md).
 
 ```ts
@@ -233,7 +234,7 @@ idle timeout is invisible to the caller.
 
 !!! note "The team stream carries raw events"
 
-    `/api/team/stream` takes `streams` and nothing else — no `blocks` — so
+    `/api/team/stream` takes `streams` and nothing else, with no `blocks`, so
     events on it are the runtime's own dialect. Treat it as a notification
     channel (something happened, to whom) and read the detail from the
     conversation's own feed, which does parse blocks. `fountain.events()` is
@@ -267,7 +268,7 @@ learned. A [suspended](reference/conversation-states.md) sandbox wakes for it.
 ## Timeouts
 
 `run()` waits as long as the turn takes; agent work legitimately runs for
-hours. `timeoutMs` stops the *waiting* — never the agent:
+hours. `timeoutMs` stops the *waiting*, never the agent.
 
 ```ts
 try {
@@ -295,7 +296,7 @@ try {
 } catch (error) {
   if (error instanceof ConversationBusyError) return "Still working on the last one.";
   if (error instanceof QuotaExceededError) return `Sandboxes full (${error.activeSandboxes}/${error.limit}).`;
-  if (error instanceof NotReadyError) return `Starting up — retry in ${error.retryAfter}s.`;
+  if (error instanceof NotReadyError) return `Starting up, retry in ${error.retryAfter}s.`;
   if (error instanceof ValidationError) return Object.entries(error.fieldErrors)[0]?.join(" ");
   throw error;
 }
@@ -303,13 +304,13 @@ try {
 
 | Class | Code / status | Retryable |
 |---|---|---|
-| `ConversationBusyError` | `conversation_busy` (400) | yes — the turn in flight has to finish |
-| `NotReadyError` | `provisioning`, `sprite_probe_failed` (503) | yes — carries the server's `Retry-After` |
-| `QuotaExceededError` | `sandbox_quota_exceeded` (429) | yes — terminate a conversation first |
-| `SubscriptionRequiredError` | `subscription_required` (402) | no — carries `upgradeUrl` |
-| `ValidationError` | 422 | no — read `fieldErrors` |
+| `ConversationBusyError` | `conversation_busy` (400) | yes, the turn in flight has to finish |
+| `NotReadyError` | `provisioning`, `sprite_probe_failed` (503) | yes, carries the server's `Retry-After` |
+| `QuotaExceededError` | `sandbox_quota_exceeded` (429) | yes, terminate a conversation first |
+| `SubscriptionRequiredError` | `subscription_required` (402) | no, carries `upgradeUrl` |
+| `ValidationError` | 422 | no, read `fieldErrors` |
 | `AuthError` / `NotFoundError` | 401 / 404 | no |
-| `ConnectionError` | never reached the server | — in a browser, usually CORS |
+| `ConnectionError` | never reached the server | in a browser, usually CORS |
 
 Every one carries `status`, `code`, `body`, `retryAfter` and a `retryable`
 flag, so a generic retry wrapper needs no table of its own.
@@ -324,14 +325,15 @@ you pass what you have:
 const fountain = new Fountain({ baseUrl, apiKey });   // from your own settings UI
 ```
 
-The server must allow your origin — `API_CORS_ORIGINS` — or every call fails
+The server must allow your origin through `API_CORS_ORIGINS`, or every call fails
 before it starts. `ConnectionError` says exactly that, because "Failed to
 fetch" has sent more than one person hunting through their own code.
 
 ## Everything else
 
-The SDK wraps the verbs worth wrapping. The rest of the API — audit, API keys,
-admin, billing, exports — is one call away with the same auth and error
+The SDK wraps the verbs worth wrapping. The rest of the API, including audit,
+API keys, admin, billing and exports, is one call away with the same auth and
+error
 handling:
 
 ```ts
@@ -345,7 +347,7 @@ those.
 
 The types are not hand-written. `src/generated/openapi.ts` comes from the same
 OpenAPI document the server serves at `GET /api/openapi.json`, and CI
-regenerates it and fails on a diff — so a field added to a schema in Elixir
+regenerates it and fails on a diff, so a field added to a schema in Elixir
 reaches the SDK on the next build, and a type here can never describe an API
 that no longer exists.
 
@@ -362,11 +364,12 @@ paths are worth a verb.
 ## Other languages
 
 There is no SDK for your language yet, but there are two worked references for
-the part that is easy to get wrong — following a turn through the log feed:
+the part that is easy to get wrong, which is following a turn through the log
+feed.
 
-- **Python** — the [Hermes plugin](integrations/hermes.md)'s `tools.py`, which
+- **Python**, the [Hermes plugin](integrations/hermes.md)'s `tools.py`, which
   polls `/events?blocks=true`.
-- **Go** — the [`fountain` CLI](cli.md)'s `fountain run`, which streams SSE.
+- **Go**, the [`fountain` CLI](cli.md)'s `fountain run`, which streams SSE.
 
 Both implement the same rules the TypeScript SDK does: keep only your own
 turn's events, keep only `text` blocks, join ACP chunks with nothing and legacy

--- a/scripts/docs-style-allow.txt
+++ b/scripts/docs-style-allow.txt
@@ -14,10 +14,7 @@ docs/integrations/acp.md
 docs/integrations/adding-a-sandbox-provider.md
 docs/integrations/buzz.md
 docs/integrations/clients.md
-docs/integrations/daytona.md
-docs/integrations/e2b.md
 docs/integrations/editors.md
-docs/integrations/github-oauth.md
 docs/integrations/hermes.md
 docs/integrations/index.md
 docs/integrations/mail.md
@@ -25,8 +22,6 @@ docs/integrations/openbot.md
 docs/integrations/openclaw.md
 docs/integrations/runners.md
 docs/integrations/sandbox-contract.md
-docs/integrations/sentry.md
 docs/integrations/sprites-contract.md
-docs/integrations/sprites.md
 docs/integrations/stripe.md
 docs/llm-integration.md

--- a/scripts/docs-style-allow.txt
+++ b/scripts/docs-style-allow.txt
@@ -30,4 +30,3 @@ docs/integrations/sprites-contract.md
 docs/integrations/sprites.md
 docs/integrations/stripe.md
 docs/llm-integration.md
-docs/sdk.md


### PR DESCRIPTION
Part of #911 and #903. Two commits.

## `sdk.md`, 28 edits

The error table is the bulk of it, where a cell reads
`yes — the turn in flight has to finish`. A comma carries that better in a
table.

One **"simply"** caught by the forbidden-phrase rule, in the redaction
paragraph:

> before: `an agent simply asked to print its token`
> after: `an agent asked outright to print its token`

The word was doing real work there, contrasting a deliberate print with an
accidental `set -x`, so it needed a replacement rather than a deletion. That is
the case the rule exists for: "simply" almost always means something more
specific, and finding out what is the point.

## The five small pages

`sprites`, `e2b`, `daytona`, `github-oauth`, `sentry`. 27 edits plus two
colon-introduced lists.

Most are in the "how the contract maps" tables, where a cell reads
`Native — sandboxes are name-addressable`. A full stop reads better there.

**The `| — |` placeholder cells in `sprites.md` and `sentry.md` survive
untouched.** That is the exemption from #924 doing its job on real pages
rather than on the planted test line I checked it with.

## Backlog

| | Files | Real violations |
|---|---|---|
| Start (#917) | 32 | 560 |
| After #924 | 23 | ~330 |
| After this | 17 | ~250 |

Everything with more than 20 sites is now done except `integrations/buzz.md`
(32), `openclaw.md` (28), `sprites-contract.md` (27) and `acp.md` (24).

## Verification

- `scripts/docs-style.py`: clean, 58 files checked
- `mkdocs build --strict`: clean
- `docs_test.exs`: 25 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
