### PR TITLE
docs: clean eleven more pages, including the ACP reference

### DIFF
--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -15,7 +15,7 @@ supply the machine:
 | Behind the bubble | What it actually means |
 |---|---|
 | a computer | a filesystem, a shell, a package manager, a network |
-| credentials | a GitHub token that works — not in the prompt, not in the transcript |
+| credentials | a GitHub token that works, not in the prompt and not in the transcript |
 | memory | the second message costs a sentence, not a re-explanation of the first |
 | isolation | one bot's token and files on a machine that is not the one serving your app |
 | a lifecycle | something starts that machine, parks it while nobody is typing, wakes it |

--- a/docs/build/team-chat.md
+++ b/docs/build/team-chat.md
@@ -49,7 +49,7 @@ const agent = await fountain.agents.create({
 const teammate = await fountain.team.add(agent.name, { name: "Watchtower" });
 
 teammate.conversation.id;      // the thread
-teammate.presence.state;       // "starting" — a computer is being provisioned
+teammate.presence.state;       // "starting", a computer is being provisioned
 ```
 
 `catalog()` is what stops the model dropdown going stale: the runtimes, the
@@ -324,7 +324,7 @@ await fountain.agents.update("watchtower", {
 
 [Substitution](../primitives.md#substitution) resolves `${GITHUB_TOKEN}` when
 the computer is set up. Three things follow, and together they are why this is
-more than a nicer way to store a string:
+more than a nicer way to store a string.
 
 - The token never appears in a prompt, a model's context, or the log feed your
   app reads.
@@ -365,7 +365,7 @@ Static hosting. The only server-side facts are on the Fountain instance:
 
 | What | Why |
 |---|---|
-| `API_CORS_ORIGINS` | a browser calling another origin's API is a CORS request; off by default, and it only ever admits a presented bearer key — cookies never cross origins |
+| `API_CORS_ORIGINS` | a browser calling another origin's API is a CORS request; off by default, and it only ever admits a presented bearer key, since cookies never cross origins |
 | `OAUTH_CLIENTS` | to offer **Sign in with Fountain** instead of asking for a pasted key |
 
 [Sign in with Fountain](../api.md#sign-in-with-fountain-oauth-20-for-browser-apps)

--- a/docs/integrations/acp.md
+++ b/docs/integrations/acp.md
@@ -1,12 +1,13 @@
-# `fountain acp` — the ACP agent reference
+# `fountain acp`, the ACP agent reference
 
 `fountain acp` is the one process every ACP client of Fountain spawns:
 [editors](editors.md) (Zed and friends), [OpenClaw](openclaw.md), and the
 [Buzz](buzz.md) harness all speak the
 [Agent Client Protocol](https://agentclientprotocol.com) to it over stdio, and
 it drives a conversation running in a Fountain sandbox. Those three pages cover
-*setting up the client*; this page is the reference for the adapter itself —
-what it accepts, what it does with it, and what it deliberately ignores — so
+*setting up the client*. This page is the reference for the adapter itself,
+covering what it accepts, what it does with it, and what it deliberately
+ignores, so
 they do not each restate it.
 
 **What it is, and is not.** A control surface for a conversation that runs on
@@ -22,15 +23,15 @@ fountain acp --agent <name-or-id> [--vault <name-or-id>] [--environment <name-or
 
 | Flag | Meaning |
 |---|---|
-| `--agent` | **Required in practice.** The Fountain agent every session runs. ACP has no field for it, so it is configured per process — one client entry per agent you want to reach. |
-| `--vault` | A vault attached to every conversation this process opens. Vault values override the agent's environment, so this is where per-entry secrets belong — an identity the agent posts under, for instance. Two entries on the same agent with different vaults stay separate. |
-| `--environment` | Provision every conversation from this environment instead of the agent's own — one agent config under several environments, one entry each. The vault still wins on key collision. When the agent sets `allowed_environment_ids`, the environment must be on that list. |
+| `--agent` | **Required in practice.** The Fountain agent every session runs. ACP has no field for it, so it is configured per process, one client entry per agent you want to reach. |
+| `--vault` | A vault attached to every conversation this process opens. Vault values override the agent's environment, so this is where per-entry secrets belong, such as an identity the agent posts under. Two entries on the same agent with different vaults stay separate. |
+| `--environment` | Provision every conversation from this environment instead of the agent's own, so one agent config runs under several environments with one entry each. The vault still wins on key collision. When the agent sets `allowed_environment_ids`, the environment must be on that list. |
 | `--log-level` | stderr verbosity: `debug`, `info` (default), `warn`, `error`. |
 | `--profile` | Which saved CLI credentials to use (global flag). |
 
 **Credentials** are the CLI's: `FOUNTAIN_API_KEY` / `FOUNTAIN_BASE_URL` in the
 environment, else the profile `fountain auth login` saved. There is no login
-inside the protocol — `authenticate` verifies what the CLI already holds and
+inside the protocol. `authenticate` verifies what the CLI already holds and
 its one advertised method just says "run `fountain auth login`". A hosted
 Buzz harness gets a freshly minted, sprite-scoped key in its environment for
 exactly this reason.
@@ -46,23 +47,23 @@ is `fountain` with the CLI's version.
 
 | Method | What Fountain does |
 |---|---|
-| `initialize` | Capability handshake. The client's own capabilities (`fs`, terminals) are logged and unused — this agent works on a sandbox filesystem, not yours. |
+| `initialize` | Capability handshake. The client's own capabilities (`fs`, terminals) are logged and unused, because this agent works on a sandbox filesystem rather than yours. |
 | `authenticate` | Verifies the CLI's saved credentials against the instance. Advertised only when none are held. |
-| `session/new` | Resolves `--agent`, refuses an agent whose runtime does not speak ACP (today: `gemini`, [#659](https://github.com/BinaryBourbon/fountain/issues/659)), and opens a conversation. **The ACP session id *is* the conversation id** — see below. Responds with the agent's model as the single available model. |
+| `session/new` | Resolves `--agent`, refuses an agent whose runtime does not speak ACP (today: `gemini`, [#659](https://github.com/BinaryBourbon/fountain/issues/659)), and opens a conversation. **The ACP session id *is* the conversation id**, as below. Responds with the agent's model as the single available model. |
 | `session/prompt` | Sends the turn (text and images; other blocks are dropped with a warning, an all-unusable prompt is refused) and streams the conversation's ACP output back as `session/update` notifications until the turn ends. |
 | `session/cancel` | Interrupts the running turn. |
 | `session/load` | Reopens a conversation this process did not start: the stored `session/update` history is replayed **before** the response, as the spec requires. |
 | `session/set_model` | Not implemented. The model belongs to the Fountain agent; changing it here would change every conversation on that agent. |
-| `session/request_permission` (agent → client) | Not forwarded yet — sandboxed runtimes run under their own permission mode ([#643](https://github.com/BinaryBourbon/fountain/issues/643), [#708](https://github.com/BinaryBourbon/fountain/issues/708)). |
+| `session/request_permission` (agent → client) | Not forwarded yet, because sandboxed runtimes run under their own permission mode ([#643](https://github.com/BinaryBourbon/fountain/issues/643), [#708](https://github.com/BinaryBourbon/fountain/issues/708)). |
 
 Advertised capabilities: `loadSession: true`; prompt `image: true`,
 `audio: false`, `embeddedContext: false` (the client may not inline a local
-file — that would be context about a machine the agent cannot see).
+file, which would be context about a machine the agent cannot see).
 
 `cwd` and `mcpServers` on `session/new` are logged and ignored: the sandbox
 clones its own checkout, and a Fountain agent carries its own MCP configuration
-to the sandbox. Fountain may *add* MCP servers of its own to a session — the
-Buzz publish tools are injected this way — but never the client's.
+to the sandbox. Fountain may *add* MCP servers of its own to a session, and the
+Buzz publish tools are injected this way, but never the client's.
 
 ### The session id is the conversation id
 
@@ -81,14 +82,15 @@ The sandbox runtime already speaks ACP to Fountain
 so the adapter is a proxy, not a translator: `agent_message_chunk`,
 `agent_thought_chunk`, `tool_call`, `tool_call_update` and friends are
 forwarded as they arrive, with the `sessionId` rewritten to yours. Two
-adjustments, both about the machine boundary:
+adjustments follow, both about the machine boundary.
 
 - **`tool_call.locations` are moved to `_meta["fountain.sandboxLocations"]`.**
   They name files in the sandbox; left in place an editor would open (or fail
   to open) paths on your machine.
 - **Stop reasons come from the sandbox** (`end_turn`, `refusal`, `cancelled`,
-  …). What the sandbox has no vocabulary for — it never provisioned, it was
-  reclaimed mid-turn, the conversation was terminated — is reported as a
+  …). What the sandbox has no vocabulary for, such as never having
+  provisioned, being reclaimed mid-turn, or the conversation being terminated,
+  is reported as a
   JSON-RPC error rather than dressed up as "the agent finished".
 
 A dropped SSE connection is not a lost turn: the server closes an idle stream
@@ -100,21 +102,21 @@ Out-of-band fields a chat harness sends; anything else in `_meta` is ignored.
 
 | Field | Meaning |
 |---|---|
-| `channelId` | Names the external channel this session serves. With it, `session/new` **resumes** the conversation already bound to that channel for this user + agent + vault (same conversation, same sandbox, same runtime session — a fresh ACP id from the client's side), so a harness that forgets its sessions on restart lands back where it was ([#774](https://github.com/BinaryBourbon/fountain/issues/774)). Without it every `session/new` is a new conversation. |
-| `freshSession` | With `channelId`: skip the resume this once — unbind the current conversation (it keeps running and is retired like any other idle one) and open a new one as the binding. This is what a Buzz owner's `!rotate` turns into ([#788](https://github.com/BinaryBourbon/fountain/pull/788)). Ignored without `channelId`. |
+| `channelId` | Names the external channel this session serves. With it, `session/new` **resumes** the conversation already bound to that channel for this user + agent + vault (same conversation, same sandbox, same runtime session, with a fresh ACP id from the client's side), so a harness that forgets its sessions on restart lands back where it was ([#774](https://github.com/BinaryBourbon/fountain/issues/774)). Without it every `session/new` is a new conversation. |
+| `freshSession` | With `channelId`, skip the resume this once. Unbind the current conversation (it keeps running and is retired like any other idle one) and open a new one as the binding. This is what a Buzz owner's `!rotate` turns into ([#788](https://github.com/BinaryBourbon/fountain/pull/788)). Ignored without `channelId`. |
 
 The same knobs exist on the API as `channel_id` / `fresh` on
 `POST /api/conversations`.
 
 ## Lifecycle, sandboxes, and what survives
 
-- **A turn ends when the conversation says so** — the terminal `turn` stage
-  event, with its stop reason — not when output goes quiet.
+- **A turn ends when the conversation says so**, at the terminal `turn` stage
+  event with its stop reason, not when output goes quiet.
 - **An idle sandbox is suspended, not lost.** The next prompt resumes it. A
   sandbox reclaimed at its maximum lifetime, or one that fails to reattach, is
   reported as an error on the turn that hit it; prompt again to provision a
-  fresh one. The transcript is untouched either way — `session/load` replays
-  it — but the agent's own working memory in the sandbox is gone
+  fresh one. The transcript is untouched either way and `session/load` replays
+  it, but the agent's own working memory in the sandbox is gone
   ([#649](https://github.com/BinaryBourbon/fountain/issues/649)).
 - **Closing the client does not stop anything.** The conversation is on the
   server; the process is a window onto it. Reopen with `session/load`, or from
@@ -131,10 +133,10 @@ are worded for a reader inside an editor rather than a terminal:
 | `agent "x" runs the gemini runtime, which does not speak ACP` | Use that agent from the conversations app or `fountain run`. |
 | `credentials for … were rejected` | Run `fountain auth login`. The message names the instance it tried, which is usually the surprise. |
 | `could not resolve agent "x" on …` | Wrong name, or the right name on a different instance. |
-| `the sandbox never started: …` | Provisioning failed — the reason is the sandbox provider's. |
-| `could not reattach to the sandbox — prompt again to provision a fresh one` | The sandbox was reclaimed; the transcript survives. |
+| `the sandbox never started: …` | Provisioning failed, and the reason is the sandbox provider's. |
+| `could not reattach to the sandbox, prompt again to provision a fresh one` | The sandbox was reclaimed, and the transcript survives. |
 
-Running the binary by hand is a fair diagnostic — it sits waiting for JSON-RPC
+Running the binary by hand is a fair diagnostic, since it sits waiting for JSON-RPC
 on stdin, which proves the process starts and finds its credentials.
 
 ## Where it is used

--- a/docs/integrations/clients.md
+++ b/docs/integrations/clients.md
@@ -4,10 +4,10 @@ Fountain is a server. This section is everything that drives it from the
 outside: an editor, a chat surface, a plugin host, a relay, your own code.
 
 None of it is set up by the operator. There is no env var, no server-side
-switch and nothing to run — each of these authenticates as an ordinary user,
+switch and nothing to run. Each of these authenticates as an ordinary user,
 with an API key or the CLI's saved login, and works against any instance it
 can reach. If you are looking for the services Fountain itself needs
-configured — sandboxes, mail, OAuth, billing, error tracking — those are in
+configured, meaning sandboxes, mail, OAuth, billing and error tracking, those are in
 [Services Fountain uses](index.md).
 
 | Client | Talks over | Set up on |
@@ -23,16 +23,16 @@ configured — sandboxes, mail, OAuth, billing, error tracking — those are in
 ## Over ACP
 
 The first three of those spawn the same adapter. Its protocol surface, `_meta`
-extensions and failure modes are on one page —
-[**`fountain acp` (reference)**](acp.md) — so the client pages below only cover
+extensions and failure modes are on one page,
+[**`fountain acp` (reference)**](acp.md), so the client pages below only cover
 setup.
 
-[**Editors**](editors.md): an ACP-capable editor — Zed and friends — spawns
+[**Editors**](editors.md): an ACP-capable editor, Zed and friends, spawns
 `fountain acp` locally and talks to your instance with the credentials the
 developer already has.
 
-[**OpenClaw**](openclaw.md) reaches the same adapter from a chat surface —
-Telegram, Discord, Slack — by registering Fountain as a custom ACP agent in its
+[**OpenClaw**](openclaw.md) reaches the same adapter from a chat surface such
+as Telegram, Discord or Slack, by registering Fountain as a custom ACP agent in its
 `acpx` plugin. The configuration is client-side, on the OpenClaw host.
 
 ## Over the API
@@ -45,15 +45,15 @@ plugin authenticates with an API key or the CLI's saved login.
 
 [**OpenBot**](openbot.md) needs no plugin at all, only a URL: Fountain answers
 [AG-UI](https://github.com/ag-ui-protocol/ag-ui) at `POST /api/agui/:agent_id`,
-and CopilotKit's OpenBot — or any other AG-UI host — registers a Fountain agent
+and CopilotKit's OpenBot, or any other AG-UI host, registers a Fountain agent
 as a coworker with a channel of its own. One channel binds to one conversation,
 so the sandbox is the memory rather than the replayed transcript. The coworker
 holds an API key.
 
-Everything that plugin does is available directly — see the
+Everything that plugin does is available directly. See the
 [API reference](../api.md), the [TypeScript SDK](../sdk.md) and the
 [CLI reference](../cli.md). If what you are building is a chat surface of your
-own — the roster-and-threads app currently being cloned everywhere —
+own, the roster-and-threads app currently being cloned everywhere,
 [**Build a chat app**](../build/index.md) walks the whole thing through in SDK
 calls. [LLM integration](../llm-integration.md) covers the
 discovery endpoints that let an agentic IDE learn the whole surface from one
@@ -61,8 +61,8 @@ fetch.
 
 ## The other direction
 
-[**Buzz**](buzz.md) inverts the arrangement: Fountain *hosts* a Buzz agent — a
-Nostr identity that lives on a relay — running its coding agent in a sandbox
+[**Buzz**](buzz.md) inverts the arrangement. Fountain *hosts* a Buzz agent, a
+Nostr identity that lives on a relay, running its coding agent in a sandbox
 and holding its signing key in a vault. Nobody drives Fountain here; Fountain
 shows up on the relay and answers. Provision one from the Buzz desktop or
 `POST /api/buzz/agents`; it self-enables on any image that ships the

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -21,30 +21,30 @@ yours.
 
 It is **not** a way for the agent to edit the files open in your editor. The
 integration declares no filesystem or terminal access, and the file paths a
-tool call reports are paths inside the sandbox — they are deliberately not sent
+tool call reports are paths inside the sandbox, and they are deliberately not sent
 as clickable locations, because clicking one would open the wrong file on your
 machine or nothing at all. They travel under
 `_meta.fountain.sandboxLocations` instead.
 
-Why reach for this rather than a local agent, then:
+Three reasons to reach for this rather than a local agent.
 
 - **The work outlives the editor.** Close the laptop mid-turn; the turn keeps
   running. Reopen and the transcript is replayed from the server.
-- **The unit is a Fountain agent** — an environment, vault overrides, skills,
+- **The unit is a Fountain agent**, meaning an environment, vault overrides, skills,
   MCP servers and inference credentials that never touch your machine.
 - **The same conversation is open in the conversations app**, for you or a teammate,
   while it runs.
 
 ## Setup
 
-1. Install the CLI and log in:
+1. Install the CLI and log in.
 
     ```bash
     brew install BinaryBourbon/tap/fountain
     fountain auth login
     ```
 
-    For a self-hosted instance, point at it first — the CLI defaults to the
+    For a self-hosted instance, point at it first, because the CLI defaults to the
     hosted one:
 
     ```bash
@@ -81,7 +81,7 @@ profile, add `"--profile", "staging"` to `args`, or set `FOUNTAIN_BASE_URL` in
 
 `--vault <name-or-id>` attaches a [vault](../concepts/vault.md) to every
 conversation the entry opens. Vault values override the agent's environment, so
-this is where a secret that belongs to *this entry* goes — an identity the
+this is where a secret that belongs to *this entry* goes, such as an identity the
 agent posts under, a token scoped to one workspace.
 
 ```json
@@ -97,9 +97,9 @@ even when they point at the same agent.
 
 `--environment <name-or-id>` provisions every conversation the entry opens from
 that [environment](../concepts/environment.md) instead of the agent's own.
-Use it when one agent config should run under several baselines — the same
+Use it when one agent config should run under several baselines, so the same
 "engineer" against a `fountain` environment in one entry and a `buzz`
-environment in another — without duplicating the agent. The vault, if any,
+environment in another, without duplicating the agent. The vault, if any,
 still wins over it on key collision, and an agent can restrict which
 environments may stand in for its own via `allowed_environment_ids`.
 
@@ -114,13 +114,13 @@ fountain acp --agent <name-or-id>
 
 spoken to over stdin/stdout. [Buzz](https://github.com/block/buzz) is
 ACP-native and should work the same way, though its configuration format for a
-custom agent is not something we have verified — if you get it working, a note
+custom agent is not something we have verified. If you get it working, a note
 in an issue would be welcome.
 
 ## What you get
 
-The adapter's full protocol surface — every method, the `_meta` extensions
-chat harnesses use, what is forwarded and what is deliberately ignored — is on
+The adapter's full protocol surface, covering every method, the `_meta`
+extensions chat harnesses use, and what is forwarded or deliberately ignored, is on
 the [`fountain acp` reference](acp.md). The short version:
 
 
@@ -172,7 +172,7 @@ Errors are written to be readable inside an editor rather than in a terminal:
 | `credentials for … were rejected` | Run `fountain auth login`. The message names the instance it tried, which is usually the surprise |
 | `could not resolve agent "x" on …` | Wrong name, or the right name on a different instance |
 
-Running the binary by hand is a fair diagnostic — it will sit waiting for
+Running the binary by hand is a fair diagnostic, since it will sit waiting for
 JSON-RPC on stdin, which tells you the process starts and finds its
 credentials.
 

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -1,8 +1,9 @@
 # Hermes Agent
 
 [Hermes Agent](https://github.com/NousResearch/hermes-agent) is Nous Research's
-self-hosted agent — a CLI, a TUI, and a gateway that fronts Telegram, Discord,
-Slack and the rest — with a plugin system for adding tools. Fountain ships a
+self-hosted agent, being a CLI, a TUI, and a gateway that fronts Telegram,
+Discord, Slack and the rest, with a plugin system for adding tools. Fountain
+ships a
 Hermes plugin that turns every Fountain agent on your account into something
 Hermes can delegate to: Hermes calls `fountain_run`, Fountain provisions a
 sandbox for that agent, the work runs there, and the answer comes back as the
@@ -15,11 +16,11 @@ tool result.
 
 It is **delegation, not a model provider.** Hermes keeps its own model and its
 own loop; a Fountain agent is a contractor it hands a task to and hears back
-from. (Hermes's `copilot-acp` provider — an ACP agent used *as the LLM* — would
+from. (Hermes's `copilot-acp` provider, an ACP agent used *as the LLM*, would
 also accept `fountain acp`, but it opens a fresh session per model call, which
 for Fountain means a sandbox per Hermes turn. The plugin is the intended path.)
 
-Why reach for it:
+Four reasons to reach for it.
 
 - **The work runs off the Hermes host**, in a sandbox with the agent's own
   environment (packages, cloned repos, network policy) and secrets that never
@@ -33,14 +34,14 @@ Why reach for it:
 
 ## Setup
 
-1. Credentials. On the Hermes host either export a key —
+1. Credentials. On the Hermes host either export a key,
 
     ```bash
     export FOUNTAIN_API_KEY=ftn_…                       # from Settings → API keys, or the CLI
     export FOUNTAIN_BASE_URL=https://fountain.example  # only for a self-hosted instance
     ```
 
-    — or install the CLI and log in; the plugin reads `~/.fountain/credentials`
+    or install the CLI and log in. The plugin reads `~/.fountain/credentials`
     exactly as the CLI does (`FOUNTAIN_PROFILE` selects a profile):
 
     ```bash
@@ -52,7 +53,7 @@ Why reach for it:
     conversation-scoped `FOUNTAIN_TOKEN` and marks the conversations it starts
     as children of the one it is running in.
 
-2. Install and enable the plugin:
+2. Install and enable the plugin.
 
     ```bash
     hermes plugins install BinaryBourbon/fountain/integrations/hermes/fountain --enable
@@ -83,7 +84,7 @@ and `default_timeout_seconds` (see Long turns).
 | Tool | Does |
 |---|---|
 | `fountain_agents` | list the account's agents (name, runtime, model) |
-| `fountain_run` | start a conversation with an agent — a fresh sandbox — and wait for the answer; `vault` / `environment` pick per-run overrides; `wait: false` returns the id at once |
+| `fountain_run` | start a conversation with an agent, on a fresh sandbox, and wait for the answer. `vault` / `environment` pick per-run overrides; `wait: false` returns the id at once |
 | `fountain_send` | a follow-up turn in the same conversation; the agent remembers the earlier turns and the sandbox keeps its files |
 | `fountain_wait` | keep waiting on the current turn and collect what arrived since the last look |
 | `fountain_status` | lifecycle status and turns, no waiting |
@@ -91,7 +92,7 @@ and `default_timeout_seconds` (see Long turns).
 | `fountain_terminate` | end a conversation and destroy its sandbox |
 
 Every result carries the conversation's `url`, so the transcript is one click
-away in the Fountain UI. The answer itself is the agent's text — Fountain
+away in the Fountain UI. The answer itself is the agent's text, and Fountain
 serves the log feed pre-parsed into blocks (`?blocks=true`, ADR 0014), so the
 plugin never learns a runtime's dialect; a claude, codex, gemini or opencode
 agent all come back the same way.
@@ -109,11 +110,11 @@ by default (`timeouts.tools.sequential_call`). The plugin never sits inside one
 call for the life of a turn: `fountain_run`, `fountain_send` and `fountain_wait`
 return after `timeout_seconds` (default 300, from `default_timeout_seconds`)
 with `done: false` and the output so far, and the model calls `fountain_wait`
-to continue — the cursor is remembered, so each call returns only new text.
+to continue. The cursor is remembered, so each call returns only new text.
 The skill spells this out; a turn is finished when `done` is `true` and
 `turn_state` says `done`, `failed` (with a `reason`) or `interrupted`.
 
-Provisioning is inside the first wait: a cold sandbox is typically 20–90 s
+Provisioning is inside the first wait, and a cold sandbox is typically 20 to 90 s
 before the agent's first token, depending on the sandbox provider and the
 environment's setup script.
 
@@ -121,7 +122,7 @@ environment's setup script.
 
 - **No permission prompts.** A Fountain agent runs under the sandbox's own
   policy; there is nothing to approve from Hermes. (Forwarding permission
-  requests to a client is #643 and lands for `fountain acp` clients first —
+  requests to a client is #643 and lands for `fountain acp` clients first,
   this plugin polls the log feed and is unaffected either way.)
 - **Text only, one direction.** The plugin returns the agent's text and the
   names of the tools it used; files it wrote stay in the sandbox (push them

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -2,38 +2,38 @@
 
 The external services a Fountain instance talks to in order to run: where a
 sandbox is provisioned, how mail goes out, who signs users in, whether spend is
-metered, where errors land. These are the operator's business — one page per
+metered, where errors land. These are the operator's business. One page per
 service covers what to create on the provider side, which env vars result, and
 how to verify it works.
 
 This is the *outbound* half. For the tools that talk **to** a running Fountain
-— editors, chat surfaces, plugins, SDKs — see
+(editors, chat surfaces, plugins, SDKs) see
 [Plugging into Fountain](clients.md); nothing there needs an env var here.
 
 | Service | Required? | Env vars | Without it |
 |---|---|---|---|
-| [A sandbox provider](sandbox-contract.md) | **Yes — one of four** | `SPRITES_TOKEN` *or* `E2B_API_KEY` *or* `DAYTONA_API_KEY` (or users' own machines via [`fountain runner`](runners.md), no credential), plus `SANDBOX_PROVIDER` to pick the default | The app boots, but every conversation fails at provision time |
+| [A sandbox provider](sandbox-contract.md) | **Yes, one of four** | `SPRITES_TOKEN` *or* `E2B_API_KEY` *or* `DAYTONA_API_KEY` (or users' own machines via [`fountain runner`](runners.md), no credential), plus `SANDBOX_PROVIDER` to pick the default | The app boots, but every conversation fails at provision time |
 | [Mail](mail.md) | **A decision, yes** | `RESEND_API_KEY` *or* `SMTP_*` *or* `EMAIL_DELIVERY=none`, `EMAIL_FROM` | Production refuses to boot with none of the three set |
 | [GitHub OAuth](github-oauth.md) | Optional | `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET` | Email + password auth only |
-| [Stripe](stripe.md) | Optional | `BILLING_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID` | No billing. Correct for most self-hosted instances — leave the gate off |
+| [Stripe](stripe.md) | Optional | `BILLING_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID` | No billing. Correct for most self-hosted instances, so leave the gate off |
 | [Sentry](sentry.md) | Optional | `SENTRY_DSN`, `SENTRY_ENVIRONMENT` | No error tracking; the SDK is inert and nothing leaves the instance |
 
-The sandbox providers — Sprites, E2B, Daytona, and users' own machines — have
+The sandbox providers (Sprites, E2B, Daytona, and users' own machines) have
 [a section of their own](sandbox-contract.md): one contract, four
 implementations. The row above is the short version.
 
 ## The service you do not configure
 
-**Inference providers — Anthropic, OpenAI, Gemini — are not set up by the
+**Inference providers, meaning Anthropic, OpenAI and Gemini, are not set up by the
 operator.** There is no platform-level API key: each user brings their own
 credentials, entered at `/account/inference-credentials` in the running app
 (an Anthropic API key or Claude Code OAuth token, an OpenAI API key, a Gemini
-API key — validated against the provider on save, stored encrypted per
+API key, validated against the provider on save, stored encrypted per
 tenant, and never echoed back).
 
 This is a deliberate design
 ([ADR 0008](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0008-byo-inference-credentials.md)):
 inference cost scales with usage and belongs to the person using it, and many
 users want their own Claude subscription doing the work. If you are looking
-for where to put `ANTHROPIC_API_KEY` in the server environment — there is
+for where to put `ANTHROPIC_API_KEY` in the server environment, there is
 nowhere, on purpose.

--- a/docs/integrations/mail.md
+++ b/docs/integrations/mail.md
@@ -11,7 +11,7 @@ visible error. There are exactly three options, checked in this order:
 | `RESEND_API_KEY` | Delivery via [Resend](https://resend.com) |
 
 Provider side: verify your sending domain in Resend (SPF, DKIM, DMARC
-records) before pointing `EMAIL_FROM` at it — an unverified domain will not
+records) before pointing `EMAIL_FROM` at it, because an unverified domain will not
 deliver to arbitrary inboxes.
 
 ## Option 2: any SMTP server
@@ -24,7 +24,7 @@ deliver to arbitrary inboxes.
 | `SMTP_PASSWORD` | — | |
 | `SMTP_TLS` | `always` | STARTTLS by default; `never` for a relay on a trusted network that does not offer it |
 
-If `RESEND_API_KEY` is also set, Resend wins — the options are checked in
+If `RESEND_API_KEY` is also set, Resend wins, because the options are checked in
 order.
 
 ## Option 3: no email, deliberately
@@ -34,7 +34,7 @@ order.
 | `EMAIL_DELIVERY=none` | Disables email with a stderr notice at boot |
 
 For an OAuth-only instance, or while evaluating. Accounts created with email
-+ password self-verify at registration — a verification link that can never
++ password self-verify at registration, since a verification link that can never
 be delivered gates nothing (ADR 0011).
 
 Password reset is dead in this mode; the only route back into a locked-out
@@ -44,18 +44,18 @@ account is operator intervention.
 
 | Variable | Default | Effect |
 |---|---|---|
-| `EMAIL_FROM` | — (required) | The From address, on a domain your provider is verified for. Required with any real delivery provider — the app refuses to boot without it rather than sending mail your provider will reject |
+| `EMAIL_FROM` | — | The From address, on a domain your provider is verified for. Required with any real delivery provider, and the app refuses to boot without it rather than sending mail your provider will reject |
 
 What actually sends email today: account verification (24-hour link),
-password reset (1-hour link), and — only with [Stripe](stripe.md) configured
-— the four lifecycle emails: the trial-ending reminder three days out,
+password reset (1-hour link), and, only with [Stripe](stripe.md) configured,
+the four lifecycle emails: the trial-ending reminder three days out,
 trial expired, payment failed, and subscription canceled. OAuth signups skip verification
 entirely, so [GitHub OAuth](github-oauth.md) plus `EMAIL_DELIVERY=none` is a
 coherent minimal setup.
 
 ## Verify
 
-Register a throwaway account and confirm the verification email arrives —
+Register a throwaway account and confirm the verification email arrives.
 check spam, which is where an unverified sending domain lands. On a running
 instance, boot logs state the chosen mode (`EMAIL_DELIVERY=none` prints its
 notice to stderr; a missing configuration refuses to boot and says so).

--- a/docs/integrations/sandbox-contract.md
+++ b/docs/integrations/sandbox-contract.md
@@ -2,7 +2,7 @@
 
 Every conversation runs in a sandbox, and every sandbox backend plugs into
 the same seam: the `Fountain.Sandbox` behaviour. There is one contract a
-provider has to meet, and it is executable — the behaviour's moduledoc
+provider has to meet, and it is executable. The behaviour's moduledoc
 specifies the callbacks, capabilities and error taxonomy, and
 `Fountain.SandboxConformanceCase` is the conformance suite every adapter
 must pass (replay-from-start attach, total `write_stdin`, exactly one
@@ -14,28 +14,28 @@ So far, four providers implement it:
 
 | Provider | What it is | Suspend semantics |
 |---|---|---|
-| [Sprites](sprites.md) | [sprites.dev](https://sprites.dev) — the original backend and the instance default | Parks implicitly: the sprite scales to zero on its own, disk preserved |
+| [Sprites](sprites.md) | [sprites.dev](https://sprites.dev), the original backend and the instance default | Parks implicitly, since the sprite scales to zero on its own, disk preserved |
 | [E2B](e2b.md) | [e2b.dev](https://e2b.dev) | Explicit `pause`: filesystem **and memory** snapshot, restored on resume |
-| [Daytona](daytona.md) | [daytona.io](https://daytona.io) — self-hostable via `DAYTONA_API_URL` | Explicit `stop`: disk preserved; long-parked sandboxes archive to object storage |
-| [Self-hosted runner](runners.md) | `fountain runner` on a machine the **user** owns; dials out to Fountain, no vendor account | Stops the sandbox's processes; the directory stays. Trusted mode — no isolation, no egress policy |
+| [Daytona](daytona.md) | [daytona.io](https://daytona.io), self-hostable via `DAYTONA_API_URL` | Explicit `stop`, disk preserved, and long-parked sandboxes archive to object storage |
+| [Self-hosted runner](runners.md) | `fountain runner` on a machine the **user** owns; dials out to Fountain, no vendor account | Stops the sandbox's processes and the directory stays. Trusted mode, with no isolation and no egress policy |
 
 The three hosted providers advertise suspend, network policy and attach; a
 runner advertises suspend and attach only. TTY support is Sprites-only. Checkpoint-based warm starts exist only in the Sprites
-transport and are currently off by default — a checkpoint id is scoped to
+transport and are currently off by default, because a checkpoint id is scoped to
 the sprite that created it, so cross-sprite warm starts cannot work (#654).
 
 ## Picking a provider
 
 - A hosted provider is **enabled** by exactly one thing: its credential is
   present (`SPRITES_TOKEN`, `E2B_API_KEY`, `DAYTONA_API_KEY`). The runner
-  provider has no credential — every daemon authenticates with the user's
-  own API key — so it is enabled unless `SANDBOX_RUNNERS_ENABLED=false`.
+  provider has no credential, since every daemon authenticates with the user's
+  own API key, so it is enabled unless `SANDBOX_RUNNERS_ENABLED=false`.
 - `SANDBOX_PROVIDER` (default `sprites`) sets the instance default for
   newly-created sandboxes. Boot refuses an explicit default whose credential
   is missing.
 - An agent can pin a provider via `sandbox_provider`; the provider select
   appears in the agent form on its own once a second provider is enabled.
-- **Existing sandboxes always stay on the provider that created them** — a
+- **Existing sandboxes always stay on the provider that created them**, since a
   parked disk lives where it was written, so waking never crosses providers.
 
 You need at least one. Without any provider credential the app boots, but
@@ -47,12 +47,12 @@ every conversation fails at provision time.
   (`:suspend`, `:network_policy`, `:attach`, `:tty`, `:checkpoint`,
   `:public_url`), and the
   lifecycle degrades accordingly: a provider without `:suspend` destroys on
-  idle rather than faking a park — agent memory lives on the sandbox disk,
+  idle rather than faking a park, because agent memory lives on the sandbox disk
   and resume-with-a-fresh-disk would be silent data loss.
 - **Errors are one taxonomy.** Every adapter normalizes provider errors into
   the shapes in the behaviour moduledoc (`:not_found`, `{:unavailable, _}`,
   `{:denied, _}`, `{:rate_limited, _}`, …), so retry policy is
-  provider-independent — and `{:error, :not_found}` is kept distinct from
+  provider-independent, and `{:error, :not_found}` is kept distinct from
   transient failure, which is what protects parked disks from being
   destroyed on a flaky network call.
 - **Network policy means what it says.** For a `limited` environment,
@@ -66,7 +66,7 @@ every conversation fails at provision time.
 
   On Sprites the endpoint defaults to requiring a platform credential, so
   Fountain opens it (`url_settings.auth = "public"`) when the sandbox is
-  created — an agent serving a page is doing it for a human who has no such
+  created, because an agent serving a page is doing it for a human who has no such
   credential. **Anything an agent serves is therefore reachable by anyone with
   the URL.** Set `config :fountain, :sprites_public_urls, false` to keep the
   default instead; sandboxes then keep their URLs but only a token holder can

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -2,16 +2,16 @@
 
 **Optional.** The subscription gate exists for the hosted service; billing is
 off by default (`BILLING_ENABLED=false`), and that is the right setting for
-most self-hosted instances — a gate with no checkout behind it is a lock with
+most self-hosted instances, because a gate with no checkout behind it is a lock with
 no key. Set this up only if you run Fountain commercially.
 
 ## Provider side
 
 1. **A product with a recurring price.** Its price ID (`price_…`) becomes
    `STRIPE_PRICE_ID`.
-2. **An API key** (Developers → API keys) — `STRIPE_SECRET_KEY`.
+2. **An API key** (Developers → API keys), as `STRIPE_SECRET_KEY`.
 3. **A webhook endpoint** pointed at `<PUBLIC_URL>/api/stripe/webhook`,
-   subscribed to:
+   subscribed to these events.
     - `checkout.session.completed`
     - `customer.subscription.created`
     - `customer.subscription.updated`
@@ -23,8 +23,8 @@ no key. Set this up only if you run Fountain commercially.
 
     Its signing secret becomes `STRIPE_WEBHOOK_SECRET`.
 
-    An existing endpoint keeps working without the three `invoice.*` events —
-    dunning state still syncs from the subscription events — but the SCA
+    An existing endpoint keeps working without the three `invoice.*` events,
+    since dunning state still syncs from the subscription events, but the SCA
     ("confirm your payment") email never fires and recovery notices depend
     solely on `customer.subscription.updated`. Add them when upgrading.
 
@@ -38,7 +38,7 @@ instance taking real money.
 | `BILLING_ENABLED` | `false` by default; `true` enforces the subscription gate on conversations |
 | `STRIPE_SECRET_KEY` | API key |
 | `STRIPE_WEBHOOK_SECRET` | Verifies webhook signatures; a bad signature is rejected with a 400 |
-| `STRIPE_PRICE_ID` | The price surfaced by Checkout. Unset with billing enabled, signups get a purely local 14-day trial and a logged warning — and Checkout is broken |
+| `STRIPE_PRICE_ID` | The price surfaced by Checkout. Unset with billing enabled, signups get a purely local 14-day trial and a logged warning, and Checkout is broken |
 
 ## Behavior worth knowing
 
@@ -52,7 +52,7 @@ instance taking real money.
   so Stripe redelivers.
 - Comped accounts are never overwritten by Stripe events.
 - `invoice.payment_failed` / `invoice.payment_action_required` drive dunning
-  and SCA emails but never write subscription status — that stays with the
+  and SCA emails but never write subscription status, which stays with the
   subscription events. `invoice.paid` writes status in exactly one case:
   `past_due → active` (dunning recovery), because Stripe also pays a $0
   invoice at trial creation and one per normal renewal, which must not touch
@@ -74,14 +74,14 @@ something you bolt onto an existing signup.
 
 ## Release verification: `mix fountain.verify_lifecycle`
 
-The Test Clock exercise above is automated as a repeatable command — run it
+The Test Clock exercise above is automated as a repeatable command. Run it
 before releasing **any billing-touching change**:
 
 ```bash
 STRIPE_SECRET_KEY=sk_test_... mix fountain.verify_lifecycle
 ```
 
-It creates a scratch user and a Test Clock, then walks the whole lifecycle —
+It creates a scratch user and a Test Clock, then walks the whole lifecycle,
 trial → T-3d warning email enqueued → expiry (gate refuses, trial-expired
 email) → paid subscription with a test card (gate opens) → cancel at period
 end (access retained, `cancel_at_period_end`/`current_period_end` synced) →
@@ -90,21 +90,21 @@ period end (gate refuses, cancellation email, flag cleared) → re-subscribe
 dunning: `past_due`, gate refuses, payment-failed email, and the real failed
 invoice fed through `invoice.payment_failed`) → dunning recovery (a working
 card pays the open invoice; `invoice.paid` flips `past_due → active`, the
-gate opens, payment-recovered email) — asserting the **Fountain-side** state
+gate opens, payment-recovered email), asserting the **Fountain-side** state
 at every step. Each fetched Stripe
 state is fed through `Billing.sync_subscription/1`, exactly what the webhook
 controller does after signature verification; webhook *delivery* needs a
 public endpoint and stays out of scope. Cleanup (clock + scratch user) runs
 even when a step fails.
 
-Notes:
+Four notes.
 
-- **Test-mode key only** — live keys are refused outright. The CLI's key
+- **Test-mode key only.** Live keys are refused outright. The CLI's key
   lives in `~/.config/stripe/config.toml` (`test_mode_api_key`) and expires
   every 90 days; an expired key fails the preflight with a `stripe login`
   hint rather than a misleading mid-run error.
 - Runs against the dev database; the scratch user is deleted afterwards.
-- Deliberately **not CI**: external, ~1–2 minutes of clock advances, needs a
+- Deliberately **not CI**, being external, about 1 to 2 minutes of clock advances, and needing a
   key. It is a release-check, run by a person (or an agent) with the result
   pasted into the PR that motivated it.
 - `STRIPE_PRICE_ID` is honored when set; otherwise a throwaway test-mode

--- a/docs/llm-integration.md
+++ b/docs/llm-integration.md
@@ -2,7 +2,7 @@
 
 Fountain is built to be consumed by AI coding tools. Every instance exposes machine-readable discovery endpoints so any agentic IDE can learn the full API from a single fetch.
 
-The examples below run against your own instance — point `FOUNTAIN_URL` at it:
+The examples below run against your own instance. Point `FOUNTAIN_URL` at it.
 
 ```bash
 FOUNTAIN_URL=http://localhost:4000

--- a/scripts/docs-style-allow.txt
+++ b/scripts/docs-style-allow.txt
@@ -10,10 +10,7 @@
 # rename cannot quietly re-exempt a page.
 docs/integrations/adding-a-sandbox-provider.md
 docs/integrations/buzz.md
-docs/integrations/editors.md
-docs/integrations/hermes.md
 docs/integrations/openbot.md
 docs/integrations/openclaw.md
 docs/integrations/runners.md
 docs/integrations/sprites-contract.md
-docs/integrations/stripe.md

--- a/scripts/docs-style-allow.txt
+++ b/scripts/docs-style-allow.txt
@@ -8,20 +8,12 @@
 #
 # The checker fails if a line here names a file that no longer exists, so a
 # rename cannot quietly re-exempt a page.
-docs/build/index.md
-docs/build/team-chat.md
-docs/integrations/acp.md
 docs/integrations/adding-a-sandbox-provider.md
 docs/integrations/buzz.md
-docs/integrations/clients.md
 docs/integrations/editors.md
 docs/integrations/hermes.md
-docs/integrations/index.md
-docs/integrations/mail.md
 docs/integrations/openbot.md
 docs/integrations/openclaw.md
 docs/integrations/runners.md
-docs/integrations/sandbox-contract.md
 docs/integrations/sprites-contract.md
 docs/integrations/stripe.md
-docs/llm-integration.md


### PR DESCRIPTION
Part of #911 and #903. Two commits, eleven pages.

**Backlog: 32 files → 6.** From ~560 real violations to ~120.

## What landed

`acp`, `sandbox-contract`, `clients`, `integrations/index`, `mail`,
`llm-integration`, `build/index`, `build/team-chat`, `stripe`, `hermes`,
`editors`. 87 dash edits plus nine colon-introduced lists.

## The counted lead-in caught a real error

This is the argument for that rule, and it showed up on its own.

Replacing `Why reach for it:` with `Three reasons to reach for it.` made me
count. `hermes.md` has **four**. It now says four.

The colon version could not have been wrong, because it asserted nothing. The
counted version is checkable, and it was checked, and it failed. That is the
whole point of ending a lead-in with a full stop.

## One list deliberately left uncounted

`stripe.md`'s webhook events read `subscribed to these events.` rather than
`eight events`, because that list grows with Stripe's API and a stale count is
worse than none. The rule is "end the lead-in with a full stop", not "always
put a number in it".

## Two other judgment calls

**`acp.md`'s H1** was `` `fountain acp` — the ACP agent reference `` and is now
`` `fountain acp`, the ACP agent reference ``. Nothing links to an H1 anchor
and the nav title is separate, so this is safe. Flagging it because a title
change looks riskier in a diff than it is.

**`mail.md`'s `EMAIL_FROM` default cell** read `— (required)`, a placeholder
carrying a qualifier, so the dash-only exemption from #924 correctly did *not*
apply. It is now bare `—` like every other row, and "required" was already
stated in the description column.

## A mistake I caught before pushing

I introduced one:

> `These are the operator's business, with one page per service covers what to
> create`

Not a sentence. Fixed to two. Mechanical prose surgery at this volume needs a
read-back, not just a passing checker — the checker is happy with ungrammatical
text as long as there is no dash in it.

## What is left

Six files, 176 sites: `buzz.md` (32), `openclaw.md` (28),
`sprites-contract.md` (27), `runners.md` (21), `openbot.md` (19),
`adding-a-sandbox-provider.md` (18).

## Verification

- `scripts/docs-style.py`: clean, 69 files checked
- `mkdocs build --strict`: clean
- `docs_test.exs` + `docs_controller_test.exs`: 32 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
