### PR TITLE
docs: generate the flag-complete CLI reference from the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,12 @@ jobs:
           echo "changed against ${base:0:7}:"
           printf '%s\n' "${changed}" | sed 's/^/  /'
 
+          # Both halves of the CLI reference: the hand-written index and the
+          # generated docs/cli/commands.md. The generated one matters here
+          # because a docs-only PR that hand-edits it would otherwise skip the
+          # Go tests entirely, and the staleness check lives in them.
           cli_docs=false
-          if printf '%s\n' "${changed}" | grep -qx 'docs/cli.md'; then
+          if printf '%s\n' "${changed}" | grep -qE '^docs/cli\.md$|^docs/cli/'; then
             cli_docs=true
           fi
 
@@ -1075,4 +1079,4 @@ jobs:
       - name: CLI docs parity
         if: ${{ needs.changes.outputs.cli_docs == 'true' }}
         working-directory: cli
-        run: go test ./internal/cmd -run 'TestEveryCommandIsDocumented|TestNoDocumentedCommandIsInvented'
+        run: go test ./internal/cmd -run 'TestEveryCommandIsDocumented|TestNoDocumentedCommandIsInvented|TestGeneratedCLIReferenceIsCurrent'

--- a/cli/internal/cmd/docsgen_test.go
+++ b/cli/internal/cmd/docsgen_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Generates docs/cli/commands.md from the real Cobra tree and fails when the
+// checked-in copy is stale. `go test ./internal/cmd/ -update-cli-docs` rewrites
+// it.
+//
+// WHY A SECOND CLI PAGE. docs/cli.md is hand-written and organised by what a
+// person is trying to do, and it stays that way. What it does not carry is
+// every flag: it shows the useful invocations, and `--help` was the only place
+// with the full list. That gap is what this file closes.
+//
+// The split is Fly.io's (fly.io/docs/flyctl/ is a task-grouped index over
+// generated per-command pages): human organisation in one file, machine truth
+// in the other, and neither pretending to be the other. The parity tests in
+// docs_test.go already read both, because readCLIDoc globs docs/cli/*.md.
+var updateCLIDocs = flag.Bool("update-cli-docs", false, "rewrite docs/cli/commands.md from the command tree")
+
+const cliDocsPath = "../../../docs/cli/commands.md"
+
+func TestGeneratedCLIReferenceIsCurrent(t *testing.T) {
+	want := renderCLIReference()
+
+	if *updateCLIDocs {
+		if err := os.MkdirAll(filepath.Dir(cliDocsPath), 0o755); err != nil {
+			t.Fatalf("creating docs/cli: %v", err)
+		}
+		if err := os.WriteFile(cliDocsPath, []byte(want), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", cliDocsPath, err)
+		}
+		t.Log("rewrote docs/cli/commands.md")
+		return
+	}
+
+	got, err := os.ReadFile(cliDocsPath)
+	if err != nil {
+		t.Fatalf("%s is missing (%v). Run: go test ./internal/cmd/ -update-cli-docs", cliDocsPath, err)
+	}
+
+	if string(got) != want {
+		t.Errorf(`docs/cli/commands.md is stale.
+
+It is generated from the Cobra tree, so a command or flag changed without it.
+Regenerate with:
+
+    cd cli && go test ./internal/cmd/ -update-cli-docs
+
+Do not hand-edit it. Prose about a command belongs in docs/cli.md.`)
+	}
+}
+
+func renderCLIReference() string {
+	var b strings.Builder
+
+	b.WriteString(`# All commands
+
+<!-- GENERATED FILE. Do not edit.
+
+     Rendered from the Cobra command tree by
+     cli/internal/cmd/docsgen_test.go. Regenerate with:
+
+         cd cli && go test ./internal/cmd/ -update-cli-docs
+
+     Prose about what a command is for, and which one to reach for, belongs in
+     the hand-written index at docs/cli.md. This file is the flag-complete
+     description and nothing else. -->
+
+Every command and every flag, generated from the binary. For what to reach for
+and why, start at the [CLI reference](../cli.md).
+
+`)
+
+	var leaves [][]string
+	walkCommands(rootCmd, nil, func(path []string) {
+		leaves = append(leaves, append([]string{}, path...))
+	})
+	sort.Slice(leaves, func(i, j int) bool {
+		return strings.Join(leaves[i], " ") < strings.Join(leaves[j], " ")
+	})
+
+	for _, path := range leaves {
+		cmd := findCommand(rootCmd, path)
+		if cmd == nil {
+			continue
+		}
+		full := "fountain " + strings.Join(path, " ")
+
+		fmt.Fprintf(&b, "## `%s`\n\n", full)
+
+		if s := strings.TrimSpace(cmd.Short); s != "" {
+			fmt.Fprintf(&b, "%s\n\n", s)
+		}
+		if l := strings.TrimSpace(cmd.Long); l != "" && l != strings.TrimSpace(cmd.Short) {
+			fmt.Fprintf(&b, "%s\n\n", l)
+		}
+
+		// UseLine() already carries the full path ("fountain conv show <id>"),
+		// so it is used as-is. Rewriting it to prepend the root name produced
+		// "fountain fountain acp", which TestNoDocumentedCommandIsInvented
+		// caught immediately: the parity tests read this file too.
+		fmt.Fprintf(&b, "```\n%s\n```\n\n", strings.TrimSpace(cmd.UseLine()))
+
+		if f := strings.TrimRight(cmd.NonInheritedFlags().FlagUsages(), "\n"); f != "" {
+			fmt.Fprintf(&b, "Options:\n\n```\n%s\n```\n\n", f)
+		}
+	}
+
+	inherited := strings.TrimRight(rootCmd.PersistentFlags().FlagUsages(), "\n")
+	if inherited != "" {
+		fmt.Fprintf(&b, "## Global flags\n\nAccepted by every command.\n\n```\n%s\n```\n", inherited)
+	}
+
+	return b.String()
+}
+
+func findCommand(c *cobra.Command, path []string) *cobra.Command {
+	cur := c
+	for _, name := range path {
+		var next *cobra.Command
+		for _, sub := range cur.Commands() {
+			if sub.Name() == name {
+				next = sub
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		cur = next
+	}
+	return cur
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,8 +4,12 @@ The `fountain` binary manages Fountain resources from the terminal or CI scripts
 It is a convenience wrapper over the REST API. Everything here can be done with
 `curl`.
 
-This page tracks the real command tree. If a command is not listed here it does
-not exist; `fountain <command> --help` is authoritative.
+This page is organised by what you are trying to do, and shows the useful
+invocations rather than every flag. For the flag-complete list, generated from
+the binary itself, see [All commands](cli/commands.md).
+
+If a command is not on one of these two pages it does not exist. A test walks
+the real command tree and fails either way round.
 
 ## Install
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -1,0 +1,393 @@
+# All commands
+
+<!-- GENERATED FILE. Do not edit.
+
+     Rendered from the Cobra command tree by
+     cli/internal/cmd/docsgen_test.go. Regenerate with:
+
+         cd cli && go test ./internal/cmd/ -update-cli-docs
+
+     Prose about what a command is for, and which one to reach for, belongs in
+     the hand-written index at docs/cli.md. This file is the flag-complete
+     description and nothing else. -->
+
+Every command and every flag, generated from the binary. For what to reach for
+and why, start at the [CLI reference](../cli.md).
+
+## `fountain acp`
+
+Speak the Agent Client Protocol on stdio (spawned by an editor)
+
+Speak the Agent Client Protocol on stdio.
+
+Not meant to be run by hand: an ACP-capable editor spawns this process and
+talks JSON-RPC to it over the pipe. stdout carries the protocol and nothing
+else; diagnostics go to stderr.
+
+--agent names the Fountain agent a session runs — the protocol has no field
+for it, so it is configured here. Point one editor entry at each agent you
+want to reach.
+
+--vault attaches a vault to every conversation this process opens. Vault
+values override the agent's environment, so this is where per-entry secrets
+belong — an identity the agent posts under, for instance. Two entries pointing
+at the same agent with different vaults stay separate; the same secret in a
+shared environment would not.
+
+--environment provisions every conversation this process opens from that
+environment instead of the agent's own. One agent config can then run under
+several environments — one entry per environment — without duplicating the
+agent. The vault still wins over it on key collision.
+
+What it is, and is not: a control surface for a conversation running in a
+Fountain sandbox — watch it, steer it, interrupt it. It has no access to the
+files open in your editor, and the paths it reports are inside the sandbox,
+not on your machine.
+
+```
+fountain acp [flags]
+```
+
+Options:
+
+```
+      --agent string         Fountain agent name or id to open sessions against
+      --environment string   environment name or id to provision each session's conversation from, instead of the agent's own
+      --log-level string     stderr log level: debug, info, warn, error (default "info")
+      --vault string         vault name or id to attach to each session's conversation
+```
+
+## `fountain agent list`
+
+List agents
+
+```
+fountain agent list [flags]
+```
+
+Options:
+
+```
+      --json   output JSON
+```
+
+## `fountain agent show`
+
+Show an agent
+
+```
+fountain agent show <id>
+```
+
+## `fountain apply`
+
+Apply resource definitions from a YAML file or directory
+
+```
+fountain apply [flags]
+```
+
+Options:
+
+```
+  -f, --file string   path to YAML file or directory
+      --var strings   extra variable for ${VAR} substitution (KEY=VAL, repeatable)
+```
+
+## `fountain auth login`
+
+Authenticate and save credentials
+
+```
+fountain auth login
+```
+
+## `fountain auth logout`
+
+Remove saved credentials
+
+```
+fountain auth logout
+```
+
+## `fountain auth whoami`
+
+Print current user info
+
+```
+fountain auth whoami
+```
+
+## `fountain buzz agents list`
+
+List hosted Buzz agents
+
+```
+fountain buzz agents list [flags]
+```
+
+Options:
+
+```
+      --json   output JSON
+```
+
+## `fountain buzz agents set-access`
+
+Change who may @-mention a hosted Buzz agent (restarts its harness)
+
+Set buzz-acp's inbound author gate on a hosted Buzz agent and restart its
+harness so it takes effect.
+
+  --respond-to  owner-only | allowlist | anyone | nobody
+  --allowlist   comma-separated 64-hex pubkeys (allowlist mode; required non-empty there)
+
+Note: a later provider deploy from the Buzz desktop resends the desktop's own
+record for the agent and overwrites what is set here.
+
+```
+fountain buzz agents set-access <name-or-id> [flags]
+```
+
+Options:
+
+```
+      --allowlist string    comma-separated 64-hex pubkeys admitted in allowlist mode
+      --respond-to string   owner-only | allowlist | anyone | nobody
+```
+
+## `fountain conv delete`
+
+Delete a conversation
+
+```
+fountain conv delete <id>
+```
+
+## `fountain conv interrupt`
+
+Interrupt the running turn
+
+```
+fountain conv interrupt <id>
+```
+
+## `fountain conv list`
+
+List conversations
+
+```
+fountain conv list [flags]
+```
+
+Options:
+
+```
+      --json   output JSON
+```
+
+## `fountain conv prompt`
+
+Send a prompt to a conversation and stream the result
+
+```
+fountain conv prompt <id> [flags]
+```
+
+Options:
+
+```
+  -i, --image strings   image file path (repeatable)
+  -p, --prompt string   prompt text (required)
+```
+
+## `fountain conv show`
+
+Show a conversation
+
+```
+fountain conv show <id>
+```
+
+## `fountain conv stream`
+
+Stream conversation events
+
+```
+fountain conv stream <id>
+```
+
+## `fountain conv terminate`
+
+Terminate a conversation
+
+```
+fountain conv terminate <id>
+```
+
+## `fountain env list`
+
+List environments
+
+```
+fountain env list [flags]
+```
+
+Options:
+
+```
+      --json   output JSON
+```
+
+## `fountain env show`
+
+Show an environment
+
+```
+fountain env show <id>
+```
+
+## `fountain keys create`
+
+Create a new API key
+
+```
+fountain keys create <name>
+```
+
+## `fountain keys list`
+
+List API keys
+
+```
+fountain keys list [flags]
+```
+
+Options:
+
+```
+      --json   output JSON
+```
+
+## `fountain keys revoke`
+
+Revoke an API key
+
+```
+fountain keys revoke <id>
+```
+
+## `fountain run`
+
+Run an agent (create conversation + stream until done)
+
+```
+fountain run <agent-name-or-id> [flags]
+```
+
+Options:
+
+```
+      --environment string   environment name or id to provision from, instead of the agent's own
+  -p, --prompt string        prompt text (required)
+      --vault string         vault name or id
+```
+
+## `fountain runner`
+
+Turn this machine into a sandbox provider for your Fountain agents
+
+Run this machine as a self-hosted Fountain runner.
+
+The daemon dials out to Fountain (no inbound port, works behind NAT), holds
+the connection, and serves sandboxes for agents whose sandbox_provider is
+"runner": each sandbox is a directory under --root, and the agent's processes
+run here, as you, with HOME pointed at that directory. Idle sandboxes park by
+stopping their processes; the directory — the agent's memory — stays.
+
+Trusted mode, and the only mode: there is no VM, container or egress policy
+between the agent and this machine. Run it on a machine you would hand a
+capable colleague a shell on. See docs/integrations/runners.md.
+
+Names are unique per account; a second daemon with the same name is refused.
+The default name is this machine's hostname.
+
+```
+fountain runner [flags]
+```
+
+Options:
+
+```
+      --log-level string   debug|info|warn|error (default "info")
+      --name string        runner name (default: the hostname, lowercased)
+      --root string        sandbox root (default: ~/.fountain/runners/<name>/sandboxes)
+```
+
+## `fountain vault create`
+
+Create a vault
+
+```
+fountain vault create <name> [flags]
+```
+
+Options:
+
+```
+      --description string   vault description
+```
+
+## `fountain vault delete`
+
+Delete a vault
+
+```
+fountain vault delete <id-or-name>
+```
+
+## `fountain vault delete-secret`
+
+Delete a vault secret
+
+```
+fountain vault delete-secret <id-or-name> <key>
+```
+
+## `fountain vault list`
+
+List vaults
+
+```
+fountain vault list [flags]
+```
+
+Options:
+
+```
+      --json   output JSON
+```
+
+## `fountain vault set-secret`
+
+Set a vault secret
+
+```
+fountain vault set-secret <id-or-name> <key> <value>
+```
+
+## `fountain vault show`
+
+Show a vault
+
+```
+fountain vault show <id-or-name>
+```
+
+## Global flags
+
+Accepted by every command.
+
+```
+      --profile string   credentials profile name
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - Sentry: integrations/sentry.md
   - Reference:
       - CLI: cli.md
+      - All CLI commands: cli/commands.md
       - API: api.md
       - TypeScript SDK: sdk.md
       - Conversation states: reference/conversation-states.md

--- a/scripts/docs-style.py
+++ b/scripts/docs-style.py
@@ -27,6 +27,12 @@ rule exists to stop a dash carrying a clause, which a lone cell cannot do.
 served at /docs or on the site. Style rules for published pages should not
 apply to a historical artifact nobody reads.
 
+A file whose first lines declare `<!-- GENERATED FILE` is skipped for the same
+reason code fences are: it quotes the world rather than describing it. Editing
+it would be undone by the next regeneration, and the fix belongs upstream in
+whatever renders it. Cleaning the *source* of a generated page is real work and
+belongs in its own change.
+
 THE RATCHET. Files listed in scripts/docs-style-allow.txt are skipped. That
 list is the pre-existing backlog (#911) and is only ever meant to shrink. A
 file NOT on the list is checked, so anything new is covered by default and
@@ -46,6 +52,10 @@ LIST_ITEM = re.compile(r"^\s*(?:[-*+]\s|\d+\.\s)")
 
 # Not in the nav, not served, not published. Historical planning material.
 EXCLUDED_DIRS = ("docs/superpowers/",)
+
+# Declared by a generated page in its own header, so adding one needs no edit
+# here. Checked against the first 2 KiB, which is past any front matter.
+GENERATED_MARKER = "<!-- GENERATED FILE"
 
 # A table cell holding nothing but a dash: `| — |`, `|—|`, and the row-start
 # and row-end variants. This is a placeholder for "none", not prose.
@@ -113,11 +123,15 @@ def check(path, rel):
 def main():
     allow = load_allowlist()
     failures = []
+    generated = []
     checked = 0
 
     for path in sorted(DOCS.rglob("*.md")):
         rel = str(path.relative_to(ROOT))
         if rel in allow or rel.startswith(EXCLUDED_DIRS):
+            continue
+        if GENERATED_MARKER in path.read_text()[:2048]:
+            generated.append(rel)
             continue
         checked += 1
         failures.extend(check(path, rel))
@@ -140,7 +154,11 @@ def main():
     if stale:
         return 1
 
-    print(f"docs style: clean ({checked} files checked, {len(allow)} on the backlog)")
+    note = f", {len(generated)} generated" if generated else ""
+    print(
+        f"docs style: clean ({checked} files checked, "
+        f"{len(allow)} on the backlog{note})"
+    )
     return 0
 
 


### PR DESCRIPTION
Part of #912 and #903. **The CLI half; the API half is separate.**

## The gap

`docs/cli.md` shows the useful invocations, organised by what a person is
trying to do. What it never carried is **every flag** — `--help` was the only
place with the full list.

`docs/cli/commands.md` is now rendered from the real Cobra tree, 393 lines,
every command and every flag.

## How it stays true

`cli/internal/cmd/docsgen_test.go` fails when the checked-in copy is stale.

```
cd cli && go test ./internal/cmd/ -update-cli-docs
```

The split is Fly.io's: `fly.io/docs/flyctl/` is a hand-written task-grouped
index over generated per-command pages, and neither file pretends to be the
other. One file rather than one per command, because 20 nav entries buy nothing
over 20 anchors and the nav parser takes one level of sections.

## Three things this needed beyond the generator

**The style checker now skips any page declaring `<!-- GENERATED FILE`** in its
first 2 KiB. The Go help strings carry em dashes, and editing the rendered
output would be undone by the next regeneration. Same reason code fences are
exempt: the page quotes the world rather than describing it. Cleaning the help
strings themselves is real work and belongs in its own change. The exemption
keys off a marker rather than a path, so adding a generated page needs no edit
to the checker.

**The `cli_docs` CI filter watched `docs/cli.md` alone.** A docs-only PR that
hand-edited the generated file would have skipped the Go tests entirely and
missed the staleness check. It now matches `docs/cli/` too, and the parity step
runs the staleness test alongside the two existing ones.

**`readCLIDoc` already globs `docs/cli/*.md`** since #916, so both parity tests
read the new file with no further change.

## The parity tests caught my first attempt

`UseLine()` already carries the full command path. Prepending the root name
produced `fountain fountain acp`, and:

```
--- FAIL: TestNoDocumentedCommandIsInvented
    docs_test.go:95: docs/cli.md documents a command that does not exist:
    "fountain fountain" (line: fountain fountain acp [flags])
```

That is the #916 change earning its keep on the first real use.

## Verification

Planted a fake command in the generated file and confirmed the staleness check
fails, then restored:

```
--- FAIL: TestGeneratedCLIReferenceIsCurrent
    docsgen_test.go:52: docs/cli/commands.md is stale.
```

- `go test ./internal/cmd/`: pass
- `go vet ./...`, `gofmt -l`: clean
- `scripts/docs-style.py`: clean, 75 files, 0 parked, 1 generated
- `mkdocs build --strict`: clean
- `docs_test.exs`: 25 tests, 0 failures

## What is left of #912

The API half. `docs/api.md` is 629 hand-written lines beside an OpenAPI spec
CI already validates. It is now clean prose and accurate, so this is less
urgent than it was, and it is a bigger lift than the CLI half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
