### PR TITLE
docs-redesign: mark the planning documents as executed, and correct two

### DIFF
--- a/docs-redesign/03-nav-tree.md
+++ b/docs-redesign/03-nav-tree.md
@@ -1,5 +1,10 @@
 # Deliverable 1: proposed nav tree
 
+> **Shipped with one change.** The `mkdocs.yml` nav parser takes one level of
+> sections and raises on anything deeper, so the Guides sub-groupings below
+> flattened into sibling sections. What shipped is `Concepts`, `Run an
+> instance`, `Troubleshooting`, `Catalog` and `Reference`. See #903.
+
 Every entry is labelled with its Diátaxis mode and its disposition.
 **KEEP**, **MOVE**, **SPLIT**, **MERGE**, **NEW**, **DELETE**.
 

--- a/docs-redesign/05-catalog-template.md
+++ b/docs-redesign/05-catalog-template.md
@@ -37,6 +37,13 @@ does not.
 
 ## Front matter, which is the whole point
 
+> **Deferred, and honestly so.** This section assumes index pages render from
+> front matter. Nothing in Fountain's MkDocs stack does that without a macros
+> plugin, which is not installed, so the catalog indexes that shipped in #915
+> and #920 are hand-written tables. Adding front matter now would be unused
+> metadata. The design below stands if a generator arrives; it is not a
+> prerequisite for writing entries.
+
 Every entry carries YAML front matter. The index pages, the badges, the
 filtering and the sort all read from it. Nothing about an entry is derived from
 its prose.

--- a/docs-redesign/README.md
+++ b/docs-redesign/README.md
@@ -1,5 +1,41 @@
 # Fountain docs: IA redesign and writing standards
 
+## Status
+
+**Mostly executed.** These were planning documents; `docs/` has since been
+rebuilt from them. Tracker: #903.
+
+| Shipped | Where |
+|---|---|
+| Concepts tree, tutorial promoted, `primitives.md` split | #901 |
+| `self-hosting.md` and `operations.md` split, Troubleshooting section | #913 |
+| The three missing explanation pages | #914 |
+| Catalog: runtimes and skills | #915 |
+| Catalog: the three MCP servers Fountain hosts | #920 |
+| Style checker, ratchet, and the whole backlog cleared | #917, #923 to #927 |
+| Generated flag-complete CLI reference | #928 |
+
+Still open: #906 (refile the 19 `integrations/` pages onto the entry
+template), #908 (a third-party MCP catalog, which needs a product decision),
+and the API half of #912.
+
+**Read these as the reasoning, not as the current state of `docs/`.** Where a
+plan below differs from what shipped, what shipped is right and the difference
+is noted inline. Two known divergences:
+
+- `03-nav-tree.md` groups Guides into sub-sections. The `mkdocs.yml` nav parser
+  takes **one level of sections** and raises on anything deeper, so those
+  flattened into sibling sections (`Run an instance`, `Troubleshooting`).
+- `05-catalog-template.md` treats YAML front matter as load-bearing, on the
+  assumption that index pages render from it. Nothing in this MkDocs stack
+  does that without a macros plugin, which is not installed. The catalog index
+  tables that shipped are hand-written. The front-matter design stands if a
+  generator ever arrives; until then it would be unused metadata.
+
+---
+
+The original note follows.
+
 Working documents, not yet a docs PR. Nothing under `docs/` has been changed.
 
 | File | What it is |


### PR DESCRIPTION
Part of #903. Small, and worth doing before the rest goes cold.

## Why

`02-audit.md` criticised documents that describe unbuilt behaviour as
existing, quoting the repo's own rule from `CLAUDE.md`. These were planning
documents, `docs/` has since been rebuilt from them, and leaving them reading
as a live plan is the same fault pointed the other way.

`README.md` now opens with what shipped and where, what is still open, and an
instruction to read the rest as reasoning rather than as the current state of
`docs/`.

## Two of my own proposals were wrong

Both now say so at the top of the file that contains them, not just in a note
at the end where I first recorded them.

**`03-nav-tree.md` groups Guides into sub-sections.** The `mkdocs.yml` nav
parser takes one level of sections and raises on anything deeper. Those
flattened into sibling sections (`Run an instance`, `Troubleshooting`).

**`05-catalog-template.md` calls YAML front matter "the whole point"**, on the
assumption that index pages render from it. Nothing in this MkDocs stack does,
without a macros plugin that is not installed. The catalog indexes that shipped
in #915 and #920 are hand-written tables, and adding front matter now would be
unused metadata.

That one is worth being plain about: it was aspirational when written, I
presented it as load-bearing, and it is labelled as deferred now. The design
stands if a generator ever arrives.

## Verification

- `scripts/docs-style.py`: clean
- `mkdocs build --strict`: clean

`docs-redesign/` is outside `docs_dir`, so none of this is published; it is
repo-internal reasoning that someone will read when they pick up #906 or #912.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
