### PR TITLE
docs: which Anthropic credential claude uses, and what happens when the org says no

### DIFF
--- a/docs/catalog/runtimes/claude.md
+++ b/docs/catalog/runtimes/claude.md
@@ -12,7 +12,7 @@
 | Skills root | `/home/sprite/.claude/skills` |
 | skills.sh agent | `claude-code` |
 | System prompt | `~/.claude/CLAUDE.md` |
-| Credential | An Anthropic API key or a Claude Code OAuth token |
+| Credential | A Claude Code OAuth token, or an Anthropic API key. See [which one it uses](#which-credential-it-uses) |
 
 ## Why you would pick this one
 
@@ -37,9 +37,48 @@ spec:
 The model must carry the `anthropic/` prefix. Anything else is rejected when
 you save the agent.
 
-Add your Anthropic key at `/account/inference-credentials` in the running app.
-An operator cannot set one for you. See
+Add your credential at `/account/inference-credentials` in the running app. An
+operator cannot set one for you. See
 [Services Fountain uses](../../integrations/index.md).
+
+## Which credential it uses
+
+Two kinds work, and if you have both on file **the OAuth token wins**.
+
+| Credential | Bills |
+|---|---|
+| Claude Code OAuth token | Your Claude.ai subscription (Pro or Team) |
+| Anthropic API key | Metered API usage |
+
+That preference is the reason the order matters to you rather than to
+Fountain. A subscription you are already paying for is usually the one you
+want spent.
+
+**Exactly one is exported into the sandbox, never both.** Claude Code prefers
+the OAuth path when it sees both, but which variable it actually picks has
+varied between CLI versions, so Fountain chooses one rather than letting the
+CLI decide.
+
+### When an organization disallows the subscription
+
+An Anthropic organization can disable Claude subscription access for Claude
+Code. When it has, a turn using the OAuth token fails with
+`oauth_org_not_allowed`.
+
+Fountain recovers rather than leaving you to work it out.
+
+- **With an API key on file**, the conversation switches to it and the turn
+  fails with a message saying so. Send the prompt again and it runs.
+- **Without one**, the turn fails with a message telling you to add one.
+
+Two details worth knowing about the recovery.
+
+**The turn still fails.** The switch is not a silent retry, so the failure and
+the fix are both in the transcript rather than only in a log nobody reads.
+
+**The switch lasts for that conversation, not forever.** A new conversation
+tries the OAuth token again, so an organization policy that is later reverted
+heals on its own instead of staying pinned to the fallback.
 
 ## Verify
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -29,7 +29,9 @@ operator.** There is no platform-level API key: each user brings their own
 credentials, entered at `/account/inference-credentials` in the running app
 (an Anthropic API key or Claude Code OAuth token, an OpenAI API key, a Gemini
 API key, validated against the provider on save, stored encrypted per
-tenant, and never echoed back).
+tenant, and never echoed back). With both Anthropic credentials on file the
+OAuth token is the one used, which bills a subscription rather than metered
+usage. See [which credential claude uses](../catalog/runtimes/claude.md#which-credential-it-uses).
 
 This is a deliberate design
 ([ADR 0008](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0008-byo-inference-credentials.md)):

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -13,6 +13,7 @@ means. Commands are shown for both deploy paths where they differ.
 |---|---|
 | A conversation sits in `running` with no output, or went `failed` | [A conversation is stuck or failed](conversation-stuck-or-failed.md) |
 | Provisioning fails while everything else is healthy | [Sandbox errors](sandbox-errors.md) |
+| A turn fails saying your organization disabled subscription access | [Which credential claude uses](../catalog/runtimes/claude.md#which-credential-it-uses) |
 | Pods restart, or sit NotReady | [Pods restarting or not ready](pods-restarting.md) |
 | Registration completes but nobody gets past "check your email" | [Nobody can log in](nobody-can-log-in.md) |
 | Everyone is rate-limited at once | [Nobody can log in](nobody-can-log-in.md) |


### PR DESCRIPTION
Follows #797. That fixed the behaviour; nothing told a user about it, and the
part they experience is a failed turn.

## Three undocumented facts, all with money attached

**The OAuth token wins when both are on file.**

| Credential | Bills |
|---|---|
| Claude Code OAuth token | Your Claude.ai subscription (Pro or Team) |
| Anthropic API key | Metered API usage |

Which one Fountain picks decides which of your two bills grows. `docs/`
previously said only "an Anthropic API key **or** a Claude Code OAuth token",
which is true and useless at the moment it matters.

**Exactly one is exported into the sandbox, never both.** Claude Code prefers
the OAuth path when it sees both, but which variable it actually picks has
varied between CLI versions, so Fountain chooses rather than letting the CLI
decide. Worth stating, because "I set both, why is only one used" is otherwise
a mystery with no visible answer.

**The org-disallows case now recovers, and the turn still fails.**

- **With an API key on file**, the conversation switches to it and the turn
  fails with a message saying so. Send the prompt again and it runs.
- **Without one**, the turn fails telling you to add one.

Two properties of that recovery are deliberate and non-obvious, so the page
says both:

- **The turn still fails**, rather than silently retrying, so the failure and
  the fix are both in the transcript instead of only in a log nobody reads.
- **The switch lasts for that conversation, not forever.** A new conversation
  tries the OAuth token again, so an org policy later reverted heals on its own
  rather than staying pinned to the fallback.

## Where it went

`catalog/runtimes/claude.md` gets the explanation, since that is where someone
choosing a runtime already is, and the At-a-glance credential row now points
at it instead of listing two options flatly.

`integrations/index.md` names the preference **at the point credentials are
entered**, which is the moment a user can act on it.

`troubleshooting/index.md` gains one symptom row, because "my organization
disabled subscription access" is something you meet in a failed turn, not while
reading about runtimes.

## Verification

Facts checked against source, not the PR description:

| Claim | Source |
|---|---|
| OAuth preferred, exactly one exported, and why | `runtimes/claude.ex` `default_env/2` |
| `oauth_org_not_allowed` detection | `runtimes/acp/peer.ex` |
| Fallback, its messages, and the per-conversation scope | `conversations/conversation_server.ex` |

- `scripts/docs-style.py`: clean, 75 files
- `mkdocs build --strict`: clean
- `docs_test.exs`: 32 tests, 0 failures, confirming all three new cross-page
  anchors resolve to real headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
