### PR TITLE
docs: give every catalog entry an At a glance box and a Related section

### DIFF
--- a/docs/integrations/buzz.md
+++ b/docs/integrations/buzz.md
@@ -55,6 +55,17 @@ inside Fountain and is used to sign; the sandbox never holds it.
 <figcaption><b>Four parties, and Fountain in the middle.</b> The owner provisions once; then Fountain speaks Nostr to the relay <em>as the agent</em>, drives the coding agent in a sandbox over ACP, and the sandbox asks Fountain to publish through an MCP tool, so it never touches the relay or the key itself.</figcaption>
 </figure>
 
+## At a glance
+
+| | |
+|---|---|
+| Direction | **Outbound.** Fountain hosts the agent and shows up on the relay |
+| Talks over | Nostr, with `buzz-acp` driving the runtime over ACP |
+| Provisioned from | The Buzz desktop, or `POST /api/buzz/agents` |
+| Credential | The agent's Nostr signing key, held in a [vault](../concepts/vault.md) |
+| Enabled by | Any image shipping the `buzz-acp` binary. No flag |
+| Publishing | Through the [fountain-buzz](../catalog/mcp-servers/fountain-buzz.md) MCP tools. The harness never publishes the agent's own text |
+
 ## What this is
 
 A Buzz agent on Fountain is a **`BuzzIdentity`**: a Nostr keypair bound to one of
@@ -427,3 +438,10 @@ Fountain-hosted MCP tool that signs with the vaulted key. Because every inbound
 turn arrives through the ACP-agent door, the conversation, its log events, its
 lifecycle and its audit trail all apply for free, being the same machinery every
 other Fountain surface uses.
+
+## Related
+
+- [fountain-buzz](../catalog/mcp-servers/fountain-buzz.md), the two publish
+  tools and why nothing is posted without them.
+- [About vaults](../concepts/vault.md), where the signing key lives.
+- [Plugging into Fountain](clients.md).

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -15,6 +15,18 @@ DAYTONA_SNAPSHOT=fountain          # a snapshot built from images/daytona/ (unse
 # SANDBOX_PROVIDER=daytona
 ```
 
+## At a glance
+
+| | |
+|---|---|
+| Role | Sandbox provider, and the closest semantic match to the contract |
+| Enabled by | `DAYTONA_API_KEY` |
+| Env vars | `DAYTONA_API_KEY`, `DAYTONA_SNAPSHOT`, `DAYTONA_API_URL` |
+| Suspend | Explicit stop, disk preserved, archiving when long-parked |
+| Capabilities advertised | `:suspend`, `:network_policy`, `:attach` |
+| Self-hostable | Yes, via `DAYTONA_API_URL` |
+| Needs first | A snapshot built from `images/daytona/`. The stock image lacks the agent CLIs |
+
 ## Snapshot
 
 The stock image does not carry the agent CLIs. Build the reference snapshot
@@ -48,3 +60,15 @@ daytona snapshot create fountain --dockerfile Dockerfile
   environments behave unexpectedly.
 - **Reaper**: reconciliation lists `fountain`-labeled sandboxes only; other
   sandboxes in the organization are never touched.
+
+## Verify
+
+Create a conversation on an agent pinned to `daytona` and watch it reach its
+first turn. Anything short of that is a provisioning failure, and the stage
+events name the step.
+
+## Related
+
+- [About sandboxes](../concepts/sandboxes.md).
+- [The sandbox contract](sandbox-contract.md).
+- [Sandbox errors](../troubleshooting/sandbox-errors.md).

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -14,6 +14,17 @@ E2B_TEMPLATE=fountain        # a template built from images/e2b/ (see below)
 # SANDBOX_PROVIDER=e2b       # make it the instance default
 ```
 
+## At a glance
+
+| | |
+|---|---|
+| Role | Sandbox provider |
+| Enabled by | `E2B_API_KEY` |
+| Env vars | `E2B_API_KEY`, `E2B_TEMPLATE`, `E2B_BASE_URL` |
+| Suspend | Explicit pause, snapshotting filesystem **and memory** |
+| Capabilities advertised | `:suspend`, `:network_policy`, `:attach` |
+| Needs first | A template built from `images/e2b/`. The stock `base` lacks the agent CLIs |
+
 ## Template
 
 The stock `base` template does not carry the agent CLIs. Build the reference
@@ -50,3 +61,15 @@ the four agent CLIs, so no per-provider provisioning code exists.
 - **Egress**: the callback host (`PUBLIC_URL`) must be reachable from
   inside; `limited` environments get it via the same allowlist mechanics as
   Sprites.
+
+## Verify
+
+Create a conversation on an agent pinned to `e2b` and watch it reach its first
+turn. Anything short of that is a provisioning failure, and the stage events
+name the step.
+
+## Related
+
+- [About sandboxes](../concepts/sandboxes.md).
+- [The sandbox contract](sandbox-contract.md).
+- [Sandbox errors](../troubleshooting/sandbox-errors.md).

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -13,6 +13,17 @@ the pipe. That process talks HTTP and SSE to your Fountain instance.
    (ACP over stdio)                                                  (the agent)
 ```
 
+## At a glance
+
+| | |
+|---|---|
+| Direction | Inbound. The editor drives Fountain |
+| Talks over | [`fountain acp`](acp.md), spawned locally |
+| Set up on | The developer's machine |
+| Credential | Whatever `fountain auth login` already saved |
+| Configured per | Agent. One editor entry per agent you want to reach |
+| Operator setup | None |
+
 ## What this is, and is not
 
 It is a **control surface for a remote conversation**. The agent runs in a
@@ -186,3 +197,9 @@ makes it an ACP *agent* for editors. Together they make Fountain a proxy: the
 same block vocabulary arrives from a sandbox on one side and leaves for an
 editor on the other, so the adapter forwards updates rather than translating
 them, and no runtime's output format is parsed twice.
+
+## Related
+
+- [`fountain acp`](acp.md), the protocol surface in full.
+- [OpenClaw](openclaw.md), the same adapter from a chat surface.
+- [Plugging into Fountain](clients.md).

--- a/docs/integrations/github-oauth.md
+++ b/docs/integrations/github-oauth.md
@@ -3,6 +3,17 @@
 **Optional.** Adds "Continue with GitHub" to the login and registration pages.
 Email + password auth works without it.
 
+## At a glance
+
+| | |
+|---|---|
+| Required | No |
+| Provider | A GitHub OAuth app |
+| Env vars | `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET` |
+| Scope requested | `user:email` |
+| Callback | `<PUBLIC_URL>/auth/oauth/github/callback` |
+| Without it | Email and password auth only, with no dead-end button |
+
 ## Provider side
 
 Create an OAuth app at
@@ -45,3 +56,18 @@ GitHub button.
 Sign in with the button. The audit log (`/audit`) records
 `auth.oauth.signup` or `auth.oauth.login`; rejections are recorded as
 `auth.oauth.rejected` with the reason.
+
+## Limits
+
+**A GitHub outage breaks the button and nothing else.** Email and password
+auth is unaffected, so an instance with both is not single-homed on GitHub.
+
+**The button is all-or-nothing.** There is no per-user or per-domain gate on
+who may use it, beyond `REGISTRATION_ALLOWED_EMAIL_DOMAINS`.
+
+## Related
+
+- [Nobody can log in](../troubleshooting/nobody-can-log-in.md), where OAuth is
+  the way back in when mail is broken.
+- [Put it on the internet](../guides/operate/put-it-on-the-internet.md).
+- [Services Fountain uses](index.md).

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -32,6 +32,17 @@ Four reasons to reach for it.
   conversation is open in the Fountain conversations app while it runs.
 - **Fan-out is a loop of tool calls**, not orchestration code.
 
+## At a glance
+
+| | |
+|---|---|
+| Direction | Inbound. Hermes delegates to Fountain |
+| Talks over | The HTTP API, through a plugin |
+| Set up on | The Hermes host |
+| Plugin | Ships in this repo, under `integrations/hermes/` |
+| Credential | An API key, or the CLI's saved login |
+| Operator setup | None |
+
 ## Setup
 
 1. Credentials. On the Hermes host either export a key,
@@ -135,3 +146,9 @@ environment's setup script.
 The plugin source and its tests are at
 [`integrations/hermes/`](https://github.com/BinaryBourbon/fountain/tree/main/integrations/hermes)
 in the Fountain repo.
+
+## Related
+
+- [API reference](../api.md), which is everything the plugin wraps.
+- [TypeScript SDK](../sdk.md), if you are building the same thing in TS.
+- [Plugging into Fountain](clients.md).

--- a/docs/integrations/mail.md
+++ b/docs/integrations/mail.md
@@ -4,6 +4,16 @@
 because a silently discarded verification email dead-ends signup with no
 visible error. There are exactly three options, checked in this order:
 
+## At a glance
+
+| | |
+|---|---|
+| Required | **A decision, yes.** Production refuses to boot without one of the three |
+| Options | Resend, any SMTP server, or none |
+| Env vars | `RESEND_API_KEY` *or* `SMTP_*` *or* `EMAIL_DELIVERY=none`, plus `EMAIL_FROM` |
+| Precedence | Checked in the order below. Resend wins if several are set |
+| Without it | Production will not start |
+
 ## Option 1: Resend
 
 | Variable | Effect |
@@ -59,3 +69,10 @@ Register a throwaway account and confirm the verification email arrives.
 check spam, which is where an unverified sending domain lands. On a running
 instance, boot logs state the chosen mode (`EMAIL_DELIVERY=none` prints its
 notice to stderr; a missing configuration refuses to boot and says so).
+
+## Related
+
+- [Configure email](../guides/operate/email.md), the operator guide.
+- [Nobody can log in](../troubleshooting/nobody-can-log-in.md), which is
+  usually this.
+- [Services Fountain uses](index.md).

--- a/docs/integrations/openbot.md
+++ b/docs/integrations/openbot.md
@@ -21,6 +21,17 @@ The endpoint is not OpenBot-specific. Any AG-UI host, whether a hand-written
 client or another product built on the protocol, registers a Fountain agent the same
 way. OpenBot is the host it was built and verified against, nothing more.
 
+## At a glance
+
+| | |
+|---|---|
+| Direction | Inbound. OpenBot drives Fountain |
+| Talks over | [AG-UI](https://github.com/ag-ui-protocol/ag-ui) at `POST /api/agui/:agent_id` |
+| Set up on | The OpenBot host |
+| Plugin | None. A URL is the whole integration |
+| Credential | An API key held by the coworker |
+| Binding | One channel is one conversation is one sandbox |
+
 ## Set it up
 
 You need two things from Fountain: the agent's id, and an API key.
@@ -202,3 +213,10 @@ curl -N -X POST "https://your-fountain/api/agui/<agent_id>" \
 A healthy run is `RUN_STARTED`, some `TEXT_MESSAGE_*`, then `RUN_FINISHED`.
 Each SSE message is `data: {"type": ...}`, so the type is inside the JSON, which
 is what the reference AG-UI encoder writes and every client parses.
+
+## Related
+
+- [Agents as teammates](../concepts/teammates.md), the same
+  one-channel-one-conversation idea inside Fountain.
+- [API reference](../api.md).
+- [Plugging into Fountain](clients.md).

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -18,6 +18,17 @@ ACP over stdio. So the integration is a config block, not code.
    (a chat channel)   (ACP over stdio)                                        (the agent)
 ```
 
+## At a glance
+
+| | |
+|---|---|
+| Direction | Inbound. OpenClaw drives Fountain |
+| Talks over | [`fountain acp`](acp.md), via OpenClaw's `acpx` plugin |
+| Set up on | The OpenClaw host |
+| Credential | Whatever `fountain auth login` saved there |
+| Needs | Node 22.22.3 or newer (or 24.15+, 25.9+) |
+| Operator setup | None. The configuration is client-side |
+
 ## What this is, and is not
 
 It is a **chat front-end for a remote conversation.** OpenClaw handles the
@@ -269,3 +280,9 @@ arrives from a sandbox on one side and leaves for the client on the other, so
 the adapter forwards updates rather than translating them. OpenClaw is one more
 client on that far side. See the
 [2026-08-16 addendum to 0015](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0015-fountain-as-an-acp-agent.md#addendum--2026-08-16-openclaw-is-another-acp-client-spike-verified).
+
+## Related
+
+- [`fountain acp`](acp.md), the protocol surface in full.
+- [Editors](editors.md), the same adapter from an editor.
+- [Plugging into Fountain](clients.md).

--- a/docs/integrations/runners.md
+++ b/docs/integrations/runners.md
@@ -19,6 +19,18 @@ Three reasons to want one.
 
 The design is [ADR 0022](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0022-self-hosted-runner-provider.md).
 
+## At a glance
+
+| | |
+|---|---|
+| Role | Sandbox provider, on a machine **you** own |
+| Enabled by | Nothing. On unless `SANDBOX_RUNNERS_ENABLED=false` |
+| Credential | None platform-side. Each daemon uses the user's own full-scope API key |
+| Suspend | Stops the sandbox's processes. The directory stays |
+| Capabilities advertised | `:suspend`, `:attach` |
+| Not advertised | Network policy, TTY, checkpoints, public URL |
+| Isolation | **None.** Trusted mode, agent processes run as you |
+
 ## Read this first: trusted mode
 
 A runner sandbox is a **directory** on the machine, and the agent's
@@ -144,3 +156,12 @@ stdin_close detach list_sessions attach`. Errors are the contract's codes
 `cli/internal/runner` the daemon, and `Fountain.Runners.FakeDaemon`, an
 in-BEAM daemon the conformance suite runs against, is the executable
 description both must agree with.
+
+## Related
+
+- [About sandboxes](../concepts/sandboxes.md), for why honest capabilities
+  change the lifecycle.
+- [The sandbox contract](sandbox-contract.md).
+- [Change sandbox lifetimes](../guides/operate/sandbox-lifetime.md), because a
+  provider without `:suspend` would destroy on idle. A runner does advertise
+  it.

--- a/docs/integrations/sentry.md
+++ b/docs/integrations/sentry.md
@@ -4,6 +4,16 @@
 configured but does nothing. No account, no events, nothing leaves your
 instance.
 
+## At a glance
+
+| | |
+|---|---|
+| Required | No |
+| Provider | sentry.io, or anything Sentry-API-compatible such as GlitchTip |
+| Env vars | `SENTRY_DSN`, `SENTRY_ENVIRONMENT` |
+| Rate limit | 20 events per minute |
+| Without it | The SDK is inert and nothing leaves the instance |
+
 ## Provider side
 
 Create a project (platform: Elixir) on [sentry.io](https://sentry.io) or any
@@ -44,3 +54,20 @@ deployment uses for its nightly `pg_dump` is reusable for any scheduled job.
 
 Set the DSN, restart, and cause any error. It appears in the project within
 seconds, tagged with environment and release. Unset it and nothing does.
+
+## Limits
+
+**Nothing is sent until you set a DSN.** Unset, the SDK is inert rather than
+buffering, so there is no backlog to flush when you turn it on.
+
+**Tenant data is deliberately withheld.** Cookies, user IPs and request bodies
+are not attached, because this app holds other people's secrets. That also
+means a report carries less context than a stock Sentry integration would.
+
+## Related
+
+- [Wire up observability](../guides/operate/observability.md), including the
+  alerting pack.
+- [Back up and restore](../guides/operate/back-up-and-restore.md), which uses
+  the Crons pattern below.
+- [Services Fountain uses](index.md).

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -10,6 +10,17 @@ The exact API surface Fountain consumes, and what a compatible replacement
 behind `SPRITES_BASE_URL` would have to provide, is written down in
 [the Sprites transport reference](sprites-contract.md).
 
+## At a glance
+
+| | |
+|---|---|
+| Role | Sandbox provider, and the instance default |
+| Enabled by | `SPRITES_TOKEN` |
+| Env vars | `SPRITES_TOKEN`, `SPRITES_BASE_URL`, `SPRITES_TIMEOUT_MS` |
+| Suspend | Parks implicitly. The sprite scales itself to zero, disk preserved |
+| Capabilities advertised | `:suspend`, `:network_policy`, `:attach`, `:tty`, `:public_url`, and `:checkpoint` (off by default, #654) |
+| Billed to | One platform token, so the operator, not the tenant |
+
 ## Provider side
 
 Create a sprites.dev account and issue an API token. That token is the whole
@@ -47,3 +58,10 @@ missing token surfaces as the `provision` stage failing, visible in the
 conversation's log view. A Sprites outage does not affect anything else,
 sign-in, dashboards and configuration keep working, and the health endpoints
 deliberately do not consult Sprites.
+
+## Related
+
+- [About sandboxes](../concepts/sandboxes.md), for what a provider is.
+- [The sandbox contract](sandbox-contract.md), and the
+  [Sprites transport reference](sprites-contract.md) for the wire protocol.
+- [Sandbox errors](../troubleshooting/sandbox-errors.md).

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -5,6 +5,16 @@ off by default (`BILLING_ENABLED=false`), and that is the right setting for
 most self-hosted instances, because a gate with no checkout behind it is a lock with
 no key. Set this up only if you run Fountain commercially.
 
+## At a glance
+
+| | |
+|---|---|
+| Required | No, and off by default |
+| Provider | Stripe |
+| Env vars | `BILLING_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID` |
+| Webhook | `<PUBLIC_URL>/api/stripe/webhook` |
+| Without it | No billing, which is correct for most self-hosted instances |
+
 ## Provider side
 
 1. **A product with a recurring price.** Its price ID (`price_…`) becomes
@@ -109,3 +119,9 @@ Four notes.
   pasted into the PR that motivated it.
 - `STRIPE_PRICE_ID` is honored when set; otherwise a throwaway test-mode
   product/price is created under the clock's lifetime.
+
+## Related
+
+- [Turn on billing](../guides/operate/billing.md), the operator guide,
+  including the backfill existing accounts need.
+- [Services Fountain uses](index.md).


### PR DESCRIPTION
**Closes #906.**

## First, a correction to my own issue

#906 says "the 19 `integrations/` pages". **Only 13 are catalog entries.** The
other six are a different Diátaxis mode, and forcing them into an entry
template would be exactly the mode-mixing this whole redesign was against:

| Page | Actually |
|---|---|
| `acp.md`, `sprites-contract.md` | protocol reference |
| `sandbox-contract.md`, `platform-requirements.md` | explanation |
| `adding-a-sandbox-provider.md` | contributor how-to |
| `clients.md`, `index.md` | hubs |

They are left alone deliberately. That correction is the main finding.

## What the 13 entries got

**At a glance**, on all 13. None had one.

Segment's move from `connections/destinations/catalog/actions-slack/`: machine
facts hoisted above the prose, so "what does this need, and what does it do" is
answerable without reading the page. For a provider that is the capability set
and the suspend semantics; for a client, the direction, the transport, and who
holds the credential.

**Related**, on all 13. None had one either. An entry that does not point at
its siblings and its concept page sends the reader back to an index every time.

**Limits**, added to `github-oauth` and `sentry`.

**Verify**, added to `e2b` and `daytona`.

## What I deliberately did not add

**Limits on the other five.** `mail`, `stripe`, `sprites`, `daytona` and
`runners` state their constraints inline already. A thin `## Limits` heading
over restated or invented content is worse than no heading, and the template
exists to make pages scannable, not to make them uniform.

**Verify on the clients.** "Does your editor talk to it" is not a check I can
write generically, and the five client pages already end with real
verification or troubleshooting sections of their own.

Page bodies are untouched throughout. This is additive.

## One claim corrected while cross-checking

The sprites At-a-glance first listed `:checkpoint` flatly.
`sandbox-contract.md` says checkpoint warm starts are Sprites-only **and off by
default** (#654 — a checkpoint id is scoped to the sprite that created it, so
cross-sprite warm starts cannot work). The row says so now.

Every capability set was checked against `sandbox-contract.md`, and the runner
one against its own contract table, rather than written from memory.

## Verification

- `scripts/docs-style.py`: clean, 75 files
- `mkdocs build --strict`: clean
- `docs_test.exs` + `docs_controller_test.exs`: 32 tests, 0 failures, which is
  what confirms the new cross-page links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
