### PR TITLE
Say why a nested docs nav section is rejected, and stop promoting one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,11 @@ in-app manual at `/docs` — the same markdown is embedded at compile time by
   the docs. Keep to the two line shapes the parser reads — `  - Title: x.md`,
   and a `  - Section:` header with six-space-indented children — because a
   line it cannot read raises at compile time rather than being skipped.
+  **Sections are one level deep.** MkDocs nests as deep as you like, but the
+  in-app sidebar renders exactly a section and its pages, so a sub-section (or
+  a page indented past its siblings) raises too. Flatten it into a sibling
+  section — `Catalog` is what that looks like, with the three hub pages sitting
+  among their own entries — or make it headings on a hub page.
 - **Anything `Fountain.Docs` reads at compile time must be `COPY`d into the
   Docker build stage.** The release image contains no `docs/`, only strings
   baked out of it, so a file outside the `COPY` list does not degrade to a

--- a/apps/fountain/lib/fountain/docs/compiler.ex
+++ b/apps/fountain/lib/fountain/docs/compiler.ex
@@ -31,6 +31,12 @@ defmodule Fountain.Docs.Compiler do
   the bug this parser exists to make impossible, so being unable to parse the
   nav has to fail the compile, not shrink the site.
 
+  Two levels is the whole depth. MkDocs nests as deep as you like; the in-app
+  sidebar at `/docs` renders exactly a section and its pages, so a third tier
+  raises here with a message that says to flatten it. That includes a page
+  indented past its siblings, which would otherwise be quietly promoted into
+  its grandparent section — the one silent outcome this parser must not have.
+
   This replaced a hand-maintained copy of the nav in `Fountain.Docs`. Adding a
   page to `mkdocs.yml` is now the whole change.
   """
@@ -51,6 +57,9 @@ defmodule Fountain.Docs.Compiler do
     |> Enum.reject(&(String.trim(&1) == "" or String.starts_with?(String.trim(&1), "#")))
   end
 
+  # A section accumulates as `{title, reversed_children, child_indent}`; the
+  # indent is remembered so a deeper line is caught rather than promoted, and
+  # dropped again by `finish_nav/1`.
   defp nav_entry(line, acc) do
     case Regex.run(~r/^(\s+)- ([^:]+):\s*(\S+)?\s*$/, line) do
       # `  - Setup: setup.md` — a top-level page.
@@ -59,28 +68,57 @@ defmodule Fountain.Docs.Compiler do
 
       # `  - Sandbox providers:` — a section header; its children follow.
       [_, indent, title] when byte_size(indent) == 2 ->
-        [{title, []} | acc]
+        [{title, [], nil} | acc]
 
       # `      - Sprites: integrations/sprites.md` — a child of the section
       # currently being built.
       [_, indent, title, file] when byte_size(indent) > 2 ->
-        case acc do
-          [{section, children} | rest] when is_list(children) ->
-            [{section, [{title, file} | children]} | rest]
+        add_child(acc, byte_size(indent), title, file, line)
 
-          _ ->
-            raise ArgumentError, "indented nav entry with no section above it: #{inspect(line)}"
-        end
+      # `      - Sandbox providers:` — a section inside a section, which this
+      # parser has no shape for.
+      [_, indent, _title] when byte_size(indent) > 2 ->
+        raise ArgumentError, one_level_message("nested nav section", line)
 
       _ ->
         raise ArgumentError, "unparsed mkdocs.yml nav line: #{inspect(line)}"
     end
   end
 
+  defp add_child([{section, children, indent} | rest], indent, title, file, _line) do
+    [{section, [{title, file} | children], indent} | rest]
+  end
+
+  defp add_child([{section, children, nil} | rest], indent, title, file, _line) do
+    [{section, [{title, file} | children], indent} | rest]
+  end
+
+  defp add_child([{_section, _children, _sibling_indent} | _rest], _indent, _title, _file, line) do
+    raise ArgumentError, one_level_message("nav entry indented past its siblings", line)
+  end
+
+  defp add_child(_acc, _indent, _title, _file, line) do
+    raise ArgumentError, "indented nav entry with no section above it: #{inspect(line)}"
+  end
+
+  # The one thing a reader of either raise needs to know: the limit is ours,
+  # not MkDocs', and flattening is the fix. Without this they go looking for a
+  # typo in a line that is perfectly good YAML.
+  defp one_level_message(what, line) do
+    """
+    #{what}: #{inspect(line)}
+
+    mkdocs.yml nav sections are one level deep. MkDocs itself nests freely, but
+    Fountain.Docs embeds the nav for the in-app sidebar at /docs, which renders
+    exactly two levels. Flatten this into a sibling top-level section, or make
+    it headings on a hub page.
+    """
+  end
+
   defp finish_nav(acc) do
     acc
     |> Enum.map(fn
-      {section, children} when is_list(children) -> {section, Enum.reverse(children)}
+      {section, children, _child_indent} -> {section, Enum.reverse(children)}
       entry -> entry
     end)
     |> Enum.reverse()

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -203,6 +203,44 @@ defmodule Fountain.DocsTest do
       end
     end
 
+    test "a section inside a section raises, naming the one-level limit" do
+      yaml = """
+      nav:
+        - Section:
+            - Subsection:
+                - Child: a/b.md
+      """
+
+      assert_raise ArgumentError, ~r/nav sections are one level deep/, fn ->
+        Compiler.parse_nav(yaml)
+      end
+    end
+
+    test "a page indented past its siblings raises rather than being promoted" do
+      yaml = """
+      nav:
+        - Section:
+            - Child: a/b.md
+                - Grandchild: a/c.md
+      """
+
+      assert_raise ArgumentError, ~r/nav sections are one level deep/, fn ->
+        Compiler.parse_nav(yaml)
+      end
+    end
+
+    test "a section's children may sit at any one indent, as long as it is one" do
+      yaml = """
+      nav:
+        - Section:
+          - First: a/b.md
+          - Second: a/c.md
+      """
+
+      assert Compiler.parse_nav(yaml) ==
+               [{"Section", [{"First", "a/b.md"}, {"Second", "a/c.md"}]}]
+    end
+
     test "a file with no nav: block raises" do
       assert_raise ArgumentError, ~r/no `nav:` block/, fn ->
         Compiler.parse_nav("site_name: Fountain\n")


### PR DESCRIPTION
An agent auditing the docs flagged that our nav only supports one tier of depth
(`docs-redesign/02-audit.md:276`, and again in `03-nav-tree.md:240` under "two
constraints that carry code changes"). This is that finding, answered.

**The limit stays.** MkDocs nests freely, but the in-app sidebar at `/docs` is a
224px column that renders exactly a section and its pages, with no collapse. A
third tier there is a UI design problem, not a parsing one, and no page is
blocked today. What was wrong is that the limit was invisible from the outside.

### What changes

1. A sub-section header raised the generic `unparsed mkdocs.yml nav line`, which
   sends the reader hunting for a typo in a line that is perfectly good YAML. It
   now says the nav is one level deep, that the limit is ours rather than
   MkDocs', and names the two ways out (a sibling section, or headings on a hub
   page).

2. **A bug.** The child clause was guarded only on `indent > 2`, so a page
   indented past its siblings was silently promoted into its grandparent
   section. That is the one outcome this parser exists to prevent — its own
   docstring says a page silently missing from `/docs` is the bug it makes
   impossible. Sections now carry their children's indent while accumulating and
   `finish_nav/1` drops it, so the shape `Fountain.Docs` consumes is unchanged:
   `nav/0`, `flat_pages/1` and the sidebar template needed no edits.

`CLAUDE.md` now states the rule, pointing at `Catalog` as what flattening looks
like in practice.

### Why now

The constraint has shaped the nav twice. The redesign flattened
`Guides > Operate > page` into "Run an instance", 13 siblings; and `Catalog`,
which landed after the audit, lists its three hub pages (`Runtimes`, `Skills`,
`MCP servers`) as peers of their own entries. Both readings are defensible, but
whoever makes the next one should hit a message that explains the choice instead
of a parse error.

### Verification

Three tests: the nested section raises, the over-indented page raises, and a
section whose children sit at a 4-space indent still parses — the check is "one
consistent indent", not a hardcoded depth.

I reverted the parser to `main`'s and re-ran them. The nested-section test fails
on the message; the over-indented one fails with *"Expected exception
ArgumentError but nothing was raised"*, which is the silent promotion, observed.

Locally green: `format --check-formatted`, `compile --warnings-as-errors`,
`credo --strict`, `dialyzer`, and the full suite (3,289 tests). The compile is
itself a check — `Fountain.Docs` parses the real `mkdocs.yml` at compile time,
so the current nav still parses to the same thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)