### PR TITLE
docs: fix the home page's first screen — an unrunnable command, and the wrong story

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,12 +9,15 @@ with the environment variables, MCP servers, skills, repos and packages that
 you configured once.
 
 !!! tip "In a hurry?"
-    Install the CLI and point it at a Fountain instance.
+    Install the CLI and log in. For your own instance, set `FOUNTAIN_BASE_URL`
+    first, because the CLI defaults to the hosted one.
     ```sh
     brew install BinaryBourbon/tap/fountain
     fountain auth login
-    fountain apply -f agent-specs
+    fountain auth whoami
     ```
+    The CLI now works, and you have no agent to run yet. The
+    [guided tour](tour.md) builds the first one.
 
 ## The problem
 


### PR DESCRIPTION
The home page's "In a hurry?" box ended on a command the reader cannot run.

```sh
brew install BinaryBourbon/tap/fountain
fountain auth login
fountain apply -f agent-specs      # ← no reader has this directory
```

Three things are wrong with that last line.

Nobody has an `agent-specs` directory. The page never supplies one, and the
phrase appears nowhere else in `docs/`.

It introduces spec-driven configuration with no specs, as the first thing a
newcomer is asked to do.

It was also the only line making the sequence look complete, which hid the
real gap: **the CLI cannot create an agent at all.** Agents are read-only from
the CLI, so `apply` or the REST API is the only route. There is no
CLI-only path from a fresh install to a first agent.

## What it says now

```sh
brew install BinaryBourbon/tap/fountain
fountain auth login
fountain auth whoami
```

Three lines that all run. The box then says plainly that there is no agent
yet, and sends the reader to the [guided tour](https://binarybourbon.github.io/fountain/tour/),
which builds one in about forty lines.

It also names the `FOUNTAIN_BASE_URL` trap up front. The CLI's built-in
default is the hosted instance, so a self-hoster who exports a key before
setting the URL sends that key to `fountain.inevitable.fyi`. That warning was
buried at the bottom of the CLI reference; it belongs where somebody first
runs `auth login`.

## Verified against the source, not the docs

`index.md` is not covered by the CLI parity test, so both claims were checked
in `cli/internal/cmd/auth.go`:

- `whoami` exists (`auth.go:39`).
- `auth login` writes `base_url` into the saved profile, so setting
  `FOUNTAIN_BASE_URL` before login is genuinely the fix and not repeated lore.

Gates: `vale lint docs`, `scripts/docs-style.py`, `mkdocs build --strict`, and
both docs test files (35 tests).

## Deliberately not in this change

A spec-driven introduction is worth having. It needs specs to hand the reader
first — a real `agent-specs` directory in the repo, or an inline manifest — so
it is its own change rather than a line that points at a directory that does
not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Second commit: the framing was wrong too

The problem section assumed the reader personally runs a coding agent on a
laptop and hit a team wall.

> A coding agent on your own machine works until there is more than one of you.
> … A new engineer spends an afternoon … Two tasks that need different
> credentials mean two checkouts and two configurations.

That is one persona, and it is the smallest one Fountain serves. It reaches
nobody building an app whose users never see an agent at all. The shape
everyone clones is a chat client whose contacts are bots, and it takes agents
to people who have never opened a terminal. An app that makes an engineer
faster is equally buildable on the same API. The opening excluded both.

It also argued that sandboxes are hard, which is a case nobody asked us to
make. The value is not that isolation is difficult. It is that **you should not
have to think about the computer at all.**

`build/index.md` already argues this correctly. The home page contradicted it.

## What it says now

The lede states what Fountain does, not who it is for.

> Fountain runs a coding agent on a machine you do not own, and gives you a
> conversation with it. You send a prompt. You read the reply. There is no
> machine for you to operate.
>
> It is an API first. Your app reaches it over a protocol you already speak, or
> through the SDK. The person who uses your app need never learn that an agent
> is there.

The problem is now what an app builder must otherwise operate — a machine with
an owner, a lifecycle, credentials and tenancy — and closes on "it is weeks of
infrastructure, and it is not your product."

A new **What Fountain does** section answers it, and names the protocols:
[ACP](https://binarybourbon.github.io/fountain/integrations/acp/) for an editor
or chat surface, [AG-UI](https://binarybourbon.github.io/fountain/integrations/openbot/)
for a coworker platform, REST and SSE for your own code.

It closes by widening the audience rather than narrowing it: a chat client
whose contacts are bots, or a tool that makes an engineer faster, and your own
user need not know which.

## One deliberate omission

**MCP is not in the protocol list.** There is no first-party MCP server;
`llm-integration.md` says so under its own heading, and CLAUDE.md forbids
describing unbuilt behaviour as existing. It would have been the obvious third
bullet and it would have been a lie.
