### PR TITLE
docs: name the sandbox, and stop the home page reading as coding-only

### DIFF
--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -14,7 +14,7 @@ machine.
 
 | Behind the bubble | What it truly means |
 |---|---|
-| A computer. | A filesystem, a shell, a package manager, a network. |
+| A machine. | A filesystem, a shell, a package manager, a network. |
 | Credentials. | A GitHub token that works, and that sits in neither the prompt nor the transcript. |
 | Memory. | The second message costs a sentence, and not a re-explanation of the first. |
 | Isolation. | One bot's token and files, on a machine that is not the one that serves your app. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Fountain
 
-Fountain runs a coding agent on a machine you do not own, and gives you a
-conversation with it. You send a prompt. You read the reply. There is no
-machine for you to operate.
+Fountain runs an agent on a cloud sandbox, and gives you a conversation with
+it. You send a prompt. You read the reply. Fountain operates the sandbox, and
+you do not.
 
 It is an API first. Your app reaches it over a protocol you already speak, or
 through the SDK. The person who uses your app need never learn that an agent
@@ -21,7 +21,7 @@ is there.
 
 ## The problem
 
-An agent is only useful with a computer behind it. That computer is the part
+An agent is only useful with a sandbox behind it. That sandbox is the part
 nobody set out to build.
 
 The agent needs a filesystem, a shell, a package manager and a network. It
@@ -29,9 +29,9 @@ needs real credentials, and those must never reach the prompt or the
 transcript. It needs to remember the last time, so the second message costs a
 sentence and not an explanation of the first.
 
-The computer also needs an owner. Something must start it, park it while
+The sandbox also needs an owner. Something must start it, park it while
 nobody speaks, and wake it when somebody does. One account must never see
-another's work. A machine that nobody stops costs money for as long as it
+another's work. A sandbox that nobody stops costs money for as long as it
 runs.
 
 You can build all of that. It is weeks of infrastructure, and it is not your
@@ -39,19 +39,19 @@ product.
 
 ## What Fountain does
 
-Fountain keeps the computer, and gives you the conversation.
+Fountain keeps the sandbox, and gives you the conversation.
 
-Send a prompt. A machine starts somewhere else, clones your repo, installs
-your packages, and runs the agent. It parks when the talk stops, and it costs
-little while parked. The next message wakes it, with the files where the agent
-left them.
+Send a prompt. A sandbox starts, with whatever packages, files and secrets you
+configured, and runs the agent. It parks when the talk stops, and it costs
+little while parked. The next message wakes it, and the agent's work is still
+there.
 
 Your secrets arrive at spawn as environment variables, so they never enter the
 prompt or the model's context. Fountain scrubs them out of the output it
 stores.
 
 Fountain is multi-tenant. Each account reaches its own agents and its own
-machines, because Fountain scopes each query to the caller. Your own users
+sandboxes, because Fountain scopes each query to the caller. Your own users
 therefore stay apart, and you write no code for it.
 
 Reach it the way you already work.


### PR DESCRIPTION
Three changes to the first screen, one theme: describe what Fountain runs,
without picking the reader's use case for them.

## Say sandbox

The lede said "a coding agent on **a machine you do not own**", which made the
reader decode a word the docs already have.

> Fountain runs an agent on a **cloud sandbox**, and gives you a conversation
> with it. You send a prompt. You read the reply. Fountain operates the
> sandbox, and you do not.

Naming the thing is not the same as arguing you need one — that was the case
#945 removed, and it stays removed.

**This also fixes a rule I broke in #945.**
`docs-redesign/06-voice-and-style.md` is explicit:

| Term | Means, in docs | Never means |
|---|---|---|
| computer | nothing. Do not use it | the sandbox |

`glossary.md` agrees: "The docs say **sandbox**." I had used "computer" four
times on the home page. `scripts/docs-style.py` does not check that word, so it
went in unnoticed. Zero uses remain.

`build/index.md` carried the same violation in one table row, also mine. It now
reads "A machine.", which keeps the plain-language naming of the *need* without
the banned term.

## Drop the coding frame

> Send a prompt. A sandbox starts, ~~clones your repo,~~ installs your
> packages…

A git checkout sat in the sentence that defines the product. A repository is
one thing an environment can hold, alongside packages, secrets and a setup
script. It now names the general case:

> Send a prompt. A sandbox starts, with whatever packages, files and secrets
> you configured, and runs the agent. It parks when the talk stops, and it
> costs little while parked. The next message wakes it, and the agent's work is
> still there.

## Left alone, deliberately

- **"your own code"**, and **"REST and SSE for your own code"** — these address
  the developer reading the page, who does write code.
- **"a tool that makes an engineer faster"** — one of the two examples that
  widen the audience, paired with the chat client whose contacts are bots.
- **"The guided tour builds an agent that clones a repo…"** — the tour really
  does that. Describing it otherwise would be inaccurate.
- **"computer" inside code fences**, OpenBot's own **browser computer**, and the
  quoted **"Run in a one-off computer"** UI label. The style sheet exempts
  code; OpenBot's computer is not a Fountain sandbox; the label is a quotation.

## Verification

`vale lint docs`, `scripts/docs-style.py`, `mkdocs build --strict`, and both
docs test files (35 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
