### PR TITLE
feat(acp): a per-tool permission policy, replacing the constant auto-allow (#939)

### DIFF
--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -39,6 +39,11 @@ defmodule Fountain.Agents.Agent do
     # non-empty = allowlist. An override *replaces* the reviewed environment
     # wholesale, so it is scoped the same way a vault override is.
     field :allowed_environment_ids, {:array, :binary_id}
+    # Per-tool permission policy (#939): %{"default" => "auto_allow",
+    # "Bash" => "auto_deny"}. Empty means no opinion, which resolves to
+    # auto_allow — what every agent does today. A launch may supply its own,
+    # but only to narrow this one; see Fountain.Permissions.
+    field :permission_policy, :map, default: %{}
     field :avatar_media_type, :string
     field :conversation_count, :integer, virtual: true, default: 0
     belongs_to :user, User
@@ -62,6 +67,7 @@ defmodule Fountain.Agents.Agent do
       :metadata,
       :allowed_vault_ids,
       :allowed_environment_ids,
+      :permission_policy,
       :user_id,
       :environment_id
     ])
@@ -74,6 +80,7 @@ defmodule Fountain.Agents.Agent do
     |> validate_sandbox_provider()
     |> validate_length(:name, min: 1, max: 200)
     |> validate_skills()
+    |> validate_permission_policy()
     |> unique_constraint(:name, name: :agents_user_id_name_index)
     |> foreign_key_constraint(:environment_id)
   end
@@ -141,6 +148,44 @@ defmodule Fountain.Agents.Agent do
           []
       end
     end)
+  end
+
+  # A policy is a flat map of tool name (or "default") to verdict. Validated
+  # here rather than trusted, because `Permissions.verdict_for/2` treats an
+  # unrecognised value as `auto_deny` — safe, but a silent deny on a typo is a
+  # bad way to find out. `ask` is a real verdict with nowhere to ask until #940
+  # builds the stream event and the answer endpoint, so it is refused at the
+  # door instead of degrading to an allow or hanging the turn.
+  defp validate_permission_policy(changeset) do
+    validate_change(changeset, :permission_policy, fn :permission_policy, policy ->
+      cond do
+        not is_map(policy) ->
+          [permission_policy: "must be a map of tool name to verdict"]
+
+        true ->
+          Enum.flat_map(policy, fn {tool, verdict} -> policy_errors(tool, verdict) end)
+      end
+    end)
+  end
+
+  defp policy_errors(tool, verdict) do
+    cond do
+      not is_binary(tool) or tool == "" ->
+        [permission_policy: "tool names must be non-empty strings"]
+
+      verdict not in Fountain.Permissions.verdicts() ->
+        [
+          permission_policy:
+            "#{tool}: unknown verdict #{inspect(verdict)} " <>
+              "(one of #{Enum.join(Fountain.Permissions.verdicts(), ", ")})"
+        ]
+
+      not Fountain.Permissions.buildable?(verdict) ->
+        [permission_policy: "#{tool}: #{verdict} is not built yet — see #940"]
+
+      true ->
+        []
+    end
   end
 
   defp validate_skills(changeset) do

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1415,6 +1415,8 @@ defmodule Fountain.Conversations do
     - `vault_id`              — optional vault whose secrets override the env's
     - `environment_id`        — optional environment to provision from instead of the
                                 agent's own (#783); subject to `agent.allowed_environment_ids`
+    - `permission_policy`     — optional per-tool permission override (#939); may only
+                                narrow the agent's own policy, never widen it
     - `source`                — optional; one of "ui", "api", "agent" (default "api")
     - `parent_conversation_id` — optional; UUID of the conversation that spawned this one
     - `title`                 — optional display title (the team page names a teammate with it)
@@ -1425,6 +1427,7 @@ defmodule Fountain.Conversations do
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
+         {:ok, perm_policy} <- resolve_permission_policy(attrs["permission_policy"], agent),
          {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Accounts.check_not_suspended(user_id),
          :ok <- Fountain.Billing.check_active(user_id),
@@ -1455,7 +1458,8 @@ defmodule Fountain.Conversations do
              source: attrs["source"] || "api",
              parent_conversation_id: parent_id,
              channel_id: attrs["channel_id"],
-             title: attrs["title"]
+             title: attrs["title"],
+             permission_policy: perm_policy
            }) do
       # Recorded here rather than in either branch below: both of them return
       # {:ok, conv}. The row exists and the sandbox reservation is spent even
@@ -1657,6 +1661,79 @@ defmodule Fountain.Conversations do
 
   defp check_environment_allowed(id, %Agents.Agent{allowed_environment_ids: allowed}) do
     if id in allowed, do: :ok, else: {:error, :environment_not_allowed}
+  end
+
+  @doc """
+  Record that the permission policy withheld a tool from a running agent.
+
+  Called by the `ConversationServer` when its peer reports a refusal (#939).
+  The actor is `sprite`: the agent asked, the policy answered, and no human was
+  involved — attributing it to the person who happened to write the policy
+  would be a lie about who was at the keyboard.
+
+  Only refusals are recorded. A turn makes dozens of tool calls and a row per
+  allow would make the trail a second copy of the transcript, which 0013
+  forbids for exactly this reason. The tool's *input* is never recorded, only
+  its name and the verdict.
+  """
+  @spec record_permission_denied(binary(), String.t() | nil, String.t()) :: :ok
+  def record_permission_denied(conversation_id, tool, verdict) when is_binary(conversation_id) do
+    case _unsafe_get_conversation(conversation_id) do
+      nil ->
+        :ok
+
+      conv ->
+        Audit.record(%{
+          user_id: conv.user_id,
+          action: "conversation.permission_denied",
+          resource_type: "conversation",
+          resource_id: conv.id,
+          actor: "sprite",
+          metadata: %{"tool" => tool, "verdict" => verdict}
+        })
+
+        :ok
+    end
+  end
+
+  # A per-launch permission override (#939). Unlike the vault and environment
+  # overrides, this one needs no allowlist on the agent: `check_narrows/2`
+  # refuses anything looser than the agent's own policy, so a launch cannot
+  # reach a permission the agent did not already grant. There is nothing to
+  # allow-list because there is nothing to escalate to.
+  #
+  # Rejected loudly rather than clamped. `Permissions.effective/2` clamps
+  # anyway — that is the invariant the peer relies on — but a caller who asked
+  # to loosen a policy and silently got a tighter one would have no way to
+  # tell, and the difference matters when the ask was a mistake.
+  defp resolve_permission_policy(nil, _agent), do: {:ok, nil}
+  defp resolve_permission_policy(policy, _agent) when policy == %{}, do: {:ok, nil}
+
+  defp resolve_permission_policy(policy, agent) when is_map(policy) do
+    with :ok <- validate_policy_shape(policy),
+         :ok <- Fountain.Permissions.check_narrows(agent.permission_policy, policy) do
+      {:ok, policy}
+    end
+  end
+
+  defp resolve_permission_policy(_policy, _agent), do: {:error, :permission_policy_invalid}
+
+  defp validate_policy_shape(policy) do
+    Enum.find_value(policy, :ok, fn {tool, verdict} ->
+      cond do
+        not is_binary(tool) or tool == "" ->
+          {:error, :permission_policy_invalid}
+
+        verdict not in Fountain.Permissions.verdicts() ->
+          {:error, :permission_policy_invalid}
+
+        not Fountain.Permissions.buildable?(verdict) ->
+          {:error, {:permission_policy_unbuilt, verdict}}
+
+        true ->
+          nil
+      end
+    end)
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -42,6 +42,14 @@ defmodule Fountain.Conversations.Conversation do
     field :usage_input_tokens, :integer, default: 0
     field :usage_output_tokens, :integer, default: 0
 
+    # Per-launch permission override (#939). nil means "this launch had no
+    # opinion" and the agent's policy stands alone. Set, it is merged with the
+    # agent's by `Permissions.effective/2`, which takes the stricter of the two
+    # per tool — so this can only ever narrow, and an agent that tightens later
+    # tightens this conversation too. The widening case is rejected at the door
+    # in `start_conversation/2` rather than silently clamped.
+    field :permission_policy, :map
+
     # Populated by list_conversations_by_activity/1 — not persisted.
     field :turn_count, :integer, virtual: true, default: 0
     field :last_active_at, :utc_datetime_usec, virtual: true
@@ -86,7 +94,8 @@ defmodule Fountain.Conversations.Conversation do
       :agent_id,
       :vault_id,
       :environment_id,
-      :channel_id
+      :channel_id,
+      :permission_policy
     ])
     |> validate_required([:runtime, :status, :sandbox_id, :user_id])
     |> validate_length(:channel_id, max: 255)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1081,7 +1081,13 @@ defmodule Fountain.Conversations.ConversationServer do
         prompt: running_turn.prompt,
         mode: :continue,
         session_id: conv.runtime_session_id,
-        attach: running_turn.acp_prompt_id
+        attach: running_turn.acp_prompt_id,
+        # A reattached peer answers `session/request_permission` exactly like a
+        # fresh one — the adapter in the sprite is mid-turn and still asking.
+        # Resolving from the agent here (rather than reading a policy frozen on
+        # the conversation row) is what makes a tightening apply across a
+        # deploy.
+        permission_policy: effective_permission_policy(conv, agent_for(conv))
       )
 
     dedup =
@@ -1542,6 +1548,18 @@ defmodule Fountain.Conversations.ConversationServer do
   def handle_info({:acp, ref, {:prompt_sent, id}}, %{current_command_ref: ref} = state) do
     {:ok, turn} = Conversations._unsafe_update_turn(state.current_turn, %{acp_prompt_id: id})
     {:noreply, %{state | current_turn: turn}}
+  end
+
+  # A tool the policy withheld (#939). Recorded in the context, per 0013: the
+  # tool and the verdict, never the tool's input. Only refusals reach here —
+  # the peer stays silent on `auto_allow`, because a turn makes dozens of tool
+  # calls and a row each would turn the trail into a transcript.
+  def handle_info(
+        {:acp, ref, {:permission_denied, tool, verdict}},
+        %{current_command_ref: ref} = state
+      ) do
+    Conversations.record_permission_denied(state.conversation_id, tool, verdict)
+    {:noreply, state}
   end
 
   # The number gate 2 exists to produce: what a turn pays for `initialize` plus
@@ -2429,7 +2447,8 @@ defmodule Fountain.Conversations.ConversationServer do
                         buzz_mcp_servers(state) ++
                         team_mcp_servers(state) ++
                         team_comms_mcp_servers(state),
-                    model: agent && Fountain.Runtimes.Model.id(agent.model)
+                    model: agent && Fountain.Runtimes.Model.id(agent.model),
+                    permission_policy: effective_permission_policy(conv, agent)
                   )
                 else
                   {nil, nil}
@@ -2737,6 +2756,19 @@ defmodule Fountain.Conversations.ConversationServer do
     %{new_state | stream_tracer: tracer}
   end
 
+  # The permission policy in force for this turn (#939): the agent's own,
+  # clamped by whatever narrowing the launch asked for. Resolved per turn from
+  # the agent rather than read off a policy frozen on the conversation row, so
+  # tightening an agent tightens the conversations already running under it.
+  defp effective_permission_policy(conv, agent) do
+    Fountain.Permissions.effective(agent && agent.permission_policy, conv.permission_policy)
+  end
+
+  # Ownership is already established: this server exists for this conversation.
+  # See the `_unsafe_` rules in CLAUDE.md — a GenServer holding the conversation
+  # is one of the legitimate callers.
+  defp agent_for(conv), do: conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)
+
   defp start_acp_peer(command, prompt, mode, runtime_session_id, opts) do
     {:ok, peer} =
       Fountain.Runtimes.ACP.Peer.start(
@@ -2749,7 +2781,8 @@ defmodule Fountain.Conversations.ConversationServer do
         cwd: Keyword.get(opts, :cwd) || "/home/sprite",
         images: Keyword.get(opts, :images, []),
         mcp_servers: Keyword.get(opts, :mcp_servers, []),
-        model: Keyword.get(opts, :model)
+        model: Keyword.get(opts, :model),
+        permission_policy: Keyword.get(opts, :permission_policy)
       )
 
     {peer, Process.monitor(peer)}

--- a/apps/fountain/lib/fountain/permissions.ex
+++ b/apps/fountain/lib/fountain/permissions.ex
@@ -1,0 +1,254 @@
+defmodule Fountain.Permissions do
+  @moduledoc """
+  What answers `session/request_permission`, per tool.
+
+  Gate 3 of [0014](decisions/0014-agent-client-protocol.md), built in #939.
+
+  Every runtime Fountain ships used to run with its safety rail removed by a
+  vendor flag. Three of those four flags went with the legacy spawn path
+  (#671-#675); what replaced them was this module's predecessor — a constant in
+  `ACP.Peer` that answered every request by picking `allow_always`, else
+  `allow_once`, else whatever was offered first. The rail was still off, but it
+  was off in one function we own, which is what made it a policy problem rather
+  than a fork-four-CLIs problem.
+
+  ## The shape
+
+  A policy is a map of tool name to verdict, plus a `"default"` key:
+
+      %{"default" => "auto_allow", "Bash" => "auto_deny"}
+
+  Tool names are matched the way the transcript labels them
+  (`ACP.Blocks.tool_name/1`): the agent's own `title`, falling back to ACP's
+  coarse `kind`. So a policy key is the string a user reads on a tool card,
+  not an internal id.
+
+  ## Narrow, never widen
+
+  An agent holds a policy; a launch may supply its own. **The launch may only
+  make the policy more restrictive.** That single rule is the no-escalation
+  guarantee, and it is why there is no `allowed_permission_policies` list beside
+  it the way `environment_id` needs `allowed_environment_ids` — a launch cannot
+  reach anything the agent did not already permit, so there is nothing to
+  allow-list.
+
+  It is enforced twice, deliberately:
+
+  - `check_narrows/2` rejects a widening launch **at the door**, so the caller
+    gets an error naming the tool rather than a silent downgrade.
+  - `effective/2` **clamps** — the result is the more restrictive of the two for
+    every tool. This is the invariant the peer actually depends on, and it means
+    an agent that tightens its policy later also tightens every conversation
+    already running under it. Storing a pre-merged policy on the conversation
+    would have frozen the old, looser one.
+
+  ## Verdicts
+
+  | verdict | what answers |
+  |---|---|
+  | `auto_allow` | today's behaviour: `allow_always`, else `allow_once`, else the first option offered |
+  | `auto_deny` | a `reject_*` option when the agent offered one, `cancelled` when it did not |
+  | `ask` | a human. **Not built** — see #940; rejected at the door until it is |
+
+  `auto_allow` is the default, so adopting a policy changes nothing until
+  someone writes one.
+
+  ## Never synthesise an option
+
+  `auto_deny` picks from what the agent offered and never invents an id. An
+  adapter that offers no rejection gets `cancelled`, which is the protocol's own
+  "no option was selected" and the only honest answer available. Inventing an
+  `optionId` the agent never advertised would at best error and at worst select
+  something unrelated.
+  """
+
+  @auto_allow "auto_allow"
+  @ask "ask"
+  @auto_deny "auto_deny"
+
+  @verdicts [@auto_allow, @ask, @auto_deny]
+
+  # Restrictiveness, low to high. `effective/2` takes the max, `check_narrows/2`
+  # requires the launch to be >= the agent. `ask` sits between the two because
+  # it withholds the tool until a human acts, which is stricter than allowing
+  # and looser than refusing outright.
+  @rank %{@auto_allow => 0, @ask => 1, @auto_deny => 2}
+
+  @default_key "default"
+
+  @doc "Every verdict a policy may name."
+  @spec verdicts() :: [String.t()]
+  def verdicts, do: @verdicts
+
+  @doc "The verdict applied when a policy names neither the tool nor a default."
+  @spec default_verdict() :: String.t()
+  def default_verdict, do: @auto_allow
+
+  @doc """
+  Verdicts that can be honoured today.
+
+  `ask` is a valid policy value with nowhere to ask: #940 builds the stream
+  event and the answer endpoint. Until then it is refused where a policy is
+  written, rather than degrading to an allow (unsafe) or hanging the turn
+  forever (worse — see the note on the ceiling in 0014 gate 3).
+  """
+  @spec buildable_verdicts() :: [String.t()]
+  def buildable_verdicts, do: [@auto_allow, @auto_deny]
+
+  @doc "Whether `verdict` can be honoured today. False for `ask` until #940."
+  @spec buildable?(String.t()) :: boolean()
+  def buildable?(verdict), do: verdict in buildable_verdicts()
+
+  @doc """
+  The verdict `policy` gives `tool`.
+
+  Falls back to the policy's own `"default"`, then to `auto_allow`.
+  """
+  @spec verdict_for(map() | nil, String.t() | nil) :: String.t()
+  def verdict_for(policy, tool) when is_map(policy) do
+    with nil <- tool && Map.get(policy, tool),
+         nil <- Map.get(policy, @default_key) do
+      @auto_allow
+    else
+      verdict when verdict in @verdicts -> verdict
+      # A value that is not a verdict is not trusted into an allow: the
+      # changesets reject these, so reaching here means the row was written
+      # around them.
+      _ -> @auto_deny
+    end
+  end
+
+  def verdict_for(_policy, _tool), do: @auto_allow
+
+  @doc """
+  Merge an agent's policy with a launch's, taking the **more restrictive** of
+  the two for every tool either of them names.
+
+  Clamping rather than replacing is what makes the launch override safe by
+  construction: no merge can produce a verdict looser than the agent's, whatever
+  was stored, and a later tightening of the agent applies to conversations
+  already running.
+  """
+  @spec effective(map() | nil, map() | nil) :: map()
+  def effective(agent_policy, launch_policy) do
+    agent_policy = normalize(agent_policy)
+    launch_policy = normalize(launch_policy)
+
+    agent_policy
+    |> keys_with(launch_policy)
+    |> Map.new(fn key ->
+      {key, stricter(verdict_for(agent_policy, key), verdict_for(launch_policy, key))}
+    end)
+    |> Map.put(
+      @default_key,
+      stricter(verdict_for(agent_policy, nil), verdict_for(launch_policy, nil))
+    )
+  end
+
+  @doc """
+  Whether `launch` is at least as restrictive as `agent` for every tool.
+
+  Returns `:ok`, or `{:error, {:permission_policy_widens, tool}}` naming the
+  first tool the launch would loosen. The check spans the union of both key
+  sets *and* the defaults, because a launch that only lowers `"default"` still
+  loosens every tool the agent covered by its own default.
+  """
+  @spec check_narrows(map() | nil, map() | nil) ::
+          :ok | {:error, {:permission_policy_widens, String.t()}}
+  def check_narrows(agent, launch) do
+    agent = normalize(agent)
+    launch = normalize(launch)
+
+    agent
+    |> keys_with(launch)
+    |> Enum.concat([@default_key])
+    |> Enum.find_value(:ok, fn key ->
+      if rank(verdict_for(launch, key)) < rank(verdict_for(agent, key)) do
+        {:error, {:permission_policy_widens, key}}
+      end
+    end)
+  end
+
+  @doc """
+  The `session/request_permission` result for `params` under `policy`.
+
+  Returns the inner `outcome` object — the caller wraps it, because ACP's
+  response body is `{"outcome": {"outcome": …}}`.
+  """
+  @spec outcome(map() | nil, map()) :: map()
+  def outcome(policy, params) when is_map(params) do
+    options = Map.get(params, "options") || []
+
+    case verdict_for(normalize(policy), tool_name(params)) do
+      @auto_deny -> deny(options)
+      # `ask` cannot reach here: it is refused where a policy is written, and
+      # clamping never invents it. Denying is the safe reading if it ever does.
+      @ask -> deny(options)
+      _ -> allow(options)
+    end
+  end
+
+  @doc """
+  The tool a permission request is about, as the transcript labels it.
+
+  Mirrors `ACP.Blocks.tool_name/1` so a policy key is the string a user reads on
+  the tool card. `nil` when the request carries no tool call at all, which falls
+  through to the policy's default.
+  """
+  @spec tool_name(map()) :: String.t() | nil
+  def tool_name(%{"toolCall" => call}) when is_map(call) do
+    case {call["title"], call["kind"]} do
+      {title, _} when is_binary(title) and title != "" -> title
+      {_, kind} when is_binary(kind) and kind != "" -> kind
+      _ -> nil
+    end
+  end
+
+  def tool_name(_params), do: nil
+
+  @doc "Which verdict of the two withholds more."
+  @spec stricter(String.t(), String.t()) :: String.t()
+  def stricter(a, b), do: if(rank(a) >= rank(b), do: a, else: b)
+
+  defp rank(verdict), do: Map.get(@rank, verdict, @rank[@auto_deny])
+
+  # Every tool either side names, minus the default — which is handled
+  # separately because it is a fallback, not a tool.
+  defp keys_with(a, b) do
+    a
+    |> Map.keys()
+    |> Enum.concat(Map.keys(b))
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 == @default_key))
+  end
+
+  defp normalize(policy) when is_map(policy), do: policy
+  defp normalize(_), do: %{}
+
+  # Today's ladder, kept verbatim: `allow_always`, else `allow_once`, else
+  # whatever was offered first. That last rung is why this is parity and not a
+  # new behaviour — an adapter offering only bespoke option kinds is answered
+  # exactly as it was before #939.
+  defp allow(options) do
+    select(options, ~w(allow_always allow_once)) || selected(List.first(options)) || cancelled()
+  end
+
+  # No such rung on the deny side. Falling back to "whatever was offered first"
+  # would pick an *allow* on any adapter that lists its options that way, which
+  # is the one thing `auto_deny` must never do. An adapter that offers no
+  # rejection gets `cancelled` — the protocol's own "nothing was selected".
+  defp deny(options) do
+    select(options, ~w(reject_always reject_once)) || cancelled()
+  end
+
+  defp select(options, kinds) do
+    Enum.find_value(kinds, fn kind ->
+      options |> Enum.find(&(is_map(&1) and &1["kind"] == kind)) |> selected()
+    end)
+  end
+
+  defp selected(%{"optionId" => id}), do: %{outcome: "selected", optionId: id}
+  defp selected(_), do: nil
+
+  defp cancelled, do: %{outcome: "cancelled"}
+end

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -120,6 +120,10 @@ defmodule Fountain.Runtimes.ACP.Peer do
       images: [],
       mcp_servers: [],
       model: nil,
+      # The effective per-tool permission policy for this turn (#939). Already
+      # merged and clamped by `Permissions.effective/2` before it gets here —
+      # the peer applies it, it does not resolve it.
+      permission_policy: %{},
       buffer: "",
       next_id: 1,
       pending: %{},
@@ -186,6 +190,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
       cwd: Keyword.get(opts, :cwd, "/home/sprite"),
       images: Keyword.get(opts, :images, []),
       mcp_servers: Keyword.get(opts, :mcp_servers, []),
+      permission_policy: Keyword.get(opts, :permission_policy) || %{},
       model: Keyword.get(opts, :model),
       replay_quiet_ms: Keyword.get(opts, :replay_quiet_ms, @replay_quiet_ms),
       replay_max_ms: Keyword.get(opts, :replay_max_ms, @replay_max_ms),
@@ -364,13 +369,28 @@ defmodule Fountain.Runtimes.ACP.Peer do
   end
 
   # `session/request_permission` is the channel gate 3 exists to use. Gate 2
-  # answers it the way the legacy path already behaves — every runtime today
-  # runs with its rail removed (`--dangerously-skip-permissions` and friends),
-  # so auto-allowing is parity, not a new exposure. Answering *something* is not
-  # optional: the agent blocks on this request, and a blocked agent is a turn in
-  # flight, which disarms idle reclaim and bills the sprite to the ceiling.
+  # answered it with a constant auto-allow, which was parity with the legacy
+  # path's `--dangerously-skip-permissions` and friends. #939 made that a
+  # policy: `Fountain.Permissions` decides per tool, and `auto_allow` — still
+  # the default — keeps the old ladder verbatim, so this is parity until
+  # someone writes a policy.
+  #
+  # Answering *something* is not optional: the agent blocks on this request, and
+  # a blocked agent is a turn in flight, which disarms idle reclaim and bills
+  # the sprite to the ceiling.
+  #
+  # The verdict is reported to the owner so a denial reaches the audit trail
+  # (0013 — in the context, tool and verdict, never values). Allows are not
+  # recorded: a turn makes dozens of tool calls, and a row each would make the
+  # trail a transcript.
   defp handle_message({:request, id, "session/request_permission", params}, state) do
-    write(state, Protocol.response(id, %{outcome: permission_outcome(params)}))
+    outcome = Fountain.Permissions.outcome(state.permission_policy, params)
+    tool = Fountain.Permissions.tool_name(params)
+    verdict = Fountain.Permissions.verdict_for(state.permission_policy, tool)
+
+    if verdict != "auto_allow", do: report(state, {:permission_denied, tool, verdict})
+
+    write(state, Protocol.response(id, %{outcome: outcome}))
   end
 
   # We declared no filesystem or terminal capabilities, so nothing should ask.
@@ -744,19 +764,5 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   # Prefer an option the agent itself marked as an allow. `optionId` is opaque
   # and adapter-defined, so picking by `kind` is the only portable choice.
-  defp permission_outcome(params) do
-    options = Map.get(params, "options") || []
-
-    chosen =
-      Enum.find(options, &(&1["kind"] == "allow_always")) ||
-        Enum.find(options, &(&1["kind"] == "allow_once")) ||
-        List.first(options)
-
-    case chosen do
-      %{"optionId" => id} -> %{outcome: "selected", optionId: id}
-      _ -> %{outcome: "cancelled"}
-    end
-  end
-
   defp noreply(state), do: {:noreply, state}
 end

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -52,6 +52,44 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # A per-launch permission override that would loosen the agent's policy
+  # (#939). 422 naming the tool, because the caller asked for something
+  # specific and a generic "invalid" would send them hunting. Refused rather
+  # than clamped: `Permissions.effective/2` would clamp it to something safe
+  # anyway, but silently handing back a tighter policy than the one requested
+  # gives the caller no way to learn the ask was a mistake.
+  def call(conn, {:error, {:permission_policy_widens, tool}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "permission_policy_widens",
+      message:
+        "permission_policy may only narrow the agent's own policy; " <>
+          "#{tool} would be loosened"
+    })
+  end
+
+  # `ask` is a real verdict with nowhere to ask until #940 builds the stream
+  # event and the answer endpoint. Refused here rather than degrading to an
+  # allow (unsafe) or hanging the turn on a prompt nobody will see (worse).
+  def call(conn, {:error, {:permission_policy_unbuilt, verdict}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "permission_policy_unbuilt",
+      message: "permission verdict #{verdict} is not supported yet"
+    })
+  end
+
+  def call(conn, {:error, :permission_policy_invalid}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "permission_policy_invalid",
+      message: "permission_policy must map tool names to auto_allow or auto_deny"
+    })
+  end
+
   # An unknown or cross-tenant parent conversation. 404 rather than 403 so the
   # caller cannot use the response to probe which conversation ids exist.
   def call(conn, {:error, :parent_not_found}) do

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -260,6 +260,16 @@ defmodule FountainWeb.Schemas do
               "allowlist is set (422 environment_not_allowed). Part of the channel_id " <>
               "resume key."
         },
+        permission_policy: %Schema{
+          type: :object,
+          nullable: true,
+          additionalProperties: %Schema{type: :string, enum: ["auto_allow", "auto_deny"]},
+          description:
+            "Per-launch permission override (#939). Merged with the agent's own policy, " <>
+              "taking the stricter of the two per tool. It may only narrow: a policy that " <>
+              "would loosen any tool is refused with 422 permission_policy_widens rather " <>
+              "than silently clamped."
+        },
         prompt: %Schema{type: :string, description: "Optional first turn prompt."},
         title: %Schema{
           type: :string,
@@ -413,6 +423,17 @@ defmodule FountainWeb.Schemas do
               "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
         },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
+        permission_policy: %Schema{
+          type: :object,
+          nullable: true,
+          additionalProperties: %Schema{type: :string, enum: ["auto_allow", "auto_deny"]},
+          description:
+            "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
+              "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
+              "default, and an unset default is auto_allow \u2014 today's behaviour. " <>
+              "\"ask\" is a known verdict but is not supported yet (422 " <>
+              "permission_policy_unbuilt)."
+        },
         skills: %Schema{
           type: :array,
           description:

--- a/apps/fountain/priv/repo/migrations/20260821190000_add_permission_policy.exs
+++ b/apps/fountain/priv/repo/migrations/20260821190000_add_permission_policy.exs
@@ -1,0 +1,23 @@
+defmodule Fountain.Repo.Migrations.AddPermissionPolicy do
+  use Ecto.Migration
+
+  # Per-tool permission policy (#939, ADR 0014 gate 3).
+  #
+  # `agents.permission_policy` is the agent's own map; `conversations` carries
+  # a per-launch override that may only narrow it. Both default to an empty
+  # map, which means "no opinion" and resolves to `auto_allow` — the behaviour
+  # every conversation has today, so this migration changes nothing on its own.
+  #
+  # Nullable on conversations rather than defaulted: nil says "this launch had
+  # no opinion", which is different from "this launch explicitly set nothing"
+  # only in intent, but keeps the column honest about what the caller sent.
+  def change do
+    alter table(:agents) do
+      add :permission_policy, :map, null: false, default: %{}
+    end
+
+    alter table(:conversations) do
+      add :permission_policy, :map
+    end
+  end
+end

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -384,4 +384,71 @@ defmodule Fountain.AgentsTest do
       assert hd(results).environment.id == env.id
     end
   end
+
+  describe "permission_policy (#939)" do
+    test "defaults to an empty map, which means auto_allow" do
+      agent = insert_agent(user_id: insert_verified_user().id)
+      assert agent.permission_policy == %{}
+      assert Fountain.Permissions.verdict_for(agent.permission_policy, "Bash") == "auto_allow"
+    end
+
+    test "accepts a per-tool map with a default" do
+      user = insert_verified_user()
+      policy = %{"default" => "auto_allow", "Bash" => "auto_deny"}
+      agent = insert_agent(user_id: user.id, permission_policy: policy)
+      assert agent.permission_policy == policy
+    end
+
+    test "rejects an unknown verdict rather than failing closed silently" do
+      user = insert_verified_user()
+
+      assert {:error, changeset} =
+               Agents.create_agent(
+                 agent_attrs(%{
+                   "user_id" => user.id,
+                   "permission_policy" => %{"Bash" => "banana"}
+                 })
+               )
+
+      assert %{permission_policy: [msg]} = errors_on(changeset)
+      assert msg =~ "unknown verdict"
+    end
+
+    test "rejects ask until #940 builds somewhere to ask" do
+      user = insert_verified_user()
+
+      assert {:error, changeset} =
+               Agents.create_agent(
+                 agent_attrs(%{"user_id" => user.id, "permission_policy" => %{"Bash" => "ask"}})
+               )
+
+      assert %{permission_policy: [msg]} = errors_on(changeset)
+      assert msg =~ "not built yet"
+    end
+
+    test "rejects a non-string tool key" do
+      user = insert_verified_user()
+
+      assert {:error, changeset} =
+               Agents.create_agent(
+                 agent_attrs(%{"user_id" => user.id, "permission_policy" => %{"" => "auto_deny"}})
+               )
+
+      assert %{permission_policy: _} = errors_on(changeset)
+    end
+
+    test "a policy change is audited by the existing agent.updated trail" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      {:ok, _} = Agents.update_agent(agent, %{"permission_policy" => %{"Bash" => "auto_deny"}})
+
+      assert [event] =
+               user.id
+               |> Fountain.Audit.list_recent_for_user(10)
+               |> Enum.filter(&(&1.action == "agent.updated"))
+
+      assert "permission_policy" in event.metadata["changed"]
+    end
+  end
 end

--- a/apps/fountain/test/fountain/conversations_start_test.exs
+++ b/apps/fountain/test/fountain/conversations_start_test.exs
@@ -274,6 +274,88 @@ defmodule Fountain.ConversationsStartTest do
   # start_conversation/2 — per-launch environment override (#783)
   # ────────────────────────────────────────────────────────────────────────────
 
+  describe "start_conversation/2 permission_policy override (#939)" do
+    setup do
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
+
+      user = insert_verified_user()
+      %{user: user}
+    end
+
+    defp launch(ctx, agent, policy) do
+      attrs = %{"agent_id" => agent.id, "user_id" => ctx.user.id}
+      attrs = if policy, do: Map.put(attrs, "permission_policy", policy), else: attrs
+      Conversations.start_conversation(attrs)
+    end
+
+    test "no override leaves the column nil, and the agent's policy stands alone", ctx do
+      agent = insert_agent(user_id: ctx.user.id, permission_policy: %{"Bash" => "auto_deny"})
+
+      assert {:ok, conv} = launch(ctx, agent, nil)
+      assert conv.permission_policy == nil
+
+      effective = Fountain.Permissions.effective(agent.permission_policy, conv.permission_policy)
+      assert Fountain.Permissions.verdict_for(effective, "Bash") == "auto_deny"
+    end
+
+    test "a launch may narrow the agent's policy", ctx do
+      agent = insert_agent(user_id: ctx.user.id, permission_policy: %{"default" => "auto_allow"})
+
+      assert {:ok, conv} = launch(ctx, agent, %{"Bash" => "auto_deny"})
+      assert conv.permission_policy == %{"Bash" => "auto_deny"}
+
+      effective = Fountain.Permissions.effective(agent.permission_policy, conv.permission_policy)
+      assert Fountain.Permissions.verdict_for(effective, "Bash") == "auto_deny"
+      assert Fountain.Permissions.verdict_for(effective, "Read") == "auto_allow"
+    end
+
+    test "a launch may not widen it, and the error names the tool", ctx do
+      # The no-escalation rule, and the reason there is no allowlist beside it:
+      # a launch cannot reach a permission the agent did not already grant.
+      agent = insert_agent(user_id: ctx.user.id, permission_policy: %{"Bash" => "auto_deny"})
+
+      assert {:error, {:permission_policy_widens, "Bash"}} =
+               launch(ctx, agent, %{"Bash" => "auto_allow"})
+    end
+
+    test "a launch may not widen via the default either", ctx do
+      agent = insert_agent(user_id: ctx.user.id, permission_policy: %{"default" => "auto_deny"})
+
+      assert {:error, {:permission_policy_widens, _}} =
+               launch(ctx, agent, %{"default" => "auto_allow"})
+    end
+
+    test "widening is refused rather than silently clamped", ctx do
+      # `effective/2` would clamp this to a safe value anyway. Refusing is about
+      # the caller: someone who asked to loosen a policy and got a tighter one
+      # without being told has no way to find out the ask was a mistake.
+      agent = insert_agent(user_id: ctx.user.id, permission_policy: %{"Bash" => "auto_deny"})
+
+      assert {:error, _} = launch(ctx, agent, %{"Bash" => "auto_allow"})
+      assert Repo.aggregate(Fountain.Conversations.Conversation, :count) == 0
+    end
+
+    test "ask is refused at the door until #940 builds somewhere to ask", ctx do
+      agent = insert_agent(user_id: ctx.user.id)
+
+      assert {:error, {:permission_policy_unbuilt, "ask"}} =
+               launch(ctx, agent, %{"Bash" => "ask"})
+    end
+
+    test "an unknown verdict is refused", ctx do
+      agent = insert_agent(user_id: ctx.user.id)
+      assert {:error, :permission_policy_invalid} = launch(ctx, agent, %{"Bash" => "banana"})
+    end
+
+    test "an empty override is the same as none", ctx do
+      agent = insert_agent(user_id: ctx.user.id)
+      assert {:ok, conv} = launch(ctx, agent, %{})
+      assert conv.permission_policy == nil
+    end
+  end
+
   describe "start_conversation/2 environment_id override" do
     setup do
       stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->

--- a/apps/fountain/test/fountain/permissions_test.exs
+++ b/apps/fountain/test/fountain/permissions_test.exs
@@ -1,0 +1,193 @@
+defmodule Fountain.PermissionsTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Permissions
+
+  defp req(options, tool \\ nil) do
+    params = %{"options" => options}
+    if tool, do: Map.put(params, "toolCall", %{"title" => tool}), else: params
+  end
+
+  defp allow_always, do: %{"optionId" => "aa", "kind" => "allow_always"}
+  defp allow_once, do: %{"optionId" => "ao", "kind" => "allow_once"}
+  defp reject_once, do: %{"optionId" => "ro", "kind" => "reject_once"}
+  defp reject_always, do: %{"optionId" => "ra", "kind" => "reject_always"}
+
+  describe "auto_allow is parity with the pre-#939 constant" do
+    test "prefers allow_always, then allow_once" do
+      assert %{outcome: "selected", optionId: "aa"} =
+               Permissions.outcome(%{}, req([reject_once(), allow_once(), allow_always()]))
+
+      assert %{outcome: "selected", optionId: "ao"} =
+               Permissions.outcome(%{}, req([reject_once(), allow_once()]))
+    end
+
+    test "falls back to the first option offered, whatever its kind" do
+      # The rung that makes this parity rather than a new behaviour: the old
+      # ladder ended in `List.first(options)`. An adapter offering only bespoke
+      # kinds must still be answered exactly as it was before.
+      assert %{outcome: "selected", optionId: "weird"} =
+               Permissions.outcome(%{}, req([%{"optionId" => "weird", "kind" => "custom"}]))
+    end
+
+    test "cancels only when nothing at all was offered" do
+      assert %{outcome: "cancelled"} = Permissions.outcome(%{}, req([]))
+    end
+
+    test "a nil policy behaves like an empty one" do
+      assert %{outcome: "selected", optionId: "aa"} =
+               Permissions.outcome(nil, req([allow_always()]))
+    end
+  end
+
+  describe "auto_deny never synthesises an option" do
+    @deny %{"default" => "auto_deny"}
+
+    test "prefers reject_always, then reject_once" do
+      assert %{outcome: "selected", optionId: "ra"} =
+               Permissions.outcome(@deny, req([reject_once(), reject_always()]))
+
+      assert %{outcome: "selected", optionId: "ro"} =
+               Permissions.outcome(@deny, req([allow_always(), reject_once()]))
+    end
+
+    test "cancels rather than picking the first option when no rejection is offered" do
+      # The deny path has no first-option rung on purpose. Falling back to
+      # "whatever was offered first" would select an *allow* here, which is the
+      # one thing auto_deny must never do.
+      assert %{outcome: "cancelled"} =
+               Permissions.outcome(@deny, req([allow_always(), allow_once()]))
+    end
+  end
+
+  describe "verdict_for" do
+    test "tool entry beats the default" do
+      policy = %{"default" => "auto_allow", "Bash" => "auto_deny"}
+      assert Permissions.verdict_for(policy, "Bash") == "auto_deny"
+      assert Permissions.verdict_for(policy, "Read") == "auto_allow"
+    end
+
+    test "an unset default is auto_allow" do
+      assert Permissions.verdict_for(%{}, "Bash") == "auto_allow"
+      assert Permissions.verdict_for(%{"Read" => "auto_deny"}, "Bash") == "auto_allow"
+    end
+
+    test "a value that is not a verdict denies rather than allowing" do
+      # The changesets reject these, so reaching here means the row was written
+      # around them. Failing closed is the only safe reading.
+      assert Permissions.verdict_for(%{"Bash" => "banana"}, "Bash") == "auto_deny"
+      assert Permissions.verdict_for(%{"default" => nil, "Bash" => 7}, "Bash") == "auto_deny"
+    end
+  end
+
+  describe "effective/2 clamps to the stricter side" do
+    test "the launch may tighten a tool" do
+      effective = Permissions.effective(%{"default" => "auto_allow"}, %{"Bash" => "auto_deny"})
+      assert Permissions.verdict_for(effective, "Bash") == "auto_deny"
+      assert Permissions.verdict_for(effective, "Read") == "auto_allow"
+    end
+
+    test "the launch cannot loosen a tool, even if the row says so" do
+      # This is the invariant the peer depends on: whatever is stored, the merge
+      # can never produce something looser than the agent's own policy.
+      effective = Permissions.effective(%{"Bash" => "auto_deny"}, %{"Bash" => "auto_allow"})
+      assert Permissions.verdict_for(effective, "Bash") == "auto_deny"
+    end
+
+    test "the launch cannot loosen via the default either" do
+      effective = Permissions.effective(%{"default" => "auto_deny"}, %{"default" => "auto_allow"})
+      assert Permissions.verdict_for(effective, "anything") == "auto_deny"
+    end
+
+    test "a tool covered only by the agent's default is still clamped" do
+      # The launch names Bash explicitly; the agent covers it by default. The
+      # merge has to compare effective verdicts, not just the key sets.
+      effective = Permissions.effective(%{"default" => "auto_deny"}, %{"Bash" => "auto_allow"})
+      assert Permissions.verdict_for(effective, "Bash") == "auto_deny"
+    end
+
+    test "nil on either side is an empty policy" do
+      assert Permissions.verdict_for(Permissions.effective(nil, nil), "Bash") == "auto_allow"
+
+      assert Permissions.verdict_for(Permissions.effective(nil, %{"Bash" => "auto_deny"}), "Bash") ==
+               "auto_deny"
+    end
+  end
+
+  describe "check_narrows/2" do
+    test "narrowing is allowed" do
+      assert :ok =
+               Permissions.check_narrows(%{"default" => "auto_allow"}, %{"Bash" => "auto_deny"})
+
+      assert :ok = Permissions.check_narrows(%{}, %{"default" => "auto_deny"})
+      assert :ok = Permissions.check_narrows(nil, nil)
+    end
+
+    test "an equal policy is allowed" do
+      assert :ok = Permissions.check_narrows(%{"Bash" => "auto_deny"}, %{"Bash" => "auto_deny"})
+    end
+
+    test "widening a named tool is refused, and names it" do
+      assert {:error, {:permission_policy_widens, "Bash"}} =
+               Permissions.check_narrows(%{"Bash" => "auto_deny"}, %{"Bash" => "auto_allow"})
+    end
+
+    test "widening the default is refused" do
+      assert {:error, {:permission_policy_widens, "default"}} =
+               Permissions.check_narrows(%{"default" => "auto_deny"}, %{"default" => "auto_allow"})
+    end
+
+    test "widening a tool the agent covered only by its default is refused" do
+      # The launch names a tool the agent never did. Comparing key sets alone
+      # would miss this: the agent's default is what covers Bash.
+      assert {:error, {:permission_policy_widens, "Bash"}} =
+               Permissions.check_narrows(%{"default" => "auto_deny"}, %{"Bash" => "auto_allow"})
+    end
+
+    test "a launch lowering only the default still loosens the agent's tools" do
+      assert {:error, {:permission_policy_widens, _}} =
+               Permissions.check_narrows(
+                 %{"default" => "auto_deny", "Read" => "auto_deny"},
+                 %{"default" => "auto_allow"}
+               )
+    end
+  end
+
+  describe "tool_name/1" do
+    test "prefers the agent's title, falls back to ACP's kind" do
+      assert Permissions.tool_name(%{"toolCall" => %{"title" => "Bash", "kind" => "execute"}}) ==
+               "Bash"
+
+      assert Permissions.tool_name(%{"toolCall" => %{"kind" => "execute"}}) == "execute"
+      assert Permissions.tool_name(%{"toolCall" => %{"title" => ""}}) == nil
+    end
+
+    test "a request with no tool call falls through to the default" do
+      assert Permissions.tool_name(%{"options" => []}) == nil
+
+      assert Permissions.outcome(%{"default" => "auto_deny"}, req([reject_once()])) ==
+               %{outcome: "selected", optionId: "ro"}
+    end
+  end
+
+  describe "ask" do
+    test "is a verdict, but not one that can be honoured yet" do
+      assert "ask" in Permissions.verdicts()
+      refute Permissions.buildable?("ask")
+      assert Permissions.buildable?("auto_allow")
+      assert Permissions.buildable?("auto_deny")
+    end
+
+    test "denies rather than allows if it ever reaches the peer" do
+      # It cannot today — refused where a policy is written, and clamping never
+      # invents it — but the safe reading is written down rather than assumed.
+      assert %{outcome: "selected", optionId: "ro"} =
+               Permissions.outcome(%{"default" => "ask"}, req([allow_always(), reject_once()]))
+    end
+
+    test "is stricter than allow and looser than deny" do
+      assert Permissions.stricter("auto_allow", "ask") == "ask"
+      assert Permissions.stricter("ask", "auto_deny") == "auto_deny"
+    end
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -475,6 +475,79 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       assert outcome["optionId"] == "yes"
     end
 
+    test "a policy that denies a tool picks the agent's own rejection, and reports it", ctx do
+      pid = start_peer(ctx, permission_policy: %{"Bash" => "auto_deny"})
+      _init = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => 101,
+          "method" => "session/request_permission",
+          "params" => %{
+            "toolCall" => %{"title" => "Bash", "kind" => "execute"},
+            "options" => [
+              %{"optionId" => "yes", "kind" => "allow_always"},
+              %{"optionId" => "no", "kind" => "reject_once"}
+            ]
+          }
+        }) <> "\n"
+      )
+
+      assert %{"id" => 101, "result" => %{"outcome" => outcome}} = next_write()
+      assert outcome["outcome"] == "selected"
+      assert outcome["optionId"] == "no"
+
+      # The refusal reaches the owner so it can be audited in the context.
+      assert_receive {:acp, _ref, {:permission_denied, "Bash", "auto_deny"}}
+    end
+
+    test "a denied tool with no rejection offered is cancelled, never allowed", ctx do
+      pid = start_peer(ctx, permission_policy: %{"default" => "auto_deny"})
+      _init = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => 102,
+          "method" => "session/request_permission",
+          "params" => %{
+            "toolCall" => %{"title" => "Bash"},
+            "options" => [%{"optionId" => "yes", "kind" => "allow_always"}]
+          }
+        }) <> "\n"
+      )
+
+      assert %{"id" => 102, "result" => %{"outcome" => %{"outcome" => "cancelled"}}} =
+               next_write()
+    end
+
+    test "a tool the policy does not name is still allowed, and is not reported", ctx do
+      pid = start_peer(ctx, permission_policy: %{"Bash" => "auto_deny"})
+      _init = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => 103,
+          "method" => "session/request_permission",
+          "params" => %{
+            "toolCall" => %{"title" => "Read"},
+            "options" => [%{"optionId" => "yes", "kind" => "allow_always"}]
+          }
+        }) <> "\n"
+      )
+
+      assert %{"id" => 103, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
+
+      # Allows are deliberately not recorded — a row each would make the audit
+      # trail a second copy of the transcript.
+      refute_receive {:acp, _ref, {:permission_denied, _, _}}, 50
+    end
+
     test "an fs/* request is refused, not ignored", ctx do
       # Silence would block the agent forever. We declared no fs capability, so
       # the honest answer is method-not-found.

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -67,6 +67,15 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.BuzzProvisionRequest, "respond_to"} => {BuzzIdentity, :respond_to_modes},
     {FountainWeb.Schemas.BuzzAccessUpdateRequest, "respond_to"} =>
       {BuzzIdentity, :respond_to_modes},
+    # The permission verdicts a policy may actually name today. Deliberately
+    # `buildable_verdicts/0` and not `verdicts/0`: "ask" is a real verdict the
+    # domain knows about, with nowhere to ask until #940, and both doors refuse
+    # it — so publishing it in the spec would advertise a value every request
+    # carrying it gets a 422 for.
+    {FountainWeb.Schemas.Agent, "permission_policy.{}"} =>
+      {Fountain.Permissions, :buildable_verdicts},
+    {FountainWeb.Schemas.ConversationCreateRequest, "permission_policy.{}"} =>
+      {Fountain.Permissions, :buildable_verdicts},
     {FountainWeb.Schemas.Conversation, "status"} => {Conversation, :statuses},
     {FountainWeb.Schemas.Conversation, "source"} => {Conversation, :sources},
     {FountainWeb.Schemas.ConversationTreeNode, "status"} => {Conversation, :statuses},

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1858,6 +1858,10 @@ export interface components {
             fresh?: boolean | null;
             /** @description Optional images to attach to the initial prompt. */
             images?: components["schemas"]["ImageInput"][] | null;
+            /** @description Per-launch permission override (#939). Merged with the agent's own policy, taking the stricter of the two per tool. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped. */
+            permission_policy?: {
+                [key: string]: "auto_allow" | "auto_deny";
+            } | null;
             /** @description Optional first turn prompt. */
             prompt?: string;
             /** @description Override the auto-generated sprite name. */
@@ -2423,6 +2427,10 @@ export interface components {
             /** @description Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The provider must match the runtime — anthropic for claude, openai for codex, google for gemini; opencode accepts any of the three. Other providers are rejected: Fountain has no credentials to export for them. The model id is not checked against a list, so a newly released model works without a Fountain release. */
             model: string;
             name: string;
+            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" is a known verdict but is not supported yet (422 permission_policy_unbuilt). */
+            permission_policy?: {
+                [key: string]: "auto_allow" | "auto_deny";
+            } | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode";
             /**


### PR DESCRIPTION
Closes #939. ADR 0014 gate 3, decided in #944.

## The problem, as it actually stands today

Every runtime used to run with its safety rail off behind a vendor flag. **Three of those four flags are already gone**, deleted with the legacy spawn path (#671–#675). What replaced them was a constant in `ACP.Peer`:

```elixir
defp permission_outcome(params) do
  chosen =
    Enum.find(options, &(&1["kind"] == "allow_always")) ||
      Enum.find(options, &(&1["kind"] == "allow_once")) ||
      List.first(options)
  ...
```

The rail is still off — but it is off in one function we own, which already has the tool name and the option list in hand and throws them away. That is a policy problem, not a fork-four-CLIs problem, and this PR is the policy.

## Narrow, never widen

`Fountain.Permissions` is a map of tool name to verdict plus a `"default"` key, held on the agent and overridable per launch (the `environment_id` shape from #783).

**A launch may only make the policy more restrictive.** That one rule is the no-escalation guarantee, and it is why this needs **no `allowed_permission_*` list** beside it the way `environment_id` needs `allowed_environment_ids`: a launch cannot reach a permission the agent did not already grant, so there is nothing to allow-list.

It is enforced twice, on purpose:

- `check_narrows/2` refuses a widening launch **at the door**, naming the tool (422 `permission_policy_widens`).
- `effective/2` **clamps** regardless — the merge takes the stricter of the two per tool.

The clamp is the invariant the peer depends on; the door check is the good error message. Refusing rather than silently clamping matters because a caller who asked to loosen a policy and quietly got a tighter one has no way to learn the ask was a mistake.

Clamping per turn — rather than storing a pre-merged policy on the conversation row — is what makes a **later tightening of the agent apply to conversations already running under it**.

## This ships as a no-op

The default is `auto_allow`, and `auto_allow` keeps the old ladder **verbatim** — including the final `List.first(options)` rung. That last rung is what makes this parity rather than a near-miss: an adapter offering only bespoke option kinds is answered exactly as it was before.

`auto_deny` has no such rung, deliberately. Falling back to "whatever was offered first" would select an **allow** on any adapter that lists its options that way, which is the one thing `auto_deny` must never do. It picks a `reject_*` when one is offered, `cancelled` when none is, and never synthesises an `optionId` the agent did not advertise.

## Also here

- **Denials audited in the context** (0013): tool and verdict, actor `sprite`, never the tool's input. Allows are not recorded — a turn makes dozens of tool calls and a row each would make the trail a second copy of the transcript. Policy *changes* turned out to be covered already by `agent.updated`'s `changed_fields`; there is a test pinning that so it stays true.
- **The reattach path gets the same policy.** A reattached peer answers permission requests exactly like a fresh one, and resolving from the agent there is what makes a tightening survive a deploy.
- **Errors that name the problem:** `permission_policy_widens` (with the tool), `permission_policy_unbuilt`, `permission_policy_invalid`.

## `ask` is refused, not half-built

`ask` is a real verdict with nowhere to ask until #940 builds the stream event and the answer endpoint. Both doors refuse it rather than degrading to an allow (unsafe) or hanging the turn on a prompt nobody will see — which is worse than it sounds: `Lifecycle.check/4` suppresses only the *idle* verdict when busy, and per 0017 the idle bound suspends while the ceiling destroys. An unanswered prompt does not hang forever; it burns the max lifetime and then takes the agent's memory with it (#649).

The published enum is `buildable_verdicts/0`, not `verdicts/0`, so the spec does not advertise a value every request carrying it gets a 422 for. The `SchemaEnumGuardrailTest` caught that this needed declaring against a domain function — it is wired to `Fountain.Permissions`, not exempted.

## Verified by reverting

Each of these breaks the suite, and restoring gives 0 failures:

| break | fails |
|---|---|
| drop the `List.first` parity rung | 1 |
| `effective/2` takes the launch value instead of the stricter | 2 |
| `check_narrows/2` ignores the defaults | 1 |
| give `auto_deny` a first-option fallback | 1 |

## Checks

`mix test` — **3,331 tests, 0 failures**. `mix format --check-formatted`, `mix credo --strict` (no issues), `mix deps.unlock --unused`, `mix sobelow --config`, `MIX_ENV=dev mix dialyzer` (**0 errors**), and `mix openapi.spec.json` + `jq empty` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
