### PR TITLE
docs: reframe the marketing landing page to match the home page

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -1,10 +1,10 @@
 <%!-- Hero --%>
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    Stop wiring up Claude instances by hand.
+    Have the conversation. Skip the infrastructure.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    Fountain gives your whole team preconfigured, sandboxed AI agents — zero local setup, real-time logs, and credentials that never drift.
+    Fountain runs an agent on a cloud sandbox and hands your app a conversation with it. Send a prompt, read the reply. The sandbox parks between messages and wakes with its work intact — and you never provision, secure, or pay for an idle machine.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a
@@ -32,28 +32,25 @@
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-16">
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-6 text-center">
-      Manual configuration doesn't scale.
+      The agent is the easy part.
     </h2>
     <ul class="max-w-xl mx-auto space-y-4 text-[var(--color-text-secondary)]">
       <li class="flex items-start gap-3">
         <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
         <span>
-          New teammates spend afternoons reverse-engineering setup instead of writing code.
+          An agent needs a machine: a filesystem, a shell, a package manager, a network. That is real infrastructure, and it is not the thing you set out to build.
         </span>
       </li>
       <li class="flex items-start gap-3">
         <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
         <span>
-          API keys expire mid-sprint with no single source of truth — the wrong <code
-            class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm"
-            phx-no-format
-          >.env</code> silently breaks the agent.
+          It needs real credentials, and those must never reach the prompt, the model's context, or the logs you keep.
         </span>
       </li>
       <li class="flex items-start gap-3">
         <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
         <span>
-          Parallel tasks with different credentials mean maintaining separate local checkouts.
+          Something has to start that machine, park it when nobody is talking, wake it on the next message, and keep every account's work apart.
         </span>
       </li>
     </ul>
@@ -63,7 +60,7 @@
 <%!-- Feature cards --%>
 <section class="max-w-5xl mx-auto px-6 py-16">
   <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
-    Everything you need, nothing you don't.
+    What you stop building.
   </h2>
   <div class="grid sm:grid-cols-2 gap-6">
     <%!-- Self-serve onboarding --%>
@@ -83,10 +80,10 @@
         </svg>
       </div>
       <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-        Teammates onboard themselves
+        Your users stay apart
       </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        A new engineer gets a URL, registers, and is running their first agent conversation before they've read a README. No documentation handoff, no ticket to the platform team.
+        Every query is scoped to the caller, so one account never reaches another's agents or sandboxes. Build a product on top and your own users are isolated from each other without you writing a line for it.
       </p>
     </div>
 
@@ -107,10 +104,10 @@
         </svg>
       </div>
       <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-        Switch credentials without touching config
+        Credentials that never reach the prompt
       </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Vaults are encrypted per-conversation overrides layered on top of your baseline environment. Test against staging, scope a contractor's access, or rotate a single key — without duplicating your setup.
+        Environments and Vaults merge when the sandbox spawns and arrive as ordinary environment variables. They stay out of the prompt and the model's context, and Fountain scrubs them from the output it stores.
       </p>
     </div>
 
@@ -131,14 +128,13 @@
         </svg>
       </div>
       <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-        Debug in seconds, not sessions
+        Watch any turn, live
       </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Every conversation's stdout, stderr, and lifecycle events stream live, turn by turn, in the
-        conversations app. No <code
+        Output and lifecycle events stream over SSE as they happen. Ask for <code
           class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
           phx-no-format
-        >curl -N</code> to a raw SSE endpoint, no log pipeline to stand up. Open a conversation and see exactly what happened.
+        >?blocks=true</code> and the server parses each runtime's dialect for you, so your client renders one shape instead of four.
       </p>
     </div>
 
@@ -155,13 +151,13 @@
         </svg>
       </div>
       <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-        Script it, click it, or pipe it to CI
+        Reach it the way you already build
       </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        REST API for automation, browser apps for hands-on work, and a <code
+        ACP for an editor or a chat surface, AG-UI for a coworker platform, REST and SSE for your own code, plus a TypeScript SDK and a <code
           class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
           phx-no-format
-        >fountain</code> CLI for pipelines — all reading and writing the same Environments, Agents, and Conversations. Pick the interface that fits the job.
+        >fountain</code> CLI. The people using what you build need never learn that an agent is there.
       </p>
     </div>
   </div>
@@ -206,7 +202,7 @@
     Start your free 14-day trial.
   </h2>
   <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
-    Spin up your first sandboxed agent conversation in under ten minutes. No credit card required.
+    Your first conversation runs in minutes. There is no machine to provision, and no credit card to enter.
   </p>
   <a
     href={~p"/auth/register"}


### PR DESCRIPTION
`/` still ran the story #945 removed from the docs home page.

| Was | Now |
|---|---|
| **"Stop wiring up Claude instances by hand."** | **"Have the conversation. Skip the infrastructure."** |
| "Fountain gives your whole team preconfigured, sandboxed AI agents — zero local setup…" | "Fountain runs an agent on a cloud sandbox and hands your app a conversation with it. Send a prompt, read the reply. The sandbox parks between messages and wakes with its work intact — and you never provision, secure, or pay for an idle machine." |
| **"Manual configuration doesn't scale."** | **"The agent is the easy part."** |

The old hero also named a single vendor, and Fountain runs four runtimes.

The three problem bullets were "new teammates reverse-engineering setup",
"API keys expire mid-sprint … the wrong `.env`", and "separate local
checkouts" — the same narrow persona, an engineer already running an agent
locally. They are now the machine behind the agent, its credentials, and its
lifecycle and tenancy: infrastructure, and not your product.

## The four cards keep their icons

Each card's art still fits what it claims, so nothing needed redrawing.

| Icon | Now claims |
|---|---|
| person | **Your users stay apart** — every query scoped to the caller, so your own users are isolated without you writing a line |
| padlock | **Credentials that never reach the prompt** — Environments and Vaults merge at spawn as env vars, and Fountain scrubs them from stored output |
| monitor | **Watch any turn, live** — SSE, and `?blocks=true` parses each runtime's dialect so your client renders one shape instead of four |
| panels | **Reach it the way you already build** — ACP, AG-UI, REST and SSE, the TypeScript SDK, the `fountain` CLI, and "the people using what you build need never learn that an agent is there" |

## Pricing is untouched, deliberately

`marketing_pricing_test.exs` asserts these verbatim, and one test asserts
`/mo per team` is **absent** when billing is disabled. All four strings and the
`monthly_price()` guards are unchanged:

- `Free 14-day trial — then {monthly_price()}/mo per team. Cancel anytime.`
- `Free 14-day trial. Cancel anytime.`
- `{monthly_price()}/mo per team after trial. Cancel anytime. No lock-in.`
- `Cancel anytime. No lock-in.`

## Two things I did not touch, and think you should decide on

The **customer quotes** and the **"Teams reach their first conversation in
under 5 minutes on average"** figure.

Both are written in the framing this PR removes — one quote is about
maintaining "three separate `.env` files", the other about "onboarding the
last two engineers". So the page now argues one thing and quotes another.

I left them because I cannot verify either. If they are real early-access
quotes, deleting them is not my call. If they are placeholder copy, they should
go — and I am not going to write replacements, because invented testimonials
and an unsourced statistic are not something I will put on a page that asks
people for a credit card.

Tell me which and I will follow up.

## Verification

- `marketing_controller_test.exs`, `marketing_pricing_test.exs`,
  `marketing_legal_unpublished_test.exs` — 15 tests, 0 failures
- `mix format --check-formatted` on the template (HEEx), run unpiped
- Full suite: **3289 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
