### PR TITLE
fix: the landing page priced per team, and billing is per user

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -21,7 +21,7 @@
     </a>
   </div>
   <p :if={monthly_price()} class="text-xs text-[var(--color-text-muted)]">
-    Free 14-day trial — then {monthly_price()}/mo per team. Cancel anytime.
+    Free 14-day trial — then {monthly_price()}/mo per user. Cancel anytime.
   </p>
   <p :if={!monthly_price()} class="text-xs text-[var(--color-text-muted)]">
     Free 14-day trial. Cancel anytime.
@@ -211,7 +211,7 @@
     Get started free
   </a>
   <p :if={monthly_price()} class="mt-4 text-sm text-[var(--color-text-muted)]">
-    {monthly_price()}/mo per team after trial. Cancel anytime. No lock-in.
+    {monthly_price()}/mo per user after trial. Cancel anytime. No lock-in.
   </p>
   <p :if={!monthly_price()} class="mt-4 text-sm text-[var(--color-text-muted)]">
     Cancel anytime. No lock-in.

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -19,22 +19,22 @@ defmodule FountainWeb.MarketingPricingTest do
     Application.put_env(:fountain, :stripe_price_monthly_cents, 2900)
 
     body = conn |> get(~p"/") |> html_response(200)
-    assert body =~ "then $29/mo per team"
-    assert body =~ "$29/mo per team after trial"
+    assert body =~ "then $29/mo per user"
+    assert body =~ "$29/mo per user after trial"
   end
 
   test "non-whole-dollar prices render with cents", %{conn: conn} do
     Application.put_env(:fountain, :stripe_price_monthly_cents, 2950)
 
     body = conn |> get(~p"/") |> html_response(200)
-    assert body =~ "$29.50/mo per team"
+    assert body =~ "$29.50/mo per user"
   end
 
   test "omits the price when STRIPE_PRICE_MONTHLY_CENTS is unset", %{conn: conn} do
     Application.put_env(:fountain, :stripe_price_monthly_cents, nil)
 
     body = conn |> get(~p"/") |> html_response(200)
-    refute body =~ "/mo per team"
+    refute body =~ "/mo per"
     assert body =~ "Free 14-day trial. Cancel anytime."
     assert body =~ "Cancel anytime. No lock-in."
   end
@@ -44,6 +44,6 @@ defmodule FountainWeb.MarketingPricingTest do
     Application.put_env(:fountain, :billing_enabled, false)
 
     body = conn |> get(~p"/") |> html_response(200)
-    refute body =~ "/mo per team"
+    refute body =~ "/mo per"
   end
 end


### PR DESCRIPTION
Both pricing lines on `/` said **"$29/mo per team"**. Fountain does not bill a
team.

- `subscription_status` is a column on the **users** table.
- One subscription belongs to one account.
- The admin MRR tile is `active subscriptions × the configured monthly price`
  (`ee/lib/fountain/billing.ex`).

So the page overstated what a customer gets for the money. Both lines now say
**per user**.

```
- Free 14-day trial — then {monthly_price()}/mo per team. Cancel anytime.
+ Free 14-day trial — then {monthly_price()}/mo per user. Cancel anytime.

- {monthly_price()}/mo per team after trial. Cancel anytime. No lock-in.
+ {monthly_price()}/mo per user after trial. Cancel anytime. No lock-in.
```

Those two are the only places in the repo where a price carries a unit — I
swept `apps/`, `ee/` and `docs/` for `$29`, `/month`, `per seat` and `per user`
before changing anything. Nothing else needed to move.

## The test needed more than a find-and-replace

`marketing_pricing_test.exs` pinned all five of its assertions to the old noun.

The **three asserts** follow the copy, which is what they are for.

The **two refutes** are different. They mean *"no pricing line rendered"* — once
when `STRIPE_PRICE_MONTHLY_CENTS` is unset, once when billing is disabled.
Pinning them to the noun meant the next rename would leave them **passing while
a price leaked**. They now refute `"/mo per"`, which survives a wording change
and still fails if a price appears:

```diff
- refute body =~ "/mo per team"
+ refute body =~ "/mo per"
```

## Verification

- 15 marketing tests (pricing, controller, legal-unpublished), 0 failures
- `mix format --check-formatted` on both changed files, run unpiped
- Full suite: **3289 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
