### PR TITLE
feat(acp): the ask path — surface a permission request, and take the answer (#940)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1664,6 +1664,58 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  Answer a permission request a running agent is blocked on (#940).
+
+  Tenant-scoped: the conversation is fetched for `user_id` first, so a request
+  id from another tenant reads as not found rather than as a permission error.
+
+  **A sprite may not answer its own prompt.** It holds a `FOUNTAIN_TOKEN` and
+  could otherwise approve the very tool it just asked for, which would make the
+  policy decorative. The loop is closed by name here rather than left to the
+  actor vocabulary to imply.
+
+  Audited as a decision about tenant-owned state, per 0013: the tool and the
+  verdict, never the tool's input.
+  """
+  @spec answer_permission_request(binary(), binary(), String.t(), String.t(), keyword()) ::
+          :ok | {:error, term()}
+  def answer_permission_request(conv_id, user_id, request_id, option_id, opts \\ [])
+      when is_binary(conv_id) and is_binary(user_id) do
+    actor = Keyword.get(opts, :actor, "self")
+
+    cond do
+      actor == "sprite" ->
+        {:error, :sprite_may_not_answer}
+
+      is_nil(get_conversation(conv_id, user_id)) ->
+        {:error, :not_found}
+
+      true ->
+        do_answer_permission(conv_id, user_id, request_id, option_id, opts)
+    end
+  end
+
+  defp do_answer_permission(conv_id, user_id, request_id, option_id, opts) do
+    case ConversationServer.answer_permission(conv_id, request_id, option_id) do
+      :ok ->
+        Audit.record(%{
+          user_id: user_id,
+          action: "conversation.permission_answered",
+          resource_type: "conversation",
+          resource_id: conv_id,
+          actor: Keyword.get(opts, :actor, "self"),
+          request_ip: Keyword.get(opts, :request_ip),
+          metadata: %{"request_id" => request_id, "option_id" => option_id}
+        })
+
+        :ok
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc """
   Record that the permission policy withheld a tool from a running agent.
 
   Called by the `ConversationServer` when its peer reports a refusal (#939).

--- a/apps/fountain/lib/fountain/conversations/blocks.ex
+++ b/apps/fountain/lib/fountain/conversations/blocks.ex
@@ -30,6 +30,7 @@ defmodule Fountain.Conversations.Blocks do
   | `:result` | `body`, `raw` |
   | `:error` | `body` |
   | `:raw` | `body`, `summary` |
+  | `:permission_request` | `request_id`, `name`, `summary`, `options` |
 
   A `tool_result` is paired to its `tool_use` on `tool_id`; that is the
   client's pass (`pair_tool_results` in the LiveView, the same in the SPA),
@@ -38,7 +39,7 @@ defmodule Fountain.Conversations.Blocks do
 
   alias Fountain.Runtimes.{ACP, LegacyBlocks}
 
-  @kinds ~w(text thinking tool_use tool_result init result error raw)
+  @kinds ~w(text thinking tool_use tool_result init result error raw permission_request)
 
   @doc "Every `kind` a block can have — the wire enum."
   def kinds, do: @kinds

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -193,6 +193,28 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   @doc """
+  Answer an outstanding permission request (#940).
+
+  Tenant scoping is the caller's job — reach this through
+  `Conversations.answer_permission_request/4`, which establishes ownership
+  first.
+
+  `{:error, :no_pending_permission}` covers every "too late": another attached
+  client answered it, the timeout denied it, the turn ended, or the server is
+  no longer running. That is deliberately not distinguished from "never
+  existed" — a client that lost the race and a client guessing ids get the same
+  answer.
+  """
+  @spec answer_permission(binary(), String.t(), String.t()) ::
+          :ok | {:error, :no_pending_permission | :unknown_option | :not_running}
+  def answer_permission(conv_id, request_id, option_id) do
+    case whereis(conv_id) do
+      nil -> {:error, :not_running}
+      pid -> call_server(pid, {:answer_permission, request_id, option_id})
+    end
+  end
+
+  @doc """
   Terminate the conversation. If the GenServer is alive, it tears down the
   sprite. If not, just mark the DB rows terminated so the user can still
   clean up dead conversations after a server restart.
@@ -355,6 +377,8 @@ defmodule Fountain.Conversations.ConversationServer do
       # rather than linked: a protocol bug must fail a turn, not take down a
       # server that is holding a sprite handle and a tenant's secrets.
       acp_peer: nil,
+      # Timer refusing an unanswered permission request (#940).
+      permission_timer: nil,
       acp_peer_mon: nil,
       # Bytes of replayed output to drop on reattach, keyed by stream.
       # Empty map outside a reattach window. See attempt_session_attach.
@@ -1087,7 +1111,13 @@ defmodule Fountain.Conversations.ConversationServer do
         # Resolving from the agent here (rather than reading a policy frozen on
         # the conversation row) is what makes a tightening apply across a
         # deploy.
-        permission_policy: effective_permission_policy(conv, agent_for(conv))
+        permission_policy: effective_permission_policy(conv, agent_for(conv)),
+        # Hand back the request the previous peer was holding, if any (#940).
+        # The agent minted the JSON-RPC id and is still blocked on it, so the
+        # id outlives our process — but only if we wrote it down. This is the
+        # same trap `acp_prompt_id` exists for, and the reason the turn row
+        # carries `pending_permission` at all.
+        pending_permission: running_turn.pending_permission
       )
 
     dedup =
@@ -1393,6 +1423,25 @@ defmodule Fountain.Conversations.ConversationServer do
      }}
   end
 
+  # First answer wins. The web apps and an editor (#708) are peer clients of
+  # this door, not fallbacks for one another, so a second answer to the same
+  # request is "too late" rather than an error in the caller.
+  def handle_call({:answer_permission, request_id, option_id}, _from, state) do
+    case state.acp_peer do
+      nil ->
+        {:reply, {:error, :no_pending_permission}, state}
+
+      peer ->
+        case Fountain.Runtimes.ACP.Peer.answer_permission(peer, request_id, option_id) do
+          :ok ->
+            {:reply, :ok, resolve_permission(state, request_id, "answered", option_id)}
+
+          {:error, reason} ->
+            {:reply, {:error, reason}, state}
+        end
+    end
+  end
+
   def handle_call(:terminate_conv, _from, state) do
     if state.handle, do: _ = Fountain.Sandbox.destroy(state.handle)
     sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
@@ -1548,6 +1597,65 @@ defmodule Fountain.Conversations.ConversationServer do
   def handle_info({:acp, ref, {:prompt_sent, id}}, %{current_command_ref: ref} = state) do
     {:ok, turn} = Conversations._unsafe_update_turn(state.current_turn, %{acp_prompt_id: id})
     {:noreply, %{state | current_turn: turn}}
+  end
+
+  # `ask`: the agent is blocked and a human has to answer (#940).
+  #
+  # Three things happen, and the order matters. The pending request is persisted
+  # on the turn first, so a deploy landing a millisecond later can still be
+  # answered; then the stage event goes out; then the timeout is armed.
+  #
+  # The timeout is not optional and it is not a tidiness measure.
+  # `Lifecycle.check/4` suppresses only the *idle* verdict while a turn is in
+  # flight, so an unanswered request would sail past the idle bound and be
+  # resolved by the max-lifetime ceiling — and per 0017 the idle bound suspends
+  # while the ceiling destroys. Left alone, a prompt nobody answers does not
+  # hang forever; it burns the whole lifetime and then takes the agent's memory
+  # with it (#649).
+  def handle_info(
+        {:acp, ref, {:permission_ask, request_id, tool, options}},
+        %{current_command_ref: ref} = state
+      ) do
+    pending = %{
+      "request_id" => request_id,
+      "tool" => tool,
+      "options" => options,
+      "asked_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+
+    state =
+      case state.current_turn do
+        nil ->
+          state
+
+        turn ->
+          {:ok, turn} = Conversations._unsafe_update_turn(turn, %{pending_permission: pending})
+          %{state | current_turn: turn}
+      end
+
+    publish_stage(state.conversation_id, "request", "started", %{
+      request_id: request_id,
+      tool: tool,
+      # The agent's own list, verbatim. A client must never offer an option
+      # that is not on it.
+      options: options,
+      timeout_ms: Fountain.Permissions.ask_timeout_ms()
+    })
+
+    timer =
+      Process.send_after(
+        self(),
+        {:permission_timeout, request_id},
+        Fountain.Permissions.ask_timeout_ms()
+      )
+
+    {:noreply, %{state | permission_timer: timer}}
+  end
+
+  # Nobody answered in time. Deny — the only safe default — and say so on the
+  # stream so a card stops waiting.
+  def handle_info({:permission_timeout, request_id}, state) do
+    {:noreply, resolve_permission(state, request_id, "timeout", nil)}
   end
 
   # A tool the policy withheld (#939). Recorded in the context, per 0013: the
@@ -1838,6 +1946,63 @@ defmodule Fountain.Conversations.ConversationServer do
   def handle_info({:EXIT, _from, reason}, state), do: {:stop, reason, state}
 
   def handle_info(_msg, state), do: {:noreply, state}
+
+  # The one place a held request stops being held, whoever ended it: an answer,
+  # the timeout, or the turn ending. Cancels the timer, clears the turn's
+  # `pending_permission`, and publishes the resolution so a card can close.
+  #
+  # `state: "done"` for every outcome, including a deny and a timeout. The stage
+  # and its status are the Prometheus counter's only tags and there is an alert
+  # on them — a timeout emitting `failed` would page someone for a policy doing
+  # exactly what it was told.
+  defp resolve_permission(state, request_id, outcome, option_id) do
+    if state.permission_timer, do: Process.cancel_timer(state.permission_timer)
+
+    # Read before the clear below wipes it.
+    tool = pending_tool(state)
+
+    if outcome != "answered" and state.acp_peer do
+      Fountain.Runtimes.ACP.Peer.deny_permission(state.acp_peer, request_id)
+    end
+
+    state =
+      case state.current_turn do
+        nil ->
+          state
+
+        turn ->
+          {:ok, turn} = Conversations._unsafe_update_turn(turn, %{pending_permission: nil})
+          %{state | current_turn: turn}
+      end
+
+    publish_stage(state.conversation_id, "request", "done", %{
+      request_id: request_id,
+      outcome: outcome,
+      option_id: option_id
+    })
+
+    if outcome != "answered" do
+      Conversations.record_permission_denied(state.conversation_id, tool, outcome)
+    end
+
+    %{state | permission_timer: nil}
+  end
+
+  defp pending_tool(%{current_turn: %{pending_permission: %{"tool" => tool}}}), do: tool
+  defp pending_tool(_state), do: nil
+
+  # Resolve whatever is held, if anything. The turn row is the source of truth
+  # rather than the timer, so this is also correct for a request raised by a
+  # previous BEAM lifetime and reattached to.
+  defp resolve_pending_permission(state, outcome) do
+    case state.current_turn do
+      %{pending_permission: %{"request_id" => request_id}} ->
+        resolve_permission(state, request_id, outcome, nil)
+
+      _ ->
+        state
+    end
+  end
 
   # The absolute lifetime ceiling measures a continuous run, not calendar age:
   # a wake from `suspended` stamps `last_resumed_at` and restarts the clock,
@@ -2799,6 +2964,12 @@ defmodule Fountain.Conversations.ConversationServer do
   defp finalize_tracer(tracer), do: Fountain.Runtimes.ACP.Tracer.finalize(tracer)
 
   defp finish_acp_turn(state, status, span_attrs, stage_meta) do
+    # Resolve a held permission request before the peer goes away (#940). The
+    # agent's blocked request dies with the process either way, but a card left
+    # open is a client waiting on an answer that can never arrive, and the
+    # turn's `pending_permission` would stay set on a turn that is over.
+    state = resolve_pending_permission(state, "turn_ended")
+
     if state.current_command, do: Fountain.Sandbox.close_stdin(state.current_command)
     stop_acp_peer(state)
 

--- a/apps/fountain/lib/fountain/conversations/turn.ex
+++ b/apps/fountain/lib/fountain/conversations/turn.ex
@@ -19,6 +19,11 @@ defmodule Fountain.Conversations.Turn do
     # JSON-RPC id of the ACP `session/prompt` in flight; nil on the legacy
     # path and until the peer has written the prompt. See the migration.
     field :acp_prompt_id, :integer
+    # The `session/request_permission` this turn is blocked on (#940): the
+    # agent's JSON-RPC id, the tool, and the options it offered. nil whenever
+    # nothing is outstanding. Persisted so a request raised before a deploy is
+    # still answerable after one.
+    field :pending_permission, :map
     # The turn's token usage as the runtime reported it when the turn ended
     # (#827): `%{"input" => n, "output" => n, "cache_read" => n?,
     # "cache_write" => n?}`. Written once by `Conversations._unsafe_record_turn_usage/2`,
@@ -47,6 +52,7 @@ defmodule Fountain.Conversations.Turn do
       :started_at,
       :ended_at,
       :acp_prompt_id,
+      :pending_permission,
       :usage,
       :reply_text,
       :conversation_id

--- a/apps/fountain/lib/fountain/permissions.ex
+++ b/apps/fountain/lib/fountain/permissions.ex
@@ -48,7 +48,7 @@ defmodule Fountain.Permissions do
   |---|---|
   | `auto_allow` | today's behaviour: `allow_always`, else `allow_once`, else the first option offered |
   | `auto_deny` | a `reject_*` option when the agent offered one, `cancelled` when it did not |
-  | `ask` | a human. **Not built** — see #940; rejected at the door until it is |
+  | `ask` | a human, over the stream, within the timeout — then deny (#940) |
 
   `auto_allow` is the default, so adopting a policy changes nothing until
   someone writes one.
@@ -76,6 +76,40 @@ defmodule Fountain.Permissions do
 
   @default_key "default"
 
+  # Well under `Lifecycle.idle_timeout_seconds/0` (60 minutes by default), and
+  # deliberately so: a held request suppresses only the idle verdict, so one
+  # that outlived the idle bound would be resolved by the max-lifetime ceiling
+  # instead — which destroys the sandbox rather than parking it (0017). The
+  # timeout has to fire first for an unanswered prompt to cost a turn rather
+  # than the agent's memory.
+  @default_ask_timeout_seconds 300
+
+  @doc """
+  How long a held `ask` waits for a human before it is denied.
+
+  Deny on expiry is the only safe default. Configurable with
+  `:permission_ask_timeout_seconds`; a value at or above the idle bound is a
+  misconfiguration, for the reason in the comment above this function.
+  """
+  @spec ask_timeout_ms() :: pos_integer()
+  def ask_timeout_ms do
+    :fountain
+    |> Application.get_env(:permission_ask_timeout_seconds, @default_ask_timeout_seconds)
+    |> to_positive_seconds(@default_ask_timeout_seconds)
+    |> Kernel.*(1000)
+  end
+
+  defp to_positive_seconds(n, _default) when is_integer(n) and n > 0, do: n
+
+  defp to_positive_seconds(n, default) when is_binary(n) do
+    case Integer.parse(n) do
+      {i, _} when i > 0 -> i
+      _ -> default
+    end
+  end
+
+  defp to_positive_seconds(_n, default), do: default
+
   @doc "Every verdict a policy may name."
   @spec verdicts() :: [String.t()]
   def verdicts, do: @verdicts
@@ -85,17 +119,22 @@ defmodule Fountain.Permissions do
   def default_verdict, do: @auto_allow
 
   @doc """
-  Verdicts that can be honoured today.
+  Verdicts that can be honoured.
 
-  `ask` is a valid policy value with nowhere to ask: #940 builds the stream
-  event and the answer endpoint. Until then it is refused where a policy is
-  written, rather than degrading to an allow (unsafe) or hanging the turn
-  forever (worse — see the note on the ceiling in 0014 gate 3).
+  All three, since #940 built somewhere to ask: the peer holds the request
+  open, the request renders as a `permission_request` block, and
+  `POST /api/conversations/:id/requests/:request_id` answers it. Before that
+  `ask` was a valid policy value with nowhere to ask, and both doors refused
+  it.
+
+  Kept as its own list rather than folded into `verdicts/0` because the
+  published OpenAPI enum reads from here: a verdict the API would 422 on must
+  not be advertised as accepted.
   """
   @spec buildable_verdicts() :: [String.t()]
-  def buildable_verdicts, do: [@auto_allow, @auto_deny]
+  def buildable_verdicts, do: @verdicts
 
-  @doc "Whether `verdict` can be honoured today. False for `ask` until #940."
+  @doc "Whether `verdict` can be honoured."
   @spec buildable?(String.t()) :: boolean()
   def buildable?(verdict), do: verdict in buildable_verdicts()
 
@@ -181,8 +220,10 @@ defmodule Fountain.Permissions do
 
     case verdict_for(normalize(policy), tool_name(params)) do
       @auto_deny -> deny(options)
-      # `ask` cannot reach here: it is refused where a policy is written, and
-      # clamping never invents it. Denying is the safe reading if it ever does.
+      # `ask` is not answered here — the peer holds the request open and a human
+      # answers it (#940). Denying is the safe reading if a caller asks this
+      # function for an outcome anyway, and `deny_outcome/1` is what the timeout
+      # and the turn's end use directly.
       @ask -> deny(options)
       _ -> allow(options)
     end
@@ -237,7 +278,17 @@ defmodule Fountain.Permissions do
   # would pick an *allow* on any adapter that lists its options that way, which
   # is the one thing `auto_deny` must never do. An adapter that offers no
   # rejection gets `cancelled` — the protocol's own "nothing was selected".
-  defp deny(options) do
+  defp deny(options), do: deny_outcome(options)
+
+  @doc """
+  The outcome that refuses a request, from the options the agent offered.
+
+  Public because #940's timeout and end-of-turn paths refuse a *held* request
+  directly, without a policy in hand — the policy already said `ask`, and what
+  is being decided at that point is only that nobody answered.
+  """
+  @spec deny_outcome([map()]) :: map()
+  def deny_outcome(options) do
     select(options, ~w(reject_always reject_once)) || cancelled()
   end
 

--- a/apps/fountain/lib/fountain/runtimes/acp/blocks.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/blocks.ex
@@ -62,10 +62,42 @@ defmodule Fountain.Runtimes.ACP.Blocks do
   @spec from_line(String.t()) :: [map()]
   def from_line(line) do
     case Protocol.classify_line(line) do
-      {:notification, "session/update", params} -> from_update(params)
-      {:invalid, raw} -> [%{kind: :raw, body: raw, summary: "raw"}]
-      _ -> []
+      {:notification, "session/update", params} ->
+        from_update(params)
+
+      # The one *request* that renders. The agent is blocked on it and a human
+      # has to answer, so it belongs inline in the transcript beside the tool
+      # call it is about, not on a separate channel a client correlates by hand
+      # (#940). Its resolution arrives as a `request` stage event and is paired
+      # here on `request_id` — the same pass that already pairs a `tool_result`
+      # to its `tool_use` on `tool_id`.
+      {:request, id, "session/request_permission", params} ->
+        permission_blocks(id, params)
+
+      {:invalid, raw} ->
+        [%{kind: :raw, body: raw, summary: "raw"}]
+
+      _ ->
+        []
     end
+  end
+
+  # `params` is always a map: `Protocol.classify/1` defaults it to `%{}`.
+  defp permission_blocks(id, params) do
+    call = Map.get(params, "toolCall") || %{}
+
+    [
+      %{
+        kind: :permission_request,
+        request_id: to_string(id),
+        name: tool_name(call),
+        summary: tool_summary(call),
+        # Exactly what the agent offered, in its order. A client must never
+        # synthesise an option that is not on this list — the same fail-closed
+        # rule `Fountain.Permissions` follows server-side.
+        options: Enum.filter(Map.get(params, "options") || [], &is_map/1)
+      }
+    ]
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -124,6 +124,11 @@ defmodule Fountain.Runtimes.ACP.Peer do
       # merged and clamped by `Permissions.effective/2` before it gets here —
       # the peer applies it, it does not resolve it.
       permission_policy: %{},
+      # `ask`: the JSON-RPC id of a `session/request_permission` the agent is
+      # still blocked on, with the options it offered. One at a time — the
+      # agent cannot proceed until it is answered — so a single slot is
+      # enough. nil whenever nothing is outstanding.
+      pending_permission: nil,
       buffer: "",
       next_id: 1,
       pending: %{},
@@ -173,6 +178,34 @@ defmodule Fountain.Runtimes.ACP.Peer do
   """
   def cancel(pid), do: GenServer.cast(pid, :cancel)
 
+  @doc """
+  Answer an outstanding `session/request_permission` with one of the options
+  the agent offered.
+
+  `option_id` must be an id from that request's own option list; anything else
+  is refused rather than forwarded, which is the fail-closed rule applied to
+  the answer side. Returns `{:error, :no_pending_permission}` when the request
+  has already been answered — by another client, by the timeout, or by the turn
+  ending — so a caller can tell "too late" from "wrong option".
+  """
+  @spec answer_permission(pid(), String.t(), String.t()) ::
+          :ok | {:error, :no_pending_permission | :unknown_option}
+  def answer_permission(pid, request_id, option_id) do
+    GenServer.call(pid, {:answer_permission, request_id, option_id})
+  end
+
+  @doc """
+  Refuse an outstanding permission request without a human answering.
+
+  This is what the timeout fires, and what the turn's end calls if a request is
+  still open. Picks a `reject_*` the agent offered, or `cancelled` when it
+  offered none — never an allow.
+  """
+  @spec deny_permission(pid(), String.t()) :: :ok
+  def deny_permission(pid, request_id) do
+    GenServer.cast(pid, {:deny_permission, request_id})
+  end
+
   # ── callbacks ─────────────────────────────────────────────────────────────
 
   @impl true
@@ -191,6 +224,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
       images: Keyword.get(opts, :images, []),
       mcp_servers: Keyword.get(opts, :mcp_servers, []),
       permission_policy: Keyword.get(opts, :permission_policy) || %{},
+      pending_permission: restore_pending(Keyword.get(opts, :pending_permission)),
       model: Keyword.get(opts, :model),
       replay_quiet_ms: Keyword.get(opts, :replay_quiet_ms, @replay_quiet_ms),
       replay_max_ms: Keyword.get(opts, :replay_max_ms, @replay_max_ms),
@@ -254,6 +288,48 @@ defmodule Fountain.Runtimes.ACP.Peer do
   end
 
   def handle_cast(:cancel, state), do: {:noreply, state}
+
+  def handle_cast({:deny_permission, request_id}, state) do
+    case state.pending_permission do
+      %{request_id: ^request_id, id: id, options: options} ->
+        outcome = Fountain.Permissions.deny_outcome(options)
+
+        state
+        |> write(Protocol.response(id, %{outcome: outcome}))
+        |> Map.put(:pending_permission, nil)
+        |> noreply()
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  @impl true
+  # Answering is a `call` so the caller learns whether the answer landed: the
+  # request may already have been resolved by another attached client, by the
+  # timeout, or by the turn ending, and "too late" and "wrong option" are
+  # different things to tell a user.
+  def handle_call({:answer_permission, request_id, option_id}, _from, state) do
+    case state.pending_permission do
+      %{request_id: ^request_id, id: id, options: options} ->
+        if Enum.any?(options, &(&1["optionId"] == option_id)) do
+          state =
+            write(
+              state,
+              Protocol.response(id, %{outcome: %{outcome: "selected", optionId: option_id}})
+            )
+
+          {:reply, :ok, %{state | pending_permission: nil}}
+        else
+          # Never forward an id the agent did not offer. The adapter would at
+          # best error and at worst match something unrelated.
+          {:reply, {:error, :unknown_option}, state}
+        end
+
+      _ ->
+        {:reply, {:error, :no_pending_permission}, state}
+    end
+  end
 
   @impl true
   def handle_info({:DOWN, mon, :process, _pid, _reason}, %State{owner_mon: mon} = state) do
@@ -384,17 +460,25 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # recorded: a turn makes dozens of tool calls, and a row each would make the
   # trail a transcript.
   defp handle_message({:request, id, "session/request_permission", params}, state) do
-    outcome = Fountain.Permissions.outcome(state.permission_policy, params)
     tool = Fountain.Permissions.tool_name(params)
     verdict = Fountain.Permissions.verdict_for(state.permission_policy, tool)
 
-    if verdict != "auto_allow", do: report(state, {:permission_denied, tool, verdict})
+    case verdict do
+      "ask" ->
+        hold_permission(state, id, tool, params)
 
-    write(state, Protocol.response(id, %{outcome: outcome}))
+      _ ->
+        if verdict != "auto_allow", do: report(state, {:permission_denied, tool, verdict})
+
+        write(
+          state,
+          Protocol.response(id, %{
+            outcome: Fountain.Permissions.outcome(state.permission_policy, params)
+          })
+        )
+    end
   end
 
-  # We declared no filesystem or terminal capabilities, so nothing should ask.
-  # If something does, it gets a JSON-RPC error rather than silence.
   defp handle_message({:request, id, method, _params}, state) do
     Logger.warning("acp peer: refusing unsupported client method #{method}")
     write(state, Protocol.error(id, Protocol.method_not_found(), "#{method} is not supported"))
@@ -404,6 +488,30 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # stdout. Those are output, not protocol, and the transcript is more useful
   # with them in it.
   defp handle_message({:invalid, line}, state), do: persist(state, "stdout", [line, "\n"])
+
+  # `ask`: do not answer. The agent stays blocked while a human decides, which
+  # is the whole point, and is also why a timeout is not optional — see the
+  # owner, which arms one.
+  #
+  # The request line is persisted to the `acp` stream so it renders as a
+  # `permission_request` block inline in the transcript, exactly where the tool
+  # card it is about appears. The resolution is a separate `request` stage
+  # event: log events are immutable, so a block cannot become "answered" — the
+  # client pairs the two on `request_id`.
+  defp hold_permission(state, id, tool, params) do
+    options = Enum.filter(Map.get(params, "options") || [], &is_map/1)
+
+    state = persist(state, "acp", Protocol.request(id, "session/request_permission", params))
+    report(state, {:permission_ask, to_string(id), tool, options})
+
+    %{
+      state
+      | pending_permission: %{id: id, request_id: to_string(id), options: options, tool: tool}
+    }
+  end
+
+  # We declared no filesystem or terminal capabilities, so nothing should ask.
+  # If something does, it gets a JSON-RPC error rather than silence.
 
   # ── responses ─────────────────────────────────────────────────────────────
 
@@ -764,5 +872,26 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   # Prefer an option the agent itself marked as an allow. `optionId` is opaque
   # and adapter-defined, so picking by `kind` is the only portable choice.
+  # A held request handed back on reattach (#940). Stored as a string-keyed map
+  # on the turn row; the peer works in atoms. The JSON-RPC id has to come back
+  # as the integer the agent sent, because that is what it is blocked on.
+  defp restore_pending(%{"request_id" => request_id, "options" => options} = pending)
+       when is_binary(request_id) do
+    case Integer.parse(request_id) do
+      {id, ""} ->
+        %{
+          id: id,
+          request_id: request_id,
+          options: List.wrap(options),
+          tool: Map.get(pending, "tool")
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  defp restore_pending(_), do: nil
+
   defp noreply(state), do: {:noreply, state}
 end

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -352,6 +352,74 @@ defmodule FountainWeb.ConversationController do
     end
   end
 
+  operation(:answer_request,
+    summary: "Answer a permission request",
+    description:
+      "Answers a `session/request_permission` the agent is blocked on (#940). The " <>
+        "request and its options arrive as a `permission_request` block on the " <>
+        "conversation's event stream; `option_id` must be one of the `optionId` values " <>
+        "that block carried. Never send an option the agent did not offer.\n\n" <>
+        "First answer wins: another attached client, the timeout, or the turn ending " <>
+        "may already have resolved it, and all of those return 409. The resolution " <>
+        "appears on the stream as a `request` stage event with state `done`.",
+    parameters: [
+      conversation_id: [in: :path, type: :string, required: true],
+      request_id: [in: :path, type: :string, required: true]
+    ],
+    request_body: {"Answer", "application/json", Schemas.PermissionAnswerRequest},
+    responses: [
+      ok: {"Answered", "application/json", Schemas.PermissionAnswerResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      conflict: {"Already resolved", "application/json", Schemas.Error},
+      unprocessable_entity: {"Unknown option", "application/json", Schemas.Error}
+    ]
+  )
+
+  def answer_request(conn, %{"conversation_id" => id, "request_id" => request_id} = params) do
+    user = conn.assigns.current_user
+
+    case params["option_id"] do
+      option_id when is_binary(option_id) and option_id != "" ->
+        conn
+        |> Audited.attribution()
+        |> then(&Conversations.answer_permission_request(id, user.id, request_id, option_id, &1))
+        |> answer_response(conn)
+
+      _ ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "option_id_required"})
+    end
+  end
+
+  defp answer_response(:ok, conn), do: json(conn, %{ok: true})
+
+  # Every "too late" is one status. A client that lost the race to another
+  # client and a client answering after the timeout are in the same position:
+  # the request is gone and the stream says how it ended.
+  defp answer_response({:error, reason}, conn)
+       when reason in [:no_pending_permission, :not_running] do
+    conn
+    |> put_status(:conflict)
+    |> json(%{error: "permission_request_resolved"})
+  end
+
+  defp answer_response({:error, :unknown_option}, conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "unknown_option", message: "option_id was not offered for this request"})
+  end
+
+  defp answer_response({:error, :sprite_may_not_answer}, conn) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{error: "sprite_may_not_answer"})
+  end
+
+  defp answer_response({:error, :not_found}, conn) do
+    conn |> put_status(:not_found) |> json(%{error: "not_found"})
+  end
+
   @doc """
   Infer the conversation's `source` and `parent_conversation_id` from
   the `X-Fountain-Parent-Conversation-Id` (or legacy `X-AoD-Parent-Conversation-Id`)

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -426,6 +426,9 @@ defmodule FountainWeb.Router do
       # The JSON read-model for the log feed; /stream below is the tail (#519).
       get "/events", ConversationController, :events, as: :events
       post "/read", ConversationController, :read, as: :read
+      # Answer a permission request the agent is blocked on (#940). Nested so
+      # the conversation is tenant-scoped before the request id is looked at.
+      post "/requests/:request_id", ConversationController, :answer_request, as: :answer_request
       get "/tree", ConversationController, :tree, as: :tree
     end
   end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -263,7 +263,10 @@ defmodule FountainWeb.Schemas do
         permission_policy: %Schema{
           type: :object,
           nullable: true,
-          additionalProperties: %Schema{type: :string, enum: ["auto_allow", "auto_deny"]},
+          additionalProperties: %Schema{
+            type: :string,
+            enum: Fountain.Permissions.buildable_verdicts()
+          },
           description:
             "Per-launch permission override (#939). Merged with the agent's own policy, " <>
               "taking the stricter of the two per tool. It may only narrow: a policy that " <>
@@ -338,6 +341,38 @@ defmodule FountainWeb.Schemas do
       type: :object,
       properties: %{status: %Schema{type: :string, example: "queued"}},
       required: [:status]
+    })
+  end
+
+  defmodule PermissionAnswerRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "PermissionAnswerRequest",
+      type: :object,
+      properties: %{
+        option_id: %Schema{
+          type: :string,
+          description:
+            "One of the `optionId` values from the request's own `options` list, as " <>
+              "carried on the `permission_request` block. An id the agent did not offer " <>
+              "is refused (422 unknown_option) rather than forwarded."
+        }
+      },
+      required: [:option_id]
+    })
+  end
+
+  defmodule PermissionAnswerResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "PermissionAnswerResponse",
+      type: :object,
+      properties: %{ok: %Schema{type: :boolean, example: true}},
+      required: [:ok]
     })
   end
 
@@ -426,13 +461,16 @@ defmodule FountainWeb.Schemas do
         permission_policy: %Schema{
           type: :object,
           nullable: true,
-          additionalProperties: %Schema{type: :string, enum: ["auto_allow", "auto_deny"]},
+          additionalProperties: %Schema{
+            type: :string,
+            enum: Fountain.Permissions.buildable_verdicts()
+          },
           description:
             "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
               "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
               "default, and an unset default is auto_allow \u2014 today's behaviour. " <>
-              "\"ask\" is a known verdict but is not supported yet (422 " <>
-              "permission_policy_unbuilt)."
+              "\"ask\" holds the tool until a human answers it on the conversation " <>
+              "stream, and denies if nobody does before the timeout."
         },
         skills: %Schema{
           type: :array,
@@ -1140,7 +1178,11 @@ defmodule FountainWeb.Schemas do
           "`text`/`thinking` carry `body`; `tool_use` carries `id`, `name`, `summary`, " <>
           "`body` (the input); `tool_result` carries `tool_id`, `body`, `error` and pairs " <>
           "with the `tool_use` of the same id; `init` carries `summary`, `body`; `result` " <>
-          "carries `body`, `raw`; `error` carries `body`; `raw` carries `body`, `summary`.",
+          "carries `body`, `raw`; `error` carries `body`; `raw` carries `body`, `summary`; " <>
+          "`permission_request` carries `request_id`, `name`, `summary` and `options` — the " <>
+          "agent is blocked on it, and a client answers with " <>
+          "POST /api/conversations/{id}/requests/{request_id}. Render only the options in " <>
+          "`options`; never synthesise one the agent did not offer.",
       type: :object,
       properties: %{
         kind: %Schema{
@@ -1153,7 +1195,21 @@ defmodule FountainWeb.Schemas do
         name: %Schema{type: :string, nullable: true},
         tool_id: %Schema{type: :string, nullable: true},
         error: %Schema{type: :boolean, nullable: true},
-        raw: %Schema{type: :string, nullable: true}
+        raw: %Schema{type: :string, nullable: true},
+        request_id: %Schema{
+          type: :string,
+          nullable: true,
+          description: "permission_request only: the id to answer with."
+        },
+        options: %Schema{
+          type: :array,
+          nullable: true,
+          description:
+            "permission_request only: the options the agent offered, in its order. " <>
+              "Each carries at least `optionId` and `kind` (allow_once, allow_always, " <>
+              "reject_once, reject_always, ...).",
+          items: %Schema{type: :object, additionalProperties: true}
+        }
       },
       required: [:kind],
       additionalProperties: true

--- a/apps/fountain/priv/repo/migrations/20260821200000_add_pending_permission_to_turns.exs
+++ b/apps/fountain/priv/repo/migrations/20260821200000_add_pending_permission_to_turns.exs
@@ -1,0 +1,19 @@
+defmodule Fountain.Repo.Migrations.AddPendingPermissionToTurns do
+  use Ecto.Migration
+
+  # The permission request a turn is blocked on (#940).
+  #
+  # Persisted for the same reason `acp_prompt_id` is: the JSON-RPC id lives in
+  # the peer and dies with it, so without this a request raised before a deploy
+  # could not be answered after one — the answer endpoint would accept a
+  # request_id no live peer recognises. `attempt_session_attach` already
+  # orphans a turn for exactly this class of problem.
+  #
+  # Holds the id, the tool, and the options the agent offered, so a reattached
+  # peer can refuse the request without having seen it arrive.
+  def change do
+    alter table(:turns) do
+      add :pending_permission, :map
+    end
+  end
+end

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -414,16 +414,10 @@ defmodule Fountain.AgentsTest do
       assert msg =~ "unknown verdict"
     end
 
-    test "rejects ask until #940 builds somewhere to ask" do
+    test "accepts ask, now that #940 gave it somewhere to ask" do
       user = insert_verified_user()
-
-      assert {:error, changeset} =
-               Agents.create_agent(
-                 agent_attrs(%{"user_id" => user.id, "permission_policy" => %{"Bash" => "ask"}})
-               )
-
-      assert %{permission_policy: [msg]} = errors_on(changeset)
-      assert msg =~ "not built yet"
+      agent = insert_agent(user_id: user.id, permission_policy: %{"Bash" => "ask"})
+      assert agent.permission_policy == %{"Bash" => "ask"}
     end
 
     test "rejects a non-string tool key" do

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -871,4 +871,192 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
   #
   # When #659 lifts the block, a gemini conversation-level test belongs here
   # again.
+  describe "permission ask path (#940)" do
+    defp ask_agent(user) do
+      insert_agent(user_id: user.id, runtime: "claude", permission_policy: %{"Bash" => "ask"})
+    end
+
+    defp raise_permission(pid, ref, id) do
+      line =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "method" => "session/request_permission",
+          "params" => %{
+            "toolCall" => %{"title" => "Bash", "kind" => "execute"},
+            "options" => [
+              %{"optionId" => "yes", "kind" => "allow_always"},
+              %{"optionId" => "no", "kind" => "reject_once"}
+            ]
+          }
+        }) <> "\n"
+
+      send(pid, {:stdout, %{ref: ref}, line})
+      settle(pid)
+    end
+
+    test "a held request is persisted on the turn and announced on the stream" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+
+      raise_permission(pid, ref, 301)
+
+      # Persisted first, so a deploy landing a millisecond later can still
+      # answer it.
+      turn = :sys.get_state(pid).current_turn
+      assert turn.pending_permission["request_id"] == "301"
+      assert turn.pending_permission["tool"] == "Bash"
+
+      # And announced, with the agent's own options.
+      events = Conversations._unsafe_list_log_events(conv.id)
+      stage = Enum.find(events, &(&1.kind == "stage" and &1.stage == "request"))
+      assert stage.state == "started"
+      assert Jason.decode!(stage.data)["request_id"] == "301"
+    end
+
+    test "the request renders as a permission_request block in the transcript" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+
+      raise_permission(pid, ref, 302)
+
+      blocks =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.filter(&(&1.stream == "acp"))
+        |> Enum.flat_map(&Fountain.Conversations.Blocks.for_event(&1, "claude"))
+
+      assert block = Enum.find(blocks, &(&1.kind == :permission_request))
+      assert block.request_id == "302"
+      assert block.name == "Bash"
+      assert Enum.map(block.options, & &1["optionId"]) == ["yes", "no"]
+    end
+
+    test "answering writes the selected option and resolves the card" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+      raise_permission(pid, ref, 303)
+
+      assert :ok = GenServer.call(pid, {:answer_permission, "303", "yes"})
+
+      assert %{"id" => 303, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
+
+      # The turn no longer holds it, and the stream says how it ended.
+      assert :sys.get_state(pid).current_turn.pending_permission == nil
+
+      done =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.filter(&(&1.kind == "stage" and &1.stage == "request" and &1.state == "done"))
+
+      assert [event] = done
+      assert Jason.decode!(event.data)["outcome"] == "answered"
+    end
+
+    test "a resolution is state done, never failed, even for a refusal" do
+      # publish_stage's stage and status are the Prometheus counter's only tags
+      # and there is an alert on them. A deny emitting `failed` would page
+      # someone for a policy doing exactly what it was told.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+      raise_permission(pid, ref, 304)
+
+      send(pid, {:permission_timeout, "304"})
+      settle(pid)
+
+      states =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.filter(&(&1.kind == "stage" and &1.stage == "request"))
+        |> Enum.map(& &1.state)
+
+      assert "done" in states
+      refute "failed" in states
+    end
+
+    test "a timeout denies, and the denial is audited" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+      raise_permission(pid, ref, 305)
+
+      send(pid, {:permission_timeout, "305"})
+      settle(pid)
+
+      # Deny is the only safe default, and it picks the agent's own rejection.
+      assert %{"id" => 305, "result" => %{"outcome" => %{"optionId" => "no"}}} = next_write()
+
+      assert Enum.any?(
+               Fountain.Audit.list_recent_for_user(user.id, 20),
+               &(&1.action == "conversation.permission_denied")
+             )
+    end
+
+    test "answering an id that was never offered is refused, not forwarded" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+      raise_permission(pid, ref, 306)
+
+      assert {:error, :unknown_option} =
+               GenServer.call(pid, {:answer_permission, "306", "made-up"})
+
+      assert :sys.get_state(pid).current_turn.pending_permission["request_id"] == "306"
+    end
+
+    test "a sprite may not answer its own prompt" do
+      # It holds a FOUNTAIN_TOKEN and could otherwise approve the very tool it
+      # just asked for, which would make the policy decorative.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+      raise_permission(pid, ref, 307)
+
+      assert {:error, :sprite_may_not_answer} =
+               Conversations.answer_permission_request(conv.id, user.id, "307", "yes",
+                 actor: "sprite"
+               )
+    end
+
+    test "another tenant cannot answer, and gets not_found rather than a hint" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+      raise_permission(pid, ref, 308)
+
+      assert {:error, :not_found} =
+               Conversations.answer_permission_request(conv.id, other.id, "308", "yes")
+    end
+
+    test "a request still held when the turn ends is resolved, not left open" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      raise_permission(pid, ref, 309)
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      done =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.filter(&(&1.kind == "stage" and &1.stage == "request" and &1.state == "done"))
+
+      assert [event] = done
+      assert Jason.decode!(event.data)["outcome"] == "turn_ended"
+    end
+  end
 end

--- a/apps/fountain/test/fountain/conversations_start_test.exs
+++ b/apps/fountain/test/fountain/conversations_start_test.exs
@@ -337,11 +337,21 @@ defmodule Fountain.ConversationsStartTest do
       assert Repo.aggregate(Fountain.Conversations.Conversation, :count) == 0
     end
 
-    test "ask is refused at the door until #940 builds somewhere to ask", ctx do
+    test "a launch may narrow to ask, now that #940 gave it somewhere to ask", ctx do
       agent = insert_agent(user_id: ctx.user.id)
 
-      assert {:error, {:permission_policy_unbuilt, "ask"}} =
-               launch(ctx, agent, %{"Bash" => "ask"})
+      assert {:ok, conv} = launch(ctx, agent, %{"Bash" => "ask"})
+      assert conv.permission_policy == %{"Bash" => "ask"}
+    end
+
+    test "ask is a narrowing of auto_allow but a widening of auto_deny", ctx do
+      lenient = insert_agent(user_id: ctx.user.id, permission_policy: %{"Bash" => "auto_allow"})
+      strict = insert_agent(user_id: ctx.user.id, permission_policy: %{"Bash" => "auto_deny"})
+
+      assert {:ok, _} = launch(ctx, lenient, %{"Bash" => "ask"})
+
+      assert {:error, {:permission_policy_widens, "Bash"}} =
+               launch(ctx, strict, %{"Bash" => "ask"})
     end
 
     test "an unknown verdict is refused", ctx do

--- a/apps/fountain/test/fountain/permissions_test.exs
+++ b/apps/fountain/test/fountain/permissions_test.exs
@@ -171,18 +171,28 @@ defmodule Fountain.PermissionsTest do
   end
 
   describe "ask" do
-    test "is a verdict, but not one that can be honoured yet" do
+    test "is buildable since #940 gave it somewhere to ask" do
       assert "ask" in Permissions.verdicts()
-      refute Permissions.buildable?("ask")
+      assert Permissions.buildable?("ask")
       assert Permissions.buildable?("auto_allow")
       assert Permissions.buildable?("auto_deny")
     end
 
-    test "denies rather than allows if it ever reaches the peer" do
-      # It cannot today — refused where a policy is written, and clamping never
-      # invents it — but the safe reading is written down rather than assumed.
+    test "outcome/2 denies rather than allows, for a caller that asks anyway" do
+      # The peer does not route `ask` through outcome/2 — it holds the request
+      # open instead — but the safe reading is written down rather than assumed.
       assert %{outcome: "selected", optionId: "ro"} =
                Permissions.outcome(%{"default" => "ask"}, req([allow_always(), reject_once()]))
+    end
+
+    test "the timeout sits under the idle bound, or an unanswered prompt costs the disk" do
+      # Lifecycle.check/4 suppresses only the idle verdict while a turn is in
+      # flight, and per 0017 the idle bound suspends while the ceiling
+      # destroys. A timeout at or above the idle bound would mean an
+      # unanswered prompt is resolved by the ceiling instead — burning the
+      # whole lifetime and taking the agent's memory with it (#649).
+      assert Permissions.ask_timeout_ms() <
+               Fountain.Conversations.Lifecycle.idle_timeout_seconds() * 1000
     end
 
     test "is stricter than allow and looser than deny" do

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -45,6 +45,21 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
     pid
   end
 
+  defp permission_line(id, tool) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "id" => id,
+      "method" => "session/request_permission",
+      "params" => %{
+        "toolCall" => %{"title" => tool, "kind" => "execute"},
+        "options" => [
+          %{"optionId" => "yes", "kind" => "allow_always"},
+          %{"optionId" => "no", "kind" => "reject_once"}
+        ]
+      }
+    }) <> "\n"
+  end
+
   # Receive the next thing the peer wrote, decoded.
   defp next_write do
     assert_receive {:wrote, line}, 1_000
@@ -546,6 +561,84 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       # Allows are deliberately not recorded — a row each would make the audit
       # trail a second copy of the transcript.
       refute_receive {:acp, _ref, {:permission_denied, _, _}}, 50
+    end
+
+    test "ask holds the request open instead of answering it", ctx do
+      pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
+      _init = next_write()
+
+      Peer.stdout(pid, permission_line(201, "Bash"))
+
+      # The agent stays blocked: nothing is written back until a human answers.
+      # The request is persisted so it renders inline as a block, and the owner
+      # is told so it can publish the stage event and arm a timeout.
+      assert_receive {:acp, _ref, {:lines, "acp", line}}
+      assert line =~ "session/request_permission"
+      assert_receive {:acp, _ref, {:permission_ask, "201", "Bash", options}}
+      assert Enum.map(options, & &1["optionId"]) == ["yes", "no"]
+
+      refute_receive {:wrote, _}, 50
+    end
+
+    test "an answer selects the option, and only an offered one", ctx do
+      pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
+      _init = next_write()
+      Peer.stdout(pid, permission_line(202, "Bash"))
+      assert_receive {:acp, _ref, {:permission_ask, "202", _, _}}
+
+      assert {:error, :unknown_option} = Peer.answer_permission(pid, "202", "made-up")
+      assert :ok = Peer.answer_permission(pid, "202", "yes")
+
+      assert %{"id" => 202, "result" => %{"outcome" => outcome}} = next_write()
+      assert outcome["outcome"] == "selected"
+      assert outcome["optionId"] == "yes"
+    end
+
+    test "a second answer is too late, not a second write", ctx do
+      # First answer wins: the web apps and an editor are peer clients of this
+      # door, so losing the race is an ordinary outcome, not a caller error.
+      pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
+      _init = next_write()
+      Peer.stdout(pid, permission_line(203, "Bash"))
+      assert_receive {:acp, _ref, {:permission_ask, "203", _, _}}
+
+      assert :ok = Peer.answer_permission(pid, "203", "yes")
+      _answer = next_write()
+
+      assert {:error, :no_pending_permission} = Peer.answer_permission(pid, "203", "no")
+      refute_receive {:wrote, _}, 50
+    end
+
+    test "denying a held request picks the agent's own rejection", ctx do
+      pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
+      _init = next_write()
+      Peer.stdout(pid, permission_line(204, "Bash"))
+      assert_receive {:acp, _ref, {:permission_ask, "204", _, _}}
+
+      Peer.deny_permission(pid, "204")
+
+      assert %{"id" => 204, "result" => %{"outcome" => outcome}} = next_write()
+      assert outcome["optionId"] == "no"
+    end
+
+    test "a request handed back on reattach is still answerable", ctx do
+      # The JSON-RPC id lives in the peer and dies with it, so a request raised
+      # before a deploy is only answerable after one because the turn row wrote
+      # it down. Same trap as `acp_prompt_id` (#772).
+      pid =
+        start_peer(ctx,
+          permission_policy: %{"Bash" => "ask"},
+          pending_permission: %{
+            "request_id" => "205",
+            "tool" => "Bash",
+            "options" => [%{"optionId" => "yes", "kind" => "allow_once"}]
+          }
+        )
+
+      _init = next_write()
+
+      assert :ok = Peer.answer_permission(pid, "205", "yes")
+      assert %{"id" => 205, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
     end
 
     test "an fs/* request is refused, not ignored", ctx do

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -188,6 +188,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/conversations/{conversation_id}/requests/{request_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Answer a permission request
+         * @description Answers a `session/request_permission` the agent is blocked on (#940). The request and its options arrive as a `permission_request` block on the conversation's event stream; `option_id` must be one of the `optionId` values that block carried. Never send an option the agent did not offer.
+         *
+         *     First answer wins: another attached client, the timeout, or the turn ending may already have resolved it, and all of those return 409. The resolution appears on the stream as a `request` stage event with state `done`.
+         */
+        post: operations["FountainWeb.ConversationController.answer_request"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/account/exports/{id}/download": {
         parameters: {
             query?: never;
@@ -1860,7 +1882,7 @@ export interface components {
             images?: components["schemas"]["ImageInput"][] | null;
             /** @description Per-launch permission override (#939). Merged with the agent's own policy, taking the stricter of the two per tool. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped. */
             permission_policy?: {
-                [key: string]: "auto_allow" | "auto_deny";
+                [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @description Optional first turn prompt. */
             prompt?: string;
@@ -2072,6 +2094,11 @@ export interface components {
         /** TeammateConversationListResponse */
         TeammateConversationListResponse: {
             data: components["schemas"]["TeammateConversation"][];
+        };
+        /** PermissionAnswerRequest */
+        PermissionAnswerRequest: {
+            /** @description One of the `optionId` values from the request's own `options` list, as carried on the `permission_request` block. An id the agent did not offer is refused (422 unknown_option) rather than forwarded. */
+            option_id: string;
         };
         /**
          * AvatarRequest
@@ -2427,9 +2454,9 @@ export interface components {
             /** @description Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The provider must match the runtime — anthropic for claude, openai for codex, google for gemini; opencode accepts any of the three. Other providers are rejected: Fountain has no credentials to export for them. The model id is not checked against a list, so a newly released model works without a Fountain release. */
             model: string;
             name: string;
-            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" is a known verdict but is not supported yet (422 permission_policy_unbuilt). */
+            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. */
             permission_policy?: {
-                [key: string]: "auto_allow" | "auto_deny";
+                [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode";
@@ -2703,16 +2730,22 @@ export interface components {
         };
         /**
          * Block
-         * @description One structured piece of a log event's output — the same parse the web UI renders (`Fountain.Conversations.Blocks`). `kind` decides the other fields: `text`/`thinking` carry `body`; `tool_use` carries `id`, `name`, `summary`, `body` (the input); `tool_result` carries `tool_id`, `body`, `error` and pairs with the `tool_use` of the same id; `init` carries `summary`, `body`; `result` carries `body`, `raw`; `error` carries `body`; `raw` carries `body`, `summary`.
+         * @description One structured piece of a log event's output — the same parse the web UI renders (`Fountain.Conversations.Blocks`). `kind` decides the other fields: `text`/`thinking` carry `body`; `tool_use` carries `id`, `name`, `summary`, `body` (the input); `tool_result` carries `tool_id`, `body`, `error` and pairs with the `tool_use` of the same id; `init` carries `summary`, `body`; `result` carries `body`, `raw`; `error` carries `body`; `raw` carries `body`, `summary`; `permission_request` carries `request_id`, `name`, `summary` and `options` — the agent is blocked on it, and a client answers with POST /api/conversations/{id}/requests/{request_id}. Render only the options in `options`; never synthesise one the agent did not offer.
          */
         Block: {
             body?: string | null;
             error?: boolean | null;
             id?: string | null;
             /** @enum {string} */
-            kind: "text" | "thinking" | "tool_use" | "tool_result" | "init" | "result" | "error" | "raw";
+            kind: "text" | "thinking" | "tool_use" | "tool_result" | "init" | "result" | "error" | "raw" | "permission_request";
             name?: string | null;
+            /** @description permission_request only: the options the agent offered, in its order. Each carries at least `optionId` and `kind` (allow_once, allow_always, reject_once, reject_always, ...). */
+            options?: {
+                [key: string]: unknown;
+            }[] | null;
             raw?: string | null;
+            /** @description permission_request only: the id to answer with. */
+            request_id?: string | null;
             summary?: string | null;
             tool_id?: string | null;
         } & {
@@ -3229,6 +3262,11 @@ export interface components {
             setup_script?: string;
             /** Format: date-time */
             updated_at?: string;
+        };
+        /** PermissionAnswerResponse */
+        PermissionAnswerResponse: {
+            /** @example true */
+            ok: boolean;
         };
         /** ConversationTreeResponse */
         ConversationTreeResponse: {
@@ -3783,6 +3821,61 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.ConversationController.answer_request": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                conversation_id: string;
+                request_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Answer */
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PermissionAnswerRequest"];
+            };
+        };
+        responses: {
+            /** @description Answered */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PermissionAnswerResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Already resolved */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unknown option */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Closes #940. ADR 0014 gate 3, decided in #944. **Stacked on #947** (#939) — review that first; this PR's base diff includes it until it merges.

#939 made the auto-allow a policy. This gives `ask` somewhere to ask — which is what #708 and jhgaylor/fountain-team#3 have actually been waiting on. Both said they were blocked on agents "running with their safety rail off", which has not been true since the ACP conversions; the requests have been arriving and being auto-answered all along.

## The wire: a block for the request, a stage event for the resolution

Log events are immutable, so a resolution cannot mutate the request — it is a second event either way. Given that, each half goes where it belongs:

- **The request is a `permission_request` block on the `acp` stream.** It already arrived as a JSON-RPC line; `ACP.Blocks.from_line/1` was dropping it. Now it renders **inline in the transcript**, beside the tool card it is about, through the pipeline both SPAs already run.
- **The resolution is a stage event** — `stage: "request"`, `state: "done"`, verdict in `data`.
- **Clients pair them on `request_id`** — the same pass they already make to pair `tool_result` to `tool_use` on `tool_id`.

**No change to the closed `state` enum**, and `state` is `done` for every outcome including a deny and a timeout: `publish_stage`'s stage and status are the Prometheus counter's only tags and there is an alert on them. A timeout emitting `failed` would page someone for a policy doing exactly what it was told.

## Deny on timeout, under the idle bound

Not tidiness. `Lifecycle.check/4` suppresses only the **idle** verdict while a turn is in flight, and per ADR 0017 the idle bound *suspends* while the ceiling *destroys*. An unanswered prompt therefore does not hang forever — it burns the whole max lifetime and then takes the agent's memory with it (#649).

Default 5 minutes against a 60-minute idle bound, and there is a test asserting the ordering rather than trusting the two defaults to stay apart:

```elixir
assert Permissions.ask_timeout_ms() < Lifecycle.idle_timeout_seconds() * 1000
```

Reporting a blocked turn as `busy?: false` so idle reclaim caught it was the alternative, and was **rejected**: it lies about busyness, and suspending a sandbox mid-request is its own failure.

## Held requests survive a deploy

The JSON-RPC id lives in the peer and dies with it, so `turns.pending_permission` writes it down — the same trap `acp_prompt_id` exists for, and the one #772 was. A reattached peer is handed it back and can answer or refuse it without having seen it arrive.

## Fail-closed on both sides

The block carries the agent's own option list verbatim, and an `option_id` that is not on it is **refused rather than forwarded** — an id the agent never advertised would at best error and at worst select something unrelated.

**A sprite may not answer its own prompt.** It holds a `FOUNTAIN_TOKEN` and could otherwise approve the very tool it just asked for, which would make the policy decorative. Closed by name in the context, before the server lookup.

## The API

`POST /api/conversations/:id/requests/:request_id` with `{"option_id": "..."}`. **First answer wins**: another attached client, the timeout, or the turn ending may have resolved it first, and all of those are one **409** — a client that lost a race and a client guessing ids are in the same position, and the stream says how it actually ended.

This is the contract jhgaylor/fountain-team#3 was written against.

## Verified by reverting

Each of these breaks the suite; restoring gives 0 failures:

| break | fails |
|---|---|
| `ask` answers immediately instead of holding | 4 |
| `answer_permission` forwards any option id | 1 |
| reattach drops the held request | 1 |
| the sprite guard is removed | 1 |
| the tenant scope is removed | 1 |

Worth flagging: two `refute_receive` assertions I wrote were watching `{:write, _}` when the harness sends `{:wrote, _}`. They were passing vacuously and would have certified nothing. Caught and fixed before commit.

The enum guardrail also earned its keep — flipping `ask` to buildable made the hardcoded spec enum drift, and it failed immediately. The schemas now read `Permissions.buildable_verdicts/0` directly rather than restating it.

## Checks

`mix test` — **3,347 tests, 0 failures**. `mix format --check-formatted`, `mix credo --strict` (no issues), `mix sobelow --config`, `MIX_ENV=dev mix dialyzer` (**0 errors** — it caught a genuinely unreachable clause), the OpenAPI spec, and the SDK's regenerated types, typecheck, 65 tests and browser bundle all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
