### PR TITLE
fix: remove fabricated testimonials, and a card that promised what we do not do

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -80,10 +80,10 @@
         </svg>
       </div>
       <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-        Your users stay apart
+        A thread and a machine per user
       </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Every query is scoped to the caller, so one account never reaches another's agents or sandboxes. Build a product on top and your own users are isolated from each other without you writing a line for it.
+        Bind a conversation to any channel id — a Slack channel, a customer, a row in your own product — and each one gets a durable thread on a sandbox of its own. No lookup table to keep, and nothing to carry between messages.
       </p>
     </div>
 
@@ -160,39 +160,6 @@
         >fountain</code> CLI. The people using what you build need never learn that an agent is there.
       </p>
     </div>
-  </div>
-</section>
-
-<%!-- Customer quotes --%>
-<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-  <div class="max-w-4xl mx-auto px-6 py-16">
-    <div class="grid sm:grid-cols-2 gap-10">
-      <figure>
-        <blockquote class="text-[var(--color-text-primary)] leading-relaxed mb-4">
-          "We were maintaining three separate <code
-            class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm"
-            phx-no-format
-          >.env</code> files and a shared Notion doc to keep our agent configs in sync. Fountain replaced all of it. Onboarding the last two engineers took ten minutes each."
-        </blockquote>
-        <figcaption class="text-sm text-[var(--color-text-muted)] font-medium">
-          — Engineering lead, early access customer
-        </figcaption>
-      </figure>
-      <figure>
-        <blockquote class="text-[var(--color-text-primary)] leading-relaxed mb-4">
-          "I evaluated Fountain on a Friday afternoon and had a shared environment running for the whole team before dinner. The Vaults alone killed our 'which <code
-            class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-sm"
-            phx-no-format
-          >.env</code> is current?' Slack thread."
-        </blockquote>
-        <figcaption class="text-sm text-[var(--color-text-muted)] font-medium">
-          — Developer, early access customer
-        </figcaption>
-      </figure>
-    </div>
-    <p class="text-center text-sm text-[var(--color-text-muted)] mt-10">
-      Teams reach their first conversation in under 5 minutes on average.
-    </p>
   </div>
 </section>
 


### PR DESCRIPTION
Two problems on `/`. The second is worse than the first.

## 1. The testimonials were invented

Two quotes attributed to an "Engineering lead" and a "Developer", both "early
access customer", plus a figure claiming *"Teams reach their first conversation
in under 5 minutes on average."*

Jake confirms the quotes are fake. The figure has no source either, sits in the
same section, and measures *teams* — which is not how this bills, as #949 just
established. **All three are gone**, and the section with them.

Invented social proof on a page that asks for a credit card is not a copy
problem.

## 2. A card promised something Fountain does not do

The tenancy card said:

> Every query is scoped to the caller, so one account never reaches another's
> agents or sandboxes. **Build a product on top and your own users are isolated
> from each other without you writing a line for it.**

The first sentence is true. The second is not.

Fountain's tenancy separates **Fountain accounts**. An app built on Fountain
normally runs on *one* account for all of its users, so isolating them is the
app's problem. `docs/build/pieces.md` says so under "Where the multi-tenancy
is":

> *Sharing* is the part you do not get for free. A teammate belongs to one
> account, so a team room that several people share stays your product's
> problem.

I wrote that card in #948. It was not merely pitched at the operator instead of
the builder — it was **false**.

### What it says now

> **A thread and a machine per user**
>
> Bind a conversation to any channel id — a Slack channel, a customer, a row in
> your own product — and each one gets a durable thread on a sandbox of its
> own. No lookup table to keep, and nothing to carry between messages.

That is a real builder-facing benefit, and it is true: `channel_id` binds a
conversation, sending to a bound channel continues it, and one conversation
gets one sandbox.

### One clause I caught in my own draft

The first version ended "…and **no chance of one thread reading another's
files**." That is false too. On the [self-hosted runner](https://binarybourbon.github.io/fountain/integrations/runners/)
provider a sandbox is a directory on a machine the user owns, running in
trusted mode with no isolation. The clause is gone.

## Verification

- 15 marketing tests, 0 failures
- `mix format --check-formatted`, run unpiped
- Full suite: **3289 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
