### PR TITLE
fix(api): permission_policy was write-only and undocumented on the agent

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/agent_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_json.ex
@@ -27,6 +27,7 @@ defmodule FountainWeb.AgentJSON do
       metadata: a.metadata,
       allowed_vault_ids: a.allowed_vault_ids,
       allowed_environment_ids: a.allowed_environment_ids,
+      permission_policy: a.permission_policy,
       conversation_count: a.conversation_count,
       avatar_media_type: a.avatar_media_type,
       inserted_at: a.inserted_at,

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -42,6 +42,7 @@ defmodule FountainWeb.ConversationJSON do
       agent_id: c.agent_id,
       vault_id: c.vault_id,
       environment_id: c.environment_id,
+      permission_policy: c.permission_policy,
       runtime: c.runtime,
       # Derived, never stored — the same signal as on an agent (#702). A
       # protocol client asks before reopening a conversation, because a

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -121,6 +121,18 @@ defmodule FountainWeb.Schemas do
         sandbox: %Schema{oneOf: [Sandbox], nullable: true},
         agent_id: %Schema{type: :string, format: :uuid, nullable: true},
         vault_id: %Schema{type: :string, format: :uuid, nullable: true},
+        permission_policy: %Schema{
+          type: :object,
+          nullable: true,
+          additionalProperties: %Schema{
+            type: :string,
+            enum: Fountain.Permissions.buildable_verdicts()
+          },
+          description:
+            "The per-launch permission override this conversation was started with, or " <>
+              "null if it had none. The policy actually in force is this merged with the " <>
+              "agent's, taking the stricter of the two per tool."
+        },
         environment_id: %Schema{
           type: :string,
           format: :uuid,
@@ -709,6 +721,20 @@ defmodule FountainWeb.Schemas do
             "Sandbox backend override; null inherits the instance default " <>
               "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
         },
+        permission_policy: %Schema{
+          type: :object,
+          nullable: true,
+          additionalProperties: %Schema{
+            type: :string,
+            enum: Fountain.Permissions.buildable_verdicts()
+          },
+          description:
+            "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
+              "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
+              "default, and an unset default is auto_allow. \"ask\" holds the tool until a " <>
+              "human answers it on the conversation stream, and denies if nobody does " <>
+              "before the timeout. A conversation may narrow this at launch, never widen it."
+        },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         skills: %Schema{
           type: :array,
@@ -797,6 +823,20 @@ defmodule FountainWeb.Schemas do
           description:
             "Sandbox backend override; null inherits the instance default " <>
               "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
+        },
+        permission_policy: %Schema{
+          type: :object,
+          nullable: true,
+          additionalProperties: %Schema{
+            type: :string,
+            enum: Fountain.Permissions.buildable_verdicts()
+          },
+          description:
+            "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
+              "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
+              "default, and an unset default is auto_allow. \"ask\" holds the tool until a " <>
+              "human answers it on the conversation stream, and denies if nobody does " <>
+              "before the timeout. A conversation may narrow this at launch, never widen it."
         },
         allowed_environment_ids: %Schema{
           type: :array,

--- a/apps/fountain/test/fountain/conversations_start_test.exs
+++ b/apps/fountain/test/fountain/conversations_start_test.exs
@@ -359,6 +359,17 @@ defmodule Fountain.ConversationsStartTest do
       assert {:error, :permission_policy_invalid} = launch(ctx, agent, %{"Bash" => "banana"})
     end
 
+    test "the launch override is readable back on the conversation", ctx do
+      # A client that set a policy at launch has to be able to see what it got.
+      # The response schema promises this field; a view that never emitted it
+      # would make the spec a lie, which is how the agent side shipped in #939.
+      agent = insert_agent(user_id: ctx.user.id)
+      {:ok, conv} = launch(ctx, agent, %{"Bash" => "auto_deny"})
+
+      rendered = FountainWeb.ConversationJSON.show(%{conversation: conv})
+      assert rendered.data.permission_policy == %{"Bash" => "auto_deny"}
+    end
+
     test "an empty override is the same as none", ctx do
       agent = insert_agent(user_id: ctx.user.id)
       assert {:ok, conv} = launch(ctx, agent, %{})

--- a/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
@@ -269,4 +269,54 @@ defmodule FountainWeb.AgentControllerTest do
       assert json_response(conn, 401)
     end
   end
+
+  describe "permission_policy over the API (#939/#940)" do
+    test "POST accepts a policy and round-trips it", %{conn: conn, raw_key: raw_key} do
+      # The agent is where a policy is normally set — a launch may only narrow
+      # it — so this is the path that matters, and it goes through
+      # CastAndValidate. A property missing from AgentRequest is invisible to
+      # every generated client even when the controller would have accepted it.
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> post("/api/agents", %{
+          "name" => "policy-agent",
+          "model" => "anthropic/claude-sonnet-4-6",
+          "runtime" => "claude",
+          "permission_policy" => %{"default" => "auto_allow", "Bash" => "ask"}
+        })
+
+      body = json_response(conn, 201)
+      assert body["data"]["permission_policy"] == %{"default" => "auto_allow", "Bash" => "ask"}
+    end
+
+    test "PUT updates a policy", %{conn: conn, user: user, raw_key: raw_key} do
+      agent = insert_agent(user_id: user.id)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> put("/api/agents/#{agent.id}", %{"permission_policy" => %{"Bash" => "auto_deny"}})
+
+      body = json_response(conn, 200)
+      assert body["data"]["permission_policy"] == %{"Bash" => "auto_deny"}
+    end
+
+    test "an unknown verdict is refused", %{conn: conn, raw_key: raw_key} do
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> post("/api/agents", %{
+          "name" => "bad-policy",
+          "model" => "anthropic/claude-sonnet-4-6",
+          "runtime" => "claude",
+          "permission_policy" => %{"Bash" => "banana"}
+        })
+
+      assert json_response(conn, 422)
+    end
+  end
 end

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -76,6 +76,12 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
       {Fountain.Permissions, :buildable_verdicts},
     {FountainWeb.Schemas.ConversationCreateRequest, "permission_policy.{}"} =>
       {Fountain.Permissions, :buildable_verdicts},
+    {FountainWeb.Schemas.AgentRequest, "permission_policy.{}"} =>
+      {Fountain.Permissions, :buildable_verdicts},
+    {FountainWeb.Schemas.AgentUpdate, "permission_policy.{}"} =>
+      {Fountain.Permissions, :buildable_verdicts},
+    {FountainWeb.Schemas.Conversation, "permission_policy.{}"} =>
+      {Fountain.Permissions, :buildable_verdicts},
     {FountainWeb.Schemas.Conversation, "status"} => {Conversation, :statuses},
     {FountainWeb.Schemas.Conversation, "source"} => {Conversation, :sources},
     {FountainWeb.Schemas.ConversationTreeNode, "status"} => {Conversation, :statuses},

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2571,6 +2571,10 @@ export interface components {
             last_read_at?: string | null;
             /** Format: uuid */
             parent_conversation_id?: string | null;
+            /** @description The per-launch permission override this conversation was started with, or null if it had none. The policy actually in force is this merged with the agent's, taking the stricter of the two per tool. */
+            permission_policy?: {
+                [key: string]: "auto_allow" | "ask" | "auto_deny";
+            } | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode";
             runtime_session_id?: string | null;
@@ -2856,6 +2860,10 @@ export interface components {
             };
             model?: string;
             name?: string;
+            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
+            permission_policy?: {
+                [key: string]: "auto_allow" | "ask" | "auto_deny";
+            } | null;
             /** @enum {string} */
             runtime?: "claude" | "codex" | "gemini" | "opencode";
             /**
@@ -3086,6 +3094,10 @@ export interface components {
             };
             model: string;
             name: string;
+            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
+            permission_policy?: {
+                [key: string]: "auto_allow" | "ask" | "auto_deny";
+            } | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode";
             /**


### PR DESCRIPTION
Follow-up to #947 / #950. **Two gaps I shipped**, both found by verifying prod rather than trusting the merged PRs' own green checks.

## 1. The spec promised a field the API never returned

#939 added `permission_policy` to the **`Agent` response schema** but not to `agent_json.ex`. So the published spec advertised the field and every response omitted it — you could set a policy and never read it back.

That is exactly the class of defect ADR 0001 forbids: a document describing behaviour the system does not have. It is worse than a plain omission, because a client author reading the spec has no way to discover it.

## 2. `AgentRequest` / `AgentUpdate` never declared it

The **agent is the primary place a policy is set** — a launch may only narrow it — and the write schemas didn't carry the field at all. It was therefore invisible to the generated SDK and to anyone reading the spec.

The controller *did* accept it: `CastAndValidate` runs with `replace_params: false`, so the raw params still reach `create_agent`. That is why the round trip "worked" in the Elixir tests while being unreachable from a typed client.

## Also: the conversation launch override is now readable

Neither the `Conversation` response schema nor `conversation_json.ex` carried `permission_policy`. No lie there — nothing promised it — but a client that pins a policy at launch could not see what it got. Added for symmetry, with a test.

## How this was found

Fetched `/api/openapi.json` from prod after the deploy rolled and diffed it against what the feature actually needs:

```
answer route:                            /api/conversations/{id}/requests/{request_id}  ✓
ConversationCreateRequest.permission_policy:  auto_allow,ask,auto_deny                  ✓
Block kinds:                             ...,permission_request                          ✓
AgentRequest.permission_policy:          MISSING                                        ✗
```

The schema-enum guardrail then did its job again — it required all four new enums to be **bound to `Permissions.buildable_verdicts/0`** rather than restated, so none of them can drift.

## Verified by reverting

Deleting the one line added to `agent_json.ex` fails two of the new controller tests. The tests drive the real controller (with the JSON content-type `CastAndValidate` requires), not the context.

## Checks

`mix test` — **3,351 tests, 0 failures**. `mix format --check-formatted`, `mix credo --strict` (no issues), `MIX_ENV=dev mix dialyzer` (**0 errors**), and the SDK's regenerated types, typecheck and 65 tests all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
