### PR TITLE
feat(gemini): stop gemini erasing the session it is asked to load (#659)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2963,6 +2963,22 @@ defmodule Fountain.Conversations.ConversationServer do
   defp finalize_tracer(nil), do: :ok
   defp finalize_tracer(tracer), do: Fountain.Runtimes.ACP.Tracer.finalize(tracer)
 
+  # gemini erases a session in the act of loading it (#659), so its store is
+  # consolidated at the end of every turn — before the next turn's
+  # `session/load` can collide with it. Best-effort and gemini-only; delete
+  # with the workaround when gemini-cli#28775 lands.
+  defp consolidate_gemini_session(%{handle: handle} = state) when not is_nil(handle) do
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+
+    if conv.runtime == "gemini" do
+      Fountain.Runtimes.Gemini.SessionStore.consolidate(handle, conv.runtime_session_id)
+    end
+
+    :ok
+  end
+
+  defp consolidate_gemini_session(_state), do: :ok
+
   defp finish_acp_turn(state, status, span_attrs, stage_meta) do
     # Resolve a held permission request before the peer goes away (#940). The
     # agent's blocked request dies with the process either way, but a card left
@@ -2972,6 +2988,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
     if state.current_command, do: Fountain.Sandbox.close_stdin(state.current_command)
     stop_acp_peer(state)
+    consolidate_gemini_session(state)
 
     # Before the turn span ends: totals land on it, abandoned tool spans close.
     finalize_tracer(state.stream_tracer)

--- a/apps/fountain/lib/fountain/runtimes/gemini.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini.ex
@@ -126,6 +126,10 @@ defmodule Fountain.Runtimes.Gemini do
     fi
     """
 
+    # The session-store workaround travels with the workspace (#659): it has to
+    # be on disk before the first turn ends, since that is when it first runs.
+    _ = Fountain.Runtimes.Gemini.SessionStore.install(handle)
+
     case Fountain.Sandbox.exec(handle, "bash", ["-lc", script],
            env: sprite_env,
            timeout: 30_000

--- a/apps/fountain/lib/fountain/runtimes/gemini/session_store.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini/session_store.ex
@@ -1,0 +1,110 @@
+defmodule Fountain.Runtimes.Gemini.SessionStore do
+  @moduledoc """
+  Keeps gemini's own chat-session store from erasing the session it is asked to
+  load — a workaround for [gemini-cli#28775][], tracked as #659.
+
+  [gemini-cli#28775]: https://github.com/google-gemini/gemini-cli/issues/28775
+
+  ## What goes wrong without this
+
+  Measured against a live `gemini --acp` on 2026-08-22, versions 0.53.0 through
+  0.56.0. `session/load` builds a fresh config on the session id *before*
+  looking the session up, which stands up a chat recorder; the recorder's
+  new-session branch names its file by **wall-clock minute**
+  (`toISOString().slice(0, 16)`) plus the id's first 8 characters, so a load in
+  the same minute as the last write computes the *same path*; it appends a
+  `$set` carrying only gemini's `<session_context>` bootstrap; and gemini's
+  reader treats `$set.messages` as a replacement rather than a merge. The
+  emptied file then fails `hasResumableContent`, drops out of `listSessions()`,
+  and `findSession` reports `-32603` "No previous sessions found for this
+  project" — about a session whose transcript is still on disk, above the line
+  that erased it.
+
+  Reproduced end to end: a turn-1 file with three resumable messages had one
+  left after a same-minute load, and the load failed.
+
+  ## Why a rename is not enough
+
+  The obvious fix — move the file out of the minute-bucketed path — holds for
+  exactly one turn. After every load **two** files carry the same `sessionId`:
+  the one we parked and the poisoned one the load just created. Gemini dedupes
+  by id keeping the later `lastUpdated`, which is the poisoned one, so turn 3
+  fails again.
+
+  So this **consolidates** on every turn instead: keep the file with real
+  content, delete the poisoned duplicates, and park the survivor under a
+  timestamp the recorder can never produce. Discovery is unaffected — gemini
+  scans on the `session-` prefix and the extension, and matches on the
+  `sessionId` *inside* the file, never on the name.
+
+  Verified live: five consecutive turns inside one wall-clock minute (the case
+  that fails on turn 2 without this), history growing 3 → 5 → 7 → 9 → 11, and
+  the agent recalling content planted before the first reload every time.
+
+  ## Lifetime
+
+  Delete this module, `priv/gemini-session-consolidate.js`, and the call in
+  `ConversationServer` when upstream lands. Nothing else depends on it.
+  """
+
+  require Logger
+
+  @script_path "/tmp/gemini-session-consolidate.js"
+
+  @source Path.join(:code.priv_dir(:fountain), "gemini-session-consolidate.js")
+  @external_resource @source
+  @script File.read!(@source)
+
+  @doc """
+  Install the consolidation script into the sandbox.
+
+  Called from `Gemini.prepare_sandbox/3`. Written to `/tmp` because gemini runs
+  with `HOME=/tmp` on the sprite and `/tmp` is writable there without the ACL
+  surprises `/home/sprite` has.
+  """
+  @spec install(Fountain.Sandbox.Handle.t()) :: :ok | {:error, term()}
+  def install(handle) do
+    Fountain.Sandbox.write_file(handle, @script_path, @script)
+  end
+
+  @doc """
+  Consolidate this session's chat files. Best-effort by contract.
+
+  Called at the end of every gemini ACP turn, before the next turn's
+  `session/load` can collide. A failure here costs the *next* turn its history,
+  which is bad, but failing the turn that just succeeded would be worse — so
+  this logs and returns `:ok` rather than propagating.
+
+  Runs with `HOME=/tmp` to match `Gemini.default_env/2`; the script resolves the
+  chats directory from `HOME` exactly as gemini does.
+  """
+  @spec consolidate(Fountain.Sandbox.Handle.t(), String.t() | nil) :: :ok
+  def consolidate(_handle, session_id) when session_id in [nil, ""], do: :ok
+
+  def consolidate(handle, session_id) do
+    case Fountain.Sandbox.exec(handle, "node", [@script_path, session_id],
+           env: [{"HOME", "/tmp"}],
+           timeout: 15_000
+         ) do
+      {:ok, out, 0} ->
+        Logger.debug("gemini session consolidate: #{String.trim(to_string(out))}")
+        :ok
+
+      {:ok, out, code} ->
+        Logger.warning(
+          "gemini session consolidate exited #{code} for #{session_id}: " <>
+            String.trim(to_string(out))
+        )
+
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("gemini session consolidate failed for #{session_id}: #{inspect(reason)}")
+
+        :ok
+    end
+  end
+
+  @doc false
+  def script_path, do: @script_path
+end

--- a/apps/fountain/priv/gemini-session-consolidate.js
+++ b/apps/fountain/priv/gemini-session-consolidate.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Keep one gemini chat-session file per session, outside the path its own
+// loader will clobber. Workaround for google-gemini/gemini-cli#28775; delete
+// this file and its call sites when that lands. Fountain issue: #659.
+//
+// The defect, in the version this was written against (0.53.0 through 0.56.0):
+//
+//   1. `session/load` builds a fresh config on the session id *before* looking
+//      the session up, which stands up a chat recorder;
+//   2. the recorder's new-session branch names its file
+//      `session-${new Date().toISOString().slice(0,16)}-${id.slice(0,8)}.jsonl`
+//      — minute resolution, so a load in the same minute as the last write
+//      computes the *same path*;
+//   3. it appends a `$set` carrying only its `<session_context>` bootstrap, and
+//      the reader treats `$set.messages` as a replacement, not a merge;
+//   4. the emptied file then fails `hasResumableContent` and is dropped from
+//      `listSessions()`, so `findSession` reports "No previous sessions found
+//      for this project" — about a session whose transcript is still on disk,
+//      above the line that erased it.
+//
+// Renaming once is not enough. After every load, *two* files carry the same
+// sessionId — the one we parked and the poisoned one the load just created —
+// and gemini dedupes by id keeping the later `lastUpdated`, which is the
+// poisoned one. So this consolidates instead: keep the file with real content,
+// delete the poisoned duplicates, park the survivor under a name whose
+// timestamp component can never be produced by the recorder.
+//
+// Discovery is unaffected: gemini's own scan filters only on the `session-`
+// prefix and the extension, and matches sessions by the `sessionId` *inside*
+// the file, never by the name.
+//
+// Usage: node gemini-session-consolidate.js <sessionId>
+// Exits 0 on success or when there is nothing to do. Never throws for a
+// missing directory: a turn that wrote no session is not an error.
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const PARKED_STAMP = "0000-00-00T00-00";
+
+function chatsDirs() {
+  const base = path.join(process.env.HOME || os.homedir(), ".gemini", "tmp");
+  let entries;
+  try {
+    entries = fs.readdirSync(base, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const c = path.join(base, e.name, "chats");
+    try {
+      if (fs.statSync(c).isDirectory()) out.push(c);
+    } catch {
+      /* no chats dir for this project */
+    }
+  }
+  return out;
+}
+
+// Mirrors gemini's own reader: records accumulate, but a `$set.messages`
+// replaces everything seen so far. Only user/gemini records with content are
+// resumable — which is exactly why a bootstrap-only `$set` reads as empty.
+function inspect(file) {
+  let text;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  let sessionId = null;
+  let messages = [];
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let rec;
+    try {
+      rec = JSON.parse(t);
+    } catch {
+      continue;
+    }
+    if (!rec || typeof rec !== "object") continue;
+    if (typeof rec.sessionId === "string" && !sessionId) sessionId = rec.sessionId;
+    if (rec.$set && Array.isArray(rec.$set.messages)) {
+      messages = rec.$set.messages.slice();
+      continue;
+    }
+    if ((rec.type === "user" || rec.type === "gemini") && rec.content !== undefined) {
+      messages.push(rec);
+    }
+  }
+  const resumable = messages.filter(
+    (m) => m && (m.type === "user" || m.type === "gemini") && m.content !== undefined
+  ).length;
+  return { sessionId, resumable };
+}
+
+function main() {
+  const sid = process.argv[2];
+  if (!sid) {
+    process.stderr.write("usage: gemini-session-consolidate.js <sessionId>\n");
+    process.exit(2);
+  }
+  const short = sid.slice(0, 8);
+  let kept = 0;
+  let removed = 0;
+
+  for (const dir of chatsDirs()) {
+    let names;
+    try {
+      names = fs.readdirSync(dir);
+    } catch {
+      continue;
+    }
+    const mine = [];
+    for (const name of names) {
+      if (!name.startsWith("session-") || !name.endsWith(".jsonl")) continue;
+      const full = path.join(dir, name);
+      const info = inspect(full);
+      if (!info || info.sessionId !== sid) continue;
+      mine.push({ full, name, resumable: info.resumable });
+    }
+    if (mine.length === 0) continue;
+
+    // Richest wins; ties keep the already-parked file so repeated runs are
+    // stable and a no-op turn cannot shuffle the archive.
+    mine.sort((a, b) => {
+      if (b.resumable !== a.resumable) return b.resumable - a.resumable;
+      const ap = a.name.includes(PARKED_STAMP) ? 0 : 1;
+      const bp = b.name.includes(PARKED_STAMP) ? 0 : 1;
+      return ap - bp;
+    });
+
+    const best = mine[0];
+    for (const f of mine.slice(1)) {
+      try {
+        fs.unlinkSync(f.full);
+        removed++;
+      } catch {
+        /* already gone */
+      }
+    }
+
+    const parked = path.join(dir, `session-${PARKED_STAMP}-${short}.jsonl`);
+    if (path.resolve(best.full) !== path.resolve(parked)) {
+      // rename, never onto a file we are still keeping — the losers are gone.
+      fs.renameSync(best.full, parked);
+    }
+    kept++;
+  }
+
+  process.stdout.write(JSON.stringify({ sessionId: sid, kept, removed }) + "\n");
+}
+
+main();

--- a/apps/fountain/test/fountain/runtimes/gemini_session_consolidate_test.exs
+++ b/apps/fountain/test/fountain/runtimes/gemini_session_consolidate_test.exs
@@ -1,0 +1,166 @@
+defmodule Fountain.Runtimes.GeminiSessionConsolidateTest do
+  @moduledoc """
+  The gemini session-store workaround (#659), exercised as the script that
+  actually runs — node against real files on disk, not a re-implementation.
+
+  Fixtures mirror what a live 0.56.0 leaves behind, measured on 2026-08-22:
+  turn 1 writes `session-<ISO minute>-<id8>.jsonl` with the transcript in it,
+  and every `session/load` adds a second file under the *same* naming scheme
+  carrying only a `$set` with gemini's `<session_context>` bootstrap.
+  """
+  use ExUnit.Case, async: true
+
+  @script Path.join([__DIR__, "..", "..", "..", "priv", "gemini-session-consolidate.js"])
+          |> Path.expand()
+
+  @parked "0000-00-00T00-00"
+
+  setup do
+    home = Path.join(System.tmp_dir!(), "gsc-#{System.unique_integer([:positive])}")
+    chats = Path.join([home, ".gemini", "tmp", "projecthash", "chats"])
+    File.mkdir_p!(chats)
+    on_exit(fn -> File.rm_rf(home) end)
+    {:ok, home: home, chats: chats}
+  end
+
+  defp msg(type, text),
+    do: %{"type" => type, "content" => text, "id" => "m#{:rand.uniform(9999)}"}
+
+  # A real session file: metadata line, then message records.
+  defp write_session(chats, name, sid, n_messages) do
+    lines =
+      ([
+         %{
+           "sessionId" => sid,
+           "projectHash" => "projecthash",
+           "startTime" => "2026-08-22T06:22:00Z"
+         }
+       ] ++
+         Enum.flat_map(1..max(n_messages, 0)//1, fn i ->
+           [msg("user", "q#{i}"), msg("gemini", "a#{i}")]
+         end))
+      |> Enum.take(n_messages)
+
+    body = Enum.map_join(lines, "\n", &Jason.encode!/1) <> "\n"
+    File.write!(Path.join(chats, name), body)
+  end
+
+  # What a load leaves: the bootstrap-only `$set` that erases the transcript.
+  defp write_poisoned(chats, name, sid) do
+    lines = [
+      %{"sessionId" => sid, "projectHash" => "projecthash"},
+      %{"$set" => %{"messages" => [%{"type" => "user", "content" => "<session_context>…"}]}}
+    ]
+
+    File.write!(Path.join(chats, name), Enum.map_join(lines, "\n", &Jason.encode!/1) <> "\n")
+  end
+
+  defp run(home, sid) do
+    {out, code} =
+      System.cmd("node", [@script, sid], env: [{"HOME", home}], stderr_to_stdout: true)
+
+    assert code == 0, "script failed: #{out}"
+    Jason.decode!(String.trim(out))
+  end
+
+  defp files(chats), do: chats |> File.ls!() |> Enum.sort()
+
+  test "the script exists where the runtime expects it" do
+    assert File.exists?(@script)
+  end
+
+  test "parks a first-turn session out of the collision path", ctx do
+    sid = "aaaaaaaa-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-2026-08-22T06-22-aaaaaaaa.jsonl", sid, 3)
+
+    assert %{"kept" => 1, "removed" => 0} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-aaaaaaaa.jsonl"]
+  end
+
+  test "keeps the transcript and deletes the poisoned duplicate a load leaves", ctx do
+    # The case that breaks a naive rename: two files, same sessionId, and
+    # gemini would pick the poisoned one because its lastUpdated is later.
+    sid = "bbbbbbbb-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-#{@parked}-bbbbbbbb.jsonl", sid, 5)
+    write_poisoned(ctx.chats, "session-2026-08-22T06-23-bbbbbbbb.jsonl", sid)
+
+    assert %{"kept" => 1, "removed" => 1} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-bbbbbbbb.jsonl"]
+
+    kept = File.read!(Path.join(ctx.chats, "session-#{@parked}-bbbbbbbb.jsonl"))
+    assert kept =~ "q1"
+    refute kept =~ "session_context"
+  end
+
+  test "never touches another session's files", ctx do
+    # One conversation per sandbox today, but a persistent sandbox (ADR 0023)
+    # puts several on one disk and this is the invariant that has to hold.
+    mine = "cccccccc-1111-2222-3333-444444444444"
+    theirs = "dddddddd-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-2026-08-22T06-22-cccccccc.jsonl", mine, 3)
+    write_session(ctx.chats, "session-2026-08-22T06-22-dddddddd.jsonl", theirs, 3)
+
+    assert %{"kept" => 1, "removed" => 0} = run(ctx.home, mine)
+
+    assert files(ctx.chats) == [
+             "session-#{@parked}-cccccccc.jsonl",
+             "session-2026-08-22T06-22-dddddddd.jsonl"
+           ]
+  end
+
+  test "is idempotent — a second run changes nothing", ctx do
+    sid = "eeeeeeee-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-2026-08-22T06-22-eeeeeeee.jsonl", sid, 3)
+
+    run(ctx.home, sid)
+    before = File.read!(Path.join(ctx.chats, "session-#{@parked}-eeeeeeee.jsonl"))
+
+    assert %{"kept" => 1, "removed" => 0} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-eeeeeeee.jsonl"]
+    assert File.read!(Path.join(ctx.chats, "session-#{@parked}-eeeeeeee.jsonl")) == before
+  end
+
+  test "richest wins even when the parked file is the poorer one", ctx do
+    # The discriminating case. If the rule were "prefer whatever is already
+    # parked" this passes anyway, so the parked file is deliberately the one
+    # with *less* content: only a genuine richest-wins comparison keeps the
+    # six-message transcript here.
+    sid = "ffffffff-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-#{@parked}-ffffffff.jsonl", sid, 2)
+    write_session(ctx.chats, "session-2026-08-22T06-30-ffffffff.jsonl", sid, 6)
+
+    assert %{"kept" => 1, "removed" => 1} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-ffffffff.jsonl"]
+
+    kept = File.read!(Path.join(ctx.chats, "session-#{@parked}-ffffffff.jsonl"))
+    assert kept =~ "q3", "kept the poorer file: richest-wins did not apply"
+  end
+
+  test "a tie keeps the already-parked file, so repeat runs are stable", ctx do
+    sid = "77777777-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-#{@parked}-77777777.jsonl", sid, 4)
+    write_session(ctx.chats, "session-2026-08-22T06-30-77777777.jsonl", sid, 4)
+
+    assert %{"kept" => 1, "removed" => 1} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-77777777.jsonl"]
+  end
+
+  test "a turn that wrote no session is not an error", ctx do
+    assert %{"kept" => 0, "removed" => 0} =
+             run(ctx.home, "99999999-1111-2222-3333-444444444444")
+  end
+
+  test "a missing .gemini directory is not an error" do
+    home = Path.join(System.tmp_dir!(), "gsc-empty-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(home)
+    on_exit(fn -> File.rm_rf(home) end)
+
+    {out, 0} =
+      System.cmd("node", [@script, "aaaaaaaa-1111-2222-3333-444444444444"],
+        env: [{"HOME", home}],
+        stderr_to_stdout: true
+      )
+
+    assert %{"kept" => 0} = Jason.decode!(String.trim(out))
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/gemini_session_store_test.exs
+++ b/apps/fountain/test/fountain/runtimes/gemini_session_store_test.exs
@@ -1,0 +1,71 @@
+defmodule Fountain.Runtimes.Gemini.SessionStoreTest do
+  @moduledoc """
+  The Elixir half of the #659 workaround: that the script is installed where the
+  turn-end call looks for it, and that a failing sandbox never costs a turn.
+  """
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Fountain.Runtimes.Gemini.SessionStore
+
+  setup :verify_on_exit!
+
+  defp handle, do: %Fountain.Sandbox.Handle{provider: :sprites, name: "test-sprite", private: %{}}
+
+  describe "install/1" do
+    test "writes the real script to the path consolidate/2 runs" do
+      test = self()
+
+      Mimic.expect(Fountain.Sandbox, :write_file, fn _h, path, body ->
+        send(test, {:wrote, path, body})
+        :ok
+      end)
+
+      assert :ok = SessionStore.install(handle())
+      assert_receive {:wrote, path, body}
+      assert path == SessionStore.script_path()
+
+      # The bundled script, not a placeholder — the module reads priv/ at
+      # compile time, so a rename there fails here rather than in a sprite.
+      assert body =~ "gemini-cli#28775"
+      assert body =~ "PARKED_STAMP"
+    end
+  end
+
+  describe "consolidate/2" do
+    test "runs the script for the session, with gemini's HOME" do
+      test = self()
+
+      Mimic.expect(Fountain.Sandbox, :exec, fn _h, cmd, args, opts ->
+        send(test, {:exec, cmd, args, opts[:env]})
+        {:ok, ~s({"kept":1,"removed":1}), 0}
+      end)
+
+      assert :ok = SessionStore.consolidate(handle(), "sess-abc")
+      assert_receive {:exec, "node", [script, "sess-abc"], env}
+      assert script == SessionStore.script_path()
+
+      # Must match Gemini.default_env/2 or the script resolves a different
+      # chats directory than the one gemini actually wrote to.
+      assert {"HOME", "/tmp"} in env
+    end
+
+    test "does nothing without a session id" do
+      Mimic.reject(&Fountain.Sandbox.exec/4)
+      assert :ok = SessionStore.consolidate(handle(), nil)
+      assert :ok = SessionStore.consolidate(handle(), "")
+    end
+
+    test "a non-zero exit does not fail the turn that just succeeded" do
+      Mimic.expect(Fountain.Sandbox, :exec, fn _h, _c, _a, _o -> {:ok, "boom", 1} end)
+      assert :ok = SessionStore.consolidate(handle(), "sess-abc")
+    end
+
+    test "an unreachable sandbox does not fail the turn either" do
+      # Losing the consolidation costs the *next* turn its history, which is
+      # bad; failing this turn on top of that would be worse.
+      Mimic.expect(Fountain.Sandbox, :exec, fn _h, _c, _a, _o -> {:error, :unavailable} end)
+      assert :ok = SessionStore.consolidate(handle(), "sess-abc")
+    end
+  end
+end

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -10,6 +10,7 @@ end
 # seam is Fountain.Sandbox.Sprites (the adapter behind the Fountain.Sandbox
 # facade); the raw SDK copies below it exist only for the adapter's own unit
 # tests and the full-stack provisioning/checkpoint pins.
+Mimic.copy(Fountain.Sandbox)
 Mimic.copy(Fountain.Sandbox.Sprites)
 Mimic.copy(Fountain.AvatarGenerator)
 Mimic.copy(Fountain.Sandbox.Sprites.Client)


### PR DESCRIPTION
Part of #659. **The workaround only — the block in `supported_runtimes/0` stays**, so nothing about how gemini runs today changes. Lifting it is a separate step, deliberately, and I say why at the bottom.

## The defect is still live on 0.56.0

Not the 0.53.0 report — measured against a live `gemini --acp` 0.56.0 on 2026-08-22:

```
turn1  session 58c7fdd7…  →  session-2026-08-22T06-22-58c7fdd7.jsonl   3 resumable messages
load   same minute        →  -32603 "No previous sessions found for this project."
after  same file                                                       1 resumable message
```

Three messages before the load, one after, in the file the load was meant to read. Upstream [gemini-cli#28775](https://github.com/google-gemini/gemini-cli/issues/28775) is still open and still `status/need-triage` — three releases on, every link intact:

1. `session/load` builds a config on the session id **before** looking it up;
2. the recorder names its file by wall-clock **minute** (`toISOString().slice(0,16)`) plus the id's first 8 chars, so a same-minute load computes the *same path*;
3. it appends a `$set` carrying only gemini's `<session_context>` bootstrap;
4. the reader treats `$set.messages` as a **replacement**, not a merge;
5. the emptied file fails `hasResumableContent` and drops out of `listSessions()`.

## Renaming the file once is not enough

This is the part worth reading, and it is why my first attempt was wrong.

**After every load, two files carry the same `sessionId`** — the one we parked and the poisoned one the load just created. Gemini dedupes by id keeping the later `lastUpdated`, which is the poisoned one. A naive rename works for exactly one turn and fails on turn 3.

So this **consolidates** on every turn: keep the file with real content, delete the poisoned duplicates, park the survivor under a timestamp the recorder cannot produce. Discovery is unaffected — gemini scans on the `session-` prefix and matches on the `sessionId` *inside* the file, never on the name.

## Verified live, end to end

Five consecutive turns inside one wall-clock minute — the case that fails on turn 2 without this:

```
turn 1                    parked:  3 messages
turn 2  load_ok=true               5
turn 3  load_ok=true               7
turn 4  load_ok=true               9
turn 5  load_ok=true              11
```

And the history is genuinely usable, not just structurally present — a word planted on turn 1 came back correctly after every reload.

## How it is tested

The logic lives in `priv/gemini-session-consolidate.js` and the tests **run that script with node against real files**, rather than re-implementing it in Elixir. Verified by reverting: dropping the `sessionId` filter, the richest-wins comparison, or the park each fail the suite.

One of those tests was **passing for the wrong reason** and is fixed here. It had the parked file also being the richest, so the parked-file tiebreak carried it and a broken richest-wins still passed. It now makes the parked file the *poorer* one, which is the only shape that discriminates.

Best-effort by contract: a failed consolidation costs the *next* turn its history, but failing the turn that just succeeded would be worse.

## Why the block stays in this PR

#659's plan ends with lifting `supported_runtimes/0`, and I have not done that. The workaround is verified against real gemini **on my machine**; what is not verified is the sprite integration — that the script lands, that `node` resolves on the sprite's PATH, and that `HOME=/tmp` finds the same chats directory there. Lifting the block routes every existing gemini agent onto the ACP path, and that is not a change to make on locally-verified-only evidence.

Landing the workaround first is safe (no behaviour change, the code is inert until the block lifts) and leaves exactly one scoped step behind: a live sprite smoke, then a one-line commit. Happy to run that smoke next.

## Checks

`mix test` — **3,483 tests, 0 failures**. `mix format --check-formatted`, `mix credo --strict` (no issues), `MIX_ENV=dev mix dialyzer` (**0 errors**), and `MIX_ENV=prod mix compile` — the `priv/` read happens at **compile time**, so the #884 class of failure would surface there and in the release boot check. `COPY apps ./apps` already carries the file into the build stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
