### PR TITLE
ci: rebuild the E2B template and Daytona snapshot, and smoke what comes out

### DIFF
--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -1,0 +1,192 @@
+# Rebuilds the sandbox base images the non-default providers boot from: the
+# E2B template and the Daytona snapshot that prod pins with E2B_TEMPLATE and
+# DAYTONA_SNAPSHOT.
+#
+# Until this existed both were hand-built artifacts from 2026-08-14, and
+# nothing rebuilt them when images/ changed or refreshed the agent CLIs baked
+# into them. A stale image does not announce itself: every conversation pinned
+# to that provider quietly runs a months-old claude, codex, gemini or opencode.
+#
+# Three triggers, one pipeline:
+#
+#   * a push to main touching images/ or these scripts — the recipe changed;
+#   * a weekly cron — the recipe did not change but the CLIs inside it did;
+#   * workflow_dispatch — a rebuild by hand, one provider at a time.
+#
+# Pull requests run the `dockerfile` job alone. It needs no provider account,
+# and it is the gate that matters for the Daytona job below: a Daytona snapshot
+# cannot be swapped in behind its name, so refreshing it means deleting the
+# name prod is pinned to and building it again. Proving the Dockerfile still
+# builds, on this runner, before touching the provider keeps that window from
+# being where an upstream apt or npm break is discovered.
+name: Sandbox images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'images/**'
+      - 'scripts/sandbox-image/**'
+      - '.github/workflows/sandbox-images.yml'
+  pull_request:
+    paths:
+      - 'images/**'
+      - 'scripts/sandbox-image/**'
+      - '.github/workflows/sandbox-images.yml'
+  # Monday, early. The CLIs are what go stale; nothing else here changes on
+  # its own.
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      providers:
+        description: Which provider images to rebuild
+        type: choice
+        default: both
+        options: [both, e2b, daytona, none]
+      skip_smoke:
+        description: Build without creating a sandbox to verify it
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Never cancel a run in flight. The Daytona job deletes the snapshot prod is
+# pinned to before it creates the new one, and a cancellation between those two
+# calls leaves the organization with no `fountain` snapshot at all.
+concurrency:
+  group: sandbox-images
+  cancel-in-progress: false
+
+env:
+  E2B_TEMPLATE: fountain
+  DAYTONA_SNAPSHOT: fountain
+
+jobs:
+  dockerfile:
+    name: Build ${{ matrix.provider }} locally and smoke it
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - provider: e2b
+            context: images/e2b
+            dockerfile: e2b.Dockerfile
+          - provider: daytona
+            context: images/daytona
+            dockerfile: Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          # Nothing here runs an authenticated git operation, and the image
+          # build should not inherit a push-capable credential.
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      # amd64 only, and deliberately: Daytona requires amd64, E2B runs amd64,
+      # and this build exists to prove the recipe, not to publish anything.
+      - name: Build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.context }}/${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: fountain-sandbox-${{ matrix.provider }}:ci
+
+      # The same checks the live smokes run inside a real sandbox. Here they
+      # answer a narrower question — is the image itself the shape provisioning
+      # assumes — before either provider account is touched.
+      - name: Smoke the image
+        run: |
+          docker run --rm \
+            -e SMOKE_EXPECT_USER=sprite \
+            -v "${PWD}/scripts/sandbox-image/smoke.sh:/tmp/smoke.sh:ro" \
+            "fountain-sandbox-${{ matrix.provider }}:ci" \
+            bash /tmp/smoke.sh
+
+  e2b:
+    name: Rebuild the E2B template
+    needs: dockerfile
+    # Pull requests stop at the dockerfile gate: a fork PR has no secrets, and
+    # a rebuild is a change to prod's artifact, not a check on a proposal.
+    if: >-
+      github.event_name != 'pull_request' &&
+      contains(fromJSON('["both", "e2b"]'), github.event.inputs.providers || 'both')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          persist-credentials: false
+
+      # A missing secret fails the job. Skipping instead would reproduce the
+      # exact failure this workflow exists to end: a green run that rebuilt
+      # nothing, and an image ageing in place.
+      - name: Require the E2B key
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: |
+          if [ -z "${E2B_API_KEY}" ]; then
+            echo "::error::E2B_API_KEY is not configured. It must be the same" \
+                 "account prod uses — a template built under another org is" \
+                 "invisible to prod's key."
+            exit 1
+          fi
+
+      - name: Build and smoke the template
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          E2B_TEMPLATE: ${{ env.E2B_TEMPLATE }}
+          SKIP_SMOKE: ${{ github.event.inputs.skip_smoke == 'true' && '1' || '' }}
+        run: scripts/sandbox-image/build-e2b.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "E2B template \`${E2B_TEMPLATE}\` — ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+
+  daytona:
+    name: Rebuild the Daytona snapshot
+    needs: dockerfile
+    if: >-
+      github.event_name != 'pull_request' &&
+      contains(fromJSON('["both", "daytona"]'), github.event.inputs.providers || 'both')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          persist-credentials: false
+
+      - name: Require the Daytona key
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+        run: |
+          if [ -z "${DAYTONA_API_KEY}" ]; then
+            echo "::error::DAYTONA_API_KEY is not configured. It must be the" \
+                 "same account prod uses — a snapshot built under another org" \
+                 "is invisible to prod's key."
+            exit 1
+          fi
+
+      - name: Build and smoke the snapshot
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_SNAPSHOT: ${{ env.DAYTONA_SNAPSHOT }}
+          SKIP_SMOKE: ${{ github.event.inputs.skip_smoke == 'true' && '1' || '' }}
+        run: scripts/sandbox-image/build-daytona.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "Daytona snapshot \`${DAYTONA_SNAPSHOT}\` — ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,24 @@ upgrade, is in
   change in Elixir cannot leave the SDK describing an API that no longer
   exists. Generating it immediately found one: see below.
 
+- **The E2B template and the Daytona snapshot are rebuilt by CI** (#692). Both
+  were hand-built artifacts from one afternoon in August, and nothing rebuilt
+  them when `images/` changed or refreshed the four agent CLIs baked into
+  them. A stale sandbox image does not announce itself: every conversation
+  pinned to that provider quietly runs a months-old `claude`, `codex`,
+  `gemini` or `opencode`. The new `Sandbox images` workflow rebuilds both on a
+  change to `images/`, once a week for the CLI versions, and on dispatch.
+
+  Each rebuild is smoke-tested in a real sandbox against
+  `scripts/sandbox-image/smoke.sh`, which is one file both providers ship
+  in-guest so they are held to the same contract. It does the global npm
+  install rather than reading the prefix setting, because #691's failure mode
+  was exit 243 with no output and the setting looked right. Pull requests run
+  the same Dockerfiles through `docker build` and the same smoke, with no
+  provider account involved — which is also what stands between an upstream
+  apt or npm break and the minutes when the Daytona snapshot name, which
+  cannot be rebuilt in place, does not exist.
+
 ### Fixed
 
 - **Every line of every code block in `/docs` and `/help` had a light box

--- a/docs/integrations/adding-a-sandbox-provider.md
+++ b/docs/integrations/adding-a-sandbox-provider.md
@@ -146,5 +146,17 @@ it passed.
 
 Two things remain after that. The provider's key goes to the Infisical prod
 project, which syncs it into `fountain-secrets` and reloads the deployment on
-its own. The image needs a rebuild story, and #692 tracks how to automate
-that.
+its own. And the image needs a rebuild, because the agent CLIs in it go stale
+in weeks.
+
+The `Sandbox images` workflow owns the rebuild. Give the new provider a
+`scripts/sandbox-image/build-<provider>.sh` that rebuilds the image and then
+smokes it. Add a matrix entry, so that `docker build` proves the Dockerfile on
+the runner first. Then add a job that runs the script with the account key as
+a repository secret. That key must belong to the account prod uses. An image
+that another account builds is not visible to prod.
+
+Every one of those scripts ships `scripts/sandbox-image/smoke.sh` into the new
+sandbox and reads its verdict. Keep the checks in that one file. It is the
+statement of what an image must give the provision pipeline, and it holds each
+provider to the same contract.

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -33,9 +33,28 @@ The stock image carries no agent CLI. Build the reference snapshot once for
 each organization.
 
 ```bash
-cd images/daytona
-daytona snapshot create fountain --dockerfile Dockerfile
+DAYTONA_API_KEY=... scripts/sandbox-image/build-daytona.sh
 ```
+
+The script sends the content of `images/daytona/Dockerfile` to the snapshot
+API and waits for the build to reach `active`. Then it creates one sandbox
+from the new snapshot. It checks the shape that the provision pipeline
+assumes, then it destroys the sandbox. `DAYTONA_SNAPSHOT` selects a different
+snapshot name.
+
+A snapshot name is unique for each organization, and Daytona has no rename. So
+a rebuild of the name that an instance points at is a delete and a create. In
+the minutes between them, the organization has no snapshot of that name. A
+conversation that starts on Daytona in that window cannot create its sandbox.
+Sandboxes that already exist keep the copy that they started from.
+
+CI runs the same script. The `Sandbox images` workflow rebuilds the snapshot
+when `images/daytona/` changes, once each week for the agent CLI versions, and
+on request. It first builds the same Dockerfile with `docker build` on the
+runner. That gate catches an upstream break before the delete opens the window
+above. The workflow needs a `DAYTONA_API_KEY` repository secret. That key must
+belong to the account the instance uses. A snapshot that another organization
+builds is not visible to the instance.
 
 ## How the contract maps
 

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -30,11 +30,25 @@ The stock `base` template carries no agent CLI. Build the reference template
 once for each account.
 
 ```bash
-cd images/e2b
-e2b template build --name fountain --dockerfile e2b.Dockerfile
+E2B_API_KEY=... scripts/sandbox-image/build-e2b.sh
 ```
 
-It recreates the sandbox shape that the provision pipeline assumes. That is a
+The script runs `e2b template create fountain` against `images/e2b/`. Then it
+creates one sandbox from the new template. It checks the shape that the
+provision pipeline assumes, then it destroys the sandbox. `E2B_TEMPLATE`
+selects a different template name.
+
+`e2b template create` takes the name and rebuilds that template in place. So
+the template id that an instance points at stays the same. Sandboxes that
+already run keep the copy that they started from.
+
+CI runs the same script. The `Sandbox images` workflow rebuilds the template
+when `images/e2b/` changes, once each week for the agent CLI versions, and on
+request. It needs an `E2B_API_KEY` repository secret. That key must belong to
+the account the instance uses. A template that another account builds is not
+visible to the instance.
+
+The image recreates the sandbox shape that the provision pipeline assumes. That is a
 `sprite` user with passwordless sudo, `/home/sprite`, node, npm, bun, git and
 the four agent CLIs. So no provision code exists for one provider alone.
 

--- a/images/daytona/Dockerfile
+++ b/images/daytona/Dockerfile
@@ -1,10 +1,14 @@
 # Reference Daytona snapshot for Fountain sandboxes.
 #
-# Build and push with the Daytona CLI from this directory:
+# Build it, and smoke the result, with:
 #
-#     daytona snapshot create fountain --dockerfile Dockerfile
+#     DAYTONA_API_KEY=... scripts/sandbox-image/build-daytona.sh
 #
-# then point the instance at it with DAYTONA_SNAPSHOT=fountain.
+# then point the instance at it with DAYTONA_SNAPSHOT=fountain. CI runs the
+# same script on a change to this directory and once a week for the CLI
+# versions below (.github/workflows/sandbox-images.yml). A snapshot name
+# cannot be rebuilt in place, so that script deletes the name and creates it
+# again; the script's header has what that costs.
 #
 # Recreates the Sprites base-image shape the provisioning pipeline assumes:
 # a `sprite` user with passwordless sudo, HOME=/home/sprite, ~/.local/bin on

--- a/images/e2b/e2b.Dockerfile
+++ b/images/e2b/e2b.Dockerfile
@@ -1,10 +1,12 @@
 # Reference E2B template for Fountain sandboxes.
 #
-# Build with the E2B CLI from this directory:
+# Build it, and smoke the result, with:
 #
-#     e2b template build --name fountain --dockerfile e2b.Dockerfile
+#     E2B_API_KEY=... scripts/sandbox-image/build-e2b.sh
 #
-# then point the instance at it with E2B_TEMPLATE=fountain.
+# then point the instance at it with E2B_TEMPLATE=fountain. CI runs the same
+# script on a change to this directory and once a week for the CLI versions
+# below (.github/workflows/sandbox-images.yml).
 #
 # The provisioning pipeline assumes the Sprites base-image shape: a `sprite`
 # user with passwordless sudo, HOME=/home/sprite, ~/.local/bin on PATH, bash,

--- a/scripts/sandbox-image/build-daytona.sh
+++ b/scripts/sandbox-image/build-daytona.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Rebuild the Daytona snapshot from images/daytona/, then smoke-test it live.
+#
+# Runs in CI (.github/workflows/sandbox-images.yml) and by hand:
+#
+#     DAYTONA_API_KEY=... scripts/sandbox-image/build-daytona.sh
+#
+# ## Why this deletes before it builds
+#
+# Snapshot names are unique per organization and there is no rename, so a
+# snapshot cannot be rebuilt in place and cannot be swapped in behind its name
+# either. Prod pins DAYTONA_SNAPSHOT=fountain, so refreshing that name means
+# deleting it and creating it again, and between those two calls the
+# organization has no `fountain` snapshot: a Daytona conversation started in
+# that window fails to create its sandbox. Sandboxes that already exist are
+# unaffected — they hold their own copy.
+#
+# The window is why the workflow builds and smokes the very same Dockerfile
+# with `docker build` on the runner first. That gate catches what actually
+# breaks these images (an apt or npm publisher upstream) before anything on the
+# Daytona side is touched. What it cannot catch is a Daytona-side build failure,
+# and if that happens the snapshot stays missing until someone re-runs this —
+# so the script says so, loudly, rather than exiting quietly.
+#
+# Environment:
+#   DAYTONA_API_KEY   required, and it must be the account prod uses — a
+#                     snapshot built under another org is invisible to prod
+#   DAYTONA_SNAPSHOT  snapshot name to rebuild (default: fountain)
+#   DAYTONA_API_URL   control plane (default: https://app.daytona.io/api)
+#   SKIP_SMOKE        set to 1 to build without creating a sandbox
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+snapshot="${DAYTONA_SNAPSHOT:-fountain}"
+api_url="${DAYTONA_API_URL:-https://app.daytona.io/api}"
+dockerfile="${root}/images/daytona/Dockerfile"
+
+# A snapshot build pulls a base image and installs four agent CLIs.
+build_timeout_s="${DAYTONA_BUILD_TIMEOUT_S:-2700}"
+start_timeout_s="${DAYTONA_START_TIMEOUT_S:-600}"
+
+if [ -z "${DAYTONA_API_KEY:-}" ]; then
+  echo "DAYTONA_API_KEY is not set — cannot talk to daytona.io" >&2
+  exit 1
+fi
+
+command -v jq > /dev/null || { echo "jq is required" >&2; exit 1; }
+
+resp="$(mktemp)"
+trap 'rm -f "$resp"' EXIT
+
+# Every call writes its body to $resp and prints the status code, so callers
+# read both instead of guessing from a merged blob.
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS -X "$method"
+    -H "Authorization: Bearer ${DAYTONA_API_KEY}"
+    -H "Content-Type: application/json"
+    -o "$resp" -w '%{http_code}')
+  if [ -n "$body" ]; then args+=(--data-binary "$body"); fi
+  curl "${args[@]}" "${api_url}${path}"
+}
+
+die() {
+  echo "$1" >&2
+  echo "response: $(cat "$resp")" >&2
+  exit 1
+}
+
+# ── the snapshot ──────────────────────────────────────────────────────────────
+
+create_body="$(jq -n --arg name "$snapshot" --rawfile df "$dockerfile" \
+  '{name: $name, buildInfo: {dockerfileContent: $df}}')"
+
+code="$(api GET "/snapshots/${snapshot}")"
+if [ "$code" = "200" ]; then
+  existing_id="$(jq -r '.id' < "$resp")"
+  echo "==> deleting the current ${snapshot} snapshot (${existing_id})"
+  code="$(api DELETE "/snapshots/${existing_id}")"
+  case "$code" in
+    2*) ;;
+    *) die "delete of snapshot ${snapshot} failed with ${code}" ;;
+  esac
+
+  # Deletion is a background job; creating the name again before it lands is a
+  # 409. Wait for the name to actually go.
+  deadline=$((SECONDS + 300))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    code="$(api GET "/snapshots/${snapshot}")"
+    [ "$code" = "404" ] && break
+    sleep 5
+  done
+  [ "$code" = "404" ] || die "snapshot ${snapshot} still present after 300s of deleting"
+elif [ "$code" != "404" ]; then
+  die "looking up snapshot ${snapshot} failed with ${code}"
+fi
+
+echo "==> creating ${snapshot} from images/daytona/Dockerfile"
+code="$(api POST /snapshots "$create_body")"
+case "$code" in
+  2*) ;;
+  *) die "PROD IS NOW WITHOUT A ${snapshot} SNAPSHOT: create failed with ${code}" ;;
+esac
+snapshot_id="$(jq -r '.id' < "$resp")"
+
+echo "==> waiting for ${snapshot} (${snapshot_id}) to reach active"
+deadline=$((SECONDS + build_timeout_s))
+state=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+  code="$(api GET "/snapshots/${snapshot_id}")"
+  [ "$code" = "200" ] || die "polling snapshot ${snapshot_id} failed with ${code}"
+  state="$(jq -r '.state' < "$resp")"
+
+  case "$state" in
+    active)
+      break
+      ;;
+    error | build_failed)
+      echo "snapshot build ended in ${state}: $(jq -r '.errorReason // "no reason given"' < "$resp")" >&2
+      echo "--- build logs ---" >&2
+      api GET "/snapshots/${snapshot_id}/build-logs" > /dev/null || true
+      cat "$resp" >&2
+      echo >&2
+      echo "PROD IS NOW WITHOUT A WORKING ${snapshot} SNAPSHOT — fix the" >&2
+      echo "Dockerfile and re-run this workflow." >&2
+      exit 1
+      ;;
+    *)
+      echo "    ${state}"
+      sleep 15
+      ;;
+  esac
+done
+
+[ "$state" = "active" ] || die "snapshot ${snapshot} stuck in ${state} after ${build_timeout_s}s"
+echo "==> ${snapshot} is active"
+
+if [ "${SKIP_SMOKE:-}" = "1" ]; then
+  echo "==> SKIP_SMOKE=1, leaving the snapshot unverified"
+  exit 0
+fi
+
+# ── the smoke ─────────────────────────────────────────────────────────────────
+
+sandbox_name="fountain-image-smoke-${GITHUB_RUN_ID:-$$}"
+
+cleanup_sandbox() {
+  echo "==> destroying smoke sandbox ${sandbox_name}"
+  api DELETE "/sandbox/${sandbox_name}" > /dev/null || true
+  rm -f "$resp"
+}
+
+echo "==> creating smoke sandbox ${sandbox_name}"
+# No `fountain: "1"` label, deliberately: that is what the reaper and the ops
+# gauges count as a Fountain sandbox, and a CI sandbox is neither leaked nor
+# theirs to reason about. The intervals are the backstop for a run that dies
+# before its trap fires — prod sets all three to 0, and a leaked CI sandbox
+# billing forever is the one thing this script must not do.
+sandbox_body="$(jq -nc --arg snapshot "$snapshot" --arg name "$sandbox_name" \
+  '{name: $name,
+    snapshot: $snapshot,
+    labels: {fountain_image_smoke: "1"},
+    autoStopInterval: 10,
+    autoDeleteInterval: 5,
+    ttlMinutes: 30}')"
+
+code="$(api POST /sandbox "$sandbox_body")"
+case "$code" in
+  2*) ;;
+  *) die "creating the smoke sandbox failed with ${code}" ;;
+esac
+trap cleanup_sandbox EXIT
+
+sandbox_id="$(jq -r '.id' < "$resp")"
+
+echo "==> waiting for ${sandbox_name} to start"
+deadline=$((SECONDS + start_timeout_s))
+state=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+  code="$(api GET "/sandbox/${sandbox_name}")"
+  [ "$code" = "200" ] || die "polling sandbox ${sandbox_name} failed with ${code}"
+  state="$(jq -r '.state' < "$resp")"
+  case "$state" in
+    started) break ;;
+    error | build_failed) die "smoke sandbox ended in ${state}" ;;
+    *)
+      echo "    ${state}"
+      sleep 5
+      ;;
+  esac
+done
+[ "$state" = "started" ] || die "smoke sandbox stuck in ${state} after ${start_timeout_s}s"
+
+# Same shape Fountain.Sandbox.Daytona.Api.toolbox_url/1 builds.
+proxy="$(jq -r '.toolboxProxyUrl // empty' < "$resp")"
+if [ -z "$proxy" ]; then
+  code="$(api GET "/sandbox/${sandbox_id}/toolbox-proxy-url")"
+  [ "$code" = "200" ] || die "no toolbox proxy URL for ${sandbox_name} (${code})"
+  proxy="$(jq -r 'if type == "string" then . else .url end' < "$resp")"
+fi
+toolbox="${proxy%/}/${sandbox_id}"
+
+echo "==> smoking ${sandbox_name}"
+smoke_b64="$(base64 < "${root}/scripts/sandbox-image/smoke.sh" | tr -d '\n')"
+exec_body="$(jq -nc --arg cmd "echo ${smoke_b64} | base64 -d | bash" \
+  '{command: $cmd, timeout: 600}')"
+
+exec_code="$(curl -sS -X POST \
+  -H "Authorization: Bearer ${DAYTONA_API_KEY}" \
+  -H "Content-Type: application/json" \
+  --data-binary "$exec_body" \
+  -o "$resp" -w '%{http_code}' \
+  "${toolbox}/process/execute")"
+
+[ "$exec_code" = "200" ] || die "toolbox execute failed with ${exec_code}"
+
+jq -r '.result // .output // ""' < "$resp"
+exit_code="$(jq -r '.exitCode // .code // 0' < "$resp")"
+
+if [ "$exit_code" != "0" ] || ! jq -r '.result // .output // ""' < "$resp" | grep -q FOUNTAIN_IMAGE_SMOKE_OK; then
+  echo "==> smoke FAILED for snapshot ${snapshot} (exit ${exit_code})" >&2
+  exit 1
+fi
+
+echo "==> snapshot ${snapshot} rebuilt and smoked clean"

--- a/scripts/sandbox-image/build-e2b.sh
+++ b/scripts/sandbox-image/build-e2b.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Rebuild the E2B template from images/e2b/, then smoke-test it live.
+#
+# Runs in CI (.github/workflows/sandbox-images.yml) and by hand:
+#
+#     E2B_API_KEY=... scripts/sandbox-image/build-e2b.sh
+#
+# `e2b template create <name>` is name-addressed and rebuilds in place, so the
+# template ID prod is pinned to (px8ej9g93zg6b8q9w01j, alias `fountain`)
+# survives every rebuild. Sandboxes already running keep the copy they started
+# from. There is no in-between state to protect, which is why this script is so
+# much shorter than its Daytona counterpart.
+#
+# Environment:
+#   E2B_API_KEY   required, and it must be the account prod uses — a template
+#                 built under another org is invisible to prod's key
+#   E2B_TEMPLATE  template name to rebuild (default: fountain)
+#   E2B_BASE_URL  control-plane base (default: https://api.e2b.app)
+#   E2B_USER      in-guest user the smoke runs as (default: sprite)
+#   SKIP_SMOKE    set to 1 to build without creating a sandbox
+
+set -euo pipefail
+
+# Pinned: the CLI decides what "template create" means, and a silent major
+# would change the artifact prod boots from.
+CLI="@e2b/cli@2.17.1"
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+template="${E2B_TEMPLATE:-fountain}"
+base_url="${E2B_BASE_URL:-https://api.e2b.app}"
+user="${E2B_USER:-sprite}"
+
+if [ -z "${E2B_API_KEY:-}" ]; then
+  echo "E2B_API_KEY is not set — cannot talk to e2b.dev" >&2
+  exit 1
+fi
+
+for tool in jq npx; do
+  command -v "$tool" > /dev/null || { echo "${tool} is required" >&2; exit 1; }
+done
+
+echo "==> building E2B template ${template} from images/e2b/e2b.Dockerfile"
+npx --yes "$CLI" template create "$template" \
+  --path "${root}/images/e2b" \
+  --dockerfile e2b.Dockerfile
+
+if [ "${SKIP_SMOKE:-}" = "1" ]; then
+  echo "==> SKIP_SMOKE=1, leaving the template unverified"
+  exit 0
+fi
+
+sandbox_id=""
+
+cleanup() {
+  if [ -n "$sandbox_id" ]; then
+    echo "==> destroying smoke sandbox ${sandbox_id}"
+    curl -sS -X DELETE -H "X-API-Key: ${E2B_API_KEY}" \
+      "${base_url}/sandboxes/${sandbox_id}" > /dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "==> creating a smoke sandbox from ${template}"
+# No `fountain: "1"` metadata, deliberately: that is the label the reaper and
+# the ops gauges count as a Fountain sandbox, and a CI sandbox is neither
+# leaked nor theirs to reason about. The short timeout is the backstop for a
+# smoke that dies before its trap runs.
+create_body="$(jq -nc --arg t "$template" \
+  '{templateID: $t, timeout: 600, metadata: {fountain_image_smoke: "1"}}')"
+
+create_out="$(curl -sS -X POST \
+  -H "X-API-Key: ${E2B_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "$create_body" \
+  "${base_url}/sandboxes")"
+
+sandbox_id="$(jq -r '.sandboxID // .sandboxId // empty' <<< "$create_out")"
+
+if [ -z "$sandbox_id" ]; then
+  echo "no sandbox ID in the create response: ${create_out}" >&2
+  exit 1
+fi
+
+echo "==> smoking ${sandbox_id} as ${user}"
+smoke_b64="$(base64 < "${root}/scripts/sandbox-image/smoke.sh" | tr -d '\n')"
+# The asserted user is E2B's own contract: envd selects the in-guest user from
+# Basic auth, so E2B_USER and the template's user have to agree or every
+# provisioning write lands in the wrong home.
+in_guest="export SMOKE_EXPECT_USER=${user}; echo ${smoke_b64} | base64 -d | bash"
+
+# envd accepts the connection before it is ready to run anything, and PR #693
+# is the record of what that race costs. Retry the first exec only.
+attempt=1
+output=""
+while :; do
+  if output="$(npx --yes "$CLI" sandbox exec --user "$user" "$sandbox_id" bash -lc "$in_guest" 2>&1)"; then
+    break
+  fi
+  if [ "$attempt" -ge 6 ]; then
+    break
+  fi
+  echo "    exec attempt ${attempt} failed, retrying in 5s"
+  attempt=$((attempt + 1))
+  sleep 5
+done
+
+echo "$output"
+
+if ! grep -q FOUNTAIN_IMAGE_SMOKE_OK <<< "$output"; then
+  echo "==> smoke FAILED for template ${template}" >&2
+  exit 1
+fi
+
+echo "==> template ${template} rebuilt and smoked clean"

--- a/scripts/sandbox-image/smoke.sh
+++ b/scripts/sandbox-image/smoke.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Asserts the base-image shape Fountain's provisioning pipeline assumes.
+#
+# This runs INSIDE a sandbox (or inside the image under `docker run`), never on
+# the CI runner. Every caller ships it the same way — base64 on one command
+# line — so the E2B template, the Daytona snapshot and a local `docker build`
+# are held to the identical contract.
+#
+# Every check stands for a provisioning step that fails in a way that is hard
+# to read from the outside. The npm one is the #691 trap: a global install as
+# `sprite` against the root-owned default prefix exits 243 with no output, and
+# the conversation only reports that the runtime is missing. It is checked by
+# doing the install, not by reading the setting, because the setting was right
+# in the image that failed.
+#
+# SMOKE_EXPECT_USER asserts which user the provider selected in-guest, and is
+# set only where Fountain pins that: E2B, where envd picks the user from Basic
+# auth and E2B_USER must match what the template creates. Daytona picks its own
+# and the value is reported rather than asserted.
+#
+# The exit code and the trailing marker both carry the verdict: a provider exec
+# API that swallows the exit code still cannot fake the marker.
+
+set -uo pipefail
+
+failures=0
+
+pass() { printf 'ok    %s\n' "$1"; }
+
+fail() {
+  printf 'FAIL  %s\n' "$1"
+  if [ -n "${2:-}" ]; then printf '      %s\n' "$2"; fi
+  failures=$((failures + 1))
+}
+
+# Run a command, capture combined output, report on the exit code.
+check() {
+  local label="$1"
+  shift
+  local out status
+  out="$(timeout 180 "$@" 2>&1)"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    pass "$label${out:+ (${out%%$'\n'*})}"
+  else
+    fail "$label" "exit ${status}: ${out:-no output}"
+  fi
+}
+
+echo "== identity"
+whoami="$(whoami 2>&1)"
+echo "      user=${whoami} home=${HOME:-unset} pwd=$(pwd)"
+
+if [ -n "${SMOKE_EXPECT_USER:-}" ]; then
+  if [ "$whoami" = "$SMOKE_EXPECT_USER" ]; then
+    pass "runs as ${SMOKE_EXPECT_USER}"
+  else
+    fail "runs as ${SMOKE_EXPECT_USER}" "got ${whoami}"
+  fi
+fi
+
+if [ -w "${HOME:-/nonexistent}" ]; then
+  pass "HOME is writable"
+else
+  fail "HOME is writable" "${HOME:-unset} is not writable by ${whoami}"
+fi
+
+echo
+echo "== base tooling"
+check "bash" bash --version
+check "git" git --version
+check "node" node --version
+check "npm" npm --version
+
+echo
+echo "== a global npm install as the exec user (#691)"
+prefix="$(npm config get prefix 2>&1)"
+echo "      npm prefix=${prefix}"
+
+# The measurement, not the setting. `--silent` is what hid the EACCES last
+# time, so it stays in, and Fountain.Runtimes.ACP installs with it.
+if npm_out="$(timeout 300 npm install -g --no-progress --silent semver 2>&1)"; then
+  if [ -x "${prefix}/bin/semver" ]; then
+    pass "npm install -g"
+  else
+    fail "npm install -g" "exit 0, but no ${prefix}/bin/semver"
+  fi
+else
+  fail "npm install -g" "exit $?: ${npm_out:-no output — the 243 signature}"
+fi
+
+echo
+echo "== agent CLIs"
+# claude, codex and gemini are root-installed into the system prefix, so they
+# answer on any PATH. opencode comes from `bun install -g`, whose bin directory
+# the runtimes reach by absolute path.
+check "claude" claude --version
+check "codex" codex --version
+check "gemini" gemini --version
+check "bun" /home/sprite/.bun/bin/bun --version
+check "opencode" /home/sprite/.bun/bin/opencode --version
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "FOUNTAIN_IMAGE_SMOKE_OK"
+  exit 0
+fi
+
+echo "FOUNTAIN_IMAGE_SMOKE_FAILED ${failures}"
+exit 1


### PR DESCRIPTION
Closes #692.

## What was wrong

The `fountain` E2B template and the `fountain` Daytona snapshot were built by
hand on 2026-08-14 and never again. Nothing rebuilt them when `images/`
changed, and nothing refreshed the four agent CLIs baked into them — which is
the half that rots. Prod pins `E2B_TEMPLATE=fountain` and
`DAYTONA_SNAPSHOT=fountain`, so every conversation on either provider has been
running the `claude`, `codex`, `gemini` and `opencode` of that afternoon, with
nothing to say so.

## What this adds

`.github/workflows/sandbox-images.yml` — three triggers, one pipeline:

| Trigger | What runs |
|---|---|
| PR touching `images/**` or `scripts/sandbox-image/**` | `dockerfile` job only |
| Push to main touching the same | everything |
| Weekly cron (Mon 06:17 UTC) | everything, for CLI freshness |
| `workflow_dispatch` | `providers: both/e2b/daytona/none`, `skip_smoke` |

- **`dockerfile`** builds both Dockerfiles with `docker build` on the runner
  and runs the smoke inside them. No provider account, so it gates PRs.
- **`e2b`** runs `scripts/sandbox-image/build-e2b.sh`: `e2b template create
  fountain` (the current command — `template build` is deprecated in CLI 2.x),
  then a live sandbox, the smoke as `sprite`, and a destroy.
- **`daytona`** runs `scripts/sandbox-image/build-daytona.sh`: the snapshot API
  with `buildInfo.dockerfileContent`, a poll to `active` (build logs dumped on
  `error`/`build_failed`), then a live sandbox, the smoke through the toolbox,
  and a destroy.

`scripts/sandbox-image/smoke.sh` is one file, shipped in-guest over base64 by
both build scripts and mounted by the local `docker run`, so all three paths
hold the image to the same contract. It **does** the global npm install rather
than reading the prefix setting, because #691's signature was exit 243 with no
output while `npm config get prefix` looked correct.

## What I verified locally

Both images built and smoked on this machine:

- `images/e2b/e2b.Dockerfile` → `FOUNTAIN_IMAGE_SMOKE_OK` (claude 2.1.239,
  codex 0.149.0, gemini 0.56.0, opencode 1.18.21, bun 1.4.0, node 22.23.2)
- `images/daytona/Dockerfile` → `FOUNTAIN_IMAGE_SMOKE_OK`
- **the smoke catches the bug it exists for**: with `npm config delete prefix`
  the install reproduces `exit 243: no output — the 243 signature` and the run
  exits 1
- a wrong `SMOKE_EXPECT_USER` fails loudly, and the base64 transport path
  (~4.4 KB command) round-trips
- `actionlint` and `shellcheck` clean; `docs-style.py`, `vale lint docs` and
  `mkdocs build --strict` pass

## What needs you

**The two repo secrets do not exist yet.** Both provider jobs fail with an
explicit `::error::` until `E2B_API_KEY` and `DAYTONA_API_KEY` are added, and
they must be the same accounts prod uses — an image built under another org is
invisible to prod's key. Failing beats skipping here: a green run that rebuilt
nothing is exactly the failure #692 is about. After adding them, the honest
first run is `workflow_dispatch` with one provider at a time.

The live paths are unverified by definition — no keys, no live run. Two places
I would expect the first dispatch to teach us something:

1. **Which user Daytona's toolbox executes as.** E2B pins it (`E2B_USER`
   selects it through envd Basic auth), so the smoke asserts `sprite` there.
   Daytona picks its own, so the smoke reports it rather than asserting. If it
   turns out to be root, the identity line in the output says so.
2. **The Daytona delete-then-create window.** Snapshot names are unique per
   org and there is no rename, so the name prod pins cannot be swapped in
   behind itself. The `dockerfile` gate runs first precisely so an upstream
   break is found before the window, and the script says loudly if it ends
   with the name missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)