### PR TITLE
fix(acp): a permission request id that is unique, and a policy key you can write

### DIFF
--- a/apps/fountain/lib/fountain/permissions.ex
+++ b/apps/fountain/lib/fountain/permissions.ex
@@ -14,14 +14,19 @@ defmodule Fountain.Permissions do
 
   ## The shape
 
-  A policy is a map of tool name to verdict, plus a `"default"` key:
+  A policy is a map of key to verdict, plus a `"default"` key:
 
-      %{"default" => "auto_allow", "Bash" => "auto_deny"}
+      %{"default" => "auto_allow", "execute" => "ask"}
 
-  Tool names are matched the way the transcript labels them
-  (`ACP.Blocks.tool_name/1`): the agent's own `title`, falling back to ACP's
-  coarse `kind`. So a policy key is the string a user reads on a tool card,
-  not an internal id.
+  A request is matched most-specific-first (`verdict_for_request/2`): the tool
+  card's title, then ACP's coarse `kind`, then `"default"`.
+
+  **Reach for `kind` unless you know the runtime's titles.** claude-agent-acp,
+  which every shipped agent runs, titles a tool call with the command itself
+  — `curl -sS … https://example.com` — so a title key matches exactly one
+  invocation and nothing else. `kind` is the stable half: `execute`, `edit`,
+  `read`, `delete`, `move`, `search`, `fetch`, `think`, `other`. Measured live
+  on 2026-08-22; see `verdict_for_request/2`.
 
   ## Narrow, never widen
 
@@ -218,7 +223,7 @@ defmodule Fountain.Permissions do
   def outcome(policy, params) when is_map(params) do
     options = Map.get(params, "options") || []
 
-    case verdict_for(normalize(policy), tool_name(params)) do
+    case verdict_for_request(policy, params) do
       @auto_deny -> deny(options)
       # `ask` is not answered here — the peer holds the request open and a human
       # answers it (#940). Denying is the safe reading if a caller asks this
@@ -228,6 +233,57 @@ defmodule Fountain.Permissions do
       _ -> allow(options)
     end
   end
+
+  @doc """
+  The verdict `policy` gives one `session/request_permission`.
+
+  Tries the request's keys in order — the tool card's title first, then ACP's
+  coarse `kind` — and falls through to the policy's `"default"`.
+
+  **The `kind` fallback is what makes a per-tool policy writable.** Measured
+  against claude-agent-acp 0.66 in production on 2026-08-22: its `toolCall.title`
+  is the command itself (`curl -sS -o /dev/null -w "%{http_code}" https://…`),
+  not the tool. A title key can therefore only ever match one invocation, which
+  left `"default"` as the only usable key on the runtime every shipped agent
+  runs — a per-tool policy in name only. `kind` (`execute`, `edit`, `read`,
+  `delete`, `move`, `search`, `fetch`, `think`, `other`) is the stable half of
+  the same request, so `%{"execute" => "ask"}` means "ask before running
+  anything in the shell" and keeps working across invocations.
+
+  Title stays first: an exact-title rule is the more specific of the two, and a
+  runtime whose titles *are* tool names (`Bash`, `Edit`) keeps behaving as
+  0014 gate 3 described.
+  """
+  @spec verdict_for_request(map() | nil, map()) :: String.t()
+  def verdict_for_request(policy, params) when is_map(params) do
+    policy = normalize(policy)
+
+    params
+    |> policy_keys()
+    |> Enum.find_value(nil, fn key -> Map.get(policy, key) end)
+    |> case do
+      verdict when verdict in @verdicts -> verdict
+      # Not a verdict at all: the changesets reject these, so a value here means
+      # the row was written around them. Not trusted into an allow.
+      verdict when not is_nil(verdict) -> @auto_deny
+      nil -> verdict_for(policy, nil)
+    end
+  end
+
+  @doc """
+  The policy keys one request matches, most specific first.
+
+  The tool card's title, then ACP's `kind`. Empty when the request carries no
+  tool call at all, which falls through to the policy's default.
+  """
+  @spec policy_keys(map()) :: [String.t()]
+  def policy_keys(%{"toolCall" => call}) when is_map(call) do
+    [call["title"], call["kind"]]
+    |> Enum.filter(&(is_binary(&1) and &1 != ""))
+    |> Enum.uniq()
+  end
+
+  def policy_keys(_params), do: []
 
   @doc """
   The tool a permission request is about, as the transcript labels it.

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -461,7 +461,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # trail a transcript.
   defp handle_message({:request, id, "session/request_permission", params}, state) do
     tool = Fountain.Permissions.tool_name(params)
-    verdict = Fountain.Permissions.verdict_for(state.permission_policy, tool)
+    verdict = Fountain.Permissions.verdict_for_request(state.permission_policy, params)
 
     case verdict do
       "ask" ->
@@ -500,14 +500,37 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # client pairs the two on `request_id`.
   defp hold_permission(state, id, tool, params) do
     options = Enum.filter(Map.get(params, "options") || [], &is_map/1)
+    request_id = mint_request_id(id)
 
-    state = persist(state, "acp", Protocol.request(id, "session/request_permission", params))
-    report(state, {:permission_ask, to_string(id), tool, options})
+    state =
+      persist(state, "acp", Protocol.request(request_id, "session/request_permission", params))
+
+    report(state, {:permission_ask, request_id, tool, options})
 
     %{
       state
-      | pending_permission: %{id: id, request_id: to_string(id), options: options, tool: tool}
+      | pending_permission: %{id: id, request_id: request_id, options: options, tool: tool}
     }
+  end
+
+  # The id a client answers with, which is **not** the adapter's own JSON-RPC
+  # id. Measured against claude-agent-acp 0.66 in production: it numbers its
+  # requests from 0 *per turn*, so every conversation's second permission
+  # request arrives as id 0 again. Two live consequences, both from one cause:
+  #
+  # - a client pairing the resolution to the request on `request_id` (which is
+  #   the contract) marks the new card resolved the moment it renders, because
+  #   turn 2's `request`/`done` already named that id;
+  # - answering from a stale card would land on whatever request is open *now*,
+  #   approving a tool the person never saw.
+  #
+  # So Fountain mints the public id: the adapter's own id, a dot, and eight
+  # random bytes. The adapter id stays in front because a transcript is read
+  # beside adapter logs, and `restore_pending/1` reads it back to answer with
+  # the id the agent is actually blocked on. A stale card now misses and gets
+  # the same 409 as any other lost race.
+  defp mint_request_id(id) do
+    "#{id}.#{Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)}"
   end
 
   # We declared no filesystem or terminal capabilities, so nothing should ask.
@@ -875,23 +898,50 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # A held request handed back on reattach (#940). Stored as a string-keyed map
   # on the turn row; the peer works in atoms. The JSON-RPC id has to come back
   # as the integer the agent sent, because that is what it is blocked on.
+  # The adapter's own JSON-RPC id, back out of the minted `request_id` (see
+  # `mint_request_id/1`): everything before the last dot. A response has to
+  # echo the id's JSON type, so a numeric id is restored as an integer and
+  # anything else as the string it was — an adapter that numbers its requests
+  # and one that names them are both answerable after a deploy.
   defp restore_pending(%{"request_id" => request_id, "options" => options} = pending)
        when is_binary(request_id) do
-    case Integer.parse(request_id) do
-      {id, ""} ->
+    case acp_id(request_id) do
+      nil ->
+        nil
+
+      id ->
         %{
           id: id,
           request_id: request_id,
           options: List.wrap(options),
           tool: Map.get(pending, "tool")
         }
-
-      _ ->
-        nil
     end
   end
 
   defp restore_pending(_), do: nil
+
+  defp acp_id(request_id) do
+    case String.split(request_id, ".") do
+      [_only] ->
+        # A request_id written before #955 minted them: the whole string is the
+        # adapter's id. Restoring it keeps a request raised across that deploy
+        # answerable instead of orphaning it.
+        parse_acp_id(request_id)
+
+      parts ->
+        parts |> Enum.drop(-1) |> Enum.join(".") |> parse_acp_id()
+    end
+  end
+
+  defp parse_acp_id(""), do: nil
+
+  defp parse_acp_id(raw) do
+    case Integer.parse(raw) do
+      {id, ""} -> id
+      _ -> raw
+    end
+  end
 
   defp noreply(state), do: {:noreply, state}
 end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -280,10 +280,13 @@ defmodule FountainWeb.Schemas do
             enum: Fountain.Permissions.buildable_verdicts()
           },
           description:
-            "Per-launch permission override (#939). Merged with the agent's own policy, " <>
-              "taking the stricter of the two per tool. It may only narrow: a policy that " <>
-              "would loosen any tool is refused with 422 permission_policy_widens rather " <>
-              "than silently clamped."
+            "Per-launch permission override (#939). Keys are matched against the tool " <>
+              "card's title first and then ACP's kind (execute, edit, read, fetch, …); " <>
+              "\"default\" covers the rest. Prefer a kind: claude titles a tool call with " <>
+              "the command it is about to run, so a title matches one invocation only. " <>
+              "Merged with the agent's own policy, taking the stricter of the two. It may " <>
+              "only narrow: a policy that would loosen any tool is refused with 422 " <>
+              "permission_policy_widens rather than silently clamped."
         },
         prompt: %Schema{type: :string, description: "Optional first turn prompt."},
         title: %Schema{
@@ -478,11 +481,13 @@ defmodule FountainWeb.Schemas do
             enum: Fountain.Permissions.buildable_verdicts()
           },
           description:
-            "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
-              "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
-              "default, and an unset default is auto_allow \u2014 today's behaviour. " <>
-              "\"ask\" holds the tool until a human answers it on the conversation " <>
-              "stream, and denies if nobody does before the timeout."
+            "Per-tool permission policy: a map of key to verdict, plus an optional " <>
+              "\"default\" key. A key is matched against the tool card's title first and " <>
+              "then ACP's kind (execute, edit, read, fetch, \u2026); prefer a kind, because " <>
+              "claude titles a tool call with the command it is about to run. Unset keys " <>
+              "fall back to the default, and an unset default is auto_allow \u2014 today's " <>
+              "behaviour. \"ask\" holds the tool until a human answers it on the " <>
+              "conversation stream, and denies if nobody does before the timeout."
         },
         skills: %Schema{
           type: :array,
@@ -729,11 +734,14 @@ defmodule FountainWeb.Schemas do
             enum: Fountain.Permissions.buildable_verdicts()
           },
           description:
-            "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
-              "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
-              "default, and an unset default is auto_allow. \"ask\" holds the tool until a " <>
-              "human answers it on the conversation stream, and denies if nobody does " <>
-              "before the timeout. A conversation may narrow this at launch, never widen it."
+            "Per-tool permission policy: a map of key to verdict, plus an optional " <>
+              "\"default\" key. A key is matched against the tool card's title first and " <>
+              "then ACP's kind (execute, edit, read, fetch, \u2026); prefer a kind, because " <>
+              "claude titles a tool call with the command it is about to run. Unset keys " <>
+              "fall back to the default, and an unset default is auto_allow. \"ask\" holds " <>
+              "the tool until a human answers it on the conversation stream, and denies if " <>
+              "nobody does before the timeout. A conversation may narrow this at launch, " <>
+              "never widen it."
         },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         skills: %Schema{
@@ -832,11 +840,14 @@ defmodule FountainWeb.Schemas do
             enum: Fountain.Permissions.buildable_verdicts()
           },
           description:
-            "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
-              "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
-              "default, and an unset default is auto_allow. \"ask\" holds the tool until a " <>
-              "human answers it on the conversation stream, and denies if nobody does " <>
-              "before the timeout. A conversation may narrow this at launch, never widen it."
+            "Per-tool permission policy: a map of key to verdict, plus an optional " <>
+              "\"default\" key. A key is matched against the tool card's title first and " <>
+              "then ACP's kind (execute, edit, read, fetch, \u2026); prefer a kind, because " <>
+              "claude titles a tool call with the command it is about to run. Unset keys " <>
+              "fall back to the default, and an unset default is auto_allow. \"ask\" holds " <>
+              "the tool until a human answers it on the conversation stream, and denies if " <>
+              "nobody does before the timeout. A conversation may narrow this at launch, " <>
+              "never widen it."
         },
         allowed_environment_ids: %Schema{
           type: :array,

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -893,6 +893,11 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
       send(pid, {:stdout, %{ref: ref}, line})
       settle(pid)
+
+      # The id a client answers with is minted by the peer, not the adapter's
+      # own — claude and codex both number theirs from 0 per turn (#957). Tests
+      # read it back rather than assuming it.
+      :sys.get_state(pid).current_turn.pending_permission["request_id"]
     end
 
     test "a held request is persisted on the turn and announced on the stream" do
@@ -901,19 +906,20 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
 
-      raise_permission(pid, ref, 301)
+      request_id = raise_permission(pid, ref, 301)
 
       # Persisted first, so a deploy landing a millisecond later can still
       # answer it.
       turn = :sys.get_state(pid).current_turn
-      assert turn.pending_permission["request_id"] == "301"
+      assert turn.pending_permission["request_id"] == request_id
+      assert request_id =~ ~r/^301\./
       assert turn.pending_permission["tool"] == "Bash"
 
       # And announced, with the agent's own options.
       events = Conversations._unsafe_list_log_events(conv.id)
       stage = Enum.find(events, &(&1.kind == "stage" and &1.stage == "request"))
       assert stage.state == "started"
-      assert Jason.decode!(stage.data)["request_id"] == "301"
+      assert Jason.decode!(stage.data)["request_id"] == request_id
     end
 
     test "the request renders as a permission_request block in the transcript" do
@@ -922,7 +928,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
 
-      raise_permission(pid, ref, 302)
+      request_id = raise_permission(pid, ref, 302)
 
       blocks =
         conv.id
@@ -931,7 +937,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
         |> Enum.flat_map(&Fountain.Conversations.Blocks.for_event(&1, "claude"))
 
       assert block = Enum.find(blocks, &(&1.kind == :permission_request))
-      assert block.request_id == "302"
+      assert block.request_id == request_id
       assert block.name == "Bash"
       assert Enum.map(block.options, & &1["optionId"]) == ["yes", "no"]
     end
@@ -941,9 +947,9 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 303)
+      request_id = raise_permission(pid, ref, 303)
 
-      assert :ok = GenServer.call(pid, {:answer_permission, "303", "yes"})
+      assert :ok = GenServer.call(pid, {:answer_permission, request_id, "yes"})
 
       assert %{"id" => 303, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
 
@@ -967,9 +973,9 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 304)
+      request_id = raise_permission(pid, ref, 304)
 
-      send(pid, {:permission_timeout, "304"})
+      send(pid, {:permission_timeout, request_id})
       settle(pid)
 
       states =
@@ -987,9 +993,9 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 305)
+      request_id = raise_permission(pid, ref, 305)
 
-      send(pid, {:permission_timeout, "305"})
+      send(pid, {:permission_timeout, request_id})
       settle(pid)
 
       # Deny is the only safe default, and it picks the agent's own rejection.
@@ -1006,12 +1012,12 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 306)
+      request_id = raise_permission(pid, ref, 306)
 
       assert {:error, :unknown_option} =
-               GenServer.call(pid, {:answer_permission, "306", "made-up"})
+               GenServer.call(pid, {:answer_permission, request_id, "made-up"})
 
-      assert :sys.get_state(pid).current_turn.pending_permission["request_id"] == "306"
+      assert :sys.get_state(pid).current_turn.pending_permission["request_id"] == request_id
     end
 
     test "a sprite may not answer its own prompt" do
@@ -1021,10 +1027,10 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 307)
+      request_id = raise_permission(pid, ref, 307)
 
       assert {:error, :sprite_may_not_answer} =
-               Conversations.answer_permission_request(conv.id, user.id, "307", "yes",
+               Conversations.answer_permission_request(conv.id, user.id, request_id, "yes",
                  actor: "sprite"
                )
     end
@@ -1035,10 +1041,10 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 308)
+      request_id = raise_permission(pid, ref, 308)
 
       assert {:error, :not_found} =
-               Conversations.answer_permission_request(conv.id, other.id, "308", "yes")
+               Conversations.answer_permission_request(conv.id, other.id, request_id, "yes")
     end
 
     test "a request still held when the turn ends is resolved, not left open" do
@@ -1047,7 +1053,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       {pid, ref} = start_acp_turn(conv)
       prompt_id = drive_to_prompt(pid, ref)
 
-      raise_permission(pid, ref, 309)
+      _request_id = raise_permission(pid, ref, 309)
       reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
 
       done =

--- a/apps/fountain/test/fountain/permissions_test.exs
+++ b/apps/fountain/test/fountain/permissions_test.exs
@@ -170,6 +170,58 @@ defmodule Fountain.PermissionsTest do
     end
   end
 
+  describe "verdict_for_request/2 matches title, then kind" do
+    defp call(options, call), do: %{"options" => options, "toolCall" => call}
+
+    test "the kind matches when the title does not" do
+      # What makes a per-tool policy writable at all against claude-agent-acp:
+      # measured live on 2026-08-22, its title is the command it is about to
+      # run, so only `kind` is the same string twice.
+      params =
+        call([allow_always(), reject_once()], %{"title" => "curl https://x", "kind" => "execute"})
+
+      assert Permissions.verdict_for_request(%{"execute" => "auto_deny"}, params) == "auto_deny"
+
+      assert %{outcome: "selected", optionId: "ro"} =
+               Permissions.outcome(%{"execute" => "auto_deny"}, params)
+    end
+
+    test "an exact title still wins over the kind" do
+      params = call([], %{"title" => "Bash", "kind" => "execute"})
+
+      assert Permissions.verdict_for_request(
+               %{"Bash" => "auto_allow", "execute" => "auto_deny"},
+               params
+             ) == "auto_allow"
+    end
+
+    test "neither key named falls through to the policy's default" do
+      params = call([], %{"title" => "Bash", "kind" => "execute"})
+
+      assert Permissions.verdict_for_request(%{"default" => "ask"}, params) == "ask"
+      assert Permissions.verdict_for_request(%{}, params) == "auto_allow"
+      assert Permissions.verdict_for_request(nil, params) == "auto_allow"
+    end
+
+    test "a value that is not a verdict is not trusted into an allow" do
+      # The changesets reject these, so reaching here means the row was written
+      # around them.
+      params = call([], %{"title" => "Bash", "kind" => "execute"})
+
+      assert Permissions.verdict_for_request(%{"Bash" => "yolo"}, params) == "auto_deny"
+    end
+
+    test "policy_keys/1 is most specific first, and empty without a tool call" do
+      assert Permissions.policy_keys(%{"toolCall" => %{"title" => "Bash", "kind" => "execute"}}) ==
+               ["Bash", "execute"]
+
+      assert Permissions.policy_keys(%{"toolCall" => %{"title" => "read", "kind" => "read"}}) ==
+               ["read"]
+
+      assert Permissions.policy_keys(%{"options" => []}) == []
+    end
+  end
+
   describe "ask" do
     test "is buildable since #940 gave it somewhere to ask" do
       assert "ask" in Permissions.verdicts()

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -574,20 +574,54 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       # is told so it can publish the stage event and arm a timeout.
       assert_receive {:acp, _ref, {:lines, "acp", line}}
       assert line =~ "session/request_permission"
-      assert_receive {:acp, _ref, {:permission_ask, "201", "Bash", options}}
+      assert_receive {:acp, _ref, {:permission_ask, request_id, "Bash", options}}
       assert Enum.map(options, & &1["optionId"]) == ["yes", "no"]
 
+      # The id a client answers with is minted here, not the adapter's own: it
+      # keeps the adapter id in front, then eight random bytes.
+      assert request_id =~ ~r/^201\.[0-9a-f]{16}$/
+
+      # And the block a client renders carries the same minted id, because the
+      # persisted line is the one we build.
+      assert %{"id" => ^request_id} = Jason.decode!(line)
+
       refute_receive {:wrote, _}, 50
+    end
+
+    test "two requests the adapter numbers alike get different ids", ctx do
+      # Measured against claude-agent-acp 0.66 in production (2026-08-22): it
+      # numbers `session/request_permission` from 0 *per turn*, so a
+      # conversation's second request arrives as id 0 again. Left as the public
+      # id, that pairs turn 2's resolution to turn 3's card — the card renders
+      # already-resolved — and lets a stale card answer a tool nobody saw.
+      pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
+      _init = next_write()
+
+      Peer.stdout(pid, permission_line(0, "Bash"))
+      assert_receive {:acp, _ref, {:permission_ask, first, _, _}}
+      assert :ok = Peer.answer_permission(pid, first, "yes")
+      _answer = next_write()
+
+      Peer.stdout(pid, permission_line(0, "Bash"))
+      assert_receive {:acp, _ref, {:permission_ask, second, _, _}}
+
+      refute first == second
+
+      # The stale card misses, so it loses the race rather than answering the
+      # request that is open now.
+      assert {:error, :no_pending_permission} = Peer.answer_permission(pid, first, "yes")
+      assert :ok = Peer.answer_permission(pid, second, "yes")
+      assert %{"id" => 0, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
     end
 
     test "an answer selects the option, and only an offered one", ctx do
       pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
       _init = next_write()
       Peer.stdout(pid, permission_line(202, "Bash"))
-      assert_receive {:acp, _ref, {:permission_ask, "202", _, _}}
+      assert_receive {:acp, _ref, {:permission_ask, request_id, _, _}}
 
-      assert {:error, :unknown_option} = Peer.answer_permission(pid, "202", "made-up")
-      assert :ok = Peer.answer_permission(pid, "202", "yes")
+      assert {:error, :unknown_option} = Peer.answer_permission(pid, request_id, "made-up")
+      assert :ok = Peer.answer_permission(pid, request_id, "yes")
 
       assert %{"id" => 202, "result" => %{"outcome" => outcome}} = next_write()
       assert outcome["outcome"] == "selected"
@@ -600,12 +634,12 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
       _init = next_write()
       Peer.stdout(pid, permission_line(203, "Bash"))
-      assert_receive {:acp, _ref, {:permission_ask, "203", _, _}}
+      assert_receive {:acp, _ref, {:permission_ask, request_id, _, _}}
 
-      assert :ok = Peer.answer_permission(pid, "203", "yes")
+      assert :ok = Peer.answer_permission(pid, request_id, "yes")
       _answer = next_write()
 
-      assert {:error, :no_pending_permission} = Peer.answer_permission(pid, "203", "no")
+      assert {:error, :no_pending_permission} = Peer.answer_permission(pid, request_id, "no")
       refute_receive {:wrote, _}, 50
     end
 
@@ -613,9 +647,9 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
       _init = next_write()
       Peer.stdout(pid, permission_line(204, "Bash"))
-      assert_receive {:acp, _ref, {:permission_ask, "204", _, _}}
+      assert_receive {:acp, _ref, {:permission_ask, request_id, _, _}}
 
-      Peer.deny_permission(pid, "204")
+      Peer.deny_permission(pid, request_id)
 
       assert %{"id" => 204, "result" => %{"outcome" => outcome}} = next_write()
       assert outcome["optionId"] == "no"
@@ -629,7 +663,7 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
         start_peer(ctx,
           permission_policy: %{"Bash" => "ask"},
           pending_permission: %{
-            "request_id" => "205",
+            "request_id" => "205.f00dcafef00dcafe",
             "tool" => "Bash",
             "options" => [%{"optionId" => "yes", "kind" => "allow_once"}]
           }
@@ -637,8 +671,49 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
 
       _init = next_write()
 
-      assert :ok = Peer.answer_permission(pid, "205", "yes")
+      # Answered with the minted id the client is holding; the adapter is
+      # answered with the id it is actually blocked on, read back out of it.
+      assert :ok = Peer.answer_permission(pid, "205.f00dcafef00dcafe", "yes")
       assert %{"id" => 205, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
+    end
+
+    test "a request written down before ids were minted is still answerable", ctx do
+      # Rows written before #955 hold the bare adapter id. A deploy landing on
+      # top of one must not orphan the request it describes.
+      pid =
+        start_peer(ctx,
+          permission_policy: %{"Bash" => "ask"},
+          pending_permission: %{
+            "request_id" => "206",
+            "tool" => "Bash",
+            "options" => [%{"optionId" => "yes", "kind" => "allow_once"}]
+          }
+        )
+
+      _init = next_write()
+
+      assert :ok = Peer.answer_permission(pid, "206", "yes")
+      assert %{"id" => 206, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
+    end
+
+    test "an adapter that names its requests instead of numbering them is answerable", ctx do
+      # `Protocol.response/2` echoes the id's JSON type, so a string id has to
+      # come back a string. Before ids were minted this shape restored as nil
+      # and the request was orphaned on reattach.
+      pid =
+        start_peer(ctx,
+          permission_policy: %{"Bash" => "ask"},
+          pending_permission: %{
+            "request_id" => "req-7.f00dcafef00dcafe",
+            "tool" => "Bash",
+            "options" => [%{"optionId" => "yes", "kind" => "allow_once"}]
+          }
+        )
+
+      _init = next_write()
+
+      assert :ok = Peer.answer_permission(pid, "req-7.f00dcafef00dcafe", "yes")
+      assert %{"id" => "req-7", "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
     end
 
     test "an fs/* request is refused, not ignored", ctx do

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2009,7 +2009,7 @@ export interface components {
             fresh?: boolean | null;
             /** @description Optional images to attach to the initial prompt. */
             images?: components["schemas"]["ImageInput"][] | null;
-            /** @description Per-launch permission override (#939). Merged with the agent's own policy, taking the stricter of the two per tool. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped. */
+            /** @description Per-launch permission override (#939). Keys are matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); "default" covers the rest. Prefer a kind: claude titles a tool call with the command it is about to run, so a title matches one invocation only. Merged with the agent's own policy, taking the stricter of the two. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
@@ -2644,7 +2644,7 @@ export interface components {
             /** @description Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The provider must match the runtime — anthropic for claude, openai for codex, google for gemini; opencode accepts any of the three. Other providers are rejected: Fountain has no credentials to export for them. The model id is not checked against a list, so a newly released model works without a Fountain release. */
             model: string;
             name: string;
-            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. */
+            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
@@ -3081,7 +3081,7 @@ export interface components {
             };
             model?: string;
             name?: string;
-            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
+            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
@@ -3327,7 +3327,7 @@ export interface components {
             };
             model: string;
             name: string;
-            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
+            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;


### PR DESCRIPTION
Closes #957. Closes #958.

Both were found the same way: by driving #939 and #940 against live claude,
codex and opencode agents in production on 2026-08-22, the day after the ask
path shipped. Neither is visible from the tests, because both are facts about
what the adapters actually send.

## The id repeats, so the second card is born resolved

claude-agent-acp numbers `session/request_permission` **from 0 per turn**;
codex-acp does the same. Fountain published that number as the `request_id`
clients answer with, so a conversation's second request arrives carrying an id
that has already been resolved. Measured on one conversation:

| turn | request | `request_id` |
|---|---|---|
| 2 | `curl … https://example.com` | `0` |
| 3 | `curl … https://example.org` | `0` |
| 4 | `curl … https://example.net` | `0` |

#940's contract is that clients pair the request block to the `request` stage
event on `request_id` — the same pass that pairs `tool_result` to `tool_use`.
A repeated id breaks that in both directions:

- **The card is dead on arrival.** jhgaylor/fountain-team#37 keeps resolutions
  by `request_id`; turn 2's `{"request_id":"0","outcome":"answered"}` is still
  there when turn 3's card renders, so the new card shows as answered and its
  buttons never arm. The ask then waits out the five-minute timeout and denies.
- **A stale card answers the wrong tool.** `POST /requests/0` matched on
  `request_id` alone, so Allow on a scrolled-back card approved whatever the
  agent is blocked on *now*.

Fixed by minting the public id in `hold_permission/4`: the adapter's own id, a
dot, eight random bytes. `restore_pending/1` reads the adapter's id back out to
answer with. No wire-schema change — `ACP.Blocks.permission_blocks/2` and the
team app's `permissionOf` both read `String(msg.id)` from the line Fountain
itself writes, so the minted id reaches them unchanged and a stale card now
misses, getting the same 409 as any other lost race.

While in there, `restore_pending/1` stopped requiring an integer, so an adapter
that names its requests instead of numbering them is answerable after a deploy
rather than silently orphaned.

## The key nobody could write

A policy key was matched against one derived name — the `toolCall` title,
falling back to ACP's kind. Measured, that title is not a tool name:

```json
"toolCall": {"kind": "execute", "title": "curl -sS -o /dev/null -w \"%{http_code}\" https://example.com"}
```

codex is the same problem from the other side: no title at all, only
`"kind": "execute"`.

So `%{"Bash" => "ask"}` — the example in the moduledoc, in ADR 0014 and in the
OpenAPI description — matched nothing on either shippable runtime, and
`"default"` was the only usable key. The per-tool policy #939 chose *over* a
single per-launch value, the thing that makes jhgaylor/fountain-team#3's
"always allow `<tool>`" buildable, was per-tool in name only.

`verdict_for_request/2` now matches most-specific-first over the request's own
keys: title, then kind, then `"default"`. `kind` is ACP's closed vocabulary
(`execute`, `edit`, `read`, `delete`, `move`, `search`, `fetch`, `think`,
`other`), so `%{"execute" => "ask"}` means "ask before running anything in the
shell" and keeps working across invocations and runtimes. Title stays ahead of
it — an exact-title rule is the more specific of the two, and a runtime whose
titles *are* tool names behaves exactly as gate 3 described.

Narrow-never-widen is untouched: `effective/2` and `check_narrows/2` compare
maps key by key and do not care what a key names.

## Verification

- New tests: two requests the adapter numbers alike get different ids and the
  stale one loses; the minted id reaches the persisted block; reattach across
  both id shapes (minted, and pre-mint rows written by #950) and a string id;
  kind-matching, title-beats-kind, fall-through and the not-a-verdict case.
- The live loop this came from, re-run end to end: ask → card → answer → the
  tool proceeds; ask → deny → `User refused permission to run tool` and the
  turn ends normally; ask → nobody answers → denied at exactly five minutes.

Part of #643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
