### PR TITLE
fix(acp): opencode never asks, so refuse its policy instead of storing one

### DIFF
--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -1,0 +1,192 @@
+# Rebuilds the sandbox base images the non-default providers boot from: the
+# E2B template and the Daytona snapshot that prod pins with E2B_TEMPLATE and
+# DAYTONA_SNAPSHOT.
+#
+# Until this existed both were hand-built artifacts from 2026-08-14, and
+# nothing rebuilt them when images/ changed or refreshed the agent CLIs baked
+# into them. A stale image does not announce itself: every conversation pinned
+# to that provider quietly runs a months-old claude, codex, gemini or opencode.
+#
+# Three triggers, one pipeline:
+#
+#   * a push to main touching images/ or these scripts — the recipe changed;
+#   * a weekly cron — the recipe did not change but the CLIs inside it did;
+#   * workflow_dispatch — a rebuild by hand, one provider at a time.
+#
+# Pull requests run the `dockerfile` job alone. It needs no provider account,
+# and it is the gate that matters for the Daytona job below: a Daytona snapshot
+# cannot be swapped in behind its name, so refreshing it means deleting the
+# name prod is pinned to and building it again. Proving the Dockerfile still
+# builds, on this runner, before touching the provider keeps that window from
+# being where an upstream apt or npm break is discovered.
+name: Sandbox images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'images/**'
+      - 'scripts/sandbox-image/**'
+      - '.github/workflows/sandbox-images.yml'
+  pull_request:
+    paths:
+      - 'images/**'
+      - 'scripts/sandbox-image/**'
+      - '.github/workflows/sandbox-images.yml'
+  # Monday, early. The CLIs are what go stale; nothing else here changes on
+  # its own.
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      providers:
+        description: Which provider images to rebuild
+        type: choice
+        default: both
+        options: [both, e2b, daytona, none]
+      skip_smoke:
+        description: Build without creating a sandbox to verify it
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Never cancel a run in flight. The Daytona job deletes the snapshot prod is
+# pinned to before it creates the new one, and a cancellation between those two
+# calls leaves the organization with no `fountain` snapshot at all.
+concurrency:
+  group: sandbox-images
+  cancel-in-progress: false
+
+env:
+  E2B_TEMPLATE: fountain
+  DAYTONA_SNAPSHOT: fountain
+
+jobs:
+  dockerfile:
+    name: Build ${{ matrix.provider }} locally and smoke it
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - provider: e2b
+            context: images/e2b
+            dockerfile: e2b.Dockerfile
+          - provider: daytona
+            context: images/daytona
+            dockerfile: Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          # Nothing here runs an authenticated git operation, and the image
+          # build should not inherit a push-capable credential.
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      # amd64 only, and deliberately: Daytona requires amd64, E2B runs amd64,
+      # and this build exists to prove the recipe, not to publish anything.
+      - name: Build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.context }}/${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: fountain-sandbox-${{ matrix.provider }}:ci
+
+      # The same checks the live smokes run inside a real sandbox. Here they
+      # answer a narrower question — is the image itself the shape provisioning
+      # assumes — before either provider account is touched.
+      - name: Smoke the image
+        run: |
+          docker run --rm \
+            -e SMOKE_EXPECT_USER=sprite \
+            -v "${PWD}/scripts/sandbox-image/smoke.sh:/tmp/smoke.sh:ro" \
+            "fountain-sandbox-${{ matrix.provider }}:ci" \
+            bash /tmp/smoke.sh
+
+  e2b:
+    name: Rebuild the E2B template
+    needs: dockerfile
+    # Pull requests stop at the dockerfile gate: a fork PR has no secrets, and
+    # a rebuild is a change to prod's artifact, not a check on a proposal.
+    if: >-
+      github.event_name != 'pull_request' &&
+      contains(fromJSON('["both", "e2b"]'), github.event.inputs.providers || 'both')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          persist-credentials: false
+
+      # A missing secret fails the job. Skipping instead would reproduce the
+      # exact failure this workflow exists to end: a green run that rebuilt
+      # nothing, and an image ageing in place.
+      - name: Require the E2B key
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: |
+          if [ -z "${E2B_API_KEY}" ]; then
+            echo "::error::E2B_API_KEY is not configured. It must be the same" \
+                 "account prod uses — a template built under another org is" \
+                 "invisible to prod's key."
+            exit 1
+          fi
+
+      - name: Build and smoke the template
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          E2B_TEMPLATE: ${{ env.E2B_TEMPLATE }}
+          SKIP_SMOKE: ${{ github.event.inputs.skip_smoke == 'true' && '1' || '' }}
+        run: scripts/sandbox-image/build-e2b.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "E2B template \`${E2B_TEMPLATE}\` — ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+
+  daytona:
+    name: Rebuild the Daytona snapshot
+    needs: dockerfile
+    if: >-
+      github.event_name != 'pull_request' &&
+      contains(fromJSON('["both", "daytona"]'), github.event.inputs.providers || 'both')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          persist-credentials: false
+
+      - name: Require the Daytona key
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+        run: |
+          if [ -z "${DAYTONA_API_KEY}" ]; then
+            echo "::error::DAYTONA_API_KEY is not configured. It must be the" \
+                 "same account prod uses — a snapshot built under another org" \
+                 "is invisible to prod's key."
+            exit 1
+          fi
+
+      - name: Build and smoke the snapshot
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_SNAPSHOT: ${{ env.DAYTONA_SNAPSHOT }}
+          SKIP_SMOKE: ${{ github.event.inputs.skip_smoke == 'true' && '1' || '' }}
+        run: scripts/sandbox-image/build-daytona.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "Daytona snapshot \`${DAYTONA_SNAPSHOT}\` — ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,24 @@ upgrade, is in
   change in Elixir cannot leave the SDK describing an API that no longer
   exists. Generating it immediately found one: see below.
 
+- **The E2B template and the Daytona snapshot are rebuilt by CI** (#692). Both
+  were hand-built artifacts from one afternoon in August, and nothing rebuilt
+  them when `images/` changed or refreshed the four agent CLIs baked into
+  them. A stale sandbox image does not announce itself: every conversation
+  pinned to that provider quietly runs a months-old `claude`, `codex`,
+  `gemini` or `opencode`. The new `Sandbox images` workflow rebuilds both on a
+  change to `images/`, once a week for the CLI versions, and on dispatch.
+
+  Each rebuild is smoke-tested in a real sandbox against
+  `scripts/sandbox-image/smoke.sh`, which is one file both providers ship
+  in-guest so they are held to the same contract. It does the global npm
+  install rather than reading the prefix setting, because #691's failure mode
+  was exit 243 with no output and the setting looked right. Pull requests run
+  the same Dockerfiles through `docker build` and the same smoke, with no
+  provider account involved — which is also what stands between an upstream
+  apt or npm break and the minutes when the Daytona snapshot name, which
+  cannot be rebuilt in place, does not exist.
+
 ### Fixed
 
 - **Every line of every code block in `/docs` and `/help` had a light box

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,28 @@ upgrade, is in
   `Host` header and TLS SNI. Redirects are never followed. See
   [Webhooks](https://binarybourbon.github.io/fountain/reference/webhooks/).
 
+- **Sandbox spend attribution: which tenant, on which provider, ran how long.**
+  Fountain pays Sprites, E2B and Daytona by the second and had no way to say
+  whose seconds those were. `Fountain.Billing.SandboxUsage` now computes active
+  sandbox time per `{user, provider}` from the sandbox rows themselves, clipped
+  to the period asked about, with parked time subtracted. A **Sandbox spend by
+  provider** panel on `/admin` reports hours, sandboxes and tenants per
+  provider, names the accounts behind the total, and marks self-hosted runner
+  hours as the tenant's own hardware rather than our bill. Every total also
+  splits into **busy and idle** — busy being the union of the sandbox's turn
+  intervals, so two conversations prompting one sandbox at once count once —
+  because a sandbox nobody is prompting is charged at full rate and is the
+  part of the bill a shorter idle timeout (decisions/0017) actually removes.
+  An hours figure that cannot separate work from waiting says nothing about
+  whether the bill is avoidable. Each account sees
+  its own split on `/account/billing` and in `usage.sandbox_minutes_by_provider`
+  on `GET /api/account/billing`, and Prometheus gained
+  `fountain_sandboxes_by_provider_count` for the live view. Deliberately no
+  money anywhere: prices are per-provider and per-machine-size, and a made-up
+  rate would look authoritative. Documented in
+  `docs/guides/operate/sandbox-spend.md`. Closes the metering-correctness half
+  of #798.
+
 - **What we need from a sandbox platform** (`docs/integrations/platform-requirements.md`):
   the ten things Fountain had to build itself because no backend promised them,
   each with the workaround it costs us and an acceptance test a platform team can
@@ -97,6 +119,23 @@ upgrade, is in
   cannot be rebuilt in place, does not exist.
 
 ### Fixed
+
+- **A sandbox that failed never recorded when it stopped.** Of the dozen
+  writers of a terminal sandbox status, the ones that terminated passed a
+  `terminated_at` and the ones that failed never did, so a failed sandbox
+  carried a null end for the rest of its life. `Conversations.update_sandbox/2`
+  now stamps the column at the same choke point that meters the transition, and
+  a migration repairs the backlog from `updated_at`. Without it, spend
+  attribution reads every historical failure as a sandbox that is still
+  running.
+
+- **Sandbox minutes only appeared when a sandbox died, and then all at once.**
+  The whole lifetime landed in whichever period the teardown happened to fall
+  in, so a long-lived agent reported zero for months and then a spike, a
+  sandbox spanning a month boundary billed entirely to the later month, and one
+  still running reported nothing at all. `usage_summary/3` and
+  `usage_summaries/2` now report the time that actually ran inside the period
+  asked about. `/account/billing` and the admin usage column change with them.
 
 - **Every line of every code block in `/docs` and `/help` had a light box
   painted behind it.** Tailwind Typography's `code` variant matches the

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -163,9 +163,30 @@ defmodule Fountain.Agents.Agent do
           [permission_policy: "must be a map of tool name to verdict"]
 
         true ->
-          Enum.flat_map(policy, fn {tool, verdict} -> policy_errors(tool, verdict) end)
+          Enum.flat_map(policy, fn {tool, verdict} -> policy_errors(tool, verdict) end) ++
+            runtime_errors(changeset, policy)
       end
     end)
+  end
+
+  # A policy the runtime will never consult is refused rather than stored. The
+  # verdicts are carried by `session/request_permission`, and opencode does not
+  # send it — measured live, see `Fountain.Runtimes.ACP.asks_permission?/1`. An
+  # accepted-but-inert `auto_deny` is the worst of the three outcomes: it reads
+  # like protection on every screen that shows it.
+  defp runtime_errors(changeset, policy) do
+    runtime = Ecto.Changeset.get_field(changeset, :runtime)
+
+    if not Fountain.Permissions.needs_enforcement?(policy) or
+         Fountain.Runtimes.ACP.asks_permission?(runtime) do
+      []
+    else
+      [
+        permission_policy:
+          "the #{runtime} runtime never asks before it runs a tool, so a policy " <>
+            "stricter than auto_allow cannot be enforced on it"
+      ]
+    end
   end
 
   defp policy_errors(tool, verdict) do

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1796,12 +1796,24 @@ defmodule Fountain.Conversations do
 
   defp resolve_permission_policy(policy, agent) when is_map(policy) do
     with :ok <- validate_policy_shape(policy),
+         :ok <- check_runtime_asks(policy, agent),
          :ok <- Fountain.Permissions.check_narrows(agent.permission_policy, policy) do
       {:ok, policy}
     end
   end
 
   defp resolve_permission_policy(_policy, _agent), do: {:error, :permission_policy_invalid}
+
+  # A launch cannot be protected by a policy the runtime never consults. Refused
+  # rather than accepted-and-ignored — see `ACP.asks_permission?/1`, measured.
+  defp check_runtime_asks(policy, agent) do
+    if not Fountain.Permissions.needs_enforcement?(policy) or
+         Fountain.Runtimes.ACP.asks_permission?(agent.runtime) do
+      :ok
+    else
+      {:error, {:permission_policy_unenforceable, agent.runtime}}
+    end
+  end
 
   defp validate_policy_shape(policy) do
     Enum.find_value(policy, :ok, fn {tool, verdict} ->

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -202,13 +202,39 @@ defmodule Fountain.Conversations do
   def update_sandbox(%Sandbox{} = sandbox, attrs) do
     was = sandbox.status
 
-    with {:ok, updated} <- sandbox |> Sandbox.changeset(attrs) |> Repo.update() do
+    changeset = sandbox |> Sandbox.changeset(attrs) |> stamp_terminated_at()
+
+    with {:ok, updated} <- Repo.update(changeset) do
       record_sandbox_usage(was, updated)
       {:ok, updated}
     end
   end
 
   @billable_terminal ~w(terminated failed)
+
+  # `terminated_at` is when a sandbox stopped costing money, so spend
+  # attribution reads it as the end of the billed interval
+  # (`Fountain.Billing.SandboxUsage`). Stamping it here rather than at each
+  # call site is the same choke-point argument as the metering below: of the
+  # dozen writers of a terminal status, the ones that terminate passed a
+  # timestamp and the ones that fail never did, which left every failed
+  # sandbox looking like it was still running years later.
+  #
+  # Only fills a gap — a caller that passes its own `terminated_at` keeps it.
+  defp stamp_terminated_at(changeset) do
+    status = Ecto.Changeset.get_field(changeset, :status)
+
+    if status in @billable_terminal and
+         is_nil(Ecto.Changeset.get_field(changeset, :terminated_at)) do
+      Ecto.Changeset.put_change(
+        changeset,
+        :terminated_at,
+        DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+    else
+      changeset
+    end
+  end
 
   # Transitions only: update_sandbox/2 is called repeatedly with the same status
   # in places, and double-counting a sandbox would overstate a bill. Provision

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2963,6 +2963,22 @@ defmodule Fountain.Conversations.ConversationServer do
   defp finalize_tracer(nil), do: :ok
   defp finalize_tracer(tracer), do: Fountain.Runtimes.ACP.Tracer.finalize(tracer)
 
+  # gemini erases a session in the act of loading it (#659), so its store is
+  # consolidated at the end of every turn — before the next turn's
+  # `session/load` can collide with it. Best-effort and gemini-only; delete
+  # with the workaround when gemini-cli#28775 lands.
+  defp consolidate_gemini_session(%{handle: handle} = state) when not is_nil(handle) do
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+
+    if conv.runtime == "gemini" do
+      Fountain.Runtimes.Gemini.SessionStore.consolidate(handle, conv.runtime_session_id)
+    end
+
+    :ok
+  end
+
+  defp consolidate_gemini_session(_state), do: :ok
+
   defp finish_acp_turn(state, status, span_attrs, stage_meta) do
     # Resolve a held permission request before the peer goes away (#940). The
     # agent's blocked request dies with the process either way, but a card left
@@ -2972,6 +2988,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
     if state.current_command, do: Fountain.Sandbox.close_stdin(state.current_command)
     stop_acp_peer(state)
+    consolidate_gemini_session(state)
 
     # Before the turn span ends: totals land on it, abandoned tool spans close.
     finalize_tracer(state.stream_tracer)

--- a/apps/fountain/lib/fountain/ops_gauges.ex
+++ b/apps/fountain/lib/fountain/ops_gauges.ex
@@ -40,8 +40,40 @@ defmodule Fountain.OpsGauges do
         Fountain.Conversations.Sandbox.statuses()
       )
 
+      emit_sandbox_provider_counts()
       emit_oban_depths()
     end)
+  end
+
+  # How many sandboxes are costing money on each provider right now — the live
+  # counterpart to the after-the-fact roll-up in
+  # `Fountain.Billing.SandboxUsage`, and the series to watch when a provider
+  # bill moves. Deliberately not tagged by tenant: attribution belongs in the
+  # database report, where a per-user dimension is a column rather than a new
+  # Prometheus series per account.
+  #
+  # Terminal statuses are excluded for the same reason Oban's are: those rows
+  # are unbounded history, not a signal.
+  @live_statuses ~w(pending starting ready suspended)
+
+  defp emit_sandbox_provider_counts do
+    counts =
+      Repo.all(
+        from(s in Fountain.Conversations.Sandbox,
+          where: s.status in @live_statuses,
+          group_by: [s.provider, s.status],
+          select: {{s.provider, s.status}, count(s.id)}
+        )
+      )
+      |> Map.new()
+
+    for provider <- Fountain.Sandbox.known_providers(), status <- @live_statuses do
+      :telemetry.execute(
+        [:fountain, :sandboxes_by_provider],
+        %{count: Map.get(counts, {provider, status}, 0)},
+        %{provider: provider, status: status}
+      )
+    end
   end
 
   defp emit_status_counts(event, schema, statuses) do

--- a/apps/fountain/lib/fountain/permissions.ex
+++ b/apps/fountain/lib/fountain/permissions.ex
@@ -14,14 +14,19 @@ defmodule Fountain.Permissions do
 
   ## The shape
 
-  A policy is a map of tool name to verdict, plus a `"default"` key:
+  A policy is a map of key to verdict, plus a `"default"` key:
 
-      %{"default" => "auto_allow", "Bash" => "auto_deny"}
+      %{"default" => "auto_allow", "execute" => "ask"}
 
-  Tool names are matched the way the transcript labels them
-  (`ACP.Blocks.tool_name/1`): the agent's own `title`, falling back to ACP's
-  coarse `kind`. So a policy key is the string a user reads on a tool card,
-  not an internal id.
+  A request is matched most-specific-first (`verdict_for_request/2`): the tool
+  card's title, then ACP's coarse `kind`, then `"default"`.
+
+  **Reach for `kind` unless you know the runtime's titles.** claude-agent-acp,
+  which every shipped agent runs, titles a tool call with the command itself
+  — `curl -sS … https://example.com` — so a title key matches exactly one
+  invocation and nothing else. `kind` is the stable half: `execute`, `edit`,
+  `read`, `delete`, `move`, `search`, `fetch`, `think`, `other`. Measured live
+  on 2026-08-22; see `verdict_for_request/2`.
 
   ## Narrow, never widen
 
@@ -218,7 +223,7 @@ defmodule Fountain.Permissions do
   def outcome(policy, params) when is_map(params) do
     options = Map.get(params, "options") || []
 
-    case verdict_for(normalize(policy), tool_name(params)) do
+    case verdict_for_request(policy, params) do
       @auto_deny -> deny(options)
       # `ask` is not answered here — the peer holds the request open and a human
       # answers it (#940). Denying is the safe reading if a caller asks this
@@ -228,6 +233,57 @@ defmodule Fountain.Permissions do
       _ -> allow(options)
     end
   end
+
+  @doc """
+  The verdict `policy` gives one `session/request_permission`.
+
+  Tries the request's keys in order — the tool card's title first, then ACP's
+  coarse `kind` — and falls through to the policy's `"default"`.
+
+  **The `kind` fallback is what makes a per-tool policy writable.** Measured
+  against claude-agent-acp 0.66 in production on 2026-08-22: its `toolCall.title`
+  is the command itself (`curl -sS -o /dev/null -w "%{http_code}" https://…`),
+  not the tool. A title key can therefore only ever match one invocation, which
+  left `"default"` as the only usable key on the runtime every shipped agent
+  runs — a per-tool policy in name only. `kind` (`execute`, `edit`, `read`,
+  `delete`, `move`, `search`, `fetch`, `think`, `other`) is the stable half of
+  the same request, so `%{"execute" => "ask"}` means "ask before running
+  anything in the shell" and keeps working across invocations.
+
+  Title stays first: an exact-title rule is the more specific of the two, and a
+  runtime whose titles *are* tool names (`Bash`, `Edit`) keeps behaving as
+  0014 gate 3 described.
+  """
+  @spec verdict_for_request(map() | nil, map()) :: String.t()
+  def verdict_for_request(policy, params) when is_map(params) do
+    policy = normalize(policy)
+
+    params
+    |> policy_keys()
+    |> Enum.find_value(nil, fn key -> Map.get(policy, key) end)
+    |> case do
+      verdict when verdict in @verdicts -> verdict
+      # Not a verdict at all: the changesets reject these, so a value here means
+      # the row was written around them. Not trusted into an allow.
+      verdict when not is_nil(verdict) -> @auto_deny
+      nil -> verdict_for(policy, nil)
+    end
+  end
+
+  @doc """
+  The policy keys one request matches, most specific first.
+
+  The tool card's title, then ACP's `kind`. Empty when the request carries no
+  tool call at all, which falls through to the policy's default.
+  """
+  @spec policy_keys(map()) :: [String.t()]
+  def policy_keys(%{"toolCall" => call}) when is_map(call) do
+    [call["title"], call["kind"]]
+    |> Enum.filter(&(is_binary(&1) and &1 != ""))
+    |> Enum.uniq()
+  end
+
+  def policy_keys(_params), do: []
 
   @doc """
   The tool a permission request is about, as the transcript labels it.

--- a/apps/fountain/lib/fountain/permissions.ex
+++ b/apps/fountain/lib/fountain/permissions.ex
@@ -144,6 +144,20 @@ defmodule Fountain.Permissions do
   def buildable?(verdict), do: verdict in buildable_verdicts()
 
   @doc """
+  Whether a policy asks for anything the runtime has to act on.
+
+  `auto_allow` everywhere is what the peer would do with no policy at all, so it
+  needs nothing from the runtime. Anything else has to reach the agent as an
+  answer to `session/request_permission` — which is why a runtime that never
+  sends one refuses such a policy at the door
+  (`Fountain.Runtimes.ACP.asks_permission?/1`).
+  """
+  @spec needs_enforcement?(map() | nil) :: boolean()
+  def needs_enforcement?(policy) do
+    policy |> normalize() |> Enum.any?(fn {_key, verdict} -> verdict != @auto_allow end)
+  end
+
+  @doc """
   The verdict `policy` gives `tool`.
 
   Falls back to the policy's own `"default"`, then to `auto_allow`.

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -150,12 +150,22 @@ defmodule Fountain.Runtimes.ACP do
     # protocol, but it is a second process model to keep in mind when something
     # hangs. Nothing to install here: `OpenCode.prepare_sandbox/3` already bun-
     # installs the binary and symlinks it onto PATH.
+    #
+    # `asks_permission: false` — measured live on 2026-08-22, not inferred.
+    # opencode ran `curl` to an external host and then `rm -rf` under an
+    # `ask`-everything policy and sent no `session/request_permission` for
+    # either: it decides permission inside its own server and never offers the
+    # protocol's channel. So a policy is unenforceable here, and #939's
+    # premise — "the request arrives on every shippable runtime" — held for
+    # claude and codex but never for this one. `Fountain.Permissions` refuses
+    # the policy at the door rather than let it read as protection (#956).
     "opencode" => %{
       bin: "opencode",
       args: ["acp"],
       package: nil,
       version: nil,
-      cwd: "/tmp/opencode-workspace"
+      cwd: "/tmp/opencode-workspace",
+      asks_permission: false
     }
   }
 
@@ -182,6 +192,36 @@ defmodule Fountain.Runtimes.ACP do
   @spec blocked_runtimes() :: %{String.t() => String.t()}
   def blocked_runtimes do
     for {name, %{blocked: reason}} <- @adapters, into: %{}, do: {name, reason}
+  end
+
+  @doc """
+  Whether a runtime asks the client before it runs a tool.
+
+  A permission policy is only worth anything on a runtime that sends
+  `session/request_permission` (#939, #940). Every entry is assumed to ask
+  until measured otherwise, which is the safe direction to be wrong in: a
+  runtime that turns out not to ask gets a loud refusal here the first time
+  someone writes a policy for it, rather than a policy that reads as
+  protection and is not.
+
+  Measured 2026-08-22 against live agents: claude (claude-agent-acp 0.66) and
+  codex (codex-acp 1.1.14) both ask per tool call. opencode does not, ever.
+  gemini is not shippable (#659) and its own bypass flag is #941's.
+  """
+  @spec asks_permission?(String.t()) :: boolean()
+  def asks_permission?(runtime) do
+    case @adapters[runtime] do
+      nil -> true
+      spec -> Map.get(spec, :asks_permission, true)
+    end
+  end
+
+  @doc """
+  Runtimes measured **not** to ask, so a policy cannot be enforced on them.
+  """
+  @spec runtimes_without_permissions() :: [String.t()]
+  def runtimes_without_permissions do
+    for {name, spec} <- @adapters, Map.get(spec, :asks_permission, true) == false, do: name
   end
 
   @doc "The npm package and version pinned for a runtime, or nil when native."

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -461,7 +461,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # trail a transcript.
   defp handle_message({:request, id, "session/request_permission", params}, state) do
     tool = Fountain.Permissions.tool_name(params)
-    verdict = Fountain.Permissions.verdict_for(state.permission_policy, tool)
+    verdict = Fountain.Permissions.verdict_for_request(state.permission_policy, params)
 
     case verdict do
       "ask" ->
@@ -500,14 +500,37 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # client pairs the two on `request_id`.
   defp hold_permission(state, id, tool, params) do
     options = Enum.filter(Map.get(params, "options") || [], &is_map/1)
+    request_id = mint_request_id(id)
 
-    state = persist(state, "acp", Protocol.request(id, "session/request_permission", params))
-    report(state, {:permission_ask, to_string(id), tool, options})
+    state =
+      persist(state, "acp", Protocol.request(request_id, "session/request_permission", params))
+
+    report(state, {:permission_ask, request_id, tool, options})
 
     %{
       state
-      | pending_permission: %{id: id, request_id: to_string(id), options: options, tool: tool}
+      | pending_permission: %{id: id, request_id: request_id, options: options, tool: tool}
     }
+  end
+
+  # The id a client answers with, which is **not** the adapter's own JSON-RPC
+  # id. Measured against claude-agent-acp 0.66 in production: it numbers its
+  # requests from 0 *per turn*, so every conversation's second permission
+  # request arrives as id 0 again. Two live consequences, both from one cause:
+  #
+  # - a client pairing the resolution to the request on `request_id` (which is
+  #   the contract) marks the new card resolved the moment it renders, because
+  #   turn 2's `request`/`done` already named that id;
+  # - answering from a stale card would land on whatever request is open *now*,
+  #   approving a tool the person never saw.
+  #
+  # So Fountain mints the public id: the adapter's own id, a dot, and eight
+  # random bytes. The adapter id stays in front because a transcript is read
+  # beside adapter logs, and `restore_pending/1` reads it back to answer with
+  # the id the agent is actually blocked on. A stale card now misses and gets
+  # the same 409 as any other lost race.
+  defp mint_request_id(id) do
+    "#{id}.#{Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)}"
   end
 
   # We declared no filesystem or terminal capabilities, so nothing should ask.
@@ -875,23 +898,50 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # A held request handed back on reattach (#940). Stored as a string-keyed map
   # on the turn row; the peer works in atoms. The JSON-RPC id has to come back
   # as the integer the agent sent, because that is what it is blocked on.
+  # The adapter's own JSON-RPC id, back out of the minted `request_id` (see
+  # `mint_request_id/1`): everything before the last dot. A response has to
+  # echo the id's JSON type, so a numeric id is restored as an integer and
+  # anything else as the string it was — an adapter that numbers its requests
+  # and one that names them are both answerable after a deploy.
   defp restore_pending(%{"request_id" => request_id, "options" => options} = pending)
        when is_binary(request_id) do
-    case Integer.parse(request_id) do
-      {id, ""} ->
+    case acp_id(request_id) do
+      nil ->
+        nil
+
+      id ->
         %{
           id: id,
           request_id: request_id,
           options: List.wrap(options),
           tool: Map.get(pending, "tool")
         }
-
-      _ ->
-        nil
     end
   end
 
   defp restore_pending(_), do: nil
+
+  defp acp_id(request_id) do
+    case String.split(request_id, ".") do
+      [_only] ->
+        # A request_id written before #955 minted them: the whole string is the
+        # adapter's id. Restoring it keeps a request raised across that deploy
+        # answerable instead of orphaning it.
+        parse_acp_id(request_id)
+
+      parts ->
+        parts |> Enum.drop(-1) |> Enum.join(".") |> parse_acp_id()
+    end
+  end
+
+  defp parse_acp_id(""), do: nil
+
+  defp parse_acp_id(raw) do
+    case Integer.parse(raw) do
+      {id, ""} -> id
+      _ -> raw
+    end
+  end
 
   defp noreply(state), do: {:noreply, state}
 end

--- a/apps/fountain/lib/fountain/runtimes/gemini.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini.ex
@@ -126,6 +126,10 @@ defmodule Fountain.Runtimes.Gemini do
     fi
     """
 
+    # The session-store workaround travels with the workspace (#659): it has to
+    # be on disk before the first turn ends, since that is when it first runs.
+    _ = Fountain.Runtimes.Gemini.SessionStore.install(handle)
+
     case Fountain.Sandbox.exec(handle, "bash", ["-lc", script],
            env: sprite_env,
            timeout: 30_000

--- a/apps/fountain/lib/fountain/runtimes/gemini/session_store.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini/session_store.ex
@@ -1,0 +1,110 @@
+defmodule Fountain.Runtimes.Gemini.SessionStore do
+  @moduledoc """
+  Keeps gemini's own chat-session store from erasing the session it is asked to
+  load — a workaround for [gemini-cli#28775][], tracked as #659.
+
+  [gemini-cli#28775]: https://github.com/google-gemini/gemini-cli/issues/28775
+
+  ## What goes wrong without this
+
+  Measured against a live `gemini --acp` on 2026-08-22, versions 0.53.0 through
+  0.56.0. `session/load` builds a fresh config on the session id *before*
+  looking the session up, which stands up a chat recorder; the recorder's
+  new-session branch names its file by **wall-clock minute**
+  (`toISOString().slice(0, 16)`) plus the id's first 8 characters, so a load in
+  the same minute as the last write computes the *same path*; it appends a
+  `$set` carrying only gemini's `<session_context>` bootstrap; and gemini's
+  reader treats `$set.messages` as a replacement rather than a merge. The
+  emptied file then fails `hasResumableContent`, drops out of `listSessions()`,
+  and `findSession` reports `-32603` "No previous sessions found for this
+  project" — about a session whose transcript is still on disk, above the line
+  that erased it.
+
+  Reproduced end to end: a turn-1 file with three resumable messages had one
+  left after a same-minute load, and the load failed.
+
+  ## Why a rename is not enough
+
+  The obvious fix — move the file out of the minute-bucketed path — holds for
+  exactly one turn. After every load **two** files carry the same `sessionId`:
+  the one we parked and the poisoned one the load just created. Gemini dedupes
+  by id keeping the later `lastUpdated`, which is the poisoned one, so turn 3
+  fails again.
+
+  So this **consolidates** on every turn instead: keep the file with real
+  content, delete the poisoned duplicates, and park the survivor under a
+  timestamp the recorder can never produce. Discovery is unaffected — gemini
+  scans on the `session-` prefix and the extension, and matches on the
+  `sessionId` *inside* the file, never on the name.
+
+  Verified live: five consecutive turns inside one wall-clock minute (the case
+  that fails on turn 2 without this), history growing 3 → 5 → 7 → 9 → 11, and
+  the agent recalling content planted before the first reload every time.
+
+  ## Lifetime
+
+  Delete this module, `priv/gemini-session-consolidate.js`, and the call in
+  `ConversationServer` when upstream lands. Nothing else depends on it.
+  """
+
+  require Logger
+
+  @script_path "/tmp/gemini-session-consolidate.js"
+
+  @source Path.join(:code.priv_dir(:fountain), "gemini-session-consolidate.js")
+  @external_resource @source
+  @script File.read!(@source)
+
+  @doc """
+  Install the consolidation script into the sandbox.
+
+  Called from `Gemini.prepare_sandbox/3`. Written to `/tmp` because gemini runs
+  with `HOME=/tmp` on the sprite and `/tmp` is writable there without the ACL
+  surprises `/home/sprite` has.
+  """
+  @spec install(Fountain.Sandbox.Handle.t()) :: :ok | {:error, term()}
+  def install(handle) do
+    Fountain.Sandbox.write_file(handle, @script_path, @script)
+  end
+
+  @doc """
+  Consolidate this session's chat files. Best-effort by contract.
+
+  Called at the end of every gemini ACP turn, before the next turn's
+  `session/load` can collide. A failure here costs the *next* turn its history,
+  which is bad, but failing the turn that just succeeded would be worse — so
+  this logs and returns `:ok` rather than propagating.
+
+  Runs with `HOME=/tmp` to match `Gemini.default_env/2`; the script resolves the
+  chats directory from `HOME` exactly as gemini does.
+  """
+  @spec consolidate(Fountain.Sandbox.Handle.t(), String.t() | nil) :: :ok
+  def consolidate(_handle, session_id) when session_id in [nil, ""], do: :ok
+
+  def consolidate(handle, session_id) do
+    case Fountain.Sandbox.exec(handle, "node", [@script_path, session_id],
+           env: [{"HOME", "/tmp"}],
+           timeout: 15_000
+         ) do
+      {:ok, out, 0} ->
+        Logger.debug("gemini session consolidate: #{String.trim(to_string(out))}")
+        :ok
+
+      {:ok, out, code} ->
+        Logger.warning(
+          "gemini session consolidate exited #{code} for #{session_id}: " <>
+            String.trim(to_string(out))
+        )
+
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("gemini session consolidate failed for #{session_id}: #{inspect(reason)}")
+
+        :ok
+    end
+  end
+
+  @doc false
+  def script_path, do: @script_path
+end

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -86,7 +86,23 @@ defmodule FountainWeb.FallbackController do
     |> put_status(:unprocessable_entity)
     |> json(%{
       error: "permission_policy_invalid",
-      message: "permission_policy must map tool names to auto_allow or auto_deny"
+      message:
+        "permission_policy must map a tool title or ACP kind to one of " <>
+          Enum.join(Fountain.Permissions.verdicts(), ", ")
+    })
+  end
+
+  # The runtime never sends `session/request_permission`, so the verdicts have
+  # nothing to travel on. Refused rather than stored: an inert `auto_deny`
+  # reads like protection everywhere it is displayed.
+  def call(conn, {:error, {:permission_policy_unenforceable, runtime}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "permission_policy_unenforceable",
+      message:
+        "the #{runtime} runtime never asks before it runs a tool, so a policy " <>
+          "stricter than auto_allow cannot be enforced on it"
     })
   end
 

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -6,6 +6,7 @@ defmodule FountainWeb.AdminLive.Index do
 
   alias Fountain.{Accounts, Billing, Conversations, Quotas}
   alias Fountain.Accounts.Deletion
+  alias Fountain.Billing.SandboxUsage
 
   @usage_window_days 30
   @per_page 25
@@ -23,6 +24,7 @@ defmodule FountainWeb.AdminLive.Index do
      |> assign(:billing_enabled, Billing.enabled?())
      |> assign(:funnel, Fountain.Funnel.summary_admin())
      |> assign_billing_overview()
+     |> assign(:provider_spend, Billing.provider_spend())
      |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
      |> assign(:admin_events, Fountain.Audit._unsafe_list_recent_admin(25))}
   end
@@ -46,6 +48,7 @@ defmodule FountainWeb.AdminLive.Index do
      |> assign_users()
      |> assign(:funnel, Fountain.Funnel.summary_admin())
      |> assign_billing_overview()
+     |> assign(:provider_spend, Billing.provider_spend())
      |> assign(:sandboxes, Conversations._unsafe_list_sandboxes_admin())
      |> assign(:admin_events, Fountain.Audit._unsafe_list_recent_admin(25))}
   end
@@ -423,7 +426,13 @@ defmodule FountainWeb.AdminLive.Index do
         DateTime.add(now, 1, :second)
       )
 
-    no_usage = %{conversations: 0, turns: 0, sandbox_minutes: 0.0}
+    no_usage = %{
+      conversations: 0,
+      turns: 0,
+      sandbox_minutes: 0.0,
+      sandbox_minutes_by_provider: %{}
+    }
+
     sandbox_counts = Quotas.active_sandbox_counts()
 
     %{users: users, total: total} =
@@ -562,6 +571,88 @@ defmodule FountainWeb.AdminLive.Index do
           <div class="text-xs">
             built an agent: {@funnel.stalled.built_agent} · created an environment: {@funnel.stalled.built_environment} · built nothing: {@funnel.stalled.built_nothing}
           </div>
+        </div>
+      </section>
+
+      <%!-- Not gated on @billing_enabled: a self-hosted instance still pays a
+            provider bill, and this is the only place that says whose sandboxes
+            it is for. --%>
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Sandbox spend by provider</h2>
+        <p class="text-xs text-zinc-500">
+          Active sandbox time {Calendar.strftime(@provider_spend.period_start, "%b %-d")} – now,
+          parked time excluded. Minutes on different providers cost different amounts — hold these
+          next to the invoice, they are not money.
+        </p>
+
+        <div :if={@provider_spend.by_provider == %{}} class="text-xs text-zinc-400">
+          No sandbox time this month.
+        </div>
+
+        <div :if={@provider_spend.by_provider != %{}} class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <div
+            :for={{provider, totals} <- Enum.sort(@provider_spend.by_provider)}
+            class="bg-white rounded shadow border border-zinc-200 px-4 py-3"
+          >
+            <div class="text-xs text-zinc-500">{provider}</div>
+            <div class="text-2xl font-semibold tabular-nums">
+              {format_hours(SandboxUsage.hours(totals.active_seconds))}
+            </div>
+            <div class="text-xs text-zinc-500 tabular-nums">
+              {totals.sandboxes} sandboxes · {totals.users} {if totals.users == 1,
+                do: "tenant",
+                else: "tenants"}
+            </div>
+            <div
+              class="text-xs tabular-nums"
+              title="No turn in flight. A shorter idle timeout removes this."
+            >
+              <span class={
+                if idle_share(totals) >= 0.5, do: "text-amber-600 font-medium", else: "text-zinc-500"
+              }>
+                {format_hours(SandboxUsage.hours(totals.idle_seconds))} idle
+              </span>
+              <span class="text-zinc-400">({round(idle_share(totals) * 100)}%)</span>
+            </div>
+            <div :if={not SandboxUsage.platform_cost?(provider)} class="text-xs text-zinc-400">
+              tenant hardware, not our bill
+            </div>
+          </div>
+        </div>
+
+        <div class="text-xs text-zinc-500 tabular-nums">
+          Billable to us: {format_hours(SandboxUsage.hours(@provider_spend.platform_seconds))}
+          <span :if={@provider_spend.platform_seconds > 0} class="text-zinc-400">
+            · {format_hours(SandboxUsage.hours(@provider_spend.platform_idle_seconds))} of it idle,
+            which is what a shorter idle timeout would remove
+          </span>
+        </div>
+
+        <div
+          :if={@provider_spend.top_tenants != []}
+          class="bg-white rounded shadow border border-zinc-200"
+        >
+          <div class="px-4 py-2 text-xs font-medium text-zinc-500 border-b border-zinc-200">
+            Who it belongs to
+          </div>
+          <ul class="divide-y divide-zinc-100">
+            <li
+              :for={tenant <- @provider_spend.top_tenants}
+              class="px-4 py-2 text-xs flex items-center justify-between gap-3"
+            >
+              <span class="truncate">
+                {tenant.email || "(deleted account)"}
+                <span class="text-zinc-400">· {tenant.provider}</span>
+              </span>
+              <span class="tabular-nums whitespace-nowrap text-zinc-500">
+                {format_hours(SandboxUsage.hours(tenant.active_seconds))}
+                <span class="text-zinc-400">
+                  ({round(idle_share(tenant) * 100)}% idle)
+                </span>
+                · {tenant.sandboxes} sandboxes
+              </span>
+            </li>
+          </ul>
         </div>
       </section>
 
@@ -832,7 +923,10 @@ defmodule FountainWeb.AdminLive.Index do
                   </div>
                 </div>
               </td>
-              <td class="px-4 py-2 text-xs text-zinc-500 tabular-nums whitespace-nowrap">
+              <td
+                class="px-4 py-2 text-xs text-zinc-500 tabular-nums whitespace-nowrap"
+                title={provider_split(u.usage.sandbox_minutes_by_provider)}
+              >
                 {u.usage.conversations}c · {u.usage.turns}t · {round(u.usage.sandbox_minutes)}m
               </td>
               <td class="px-4 py-2">
@@ -1051,6 +1145,22 @@ defmodule FountainWeb.AdminLive.Index do
     dollars = div(cents, 100)
     remainder = rem(cents, 100)
     "$#{dollars}.#{String.pad_leading(to_string(remainder), 2, "0")}/mo"
+  end
+
+  # Share of a provider's paid time with no turn in flight. Zero active time
+  # is 0.0 rather than a division by zero — nothing running is not "all idle".
+  defp idle_share(%{active_seconds: 0}), do: 0.0
+  defp idle_share(%{active_seconds: active, idle_seconds: idle}), do: idle / active
+
+  # Which provider a tenant's sandbox minutes ran on, for the usage cell's
+  # tooltip. Empty when the tenant had no sandbox time, so the attribute
+  # renders as nothing rather than as an empty tooltip.
+  defp provider_split(by_provider) when map_size(by_provider) == 0, do: nil
+
+  defp provider_split(by_provider) do
+    by_provider
+    |> Enum.sort()
+    |> Enum.map_join(" · ", fn {provider, minutes} -> "#{provider} #{round(minutes)}m" end)
   end
 
   defp format_hours(h) when h < 1, do: "#{round(h * 60)}m"

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1581,7 +1581,17 @@ defmodule FountainWeb.Schemas do
               properties: %{
                 conversations: %Schema{type: :integer},
                 turns: %Schema{type: :integer},
-                sandbox_minutes: %Schema{type: :number}
+                sandbox_minutes: %Schema{
+                  type: :number,
+                  description: "Active sandbox minutes inside the period, parked time excluded."
+                },
+                sandbox_minutes_by_provider: %Schema{
+                  type: :object,
+                  description:
+                    "sandbox_minutes split by sandbox provider (sprites, e2b, " <>
+                      "daytona, runner). Providers not used in the period are absent.",
+                  additionalProperties: %Schema{type: :number}
+                }
               }
             }
           },

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -280,10 +280,13 @@ defmodule FountainWeb.Schemas do
             enum: Fountain.Permissions.buildable_verdicts()
           },
           description:
-            "Per-launch permission override (#939). Merged with the agent's own policy, " <>
-              "taking the stricter of the two per tool. It may only narrow: a policy that " <>
-              "would loosen any tool is refused with 422 permission_policy_widens rather " <>
-              "than silently clamped."
+            "Per-launch permission override (#939). Keys are matched against the tool " <>
+              "card's title first and then ACP's kind (execute, edit, read, fetch, …); " <>
+              "\"default\" covers the rest. Prefer a kind: claude titles a tool call with " <>
+              "the command it is about to run, so a title matches one invocation only. " <>
+              "Merged with the agent's own policy, taking the stricter of the two. It may " <>
+              "only narrow: a policy that would loosen any tool is refused with 422 " <>
+              "permission_policy_widens rather than silently clamped."
         },
         prompt: %Schema{type: :string, description: "Optional first turn prompt."},
         title: %Schema{
@@ -478,11 +481,13 @@ defmodule FountainWeb.Schemas do
             enum: Fountain.Permissions.buildable_verdicts()
           },
           description:
-            "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
-              "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
-              "default, and an unset default is auto_allow \u2014 today's behaviour. " <>
-              "\"ask\" holds the tool until a human answers it on the conversation " <>
-              "stream, and denies if nobody does before the timeout."
+            "Per-tool permission policy: a map of key to verdict, plus an optional " <>
+              "\"default\" key. A key is matched against the tool card's title first and " <>
+              "then ACP's kind (execute, edit, read, fetch, \u2026); prefer a kind, because " <>
+              "claude titles a tool call with the command it is about to run. Unset keys " <>
+              "fall back to the default, and an unset default is auto_allow \u2014 today's " <>
+              "behaviour. \"ask\" holds the tool until a human answers it on the " <>
+              "conversation stream, and denies if nobody does before the timeout."
         },
         skills: %Schema{
           type: :array,
@@ -729,11 +734,14 @@ defmodule FountainWeb.Schemas do
             enum: Fountain.Permissions.buildable_verdicts()
           },
           description:
-            "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
-              "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
-              "default, and an unset default is auto_allow. \"ask\" holds the tool until a " <>
-              "human answers it on the conversation stream, and denies if nobody does " <>
-              "before the timeout. A conversation may narrow this at launch, never widen it."
+            "Per-tool permission policy: a map of key to verdict, plus an optional " <>
+              "\"default\" key. A key is matched against the tool card's title first and " <>
+              "then ACP's kind (execute, edit, read, fetch, \u2026); prefer a kind, because " <>
+              "claude titles a tool call with the command it is about to run. Unset keys " <>
+              "fall back to the default, and an unset default is auto_allow. \"ask\" holds " <>
+              "the tool until a human answers it on the conversation stream, and denies if " <>
+              "nobody does before the timeout. A conversation may narrow this at launch, " <>
+              "never widen it."
         },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         skills: %Schema{
@@ -832,11 +840,14 @@ defmodule FountainWeb.Schemas do
             enum: Fountain.Permissions.buildable_verdicts()
           },
           description:
-            "Per-tool permission policy: a map of tool name (as the transcript labels it) " <>
-              "to verdict, plus an optional \"default\" key. Unset tools fall back to the " <>
-              "default, and an unset default is auto_allow. \"ask\" holds the tool until a " <>
-              "human answers it on the conversation stream, and denies if nobody does " <>
-              "before the timeout. A conversation may narrow this at launch, never widen it."
+            "Per-tool permission policy: a map of key to verdict, plus an optional " <>
+              "\"default\" key. A key is matched against the tool card's title first and " <>
+              "then ACP's kind (execute, edit, read, fetch, \u2026); prefer a kind, because " <>
+              "claude titles a tool call with the command it is about to run. Unset keys " <>
+              "fall back to the default, and an unset default is auto_allow. \"ask\" holds " <>
+              "the tool until a human answers it on the conversation stream, and denies if " <>
+              "nobody does before the timeout. A conversation may narrow this at launch, " <>
+              "never widen it."
         },
         allowed_environment_ids: %Schema{
           type: :array,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -286,7 +286,8 @@ defmodule FountainWeb.Schemas do
               "the command it is about to run, so a title matches one invocation only. " <>
               "Merged with the agent's own policy, taking the stricter of the two. It may " <>
               "only narrow: a policy that would loosen any tool is refused with 422 " <>
-              "permission_policy_widens rather than silently clamped."
+              "permission_policy_widens rather than silently clamped, and one the runtime " <>
+              "never consults is refused with 422 permission_policy_unenforceable."
         },
         prompt: %Schema{type: :string, description: "Optional first turn prompt."},
         title: %Schema{
@@ -487,7 +488,9 @@ defmodule FountainWeb.Schemas do
               "claude titles a tool call with the command it is about to run. Unset keys " <>
               "fall back to the default, and an unset default is auto_allow \u2014 today's " <>
               "behaviour. \"ask\" holds the tool until a human answers it on the " <>
-              "conversation stream, and denies if nobody does before the timeout."
+              "conversation stream, and denies if nobody does before the timeout. A " <>
+              "runtime that never asks (opencode) refuses anything stricter than " <>
+              "auto_allow with 422 permission_policy_unenforceable."
         },
         skills: %Schema{
           type: :array,
@@ -741,7 +744,8 @@ defmodule FountainWeb.Schemas do
               "fall back to the default, and an unset default is auto_allow. \"ask\" holds " <>
               "the tool until a human answers it on the conversation stream, and denies if " <>
               "nobody does before the timeout. A conversation may narrow this at launch, " <>
-              "never widen it."
+              "never widen it. A runtime that never asks (opencode) refuses anything " <>
+              "stricter than auto_allow with 422 permission_policy_unenforceable."
         },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         skills: %Schema{
@@ -847,7 +851,8 @@ defmodule FountainWeb.Schemas do
               "fall back to the default, and an unset default is auto_allow. \"ask\" holds " <>
               "the tool until a human answers it on the conversation stream, and denies if " <>
               "nobody does before the timeout. A conversation may narrow this at launch, " <>
-              "never widen it."
+              "never widen it. A runtime that never asks (opencode) refuses anything " <>
+              "stricter than auto_allow with 422 permission_policy_unenforceable."
         },
         allowed_environment_ids: %Schema{
           type: :array,

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -354,6 +354,15 @@ defmodule FountainWeb.Telemetry do
         tags: [:status],
         description: "Sandbox rows by status"
       ),
+      # The live view of what the sandbox providers are charging for. Tagged
+      # by provider because a minute on each is bought at a different price;
+      # not tagged by tenant, which is a database report, not a series.
+      last_value("fountain.sandboxes_by_provider.count",
+        event_name: [:fountain, :sandboxes_by_provider],
+        measurement: :count,
+        tags: [:provider, :status],
+        description: "Non-terminal sandbox rows by provider and status"
+      ),
       last_value("fountain.oban_queue.depth",
         event_name: [:fountain, :oban_queue],
         measurement: :depth,

--- a/apps/fountain/priv/gemini-session-consolidate.js
+++ b/apps/fountain/priv/gemini-session-consolidate.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Keep one gemini chat-session file per session, outside the path its own
+// loader will clobber. Workaround for google-gemini/gemini-cli#28775; delete
+// this file and its call sites when that lands. Fountain issue: #659.
+//
+// The defect, in the version this was written against (0.53.0 through 0.56.0):
+//
+//   1. `session/load` builds a fresh config on the session id *before* looking
+//      the session up, which stands up a chat recorder;
+//   2. the recorder's new-session branch names its file
+//      `session-${new Date().toISOString().slice(0,16)}-${id.slice(0,8)}.jsonl`
+//      — minute resolution, so a load in the same minute as the last write
+//      computes the *same path*;
+//   3. it appends a `$set` carrying only its `<session_context>` bootstrap, and
+//      the reader treats `$set.messages` as a replacement, not a merge;
+//   4. the emptied file then fails `hasResumableContent` and is dropped from
+//      `listSessions()`, so `findSession` reports "No previous sessions found
+//      for this project" — about a session whose transcript is still on disk,
+//      above the line that erased it.
+//
+// Renaming once is not enough. After every load, *two* files carry the same
+// sessionId — the one we parked and the poisoned one the load just created —
+// and gemini dedupes by id keeping the later `lastUpdated`, which is the
+// poisoned one. So this consolidates instead: keep the file with real content,
+// delete the poisoned duplicates, park the survivor under a name whose
+// timestamp component can never be produced by the recorder.
+//
+// Discovery is unaffected: gemini's own scan filters only on the `session-`
+// prefix and the extension, and matches sessions by the `sessionId` *inside*
+// the file, never by the name.
+//
+// Usage: node gemini-session-consolidate.js <sessionId>
+// Exits 0 on success or when there is nothing to do. Never throws for a
+// missing directory: a turn that wrote no session is not an error.
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const PARKED_STAMP = "0000-00-00T00-00";
+
+function chatsDirs() {
+  const base = path.join(process.env.HOME || os.homedir(), ".gemini", "tmp");
+  let entries;
+  try {
+    entries = fs.readdirSync(base, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const c = path.join(base, e.name, "chats");
+    try {
+      if (fs.statSync(c).isDirectory()) out.push(c);
+    } catch {
+      /* no chats dir for this project */
+    }
+  }
+  return out;
+}
+
+// Mirrors gemini's own reader: records accumulate, but a `$set.messages`
+// replaces everything seen so far. Only user/gemini records with content are
+// resumable — which is exactly why a bootstrap-only `$set` reads as empty.
+function inspect(file) {
+  let text;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  let sessionId = null;
+  let messages = [];
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let rec;
+    try {
+      rec = JSON.parse(t);
+    } catch {
+      continue;
+    }
+    if (!rec || typeof rec !== "object") continue;
+    if (typeof rec.sessionId === "string" && !sessionId) sessionId = rec.sessionId;
+    if (rec.$set && Array.isArray(rec.$set.messages)) {
+      messages = rec.$set.messages.slice();
+      continue;
+    }
+    if ((rec.type === "user" || rec.type === "gemini") && rec.content !== undefined) {
+      messages.push(rec);
+    }
+  }
+  const resumable = messages.filter(
+    (m) => m && (m.type === "user" || m.type === "gemini") && m.content !== undefined
+  ).length;
+  return { sessionId, resumable };
+}
+
+function main() {
+  const sid = process.argv[2];
+  if (!sid) {
+    process.stderr.write("usage: gemini-session-consolidate.js <sessionId>\n");
+    process.exit(2);
+  }
+  const short = sid.slice(0, 8);
+  let kept = 0;
+  let removed = 0;
+
+  for (const dir of chatsDirs()) {
+    let names;
+    try {
+      names = fs.readdirSync(dir);
+    } catch {
+      continue;
+    }
+    const mine = [];
+    for (const name of names) {
+      if (!name.startsWith("session-") || !name.endsWith(".jsonl")) continue;
+      const full = path.join(dir, name);
+      const info = inspect(full);
+      if (!info || info.sessionId !== sid) continue;
+      mine.push({ full, name, resumable: info.resumable });
+    }
+    if (mine.length === 0) continue;
+
+    // Richest wins; ties keep the already-parked file so repeated runs are
+    // stable and a no-op turn cannot shuffle the archive.
+    mine.sort((a, b) => {
+      if (b.resumable !== a.resumable) return b.resumable - a.resumable;
+      const ap = a.name.includes(PARKED_STAMP) ? 0 : 1;
+      const bp = b.name.includes(PARKED_STAMP) ? 0 : 1;
+      return ap - bp;
+    });
+
+    const best = mine[0];
+    for (const f of mine.slice(1)) {
+      try {
+        fs.unlinkSync(f.full);
+        removed++;
+      } catch {
+        /* already gone */
+      }
+    }
+
+    const parked = path.join(dir, `session-${PARKED_STAMP}-${short}.jsonl`);
+    if (path.resolve(best.full) !== path.resolve(parked)) {
+      // rename, never onto a file we are still keeping — the losers are gone.
+      fs.renameSync(best.full, parked);
+    }
+    kept++;
+  }
+
+  process.stdout.write(JSON.stringify({ sessionId: sid, kept, removed }) + "\n");
+}
+
+main();

--- a/apps/fountain/priv/repo/migrations/20260822100000_backfill_sandbox_terminated_at.exs
+++ b/apps/fountain/priv/repo/migrations/20260822100000_backfill_sandbox_terminated_at.exs
@@ -1,0 +1,27 @@
+defmodule Fountain.Repo.Migrations.BackfillSandboxTerminatedAt do
+  use Ecto.Migration
+
+  # Only the paths that *terminated* a sandbox ever passed a `terminated_at`;
+  # the ones that marked it `failed` did not, so a failed row carried a null
+  # end for the rest of its life. Spend attribution reads that column as the
+  # end of the billed interval, and a null there reads as "still running" —
+  # every historical failure would accrue minutes forever.
+  #
+  # `updated_at` is the closest thing to the truth for these rows: the write
+  # that set the terminal status was, for a failed sandbox, the last write it
+  # ever received. Conversations.update_sandbox/2 now stamps the column, so
+  # this only has to repair the backlog.
+  def up do
+    execute("""
+    UPDATE sandboxes
+       SET terminated_at = updated_at
+     WHERE status IN ('terminated', 'failed')
+       AND terminated_at IS NULL
+    """)
+  end
+
+  # Irreversible by design: the pre-migration state is "we do not know when
+  # this ended", and nulling the column again would only throw away the best
+  # estimate we have. Rolling back leaves the repaired timestamps in place.
+  def down, do: :ok
+end

--- a/apps/fountain/priv/repo/migrations/20260822100100_index_sandboxes_inserted_at.exs
+++ b/apps/fountain/priv/repo/migrations/20260822100100_index_sandboxes_inserted_at.exs
@@ -1,0 +1,11 @@
+defmodule Fountain.Repo.Migrations.IndexSandboxesInsertedAt do
+  use Ecto.Migration
+
+  # Spend attribution asks "which sandboxes overlapped this period", which is
+  # a range scan on `inserted_at`. `sandboxes` is never pruned — it is the
+  # durable record of what the platform paid a provider for — so the scan
+  # grows with the lifetime of the instance while a month's answer does not.
+  def change do
+    create index(:sandboxes, [:inserted_at])
+  end
+end

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -431,6 +431,40 @@ defmodule Fountain.AgentsTest do
       assert %{permission_policy: _} = errors_on(changeset)
     end
 
+    test "a runtime that never asks refuses the policy instead of ignoring it" do
+      # Measured live 2026-08-22: opencode ran an external `curl` and an `rm -rf`
+      # under an ask-everything policy without ever sending
+      # `session/request_permission`. Storing the policy anyway would put
+      # "auto_deny" on every screen that shows the agent and enforce nothing.
+      user = insert_verified_user()
+
+      assert {:error, changeset} =
+               Agents.create_agent(
+                 agent_attrs(%{
+                   "user_id" => user.id,
+                   "runtime" => "opencode",
+                   "model" => "anthropic/claude-sonnet-5",
+                   "permission_policy" => %{"default" => "auto_deny"}
+                 })
+               )
+
+      assert %{permission_policy: [msg]} = errors_on(changeset)
+      assert msg =~ "never asks"
+
+      # auto_allow everywhere asks nothing of the runtime, so it still stores.
+      assert {:ok, agent} =
+               Agents.create_agent(
+                 agent_attrs(%{
+                   "user_id" => user.id,
+                   "runtime" => "opencode",
+                   "model" => "anthropic/claude-sonnet-5",
+                   "permission_policy" => %{"default" => "auto_allow"}
+                 })
+               )
+
+      assert agent.permission_policy == %{"default" => "auto_allow"}
+    end
+
     test "a policy change is audited by the existing agent.updated trail" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -893,6 +893,11 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
       send(pid, {:stdout, %{ref: ref}, line})
       settle(pid)
+
+      # The id a client answers with is minted by the peer, not the adapter's
+      # own — claude and codex both number theirs from 0 per turn (#957). Tests
+      # read it back rather than assuming it.
+      :sys.get_state(pid).current_turn.pending_permission["request_id"]
     end
 
     test "a held request is persisted on the turn and announced on the stream" do
@@ -901,19 +906,20 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
 
-      raise_permission(pid, ref, 301)
+      request_id = raise_permission(pid, ref, 301)
 
       # Persisted first, so a deploy landing a millisecond later can still
       # answer it.
       turn = :sys.get_state(pid).current_turn
-      assert turn.pending_permission["request_id"] == "301"
+      assert turn.pending_permission["request_id"] == request_id
+      assert request_id =~ ~r/^301\./
       assert turn.pending_permission["tool"] == "Bash"
 
       # And announced, with the agent's own options.
       events = Conversations._unsafe_list_log_events(conv.id)
       stage = Enum.find(events, &(&1.kind == "stage" and &1.stage == "request"))
       assert stage.state == "started"
-      assert Jason.decode!(stage.data)["request_id"] == "301"
+      assert Jason.decode!(stage.data)["request_id"] == request_id
     end
 
     test "the request renders as a permission_request block in the transcript" do
@@ -922,7 +928,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
 
-      raise_permission(pid, ref, 302)
+      request_id = raise_permission(pid, ref, 302)
 
       blocks =
         conv.id
@@ -931,7 +937,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
         |> Enum.flat_map(&Fountain.Conversations.Blocks.for_event(&1, "claude"))
 
       assert block = Enum.find(blocks, &(&1.kind == :permission_request))
-      assert block.request_id == "302"
+      assert block.request_id == request_id
       assert block.name == "Bash"
       assert Enum.map(block.options, & &1["optionId"]) == ["yes", "no"]
     end
@@ -941,9 +947,9 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 303)
+      request_id = raise_permission(pid, ref, 303)
 
-      assert :ok = GenServer.call(pid, {:answer_permission, "303", "yes"})
+      assert :ok = GenServer.call(pid, {:answer_permission, request_id, "yes"})
 
       assert %{"id" => 303, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
 
@@ -967,9 +973,9 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 304)
+      request_id = raise_permission(pid, ref, 304)
 
-      send(pid, {:permission_timeout, "304"})
+      send(pid, {:permission_timeout, request_id})
       settle(pid)
 
       states =
@@ -987,9 +993,9 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 305)
+      request_id = raise_permission(pid, ref, 305)
 
-      send(pid, {:permission_timeout, "305"})
+      send(pid, {:permission_timeout, request_id})
       settle(pid)
 
       # Deny is the only safe default, and it picks the agent's own rejection.
@@ -1006,12 +1012,12 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 306)
+      request_id = raise_permission(pid, ref, 306)
 
       assert {:error, :unknown_option} =
-               GenServer.call(pid, {:answer_permission, "306", "made-up"})
+               GenServer.call(pid, {:answer_permission, request_id, "made-up"})
 
-      assert :sys.get_state(pid).current_turn.pending_permission["request_id"] == "306"
+      assert :sys.get_state(pid).current_turn.pending_permission["request_id"] == request_id
     end
 
     test "a sprite may not answer its own prompt" do
@@ -1021,10 +1027,10 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 307)
+      request_id = raise_permission(pid, ref, 307)
 
       assert {:error, :sprite_may_not_answer} =
-               Conversations.answer_permission_request(conv.id, user.id, "307", "yes",
+               Conversations.answer_permission_request(conv.id, user.id, request_id, "yes",
                  actor: "sprite"
                )
     end
@@ -1035,10 +1041,10 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       conv = insert_conversation(user_id: user.id, agent: ask_agent(user))
       {pid, ref} = start_acp_turn(conv)
       _init = next_write()
-      raise_permission(pid, ref, 308)
+      request_id = raise_permission(pid, ref, 308)
 
       assert {:error, :not_found} =
-               Conversations.answer_permission_request(conv.id, other.id, "308", "yes")
+               Conversations.answer_permission_request(conv.id, other.id, request_id, "yes")
     end
 
     test "a request still held when the turn ends is resolved, not left open" do
@@ -1047,7 +1053,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       {pid, ref} = start_acp_turn(conv)
       prompt_id = drive_to_prompt(pid, ref)
 
-      raise_permission(pid, ref, 309)
+      _request_id = raise_permission(pid, ref, 309)
       reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
 
       done =

--- a/apps/fountain/test/fountain/conversations_context_test.exs
+++ b/apps/fountain/test/fountain/conversations_context_test.exs
@@ -96,6 +96,44 @@ defmodule Fountain.ConversationsContextTest do
       assert {:error, changeset} = Conversations.update_sandbox(sandbox, %{status: "invalid"})
       assert errors_on(changeset)[:status]
     end
+
+    test "stamps terminated_at when a sandbox fails" do
+      # Every path that marked a sandbox `failed` left terminated_at null, so
+      # spend attribution — which reads it as the end of the billed interval —
+      # saw a failed sandbox as one that never stopped running.
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "starting")
+
+      assert {:ok, updated} = Conversations.update_sandbox(sandbox, %{status: "failed"})
+      assert %DateTime{} = updated.terminated_at
+    end
+
+    test "stamps terminated_at when a sandbox terminates without one" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      assert {:ok, updated} = Conversations.update_sandbox(sandbox, %{status: "terminated"})
+      assert %DateTime{} = updated.terminated_at
+    end
+
+    test "keeps a terminated_at the caller supplied" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      at = ~U[2026-05-10 12:00:00Z]
+
+      assert {:ok, updated} =
+               Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: at})
+
+      assert updated.terminated_at == at
+    end
+
+    test "does not stamp terminated_at on a non-terminal transition" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      assert {:ok, updated} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      assert is_nil(updated.terminated_at)
+    end
   end
 
   # ────────────────────────────────────────────────────────────────────────────

--- a/apps/fountain/test/fountain/conversations_start_test.exs
+++ b/apps/fountain/test/fountain/conversations_start_test.exs
@@ -344,6 +344,27 @@ defmodule Fountain.ConversationsStartTest do
       assert conv.permission_policy == %{"Bash" => "ask"}
     end
 
+    test "a runtime that never asks refuses the override, naming itself", ctx do
+      # opencode decides permission inside its own server and sends no
+      # `session/request_permission` (measured 2026-08-22). A launch policy it
+      # will never consult is refused, not stored: the caller asked for a
+      # restriction and has to learn they did not get one.
+      agent =
+        insert_agent(
+          user_id: ctx.user.id,
+          runtime: "opencode",
+          model: "anthropic/claude-sonnet-5"
+        )
+
+      assert {:error, {:permission_policy_unenforceable, "opencode"}} =
+               launch(ctx, agent, %{"default" => "ask"})
+
+      assert Repo.aggregate(Fountain.Conversations.Conversation, :count) == 0
+
+      # A policy that asks nothing of the runtime still launches.
+      assert {:ok, _conv} = launch(ctx, agent, %{"default" => "auto_allow"})
+    end
+
     test "ask is a narrowing of auto_allow but a widening of auto_deny", ctx do
       lenient = insert_agent(user_id: ctx.user.id, permission_policy: %{"Bash" => "auto_allow"})
       strict = insert_agent(user_id: ctx.user.id, permission_policy: %{"Bash" => "auto_deny"})

--- a/apps/fountain/test/fountain/ops_gauges_test.exs
+++ b/apps/fountain/test/fountain/ops_gauges_test.exs
@@ -54,6 +54,44 @@ defmodule Fountain.OpsGaugesTest do
     end
   end
 
+  test "counts non-terminal sandboxes by provider and status" do
+    # The live counterpart to the after-the-fact roll-up: which providers are
+    # charging us right now. Tagged by provider, never by tenant — that would
+    # be one Prometheus series per account.
+    attach([[:fountain, :sandboxes_by_provider]])
+
+    user = insert_verified_user()
+    insert_sandbox(user_id: user.id, provider: "e2b", status: "ready")
+    insert_sandbox(user_id: user.id, provider: "e2b", status: "ready")
+    insert_sandbox(user_id: user.id, provider: "sprites", status: "suspended")
+
+    assert :ok = OpsGauges.emit_telemetry()
+
+    assert_receive {:telemetry, [:fountain, :sandboxes_by_provider], %{count: 2},
+                    %{provider: "e2b", status: "ready"}}
+
+    assert_receive {:telemetry, [:fountain, :sandboxes_by_provider], %{count: 1},
+                    %{provider: "sprites", status: "suspended"}}
+
+    # Zeros for every provider Fountain knows, so a series exists from boot.
+    for provider <- Fountain.Sandbox.known_providers() do
+      assert_receive {:telemetry, [:fountain, :sandboxes_by_provider], %{count: _},
+                      %{provider: ^provider, status: "pending"}}
+    end
+  end
+
+  test "does not count terminal sandboxes — those rows are history, not a signal" do
+    attach([[:fountain, :sandboxes_by_provider]])
+
+    user = insert_verified_user()
+    insert_sandbox(user_id: user.id, provider: "daytona", status: "terminated")
+
+    assert :ok = OpsGauges.emit_telemetry()
+
+    refute_receive {:telemetry, [:fountain, :sandboxes_by_provider], _,
+                    %{provider: "daytona", status: "terminated"}}
+  end
+
   test "counts queued Oban jobs by queue and state" do
     attach([[:fountain, :oban_queue]])
 

--- a/apps/fountain/test/fountain/permissions_test.exs
+++ b/apps/fountain/test/fountain/permissions_test.exs
@@ -170,6 +170,58 @@ defmodule Fountain.PermissionsTest do
     end
   end
 
+  describe "verdict_for_request/2 matches title, then kind" do
+    defp call(options, call), do: %{"options" => options, "toolCall" => call}
+
+    test "the kind matches when the title does not" do
+      # What makes a per-tool policy writable at all against claude-agent-acp:
+      # measured live on 2026-08-22, its title is the command it is about to
+      # run, so only `kind` is the same string twice.
+      params =
+        call([allow_always(), reject_once()], %{"title" => "curl https://x", "kind" => "execute"})
+
+      assert Permissions.verdict_for_request(%{"execute" => "auto_deny"}, params) == "auto_deny"
+
+      assert %{outcome: "selected", optionId: "ro"} =
+               Permissions.outcome(%{"execute" => "auto_deny"}, params)
+    end
+
+    test "an exact title still wins over the kind" do
+      params = call([], %{"title" => "Bash", "kind" => "execute"})
+
+      assert Permissions.verdict_for_request(
+               %{"Bash" => "auto_allow", "execute" => "auto_deny"},
+               params
+             ) == "auto_allow"
+    end
+
+    test "neither key named falls through to the policy's default" do
+      params = call([], %{"title" => "Bash", "kind" => "execute"})
+
+      assert Permissions.verdict_for_request(%{"default" => "ask"}, params) == "ask"
+      assert Permissions.verdict_for_request(%{}, params) == "auto_allow"
+      assert Permissions.verdict_for_request(nil, params) == "auto_allow"
+    end
+
+    test "a value that is not a verdict is not trusted into an allow" do
+      # The changesets reject these, so reaching here means the row was written
+      # around them.
+      params = call([], %{"title" => "Bash", "kind" => "execute"})
+
+      assert Permissions.verdict_for_request(%{"Bash" => "yolo"}, params) == "auto_deny"
+    end
+
+    test "policy_keys/1 is most specific first, and empty without a tool call" do
+      assert Permissions.policy_keys(%{"toolCall" => %{"title" => "Bash", "kind" => "execute"}}) ==
+               ["Bash", "execute"]
+
+      assert Permissions.policy_keys(%{"toolCall" => %{"title" => "read", "kind" => "read"}}) ==
+               ["read"]
+
+      assert Permissions.policy_keys(%{"options" => []}) == []
+    end
+  end
+
   describe "ask" do
     test "is buildable since #940 gave it somewhere to ask" do
       assert "ask" in Permissions.verdicts()

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -574,20 +574,54 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       # is told so it can publish the stage event and arm a timeout.
       assert_receive {:acp, _ref, {:lines, "acp", line}}
       assert line =~ "session/request_permission"
-      assert_receive {:acp, _ref, {:permission_ask, "201", "Bash", options}}
+      assert_receive {:acp, _ref, {:permission_ask, request_id, "Bash", options}}
       assert Enum.map(options, & &1["optionId"]) == ["yes", "no"]
 
+      # The id a client answers with is minted here, not the adapter's own: it
+      # keeps the adapter id in front, then eight random bytes.
+      assert request_id =~ ~r/^201\.[0-9a-f]{16}$/
+
+      # And the block a client renders carries the same minted id, because the
+      # persisted line is the one we build.
+      assert %{"id" => ^request_id} = Jason.decode!(line)
+
       refute_receive {:wrote, _}, 50
+    end
+
+    test "two requests the adapter numbers alike get different ids", ctx do
+      # Measured against claude-agent-acp 0.66 in production (2026-08-22): it
+      # numbers `session/request_permission` from 0 *per turn*, so a
+      # conversation's second request arrives as id 0 again. Left as the public
+      # id, that pairs turn 2's resolution to turn 3's card — the card renders
+      # already-resolved — and lets a stale card answer a tool nobody saw.
+      pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
+      _init = next_write()
+
+      Peer.stdout(pid, permission_line(0, "Bash"))
+      assert_receive {:acp, _ref, {:permission_ask, first, _, _}}
+      assert :ok = Peer.answer_permission(pid, first, "yes")
+      _answer = next_write()
+
+      Peer.stdout(pid, permission_line(0, "Bash"))
+      assert_receive {:acp, _ref, {:permission_ask, second, _, _}}
+
+      refute first == second
+
+      # The stale card misses, so it loses the race rather than answering the
+      # request that is open now.
+      assert {:error, :no_pending_permission} = Peer.answer_permission(pid, first, "yes")
+      assert :ok = Peer.answer_permission(pid, second, "yes")
+      assert %{"id" => 0, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
     end
 
     test "an answer selects the option, and only an offered one", ctx do
       pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
       _init = next_write()
       Peer.stdout(pid, permission_line(202, "Bash"))
-      assert_receive {:acp, _ref, {:permission_ask, "202", _, _}}
+      assert_receive {:acp, _ref, {:permission_ask, request_id, _, _}}
 
-      assert {:error, :unknown_option} = Peer.answer_permission(pid, "202", "made-up")
-      assert :ok = Peer.answer_permission(pid, "202", "yes")
+      assert {:error, :unknown_option} = Peer.answer_permission(pid, request_id, "made-up")
+      assert :ok = Peer.answer_permission(pid, request_id, "yes")
 
       assert %{"id" => 202, "result" => %{"outcome" => outcome}} = next_write()
       assert outcome["outcome"] == "selected"
@@ -600,12 +634,12 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
       _init = next_write()
       Peer.stdout(pid, permission_line(203, "Bash"))
-      assert_receive {:acp, _ref, {:permission_ask, "203", _, _}}
+      assert_receive {:acp, _ref, {:permission_ask, request_id, _, _}}
 
-      assert :ok = Peer.answer_permission(pid, "203", "yes")
+      assert :ok = Peer.answer_permission(pid, request_id, "yes")
       _answer = next_write()
 
-      assert {:error, :no_pending_permission} = Peer.answer_permission(pid, "203", "no")
+      assert {:error, :no_pending_permission} = Peer.answer_permission(pid, request_id, "no")
       refute_receive {:wrote, _}, 50
     end
 
@@ -613,9 +647,9 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
       _init = next_write()
       Peer.stdout(pid, permission_line(204, "Bash"))
-      assert_receive {:acp, _ref, {:permission_ask, "204", _, _}}
+      assert_receive {:acp, _ref, {:permission_ask, request_id, _, _}}
 
-      Peer.deny_permission(pid, "204")
+      Peer.deny_permission(pid, request_id)
 
       assert %{"id" => 204, "result" => %{"outcome" => outcome}} = next_write()
       assert outcome["optionId"] == "no"
@@ -629,7 +663,7 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
         start_peer(ctx,
           permission_policy: %{"Bash" => "ask"},
           pending_permission: %{
-            "request_id" => "205",
+            "request_id" => "205.f00dcafef00dcafe",
             "tool" => "Bash",
             "options" => [%{"optionId" => "yes", "kind" => "allow_once"}]
           }
@@ -637,8 +671,49 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
 
       _init = next_write()
 
-      assert :ok = Peer.answer_permission(pid, "205", "yes")
+      # Answered with the minted id the client is holding; the adapter is
+      # answered with the id it is actually blocked on, read back out of it.
+      assert :ok = Peer.answer_permission(pid, "205.f00dcafef00dcafe", "yes")
       assert %{"id" => 205, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
+    end
+
+    test "a request written down before ids were minted is still answerable", ctx do
+      # Rows written before #955 hold the bare adapter id. A deploy landing on
+      # top of one must not orphan the request it describes.
+      pid =
+        start_peer(ctx,
+          permission_policy: %{"Bash" => "ask"},
+          pending_permission: %{
+            "request_id" => "206",
+            "tool" => "Bash",
+            "options" => [%{"optionId" => "yes", "kind" => "allow_once"}]
+          }
+        )
+
+      _init = next_write()
+
+      assert :ok = Peer.answer_permission(pid, "206", "yes")
+      assert %{"id" => 206, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
+    end
+
+    test "an adapter that names its requests instead of numbering them is answerable", ctx do
+      # `Protocol.response/2` echoes the id's JSON type, so a string id has to
+      # come back a string. Before ids were minted this shape restored as nil
+      # and the request was orphaned on reattach.
+      pid =
+        start_peer(ctx,
+          permission_policy: %{"Bash" => "ask"},
+          pending_permission: %{
+            "request_id" => "req-7.f00dcafef00dcafe",
+            "tool" => "Bash",
+            "options" => [%{"optionId" => "yes", "kind" => "allow_once"}]
+          }
+        )
+
+      _init = next_write()
+
+      assert :ok = Peer.answer_permission(pid, "req-7.f00dcafef00dcafe", "yes")
+      assert %{"id" => "req-7", "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
     end
 
     test "an fs/* request is refused, not ignored", ctx do

--- a/apps/fountain/test/fountain/runtimes/acp_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp_test.exs
@@ -47,6 +47,21 @@ defmodule Fountain.Runtimes.ACPTest do
       end
     end
 
+    test "asks_permission? carries a measurement, and defaults to asking" do
+      # Measured 2026-08-22 against live agents: claude and codex both send
+      # `session/request_permission` per tool call; opencode ran an external
+      # `curl` and an `rm -rf` under an ask-everything policy and sent none.
+      assert ACP.asks_permission?("claude")
+      assert ACP.asks_permission?("codex")
+      refute ACP.asks_permission?("opencode")
+      assert ACP.runtimes_without_permissions() == ["opencode"]
+
+      # Unmeasured is assumed to ask, which is the safe direction to be wrong
+      # in: the first policy written for it gets a loud refusal, not a silent
+      # one.
+      assert ACP.asks_permission?("somethingelse")
+    end
+
     test "a runtime with no adapter entry stays legacy" do
       # For an unconvertible runtime the legacy path is the only path.
       refute ACP.enabled?("somethingelse")

--- a/apps/fountain/test/fountain/runtimes/gemini_session_consolidate_test.exs
+++ b/apps/fountain/test/fountain/runtimes/gemini_session_consolidate_test.exs
@@ -1,0 +1,166 @@
+defmodule Fountain.Runtimes.GeminiSessionConsolidateTest do
+  @moduledoc """
+  The gemini session-store workaround (#659), exercised as the script that
+  actually runs — node against real files on disk, not a re-implementation.
+
+  Fixtures mirror what a live 0.56.0 leaves behind, measured on 2026-08-22:
+  turn 1 writes `session-<ISO minute>-<id8>.jsonl` with the transcript in it,
+  and every `session/load` adds a second file under the *same* naming scheme
+  carrying only a `$set` with gemini's `<session_context>` bootstrap.
+  """
+  use ExUnit.Case, async: true
+
+  @script Path.join([__DIR__, "..", "..", "..", "priv", "gemini-session-consolidate.js"])
+          |> Path.expand()
+
+  @parked "0000-00-00T00-00"
+
+  setup do
+    home = Path.join(System.tmp_dir!(), "gsc-#{System.unique_integer([:positive])}")
+    chats = Path.join([home, ".gemini", "tmp", "projecthash", "chats"])
+    File.mkdir_p!(chats)
+    on_exit(fn -> File.rm_rf(home) end)
+    {:ok, home: home, chats: chats}
+  end
+
+  defp msg(type, text),
+    do: %{"type" => type, "content" => text, "id" => "m#{:rand.uniform(9999)}"}
+
+  # A real session file: metadata line, then message records.
+  defp write_session(chats, name, sid, n_messages) do
+    lines =
+      ([
+         %{
+           "sessionId" => sid,
+           "projectHash" => "projecthash",
+           "startTime" => "2026-08-22T06:22:00Z"
+         }
+       ] ++
+         Enum.flat_map(1..max(n_messages, 0)//1, fn i ->
+           [msg("user", "q#{i}"), msg("gemini", "a#{i}")]
+         end))
+      |> Enum.take(n_messages)
+
+    body = Enum.map_join(lines, "\n", &Jason.encode!/1) <> "\n"
+    File.write!(Path.join(chats, name), body)
+  end
+
+  # What a load leaves: the bootstrap-only `$set` that erases the transcript.
+  defp write_poisoned(chats, name, sid) do
+    lines = [
+      %{"sessionId" => sid, "projectHash" => "projecthash"},
+      %{"$set" => %{"messages" => [%{"type" => "user", "content" => "<session_context>…"}]}}
+    ]
+
+    File.write!(Path.join(chats, name), Enum.map_join(lines, "\n", &Jason.encode!/1) <> "\n")
+  end
+
+  defp run(home, sid) do
+    {out, code} =
+      System.cmd("node", [@script, sid], env: [{"HOME", home}], stderr_to_stdout: true)
+
+    assert code == 0, "script failed: #{out}"
+    Jason.decode!(String.trim(out))
+  end
+
+  defp files(chats), do: chats |> File.ls!() |> Enum.sort()
+
+  test "the script exists where the runtime expects it" do
+    assert File.exists?(@script)
+  end
+
+  test "parks a first-turn session out of the collision path", ctx do
+    sid = "aaaaaaaa-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-2026-08-22T06-22-aaaaaaaa.jsonl", sid, 3)
+
+    assert %{"kept" => 1, "removed" => 0} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-aaaaaaaa.jsonl"]
+  end
+
+  test "keeps the transcript and deletes the poisoned duplicate a load leaves", ctx do
+    # The case that breaks a naive rename: two files, same sessionId, and
+    # gemini would pick the poisoned one because its lastUpdated is later.
+    sid = "bbbbbbbb-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-#{@parked}-bbbbbbbb.jsonl", sid, 5)
+    write_poisoned(ctx.chats, "session-2026-08-22T06-23-bbbbbbbb.jsonl", sid)
+
+    assert %{"kept" => 1, "removed" => 1} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-bbbbbbbb.jsonl"]
+
+    kept = File.read!(Path.join(ctx.chats, "session-#{@parked}-bbbbbbbb.jsonl"))
+    assert kept =~ "q1"
+    refute kept =~ "session_context"
+  end
+
+  test "never touches another session's files", ctx do
+    # One conversation per sandbox today, but a persistent sandbox (ADR 0023)
+    # puts several on one disk and this is the invariant that has to hold.
+    mine = "cccccccc-1111-2222-3333-444444444444"
+    theirs = "dddddddd-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-2026-08-22T06-22-cccccccc.jsonl", mine, 3)
+    write_session(ctx.chats, "session-2026-08-22T06-22-dddddddd.jsonl", theirs, 3)
+
+    assert %{"kept" => 1, "removed" => 0} = run(ctx.home, mine)
+
+    assert files(ctx.chats) == [
+             "session-#{@parked}-cccccccc.jsonl",
+             "session-2026-08-22T06-22-dddddddd.jsonl"
+           ]
+  end
+
+  test "is idempotent — a second run changes nothing", ctx do
+    sid = "eeeeeeee-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-2026-08-22T06-22-eeeeeeee.jsonl", sid, 3)
+
+    run(ctx.home, sid)
+    before = File.read!(Path.join(ctx.chats, "session-#{@parked}-eeeeeeee.jsonl"))
+
+    assert %{"kept" => 1, "removed" => 0} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-eeeeeeee.jsonl"]
+    assert File.read!(Path.join(ctx.chats, "session-#{@parked}-eeeeeeee.jsonl")) == before
+  end
+
+  test "richest wins even when the parked file is the poorer one", ctx do
+    # The discriminating case. If the rule were "prefer whatever is already
+    # parked" this passes anyway, so the parked file is deliberately the one
+    # with *less* content: only a genuine richest-wins comparison keeps the
+    # six-message transcript here.
+    sid = "ffffffff-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-#{@parked}-ffffffff.jsonl", sid, 2)
+    write_session(ctx.chats, "session-2026-08-22T06-30-ffffffff.jsonl", sid, 6)
+
+    assert %{"kept" => 1, "removed" => 1} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-ffffffff.jsonl"]
+
+    kept = File.read!(Path.join(ctx.chats, "session-#{@parked}-ffffffff.jsonl"))
+    assert kept =~ "q3", "kept the poorer file: richest-wins did not apply"
+  end
+
+  test "a tie keeps the already-parked file, so repeat runs are stable", ctx do
+    sid = "77777777-1111-2222-3333-444444444444"
+    write_session(ctx.chats, "session-#{@parked}-77777777.jsonl", sid, 4)
+    write_session(ctx.chats, "session-2026-08-22T06-30-77777777.jsonl", sid, 4)
+
+    assert %{"kept" => 1, "removed" => 1} = run(ctx.home, sid)
+    assert files(ctx.chats) == ["session-#{@parked}-77777777.jsonl"]
+  end
+
+  test "a turn that wrote no session is not an error", ctx do
+    assert %{"kept" => 0, "removed" => 0} =
+             run(ctx.home, "99999999-1111-2222-3333-444444444444")
+  end
+
+  test "a missing .gemini directory is not an error" do
+    home = Path.join(System.tmp_dir!(), "gsc-empty-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(home)
+    on_exit(fn -> File.rm_rf(home) end)
+
+    {out, 0} =
+      System.cmd("node", [@script, "aaaaaaaa-1111-2222-3333-444444444444"],
+        env: [{"HOME", home}],
+        stderr_to_stdout: true
+      )
+
+    assert %{"kept" => 0} = Jason.decode!(String.trim(out))
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/gemini_session_store_test.exs
+++ b/apps/fountain/test/fountain/runtimes/gemini_session_store_test.exs
@@ -1,0 +1,71 @@
+defmodule Fountain.Runtimes.Gemini.SessionStoreTest do
+  @moduledoc """
+  The Elixir half of the #659 workaround: that the script is installed where the
+  turn-end call looks for it, and that a failing sandbox never costs a turn.
+  """
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Fountain.Runtimes.Gemini.SessionStore
+
+  setup :verify_on_exit!
+
+  defp handle, do: %Fountain.Sandbox.Handle{provider: :sprites, name: "test-sprite", private: %{}}
+
+  describe "install/1" do
+    test "writes the real script to the path consolidate/2 runs" do
+      test = self()
+
+      Mimic.expect(Fountain.Sandbox, :write_file, fn _h, path, body ->
+        send(test, {:wrote, path, body})
+        :ok
+      end)
+
+      assert :ok = SessionStore.install(handle())
+      assert_receive {:wrote, path, body}
+      assert path == SessionStore.script_path()
+
+      # The bundled script, not a placeholder — the module reads priv/ at
+      # compile time, so a rename there fails here rather than in a sprite.
+      assert body =~ "gemini-cli#28775"
+      assert body =~ "PARKED_STAMP"
+    end
+  end
+
+  describe "consolidate/2" do
+    test "runs the script for the session, with gemini's HOME" do
+      test = self()
+
+      Mimic.expect(Fountain.Sandbox, :exec, fn _h, cmd, args, opts ->
+        send(test, {:exec, cmd, args, opts[:env]})
+        {:ok, ~s({"kept":1,"removed":1}), 0}
+      end)
+
+      assert :ok = SessionStore.consolidate(handle(), "sess-abc")
+      assert_receive {:exec, "node", [script, "sess-abc"], env}
+      assert script == SessionStore.script_path()
+
+      # Must match Gemini.default_env/2 or the script resolves a different
+      # chats directory than the one gemini actually wrote to.
+      assert {"HOME", "/tmp"} in env
+    end
+
+    test "does nothing without a session id" do
+      Mimic.reject(&Fountain.Sandbox.exec/4)
+      assert :ok = SessionStore.consolidate(handle(), nil)
+      assert :ok = SessionStore.consolidate(handle(), "")
+    end
+
+    test "a non-zero exit does not fail the turn that just succeeded" do
+      Mimic.expect(Fountain.Sandbox, :exec, fn _h, _c, _a, _o -> {:ok, "boom", 1} end)
+      assert :ok = SessionStore.consolidate(handle(), "sess-abc")
+    end
+
+    test "an unreachable sandbox does not fail the turn either" do
+      # Losing the consolidation costs the *next* turn its history, which is
+      # bad; failing this turn on top of that would be worse.
+      Mimic.expect(Fountain.Sandbox, :exec, fn _h, _c, _a, _o -> {:error, :unavailable} end)
+      assert :ok = SessionStore.consolidate(handle(), "sess-abc")
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -753,6 +753,71 @@ defmodule FountainWeb.AdminLiveTest do
       assert html =~ "1c · 1t · 0m"
     end
   end
+
+  describe "AdminLive.Index — sandbox spend by provider" do
+    defp sandbox_run(user, provider, minutes) do
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      {period_start, _} = Fountain.Billing.current_month_range()
+      started = Enum.max([DateTime.add(now, -minutes, :minute), period_start], DateTime)
+
+      insert_sandbox(
+        user_id: user.id,
+        provider: provider,
+        status: "terminated",
+        inserted_at: started,
+        terminated_at: now
+      )
+    end
+
+    test "names each provider and the tenants behind it", %{conn: conn} do
+      admin = insert_admin()
+      user = insert_verified_user()
+      sandbox_run(user, "e2b", 30)
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "Sandbox spend by provider"
+      assert html =~ "e2b"
+      assert html =~ "Billable to us"
+      assert html =~ user.email
+    end
+
+    test "marks a self-hosted runner as not our bill", %{conn: conn} do
+      admin = insert_admin()
+      user = insert_verified_user()
+      sandbox_run(user, "runner", 30)
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "tenant hardware, not our bill"
+    end
+
+    test "reports how much of the paid time was idle", %{conn: conn} do
+      # The number that says whether the bill is avoidable. A sandbox that
+      # never took a turn is 100% idle.
+      admin = insert_admin()
+      user = insert_verified_user()
+      sandbox_run(user, "e2b", 30)
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "idle"
+      assert html =~ "100%"
+      assert html =~ "what a shorter idle timeout would remove"
+    end
+
+    test "renders with no sandbox time at all", %{conn: conn} do
+      admin = insert_admin()
+
+      conn = login_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "No sandbox time this month."
+    end
+  end
 end
 
 defmodule FountainWeb.AdminLiveErrorTest do

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -187,6 +187,7 @@ defmodule FountainWeb.MetricsTest do
         # Fountain.OpsGaugesTest since the poller is off in test
         [:fountain, :conversations],
         [:fountain, :sandboxes],
+        [:fountain, :sandboxes_by_provider],
         [:fountain, :oban_queue],
         # Emitted by Oban itself around every job execution
         [:oban, :job, :stop],

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -180,9 +180,19 @@ defmodule Fountain.Factory do
       %{sprite_name: "test-sprite-#{uniq()}", status: "pending", user_id: user_id}
       |> Map.merge(overrides_map)
 
-    %Sandbox{}
-    |> Sandbox.changeset(attrs)
-    |> Repo.insert!()
+    sandbox =
+      %Sandbox{}
+      |> Sandbox.changeset(attrs)
+      |> Repo.insert!()
+
+    # `inserted_at` is when a sandbox started costing money, so anything
+    # testing spend attribution has to be able to place one in the past. The
+    # changeset does not cast it (nothing in the app sets it), so back-date the
+    # row directly.
+    case Map.get(overrides_map, :inserted_at) do
+      nil -> sandbox
+      at -> sandbox |> Ecto.Changeset.change(inserted_at: at) |> Repo.update!()
+    end
   end
 
   def insert_conversation(overrides \\ %{}) do

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -10,6 +10,7 @@ end
 # seam is Fountain.Sandbox.Sprites (the adapter behind the Fountain.Sandbox
 # facade); the raw SDK copies below it exist only for the adapter's own unit
 # tests and the full-stack provisioning/checkpoint pins.
+Mimic.copy(Fountain.Sandbox)
 Mimic.copy(Fountain.Sandbox.Sprites)
 Mimic.copy(Fountain.AvatarGenerator)
 Mimic.copy(Fountain.Sandbox.Sprites.Client)

--- a/docs/guides/operate/billing.md
+++ b/docs/guides/operate/billing.md
@@ -53,6 +53,8 @@ gated action. An account that cannot is one the backfill missed.
 ## Related
 
 - [Stripe integration guide](../../integrations/stripe.md).
+- [See what sandboxes cost](sandbox-spend.md), for what each account runs and
+  which provider you pay for it.
 - [Run a release task](run-a-release-task.md).
 
 <!-- vale STE.IngForms = YES -->

--- a/docs/guides/operate/observability.md
+++ b/docs/guides/operate/observability.md
@@ -23,6 +23,12 @@ observability pack, built from a real run of the hosted instance.
   into Grafana, then choose your Prometheus datasource. On compose, point any
   Prometheus at the metrics port and import the same file.
 
+One series is worth naming here, because it is the one that maps to money.
+`fountain_sandboxes_by_provider_count` reports how many sandboxes each provider
+holds right now, by status. See
+[See what sandboxes cost](sandbox-spend.md) for the per-account view that goes
+with it.
+
 ## Logs
 
 Logs go to stdout.

--- a/docs/guides/operate/sandbox-spend.md
+++ b/docs/guides/operate/sandbox-spend.md
@@ -1,0 +1,110 @@
+# See what sandboxes cost
+
+Every conversation runs in a sandbox, and a sandbox costs money for as long as
+it runs. This guide shows you how to read that cost per provider, and how to
+say which account it belongs to.
+
+## What Fountain measures
+
+Fountain measures active sandbox time. The clock starts when Fountain creates a
+sandbox, because a provider charges from the moment it starts to build one. The
+clock stops when the sandbox goes away.
+
+Parked time does not count. A suspended sandbox scales to zero and costs almost
+nothing. See
+[Change sandbox lifetimes](sandbox-lifetime.md) for what parks a sandbox.
+
+Fountain cuts every number to the period you ask about. A sandbox that spans
+the end of a month gives each month the time it ran in that month. A sandbox
+that has not stopped gives you the time up to now. This is what makes a month
+of Fountain numbers comparable with a month of provider invoices.
+
+## Idle time, and why it is the number to look at
+
+A sandbox that nobody prompts still runs, and a provider still charges full
+rate for it. So idle time counts as active time. Fountain also reports it on
+its own, because it is the part of the bill you can remove.
+
+Busy time is the time with a turn in flight. Idle time is the rest. Together
+they add up to the active hours. Read a card that says 40 hours, 36 of them
+idle, as agents that sat at a prompt. The idle timeout is too long. See
+[Change sandbox lifetimes](sandbox-lifetime.md) to shorten it.
+
+Two conversations that prompt the same sandbox at the same moment make one
+busy sandbox, not two. Fountain counts the overlap once.
+
+## Read it in the admin panel
+
+Sign in as an admin and open `/admin`. The **Sandbox spend by provider** panel
+shows one card for each provider. Each card gives the active hours, the sandbox
+count, how many accounts are behind it, and the idle hours inside that total.
+The idle figure turns amber above 50%. Below the cards, **Who it belongs to**
+names the accounts with the most hours, each with its own idle share.
+
+The panel is there whether or not you turn billing on. A self-hosted instance <!-- vale disable-line STE.IngForms -->
+still pays a provider.
+
+## What each provider means for your bill
+
+| Provider | Who pays |
+|---|---|
+| `sprites` | You. Time here lands on your Sprites invoice. |
+| `e2b` | You. Time here lands on your E2B invoice. |
+| `daytona` | You. Time here lands on your Daytona invoice. |
+| `runner` | The account that owns the machine. A [self-hosted runner](../../integrations/runners.md) runs on hardware you do not pay for. |
+
+The **Billable to us** line adds up only the first three. The panel shows
+runner hours so the picture is complete. It keeps them out of that total so the
+total stays true.
+
+## Read one account's own view
+
+Each account sees its own sandbox minutes on `/account/billing`, split by
+provider. The same numbers come back from the API.
+
+```bash
+curl -sS https://your-instance/api/account/billing \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY"
+```
+
+The `usage.sandbox_minutes_by_provider` field holds the split. A provider the
+account did not use is absent rather than zero.
+
+## Watch it live
+
+The Prometheus endpoint exports
+`fountain_sandboxes_by_provider_count`, tagged by provider and status. Use it
+to see how many sandboxes each provider runs right now. It carries no
+account tag, because one time series per account would grow without a bound.
+Per-account numbers belong in the admin panel and the API, where they are a
+column.
+
+See [Wire up observability](observability.md) for how to scrape the endpoint.
+
+## When to distrust the parked figures
+
+Fountain writes a sandbox row synchronously, and cannot lose it. The suspend
+and resume records that mark parked time are different. Fountain writes those
+best-effort on purpose, because a metering problem must not fail somebody's <!-- vale disable-line STE.IngForms -->
+conversation. A database problem can drop one.
+
+A dropped suspend record makes parked time look like run time, and Fountain
+charges the account for it. A dropped resume record does the opposite. Neither
+one is silent. Each drop increments the `fountain_usage_dropped_count` metric.
+Read that metric for the period you want. A count above zero says the parked
+figures rest on an incomplete record. Treat that period as approximate.
+
+## What these numbers are not
+
+They are hours, not money. Providers price by machine size and by contract, and
+Fountain holds no rate card. Multiply the hours by the rate you pay.
+
+They also cover sandboxes only. Model inference runs on your users' own
+credentials and never reaches a Fountain invoice.
+
+## Related
+
+- [Start billing](billing.md), to charge for what you measure here. <!-- vale disable-line STE.IngForms -->
+- [Change sandbox lifetimes](sandbox-lifetime.md), the main lever on the total.
+- [About sandboxes](../../concepts/sandboxes.md), for what a sandbox is.
+- [Wire up observability](observability.md), for the metrics endpoint.

--- a/docs/integrations/adding-a-sandbox-provider.md
+++ b/docs/integrations/adding-a-sandbox-provider.md
@@ -146,5 +146,17 @@ it passed.
 
 Two things remain after that. The provider's key goes to the Infisical prod
 project, which syncs it into `fountain-secrets` and reloads the deployment on
-its own. The image needs a rebuild story, and #692 tracks how to automate
-that.
+its own. And the image needs a rebuild, because the agent CLIs in it go stale
+in weeks.
+
+The `Sandbox images` workflow owns the rebuild. Give the new provider a
+`scripts/sandbox-image/build-<provider>.sh` that rebuilds the image and then
+smokes it. Add a matrix entry, so that `docker build` proves the Dockerfile on
+the runner first. Then add a job that runs the script with the account key as
+a repository secret. That key must belong to the account prod uses. An image
+that another account builds is not visible to prod.
+
+Every one of those scripts ships `scripts/sandbox-image/smoke.sh` into the new
+sandbox and reads its verdict. Keep the checks in that one file. It is the
+statement of what an image must give the provision pipeline, and it holds each
+provider to the same contract.

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -33,9 +33,28 @@ The stock image carries no agent CLI. Build the reference snapshot once for
 each organization.
 
 ```bash
-cd images/daytona
-daytona snapshot create fountain --dockerfile Dockerfile
+DAYTONA_API_KEY=... scripts/sandbox-image/build-daytona.sh
 ```
+
+The script sends the content of `images/daytona/Dockerfile` to the snapshot
+API and waits for the build to reach `active`. Then it creates one sandbox
+from the new snapshot. It checks the shape that the provision pipeline
+assumes, then it destroys the sandbox. `DAYTONA_SNAPSHOT` selects a different
+snapshot name.
+
+A snapshot name is unique for each organization, and Daytona has no rename. So
+a rebuild of the name that an instance points at is a delete and a create. In
+the minutes between them, the organization has no snapshot of that name. A
+conversation that starts on Daytona in that window cannot create its sandbox.
+Sandboxes that already exist keep the copy that they started from.
+
+CI runs the same script. The `Sandbox images` workflow rebuilds the snapshot
+when `images/daytona/` changes, once each week for the agent CLI versions, and
+on request. It first builds the same Dockerfile with `docker build` on the
+runner. That gate catches an upstream break before the delete opens the window
+above. The workflow needs a `DAYTONA_API_KEY` repository secret. That key must
+belong to the account the instance uses. A snapshot that another organization
+builds is not visible to the instance.
 
 ## How the contract maps
 

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -30,11 +30,25 @@ The stock `base` template carries no agent CLI. Build the reference template
 once for each account.
 
 ```bash
-cd images/e2b
-e2b template build --name fountain --dockerfile e2b.Dockerfile
+E2B_API_KEY=... scripts/sandbox-image/build-e2b.sh
 ```
 
-It recreates the sandbox shape that the provision pipeline assumes. That is a
+The script runs `e2b template create fountain` against `images/e2b/`. Then it
+creates one sandbox from the new template. It checks the shape that the
+provision pipeline assumes, then it destroys the sandbox. `E2B_TEMPLATE`
+selects a different template name.
+
+`e2b template create` takes the name and rebuilds that template in place. So
+the template id that an instance points at stays the same. Sandboxes that
+already run keep the copy that they started from.
+
+CI runs the same script. The `Sandbox images` workflow rebuilds the template
+when `images/e2b/` changes, once each week for the agent CLI versions, and on
+request. It needs an `E2B_API_KEY` repository secret. That key must belong to
+the account the instance uses. A template that another account builds is not
+visible to the instance.
+
+The image recreates the sandbox shape that the provision pipeline assumes. That is a
 `sprite` user with passwordless sudo, `/home/sprite`, node, npm, bun, git and
 the four agent CLIs. So no provision code exists for one provider alone.
 

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -33,6 +33,7 @@ defmodule Fountain.Billing do
 
   alias Fountain.Accounts.User
   alias Fountain.Audit
+  alias Fountain.Billing.SandboxUsage
   alias Fountain.Billing.UsageEvent
   alias Fountain.Repo
 
@@ -1547,42 +1548,72 @@ defmodule Fountain.Billing do
     still accrue sandbox minutes; excluding them makes the two numbers
     diverge for exactly the accounts where provisioning is failing.
   - `:turns` — count of `turn_started` events
-  - `:sandbox_minutes` — total wall-clock sandbox time in minutes, derived
-    from `duration_ms` metadata on `sandbox_terminated` events, minus any
-    parked interval bracketed by `sandbox_suspended`/`sandbox_resumed` (or, for
-    a sandbox that parks and is torn down without ever waking again,
-    `sandbox_suspended` paired with the terminated event itself) (#665).
+  - `:sandbox_minutes` — active sandbox time in minutes inside the period,
+    parked time excluded. Computed by `Fountain.Billing.SandboxUsage` from the
+    sandbox rows themselves, clipped to the period: a sandbox that spans a
+    month boundary contributes to each month what it ran in that month, and
+    one still running contributes everything up to now.
+  - `:sandbox_minutes_by_provider` — the same minutes split per sandbox
+    provider, `%{provider => minutes}`. Providers the tenant did not use are
+    absent. Minutes on different providers are bought at different prices, so
+    this split is what makes the total attributable to a cost.
   """
   @spec usage_summary(binary(), DateTime.t(), DateTime.t()) ::
-          %{conversations: non_neg_integer(), turns: non_neg_integer(), sandbox_minutes: float()}
+          %{
+            conversations: non_neg_integer(),
+            turns: non_neg_integer(),
+            sandbox_minutes: float(),
+            sandbox_minutes_by_provider: %{optional(String.t()) => float()}
+          }
   def usage_summary(user_id, %DateTime{} = period_start, %DateTime{} = period_end) do
     events =
       from(e in UsageEvent,
         where:
           e.user_id == ^user_id and
             e.inserted_at >= ^period_start and
-            e.inserted_at < ^period_end
+            e.inserted_at < ^period_end and
+            e.event_type in ["sandbox_provisioned", "sandbox_provision_failed", "turn_started"],
+        select: e.event_type
       )
       |> Repo.all()
 
     conversations =
-      Enum.count(events, &(&1.event_type in ["sandbox_provisioned", "sandbox_provision_failed"]))
+      Enum.count(events, &(&1 in ["sandbox_provisioned", "sandbox_provision_failed"]))
 
-    turns = Enum.count(events, &(&1.event_type == "turn_started"))
+    turns = Enum.count(events, &(&1 == "turn_started"))
 
-    %{conversations: conversations, turns: turns, sandbox_minutes: sandbox_minutes(events)}
+    seconds_by_provider = SandboxUsage.for_user(user_id, period_start, period_end)
+
+    %{
+      conversations: conversations,
+      turns: turns,
+      # Rounded once, from the total — summing rounded per-provider minutes
+      # would let the parts disagree with the whole.
+      sandbox_minutes:
+        seconds_by_provider |> Map.values() |> Enum.sum() |> SandboxUsage.minutes(),
+      sandbox_minutes_by_provider:
+        Map.new(seconds_by_provider, fn {provider, seconds} ->
+          {provider, SandboxUsage.minutes(seconds)}
+        end)
+    }
   end
 
   @doc """
   `usage_summary/3` for every user at once, in one query — for the admin view,
   which refreshes on a timer and must not run a query per user.
 
-  Returns `%{user_id => %{conversations: n, turns: n, sandbox_minutes: f}}`;
-  users with no events in the period are absent.
+  Returns `%{user_id => %{conversations: n, turns: n, sandbox_minutes: f,
+  sandbox_minutes_by_provider: %{provider => f}}}`; users with neither events
+  nor sandbox time in the period are absent.
   """
   @spec usage_summaries(DateTime.t(), DateTime.t()) :: %{optional(binary()) => map()}
   def usage_summaries(%DateTime{} = period_start, %DateTime{} = period_end) do
-    empty = %{conversations: 0, turns: 0, sandbox_minutes: 0.0}
+    empty = %{
+      conversations: 0,
+      turns: 0,
+      sandbox_minutes: 0.0,
+      sandbox_minutes_by_provider: %{}
+    }
 
     counted =
       from(e in UsageEvent,
@@ -1611,80 +1642,109 @@ defmodule Fountain.Billing do
         Map.put(acc, user_id, summary)
       end)
 
-    # Separate pass, in its own (still single) query: pairing suspend/resume
-    # intervals against a sandbox's terminated duration (#665) needs the raw
-    # per-sandbox event timeline, which a `sum(duration_ms)` aggregate throws
-    # away. These three event types are a small slice of `usage_events`
-    # compared to `turn_started`, so pulling their rows is cheap next to the
-    # one-query-per-admin-refresh constraint above.
-    from(e in UsageEvent,
-      where:
-        e.inserted_at >= ^period_start and e.inserted_at < ^period_end and
-          e.event_type in ["sandbox_suspended", "sandbox_resumed", "sandbox_terminated"]
-    )
-    |> Repo.all()
-    |> Enum.group_by(& &1.user_id)
-    |> Enum.reduce(counted, fn {user_id, user_events}, acc ->
+    # Sandbox minutes come from the sandbox rows, not from these events — the
+    # period-clipped, per-provider computation in `SandboxUsage`, which is two
+    # more queries for every user at once rather than one per user.
+    period_start
+    |> SandboxUsage.attribution(period_end)
+    |> SandboxUsage.by_user()
+    # Sandboxes whose owner has been deleted keep their seconds under a `nil`
+    # owner in the provider report; here there is no user row to hang them on.
+    |> Enum.reject(fn {user_id, _} -> is_nil(user_id) end)
+    |> Enum.reduce(counted, fn {user_id, seconds_by_provider}, acc ->
       summary = Map.get(acc, user_id, empty)
-      Map.put(acc, user_id, %{summary | sandbox_minutes: sandbox_minutes(user_events)})
+
+      Map.put(acc, user_id, %{
+        summary
+        | sandbox_minutes:
+            seconds_by_provider |> Map.values() |> Enum.sum() |> SandboxUsage.minutes(),
+          sandbox_minutes_by_provider:
+            Map.new(seconds_by_provider, fn {provider, seconds} ->
+              {provider, SandboxUsage.minutes(seconds)}
+            end)
+      })
     end)
   end
 
-  # Shared by usage_summary/3 (one user's events) and usage_summaries/2 (one
-  # user's slice of the all-users pull) — sums sandbox_terminated's
-  # duration_ms, minus whatever of that span was parked rather than running.
-  defp sandbox_minutes(events) do
-    parked_ms_by_sandbox = parked_ms_by_sandbox(events)
+  # ─── Provider spend attribution ─────────────────────────────────────────────
 
-    events
-    |> Enum.filter(&(&1.event_type == "sandbox_terminated"))
-    |> Enum.reduce(0.0, fn ev, acc ->
-      ms =
-        get_in(ev.metadata, ["duration_ms"]) ||
-          get_in(ev.metadata, [:duration_ms]) || 0
+  @doc """
+  Sandbox time per provider for a period, and who it belongs to — the number to
+  hold a Sprites, E2B or Daytona invoice next to.
 
-      parked_ms = Map.get(parked_ms_by_sandbox, ev.resource_id, 0)
-      acc + max(ms - parked_ms, 0) / 60_000.0
-    end)
+  Options:
+    * `:period` — `{period_start, period_end}`, default the current month
+    * `:top` — how many tenants `:top_tenants` names (default 10)
+    * `:now` — pins the clock (tests)
+
+  Returns:
+    * `:period_start` / `:period_end` — the window these numbers cover
+    * `:by_provider` — `%{provider => %{active_seconds, busy_seconds,
+      idle_seconds, sandboxes, users}}`, parked time already excluded
+    * `:platform_seconds` — seconds on providers Fountain pays for. Self-hosted
+      runners (decisions/0022) run on the tenant's own machine, so they appear
+      in `:by_provider` but deliberately not in this total
+    * `:platform_idle_seconds` — the part of `:platform_seconds` with no turn
+      in flight. This is the number a shorter idle timeout removes, so it is
+      the one to read before changing anything about the bill
+    * `:top_tenants` — the accounts behind that total, biggest first, each with
+      its `email` (`nil` once the account is deleted — the seconds were still
+      paid for, they are simply no longer attributable)
+    * `:attribution` — every per-tenant row the totals were built from
+
+  Deliberately no money: prices are per-provider, per-machine-size and
+  negotiated, and none of them are in this codebase. A made-up rate would make
+  this look authoritative when it is not — multiply outside, against the rate
+  card you actually pay.
+  """
+  @spec provider_spend(keyword()) :: %{
+          period_start: DateTime.t(),
+          period_end: DateTime.t(),
+          by_provider: map(),
+          platform_seconds: non_neg_integer(),
+          platform_idle_seconds: non_neg_integer(),
+          top_tenants: [map()],
+          attribution: [SandboxUsage.row()]
+        }
+  def provider_spend(opts \\ []) do
+    {period_start, period_end} = Keyword.get(opts, :period) || current_month_range()
+
+    attribution_opts =
+      case Keyword.fetch(opts, :now) do
+        {:ok, now} -> [now: now]
+        :error -> []
+      end
+
+    rows = SandboxUsage.attribution(period_start, period_end, attribution_opts)
+    paid = Enum.filter(rows, &SandboxUsage.platform_cost?(&1.provider))
+
+    %{
+      period_start: period_start,
+      period_end: period_end,
+      by_provider: SandboxUsage.by_provider(rows),
+      platform_seconds: paid |> Enum.map(& &1.active_seconds) |> Enum.sum(),
+      platform_idle_seconds: paid |> Enum.map(& &1.idle_seconds) |> Enum.sum(),
+      top_tenants: top_tenants(paid, Keyword.get(opts, :top, 10)),
+      attribution: rows
+    }
   end
 
-  # A sandbox's parked time, in milliseconds, keyed by resource_id (the
-  # sandbox id). Pairs each `sandbox_suspended` with the `sandbox_resumed` (or,
-  # failing that, the `sandbox_terminated`) that closes it, in event order —
-  # a `sandbox_suspended` with neither in this event set is still parked as of
-  # `period_end` and contributes nothing yet, matching `sandbox_terminated`'s
-  # own absence from the minutes total until it fires.
-  defp parked_ms_by_sandbox(events) do
-    events
-    |> Enum.filter(
-      &(&1.event_type in ["sandbox_suspended", "sandbox_resumed", "sandbox_terminated"])
-    )
-    |> Enum.group_by(& &1.resource_id)
-    |> Map.new(fn {resource_id, resource_events} ->
-      parked_ms =
-        resource_events
-        |> Enum.sort_by(& &1.inserted_at, DateTime)
-        |> sum_parked_intervals()
+  # One email lookup for the whole list rather than one per row — this renders
+  # on the admin panel's ten-second refresh.
+  defp top_tenants(rows, limit) do
+    top = rows |> Enum.sort_by(& &1.active_seconds, :desc) |> Enum.take(limit)
 
-      {resource_id, parked_ms}
-    end)
-  end
+    emails =
+      top
+      |> Enum.map(& &1.user_id)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+      |> case do
+        [] -> %{}
+        ids -> Repo.all(from u in User, where: u.id in ^ids, select: {u.id, u.email}) |> Map.new()
+      end
 
-  defp sum_parked_intervals(sorted_events) do
-    {total_ms, _suspended_since} =
-      Enum.reduce(sorted_events, {0, nil}, fn
-        %{event_type: "sandbox_suspended", inserted_at: at}, {total_ms, nil} ->
-          {total_ms, at}
-
-        %{event_type: type, inserted_at: at}, {total_ms, since}
-        when type in ["sandbox_resumed", "sandbox_terminated"] and not is_nil(since) ->
-          {total_ms + DateTime.diff(at, since, :millisecond), nil}
-
-        _event, acc ->
-          acc
-      end)
-
-    total_ms
+    Enum.map(top, &Map.put(&1, :email, Map.get(emails, &1.user_id)))
   end
 
   # ─── Admin billing overview (#286) ──────────────────────────────────────────

--- a/ee/lib/fountain/billing/sandbox_usage.ex
+++ b/ee/lib/fountain/billing/sandbox_usage.ex
@@ -1,0 +1,437 @@
+defmodule Fountain.Billing.SandboxUsage do
+  @moduledoc """
+  Active sandbox seconds, split by tenant and by provider, clipped to a period.
+
+  Fountain pays Sprites, E2B and Daytona for the seconds its tenants' sandboxes
+  are running (ADR 0005, ADR 0018). This module answers the question that turns
+  one of those invoices into an internal number: *which tenant, on which
+  provider, ran how long inside this period?*
+
+  ## Where the numbers come from
+
+  The `sandboxes` table is the authority, not `usage_events`. A sandbox row
+  carries the four facts an interval needs — `provider`, `user_id`,
+  `inserted_at` and `terminated_at` — it is written by the one choke point
+  every status change goes through (`Conversations.update_sandbox/2`), and it
+  is never pruned. `usage_events` supplies exactly one thing on top: the
+  `sandbox_suspended` / `sandbox_resumed` pairs that say when a sandbox was
+  parked rather than running.
+
+  Billing starts at `inserted_at`, not at the moment the sandbox reported
+  ready: a provider charges from the moment provisioning begins, which is the
+  same basis `Fountain.Quotas` counts on.
+
+  ## Clipping, and why it matters
+
+  Every interval is intersected with `[period_start, period_end)`:
+
+    * a sandbox that spans a month boundary contributes to each month only what
+      it actually ran in that month;
+    * a sandbox still running at `period_end` contributes everything up to
+      `period_end`, rather than nothing.
+
+  Both were wrong before. Minutes accrued only when a sandbox was torn down and
+  the whole lifetime landed in whichever period the teardown happened to fall
+  in, so a long-lived agent reported zero for months and then a spike, and no
+  month's total could be reconciled against that month's invoice. Clipping is
+  what makes these numbers add up to something a provider bill can be checked
+  against.
+
+  ## Parked time
+
+  Time between `sandbox_suspended` and the `sandbox_resumed` that closes it is
+  subtracted: a parked sandbox is scaled to zero and costs ~nothing
+  (decisions/0017). A suspend still open at the end of the interval is closed
+  by the sandbox's own end, or by `period_end`.
+
+  **The interval is durable; the discount is not.** A sandbox row is written
+  synchronously and cannot be lost, but `Billing.record_usage/5` is
+  deliberately best-effort — metering must never be able to fail a
+  conversation (#503) — so the suspend/resume rows this subtraction pairs on
+  can be dropped. A dropped `sandbox_suspended` bills parked time as running;
+  a dropped `sandbox_resumed` treats a woken sandbox as parked until it dies.
+  Neither can crash a report and neither is silent: every drop increments
+  `[:fountain, :usage, :dropped]`. A non-zero count on that counter over a
+  period means that period's parked figures rest on an incomplete record, and
+  the numbers here should be read as approximate until it is back to zero.
+
+  ## Idle time
+
+  A sandbox nobody is prompting still runs and is still charged at full rate,
+  so idle time counts as active — that is what the invoice says. It is also
+  reported on its own, because it is the part that a shorter idle timeout can
+  remove (decisions/0017, `docs/guides/operate/sandbox-lifetime.md`), and an
+  hours total that cannot separate work from waiting says nothing about
+  whether the bill is avoidable.
+
+  Busy time is the union of the sandbox's turn intervals (`turns.started_at`
+  to `turns.ended_at`), not their sum: two conversations on one sandbox
+  prompting at once is one busy sandbox, not two. A turn still running closes
+  at the same ceiling everything else does. So
+
+      active = busy + idle
+
+  by construction, with `busy` capped at `active` so an odd row cannot produce
+  negative idle.
+
+  ## What a provider column does and does not mean
+
+  `runner` is a tenant's own machine (decisions/0022) — real sandbox time, zero
+  platform spend. It is reported so the hours are complete, and
+  `platform_cost?/1` marks the providers whose seconds Fountain actually pays
+  for. Do not sum across providers and call the result cost: an E2B second and
+  a Sprites second are bought at different prices, which is the whole reason
+  this module reports them apart.
+
+  Seconds whose owner has been deleted stay in the totals under a `nil`
+  `user_id` (account deletion nilifies the column rather than dropping the row,
+  decisions/0009). The platform still paid for them; they are simply no longer
+  attributable.
+
+  ## Cost
+
+  Two queries: the sandbox rows overlapping the period, and the park events for
+  those rows. Pairing suspends with resumes needs the per-sandbox timeline, so
+  the folding happens in Elixir — the same trade `Billing.usage_summaries/2`
+  already makes, and on a strictly smaller set of rows.
+  """
+
+  import Ecto.Query
+
+  alias Fountain.Billing.UsageEvent
+  alias Fountain.Conversations.Conversation
+  alias Fountain.Conversations.Sandbox
+  alias Fountain.Conversations.Turn
+  alias Fountain.Repo
+
+  @terminal ~w(terminated failed)
+  @park_events ~w(sandbox_suspended sandbox_resumed)
+
+  # Providers whose seconds land on a bill Fountain pays. `runner` is the
+  # tenant's own hardware and is deliberately absent — see the moduledoc.
+  @platform_paid ~w(sprites e2b daytona)
+
+  @typedoc """
+  One tenant's time on one provider inside the period.
+
+  `active_seconds` is what the provider charges for. `busy_seconds` is the part
+  of it with a turn in flight and `idle_seconds` the rest; the two add up to
+  `active_seconds`.
+
+  `user_id` is `nil` for sandboxes whose owner has been deleted.
+  """
+  @type row :: %{
+          user_id: binary() | nil,
+          provider: String.t(),
+          active_seconds: non_neg_integer(),
+          busy_seconds: non_neg_integer(),
+          idle_seconds: non_neg_integer(),
+          sandboxes: pos_integer()
+        }
+
+  @doc """
+  Active seconds per `{user_id, provider}` over `[period_start, period_end)`.
+
+  Pass `user_id: id` to scope to a single tenant — the same computation, one
+  tenant's rows. `:now` pins the clock (tests).
+
+  A still-running sandbox accrues only up to *now*, never to a `period_end`
+  that has not happened yet: asked about the current month, this reports what
+  has been spent so far, not what the month will cost if nothing changes.
+
+  Sorted by provider, then by seconds descending, so the head of the list is
+  the tenant costing the most on each provider.
+  """
+  @spec attribution(DateTime.t(), DateTime.t(), keyword()) :: [row()]
+  def attribution(%DateTime{} = period_start, %DateTime{} = period_end, opts \\ []) do
+    sandboxes = overlapping_sandboxes(period_start, period_end, opts)
+    ceiling = earliest(period_end, Keyword.get(opts, :now) || DateTime.utc_now())
+
+    overlapping =
+      sandboxes
+      |> Enum.map(&{&1, overlap_seconds(&1, period_start, ceiling)})
+      |> Enum.reject(fn {_sandbox, seconds} -> seconds <= 0 end)
+
+    sandboxes_in_period = Enum.map(overlapping, &elem(&1, 0))
+    parked = parked_seconds(sandboxes_in_period, period_start, ceiling)
+    busy = busy_seconds(sandboxes_in_period, period_start, ceiling)
+
+    overlapping
+    |> Enum.group_by(fn {sandbox, _} -> {sandbox.user_id, sandbox.provider} end)
+    |> Enum.map(fn {{user_id, provider}, group} ->
+      {active, busy_total} =
+        Enum.reduce(group, {0, 0}, fn {sandbox, seconds}, {active_acc, busy_acc} ->
+          sandbox_active = max(seconds - Map.get(parked, sandbox.id, 0), 0)
+
+          # Capped per sandbox rather than per group: a single row whose turns
+          # somehow outrun its own active window must not borrow headroom from
+          # a sibling and hide the anomaly.
+          sandbox_busy = min(Map.get(busy, sandbox.id, 0), sandbox_active)
+
+          {active_acc + sandbox_active, busy_acc + sandbox_busy}
+        end)
+
+      %{
+        user_id: user_id,
+        provider: provider,
+        active_seconds: active,
+        busy_seconds: busy_total,
+        idle_seconds: active - busy_total,
+        sandboxes: length(group)
+      }
+    end)
+    |> Enum.sort_by(&{&1.provider, -&1.active_seconds})
+  end
+
+  @doc """
+  Roll `attribution/3` rows up to one entry per provider — the operator's view,
+  and the one to hold a provider invoice next to.
+
+  `users` counts distinct owners; every unattributable sandbox collapses into
+  the single `nil` owner, so it is a floor rather than an exact count when
+  deleted accounts are in the period.
+  """
+  @spec by_provider([row()]) :: %{
+          optional(String.t()) => %{
+            active_seconds: non_neg_integer(),
+            busy_seconds: non_neg_integer(),
+            idle_seconds: non_neg_integer(),
+            sandboxes: non_neg_integer(),
+            users: non_neg_integer()
+          }
+        }
+  def by_provider(rows) when is_list(rows) do
+    rows
+    |> Enum.group_by(& &1.provider)
+    |> Map.new(fn {provider, group} ->
+      {provider,
+       %{
+         active_seconds: group |> Enum.map(& &1.active_seconds) |> Enum.sum(),
+         busy_seconds: group |> Enum.map(& &1.busy_seconds) |> Enum.sum(),
+         idle_seconds: group |> Enum.map(& &1.idle_seconds) |> Enum.sum(),
+         sandboxes: group |> Enum.map(& &1.sandboxes) |> Enum.sum(),
+         users: group |> Enum.map(& &1.user_id) |> Enum.uniq() |> length()
+       }}
+    end)
+  end
+
+  @doc """
+  Roll `attribution/3` rows up to `%{user_id => %{provider => active_seconds}}`
+  — the per-tenant view of the same numbers.
+  """
+  @spec by_user([row()]) :: %{
+          optional(binary() | nil) => %{optional(String.t()) => non_neg_integer()}
+        }
+  def by_user(rows) when is_list(rows) do
+    rows
+    |> Enum.group_by(& &1.user_id)
+    |> Map.new(fn {user_id, group} ->
+      {user_id, Map.new(group, &{&1.provider, &1.active_seconds})}
+    end)
+  end
+
+  @doc """
+  One tenant's active seconds per provider: `%{provider => active_seconds}`.
+
+  Providers the tenant did not use in the period are absent rather than zero —
+  an empty map means no sandbox time at all.
+  """
+  @spec for_user(binary(), DateTime.t(), DateTime.t()) :: %{
+          optional(String.t()) => non_neg_integer()
+        }
+  def for_user(user_id, %DateTime{} = period_start, %DateTime{} = period_end)
+      when is_binary(user_id) do
+    period_start
+    |> attribution(period_end, user_id: user_id)
+    |> Map.new(&{&1.provider, &1.active_seconds})
+  end
+
+  @doc """
+  Does time on this provider land on a bill Fountain pays?
+
+  False for `runner` (the tenant's own machine) and for any provider this
+  build does not know about — a name we cannot price is not a name to assume
+  we are paying for.
+  """
+  @spec platform_cost?(String.t()) :: boolean()
+  def platform_cost?(provider) when is_binary(provider), do: provider in @platform_paid
+
+  @doc "Seconds as minutes, rounded to two places — for display."
+  @spec minutes(non_neg_integer()) :: float()
+  def minutes(seconds) when is_integer(seconds), do: Float.round(seconds / 60, 2)
+
+  @doc "Seconds as hours, rounded to two places — the unit provider invoices use."
+  @spec hours(non_neg_integer()) :: float()
+  def hours(seconds) when is_integer(seconds), do: Float.round(seconds / 3600, 2)
+
+  @doc "Providers whose seconds Fountain pays for, in report order."
+  @spec platform_paid_providers() :: [String.t()]
+  def platform_paid_providers, do: @platform_paid
+
+  # ── internals ───────────────────────────────────────────────────────────────
+
+  defp overlapping_sandboxes(period_start, period_end, opts) do
+    query =
+      from s in Sandbox,
+        where: s.inserted_at < ^period_end,
+        where: is_nil(s.terminated_at) or s.terminated_at >= ^period_start,
+        select: %{
+          id: s.id,
+          user_id: s.user_id,
+          provider: s.provider,
+          status: s.status,
+          inserted_at: s.inserted_at,
+          terminated_at: s.terminated_at,
+          updated_at: s.updated_at
+        }
+
+    query =
+      case Keyword.get(opts, :user_id) do
+        nil -> query
+        user_id -> from s in query, where: s.user_id == ^user_id
+      end
+
+    Repo.all(query)
+  end
+
+  # When the sandbox stopped costing money. `terminated_at` where it is set;
+  # `updated_at` for a terminal row predating the migration that backfilled the
+  # column (the last write such a row ever received); otherwise it is still
+  # running and the ceiling is as far as this report can see.
+  defp effective_end(%{terminated_at: %DateTime{} = at}, _ceiling), do: at
+
+  defp effective_end(%{status: status, updated_at: at}, _ceiling) when status in @terminal,
+    do: at
+
+  defp effective_end(_sandbox, ceiling), do: ceiling
+
+  defp overlap_seconds(sandbox, period_start, ceiling) do
+    span_seconds(sandbox.inserted_at, effective_end(sandbox, ceiling), period_start, ceiling)
+  end
+
+  # An interval intersected with the period, in whole seconds. Negative
+  # intersections (an interval entirely outside the period) clamp to zero.
+  defp span_seconds(from, to, period_start, ceiling) do
+    start = latest(from, period_start)
+    stop = earliest(to, ceiling)
+
+    stop |> DateTime.diff(start, :second) |> max(0)
+  end
+
+  defp earliest(a, b), do: if(DateTime.compare(a, b) == :gt, do: b, else: a)
+  defp latest(a, b), do: if(DateTime.compare(a, b) == :lt, do: b, else: a)
+
+  defp parked_seconds([], _period_start, _ceiling), do: %{}
+
+  defp parked_seconds(sandboxes, period_start, ceiling) do
+    ids = Enum.map(sandboxes, & &1.id)
+
+    events =
+      from(e in UsageEvent,
+        where: e.resource_id in ^ids,
+        where: e.event_type in @park_events,
+        order_by: [asc: e.inserted_at, asc: e.id],
+        select: %{
+          resource_id: e.resource_id,
+          event_type: e.event_type,
+          inserted_at: e.inserted_at
+        }
+      )
+      |> Repo.all()
+      |> Enum.group_by(& &1.resource_id)
+
+    Enum.reduce(sandboxes, %{}, fn sandbox, acc ->
+      case Map.get(events, sandbox.id) do
+        nil -> acc
+        own -> Map.put(acc, sandbox.id, sum_parked(own, sandbox, period_start, ceiling))
+      end
+    end)
+  end
+
+  defp busy_seconds([], _period_start, _ceiling), do: %{}
+
+  defp busy_seconds(sandboxes, period_start, ceiling) do
+    ids = Enum.map(sandboxes, & &1.id)
+
+    # Bounded at the database by the period: `turns` is the largest table in
+    # play here, and only the ones overlapping the window can contribute.
+    turns =
+      from(t in Turn,
+        join: c in Conversation,
+        on: c.id == t.conversation_id,
+        where: c.sandbox_id in ^ids,
+        where: not is_nil(t.started_at),
+        where: t.started_at < ^ceiling,
+        where: is_nil(t.ended_at) or t.ended_at >= ^period_start,
+        select: %{sandbox_id: c.sandbox_id, started_at: t.started_at, ended_at: t.ended_at}
+      )
+      |> Repo.all()
+      |> Enum.group_by(& &1.sandbox_id)
+
+    Enum.reduce(sandboxes, %{}, fn sandbox, acc ->
+      case Map.get(turns, sandbox.id) do
+        nil ->
+          acc
+
+        own ->
+          # A turn with no end is still running, or ended without the row being
+          # written; either way it cannot outlive the sandbox.
+          close = effective_end(sandbox, ceiling)
+
+          seconds =
+            own
+            |> Enum.map(&{&1.started_at, &1.ended_at || close})
+            |> merge_intervals()
+            |> Enum.map(fn {from, to} -> span_seconds(from, to, period_start, ceiling) end)
+            |> Enum.sum()
+
+          Map.put(acc, sandbox.id, seconds)
+      end
+    end)
+  end
+
+  # Union, not sum: two conversations prompting on one sandbox at the same
+  # moment is one busy sandbox. Summing them would let busy exceed active and
+  # report negative idle.
+  defp merge_intervals(intervals) do
+    intervals
+    |> Enum.sort_by(fn {from, _} -> from end, DateTime)
+    |> Enum.reduce([], fn
+      interval, [] ->
+        [interval]
+
+      {from, to}, [{open_from, open_to} | rest] = acc ->
+        if DateTime.compare(from, open_to) == :gt do
+          [{from, to} | acc]
+        else
+          [{open_from, latest(to, open_to)} | rest]
+        end
+    end)
+  end
+
+  # Pairs each suspend with the resume that closes it, in event order, and adds
+  # up the parts of those intervals that fall inside the period. A suspend with
+  # no resume is closed by the sandbox's own end — the sandbox was torn down
+  # while parked, or is parked still.
+  defp sum_parked(events, sandbox, period_start, ceiling) do
+    close = effective_end(sandbox, ceiling)
+
+    {total, open} =
+      Enum.reduce(events, {0, nil}, fn
+        %{event_type: "sandbox_suspended", inserted_at: at}, {total, nil} ->
+          {total, at}
+
+        %{event_type: "sandbox_resumed", inserted_at: at}, {total, since}
+        when not is_nil(since) ->
+          {total + span_seconds(since, at, period_start, ceiling), nil}
+
+        _event, acc ->
+          acc
+      end)
+
+    case open do
+      nil -> total
+      since -> total + span_seconds(since, close, period_start, ceiling)
+    end
+  end
+end

--- a/ee/lib/fountain_web/controllers/billing_api_json.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_json.ex
@@ -16,7 +16,10 @@ defmodule FountainWeb.BillingApiJSON do
         usage: %{
           conversations: usage.conversations,
           turns: usage.turns,
-          sandbox_minutes: Float.round(usage.sandbox_minutes, 2)
+          sandbox_minutes: Float.round(usage.sandbox_minutes, 2),
+          # Which sandbox provider the minutes ran on. Absent providers were
+          # not used; the values sum to `sandbox_minutes`.
+          sandbox_minutes_by_provider: usage.sandbox_minutes_by_provider
         }
       }
     }

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -219,6 +219,15 @@ defmodule FountainWeb.Live.BillingLive do
             <dd class="mt-1 text-2xl font-semibold">{format_minutes(@usage.sandbox_minutes)}</dd>
           </div>
         </dl>
+        <p :if={@usage.sandbox_minutes_by_provider != %{}} class="mt-3 text-xs text-gray-500">
+          Sandbox minutes by provider
+          <span
+            :for={{provider, minutes} <- Enum.sort(@usage.sandbox_minutes_by_provider)}
+            class="ml-2 inline-block rounded bg-gray-100 px-1.5 py-0.5 tabular-nums"
+          >
+            <span class="font-medium text-gray-700">{provider}</span> {format_minutes(minutes)}
+          </span>
+        </p>
       </div>
     </div>
     """

--- a/ee/test/fountain/billing_sandbox_usage_test.exs
+++ b/ee/test/fountain/billing_sandbox_usage_test.exs
@@ -1,0 +1,558 @@
+defmodule Fountain.Billing.SandboxUsageTest do
+  @moduledoc """
+  Provider spend attribution: which tenant, on which provider, ran how long.
+
+  The cases that matter here are the ones the old terminate-only accrual got
+  wrong — a sandbox that outlives the period, one that starts before it, one
+  still running — because those are exactly the sandboxes a provider invoice
+  is mostly made of.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Billing
+  alias Fountain.Billing.SandboxUsage
+  alias Fountain.Billing.UsageEvent
+  alias Fountain.Conversations
+  alias Fountain.Repo
+
+  @period_start ~U[2026-05-01 00:00:00Z]
+  @period_end ~U[2026-06-01 00:00:00Z]
+  # Well past period_end, so the ceiling is the period rather than the clock.
+  @now ~U[2026-07-01 00:00:00Z]
+
+  defp attribution(opts \\ []) do
+    SandboxUsage.attribution(@period_start, @period_end, Keyword.put_new(opts, :now, @now))
+  end
+
+  defp seconds_for(rows, user_id, provider) do
+    case Enum.find(rows, &(&1.user_id == user_id and &1.provider == provider)) do
+      nil -> nil
+      row -> row.active_seconds
+    end
+  end
+
+  defp terminated_sandbox(user, provider, started, ended) do
+    insert_sandbox(
+      user_id: user.id,
+      provider: provider,
+      status: "terminated",
+      inserted_at: started,
+      terminated_at: ended
+    )
+  end
+
+  defp park_event(sandbox, type, at) do
+    Repo.insert!(%UsageEvent{
+      user_id: sandbox.user_id,
+      event_type: type,
+      resource_id: sandbox.id,
+      resource_type: "sandbox",
+      metadata: %{},
+      inserted_at: at
+    })
+  end
+
+  describe "attribution/3" do
+    test "attributes a sandbox's seconds to its owner and its provider" do
+      user = insert_verified_user()
+
+      terminated_sandbox(user, "e2b", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      assert [row] = attribution()
+      assert row.user_id == user.id
+      assert row.provider == "e2b"
+      assert row.active_seconds == 3600
+      assert row.sandboxes == 1
+    end
+
+    test "keeps two providers apart for the same tenant" do
+      user = insert_verified_user()
+
+      terminated_sandbox(user, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:10:00Z])
+      terminated_sandbox(user, "daytona", ~U[2026-05-03 00:00:00Z], ~U[2026-05-03 00:30:00Z])
+
+      rows = attribution()
+
+      assert seconds_for(rows, user.id, "sprites") == 600
+      assert seconds_for(rows, user.id, "daytona") == 1800
+    end
+
+    test "keeps two tenants apart on the same provider" do
+      one = insert_verified_user()
+      two = insert_verified_user()
+
+      terminated_sandbox(one, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:10:00Z])
+      terminated_sandbox(two, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:20:00Z])
+
+      rows = attribution()
+
+      assert seconds_for(rows, one.id, "sprites") == 600
+      assert seconds_for(rows, two.id, "sprites") == 1200
+    end
+
+    test "counts several sandboxes of one tenant as one row with a sandbox count" do
+      user = insert_verified_user()
+
+      terminated_sandbox(user, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:10:00Z])
+      terminated_sandbox(user, "sprites", ~U[2026-05-04 00:00:00Z], ~U[2026-05-04 00:10:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 1200
+      assert row.sandboxes == 2
+    end
+
+    test "counts only the part of a sandbox that ran inside the period" do
+      # Runs from a week before the period to a week into it: the month is
+      # charged for its week, not for the whole fifteen days.
+      user = insert_verified_user()
+
+      terminated_sandbox(user, "sprites", ~U[2026-04-24 00:00:00Z], ~U[2026-05-08 00:00:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 7 * 24 * 3600
+    end
+
+    test "counts a sandbox that outlives the period up to period_end, not beyond" do
+      user = insert_verified_user()
+
+      terminated_sandbox(user, "sprites", ~U[2026-05-30 00:00:00Z], ~U[2026-06-15 00:00:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 2 * 24 * 3600
+    end
+
+    test "counts a sandbox that is still running — the terminate-only gap" do
+      user = insert_verified_user()
+
+      insert_sandbox(
+        user_id: user.id,
+        provider: "sprites",
+        status: "ready",
+        inserted_at: ~U[2026-05-20 00:00:00Z]
+      )
+
+      assert [row] = attribution()
+      assert row.active_seconds == 12 * 24 * 3600
+    end
+
+    test "a still-running sandbox accrues only up to now, never past it" do
+      # Asked about the current month mid-month, the answer is what has been
+      # spent so far — not what the month will cost if nothing changes.
+      user = insert_verified_user()
+
+      insert_sandbox(
+        user_id: user.id,
+        provider: "sprites",
+        status: "ready",
+        inserted_at: ~U[2026-05-20 00:00:00Z]
+      )
+
+      assert [row] =
+               SandboxUsage.attribution(@period_start, @period_end, now: ~U[2026-05-22 00:00:00Z])
+
+      assert row.active_seconds == 2 * 24 * 3600
+    end
+
+    test "ignores a sandbox that ended before the period" do
+      user = insert_verified_user()
+
+      terminated_sandbox(user, "sprites", ~U[2026-04-01 00:00:00Z], ~U[2026-04-02 00:00:00Z])
+
+      assert attribution() == []
+    end
+
+    test "ignores a sandbox that started after the period" do
+      user = insert_verified_user()
+
+      terminated_sandbox(user, "sprites", ~U[2026-06-02 00:00:00Z], ~U[2026-06-03 00:00:00Z])
+
+      assert attribution() == []
+    end
+
+    test "falls back to updated_at for a terminal row with no terminated_at" do
+      # Failed sandboxes never carried a terminated_at before the backfill.
+      # Without the fallback such a row reads as still running and accrues to
+      # the end of every period, forever.
+      user = insert_verified_user()
+
+      sandbox =
+        insert_sandbox(
+          user_id: user.id,
+          provider: "sprites",
+          status: "failed",
+          inserted_at: ~U[2026-05-10 12:00:00Z]
+        )
+
+      Repo.update_all(
+        from(s in Fountain.Conversations.Sandbox, where: s.id == ^sandbox.id),
+        set: [terminated_at: nil, updated_at: ~U[2026-05-10 12:05:00Z]]
+      )
+
+      assert [row] = attribution()
+      assert row.active_seconds == 300
+    end
+
+    test "scopes to one tenant with :user_id" do
+      one = insert_verified_user()
+      two = insert_verified_user()
+
+      terminated_sandbox(one, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:10:00Z])
+      terminated_sandbox(two, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:20:00Z])
+
+      assert [row] = attribution(user_id: one.id)
+      assert row.user_id == one.id
+      assert row.active_seconds == 600
+    end
+  end
+
+  describe "attribution/3 — parked time" do
+    test "subtracts a suspend/resume interval" do
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      park_event(sandbox, "sandbox_suspended", ~U[2026-05-10 12:15:00Z])
+      park_event(sandbox, "sandbox_resumed", ~U[2026-05-10 12:45:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 1800
+    end
+
+    test "closes a suspend that never resumed at the sandbox's own end" do
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      park_event(sandbox, "sandbox_suspended", ~U[2026-05-10 12:30:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 1800
+    end
+
+    test "closes a still-parked sandbox's suspend at the period's end" do
+      user = insert_verified_user()
+
+      sandbox =
+        insert_sandbox(
+          user_id: user.id,
+          provider: "sprites",
+          status: "suspended",
+          inserted_at: ~U[2026-05-29 00:00:00Z]
+        )
+
+      park_event(sandbox, "sandbox_suspended", ~U[2026-05-30 00:00:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 24 * 3600
+    end
+
+    test "clips a parked interval that starts before the period" do
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-04-25 00:00:00Z], ~U[2026-05-03 00:00:00Z])
+
+      park_event(sandbox, "sandbox_suspended", ~U[2026-04-28 00:00:00Z])
+      park_event(sandbox, "sandbox_resumed", ~U[2026-05-02 00:00:00Z])
+
+      # In-period lifetime is 2 days (May 1–3); the first of them was parked.
+      assert [row] = attribution()
+      assert row.active_seconds == 24 * 3600
+    end
+
+    test "never reports negative seconds when parked time covers the whole period" do
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-04-01 00:00:00Z], ~U[2026-06-15 00:00:00Z])
+
+      park_event(sandbox, "sandbox_suspended", ~U[2026-04-02 00:00:00Z])
+      park_event(sandbox, "sandbox_resumed", ~U[2026-06-14 00:00:00Z])
+
+      assert seconds_for(attribution(), user.id, "sprites") == 0
+    end
+  end
+
+  describe "attribution/3 — idle time" do
+    # A sandbox nobody is prompting still costs full price, so it stays in
+    # active. Reporting it separately is what says whether the bill is
+    # avoidable.
+    defp turn(sandbox, user, started_at, ended_at) do
+      agent = insert_agent(user_id: user.id)
+
+      conversation =
+        insert_conversation(user_id: user.id, agent_id: agent.id, sandbox: sandbox)
+
+      {:ok, _} =
+        Conversations._unsafe_create_turn(%{
+          conversation_id: conversation.id,
+          turn_number: System.unique_integer([:positive]),
+          prompt: "hello",
+          status: "completed",
+          started_at: started_at,
+          ended_at: ended_at
+        })
+    end
+
+    test "an hour with a ten-minute turn is fifty minutes idle" do
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      turn(sandbox, user, ~U[2026-05-10 12:10:00Z], ~U[2026-05-10 12:20:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 3600
+      assert row.busy_seconds == 600
+      assert row.idle_seconds == 3000
+    end
+
+    test "a sandbox that never took a turn is entirely idle" do
+      user = insert_verified_user()
+
+      terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      assert [row] = attribution()
+      assert row.busy_seconds == 0
+      assert row.idle_seconds == row.active_seconds
+    end
+
+    test "busy and idle always add up to active" do
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      turn(sandbox, user, ~U[2026-05-10 12:05:00Z], ~U[2026-05-10 12:15:00Z])
+      turn(sandbox, user, ~U[2026-05-10 12:40:00Z], ~U[2026-05-10 12:50:00Z])
+
+      assert [row] = attribution()
+      assert row.busy_seconds + row.idle_seconds == row.active_seconds
+      assert row.busy_seconds == 1200
+    end
+
+    test "overlapping turns on one sandbox count once, not twice" do
+      # Two conversations prompting at the same moment is one busy sandbox.
+      # Summing them would push busy past active and report negative idle.
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      turn(sandbox, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:30:00Z])
+      turn(sandbox, user, ~U[2026-05-10 12:10:00Z], ~U[2026-05-10 12:40:00Z])
+
+      assert [row] = attribution()
+      assert row.busy_seconds == 2400
+      assert row.idle_seconds == 1200
+    end
+
+    test "a turn still running is busy up to the ceiling" do
+      user = insert_verified_user()
+
+      sandbox =
+        insert_sandbox(
+          user_id: user.id,
+          provider: "sprites",
+          status: "ready",
+          inserted_at: ~U[2026-05-31 22:00:00Z]
+        )
+
+      turn(sandbox, user, ~U[2026-05-31 23:00:00Z], nil)
+
+      assert [row] = attribution()
+      assert row.active_seconds == 2 * 3600
+      assert row.busy_seconds == 3600
+      assert row.idle_seconds == 3600
+    end
+
+    test "a turn is clipped to the period, like everything else" do
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-04-30 22:00:00Z], ~U[2026-05-01 02:00:00Z])
+
+      # Runs from an hour before the period into its first hour.
+      turn(sandbox, user, ~U[2026-04-30 23:00:00Z], ~U[2026-05-01 01:00:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 2 * 3600
+      assert row.busy_seconds == 3600
+    end
+
+    test "parked time is neither busy nor idle — it is not paid for" do
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      park_event(sandbox, "sandbox_suspended", ~U[2026-05-10 12:30:00Z])
+      park_event(sandbox, "sandbox_resumed", ~U[2026-05-10 12:45:00Z])
+      turn(sandbox, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:10:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 2700
+      assert row.busy_seconds == 600
+      assert row.idle_seconds == 2100
+    end
+
+    test "never reports negative idle when turns outrun the paid window" do
+      # Defensive: a mostly-parked sandbox whose turn rows say it was busy
+      # throughout. Busy caps at active rather than going through it.
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      park_event(sandbox, "sandbox_suspended", ~U[2026-05-10 12:05:00Z])
+      park_event(sandbox, "sandbox_resumed", ~U[2026-05-10 12:55:00Z])
+      turn(sandbox, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 600
+      assert row.busy_seconds == 600
+      assert row.idle_seconds == 0
+    end
+
+    test "one sandbox's turns do not make another look busy" do
+      user = insert_verified_user()
+
+      busy =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      terminated_sandbox(user, "e2b", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      turn(busy, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:30:00Z])
+
+      rows = attribution()
+
+      assert Enum.find(rows, &(&1.provider == "sprites")).busy_seconds == 1800
+      assert Enum.find(rows, &(&1.provider == "e2b")).busy_seconds == 0
+    end
+  end
+
+  describe "by_provider/1" do
+    test "totals seconds, sandboxes and distinct tenants per provider" do
+      one = insert_verified_user()
+      two = insert_verified_user()
+
+      terminated_sandbox(one, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:10:00Z])
+      terminated_sandbox(two, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:20:00Z])
+      terminated_sandbox(two, "e2b", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:05:00Z])
+
+      totals = attribution() |> SandboxUsage.by_provider()
+
+      # No turns anywhere, so every paid second is idle.
+      assert totals["sprites"] == %{
+               active_seconds: 1800,
+               busy_seconds: 0,
+               idle_seconds: 1800,
+               sandboxes: 2,
+               users: 2
+             }
+
+      assert totals["e2b"] == %{
+               active_seconds: 300,
+               busy_seconds: 0,
+               idle_seconds: 300,
+               sandboxes: 1,
+               users: 1
+             }
+    end
+  end
+
+  describe "platform_cost?/1" do
+    test "the providers Fountain pays for" do
+      assert SandboxUsage.platform_cost?("sprites")
+      assert SandboxUsage.platform_cost?("e2b")
+      assert SandboxUsage.platform_cost?("daytona")
+    end
+
+    test "a self-hosted runner is the tenant's own machine" do
+      refute SandboxUsage.platform_cost?("runner")
+    end
+
+    test "an unknown provider is not assumed to be ours" do
+      refute SandboxUsage.platform_cost?("something-new")
+    end
+  end
+
+  describe "for_user/3" do
+    test "one tenant's seconds per provider" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+
+      terminated_sandbox(user, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:10:00Z])
+      terminated_sandbox(user, "e2b", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:05:00Z])
+      terminated_sandbox(other, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 01:00:00Z])
+
+      assert SandboxUsage.for_user(user.id, @period_start, @period_end) == %{
+               "sprites" => 600,
+               "e2b" => 300
+             }
+    end
+
+    test "is empty for a tenant with no sandbox time" do
+      user = insert_verified_user()
+
+      assert SandboxUsage.for_user(user.id, @period_start, @period_end) == %{}
+    end
+  end
+
+  describe "Billing.provider_spend/1" do
+    test "splits by provider and names the tenants behind the bill" do
+      one = insert_verified_user()
+      two = insert_verified_user()
+
+      terminated_sandbox(one, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 01:00:00Z])
+      terminated_sandbox(two, "e2b", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 00:30:00Z])
+
+      spend = Billing.provider_spend(period: {@period_start, @period_end}, now: @now)
+
+      assert spend.by_provider["sprites"].active_seconds == 3600
+      assert spend.by_provider["e2b"].active_seconds == 1800
+      assert spend.platform_seconds == 5400
+      # Neither sandbox took a turn, so all of it is time we could not justify.
+      assert spend.platform_idle_seconds == 5400
+
+      assert [top, second] = spend.top_tenants
+      assert top.email == one.email
+      assert top.provider == "sprites"
+      assert second.email == two.email
+    end
+
+    test "self-hosted runner hours are reported but are not our bill" do
+      user = insert_verified_user()
+
+      terminated_sandbox(user, "runner", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 01:00:00Z])
+
+      spend = Billing.provider_spend(period: {@period_start, @period_end}, now: @now)
+
+      assert spend.by_provider["runner"].active_seconds == 3600
+      assert spend.platform_seconds == 0
+      assert spend.top_tenants == []
+    end
+
+    test "keeps a deleted account's seconds in the provider total" do
+      # The platform paid for them; they are simply no longer attributable.
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-02 01:00:00Z])
+
+      Repo.update_all(
+        from(s in Fountain.Conversations.Sandbox, where: s.id == ^sandbox.id),
+        set: [user_id: nil]
+      )
+
+      spend = Billing.provider_spend(period: {@period_start, @period_end}, now: @now)
+
+      assert spend.by_provider["sprites"].active_seconds == 3600
+      assert [%{email: nil}] = spend.top_tenants
+    end
+  end
+end

--- a/ee/test/fountain/billing_test.exs
+++ b/ee/test/fountain/billing_test.exs
@@ -79,15 +79,9 @@ defmodule Fountain.BillingTest do
       assert summary.turns == 3
     end
 
-    test "sums duration_ms from sandbox_terminated events into sandbox_minutes", %{user: user} do
-      # 60_000 ms = 1 min, 120_000 ms = 2 min -> total 3.0 minutes
-      insert_event(user, "sandbox_terminated", ~U[2026-05-10 12:00:00Z], %{
-        "duration_ms" => 60_000
-      })
-
-      insert_event(user, "sandbox_terminated", ~U[2026-05-10 12:30:00Z], %{
-        "duration_ms" => 120_000
-      })
+    test "sums the sandboxes' active time into sandbox_minutes", %{user: user} do
+      terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:01:00Z])
+      terminated_sandbox(user, "sprites", ~U[2026-05-10 12:30:00Z], ~U[2026-05-10 12:32:00Z])
 
       summary = Billing.usage_summary(user.id, @period_start, @period_end)
 
@@ -477,7 +471,7 @@ defmodule Fountain.BillingTest do
     end
   end
 
-  describe "usage_summary/3 — sandbox_minutes edge cases" do
+  describe "usage_summary/3 — sandbox_minutes per provider" do
     @period_start ~U[2026-05-01 00:00:00Z]
     @period_end ~U[2026-06-01 00:00:00Z]
 
@@ -485,149 +479,66 @@ defmodule Fountain.BillingTest do
       {:ok, user: insert_verified_user()}
     end
 
-    test "sandbox_minutes defaults to 0 when duration_ms key is absent from metadata", %{
-      user: user
-    } do
-      insert_event(user, "sandbox_terminated", ~U[2026-05-10 12:00:00Z], %{})
+    test "splits the minutes by the provider that ran them", %{user: user} do
+      terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:10:00Z])
+      terminated_sandbox(user, "e2b", ~U[2026-05-11 12:00:00Z], ~U[2026-05-11 12:05:00Z])
 
+      summary = Billing.usage_summary(user.id, @period_start, @period_end)
+
+      assert summary.sandbox_minutes_by_provider == %{"sprites" => 10.0, "e2b" => 5.0}
+    end
+
+    test "the split adds up to the total", %{user: user} do
+      terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:10:00Z])
+      terminated_sandbox(user, "daytona", ~U[2026-05-11 12:00:00Z], ~U[2026-05-11 12:07:00Z])
+
+      summary = Billing.usage_summary(user.id, @period_start, @period_end)
+
+      assert summary.sandbox_minutes == 17.0
+
+      assert summary.sandbox_minutes_by_provider |> Map.values() |> Enum.sum() ==
+               summary.sandbox_minutes
+    end
+
+    test "is empty for a tenant with no sandbox time", %{user: user} do
       summary = Billing.usage_summary(user.id, @period_start, @period_end)
 
       assert summary.sandbox_minutes == 0.0
+      assert summary.sandbox_minutes_by_provider == %{}
     end
 
-    test "sandbox_minutes handles mixed events where some lack duration_ms", %{user: user} do
-      insert_event(user, "sandbox_terminated", ~U[2026-05-10 12:00:00Z], %{
-        "duration_ms" => 60_000
-      })
-
-      insert_event(user, "sandbox_terminated", ~U[2026-05-11 12:00:00Z], %{})
+    test "counts a sandbox still running at the period's end", %{user: user} do
+      # The gap terminate-only accrual left: a long-lived agent reported zero
+      # for months and then a spike in whichever month it happened to die.
+      insert_sandbox(
+        user_id: user.id,
+        provider: "sprites",
+        status: "ready",
+        inserted_at: ~U[2026-05-31 23:00:00Z]
+      )
 
       summary = Billing.usage_summary(user.id, @period_start, @period_end)
 
-      # Only the first event contributes 1 minute; the second defaults to 0
-      assert summary.sandbox_minutes == 1.0
-    end
-  end
-
-  describe "usage_summary/3 — suspend-aware sandbox_minutes (#665)" do
-    @period_start ~U[2026-05-01 00:00:00Z]
-    @period_end ~U[2026-06-01 00:00:00Z]
-    @sandbox_id Ecto.UUID.generate()
-
-    setup do
-      {:ok, user: insert_verified_user()}
+      assert summary.sandbox_minutes == 60.0
     end
 
-    test "subtracts a closed suspend/resume interval from the terminated duration", %{
-      user: user
-    } do
-      # Alive 12:00 -> 13:00 (1h = 3_600_000ms), parked 12:20 -> 12:50 (30min).
-      # Net run time: 30 minutes.
-      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, @sandbox_id)
-      insert_event(user, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, @sandbox_id)
+    test "excludes parked time", %{user: user} do
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
 
-      insert_event(
-        user,
-        "sandbox_terminated",
-        ~U[2026-05-10 13:00:00Z],
-        %{"duration_ms" => 3_600_000},
-        @sandbox_id
-      )
+      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, sandbox.id)
+      insert_event(user, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, sandbox.id)
 
       summary = Billing.usage_summary(user.id, @period_start, @period_end)
 
       assert summary.sandbox_minutes == 30.0
     end
-
-    test "closes a dangling suspend against the terminated event itself", %{user: user} do
-      # A sandbox that parks and is torn down (account deletion, tenant reap)
-      # without ever waking again: no sandbox_resumed at all. The whole parked
-      # span (12:20 -> 13:00, 40 minutes) must come off the hour.
-      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, @sandbox_id)
-
-      insert_event(
-        user,
-        "sandbox_terminated",
-        ~U[2026-05-10 13:00:00Z],
-        %{"duration_ms" => 3_600_000},
-        @sandbox_id
-      )
-
-      summary = Billing.usage_summary(user.id, @period_start, @period_end)
-
-      assert summary.sandbox_minutes == 20.0
-    end
-
-    test "sums multiple park cycles on the same sandbox", %{user: user} do
-      # Two separate suspend/resume cycles of 10 minutes each = 20 minutes
-      # parked out of the hour.
-      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:10:00Z], %{}, @sandbox_id)
-      insert_event(user, "sandbox_resumed", ~U[2026-05-10 12:20:00Z], %{}, @sandbox_id)
-      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:40:00Z], %{}, @sandbox_id)
-      insert_event(user, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, @sandbox_id)
-
-      insert_event(
-        user,
-        "sandbox_terminated",
-        ~U[2026-05-10 13:00:00Z],
-        %{"duration_ms" => 3_600_000},
-        @sandbox_id
-      )
-
-      summary = Billing.usage_summary(user.id, @period_start, @period_end)
-
-      assert summary.sandbox_minutes == 40.0
-    end
-
-    test "never goes negative when parked time would exceed the recorded duration", %{
-      user: user
-    } do
-      insert_event(user, "sandbox_suspended", ~U[2026-05-10 11:00:00Z], %{}, @sandbox_id)
-
-      insert_event(
-        user,
-        "sandbox_terminated",
-        ~U[2026-05-10 13:00:00Z],
-        %{"duration_ms" => 60_000},
-        @sandbox_id
-      )
-
-      summary = Billing.usage_summary(user.id, @period_start, @period_end)
-
-      assert summary.sandbox_minutes == 0.0
-    end
-
-    test "keys parked intervals per sandbox — one sandbox's suspend does not bleed into another's",
-         %{user: user} do
-      other_sandbox_id = Ecto.UUID.generate()
-
-      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, other_sandbox_id)
-      insert_event(user, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, other_sandbox_id)
-
-      insert_event(
-        user,
-        "sandbox_terminated",
-        ~U[2026-05-10 13:00:00Z],
-        %{"duration_ms" => 3_600_000},
-        @sandbox_id
-      )
-
-      summary = Billing.usage_summary(user.id, @period_start, @period_end)
-
-      # The suspend/resume pair belongs to a different sandbox; the terminated
-      # sandbox's full hour still counts.
-      assert summary.sandbox_minutes == 60.0
-    end
-
-    test "a suspend still parked at period end (no resume, no terminated event) contributes nothing",
-         %{user: user} do
-      insert_event(user, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, @sandbox_id)
-
-      summary = Billing.usage_summary(user.id, @period_start, @period_end)
-
-      assert summary.sandbox_minutes == 0.0
-    end
   end
+
+  # The interval arithmetic these used to pin — parked spans, dangling
+  # suspends, per-sandbox keying, never-negative — moved with the computation
+  # into Fountain.Billing.SandboxUsage (billing_sandbox_usage_test.exs), which
+  # exercises it against real sandbox rows rather than hand-written events.
 
   describe "sync_subscription/1 — trial_end nil branch" do
     setup do
@@ -658,32 +569,6 @@ defmodule Fountain.BillingTest do
       }
 
       assert {:error, :user_not_found} = Billing.sync_subscription(event)
-    end
-  end
-
-  describe "usage_summary/3 — atom-key duration_ms metadata" do
-    @period_start ~U[2026-05-01 00:00:00Z]
-    @period_end ~U[2026-06-01 00:00:00Z]
-
-    setup do
-      {:ok, user: insert_verified_user()}
-    end
-
-    test "reads duration_ms from atom-keyed metadata when string key is absent", %{user: user} do
-      # Insert the event directly with atom key in metadata (bypasses Jason decode path)
-      %UsageEvent{}
-      |> UsageEvent.changeset(%{
-        user_id: user.id,
-        event_type: "sandbox_terminated",
-        inserted_at: ~U[2026-05-10 12:00:00Z],
-        metadata: %{duration_ms: 120_000}
-      })
-      |> Repo.insert!()
-
-      summary = Billing.usage_summary(user.id, @period_start, @period_end)
-
-      # 120_000 ms = 2.0 minutes
-      assert summary.sandbox_minutes == 2.0
     end
   end
 
@@ -827,6 +712,18 @@ defmodule Fountain.BillingTest do
       resource_id: resource_id
     })
     |> Repo.insert!()
+  end
+
+  # Sandbox minutes are read off the sandbox rows themselves, so anything
+  # asserting on them has to create one rather than hand-write an event.
+  defp terminated_sandbox(user, provider, started, ended) do
+    insert_sandbox(
+      user_id: user.id,
+      provider: provider,
+      status: "terminated",
+      inserted_at: started,
+      terminated_at: ended
+    )
   end
 
   describe "extend_trial/2" do
@@ -1067,17 +964,28 @@ defmodule Fountain.BillingTest do
       {:ok, _} = Billing.record_usage(a.id, "sandbox_provisioned", nil, nil)
       {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil)
       {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil)
-
-      {:ok, _} =
-        Billing.record_usage(a.id, "sandbox_terminated", nil, nil, %{"duration_ms" => 120_000})
-
       {:ok, _} = Billing.record_usage(b.id, "turn_started", nil, nil)
 
-      now = DateTime.utc_now()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      terminated_sandbox(a, "sprites", DateTime.add(now, -2, :minute), now)
+
       summaries = Billing.usage_summaries(DateTime.add(now, -1, :day), DateTime.add(now, 1, :day))
 
-      assert summaries[a.id] == %{conversations: 1, turns: 2, sandbox_minutes: 2.0}
-      assert summaries[b.id] == %{conversations: 0, turns: 1, sandbox_minutes: 0.0}
+      assert summaries[a.id] == %{
+               conversations: 1,
+               turns: 2,
+               sandbox_minutes: 2.0,
+               sandbox_minutes_by_provider: %{"sprites" => 2.0}
+             }
+
+      assert summaries[b.id] == %{
+               conversations: 0,
+               turns: 1,
+               sandbox_minutes: 0.0,
+               sandbox_minutes_by_provider: %{}
+             }
+
       refute Map.has_key?(summaries, quiet.id)
     end
 
@@ -1096,35 +1004,36 @@ defmodule Fountain.BillingTest do
     test "subtracts parked time per sandbox, per user (#665)" do
       a = insert_verified_user()
       b = insert_verified_user()
-      sandbox_a = Ecto.UUID.generate()
-      sandbox_b = Ecto.UUID.generate()
 
       # a: alive an hour, parked 30 of those minutes -> nets 30.
-      insert_event(a, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, sandbox_a)
-      insert_event(a, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, sandbox_a)
+      sandbox_a =
+        terminated_sandbox(a, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
 
-      insert_event(
-        a,
-        "sandbox_terminated",
-        ~U[2026-05-10 13:00:00Z],
-        %{"duration_ms" => 3_600_000},
-        sandbox_a
-      )
+      insert_event(a, "sandbox_suspended", ~U[2026-05-10 12:20:00Z], %{}, sandbox_a.id)
+      insert_event(a, "sandbox_resumed", ~U[2026-05-10 12:50:00Z], %{}, sandbox_a.id)
 
       # b: alive an hour, never suspended -> nets the full 60.
-      insert_event(
-        b,
-        "sandbox_terminated",
-        ~U[2026-05-10 13:00:00Z],
-        %{"duration_ms" => 3_600_000},
-        sandbox_b
-      )
+      terminated_sandbox(b, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
 
       summaries =
         Billing.usage_summaries(~U[2026-05-01 00:00:00Z], ~U[2026-06-01 00:00:00Z])
 
       assert summaries[a.id].sandbox_minutes == 30.0
       assert summaries[b.id].sandbox_minutes == 60.0
+    end
+
+    test "splits each user's minutes by provider" do
+      a = insert_verified_user()
+
+      terminated_sandbox(a, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:10:00Z])
+      terminated_sandbox(a, "runner", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:04:00Z])
+
+      summaries = Billing.usage_summaries(~U[2026-05-01 00:00:00Z], ~U[2026-06-01 00:00:00Z])
+
+      assert summaries[a.id].sandbox_minutes_by_provider == %{
+               "sprites" => 10.0,
+               "runner" => 4.0
+             }
     end
   end
 

--- a/ee/test/fountain_web/controllers/billing_api_controller_test.exs
+++ b/ee/test/fountain_web/controllers/billing_api_controller_test.exs
@@ -65,8 +65,42 @@ defmodule FountainWeb.BillingApiControllerTest do
       assert body["data"]["usage"]["conversations"] == 0
       assert body["data"]["usage"]["turns"] == 0
       assert body["data"]["usage"]["sandbox_minutes"] == 0
+      assert body["data"]["usage"]["sandbox_minutes_by_provider"] == %{}
       assert body["data"]["period"]["start"]
       assert body["data"]["period"]["end"]
+    end
+
+    test "sandbox minutes are reported per provider", %{conn: conn, user: user, key: key} do
+      # Which provider ran the minutes is what makes them attributable to a
+      # cost: a minute on each is bought at a different price.
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      {period_start, _} = Fountain.Billing.current_month_range()
+
+      # Clamped to the month the endpoint reports on, so the run is ten minutes
+      # long every day except the first ten minutes of a month, when it is
+      # shorter — and the expected value follows it rather than going stale.
+      started =
+        [DateTime.add(now, -10, :minute), period_start]
+        |> Enum.max(DateTime)
+
+      insert_sandbox(
+        user_id: user.id,
+        provider: "e2b",
+        status: "terminated",
+        inserted_at: started,
+        terminated_at: now
+      )
+
+      expected = Float.round(DateTime.diff(now, started, :second) / 60, 2)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/account/billing")
+        |> json_response(200)
+
+      assert body["data"]["usage"]["sandbox_minutes"] == expected
+      assert body["data"]["usage"]["sandbox_minutes_by_provider"] == %{"e2b" => expected}
     end
 
     test "trial dates answer the 'why did my API calls start failing' question", %{

--- a/images/daytona/Dockerfile
+++ b/images/daytona/Dockerfile
@@ -1,10 +1,14 @@
 # Reference Daytona snapshot for Fountain sandboxes.
 #
-# Build and push with the Daytona CLI from this directory:
+# Build it, and smoke the result, with:
 #
-#     daytona snapshot create fountain --dockerfile Dockerfile
+#     DAYTONA_API_KEY=... scripts/sandbox-image/build-daytona.sh
 #
-# then point the instance at it with DAYTONA_SNAPSHOT=fountain.
+# then point the instance at it with DAYTONA_SNAPSHOT=fountain. CI runs the
+# same script on a change to this directory and once a week for the CLI
+# versions below (.github/workflows/sandbox-images.yml). A snapshot name
+# cannot be rebuilt in place, so that script deletes the name and creates it
+# again; the script's header has what that costs.
 #
 # Recreates the Sprites base-image shape the provisioning pipeline assumes:
 # a `sprite` user with passwordless sudo, HOME=/home/sprite, ~/.local/bin on

--- a/images/e2b/e2b.Dockerfile
+++ b/images/e2b/e2b.Dockerfile
@@ -1,10 +1,12 @@
 # Reference E2B template for Fountain sandboxes.
 #
-# Build with the E2B CLI from this directory:
+# Build it, and smoke the result, with:
 #
-#     e2b template build --name fountain --dockerfile e2b.Dockerfile
+#     E2B_API_KEY=... scripts/sandbox-image/build-e2b.sh
 #
-# then point the instance at it with E2B_TEMPLATE=fountain.
+# then point the instance at it with E2B_TEMPLATE=fountain. CI runs the same
+# script on a change to this directory and once a week for the CLI versions
+# below (.github/workflows/sandbox-images.yml).
 #
 # The provisioning pipeline assumes the Sprites base-image shape: a `sprite`
 # user with passwordless sudo, HOME=/home/sprite, ~/.local/bin on PATH, bash,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Deploy on Kubernetes: guides/operate/kubernetes.md
       - Configure email: guides/operate/email.md
       - Change sandbox lifetimes: guides/operate/sandbox-lifetime.md
+      - See what sandboxes cost: guides/operate/sandbox-spend.md
       - Start billing: guides/operate/billing.md
       - Back up and restore: guides/operate/back-up-and-restore.md
       - Upgrade an instance: guides/operate/upgrade.md

--- a/scripts/sandbox-image/build-daytona.sh
+++ b/scripts/sandbox-image/build-daytona.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Rebuild the Daytona snapshot from images/daytona/, then smoke-test it live.
+#
+# Runs in CI (.github/workflows/sandbox-images.yml) and by hand:
+#
+#     DAYTONA_API_KEY=... scripts/sandbox-image/build-daytona.sh
+#
+# ## Why this deletes before it builds
+#
+# Snapshot names are unique per organization and there is no rename, so a
+# snapshot cannot be rebuilt in place and cannot be swapped in behind its name
+# either. Prod pins DAYTONA_SNAPSHOT=fountain, so refreshing that name means
+# deleting it and creating it again, and between those two calls the
+# organization has no `fountain` snapshot: a Daytona conversation started in
+# that window fails to create its sandbox. Sandboxes that already exist are
+# unaffected — they hold their own copy.
+#
+# The window is why the workflow builds and smokes the very same Dockerfile
+# with `docker build` on the runner first. That gate catches what actually
+# breaks these images (an apt or npm publisher upstream) before anything on the
+# Daytona side is touched. What it cannot catch is a Daytona-side build failure,
+# and if that happens the snapshot stays missing until someone re-runs this —
+# so the script says so, loudly, rather than exiting quietly.
+#
+# Environment:
+#   DAYTONA_API_KEY   required, and it must be the account prod uses — a
+#                     snapshot built under another org is invisible to prod
+#   DAYTONA_SNAPSHOT  snapshot name to rebuild (default: fountain)
+#   DAYTONA_API_URL   control plane (default: https://app.daytona.io/api)
+#   SKIP_SMOKE        set to 1 to build without creating a sandbox
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+snapshot="${DAYTONA_SNAPSHOT:-fountain}"
+api_url="${DAYTONA_API_URL:-https://app.daytona.io/api}"
+dockerfile="${root}/images/daytona/Dockerfile"
+
+# A snapshot build pulls a base image and installs four agent CLIs.
+build_timeout_s="${DAYTONA_BUILD_TIMEOUT_S:-2700}"
+start_timeout_s="${DAYTONA_START_TIMEOUT_S:-600}"
+
+if [ -z "${DAYTONA_API_KEY:-}" ]; then
+  echo "DAYTONA_API_KEY is not set — cannot talk to daytona.io" >&2
+  exit 1
+fi
+
+command -v jq > /dev/null || { echo "jq is required" >&2; exit 1; }
+
+resp="$(mktemp)"
+trap 'rm -f "$resp"' EXIT
+
+# Every call writes its body to $resp and prints the status code, so callers
+# read both instead of guessing from a merged blob.
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS -X "$method"
+    -H "Authorization: Bearer ${DAYTONA_API_KEY}"
+    -H "Content-Type: application/json"
+    -o "$resp" -w '%{http_code}')
+  if [ -n "$body" ]; then args+=(--data-binary "$body"); fi
+  curl "${args[@]}" "${api_url}${path}"
+}
+
+die() {
+  echo "$1" >&2
+  echo "response: $(cat "$resp")" >&2
+  exit 1
+}
+
+# ── the snapshot ──────────────────────────────────────────────────────────────
+
+create_body="$(jq -n --arg name "$snapshot" --rawfile df "$dockerfile" \
+  '{name: $name, buildInfo: {dockerfileContent: $df}}')"
+
+code="$(api GET "/snapshots/${snapshot}")"
+if [ "$code" = "200" ]; then
+  existing_id="$(jq -r '.id' < "$resp")"
+  echo "==> deleting the current ${snapshot} snapshot (${existing_id})"
+  code="$(api DELETE "/snapshots/${existing_id}")"
+  case "$code" in
+    2*) ;;
+    *) die "delete of snapshot ${snapshot} failed with ${code}" ;;
+  esac
+
+  # Deletion is a background job; creating the name again before it lands is a
+  # 409. Wait for the name to actually go.
+  deadline=$((SECONDS + 300))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    code="$(api GET "/snapshots/${snapshot}")"
+    [ "$code" = "404" ] && break
+    sleep 5
+  done
+  [ "$code" = "404" ] || die "snapshot ${snapshot} still present after 300s of deleting"
+elif [ "$code" != "404" ]; then
+  die "looking up snapshot ${snapshot} failed with ${code}"
+fi
+
+echo "==> creating ${snapshot} from images/daytona/Dockerfile"
+code="$(api POST /snapshots "$create_body")"
+case "$code" in
+  2*) ;;
+  *) die "PROD IS NOW WITHOUT A ${snapshot} SNAPSHOT: create failed with ${code}" ;;
+esac
+snapshot_id="$(jq -r '.id' < "$resp")"
+
+echo "==> waiting for ${snapshot} (${snapshot_id}) to reach active"
+deadline=$((SECONDS + build_timeout_s))
+state=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+  code="$(api GET "/snapshots/${snapshot_id}")"
+  [ "$code" = "200" ] || die "polling snapshot ${snapshot_id} failed with ${code}"
+  state="$(jq -r '.state' < "$resp")"
+
+  case "$state" in
+    active)
+      break
+      ;;
+    error | build_failed)
+      echo "snapshot build ended in ${state}: $(jq -r '.errorReason // "no reason given"' < "$resp")" >&2
+      echo "--- build logs ---" >&2
+      api GET "/snapshots/${snapshot_id}/build-logs" > /dev/null || true
+      cat "$resp" >&2
+      echo >&2
+      echo "PROD IS NOW WITHOUT A WORKING ${snapshot} SNAPSHOT — fix the" >&2
+      echo "Dockerfile and re-run this workflow." >&2
+      exit 1
+      ;;
+    *)
+      echo "    ${state}"
+      sleep 15
+      ;;
+  esac
+done
+
+[ "$state" = "active" ] || die "snapshot ${snapshot} stuck in ${state} after ${build_timeout_s}s"
+echo "==> ${snapshot} is active"
+
+if [ "${SKIP_SMOKE:-}" = "1" ]; then
+  echo "==> SKIP_SMOKE=1, leaving the snapshot unverified"
+  exit 0
+fi
+
+# ── the smoke ─────────────────────────────────────────────────────────────────
+
+sandbox_name="fountain-image-smoke-${GITHUB_RUN_ID:-$$}"
+
+cleanup_sandbox() {
+  echo "==> destroying smoke sandbox ${sandbox_name}"
+  api DELETE "/sandbox/${sandbox_name}" > /dev/null || true
+  rm -f "$resp"
+}
+
+echo "==> creating smoke sandbox ${sandbox_name}"
+# No `fountain: "1"` label, deliberately: that is what the reaper and the ops
+# gauges count as a Fountain sandbox, and a CI sandbox is neither leaked nor
+# theirs to reason about. The intervals are the backstop for a run that dies
+# before its trap fires — prod sets all three to 0, and a leaked CI sandbox
+# billing forever is the one thing this script must not do.
+sandbox_body="$(jq -nc --arg snapshot "$snapshot" --arg name "$sandbox_name" \
+  '{name: $name,
+    snapshot: $snapshot,
+    labels: {fountain_image_smoke: "1"},
+    autoStopInterval: 10,
+    autoDeleteInterval: 5,
+    ttlMinutes: 30}')"
+
+code="$(api POST /sandbox "$sandbox_body")"
+case "$code" in
+  2*) ;;
+  *) die "creating the smoke sandbox failed with ${code}" ;;
+esac
+trap cleanup_sandbox EXIT
+
+sandbox_id="$(jq -r '.id' < "$resp")"
+
+echo "==> waiting for ${sandbox_name} to start"
+deadline=$((SECONDS + start_timeout_s))
+state=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+  code="$(api GET "/sandbox/${sandbox_name}")"
+  [ "$code" = "200" ] || die "polling sandbox ${sandbox_name} failed with ${code}"
+  state="$(jq -r '.state' < "$resp")"
+  case "$state" in
+    started) break ;;
+    error | build_failed) die "smoke sandbox ended in ${state}" ;;
+    *)
+      echo "    ${state}"
+      sleep 5
+      ;;
+  esac
+done
+[ "$state" = "started" ] || die "smoke sandbox stuck in ${state} after ${start_timeout_s}s"
+
+# Same shape Fountain.Sandbox.Daytona.Api.toolbox_url/1 builds.
+proxy="$(jq -r '.toolboxProxyUrl // empty' < "$resp")"
+if [ -z "$proxy" ]; then
+  code="$(api GET "/sandbox/${sandbox_id}/toolbox-proxy-url")"
+  [ "$code" = "200" ] || die "no toolbox proxy URL for ${sandbox_name} (${code})"
+  proxy="$(jq -r 'if type == "string" then . else .url end' < "$resp")"
+fi
+toolbox="${proxy%/}/${sandbox_id}"
+
+echo "==> smoking ${sandbox_name}"
+smoke_b64="$(base64 < "${root}/scripts/sandbox-image/smoke.sh" | tr -d '\n')"
+exec_body="$(jq -nc --arg cmd "echo ${smoke_b64} | base64 -d | bash" \
+  '{command: $cmd, timeout: 600}')"
+
+exec_code="$(curl -sS -X POST \
+  -H "Authorization: Bearer ${DAYTONA_API_KEY}" \
+  -H "Content-Type: application/json" \
+  --data-binary "$exec_body" \
+  -o "$resp" -w '%{http_code}' \
+  "${toolbox}/process/execute")"
+
+[ "$exec_code" = "200" ] || die "toolbox execute failed with ${exec_code}"
+
+jq -r '.result // .output // ""' < "$resp"
+exit_code="$(jq -r '.exitCode // .code // 0' < "$resp")"
+
+if [ "$exit_code" != "0" ] || ! jq -r '.result // .output // ""' < "$resp" | grep -q FOUNTAIN_IMAGE_SMOKE_OK; then
+  echo "==> smoke FAILED for snapshot ${snapshot} (exit ${exit_code})" >&2
+  exit 1
+fi
+
+echo "==> snapshot ${snapshot} rebuilt and smoked clean"

--- a/scripts/sandbox-image/build-e2b.sh
+++ b/scripts/sandbox-image/build-e2b.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Rebuild the E2B template from images/e2b/, then smoke-test it live.
+#
+# Runs in CI (.github/workflows/sandbox-images.yml) and by hand:
+#
+#     E2B_API_KEY=... scripts/sandbox-image/build-e2b.sh
+#
+# `e2b template create <name>` is name-addressed and rebuilds in place, so the
+# template ID prod is pinned to (px8ej9g93zg6b8q9w01j, alias `fountain`)
+# survives every rebuild. Sandboxes already running keep the copy they started
+# from. There is no in-between state to protect, which is why this script is so
+# much shorter than its Daytona counterpart.
+#
+# Environment:
+#   E2B_API_KEY   required, and it must be the account prod uses — a template
+#                 built under another org is invisible to prod's key
+#   E2B_TEMPLATE  template name to rebuild (default: fountain)
+#   E2B_BASE_URL  control-plane base (default: https://api.e2b.app)
+#   E2B_USER      in-guest user the smoke runs as (default: sprite)
+#   SKIP_SMOKE    set to 1 to build without creating a sandbox
+
+set -euo pipefail
+
+# Pinned: the CLI decides what "template create" means, and a silent major
+# would change the artifact prod boots from.
+CLI="@e2b/cli@2.17.1"
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+template="${E2B_TEMPLATE:-fountain}"
+base_url="${E2B_BASE_URL:-https://api.e2b.app}"
+user="${E2B_USER:-sprite}"
+
+if [ -z "${E2B_API_KEY:-}" ]; then
+  echo "E2B_API_KEY is not set — cannot talk to e2b.dev" >&2
+  exit 1
+fi
+
+for tool in jq npx; do
+  command -v "$tool" > /dev/null || { echo "${tool} is required" >&2; exit 1; }
+done
+
+echo "==> building E2B template ${template} from images/e2b/e2b.Dockerfile"
+npx --yes "$CLI" template create "$template" \
+  --path "${root}/images/e2b" \
+  --dockerfile e2b.Dockerfile
+
+if [ "${SKIP_SMOKE:-}" = "1" ]; then
+  echo "==> SKIP_SMOKE=1, leaving the template unverified"
+  exit 0
+fi
+
+sandbox_id=""
+
+cleanup() {
+  if [ -n "$sandbox_id" ]; then
+    echo "==> destroying smoke sandbox ${sandbox_id}"
+    curl -sS -X DELETE -H "X-API-Key: ${E2B_API_KEY}" \
+      "${base_url}/sandboxes/${sandbox_id}" > /dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "==> creating a smoke sandbox from ${template}"
+# No `fountain: "1"` metadata, deliberately: that is the label the reaper and
+# the ops gauges count as a Fountain sandbox, and a CI sandbox is neither
+# leaked nor theirs to reason about. The short timeout is the backstop for a
+# smoke that dies before its trap runs.
+create_body="$(jq -nc --arg t "$template" \
+  '{templateID: $t, timeout: 600, metadata: {fountain_image_smoke: "1"}}')"
+
+create_out="$(curl -sS -X POST \
+  -H "X-API-Key: ${E2B_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "$create_body" \
+  "${base_url}/sandboxes")"
+
+sandbox_id="$(jq -r '.sandboxID // .sandboxId // empty' <<< "$create_out")"
+
+if [ -z "$sandbox_id" ]; then
+  echo "no sandbox ID in the create response: ${create_out}" >&2
+  exit 1
+fi
+
+echo "==> smoking ${sandbox_id} as ${user}"
+smoke_b64="$(base64 < "${root}/scripts/sandbox-image/smoke.sh" | tr -d '\n')"
+# The asserted user is E2B's own contract: envd selects the in-guest user from
+# Basic auth, so E2B_USER and the template's user have to agree or every
+# provisioning write lands in the wrong home.
+in_guest="export SMOKE_EXPECT_USER=${user}; echo ${smoke_b64} | base64 -d | bash"
+
+# envd accepts the connection before it is ready to run anything, and PR #693
+# is the record of what that race costs. Retry the first exec only.
+attempt=1
+output=""
+while :; do
+  if output="$(npx --yes "$CLI" sandbox exec --user "$user" "$sandbox_id" bash -lc "$in_guest" 2>&1)"; then
+    break
+  fi
+  if [ "$attempt" -ge 6 ]; then
+    break
+  fi
+  echo "    exec attempt ${attempt} failed, retrying in 5s"
+  attempt=$((attempt + 1))
+  sleep 5
+done
+
+echo "$output"
+
+if ! grep -q FOUNTAIN_IMAGE_SMOKE_OK <<< "$output"; then
+  echo "==> smoke FAILED for template ${template}" >&2
+  exit 1
+fi
+
+echo "==> template ${template} rebuilt and smoked clean"

--- a/scripts/sandbox-image/smoke.sh
+++ b/scripts/sandbox-image/smoke.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Asserts the base-image shape Fountain's provisioning pipeline assumes.
+#
+# This runs INSIDE a sandbox (or inside the image under `docker run`), never on
+# the CI runner. Every caller ships it the same way — base64 on one command
+# line — so the E2B template, the Daytona snapshot and a local `docker build`
+# are held to the identical contract.
+#
+# Every check stands for a provisioning step that fails in a way that is hard
+# to read from the outside. The npm one is the #691 trap: a global install as
+# `sprite` against the root-owned default prefix exits 243 with no output, and
+# the conversation only reports that the runtime is missing. It is checked by
+# doing the install, not by reading the setting, because the setting was right
+# in the image that failed.
+#
+# SMOKE_EXPECT_USER asserts which user the provider selected in-guest, and is
+# set only where Fountain pins that: E2B, where envd picks the user from Basic
+# auth and E2B_USER must match what the template creates. Daytona picks its own
+# and the value is reported rather than asserted.
+#
+# The exit code and the trailing marker both carry the verdict: a provider exec
+# API that swallows the exit code still cannot fake the marker.
+
+set -uo pipefail
+
+failures=0
+
+pass() { printf 'ok    %s\n' "$1"; }
+
+fail() {
+  printf 'FAIL  %s\n' "$1"
+  if [ -n "${2:-}" ]; then printf '      %s\n' "$2"; fi
+  failures=$((failures + 1))
+}
+
+# Run a command, capture combined output, report on the exit code.
+check() {
+  local label="$1"
+  shift
+  local out status
+  out="$(timeout 180 "$@" 2>&1)"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    pass "$label${out:+ (${out%%$'\n'*})}"
+  else
+    fail "$label" "exit ${status}: ${out:-no output}"
+  fi
+}
+
+echo "== identity"
+whoami="$(whoami 2>&1)"
+echo "      user=${whoami} home=${HOME:-unset} pwd=$(pwd)"
+
+if [ -n "${SMOKE_EXPECT_USER:-}" ]; then
+  if [ "$whoami" = "$SMOKE_EXPECT_USER" ]; then
+    pass "runs as ${SMOKE_EXPECT_USER}"
+  else
+    fail "runs as ${SMOKE_EXPECT_USER}" "got ${whoami}"
+  fi
+fi
+
+if [ -w "${HOME:-/nonexistent}" ]; then
+  pass "HOME is writable"
+else
+  fail "HOME is writable" "${HOME:-unset} is not writable by ${whoami}"
+fi
+
+echo
+echo "== base tooling"
+check "bash" bash --version
+check "git" git --version
+check "node" node --version
+check "npm" npm --version
+
+echo
+echo "== a global npm install as the exec user (#691)"
+prefix="$(npm config get prefix 2>&1)"
+echo "      npm prefix=${prefix}"
+
+# The measurement, not the setting. `--silent` is what hid the EACCES last
+# time, so it stays in, and Fountain.Runtimes.ACP installs with it.
+if npm_out="$(timeout 300 npm install -g --no-progress --silent semver 2>&1)"; then
+  if [ -x "${prefix}/bin/semver" ]; then
+    pass "npm install -g"
+  else
+    fail "npm install -g" "exit 0, but no ${prefix}/bin/semver"
+  fi
+else
+  fail "npm install -g" "exit $?: ${npm_out:-no output — the 243 signature}"
+fi
+
+echo
+echo "== agent CLIs"
+# claude, codex and gemini are root-installed into the system prefix, so they
+# answer on any PATH. opencode comes from `bun install -g`, whose bin directory
+# the runtimes reach by absolute path.
+check "claude" claude --version
+check "codex" codex --version
+check "gemini" gemini --version
+check "bun" /home/sprite/.bun/bin/bun --version
+check "opencode" /home/sprite/.bun/bin/opencode --version
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "FOUNTAIN_IMAGE_SMOKE_OK"
+  exit 0
+fi
+
+echo "FOUNTAIN_IMAGE_SMOKE_FAILED ${failures}"
+exit 1

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2009,7 +2009,7 @@ export interface components {
             fresh?: boolean | null;
             /** @description Optional images to attach to the initial prompt. */
             images?: components["schemas"]["ImageInput"][] | null;
-            /** @description Per-launch permission override (#939). Keys are matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); "default" covers the rest. Prefer a kind: claude titles a tool call with the command it is about to run, so a title matches one invocation only. Merged with the agent's own policy, taking the stricter of the two. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped. */
+            /** @description Per-launch permission override (#939). Keys are matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); "default" covers the rest. Prefer a kind: claude titles a tool call with the command it is about to run, so a title matches one invocation only. Merged with the agent's own policy, taking the stricter of the two. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped, and one the runtime never consults is refused with 422 permission_policy_unenforceable. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
@@ -2644,7 +2644,7 @@ export interface components {
             /** @description Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The provider must match the runtime — anthropic for claude, openai for codex, google for gemini; opencode accepts any of the three. Other providers are rejected: Fountain has no credentials to export for them. The model id is not checked against a list, so a newly released model works without a Fountain release. */
             model: string;
             name: string;
-            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. */
+            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
@@ -3081,7 +3081,7 @@ export interface components {
             };
             model?: string;
             name?: string;
-            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
+            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
@@ -3327,7 +3327,7 @@ export interface components {
             };
             model: string;
             name: string;
-            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
+            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3605,7 +3605,12 @@ export interface components {
                 trial_ends_at?: string | null;
                 usage: {
                     conversations?: number;
+                    /** @description Active sandbox minutes inside the period, parked time excluded. */
                     sandbox_minutes?: number;
+                    /** @description sandbox_minutes split by sandbox provider (sprites, e2b, daytona, runner). Providers not used in the period are absent. */
+                    sandbox_minutes_by_provider?: {
+                        [key: string]: number;
+                    };
                     turns?: number;
                 };
             };

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2009,7 +2009,7 @@ export interface components {
             fresh?: boolean | null;
             /** @description Optional images to attach to the initial prompt. */
             images?: components["schemas"]["ImageInput"][] | null;
-            /** @description Per-launch permission override (#939). Merged with the agent's own policy, taking the stricter of the two per tool. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped. */
+            /** @description Per-launch permission override (#939). Keys are matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); "default" covers the rest. Prefer a kind: claude titles a tool call with the command it is about to run, so a title matches one invocation only. Merged with the agent's own policy, taking the stricter of the two. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
@@ -2644,7 +2644,7 @@ export interface components {
             /** @description Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The provider must match the runtime — anthropic for claude, openai for codex, google for gemini; opencode accepts any of the three. Other providers are rejected: Fountain has no credentials to export for them. The model id is not checked against a list, so a newly released model works without a Fountain release. */
             model: string;
             name: string;
-            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. */
+            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
@@ -3081,7 +3081,7 @@ export interface components {
             };
             model?: string;
             name?: string;
-            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
+            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
@@ -3327,7 +3327,7 @@ export interface components {
             };
             model: string;
             name: string;
-            /** @description Per-tool permission policy: a map of tool name (as the transcript labels it) to verdict, plus an optional "default" key. Unset tools fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
+            /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;


### PR DESCRIPTION
Closes #959. Stacked on #960 — merge that first.

## What was measured

**opencode never sends `session/request_permission`.** One conversation launched
with `permission_policy: {"default": "ask"}`, two probes:

1. `curl -sS -o /dev/null -w "%{http_code}" https://example.com` — ran, returned `200`.
2. `rm -rf /tmp/opencode-workspace/none-such && echo REMOVED` — ran.

Not one request in the conversation's `acp` stream. It decides permission inside
its own server and never offers the protocol's channel. claude
(claude-agent-acp 0.66) and codex (codex-acp 1.1.14) were driven the same way in
the same session and both ask, per tool call.

#939 and #643 both say the request "arrives, per tool call, on every shippable
runtime". True for two of the three; nothing had checked the third.

## Why this is a bug and not a gap

The policy was **accepted and stored**. An opencode agent with
`{"default": "auto_deny"}` showed a deny-everything policy on the agent page, in
`GET /api/agents/:id`, and in the launch response — and ran every tool anyway.
An inert control that displays as a control is worse than a missing one, and it
is the same failure the fail-closed rules elsewhere in this feature exist to
prevent.

## What this does

`Fountain.Runtimes.ACP.asks_permission?/1` carries the measurement beside the
adapter entry it is about. A policy that needs enforcement — anything other than
`auto_allow` everywhere — on a runtime that does not ask is refused at both
doors with 422 `permission_policy_unenforceable`, naming the runtime:

- the agent changeset, so it never reaches a row;
- the launch override, so a narrowing launch cannot buy protection either.

Every adapter entry is assumed to ask until measured otherwise. That is the safe
direction to be wrong in: a runtime that turns out not to ask gets a loud
refusal the first time someone writes a policy for it, rather than a policy that
reads as protection and is not.

No migration: no agent in production carries a non-empty `permission_policy`
(checked), so nothing stored becomes unwritable.

## Not in this PR

**Making opencode ask.** It has its own permission configuration, and whether
its ACP mode forwards those prompts as `session/request_permission` is a
separate measurement and a separate change — the same shape as
`enableAllProjectMcpServers` in `Runtimes.Claude`. Filed as its own issue so
this one stays "stop claiming a protection we do not have", which can ship now.

gemini's `--approval-mode yolo` is #941 and is untouched here.

Part of #643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
