### PR TITLE
feat(web): set an agent's permission policy from the console, and document the field

### DIFF
--- a/apps/fountain/lib/fountain/permissions.ex
+++ b/apps/fountain/lib/fountain/permissions.ex
@@ -81,6 +81,9 @@ defmodule Fountain.Permissions do
 
   @default_key "default"
 
+  # ACP's `toolCall.kind` vocabulary, in the protocol's own order.
+  @tool_kinds ~w(read edit delete move search execute think fetch switch_mode other)
+
   # Well under `Lifecycle.idle_timeout_seconds/0` (60 minutes by default), and
   # deliberately so: a held request suppresses only the idle verdict, so one
   # that outlived the idle bound would be resolved by the max-lifetime ceiling
@@ -118,6 +121,18 @@ defmodule Fountain.Permissions do
   @doc "Every verdict a policy may name."
   @spec verdicts() :: [String.t()]
   def verdicts, do: @verdicts
+
+  @doc """
+  ACP's own tool kinds, which are the policy keys worth offering in a form.
+
+  The protocol's closed list, so it is the stable half of a request: a title
+  matches one invocation of one command on claude (#958), while a kind means
+  the same thing on every runtime and every turn. A policy may still name a
+  title — `verdict_for_request/2` tries that first — it is simply not something
+  to invite someone to type.
+  """
+  @spec tool_kinds() :: [String.t()]
+  def tool_kinds, do: @tool_kinds
 
   @doc "The verdict applied when a policy names neither the tool nor a default."
   @spec default_verdict() :: String.t()

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -4,6 +4,8 @@ defmodule FountainWeb.AgentsLive.Form do
 
   alias Fountain.{Agents, AvatarGenerator, Environments, InferenceCredentials}
   alias Fountain.Agents.Agent
+  alias Fountain.Permissions
+  alias Fountain.Runtimes.ACP
   alias Fountain.Runtimes.Model
 
   @impl true
@@ -60,8 +62,45 @@ defmodule FountainWeb.AgentsLive.Form do
       "model" => a.model || "anthropic/claude-sonnet-4-6",
       "runtime" => a.runtime || "claude",
       "sandbox_provider" => a.sandbox_provider || "",
-      "environment_id" => a.environment_id || ""
+      "environment_id" => a.environment_id || "",
+      "permission_default" => Permissions.verdict_for(a.permission_policy, nil),
+      "permission_kinds" => permission_kind_form(a.permission_policy)
     }
+  end
+
+  # The per-kind half of the policy, as the form holds it: every ACP kind, with
+  # "" meaning "whatever the default says". Only the kinds are offered here —
+  # a title key matches one invocation of one command on the runtime every
+  # agent runs (#958), so a form that invited one would be inviting a rule that
+  # never fires.
+  defp permission_kind_form(policy) do
+    policy = policy || %{}
+    Map.new(Permissions.tool_kinds(), fn kind -> {kind, Map.get(policy, kind, "")} end)
+  end
+
+  # The other direction: form state back to the map the changeset takes. An
+  # empty default plus no overrides is an empty policy rather than
+  # `%{"default" => "auto_allow"}`, so an agent nobody has touched keeps the
+  # empty map it has always had.
+  defp form_to_permission_policy(params) do
+    kinds =
+      params
+      |> Map.get("permission_kinds", %{})
+      |> Enum.filter(fn {_kind, verdict} -> verdict in Permissions.verdicts() end)
+      |> Map.new()
+
+    case Map.get(params, "permission_default") do
+      verdict when verdict in ["ask", "auto_deny"] -> Map.put(kinds, "default", verdict)
+      _ -> kinds
+    end
+  end
+
+  defp asks_permission?(runtime), do: ACP.asks_permission?(runtime || "claude")
+
+  defp permission_override_count(form) do
+    form
+    |> Map.get("permission_kinds", %{})
+    |> Enum.count(fn {_kind, verdict} -> verdict not in [nil, ""] end)
   end
 
   defp agent_to_skill_list(skills) do
@@ -320,6 +359,7 @@ defmodule FountainWeb.AgentsLive.Form do
         params
         |> Map.put("skills", skills)
         |> Map.put("mcp_servers", mcp_map)
+        |> Map.put("permission_policy", form_to_permission_policy(params))
         |> Map.put("user_id", socket.assigns.user_id)
         |> nil_if_blank("environment_id")
         |> nil_if_blank("sandbox_provider")
@@ -644,6 +684,70 @@ defmodule FountainWeb.AgentsLive.Form do
               {e.name}
             </option>
           </select>
+        </div>
+
+        <%!-- Permissions (#939): what answers before the agent runs a tool. --%>
+        <div class="space-y-2">
+          <label class="block text-sm font-medium text-zinc-700">
+            Before the agent runs a tool
+          </label>
+          <select
+            name="agent[permission_default]"
+            disabled={not asks_permission?(@form["runtime"])}
+            class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm disabled:bg-zinc-100 disabled:text-zinc-500"
+          >
+            <option value="auto_allow" selected={@form["permission_default"] == "auto_allow"}>
+              Run it
+            </option>
+            <option value="ask" selected={@form["permission_default"] == "ask"}>
+              Ask a human, and refuse if nobody answers
+            </option>
+            <option value="auto_deny" selected={@form["permission_default"] == "auto_deny"}>
+              Refuse it
+            </option>
+          </select>
+
+          <p :if={not asks_permission?(@form["runtime"])} class="text-xs text-amber-700">
+            The {@form["runtime"]} runtime decides this inside its own server and never asks
+            Fountain, so a policy here would show a restriction it could not enforce.
+          </p>
+
+          <details :if={asks_permission?(@form["runtime"])} class="text-sm">
+            <summary class="cursor-pointer text-zinc-600">
+              Per kind of tool ({permission_override_count(@form)} set)
+            </summary>
+            <p class="mt-2 text-xs text-zinc-500">
+              A kind is the agent's own label for what a tool call does. Leave one alone to
+              follow the setting above.
+            </p>
+            <div class="mt-2 grid grid-cols-2 gap-2">
+              <div :for={kind <- Permissions.tool_kinds()} class="flex items-center gap-2">
+                <label class="w-20 text-xs text-zinc-600" for={"permission-#{kind}"}>{kind}</label>
+                <select
+                  id={"permission-#{kind}"}
+                  name={"agent[permission_kinds][#{kind}]"}
+                  class="flex-1 rounded-md border border-zinc-300 bg-white px-2 py-1 text-xs"
+                >
+                  <option value="" selected={@form["permission_kinds"][kind] in [nil, ""]}>
+                    Same as above
+                  </option>
+                  <option
+                    :for={verdict <- Permissions.verdicts()}
+                    value={verdict}
+                    selected={@form["permission_kinds"][kind] == verdict}
+                  >
+                    {verdict}
+                  </option>
+                </select>
+              </div>
+            </div>
+          </details>
+
+          <p class="text-xs text-zinc-500">
+            A conversation may narrow this at launch, never widen it. An unanswered request is
+            refused after five minutes, and the turn carries on.
+          </p>
+          <.error_msg field="permission_policy" errors={@errors} />
         </div>
 
         <%!-- Avatar --%>

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -198,4 +198,94 @@ defmodule FountainWeb.AgentsLive.IndexTest do
       assert path =~ "/auth/login"
     end
   end
+
+  describe "permission policy (#939)" do
+    # The form renders a credential card, as its own nested <form>, when the
+    # account holds no key for the model's provider. Nested forms truncate the
+    # outer one for LiveViewTest, so a submit test needs the key on file.
+    defp with_credential(user) do
+      {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+
+      {:ok, _} =
+        Fountain.InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, "sk-ant-x")
+
+      user
+    end
+
+    test "the form shows what answers before the agent runs a tool", %{conn: conn} do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id, permission_policy: %{"default" => "ask"})
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+
+      assert html =~ "Before the agent runs a tool"
+      assert html =~ "Ask a human"
+      # The stored default is the one selected, rather than the field showing
+      # allow while the row says otherwise.
+      assert html =~ ~r/<option value="ask" selected/
+    end
+
+    test "saving stores the default and the per-kind overrides", %{conn: conn} do
+      user = with_credential(insert_verified_user())
+      agent = insert_agent(user_id: user.id)
+      conn = login_user(conn, user)
+
+      {:ok, view, _html} = live(conn, ~p"/agents/#{agent.id}/edit")
+
+      view
+      |> form("form", %{
+        "agent" => %{
+          "name" => agent.name,
+          "model" => agent.model,
+          "runtime" => agent.runtime,
+          "permission_default" => "ask",
+          "permission_kinds" => %{"execute" => "auto_deny", "read" => ""}
+        }
+      })
+      |> render_submit()
+
+      assert %{"default" => "ask", "execute" => "auto_deny"} =
+               Fountain.Agents.get_agent(agent.id, user.id).permission_policy
+    end
+
+    test "an untouched form leaves the policy empty rather than writing a default", %{conn: conn} do
+      # Every agent predates this field. Saving an unrelated edit must not
+      # start writing `%{"default" => "auto_allow"}` into rows that had `%{}`,
+      # which would read as a policy someone chose.
+      user = with_credential(insert_verified_user())
+      agent = insert_agent(user_id: user.id)
+      conn = login_user(conn, user)
+
+      {:ok, view, _html} = live(conn, ~p"/agents/#{agent.id}/edit")
+
+      view
+      |> form("form", %{
+        "agent" => %{
+          "name" => "renamed",
+          "model" => agent.model,
+          "runtime" => agent.runtime
+        }
+      })
+      |> render_submit()
+
+      assert Fountain.Agents.get_agent(agent.id, user.id).permission_policy == %{}
+    end
+
+    test "a runtime that never asks says so instead of offering the choice", %{conn: conn} do
+      # opencode decides permission in its own server and sends no request
+      # (#959), so a policy here would display a restriction nothing enforces.
+      user = insert_verified_user()
+
+      agent =
+        insert_agent(user_id: user.id, runtime: "opencode", model: "anthropic/claude-sonnet-5")
+
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+
+      assert html =~ "decides this inside its own server"
+      assert html =~ "disabled"
+    end
+  end
 end

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -1,0 +1,99 @@
+# Before a tool runs
+
+An agent works in a sandbox. Sooner or later it wants to run a command, edit a
+file, or fetch a URL. A **permission policy** says what happens at that moment.
+
+The runtime asks Fountain first. Fountain answers from the policy. The tool
+then runs, or it does not.
+
+## The three answers
+
+| Verdict | What Fountain does |
+|---|---|
+| `auto_allow` | It permits the tool. This is the default, and it is what every agent did before the policy existed. |
+| `ask` | It holds the request, and a human answers it. Nobody answers in 5 minutes, and Fountain refuses. |
+| `auto_deny` | It refuses the tool. It chooses a refusal that the runtime offered, and invents none. |
+
+A refusal does not stop the turn. The agent reads that it has no permission,
+and it continues.
+
+## Where a policy lives
+
+An agent holds one. Each conversation on that agent runs under it.
+
+A launch can send its own policy, on `POST /api/conversations`, on ACP
+`session/new`, or with `fountain acp --permission`. Fountain merges the two,
+and keeps the stricter verdict for each key.
+
+**A launch can only narrow.** A launch policy that permits more than the agent
+does gets a 422 that names the key. Fountain refuses it, and does not clamp it
+quietly. Because of that rule, there is no allowlist beside this field. A
+launch cannot reach a permission that the agent does not hold.
+
+## Keys
+
+A policy is a map. Each key names what the tool call is, and each value is a
+verdict. The key `default` covers everything else.
+
+```json
+{ "default": "auto_allow", "execute": "ask" }
+```
+
+Fountain reads the keys in this order.
+
+1. The **title** on the tool card, which is the agent's own words.
+2. The **kind**, which is ACP's own short list. It is one of `read`, `edit`,
+   `delete`, `move`, `search`, `execute`, `think`, `fetch`, `switch_mode` and
+   `other`.
+3. The key `default`.
+
+**Prefer a kind.** The claude runtime puts the command itself in the title. A
+title key therefore matches one command, and nothing else. A kind means the
+same thing on each turn, and on each runtime.
+
+## When a human answers
+
+With `ask`, the agent stops and waits. Fountain puts the request on the
+conversation stream, as a `permission_request` block. It carries the tool, a
+summary, and the runtime's own options.
+
+Anyone with the conversation can answer it. The team app and the conversations
+app show a card. An editor over `fountain acp` shows its own approval prompt.
+Your own code can answer with
+`POST /api/conversations/{id}/requests/{request_id}`.
+
+Some rules keep that safe.
+
+- **The first answer wins.** The other clients see a request that no longer
+  waits. No client is a fallback for another.
+- **Nobody is also an answer.** After 5 minutes, Fountain refuses the tool. The
+  timeout sits below the idle bound, so a request that waits costs a turn and
+  not the sandbox.
+- **An option must come from the runtime.** Fountain refuses an option id that
+  the runtime did not offer.
+- **The agent cannot answer itself.** The sandbox holds an API token, and
+  Fountain refuses that loop by name.
+
+## What each runtime can do
+
+| Runtime | Asks before a tool | Notes |
+|---|---|---|
+| claude | Yes | Measured on claude-agent-acp 0.66. Safe commands that its own sandbox runs never reach Fountain. |
+| codex | Yes | Measured on codex-acp 1.1.14. |
+| opencode | **No** | It decides this in its own server, and sends nothing. Fountain refuses a policy stricter than `auto_allow` on this runtime, with 422 `permission_policy_unenforceable` ([#959](https://github.com/BinaryBourbon/fountain/issues/959)). |
+| gemini | n/a | Not available yet ([#659](https://github.com/BinaryBourbon/fountain/issues/659)). |
+
+## What the audit trail keeps
+
+Fountain records a refusal, with the tool and the verdict. It records no
+values, and no inputs.
+
+It records no permits. One turn makes many tool calls, and a row for each would
+make the trail a copy of the transcript.
+
+## How to set one
+
+- **The console.** Open the agent, and use *Before the agent runs a tool*.
+- **The API.** `PATCH /api/agents/{id}` with `permission_policy`.
+- **An editor.** `fountain acp --permission ask`, or
+  `fountain acp --permission execute=ask`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Agents as teammates: concepts/teammates.md
       - Where a secret comes from: concepts/secrets.md
       - About sandboxes: concepts/sandboxes.md
+      - Before a tool runs: concepts/permissions.md
       - The console, the apps, and the API: concepts/surfaces.md
       - Architecture: architecture.md
   - Setup: setup.md


### PR DESCRIPTION
Part of #643. Stacked on #961 — merge that first.

## The gap

#939 built the policy. #940 built the ask path. #952 made the field readable
over the API. Nothing could **write** one without curl:

| door | before this PR |
|---|---|
| the console's agent form | no field |
| the team app | no field |
| `fountain run` / `fountain acp` | launch override only (and the ACP flag arrives in #963) |
| `PATCH /api/agents/:id` | yes |

So every agent in production runs at the default, `auto_allow`, and a
permission request is never raised for anyone to answer. The safety story built
over two PRs was reachable only from a terminal.

## What this adds

**One select**, *Before the agent runs a tool*: run it, ask a human, or refuse
it. That is the policy's `default`.

**A per-kind list** behind a disclosure, for narrowing one kind of tool without
touching the rest. Only ACP's kinds are offered, and that is deliberate: a
title key matches one invocation of one command on claude (#958), so a form
that invited a title would be inviting a rule that never fires.

**An untouched form changes nothing.** An agent whose policy is `%{}` keeps
`%{}` after an unrelated edit, rather than acquiring
`%{"default" => "auto_allow"}` that reads as a choice somebody made. There is a
test for exactly this.

**A runtime that never asks says so.** opencode (#959) gets a disabled control
and a line explaining that it decides permission inside its own server, instead
of a restriction that nothing would enforce.

## Docs

`docs/concepts/permissions.md` is the page that did not exist. Before this,
`permission_policy` appeared **nowhere** in the published docs — not the
verdicts, not the key matching, not the five-minute timeout, not which runtimes
honour it, not the narrow-never-widen rule. The page covers all of it, plus
what the audit trail keeps and what it deliberately does not.

## Verification

Four new LiveView tests, and the save test was verified to fail with the
wiring removed — which is the failure mode #863 was: a form that renders a
control which never reaches the changeset. `mkdocs build --strict`,
`docs-style.py` and `docs_test.exs` all pass with the new page in the nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
