### PR TITLE
fix(acp): a reattach must not ask the same permission twice

### DIFF
--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -463,11 +463,20 @@ defmodule Fountain.Runtimes.ACP.Peer do
     tool = Fountain.Permissions.tool_name(params)
     verdict = Fountain.Permissions.verdict_for_request(state.permission_policy, params)
 
-    case verdict do
-      "ask" ->
+    cond do
+      held?(state, id) ->
+        # The replay of a request this peer already holds, which is what a
+        # reattach reads out of the sprite's buffer (#967). Raising it again
+        # would publish a second card for one question, and — because the id a
+        # client answers with is minted per hold — would leave the card someone
+        # is actually looking at unanswerable. The agent is still blocked on
+        # the request we are already holding, so there is nothing to do.
+        state
+
+      verdict == "ask" ->
         hold_permission(state, id, tool, params)
 
-      _ ->
+      true ->
         if verdict != "auto_allow", do: report(state, {:permission_denied, tool, verdict})
 
         write(
@@ -488,6 +497,12 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # stdout. Those are output, not protocol, and the transcript is more useful
   # with them in it.
   defp handle_message({:invalid, line}, state), do: persist(state, "stdout", [line, "\n"])
+
+  # Whether this is the request the peer is already holding open. An agent
+  # cannot have two requests outstanding under one JSON-RPC id, so a matching
+  # id while something is held means the line was replayed, not re-asked.
+  defp held?(%{pending_permission: %{id: held_id}}, id), do: held_id == id
+  defp held?(_state, _id), do: false
 
   # `ask`: do not answer. The agent stays blocked while a human decides, which
   # is the whole point, and is also why a timeout is not optional — see the

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -716,6 +716,51 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       assert %{"id" => "req-7", "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
     end
 
+    test "the replay of a held request is not raised a second time", ctx do
+      # A reattached peer reads the sprite's buffer, which still holds the
+      # `session/request_permission` line the agent is blocked on (#967).
+      # Raising it again would publish a second card for one question, and
+      # would leave the card someone is looking at unanswerable, because the
+      # id a client answers with is minted per hold.
+      pid =
+        start_peer(ctx,
+          permission_policy: %{"Bash" => "ask"},
+          attach: 900,
+          pending_permission: %{
+            "request_id" => "210.abcdefabcdefabcd",
+            "tool" => "Bash",
+            "options" => [
+              %{"optionId" => "yes", "kind" => "allow_always"},
+              %{"optionId" => "no", "kind" => "reject_once"}
+            ]
+          }
+        )
+
+      Peer.stdout(pid, permission_line(210, "Bash"))
+
+      refute_receive {:acp, _ref, {:permission_ask, _, _, _}}, 100
+      refute_receive {:acp, _ref, {:lines, "acp", _}}, 50
+
+      # And the id the client is holding still answers the agent.
+      assert :ok = Peer.answer_permission(pid, "210.abcdefabcdefabcd", "yes")
+      assert %{"id" => 210, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
+    end
+
+    test "a different request while one is held is still raised", ctx do
+      # The guard is about the id, not about holding: an adapter that asked
+      # again under a new id is asking a new question.
+      pid = start_peer(ctx, permission_policy: %{"Bash" => "ask"})
+      _init = next_write()
+
+      Peer.stdout(pid, permission_line(211, "Bash"))
+      assert_receive {:acp, _ref, {:permission_ask, first, _, _}}
+
+      Peer.stdout(pid, permission_line(212, "Bash"))
+      assert_receive {:acp, _ref, {:permission_ask, second, _, _}}
+
+      refute first == second
+    end
+
     test "an fs/* request is refused, not ignored", ctx do
       # Silence would block the agent forever. We declared no fs capability, so
       # the honest answer is method-not-found.


### PR DESCRIPTION
Closes #967.

Found the way the last three were: by watching production. A deploy landed
while a teammate was blocked on a permission request, and the reattached peer
asked the same question again 34 seconds later.

```
07:36:59  PERM 0.6ee88126968ea3f2      ← the agent asks; the card renders
07:36:59  STAGE request started
07:37:33  STAGE reattach started        ← my own merge deploying
07:37:34  STAGE reattach done
07:37:34  PERM 0.0cfb3fb32489ebab      ← the same question, a second card
07:37:34  STAGE request started
```

## Why

A reattached peer reads the tail of the sprite's session buffer, which still
holds the `session/request_permission` the agent is blocked on. Acting on
requests found in that replay is deliberate — an unanswered one is a turn that
never ends. But under `ask` the peer *holds* rather than answers, and every
hold mints a fresh client-facing id (#957).

So one question became two cards, and the live one was not the one on screen:
`pending_permission` now held the new id, so the card the human was looking at
answered nothing and took a 409 on the only id it had. The transcript also grew
a second `permission_request` block and a second `request`/`started` event for
a question asked once.

Before ids were minted this was invisible: the replayed line re-raised under
the adapter's own id, which matched what was already persisted, so the answer
path kept working by luck. The duplicate block and stage event were there all
along.

## The fix

The peer knows what it is holding. A request whose JSON-RPC id matches
`pending_permission.id` is the replay of that request — an agent cannot have
two outstanding under one id — so it is dropped: no second hold, no second
block, no second stage event, and the id the client holds still answers the
agent.

The guard is on the **id**, not on holding, so an adapter that genuinely asks
again under a different id while one is held is still raised. There is a test
for each direction, and the first was verified to fail with the guard removed.

Part of #643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
