### PR TITLE
feat(gemini): delete the last vendor permission-bypass flag (#941)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2473,9 +2473,9 @@ defmodule Fountain.Conversations.ConversationServer do
           # nothing and the id that comes back overwrites this one (see the
           # `{:acp, ref, {:session, id}}` handler). What the row still buys is
           # the `mode` decision above — a persisted id means "a turn has
-          # happened", which is the only thing gemini's legacy `--resume`
-          # needs, since `Gemini.build_command/5` ignores the id and re-enters
-          # the most recent conversation in the workspace.
+          # happened", which is what picks `session/resume` or `session/load`
+          # over `session/new`. It used to buy gemini's legacy `--resume` the
+          # same signal; that argv is gone with #941.
           new_id = Ecto.UUID.generate()
           {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: new_id})
           new_id

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -29,11 +29,12 @@ defmodule Fountain.Runtimes.ACP do
   `Peer`'s replay-discard exists for exactly this, and Gemini is the runtime
   that actually exercises it.
 
-  Converting Gemini is still worth it despite the replay, because its legacy
-  resume is the worst thing we ship: `gemini --resume` re-enters "the most
-  recent conversation in the workspace" (`gemini.ex:14-17`), which is correct
-  only while one conversation ever runs per workspace — an invariant held by
-  accident and asserted by no test. ACP names the session.
+  Converting Gemini was worth it despite the replay, because its legacy resume
+  was the worst thing we shipped: `gemini --resume` re-entered "the most recent
+  conversation in the workspace", correct only while one conversation ever ran
+  per workspace — an invariant held by accident and asserted by no test. ACP
+  names the session. That argv is deleted (#941), and with it the last vendor
+  permission-bypass flag Fountain passed.
 
   **Gemini was held back for eleven days** (#659) by a defect in its own
   session store, and now ships behind a workaround for it. The mechanism is

--- a/apps/fountain/lib/fountain/runtimes/gemini.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini.ex
@@ -2,26 +2,35 @@ defmodule Fountain.Runtimes.Gemini do
   @moduledoc """
   Google Gemini CLI runtime.
 
-  Argv shape:
+  Provisioning only. Gemini speaks ACP since #659, so a turn spawns
+  `gemini --acp` (`Fountain.Runtimes.ACP`) and the prompt, the model, the
+  session id and the MCP servers all travel over the protocol rather than in
+  argv. This module is what remains: the workspace, the skills paths, the
+  settings file and `GEMINI_API_KEY`.
 
-      mode == :run       → gemini --output-format stream-json --model <model_id>
-      mode == :continue  → gemini --resume --output-format stream-json --model <model_id>
+  `build_command/5` is gone with #941. It was the last implementation of that
+  callback and the last place Fountain passed a vendor permission-bypass flag
+  (`--approval-mode yolo`, matching the `--dangerously-*` flags claude, codex
+  and opencode lost when their legacy spawn paths were deleted). Permissions
+  are now a policy (#939) answered per tool over `session/request_permission`,
+  with `ask` reaching a human (#940).
 
-  `--model` (also spelled `-m`) takes the bare id, so the canonical
-  `google/` prefix on `agent.model` is stripped — see
-  `Fountain.Runtimes.Model`.
+  Two things that lived in that argv and did not disappear with it:
 
-  Gemini manages its own session state — `--resume` re-enters the most
-  recent conversation in the workspace, so we don't pass a session id.
-  `--output-format stream-json` is the line-delimited stream the worker
-  tails.
+  * **the model.** `--model` took the bare id, stripped from the canonical
+    `google/` prefix. ACP pins it per session instead — gemini advertises
+    `models`, so `Peer` sends `session/set_model` (see "model selection" in
+    `acp/peer_test.exs`). The #553 regression it guarded against is still
+    guarded, one layer down.
+  * **`--resume`.** It re-entered "the most recent conversation in the
+    workspace", correct only while one conversation ever ran per workspace.
+    ACP names the session, which is the whole reason the conversion was worth
+    doing.
 
   Auth: `GEMINI_API_KEY` exported into the sprite.
   """
 
   @behaviour Fountain.Runtimes
-
-  alias Fountain.Runtimes.Model
 
   # Run gemini from a workspace dir we own and have git-init'd; avoids
   # the noisy `[WARN] [MemoryDiscovery] EACCES at /home/sprite/.git`
@@ -37,45 +46,6 @@ defmodule Fountain.Runtimes.Gemini do
 
   @impl true
   def skills_sh_agent, do: "gemini-cli"
-
-  @impl true
-  def build_command(agent, _prompt, mode, _runtime_session_id, opts) do
-    base =
-      [
-        "--output-format",
-        "stream-json",
-        # `yolo` auto-approves tool calls — matches claude's
-        # `--dangerously-skip-permissions` and codex's
-        # `--dangerously-bypass-approvals-and-sandbox`.
-        "--approval-mode",
-        "yolo"
-      ] ++ Model.model_args(agent)
-
-    # Non-interactive gemini does NOT load MCP tools by default. The
-    # `--allowed-mcp-server-names` flag is the explicit allow-list.
-    mcp_args =
-      case mcp_server_names(agent) do
-        [] -> []
-        names -> ["--allowed-mcp-server-names" | names]
-      end
-
-    resume = if mode == :continue, do: ["--resume"], else: []
-
-    # Gemini has no --image flag. The @path syntax embedded in the prompt
-    # text tells gemini-cli to include that file as multimodal context.
-    prompt_suffix =
-      case Keyword.get(opts, :images, []) do
-        [] -> ""
-        images -> "\n" <> Enum.map_join(images, "\n", fn {path, _mt} -> "@#{path}" end)
-      end
-
-    {"gemini", resume ++ base ++ mcp_args, [dir: @workdir, prompt_suffix: prompt_suffix]}
-  end
-
-  defp mcp_server_names(%{mcp_servers: m}) when is_map(m) and m != %{},
-    do: m |> Map.keys() |> Enum.map(&to_string/1)
-
-  defp mcp_server_names(_), do: []
 
   @impl true
   def default_env(_agent, inference_credentials) do

--- a/apps/fountain/test/fountain/runtimes/model_test.exs
+++ b/apps/fountain/test/fountain/runtimes/model_test.exs
@@ -114,23 +114,14 @@ defmodule Fountain.Runtimes.ModelTest do
   end
 
   # The regression #553 describes: runtimes built argv that never mentioned
-  # agent.model, so the CLI's own default ran instead. Only gemini still
-  # builds argv — the other runtimes' turns travel over ACP, where the model
-  # is pinned per session by the peer (see "model selection" in
-  # acp/peer_test.exs).
-  describe "build_command/5 honours agent.model" do
-    test "gemini passes the bare id" do
-      {"gemini", argv, _opts} =
-        Runtimes.Gemini.build_command(
-          agent("gemini", "google/gemini-2.5-pro"),
-          "hi",
-          :run,
-          nil,
-          []
-        )
-
-      assert "--model" in argv
-      assert Enum.at(argv, Enum.find_index(argv, &(&1 == "--model")) + 1) == "gemini-2.5-pro"
-    end
-  end
+  # agent.model, so the CLI's own default ran instead.
+  #
+  # No runtime builds argv any more. gemini was the last one, and #941 deleted
+  # its `build_command/5` along with the `--approval-mode yolo` it carried. The
+  # model is pinned per session over ACP now — see "model selection" in
+  # `acp/peer_test.exs`, which is where this regression is guarded.
+  #
+  # `Model.model_args/1` itself is still tested above: it is what an argv-based
+  # runtime would use, and it is cheaper to keep than to re-derive if a fifth
+  # runtime ever arrives that cannot speak ACP.
 end


### PR DESCRIPTION
Closes #941. **ADR 0014 gate 3 is now complete for every runtime.**

`--approval-mode yolo` was the last vendor permission-bypass flag Fountain passed. The other three went with their legacy spawn paths in #671–#675; this one survived only because gemini was still on that path, and #964 took it off.

## Why the whole function, not just the two argv elements

`Gemini.build_command/5` was the last implementation of that callback, and with gemini on ACP it is unreachable. A legacy spawn *stripped of the bypass flag* would hang on an approval prompt nobody can answer — so leaving the function without the flag would be worse than leaving it with one. Deleting it is the honest end state.

## Two things lived in that argv and did not disappear with it

The moduledoc now says where they went, because both were load-bearing:

- **The model.** `--model` took the bare id, stripped of the canonical `google/` prefix. ACP pins it per session instead — gemini advertises `models`, so `Peer` sends `session/set_model`. **The #553 regression that argv guarded against is still guarded**, one layer down; `model_test.exs` now points at the ACP test that does it rather than at a function that no longer exists.
- **`--resume`**, which re-entered *"the most recent conversation in the workspace"* — correct only while one conversation ever ran per workspace, an invariant held by accident and asserted by no test. Removing that was the whole reason converting gemini was worth doing.

`Model.model_args/1` stays, and stays tested: it is what an argv-based runtime would use, and cheaper to keep than to re-derive if a fifth runtime ever arrives that cannot speak ACP.

## Verified

No `yolo` and no `--dangerously-*` flag is passed anywhere in `apps/fountain/lib`. The only remaining mentions are comments explaining what was removed and why — including `peer.ex`, where the comment records that gate 2's constant auto-allow was parity with these flags, which is what #939 turned into a policy.

Also corrects two comments that still described gemini's legacy resume in the present tense.

## Checks

`mix test` — **3,543 tests, 0 failures**. `mix format --check-formatted`, `mix credo --strict` (no issues), `MIX_ENV=dev mix dialyzer` (**0 errors**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
