### PR TITLE
One layout table, so a runtime's HOME and its files agree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,19 @@ upgrade, is in
 
 ### Fixed
 
+- **An opencode or gemini agent ignored its system prompt.** Both runtimes run
+  with `HOME=/tmp` — a workaround for a rename that fails across
+  `/home/sprite`'s ACL boundary — and their skills were written there
+  correctly. The system prompt was not: it went to
+  `/home/sprite/.config/opencode/AGENTS.md` and `/home/sprite/.gemini/GEMINI.md`,
+  which neither CLI reads. Every agent on
+  those two runtimes ran on its CLI's default persona, with nothing in the log
+  to say so, and the test asserted the same wrong paths. Both the `HOME` export
+  and the paths written under it now come from one table
+  (`Fountain.Runtimes.Layout`), so they cannot disagree, and a guardrail test
+  checks the agreement rather than the literals. claude and codex were never
+  affected.
+
 - **A sandbox that failed never recorded when it stopped.** Of the dozen
   writers of a terminal sandbox status, the ones that terminated passed a
   `terminated_at` and the ones that failed never did, so a failed sandbox

--- a/apps/fountain/lib/fountain/runtimes.ex
+++ b/apps/fountain/lib/fountain/runtimes.ex
@@ -7,6 +7,24 @@ defmodule Fountain.Runtimes do
   skills layout, sandbox bootstrap. Turn I/O is ACP (`Fountain.Runtimes.ACP`)
   for every supported runtime; `build_command/5` exists only for runtimes
   still on the legacy spawn path (gemini, #659), which is why it is optional.
+
+  What varies between runtimes here falls into three kinds, and only the last
+  needs code:
+
+    * **Layout** — where files go. Perfectly regular (`<home>/<config_dir>/…`)
+      and now stated once, in `Fountain.Runtimes.Layout`. `skills_root/0`,
+      `skills_sh_agent/0`, the instructions path and every workspace directory
+      are derived from that table rather than restated per module.
+    * **Workarounds** — an upstream defect each runtime carries, with a
+      deletion condition: claude's MCP servers going in as files because the
+      ACP session-scoped channel is dropped on the floor
+      (`claude-agent-acp#883`), gemini's session store consolidation
+      (`gemini-cli#28775`), opencode not being on the base image, and
+      `HOME=/tmp` for the two runtimes that trip the sprite's rename ACL.
+    * **Credential delivery** — genuinely irreducible, and two shapes rather
+      than four: an env var (claude, gemini, opencode) or a login exec that
+      consumes the key on stdin (codex, whose CLI ignores the process env).
+      See `default_env/2` and `prepare_sandbox/3`.
   """
 
   alias Fountain.Agents.Agent
@@ -40,6 +58,30 @@ defmodule Fountain.Runtimes do
   decrypted from the user's `inference_credentials` row at conversation
   start (see `Fountain.InferenceCredentials.decrypted_for_user/2`).
   Providers the user hasn't set are simply absent from the map.
+
+  ## Why this cannot be a table
+
+  Three things happen here that layout cannot express, and they are the
+  reason this stays a callback rather than another column:
+
+    * **Which provider.** claude, codex and gemini each have one. opencode is
+      a front-end for all three, so the variable it needs is a function of
+      `agent.model` — `Fountain.Runtimes.Model.provider/1` decides at
+      provision time.
+    * **Which credential, for one provider.** claude takes either a
+      `CLAUDE_CODE_OAUTH_TOKEN` (bills a Claude.ai subscription) or an
+      `ANTHROPIC_API_KEY` (metered), never both — exporting both has picked
+      the wrong one depending on CLI version. The precedence, and the
+      mid-conversation fall back to the API key when an org refuses the OAuth
+      token (#655), are provider policy with no analogue on the others.
+    * **Whether an env var works at all.** codex 0.118+ does not read
+      `OPENAI_API_KEY` at exec time. It reads `~/.codex/auth.json`, which only
+      `codex login --with-api-key` writes, so its credential is delivered by
+      `prepare_sandbox/3` instead — see there.
+
+  So the shape is two-of-four, not four-of-four: an env var, or a login exec.
+  Worth restating whenever a fifth runtime arrives, because "just add a column
+  for the variable name" is right up until it is codex.
   """
   @callback default_env(
               agent :: %Agent{},
@@ -61,6 +103,23 @@ defmodule Fountain.Runtimes do
 
   Receives the same `sprite_env` pairs the spawn will use. Implementers
   pull whichever keys they need out of that list. No-op by default.
+
+  ## This is the escape hatch, and it should stay one
+
+  Three runtimes implement it and each does something genuinely imperative —
+  a login that consumes a key on stdin, a `bun install`, a `git init`. None
+  of those is expressible as data, and an abstraction that swallowed them
+  would cost more than the duplication it removed. What *was* data (where the
+  workspace lives, what HOME is) has already moved to
+  `Fountain.Runtimes.Layout`; what is left here is the residue that has to be
+  code.
+
+  Runs after `Fountain.Runtimes.ACP.install/3` and after the whole
+  provisioning pipeline, so it can assume the adapter is on PATH. Note the
+  ordering costs something: `Provisioning.apply_network_policy/3` has already
+  run, so opencode's `bun install` here needs the npm registry on the
+  allowlist of any `limited` environment. It works today because the default
+  is `unrestricted`.
   """
   @callback prepare_sandbox(
               handle :: Fountain.Sandbox.Handle.t(),
@@ -72,6 +131,10 @@ defmodule Fountain.Runtimes do
   Absolute path on the sprite where inline skills are written as
   `<skills_root>/<name>/SKILL.md`. Each runtime points this at whatever
   directory its CLI scans for skills.
+
+  Answered from `Fountain.Runtimes.Layout` by every implementation — it stays
+  a callback because `Fountain.SandboxSkills` reaches it through the module,
+  not because any runtime has ever needed to depart from the table.
   """
   @callback skills_root() :: String.t()
 
@@ -79,7 +142,7 @@ defmodule Fountain.Runtimes do
   Identifier passed to `npx skills add ... --agent <id>` when installing
   a github-source skill. The skills.sh CLI uses this to choose the
   on-disk layout for the target runtime (claude-code, codex, gemini-cli,
-  opencode).
+  opencode). Also from `Fountain.Runtimes.Layout`.
   """
   @callback skills_sh_agent() :: String.t()
 

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -110,7 +110,10 @@ defmodule Fountain.Runtimes.ACP do
 
   alias Fountain.Agents.Agent
 
-  # Per runtime: how ACP is reached, and where the agent should run.
+  # Per runtime: how ACP is reached. Where the agent *runs* is not here —
+  # that is layout, and it lives in `Fountain.Runtimes.Layout` alongside the
+  # workspace each runtime's `prepare_sandbox/3` git-inits. This table used
+  # to carry its own `cwd` copy, with a comment admitting the mirror.
   #
   # `package` nil means native support — the runtime speaks ACP itself and
   # arrives with the sprite base image, so there is nothing to install and
@@ -126,16 +129,13 @@ defmodule Fountain.Runtimes.ACP do
       bin: "claude-agent-acp",
       args: [],
       package: "@agentclientprotocol/claude-agent-acp",
-      version: "0.66.0",
-      cwd: "/home/sprite"
+      version: "0.66.0"
     },
     # Native: `gemini --acp`. Advertises `loadSession: true` and **no**
     # `sessionCapabilities`, so every turn after the first pays a full replay
-    # that `Peer` discards. The cwd mirrors `Fountain.Runtimes.Gemini`'s
-    # `@workdir` — gemini walks up from cwd looking for a `.git`, and
-    # `Gemini.prepare_sandbox/3` git-inits exactly this directory. Pointing it
-    # at /home/sprite instead reintroduces the EACCES noise that workspace
-    # exists to avoid.
+    # that `Peer` discards. Its cwd matters more than the others' — gemini
+    # walks up from it looking for a `.git` — and both that path and the
+    # `git init` that satisfies it now come from `Fountain.Runtimes.Layout`.
     # Shippable since #659. Gemini's own session store erases a session in the
     # act of loading it (google-gemini/gemini-cli#28775, still open on 0.56.0 —
     # the moduledoc has the mechanism), which held this entry back for eleven
@@ -146,8 +146,7 @@ defmodule Fountain.Runtimes.ACP do
       bin: "gemini",
       args: ["--acp"],
       package: nil,
-      version: nil,
-      cwd: "/tmp/gemini-workspace"
+      version: nil
     },
     # Adapter, on the Codex App Server. The `zed-industries/codex-acp` that
     # earlier drafts named is archived; this is its successor under the
@@ -158,8 +157,7 @@ defmodule Fountain.Runtimes.ACP do
       bin: "codex-acp",
       args: [],
       package: "@agentclientprotocol/codex-acp",
-      version: "1.1.14",
-      cwd: "/home/sprite"
+      version: "1.1.14"
     },
     # Native: `opencode acp`. Heavier than the others — the subcommand starts a
     # local HTTP server inside the sprite and drives it through opencode's own
@@ -181,7 +179,6 @@ defmodule Fountain.Runtimes.ACP do
       args: ["acp"],
       package: nil,
       version: nil,
-      cwd: "/tmp/opencode-workspace",
       asks_permission: false
     }
   }
@@ -263,7 +260,7 @@ defmodule Fountain.Runtimes.ACP do
   repo (gemini does) behaves differently depending on what we say here.
   """
   @spec cwd(String.t()) :: String.t()
-  def cwd(runtime), do: get_in(@adapters, [runtime, :cwd]) || "/home/sprite"
+  def cwd(runtime), do: Fountain.Runtimes.Layout.cwd(runtime) || "/home/sprite"
 
   @doc """
   Whether this turn speaks ACP.
@@ -303,10 +300,18 @@ defmodule Fountain.Runtimes.ACP do
   @doc """
   Install the pinned adapter into a sprite.
 
-  Runs at provision time, with the rest of the package installs, because it
-  needs unrestricted network — by the time a turn spawns, the network policy
-  has been applied and an install would fail in a way that looks like a
-  protocol bug.
+  Runs at provision time rather than at spawn: by the time a turn spawns the
+  sandbox may be suspended-and-resumed or policy-restricted, and an install
+  failing there reads as a protocol bug rather than a missing package.
+
+  It does **not** run with the rest of the package installs, which an earlier
+  version of this paragraph claimed. `prepare_runtime_sprite/5` is called
+  after `run_provisioning_pipeline/5`, so this lands *after*
+  `Provisioning.apply_network_policy/3`. On the default `unrestricted`
+  environment that costs nothing. On a `limited` one the allowlist has to
+  include the npm registry, or the adapter install fails here — the same
+  exposure `Fountain.Runtimes.OpenCode.prepare_sandbox/3`'s `bun install` has,
+  for the same reason.
 
   Idempotent on the exact pinned version: an image that already carries a
   different version is corrected rather than accepted, since "some adapter is

--- a/apps/fountain/lib/fountain/runtimes/claude.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude.ex
@@ -36,14 +36,20 @@ defmodule Fountain.Runtimes.Claude do
 
   @behaviour Fountain.Runtimes
 
-  @mcp_config "/home/sprite/.mcp.json"
-  @settings "/home/sprite/.claude/settings.json"
+  alias Fountain.Runtimes.Layout
+
+  @runtime "claude"
+
+  # The project-scope config sits at the repo root the agent runs in, not
+  # under the config directory — that is what makes it *project* scope.
+  @mcp_config Path.join(Layout.cwd(@runtime), ".mcp.json")
+  @settings Path.join(Layout.config_root(@runtime), "settings.json")
 
   @impl true
-  def skills_root, do: "/home/sprite/.claude/skills"
+  def skills_root, do: Layout.skills_root(@runtime)
 
   @impl true
-  def skills_sh_agent, do: "claude-code"
+  def skills_sh_agent, do: Layout.skills_sh_agent(@runtime)
 
   @impl true
   def default_env(_agent, inference_credentials) do

--- a/apps/fountain/lib/fountain/runtimes/codex.ex
+++ b/apps/fountain/lib/fountain/runtimes/codex.ex
@@ -15,11 +15,15 @@ defmodule Fountain.Runtimes.Codex do
 
   @behaviour Fountain.Runtimes
 
-  @impl true
-  def skills_root, do: "/home/sprite/.codex/skills"
+  alias Fountain.Runtimes.Layout
+
+  @runtime "codex"
 
   @impl true
-  def skills_sh_agent, do: "codex"
+  def skills_root, do: Layout.skills_root(@runtime)
+
+  @impl true
+  def skills_sh_agent, do: Layout.skills_sh_agent(@runtime)
 
   @impl true
   def default_env(_agent, inference_credentials) do

--- a/apps/fountain/lib/fountain/runtimes/gemini.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini.ex
@@ -32,20 +32,24 @@ defmodule Fountain.Runtimes.Gemini do
 
   @behaviour Fountain.Runtimes
 
+  alias Fountain.Runtimes.Layout
+
+  @runtime "gemini"
+
   # Run gemini from a workspace dir we own and have git-init'd; avoids
   # the noisy `[WARN] [MemoryDiscovery] EACCES at /home/sprite/.git`
   # message (gemini walks up from cwd looking for .git, and /home/sprite's
   # perms trip it).  Also gives MemoryDiscovery a real workspace root
-  # to anchor on instead of crawling /home.
-  @workdir "/tmp/gemini-workspace"
-
-  # gemini runs with HOME=/tmp on the sprite, so its skill discovery
-  # path is /tmp/.gemini/skills (NOT /home/sprite/.gemini/skills).
-  @impl true
-  def skills_root, do: "/tmp/.gemini/skills"
+  # to anchor on instead of crawling /home. `Fountain.Runtimes.Layout` owns
+  # the path, and the ACP session runs in the same place because it reads
+  # the same row.
+  @workdir Layout.cwd(@runtime)
 
   @impl true
-  def skills_sh_agent, do: "gemini-cli"
+  def skills_root, do: Layout.skills_root(@runtime)
+
+  @impl true
+  def skills_sh_agent, do: Layout.skills_sh_agent(@runtime)
 
   @impl true
   def default_env(_agent, inference_credentials) do
@@ -61,8 +65,10 @@ defmodule Fountain.Runtimes.Gemini do
     # can write into /home/sprite/.gemini at first glance (ACLs let `ls`
     # and most writes through), but rename across that boundary errors
     # out. /tmp side-steps it cleanly. Mirrors the same fix we needed
-    # for opencode's `~/.opencode` access path.
-    base ++ [{"HOME", "/tmp"}]
+    # for opencode's `~/.opencode` access path. The path itself lives in
+    # `Fountain.Runtimes.Layout`, so the HOME gemini gets and the HOME
+    # Fountain writes its config under are the same one by construction.
+    base ++ Layout.home_env(@runtime)
   end
 
   # Gemini reads user-scope MCP servers from `$HOME/.gemini/settings.json`,
@@ -70,13 +76,15 @@ defmodule Fountain.Runtimes.Gemini do
   # with HOME=/tmp, write there only — duplicating into /home/sprite
   # was making gemini register every MCP tool twice on startup and
   # spam the log with `Tool ... already registered. Overwriting.` lines.
+  @settings Path.join(Layout.config_root(@runtime), "settings.json")
+
   @impl true
   def write_config(_handle, nil), do: :ok
   def write_config(_handle, %{mcp_servers: m}) when m == %{} or is_nil(m), do: :ok
 
   def write_config(handle, %{mcp_servers: mcp_servers}) do
     payload = Jason.encode!(%{"mcpServers" => mcp_servers}, pretty: true)
-    Fountain.Sandbox.write_file(handle, "/tmp/.gemini/settings.json", payload)
+    Fountain.Sandbox.write_file(handle, @settings, payload)
     :ok
   end
 

--- a/apps/fountain/lib/fountain/runtimes/instructions.ex
+++ b/apps/fountain/lib/fountain/runtimes/instructions.ex
@@ -22,22 +22,24 @@ defmodule Fountain.Runtimes.Instructions do
   | opencode | `~/.config/opencode/AGENTS.md`       |
   | gemini   | `~/.gemini/GEMINI.md`                |
 
+  `~` is the runtime's own HOME, which is **not** `/home/sprite` for all of
+  them — opencode and gemini run with `HOME=/tmp`. This module used to expand
+  the table above against a hardcoded `/home/sprite`, so for those two the
+  prompt was written where their CLI never looks: they ran on the default
+  persona, silently, and the test pinned the wrong path alongside. The paths
+  now come from `Fountain.Runtimes.Layout`, which is also where the `HOME`
+  export is derived from, so the two cannot disagree again.
+
   The file carries a short header so a human (or the agent) reading it knows
   where it came from, then the prompt verbatim.
   """
 
-  @home "/home/sprite"
-
-  @paths %{
-    "claude" => "#{@home}/.claude/CLAUDE.md",
-    "codex" => "#{@home}/.codex/AGENTS.md",
-    "opencode" => "#{@home}/.config/opencode/AGENTS.md",
-    "gemini" => "#{@home}/.gemini/GEMINI.md"
-  }
+  alias Fountain.Runtimes.Layout
 
   @doc "The user-level instructions file the runtime reads, or nil for a runtime we do not know."
   @spec path(String.t() | nil) :: String.t() | nil
-  def path(runtime), do: Map.get(@paths, runtime)
+  def path(runtime) when is_binary(runtime), do: Layout.instructions_path(runtime)
+  def path(_runtime), do: nil
 
   @doc """
   Write the agent's system prompt for the runtime into the sandbox. Returns

--- a/apps/fountain/lib/fountain/runtimes/layout.ex
+++ b/apps/fountain/lib/fountain/runtimes/layout.ex
@@ -1,0 +1,175 @@
+defmodule Fountain.Runtimes.Layout do
+  @moduledoc """
+  Where a runtime keeps its files inside a sandbox — one table, derived
+  everywhere else.
+
+  Every path Fountain writes for a runtime has the same shape:
+
+      <home>/<config_dir>/<leaf>
+
+  and each runtime module used to restate its own half of that from memory.
+  `skills_root/0` derived it correctly; `Fountain.Runtimes.Instructions`
+  derived it again with `/home/sprite` hardcoded; `Fountain.Runtimes.Gemini`
+  and `Fountain.Runtimes.OpenCode` each named a workspace directory that
+  `Fountain.Runtimes.ACP`'s adapter table then named a second time — with a
+  comment admitting the mirror.
+
+  That duplication was not merely untidy, it was wrong: opencode and gemini
+  run with `HOME=/tmp` (see `home/1`), so their system prompts were being
+  written to `/home/sprite/...`, where neither CLI looks. The agent ran on its
+  CLI's default persona and nothing reported it. Deriving both the HOME export
+  and the instructions path from the same row makes that class of drift
+  unrepresentable.
+
+  ## The table
+
+  | runtime  | home           | config_dir        | instructions   |
+  |----------|----------------|-------------------|----------------|
+  | claude   | `/home/sprite` | `.claude`         | `CLAUDE.md`    |
+  | codex    | `/home/sprite` | `.codex`          | `AGENTS.md`    |
+  | gemini   | `/tmp`         | `.gemini`         | `GEMINI.md`    |
+  | opencode | `/tmp`         | `.config/opencode`| `AGENTS.md`    |
+
+  This is layout only — where files go, and which on-disk dialect writes
+  them. What goes *in* those files (credentials, MCP servers, the agent's
+  prompt) stays with the runtime modules, and the imperative bootstrap each
+  runtime needs stays in its `prepare_sandbox/3`. See `Fountain.Runtimes`.
+  """
+
+  # The sprite image's own home directory. A runtime whose `home` matches
+  # inherits it and exports nothing; one that differs gets an explicit HOME
+  # (see `home_env/1`).
+  @image_home "/home/sprite"
+
+  @layouts %{
+    "claude" => %{
+      home: @image_home,
+      config_dir: ".claude",
+      instructions_file: "CLAUDE.md",
+      skills_sh_agent: "claude-code",
+      cwd: @image_home
+    },
+    "codex" => %{
+      home: @image_home,
+      config_dir: ".codex",
+      instructions_file: "AGENTS.md",
+      skills_sh_agent: "codex",
+      cwd: @image_home
+    },
+    # HOME=/tmp: gemini-cli aborts during init if it cannot rename
+    # `~/.gemini/projects.json.tmp` onto `projects.json`, and that rename
+    # errors across /home/sprite's ACL boundary even though plain writes
+    # succeed. The workspace is separate again because gemini walks up from
+    # cwd looking for a `.git` and trips the same perms on /home/sprite;
+    # `Fountain.Runtimes.Gemini.prepare_sandbox/3` git-inits exactly this
+    # directory.
+    "gemini" => %{
+      home: "/tmp",
+      config_dir: ".gemini",
+      instructions_file: "GEMINI.md",
+      skills_sh_agent: "gemini-cli",
+      cwd: "/tmp/gemini-workspace"
+    },
+    # HOME=/tmp for the same rename/ACL reason as gemini. opencode also
+    # insists on running inside a git repo, and the sprite user cannot
+    # `git init` in $HOME (work-tree perms), so the workspace is its own
+    # directory under /tmp.
+    "opencode" => %{
+      home: "/tmp",
+      config_dir: ".config/opencode",
+      instructions_file: "AGENTS.md",
+      skills_sh_agent: "opencode",
+      cwd: "/tmp/opencode-workspace"
+    }
+  }
+
+  @type runtime :: String.t()
+
+  @doc "Every runtime with a layout. Sorted, so callers get a stable order."
+  @spec runtimes() :: [runtime()]
+  def runtimes, do: @layouts |> Map.keys() |> Enum.sort()
+
+  @doc """
+  The runtime's HOME inside the sandbox.
+
+  Not always the image's own: two runtimes are moved to `/tmp` to dodge a
+  rename that fails across `/home/sprite`'s ACL boundary. Returns nil for a
+  runtime we do not know.
+  """
+  @spec home(runtime()) :: String.t() | nil
+  def home(runtime), do: get_in(@layouts, [runtime, :home])
+
+  @doc """
+  The `HOME` pair to export for this runtime, or `[]` when the image's own
+  home is already right.
+
+  Meant to be appended to a runtime's `default_env/2`, so the HOME the
+  process gets and the HOME the provisioning paths are built from cannot
+  disagree.
+  """
+  @spec home_env(runtime()) :: [{String.t(), String.t()}]
+  def home_env(runtime) do
+    case home(runtime) do
+      nil -> []
+      @image_home -> []
+      other -> [{"HOME", other}]
+    end
+  end
+
+  @doc "The runtime's config directory, absolute: `<home>/<config_dir>`."
+  @spec config_root(runtime()) :: String.t() | nil
+  def config_root(runtime) do
+    with home when is_binary(home) <- home(runtime),
+         dir when is_binary(dir) <- get_in(@layouts, [runtime, :config_dir]) do
+      Path.join(home, dir)
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Absolute path the runtime's CLI scans for skills, written as
+  `<skills_root>/<name>/SKILL.md` by `Fountain.SandboxSkills`.
+
+  Every runtime puts this directly under its config root; none of them has
+  ever needed to differ, which is why it is derived rather than listed.
+  """
+  @spec skills_root(runtime()) :: String.t() | nil
+  def skills_root(runtime) do
+    case config_root(runtime) do
+      nil -> nil
+      root -> Path.join(root, "skills")
+    end
+  end
+
+  @doc """
+  The user-level instructions file the runtime reads at session start — where
+  the agent's `system` prompt is delivered. See
+  `Fountain.Runtimes.Instructions`.
+  """
+  @spec instructions_path(runtime()) :: String.t() | nil
+  def instructions_path(runtime) do
+    with root when is_binary(root) <- config_root(runtime),
+         file when is_binary(file) <- get_in(@layouts, [runtime, :instructions_file]) do
+      Path.join(root, file)
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Working directory the agent runs in — the cwd handed to the ACP session,
+  and the workspace a runtime's `prepare_sandbox/3` git-inits when it needs
+  one. Returns nil for a runtime we do not know; `Fountain.Runtimes.ACP.cwd/1`
+  is where the fallback for that lives.
+  """
+  @spec cwd(runtime()) :: String.t() | nil
+  def cwd(runtime), do: get_in(@layouts, [runtime, :cwd])
+
+  @doc """
+  Identifier passed to `npx skills add ... --agent <id>`. The skills.sh CLI
+  uses it to choose the on-disk layout for the target runtime.
+  """
+  @spec skills_sh_agent(runtime()) :: String.t() | nil
+  def skills_sh_agent(runtime), do: get_in(@layouts, [runtime, :skills_sh_agent])
+end

--- a/apps/fountain/lib/fountain/runtimes/open_code.ex
+++ b/apps/fountain/lib/fountain/runtimes/open_code.ex
@@ -20,29 +20,32 @@ defmodule Fountain.Runtimes.OpenCode do
 
   @behaviour Fountain.Runtimes
 
+  alias Fountain.Runtimes.Layout
   alias Fountain.Runtimes.Model
 
-  # opencode insists on being inside a git repo. Putting the workspace
-  # in /tmp side-steps the sprite user's lack of write access on
-  # /home/sprite (which prevents `git init` from stat'ing the work tree).
-  # Mirrors `Fountain.Runtimes.ACP.cwd("opencode")`, which is where the ACP
-  # session actually runs.
-  @workdir "/tmp/opencode-workspace"
+  @runtime "opencode"
 
-  # opencode runs with HOME=/tmp (see default_env/1), so its skills
-  # discovery path is rooted there.
-  @impl true
-  def skills_root, do: "/tmp/.config/opencode/skills"
+  # opencode insists on being inside a git repo, and the sprite user cannot
+  # `git init` in /home/sprite (work-tree perms). The workspace lives under
+  # /tmp for that reason; `Fountain.Runtimes.Layout` owns the path, and the
+  # ACP session runs in the same place because it reads the same row.
+  @workdir Layout.cwd(@runtime)
 
   @impl true
-  def skills_sh_agent, do: "opencode"
+  def skills_root, do: Layout.skills_root(@runtime)
 
+  @impl true
+  def skills_sh_agent, do: Layout.skills_sh_agent(@runtime)
+
+  # HOME comes from the layout, so the directory opencode actually reads and
+  # the directory Fountain writes its skills and instructions into are the
+  # same one by construction.
   @impl true
   def default_env(%{model: model} = agent, inference_credentials) when is_binary(model) do
-    provider_env(agent, inference_credentials) ++ [{"HOME", "/tmp"}]
+    provider_env(agent, inference_credentials) ++ Layout.home_env(@runtime)
   end
 
-  def default_env(_, _inference_credentials), do: [{"HOME", "/tmp"}]
+  def default_env(_, _inference_credentials), do: Layout.home_env(@runtime)
 
   defp provider_env(%{model: model}, inference_credentials) do
     case Model.provider(model) do

--- a/apps/fountain/test/fountain/runtimes/instructions_test.exs
+++ b/apps/fountain/test/fountain/runtimes/instructions_test.exs
@@ -11,9 +11,17 @@ defmodule Fountain.Runtimes.InstructionsTest do
   test "each ACP runtime has a user-level instructions file; unknown runtimes none" do
     assert Instructions.path("claude") == "/home/sprite/.claude/CLAUDE.md"
     assert Instructions.path("codex") == "/home/sprite/.codex/AGENTS.md"
-    assert Instructions.path("opencode") == "/home/sprite/.config/opencode/AGENTS.md"
-    assert Instructions.path("gemini") == "/home/sprite/.gemini/GEMINI.md"
+
+    # Under the runtime's *own* HOME, which is /tmp for these two. The earlier
+    # version of this test asserted /home/sprite for both — the same wrong
+    # answer the code gave, so it pinned the bug instead of catching it.
+    # `Fountain.Runtimes.LayoutTest` now checks the agreement rather than the
+    # literal.
+    assert Instructions.path("opencode") == "/tmp/.config/opencode/AGENTS.md"
+    assert Instructions.path("gemini") == "/tmp/.gemini/GEMINI.md"
+
     assert Instructions.path("nope") == nil
+    assert Instructions.path(nil) == nil
   end
 
   test "writes the prompt verbatim, with a provenance header, to the runtime's file" do

--- a/apps/fountain/test/fountain/runtimes/layout_test.exs
+++ b/apps/fountain/test/fountain/runtimes/layout_test.exs
@@ -1,0 +1,113 @@
+defmodule Fountain.Runtimes.LayoutTest do
+  @moduledoc """
+  The layout table, and the agreement it exists to enforce.
+
+  The interesting tests here are the last two: they walk every runtime and
+  check that the HOME the process is given and the HOME its files are written
+  under are the same directory. That disagreement is what shipped — opencode
+  and gemini ran with `HOME=/tmp` while their system prompts were written to
+  `/home/sprite`, so both ran on the CLI's default persona and nothing said
+  so.
+  """
+  use ExUnit.Case, async: true
+
+  alias Fountain.Runtimes
+  alias Fountain.Runtimes.Instructions
+  alias Fountain.Runtimes.Layout
+
+  test "every runtime in the dispatcher has a layout row, and vice versa" do
+    assert Layout.runtimes() == ["claude", "codex", "gemini", "opencode"]
+
+    for runtime <- Layout.runtimes() do
+      assert {:ok, _mod} = Runtimes.for_runtime(runtime)
+    end
+  end
+
+  test "paths are derived from home and config_dir" do
+    assert Layout.config_root("claude") == "/home/sprite/.claude"
+    assert Layout.skills_root("claude") == "/home/sprite/.claude/skills"
+    assert Layout.instructions_path("claude") == "/home/sprite/.claude/CLAUDE.md"
+
+    assert Layout.config_root("codex") == "/home/sprite/.codex"
+    assert Layout.skills_root("codex") == "/home/sprite/.codex/skills"
+    assert Layout.instructions_path("codex") == "/home/sprite/.codex/AGENTS.md"
+
+    # HOME=/tmp for these two — the paths follow it.
+    assert Layout.config_root("gemini") == "/tmp/.gemini"
+    assert Layout.skills_root("gemini") == "/tmp/.gemini/skills"
+    assert Layout.instructions_path("gemini") == "/tmp/.gemini/GEMINI.md"
+
+    assert Layout.config_root("opencode") == "/tmp/.config/opencode"
+    assert Layout.skills_root("opencode") == "/tmp/.config/opencode/skills"
+    assert Layout.instructions_path("opencode") == "/tmp/.config/opencode/AGENTS.md"
+  end
+
+  test "an unknown runtime has no layout rather than a plausible-looking one" do
+    for f <- [:home, :config_root, :skills_root, :instructions_path, :cwd, :skills_sh_agent] do
+      assert apply(Layout, f, ["nope"]) == nil
+    end
+
+    assert Layout.home_env("nope") == []
+  end
+
+  test "home_env exports HOME only where it differs from the image's own" do
+    assert Layout.home_env("claude") == []
+    assert Layout.home_env("codex") == []
+    assert Layout.home_env("gemini") == [{"HOME", "/tmp"}]
+    assert Layout.home_env("opencode") == [{"HOME", "/tmp"}]
+  end
+
+  test "the workspace an agent runs in is the one its layout names" do
+    assert Layout.cwd("claude") == "/home/sprite"
+    assert Layout.cwd("codex") == "/home/sprite"
+    assert Layout.cwd("gemini") == "/tmp/gemini-workspace"
+    assert Layout.cwd("opencode") == "/tmp/opencode-workspace"
+
+    # ACP hands this to the agent in `session/new`; it must not have drifted
+    # back into a second copy.
+    for runtime <- Layout.runtimes() do
+      assert Fountain.Runtimes.ACP.cwd(runtime) == Layout.cwd(runtime)
+    end
+  end
+
+  describe "the HOME a runtime gets and the HOME its files go under" do
+    test "agree, for every runtime" do
+      for runtime <- Layout.runtimes() do
+        {:ok, mod} = Runtimes.for_runtime(runtime)
+
+        # No credentials on file, so whatever is left is the layout's doing.
+        exported =
+          case List.keyfind(mod.default_env(nil, %{}), "HOME", 0) do
+            {"HOME", home} -> home
+            nil -> "/home/sprite"
+          end
+
+        assert exported == Layout.home(runtime),
+               "#{runtime} runs with HOME=#{exported} but its layout says #{Layout.home(runtime)}"
+      end
+    end
+
+    test "so every provisioned path sits under the runtime's own HOME" do
+      for runtime <- Layout.runtimes() do
+        {:ok, mod} = Runtimes.for_runtime(runtime)
+        home = Layout.home(runtime)
+
+        for {what, path} <- [
+              skills_root: mod.skills_root(),
+              instructions: Instructions.path(runtime)
+            ] do
+          assert String.starts_with?(path, home <> "/"),
+                 "#{runtime}'s #{what} is #{path}, which is not under HOME=#{home}"
+        end
+      end
+    end
+  end
+
+  test "runtime modules answer from the table rather than their own copy" do
+    for runtime <- Layout.runtimes() do
+      {:ok, mod} = Runtimes.for_runtime(runtime)
+      assert mod.skills_root() == Layout.skills_root(runtime)
+      assert mod.skills_sh_agent() == Layout.skills_sh_agent(runtime)
+    end
+  end
+end


### PR DESCRIPTION
Tier 1 of unifying the per-runtime provisioning path: collapse the layout duplication, and fix the bug it was producing.

## The bug

Every path Fountain writes for a runtime has the shape `<home>/<config_dir>/<leaf>`, and four modules each derived their own half of it from memory:

- `skills_root/0` on each runtime module — correct
- `Runtimes.Instructions.@paths` — derived it again, with `@home "/home/sprite"` hardcoded
- `Gemini.@workdir` / `OpenCode.@workdir` — each restated in `ACP.@adapters[:cwd]`, with a comment admitting the mirror

The `Instructions` copy was not merely untidy. opencode and gemini run with `HOME=/tmp` (a workaround for a rename that fails across `/home/sprite`'s ACL boundary — `Gemini.write_config/2` carries the comment explaining it). So the agent's `system` prompt was being written to `/home/sprite/.config/opencode/AGENTS.md` and `/home/sprite/.gemini/GEMINI.md`, where neither CLI looks.

**Every agent on those two runtimes ran on its CLI's default persona**, with nothing in the log to say so. `instructions_test.exs` asserted the same wrong paths, so it pinned the bug rather than catching it. claude and codex were never affected — they run on `HOME=/home/sprite`, so the hardcode happened to be right for them.

The docs had it right all along (`docs/catalog/runtimes/index.md` says `~/.config/opencode/AGENTS.md`); only the code expanded `~` against the wrong home.

## The fix

`Fountain.Runtimes.Layout` is the single table. `skills_root/0`, `skills_sh_agent/0`, the instructions path, both workspace directories and `ACP.cwd/1` are all derived from it — **and so is the `HOME` export itself**, via `Layout.home_env/1`. That is what makes the disagreement unrepresentable rather than merely fixed once.

`LayoutTest` checks the agreement rather than the literals:

- for every runtime, the `HOME` its `default_env/2` exports equals `Layout.home/1`
- `skills_root` and the instructions path both sit under that HOME
- `ACP.cwd/1` has not drifted back into a second copy

## Also in here

`ACP.install/3`'s docstring claimed it runs "with the rest of the package installs, because it needs unrestricted network." It does not — `prepare_runtime_sprite/5` is called *after* `run_provisioning_pipeline/5`, so both the adapter install and opencode's `bun install` land after `Provisioning.apply_network_policy/3`. Costs nothing on the default `unrestricted` environment; on a `limited` one the npm registry has to be on the allowlist or the install fails. **Behaviour unchanged — only the claim corrected.** Worth a follow-up decision on whether the ordering should change.

`Fountain.Runtimes`' moduledoc now names the three kinds of per-runtime variation (layout / workarounds / credential delivery) and says why the third cannot become a column: it is two shapes, not four — an env var, or a login exec that consumes the key on stdin, because codex 0.118+ ignores `OPENAI_API_KEY` at exec time.

## Scope

Layout only. What goes *in* those files, and the imperative bootstrap each runtime needs (`prepare_sandbox/3`), stay exactly where they are. Tier 2 — quarantining the upstream workarounds behind explicit deletion conditions — follows in its own PR.

## Verification

- `mix test` — 3552 tests, 6 doctests, 3 properties, 0 failures
- `mix credo --strict` — no issues
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix sobelow --config` — clean

Not verified live on a sandbox. The write path is unchanged (`Sandbox.write_file/3`, already used for `/tmp/.gemini/settings.json`), only the destination, and `write_instructions/3` is best-effort so a refused write cannot fail a provision. Worth confirming on a real opencode conversation that the persona now takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)