### PR TITLE
docs: gemini asks too, measured on the day it shipped

### DIFF
--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -221,9 +221,14 @@ defmodule Fountain.Runtimes.ACP do
   someone writes a policy for it, rather than a policy that reads as
   protection and is not.
 
-  Measured 2026-08-22 against live agents: claude (claude-agent-acp 0.66) and
-  codex (codex-acp 1.1.14) both ask per tool call. opencode does not, ever.
-  gemini is not shippable (#659) and its own bypass flag is #941's.
+  Measured 2026-08-22 against live agents: claude (claude-agent-acp 0.66),
+  codex (codex-acp 1.1.14) and gemini (0.53, on the ACP path since #964) all ask
+  per tool call. opencode does not, ever.
+
+  Each runtime names its options differently — claude answers to `allow` and
+  `reject`, codex to `allow_once` and `reject_once`, gemini to `proceed_once`
+  and `cancel` — which is why every answer path picks from the list the agent
+  sent rather than from a name we know.
   """
   @spec asks_permission?(String.t()) :: boolean()
   def asks_permission?(runtime) do

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -47,9 +47,9 @@ Fountain reads the keys in this order.
    `other`.
 3. The key `default`.
 
-**Prefer a kind.** The claude runtime puts the command itself in the title. A
-title key therefore matches one command, and nothing else. A kind means the
-same thing on each turn, and on each runtime.
+**Prefer a kind.** The claude and gemini runtimes put the command itself in the
+title, and codex sends no title. A title key therefore matches one command, and
+nothing else. A kind means the same thing on each turn, and on each runtime.
 
 ## When a human answers
 
@@ -81,7 +81,7 @@ Some rules keep that safe.
 | claude | Yes | Measured on claude-agent-acp 0.66. Safe commands that its own sandbox runs never reach Fountain. |
 | codex | Yes | Measured on codex-acp 1.1.14. |
 | opencode | **No** | It decides this in its own server, and sends nothing. Fountain refuses a policy stricter than `auto_allow` on this runtime, with 422 `permission_policy_unenforceable` ([#959](https://github.com/BinaryBourbon/fountain/issues/959)). |
-| gemini | n/a | Not available yet ([#659](https://github.com/BinaryBourbon/fountain/issues/659)). |
+| gemini | Yes | Measured on gemini 0.53 with `gemini-2.5-flash`. Its option ids are its own (`proceed_once`, `cancel`), so answer with an id from the request, never a name you know from another runtime. |
 
 ## What the audit trail keeps
 


### PR DESCRIPTION
Both places I wrote yesterday said gemini was not available (#659). It shipped
this morning (#964), so they were stale within hours.

**Measured, not assumed.** One `ask` launch on gemini 0.53 with
`gemini-2.5-flash`, one external `curl`:

```
toolCall: {"kind": "execute", "title": "curl -sS -o /dev/null -w \"%{http_code}\" https://example.com"}
options:  [("proceed_always","allow_always"), ("proceed_once","allow_once"), ("cancel","reject_once")]
```

Answered `proceed_once` → resolved, tool ran, turn ended `end_turn`.

Two things worth naming rather than leaving in an issue comment:

- **Its option ids are its own.** claude answers to `allow`/`reject`, codex to
  `allow_once`/`reject_once`, gemini to `proceed_once`/`cancel`. A client that
  hard-codes any set breaks on the other two — which is the concrete reason
  every answer path picks from the list the agent sent. That now sits in
  `ACP.asks_permission?/1`'s docstring, beside the measurement it explains.
- **Gemini titles a tool call with the command**, exactly like claude, so the
  prefer-a-kind advice covers three runtimes rather than one.

`gemini-2.5-pro`, the other model the catalog lists, is refused for new users —
that is #970 and not this PR.

Part of #643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)