### PR TITLE
Register each runtime workaround with its deletion condition

### DIFF
--- a/apps/fountain/lib/fountain/runtimes.ex
+++ b/apps/fountain/lib/fountain/runtimes.ex
@@ -15,12 +15,10 @@ defmodule Fountain.Runtimes do
       and now stated once, in `Fountain.Runtimes.Layout`. `skills_root/0`,
       `skills_sh_agent/0`, the instructions path and every workspace directory
       are derived from that table rather than restated per module.
-    * **Workarounds** — an upstream defect each runtime carries, with a
-      deletion condition: claude's MCP servers going in as files because the
-      ACP session-scoped channel is dropped on the floor
-      (`claude-agent-acp#883`), gemini's session store consolidation
-      (`gemini-cli#28775`), opencode not being on the base image, and
-      `HOME=/tmp` for the two runtimes that trip the sprite's rename ACL.
+    * **Workarounds** — a defect each runtime carries, with a deletion
+      condition. Registered in `Fountain.Runtimes.Quirks`, which names the
+      function implementing each one and is guarded by a test, so a workaround
+      cannot outlive its defect unnoticed.
     * **Credential delivery** — genuinely irreducible, and two shapes rather
       than four: an env var (claude, gemini, opencode) or a login exec that
       consumes the key on stdin (codex, whose CLI ignores the process env).

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -141,7 +141,9 @@ defmodule Fountain.Runtimes.ACP do
     # the moduledoc has the mechanism), which held this entry back for eleven
     # days. `Fountain.Runtimes.Gemini.SessionStore` consolidates the store at
     # the end of every turn so the load cannot collide with what it is loading.
-    # Delete that module and this comment when upstream lands.
+    # Delete that module and this comment when upstream lands — the
+    # condition, and the procedure for checking it, are recorded as
+    # `:gemini_session_store_consolidation` in `Fountain.Runtimes.Quirks`.
     "gemini" => %{
       bin: "gemini",
       args: ["--acp"],
@@ -324,6 +326,8 @@ defmodule Fountain.Runtimes.ACP do
   in the default PATH — `command -v claude-agent-acp` after a successful global
   install returns nothing. The spawn would then fail with `command not found`,
   which reads like a protocol bug and is not one.
+
+  Registered as `:npm_global_bin_off_path` in `Fountain.Runtimes.Quirks`.
 
   So we symlink into `/home/sprite/.local/bin`, which *is* on PATH. This is the
   same shape as `Fountain.Runtimes.OpenCode.prepare_sandbox/3`, which hit the

--- a/apps/fountain/lib/fountain/runtimes/claude.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude.ex
@@ -31,7 +31,10 @@ defmodule Fountain.Runtimes.Claude do
 
   When the upstream bug is fixed, the session-scoped path will start working
   too; at that point drop this provisioning to avoid double-registration
-  (cf. the same lesson in `Fountain.Runtimes.Gemini`).
+  (cf. the same lesson in `Fountain.Runtimes.Gemini`). Registered as
+  `:claude_mcp_via_files` in `Fountain.Runtimes.Quirks`, which carries the
+  re-probe procedure and is guarded by a test that fails if this function
+  disappears without the entry.
   """
 
   @behaviour Fountain.Runtimes

--- a/apps/fountain/lib/fountain/runtimes/gemini/session_store.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini/session_store.ex
@@ -1,5 +1,9 @@
 defmodule Fountain.Runtimes.Gemini.SessionStore do
   @moduledoc """
+  A workaround, registered as `:gemini_session_store_consolidation` in
+  `Fountain.Runtimes.Quirks` — which carries the deletion condition and how
+  to re-probe it. This whole module goes when gemini-cli#28775 lands.
+
   Keeps gemini's own chat-session store from erasing the session it is asked to
   load — a workaround for [gemini-cli#28775][], tracked as #659.
 

--- a/apps/fountain/lib/fountain/runtimes/open_code.ex
+++ b/apps/fountain/lib/fountain/runtimes/open_code.ex
@@ -15,7 +15,8 @@ defmodule Fountain.Runtimes.OpenCode do
   Heads-up: opencode is *not* pre-installed on the sprite base image —
   the first session on a new sprite will install it (10–30s longer than
   the other runtimes). Subsequent turns on the same sprite are normal
-  speed.
+  speed. Registered as `:opencode_absent_from_base_image` in
+  `Fountain.Runtimes.Quirks`.
   """
 
   @behaviour Fountain.Runtimes

--- a/apps/fountain/lib/fountain/runtimes/quirks.ex
+++ b/apps/fountain/lib/fountain/runtimes/quirks.ex
@@ -1,0 +1,226 @@
+defmodule Fountain.Runtimes.Quirks do
+  @moduledoc """
+  Every workaround Fountain carries on a runtime's behalf, the defect that
+  justifies it, and the condition under which it is deleted.
+
+  ## Why a registry rather than comments
+
+  The comments already exist, and they are good ones — `Fountain.Runtimes.ACP`
+  spends forty lines on how gemini's session store erases a session in the act
+  of loading it, and `Fountain.Runtimes.Claude` explains exactly why MCP
+  servers go in as files. Both end with some version of "delete this when
+  upstream lands."
+
+  Nothing checks that. A workaround outliving its defect is invisible: it
+  keeps working, so no test fails and no user complains, and the cost shows up
+  only as the next person reasoning about a system that is stranger than it
+  needs to be. Worse is the version where the upstream fix lands and the
+  workaround now *conflicts* with it — the case
+  `Fountain.Runtimes.Claude`'s moduledoc already anticipates, where a fixed
+  session-scoped channel plus our file-based provisioning would register every
+  MCP server twice.
+
+  So each entry names the code that implements it as an MFA, and
+  `quirks_test.exs` asserts that function still exists. Delete the workaround
+  without the entry and the test fails; leave an entry pointing at code that
+  is gone and the test fails. The registry cannot silently rot, which is the
+  only property that makes it worth more than the comments.
+
+  ## What is not a quirk
+
+  A runtime doing something *unusual* is not a quirk. codex delivering its
+  credential through `codex login --with-api-key` rather than
+  `OPENAI_API_KEY` looks like one and is not: that is codex's documented auth
+  mechanism, no upstream fix would remove it, and there is no condition under
+  which we stop doing it. It belongs to the irreducible tier described in
+  `Fountain.Runtimes`. The test for a quirk is whether you can state what
+  would have to change for the code to be deleted. If you cannot, it is not a
+  workaround — it is just how that runtime works.
+
+  ## Re-probing
+
+  `reprobe` says how to find out whether the defect is still there. It is the
+  checklist for a version bump: when the claude adapter pin moves, the
+  question "does `session/new`'s `mcpServers` launch stdio servers yet?" has
+  a known answer procedure, and if the answer changed the entry says what to
+  delete.
+  """
+
+  @typedoc """
+  `upstream` is a URL, or `{:none, reason}` for a workaround with no upstream
+  to track — one we carry because of a decision on our own side, usually the
+  sprite base image.
+  """
+  @type quirk :: %{
+          id: atom(),
+          runtimes: [String.t()],
+          summary: String.t(),
+          why: String.t(),
+          upstream: String.t() | {:none, String.t()},
+          measured_against: String.t(),
+          implemented_by: {module(), atom(), arity()},
+          reprobe: String.t(),
+          delete_when: String.t()
+        }
+
+  @quirks [
+    %{
+      id: :claude_mcp_via_files,
+      runtimes: ["claude"],
+      summary: "claude's MCP servers are provisioned as files, not sent over ACP",
+      why: """
+      ACP defines a session-scoped channel for MCP servers (`session/new`'s
+      `mcpServers`) and `Fountain.Runtimes.ACP.Peer` sends the agent's servers
+      there correctly. claude-agent-acp never launches stdio servers passed
+      that way, so the session-scoped path delivers nothing. We write a
+      project `.mcp.json` plus `enableAllProjectMcpServers` instead, which the
+      CLI picks up through its `settingSources`.
+      """,
+      upstream: "https://github.com/agentclientprotocol/claude-agent-acp/issues/883",
+      measured_against: "claude-agent-acp 0.66–0.70, reproduced standalone",
+      implemented_by: {Fountain.Runtimes.Claude, :write_config, 2},
+      reprobe: """
+      Run a conversation with an MCP server declared on the agent, with
+      `write_config/2` stubbed out, and check the model can call an
+      `mcp__<server>__*` tool. If it can, the session-scoped path works.
+      """,
+      delete_when: """
+      `session/new`'s `mcpServers` launches stdio servers. Then drop
+      `Claude.write_config/2` in the same PR that confirms it — leaving both
+      paths on registers every server twice, which is the failure
+      `Fountain.Runtimes.Gemini` already had and fixed by writing to one
+      place only.
+      """
+    },
+    %{
+      id: :gemini_session_store_consolidation,
+      runtimes: ["gemini"],
+      summary: "Fountain rewrites gemini's private chat store after every turn",
+      why: """
+      gemini's `session/load` builds a fresh config on the same session id
+      before looking the session up, and that config's chat recorder takes its
+      new-session branch: it appends a `$set` carrying only its
+      `<session_context>` bootstrap to the file it is about to read. gemini's
+      own reader treats `$set.messages` as a replacement, so loading a session
+      erases it — permanently, not just for that turn. `SessionStore`
+      consolidates the chats directory at the end of every turn: keep the file
+      with real content, delete the poisoned duplicates, park the survivor
+      under a timestamp the recorder cannot produce.
+      """,
+      upstream: "https://github.com/google-gemini/gemini-cli/issues/28775",
+      measured_against: "gemini-cli 0.53.0 through 0.56.0, verified live in both directions",
+      implemented_by: {Fountain.Runtimes.Gemini.SessionStore, :install, 1},
+      reprobe: """
+      Five consecutive turns inside one wall-clock minute with the consolidation
+      disabled. The collision is bucketed by minute, so spacing turns out hides
+      it — that is what made the original bug look random.
+      """,
+      delete_when: """
+      `session/load` stops appending a `$set` that replaces the transcript it
+      is loading. Delete `Fountain.Runtimes.Gemini.SessionStore`, its call in
+      `Gemini.prepare_sandbox/3`, the per-turn `consolidate/2` call, and the
+      mechanism section of `Fountain.Runtimes.ACP`'s moduledoc.
+      """
+    },
+    %{
+      id: :opencode_absent_from_base_image,
+      runtimes: ["opencode"],
+      summary: "opencode is installed into every sandbox at provision time",
+      why: """
+      opencode does not ship in the sprite base image, so the first session on
+      a new sandbox pays a `bun install -g opencode-ai` plus a symlink onto
+      PATH — 10–30s the other runtimes do not pay. It is also the one runtime
+      we cannot version-pin this way, since the install takes whatever is
+      current.
+      """,
+      upstream: {:none, "a sprite base-image decision on our side, not a defect in opencode"},
+      measured_against: "sprite base image as of 2026-08-22",
+      implemented_by: {Fountain.Runtimes.OpenCode, :prepare_sandbox, 3},
+      reprobe: "`command -v opencode` on a fresh sandbox before provisioning runs.",
+      delete_when: """
+      opencode ships in the sprite base image at a version we choose. Note
+      this also removes an exposure rather than only a delay: the install
+      currently runs after `Provisioning.apply_network_policy/3`, so a
+      `limited` environment has to allowlist the npm registry for it to
+      succeed at all.
+      """
+    },
+    %{
+      id: :home_on_tmp,
+      runtimes: ["gemini", "opencode"],
+      summary: "two runtimes are moved to HOME=/tmp to dodge a failing rename",
+      why: """
+      gemini-cli aborts during init if it cannot rename
+      `$HOME/.gemini/projects.json.tmp` onto `projects.json`. The sprite user
+      appears to have write access to /home/sprite — `ls` and most writes go
+      through — but a rename across that ACL boundary errors out. opencode
+      hits the same boundary from the other direction: it cannot `git init` in
+      $HOME because of work-tree permissions. Both are moved to /tmp, and
+      every path Fountain writes for them follows.
+      """,
+      upstream: {:none, "sprite base-image filesystem permissions, ours to change"},
+      measured_against: "sprite base image as of 2026-08-22",
+      implemented_by: {Fountain.Runtimes.Layout, :home_env, 1},
+      reprobe: """
+      As the sprite user on a live sandbox: `touch /home/sprite/.probe.tmp &&
+      mv /home/sprite/.probe.tmp /home/sprite/.probe`. A clean rename means
+      the workaround is unnecessary.
+      """,
+      delete_when: """
+      The sprite user can rename across /home/sprite. Then both rows in
+      `Fountain.Runtimes.Layout` take the image's own home and `home_env/1`
+      returns `[]` for every runtime — no other change is needed, which is
+      the point of deriving the paths from it.
+      """
+    },
+    %{
+      id: :npm_global_bin_off_path,
+      runtimes: ["claude", "codex"],
+      summary: "installed ACP adapters are symlinked onto PATH by hand",
+      why: """
+      `npm prefix -g` on the sprite is inside the nvm tree, whose `bin/` is not
+      on the default PATH: `command -v claude-agent-acp` after a successful
+      global install returns nothing, and the spawn then fails with `command
+      not found` — which reads like a protocol bug and is not one. So the
+      install symlinks into `/home/sprite/.local/bin`, which is on PATH. bun
+      has the identical problem, handled the same way in
+      `OpenCode.prepare_sandbox/3`.
+      """,
+      upstream: {:none, "sprite base-image PATH, ours to change"},
+      measured_against: "verified on a live sprite 2026-08-10, node v24.18.0",
+      implemented_by: {Fountain.Runtimes.ACP, :install, 3},
+      reprobe: """
+      `npm install -g <anything with a bin>` on a fresh sandbox, then
+      `command -v` it without the symlink.
+      """,
+      delete_when: """
+      The sprite's default PATH includes npm's and bun's global bin
+      directories. Both symlink steps go, here and in
+      `OpenCode.prepare_sandbox/3`.
+      """
+    }
+  ]
+
+  @doc "Every recorded quirk, in declaration order."
+  @spec all() :: [quirk()]
+  def all, do: @quirks
+
+  @doc "The quirks Fountain carries for one runtime."
+  @spec for_runtime(String.t()) :: [quirk()]
+  def for_runtime(runtime) when is_binary(runtime),
+    do: Enum.filter(@quirks, &(runtime in &1.runtimes))
+
+  @doc "One quirk by id, or nil."
+  @spec get(atom()) :: quirk() | nil
+  def get(id) when is_atom(id), do: Enum.find(@quirks, &(&1.id == id))
+
+  @doc """
+  Quirks with an upstream issue to watch, as `{id, url}` pairs — the ones
+  whose deletion depends on somebody else. The rest are ours to remove
+  whenever we decide to.
+  """
+  @spec upstream_tracked() :: [{atom(), String.t()}]
+  def upstream_tracked do
+    for %{id: id, upstream: url} <- @quirks, is_binary(url), do: {id, url}
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/quirks_test.exs
+++ b/apps/fountain/test/fountain/runtimes/quirks_test.exs
@@ -1,0 +1,101 @@
+defmodule Fountain.Runtimes.QuirksTest do
+  @moduledoc """
+  The guardrail that makes the registry worth more than the comments it
+  replaces.
+
+  The load-bearing test is `implemented_by`: every entry names the function
+  that carries the workaround, and that function has to exist. Delete a
+  workaround without deleting its entry and this fails; leave an entry
+  pointing at code that is gone and this fails. Everything else here is
+  shape-checking so an entry cannot be added without saying what would delete
+  it.
+  """
+  use ExUnit.Case, async: true
+
+  alias Fountain.Runtimes.Layout
+  alias Fountain.Runtimes.Quirks
+
+  test "ids are unique" do
+    ids = Enum.map(Quirks.all(), & &1.id)
+    assert ids == Enum.uniq(ids)
+  end
+
+  test "every quirk names at least one runtime, and every runtime is a real one" do
+    for q <- Quirks.all() do
+      assert q.runtimes != [], "#{q.id} names no runtime"
+
+      for runtime <- q.runtimes do
+        assert runtime in Layout.runtimes(),
+               "#{q.id} names runtime #{inspect(runtime)}, which has no layout"
+      end
+    end
+  end
+
+  test "the code each quirk points at still exists" do
+    for %{id: id, implemented_by: {mod, fun, arity}} <- Quirks.all() do
+      Code.ensure_loaded!(mod)
+
+      assert function_exported?(mod, fun, arity),
+             """
+             #{id} says it is implemented by #{inspect(mod)}.#{fun}/#{arity}, \
+             which does not exist. Either the workaround was removed and the \
+             entry should go with it, or it moved and the entry should follow.\
+             """
+    end
+  end
+
+  test "every quirk says what would delete it, and how to find out" do
+    for q <- Quirks.all() do
+      for field <- [:summary, :why, :reprobe, :delete_when, :measured_against] do
+        value = Map.fetch!(q, field)
+
+        assert is_binary(value) and String.trim(value) != "",
+               "#{q.id} has an empty #{field}"
+      end
+    end
+  end
+
+  test "upstream is a URL, or an explicit reason there is none" do
+    for q <- Quirks.all() do
+      case q.upstream do
+        url when is_binary(url) ->
+          assert String.starts_with?(url, "https://"), "#{q.id}'s upstream is not a URL"
+
+        {:none, reason} ->
+          assert is_binary(reason) and String.trim(reason) != "",
+                 "#{q.id} has no upstream and no reason why not"
+
+        other ->
+          flunk("#{q.id} has an unrecognised upstream: #{inspect(other)}")
+      end
+    end
+  end
+
+  test "for_runtime/1 and upstream_tracked/0 select from the same table" do
+    assert Enum.map(Quirks.for_runtime("gemini"), & &1.id) == [
+             :gemini_session_store_consolidation,
+             :home_on_tmp
+           ]
+
+    assert Quirks.for_runtime("codex") |> Enum.map(& &1.id) == [:npm_global_bin_off_path]
+    assert Quirks.for_runtime("nope") == []
+
+    assert Quirks.get(:home_on_tmp).runtimes == ["gemini", "opencode"]
+    assert Quirks.get(:not_a_quirk) == nil
+
+    # The two we are waiting on someone else for.
+    assert Keyword.keys(Quirks.upstream_tracked()) == [
+             :claude_mcp_via_files,
+             :gemini_session_store_consolidation
+           ]
+  end
+
+  test "codex's login is deliberately not recorded as a quirk" do
+    # It is codex's documented auth mechanism, not a defect: no upstream fix
+    # would remove it and there is no condition under which we stop. It
+    # belongs to the irreducible tier in `Fountain.Runtimes`. Recorded as a
+    # test so the next person to look at `Codex.prepare_sandbox/3` and reach
+    # for this registry finds the reasoning rather than repeating it.
+    refute Enum.any?(Quirks.all(), &match?({Fountain.Runtimes.Codex, _, _}, &1.implemented_by))
+  end
+end


### PR DESCRIPTION
Tier 2, following #972 (merged). Rebased onto main, so the diff here is the quirks commit alone.

## The problem

The comments explaining these workarounds are already good. `Fountain.Runtimes.ACP`'s moduledoc spends forty lines on how gemini's session store erases a session in the act of loading it, and `Fountain.Runtimes.Claude` explains exactly why MCP servers go in as files instead of over ACP. Every one of them ends with some version of *"delete this when upstream lands."*

Nothing checks that. A workaround outliving its defect is invisible — it keeps working, no test fails, no user complains, and the cost lands on whoever next has to reason about a system stranger than it needs to be.

The worse case is the one `Claude`'s moduledoc already anticipates: the upstream fix arrives and the workaround starts *conflicting* with it. A fixed session-scoped MCP channel plus our file-based provisioning would register every server twice — which is a failure `Fountain.Runtimes.Gemini` has already had once, and fixed by writing to one place only.

## What this adds

`Fountain.Runtimes.Quirks` records five, each with why, what it was measured against, how to re-probe the defect, and what deletes it:

| id | runtime(s) | upstream |
|---|---|---|
| `:claude_mcp_via_files` | claude | [claude-agent-acp#883](https://github.com/agentclientprotocol/claude-agent-acp/issues/883) |
| `:gemini_session_store_consolidation` | gemini | [gemini-cli#28775](https://github.com/google-gemini/gemini-cli/issues/28775) |
| `:opencode_absent_from_base_image` | opencode | none — our image decision |
| `:home_on_tmp` | gemini, opencode | none — sprite filesystem ACL |
| `:npm_global_bin_off_path` | claude, codex | none — sprite PATH |

## Why this is more than the comments it summarises

`implemented_by`. Each entry names the function carrying the workaround as an MFA, and the test asserts that function exists:

- delete the workaround without deleting the entry → the test fails
- leave an entry pointing at code that has moved or gone → the test fails

That is the only property that makes a registry worth maintaining. Without it this would rot into a second, staler copy of the comments.

`reprobe` is the other half: when the claude adapter pin moves, *"does `session/new`'s `mcpServers` launch stdio servers yet?"* now has a written answer procedure, and if the answer changed the entry says what to delete.

## What is deliberately not in here

codex's `login --with-api-key`, with a test recording the reasoning. It looks like a quirk and is not: it is codex's documented auth mechanism, no upstream fix would remove it, and there is no condition under which we stop doing it. That is the irreducible tier described in `Fountain.Runtimes`.

The distinction is the point of the registry. **The test for a quirk is whether you can state what would have to change for the code to be deleted.** If you cannot, it is not a workaround — it is just how that runtime works.

## Verification

- `mix test` — full suite green
- `mix credo --strict`, `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix dialyzer` — clean

No behaviour change: this is a registry plus cross-references from the moduledocs that already carried the same knowledge in prose.

## Possible follow-up

The registry is currently code-level only. If it would be useful to operators, `upstream_tracked/0` is the shape you would surface on an admin page or in `/api/catalog` — not done here, since it is not obvious anyone outside the repo needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
