### PR TITLE
docs: three comments that outlived the legacy spawn path

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2490,9 +2490,15 @@ defmodule Fountain.Conversations.ConversationServer do
     # `build_command/5` is not consulted at all on this path. There is no
     # opt-in left to check: gate 4 deleted the legacy spawn path for claude,
     # codex and opencode along with the per-agent flag, so `acp?` is a
-    # property of `conv.runtime` alone. The `else` branch survives for gemini,
-    # the one runtime held back (#659), and for it the CLI is not a fallback —
-    # it is the only path.
+    # property of `conv.runtime` alone.
+    #
+    # The `else` branch is now **unreachable in production**. It survived for
+    # gemini until #659 put it on ACP and #941 deleted its `build_command/5`;
+    # no runtime module implements that callback any more, and `for_runtime/1`
+    # refuses a name that has no module, so a conversation whose runtime lacks
+    # an ACP adapter cannot start in the first place. It is kept because the
+    # turn machinery it leads to — the log budget, stdin handling, exit codes —
+    # is shared, and `Fountain.Test.FakeRuntime` still drives it here.
     {cmd, args, build_opts} =
       if acp? do
         {c, a} = Fountain.Runtimes.ACP.command(conv.runtime)

--- a/apps/fountain/lib/fountain/runtimes.ex
+++ b/apps/fountain/lib/fountain/runtimes.ex
@@ -5,8 +5,13 @@ defmodule Fountain.Runtimes do
 
   This is the **provisioning** layer ADR 0014 deliberately kept: credentials,
   skills layout, sandbox bootstrap. Turn I/O is ACP (`Fountain.Runtimes.ACP`)
-  for every supported runtime; `build_command/5` exists only for runtimes
-  still on the legacy spawn path (gemini, #659), which is why it is optional.
+  for every supported runtime. `build_command/5` has **no implementation left**
+  — gemini was the last one and #941 deleted it — so the callback stays
+  optional and the legacy spawn path in `ConversationServer` is unreachable for
+  any runtime `for_runtime/1` will resolve. Both are kept rather than deleted
+  because a fifth runtime that cannot speak ACP would need them, and because
+  the turn machinery around them (log budget, exit handling) is shared and
+  still exercised through `Fountain.Test.FakeRuntime`.
 
   What varies between runtimes here falls into three kinds, and only the last
   needs code:

--- a/apps/fountain/lib/fountain/runtimes/legacy_blocks.ex
+++ b/apps/fountain/lib/fountain/runtimes/legacy_blocks.ex
@@ -11,15 +11,15 @@ defmodule Fountain.Runtimes.LegacyBlocks do
 
   ## What is live and what is frozen
 
-  - **gemini** is the only dialect still *produced*: its ACP conversion is
-    held back by an upstream defect (#659), so gemini turns keep writing
-    stream-json to the `stdout` stream and this parser keeps earning its
-    place.
-  - **claude, codex, opencode** are **frozen**: their runtimes speak only ACP
-    now, so their parsers exist solely to render `stdout` rows recorded
-    before the conversion. Frozen means exactly that — the input set is
-    historical and can no longer change, so these clauses must never be
-    extended. When pre-ACP history ages out of retention, they are deleted.
+  **All four are frozen.** gemini was the last dialect still being produced;
+  #659 put it on ACP and #941 deleted the argv that produced it, so nothing
+  writes a legacy dialect any more.
+
+  Frozen means exactly that: every parser here exists solely to render `stdout`
+  rows recorded before its runtime was converted. The input set is historical
+  and can no longer grow, so these clauses must never be extended. **When
+  pre-ACP history ages out of retention, this module is deleted** — that is now
+  the only thing standing between it and deletion, for all four.
 
   **A dialect parser must never be written again.** A fifth runtime that does
   not speak ACP gets an adapter at the sandbox boundary, not a fifth set of


### PR DESCRIPTION
Swept for legacy-path leftovers across all four providers after #941. **The code is clean; three comments were not**, and each asserted something now false — the kind of rot ADR 0001 exists to prevent.

## Corrected

| where | claimed | actually |
|---|---|---|
| `LegacyBlocks` | gemini "is the only dialect still **produced**", so its parser "keeps earning its place" | Nothing produces a legacy dialect. #659 put gemini on ACP, #941 deleted the argv. **All four are frozen**, and the only thing between this module and deletion is pre-ACP history ageing out of retention. |
| `ConversationServer` spawn branch | the `else` arm "**survives for gemini**, the one runtime held back" | **Unreachable in production.** No runtime module implements `build_command/5`, and `for_runtime/1` refuses a name with no module — so a conversation whose runtime lacks an ACP adapter cannot start at all. |
| `Fountain.Runtimes` | `build_command/5` "exists only for runtimes still on the legacy spawn path (gemini, #659)" | It has **no implementation left**. |

## Kept, deliberately, and the comments now say why

The callback, the `else` arm, and the machinery behind it — stdin handling, prompt suffix, exit codes — stay. That machinery is **shared with the ACP path**, and `Fountain.Test.FakeRuntime` is what exercises it (47 tests in `conversation_server_test.exs`). Deleting it is a real decision that would cost that coverage, not a tidy-up, so it belongs in its own change rather than being smuggled into a comment fix.

## What the sweep found clean

- No `--dangerously-*`, `yolo`, or `--approval-mode` anywhere in `apps/fountain/lib` outside comments explaining their removal.
- No `--resume` / `--last` / `--continue` argv on any runtime — claude, codex, gemini, opencode.
- The Go CLI's only `stream-json` mentions are about **rendering** output, never spawning.
- Zero `build_command/5` implementations in `lib/`; the two that remain are in `test/support/fake_runtime.ex`.

## Checks

`mix test` — **3,545 tests, 0 failures**. `mix format --check-formatted` and `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
