### PR TITLE
fix(conversations): a reattach announces itself once the sprite answers, not on the way in

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -880,11 +880,26 @@ defmodule Fountain.Conversations.ConversationServer do
     )
   end
 
+  # The `started` event is published **after** the sprite answers, not on the
+  # way in, and that is deliberate (#971).
+  #
+  # A `ConversationServer` is a Horde child, so cluster churn stops and starts
+  # it — every rebalance runs this function again from the top. Announcing on
+  # entry turned that into a transcript: production logged 51 `reattach`
+  # `started` events for one conversation inside one second, in lockstep with a
+  # second conversation on the same node, and exactly one of them reached
+  # `done`. Fifty of those describe a process that was replaced before it
+  # touched anything, which is a fact about our supervision tree and not about
+  # the user's conversation.
+  #
+  # The provider round trip outlives a rebalance, so a start that is going to
+  # be replaced is replaced before this line and writes nothing. What survives
+  # to publish has a live sprite and is really reattaching.
+  #
+  # The node is stamped on every reattach event for the same incident: it is
+  # what tells a redistribution storm (many nodes, one conversation) from a
+  # crash loop (one node, restarting) without guessing.
   defp do_reattach(state, conv, sandbox, agent, env, secrets) do
-    publish_stage(state.conversation_id, "reattach", "started", %{
-      sprite_name: sandbox.sprite_name
-    })
-
     handle =
       Fountain.Sandbox.build_handle(
         Fountain.Conversations.sandbox_provider_atom(sandbox),
@@ -896,6 +911,11 @@ defmodule Fountain.Conversations.ConversationServer do
            label: "sprite lookup on wake"
          ) do
       {:ok, _info} ->
+        publish_stage(state.conversation_id, "reattach", "started", %{
+          sprite_name: sandbox.sprite_name,
+          node: to_string(node())
+        })
+
         {state, _conv} = rotate_callback_api_key(state, conv)
         sprite_env = build_sprite_env(state, agent, env, secrets)
 
@@ -944,7 +964,8 @@ defmodule Fountain.Conversations.ConversationServer do
 
         publish_stage(state.conversation_id, "reattach", "failed", %{
           reason: "not_found",
-          retryable: false
+          retryable: false,
+          node: to_string(node())
         })
 
         {:ok, _} =
@@ -978,7 +999,8 @@ defmodule Fountain.Conversations.ConversationServer do
 
         publish_stage(state.conversation_id, "reattach", "failed", %{
           reason: inspect(reason),
-          retryable: true
+          retryable: true,
+          node: to_string(node())
         })
 
         {:stop, :normal, state}

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -525,6 +525,49 @@ defmodule Fountain.Conversations.ConversationServerTest do
       assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
     end
 
+    test "a reattach that never reaches the sprite announces nothing", %{conv: conv} do
+      # #971: a Horde child is stopped and started by cluster churn, and every
+      # rebalance re-enters this path. Announcing on the way in wrote 51
+      # `started` events for one conversation in one second — fifty of them
+      # describing a process that was replaced before it touched anything.
+      # The provider round trip outlives a rebalance, so a start that will be
+      # replaced is replaced before the announcement.
+      stub_happy_sprite()
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+        {:error, {:unavailable, %Req.TransportError{reason: :nxdomain}}}
+      end)
+
+      {_pid, ref, _} = start_server(conv)
+      assert :normal = assert_stopped(ref)
+
+      stages =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.filter(&(&1.kind == "stage" and &1.stage == "reattach"))
+
+      # The failure is announced; the arrival is not.
+      assert Enum.map(stages, & &1.state) == ["failed"]
+    end
+
+    test "a reattach that reaches the sprite says which node it is on", %{conv: conv} do
+      # The other half of #971: with the node stamped, a redistribution storm
+      # (many nodes, one conversation) is one query away from a crash loop
+      # (one node, restarting), rather than a guess.
+      stub_happy_sprite()
+
+      {pid, _ref, _} = start_server(conv)
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid, :normal) end)
+
+      started =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.find(&(&1.kind == "stage" and &1.stage == "reattach" and &1.state == "started"))
+
+      assert %{"node" => node_name, "sprite_name" => _} = Jason.decode!(started.data)
+      assert node_name == to_string(node())
+    end
+
     test "a definitive not-found retires the sandbox so the next prompt provisions fresh", %{
       conv: conv,
       sandbox: sandbox


### PR DESCRIPTION
Closes #971.

## What the storm actually is

The 51 events for one conversation are **51 process starts**, not one process
retrying. `do_reattach/6` announced `reattach`/`started` as its first act, and
a `ConversationServer` is a Horde child, so every convergence cycle re-entered
it from the top.

The decisive detail is that two conversations stormed in **perfect
alternation**, and both finished with a clean pair:

```
160050 190e4fce reattach started
160051 50c88dc8 reattach started
160052 190e4fce reattach started
160053 50c88dc8 reattach started
…                             ~25 cycles, ~40 ms apart
160061 50c88dc8 reattach done
160062 190e4fce reattach done
```

Two children restarting in lockstep is a supervision event, not a per-
conversation fault. ~40 ms a cycle is shorter than any call to the provider, so
each start was replaced before it reached the network — which is why fifty of
them produced no other event of any kind.

## The fix

Announce **after** the provider answers. A start that is going to be replaced
is replaced before that line and writes nothing; what survives has a live
sprite and is really reattaching. `done` and `failed` are untouched, so an
operator still sees every reattach that got far enough to mean something.

Every reattach event also carries `node` now. That is the measurement this
incident lacked: many nodes on one conversation is a redistribution storm, one
node restarting is a crash loop, and the events could not tell those apart.

## What this does not fix, and what I know about it

The churn itself. The evidence points at **registry convergence**, not a
crashing child:

- `process_redistribution` is already Horde's `:passive` default here, so
  children move when a node dies, not on every membership change;
- the same rollout logged `global: Name conflict terminating {…}` for an
  unrelated process, four times — nodes were merging repeatedly;
- this is the storm `Rehydrator`'s own moduledoc describes for boot ("duplicate
  names and mass-terminate the losers — a brief window of duplicate sprite
  servers and a noisy log storm"), reached by a different door.

It is **not reproducible on demand**: a plain `rollout restart` gives one clean
reattach per conversation, and two overlapping restarts give exactly two. Every
observed storm followed an image-change deploy. I did not chase it further
rather than change supervision behaviour on a hypothesis I could not
reproduce — with the node stamped, the next occurrence answers the question in
one query.

## Tests

Two, both verified to fail against the old ordering: a reattach that never
reaches the sprite publishes `failed` and no `started`; one that does publishes
`started` naming this node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
