### PR TITLE
fix(models): every google model Fountain suggested is retired

### DIFF
--- a/apps/fountain/lib/fountain/runtimes/model.ex
+++ b/apps/fountain/lib/fountain/runtimes/model.ex
@@ -10,7 +10,7 @@ defmodule Fountain.Runtimes.Model do
 
       claude --model claude-sonnet-4-6
       codex  --model gpt-5-codex        # also spelled -m
-      gemini --model gemini-2.5-pro     # also spelled -m
+      gemini --model gemini-3.1-pro-preview   # also spelled -m
 
   `Fountain.Agents.Agent` rejects a model whose prefix doesn't match its
   runtime at write time (via `provider_for_runtime/1`), so by the time a
@@ -51,7 +51,19 @@ defmodule Fountain.Runtimes.Model do
       claude-haiku-4-5
     ),
     "openai" => ~w(gpt-5-codex gpt-5),
-    "google" => ~w(gemini-2.5-pro gemini-2.5-flash)
+    # Both 2.5 entries were removed on 2026-08-22: Google retired
+    # `gemini-2.5-pro` *and* `gemini-2.5-flash` for new API keys, so every
+    # model Fountain suggested for google answered
+    # "no longer available to new users" on a key issued after the cutoff.
+    # Verified against generativelanguage.googleapis.com, not inferred from a
+    # release note. `gemini-3.1-pro-preview` is the replacement Google's own
+    # error names; the flash tier is listed newest-first beside it.
+    "google" => ~w(
+      gemini-3.1-pro-preview
+      gemini-3.7-flash
+      gemini-3.6-flash
+      gemini-3.5-flash
+    )
   }
 
   # Stable order for the UI: the single-provider runtimes in the order they

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -141,7 +141,7 @@ defmodule FountainWeb.AgentsLive.Form do
   # rejects a mismatched prefix (#553). Track the selected runtime so the hint
   # can't lead someone into that error.
   defp model_placeholder("codex"), do: "openai/gpt-5-codex"
-  defp model_placeholder("gemini"), do: "google/gemini-2.5-pro"
+  defp model_placeholder("gemini"), do: "google/gemini-3.1-pro-preview"
   defp model_placeholder(_runtime), do: "anthropic/claude-sonnet-4-6"
 
   # A model id off the curated list is legitimate — new models ship between

--- a/apps/fountain/priv/help/agents.md
+++ b/apps/fountain/priv/help/agents.md
@@ -3,7 +3,7 @@
 An **Agent** is a named configuration for a single coding-agent CLI. It bundles together:
 
 - a **runtime** (`claude` / `codex` / `gemini` / `opencode`) — which binary runs in the sprite
-- a **model** (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.1`, `google/gemini-2.5-pro`, etc.)
+- a **model** (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.1`, `google/gemini-3.1-pro-preview`, etc.)
 - an optional **system prompt** (`system`)
 - an optional **environment** reference (`environment_id` or `environment` by name) — the sprite shape to provision
 - optional **skills** — names of bundled skills to mount into the sprite
@@ -74,7 +74,7 @@ Use `$${VAR}` only when the MCP server (or some downstream process the runtime s
 | --- | --- | --- | --- |
 | claude | `claude` | `anthropic/claude-sonnet-4-6` | `CLAUDE_CODE_OAUTH_TOKEN` (preferred) or `ANTHROPIC_API_KEY` |
 | codex | `codex` | `openai/gpt-5.1` | `OPENAI_API_KEY` (consumed via `codex login --with-api-key` at provision time) |
-| gemini | `gemini` | `google/gemini-2.5-pro` | `GEMINI_API_KEY` |
+| gemini | `gemini` | `google/gemini-3.1-pro-preview` | `GEMINI_API_KEY` |
 | opencode | `opencode` | `provider/model` (anthropic / openai / google) | per provider |
 
 Each has its own quirks — codex needs a one-shot login, opencode auto-installs from `bun install -g`, gemini needs `--allowed-mcp-server-names` for MCP, etc. The runtime modules in `apps/fountain/lib/fountain/runtimes/*.ex` handle these transparently.

--- a/apps/fountain/test/fountain/agents/agent_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_test.exs
@@ -14,7 +14,7 @@ defmodule Fountain.Agents.AgentTest do
   @model_for %{
     "claude" => "anthropic/claude-sonnet-4-6",
     "codex" => "openai/gpt-5-codex",
-    "gemini" => "google/gemini-2.5-pro",
+    "gemini" => "google/gemini-3.1-pro-preview",
     "opencode" => "anthropic/claude-sonnet-4-6"
   }
 
@@ -94,7 +94,7 @@ defmodule Fountain.Agents.AgentTest do
     end
 
     test "opencode accepts any known provider — it is the multi-provider runtime" do
-      for model <- ~w(anthropic/claude-sonnet-4-6 openai/gpt-5 google/gemini-2.5-pro) do
+      for model <- ~w(anthropic/claude-sonnet-4-6 openai/gpt-5 google/gemini-3.1-pro-preview) do
         attrs = Map.merge(@valid_attrs, %{runtime: "opencode", model: model})
         assert Agent.changeset(%Agent{}, attrs).valid?
       end

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -233,7 +233,7 @@ defmodule Fountain.Conversations.ConversationServerTest do
         %Fountain.Agents.Agent{}
         |> Fountain.Agents.Agent.changeset(%{
           "name" => "legacy-cross-tenant",
-          "model" => "google/gemini-2.5-pro",
+          "model" => "google/gemini-3.1-pro-preview",
           "runtime" => "gemini",
           "user_id" => attacker.id,
           "environment_id" => victim_env.id

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -895,7 +895,7 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
     test "says so in the transcript when the runtime has no model option", ctx do
       # Silently running someone else's model is the failure mode this whole
       # campaign keeps turning up. Not fatal, but not invisible either.
-      pid = start_peer(ctx, model: "gemini-2.5-pro")
+      pid = start_peer(ctx, model: "gemini-3.1-pro-preview")
       %{"id" => init_id} = next_write()
       send_response(pid, init_id, %{"agentCapabilities" => caps()})
       %{"id" => new_id} = next_write()
@@ -903,7 +903,7 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
 
       assert_receive {:acp, _ref, {:lines, "stderr", msg}}
       assert msg =~ "does not expose model selection"
-      assert msg =~ "gemini-2.5-pro"
+      assert msg =~ "gemini-3.1-pro-preview"
 
       assert %{"method" => "session/prompt"} = next_write()
     end

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -160,7 +160,7 @@ defmodule Fountain.Factory do
   end
 
   defp default_model_for("codex"), do: "openai/gpt-5-codex"
-  defp default_model_for("gemini"), do: "google/gemini-2.5-pro"
+  defp default_model_for("gemini"), do: "google/gemini-3.1-pro-preview"
   defp default_model_for(_runtime), do: "anthropic/claude-sonnet-4-6"
 
   def insert_agent(overrides \\ %{}) do

--- a/docs/catalog/runtimes/gemini.md
+++ b/docs/catalog/runtimes/gemini.md
@@ -30,7 +30,7 @@ metadata:
   name: gemini-agent
 spec:
   runtime: gemini
-  model: google/gemini-2.5-pro
+  model: google/gemini-3.1-pro-preview
 ```
 
 Add your Gemini key at `/account/inference-credentials`.

--- a/docs/catalog/runtimes/index.md
+++ b/docs/catalog/runtimes/index.md
@@ -50,7 +50,7 @@ The agent form offers these as suggestions. They are not an allowlist.
 |---|---|
 | `anthropic` | `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
 | `openai` | `gpt-5-codex`, `gpt-5` |
-| `google` | `gemini-2.5-pro`, `gemini-2.5-flash` |
+| `google` | `gemini-3.1-pro-preview`, `gemini-3.7-flash` |
 
 `GET /api/catalog` returns this list for each runtime. A client can then
 render the current set, and it does not hard-code one.

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -81,7 +81,7 @@ Some rules keep that safe.
 | claude | Yes | Measured on claude-agent-acp 0.66. Safe commands that its own sandbox runs never reach Fountain. |
 | codex | Yes | Measured on codex-acp 1.1.14. |
 | opencode | **No** | It decides this in its own server, and sends nothing. Fountain refuses a policy stricter than `auto_allow` on this runtime, with 422 `permission_policy_unenforceable` ([#959](https://github.com/BinaryBourbon/fountain/issues/959)). |
-| gemini | Yes | Measured on gemini 0.53 with `gemini-2.5-flash`. Its option ids are its own (`proceed_once`, `cancel`), so answer with an id from the request, never a name you know from another runtime. |
+| gemini | Yes | Measured on gemini 0.53 with `gemini-2.5-flash`. Google removed that model for new API keys after this measurement. Its option ids are its own (`proceed_once`, `cancel`), so answer with an id from the request, never a name you know from another runtime. |
 
 ## What the audit trail keeps
 


### PR DESCRIPTION
**Both** google models Fountain suggested are retired. Verified by calling them, not inferred from a release note:

```
gemini-2.5-pro          404  "no longer available to new users"
gemini-2.5-flash        404  "no longer available to new users"
gemini-3.1-pro-preview  200
gemini-3.7-flash        200
gemini-3.6-flash        200
gemini-3.5-flash        200
```

`@catalog`'s entire `"google"` list was those two, so the agent form's suggestions, the form placeholder, the in-app help and the docs all pointed a new user at a model their key cannot call.

Found while smoke-testing gemini over ACP (#659) — the first turn failed with Google's own message, which names `gemini-3.1-pro-preview` as the replacement.

## The blast radius is smaller than it looks

Worth being precise: **the model id is not gated.** An unrecognised id is accepted and passed to the CLI verbatim, deliberately, so a model released after the last deploy works the day it ships (#554). Only the *provider* half is validated.

So this was **bad advice everywhere, not a hard block** — anyone who typed a current id was always fine, and the fix changes no behaviour beyond what Fountain recommends.

## The listing endpoint lies

`GET /v1beta/models` still returns `gemini-2.5-pro` with `generateContent` in its `supportedGenerationMethods`. It then 404s when you actually call it with a new key. Only calling the model tells you it is gone — worth knowing next time this needs checking.

## Left alone on purpose

- `docs/concepts/permissions.md` records that gemini's permission behaviour was **measured** with `gemini-2.5-flash`. That is a fact about a measurement, so it stays — with one sentence noting the model is gone, so nobody tries to reproduce it.
- `legacy_blocks_test.exs` keeps its 2.5 lines: they are a record of what gemini's legacy stream actually emitted.

## Checks

`mix test` — **3,602 tests, 0 failures**. `mix format --check-formatted`, `mix credo --strict`, `python3 scripts/docs-style.py`, **`vale lint docs` (0 errors)** and **`mkdocs build --strict`** all run locally and clean — I pulled the darwin build of the pinned STE linter rather than guess at compliance, since `.valeignore` is empty by design and parking a page is not an option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
