### PR TITLE
feat(otel): export traces to the cluster's tempo instead of nowhere

### DIFF
--- a/apps/fountain/priv/help/runbook.md
+++ b/apps/fountain/priv/help/runbook.md
@@ -197,10 +197,22 @@ curl -s localhost:9090/api/v1/alerts | jq '.data.alerts[] | select(.labels.names
 ```
 
 **Traces.** Instrumented (`Fountain.Telemetry` spans, `traceparent` propagated
-into sprites) but exported nowhere: `OTEL_TRACES_EXPORTER=none` on the
-Deployment, because there is no Tempo/Jaeger/collector in the cluster. Turning
-it on without one makes the exporter retry `localhost:4318` per span and flood
-the logs. Stand up a collector first.
+into sprites) and exported to Tempo, which runs in-cluster and keeps its blocks
+in garage. The Deployment sets `OTEL_EXPORTER_OTLP_ENDPOINT` at
+`tempo.tempo.svc.cluster.local:4318`; that alone turns the export on, since
+`runtime.exs` treats "no target configured" as "export nothing". Query them in
+Grafana under the **Tempo** datasource. A span carries `k8s.namespace.name` and
+`k8s.pod.name`, so the Tempo → Loki jump lands on the logs for the same pod and
+time window.
+
+Retention is 72h, capped by a 5 GiB quota on the garage bucket. If traces stop
+appearing, check the bucket first — garage refuses writes past the quota rather
+than evicting:
+
+```bash
+kubectl exec -n garage garage-0 -- /garage bucket info tempo
+kubectl logs -n tempo statefulset/tempo --tail=50
+```
 
 **Error tracking.** Still none — no Sentry/GlitchTip. Exceptions reach the logs
 and the `phoenix_router_dispatch_exception_count` counter, but there is no

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -158,12 +158,36 @@ spec:
             # default trust list already covers. (Cloudflare egress ranges
             # were listed here briefly; the tunnel made them unnecessary —
             # CF's own addresses never appear as hops.)
-            # No OTLP collector in-cluster yet — without this,
-            # opentelemetry_exporter retries localhost:4318 per span and
-            # floods logs with :econnrefused. Swap to the real
-            # OTEL_EXPORTER_OTLP_ENDPOINT once a collector is wired up.
-            - name: OTEL_TRACES_EXPORTER
-              value: "none"
+            # --- Tracing (OTel -> Tempo) ---
+            # Tempo runs in-cluster (home-cloud platform/tempo), keeping blocks
+            # in garage under a 5 GiB bucket quota with 72h retention. This
+            # replaces OTEL_TRACES_EXPORTER=none, which was here because
+            # nothing was listening and opentelemetry_exporter retried
+            # localhost:4318 per span, flooding the logs with :econnrefused.
+            #
+            # Setting an endpoint is the whole switch: runtime.exs flips
+            # traces_exporter to :otlp as soon as one of
+            # OTEL_EXPORTER_OTLP_ENDPOINT / HONEYCOMB_* is present (#317 made
+            # "no target configured" mean "export nothing", so a self-hoster
+            # who sets none of these still exports nowhere). The exporter
+            # speaks OTLP over HTTP/protobuf, so this is Tempo's http receiver
+            # port 4318 — not grpc's 4317.
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://tempo.tempo.svc.cluster.local:4318
+            - name: OTEL_SERVICE_NAME
+              value: fountain
+            # Pod identity on every span, so Grafana's Tempo -> Loki jump can
+            # narrow from a slow span to that pod's logs: the tempo datasource
+            # maps k8s.namespace.name / k8s.pod.name onto the namespace / pod
+            # labels alloy puts on log lines. The Erlang SDK merges
+            # OTEL_RESOURCE_ATTRIBUTES into the resource runtime.exs builds.
+            # POD_NAME must be declared before the var that references it.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: k8s.namespace.name=fountain,k8s.pod.name=$(POD_NAME)
           # Replaces the base's list (configMap + secret): this deployment has
           # no ConfigMap — non-secret config is the explicit env above, and
           # everything else comes from the Infisical-materialized Secret:


### PR DESCRIPTION
## What

Points Fountain's OTel exporter at the Tempo instance added in [jhgaylor/home-cloud#112](https://github.com/jhgaylor/home-cloud/pull/112).

Fountain has been instrumented since the ACP tracer landed (#637) — Phoenix, Ecto, per-turn spans, and a `fountain.tool_use` child span per tool call for every runtime — and exporting all of it to nothing. `OTEL_TRACES_EXPORTER=none` was on the deployment because no collector existed, and without it `opentelemetry_exporter` retried `localhost:4318` per span and flooded the logs with `:econnrefused`.

## The change

```diff
-            - name: OTEL_TRACES_EXPORTER
-              value: "none"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://tempo.tempo.svc.cluster.local:4318
+            - name: OTEL_SERVICE_NAME
+              value: fountain
+            - name: POD_NAME        # downward API
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: k8s.namespace.name=fountain,k8s.pod.name=$(POD_NAME)
```

Setting the endpoint is the entire switch — `runtime.exs` flips `traces_exporter` to `:otlp` as soon as a target is configured. That is #317's design, so a self-hoster who sets nothing still exports nowhere; `deploy/k8s/` is deliberately unchanged. Port **4318**, not 4317: the exporter speaks OTLP over HTTP/protobuf.

`OTEL_RESOURCE_ATTRIBUTES` puts `k8s.namespace.name` / `k8s.pod.name` on every span. The Erlang SDK merges those into the resource `runtime.exs` builds, and Grafana's Tempo datasource maps them onto the `namespace` / `pod` labels alloy puts on log lines — so a slow span jumps straight to that pod's logs for that window. `POD_NAME` is declared before the var referencing it, per the existing `POD_IP` note.

Also refreshes `priv/help/runbook.md`, whose tracing section said traces went nowhere and told the operator to stand up a collector first.

## Verification

- `kubectl kustomize k8s` renders with `OTEL_TRACES_EXPORTER` gone and `POD_NAME` (index 19) ahead of `OTEL_RESOURCE_ATTRIBUTES` (index 20), so `$(POD_NAME)` substitutes
- `config_reference_test.exs` scans `config/runtime.exs` only, which is untouched — no new doc rows required, and `docs/configuration.md` already documents this env surface correctly

## Ordering

Merge home-cloud#112 first. Merging this before Tempo exists reintroduces the `:econnrefused` log flood — the failure mode the `none` was there to prevent.

Sentry and PostHog are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)