### PR TITLE
fix(audit): the API request-log action is the route pattern, not the path

### DIFF
--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -203,7 +203,7 @@ defmodule Fountain.Runtimes.ACP do
   Runtimes with an adapter entry that are held back, and why.
 
   Public so the reason travels with the code rather than living only in an
-  issue: `%{"gemini" => "#659"}`.
+  issue. Empty since #964; the last entry was `%{"gemini" => "#659"}`.
   """
   @spec blocked_runtimes() :: %{String.t() => String.t()}
   def blocked_runtimes do
@@ -273,9 +273,10 @@ defmodule Fountain.Runtimes.ACP do
   Whether this turn speaks ACP.
 
   A property of the runtime alone: supported runtimes always do, and for them
-  the legacy spawn path no longer exists. A blocked or unknown runtime
-  (gemini, #659) takes the legacy path — for those it is not a failure mode,
-  it is the only path.
+  the legacy spawn path no longer exists. Since #964 that is all four, so the
+  false branch has no runtime left — it answers for a conversation row naming
+  a runtime with no adapter entry, and for a blocked one should `blocked:`
+  ever be used again.
 
   Takes the runtime string, not the agent, because a conversation outlives
   its agent (deleting one nilifies `agent_id`) and the conversation row

--- a/apps/fountain/lib/fountain_web/plugs/audit.ex
+++ b/apps/fountain/lib/fountain_web/plugs/audit.ex
@@ -3,8 +3,9 @@ defmodule FountainWeb.Plugs.Audit do
   Records state-changing API requests to the audit log on the way out.
 
   Captures:
-    * `action`: HTTP verb + last path segment after `/api/` (e.g.
-      `POST conversations`, `DELETE environments/:id/secrets/:id`).
+    * `action`: HTTP verb + the matched *route pattern* (e.g.
+      `POST /api/conversations`, `DELETE /api/environments/:environment_id/secrets/:id`).
+      The pattern, not the request path: see "Why the pattern and not the path".
     * `resource_type`, `resource_id`: derived from the matched route's
       action + params.
     * `actor`: derived from the credential — `"sprite"` for a per-conversation
@@ -40,6 +41,32 @@ defmodule FountainWeb.Plugs.Audit do
 
   Recorded as a decision in ADR 0013 §4 — two rows per API mutation is
   intended, and deduplicating them in the UI would lose the refused requests.
+
+  ## Why the pattern and not the path
+
+  This used to record `conn.request_path` verbatim, which put the resource id
+  inside the action string: `POST /api/conversations/<uuid>/read` was a
+  different action from the same call against a different conversation. Two
+  things break when it does.
+
+  The trail loses its only groupable field. "Show me every read of a
+  conversation" is a `LIKE` over a column that has one distinct value per
+  conversation, and the id is already in `resource_id` where a query can use
+  it.
+
+  And `Fountain.Analytics` mirrors `action` straight through as the **PostHog
+  event name**. One event definition per uuid is unbounded cardinality in a
+  third-party project that never garbage-collects definitions — the Fountain
+  project had already grown `POST /api/conversations/<uuid>/read`,
+  `POST /api/team/<uuid>/messages` and `POST /api/mcp/team/<uuid>` as separate
+  events by the time anyone looked at the taxonomy.
+
+  The route pattern is what both want. `Phoenix.Router.route_info/4` gives it
+  exactly, from the same match the request already went through. When there is
+  no router on the conn or the path does not match a route — neither happens
+  on a live request that reached this pipeline, but both happen in a unit test
+  that builds a bare conn — uuid-shaped segments are masked to `:id` instead,
+  so the fallback is bounded too.
   """
 
   import Plug.Conn
@@ -67,7 +94,7 @@ defmodule FountainWeb.Plugs.Audit do
     {resource_type, resource_id} = derive_resource(conn)
 
     Audit.record(%{
-      action: "#{conn.method} #{conn.request_path}",
+      action: "#{conn.method} #{route_pattern(conn)}",
       resource_type: resource_type,
       resource_id: resource_id,
       actor: actor(conn),
@@ -77,6 +104,29 @@ defmodule FountainWeb.Plugs.Audit do
     })
 
     conn
+  end
+
+  # The matched route as declared in the router, e.g. "/api/agents/:id". See
+  # "Why the pattern and not the path" in the moduledoc for why this is not
+  # `conn.request_path`.
+  defp route_pattern(conn) do
+    with router when not is_nil(router) <- conn.private[:phoenix_router],
+         %{route: route} when is_binary(route) <-
+           Phoenix.Router.route_info(router, conn.method, conn.request_path, conn.host) do
+      route
+    else
+      _ -> mask_ids(conn.request_path)
+    end
+  end
+
+  @uuid ~r/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+  defp mask_ids(path) do
+    path
+    |> String.split("/")
+    |> Enum.map_join("/", fn segment ->
+      if Regex.match?(@uuid, segment), do: ":id", else: segment
+    end)
   end
 
   # A sandbox acting on the tenant's behalf is a materially different claim from

--- a/apps/fountain/test/fountain_web/plugs/audit_plug_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/audit_plug_test.exs
@@ -300,4 +300,114 @@ defmodule FountainWeb.Plugs.AuditTest do
       assert %Plug.Conn{} = sent_conn(conn)
     end
   end
+
+  # The action string is mirrored straight through as the PostHog event name
+  # (`Fountain.Audit.do_mirror/1`), so a resource id inside it is one event
+  # definition per resource in a third-party project. It is also the only
+  # groupable column the trail has.
+  describe "action — the route pattern, never the request path" do
+    setup do
+      user = insert_verified_user()
+      {_key, raw_key} = insert_api_key(user)
+      {:ok, user: user, raw_key: raw_key}
+    end
+
+    test "a nested member route records the pattern, not the uuid", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      # 404 on purpose: the plug records what was attempted, and a refused
+      # request is exactly the case a semantic context event cannot cover.
+      conn
+      |> authed_with_key(raw_key)
+      |> post("/api/conversations/#{Ecto.UUID.generate()}/read")
+
+      assert action_for(user) == "POST /api/conversations/:conversation_id/read"
+    end
+
+    test "a top-level member route records the pattern", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conn
+      |> authed_with_key(raw_key)
+      |> delete("/api/agents/#{Ecto.UUID.generate()}")
+
+      assert action_for(user) == "DELETE /api/agents/:id"
+    end
+
+    test "a collection route is unchanged", %{conn: conn, user: user, raw_key: raw_key} do
+      conn
+      |> authed_with_key(raw_key)
+      |> post("/api/agents", %{})
+
+      assert action_for(user) == "POST /api/agents"
+    end
+
+    test "no route id leaks into any action a routed request records", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      id = Ecto.UUID.generate()
+
+      conn
+      |> authed_with_key(raw_key)
+      |> post("/api/conversations/#{id}/read")
+
+      refute action_for(user) =~ id
+    end
+
+    # Only reachable from a hand-built conn, but the fallback has to be
+    # bounded too or it reintroduces the cardinality it exists to prevent.
+    test "falls back to masking uuid segments when the conn has no router", %{
+      conn: conn,
+      user: user
+    } do
+      id = Ecto.UUID.generate()
+
+      conn
+      |> Map.merge(%{
+        method: "POST",
+        request_path: "/api/conversations/#{id}/read",
+        path_info: ["api", "conversations", id, "read"],
+        params: %{},
+        private: %{}
+      })
+      |> Map.put(:remote_ip, {127, 0, 0, 1})
+      |> Plug.Conn.assign(:current_user, user)
+      |> Audit.call([])
+      |> Plug.Conn.send_resp(404, "")
+
+      assert action_for(user) == "POST /api/conversations/:id/read"
+    end
+
+    test "leaves a routerless path with no uuid alone", %{conn: conn, user: user} do
+      conn
+      |> Map.merge(%{
+        method: "POST",
+        request_path: "/api/conversations",
+        path_info: ["api", "conversations"],
+        params: %{},
+        private: %{}
+      })
+      |> Map.put(:remote_ip, {127, 0, 0, 1})
+      |> Plug.Conn.assign(:current_user, user)
+      |> Audit.call([])
+      |> Plug.Conn.send_resp(201, "ok")
+
+      assert action_for(user) == "POST /api/conversations"
+    end
+  end
+
+  # The plug's row is the one whose action starts with an HTTP verb — the
+  # context that handled the request writes its own semantic row through the
+  # same table.
+  defp action_for(user) do
+    Fountain.Audit.list_recent_for_user(user.id)
+    |> Enum.map(& &1.action)
+    |> Enum.find(&String.starts_with?(&1, ~w(POST PUT PATCH DELETE)))
+  end
 end

--- a/decisions/0013-audit-trail.md
+++ b/decisions/0013-audit-trail.md
@@ -177,6 +177,14 @@ considered and rejected: that list is a second place to remember, one forgotten
 entry away from a silently unaudited route — the exact failure mode #540
 existed to remove.
 
+The plug's action is the **route pattern** (`PUT /api/agents/:id`), not the
+request path. The code recorded `conn.request_path` until #979, which put the
+resource id inside the action and cost two things: the trail's only groupable
+column, and — because `Fountain.Analytics` mirrors `action` through as the
+PostHog event name ([ADR 0025](0025-product-analytics-in-posthog.md)) — a bounded event
+taxonomy. The Fountain project had grown a separate event definition per
+conversation before anyone looked.
+
 ### 5. Deleting an account anonymises its trail
 
 `audit_events.user_id` is `on_delete: :nilify_all`. Deleting an account does

--- a/docs/catalog/runtimes/gemini.md
+++ b/docs/catalog/runtimes/gemini.md
@@ -1,6 +1,7 @@
 # gemini
 
-> Google's Gemini CLI. The only runtime off ACP.
+> Google's Gemini CLI. The last runtime to reach ACP, and it reached it on
+> 2026-08-22.
 
 ## At a glance
 
@@ -8,7 +9,7 @@
 |---|---|
 | Provider | `google` |
 | Multi-provider | No |
-| Transport | **Legacy**. A line-delimited `stream-json` that the worker tails. |
+| Transport | ACP, through the CLI's own `--acp` flag |
 | Skills root | `/tmp/.gemini/skills` |
 | skills.sh agent | `gemini-cli` |
 | System prompt | `~/.gemini/GEMINI.md` |
@@ -18,8 +19,9 @@
 
 You want a Gemini model in particular. That is the whole case.
 
-If you do not, choose [claude](claude.md), [codex](codex.md) or
-[opencode](opencode.md). All three are on ACP.
+All four runtimes speak ACP, so the transport no longer decides this. Choose
+[opencode](opencode.md) instead to move one agent definition between
+providers.
 
 ## Set it up
 
@@ -37,21 +39,25 @@ Add your Gemini key at `/account/inference-credentials`.
 
 ## Verify
 
-Run a conversation. Output that arrives at all proves the credential and the
-legacy stream parser.
+Run a conversation, then ask it what model it is. A turn that reaches output
+at all proves the credential, the runtime and the sandbox.
 
 ## Limits
 
-**Off ACP.** The other three runtimes speak the Agent Client Protocol, which
-carries editor integration and the shared block format. Gemini uses the older
-path, so it gets neither.
+**Every turn after the first replays the whole transcript.** Gemini advertises
+`loadSession` and no resume capability, so a turn loads the session again from
+the start. Fountain discards that replay. The cost is time at the head of a
+turn, and it grows with the transcript. The other three runtimes reattach.
 
-**The sessions belong to the CLI, and not to Fountain.** Gemini manages its
-own session state. Its `--resume` re-enters the most recent conversation in
-the workspace, so Fountain passes no session id. One workspace holds one
-session that you can resume.
+**Fountain repairs gemini's session store after every turn.** The store
+deletes a session while it loads it, an upstream defect
+([gemini-cli#28775](https://github.com/google-gemini/gemini-cli/issues/28775)).
+Fountain consolidates the store at the end of each turn, so a load cannot
+collide with what it loads. That workaround goes away when upstream lands a
+fix.
 
 ## Related
 
 - [About agents](../../concepts/agent.md)
+- [`fountain acp`](../../integrations/acp.md)
 - [Runtimes](index.md)

--- a/docs/catalog/runtimes/index.md
+++ b/docs/catalog/runtimes/index.md
@@ -12,7 +12,7 @@ prompt.
 | [claude](claude.md) | `anthropic` | ACP | No |
 | [codex](codex.md) | `openai` | ACP | No |
 | [opencode](opencode.md) | Any of the three | ACP | **Yes** |
-| [gemini](gemini.md) | `google` | Legacy stream | No |
+| [gemini](gemini.md) | `google` | ACP, through `gemini --acp` | No |
 
 ## How to choose
 
@@ -26,9 +26,10 @@ providers. Read
 is the only multi-provider runtime. It takes the canonical `provider/model-id`
 string word for word, then reads the prefix to decide which key to export.
 
-**Do not choose `gemini` unless you want it in particular.** It is the only
-runtime off ACP. So it gets no editor integration, no permission flow, and
-none of the shared block format that the other three have.
+**All four speak ACP.** Gemini was the last one off it, and it joined on
+2026-08-22. So editor integration, the permission flow and the shared block
+format reach every runtime, and the choice is about the provider and the CLI
+rather than about the transport.
 
 ## The rule that catches people
 

--- a/docs/integrations/acp.md
+++ b/docs/integrations/acp.md
@@ -51,7 +51,7 @@ version when that is lower. `agentInfo` is `fountain`, with the CLI's version.
 |---|---|
 | `initialize` | The capability handshake. Fountain logs the client's own capabilities, which are `fs` and terminals, and uses neither. This agent works on a sandbox filesystem, and not on yours. |
 | `authenticate` | Verifies the CLI's saved credentials against the instance. Fountain advertises it only when it holds none. |
-| `session/new` | Resolves `--agent`. It refuses an agent whose runtime does not speak ACP, which today is `gemini` ([#659](https://github.com/BinaryBourbon/fountain/issues/659)). Then it opens a conversation. **The ACP session id *is* the conversation id**, as below. It responds with the agent's model, as the one model available. |
+| `session/new` | Resolves `--agent`. It refuses an agent whose runtime has no ACP adapter, which today is no runtime at all. Then it opens a conversation. **The ACP session id *is* the conversation id**, as below. It responds with the agent's model, as the one model available. |
 | `session/prompt` | Sends the turn, as text and images. It drops another block with a warning, and refuses a prompt where it can use nothing. It then streams the conversation's ACP output back as `session/update` notifications, until the turn ends. |
 | `session/cancel` | Interrupts the turn that runs. |
 | `session/load` | Reopens a conversation that this process did not start. It replays the stored `session/update` history **before** the response, as the spec demands. |
@@ -176,7 +176,7 @@ terminal.
 | Message | Meaning |
 |---|---|
 | `no Fountain agent configured` | The entry has no `--agent`. |
-| `agent "x" runs the gemini runtime, which does not speak ACP` | Use that agent from the conversations app, or with `fountain run`. |
+| `agent "x" runs the … runtime, which does not speak ACP` | All four runtimes speak ACP. This names a conversation whose runtime column holds a name that no adapter covers. Use that agent from the conversations app, or with `fountain run`. |
 | `credentials for … were rejected` | Run `fountain auth login`. The message names the instance it tried, and that is usually the surprise. |
 | `could not resolve agent "x" on …` | The wrong name, or the right name on a different instance. |
 | `the sandbox never started: …` | The provision failed, and the reason belongs to the sandbox provider. |

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -116,6 +116,25 @@ Use it when one agent config must run under several baselines. The same
 is one, still wins on a key collision. An agent can also restrict which
 environments can stand in for its own, with `allowed_environment_ids`.
 
+### Approve a tool before it runs
+
+By default the agent runs a tool without a question. `--permission ask` puts
+the question in your editor instead, as its own approval prompt. The tool waits
+for your answer.
+
+```json
+"args": ["acp", "--agent", "researcher", "--permission", "ask"]
+```
+
+To ask about one kind of tool only, name the kind. `--permission execute=ask`
+asks before a shell command, and permits the rest. An entry can only narrow
+what the agent itself permits. [Before a tool runs](../concepts/permissions.md)
+holds the policy, the keys and the three verdicts.
+
+No answer is an answer. Fountain refuses a prompt that you dismiss. It refuses
+one that your editor never answers, and one that waits 5 minutes. The turn
+continues either way, and the agent reads that it has no permission.
+
 ### Any other ACP client
 
 Nothing in the adapter is specific to Zed. Whatever your client calls it, the
@@ -144,6 +163,7 @@ version.
 | `session/prompt` | Runs a turn. Messages, thoughts and tool calls stream back as they happen. |
 | `session/cancel` | Interrupts the turn that runs. |
 | `session/load` | Replays the conversation into an editor you just opened. |
+| `session/request_permission` (agent → editor) | Asks you before the agent runs a tool, when the policy says `ask`. Your answer goes back to the agent. |
 
 A prompt can carry images. A dropped connection is not a lost turn. The server
 closes an idle stream after 60 seconds, and the adapter reconnects and
@@ -152,14 +172,12 @@ continues from where it stopped.
 ## Limits, stated rather than discovered
 
 - **No access to your local files**, as above.
-- **Fountain refuses an agent on the `gemini` runtime** when the editor opens
-  a session, and names it. Gemini is not on ACP yet
-  ([#659](https://github.com/BinaryBourbon/fountain/issues/659)). Use those
-  agents from the conversations app, or with `fountain run`.
-- **Fountain does not forward a permission prompt yet.** An agent today
-  handles its own permissions, so nothing asks your editor to approve a tool
-  call ([#643](https://github.com/BinaryBourbon/fountain/issues/643),
-  [#708](https://github.com/BinaryBourbon/fountain/issues/708)).
+- **The opencode runtime never asks.** It decides permission inside its own
+  server, and it sends no request to your editor. Fountain refuses a policy it
+  cannot enforce, with a 422 at session start
+  ([#959](https://github.com/BinaryBourbon/fountain/issues/959)). Nobody has
+  measured whether opencode's own config reaches the protocol
+  ([#962](https://github.com/BinaryBourbon/fountain/issues/962)).
 - **A reclaimed sandbox loses the agent's memory.** If Fountain reclaimed a
   conversation's sandbox while you were away, `session/load` still replays the
   full transcript. The agent itself does not remember it
@@ -181,7 +199,7 @@ terminal.
 | Message | Meaning |
 |---|---|
 | `no Fountain agent configured` | The entry has no `--agent`. |
-| `agent "x" runs the gemini runtime, which does not speak ACP` | Read the limits above. |
+| `agent "x" runs the … runtime, which does not speak ACP` | All four runtimes speak ACP. This names a conversation whose runtime column holds a name that no adapter covers. |
 | `credentials for … were rejected` | Run `fountain auth login`. The message names the instance it tried, and that is usually the surprise. |
 | `could not resolve agent "x" on …` | The wrong name, or the right name on a different instance. |
 

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -103,8 +103,8 @@ OpenClaw runs on Node, and needs **Node ≥ 22.22.3**, or ≥ 24.15, or ≥ 25.9
               // the id you spawn/bind, mapped to the command OpenClaw runs
               fountain: { command: "fountain", args: ["acp", "--agent", "researcher"] }
             },
-            // until permission forwarding lands (see Limits), the sandbox's own
-            // policy runs the turn; ask acpx not to block on an approval prompt
+            // the agent's own policy runs the turn; nobody has measured an
+            // `ask` policy through acpx yet (see Limits)
             permissionMode: "approve-all"
           }
         }
@@ -207,15 +207,13 @@ environments can stand in for its own, with `allowed_environment_ids`.
 - **One identity for each host.** OpenClaw is single-user and self-hosted, so
   each session authenticates as the host's Fountain login. This integration
   gives you no Fountain identity for each channel user.
-- **Fountain refuses an agent on the `gemini` runtime** when a session opens,
-  and names it. Gemini is not on ACP yet
-  ([#659](https://github.com/BinaryBourbon/fountain/issues/659)). Use those
-  agents from the conversations app, or with `fountain run`.
-- **Fountain does not forward a permission prompt yet.** An agent today
-  handles its own permissions, which is why the setup above sets
-  `permissionMode: "approve-all"`. Nothing asks an OpenClaw channel to approve
-  a tool call ([#643](https://github.com/BinaryBourbon/fountain/issues/643),
-  [#708](https://github.com/BinaryBourbon/fountain/issues/708)).
+- **We have not measured a permission prompt in a channel.** Fountain forwards
+  `session/request_permission` to an ACP client
+  ([#708](https://github.com/BinaryBourbon/fountain/issues/708)), and the setup
+  above keeps `permissionMode: "approve-all"` because nobody has driven an
+  `ask` policy through OpenClaw yet. An unanswered prompt blocks the tool for 5
+  minutes, and Fountain then refuses it. Leave the default until somebody
+  measures it.
 - **The model, and the thinking level, belong to the Fountain agent.** <!-- vale disable-line STE.IngForms -->
   Fountain accepts and ignores OpenClaw's `--model`, the `model` and
   `thinking` on `sessions_spawn`, and the `/acp` model controls. A Fountain
@@ -286,7 +284,7 @@ fountain acp --agent researcher --log-level debug
 | Message | Meaning |
 |---|---|
 | `no Fountain agent configured` | The entry has no `--agent`. |
-| `agent "x" runs the gemini runtime, which does not speak ACP` | Read the limits above. |
+| `agent "x" runs the … runtime, which does not speak ACP` | All four runtimes speak ACP. This names a conversation whose runtime column holds a name that no adapter covers. |
 | `credentials for … were rejected` | Run `fountain auth login` on the host. The message names the instance it tried. |
 | `could not resolve agent "x" on …` | The wrong name, or the right name on a different instance. |
 


### PR DESCRIPTION
## What

`FountainWeb.Plugs.Audit` recorded `"#{conn.method} #{conn.request_path}"`, putting the resource id inside the action string. `POST /api/conversations/<uuid>/read` was a different action from the same call against a different conversation.

Now it records the matched **route pattern**: `POST /api/conversations/:conversation_id/read`.

## Why

**The trail loses its only groupable column.** "Show me every read of a conversation" is a `LIKE` over a column with one distinct value per conversation — and the id is already in `resource_id`, where a query can use it. [ADR 0013 §4](../blob/main/decisions/0013-audit-trail.md) has always described this row as `PUT /api/agents/:id`; the code is what drifted.

**It is also the PostHog event name.** `Fountain.Audit.do_mirror/1` passes `action` straight through to `Fountain.Analytics.capture/4` (ADR 0025), so every uuid became its own event definition in a third-party project that never garbage-collects them. Reading the live taxonomy today, the Fountain project has already grown these as separate events:

```
POST /api/conversations/720b27a7-304a-4424-993a-74b451f82b94/read
POST /api/conversations/ed5cf0d6-2638-44bc-ab0c-7a7401ea387a/read
POST /api/team/77ac0055-67cc-46c7-a4be-2e59ef0ab332/messages
POST /api/mcp/team/720b27a7-304a-4424-993a-74b451f82b94
```

Unbounded, and growing once per conversation.

## How

`Phoenix.Router.route_info/4` returns the pattern from the same match the request already went through — exact, no string heuristics.

When the conn carries no router, or the path matches no route, uuid-shaped segments are masked to `:id`. Neither case happens on a live request that reached this pipeline (the plug sits inside the `:api` pipeline, which only runs on a matched route), but both happen in a unit test that builds a bare conn — and the fallback has to be bounded too, or it reintroduces exactly what this removes.

## Tests

Six new tests in `audit_plug_test.exs`, four of which fail against the old code (verified by reverting the one-line change and re-running):

- a nested member route records `POST /api/conversations/:conversation_id/read`
- a top-level member route records `DELETE /api/agents/:id`
- a collection route is unchanged
- no route id leaks into any action a routed request records
- the routerless fallback masks uuids
- the routerless fallback leaves a uuid-free path alone

The first four go through the real router with a real API key, so they cover the wiring and not just the function.

## Note

Existing audit rows keep their raw-path actions. Nothing parses the column (checked), so no migration. PostHog keeps the old event definitions — they will simply stop receiving events; they can be deleted in the project UI.

## Gates run locally

`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `scripts/sobelow.sh`, `mix dialyzer` (0 errors), `okf validate decisions`, and 139 audit/analytics tests — all green.