### PR TITLE
fix(analytics): stop mirroring machine churn from the audit trail into PostHog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ upgrade, is in
   `$feature_flag_called` while stamping `$feature/<key>` onto every other
   event.
 
+  The trail is a superset of the product stream, and two things it carries are
+  refused: the `:api` pipeline's request-log row, whose name holds a resource
+  id and would make a new PostHog event type per resource, and an API key
+  Fountain issued to itself (a sandbox credential, a Buzz harness credential,
+  an OAuth token). Those were 70% of the trail in its first day. A key a
+  person mints in the console or through the API is kept. Nothing is dropped
+  from the audit trail itself.
+
   Nothing is sent without `POSTHOG_PROJECT_API_KEY`, and `POSTHOG_CAPTURE=false`
   keeps flag evaluation while stopping capture. Events carry action names,
   resource types, counts and sizes, never secret values, prompts or agent

--- a/apps/fountain/lib/fountain/analytics.ex
+++ b/apps/fountain/lib/fountain/analytics.ex
@@ -169,6 +169,65 @@ defmodule Fountain.Analytics do
     )
   end
 
+  # A context action name: dotted, lowercase, closed vocabulary
+  # (`agent.created`, `team.contact.provisioned`). Anything else arriving from
+  # the audit trail is the `:api` pipeline's request-log row, which is named
+  # after the request line and carries a UUID.
+  @context_action ~r/^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+$/
+
+  # The two surfaces a person mints an API key from. Everything else is a
+  # credential the system issued itself.
+  @human_actors ~w(ui api)
+
+  @doc """
+  Whether an audited action belongs in PostHog.
+
+  The audit trail and a product analytics stream want different things, and
+  mirroring one into the other wholesale was wrong in two ways that a day of
+  production data made obvious (2,160 audit rows in 24 hours).
+
+  ## The request log is not a product event
+
+  ADR 0013 §4 keeps a **second** row for every API mutation, written by the
+  `:api` pipeline plug and named after the request line
+  (`POST /api/conversations/<uuid>/read`). It answers "what was attempted",
+  including for requests that were refused, which is what an access log is
+  for. The semantic row for the same mutation (`conversation.created`) is
+  already captured, so nothing is lost by declining the second one.
+
+  What would be lost by keeping it is the event taxonomy. Those names embed
+  resource ids: **73 distinct action names in one day**, every one of which
+  PostHog registers as its own event definition, permanently. A product
+  vocabulary has to be closed, and `@context_action` is that fence.
+
+  ## A credential the system issued itself is not a product event
+
+  `api_key.created` and `api_key.revoked` were **1,513 of those 2,160 rows —
+  70% of the entire trail**. Not one carried a human actor: 534 `self`
+  (the context default, which OAuth token issuance takes — a Fountain OAuth
+  token *is* an API key, ADR 0021), 445 `system:conversation_server`, 341
+  `system:buzz_harness`, 193 `system:buzz_boot_sweep`. Those are sprite
+  credentials minted and revoked per conversation and per harness boot. They
+  say how busy the machine is, which is a telemetry question, and they would
+  have drowned every real signal in the project.
+
+  A person minting a key in the console or through the API is genuine product
+  usage and is kept: both call sites pass `FountainWeb.Audited.attribution/2`,
+  so they arrive as `ui` or `api`.
+
+  This filter never touches what is *audited*. The trail keeps every row.
+  """
+  @spec product_event?(String.t(), String.t() | nil) :: boolean()
+  def product_event?(action, actor) when is_binary(action) do
+    cond do
+      not Regex.match?(@context_action, action) -> false
+      String.starts_with?(action, "api_key.") -> actor in @human_actors
+      true -> true
+    end
+  end
+
+  def product_event?(_action, _actor), do: false
+
   @doc """
   Person properties derived from a user row.
 

--- a/apps/fountain/lib/fountain/audit.ex
+++ b/apps/fountain/lib/fountain/audit.ex
@@ -112,8 +112,21 @@ defmodule Fountain.Audit do
   end
 
   defp do_mirror(%Event{} = event) do
+    # Not every audited row is a product event. `Analytics.product_event?/2`
+    # owns that judgement and says why; the short version is that the `:api`
+    # pipeline's request-log row is named after the request line (so its name
+    # carries a UUID) and self-issued API keys were 70% of the trail.
+    #
+    # `refresh_person/1` still runs for the rows this drops. A subscription
+    # transition recorded against a system actor changes the account's shape
+    # whether or not the row itself is worth counting.
     refresh_person(event)
 
+    if Fountain.Analytics.product_event?(event.action, event.actor),
+      do: capture_event(event)
+  end
+
+  defp capture_event(%Event{} = event) do
     Fountain.Analytics.capture(
       event.action,
       event.user_id,

--- a/apps/fountain/test/fountain/analytics_bridges_test.exs
+++ b/apps/fountain/test/fountain/analytics_bridges_test.exs
@@ -136,6 +136,63 @@ defmodule Fountain.AnalyticsBridgesTest do
     end
   end
 
+  describe "what the audit trail does not forward" do
+    test "the api pipeline's request-log row is audited but not captured" do
+      user = insert_verified_user()
+      forget_setup()
+
+      {:ok, _} =
+        Audit.record(%{
+          action: "DELETE /api/agents/02100b96-193b-4bdf-b9d9-d1f6e356061d",
+          resource_type: "request",
+          user_id: user.id,
+          actor: "api"
+        })
+
+      assert captured() == []
+
+      # Still in the trail, which is the point: this drops nothing from the
+      # audit record, only from the product stream.
+      assert Enum.any?(
+               Fountain.Audit.list_for_user(user.id),
+               &(&1.action == "DELETE /api/agents/02100b96-193b-4bdf-b9d9-d1f6e356061d")
+             )
+    end
+
+    test "an API key the system issued itself is not captured" do
+      user = insert_verified_user()
+      forget_setup()
+
+      for actor <- ["self", "system:conversation_server", "system:buzz_harness"] do
+        {:ok, _} =
+          Audit.record(%{
+            action: "api_key.created",
+            resource_type: "api_key",
+            user_id: user.id,
+            actor: actor
+          })
+      end
+
+      assert captured() == []
+    end
+
+    test "an API key a person minted is captured" do
+      user = insert_verified_user()
+      forget_setup()
+
+      {:ok, _} =
+        Audit.record(%{
+          action: "api_key.created",
+          resource_type: "api_key",
+          user_id: user.id,
+          actor: "ui"
+        })
+
+      assert event = event_named("api_key.created")
+      assert event["properties"]["actor"] == "ui"
+    end
+  end
+
   describe "the metering choke point" do
     test "a usage event is also a product event" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain/analytics_test.exs
+++ b/apps/fountain/test/fountain/analytics_test.exs
@@ -196,6 +196,50 @@ defmodule Fountain.AnalyticsTest do
     end
   end
 
+  describe "product_event?/2" do
+    test "an ordinary context action is a product event" do
+      assert Analytics.product_event?("agent.created", "ui")
+      assert Analytics.product_event?("conversation.created", "api")
+      assert Analytics.product_event?("team.contact.provisioned", "self")
+      assert Analytics.product_event?("billing.trial.started", "system:trial_sweeper")
+    end
+
+    test "the api pipeline's request-log row is not" do
+      # ADR 0013 §4 writes one of these per API mutation, named after the
+      # request line. Its name carries a resource id, so PostHog would register
+      # a new event definition for every conversation anyone touched.
+      refute Analytics.product_event?("POST /api/conversations", "api")
+
+      refute Analytics.product_event?(
+               "DELETE /api/agents/02100b96-193b-4bdf-b9d9-d1f6e356061d",
+               "api"
+             )
+
+      refute Analytics.product_event?("GET /api/agents", "api")
+    end
+
+    test "an API key the system issued itself is not" do
+      refute Analytics.product_event?("api_key.created", "self")
+      refute Analytics.product_event?("api_key.created", "system:conversation_server")
+      refute Analytics.product_event?("api_key.revoked", "system:buzz_harness")
+      refute Analytics.product_event?("api_key.created", nil)
+    end
+
+    test "an API key a person minted is" do
+      assert Analytics.product_event?("api_key.created", "ui")
+      assert Analytics.product_event?("api_key.revoked", "ui")
+      assert Analytics.product_event?("api_key.created", "api")
+    end
+
+    test "a name outside the closed vocabulary is refused" do
+      refute Analytics.product_event?("Agent.Created", "ui")
+      refute Analytics.product_event?("agent created", "ui")
+      refute Analytics.product_event?("agent", "ui")
+      refute Analytics.product_event?("", "ui")
+      refute Analytics.product_event?(nil, "ui")
+    end
+  end
+
   describe "sanitize/1" do
     test "passes scalars through" do
       assert Analytics.sanitize(%{"provider" => "sprites", "count" => 3, "ok" => true}) ==

--- a/decisions/0025-product-analytics-in-posthog.md
+++ b/decisions/0025-product-analytics-in-posthog.md
@@ -77,6 +77,27 @@ audit trail means the analytics vocabulary *is* the audit vocabulary, the
 guardrail test that forces a new mutation to audit also forces it to be
 captured, and the two can never drift apart in coverage.
 
+**The trail is a superset of the product stream.** Riding the audit trail gives
+coverage for free, and the first day in production showed it also carries two
+things a product stream must refuse. Of 2,160 audit rows in 24 hours:
+
+- **1,513 (70%) were `api_key.created` / `api_key.revoked`**, and not one had a
+  human actor: 534 `self` (the default, which OAuth token issuance takes — a
+  Fountain OAuth token *is* an API key, ADR 0021), 445
+  `system:conversation_server`, 341 `system:buzz_harness`, 193
+  `system:buzz_boot_sweep`. Those are sprite credentials minted and revoked per
+  conversation and per harness boot. A key a person mints in the console or
+  through the API arrives as `ui` or `api` and is kept.
+- **425 rows across 73 distinct names were the `:api` pipeline's request-log
+  row** (ADR 0013 §4), named after the request line and carrying a resource id.
+  PostHog registers each distinct name as its own event definition, so that is
+  73 new definitions per day, permanently. The semantic row for the same
+  mutation is already captured, so refusing it loses nothing.
+
+`Fountain.Analytics.product_event?/2` is that filter: a closed dotted
+vocabulary, and `api_key.*` only from a human actor. It changes nothing about
+what is audited — every row still lands in the trail.
+
 **Off unless configured, and it never carries content.** No
 `POSTHOG_PROJECT_API_KEY` means nothing is sent. `POSTHOG_CAPTURE=false` keeps
 flag evaluation and stops capture. Events carry action names, resource types,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,6 +238,17 @@ without a new call site.
 - The end of a conversation turn, as `conversation.turn.done`,
   `conversation.turn.failed` or `conversation.turn.interrupted`.
 
+Two kinds of audited change stay out of PostHog. The audit trail keeps both.
+
+- The request log. Each API write leaves a second audit row named after the
+  request line, such as `POST /api/agents/<id>`. The name holds a resource id,
+  so PostHog would make a new event type for each resource. The first row
+  already says what changed.
+- An API key that Fountain issued to itself. A sandbox and a Buzz harness each
+  get a key, and an OAuth token is a key. These were 70 percent of the trail in
+  one day. A key that a person makes in the console, or through the API, is
+  kept.
+
 Fountain also captures `$pageview` for each console page, `$identify` when the
 shape of an account changes, and `$feature_flag_called` when it reads a flag.
 Each event carries the flags that Fountain already knows for that person, as


### PR DESCRIPTION
#973 mirrored the audit trail into PostHog on the argument that a choke point
cannot drift out of coverage. That argument holds. What the first day in
production showed is that the trail is a **superset** of a product stream, and
carries two things a product stream has to refuse.

Of 2,160 audit rows in 24 hours:

| | rows | |
|---|---|---|
| `api_key.created` / `api_key.revoked` | 1,513 | 70% of the trail |
| the `:api` pipeline's request-log row | 425 | across **73 distinct names** |
| everything else | 222 | the actual product signal |

## Self-issued credentials

Not one of those 1,513 had a human actor:

```
self                        534   the context default, which OAuth token
                                  issuance takes (a Fountain OAuth token
                                  IS an API key, ADR 0021)
system:conversation_server  445   a sandbox credential per conversation
system:buzz_harness         341
system:buzz_boot_sweep      193
```

Sandbox and harness credentials, minted and revoked per conversation and per
boot. They say how busy the machine is, which is a telemetry question, and they
would have drowned every real signal in the project.

A key a person mints is genuine product usage and is kept. Both call sites
(`ApiKeysLive` and `ApiKeyController`) pass
`FountainWeb.Audited.attribution/2`, so those arrive as `ui` or `api`.

## The request log, which is the worse of the two

Not because of volume. ADR 0013 §4 keeps a second row per API mutation
deliberately, written by the `:api` pipeline plug and named after the request
line, so its name holds a resource id:

```
DELETE /api/agents/02100b96-193b-4bdf-b9d9-d1f6e356061d
POST /api/conversations/ed5cf0d6-2638-44bc-ab0c-7a7401ea387a/read
```

PostHog registers each distinct name as its own **event definition**. That is
73 new definitions a day, permanently, and no amount of retention clears them.
A product vocabulary has to be closed.

The semantic row for the same mutation (`agent.deleted`) is already captured,
and ADR 0013 §4's own reasoning says why the two exist: the context event says
what changed, the plug row says what was attempted. The second is an access-log
question. Declining to mirror it loses nothing.

## The change

`Analytics.product_event?/2`: a closed dotted vocabulary
(`^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+$`), and `api_key.*` only from a `ui` or `api`
actor. Called from the audit bridge.

Projected server-side volume: **~2,160/day → ~445/day** (222 audit + 137
metering + 86 turn outcomes), measured against the same 24 hours.

**Nothing changes about what is audited.** Every row still lands in the trail;
a test asserts that a dropped row is still there. `refresh_person/1` also still
runs for dropped rows, because a subscription transition against a system actor
changes the account's shape whether or not the row itself is worth counting.

## Verification

`mix precommit` green: credo `found no issues`, dialyzer `Total errors: 0`,
sobelow clean, 3612 tests 0 failures. `vale lint docs` 0 errors 0 warnings,
`docs-style.py` clean, `mkdocs build --strict` clean, `okf validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
