### PR TITLE
docs(runbook): error tracking is Sentry, not "still none"

### DIFF
--- a/apps/fountain/priv/help/runbook.md
+++ b/apps/fountain/priv/help/runbook.md
@@ -214,9 +214,26 @@ kubectl exec -n garage garage-0 -- /garage bucket info tempo
 kubectl logs -n tempo statefulset/tempo --tail=50
 ```
 
-**Error tracking.** Still none — no Sentry/GlitchTip. Exceptions reach the logs
-and the `phoenix_router_dispatch_exception_count` counter, but there is no
-grouping, no stack-trace history, and no per-release regression view.
+**Error tracking.** Sentry, wired in three places: `Sentry.LoggerHandler`
+(attached by `Fountain.Application`, rate-limited to 20 events a minute),
+`Sentry.PlugContext` on the endpoint for request context, and
+`in_app_otp_apps: [:fountain]` so the SDK knows which frames are ours. Events
+carry `release: FOUNTAIN_BUILD_SHA`, so a regression points at the deploy that
+introduced it, and `environment_name` from `SENTRY_ENVIRONMENT`.
+
+Nothing tenant-shaped rides along. `send_default_pii: false` keeps cookies,
+user IPs and bodies out by default, and `FountainWeb.SentryScrubber` replaces
+every string in a request body with a length tag (#402) — an allowlist of
+shape, because Sentry's own scrubber is a three-name denylist that the
+secret-write endpoints sailed straight through.
+
+`SENTRY_DSN` arrives in the Infisical-materialized Secret. An instance without
+one skips the handler entirely, and a *blank* one is deleted from the
+environment rather than passed through, because the SDK reads the variable
+itself and a blank value crashes the `:sentry` app at boot no matter what the
+config says (#497, #513). The package is API-compatible with GlitchTip, so
+re-pointing `SENTRY_DSN` is the whole migration if you ever want the tracker
+off this cluster.
 
 ## Email is not being delivered
 


### PR DESCRIPTION
## What

`priv/help/runbook.md` told an operator, under **What you have when it breaks**:

> **Error tracking.** Still none — no Sentry/GlitchTip. Exceptions reach the logs and the `phoenix_router_dispatch_exception_count` counter, but there is no grouping, no stack-trace history, and no per-release regression view.

Every clause is false. Sentry is wired in three places:

| | where |
|---|---|
| `Sentry.LoggerHandler` | `Fountain.Application.attach_sentry_handler/0`, rate-limited to 20 events/min |
| `Sentry.PlugContext` | `FountainWeb.Endpoint`, with a custom body scrubber |
| `release` / `environment_name` | `config/runtime.exs` — `FOUNTAIN_BUILD_SHA` and `SENTRY_ENVIRONMENT` |

`SENTRY_DSN` is live in prod (confirmed present in the `fountain-secrets` Secret and in the running pod's environment), so the handler is attached and "no per-release regression view" is exactly backwards — `release:` is set precisely so a regression points at its deploy.

This is the kind of staleness that costs time at the worst moment: someone reads it mid-incident and goes hunting through logs for something Sentry already grouped.

## What replaces it

The three wiring points, plus the two details worth knowing *before* an incident rather than during one:

- **Bodies are scrubbed to a length tag** by `FountainWeb.SentryScrubber` (#402) — an allowlist of shape, because Sentry's default scrubber is a three-name denylist (`password`, `passwd`, `secret`) that the secret-write endpoints sailed straight through.
- **A blank `SENTRY_DSN` is deleted from the environment**, not merely left out of config, because the SDK reads the variable itself and a blank value crashes the `:sentry` app at boot regardless of what `config :sentry, dsn:` says (#497, #513).

Also keeps the note that the package is API-compatible with GlitchTip, since that is the whole migration if the tracker should ever move off a cluster it is meant to watch.

## Scope

Docs only, and `priv/help/` is outside the `docs/` gates (`docs-style.py` and `vale lint docs` both scan `docs/` only), so this matches the file's existing prose register rather than ASD-STE100.

Spotted while updating the **Traces** paragraph directly above it in #979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)