### PR TITLE
fix(conversations): channel resume skips a conversation whose sandbox is gone

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1402,8 +1402,13 @@ defmodule Fountain.Conversations do
 
   Resumes the **latest live** conversation for the same user + agent + vault
   + environment override + channel — `terminated` and `failed` ones are past
-  resuming, so a new one is opened and becomes the binding. Returns `{:ok, conv, :resumed}` or
-  `{:ok, conv, :created}`; without a `channel_id` it always creates.
+  resuming, so a new one is opened and becomes the binding. So is one whose
+  *sandbox* is `terminated` or `failed` (#779): the machine is gone, and the
+  workspace with it, so the channel gets a new conversation on a working one
+  rather than a continuous-looking transcript on a blank disk. A `suspended`
+  sandbox is parked, not gone, and still resumes. Returns `{:ok, conv,
+  :resumed}` or `{:ok, conv, :created}`; without a `channel_id` it always
+  creates.
 
   `attrs["fresh"]` (`true`) skips the resume this once: the conversation
   currently bound to the channel is unbound (its `channel_id` cleared — it
@@ -1467,11 +1472,22 @@ defmodule Fountain.Conversations do
   # different identities (#727) and must not share a conversation. So is the
   # environment override (#783): an identity that switches environments must
   # not resume a conversation provisioned from the old one.
+  #
+  # The sandbox is part of it too (#779): the 24 hour ceiling destroys a
+  # sandbox while its conversation stays `idle`, and resuming that row wakes
+  # onto a *fresh* machine with the workspace gone (#778 makes the turn work;
+  # #936 is the memory it loses) inside a transcript that reads as continuous.
+  # A channel is better served by a new conversation on a working machine, so
+  # the binding follows the machine, not just the conversation row.
+  # `suspended` is not in the list: that sandbox is parked, not gone, and its
+  # disk wakes back up with the workspace on it.
   defp find_channel_conversation(user_id, agent_id, vault_id, env_id, channel_id) do
     from(c in Conversation,
+      join: s in assoc(c, :sandbox),
       where:
         c.user_id == ^user_id and c.agent_id == ^agent_id and c.channel_id == ^channel_id and
-          c.status not in ["terminated", "failed"],
+          c.status not in ["terminated", "failed"] and
+          s.status not in ["terminated", "failed"],
       order_by: [desc: c.inserted_at],
       limit: 1
     )

--- a/apps/fountain/test/fountain/conversations_start_test.exs
+++ b/apps/fountain/test/fountain/conversations_start_test.exs
@@ -534,6 +534,71 @@ defmodule Fountain.ConversationsStartTest do
   end
 
   # ────────────────────────────────────────────────────────────────────────────
+  # start_or_resume_conversation/2 — the binding follows the machine (#779)
+  # ────────────────────────────────────────────────────────────────────────────
+
+  # A conversation bound to the #779 channel whose sandbox is in `status`.
+  defp bound_conversation(ctx, sandbox_status) do
+    sandbox = insert_sandbox(user_id: ctx.user.id, status: sandbox_status)
+
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: sandbox,
+      status: "idle",
+      channel_id: "chan-779"
+    )
+  end
+
+  describe "start_or_resume_conversation/2 sandbox liveness" do
+    setup do
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
+
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      %{
+        user: user,
+        agent: agent,
+        attrs: %{"agent_id" => agent.id, "user_id" => user.id, "channel_id" => "chan-779"}
+      }
+    end
+
+    for status <- ~w(terminated failed) do
+      test "a conversation whose sandbox is #{status} is not resumed", ctx do
+        # The 24 hour ceiling destroys the sandbox and leaves the conversation
+        # `idle`. Resuming it wakes onto a fresh machine with the workspace
+        # gone, in a transcript that reads as continuous — the channel is
+        # better served by a new conversation on a working machine.
+        dead = bound_conversation(ctx, unquote(status))
+
+        assert {:ok, fresh, :created} = Conversations.start_or_resume_conversation(ctx.attrs)
+        refute fresh.id == dead.id
+
+        # And the new one is what the channel resumes from here.
+        assert {:ok, resumed, :resumed} = Conversations.start_or_resume_conversation(ctx.attrs)
+        assert resumed.id == fresh.id
+      end
+    end
+
+    test "a suspended sandbox is parked, not gone, and still resumes", ctx do
+      parked = bound_conversation(ctx, "suspended")
+
+      assert {:ok, resumed, :resumed} = Conversations.start_or_resume_conversation(ctx.attrs)
+      assert resumed.id == parked.id
+    end
+
+    test "a ready sandbox resumes, as before", ctx do
+      live = bound_conversation(ctx, "ready")
+
+      assert {:ok, resumed, :resumed} = Conversations.start_or_resume_conversation(ctx.attrs)
+      assert resumed.id == live.id
+    end
+  end
+
+  # ────────────────────────────────────────────────────────────────────────────
   # _unsafe_list_active_conversations/0 — ordering
   # ────────────────────────────────────────────────────────────────────────────
 

--- a/docs/integrations/acp.md
+++ b/docs/integrations/acp.md
@@ -111,7 +111,7 @@ other field in `_meta`.
 
 | Field | Meaning |
 |---|---|
-| `channelId` | Names the external channel that this session serves. With it, `session/new` **resumes** the conversation already bound to that channel, for this user, agent and vault. That is the same conversation, the same sandbox and the same runtime session, with a fresh ACP id on the client's side. A harness that forgets its sessions on restart therefore lands back where it was ([#774](https://github.com/BinaryBourbon/fountain/issues/774)). Without it, each `session/new` is a new conversation. |
+| `channelId` | Names the external channel that this session serves. With it, `session/new` **resumes** the conversation already bound to that channel, for this user, agent and vault. That is the same conversation, the same sandbox and the same runtime session, with a fresh ACP id on the client's side. A harness that forgets its sessions on restart therefore lands back where it was ([#774](https://github.com/BinaryBourbon/fountain/issues/774)). A destroyed sandbox also stops the resume. The workspace does not survive it, so Fountain opens a new conversation on a new sandbox ([#779](https://github.com/BinaryBourbon/fountain/issues/779)). Without it, each `session/new` is a new conversation. |
 | `freshSession` | With `channelId`, it skips the resume this one time. It unbinds the current conversation, which continues and then retires like any other idle one. It opens a new conversation, and binds the channel to that. A Buzz owner's `!rotate` turns into this ([#788](https://github.com/BinaryBourbon/fountain/pull/788)). Fountain ignores it without `channelId`. |
 
 The same knobs exist on the API, as `channel_id` and `fresh` on


### PR DESCRIPTION
Closes #779.

## The problem

`find_channel_conversation/5` (`apps/fountain/lib/fountain/conversations.ex:1484`) filtered on the *conversation's* status only. After the 24 hour ceiling destroys a sandbox the conversation is still `idle`, so the channel kept binding to it.

Since #778 that binding is no longer a break: the wake clears `runtime_session_id` and provisions a fresh machine, and the turn runs. What it cannot bring back is the workspace (#936), so the agent starts cold in a transcript that reads as continuous. This is the quality fix the refreshed issue asks for, not an outage fix.

## The change

Join the sandbox and skip rows whose sandbox status is `terminated` or `failed`. A new conversation opens and takes over the binding, exactly as for a terminated conversation today, so the binding follows the *machine* and not just the conversation row.

`suspended` is deliberately not in the list: that sandbox is parked, not gone, and its disk wakes back up with the workspace on it (0017). `ready`, `pending` and `starting` resume as before.

The join is inner (`join: s in assoc(c, :sandbox)`); `sandbox_id` is required by the conversation changeset, and a row without one falls through to "create a new conversation", which is the safe side.

## Tests

New `describe "start_or_resume_conversation/2 sandbox liveness"` in `conversations_start_test.exs`, four tests: `terminated` and `failed` sandboxes are not resumed and the fresh conversation becomes the binding; `suspended` and `ready` still resume.

Verified by reverting the query change: the two dead-sandbox tests fail, the two live-sandbox ones pass.

## Docs

`docs/integrations/acp.md` — the `channelId` row now says a destroyed sandbox stops the resume. `vale lint` and `scripts/docs-style.py` are clean (the first draft tripped `STE.IngForms` on "binding" as a noun; reworded).

## Verification

- `mix precommit`: 6 doctests, 3 properties, 3622 tests, 0 failures
- `mix format --check-formatted`, `mix credo --strict` (no issues), `mix dialyzer` (0 errors) re-run individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)