### PR TITLE
test(conversations): drive the registry settle window instead of racing it

### DIFF
--- a/apps/fountain/test/fountain/conversations_wake_test.exs
+++ b/apps/fountain/test/fountain/conversations_wake_test.exs
@@ -266,27 +266,41 @@ defmodule Fountain.ConversationsWakeTest do
 
       test = self()
 
-      # A stand-in for the first server: registers under the conversation's
-      # name a beat after the wake starts looking, then relays the prompt
-      # cast it receives.
+      # A stand-in for the first server: it only has to receive the prompt
+      # cast and relay it.
       late_server =
         spawn_link(fn ->
-          Process.sleep(40)
-          {:ok, _} = Horde.Registry.register(Fountain.ConversationRegistry, conv.id, nil)
-          send(test, :registered)
-
           receive do
             {:"$gen_cast", {:initial_prompt, prompt, images}} ->
               send(test, {:handed_off, prompt, images})
           end
         end)
 
+      # The registry catches up on the second poll. This used to be a
+      # stand-in that slept 40 ms before registering for real, which made the
+      # test a wall-clock race: a loaded runner could burn the whole settle
+      # window before the sleep returned, the wake would correctly give up,
+      # and the `reject` below would fail on a green build (#921). Deciding
+      # per lookup which poll finds the server drives the same branch with no
+      # clock in it.
+      {:ok, polls} = Agent.start_link(fn -> 0 end)
+
+      stub(Horde.Registry, :lookup, fn Fountain.ConversationRegistry, _key ->
+        case Agent.get_and_update(polls, &{&1, &1 + 1}) do
+          0 -> []
+          _ -> [{late_server, nil}]
+        end
+      end)
+
       # No second server, no second sandbox.
       reject(&Horde.DynamicSupervisor.start_child/2)
 
       assert {:ok, woken} = Conversations.wake_conversation(conv.id, "hello")
-      assert_receive :registered
       assert_receive {:handed_off, "hello", []}, 500
+
+      # The first poll missed: the wake waited for the registry rather than
+      # concluding the provision was dead on the strength of one lookup.
+      assert Agent.get(polls, & &1) >= 2
 
       assert woken.sandbox_id == sandbox.id
       assert Repo.reload(sandbox).status == "pending"

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -18,6 +18,10 @@ Mimic.copy(Fountain.Sandbox.Daytona.LogStream)
 Mimic.copy(Sprites)
 Mimic.copy(Sprites.Filesystem)
 Mimic.copy(Horde.DynamicSupervisor)
+# Horde.Registry is copied so the registry settle window (#800) can be driven
+# from a test rather than waited out: a stub decides which poll finds the
+# server, which is what stops that test racing a loaded runner (#921).
+Mimic.copy(Horde.Registry)
 Mimic.copy(Req)
 
 # Stripe modules — needed by billing tests and webhook controller tests.


### PR DESCRIPTION
Closes #921.

## The flake

`conversations_wake_test.exs`'s #800 test spawned a stand-in server that slept 40 ms before registering in `Fountain.ConversationRegistry`, then asserted the wake had waited for it rather than starting a second server. The settle window is 150 ms in test config, so on a loaded runner the window elapses before the sleep returns, the wake correctly takes `:timeout` → `create_fresh_sandbox_and_start`, and `reject(&Horde.DynamicSupervisor.start_child/2)` fires.

The failure therefore means "this runner was slow", not "the #800 fix regressed" — and it lands in partition 3, on docs-only and scripts-only PRs whose authors have no reason to suspect their change.

## The fix

Option 1 from the issue: drive the timing rather than sleeping.

- The stand-in no longer registers or sleeps. It only receives the prompt cast and relays it.
- A `stub(Horde.Registry, :lookup, …)` decides which poll finds the server: the first lookup misses, every one after it hits. That is exactly the "server appeared during the settle window" branch, with no clock in it.
- The poll count is asserted (`>= 2`), which is what the sleep was standing in for — the test still proves the wake waited instead of concluding the provision was dead on the strength of one lookup.

`Mimic.copy(Horde.Registry)` is added to `test_helper.exs` so the stub is possible; unstubbed calls pass through as before.

## Verification

- `mix test test/fountain/conversations_wake_test.exs` — 17 tests, 0 failures.
- Reverted the fix under test (made `do_await_registered/2` give up on the first miss, i.e. no settle loop) and confirmed this test fails. It still catches the regression it exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)