### PR TITLE
feat(sandbox): name the reason when a backend cannot enforce a limited environment

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -692,7 +692,24 @@ defmodule Fountain.Conversations.ConversationServer do
     {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
     publish_stage(state.conversation_id, "provision", "started")
 
-    case create_sandbox_handle(sandbox) do
+    # A `limited` environment on a backend with no `:network_policy` capability
+    # can only fail. It failed closed before, but several steps in, after a
+    # sandbox had been created and torn down, and wearing the shape of a
+    # transport error. Refuse the pairing here, by name, before anything is
+    # provisioned (#935).
+    provider = Fountain.Conversations.sandbox_provider_atom(sandbox)
+
+    handle_result =
+      with :ok <-
+             Fountain.Conversations.Provisioning.check_network_policy_support(
+               provider,
+               env,
+               state.conversation_id
+             ) do
+        create_sandbox_handle(provider, sandbox)
+      end
+
+    case handle_result do
       {:ok, handle} ->
         skills = (agent && agent.skills) || []
         # conv.runtime is validated-required and outlives the agent; the agent
@@ -754,7 +771,7 @@ defmodule Fountain.Conversations.ConversationServer do
         end
 
       {:error, reason} ->
-        Logger.error("sprite provision failed: #{inspect(reason)}")
+        Logger.error("provision could not start: #{inspect(reason)}")
         {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
         publish_stage(state.conversation_id, "provision", "failed", %{reason: inspect(reason)})
         Conversations.update_conversation(conv, %{status: "failed"})
@@ -2271,9 +2288,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   # The row's provider decides where the sandbox is created; adopt-on-
   # already-exists is the adapter's job.
-  defp create_sandbox_handle(sandbox) do
-    provider = Fountain.Conversations.sandbox_provider_atom(sandbox)
-
+  defp create_sandbox_handle(provider, sandbox) do
     Fountain.Retry.with_backoff(
       fn -> Fountain.Sandbox.create(provider, sandbox.sprite_name) end,
       label: "sprite create #{sandbox.sprite_name}"

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -287,7 +287,7 @@ defmodule Fountain.Conversations.Provisioning do
   this on its own — one environment is reachable from agents on different
   backends. Both facts are only known here, at launch (#935, #627).
   """
-  @spec check_network_policy_support(atom(), Environment.t() | nil, String.t()) ::
+  @spec check_network_policy_support(atom(), %Environment{} | nil, String.t()) ::
           :ok | {:error, {:network_policy, :unsupported_by_backend}}
   def check_network_policy_support(_provider, nil, _conv_id), do: :ok
 

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -287,7 +287,7 @@ defmodule Fountain.Conversations.Provisioning do
   this on its own — one environment is reachable from agents on different
   backends. Both facts are only known here, at launch (#935, #627).
   """
-  @spec check_network_policy_support(atom(), %Environment{} | nil, String.t()) ::
+  @spec check_network_policy_support(atom(), Environment.t() | nil, String.t()) ::
           :ok | {:error, {:network_policy, :unsupported_by_backend}}
   def check_network_policy_support(_provider, nil, _conv_id), do: :ok
 

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -267,6 +267,47 @@ defmodule Fountain.Conversations.Provisioning do
   # ── network policy ────────────────────────────────────────────────────────
 
   @doc """
+  Refuse a `limited` environment on a backend that cannot enforce one, before
+  anything is provisioned.
+
+  Not every provider can hold egress. `Fountain.Sandbox.Runner` answers
+  `{:error, :not_supported}` and leaves `:network_policy` out of its
+  `capabilities/0`; Sprites, E2B and Daytona all advertise it. The pairing has
+  always failed closed — `apply_network_policy/3` turns the `:not_supported`
+  into `{:error, {:network_policy, :not_supported}}` and the cold-provision
+  `with` aborts — so a `limited` environment has never run unrestricted.
+
+  What was missing is *when* and *why* the operator finds out. The failure
+  arrived several steps into provisioning, after a sandbox had been created,
+  wearing the same shape as a transport error. This check runs before the
+  sandbox exists and names the cause: a `network` / `failed` stage event whose
+  reason is `backend_lacks_network_policy`.
+
+  The provider is per agent since ADR 0018, so an `Environment` cannot answer
+  this on its own — one environment is reachable from agents on different
+  backends. Both facts are only known here, at launch (#935, #627).
+  """
+  @spec check_network_policy_support(atom(), Environment.t() | nil, String.t()) ::
+          :ok | {:error, {:network_policy, :unsupported_by_backend}}
+  def check_network_policy_support(_provider, nil, _conv_id), do: :ok
+
+  def check_network_policy_support(provider, %Environment{networking_type: "limited"}, conv_id) do
+    if Sandbox.supports?(provider, :network_policy) do
+      :ok
+    else
+      publish_stage(conv_id, "network", "failed", %{
+        type: "limited",
+        provider: to_string(provider),
+        reason: "backend_lacks_network_policy"
+      })
+
+      {:error, {:network_policy, :unsupported_by_backend}}
+    end
+  end
+
+  def check_network_policy_support(_provider, _env, _conv_id), do: :ok
+
+  @doc """
   Apply the env's networking config to the sandbox. `unrestricted` is a
   no-op (sandboxes are open by default). `limited` builds an allowlist from
   `networking_config.allowed_hosts: [...]` and applies it as a default-deny

--- a/apps/fountain/lib/fountain/environments/environment.ex
+++ b/apps/fountain/lib/fountain/environments/environment.ex
@@ -5,6 +5,8 @@ defmodule Fountain.Environments.Environment do
   alias Fountain.Accounts.User
   alias Fountain.Environments.Secret
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -684,6 +684,14 @@ defmodule FountainWeb.AgentsLive.Form do
               {e.name}
             </option>
           </select>
+          <%!-- The provider is per agent (ADR 0018) and the egress policy is
+                per environment, so this pairing is the only place both are
+                known before a launch (#935). --%>
+          <.network_policy_note
+            provider={@form["sandbox_provider"]}
+            env_id={@form["environment_id"]}
+            envs={@envs}
+          />
         </div>
 
         <%!-- Permissions (#939): what answers before the agent runs a tool. --%>
@@ -1172,6 +1180,57 @@ defmodule FountainWeb.AgentsLive.Form do
       {Map.get(@errors, @field)}
     </p>
     """
+  end
+
+  attr :provider, :any, required: true
+  attr :env_id, :any, required: true
+  attr :envs, :list, required: true
+
+  defp network_policy_note(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :backend,
+        unenforceable_network_policy(assigns.provider, assigns.env_id, assigns.envs)
+      )
+
+    ~H"""
+    <p
+      :if={@backend}
+      class="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900"
+    >
+      <span class="font-medium">{@backend} cannot hold a limited environment.</span>
+      This environment sets <code>networking_type: limited</code>, and that backend advertises
+      no egress policy. The agent saves, but a conversation on this pairing refuses to start
+      rather than run unrestricted.
+    </p>
+    """
+  end
+
+  # The provider that will run this agent, and whether it can enforce the
+  # selected environment's egress policy. Returns the provider's name when the
+  # pairing cannot work, nil when it can (#935).
+  defp unenforceable_network_policy(provider_str, env_id, envs) do
+    provider =
+      case provider_str do
+        p when is_binary(p) and p != "" -> safe_provider(p)
+        _ -> Fountain.Sandbox.default_provider()
+      end
+
+    env = provider && Enum.find(envs, &(&1.id == env_id))
+
+    if env && env.networking_type == "limited" &&
+         not Fountain.Sandbox.supports?(provider, :network_policy) do
+      to_string(provider)
+    end
+  end
+
+  # @form is whatever was posted, so the string is only converted when the
+  # schema would accept it. Enabledness is not the question here: a stored
+  # agent on a provider the operator has since switched off still shows the
+  # pairing it will fail on.
+  defp safe_provider(str) do
+    if str in Fountain.Sandbox.known_providers(), do: String.to_existing_atom(str)
   end
 
   attr :missing, :any, required: true

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -452,6 +452,56 @@ defmodule Fountain.Conversations.ConversationServerTest do
       assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
     end
 
+    test "a limited environment on a backend that cannot enforce it fails before any sandbox exists",
+         %{user: user} do
+      # `Fountain.Sandbox.Runner` does not advertise `:network_policy`, so this
+      # pairing could only ever fail. It used to fail several steps into
+      # provisioning, after a sandbox had been created and torn down, wearing
+      # the shape of a transport error. Now it is refused up front, by name
+      # (#935).
+      stub_happy_sprite()
+      test_pid = self()
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :create, fn name, _opts ->
+        send(test_pid, {:created, name})
+        {:ok, Fountain.Sandbox.Sprites.build_handle(name)}
+      end)
+
+      limited =
+        insert_env(user_id: user.id, networking_type: "limited", networking_config: %{})
+
+      agent = insert_agent(user_id: user.id, environment_id: limited.id, runtime: "claude")
+      sandbox = insert_sandbox(user_id: user.id, status: "pending", provider: "runner")
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          runtime: @legacy_runtime,
+          sandbox_id: sandbox.id,
+          status: "pending"
+        )
+
+      {_pid, ref, _} = start_server(conv)
+      assert_stopped(ref)
+
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "failed"
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
+
+      # Nothing was provisioned, so there is nothing to bill or to leak.
+      refute_received {:created, _}
+
+      events =
+        Fountain.Repo.all(
+          from(e in Fountain.Conversations.LogEvent,
+            where: e.conversation_id == ^conv.id and e.kind == "stage" and e.stage == "network"
+          )
+        )
+
+      assert [%{state: "failed"} = event] = events
+      assert Jason.decode!(event.data)["reason"] == "backend_lacks_network_policy"
+    end
+
     test "unreadable tenant credentials fail the conversation rather than provisioning blind", %{
       conv: conv,
       sandbox: sandbox

--- a/apps/fountain/test/fountain/conversations/provisioning_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_test.exs
@@ -69,6 +69,60 @@ defmodule Fountain.Conversations.ProvisioningTest do
     end
   end
 
+  describe "check_network_policy_support/3" do
+    test "a limited environment on a backend without :network_policy is refused by name" do
+      env = insert_env(%{"networking_type" => "limited"})
+      conv = insert_conversation()
+
+      refute Fountain.Sandbox.supports?(:runner, :network_policy)
+
+      assert {:error, {:network_policy, :unsupported_by_backend}} =
+               Provisioning.check_network_policy_support(:runner, env, conv.id)
+
+      # The point of the check: the operator is told which backend and why,
+      # before a sandbox exists, instead of reading a transport-shaped error
+      # out of the middle of provisioning (#935).
+      assert [event] = stage_events(conv.id, "network")
+      assert event.state == "failed"
+
+      assert %{"reason" => "backend_lacks_network_policy", "provider" => "runner"} =
+               Jason.decode!(event.data)
+    end
+
+    test "a limited environment on a backend that advertises the capability passes" do
+      env = insert_env(%{"networking_type" => "limited"})
+      conv = insert_conversation()
+
+      assert Fountain.Sandbox.supports?(:sprites, :network_policy)
+      assert :ok = Provisioning.check_network_policy_support(:sprites, env, conv.id)
+      assert stage_events(conv.id, "network") == []
+    end
+
+    test "an unrestricted environment passes on a backend without the capability" do
+      env = insert_env(%{"networking_type" => "unrestricted"})
+      conv = insert_conversation()
+
+      assert :ok = Provisioning.check_network_policy_support(:runner, env, conv.id)
+      assert stage_events(conv.id, "network") == []
+    end
+
+    test "no environment at all passes" do
+      conv = insert_conversation()
+
+      assert :ok = Provisioning.check_network_policy_support(:runner, nil, conv.id)
+      assert stage_events(conv.id, "network") == []
+    end
+  end
+
+  defp stage_events(conv_id, stage) do
+    Fountain.Repo.all(
+      from(e in Fountain.Conversations.LogEvent,
+        where: e.conversation_id == ^conv_id and e.kind == "stage" and e.stage == ^stage,
+        order_by: e.id
+      )
+    )
+  end
+
   # ── .env quoting ───────────────────────────────────────────────────────────
 
   # The file exists to be `source`d by the user's setup_script, so the only

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -289,3 +289,72 @@ defmodule FountainWeb.AgentsLive.IndexTest do
     end
   end
 end
+
+defmodule FountainWeb.AgentsLive.NetworkPolicyNoteTest do
+  # async: false because it flips `:runners_enabled`, which is application-wide
+  # config the rest of the suite reads to decide which providers are enabled.
+  # `:runner` is the only adapter in tree without `:network_policy`, so it is
+  # the only pairing that can express this.
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  setup do
+    previous = Application.get_env(:fountain, :runners_enabled)
+    Application.put_env(:fountain, :runners_enabled, true)
+    on_exit(fn -> Application.put_env(:fountain, :runners_enabled, previous) end)
+    :ok
+  end
+
+  describe "network policy the backend cannot enforce (#935)" do
+    # The provider is per agent (ADR 0018) and the egress policy is per
+    # environment, so the agent form is the only console page where both are
+    # known. Without this the pairing is discovered by a conversation dying
+    # mid-provision.
+    test "warns when a limited environment is paired with a backend that has no policy", %{
+      conn: conn
+    } do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id, networking_type: "limited", networking_config: %{})
+
+      agent =
+        insert_agent(user_id: user.id, environment_id: env.id, sandbox_provider: "runner")
+
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+
+      assert html =~ "cannot hold a limited environment"
+      assert html =~ "runner"
+    end
+
+    test "no warning when the backend advertises a network policy", %{conn: conn} do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id, networking_type: "limited", networking_config: %{})
+
+      # No pin, so the agent runs on the instance default. That is sprites,
+      # which advertises `:network_policy`, as do e2b and daytona.
+      agent = insert_agent(user_id: user.id, environment_id: env.id)
+
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+
+      refute html =~ "cannot hold a limited environment"
+    end
+
+    test "no warning when the environment is unrestricted", %{conn: conn} do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id, networking_type: "unrestricted")
+
+      agent =
+        insert_agent(user_id: user.id, environment_id: env.id, sandbox_provider: "runner")
+
+      conn = login_user(conn, user)
+
+      {:ok, _view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+
+      refute html =~ "cannot hold a limited environment"
+    end
+  end
+end

--- a/docs/concepts/environment.md
+++ b/docs/concepts/environment.md
@@ -77,6 +77,14 @@ out. That is deliberate, and it is not a defect. An empty allowlist that
 quietly meant "allow everything" would be the worst default for a policy whose
 whole purpose is restriction.
 
+Not every backend can hold egress. Sprites, E2B and Daytona can. A
+[self-hosted runner](../integrations/runners.md) cannot. The agent selects the
+backend, and the environment sets the policy. Fountain therefore compares the
+two at launch. It refuses a `limited` environment on a backend that cannot
+enforce one. The conversation fails with a `network` / `failed` event. The
+reason is `backend_lacks_network_policy`, and Fountain creates no sandbox. The
+agent form gives you the same warning before you save the agent.
+
 ## What an environment is not
 
 **Not a deployment tier.** "Environment" in Fountain never means dev, staging <!-- vale disable-line STE.IngForms -->

--- a/docs/integrations/runners.md
+++ b/docs/integrations/runners.md
@@ -95,7 +95,7 @@ Two things translate, and two do not.
 | `/home/sprite` is home. | Mapped to the sandbox directory. That holds for a file path, for a work directory **and for a command argument**. A `bash -lc` script that says `/home/sprite/.local/bin/x` lands in the sandbox. |
 | `~` and a relative path. | The sandbox directory. |
 | `packages.apt` in an environment. | Fails. A Mac has no `apt`, and the daemon does not translate to `brew`. Leave it empty, or use `setup_script`. |
-| `networking_type: limited`. | Fails to provision. The provider does not advertise an egress policy, and it will not pretend. |
+| `networking_type: limited`. | Refused at launch. The provider does not advertise an egress policy, and it will not pretend. The conversation fails before a sandbox exists, with a `network` / `failed` event whose reason is `backend_lacks_network_policy`. The agent form shows the same warning when you pair the two. |
 
 `/tmp` is the machine's `/tmp`. The gemini and opencode workspaces live there,
 and each sandbox sees the same ones, as it does inside one Linux sandbox.


### PR DESCRIPTION
Closes #935.

An environment with `networking_type: "limited"` is accepted unconditionally — `environment.ex` only does `validate_inclusion`. Nothing checks whether the backend that will run it can enforce an egress policy, and `Fountain.Sandbox.Runner` cannot: it returns `{:error, :not_supported}` and leaves `:network_policy` out of `capabilities/0`. Sprites, E2B and Daytona all advertise it.

This already failed closed, and that part was fine. What was wrong was *when* and *why* the operator found out: the conversation died several steps into provisioning, after a sandbox had been created and torn down, with a `network` / `failed` event carrying a transport-shaped reason.

## What this changes

**1. A pre-flight check, before anything is provisioned.**

`Provisioning.check_network_policy_support/3` compares the resolved environment against the sandbox row's provider. On a `limited` environment paired with a backend that has no `:network_policy` capability it publishes a `network` / `failed` stage event with

```json
{"type": "limited", "provider": "runner", "reason": "backend_lacks_network_policy"}
```

and returns `{:error, {:network_policy, :unsupported_by_backend}}`. It runs in `do_fresh_provision_inner/6` ahead of `create_sandbox_handle/2`, so no sprite is created — nothing to bill, nothing to leak. Both rows go `failed` through the path that already existed.

One deviation from the issue's wording: it publishes `network` / `failed` with `reason: "backend_lacks_network_policy"` rather than inventing a `backend_lacks_network_policy` *stage*. The stage vocabulary is a closed compatibility surface (`webhooks/events.ex`, `docs/reference/webhooks.md`); a new stage name would be a webhook-subscriber-visible addition for no gain, and "name the reason" is what the issue is actually about.

**2. The console warns on the pairing.**

The agent form is the one page where the provider and the environment are both visible — the provider is per agent since ADR 0018, the policy is per environment. The note renders live off `@form`, so it appears as soon as either select changes and before anything is saved. It is a warning, not a refusal, exactly as the issue argues: the environment set can change afterwards either way.

**3. Docs.**

`docs/integrations/runners.md` said "Fails to provision"; it now names the event and the reason. `docs/concepts/environment.md` gains a paragraph on which backends can hold egress and what happens when they cannot.

## Not done, deliberately

The issue's "also worth fixing" item — a permanent `:not_supported` being retried with backoff — does not apply. `Retry.transient?/1` already classifies `:not_supported` as permanent (`retry.ex:116`), so `apply_network_policy/3` fails on the first attempt today.

## Verification

- `mix test` — 6 doctests, 3 properties, 3630 tests, 0 failures.
- `mix credo --strict` — no issues. `mix format --check-formatted` clean.
- `python3 scripts/docs-style.py` clean; `vale lint docs` exits 0 with 0 errors and 0 warnings.
- Reverted the check (forced `check_network_policy_support/3` to `:ok`) and confirmed both new tests fail — the provisioning one on the missing stage event, the server one on the sprite it then creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)