### PR TITLE
feat(api): ?blocks=true on the team stream, and declare Last-Event-ID

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/events_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/events_controller.ex
@@ -36,6 +36,14 @@ defmodule FountainWeb.EventsController do
         "`?blocks=true` adds server-parsed blocks. Heartbeats every 15 s; closes after " <>
         "60 s idle so the client reconnects. The first byte is a `: connected` comment.",
     parameters: [
+      "Last-Event-ID": [
+        in: :header,
+        type: :string,
+        required: false,
+        description:
+          "Resume after this event id (integer as string). " <>
+            "Missing or unparseable values are treated as 0."
+      ],
       streams: [
         in: :query,
         type: :string,

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -391,14 +391,34 @@ defmodule FountainWeb.TeamController do
         "conversation on its own; the client re-lists. A `schedule` event (same " <>
         "data) is sent when a team schedule is created, updated, deleted or fired " <>
         "(#825); the client re-lists `/api/team/schedules`. `Last-Event-ID` (a log event " <>
-        "id) replays what was missed on each teammate's conversation. Heartbeats " <>
-        "every 15s; closes after 60s idle so the client reconnects.",
+        "id) replays what was missed on each teammate's conversation. `?blocks=true` adds " <>
+        "server-parsed blocks, per event, for the runtime of the conversation that " <>
+        "produced it. Heartbeats every 15s; closes after 60s idle so the client reconnects.",
     parameters: [
+      "Last-Event-ID": [
+        in: :header,
+        type: :string,
+        required: false,
+        description:
+          "Resume after this event id (integer as string). " <>
+            "Missing or unparseable values are treated as 0."
+      ],
       streams: [
         in: :query,
         type: :string,
         required: false,
         description: "Comma-separated stream allow-list (`stdout,stderr,acp,stage,...`)."
+      ],
+      blocks: [
+        in: :query,
+        type: :boolean,
+        required: false,
+        description:
+          "Add `blocks` to each event payload — its `data` parsed server-side into the " <>
+            "structured blocks a transcript renders, as on " <>
+            "`/api/conversations/:id/stream?blocks=true`. The stream is " <>
+            "multi-conversation, so the runtime is taken per event from the " <>
+            "conversation that produced it. Defaults to false."
       ]
     ],
     responses: [
@@ -419,6 +439,7 @@ defmodule FountainWeb.TeamController do
     user_id = conn.assigns.current_user.id
     last_event_id = conn |> get_req_header("last-event-id") |> List.first() |> parse_id()
     streams = parse_streams(params["streams"])
+    blocks? = params["blocks"] in [true, "true", "1"]
 
     Team.subscribe(user_id)
     # A runner going offline or online changes presence for every teammate
@@ -444,11 +465,19 @@ defmodule FountainWeb.TeamController do
         {:error, _} -> conn
       end
 
-    case replay(conn, followed, last_event_id, streams) do
+    state = %{
+      user_id: user_id,
+      followed: followed,
+      last_id: last_event_id,
+      streams: streams,
+      blocks?: blocks?
+    }
+
+    case replay(conn, state) do
       {:ok, conn, last_id} ->
         Process.send_after(self(), :heartbeat, heartbeat_ms())
 
-        sse_loop(conn, %{user_id: user_id, followed: followed, last_id: last_id, streams: streams})
+        sse_loop(conn, %{state | last_id: last_id})
 
       {:closed, conn, _} ->
         conn
@@ -456,8 +485,12 @@ defmodule FountainWeb.TeamController do
   end
 
   # Subscribe to every teammate's conversation not yet followed. Returns the
-  # map conversation_id → agent_id the loop labels events with. Topics are
-  # never unsubscribed: a removed teammate's conversation stops publishing.
+  # map conversation_id → `{agent_id, runtime}`: the agent id labels the event
+  # for the roster, and the runtime is what `?blocks=true` parses the event's
+  # data with. The runtime has to travel with the conversation rather than
+  # with the request, because this stream carries every teammate at once and
+  # they do not share one (#881). Topics are never unsubscribed: a removed
+  # teammate's conversation stops publishing.
   defp follow_team(user_id, followed) do
     user_id
     |> Team.list_teammates()
@@ -466,21 +499,21 @@ defmodule FountainWeb.TeamController do
         Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv.id}")
       end
 
-      Map.put(acc, conv.id, agent.id)
+      Map.put(acc, conv.id, {agent.id, conv.runtime})
     end)
   end
 
-  defp replay(conn, _followed, 0, _streams), do: {:ok, conn, 0}
+  defp replay(conn, %{last_id: 0}), do: {:ok, conn, 0}
 
-  defp replay(conn, followed, after_id, streams) do
+  defp replay(conn, state) do
     # Ownership: `followed` came from the tenant-scoped Team.list_teammates.
-    followed
-    |> Enum.flat_map(fn {conv_id, _agent_id} ->
-      Conversations._unsafe_list_log_events(conv_id, after_id, streams: streams)
+    state.followed
+    |> Enum.flat_map(fn {conv_id, _} ->
+      Conversations._unsafe_list_log_events(conv_id, state.last_id, streams: state.streams)
     end)
     |> Enum.sort_by(& &1.id)
-    |> Enum.reduce_while({:ok, conn, after_id}, fn ev, {:ok, acc, last_id} ->
-      case write_event(acc, ev, followed) do
+    |> Enum.reduce_while({:ok, conn, state.last_id}, fn ev, {:ok, acc, last_id} ->
+      case write_event(acc, ev, state) do
         {:ok, c} -> {:cont, {:ok, c, max(ev.id, last_id)}}
         {:error, _} -> {:halt, {:closed, acc, last_id}}
       end
@@ -491,7 +524,7 @@ defmodule FountainWeb.TeamController do
     receive do
       {:log_event, %LogEvent{id: ev_id} = ev} when ev_id > state.last_id ->
         if Conversations.event_in_streams?(ev, state.streams) do
-          case write_event(conn, ev, state.followed) do
+          case write_event(conn, ev, state) do
             {:ok, conn} -> sse_loop(conn, %{state | last_id: ev_id})
             {:error, _} -> conn
           end
@@ -553,11 +586,13 @@ defmodule FountainWeb.TeamController do
 
   # Field-for-field the per-conversation stream's payload, plus the two ids a
   # client needs to route the event to a roster row.
-  defp write_event(conn, %LogEvent{} = ev, followed) do
+  defp write_event(conn, %LogEvent{} = ev, state) do
+    {agent_id, runtime} = Map.get(state.followed, ev.conversation_id) || {nil, nil}
+
     payload =
-      Jason.encode!(%{
+      %{
         conversation_id: ev.conversation_id,
-        agent_id: Map.get(followed, ev.conversation_id),
+        agent_id: agent_id,
         kind: ev.kind,
         stream: ev.stream,
         data: ev.data,
@@ -565,7 +600,9 @@ defmodule FountainWeb.TeamController do
         state: ev.state,
         turn_id: ev.turn_id,
         ts: ev.inserted_at
-      })
+      }
+      |> FountainWeb.ConversationJSON.put_blocks(ev, if(state.blocks?, do: runtime))
+      |> Jason.encode!()
 
     Plug.Conn.chunk(conn, "id: #{ev.id}\nevent: #{ev.kind}\ndata: #{payload}\n\n")
   end

--- a/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_stream_test.exs
@@ -58,7 +58,7 @@ defmodule FountainWeb.TeamStreamTest do
     ev
   end
 
-  defp stream_async(raw_key, headers \\ []) do
+  defp stream_async(raw_key, headers \\ [], path \\ "/api/team/stream") do
     parent = self()
 
     Task.async(fn ->
@@ -69,8 +69,22 @@ defmodule FountainWeb.TeamStreamTest do
           Plug.Conn.put_req_header(c, k, v)
         end)
 
-      Phoenix.ConnTest.dispatch(conn, @endpoint, :get, "/api/team/stream")
+      Phoenix.ConnTest.dispatch(conn, @endpoint, :get, path)
     end)
+  end
+
+  defp acp_text(text) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{
+        "sessionId" => "s",
+        "update" => %{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => text}
+        }
+      }
+    })
   end
 
   test "events from every teammate arrive on one connection, labelled", %{
@@ -228,5 +242,102 @@ defmodule FountainWeb.TeamStreamTest do
     refute conn.resp_body =~ "replayed-stdout"
     refute conn.resp_body =~ "live-stdout"
     refute conn.resp_body =~ "before"
+  end
+
+  # #881: this stream is the one a team UI actually opens, and it was the only
+  # feed that could not hand back server-parsed blocks. Without them a client
+  # either re-parses the runtime's own dialect or opens a second connection per
+  # thread for detail, which is exactly what `?blocks=true` exists to prevent.
+  describe "?blocks=true (#881)" do
+    test "adds the server-parsed blocks per event, in replay and in the live tail", %{
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada, %{runtime: "claude"})
+      marker = insert_log_event(conv, %{kind: "output", stream: "acp", data: "m"})
+      insert_log_event(conv, %{kind: "output", stream: "acp", data: acp_text("replayed")})
+
+      task =
+        stream_async(
+          key,
+          [{"last-event-id", to_string(marker.id)}],
+          "/api/team/stream?blocks=true"
+        )
+
+      Process.sleep(300)
+      publish(conv, %{kind: "output", stream: "acp", data: acp_text("live")})
+
+      body = Task.await(task, 5_000).resp_body
+
+      for text <- ["replayed", "live"] do
+        [payload] =
+          Regex.run(~r/data: (\{[^\n]*#{text}[^\n]*\})/, body, capture: :all_but_first)
+
+        decoded = Jason.decode!(payload)
+        assert %{"blocks" => [%{"kind" => "text", "body" => ^text}]} = decoded
+        # Still labelled, so a client can route it to a roster row.
+        assert decoded["agent_id"] == ada.id
+      end
+    end
+
+    test "the runtime comes from the conversation that produced the event, not the request", %{
+      user: user,
+      raw_key: key
+    } do
+      # The whole complication of this stream: it is multi-conversation, so
+      # there is no single runtime to parse against.
+      claude = insert_agent(user_id: user.id, name: "Ada", runtime: "claude")
+      other = insert_agent(user_id: user.id, name: "Linus", runtime: "codex")
+      claude_conv = insert_teammate_conv(user, claude, %{runtime: "claude"})
+      other_conv = insert_teammate_conv(user, other, %{runtime: "codex"})
+
+      task = stream_async(key, [], "/api/team/stream?blocks=true")
+      Process.sleep(300)
+      publish(claude_conv, %{kind: "output", stream: "acp", data: acp_text("from-claude")})
+      publish(other_conv, %{kind: "output", stream: "acp", data: acp_text("from-codex")})
+
+      body = Task.await(task, 5_000).resp_body
+
+      for text <- ["from-claude", "from-codex"] do
+        [payload] =
+          Regex.run(~r/data: (\{[^\n]*#{text}[^\n]*\})/, body, capture: :all_but_first)
+
+        assert %{"blocks" => [%{"kind" => "text", "body" => ^text}]} = Jason.decode!(payload)
+      end
+    end
+
+    test "without the flag the field is absent, so existing clients see the same payload", %{
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada, %{runtime: "claude"})
+
+      task = stream_async(key)
+      Process.sleep(300)
+      publish(conv, %{kind: "output", stream: "acp", data: acp_text("plain")})
+
+      [payload] =
+        Regex.run(
+          ~r/data: (\{[^\n]*plain[^\n]*\})/,
+          Task.await(task, 5_000).resp_body,
+          capture: :all_but_first
+        )
+
+      refute Map.has_key?(Jason.decode!(payload), "blocks")
+    end
+
+    test "blocks=true is accepted rather than rejected as an unknown parameter", %{
+      user: user,
+      raw_key: key
+    } do
+      # OpenApiSpex rejects undeclared query parameters, so before #881 this
+      # was a hard 422 and the SDK had to special-case the endpoint.
+      insert_teammate_conv(user, insert_agent(user_id: user.id))
+
+      conn = stream_async(key, [], "/api/team/stream?blocks=true") |> Task.await(5_000)
+      assert conn.status == 200
+    end
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -533,7 +533,7 @@ POST   /api/team/:agent_id/contact  # give the teammate an email address + phone
 PATCH  /api/team/:agent_id/contact  # change prompt_from_number (nothing bought or released)
 DELETE /api/team/:agent_id/contact  # release them
 GET    /api/team/comms              # {enabled, configured}: may this caller, and can this instance
-GET    /api/team/stream             # SSE: every teammate's events on one connection
+GET    /api/team/stream             # SSE: every teammate's events on one connection (`?blocks=true`)
 ```
 
 `PATCH /api/team/:agent_id` sets the teammate's name, which is its

--- a/docs/build/pieces.md
+++ b/docs/build/pieces.md
@@ -128,7 +128,7 @@ The two feeds a client uses are different on purpose.
 | | `/api/team/stream` | `/api/conversations/:id/events` |
 |---|---|---|
 | Covers | Each teammate. | One thread. |
-| Carries | Raw events, with `conversation_id` and `agent_id`. | Events, and `blocks` on request. |
+| Carries | Events, and `blocks` on request, with `conversation_id` and `agent_id`. | Events, and `blocks` on request. |
 | Answers | *Something happened, and to whom.* | *The words themselves.* |
 | You use it for | The roster, the dots that show a reply on the way, notifications, unread counts. | The thread, as you render it. |
 

--- a/docs/build/team-chat.md
+++ b/docs/build/team-chat.md
@@ -173,14 +173,14 @@ Those are `provision`, `setup` and `reattach`, then `turn`, then
 `terminate`. Each one carries a `state` of `started`, `done`, `failed` or
 `interrupted`.
 
-!!! note "The team stream carries raw events"
+!!! note "The team stream carries blocks"
 
-    `/api/team/stream` takes `streams` and nothing else. It has no `blocks`.
-    So treat it as a notification channel, which says *something happened, and
-    to whom*.
+    `/api/team/stream` takes `blocks` as well as `streams`, and the SDK sends
+    it for you. An event arrives parsed, so this one connection is enough to
+    show *something happened, and to whom* **and** to render the words.
 
-    Read the transcript itself from the conversation's own feed, which does
-    parse blocks. The next section covers that.
+    The next section covers the conversation's own feed, which is what you read
+    when somebody opens one thread and you want its history.
 
 ## 6. Open a thread
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -243,15 +243,15 @@ for await (const event of fountain.team.stream({ streams: ["stage"] })) {
 The stream reconnects from its last event id on its own. So the caller sees
 neither a deploy nor an idle timeout.
 
-!!! note "The team stream carries raw events"
+!!! note "The team stream carries blocks"
 
-    `/api/team/stream` takes `streams` and nothing else. It has no `blocks`,
-    so an event on it is in the runtime's own dialect.
+    `/api/team/stream` takes `blocks` and `streams`. The SDK sends `blocks` for
+    you, so an event on it arrives parsed, not in the runtime's own dialect.
+    The stream covers many conversations, so the server picks the runtime per
+    event from the conversation that produced it.
 
-    Treat it as a notification channel, which says something happened and to
-    whom. Read the detail from the conversation's own feed, which does parse
-    blocks. `fountain.events()` is the same idea across each conversation you
-    own, and it *does* take `blocks`.
+    You can therefore render a thread from this one connection.
+    `fountain.events()` is the same idea across each conversation you own.
 
 ## Reading a thread
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -246,8 +246,9 @@ for await (const event of fountain.team.stream({ streams: ["stage"] })) {
 
 `list`, `get`, `rename`, `remove`, `history`, `freshConversation`, and
 `team.schedules.*` for cron routines. The stream reconnects from its last event
-id on its own; note it carries raw events (the endpoint takes no `blocks`), so
-use it as a notification channel and read detail from the conversation feed.
+id on its own, and carries server-parsed `blocks` like every other feed — the
+runtime is picked per event from the conversation that produced it — so one
+connection is enough to render a thread.
 
 Opening a thread is two calls, and every app wrote both by hand first:
 

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1643,7 +1643,7 @@ export interface paths {
         };
         /**
          * Stream the whole team's events (SSE)
-         * @description One `text/event-stream` carrying the log events of every teammate's conversation, each payload the shape of `GET /api/conversations/:id/stream` plus `conversation_id` and `agent_id`. A `team` event (data `{reason: changed}`) is sent when the roster changes — a teammate added or removed, or a fresh conversation opened for one, or a self-hosted runner connecting or dropping (presence changes for the teammates on it) — and the stream follows the new conversation on its own; the client re-lists. A `schedule` event (same data) is sent when a team schedule is created, updated, deleted or fired (#825); the client re-lists `/api/team/schedules`. `Last-Event-ID` (a log event id) replays what was missed on each teammate's conversation. Heartbeats every 15s; closes after 60s idle so the client reconnects.
+         * @description One `text/event-stream` carrying the log events of every teammate's conversation, each payload the shape of `GET /api/conversations/:id/stream` plus `conversation_id` and `agent_id`. A `team` event (data `{reason: changed}`) is sent when the roster changes — a teammate added or removed, or a fresh conversation opened for one, or a self-hosted runner connecting or dropping (presence changes for the teammates on it) — and the stream follows the new conversation on its own; the client re-lists. A `schedule` event (same data) is sent when a team schedule is created, updated, deleted or fired (#825); the client re-lists `/api/team/schedules`. `Last-Event-ID` (a log event id) replays what was missed on each teammate's conversation. `?blocks=true` adds server-parsed blocks, per event, for the runtime of the conversation that produced it. Heartbeats every 15s; closes after 60s idle so the client reconnects.
          */
         get: operations["FountainWeb.TeamController.stream"];
         put?: never;
@@ -6283,7 +6283,10 @@ export interface operations {
                 /** @description Add `blocks` to each event payload. Defaults to false. */
                 blocks?: boolean;
             };
-            header?: never;
+            header?: {
+                /** @description Resume after this event id (integer as string). Missing or unparseable values are treated as 0. */
+                "Last-Event-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -7892,8 +7895,13 @@ export interface operations {
             query?: {
                 /** @description Comma-separated stream allow-list (`stdout,stderr,acp,stage,...`). */
                 streams?: string;
+                /** @description Add `blocks` to each event payload — its `data` parsed server-side into the structured blocks a transcript renders, as on `/api/conversations/:id/stream?blocks=true`. The stream is multi-conversation, so the runtime is taken per event from the conversation that produced it. Defaults to false. */
+                blocks?: boolean;
             };
-            header?: never;
+            header?: {
+                /** @description Resume after this event id (integer as string). Missing or unparseable values are treated as 0. */
+                "Last-Event-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };

--- a/sdk/typescript/src/sse.ts
+++ b/sdk/typescript/src/sse.ts
@@ -102,9 +102,8 @@ export interface StreamOptions {
   /**
    * Ask for server-parsed `blocks` on each event.
    *
-   * Not every stream takes it: `/api/team/stream` accepts `streams` and
-   * nothing else, and OpenApiSpex rejects an unexpected query parameter
-   * outright — so this is opt-in per endpoint rather than always-on.
+   * Every SSE endpoint takes it, so the wrappers here send it by default and
+   * a caller only sets this to stream the runtime's raw dialect instead.
    */
   blocks?: boolean;
 }

--- a/sdk/typescript/src/team.ts
+++ b/sdk/typescript/src/team.ts
@@ -165,16 +165,17 @@ export class Team {
    * Each payload is a conversation event plus `conversation_id` and
    * `agent_id`, so a roster row can be found without a socket per teammate.
    *
-   * Note that this endpoint carries raw events only — it takes no `blocks`
-   * parameter, so a client rendering a transcript from it either parses the
-   * runtime's dialect itself or reads the conversation's own feed, which does
-   * support blocks. Use it as a notification channel and fetch detail per
-   * conversation.
+   * Events carry server-parsed `blocks`, as on every other feed, so a client
+   * renders a transcript from this stream alone rather than re-parsing a
+   * runtime's dialect or opening a second connection per thread. The stream is
+   * multi-conversation, so the server picks the runtime per event from the
+   * conversation that produced it (#881).
    */
   stream(options: StreamRequest = {}): AsyncIterable<TeamEvent> {
-    // No `blocks` here: the endpoint does not accept it and the spec
-    // validator rejects unknown query parameters.
-    return streamPath(this.http, "/api/team/stream", normalizeStreams(options));
+    return streamPath(this.http, "/api/team/stream", {
+      blocks: true,
+      ...normalizeStreams(options),
+    });
   }
 
   private async agentId(agent: string): Promise<string> {

--- a/sdk/typescript/test/server.ts
+++ b/sdk/typescript/test/server.ts
@@ -53,7 +53,13 @@ export class FakeFountain {
 
   readonly conversations = new Map<string, FakeConversation>();
   /** Every request the SDK made, for assertions about the wire. */
-  readonly requests: { method: string; path: string; body: unknown; headers: NodeJS.Dict<string | string[]> }[] = [];
+  readonly requests: {
+    method: string;
+    path: string;
+    query: URLSearchParams;
+    body: unknown;
+    headers: NodeJS.Dict<string | string[]>;
+  }[] = [];
 
   /** Called when a conversation opens or a prompt lands; script the turn here. */
   onTurn: ((conversation: FakeConversation, turnNumber: number) => void) | null = null;
@@ -150,7 +156,13 @@ export class FakeFountain {
   private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
     const url = new URL(req.url ?? "/", "http://localhost");
     const body = await readBody(req);
-    this.requests.push({ method: req.method ?? "GET", path: url.pathname, body, headers: req.headers });
+    this.requests.push({
+      method: req.method ?? "GET",
+      path: url.pathname,
+      query: url.searchParams,
+      body,
+      headers: req.headers,
+    });
 
     if (this.failNextWith) {
       const failure = this.failNextWith;

--- a/sdk/typescript/test/team.test.ts
+++ b/sdk/typescript/test/team.test.ts
@@ -130,6 +130,9 @@ describe("team", () => {
 
     const stream = fake.requests.find((r) => r.path === "/api/team/stream");
     assert.ok(stream, "used the team stream, not one connection per teammate");
+    // #881: the endpoint takes `blocks` now, so a client renders a transcript
+    // from this connection instead of re-parsing the runtime's dialect.
+    assert.equal(stream.query.get("blocks"), "true");
   });
 
   test("routines", async () => {


### PR DESCRIPTION
Closes #881.

`/api/team/stream` accepted `streams` and nothing else. It never read `params["blocks"]`, so events on it were the runtime's own dialect rather than the server-parsed blocks every other feed can hand back — the thing CLAUDE.md says the server exists to prevent, on the one stream a team UI actually opens.

| Endpoint | `streams` | `blocks` | `Last-Event-ID` declared |
|---|---|---|---|
| `/api/conversations/{id}/stream` | yes | yes | yes |
| `/api/events/stream` | yes | yes | **now** |
| `/api/team/stream` | yes | **now** | **now** |

## The complication, and how it is handled

The team stream is multi-conversation, so there is no single runtime to parse an event against. `follow_team/2` now carries `{agent_id, runtime}` per followed conversation instead of the agent id alone, and `write_event/3` selects the runtime from the conversation that produced the event. The rest of the loop moves onto the state map `EventsController` already uses — that controller solved this shape first, and the two now read the same way.

Without the flag the payload is byte-for-byte what it was: `put_blocks/3` with a `nil` runtime adds no key.

## Last-Event-ID

Declared on both `/api/team/stream` and `/api/events/stream`. Both read the header already; neither said so, so a generated client could not resume without knowing to send it anyway.

## SDK and docs

- `team.stream()` sends `blocks: true`, like `events()` and `streamEvents()`. The comment explaining why it could not is gone.
- `StreamOptions.blocks` no longer documents a per-endpoint exception.
- `sdk/typescript/src/generated/openapi.ts` regenerated (CI fails on a stale one).
- `docs/sdk.md`, `docs/build/team-chat.md`, `docs/build/pieces.md`, `docs/api.md` and the SDK README all told readers to treat this stream as a notification channel and read detail elsewhere. They now say what it carries.

## Verification

- `mix test` — 6 doctests, 3 properties, 3626 tests, 0 failures. Four new tests in `team_stream_test.exs` cover replay, the live tail, per-conversation runtime selection (a `claude` and a `codex` teammate on one connection), the unflagged payload, and that `blocks=true` is a 200 rather than a 422.
- Reverted the wiring (`put_blocks` forced to `nil`) and confirmed two of them fail.
- `npm test` (65 pass) and `npm run typecheck` in `sdk/typescript`; the fake server now records the query string so the test can assert the parameter is actually sent.
- `mix credo --strict`, `mix format --check-formatted`, `scripts/docs-style.py`, `vale lint docs` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)