### PR TITLE
fix(sandbox): a warm start applies the network policy instead of skipping it

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -762,15 +762,22 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
-  # Try a checkpoint restore first if the env has one. If restore
-  # succeeds, skip the slow steps (network policy + packages + clone +
-  # setup_script) — they all ran when the checkpoint was originally
-  # taken. If restore fails, clear the checkpoint id and fall through to
-  # the full pipeline.
+  # Try a checkpoint restore first if the env has one. If restore succeeds,
+  # skip the slow steps (packages + clone + setup_script) — they all wrote to
+  # the disk the checkpoint captured, so restoring it restores their effect.
+  # If restore fails, clear the checkpoint id and fall through to the full
+  # pipeline.
+  #
+  # The network policy is **not** one of those steps and is applied on both
+  # arms (#989). It is configuration on the sandbox, not a file: a warm start
+  # creates a fresh sandbox and pours a disk image into it, and that sandbox
+  # carries no policy. Skipping it turned a `limited` environment into an
+  # unrestricted one, silently, and reported `provision/done`. It costs one
+  # fast API call, so the warm start pays nothing for it.
   defp run_provisioning_pipeline(handle, env, sprite_env, secrets, conv_id) do
     case attempt_warm_start(handle, env, conv_id) do
       :warm_started ->
-        :ok
+        Fountain.Conversations.Provisioning.apply_network_policy(handle, env, conv_id)
 
       :cold ->
         with :ok <-

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -385,6 +385,62 @@ defmodule Fountain.Conversations.ConversationServerTest do
     end
   end
 
+  describe "provisioning — warm start from a checkpoint (#989)" do
+    test "the network policy is applied on the warm arm, not skipped with the disk steps", %{
+      user: user
+    } do
+      # A checkpoint captures the disk, so packages, clones and the setup
+      # script legitimately do not re-run. An egress policy is configuration on
+      # the sandbox, and a warm start creates a *new* sandbox — skipping it
+      # turned a `limited` environment into an unrestricted one and still
+      # reported `provision/done`.
+      stub_happy_sprite()
+      test_pid = self()
+
+      env =
+        insert_env(
+          user_id: user.id,
+          networking_type: "limited",
+          networking_config: %{"allowed_hosts" => ["github.com"]},
+          checkpoint_id: "ckpt-1"
+        )
+
+      agent = insert_agent(user_id: user.id, environment_id: env.id, runtime: "claude")
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          runtime: @legacy_runtime,
+          sandbox_id: sandbox.id,
+          status: "pending"
+        )
+
+      # The harness stubs a restore failure by default, which falls through to
+      # the cold path; this test is about the warm one.
+      Mimic.stub(Fountain.Conversations.Provisioning, :restore_checkpoint, fn _h, _id -> :ok end)
+
+      Mimic.stub(Fountain.Conversations.Provisioning, :apply_network_policy, fn _h, e, _c ->
+        send(test_pid, {:network_policy, e.networking_type})
+        :ok
+      end)
+
+      # The disk steps stay skipped: that part of the warm start is correct.
+      Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->
+        send(test_pid, :packages)
+        :ok
+      end)
+
+      {pid, _ref, :alive} = start_server(conv)
+
+      assert_received {:network_policy, "limited"}
+      refute_received :packages
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
+      GenServer.stop(pid)
+    end
+  end
+
   describe "provisioning — failure paths" do
     test "a sprite that cannot be created marks both rows failed", %{conv: conv, sandbox: sandbox} do
       stub_happy_sprite()


### PR DESCRIPTION
Closes #989. Found while building #935 (PR #987); filed and fixed separately rather than growing that PR.

## The bug

`run_provisioning_pipeline/5` skips four steps when a checkpoint restore succeeds, on this reasoning:

> skip the slow steps (network policy + packages + clone + setup_script) — they all ran when the checkpoint was originally taken.

That holds for `install_packages`, `clone_repositories` and `run_setup_script`. All three write to the disk the checkpoint captures.

It does not hold for `apply_network_policy/3`. An egress policy is configuration on the **sandbox** — a live `Fountain.Sandbox.apply_network_policy/2` call against a `Handle` — not a file. A warm start creates a *new* sandbox and restores a disk image into it, and that sandbox carries no policy.

So an environment with `networking_type: "limited"` and a non-empty `checkpoint_id` provisioned a sandbox with **no egress restriction at all**, on every provider, and reported `provision/done`. Silently: no `network` stage event is emitted on either arm, so nothing in the transcript said the policy had been skipped.

## Why it is latent, not live

`checkpoint_creation_enabled?/0` defaults to `false`, so nothing sets `checkpoint_id` and `attempt_warm_start/3`'s live branch is unreachable. That default exists because #654 found checkpoint ids are scoped to the sprite that created them. The flag was deliberately left in place so a future fork-from-checkpoint is a one-line re-enable (#936 lists it as an option), which is the day this stops being latent.

## The fix

Apply the policy on the warm arm. Deliberately *not* hoisted above the `case`: keeping it inside leaves the cold path's ordering byte-for-byte unchanged, and nothing here needs to answer whether a restore can clobber a policy applied beforehand. It is one fast call (`Provisioning`'s own moduledoc labels it "sandbox API call — fast"), so a warm start pays effectively nothing.

The misleading comment is corrected too — it is what made the skip look safe.

## Verification

- New test in `conversation_server_test.exs`: an env with `networking_type: "limited"` and a `checkpoint_id`, a restore stubbed to succeed, asserting `apply_network_policy` runs and `install_packages` does not. There was **no** warm-start coverage in the suite before this.
- Reverted the fix and confirmed the test fails.
- `mix test` — 2 unrelated failures locally, both DB-pool contention from running in a worktree that shares `fountain_test`; both pass in isolation. `mix credo --strict`, `mix format --check-formatted` and `MIX_ENV=dev mix dialyzer` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)