### PR TITLE
fix(acp): say which model the provider refused, instead of an inspected tuple

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1808,6 +1808,38 @@ defmodule Fountain.Conversations.ConversationServer do
      )}
   end
 
+  # #970: the provider refused the model, so this turn and every later one on
+  # this agent fail the same way until someone changes the field. The peer
+  # already read the kind out of the provider's sentence; what is left is to
+  # deliver it as a sentence rather than as an inspected tuple, and to publish
+  # the `model` stage so a client has the requested id as a field and can point
+  # at the agent that carries it.
+  #
+  # Nothing is swapped in, unlike the OAuth clause above. There is no second
+  # model to fall back to that the tenant did not choose, and picking one would
+  # answer their prompt with a model they never asked for.
+  def handle_info(
+        {:acp, ref, {:failed, {:model_unavailable, requested, detail}}},
+        %{current_command_ref: ref} = state
+      ) do
+    Logger.warning(
+      "conv #{state.conversation_id}: provider refused model #{requested || "(unset)"}: #{detail}"
+    )
+
+    publish_stage(state.conversation_id, "model", "failed", %{
+      requested: requested,
+      detail: detail,
+      using: "none, the turn failed"
+    })
+
+    message = model_unavailable_message(requested, detail)
+
+    {:noreply,
+     finish_acp_turn(state, "failed", %{"error" => message, "acp.model_unavailable" => true}, %{
+       reason: message
+     })}
+  end
+
   def handle_info({:acp, ref, {:failed, reason}}, %{current_command_ref: ref} = state) do
     Logger.error("conv #{state.conversation_id}: acp peer failed: #{inspect(reason)}")
 
@@ -3184,6 +3216,18 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp publish_stage(conv_id, stage, status, meta \\ %{}) do
     Conversations.publish_stage(conv_id, stage, status, meta)
+  end
+
+  # The provider's own sentence is the useful half, and it usually names the
+  # replacement, so it is quoted rather than summarised. Fountain adds only
+  # what the provider cannot know: which field holds the model, and that no
+  # retry helps until that field changes.
+  defp model_unavailable_message(requested, detail) do
+    named = if is_binary(requested) and requested != "", do: " (#{requested})", else: ""
+
+    "The provider refused this agent's model#{named}: #{String.trim(detail)} " <>
+      "Change the agent's model, then send your prompt again. " <>
+      "Every turn fails the same way until it changes."
   end
 
   # Every turn passes through here, whichever door it came in by — the

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -439,6 +439,12 @@ defmodule Fountain.Runtimes.ACP.Peer do
       tag == :prompt and oauth_org_not_allowed?(error) ->
         fail(state, {:oauth_org_not_allowed, error_detail(error)})
 
+      # The provider refused the model itself (#970). Here rather than in the
+      # generic arm for the same reason as the clause above: the tenant can act
+      # on it, but only if it reaches them as a sentence.
+      tag == :prompt and model_unavailable?(error) ->
+        fail(state, {:model_unavailable, state.model, error_detail(error)})
+
       true ->
         fail(state, {:acp_error, tag, error})
     end
@@ -669,6 +675,41 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # shape we did not anticipate, unlike a `get_in` chain would.
   defp oauth_org_not_allowed?(error),
     do: error |> inspect() |> String.contains?("oauth_org_not_allowed")
+
+  # The provider retired the model, or never had it, or this key cannot reach
+  # it. Google's is the one that prompted this (#970), and it is the awkward
+  # shape: the model was in Fountain's own catalog, `session/set_model`
+  # accepted it (google's listing endpoint still advertises models it has
+  # retired), and the refusal arrived only when the turn called it.
+  #
+  #     "This model models/gemini-2.5-pro is no longer available to new users.
+  #      Please update your code to use models/gemini-3.1-pro-preview ..."
+  #
+  # Left in the generic arm, that reached the tenant as an inspected
+  # `{:acp_error, :prompt, %{...}}` tuple: the one thing they have to change,
+  # printed in the one register they cannot act on.
+  #
+  # There is no field to key off. Google sends this as a 500, anthropic and
+  # openai as a 404 their adapters re-wrap, and none of the three marks the
+  # kind — so it is read out of the sentence. Both halves are required, a
+  # phrase *and* the word model, so that a "not found" about a file, a session
+  # or an MCP server is never read as a model refusal.
+  @model_gone_phrases [
+    "no longer available",
+    "does not exist or you do not have access",
+    "is not found for api version",
+    "model_not_found",
+    "model not found",
+    "unknown model",
+    "invalid model"
+  ]
+
+  defp model_unavailable?(error) do
+    text = error |> inspect() |> String.downcase()
+
+    String.contains?(text, "model") and
+      Enum.any?(@model_gone_phrases, &String.contains?(text, &1))
+  end
 
   # Prefer a method naming an API key in its `_meta`: that is what an agent
   # offers for "there is a key in the environment, use it", as against an

--- a/apps/fountain/lib/fountain/runtimes/model.ex
+++ b/apps/fountain/lib/fountain/runtimes/model.ex
@@ -42,6 +42,26 @@ defmodule Fountain.Runtimes.Model do
   # prefixes). A typo like `anthopic/...` used to reach the sprite with no
   # inference credentials at all and fail as an auth error in the conversation
   # log; `Agent.changeset/2` now rejects it at write time.
+  #
+  # #970 asked whether the picker should instead verify a model against the
+  # provider. It should not, and the reason is worth keeping:
+  #
+  #   * The listings lie. Google's `GET /v1beta/models` still returns
+  #     `gemini-2.5-pro` with `generateContent` among its supported methods,
+  #     months after the API stopped serving it to new keys. So does gemini's
+  #     own ACP adapter, which accepted `session/set_model` for that id and
+  #     failed only when the turn called it.
+  #   * The only authoritative check is a real inference call, per tenant key,
+  #     billed, at form time — for an answer that is true for one key at one
+  #     moment and that a retirement can invalidate the next day.
+  #   * A verified picker would still not have caught #970. The agent was saved
+  #     while the model worked.
+  #
+  # The catalog therefore stays advice, and the honest guarantee is made at the
+  # other end: when the provider does refuse a model, the peer names that as
+  # the kind of failure and the tenant reads the provider's own sentence, which
+  # names the replacement. See `Fountain.Runtimes.ACP.Peer`'s
+  # `model_unavailable?/1` and its handler in `ConversationServer`.
   @catalog %{
     "anthropic" => ~w(
       claude-opus-5

--- a/apps/fountain/priv/help/agents.md
+++ b/apps/fountain/priv/help/agents.md
@@ -31,7 +31,9 @@ curl -s -X POST "$FOUNTAIN_BASE_URL/api/agents" \
   }'
 ```
 
-The `model` field always uses the `provider/model` shape — even though codex/gemini don't pass it through to the CLI, the schema enforces the format.
+The `model` field always uses the `provider/model` shape. Only the *provider* half is validated: Fountain can only export credentials for anthropic / openai / google. The model id itself is passed to the runtime verbatim, so a model released after the last deploy works the day it ships.
+
+That means the models Fountain lists are **suggestions, not an allowlist** — and a provider can retire one at any time. Fountain does not call the provider to check an id at save time (the listing endpoints advertise models they no longer serve, so only a real, billed inference call would tell you, and only for that key at that moment). When a provider does refuse the model, the turn fails with the provider's own message, which usually names the replacement — change the agent's model and prompt again.
 
 ## Updating
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -475,6 +475,67 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
     end
   end
 
+  describe "a model the provider refuses (#970)" do
+    setup do
+      user = insert_verified_user()
+
+      agent =
+        insert_agent(user_id: user.id, runtime: "gemini", model: "google/gemini-2.5-pro")
+
+      {:ok, conv: insert_conversation(agent: agent, user_id: user.id)}
+    end
+
+    defp model_gone_reply(pid, ref, id) do
+      line =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "error" => %{
+            "code" => 500,
+            "message" =>
+              "This model models/gemini-2.5-pro is no longer available to new users. " <>
+                "Please update your code to use models/gemini-3.1-pro-preview for the " <>
+                "latest features and improvements."
+          }
+        }) <> "\n"
+
+      send(pid, {:stdout, %{ref: ref}, line})
+      settle(pid)
+    end
+
+    test "the turn fails with the provider's sentence, not an inspected tuple", %{conv: conv} do
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+      model_gone_reply(pid, ref, prompt_id)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "failed"
+
+      stage = failed_turn_stage(conv.id)
+      # The point of #970: what the tenant reads names the model, quotes the
+      # provider (which names the replacement) and says what to change.
+      assert stage.data =~ "gemini-2.5-pro"
+      assert stage.data =~ "no longer available to new users"
+      assert stage.data =~ "gemini-3.1-pro-preview"
+      assert stage.data =~ "Change the agent's model"
+      refute stage.data =~ ":acp_error"
+    end
+
+    test "publishes a model stage carrying the requested id as a field", %{conv: conv} do
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+      model_gone_reply(pid, ref, prompt_id)
+
+      assert stage =
+               conv.id
+               |> Conversations._unsafe_list_log_events()
+               |> Enum.find(&(&1.kind == "stage" and &1.stage == "model"))
+
+      assert stage.state == "failed"
+      assert stage.data =~ "gemini-2.5-pro"
+    end
+  end
+
   describe "turn 2" do
     test "resumes by the persisted id rather than guessing" do
       # The hazard 0014 names: gemini's `--resume` and codex's `--last` re-enter

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -422,6 +422,57 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
       assert detail =~ "oauth_org_not_allowed"
     end
 
+    test "a provider that refuses the model is distinguished from a generic error (#970)", ctx do
+      pid = start_peer(ctx, model: "gemini-2.5-pro")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      # No `models` and no `configOptions`, so the model is never pinned — which
+      # is the #970 shape at its worst: nothing refuses the id until the turn
+      # calls it.
+      send_response(pid, new_id, %{"sessionId" => "s"})
+      %{"id" => prompt_id} = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => prompt_id,
+          "error" => %{
+            "code" => 500,
+            "message" =>
+              "This model models/gemini-2.5-pro is no longer available to new users. " <>
+                "Please update your code to use models/gemini-3.1-pro-preview for the " <>
+                "latest features and improvements."
+          }
+        }) <> "\n"
+      )
+
+      assert_receive {:acp, _ref, {:failed, {:model_unavailable, "gemini-2.5-pro", detail}}}
+      assert detail =~ "no longer available to new users"
+      assert detail =~ "gemini-3.1-pro-preview"
+    end
+
+    test "a not-found that is not about a model stays a generic error (#970)", ctx do
+      pid = start_peer(ctx, model: "gemini-3.1-pro-preview")
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+      %{"id" => prompt_id} = next_write()
+
+      Peer.stdout(
+        pid,
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => prompt_id,
+          "error" => %{"code" => -32_602, "message" => "session not found"}
+        }) <> "\n"
+      )
+
+      assert_receive {:acp, _ref, {:failed, {:acp_error, :prompt, _error}}}
+    end
+
     test "the same error kind at session setup is not special-cased — only the prompt call is",
          ctx do
       pid = start_peer(ctx, [])

--- a/docs/reference/webhooks.md
+++ b/docs/reference/webhooks.md
@@ -67,7 +67,7 @@ counter uses the same pair as its tags.
 | `reattach` | `started` `done` `failed` `interrupted` | The server reconnects to a sandbox after a restart. |
 | `turn` | `started` `done` `failed` `interrupted` | One prompt and its reply. |
 | `request` | `started` `done` | The agent asked permission for a tool. It got an answer, or the request expired. |
-| `model` | `failed` | The runtime refused the model the agent asks for. |
+| `model` | `failed` | The runtime or the provider refused the model the agent asks for. |
 | `session` | `done` | The runtime reported a session id for the conversation. |
 | `sandbox` | `done` | Fountain reclaimed the sandbox. The conversation stays resumable. |
 | `terminate` | `done` | The conversation ended. |

--- a/docs/troubleshooting/conversation-stuck-or-failed.md
+++ b/docs/troubleshooting/conversation-stuck-or-failed.md
@@ -29,6 +29,28 @@ fountain conv interrupt <conv-id>     # stop the in-flight turn, keep the sandbo
 fountain conv terminate <conv-id>     # destroy the sandbox, end the conversation
 ```
 
+## The provider refused the model
+
+A turn fails when the model provider refuses the agent's model. Fountain
+records a `model` stage event with the refused id. The `turn` stage event holds
+the provider's own message, and that message usually names a replacement.
+
+```
+The provider refused this agent's model (gemini-2.5-pro): This model
+models/gemini-2.5-pro is no longer available to new users. Please update
+your code to use models/gemini-3.1-pro-preview for the latest features
+and improvements.
+```
+
+Open the agent. Set the model field to the replacement. Send the prompt again.
+Each turn fails in the same way until that field changes.
+
+The models Fountain lists are advice, not a set of permitted values. Fountain
+sends any model id under a known provider to the runtime without a check. A
+model released after the last deploy therefore works on the day it ships. A
+provider can also retire a model at any time. A model that worked last month
+can fail today.
+
 ## What the statuses mean
 
 `failed` and `terminated` are the two terminal states. Fountain refuses a


### PR DESCRIPTION
Closes #970.

#970 had two halves, and #978 shipped the first one: the google catalog moved
to the 3.x names, so `gemini-2.5-pro` is no longer offered. This is the second
half, which the issue left as a question — *"whether the picker verifies
against the provider"*.

## The decision: it does not, and here is why

Recorded as a comment on `@catalog`, because that is where the next person
will ask.

- **The listings lie.** `GET /v1beta/models` still returns `gemini-2.5-pro`
  with `generateContent` among its supported methods, and so does gemini's own
  ACP adapter — it accepted `session/set_model` for that id and failed only
  when the turn actually called the model. A verifier reading either would
  have said "fine".
- **The only authoritative check is a real inference call**, per tenant key,
  billed, at form time, for an answer that is true for one key at one moment.
- **A verified picker would not have caught #970 anyway.** The agent was saved
  while the model worked. The model was retired afterwards.

So the catalog stays advice (#554), and the guarantee is made at the other
end: when the provider *does* refuse, the tenant gets a sentence they can act
on rather than a tuple.

## What changed

**`ACP.Peer`** — a `model_unavailable?/1` classifier beside the existing
`oauth_org_not_allowed?/1`, scoped to the `:prompt` call, failing the turn as
`{:model_unavailable, requested, detail}`. There is no field to key off (google
sends 500, anthropic and openai send a 404 their adapters re-wrap), so the kind
is read out of the sentence. Both halves are required — a phrase *and* the word
model — so a "not found" about a file, a session or an MCP server is never read
as a model refusal. A test pins that direction too.

**`ConversationServer`** — a handler that publishes the `model` stage with the
requested id as a field (so a client has something structured to link to the
agent with), and finishes the turn with:

> The provider refused this agent's model (gemini-2.5-pro): This model
> models/gemini-2.5-pro is no longer available to new users. Please update your
> code to use models/gemini-3.1-pro-preview for the latest features and
> improvements. Change the agent's model, then send your prompt again. Every
> turn fails the same way until it changes.

The provider's own sentence is quoted rather than summarised, because it is the
half that names the replacement. Nothing is swapped in, unlike the OAuth clause
above it: there is no second model to fall back to that the tenant did not
choose.

**Docs** — a troubleshooting section, the `model` webhook row (it now has two
causes, the runtime's pin refusal and the provider's), and the in-app agents
help, which now says the model list is suggestions and that Fountain does not
check an id at save time. While there: that page claimed codex and gemini do
not pass the model to the CLI, which stopped being true at #553.

## Checks

`mix precommit` clean — **3,638 tests, 0 failures**, credo `--strict` no
issues, dialyzer `Total errors: 0`, sobelow scan complete, format clean.
`python3 scripts/docs-style.py` clean, `vale lint docs` **0 errors**, and
`mkdocs build --strict` builds.

Both new behaviours were verified by reverting the fix: with the peer clause
disabled, all three new tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
