### PR TITLE
chore(models): retire gpt-5-codex, list claude-opus-4-7, verified by calling every id

### DIFF
--- a/apps/fountain/lib/fountain/runtimes/model.ex
+++ b/apps/fountain/lib/fountain/runtimes/model.ex
@@ -9,7 +9,7 @@ defmodule Fountain.Runtimes.Model do
   provider and want the bare id:
 
       claude --model claude-sonnet-4-6
-      codex  --model gpt-5-codex        # also spelled -m
+      codex  --model gpt-5.3-codex      # also spelled -m
       gemini --model gemini-3.1-pro-preview   # also spelled -m
 
   `Fountain.Agents.Agent` rejects a model whose prefix doesn't match its
@@ -62,15 +62,36 @@ defmodule Fountain.Runtimes.Model do
   # the kind of failure and the tenant reads the provider's own sentence, which
   # names the replacement. See `Fountain.Runtimes.ACP.Peer`'s
   # `model_unavailable?/1` and its handler in `ConversationServer`.
+  #
+  # Every id below was checked with a real inference call on 2026-08-22, per
+  # provider, on this instance's own keys. That is the only check worth making
+  # — see the listing-endpoint note above.
   @catalog %{
+    # `claude-opus-4-7` added 2026-08-22. It is not new, but it was never
+    # listed, and it is the third most configured model on this instance (9
+    # agents, 290 completed turns) — a working model that the picker did not
+    # offer, so every one of those agents was typed in from somewhere else.
     "anthropic" => ~w(
       claude-opus-5
       claude-sonnet-5
       claude-opus-4-8
+      claude-opus-4-7
       claude-sonnet-4-6
       claude-haiku-4-5
     ),
-    "openai" => ~w(gpt-5-codex gpt-5),
+    # `gpt-5-codex` was retired and removed on 2026-08-22 — the same defect as
+    # the google entries below, and a worse one, because it was the suggestion
+    # *and* the form placeholder for the codex runtime, so it was what a new
+    # codex user was told to type. `/v1/responses` answers 404 "Model not
+    # found gpt-5-codex" for it and 200 for `gpt-5.3-codex`.
+    #
+    # A trap for the next person to check this: codex-line models are not
+    # served on `/v1/responses` once they are old, so a 404 there is a real
+    # retirement — but `GET /v1/models` still lists every one of them
+    # (`gpt-5.1-codex`, `gpt-5.2-codex`, ...). The listing lies here exactly as
+    # it does for google. `gpt-5` still answers 200 and was replaced only for
+    # being five releases behind.
+    "openai" => ~w(gpt-5.3-codex gpt-5.5),
     # Both 2.5 entries were removed on 2026-08-22: Google retired
     # `gemini-2.5-pro` *and* `gemini-2.5-flash` for new API keys, so every
     # model Fountain suggested for google answered

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -140,7 +140,7 @@ defmodule FountainWeb.AgentsLive.Form do
   # Each runtime but opencode only reaches one provider, and the changeset
   # rejects a mismatched prefix (#553). Track the selected runtime so the hint
   # can't lead someone into that error.
-  defp model_placeholder("codex"), do: "openai/gpt-5-codex"
+  defp model_placeholder("codex"), do: "openai/gpt-5.3-codex"
   defp model_placeholder("gemini"), do: "google/gemini-3.1-pro-preview"
   defp model_placeholder(_runtime), do: "anthropic/claude-sonnet-4-6"
 

--- a/apps/fountain/priv/help/agents.md
+++ b/apps/fountain/priv/help/agents.md
@@ -3,7 +3,7 @@
 An **Agent** is a named configuration for a single coding-agent CLI. It bundles together:
 
 - a **runtime** (`claude` / `codex` / `gemini` / `opencode`) — which binary runs in the sprite
-- a **model** (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.1`, `google/gemini-3.1-pro-preview`, etc.)
+- a **model** (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.3-codex`, `google/gemini-3.1-pro-preview`, etc.)
 - an optional **system prompt** (`system`)
 - an optional **environment** reference (`environment_id` or `environment` by name) — the sprite shape to provision
 - optional **skills** — names of bundled skills to mount into the sprite
@@ -75,7 +75,7 @@ Use `$${VAR}` only when the MCP server (or some downstream process the runtime s
 | runtime | CLI | model format | auth |
 | --- | --- | --- | --- |
 | claude | `claude` | `anthropic/claude-sonnet-4-6` | `CLAUDE_CODE_OAUTH_TOKEN` (preferred) or `ANTHROPIC_API_KEY` |
-| codex | `codex` | `openai/gpt-5.1` | `OPENAI_API_KEY` (consumed via `codex login --with-api-key` at provision time) |
+| codex | `codex` | `openai/gpt-5.3-codex` | `OPENAI_API_KEY` (consumed via `codex login --with-api-key` at provision time) |
 | gemini | `gemini` | `google/gemini-3.1-pro-preview` | `GEMINI_API_KEY` |
 | opencode | `opencode` | `provider/model` (anthropic / openai / google) | per provider |
 

--- a/apps/fountain/test/fountain/agents/agent_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_test.exs
@@ -13,7 +13,7 @@ defmodule Fountain.Agents.AgentTest do
   # multi-provider, so any prefix is fine there.
   @model_for %{
     "claude" => "anthropic/claude-sonnet-4-6",
-    "codex" => "openai/gpt-5-codex",
+    "codex" => "openai/gpt-5.3-codex",
     "gemini" => "google/gemini-3.1-pro-preview",
     "opencode" => "anthropic/claude-sonnet-4-6"
   }

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -143,7 +143,7 @@ defmodule FountainWeb.AgentsLive.IndexTest do
       # Switching runtime re-scopes the list — codex can't reach an
       # anthropic/ model, and the changeset rejects one.
       html = render_change(view, "validate", %{"agent" => %{"runtime" => "codex"}})
-      assert html =~ "openai/gpt-5-codex"
+      assert html =~ "openai/gpt-5.3-codex"
       refute html =~ "anthropic/claude-opus-5"
     end
 

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -159,7 +159,7 @@ defmodule Fountain.Factory do
     )
   end
 
-  defp default_model_for("codex"), do: "openai/gpt-5-codex"
+  defp default_model_for("codex"), do: "openai/gpt-5.3-codex"
   defp default_model_for("gemini"), do: "google/gemini-3.1-pro-preview"
   defp default_model_for(_runtime), do: "anthropic/claude-sonnet-4-6"
 

--- a/docs/catalog/runtimes/codex.md
+++ b/docs/catalog/runtimes/codex.md
@@ -28,7 +28,7 @@ metadata:
   name: reviewer
 spec:
   runtime: codex
-  model: openai/gpt-5-codex
+  model: openai/gpt-5.3-codex
 ```
 
 The model must carry the `openai/` prefix.

--- a/docs/catalog/runtimes/index.md
+++ b/docs/catalog/runtimes/index.md
@@ -49,8 +49,8 @@ The agent form offers these as suggestions. They are not an allowlist.
 
 | Provider | Suggested |
 |---|---|
-| `anthropic` | `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
-| `openai` | `gpt-5-codex`, `gpt-5` |
+| `anthropic` | `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
+| `openai` | `gpt-5.3-codex`, `gpt-5.5` |
 | `google` | `gemini-3.1-pro-preview`, `gemini-3.7-flash` |
 
 `GET /api/catalog` returns this list for each runtime. A client can then


### PR DESCRIPTION
Follow-on from #992. Started as "add the two models prod uses that the catalog
does not list" and one of the two turned out not to exist, while a model the
catalog *does* list turned out to be dead.

Every id in `@catalog` was checked with a real inference call on this
instance's own keys. The listing endpoints were only used to find candidates.

## What the probes said

```
anthropic  /v1/messages
  claude-opus-4-7          200      <- works, was never listed
  claude-opus-5            200
  claude-sonnet-5          200
  claude-opus-4-8          200
  claude-sonnet-4-6        200
  claude-haiku-4-5         200

openai     /v1/responses
  gpt-5-codex              404  "Model not found gpt-5-codex"   <- in the catalog
  gpt-5.3-codex            200
  gpt-5                    200      (works, five releases behind)
  gpt-5.5                  200

google     :generateContent
  gemini-3.1-pro-preview   200      <- already correct, no change
  gemini-3.7-pro           404      <- the model I thought we should add
  gemini-3.6-pro           404
  gemini-3.5-pro           404
```

## The three changes

**`gpt-5-codex` is retired.** This is the #970 defect again, and a worse
instance of it: `gpt-5-codex` was the suggestion *and* the form placeholder for
the codex runtime, so it was literally what a new codex user was told to type.
Replaced with `gpt-5.3-codex`.

**`claude-opus-4-7` is added.** Not new, but never listed — and it is the third
most configured model on this instance: **9 agents, 49 conversations, 290
completed turns, 3 failed, last used 2026-08-20.** A working model the picker
did not offer, so all 9 of those agents were typed in from somewhere else.

**`gpt-5` becomes `gpt-5.5`.** `gpt-5` still answers 200; it was replaced only
for being five releases behind.

Google is unchanged. `gemini-3.1-pro-preview` really is the newest pro that
answers, even though the flash tier is at 3.7.

## A trap for whoever checks this next

The codex line is not served on `/v1/responses` once a model is old, and
`GET /v1/models` still lists every retired one (`gpt-5-codex`, `gpt-5.1-codex`,
`gpt-5.2-codex`, `gpt-5.1-codex-max`). The listing lies here exactly as it does
for google, which still advertises `gemini-2.5-pro` today. A 404 from a real
call is the retirement; a listing hit is not evidence of anything. That is
written on `@catalog`.

## Not in this PR

**8 agents are configured with `google/gemini-3.7-pro`, which does not exist**
(404). They have 8 conversations between them and **zero turns, ever** — dead
config, never run, so nobody has been hurt by it. Adding a nonexistent model to
the catalog would have been the wrong fix; cleaning up those rows is a separate
call and yours to make. Worth noting that after #992 those agents now fail with
`models/gemini-3.7-pro is not found for API version v1beta` in plain text
rather than an inspected tuple, which is the classifier doing its job.

## Checks

`mix precommit` clean — **3,639 tests, 0 failures**, credo `--strict` no
issues, dialyzer `Total errors: 0`, sobelow scan complete, format clean.
`docs-style.py` clean, `vale lint docs` **0 errors**, `mkdocs build --strict`
builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
