### PR TITLE
docs(sprites): the exit frame is one byte, and Sprites meets exit-truth

### DIFF
--- a/docs/integrations/platform-requirements.md
+++ b/docs/integrations/platform-requirements.md
@@ -224,7 +224,7 @@ a scorecard. Several entries are probably stale already.
 
 | Requirement | [Sprites](sprites.md) | [E2B](e2b.md) | [Daytona](daytona.md) | [Runner](runners.md) |
 |---|---|---|---|---|
-| exit-truth | No. Exec reports 0 whatever happened. | Yes. | No. A session-command record carries no exit code. | Yes. |
+| exit-truth | Yes. | Yes. | No. A session-command record carries no exit code. | Yes. |
 | replay-cursor | Partial. It replays the last 16 KiB, and starts mid-line. | No. We ship a journal shim and a tail replayer. | Yes. The journal replays from byte zero. | Yes. |
 | detached-sessions | Yes. | No. The adapter emulates them. | Yes. | Yes. |
 | absence-definitive | Undocumented. | Undocumented. | Undocumented. | Yes. Each offline shape is transient by construction. |
@@ -234,6 +234,16 @@ a scorecard. Several entries are probably stale already.
 | honest-listing | Yes, with continuation tokens. | Not measured. | Not measured. | Yes. |
 | egress-deny | Partial. The translation fails open. | Yes. | Yes, and the tier gates it. | No, by design. The machine is the user's. |
 | url-or-nothing | Yes. | No. It has a hostname for each port, and no more. | No. | No. |
+
+One entry here was wrong for three months. This table said Sprites failed
+exit-truth, because each command we ran through it reported 0. The platform
+sent the true code every time. Our Elixir client read the one-byte field as
+four bytes, matched no frame, and reported a 0 that nobody had sent. See
+[#880](https://github.com/BinaryBourbon/fountain/issues/880).
+
+Read that as a warning about this table. We measure each platform through our
+own adapter, so every row says something about the adapter as well as the
+platform. A row that reports a failure is the row to distrust first.
 
 The fourth backend is our own daemon, the
 [self-hosted runner](runners.md). Read it as an existence proof, and not as a

--- a/docs/integrations/sprites-contract.md
+++ b/docs/integrations/sprites-contract.md
@@ -65,17 +65,24 @@ Frames are binary, with a one-byte stream id in front.
 | `0` | stdin, client to server. |
 | `1` | stdout. |
 | `2` | stderr. |
-| `3` | exit, and then a 4-byte big-endian exit code. |
+| `3` | exit, and then a one-byte exit code. |
 | `4` | stdin EOF, client to server. |
 
 In TTY mode the prefix disappears. A binary frame is then raw terminal bytes,
 and a JSON text frame carries a control message, which is `exit`, `resize` or
 `port`.
 
-Fountain depends on two subtleties.
+Fountain depends on three subtleties.
 
+- **The exit code is one byte.** This page said four bytes until August 2026,
+  and our Elixir client read four. No real frame `3` ever matched, so the
+  client discarded every one of them. Read
+  [#880](https://github.com/BinaryBourbon/fountain/issues/880) before you
+  change this row.
 - **A close with no exit frame counts as exit 0.** A replacement that drops a
   connection and sends no frame `3` makes a failed command look successful.
+  This rule is what turned the wrong width into silence. The client dropped
+  the frame, the socket closed, and the command reported success.
 - The client enforces the timeout for each command. The turn itself runs
   unbounded, and the [sandbox lifecycle](../architecture.md) ends it. The
   transport does not.

--- a/docs/troubleshooting/conversation-stuck-or-failed.md
+++ b/docs/troubleshooting/conversation-stuck-or-failed.md
@@ -85,13 +85,14 @@ kubectl logs -n fountain -l app=fountain --since=2h | grep 'reaper:'
 `parked` counts the idle sandboxes the reaper suspended. The reaper can undo
 that, and it is not a teardown.
 
-## One trap worth knowing
+## Conversations from before August 2026
 
-On the default provider, a setup script or a clone that failed can record as
-successful. The exec transport reports exit code 0 for each command
-([#880](https://github.com/BinaryBourbon/fountain/issues/880), open). When a
-conversation starts in a state you did not expect, read the logged output. Do
-not trust the stage status.
+Stage status is reliable now. It was not always. On the default provider, a
+setup script or a clone that failed could record as successful. The client
+discarded the exit code and read a 0. See
+[#880](https://github.com/BinaryBourbon/fountain/issues/880), fixed on
+2026-08-23. For a conversation that ran before that date, read the logged
+output. Do not trust its stage status.
 
 ## Related
 


### PR DESCRIPTION
Follow-up to #994, which fixed [#880](https://github.com/BinaryBourbon/fountain/issues/880). The docs asserted the opposite of what is now true, in three places.

## What was wrong

**`integrations/sprites-contract.md`** is the important one. It documented the exit frame as **"a 4-byte big-endian exit code"**. Sprites sends one byte. This page is our written spec of that wire protocol, so the client's bug had a matching spec backing it up, and anyone checking the code against the docs found agreement. Both were wrong together.

It now says one byte, and adds a third subtlety recording why. The existing caveat — a close with no exit frame counts as exit 0 — stays, because that rule is what converted the wrong width into silent success instead of a decode error. It remains the residual hazard flagged in #994.

**`integrations/platform-requirements.md`** scored Sprites `No. Exec reports 0 whatever happened.` on exit-truth. That verdict came from measuring a platform through a broken adapter of ours. The row is now `Yes.`

The page also gains the warning it earned. It already said the table was measured "through the adapters in this repository", and this is what that disclaimer looks like when it bites: every row describes our adapter as much as the platform, so **a row reporting a failure is the one to distrust first**. A wrong `No` here is not a neutral error, it is a public claim that a vendor fails a requirement they meet.

**`troubleshooting/conversation-stuck-or-failed.md`** told operators to read the logged output and not trust the stage status. That was correct advice and is now actively harmful, since it trains people to ignore a signal that works. It is now scoped to conversations that ran before 2026-08-23. The page's opening line, "the event data holds the exit code", is finally true.

## Verification

Against the deployed image (`sha-0b655bd`, both pods confirmed on it), an environment whose setup script is `echo "about to fail"; exit 42`:

```
stage='setup'      data={"exit_code":42}
stage='provision'  data={"reason":"{:setup_exit, 42}"}
```

And in the database:

```
code | count
-----+------
0    |  534
42   |    1
```

That 42 is the first non-zero exit code ever recorded in Fountain production.

Worth noting one false positive from the first probe attempt: the conversation failed, which looked like the expected result, but the events showed it died at `provision` because the agent I picked declares MCP servers needing env keys the bare probe environment lacked. The setup script never ran. Re-probed with a purpose-built agent with no MCP servers. Probe agent, environment and conversations have been cleaned up.

## Gates

`python3 scripts/docs-style.py` clean (78 files, 0 on the backlog). `vale lint docs` **0 errors** (3013 suggestions, all `STE.Vocabulary`, which advises and does not gate). `mkdocs build --strict` clean. Both docs test files pass, 35 tests, 0 failures.

One STE catch worth recording: the first draft of the troubleshooting rewrite tripped `STE.SentenceLength` at 31 words against a 25-word limit. Split into shorter sentences.
