### PR TITLE
docs(permissions): record what an "always" answer actually grants

### DIFF
--- a/apps/fountain/lib/fountain/permissions.ex
+++ b/apps/fountain/lib/fountain/permissions.ex
@@ -65,6 +65,37 @@ defmodule Fountain.Permissions do
   "no option was selected" and the only honest answer available. Inventing an
   `optionId` the agent never advertised would at best error and at worst select
   something unrelated.
+
+  ## Fountain does not remember an answer, and "always" often does not either
+
+  An answer is relayed to the peer and forgotten. Every "remember this"
+  semantic belongs to the agent, and each of the three that ask implements it
+  differently. Measured live against production on 2026-08-22 — do not
+  re-derive, and do not assume an `allow_always` option means what it says:
+
+  | runtime | what `allow_always` does |
+  |---|---|
+  | claude | Writes a rule into `.claude/settings.local.json` in the sandbox. Holds across turns, dies with the sandbox. **Except** where the command writes outside the working directory — see below. |
+  | codex | "Allow for Session" lives in the codex process, so it lasts exactly one turn. "Allow Commands Starting With …" (`accept_execpolicy_amendment`) is written to disk and holds. |
+  | opencode | Never asks, so there is nothing to grant (#959). |
+
+  Two consequences worth holding on to. **codex's session grant is ours, not
+  a defect**: one ACP connection per turn (0014) tears that process down at
+  turn end, which is the same lever as #817. And **every grant dies with the
+  sandbox**, so a `Lifecycle` reclaim silently resets consent.
+
+  claude's exception is upstream and is a prompt loop no clicking resolves
+  (anthropics/claude-code#88919). A shell redirect to a path outside the
+  session's working directory is gated by a filesystem write check that no
+  `Bash(...)` or `Read(...)` rule participates in, and `allow_always` only ever
+  proposes those. So it writes a well-formed, general, irrelevant rule, and the
+  byte-identical command asks again — measured twice within a single turn, in
+  one process. The rule of thumb: **`allow_always` holds only where the command
+  writes nothing outside its cwd.**
+
+  None of this is worked around here. #996 is where the question of whether
+  Fountain should own grants at all is being decided; a matcher written before
+  that decision would be a second permission authority arriving by accident.
   """
 
   @auto_allow "auto_allow"

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -237,6 +237,28 @@ That is the shape we already run, with the protocol swapped in underneath it:
 > replayed lines are de-duplicated by content, not by the byte count the
 > legacy path still uses.
 
+> **Addendum, 2026-08-22 — the turn-scoped connection deletes a permission
+> grant, and that is a real cost this ADR did not price.** Gate 3 (#939/#940)
+> gave a human the `ask` verdict, and agents answer it with options that mean
+> "and stop asking me". Where the agent keeps that grant **in its own process**,
+> closing the connection at turn end throws it away. Measured on codex
+> 2026-08-22: "Allow for Session" (`_meta.codex.decision: acceptForSession`)
+> suppresses the second identical call inside one turn and is gone by the next
+> one, while its `accept_execpolicy_amendment` option, which codex writes to
+> disk, survives. claude's grants are written to
+> `.claude/settings.local.json` and so are unaffected by connection lifetime —
+> they have a separate upstream defect, anthropics/claude-code#88919, which is
+> not this ADR's to answer.
+>
+> This does not overturn the rule. Turn-scoped is still what keeps protocol
+> state from becoming a reason to hold a sandbox open, and sandbox-scoped
+> remains the permitted optimisation rather than a correction. But the cost
+> column now has an entry beyond latency: **a runtime that holds consent in
+> memory cannot honour "always" under this design**, and no client can paper
+> over it, because the option carries no metadata saying so. #817 asks for the
+> same widening from the other direction — Claude Code's background tasks die
+> at the same boundary — and #996 is where the two are being weighed together.
+
 **The rule that keeps this from eroding one optimisation at a time: no ACP
 state may become a reason to keep a sandbox alive.** A connection may be
 scoped to the turn (v1) or, if per-turn `initialize` proves too slow, to the

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -83,6 +83,33 @@ Some rules keep that safe.
 | opencode | **No** | It decides this in its own server, and sends nothing. Fountain refuses a policy stricter than `auto_allow` on this runtime, with 422 `permission_policy_unenforceable` ([#959](https://github.com/BinaryBourbon/fountain/issues/959)). |
 | gemini | Yes | Measured on gemini 0.53 with `gemini-2.5-flash`. Google removed that model for new API keys after this measurement. Its option ids are its own (`proceed_once`, `cancel`), so answer with an id from the request, never a name you know from another runtime. |
 
+## An "always" answer does not always hold
+
+Each runtime that asks offers an option that means "do not ask me again".
+Fountain sends the option id, and it keeps no record of the answer. The runtime
+decides how long its own grant lasts, and the three runtimes disagree.
+
+| Runtime | How long an "always" answer lasts |
+|---|---|
+| claude | It writes a rule to a file in the sandbox. The rule holds for later turns. |
+| codex | `Allow for Session` lasts one turn. The option that amends the command policy goes to a file, and it holds. |
+| opencode | This runtime never asks, so it grants nothing. |
+
+Every grant lives inside the sandbox. A new sandbox starts with none of them.
+
+Two limits are open work.
+
+- codex loses a session grant at the end of each turn. Fountain opens one
+  protocol connection per turn, and the grant lives in the runtime process.
+  See [#817](https://github.com/BinaryBourbon/fountain/issues/817) and
+  [#996](https://github.com/BinaryBourbon/fountain/issues/996).
+- claude asks again for a command that writes outside the directory where it
+  runs.
+  The rule that `Always Allow` writes cannot answer the check that stopped the
+  command, so the prompt repeats. This is a defect in the runtime, and the
+  report is
+  [anthropics/claude-code#88919](https://github.com/anthropics/claude-code/issues/88919).
+
 ## What the audit trail keeps
 
 Fountain records a refusal, with the tool and the verdict. It records no


### PR DESCRIPTION
Answering **Always Allow** and being asked again is the most common thing people report about the permission prompts. Until now nothing in the repo said what "always" means. It means three different things, and one of them means nothing at all.

Measured live against production on 2026-08-22, across three runtimes. No behaviour changes here — this is the record, so the next person does not re-derive it.

## What was measured

| runtime | what `allow_always` does |
|---|---|
| claude | Writes a rule into `.claude/settings.local.json` in the sandbox. Holds across turns, dies with the sandbox. **Except** the case below. |
| codex | "Allow for Session" lives in the codex process, so it lasts exactly one turn. The execpolicy amendment goes to disk and holds. |
| opencode | Never asks, so nothing to grant (#959). |

### codex's session grant is ours

One ACP connection per turn (ADR 0014) tears that process down at turn end, so "Allow for Session" cannot work as named. Isolated by the fact that codex's *other* always-option, which it writes to disk, survives the same boundary.

No client can paper over it either: that option carries **no `_meta.permission`**, so there is nothing to render a scope warning from — unlike claude, whose options describe their own lifetime. ADR 0014 gains an addendum pricing this. The turn-scoped rule is **not** overturned; its cost column now has an entry beyond latency. #817 asks for the same widening from the other direction.

### claude's case is upstream

A shell redirect to a path outside the working directory is gated by a **filesystem write** check that no `Bash(...)` or `Read(...)` rule participates in, and `allow_always` only ever proposes those. So it writes a well-formed, genuinely general, completely irrelevant rule, and the byte-identical command asks again — forever. Filed as [anthropics/claude-code#88919](https://github.com/anthropics/claude-code/issues/88919) with a repro that needs no ACP at all.

Two earlier hypotheses were wrong, and the moduledoc records them as such: it is **not** shell operators (`echo hello a && echo hello b` runs silently against `Bash(echo hello *)`), and it is **not** our connection lifetime — the identical command asks twice inside a single turn, in one process. That second measurement is the one to make first next time, and it is written down for exactly that reason.

Rule of thumb, now in the moduledoc: **`allow_always` holds only where the command writes nothing outside its cwd.**

## What changed

- `Fountain.Permissions` moduledoc — the per-runtime table, the upstream link, the disproved hypotheses, and why no workaround lives here.
- `decisions/0014-agent-client-protocol.md` — an addendum in the file's existing style, pricing the permission cost of the turn-scoped connection.
- `docs/concepts/permissions.md` — a user-facing section saying "always" is per-runtime, and naming both open limits.

## Deliberately not done

- **No `Runtimes.Quirks` entry.** Every entry needs an `implemented_by` MFA that can be deleted, and we carry no code for either defect. Quirks is for workarounds we ship, not defects we know about.
- **No fix.** Whether Fountain should own grants at all is #996. A matcher written before that decision would be a second permission authority arriving by accident, and one that over-matches turns an annoying prompt into a privilege escalation.

## Gates

`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), `permissions_test.exs` + `docs_test.exs` (59 tests, 0 failures), `vale lint` (0 errors, 0 warnings — my first draft added one of each and both are fixed), `python3 scripts/docs-style.py` (clean), `okf validate decisions` (valid), `mkdocs build --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)