### PR TITLE
fix(ci): stage every deploy/ tree Flux builds, and build the staged tree

### DIFF
--- a/.github/workflows/publish-manifests.yml
+++ b/.github/workflows/publish-manifests.yml
@@ -258,14 +258,27 @@ jobs:
             fi
           fi
 
-          # Stage exactly what the cluster Kustomization consumes: ./k8s plus
-          # the ../deploy/k8s baseline its kustomization references, relative
-          # layout intact. The tree is evaluated in-cluster by
-          # kustomize-controller.
+          # Stage what the cluster Kustomization consumes: ./k8s plus every
+          # ../deploy/* tree its kustomization references, relative layout
+          # intact. The tree is evaluated in-cluster by kustomize-controller.
+          #
+          # All of deploy/ rather than a named list. The named list was
+          # `deploy/k8s` alone, and when #1001 added `- ../deploy/grafana` to
+          # k8s/kustomization.yaml the artifact went out without it. Flux could
+          # not build and sat at Ready=False (BuildFailed), which wedges every
+          # later deploy while the running workload stays healthy — the quiet
+          # kind of broken.
           staging=$(mktemp -d)
           cp -R k8s "${staging}/k8s"
-          mkdir -p "${staging}/deploy"
-          cp -R deploy/k8s "${staging}/deploy/k8s"
+          cp -R deploy "${staging}/deploy"
+
+          # Build what is about to be published, not the repo. The earlier
+          # kustomize step runs against the full checkout, where a
+          # `../deploy/<x>` reference resolves whether or not it was staged, so
+          # it cannot see a staging omission by construction. This can, because
+          # it builds the same subset kustomize-controller will.
+          echo "── verifying the staged tree builds"
+          kubectl kustomize "${staging}/k8s" > /dev/null
 
           flux push artifact "oci://${MANIFESTS}:sha-${SHORT}" \
             --path="${staging}" \

--- a/.github/workflows/publish-manifests.yml
+++ b/.github/workflows/publish-manifests.yml
@@ -49,7 +49,7 @@ on:
     branches: [main]
     paths:
       - "k8s/**"
-      - "deploy/k8s/**"
+      - "deploy/**"
   # Manual escape hatch: republishes from a given commit's tree. The
   # ancestor-walk image resolution keeps it honest — a tree whose history
   # contains no built image is refused before anything is published.


### PR DESCRIPTION
**Flux is currently wedged on `main`. This unwedges it.**

## What broke

#1001 added `- ../deploy/grafana` to `k8s/kustomization.yaml`. The manifest
artifact stages a **named list**, which was `k8s` and `deploy/k8s` only, so the
artifact published without `deploy/grafana` and kustomize-controller cannot
build it:

```
Ready=False (BuildFailed)
kustomize build failed: accumulating resources from '../deploy/grafana':
  no such file or directory
```

This is the quiet kind of broken. The running workload is fine and the
Kustomization still reports `Healthy=True` from its last good apply, so nothing
pages. But **every later deploy is blocked** behind a build that cannot
succeed, including the image from #1001 itself.

## Why CI did not catch it

The existing `kustomize build + kubeconform` step runs against the **full repo
checkout**, where `../deploy/grafana` resolves whether or not it was staged. It
cannot detect a staging omission by construction, so it went green on #1001
while blessing an artifact that could not be built.

## The fix

**Stage all of `deploy/` rather than a named list.** A named list has to be
updated by whoever adds a `../deploy/<x>` reference, in a different file, in a
workflow they are probably not reading. `deploy/` holds `grafana` and `k8s`
today, both consumed by the cluster.

**Build the staged tree before publishing it.** The new check builds the same
subset kustomize-controller will, so this class of omission fails in CI rather
than in the cluster.

## Verification

Both directions, locally:

- staging `k8s` + `deploy/k8s` reproduces the cluster's failure exactly
  (`accumulating resources from '../deploy/grafana'`)
- staging `k8s` + `deploy` builds **25 resources**, including the three
  `fountain-grafana-*` ConfigMaps

Workflow YAML re-parsed.

## Note for after the merge

The three dashboard ConfigMaps already exist in the cluster, created
`2026-08-22T09:13:26Z` with field manager `kubectl-client-side-apply` — they
were applied by hand and Flux has never owned them. Once this merges and Flux
reconciles, it should adopt them. Worth watching for a field-manager conflict
on that first apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)