### PR TITLE
feat(sdk): publish @agentshit/fountain-sdk 0.1.0 — with me() fixed and the ask flow answerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,11 @@ upgrade, is in
 ### Added
 
 - **The TypeScript SDK is ready to publish, and can answer a permission
-  request** (`sdk/typescript`). `fountain-sdk` goes to npm as **0.1.0**. The
-  install instructions in `README.md` and `docs/sdk.md` no longer say "build it
-  from a checkout", because there is now a package to install.
+  request** (`sdk/typescript`). It goes to npm as
+  **`@agentshit/fountain-sdk` 0.1.0** — scoped, because the `agentshit` org is
+  where Fountain's packages live. The install instructions in `README.md`,
+  `docs/sdk.md` and `docs/tour.md` no longer say "build it from a checkout",
+  because there is now a package to install.
 
   With it, the one part of the API the SDK could not drive: an agent whose
   `permission_policy` has an `ask` entry stops before the tool call, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ upgrade, is in
 
 ### Added
 
+- **The TypeScript SDK is ready to publish, and can answer a permission
+  request** (`sdk/typescript`). `fountain-sdk` goes to npm as **0.1.0**. The
+  install instructions in `README.md` and `docs/sdk.md` no longer say "build it
+  from a checkout", because there is now a package to install.
+
+  With it, the one part of the API the SDK could not drive: an agent whose
+  `permission_policy` has an `ask` entry stops before the tool call, and a
+  `permission_request` block used to reach a caller as an anonymous block with
+  no way to reply. It is now a `{ type: "permission" }` run event carrying the
+  request id, the summary and the options the agent offered, and
+  `run.answer(requestId, optionId)` (or `resume(id).answer(...)`) sends the
+  reply. An `ask` agent driven from a script previously lost every held tool
+  call to the server's deny-on-expiry.
+
 - **Five dashboards, for three teams** (`deploy/grafana/`,
   `docs/guides/operate/dashboards.md`). Fountain exported 57 Prometheus series,
   a Tempo trace stream and a PostHog event stream, and shipped one starter
@@ -203,6 +217,17 @@ upgrade, is in
   cannot be rebuilt in place, does not exist.
 
 ### Fixed
+
+- **`fountain.me()` returned `null` against a real Fountain**
+  (`sdk/typescript`). `GET /api/auth/me` is one of the nine endpoints that
+  answers with the object itself instead of `{data: …}`, and the SDK unwrapped
+  it anyway, so the call documented as "the cheapest way to check a key works"
+  handed back `null` on success. The test suite was green because the in-process
+  fake wrapped the response too, and the only test touching the path used the
+  raw `request()` escape hatch rather than the verb. The fake now answers
+  unenveloped, `me()` is tested through `me()`, and `test/server.ts` carries the
+  list of unenveloped endpoints so the next route added there is checked against
+  the real envelope.
 
 - **An opencode or gemini agent ignored its system prompt.** Both runtimes run
   with `HOME=/tmp` — a workaround for a rename that fails across

--- a/README.md
+++ b/README.md
@@ -24,12 +24,16 @@ code actually reaches for.
 | **Web UI** (`/dashboard`) | Getting started, debugging conversations, managing resources visually |
 | **REST API** (`/api/*`) | Scripting, CI/CD pipelines, integrating Fountain into your own tools |
 | **CLI** (`fountain`) | Local workflows, manifest-driven `apply`, shell scripting |
-| **TypeScript SDK** (`sdk/typescript`) | Running an agent from your own code: `fountain.run(prompt, { agent, vault })` |
+| **TypeScript SDK** (`@agentshit/fountain-sdk`) | Running an agent from your own code: `fountain.run(prompt, { agent, vault })` |
 
 The CLI and the SDK are convenience wrappers over the REST API. Everything they do, you can do with `curl`.
 
+```bash
+npm install @agentshit/fountain-sdk
+```
+
 ```ts
-import { Fountain } from "fountain-sdk";
+import { Fountain } from "@agentshit/fountain-sdk";
 
 const run = await new Fountain().run("Upgrade us to Phoenix 1.8 and open a PR", {
   agent: "reposage",

--- a/docs/build/team-chat.md
+++ b/docs/build/team-chat.md
@@ -13,7 +13,7 @@ bearer token.
 ## 1. A client
 
 ```ts
-import { Fountain } from "fountain-sdk";
+import { Fountain } from "@agentshit/fountain-sdk";
 
 const fountain = new Fountain({
   baseUrl: "https://fountain.example.com",   // your instance
@@ -202,7 +202,7 @@ Each turn is a pair of bubbles. The words, and everything the agent did about
 them. Group the feed by `turn_id` and you have both.
 
 ```ts
-import type { Block, LogEvent, Turn } from "fountain-sdk";
+import type { Block, LogEvent, Turn } from "@agentshit/fountain-sdk";
 
 function bubbles(turns: Turn[], events: LogEvent[]) {
   const byTurn = new Map<string, Block[]>();
@@ -261,7 +261,7 @@ ACP parser. Do not repeat that.
 message sent mid-turn, and the right answer is not an error toast.
 
 ```ts
-import { ConversationBusyError } from "fountain-sdk";
+import { ConversationBusyError } from "@agentshit/fountain-sdk";
 
 try {
   await fountain.team.message("watchtower", text);

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -21,12 +21,9 @@ The source lives in
 [`sdk/typescript/`](https://github.com/BinaryBourbon/fountain/tree/main/sdk/typescript).
 It has no runtime dependency, and it needs Node 20.19 or newer.
 
-!!! note "Not on npm yet"
-
-    Nobody has published the package yet. Until somebody does, build it from a
-    checkout with
-    `cd sdk/typescript && npm install && npm run build && npm link`. Then run
-    `npm link fountain-sdk` in the project that wants it.
+```bash
+npm install fountain-sdk
+```
 
 ## What the second argument is for
 
@@ -102,6 +99,32 @@ const results = await Promise.all(agents.map((agent) => fountain.run(prompt, { a
 A turn that **fails** is a result, and not an exception. So check
 `result.state`, which is `done`, `failed`, `interrupted` or `timeout`. Only a
 transport failure, a request the server rejected, or a timeout throws.
+
+## When the agent asks first
+
+An agent can hold a tool call and wait for a person. Give its
+`permission_policy` an `ask` entry, and the agent stops before that tool. The
+turn does not continue until an answer comes back.
+
+```ts
+for await (const event of run) {
+  if (event.type !== "permission") continue;
+
+  console.log(event.request.summary);
+  const allow = event.request.options.find((o) => o.kind === "allow_once");
+  await run.answer(event.request.requestId, allow.optionId);
+}
+```
+
+The `options` list holds the choices of the agent, in the order of the agent.
+Branch on `kind`, which is `allow_once`, `allow_always`, `reject_once` or
+`reject_always`. An `optionId` that the agent did not offer causes a
+`ValidationError`. To answer from a different process, use
+`fountain.resume(id).answer(...)`.
+
+A request that gets no answer expires, and the server then denies it. The turn
+continues, but the agent did not do that step. Answer each request, or give the
+agent the default `auto_allow` policy.
 
 ## A whole definition, in code
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -4,7 +4,7 @@ The REST API describes machinery. Conversations, turns, log events, blocks.
 The SDK describes the job.
 
 ```ts
-import { Fountain } from "fountain-sdk";
+import { Fountain } from "@agentshit/fountain-sdk";
 
 const fountain = new Fountain();
 
@@ -22,7 +22,7 @@ The source lives in
 It has no runtime dependency, and it needs Node 20.19 or newer.
 
 ```bash
-npm install fountain-sdk
+npm install @agentshit/fountain-sdk
 ```
 
 ## What the second argument is for
@@ -392,7 +392,7 @@ schema in Elixir reaches the SDK on the next build. A type here can never
 describe an API that has gone.
 
 ```ts
-import type { components, paths } from "fountain-sdk";
+import type { components, paths } from "@agentshit/fountain-sdk";
 
 type Teammate = components["schemas"]["Teammate"];
 ```

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -18,11 +18,11 @@ real run.
   the smallest one that works.
 
 ```bash
-npm install fountain-sdk
+npm install @agentshit/fountain-sdk
 ```
 
 ```ts
-import { Fountain } from "fountain-sdk";
+import { Fountain } from "@agentshit/fountain-sdk";
 
 const fountain = new Fountain();          // FOUNTAIN_API_KEY
 const REPO = "https://github.com/you/your-app";

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -18,7 +18,7 @@ real run.
   the smallest one that works.
 
 ```bash
-npm install fountain-sdk   # see the SDK page: not on npm yet, build from the repo
+npm install fountain-sdk
 ```
 
 ```ts

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Notable changes to `fountain-sdk`. Format:
+Notable changes to `@agentshit/fountain-sdk`. Format:
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+Notable changes to `fountain-sdk`. Format:
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
+[SemVer](https://semver.org/).
+
+The SDK versions independently of the Fountain server. It talks to the REST
+API, which is additive, so a given SDK release keeps working against later
+server releases.
+
+---
+
+## [0.1.0] — unreleased
+
+First published release.
+
+### Added
+
+- `fountain.run(prompt, { agent, vault, environment })` — one call that
+  provisions a sandbox, runs the agent in it and folds the log feed into an
+  answer. `await` it, `for await` it, or read `.textStream`; all three are
+  views of one run.
+- `fountain.resume(id)` — the sandbox and the agent's session are still there,
+  so a follow-up costs one prompt rather than a re-explanation.
+- `agents`, `environments`, `vaults` — list, read, create, update, delete, and
+  write-only secrets. All of them take a **name** where an id would do.
+- `team` — teammates, their standing threads, and their routines.
+- Streams that reconnect from a cursor, so a deploy mid-turn neither drops the
+  answer nor replays it.
+- Errors keyed on the API's `error` code rather than the status, because
+  `conversation_busy` is a 400, `sandbox_quota_exceeded` a 429 and
+  `provisioning` a 503, and what a caller does about each is unrelated to the
+  number. Every error carries `retryable`.
+- `run.answer(requestId, optionId)` and `resume(id).answer(...)`, with a
+  `{ type: "permission" }` run event, for agents whose `permission_policy` has
+  an `ask` entry.
+- Types generated from the server's own OpenAPI document, with CI failing on
+  any drift between the two.
+- A browser entry with no Node built-in reachable from it, and a Node entry
+  that adds `~/.fountain/credentials`.
+
+[0.1.0]: https://github.com/BinaryBourbon/fountain/tree/main/sdk/typescript

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,9 +1,9 @@
-# fountain-sdk
+# @agentshit/fountain-sdk
 
 Give an agent a computer, your repos and your credentials — in one call.
 
 ```ts
-import { Fountain } from "fountain-sdk";
+import { Fountain } from "@agentshit/fountain-sdk";
 
 const fountain = new Fountain();
 
@@ -91,7 +91,7 @@ tests.
 ## Install
 
 ```bash
-npm install fountain-sdk
+npm install @agentshit/fountain-sdk
 ```
 
 Node 20.19+ (native `fetch` and ESM). No runtime dependencies.
@@ -327,7 +327,7 @@ sent more than one person hunting through their own code.
 
 `src/generated/openapi.ts` is produced from the same OpenAPI document the
 server serves, and CI regenerates it and fails on a diff — so the types cannot
-drift from the API. `import type { components, paths } from "fountain-sdk"` for
+drift from the API. `import type { components, paths } from "@agentshit/fountain-sdk"` for
 the raw shapes. What is hand-written is what a spec cannot express: that many
 log events fold into one turn, and which of 85 paths are worth a verb.
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -90,14 +90,9 @@ tests.
 
 ## Install
 
-**Not on npm yet.** Until it is published, install it from a checkout:
-
 ```bash
-cd sdk/typescript && npm install && npm run build && npm link
-npm link fountain-sdk            # in the project that wants it
+npm install fountain-sdk
 ```
-
-Once published, it will be `npm install fountain-sdk`.
 
 Node 20.19+ (native `fetch` and ESM). No runtime dependencies.
 
@@ -166,6 +161,32 @@ A `RunResult` is:
 A turn that **fails** is a result, not an exception — the agent ran and has
 something to say about it. Check `state`. Only a transport failure, a rejected
 request or a timeout throws.
+
+## When the agent asks first
+
+An agent whose `permission_policy` has an `ask` entry stops before the tool
+call and waits to be told. Nothing else in the turn moves until it is answered,
+and an unanswered request is denied when it expires — so an `ask` agent driven
+by a caller that ignores these finishes having quietly skipped the work.
+
+```ts
+for await (const event of run) {
+  if (event.type !== "permission") continue;
+
+  console.log(event.request.summary);          // "Run rm -rf build"
+  const allow = event.request.options.find((o) => o.kind === "allow_once");
+  await run.answer(event.request.requestId, allow!.optionId);
+}
+```
+
+`options` is whatever the agent offered, in its order; `kind` is the part worth
+branching on (`allow_once`, `allow_always`, `reject_once`, `reject_always`).
+Sending an id the agent did not offer is a `ValidationError`, not a forwarded
+answer. `resume(id).answer(...)` is the same call from a process that is not
+the one following the turn.
+
+The default policy is `auto_allow` and never asks, so this is opt-in per agent.
+`opencode` never asks at all and refuses anything stricter than `auto_allow`.
 
 ## Defining what you run
 
@@ -272,6 +293,23 @@ if (error instanceof ValidationError) …         // error.fieldErrors
 
 Every error carries `status`, `code`, `body`, `retryAfter` and `retryable`.
 
+| class | when |
+|---|---|
+| `AuthError` | 401, or no key configured at all |
+| `SubscriptionRequiredError` | 402 — carries `upgradeUrl` |
+| `NotFoundError` | 404 — wrong id, or it belongs to another account |
+| `ValidationError` | 422 — read `fieldErrors` |
+| `RateLimitError` | 429 |
+| `ConversationBusyError` | the agent is still on the previous prompt |
+| `QuotaExceededError` | at the concurrent-sandbox cap — `activeSandboxes` / `limit` |
+| `NotReadyError` | the sandbox is still coming up — retry after `retryAfter` |
+| `TimeoutError` | the SDK stopped waiting — carries `conversationId` and `partialText` |
+| `ResolutionError` | a name matched no agent/vault/environment, or matched several |
+| `ConnectionError` | the request never reached Fountain — in a browser, usually CORS |
+
+A `ResolutionError` names what the account actually has, so a typo is a
+one-line fix rather than a trip to the console.
+
 ## In a browser
 
 The default entry imports no Node built-in, so it bundles as-is; the
@@ -327,23 +365,6 @@ try {
 - `run.interrupt()` — ask the agent to stop the turn. The sandbox stays up.
 - `run.terminate()` — tear the sandbox down. Nothing resumes after this.
 
-## Errors
-
-Every failure is a `FountainError` with `status`, `code` and `body`:
-
-| class | when |
-|---|---|
-| `AuthError` | 401, or no key configured at all |
-| `SubscriptionRequiredError` | 402 — carries `upgradeUrl` |
-| `NotFoundError` | 404 — wrong id, or it belongs to another account |
-| `ValidationError` | 422 |
-| `RateLimitError` | 429 |
-| `TimeoutError` | the SDK stopped waiting — carries `conversationId` and `partialText` |
-| `ResolutionError` | a name matched no agent/vault/environment, or matched several |
-
-A `ResolutionError` names what the account actually has, so a typo is a
-one-line fix rather than a trip to the console.
-
 ## The rest of the API
 
 The verbs above are the ones worth wrapping. Everything else Fountain exposes —
@@ -377,6 +398,31 @@ The tests run a fake Fountain over real HTTP and real SSE, including the parts
 that are easy to get wrong: a connection that dies mid-turn, output belonging
 to another turn, and the two different ways runtimes chunk their text.
 
+`npm test` runs the TypeScript sources directly, which needs Node 22.6+ even
+though the published package only needs 20.19 — the tarball is compiled. CI
+runs on Node 24.
+
+A route added to `test/server.ts` has to answer in the same envelope the real
+one does. Nearly everything is `{data: …}`; the nine that are not are listed at
+the top of that file. A fake that wraps one of those turns a green suite into a
+lie, which is how `me()` shipped returning `null`.
+
+### Releasing
+
+The version lives in `package.json` and is asserted against `USER_AGENT` by a
+test, so a bump that misses one fails rather than shipping a lie.
+
+```bash
+npm version patch          # or minor — updates package.json, tags
+npm publish                # prepublishOnly runs typecheck, tests and build
+```
+
+Add the release to `CHANGELOG.md` in the same commit, and check that
+`docs/sdk.md` still describes what shipped.
+
 ## License
 
-MIT, same as Fountain.
+[Apache-2.0](LICENSE). Fountain is not licensed as a single unit: the server is
+AGPL-3.0-or-later, and the clients — this SDK and the CLI — are Apache-2.0 on
+purpose. Talking to the API, or shipping this SDK inside a proprietary
+application, puts no licence obligation on your code.

--- a/sdk/typescript/examples/permissions.ts
+++ b/sdk/typescript/examples/permissions.ts
@@ -1,0 +1,48 @@
+/**
+ * Sit in front of an agent and approve its tool calls one at a time.
+ *
+ * The agent needs an `ask` entry in its `permission_policy` — the default is
+ * `auto_allow`, which never asks. `execute` is the one worth holding, because
+ * it is the kind that runs commands:
+ *
+ *   await fountain.agents.update("<agent>", {
+ *     permission_policy: { execute: "ask", default: "auto_allow" },
+ *   });
+ *
+ *   FOUNTAIN_API_KEY=... node examples/permissions.ts "<agent>"
+ *
+ * Answer promptly. A request that expires is denied, and the turn carries on
+ * without that step — so ignoring these is not the same as allowing them.
+ */
+import { Fountain } from "../src/index.ts";
+
+const agent = process.argv[2] ?? "smoke-runner";
+const fountain = new Fountain();
+
+const run = fountain.run("Count the lines of TypeScript in this repo.", { agent });
+
+console.log(`watch: ${await run.url}\n`);
+
+for await (const event of run) {
+  if (event.type === "text") process.stdout.write(event.text);
+  if (event.type !== "permission") continue;
+
+  const { requestId, summary, toolName, options } = event.request;
+  console.log(`\n? ${summary ?? toolName ?? "the agent wants to run a tool"}`);
+  console.log(`  ${options.map((o) => `${o.optionId} (${o.kind})`).join("  ")}`);
+
+  // Approve reads, refuse anything else. A real caller would ask a person —
+  // and would have the whole `options` list to offer them, in the agent's own
+  // order, rather than assuming two choices.
+  const wanted = /^(ls|cat|rg|grep|wc|find)\b/.test(summary ?? "") ? "allow_once" : "reject_once";
+  const choice = options.find((o) => o.kind === wanted) ?? options[0];
+  if (!choice) continue;
+
+  console.log(`> ${choice.optionId}`);
+  await run.answer(requestId, choice.optionId);
+}
+
+const result = await run;
+console.log(`\n· ${result.state}`);
+
+await fountain.resume(result.conversationId).terminate();

--- a/sdk/typescript/examples/pull-request.ts
+++ b/sdk/typescript/examples/pull-request.ts
@@ -16,7 +16,7 @@
  * (Inside this repository the import below resolves to the SDK itself, so run
  * `npm run build` in sdk/typescript first. Installed from npm it just works.)
  */
-import { Fountain } from "fountain-sdk";
+import { Fountain } from "@agentshit/fountain-sdk";
 
 const repo = process.env.REPO_URL;
 const token = process.env.GITHUB_TOKEN;

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "fountain-sdk",
+  "name": "@agentshit/fountain-sdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fountain-sdk",
+      "name": "@agentshit/fountain-sdk",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",
         "openapi-typescript": "^7.13.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "fountain-sdk",
+  "name": "@agentshit/fountain-sdk",
   "version": "0.1.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "engines": {
     "node": ">=20.19"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -35,7 +35,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -162,7 +162,7 @@ export class Fountain {
    *
    * `request`, not `data`: this is one of the few endpoints that answers with
    * the object itself rather than `{data: …}`, so unwrapping would hand back
-   * `null` for a call that succeeded. See `UNENVELOPED` in `test/server.ts`.
+   * `null` for a call that succeeded. `test/server.ts` lists the others.
    */
   async me(): Promise<AuthMe> {
     return this.api.request<AuthMe>("GET", "/api/auth/me");

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -144,16 +144,28 @@ export class Fountain {
     return new Conversation(this.api, conversationId);
   }
 
-  /** The account's conversations, newest first. */
+  /**
+   * The account's conversations, newest first.
+   *
+   * Roots only by default: a conversation an agent spawned from inside a
+   * sandbox is listed under its parent's tree, not again at the top level.
+   * Pass `{ rootsOnly: false }` for the flat list, children included.
+   */
   async conversations(opts: { rootsOnly?: boolean } = {}): Promise<ConversationRecord[]> {
     return this.api.list<ConversationRecord>("/api/conversations", {
       query: { roots_only: opts.rootsOnly === false ? undefined : "true" },
     });
   }
 
-  /** Who this key belongs to. The cheapest way to check a key works. */
+  /**
+   * Who this key belongs to. The cheapest way to check a key works.
+   *
+   * `request`, not `data`: this is one of the few endpoints that answers with
+   * the object itself rather than `{data: …}`, so unwrapping would hand back
+   * `null` for a call that succeeded. See `UNENVELOPED` in `test/server.ts`.
+   */
   async me(): Promise<AuthMe> {
-    return this.api.data<AuthMe>("GET", "/api/auth/me");
+    return this.api.request<AuthMe>("GET", "/api/auth/me");
   }
 
   /**

--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -35,7 +35,7 @@ function unquote(value: string): string {
  *
  * The eleven apps built on Fountain so far are browser apps, and a bare
  * `import "node:fs"` at the top of this module breaks their bundles. So the
- * file reader is injected: `fountain-sdk` resolves to a Node entry that
+ * file reader is injected: `@agentshit/fountain-sdk` resolves to a Node entry that
  * installs one, and to this browser-safe module everywhere else. Nothing here
  * touches a Node built-in.
  */

--- a/sdk/typescript/src/conversation.ts
+++ b/sdk/typescript/src/conversation.ts
@@ -81,6 +81,31 @@ export class Conversation {
   }
 
   /**
+   * Answer a permission request the agent is holding a tool call on.
+   *
+   * `optionId` has to be one of the ids the agent offered on the
+   * `permission_request` block — the server refuses anything else with a 422
+   * rather than forwarding it. Answer promptly: the request expires, and an
+   * expired one is denied.
+   *
+   * ```ts
+   * for await (const event of run) {
+   *   if (event.type === "permission") {
+   *     const allow = event.request.options.find((o) => o.kind === "allow_once");
+   *     if (allow) await conversation.answer(event.request.requestId, allow.optionId);
+   *   }
+   * }
+   * ```
+   */
+  async answer(requestId: string, optionId: string): Promise<void> {
+    await this.http.request(
+      "POST",
+      `/api/conversations/${this.id}/requests/${encodeURIComponent(requestId)}`,
+      { body: { option_id: optionId } },
+    );
+  }
+
+  /**
    * Mark everything so far as read, clearing the teammate's unread badge.
    *
    * Every application built on Fountain calls this — it is what stops a UI

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -13,6 +13,12 @@ export interface RequestOptions {
   accept?: string;
 }
 
+/**
+ * The product token this client sends. Deliberately not the package name: a
+ * scope reads as a second token in a User-Agent (`@agentshit/…/0.1.0`), and
+ * this string is already what Fountain's request logs are keyed on. The
+ * version half is asserted against `package.json` by a test.
+ */
 export const USER_AGENT = "fountain-sdk-js/0.1.0";
 
 /**

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -40,6 +40,8 @@ export type {
   EnvironmentInput,
   LogEvent,
   NamedResource,
+  PermissionOption,
+  PermissionRequest,
   Stream,
   TeamEvent,
   Repository,

--- a/sdk/typescript/src/node.ts
+++ b/sdk/typescript/src/node.ts
@@ -3,7 +3,7 @@
  *
  * Everything the SDK does works in a browser, and `src/index.ts` is what a
  * bundler gets. The one thing that cannot work there is reading
- * `~/.fountain/credentials`, so that lives here: importing `fountain-sdk`
+ * `~/.fountain/credentials`, so that lives here: importing `@agentshit/fountain-sdk`
  * under Node resolves to this module, which installs the reader and then
  * re-exports the same API.
  */

--- a/sdk/typescript/src/resources.ts
+++ b/sdk/typescript/src/resources.ts
@@ -3,11 +3,14 @@ import type { Resolver } from "./resolve.ts";
 import type {
   Agent,
   AgentInput,
+  AgentPatch,
   Environment,
   EnvironmentInput,
+  EnvironmentPatch,
   Secret,
   Vault,
   VaultInput,
+  VaultPatch,
 } from "./types.ts";
 
 /**
@@ -20,8 +23,14 @@ import type {
  * because those are not data.
  */
 
-/** List, read, define, change and delete one kind of thing. */
-class Collection<T extends { id: string }, Input> {
+/**
+ * List, read, define, change and delete one kind of thing.
+ *
+ * `Patch` is its own parameter rather than `Partial<Input>`: the API's update
+ * schemas are not simply every create field made optional, and the generated
+ * ones say so exactly.
+ */
+class Collection<T extends { id: string }, Input, Patch> {
   protected readonly http: HttpClient;
   protected readonly resolver: Resolver;
   protected readonly path: string;
@@ -54,7 +63,7 @@ class Collection<T extends { id: string }, Input> {
   }
 
   /** Change one. Only the fields you pass are touched. */
-  async update(nameOrId: string, patch: Partial<Input>): Promise<T> {
+  async update(nameOrId: string, patch: Patch): Promise<T> {
     const { id } = await this.resolver.resolve(this.path, this.what, nameOrId);
     const updated = await this.http.data<T>("PATCH", `${this.path}/${id}`, { body: patch });
     // The patch may have renamed it.
@@ -128,14 +137,14 @@ class Secrets {
 }
 
 /** The agents on this account. */
-export class Agents extends Collection<Agent, AgentInput> {
+export class Agents extends Collection<Agent, AgentInput, AgentPatch> {
   constructor(http: HttpClient, resolver: Resolver) {
     super(http, resolver, "/api/agents", "agent");
   }
 }
 
 /** The environments on this account, and their secrets. */
-export class Environments extends Collection<Environment, EnvironmentInput> {
+export class Environments extends Collection<Environment, EnvironmentInput, EnvironmentPatch> {
   readonly secrets: Secrets;
 
   constructor(http: HttpClient, resolver: Resolver) {
@@ -145,7 +154,7 @@ export class Environments extends Collection<Environment, EnvironmentInput> {
 }
 
 /** The vaults on this account, and their secrets. */
-export class Vaults extends Collection<Vault, VaultInput> {
+export class Vaults extends Collection<Vault, VaultInput, VaultPatch> {
   readonly secrets: Secrets;
 
   constructor(http: HttpClient, resolver: Resolver) {

--- a/sdk/typescript/src/run.ts
+++ b/sdk/typescript/src/run.ts
@@ -96,6 +96,32 @@ export class Run implements Promise<RunResult>, AsyncIterable<RunEvent> {
     this.abort.abort();
   }
 
+  /**
+   * Answer a permission request this turn is blocked on — the `requestId` and
+   * the `optionId` both come off a `{ type: "permission" }` event.
+   *
+   * ```ts
+   * for await (const event of run) {
+   *   if (event.type === "permission") {
+   *     const allow = event.request.options.find((o) => o.kind === "allow_once");
+   *     if (allow) await run.answer(event.request.requestId, allow.optionId);
+   *   }
+   * }
+   * ```
+   *
+   * Only an agent with an `ask` entry in its `permission_policy` produces
+   * these. Leave them unanswered and the server denies each one when it
+   * expires, so the turn finishes having skipped the work.
+   */
+  async answer(requestId: string, optionId: string): Promise<void> {
+    const id = await this.conversationId;
+    await this.http.request(
+      "POST",
+      `/api/conversations/${id}/requests/${encodeURIComponent(requestId)}`,
+      { body: { option_id: optionId } },
+    );
+  }
+
   /** Ask the agent to stop the turn it is on. The sandbox stays up. */
   async interrupt(): Promise<void> {
     const id = await this.conversationId;

--- a/sdk/typescript/src/turn.ts
+++ b/sdk/typescript/src/turn.ts
@@ -1,4 +1,4 @@
-import type { Block, LogEvent, RunEvent, TurnState } from "./types.ts";
+import type { Block, LogEvent, PermissionOption, PermissionRequest, RunEvent, TurnState } from "./types.ts";
 
 const TERMINAL_TURN_STATES = new Set(["done", "failed", "interrupted"]);
 
@@ -125,6 +125,14 @@ export class TurnFollower {
 
     this.breakBeforeText = true;
 
+    // The turn is now blocked until somebody answers. Surface it as its own
+    // event rather than a bare block, because a caller that does not handle it
+    // loses the tool call to the server's deny-on-timeout.
+    if (block.kind === "permission_request") {
+      const request = toPermissionRequest(block);
+      return request ? [{ type: "permission", request, block }] : [];
+    }
+
     if (block.kind === "tool_use") {
       const name = asString(block.name);
       if (!name) return [];
@@ -157,6 +165,37 @@ export class TurnFollower {
     const last = this.chunks[this.chunks.length - 1] ?? "";
     return last.endsWith("\n") ? "" : "\n\n";
   }
+}
+
+/**
+ * Read a `permission_request` block into something answerable.
+ *
+ * No `request_id` means there is nothing a caller could send back, and an
+ * empty `options` list means there is nothing they could choose — either way
+ * the block is a notice, not a question, so it is dropped rather than handed
+ * over as a request that cannot be answered.
+ */
+function toPermissionRequest(block: Block): PermissionRequest | null {
+  const requestId = asString(block.request_id);
+  if (!requestId) return null;
+
+  const options: PermissionOption[] = [];
+  for (const raw of block.options ?? []) {
+    if (!raw || typeof raw !== "object") continue;
+    const option = raw as Record<string, unknown>;
+    const optionId = asString(option.optionId) ?? asString(option.option_id);
+    if (!optionId) continue;
+    options.push({ ...option, optionId });
+  }
+  if (!options.length) return null;
+
+  return {
+    requestId,
+    summary: asString(block.summary) ?? asString(block.body),
+    toolName: asString(block.name),
+    toolId: asString(block.tool_id),
+    options,
+  };
 }
 
 function parseJson(raw: unknown): Record<string, unknown> | null {

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -72,6 +72,40 @@ export interface TeamEvent extends LogEvent {
 /** The log-event streams a conversation carries. */
 export type Stream = "stdout" | "stderr" | "acp" | "stage";
 
+/**
+ * One choice an agent offered when it asked permission. `optionId` is what an
+ * answer sends back; `kind` is the vocabulary a UI can render without reading
+ * the label (`allow_once`, `allow_always`, `reject_once`, `reject_always`, …).
+ * Runtimes may add fields, so the rest is left open.
+ */
+export interface PermissionOption {
+  optionId: string;
+  kind?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * The agent is holding a tool call, waiting to be told whether to run it.
+ *
+ * Only agents with an `ask` entry in `permission_policy` produce these; the
+ * default is `auto_allow` and never asks. Nothing else in the turn advances
+ * until this is answered, and if nobody answers before the server's timeout it
+ * is denied — so a caller that ignores these on an `ask` agent gets a turn that
+ * does less than it was told to, not an error.
+ */
+export interface PermissionRequest {
+  /** Pass this to `answer`. */
+  requestId: string;
+  /** What the agent wants to do, in the runtime's words. */
+  summary: string | null;
+  /** The tool it is asking about. Claude titles this with the command itself. */
+  toolName: string | null;
+  toolId: string | null;
+  /** The choices the agent offered, in its order. Answer with one of these. */
+  options: PermissionOption[];
+}
+
 /** How a turn ended. `timeout` means the SDK stopped waiting, not that the agent did. */
 export type TurnState = "done" | "failed" | "interrupted" | "timeout";
 
@@ -82,6 +116,7 @@ export type RunEvent =
   | { type: "text"; text: string }
   | { type: "thinking"; text: string }
   | { type: "tool"; name: string; block: Block }
+  | { type: "permission"; request: PermissionRequest; block: Block }
   | { type: "block"; block: Block; event: LogEvent }
   | { type: "event"; event: LogEvent }
   | { type: "turn-end"; state: TurnState; exitCode: number | null; reason: string | null };

--- a/sdk/typescript/test/config.test.ts
+++ b/sdk/typescript/test/config.test.ts
@@ -1,12 +1,13 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 // Importing the Node entry is what installs the credentials-file reader; the
 // browser entry deliberately has none. Doing it here tests that wiring too.
 import "../src/node.ts";
 import { resolveConfig, conversationUrl, DEFAULT_BASE_URL } from "../src/config.ts";
+import { USER_AGENT } from "../src/http.ts";
 
 const VARS = [
   "FOUNTAIN_API_KEY",
@@ -121,5 +122,15 @@ describe("conversationUrl", () => {
   test("a deployment with no app falls back to something fetchable", () => {
     const config = resolveConfig({ baseUrl: "https://self.hosted", appUrl: "" });
     assert.equal(conversationUrl("abc", config), "https://self.hosted/api/conversations/abc");
+  });
+});
+
+describe("the version the server sees", () => {
+  // `USER_AGENT` is a literal, because importing package.json would need a JSON
+  // import attribute in every consumer's bundler. A literal drifts silently, so
+  // it is asserted instead: bump the version, and this says where else to.
+  test("USER_AGENT carries the published version", () => {
+    const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+    assert.equal(USER_AGENT, `fountain-sdk-js/${pkg.version}`);
   });
 });

--- a/sdk/typescript/test/run.test.ts
+++ b/sdk/typescript/test/run.test.ts
@@ -30,6 +30,8 @@ beforeEach(() => {
   fake.onTurn = null;
   fake.dieAfterEvents = null;
   fake.failNextWith = null;
+  fake.onAnswer = null;
+  fake.answers.length = 0;
 });
 
 describe("run", () => {
@@ -362,15 +364,112 @@ describe("errors", () => {
     );
   });
 
+  // An `ask` policy holds the tool call until somebody answers, and denies it
+  // when nobody does. The SDK has to both surface the question and be able to
+  // answer it, or an `ask` agent silently does less than it was asked to.
+  test("a held tool call is surfaced, answered, and the turn then finishes", async () => {
+    fake.onTurn = (conversation) => {
+      fake.emit(conversation.id, {
+        kind: "stage",
+        stage: "turn",
+        state: "started",
+        stream: "stage",
+        data: JSON.stringify({ turn_number: 1, turn_id: "t1" }),
+      });
+      fake.emit(conversation.id, {
+        kind: "output",
+        stream: "acp",
+        turn_id: "t1",
+        blocks: [
+          {
+            kind: "permission_request",
+            request_id: "req-7",
+            summary: "Run the migration",
+            options: [
+              { optionId: "opt-allow", kind: "allow_once" },
+              { optionId: "opt-deny", kind: "reject_once" },
+            ],
+          },
+        ],
+      });
+      // and then nothing: the turn is held open until the answer arrives.
+    };
+
+    fake.onAnswer = (conversationId) => {
+      fake.emit(conversationId, {
+        kind: "output",
+        stream: "acp",
+        turn_id: "t1",
+        blocks: [{ kind: "text", body: "Migration applied." }],
+      });
+      fake.emit(conversationId, {
+        kind: "stage",
+        stage: "turn",
+        state: "done",
+        stream: "stage",
+        data: JSON.stringify({ turn_number: 1, turn_id: "t1" }),
+      });
+    };
+
+    // A deadline so a regression fails in five seconds instead of hanging CI:
+    // if the ask is never surfaced, nothing answers it and the turn never ends.
+    const run = client().run("Migrate the database", { agent: "reposage", timeoutMs: 5_000 });
+
+    let asked = 0;
+    for await (const event of run) {
+      if (event.type !== "permission") continue;
+      asked++;
+      assert.equal(event.request.summary, "Run the migration");
+      const allow = event.request.options.find((option) => option.kind === "allow_once");
+      assert.ok(allow, "the allow option must survive the trip");
+      await run.answer(event.request.requestId, allow.optionId);
+    }
+
+    const result = await run;
+    assert.equal(asked, 1);
+    assert.equal(result.state, "done");
+    assert.equal(result.text, "Migration applied.");
+    assert.deepEqual(
+      fake.answers.map((a) => [a.requestId, a.optionId]),
+      [["req-7", "opt-allow"]],
+    );
+  });
+
+  test("answering through a resumed conversation hits the same endpoint", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.scriptTurn(conversation.id, { turnNumber, turnId: "t1", text: ["ok"] });
+    };
+    const run = client().run("go", { agent: "reposage" });
+    const id = await run.conversationId;
+    await run;
+
+    await client().resume(id).answer("req-9", "opt-deny");
+    assert.deepEqual(fake.answers.at(-1), {
+      conversationId: id,
+      requestId: "req-9",
+      optionId: "opt-deny",
+    });
+  });
+
   test("a missing key fails before any request", async () => {
     const bare = new Fountain({ baseUrl, apiKey: "", profile: "no-such-profile" });
     await assert.rejects(() => bare.me(), /No Fountain API key/);
+  });
+
+  // `/api/auth/me` answers with the identity itself, not `{data: …}`. Unwrapping
+  // it returned `null` for a call that had succeeded, and nothing caught that
+  // because the fake wrapped it too and the only test called `request()`.
+  test("me() returns the identity, which the endpoint sends unenveloped", async () => {
+    const me = await client().me();
+    assert.equal(me.email, "test@example.com");
+    assert.equal(me.role, "user");
+    assert.ok(me.id, "an identity with no id means the envelope was unwrapped away");
   });
 });
 
 describe("escape hatch", () => {
   test("api reaches endpoints the SDK does not wrap", async () => {
-    const me = await client().request<{ data: { email: string } }>("GET", "/api/auth/me");
-    assert.equal(me.data.email, "test@example.com");
+    const me = await client().request<{ email: string }>("GET", "/api/auth/me");
+    assert.equal(me.email, "test@example.com");
   });
 });

--- a/sdk/typescript/test/server.ts
+++ b/sdk/typescript/test/server.ts
@@ -5,6 +5,26 @@
  * server that can hand out a feed on demand — including the awkward parts: a
  * connection that dies mid-turn, output belonging to somebody else's turn, an
  * ACP runtime that streams a sentence as five chunks.
+ *
+ * **A route here must answer in the same envelope the real one does.** Almost
+ * everything is wrapped in `{data: …}`, and a fake that wraps one of the few
+ * that are not turns a green suite into a lie — `me()` shipped returning `null`
+ * against production for exactly that reason, because this file wrapped
+ * `/api/auth/me` and the only test that touched the path called `request()`
+ * rather than the verb. The unwrapped ones, from the OpenAPI document:
+ *
+ *   GET  /api/auth/me
+ *   POST /api/auth/api-keys
+ *   POST /api/conversations/{id}/prompts
+ *   POST /api/conversations/{id}/requests/{request_id}
+ *   POST /api/team/{agent_id}/messages
+ *   POST /api/team/{agent_id}/schedules/{id}/run
+ *   POST /api/webhooks/{id}/test
+ *   POST /api/webhooks/{id}/deliveries/{delivery_id}/redeliver
+ *   GET  /health, GET /health/ready
+ *
+ * Regenerate that list against a fresh spec rather than trusting it to age
+ * well: `jq` the schemas whose 2xx body has no `data` property.
  */
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -69,6 +89,10 @@ export class FakeFountain {
   failNextWith: { status: number; body: unknown; retryAfter?: number } | null = null;
   /** Teammates that answer `conversation_busy` instead of taking a message. */
   readonly busyTeammates = new Set<string>();
+  /** Every permission answer that arrived, in order. */
+  readonly answers: { conversationId: string; requestId: string; optionId: string }[] = [];
+  /** Called when one lands — script the rest of the held turn from here. */
+  onAnswer: ((conversationId: string, requestId: string, optionId: string) => void) | null = null;
 
   private nextEventId = 1;
   private nextConversation = 1;
@@ -177,7 +201,10 @@ export class FakeFountain {
 
     const path = url.pathname;
 
-    if (path === "/api/auth/me") return json(res, 200, { data: { email: "test@example.com" } });
+    // Unenveloped, exactly as the real server answers it. See UNENVELOPED.
+    if (path === "/api/auth/me") {
+      return json(res, 200, { id: "user-1", email: "test@example.com", role: "user", email_verified: true });
+    }
     if (path === "/api/catalog") return json(res, 200, { data: this.catalog });
     if (path === "/api/search") return json(res, 200, { data: [{ conversation_id: "conv-1", snippet: "hit" }] });
 
@@ -218,6 +245,20 @@ export class FakeFountain {
         this.onTurn?.(conversation, turnNumber);
         return;
       }
+      // Answering a held tool call. Unenveloped, like the real one.
+      const answering = /^\/requests\/([^/]+)$/.exec(rest);
+      if (answering && req.method === "POST") {
+        const optionId = (body as { option_id?: unknown } | null)?.option_id;
+        if (typeof optionId !== "string" || !optionId) {
+          return json(res, 422, { error: "unprocessable_entity", errors: { option_id: ["is required"] } });
+        }
+        const requestId = decodeURIComponent(answering[1] as string);
+        this.answers.push({ conversationId: conversation.id, requestId, optionId });
+        json(res, 200, { ok: true });
+        this.onAnswer?.(conversation.id, requestId, optionId);
+        return;
+      }
+
       if (rest === "/interrupt" || rest === "/terminate") return json(res, 200, { status: "ok" });
       if (rest === "/read" && req.method === "POST") return json(res, 204, null);
       if (rest === "/tree") return json(res, 200, { data: { id: conversation.id, children: [] } });

--- a/sdk/typescript/test/server.ts
+++ b/sdk/typescript/test/server.ts
@@ -11,7 +11,7 @@
  * that are not turns a green suite into a lie — `me()` shipped returning `null`
  * against production for exactly that reason, because this file wrapped
  * `/api/auth/me` and the only test that touched the path called `request()`
- * rather than the verb. The unwrapped ones, from the OpenAPI document:
+ * rather than the verb. The unenveloped ones, from the OpenAPI document:
  *
  *   GET  /api/auth/me
  *   POST /api/auth/api-keys
@@ -201,7 +201,7 @@ export class FakeFountain {
 
     const path = url.pathname;
 
-    // Unenveloped, exactly as the real server answers it. See UNENVELOPED.
+    // Unenveloped, exactly as the real server answers it — see the note above.
     if (path === "/api/auth/me") {
       return json(res, 200, { id: "user-1", email: "test@example.com", role: "user", email_verified: true });
     }

--- a/sdk/typescript/test/sse.test.ts
+++ b/sdk/typescript/test/sse.test.ts
@@ -124,6 +124,58 @@ describe("TurnFollower", () => {
     assert.equal(follower.reason, "oom");
   });
 
+  test("a permission request becomes an answerable event", () => {
+    const follower = new TurnFollower(1);
+    follower.apply(stage("started", { turn_number: 1, turn_id: "t1" }));
+    const events = follower.apply(
+      output(
+        [
+          {
+            kind: "permission_request",
+            request_id: "req-1",
+            name: "rm -rf build",
+            tool_id: "tool-9",
+            summary: "Run rm -rf build",
+            options: [
+              { optionId: "allow", kind: "allow_once", name: "Allow once" },
+              { optionId: "deny", kind: "reject_once", name: "Deny" },
+            ],
+          },
+        ],
+        "t1",
+      ),
+    );
+
+    const ask = events.find((e) => e.type === "permission");
+    assert.ok(ask, "a permission_request block must surface as its own event");
+    assert.equal(ask.request.requestId, "req-1");
+    assert.equal(ask.request.summary, "Run rm -rf build");
+    assert.equal(ask.request.toolName, "rm -rf build");
+    assert.equal(ask.request.toolId, "tool-9");
+    assert.deepEqual(
+      ask.request.options.map((o) => o.optionId),
+      ["allow", "deny"],
+    );
+    // Asking is not saying, and it is not a tool the agent got to use.
+    assert.equal(follower.text, "");
+    assert.deepEqual(follower.toolsUsed, []);
+  });
+
+  test("an unanswerable ask is dropped rather than handed over", () => {
+    const follower = new TurnFollower(1);
+    follower.apply(stage("started", { turn_number: 1, turn_id: "t1" }));
+
+    const noId = follower.apply(
+      output([{ kind: "permission_request", options: [{ optionId: "allow" }] }], "t1"),
+    );
+    assert.equal(noId.some((e) => e.type === "permission"), false);
+
+    const noOptions = follower.apply(
+      output([{ kind: "permission_request", request_id: "req-2", options: [] }], "t1"),
+    );
+    assert.equal(noOptions.some((e) => e.type === "permission"), false);
+  });
+
   test("matches on turn_id once known, even if the turn number drifts", () => {
     const follower = new TurnFollower(3);
     follower.apply(stage("started", { turn_number: 3, turn_id: "t3" }));

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -22,7 +22,7 @@
     // it. Node resolves that through this package's own `exports` (to `dist`);
     // this mapping points the *typechecker* at the sources instead, so a
     // typecheck never depends on a build having happened first.
-    "paths": { "fountain-sdk": ["./src/node.ts"] }
+    "paths": { "@agentshit/fountain-sdk": ["./src/node.ts"] }
   },
   "include": ["src/**/*.ts", "test/**/*.ts", "examples/**/*.ts"]
 }


### PR DESCRIPTION
Everything between `fountain-sdk` and its first npm release.

## The two that mattered

**`fountain.me()` returned `null` against a real Fountain.** `GET /api/auth/me`
is one of nine endpoints that answer with the object itself rather than
`{data: …}`, and the SDK unwrapped it anyway. The call whose docstring calls it
"the cheapest way to check a key works" answered `null` on success.

The suite was green because `test/server.ts` wrapped the response too, and the
only test touching that path used the raw `request()` escape hatch rather than
the verb — so `me()` had never been exercised. The fake now answers
unenveloped, `me()` is tested through `me()`, and that file carries the list of
unenveloped endpoints, because a fake that disagrees with the server turns a
green suite into a lie.

**An `ask` agent had no way to answer.** The server emits a
`permission_request` block with a request id and the options the agent offered,
and takes the reply at `POST /conversations/:id/requests/:rid` (#950). The SDK
surfaced neither, so the block reached a caller anonymously with nothing to
answer it — and an unanswered request is denied when it expires. An `ask` agent
driven from a script silently skipped every held tool call and still reported
`done`.

```ts
for await (const event of run) {
  if (event.type !== "permission") continue;
  const allow = event.request.options.find((o) => o.kind === "allow_once");
  await run.answer(event.request.requestId, allow.optionId);
}
```

`resume(id).answer(...)` is the same call from a process that is not following
the turn. The end-to-end test carries a deadline, so a regression fails in five
seconds instead of hanging CI on a turn that never ends.

## What publishing needed

- The README's licence section said **MIT**. The SDK is Apache-2.0 and the
  server is AGPL-3.0 (#998), and that file is the npm front page.
- `USER_AGENT` is a literal that would drift from `package.json` on the next
  bump; a test now asserts the two agree.
- `README.md` and `docs/sdk.md` no longer say "build it from a checkout".
- A package `CHANGELOG.md`, shipped in the tarball.
- `update()` takes the API's own patch schema rather than `Partial<Input>`; the
  README's two `## Errors` sections are one; `conversations()` admits in its
  docstring that it is roots-only by default.

## Verification

Both fixes were checked by reverting them — the new tests fail, and pass again
with the fix. Beyond CI, against **production**, from the packed tarball:

```
me(): jhgaylor@gmail.com | role: admin | verified: true
state: done | turn: 1 | status: idle
text: "sdk-live-ok"
events: conversation → turn-start → thinking → text → turn-end
elapsed: 15.7s
```

Also green locally: typecheck, 71 tests, build, the browser bundle, no OpenAPI
drift, `vale lint docs` (0 errors), `scripts/docs-style.py`, and
`mkdocs build --strict`.

## After merge

`fountain-sdk` is not on npm yet, and this PR's docs say `npm install
fountain-sdk`. **Publish before or with the merge**, or the docs site is briefly
wrong. Steps are in the SDK README's Releasing section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)