### PR TITLE
chore(sdk): 0.1.1, the first release published by CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ upgrade, is in
 
 ### Added
 
+- **The SDK publishes itself from CI, with provenance**
+  (`.github/workflows/sdk-publish.yml`). `@agentshit/fountain-sdk@0.1.0` reached
+  npm from a laptop, authenticated by a long-lived token in a `~/.npmrc`. The
+  `Publish SDK` workflow replaces that with npm trusted publishing: npm trades
+  the workflow's OIDC identity for a short-lived credential, so the repository
+  holds no `NPM_TOKEN`, and each tarball carries an attestation a consumer can
+  verify back to the workflow and commit that built it (`npm audit
+  signatures`). It fires on an `sdk-v*.*.*` tag — the SDK versions on its own
+  clock, because the REST API it wraps is additive — and refuses to run when
+  the tag and `package.json` disagree, since npm never allows a version to be
+  republished.
+
 - **The TypeScript SDK is ready to publish, and can answer a permission
   request** (`sdk/typescript`). It goes to npm as
   **`@agentshit/fountain-sdk` 0.1.0** — scoped, because the `agentshit` org is

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,7 +10,14 @@ server releases.
 
 ---
 
-## [0.1.0] — unreleased
+## [0.1.1] — 2026-08-23
+
+No code change from 0.1.0. This is the first release published by CI through
+npm's trusted publishing, so unlike 0.1.0 — which went out from a laptop — the
+tarball carries a provenance attestation tying it to the workflow, the
+repository and the commit that built it. Verify with `npm audit signatures`.
+
+## [0.1.0] — 2026-08-23
 
 First published release.
 
@@ -39,4 +46,5 @@ First published release.
 - A browser entry with no Node built-in reachable from it, and a Node entry
   that adds `~/.fountain/credentials`.
 
-[0.1.0]: https://github.com/BinaryBourbon/fountain/tree/main/sdk/typescript
+[0.1.1]: https://www.npmjs.com/package/@agentshit/fountain-sdk/v/0.1.1
+[0.1.0]: https://www.npmjs.com/package/@agentshit/fountain-sdk/v/0.1.0

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -15,11 +15,11 @@ export interface RequestOptions {
 
 /**
  * The product token this client sends. Deliberately not the package name: a
- * scope reads as a second token in a User-Agent (`@agentshit/…/0.1.0`), and
+ * scope reads as a second token in a User-Agent (`@agentshit/…/0.1.1`), and
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.0";
+export const USER_AGENT = "fountain-sdk-js/0.1.1";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Same code as 0.1.0. The difference is where the tarball comes from.

`0.1.0` was pushed from a laptop with a long-lived token. `0.1.1` goes out
through the `Publish SDK` workflow, so it carries a provenance attestation
tying it to the workflow, the repository and this commit — verifiable with
`npm audit signatures`. That makes it the cheapest possible test of the
trusted-publishing path npm was just configured for: if the OIDC exchange is
wrong, nothing is lost but a version number.

A version bump is the only way to test it at all — npm never allows a version
to be republished, so `0.1.0` cannot be sent again.

### The drift guard earned itself

The `USER_AGENT` test added alongside the `me()` fix caught a real drift on its
very first bump. `npm version` touches `package.json` and the lockfile and
nothing else, so the constant still read `fountain-sdk-js/0.1.0`:

```
✖ USER_AGENT carries the published version
ℹ pass 70
ℹ fail 1
```

Corrected, and green again at 71/71. Without it, 0.1.1 would have shipped
announcing itself as 0.1.0 to the server.

### After merge

```bash
git tag sdk-v0.1.1 && git push origin sdk-v0.1.1
```

The workflow's guard asserts the tag matches `package.json` before it publishes
anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)