### PR TITLE
ci(sdk): make CI the only publisher, and the version bump part of review

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,26 +1,30 @@
 name: Publish SDK
 
-# Publishes `@agentshit/fountain-sdk` to npm with **trusted publishing**: npm
-# trades this workflow's OIDC identity for a short-lived credential, so there
-# is no NPM_TOKEN in this repository and nothing to leak or rotate. That only
-# works if npm is told, on the package's settings page, to trust exactly this
-# repository and exactly this workflow *filename* — so renaming this file
-# breaks publishing until the trusted publisher is updated to match.
+# Publishes `@agentshit/fountain-sdk` to npm. **CI is the only publisher** —
+# nothing is ever released from a laptop.
 #
-# Publishing is deliberately not attached to the server's `v*.*.*` tags. The
-# SDK talks to the REST API, which is additive, so it versions on its own
-# clock; tying it to the server would either publish a byte-identical package
-# on every server release or hold a ready SDK fix behind one.
+# The trigger is the version itself: merge a PR that bumps
+# `sdk/typescript/package.json` and that version goes out. There is no tag to
+# push and no button to remember, because a release step a human performs is a
+# release step a human forgets. The `SDK release gate` workflow is the other
+# half — it fails a PR that changes what the SDK ships without bumping, so the
+# bump happens during review rather than after.
 #
-#   git tag sdk-v0.1.1 && git push origin sdk-v0.1.1
+# Idempotent by construction: the run starts by asking the registry whether
+# this version already exists and stops if it does. So a PR touching only the
+# SDK's tests runs this workflow, finds nothing to do, and says so.
 #
-# or run it by hand from the Actions tab, which publishes whatever version
-# `sdk/typescript/package.json` currently names.
+# npm authenticates this through **trusted publishing** — it trades the OIDC
+# identity below for a short-lived credential, so no NPM_TOKEN exists in this
+# repository. npm is configured to trust this repository and this workflow
+# *filename*: renaming this file breaks publishing until the trusted publisher
+# on npmjs.com is updated to match.
 
 on:
   push:
-    tags:
-      - "sdk-v*.*.*"
+    branches: [main]
+    paths:
+      - "sdk/typescript/**"
   workflow_dispatch:
 
 permissions:
@@ -31,16 +35,15 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: read
-      # The whole point: this is what lets the runner mint an OIDC token for
-      # npm to verify. Without it `npm publish` falls back to looking for a
-      # token and fails.
-      id-token: write
 
-    defaults:
-      run:
-        working-directory: sdk/typescript
+    permissions:
+      # `contents: write` only to push the `sdk-v*` tag *after* a successful
+      # publish, as a record of which commit produced which version. The tag is
+      # an output of a release, never the input that causes one.
+      contents: write
+      # What lets the runner mint an OIDC token for npm to verify. Without it
+      # `npm publish` looks for a token instead and fails.
+      id-token: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
@@ -69,56 +72,96 @@ jobs:
             exit 1
           fi
 
-      # A tag that disagrees with package.json publishes the wrong version
-      # under the right name, which cannot be undone — npm does not allow a
-      # re-publish of the same version.
-      - name: The tag matches the version being published
-        if: startsWith(github.ref, 'refs/tags/sdk-v')
+      - name: Is there anything to publish?
+        id: release
         run: |
-          tagged="${GITHUB_REF_NAME#sdk-v}"
-          declared=$(node -p "require('./package.json').version")
-          echo "tag: $tagged / package.json: $declared"
-          if [ "$tagged" != "$declared" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $declared." >&2
-            exit 1
-          fi
+          node scripts/sdk-release.mjs state > state.json
+          cat state.json
+          version=$(node -p "require('./state.json').version")
+          tag=$(node -p "require('./state.json').tag")
+          published=$(node -p "require('./state.json').published")
+          if [ "$published" = "true" ]; then needed=no; else needed=yes; fi
+          {
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "needed=$needed"
+          } >> "$GITHUB_OUTPUT"
+          echo "version $version already on npm: $published (publish: $needed)"
 
       - name: Install
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/typescript
         run: npm ci
 
-      # `prepublishOnly` runs these again on publish. They are here as their
-      # own steps so a failure says which gate failed, instead of surfacing as
-      # a publish that died somewhere inside npm.
+      # `prepublishOnly` runs these again. They are here as their own steps so a
+      # failure names the gate that failed, instead of surfacing as a publish
+      # that died somewhere inside npm.
       - name: Typecheck
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/typescript
         run: npm run typecheck
 
       - name: Test
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/typescript
         run: npm test
 
       - name: Build
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/typescript
         run: npm run build
 
       - name: The default entry still bundles for a browser
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/typescript
         run: npx --yes esbuild dist/index.js --bundle --platform=browser --format=esm --outfile=/dev/null
 
-      # No NPM_TOKEN. npm exchanges the OIDC token from `id-token: write` for a
-      # short-lived credential, and publishes with provenance attached, which
-      # is how a consumer can verify this tarball came from this workflow in
-      # this repository rather than from somebody's laptop.
+      # No NPM_TOKEN. npm exchanges the OIDC token for a short-lived credential
+      # and attaches provenance, which is how a consumer verifies this tarball
+      # came from this workflow at this commit rather than from someone's
+      # laptop. FOUNTAIN_CI is what tells `prepublishOnly` this is CI.
       - name: Publish
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/typescript
+        env:
+          FOUNTAIN_CI_PUBLISH: "1"
         run: npm publish
 
-      - name: Say what landed
+      # After the fact, and only on success: which commit produced which
+      # version. A failed publish leaves no tag to clean up.
+      - name: Record the release as a tag
+        if: steps.release.outputs.needed == 'yes'
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
-          version=$(node -p "require('./package.json').version")
-          {
-            echo "### Published"
-            echo
-            echo '`@agentshit/fountain-sdk@'"$version"'`'
-            echo
-            echo "https://www.npmjs.com/package/@agentshit/fountain-sdk/v/$version"
-            echo
-            echo "A freshly published version can 404 on the public registry for"
-            echo "a few minutes before the CDN serves it. That is propagation,"
-            echo "not a failed publish."
-          } >> "$GITHUB_STEP_SUMMARY"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "@agentshit/fountain-sdk ${TAG#sdk-v}" "$GITHUB_SHA"
+          git push origin "$TAG"
+
+      - name: Say what happened
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          NEEDED: ${{ steps.release.outputs.needed }}
+        run: |
+          if [ "$NEEDED" = "yes" ]; then
+            {
+              echo "### Published \`@agentshit/fountain-sdk@$VERSION\`"
+              echo
+              echo "https://www.npmjs.com/package/@agentshit/fountain-sdk/v/$VERSION"
+              echo
+              echo "Tagged \`sdk-v$VERSION\` at \`$GITHUB_SHA\`. Verify the provenance with"
+              echo '`npm audit signatures` after installing.'
+              echo
+              echo "A new version 404s on the public registry for a few minutes"
+              echo "before the CDN serves it. That is propagation, not failure."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### Nothing to publish"
+              echo
+              echo "\`@agentshit/fountain-sdk@$VERSION\` is already on npm. This push"
+              echo "changed the SDK without changing its version, which is fine for"
+              echo "tests, examples and the changelog."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/sdk-release-gate.yml
+++ b/.github/workflows/sdk-release-gate.yml
@@ -1,0 +1,46 @@
+name: SDK release gate
+
+# Makes "does this need a release?" part of review rather than something
+# remembered afterwards.
+#
+# The publish workflow ships whatever version lands on main, so a PR that
+# changes what the SDK ships and leaves the version alone produces a change
+# that sits on main unreleased — invisible, until somebody wonders why the fix
+# they merged is not on npm. This says so on the PR instead.
+#
+# It also front-loads everything that would make the publish fail on main,
+# where failing is cheap and a person is already looking: a version already on
+# npm (which can never be republished), a missing changelog entry, and the
+# USER_AGENT constant that `npm version` does not touch.
+
+on:
+  pull_request:
+    paths:
+      - "sdk/typescript/**"
+      - "scripts/sdk-release.mjs"
+      - ".github/workflows/sdk-release-gate.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: A change to the SDK says whether it releases
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # The deliberate exception: changing the published surface without cutting
+    # a release. Rare, and it should take a label and a sentence in the PR.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'sdk-no-release') }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          # The guard diffs against the merge base, so it needs history.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Does this PR need a version bump?
+        run: node scripts/sdk-release.mjs guard "origin/${{ github.base_ref }}"

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -401,6 +401,20 @@ What people write by hand is the part a spec cannot express. That many log
 events fold into one *turn*. That you can await a run or stream it. Which of
 85 paths are worth a verb.
 
+## How CI publishes it
+
+CI publishes every version. No person publishes from a workstation. npm accepts
+a release only from the `Publish SDK` workflow in this repository. Each tarball
+therefore carries a provenance attestation. To examine it, install the package
+and then run this command:
+
+```bash
+npm audit signatures
+```
+
+A verified attestation identifies the workflow and the commit that made the
+tarball. A package that a person sends by hand has no such attestation.
+
 ## Other languages
 
 There is no SDK for your language yet. There are two worked references for the

--- a/scripts/sdk-release.mjs
+++ b/scripts/sdk-release.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * The facts about an SDK release, in one place, so the PR gate and the publish
+ * workflow cannot disagree about them.
+ *
+ *   node scripts/sdk-release.mjs state          → JSON on stdout
+ *   node scripts/sdk-release.mjs guard <base>   → the PR gate; exits 1 on a problem
+ *
+ * No dependencies: this runs before `npm ci` in at least one caller.
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const PKG_DIR = "sdk/typescript";
+
+/** Files whose contents reach a consumer. Changing one needs a release. */
+const PUBLISHED_GLOBS = [`${PKG_DIR}/src/`, `${PKG_DIR}/package.json`, `${PKG_DIR}/README.md`];
+
+/**
+ * The manifest fields a consumer is actually affected by.
+ *
+ * `package.json` ships, so a naive rule calls every edit to it a release —
+ * including `scripts`, which exists only for this repository, and
+ * `devDependencies`, which nobody installing the package ever resolves.
+ * Comparing this projection instead means the gate fires on a changed export
+ * map or a dropped Node engine, and stays quiet for repository plumbing.
+ */
+const CONSUMER_FIELDS = [
+  "name",
+  "version",
+  "type",
+  "exports",
+  "main",
+  "types",
+  "browser",
+  "bin",
+  "files",
+  "engines",
+  "license",
+  "sideEffects",
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+];
+
+const consumerFacing = (pkg) =>
+  JSON.stringify(Object.fromEntries(CONSUMER_FIELDS.map((k) => [k, pkg[k] ?? null])));
+
+/**
+ * Files inside the package that a consumer never receives. Tests, examples and
+ * the changelog are excluded on purpose — requiring a version bump to write the
+ * changelog entry for that very version is a loop with no entrance.
+ */
+const UNPUBLISHED = (path) =>
+  path.startsWith(`${PKG_DIR}/test/`) ||
+  path.startsWith(`${PKG_DIR}/examples/`) ||
+  path === `${PKG_DIR}/CHANGELOG.md` ||
+  path === `${PKG_DIR}/tsconfig.json` ||
+  path === `${PKG_DIR}/tsconfig.build.json` ||
+  path === `${PKG_DIR}/package-lock.json`;
+
+const manifest = (ref) => {
+  const raw =
+    ref === null
+      ? readFileSync(`${PKG_DIR}/package.json`, "utf8")
+      : git(["show", `${ref}:${PKG_DIR}/package.json`]);
+  return JSON.parse(raw);
+};
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" });
+}
+
+/** Whether the registry already has this exact version. */
+async function isPublished(name, version) {
+  const url = `https://registry.npmjs.org/${name.replace("/", "%2F")}/${version}`;
+  const response = await fetch(url, { headers: { accept: "application/json" } });
+  if (response.status === 200) return true;
+  if (response.status === 404) return false;
+  throw new Error(`registry answered ${response.status} for ${name}@${version}`);
+}
+
+async function state() {
+  const pkg = manifest(null);
+  return {
+    name: pkg.name,
+    version: pkg.version,
+    published: await isPublished(pkg.name, pkg.version),
+    tag: `sdk-v${pkg.version}`,
+  };
+}
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exitCode = 1;
+}
+
+async function guard(baseRef) {
+  const changed = git(["diff", "--name-only", `${baseRef}...HEAD`]).split("\n").filter(Boolean);
+  const touched = changed.filter((p) => p.startsWith(`${PKG_DIR}/`));
+  const head = manifest(null);
+  const base = manifest(baseRef);
+  const bumped = head.version !== base.version;
+
+  const manifestMattersToConsumers = consumerFacing(head) !== consumerFacing(base);
+  const needsRelease = touched.filter((p) => {
+    if (UNPUBLISHED(p)) return false;
+    // package.json ships, but most of what changes in it is repository-only.
+    if (p === `${PKG_DIR}/package.json`) return manifestMattersToConsumers;
+    return PUBLISHED_GLOBS.some((g) => p.startsWith(g));
+  });
+
+  console.log(`package:  ${head.name}`);
+  console.log(`base:     ${base.version}`);
+  console.log(`head:     ${head.version}${bumped ? "  (bumped)" : "  (unchanged)"}`);
+  console.log(`touched:  ${touched.length} file(s) under ${PKG_DIR}`);
+  if (needsRelease.length) console.log(`shipped:  ${needsRelease.join(", ")}`);
+
+  if (needsRelease.length && !bumped) {
+    fail(
+      `This PR changes what the SDK ships (${needsRelease.join(", ")}) but leaves the ` +
+        `version at ${head.version}. Nothing publishes without a bump, so the change would ` +
+        `sit on main unreleased. Run \`cd ${PKG_DIR} && npm version patch\` (or minor/major), ` +
+        `update USER_AGENT and CHANGELOG.md, and commit. To change the published surface ` +
+        `without releasing, add the "sdk-no-release" label.`,
+    );
+    return;
+  }
+
+  if (!bumped) {
+    console.log("\nNo release needed for this PR.");
+    return;
+  }
+
+  // From here on the PR claims a release, so everything that would make the
+  // publish fail on main is checked here instead — where it is still cheap.
+  if (await isPublished(head.name, head.version)) {
+    fail(
+      `${head.name}@${head.version} is already on npm, and npm never allows a version to be ` +
+        `republished. Bump to something new.`,
+    );
+  }
+
+  const changelog = readFileSync(`${PKG_DIR}/CHANGELOG.md`, "utf8");
+  if (!changelog.includes(`## [${head.version}]`)) {
+    fail(`CHANGELOG.md has no "## [${head.version}]" heading. A release says what changed.`);
+  }
+
+  const http = readFileSync(`${PKG_DIR}/src/http.ts`, "utf8");
+  if (!http.includes(`fountain-sdk-js/${head.version}`)) {
+    fail(
+      `USER_AGENT in ${PKG_DIR}/src/http.ts still does not say ${head.version}. ` +
+        `\`npm version\` does not touch it.`,
+    );
+  }
+
+  if (process.exitCode !== 1) {
+    console.log(`\nRelease looks well-formed. Merging this publishes ${head.version}.`);
+  }
+}
+
+const [command, arg] = process.argv.slice(2);
+
+if (command === "state") {
+  console.log(JSON.stringify(await state(), null, 2));
+} else if (command === "guard") {
+  if (!arg) {
+    console.error("usage: sdk-release.mjs guard <base-ref>");
+    process.exit(2);
+  }
+  await guard(arg);
+} else {
+  console.error("usage: sdk-release.mjs state | guard <base-ref>");
+  process.exit(2);
+}

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -409,16 +409,33 @@ lie, which is how `me()` shipped returning `null`.
 
 ### Releasing
 
-The version lives in `package.json` and is asserted against `USER_AGENT` by a
-test, so a bump that misses one fails rather than shipping a lie.
+**CI is the only publisher.** `npm publish` from a checkout refuses, and npm is
+configured to accept releases only from this repository's `Publish SDK`
+workflow — so a tarball on the registry always carries provenance tying it to
+a commit and a workflow run.
+
+There is no release command and no tag to push. **Merging a version bump is the
+release.**
 
 ```bash
-npm version patch          # or minor — updates package.json, tags
-npm publish                # prepublishOnly runs typecheck, tests and build
+cd sdk/typescript
+npm version patch          # or minor / major — edits package.json + the lockfile
 ```
 
-Add the release to `CHANGELOG.md` in the same commit, and check that
-`docs/sdk.md` still describes what shipped.
+Then update two things `npm version` does not touch, and open a PR as usual:
+
+- `USER_AGENT` in `src/http.ts`
+- a `## [x.y.z]` section in `CHANGELOG.md`
+
+The `SDK release gate` check on the PR fails if either is missing, if the
+version is already on npm, or if you changed what the package ships without
+bumping at all. When the PR merges, `Publish SDK` sees a version the registry
+does not have, publishes it, and tags the merge commit `sdk-v<version>`.
+
+A PR that touches only tests, examples or the changelog needs no bump; the
+gate stays quiet, and the publish workflow finds nothing to do. To change the
+published surface deliberately without releasing, label the PR
+`sdk-no-release`.
 
 ## License
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -46,7 +46,7 @@
     "generate": "openapi-typescript ${FOUNTAIN_OPENAPI:-/tmp/fountain-openapi.json} -o src/generated/openapi.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --test test/*.test.ts",
-    "prepublishOnly": "npm run typecheck && npm test && npm run build"
+    "prepublishOnly": "node scripts/ci-publishes.mjs && npm run typecheck && npm test && npm run build"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/sdk/typescript/scripts/ci-publishes.mjs
+++ b/sdk/typescript/scripts/ci-publishes.mjs
@@ -1,0 +1,33 @@
+/**
+ * Refuse to publish from anywhere but this repository's release workflow.
+ *
+ * npm's "Require trusted publishing" setting is the real lock — it is enforced
+ * by the registry, and nothing here can be a substitute for it. This is the
+ * guardrail in front of it: it turns an absent-minded `npm publish` into a
+ * message explaining the actual release process, instead of a rejection from
+ * npm that a person might read as something to work around.
+ *
+ * Being a lifecycle script, `--ignore-scripts` walks straight past it. That is
+ * fine. It is here to catch habit, not to stop a determined person, and the
+ * registry stops them anyway.
+ */
+const inCi = process.env.FOUNTAIN_CI_PUBLISH === "1" && process.env.GITHUB_ACTIONS === "true";
+
+if (!inCi) {
+  console.error(`
+  Refusing to publish from here. CI is the only publisher.
+
+  Releases happen by merging a version bump — there is no tag to push and no
+  command to run:
+
+    1. cd sdk/typescript && npm version patch     (or minor / major)
+    2. update USER_AGENT in src/http.ts and add a CHANGELOG.md entry
+       (the release gate on your PR tells you if you miss either)
+    3. open the PR as normal
+
+  Merging it publishes that version, with provenance tying the tarball to the
+  workflow and commit that built it. A release published from a laptop has no
+  such attestation, which is the whole reason this refuses.
+`);
+  process.exit(1);
+}


### PR DESCRIPTION
`0.1.0` went to npm from a laptop; `0.1.1` needed a hand-pushed tag. Neither is
a release process — both are a person remembering. This makes **merging a
version bump the release**, and makes publishing from anywhere else fail.

## Publishing follows the version

`Publish SDK` now runs on a push to main touching `sdk/typescript/`, asks the
registry whether that version exists, and publishes it if not. No tag to push,
no button to press. A PR that only touches tests runs it, finds nothing to do,
and says so in the summary.

The `sdk-v*` tag is now written **after** a successful publish, as a record of
which commit produced which version — rather than being the input that causes
one. That is why the job takes `contents: write`.

## The bump happens during review

`SDK release gate` fails a PR that changes what the package ships without
bumping. Otherwise the change lands on main unreleased and nobody notices until
they wonder why the fix they merged isn't on npm.

It also front-loads everything that would fail the publish later, where failing
is cheap and a reviewer is already looking:

- a version already on npm — which npm **never** lets you replace
- a missing `CHANGELOG.md` entry
- the `USER_AGENT` constant, which `npm version` does not touch (this bit us on
  0.1.1)

`sdk-no-release` is the deliberate way out.

### It compares a projection of package.json, not the file

The manifest ships, so a naive rule demands a release for editing `scripts` —
which exists only for this repository. The gate compares the fields a consumer
actually resolves (`exports`, `engines`, `dependencies`, …), so it fires on a
changed export map and stays quiet for plumbing. **This PR is the case in
point:** it edits `package.json` and correctly needs no release.

## Laptops can't publish

`npm publish` from a checkout now refuses with a message explaining the flow.
`--ignore-scripts` walks past it, and that's fine — npm's **"Require trusted
publishing"** setting is the enforcement; this is the guardrail in front of it
that turns a habit into an explanation rather than a confusing registry
rejection.

## Verification

Every branch exercised against a real base (a clean clone at `f9b0644`), not
argued from the code:

| case | want | got |
|---|---|---|
| `src/` changed, no bump | fail | fail |
| bump to already-published `0.1.0` | fail | fail |
| new version, stale CHANGELOG + `USER_AGENT` | fail | fail |
| `README.md` changed, no bump (it ships) | fail | fail |
| `package.json` `scripts` only | pass | pass |
| tests only | pass | pass |
| changelog only | pass | pass |

Also green: 71/71 SDK tests, typecheck, `vale lint docs` (0 errors, 0 warnings),
`scripts/docs-style.py`, `mkdocs build --strict`. The refusal path was run
locally — `npm publish --dry-run` exits non-zero with the explanation.

## One thing still yours

Turn on **"Require trusted publishing"** on the npm package settings. Until
then the laptop path still works at the registry; everything here is repo-side
guardrail, not enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)