### PR TITLE
docs: leave a tombstone on the retired Pages site

### DIFF
--- a/.github/workflows/pages-tombstone.yml
+++ b/.github/workflows/pages-tombstone.yml
@@ -1,0 +1,69 @@
+# Replaces the retired GitHub Pages site with redirects into /docs.
+#
+# #1008 retired the MkDocs build and made /docs the only publisher of the
+# manual. That stopped new publishes but left the last snapshot serving
+# forever, which is worse than a 404: stale docs nothing marks as stale,
+# drifting further from /docs with every docs PR.
+#
+# So the site becomes a tombstone. Every URL it used to answer still answers
+# and redirects to the same page at https://fountain.inevitable.fyi/docs.
+#
+# DELIBERATELY `workflow_dispatch` ONLY. This is not a docs publishing path
+# and must not become one — nothing here reads a page's content, only the nav.
+# Run it by hand, once. If the nav changes enough that the redirects go stale,
+# run it again; `scripts/build-pages-tombstone.py` exits non-zero rather than
+# emit a redirect to a page that is not there.
+#
+# When these URLs have decayed enough not to be worth answering, delete this
+# workflow, `scripts/build-pages-tombstone.py`, and the Pages site itself
+# (`gh api -X DELETE repos/BinaryBourbon/fountain/pages`).
+name: Pages tombstone
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish the redirects
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: Build the redirects
+        run: python3 scripts/build-pages-tombstone.py
+
+      # One redirect per page the nav names, plus the home page and a 404 that
+      # catches everything else. A count that collapses means the nav parser
+      # stopped recognising the file, and publishing that would take the whole
+      # site down to a single page.
+      - name: Check the site is not empty
+        run: |
+          count=$(find _pages_tombstone -name index.html | wc -l)
+          echo "generated ${count} redirects"
+          if [ "${count}" -lt 50 ]; then
+            echo "::error::only ${count} redirects — refusing to publish a collapsed site"
+            exit 1
+          fi
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _pages_tombstone
+
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ priv/plts/
 # Python (integrations/hermes)
 __pycache__/
 *.pyc
+
+# Build output of scripts/build-pages-tombstone.py.
+/_pages_tombstone/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,16 @@ upgrade, is in
   since the docs IA campaign moved that content, because nothing checked
   absolute links; they point at the right pages now (#1006)
 
+  The old site does not simply stop: it becomes a **tombstone**, one redirect
+  per URL it used to answer, each pointing at the same page under `/docs` and
+  carrying the fragment across. Deleting the workflow would have left the last
+  snapshot serving forever, which is worse than a 404, and deleting the site
+  would have broken every link anyone ever made to it.
+  `scripts/build-pages-tombstone.py` generates it from the nav and refuses to
+  emit a redirect to a page that is not there;
+  `.github/workflows/pages-tombstone.yml` publishes it by hand and is
+  `workflow_dispatch` only, so it is not a docs publishing path (#1006)
+
 ### Changed
 
 - **Fountain is no longer MIT licensed** (ADR 0027). The server under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,7 +351,16 @@ markdown is embedded at compile time by `Fountain.Docs`. It used to be built as
 a MkDocs Material site and deployed to GitHub Pages as well; that copy was
 retired in #1006, so there is no `mkdocs.yml`, no `docs.yml` workflow and no
 `mkdocs build` step to keep green. A page reaches a reader through `/docs` or
-not at all. Guardrails that trip people who only edit markdown:
+not at all.
+
+The one thing left on GitHub Pages is a **tombstone**: one redirect per old URL
+into `/docs`, built by `scripts/build-pages-tombstone.py` from the nav and
+published by hand from `.github/workflows/pages-tombstone.yml`. It is
+`workflow_dispatch` only and reads no page content. **Do not turn it into a
+docs publishing path**, and do not treat a docs edit as needing a re-run —
+the redirects only go stale if a page's *slug* changes.
+
+Guardrails that trip people who only edit markdown:
 
 - **The nav lives only in `docs/nav.yml`.** `Fountain.Docs` parses that file's
   `nav:` block at compile time, so adding, renaming or moving a page is a

--- a/scripts/build-pages-tombstone.py
+++ b/scripts/build-pages-tombstone.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Build the tombstone that replaces the retired GitHub Pages site.
+
+#1008 retired the MkDocs build and made `/docs` the only publisher of the
+manual. Deleting the workflow stopped new publishes but left the last snapshot
+serving forever, which is worse than a 404: stale docs that nothing marks as
+stale, drifting further from `/docs` with every docs PR.
+
+This builds a site of redirects instead. Every URL the old site answered keeps
+answering, and sends the reader to the same page at
+https://fountain.inevitable.fyi/docs. It is published once, by hand, from
+`.github/workflows/pages-tombstone.yml`.
+
+MkDocs served directory URLs, so `setup.md` was `/fountain/setup/` and
+`catalog/index.md` was `/fountain/catalog/`. That is exactly the mapping
+`Fountain.Docs.Compiler.slug_for/1` already makes, so the nav is the whole
+input: one redirect per page it names.
+
+An unknown path lands on `404.html`, which goes to the manual's home rather
+than guessing. The pages that path could name are the ones that no longer
+exist anywhere (`docs/superpowers/`, which MkDocs published without a nav
+entry), so guessing would send a reader from one dead URL to another.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+NAV = ROOT / "docs" / "nav.yml"
+DOCS = "https://fountain.inevitable.fyi/docs"
+
+# The two line shapes docs/nav.yml uses, same as the Elixir parser. A page
+# entry at any indent; a section header carries no file and is skipped.
+ENTRY = re.compile(r"^\s+- ([^:]+):\s*(\S+)\s*$")
+
+
+def slugs():
+    """Every page slug in the nav. `index.md` is "", `x/index.md` is "x"."""
+    block = NAV.read_text().split("\nnav:\n", 1)
+    if len(block) != 2:
+        sys.exit("docs/nav.yml has no `nav:` block")
+
+    out = []
+    for line in block[1].splitlines():
+        if not line.strip() or line.strip().startswith("#"):
+            continue
+        if not line.startswith(" "):
+            break
+        m = ENTRY.match(line)
+        if not m:
+            continue
+        stem = m.group(2).rsplit(".", 1)[0]
+        out.append("" if stem == "index" else re.sub(r"/index$", "", stem))
+    return out
+
+
+def page(target, note):
+    """A redirect that works with JavaScript off, and keeps the fragment on.
+
+    `meta refresh` is the one that survives a reader with no JS. It cannot
+    carry `location.hash`, so the script goes first and does; browsers preserve
+    a fragment across a meta refresh inconsistently, and an anchor is how these
+    pages link to each other.
+    """
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Moved to {DOCS}</title>
+<link rel="canonical" href="{target}">
+<meta name="robots" content="noindex">
+<meta http-equiv="refresh" content="0; url={target}">
+<script>location.replace({target!r} + location.hash);</script>
+<style>
+  body {{ font: 16px/1.6 system-ui, sans-serif; margin: 6rem auto; max-width: 34rem;
+         padding: 0 1.5rem; color: #1f2328; background: #fff; }}
+  a {{ color: #6d28d9; }}
+  @media (prefers-color-scheme: dark) {{
+    body {{ color: #e6e6e6; background: #16161a; }}
+    a {{ color: #c4b5fd; }}
+  }}
+</style>
+</head>
+<body>
+<h1>The documentation moved.</h1>
+<p>{note}</p>
+<p><a href="{target}">{target}</a></p>
+</body>
+</html>
+"""
+
+
+def main():
+    out = ROOT / "_pages_tombstone"
+    for stale in sorted(out.rglob("*"), reverse=True):
+        stale.unlink() if stale.is_file() else stale.rmdir()
+    out.mkdir(exist_ok=True)
+
+    # This is a second parser for docs/nav.yml; Fountain.Docs.Compiler is the
+    # one that decides what /docs actually serves. They were verified to
+    # produce the identical 79 pages plus the home slug when this was written.
+    # If they ever disagree, this site sends readers from a live URL to a 404,
+    # which is the one outcome worse than the stale snapshot it replaces — so
+    # check the page is really there rather than trusting the two agree.
+    found = slugs()
+    if not found:
+        sys.exit("docs/nav.yml parsed to no pages at all")
+
+    written = 0
+    for slug in found:
+        source = ROOT / "docs" / ((slug + "/index.md") if slug else "index.md")
+        if not source.exists() and not (ROOT / "docs" / f"{slug}.md").exists():
+            sys.exit(f"nav names {slug!r}, which is no page on disk")
+
+        target = f"{DOCS}/{slug}" if slug else DOCS
+        directory = out / slug if slug else out
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "index.html").write_text(
+            page(target, "This page is now served by Fountain itself.")
+        )
+        written += 1
+
+    (out / "404.html").write_text(
+        page(DOCS, "That page is no longer here. The manual is served by Fountain.")
+    )
+
+    # GitHub Pages runs Jekyll unless told not to, and Jekyll skips a directory
+    # whose name begins with an underscore. None of ours do today, but a future
+    # nav entry could, and the failure would be one missing redirect in a site
+    # nobody reads until they need it.
+    (out / ".nojekyll").write_text("")
+
+    print(f"tombstone: {written} redirects + 404.html in {out.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #1008, which deleted the workflow that published `docs/` to GitHub Pages.

That stopped new publishes but left the last snapshot serving forever — stale docs that nothing marks as stale, drifting further from `/docs` with every docs PR. Deleting the site outright would instead break every link anyone ever made to it, and some of those links are in released CHANGELOG entries.

So the site becomes redirects.

## What it does

One redirect per URL the old site answered, each pointing at the same page under `/docs`:

```
binarybourbon.github.io/fountain/guides/operate/upgrade/
  → fountain.inevitable.fyi/docs/guides/operate/upgrade
```

The fragment comes along, which matters because these pages cross-link by anchor. `location.replace` handles that; the `meta refresh` behind it is for a reader with JS off, since it cannot carry a hash itself.

Anything unmatched hits `404.html` and goes to the manual's home rather than guessing. The paths it could plausibly name are the `docs/superpowers/` pages MkDocs published without a nav entry, and those no longer exist anywhere — guessing would send a reader from one dead URL to another.

## How it is built

`scripts/build-pages-tombstone.py`, from `docs/nav.yml`. MkDocs served directory URLs, so `setup.md` was `/fountain/setup/` and `catalog/index.md` was `/fountain/catalog/` — exactly the mapping `slug_for/1` already makes. That makes the nav the whole input.

It is a **second parser** for that file, and `Fountain.Docs.Compiler` is the one that decides what `/docs` really serves. If they disagree this site sends readers from a live URL to a 404, which is the one outcome worse than the snapshot it replaces. Two things guard that:

- I diffed the two parsers' output: identical, 79 pages plus the home slug.
- The script checks each slug against a real file on disk and exits non-zero otherwise, so it does not depend on that agreement holding. Verified by adding a bogus nav entry:

  ```
  nav names 'no-such-page', which is no page on disk
  exit=1
  ```

## How it is published

`.github/workflows/pages-tombstone.yml`, **`workflow_dispatch` only**. It reads no page content, only the nav, so it is not a docs publishing path and must not become one — `CLAUDE.md` says so next to it. A docs edit does not need a re-run; only a changed *slug* makes the redirects stale.

It also refuses to publish a site that collapsed to under 50 redirects. A nav the parser stopped recognising would otherwise quietly replace the whole site with a single page.

## When to delete it

When these URLs have decayed enough not to be worth answering: drop the workflow, the script, and the site (`gh api -X DELETE repos/BinaryBourbon/fountain/pages`). The workflow header says this.

Verified: docs tests 36/36, `docs-style.py` clean over 79 files, `vale lint docs` 0 errors, `mix format --check-formatted` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)