### PR TITLE
docs: cite the right PRs for the Pages retirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
           #
           # docs/nav.yml is under docs/ and so is covered by both greps here
           # without a special case — it used to be mkdocs.yml at the repo root,
-          # which needed naming twice (#1006).
+          # which needed naming twice (#1008).
           docs_touched=false
           if printf '%s\n' "${changed}" | grep -qE '^docs/'; then
             docs_touched=true
@@ -823,7 +823,7 @@ jobs:
       # on disk, every internal /docs link and every anchor — lives in
       # docs_test.exs and runs in the Elixir suite, so it needs nothing here.
       # That is what `mkdocs build --strict` used to carry, and the test is the
-      # stronger of the two: MkDocs never checked anchors (#1006).
+      # stronger of the two: MkDocs never checked anchors (#1008).
       - name: Docs style
         if: ${{ needs.changes.outputs.docs_touched == 'true' }}
         run: python3 scripts/docs-style.py
@@ -942,7 +942,7 @@ jobs:
   # pull request at all before this job existed — the GitHub Pages workflow was
   # push-to-main only — so a broken relative link or a page missing from the
   # nav passed CI and failed after the merge, on main, where nobody was
-  # looking. That workflow is gone (#1006); this job is the gate.
+  # looking. That workflow is gone (#1008); this job is the gate.
   #
   # The compile step is the load-bearing one. Fountain.Docs embeds every page
   # at compile time, so a snippet include pointing at a file that is not there
@@ -1062,7 +1062,7 @@ jobs:
 
       # docs_test.exs: the docs/nav.yml parser, the snippet-to-Dockerfile COPY
       # coverage, the dialect preprocessing, and every internal /docs link and
-      # anchor. Since #1006 it is the whole structural gate — there is no
+      # anchor. Since #1008 it is the whole structural gate — there is no
       # second renderer to build the pages strictly against.
       # docs_controller_test.exs: that the pages actually serve.
       - name: Docs tests

--- a/.vale-ste.yml
+++ b/.vale-ste.yml
@@ -44,7 +44,7 @@ sentence:
 
 # Everything under docs/ is a published page, so everything under docs/ is
 # linted. `docs/superpowers/**` used to be excluded here — planning material
-# that MkDocs published and /docs did not. #1006 retired the MkDocs site and
+# that MkDocs published and /docs did not. #1008 retired the MkDocs site and
 # moved those pages to `superpowers/` at the repo root.
 files:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ upgrade, is in
   `deploy/k8s/` and the SDK examples now point at
   `https://fountain.inevitable.fyi/docs/...`. Four of them had been broken
   since the docs IA campaign moved that content, because nothing checked
-  absolute links; they point at the right pages now (#1006)
+  absolute links; they point at the right pages now (#1008)
 
   The old site does not simply stop: it becomes a **tombstone**, one redirect
   per URL it used to answer, each pointing at the same page under `/docs` and
@@ -62,7 +62,7 @@ upgrade, is in
   `scripts/build-pages-tombstone.py` generates it from the nav and refuses to
   emit a redirect to a page that is not there;
   `.github/workflows/pages-tombstone.yml` publishes it by hand and is
-  `workflow_dispatch` only, so it is not a docs publishing path (#1006)
+  `workflow_dispatch` only, so it is not a docs publishing path (#1011)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,13 +349,13 @@ See `.env.example` for the full list. Key ones for local dev:
 `docs/` is the public manual, published at `/docs` and **nowhere else** — the
 markdown is embedded at compile time by `Fountain.Docs`. It used to be built as
 a MkDocs Material site and deployed to GitHub Pages as well; that copy was
-retired in #1006, so there is no `mkdocs.yml`, no `docs.yml` workflow and no
+retired in #1008, so there is no `mkdocs.yml`, no `docs.yml` workflow and no
 `mkdocs build` step to keep green. A page reaches a reader through `/docs` or
 not at all.
 
-The one thing left on GitHub Pages is a **tombstone**: one redirect per old URL
-into `/docs`, built by `scripts/build-pages-tombstone.py` from the nav and
-published by hand from `.github/workflows/pages-tombstone.yml`. It is
+The one thing left on GitHub Pages is a **tombstone** (#1011): one redirect per
+old URL into `/docs`, built by `scripts/build-pages-tombstone.py` from the nav
+and published by hand from `.github/workflows/pages-tombstone.yml`. It is
 `workflow_dispatch` only and reads no page content. **Do not turn it into a
 docs publishing path**, and do not treat a docs edit as needing a re-run —
 the redirects only go stale if a page's *slug* changes.

--- a/apps/fountain/lib/fountain/docs.ex
+++ b/apps/fountain/lib/fountain/docs.ex
@@ -7,7 +7,7 @@ defmodule Fountain.Docs do
   static MkDocs Material site and deployed to GitHub Pages as well; that second
   copy was retired once `/docs` served the same markdown from the same nav,
   because two publishing paths for one set of pages is two things to keep
-  green (#1006).
+  green (#1008).
 
   Pages are read at compile time (`@external_resource`, so edits recompile in
   dev), preprocessed to plain markdown by `Fountain.Docs.Compiler`, and served

--- a/apps/fountain/lib/fountain/docs/compiler.ex
+++ b/apps/fountain/lib/fountain/docs/compiler.ex
@@ -8,7 +8,7 @@ defmodule Fountain.Docs.Compiler do
   Covers exactly the dialect the docs use (see the `Fountain.Docs` moduledoc):
   snippet includes, admonitions, and relative `.md` links. The syntax is
   inherited from the MkDocs Material site these pages were published as until
-  #1006; this is not, and never was, a general MkDocs renderer.
+  #1008; this is not, and never was, a general MkDocs renderer.
   """
 
   @doc ~S(`"index.md"` → `""`, `"integrations/index.md"` → `"integrations"`, else the rootname.)

--- a/apps/fountain/lib/fountain_web/controllers/docs_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/docs_controller.ex
@@ -5,7 +5,7 @@ defmodule FountainWeb.DocsController do
   `FountainWeb.Markdown` pipeline, same as `/help` (#323).
 
   Public, like the marketing pages, and deliberately so: since the GitHub Pages
-  copy was retired (#1006) this route is the only published manual, and the
+  copy was retired (#1008) this route is the only published manual, and the
   people who most need it — someone deciding whether to self-host, or reading
   `setup.md` before they have an account — have no session to authenticate.
   """

--- a/apps/fountain/lib/fountain_web/controllers/docs_html/show.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/docs_html/show.html.heex
@@ -78,7 +78,7 @@ Added because the pages whose point is a script you are meant to take away
 (docs/tour.md) need one. The MkDocs site these pages were also published as
 got it from Material's `content.code.copy`; this route rendered the same
 markdown with no equivalent until #765, and is now the only place they are
-published at all (#1006). There is no asset pipeline here — the
+published at all (#1008). There is no asset pipeline here — the
 layout loads Tailwind and Phoenix from a CDN and everything else is inline —
 so this is inline too.
 

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -134,7 +134,7 @@ defmodule FountainWeb.Router do
     get "/", MarketingController, :home
     get "/terms", MarketingController, :terms
     get "/privacy", MarketingController, :privacy
-    # The public manual, and since #1006 the only place it is published —
+    # The public manual, and since #1008 the only place it is published —
     # content embedded at compile time by Fountain.Docs. Distinct from /help
     # (curated in-app topics) and /api/docs (Swagger).
     get "/docs", DocsController, :show

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -2,7 +2,7 @@ defmodule Fountain.DocsTest do
   @moduledoc """
   The embedded docs manual against `docs/nav.yml` and against itself.
 
-  Since #1006 retired the GitHub Pages build, this file is the *whole*
+  Since #1008 retired the GitHub Pages build, this file is the *whole*
   structural gate on `docs/`. `mkdocs build --strict` used to run on main and
   catch a relative link that did not resolve; nothing else renders these pages
   now, so the checks that replaced it live here: every page the nav names
@@ -260,7 +260,7 @@ defmodule Fountain.DocsTest do
     end
 
     @doc """
-    The other direction, and the one that had no gate before #1006. MkDocs
+    The other direction, and the one that had no gate before #1008. MkDocs
     built every page under `docs/` whether the nav named it or not, so a page
     left out of the nav was still reachable on the GitHub Pages site and its
     absence from `/docs` looked like a rendering quirk rather than a mistake.
@@ -348,7 +348,7 @@ defmodule Fountain.DocsTest do
     # The rendered target must carry the anchor as a heading id — MDEx emits
     # them on the trusted path (#765). Comrak's slug is now the only one that
     # matters: the MkDocs build that slugged the same headings differently for
-    # *duplicate* headings (comrak `-1`, python-markdown `_1`) is gone (#1006).
+    # *duplicate* headings (comrak `-1`, python-markdown `_1`) is gone (#1008).
     test "every internal /docs anchor link targets a heading on that page" do
       rendered =
         Map.new(Docs.slugs(), fn slug ->

--- a/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
@@ -2,7 +2,7 @@ defmodule FountainWeb.DocsControllerTest do
   use FountainWeb.ConnCase, async: true
 
   # All requests here are unauthenticated on purpose: /docs is the public
-  # manual, so it sits in the public marketing scope. Since #1006 it is the
+  # manual, so it sits in the public marketing scope. Since #1008 it is the
   # only place that manual is published, which makes the anonymous case the
   # one that matters most — nobody reading setup.md has an account yet.
 

--- a/apps/fountain/test/fountain_web/markdown_test.exs
+++ b/apps/fountain/test/fountain_web/markdown_test.exs
@@ -319,7 +319,7 @@ end|
     # test above and break the Dockerfile's cache step. The fence still says
     # `promql`, because the fence names the language rather than requesting a
     # renderer, and renaming it to hide the gap would be a lie a future parser
-    # never undoes. (Until #1006 there was a second reason: the MkDocs build
+    # never undoes. (Until #1008 there was a second reason: the MkDocs build
     # highlighted it, Pygments having a lexer.)
     #
     # This list is the difference between a gap that is known and one that is

--- a/scripts/docs-style.py
+++ b/scripts/docs-style.py
@@ -25,7 +25,7 @@ rule exists to stop a dash carrying a clause, which a lone cell cannot do.
 
 There is no directory exclusion any more. `docs/superpowers/` was one —
 internal planning material that sat under `docs/` without a nav entry, so
-MkDocs published it and /docs did not. #1006 retired the MkDocs site and made
+MkDocs published it and /docs did not. #1008 retired the MkDocs site and made
 "in docs/ but not in the nav" a test failure, and those four pages moved to
 `superpowers/` at the repo root. Everything under `docs/` is now a published
 page, so every page under `docs/` is checked.

--- a/superpowers/README.md
+++ b/superpowers/README.md
@@ -6,7 +6,7 @@ how the work was scoped, not current documentation — read the code, the
 [decisions](../decisions/index.md) and the manual at `/docs` for what is true
 now.
 
-They sat under `docs/` until #1006. Nothing in the manual linked to them and
+They sat under `docs/` until #1008. Nothing in the manual linked to them and
 `docs/nav.yml` never named them, so they were invisible at `/docs` and reached
 the public only as unlinked pages on the GitHub Pages build. Retiring that
 build moved them here, beside `runbooks/` and `docs-redesign/`, which are


### PR DESCRIPTION
Twenty comments, docstrings and CHANGELOG lines across thirteen files cited **#1006** for retiring the GitHub Pages docs site.

#1006 is an unrelated open PR: *"ci(sdk): make CI the only publisher, and the version bump part of review."* The number was wrong from the first commit of that work and got copied outward from there into `docs.ex`, `compiler.ex`, `router.ex`, `docs_controller.ex`, the docs tests, `ci.yml`, `CLAUDE.md`, `.vale-ste.yml`, `docs-style.py`, `superpowers/README.md` and the changelog.

The retirement is **#1008**. The tombstone that replaced the site is **#1011**. Every citation now points at one of those, and the changelog's tombstone paragraph gets #1011 rather than inheriting #1008 from the entry around it.

This is a failure mode the repo has hit before — `fountain-adr-numbers-in-old-issues` records two older documents citing ADRs that turned out to be different documents. The cost is the same either way: a reader follows the reference into work that has nothing to do with what they were reading, and the comment that looked authoritative was the thing that misled them.

## Not fixed

The two squash-merge subjects on `main` carry the wrong number in their own titles:

```
d1656fb docs: leave a tombstone on the retired Pages site (#1006) (#1011)
f89523f chore(docs): retire the GitHub Pages site; /docs is the manual (#1006) (#1008)
```

Correcting those means rewriting `main`, which is not worth it for a citation. The trailing `(#1008)` / `(#1011)` GitHub appends is the reference that actually resolves.

Verified: docs + markdown tests 77/77, `docs-style.py` clean over 79 files, `vale lint docs` 0 errors, `mix format --check-formatted` clean, and the tombstone still generates its 80 redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)