### PR TITLE
docs(llms): point /llms.txt at /docs, not the authenticated /help routes

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
@@ -7,15 +7,153 @@ defmodule FountainWeb.LlmsController do
   Three endpoints:
 
     * `GET /llms.txt`      — short index pointing at the bits an LLM needs
-    * `GET /llms-full.txt` — every help doc and the external skill concatenated
+    * `GET /llms-full.txt` — every page the index links, inlined, plus the skill
     * `GET /skill`         — the external `SKILL.md` only, drop-in for `~/.claude/skills/fountain/`
 
   All three are public, plain-text, no auth. The base URL embedded in the
   output is `Application.get_env(:fountain, :public_url)` so a self-hosted
   instance points at itself.
+
+  ## Why this points at `/docs` and not `/help`
+
+  It used to link `/help/:topic`. Those routes live in `live_session
+  :authenticated` — an unauthenticated fetch renders the app shell, whose only
+  text is "Sign in". So every Concepts link in the index resolved to a login
+  page for the one audience the file exists for, and nobody noticed because
+  the content was *also* inlined into `/llms-full.txt`, which is the path most
+  agents take. An agent that followed the index instead struck out seven times
+  in a row.
+
+  `/docs` is public, server-rendered, and the full manual. Everything here is
+  built from `Fountain.Docs`, so a link and its inlined body cannot disagree,
+  and `@corpus` is checked against the compiled page list at compile time — a
+  page renamed in `docs/nav.yml` breaks the build rather than shipping a dead
+  link in the file whose entire job is to be followed by a machine.
   """
 
   use FountainWeb, :controller
+
+  # The pages `/llms.txt` links and `/llms-full.txt` inlines, in reading order.
+  # `{slug, blurb}`, or `{slug, title, blurb}` where the nav title does not read
+  # well out of the sidebar (three of them are just "Overview"). The default
+  # title comes from `Fountain.Docs`, so it cannot drift from the nav.
+  # Slug `""` is the docs home page (`/docs`).
+  #
+  # This is deliberately not all of `Fountain.Docs.nav()`. The full manual is
+  # ~490 KB, over half of it operator runbooks (Kubernetes, Stripe, backups)
+  # that an agent calling the API has no use for. What is inlined is the
+  # "use Fountain" half, ~230 KB. The rest is linked under "More on /docs",
+  # labelled as not inlined.
+  @corpus [
+    {"Get started",
+     [
+       {"", "What Fountain is",
+        "the problem it solves, what it does about it, and `brew install` + `fountain auth login`"},
+       {"tour",
+        "forty lines of SDK that build an agent which clones a repo and opens a real pull request, then revise it on the same live sandbox"},
+       {"cli",
+        "`fountain auth|apply|run`, the `fountain.yml` manifest, and 1Password/Bitwarden/Infisical resolution at apply time"}
+     ]},
+    {"Concepts",
+     [
+       {"primitives", "how the four objects compose, and which one owns what"},
+       {"concepts/environment",
+        "apt packages, repos to clone, env vars, networking allowlist, setup script"},
+       {"concepts/vault",
+        "encrypted overrides picked per conversation; vault values win on key collision"},
+       {"concepts/agent",
+        "runtime, model, system prompt, skills, MCP servers, and a default environment"},
+       {"concepts/conversation",
+        "one run in a fresh sandbox: turns, suspend and resume, SSE streams"},
+       {"concepts/teammates",
+        "a conversation that continues, bound to the reserved `fountain:team` channel, and why it is not a fifth primitive"},
+       {"concepts/secrets",
+        "the layering order, and why a value never reaches the prompt or the transcript"},
+       {"concepts/sandboxes",
+        "provisioning, suspend and resume, reclamation, and what one costs while it runs"},
+       {"concepts/permissions", "what happens before a tool runs inside the sandbox"},
+       {"concepts/surfaces",
+        "which surface you are talking to, and where a conversation-facing feature belongs"}
+     ]},
+    {"API and SDK",
+     [
+       {"api",
+        "endpoints, the response envelope, SSE streaming, and calling back from inside a sandbox to spawn more"},
+       {"sdk",
+        "TypeScript: `fountain.run(prompt, {agent, vault})`, awaitable, streamable, resumable"},
+       {"reference/webhooks", "event payloads and delivery"},
+       {"reference/conversation-states", "the lifecycle, and every terminal state"}
+     ]},
+    {"Catalog",
+     [
+       {"catalog", "Catalog", "everything you can name in an agent spec"},
+       {"catalog/runtimes", "the four agent CLIs side by side"},
+       {"catalog/runtimes/claude",
+        "Anthropic's Claude Code, headless: transport, skills root, which credential it uses"},
+       {"catalog/runtimes/codex", "OpenAI's Codex CLI, headless"},
+       {"catalog/runtimes/opencode", "the only runtime that can reach more than one provider"},
+       {"catalog/runtimes/gemini", "Google's Gemini CLI, headless"},
+       {"catalog/skills", "how skills mount per runtime, and the injection order"},
+       {"catalog/skills/fountain",
+        "the bundled skill that lets an agent inside a sandbox spawn more"},
+       {"catalog/skills/create-team", "the bundled skill that proposes a roster and creates it"},
+       {"catalog/mcp-servers", "what you can attach, and `${VAR}` substitution in the config"},
+       {"catalog/mcp-servers/fountain-team", "lets a teammate see the roster and message it"},
+       {"catalog/mcp-servers/fountain-buzz",
+        "lets an agent publish its reply to a Nostr channel"},
+       {"catalog/mcp-servers/fountain-comms",
+        "gives a teammate its own email address and phone number"}
+     ]},
+    {"Build on it",
+     [
+       {"build", "Build a chat app", "the shape everyone clones, and why"},
+       {"integrations/clients", "Plug into Fountain",
+        "editors over ACP, AG-UI, plugin hosts, relays, or your own code"},
+       {"llm-integration", "this file, `/llms-full.txt`, and `/skill`, explained"}
+     ]},
+    {"Reference",
+     [
+       {"cli/commands", "every CLI command and flag"},
+       {"reference/glossary", "the vocabulary, defined once"}
+     ]},
+    {"Run your own instance",
+     [
+       {"self-hosting", "what you are signing up to operate"},
+       {"configuration", "every environment variable the server reads"},
+       {"troubleshooting", "Troubleshooting", "start from the symptom you can see"}
+     ]}
+  ]
+
+  # Linked but not inlined. Real pages, off the path of "use Fountain".
+  @more [
+    {"architecture", "how the server, the sandboxes and the runners fit together"},
+    {"build/team-chat", "that chat app, end to end"},
+    {"build/pieces", "what each piece of it does"},
+    {"setup", "Local setup", "the toolchain for hacking on Fountain itself, not for using it"},
+    {"changelog", "release notes"}
+  ]
+
+  # A slug that no longer exists is a dead link in a machine-readable index.
+  # Fail the compile instead — same bargain `Fountain.Docs` makes with its nav
+  # parser, and the same reason: a silently missing page is the bug.
+  @known MapSet.new(Fountain.Docs.slugs())
+
+  for {slug, _title, _blurb} <-
+        Enum.map(
+          Enum.flat_map(@corpus, fn {_s, pages} -> pages end) ++ @more,
+          fn
+            {slug, title, blurb} -> {slug, title, blurb}
+            {slug, blurb} -> {slug, nil, blurb}
+          end
+        ) do
+    unless MapSet.member?(@known, slug) do
+      raise """
+      FountainWeb.LlmsController lists docs page #{inspect(slug)}, which \
+      Fountain.Docs does not have. Either it was renamed in docs/nav.yml or the \
+      slug is wrong. Known slugs: #{@known |> Enum.sort() |> Enum.join(", ")}\
+      """
+    end
+  end
 
   def index(conn, _params) do
     send_text(conn, render_index(base_url()))
@@ -32,71 +170,88 @@ defmodule FountainWeb.LlmsController do
   ## ─── Rendering ────────────────────────────────────────────────────────────
 
   defp render_index(base) do
-    """
-    # Fountain
+    [
+      """
+      # Fountain
 
-    > Fountain is a multi-tenant service for running sandboxed coding agents. It provisions an isolated sprite per conversation, mounts a preconfigured environment (packages, repos, env vars, MCP servers, skills), and runs the agent CLI — claude, codex, gemini, or opencode — inside. Use it to delegate, fan out, or parallelize coding agents from your own scripts, CI, or IDE.
+      > Fountain is a multi-tenant service for running sandboxed coding agents. It provisions an isolated sandbox per conversation, mounts a preconfigured environment (packages, repos, env vars, MCP servers, skills), and runs the agent CLI — claude, codex, gemini, or opencode — inside. Use it to delegate, fan out, or parallelize coding agents from your own scripts, CI, or IDE.
 
-    The four primitives:
+      The four primitives:
 
-    - **Environment** — sandbox shape (apt packages, env vars, repos to clone, networking allowlist, setup script)
-    - **Vault** — free-floating bag of encrypted secret overrides, picked per-conversation; layered over the env's secrets
-    - **Agent** — named runtime config (runtime + model + system prompt + skills + MCP servers + an environment)
-    - **Conversation** — one running instance of an agent inside a freshly provisioned sprite, streamable over SSE
+      - **Environment** — sandbox shape (apt packages, env vars, repos to clone, networking allowlist, setup script)
+      - **Vault** — free-floating bag of encrypted secret overrides, picked per-conversation; layered over the env's secrets
+      - **Agent** — named runtime config (runtime + model + system prompt + skills + MCP servers + an environment)
+      - **Conversation** — one running instance of an agent inside a freshly provisioned sandbox, streamable over SSE
 
-    Public instance: <https://fountain.inevitable.fyi>. Source: <https://github.com/BinaryBourbon/fountain>.
+      Reach for it instead of your agent's own sub-agents when you need isolation from your machine, a different set of credentials per run, or a runtime that isn't the one you're sitting in. It is the same delegation, on a machine that is not yours and does not hold your keys.
 
-    ## Get started
+      Public instance: <#{base}>. Source: <https://github.com/BinaryBourbon/fountain>. Getting an account: sign in with GitHub at <#{base}>, then `fountain auth login`. Self-hosting is a supported first-class path — see "Run your own instance" below.
 
-    - [Quickstart](#{base}/help/quickstart): five minutes from install to first conversation
-    - [CLI install (Homebrew)](https://github.com/BinaryBourbon/homebrew-tap): `brew install BinaryBourbon/tap/fountain`
-    - [Example agent specs](https://github.com/jhgaylor/agent-specs): public manifest tree you can `fountain apply`
+      ## Read this first if you are an agent
 
-    ## Concepts
+      - [/llms-full.txt](#{base}/llms-full.txt): every page linked below, inlined as one document (~230 KB). One fetch instead of #{corpus_count()}.
+      - [/skill](#{base}/skill): a `SKILL.md` to drop into `~/.claude/skills/fountain/` so Claude Code (or anything that loads SKILL.md) can drive Fountain without reading the manual first.
 
-    - [Agents](#{base}/help/agents): runtime, model, skills, MCP server config
-    - [Environments](#{base}/help/environments): sandbox shape, packages, repositories, networking
-    - [Vaults](#{base}/help/vaults): per-conversation credential overrides
-    - [Manifest](#{base}/help/manifest): `fountain apply -f fountain.yml` declarative format
-    - [Spawning sub-agents](#{base}/help/spawning): how agents inside sprites call back to spawn more
-    - [Secrets managers](#{base}/help/secrets-managers): 1Password, Bitwarden, Infisical apply-time resolution
-    - [Operator runbook](#{base}/help/runbook): incident response, key rotation, orphaned sprite cleanup
+      ```sh
+      mkdir -p ~/.claude/skills/fountain
+      curl -fsSL #{base}/skill > ~/.claude/skills/fountain/SKILL.md
+      ```
 
-    ## API
+      ## API contract
 
-    - [OpenAPI 3 spec](#{base}/api/openapi.json): machine-readable contract
-    - [Swagger UI](#{base}/api/docs): interactive try-it, click "Authorize" to set your bearer token
-    - [Endpoint summary](#{base}/help/api): summary table and response envelope
-    - [TypeScript SDK](https://github.com/BinaryBourbon/fountain/tree/main/sdk/typescript): `fountain.run(prompt, {agent, vault})` over the conversation endpoints; awaitable, streamable, resumable
+      - [OpenAPI 3 spec](#{base}/api/openapi.json): machine-readable, the authority on request and response shapes
+      - [Swagger UI](#{base}/api/docs): interactive try-it, click "Authorize" to set your bearer token
+      - [TypeScript SDK](https://www.npmjs.com/package/@agentshit/fountain-sdk): `npm install @agentshit/fountain-sdk`
+      - [CLI (Homebrew)](https://github.com/BinaryBourbon/homebrew-tap): `brew install BinaryBourbon/tap/fountain`
+      - [Example agent specs](https://github.com/jhgaylor/agent-specs): public manifest tree you can `fountain apply`
+      """,
+      Enum.map(@corpus, fn {section, pages} ->
+        ["\n## ", section, "\n\n", Enum.map(pages, &link_line(&1, base)), ""]
+      end),
+      """
 
-    ## For LLMs
+      ## More on /docs
 
-    - [/llms-full.txt](#{base}/llms-full.txt): everything in this index expanded and inlined as one document
-    - [/skill](#{base}/skill): a `SKILL.md` you can drop into `~/.claude/skills/fountain/` to teach Claude Code (or any agent that loads SKILL.md) how to use Fountain
+      Real pages, not inlined in `/llms-full.txt`.
 
-    Install the skill:
+      """,
+      Enum.map(@more, &link_line(&1, base)),
+      """
 
-    ```sh
-    mkdir -p ~/.claude/skills/fountain
-    curl -fsSL #{base}/skill > ~/.claude/skills/fountain/SKILL.md
-    ```
+      ## Optional
 
-    ## Optional
+      - [GitHub repo](https://github.com/BinaryBourbon/fountain): source, releases, issues
+      - [llms.txt spec](https://llmstxt.org/): the convention this file follows
+      """
+    ]
+    |> IO.iodata_to_binary()
+  end
 
-    - [GitHub repo](https://github.com/BinaryBourbon/fountain): source, releases, issues
-    - [Homebrew tap](https://github.com/BinaryBourbon/homebrew-tap): pinned binaries
-    - [llms.txt spec](https://llmstxt.org/): the convention this file follows
-    """
+  defp link_line(entry, base) do
+    {slug, title, blurb} = normalize(entry)
+
+    [
+      "- [",
+      title,
+      "](",
+      base,
+      Fountain.Docs.Compiler.path_for_slug(slug),
+      "): ",
+      blurb,
+      "\n"
+    ]
   end
 
   defp render_full(base) do
     [
       render_index(base),
       "\n\n---\n\n# Full documentation\n\n",
-      "Everything below is the in-app help corpus inlined for LLMs that prefer a single document over crawling links.\n\n",
-      bundled_help_sections(),
+      "Every page linked above, inlined for agents that would rather take one fetch than crawl #{corpus_count()} links. Source of truth is the same markdown served at `#{base}/docs`.\n",
+      Enum.map(@corpus, fn {section, pages} ->
+        ["\n\n---\n\n# ", section, "\n", Enum.map(pages, &inlined_page(&1, base))]
+      end),
       "\n\n---\n\n# SKILL.md (external)\n\n",
-      "The block below is also served at `#{base}/skill`. Drop it into `~/.claude/skills/fountain/SKILL.md` (or the equivalent for your agent) so the agent has the full operational knowledge below loaded as a skill.\n\n",
+      "The block below is also served at `#{base}/skill`. Drop it into `~/.claude/skills/fountain/SKILL.md` (or the equivalent for your agent) so the agent has the operational knowledge loaded as a skill.\n\n",
       "```markdown\n",
       read_skill(),
       "\n```\n"
@@ -104,25 +259,39 @@ defmodule FountainWeb.LlmsController do
     |> IO.iodata_to_binary()
   end
 
-  defp bundled_help_sections do
-    Enum.map(Fountain.Help.topics(), fn {slug, title} ->
-      body = read_help(slug)
-      ["\n\n## ", title, " (`/help/", slug, "`)\n\n", body, "\n"]
-    end)
+  defp inlined_page(entry, base) do
+    {slug, title, _blurb} = normalize(entry)
+    {:ok, %{body: body}} = Fountain.Docs.get(slug)
+
+    [
+      "\n\n## ",
+      title,
+      " (`",
+      Fountain.Docs.Compiler.path_for_slug(slug),
+      "`)\n\n",
+      absolutize(body, base),
+      "\n"
+    ]
   end
+
+  # `Fountain.Docs.Compiler` rewrites a page's relative `.md` links to
+  # root-relative `/docs/...` paths, which is right for the browser and wrong
+  # here: `/llms-full.txt` is read as a detached string, with no page for a
+  # relative link to be relative to. Give every in-page link the host back.
+  defp absolutize(body, base), do: String.replace(body, "](/", "](" <> base <> "/")
+
+  # `{slug, blurb}` takes its title from the nav; `{slug, title, blurb}` overrides
+  # it, for the pages whose nav title only makes sense next to its siblings.
+  defp normalize({slug, title, blurb}), do: {slug, title, blurb}
+
+  defp normalize({slug, blurb}) do
+    {:ok, %{title: title}} = Fountain.Docs.get(slug)
+    {slug, title, blurb}
+  end
+
+  defp corpus_count, do: @corpus |> Enum.flat_map(fn {_s, pages} -> pages end) |> length()
 
   ## ─── File reads ───────────────────────────────────────────────────────────
-
-  # sobelow_skip ["Traversal.FileModule"] — slug comes from the compile-time
-  # Fountain.Help.topics() list, never from the request.
-  defp read_help(slug) do
-    path = Path.join([priv_dir(), "help", slug <> ".md"])
-
-    case File.read(path) do
-      {:ok, body} -> body
-      {:error, _} -> "_(missing: " <> slug <> ".md)_"
-    end
-  end
 
   # sobelow_skip ["Traversal.FileModule"] — fixed priv path, no user input.
   defp read_skill do

--- a/apps/fountain/priv/external_skills/fountain/SKILL.md
+++ b/apps/fountain/priv/external_skills/fountain/SKILL.md
@@ -302,7 +302,8 @@ Errors:
 
 ## Further reading
 
-- Quickstart: `$FOUNTAIN_BASE_URL/help/quickstart`
+- Guided tour, end to end: `$FOUNTAIN_BASE_URL/docs/tour`
+- API reference: `$FOUNTAIN_BASE_URL/docs/api`
 - Full doc bundle for LLMs: `$FOUNTAIN_BASE_URL/llms-full.txt`
 - OpenAPI spec: `$FOUNTAIN_BASE_URL/api/openapi.json`
 - Source: https://github.com/BinaryBourbon/fountain

--- a/apps/fountain/test/fountain_web/controllers/llms_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/llms_controller_test.exs
@@ -12,16 +12,43 @@ defmodule FountainWeb.LlmsControllerTest do
 
       body = conn.resp_body
       assert body =~ "# Fountain"
-      assert body =~ "## API"
+      assert body =~ "## API contract"
       assert body =~ "/api/openapi.json"
-      assert body =~ "## For LLMs"
       assert body =~ "/llms-full.txt"
       assert body =~ "/skill"
+    end
+
+    test "links only public /docs pages, never the authenticated /help routes", %{conn: conn} do
+      body = get(conn, ~p"/llms.txt").resp_body
+
+      # /help/:topic is in live_session :authenticated. An unauthenticated
+      # fetch of one renders the app shell, whose only text is "Sign in", so a
+      # link to it in the file agents are meant to follow is a dead link.
+      refute body =~ "/help/"
+
+      for slug <- ["/docs/primitives", "/docs/api", "/docs/tour", "/docs/concepts/vault"] do
+        assert body =~ slug, "expected llms.txt to link #{slug}"
+      end
+    end
+
+    test "every /docs page it links is a page Fountain.Docs can serve", %{conn: conn} do
+      known = MapSet.new(Fountain.Docs.slugs())
+
+      ~r{\]\(https?://[^/)]+/docs(/[^)\s]*)?\)}
+      |> Regex.scan(get(conn, ~p"/llms.txt").resp_body, capture: :all_but_first)
+      |> Enum.map(fn
+        [] -> ""
+        [path] -> String.trim_leading(path, "/")
+      end)
+      |> Enum.each(fn slug ->
+        assert MapSet.member?(known, slug),
+               "llms.txt links /docs/#{slug}, which Fountain.Docs does not have"
+      end)
     end
   end
 
   describe "GET /llms-full.txt" do
-    test "concatenates the index + help corpus + external SKILL.md", %{conn: conn} do
+    test "concatenates the index + the docs corpus + external SKILL.md", %{conn: conn} do
       conn = get(conn, ~p"/llms-full.txt")
 
       assert conn.status == 200
@@ -34,25 +61,32 @@ defmodule FountainWeb.LlmsControllerTest do
       # Index is included up top
       assert body =~ "# Fountain"
 
-      # Every curated help topic appears
-      for {_slug, title} <- [
-            {"quickstart", "Quickstart"},
-            {"agents", "Agents"},
-            {"environments", "Environments"},
-            {"vaults", "Vaults"},
-            {"manifest", "Manifest"},
-            {"spawning", "Spawning sub-agents"},
-            {"api", "API reference"},
-            {"secrets-managers", "Secrets managers"},
-            {"for-llms", "For LLMs"},
-            {"runbook", "Operating"}
-          ] do
-        assert body =~ title, "expected llms-full.txt to mention #{title}"
+      # Section headers, then the pages under them, keyed by the /docs path so
+      # a reader can go back to the live page.
+      for section <- ["# Get started", "# Concepts", "# API and SDK", "# Catalog"] do
+        assert body =~ section, "expected llms-full.txt to have section #{section}"
+      end
+
+      for path <- ["(`/docs/primitives`)", "(`/docs/api`)", "(`/docs/concepts/vault`)"] do
+        assert body =~ path, "expected llms-full.txt to inline #{path}"
       end
 
       # External SKILL.md tail
       assert body =~ "SKILL.md (external)"
       assert body =~ "FOUNTAIN_API_KEY"
+    end
+
+    test "inlines the body of every page the index links", %{conn: conn} do
+      body = get(conn, ~p"/llms-full.txt").resp_body
+
+      # A phrase from a page body, not from its blurb in the index.
+      assert body =~ "vault"
+      assert body =~ "sandbox"
+
+      # The bundle is read detached from any page, so a root-relative link in
+      # an inlined body has nothing to be relative to.
+      refute body =~ "](/docs/"
+      assert body =~ "/docs/concepts/"
     end
   end
 
@@ -69,6 +103,7 @@ defmodule FountainWeb.LlmsControllerTest do
       assert body =~ "---\nname: fountain"
       assert body =~ "FOUNTAIN_API_KEY"
       assert body =~ "fountain apply"
+      refute body =~ "/help/"
     end
 
     test "is also reachable at /skills/fountain/SKILL.md", %{conn: conn} do

--- a/docs/llm-integration.md
+++ b/docs/llm-integration.md
@@ -2,7 +2,7 @@
 
 Fountain exists for an AI coding tool to consume. Each instance serves
 discovery endpoints that a machine can read, so an agentic IDE learns the full
-API from one fetch.
+API from one fetch. Each one links pages on `/docs`, which needs no login.
 
 The examples below run against your own instance. Point `FOUNTAIN_URL` at it.
 
@@ -24,8 +24,8 @@ the auth module. It works with no more setup.
 
 | Endpoint | Content | Best for |
 |---|---|---|
-| `/llms.txt` | A short API summary, about 500 tokens. | A model with little context to spare. |
-| `/llms-full.txt` | The full API reference. | An agent that calls many tools. |
+| `/llms.txt` | An index of the manual, with a summary of what Fountain is. About 2,000 tokens. | A first fetch, or a model with little context to spare. |
+| `/llms-full.txt` | Every page that the index links, in one document. About 230 KB. | An agent that must not crawl links. |
 | `/skill` | The skill file for Claude Code and Cursor. | IDE skills. |
 
 ```bash


### PR DESCRIPTION
## The bug

Every Concepts link in `/llms.txt` pointed at `/help/:topic`. Those routes live in `live_session :authenticated`, so an unauthenticated fetch renders the app shell, whose only text content is "Sign in". Seven links in the file whose entire audience is machines resolved to a login page.

```
$ curl -s https://fountain.inevitable.fyi/help/agents | sed 's/<[^>]*>/ /g' | tail -3
 Sign in
 or
 Continue with GitHub
```

It went unnoticed because the same content was *also* inlined into `/llms-full.txt`, which is the path most agents take. An agent that followed the index instead struck out seven times in a row.

## The fix

`/docs` is public, server-rendered and the full manual, so the index points there now. All 43 linked `/docs` URLs were checked against the live site: every one returns 200.

- **One source.** The index and the bundle are generated from a single `@corpus` list built on `Fountain.Docs`, so a link and its inlined body cannot disagree. Titles come from the nav by default; a 3-tuple entry overrides the three that read as a bare "Overview" outside the sidebar.
- **A dead link fails the build.** A slug `Fountain.Docs` does not have raises at compile time, the same bargain the nav parser makes and for the same reason.
- **`/llms-full.txt` inlines the docs corpus** instead of the help corpus: 38 pages, ~230 KB. Deliberately not all of `nav()`, which is ~490 KB and over half operator runbooks (Kubernetes, Stripe, backups) that an agent calling the API has no use for. The rest is linked under "More on /docs" and labelled as not inlined, so the "everything above, expanded" promise stays true.
- **Links in the bundle get their host back.** `Compiler` rewrites relative `.md` links to root-relative `/docs/...`, which is right for a browser and wrong in a bundle read as a detached string with no page to be relative to. 321 of them.

Two gaps in the index closed while it was being rebuilt: how you get an account (GitHub sign-in, and self-hosting as a first-class path), and when to reach for Fountain over the sub-agents the reader already has.

Also fixes the one dead `/help/quickstart` link in the external `SKILL.md`, and the `docs/llm-integration.md` table, which called `/llms.txt` a 500-token API summary and `/llms-full.txt` the API reference.

## Checks

`mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` (578 files), `scripts/docs-style.py`, and 40 tests across `llms_controller_test`, `docs_test` and `help_test`. Vale is not installed locally, so the STE gate on the `docs/llm-integration.md` edit is unverified here.

Tests added: a `refute body =~ "/help/"` guard on both the index and the skill, and a scan of every `/docs` link in the rendered index against `Fountain.Docs.slugs()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)