### PR TITLE
feat(web): serve the marketing page only where the deployment says so

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,14 @@ SPRITES_TOKEN=
 # UNVERIFIED_PRUNE_AFTER_DAYS=30
 # UNVERIFIED_PRUNE_EXEMPT=
 
+# ── Public pages ─────────────────────────────────────────────────────────────
+
+# Which page `/` serves. Off, it is a plain front door: the instance, a way in,
+# and a link to the docs. On, it is the Fountain project's product page, with
+# the pitch, the price and the free trial — which is the project's own hosted
+# deployment, and nobody else's.
+# MARKETING_SITE=true
+
 # ── Legal pages ──────────────────────────────────────────────────────────────
 
 # The legal identity /terms and /privacy render — yours, not the Fountain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,27 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Changed
+
+- **`/` is no longer the same page on every deployment.** The homepage sold a
+  product: a hero, a 14-day trial, a monthly price, and a footer calling
+  Fountain "managed agent infrastructure". Every self-hosted instance served
+  it, to an audience of the operator and their own team, none of whom are
+  buying a trial of the thing they already run. `/` now serves a plain front
+  door — the instance, a way in, and a link to `/docs` — unless the deployment
+  sets `MARKETING_SITE=true`. This is the reasoning `LEGAL_ENTITY` already
+  applies one page over (#517): an instance must not serve the upstream
+  project's terms, and it has no more business serving the upstream project's
+  sales copy. The flag is off by default, so a self-host is right without
+  reading this entry. It is deliberately not `BILLING_ENABLED`, which an
+  operator running Fountain commercially inside their own company may well
+  turn on.
+- **A closed instance stops advertising registration.** With
+  `REGISTRATION_ENABLED=false` the public pages still linked "Get started" and
+  "Register", and `Accounts.registration_allowed?/1` then refused the submit.
+  The nav, the footer and the new front door now hide the link. The context
+  check is unchanged and is still the control.
+
 ### Removed
 
 - **The GitHub Pages documentation site.** `docs/` had two publishers: the

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -64,7 +64,7 @@ defmodule Fountain.Accounts do
   @spec registration_allowed?(String.t() | nil) :: :ok | {:error, atom()}
   def registration_allowed?(email) do
     cond do
-      not Application.get_env(:fountain, :registration_enabled, true) ->
+      not registration_enabled?() ->
         {:error, :registration_closed}
 
       not domain_allowed?(email) ->
@@ -74,6 +74,17 @@ defmodule Fountain.Accounts do
         :ok
     end
   end
+
+  @doc """
+  Whether registration is open at all, with no email in hand.
+
+  For a front door deciding whether to offer a "create an account" link: a link
+  that leads to a refusal is worse than no link. It is not a control —
+  `registration_allowed?/1` stays the thing that refuses the submit, on all
+  three paths.
+  """
+  @spec registration_enabled?() :: boolean()
+  def registration_enabled?, do: Application.get_env(:fountain, :registration_enabled, true)
 
   defp domain_allowed?(email) do
     case Application.get_env(:fountain, :registration_allowed_email_domains, []) do

--- a/apps/fountain/lib/fountain/marketing.ex
+++ b/apps/fountain/lib/fountain/marketing.ex
@@ -1,0 +1,27 @@
+defmodule Fountain.Marketing do
+  @moduledoc """
+  Whether this deployment is the Fountain project's own marketing site.
+
+  `/` serves one of two pages. The hosted deployment serves the product pitch:
+  a hero, a price, a free trial. Every other deployment serves a plain front
+  door — the instance, a way in, and a link to the manual.
+
+  The reasoning is `Fountain.Legal`'s (#517), one page over. A self-hosted
+  instance must never serve the upstream project's legal terms, and it has no
+  more business serving the upstream project's sales copy: nobody running
+  Fountain for their own team is selling a 14-day trial of it.
+
+  Off unless `MARKETING_SITE=true` (config/runtime.exs), so a self-host is
+  right by default and the hosted deployment opts in — the same shape, for the
+  same reason, as `BILLING_ENABLED` (#336).
+
+  Deliberately *not* `Fountain.Billing.enabled?/0`, the closest existing flag.
+  Billing says "this instance charges money", which an operator running
+  Fountain commercially inside their own company may well turn on. That must
+  not hand them a homepage selling somebody else's product.
+  """
+
+  @doc "Whether `/` serves the product pitch rather than a plain front door."
+  @spec site?() :: boolean()
+  def site?, do: Application.get_env(:fountain, :marketing_site, false)
+end

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -28,6 +28,7 @@
             Sign in
           </a>
           <a
+            :if={Fountain.Accounts.registration_enabled?()}
             href={~p"/auth/register"}
             class="text-sm font-medium bg-[var(--color-brand)] text-white px-4 py-1.5 rounded-md hover:bg-[var(--color-brand-hover)] transition-colors"
           >
@@ -46,9 +47,12 @@
   <%!-- Footer --%>
   <footer class="border-t border-[var(--color-border)] bg-[var(--color-bg-1)]">
     <div class="max-w-5xl mx-auto px-6 py-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-[var(--color-text-muted)]">
-      <span>
+      <%!-- The project's copyright line and its one-line pitch belong on the
+        project's own site. Somebody else's deployment gets an attribution. --%>
+      <span :if={Fountain.Marketing.site?()}>
         © 2026 Fountain. Managed agent infrastructure for teams who'd rather build than configure.
       </span>
+      <span :if={!Fountain.Marketing.site?()}>Powered by Fountain.</span>
       <div class="flex items-center gap-4">
         <a href="/docs" class="hover:text-[var(--color-text-secondary)] transition-colors">
           Docs
@@ -79,6 +83,7 @@
             Sign in
           </a>
           <a
+            :if={Fountain.Accounts.registration_enabled?()}
             href={~p"/auth/register"}
             class="hover:text-[var(--color-text-secondary)] transition-colors"
           >

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -1,9 +1,18 @@
 defmodule FountainWeb.MarketingController do
-  @moduledoc false
+  @moduledoc """
+  The public pages: `/`, `/terms` and `/privacy`.
+
+  None of the three is the same page on every deployment. `/` serves the
+  product pitch on the marketing site and a plain front door everywhere else
+  (`Fountain.Marketing`); the legal pages render the operator's identity, or
+  nothing at all (`Fountain.Legal`). A deployment is not the Fountain project,
+  and these pages are the three that would claim otherwise.
+  """
   use FountainWeb, :controller
 
   def home(conn, _params) do
-    render(conn, :home, layout: {FountainWeb.Layouts, :marketing})
+    page = if Fountain.Marketing.site?(), do: :home, else: :instance
+    render(conn, page, layout: {FountainWeb.Layouts, :marketing})
   end
 
   def terms(conn, _params) do

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/instance.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/instance.html.heex
@@ -1,0 +1,47 @@
+<%!--
+  The front door on every deployment that is not the project's marketing site.
+  Deliberately plain: what this is, the way in, and the manual. No pitch, no
+  price, no trial — see Fountain.Marketing.
+--%>
+<section class="max-w-xl mx-auto px-6 py-24">
+  <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-8 text-center">
+    <img src="/images/app-icon.png" alt="" class="size-12 rounded-xl mx-auto mb-5" />
+    <h1 class="text-2xl font-semibold tracking-tight text-[var(--color-text-primary)] mb-3">
+      Fountain
+    </h1>
+    <p class="text-[var(--color-text-secondary)] leading-relaxed mb-8">
+      This instance runs agents on sandboxes and serves their conversations over an API. Sign in to reach the console.
+    </p>
+
+    <div class="flex flex-col sm:flex-row gap-3 justify-center">
+      <%= if @current_user do %>
+        <a
+          href={~p"/dashboard"}
+          class="inline-flex items-center justify-center px-6 py-2.5 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+        >
+          Open the console
+        </a>
+      <% else %>
+        <a
+          href={~p"/auth/login"}
+          class="inline-flex items-center justify-center px-6 py-2.5 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+        >
+          Sign in
+        </a>
+        <a
+          :if={Fountain.Accounts.registration_enabled?()}
+          href={~p"/auth/register"}
+          class="inline-flex items-center justify-center px-6 py-2.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+        >
+          Create an account
+        </a>
+      <% end %>
+      <a
+        href="/docs"
+        class="inline-flex items-center justify-center px-6 py-2.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+      >
+        Read the manual
+      </a>
+    </div>
+  </div>
+</section>

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -1,0 +1,81 @@
+# async: false — these mutate the global :marketing_site / :registration_enabled
+# app env, which config/test.exs pins for the whole suite.
+defmodule FountainWeb.MarketingInstanceTest do
+  use FountainWeb.ConnCase, async: false
+
+  setup do
+    marketing = Application.get_env(:fountain, :marketing_site)
+    registration = Application.get_env(:fountain, :registration_enabled)
+
+    on_exit(fn ->
+      Application.put_env(:fountain, :marketing_site, marketing)
+      Application.put_env(:fountain, :registration_enabled, registration)
+    end)
+
+    :ok
+  end
+
+  describe "GET / where the deployment is not the marketing site" do
+    setup do
+      Application.put_env(:fountain, :marketing_site, false)
+      :ok
+    end
+
+    test "serves a plain front door and none of the pitch", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      assert body =~ "This instance runs agents on sandboxes"
+      assert body =~ ~p"/auth/login"
+      assert body =~ "/docs"
+
+      refute body =~ "Have the conversation. Skip the infrastructure."
+      refute body =~ "What you stop building."
+      refute body =~ "14-day trial"
+      refute body =~ "Managed agent infrastructure"
+    end
+
+    test "keeps the price off the page even with a price configured", %{conn: conn} do
+      Application.put_env(:fountain, :stripe_price_monthly_cents, 2900)
+      on_exit(fn -> Application.delete_env(:fountain, :stripe_price_monthly_cents) end)
+
+      refute conn |> get(~p"/") |> html_response(200) =~ "/mo per user"
+    end
+
+    test "offers registration while registration is open", %{conn: conn} do
+      Application.put_env(:fountain, :registration_enabled, true)
+
+      body = conn |> get(~p"/") |> html_response(200)
+      assert body =~ ~p"/auth/register"
+      assert body =~ "Create an account"
+    end
+
+    test "drops every registration link once registration is closed", %{conn: conn} do
+      Application.put_env(:fountain, :registration_enabled, false)
+
+      # Not only the page's own CTA: the shared marketing layout's nav and
+      # footer link it too, and a link to a door the context refuses is worse
+      # than no link.
+      refute conn |> get(~p"/") |> html_response(200) =~ ~p"/auth/register"
+    end
+
+    test "points a signed-in visitor at the console", %{conn: conn} do
+      user = insert_verified_user()
+
+      body = conn |> login_user(user) |> get(~p"/") |> html_response(200)
+      assert body =~ "Open the console"
+      assert body =~ ~p"/dashboard"
+      refute body =~ ~p"/auth/register"
+    end
+  end
+
+  describe "GET / on the marketing site" do
+    test "still serves the pitch", %{conn: conn} do
+      Application.put_env(:fountain, :marketing_site, true)
+
+      body = conn |> get(~p"/") |> html_response(200)
+      assert body =~ "Have the conversation. Skip the infrastructure."
+      assert body =~ "Managed agent infrastructure"
+      refute body =~ "This instance runs agents on sandboxes"
+    end
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -48,7 +48,11 @@ config :fountain, Oban,
 config :fountain,
   billing_enabled: true,
   registration_enabled: true,
-  registration_allowed_email_domains: []
+  registration_allowed_email_domains: [],
+  # Which page `/` serves. False everywhere but the hosted deployment, which
+  # opts in with MARKETING_SITE (runtime.exs); config/test.exs pins it true so
+  # the suite covers the pitch and flips it off per-test. See Fountain.Marketing.
+  marketing_site: false
 
 # Sandbox lifetime bounds. Crossing the idle bound SUSPENDS the sandbox — the
 # sprite stays (scaled to zero) and the next prompt resumes the agent with its

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -347,6 +347,17 @@ if config_env() != :test do
   config :fountain, :billing_enabled, System.get_env("BILLING_ENABLED", "false") != "false"
 end
 
+# Which page `/` serves. The hosted deployment shows the product pitch; every
+# other deployment shows a plain front door, for the reason a self-hosted
+# instance does not serve the upstream project's legal terms either. Off by
+# default, opted into by k8s/deployment.yaml.
+#
+# Skipped in :test — config/test.exs pins it on, so the suite exercises the
+# marketing page and flips it off per-test through the application env.
+if config_env() != :test do
+  config :fountain, :marketing_site, System.get_env("MARKETING_SITE", "false") != "false"
+end
+
 # The legal identity /terms and /privacy render (#517). Instance config, not
 # source: a self-hosted operator must never serve the upstream project's legal
 # terms, and the hosted instance's real entity does not belong in the repo.

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,6 +30,11 @@ config :ueberauth, Ueberauth.Strategy.Github.OAuth,
 # toggles it per-test via the application env.
 config :fountain, :billing_enabled, true
 
+# `/` serves the marketing page in :test (MARKETING_SITE is not read in :test —
+# see config/runtime.exs), so the existing homepage tests keep covering the
+# pitch. The plain front door is covered by flipping this off per-test.
+config :fountain, :marketing_site, true
+
 # Legal identity pinned (LEGAL_* env vars are not read in :test — see
 # config/runtime.exs) so the developer's shell can't change suite behavior;
 # unpublished-page tests set :legal to nil through the application env.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,19 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 
 <!-- vale STE.IngForms = YES -->
 
+## Public pages
+
+The `/` page is not the same page on every deployment. The Fountain project's
+own site shows the product page, with the price and the free trial. Every other
+deployment shows a plain front door: the name, a way in, and a link to this
+manual.
+
+Your deployment is not the Fountain project, so the front door is the default.
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `MARKETING_SITE` | `false` | — | A `true` serves the Fountain project's product page at `/`. It also puts the project's copyright line in the footer. Turn it on only if you operate the project's own site. |
+
 ## Legal pages
 
 These four variables carry the identity that `/terms` and `/privacy` render.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -120,6 +120,10 @@ spec:
             # hosted instance is the deployment that opts in.
             - name: BILLING_ENABLED
               value: "true"
+            # `/` serves a plain front door unless a deployment says it is the
+            # project's own site. This is the one that is.
+            - name: MARKETING_SITE
+              value: "true"
             # TODO(#500): before billing launch, set LEGAL_ENTITY,
             # LEGAL_CONTACT_EMAIL, LEGAL_JURISDICTION, LEGAL_EFFECTIVE_DATE
             # (#517) — until then /terms and /privacy render loud


### PR DESCRIPTION
## The problem

`/` sold a product on every deployment. A hero ("Have the conversation. Skip the infrastructure."), a 14-day trial, a monthly price read from Stripe, a "Start free — no credit card" CTA, and a footer calling Fountain "managed agent infrastructure for teams who'd rather build than configure".

Every self-hosted instance served all of that, to an audience of the operator and their own team — none of whom are buying a trial of the thing they already run.

## The change

`/` now serves one of two pages:

| Deployment | `/` |
|---|---|
| `MARKETING_SITE=true` | The product page, unchanged |
| Everything else (default) | A plain front door: the instance, a way in, a link to `/docs` |

This is the reasoning `Fountain.Legal` already applies one page over (#517) — an instance must not serve the upstream project's legal terms, and it has no more business serving the upstream project's sales copy. The flag is off by default, so a self-host is right without reading a changelog; `k8s/deployment.yaml` is the deployment that opts in, the same shape as `BILLING_ENABLED` (#336).

**Deliberately not `Fountain.Billing.enabled?/0`**, the closest existing flag. Billing means "this instance charges money", which an operator running Fountain commercially inside their own company may well turn on. That must not hand them a homepage selling somebody else's product.

The marketing layout's footer branches too: the project's copyright line and one-line pitch on the marketing site, `Powered by Fountain.` everywhere else.

### A smaller lie on the same pages

With `REGISTRATION_ENABLED=false`, the nav and footer still linked "Get started" and "Register" — and `Accounts.registration_allowed?/1` then refused the submit. Both links, and the new front door's, now read a new `Accounts.registration_enabled?/0`. The context check is unchanged and is still the control; this only stops the page advertising a door that is locked.

## What it looks like

The front door (`MARKETING_SITE` unset), rendered by `mix phx.server` in dev:

- Icon, "Fountain", one neutral sentence about what the instance is
- Sign in / Create an account / Read the manual
- Signed in, the primary button becomes "Open the console"
- Footer reads `Powered by Fountain.`

No price, no trial, no pitch — asserted by `refute` in the new test.

## Not in scope

Moving `home.html.heex` under `ee/` (Elastic 2.0) would say the copy is not licensed for reuse. That is a licence decision, independent of this one: `ee/lib` compiles into every build (`apps/fountain/mix.exs:44-45`), so it would not change what any deployment serves. Worth deciding separately, with a note in decisions/0027.

## Deploy note

This touches `k8s/deployment.yaml`, so merging publishes manifests and Flux applies the new `MARKETING_SITE=true` to prod. That is what keeps the marketing page on `fountain.inevitable.fyi`. If the manifest change and the image land out of order, the window shows the front door on prod — cosmetic, and it self-corrects.

## Testing

- New `marketing_instance_test.exs`: no pitch, no price, docs and sign-in links present, registration link appears and disappears with `REGISTRATION_ENABLED`, signed-in visitor is sent to the console, and the pitch still renders with the flag on.
- Verified the registration assertion against the un-fixed layout: it fails without the `:if` guards.
- Full local gate green — `mix precommit`: compile --warnings-as-errors, format, `credo --strict` (0 issues), dialyzer (0 errors), sobelow, **3651 tests, 0 failures**.
- `python3 scripts/docs-style.py` clean; `vale lint docs/configuration.md` reports 0 errors and 0 warnings (Vocabulary suggestions only, which do not gate).
- Both branches confirmed live in dev with and without `MARKETING_SITE=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)