### PR TITLE
fix(billing): read the period from the subscription item, and let verify_plans run in a release

### DIFF
--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -81,8 +81,11 @@ and charges another.
 Run the verifier against the same key the instance uses.
 
 ```bash
-bin/fountain_server eval 'Mix.Tasks.Fountain.VerifyPlans.run([])'
+bin/fountain_server rpc 'Mix.Tasks.Fountain.VerifyPlans.run([])'
 ```
+
+Use `rpc`, not `eval`. An `eval` starts a second copy of the code with no
+application running, so it reads none of the configuration you want to check.
 
 From a checkout, run `mix fountain.verify_plans` instead. The task reads each
 price from Stripe. It fails if the amount, the currency, the interval or the

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -543,7 +543,7 @@ defmodule Fountain.Billing do
           %{
             subscription_status: coerce_status(sub.status, "trial_sweep"),
             trial_ends_at: unix_field(Map.get(sub, :trial_end)),
-            current_period_end: unix_field(Map.get(sub, :current_period_end))
+            current_period_end: unix_field(period_end_unix(sub))
           },
           now,
           :synced
@@ -635,7 +635,7 @@ defmodule Fountain.Billing do
     attrs = %{
       subscription_status: coerce_status(sub.status, "admin_resync"),
       trial_ends_at: unix_field(Map.get(sub, :trial_end)),
-      current_period_end: unix_field(Map.get(sub, :current_period_end)),
+      current_period_end: unix_field(period_end_unix(sub)),
       cancel_at_period_end: Map.get(sub, :cancel_at_period_end) == true,
       subscription_synced_at: DateTime.utc_now() |> DateTime.truncate(:second)
     }
@@ -1425,7 +1425,7 @@ defmodule Fountain.Billing do
       type != "customer.subscription.deleted" and Map.get(sub, :cancel_at_period_end) == true
 
     current_period_end =
-      case Map.get(sub, :current_period_end) do
+      case period_end_unix(sub) do
         ts when is_integer(ts) -> DateTime.from_unix!(ts) |> DateTime.truncate(:second)
         _ -> nil
       end
@@ -1827,6 +1827,39 @@ defmodule Fountain.Billing do
   defp subscription_items(%{items: data}) when is_list(data), do: data
   defp subscription_items(%{"items" => %{"data" => data}}) when is_list(data), do: data
   defp subscription_items(_), do: []
+
+  @doc false
+  # When the current billing period ends, as a unix timestamp, or nil.
+  #
+  # Stripe moved `current_period_start`/`current_period_end` off the
+  # subscription and onto its items. On the API version this account is pinned
+  # to, the subscription-level field reads `nil` and the real value sits on
+  # `items.data[]` — so the obvious `Map.get(sub, :current_period_end)` had
+  # never once populated `users.current_period_end` (#1018), and the
+  # "access until <date>" a cancelling customer is shown was blank.
+  #
+  # Reads the item, falling back to the subscription-level field so an older
+  # API version — and every existing test fixture, which is built in the old
+  # shape and is exactly why this went unseen — still works.
+  #
+  # Any item will do: a plan item and a teammate-contact add-on ride the same
+  # subscription and therefore share its period.
+  def period_end_unix(sub) do
+    case Map.get(sub, :current_period_end) || Map.get(sub, "current_period_end") do
+      ts when is_integer(ts) ->
+        ts
+
+      _ ->
+        sub
+        |> subscription_items()
+        |> Enum.find_value(fn item ->
+          case Map.get(item, :current_period_end) || Map.get(item, "current_period_end") do
+            ts when is_integer(ts) -> ts
+            _ -> nil
+          end
+        end)
+    end
+  end
 
   defp item_price_id(%{price: %{id: id}}), do: id
   defp item_price_id(%{price: id}) when is_binary(id), do: id

--- a/ee/lib/mix/tasks/fountain.verify_plans.ex
+++ b/ee/lib/mix/tasks/fountain.verify_plans.ex
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Fountain.VerifyPlans do
     {:ok, _} = Application.ensure_all_started(:stripity_stripe)
 
     unless configured_key?() do
-      Mix.raise("STRIPE_SECRET_KEY is not set — there is nothing to verify against.")
+      abort("STRIPE_SECRET_KEY is not set — there is nothing to verify against.")
     end
 
     results = Enum.map(Plans.all(), &check_plan/1) ++ [check_contact_addon()]
@@ -67,13 +67,26 @@ defmodule Mix.Tasks.Fountain.VerifyPlans do
 
     failures = Enum.count(results, &match?({:fail, _, _}, &1))
 
-    Mix.shell().info("")
+    IO.puts("")
 
     if failures == 0 do
-      Mix.shell().info("All configured prices match the catalog.")
+      IO.puts("All configured prices match the catalog.")
     else
-      Mix.raise("#{failures} price(s) do not match the catalog — see above.")
+      abort("#{failures} price(s) do not match the catalog — see above.")
     end
+  end
+
+  # `IO.puts` rather than `Mix.shell()`, and a plain raise rather than
+  # `Mix.raise`: `Mix` is not in a prod release, so every `Mix.*` call at
+  # runtime blew up the moment this ran the way the operator guide says to run
+  # it — `bin/fountain_server rpc`. It got as far as talking to Stripe and then
+  # died printing the answer (#1018).
+  #
+  # `use Mix.Task` above is fine: that is compile-time, so the module is in the
+  # release and `rpc` can reach it.
+  defp abort(message) do
+    IO.warn(message, [])
+    raise message
   end
 
   defp check_plan(plan) do
@@ -143,11 +156,9 @@ defmodule Mix.Tasks.Fountain.VerifyPlans do
   defp unless_ok(true, _message), do: nil
   defp unless_ok(_false, message), do: message
 
-  defp report({:ok, label, detail}), do: Mix.shell().info("  ok    #{label}: #{detail}")
-  defp report({:skip, label, detail}), do: Mix.shell().info("  --    #{label}: #{detail}")
-
-  defp report({:fail, label, detail}),
-    do: Mix.shell().error("  FAIL  #{label}: #{detail}")
+  defp report({:ok, label, detail}), do: IO.puts("  ok    #{label}: #{detail}")
+  defp report({:skip, label, detail}), do: IO.puts("  --    #{label}: #{detail}")
+  defp report({:fail, label, detail}), do: IO.puts(:stderr, "  FAIL  #{label}: #{detail}")
 
   defp label(plan) do
     if plan.public?, do: plan.name, else: "#{plan.name} (closed)"

--- a/ee/test/fountain/billing_period_shape_test.exs
+++ b/ee/test/fountain/billing_period_shape_test.exs
@@ -1,0 +1,135 @@
+defmodule Fountain.BillingPeriodShapeTest do
+  @moduledoc """
+  The billing period as Stripe actually sends it today (#1018).
+
+  Stripe moved `current_period_start`/`current_period_end` off the subscription
+  and onto its items. Every other test in this suite hand-builds the *old*
+  shape, so the fixture agreed with the code and both disagreed with Stripe —
+  which is why `users.current_period_end` was null for every account in
+  production and nobody noticed. These fixtures are built the new way on
+  purpose.
+  """
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts.User
+  alias Fountain.Billing
+  alias Fountain.Repo
+
+  defp customer(id) do
+    user = insert_verified_user()
+
+    {:ok, user} =
+      user
+      |> User.billing_changeset(%{
+        stripe_customer_id: id,
+        stripe_subscription_id: "sub_#{id}",
+        subscription_status: "active"
+      })
+      |> Repo.update()
+
+    user
+  end
+
+  defp event(customer_id, object) do
+    %Stripe.Event{
+      id: "evt_#{System.unique_integer([:positive])}",
+      type: "customer.subscription.updated",
+      created: DateTime.utc_now() |> DateTime.to_unix(),
+      data: %{
+        object:
+          Map.merge(
+            %{
+              id: "sub_#{customer_id}",
+              customer: customer_id,
+              status: "active",
+              trial_end: nil,
+              cancel_at_period_end: true
+            },
+            object
+          )
+      }
+    }
+  end
+
+  describe "period_end_unix/1" do
+    test "prefers the subscription-level field when Stripe still sends one" do
+      assert Billing.period_end_unix(%{current_period_end: 1_800_000_000}) == 1_800_000_000
+    end
+
+    # The shape that broke it: null at the top, real value on the item.
+    test "falls back to the item when the subscription-level field is null" do
+      sub = %{
+        current_period_end: nil,
+        items: %{data: [%{id: "si_1", current_period_end: 1_789_036_174}]}
+      }
+
+      assert Billing.period_end_unix(sub) == 1_789_036_174
+    end
+
+    test "reads string keys too" do
+      sub = %{"items" => %{"data" => [%{"current_period_end" => 1_789_036_174}]}}
+      assert Billing.period_end_unix(sub) == 1_789_036_174
+    end
+
+    # A tenant with teammate contacts carries a plan item and an add-on item;
+    # both ride the same subscription and share its period, so any item will do
+    # — but it must not stop at an item that happens to carry no period.
+    test "skips an item with no period and takes the one that has it" do
+      sub = %{
+        items: %{
+          data: [
+            %{id: "si_addon"},
+            %{id: "si_plan", current_period_end: 1_789_036_174}
+          ]
+        }
+      }
+
+      assert Billing.period_end_unix(sub) == 1_789_036_174
+    end
+
+    test "answers nil when nothing carries a period" do
+      assert Billing.period_end_unix(%{}) == nil
+      assert Billing.period_end_unix(%{items: %{data: [%{id: "si_1"}]}}) == nil
+    end
+  end
+
+  describe "sync_subscription/1 with the current Stripe shape" do
+    # The end-to-end version of the bug: a cancelling customer is promised
+    # "access until <date>", and the date came out blank.
+    test "records the period end from the item" do
+      user = customer("cus_shape")
+      period_end = 1_789_036_174
+
+      assert {:ok, updated} =
+               Billing.sync_subscription(
+                 event("cus_shape", %{
+                   current_period_end: nil,
+                   items: %{data: [%{id: "si_1", current_period_end: period_end}]}
+                 })
+               )
+
+      assert updated.id == user.id
+      assert updated.cancel_at_period_end
+      assert updated.current_period_end == DateTime.from_unix!(period_end)
+    end
+
+    test "still records it from the old shape, so older API versions keep working" do
+      _user = customer("cus_old")
+      period_end = 1_800_000_000
+
+      assert {:ok, updated} =
+               Billing.sync_subscription(event("cus_old", %{current_period_end: period_end}))
+
+      assert updated.current_period_end == DateTime.from_unix!(period_end)
+    end
+
+    test "a subscription carrying no period anywhere records nil rather than raising" do
+      _user = customer("cus_none")
+
+      assert {:ok, updated} =
+               Billing.sync_subscription(event("cus_none", %{items: %{data: [%{id: "si_1"}]}}))
+
+      assert updated.current_period_end == nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #1018.

Two bugs of the same kind, both found by running the code against real Stripe
rather than against our own fixtures.

## `users.current_period_end` had never been populated

Stripe moved `current_period_start`/`current_period_end` **off the subscription
and onto its items**. On the API version this account is pinned to, the
subscription-level fields read `null`:

```
"sub_level":  { "current_period_start": null, "current_period_end": null }
"item_level": [ { "current_period_start": 1786357774,
                  "current_period_end":   1789036174 } ]
```

`sync_subscription/1` read the subscription-level field, got nil, wrote nil.
Measured in prod before this fix:

```
accounts with a stripe_subscription_id: 3
accounts with current_period_end set:   0
```

Not "a few stale ones" — the column has never held a value since it was added.

**The visible cost:** a customer who cancels is shown *"you keep full access
until &lt;date&gt;"* on `/account/billing`, and there was no date. That reassurance
is exactly what #284 added the column for. Same for `current_period_end` on
`GET /api/account/billing` and the admin view.

`period_end_unix/1` reads the item and falls back to the subscription-level
field, so an older API version keeps working. Any item will do — a plan item
and a teammate-contact add-on ride the same subscription and share its period —
but it skips an item carrying no period rather than stopping at the first.

Three call sites: the webhook sync, the trial sweep, and the admin resync.

## `mix fountain.verify_plans` could not run in a release

`Mix` is not packaged into a prod release, so `Mix.shell()` raised the moment
the task ran the way the operator guide says to run it:

```
** (UndefinedFunctionError) function Mix.shell/0 is undefined
    (fountain 0.12.0) ee/lib/mix/tasks/fountain.verify_plans.ex:146
```

It got as far as talking to Stripe and then died printing the answer. Now
`IO.puts`/`IO.warn` and a plain raise. `use Mix.Task` stays — that is
compile-time, so the module is in the release and `rpc` can reach it.

The guide also said `eval`; it now says `rpc`, because an `eval` starts a
second copy of the code with no application running and therefore reads none
of the configuration the task exists to check.

## Why the suite was green through both

Every existing test hand-builds a subscription in the **old** shape. The
fixture agreed with the code, and both disagreed with Stripe — so the tests
confirmed our idea of the world rather than the world.

`billing_period_shape_test.exs` builds the current shape on purpose: period on
the item, absent at the top level. **Verified by reverting the fallback**, which
fails four of its eight cases. Without that check this fix would have passed
for the same reason the bug survived.

## Knock-on for #1016

Its step 1 says syncing `current_period_start` is "one line beside the
`current_period_end` that is already read there". That line read a field that
does not exist. Both dates have to come from the item, and #1016 should reuse
this helper's shape — worth landing this first, since an included-hours
allowance measured against a silently-null period would be worse than none.

## Verification

`mix test` 3752 tests / 0 failures · credo clean · dialyzer 0 errors · format
clean · vale 0 errors · docs-style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
