### PR TITLE
feat(billing): included turn hours, measured over the invoiced period (#1016)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,11 @@ every plan.
 | | solo | team | scale | legacy |
 |---|---|---|---|---|
 | concurrent sandboxes | 5 | 15 | 40 | 15 |
+| included turn hours | 100 | 300 | 800 | 300 |
 | teammate contacts | 1 | 3 | 10 | 3 |
 | price | $29 | $79 | $199 | $29 (closed) |
 
-Three rules that are easy to get wrong:
+Four rules that are easy to get wrong:
 
 - **The plan is not the cap.** `Quotas.sandbox_limit/1` returns
   `users.sandbox_limit_override` when it is set and the plan's number
@@ -86,6 +87,22 @@ Three rules that are easy to get wrong:
   an allowance. Two levers comp one: `comp_account/1` makes everything free,
   `users.comped_contacts` takes N off the billed quantity for a tenant who
   still pays for their tier.
+
+- **A turn hour is not a sandbox hour, and nothing enforces either.**
+  `included_turn_hours` is 20 per concurrent slot, measured against
+  `SandboxUsage`'s `busy_seconds` (a prompt in flight) on platform-paid
+  providers only — an idle sandbox and a self-hosted runner spend none of it.
+  `Billing.turn_hour_allowance/2` is the one shape every surface renders, so
+  they cannot disagree. **No gate reads it** (#1016 steps 4 and 5 are unbuilt);
+  do not add one without deciding the overage shape first.
+
+- **Usage is measured over the invoiced period, or says it is not.**
+  `Billing.billing_period/2` returns `%{start, end, source}` — `:subscription`
+  from `users.current_period_start`/`_end`, `:calendar_month` when there is no
+  such period (comped, self-hosted, or no webhook yet). The fallback is never
+  silent: if you add a surface that shows a usage number, show the source too.
+  `Fountain.Release.backfill_billing_periods/1` fills the column from Stripe
+  for accounts that predate it.
 
 Price ids come from config (`STRIPE_PRICE_ID_SOLO` and friends), the display
 cents from the catalog. `mix fountain.verify_plans` is the only thing that

--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -52,6 +52,14 @@ defmodule Fountain.Accounts.User do
     # access continues until current_period_end, when `.deleted` fires. Synced
     # from subscription webhooks so the UI can say "access until <date>".
     field :cancel_at_period_end, :boolean, default: false
+    # The invoiced period, both ends of it, synced from the Stripe
+    # subscription. `current_period_start` is what makes an allowance
+    # measurable over the window the customer is actually charged for rather
+    # than over a calendar month that drifts out of step with every renewal.
+    # Null on a trialing account Stripe has not reported a period for, on a
+    # comped account, and on a self-hosted deployment with no Stripe —
+    # `Fountain.Billing.billing_period/2` handles all three.
+    field :current_period_start, :utc_datetime
     field :current_period_end, :utc_datetime
     field :session_version, :integer, default: 0
     field :theme_preference, :string, default: "system"
@@ -143,6 +151,7 @@ defmodule Fountain.Accounts.User do
       :trial_ends_at,
       :subscription_synced_at,
       :cancel_at_period_end,
+      :current_period_start,
       :current_period_end,
       # Only ever put here when the price on the subscription mapped to a
       # known plan. An unrecognised price leaves the key out entirely rather

--- a/apps/fountain/lib/fountain/plans.ex
+++ b/apps/fountain/lib/fountain/plans.ex
@@ -13,18 +13,38 @@ defmodule Fountain.Plans do
 
   Concurrent sandboxes, and only that. It is the one thing that is both a real
   cost to Fountain (capacity on the shared provider account, ADR 0005/0018)
-  and legible to a customer without a usage meter. Sandbox-hours are the
-  honest *variable* unit and remain the plan for a later revision of #798;
-  they need metering correctness first and they are not what these tiers sell.
+  and legible to a customer without a usage meter. The tiers are still priced
+  on it; the turn-hour allowance below is an amount of work *inside* a tier,
+  not a second axis to sell on.
+
+  ## Included turn hours
+
+  `included_turn_hours` is derived, not chosen per tier: **20 turn hours per
+  concurrent sandbox the plan allows**, so Solo's 5 slots carry 100 hours and
+  Scale's 40 carry 800. Deriving it keeps the ladder on one axis — a plan
+  cannot end up with more capacity and less work to do with it.
+
+  A *turn* hour is time with a prompt actually in flight
+  (`Fountain.Billing.SandboxUsage`'s `busy_seconds`), not wall-clock sandbox
+  time. The distinction is the whole point: a sandbox left running overnight
+  with nobody prompting it burns `active_seconds` and no allowance, so the
+  meter measures work rather than forgetfulness. Hours on a tenant's own
+  runner (ADR 0022) do not count either — Fountain pays nothing for them.
+
+  **Nothing enforces this yet.** `Fountain.Billing.turn_hour_allowance/2`
+  reports used against included and every surface displays it; no code path
+  refuses anything because of it. The overage shape — post-paid or prepaid
+  credits — is deliberately still open (#1016 step 4), to be decided with a
+  cycle of real numbers in hand.
 
   ## The catalog
 
-  | Plan | Concurrent | Teammate contacts | Price |
-  |---|---|---|---|
-  | `solo` | 5 | 1 | $29/mo |
-  | `team` | 15 | 3 | $79/mo |
-  | `scale` | 40 | 10 | $199/mo |
-  | `legacy` | 15 | 3 | $29/mo (closed) |
+  | Plan | Concurrent | Turn hours | Teammate contacts | Price |
+  |---|---|---|---|---|
+  | `solo` | 5 | 100 | 1 | $29/mo |
+  | `team` | 15 | 300 | 3 | $79/mo |
+  | `scale` | 40 | 800 | 10 | $199/mo |
+  | `legacy` | 15 | 300 | 3 | $29/mo (closed) |
 
   `legacy` is the flat price every account bought before the tiers existed.
   It is pinned to the old `STRIPE_PRICE_ID`, carries `team`'s capacity so that
@@ -71,6 +91,7 @@ defmodule Fountain.Plans do
     :tagline,
     :monthly_cents,
     :concurrent_sandboxes,
+    :included_turn_hours,
     :team_contacts,
     :order,
     public?: true
@@ -81,6 +102,11 @@ defmodule Fountain.Plans do
   # Plain maps, not structs: a module attribute cannot hold a struct of the
   # module that is defining it. `all/0` is what turns these into `%Plans{}`,
   # and with four of them the cost of doing so per call is not worth caching.
+  #
+  # `included_turn_hours` is 20 per concurrent slot, written out per plan
+  # rather than computed, so the catalog stays a table you can read every
+  # entitlement off. `plans_test.exs` asserts the ratio, so breaking it for a
+  # future plan is a deliberate act rather than a typo.
   @plan_specs [
     %{
       slug: "solo",
@@ -88,6 +114,7 @@ defmodule Fountain.Plans do
       tagline: "One person, a handful of agents at a time.",
       monthly_cents: 2_900,
       concurrent_sandboxes: 5,
+      included_turn_hours: 100,
       team_contacts: 1,
       order: 1
     },
@@ -97,6 +124,7 @@ defmodule Fountain.Plans do
       tagline: "A standing team of agents, working in parallel.",
       monthly_cents: 7_900,
       concurrent_sandboxes: 15,
+      included_turn_hours: 300,
       team_contacts: 3,
       order: 2
     },
@@ -106,6 +134,7 @@ defmodule Fountain.Plans do
       tagline: "Fleet-sized fan-out, without asking first.",
       monthly_cents: 19_900,
       concurrent_sandboxes: 40,
+      included_turn_hours: 800,
       team_contacts: 10,
       order: 3
     },
@@ -115,6 +144,7 @@ defmodule Fountain.Plans do
       tagline: "The original flat plan, at Team capacity.",
       monthly_cents: 2_900,
       concurrent_sandboxes: 15,
+      included_turn_hours: 300,
       team_contacts: 3,
       order: 0,
       public?: false
@@ -198,6 +228,22 @@ defmodule Fountain.Plans do
   @spec concurrent_sandboxes(term()) :: non_neg_integer()
   def concurrent_sandboxes(%__MODULE__{concurrent_sandboxes: n}), do: n
   def concurrent_sandboxes(subject), do: resolve(subject).concurrent_sandboxes
+
+  @doc """
+  The turn hours a user's, slug's or plan's subscription includes per billing
+  period.
+
+  A turn hour is an hour with a prompt in flight, on a provider Fountain pays
+  for. It is **not** wall-clock sandbox time: see the moduledoc, and
+  `Fountain.Billing.turn_hour_allowance/2` for the used side of the same
+  number.
+
+  Reported everywhere, enforced nowhere — no code path refuses anything
+  because a tenant is over.
+  """
+  @spec included_turn_hours(term()) :: non_neg_integer()
+  def included_turn_hours(%__MODULE__{included_turn_hours: n}), do: n
+  def included_turn_hours(subject), do: resolve(subject).included_turn_hours
 
   @doc """
   The most teammate contacts a user, slug or plan may hold at once.

--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -265,6 +265,129 @@ defmodule Fountain.Release do
     end
   end
 
+  @doc """
+  Backfills `users.current_period_start` from Stripe (#1016).
+
+  The column arrived after every existing subscription had already been
+  created, so until each account's next `customer.subscription.updated` event
+  lands it has an end date and no start, and `Fountain.Billing.billing_period/2`
+  reports a calendar month for it. That is correct behaviour, and it is also
+  a month of every usage number being measured over a window that is not the
+  one the customer is invoiced for. This closes the gap in one pass.
+
+      # See who is missing a period start, call Stripe for none of them:
+      bin/fountain_server eval 'Fountain.Release.backfill_billing_periods(dry_run: true)'
+
+      # Do it:
+      bin/fountain_server eval 'Fountain.Release.backfill_billing_periods()'
+
+  Every account skipped means the run repaired nothing, which the task says
+  out loud rather than reporting a clean pass.
+
+  `eval`, not the `rpc` that `mix fountain.verify_plans` wants. Every task in
+  this module goes through `with_repo/1`, and `Ecto.Migrator.with_repo`
+  restarts the repo's pool child when it finds one already started — over
+  `rpc` that would bounce the connection pool of a pod that is serving. The
+  Stripe key this needs comes from `config/runtime.exs`, which a release
+  `eval` does execute.
+
+  One Stripe read per account, and only for accounts that have a subscription
+  of record and no start recorded — so it is safe to re-run, and a second run
+  after the first is a handful of queries and no API calls. Comped accounts
+  are skipped: they have no invoiced period, which is the state the fallback
+  exists for.
+
+  Writes `current_period_start` and `current_period_end` only. Status, trial
+  and plan are deliberately untouched — repairing those from Stripe is
+  `Billing.resync_from_stripe/1`'s job, it participates in the webhook
+  ordering guard, and a bulk backfill quietly flipping account statuses is
+  exactly the kind of surprise a one-column migration helper should not have.
+  """
+  def backfill_billing_periods(opts \\ []) do
+    with_repo(fn -> do_backfill_billing_periods(opts) end)
+  end
+
+  defp do_backfill_billing_periods(opts) do
+    dry_run? = Keyword.get(opts, :dry_run, false)
+    import Ecto.Query
+
+    query =
+      from u in Fountain.Accounts.User,
+        where: not is_nil(u.stripe_subscription_id) and u.stripe_subscription_id != "",
+        where: is_nil(u.current_period_start),
+        where: u.subscription_status != "comped",
+        select: %{id: u.id, subscription_id: u.stripe_subscription_id}
+
+    pending = Fountain.Repo.all(query)
+
+    if dry_run? do
+      IO.puts("#{length(pending)} subscribed account(s) have no current_period_start.")
+      IO.puts("Running without dry_run: would read each one from Stripe and record its period.")
+      {:ok, length(pending)}
+    else
+      {:ok, _} = Application.ensure_all_started(:stripity_stripe)
+      tally = Enum.reduce(pending, %{updated: 0, skipped: 0}, &backfill_one/2)
+
+      Fountain.Audit.record(%{
+        user_id: nil,
+        action: "release.billing_periods_backfilled",
+        resource_type: "release_task",
+        actor: "system:release_task",
+        metadata: %{
+          "accounts_considered" => length(pending),
+          "accounts_updated" => tally.updated,
+          "accounts_skipped" => tally.skipped
+        }
+      })
+
+      IO.puts(
+        "Recorded a billing period on #{tally.updated} account(s), #{tally.skipped} skipped."
+      )
+
+      # One skipped account is a deleted subscription. Every account skipped is
+      # not a coincidence — it is an unset, revoked or wrong-mode
+      # STRIPE_SECRET_KEY, or Stripe being unreachable — and without saying so
+      # the task reports a successful run that repaired nothing. Checking the
+      # outcome rather than the config catches all four.
+      if tally.updated == 0 and tally.skipped > 0 do
+        IO.warn(
+          "every one of the #{tally.skipped} account(s) was skipped — check " <>
+            "STRIPE_SECRET_KEY and the reasons above before assuming this ran"
+        )
+      end
+
+      {:ok, tally.updated}
+    end
+  end
+
+  # A subscription Stripe cannot hand back — deleted, or belonging to a key
+  # this deployment no longer holds — is skipped rather than fatal. The point
+  # of the pass is the accounts it can repair.
+  defp backfill_one(%{id: user_id, subscription_id: subscription_id}, tally) do
+    with {:ok, sub} <- Stripe.Subscription.retrieve(subscription_id),
+         %DateTime{} = period_start <- unix_datetime(Map.get(sub, :current_period_start)) do
+      user = Fountain.Repo.get!(Fountain.Accounts.User, user_id)
+
+      user
+      |> Fountain.Accounts.User.billing_changeset(%{
+        current_period_start: period_start,
+        current_period_end: unix_datetime(Map.get(sub, :current_period_end))
+      })
+      |> Fountain.Repo.update!()
+
+      %{tally | updated: tally.updated + 1}
+    else
+      other ->
+        IO.puts("  skipped #{user_id} (#{subscription_id}): #{inspect(other)}")
+        %{tally | skipped: tally.skipped + 1}
+    end
+  end
+
+  defp unix_datetime(ts) when is_integer(ts),
+    do: ts |> DateTime.from_unix!() |> DateTime.truncate(:second)
+
+  defp unix_datetime(_), do: nil
+
   defp repos do
     Application.fetch_env!(@app, :ecto_repos)
   end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -35,7 +35,14 @@ defmodule FountainWeb.MarketingHTML do
 
   @doc """
   The one-line capacity claim under a plan's price. Concurrency is the axis
-  the tiers are sold on, so it is the only number here.
+  the tiers are sold on, so it is the headline number.
   """
   def plan_capacity(plan), do: "#{plan.concurrent_sandboxes} agents at once"
+
+  @doc """
+  The work that comes with the capacity. A turn hour is an hour with a prompt
+  in flight, so an agent left sitting idle does not spend one — which is the
+  part worth being explicit about on a pricing page.
+  """
+  def plan_turn_hours(plan), do: "#{plan.included_turn_hours} turn hours a month"
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -219,6 +219,12 @@
         <p class="mt-1 text-xs text-[var(--color-text-muted)]">
           concurrent sandboxes. Queue as much work as you like behind them.
         </p>
+        <p class="mt-3 text-sm font-medium text-[var(--color-text-primary)]">
+          {plan_turn_hours(plan)}
+        </p>
+        <p class="mt-1 text-xs text-[var(--color-text-muted)]">
+          counted while an agent is working, not while it waits.
+        </p>
         <a
           href={~p"/auth/register"}
           class="mt-6 inline-flex items-center justify-center px-4 py-2 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"

--- a/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
@@ -86,6 +86,14 @@ defmodule FountainWeb.AdminLive.UserDetail do
     |> assign(:vault_count, length(Vaults.list_vaults(user.id)))
     |> assign(:audit_events, Audit.list_recent_for_user(user.id, 50))
     |> assign(:admin_events, Audit._unsafe_list_admin_events_for_target(user.id, 50))
+    |> assign(:allowance, turn_hour_allowance(user))
+  end
+
+  # Two DB queries against the sandbox and turn rows, so it is skipped
+  # entirely where there is no allowance to report — a billing-disabled
+  # instance shows no billing tiles at all.
+  defp turn_hour_allowance(user) do
+    if Fountain.Billing.enabled?(), do: Fountain.Billing.turn_hour_allowance(user)
   end
 
   @impl true
@@ -141,7 +149,7 @@ defmodule FountainWeb.AdminLive.UserDetail do
         <p class="text-xs text-zinc-400 mt-2 font-mono">{@user.id}</p>
       </div>
 
-      <section class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <section class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
         <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
           <div class="text-xs text-zinc-500">Joined</div>
           <div class="text-sm font-medium">{format_date(@user.inserted_at)}</div>
@@ -188,6 +196,20 @@ defmodule FountainWeb.AdminLive.UserDetail do
             active / limit · {if @user.sandbox_limit_override,
               do: "override",
               else: "#{Fountain.Plans.resolve(@user.plan).name} plan"}
+          </div>
+        </div>
+        <div :if={@allowance} class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Turn hours</div>
+          <div class={[
+            "text-sm font-medium tabular-nums",
+            @allowance.over? && "text-amber-700"
+          ]}>
+            {Float.round(@allowance.used, 1)} / {@allowance.included}
+          </div>
+          <div class="text-xs text-zinc-500">
+            used / included · {if @allowance.period.source == :subscription,
+              do: "billing period",
+              else: "calendar month"}
           </div>
         </div>
         <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1601,6 +1601,15 @@ defmodule FountainWeb.Schemas do
               nullable: true
             },
             trial_ends_at: %Schema{type: :string, format: :"date-time", nullable: true},
+            current_period_start: %Schema{
+              type: :string,
+              format: :"date-time",
+              nullable: true,
+              description:
+                "Start of the period Stripe is invoicing. Null for a comped " <>
+                  "account, a deployment without Stripe, and any subscription " <>
+                  "that has not sent a webhook since this field existed."
+            },
             current_period_end: %Schema{type: :string, format: :"date-time", nullable: true},
             cancel_at_period_end: %Schema{
               type: :boolean,
@@ -1618,6 +1627,12 @@ defmodule FountainWeb.Schemas do
                   type: :integer,
                   description: "The plan's concurrency cap."
                 },
+                included_turn_hours: %Schema{
+                  type: :integer,
+                  description:
+                    "Turn hours the plan includes per billing period. Reported " <>
+                      "only: no request is refused for exceeding it."
+                },
                 sandbox_limit: %Schema{
                   type: :integer,
                   description:
@@ -1632,10 +1647,21 @@ defmodule FountainWeb.Schemas do
             },
             period: %Schema{
               type: :object,
-              description: "The window the usage numbers cover (current calendar month).",
+              description:
+                "The window the usage numbers cover: the period Stripe is " <>
+                  "invoicing, or the current calendar month when there is no " <>
+                  "such period.",
               properties: %{
                 start: %Schema{type: :string, format: :"date-time"},
-                end: %Schema{type: :string, format: :"date-time"}
+                end: %Schema{type: :string, format: :"date-time"},
+                source: %Schema{
+                  type: :string,
+                  enum: ~w(subscription calendar_month),
+                  description:
+                    "`calendar_month` means these numbers do not line up with " <>
+                      "an invoice — the account is comped, self-hosted, or has " <>
+                      "not reported a period yet."
+                }
               }
             },
             usage: %Schema{
@@ -1643,6 +1669,21 @@ defmodule FountainWeb.Schemas do
               properties: %{
                 conversations: %Schema{type: :integer},
                 turns: %Schema{type: :integer},
+                turn_hours: %Schema{
+                  type: :number,
+                  description:
+                    "Hours with a prompt in flight, on providers Fountain pays " <>
+                      "for. The unit included_turn_hours is denominated in. An " <>
+                      "idle sandbox spends none of these; sandbox_minutes counts it."
+                },
+                turn_hours_included: %Schema{
+                  type: :integer,
+                  description: "The plan's allowance, repeated here beside what was used."
+                },
+                turn_hours_remaining: %Schema{
+                  type: :number,
+                  description: "Clamped at zero; an account over its allowance is not owed hours."
+                },
                 sandbox_minutes: %Schema{
                   type: :number,
                   description: "Active sandbox minutes inside the period, parked time excluded."

--- a/apps/fountain/priv/repo/migrations/20260823060000_add_current_period_start_to_users.exs
+++ b/apps/fountain/priv/repo/migrations/20260823060000_add_current_period_start_to_users.exs
@@ -1,0 +1,24 @@
+defmodule Fountain.Repo.Migrations.AddCurrentPeriodStartToUsers do
+  use Ecto.Migration
+
+  @moduledoc """
+  `users.current_period_end` has been synced from Stripe since the cancellation
+  notice needed it, but nothing recorded where the period *began*. Every
+  surface that measured usage therefore measured a calendar month, which is
+  fine for a display stat and wrong for an allowance: a customer who subscribed
+  on the 20th gets a 10-day first "month" and every renewal boundary sits out
+  of step with the invoice they are charged against.
+
+  Nullable, and it stays nullable. A self-hosted deployment has no Stripe at
+  all, a comped account has no invoiced period, and an account that has not
+  received a subscription webhook since this shipped has none yet.
+  `Fountain.Billing.billing_period/2` falls back to the calendar month for all
+  three and says so rather than substituting silently.
+  """
+
+  def change do
+    alter table(:users) do
+      add :current_period_start, :utc_datetime
+    end
+  end
+end

--- a/apps/fountain/test/fountain/plans_test.exs
+++ b/apps/fountain/test/fountain/plans_test.exs
@@ -45,6 +45,28 @@ defmodule Fountain.PlansTest do
       assert length(Enum.uniq(caps)) == length(caps)
     end
 
+    # The allowance is derived, not chosen per tier (#1016). Asserting the
+    # ratio is what makes breaking it a deliberate act rather than a typo in
+    # one of four near-identical literals.
+    test "included turn hours are 20 per concurrent slot, on every plan" do
+      for plan <- Plans.all() do
+        assert plan.included_turn_hours == plan.concurrent_sandboxes * 20,
+               "#{plan.slug} carries #{plan.included_turn_hours} hours for " <>
+                 "#{plan.concurrent_sandboxes} slots"
+      end
+    end
+
+    test "the closed plan carries Team's hours, as it carries Team's capacity" do
+      assert Plans.fetch!("legacy").included_turn_hours ==
+               Plans.fetch!("team").included_turn_hours
+    end
+
+    test "each public plan includes strictly more hours than the one below" do
+      hours = Enum.map(Plans.public(), & &1.included_turn_hours)
+      assert hours == Enum.sort(hours)
+      assert length(Enum.uniq(hours)) == length(hours)
+    end
+
     test "each public plan costs strictly more than the one below" do
       prices = Enum.map(Plans.public(), & &1.monthly_cents)
       assert prices == Enum.sort(prices)
@@ -124,6 +146,7 @@ defmodule Fountain.PlansTest do
 
       for subject <- [plan, "scale", %{plan: "scale"}] do
         assert Plans.concurrent_sandboxes(subject) == plan.concurrent_sandboxes
+        assert Plans.included_turn_hours(subject) == plan.included_turn_hours
         assert Plans.team_contacts(subject) == plan.team_contacts
         assert Plans.monthly_cents(subject) == plan.monthly_cents
       end

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -43,7 +43,19 @@ defmodule FountainWeb.MarketingPricingTest do
       assert body =~ plan.name
       assert body =~ Plans.format_usd(plan.monthly_cents)
       assert body =~ "#{plan.concurrent_sandboxes} agents at once"
+      assert body =~ "#{plan.included_turn_hours} turn hours a month"
     end
+  end
+
+  # The hours are a public promise, so the page has to say what a turn hour
+  # is. A reader who assumes it means wall-clock sandbox time reads Solo's
+  # 100 hours as four days and concludes the plan is unusable.
+  test "the pricing table explains that hours are counted while an agent works",
+       %{conn: conn} do
+    price_all()
+
+    body = conn |> get(~p"/") |> html_response(200)
+    assert body =~ "counted while an agent is working, not while it waits"
   end
 
   test "the hero quotes the cheapest sellable plan", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
@@ -47,6 +47,19 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
       refute html =~ "key_hash"
     end
 
+    test "shows the tenant's turn hours against their plan (#1016)", %{conn: conn} do
+      admin = insert_admin()
+      target = insert_verified_user(plan: "team")
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/users/#{target.id}")
+
+      assert html =~ "Turn hours"
+      assert html =~ "0.0 / 300"
+      # No Stripe period on this account, so the window is a calendar month
+      # and support has to be able to see that before quoting the number.
+      assert html =~ "calendar month"
+    end
+
     test "shows admin actions taken against the account", %{conn: conn} do
       admin = insert_admin()
       target = insert_verified_user()

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -124,6 +124,11 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
       "admin reap result — response vocabulary, not persisted state",
     {FountainWeb.Schemas.AdminResyncResponse, "data.outcome"} =>
       "admin resync result — response vocabulary, not persisted state",
+    # Which window the usage numbers cover. Computed by
+    # `Billing.billing_period/2` from whether Stripe has reported a period;
+    # nothing stores it, and there is no column to compare against.
+    {FountainWeb.Schemas.BillingResponse, "data.period.source"} =>
+      "usage window provenance — computed per response, not persisted state",
     # Per-resource results from `fountain apply`. Manifest reports these as
     # atoms built inline per branch; there is no list to compare against.
     {FountainWeb.Schemas.ApplyResult, "action"} =>

--- a/decisions/0026-plans-and-entitlements.md
+++ b/decisions/0026-plans-and-entitlements.md
@@ -235,10 +235,54 @@ is where it is worth running.
   invoice once `STRIPE_PRICE_ID_CONTACT` is set; setting that variable is
   therefore a customer-facing act, not a config tidy-up.
 * The tiers make the #798 hours work easier, not harder, but they also mean a
-  later hours model has to fit *inside* a tier rather than replace it.
+  later hours model has to fit *inside* a tier rather than replace it. See the
+  amendment below, which is that model's first increment.
 * Price points are now partly in code (`Fountain.Plans`) and partly in Stripe.
   `verify_plans` is the only thing standing between that and a customer being
   shown one number and charged another. Run it.
+
+## Amendment (2026-08-23) — included turn hours, reported and not enforced
+
+**Status:** Accepted and built (#1016 steps 1 to 3). The allowance is
+displayed on every surface. **No code path refuses anything because of it**;
+steps 4 and 5 of #1016, which decide the overage shape and add a ceiling, are
+deliberately not built.
+
+Each plan now carries `included_turn_hours` — 20 hours per concurrent slot, so
+Solo 100, Team 300, Scale 800, `legacy` 300 at Team's capacity. Three things
+about it are decisions rather than details.
+
+**The unit is turn time, not sandbox-active time.** #798 called
+sandbox-active-hours the honest variable unit, and for *Fountain's* cost it is:
+an idle sprite is billed at full rate. It is the wrong unit to sell, because
+the tenant behaviour it punishes is forgetting to close a tab, not doing work.
+`SandboxUsage` has separated `busy_seconds` from `idle_seconds` since #666, so
+the allowance is denominated in busy time and the idle half stays a cost signal
+for the operator (`provider_spend/1`) rather than a customer-facing number.
+Hours on a self-hosted runner (0022) are excluded for the same reason from the
+other direction: Fountain pays nothing for that machine.
+
+The prod distribution this was set against, at the time of writing: the
+dogfood account burned 271 turn hours in a month against 11,091 active hours,
+and every other tenant was under half a turn hour. The ratio between those two
+columns is the whole argument.
+
+**The period is Stripe's, not the calendar's.** `users.current_period_start`
+is now synced beside `current_period_end`, and `Billing.billing_period/2`
+returns `%{start, end, source}`. An account with no invoiced period — comped,
+self-hosted, or not yet reported by a webhook — gets the calendar month with
+`source: :calendar_month`, and **every surface displays that fact**. The
+alternative considered and rejected was deriving the start from the previous
+`current_period_end`, which is wrong for a `trialing` account, where that field
+holds the trial end rather than a period boundary.
+
+**It is reported before it is enforced, on purpose.** Setting a number that
+bills people before seeing a cycle of real usage against it is how you pick a
+figure that is wrong for everybody. The overage shape (post-paid versus prepaid
+credits) stays open in #1016. Note for whoever closes it: the contact add-on
+this ADR built is a *licensed* quantity price, and Stripe ignores quantity on a
+metered price — hours need Meter Events or a credit balance, not a second
+licensed item.
 
 ## Alternatives considered
 

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -16,12 +16,12 @@ commercial instance with `BILLING_ENABLED=true`. Read
 A plan sets one number that Fountain enforces. That number is the count of
 sandboxes a tenant can run at the same time.
 
-| Plan | Concurrent sandboxes | Contact ceiling | Price |
-|---|---|---|---|
-| Solo | 5 | 1 | $29/mo |
-| Team | 15 | 3 | $79/mo |
-| Scale | 40 | 10 | $199/mo |
-| Legacy | 15 | 3 | $29/mo |
+| Plan | Concurrent sandboxes | Turn hours | Contact ceiling | Price |
+|---|---|---|---|---|
+| Solo | 5 | 100 | 1 | $29/mo |
+| Team | 15 | 300 | 3 | $79/mo |
+| Scale | 40 | 800 | 10 | $199/mo |
+| Legacy | 15 | 300 | 3 | $29/mo |
 
 Every plan carries the whole product. Only the cap differs. See
 [ADR 0026](https://github.com/jhgaylor/fountain/blob/main/decisions/0026-plans-and-entitlements.md)
@@ -33,6 +33,50 @@ keep it, at Team capacity.
 
 The contact ceiling bounds teammate email and phone contacts. It is an abuse
 bound, not an allowance. Fountain charges for each contact separately.
+
+### Turn hours measure work, not clock time
+
+Each plan includes 20 turn hours for each concurrent sandbox. A turn hour is
+one hour with a prompt in flight. An agent that waits for a person spends no
+turn hours. Time on a self-hosted runner also spends none, because Fountain
+pays nothing for that machine.
+
+Fountain reports these hours and enforces nothing. No request fails because a
+tenant exceeds the included hours. The price of an overage is still an open
+question. See
+[issue 1016](https://github.com/BinaryBourbon/fountain/issues/1016) for the
+current state.
+
+Three surfaces show the number. The billing page shows it to the tenant. The
+API reports it at `GET /api/account/billing`. The admin page for one account
+shows it beside the sandbox count.
+
+### The billing period
+
+Fountain measures the hours over the period that Stripe invoices. The
+`users.current_period_start` column holds the start of that period, and
+Fountain reads it from the subscription at every webhook.
+
+An account without such a period gets the calendar month instead. Every
+surface states which window it used, because a number measured over the wrong
+window must say so. Three kinds of account have no period. A comped account
+has none. A self-hosted account has none. An account that received no
+subscription webhook since this column arrived has none yet.
+
+Fountain fills the column for one such account at the next renewal. To fill it
+for every account at once, run this task.
+
+```bash
+bin/fountain_server eval 'Fountain.Release.backfill_billing_periods(dry_run: true)'
+bin/fountain_server eval 'Fountain.Release.backfill_billing_periods()'
+```
+
+The task makes one Stripe read for each account that needs one. It writes the
+two period columns and nothing else. It is safe to run more than once.
+
+Use `eval` for this task, and `rpc` for the verifier above. This task starts
+its own database connection, and an `rpc` restarts the pool of a pod that
+serves traffic.
 
 ### A downgrade does not stop work in progress
 

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -543,6 +543,7 @@ defmodule Fountain.Billing do
           %{
             subscription_status: coerce_status(sub.status, "trial_sweep"),
             trial_ends_at: unix_field(Map.get(sub, :trial_end)),
+            current_period_start: unix_field(period_start_unix(sub)),
             current_period_end: unix_field(period_end_unix(sub))
           },
           now,
@@ -635,6 +636,7 @@ defmodule Fountain.Billing do
     attrs = %{
       subscription_status: coerce_status(sub.status, "admin_resync"),
       trial_ends_at: unix_field(Map.get(sub, :trial_end)),
+      current_period_start: unix_field(period_start_unix(sub)),
       current_period_end: unix_field(period_end_unix(sub)),
       cancel_at_period_end: Map.get(sub, :cancel_at_period_end) == true,
       subscription_synced_at: DateTime.utc_now() |> DateTime.truncate(:second)
@@ -1424,6 +1426,17 @@ defmodule Fountain.Billing do
     cancel_at_period_end =
       type != "customer.subscription.deleted" and Map.get(sub, :cancel_at_period_end) == true
 
+    # Both ends of the invoiced period, not just the one the cancellation
+    # notice needed. `current_period_start` is what `billing_period/2`
+    # measures an allowance over; without it every usage number was reported
+    # against a calendar month that drifts out of step with the invoice at
+    # every renewal.
+    current_period_start =
+      case period_start_unix(sub) do
+        ts when is_integer(ts) -> DateTime.from_unix!(ts) |> DateTime.truncate(:second)
+        _ -> nil
+      end
+
     current_period_end =
       case period_end_unix(sub) do
         ts when is_integer(ts) -> DateTime.from_unix!(ts) |> DateTime.truncate(:second)
@@ -1467,6 +1480,7 @@ defmodule Fountain.Billing do
                 trial_ends_at: trial_ends_at,
                 subscription_synced_at: event_created || user.subscription_synced_at,
                 cancel_at_period_end: cancel_at_period_end,
+                current_period_start: current_period_start,
                 current_period_end: current_period_end
               }
               |> maybe_adopt_subscription_id(user, subscription_id, type)
@@ -1690,6 +1704,13 @@ defmodule Fountain.Billing do
   # will confirm — necessary because that webhook may have already arrived and
   # been ignored for carrying an unrecorded subscription id.
   #
+  # The billing period is deliberately *not* written here. A Checkout session
+  # carries the subscription's id, not its object, and this runs inside the
+  # event-claim transaction, where a Stripe read must not happen. The
+  # `customer.subscription.created` event for the very subscription being
+  # adopted carries both period ends and lands within seconds; until it does,
+  # `billing_period/2` reports a calendar month and says so.
+  #
   # The watermark stamp (#393) makes the adoption participate in the stale?/2
   # ordering guard: without it, any older event for the adopted subscription
   # that straggled in afterwards was treated as fresh and could move the
@@ -1844,8 +1865,18 @@ defmodule Fountain.Billing do
   #
   # Any item will do: a plan item and a teammate-contact add-on ride the same
   # subscription and therefore share its period.
-  def period_end_unix(sub) do
-    case Map.get(sub, :current_period_end) || Map.get(sub, "current_period_end") do
+  def period_end_unix(sub), do: period_unix(sub, :current_period_end)
+
+  @doc false
+  # The other end of the same period (#1016), read the same way and for the
+  # same reason. It moved onto the item in the same API change, so a
+  # subscription-level read here would have repeated #1018 exactly: a column
+  # that is never once populated, behind a green suite whose fixtures all
+  # carry the old shape.
+  def period_start_unix(sub), do: period_unix(sub, :current_period_start)
+
+  defp period_unix(sub, key) do
+    case field(sub, key) do
       ts when is_integer(ts) ->
         ts
 
@@ -1853,13 +1884,17 @@ defmodule Fountain.Billing do
         sub
         |> subscription_items()
         |> Enum.find_value(fn item ->
-          case Map.get(item, :current_period_end) || Map.get(item, "current_period_end") do
+          case field(item, key) do
             ts when is_integer(ts) -> ts
             _ -> nil
           end
         end)
     end
   end
+
+  # Stripe hands these back atom-keyed on the API path and string-keyed on
+  # some webhook paths; tests build both.
+  defp field(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
 
   defp item_price_id(%{price: %{id: id}}), do: id
   defp item_price_id(%{price: id}) when is_binary(id), do: id
@@ -1912,6 +1947,132 @@ defmodule Fountain.Billing do
     }
 
     {period_start, period_end}
+  end
+
+  @doc """
+  The window a tenant's usage should be measured over: the period Stripe is
+  actually invoicing them for, or the calendar month when there is no such
+  period — and which of the two it is.
+
+  Returns `%{start:, end:, source:}` rather than a bare `{start, end}` on
+  purpose. A number measured over the wrong window has to be able to say so:
+  enforcing an allowance, or even displaying one, against a calendar month
+  when the customer's invoice runs the 20th to the 20th is a support ticket
+  per customer per month. Every surface that shows the number carries the
+  `:source` with it.
+
+  `:subscription` requires both ends synced from Stripe *and* that the stored
+  period contains `now`. Everything else falls back to `:calendar_month`:
+
+    * a self-hosted deployment with no Stripe at all;
+    * a comped account, which has no invoiced period;
+    * a trialing account Stripe has not reported a period for;
+    * an account whose stored period has already ended — a cancelled
+      subscription's final period, or the seconds between a renewal and the
+      webhook that reports the new one.
+
+  The last case is a real (brief) wobble at every renewal: the numbers move
+  to a calendar month until `customer.subscription.updated` lands. Rolling the
+  stored period forward instead would mean inventing a boundary Stripe has not
+  confirmed, and the flag makes the substitution visible either way.
+  """
+  @spec billing_period(User.t(), DateTime.t() | nil) :: %{
+          start: DateTime.t(),
+          end: DateTime.t(),
+          source: :subscription | :calendar_month
+        }
+  def billing_period(user, now \\ nil)
+
+  def billing_period(
+        %User{
+          current_period_start: %DateTime{} = period_start,
+          current_period_end: %DateTime{} = period_end
+        },
+        now
+      ) do
+    now = now || DateTime.utc_now()
+
+    if DateTime.compare(period_start, now) != :gt and DateTime.compare(now, period_end) == :lt do
+      %{start: period_start, end: period_end, source: :subscription}
+    else
+      calendar_month_period()
+    end
+  end
+
+  def billing_period(%User{}, _now), do: calendar_month_period()
+
+  defp calendar_month_period do
+    {period_start, period_end} = current_month_range()
+    %{start: period_start, end: period_end, source: :calendar_month}
+  end
+
+  @doc """
+  Turn hours a tenant has spent in a period, on the providers Fountain pays
+  for.
+
+  A *turn* hour is an hour with a prompt in flight, not an hour of sandbox
+  wall-clock: an agent left running overnight with nobody talking to it costs
+  Fountain money (and is reported by `usage_summary/3` as sandbox minutes) but
+  spends none of the tenant's allowance. Time on a tenant's own runner
+  (ADR 0022) is excluded too — Fountain pays nothing for it, so charging an
+  allowance against it would be indefensible.
+
+  Pass a period as `{start, end}`; defaults to the tenant's `billing_period/2`.
+  """
+  @spec turn_hours_used(User.t(), keyword()) :: float()
+  def turn_hours_used(%User{} = user, opts \\ []) do
+    {period_start, period_end} =
+      case Keyword.get(opts, :period) do
+        {%DateTime{} = s, %DateTime{} = e} -> {s, e}
+        nil -> billing_period(user) |> then(&{&1.start, &1.end})
+      end
+
+    user.id
+    |> SandboxUsage.busy_for_user(period_start, period_end)
+    |> Enum.filter(fn {provider, _seconds} -> SandboxUsage.platform_cost?(provider) end)
+    |> Enum.map(&elem(&1, 1))
+    |> Enum.sum()
+    |> SandboxUsage.hours()
+  end
+
+  @doc """
+  The turn-hour meter, in one shape, for every surface that shows it: the
+  billing page, `GET /api/account/billing`, and the admin per-tenant view.
+
+  One function so the three cannot disagree about the window, the unit, or
+  which providers count.
+
+    * `:used` / `:included` — turn hours spent, and what the plan carries
+    * `:remaining` — clamped at zero; a tenant over their allowance is not
+      owed negative hours
+    * `:period` — the `billing_period/2` map, `:source` included, so a
+      surface can label a calendar-month fallback as one
+    * `:over?` — whether `:used` has passed `:included`
+
+  **Nothing acts on this.** No gate, no ceiling, no invoice line. Whether
+  going over means post-paid overage or exhausted prepaid credits is still
+  open (#1016 step 4) and is meant to be decided against a cycle of these
+  numbers rather than ahead of one.
+  """
+  @spec turn_hour_allowance(User.t(), keyword()) :: %{
+          used: float(),
+          included: non_neg_integer(),
+          remaining: float(),
+          period: %{start: DateTime.t(), end: DateTime.t(), source: atom()},
+          over?: boolean()
+        }
+  def turn_hour_allowance(%User{} = user, opts \\ []) do
+    period = Keyword.get(opts, :period) || billing_period(user)
+    used = turn_hours_used(user, period: {period.start, period.end})
+    included = Plans.included_turn_hours(user.plan)
+
+    %{
+      used: used,
+      included: included,
+      remaining: Float.round(max(included - used, 0.0), 2),
+      period: period,
+      over?: used > included
+    }
   end
 
   @doc """

--- a/ee/lib/fountain/billing/sandbox_usage.ex
+++ b/ee/lib/fountain/billing/sandbox_usage.ex
@@ -247,6 +247,30 @@ defmodule Fountain.Billing.SandboxUsage do
   end
 
   @doc """
+  One tenant's *turn* seconds per provider: `%{provider => busy_seconds}`.
+
+  The same rows `for_user/3` reads, reporting the part of each with a prompt
+  actually in flight rather than the whole active window. This is the unit a
+  plan's included hours are measured in (`Fountain.Plans.included_turn_hours/1`):
+  an idle sandbox costs Fountain money and is reported by `for_user/3`, but
+  spending nothing of a customer's allowance is the deliberate choice — the
+  allowance measures work, not forgetfulness.
+
+  Providers with no turn time in the period are absent rather than zero, so a
+  tenant whose sandboxes all sat idle gets an empty map, not `%{"sprites" => 0}`.
+  """
+  @spec busy_for_user(binary(), DateTime.t(), DateTime.t()) :: %{
+          optional(String.t()) => non_neg_integer()
+        }
+  def busy_for_user(user_id, %DateTime{} = period_start, %DateTime{} = period_end)
+      when is_binary(user_id) do
+    period_start
+    |> attribution(period_end, user_id: user_id)
+    |> Enum.reject(&(&1.busy_seconds == 0))
+    |> Map.new(&{&1.provider, &1.busy_seconds})
+  end
+
+  @doc """
   Does time on this provider land on a bill Fountain pays?
 
   False for `runner` (the tenant's own machine) and for any provider this

--- a/ee/lib/fountain_web/controllers/billing_api_controller.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_controller.ex
@@ -30,7 +30,9 @@ defmodule FountainWeb.BillingApiController do
     summary: "Subscription status and current-period usage",
     description:
       "Trial and period dates alongside the usage numbers the billing page " <>
-        "shows. On an instance with billing disabled this is a 404 carrying " <>
+        "shows, measured over the period Stripe invoices where one is known " <>
+        "and the calendar month otherwise (`period.source` says which). " <>
+        "On an instance with billing disabled this is a 404 carrying " <>
         "`billing: \"disabled\"`, mirroring the UI, which redirects away from " <>
         "the billing page entirely.",
     responses: [
@@ -43,13 +45,13 @@ defmodule FountainWeb.BillingApiController do
   def show(conn, _params) do
     with :ok <- require_billing() do
       user = conn.assigns.current_user
-      {period_start, period_end} = current_month_range()
+      period = Billing.billing_period(user)
 
       render(conn, :show,
         user: user,
-        usage: Billing.usage_summary(user.id, period_start, period_end),
-        period_start: period_start,
-        period_end: period_end
+        usage: Billing.usage_summary(user.id, period.start, period.end),
+        allowance: Billing.turn_hour_allowance(user, period: period),
+        period: period
       )
     end
   end
@@ -181,7 +183,4 @@ defmodule FountainWeb.BillingApiController do
   end
 
   defp return_url, do: FountainWeb.Endpoint.url() <> "/account/billing"
-
-  # The same calendar-month window the billing page reports.
-  defp current_month_range, do: Billing.current_month_range()
 end

--- a/ee/lib/fountain_web/controllers/billing_api_json.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_json.ex
@@ -1,22 +1,32 @@
 defmodule FountainWeb.BillingApiJSON do
   @moduledoc false
 
-  def show(%{user: user, usage: usage, period_start: period_start, period_end: period_end}) do
+  def show(%{user: user, usage: usage, allowance: allowance, period: period}) do
     %{
       data: %{
         status: user.subscription_status,
         plan: plan_data(user),
         trial_ends_at: user.trial_ends_at,
+        current_period_start: user.current_period_start,
         current_period_end: user.current_period_end,
         # Only an active subscription can be pending cancellation; once the
         # `.deleted` event lands the status is canceled and the flag clears.
         cancel_at_period_end:
           user.subscription_status == "active" and user.cancel_at_period_end == true,
         has_stripe_customer: user.stripe_customer_id not in [nil, ""],
-        period: %{start: period_start, end: period_end},
+        # `source` is not decoration: `calendar_month` means these numbers
+        # cover a window the customer is not invoiced over, which a client
+        # showing an allowance has to be able to say.
+        period: %{start: period.start, end: period.end, source: period.source},
         usage: %{
           conversations: usage.conversations,
           turns: usage.turns,
+          # Hours with a prompt in flight, on providers Fountain pays for —
+          # the unit `plan.included_turn_hours` is denominated in. Distinct
+          # from `sandbox_minutes`, which is wall-clock and includes idle.
+          turn_hours: allowance.used,
+          turn_hours_included: allowance.included,
+          turn_hours_remaining: allowance.remaining,
           sandbox_minutes: Float.round(usage.sandbox_minutes, 2),
           # Which sandbox provider the minutes ran on. Absent providers were
           # not used; the values sum to `sandbox_minutes`.
@@ -39,6 +49,7 @@ defmodule FountainWeb.BillingApiJSON do
       name: plan.name,
       monthly_cents: plan.monthly_cents,
       concurrent_sandboxes: plan.concurrent_sandboxes,
+      included_turn_hours: plan.included_turn_hours,
       sandbox_limit: Fountain.Quotas.sandbox_limit_for(user),
       team_contacts: plan.team_contacts
     }

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -21,15 +21,19 @@ defmodule FountainWeb.Live.BillingLive do
   def mount(_params, _session, socket) do
     if Billing.enabled?() do
       user = socket.assigns.current_user
-      {period_start, period_end} = current_month_range()
-      usage = Billing.usage_summary(user.id, period_start, period_end)
+      # The window Stripe invoices, not the calendar month — an allowance
+      # measured over a period the customer is not charged for is worse than
+      # no allowance. `:source` says which one this is; the template shows a
+      # note when it is the fallback.
+      period = Billing.billing_period(user)
+      usage = Billing.usage_summary(user.id, period.start, period.end)
 
       {:ok,
        assign(socket,
          page_title: "Billing",
          usage: usage,
-         period_start: period_start,
-         period_end: period_end,
+         allowance: Billing.turn_hour_allowance(user, period: period),
+         period: period,
          stripe_url_loading: false,
          plan: Billing.plan(user),
          sandbox_limit: Quotas.sandbox_limit_for(user),
@@ -213,8 +217,8 @@ defmodule FountainWeb.Live.BillingLive do
             <div class="flex items-center justify-between">
               <dt class="text-sm text-gray-500">Billing period</dt>
               <dd class="text-sm font-medium">
-                {Calendar.strftime(@period_start, "%B %-d")} – {Calendar.strftime(
-                  @period_end,
+                {Calendar.strftime(@period.start, "%B %-d")} – {Calendar.strftime(
+                  @period.end,
                   "%B %-d, %Y"
                 )}
               </dd>
@@ -273,7 +277,8 @@ defmodule FountainWeb.Live.BillingLive do
       >
         <h2 class="text-lg font-medium">Change plan</h2>
         <p class="mt-1 text-sm text-gray-500">
-          Plans differ by how many sandboxes you can run at the same time.
+          Plans differ by how many sandboxes you can run at the same time,
+          and by the turn hours that come with them.
           Upgrades take effect immediately and are prorated; downgrades apply
           from your next invoice.
         </p>
@@ -292,6 +297,9 @@ defmodule FountainWeb.Live.BillingLive do
             </div>
             <p class="mt-1 text-xs text-gray-500">
               {plan.concurrent_sandboxes} agents at once
+            </p>
+            <p class="mt-0.5 text-xs text-gray-500">
+              {plan.included_turn_hours} turn hours included
             </p>
             <div class="mt-3">
               <span :if={plan.slug == @plan.slug} class="text-xs font-medium text-indigo-700">
@@ -317,11 +325,46 @@ defmodule FountainWeb.Live.BillingLive do
         </p>
       </div>
 
-      <%!-- Monthly usage summary --%>
+      <%!-- Turn hours against the plan's allowance. Reported only; nothing
+            refuses anything because a tenant is over it (#1016 step 4). --%>
       <div class="rounded-lg border bg-white p-6 shadow-sm">
-        <h2 class="mb-1 text-lg font-medium">Usage This Month</h2>
+        <div class="flex items-baseline justify-between">
+          <h2 class="text-lg font-medium">Turn hours</h2>
+          <p class="text-sm tabular-nums">
+            <span class="font-semibold">{format_hours(@allowance.used)}</span>
+            <span class="text-gray-500">of {@allowance.included} included</span>
+          </p>
+        </div>
+        <div class="mt-3 h-2 w-full overflow-hidden rounded-full bg-gray-100">
+          <div
+            class={[
+              "h-full rounded-full",
+              if(@allowance.over?, do: "bg-amber-500", else: "bg-indigo-500")
+            ]}
+            style={"width: #{meter_width(@allowance)}%"}
+          >
+          </div>
+        </div>
+        <p class="mt-3 text-xs text-gray-500">
+          A turn hour is an hour with a prompt in flight. An agent sitting idle
+          costs you nothing here, and neither does time on your own runner.
+          Parked sandboxes are excluded from every number on this page.
+        </p>
+        <p :if={@allowance.over?} class="mt-2 text-xs text-amber-700">
+          You are over the hours your plan includes. Nothing is limited and
+          nothing extra is charged — we are showing you the number while we
+          work out what a fair overage looks like.
+        </p>
+      </div>
+
+      <%!-- Usage over the billing period --%>
+      <div class="rounded-lg border bg-white p-6 shadow-sm">
+        <h2 class="mb-1 text-lg font-medium">Usage this period</h2>
         <p class="mb-4 text-xs text-gray-400">
-          {Calendar.strftime(@period_start, "%b %-d")} – {Calendar.strftime(@period_end, "%b %-d, %Y")}
+          {Calendar.strftime(@period.start, "%b %-d")} – {Calendar.strftime(@period.end, "%b %-d, %Y")}
+          <span :if={@period.source == :calendar_month}>
+            · calendar month (we do not have an invoiced period for this account yet)
+          </span>
         </p>
         <dl class="grid grid-cols-3 gap-4">
           <div class="rounded-md bg-gray-50 p-4 text-center">
@@ -352,8 +395,6 @@ defmodule FountainWeb.Live.BillingLive do
   end
 
   # ─── Private helpers ───────────────────────────────────────────────────────────
-
-  defp current_month_range, do: Billing.current_month_range()
 
   # Refused outright rather than relying on the button being hidden (#399):
   # a stale socket or a hand-sent event must not open Checkout for an
@@ -416,4 +457,16 @@ defmodule FountainWeb.Live.BillingLive do
     |> Float.round(1)
     |> to_string()
   end
+
+  defp format_hours(hours), do: hours |> Float.round(1) |> to_string()
+
+  # Capped at 100 so an over-allowance account gets a full bar rather than one
+  # that overflows its track. `over?` is what says it went past, not the width.
+  # A plan with no hours (nothing sells one today) would divide by zero.
+  defp meter_width(%{included: included}) when included <= 0, do: 0
+
+  # `min/2` last and against a float: `min(101.5, 100)` returns the *integer*
+  # 100, which Float.round/2 refuses — an over-allowance account 500s the page.
+  defp meter_width(%{used: used, included: included}),
+    do: (used / included * 100) |> Float.round(1) |> min(100.0)
 end

--- a/ee/test/fountain/billing_period_shape_test.exs
+++ b/ee/test/fountain/billing_period_shape_test.exs
@@ -93,6 +93,81 @@ defmodule Fountain.BillingPeriodShapeTest do
     end
   end
 
+  # The same trap, one field over (#1016). `current_period_start` moved onto
+  # the item in the same API change, so an allowance measured over the billing
+  # period would have been measured over a calendar month forever — with the
+  # fallback quietly reporting `:calendar_month` and looking like correct
+  # behaviour rather than a bug.
+  describe "period_start_unix/1" do
+    test "prefers the subscription-level field when Stripe still sends one" do
+      assert Billing.period_start_unix(%{current_period_start: 1_797_408_000}) == 1_797_408_000
+    end
+
+    test "falls back to the item when the subscription-level field is null" do
+      sub = %{
+        current_period_start: nil,
+        items: %{data: [%{id: "si_1", current_period_start: 1_786_357_774}]}
+      }
+
+      assert Billing.period_start_unix(sub) == 1_786_357_774
+    end
+
+    test "reads string keys too" do
+      sub = %{"items" => %{"data" => [%{"current_period_start" => 1_786_357_774}]}}
+      assert Billing.period_start_unix(sub) == 1_786_357_774
+    end
+
+    test "skips an item with no period and takes the one that has it" do
+      sub = %{
+        items: %{
+          data: [
+            %{id: "si_addon"},
+            %{id: "si_plan", current_period_start: 1_786_357_774}
+          ]
+        }
+      }
+
+      assert Billing.period_start_unix(sub) == 1_786_357_774
+    end
+
+    test "answers nil when nothing carries a period" do
+      assert Billing.period_start_unix(%{}) == nil
+      assert Billing.period_start_unix(%{items: %{data: [%{id: "si_1"}]}}) == nil
+    end
+
+    # Both ends come off the same item, so a subscription in the current shape
+    # yields a period that `billing_period/2` will actually accept.
+    test "both ends read off one item make a usable billing period" do
+      _user = customer("cus_both_ends")
+      period_start = 1_786_357_774
+      period_end = 1_789_036_174
+
+      assert {:ok, updated} =
+               Billing.sync_subscription(
+                 event("cus_both_ends", %{
+                   current_period_start: nil,
+                   current_period_end: nil,
+                   items: %{
+                     data: [
+                       %{
+                         id: "si_1",
+                         current_period_start: period_start,
+                         current_period_end: period_end
+                       }
+                     ]
+                   }
+                 })
+               )
+
+      assert updated.current_period_start == DateTime.from_unix!(period_start)
+      assert updated.current_period_end == DateTime.from_unix!(period_end)
+
+      # The point of the column: a window Stripe invoices, not a calendar month.
+      assert %{source: :subscription} =
+               Billing.billing_period(updated, DateTime.from_unix!(period_start + 3600))
+    end
+  end
+
   describe "sync_subscription/1 with the current Stripe shape" do
     # The end-to-end version of the bug: a cancelling customer is promised
     # "access until <date>", and the date came out blank.

--- a/ee/test/fountain/billing_test.exs
+++ b/ee/test/fountain/billing_test.exs
@@ -361,6 +361,34 @@ defmodule Fountain.BillingTest do
       refute updated.cancel_at_period_end
       assert updated.current_period_end == nil
     end
+
+    test "both ends of the invoiced period are recorded (#1016)", %{user: _user} do
+      # The start is what makes a usage window match an invoice. Without it
+      # every number was measured over a calendar month, which for anyone who
+      # subscribed on the 20th is not the period they are charged for.
+      period_start = 1_797_408_000
+      period_end = 1_800_000_000
+
+      event = %Stripe.Event{
+        type: "customer.subscription.updated",
+        data: %{
+          object: %{
+            customer: "cus_cap",
+            status: "active",
+            trial_end: nil,
+            current_period_start: period_start,
+            current_period_end: period_end
+          }
+        }
+      }
+
+      assert {:ok, updated} = Billing.sync_subscription(event)
+      assert updated.current_period_start == DateTime.from_unix!(period_start)
+      assert updated.current_period_end == DateTime.from_unix!(period_end)
+
+      assert %{source: :subscription} =
+               Billing.billing_period(updated, DateTime.from_unix!(period_start + 60))
+    end
   end
 
   describe "sync_subscription/1 — the return path for canceled" do
@@ -585,6 +613,8 @@ defmodule Fountain.BillingTest do
       period_end =
         DateTime.utc_now() |> DateTime.add(30, :day) |> DateTime.truncate(:second)
 
+      period_start = DateTime.add(period_end, -30, :day)
+
       user =
         billing_state(insert_verified_user(),
           subscription_status: "past_due",
@@ -599,6 +629,7 @@ defmodule Fountain.BillingTest do
            id: "sub_resync",
            status: "active",
            trial_end: nil,
+           current_period_start: DateTime.to_unix(period_start),
            current_period_end: DateTime.to_unix(period_end),
            cancel_at_period_end: false
          }}
@@ -606,6 +637,7 @@ defmodule Fountain.BillingTest do
 
       assert {:ok, updated} = Billing.resync_from_stripe(user)
       assert updated.subscription_status == "active"
+      assert updated.current_period_start == period_start
       assert updated.current_period_end == period_end
       assert updated.subscription_synced_at
     end

--- a/ee/test/fountain/billing_turn_hours_test.exs
+++ b/ee/test/fountain/billing_turn_hours_test.exs
@@ -1,0 +1,294 @@
+defmodule Fountain.Billing.TurnHoursTest do
+  @moduledoc """
+  The billing period, and the turn-hour allowance measured over it (#1016).
+
+  Two things are easy to get wrong here and both are tested hard. The window
+  has to be the one Stripe invoices — or say out loud that it is not — because
+  an allowance reported over a calendar month a customer is not charged for is
+  a support ticket per customer per month. And the unit has to be *turn* time:
+  an idle sandbox costs Fountain money but spends none of a tenant's hours,
+  and a tenant's own runner costs Fountain nothing at all.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Billing
+  alias Fountain.Billing.SandboxUsage
+  alias Fountain.Conversations
+  alias Fountain.Plans
+
+  # A period wholly in the past, so `attribution/3`'s ceiling is the period end
+  # rather than the wall clock and every expected figure is exact.
+  @period_start ~U[2026-05-01 00:00:00Z]
+  @period_end ~U[2026-06-01 00:00:00Z]
+
+  defp with_period(user, period_start, period_end) do
+    {:ok, user} =
+      user
+      |> Fountain.Accounts.User.billing_changeset(%{
+        current_period_start: period_start,
+        current_period_end: period_end
+      })
+      |> Repo.update()
+
+    user
+  end
+
+  defp sandbox_running(user, provider, started, ended) do
+    insert_sandbox(
+      user_id: user.id,
+      provider: provider,
+      status: "terminated",
+      inserted_at: started,
+      terminated_at: ended
+    )
+  end
+
+  defp turn(sandbox, user, started_at, ended_at) do
+    agent = insert_agent(user_id: user.id)
+    conversation = insert_conversation(user_id: user.id, agent_id: agent.id, sandbox: sandbox)
+
+    {:ok, _} =
+      Conversations._unsafe_create_turn(%{
+        conversation_id: conversation.id,
+        turn_number: System.unique_integer([:positive]),
+        prompt: "hello",
+        status: "completed",
+        started_at: started_at,
+        ended_at: ended_at
+      })
+  end
+
+  describe "billing_period/2" do
+    test "uses the Stripe period when one is stored and it contains now" do
+      user =
+        insert_verified_user()
+        |> with_period(~U[2026-05-20 00:00:00Z], ~U[2026-06-20 00:00:00Z])
+
+      assert %{
+               start: ~U[2026-05-20 00:00:00Z],
+               end: ~U[2026-06-20 00:00:00Z],
+               source: :subscription
+             } = Billing.billing_period(user, ~U[2026-06-01 12:00:00Z])
+    end
+
+    test "the mid-month subscriber's window is theirs, not the calendar's" do
+      # The case the whole column exists for: subscribe on the 20th and every
+      # allowance boundary lines up with the invoice instead of the 1st.
+      user =
+        insert_verified_user()
+        |> with_period(~U[2026-05-20 00:00:00Z], ~U[2026-06-20 00:00:00Z])
+
+      period = Billing.billing_period(user, ~U[2026-06-05 00:00:00Z])
+
+      assert period.start.day == 20
+      refute period.start.day == 1
+    end
+
+    test "falls back to the calendar month, and says so, with no period stored" do
+      user = insert_verified_user()
+
+      period = Billing.billing_period(user, ~U[2026-06-05 00:00:00Z])
+
+      assert period.source == :calendar_month
+      assert period.start.day == 1
+    end
+
+    test "a half-synced period is not a period" do
+      # An end with no start is exactly the state every existing subscription
+      # was in the moment the column shipped. Deriving the start from it is
+      # what the issue warned against, so it falls back instead.
+      user = insert_verified_user() |> with_period(nil, ~U[2026-06-20 00:00:00Z])
+
+      assert Billing.billing_period(user, ~U[2026-06-05 00:00:00Z]).source == :calendar_month
+    end
+
+    test "a period that has already ended falls back rather than reporting a stale window" do
+      # A cancelled subscription's final period, or the seconds between a
+      # renewal and the webhook reporting the new one.
+      user =
+        insert_verified_user()
+        |> with_period(~U[2026-01-20 00:00:00Z], ~U[2026-02-20 00:00:00Z])
+
+      assert Billing.billing_period(user, ~U[2026-06-05 00:00:00Z]).source == :calendar_month
+    end
+
+    test "a period that has not started yet falls back too" do
+      user =
+        insert_verified_user()
+        |> with_period(~U[2026-09-20 00:00:00Z], ~U[2026-10-20 00:00:00Z])
+
+      assert Billing.billing_period(user, ~U[2026-06-05 00:00:00Z]).source == :calendar_month
+    end
+  end
+
+  describe "turn_hours_used/2" do
+    test "counts time with a prompt in flight, not the sandbox's whole life" do
+      user = insert_verified_user()
+
+      sandbox =
+        sandbox_running(user, "sprites", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      turn(sandbox, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 14:00:00Z])
+
+      assert Billing.turn_hours_used(user, period: {@period_start, @period_end}) == 2.0
+    end
+
+    test "an agent left running with nobody prompting it spends nothing" do
+      # The reason the allowance is denominated in turn hours: a sandbox
+      # forgotten overnight is a Fountain cost, not a customer overage.
+      user = insert_verified_user()
+      sandbox_running(user, "sprites", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      assert Billing.turn_hours_used(user, period: {@period_start, @period_end}) == 0.0
+
+      # ...while the wall-clock number the provider invoice is checked against
+      # still sees the whole day.
+      assert %{"sprites" => 86_400} =
+               SandboxUsage.for_user(user.id, @period_start, @period_end)
+    end
+
+    test "hours on the tenant's own runner do not count" do
+      user = insert_verified_user()
+
+      runner =
+        sandbox_running(user, "runner", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      turn(runner, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 15:00:00Z])
+
+      assert Billing.turn_hours_used(user, period: {@period_start, @period_end}) == 0.0
+    end
+
+    test "platform providers are summed, the runner is left out of the same total" do
+      user = insert_verified_user()
+
+      sprites =
+        sandbox_running(user, "sprites", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      e2b = sandbox_running(user, "e2b", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      runner =
+        sandbox_running(user, "runner", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      turn(sprites, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+      turn(e2b, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:30:00Z])
+      turn(runner, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 20:00:00Z])
+
+      assert Billing.turn_hours_used(user, period: {@period_start, @period_end}) == 1.5
+    end
+
+    test "a turn spanning the period boundary counts only the part inside it" do
+      user = insert_verified_user()
+
+      sandbox =
+        sandbox_running(user, "sprites", ~U[2026-04-28 00:00:00Z], ~U[2026-05-02 00:00:00Z])
+
+      turn(sandbox, user, ~U[2026-04-30 23:00:00Z], ~U[2026-05-01 01:00:00Z])
+
+      assert Billing.turn_hours_used(user, period: {@period_start, @period_end}) == 1.0
+    end
+
+    test "one tenant's turns are not another's" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+
+      sandbox =
+        sandbox_running(other, "sprites", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      turn(sandbox, other, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 14:00:00Z])
+
+      assert Billing.turn_hours_used(user, period: {@period_start, @period_end}) == 0.0
+    end
+
+    test "defaults to the tenant's billing period" do
+      user =
+        insert_verified_user()
+        |> with_period(@period_start, @period_end)
+
+      sandbox =
+        sandbox_running(user, "sprites", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      turn(sandbox, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      # The stored period has ended, so this falls back to the current calendar
+      # month — which contains none of the turn above. The point of the
+      # assertion is that the default window is *derived*, not hardcoded.
+      assert Billing.turn_hours_used(user) == 0.0
+      assert Billing.turn_hours_used(user, period: {@period_start, @period_end}) == 1.0
+    end
+  end
+
+  describe "busy_for_user/3" do
+    test "reports turn seconds per provider, omitting providers with none" do
+      user = insert_verified_user()
+
+      sprites =
+        sandbox_running(user, "sprites", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      sandbox_running(user, "e2b", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+      turn(sprites, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 12:30:00Z])
+
+      assert SandboxUsage.busy_for_user(user.id, @period_start, @period_end) ==
+               %{"sprites" => 1800}
+    end
+  end
+
+  describe "turn_hour_allowance/2" do
+    test "reports used against the plan's included hours" do
+      user = insert_verified_user(plan: "solo")
+
+      sandbox =
+        sandbox_running(user, "sprites", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
+
+      turn(sandbox, user, ~U[2026-05-10 00:00:00Z], ~U[2026-05-10 04:00:00Z])
+
+      allowance =
+        Billing.turn_hour_allowance(user,
+          period: %{start: @period_start, end: @period_end, source: :subscription}
+        )
+
+      assert allowance.used == 4.0
+      assert allowance.included == Plans.included_turn_hours("solo")
+      assert allowance.remaining == 96.0
+      refute allowance.over?
+    end
+
+    test "remaining never goes negative, and over? is what says so" do
+      user = insert_verified_user(plan: "solo")
+
+      # 101 hours against Solo's 100: one hour over.
+      sandbox =
+        sandbox_running(user, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-10 00:00:00Z])
+
+      turn(sandbox, user, ~U[2026-05-02 00:00:00Z], ~U[2026-05-06 05:00:00Z])
+
+      allowance =
+        Billing.turn_hour_allowance(user,
+          period: %{start: @period_start, end: @period_end, source: :subscription}
+        )
+
+      assert allowance.used == 101.0
+      assert allowance.remaining == 0.0
+      assert allowance.over?
+    end
+
+    test "carries the period and its source through untouched" do
+      # Every surface labels the fallback from this, so it must survive the
+      # trip rather than being recomputed per caller.
+      user = insert_verified_user()
+
+      allowance = Billing.turn_hour_allowance(user)
+
+      assert allowance.period.source == :calendar_month
+      assert allowance.period.start.day == 1
+    end
+
+    test "a bigger plan carries proportionally more" do
+      solo = insert_verified_user(plan: "solo")
+      scale = insert_verified_user(plan: "scale")
+
+      assert Billing.turn_hour_allowance(scale).included >
+               Billing.turn_hour_allowance(solo).included
+    end
+  end
+end

--- a/ee/test/fountain/release_billing_periods_test.exs
+++ b/ee/test/fountain/release_billing_periods_test.exs
@@ -1,0 +1,145 @@
+defmodule Fountain.Release.BillingPeriodsTest do
+  @moduledoc """
+  `Fountain.Release.backfill_billing_periods/1` (#1016).
+
+  `users.current_period_start` shipped after every existing subscription had
+  been created, so without this pass each account keeps reporting usage over a
+  calendar month until its next renewal webhook lands — correct, flagged, and
+  still a month of numbers that do not match an invoice.
+
+  Lives in `ee/test` because it only means anything with Stripe, even though
+  the task itself sits in core's `Fountain.Release` beside the other eval
+  tasks.
+  """
+
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  import ExUnit.CaptureIO
+
+  alias Fountain.Accounts.User
+  alias Fountain.Release
+
+  defp subscribed(attrs) do
+    {:ok, user} =
+      insert_verified_user()
+      |> User.billing_changeset(Map.merge(%{subscription_status: "active"}, attrs))
+      |> Repo.update()
+
+    user
+  end
+
+  defp stub_retrieve(sub_id, result) do
+    stub(Stripe.Subscription, :retrieve, fn ^sub_id -> result end)
+    stub(Stripe.Subscription, :retrieve, fn ^sub_id, _opts -> result end)
+  end
+
+  test "a dry run counts the gap and calls nothing" do
+    subscribed(%{stripe_subscription_id: "sub_dry"})
+
+    # No Stripe stub at all: a dry run that reached the API would blow up here
+    # rather than quietly costing a call per account.
+    capture_io(fn ->
+      assert {:ok, count} = Release.backfill_billing_periods(dry_run: true)
+      assert count >= 1
+    end)
+  end
+
+  test "records both ends of the period Stripe reports" do
+    period_start = ~U[2026-05-20 00:00:00Z]
+    period_end = ~U[2026-06-20 00:00:00Z]
+    user = subscribed(%{stripe_subscription_id: "sub_backfill_#{System.unique_integer()}"})
+
+    stub_retrieve(
+      user.stripe_subscription_id,
+      {:ok,
+       %Stripe.Subscription{
+         id: user.stripe_subscription_id,
+         status: "active",
+         current_period_start: DateTime.to_unix(period_start),
+         current_period_end: DateTime.to_unix(period_end)
+       }}
+    )
+
+    capture_io(fn -> assert {:ok, _} = Release.backfill_billing_periods() end)
+
+    reloaded = Repo.reload!(user)
+    assert reloaded.current_period_start == period_start
+    assert reloaded.current_period_end == period_end
+  end
+
+  test "leaves status, trial and plan alone" do
+    # A bulk repair that quietly flipped account statuses would be a much
+    # bigger action than the one an operator asked for. `resync_from_stripe/1`
+    # is the function that adopts everything Stripe says.
+    period_start = ~U[2026-05-20 00:00:00Z]
+
+    user =
+      subscribed(%{
+        stripe_subscription_id: "sub_narrow_#{System.unique_integer()}",
+        subscription_status: "past_due",
+        plan: "team"
+      })
+
+    stub_retrieve(
+      user.stripe_subscription_id,
+      {:ok,
+       %Stripe.Subscription{
+         id: user.stripe_subscription_id,
+         status: "canceled",
+         trial_end: DateTime.to_unix(~U[2026-01-01 00:00:00Z]),
+         current_period_start: DateTime.to_unix(period_start),
+         current_period_end: DateTime.to_unix(~U[2026-06-20 00:00:00Z])
+       }}
+    )
+
+    capture_io(fn -> assert {:ok, _} = Release.backfill_billing_periods() end)
+
+    reloaded = Repo.reload!(user)
+    assert reloaded.current_period_start == period_start
+    assert reloaded.subscription_status == "past_due"
+    assert reloaded.plan == "team"
+    assert reloaded.trial_ends_at == user.trial_ends_at
+  end
+
+  test "a subscription Stripe cannot hand back is skipped, not fatal" do
+    user = subscribed(%{stripe_subscription_id: "sub_gone_#{System.unique_integer()}"})
+
+    stub_retrieve(
+      user.stripe_subscription_id,
+      {:error,
+       %Stripe.Error{
+         source: :stripe,
+         code: :resource_missing,
+         message: "no such subscription"
+       }}
+    )
+
+    # Nothing repaired and nothing raised — but the task must not report a
+    # clean pass over a run that fixed nothing. One skipped account is a
+    # deleted subscription; every account skipped is a bad STRIPE_SECRET_KEY
+    # or an unreachable Stripe, and the operator has to hear about it.
+    warning =
+      capture_io(:stderr, fn ->
+        capture_io(fn -> assert {:ok, 0} = Release.backfill_billing_periods() end)
+      end)
+
+    assert warning =~ "was skipped"
+    assert warning =~ "STRIPE_SECRET_KEY"
+    assert is_nil(Repo.reload!(user).current_period_start)
+  end
+
+  test "an account that already has a start is not re-read" do
+    user =
+      subscribed(%{
+        stripe_subscription_id: "sub_done_#{System.unique_integer()}",
+        current_period_start: ~U[2026-05-20 00:00:00Z],
+        current_period_end: ~U[2026-06-20 00:00:00Z]
+      })
+
+    # No stub: re-reading it would raise, which is the assertion.
+    capture_io(fn -> assert {:ok, _} = Release.backfill_billing_periods() end)
+
+    assert Repo.reload!(user).current_period_start == ~U[2026-05-20 00:00:00Z]
+  end
+end

--- a/ee/test/fountain_web/controllers/billing_api_controller_test.exs
+++ b/ee/test/fountain_web/controllers/billing_api_controller_test.exs
@@ -68,6 +68,85 @@ defmodule FountainWeb.BillingApiControllerTest do
       assert body["data"]["usage"]["sandbox_minutes_by_provider"] == %{}
       assert body["data"]["period"]["start"]
       assert body["data"]["period"]["end"]
+      # No subscription period synced yet, so the numbers cover a calendar
+      # month — and the response has to say so rather than let a client show
+      # an allowance against a window nobody is invoiced for.
+      assert body["data"]["period"]["source"] == "calendar_month"
+    end
+
+    test "the plan's turn-hour allowance travels with the usage", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      # Turn hours, not sandbox minutes: an hour with a prompt in flight.
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      {period_start, _} = Fountain.Billing.current_month_range()
+      started = Enum.max([DateTime.add(now, -30, :minute), period_start], DateTime)
+
+      sandbox =
+        insert_sandbox(
+          user_id: user.id,
+          provider: "sprites",
+          status: "terminated",
+          inserted_at: started,
+          terminated_at: now
+        )
+
+      agent = insert_agent(user_id: user.id)
+
+      conversation =
+        insert_conversation(user_id: user.id, agent_id: agent.id, sandbox: sandbox)
+
+      {:ok, _} =
+        Fountain.Conversations._unsafe_create_turn(%{
+          conversation_id: conversation.id,
+          turn_number: 1,
+          prompt: "hello",
+          status: "completed",
+          started_at: started,
+          ended_at: now
+        })
+
+      expected = Float.round(DateTime.diff(now, started, :second) / 3600, 2)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/account/billing")
+        |> json_response(200)
+
+      assert body["data"]["usage"]["turn_hours"] == expected
+      assert body["data"]["usage"]["turn_hours_included"] == 100
+      assert body["data"]["plan"]["included_turn_hours"] == 100
+      assert body["data"]["usage"]["turn_hours_remaining"] == Float.round(100 - expected, 2)
+    end
+
+    test "an idle sandbox spends sandbox minutes and no turn hours", %{
+      conn: conn,
+      user: user,
+      key: key
+    } do
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      {period_start, _} = Fountain.Billing.current_month_range()
+      started = Enum.max([DateTime.add(now, -30, :minute), period_start], DateTime)
+
+      insert_sandbox(
+        user_id: user.id,
+        provider: "sprites",
+        status: "terminated",
+        inserted_at: started,
+        terminated_at: now
+      )
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/account/billing")
+        |> json_response(200)
+
+      assert body["data"]["usage"]["sandbox_minutes"] > 0
+      assert body["data"]["usage"]["turn_hours"] == 0.0
     end
 
     test "sandbox minutes are reported per provider", %{conn: conn, user: user, key: key} do

--- a/ee/test/fountain_web/live/billing_live_test.exs
+++ b/ee/test/fountain_web/live/billing_live_test.exs
@@ -77,7 +77,8 @@ defmodule FountainWeb.BillingLiveTest do
       {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
 
       assert html =~ "Subscription"
-      assert html =~ "Usage This Month"
+      assert html =~ "Usage this period"
+      assert html =~ "Turn hours"
     end
   end
 
@@ -387,6 +388,91 @@ defmodule FountainWeb.BillingLiveTest do
     end
   end
 
+  describe "the turn-hour meter (#1016)" do
+    defp busy_hours(user, hours) do
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      {period_start, _} = Billing.current_month_range()
+      started = Enum.max([DateTime.add(now, -hours * 3600, :second), period_start], DateTime)
+
+      sandbox =
+        insert_sandbox(
+          user_id: user.id,
+          provider: "sprites",
+          status: "terminated",
+          inserted_at: started,
+          terminated_at: now
+        )
+
+      agent = insert_agent(user_id: user.id)
+
+      conversation =
+        insert_conversation(user_id: user.id, agent_id: agent.id, sandbox: sandbox)
+
+      {:ok, _} =
+        Fountain.Conversations._unsafe_create_turn(%{
+          conversation_id: conversation.id,
+          turn_number: 1,
+          prompt: "hello",
+          status: "completed",
+          started_at: started,
+          ended_at: now
+        })
+
+      :ok
+    end
+
+    test "shows hours used against the plan's allowance", %{conn: conn} do
+      user = insert_verified_user(plan: "solo")
+      busy_hours(user, 3)
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+      assert html =~ "Turn hours"
+      assert html =~ "of 100 included"
+      assert html =~ "A turn hour is an hour with a prompt in flight"
+    end
+
+    test "says nothing is limited when a tenant is over", %{conn: conn} do
+      user = insert_verified_user(plan: "solo")
+      busy_hours(user, 120)
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+      # Reported, never enforced (#1016 step 4 is still open). A page that
+      # implied a limit it does not have would be worse than no meter.
+      assert html =~ "You are over the hours your plan includes"
+      assert html =~ "Nothing is limited and"
+    end
+
+    test "labels a calendar-month window as the fallback it is", %{conn: conn} do
+      # No Stripe period synced, so these numbers do not line up with an
+      # invoice. Saying so is the whole reason `billing_period/2` returns a
+      # source rather than a bare tuple.
+      user = insert_verified_user()
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+      assert html =~ "we do not have an invoiced period for this account yet"
+    end
+
+    test "does not label the window when it is the invoiced one", %{conn: conn} do
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      {:ok, user} =
+        insert_verified_user()
+        |> Fountain.Accounts.User.billing_changeset(%{
+          subscription_status: "active",
+          current_period_start: DateTime.add(now, -5, :day),
+          current_period_end: DateTime.add(now, 25, :day)
+        })
+        |> Fountain.Repo.update()
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+      refute html =~ "we do not have an invoiced period for this account yet"
+    end
+  end
+
   describe "the plan picker" do
     setup do
       Application.put_env(:fountain, :stripe_price_ids, %{
@@ -427,6 +513,9 @@ defmodule FountainWeb.BillingLiveTest do
       # switch back onto.
       refute html =~ "Switch to Legacy"
       assert html =~ "an earlier plan we no longer sell"
+      # The hours are part of what a customer is choosing between.
+      assert html =~ "100 turn hours included"
+      assert html =~ "800 turn hours included"
     end
 
     test "the current plan is not offered as a switch", %{conn: conn} do

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,36 @@ server releases.
 
 ---
 
+## [0.1.3] — 2026-08-23
+
+### Added
+
+- Turn-hour types, generated from the server's OpenAPI spec (fountain ADR 0026,
+  amended). `GET /api/account/billing` now reports what a plan includes and
+  what the account has spent against it.
+
+  - `plan.included_turn_hours` — turn hours the tier carries per billing
+    period.
+  - `usage.turn_hours`, `usage.turn_hours_included`,
+    `usage.turn_hours_remaining`.
+  - `current_period_start` beside the existing `current_period_end`.
+  - `period.source` — `"subscription"` or `"calendar_month"`.
+
+  A **turn hour is not a sandbox hour.** It counts time with a prompt in
+  flight, so an agent left running with nobody talking to it spends
+  `usage.sandbox_minutes` and none of the allowance. Do not present the two as
+  the same unit.
+
+  Read `period.source` before showing an allowance. `"calendar_month"` means
+  the server has no invoiced period for that account (comped, self-hosted, or
+  no subscription webhook yet), so the numbers do not line up with an invoice
+  and a UI that implies they do will be wrong for exactly those accounts.
+
+  Nothing is enforced against these numbers today — no request fails for
+  exceeding the included hours.
+
+All fields are optional and additive; nothing existing changed shape.
+
 ## [0.1.2] — 2026-08-23
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1823,7 +1823,7 @@ export interface paths {
         };
         /**
          * Subscription status and current-period usage
-         * @description Trial and period dates alongside the usage numbers the billing page shows. On an instance with billing disabled this is a 404 carrying `billing: "disabled"`, mirroring the UI, which redirects away from the billing page entirely.
+         * @description Trial and period dates alongside the usage numbers the billing page shows, measured over the period Stripe invoices where one is known and the calendar month otherwise (`period.source` says which). On an instance with billing disabled this is a 404 carrying `billing: "disabled"`, mirroring the UI, which redirects away from the billing page entirely.
          */
         get: operations["FountainWeb.BillingApiController.show"];
         put?: never;
@@ -3601,11 +3601,21 @@ export interface components {
                 cancel_at_period_end?: boolean;
                 /** Format: date-time */
                 current_period_end?: string | null;
+                /**
+                 * Format: date-time
+                 * @description Start of the period Stripe is invoicing. Null for a comped account, a deployment without Stripe, and any subscription that has not sent a webhook since this field existed.
+                 */
+                current_period_start?: string | null;
                 has_stripe_customer?: boolean;
-                /** @description The window the usage numbers cover (current calendar month). */
+                /** @description The window the usage numbers cover: the period Stripe is invoicing, or the current calendar month when there is no such period. */
                 period?: {
                     /** Format: date-time */
                     end?: string;
+                    /**
+                     * @description `calendar_month` means these numbers do not line up with an invoice — the account is comped, self-hosted, or has not reported a period yet.
+                     * @enum {string}
+                     */
+                    source?: "subscription" | "calendar_month";
                     /** Format: date-time */
                     start?: string;
                 };
@@ -3613,6 +3623,8 @@ export interface components {
                 plan?: {
                     /** @description The plan's concurrency cap. */
                     concurrent_sandboxes?: number;
+                    /** @description Turn hours the plan includes per billing period. Reported only: no request is refused for exceeding it. */
+                    included_turn_hours?: number;
                     monthly_cents?: number;
                     name?: string;
                     /** @description The cap actually enforced for this account. Differs from concurrent_sandboxes when an operator has set an override. */
@@ -3634,6 +3646,12 @@ export interface components {
                     sandbox_minutes_by_provider?: {
                         [key: string]: number;
                     };
+                    /** @description Hours with a prompt in flight, on providers Fountain pays for. The unit included_turn_hours is denominated in. An idle sandbox spends none of these; sandbox_minutes counts it. */
+                    turn_hours?: number;
+                    /** @description The plan's allowance, repeated here beside what was used. */
+                    turn_hours_included?: number;
+                    /** @description Clamped at zero; an account over its allowance is not owed hours. */
+                    turn_hours_remaining?: number;
                     turns?: number;
                 };
             };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.2";
+export const USER_AGENT = "fountain-sdk-js/0.1.3";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Closes steps 1 to 3 of #1016. Steps 4 and 5 (the overage shape, and a ceiling)
are deliberately not here — they are meant to be decided against a cycle of
these numbers rather than ahead of one.

The measurement half was already the good version. `SandboxUsage` has been
park-aware, period-clipped, split by provider and busy/idle-separated since
#665, and `/account/billing` has shown a customer their sandbox minutes for
months. There was nothing to compare them against, and no period to compare
them over.

## The unit is turn hours, not sandbox hours

| | solo | team | scale | legacy |
|---|---|---|---|---|
| concurrent sandboxes | 5 | 15 | 40 | 15 |
| **included turn hours** | **100** | **300** | **800** | **300** |
| price | $29 | $79 | $199 | $29 (closed) |

20 hours per concurrent slot, derived rather than chosen per tier, so a plan
cannot end up with more capacity and less work to do with it.

#798 called sandbox-active-hours the honest variable unit, and for Fountain's
*cost* it is — an idle sprite bills at full rate. It is the wrong unit to
**sell**, because the tenant behaviour it punishes is forgetting to close a
tab. So the allowance is denominated in `busy_seconds` (a prompt in flight)
and the idle half stays an operator cost signal in `provider_spend/1`. Hours
on a self-hosted runner (0022) are excluded from the other direction: Fountain
pays nothing for that machine.

The prod distribution these numbers were set against, read live:

| month | dogfood account | every other tenant |
|---|---|---|
| Aug, turn hours | 271 | < 0.5 |
| Aug, active hours | 11,091 | 1 – 21 |

The gap between those two rows is the whole argument for the unit. Against
turn hours the allowance actually bites somewhere; against active hours the
same account would be 30x over on every tier.

## The period, which had to come first

`users.current_period_start` is new, nullable, and synced from Stripe beside
the `current_period_end` already read in the subscription webhook, the trial
sweep and the admin resync.

`Billing.billing_period/2` returns `%{start, end, source}` rather than a bare
tuple, because **a number measured over the wrong window has to be able to say
so**. `:subscription` requires both ends known *and* the stored window to
contain now; everything else gets `:calendar_month` — self-hosted, comped, a
trialing account Stripe has not reported a period for, or a period that has
already ended. Every surface displays the flag.

A customer who subscribed on the 20th was getting a 10-day first "month" and a
renewal boundary out of step with every invoice. Deriving the start from the
previous `current_period_end` was rejected: on a `trialing` account that field
holds the trial end, not a period boundary.

`Fountain.Release.backfill_billing_periods/1` fills the column from Stripe for
subscriptions that predate it. One read per account that needs one, `dry_run:`
first, safe to re-run, and it writes the two period columns and **nothing
else** — status/trial/plan repair stays `resync_from_stripe/1`'s job. Without
it every existing account reports a calendar month until its next renewal.

## Reported, enforced nowhere

`Billing.turn_hour_allowance/2` is the single shape all three surfaces render,
so the billing page, `GET /api/account/billing` and the admin per-tenant view
cannot disagree about the window, the unit, or which providers count. **No
gate reads it.** The billing page says so out loud to a tenant who is over.

Note for whoever closes step 4: the contact add-on #991 built is a *licensed*
quantity price, and Stripe ignores quantity on a metered one. Hours need Meter
Events or a credit balance, not a second licensed item.

## Reviewing

Five things worth a look:

1. **`billing_period/2`'s contains-now rule.** It has one wobble: between a
   renewal and the `customer.subscription.updated` that reports the new
   period, an account reads as `:calendar_month` for a few seconds. Rolling
   the stored period forward instead would mean inventing a boundary Stripe
   has not confirmed. Flagged rather than papered over.
2. **`SandboxUsage.busy_for_user/3`** omits providers with zero turn time
   rather than reporting them as `0`, matching `for_user/3`'s "absent means
   none" contract.
3. **The API is additive**: `usage.turn_hours{,_included,_remaining}`,
   `plan.included_turn_hours`, `period.source`, `current_period_start`.
   Nothing was renamed or removed, and `sandbox_minutes` still means exactly
   what it did.
4. **`meter_width/1` rounds before clamping.** `min(101.5, 100)` returns the
   *integer* 100, which `Float.round/2` refuses — a 500 on the billing page
   for exactly the accounts the meter exists for. The test caught it; the
   comment keeps it caught.
5. **The pricing page explains the unit.** A reader who assumes wall-clock
   reads Solo's 100 hours as four days and concludes the plan is unusable.

## Verification

- Full suite green: 3,779 tests, 6 doctests, 3 properties, 0 failures.
- `mix format --check-formatted`, `mix credo --strict` (no issues), `mix
  sobelow --config`, `MIX_ENV=dev mix dialyzer` (0 errors) all clean.
- `mix openapi.spec.json` + `jq empty` valid; the new `period.source` enum is
  classified in `schema_enum_guardrail_test.exs`.
- `python3 scripts/docs-style.py` clean, `vale lint docs` exits 0 with no
  gating rule violations on the changed page.
- `okf validate decisions` valid; the index needed no regeneration (no status
  change).

Prod numbers above were read read-only from a pod, no writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Rebased onto #1019 — and it changed the code, not just the context

#1019 landed while this was open and found that Stripe moved
`current_period_start`/`current_period_end` **off the subscription and onto its
items**, so the subscription-level field reads `null`. It fixed the `end` side
with `period_end_unix/1`.

**The textual conflict was the harmless part.** Two hunks conflicted and were
obvious. The dangerous one merged *cleanly*: the webhook's new
`current_period_start` read `Map.get(sub, :current_period_start)` — the field
#1019 had just proved is always nil. Git had no reason to complain, and the
result would have been #1018 repeated one field over: a column never once
populated, `billing_period/2` reporting `:calendar_month` forever, and the
fallback making it look like correct behaviour rather than a bug.

So the resolution generalises #1019's helper rather than sitting beside it:

```elixir
def period_end_unix(sub),   do: period_unix(sub, :current_period_end)
def period_start_unix(sub), do: period_unix(sub, :current_period_start)
```

Same item-then-subscription fallback, same atom/string key handling, now shared.
All three call sites (webhook sync, trial sweep, admin resync) read both ends
through it.

`billing_period_shape_test.exs` — #1019's fixture-shape test — gains six cases
for the start field, including one that reads both ends off a single item and
asserts `billing_period/2` accepts the result as `:subscription`. **Verified by
reverting the fix**: `period_start_unix` restored to a subscription-level read
fails 4 of them.

## The release task runs under `eval`, and says when it did nothing

Two corrections while rebasing, both from #1019's neighbourhood:

- **`eval`, not `rpc`.** #1019 moved `verify_plans` to `rpc`, which is right
  for a Mix task. It is wrong here: `Ecto.Migrator.with_repo` *restarts the
  repo's pool child* when it finds one already started, so an `rpc` would bounce
  the connection pool of a pod that is serving. Every `Fountain.Release.*` task
  uses `eval` for that reason, and `config/runtime.exs` (which sets
  `STRIPE_SECRET_KEY` unconditionally) does execute under it. Both invocations
  now appear on the same docs page, so the distinction is written down.
- **All-skipped is now loud.** One skipped account is a deleted subscription.
  *Every* account skipped is an unset, revoked or wrong-mode key, or Stripe
  being unreachable — and the task would have printed a clean summary over a run
  that repaired nothing. It now warns. I first wrote this as a config check for
  `api_key`; that was worse (it misses a revoked key, a wrong-mode key and an
  outage) and it broke four tests, since the test env deliberately configures no
  key. Checking the outcome catches all four cases and needs no global env.

## SDK: publishing 0.1.3

The generated types change what the SDK ships, so the release gate asked for the
decision in review. Bumped to 0.1.3 with `USER_AGENT` and a changelog entry —
**merging this publishes `@agentshit/fountain-sdk@0.1.3` to npm.**

Additive only, so an app on 0.1.2 keeps compiling. The changelog spells out the
two things a client can get wrong: a turn hour is not a sandbox hour, and
`period.source == "calendar_month"` means the numbers do not line up with an
invoice.

## Re-verified after the rebase

3,793 tests 0 failures · credo `--strict` clean · dialyzer 0 errors · format
clean · docs-style + vale clean · SDK typecheck + 71 tests · generated types
regenerate to no diff · release gate reports "Release looks well-formed".
