### PR TITLE
feat(plans): a trial is its own, smaller plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,14 +58,25 @@ fountain/                  umbrella root
 sandboxes a tenant may run at once. Everything else the product does is on
 every plan.
 
-| | solo | team | scale | legacy |
-|---|---|---|---|---|
-| concurrent sandboxes | 5 | 15 | 40 | 15 |
-| included turn hours | 100 | 300 | 800 | 300 |
-| teammate contacts | 1 | 3 | 10 | 3 |
-| price | $29 | $79 | $199 | $29 (closed) |
+| | trial | solo | team | scale | legacy |
+|---|---|---|---|---|---|
+| concurrent sandboxes | 2 | 5 | 15 | 40 | 15 |
+| included turn hours | 40 | 100 | 300 | 800 | 300 |
+| teammate contacts | 0 | 1 | 3 | 10 | 3 |
+| price | free | $29 | $79 | $199 | $29 (closed) |
 
-Four rules that are easy to get wrong:
+Five rules that are easy to get wrong:
+
+- **A trialing account gets `trial`'s numbers, not its tier's.**
+  `Plans.effective/1` is what applies today; `Plans.resolve/1` is the tier the
+  subscription names and what it converts into. Every entitlement reader
+  (`concurrent_sandboxes/1`, `included_turn_hours/1`, `team_contacts/1`) routes
+  through `effective/1` **when handed a `%User{}`** — hand it a bare slug and
+  it cannot know the status, which is how `turn_hour_allowance/2` first got it
+  wrong. Only applies when billing is on: `subscription_status` defaults to
+  `"trialing"`, so without that guard every self-hosted account would be capped
+  at two sandboxes. In tests, `insert_verified_user/1` is trialing —
+  `insert_active_user/1` is the one that gets the plan's numbers.
 
 - **The plan is not the cap.** `Quotas.sandbox_limit/1` returns
   `users.sandbox_limit_override` when it is set and the plan's number

--- a/apps/fountain/lib/fountain/plans.ex
+++ b/apps/fountain/lib/fountain/plans.ex
@@ -45,6 +45,20 @@ defmodule Fountain.Plans do
   | `team` | 15 | 300 | 3 | $79/mo |
   | `scale` | 40 | 800 | 10 | $199/mo |
   | `legacy` | 15 | 300 | 3 | $29/mo (closed) |
+  | `trial` | 2 | 40 | 0 | free (closed) |
+
+  ## The trial is a plan, and a smaller one
+
+  `trial` is what a `trialing` account gets, whatever tier its subscription
+  names — see `effective/1`. It is deliberately below every paid plan on every
+  axis, because a trial that hands over the full tier gives a converting
+  customer nothing on the day they pay, and the customer portal is configured
+  to end the trial on a plan change precisely so they get something.
+
+  Its zero contacts are the sharpest edge: an AgentMail inbox and an
+  AgentPhone number cost real money the moment they exist, and a free trial
+  that mints one is an abuse vector with a monthly bill attached. That is one
+  number in the catalog to change if the trade turns out to be wrong.
 
   `legacy` is the flat price every account bought before the tiers existed.
   It is pinned to the old `STRIPE_PRICE_ID`, carries `team`'s capacity so that
@@ -148,10 +162,28 @@ defmodule Fountain.Plans do
       team_contacts: 3,
       order: 0,
       public?: false
+    },
+    %{
+      slug: "trial",
+      name: "Trial",
+      tagline: "Enough to judge it by, for fourteen days.",
+      monthly_cents: 0,
+      concurrent_sandboxes: 2,
+      included_turn_hours: 40,
+      team_contacts: 0,
+      order: -1,
+      public?: false
     }
   ]
 
-  @slugs Enum.map(@plan_specs, & &1.slug)
+  # `trial` is derived, never stored. `users.plan` is written only from the
+  # Stripe price on a subscription and there is no trial price, so the column
+  # cannot hold it — and nothing should be able to put it there by hand
+  # either. Keeping it out of `@slugs` is what stops the changeset accepting
+  # it, the admin selector offering it, `change_plan/3` switching onto it, and
+  # the OpenAPI enums advertising a value the API can never return.
+  @storable_specs Enum.reject(@plan_specs, &(&1.slug == "trial"))
+  @slugs Enum.map(@storable_specs, & &1.slug)
   @sorted_specs Enum.sort_by(@plan_specs, & &1.order)
   @fallback_default "solo"
 
@@ -168,7 +200,12 @@ defmodule Fountain.Plans do
   @spec public() :: [t()]
   def public, do: Enum.filter(all(), & &1.public?)
 
-  @doc "Every known slug."
+  @doc """
+  Every slug a `users.plan` row may hold.
+
+  Excludes `trial`, which is derived from subscription status rather than
+  stored — see `effective/1`. `all/0` is the one that lists the whole catalog.
+  """
   @spec slugs() :: [String.t()]
   def slugs, do: @slugs
 
@@ -182,7 +219,13 @@ defmodule Fountain.Plans do
   @spec public_slugs() :: [String.t()]
   def public_slugs, do: Enum.map(public(), & &1.slug)
 
-  @doc "Whether `slug` names a plan in the catalog."
+  @doc """
+  Whether `slug` names a plan an account can be *put on*.
+
+  False for `trial`, on purpose: it is derived from subscription status, so
+  `DEFAULT_PLAN=trial` and `change_plan(user, "trial")` are both nonsense and
+  are refused here rather than deeper in.
+  """
   @spec known?(term()) :: boolean()
   def known?(slug) when is_binary(slug), do: slug in @slugs
   def known?(_), do: false
@@ -224,10 +267,55 @@ defmodule Fountain.Plans do
   def resolve(slug) when is_binary(slug), do: get(slug) || default()
   def resolve(_), do: default()
 
-  @doc "The concurrent-sandbox cap for a user, slug or plan."
+  @doc """
+  The plan whose numbers apply to this user **right now**.
+
+  Distinct from `resolve/1`, and the distinction is the point:
+
+    * `resolve/1` answers *what tier is this account subscribed to* — the thing
+      Stripe charges for, what the plan picker highlights, which price id to
+      use. For a trialing account that is the tier the trial converts into.
+    * `effective/1` answers *which numbers does this account get today*. While
+      the trial runs, that is the `trial` plan, not the tier being trialled.
+
+  A trial is a sample, not a smaller subscription. It carries lower limits so
+  that converting hands the customer something immediately, which is also why
+  the customer portal is configured to end the trial on a plan change rather
+  than continue it — continuing would take their money and leave them on these
+  numbers until the clock ran out.
+
+  Only applies when billing is on. `subscription_status` defaults to
+  `"trialing"` in the schema, so on a self-hosted instance every account would
+  otherwise be silently capped at the trial's two sandboxes — a bad surprise
+  for someone paying their own provider bill (see `default_slug/0`).
+
+  Every entitlement reader below goes through this, so passing a `%User{}` to
+  `concurrent_sandboxes/1` and friends gives the enforced number without the
+  caller having to know the trial exists. Passing a bare **slug** does not:
+  a slug has no status. `Billing.turn_hour_allowance/2` had exactly that bug
+  before this function existed.
+  """
+  @spec effective(term()) :: t()
+  def effective(%{subscription_status: "trialing"} = user) do
+    if trial_limits?(), do: fetch!("trial"), else: resolve(user)
+  end
+
+  def effective(subject), do: resolve(subject)
+
+  # `Fountain.Billing.enabled?/0` rather than reading the config here: core
+  # already calls it from Accounts, Legal and Funnel, and a second definition
+  # of "is this deployment commercial" is a thing that drifts.
+  defp trial_limits?, do: Fountain.Billing.enabled?()
+
+  @doc """
+  The concurrent-sandbox cap for a user, slug or plan.
+
+  Given a `%User{}` this is the *effective* number — the trial's while a trial
+  runs. Given a slug it is that plan's, because a slug carries no status.
+  """
   @spec concurrent_sandboxes(term()) :: non_neg_integer()
   def concurrent_sandboxes(%__MODULE__{concurrent_sandboxes: n}), do: n
-  def concurrent_sandboxes(subject), do: resolve(subject).concurrent_sandboxes
+  def concurrent_sandboxes(subject), do: effective(subject).concurrent_sandboxes
 
   @doc """
   The turn hours a user's, slug's or plan's subscription includes per billing
@@ -243,7 +331,7 @@ defmodule Fountain.Plans do
   """
   @spec included_turn_hours(term()) :: non_neg_integer()
   def included_turn_hours(%__MODULE__{included_turn_hours: n}), do: n
-  def included_turn_hours(subject), do: resolve(subject).included_turn_hours
+  def included_turn_hours(subject), do: effective(subject).included_turn_hours
 
   @doc """
   The most teammate contacts a user, slug or plan may hold at once.
@@ -253,7 +341,7 @@ defmodule Fountain.Plans do
   """
   @spec team_contacts(term()) :: non_neg_integer()
   def team_contacts(%__MODULE__{team_contacts: n}), do: n
-  def team_contacts(subject), do: resolve(subject).team_contacts
+  def team_contacts(subject), do: effective(subject).team_contacts
 
   @doc "Display price in cents for a user, slug or plan."
   @spec monthly_cents(term()) :: non_neg_integer()

--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -91,10 +91,16 @@ defmodule Fountain.Quotas do
   """
   @spec sandbox_limit(binary()) :: non_neg_integer()
   def sandbox_limit(user_id) when is_binary(user_id) do
-    query = from u in User, where: u.id == ^user_id, select: {u.sandbox_limit_override, u.plan}
+    # `subscription_status` is selected because a trial is capped lower than
+    # the tier it trials (`Plans.effective/1`). Selecting only the plan slug
+    # would hand a trialing account the paid number.
+    query =
+      from u in User,
+        where: u.id == ^user_id,
+        select: {u.sandbox_limit_override, u.plan, u.subscription_status}
 
     case Repo.one(query) do
-      {override, plan} -> resolve_limit(override, plan)
+      {override, plan, status} -> resolve_limit(override, plan, status)
       nil -> Plans.concurrent_sandboxes(nil)
     end
   end
@@ -105,11 +111,16 @@ defmodule Fountain.Quotas do
   row (the same contract as `active_sandbox_counts/0`).
   """
   @spec sandbox_limit_for(User.t()) :: non_neg_integer()
-  def sandbox_limit_for(%User{sandbox_limit_override: override, plan: plan}),
-    do: resolve_limit(override, plan)
+  def sandbox_limit_for(%User{} = user),
+    do: resolve_limit(user.sandbox_limit_override, user.plan, user.subscription_status)
 
-  defp resolve_limit(override, _plan) when is_integer(override), do: override
-  defp resolve_limit(_override, plan), do: Plans.concurrent_sandboxes(plan)
+  # An explicit override beats everything, the trial included: it is the
+  # operator saying "this account, this number", and a trial is not a reason
+  # to second-guess that.
+  defp resolve_limit(override, _plan, _status) when is_integer(override), do: override
+
+  defp resolve_limit(_override, plan, status),
+    do: Plans.concurrent_sandboxes(%{plan: plan, subscription_status: status})
 
   @doc """
   Check `user_id` against the sandbox concurrency cap.

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -1039,8 +1039,12 @@ defmodule FountainWeb.AdminLive.Index do
                       class="rounded border border-zinc-200 px-1 py-0.5 text-xs"
                       title={"#{u.plan.concurrent_sandboxes} concurrent · #{u.plan.team_contacts} contacts"}
                     >
+                      <%!-- Storable slugs only: `trial` is derived from
+                            subscription status, so offering it here would
+                            let an operator pin an account to a plan the
+                            column cannot hold. --%>
                       <option
-                        :for={p <- Fountain.Plans.all()}
+                        :for={p <- Enum.map(Fountain.Plans.slugs(), &Fountain.Plans.fetch!/1)}
                         value={p.slug}
                         selected={p.slug == u.plan.slug}
                       >

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -119,7 +119,7 @@ defmodule Fountain.AuditGuardrailTest do
 
   for {label, fun, action} <- @must_audit do
     test "#{label} leaves an audit event" do
-      user = insert_verified_user()
+      user = insert_active_user()
 
       unquote(fun).(user)
 

--- a/apps/fountain/test/fountain/conversations_start_test.exs
+++ b/apps/fountain/test/fountain/conversations_start_test.exs
@@ -14,7 +14,7 @@ defmodule Fountain.ConversationsStartTest do
 
   describe "wake_conversation/2 — provider resume" do
     test "a failed resume leaves the row suspended and fails retryably" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
       sandbox = insert_sandbox(user_id: user.id, sprite_name: "parked-wont-wake")
       {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
@@ -38,7 +38,7 @@ defmodule Fountain.ConversationsStartTest do
       # Falling through to :create_new would retire the row and orphan (or
       # lose) the parked disk; a retryable error keeps the agent's memory
       # safe until the operator restores the provider's credentials.
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
       sandbox = insert_sandbox(user_id: user.id, sprite_name: "parked-on-e2b")
 
@@ -56,7 +56,7 @@ defmodule Fountain.ConversationsStartTest do
 
   describe "start_conversation/1" do
     test "the sandbox row is stamped with the resolved provider" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
       stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
 
@@ -68,7 +68,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "an agent pinned to a disabled provider is refused before any row is allocated" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
 
       # Simulate drift: the override was saved while the provider was
@@ -89,8 +89,8 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "returns {:error, :vault_not_found} when vault_id belongs to a different user" do
-      user1 = insert_verified_user()
-      user2 = insert_verified_user()
+      user1 = insert_active_user()
+      user2 = insert_active_user()
       agent = insert_agent(user_id: user1.id)
       # vault belongs to user2, not user1
       vault = insert_vault(user_id: user2.id)
@@ -105,7 +105,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "is refused once the tenant is at its concurrent-sandbox cap" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
 
       for _ <- 1..Fountain.Quotas.default_limit(),
@@ -116,7 +116,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "the cap is checked before any sandbox row is allocated" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
       for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
 
@@ -131,8 +131,8 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "one tenant at its cap does not block another" do
-      capped = insert_verified_user()
-      other = insert_verified_user()
+      capped = insert_active_user()
+      other = insert_active_user()
       for _ <- 1..5, do: insert_sandbox(user_id: capped.id, status: "ready")
       agent = insert_agent(user_id: other.id)
 
@@ -143,7 +143,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "terminated sandboxes free capacity" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
       [first | _] = for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
 
@@ -158,7 +158,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "creates sandbox, conversation, and starts server", %{} do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
 
       stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
@@ -178,7 +178,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "broadcasts graph update when parent_conversation_id is set", %{} do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
       parent_conv = insert_conversation(user_id: user.id)
 
@@ -197,7 +197,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "succeeds when vault_id is empty string", %{} do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
 
       stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
@@ -210,7 +210,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "succeeds and links vault when valid vault_id provided", %{} do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
       vault = insert_vault(user_id: user.id)
 
@@ -224,7 +224,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "allows a vault on the agent's allowed_vault_ids list", %{} do
-      user = insert_verified_user()
+      user = insert_active_user()
       vault = insert_vault(user_id: user.id)
       agent = insert_agent(user_id: user.id, allowed_vault_ids: [vault.id])
 
@@ -238,7 +238,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "returns {:error, :vault_not_allowed} for a vault outside the allowlist", %{} do
-      user = insert_verified_user()
+      user = insert_active_user()
       allowed = insert_vault(user_id: user.id)
       other = insert_vault(user_id: user.id)
       agent = insert_agent(user_id: user.id, allowed_vault_ids: [allowed.id])
@@ -248,7 +248,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "returns {:error, :vault_not_allowed} for any vault when the allowlist is empty", %{} do
-      user = insert_verified_user()
+      user = insert_active_user()
       vault = insert_vault(user_id: user.id)
       agent = insert_agent(user_id: user.id, allowed_vault_ids: [])
 
@@ -257,7 +257,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "empty allowlist still permits starting with no vault at all", %{} do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id, allowed_vault_ids: [])
 
       stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
@@ -280,7 +280,7 @@ defmodule Fountain.ConversationsStartTest do
         {:ok, spawn(fn -> :ok end)}
       end)
 
-      user = insert_verified_user()
+      user = insert_active_user()
       %{user: user}
     end
 
@@ -404,7 +404,7 @@ defmodule Fountain.ConversationsStartTest do
         {:ok, spawn(fn -> :ok end)}
       end)
 
-      user = insert_verified_user()
+      user = insert_active_user()
       agent_env = insert_env(user_id: user.id)
       other_env = insert_env(user_id: user.id)
       agent = insert_agent(user_id: user.id, environment_id: agent_env.id)
@@ -442,7 +442,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "a foreign environment reads as not found — same as an unknown id", ctx do
-      stranger = insert_verified_user()
+      stranger = insert_active_user()
       foreign = insert_env(user_id: stranger.id)
 
       for id <- [foreign.id, Ecto.UUID.generate()] do
@@ -497,7 +497,7 @@ defmodule Fountain.ConversationsStartTest do
 
     test "the allowlist is checked before the fetch, so a foreign id is refused not probed",
          ctx do
-      stranger = insert_verified_user()
+      stranger = insert_active_user()
       foreign = insert_env(user_id: stranger.id)
       {:ok, agent} = Agents.update_agent(ctx.agent, %{allowed_environment_ids: []})
 
@@ -556,7 +556,7 @@ defmodule Fountain.ConversationsStartTest do
         {:ok, spawn(fn -> :ok end)}
       end)
 
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
 
       %{
@@ -604,7 +604,7 @@ defmodule Fountain.ConversationsStartTest do
 
   describe "_unsafe_list_active_conversations/0 ordering" do
     test "running conversations appear before idle conversations" do
-      user = insert_verified_user()
+      user = insert_active_user()
       idle = insert_conversation(user_id: user.id, status: "idle")
       running = insert_conversation(user_id: user.id, status: "running")
 
@@ -620,7 +620,7 @@ defmodule Fountain.ConversationsStartTest do
 
   describe "_unsafe_list_turns/1 image preloads" do
     test "preloads images association on each turn" do
-      user = insert_verified_user()
+      user = insert_active_user()
       conv = insert_conversation(user_id: user.id)
       turn = insert_turn(conv)
 
@@ -642,7 +642,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "returns turns with empty images list when no images have been inserted" do
-      user = insert_verified_user()
+      user = insert_active_user()
       conv = insert_conversation(user_id: user.id)
       _turn = insert_turn(conv)
 
@@ -651,7 +651,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "orders images by position ascending when multiple images exist" do
-      user = insert_verified_user()
+      user = insert_active_user()
       conv = insert_conversation(user_id: user.id)
       turn = insert_turn(conv)
 
@@ -681,7 +681,7 @@ defmodule Fountain.ConversationsStartTest do
 
   describe "insert_sandbox/1 factory — no explicit user_id" do
     test "creates a new user when no user_id is provided" do
-      # Triggers the insert_verified_user().id fallback in insert_sandbox (factory.ex line 129)
+      # Triggers the insert_active_user().id fallback in insert_sandbox (factory.ex line 129)
       sandbox = insert_sandbox()
       assert is_binary(sandbox.user_id)
     end
@@ -689,7 +689,7 @@ defmodule Fountain.ConversationsStartTest do
 
   describe "insert_conversation/1 factory — agent without explicit user_id" do
     test "derives user_id from agent when no user_id is provided" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
       conv = insert_conversation(agent: agent)
       assert conv.user_id == user.id
@@ -697,7 +697,7 @@ defmodule Fountain.ConversationsStartTest do
     end
 
     test "creates a new user when neither user_id nor agent is provided" do
-      # Triggers the insert_verified_user().id fallback (factory.ex line 147)
+      # Triggers the insert_active_user().id fallback (factory.ex line 147)
       conv = insert_conversation()
       assert is_binary(conv.user_id)
       assert is_nil(conv.agent_id)

--- a/apps/fountain/test/fountain/plans_test.exs
+++ b/apps/fountain/test/fountain/plans_test.exs
@@ -29,8 +29,10 @@ defmodule Fountain.PlansTest do
   end
 
   describe "the catalog" do
-    test "is ordered cheapest first, with the closed plan before them" do
-      assert Enum.map(Plans.all(), & &1.slug) == ~w(legacy solo team scale)
+    # `trial` sorts below `legacy`, which is what makes every real plan an
+    # upgrade from it and keeps it out of every "switch to" list.
+    test "is ordered cheapest first, with the two closed plans before them" do
+      assert Enum.map(Plans.all(), & &1.slug) == ~w(trial legacy solo team scale)
     end
 
     test "public/0 hides the closed plan" do
@@ -126,7 +128,9 @@ defmodule Fountain.PlansTest do
       assert_raise ArgumentError, ~r/unknown plan/, fn -> Plans.fetch!("enterprise") end
     end
 
-    test "slugs/0 lists every plan, including the closed one" do
+    # Storable slugs, so `legacy` is in and `trial` is not: a `users.plan` row
+    # can hold the closed flat plan but never the derived trial one.
+    test "slugs/0 lists every plan a row can hold, including the closed one" do
       assert Enum.sort(Plans.slugs()) == Enum.sort(~w(solo team scale legacy))
     end
 

--- a/apps/fountain/test/fountain/plans_trial_test.exs
+++ b/apps/fountain/test/fountain/plans_trial_test.exs
@@ -1,0 +1,178 @@
+defmodule Fountain.PlansTrialTest do
+  @moduledoc """
+  A trial is a sample, not a smaller subscription: while it runs the `trial`
+  plan's numbers apply, not those of the tier being trialled.
+
+  `async: false` — several of these move `:billing_enabled`, which is global.
+  """
+  use Fountain.DataCase, async: false
+
+  alias Fountain.{Plans, Quotas}
+
+  setup do
+    previous = Application.get_env(:fountain, :billing_enabled)
+    Application.put_env(:fountain, :billing_enabled, true)
+    on_exit(fn -> Application.put_env(:fountain, :billing_enabled, previous) end)
+    :ok
+  end
+
+  defp with_billing_off(fun) do
+    Application.put_env(:fountain, :billing_enabled, false)
+    fun.()
+  after
+    Application.put_env(:fountain, :billing_enabled, true)
+  end
+
+  describe "the trial plan" do
+    test "is smaller than every public plan on every axis" do
+      trial = Plans.fetch!("trial")
+
+      for plan <- Plans.public() do
+        assert trial.concurrent_sandboxes < plan.concurrent_sandboxes
+        assert trial.included_turn_hours < plan.included_turn_hours
+        assert trial.team_contacts <= plan.team_contacts
+      end
+    end
+
+    # The whole reason it exists: converting has to hand the customer something
+    # the same day, which is also what makes the portal's `end_trial` setting
+    # coherent rather than punitive.
+    test "is never offered for sale, and sorts below everything" do
+      trial = Plans.fetch!("trial")
+
+      refute trial.public?
+      refute "trial" in Plans.public_slugs()
+      assert Enum.all?(Plans.public(), &Plans.upgrade?(trial, &1))
+      assert trial.monthly_cents == 0
+    end
+
+    test "holds the 20-hours-per-slot ratio the other plans do" do
+      trial = Plans.fetch!("trial")
+      assert trial.included_turn_hours == trial.concurrent_sandboxes * 20
+    end
+
+    # `users.plan` is written only from the Stripe price on a subscription and
+    # there is no trial price, so the column cannot hold "trial" — and nothing
+    # should be able to put it there by hand either. Keeping it out of
+    # `slugs/0` is what stops the changeset, the admin selector, `change_plan/3`
+    # and the OpenAPI enums each having to know separately.
+    test "is derived, never stored" do
+      refute "trial" in Plans.slugs()
+      refute Plans.known?("trial")
+
+      assert %Ecto.Changeset{valid?: false} =
+               Fountain.Accounts.User.plan_changeset(%Fountain.Accounts.User{}, %{plan: "trial"})
+
+      # Still reachable in the catalog, which is how `effective/1` returns it.
+      assert Plans.fetch!("trial").slug == "trial"
+      assert Enum.any?(Plans.all(), &(&1.slug == "trial"))
+    end
+
+    # A slug that cannot be stored must not be a DEFAULT_PLAN either, or a
+    # self-hoster could cap their whole instance at two sandboxes by typo.
+    test "cannot be set as DEFAULT_PLAN" do
+      previous = Application.get_env(:fountain, :default_plan)
+      Application.put_env(:fountain, :default_plan, "trial")
+      on_exit(fn -> Application.put_env(:fountain, :default_plan, previous) end)
+
+      assert Plans.default_slug() == "solo"
+    end
+  end
+
+  describe "effective/1" do
+    test "a trialing account gets the trial's numbers, not its tier's" do
+      user = %{plan: "scale", subscription_status: "trialing"}
+
+      assert Plans.effective(user).slug == "trial"
+      assert Plans.concurrent_sandboxes(user) == 2
+      assert Plans.included_turn_hours(user) == 40
+      assert Plans.team_contacts(user) == 0
+    end
+
+    # `resolve/1` still answers "what will they pay for", which is what the
+    # picker, the price id and the billing page's plan name all need.
+    test "resolve/1 keeps naming the tier the trial converts into" do
+      user = %{plan: "scale", subscription_status: "trialing"}
+
+      assert Plans.resolve(user).slug == "scale"
+      assert Plans.monthly_cents(user) == Plans.fetch!("scale").monthly_cents
+    end
+
+    test "every other status gets the tier" do
+      for status <- ~w(active past_due canceled comped) do
+        user = %{plan: "team", subscription_status: status}
+        assert Plans.effective(user).slug == "team", "status=#{status}"
+        assert Plans.concurrent_sandboxes(user) == 15
+      end
+    end
+
+    # A slug carries no status, so it cannot be trial-aware. Pinned because
+    # `turn_hour_allowance/2` passed one and silently handed trialing accounts
+    # the paid allowance.
+    test "a bare slug is the plan's own number, trial or not" do
+      assert Plans.concurrent_sandboxes("scale") == 40
+      assert Plans.included_turn_hours("scale") == 800
+    end
+
+    # `subscription_status` defaults to "trialing" in the schema, so without
+    # this guard every self-hosted account would be silently capped at two
+    # sandboxes — for someone paying their own provider bill.
+    test "billing disabled means no trial limits at all" do
+      user = %{plan: "scale", subscription_status: "trialing"}
+
+      with_billing_off(fn ->
+        assert Plans.effective(user).slug == "scale"
+        assert Plans.concurrent_sandboxes(user) == 40
+      end)
+    end
+
+    test "billing disabled with no plan follows DEFAULT_PLAN, not the trial" do
+      user = %{plan: nil, subscription_status: "trialing"}
+
+      with_billing_off(fn ->
+        assert Plans.effective(user).slug == Plans.default_slug()
+      end)
+    end
+  end
+
+  describe "the cap actually enforced" do
+    test "a trialing account is capped at the trial's concurrency" do
+      user = insert_verified_user(plan: "scale")
+      assert Quotas.sandbox_limit(user.id) == 2
+      assert Quotas.sandbox_limit_for(reload(user)) == 2
+    end
+
+    test "converting to active lifts it the same day, with no migration" do
+      user = insert_verified_user(plan: "scale")
+      assert Quotas.sandbox_limit(user.id) == 2
+
+      {:ok, _} = activate(user)
+      assert Quotas.sandbox_limit(user.id) == 40
+    end
+
+    # An override is the operator saying "this account, this number". A trial
+    # is not a reason to second-guess that.
+    test "an operator override beats the trial, in both directions" do
+      up = insert_verified_user(plan: "solo")
+      {:ok, up} = Fountain.Accounts.update_sandbox_limit(up, 25)
+      assert Quotas.sandbox_limit(up.id) == 25
+
+      down = insert_verified_user(plan: "scale")
+      {:ok, down} = Fountain.Accounts.update_sandbox_limit(down, 0)
+      assert Quotas.sandbox_limit(down.id) == 0
+    end
+
+    test "sandbox_limit_for/1 agrees with sandbox_limit/1 for a trialing account" do
+      user = insert_verified_user(plan: "team")
+      assert Quotas.sandbox_limit_for(reload(user)) == Quotas.sandbox_limit(user.id)
+    end
+  end
+
+  defp reload(user), do: Fountain.Repo.get!(Fountain.Accounts.User, user.id)
+
+  defp activate(user) do
+    user
+    |> Fountain.Accounts.User.billing_changeset(%{subscription_status: "active"})
+    |> Fountain.Repo.update()
+  end
+end

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -5,8 +5,8 @@ defmodule Fountain.QuotasTest do
 
   describe "active_sandbox_count/2" do
     test "counts only the given tenant's sandboxes" do
-      user = insert_verified_user()
-      other = insert_verified_user()
+      user = insert_active_user()
+      other = insert_active_user()
 
       insert_sandbox(user_id: user.id, status: "ready")
       insert_sandbox(user_id: user.id, status: "pending")
@@ -17,7 +17,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "pending and starting count — a sprite bills from provisioning, not from ready" do
-      user = insert_verified_user()
+      user = insert_active_user()
 
       for status <- ~w(pending starting ready) do
         insert_sandbox(user_id: user.id, status: status)
@@ -27,7 +27,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "terminated and failed do not count" do
-      user = insert_verified_user()
+      user = insert_active_user()
 
       insert_sandbox(user_id: user.id, status: "ready")
       insert_sandbox(user_id: user.id, status: "terminated")
@@ -40,7 +40,7 @@ defmodule Fountain.QuotasTest do
       # Otherwise five abandoned conversations would permanently lock a
       # default-cap tenant out of starting anything. Waking a suspended
       # sandbox re-runs the gate (Conversations.wake_suspended_sandbox/2).
-      user = insert_verified_user()
+      user = insert_active_user()
 
       insert_sandbox(user_id: user.id, status: "ready")
       insert_sandbox(user_id: user.id, status: "suspended")
@@ -49,7 +49,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "exclude: leaves the named sandbox out" do
-      user = insert_verified_user()
+      user = insert_active_user()
       keep = insert_sandbox(user_id: user.id, status: "ready")
       insert_sandbox(user_id: user.id, status: "ready")
 
@@ -58,7 +58,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "is zero for a tenant with no sandboxes" do
-      assert Quotas.active_sandbox_count(insert_verified_user().id) == 0
+      assert Quotas.active_sandbox_count(insert_active_user().id) == 0
     end
   end
 
@@ -70,27 +70,27 @@ defmodule Fountain.QuotasTest do
     # on, so changing a cap in the catalog has to be a deliberate edit here.
 
     test "a user with no plan gets the default plan's cap, which is 5" do
-      assert Quotas.sandbox_limit(insert_verified_user().id) == 5
+      assert Quotas.sandbox_limit(insert_active_user().id) == 5
     end
 
     test "the cap follows the plan" do
-      assert Quotas.sandbox_limit(insert_verified_user(plan: "solo").id) == 5
-      assert Quotas.sandbox_limit(insert_verified_user(plan: "team").id) == 15
-      assert Quotas.sandbox_limit(insert_verified_user(plan: "scale").id) == 40
+      assert Quotas.sandbox_limit(insert_active_user(plan: "solo").id) == 5
+      assert Quotas.sandbox_limit(insert_active_user(plan: "team").id) == 15
+      assert Quotas.sandbox_limit(insert_active_user(plan: "scale").id) == 40
     end
 
     # Grandfathering, in one assertion: the closed plan is priced like Solo
     # and capped like Team, so nobody lost capacity at the changeover.
     test "the closed legacy plan carries Team's cap" do
-      assert Quotas.sandbox_limit(insert_verified_user(plan: "legacy").id) == 15
+      assert Quotas.sandbox_limit(insert_active_user(plan: "legacy").id) == 15
     end
 
     test "an override beats the plan, in either direction" do
-      up = insert_verified_user(plan: "solo")
+      up = insert_active_user(plan: "solo")
       {:ok, up} = Fountain.Accounts.update_sandbox_limit(up, 25)
       assert Quotas.sandbox_limit(up.id) == 25
 
-      down = insert_verified_user(plan: "scale")
+      down = insert_active_user(plan: "scale")
       {:ok, down} = Fountain.Accounts.update_sandbox_limit(down, 1)
       assert Quotas.sandbox_limit(down.id) == 1
     end
@@ -98,14 +98,14 @@ defmodule Fountain.QuotasTest do
     # Zero is the abuse lever and must survive the "is there an override?"
     # test, which a truthiness check would get wrong.
     test "an override of zero is an override, not an absent one" do
-      user = insert_verified_user(plan: "scale")
+      user = insert_active_user(plan: "scale")
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 0)
 
       assert Quotas.sandbox_limit(user.id) == 0
     end
 
     test "clearing the override hands the cap back to the plan" do
-      user = insert_verified_user(plan: "team")
+      user = insert_active_user(plan: "team")
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 1)
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, nil)
 
@@ -123,7 +123,7 @@ defmodule Fountain.QuotasTest do
     test "agrees with sandbox_limit/1 without touching the database" do
       for plan <- ["solo", "team", "scale", "legacy", nil],
           override <- [nil, 0, 25] do
-        user = insert_verified_user(plan: plan)
+        user = insert_active_user(plan: plan)
         {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, override)
 
         assert Quotas.sandbox_limit_for(user) == Quotas.sandbox_limit(user.id),
@@ -134,14 +134,14 @@ defmodule Fountain.QuotasTest do
 
   describe "check_sandbox_quota/2" do
     test "passes below the cap" do
-      user = insert_verified_user()
+      user = insert_active_user()
       insert_sandbox(user_id: user.id, status: "ready")
 
       assert :ok = Quotas.check_sandbox_quota(user.id)
     end
 
     test "denies at the cap" do
-      user = insert_verified_user()
+      user = insert_active_user()
       for _ <- 1..Quotas.default_limit(), do: insert_sandbox(user_id: user.id, status: "ready")
 
       assert {:error, {:sandbox_quota_exceeded, %{count: 5, limit: 5}}} =
@@ -149,7 +149,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "denies above the cap" do
-      user = insert_verified_user()
+      user = insert_active_user()
       for _ <- 1..7, do: insert_sandbox(user_id: user.id, status: "ready")
 
       assert {:error, {:sandbox_quota_exceeded, %{count: 7, limit: 5}}} =
@@ -157,8 +157,8 @@ defmodule Fountain.QuotasTest do
     end
 
     test "one tenant at its cap does not affect another" do
-      user = insert_verified_user()
-      other = insert_verified_user()
+      user = insert_active_user()
+      other = insert_active_user()
       for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
 
       assert {:error, _} = Quotas.check_sandbox_quota(user.id)
@@ -166,7 +166,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "exclude: lets a replacement through at exactly the cap" do
-      user = insert_verified_user()
+      user = insert_active_user()
       [replacing | _] = for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
 
       assert {:error, _} = Quotas.check_sandbox_quota(user.id)
@@ -174,7 +174,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "a raised cap admits more" do
-      user = insert_verified_user()
+      user = insert_active_user()
       for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
       assert {:error, _} = Quotas.check_sandbox_quota(user.id)
 
@@ -183,7 +183,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "a cap of zero denies everything — the lever for shutting off abuse" do
-      user = insert_verified_user()
+      user = insert_active_user()
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 0)
 
       assert {:error, {:sandbox_quota_exceeded, %{count: 0, limit: 0}}} =
@@ -200,7 +200,7 @@ defmodule Fountain.QuotasTest do
     alias Fountain.Quotas
 
     test "creates the row when below the cap" do
-      user = insert_verified_user()
+      user = insert_active_user()
 
       assert {:ok, sandbox} =
                Quotas.with_sandbox_reservation(user.id, fn ->
@@ -212,7 +212,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "refuses at the cap and creates nothing" do
-      user = insert_verified_user()
+      user = insert_active_user()
       for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
 
       assert {:error, {:sandbox_quota_exceeded, %{count: 5, limit: 5}}} =
@@ -224,7 +224,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "a failure in fun rolls the reservation back" do
-      user = insert_verified_user()
+      user = insert_active_user()
 
       assert {:error, :boom} =
                Quotas.with_sandbox_reservation(user.id, fn ->
@@ -237,7 +237,7 @@ defmodule Fountain.QuotasTest do
     end
 
     test "honours the :exclude option the wake path needs" do
-      user = insert_verified_user()
+      user = insert_active_user()
       sandboxes = for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
       replacing = hd(sandboxes)
 
@@ -250,11 +250,11 @@ defmodule Fountain.QuotasTest do
 
   describe "check_sandbox_quota!/2" do
     test "returns :ok below the cap" do
-      assert :ok = Quotas.check_sandbox_quota!(insert_verified_user().id)
+      assert :ok = Quotas.check_sandbox_quota!(insert_active_user().id)
     end
 
     test "raises at the cap with the counts in the message" do
-      user = insert_verified_user()
+      user = insert_active_user()
       for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
 
       err =

--- a/apps/fountain/test/fountain/team/comms_plan_test.exs
+++ b/apps/fountain/test/fountain/team/comms_plan_test.exs
@@ -89,8 +89,8 @@ defmodule Fountain.Team.CommsPlanTest do
 
   describe "contact_count/1" do
     test "counts only this tenant's contacts" do
-      user = insert_verified_user(plan: "team")
-      other = insert_verified_user(plan: "team")
+      user = insert_active_user(plan: "team")
+      other = insert_active_user(plan: "team")
 
       {_a, {:ok, _}} = provision(user, "Ada")
       {_b, {:ok, _}} = provision(other, "Bob")
@@ -102,12 +102,12 @@ defmodule Fountain.Team.CommsPlanTest do
 
   describe "the plan ceiling" do
     test "a teammate under the ceiling gets a contact" do
-      user = insert_verified_user(plan: "solo")
+      user = insert_active_user(plan: "solo")
       assert {_agent, {:ok, _contact}} = provision(user, "Ada")
     end
 
     test "refuses at the ceiling, and says which one" do
-      user = insert_verified_user(plan: "solo")
+      user = insert_active_user(plan: "solo")
       fill_to_ceiling(user)
 
       limit = Plans.team_contacts("solo")
@@ -118,7 +118,7 @@ defmodule Fountain.Team.CommsPlanTest do
 
     test "a bigger plan allows more" do
       solo = Plans.team_contacts("solo")
-      user = insert_verified_user(plan: "team")
+      user = insert_active_user(plan: "team")
 
       for n <- 1..(solo + 1) do
         assert {_agent, {:ok, _}} = provision(user, "mate-#{n}")
@@ -128,7 +128,7 @@ defmodule Fountain.Team.CommsPlanTest do
     # Nothing is bought before the ceiling is checked: a refused provision must
     # not leave an orphan inbox or number behind at the provider.
     test "buys nothing when it refuses" do
-      user = insert_verified_user(plan: "solo")
+      user = insert_active_user(plan: "solo")
       fill_to_ceiling(user)
       before = Comms.contact_count(user.id)
 
@@ -140,7 +140,7 @@ defmodule Fountain.Team.CommsPlanTest do
     end
 
     test "releasing one makes room again" do
-      user = insert_verified_user(plan: "solo")
+      user = insert_active_user(plan: "solo")
       fill_to_ceiling(user)
       {agent, _} = provision(user, "refused")
 
@@ -155,7 +155,7 @@ defmodule Fountain.Team.CommsPlanTest do
 
   describe "the add-on quantity sync" do
     test "runs after a contact is provisioned" do
-      user = insert_verified_user(plan: "team")
+      user = insert_active_user(plan: "team")
       test_pid = self()
 
       expect(Fountain.Billing, :sync_contact_addon, fn user_id ->
@@ -169,7 +169,7 @@ defmodule Fountain.Team.CommsPlanTest do
     end
 
     test "runs after one is released" do
-      user = insert_verified_user(plan: "team")
+      user = insert_active_user(plan: "team")
       {agent, {:ok, _}} = provision(user, "Ada")
       test_pid = self()
 
@@ -186,7 +186,7 @@ defmodule Fountain.Team.CommsPlanTest do
     # this runs, so a Stripe outage must not fail the provision or strand a
     # released number as un-released.
     test "a failing sync does not fail the provision" do
-      user = insert_verified_user(plan: "team")
+      user = insert_active_user(plan: "team")
       stub(Fountain.Billing, :sync_contact_addon, fn _ -> raise "stripe is down" end)
 
       assert {_agent, {:ok, _contact}} = provision(user, "Ada")

--- a/apps/fountain/test/fountain/team/comms_test.exs
+++ b/apps/fountain/test/fountain/team/comms_test.exs
@@ -76,7 +76,7 @@ defmodule Fountain.Team.CommsTest do
 
   describe "gates" do
     test "status reports the flag and the providers separately" do
-      user = insert_verified_user()
+      user = insert_active_user()
       flag(false)
       assert Comms.status(user) == %{enabled: false, configured: true}
       flag(true)
@@ -84,7 +84,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "provision is refused with the flag off, and nothing is called" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       flag(false)
       Req.Test.stub(AgentMail, fn _ -> flunk("AgentMail must not be called") end)
@@ -94,7 +94,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "provision is refused when a provider key is missing" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       flag(true)
       previous = Application.get_env(:fountain, :agentphone_api_key)
@@ -113,7 +113,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "creates an inbox and a number, records them, audits, broadcasts" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user, "Ada Lovelace")
       stub_providers_ok()
       Team.subscribe(user.id)
@@ -154,7 +154,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "the teammate's contact rides along on the roster" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       stub_providers_ok()
       {:ok, contact} = Comms.provision_contact(user.id, agent.id, @req)
@@ -164,7 +164,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "refuses a second contact for the same teammate" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       stub_providers_ok()
       {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
@@ -172,7 +172,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "a missing or bad prompt_from_number is refused before anything is bought" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       Req.Test.stub(AgentMail, fn _ -> flunk("nothing is bought on a bad request") end)
       Req.Test.stub(AgentPhone, fn _ -> flunk("nothing is bought on a bad request") end)
@@ -188,20 +188,20 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "an agent not on the team gets not_found" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = insert_agent(user_id: user.id)
       assert {:error, :not_found} = Comms.provision_contact(user.id, agent.id, @req)
     end
 
     test "another tenant's teammate is not_found" do
-      user = insert_verified_user()
-      other = insert_verified_user()
+      user = insert_active_user()
+      other = insert_active_user()
       agent = teammate(other)
       assert {:error, :not_found} = Comms.provision_contact(user.id, agent.id, @req)
     end
 
     test "all or nothing: a failed number deletes the inbox again" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       test = self()
 
@@ -247,7 +247,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "a failed inbox is reported as the email channel, and no number is bought" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
 
       Req.Test.stub(AgentMail, fn conn ->
@@ -268,7 +268,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "changes the prompt number without touching the providers" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       stub_providers_ok()
       {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
@@ -288,7 +288,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "no contact is not_found" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
 
       assert {:error, :not_found} =
@@ -303,7 +303,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "deletes the inbox and the number, removes the row, audits" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       stub_providers_ok()
       {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
@@ -323,7 +323,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "a provider that already forgot the resource counts as released" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       stub_providers_ok()
       {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
@@ -341,7 +341,7 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "a provider failure keeps the row so nothing is orphaned" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       stub_providers_ok()
       {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
@@ -355,13 +355,13 @@ defmodule Fountain.Team.CommsTest do
     end
 
     test "no contact is not_found" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       assert {:error, :not_found} = Comms.release_contact(user.id, agent.id)
     end
 
     test "removing the teammate releases its contact too" do
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       stub_providers_ok()
       {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
@@ -376,7 +376,7 @@ defmodule Fountain.Team.CommsTest do
   describe "conversation_mcp_servers/2" do
     test "injects the tools for a teammate with a contact when the flag is on" do
       flag(true)
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       stub_providers_ok()
       {:ok, _} = Comms.provision_contact(user.id, agent.id, @req)
@@ -391,7 +391,7 @@ defmodule Fountain.Team.CommsTest do
 
     test "nothing without a contact, off the team, with the flag off, or without a token" do
       flag(true)
-      user = insert_verified_user()
+      user = insert_active_user()
       agent = teammate(user)
       %{conversation: conv} = Team.get_teammate(user.id, agent.id)
       assert [] = Comms.conversation_mcp_servers(conv.id, "tok")

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -6,7 +6,7 @@ defmodule FountainWeb.ConversationControllerTest do
   alias FountainWeb.ConversationController
 
   setup do
-    user = insert_verified_user()
+    user = insert_active_user()
     {_key_record, raw_key} = insert_api_key(user)
     {:ok, user: user, raw_key: raw_key}
   end
@@ -27,7 +27,7 @@ defmodule FountainWeb.ConversationControllerTest do
       conn: conn,
       raw_key: raw_key
     } do
-      other_user = insert_verified_user()
+      other_user = insert_active_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
       conn = conn |> authed_with_key(raw_key) |> get("/api/conversations")
@@ -132,7 +132,7 @@ defmodule FountainWeb.ConversationControllerTest do
       conn: conn,
       raw_key: raw_key
     } do
-      other_user = insert_verified_user()
+      other_user = insert_active_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
       conn = conn |> authed_with_key(raw_key) |> get("/api/conversations/#{other_conv.id}")
@@ -217,7 +217,7 @@ defmodule FountainWeb.ConversationControllerTest do
       conn: conn,
       raw_key: raw_key
     } do
-      other_user = insert_verified_user()
+      other_user = insert_active_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
       conn = conn |> authed_with_key(raw_key) |> get("/api/conversations/#{other_conv.id}/turns")
@@ -348,7 +348,7 @@ defmodule FountainWeb.ConversationControllerTest do
       conn: conn,
       raw_key: raw_key
     } do
-      other_user = insert_verified_user()
+      other_user = insert_active_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
       conn = conn |> authed_with_key(raw_key) |> delete("/api/conversations/#{other_conv.id}")
@@ -412,7 +412,7 @@ defmodule FountainWeb.ConversationControllerTest do
     end
 
     test "returns 404 when agent belongs to a different user", %{conn: conn, raw_key: raw_key} do
-      other_user = insert_verified_user()
+      other_user = insert_active_user()
       other_agent = insert_agent(user_id: other_user.id)
 
       conn =
@@ -562,7 +562,7 @@ defmodule FountainWeb.ConversationControllerTest do
       conn: conn,
       raw_key: raw_key
     } do
-      other_user = insert_verified_user()
+      other_user = insert_active_user()
       other_conv = insert_conversation(user_id: other_user.id)
 
       conn =
@@ -874,7 +874,7 @@ defmodule FountainWeb.ConversationControllerTest do
     end
 
     test "another tenant's conversation is still a 404", %{conn: conn, raw_key: raw_key} do
-      other = insert_conversation(user_id: insert_verified_user().id)
+      other = insert_conversation(user_id: insert_active_user().id)
 
       conn =
         conn
@@ -1016,7 +1016,7 @@ defmodule FountainWeb.ConversationControllerTest do
       raw_key: raw_key,
       agent: agent
     } do
-      foreign = insert_env(user_id: insert_verified_user().id)
+      foreign = insert_env(user_id: insert_active_user().id)
 
       for id <- [foreign.id, Ecto.UUID.generate()] do
         assert conn
@@ -1160,7 +1160,7 @@ defmodule FountainWeb.ConversationControllerTest do
     end
 
     test "another user's binding is invisible", %{conn: conn, agent: agent} do
-      other = insert_verified_user()
+      other = insert_active_user()
       {_k, other_key} = insert_api_key(other)
       other_agent = insert_agent(user_id: other.id)
 

--- a/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
@@ -11,7 +11,7 @@ defmodule FountainWeb.TeamCommsControllerTest do
     previous = Application.get_env(:fountain, :feature_flag_overrides)
     on_exit(fn -> restore(:feature_flag_overrides, previous) end)
 
-    user = insert_verified_user()
+    user = insert_active_user()
     {_key, raw_key} = insert_api_key(user)
     {:ok, user: user, raw_key: raw_key}
   end
@@ -196,7 +196,7 @@ defmodule FountainWeb.TeamCommsControllerTest do
     } do
       flag(true)
       loose = insert_agent(user_id: user.id)
-      {theirs, _} = teammate(insert_verified_user())
+      {theirs, _} = teammate(insert_active_user())
 
       give(conn, key, loose.id)
       |> json_response(404)
@@ -377,7 +377,7 @@ defmodule FountainWeb.TeamCommsControllerTest do
     end
 
     test "is 404 for another tenant", %{conn: conn, conv: conv} do
-      other = insert_verified_user()
+      other = insert_active_user()
       {_key, other_key} = insert_api_key(other)
 
       assert rpc(conn, other_key, conv.id, %{"id" => 1, "method" => "initialize"})

--- a/apps/fountain/test/fountain_web/controllers/turn_image_ingest_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/turn_image_ingest_test.exs
@@ -26,7 +26,7 @@ defmodule FountainWeb.TurnImageIngestTest do
   alias Fountain.Conversations
 
   setup do
-    user = insert_verified_user()
+    user = insert_active_user()
     {_key, raw_key} = insert_api_key(user)
     agent = insert_agent(user_id: user.id)
     {:ok, user: user, raw_key: raw_key, agent: agent}
@@ -98,7 +98,7 @@ defmodule FountainWeb.TurnImageIngestTest do
       # MatchError inside CachingBodyReader and surface as a 500 for every
       # endpoint — fixed here, so it is now the 413 it should always have been.
       oversized = Base.encode64(:binary.copy(<<0>>, 10 * 1024 * 1024 + 1))
-      user = insert_verified_user()
+      user = insert_active_user()
       {_key, raw_key} = insert_api_key(user)
       agent = insert_agent(user_id: user.id)
 

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -6,7 +6,7 @@ defmodule FountainWeb.AdminLiveTest do
   alias Fountain.Accounts
 
   defp insert_admin(overrides \\ %{}) do
-    user = insert_verified_user(overrides)
+    user = insert_active_user(overrides)
     {:ok, admin} = Accounts.update_user_role(user, "admin")
     admin
   end
@@ -21,7 +21,7 @@ defmodule FountainWeb.AdminLiveTest do
     end
 
     test "regular user is redirected away from /admin", %{conn: conn} do
-      user = insert_verified_user()
+      user = insert_active_user()
       conn = login_user(conn, user)
       assert {:error, {:live_redirect, _}} = live(conn, ~p"/admin")
     end
@@ -35,7 +35,7 @@ defmodule FountainWeb.AdminLiveTest do
   describe "AdminLive.Index — user list" do
     test "displays all users", %{conn: conn} do
       admin = insert_admin()
-      other = insert_verified_user()
+      other = insert_active_user()
       conn = login_user(conn, admin)
       {:ok, _lv, html} = live(conn, ~p"/admin")
 
@@ -55,7 +55,7 @@ defmodule FountainWeb.AdminLiveTest do
   describe "AdminLive.Index — toggle_admin" do
     test "promotes a regular user to admin", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
 
@@ -96,7 +96,7 @@ defmodule FountainWeb.AdminLiveTest do
       conn = login_user(conn, admin)
       {:ok, lv, html_before} = live(conn, ~p"/admin")
 
-      new_user = insert_verified_user()
+      new_user = insert_active_user()
 
       send(lv.pid, :refresh)
       html_after = render(lv)
@@ -129,7 +129,7 @@ defmodule FountainWeb.AdminLiveTest do
       conn: conn
     } do
       admin = insert_admin()
-      owner = insert_verified_user()
+      owner = insert_active_user()
       sandbox = insert_sandbox(user_id: owner.id, status: "ready")
       conv = insert_conversation(user_id: owner.id, sandbox: sandbox)
 
@@ -285,7 +285,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "admin can raise a user's cap", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
 
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
@@ -303,7 +303,7 @@ defmodule FountainWeb.AdminLiveTest do
     # entitlements of exactly the accounts an operator hand-manages.
     test "admin can set a user's plan", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user(plan: "solo")
+      target = insert_active_user(plan: "solo")
 
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
@@ -322,7 +322,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "admin can comp a user's teammate contacts", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user(plan: "team")
+      target = insert_active_user(plan: "team")
 
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
@@ -348,7 +348,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "an empty field clears the override and the cap follows the plan", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user(plan: "team")
+      target = insert_active_user(plan: "team")
       {:ok, _} = Fountain.Accounts.update_sandbox_limit(target, 25, actor: "admin")
 
       conn = login_user(conn, admin)
@@ -368,7 +368,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "admin can drop a cap to zero to cut off an abusive tenant", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
 
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
@@ -385,7 +385,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "a negative cap is rejected", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
 
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
@@ -400,7 +400,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "a non-numeric cap is rejected", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
 
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
@@ -418,7 +418,7 @@ defmodule FountainWeb.AdminLiveTest do
     test "shows subscription status, trial end and a Stripe link", %{conn: conn} do
       admin = insert_admin()
 
-      user = insert_verified_user()
+      user = insert_active_user()
 
       user =
         Fountain.Repo.update!(
@@ -444,7 +444,7 @@ defmodule FountainWeb.AdminLiveTest do
 
       user =
         Fountain.Repo.update!(
-          Ecto.Changeset.change(insert_verified_user(),
+          Ecto.Changeset.change(insert_active_user(),
             subscription_status: "canceled",
             trial_ends_at: nil
           )
@@ -470,6 +470,8 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "rejects a non-numeric day count", %{conn: conn} do
       admin = insert_admin()
+      # Trialing on purpose: the extend-trial form is only rendered for an
+      # account that has a trial, and `extend_trial/2` refuses an active one.
       user = insert_verified_user()
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
@@ -486,7 +488,7 @@ defmodule FountainWeb.AdminLiveTest do
   describe "AdminLive.Index — toggle_comp" do
     test "comps and un-comps an account, with audit events", %{conn: conn} do
       admin = insert_admin()
-      user = insert_verified_user()
+      user = insert_active_user()
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
 
@@ -553,7 +555,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "shows the stalled-verified breakdown", %{conn: conn} do
       admin = insert_admin()
-      stalled = insert_verified_user()
+      stalled = insert_active_user()
       insert_agent(user_id: stalled.id)
       conn = login_user(conn, admin)
 
@@ -568,7 +570,7 @@ defmodule FountainWeb.AdminLiveTest do
   describe "AdminLive.Index — suspend (#287)" do
     test "suspends and unsuspends with audit events and a badge", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
       insert_sandbox(user_id: target.id, status: "ready")
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
@@ -613,7 +615,7 @@ defmodule FountainWeb.AdminLiveTest do
       admin = insert_admin()
 
       Fountain.Repo.update!(
-        Ecto.Changeset.change(insert_verified_user(), subscription_status: "active")
+        Ecto.Changeset.change(insert_active_user(), subscription_status: "active")
       )
 
       Fountain.Repo.insert_all("stripe_events", [
@@ -665,8 +667,8 @@ defmodule FountainWeb.AdminLiveTest do
     # assertions must target a third user, never the admin.
     test "?q= narrows the table to matching emails", %{conn: conn} do
       admin = insert_admin()
-      needle = insert_verified_user(%{email: "needle@example.com"})
-      straw = insert_verified_user(%{email: "straw@example.com"})
+      needle = insert_active_user(%{email: "needle@example.com"})
+      straw = insert_active_user(%{email: "straw@example.com"})
       conn = login_user(conn, admin)
 
       {:ok, _lv, html} = live(conn, ~p"/admin?q=needle")
@@ -677,8 +679,8 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "typing in the search box patches the URL and filters", %{conn: conn} do
       admin = insert_admin()
-      needle = insert_verified_user(%{email: "needle@example.com"})
-      straw = insert_verified_user(%{email: "straw@example.com"})
+      needle = insert_active_user(%{email: "needle@example.com"})
+      straw = insert_active_user(%{email: "straw@example.com"})
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
 
@@ -694,11 +696,11 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "filters by subscription status", %{conn: conn} do
       admin = insert_admin()
-      trialing = insert_verified_user(%{email: "still-trialing@example.com"})
+      trialing = insert_active_user(%{email: "still-trialing@example.com"})
 
       canceled =
         Fountain.Repo.update!(
-          Ecto.Changeset.change(insert_verified_user(), subscription_status: "canceled")
+          Ecto.Changeset.change(insert_active_user(), subscription_status: "canceled")
         )
 
       conn = login_user(conn, admin)
@@ -710,7 +712,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "filters by verification state and badges unverified users", %{conn: conn} do
       admin = insert_admin()
-      verified = insert_verified_user(%{email: "is-verified@example.com"})
+      verified = insert_active_user(%{email: "is-verified@example.com"})
       unverified = insert_user()
       conn = login_user(conn, admin)
 
@@ -722,8 +724,8 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "sorts by email via the header link", %{conn: conn} do
       admin = insert_admin()
-      insert_verified_user(%{email: "zzz-sort@example.com"})
-      insert_verified_user(%{email: "aaa-sort@example.com"})
+      insert_active_user(%{email: "zzz-sort@example.com"})
+      insert_active_user(%{email: "aaa-sort@example.com"})
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
 
@@ -811,7 +813,7 @@ defmodule FountainWeb.AdminLiveTest do
   describe "AdminLive.Index — usage column" do
     test "shows 30-day usage per user", %{conn: conn} do
       admin = insert_admin()
-      user = insert_verified_user()
+      user = insert_active_user()
       {:ok, _} = Fountain.Billing.record_usage(user.id, "turn_started", nil, nil)
       {:ok, _} = Fountain.Billing.record_usage(user.id, "sandbox_provisioned", nil, nil)
 
@@ -839,7 +841,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "names each provider and the tenants behind it", %{conn: conn} do
       admin = insert_admin()
-      user = insert_verified_user()
+      user = insert_active_user()
       sandbox_run(user, "e2b", 30)
 
       conn = login_user(conn, admin)
@@ -853,7 +855,7 @@ defmodule FountainWeb.AdminLiveTest do
 
     test "marks a self-hosted runner as not our bill", %{conn: conn} do
       admin = insert_admin()
-      user = insert_verified_user()
+      user = insert_active_user()
       sandbox_run(user, "runner", 30)
 
       conn = login_user(conn, admin)
@@ -866,7 +868,7 @@ defmodule FountainWeb.AdminLiveTest do
       # The number that says whether the bill is avoidable. A sandbox that
       # never took a turn is 100% idle.
       admin = insert_admin()
-      user = insert_verified_user()
+      user = insert_active_user()
       sandbox_run(user, "e2b", 30)
 
       conn = login_user(conn, admin)
@@ -897,7 +899,7 @@ defmodule FountainWeb.AdminLiveErrorTest do
   alias Fountain.Accounts
 
   defp insert_admin(overrides \\ %{}) do
-    user = insert_verified_user(overrides)
+    user = insert_active_user(overrides)
     {:ok, admin} = Accounts.update_user_role(user, "admin")
     admin
   end
@@ -905,7 +907,7 @@ defmodule FountainWeb.AdminLiveErrorTest do
   describe "AdminLive.Index — toggle_admin error path" do
     test "shows error flash when update_user_role fails", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")
 
@@ -928,7 +930,7 @@ defmodule FountainWeb.AdminLiveErrorTest do
 
       user =
         Fountain.Repo.update!(
-          Ecto.Changeset.change(insert_verified_user(),
+          Ecto.Changeset.change(insert_active_user(),
             subscription_status: "past_due",
             stripe_customer_id: "cus_lv_resync",
             stripe_subscription_id: "sub_lv_resync"
@@ -960,7 +962,7 @@ defmodule FountainWeb.AdminLiveErrorTest do
 
     test "a user with no subscription of record gets a customer sync enqueued", %{conn: conn} do
       admin = insert_admin()
-      user = insert_verified_user()
+      user = insert_active_user()
 
       conn = login_user(conn, admin)
       {:ok, lv, _html} = live(conn, ~p"/admin")

--- a/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
@@ -10,21 +10,21 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
   alias Fountain.Repo
 
   defp insert_admin(overrides \\ %{}) do
-    user = insert_verified_user(overrides)
+    user = insert_active_user(overrides)
     {:ok, admin} = Accounts.update_user_role(user, "admin")
     admin
   end
 
   describe "access control" do
     test "regular user is redirected away", %{conn: conn} do
-      user = insert_verified_user()
-      target = insert_verified_user()
+      user = insert_active_user()
+      target = insert_active_user()
       conn = login_user(conn, user)
       assert {:error, {:live_redirect, _}} = live(conn, ~p"/admin/users/#{target.id}")
     end
 
     test "unauthenticated user is redirected to login", %{conn: conn} do
-      target = insert_verified_user()
+      target = insert_active_user()
       assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/admin/users/#{target.id}")
       assert path =~ "/auth/login"
     end
@@ -33,7 +33,7 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
   describe "detail page" do
     test "shows another tenant's account, conversations and API-key metadata", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
       conv = insert_conversation(user_id: target.id)
       {_key, _raw} = insert_api_key(target, "support-visible-key")
 
@@ -49,7 +49,7 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
 
     test "shows the tenant's turn hours against their plan (#1016)", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user(plan: "team")
+      target = insert_active_user(plan: "team")
 
       {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/users/#{target.id}")
 
@@ -62,7 +62,7 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
 
     test "shows admin actions taken against the account", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
 
       {:ok, _} =
         Fountain.Audit.record_admin(%{
@@ -80,7 +80,7 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
 
     test "records an admin.user.viewed audit event on visit", %{conn: conn} do
       admin = insert_admin()
-      target = insert_verified_user()
+      target = insert_active_user()
 
       conn = login_user(conn, admin)
       {:ok, _lv, _html} = live(conn, ~p"/admin/users/#{target.id}")
@@ -107,7 +107,7 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
   describe "invoices (#502)" do
     defp insert_target_with_customer(customer_id) do
       {:ok, user} =
-        insert_verified_user()
+        insert_active_user()
         |> Accounts.User.billing_changeset(%{stripe_customer_id: customer_id})
         |> Repo.update()
 
@@ -161,7 +161,7 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
     end
 
     test "a user with no Stripe customer shows an empty state", %{conn: conn} do
-      target = insert_verified_user()
+      target = insert_active_user()
 
       {:ok, lv, _html} = live(login_user(conn, insert_admin()), ~p"/admin/users/#{target.id}")
 

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -41,6 +41,22 @@ defmodule Fountain.Factory do
     verified
   end
 
+  @doc """
+  A verified user with a live subscription — `subscription_status: "active"`.
+
+  `insert_verified_user/1` leaves the schema default, `"trialing"`, and a
+  trialing account is deliberately capped below its tier (`Fountain.Plans`'
+  `trial` plan): two sandboxes, forty turn hours, no teammate contacts. Reach
+  for this one whenever the test is about what a *plan* allows rather than
+  about the trial, or the plan's numbers will not be the ones in force.
+  """
+  def insert_active_user(overrides \\ %{}) do
+    overrides
+    |> insert_verified_user()
+    |> Fountain.Accounts.User.billing_changeset(%{subscription_status: "active"})
+    |> Repo.update!()
+  end
+
   def insert_api_key(user, name \\ nil, opts \\ []) do
     name = name || "key-#{uniq()}"
     {:ok, {key_record, raw_key}} = Fountain.Accounts.create_api_key(user.id, name, opts)

--- a/decisions/0026-plans-and-entitlements.md
+++ b/decisions/0026-plans-and-entitlements.md
@@ -54,6 +54,7 @@ Three public tiers, differing in nothing but the cap `Quotas` already enforces:
 
 | Plan | Concurrent sandboxes | Contact ceiling | Price |
 |---|---|---|---|
+| Trial | 2 | 0 | free |
 | Solo | 5 | 1 | $29/mo |
 | Team | 15 | 3 | $79/mo |
 | Scale | 40 | 10 | $199/mo |
@@ -170,6 +171,45 @@ for them until they happened to add or remove one.
 `complete_checkout/4` re-attaches the item after adopting the subscription,
 best-effort and last, so a Stripe hiccup there cannot make the webhook fail and
 have Stripe redeliver an adoption that already succeeded.
+
+### The trial is a plan, and a smaller one
+
+A `trialing` account gets the `trial` plan's numbers — 2 concurrent, 40 turn
+hours, 0 teammate contacts — whatever tier its subscription names.
+
+Before this, a trial carried the full numbers of the tier it sat on (`solo`,
+because that is the price registration opens the trial with). Converting
+therefore bought the customer nothing on the day they paid, which is a strange
+thing for the moment you most want to feel like progress. It also made the
+customer portal's `end_trial` setting look punitive rather than generous: end
+the trial early and the customer loses free days for no gain. With the trial
+genuinely smaller, ending it *is* the upgrade.
+
+`Plans.effective/1` is the split. `resolve/1` keeps answering "what tier is
+this subscription for" — the price id, the plan picker, what the trial converts
+into. `effective/1` answers "whose numbers apply today". Every entitlement
+reader routes through the second when handed a `%User{}`; a bare slug carries
+no status and cannot, which is exactly how `turn_hour_allowance/2` first read
+the paid allowance for a trialing account.
+
+Two constraints shaped it:
+
+* **Only when billing is on.** `subscription_status` defaults to `"trialing"`
+  in the schema, so on a self-hosted instance every account would otherwise be
+  silently capped at two sandboxes — for someone paying their own provider
+  bill. The guard is `Billing.enabled?/0`, the same switch `DEFAULT_PLAN`
+  answers to.
+* **An operator override still wins.** `sandbox_limit_override` is an operator
+  naming a number for an account; a trial is not a reason to second-guess it.
+
+Zero contacts is the sharpest edge and the one most likely to be revisited: it
+means a prospective customer cannot evaluate teammate email and phone during
+their trial at all. It is set that way because each contact is a recurring bill
+from the moment it exists, and a free trial that mints one is an abuse vector
+with a monthly cost. One number in the catalog changes it.
+
+The trial's 40 hours keep the 20-per-slot ratio the other plans hold, rather
+than being chosen freely — the ladder stays derivable from one axis.
 
 ### Two levers for comping, deliberately separate
 

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -31,6 +31,26 @@ for why.
 to a new customer. It exists so that the accounts which bought the old price
 keep it, at Team capacity.
 
+### A trial is smaller than any plan
+
+A trial is not one of the plans above. It is its own, smaller one, and an
+account gets it for the first 14 days whatever tier the subscription names.
+
+| Plan | Concurrent sandboxes | Turn hours | Contact ceiling | Price |
+|---|---|---|---|---|
+| Trial | 2 | 40 | 0 | free |
+
+The trial is below every paid plan on every axis, so a customer who subscribes
+gets more capacity the same day. This is also why the customer portal ends the
+trial on a plan change instead of continuing it. To continue the trial would
+take the payment and leave the customer on these numbers.
+
+A trial includes no teammate contacts. An inbox and a phone number cost money
+as soon as they exist. A free trial that gives one away invites abuse.
+
+The trial applies only where billing is on. On a self-hosted instance every
+account carries the `trialing` status and none of these limits.
+
 The contact ceiling bounds teammate email and phone contacts. It is an abuse
 bound, not an allowance. Fountain charges for each contact separately.
 

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -2064,7 +2064,10 @@ defmodule Fountain.Billing do
   def turn_hour_allowance(%User{} = user, opts \\ []) do
     period = Keyword.get(opts, :period) || billing_period(user)
     used = turn_hours_used(user, period: {period.start, period.end})
-    included = Plans.included_turn_hours(user.plan)
+    # The user, not `user.plan`: a slug carries no subscription status, so
+    # passing one would quietly hand a trialing account the paid tier's
+    # allowance (`Plans.effective/1`).
+    included = Plans.included_turn_hours(user)
 
     %{
       used: used,

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -35,7 +35,13 @@ defmodule FountainWeb.Live.BillingLive do
          allowance: Billing.turn_hour_allowance(user, period: period),
          period: period,
          stripe_url_loading: false,
+         # Two plans, deliberately. `plan` is the tier the subscription names
+         # — what Stripe charges for, what the picker highlights. `effective_plan`
+         # is whose numbers apply today, which during a trial is the smaller
+         # `trial` plan (`Plans.effective/1`).
          plan: Billing.plan(user),
+         effective_plan: Plans.effective(user),
+         on_trial: user.subscription_status == "trialing" and Billing.enabled?(),
          sandbox_limit: Quotas.sandbox_limit_for(user),
          available_plans: Billing.available_plans()
        )}
@@ -170,19 +176,35 @@ defmodule FountainWeb.Live.BillingLive do
       <div class="rounded-lg border bg-white p-6 shadow-sm">
         <h2 class="mb-4 text-lg font-medium">Subscription</h2>
         <dl class="space-y-3">
+          <%!-- While a trial runs, `@plan` is the tier it converts into and
+                `@effective_plan` is the smaller set of numbers in force. Both
+                are named, because showing "Solo" beside Trial's two sandboxes
+                is how a customer concludes the product is broken. --%>
           <div class="flex items-center justify-between">
             <dt class="text-sm text-gray-500">Plan</dt>
-            <dd class="text-sm font-medium">{@plan.name}</dd>
+            <dd class="text-sm font-medium">
+              <span :if={@on_trial}>Trial, then {@plan.name}</span>
+              <span :if={!@on_trial}>{@plan.name}</span>
+            </dd>
           </div>
-          <%!-- The number the plan is sold on, and the one an operator
-                override can make differ from it — so show what is actually
-                enforced rather than what the tier says. --%>
+          <%!-- The number the plan is sold on, and the one a trial or an
+                operator override can make differ from it — so show what is
+                actually enforced rather than what the tier says. --%>
           <div class="flex items-center justify-between">
             <dt class="text-sm text-gray-500">Agents at once</dt>
             <dd class="text-sm font-medium">
               {@sandbox_limit}
-              <span :if={@sandbox_limit != @plan.concurrent_sandboxes} class="text-gray-500">
+              <span
+                :if={@sandbox_limit != @effective_plan.concurrent_sandboxes}
+                class="text-gray-500"
+              >
                 (adjusted for this account)
+              </span>
+              <span
+                :if={@on_trial and @sandbox_limit == @effective_plan.concurrent_sandboxes}
+                class="text-gray-500"
+              >
+                on trial, {@plan.concurrent_sandboxes} on {@plan.name}
               </span>
             </dd>
           </div>
@@ -333,6 +355,9 @@ defmodule FountainWeb.Live.BillingLive do
           <p class="text-sm tabular-nums">
             <span class="font-semibold">{format_hours(@allowance.used)}</span>
             <span class="text-gray-500">of {@allowance.included} included</span>
+            <%!-- Without this the trial's smaller allowance reads as the tier's,
+                  and a customer evaluating Solo judges it on Trial's number. --%>
+            <span :if={@on_trial} class="text-gray-500">on trial</span>
           </p>
         </div>
         <div class="mt-3 h-2 w-full overflow-hidden rounded-full bg-gray-100">
@@ -349,6 +374,10 @@ defmodule FountainWeb.Live.BillingLive do
           A turn hour is an hour with a prompt in flight. An agent sitting idle
           costs you nothing here, and neither does time on your own runner.
           Parked sandboxes are excluded from every number on this page.
+        </p>
+        <p :if={@on_trial} class="mt-2 text-xs text-gray-500">
+          A trial includes {@effective_plan.included_turn_hours} turn hours and {@effective_plan.concurrent_sandboxes} agents at once. {@plan.name} raises those to {@plan.included_turn_hours} and {@plan.concurrent_sandboxes} as soon as you subscribe — you do not
+          wait for the trial to run out.
         </p>
         <p :if={@allowance.over?} class="mt-2 text-xs text-amber-700">
           You are over the hours your plan includes. Nothing is limited and

--- a/ee/test/fountain/billing_trial_allowance_test.exs
+++ b/ee/test/fountain/billing_trial_allowance_test.exs
@@ -1,0 +1,65 @@
+defmodule Fountain.BillingTrialAllowanceTest do
+  @moduledoc """
+  The turn-hour allowance during a trial (#1016 + trial limits).
+
+  `turn_hour_allowance/2` is the single shape all three surfaces render, so if
+  it reads the wrong plan every one of them shows a trialing customer the paid
+  tier's number. It reached the catalog through `user.plan` — a bare slug,
+  which carries no subscription status and therefore cannot be trial-aware.
+  That is the bug this file exists to keep fixed.
+  """
+  use Fountain.DataCase, async: false
+
+  alias Fountain.{Billing, Plans}
+
+  setup do
+    previous = Application.get_env(:fountain, :billing_enabled)
+    Application.put_env(:fountain, :billing_enabled, true)
+    on_exit(fn -> Application.put_env(:fountain, :billing_enabled, previous) end)
+    :ok
+  end
+
+  defp user_on(plan, status) do
+    user = insert_verified_user(plan: plan)
+
+    {:ok, user} =
+      user
+      |> Fountain.Accounts.User.billing_changeset(%{subscription_status: status})
+      |> Repo.update()
+
+    user
+  end
+
+  test "a trialing account is measured against the trial's hours, not its tier's" do
+    user = user_on("scale", "trialing")
+
+    allowance = Billing.turn_hour_allowance(user)
+
+    assert allowance.included == Plans.fetch!("trial").included_turn_hours
+    assert allowance.included == 40
+    refute allowance.included == Plans.fetch!("scale").included_turn_hours
+  end
+
+  test "the same account on that tier gets the tier's hours" do
+    user = user_on("scale", "active")
+
+    assert Billing.turn_hour_allowance(user).included == 800
+  end
+
+  # The allowance is smaller during a trial, so `over?` can be true for a
+  # trialing account that would be well inside its tier. That is the intended
+  # behaviour — nothing is enforced, but the number has to be honest.
+  test "over? is computed against the trial's smaller allowance" do
+    user = user_on("scale", "trialing")
+    allowance = Billing.turn_hour_allowance(user)
+
+    assert allowance.remaining == Float.round(max(40 - allowance.used, 0.0), 2)
+  end
+
+  test "billing disabled means the tier's hours even while trialing" do
+    user = user_on("scale", "trialing")
+    Application.put_env(:fountain, :billing_enabled, false)
+
+    assert Billing.turn_hour_allowance(user).included == 800
+  end
+end

--- a/ee/test/fountain/billing_turn_hours_test.exs
+++ b/ee/test/fountain/billing_turn_hours_test.exs
@@ -235,7 +235,7 @@ defmodule Fountain.Billing.TurnHoursTest do
 
   describe "turn_hour_allowance/2" do
     test "reports used against the plan's included hours" do
-      user = insert_verified_user(plan: "solo")
+      user = insert_active_user(plan: "solo")
 
       sandbox =
         sandbox_running(user, "sprites", ~U[2026-05-10 00:00:00Z], ~U[2026-05-11 00:00:00Z])
@@ -254,7 +254,7 @@ defmodule Fountain.Billing.TurnHoursTest do
     end
 
     test "remaining never goes negative, and over? is what says so" do
-      user = insert_verified_user(plan: "solo")
+      user = insert_active_user(plan: "solo")
 
       # 101 hours against Solo's 100: one hour over.
       sandbox =
@@ -284,8 +284,8 @@ defmodule Fountain.Billing.TurnHoursTest do
     end
 
     test "a bigger plan carries proportionally more" do
-      solo = insert_verified_user(plan: "solo")
-      scale = insert_verified_user(plan: "scale")
+      solo = insert_active_user(plan: "solo")
+      scale = insert_active_user(plan: "scale")
 
       assert Billing.turn_hour_allowance(scale).included >
                Billing.turn_hour_allowance(solo).included

--- a/ee/test/fountain_web/controllers/billing_api_controller_test.exs
+++ b/ee/test/fountain_web/controllers/billing_api_controller_test.exs
@@ -24,7 +24,9 @@ defmodule FountainWeb.BillingApiControllerTest do
       end
     end)
 
-    user = insert_verified_user()
+    # Active, not trialing: these assert what a *plan* reports, and a trial is
+    # deliberately capped below its tier (`Fountain.Plans`' `trial` plan).
+    user = insert_active_user()
     {_rec, key} = insert_api_key(user)
     {:ok, user: user, key: key}
   end

--- a/ee/test/fountain_web/live/billing_live_test.exs
+++ b/ee/test/fountain_web/live/billing_live_test.exs
@@ -422,7 +422,9 @@ defmodule FountainWeb.BillingLiveTest do
     end
 
     test "shows hours used against the plan's allowance", %{conn: conn} do
-      user = insert_verified_user(plan: "solo")
+      # Active: a trialing account is capped at the trial's 40 hours, which
+      # the trial-specific tests below cover.
+      user = insert_active_user(plan: "solo")
       busy_hours(user, 3)
 
       {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
@@ -430,6 +432,24 @@ defmodule FountainWeb.BillingLiveTest do
       assert html =~ "Turn hours"
       assert html =~ "of 100 included"
       assert html =~ "A turn hour is an hour with a prompt in flight"
+    end
+
+    # The trap this could create: showing "Solo" beside Trial's numbers, so a
+    # customer evaluating Solo judges it on two sandboxes and forty hours and
+    # concludes the product is unusable. Both have to be named.
+    test "a trialing account sees the trial's numbers and what the tier raises them to",
+         %{conn: conn} do
+      user = insert_verified_user(plan: "team")
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+      assert html =~ "Trial, then Team"
+      assert html =~ "of 40 included"
+      assert html =~ "on trial"
+      # The tier's numbers are stated as what subscribing raises them to.
+      assert html =~ "300"
+      assert html =~ "15"
+      refute html =~ "of 300 included"
     end
 
     test "says nothing is limited when a tenant is over", %{conn: conn} do


### PR DESCRIPTION
Builds on #1020, rebased onto main now that it has landed.

## The problem

A trialing account carried the **full numbers of the tier its trial sits on** —
`solo`, because that is the price registration opens a trial with. So
converting bought the customer nothing on the day they paid, which is a strange
thing for the moment you most want to feel like progress.

It also made the customer portal's `end_trial` setting read as punitive: end
the trial early and lose free days for no gain. With the trial genuinely
smaller, ending it **is** the upgrade. That setting is already live in Stripe;
this is the half that makes it honest.

## The trial plan

| | trial | solo | team | scale | legacy |
|---|---|---|---|---|---|
| concurrent sandboxes | **2** | 5 | 15 | 40 | 15 |
| included turn hours | **40** | 100 | 300 | 800 | 300 |
| teammate contacts | **0** | 1 | 3 | 10 | 3 |

Below every paid plan on every axis, closed, and ordered below `legacy` so
every real plan is an upgrade from it. The 40 hours keep #1020's
20-per-concurrent-slot ratio rather than being picked freely, so the ladder
stays derivable from one axis and `plans_test`'s invariant still holds.

## `resolve/1` and `effective/1`

The split is the design:

* **`resolve/1`** — what tier is this subscription for. The price id, the plan
  picker, what the trial converts into. Unchanged.
* **`effective/1`** — whose numbers apply today. The trial's, while it runs.

Every entitlement reader (`concurrent_sandboxes/1`, `included_turn_hours/1`,
`team_contacts/1`) routes through `effective/1` **when handed a `%User{}`**, so
existing call sites became trial-aware without each one having to know. Hand
one a bare **slug** and it cannot — a slug carries no status. That is exactly
how `turn_hour_allowance/2` read the paid allowance for a trialing account;
**verified by reverting that one argument, which fails two tests.**

Two constraints, both pinned by tests verified the same way:

* **Only when billing is on.** `subscription_status` defaults to `"trialing"`
  in the schema, so without the guard every self-hosted account would be
  silently capped at two sandboxes — for someone paying their own provider
  bill. Reverting the guard fails two tests.
* **An operator override still wins.** `sandbox_limit_override` is an operator
  naming a number for an account; a trial is not a reason to overrule it.

## `trial` is derived, never stored

`users.plan` is written only from the Stripe price on a subscription, and there
is no trial price — so the column *cannot* hold `"trial"`. Caught while
reviewing the SDK diff, which had started advertising a plan slug the API can
never return.

So `trial` is out of `slugs/0` and `known?/1`, which in one place stops: the
changeset accepting it, the admin selector offering it, `change_plan/3`
switching onto it, `DEFAULT_PLAN=trial` capping a whole self-hosted instance by
typo, and the OpenAPI enums publishing it. `all/0` and `fetch!/1` still reach
it, which is how `effective/1` returns it.

**Net effect: the SDK surface is unchanged, so no version bump and no npm
publish on merge.**

## What a trialing customer sees

The billing page names both plans — *"Trial, then Team"*, `of 40 included on
trial`, and a line saying what subscribing raises the numbers to, today. The
trap otherwise is showing "Solo" beside Trial's two sandboxes, which is how
someone evaluating Solo concludes the product is unusable.

## The sharpest edge

**Zero contacts** means a prospective customer cannot evaluate teammate email
and phone during a trial at all. Set that way because each contact is a
recurring bill from the moment it exists, and a free trial that mints a phone
number is an abuse vector with a monthly cost. It is one number in the catalog
if the trade turns out wrong — flagged in the ADR rather than buried.

## 65 tests changed, which is the blast radius rather than churn

Tests build users with `insert_verified_user/1`, which is **trialing** — so
every test that meant "an account on its plan" started getting the trial's
numbers. That is the feature working, and the failures were a fair map of what
it touches. `insert_active_user/1` is new and is the one to reach for when a
test is about what a *plan* allows.

One test kept its trialing user deliberately: `extend_trial` refuses an active
subscription.

## Verification

3813 tests / 0 failures · credo clean · dialyzer 0 errors · format clean ·
`deps.unlock --unused` clean · vale 0 errors · docs-style clean · `okf validate`
clean · OpenAPI regenerates identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
