### PR TITLE
fix(marketing): say what parked time costs, and what happens at each limit

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -45,4 +45,13 @@ defmodule FountainWeb.MarketingHTML do
   part worth being explicit about on a pricing page.
   """
   def plan_turn_hours(plan), do: "#{plan.included_turn_hours} turn hours a month"
+
+  @doc """
+  The trial plan, so the page can state what fourteen days actually gets you.
+
+  Read from the catalog rather than written into the template: the trial's
+  numbers are enforced from `Fountain.Plans`, and a page that repeats them by
+  hand is a page that will one day advertise limits the product does not have.
+  """
+  def trial_plan, do: Plans.fetch!("trial")
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -222,8 +222,13 @@
         <p class="mt-3 text-sm font-medium text-[var(--color-text-primary)]">
           {plan_turn_hours(plan)}
         </p>
+        <%!-- Naming parking explicitly, rather than the softer "not while it
+              waits": scale-to-zero is the strongest claim in the product, and
+              a pricing page that only gestures at it quietly undercuts the
+              thing the rest of the page is arguing. --%>
         <p class="mt-1 text-xs text-[var(--color-text-muted)]">
-          counted while an agent is working, not while it waits.
+          counted only while a prompt is in flight. A parked agent, an idle one,
+          and one running on your own machine all cost nothing.
         </p>
         <a
           href={~p"/auth/register"}
@@ -234,8 +239,36 @@
       </div>
     </div>
 
-    <p class="mt-8 text-center text-xs text-[var(--color-text-muted)]">
-      14 days free on any plan, no card. Change plan or cancel at any time.
-    </p>
+    <%!-- The two questions an engineer asks before signing up, answered where
+          they are asked rather than on the billing page they cannot see yet.
+
+          "What happens at the limit" has to be answered even though the answer
+          is currently "nothing": a plan that lists 800 hours and then says
+          nothing reads as a hard stop, and a hard stop on hours sounds like an
+          agent dying mid-task. Concurrency is a cap and behaves like one; hours
+          are not, and the page should not let the reader assume they are. --%>
+    <div class="mt-10 max-w-2xl mx-auto space-y-3 text-center text-xs text-[var(--color-text-muted)]">
+      <p>
+        <span class="text-[var(--color-text-secondary)]">
+          Going over the hours does not stop anything.
+        </span>
+        No agent is killed, no request is refused, and nothing extra is charged
+        today. We are still working out what a fair overage looks like, and you
+        will hear it from us before it changes.
+      </p>
+      <p>
+        <span class="text-[var(--color-text-secondary)]">
+          Running at the concurrency cap does.
+        </span>
+        A sandbox beyond it waits for a free slot rather than starting, so the
+        number to choose a plan on is how many agents you want working at once.
+      </p>
+      <p>
+        The 14-day trial runs {trial_plan().concurrent_sandboxes} agents at once
+        with {trial_plan().included_turn_hours} turn hours, so you can judge it
+        before paying. Subscribing lifts both the same day. No card to start,
+        and you can change plan or cancel at any time.
+      </p>
+    </div>
   </div>
 </section>

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -50,12 +50,44 @@ defmodule FountainWeb.MarketingPricingTest do
   # The hours are a public promise, so the page has to say what a turn hour
   # is. A reader who assumes it means wall-clock sandbox time reads Solo's
   # 100 hours as four days and concludes the plan is unusable.
-  test "the pricing table explains that hours are counted while an agent works",
-       %{conn: conn} do
+  # Scale-to-zero (0017) is the strongest claim the rest of the page makes. A
+  # pricing page that charged for parked time, or merely failed to say it did
+  # not, would undercut it.
+  test "the pricing table says parked and idle time cost nothing", %{conn: conn} do
     price_all()
 
     body = conn |> get(~p"/") |> html_response(200)
-    assert body =~ "counted while an agent is working, not while it waits"
+    assert body =~ "counted only while a prompt is in flight"
+    assert body =~ "A parked agent, an idle one"
+    assert body =~ "your own machine all cost nothing"
+  end
+
+  # "800 hours included" followed by silence reads as a hard stop, and a hard
+  # stop on hours sounds like an agent dying mid-task. The two limits behave
+  # differently and the page has to say which is which.
+  test "the pricing table says what happens at each limit", %{conn: conn} do
+    price_all()
+
+    body = conn |> get(~p"/") |> html_response(200)
+
+    assert body =~ "Going over the hours does not stop anything"
+    assert body =~ "nothing extra is charged"
+    assert body =~ "Running at the concurrency cap does"
+    assert body =~ "waits for a free slot"
+  end
+
+  # The trial's numbers are enforced from the catalog, so the page reads them
+  # from there. Hardcoding them is how a pricing page ends up advertising
+  # limits the product does not have.
+  test "the trial line comes from the catalog, not from the template", %{conn: conn} do
+    price_all()
+    trial = Plans.fetch!("trial")
+
+    body = conn |> get(~p"/") |> html_response(200)
+
+    assert body =~ "#{trial.concurrent_sandboxes} agents at once"
+    assert body =~ "with #{trial.included_turn_hours} turn hours"
+    assert body =~ "Subscribing lifts both the same day"
   end
 
   test "the hero quotes the cheapest sellable plan", %{conn: conn} do

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -67,9 +67,15 @@ question. See
 [issue 1016](https://github.com/BinaryBourbon/fountain/issues/1016) for the
 current state.
 
-Three surfaces show the number. The billing page shows it to the tenant. The
-API reports it at `GET /api/account/billing`. The admin page for one account
-shows it beside the sandbox count.
+The pricing page states this to a visitor, because a plan that lists 800 hours
+and then says nothing reads as a hard stop. The two limits behave differently.
+A tenant at the concurrency cap waits for a free slot. A tenant over the hours
+continues, and pays no more.
+
+Four surfaces show the number. The pricing page shows it to a visitor. The
+billing page shows it to the tenant. The API reports it at
+`GET /api/account/billing`. The admin page for one account shows it beside the
+sandbox count.
 
 ### The billing period
 


### PR DESCRIPTION
Follow-up to the launch feedback on #991 / #1020 / #1022.

## Two of the five points described a page that no longer exists

Checked against `fountain.inevitable.fyi` before acting on them:

- **"The three-tier table isn't rendering; price ids aren't set."** It renders,
  with all three tiers, prices, concurrency *and* turn hours. The price ids
  were set in Infisical during the launch and `mix fountain.verify_plans`
  reports *All configured prices match the catalog*. That feedback predates it.
- **"`$29/mo per user` — per-seat language for a per-sandbox model."** Not on
  the page. The hero reads **"then from $29/mo. Cancel anytime."** The only
  `per user` in the document is the feature-card heading *"A thread and a
  machine per user"*, which is about binding a conversation to each of **your
  app's** end users. Rewriting that would make the card wrong.

A third — **"publish the total, not the ratio"** — was already how it ships:
each card says *"100 turn hours a month"*, and 20-per-slot appears only in the
ADR and moduledoc as a construction rule. Nobody is asked to multiply.

The remaining two were right, and are what this PR does.

## Parked time is free, said out loud

The cards said hours are *"counted while an agent is working, not while it
waits"* — true, and too soft. Scale-to-zero (ADR 0017) is the strongest claim
the rest of the page makes; a pricing page that only gestures at it undercuts
the argument above it.

> counted only while a prompt is in flight. A parked agent, an idle one, and
> one running on your own machine all cost nothing.

## What happens at each limit

*"800 turn hours a month"* followed by silence reads as a hard stop, and a hard
stop on hours sounds like an agent dying mid-PR. The two limits genuinely
differ, and the page now says which is which:

> **Going over the hours does not stop anything.** No agent is killed, no
> request is refused, and nothing extra is charged today. We are still working
> out what a fair overage looks like, and you will hear it from us before it
> changes.
>
> **Running at the concurrency cap does.** A sandbox beyond it waits for a free
> slot rather than starting, so the number to choose a plan on is how many
> agents you want working at once.

The hours answer is honest about being unsettled (#1016 steps 4–5 are open)
rather than inventing a policy. **The one thing worth a second opinion is
"you will hear it from us before it changes"** — that is a promise, and it is
easy to drop if you would rather not make it yet.

## The trial line now reads from the catalog

#1022 gave trials real limits, so the footer's *"14 days free on any plan"* had
quietly become untrue. It now states what a trial actually runs, through
`trial_plan/0` rather than numbers typed into the template — a page that
repeats enforced limits by hand is a page that will one day advertise limits
the product does not have.

The operator guide gains the same two-limits paragraph, so it and the pricing
page cannot drift apart on the answer.

## Verification

3815 tests / 0 failures · credo clean · dialyzer 0 errors · format clean ·
vale 0 errors · docs-style clean. Three new tests pin the parked-time claim,
both limit answers, and that the trial figures come from `Fountain.Plans`
rather than the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
