### PR TITLE
feat(admin): a finance panel — revenue against what each tenant costs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -237,10 +237,38 @@ STRIPE_CONTACT_PRICE_CENTS=
 # The flat price the plans replaced. Accounts that bought it are on the closed
 # `legacy` plan and still point at this id. A new deployment does not need it.
 STRIPE_PRICE_ID=
-# Monthly price of the `legacy` plan in cents (e.g. 2900), display-only: feeds
-# the admin billing overview's MRR tile. Optional — unset shows "price not
-# configured". Public plans carry their own display price in Fountain.Plans.
+# Monthly price of the `legacy` plan in cents (e.g. 2900), display-only.
+# Optional. Public plans carry their own display price in Fountain.Plans, and
+# the admin MRR tile now prices every account from that catalog rather than
+# from this one number.
 STRIPE_PRICE_MONTHLY_CENTS=
+
+# ── The finance panel's rate card (/admin/finance) ───────────────────────────
+#
+# What Fountain PAYS, which nothing else in the codebase knows: provider prices
+# are per-machine-size and negotiated, and AgentMail/AgentPhone bill per unit
+# and per message. All optional. Unset, /admin/finance reports hours, inboxes,
+# numbers and message counts with no dollars at all — an unpriced line shows
+# "—" and never becomes $0.
+#
+# Cents per active sandbox hour, per provider. A provider left out is unpriced,
+# and the tenants using it report no cost rather than a cost that omits it.
+# `runner` is never priced: it is the tenant's own machine (ADR 0022).
+# PROVIDER_HOURLY_CENTS=sprites=12,e2b=15,daytona=10
+#
+# Which hours that rate multiplies: `active` (default, every hour the sandbox
+# was awake) or `turn` (only the hours with a prompt in flight). Use `turn`
+# where the provider scales to near-zero between prompts. The panel can switch
+# between the two per view; this is what it opens on.
+# PROVIDER_COST_BASIS=turn
+#
+# Teammate contacts. The monthly pair is pro-rated to the window the panel
+# shows; the message pair is charged per message, inbound SMS included, since
+# AgentPhone charges to receive.
+# AGENTMAIL_INBOX_CENTS=200
+# AGENTPHONE_NUMBER_CENTS=150
+# AGENTMAIL_MESSAGE_CENTS=1
+# AGENTPHONE_MESSAGE_CENTS=8
 
 # The plan an account with no plan of its own gets — every account on a
 # self-hosted instance. `scale` lifts the concurrency cap for everyone at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,39 @@ upgrade, is in
   about the event *name* (73 distinct request-line names in one day, each a
   permanent PostHog event definition), and a property is where PostHog can
   break down by a value the router bounds.
+- **A finance panel at `/admin/finance`.** `/admin` had an MRR tile with no
+  cost beside it and a sandbox-hours table with no money in it, so the only
+  question an operator asks a finance page — which accounts cost more than
+  they pay — had no answer anywhere. The new page puts revenue, platform
+  spend and the margin between them on one row per tenant, worst margin
+  first, with a month picker back through the last six.
+
+  It reports **no money it was not told**. Fountain's own costs are nowhere in
+  this codebase (provider prices are per-machine-size and negotiated;
+  AgentMail and AgentPhone bill per unit and per message), so cost is priced
+  from a rate card in config: `PROVIDER_HOURLY_CENTS`,
+  `AGENTMAIL_INBOX_CENTS`, `AGENTPHONE_NUMBER_CENTS`,
+  `AGENTMAIL_MESSAGE_CENTS`, `AGENTPHONE_MESSAGE_CENTS`. Set none of them and
+  the panel still works, in hours, inboxes, numbers and message counts. An
+  unpriced line renders `—` and never `$0.00`, and the `nil` propagates to the
+  total: a cost that quietly omitted the provider nobody priced would read as
+  a cheap tenant, most convincingly on the expensive ones.
+
+  It also does not assume **which** hours a provider bills. The rate can
+  multiply every hour a sandbox was awake, or only the hours with a prompt in
+  flight, and a toggle on the page switches between the two
+  (`PROVIDER_COST_BASIS` sets the default). Which one is right is a fact about
+  the invoice rather than about this codebase, and the way to find out is to
+  put both next to one. Both hour figures stay on every row either way, since
+  the gap between them is idle time and that is the lever on the bill.
+- **Teammate messages are metered.** `comms_email_sent`, `comms_sms_sent` and
+  `comms_sms_received` join the usage-event vocabulary, recorded at the two
+  choke points a message already passes through
+  (`FountainWeb.TeamCommsMcpController`'s audit callback and
+  `Team.Comms.Inbound`). An inbox and a number cost money every month and a
+  message costs money each time, and only the first half was visible. Inbound
+  counts, because AgentPhone charges to receive. Best-effort by the same
+  contract as every other usage event; neither call can fail a send.
 
 ### Fixed
 
@@ -66,6 +99,33 @@ upgrade, is in
 
 ### Changed
 
+- **The admin MRR tile prices each account at its own plan.** It was
+  `active × STRIPE_PRICE_MONTHLY_CENTS` — one configured amount for
+  everybody. The comment said the day there was a second price would be loud;
+  it was not. #991 shipped four tiers and the tile went on charging every
+  active account the legacy $29, so a deployment selling Scale under-reported
+  its own revenue sevenfold. `Billing.overview_admin/1` now reads
+  `Fountain.Billing.Finance.mrr/0`, which prices from the plan catalog and
+  adds the teammate-contact add-on, and carries the per-plan split with it.
+  `STRIPE_PRICE_MONTHLY_CENTS` is no longer read there and stays what it says
+  it is: the closed `legacy` plan's display price.
+- **The dashboard's usage tile is turn hours, not sandbox time.** "Sandbox
+  time" was wall-clock hours a tenant's sandboxes were awake — Fountain's cost
+  signal, and nothing a customer buys or is measured on. It went up while they
+  slept. The tile now shows turn hours against the plan's included hours, the
+  unit `Fountain.Plans` actually denominates an allowance in, and the sandbox
+  figure moved into the hint. The whole "this month" section also moves to the
+  window Stripe invoices where there is one, so the dashboard and
+  `/account/billing` can no longer report different numbers for the same
+  period; the heading says which window it is on.
+- **`/admin`'s per-user usage column shows turn hours.** Same reasoning, one
+  page over: sandbox minutes belong next to the bill Fountain pays, on
+  `/admin/finance`. The sandbox total and its per-provider split stay in the
+  cell's tooltip.
+- `Billing.usage_summary/3` and `usage_summaries/2` both carry `turn_hours`
+  now, computed from the attribution pass they already ran. `usage_summary/3`
+  makes one pass where it used to make one and would have needed two. No API
+  field was renamed or removed.
 - **`/` is no longer the same page on every deployment.** The homepage sold a
   product: a hero, a 14-day trial, a monthly price, and a footer calling
   Fountain "managed agent infrastructure". Every self-hosted instance served

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ upgrade, is in
   total: a cost that quietly omitted the provider nobody priced would read as
   a cheap tenant, most convincingly on the expensive ones.
 
+  Every tenant row carries both plans the trial split introduced: the tier the
+  subscription is for, which prices its revenue, and the plan whose numbers
+  apply today, which the allowance column is measured against. A trialing
+  account read through the first would be measured against hours it has not
+  bought yet, and would report as inside an allowance it is over.
+
   It also does not assume **which** hours a provider bills. The rate can
   multiply every hour a sandbox was awake, or only the hours with a prompt in
   flight, and a toggle on the page switches between the two

--- a/apps/fountain/lib/fountain/analytics.ex
+++ b/apps/fountain/lib/fountain/analytics.ex
@@ -7,8 +7,8 @@ defmodule Fountain.Analytics do
 
     * `Fountain.Audit` — who changed what, kept forever, tenant-visible. A
       compliance record, not a metric.
-    * `Fountain.Billing.record_usage/5` — what to charge for. Six event types,
-      shaped by the invoice.
+    * `Fountain.Billing.record_usage/5` — what to charge for. A closed set of
+      event types, shaped by the invoice.
     * OTel spans / `Fountain.Telemetry` — how the machine is behaving.
 
   None of them answers "did the people who verified last week come back", so

--- a/apps/fountain/lib/fountain/team/comms.ex
+++ b/apps/fountain/lib/fountain/team/comms.ex
@@ -86,6 +86,54 @@ defmodule Fountain.Team.Comms do
     |> Map.new()
   end
 
+  @doc """
+  The two channels counted apart, for every tenant holding at least one
+  contact: `%{user_id => %{inboxes: n, numbers: n}}`.
+
+  `contact_counts/0` answers the *billing* question — a contact is one add-on
+  unit whatever channels it ended up with. This answers the *cost* one, which
+  is a different number: AgentMail charges per inbox and AgentPhone per
+  number, at rates that have nothing to do with each other, so
+  `Fountain.Billing.Finance` cannot price a bare contact count.
+
+  The two usually agree. They come apart exactly where the schema says they
+  can: `provision_contact/4` is all-or-nothing, but a contact whose number was
+  later released keeps its inbox, and `Contact.email?/1` / `phone?/1` are what
+  decide either way. The counts here apply the same test in SQL — a null or
+  empty provider id is not a channel — so a half-released contact is billed
+  for the half that still exists.
+
+  One query, like `contact_counts/0`, and for the same reason: the finance
+  panel renders a row per tenant.
+  """
+  @spec channel_counts() :: %{
+          optional(binary()) => %{inboxes: non_neg_integer(), numbers: non_neg_integer()}
+        }
+  def channel_counts do
+    from(c in Contact,
+      group_by: c.user_id,
+      select: {
+        c.user_id,
+        %{
+          inboxes:
+            fragment(
+              "count(*) filter (where ? is not null and ? <> '')",
+              c.email_inbox_id,
+              c.email_inbox_id
+            ),
+          numbers:
+            fragment(
+              "count(*) filter (where ? is not null and ? <> '')",
+              c.phone_number_id,
+              c.phone_number_id
+            )
+        }
+      }
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
   @doc "Contacts for many teammates at once, `%{agent_id => %Contact{}}`."
   def contacts_by_agent(user_id, agent_ids) when is_binary(user_id) and is_list(agent_ids) do
     from(c in Contact, where: c.user_id == ^user_id and c.agent_id in ^agent_ids)

--- a/apps/fountain/lib/fountain/team/comms/inbound.ex
+++ b/apps/fountain/lib/fountain/team/comms/inbound.ex
@@ -255,6 +255,18 @@ defmodule Fountain.Team.Comms.Inbound do
         "prompt_bytes" => byte_size(text)
       }
     })
+
+    # AgentPhone charges for an inbound message as well as an outbound one, so
+    # it is metered on the same footing as a send
+    # (`FountainWeb.TeamCommsMcpController`). Best-effort, after the prompt is
+    # already away.
+    Fountain.Billing.record_usage(
+      contact.user_id,
+      "comms_sms_received",
+      contact.id,
+      "team_contact",
+      %{"agent_id" => contact.agent_id, "conversation_id" => conv.id}
+    )
   end
 
   defmodule Seen do

--- a/apps/fountain/lib/fountain_web/controllers/team_comms_mcp_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_comms_mcp_controller.ex
@@ -51,6 +51,12 @@ defmodule FountainWeb.TeamCommsMcpController do
   # A send is an effect, not a tenant-state mutation, so it is audited here
   # rather than in a context. Records what happened — never the recipients,
   # the subject or the body (ADR 0013).
+  #
+  # The same callback meters it. AgentMail and AgentPhone charge per message
+  # on top of the monthly cost of the inbox and the number, so a send is the
+  # one comms event with a variable price, and the finance panel could not
+  # price it from the contact rows alone. Both calls are best-effort by
+  # contract and neither can fail the send.
   defp audit_fn(contact, user) do
     fn tool, summary ->
       Audit.record(%{
@@ -61,6 +67,34 @@ defmodule FountainWeb.TeamCommsMcpController do
         actor: "sprite",
         metadata: Map.merge(%{"tool" => tool, "agent_id" => contact.agent_id}, summary)
       })
+
+      meter(tool, contact, user, summary)
     end
+  end
+
+  # Only the tools that actually put a message on the wire. `audit` is called
+  # for those alone today, so the fallback clause is a guard against a future
+  # tool joining the audit path without joining the rate card.
+  defp meter(tool, contact, user, summary) when tool in ~w(email_send email_reply) do
+    record_message(user, contact, "comms_email_sent", %{
+      "tool" => tool,
+      "recipients" => Map.get(summary, "recipients", 1)
+    })
+  end
+
+  defp meter("sms_send", contact, user, _summary) do
+    record_message(user, contact, "comms_sms_sent", %{"tool" => "sms_send"})
+  end
+
+  defp meter(_tool, _contact, _user, _summary), do: :ok
+
+  defp record_message(user, contact, event_type, metadata) do
+    Fountain.Billing.record_usage(
+      user.id,
+      event_type,
+      contact.id,
+      "team_contact",
+      Map.put(metadata, "agent_id", contact.agent_id)
+    )
   end
 end

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -520,7 +520,8 @@ defmodule FountainWeb.AdminLive.Index do
       conversations: 0,
       turns: 0,
       sandbox_minutes: 0.0,
-      sandbox_minutes_by_provider: %{}
+      sandbox_minutes_by_provider: %{},
+      turn_hours: 0.0
     }
 
     sandbox_counts = Quotas.active_sandbox_counts()
@@ -755,17 +756,18 @@ defmodule FountainWeb.AdminLive.Index do
       <section :if={@billing_enabled} class="space-y-3">
         <h2 class="text-lg font-medium">Billing</h2>
         <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
-          <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <.link
+            navigate={~p"/admin/finance"}
+            class="bg-white rounded shadow border border-zinc-200 px-4 py-3 hover:border-zinc-400"
+          >
             <div class="text-xs text-zinc-500">MRR</div>
             <div class="text-2xl font-semibold tabular-nums">
               {format_mrr(@billing_overview.mrr_cents)}
             </div>
-            <div class="text-xs text-zinc-500">
-              {if @billing_overview.mrr_cents,
-                do: "active × monthly price",
-                else: "set STRIPE_PRICE_MONTHLY_CENTS"}
+            <div class="text-xs text-zinc-500" title={mrr_split(@billing_overview.mrr_by_plan)}>
+              active subscriptions, per plan · finance ↗
             </div>
-          </div>
+          </.link>
           <.link
             navigate={~p"/admin?status=trialing&sort=trial_end&dir=asc"}
             class="bg-white rounded shadow border border-zinc-200 px-4 py-3 hover:border-zinc-400"
@@ -904,7 +906,10 @@ defmodule FountainWeb.AdminLive.Index do
               >
                 Plan
               </th>
-              <th class="px-4 py-2" title="Last 30 days: conversations / turns / sandbox minutes">
+              <th
+                class="px-4 py-2"
+                title="Last 30 days: conversations · turns · turn hours (the unit a plan includes)"
+              >
                 Usage 30d
               </th>
               <th class="px-4 py-2">Sandboxes</th>
@@ -1075,11 +1080,16 @@ defmodule FountainWeb.AdminLive.Index do
                   </form>
                 </div>
               </td>
+              <%!-- Turn hours, not sandbox minutes. Sandbox time is what
+                    Fountain is billed and it is on /admin/finance; what a
+                    tenant *buys* is turn hours (Fountain.Plans), so that is
+                    the number to read beside their plan. The tooltip keeps
+                    the sandbox side one hover away. --%>
               <td
                 class="px-4 py-2 text-xs text-zinc-500 tabular-nums whitespace-nowrap"
-                title={provider_split(u.usage.sandbox_minutes_by_provider)}
+                title={usage_tooltip(u.usage)}
               >
-                {u.usage.conversations}c · {u.usage.turns}t · {round(u.usage.sandbox_minutes)}m
+                {u.usage.conversations}c · {u.usage.turns}t · {format_hours(u.usage.turn_hours)}
               </td>
               <td class="px-4 py-2">
                 <form
@@ -1309,15 +1319,27 @@ defmodule FountainWeb.AdminLive.Index do
   defp idle_share(%{active_seconds: 0}), do: 0.0
   defp idle_share(%{active_seconds: active, idle_seconds: idle}), do: idle / active
 
-  # Which provider a tenant's sandbox minutes ran on, for the usage cell's
-  # tooltip. Empty when the tenant had no sandbox time, so the attribute
-  # renders as nothing rather than as an empty tooltip.
-  defp provider_split(by_provider) when map_size(by_provider) == 0, do: nil
+  # The sandbox side of the usage cell, which the cell itself no longer shows:
+  # total active time and which provider it ran on. Nil when the tenant had no
+  # sandbox time, so the attribute renders as nothing rather than as an empty
+  # tooltip.
+  defp usage_tooltip(%{sandbox_minutes_by_provider: by_provider}) when map_size(by_provider) == 0,
+    do: nil
 
-  defp provider_split(by_provider) do
-    by_provider
-    |> Enum.sort()
-    |> Enum.map_join(" · ", fn {provider, minutes} -> "#{provider} #{round(minutes)}m" end)
+  defp usage_tooltip(usage) do
+    split =
+      usage.sandbox_minutes_by_provider
+      |> Enum.sort()
+      |> Enum.map_join(" · ", fn {provider, minutes} -> "#{provider} #{round(minutes)}m" end)
+
+    "#{round(usage.sandbox_minutes)}m sandbox time (#{split}) — what we are billed, on /admin/finance"
+  end
+
+  # Every active plan behind the MRR tile, for its tooltip.
+  defp mrr_split([]), do: nil
+
+  defp mrr_split(by_plan) do
+    Enum.map_join(by_plan, " · ", fn line -> "#{line.plan.name} ×#{line.accounts}" end)
   end
 
   defp format_hours(h) when h < 1, do: "#{round(h * 60)}m"

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -50,18 +50,32 @@ defmodule FountainWeb.DashboardLive.Index do
      |> assign_usage(user)}
   end
 
-  # This month, on the same calendar the billing page uses. The counts come
-  # from usage events, which are written whether or not billing is switched
-  # on — so a self-hosted console, which has no billing page at all, still
-  # gets to see what its agents have been doing.
+  # The window Stripe invoices where there is one, the calendar month
+  # otherwise — the same call the billing page makes, so the two pages cannot
+  # report different numbers for "this period". `period.source` says which it
+  # got, and the heading says so too: a customer whose invoice runs the 20th
+  # to the 20th was being shown a calendar month here and an invoiced period
+  # one click away.
+  #
+  # The counts come from usage events, which are written whether or not
+  # billing is switched on, so a self-hosted console still sees what its
+  # agents have been doing.
   defp assign_usage(socket, user) do
-    {period_start, period_end} = Fountain.Billing.current_month_range()
+    billing_enabled? = Fountain.Billing.enabled?()
+    period = Fountain.Billing.billing_period(user)
 
     socket
-    |> assign(:usage, Fountain.Billing.usage_summary(user.id, period_start, period_end))
-    |> assign(:tokens, Conversations.token_usage(user.id, period_start, period_end))
-    |> assign(:period_start, period_start)
-    |> assign(:billing_enabled?, Fountain.Billing.enabled?())
+    |> assign(:usage, Fountain.Billing.usage_summary(user.id, period.start, period.end))
+    |> assign(:tokens, Conversations.token_usage(user.id, period.start, period.end))
+    |> assign(:period, period)
+    |> assign(:period_start, period.start)
+    |> assign(:billing_enabled?, billing_enabled?)
+    # Two queries against the sandbox and turn rows, so it is skipped where
+    # there is no allowance to report at all.
+    |> assign(
+      :allowance,
+      billing_enabled? && Fountain.Billing.turn_hour_allowance(user, period: period)
+    )
   end
 
   @impl true
@@ -131,7 +145,9 @@ defmodule FountainWeb.DashboardLive.Index do
 
       <section>
         <div class="flex items-baseline justify-between mb-3">
-          <h2 class="text-lg font-medium">This month</h2>
+          <h2 class="text-lg font-medium">
+            {if @period.source == :subscription, do: "This billing period", else: "This month"}
+          </h2>
           <span class="text-xs text-[var(--color-text-muted)]">
             since {Calendar.strftime(@period_start, "%-d %B")}
             <a
@@ -146,10 +162,16 @@ defmodule FountainWeb.DashboardLive.Index do
         <div class="grid gap-4 grid-cols-2 lg:grid-cols-4">
           <.metric label="Conversations" value={format_count(@usage.conversations)} />
           <.metric label="Turns" value={format_count(@usage.turns)} />
+          <%!-- Turn hours, not sandbox time. Sandbox wall-clock is Fountain's
+                cost and nothing a customer buys or is measured on: it went up
+                while they slept, and the number that decides whether they are
+                inside their plan is this one (Fountain.Plans). The sandbox
+                figure stays in the hint, where it explains itself. --%>
           <.metric
-            label="Sandbox time"
-            value={format_minutes(@usage.sandbox_minutes)}
-            hint="Wall-clock time your agents' sandboxes were awake."
+            label="Turn hours"
+            value={turn_hours_value(assigns)}
+            sub={turn_hours_sub(assigns)}
+            hint={turn_hours_hint(assigns)}
           />
           <.metric
             label="Tokens"
@@ -217,6 +239,45 @@ defmodule FountainWeb.DashboardLive.Index do
       assigns.usage.sandbox_minutes == 0 and Conversations.total_input(assigns.tokens) == 0 and
       assigns.tokens.output == 0
   end
+
+  # Turn hours: the used side always, the allowance beside it when billing is
+  # on. Rounded to one place, which is the resolution a customer can act on.
+  defp turn_hours_value(%{allowance: %{used: used}}), do: format_hours(used)
+  defp turn_hours_value(%{usage: usage}), do: format_hours(billable_turn_hours(usage))
+
+  defp turn_hours_sub(%{allowance: %{included: included}}), do: "of #{included} included"
+  defp turn_hours_sub(_assigns), do: nil
+
+  defp turn_hours_hint(assigns) do
+    base =
+      "Time with a prompt in flight. An agent left running with nobody talking to it " <>
+        "spends none of this."
+
+    case assigns.usage.sandbox_minutes do
+      minutes when minutes > 0 ->
+        base <> " Your sandboxes were awake for #{format_minutes(minutes)}."
+
+      _ ->
+        base
+    end
+  end
+
+  # Billing off: there is no allowance, so the tile falls back to the same
+  # arithmetic `Billing.turn_hours_used/2` does — turn time on the providers
+  # the platform pays for, which excludes a tenant's own runner (ADR 0022).
+  defp billable_turn_hours(usage) do
+    Map.get(usage, :turn_hours, 0.0)
+  end
+
+  defp format_hours(hours) when is_number(hours) do
+    cond do
+      hours == 0 -> "0"
+      hours < 0.1 -> "<0.1"
+      true -> "#{Float.round(hours * 1.0, 1)}"
+    end
+  end
+
+  defp format_hours(_), do: "—"
 
   defp ready?(assigns) do
     assigns.has_credential? and assigns.agent_count > 0 and

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -622,6 +622,8 @@ defmodule FountainWeb.Router do
         {FountainWeb.Live.Hooks, :require_admin}
       ] do
       live "/admin", AdminLive.Index, :index
+      # Lives in ee/ with the rest of billing (#472): it is a revenue page.
+      live "/admin/finance", Live.AdminFinanceLive, :index
       live "/admin/users/:id", AdminLive.UserDetail, :show
       live "/admin/conversations/:id", AdminLive.ConversationDetail, :show
     end

--- a/apps/fountain/test/fountain/team/comms/inbound_test.exs
+++ b/apps/fountain/test/fountain/team/comms/inbound_test.exs
@@ -97,6 +97,19 @@ defmodule Fountain.Team.Comms.InboundTest do
     assert event.resource_id == contact.id
     assert event.metadata["prompt_bytes"] == 7
     refute inspect(event.metadata) =~ "ship it"
+
+    # AgentPhone charges to receive, so an inbound text is metered on the same
+    # footing as a send — otherwise the finance panel prices only half of SMS.
+    import Ecto.Query
+
+    [usage] =
+      Repo.all(
+        from e in Fountain.Billing.UsageEvent,
+          where: e.user_id == ^user.id and e.event_type == "comms_sms_received"
+      )
+
+    assert usage.resource_id == contact.id
+    refute inspect(usage.metadata) =~ "ship it"
   end
 
   test "the sender is matched after normalization; anyone else is ignored" do

--- a/apps/fountain/test/fountain/team/comms_test.exs
+++ b/apps/fountain/test/fountain/team/comms_test.exs
@@ -373,6 +373,52 @@ defmodule Fountain.Team.CommsTest do
     end
   end
 
+  describe "channel_counts/0" do
+    test "counts inboxes and numbers apart, because the providers charge apart" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+
+      contact!(user, email: true, phone: true)
+      contact!(user, email: true, phone: false)
+      contact!(other, email: false, phone: true)
+
+      counts = Comms.channel_counts()
+
+      assert counts[user.id] == %{inboxes: 2, numbers: 1}
+      assert counts[other.id] == %{inboxes: 0, numbers: 1}
+    end
+
+    test "a blank provider id is not a channel" do
+      # `Contact.email?/1` treats "" as absent; the SQL has to agree, or a
+      # half-released contact gets billed for a channel it no longer has.
+      user = insert_verified_user()
+      contact!(user, email: true, phone: true)
+      Repo.update_all(Contact, set: [phone_number_id: ""])
+
+      assert Comms.channel_counts()[user.id] == %{inboxes: 1, numbers: 0}
+    end
+
+    test "a tenant with no contacts is absent, like contact_counts/0" do
+      user = insert_verified_user()
+      assert Comms.channel_counts()[user.id] == nil
+    end
+
+    defp contact!(user, opts) do
+      agent = insert_agent(user_id: user.id)
+      id = System.unique_integer([:positive])
+
+      Repo.insert!(%Contact{
+        user_id: user.id,
+        agent_id: agent.id,
+        email_address: if(opts[:email], do: "t#{id}@agentmail.to"),
+        email_inbox_id: if(opts[:email], do: "inbox_#{id}"),
+        phone_number: if(opts[:phone], do: "+1555000#{rem(id, 10_000)}"),
+        phone_number_id: if(opts[:phone], do: "num_#{id}"),
+        prompt_from_number: "+15550001111"
+      })
+    end
+  end
+
   describe "conversation_mcp_servers/2" do
     test "injects the tools for a teammate with a contact when the flag is on" do
       flag(true)

--- a/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
@@ -349,6 +349,63 @@ defmodule FountainWeb.TeamCommsControllerTest do
       refute inspect(event.metadata) =~ "+15550001111"
     end
 
+    test "a send is metered as well as audited — it costs money per message", %{
+      conn: conn,
+      raw_key: key,
+      conv: conv,
+      user: user,
+      contact: contact
+    } do
+      Req.Test.stub(AgentPhone, fn conn ->
+        Req.Test.json(conn, %{"id" => "sms_1", "status" => "queued", "channel" => "sms"})
+      end)
+
+      rpc(conn, key, conv.id, %{
+        "id" => 3,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "sms_send",
+          "arguments" => %{"to" => "+15550001111", "body" => "hi"}
+        }
+      })
+      |> json_response(200)
+
+      [event] = usage_events(user.id, "comms_sms_sent")
+      assert event.resource_id == contact.id
+      assert event.resource_type == "team_contact"
+      # The trail records what happened, never who it went to (ADR 0013).
+      refute inspect(event.metadata) =~ "+15550001111"
+    end
+
+    test "a read is not metered — only messages on the wire cost", %{
+      conn: conn,
+      raw_key: key,
+      conv: conv,
+      user: user
+    } do
+      Req.Test.stub(AgentPhone, fn conn ->
+        Req.Test.json(conn, %{"data" => [], "hasMore" => false})
+      end)
+
+      rpc(conn, key, conv.id, %{
+        "id" => 4,
+        "method" => "tools/call",
+        "params" => %{"name" => "sms_list", "arguments" => %{}}
+      })
+      |> json_response(200)
+
+      assert usage_events(user.id, "comms_sms_sent") == []
+    end
+
+    defp usage_events(user_id, event_type) do
+      import Ecto.Query
+
+      Fountain.Repo.all(
+        from e in Fountain.Billing.UsageEvent,
+          where: e.user_id == ^user_id and e.event_type == ^event_type
+      )
+    end
+
     test "a notification is 202 with no body", %{conn: conn, raw_key: key, conv: conv} do
       assert rpc(conn, key, conv.id, %{"method" => "notifications/initialized"}) |> response(202) ==
                ""

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -632,8 +632,10 @@ defmodule FountainWeb.AdminLiveTest do
       assert html =~ "MRR"
       assert html =~ "Trials ending in 7 days"
       assert html =~ "Conversions this month"
-      # no STRIPE_PRICE_MONTHLY_CENTS in test → honest placeholder, not a number
-      assert html =~ "set STRIPE_PRICE_MONTHLY_CENTS"
+      # MRR is priced from the plan catalog now, so it is a real number even
+      # with no price env var set — and the tile leads to the finance panel.
+      assert html =~ "active subscriptions, per plan"
+      assert html =~ "/admin/finance"
       # status chips link into the filtered user table from #285
       assert html =~ "/admin?status=active"
       assert html =~ "/admin?status=past_due"

--- a/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
@@ -127,6 +127,49 @@ defmodule FountainWeb.DashboardLiveTest do
     refute html =~ ~s|href="/conversations/#{conv.id}"|
   end
 
+  describe "turn hours" do
+    test "the tile reports turn time, not the wall-clock the sandbox was awake", %{
+      conn: conn,
+      user: user
+    } do
+      # Ten hours awake, two with a prompt in flight. The old tile said "10h"
+      # and a customer could do nothing with it: what their plan includes, and
+      # what they are measured on, is the two.
+      {period_start, _} = Fountain.Billing.current_month_range()
+
+      sandbox =
+        insert_sandbox(
+          user_id: user.id,
+          provider: "sprites",
+          status: "terminated",
+          inserted_at: period_start,
+          terminated_at: DateTime.add(period_start, 10 * 3600, :second)
+        )
+
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent_id: agent.id, sandbox: sandbox)
+
+      {:ok, _} =
+        Fountain.Conversations._unsafe_create_turn(%{
+          conversation_id: conv.id,
+          turn_number: 1,
+          prompt: "hello",
+          status: "completed",
+          started_at: period_start,
+          ended_at: DateTime.add(period_start, 2 * 3600, :second)
+        })
+
+      {:ok, _lv, html} = live(conn, ~p"/dashboard")
+
+      assert html =~ "Turn hours"
+      assert html =~ "2.0"
+      # Billing is on in test, so the plan's allowance is beside it.
+      assert html =~ "of #{Fountain.Plans.included_turn_hours(user)} included"
+      # The sandbox side is still available, in the hint where it belongs.
+      assert html =~ "sandboxes were awake"
+    end
+  end
+
   describe "this month" do
     test "reports conversations, turns, sandbox time and tokens", %{conn: conn, user: user} do
       now = DateTime.utc_now() |> DateTime.truncate(:second)
@@ -160,7 +203,10 @@ defmodule FountainWeb.DashboardLiveTest do
       assert html =~ "This month"
       assert html =~ "Conversations"
       assert html =~ "Turns"
-      assert html =~ "Sandbox time"
+      # Turn hours, not sandbox time: what a plan includes, and the only one of
+      # the two a customer can act on.
+      assert html =~ "Turn hours"
+      refute html =~ "Sandbox time"
       assert html =~ "Tokens"
       # 1,500 in / 250 out, compacted.
       assert html =~ "1.5k / 250"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -657,6 +657,74 @@ stripe_price_monthly_cents =
 
 config :fountain, :stripe_price_monthly_cents, stripe_price_monthly_cents
 
+# ── The finance panel's rate card (/admin/finance) ────────────────────────────
+#
+# What Fountain *pays*, which is nowhere else in this codebase: provider
+# prices are per-machine-size and negotiated, and AgentMail/AgentPhone bill
+# per unit and per message. `Fountain.Billing.Finance` reports hours and units
+# with no money at all until these are set, and an unpriced line stays `nil`
+# rather than collapsing to zero — a cost of $0 and a cost nobody has told us
+# reads very differently next to revenue.
+#
+# PROVIDER_HOURLY_CENTS is cents per active sandbox hour, per provider:
+#   PROVIDER_HOURLY_CENTS="sprites=12,e2b=15,daytona=10"
+# A provider absent from the list is unpriced. `runner` is never priced: it is
+# the tenant's own machine (ADR 0022) and costs Fountain nothing.
+parse_cents = fn var, raw ->
+  case Integer.parse(String.trim(raw)) do
+    {cents, ""} when cents >= 0 -> cents
+    _ -> raise "#{var} must be a whole number of cents, got #{inspect(raw)}"
+  end
+end
+
+provider_hourly_cents =
+  case System.get_env("PROVIDER_HOURLY_CENTS") do
+    value when value in [nil, ""] ->
+      %{}
+
+    value ->
+      value
+      |> String.split(",", trim: true)
+      |> Map.new(fn pair ->
+        case String.split(pair, "=", parts: 2) do
+          [provider, cents] ->
+            {String.trim(provider), parse_cents.("PROVIDER_HOURLY_CENTS", cents)}
+
+          _ ->
+            raise "PROVIDER_HOURLY_CENTS: #{inspect(pair)} is not provider=cents"
+        end
+      end)
+  end
+
+config :fountain, :provider_hourly_cents, provider_hourly_cents
+
+# Which hours that rate multiplies. `active` (the default) is every hour a
+# sandbox was awake, idle included. `turn` is only the hours with a prompt in
+# flight, which is the closer match where a provider scales to near-zero
+# between prompts. /admin/finance can switch between the two per view; this
+# sets what it opens on. Anything unrecognised reads as `active`, because a
+# typo must not quietly halve the reported bill.
+config :fountain,
+       :cost_basis,
+       if(System.get_env("PROVIDER_COST_BASIS") == "turn", do: :turn, else: :active)
+
+# Teammate contacts: what AgentMail charges per inbox per month, AgentPhone
+# per number per month, and each of them per message. The monthly pair is
+# pro-rated to whatever window the panel is showing; messages are counted from
+# the `comms_*` usage events. Unset means unpriced, which the panel reports as
+# `—` rather than as free.
+contact_rate = fn var ->
+  case System.get_env(var) do
+    value when value in [nil, ""] -> nil
+    value -> parse_cents.(var, value)
+  end
+end
+
+config :fountain, :agentmail_inbox_cents, contact_rate.("AGENTMAIL_INBOX_CENTS")
+config :fountain, :agentphone_number_cents, contact_rate.("AGENTPHONE_NUMBER_CENTS")
+config :fountain, :agentmail_message_cents, contact_rate.("AGENTMAIL_MESSAGE_CENTS")
+config :fountain, :agentphone_message_cents, contact_rate.("AGENTPHONE_MESSAGE_CENTS")
+
 # Mail delivery.
 #
 # With no adapter configured this used to silently fall back to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,8 +121,14 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `STRIPE_PRICE_ID_SCALE` | — | For the Scale plan. | The Stripe price for Scale. |
 | `STRIPE_PRICE_ID_CONTACT` | — | No. | The Stripe price for one teammate contact. Fountain sets the quantity of that subscription item to the number of contacts the tenant holds. Leave it unset, and teammate contacts cost the tenant nothing. |
 | `STRIPE_CONTACT_PRICE_CENTS` | `500` | No. | The monthly price of one teammate contact, in cents. It is for display alone. |
-| `STRIPE_PRICE_MONTHLY_CENTS` | — | No. | The monthly price of the `legacy` plan, in cents, such as `2900`. It is for display alone, and it feeds the MRR tile in the admin overview. Unset, the tile shows a placeholder, and not a number somebody invented. |
+| `STRIPE_PRICE_MONTHLY_CENTS` | — | No. | The monthly price of the `legacy` plan, in cents, such as `2900`. It is for display alone. The admin MRR tile reads every other plan's price from the catalog. |
 | `DEFAULT_PLAN` | `solo` | No. | The plan for an account that has no plan of its own. On a self-hosted instance that is every account. Set `DEFAULT_PLAN=scale` to give every account the highest concurrency cap. |
+| `PROVIDER_HOURLY_CENTS` | — | No. | What you pay each sandbox provider, in cents per active hour, as `sprites=12,e2b=15`. A provider you leave out stays unpriced. |
+| `PROVIDER_COST_BASIS` | `active` | No. | Which hours the provider rate multiplies. An `active` counts every hour a sandbox was awake. A `turn` counts only the hours with a prompt in flight. Use `turn` where the provider drops to near-zero between prompts. |
+| `AGENTMAIL_INBOX_CENTS` | — | No. | What AgentMail charges for one inbox each month, in cents. |
+| `AGENTPHONE_NUMBER_CENTS` | — | No. | What AgentPhone charges for one number each month, in cents. |
+| `AGENTMAIL_MESSAGE_CENTS` | — | No. | What AgentMail charges for one email, in cents. |
+| `AGENTPHONE_MESSAGE_CENTS` | — | No. | What AgentPhone charges for one SMS, in cents. Fountain counts an inbound message too, because AgentPhone charges for it. |
 
 <!-- vale STE.IngForms = YES -->
 
@@ -130,6 +136,18 @@ Each plan sets one number that Fountain enforces: how many sandboxes the tenant
 can run at the same time. Run `mix fountain.verify_plans` after you set a price
 variable. The task reads each price from Stripe and fails if the amount differs
 from the catalog.
+
+The rate variables are different from every other price here. They are what
+**you pay**, not what a tenant pays, and no other part of Fountain knows them.
+The admin finance panel at `/admin/finance` holds them next to your revenue,
+per tenant. The panel also switches between the two hour bases per view, so
+you can compare both totals against a real invoice and keep the one that
+matches.
+
+Set none of them and the panel still works. It shows hours, inboxes, numbers
+and message counts, and it shows `—` in each money column. A rate you do not
+set stays `—` and never becomes `$0`, because a cost of zero and a cost nobody
+told us about are different facts.
 
 ## Public pages
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,9 +140,8 @@ from the catalog.
 The rate variables are different from every other price here. They are what
 **you pay**, not what a tenant pays, and no other part of Fountain knows them.
 The admin finance panel at `/admin/finance` holds them next to your revenue,
-per tenant. The panel also switches between the two hour bases per view, so
-you can compare both totals against a real invoice and keep the one that
-matches.
+per tenant. The panel switches between the two hour bases per view. Compare
+both totals against a real invoice, then keep the basis that matches.
 
 Set none of them and the panel still works. It shows hours, inboxes, numbers
 and message counts, and it shows `—` in each money column. A rate you do not

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -33,6 +33,7 @@ defmodule Fountain.Billing do
 
   alias Fountain.Accounts.User
   alias Fountain.Audit
+  alias Fountain.Billing.Finance
   alias Fountain.Billing.SandboxUsage
   alias Fountain.Billing.UsageEvent
   alias Fountain.Plans
@@ -2096,13 +2097,19 @@ defmodule Fountain.Billing do
     provider, `%{provider => minutes}`. Providers the tenant did not use are
     absent. Minutes on different providers are bought at different prices, so
     this split is what makes the total attributable to a cost.
+  - `:turn_hours` — the part of that time with a prompt actually in flight, on
+    the providers Fountain pays for. The same number
+    `turn_hours_used/2` computes, carried here so a surface showing usage does
+    not need a second pass over the same rows to show the unit a plan is
+    denominated in (`Fountain.Plans.included_turn_hours/1`).
   """
   @spec usage_summary(binary(), DateTime.t(), DateTime.t()) ::
           %{
             conversations: non_neg_integer(),
             turns: non_neg_integer(),
             sandbox_minutes: float(),
-            sandbox_minutes_by_provider: %{optional(String.t()) => float()}
+            sandbox_minutes_by_provider: %{optional(String.t()) => float()},
+            turn_hours: float()
           }
   def usage_summary(user_id, %DateTime{} = period_start, %DateTime{} = period_end) do
     events =
@@ -2121,7 +2128,9 @@ defmodule Fountain.Billing do
 
     turns = Enum.count(events, &(&1 == "turn_started"))
 
-    seconds_by_provider = SandboxUsage.for_user(user_id, period_start, period_end)
+    # One attribution pass, read two ways. `for_user/3` and `busy_for_user/3`
+    # would each run it again; this is the same two queries once.
+    rows = SandboxUsage.attribution(period_start, period_end, user_id: user_id)
 
     %{
       conversations: conversations,
@@ -2129,11 +2138,17 @@ defmodule Fountain.Billing do
       # Rounded once, from the total — summing rounded per-provider minutes
       # would let the parts disagree with the whole.
       sandbox_minutes:
-        seconds_by_provider |> Map.values() |> Enum.sum() |> SandboxUsage.minutes(),
+        rows |> Enum.map(& &1.active_seconds) |> Enum.sum() |> SandboxUsage.minutes(),
       sandbox_minutes_by_provider:
-        Map.new(seconds_by_provider, fn {provider, seconds} ->
-          {provider, SandboxUsage.minutes(seconds)}
-        end)
+        rows
+        |> Enum.reject(&(&1.active_seconds == 0))
+        |> Map.new(&{&1.provider, SandboxUsage.minutes(&1.active_seconds)}),
+      turn_hours:
+        rows
+        |> Enum.filter(&SandboxUsage.platform_cost?(&1.provider))
+        |> Enum.map(& &1.busy_seconds)
+        |> Enum.sum()
+        |> SandboxUsage.hours()
     }
   end
 
@@ -2142,8 +2157,16 @@ defmodule Fountain.Billing do
   which refreshes on a timer and must not run a query per user.
 
   Returns `%{user_id => %{conversations: n, turns: n, sandbox_minutes: f,
-  sandbox_minutes_by_provider: %{provider => f}}}`; users with neither events
-  nor sandbox time in the period are absent.
+  sandbox_minutes_by_provider: %{provider => f}, turn_hours: f}}`; users with
+  neither events nor sandbox time in the period are absent.
+
+  Carries two units on purpose, because they answer different questions and
+  the admin table shows both. `sandbox_minutes` is wall-clock sandbox time —
+  what a provider bills Fountain, so minutes, per provider, because the
+  providers charge differently. `turn_hours` is time with a prompt in flight —
+  what a *plan* includes (`Fountain.Plans.included_turn_hours/1`), so hours,
+  and summed only over the providers Fountain pays for, exactly as
+  `turn_hours_used/2` computes it for one tenant.
   """
   @spec usage_summaries(DateTime.t(), DateTime.t()) :: %{optional(binary()) => map()}
   def usage_summaries(%DateTime{} = period_start, %DateTime{} = period_end) do
@@ -2151,7 +2174,8 @@ defmodule Fountain.Billing do
       conversations: 0,
       turns: 0,
       sandbox_minutes: 0.0,
-      sandbox_minutes_by_provider: %{}
+      sandbox_minutes_by_provider: %{},
+      turn_hours: 0.0
     }
 
     counted =
@@ -2181,26 +2205,33 @@ defmodule Fountain.Billing do
         Map.put(acc, user_id, summary)
       end)
 
-    # Sandbox minutes come from the sandbox rows, not from these events — the
-    # period-clipped, per-provider computation in `SandboxUsage`, which is two
-    # more queries for every user at once rather than one per user.
+    # Both sandbox figures come from the sandbox rows, not from these events —
+    # the period-clipped, per-provider computation in `SandboxUsage`, which is
+    # two more queries for every user at once rather than one per user.
+    # `Finance.usage_by_user/1` rather than `SandboxUsage.by_user/1` because
+    # the latter collapses to active seconds and drops the busy/idle split
+    # turn hours are read off. Sandboxes whose owner has been deleted keep
+    # their seconds under a `nil` owner in the provider report; it drops them,
+    # since here there is no user row to hang them on.
     period_start
     |> SandboxUsage.attribution(period_end)
-    |> SandboxUsage.by_user()
-    # Sandboxes whose owner has been deleted keep their seconds under a `nil`
-    # owner in the provider report; here there is no user row to hang them on.
-    |> Enum.reject(fn {user_id, _} -> is_nil(user_id) end)
-    |> Enum.reduce(counted, fn {user_id, seconds_by_provider}, acc ->
+    |> Finance.usage_by_user()
+    |> Enum.reduce(counted, fn {user_id, usage}, acc ->
       summary = Map.get(acc, user_id, empty)
 
       Map.put(acc, user_id, %{
         summary
-        | sandbox_minutes:
-            seconds_by_provider |> Map.values() |> Enum.sum() |> SandboxUsage.minutes(),
+        | sandbox_minutes: SandboxUsage.minutes(usage.active_seconds),
           sandbox_minutes_by_provider:
-            Map.new(seconds_by_provider, fn {provider, seconds} ->
-              {provider, SandboxUsage.minutes(seconds)}
-            end)
+            Map.new(usage.by_provider, fn row ->
+              {row.provider, SandboxUsage.minutes(row.active)}
+            end),
+          turn_hours:
+            usage.by_provider
+            |> Enum.filter(&SandboxUsage.platform_cost?(&1.provider))
+            |> Enum.map(& &1.busy)
+            |> Enum.sum()
+            |> SandboxUsage.hours()
       })
     end)
   end
@@ -2299,30 +2330,32 @@ defmodule Fountain.Billing do
     since the start of the current UTC month. Every verified webhook is
     claimed into `stripe_events` before handling, so the claim table is a
     complete record of checkouts — including a canceled user coming back.
-  - `mrr_cents` — active subscriptions × the configured monthly price
-    (`:stripe_price_monthly_cents`, from `STRIPE_PRICE_MONTHLY_CENTS`).
-    `nil` when the price isn't configured — no number is better than a made-up
-    one. Deliberately `active` only: `past_due` is at-risk revenue, comped is
-    not revenue. Honesty note: this breaks the day there is a second price;
-    the config is a single amount on purpose so that day is loud.
+  - `mrr_cents` / `mrr_by_plan` — recurring revenue, priced per plan from
+    `Fountain.Billing.Finance.mrr/0`: each active subscription at its own
+    tier's price, plus the teammate-contact add-on. Deliberately `active`
+    only: `past_due` is at-risk revenue, comped is not revenue.
+
+    It used to be `active × :stripe_price_monthly_cents`, one configured
+    amount for everybody. The day there was a second price was supposed to be
+    loud and was not — #991 shipped four tiers and this tile went on charging
+    every account the legacy $29, under-reporting a deployment selling Scale
+    by a factor of seven. The catalog has held every plan's price since, so
+    there is nothing left to configure and nothing left to get out of step.
+    `STRIPE_PRICE_MONTHLY_CENTS` is no longer read here.
   - `recent_events` — the last processed webhook events, newest first.
   - `failed_events` — unresolved webhook processing failures, most recently
     failed first (#501). Failed deliveries are never claimed (the claim rolls
     back with the failed apply), so these come from `stripe_webhook_failures`,
     written by the controller outside the rolled-back transaction.
 
-  Options: `:price_cents` overrides the configured price (tests), `:now`
-  pins the clock, `:event_limit` caps `recent_events`/`failed_events`
-  (default 10).
+  Options: `:now` pins the clock, `:event_limit` caps
+  `recent_events`/`failed_events` (default 10).
   """
   @spec overview_admin(keyword()) :: map()
   def overview_admin(opts \\ []) do
     now = Keyword.get(opts, :now, DateTime.utc_now())
-
-    price_cents =
-      Keyword.get(opts, :price_cents, Application.get_env(:fountain, :stripe_price_monthly_cents))
-
     event_limit = Keyword.get(opts, :event_limit, 10)
+    mrr = Finance.mrr()
 
     status_counts =
       from(u in User,
@@ -2375,13 +2408,12 @@ defmodule Fountain.Billing do
           }
       )
 
-    active = Map.get(status_counts, "active", 0)
-
     %{
       status_counts: status_counts,
       trials_ending_7d: trials_ending_7d,
       conversions_this_month: conversions_this_month,
-      mrr_cents: price_cents && active * price_cents,
+      mrr_cents: mrr.mrr_cents,
+      mrr_by_plan: mrr.by_plan,
       recent_events: recent_events,
       failed_events: failed_events
     }

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -24,6 +24,14 @@ defmodule Fountain.Billing.Finance do
   reported apart as at-risk rather than folded into MRR: it is revenue that
   has not arrived.
 
+  Every row carries two plans, because since #1022 they can differ. `:plan` is
+  `Plans.resolve/1` — the tier the subscription is *for*, which is what a
+  trial converts into and what its revenue lines are priced at.
+  `:effective_plan` is `Plans.effective/1` — whose entitlements apply *today*,
+  which during a trial is the smaller `trial` plan. The allowance columns read
+  the second. Reading the first would measure a trialing account against hours
+  it does not have yet, and report it inside an allowance it is over.
+
   ## Cost, and the rate card
 
   Fountain's spend is not in this codebase, and inventing it would make this
@@ -111,6 +119,7 @@ defmodule Fountain.Billing.Finance do
           user_id: binary(),
           email: String.t(),
           plan: Plans.t(),
+          effective_plan: Plans.t(),
           subscription_status: String.t(),
           revenue_cents: non_neg_integer(),
           plan_cents: non_neg_integer(),
@@ -472,8 +481,9 @@ defmodule Fountain.Billing.Finance do
   Turn hours sold against turn hours used — the utilization of the thing the
   plans actually include.
 
-  Sold counts every account whose plan is live for them, trials included: a
-  trial hands over the same allowance and costs the same to serve. Utilization
+  Sold counts every account whose plan is live for them, trials included at
+  the trial plan's smaller allowance (#1022) rather than at the tier they are
+  trialling — a trial that has not converted has not sold those hours. Utilization
   is what says whether the included hours are priced anywhere near what
   tenants do with them, which is the number #1016 step 4 was left open for.
   """
@@ -497,7 +507,16 @@ defmodule Fountain.Billing.Finance do
   ## ── one tenant ──────────────────────────────────────────────────────────
 
   defp tenant_row(user, usage, channels, messages, contacts, card, fraction) do
-    plan = Plans.resolve(user.plan)
+    # `plan` is the tier the subscription is for — what Stripe charges, and
+    # what a trial converts into. `effective_plan` is whose numbers apply
+    # today, which during a trial is the smaller `trial` plan (#1022).
+    #
+    # Revenue reads the first and the allowance reads the second, and using
+    # one for the other is the specific mistake this split exists to prevent:
+    # a trialing account measured against its future tier's 100 hours would
+    # look comfortably inside an allowance it is actually over.
+    plan = Plans.resolve(user)
+    effective_plan = Plans.effective(user)
     paying? = user.subscription_status in @paying
 
     plan_cents = plan.monthly_cents
@@ -531,8 +550,9 @@ defmodule Fountain.Billing.Finance do
       plan_cents: plan_cents,
       contact_revenue_cents: contact_revenue_cents,
       turn_hours: SandboxUsage.hours(turn_seconds),
-      included_turn_hours: plan.included_turn_hours,
-      allowance_used: allowance_used(turn_seconds, plan.included_turn_hours),
+      effective_plan: effective_plan,
+      included_turn_hours: effective_plan.included_turn_hours,
+      allowance_used: allowance_used(turn_seconds, effective_plan.included_turn_hours),
       active_hours: SandboxUsage.hours(usage.active_seconds),
       idle_hours: SandboxUsage.hours(usage.idle_seconds),
       inboxes: channels.inboxes,

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -1,0 +1,743 @@
+defmodule Fountain.Billing.Finance do
+  @moduledoc """
+  What Fountain is paid and what Fountain pays, per tenant, over a period.
+
+  The pieces have existed for a while and never met. `Billing.overview_admin/1`
+  had revenue with no cost beside it, `Billing.provider_spend/1` had cost with
+  no revenue beside it and deliberately no money in it at all, and
+  `Billing.turn_hour_allowance/2` had the sold unit but only ever for one
+  tenant at a time. This module puts the three on one row so the question
+  "which tenants cost more than they pay" has an answer.
+
+  ## Revenue
+
+  Two lines, both from what the tenant is actually subscribed to:
+
+    * the **plan** — `Fountain.Plans.monthly_cents/1` for their tier;
+    * the **teammate-contact add-on** — the billable contact count times
+      `Plans.contact_monthly_cents/0` (#991), less the contacts an operator
+      has comped.
+
+  Only an `active` subscription contributes. A trialing account pays nothing
+  yet and a comped one pays nothing by decision, so both count as zero
+  revenue against real cost — which is the point of looking. `past_due` is
+  reported apart as at-risk rather than folded into MRR: it is revenue that
+  has not arrived.
+
+  ## Cost, and the rate card
+
+  Fountain's spend is not in this codebase, and inventing it would make this
+  page look authoritative when it is not — the reasoning `provider_spend/1`
+  already committed to. So cost is priced from a **rate card in config**, and
+  where the card is silent the answer is `nil`, never a guess:
+
+  | Config key | Env var | Unit |
+  |---|---|---|
+  | `:provider_hourly_cents` | `PROVIDER_HOURLY_CENTS` | cents per sandbox hour, per provider |
+  | `:cost_basis` | `PROVIDER_COST_BASIS` | `active` (default) or `turn` — which hours that rate multiplies |
+  | `:agentmail_inbox_cents` | `AGENTMAIL_INBOX_CENTS` | cents per inbox per month |
+  | `:agentphone_number_cents` | `AGENTPHONE_NUMBER_CENTS` | cents per number per month |
+  | `:agentmail_message_cents` | `AGENTMAIL_MESSAGE_CENTS` | cents per email sent |
+  | `:agentphone_message_cents` | `AGENTPHONE_MESSAGE_CENTS` | cents per SMS, each way |
+
+  `nil` propagates: a tenant with sandbox hours on a provider that has no rate
+  has `cost_cents: nil`, not a cost that silently omits them, and their margin
+  is `nil` too. `priced?/0` says whether the card covers anything at all, so a
+  surface can offer hours instead of dollars rather than showing zeroes. A
+  self-hosted instance sets none of it and gets exactly the hours report it
+  had before.
+
+  ## Three kinds of cost, three shapes
+
+  **Sandbox hours** come in two flavours and the panel prices whichever one
+  the invoice actually tracks. `:active` is the whole window a sprite was
+  awake, idle included; `:turn` is only the part with a prompt in flight. A
+  provider that bills wall-clock matches the first, and one that scales to
+  near-zero between prompts matches the second closely enough to reconcile
+  against. `:cost_basis` on the config (`PROVIDER_COST_BASIS`) sets the
+  default and `summary/1` takes a `:basis` override, because the way to find
+  out which one a provider bills is to hold both next to the invoice.
+
+  Every row carries active hours **and** turn hours whichever basis is
+  chosen, because the gap between them is the tenant's idle time and it is
+  the single largest lever on the bill. Note that turn hours are also the
+  unit revenue is measured in (`Plans.included_turn_hours/1`) — so on the
+  `:turn` basis, cost and allowance move together, and on `:active` they do
+  not.
+
+  **Contacts** are a monthly recurring charge per inbox and per number, so
+  they are pro-rated against the period rather than charged whole: a panel
+  looking at a week of a month should not show a month of AgentMail. The
+  channels are counted apart (`Team.Comms.channel_counts/0`) because the two
+  providers charge differently and a contact can hold either, neither or both.
+
+  **Messages** are per-send, from the `comms_email_sent`, `comms_sms_sent` and
+  `comms_sms_received` usage events (`FountainWeb.TeamCommsMcpController`,
+  `Team.Comms.Inbound`). Inbound counts: AgentPhone charges to receive.
+
+  ## Cost, ownership and the tenants that are not there
+
+  Sandbox seconds whose owner has been deleted keep a `nil` `user_id` all the
+  way through `SandboxUsage` (decisions/0009). They are real spend and they
+  are in `:unattributed_cost_cents`, out of the per-tenant rows, because there
+  is no tenant to put them on. A total that quietly dropped them would
+  understate the bill.
+
+  ## Cost
+
+  `summary/1` is four queries plus the two `SandboxUsage.attribution/3`
+  already runs — one pass for every tenant, not a query per row. The finance
+  panel refreshes on a timer, and so does `/admin`.
+  """
+
+  import Ecto.Query
+
+  alias Fountain.Accounts.User
+  alias Fountain.Billing
+  alias Fountain.Billing.SandboxUsage
+  alias Fountain.Billing.UsageEvent
+  alias Fountain.Plans
+  alias Fountain.Repo
+  alias Fountain.Team.Comms
+
+  @message_events ~w(comms_email_sent comms_sms_sent comms_sms_received)
+
+  # Statuses that are paying today. `trialing` will be, `past_due` was, and
+  # `comped` never will be — none of them is MRR.
+  @paying ~w(active)
+
+  @typedoc "One tenant's money for a period. Every `*_cents` may be `nil` when the rate card is silent."
+  @type tenant_row :: %{
+          user_id: binary(),
+          email: String.t(),
+          plan: Plans.t(),
+          subscription_status: String.t(),
+          revenue_cents: non_neg_integer(),
+          plan_cents: non_neg_integer(),
+          contact_revenue_cents: non_neg_integer(),
+          turn_hours: float(),
+          included_turn_hours: non_neg_integer(),
+          allowance_used: float() | nil,
+          active_hours: float(),
+          idle_hours: float(),
+          inboxes: non_neg_integer(),
+          numbers: non_neg_integer(),
+          emails_sent: non_neg_integer(),
+          sms_sent: non_neg_integer(),
+          sms_received: non_neg_integer(),
+          sandbox_cost_cents: non_neg_integer() | nil,
+          contact_cost_cents: non_neg_integer() | nil,
+          message_cost_cents: non_neg_integer() | nil,
+          cost_cents: non_neg_integer() | nil,
+          margin_cents: integer() | nil
+        }
+
+  ## ── the rate card ───────────────────────────────────────────────────────
+
+  @doc """
+  What this deployment says it pays, in cents. Absent keys mean "unpriced",
+  which is a different answer from zero and is reported as `nil` throughout.
+  """
+  @spec rate_card() :: %{
+          providers: %{optional(String.t()) => non_neg_integer()},
+          basis: :active | :turn,
+          inbox_month: non_neg_integer() | nil,
+          number_month: non_neg_integer() | nil,
+          email: non_neg_integer() | nil,
+          sms: non_neg_integer() | nil
+        }
+  def rate_card(basis \\ nil) do
+    %{
+      providers: provider_rates(),
+      basis: basis || default_basis(),
+      inbox_month: rate(:agentmail_inbox_cents),
+      number_month: rate(:agentphone_number_cents),
+      email: rate(:agentmail_message_cents),
+      sms: rate(:agentphone_message_cents)
+    }
+  end
+
+  @doc """
+  The hours a provider rate multiplies, unless a caller overrides it.
+
+  `:active` — every hour the sandbox was awake — unless
+  `PROVIDER_COST_BASIS=turn` says this deployment's providers bill closer to
+  prompt time. Anything else reads as `:active`: a misspelt env var must not
+  silently halve the reported bill.
+  """
+  @spec default_basis() :: :active | :turn
+  def default_basis do
+    case Application.get_env(:fountain, :cost_basis) do
+      :turn -> :turn
+      "turn" -> :turn
+      _ -> :active
+    end
+  end
+
+  @doc "Both bases, for a surface that offers the choice."
+  @spec bases() :: [:active | :turn]
+  def bases, do: [:active, :turn]
+
+  @doc """
+  Whether the rate card prices anything at all.
+
+  False on a fresh or self-hosted instance, where the panel shows hours and
+  units and says out loud that it has no rates — which is the honest state,
+  not an error.
+  """
+  @spec priced?() :: boolean()
+  def priced? do
+    card = rate_card()
+
+    card.providers != %{} or
+      Enum.any?([card.inbox_month, card.number_month, card.email, card.sms], &(&1 != nil))
+  end
+
+  defp provider_rates do
+    case Application.get_env(:fountain, :provider_hourly_cents) do
+      map when is_map(map) -> map
+      _ -> %{}
+    end
+  end
+
+  defp rate(key) do
+    case Application.get_env(:fountain, key) do
+      cents when is_integer(cents) and cents >= 0 -> cents
+      _ -> nil
+    end
+  end
+
+  ## ── the whole panel ─────────────────────────────────────────────────────
+
+  @doc """
+  Everything the finance panel renders, in one pass.
+
+  Options:
+    * `:period` — `{start, end}`, default the current calendar month. Per-user
+      billing periods are deliberately not used here: the panel adds tenants
+      together, and a sum over windows that each start on a different day is
+      not a number anyone can hold next to a provider invoice. Each tenant's
+      own invoiced window stays on their detail page.
+    * `:basis` — `:active` or `:turn`, which hours the provider rates
+      multiply. Defaults to `default_basis/0`. See the moduledoc: the way to
+      learn which one a provider bills is to compare both against an invoice.
+    * `:now` — pins the clock (tests)
+
+  Returns `%{period_start:, period_end:, priced?:, rate_card:, revenue:,
+  cost:, turn_hours:, tenants:, unattributed_cost_cents:}`. `rate_card.basis`
+  says which hours were priced, so a surface can label its own number.
+  """
+  @spec summary(keyword()) :: map()
+  def summary(opts \\ []) do
+    {period_start, period_end} = Keyword.get(opts, :period) || Billing.current_month_range()
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
+
+    rows = SandboxUsage.attribution(period_start, period_end, now: now)
+    users = paying_users()
+    card = rate_card(Keyword.get(opts, :basis))
+    fraction = period_fraction(period_start, period_end, now)
+
+    usage = usage_by_user(rows)
+    channels = Comms.channel_counts()
+    messages = message_counts(period_start, period_end)
+    contacts = billable_contacts()
+
+    tenants =
+      users
+      |> Enum.map(
+        &tenant_row(
+          &1,
+          Map.get(usage, &1.id, empty_usage()),
+          Map.get(channels, &1.id, %{inboxes: 0, numbers: 0}),
+          Map.get(messages, &1.id, empty_messages()),
+          Map.get(contacts, &1.id, 0),
+          card,
+          fraction
+        )
+      )
+      |> Enum.sort_by(&sort_key/1)
+
+    %{
+      period_start: period_start,
+      period_end: period_end,
+      period_fraction: fraction,
+      priced?: priced?(),
+      rate_card: card,
+      revenue: revenue(tenants),
+      cost: cost(tenants, rows, card),
+      turn_hours: turn_hours(tenants),
+      tenants: tenants,
+      unattributed_cost_cents: unattributed_cost_cents(rows, card)
+    }
+  end
+
+  # Biggest loss first, then biggest cost — the row an operator opened the
+  # page for. An unpriced deployment has no margin to sort on and falls back
+  # to sandbox hours, which is the only cost signal it has.
+  defp sort_key(%{margin_cents: nil, active_hours: hours}), do: {0, -hours}
+  defp sort_key(%{margin_cents: margin}), do: {-1, margin}
+
+  ## ── revenue ─────────────────────────────────────────────────────────────
+
+  @doc """
+  Recurring revenue, by plan, from the tenant rows `summary/1` built.
+
+  `:mrr_cents` counts `active` subscriptions only. It replaced a single
+  `active × STRIPE_PRICE_MONTHLY_CENTS`, which had been silently wrong since
+  the tiers landed (#991): it charged every active account the legacy price,
+  so a deployment selling Scale under-reported its own revenue by a factor of
+  seven.
+
+  `:at_risk_cents` is what `past_due` accounts would be paying, and
+  `:comped_cents` what comped ones would — both real numbers an operator
+  wants, neither of them MRR.
+  """
+  @spec revenue([tenant_row()]) :: map()
+  def revenue(tenants) when is_list(tenants) do
+    paying = Enum.filter(tenants, &(&1.subscription_status in @paying))
+
+    by_plan =
+      paying
+      |> Enum.group_by(& &1.plan.slug)
+      |> Enum.map(fn {slug, group} ->
+        %{
+          plan: Plans.resolve(slug),
+          accounts: length(group),
+          plan_cents: group |> Enum.map(& &1.plan_cents) |> Enum.sum(),
+          contact_cents: group |> Enum.map(& &1.contact_revenue_cents) |> Enum.sum()
+        }
+      end)
+      |> Enum.sort_by(& &1.plan.order)
+
+    %{
+      mrr_cents: paying |> Enum.map(& &1.revenue_cents) |> Enum.sum(),
+      plan_cents: paying |> Enum.map(& &1.plan_cents) |> Enum.sum(),
+      contact_cents: paying |> Enum.map(& &1.contact_revenue_cents) |> Enum.sum(),
+      by_plan: by_plan,
+      at_risk_cents: status_cents(tenants, "past_due"),
+      comped_cents: status_cents(tenants, "comped"),
+      trialing_cents: status_cents(tenants, "trialing")
+    }
+  end
+
+  # What a non-paying cohort *would* bill at their current plan — the size of
+  # the conversion, or of the discount.
+  defp status_cents(tenants, status) do
+    tenants
+    |> Enum.filter(&(&1.subscription_status == status))
+    |> Enum.map(&(&1.plan_cents + &1.contact_revenue_cents))
+    |> Enum.sum()
+  end
+
+  @doc """
+  Monthly recurring revenue on its own, in two grouped queries — for `/admin`,
+  which wants the number without the whole finance pass behind it.
+
+  Same arithmetic as `revenue/1`, and `finance_test.exs` asserts the two agree:
+  a tile and a table that disagree about MRR is how an operator stops trusting
+  both.
+
+  Replaces `active × STRIPE_PRICE_MONTHLY_CENTS`, which had been quietly wrong
+  since the tiers landed (#991) — it charged every active account the legacy
+  $29, so a deployment selling Scale under-reported itself sevenfold.
+  """
+  @spec mrr() :: %{
+          mrr_cents: non_neg_integer(),
+          plan_cents: non_neg_integer(),
+          contact_cents: non_neg_integer(),
+          by_plan: [map()]
+        }
+  def mrr do
+    counts =
+      Repo.all(
+        from u in User,
+          where: u.subscription_status in ^@paying,
+          group_by: u.plan,
+          select: {u.plan, count(u.id)}
+      )
+
+    contacts = active_contact_cents()
+
+    by_plan =
+      counts
+      |> Enum.map(fn {slug, accounts} ->
+        plan = Plans.resolve(slug)
+
+        %{
+          plan: plan,
+          accounts: accounts,
+          plan_cents: accounts * plan.monthly_cents,
+          contact_cents: Map.get(contacts, plan.slug, 0)
+        }
+      end)
+      # A null `plan` and an unknown slug both resolve to the deployment
+      # default, so two groups can land on one plan; merge them rather than
+      # rendering the same tier twice.
+      |> Enum.group_by(& &1.plan.slug)
+      |> Enum.map(fn {_slug, group} ->
+        %{
+          plan: hd(group).plan,
+          accounts: group |> Enum.map(& &1.accounts) |> Enum.sum(),
+          plan_cents: group |> Enum.map(& &1.plan_cents) |> Enum.sum(),
+          contact_cents: hd(group).contact_cents
+        }
+      end)
+      |> Enum.sort_by(& &1.plan.order)
+
+    plan_cents = by_plan |> Enum.map(& &1.plan_cents) |> Enum.sum()
+    contact_cents = by_plan |> Enum.map(& &1.contact_cents) |> Enum.sum()
+
+    %{
+      mrr_cents: plan_cents + contact_cents,
+      plan_cents: plan_cents,
+      contact_cents: contact_cents,
+      by_plan: by_plan
+    }
+  end
+
+  # Contact add-on revenue for active accounts only, grouped by the plan they
+  # are on, so the per-plan table's two columns come from the same cohort.
+  defp active_contact_cents do
+    billable = billable_contacts()
+
+    plans =
+      Repo.all(
+        from u in User,
+          where: u.subscription_status in ^@paying,
+          select: {u.id, u.plan}
+      )
+
+    Enum.reduce(plans, %{}, fn {user_id, slug}, acc ->
+      case Map.get(billable, user_id, 0) do
+        0 ->
+          acc
+
+        count ->
+          key = Plans.resolve(slug).slug
+          Map.update(acc, key, count, &(&1 + count))
+      end
+    end)
+    |> Map.new(fn {slug, count} -> {slug, count * Plans.contact_monthly_cents()} end)
+  end
+
+  ## ── cost ────────────────────────────────────────────────────────────────
+
+  @doc """
+  Platform spend for the period: the hours behind it, and the money when the
+  rate card can price them.
+
+  `:sandbox_cents` covers every provider Fountain pays for — including the
+  seconds of deleted accounts, which is why it is computed from the raw
+  attribution rows rather than by adding the tenant rows up.
+  """
+  @spec cost([tenant_row()], [SandboxUsage.row()], map()) :: map()
+  def cost(tenants, rows, card) do
+    paid = Enum.filter(rows, &SandboxUsage.platform_cost?(&1.provider))
+
+    %{
+      active_hours: paid |> Enum.map(& &1.active_seconds) |> Enum.sum() |> SandboxUsage.hours(),
+      idle_hours: paid |> Enum.map(& &1.idle_seconds) |> Enum.sum() |> SandboxUsage.hours(),
+      basis: card.basis,
+      sandbox_cents:
+        sum_or_nil(paid, &provider_cost_cents(billed_seconds(&1, card.basis), &1.provider, card)),
+      # Only meaningful on the `:active` basis: on `:turn` the idle hours are
+      # already outside the bill, so there is nothing for a shorter timeout to
+      # remove and reporting a saving would be an invention.
+      idle_cents:
+        if(card.basis == :active,
+          do: sum_or_nil(paid, &provider_cost_cents(&1.idle_seconds, &1.provider, card))
+        ),
+      contact_cents: sum_or_nil(tenants, & &1.contact_cost_cents),
+      message_cents: sum_or_nil(tenants, & &1.message_cost_cents),
+      inboxes: tenants |> Enum.map(& &1.inboxes) |> Enum.sum(),
+      numbers: tenants |> Enum.map(& &1.numbers) |> Enum.sum(),
+      emails_sent: tenants |> Enum.map(& &1.emails_sent) |> Enum.sum(),
+      sms_sent: tenants |> Enum.map(& &1.sms_sent) |> Enum.sum(),
+      sms_received: tenants |> Enum.map(& &1.sms_received) |> Enum.sum(),
+      by_provider: SandboxUsage.by_provider(rows)
+    }
+  end
+
+  # The spend nobody can be charged for: sandboxes whose owner has been
+  # deleted. Real money, no tenant row.
+  defp unattributed_cost_cents(rows, card) do
+    rows
+    |> Enum.filter(&(is_nil(&1.user_id) and SandboxUsage.platform_cost?(&1.provider)))
+    |> sum_or_nil(&provider_cost_cents(billed_seconds(&1, card.basis), &1.provider, card))
+  end
+
+  ## ── turn hours ──────────────────────────────────────────────────────────
+
+  @doc """
+  Turn hours sold against turn hours used — the utilization of the thing the
+  plans actually include.
+
+  Sold counts every account whose plan is live for them, trials included: a
+  trial hands over the same allowance and costs the same to serve. Utilization
+  is what says whether the included hours are priced anywhere near what
+  tenants do with them, which is the number #1016 step 4 was left open for.
+  """
+  @spec turn_hours([tenant_row()]) :: map()
+  def turn_hours(tenants) do
+    live = Enum.reject(tenants, &(&1.subscription_status == "canceled"))
+    sold = live |> Enum.map(& &1.included_turn_hours) |> Enum.sum()
+    used = tenants |> Enum.map(& &1.turn_hours) |> Enum.sum() |> Float.round(2)
+
+    %{
+      sold: sold,
+      used: used,
+      over_allowance: Enum.count(tenants, &over_allowance?/1),
+      utilization: if(sold > 0, do: Float.round(used / sold, 4))
+    }
+  end
+
+  defp over_allowance?(%{turn_hours: used, included_turn_hours: included}),
+    do: included > 0 and used > included
+
+  ## ── one tenant ──────────────────────────────────────────────────────────
+
+  defp tenant_row(user, usage, channels, messages, contacts, card, fraction) do
+    plan = Plans.resolve(user.plan)
+    paying? = user.subscription_status in @paying
+
+    plan_cents = plan.monthly_cents
+    contact_revenue_cents = contacts * Plans.contact_monthly_cents()
+
+    sandbox_cost =
+      sum_or_nil(
+        usage.by_provider,
+        &provider_cost_cents(billed_seconds(&1, card.basis), &1.provider, card)
+      )
+
+    contact_cost = contact_cost_cents(channels, card, fraction)
+    message_cost = message_cost_cents(messages, card)
+    turn_seconds = billable_turn_seconds(usage)
+
+    cost = add_or_nil([sandbox_cost, contact_cost, message_cost])
+
+    # Revenue is what they are billed *this month*, so it is the full monthly
+    # price rather than a pro-rated one, while the recurring contact cost above
+    # is pro-rated to the window being looked at. They are answering different
+    # questions and a part-month view will show the two out of step; the panel
+    # says which window it is on.
+    revenue_cents = if paying?, do: plan_cents + contact_revenue_cents, else: 0
+
+    %{
+      user_id: user.id,
+      email: user.email,
+      plan: plan,
+      subscription_status: user.subscription_status,
+      revenue_cents: revenue_cents,
+      plan_cents: plan_cents,
+      contact_revenue_cents: contact_revenue_cents,
+      turn_hours: SandboxUsage.hours(turn_seconds),
+      included_turn_hours: plan.included_turn_hours,
+      allowance_used: allowance_used(turn_seconds, plan.included_turn_hours),
+      active_hours: SandboxUsage.hours(usage.active_seconds),
+      idle_hours: SandboxUsage.hours(usage.idle_seconds),
+      inboxes: channels.inboxes,
+      numbers: channels.numbers,
+      emails_sent: messages.emails_sent,
+      sms_sent: messages.sms_sent,
+      sms_received: messages.sms_received,
+      sandbox_cost_cents: sandbox_cost,
+      contact_cost_cents: contact_cost,
+      message_cost_cents: message_cost,
+      cost_cents: cost,
+      margin_cents: cost && revenue_cents - cost
+    }
+  end
+
+  # Turn seconds that spend a tenant's allowance: the providers Fountain pays
+  # for, so a tenant's own runner (ADR 0022) is excluded. The same filter
+  # `Billing.turn_hours_used/2` applies, and it has to be the same one — the
+  # allowance shown here and the allowance shown on the tenant's own billing
+  # page cannot come apart.
+  defp billable_turn_seconds(usage) do
+    usage.by_provider
+    |> Enum.filter(&SandboxUsage.platform_cost?(&1.provider))
+    |> Enum.map(& &1.busy)
+    |> Enum.sum()
+  end
+
+  defp allowance_used(_busy_seconds, 0), do: nil
+
+  defp allowance_used(busy_seconds, included),
+    do: Float.round(SandboxUsage.hours(busy_seconds) / included, 4)
+
+  ## ── pricing helpers ─────────────────────────────────────────────────────
+
+  # Which seconds a provider rate multiplies. The two row shapes in play name
+  # the same two numbers differently — `SandboxUsage.row()` has
+  # `active_seconds`/`busy_seconds`, the per-tenant fold has `active`/`busy` —
+  # so both are read here rather than at four call sites.
+  defp billed_seconds(%{active_seconds: active}, :active), do: active
+  defp billed_seconds(%{busy_seconds: busy}, :turn), do: busy
+  defp billed_seconds(%{active: active}, :active), do: active
+  defp billed_seconds(%{busy: busy}, :turn), do: busy
+
+  # `nil` for a provider the rate card does not name, and for one Fountain
+  # does not pay at all (a tenant's own runner, ADR 0022) — but zero for the
+  # runner rather than nil, because "we pay nothing for this" is a known
+  # price, not a missing one.
+  defp provider_cost_cents(seconds, provider, card) do
+    cond do
+      not SandboxUsage.platform_cost?(provider) -> 0
+      rate = Map.get(card.providers, provider) -> round(seconds / 3600 * rate)
+      true -> nil
+    end
+  end
+
+  # Monthly charges, pro-rated to the window. Zero units costs zero whether or
+  # not there is a rate — a tenant with no inbox is not unpriced.
+  defp contact_cost_cents(%{inboxes: 0, numbers: 0}, _card, _fraction), do: 0
+
+  defp contact_cost_cents(%{inboxes: inboxes, numbers: numbers}, card, fraction) do
+    add_or_nil([
+      monthly_cost(inboxes, card.inbox_month, fraction),
+      monthly_cost(numbers, card.number_month, fraction)
+    ])
+  end
+
+  defp monthly_cost(0, _cents, _fraction), do: 0
+  defp monthly_cost(_units, nil, _fraction), do: nil
+  defp monthly_cost(units, cents, fraction), do: round(units * cents * fraction)
+
+  defp message_cost_cents(%{emails_sent: 0, sms_sent: 0, sms_received: 0}, _card), do: 0
+
+  defp message_cost_cents(messages, card) do
+    add_or_nil([
+      per_message(messages.emails_sent, card.email),
+      per_message(messages.sms_sent + messages.sms_received, card.sms)
+    ])
+  end
+
+  defp per_message(0, _cents), do: 0
+  defp per_message(_count, nil), do: nil
+  defp per_message(count, cents), do: count * cents
+
+  # `nil` is contagious: a total missing one of its parts is not a total. It
+  # must not silently become the sum of the parts that happened to be priced.
+  defp add_or_nil(parts) do
+    if Enum.any?(parts, &is_nil/1), do: nil, else: Enum.sum(parts)
+  end
+
+  defp sum_or_nil(items, fun) do
+    items |> Enum.map(fun) |> add_or_nil()
+  end
+
+  ## ── the reads ───────────────────────────────────────────────────────────
+
+  # Every account that can carry a plan. Deleted accounts are gone; suspended
+  # ones are still subscribed and still cost money, so they stay.
+  defp paying_users do
+    Repo.all(
+      from u in User,
+        select: %{
+          id: u.id,
+          email: u.email,
+          plan: u.plan,
+          subscription_status: u.subscription_status
+        }
+    )
+  end
+
+  # The billable contact quantity per tenant — the same arithmetic
+  # `Billing.billable_contacts/1` does for the Stripe add-on item, in one
+  # query rather than one per row, so the panel's revenue line and the
+  # subscription item cannot disagree.
+  defp billable_contacts do
+    counts = Comms.contact_counts()
+
+    comped =
+      Repo.all(from u in User, where: u.comped_contacts > 0, select: {u.id, u.comped_contacts})
+      |> Map.new()
+
+    Map.new(counts, fn {user_id, count} ->
+      {user_id, max(count - Map.get(comped, user_id, 0), 0)}
+    end)
+  end
+
+  # Message counts per tenant for the period, one grouped query over the same
+  # `usage_events` table the sandbox counts come from.
+  defp message_counts(period_start, period_end) do
+    from(e in UsageEvent,
+      where:
+        e.inserted_at >= ^period_start and e.inserted_at < ^period_end and
+          e.event_type in @message_events and not is_nil(e.user_id),
+      group_by: [e.user_id, e.event_type],
+      select: {e.user_id, e.event_type, count(e.id)}
+    )
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn {user_id, type, count}, acc ->
+      counts = Map.get(acc, user_id, empty_messages())
+
+      Map.put(acc, user_id, %{
+        counts
+        | emails_sent: counts.emails_sent + if(type == "comms_email_sent", do: count, else: 0),
+          sms_sent: counts.sms_sent + if(type == "comms_sms_sent", do: count, else: 0),
+          sms_received: counts.sms_received + if(type == "comms_sms_received", do: count, else: 0)
+      })
+    end)
+  end
+
+  defp empty_messages, do: %{emails_sent: 0, sms_sent: 0, sms_received: 0}
+
+  defp empty_usage,
+    do: %{active_seconds: 0, busy_seconds: 0, idle_seconds: 0, by_provider: []}
+
+  @doc """
+  `SandboxUsage.attribution/3` rows folded per tenant, keeping the per-provider
+  split the totals were built from.
+
+  `SandboxUsage.by_user/1` collapses to `%{provider => active_seconds}`, which
+  loses both the busy/idle split and the ability to price a provider at its
+  own rate. Public because `/admin`'s user table wants the same fold for the
+  turn hours on each row.
+  """
+  @spec usage_by_user([SandboxUsage.row()]) :: %{optional(binary()) => map()}
+  def usage_by_user(rows) when is_list(rows) do
+    rows
+    |> Enum.reject(&is_nil(&1.user_id))
+    |> Enum.group_by(& &1.user_id)
+    |> Map.new(fn {user_id, group} ->
+      {user_id,
+       %{
+         active_seconds: group |> Enum.map(& &1.active_seconds) |> Enum.sum(),
+         busy_seconds: group |> Enum.map(& &1.busy_seconds) |> Enum.sum(),
+         idle_seconds: group |> Enum.map(& &1.idle_seconds) |> Enum.sum(),
+         by_provider:
+           Enum.map(
+             group,
+             &%{
+               provider: &1.provider,
+               active: &1.active_seconds,
+               busy: &1.busy_seconds,
+               idle: &1.idle_seconds
+             }
+           )
+       }}
+    end)
+  end
+
+  @doc """
+  How much of the period has actually elapsed, `0.0..1.0`.
+
+  Recurring monthly charges are pro-rated by this so a panel opened on the 3rd
+  reports three days of AgentMail rather than a month of it, and so the cost
+  column can be read against sandbox hours, which are only ever accrued
+  hours. A period entirely in the past is `1.0`.
+  """
+  @spec period_fraction(DateTime.t(), DateTime.t(), DateTime.t()) :: float()
+  def period_fraction(period_start, period_end, now) do
+    total = DateTime.diff(period_end, period_start, :second)
+    elapsed = DateTime.diff(now, period_start, :second)
+
+    cond do
+      total <= 0 -> 1.0
+      elapsed >= total -> 1.0
+      elapsed <= 0 -> 0.0
+      true -> elapsed / total
+    end
+  end
+end

--- a/ee/lib/fountain/billing/usage_event.ex
+++ b/ee/lib/fountain/billing/usage_event.ex
@@ -26,8 +26,12 @@ defmodule Fountain.Billing.UsageEvent do
     field :inserted_at, :utc_datetime
   end
 
+  # The closed vocabulary of things Fountain pays for. Sandbox lifecycle, and
+  # the teammate messages that carry a per-message provider charge on top of
+  # the monthly cost of an inbox or a number (`Fountain.Billing.Finance`).
   @valid_event_types ~w(sandbox_provisioned sandbox_provision_failed turn_started sandbox_terminated
-                         sandbox_suspended sandbox_resumed)
+                         sandbox_suspended sandbox_resumed
+                         comms_email_sent comms_sms_sent comms_sms_received)
 
   def changeset(usage_event, attrs) do
     usage_event

--- a/ee/lib/fountain_web/live/admin_finance_live.ex
+++ b/ee/lib/fountain_web/live/admin_finance_live.ex
@@ -435,7 +435,11 @@ defmodule FountainWeb.Live.AdminFinanceLive do
                     {t.subscription_status}
                   </span>
                 </td>
-                <td class="px-3 py-2 text-xs">{t.plan.name}</td>
+                <%!-- Both plans, when they differ: the trial's numbers are
+                      what the allowance column is measured against, and the
+                      tier is what converting would bill. Showing only one of
+                      them makes the other column look wrong. --%>
+                <td class="px-3 py-2 text-xs">{plan_label(t)}</td>
                 <td class="px-3 py-2 text-right tabular-nums text-xs">
                   {money(t.revenue_cents)}
                   <div :if={t.contact_revenue_cents > 0} class="text-zinc-400">
@@ -536,6 +540,11 @@ defmodule FountainWeb.Live.AdminFinanceLive do
 
   defp pluralize(1, singular, _plural), do: singular
   defp pluralize(_n, _singular, plural), do: plural
+
+  defp plan_label(%{plan: plan, effective_plan: plan}), do: plan.name
+
+  defp plan_label(%{plan: plan, effective_plan: effective}),
+    do: "#{effective.name} → #{plan.name}"
 
   defp basis_label(:active), do: "active hours"
   defp basis_label(:turn), do: "turn hours"

--- a/ee/lib/fountain_web/live/admin_finance_live.ex
+++ b/ee/lib/fountain_web/live/admin_finance_live.ex
@@ -1,0 +1,559 @@
+defmodule FountainWeb.Live.AdminFinanceLive do
+  @moduledoc """
+  `/admin/finance` — what Fountain is paid, what Fountain pays, and the gap,
+  per tenant.
+
+  `/admin` had both halves and never put them together: an MRR tile with no
+  cost beside it, and a sandbox-hours table with no money in it. Neither could
+  answer the only question an operator actually asks a finance page, which is
+  which accounts cost more than they bring in.
+
+  Three things this page is careful about, because each has a way of lying:
+
+    * **It shows no money it was not told.** The rate card
+      (`Fountain.Billing.Finance.rate_card/0`) is config, and an unpriced line
+      renders as `—`, never as `$0.00`. A deployment that has set nothing sees
+      hours, inboxes, numbers and message counts — a complete report in the
+      units it does know.
+    * **It does not assume which hours the provider bills.** Cost prices either
+      every hour a sandbox was awake or only the hours with a prompt in
+      flight, and the toggle switches between them. Which one is right is a
+      fact about the provider's invoice rather than about this codebase, so
+      the page offers both and labels the one it is on. Active hours and turn
+      hours sit on every row either way, because the gap between them is idle
+      time and that is the lever on the bill.
+    * **The window is one calendar month for everybody.** Per-tenant invoiced
+      periods each start on a different day, and a total over windows like
+      that is not a number that can be held next to a provider invoice. A
+      tenant's own invoiced period stays on their detail page.
+
+  Read-only. Every lever stays on `/admin` next to its confirmation.
+  """
+
+  use FountainWeb, :live_view
+
+  import FountainWeb.AdminLive.Helpers
+
+  alias Fountain.Billing
+  alias Fountain.Billing.Finance
+  alias Fountain.Billing.SandboxUsage
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Process.send_after(self(), :refresh, 30_000)
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Admin · Finance")
+     |> assign(:billing_enabled, Billing.enabled?())
+     |> assign(:months_ago, 0)
+     |> assign(:basis, Finance.default_basis())
+     |> assign_finance()}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    months_ago =
+      case params["months_ago"] do
+        raw when is_binary(raw) ->
+          case Integer.parse(raw) do
+            {n, ""} when n >= 0 and n <= 11 -> n
+            _ -> 0
+          end
+
+        _ ->
+          0
+      end
+
+    {:noreply,
+     socket
+     |> assign(:months_ago, months_ago)
+     |> assign(:basis, parse_basis(params["basis"]))
+     |> assign_finance()}
+  end
+
+  # Both names are honoured, because the toggle emits both: a link reading
+  # "active hours" has to select active even where the deployment default is
+  # turn. Anything else falls back to the default rather than to `:active`, so
+  # a mistyped URL does not quietly show a self-hoster the wrong basis.
+  defp parse_basis("turn"), do: :turn
+  defp parse_basis("active"), do: :active
+  defp parse_basis(_), do: Finance.default_basis()
+
+  @impl true
+  def handle_info(:refresh, socket) do
+    Process.send_after(self(), :refresh, 30_000)
+    {:noreply, assign_finance(socket)}
+  end
+
+  # Heavier than the /admin refresh (a full attribution pass plus four grouped
+  # queries), so it runs on 30s rather than 10s, and a closed month is not
+  # recomputed at all — nothing in it can change.
+  defp assign_finance(socket) do
+    assign(
+      socket,
+      :finance,
+      Finance.summary(
+        period: month_range(socket.assigns.months_ago),
+        basis: socket.assigns.basis
+      )
+    )
+  end
+
+  # `months_ago` back from the current month, as a whole UTC month. Zero is
+  # the running month, which is the default and the only one still moving.
+  defp month_range(0), do: Billing.current_month_range()
+
+  defp month_range(months_ago) do
+    now = DateTime.utc_now()
+    total = now.year * 12 + (now.month - 1) - months_ago
+    {year, month} = {div(total, 12), rem(total, 12) + 1}
+
+    start = %DateTime{
+      now
+      | year: year,
+        month: month,
+        day: 1,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        microsecond: {0, 0}
+    }
+
+    %DateTime{
+      start
+      | day: :calendar.last_day_of_the_month(year, month),
+        hour: 23,
+        minute: 59,
+        second: 59
+    }
+    |> then(&{start, &1})
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-8">
+      <div>
+        <.link navigate={~p"/admin"} class="text-xs text-zinc-500 hover:text-zinc-900 underline">
+          ← Admin
+        </.link>
+        <h1 class="text-2xl font-semibold mt-1">Finance</h1>
+        <p class="text-sm text-zinc-500 mt-1">
+          Revenue against platform spend, per tenant, for {Calendar.strftime(
+            @finance.period_start,
+            "%B %Y"
+          )}. {if @months_ago == 0,
+            do: "The month so far; refreshes every 30s.",
+            else: "A closed month."}
+        </p>
+        <div class="flex flex-wrap gap-2 mt-3">
+          <.link
+            :for={n <- 0..5}
+            patch={~p"/admin/finance?months_ago=#{n}&basis=#{@basis}"}
+            class={[
+              "rounded border px-2 py-1 text-xs",
+              if(@months_ago == n,
+                do: "bg-zinc-900 text-white border-zinc-900",
+                else: "bg-white text-zinc-600 border-zinc-200 hover:border-zinc-400"
+              )
+            ]}
+          >
+            {month_label(n)}
+          </.link>
+        </div>
+        <%!-- Which hours a provider rate multiplies is a fact about their
+              invoice, and the only way to settle it is to try both and see
+              which total lands. So it is a toggle, not a constant. --%>
+        <div class="flex flex-wrap items-center gap-2 mt-2 text-xs">
+          <span class="text-zinc-500">Charge sandbox hours as</span>
+          <.link
+            :for={b <- Finance.bases()}
+            patch={~p"/admin/finance?months_ago=#{@months_ago}&basis=#{b}"}
+            class={[
+              "rounded border px-2 py-1",
+              if(@basis == b,
+                do: "bg-zinc-900 text-white border-zinc-900",
+                else: "bg-white text-zinc-600 border-zinc-200 hover:border-zinc-400"
+              )
+            ]}
+          >
+            {basis_label(b)}
+          </.link>
+        </div>
+      </div>
+
+      <%!-- The whole page's honesty depends on this being visible when it
+            applies: without a rate card the cost columns are hours and units,
+            not dollars, and a reader who assumes otherwise reads every `—` as
+            a zero. --%>
+      <div
+        :if={not @finance.priced?}
+        class="bg-amber-50 border border-amber-200 rounded px-4 py-3 text-sm text-amber-900 space-y-1"
+      >
+        <div class="font-medium">No rate card is configured, so there is no cost in dollars.</div>
+        <div class="text-xs">
+          Hours, inboxes, numbers and messages below are real. Set <code>PROVIDER_HOURLY_CENTS</code>, <code>AGENTMAIL_INBOX_CENTS</code>, <code>AGENTPHONE_NUMBER_CENTS</code>,
+          <code>AGENTMAIL_MESSAGE_CENTS</code>
+          and <code>AGENTPHONE_MESSAGE_CENTS</code>
+          to price them. An unpriced line stays <code>—</code>; it never becomes $0.
+        </div>
+      </div>
+
+      <%!-- ── The three numbers, and the one that matters ── --%>
+      <section class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">MRR</div>
+          <div class="text-2xl font-semibold tabular-nums">
+            {money(@finance.revenue.mrr_cents)}
+          </div>
+          <div class="text-xs text-zinc-500">
+            active subscriptions, priced per plan
+          </div>
+        </div>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Platform cost</div>
+          <div class="text-2xl font-semibold tabular-nums">{money(total_cost(@finance))}</div>
+          <div class="text-xs text-zinc-500">
+            sandboxes · contacts · messages
+          </div>
+        </div>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Gross margin</div>
+          <div class={[
+            "text-2xl font-semibold tabular-nums",
+            negative?(gross_margin(@finance)) && "text-red-700"
+          ]}>
+            {money(gross_margin(@finance))}
+          </div>
+          <div class="text-xs text-zinc-500">
+            {margin_pct(@finance) || "no rate card"}
+          </div>
+        </div>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Turn hours used / sold</div>
+          <div class="text-2xl font-semibold tabular-nums">
+            {Float.round(@finance.turn_hours.used, 1)}
+            <span class="text-base text-zinc-400">/ {@finance.turn_hours.sold}</span>
+          </div>
+          <div class="text-xs text-zinc-500">
+            {if @finance.turn_hours.utilization,
+              do: "#{round(@finance.turn_hours.utilization * 100)}% of the allowance sold",
+              else: "nothing sold"}
+            <span :if={@finance.turn_hours.over_allowance > 0} class="text-amber-700">
+              · {@finance.turn_hours.over_allowance} over
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <%!-- ── Revenue ── --%>
+      <section :if={@billing_enabled} class="space-y-3">
+        <h2 class="text-lg font-medium">Revenue</h2>
+        <div :if={@finance.revenue.by_plan == []} class="text-sm text-zinc-500">
+          No active subscriptions.
+        </div>
+        <table
+          :if={@finance.revenue.by_plan != []}
+          class="w-full text-sm bg-white rounded shadow border border-zinc-200"
+        >
+          <thead class="text-left text-zinc-500 border-b border-zinc-200">
+            <tr>
+              <th class="px-4 py-2">Plan</th>
+              <th class="px-4 py-2 text-right">Accounts</th>
+              <th class="px-4 py-2 text-right">Plan MRR</th>
+              <th class="px-4 py-2 text-right">Contact add-on</th>
+              <th class="px-4 py-2 text-right">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={line <- @finance.revenue.by_plan} class="border-b border-zinc-100">
+              <td class="px-4 py-2">
+                {line.plan.name}
+                <span class="text-xs text-zinc-400">
+                  {Fountain.Plans.format_usd(line.plan.monthly_cents)}/mo · {line.plan.included_turn_hours}h
+                </span>
+              </td>
+              <td class="px-4 py-2 text-right tabular-nums">{line.accounts}</td>
+              <td class="px-4 py-2 text-right tabular-nums">{money(line.plan_cents)}</td>
+              <td class="px-4 py-2 text-right tabular-nums">{money(line.contact_cents)}</td>
+              <td class="px-4 py-2 text-right tabular-nums font-medium">
+                {money(line.plan_cents + line.contact_cents)}
+              </td>
+            </tr>
+          </tbody>
+          <tfoot class="border-t border-zinc-200 font-medium">
+            <tr>
+              <td class="px-4 py-2" colspan="4">MRR</td>
+              <td class="px-4 py-2 text-right tabular-nums">
+                {money(@finance.revenue.mrr_cents)}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <div class="text-xs text-zinc-500 space-x-3">
+          <span title="What past_due accounts would bill at their current plan — revenue that has not arrived.">
+            At risk (past_due):
+            <span class="tabular-nums">{money(@finance.revenue.at_risk_cents)}</span>
+          </span>
+          <span title="What trialing accounts will bill if they convert.">
+            · In trial: <span class="tabular-nums">{money(@finance.revenue.trialing_cents)}</span>
+          </span>
+          <span title="What comped accounts would bill — the size of the discount, and it is not revenue.">
+            · Comped: <span class="tabular-nums">{money(@finance.revenue.comped_cents)}</span>
+          </span>
+        </div>
+      </section>
+
+      <%!-- ── Cost ── --%>
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Cost</h2>
+        <div class="grid grid-cols-2 lg:grid-cols-3 gap-3">
+          <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+            <div class="text-xs text-zinc-500">Sandboxes</div>
+            <div class="text-xl font-semibold tabular-nums">
+              {money(@finance.cost.sandbox_cents)}
+            </div>
+            <div class="text-xs text-zinc-500 tabular-nums">
+              {format_hours(billed_hours(@finance))} {basis_label(@basis)}, on providers we pay
+            </div>
+            <div
+              :if={@basis == :active and @finance.cost.idle_hours > 0}
+              class="text-xs tabular-nums text-amber-700"
+            >
+              {format_hours(@finance.cost.idle_hours)} of it idle
+              <span :if={@finance.cost.idle_cents}>
+                — {money(@finance.cost.idle_cents)} a shorter timeout would remove
+              </span>
+            </div>
+            <div :if={@basis == :turn} class="text-xs text-zinc-400 tabular-nums">
+              {format_hours(@finance.cost.active_hours)} awake in total; the idle part is charged
+              at nothing on this basis
+            </div>
+          </div>
+          <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+            <div class="text-xs text-zinc-500">Contacts (AgentMail · AgentPhone)</div>
+            <div class="text-xl font-semibold tabular-nums">
+              {money(@finance.cost.contact_cents)}
+            </div>
+            <div class="text-xs text-zinc-500 tabular-nums">
+              {@finance.cost.inboxes} {pluralize(@finance.cost.inboxes, "inbox", "inboxes")} · {@finance.cost.numbers} {pluralize(
+                @finance.cost.numbers,
+                "number",
+                "numbers"
+              )}
+            </div>
+            <div class="text-xs text-zinc-400">
+              monthly, pro-rated to {round(@finance.period_fraction * 100)}% of the month
+            </div>
+          </div>
+          <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+            <div class="text-xs text-zinc-500">Messages</div>
+            <div class="text-xl font-semibold tabular-nums">
+              {money(@finance.cost.message_cents)}
+            </div>
+            <div class="text-xs text-zinc-500 tabular-nums">
+              {@finance.cost.emails_sent} email · {@finance.cost.sms_sent} SMS out · {@finance.cost.sms_received} SMS in
+            </div>
+            <div class="text-xs text-zinc-400">inbound counts — AgentPhone charges to receive</div>
+          </div>
+        </div>
+
+        <div :if={@finance.cost.by_provider != %{}} class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <div
+            :for={{provider, totals} <- Enum.sort(@finance.cost.by_provider)}
+            class="bg-white rounded shadow border border-zinc-200 px-4 py-3"
+          >
+            <div class="text-xs text-zinc-500">{provider}</div>
+            <div class="text-lg font-semibold tabular-nums">
+              {format_hours(SandboxUsage.hours(totals.active_seconds))}
+            </div>
+            <div class="text-xs text-zinc-500 tabular-nums">
+              {rate_label(@finance.rate_card, provider)}
+            </div>
+            <div :if={not SandboxUsage.platform_cost?(provider)} class="text-xs text-zinc-400">
+              tenant hardware, not our bill
+            </div>
+          </div>
+        </div>
+
+        <div :if={@finance.unattributed_cost_cents not in [nil, 0]} class="text-xs text-zinc-500">
+          {money(@finance.unattributed_cost_cents)} of that belongs to deleted accounts and is in
+          no tenant row below — spend nobody can be charged for.
+        </div>
+      </section>
+
+      <%!-- ── The row that matters ── --%>
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Per tenant ({length(@finance.tenants)})</h2>
+        <p class="text-xs text-zinc-500">
+          Worst margin first. <strong>Active hours</strong>
+          is what a provider charges for; <strong>turn hours</strong>
+          is the part with a prompt in flight, which is what the plan includes. The gap is idle time.
+        </p>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm bg-white rounded shadow border border-zinc-200">
+            <thead class="text-left text-zinc-500 border-b border-zinc-200">
+              <tr>
+                <th class="px-3 py-2">Account</th>
+                <th class="px-3 py-2">Plan</th>
+                <th class="px-3 py-2 text-right">Revenue</th>
+                <th
+                  class="px-3 py-2 text-right"
+                  title="Turn hours used against the plan's included hours"
+                >
+                  Turn h
+                </th>
+                <th
+                  class="px-3 py-2 text-right"
+                  title="Active sandbox hours — what providers charge for"
+                >
+                  Active h
+                </th>
+                <th class="px-3 py-2 text-right">Contacts</th>
+                <th class="px-3 py-2 text-right">Msgs</th>
+                <th class="px-3 py-2 text-right">Cost</th>
+                <th class="px-3 py-2 text-right">Margin</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :if={@finance.tenants == []}>
+                <td colspan="9" class="px-3 py-6 text-center text-sm text-zinc-500">No accounts.</td>
+              </tr>
+              <tr
+                :for={t <- @finance.tenants}
+                class="border-b border-zinc-100 last:border-0 hover:bg-zinc-50"
+              >
+                <td class="px-3 py-2 font-mono text-xs">
+                  <.link navigate={~p"/admin/users/#{t.user_id}"} class="hover:underline">
+                    {t.email}
+                  </.link>
+                  <span class={[
+                    "ml-1 inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium border",
+                    subscription_status_color(t.subscription_status)
+                  ]}>
+                    {t.subscription_status}
+                  </span>
+                </td>
+                <td class="px-3 py-2 text-xs">{t.plan.name}</td>
+                <td class="px-3 py-2 text-right tabular-nums text-xs">
+                  {money(t.revenue_cents)}
+                  <div :if={t.contact_revenue_cents > 0} class="text-zinc-400">
+                    incl. {money(t.contact_revenue_cents)} contacts
+                  </div>
+                </td>
+                <td class={[
+                  "px-3 py-2 text-right tabular-nums text-xs",
+                  t.allowance_used && t.allowance_used > 1.0 && "text-amber-700 font-medium"
+                ]}>
+                  {Float.round(t.turn_hours, 1)}
+                  <span class="text-zinc-400">/ {t.included_turn_hours}</span>
+                </td>
+                <td class="px-3 py-2 text-right tabular-nums text-xs">
+                  {Float.round(t.active_hours, 1)}
+                  <div :if={t.idle_hours > 0} class="text-zinc-400">
+                    {Float.round(t.idle_hours, 1)} idle
+                  </div>
+                </td>
+                <td class="px-3 py-2 text-right tabular-nums text-xs text-zinc-500">
+                  {contacts_cell(t)}
+                </td>
+                <td
+                  class="px-3 py-2 text-right tabular-nums text-xs text-zinc-500"
+                  title={"#{t.emails_sent} email · #{t.sms_sent} SMS out · #{t.sms_received} SMS in"}
+                >
+                  {t.emails_sent + t.sms_sent + t.sms_received}
+                </td>
+                <td class="px-3 py-2 text-right tabular-nums text-xs" title={cost_breakdown(t)}>
+                  {money(t.cost_cents)}
+                </td>
+                <td class={[
+                  "px-3 py-2 text-right tabular-nums text-xs font-medium",
+                  negative?(t.margin_cents) && "text-red-700"
+                ]}>
+                  {money(t.margin_cents)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+    """
+  end
+
+  ## ── formatting ────────────────────────────────────────────────────────────
+
+  # `nil` is "we were not told", and it must not render as a number. Every
+  # money cell on this page goes through here for that reason.
+  defp money(nil), do: "—"
+
+  defp money(cents) when is_integer(cents) do
+    sign = if cents < 0, do: "-", else: ""
+    abs = abs(cents)
+    "#{sign}$#{div(abs, 100)}.#{String.pad_leading(to_string(rem(abs, 100)), 2, "0")}"
+  end
+
+  defp negative?(cents), do: is_integer(cents) and cents < 0
+
+  defp total_cost(%{cost: cost}) do
+    [cost.sandbox_cents, cost.contact_cents, cost.message_cents]
+    |> then(fn parts -> if Enum.any?(parts, &is_nil/1), do: nil, else: Enum.sum(parts) end)
+  end
+
+  defp gross_margin(finance) do
+    case total_cost(finance) do
+      nil -> nil
+      cost -> finance.revenue.mrr_cents - cost
+    end
+  end
+
+  defp margin_pct(finance) do
+    mrr = finance.revenue.mrr_cents
+
+    case gross_margin(finance) do
+      nil -> nil
+      _ when mrr <= 0 -> "no revenue to divide"
+      margin -> "#{round(margin / mrr * 100)}% of MRR"
+    end
+  end
+
+  defp rate_label(card, provider) do
+    cond do
+      not SandboxUsage.platform_cost?(provider) -> "no cost to us"
+      cents = Map.get(card.providers, provider) -> "#{money(cents)}/hour"
+      true -> "no rate configured"
+    end
+  end
+
+  defp contacts_cell(%{inboxes: 0, numbers: 0}), do: "—"
+  defp contacts_cell(%{inboxes: n, numbers: n}), do: "#{n}✉ #{n}☎"
+  defp contacts_cell(%{inboxes: i, numbers: n}), do: "#{i}✉ #{n}☎"
+
+  defp cost_breakdown(t) do
+    "sandboxes #{money(t.sandbox_cost_cents)} · contacts #{money(t.contact_cost_cents)} · messages #{money(t.message_cost_cents)}"
+  end
+
+  defp pluralize(1, singular, _plural), do: singular
+  defp pluralize(_n, _singular, plural), do: plural
+
+  defp basis_label(:active), do: "active hours"
+  defp basis_label(:turn), do: "turn hours"
+
+  # The hours the reported cost was actually computed from, so the tile's
+  # subtitle cannot claim one basis while its number came from the other.
+  defp billed_hours(%{cost: cost, turn_hours: turn_hours}) do
+    case cost.basis do
+      :turn -> turn_hours.used
+      :active -> cost.active_hours
+    end
+  end
+
+  defp month_label(0), do: "This month"
+  defp month_label(1), do: "Last month"
+  defp month_label(n), do: "#{n} months ago"
+
+  defp format_hours(h) when h < 1, do: "#{round(h * 60)}m"
+  defp format_hours(h) when h < 48, do: "#{Float.round(h * 1.0, 1)}h"
+  defp format_hours(h), do: "#{Float.round(h / 24, 1)}d"
+end

--- a/ee/test/fountain/billing_finance_test.exs
+++ b/ee/test/fountain/billing_finance_test.exs
@@ -1,0 +1,623 @@
+defmodule Fountain.Billing.FinanceTest do
+  @moduledoc """
+  The finance panel's numbers: revenue per plan, cost per tenant, and the
+  margin between them.
+
+  Three properties carry the page, and each is tested against the way it would
+  otherwise lie:
+
+    * **`nil` is not zero.** An unpriced line has to stay unpriced all the way
+      to the total. A cost that silently drops the part nobody gave a rate for
+      reads as a cheap tenant.
+    * **Revenue is per plan.** The number this replaced charged every active
+      account the legacy price, which was invisible precisely because it was
+      still a plausible-looking dollar figure.
+    * **The cost basis changes the price and never the hours.** Which hours a
+      provider bills is a fact about their invoice, so the panel offers both;
+      a toggle whose arithmetic did not differ would be decoration.
+  """
+
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Accounts
+  alias Fountain.Billing
+  alias Fountain.Billing.Finance
+  alias Fountain.Conversations
+  alias Fountain.Plans
+
+  # Wholly in the past, so the attribution ceiling is the period end and every
+  # figure below is exact rather than a function of the wall clock.
+  @period_start ~U[2026-05-01 00:00:00Z]
+  @period_end ~U[2026-06-01 00:00:00Z]
+  @period {@period_start, @period_end}
+  # After the period, so `period_fraction/3` is a full month.
+  @now ~U[2026-06-02 00:00:00Z]
+
+  setup do
+    # async: false and an explicit reset: the rate card is application env,
+    # which is global. Every test states the card it wants.
+    original =
+      Map.new(
+        [
+          :provider_hourly_cents,
+          :agentmail_inbox_cents,
+          :agentphone_number_cents,
+          :agentmail_message_cents,
+          :agentphone_message_cents,
+          :cost_basis
+        ],
+        &{&1, Application.get_env(:fountain, &1)}
+      )
+
+    on_exit(fn ->
+      Enum.each(original, fn
+        {key, nil} -> Application.delete_env(:fountain, key)
+        {key, value} -> Application.put_env(:fountain, key, value)
+      end)
+    end)
+
+    Enum.each(original, fn {key, _} -> Application.delete_env(:fountain, key) end)
+    :ok
+  end
+
+  defp rate_card(opts) do
+    Enum.each(opts, fn {key, value} -> Application.put_env(:fountain, key, value) end)
+  end
+
+  defp subscriber(plan, status \\ "active") do
+    user = insert_verified_user()
+
+    {:ok, user} =
+      user
+      |> Ecto.Changeset.change(plan: plan, subscription_status: status)
+      |> Repo.update()
+
+    user
+  end
+
+  # A sandbox that ran for `hours`, with a prompt in flight for `busy_hours` of
+  # them. The rest is idle: real cost, no allowance spent.
+  defp ran(user, provider, hours, busy_hours) do
+    started = @period_start
+    ended = DateTime.add(started, hours * 3600, :second)
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        provider: provider,
+        status: "terminated",
+        inserted_at: started,
+        terminated_at: ended
+      )
+
+    if busy_hours > 0 do
+      agent = insert_agent(user_id: user.id)
+
+      conversation =
+        insert_conversation(user_id: user.id, agent_id: agent.id, sandbox: sandbox)
+
+      {:ok, _} =
+        Conversations._unsafe_create_turn(%{
+          conversation_id: conversation.id,
+          turn_number: System.unique_integer([:positive]),
+          prompt: "hello",
+          status: "completed",
+          started_at: started,
+          ended_at: DateTime.add(started, busy_hours * 3600, :second)
+        })
+    end
+
+    sandbox
+  end
+
+  defp summary, do: Finance.summary(period: @period, now: @now)
+
+  defp row_for(summary, user), do: Enum.find(summary.tenants, &(&1.user_id == user.id))
+
+  ## ── the rate card ─────────────────────────────────────────────────────────
+
+  describe "rate_card/0 and priced?/0" do
+    test "a deployment that has set nothing prices nothing" do
+      refute Finance.priced?()
+
+      assert %{providers: %{}, inbox_month: nil, number_month: nil, email: nil, sms: nil} =
+               Finance.rate_card()
+    end
+
+    test "one rate is enough to be priced" do
+      rate_card(agentmail_inbox_cents: 200)
+      assert Finance.priced?()
+    end
+
+    test "a negative or non-integer rate is no rate at all" do
+      rate_card(agentmail_inbox_cents: -1, agentphone_number_cents: "200")
+
+      assert %{inbox_month: nil, number_month: nil} = Finance.rate_card()
+    end
+
+    test "the default basis is active, and only an exact \"turn\" changes it" do
+      assert Finance.default_basis() == :active
+
+      Application.put_env(:fountain, :cost_basis, :turn)
+      assert Finance.default_basis() == :turn
+
+      # A typo must not quietly halve the reported bill.
+      Application.put_env(:fountain, :cost_basis, "Turn")
+      assert Finance.default_basis() == :active
+
+      Application.delete_env(:fountain, :cost_basis)
+    end
+  end
+
+  ## ── cost, and the nil that must not become a zero ─────────────────────────
+
+  describe "cost" do
+    test "sandbox cost is active hours at the provider's rate, idle included" do
+      rate_card(provider_hourly_cents: %{"sprites" => 100})
+      user = subscriber("solo")
+      ran(user, "sprites", 10, 2)
+
+      row = row_for(summary(), user)
+
+      # Ten hours awake, two of them working. The provider charges for ten.
+      assert row.active_hours == 10.0
+      assert row.turn_hours == 2.0
+      assert row.idle_hours == 8.0
+      assert row.sandbox_cost_cents == 1000
+    end
+
+    test "the turn basis charges only the hours with a prompt in flight" do
+      # Which of the two a provider actually bills is a fact about their
+      # invoice. The panel offers both so the totals can be compared against
+      # one; the arithmetic has to differ, or the toggle is decoration.
+      rate_card(provider_hourly_cents: %{"sprites" => 100})
+      user = subscriber("solo")
+      ran(user, "sprites", 10, 2)
+
+      active = Finance.summary(period: @period, now: @now, basis: :active) |> row_for(user)
+      turn = Finance.summary(period: @period, now: @now, basis: :turn) |> row_for(user)
+
+      assert active.sandbox_cost_cents == 1000
+      assert turn.sandbox_cost_cents == 200
+
+      # Both rows still report both hour figures whichever basis priced them.
+      assert turn.active_hours == 10.0
+      assert turn.turn_hours == 2.0
+    end
+
+    test "the turn basis reports no idle saving, because idle is already free" do
+      rate_card(provider_hourly_cents: %{"sprites" => 100})
+      user = subscriber("solo")
+      ran(user, "sprites", 10, 2)
+
+      assert Finance.summary(period: @period, now: @now, basis: :active).cost.idle_cents == 800
+      # Nothing for a shorter timeout to remove — claiming a saving here would
+      # be an invention.
+      assert Finance.summary(period: @period, now: @now, basis: :turn).cost.idle_cents == nil
+    end
+
+    test "the basis reaches the totals and says which one it was" do
+      rate_card(provider_hourly_cents: %{"sprites" => 100})
+      user = subscriber("solo")
+      ran(user, "sprites", 10, 2)
+
+      turn = Finance.summary(period: @period, now: @now, basis: :turn)
+
+      assert turn.cost.basis == :turn
+      assert turn.rate_card.basis == :turn
+      assert turn.cost.sandbox_cents == 200
+      # The hours themselves never change with the basis; only the price does.
+      assert turn.cost.active_hours == 10.0
+    end
+
+    test "an unattributable sandbox is priced on the same basis as the rest" do
+      rate_card(provider_hourly_cents: %{"sprites" => 100})
+      user = subscriber("solo")
+      ran(user, "sprites", 10, 2)
+      Repo.update_all(Fountain.Conversations.Sandbox, set: [user_id: nil])
+
+      assert Finance.summary(period: @period, now: @now, basis: :active).unattributed_cost_cents ==
+               1000
+
+      assert Finance.summary(period: @period, now: @now, basis: :turn).unattributed_cost_cents ==
+               200
+    end
+
+    test "a provider with no rate leaves the tenant's cost nil, not short" do
+      # The failure this guards: pricing sprites, saying nothing about e2b, and
+      # reporting a cost that quietly covers only half the hours.
+      rate_card(provider_hourly_cents: %{"sprites" => 100})
+      user = subscriber("solo")
+      ran(user, "sprites", 10, 10)
+      ran(user, "e2b", 10, 10)
+
+      row = row_for(summary(), user)
+
+      assert row.active_hours == 20.0
+      assert row.sandbox_cost_cents == nil
+      assert row.cost_cents == nil
+      assert row.margin_cents == nil
+    end
+
+    test "a tenant's own runner costs nothing, and needs no rate to say so" do
+      rate_card(provider_hourly_cents: %{"sprites" => 100})
+      user = subscriber("solo")
+      ran(user, "sprites", 1, 1)
+      ran(user, "runner", 100, 100)
+
+      row = row_for(summary(), user)
+
+      # The runner hours are real and reported...
+      assert row.active_hours == 101.0
+      # ...and priced at zero rather than dropping the whole row to nil:
+      # ADR 0022 says Fountain pays nothing for that machine.
+      assert row.sandbox_cost_cents == 100
+    end
+
+    test "runner turn hours do not count against the plan" do
+      user = subscriber("solo")
+      ran(user, "runner", 50, 50)
+
+      row = row_for(summary(), user)
+
+      assert row.active_hours == 50.0
+      assert row.turn_hours == 0.0
+    end
+
+    test "contacts are pro-rated to the window, and counted per channel" do
+      rate_card(agentmail_inbox_cents: 300, agentphone_number_cents: 500)
+      user = subscriber("solo")
+      contact(user, email: true, phone: true)
+      contact(user, email: true, phone: false)
+
+      row = row_for(summary(), user)
+
+      assert row.inboxes == 2
+      assert row.numbers == 1
+      # A full month elapsed, so no pro-rating: 2×300 + 1×500.
+      assert row.contact_cost_cents == 1100
+    end
+
+    test "half a period charges half a month of contacts" do
+      rate_card(agentmail_inbox_cents: 300, agentphone_number_cents: 500)
+      user = subscriber("solo")
+      contact(user, email: true, phone: true)
+
+      halfway = ~U[2026-05-16 12:00:00Z]
+      row = Finance.summary(period: @period, now: halfway) |> row_for(user)
+
+      assert_in_delta row.contact_cost_cents, 400, 5
+    end
+
+    test "no contacts costs zero even with no rate configured" do
+      user = subscriber("solo")
+
+      row = row_for(summary(), user)
+
+      # Nothing bought is a known price, not a missing one — otherwise every
+      # tenant on an unpriced-contacts deployment would have a nil cost.
+      assert row.contact_cost_cents == 0
+    end
+
+    test "messages are counted each way and priced apart" do
+      rate_card(agentmail_message_cents: 2, agentphone_message_cents: 10)
+      user = subscriber("solo")
+
+      message(user, "comms_email_sent", 3)
+      message(user, "comms_sms_sent", 2)
+      message(user, "comms_sms_received", 4)
+
+      row = row_for(summary(), user)
+
+      assert row.emails_sent == 3
+      assert row.sms_sent == 2
+      assert row.sms_received == 4
+      # 3×2 email, plus 6 SMS both directions at 10.
+      assert row.message_cost_cents == 66
+    end
+
+    test "messages outside the period are not this period's cost" do
+      rate_card(agentmail_message_cents: 2)
+      user = subscriber("solo")
+
+      message(user, "comms_email_sent", 1, ~U[2026-04-15 00:00:00Z])
+      message(user, "comms_email_sent", 1, ~U[2026-05-15 00:00:00Z])
+
+      assert row_for(summary(), user).emails_sent == 1
+    end
+
+    test "the three parts add up to the tenant's cost" do
+      rate_card(
+        provider_hourly_cents: %{"sprites" => 100},
+        agentmail_inbox_cents: 300,
+        agentphone_number_cents: 500,
+        agentmail_message_cents: 2
+      )
+
+      user = subscriber("solo")
+      ran(user, "sprites", 4, 1)
+      contact(user, email: true, phone: true)
+      message(user, "comms_email_sent", 5)
+
+      row = row_for(summary(), user)
+
+      assert row.sandbox_cost_cents == 400
+      assert row.contact_cost_cents == 800
+      assert row.message_cost_cents == 10
+      assert row.cost_cents == 1210
+    end
+  end
+
+  ## ── revenue ──────────────────────────────────────────────────────────────
+
+  describe "revenue" do
+    test "each active account is priced at its own plan, not one flat price" do
+      # The bug this replaced: `active × STRIPE_PRICE_MONTHLY_CENTS` billed the
+      # Scale account $29.
+      subscriber("solo")
+      subscriber("team")
+      subscriber("scale")
+
+      revenue = summary().revenue
+
+      assert revenue.mrr_cents ==
+               Plans.monthly_cents("solo") + Plans.monthly_cents("team") +
+                 Plans.monthly_cents("scale")
+
+      assert [%{plan: %{slug: "solo"}}, %{plan: %{slug: "team"}}, %{plan: %{slug: "scale"}}] =
+               revenue.by_plan
+    end
+
+    test "only active subscriptions are MRR" do
+      subscriber("scale", "trialing")
+      subscriber("scale", "past_due")
+      subscriber("scale", "comped")
+      subscriber("scale", "canceled")
+
+      revenue = summary().revenue
+
+      assert revenue.mrr_cents == 0
+      # ...but each cohort is reported at what it would bill, which is the
+      # number an operator actually wants from them.
+      assert revenue.trialing_cents == Plans.monthly_cents("scale")
+      assert revenue.at_risk_cents == Plans.monthly_cents("scale")
+      assert revenue.comped_cents == Plans.monthly_cents("scale")
+    end
+
+    test "the contact add-on is revenue, less what an operator comped" do
+      user = subscriber("team")
+      contact(user, email: true, phone: true)
+      contact(user, email: true, phone: true)
+      contact(user, email: true, phone: true)
+      {:ok, _} = Accounts.update_comped_contacts(user, 1, actor: "admin")
+
+      row = row_for(summary(), user)
+
+      assert row.contact_revenue_cents == 2 * Plans.contact_monthly_cents()
+      assert row.revenue_cents == Plans.monthly_cents("team") + row.contact_revenue_cents
+    end
+
+    test "comping more contacts than exist does not become negative revenue" do
+      user = subscriber("team")
+      contact(user, email: true, phone: true)
+      {:ok, _} = Accounts.update_comped_contacts(user, 5, actor: "admin")
+
+      assert row_for(summary(), user).contact_revenue_cents == 0
+    end
+
+    test "mrr/0 agrees with the full pass" do
+      # Two code paths to the same number is two chances to disagree, and a
+      # tile that contradicts the table below it destroys trust in both.
+      subscriber("solo")
+      subscriber("team")
+      user = subscriber("scale")
+      contact(user, email: true, phone: true)
+
+      assert Finance.mrr().mrr_cents == summary().revenue.mrr_cents
+    end
+
+    test "mrr/0 merges a null plan into the deployment default" do
+      # A row with no plan resolves to the default; so does an unknown slug.
+      # Rendered as two groups they would show the same tier twice.
+      user = insert_verified_user()
+
+      {:ok, _} =
+        user
+        |> Ecto.Changeset.change(plan: nil, subscription_status: "active")
+        |> Repo.update()
+
+      other = subscriber(Plans.default_slug())
+
+      assert other
+      assert [%{accounts: 2}] = Finance.mrr().by_plan
+    end
+  end
+
+  ## ── margin ───────────────────────────────────────────────────────────────
+
+  describe "margin" do
+    test "a tenant costing more than they pay shows negative, and sorts first" do
+      rate_card(provider_hourly_cents: %{"sprites" => 500})
+
+      cheap = subscriber("scale")
+      ran(cheap, "sprites", 1, 1)
+
+      expensive = subscriber("solo")
+      ran(expensive, "sprites", 100, 100)
+
+      summary = summary()
+
+      assert row_for(summary, expensive).margin_cents ==
+               Plans.monthly_cents("solo") - 50_000
+
+      assert row_for(summary, expensive).margin_cents < 0
+      assert row_for(summary, cheap).margin_cents > 0
+      assert hd(summary.tenants).user_id == expensive.id
+    end
+
+    test "with no rate card there is no margin, and rows sort by hours" do
+      quiet = subscriber("solo")
+      ran(quiet, "sprites", 1, 1)
+
+      busy = subscriber("solo")
+      ran(busy, "sprites", 40, 40)
+
+      summary = summary()
+
+      assert row_for(summary, busy).margin_cents == nil
+      assert hd(summary.tenants).user_id == busy.id
+    end
+  end
+
+  ## ── the totals ───────────────────────────────────────────────────────────
+
+  describe "summary/1" do
+    test "turn hours sold counts live accounts, used counts everybody" do
+      subscriber("solo")
+      trialing = subscriber("team", "trialing")
+      ran(trialing, "sprites", 5, 5)
+      cancelled = subscriber("scale", "canceled")
+      ran(cancelled, "sprites", 3, 3)
+
+      turn_hours = summary().turn_hours
+
+      # A trial hands over the same allowance and costs the same to serve; a
+      # cancelled account is no longer sold anything.
+      assert turn_hours.sold == 100 + 300
+      # ...but hours a cancelled account burned this period are still hours.
+      assert turn_hours.used == 8.0
+    end
+
+    test "an over-allowance tenant is counted" do
+      user = subscriber("solo")
+      ran(user, "sprites", 150, 150)
+
+      assert summary().turn_hours.over_allowance == 1
+      assert row_for(summary(), user).allowance_used > 1.0
+    end
+
+    test "spend by a deleted account stays in the total and out of the rows" do
+      rate_card(provider_hourly_cents: %{"sprites" => 100})
+      user = subscriber("solo")
+      ran(user, "sprites", 10, 10)
+
+      # Deletion nilifies the owner rather than dropping the row (0009); the
+      # platform still paid for those hours.
+      Repo.update_all(Fountain.Conversations.Sandbox, set: [user_id: nil])
+
+      summary = summary()
+
+      assert summary.tenants |> Enum.map(& &1.active_hours) |> Enum.sum() == 0.0
+      assert summary.cost.active_hours == 10.0
+      assert summary.unattributed_cost_cents == 1000
+    end
+
+    test "the cost total includes providers no tenant row could carry" do
+      rate_card(provider_hourly_cents: %{"sprites" => 100})
+      user = subscriber("solo")
+      ran(user, "sprites", 2, 2)
+
+      summary = summary()
+
+      assert summary.cost.sandbox_cents == 200
+      assert summary.cost.active_hours == 2.0
+      assert summary.cost.idle_hours == 0.0
+    end
+
+    test "period_fraction is bounded and a past period is whole" do
+      assert Finance.period_fraction(@period_start, @period_end, @now) == 1.0
+      assert Finance.period_fraction(@period_start, @period_end, ~U[2026-04-01 00:00:00Z]) == 0.0
+
+      assert_in_delta Finance.period_fraction(
+                        @period_start,
+                        @period_end,
+                        ~U[2026-05-16 12:00:00Z]
+                      ),
+                      0.5,
+                      0.01
+    end
+  end
+
+  ## ── the fold /admin shares ────────────────────────────────────────────────
+
+  describe "usage_by_user/1" do
+    test "keeps the busy/idle split by_user/1 collapses away" do
+      user = subscriber("solo")
+      ran(user, "sprites", 10, 3)
+
+      rows = Fountain.Billing.SandboxUsage.attribution(@period_start, @period_end, now: @now)
+      usage = Finance.usage_by_user(rows)
+
+      assert %{active_seconds: 36_000, busy_seconds: 10_800, idle_seconds: 25_200} =
+               usage[user.id]
+
+      assert [%{provider: "sprites", active: 36_000, busy: 10_800}] = usage[user.id].by_provider
+    end
+
+    test "drops the unattributable rows a user map has no key for" do
+      user = subscriber("solo")
+      ran(user, "sprites", 1, 1)
+      Repo.update_all(Fountain.Conversations.Sandbox, set: [user_id: nil])
+
+      rows = Fountain.Billing.SandboxUsage.attribution(@period_start, @period_end, now: @now)
+
+      assert Finance.usage_by_user(rows) == %{}
+    end
+  end
+
+  ## ── usage_summaries, which /admin's table reads ───────────────────────────
+
+  describe "Billing.usage_summaries/2 turn hours" do
+    test "reports turn hours beside sandbox minutes" do
+      user = subscriber("solo")
+      ran(user, "sprites", 10, 3)
+
+      summary = Billing.usage_summaries(@period_start, @period_end)[user.id]
+
+      assert summary.turn_hours == 3.0
+      assert summary.sandbox_minutes == 600.0
+    end
+
+    test "excludes runner hours from turn hours but not from sandbox minutes" do
+      user = subscriber("solo")
+      ran(user, "runner", 4, 4)
+
+      summary = Billing.usage_summaries(@period_start, @period_end)[user.id]
+
+      assert summary.turn_hours == 0.0
+      assert summary.sandbox_minutes == 240.0
+    end
+  end
+
+  ## ── helpers ──────────────────────────────────────────────────────────────
+
+  defp contact(user, opts) do
+    agent = insert_agent(user_id: user.id)
+    id = System.unique_integer([:positive])
+
+    %Fountain.Team.Contact{}
+    |> Fountain.Team.Contact.changeset(%{
+      user_id: user.id,
+      agent_id: agent.id,
+      email_address: if(opts[:email], do: "t#{id}@example.com"),
+      email_inbox_id: if(opts[:email], do: "inbox_#{id}"),
+      phone_number: if(opts[:phone], do: "+1555000#{rem(id, 10_000)}"),
+      phone_number_id: if(opts[:phone], do: "num_#{id}"),
+      prompt_from_number: "+15551234567"
+    })
+    |> Repo.insert!()
+  end
+
+  defp message(user, event_type, count, at \\ ~U[2026-05-10 00:00:00Z]) do
+    for _ <- 1..count do
+      %Fountain.Billing.UsageEvent{}
+      |> Fountain.Billing.UsageEvent.changeset(%{
+        user_id: user.id,
+        event_type: event_type,
+        resource_type: "team_contact",
+        inserted_at: at
+      })
+      |> Repo.insert!()
+    end
+  end
+end

--- a/ee/test/fountain/billing_finance_test.exs
+++ b/ee/test/fountain/billing_finance_test.exs
@@ -481,11 +481,30 @@ defmodule Fountain.Billing.FinanceTest do
 
       turn_hours = summary().turn_hours
 
-      # A trial hands over the same allowance and costs the same to serve; a
-      # cancelled account is no longer sold anything.
-      assert turn_hours.sold == 100 + 300
+      # The trialing account is sold the *trial's* 40, not the 300 of the tier
+      # it is trialling (#1022): hours it has not bought are not hours sold. A
+      # cancelled account is sold nothing at all.
+      assert turn_hours.sold == 100 + Plans.included_turn_hours("trial")
       # ...but hours a cancelled account burned this period are still hours.
       assert turn_hours.used == 8.0
+    end
+
+    test "a trialing account is measured against the trial's allowance (#1022)" do
+      # The specific trap the resolve/effective split exists for: 50 turn
+      # hours is comfortably inside Team's 300 and well over a trial's 40. Read
+      # through `resolve/1` this account looks fine; it is not.
+      user = subscriber("team", "trialing")
+      ran(user, "sprites", 50, 50)
+
+      row = row_for(summary(), user)
+
+      assert row.included_turn_hours == Plans.included_turn_hours("trial")
+      assert row.effective_plan.slug == "trial"
+      # `plan` stays the tier the trial converts into — that is what its
+      # revenue lines are priced at.
+      assert row.plan.slug == "team"
+      assert row.allowance_used > 1.0
+      assert summary().turn_hours.over_allowance == 1
     end
 
     test "an over-allowance tenant is counted" do

--- a/ee/test/fountain/billing_overview_test.exs
+++ b/ee/test/fountain/billing_overview_test.exs
@@ -9,6 +9,8 @@ defmodule Fountain.BillingOverviewTest do
     Repo.update!(Ecto.Changeset.change(user, [subscription_status: status] ++ extra))
   end
 
+  defp set_plan!(user, plan), do: Repo.update!(Ecto.Changeset.change(user, plan: plan))
+
   defp insert_stripe_event!(id, type, inserted_at) do
     Repo.insert_all("stripe_events", [
       %{id: id, type: type, inserted_at: DateTime.truncate(inserted_at, :second)}
@@ -75,19 +77,33 @@ defmodule Fountain.BillingOverviewTest do
   end
 
   describe "overview_admin/1 — MRR" do
-    test "active count times the configured price; comped and past_due excluded" do
-      set_status!(insert_verified_user(), "active")
-      set_status!(insert_verified_user(), "active")
-      set_status!(insert_verified_user(), "past_due")
-      set_status!(insert_verified_user(), "comped")
+    test "each active account at its own plan's price; comped and past_due excluded" do
+      set_plan!(set_status!(insert_verified_user(), "active"), "solo")
+      set_plan!(set_status!(insert_verified_user(), "active"), "scale")
+      set_plan!(set_status!(insert_verified_user(), "past_due"), "scale")
+      set_plan!(set_status!(insert_verified_user(), "comped"), "scale")
 
-      assert %{mrr_cents: 5800} = Billing.overview_admin(now: @now, price_cents: 2900)
+      expected = Fountain.Plans.monthly_cents("solo") + Fountain.Plans.monthly_cents("scale")
+
+      assert %{mrr_cents: ^expected} = Billing.overview_admin(now: @now)
     end
 
-    test "nil when no price is configured — no fabricated number" do
-      set_status!(insert_verified_user(), "active")
+    test "the tile carries the per-plan split behind it" do
+      set_plan!(set_status!(insert_verified_user(), "active"), "team")
+      set_plan!(set_status!(insert_verified_user(), "active"), "team")
 
-      assert %{mrr_cents: nil} = Billing.overview_admin(now: @now, price_cents: nil)
+      assert %{mrr_by_plan: [%{plan: %{slug: "team"}, accounts: 2}]} =
+               Billing.overview_admin(now: @now)
+    end
+
+    test "no active subscriptions is zero, not nil" do
+      set_status!(insert_verified_user(), "trialing")
+
+      # It used to be `nil` whenever `STRIPE_PRICE_MONTHLY_CENTS` was unset,
+      # because there was no way to price an account without it. The catalog
+      # holds every plan's price now, so an empty MRR is a fact rather than a
+      # missing configuration.
+      assert %{mrr_cents: 0} = Billing.overview_admin(now: @now)
     end
   end
 

--- a/ee/test/fountain/billing_test.exs
+++ b/ee/test/fountain/billing_test.exs
@@ -1008,14 +1008,18 @@ defmodule Fountain.BillingTest do
                conversations: 1,
                turns: 2,
                sandbox_minutes: 2.0,
-               sandbox_minutes_by_provider: %{"sprites" => 2.0}
+               sandbox_minutes_by_provider: %{"sprites" => 2.0},
+               # No turns overlapped the sandbox, so no allowance was spent —
+               # two minutes of cost against zero hours of work.
+               turn_hours: 0.0
              }
 
       assert summaries[b.id] == %{
                conversations: 0,
                turns: 1,
                sandbox_minutes: 0.0,
-               sandbox_minutes_by_provider: %{}
+               sandbox_minutes_by_provider: %{},
+               turn_hours: 0.0
              }
 
       refute Map.has_key?(summaries, quiet.id)

--- a/ee/test/fountain_web/admin_finance_live_test.exs
+++ b/ee/test/fountain_web/admin_finance_live_test.exs
@@ -1,0 +1,247 @@
+defmodule FountainWeb.AdminFinanceLiveTest do
+  @moduledoc """
+  `/admin/finance`.
+
+  The behaviour worth guarding is what the page does when it has *not* been
+  told what things cost. A finance page that renders `$0.00` over an unset
+  rate card is worse than one that renders nothing: it reads as a free tenant,
+  and it reads that way most convincingly on the accounts costing the most.
+  """
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Accounts
+  alias Fountain.Conversations
+  alias Fountain.Plans
+  alias Fountain.Repo
+
+  @rate_keys [
+    :provider_hourly_cents,
+    :agentmail_inbox_cents,
+    :agentphone_number_cents,
+    :agentmail_message_cents,
+    :agentphone_message_cents,
+    :cost_basis
+  ]
+
+  setup do
+    original = Map.new(@rate_keys, &{&1, Application.get_env(:fountain, &1)})
+
+    on_exit(fn ->
+      Enum.each(original, fn
+        {key, nil} -> Application.delete_env(:fountain, key)
+        {key, value} -> Application.put_env(:fountain, key, value)
+      end)
+    end)
+
+    Enum.each(@rate_keys, &Application.delete_env(:fountain, &1))
+    :ok
+  end
+
+  defp insert_admin do
+    {:ok, admin} = Accounts.update_user_role(insert_verified_user(), "admin")
+    admin
+  end
+
+  defp subscriber(plan) do
+    insert_verified_user()
+    |> Ecto.Changeset.change(plan: plan, subscription_status: "active")
+    |> Repo.update!()
+  end
+
+  # A sandbox in the current month, awake for `hours` with a prompt in flight
+  # for `busy_hours`. Anchored to the start of this month so the page's default
+  # window contains it whatever day the suite runs.
+  defp ran(user, hours, busy_hours) do
+    now = DateTime.utc_now()
+    started = %DateTime{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 0}}
+    ended = DateTime.add(started, hours * 3600, :second)
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        provider: "sprites",
+        status: "terminated",
+        inserted_at: started,
+        terminated_at: ended
+      )
+
+    if busy_hours > 0 do
+      agent = insert_agent(user_id: user.id)
+      conv = insert_conversation(user_id: user.id, agent_id: agent.id, sandbox: sandbox)
+
+      {:ok, _} =
+        Conversations._unsafe_create_turn(%{
+          conversation_id: conv.id,
+          turn_number: System.unique_integer([:positive]),
+          prompt: "hello",
+          status: "completed",
+          started_at: started,
+          ended_at: DateTime.add(started, busy_hours * 3600, :second)
+        })
+    end
+
+    sandbox
+  end
+
+  describe "access control" do
+    test "a regular user is pushed back to the dashboard", %{conn: conn} do
+      conn = login_user(conn, insert_verified_user())
+      assert {:error, {:live_redirect, _}} = live(conn, ~p"/admin/finance")
+    end
+
+    test "an anonymous visitor goes to login", %{conn: conn} do
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/admin/finance")
+      assert path =~ "/auth/login"
+    end
+  end
+
+  describe "with no rate card" do
+    test "says so, and shows no dollar cost at all", %{conn: conn} do
+      admin = insert_admin()
+      user = subscriber("solo")
+      ran(user, 10, 4)
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+
+      assert html =~ "No rate card is configured"
+      assert html =~ "PROVIDER_HOURLY_CENTS"
+      # Revenue is known regardless — it comes from the plan catalog.
+      assert html =~ Plans.format_usd(Plans.monthly_cents("solo"))
+      # ...and the hours are real even with nothing priced.
+      assert html =~ "10.0"
+      assert html =~ user.email
+    end
+  end
+
+  describe "with a rate card" do
+    test "prices the hours and shows the margin", %{conn: conn} do
+      Application.put_env(:fountain, :provider_hourly_cents, %{"sprites" => 100})
+
+      admin = insert_admin()
+      user = subscriber("solo")
+      ran(user, 10, 4)
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+
+      refute html =~ "No rate card is configured"
+      # Ten active hours at $1 — active, not the four turn hours: the provider
+      # charges for the idle six.
+      assert html =~ "$10.00"
+      assert html =~ "Gross margin"
+    end
+
+    test "a tenant costing more than they pay renders in red", %{conn: conn} do
+      Application.put_env(:fountain, :provider_hourly_cents, %{"sprites" => 500})
+
+      admin = insert_admin()
+      user = subscriber("solo")
+      ran(user, 100, 100)
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+
+      assert html =~ "text-red-700"
+      assert html =~ "-$471.00"
+      assert html =~ user.email
+    end
+  end
+
+  describe "the cost basis" do
+    test "the toggle reprices the same hours", %{conn: conn} do
+      Application.put_env(:fountain, :provider_hourly_cents, %{"sprites" => 100})
+
+      admin = insert_admin()
+      user = subscriber("solo")
+      ran(user, 10, 2)
+
+      conn = login_user(conn, admin)
+
+      {:ok, lv, html} = live(conn, ~p"/admin/finance")
+      assert html =~ "active hours"
+      # Ten awake hours at $1.
+      assert html =~ "$10.00"
+
+      html =
+        lv
+        |> element(~s{a[href="/admin/finance?months_ago=0&basis=turn"]})
+        |> render_click()
+
+      # The same two turn hours, now the thing being charged for.
+      assert html =~ "$2.00"
+      assert html =~ "turn hours"
+      assert html =~ "at nothing on this basis"
+    end
+
+    test "PROVIDER_COST_BASIS sets what the page opens on", %{conn: conn} do
+      Application.put_env(:fountain, :cost_basis, :turn)
+      Application.put_env(:fountain, :provider_hourly_cents, %{"sprites" => 100})
+
+      admin = insert_admin()
+      user = subscriber("solo")
+      ran(user, 10, 2)
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+
+      assert html =~ "$2.00"
+    end
+  end
+
+  describe "the window" do
+    test "defaults to this month and can look back", %{conn: conn} do
+      admin = insert_admin()
+      conn = login_user(conn, admin)
+
+      {:ok, lv, html} = live(conn, ~p"/admin/finance")
+      assert html =~ Calendar.strftime(DateTime.utc_now(), "%B %Y")
+      assert html =~ "The month so far"
+
+      html =
+        lv
+        |> element(~s{a[href="/admin/finance?months_ago=1&basis=active"]})
+        |> render_click()
+
+      assert html =~ "A closed month"
+    end
+
+    test "changing the month keeps the basis you chose", %{conn: conn} do
+      # Otherwise comparing two months on the turn basis silently switches one
+      # of them back to active, and the comparison is between two things.
+      Application.put_env(:fountain, :provider_hourly_cents, %{"sprites" => 100})
+      conn = login_user(conn, insert_admin())
+
+      {:ok, lv, _html} = live(conn, ~p"/admin/finance?basis=turn")
+
+      html =
+        lv
+        |> element(~s{a[href="/admin/finance?months_ago=1&basis=turn"]})
+        |> render_click()
+
+      assert html =~ "A closed month"
+      assert html =~ "turn hours"
+    end
+
+    test "a nonsense months_ago falls back to this month rather than erroring", %{conn: conn} do
+      conn = login_user(conn, insert_admin())
+
+      {:ok, _lv, html} = live(conn, ~p"/admin/finance?months_ago=nope")
+      assert html =~ "The month so far"
+
+      {:ok, _lv, html} = live(conn, ~p"/admin/finance?months_ago=999")
+      assert html =~ "The month so far"
+    end
+  end
+
+  describe "/admin" do
+    test "the MRR tile links here and is priced per plan", %{conn: conn} do
+      admin = insert_admin()
+      subscriber("scale")
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin")
+
+      assert html =~ "/admin/finance"
+      # $199, not the legacy $29 the tile used to charge everybody.
+      assert html =~ "$199.00/mo"
+    end
+  end
+end


### PR DESCRIPTION
Closes the gap #991 and #1020 left open: the plans and the turn-hour meter
exist, and nothing anywhere held them next to what a tenant actually costs.

## What this adds

`/admin/finance` — revenue, platform spend and the margin between them, one
row per tenant, worst margin first, with a month picker back through the last
six. Read-only; every lever stays on `/admin` next to its confirmation.

## The five things worth reviewing

**It reports no money it was not told.** Fountain's own costs are nowhere in
this codebase — provider prices are per-machine-size and negotiated, and
AgentMail/AgentPhone bill per unit and per message — so cost comes from a rate
card in config. Set none of it and the panel still works, in hours, inboxes,
numbers and message counts, with a banner saying so. An unpriced line renders
`—` and never `$0.00`, and **the nil propagates to the total**: a cost that
quietly omitted the provider nobody priced would read as a cheap tenant, most
convincingly on the expensive ones. `finance_test.exs` tests that
specifically, and reverting `add_or_nil/1` to a filtering sum fails two cases.

**It does not assume which hours a provider bills.** You said the bill tracks
turn hours more closely than sandbox hours, and whether that is true is a fact
about the invoice rather than about this code. So the rate multiplies either
one and a toggle switches between them (`PROVIDER_COST_BASIS` sets the
default). Both hour figures stay on every row either way, since the gap
between them is idle time and that is the lever. On the `:turn` basis the
"a shorter timeout would save this" line disappears rather than reporting a
saving that does not exist.

⚠️ **Nothing is priced until you set the rate card.** Nothing here changes
behavior for a self-hosted instance, which sets none of it.

**Teammate messages are metered, for the first time.** `comms_email_sent`,
`comms_sms_sent` and `comms_sms_received` join the usage-event vocabulary,
recorded at the two choke points a message already passes through — the MCP
controller's audit callback and `Team.Comms.Inbound` — rather than at each
send site. An inbox and a number are a monthly charge and a message is a
per-unit one, and only the first half was visible. Inbound counts, because
AgentPhone charges to receive. Best-effort by the same contract as every other
usage event; neither call can fail a send. `Comms.channel_counts/0` counts
inboxes and numbers apart, because the two providers charge apart and a
half-released contact must be billed for the half that still exists.

**The admin MRR tile was silently wrong, and this fixes it.** It was
`active × STRIPE_PRICE_MONTHLY_CENTS` — one amount for everybody. Its comment
said the day there was a second price would be loud; it was not. #991 shipped
four tiers and the tile went on charging every active account the legacy $29,
so a deployment selling Scale under-reported its own revenue sevenfold. It now
reads `Finance.mrr/0`, priced from the plan catalog with the contact add-on
added, and carries the per-plan split. `STRIPE_PRICE_MONTHLY_CENTS` is no
longer read there. A test asserts `mrr/0` and the full pass agree — a tile
that contradicts the table under it destroys trust in both.

**The dashboard shows turn hours, not sandbox time.** Sandbox wall-clock is
Fountain's cost signal and nothing a customer buys or is measured on; it went
up while they slept. The tile is now turn hours against the plan's included
hours, and the sandbox figure moved to the hint. The whole "this month"
section also moves to the window Stripe invoices where there is one, so the
dashboard and `/account/billing` can no longer report different numbers for
the same period; the heading says which window it is on. `/admin`'s per-user
usage column changes for the same reason, with the sandbox split kept in the
tooltip.

## One bug the tests caught

The per-tenant row counted turn hours on a tenant's own runner against their
allowance. `Billing.turn_hours_used/2` deliberately excludes it (ADR 0022 —
Fountain pays nothing for that machine), so the panel and the tenant's own
billing page would have disagreed about the same number. Test written first,
failed, fixed.

## What is deliberately not here

Per-tenant cost on `/admin/users/:id`. The finance table carries it and each
row links to the detail page; a second read path for one tenant is a second
chance to disagree.

No gate reads any of this. #1016 step 4 — the overage shape — was left open to
be decided against a cycle of real numbers, and this is the page that produces
them.

## Verification

- `mix test` — 3,846 tests, 6 doctests, 3 properties, **0 failures**
- `mix credo --strict` — no issues · `MIX_ENV=dev mix dialyzer` — 0 errors
- `mix format --check-formatted`, `mix sobelow --config`,
  `mix deps.unlock --unused` — clean
- `mix openapi.spec.json` + `jq empty` — valid (the API is unchanged; no field
  renamed or removed)
- `python3 scripts/docs-style.py` clean · `vale lint docs` 0 errors ·
  `okf validate decisions` valid
- `ConfigReferenceTest` caught `PROVIDER_COST_BASIS` before I documented it,
  which is the guardrail working

New tests: `billing_finance_test.exs` (35 — the rate card, nil propagation,
both cost bases, per-plan revenue, margin ordering, deleted-account spend),
`admin_finance_live_test.exs` (11 — access control, the unpriced state, the
toggle, the month window), plus `channel_counts/0`, comms metering at both
choke points, and the dashboard tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)