### PR TITLE
fix(pricing): the cap refuses the next sandbox, it does not queue it

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -217,7 +217,7 @@
           {plan_capacity(plan)}
         </p>
         <p class="mt-1 text-xs text-[var(--color-text-muted)]">
-          concurrent sandboxes. Queue as much work as you like behind them.
+          concurrent sandboxes. A start beyond the cap is refused until one frees.
         </p>
         <p class="mt-3 text-sm font-medium text-[var(--color-text-primary)]">
           {plan_turn_hours(plan)}
@@ -260,8 +260,9 @@
         <span class="text-[var(--color-text-secondary)]">
           Running at the concurrency cap does.
         </span>
-        A sandbox beyond it waits for a free slot rather than starting, so the
-        number to choose a plan on is how many agents you want working at once.
+        A sandbox beyond it is refused rather than queued, so the number to
+        choose a plan on is how many agents you want working at once. Terminate
+        a conversation, or upgrade.
       </p>
       <p>
         The 14-day trial runs {trial_plan().concurrent_sandboxes} agents at once

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -73,7 +73,21 @@ defmodule FountainWeb.MarketingPricingTest do
     assert body =~ "Going over the hours does not stop anything"
     assert body =~ "nothing extra is charged"
     assert body =~ "Running at the concurrency cap does"
-    assert body =~ "waits for a free slot"
+    assert body =~ "is refused rather than queued"
+  end
+
+  # #1026: the page promised a queue for a whole release, pinned by a test that
+  # asserted the sentence was present. There is no queue —
+  # `Quotas.check_sandbox_quota/2` refuses the next start, and
+  # `FallbackController` returns 429. A buyer picks a tier on this sentence, so
+  # the queue wording is asserted absent, not merely replaced.
+  test "the pricing table does not promise a queue behind the cap", %{conn: conn} do
+    price_all()
+
+    body = conn |> get(~p"/") |> html_response(200)
+
+    refute body =~ "waits for a free slot"
+    refute body =~ "Queue as much work"
   end
 
   # The trial's numbers are enforced from the catalog, so the page reads them

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -69,8 +69,8 @@ current state.
 
 The pricing page states this to a visitor, because a plan that lists 800 hours
 and then says nothing reads as a hard stop. The two limits behave differently.
-A tenant at the concurrency cap waits for a free slot. A tenant over the hours
-continues, and pays no more.
+Fountain refuses the next start for a tenant at the concurrency cap. A tenant
+over the hours continues, and pays no more.
 
 Four surfaces show the number. The pricing page shows it to a visitor. The
 billing page shows it to the tenant. The API reports it at


### PR DESCRIPTION
Closes #1026.

The pricing section told a buyer that work waits behind the concurrency cap. Nothing waits.

`Fountain.Quotas.check_sandbox_quota/2` returns `{:error, {:sandbox_quota_exceeded, %{count: n, limit: n}}}`, and `FountainWeb.FallbackController` turns that into a 429: *"You have {count} of {limit} concurrent sandboxes in use. Terminate a conversation before starting another."* There is no queue, no waiting slot and no retry.

That sentence sits on the one the page itself nominates as the one to decide on, so a developer who fans out six conversations on Solo meets a 4xx on their first day, on the promise they used to pick the tier.

## What changed

**`home.html.heex`**

- L220 — "Queue as much work as you like behind them." → "A start beyond the cap is refused until one frees."
- L263 — "waits for a free slot rather than starting" → "is refused rather than queued … Terminate a conversation, or upgrade."

**`docs/guides/operate/plans-and-prices.md` L72** — "A tenant at the concurrency cap waits for a free slot" → "Fountain refuses the next start for a tenant at the concurrency cap." L109 of the same file already said this correctly ("Fountain refuses the next one until the count falls below the new cap"); the two now agree. Active voice keeps the STE gate happy.

**`marketing_pricing_test.exs`** — this is the part worth reviewing. The old test asserted `body =~ "waits for a free slot"`, so a false claim read as verified when what was verified is that the sentence was on the page. It now asserts the refusal wording, and a second test asserts the queue wording is *absent* — a claim a buyer picks a tier on should not be able to drift back in silently.

## Why copy and not a queue

A queue is a legitimate feature and would make the original sentence true. It is different work, and it should not be what unblocks a launch. A refusal is also the better upgrade lever: a queue quietly removes the reason to move up a tier, since work still completes, just later.

The hours limit on the same page stays as it is. It states the limit, states that nothing is enforced today, and says the overage shape is undecided — the register this fix matches.

## Verification

- `mix test apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs` — 11 tests, 0 failures.
- Reverted the heex copy and re-ran: 2 failures, so both the positive assertion and the negative guard actually catch the regression.
- `mix format --check-formatted`, `mix credo --strict` on the changed files, `python3 scripts/docs-style.py` (clean, 80 files), `vale --config .vale-ste.yml` on the changed page (0 errors, 0 warnings; only non-gating Vocabulary suggestions), and both docs test files (36 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)