### PR TITLE
docs(analytics): say that the public pages are recorded, and state the masking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,6 +181,10 @@ EMAIL_FROM=noreply@fountain.example.com
 # library, which is the only thing that sees visitors who have no account yet:
 # sessions, referrers and devices. Set false to keep it off; the console never
 # loads it either way, and server capture is unaffected.
+#
+# Those pages are also SESSION RECORDED when replay is on in your PostHog
+# project — that switch is PostHog's, not Fountain's. All inputs are masked.
+# The console is never recorded; it loads no library.
 # POSTHOG_BROWSER_CAPTURE=true
 # Names this deployment as a PostHog group. Defaults to PHX_HOST.
 # POSTHOG_INSTANCE=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ upgrade, is in
 
 ### Added
 
+- **The public pages are session recorded, and now say so.** This started as a
+  side effect rather than a decision: session replay is switched on in the
+  PostHog *project*, and posthog-js records whenever it is, so loading the
+  library for visitor analytics turned replay on for the landing page, the
+  legal pages, the manual and the auth flow without anyone choosing it. Found
+  in production, kept on review — replay of the sign-up flow answers "where did
+  this funnel lose people" in a way a pageview count cannot — and written down,
+  because a capability nobody chose is one nobody maintains. The console is
+  still not recorded; it loads no library. The layout now states
+  `session_recording: { maskAllInputs: true }` rather than inheriting it, so
+  the masking is visible to a reader of the file and cannot change quietly when
+  a dependency's default does. It covers the email address on `/auth/login` and
+  `/auth/register`; passwords are masked by rrweb regardless. ADR 0028.
+
 - **The public pages report visitors.** Fountain's analytics were server-side
   only, and `capture/4` drops an event with no account attached — so the
   landing page, the legal pages, the manual and the whole auth flow sent

--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -29,6 +29,18 @@
       appears when an account does, which is the same rule the server-side
       capture keeps, and it is what stops the manual from becoming the
       project's largest cohort.
+
+      `session_recording` is stated rather than left to the default, because
+      the default is not ours to rely on: replay is switched on in the PostHog
+      *project*, so posthog-js starts recording on its own unless a page says
+      otherwise. A reader of this file should be able to see that these pages
+      are recorded without going and checking a project setting, and the
+      masking should not silently change when a dependency does.
+
+      Everything typed is masked. The public surface includes /auth/login and
+      /auth/register, so this is where someone types their email address and
+      their password. `maskAllInputs` covers the address; passwords are masked
+      by rrweb regardless.
     --%>
     <script
       :if={assigns[:web_analytics]}
@@ -59,7 +71,8 @@
         window.posthog.init(cfg.dataset.apiKey, {
           api_host: cfg.dataset.apiHost,
           defaults: "2025-05-24",
-          person_profiles: "identified_only"
+          person_profiles: "identified_only",
+          session_recording: { maskAllInputs: true }
         });
         window.posthog.register({ surface: "public" });
       });

--- a/apps/fountain/lib/fountain_web/plugs/web_analytics.ex
+++ b/apps/fountain/lib/fountain_web/plugs/web_analytics.ex
@@ -40,6 +40,21 @@ defmodule FountainWeb.Plugs.WebAnalytics do
   `surface: "console"` the hook sets, so the two halves stay separable in a
   project that now receives both.
 
+  ## These pages are recorded
+
+  Session replay is switched on in the PostHog project, and posthog-js records
+  whenever it is, so the public pages are replayed as well as counted. That
+  followed from loading the library rather than from a decision, and it is
+  worth saying plainly rather than leaving to a project setting: **a visitor to
+  the landing page, the manual or the auth flow has that visit recorded.**
+
+  The console is not recorded, because it loads no library.
+
+  All inputs are masked (`maskAllInputs`), which the layout states rather than
+  inherits. It matters most on `/auth/login` and `/auth/register` — the two
+  public pages with a form worth typing into — where it covers the email
+  address; passwords are masked by rrweb whatever this says.
+
   ## The CSP is widened here, not in the router
 
   `FountainWeb.Router`'s `@csp` names no PostHog origin, which keeps the

--- a/apps/fountain/test/fountain_web/plugs/web_analytics_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/web_analytics_test.exs
@@ -90,6 +90,25 @@ defmodule FountainWeb.Plugs.WebAnalyticsTest do
 
       assert html =~ ~s|register({ surface: "public" })|
     end
+
+    test "recording masks what people type, and says so rather than inheriting it", %{conn: conn} do
+      # Replay is on in the PostHog *project*, so posthog-js records these
+      # pages whether or not this file mentions it. Stating the masking is what
+      # keeps it from changing when a dependency's default does — and the
+      # public surface includes the two pages with a form worth typing into.
+      html = conn |> get(~p"/") |> html_response(200)
+
+      assert html =~ ~s|session_recording: { maskAllInputs: true }|
+    end
+
+    test "the auth pages, where people type, carry the same masking", %{conn: conn} do
+      for path <- [~p"/auth/login", ~p"/auth/register"] do
+        html = conn |> get(path) |> html_response(200)
+
+        assert html =~ ~s|session_recording: { maskAllInputs: true }|,
+               "#{path} is recorded without stating that inputs are masked"
+      end
+    end
   end
 
   describe "the console" do
@@ -101,6 +120,23 @@ defmodule FountainWeb.Plugs.WebAnalyticsTest do
       {:ok, _lv, html} = live(conn, ~p"/dashboard")
 
       refute snippet?(html)
+    end
+
+    test "the admin pages load no library, so nothing there is ever recorded", %{conn: conn} do
+      # The public pages are session recorded (ADR 0028). The console is not,
+      # because it loads no library — and that is the whole of the protection,
+      # so it is worth pinning where it matters most rather than trusting that
+      # nobody adds :public_analytics to a wider scope later. /admin/finance is
+      # a revenue page; /admin lists accounts.
+      {:ok, admin} = Fountain.Accounts.update_user_role(insert_verified_user(), "admin")
+      conn = login_user(conn, admin)
+
+      for path <- [~p"/admin", ~p"/admin/finance"] do
+        html = conn |> get(path) |> html_response(200)
+
+        refute snippet?(html), "#{path} rendered the analytics snippet"
+        refute html =~ "array.js", "#{path} loaded posthog-js"
+      end
     end
 
     test "the console's dead render loads neither the snippet nor the library", %{conn: conn} do

--- a/decisions/0028-web-analytics-and-api-usage.md
+++ b/decisions/0028-web-analytics-and-api-usage.md
@@ -132,6 +132,38 @@ attribute on its own, so the layout interpolates nothing into JavaScript and
 needs no `raw/1`. A template that concatenates config into a script body is an
 XSS surface that has to be argued about; one that does not is not.
 
+**The public pages are recorded, and that is now deliberate.** It did not
+start out that way: session replay is switched on in the PostHog *project*,
+and posthog-js records whenever it is, so loading the library turned replay on
+for the landing page, the legal pages, the manual and the auth flow without
+anyone deciding it. The behaviour was found in production, kept on review, and
+is written down here because a capability nobody chose is one nobody is
+maintaining.
+
+So, plainly: **a visitor to a public Fountain page has that visit recorded.**
+
+**No LiveView is recorded, and the admin pages least of all.** There is nothing
+to exclude, because exclusion is not the mechanism: the console scope never
+pipes through `:public_analytics`, so `@web_analytics` is unset, the layout's
+`:if` is false, and posthog-js is never fetched. No library means no recorder,
+on `/dashboard`, on `/admin`, and on `/admin/finance` — which lists accounts
+and revenue and is the page it would matter most on.
+
+That protection is a single routing fact, which is a thin thing to rest on, so
+it is pinned by tests that name `/admin` and `/admin/finance` directly. Adding
+`:public_analytics` to the console scope fails four of them. If a console page
+ever does need a client-side event, it goes through the server, not by loading
+the library on that surface.
+
+The layout states `session_recording: { maskAllInputs: true }` rather than
+relying on the default. Two reasons, neither of which is that the default is
+wrong (it is `true`): a reader should be able to see that these pages are
+recorded and how, without going to check a project setting; and masking should
+not change silently when a dependency's default does. It matters most on
+`/auth/login` and `/auth/register`, the two public pages with a form worth
+typing into, where it covers the email address. Passwords are masked by rrweb
+regardless.
+
 **`POSTHOG_BROWSER_CAPTURE=false`** keeps the library off the public pages and
 leaves server capture untouched. Loading a third-party script into a visitor's
 browser is a different decision from sending product events from a server, and
@@ -173,12 +205,32 @@ captured volume for API-heavy tenants. It is one event definition, and it is
 the only event in the project whose name is fixed while its meaning varies by
 property.
 
+Replay storage and retention now apply to Fountain's public traffic, which
+they did not before. Recordings count against the PostHog plan, and a page that
+is recorded is a page whose DOM leaves the building — masked, but present. If a
+future public page carries anything that should not be replayed, masking it is
+a per-page job (`ph-mask`, `ph-no-capture`) rather than something this decision
+covers.
+
+The trigger for replay is a **project setting**, not this code. Switching
+replay off in PostHog stops it with no deploy; switching it on for a second
+project would surprise a deployment that pointed at one. That is the honest
+seam: this repository chooses to *load the library*, and PostHog chooses what
+the library does.
+
 ## Alternatives considered
 
 - **A snippet on the console too.** It would give the console sessions and
   replay, and it would double every pageview unless the server-side hook were
   deleted at the same time. Out of scope by choice; if it is ever done, the
   hook goes with it.
+- **`disable_session_recording: true` on the public pages.** The alternative
+  once the recording was discovered, and the one that matched the original
+  scope, which had said nothing about replay. Rejected on review: replay of the
+  landing page and the sign-up flow answers "where did this funnel actually
+  lose people" in a way a pageview count cannot, and the pages carry nothing
+  private beyond what masking already covers. Writing it down beat switching it
+  off.
 - **Lifting `product_event?/2`'s refusal and letting route-named events
   through.** The original reasoning holds: 73 permanent event definitions per
   day, and PostHog never garbage-collects one.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -314,6 +314,23 @@ public pages have visitors who are not yet accounts.
 The browser library sends anonymous events. It makes no person profile for a
 reader. A person profile appears when an account appears.
 
+### PostHog records the public pages
+
+PostHog session replay makes a record of each visit to a public page. The
+record covers the home page, the legal pages, the manual and the sign-in flow.
+
+PostHog does not record the console. This includes the dashboard, the agent and
+vault pages, and the admin pages. The console loads no browser library, so
+there is no recorder on those pages.
+
+Fountain masks every input in the record. This matters on the sign-in and
+sign-up pages, where the mask hides the email address. PostHog masks a password
+field in all conditions.
+
+The switch for replay is a PostHog project setting, not a Fountain setting. To
+stop the records, turn replay off in your PostHog project. To stop the browser
+library and the records together, set `POSTHOG_BROWSER_CAPTURE` to `false`.
+
 Fountain joins the two halves at sign-in. It reads the anonymous id from the
 PostHog cookie, and it tells PostHog to merge that visitor into the account.
 The pages a person read before the account then belong to the account. Fountain
@@ -340,7 +357,7 @@ analytics failure cannot fail the operation it measures.
 | Variable | Default | Required | Effect |
 |---|---|---|---|
 | `POSTHOG_CAPTURE` | `true` | — | Set it to `false` to stop product events. Flag evaluation continues. |
-| `POSTHOG_BROWSER_CAPTURE` | `true` | — | Set it to `false` to keep the PostHog browser library off the public pages. Server capture continues. |
+| `POSTHOG_BROWSER_CAPTURE` | `true` | — | Set it to `false` to keep the PostHog browser library off the public pages. This also stops the session recordings. Server capture continues. |
 | `POSTHOG_PERSON_PII` | `true` | — | Set it to `false` to keep the account email out of PostHog. The person is then known by user id alone. |
 | `POSTHOG_INSTANCE` | `PHX_HOST` | — | The name of this deployment. Each event is a member of this PostHog group, so two deployments that report to one project stay apart. |
 


### PR DESCRIPTION
Follow-up to #1023, from a question that turned out to have an unwelcome answer.

## What happened

Session replay is switched on in the PostHog **project**, and posthog-js records
whenever it is. So #1023, which loaded the library on the public pages for
*visitor analytics*, also turned on **session recording** for the landing page,
the legal pages, the manual and the auth flow. Nobody decided that. ADR 0028
did not mention it, the docs did not mention it, and the CHANGELOG did not
mention it.

It was found in production by looking at a recording's `start_url`:

```
start_url: "https://fountain.inevitable.fyi/"
recording_duration: 878
```

## What this does

Kept on review rather than switched off — replay of the sign-up flow answers
"where did this funnel actually lose people" in a way a pageview count cannot,
and the pages carry nothing private that masking does not already cover. So
this writes it down. A capability nobody chose is one nobody maintains.

**The masking is now stated, not inherited.** The layout declares
`session_recording: { maskAllInputs: true }`. The posthog-js default is already
`true` (verified in the bundled recorder: `maskAllInputs:!0`,
`maskInputOptions:{password:!0}`), so **this changes no behaviour**. It changes
who can tell: a reader of the layout can now see that these pages are recorded
and how, without going to check a PostHog project setting, and the masking
cannot change quietly when a dependency's default does. It covers the email
address on `/auth/login` and `/auth/register`; passwords are masked by rrweb
regardless.

**ADR 0028, `docs/configuration.md`, `.env.example` and the CHANGELOG** now all
say plainly that a visitor to a public page has that visit recorded, and that
the trigger is a PostHog project setting rather than anything in this repo.

## No LiveView is recorded, and there is nothing to exclude

Worth stating because it is the obvious next worry, and because the answer is
structural rather than a filter: the console scope never pipes through
`:public_analytics`, so `@web_analytics` is unset, the layout's `:if` is false,
and posthog-js is **never fetched**. No library means no recorder — on
`/dashboard`, on `/admin`, and on `/admin/finance`, which lists accounts and
revenue and is the page it would matter most on.

That protection is a single routing fact, which is thin, so it is now pinned by
tests naming `/admin` and `/admin/finance` directly. I verified they bite:
adding `:public_analytics` to the console scope fails **four** tests (the two
new admin assertions, the dead-render guard, and the CSP guard). Router
restored afterwards; the diff touches no routing.

## Gate

`3927 tests, 0 failures` · `compile --warnings-as-errors` · `credo --strict`
clean · `sobelow` exit 0 · `docs-style.py`, `vale lint docs` and
`okf validate decisions` clean.

Two STE gate violations in the first draft of the docs prose (a passive "are
recorded", an `-ing` "recording") are fixed — `vale lint docs` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
