### PR TITLE
feat(finance): fill in the rate card, and let a rate be fractional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -254,7 +254,8 @@ STRIPE_PRICE_MONTHLY_CENTS=
 # Cents per active sandbox hour, per provider. A provider left out is unpriced,
 # and the tenants using it report no cost rather than a cost that omits it.
 # `runner` is never priced: it is the tenant's own machine (ADR 0022).
-# PROVIDER_HOURLY_CENTS=sprites=12,e2b=15,daytona=10
+# Fractional cents are allowed, and per-message rates usually need them.
+# PROVIDER_HOURLY_CENTS=sprites=10.76,e2b=5.45,daytona=5.45
 #
 # Which hours that rate multiplies: `active` (default, every hour the sandbox
 # was awake) or `turn` (only the hours with a prompt in flight). Use `turn`
@@ -266,9 +267,9 @@ STRIPE_PRICE_MONTHLY_CENTS=
 # shows; the message pair is charged per message, inbound SMS included, since
 # AgentPhone charges to receive.
 # AGENTMAIL_INBOX_CENTS=200
-# AGENTPHONE_NUMBER_CENTS=150
-# AGENTMAIL_MESSAGE_CENTS=1
-# AGENTPHONE_MESSAGE_CENTS=8
+# AGENTPHONE_NUMBER_CENTS=300
+# AGENTMAIL_MESSAGE_CENTS=0.2
+# AGENTPHONE_MESSAGE_CENTS=2
 
 # The plan an account with no plan of its own gets — every account on a
 # self-hosted instance. `scale` lifts the concurrency cap for everyone at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,36 @@ upgrade, is in
 
 ## [Unreleased]
 
+
+### Added
+
+- **The finance panel's rate card is filled in, and rates may be fractional.**
+  `/admin/finance` shipped reporting hours with no money in them until an
+  operator supplied prices (#1025). The published rates are now set:
+  `PROVIDER_COST_BASIS=turn`, `PROVIDER_HOURLY_CENTS`, and the AgentMail and
+  AgentPhone per-unit and per-message rates.
+
+  **The basis is the load-bearing choice.** Sprites sleeps a sandbox after 30
+  seconds of inactivity and bills "just the CPU hours, RAM hours and GB-hours
+  of storage you use while the Sprite is awake", so the billable unit is close
+  to turn time and not the sandbox's wall-clock lifetime.
+  `SandboxUsage.active_seconds` reports the latter — it subtracts only the
+  explicit suspend/resume of #665 and knows nothing about the provider's own
+  auto-sleep. Over one month those two read 1,908h against 16,659h, so the
+  basis is worth 9x and the rate is worth rather less.
+
+  Rates are fractional now because per-message rates are. AgentMail bills
+  about $0.002 an email; as a whole number of cents that is zero, and the
+  panel would have reported email as free however much of it an agent sent.
+  Each cost component still rounds to whole cents exactly once, at the end,
+  so 400 emails at 0.2c is 80c rather than 400 roundings of nothing.
+
+  One rate card prices every provider on one basis, which is right only while
+  the providers behave alike. `sprites` (asleep after 30s) and `e2b` (billed
+  until paused) do not, and a deployment with real traffic on both wants a
+  per-provider basis. It does not bite today: every hour on the bill is a
+  Sprites hour.
+
 ### Added
 
 - **The public pages report visitors.** Fountain's analytics were server-side

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -666,14 +666,20 @@ config :fountain, :stripe_price_monthly_cents, stripe_price_monthly_cents
 # rather than collapsing to zero — a cost of $0 and a cost nobody has told us
 # reads very differently next to revenue.
 #
-# PROVIDER_HOURLY_CENTS is cents per active sandbox hour, per provider:
-#   PROVIDER_HOURLY_CENTS="sprites=12,e2b=15,daytona=10"
+# PROVIDER_HOURLY_CENTS is cents per sandbox hour, per provider, and may be
+# fractional:
+#   PROVIDER_HOURLY_CENTS="sprites=10.76,e2b=5.45,daytona=5.45"
 # A provider absent from the list is unpriced. `runner` is never priced: it is
 # the tenant's own machine (ADR 0022) and costs Fountain nothing.
+# Cents, whole or fractional. Fractional is the normal case for a per-message
+# rate: AgentMail bills about $0.002 an email, which as a whole number of cents
+# is zero, and the panel would report email as free.
 parse_cents = fn var, raw ->
-  case Integer.parse(String.trim(raw)) do
+  trimmed = String.trim(raw)
+
+  case Float.parse(trimmed) do
     {cents, ""} when cents >= 0 -> cents
-    _ -> raise "#{var} must be a whole number of cents, got #{inspect(raw)}"
+    _ -> raise "#{var} must be a number of cents, 0 or more, got #{inspect(raw)}"
   end
 end
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,11 +123,11 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `STRIPE_CONTACT_PRICE_CENTS` | `500` | No. | The monthly price of one teammate contact, in cents. It is for display alone. |
 | `STRIPE_PRICE_MONTHLY_CENTS` | — | No. | The monthly price of the `legacy` plan, in cents, such as `2900`. It is for display alone. The admin MRR tile reads every other plan's price from the catalog. |
 | `DEFAULT_PLAN` | `solo` | No. | The plan for an account that has no plan of its own. On a self-hosted instance that is every account. Set `DEFAULT_PLAN=scale` to give every account the highest concurrency cap. |
-| `PROVIDER_HOURLY_CENTS` | — | No. | What you pay each sandbox provider, in cents per active hour, as `sprites=12,e2b=15`. A provider you leave out stays unpriced. |
+| `PROVIDER_HOURLY_CENTS` | — | No. | What you pay each sandbox provider, in cents per sandbox hour, as `sprites=10.76,e2b=5.45`. Rates can be fractional. A provider you leave out stays unpriced. |
 | `PROVIDER_COST_BASIS` | `active` | No. | Which hours the provider rate multiplies. An `active` counts every hour a sandbox was awake. A `turn` counts only the hours with a prompt in flight. Use `turn` where the provider drops to near-zero between prompts. |
 | `AGENTMAIL_INBOX_CENTS` | — | No. | What AgentMail charges for one inbox each month, in cents. |
 | `AGENTPHONE_NUMBER_CENTS` | — | No. | What AgentPhone charges for one number each month, in cents. |
-| `AGENTMAIL_MESSAGE_CENTS` | — | No. | What AgentMail charges for one email, in cents. |
+| `AGENTMAIL_MESSAGE_CENTS` | — | No. | What AgentMail charges for one email, in cents. Give the fraction, such as `0.2` for $2 per 1,000 emails. A whole number rounds this rate to zero. |
 | `AGENTPHONE_MESSAGE_CENTS` | — | No. | What AgentPhone charges for one SMS, in cents. Fountain counts an inbound message too, because AgentPhone charges for it. |
 
 <!-- vale STE.IngForms = YES -->
@@ -142,6 +142,9 @@ The rate variables are different from every other price here. They are what
 The admin finance panel at `/admin/finance` holds them next to your revenue,
 per tenant. The panel switches between the two hour bases per view. Compare
 both totals against a real invoice, then keep the basis that matches.
+
+Each rate can be fractional. Per-message rates usually are, and a whole number
+rounds them to zero.
 
 Set none of them and the panel still works. It shows hours, inboxes, numbers
 and message counts, and it shows `—` in each money column. A rate you do not

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -48,6 +48,18 @@ defmodule Fountain.Billing.Finance do
   | `:agentmail_message_cents` | `AGENTMAIL_MESSAGE_CENTS` | cents per email sent |
   | `:agentphone_message_cents` | `AGENTPHONE_MESSAGE_CENTS` | cents per SMS, each way |
 
+  **Every rate may be fractional.** Per-message rates in particular usually
+  are — AgentMail bills roughly $0.002 an email, which as a whole number of
+  cents is zero. Rates stay fractional through the arithmetic and each cost
+  component rounds to whole cents exactly once, at the end.
+
+  One rate card covers every provider, and it prices them all on the same
+  basis. That is right while the providers Fountain actually bills for behave
+  the same way, and `sprites` (asleep after 30s idle, billed awake) and `e2b`
+  (billed until paused) do not. Today it does not bite — every hour on the
+  bill is a Sprites hour — but a deployment with real traffic on both wants a
+  per-provider basis, not this.
+
   `nil` propagates: a tenant with sandbox hours on a provider that has no rate
   has `cost_cents: nil`, not a cost that silently omits them, and their margin
   is `nil` too. `priced?/0` says whether the card covers anything at all, so a
@@ -209,9 +221,13 @@ defmodule Fountain.Billing.Finance do
     end
   end
 
+  # Fractional cents are the normal case, not an edge one: AgentMail bills
+  # around $0.002 an email, so a whole-cent rate rounds it to zero and the
+  # panel reports email as free. Rates stay fractional through the
+  # arithmetic; each cost component rounds to whole cents once, at the end.
   defp rate(key) do
     case Application.get_env(:fountain, key) do
-      cents when is_integer(cents) and cents >= 0 -> cents
+      cents when is_number(cents) and cents >= 0 -> cents
       _ -> nil
     end
   end
@@ -626,10 +642,17 @@ defmodule Fountain.Billing.Finance do
   defp message_cost_cents(%{emails_sent: 0, sms_sent: 0, sms_received: 0}, _card), do: 0
 
   defp message_cost_cents(messages, card) do
-    add_or_nil([
+    # Rounded once from the total rather than per channel: at $0.002 an email,
+    # rounding each channel first turns 400 emails and 10 texts into `0 + 20`
+    # instead of `80 + 20`.
+    [
       per_message(messages.emails_sent, card.email),
+      # AgentPhone charges "$0.02/message (inbound and outbound)", so both
+      # directions are billed at the one rate.
       per_message(messages.sms_sent + messages.sms_received, card.sms)
-    ])
+    ]
+    |> add_or_nil()
+    |> then(&(&1 && round(&1)))
   end
 
   defp per_message(0, _cents), do: 0

--- a/ee/test/fountain/billing_finance_test.exs
+++ b/ee/test/fountain/billing_finance_test.exs
@@ -135,6 +135,15 @@ defmodule Fountain.Billing.FinanceTest do
       assert %{inbox_month: nil, number_month: nil} = Finance.rate_card()
     end
 
+    test "a fractional rate survives, because per-message rates are fractional" do
+      # AgentMail bills about $0.002 an email. Read as whole cents that is
+      # zero, and every deployment that priced email would report it as free.
+      rate_card(agentmail_message_cents: 0.2, provider_hourly_cents: %{"sprites" => 10.76})
+
+      assert %{email: 0.2, providers: %{"sprites" => 10.76}} = Finance.rate_card()
+      assert Finance.priced?()
+    end
+
     test "the default basis is active, and only an exact \"turn\" changes it" do
       assert Finance.default_basis() == :active
 
@@ -297,6 +306,30 @@ defmodule Fountain.Billing.FinanceTest do
       # Nothing bought is a known price, not a missing one — otherwise every
       # tenant on an unpriced-contacts deployment would have a nil cost.
       assert row.contact_cost_cents == 0
+    end
+
+    test "sub-cent email rates accumulate instead of rounding away" do
+      # 400 emails at 0.2c is $0.80, not $0. Rounding per channel first would
+      # make the email column zero however much mail an agent sent.
+      rate_card(agentmail_message_cents: 0.2, agentphone_message_cents: 2)
+      user = subscriber("solo")
+
+      message(user, "comms_email_sent", 400)
+      message(user, "comms_sms_sent", 10)
+
+      row = row_for(summary(), user)
+
+      # 400 x 0.2c = 80c, plus 10 texts at 2c = 20c.
+      assert row.message_cost_cents == 100
+    end
+
+    test "a fractional provider rate prices the hours it should" do
+      rate_card(provider_hourly_cents: %{"sprites" => 10.76})
+      user = subscriber("solo")
+      ran(user, "sprites", 100, 100)
+
+      # 100 hours at 10.76c, whichever basis — they are equal here.
+      assert row_for(summary(), user).sandbox_cost_cents == 1076
     end
 
     test "messages are counted each way and priced apart" do

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -141,6 +141,52 @@ spec:
             # catalog's amounts against Stripe — run it after any price change.
             - name: STRIPE_PRICE_MONTHLY_CENTS
               value: "2900"
+            # ── The finance panel's rate card (/admin/finance, #1025) ──
+            #
+            # What we PAY, which nothing else in the codebase knows. Not
+            # secrets: published list prices, and a wrong one shows a wrong
+            # number on one admin page rather than leaking anything.
+            #
+            # Sprites sleeps a sandbox after 30 seconds of inactivity and
+            # bills "just the CPU hours, RAM hours and GB-hours of storage you
+            # use while the Sprite is awake". So the billable unit is close to
+            # turn time, and NOT the sandbox's wall-clock lifetime, which
+            # `SandboxUsage.active_seconds` reports: that only subtracts the
+            # explicit suspend/resume of #665 and knows nothing about Sprites'
+            # own auto-sleep. In August those two read 1,908h against 16,659h
+            # — a 9x error in whichever direction you get this wrong.
+            - name: PROVIDER_COST_BASIS
+              value: turn
+            # Cents per hour, fractional. Sprites publishes $0.07/vCPU-hr and
+            # $0.04375/GB-hr; at the shape a Claude Code session actually runs
+            # (~30% of 2 vCPU, 1.5 GB) that blends to 10.76c/hr, which
+            # reproduces the widely-quoted ~$0.44 for a 4-hour session.
+            # Cross-check: 1,908 turn hours implies ~1,145 CPU-hrs and ~2,862
+            # RAM-hrs, inside the Champion tier ($200/mo, 1,800 + 7,200), and
+            # 1,908h x 10.76c = $205. Two routes, one number.
+            #
+            # e2b and daytona both publish $0.0504/vCPU-hr + $0.0162/GiB-hr,
+            # which blends to 5.45c/hr at the same shape. Neither has run an
+            # hour here; they are priced anyway because a provider with hours
+            # and no rate takes that whole tenant's cost to nil.
+            - name: PROVIDER_HOURLY_CENTS
+              value: sprites=10.76,e2b=5.45,daytona=5.45
+            # AgentPhone: "$3.00/month" a number, "$0.02/message (inbound and
+            # outbound)" — both directions, which is why inbound is metered.
+            - name: AGENTPHONE_NUMBER_CENTS
+              value: "300"
+            - name: AGENTPHONE_MESSAGE_CENTS
+              value: "2"
+            # AgentMail: Developer is $20/mo for 10 inboxes, so $2 an inbox.
+            # The per-email rate is the one number neither the pricing page nor
+            # the docs state; $2 per 1,000 emails is what the secondary
+            # write-ups agree on and what the plan tiers imply. Fractional
+            # cents exist for exactly this: 0.2c an email is zero as a whole
+            # number, and email would report as free.
+            - name: AGENTMAIL_INBOX_CENTS
+              value: "200"
+            - name: AGENTMAIL_MESSAGE_CENTS
+              value: "0.2"
             # Deliberate unverified accounts (operator tests) survive the
             # unverified-account pruner (#258).
             - name: UNVERIFIED_PRUNE_EXEMPT


### PR DESCRIPTION
Follows #1025, which shipped `/admin/finance` reporting hours with no money in
them until someone supplied prices. These are the published ones, looked up
and cross-checked.

## The basis is the load-bearing choice, not the rate

Sprites' own copy:

> They go to sleep after 30 seconds of inactivity, wake up quickly when needed
> and bill you for just the CPU hours, RAM hours and GB-hours of storage you
> use **while the Sprite is awake**.

So the billable unit is close to turn time, not the sandbox's wall-clock
lifetime — and `SandboxUsage.active_seconds` reports the latter. It subtracts
only the explicit suspend/resume of #665 and knows nothing about the
provider's own auto-sleep.

Read live from prod, August, sprites only:

| basis | hours | at 10.76c/hr |
|---|---:|---:|
| turn | 1,908 | **$205** |
| active | 16,659 | $1,793 |

`PROVIDER_COST_BASIS=turn`. Getting this wrong is a 9x error; getting the rate
wrong is a rounding one.

## Where 10.76c/hr comes from

Sprites publishes **$0.07/vCPU-hr** and **$0.04375/GB-hr**. At the shape a
coding session actually runs — ~30% of 2 vCPU, 1.5 GB — that blends to
$0.1076/hr, which reproduces the widely quoted **~$0.44 for a four-hour
session** to the cent.

Independent cross-check: 1,908 turn hours implies ~1,145 CPU-hrs and ~2,862
RAM-hrs, which sits inside Sprites' **Champion** tier ($200/mo for 1,800
CPU-hrs + 7,200 RAM-hrs) — and 1,908h × 10.76c = **$205**. Two routes, one
number.

`e2b` and `daytona` both publish $0.0504/vCPU-hr + $0.0162/GiB-hr, blending to
5.45c/hr at the same shape. Neither has run an hour here; they are priced
anyway, because **a provider with hours and no rate takes that whole tenant's
cost to `nil`** — the nil-propagation #1025 deliberately built.

## A bug in #1025: sub-cent rates rounded to zero

AgentMail bills about **$0.002 an email**. `AGENTMAIL_MESSAGE_CENTS` took whole
cents, so that read as `0` and the panel would have reported email as free
however much of it an agent sent. AgentPhone's 2c SMS happened to be fine,
which is exactly why this would have gone unnoticed.

Rates are fractional now, and each cost component rounds to whole cents
**once, at the end** — so 400 emails at 0.2c is 80c, not 400 roundings of
nothing. The config parser takes fractions and still rejects `-1`, `abc`,
`1.2.3` and `""`. **Verified by reverting to an integer rate, which fails two
tests.**

## One thing the lookup corrected

AgentPhone's docs say **"$0.02/message (inbound and outbound)"** — both
directions at one rate. So #1025 metering inbound SMS was right. A competitor
comparison page claiming AgentPhone doesn't bill inbound was wrong, and taking
it at face value would have under-reported SMS by half.

## Rates set

| | value | source |
|---|---|---|
| `PROVIDER_COST_BASIS` | `turn` | Sprites sleeps at 30s |
| `PROVIDER_HOURLY_CENTS` | `sprites=10.76,e2b=5.45,daytona=5.45` | published rates, blended |
| `AGENTPHONE_NUMBER_CENTS` | `300` | $3.00/month |
| `AGENTPHONE_MESSAGE_CENTS` | `2` | $0.02, each way |
| `AGENTMAIL_INBOX_CENTS` | `200` | $20/mo ÷ 10 inboxes |
| `AGENTMAIL_MESSAGE_CENTS` | `0.2` | $2 per 1,000 |

They go in `k8s/deployment.yaml` as plain env, not Infisical: published list
prices, and a wrong one shows a wrong number on one admin page rather than
leaking anything.

⚠️ **`AGENTMAIL_MESSAGE_CENTS` is the one soft number.** Neither AgentMail's
pricing page nor its docs state a per-email rate; $2/1,000 is what the
secondary write-ups agree on and what the plan tiers imply. Everything else is
quoted from a primary source.

## A limitation, written down rather than papered over

One rate card prices every provider on **one** basis. That holds only while the
providers behave alike, and `sprites` (asleep after 30s) and `e2b` (billed
until paused) do not. It does not bite today — every hour on the bill is a
Sprites hour — but a deployment with real traffic on both wants a per-provider
basis. Noted in the moduledoc and the changelog.

The panel's toggle still overrides the basis per view, so both totals can be
compared against a real invoice without a redeploy.

## Verification

- `mix test` — 3,928 tests, 6 doctests, 3 properties, **0 failures**
- `mix credo --strict` no issues · `mix dialyzer` 0 errors · `mix format` clean
- `vale lint docs` 0 errors · `python3 scripts/docs-style.py` clean
- The runtime parser checked against the exact manifest values, including the
  four malformed inputs it must still refuse
- `k8s/deployment.yaml` parses as YAML

Sources: [Sprites rates and sleep behaviour](https://simonwillison.net/2026/Jan/9/sprites-dev/) · [Sprites plan tiers](https://community.fly.io/t/more-sprites-plans/26857) · [AgentPhone usage docs](https://docs.agentphone.ai/usage) · [AgentMail pricing](https://www.agentmail.to/pricing) · [E2B](https://e2b.dev/docs/faq/calculate-sandbox-price) · [Daytona](https://www.daytona.io/pricing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)