### PR TITLE
docs(analytics): retract "a PostHog event definition is permanent"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Fixed
+
+- **ADR 0028 said a PostHog event definition is permanent. It is not.** The
+  claim came from ADR 0025 and was repeated without checking. Trying to act on
+  it is what disproved it: the nine request-line definitions `api.request`
+  retired stopped receiving events on 2026-08-22, and about a day later they
+  were gone from the project's taxonomy — a full listing returns 32
+  definitions with no request line among them, `?search=POST` returns zero,
+  and `?include_hidden=true` returns the same 32. The historical events remain
+  queryable; only the taxonomy entries went. The decision does not change and
+  neither does `product_event?/2` — 73 new names a day is still a taxonomy
+  nobody can read — but the cost is paid while those names exist rather than
+  forever, which is a weaker argument for the same conclusion. Corrected in
+  ADR 0028's new Correction section, in ADR 0025, in the `Fountain.Analytics`
+  and `FountainWeb.Plugs.Audit` docstrings, and in the configuration guide.
 
 ### Added
 
@@ -88,9 +103,9 @@ upgrade, is in
   audit trail held the data for all three. They now arrive as a single
   `api.request` event carrying `method`, `route`, `status` and `status_class`.
   One event name, with the route as a *property*: the original refusal was
-  about the event *name* (73 distinct request-line names in one day, each a
-  permanent PostHog event definition), and a property is where PostHog can
-  break down by a value the router bounds.
+  about the event *name* (73 distinct request-line names in one day, each its
+  own PostHog event definition in the taxonomy everyone reads), and a property
+  is where PostHog can break down by a value the router bounds.
 - **A finance panel at `/admin/finance`.** `/admin` had an MRR tile with no
   cost beside it and a sandbox-hours table with no money in it, so the only
   question an operator asks a finance page — which accounts cost more than

--- a/apps/fountain/lib/fountain/analytics.ex
+++ b/apps/fountain/lib/fountain/analytics.ex
@@ -317,8 +317,8 @@ defmodule Fountain.Analytics do
 
   What would be lost by keeping it is the event taxonomy. Those names embed
   resource ids: **73 distinct action names in one day**, every one of which
-  PostHog registers as its own event definition, permanently. A product
-  vocabulary has to be closed, and `@context_action` is that fence.
+  PostHog registers as its own event definition. A product vocabulary has to
+  be closed, and `@context_action` is that fence.
 
   ## A credential the system issued itself is not a product event
 
@@ -359,7 +359,9 @@ defmodule Fountain.Analytics do
   `product_event?/2` refuses these rows and gives the reason: their *names*
   are request lines, and one PostHog event definition per route — per uuid,
   before `FountainWeb.Plugs.Audit` started recording the pattern — is
-  unbounded cardinality in a project that never garbage-collects definitions.
+  unbounded cardinality in the one taxonomy every reader of the project
+  shares: the event picker, autocomplete, and anyone trying to learn the
+  vocabulary.
 
   That argument is about the name, and only the name. It was read as "API
   traffic does not belong in PostHog", which left the product with no answer
@@ -369,10 +371,16 @@ defmodule Fountain.Analytics do
 
   So the row still becomes an event; it becomes **one** event,
   `api.request`, with the route as a *property*. Cardinality moves from the
-  event definition, where it is permanent and unbounded, to a property value,
-  where PostHog is built to break down by it and the router bounds the set.
-  One name, one definition, and `route`, `method` and `status` are the three
-  breakdowns that answer all three questions.
+  event definition, which is shared, to a property value, where PostHog is
+  built to break down by it and the router bounds the set. One name, one
+  definition, and `route`, `method` and `status` are the three breakdowns that
+  answer all three questions.
+
+  ADR 0028's Correction section retracts a stronger claim this docstring and
+  ADR 0025 both used to make — that a definition is permanent, and that PostHog
+  never removes one. The retired request-line definitions left the taxonomy
+  about a day after their last event. The cost is paid while they exist, which
+  is reason enough; it is not paid forever.
 
   Returns `:error` for anything that is not a request line, which is every
   semantic context action.

--- a/apps/fountain/lib/fountain_web/plugs/audit.ex
+++ b/apps/fountain/lib/fountain_web/plugs/audit.ex
@@ -54,12 +54,13 @@ defmodule FountainWeb.Plugs.Audit do
   conversation, and the id is already in `resource_id` where a query can use
   it.
 
-  And `Fountain.Analytics` mirrors `action` straight through as the **PostHog
-  event name**. One event definition per uuid is unbounded cardinality in a
-  third-party project that never garbage-collects definitions — the Fountain
-  project had already grown `POST /api/conversations/<uuid>/read`,
-  `POST /api/team/<uuid>/messages` and `POST /api/mcp/team/<uuid>` as separate
-  events by the time anyone looked at the taxonomy.
+  And `Fountain.Analytics` derives the **PostHog event name** from `action`.
+  One event definition per uuid is unbounded cardinality in a taxonomy every
+  reader of the project shares — the Fountain project had already grown
+  `POST /api/conversations/<uuid>/read`, `POST /api/team/<uuid>/messages` and
+  `POST /api/mcp/team/<uuid>` as separate events by the time anyone looked at
+  it. (Those definitions have since aged out; ADR 0028's Correction retracts
+  the claim that they never would.)
 
   The route pattern is what both want. `Phoenix.Router.route_info/4` gives it
   exactly, from the same match the request already went through. When there is

--- a/decisions/0025-product-analytics-in-posthog.md
+++ b/decisions/0025-product-analytics-in-posthog.md
@@ -96,11 +96,16 @@ things a product stream must refuse. Of 2,160 audit rows in 24 hours:
 - **425 rows across 73 distinct names were the `:api` pipeline's request-log
   row** (ADR 0013 §4), named after the request line and carrying a resource id.
   PostHog registers each distinct name as its own event definition, so that is
-  73 new definitions per day, permanently. The semantic row for the same
-  mutation is already captured, so refusing it loses nothing.
+  73 new definitions per day. The semantic row for the same mutation is already
+  captured, so refusing it loses nothing.
   **Amended by ADR 0028**: the reasoning above is about the *name*, and was
   applied to the row. The row is now captured as one `api.request` event with
   the route as a property.
+  **Corrected by ADR 0028 (2026-08-23)**: this said "permanently", and that is
+  not true — the retired request-line definitions left the project's taxonomy
+  about a day after their events stopped. The cost of a name-per-route is paid
+  while it exists, by everyone who reads the taxonomy, which is enough to
+  refuse it; it is not paid forever. See ADR 0028's Correction section.
 
 `Fountain.Analytics.product_event?/2` is that filter: a closed dotted
 vocabulary, and `api_key.*` only from a human actor. It changes nothing about

--- a/decisions/0028-web-analytics-and-api-usage.md
+++ b/decisions/0028-web-analytics-and-api-usage.md
@@ -54,10 +54,10 @@ stop exactly this caused it.
 
 **API usage was refused wholesale.** ADR 0025 declined the `:api` pipeline's
 request-log rows, correctly, because their *names* are request lines and 73
-distinct names in one day is 73 permanent event definitions. That reasoning is
-about the name. It was applied to the row, which left "which endpoints does
-anyone call", "is the SDK erroring", and "did that release change API usage"
-with no answer, while the audit trail held the data for all three.
+distinct names in one day is 73 new event definitions. That reasoning is about
+the name. It was applied to the row, which left "which endpoints does anyone
+call", "is the SDK erroring", and "did that release change API usage" with no
+answer, while the audit trail held the data for all three.
 
 ## Decision
 
@@ -96,10 +96,10 @@ person lands on after signing in.
 
 **The `:api` request log becomes one event.** `api.request`, with `method`,
 `route`, `status` and `status_class` as properties. The cardinality moves from
-the event definition, where it is permanent and unbounded, to a property
-value, where PostHog is built to break down by it and the router bounds the
-set. `Fountain.Analytics.api_request/1` owns the classification, and the two
-classifiers are mutually exclusive by test.
+the event definition, where it is unbounded and shared by everything that reads
+the taxonomy, to a property value, where PostHog is built to break down by it
+and the router bounds the set. `Fountain.Analytics.api_request/1` owns the
+classification, and the two classifiers are mutually exclusive by test.
 
 A request refused before Fountain knows the account has no subject and is not
 captured. That preserves ADR 0025's rule that persons mean accounts, and it
@@ -232,8 +232,11 @@ the library does.
   private beyond what masking already covers. Writing it down beat switching it
   off.
 - **Lifting `product_event?/2`'s refusal and letting route-named events
-  through.** The original reasoning holds: 73 permanent event definitions per
-  day, and PostHog never garbage-collects one.
+  through.** The original reasoning holds, though **not for the reason first
+  given here** — see the correction below. 73 new event definitions a day is a
+  taxonomy nobody can read, an autocomplete nobody can use, and a
+  `read-data-schema` answer in which the real vocabulary is a minority of the
+  output. That is enough on its own.
 - **Answering API usage from Grafana instead.** The data is already there and
   this would have cost nothing. It splits one question across two tools: "did
   the accounts that signed up last week start using the API" needs the person,
@@ -248,3 +251,38 @@ the library does.
   PostHog's own issue tracker, and it would fix the symptom for every event at
   once. It is a project setting rather than a property of this deployment, so
   a second Fountain reporting into the same project would inherit it silently.
+
+## Correction (2026-08-23)
+
+This ADR was accepted saying that a PostHog event definition is **permanent**,
+and that "PostHog never garbage-collects one". That is not true, and the
+statement was inherited from ADR 0025 rather than checked.
+
+The nine request-line definitions this decision retired
+(`POST /api/conversations`, `POST /api/mcp/team/:conversation_id`, and the
+seven uuid-carrying names that predate the route-pattern fix) stopped receiving
+events at 2026-08-22T09:00Z. Roughly a day later they were **gone from the
+project's taxonomy**: a full listing of `/api/event_definitions/` returns 32
+definitions and none of them is a request line, `?search=POST` returns zero,
+and `?include_hidden=true` returns the same 32. The historical events are still
+queryable in `events`; only the taxonomy entries are absent.
+
+Whether PostHog prunes a definition once its event stops arriving, or whether
+the tool that first listed them reads distinct names out of event data rather
+than out of the definitions table, is not determinable from the API. Either
+way, "permanent" is unsupported.
+
+**The decision does not change**, and neither does `product_event?/2`. One
+bounded event name is still right, because the cost of 73 new names a day is
+paid while they exist and by everyone who reads the taxonomy — the event
+picker, autocomplete, `read-data-schema`, and anyone trying to learn the
+vocabulary. That cost is real and self-limiting rather than real and forever,
+which is a weaker argument for the same conclusion.
+
+What is worth carrying forward is the method: this was found by trying to act
+on the ADR's claim (cleaning up the definitions it said would accumulate) and
+discovering there was nothing to clean up. An ADR's justification is checkable,
+and this one had not been checked.
+
+ADR 0025 §"the request log is not a product event" carries the same
+"permanently" and inherits this correction.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,9 +283,9 @@ without a new call site.
 
 Each API write leaves a second audit row named after the request line. Fountain
 sends these rows as one event, `api.request`. The route is a property, not part
-of the name. A name per route makes a permanent event type per route, and
-PostHog never removes an event type. A property keeps the count of names at
-one, and PostHog can break down a property.
+of the name. A name per route makes an event type per route, and each event
+type fills the list that every person on the project reads. A property keeps
+the count of names at one, and PostHog can break down a property.
 
 The `api.request` event carries `method`, `route`, `status` and `status_class`.
 Together they answer which endpoints your callers use, and which of them fail.


### PR DESCRIPTION
ADR 0028 was accepted saying an event definition is **permanent**, and that
*"PostHog never garbage-collects one"*. Both are false. The claim came from ADR
0025 and I repeated it without checking.

## How it was found

By trying to act on it. The plan was to clean up the request-line definitions
the ADR said would accumulate — and there was nothing to clean up.

The nine names `api.request` retired stopped receiving events at
`2026-08-22T09:00Z`. About a day later they were gone from the project's
taxonomy. Three checks agree:

| Check | Result |
|---|---|
| Full listing of `/api/event_definitions/` | 32 definitions, **no request line among them** (matches the API's own `count`) |
| `?search=POST` | **0** |
| `?include_hidden=true` | the same 32 |

The historical events are still queryable in `events` — only the taxonomy
entries went.

Whether PostHog prunes a definition once its event stops arriving, or whether
the tool that first listed them reads distinct names out of event data rather
than out of the definitions table, is not determinable from the API. I have not
claimed a mechanism. Either way, "permanent" is unsupported.

## What does not change

**The decision, and `product_event?/2`.** One bounded event name is still
right. 73 new names a day is a taxonomy nobody can read, an autocomplete nobody
can use, and a `read-data-schema` answer in which the real vocabulary is a
minority of the output. That cost is real and self-limiting rather than real and
forever — a weaker argument for the same conclusion, which is worth stating
accurately in a document meant to constrain future work.

No behaviour changes. No test changes. `api.request` is untouched.

## Where it is corrected

- **ADR 0028** — a new `## Correction (2026-08-23)` section, plus the three
  places that said "permanent"
- **ADR 0025** — where the claim originated, marked corrected in place
- **`Fountain.Analytics`** — the `product_event?/2` and `api_request/1`
  docstrings
- **`FountainWeb.Plugs.Audit`** — the same claim, and while there it stops
  saying `Analytics` "mirrors `action` straight through as the PostHog event
  name", which stopped being true when `api.request` landed
- **`docs/configuration.md`** and the CHANGELOG

## Gate

`3931 tests, 0 failures` · `compile --warnings-as-errors` · `credo --strict`
clean · `docs-style.py`, `vale lint docs` and `okf validate decisions` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
