### PR TITLE
fix(finance): render a fractional rate instead of 500ing on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ upgrade, is in
 ## [Unreleased]
 
 
+
+### Fixed
+
+- **`/admin/finance` 500'd as soon as a rate card was configured.** #1029 made
+  rates fractional; `money/1` still matched only integers, and `rate_label/2`
+  passed it the raw rate. The page raised `FunctionClauseError` on
+  `money(5.45)` for every visit. It was invisible in CI because every test
+  used whole-number rates, and the one test that did use a fractional rate
+  exercised the arithmetic rather than the render — no test had ever rendered
+  the provider card with a rate set at all.
+
+  A rate is now shown in cents keeping its fraction (`10.76c/hour`), because
+  it is a rate and not a total: rounded to whole cents, 10.76 and 5.45 stop
+  being comparable and anything between 4.5 and 5.5 reads the same. `money/1`
+  also rounds a float rather than raising — every cost path already rounds
+  before display, but a cent of rounding is a better answer than a dead page.
+
 ### Added
 
 - **The finance panel's rate card is filled in, and rates may be fractional.**

--- a/ee/lib/fountain_web/live/admin_finance_live.ex
+++ b/ee/lib/fountain_web/live/admin_finance_live.ex
@@ -492,6 +492,14 @@ defmodule FountainWeb.Live.AdminFinanceLive do
   # money cell on this page goes through here for that reason.
   defp money(nil), do: "—"
 
+  # Rates are fractional cents (#1029) and a cost total is whole ones. Every
+  # cost path rounds before it gets here, but a float reaching this function
+  # must round rather than raise: a 500 on the finance page is a worse answer
+  # than a cent of rounding, and that is exactly what shipped — `rate_label/2`
+  # handed `money/1` a raw `10.76` and took the whole page down the moment a
+  # rate card was configured.
+  defp money(cents) when is_float(cents), do: money(round(cents))
+
   defp money(cents) when is_integer(cents) do
     sign = if cents < 0, do: "-", else: ""
     abs = abs(cents)
@@ -522,12 +530,24 @@ defmodule FountainWeb.Live.AdminFinanceLive do
     end
   end
 
+  # A rate is not a total, and rounding it to whole cents throws away the part
+  # that matters: 10.76c/hr and 5.45c/hr both render as "$0.11" and "$0.05"
+  # once, and as the same "$0.05" for anything between 4.5 and 5.5. Rates are
+  # shown in cents, with their fraction.
   defp rate_label(card, provider) do
     cond do
       not SandboxUsage.platform_cost?(provider) -> "no cost to us"
-      cents = Map.get(card.providers, provider) -> "#{money(cents)}/hour"
+      rate = Map.get(card.providers, provider) -> "#{trim_zeros(rate)}c/hour"
       true -> "no rate configured"
     end
+  end
+
+  # `10.76` renders as "10.76", `2.0` as "2" — a whole rate should not grow a
+  # decimal point just because the config parser returns a float.
+  defp trim_zeros(rate) when is_integer(rate), do: Integer.to_string(rate)
+
+  defp trim_zeros(rate) when is_float(rate) do
+    if rate == Float.round(rate), do: Integer.to_string(trunc(rate)), else: to_string(rate)
   end
 
   defp contacts_cell(%{inboxes: 0, numbers: 0}), do: "—"

--- a/ee/test/fountain_web/admin_finance_live_test.exs
+++ b/ee/test/fountain_web/admin_finance_live_test.exs
@@ -147,6 +147,46 @@ defmodule FountainWeb.AdminFinanceLiveTest do
     end
   end
 
+  describe "fractional rates" do
+    # The gap that took /admin/finance down in prod the moment a rate card was
+    # configured: every rate here was a whole number, and `money/1` only
+    # matched integers. The context tests covered fractional arithmetic; none
+    # of them *rendered* the provider card that shows the rate.
+    test "renders the provider card at the rates prod actually runs", %{conn: conn} do
+      Application.put_env(:fountain, :provider_hourly_cents, %{
+        "sprites" => 10.76,
+        "e2b" => 5.45,
+        "daytona" => 5.45
+      })
+
+      Application.put_env(:fountain, :agentmail_message_cents, 0.2)
+
+      admin = insert_admin()
+      user = subscriber("solo")
+      ran(user, 10, 4)
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+
+      # A rate is shown in cents keeping its fraction — rounded to whole cents
+      # 10.76 and 5.45 would both collapse and stop being comparable.
+      assert html =~ "10.76c/hour"
+      refute html =~ "no rate configured"
+    end
+
+    test "a whole fractional rate does not grow a decimal point", %{conn: conn} do
+      Application.put_env(:fountain, :provider_hourly_cents, %{"sprites" => 12.0})
+
+      admin = insert_admin()
+      user = subscriber("solo")
+      ran(user, 5, 5)
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+
+      assert html =~ "12c/hour"
+      refute html =~ "12.0c/hour"
+    end
+  end
+
   describe "the cost basis" do
     test "the toggle reprices the same hours", %{conn: conn} do
       Application.put_env(:fountain, :provider_hourly_cents, %{"sprites" => 100})


### PR DESCRIPTION
`/admin/finance` has been returning 500 on every visit since #1029 deployed.

```
** (FunctionClauseError) no function clause matching in
   FountainWeb.Live.AdminFinanceLive.money/1
   admin_finance_live.ex:493: money(5.45)
   admin_finance_live.ex:528: rate_label/2
   admin_finance_live.ex:372: anonymous fn/7 in render/1
```

#1029 made rates fractional. `money/1` still matched only `nil` and integers,
and `rate_label/2` passed it the raw rate.

## Why CI was green

Every test used whole-number rates (`%{"sprites" => 100}`). The one test I
added with a fractional rate checked the **arithmetic**, not the render — so
no test had ever rendered the provider card with a rate set at all. With no
rate card, `Map.get(card.providers, provider)` is `nil` and the branch returns
`"no rate configured"` without ever calling `money/1`. The entire failing path
was reachable only in a configured deployment, and only prod was configured.

Both new tests reproduce the exact prod exception when the fix is reverted.

## The fix

**A rate is not a total.** Rounded to whole cents, `10.76` and `5.45` stop
being comparable, and everything between 4.5 and 5.5 renders identically —
which defeats the point of having per-provider rates. Rates now render in
cents keeping the fraction: `10.76c/hour`. A whole rate still prints without a
decimal point, since the parser returns a float either way (`12.0` → `12c/hour`).

**`money/1` rounds a float rather than raising.** Every cost path already
rounds before display, so this clause should be unreachable. It exists because
a cent of rounding is a better failure than a dead page — which is exactly the
trade that just went the wrong way.

## Verification

- `mix test` — 3,933 tests, **0 failures**
- `mix credo --strict` no issues · `mix dialyzer` 0 errors · format clean
- **Reverted the fix: both new tests fail with the prod `FunctionClauseError`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)