### PR TITLE
fix(finance): stop reporting contact revenue nobody is charged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@ upgrade, is in
 
 ## [Unreleased]
 
+
+### Fixed
+
+- **The finance panel reported teammate-contact revenue nobody was charged.**
+  It priced every non-comped contact at `Plans.contact_monthly_cents/0`, which
+  returns $5 whether or not anything is configured to charge it. The actual
+  billing path, `sync_contact_addon/1`, has four guards in front of that
+  arithmetic — billing off, **no `STRIPE_PRICE_ID_CONTACT` on this
+  deployment**, a comped account, or an account with no Stripe subscription to
+  hang an item on — and any one of them means the invoice says zero.
+
+  The panel copied only the last step, and a comment claimed the two "cannot
+  disagree". They disagreed for every deployment that had not set the contact
+  price, which is the state a deployment stays in on purpose: setting that
+  variable puts a line item on the next invoice of every tenant already
+  holding contacts (#991). `/admin`'s MRR tile inherited the same error
+  through `Finance.mrr/0`.
+
+  Contact revenue is now what the add-on would actually bill. Where nothing
+  bills for contacts the panel says so out loud rather than showing a bare
+  `$0.00` beside a cost section still counting real inboxes and numbers —
+  which is the true and useful shape of it: those contacts cost money and earn
+  none.
+
 ### Fixed
 
 - **ADR 0028 said a PostHog event definition is permanent. It is not.** The

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -18,6 +18,16 @@ defmodule Fountain.Billing.Finance do
       `Plans.contact_monthly_cents/0` (#991), less the contacts an operator
       has comped.
 
+  Contact revenue is what `sync_contact_addon/1` would actually put on the
+  invoice, guards included — **not** the contact count times a price. Where a
+  deployment has no `STRIPE_PRICE_ID_CONTACT` (the state one stays in until an
+  operator deliberately leaves it, because setting it bills every existing
+  tenant on their next invoice) the add-on earns nothing, however many
+  contacts exist. `Plans.contact_monthly_cents/0` returns $5 regardless of
+  whether anything is configured to charge it, which is exactly how this panel
+  came to report revenue no invoice contained. The cost side still counts
+  every inbox and number, because Fountain pays for those either way.
+
   Only an `active` subscription contributes. A trialing account pays nothing
   yet and a comped one pays nothing by decision, so both count as zero
   revenue against real cost — which is the point of looking. `past_due` is
@@ -265,7 +275,7 @@ defmodule Fountain.Billing.Finance do
     usage = usage_by_user(rows)
     channels = Comms.channel_counts()
     messages = message_counts(period_start, period_end)
-    contacts = billable_contacts()
+    contacts = billable_contacts(users)
 
     tenants =
       users
@@ -422,23 +432,32 @@ defmodule Fountain.Billing.Finance do
 
   # Contact add-on revenue for active accounts only, grouped by the plan they
   # are on, so the per-plan table's two columns come from the same cohort.
+  #
+  # Empty on a deployment that does not bill contacts, which is what keeps the
+  # `/admin` MRR tile and this panel telling the same story: both read this,
+  # and both used to add $5 a contact against invoices charging nothing.
   defp active_contact_cents do
-    billable = billable_contacts()
-
-    plans =
+    users =
       Repo.all(
         from u in User,
           where: u.subscription_status in ^@paying,
-          select: {u.id, u.plan}
+          select: %{
+            id: u.id,
+            plan: u.plan,
+            subscription_status: u.subscription_status,
+            stripe_subscription_id: u.stripe_subscription_id
+          }
       )
 
-    Enum.reduce(plans, %{}, fn {user_id, slug}, acc ->
-      case Map.get(billable, user_id, 0) do
+    billable = billable_contacts(users)
+
+    Enum.reduce(users, %{}, fn user, acc ->
+      case Map.get(billable, user.id, 0) do
         0 ->
           acc
 
         count ->
-          key = Plans.resolve(slug).slug
+          key = Plans.resolve(user.plan).slug
           Map.update(acc, key, count, &(&1 + count))
       end
     end)
@@ -680,26 +699,68 @@ defmodule Fountain.Billing.Finance do
           id: u.id,
           email: u.email,
           plan: u.plan,
-          subscription_status: u.subscription_status
+          subscription_status: u.subscription_status,
+          # Not decoration: an account with no subscription has no item for
+          # the contact add-on to sit on, so `sync_contact_addon/1` bills it
+          # nothing however many contacts it holds.
+          stripe_subscription_id: u.stripe_subscription_id
         }
     )
   end
 
-  # The billable contact quantity per tenant — the same arithmetic
-  # `Billing.billable_contacts/1` does for the Stripe add-on item, in one
-  # query rather than one per row, so the panel's revenue line and the
-  # subscription item cannot disagree.
-  defp billable_contacts do
-    counts = Comms.contact_counts()
+  @doc """
+  Whether this deployment puts teammate contacts on an invoice at all.
 
-    comped =
-      Repo.all(from u in User, where: u.comped_contacts > 0, select: {u.id, u.comped_contacts})
-      |> Map.new()
+  False when billing is off, and false when `STRIPE_PRICE_ID_CONTACT` is
+  unset — which is the state a deployment stays in until an operator
+  deliberately leaves it, because setting that variable adds a line item to
+  the next invoice of every tenant who already holds contacts (#991).
 
-    Map.new(counts, fn {user_id, count} ->
-      {user_id, max(count - Map.get(comped, user_id, 0), 0)}
-    end)
+  While it is false the contacts are real, they cost Fountain real money, and
+  they earn nothing. That is a fact worth seeing rather than a zero to hide,
+  so the panel says it out loud.
+  """
+  @spec contacts_billed?() :: boolean()
+  def contacts_billed?, do: Billing.enabled?() and not is_nil(Plans.contact_price_id())
+
+  # The billable contact quantity per tenant: what `sync_contact_addon/1`
+  # would actually set the Stripe item to, in one query rather than one per
+  # row.
+  #
+  # It is not enough to copy `billable_contacts/1`'s subtraction, which is
+  # what this did and why the panel invented revenue. That function is the
+  # *last* step of `sync_contact_addon/1`, behind four guards that each mean
+  # "nothing is billed": billing off, no contact price on this deployment, a
+  # comped account, or an account with no Stripe subscription to hang an item
+  # on. Prod sits behind the second of those, so every contact was reported at
+  # $5 a month against invoices that charge nothing for them.
+  defp billable_contacts(users) do
+    if contacts_billed?() do
+      counts = Comms.contact_counts()
+
+      comped =
+        Repo.all(from u in User, where: u.comped_contacts > 0, select: {u.id, u.comped_contacts})
+        |> Map.new()
+
+      billable =
+        Map.new(users, fn user ->
+          {user.id, user.subscription_status != "comped" and subscribed?(user)}
+        end)
+
+      Map.new(counts, fn {user_id, count} ->
+        if Map.get(billable, user_id, false) do
+          {user_id, max(count - Map.get(comped, user_id, 0), 0)}
+        else
+          {user_id, 0}
+        end
+      end)
+    else
+      %{}
+    end
   end
+
+  defp subscribed?(%{stripe_subscription_id: id}), do: id not in [nil, ""]
+  defp subscribed?(_), do: false
 
   # Message counts per tenant for the period, one grouped query over the same
   # `usage_events` table the sandbox counts come from.

--- a/ee/lib/fountain_web/live/admin_finance_live.ex
+++ b/ee/lib/fountain_web/live/admin_finance_live.ex
@@ -46,6 +46,7 @@ defmodule FountainWeb.Live.AdminFinanceLive do
      socket
      |> assign(:page_title, "Admin · Finance")
      |> assign(:billing_enabled, Billing.enabled?())
+     |> assign(:contacts_billed?, Finance.contacts_billed?())
      |> assign(:months_ago, 0)
      |> assign(:basis, Finance.default_basis())
      |> assign_finance()}
@@ -291,6 +292,21 @@ defmodule FountainWeb.Live.AdminFinanceLive do
             </tr>
           </tfoot>
         </table>
+        <%!-- A bare $0.00 in the add-on column next to a page that also
+              reports real inboxes and numbers reads as "nobody has contacts".
+              It usually means the opposite: they have them and nothing bills
+              for them. --%>
+        <div
+          :if={not @contacts_billed?}
+          class="bg-amber-50 border border-amber-200 rounded px-4 py-3 text-xs text-amber-900"
+        >
+          <span class="font-medium">Teammate contacts are not billed on this deployment.</span>
+          The add-on column is $0 by configuration, not because nobody holds one — the cost
+          section below still counts every inbox and number, because we pay for those either way.
+          Set <code>STRIPE_PRICE_ID_CONTACT</code>
+          to start charging. It puts a line item on the next invoice of every tenant who already
+          holds contacts, so tell them first.
+        </div>
         <div class="text-xs text-zinc-500 space-x-3">
           <span title="What past_due accounts would bill at their current plan — revenue that has not arrived.">
             At risk (past_due):

--- a/ee/test/fountain/billing_finance_test.exs
+++ b/ee/test/fountain/billing_finance_test.exs
@@ -69,10 +69,23 @@ defmodule Fountain.Billing.FinanceTest do
 
     {:ok, user} =
       user
-      |> Ecto.Changeset.change(plan: plan, subscription_status: status)
+      |> Ecto.Changeset.change(
+        plan: plan,
+        subscription_status: status,
+        # A real subscription: the contact add-on needs an item to sit on, and
+        # `sync_contact_addon/1` bills nothing without one.
+        stripe_subscription_id: "sub_#{System.unique_integer([:positive])}"
+      )
       |> Repo.update()
 
     user
+  end
+
+  # Turn on contact billing for a test. Off by default, which is both the
+  # shipped default and prod's actual state.
+  defp bill_contacts! do
+    Application.put_env(:fountain, :stripe_price_ids, %{"contact" => "price_contact_test"})
+    on_exit(fn -> Application.delete_env(:fountain, :stripe_price_ids) end)
   end
 
   # A sandbox that ran for `hours`, with a prompt in flight for `busy_hours` of
@@ -418,6 +431,7 @@ defmodule Fountain.Billing.FinanceTest do
     end
 
     test "the contact add-on is revenue, less what an operator comped" do
+      bill_contacts!()
       user = subscriber("team")
       contact(user, email: true, phone: true)
       contact(user, email: true, phone: true)
@@ -431,6 +445,7 @@ defmodule Fountain.Billing.FinanceTest do
     end
 
     test "comping more contacts than exist does not become negative revenue" do
+      bill_contacts!()
       user = subscriber("team")
       contact(user, email: true, phone: true)
       {:ok, _} = Accounts.update_comped_contacts(user, 5, actor: "admin")
@@ -438,7 +453,38 @@ defmodule Fountain.Billing.FinanceTest do
       assert row_for(summary(), user).contact_revenue_cents == 0
     end
 
+    test "contacts earn nothing where the deployment does not bill for them" do
+      # Prod's actual state: STRIPE_PRICE_ID_CONTACT unset, so
+      # `sync_contact_addon/1` returns :not_billed and Stripe charges nothing.
+      # The panel used to report $5 a contact against those invoices.
+      user = subscriber("team")
+      contact(user, email: true, phone: true)
+      contact(user, email: true, phone: true)
+
+      refute Finance.contacts_billed?()
+
+      row = row_for(summary(), user)
+
+      assert row.contact_revenue_cents == 0
+      assert row.revenue_cents == Plans.monthly_cents("team")
+      # The cost side is untouched: we pay AgentMail and AgentPhone regardless.
+      assert row.inboxes == 2
+      assert row.numbers == 2
+      # ...and the tile that reads the same numbers agrees.
+      assert Finance.mrr().contact_cents == 0
+    end
+
+    test "an account with no Stripe subscription has no item to bill the add-on on" do
+      bill_contacts!()
+      user = subscriber("team")
+      Repo.update!(Ecto.Changeset.change(user, stripe_subscription_id: nil))
+      contact(user, email: true, phone: true)
+
+      assert row_for(summary(), user).contact_revenue_cents == 0
+    end
+
     test "mrr/0 agrees with the full pass" do
+      bill_contacts!()
       # Two code paths to the same number is two chances to disagree, and a
       # tile that contradicts the table below it destroys trust in both.
       subscriber("solo")

--- a/ee/test/fountain_web/admin_finance_live_test.exs
+++ b/ee/test/fountain_web/admin_finance_live_test.exs
@@ -46,7 +46,11 @@ defmodule FountainWeb.AdminFinanceLiveTest do
 
   defp subscriber(plan) do
     insert_verified_user()
-    |> Ecto.Changeset.change(plan: plan, subscription_status: "active")
+    |> Ecto.Changeset.change(
+      plan: plan,
+      subscription_status: "active",
+      stripe_subscription_id: "sub_#{System.unique_integer([:positive])}"
+    )
     |> Repo.update!()
   end
 
@@ -144,6 +148,30 @@ defmodule FountainWeb.AdminFinanceLiveTest do
       assert html =~ "text-red-700"
       assert html =~ "-$471.00"
       assert html =~ user.email
+    end
+  end
+
+  describe "contacts that nothing bills for" do
+    test "says why the add-on column is zero", %{conn: conn} do
+      admin = insert_admin()
+      subscriber("team")
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+
+      assert html =~ "Teammate contacts are not billed on this deployment"
+      assert html =~ "STRIPE_PRICE_ID_CONTACT"
+    end
+
+    test "no such note once a contact price exists", %{conn: conn} do
+      Application.put_env(:fountain, :stripe_price_ids, %{"contact" => "price_contact_test"})
+      on_exit(fn -> Application.delete_env(:fountain, :stripe_price_ids) end)
+
+      admin = insert_admin()
+      subscriber("team")
+
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+
+      refute html =~ "not billed on this deployment"
     end
   end
 


### PR DESCRIPTION
You spotted that the panel does not account for included contacts in revenue.
It is worse than that: it reported contact revenue **this deployment does not
charge at all**.

## What was wrong

The panel priced every non-comped contact at `Plans.contact_monthly_cents/0`
— which returns `$5` whether or not anything is configured to charge it:

```elixir
def contact_monthly_cents do
  Application.get_env(:fountain, :stripe_contact_price_cents, 500)
end
```

The real billing path is `sync_contact_addon/1`, and `billable_contacts/1` is
only its **last step**. Four guards sit in front, each meaning "the invoice
says zero":

```elixir
not enabled?()                              -> {:ok, :not_billed}
is_nil(price_id)                            -> {:ok, :not_billed}   # <- this one
is_nil(user)                                -> {:ok, :not_billed}
user.subscription_status == "comped"        -> {:ok, :not_billed}
user.stripe_subscription_id in [nil, ""]    -> {:ok, :not_billed}
```

The panel copied the arithmetic and none of the guards — behind a comment I
wrote claiming the two "cannot disagree".

## It bites here, right now

`STRIPE_PRICE_ID_CONTACT` is **not set in prod** — not in the deployment env,
not in the Infisical-managed secret. I checked. That is deliberate: setting it
puts a line item on the next invoice of every tenant already holding contacts,
which #991 flagged as a customer-facing change to announce first.

So `sync_contact_addon/1` returns `:not_billed`, Stripe charges nothing, and
the panel was reporting $5/contact/month of revenue against invoices
containing none of it. `/admin`'s MRR tile inherited the same error through
`Finance.mrr/0`.

## The fix

Contact revenue is now what the add-on **would actually bill**, guards
included.

**The cost side is deliberately untouched.** Fountain pays AgentMail and
AgentPhone whether or not it charges anyone, so contacts are currently pure
cost against zero revenue — and that asymmetry is the single most useful thing
this page can show about them. Hiding it behind a bare `$0.00` would be the
same class of error again, so where nothing bills for contacts the panel says
so, and points at the variable that changes it.

## On "included contacts"

Worth stating plainly, because it is a live design question rather than a bug:
`Plans.team_contacts` (solo 1, team 3, scale 10) is documented as an **abuse
ceiling, not an allowance** — every contact is an add-on unit from the first.
Nothing customer-facing contradicts that: neither the pricing page nor
`/account/billing` mentions contacts at all.

**This PR does not change that.** If the intent is that a plan *includes* its
`team_contacts` free, that is a different and larger change — it alters what
Stripe is billed via `billable_contacts/1`, not just what the panel displays,
and it is a price cut for anyone on the add-on. Say the word and I will do it
as its own PR.

## Verification

- `mix test` — 3,937 tests, **0 failures**
- `mix credo --strict` no issues · `mix dialyzer` 0 errors · format clean
- **Both guards verified by reverting them**: the deployment guard fails one
  test, the subscription guard another
- `STRIPE_PRICE_ID_CONTACT` confirmed absent from both the pod env and
  `fountain-secrets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)