### PR TITLE
feat(billing): plan concurrency caps retuned to 2 / 5 / 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Changed
+
+- **Plan concurrency caps retuned to 2 / 5 / 10.** Solo now allows 2
+  concurrent sandboxes (was 5), Team 5 (was 15) and Scale 10 (was 40), with
+  the closed `legacy` plan following Team down to 5. Included turn hours stay
+  derived at 20 per slot, so they move with the caps: 40 / 100 / 200. Prices
+  do not change, no Stripe price is touched, and there is no migration — the
+  cap resolves from `users.plan` on each request, so the new numbers apply at
+  the next deploy.
+
+  **This lowers the cap on accounts that already have one.** A tenant sitting
+  above their new cap keeps the sandboxes they are running and is refused the
+  next start until they are under it. Per-account relief is
+  `sandbox_limit_override` from `/admin`, which still beats the plan in either
+  direction. Self-hosters are affected too: the default plan is `solo`, so an
+  instance with no billing drops from 5 to 2 unless it sets `DEFAULT_PLAN` or
+  an override.
+
+  The trial keeps 2 concurrent and 40 hours, which now ties Solo. The
+  invariant it is held to changed from "smaller than every paid plan on every
+  axis" to "never larger than one" — it stays strictly below Team and Scale,
+  and strictly below Solo on teammate contacts, which is the only axis still
+  separating the two. ADR 0026 carries an amendment with the reasoning.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,8 @@ every plan.
 
 | | trial | solo | team | scale | legacy |
 |---|---|---|---|---|---|
-| concurrent sandboxes | 2 | 5 | 15 | 40 | 15 |
-| included turn hours | 40 | 100 | 300 | 800 | 300 |
+| concurrent sandboxes | 2 | 2 | 5 | 10 | 5 |
+| included turn hours | 40 | 40 | 100 | 200 | 100 |
 | teammate contacts | 0 | 1 | 3 | 10 | 3 |
 | price | free | $29 | $79 | $199 | $29 (closed) |
 
@@ -73,9 +73,11 @@ Five rules that are easy to get wrong:
   (`concurrent_sandboxes/1`, `included_turn_hours/1`, `team_contacts/1`) routes
   through `effective/1` **when handed a `%User{}`** — hand it a bare slug and
   it cannot know the status, which is how `turn_hour_allowance/2` first got it
-  wrong. Only applies when billing is on: `subscription_status` defaults to
-  `"trialing"`, so without that guard every self-hosted account would be capped
-  at two sandboxes. In tests, `insert_verified_user/1` is trialing —
+  wrong. The trial now *ties* Solo on concurrency and hours — the guardrail
+  is that it is never larger than a plan somebody pays for, and contacts are
+  the only axis still separating the two. Only applies when billing is on:
+  `subscription_status` defaults to `"trialing"`, so without that guard every
+  self-hosted account would be capped at two sandboxes. In tests, `insert_verified_user/1` is trialing —
   `insert_active_user/1` is the one that gets the plan's numbers.
 
 - **The plan is not the cap.** `Quotas.sandbox_limit/1` returns

--- a/apps/fountain/lib/fountain/plans.ex
+++ b/apps/fountain/lib/fountain/plans.ex
@@ -20,8 +20,8 @@ defmodule Fountain.Plans do
   ## Included turn hours
 
   `included_turn_hours` is derived, not chosen per tier: **20 turn hours per
-  concurrent sandbox the plan allows**, so Solo's 5 slots carry 100 hours and
-  Scale's 40 carry 800. Deriving it keeps the ladder on one axis — a plan
+  concurrent sandbox the plan allows**, so Solo's 2 slots carry 40 hours and
+  Scale's 10 carry 200. Deriving it keeps the ladder on one axis — a plan
   cannot end up with more capacity and less work to do with it.
 
   A *turn* hour is time with a prompt actually in flight
@@ -41,24 +41,28 @@ defmodule Fountain.Plans do
 
   | Plan | Concurrent | Turn hours | Teammate contacts | Price |
   |---|---|---|---|---|
-  | `solo` | 5 | 100 | 1 | $29/mo |
-  | `team` | 15 | 300 | 3 | $79/mo |
-  | `scale` | 40 | 800 | 10 | $199/mo |
-  | `legacy` | 15 | 300 | 3 | $29/mo (closed) |
+  | `solo` | 2 | 40 | 1 | $29/mo |
+  | `team` | 5 | 100 | 3 | $79/mo |
+  | `scale` | 10 | 200 | 10 | $199/mo |
+  | `legacy` | 5 | 100 | 3 | $29/mo (closed) |
   | `trial` | 2 | 40 | 0 | free (closed) |
 
-  ## The trial is a plan, and a smaller one
+  ## The trial is a plan, and never a larger one
 
   `trial` is what a `trialing` account gets, whatever tier its subscription
-  names — see `effective/1`. It is deliberately below every paid plan on every
-  axis, because a trial that hands over the full tier gives a converting
-  customer nothing on the day they pay, and the customer portal is configured
-  to end the trial on a plan change precisely so they get something.
+  names — see `effective/1`. It is never *above* a paid plan on any axis, and
+  it may sit level with the smallest one: it matches Solo's capacity and
+  carries no teammate contacts. A trial that handed over a *higher* tier's
+  capacity would make converting a downgrade, which is the failure this
+  bounds. Converting at the bottom of the ladder buys the contact and the
+  removal of the clock rather than more concurrency, and the customer portal
+  is still configured to end the trial on a plan change.
 
-  Its zero contacts are the sharpest edge: an AgentMail inbox and an
-  AgentPhone number cost real money the moment they exist, and a free trial
-  that mints one is an abuse vector with a monthly bill attached. That is one
-  number in the catalog to change if the trade turns out to be wrong.
+  Its zero contacts are the sharpest edge, and now the only axis separating it
+  from Solo: an AgentMail inbox and an AgentPhone number cost real money the
+  moment they exist, and a free trial that mints one is an abuse vector with a
+  monthly bill attached. That is one number in the catalog to change if the
+  trade turns out to be wrong.
 
   `legacy` is the flat price every account bought before the tiers existed.
   It is pinned to the old `STRIPE_PRICE_ID`, carries `team`'s capacity so that
@@ -125,10 +129,10 @@ defmodule Fountain.Plans do
     %{
       slug: "solo",
       name: "Solo",
-      tagline: "One person, a handful of agents at a time.",
+      tagline: "One person, a couple of agents at a time.",
       monthly_cents: 2_900,
-      concurrent_sandboxes: 5,
-      included_turn_hours: 100,
+      concurrent_sandboxes: 2,
+      included_turn_hours: 40,
       team_contacts: 1,
       order: 1
     },
@@ -137,8 +141,8 @@ defmodule Fountain.Plans do
       name: "Team",
       tagline: "A standing team of agents, working in parallel.",
       monthly_cents: 7_900,
-      concurrent_sandboxes: 15,
-      included_turn_hours: 300,
+      concurrent_sandboxes: 5,
+      included_turn_hours: 100,
       team_contacts: 3,
       order: 2
     },
@@ -147,8 +151,8 @@ defmodule Fountain.Plans do
       name: "Scale",
       tagline: "Fleet-sized fan-out, without asking first.",
       monthly_cents: 19_900,
-      concurrent_sandboxes: 40,
-      included_turn_hours: 800,
+      concurrent_sandboxes: 10,
+      included_turn_hours: 200,
       team_contacts: 10,
       order: 3
     },
@@ -157,8 +161,8 @@ defmodule Fountain.Plans do
       name: "Legacy",
       tagline: "The original flat plan, at Team capacity.",
       monthly_cents: 2_900,
-      concurrent_sandboxes: 15,
-      included_turn_hours: 300,
+      concurrent_sandboxes: 5,
+      included_turn_hours: 100,
       team_contacts: 3,
       order: 0,
       public?: false

--- a/apps/fountain/test/fountain/conversations_start_test.exs
+++ b/apps/fountain/test/fountain/conversations_start_test.exs
@@ -108,17 +108,19 @@ defmodule Fountain.ConversationsStartTest do
       user = insert_active_user()
       agent = insert_agent(user_id: user.id)
 
-      for _ <- 1..Fountain.Quotas.default_limit(),
-          do: insert_sandbox(user_id: user.id, status: "ready")
+      limit = Fountain.Quotas.default_limit()
+      for _ <- 1..limit, do: insert_sandbox(user_id: user.id, status: "ready")
 
-      assert {:error, {:sandbox_quota_exceeded, %{count: 5, limit: 5}}} =
+      assert {:error, {:sandbox_quota_exceeded, %{count: ^limit, limit: ^limit}}} =
                Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
     end
 
     test "the cap is checked before any sandbox row is allocated" do
       user = insert_active_user()
       agent = insert_agent(user_id: user.id)
-      for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+
+      for _ <- 1..Fountain.Quotas.default_limit(),
+          do: insert_sandbox(user_id: user.id, status: "ready")
 
       before = Fountain.Quotas.active_sandbox_count(user.id)
 
@@ -133,7 +135,10 @@ defmodule Fountain.ConversationsStartTest do
     test "one tenant at its cap does not block another" do
       capped = insert_active_user()
       other = insert_active_user()
-      for _ <- 1..5, do: insert_sandbox(user_id: capped.id, status: "ready")
+
+      for _ <- 1..Fountain.Quotas.default_limit(),
+          do: insert_sandbox(user_id: capped.id, status: "ready")
+
       agent = insert_agent(user_id: other.id)
 
       stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
@@ -145,7 +150,10 @@ defmodule Fountain.ConversationsStartTest do
     test "terminated sandboxes free capacity" do
       user = insert_active_user()
       agent = insert_agent(user_id: user.id)
-      [first | _] = for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+
+      [first | _] =
+        for _ <- 1..Fountain.Quotas.default_limit(),
+            do: insert_sandbox(user_id: user.id, status: "ready")
 
       assert {:error, _} =
                Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})

--- a/apps/fountain/test/fountain/plans_trial_test.exs
+++ b/apps/fountain/test/fountain/plans_trial_test.exs
@@ -24,14 +24,27 @@ defmodule Fountain.PlansTrialTest do
   end
 
   describe "the trial plan" do
-    test "is smaller than every public plan on every axis" do
+    # `<=`, not `<`: the trial matches Solo's capacity rather than sitting
+    # under it. What must never happen is the trial being *larger* than a plan
+    # somebody pays for, which would make converting a downgrade — and since
+    # the public caps climb strictly (`plans_test.exs`), levelling with the
+    # cheapest still leaves it strictly below Team and Scale.
+    test "is never larger than any public plan, on any axis" do
       trial = Plans.fetch!("trial")
 
       for plan <- Plans.public() do
-        assert trial.concurrent_sandboxes < plan.concurrent_sandboxes
-        assert trial.included_turn_hours < plan.included_turn_hours
+        assert trial.concurrent_sandboxes <= plan.concurrent_sandboxes
+        assert trial.included_turn_hours <= plan.included_turn_hours
         assert trial.team_contacts <= plan.team_contacts
       end
+    end
+
+    # The one axis that still separates the trial from the plan directly above
+    # it. If this ever ties too, a free trial and a paid Solo are the same
+    # thing with a clock on one of them.
+    test "carries strictly fewer contacts than the cheapest public plan" do
+      cheapest = Plans.public() |> List.first()
+      assert Plans.fetch!("trial").team_contacts < cheapest.team_contacts
     end
 
     # The whole reason it exists: converting has to hand the customer something
@@ -102,7 +115,7 @@ defmodule Fountain.PlansTrialTest do
       for status <- ~w(active past_due canceled comped) do
         user = %{plan: "team", subscription_status: status}
         assert Plans.effective(user).slug == "team", "status=#{status}"
-        assert Plans.concurrent_sandboxes(user) == 15
+        assert Plans.concurrent_sandboxes(user) == 5
       end
     end
 
@@ -110,8 +123,8 @@ defmodule Fountain.PlansTrialTest do
     # `turn_hour_allowance/2` passed one and silently handed trialing accounts
     # the paid allowance.
     test "a bare slug is the plan's own number, trial or not" do
-      assert Plans.concurrent_sandboxes("scale") == 40
-      assert Plans.included_turn_hours("scale") == 800
+      assert Plans.concurrent_sandboxes("scale") == 10
+      assert Plans.included_turn_hours("scale") == 200
     end
 
     # `subscription_status` defaults to "trialing" in the schema, so without
@@ -122,7 +135,7 @@ defmodule Fountain.PlansTrialTest do
 
       with_billing_off(fn ->
         assert Plans.effective(user).slug == "scale"
-        assert Plans.concurrent_sandboxes(user) == 40
+        assert Plans.concurrent_sandboxes(user) == 10
       end)
     end
 
@@ -147,7 +160,7 @@ defmodule Fountain.PlansTrialTest do
       assert Quotas.sandbox_limit(user.id) == 2
 
       {:ok, _} = activate(user)
-      assert Quotas.sandbox_limit(user.id) == 40
+      assert Quotas.sandbox_limit(user.id) == 10
     end
 
     # An override is the operator saying "this account, this number". A trial

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -69,20 +69,20 @@ defmodule Fountain.QuotasTest do
     # plan caps — writing them out is what pins the ladder the tiers are sold
     # on, so changing a cap in the catalog has to be a deliberate edit here.
 
-    test "a user with no plan gets the default plan's cap, which is 5" do
-      assert Quotas.sandbox_limit(insert_active_user().id) == 5
+    test "a user with no plan gets the default plan's cap, which is 2" do
+      assert Quotas.sandbox_limit(insert_active_user().id) == 2
     end
 
     test "the cap follows the plan" do
-      assert Quotas.sandbox_limit(insert_active_user(plan: "solo").id) == 5
-      assert Quotas.sandbox_limit(insert_active_user(plan: "team").id) == 15
-      assert Quotas.sandbox_limit(insert_active_user(plan: "scale").id) == 40
+      assert Quotas.sandbox_limit(insert_active_user(plan: "solo").id) == 2
+      assert Quotas.sandbox_limit(insert_active_user(plan: "team").id) == 5
+      assert Quotas.sandbox_limit(insert_active_user(plan: "scale").id) == 10
     end
 
     # Grandfathering, in one assertion: the closed plan is priced like Solo
     # and capped like Team, so nobody lost capacity at the changeover.
     test "the closed legacy plan carries Team's cap" do
-      assert Quotas.sandbox_limit(insert_active_user(plan: "legacy").id) == 15
+      assert Quotas.sandbox_limit(insert_active_user(plan: "legacy").id) == 5
     end
 
     test "an override beats the plan, in either direction" do
@@ -109,11 +109,11 @@ defmodule Fountain.QuotasTest do
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 1)
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, nil)
 
-      assert Quotas.sandbox_limit(user.id) == 15
+      assert Quotas.sandbox_limit(user.id) == 5
     end
 
     test "an unknown user falls back to the default plan rather than being unlimited" do
-      assert Quotas.sandbox_limit(Ecto.UUID.generate()) == 5
+      assert Quotas.sandbox_limit(Ecto.UUID.generate()) == 2
     end
   end
 
@@ -140,26 +140,33 @@ defmodule Fountain.QuotasTest do
       assert :ok = Quotas.check_sandbox_quota(user.id)
     end
 
+    # Unlike the block above, these derive the cap rather than writing it out:
+    # what is under test is the counting and the exclusion, not which number
+    # the catalog holds. Pinning it here only makes every future cap change
+    # break six unrelated tests.
     test "denies at the cap" do
       user = insert_active_user()
-      for _ <- 1..Quotas.default_limit(), do: insert_sandbox(user_id: user.id, status: "ready")
+      limit = Quotas.default_limit()
+      for _ <- 1..limit, do: insert_sandbox(user_id: user.id, status: "ready")
 
-      assert {:error, {:sandbox_quota_exceeded, %{count: 5, limit: 5}}} =
+      assert {:error, {:sandbox_quota_exceeded, %{count: ^limit, limit: ^limit}}} =
                Quotas.check_sandbox_quota(user.id)
     end
 
     test "denies above the cap" do
       user = insert_active_user()
-      for _ <- 1..7, do: insert_sandbox(user_id: user.id, status: "ready")
+      limit = Quotas.default_limit()
+      over = limit + 2
+      for _ <- 1..over, do: insert_sandbox(user_id: user.id, status: "ready")
 
-      assert {:error, {:sandbox_quota_exceeded, %{count: 7, limit: 5}}} =
+      assert {:error, {:sandbox_quota_exceeded, %{count: ^over, limit: ^limit}}} =
                Quotas.check_sandbox_quota(user.id)
     end
 
     test "one tenant at its cap does not affect another" do
       user = insert_active_user()
       other = insert_active_user()
-      for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+      for _ <- 1..Quotas.default_limit(), do: insert_sandbox(user_id: user.id, status: "ready")
 
       assert {:error, _} = Quotas.check_sandbox_quota(user.id)
       assert :ok = Quotas.check_sandbox_quota(other.id)
@@ -167,7 +174,10 @@ defmodule Fountain.QuotasTest do
 
     test "exclude: lets a replacement through at exactly the cap" do
       user = insert_active_user()
-      [replacing | _] = for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+
+      [replacing | _] =
+        for _ <- 1..Quotas.default_limit(),
+            do: insert_sandbox(user_id: user.id, status: "ready")
 
       assert {:error, _} = Quotas.check_sandbox_quota(user.id)
       assert :ok = Quotas.check_sandbox_quota(user.id, exclude: replacing.id)
@@ -175,10 +185,11 @@ defmodule Fountain.QuotasTest do
 
     test "a raised cap admits more" do
       user = insert_active_user()
-      for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+      limit = Quotas.default_limit()
+      for _ <- 1..limit, do: insert_sandbox(user_id: user.id, status: "ready")
       assert {:error, _} = Quotas.check_sandbox_quota(user.id)
 
-      {:ok, _} = Fountain.Accounts.update_sandbox_limit(user, 10)
+      {:ok, _} = Fountain.Accounts.update_sandbox_limit(user, limit + 5)
       assert :ok = Quotas.check_sandbox_quota(user.id)
     end
 
@@ -213,14 +224,15 @@ defmodule Fountain.QuotasTest do
 
     test "refuses at the cap and creates nothing" do
       user = insert_active_user()
-      for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+      limit = Quotas.default_limit()
+      for _ <- 1..limit, do: insert_sandbox(user_id: user.id, status: "ready")
 
-      assert {:error, {:sandbox_quota_exceeded, %{count: 5, limit: 5}}} =
+      assert {:error, {:sandbox_quota_exceeded, %{count: ^limit, limit: ^limit}}} =
                Quotas.with_sandbox_reservation(user.id, fn ->
                  flunk("fun must not run once the quota refuses")
                end)
 
-      assert Quotas.active_sandbox_count(user.id) == 5
+      assert Quotas.active_sandbox_count(user.id) == limit
     end
 
     test "a failure in fun rolls the reservation back" do
@@ -238,7 +250,11 @@ defmodule Fountain.QuotasTest do
 
     test "honours the :exclude option the wake path needs" do
       user = insert_active_user()
-      sandboxes = for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+
+      sandboxes =
+        for _ <- 1..Quotas.default_limit(),
+            do: insert_sandbox(user_id: user.id, status: "ready")
+
       replacing = hd(sandboxes)
 
       assert {:ok, _} =
@@ -255,16 +271,17 @@ defmodule Fountain.QuotasTest do
 
     test "raises at the cap with the counts in the message" do
       user = insert_active_user()
-      for _ <- 1..5, do: insert_sandbox(user_id: user.id, status: "ready")
+      limit = Quotas.default_limit()
+      for _ <- 1..limit, do: insert_sandbox(user_id: user.id, status: "ready")
 
       err =
         assert_raise Quotas.QuotaExceededError, fn ->
           Quotas.check_sandbox_quota!(user.id)
         end
 
-      assert err.count == 5
-      assert err.limit == 5
-      assert err.message =~ "5/5"
+      assert err.count == limit
+      assert err.limit == limit
+      assert err.message =~ "#{limit}/#{limit}"
     end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -279,8 +279,8 @@ defmodule FountainWeb.ConversationControllerTest do
     } do
       agent = insert_agent(user_id: user.id)
 
-      for _ <- 1..Fountain.Quotas.default_limit(),
-          do: insert_sandbox(user_id: user.id, status: "ready")
+      limit = Fountain.Quotas.default_limit()
+      for _ <- 1..limit, do: insert_sandbox(user_id: user.id, status: "ready")
 
       conn =
         conn
@@ -289,8 +289,8 @@ defmodule FountainWeb.ConversationControllerTest do
 
       body = json_response(conn, 429)
       assert body["error"] == "sandbox_quota_exceeded"
-      assert body["active_sandboxes"] == 5
-      assert body["limit"] == 5
+      assert body["active_sandboxes"] == limit
+      assert body["limit"] == limit
     end
 
     test "POST /api/conversations succeeds below the cap", %{
@@ -1057,6 +1057,10 @@ defmodule FountainWeb.ConversationControllerTest do
     # fresh one per restart. The key is opaque; Fountain only matches it.
     setup %{user: user} do
       stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+      # Channel binding, not the quota: several of these open three sandboxes
+      # for one tenant, which is above the default plan's cap. An override
+      # takes the cap out of the way rather than shaping the test around it.
+      {:ok, _} = Fountain.Accounts.update_sandbox_limit(user, 25)
       %{agent: insert_agent(user_id: user.id)}
     end
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -118,7 +118,7 @@ defmodule FountainWeb.MarketingPricingTest do
 
     body = conn |> get(~p"/") |> html_response(200)
     assert body =~ "then from $79/mo"
-    assert body =~ "15 agents at once"
+    assert body =~ "#{Fountain.Plans.concurrent_sandboxes("team")} agents at once"
     refute body =~ "Solo"
     refute body =~ "Scale"
   end

--- a/apps/fountain/test/fountain_web/controllers/turn_image_ingest_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/turn_image_ingest_test.exs
@@ -27,6 +27,11 @@ defmodule FountainWeb.TurnImageIngestTest do
 
   setup do
     user = insert_active_user()
+    # "every allowed type is accepted" opens one conversation per media type,
+    # which is more sandboxes than the default plan allows. The subject here
+    # is the image payload, so the quota is lifted out of the way rather than
+    # being allowed to answer 429 and read as a rejected media type.
+    {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 25)
     {_key, raw_key} = insert_api_key(user)
     agent = insert_agent(user_id: user.id)
     {:ok, user: user, raw_key: raw_key, agent: agent}

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -313,7 +313,10 @@ defmodule FountainWeb.AdminLiveTest do
       |> render_change(%{"user_id" => target.id, "plan" => "scale"})
 
       assert Fountain.Accounts.get_user(target.id).plan == "scale"
-      assert Fountain.Quotas.sandbox_limit(target.id) == 40
+
+      assert Fountain.Quotas.sandbox_limit(target.id) ==
+               Fountain.Plans.concurrent_sandboxes("scale")
+
       # The privilege trail, not just the effect: record_admin/1 is
       # best-effort and silently drops an event type missing from its closed
       # allowlist, which is how admin actions have shipped unaudited before.

--- a/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_user_detail_live_test.exs
@@ -54,7 +54,7 @@ defmodule FountainWeb.AdminUserDetailLiveTest do
       {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/users/#{target.id}")
 
       assert html =~ "Turn hours"
-      assert html =~ "0.0 / 300"
+      assert html =~ "0.0 / #{Fountain.Plans.included_turn_hours("team")}"
       # No Stripe period on this account, so the window is a calendar month
       # and support has to be able to see that before quoting the number.
       assert html =~ "calendar month"

--- a/decisions/0026-plans-and-entitlements.md
+++ b/decisions/0026-plans-and-entitlements.md
@@ -59,6 +59,10 @@ Three public tiers, differing in nothing but the cap `Quotas` already enforces:
 | Team | 15 | 3 | $79/mo |
 | Scale | 40 | 10 | $199/mo |
 
+> **These caps were retuned on 2026-08-23** to 2 / 5 / 10 at the same prices.
+> See the second amendment at the end of this document; `Fountain.Plans` is
+> the live catalog either way.
+
 Concurrency is the only axis because it is the only number that is
 simultaneously a real cost to Fountain (capacity on the shared provider
 account, ADR 0005/0018), already enforced in code, and legible to a customer
@@ -344,3 +348,41 @@ all of that in one place.
 
 Refs: #798, ADR 0005, ADR 0006 (and its 2026-08-05 addendum), ADR 0013,
 ADR 0017, ADR 0018.
+
+## Amendment (2026-08-23) — the caps retuned to 2 / 5 / 10, and the trial ties Solo
+
+**Status:** Accepted and built. Only the numbers in `@plan_specs` moved. The
+axis, the derivation, the override, the webhook-writes-the-plan rule and the
+contact add-on are all unchanged.
+
+| Plan | Concurrent | Turn hours | Was |
+|---|---|---|---|
+| `trial` | 2 | 40 | unchanged |
+| `solo` | 2 | 40 | 5 / 100 |
+| `team` | 5 | 100 | 15 / 300 |
+| `scale` | 10 | 200 | 40 / 800 |
+| `legacy` | 5 | 100 | 15 / 300 |
+
+Prices do not move, so no Stripe price is touched and `verify_plans` keeps
+passing. Nothing is migrated: `Quotas.sandbox_limit/1` resolves the cap from
+`users.plan` on each request, so the new numbers apply at the next deploy and
+an operator override still beats them.
+
+**This lowers the cap on existing accounts, which the original ladder never
+did.** The 2026-08-22 changeover was written so that nobody lost capacity;
+this one is a deliberate reduction, and a tenant sitting above their new cap
+keeps the sandboxes they have and is refused the next start. The lever for an
+account that needs the old number is `sandbox_limit_override`, per account,
+which is what it is for.
+
+**The trial now ties Solo rather than sitting below it.** The section above
+argued that a trial carrying its tier's full numbers gives a converting
+customer nothing on the day they pay. At 2 concurrent on both, that is again
+true for the *bottom* tier specifically: converting from the trial to Solo
+buys the teammate contact and the removal of the clock, not more concurrency.
+The invariant that replaces "smaller on every axis" is **never larger than a
+plan somebody pays for** — enforced as `<=` in `plans_trial_test.exs`, which
+still leaves the trial strictly below Team and Scale because the public caps
+climb strictly. Contacts stay strictly below Solo, and that assertion is
+pinned separately: if that ties too, a free trial and a paid Solo are the same
+product with a clock on one of them.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,7 +131,7 @@ a state of `started`, `done`, `failed` or `interrupted`.
    to you*, because Fountain scopes each query in the system to one tenant.
    The vault must be on the agent's allowlist. The subscription gate applies
    when you turned Stripe on, and answers `402` otherwise. The quota for
-   concurrent sandboxes applies, and it is 5 for each user by default. <!-- vale disable-line STE.IngForms -->
+   concurrent sandboxes applies, and it is 2 for each user by default. <!-- vale disable-line STE.IngForms -->
 2. **`provision`.** Fountain creates the sandbox and conversation rows, as
    `pending`, then starts a conversation server. That server creates the
    sprite, mounts the skills, and mints a scoped API key that expires. The

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -18,10 +18,10 @@ sandboxes a tenant can run at the same time.
 
 | Plan | Concurrent sandboxes | Turn hours | Contact ceiling | Price |
 |---|---|---|---|---|
-| Solo | 5 | 100 | 1 | $29/mo |
-| Team | 15 | 300 | 3 | $79/mo |
-| Scale | 40 | 800 | 10 | $199/mo |
-| Legacy | 15 | 300 | 3 | $29/mo |
+| Solo | 2 | 40 | 1 | $29/mo |
+| Team | 5 | 100 | 3 | $79/mo |
+| Scale | 10 | 200 | 10 | $199/mo |
+| Legacy | 5 | 100 | 3 | $29/mo |
 
 Every plan carries the whole product. Only the cap differs. See
 [ADR 0026](https://github.com/jhgaylor/fountain/blob/main/decisions/0026-plans-and-entitlements.md)
@@ -31,22 +31,23 @@ for why.
 to a new customer. It exists so that the accounts which bought the old price
 keep it, at Team capacity.
 
-### A trial is smaller than any plan
+### A trial is never larger than a plan
 
-A trial is not one of the plans above. It is its own, smaller one, and an
-account gets it for the first 14 days whatever tier the subscription names.
+A trial is not one of the plans above. It is its own plan, and an account gets
+it for the first 14 days whatever tier the subscription names.
 
 | Plan | Concurrent sandboxes | Turn hours | Contact ceiling | Price |
 |---|---|---|---|---|
 | Trial | 2 | 40 | 0 | free |
 
-The trial is below every paid plan on every axis, so a customer who subscribes
-gets more capacity the same day. This is also why the customer portal ends the
-trial on a plan change instead of continuing it. To continue the trial would
-take the payment and leave the customer on these numbers.
+The trial matches Solo on capacity and hours. It stays below Team and Scale.
+No trial is larger than a plan that a customer pays for, so a subscription is
+never a downgrade. This is also why the customer portal ends the trial on a
+plan change instead of continuing it.
 
-A trial includes no teammate contacts. An inbox and a phone number cost money
-as soon as they exist. A free trial that gives one away invites abuse.
+A trial includes no teammate contacts. That is the only limit which separates
+a trial from Solo. An inbox and a phone number cost money as soon as they
+exist. A free trial that gives one away invites abuse.
 
 The trial applies only where billing is on. On a self-hosted instance every
 account carries the `trialing` status and none of these limits.
@@ -67,7 +68,7 @@ question. See
 [issue 1016](https://github.com/BinaryBourbon/fountain/issues/1016) for the
 current state.
 
-The pricing page states this to a visitor, because a plan that lists 800 hours
+The pricing page states this to a visitor, because a plan that lists 200 hours
 and then says nothing reads as a hard stop. The two limits behave differently.
 Fountain refuses the next start for a tenant at the concurrency cap. A tenant
 over the hours continues, and pays no more.
@@ -167,8 +168,8 @@ Run it again after every price change.
 ## Check the accounts you already have
 
 The migration puts every account with a Stripe customer on the `legacy` plan.
-Those accounts gain capacity, from 5 concurrent sandboxes to 15. No account
-loses any.
+Those accounts hold 5 concurrent sandboxes, the same number as the old default
+cap. No account lost capacity at the changeover.
 
 The migration also clears the per-account cap wherever it still held the old
 default of 5. A cap that an operator set to another value survives as an

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -43,10 +43,10 @@ it. On yours, you pay. Two results follow.
 
 - Each signup that can start a conversation can spend your money. Close
   registration, or restrict it, before you put an instance on the internet.
-- Fountain caps concurrency for each user. `max_concurrent_sandboxes` defaults
-  to 5, and an admin can change it for one user from the admin panel. A
-  sandbox counts from the moment a provision starts, because that is the
-  moment it starts to cost money.
+- Fountain caps concurrency for each user. The plan sets the cap, and it is 2
+  on the default plan. An admin can override it for one user from the admin
+  panel. A sandbox counts from the moment a provision starts, because that is
+  the moment it starts to cost money.
 
 Fountain never shows the token to a tenant, to the admin UI, or to a sandbox.
 A sprite receives a scoped token that expires, and its only audience is your

--- a/docs/troubleshooting/conversation-stuck-or-failed.md
+++ b/docs/troubleshooting/conversation-stuck-or-failed.md
@@ -69,7 +69,7 @@ the full table in [Conversation states](../reference/conversation-states.md).
 ## The knock-on effect on quota
 
 A crash in the middle of a provision leaves a `pending` or `starting` sandbox
-row. That row counts against the user's quota, which is 5 concurrent sandboxes
+row. That row counts against the user's quota, which is 2 concurrent sandboxes
 by default.
 
 The reaper runs each hour at :07 and releases a row that has been stuck for

--- a/docs/troubleshooting/sandbox-errors.md
+++ b/docs/troubleshooting/sandbox-errors.md
@@ -43,7 +43,7 @@ If you scrape metrics, a failure to provision shows as
 
 ## Quota, and not an outage
 
-A user at their quota for concurrent sandboxes, which is 5 by default, sees a
+A user at their quota for concurrent sandboxes, which is 2 by default, sees a
 provision fail while the provider is healthy. A crashed provision leaves a row
 that counts until the reaper releases it, each hour at :07. Read
 [A conversation is stuck or failed](conversation-stuck-or-failed.md).

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -41,6 +41,10 @@ defmodule FountainWeb.Live.BillingLive do
          # `trial` plan (`Plans.effective/1`).
          plan: Billing.plan(user),
          effective_plan: Plans.effective(user),
+         # Whether subscribing actually moves a number. The trial ties the
+         # cheapest tier on concurrency and hours, so for a Solo trialist
+         # "raises those to 2 and 40" would be a sentence that says nothing.
+         trial_raises_numbers?: trial_raises_numbers?(user),
          on_trial: user.subscription_status == "trialing" and Billing.enabled?(),
          sandbox_limit: Quotas.sandbox_limit_for(user),
          available_plans: Billing.available_plans()
@@ -48,6 +52,18 @@ defmodule FountainWeb.Live.BillingLive do
     else
       {:ok, redirect(socket, to: ~p"/account")}
     end
+  end
+
+  # A trial is never *larger* than a paid plan, but since the caps were
+  # retuned it can tie the cheapest one. Comparing rather than assuming is
+  # what keeps the page from telling a Solo trialist that subscribing raises
+  # their numbers to exactly the numbers they already have.
+  defp trial_raises_numbers?(user) do
+    tier = Plans.resolve(user.plan)
+    now = Plans.effective(user)
+
+    tier.included_turn_hours > now.included_turn_hours or
+      tier.concurrent_sandboxes > now.concurrent_sandboxes
   end
 
   # Switching tier reprices the existing subscription rather than opening
@@ -201,7 +217,10 @@ defmodule FountainWeb.Live.BillingLive do
                 (adjusted for this account)
               </span>
               <span
-                :if={@on_trial and @sandbox_limit == @effective_plan.concurrent_sandboxes}
+                :if={
+                  @on_trial and @sandbox_limit == @effective_plan.concurrent_sandboxes and
+                    @plan.concurrent_sandboxes > @effective_plan.concurrent_sandboxes
+                }
                 class="text-gray-500"
               >
                 on trial, {@plan.concurrent_sandboxes} on {@plan.name}
@@ -375,9 +394,12 @@ defmodule FountainWeb.Live.BillingLive do
           costs you nothing here, and neither does time on your own runner.
           Parked sandboxes are excluded from every number on this page.
         </p>
-        <p :if={@on_trial} class="mt-2 text-xs text-gray-500">
+        <p :if={@on_trial and @trial_raises_numbers?} class="mt-2 text-xs text-gray-500">
           A trial includes {@effective_plan.included_turn_hours} turn hours and {@effective_plan.concurrent_sandboxes} agents at once. {@plan.name} raises those to {@plan.included_turn_hours} and {@plan.concurrent_sandboxes} as soon as you subscribe — you do not
           wait for the trial to run out.
+        </p>
+        <p :if={@on_trial and not @trial_raises_numbers?} class="mt-2 text-xs text-gray-500">
+          A trial includes {@effective_plan.included_turn_hours} turn hours and {@effective_plan.concurrent_sandboxes} agents at once, which is what {@plan.name} carries too. Subscribing keeps those numbers and lifts the fourteen-day limit; a larger tier is what raises them.
         </p>
         <p :if={@allowance.over?} class="mt-2 text-xs text-amber-700">
           You are over the hours your plan includes. Nothing is limited and

--- a/ee/test/fountain/billing_finance_test.exs
+++ b/ee/test/fountain/billing_finance_test.exs
@@ -560,17 +560,19 @@ defmodule Fountain.Billing.FinanceTest do
 
       turn_hours = summary().turn_hours
 
-      # The trialing account is sold the *trial's* 40, not the 300 of the tier
-      # it is trialling (#1022): hours it has not bought are not hours sold. A
+      # The trialing account is sold the *trial's* hours, not the tier's it is
+      # trialling (#1022): hours it has not bought are not hours sold. A
       # cancelled account is sold nothing at all.
-      assert turn_hours.sold == 100 + Plans.included_turn_hours("trial")
+      assert turn_hours.sold ==
+               Plans.included_turn_hours("solo") + Plans.included_turn_hours("trial")
+
       # ...but hours a cancelled account burned this period are still hours.
       assert turn_hours.used == 8.0
     end
 
     test "a trialing account is measured against the trial's allowance (#1022)" do
       # The specific trap the resolve/effective split exists for: 50 turn
-      # hours is comfortably inside Team's 300 and well over a trial's 40. Read
+      # hours is comfortably inside Team's 100 and well over a trial's 40. Read
       # through `resolve/1` this account looks fine; it is not.
       user = subscriber("team", "trialing")
       ran(user, "sprites", 50, 50)

--- a/ee/test/fountain/billing_trial_allowance_test.exs
+++ b/ee/test/fountain/billing_trial_allowance_test.exs
@@ -43,7 +43,8 @@ defmodule Fountain.BillingTrialAllowanceTest do
   test "the same account on that tier gets the tier's hours" do
     user = user_on("scale", "active")
 
-    assert Billing.turn_hour_allowance(user).included == 800
+    assert Billing.turn_hour_allowance(user).included ==
+             Plans.fetch!("scale").included_turn_hours
   end
 
   # The allowance is smaller during a trial, so `over?` can be true for a
@@ -60,6 +61,7 @@ defmodule Fountain.BillingTrialAllowanceTest do
     user = user_on("scale", "trialing")
     Application.put_env(:fountain, :billing_enabled, false)
 
-    assert Billing.turn_hour_allowance(user).included == 800
+    assert Billing.turn_hour_allowance(user).included ==
+             Plans.fetch!("scale").included_turn_hours
   end
 end

--- a/ee/test/fountain/billing_turn_hours_test.exs
+++ b/ee/test/fountain/billing_turn_hours_test.exs
@@ -249,14 +249,14 @@ defmodule Fountain.Billing.TurnHoursTest do
 
       assert allowance.used == 4.0
       assert allowance.included == Plans.included_turn_hours("solo")
-      assert allowance.remaining == 96.0
+      assert allowance.remaining == Plans.included_turn_hours("solo") - 4.0
       refute allowance.over?
     end
 
     test "remaining never goes negative, and over? is what says so" do
       user = insert_active_user(plan: "solo")
 
-      # 101 hours against Solo's 100: one hour over.
+      # 101 hours against Solo's allowance: comfortably over it.
       sandbox =
         sandbox_running(user, "sprites", ~U[2026-05-02 00:00:00Z], ~U[2026-05-10 00:00:00Z])
 

--- a/ee/test/fountain_web/controllers/billing_api_controller_test.exs
+++ b/ee/test/fountain_web/controllers/billing_api_controller_test.exs
@@ -118,10 +118,14 @@ defmodule FountainWeb.BillingApiControllerTest do
         |> get("/api/account/billing")
         |> json_response(200)
 
+      included = Fountain.Plans.included_turn_hours(Fountain.Plans.default_slug())
+
       assert body["data"]["usage"]["turn_hours"] == expected
-      assert body["data"]["usage"]["turn_hours_included"] == 100
-      assert body["data"]["plan"]["included_turn_hours"] == 100
-      assert body["data"]["usage"]["turn_hours_remaining"] == Float.round(100 - expected, 2)
+      assert body["data"]["usage"]["turn_hours_included"] == included
+      assert body["data"]["plan"]["included_turn_hours"] == included
+
+      assert body["data"]["usage"]["turn_hours_remaining"] ==
+               Float.round(included - expected, 2)
     end
 
     test "an idle sandbox spends sandbox minutes and no turn hours", %{

--- a/ee/test/fountain_web/live/billing_live_test.exs
+++ b/ee/test/fountain_web/live/billing_live_test.exs
@@ -430,7 +430,7 @@ defmodule FountainWeb.BillingLiveTest do
       {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
 
       assert html =~ "Turn hours"
-      assert html =~ "of 100 included"
+      assert html =~ "of #{Fountain.Plans.included_turn_hours("solo")} included"
       assert html =~ "A turn hour is an hour with a prompt in flight"
     end
 
@@ -443,13 +443,39 @@ defmodule FountainWeb.BillingLiveTest do
 
       {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
 
+      team = Fountain.Plans.fetch!("team")
+      trial = Fountain.Plans.fetch!("trial")
+
       assert html =~ "Trial, then Team"
-      assert html =~ "of 40 included"
+      assert html =~ "of #{trial.included_turn_hours} included"
       assert html =~ "on trial"
       # The tier's numbers are stated as what subscribing raises them to.
-      assert html =~ "300"
-      assert html =~ "15"
-      refute html =~ "of 300 included"
+      assert html =~
+               "raises those to #{team.included_turn_hours} and #{team.concurrent_sandboxes}"
+
+      refute html =~ "of #{team.included_turn_hours} included"
+    end
+
+    # The trial ties the cheapest tier on concurrency and hours, so the
+    # "raises those to" sentence would name the numbers the customer already
+    # has. Subscribing at the bottom of the ladder buys the clock, not
+    # capacity, and the page has to say the true thing.
+    test "a trialing account on a tier that ties the trial is not promised a raise",
+         %{conn: conn} do
+      solo = Fountain.Plans.fetch!("solo")
+      trial = Fountain.Plans.fetch!("trial")
+      # Guard: if Solo ever climbs above the trial again, this test is
+      # asserting the wrong branch and should be deleted rather than fixed.
+      assert solo.concurrent_sandboxes == trial.concurrent_sandboxes
+      assert solo.included_turn_hours == trial.included_turn_hours
+
+      user = insert_verified_user(plan: "solo")
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+
+      refute html =~ "raises those to"
+      assert html =~ "which is what Solo carries too"
+      assert html =~ "lifts the fourteen-day limit"
     end
 
     test "says nothing is limited when a tenant is over", %{conn: conn} do
@@ -533,9 +559,11 @@ defmodule FountainWeb.BillingLiveTest do
       # switch back onto.
       refute html =~ "Switch to Legacy"
       assert html =~ "an earlier plan we no longer sell"
-      # The hours are part of what a customer is choosing between.
-      assert html =~ "100 turn hours included"
-      assert html =~ "800 turn hours included"
+      # The hours are part of what a customer is choosing between. Derived
+      # from the catalog: which numbers the tiers carry is pinned in
+      # plans_test.exs, and this is about the picker rendering them.
+      assert html =~ "#{Fountain.Plans.included_turn_hours("solo")} turn hours included"
+      assert html =~ "#{Fountain.Plans.included_turn_hours("scale")} turn hours included"
     end
 
     test "the current plan is not offered as a switch", %{conn: conn} do


### PR DESCRIPTION
Retunes the one axis the tiers are sold on. Prices do not move.

| Plan | Concurrent | Turn hours | Was |
|---|---|---|---|
| `trial` | 2 | 40 | unchanged |
| `solo` | **2** | **40** | 5 / 100 |
| `team` | **5** | **100** | 15 / 300 |
| `scale` | **10** | **200** | 40 / 800 |
| `legacy` | **5** | **100** | 15 / 300 |

Turn hours are derived at 20 per slot (`plans_test.exs` asserts the ratio), so they follow the caps rather than being chosen.

## What this does not touch

- **No migration.** `Quotas.sandbox_limit/1` resolves the cap from `users.plan` on every request. The new numbers apply at the next deploy.
- **No Stripe change.** Same prices, same price ids, `mix fountain.verify_plans` still passes.
- **Overrides still win.** `users.sandbox_limit_override` beats the plan in both directions, including the deliberate zeros.

## This lowers a cap accounts already hold

ADR 0026's original changeover was written so nobody lost capacity. This one is a deliberate reduction, so it is worth being explicit: a tenant above their new cap **keeps the sandboxes they are running** and is refused the next start until they are under it. The per-account lever is `sandbox_limit_override` from `/admin`.

Checked against prod before writing this:

| | |
|---|---|
| Accounts total | 140 |
| `active` / `trialing` / `past_due` | 3 |
| With an override (unaffected) | 5 |
| **Above the new cap, no override** | **1** |

That one is the team-demo account: comped Solo, no override, 4 live sandboxes, cap 5 → 2. It needs an override of 4+ or a bump to Team before this deploys. The dogfood `scale` account has an override of 100 and is untouched.

**Self-hosters are affected too.** `DEFAULT_PLAN` defaults to `solo`, so an instance with billing off drops from 5 to 2 unless it sets `DEFAULT_PLAN` or an override. Called out in the changelog.

## The trial now ties Solo

At 2/40 on both, the trial can no longer be "smaller than every paid plan on every axis". The invariant becomes **never larger than a plan somebody pays for** (`<=` in `plans_trial_test.exs`), which still leaves it strictly below Team and Scale because the public caps climb strictly. Teammate contacts stay strictly below Solo (0 vs 1) and that is now pinned on its own test — if that ties too, a free trial and a paid Solo are the same product with a clock on one of them.

**The tie caught a real copy bug.** The billing page told a Solo trialist that subscribing *"raises those to 40 and 2"* — the numbers they already had. That sentence is now conditional on the tier actually moving a number; the tie case says subscribing keeps the numbers and lifts the fourteen-day limit. The redundant "2 on Solo" beside the sandbox limit is suppressed the same way. New test asserts the tie first, so if Solo climbs back above the trial the test tells you to delete it rather than patch it.

## Tests

Three kinds, deliberately:

- **Pin the catalog** — the literals in the `sandbox_limit/1` block stay literal. That is what makes a cap change a deliberate edit.
- **Derive it** — 14 tests wrote a cap or an allowance out while testing something else (counting, `exclude:`, 429 shapes, meter rendering). They derive now, so the next cap change does not break tests that are not about caps.
- **Lift it out of the way** — two fixtures open more sandboxes for one tenant than the new cap allows: three channel bindings, and one conversation per allowed image media type. Both take an override. The second was failing as `image/gif was rejected with 429`, where the 429 was the quota, not the media type.

## Gate

`mix test` 3933 tests / 0 failures · `format --check-formatted` · `credo --strict` · `sobelow` · `dialyzer` 0 errors · `deps.unlock --unused` · `docs-style.py` 80 files clean · `vale lint docs` 0 errors · `okf validate decisions` valid.

ADR 0026 carries an amendment with the reasoning. Docs, CLAUDE.md and CHANGELOG follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
