### PR TITLE
Ship the fountain-contributor canned agent (#1010)

### DIFF
--- a/.vale-ste.yml
+++ b/.vale-ste.yml
@@ -48,11 +48,15 @@ sentence:
 # moved those pages to `superpowers/` at the repo root.
 files:
   include:
-    # Both patterns. `docs/**/*.md` alone does not match `docs/index.md` on a
-    # directory walk, because `**` wants at least one directory, and that
-    # silently exempted all thirteen top-level pages.
+    # One pattern per directory depth. On this walker `**` matches exactly
+    # one directory, so `docs/**/*.md` alone does not match `docs/index.md`
+    # (no directory) and does not match `docs/catalog/skills/fountain.md`
+    # (two directories). The second gap was found in #1010: every page two
+    # levels deep — all of `docs/catalog/*/` and `docs/guides/operate/` —
+    # was silently outside the gate.
     - "docs/*.md"
     - "docs/**/*.md"
+    - "docs/**/**/*.md"
   exclude:
     # A record of what happened, not a description of how the system works.
     # docs/changelog.md is a one-line snippet include of it.

--- a/cli/internal/manifest/examples_test.go
+++ b/cli/internal/manifest/examples_test.go
@@ -1,0 +1,67 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExamplesParse walks the repo's examples/ tree and asserts every YAML
+// document in it is a well-formed resource: a known kind, a metadata.name,
+// and a map spec. Read() silently drops docs missing apiVersion/kind, which
+// is right for a user's mixed specs tree and wrong for our own examples —
+// so this walks the files directly and checks every document.
+func TestExamplesParse(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "examples")
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("examples/ not found relative to cli/internal/manifest: %v", err)
+	}
+
+	files, err := listYAMLFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no .yml/.yaml files under examples/")
+	}
+
+	knownKinds := map[string]bool{"Environment": true, "Vault": true, "Agent": true}
+	total := 0
+	for _, f := range files {
+		docs, err := readFile(f)
+		if err != nil {
+			t.Errorf("%s: %v", f, err)
+			continue
+		}
+		if len(docs) == 0 {
+			t.Errorf("%s: no documents", f)
+		}
+		for i, d := range docs {
+			total++
+			if !d.IsResource() {
+				t.Errorf("%s doc %d: missing apiVersion or kind (would be silently skipped by apply)", f, i)
+				continue
+			}
+			if !knownKinds[d.Kind] {
+				t.Errorf("%s doc %d: unknown kind %q", f, i, d.Kind)
+			}
+			if d.Name() == "" {
+				t.Errorf("%s doc %d (%s): missing metadata.name", f, i, d.Kind)
+			}
+			if d.Spec == nil {
+				t.Errorf("%s doc %d (%s/%s): missing map spec", f, i, d.Kind, d.Name())
+			}
+			// Secrets, when present, must be the map form: the server keeps a
+			// map and silently drops anything else, and the CLI's ${VAR} and
+			// secret-manager resolution only walk the map form.
+			if raw, ok := d.Spec["secrets"]; ok {
+				if _, isMap := raw.(map[string]any); !isMap {
+					t.Errorf("%s doc %d (%s/%s): spec.secrets must be a map of KEY: value", f, i, d.Kind, d.Name())
+				}
+			}
+		}
+	}
+	if total == 0 {
+		t.Fatal("no resource documents under examples/")
+	}
+}

--- a/docs/catalog/agents/fountain-contributor.md
+++ b/docs/catalog/agents/fountain-contributor.md
@@ -10,7 +10,7 @@
 | Manifest | [`examples/agents/fountain-contributor/`](https://github.com/BinaryBourbon/fountain/tree/main/examples/agents/fountain-contributor) | <!-- vale disable-line STE.SentenceLength -->
 | Runtime | claude, model `anthropic/claude-opus-5` |
 | Resources | one Environment, one Vault, one Agent |
-| First run | 30 to 60 minutes to provision, paid one time into a checkpoint |
+| First run | about 15 minutes to provision (measured), paid one time into a checkpoint |
 | Network policy | `unrestricted` |
 | Vault needs | a GitHub token with `repo` scope, and your git identity |
 

--- a/docs/catalog/agents/fountain-contributor.md
+++ b/docs/catalog/agents/fountain-contributor.md
@@ -1,0 +1,97 @@
+# fountain-contributor
+
+> An agent that contributes to Fountain itself, configured to work the way a
+> maintainer's laptop session does.
+
+## At a glance
+
+| | |
+|---|---|
+| Manifest | [`examples/agents/fountain-contributor/`](https://github.com/BinaryBourbon/fountain/tree/main/examples/agents/fountain-contributor) | <!-- vale disable-line STE.SentenceLength -->
+| Runtime | claude, model `anthropic/claude-opus-5` |
+| Resources | one Environment, one Vault, one Agent |
+| First run | 30 to 60 minutes to provision, paid one time into a checkpoint |
+| Network policy | `unrestricted` |
+| Vault needs | a GitHub token with `repo` scope, and your git identity |
+
+## What it does
+
+It checks out
+[BinaryBourbon/fountain](https://github.com/BinaryBourbon/fountain), reads
+`CLAUDE.md` and the ADRs, makes a change, runs the full local gate, and opens
+one pull request with `gh`. Its commits carry a DCO sign-off under your name,
+from the vault.
+
+The environment rebuilds a maintainer's machine inside the sandbox. The
+pinned Erlang and Elixir toolchain from `.tool-versions`, and Go for the CLI
+suite. Postgres, with the dev and test databases. Then `gh`, the dialyzer
+PLT, and the docs linters that CI runs.
+
+## What you will need
+
+| | Where it comes from |
+|---|---|
+| `GITHUB_TOKEN`, `GH_TOKEN` | one GitHub token with `repo` scope |
+| `GIT_NAME`, `GIT_EMAIL` | your DCO identity, substituted at apply time |
+| a secret manager, or not | The 1Password CLI resolves `op://` refs. Without one, pass `--var`. |
+
+Inference credentials are not part of the manifest. Fountain injects them
+from your account. Fountain derives `MASTER_SECRETS_KEY` itself in dev and
+test, so the suite runs without it.
+
+## Set it up
+
+1. Apply the manifest.
+
+    ```bash
+    fountain apply -f examples/agents/fountain-contributor/manifest.yml \
+      --var GIT_NAME="Ada Lovelace" --var GIT_EMAIL="ada@example.com"
+    ```
+
+2. Start a conversation with your vault attached.
+
+    ```bash
+    fountain run fountain-contributor --vault fountain-contributor-me \
+      -p "Read issue #NNN and fix it"
+    ```
+
+The `--vault` flag is not optional in practice. The repo clone, `gh`, and the
+DCO identity all come from the vault.
+
+## Verify
+
+Ask the agent to run the gate and read what it reports.
+
+```
+mix precommit
+```
+
+Done means it saw "N tests, 0 failures" in the output, and one pull request
+exists on the repository with signed-off commits.
+
+## Limits
+
+**The first conversation is slow.** The setup script builds Erlang from
+source and the dialyzer PLT. The checkpoint absorbs that cost, and every
+later conversation warm-starts in seconds.
+
+**An edit to the environment costs a rebuild.** A one-character change to
+`setup_script`, `packages` or `repositories` invalidates the checkpoint, and
+the next conversation pays the full build again.
+
+**A warm start restores a stale checkout.** The checkpoint skips the clone
+and the setup script, so the tree on disk is as old as the checkpoint. The
+agent's system prompt orders a `git fetch` first, for exactly this reason.
+
+**The git identity override is not optional.** Fountain gives every sandbox
+`AoD <aod@local>` as its git identity, and the DCO check rejects commits
+signed off that way. The vault's `GIT_*` values win, on every provider. We
+measured this rather than assumed it.
+
+## Related
+
+- [Agents](index.md).
+- [About environments](../../concepts/environment.md), where the machine
+  comes from.
+- [About vaults](../../concepts/vault.md), where your credentials live.
+- [claude](../runtimes/claude.md), the runtime it runs on.

--- a/docs/catalog/agents/index.md
+++ b/docs/catalog/agents/index.md
@@ -1,0 +1,28 @@
+# Agents
+
+An entry here is one ready-to-apply manifest. One file holds an Environment,
+a Vault and an Agent, and one `fountain apply -f` reconciles all three.
+
+Every field in a hand-written manifest is a decision. Which runtime, which
+model, what a `setup_script` must do, what belongs in an Environment and what
+in a Vault. A canned agent makes those decisions for you, in a single file
+you can read from top to bottom. The per-person secrets stay out of the file.
+They arrive at apply time, from your secret manager or from `--var` flags.
+
+The manifests live in the repository, under
+[`examples/agents/`](https://github.com/BinaryBourbon/fountain/tree/main/examples/agents).
+Each folder holds the manifest and a README that covers cost, first-run time
+and what the vault needs. CI parses every document, so a broken example fails
+the build before it can mislead anyone.
+
+## All 1 agents
+
+| Agent | What it does | Runtime |
+|---|---|---|
+| [fountain-contributor](fountain-contributor.md) | Contributes to Fountain itself. Full toolchain, a database, the local gate, one pull request. | claude |
+
+## Not here yet
+
+**A docs writer and a triager.** Both need much less machine than the
+contributor, and both wait until the shape has proven itself. If you want an
+entry that does not exist, open an issue.

--- a/docs/catalog/index.md
+++ b/docs/catalog/index.md
@@ -13,6 +13,13 @@ Each entry has the same shape. Read one and you can skim the rest.
 | [Skills](skills/index.md) | One `SKILL.md` that Fountain writes into the sandbox. | 2 bundled, and any repo on GitHub. |
 | [MCP servers](mcp-servers/index.md) | One server that gives the runtime tools. | 3 hosted, and any server you declare. |
 
+## Start from a whole agent
+
+[Agents](agents/index.md) is the catalog of ready-to-apply manifests. One
+file holds an Environment, a Vault and an Agent, and one `fountain apply -f`
+reconciles all three. There is 1 entry, a
+[Fountain contributor](agents/fountain-contributor.md).
+
 ## Elsewhere in these docs
 
 Two catalogs are older than this section, and they keep their own pages for

--- a/docs/catalog/runtimes/index.md
+++ b/docs/catalog/runtimes/index.md
@@ -28,7 +28,7 @@ string word for word, then reads the prefix to decide which key to export.
 
 **All four speak ACP.** Gemini was the last one off it, and it joined on
 2026-08-22. So editor integration, the permission flow and the shared block
-format reach every runtime, and the choice is about the provider and the CLI
+format reach every runtime. The choice is about the provider and the CLI
 rather than about the transport.
 
 ## The rule that catches people

--- a/docs/concepts/environment.md
+++ b/docs/concepts/environment.md
@@ -57,12 +57,18 @@ metadata:
   name: python-data-env
 spec:
   packages:
-    python: "3.12"
+    apt:
+      - jq
   networking_type: limited
   secrets:
-    - key: OPENAI_API_KEY
-      value: sk-...
+    OPENAI_API_KEY: sk-...
 ```
+
+`secrets` must be a map of `KEY: value`. The server keeps only the map form
+and drops any other shape without an error. The map form is also what the
+CLI's `${VAR}` substitution and secret-manager references resolve against.
+`packages` has two keys that install software, `apt` and `npm`. Other
+language toolchains go in `setup_script`.
 
 ### The network policy is not symmetric
 

--- a/docs/concepts/vault.md
+++ b/docs/concepts/vault.md
@@ -43,9 +43,11 @@ metadata:
   name: staging-creds
 spec:
   secrets:
-    - key: DATABASE_URL
-      value: postgres://staging-host/mydb
+    DATABASE_URL: postgres://staging-host/mydb
 ```
+
+`secrets` must be a map of `KEY: value`. The server keeps only the map form
+and drops any other shape without an error.
 
 ## Why it exists
 

--- a/docs/guides/operate/observability.md
+++ b/docs/guides/operate/observability.md
@@ -27,9 +27,9 @@ observability pack, built from a real run of the hosted instance.
   trace panels. [Read the dashboards](dashboards.md) says what each number
   means, and which questions belong in PostHog instead.
 
-One series is worth naming here, because it is the one that maps to money.
-`fountain_sandboxes_by_provider_count` reports how many sandboxes each provider
-holds right now, by status. See
+One series gets a mention here, because it is the one that maps to money.
+The gauge `fountain_sandboxes_by_provider_count` reports how many sandboxes
+each provider holds right now, by status. See
 [See what sandboxes cost](sandbox-spend.md) for the per-account view that goes
 with it.
 

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -74,6 +74,8 @@ nav:
       - fountain-team: catalog/mcp-servers/fountain-team.md
       - fountain-buzz: catalog/mcp-servers/fountain-buzz.md
       - fountain-comms: catalog/mcp-servers/fountain-comms.md
+      - Agents: catalog/agents/index.md
+      - fountain-contributor (agent): catalog/agents/fountain-contributor.md
   - Sandbox providers:
       - The contract: integrations/sandbox-contract.md
       - Sprites: integrations/sprites.md

--- a/examples/agents/fountain-contributor/README.md
+++ b/examples/agents/fountain-contributor/README.md
@@ -1,0 +1,95 @@
+# fountain-contributor
+
+An agent that contributes to Fountain itself, set up to do what a
+maintainer's laptop session does: the pinned Erlang/Elixir toolchain, Go for
+the CLI, Postgres for the suite, `gh` for the pull request, and the docs and
+decisions linters CI runs. One file defines all three resources — the
+Environment (machine + toolchain), a Vault (your credentials and git
+identity), and the Agent (model, runtime, working rules).
+
+## What the vault needs
+
+Two credentials and a git identity, all resolved on **your** machine at apply
+time — nothing secret is stored in this file:
+
+| Key | Purpose | Where it comes from |
+|---|---|---|
+| `GITHUB_TOKEN` | clones the repo (`repositories[].secret_key`) | a token with `repo` scope |
+| `GH_TOKEN` | authenticates `gh` for the pull request | same token |
+| `GIT_AUTHOR_NAME` / `GIT_COMMITTER_NAME` | DCO sign-off identity | `${GIT_NAME}` substitution |
+| `GIT_AUTHOR_EMAIL` / `GIT_COMMITTER_EMAIL` | DCO sign-off identity | `${GIT_EMAIL}` substitution |
+
+The manifest ships with `${VAR}` references, which `fountain apply`
+substitutes from your local environment or from `--var` flags. Keep the token
+in a secret manager? Replace the value with a ref like
+`op://Private/github/token` (1Password), `bws://...` (Bitwarden) or
+`infisical://...`, and the CLI resolves it at apply time instead. Either way,
+resolution happens on your machine and the manifest never holds a secret:
+
+```bash
+fountain apply -f examples/agents/fountain-contributor/manifest.yml \
+  --var GITHUB_TOKEN="$(gh auth token)" \
+  --var GH_TOKEN="$(gh auth token)" \
+  --var GIT_NAME="Ada Lovelace" \
+  --var GIT_EMAIL="ada@example.com"
+```
+
+The git identity is not decoration. Fountain injects `AoD <aod@local>` as the
+git author/committer into every sandbox, and `git commit -s` signs off with
+the committer ident, so without the override the DCO check rejects every
+commit this agent makes. The vault values are appended after the platform
+defaults, and **last wins on every provider** — measured on Sprites
+(duplicate keys are deduplicated to the last value in the process
+environment), and by construction on E2B (map conversion), Daytona (shell
+`K=V` prefix) and self-hosted runners (Go `exec.Cmd` semantics).
+
+## Run it
+
+```bash
+fountain apply -f examples/agents/fountain-contributor/manifest.yml
+fountain run fountain-contributor --vault fountain-contributor-me \
+  -p "Read issue #NNN and fix it"
+```
+
+The `--vault` flag matters: the agent's environment has the toolchain, but
+the repo clone, `gh`, and the DCO identity all come from the vault. The
+manifest deliberately leaves `allowed_vault_ids` unset — unset means any of
+your vaults may attach; an empty list would forbid attaching one at all.
+
+## What the first run costs
+
+The setup script builds Erlang/OTP from source (mise honors the repo's
+`.tool-versions` pin), compiles the umbrella twice (dev + test), and builds
+the dialyzer PLT. Expect **30–60 minutes of provisioning** on the first
+conversation, before the agent says anything.
+
+That cost is paid once. Fountain checkpoints the fully-provisioned sandbox,
+and every later conversation warm-starts from the checkpoint in seconds.
+
+Two consequences of the checkpoint worth knowing before you edit anything:
+
+- **Editing any warm-start field invalidates the checkpoint.** A
+  one-character change to `setup_script`, `packages`, or `repositories` costs
+  the next conversation the full 30–60 minute build. Batch your edits.
+- **A warm start skips the clone and the setup script entirely.** The
+  checkout restored from the checkpoint is as old as the checkpoint. The
+  agent's system prompt orders a `git fetch` before reading anything for
+  exactly this reason; don't remove that instruction.
+
+Inference credentials are **not** part of this manifest: they are per-user
+and Fountain injects them from your account's credentials, never from an
+Environment. Likewise `MASTER_SECRETS_KEY` is derived automatically in dev
+and test, so the suite runs in the sandbox without it.
+
+## What "done" looks like
+
+A green `mix precommit` in the sandbox — the agent is told to read the
+output, not the exit code — and one pull request on
+[BinaryBourbon/fountain](https://github.com/BinaryBourbon/fountain), opened
+with `gh`, commits signed off (`git commit -s`) under your vault's identity.
+
+## Guardrails
+
+Every document in `examples/` is parsed by
+`cli/internal/manifest/examples_test.go`, so a manifest that stops parsing —
+or a document that loses its `apiVersion`/`kind`/`metadata.name` — fails CI.

--- a/examples/agents/fountain-contributor/README.md
+++ b/examples/agents/fountain-contributor/README.md
@@ -60,8 +60,9 @@ your vaults may attach; an empty list would forbid attaching one at all.
 
 The setup script builds Erlang/OTP from source (mise honors the repo's
 `.tool-versions` pin), compiles the umbrella twice (dev + test), and builds
-the dialyzer PLT. Expect **30–60 minutes of provisioning** on the first
-conversation, before the agent says anything.
+the dialyzer PLT. Expect **about 15 minutes of provisioning** on the first
+conversation, before the agent says anything (measured 15m38s on a Sprites
+sandbox, packages through checkpoint).
 
 That cost is paid once. Fountain checkpoints the fully-provisioned sandbox,
 and every later conversation warm-starts from the checkpoint in seconds.
@@ -70,7 +71,7 @@ Two consequences of the checkpoint worth knowing before you edit anything:
 
 - **Editing any warm-start field invalidates the checkpoint.** A
   one-character change to `setup_script`, `packages`, or `repositories` costs
-  the next conversation the full 30–60 minute build. Batch your edits.
+  the next conversation the full ~15 minute build. Batch your edits.
 - **A warm start skips the clone and the setup script entirely.** The
   checkout restored from the checkpoint is as old as the checkpoint. The
   agent's system prompt orders a `git fetch` before reading anything for

--- a/examples/agents/fountain-contributor/manifest.yml
+++ b/examples/agents/fountain-contributor/manifest.yml
@@ -1,0 +1,153 @@
+# A Fountain agent that contributes to Fountain itself, configured to do what
+# a maintainer's laptop session does: the pinned toolchain, a database, the
+# full local gate, and one pull request at the end.
+#
+# Apply it, then start a conversation with your own vault attached:
+#
+#   fountain apply -f examples/agents/fountain-contributor/manifest.yml
+#   fountain run fountain-contributor --vault fountain-contributor-me \
+#     -p "Fix issue #NNN"
+#
+# Read the README next to this file before the first apply — the vault below
+# needs your credentials, and the first conversation pays for a from-source
+# Erlang build (subsequent ones warm-start from the checkpoint).
+apiVersion: fountain.dev/v1
+kind: Environment
+metadata:
+  name: fountain-contributor
+spec:
+  networking_type: unrestricted
+  packages:
+    apt:
+      - build-essential
+      - autoconf
+      - m4
+      - libncurses-dev
+      - libssl-dev
+      - unzip
+      - jq
+      - ripgrep
+      - postgresql
+      - postgresql-contrib
+      - python3
+  env_vars:
+    LANG: C.UTF-8
+    DATABASE_URL: postgres://postgres:postgres@localhost:5432/fountain_dev
+  repositories:
+    - url: https://github.com/BinaryBourbon/fountain
+      mount_path: /workspace/fountain
+      secret_key: GITHUB_TOKEN
+  setup_script: |
+    set -euxo pipefail
+
+    # The platform gives up on a setup step after 120s of *silence*, not
+    # 120s of runtime. The OTP build and the dialyzer PLT both go quiet for
+    # longer than that, so keep a ticker printing for the whole script.
+    (while true; do echo "[keepalive] $(date -u +%H:%M:%S)"; sleep 60; done) &
+    KEEPALIVE=$!
+    trap 'kill "$KEEPALIVE" 2>/dev/null || true' EXIT
+
+    # Postgres: apt installs a cluster but starts nothing in a sandbox, and
+    # the image's Debian release picks the major version — ask, don't assume.
+    PG_MAJOR=$(ls /etc/postgresql | sort -n | tail -1)
+    sudo pg_ctlcluster "$PG_MAJOR" main start
+    sudo -u postgres psql -c "ALTER ROLE postgres WITH LOGIN SUPERUSER PASSWORD 'postgres'"
+
+    # gh, for the pull request at the end of the job.
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | sudo tee /etc/apt/sources.list.d/github-cli.list
+    sudo apt-get update -qq && sudo apt-get install -y -qq gh
+
+    # The pinned toolchain. mise reads .tool-versions from the checkout, so
+    # this builds the exact Erlang/Elixir CI runs. Slow once; the checkpoint
+    # absorbs it.
+    curl -fsSL https://mise.run | sh
+    export PATH="$HOME/.local/bin:$PATH"
+    echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
+    cd /workspace/fountain
+    mise install
+    mise use -g go@1.26.0
+    eval "$(mise env -s bash)"
+
+    mix local.hex --force && mix local.rebar --force
+    mix deps.get
+    mix setup
+    MIX_ENV=test mix ecto.create
+    MIX_ENV=test mix ecto.migrate
+
+    # The slow half of `mix precommit`, paid once into the checkpoint.
+    MIX_ENV=dev mix dialyzer --plt
+    MIX_ENV=test mix compile
+
+    # The docs and decisions gates, pinned the way .github/workflows/ci.yml
+    # pins them. docs-style.py needs only python3; vale is a single binary.
+    GOBIN="$HOME/.local/bin" go install github.com/okfcli/okf/cmd/okf@latest
+    curl -fsSL -o /tmp/vale.tar.gz \
+      https://github.com/stuffbucket/vale/releases/download/v0.15.0/vale_0.15.0_linux_amd64.tar.gz
+    echo "c6b85fd4da8ca2b0f631b17556c3f38bc3f30e9ce636517c00ad507c522c2a5c  /tmp/vale.tar.gz" | sha256sum -c -
+    tar -xzf /tmp/vale.tar.gz -C "$HOME/.local/bin" vale
+---
+# Your per-person overlay. Attach it at launch (`--vault`); its values win
+# over the environment's on key collision, and — measured on every provider —
+# over the platform's own defaults, which is what makes the git identity
+# below effective.
+apiVersion: fountain.dev/v1
+kind: Vault
+metadata:
+  name: fountain-contributor-me
+spec:
+  secrets:
+    # Clones the repo, authenticates gh, opens the pull request. `${VAR}`
+    # substitutes from your environment or from `--var` at apply time; a
+    # secret-manager ref like `op://Private/github/token` resolves through
+    # the 1Password CLI instead, if you keep it there — see the README.
+    GITHUB_TOKEN: ${GITHUB_TOKEN}
+    GH_TOKEN: ${GITHUB_TOKEN}
+    # Not secret, but the vault is the only per-person overlay we have, and
+    # these must override the platform default (`AoD <aod@local>`) so
+    # `git commit -s` signs off as a person the DCO check accepts.
+    GIT_AUTHOR_NAME: ${GIT_NAME}
+    GIT_AUTHOR_EMAIL: ${GIT_EMAIL}
+    GIT_COMMITTER_NAME: ${GIT_NAME}
+    GIT_COMMITTER_EMAIL: ${GIT_EMAIL}
+---
+apiVersion: fountain.dev/v1
+kind: Agent
+metadata:
+  name: fountain-contributor
+spec:
+  runtime: claude
+  model: anthropic/claude-opus-5
+  environment: fountain-contributor
+  description: >
+    Works on BinaryBourbon/fountain the way a maintainer does: reads CLAUDE.md
+    and the ADRs first, runs the full local gate, opens one pull request.
+  system: |
+    You contribute to Fountain. The checkout is at /workspace/fountain, and it
+    is not your working directory, so nothing in it has been loaded for you.
+
+    Before you touch anything, in this order:
+      1. cd /workspace/fountain && git fetch origin && git checkout -B <branch> origin/main
+         The sandbox may have warm-started from a checkpoint, so the checkout
+         on disk can be days old. Fetch before you read it.
+      2. Read CLAUDE.md. It is the contract: tenant scoping and the `_unsafe_`
+         rule, audit-in-the-context, the test patterns, the things not to do.
+      3. Read CONTRIBUTING.md, and decisions/index.md if the change is
+         architectural.
+
+    Before you push: `mix precommit`. Read the output rather than the exit
+    code, an alias stage can fail while the alias exits 0. Confirm you reached
+    "N tests, 0 failures". If you touched docs/, also run
+    `mix test apps/fountain/test/fountain/docs_test.exs`,
+    `python3 scripts/docs-style.py` and `vale lint docs`.
+
+    Commit with `git commit -s` (DCO). Never push to main. One pull request,
+    with what changed and why, and the gate output you actually saw.
+  permission_policy:
+    default: auto_allow
+  # `allowed_vault_ids` is deliberately absent: absent means any of your own
+  # vaults may attach, an empty list would forbid attaching one at all — and
+  # this agent needs the vault above. Tighten it to your vault's id after the
+  # first apply if you want the allowlist.


### PR DESCRIPTION
Implements #1010: a maintained, ready-to-apply agent manifest in the repo, with the Fountain contributor as the first entry.

## What's here

- **`examples/agents/fountain-contributor/`** — one manifest (Environment + Vault + Agent) plus a README covering cost, first-run time, what the vault needs, and the checkpoint/warm-start caveats.
- **`cli/internal/manifest/examples_test.go`** — walks `examples/` file by file (not through `Read`'s silent-skip filter), asserting every document is a known kind with a name, a map spec, and map-form secrets.
- **`docs/catalog/agents/`** — index + entry page, wired as siblings into the Catalog nav section.
- **Finding 5 fix** — `concepts/environment.md` and `concepts/vault.md` showed `spec.secrets` as a list of `{key, value}`, which the server and CLI silently drop; both now show the map form and say so. The environment example also stops suggesting a `python:` package key nothing installs.
- **Gate fix (surfaced while validating the new pages)** — `vale lint docs` was skipping every page two directories deep (`docs/catalog/*/`, `docs/guides/operate/`): the walker's `**` matches exactly one directory. Added the depth-2 include and fixed the three violations that surfaced.

## Deviations from the issue's draft, each verified

- **`allowed_vault_ids` omitted**, not `[]` — an empty list forbids attaching any vault (`check_vault_allowed/2`), and this agent depends on its vault.
- **Keepalive ticker in `setup_script`** — the 120s setup timeout is an *inactivity* timeout on Sprites (`collect/4` re-arms per chunk); the OTP build and `dialyzer --plt` go quiet for longer.
- **Postgres major read from `/etc/postgresql`** — the sandbox image ships Ubuntu 26.04 / Postgres 18, not the 16 SETUP.md pins for laptops.
- **Post-#1008 docs gates** — `mkdocs build --strict` and `docs/requirements.txt` no longer exist; the manifest installs vale (pinned + checksummed like CI) and okf, and the system prompt names `docs_test.exs` / `docs-style.py` / `vale lint docs`.
- **Vault tokens ship as `${VAR}` substitutions** with secret-manager refs (`op://` etc.) documented as the alternative — the substitution form is what works with nothing installed.

## Finding 2: measured, not assumed

Duplicate env keys resolve **last-wins on all four providers**, so the vault's `GIT_*` override beats the platform's `AoD <aod@local>` and DCO sign-off works. Measured live on Sprites (daemon dedupes to the last value; probed via `sh`, raw `environ`, and `getenv`); by construction on E2B (`Map.new`), Daytona (shell `K=V` prefix) and runners (Go `exec.Cmd`). Details in [the issue comment](https://github.com/BinaryBourbon/fountain/issues/1010#issuecomment-5388549205).

## Live validation: complete ✅

Applied against production with exactly the README's command (`env +` / `vault +` with six secrets / `agent +`), then one conversation (`ca4244ce`) run from it against issue #1040:

- **Cold provision: 15m38s** end to end (packages → clone via the vault token → OTP from source → deps → dev+test DBs → PLT → linters), `setup exit_code: 0`. The README's cost section now states the measured number.
- **Green gate in the sandbox**: the agent reported `mix precommit` stage by stage — compile clean, format clean, credo no issues, dialyzer 0 errors, sobelow clean, `3947 tests, 0 failures` — plus the pool-contention repro from #1040's acceptance list.
- **One pull request opened by the agent**: #1045, commits `Signed-off-by: Jake Gaylor <jhgaylor@gmail.com>` — the vault's DCO identity override proven end to end in production.

## Gates

- `go test ./...` + `go vet` in `cli/`: green
- `mix precommit`: "6 doctests, 3 properties, 3943 tests, 0 failures" (read from output, not exit code)
- `docs_test.exs`: 29 tests, 0 failures
- `python3 scripts/docs-style.py`: clean (82 files)
- `vale lint docs`: 0 errors, 0 warnings — now over every page, including the previously unscanned depth-2 directories

Closes #1010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)