### PR TITLE
fix(api): unlink the best-effort writes a request never awaits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,16 @@ Mimic is available. Prefer integration tests through real changesets over heavy 
 - **Don't reach for `_unsafe_*` without established ownership.** These skip tenant scoping; the legitimate caller shapes (including the scoped-parent-fetch-then-`_unsafe_`-child pattern) are in the tenant isolation section above.
 - **Don't lower the test pool size below 20.** Pool exhaustion causes flaky timeouts.
 - **Don't remove `:ueberauth_test_mode` or `:rate_limit_test_isolation` from `config/test.exs`.** They're correctness guards, not performance flags.
+- **Don't start fire-and-forget work with `Task.async`.** It *links* to the
+  caller and nothing awaits it, so a transient failure in a write nobody wants
+  the result of takes the request process down — and under the SQL Sandbox that
+  process is the test, which is how a stamp on `last_used_at` failed a
+  scheduling test that had already passed (#1040). Use
+  `Task.Supervisor.start_child(Fountain.TaskSupervisor, fun)`: unlinked,
+  supervised, and a crash is logged. `DataCase` waits for the tasks a test
+  started before stopping the sandbox owner, so the write lands rather than
+  having its connection pulled away. `Task.async` is right where the caller
+  keeps the ref and handles the reply (`Analytics.Sink`).
 - **Don't push directly to `main`.** All changes go through PRs; the CI gate must pass.
 - **Don't add `async: false` to tests unless the test genuinely requires it** (e.g. global ETS state). The SQL Sandbox handles DB isolation.
 

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -15,7 +15,7 @@ defmodule Fountain.Accounts do
   - `create_api_key/2` — issue a new API key (returns the plaintext once)
   - `revoke_api_key/2` — permanently invalidate a key
   - `get_user_by_api_key/1` — authenticate a raw API key string
-  - `touch_api_key/1` — update last_used_at (called async after auth)
+  - `touch_api_key/1` — update last_used_at (best-effort, off the request)
   - `upsert_oauth_user/3` — find-or-create user from OAuth callback
   """
 
@@ -786,8 +786,15 @@ defmodule Fountain.Accounts do
   end
 
   @doc """
-  Update `last_used_at` for the API key matching `raw_key`. Intended to be called
-  asynchronously (via `Task.async`) so it does not block the request.
+  Update `last_used_at` for the API key matching `raw_key`.
+
+  Called from an unlinked task under `Fountain.TaskSupervisor` (see
+  `FountainWeb.Plugs.TenantAPIAuth`) so it does not block the request, and
+  best-effort *by rescuing*, the position `Audit.record/1` takes for the same
+  reason: a failed stamp on a column nothing reads on the hot path is a log
+  line, never the reason an already-authenticated request fails (#1040).
+
+  Always returns `:ok`.
   """
   @spec touch_api_key(String.t()) :: :ok
   def touch_api_key(raw_key) when is_binary(raw_key) do
@@ -798,6 +805,10 @@ defmodule Fountain.Accounts do
     |> Repo.update_all(set: [last_used_at: now])
 
     :ok
+  rescue
+    e ->
+      Logger.warning("touch_api_key: last_used_at stamp failed: #{inspect(e)}")
+      :ok
   end
 
   ## Internal helpers

--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -30,6 +30,13 @@ defmodule Fountain.Application do
          repos: Application.fetch_env!(:fountain, :ecto_repos), skip: skip_migrations?()},
         {DNSCluster, query: Application.get_env(:fountain, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: Fountain.PubSub},
+        # Fire-and-forget work started from a request and never awaited: the
+        # `last_used_at` stamp on an API key, the password-reset email. These
+        # used to be `Task.async`, which *links* to the caller — so a transient
+        # failure in a write nobody wants the result of could take down the
+        # request process that started it, or the test that made the request
+        # (#1040). Supervised and unlinked, a crash here is a log line.
+        {Task.Supervisor, name: Fountain.TaskSupervisor},
         FountainWeb.Plugs.RateLimit.Sweeper,
         Fountain.Conversations.Redaction,
         Fountain.FeatureFlags.Cache,

--- a/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/password_reset_controller.ex
@@ -73,7 +73,12 @@ defmodule FountainWeb.PasswordResetController do
       # token for the user — without this, a used link stayed live for the
       # rest of its hour (shared inbox, forwarded mail, proxy log).
       token = Phoenix.Token.sign(conn, "password_reset", {user.id, user.session_version})
-      Task.async(fn -> UserEmails.deliver_password_reset_email(user, token) end)
+      # Unlinked and supervised (#1040): this was a linked `Task.async` that
+      # nothing awaited, so a delivery error could take down the request that
+      # was about to answer 200.
+      Task.Supervisor.start_child(Fountain.TaskSupervisor, fn ->
+        UserEmails.deliver_password_reset_email(user, token)
+      end)
     end
 
     conn

--- a/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
+++ b/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
@@ -4,8 +4,8 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
   looks up the API key, loads the owning user, and sets
   `conn.assigns.current_user`.
 
-  Updates `last_used_at` asynchronously via `Task.async` so it never blocks
-  the request.
+  Updates `last_used_at` in an unlinked task under `Fountain.TaskSupervisor`,
+  so the stamp never blocks the request and cannot take it down.
 
   Returns 401 JSON on failure. The response body includes a machine-readable
   `reason` so clients (especially in-sprite agents holding a rotated
@@ -30,7 +30,13 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
     with [auth_header] <- get_req_header(conn, "authorization"),
          "Bearer " <> raw_key <- auth_header,
          {:ok, user, api_key} <- Accounts.authenticate_api_key(raw_key) do
-      Task.async(fn -> Accounts.touch_api_key(raw_key) end)
+      # Unlinked and supervised (#1040). `Task.async` linked this to the conn
+      # process and nothing ever awaited it, so a pool blip stamping a column
+      # nothing reads on the hot path could kill a request that had already
+      # authenticated — and, under the SQL Sandbox, the test that made it.
+      Task.Supervisor.start_child(Fountain.TaskSupervisor, fn ->
+        Accounts.touch_api_key(raw_key)
+      end)
 
       conn
       |> assign(:current_user, user)

--- a/apps/fountain/test/fountain/accounts_additional_test.exs
+++ b/apps/fountain/test/fountain/accounts_additional_test.exs
@@ -5,6 +5,7 @@ defmodule Fountain.AccountsAdditionalTest do
   alias Fountain.Accounts.ApiKey
 
   import Fountain.Factory
+  import ExUnit.CaptureLog
 
   # ── get_user_by_email/1 ─────────────────────────────────────────────────────
 
@@ -356,6 +357,25 @@ defmodule Fountain.AccountsAdditionalTest do
     test "returns :ok silently for an unknown key (no error)" do
       fake_raw = "ftn_" <> String.duplicate("b", 64)
       assert :ok = Accounts.touch_api_key(fake_raw)
+    end
+
+    # #1040: best-effort by rescuing, the position `Audit.record/1` takes. A
+    # process with no checked-out connection is what a pool blip looks like
+    # from inside the task, and the raise it produces must not escape.
+    test "returns :ok when the write cannot reach the database" do
+      user = insert_verified_user()
+      {:ok, {_key, raw_key}} = Accounts.create_api_key(user.id, "unreachable")
+      test_pid = self()
+
+      log =
+        capture_log(fn ->
+          # spawn/1, not Task.async: no `$callers`, so the sandbox has no
+          # connection to hand this process and `Repo.update_all` raises.
+          spawn(fn -> send(test_pid, {:touched, Accounts.touch_api_key(raw_key)}) end)
+          assert_receive {:touched, :ok}
+        end)
+
+      assert log =~ "touch_api_key: last_used_at stamp failed"
     end
   end
 

--- a/apps/fountain/test/fountain/accounts_additional_test.exs
+++ b/apps/fountain/test/fountain/accounts_additional_test.exs
@@ -7,6 +7,12 @@ defmodule Fountain.AccountsAdditionalTest do
   import Fountain.Factory
   import ExUnit.CaptureLog
 
+  # `assert_receive`'s 100 ms default is a bet on how fast another process gets
+  # scheduled, and a loaded CI runner loses it: the raise, rescue and log line
+  # below took longer than that on partition 6 and failed a test written to
+  # catch a timing flake. Nothing here waits the full window when it passes.
+  @receive_timeout 5_000
+
   # ── get_user_by_email/1 ─────────────────────────────────────────────────────
 
   describe "get_user_by_email/1" do
@@ -372,7 +378,7 @@ defmodule Fountain.AccountsAdditionalTest do
           # spawn/1, not Task.async: no `$callers`, so the sandbox has no
           # connection to hand this process and `Repo.update_all` raises.
           spawn(fn -> send(test_pid, {:touched, Accounts.touch_api_key(raw_key)}) end)
-          assert_receive {:touched, :ok}
+          assert_receive {:touched, :ok}, @receive_timeout
         end)
 
       assert log =~ "touch_api_key: last_used_at stamp failed"

--- a/apps/fountain/test/fountain_web/controllers/password_reset_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/password_reset_controller_test.exs
@@ -1,5 +1,8 @@
 defmodule FountainWeb.PasswordResetControllerTest do
   use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  import ExUnit.CaptureLog
 
   alias Fountain.Accounts
 
@@ -38,6 +41,36 @@ defmodule FountainWeb.PasswordResetControllerTest do
         |> post("/api/auth/forgot", Jason.encode!(%{}))
 
       assert json_response(conn, 200)
+    end
+
+    # #1040: the send is fire-and-forget and nothing awaits it. As a linked
+    # `Task.async` a delivery error took the request down with it, so the
+    # caller saw a 500 (or nothing) for a reset that had already been signed.
+    test "a delivery error does not fail the request", %{conn: conn} do
+      user = insert_verified_user()
+      test_pid = self()
+
+      stub(Fountain.Mailer, :deliver, fn _email ->
+        send(test_pid, {:delivering, self()})
+        raise "smtp is down"
+      end)
+
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> Plug.Conn.put_req_header("content-type", "application/json")
+            |> post("/api/auth/forgot", Jason.encode!(%{email: user.email}))
+
+          assert_receive {:delivering, task_pid}
+
+          ref = Process.monitor(task_pid)
+          assert_receive {:DOWN, ^ref, :process, ^task_pid, _reason}
+
+          assert json_response(conn, 200)["message"] =~ "registered"
+        end)
+
+      assert log =~ "smtp is down"
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/password_reset_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/password_reset_controller_test.exs
@@ -6,6 +6,10 @@ defmodule FountainWeb.PasswordResetControllerTest do
 
   alias Fountain.Accounts
 
+  # See the note in `tenant_api_auth_test.exs`: `assert_receive`'s 100 ms
+  # default is a bet on scheduling latency that a loaded runner loses.
+  @receive_timeout 5_000
+
   describe "GET /auth/forgot-password" do
     test "renders the forgot password form", %{conn: conn} do
       conn = get(conn, ~p"/auth/forgot-password")
@@ -62,10 +66,10 @@ defmodule FountainWeb.PasswordResetControllerTest do
             |> Plug.Conn.put_req_header("content-type", "application/json")
             |> post("/api/auth/forgot", Jason.encode!(%{email: user.email}))
 
-          assert_receive {:delivering, task_pid}
+          assert_receive {:delivering, task_pid}, @receive_timeout
 
           ref = Process.monitor(task_pid)
-          assert_receive {:DOWN, ^ref, :process, ^task_pid, _reason}
+          assert_receive {:DOWN, ^ref, :process, ^task_pid, _reason}, @receive_timeout
 
           assert json_response(conn, 200)["message"] =~ "registered"
         end)

--- a/apps/fountain/test/fountain_web/plugs/tenant_api_auth_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/tenant_api_auth_test.exs
@@ -7,6 +7,12 @@ defmodule FountainWeb.Plugs.TenantAPIAuthTest do
   alias Fountain.Accounts
   alias FountainWeb.Plugs.TenantAPIAuth
 
+  # Explicit, because `assert_receive`'s 100 ms default is a bet on how fast a
+  # task gets scheduled on a loaded runner — and losing that bet fails a test
+  # about a race with a race of its own. The `refute_receive` below keeps the
+  # default: that one is a window we want short.
+  @receive_timeout 5_000
+
   describe "call/2" do
     test "sets current_user when valid Bearer key is provided", %{conn: conn} do
       user = insert_verified_user()
@@ -143,7 +149,7 @@ defmodule FountainWeb.Plugs.TenantAPIAuthTest do
         |> authed_with_key(raw_key)
         |> TenantAPIAuth.call([])
 
-      assert_receive {:touched, ^raw_key, task_pid}
+      assert_receive {:touched, ^raw_key, task_pid}, @receive_timeout
       refute task_pid == test_pid
       refute conn.halted
       assert conn.assigns.current_user.id == user.id
@@ -170,12 +176,12 @@ defmodule FountainWeb.Plugs.TenantAPIAuthTest do
             |> authed_with_key(raw_key)
             |> TenantAPIAuth.call([])
 
-          assert_receive {:touching, task_pid}
+          assert_receive {:touching, task_pid}, @receive_timeout
 
           # Sync on the task actually dying, so the assertions below are about
           # a crash that has already happened rather than one still in flight.
           ref = Process.monitor(task_pid)
-          assert_receive {:DOWN, ^ref, :process, ^task_pid, _reason}
+          assert_receive {:DOWN, ^ref, :process, ^task_pid, _reason}, @receive_timeout
 
           refute_receive {:EXIT, ^task_pid, _reason}
 

--- a/apps/fountain/test/fountain_web/plugs/tenant_api_auth_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/tenant_api_auth_test.exs
@@ -1,6 +1,10 @@
 defmodule FountainWeb.Plugs.TenantAPIAuthTest do
   use FountainWeb.ConnCase, async: true
+  use Mimic
 
+  import ExUnit.CaptureLog
+
+  alias Fountain.Accounts
   alias FountainWeb.Plugs.TenantAPIAuth
 
   describe "call/2" do
@@ -114,6 +118,73 @@ defmodule FountainWeb.Plugs.TenantAPIAuthTest do
       refute conn.halted
       # user_a's key does not return user_b
       refute conn.assigns.current_user.id == user_b.id
+    end
+  end
+
+  # #1040. The stamp is best-effort and nothing awaits it, so it must not be
+  # able to fail the request it rode in on. It used to run in a `Task.async`,
+  # which links to the caller: a pool blip under load raised in the task, the
+  # exit signal followed the link back to the conn process, and under the SQL
+  # Sandbox that process is the test — which is how a passing test failed on a
+  # write it never asserted on.
+  describe "the last_used_at stamp" do
+    test "runs in a process other than the one serving the request", %{conn: conn} do
+      user = insert_verified_user()
+      {_record, raw_key} = insert_api_key(user)
+      test_pid = self()
+
+      stub(Accounts, :touch_api_key, fn key ->
+        send(test_pid, {:touched, key, self()})
+        :ok
+      end)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> TenantAPIAuth.call([])
+
+      assert_receive {:touched, ^raw_key, task_pid}
+      refute task_pid == test_pid
+      refute conn.halted
+      assert conn.assigns.current_user.id == user.id
+    end
+
+    test "a raise inside it kills neither the request nor the test that made it", %{conn: conn} do
+      # Trapped so a link, if one came back, shows up as an assertable message
+      # rather than as this test dying with an unrelated EXIT.
+      Process.flag(:trap_exit, true)
+
+      user = insert_verified_user()
+      {_record, raw_key} = insert_api_key(user)
+      test_pid = self()
+
+      stub(Accounts, :touch_api_key, fn _key ->
+        send(test_pid, {:touching, self()})
+        raise "connection not available and request was dropped from queue"
+      end)
+
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> authed_with_key(raw_key)
+            |> TenantAPIAuth.call([])
+
+          assert_receive {:touching, task_pid}
+
+          # Sync on the task actually dying, so the assertions below are about
+          # a crash that has already happened rather than one still in flight.
+          ref = Process.monitor(task_pid)
+          assert_receive {:DOWN, ^ref, :process, ^task_pid, _reason}
+
+          refute_receive {:EXIT, ^task_pid, _reason}
+
+          refute conn.halted
+          assert conn.assigns.current_user.id == user.id
+        end)
+
+      # Supervised, so the crash is reported rather than propagated.
+      assert log =~ "connection not available and request was dropped from queue"
     end
   end
 end

--- a/apps/fountain/test/support/data_case.ex
+++ b/apps/fountain/test/support/data_case.ex
@@ -35,12 +35,60 @@ defmodule Fountain.DataCase do
     :ok
   end
 
+  # Long enough that a `last_used_at` stamp or a test-adapter email always
+  # lands, short enough that a task which is genuinely stuck cannot stall the
+  # suite. Never reached in practice — both sites are a single round trip.
+  @drain_timeout_ms 500
+
   @doc """
   Sets up the sandbox based on the test tags.
   """
   def setup_sandbox(tags) do
+    test_pid = self()
     pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Fountain.Repo, shared: not tags[:async])
     on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    # `on_exit` callbacks run last-registered-first, so this drains before the
+    # owner above is stopped.
+    on_exit(fn -> drain_best_effort_tasks(test_pid) end)
+  end
+
+  @doc """
+  Wait for the fire-and-forget tasks this test started to finish.
+
+  Best-effort work off a request — the `last_used_at` stamp, the password-reset
+  email — runs in an *unlinked* task under `Fountain.TaskSupervisor` (#1040), so
+  unlike the linked `Task.async` it replaced it is not killed when the test
+  process finishes. Left alone it would still be holding a sandbox connection
+  when the owner is stopped, which drops that connection and logs a disconnect:
+  churn in the pool the flake in #1040 was blamed on to begin with.
+
+  Only tasks started by `test_pid` are waited on — `Task.Supervisor` propagates
+  `$callers`, which is also how the task reaches this test's connection at all,
+  so it identifies the ones that matter without an async test waiting on
+  another's work.
+  """
+  def drain_best_effort_tasks(test_pid) do
+    Fountain.TaskSupervisor
+    |> Task.Supervisor.children()
+    |> Enum.filter(&started_by?(&1, test_pid))
+    |> Enum.each(&await_down/1)
+  end
+
+  defp started_by?(pid, test_pid) do
+    case Process.info(pid, :dictionary) do
+      {:dictionary, dictionary} -> test_pid in Keyword.get(dictionary, :"$callers", [])
+      nil -> false
+    end
+  end
+
+  defp await_down(pid) do
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    after
+      @drain_timeout_ms -> Process.demonitor(ref, [:flush])
+    end
   end
 
   @doc """

--- a/apps/fountain/test/support/data_case.ex
+++ b/apps/fountain/test/support/data_case.ex
@@ -37,8 +37,11 @@ defmodule Fountain.DataCase do
 
   # Long enough that a `last_used_at` stamp or a test-adapter email always
   # lands, short enough that a task which is genuinely stuck cannot stall the
-  # suite. Never reached in practice — both sites are a single round trip.
-  @drain_timeout_ms 500
+  # suite. Never reached in practice — both sites are a single round trip, and
+  # this returns as soon as the task is down — but the ceiling is generous on
+  # purpose: the drain exists to keep loaded runs from churning connections, so
+  # it must not be the thing that gives up first when a run is loaded.
+  @drain_timeout_ms 2_000
 
   @doc """
   Sets up the sandbox based on the test tags.


### PR DESCRIPTION
Fixes #1040.

## What was wrong

`FountainWeb.Plugs.TenantAPIAuth` stamped `last_used_at` in a `Task.async` that nothing awaited. `Task.async` **links**, so when the stamp could not check out a connection it raised and the exit signal followed the link back to the process that started it:

- in production that is the request process, so a blip writing a column nothing reads on the hot path could kill an API call that had already authenticated;
- under the SQL Sandbox it is the test process, which is how the issue surfaced — a `TeamScheduleControllerTest` case failed in CI on a write it never asserted on, and passed on re-run.

`FountainWeb.PasswordResetController.api_forgot/2` had the same shape, so a delivery error could take down the request that was about to answer 200.

## What changed

- **`Fountain.TaskSupervisor` in the application tree** (option 1 in the issue). Both fire-and-forget sites now use `Task.Supervisor.start_child/2`: unlinked, supervised, and a crash is logged rather than propagated.
- **`Accounts.touch_api_key/1` rescues** as well (option 3), the position `Audit.record/1` already takes for the same reason: a failed best-effort write is a log line, not a crash report. Its docstring no longer says "via `Task.async`" — that was the part that was wrong — and now states that it always returns `:ok`.
- **`DataCase` drains the tasks a test started** before stopping the sandbox owner. This one is not in the issue but falls out of the fix: an unlinked task outlives the test that started it, so it was still holding a sandbox connection when the owner stopped. That drops the connection and logs a disconnect on roughly every API test — churn in the very pool the original flake was blamed on. Tasks are matched by `$callers` (which is also how the task reaches the test's connection at all), so an async test never waits on another's work. Measured: the touched files went from 2 disconnect reports per run to 0.
- **CLAUDE.md** gains a "things not to do" bullet, since the next unawaited `Task.async` is the next instance of this bug. `Analytics.Sink` and `Sandbox.E2B.CommandServer` keep theirs — they hold the ref and handle the reply, which is what `Task.async` is for.

No ADR: this is a bug fix that adds one supervisor, and it constrains nothing the guide does not already say.

## Coverage, against the issue's acceptance list

- *No unawaited `Task.async` remains in a request path* — the two sites are the only ones; the two that stay are awaited inside a supervised GenServer.
- *A raise inside the `last_used_at` write cannot fail the request or the test that made it* — `tenant_api_auth_test.exs` stubs the stamp to raise, syncs on the task actually dying, then asserts the conn is intact, the crash was logged, and (trapping exits, so a regression is an assertion failure rather than a mystery EXIT) that no exit signal came back. A second test pins that the stamp runs off the request process at all. `password_reset_controller_test.exs` does the same for a raising delivery. `accounts_additional_test.exs` covers the rescue directly, from a process with no sandbox connection — what a pool blip looks like from inside the task.
- *`TeamScheduleControllerTest` and `ApiKeyControllerTest` survive a run with the test pool under contention* — ran both against a second BEAM working through `test/fountain_web/controllers/` on the same 20-connection pool: 23 tests, 0 failures in the foreground, 705 tests, 0 failures in the background.

## Gate

`mix precommit`, read stage by stage rather than by exit code:

```
compile --warnings-as-errors   clean
format --check-formatted       clean
credo --strict                 5591 mods/funs, found no issues
dialyzer                       Total errors: 0, Skipped: 0, Unnecessary Skips: 0
sobelow --config               SCAN COMPLETE, no findings
test                           6 doctests, 3 properties, 3947 tests, 0 failures
```

No `docs/` changes, so the prose gates do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)