### PR TITLE
docs(examples): fountain-contributor runs the gate in the foreground and ends no turn with work pending

### DIFF
--- a/examples/agents/fountain-contributor/README.md
+++ b/examples/agents/fountain-contributor/README.md
@@ -84,10 +84,13 @@ and test, so the suite runs in the sandbox without it.
 
 ## What "done" looks like
 
-A green `mix precommit` in the sandbox — the agent is told to read the
-output, not the exit code — and one pull request on
+A green `mix precommit` in the sandbox — the agent is told to run it in the
+foreground and read the output, not the exit code — and one pull request on
 [BinaryBourbon/fountain](https://github.com/BinaryBourbon/fountain), opened
 with `gh`, commits signed off (`git commit -s`) under your vault's identity.
+The turn that claims completion names the pushed commit sha and the gate
+output it saw: backgrounded work dies when a turn ends (#817), so "I'll push
+once the suite passes" pushes nothing.
 
 ## Guardrails
 

--- a/examples/agents/fountain-contributor/manifest.yml
+++ b/examples/agents/fountain-contributor/manifest.yml
@@ -137,11 +137,17 @@ spec:
       3. Read CONTRIBUTING.md, and decisions/index.md if the change is
          architectural.
 
-    Before you push: `mix precommit`. Read the output rather than the exit
-    code, an alias stage can fail while the alias exits 0. Confirm you reached
+    Before you push: `mix precommit`, run in the **foreground** — anything
+    you background dies when your turn ends, and a gate that died is a gate
+    that did not run. Read the output rather than the exit code, an alias
+    stage can fail while the alias exits 0. Confirm you reached
     "N tests, 0 failures". If you touched docs/, also run
     `mix test apps/fountain/test/fountain/docs_test.exs`,
     `python3 scripts/docs-style.py` and `vale lint docs`.
+
+    Never end a turn with work pending. "I'll push once the suite passes" is
+    a turn that pushed nothing: the turn that did the work is the turn that
+    states the pushed commit sha and the gate output you actually saw.
 
     Commit with `git commit -s` (DCO). Never push to main. One pull request,
     with what changed and why, and the gate output you actually saw.


### PR DESCRIPTION
Closes #1046.

Two additions to the `fountain-contributor` system prompt, per the issue:

- **Run `mix precommit` in the foreground** — backgrounded work dies when the turn ends (#817), so a backgrounded gate is a gate that did not run.
- **Never end a turn with work pending** — the turn that did the work states the pushed commit sha and the gate output actually seen; "I'll push once the suite passes" is a turn that pushed nothing.

Plus one matching sentence in the README's "What done looks like" section. `Agent.spec.system` is not a warm-start field, so this costs no checkpoint rebuild (the README's caveat is about `setup_script`/`packages`/`repositories`).

**Gate output seen**: `go test ./internal/manifest/...` → `ok github.com/BinaryBourbon/fountain/cli/internal/manifest 0.188s` (the examples-parse test the README names). No Elixir code touched, so the Elixir gate is CI's to confirm.

Pushed sha: e7ac521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mjb9TxAZD2Ebc1UnEDg2m