### PR TITLE
fix(test): FakeDaemon.stop/1 no longer races the socket it stops

### DIFF
--- a/apps/fountain/test/fountain/runners/fake_daemon_test.exs
+++ b/apps/fountain/test/fountain/runners/fake_daemon_test.exs
@@ -1,0 +1,43 @@
+defmodule Fountain.Runners.FakeDaemonTest do
+  @moduledoc """
+  `FakeDaemon.stop/1` is every runner test's `on_exit`, so it must never
+  raise: a teardown that exits fails a test that already passed. The socket
+  it stops can be gone before it gets there — a test that closed it, the
+  daemon going first — which is the race that took a `main` run down
+  (32676969894, partition 3).
+
+  These pin the contract (`:ok` whether the socket is up or already down),
+  not the interleaving: a socket dying between an aliveness check and the
+  stop cannot be scheduled deterministically, which is why `stop/1` has no
+  such check and catches the exit instead.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Runners.FakeDaemon
+
+  @runner_id "0f0e0d0c-0b0a-4908-8706-050403020101"
+  @user_id "11111111-2222-4333-8444-555555555556"
+
+  test "stop/1 is :ok when the socket is already down" do
+    {:ok, %{socket: socket} = daemon} = FakeDaemon.start(@runner_id, @user_id, name: "dead")
+
+    # Take the socket down before teardown does, the way a test that closes
+    # the connection (or a daemon crash) would. Unlink first: the socket is
+    # linked to this process and its exit would otherwise take the test with it.
+    Process.unlink(socket)
+    ref = Process.monitor(socket)
+    Process.exit(socket, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^socket, _}
+
+    assert :ok = FakeDaemon.stop(daemon)
+  end
+
+  test "stop/1 is :ok on a live socket, and the socket goes down" do
+    {:ok, %{socket: socket} = daemon} = FakeDaemon.start(@runner_id, @user_id, name: "live")
+    ref = Process.monitor(socket)
+
+    assert :ok = FakeDaemon.stop(daemon)
+    assert_receive {:DOWN, ^ref, :process, ^socket, _}
+  end
+end

--- a/apps/fountain/test/support/fake_runner_daemon.ex
+++ b/apps/fountain/test/support/fake_runner_daemon.ex
@@ -110,7 +110,17 @@ defmodule Fountain.Runners.FakeDaemon do
     Process.unlink(socket)
     Process.unlink(daemon)
     ref = Process.monitor(socket)
-    if Process.alive?(socket), do: GenServer.stop(socket, :shutdown, 1_000)
+
+    # The socket may already be down — a test that closed it, or the daemon
+    # going first — and `Process.alive?/1` followed by `stop/3` is a race: a
+    # process that dies between the two turns this teardown into a `:noproc`
+    # exit that fails a test which already passed (main run 32676969894).
+    # Stop it if it is there; the monitor below settles the rest either way.
+    try do
+      GenServer.stop(socket, :shutdown, 1_000)
+    catch
+      :exit, _ -> :ok
+    end
 
     receive do
       {:DOWN, ^ref, :process, _, _} -> :ok


### PR DESCRIPTION
## What

`main`'s CI run for `c35e8dd6` (#1049's merge) failed in partition 3 on `runner_conformance_test.exs:8` — not in the test, in its `on_exit`: `FakeDaemon.stop/1` exited with `no process` from `GenServer.stop/3`. The same partition was green on the PR at identical content; the job passed on re-run. https://github.com/BinaryBourbon/fountain/actions/runs/32676969894

## Why

`stop/1` did `if Process.alive?(socket), do: GenServer.stop(socket, :shutdown, 1_000)` — a check-then-act. A socket that dies between the two (a test that closed the connection, or the daemon going first) turns every runner test's teardown into a `:noproc` exit that fails a test which already passed.

## How

Drop the aliveness check; stop the socket if it is there and catch the exit. The monitor + `:DOWN` wait that already followed settles the rest either way. The daemon kill is unchanged.

## Testing

- New `fake_daemon_test.exs`: `stop/1` is `:ok` with the socket up and with it already down. **This pins the contract, not the race** — a death between two adjacent calls can't be scheduled deterministically. Verified by reverting the fix: the old code passes it too (its `alive?` guard handles an *already*-dead socket; what it can't handle is the window). So the test guards the shape of the fix; the fix is correct by construction.
- `runner_conformance_test.exs` ×5 and all eight `FakeDaemon` callers: 61 tests, 0 failures. `mix format --check-formatted` and `credo --strict` clean. Full suite running locally as this opens; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
