### PR TITLE
feat(conversations): a conversation's identity travels with its process, not the sandbox's disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Changed
+
+- **A conversation's identity travels with its process, not the sandbox's
+  disk.** `FOUNTAIN_TOKEN`, `FOUNTAIN_CONVERSATION_ID` and `TRACEPARENT` are
+  no longer written to `/home/sprite/.env`; they reach the agent as
+  environment on every spawn, exactly as before from the agent's point of
+  view. The runtime's detachable session is now started as
+  `env FOUNTAIN_CONVERSATION_ID=<id> <adapter> …`, and a reattach after a
+  deploy binds to the session carrying its own conversation's tag rather
+  than the head of the sandbox's session list — the prerequisite for several
+  conversations sharing one sandbox (ADR 0023, gate 1). A `setup_script`
+  that did `source .env` no longer sees the callback token; environment and
+  vault values are unaffected. The reattach stage event reports
+  `matched_by` (`tag`, or `untagged_head` for a session started before this
+  release).
+
 ### Added
 
 - **Agent config versioning with diff and rollback.** Every config change

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -727,7 +727,12 @@ defmodule Fountain.Conversations.ConversationServer do
 
         write_runtime_config(handle, state.runtime_module, agent)
         write_instructions(handle, runtime, agent)
-        Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
+        # The file is the machine's; the conversation's identity travels as
+        # process env on every spawn (`Fountain.Conversations.Identity`).
+        Fountain.Conversations.Provisioning.write_env_file(
+          handle,
+          Fountain.Conversations.Identity.disk_env(sprite_env)
+        )
 
         with :ok <-
                run_provisioning_pipeline(handle, env, sprite_env, secrets, state.conversation_id),
@@ -945,7 +950,12 @@ defmodule Fountain.Conversations.ConversationServer do
 
         # Refresh the .env file in case secrets/env_vars were edited
         # between the original provision and this reattach.
-        Fountain.Conversations.Provisioning.write_env_file(handle, sprite_env)
+        # The file is the machine's; the conversation's identity travels as
+        # process env on every spawn (`Fountain.Conversations.Identity`).
+        Fountain.Conversations.Provisioning.write_env_file(
+          handle,
+          Fountain.Conversations.Identity.disk_env(sprite_env)
+        )
         # Same for the agent's system prompt: an edit reaches the existing
         # computer on its next wake (#848).
         write_instructions(handle, conv.runtime || (agent && agent.runtime) || "claude", agent)
@@ -1052,7 +1062,21 @@ defmodule Fountain.Conversations.ConversationServer do
           # `is_active: false` while no client is connected, but the
           # underlying exec is alive and `attach_session` resumes its
           # stream (replaying the session buffer + live-tailing).
-          attempt_session_attach(state, running_turn, sessions)
+          #
+          # Match on the conversation tag, never the head of the list: with
+          # several conversations on one machine, the head is as likely to be
+          # someone else's process as ours (`Fountain.Conversations.Identity`).
+          case Fountain.Conversations.Identity.pick_session(sessions, state.conversation_id) do
+            :none ->
+              mark_orphan(state, running_turn, "no_active_session")
+              state
+
+            {:tagged, session} ->
+              attempt_session_attach(state, running_turn, session, "tag")
+
+            {:untagged, session} ->
+              attempt_session_attach(state, running_turn, session, "untagged_head")
+          end
 
         {:error, reason} ->
           Logger.warning("list_sessions failed during reattach: #{inspect(reason)}")
@@ -1062,12 +1086,7 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
-  defp attempt_session_attach(state, running_turn, []) do
-    mark_orphan(state, running_turn, "no_active_session")
-    state
-  end
-
-  defp attempt_session_attach(state, running_turn, [session | _]) do
+  defp attempt_session_attach(state, running_turn, session, matched_by) do
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     acp? = Fountain.Runtimes.ACP.enabled?(conv.runtime)
 
@@ -1100,6 +1119,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
         publish_stage(state.conversation_id, "reattach", "done", %{
           outcome: "session_attached",
+          matched_by: matched_by,
           session_id: session.id,
           turn_id: running_turn.id,
           turn_number: running_turn.turn_number,
@@ -2638,6 +2658,11 @@ defmodule Fountain.Conversations.ConversationServer do
       })
 
     previous_span = OpenTelemetry.Tracer.set_current_span(turn_span)
+
+    # Tag the detachable session with this conversation, on its own command
+    # line, so a reattach after a deploy can tell it from another
+    # conversation's process on the same machine (ADR 0023 gate 1).
+    {cmd, args} = Fountain.Conversations.Identity.tag_command(state.conversation_id, cmd, args)
 
     # Stamped before the spawn so the duration covers the round trip to
     # sprites.dev — that latency is part of what the user waits through.

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -956,6 +956,7 @@ defmodule Fountain.Conversations.ConversationServer do
           handle,
           Fountain.Conversations.Identity.disk_env(sprite_env)
         )
+
         # Same for the agent's system prompt: an edit reaches the existing
         # computer on its next wake (#848).
         write_instructions(handle, conv.runtime || (agent && agent.runtime) || "claude", agent)

--- a/apps/fountain/lib/fountain/conversations/identity.ex
+++ b/apps/fountain/lib/fountain/conversations/identity.ex
@@ -1,0 +1,131 @@
+defmodule Fountain.Conversations.Identity do
+  @moduledoc """
+  Which conversation a process inside a sandbox belongs to — carried by the
+  process, never by the disk.
+
+  A sandbox row has been `has_many :conversations` since the first migration,
+  and `Fountain.Team.open_fresh_conversation/3` has produced a second
+  conversation on one row in production since #840. What stayed 1:1 was the
+  identity: `FOUNTAIN_TOKEN` (the per-conversation callback key) and
+  `FOUNTAIN_CONVERSATION_ID` were written to `/home/sprite/.env` — one path,
+  rewritten on every provision and reattach — and a reattach after a deploy
+  bound to the *head* of the sandbox's session list, because nothing on a
+  session said whose it was. Two conversations mid-turn on one machine across
+  a deploy would have streamed one agent into the other's transcript
+  (ADR 0023, survey items 1 and 2).
+
+  Three rules, all enforced here:
+
+    * **Identity is process env.** `disk_env/1` strips the per-conversation
+      pairs before the env file is written; the same pairs still reach every
+      spawn through `env:`, so the agent's tools inherit them exactly as
+      before. What a `source .env` in a setup script loses is the callback
+      token, which it had no business holding — the file is for environment
+      and vault values, which are the same for every conversation on the
+      machine.
+
+    * **A session names its conversation.** `tag_command/3` wraps the spawn as
+      `env FOUNTAIN_CONVERSATION_ID=<id> <cmd> <args…>`, so the tag is in the
+      command line every provider reports for a detachable session
+      (`Fountain.Sandbox.Session.command`) *and* the process gets the variable
+      from the same line. No argv is added to the adapter itself, which would
+      reject it.
+
+    * **Reattach matches on the tag.** `pick_session/2` takes the session
+      tagged with this conversation, ignores one tagged with another, and —
+      only while sessions spawned before this module existed are still alive —
+      falls back to an untagged head. That fallback is what keeps the deploy
+      that ships this from orphaning every turn in flight; it is not a
+      contract, and a session that carries someone else's tag is never taken.
+  """
+
+  alias Fountain.Sandbox.Session
+
+  @tag_key "FOUNTAIN_CONVERSATION_ID"
+
+  # Per-conversation pairs. `FOUNTAIN_BASE_URL` stays on disk: it is the same
+  # for every conversation and a setup script may legitimately read it.
+  @process_only [@tag_key, "FOUNTAIN_TOKEN", "TRACEPARENT"]
+
+  @tag_re ~r/(?:^|\s)FOUNTAIN_CONVERSATION_ID=([0-9a-fA-F-]{36})(?:\s|$)/
+
+  @doc "The env var that tags a session with its conversation."
+  @spec tag_key() :: String.t()
+  def tag_key, do: @tag_key
+
+  @doc """
+  The keys that never reach the shared env file.
+  """
+  @spec process_only_keys() :: [String.t()]
+  def process_only_keys, do: @process_only
+
+  @doc """
+  The subset of a sprite env that belongs on the machine's disk: everything
+  except the per-conversation identity.
+  """
+  @spec disk_env([{String.t(), String.t()}]) :: [{String.t(), String.t()}]
+  def disk_env(sprite_env) when is_list(sprite_env) do
+    Enum.reject(sprite_env, fn {k, _v} -> to_string(k) in @process_only end)
+  end
+
+  @doc """
+  Wrap a command so its session is tagged with `conv_id` and the process sees
+  the variable: `{"env", ["FOUNTAIN_CONVERSATION_ID=<id>", cmd | args]}`.
+  """
+  @spec tag_command(String.t(), String.t(), [String.t()]) :: {String.t(), [String.t()]}
+  def tag_command(conv_id, cmd, args) when is_binary(conv_id) and is_binary(cmd) do
+    {"env", ["#{@tag_key}=#{conv_id}", cmd | args]}
+  end
+
+  @doc """
+  The conversation a session was spawned for, read from its command line, or
+  `nil` for a session spawned before tagging existed (or by something else).
+  """
+  @spec conversation_id(Session.t()) :: String.t() | nil
+  def conversation_id(%Session{command: command}) when is_binary(command) do
+    case Regex.run(@tag_re, command, capture: :all_but_first) do
+      [id] -> String.downcase(id)
+      _ -> nil
+    end
+  end
+
+  def conversation_id(%Session{}), do: nil
+
+  @doc """
+  The session a reattaching server for `conv_id` should bind to.
+
+    * `{:tagged, session}` — a session carrying this conversation's tag. The
+      newest one if there are several (a peer that died mid-handshake can
+      leave an older idle adapter behind; the caller already stops those).
+    * `{:untagged, session}` — no session carries our tag, but one carries no
+      tag at all. Transitional: only sessions spawned before this tagging
+      existed look like this.
+    * `:none` — nothing to bind to. Sessions tagged with *another*
+      conversation are never offered.
+  """
+  @spec pick_session([Session.t()], String.t()) ::
+          {:tagged, Session.t()} | {:untagged, Session.t()} | :none
+  def pick_session(sessions, conv_id) when is_list(sessions) and is_binary(conv_id) do
+    wanted = String.downcase(conv_id)
+
+    {ours, others} =
+      Enum.split_with(sessions, fn s -> conversation_id(s) == wanted end)
+
+    untagged = Enum.filter(others, &is_nil(conversation_id(&1)))
+
+    cond do
+      ours != [] -> {:tagged, newest(ours)}
+      untagged != [] -> {:untagged, hd(untagged)}
+      true -> :none
+    end
+  end
+
+  # Providers report `created_at`; where they do not, list order stands.
+  defp newest(sessions) do
+    if Enum.all?(sessions, &match?(%DateTime{}, &1.created_at)) do
+      Enum.max_by(sessions, & &1.created_at, DateTime)
+    else
+      hd(sessions)
+    end
+  end
+end

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -32,9 +32,15 @@ defmodule Fountain.Conversations.Provisioning do
   @env_file "/home/sprite/.env"
 
   @doc """
-  Write the merged sprite env (default + callback + env_vars + secrets)
-  to `/home/sprite/.env` so a `setup_script` that does `source .env`
-  picks up the variables. Mirrors the legacy AoD's `env_file.py`.
+  Write the machine's env (runtime defaults + env_vars + secrets) to
+  `/home/sprite/.env` so a `setup_script` that does `source .env` picks up
+  the variables. Mirrors the legacy AoD's `env_file.py`.
+
+  The per-conversation identity — `FOUNTAIN_TOKEN`, `FOUNTAIN_CONVERSATION_ID`,
+  `TRACEPARENT` — is not in this file: callers pass the env through
+  `Fountain.Conversations.Identity.disk_env/1` first. The file is shared by
+  every conversation on the machine; the identity reaches each process as
+  spawn env instead.
 
   Written with mode 600, and `chmod 600` again after the write as defense
   in depth — other sandbox users (if any) must not be able to read tokens.

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -166,8 +166,10 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
     end
 
     test "runs the pinned adapter rather than the claude CLI", %{pid: pid} do
-      assert_receive {:spawned, cmd, _args, opts}
-      assert cmd == ACP.adapter_bin("claude")
+      # Spawned through `env` so the session carries its conversation tag on
+      # its own command line (ADR 0023 gate 1); the adapter is argv[1].
+      assert_receive {:spawned, "env", ["FOUNTAIN_CONVERSATION_ID=" <> _, bin | _], opts}
+      assert bin == ACP.adapter_bin("claude")
       assert opts[:stdin] == true
     end
 
@@ -934,7 +936,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
     test "a gemini turn spawns the native ACP binary in its own workspace", ctx do
       {_pid, _ref} = start_acp_turn(ctx.conv)
 
-      assert_receive {:spawned, "gemini", ["--acp"], opts}
+      assert_receive {:spawned, "env", ["FOUNTAIN_CONVERSATION_ID=" <> _, "gemini", "--acp"], opts}
       # /home/sprite would reintroduce the EACCES noise this workspace exists
       # to avoid, and gemini walks up from cwd looking for a .git.
       assert opts[:dir] == "/tmp/gemini-workspace"

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -936,7 +936,9 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
     test "a gemini turn spawns the native ACP binary in its own workspace", ctx do
       {_pid, _ref} = start_acp_turn(ctx.conv)
 
-      assert_receive {:spawned, "env", ["FOUNTAIN_CONVERSATION_ID=" <> _, "gemini", "--acp"], opts}
+      assert_receive {:spawned, "env", ["FOUNTAIN_CONVERSATION_ID=" <> _, "gemini", "--acp"],
+                      opts}
+
       # /home/sprite would reintroduce the EACCES noise this workspace exists
       # to avoid, and gemini walks up from cwd looking for a .git.
       assert opts[:dir] == "/tmp/gemini-workspace"

--- a/apps/fountain/test/fountain/conversations/conversation_server_identity_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_identity_test.exs
@@ -109,7 +109,9 @@ defmodule Fountain.Conversations.ConversationServerIdentityTest do
 
     test "binds to the session tagged with this conversation, not the head", ctx do
       {conv, _turn} = reattach_fixture(ctx)
-      other_conv = insert_conversation(user_id: ctx.user.id, agent: ctx.agent, sandbox: conv.sandbox)
+
+      other_conv =
+        insert_conversation(user_id: ctx.user.id, agent: ctx.agent, sandbox: conv.sandbox)
 
       stub_happy_sprite()
       ref = stub_turn_boundary()
@@ -139,7 +141,9 @@ defmodule Fountain.Conversations.ConversationServerIdentityTest do
 
     test "never takes a session tagged for another conversation", ctx do
       {conv, turn} = reattach_fixture(ctx)
-      other_conv = insert_conversation(user_id: ctx.user.id, agent: ctx.agent, sandbox: conv.sandbox)
+
+      other_conv =
+        insert_conversation(user_id: ctx.user.id, agent: ctx.agent, sandbox: conv.sandbox)
 
       stub_happy_sprite()
       _ref = stub_turn_boundary()

--- a/apps/fountain/test/fountain/conversations/conversation_server_identity_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_identity_test.exs
@@ -1,0 +1,197 @@
+defmodule Fountain.Conversations.ConversationServerIdentityTest do
+  # Per-process identity (ADR 0023 gate 1): the conversation a process belongs
+  # to travels with the process, never with the disk. The shared env file
+  # carries environment and vault values only; the callback token and the
+  # conversation id reach the adapter as process env; and the detachable
+  # session is tagged so a reattach after a deploy binds to *this*
+  # conversation's process rather than the head of the sandbox's list.
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Sandbox.Session
+
+  setup do
+    user = insert_verified_user()
+    env = insert_env(user_id: user.id, env_vars: %{"FROM_ENVIRONMENT" => "yes"})
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+    {:ok, user: user, agent: agent, env: env}
+  end
+
+  defp stub_turn_boundary do
+    test = self()
+    ref = make_ref()
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, cmd, args, opts ->
+      send(test, {:spawned, cmd, args, opts})
+      {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
+    end)
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _c, _data -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _c -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :stop_command, fn _c -> :ok end)
+    ref
+  end
+
+  describe "a fresh provision" do
+    test "keeps the identity off the disk and on the process", %{user: user, agent: agent} do
+      conv = insert_conversation(user_id: user.id, agent: agent)
+      test = self()
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+
+      Mimic.stub(Fountain.Conversations.Provisioning, :write_env_file, fn _h, env ->
+        send(test, {:env_file, env})
+        :ok
+      end)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      assert_receive {:env_file, file_env}, 2_000
+      file_keys = Enum.map(file_env, fn {k, _} -> k end)
+
+      # The file is the machine's: environment values, no conversation.
+      assert "FROM_ENVIRONMENT" in file_keys
+      refute "FOUNTAIN_TOKEN" in file_keys
+      refute "FOUNTAIN_CONVERSATION_ID" in file_keys
+      refute "TRACEPARENT" in file_keys
+
+      # The process is the conversation's: identity as env, and the session
+      # tagged on its own command line.
+      assert_receive {:spawned, cmd, args, opts}, 2_000
+      spawn_env = Keyword.fetch!(opts, :env)
+      assert {"FOUNTAIN_CONVERSATION_ID", conv.id} in spawn_env
+      assert Enum.any?(spawn_env, &match?({"FOUNTAIN_TOKEN", token} when is_binary(token), &1))
+      assert {"FROM_ENVIRONMENT", "yes"} in spawn_env
+
+      assert cmd == "env"
+      assert ["FOUNTAIN_CONVERSATION_ID=" <> tag, "claude-agent-acp" | _] = args
+      assert tag == conv.id
+    end
+  end
+
+  describe "a reattach after a deploy" do
+    # A `ready` sandbox with a `running` ACP turn is what a server finds after
+    # a restart. The prompt id makes the attach a real one (#772).
+    defp reattach_fixture(%{user: user, agent: agent}) do
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      conv =
+        insert_conversation(
+          agent: agent,
+          user_id: user.id,
+          sandbox: sandbox,
+          status: "running",
+          runtime_session_id: "sess_live"
+        )
+
+      turn =
+        insert_turn(conv, %{
+          status: "running",
+          prompt: "long task",
+          started_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          acp_prompt_id: 4
+        })
+
+      {conv, turn}
+    end
+
+    defp tagged(id, conv_id) do
+      %Session{id: id, command: "env FOUNTAIN_CONVERSATION_ID=#{conv_id} claude-agent-acp"}
+    end
+
+    defp reattach_outcomes(conv_id) do
+      conv_id
+      |> Conversations._unsafe_list_log_events()
+      |> Enum.filter(&(&1.kind == "stage" and &1.stage == "reattach"))
+      |> Enum.map(&Jason.decode!(&1.data))
+    end
+
+    test "binds to the session tagged with this conversation, not the head", ctx do
+      {conv, _turn} = reattach_fixture(ctx)
+      other_conv = insert_conversation(user_id: ctx.user.id, agent: ctx.agent, sandbox: conv.sandbox)
+
+      stub_happy_sprite()
+      ref = stub_turn_boundary()
+      test = self()
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :list_sessions, fn _h ->
+        {:ok, [tagged("theirs", other_conv.id), tagged("ours", conv.id)]}
+      end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :attach, fn _h, id, _opts ->
+        send(test, {:attached, id})
+        {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
+      end)
+
+      {pid, _mon, :alive} = start_server(conv)
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      assert_receive {:attached, "ours"}, 2_000
+      refute_received {:attached, "theirs"}
+      assert is_pid(:sys.get_state(pid).acp_peer)
+
+      assert Enum.any?(reattach_outcomes(conv.id), fn d ->
+               d["outcome"] == "session_attached" and d["session_id"] == "ours" and
+                 d["matched_by"] == "tag"
+             end)
+    end
+
+    test "never takes a session tagged for another conversation", ctx do
+      {conv, turn} = reattach_fixture(ctx)
+      other_conv = insert_conversation(user_id: ctx.user.id, agent: ctx.agent, sandbox: conv.sandbox)
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+      test = self()
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :list_sessions, fn _h ->
+        {:ok, [tagged("theirs", other_conv.id)]}
+      end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :attach, fn _h, id, _opts ->
+        send(test, {:attached, id})
+        {:error, :should_not_be_called}
+      end)
+
+      {pid, _mon, :alive} = start_server(conv)
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      _ = :sys.get_state(pid)
+
+      refute_received {:attached, _}
+      assert [%{id: turn_id, status: "interrupted"}] = Conversations._unsafe_list_turns(conv.id)
+      assert turn_id == turn.id
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      assert Enum.any?(reattach_outcomes(conv.id), fn d ->
+               d["outcome"] == "turn_orphaned" and d["reason"] == "no_active_session"
+             end)
+    end
+
+    test "still binds to an untagged session from before tagging existed", ctx do
+      {conv, _turn} = reattach_fixture(ctx)
+
+      stub_happy_sprite()
+      ref = stub_turn_boundary()
+      test = self()
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :list_sessions, fn _h ->
+        {:ok, [%Session{id: "legacy", command: "claude-agent-acp"}]}
+      end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :attach, fn _h, id, _opts ->
+        send(test, {:attached, id})
+        {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
+      end)
+
+      {pid, _mon, :alive} = start_server(conv)
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      assert_receive {:attached, "legacy"}, 2_000
+
+      assert Enum.any?(reattach_outcomes(conv.id), fn d ->
+               d["outcome"] == "session_attached" and d["matched_by"] == "untagged_head"
+             end)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/identity_test.exs
+++ b/apps/fountain/test/fountain/conversations/identity_test.exs
@@ -1,0 +1,107 @@
+defmodule Fountain.Conversations.IdentityTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Conversations.Identity
+  alias Fountain.Sandbox.Session
+
+  @conv "0b0f6e1a-4d4c-4c1a-9a2b-3c4d5e6f7a8b"
+  @other "ffffffff-1111-4222-8333-444444444444"
+
+  describe "disk_env/1" do
+    test "strips the per-conversation identity and keeps everything else" do
+      env = [
+        {"ANTHROPIC_API_KEY", "sk-1"},
+        {"FOUNTAIN_BASE_URL", "https://f.example"},
+        {"FOUNTAIN_TOKEN", "fk_secret"},
+        {"FOUNTAIN_CONVERSATION_ID", @conv},
+        {"TRACEPARENT", "00-abc-def-01"},
+        {"SANDBOX_URL", "https://sb.example"},
+        {"GITHUB_TOKEN", "ghp_x"}
+      ]
+
+      assert Identity.disk_env(env) == [
+               {"ANTHROPIC_API_KEY", "sk-1"},
+               {"FOUNTAIN_BASE_URL", "https://f.example"},
+               {"SANDBOX_URL", "https://sb.example"},
+               {"GITHUB_TOKEN", "ghp_x"}
+             ]
+    end
+
+    test "an empty env stays empty" do
+      assert Identity.disk_env([]) == []
+    end
+  end
+
+  describe "tag_command/3" do
+    test "wraps the command in env with the tag first" do
+      assert Identity.tag_command(@conv, "claude-agent-acp", ["--x"]) ==
+               {"env", ["FOUNTAIN_CONVERSATION_ID=#{@conv}", "claude-agent-acp", "--x"]}
+    end
+
+    test "round-trips through a provider's reported command line" do
+      {cmd, args} = Identity.tag_command(@conv, "codex-acp", [])
+      session = %Session{id: "1", command: Enum.join([cmd | args], " ")}
+      assert Identity.conversation_id(session) == @conv
+    end
+  end
+
+  describe "conversation_id/1" do
+    test "reads the tag wherever it sits on the line" do
+      assert Identity.conversation_id(%Session{
+               id: "1",
+               command: "/usr/bin/env FOUNTAIN_CONVERSATION_ID=#{@conv} gemini --acp"
+             }) == @conv
+    end
+
+    test "is nil for an untagged or absent command" do
+      assert Identity.conversation_id(%Session{id: "1", command: "claude-agent-acp"}) == nil
+      assert Identity.conversation_id(%Session{id: "1", command: nil}) == nil
+    end
+
+    test "does not match a value that is not a uuid" do
+      assert Identity.conversation_id(%Session{
+               id: "1",
+               command: "env FOUNTAIN_CONVERSATION_ID=nope claude-agent-acp"
+             }) == nil
+    end
+  end
+
+  describe "pick_session/2" do
+    defp tagged(id, conv, created \\ nil) do
+      %Session{
+        id: id,
+        command: "env FOUNTAIN_CONVERSATION_ID=#{conv} claude-agent-acp",
+        created_at: created
+      }
+    end
+
+    test "takes our tagged session over an earlier one tagged for another conversation" do
+      assert {:tagged, %Session{id: "ours"}} =
+               Identity.pick_session([tagged("theirs", @other), tagged("ours", @conv)], @conv)
+    end
+
+    test "never offers a session tagged for another conversation" do
+      assert :none = Identity.pick_session([tagged("theirs", @other)], @conv)
+    end
+
+    test "falls back to an untagged head only when nothing carries our tag" do
+      legacy = %Session{id: "legacy", command: "claude-agent-acp"}
+
+      assert {:untagged, ^legacy} =
+               Identity.pick_session([tagged("theirs", @other), legacy], @conv)
+
+      assert {:tagged, %Session{id: "ours"}} =
+               Identity.pick_session([legacy, tagged("ours", @conv)], @conv)
+    end
+
+    test "prefers the newest of several sessions tagged for us" do
+      old = tagged("old", @conv, ~U[2026-08-23 10:00:00Z])
+      new = tagged("new", @conv, ~U[2026-08-23 10:05:00Z])
+      assert {:tagged, %Session{id: "new"}} = Identity.pick_session([old, new], @conv)
+    end
+
+    test "an empty list is :none" do
+      assert :none = Identity.pick_session([], @conv)
+    end
+  end
+end

--- a/apps/fountain/test/support/fake_sandbox.ex
+++ b/apps/fountain/test/support/fake_sandbox.ex
@@ -164,7 +164,9 @@ defmodule Fountain.Sandbox.Fake do
 
       Agent.update(@registry, fn state ->
         put_in(state, [name, :sessions, session_id], %{
-          command: cmd,
+          # The full line, as the runner daemon and the sprites API report it —
+          # a session's conversation tag lives in its argv.
+          command: Enum.join([cmd | args], " "),
           pid: pid,
           exit: nil,
           buffer: [],


### PR DESCRIPTION
ADR 0023 **gate 1** (as amended in #1057): the prerequisite for several conversations sharing one sandbox, and a bug fix for the ephemeral mode on its own.

## Why

The sandbox row has been `has_many :conversations` since the first migration, and `Team.open_fresh_conversation` (#840) produces a second conversation on one row in production. What stayed 1:1 was the identity:

- `FOUNTAIN_TOKEN` and `FOUNTAIN_CONVERSATION_ID` were written to `/home/sprite/.env` — one path, rewritten on every provision and reattach.
- A reattach after a deploy bound to the **head** of the sandbox's session list (`attempt_session_attach/3`), because nothing on a `Session` said whose it was.

Two conversations mid-turn on one machine across a deploy would have streamed one agent into the other's transcript, silently. #817's planned "reap on reattach" needs the same tag to avoid killing another conversation's turn.

## What

- **`Fountain.Conversations.Identity`** (new, pure). `disk_env/1` strips `FOUNTAIN_TOKEN`, `FOUNTAIN_CONVERSATION_ID`, `TRACEPARENT` before the env file is written; they still reach every spawn through `env:`, which is where the agent's tools already read them. `FOUNTAIN_BASE_URL` stays on disk.
- **Sessions are tagged.** The turn is spawned as `env FOUNTAIN_CONVERSATION_ID=<id> <adapter> …`, so the tag is in the command line every provider reports for a detachable session (sprites sends `cmd: [command | args]`; the runner daemon journals `cmd.Path + args`) and the process gets the variable from the same line. No argv reaches the adapter.
- **Reattach matches on the tag.** `pick_session/2`: ours wins (newest if several), a session tagged for *another* conversation is never taken, and an untagged session — one spawned before this release — is still attached to as the head, so the deploy that ships this does not orphan turns in flight. The `reattach`/`done` stage event carries `matched_by: "tag" | "untagged_head"` so the transition is observable in prod.
- `FakeSandbox` records the full command line, matching both real providers.

**Behaviour change to know about:** a `setup_script` that did `source .env` no longer sees the callback token. Environment and vault values are unaffected. CHANGELOG has the entry.

## Verify after deploy

Look for `matched_by` on `reattach`/`done` events after the first deploy past this one: `untagged_head` for sessions spawned before, `tag` after. If a post-deploy reattach reports `untagged_head` for a session spawned *after* this release, sprites is not reporting argv in `command` and the tag needs a second carrier.

## Gate

- `mix precommit` — **3,993 tests, 0 failures**; format and credo clean (run explicitly).
- New: `identity_test.exs` (12), `conversation_server_identity_test.exs` (4: env file vs spawn env, tag beats head, foreign tag is never taken, untagged fallback). The four server tests were run against the unchanged server first and failed for the expected reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
