### PR TITLE
feat(conversations): a sandbox several conversations hold is one machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ upgrade, is in
 
 ### Changed
 
+- **A sandbox several conversations hold is treated as one machine.**
+  Three rules that used to be one conversation's to break (ADR 0023, steps
+  4 and 5): a turn on an opencode or gemini sandbox is refused with
+  `409 sandbox_at_capacity` while another conversation's turn runs there
+  (claude and codex run several at once — `Runtimes.ACP.concurrency/1`, and
+  the check is made under a per-sandbox lock so two prompts cannot both
+  start); terminating a conversation destroys the sprite only when it was
+  the last conversation on it; and the idle timeout parks the machine only
+  when every conversation on it has been quiet for the bound, at which
+  point the other conversations' servers are stopped so their next prompt
+  wakes it properly. Scheduled teammate runs treat `sandbox_at_capacity`
+  like a busy teammate and retry within their window.
+
 - **A conversation's identity travels with its process, not the sandbox's
   disk.** `FOUNTAIN_TOKEN`, `FOUNTAIN_CONVERSATION_ID` and `TRACEPARENT` are
   no longer written to `/home/sprite/.env`; they reach the agent as

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -989,6 +989,142 @@ defmodule Fountain.Conversations do
     end
   end
 
+  # Advisory-lock namespace for per-sandbox machine operations. Distinct from
+  # Quotas' per-user reservation (4315): this one is taken inside a turn
+  # start, and the two must never be mistaken for one another.
+  @sandbox_lock_namespace 4316
+
+  @doc """
+  Create a turn on a sandbox that may be shared, refusing when the runtime's
+  capacity is used up by another conversation's running turn.
+
+  `capacity` is `Fountain.Runtimes.ACP.concurrency/1`: `:unbounded` (claude,
+  codex — several processes on one disk is the laptop shape) inserts exactly
+  as `_unsafe_create_turn/1` does; an integer is checked and inserted under
+  a per-sandbox advisory lock, so two conversations prompting the same
+  opencode or gemini machine at the same moment cannot both win. Answers
+  `{:error, :sandbox_at_capacity}` rather than queueing (ADR 0023 step 4).
+  Usage is recorded after the transaction commits, never inside it.
+  """
+  def _unsafe_create_turn_on_sandbox(attrs, _sandbox_id, :unbounded),
+    do: _unsafe_create_turn(attrs)
+
+  def _unsafe_create_turn_on_sandbox(attrs, sandbox_id, capacity)
+      when is_binary(sandbox_id) and is_integer(capacity) and capacity > 0 do
+    conv_id = Map.fetch!(attrs, :conversation_id)
+
+    result =
+      Repo.transaction(fn ->
+        Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
+          @sandbox_lock_namespace,
+          :erlang.phash2(sandbox_id)
+        ])
+
+        if _unsafe_running_turns_elsewhere(sandbox_id, conv_id) >= capacity do
+          Repo.rollback(:sandbox_at_capacity)
+        else
+          case %Turn{} |> Turn.changeset(attrs) |> Repo.insert() do
+            {:ok, turn} -> turn
+            {:error, changeset} -> Repo.rollback(changeset)
+          end
+        end
+      end)
+
+    with {:ok, turn} <- result do
+      record_turn_usage(turn)
+      {:ok, turn}
+    end
+  end
+
+  @doc """
+  How many turns are running right now on `sandbox_id` for conversations
+  other than `conv_id`. `_unsafe_`: the caller owns `conv_id`.
+  """
+  def _unsafe_running_turns_elsewhere(sandbox_id, conv_id)
+      when is_binary(sandbox_id) and is_binary(conv_id) do
+    Repo.one(
+      from t in Turn,
+        join: c in Conversation,
+        on: c.id == t.conversation_id,
+        where: c.sandbox_id == ^sandbox_id and c.id != ^conv_id and t.status == "running",
+        select: count(t.id)
+    )
+  end
+
+  @doc """
+  Whether `sandbox_id` cannot take another turn from `conv_id` because other
+  conversations already fill its runtime's capacity. Always false for
+  `:unbounded`. An unlocked read for the API door; the locked check is
+  `_unsafe_create_turn_on_sandbox/3`.
+  """
+  def _unsafe_sandbox_at_capacity?(_sandbox_id, _conv_id, :unbounded), do: false
+
+  def _unsafe_sandbox_at_capacity?(sandbox_id, conv_id, capacity) when is_integer(capacity) do
+    _unsafe_running_turns_elsewhere(sandbox_id, conv_id) >= capacity
+  end
+
+  @doc """
+  The other conversations still holding `sandbox_id` — not `terminated` or
+  `failed` — as ids: the machine's co-tenants, for a lifecycle decision one
+  of them is about to make for all of them.
+  """
+  def _unsafe_list_cotenant_ids(sandbox_id, conv_id)
+      when is_binary(sandbox_id) and is_binary(conv_id) do
+    Repo.all(
+      from c in Conversation,
+        where:
+          c.sandbox_id == ^sandbox_id and c.id != ^conv_id and
+            c.status not in ["terminated", "failed"],
+        select: c.id
+    )
+  end
+
+  @doc """
+  Whether any *other* conversation on `sandbox_id` is mid-turn, or was active
+  within the last `idle_seconds`.
+
+  A server that finds its own conversation idle asks this before parking the
+  machine everyone is on: the idle verdict is the machine's, taken over the
+  union of its conversations' activity (ADR 0023 step 5), not one
+  conversation's clock. Activity is a co-tenant's newest turn row (start or
+  end), falling back to the conversation's own `updated_at` for one that
+  never took a turn — the same fold `SandboxReaper.last_activity_at/1` makes
+  for a sandbox with no server at all. `nil` idle seconds (the bound is off)
+  is never busy.
+  """
+  def _unsafe_sandbox_busy_elsewhere?(
+        sandbox_id,
+        conv_id,
+        idle_seconds,
+        now \\ DateTime.utc_now()
+      )
+
+  def _unsafe_sandbox_busy_elsewhere?(_sandbox_id, _conv_id, nil, _now), do: false
+
+  def _unsafe_sandbox_busy_elsewhere?(sandbox_id, conv_id, idle_seconds, now)
+      when is_integer(idle_seconds) do
+    cutoff = now |> DateTime.add(-idle_seconds, :second) |> DateTime.truncate(:second)
+
+    case _unsafe_list_cotenant_ids(sandbox_id, conv_id) do
+      [] ->
+        false
+
+      cotenants ->
+        Repo.exists?(
+          from t in Turn,
+            where:
+              t.conversation_id in ^cotenants and
+                (t.status == "running" or t.inserted_at > ^cutoff or t.ended_at > ^cutoff)
+        ) or
+          Repo.exists?(
+            from c in Conversation,
+              left_join: t in Turn,
+              on: t.conversation_id == c.id,
+              where: c.id in ^cotenants and is_nil(t.id) and c.updated_at > ^cutoff
+          )
+    end
+  end
+
   # Turns carry no user_id of their own, so resolve it through the conversation.
   # One narrow select per turn, and turns are prompt-frequency rather than
   # request-frequency, so this is not a hot path.

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1425,13 +1425,12 @@ defmodule Fountain.Conversations.ConversationServer do
     else
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
 
-      case turn_gate(conv.user_id) do
-        :ok ->
-          agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
-          {:reply, :ok, kick_turn(state, prompt, agent, images)}
-
-        {:error, _} = err ->
-          {:reply, err, state}
+      with :ok <- turn_gate(conv.user_id),
+           :ok <- capacity_gate(state, conv) do
+        agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
+        {:reply, :ok, kick_turn(state, prompt, agent, images)}
+      else
+        {:error, _} = err -> {:reply, err, state}
       end
     end
   end
@@ -1441,53 +1440,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   def handle_call(:interrupt, _from, state) do
-    # Tell the agent before killing its process. `session/cancel` is a
-    # notification with no reply, so this costs one write and does not delay the
-    # kill below — but it is the difference between an agent that stops its
-    # tool calls and one that is shot mid-write. This is the other reason stdin
-    # stays open on the ACP path.
-    if state.acp_peer, do: Fountain.Runtimes.ACP.Peer.cancel(state.acp_peer)
-
-    Fountain.Sandbox.stop_command(state.current_command)
-
-    {:ok, _turn} =
-      Conversations._unsafe_update_turn(state.current_turn, %{
-        status: "interrupted",
-        ended_at: now()
-      })
-
-    publish_stage(state.conversation_id, "turn", "interrupted", %{
-      turn_id: state.current_turn.id,
-      turn_number: state.current_turn.turn_number
-    })
-
-    # Finalize stream tracer: close any tool spans still open (abandoned calls).
-    finalize_tracer(state.stream_tracer)
-
-    # An ACP turn can also end here — the adapter exits, is interrupted, or its
-    # socket drops before it ever answers `session/prompt`. The peer has nothing
-    # left to drive and must not outlive the turn.
-    stop_acp_peer(state)
-
-    end_turn_span(state.current_turn_span, :error, %{"outcome" => "interrupted"})
-
-    emit_turn_completed(state, "interrupted")
-
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
-
-    {:reply, :ok,
-     %{
-       state
-       | current_command: nil,
-         current_command_ref: nil,
-         current_turn: nil,
-         current_turn_span: nil,
-         turn_metrics: nil,
-         stream_tracer: nil,
-         acp_peer: nil,
-         acp_peer_mon: nil
-     }}
+    {:reply, :ok, interrupt_turn(state)}
   end
 
   # First answer wins. The web apps and an editor (#708) are peer clients of
@@ -1510,16 +1463,34 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   def handle_call(:terminate_conv, _from, state) do
-    if state.handle, do: _ = Fountain.Sandbox.destroy(state.handle)
-    sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
+    if Conversations._unsafe_sandbox_held_by_other?(state.sandbox_id, state.conversation_id) do
+      # The machine is shared (ADR 0023): end this conversation and leave the
+      # sprite to the others — the same guard the no-server path applies in
+      # terminate_conversation/2. A turn of ours still running is cut first,
+      # since nothing would be left to drive it; `handle: nil` so no stop path
+      # touches the sprite.
+      state = if state.current_turn, do: interrupt_turn(state), else: state
+      conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
 
-    {:ok, _} =
-      Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
+      publish_stage(state.conversation_id, "terminate", "done", %{
+        sandbox: "kept",
+        reason: "held_by_another_conversation"
+      })
 
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
-    publish_stage(state.conversation_id, "terminate", "done")
-    {:stop, :normal, :ok, state}
+      {:stop, :normal, :ok, %{state | handle: nil}}
+    else
+      if state.handle, do: _ = Fountain.Sandbox.destroy(state.handle)
+      sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
+
+      {:ok, _} =
+        Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
+
+      conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+      publish_stage(state.conversation_id, "terminate", "done")
+      {:stop, :normal, :ok, state}
+    end
   end
 
   # End the conversation, keep the sandbox — see release_conversation/2. A
@@ -1577,6 +1548,26 @@ defmodule Fountain.Conversations.ConversationServer do
           {:noreply, state}
       end
     end
+  end
+
+  # Another conversation on this machine parked or destroyed it (see
+  # stop_cotenants/4). Record that on this transcript, cut a turn that has
+  # nothing left to run on, and stop: with no handle there is nothing this
+  # server can do, and the wake path is what brings the machine back.
+  def handle_cast({:machine_gone, event, reason, message}, state) do
+    state = if state.current_turn, do: interrupt_turn(state), else: state
+
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
+
+    publish_stage(state.conversation_id, "sandbox", "done", %{
+      event: event,
+      reason: reason,
+      by: "another_conversation",
+      message: message
+    })
+
+    {:stop, :normal, %{state | handle: nil}}
   end
 
   # Catch-all for the same reason as the handle_call one above (#315).
@@ -2133,6 +2124,30 @@ defmodule Fountain.Conversations.ConversationServer do
   # billing too, so both of those degrade to the destroy arm. The decision
   # lives in Lifecycle.idle_action/1.
   defp reclaim_sandbox(state, :idle) do
+    if Conversations._unsafe_sandbox_busy_elsewhere?(
+         state.sandbox_id,
+         state.conversation_id,
+         Lifecycle.idle_timeout_seconds()
+       ) do
+      # This conversation is idle; the machine is not. Another conversation
+      # on it is mid-turn or was active more recently than the bound, so the
+      # verdict is the machine's to reach, over all of them (ADR 0023 step 5).
+      # Checked again on the next tick.
+      {:noreply, state}
+    else
+      reclaim_idle_machine(state)
+    end
+  end
+
+  # Max lifetime: tear down and stop, whatever the provider. This bound exists
+  # for the conversation that never stops being busy; the conversation stays
+  # `idle` and resumable — setting it `terminated` here would make a cost
+  # control into data loss. See Fountain.Conversations.Lifecycle.
+  defp reclaim_sandbox(state, :max_lifetime) do
+    destroy_sandbox(state, :max_lifetime)
+  end
+
+  defp reclaim_idle_machine(state) do
     with :suspend <- Lifecycle.idle_action(provider(state)),
          :ok <- suspend_sandbox(state) do
       park_sandbox(state)
@@ -2148,14 +2163,6 @@ defmodule Fountain.Conversations.ConversationServer do
 
         destroy_sandbox(state, :idle)
     end
-  end
-
-  # Max lifetime: tear down and stop, whatever the provider. This bound exists
-  # for the conversation that never stops being busy; the conversation stays
-  # `idle` and resumable — setting it `terminated` here would make a cost
-  # control into data loss. See Fountain.Conversations.Lifecycle.
-  defp reclaim_sandbox(state, :max_lifetime) do
-    destroy_sandbox(state, :max_lifetime)
   end
 
   # Explicitly park the sandbox before the row flips: for Sprites this is a
@@ -2195,7 +2202,25 @@ defmodule Fountain.Conversations.ConversationServer do
       provider: provider(state)
     })
 
+    stop_cotenants(state, "suspended", "idle", Lifecycle.explain(:idle, :suspend))
+
     {:stop, :normal, %{state | handle: nil}}
+  end
+
+  # A park or a destroy is a machine operation: every other conversation on
+  # the sandbox loses its handle with it. Tell their servers, so each records
+  # what happened on its own transcript and stops — the next prompt then takes
+  # the wake path, the only path that brings the machine back. A cast: a
+  # co-tenant whose server is already gone is not an error here.
+  defp stop_cotenants(state, event, reason, message) do
+    state.sandbox_id
+    |> Conversations._unsafe_list_cotenant_ids(state.conversation_id)
+    |> Enum.each(fn conv_id ->
+      case whereis(conv_id) do
+        nil -> :ok
+        pid -> GenServer.cast(pid, {:machine_gone, event, reason, message})
+      end
+    end)
   end
 
   # Tear down the sandbox and stop; the conversation stays `idle` and
@@ -2237,6 +2262,8 @@ defmodule Fountain.Conversations.ConversationServer do
       reason: reason,
       provider: provider(state)
     })
+
+    stop_cotenants(state, "reclaimed", to_string(reason), reclaim_message(reason))
 
     {:stop, :normal, %{state | handle: nil}}
   end
@@ -2490,19 +2517,107 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
+  # End the running turn without a verdict from the agent: the user asked, or
+  # the machine under it is going away. Tells the agent before killing its
+  # process — `session/cancel` is a notification with no reply, so it costs
+  # one write and does not delay the kill, but it is the difference between
+  # an agent that stops its tool calls and one that is shot mid-write. This is
+  # the other reason stdin stays open on the ACP path.
+  defp interrupt_turn(state) do
+    if state.acp_peer, do: Fountain.Runtimes.ACP.Peer.cancel(state.acp_peer)
+    if state.current_command, do: Fountain.Sandbox.stop_command(state.current_command)
+
+    {:ok, _turn} =
+      Conversations._unsafe_update_turn(state.current_turn, %{
+        status: "interrupted",
+        ended_at: now()
+      })
+
+    publish_stage(state.conversation_id, "turn", "interrupted", %{
+      turn_id: state.current_turn.id,
+      turn_number: state.current_turn.turn_number
+    })
+
+    # Finalize stream tracer: close any tool spans still open (abandoned calls).
+    finalize_tracer(state.stream_tracer)
+
+    # An ACP turn can also end here — the adapter exits, is interrupted, or its
+    # socket drops before it ever answers `session/prompt`. The peer has nothing
+    # left to drive and must not outlive the turn.
+    stop_acp_peer(state)
+
+    end_turn_span(state.current_turn_span, :error, %{"outcome" => "interrupted"})
+
+    emit_turn_completed(state, "interrupted")
+
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+
+    %{
+      state
+      | current_command: nil,
+        current_command_ref: nil,
+        current_turn: nil,
+        current_turn_span: nil,
+        turn_metrics: nil,
+        stream_tracer: nil,
+        acp_peer: nil,
+        acp_peer_mon: nil
+    }
+  end
+
+  # Whether this machine can take a turn from this conversation right now. An
+  # unlocked read — the locked check is inside the turn insert
+  # (`_unsafe_create_turn_on_sandbox/3`); this one exists so the API door gets
+  # a refusal to render rather than an `:ok` followed by a refused stage.
+  defp capacity_gate(state, conv) do
+    capacity = Fountain.Runtimes.ACP.concurrency(conv.runtime)
+
+    if Conversations._unsafe_sandbox_at_capacity?(state.sandbox_id, conv.id, capacity),
+      do: {:error, :sandbox_at_capacity},
+      else: :ok
+  end
+
   defp kick_turn(state, prompt, agent, images) do
     state = touch_activity(state)
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     turn_number = Conversations._unsafe_next_turn_number(state.conversation_id)
 
-    {:ok, turn} =
-      Conversations._unsafe_create_turn(%{
-        conversation_id: conv.id,
-        turn_number: turn_number,
-        prompt: prompt,
-        status: "running",
-        started_at: now()
-      })
+    attrs = %{
+      conversation_id: conv.id,
+      turn_number: turn_number,
+      prompt: prompt,
+      status: "running",
+      started_at: now()
+    }
+
+    # The machine may be shared (ADR 0023). For a runtime that takes one turn
+    # at a time the insert is checked under the sandbox's lock, so two
+    # conversations prompting the same machine at once cannot both start.
+    capacity = Fountain.Runtimes.ACP.concurrency(conv.runtime)
+
+    case Conversations._unsafe_create_turn_on_sandbox(attrs, state.sandbox_id, capacity) do
+      {:ok, turn} ->
+        run_turn(state, conv, turn, prompt, agent, images)
+
+      {:error, :sandbox_at_capacity} ->
+        # Refused, not queued. Nothing was written; the conversation stays
+        # idle and the caller sends again when the other turn ends.
+        publish_stage(state.conversation_id, "sandbox", "done", %{
+          event: "at_capacity",
+          reason: "sandbox_at_capacity",
+          runtime: conv.runtime,
+          message:
+            "Another conversation is running a turn on this sandbox, and #{conv.runtime} " <>
+              "takes one turn at a time. Wait for it to finish, or interrupt it, then send again."
+        })
+
+        state
+    end
+  end
+
+  defp run_turn(state, conv, turn, prompt, agent, images) do
+    turn_number = turn.turn_number
 
     # Store images. A rejected image must not take the turn down with it: this
     # used to hard-match {:ok, _}, which is why validation could not be added to

--- a/apps/fountain/lib/fountain/runtimes/acp.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp.ex
@@ -148,7 +148,11 @@ defmodule Fountain.Runtimes.ACP do
       bin: "gemini",
       args: ["--acp"],
       package: nil,
-      version: nil
+      version: nil,
+      # One turn at a time on a shared sandbox: the session store is
+      # consolidated at the end of every turn, and a second live session
+      # during that consolidation is the collision it exists to avoid.
+      concurrency: 1
     },
     # Adapter, on the Codex App Server. The `zed-industries/codex-acp` that
     # earlier drafts named is archived; this is its successor under the
@@ -181,7 +185,11 @@ defmodule Fountain.Runtimes.ACP do
       args: ["acp"],
       package: nil,
       version: nil,
-      asks_permission: false
+      asks_permission: false,
+      # One turn at a time on a shared sandbox: `opencode acp` starts an HTTP
+      # server per process over one sqlite store — a port and a writer
+      # collision the moment a second one starts.
+      concurrency: 1
     }
   }
 
@@ -197,6 +205,30 @@ defmodule Fountain.Runtimes.ACP do
   @spec supported_runtimes() :: [String.t()]
   def supported_runtimes do
     @adapters |> Enum.reject(fn {_k, v} -> v[:blocked] end) |> Enum.map(&elem(&1, 0))
+  end
+
+  @doc """
+  How many turns may run at once on **one sandbox** for this runtime — the
+  machine's capacity for it, not the agent's (ADR 0023 step 4).
+
+  Several conversations may share a sandbox, each with its own adapter
+  process. What collides when two of those start on one disk is a property
+  of the runtime: claude and codex run one adapter per connection with
+  sessions keyed by explicit id and coexist the way several terminals do in
+  one repo (`:unbounded`); opencode and gemini keep state that two processes
+  cannot share (`1`, see the adapter table). A runtime without an adapter
+  entry has nothing to collide with and reads as `:unbounded`.
+
+  At capacity a turn is **refused**, not queued — `ConversationServer`
+  answers `{:error, :sandbox_at_capacity}` and the caller sends again when
+  the other turn ends.
+  """
+  @spec concurrency(String.t()) :: :unbounded | pos_integer()
+  def concurrency(runtime) when is_binary(runtime) do
+    case @adapters[runtime] do
+      %{concurrency: n} when is_integer(n) and n > 0 -> n
+      _ -> :unbounded
+    end
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/team/schedules.ex
+++ b/apps/fountain/lib/fountain/team/schedules.ex
@@ -287,6 +287,7 @@ defmodule Fountain.Team.Schedules do
 
   def describe_error(:sandbox_at_capacity),
     do: "teammate's computer was busy with another conversation"
+
   def describe_error(:provisioning), do: "teammate's computer was still starting"
   def describe_error(:not_found), do: "agent is not on the team"
   def describe_error(:subscription_required), do: "subscription inactive"

--- a/apps/fountain/lib/fountain/team/schedules.ex
+++ b/apps/fountain/lib/fountain/team/schedules.ex
@@ -284,6 +284,9 @@ defmodule Fountain.Team.Schedules do
 
   # What a run's failure reads as on the row and in the UI. Never the prompt.
   def describe_error(:busy), do: "teammate was busy"
+
+  def describe_error(:sandbox_at_capacity),
+    do: "teammate's computer was busy with another conversation"
   def describe_error(:provisioning), do: "teammate's computer was still starting"
   def describe_error(:not_found), do: "agent is not on the team"
   def describe_error(:subscription_required), do: "subscription inactive"

--- a/apps/fountain/lib/fountain/workers/team_schedule_run.ex
+++ b/apps/fountain/lib/fountain/workers/team_schedule_run.ex
@@ -47,7 +47,11 @@ defmodule Fountain.Workers.TeamScheduleRun do
 
           # A runner-backed teammate whose machine is off (#834) is the
           # same wait: it may come back within the window.
-          {:error, reason} when reason in [:busy, :provisioning, :runner_offline] ->
+          # A shared machine busy with another conversation's turn
+          # (`:sandbox_at_capacity`) frees itself the same way a busy
+          # teammate does.
+          {:error, reason}
+          when reason in [:busy, :provisioning, :runner_offline, :sandbox_at_capacity] ->
             if stale?(args), do: :ok, else: {:snooze, @snooze}
 
           {:error, reason} ->

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -190,6 +190,20 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # A turn refused because another conversation is running one on the same
+  # sandbox and the runtime takes one at a time (ADR 0023 step 4). Not a
+  # queue: the caller sends again when the other turn ends, or interrupts it.
+  def call(conn, {:error, :sandbox_at_capacity}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "sandbox_at_capacity",
+      message:
+        "another conversation is running a turn on this sandbox and its runtime takes one " <>
+          "at a time; wait for it to finish or interrupt it, then send again"
+    })
+  end
+
   # The wake path could not reach the sandbox provider to check whether the
   # conversation's sandbox is still there (#799). Nothing was changed — the
   # row is deliberately left as it was rather than retired on a transport

--- a/apps/fountain/test/fountain/conversations/conversation_server_shared_sandbox_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_shared_sandbox_test.exs
@@ -1,0 +1,182 @@
+defmodule Fountain.Conversations.ConversationServerSharedSandboxTest do
+  # A ConversationServer on a machine other conversations also hold
+  # (ADR 0023 steps 4 and 5): a turn is refused at the runtime's capacity,
+  # terminating one conversation leaves the sprite to the others, and the
+  # idle verdict is taken over everyone's activity, not one server's clock.
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Repo
+
+  defp with_bounds(pairs, fun) do
+    previous = Enum.map(pairs, fn {k, _} -> {k, Application.get_env(:fountain, k)} end)
+    Enum.each(pairs, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+
+    try do
+      fun.()
+    after
+      Enum.each(previous, fn {k, v} -> Application.put_env(:fountain, k, v) end)
+    end
+  end
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+  # Two idle conversations of one agent on one `ready` sandbox. Starting a
+  # server for either takes the reattach path, which the shared harness's
+  # `get/1` probe stub already satisfies.
+  defp shared_machine(runtime) do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, runtime: runtime)
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    a = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    b = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    %{user: user, agent: agent, sandbox: sandbox, a: a, b: b}
+  end
+
+  defp stub_turn_boundary do
+    test = self()
+    ref = make_ref()
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :spawn, fn _h, cmd, args, opts ->
+      send(test, {:spawned, cmd, args, opts})
+      {:ok, %Fountain.Sandbox.Command{provider: :sprites, ref: ref}}
+    end)
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :write_stdin, fn _c, _data -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :close_stdin, fn _c -> :ok end)
+    Mimic.stub(Fountain.Sandbox.Sprites, :stop_command, fn _c -> :ok end)
+    ref
+  end
+
+  defp start(conv) do
+    {pid, ref, :alive} = start_server(conv)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    {pid, ref}
+  end
+
+  defp sandbox_stages(conv_id) do
+    conv_id
+    |> Conversations._unsafe_list_log_events()
+    |> Enum.filter(&(&1.kind == "stage" and &1.stage == "sandbox"))
+    |> Enum.map(&Jason.decode!(&1.data))
+  end
+
+  describe "capacity" do
+    test "a second prompt on an opencode machine is refused while another turn runs" do
+      %{a: a, b: b} = shared_machine("opencode")
+      insert_turn(a, %{status: "running", prompt: "busy", started_at: now()})
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+      {pid, _} = start(b)
+
+      assert {:error, :sandbox_at_capacity} = GenServer.call(pid, {:send_prompt, "hi", []})
+      assert Conversations._unsafe_list_turns(b.id) == []
+      assert Conversations._unsafe_get_conversation!(b.id).status == "idle"
+      refute_received {:spawned, _, _, _}
+    end
+
+    test "claude conversations run at the same time on one machine" do
+      %{a: a, b: b} = shared_machine("claude")
+      insert_turn(a, %{status: "running", prompt: "busy", started_at: now()})
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+      {pid, _} = start(b)
+
+      assert :ok = GenServer.call(pid, {:send_prompt, "hi", []})
+      assert_receive {:spawned, "env", _, _}, 2_000
+      assert [%{status: "running"}] = Conversations._unsafe_list_turns(b.id)
+    end
+
+    test "the locked insert refuses on the path that has no gate, and says so" do
+      # The API door reads the gate first; the initial prompt (a cast, no
+      # caller to answer) goes straight to the insert, which checks under the
+      # sandbox's advisory lock. Refused there means: no turn row, a stage
+      # event on the transcript, the conversation still idle.
+      %{a: a, b: b} = shared_machine("opencode")
+      insert_turn(a, %{status: "running", prompt: "busy", started_at: now()})
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+      {pid, _mon, :alive} = start_server(b, initial_prompt: "hi")
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      _ = :sys.get_state(pid)
+
+      assert Conversations._unsafe_list_turns(b.id) == []
+      assert Conversations._unsafe_get_conversation!(b.id).status == "idle"
+      refute_received {:spawned, _, _, _}
+
+      assert Enum.any?(sandbox_stages(b.id), &(&1["event"] == "at_capacity"))
+    end
+  end
+
+  describe "terminate" do
+    test "keeps the sprite while another conversation holds it, destroys it when last" do
+      %{a: a, b: b, sandbox: sandbox} = shared_machine("claude")
+      stub_happy_sprite()
+      test = self()
+      Mimic.stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> send(test, :destroyed) && :ok end)
+
+      {pid_a, ref_a} = start(a)
+      assert :ok = GenServer.call(pid_a, :terminate_conv)
+      assert :normal = assert_stopped(ref_a)
+
+      refute_received :destroyed
+      assert Repo.reload(sandbox).status == "ready"
+      assert Conversations._unsafe_get_conversation!(a.id).status == "terminated"
+
+      {pid_b, ref_b} = start(b)
+      assert :ok = GenServer.call(pid_b, :terminate_conv)
+      assert :normal = assert_stopped(ref_b)
+
+      assert_received :destroyed
+      assert Repo.reload(sandbox).status == "terminated"
+    end
+  end
+
+  describe "idle" do
+    test "an idle conversation does not park a machine another one is using" do
+      %{a: a, b: b, sandbox: sandbox} = shared_machine("claude")
+      stub_happy_sprite()
+      reject(&Fountain.Sandbox.Sprites.destroy/1)
+      turn = insert_turn(b, %{status: "running", prompt: "long", started_at: now()})
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        {pid, ref} = start(a)
+
+        :sys.replace_state(pid, fn state ->
+          %{state | last_activity_at: DateTime.add(DateTime.utc_now(), -7200, :second)}
+        end)
+
+        send(pid, :lifecycle_check)
+        _ = :sys.get_state(pid)
+        assert Process.alive?(pid)
+        assert Repo.reload(sandbox).status == "ready"
+
+        # The other conversation goes quiet: its turn ended two hours ago.
+        old = DateTime.add(now(), -7200, :second)
+
+        turn
+        |> Ecto.Changeset.change(status: "completed", ended_at: old, inserted_at: old)
+        |> Repo.update!()
+
+        send(pid, :lifecycle_check)
+        assert :normal = assert_stopped(ref)
+        assert Repo.reload(sandbox).status == "suspended"
+      end)
+    end
+
+    test "a co-tenant told the machine is gone records it and stops" do
+      %{b: b} = shared_machine("claude")
+      stub_happy_sprite()
+      {pid, ref} = start(b)
+
+      GenServer.cast(pid, {:machine_gone, "suspended", "idle", "parked by a neighbour"})
+      assert :normal = assert_stopped(ref)
+
+      assert Enum.any?(sandbox_stages(b.id), fn d ->
+               d["event"] == "suspended" and d["by"] == "another_conversation"
+             end)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/shared_sandbox_test.exs
+++ b/apps/fountain/test/fountain/conversations/shared_sandbox_test.exs
@@ -1,0 +1,151 @@
+defmodule Fountain.Conversations.SharedSandboxTest do
+  # The context-level rules for a sandbox that several conversations hold
+  # (ADR 0023 steps 4 and 5): capacity at turn start, co-tenancy, and the
+  # machine-wide idle verdict.
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+  alias Fountain.Repo
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, runtime: "opencode")
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    a = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    b = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    {:ok, user: user, agent: agent, sandbox: sandbox, a: a, b: b}
+  end
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+  defp running_turn(conv) do
+    insert_turn(conv, %{status: "running", prompt: "go", started_at: now()})
+  end
+
+  # A turn that ended `ago` seconds in the past, with its row dated to match.
+  defp old_turn(conv, ago) do
+    at = DateTime.add(now(), -ago, :second)
+
+    conv
+    |> insert_turn(%{status: "completed", prompt: "done", started_at: at, ended_at: at})
+    |> Ecto.Changeset.change(inserted_at: at)
+    |> Repo.update!()
+  end
+
+  describe "_unsafe_running_turns_elsewhere/2" do
+    test "counts other conversations' running turns only", %{a: a, b: b, sandbox: sandbox} do
+      assert Conversations._unsafe_running_turns_elsewhere(sandbox.id, a.id) == 0
+
+      running_turn(b)
+      old_turn(b, 10)
+      running_turn(a)
+
+      assert Conversations._unsafe_running_turns_elsewhere(sandbox.id, a.id) == 1
+      assert Conversations._unsafe_running_turns_elsewhere(sandbox.id, b.id) == 1
+    end
+  end
+
+  describe "_unsafe_create_turn_on_sandbox/3" do
+    test "refuses at capacity and writes nothing", %{a: a, b: b, sandbox: sandbox} do
+      running_turn(b)
+
+      attrs = %{
+        conversation_id: a.id,
+        turn_number: 1,
+        prompt: "hi",
+        status: "running",
+        started_at: now()
+      }
+
+      assert {:error, :sandbox_at_capacity} =
+               Conversations._unsafe_create_turn_on_sandbox(attrs, sandbox.id, 1)
+
+      assert Conversations._unsafe_list_turns(a.id) == []
+    end
+
+    test "inserts below capacity", %{a: a, sandbox: sandbox} do
+      attrs = %{
+        conversation_id: a.id,
+        turn_number: 1,
+        prompt: "hi",
+        status: "running",
+        started_at: now()
+      }
+
+      assert {:ok, turn} = Conversations._unsafe_create_turn_on_sandbox(attrs, sandbox.id, 1)
+      assert turn.status == "running"
+    end
+
+    test "an unbounded runtime never refuses", %{a: a, b: b, sandbox: sandbox} do
+      running_turn(b)
+
+      attrs = %{
+        conversation_id: a.id,
+        turn_number: 1,
+        prompt: "hi",
+        status: "running",
+        started_at: now()
+      }
+
+      assert {:ok, _} =
+               Conversations._unsafe_create_turn_on_sandbox(attrs, sandbox.id, :unbounded)
+    end
+  end
+
+  describe "_unsafe_sandbox_at_capacity?/3" do
+    test "is never at capacity for :unbounded", %{a: a, b: b, sandbox: sandbox} do
+      running_turn(b)
+      refute Conversations._unsafe_sandbox_at_capacity?(sandbox.id, a.id, :unbounded)
+      assert Conversations._unsafe_sandbox_at_capacity?(sandbox.id, a.id, 1)
+    end
+  end
+
+  describe "_unsafe_list_cotenant_ids/2" do
+    test "lists the live conversations on the machine other than this one", ctx do
+      assert Conversations._unsafe_list_cotenant_ids(ctx.sandbox.id, ctx.a.id) == [ctx.b.id]
+
+      {:ok, _} = Conversations.update_conversation(ctx.b, %{status: "terminated"})
+      assert Conversations._unsafe_list_cotenant_ids(ctx.sandbox.id, ctx.a.id) == []
+    end
+  end
+
+  describe "_unsafe_sandbox_busy_elsewhere?/4" do
+    test "no co-tenant, or the bound switched off, is never busy", ctx do
+      {:ok, _} = Conversations.update_conversation(ctx.b, %{status: "terminated"})
+      refute Conversations._unsafe_sandbox_busy_elsewhere?(ctx.sandbox.id, ctx.a.id, 3600)
+      refute Conversations._unsafe_sandbox_busy_elsewhere?(ctx.sandbox.id, ctx.a.id, nil)
+    end
+
+    test "a co-tenant mid-turn is busy however old the turn is", ctx do
+      turn = running_turn(ctx.b)
+      old = DateTime.add(now(), -99_999, :second)
+      turn |> Ecto.Changeset.change(inserted_at: old, started_at: old) |> Repo.update!()
+
+      assert Conversations._unsafe_sandbox_busy_elsewhere?(ctx.sandbox.id, ctx.a.id, 3600)
+    end
+
+    test "a co-tenant that finished a turn recently is busy; long ago is not", ctx do
+      old_turn(ctx.b, 7200)
+      refute Conversations._unsafe_sandbox_busy_elsewhere?(ctx.sandbox.id, ctx.a.id, 3600)
+
+      old_turn(ctx.b, 60)
+      assert Conversations._unsafe_sandbox_busy_elsewhere?(ctx.sandbox.id, ctx.a.id, 3600)
+    end
+
+    test "a co-tenant that never took a turn counts by its own row's age", ctx do
+      # Fresh row: touched just now.
+      assert Conversations._unsafe_sandbox_busy_elsewhere?(ctx.sandbox.id, ctx.a.id, 3600)
+
+      old = DateTime.add(now(), -7200, :second)
+      ctx.b |> Ecto.Changeset.change(updated_at: old) |> Repo.update!()
+      refute Conversations._unsafe_sandbox_busy_elsewhere?(ctx.sandbox.id, ctx.a.id, 3600)
+    end
+
+    test "this conversation's own activity does not count", ctx do
+      running_turn(ctx.a)
+      old = DateTime.add(now(), -7200, :second)
+      ctx.b |> Ecto.Changeset.change(updated_at: old) |> Repo.update!()
+      refute Conversations._unsafe_sandbox_busy_elsewhere?(ctx.sandbox.id, ctx.a.id, 3600)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/runtimes/acp_concurrency_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp_concurrency_test.exs
@@ -1,0 +1,29 @@
+defmodule Fountain.Runtimes.ACPConcurrencyTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Runtimes.ACP
+
+  # ADR 0023 step 4: how many turns one sandbox takes at once is a property
+  # of the runtime, not of the machine.
+
+  test "claude and codex run several turns at once on one sandbox" do
+    assert ACP.concurrency("claude") == :unbounded
+    assert ACP.concurrency("codex") == :unbounded
+  end
+
+  test "opencode and gemini take one turn at a time" do
+    assert ACP.concurrency("opencode") == 1
+    assert ACP.concurrency("gemini") == 1
+  end
+
+  test "a runtime with no adapter has nothing to collide with" do
+    assert ACP.concurrency("no-such-runtime") == :unbounded
+  end
+
+  test "every supported runtime has a capacity" do
+    for runtime <- ACP.supported_runtimes() do
+      assert ACP.concurrency(runtime) == :unbounded or
+               (is_integer(ACP.concurrency(runtime)) and ACP.concurrency(runtime) > 0)
+    end
+  end
+end


### PR DESCRIPTION
ADR 0023 **gate 2** (steps 4 and 5, as amended in #1057). Three decisions that one conversation's `ConversationServer` used to make for everyone on its sandbox are now the machine's. Builds on #1058.

## Capacity at turn start

`Runtimes.ACP.concurrency/1` says how many turns one sandbox takes at once for a runtime: `:unbounded` for claude and codex (one adapter per connection, sessions by explicit id — the laptop shape), `1` for opencode (`opencode acp` starts an HTTP server per process over one sqlite store) and gemini (its session store is consolidated at the end of every turn).

- A turn at capacity is **refused** — `{:error, :sandbox_at_capacity}`, `409 sandbox_at_capacity` at the API — never queued (decided 2026-08-23).
- The API door checks first so it has a refusal to render; the insert checks again under a **per-sandbox advisory lock** (`_unsafe_create_turn_on_sandbox/3`, namespace 4316 beside Quotas' 4315) so two prompts on one machine cannot both win. A refusal on the gateless path (the initial prompt, a cast) leaves a `sandbox`/`done` stage event with `event: "at_capacity"` and no turn row.
- Scheduled teammate runs snooze on `:sandbox_at_capacity` as they do on `:busy`.

## Terminate

The live `:terminate_conv` path now applies the guard the no-server path already had (`_unsafe_sandbox_held_by_other?`): the sprite is destroyed only when this was the **last** conversation on it. Otherwise our running turn is cut (`interrupt_turn/1`, extracted from the interrupt handler), the conversation ends, and the machine stays — stage `terminate`/`done` with `sandbox: "kept"`.

## Idle is the machine's verdict

`_unsafe_sandbox_busy_elsewhere?/4` folds the other conversations' activity the way `SandboxReaper.last_activity_at/1` already does: a server whose own conversation is idle does **not** park a sandbox another conversation is mid-turn on or used within the bound; it checks again next tick. When a park or a ceiling destroy does happen, the co-tenant servers are told (`{:machine_gone, event, reason, message}`), record it on their own transcripts, cut any turn, and stop — so their next prompt takes the wake path, the only path that brings the machine back.

**Design note vs the ADR text.** The ADR names a `SandboxServer` process as the lock and counter. This PR delivers the same three properties with a Postgres advisory lock at the one place a race matters (turn insert) and DB state for the refcount and clock — the pattern `with_sandbox_reservation/3` already uses — rather than a new cluster-wide Horde process to fail over. A process becomes worth it when the handle moves out of `ConversationServer`; I'll record this in the ADR when it moves to Accepted.

## Reachability

No API creates a second live conversation on a sandbox yet (that is gate 3, `sandbox_id` attach). Today the only path is `Team.open_fresh_conversation`, which releases the old one first — so these rules are inert in production until gate 3 lands, which is the point of shipping them first.

## Gate

- `mix precommit` at the root: **4,014 tests, 1 failure** — an unrelated 1 s `assert_receive` flake that passed on `mix test --failed`; format and credo clean; long lines wrapped for the pinned 1.19.2 formatter.
- New: `acp_concurrency_test.exs` (4), `shared_sandbox_test.exs` (11, context rules), `conversation_server_shared_sandbox_test.exs` (6). The six server tests were run against the reverted implementation: **5 fail, 1 passes** (the claude-runs-concurrently case, which is today's behaviour kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
