### PR TITLE
feat(conversations): attach a conversation to a sandbox you already have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Added
+
+- **A second conversation on a sandbox you already have.** `sandbox_id` on
+  `POST /api/conversations` attaches the new conversation to an existing
+  machine instead of provisioning one: it must be yours, `ready` or
+  `suspended`, and built for the same agent, environment and vault
+  (`sandbox_not_found`, `sandbox_not_attachable`,
+  `sandbox_identity_mismatch`, `sandbox_runtime_mismatch` say which rule
+  refused). The conversation opens idle on that disk and a prompt wakes it;
+  several conversations then run there at once. `GET /api/sandboxes` and
+  `GET /api/sandboxes/:id` list the caller's machines with the conversations
+  on each and which is mid-turn. Sandboxes now record the `agent_id` and
+  `vault_id` they were built for (backfilled). `fountain run --sandbox` and
+  the SDK's `run({ sandbox })`, `sandboxes()` and `sandbox(id)` carry it.
+  ADR 0023 gate 3.
+
 ### Changed
 
 - **A sandbox several conversations hold is treated as one machine.**

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1051,6 +1051,17 @@ defmodule Fountain.Conversations do
     )
   end
 
+  # No conversation to exclude: every running turn on the machine counts.
+  def _unsafe_running_turns_elsewhere(sandbox_id, nil) when is_binary(sandbox_id) do
+    Repo.one(
+      from t in Turn,
+        join: c in Conversation,
+        on: c.id == t.conversation_id,
+        where: c.sandbox_id == ^sandbox_id and t.status == "running",
+        select: count(t.id)
+    )
+  end
+
   @doc """
   Whether `sandbox_id` cannot take another turn from `conv_id` because other
   conversations already fill its runtime's capacity. Always false for
@@ -1059,7 +1070,8 @@ defmodule Fountain.Conversations do
   """
   def _unsafe_sandbox_at_capacity?(_sandbox_id, _conv_id, :unbounded), do: false
 
-  def _unsafe_sandbox_at_capacity?(sandbox_id, conv_id, capacity) when is_integer(capacity) do
+  def _unsafe_sandbox_at_capacity?(sandbox_id, conv_id, capacity)
+      when is_integer(capacity) and (is_binary(conv_id) or is_nil(conv_id)) do
     _unsafe_running_turns_elsewhere(sandbox_id, conv_id) >= capacity
   end
 
@@ -1671,7 +1683,17 @@ defmodule Fountain.Conversations do
     - `parent_conversation_id` — optional; UUID of the conversation that spawned this one
     - `title`                 — optional display title (the team page names a teammate with it)
   """
-  def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts \\ [])
+  def start_conversation(attrs, opts \\ [])
+
+  # `sandbox_id`: attach to a machine the caller already has instead of
+  # provisioning one (ADR 0023 gate 3). Everything about the launch is
+  # resolved the same way; only the sandbox step differs.
+  def start_conversation(%{"sandbox_id" => sandbox_id} = attrs, opts)
+      when is_binary(sandbox_id) and sandbox_id != "" do
+    attach_conversation(sandbox_id, attrs, opts)
+  end
+
+  def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts)
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
@@ -1690,6 +1712,10 @@ defmodule Fountain.Conversations do
            Fountain.Quotas.with_sandbox_reservation(user_id, fn ->
              create_sandbox(%{
                environment_id: env_id || agent.environment_id,
+               # The identity the disk is built from (ADR 0023); an attach
+               # later must name the same three.
+               agent_id: agent.id,
+               vault_id: vault_id,
                sprite_name: sprite_name,
                status: "pending",
                provider: Atom.to_string(provider),
@@ -1786,6 +1812,191 @@ defmodule Fountain.Conversations do
     else
       nil -> {:error, :not_found}
       {:error, _} = err -> err
+    end
+  end
+
+  # A conversation on a machine the caller already has (ADR 0023 gate 3).
+  #
+  # The launch is resolved exactly as a fresh one — agent, vault, environment,
+  # permission policy, parent, the account and billing gates — and then the
+  # sandbox is fetched tenant-scoped and checked instead of created: it must
+  # be `ready` or `suspended`, it must have been built for the same agent,
+  # environment and vault, and the runtime that shaped its disk must be the
+  # agent's runtime still. No quota reservation: nothing new is provisioned,
+  # and waking a `suspended` machine goes through the quota gate on the first
+  # prompt as every wake does. The conversation is opened `idle` with no
+  # server; a prompt supplied here is delivered through the ordinary wake
+  # path, so a `ready` machine reattaches and a `suspended` one resumes, and
+  # if that delivery is refused the row is removed again so a refused request
+  # creates nothing.
+  defp attach_conversation(
+         sandbox_id,
+         %{"agent_id" => agent_id, "user_id" => user_id} = attrs,
+         opts
+       )
+       when is_binary(user_id) do
+    with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         {:ok, _runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
+         {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
+         {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
+         {:ok, perm_policy} <- resolve_permission_policy(attrs["permission_policy"], agent),
+         {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
+         :ok <- Fountain.Accounts.check_not_suspended(user_id),
+         :ok <- Fountain.Billing.check_active(user_id),
+         %Sandbox{} = sandbox <- get_sandbox(sandbox_id, user_id) || {:error, :sandbox_not_found},
+         :ok <- check_attachable(sandbox, agent, vault_id, env_id),
+         :ok <- check_attach_capacity(sandbox, agent, attrs["prompt"]),
+         {:ok, conv} <-
+           create_conversation(%{
+             sandbox_id: sandbox.id,
+             agent_id: agent.id,
+             # Ownership: agent came from the scoped get_agent above.
+             agent_version_id: Agents._unsafe_current_version_id(agent.id),
+             vault_id: vault_id,
+             environment_id: env_id,
+             user_id: user_id,
+             runtime: agent.runtime,
+             status: "idle",
+             source: attrs["source"] || "api",
+             parent_conversation_id: parent_id,
+             channel_id: attrs["channel_id"],
+             title: attrs["title"],
+             permission_policy: perm_policy
+           }) do
+      Audit.record(%{
+        user_id: user_id,
+        action: "conversation.created",
+        resource_type: "conversation",
+        resource_id: conv.id,
+        actor: Keyword.get(opts, :actor, "self"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{
+          "agent_id" => agent.id,
+          "agent_name" => agent.name,
+          "source" => conv.source,
+          "with_prompt" => is_binary(attrs["prompt"]) and attrs["prompt"] != "",
+          "parent_conversation_id" => parent_id,
+          "sandbox_attached" => sandbox.id
+        }
+      })
+
+      broadcast_sidebar_update(user_id)
+      deliver_attach_prompt(conv, attrs, opts)
+    else
+      nil -> {:error, :not_found}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp deliver_attach_prompt(conv, attrs, opts) do
+    prompt = attrs["prompt"]
+
+    if is_binary(prompt) and prompt != "" do
+      case ConversationServer.send_prompt(conv.id, prompt, attrs["images"] || [], opts) do
+        :ok ->
+          {:ok, _unsafe_get_conversation!(conv.id)}
+
+        {:error, _} = err ->
+          # Nothing ran. Take the row back so a refused request created
+          # nothing, exactly like a refused fresh launch.
+          _ = Repo.delete(conv)
+          broadcast_sidebar_update(conv.user_id)
+          err
+      end
+    else
+      {:ok, _unsafe_get_conversation!(conv.id)}
+    end
+  end
+
+  defp check_attachable(%Sandbox{status: status}, _agent, _vault_id, _env_id)
+       when status not in ["ready", "suspended"],
+       do: {:error, {:sandbox_not_attachable, status}}
+
+  defp check_attachable(%Sandbox{} = sandbox, %Agents.Agent{} = agent, vault_id, env_id) do
+    cond do
+      sandbox.agent_id != agent.id ->
+        {:error, :sandbox_identity_mismatch}
+
+      sandbox.vault_id != vault_id ->
+        {:error, :sandbox_identity_mismatch}
+
+      sandbox.environment_id != (env_id || agent.environment_id) ->
+        {:error, :sandbox_identity_mismatch}
+
+      # The disk was shaped by the runtime that first ran on it; an agent
+      # whose runtime changed since gets a new machine, not this one.
+      _unsafe_sandbox_runtime(sandbox.id) not in [nil, agent.runtime] ->
+        {:error, :sandbox_runtime_mismatch}
+
+      true ->
+        :ok
+    end
+  end
+
+  # With a prompt, the attach is a turn start too, so the capacity rule of
+  # step 4 applies at the door; without one, the later prompt is gated by
+  # `ConversationServer` as any prompt is.
+  defp check_attach_capacity(%Sandbox{} = sandbox, %Agents.Agent{runtime: runtime}, prompt)
+       when is_binary(prompt) and prompt != "" do
+    capacity = Fountain.Runtimes.ACP.concurrency(runtime)
+
+    if _unsafe_sandbox_at_capacity?(sandbox.id, nil, capacity),
+      do: {:error, :sandbox_at_capacity},
+      else: :ok
+  end
+
+  defp check_attach_capacity(_sandbox, _agent, _prompt), do: :ok
+
+  @doc "The runtime of the newest conversation on `sandbox_id`, or nil when it has none."
+  def _unsafe_sandbox_runtime(sandbox_id) when is_binary(sandbox_id) do
+    Repo.one(
+      from c in Conversation,
+        where: c.sandbox_id == ^sandbox_id,
+        order_by: [desc: c.inserted_at, desc: c.id],
+        limit: 1,
+        select: c.runtime
+    )
+  end
+
+  @doc "One of the caller's sandboxes, or nil. A foreign or malformed id reads as nil."
+  def get_sandbox(id, user_id) when is_binary(id) and is_binary(user_id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, _} -> Repo.get_by(Sandbox, id: id, user_id: user_id)
+      :error -> nil
+    end
+  end
+
+  @doc """
+  The caller's sandboxes, newest first, each with its conversations (newest
+  first). `status: [...]` filters; anything else lists every status, the
+  terminated ones included — a machine's history is part of the account.
+  """
+  def list_sandboxes(user_id, opts \\ []) when is_binary(user_id) do
+    query =
+      from(s in Sandbox,
+        where: s.user_id == ^user_id,
+        order_by: [desc: s.inserted_at, desc: s.id]
+      )
+
+    query =
+      case Keyword.get(opts, :status) do
+        [_ | _] = statuses -> where(query, [s], s.status in ^statuses)
+        _ -> query
+      end
+
+    query
+    |> Repo.all()
+    |> Repo.preload(conversations: from(c in Conversation, order_by: [desc: c.inserted_at]))
+  end
+
+  @doc "`get_sandbox/2` with the conversations preloaded, newest first."
+  def get_sandbox_with_conversations(id, user_id) when is_binary(id) and is_binary(user_id) do
+    case get_sandbox(id, user_id) do
+      nil ->
+        nil
+
+      s ->
+        Repo.preload(s, conversations: from(c in Conversation, order_by: [desc: c.inserted_at]))
     end
   end
 
@@ -2354,6 +2565,8 @@ defmodule Fountain.Conversations do
              fn ->
                create_sandbox(%{
                  environment_id: conv.environment_id || agent.environment_id,
+                 agent_id: conv.agent_id,
+                 vault_id: conv.vault_id,
                  sprite_name: sprite_name,
                  status: "pending",
                  provider: Atom.to_string(provider),

--- a/apps/fountain/lib/fountain/conversations/sandbox.ex
+++ b/apps/fountain/lib/fountain/conversations/sandbox.ex
@@ -31,6 +31,14 @@ defmodule Fountain.Conversations.Sandbox do
     field :terminated_at, :utc_datetime
     field :last_resumed_at, :utc_datetime
     belongs_to :environment, Environment
+    # The identity the disk was materialized from, with the environment
+    # (ADR 0023): env vars, packages, repos and setup scripts are written at
+    # provision, so a machine built for one agent, environment and vault is
+    # not a machine built for another. A conversation attaches only with the
+    # same three. Nilified when the agent or vault is deleted, like a
+    # conversation's own pointers — the row outlives them as history.
+    belongs_to :agent, Fountain.Agents.Agent
+    belongs_to :vault, Fountain.Vaults.Vault
     belongs_to :user, User
     has_many :conversations, Conversation
     timestamps(type: :utc_datetime)
@@ -48,6 +56,8 @@ defmodule Fountain.Conversations.Sandbox do
       :terminated_at,
       :last_resumed_at,
       :environment_id,
+      :agent_id,
+      :vault_id,
       :user_id
     ])
     |> validate_required([:sprite_name, :status, :provider, :user_id])

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -73,12 +73,18 @@ defmodule FountainWeb.ConversationJSON do
     %{id: id, source: source, status: status, parent_id: parent_id}
   end
 
-  defp sandbox_data(%Sandbox{} = s) do
+  @doc false
+  def sandbox_data(%Sandbox{} = s) do
     %{
       id: s.id,
       sprite_name: s.sprite_name,
       status: s.status,
       provider: s.provider,
+      # The identity the disk was built from (ADR 0023): what a launch must
+      # match to attach to this machine with `sandbox_id`.
+      agent_id: s.agent_id,
+      environment_id: s.environment_id,
+      vault_id: s.vault_id,
       # The sandbox's own HTTP endpoint, for providers that give it one. Read
       # from the row rather than the provider so listing conversations stays a
       # single query; null means the provider has no such concept (or the
@@ -91,7 +97,7 @@ defmodule FountainWeb.ConversationJSON do
     }
   end
 
-  defp sandbox_data(_), do: nil
+  def sandbox_data(_), do: nil
 
   defp runner_data(nil), do: nil
 

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -204,6 +204,49 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # Attaching a conversation to an existing sandbox (ADR 0023 gate 3). 404
+  # for an unknown or foreign id, indistinguishable on purpose; 409 for a
+  # machine in a state nothing can attach to; 422 when the launch names a
+  # different identity than the disk was built from.
+  def call(conn, {:error, :sandbox_not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> json(%{error: "sandbox_not_found"})
+  end
+
+  def call(conn, {:error, {:sandbox_not_attachable, status}}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "sandbox_not_attachable",
+      message:
+        "the sandbox is #{status}; a conversation attaches only to a ready or suspended one",
+      status: status
+    })
+  end
+
+  def call(conn, {:error, :sandbox_identity_mismatch}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "sandbox_identity_mismatch",
+      message:
+        "the sandbox was built for a different agent, environment or vault; a conversation " <>
+          "attaches only with the same three"
+    })
+  end
+
+  def call(conn, {:error, :sandbox_runtime_mismatch}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "sandbox_runtime_mismatch",
+      message:
+        "the agent's runtime changed since this sandbox was built and the disk was shaped " <>
+          "by the old one; start a new conversation instead"
+    })
+  end
+
   # The wake path could not reach the sandbox provider to check whether the
   # conversation's sandbox is still there (#799). Nothing was changed — the
   # row is deliberately left as it was rather than retired on a transport

--- a/apps/fountain/lib/fountain_web/controllers/sandbox_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/sandbox_controller.ex
@@ -1,0 +1,78 @@
+defmodule FountainWeb.SandboxController do
+  @moduledoc """
+  The caller's sandboxes — the machines their conversations run on.
+
+  Read-only. A sandbox is created by `POST /api/conversations` and reused by
+  passing its id back as `sandbox_id` (ADR 0023 gate 3); this is where a
+  client learns which machines it has, and which conversations are on each.
+  """
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Sandbox
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Sandboxes"])
+
+  operation(:index,
+    summary: "List sandboxes",
+    description:
+      "Every sandbox the caller has provisioned, newest first, each with the conversations " <>
+        "on it and which of them is mid-turn. `status` filters by a comma-separated list; " <>
+        "without it every status is listed, terminated ones included.",
+    parameters: [
+      status: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Comma-separated: pending, starting, ready, suspended, terminated, failed."
+      ]
+    ],
+    responses: [
+      ok: {"Sandboxes", "application/json", Schemas.SandboxListResponse},
+      bad_request: {"Unknown status", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index(conn, params) do
+    user = conn.assigns.current_user
+
+    with {:ok, statuses} <- parse_statuses(params["status"]) do
+      render(conn, :index, sandboxes: Conversations.list_sandboxes(user.id, status: statuses))
+    end
+  end
+
+  operation(:show,
+    summary: "Get a sandbox",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Sandbox", "application/json", Schemas.SandboxResponse},
+      not_found: {"Not found", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_sandbox_with_conversations(id, user.id) do
+      nil -> {:error, :not_found}
+      sandbox -> render(conn, :show, sandbox: sandbox)
+    end
+  end
+
+  defp parse_statuses(nil), do: {:ok, nil}
+  defp parse_statuses(""), do: {:ok, nil}
+
+  defp parse_statuses(raw) when is_binary(raw) do
+    statuses = raw |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+
+    if statuses != [] and Enum.all?(statuses, &(&1 in Sandbox.statuses())),
+      do: {:ok, statuses},
+      else: {:error, "invalid_status"}
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/sandbox_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/sandbox_json.ex
@@ -1,0 +1,33 @@
+defmodule FountainWeb.SandboxJSON do
+  @moduledoc false
+  alias Fountain.Conversations.{Conversation, Sandbox}
+  alias FountainWeb.ConversationJSON
+
+  def index(%{sandboxes: sandboxes}), do: %{data: Enum.map(sandboxes, &data/1)}
+  def show(%{sandbox: sandbox}), do: %{data: data(sandbox)}
+
+  # The same shape a conversation embeds, plus the machine's own history and
+  # the conversations on it.
+  def data(%Sandbox{} = s) do
+    s
+    |> ConversationJSON.sandbox_data()
+    |> Map.merge(%{
+      inserted_at: s.inserted_at,
+      last_resumed_at: s.last_resumed_at,
+      conversations: Enum.map(s.conversations || [], &conversation_data/1)
+    })
+  end
+
+  defp conversation_data(%Conversation{} = c) do
+    %{
+      id: c.id,
+      status: c.status,
+      title: c.title,
+      runtime: c.runtime,
+      # `running` is set for exactly the span of a turn (kick_turn → finish),
+      # so it is the honest "is this one using the machine right now".
+      mid_turn: c.status == "running",
+      inserted_at: c.inserted_at
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -457,6 +457,12 @@ defmodule FountainWeb.Router do
     get "/support/reports", SupportReportController, :index
     get "/support/reports/:id", SupportReportController, :show
 
+    # The machines conversations run on (ADR 0023 gate 3). Read-only: a
+    # sandbox is made by creating a conversation and reused by naming it as
+    # `sandbox_id` on the next one.
+    get "/sandboxes", SandboxController, :index
+    get "/sandboxes/:id", SandboxController, :show
+
     resources "/conversations", ConversationController, only: [:index, :show, :create, :delete] do
       post "/prompts", ConversationController, :prompt, as: :prompt
       post "/interrupt", ConversationController, :interrupt, as: :interrupt

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -15,7 +15,9 @@ defmodule FountainWeb.Schemas do
 
     OpenApiSpex.schema(%{
       title: "Sandbox",
-      description: "One sprite lifespan owned by a conversation.",
+      description:
+        "One machine. Provisioned for a conversation; several conversations may run on " <>
+          "it at once (ADR 0023).",
       type: :object,
       properties: %{
         id: %Schema{type: :string, format: :uuid},
@@ -24,6 +26,16 @@ defmodule FountainWeb.Schemas do
           type: :string,
           enum: ~w(pending starting ready suspended terminated failed)
         },
+        agent_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "The agent the machine was built for. With environment_id and vault_id it is " <>
+              "the identity a conversation must match to attach (sandbox_id on create)."
+        },
+        environment_id: %Schema{type: :string, format: :uuid, nullable: true},
+        vault_id: %Schema{type: :string, format: :uuid, nullable: true},
         url: %Schema{
           type: :string,
           nullable: true,
@@ -62,6 +74,51 @@ defmodule FountainWeb.Schemas do
         }
       },
       required: [:id, :sprite_name, :status]
+    })
+  end
+
+  defmodule SandboxConversation do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SandboxConversation",
+      description: "A conversation on a sandbox, as the sandbox lists it.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        status: %Schema{type: :string, enum: ~w(pending running idle failed terminated)},
+        title: %Schema{type: :string, nullable: true},
+        runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        mid_turn: %Schema{
+          type: :boolean,
+          description: "True while this conversation is running a turn on the machine."
+        },
+        inserted_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :status, :mid_turn]
+    })
+  end
+
+  defmodule SandboxDetail do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SandboxDetail",
+      description: "A sandbox with the conversations on it.",
+      type: :object,
+      properties:
+        Map.merge(Sandbox.schema().properties, %{
+          conversations: %Schema{
+            type: :array,
+            items: SandboxConversation,
+            description: "Every conversation ever opened on this machine, newest first."
+          },
+          inserted_at: %Schema{type: :string, format: :"date-time"},
+          last_resumed_at: %Schema{type: :string, format: :"date-time", nullable: true}
+        }),
+      required: [:id, :sprite_name, :status, :conversations]
     })
   end
 
@@ -305,6 +362,20 @@ defmodule FountainWeb.Schemas do
         sprite_name: %Schema{
           type: :string,
           description: "Override the auto-generated sprite name."
+        },
+        sandbox_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Attach the conversation to a sandbox you already have instead of provisioning " <>
+              "one (ADR 0023). The sandbox must be yours (404 sandbox_not_found), ready or " <>
+              "suspended (409 sandbox_not_attachable), and built for the same agent, " <>
+              "environment and vault as this launch (422 sandbox_identity_mismatch; 422 " <>
+              "sandbox_runtime_mismatch if the agent's runtime changed since). The " <>
+              "conversation opens idle on that machine; a prompt here wakes it. Several " <>
+              "conversations then run on one disk at once, except on opencode and gemini, " <>
+              "where a second turn is refused with 409 sandbox_at_capacity while one runs."
         },
         channel_id: %Schema{
           type: :string,
@@ -1006,6 +1077,8 @@ defmodule FountainWeb.Schemas do
   item_response(EnvironmentResponse, of: Environment)
 
   list_response(EnvironmentListResponse, of: Environment)
+  item_response(SandboxResponse, of: SandboxDetail)
+  list_response(SandboxListResponse, of: SandboxDetail)
 
   defmodule EnvironmentRequest do
     @moduledoc false

--- a/apps/fountain/priv/repo/migrations/20260824010000_add_agent_and_vault_to_sandboxes.exs
+++ b/apps/fountain/priv/repo/migrations/20260824010000_add_agent_and_vault_to_sandboxes.exs
@@ -1,0 +1,38 @@
+defmodule Fountain.Repo.Migrations.AddAgentAndVaultToSandboxes do
+  use Ecto.Migration
+
+  # A sandbox is materialized from an agent's environment and a vault at
+  # provision time, so a conversation may attach to it only with the same
+  # three (ADR 0023). `environment_id` was already on the row; the agent and
+  # the vault were only knowable through the conversations on it. Backfilled
+  # from each sandbox's newest conversation — 1:1 in practice until now, so
+  # "newest" and "only" agree.
+  def up do
+    alter table(:sandboxes) do
+      add :agent_id, references(:agents, type: :binary_id, on_delete: :nilify_all)
+      add :vault_id, references(:vaults, type: :binary_id, on_delete: :nilify_all)
+    end
+
+    create index(:sandboxes, [:user_id, :agent_id])
+
+    execute """
+    UPDATE sandboxes AS s
+    SET agent_id = c.agent_id, vault_id = c.vault_id
+    FROM (
+      SELECT DISTINCT ON (sandbox_id) sandbox_id, agent_id, vault_id
+      FROM conversations
+      ORDER BY sandbox_id, inserted_at DESC
+    ) AS c
+    WHERE c.sandbox_id = s.id
+    """
+  end
+
+  def down do
+    drop index(:sandboxes, [:user_id, :agent_id])
+
+    alter table(:sandboxes) do
+      remove :agent_id
+      remove :vault_id
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/attach_test.exs
+++ b/apps/fountain/test/fountain/conversations/attach_test.exs
@@ -1,0 +1,141 @@
+defmodule Fountain.Conversations.AttachTest do
+  # `sandbox_id` on start_conversation (ADR 0023 gate 3): a conversation on a
+  # machine the caller already has, under the attach rules.
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+
+  setup do
+    user = insert_active_user()
+    env = insert_env(user_id: user.id)
+    vault = insert_vault(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        agent_id: agent.id,
+        environment_id: env.id,
+        vault_id: nil
+      )
+
+    first = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    {:ok, user: user, env: env, vault: vault, agent: agent, sandbox: sandbox, first: first}
+  end
+
+  defp attach(ctx, extra \\ %{}) do
+    Conversations.start_conversation(
+      Map.merge(
+        %{"agent_id" => ctx.agent.id, "user_id" => ctx.user.id, "sandbox_id" => ctx.sandbox.id},
+        extra
+      )
+    )
+  end
+
+  test "opens an idle conversation on the same machine, with no server", ctx do
+    assert {:ok, conv} = attach(ctx)
+    assert conv.sandbox_id == ctx.sandbox.id
+    assert conv.status == "idle"
+    assert conv.agent_id == ctx.agent.id
+    assert conv.runtime == "claude"
+    assert Conversations._unsafe_list_cotenant_ids(ctx.sandbox.id, conv.id) == [ctx.first.id]
+  end
+
+  test "a foreign or malformed sandbox reads as not found", ctx do
+    foreign = insert_sandbox(user_id: insert_active_user().id, status: "ready")
+
+    assert {:error, :sandbox_not_found} = attach(ctx, %{"sandbox_id" => foreign.id})
+    assert {:error, :sandbox_not_found} = attach(ctx, %{"sandbox_id" => "not-a-uuid"})
+    assert {:error, :sandbox_not_found} = attach(ctx, %{"sandbox_id" => Ecto.UUID.generate()})
+  end
+
+  test "only a ready or suspended machine takes a conversation", ctx do
+    for status <- ["pending", "starting", "terminated", "failed"] do
+      {:ok, _} = Conversations.update_sandbox(ctx.sandbox, %{status: status})
+      assert {:error, {:sandbox_not_attachable, ^status}} = attach(ctx)
+    end
+
+    {:ok, _} = Conversations.update_sandbox(ctx.sandbox, %{status: "suspended"})
+    assert {:ok, _} = attach(ctx)
+  end
+
+  test "the launch must name the identity the disk was built from", ctx do
+    # A vault the machine was not built with.
+    assert {:error, :sandbox_identity_mismatch} = attach(ctx, %{"vault_id" => ctx.vault.id})
+
+    # An environment override that is not the machine's.
+    other_env = insert_env(user_id: ctx.user.id)
+    assert {:error, :sandbox_identity_mismatch} = attach(ctx, %{"environment_id" => other_env.id})
+
+    # Naming the machine's own environment explicitly is the same identity.
+    assert {:ok, _} = attach(ctx, %{"environment_id" => ctx.env.id})
+
+    # Another agent, even the same user's.
+    other_agent =
+      insert_agent(user_id: ctx.user.id, runtime: "claude", environment_id: ctx.env.id)
+
+    assert {:error, :sandbox_identity_mismatch} = attach(ctx, %{"agent_id" => other_agent.id})
+  end
+
+  test "an agent whose runtime changed since gets a new machine, not this one", ctx do
+    agent = ctx.agent |> Ecto.Changeset.change(runtime: "codex") |> Repo.update!()
+    assert {:error, :sandbox_runtime_mismatch} = attach(%{ctx | agent: agent})
+  end
+
+  test "with a prompt, a one-at-a-time runtime's machine refuses while a turn runs", ctx do
+    agent = ctx.agent |> Ecto.Changeset.change(runtime: "opencode") |> Repo.update!()
+    {:ok, _} = Conversations.update_conversation(ctx.first, %{runtime: "opencode"})
+    ctx = %{ctx | agent: agent}
+
+    insert_turn(ctx.first, %{
+      status: "running",
+      prompt: "busy",
+      started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+
+    assert {:error, :sandbox_at_capacity} = attach(ctx, %{"prompt" => "hello"})
+    # Without a prompt nothing runs yet, so nothing is refused.
+    assert {:ok, _} = attach(ctx)
+  end
+
+  test "a fresh launch stamps the identity on the sandbox it provisions", ctx do
+    stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+    assert {:ok, conv} =
+             Conversations.start_conversation(%{
+               "agent_id" => ctx.agent.id,
+               "user_id" => ctx.user.id,
+               "vault_id" => ctx.vault.id
+             })
+
+    sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+    assert sandbox.agent_id == ctx.agent.id
+    assert sandbox.vault_id == ctx.vault.id
+    assert sandbox.environment_id == ctx.env.id
+  end
+
+  describe "listing" do
+    test "sandboxes are tenant-scoped, newest first, with their conversations", ctx do
+      _foreign = insert_sandbox(user_id: insert_active_user().id, status: "ready")
+      {:ok, second} = attach(ctx)
+
+      assert [%{id: id, conversations: convs}] = Conversations.list_sandboxes(ctx.user.id)
+      assert id == ctx.sandbox.id
+      # Both rows land in the same second, so the order between them is not
+      # pinned; the membership is.
+      assert Enum.sort(Enum.map(convs, & &1.id)) == Enum.sort([second.id, ctx.first.id])
+
+      assert [] = Conversations.list_sandboxes(ctx.user.id, status: ["terminated"])
+      assert [_] = Conversations.list_sandboxes(ctx.user.id, status: ["ready", "suspended"])
+    end
+
+    test "get_sandbox is scoped and tolerant of a bad id", ctx do
+      assert %{id: id} = Conversations.get_sandbox(ctx.sandbox.id, ctx.user.id)
+      assert id == ctx.sandbox.id
+      assert nil == Conversations.get_sandbox(ctx.sandbox.id, insert_active_user().id)
+      assert nil == Conversations.get_sandbox("nope", ctx.user.id)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/conversation_attach_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_attach_controller_test.exs
@@ -1,0 +1,102 @@
+defmodule FountainWeb.ConversationAttachControllerTest do
+  # `sandbox_id` on POST /api/conversations (ADR 0023 gate 3), at the door.
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  setup do
+    user = insert_active_user()
+    {_key_record, raw_key} = insert_api_key(user)
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        agent_id: agent.id,
+        environment_id: env.id
+      )
+
+    first = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    {:ok, user: user, raw_key: raw_key, agent: agent, sandbox: sandbox, first: first}
+  end
+
+  defp create(ctx, body) do
+    ctx.conn
+    |> authed_with_key(ctx.raw_key)
+    |> post_json("/api/conversations", Map.merge(%{"agent_id" => ctx.agent.id}, body))
+  end
+
+  test "attaches: 201, idle, on the named sandbox", ctx do
+    data =
+      ctx
+      |> create(%{"sandbox_id" => ctx.sandbox.id})
+      |> json_response(201)
+      |> Map.fetch!("data")
+
+    assert data["sandbox_id"] == ctx.sandbox.id
+    assert data["status"] == "idle"
+    assert data["sandbox"]["agent_id"] == ctx.agent.id
+  end
+
+  test "with a prompt, the first turn goes through the wake path", ctx do
+    # A `ready` machine with no server: the prompt probes it and starts a
+    # server, exactly as prompting a parked conversation does.
+    stub(Fountain.Sandbox.Sprites, :get, fn _handle -> {:ok, %{status: :running, raw: %{}}} end)
+    stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+    data =
+      ctx
+      |> create(%{"sandbox_id" => ctx.sandbox.id, "prompt" => "hello"})
+      |> json_response(201)
+      |> Map.fetch!("data")
+
+    assert data["sandbox_id"] == ctx.sandbox.id
+  end
+
+  test "an unknown or foreign sandbox is a 404", ctx do
+    foreign = insert_sandbox(user_id: insert_active_user().id, status: "ready")
+
+    for id <- [foreign.id, Ecto.UUID.generate()] do
+      assert %{"error" => "sandbox_not_found"} =
+               ctx |> create(%{"sandbox_id" => id}) |> json_response(404)
+    end
+  end
+
+  test "a terminated sandbox is a 409 that names its state", ctx do
+    {:ok, _} = Fountain.Conversations.update_sandbox(ctx.sandbox, %{status: "terminated"})
+
+    assert %{"error" => "sandbox_not_attachable", "status" => "terminated"} =
+             ctx |> create(%{"sandbox_id" => ctx.sandbox.id}) |> json_response(409)
+  end
+
+  test "a different identity is a 422", ctx do
+    vault = insert_vault(user_id: ctx.user.id)
+
+    assert %{"error" => "sandbox_identity_mismatch"} =
+             ctx
+             |> create(%{"sandbox_id" => ctx.sandbox.id, "vault_id" => vault.id})
+             |> json_response(422)
+  end
+
+  test "a one-at-a-time runtime at capacity is a 409 when a prompt comes with it", ctx do
+    agent = ctx.agent |> Ecto.Changeset.change(runtime: "opencode") |> Fountain.Repo.update!()
+    {:ok, _} = Fountain.Conversations.update_conversation(ctx.first, %{runtime: "opencode"})
+
+    insert_turn(ctx.first, %{
+      status: "running",
+      prompt: "busy",
+      started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+
+    ctx = %{ctx | agent: agent}
+
+    assert %{"error" => "sandbox_at_capacity"} =
+             ctx
+             |> create(%{"sandbox_id" => ctx.sandbox.id, "prompt" => "hello"})
+             |> json_response(409)
+
+    # Nothing was created by the refusal.
+    assert length(Fountain.Conversations.list_conversations(ctx.user.id)) == 1
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/sandbox_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sandbox_controller_test.exs
@@ -1,0 +1,74 @@
+defmodule FountainWeb.SandboxControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  setup do
+    user = insert_active_user()
+    {_key_record, raw_key} = insert_api_key(user)
+    agent = insert_agent(user_id: user.id, runtime: "claude")
+
+    sandbox = insert_sandbox(user_id: user.id, status: "ready", agent_id: agent.id)
+    idle = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+    busy =
+      insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "running")
+
+    {:ok, user: user, raw_key: raw_key, agent: agent, sandbox: sandbox, idle: idle, busy: busy}
+  end
+
+  describe "GET /api/sandboxes" do
+    test "lists the caller's machines with the conversations on each", ctx do
+      _foreign = insert_sandbox(user_id: insert_active_user().id, status: "ready")
+
+      assert [row] =
+               ctx.conn
+               |> authed_with_key(ctx.raw_key)
+               |> get("/api/sandboxes")
+               |> json_response(200)
+               |> Map.fetch!("data")
+
+      assert row["id"] == ctx.sandbox.id
+      assert row["agent_id"] == ctx.agent.id
+      assert row["status"] == "ready"
+
+      by_id = Map.new(row["conversations"], &{&1["id"], &1})
+      assert by_id[ctx.busy.id]["mid_turn"] == true
+      assert by_id[ctx.idle.id]["mid_turn"] == false
+    end
+
+    test "filters by status and refuses an unknown one", ctx do
+      assert [] =
+               ctx.conn
+               |> authed_with_key(ctx.raw_key)
+               |> get("/api/sandboxes?status=terminated,failed")
+               |> json_response(200)
+               |> Map.fetch!("data")
+
+      assert %{"error" => "invalid_status"} =
+               ctx.conn
+               |> authed_with_key(ctx.raw_key)
+               |> get("/api/sandboxes?status=bogus")
+               |> json_response(400)
+    end
+  end
+
+  describe "GET /api/sandboxes/:id" do
+    test "shows one, and a foreign one is not found", ctx do
+      data =
+        ctx.conn
+        |> authed_with_key(ctx.raw_key)
+        |> get("/api/sandboxes/#{ctx.sandbox.id}")
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert data["id"] == ctx.sandbox.id
+      assert length(data["conversations"]) == 2
+
+      foreign = insert_sandbox(user_id: insert_active_user().id, status: "ready")
+
+      assert ctx.conn
+             |> authed_with_key(ctx.raw_key)
+             |> get("/api/sandboxes/#{foreign.id}")
+             |> json_response(404)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -98,6 +98,11 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.ManifestResource, "kind"} => {Manifest, :kinds},
     {FountainWeb.Schemas.OnboardingResponse, "data.state"} => {Accounts, :onboarding_states},
     {FountainWeb.Schemas.Sandbox, "status"} => {Sandbox, :statuses},
+    # The sandbox listing (ADR 0023 gate 3): a sandbox with its conversations.
+    {FountainWeb.Schemas.SandboxDetail, "status"} => {Sandbox, :statuses},
+    {FountainWeb.Schemas.SandboxDetail, "provider"} => {Fountain.Sandbox, :known_providers},
+    {FountainWeb.Schemas.SandboxConversation, "status"} => {Conversation, :statuses},
+    {FountainWeb.Schemas.SandboxConversation, "runtime"} => {Agent, :runtimes},
     {FountainWeb.Schemas.Turn, "status"} => {Turn, :statuses},
     {FountainWeb.Schemas.Teammate, "presence.state"} =>
       {FountainWeb.TeamPresenter, :presence_states},

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -84,6 +84,7 @@ func init() {
 	runCmd.Flags().StringP("prompt", "p", "", "prompt text (required)")
 	runCmd.Flags().String("vault", "", "vault name or id")
 	runCmd.Flags().String("environment", "", "environment name or id to provision from, instead of the agent's own")
+	runCmd.Flags().String("sandbox", "", "sandbox id to attach to, instead of provisioning a new one")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -277,6 +278,10 @@ func runAgent(cmd *cobra.Command, target string) error {
 	}
 	if environment != "" {
 		body["environment_id"] = resolveEnvironmentID(environment)
+	}
+	// Sandboxes have ids only, no names: nothing to resolve.
+	if sandbox, _ := cmd.Flags().GetString("sandbox"); sandbox != "" {
+		body["sandbox_id"] = sandbox
 	}
 
 	c := activeClient()

--- a/docs/api.md
+++ b/docs/api.md
@@ -336,7 +336,7 @@ it again and again.
 
 ```
 GET    /api/conversations                  # list (?roots_only=true; ?agent_id= ?channel_id= ?status=idle,terminated)
-POST   /api/conversations                  # start (agent_id; optional vault_id, prompt, images)
+POST   /api/conversations                  # start (agent_id; optional vault_id, environment_id, sandbox_id, prompt, images)
 GET    /api/conversations/:id
 DELETE /api/conversations/:id
 POST   /api/conversations/:id/read         # clear unread state
@@ -353,6 +353,15 @@ GET    /api/conversations/:id/turns/:turn_id/images/:position   # image bytes
 A turn carries `image_count`. The image endpoint takes a `position` into that
 count, which starts at zero, and returns the raw bytes with the stored media
 type.
+
+`sandbox_id` attaches the new conversation to a sandbox you already have.
+Fountain then provisions nothing. The sandbox must be `ready` or `suspended`,
+and Fountain must have built it for the same agent, environment and vault.
+Otherwise you get `404 sandbox_not_found`, `409 sandbox_not_attachable` or
+`422 sandbox_identity_mismatch`. Several conversations can then run on one
+disk at the same time. On an opencode or gemini sandbox, only one turn runs
+at a time. A second prompt gets `409 sandbox_at_capacity` while the first
+one runs.
 
 Whatever does not resolve is a `404`, so nobody can probe for an id.
 
@@ -468,6 +477,22 @@ own, and the client lists them again.
 `Last-Event-ID` replays what you missed, across each conversation the stream
 follows. The first byte is a `: connected` comment. A heartbeat arrives every
 15 s. The stream closes after 60 s idle, so the client reconnects.
+
+## Sandboxes
+
+A sandbox is the computer a conversation runs on. One sandbox can hold
+several conversations.
+
+```
+GET    /api/sandboxes          # list (?status=ready,suspended)
+GET    /api/sandboxes/:id
+```
+
+Each sandbox carries `status`, `provider` and `url`. It also carries the
+`agent_id`, `environment_id` and `vault_id` that Fountain built it for, and
+`conversations`. Each entry there carries `mid_turn`, which is true while
+that conversation runs a turn. To put a second conversation on a sandbox,
+pass its id as `sandbox_id` to `POST /api/conversations`.
 
 ## Search
 
@@ -898,6 +923,7 @@ to walk the whole trail.
 | `402` | You need a live subscription. The code is `subscription_required`, and the body carries `upgrade_url`. |
 | `403` | The wrong tenant. |
 | `404` | Nothing found. |
+| `409` | The request conflicts with the current state. The codes are `no_runner_online`, `sandbox_at_capacity` and `sandbox_not_attachable`. |
 | `410` | Somebody terminated the conversation. The code is `conversation_terminated`. Stop, and do not try again. |
 | `422` | A validation error. |
 | `429` | The rate limit stopped you. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -135,6 +135,7 @@ You can repeat `-i` and `--image`. Each one takes a local file path.
 fountain run <agent-name-or-id> -p "Audit the auth module"
 fountain run <agent-name-or-id> -p "Run the test suite" --vault staging-creds
 fountain run <agent-name-or-id> -p "Run the test suite" --environment staging
+fountain run <agent-name-or-id> -p "Now fix the failures" --sandbox <sandbox-id>
 ```
 
 `run` creates a conversation, then streams until the turn reaches a terminal
@@ -143,6 +144,10 @@ state.
 `--vault` layers a vault's secrets over the agent's environment, and the vault
 wins on a collision. `--environment` provisions from that environment, and not
 from the agent's own.
+
+The `--sandbox` flag attaches the conversation to a sandbox you already have,
+by id. Two conversations then share one disk. A conversation's `sandbox_id`
+names its sandbox.
 
 ### Long-running turns
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -303,6 +303,7 @@ Options:
 ```
       --environment string   environment name or id to provision from, instead of the agent's own
   -p, --prompt string        prompt text (required)
+      --sandbox string       sandbox id to attach to, instead of provisioning a new one
       --vault string         vault name or id
 ```
 

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,21 @@ server releases.
 
 ---
 
+## [0.1.6] — 2026-08-24
+
+### Added
+
+- `run({ sandbox })` attaches the new conversation to a sandbox you already
+  have, by id, instead of provisioning one — several conversations then run
+  on one disk at once (ADR 0023). `fountain.sandboxes()` and
+  `fountain.sandbox(id)` list your machines with the conversations on each
+  and which is mid-turn; `SandboxRecord` is their type. `Sandbox` records
+  now carry `agent_id`, `environment_id` and `vault_id`.
+- Error codes: `sandbox_not_found`, `sandbox_not_attachable`,
+  `sandbox_identity_mismatch`, `sandbox_runtime_mismatch`, and
+  `sandbox_at_capacity` (retryable — a one-at-a-time runtime's machine is
+  busy with another conversation's turn).
+
 ## [0.1.5] — 2026-08-24
 
 ### Fixed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -6,7 +6,14 @@ import { Conversation } from "./conversation.ts";
 import { Agents, Environments, Vaults } from "./resources.ts";
 import { Team, normalizeStreams } from "./team.ts";
 import { streamPath, type StreamRequest } from "./sse.ts";
-import type { AuthMe, Catalog, ConversationRecord, LogEvent, SearchHit } from "./types.ts";
+import type {
+  AuthMe,
+  Catalog,
+  ConversationRecord,
+  LogEvent,
+  SandboxRecord,
+  SearchHit,
+} from "./types.ts";
 
 export interface FountainOptions extends ConfigOptions {
   /** Swap the fetch implementation — a test server, a proxy, an instrumented one. */
@@ -40,6 +47,12 @@ export interface RunConfig extends RunOptions {
   fresh?: boolean;
   /** Override the generated sandbox name. */
   spriteName?: string;
+  /**
+   * Attach to a sandbox you already have, by id, instead of provisioning a
+   * new one. It must be ready or suspended and built for the same agent,
+   * environment and vault; several conversations then share one disk.
+   */
+  sandbox?: string;
 }
 
 /**
@@ -119,6 +132,7 @@ export class Fountain {
           if (config.channelId) body.channel_id = config.channelId;
           if (config.fresh) body.fresh = true;
           if (config.spriteName) body.sprite_name = config.spriteName;
+          if (config.sandbox) body.sandbox_id = config.sandbox;
 
           const conversation = await this.api.data<ConversationRecord>(
             "POST",
@@ -175,6 +189,22 @@ export class Fountain {
    */
   async catalog(): Promise<Catalog> {
     return this.api.data<Catalog>("GET", "/api/catalog");
+  }
+
+  /**
+   * The account's sandboxes — the machines conversations run on — newest
+   * first, each with the conversations on it. Pass one's id as
+   * `run({ sandbox })` to put another conversation on it.
+   */
+  async sandboxes(opts: { status?: string[] } = {}): Promise<SandboxRecord[]> {
+    return this.api.list<SandboxRecord>("/api/sandboxes", {
+      query: { status: opts.status?.join(",") },
+    });
+  }
+
+  /** One sandbox, by id. */
+  async sandbox(id: string): Promise<SandboxRecord> {
+    return this.api.data<SandboxRecord>("GET", `/api/sandboxes/${id}`);
   }
 
   /** Full-text search across the caller's conversations. */

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -14,6 +14,11 @@ export type FountainErrorCode =
   | "provisioning"
   | "sprite_probe_failed"
   | "sandbox_quota_exceeded"
+  | "sandbox_at_capacity"
+  | "sandbox_not_found"
+  | "sandbox_not_attachable"
+  | "sandbox_identity_mismatch"
+  | "sandbox_runtime_mismatch"
   | "subscription_required"
   | "rate_limited"
   | "account_suspended"
@@ -81,6 +86,9 @@ const RETRYABLE_CODES = new Set([
   "provisioning",
   "sprite_probe_failed",
   "sandbox_quota_exceeded",
+  // Another conversation's turn is using a one-at-a-time runtime's sandbox;
+  // it clears when that turn ends.
+  "sandbox_at_capacity",
   "rate_limited",
 ]);
 

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -41,6 +41,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/sandboxes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List sandboxes
+         * @description Every sandbox the caller has provisioned, newest first, each with the conversations on it and which of them is mid-turn. `status` filters by a comma-separated list; without it every status is listed, terminated ones included.
+         */
+        get: operations["FountainWeb.SandboxController.index"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/vaults/{vault_id}/secrets/{id}": {
         parameters: {
             query?: never;
@@ -182,6 +202,23 @@ export interface paths {
          * @description Tears down the sprite and marks the conversation `terminated`. Idempotent for already-dead conversations.
          */
         post: operations["FountainWeb.ConversationController.terminate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sandboxes/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a sandbox */
+        get: operations["FountainWeb.SandboxController.show"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1910,6 +1947,10 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** SandboxResponse */
+        SandboxResponse: {
+            data: components["schemas"]["SandboxDetail"];
+        };
         /** ApiKeyRequest */
         ApiKeyRequest: {
             /** @description What this key is for. */
@@ -2015,6 +2056,11 @@ export interface components {
             } | null;
             /** @description Optional first turn prompt. */
             prompt?: string;
+            /**
+             * Format: uuid
+             * @description Attach the conversation to a sandbox you already have instead of provisioning one (ADR 0023). The sandbox must be yours (404 sandbox_not_found), ready or suspended (409 sandbox_not_attachable), and built for the same agent, environment and vault as this launch (422 sandbox_identity_mismatch; 422 sandbox_runtime_mismatch if the agent's runtime changed since). The conversation opens idle on that machine; a prompt here wakes it. Several conversations then run on one disk at once, except on opencode and gemini, where a second turn is refused with 409 sandbox_at_capacity while one runs.
+             */
+            sandbox_id?: string | null;
             /** @description Override the auto-generated sprite name. */
             sprite_name?: string;
             /** @description Optional display title. The team page names a teammate with it. */
@@ -2236,6 +2282,50 @@ export interface components {
             option_id: string;
         };
         /**
+         * SandboxDetail
+         * @description A sandbox with the conversations on it.
+         */
+        SandboxDetail: {
+            /**
+             * Format: uuid
+             * @description The agent the machine was built for. With environment_id and vault_id it is the identity a conversation must match to attach (sandbox_id on create).
+             */
+            agent_id?: string | null;
+            /** @description Every conversation ever opened on this machine, newest first. */
+            conversations: components["schemas"]["SandboxConversation"][];
+            /** Format: uuid */
+            environment_id?: string | null;
+            /** Format: uuid */
+            id: string;
+            /** Format: date-time */
+            inserted_at?: string;
+            /** Format: date-time */
+            last_resumed_at?: string | null;
+            /**
+             * @description The sandbox backend this row lives on.
+             * @enum {string}
+             */
+            provider?: "sprites" | "e2b" | "daytona" | "runner";
+            /** @description For `provider: runner` — the user's own machine the sandbox lives on, and its directory there (#834). Null for hosted providers; the inner fields are null when the runner row was forgotten. */
+            runner?: {
+                hostname?: string | null;
+                /** Format: uuid */
+                id?: string | null;
+                name?: string | null;
+                /** @description Whether the runner daemon is connected right now. */
+                online: boolean;
+                /** @description The sandbox directory on the machine (`<root>/<name>`). */
+                path?: string | null;
+            } | null;
+            sprite_name: string;
+            /** @enum {string} */
+            status: "pending" | "starting" | "ready" | "suspended" | "terminated" | "failed";
+            /** @description The sandbox's own HTTP endpoint, where a service the agent starts is reachable. Null for providers that expose no such URL. The same value is available inside the sandbox as `SANDBOX_URL`. */
+            url?: string | null;
+            /** Format: uuid */
+            vault_id?: string | null;
+        };
+        /**
          * AvatarRequest
          * @description JSON form of an avatar upload. The raw-bytes form sends the image directly with an image content-type instead.
          */
@@ -2286,9 +2376,16 @@ export interface components {
         };
         /**
          * Sandbox
-         * @description One sprite lifespan owned by a conversation.
+         * @description One machine. Provisioned for a conversation; several conversations may run on it at once (ADR 0023).
          */
         Sandbox: {
+            /**
+             * Format: uuid
+             * @description The agent the machine was built for. With environment_id and vault_id it is the identity a conversation must match to attach (sandbox_id on create).
+             */
+            agent_id?: string | null;
+            /** Format: uuid */
+            environment_id?: string | null;
             /** Format: uuid */
             id: string;
             /**
@@ -2312,6 +2409,8 @@ export interface components {
             status: "pending" | "starting" | "ready" | "suspended" | "terminated" | "failed";
             /** @description The sandbox's own HTTP endpoint, where a service the agent starts is reachable. Null for providers that expose no such URL. The same value is available inside the sandbox as `SANDBOX_URL`. */
             url?: string | null;
+            /** Format: uuid */
+            vault_id?: string | null;
         };
         /**
          * TeammateContact
@@ -2351,6 +2450,23 @@ export interface components {
         /** Error */
         Error: {
             error: string;
+        };
+        /**
+         * SandboxConversation
+         * @description A conversation on a sandbox, as the sandbox lists it.
+         */
+        SandboxConversation: {
+            /** Format: uuid */
+            id: string;
+            /** Format: date-time */
+            inserted_at?: string;
+            /** @description True while this conversation is running a turn on the machine. */
+            mid_turn: boolean;
+            /** @enum {string} */
+            runtime?: "claude" | "codex" | "gemini" | "opencode";
+            /** @enum {string} */
+            status: "pending" | "running" | "idle" | "failed" | "terminated";
+            title?: string | null;
         };
         /** AdminCompRequest */
         AdminCompRequest: {
@@ -2573,6 +2689,10 @@ export interface components {
              */
             email: string;
             message: string;
+        };
+        /** SandboxListResponse */
+        SandboxListResponse: {
+            data: components["schemas"]["SandboxDetail"][];
         };
         /** InferenceCredentialListResponse */
         InferenceCredentialListResponse: {
@@ -3788,6 +3908,38 @@ export interface operations {
             };
         };
     };
+    "FountainWeb.SandboxController.index": {
+        parameters: {
+            query?: {
+                /** @description Comma-separated: pending, starting, ready, suspended, terminated, failed. */
+                status?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sandboxes */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxListResponse"];
+                };
+            };
+            /** @description Unknown status */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     "FountainWeb.VaultSecretController.delete": {
         parameters: {
             query?: never;
@@ -4127,6 +4279,37 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SandboxController.show": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sandbox */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxResponse"];
+                };
             };
             /** @description Not found */
             404: {

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.5";
+export const USER_AGENT = "fountain-sdk-js/0.1.6";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and

--- a/sdk/typescript/src/schemas.ts
+++ b/sdk/typescript/src/schemas.ts
@@ -39,6 +39,8 @@ export type VaultPatch = S["VaultUpdate"];
 
 /** One run of an agent inside a sandbox. */
 export type ConversationRecord = S["Conversation"];
+/** A machine, with the conversations on it. */
+export type SandboxRecord = S["SandboxDetail"];
 /** One prompt and everything the agent did in response. */
 export type Turn = S["Turn"];
 /** One row of a conversation's log feed. */

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -22,6 +22,7 @@ export type {
   LogEvent,
   Repository,
   Runner,
+  SandboxRecord,
   Schedule,
   ScheduleInput,
   SchedulePatch,


### PR DESCRIPTION
ADR 0023 **gate 3**. `sandbox_id` on `POST /api/conversations` opens a new conversation on a machine you already have instead of provisioning one, and `GET /api/sandboxes[/:id]` lists your machines with the conversations on each. **From here two claude conversations run at once on one sprite** — the rules #1061 shipped become reachable.

## Schema

`sandboxes` gains `agent_id` and `vault_id` (additive, nilify on delete, backfilled from each row's newest conversation). With `environment_id` they are the identity the disk was materialized from — env vars, packages, repos, setup scripts are written at provision — and what a launch must match to attach. Fresh launches and the wake fallback stamp them.

## Attach rules (`Conversations.attach_conversation/3`)

The launch resolves exactly as a fresh one (agent, vault, environment, permission policy, parent, account and billing gates), then the sandbox is fetched **tenant-scoped** and checked instead of created:

| refused when | response |
|---|---|
| unknown, foreign or malformed id | `404 sandbox_not_found` (indistinguishable on purpose) |
| status not `ready` / `suspended` | `409 sandbox_not_attachable` (+ `status`) |
| different agent, environment or vault | `422 sandbox_identity_mismatch` |
| agent's runtime changed since the disk was shaped | `422 sandbox_runtime_mismatch` |
| a prompt is supplied and a one-at-a-time runtime's machine is mid-turn | `409 sandbox_at_capacity` |

The conversation opens `idle` with no server. A prompt supplied at create goes through the **ordinary wake path** — reattach for `ready`, resume under the quota gate for `suspended` — and a refused delivery removes the row again, so a refused request creates nothing. No quota reservation for the attach itself: nothing new is provisioned.

## Surface

- `SandboxController` (`index` with `?status=`, `show`), `SandboxJSON`; OpenAPI: `Sandbox` gains `agent_id`/`environment_id`/`vault_id`, new `SandboxDetail` and `SandboxConversation` (with `mid_turn`), enum-guardrail rows; four fallback arms.
- `docs/api.md`: the create field, a **Sandboxes** section, a `409` row. `docs/cli.md` + regenerated reference for `fountain run --sandbox`.
- SDK: `run({ sandbox })`, `fountain.sandboxes()`, `fountain.sandbox(id)`, `SandboxRecord`, the new error codes (`sandbox_at_capacity` retryable); `openapi.ts` regenerated from the spec.

Not in this PR, on purpose: `Team.open_fresh_conversation` keeps its own release-then-open path (it retires the old thread first, which attach does not); `sandbox_mode` / `find_or_create_home` is gate 6.

## Gate

- `mix precommit` at the root: **4,032 tests, 0 failures**; format clean (root, and hand-wrapped for 1.19.2).
- `go test ./... && go vet ./...`, gofmt clean; SDK `typecheck` + `npm test`; `vale lint docs` 0 errors; `docs-style.py` clean.
- New: `attach_test.exs` (9, every rule at the context), `sandbox_controller_test.exs` (4), `conversation_attach_controller_test.exs` (6, every status at the door including the prompt-through-wake path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
