### PR TITLE
feat(billing): turn hours add up per turn; a sandbox's busy time stays a union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ upgrade, is in
 
 ### Changed
 
+- **Turn hours add up per turn.** With several conversations on one sandbox
+  at once, a tenant's turn hours are the sum of their turns (two
+  conversations each running an hour on one machine spend two), while the
+  sandbox's busy time stays the union of the same intervals — the machine's
+  view, which a provider bill relates to. `SandboxUsage` reports both
+  (`turn_seconds` beside `busy_seconds`); the billing page, the API usage
+  summary and the admin finance panel now read the sum. On a sandbox with
+  one conversation the two numbers are equal, so nothing changes for
+  today's accounts. ADR 0026 addendum; ADR 0023 step 6.
+
 - **A sandbox several conversations hold is treated as one machine.**
   Three rules that used to be one conversation's to break (ADR 0023, steps
   4 and 5): a turn on an opencode or gemini sandbox is refused with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,12 @@ Five rules that are easy to get wrong:
 
 - **A turn hour is not a sandbox hour, and nothing enforces either.**
   `included_turn_hours` is 20 per concurrent slot, measured against
-  `SandboxUsage`'s `busy_seconds` (a prompt in flight) on platform-paid
-  providers only — an idle sandbox and a self-hosted runner spend none of it.
+  `SandboxUsage`'s `turn_seconds` (the turns summed, each clipped to the
+  period) on platform-paid providers only — an idle sandbox and a self-hosted
+  runner spend none of it. `busy_seconds` is the *union* of the same intervals
+  (how long the machine had any turn in flight) and is what a provider bill
+  relates to; several conversations share one sandbox (ADR 0023), so the two
+  differ and must not be swapped.
   `Billing.turn_hour_allowance/2` is the one shape every surface renders, so
   they cannot disagree. **No gate reads it** (#1016 steps 4 and 5 are unbuilt);
   do not add one without deciding the overage shape first.

--- a/decisions/0026-plans-and-entitlements.md
+++ b/decisions/0026-plans-and-entitlements.md
@@ -306,6 +306,16 @@ for the operator (`provider_spend/1`) rather than a customer-facing number.
 Hours on a self-hosted runner (0022) are excluded for the same reason from the
 other direction: Fountain pays nothing for that machine.
 
+> **Addendum, 2026-08-24 — summed per turn, not the sandbox's union.** Once
+> several conversations may run on one sandbox at the same time (0023, step
+> 6), "busy time" has two readings: the union of a sandbox's turn intervals
+> (how long the machine had any turn in flight, which is what a provider bill
+> relates to) and their sum (how much work the tenant did). The allowance is
+> spent in the sum — `SandboxUsage.turn_seconds` and
+> `turn_seconds_for_user/3` — so two conversations each running an hour on
+> one machine spend two hours of it. `busy_seconds` keeps the union and stays
+> capped at `active_seconds`; `turn_seconds` is not capped and may exceed it.
+
 The prod distribution this was set against, at the time of writing: the
 dogfood account burned 271 turn hours in a month against 11,091 active hours,
 and every other tenant was under half a turn hour. The ratio between those two

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -60,7 +60,9 @@ bound, not an allowance. Fountain charges for each contact separately.
 Each plan includes 20 turn hours for each concurrent sandbox. A turn hour is
 one hour with a prompt in flight. An agent that waits for a person spends no
 turn hours. Time on a self-hosted runner also spends none, because Fountain
-pays nothing for that machine.
+pays nothing for that machine. Turn hours add up for each turn. Two
+conversations that each run for an hour on one sandbox spend two turn hours,
+on a sandbox that was busy for one.
 
 Fountain reports these hours and enforces nothing. No request fails because a
 tenant exceeds the included hours. The price of an overage is still an open

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -2018,6 +2018,10 @@ defmodule Fountain.Billing do
   (ADR 0022) is excluded too — Fountain pays nothing for it, so charging an
   allowance against it would be indefensible.
 
+  Summed per turn, not the sandbox's busy union: several conversations may run
+  on one sandbox at once (ADR 0023), and two of them each running an hour are
+  two hours of work on a machine that was busy for one.
+
   Pass a period as `{start, end}`; defaults to the tenant's `billing_period/2`.
   """
   @spec turn_hours_used(User.t(), keyword()) :: float()
@@ -2029,7 +2033,7 @@ defmodule Fountain.Billing do
       end
 
     user.id
-    |> SandboxUsage.busy_for_user(period_start, period_end)
+    |> SandboxUsage.turn_seconds_for_user(period_start, period_end)
     |> Enum.filter(fn {provider, _seconds} -> SandboxUsage.platform_cost?(provider) end)
     |> Enum.map(&elem(&1, 1))
     |> Enum.sum()
@@ -2097,8 +2101,9 @@ defmodule Fountain.Billing do
     provider, `%{provider => minutes}`. Providers the tenant did not use are
     absent. Minutes on different providers are bought at different prices, so
     this split is what makes the total attributable to a cost.
-  - `:turn_hours` — the part of that time with a prompt actually in flight, on
-    the providers Fountain pays for. The same number
+  - `:turn_hours` — hours of turns on the providers Fountain pays for, summed
+    per turn (two conversations each an hour on one machine are two, ADR 0023
+    step 6), not the sandbox's busy time. The same number
     `turn_hours_used/2` computes, carried here so a surface showing usage does
     not need a second pass over the same rows to show the unit a plan is
     denominated in (`Fountain.Plans.included_turn_hours/1`).
@@ -2146,7 +2151,7 @@ defmodule Fountain.Billing do
       turn_hours:
         rows
         |> Enum.filter(&SandboxUsage.platform_cost?(&1.provider))
-        |> Enum.map(& &1.busy_seconds)
+        |> Enum.map(& &1.turn_seconds)
         |> Enum.sum()
         |> SandboxUsage.hours()
     }
@@ -2229,7 +2234,7 @@ defmodule Fountain.Billing do
           turn_hours:
             usage.by_provider
             |> Enum.filter(&SandboxUsage.platform_cost?(&1.provider))
-            |> Enum.map(& &1.busy)
+            |> Enum.map(& &1.turn)
             |> Enum.sum()
             |> SandboxUsage.hours()
       })

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -604,21 +604,22 @@ defmodule Fountain.Billing.Finance do
   end
 
   # Turn seconds that spend a tenant's allowance: the providers Fountain pays
-  # for, so a tenant's own runner (ADR 0022) is excluded. The same filter
-  # `Billing.turn_hours_used/2` applies, and it has to be the same one — the
-  # allowance shown here and the allowance shown on the tenant's own billing
-  # page cannot come apart.
+  # for, so a tenant's own runner (ADR 0022) is excluded, summed per turn
+  # rather than the sandbox's busy union (ADR 0023 step 6). The same filter and
+  # the same figure `Billing.turn_hours_used/2` applies, and it has to be the
+  # same one — the allowance shown here and the allowance shown on the tenant's
+  # own billing page cannot come apart.
   defp billable_turn_seconds(usage) do
     usage.by_provider
     |> Enum.filter(&SandboxUsage.platform_cost?(&1.provider))
-    |> Enum.map(& &1.busy)
+    |> Enum.map(& &1.turn)
     |> Enum.sum()
   end
 
-  defp allowance_used(_busy_seconds, 0), do: nil
+  defp allowance_used(_turn_seconds, 0), do: nil
 
-  defp allowance_used(busy_seconds, included),
-    do: Float.round(SandboxUsage.hours(busy_seconds) / included, 4)
+  defp allowance_used(turn_seconds, included),
+    do: Float.round(SandboxUsage.hours(turn_seconds) / included, 4)
 
   ## ── pricing helpers ─────────────────────────────────────────────────────
 
@@ -810,6 +811,7 @@ defmodule Fountain.Billing.Finance do
          active_seconds: group |> Enum.map(& &1.active_seconds) |> Enum.sum(),
          busy_seconds: group |> Enum.map(& &1.busy_seconds) |> Enum.sum(),
          idle_seconds: group |> Enum.map(& &1.idle_seconds) |> Enum.sum(),
+         turn_seconds: group |> Enum.map(& &1.turn_seconds) |> Enum.sum(),
          by_provider:
            Enum.map(
              group,
@@ -817,7 +819,8 @@ defmodule Fountain.Billing.Finance do
                provider: &1.provider,
                active: &1.active_seconds,
                busy: &1.busy_seconds,
-               idle: &1.idle_seconds
+               idle: &1.idle_seconds,
+               turn: &1.turn_seconds
              }
            )
        }}

--- a/ee/lib/fountain/billing/sandbox_usage.ex
+++ b/ee/lib/fountain/billing/sandbox_usage.ex
@@ -74,6 +74,13 @@ defmodule Fountain.Billing.SandboxUsage do
   by construction, with `busy` capped at `active` so an odd row cannot produce
   negative idle.
 
+  Turn time (`turn_seconds`) is the *sum* of those same intervals, each clipped
+  to the period. What the plans sell (decisions/0026) is hours of work, and
+  two conversations each running an hour on one machine are two hours of work
+  on a machine that was busy for one (decisions/0023, step 6). It is not
+  capped at `active` and may exceed it; `busy` is the machine's view, `turn`
+  the tenant's.
+
   ## What a provider column does and does not mean
 
   `runner` is a tenant's own machine (decisions/0022) — real sandbox time, zero
@@ -116,7 +123,8 @@ defmodule Fountain.Billing.SandboxUsage do
 
   `active_seconds` is what the provider charges for. `busy_seconds` is the part
   of it with a turn in flight and `idle_seconds` the rest; the two add up to
-  `active_seconds`.
+  `active_seconds`. `turn_seconds` is the turns themselves, summed — the unit a
+  plan's allowance is spent in — and is not bounded by `active_seconds`.
 
   `user_id` is `nil` for sandboxes whose owner has been deleted.
   """
@@ -126,6 +134,7 @@ defmodule Fountain.Billing.SandboxUsage do
           active_seconds: non_neg_integer(),
           busy_seconds: non_neg_integer(),
           idle_seconds: non_neg_integer(),
+          turn_seconds: non_neg_integer(),
           sandboxes: pos_integer()
         }
 
@@ -159,16 +168,20 @@ defmodule Fountain.Billing.SandboxUsage do
     overlapping
     |> Enum.group_by(fn {sandbox, _} -> {sandbox.user_id, sandbox.provider} end)
     |> Enum.map(fn {{user_id, provider}, group} ->
-      {active, busy_total} =
-        Enum.reduce(group, {0, 0}, fn {sandbox, seconds}, {active_acc, busy_acc} ->
+      {active, busy_total, turn_total} =
+        Enum.reduce(group, {0, 0, 0}, fn {sandbox, seconds}, {active_acc, busy_acc, turn_acc} ->
           sandbox_active = max(seconds - Map.get(parked, sandbox.id, 0), 0)
+          {union, sum} = Map.get(busy, sandbox.id, {0, 0})
 
           # Capped per sandbox rather than per group: a single row whose turns
           # somehow outrun its own active window must not borrow headroom from
           # a sibling and hide the anomaly.
-          sandbox_busy = min(Map.get(busy, sandbox.id, 0), sandbox_active)
+          sandbox_busy = min(union, sandbox_active)
 
-          {active_acc + sandbox_active, busy_acc + sandbox_busy}
+          # Turn seconds are deliberately not capped: two conversations each
+          # running an hour on one machine are two hours of work on a machine
+          # that was busy for one (decisions/0023, step 6).
+          {active_acc + sandbox_active, busy_acc + sandbox_busy, turn_acc + sum}
         end)
 
       %{
@@ -177,6 +190,7 @@ defmodule Fountain.Billing.SandboxUsage do
         active_seconds: active,
         busy_seconds: busy_total,
         idle_seconds: active - busy_total,
+        turn_seconds: turn_total,
         sandboxes: length(group)
       }
     end)
@@ -196,6 +210,7 @@ defmodule Fountain.Billing.SandboxUsage do
             active_seconds: non_neg_integer(),
             busy_seconds: non_neg_integer(),
             idle_seconds: non_neg_integer(),
+            turn_seconds: non_neg_integer(),
             sandboxes: non_neg_integer(),
             users: non_neg_integer()
           }
@@ -209,6 +224,7 @@ defmodule Fountain.Billing.SandboxUsage do
          active_seconds: group |> Enum.map(& &1.active_seconds) |> Enum.sum(),
          busy_seconds: group |> Enum.map(& &1.busy_seconds) |> Enum.sum(),
          idle_seconds: group |> Enum.map(& &1.idle_seconds) |> Enum.sum(),
+         turn_seconds: group |> Enum.map(& &1.turn_seconds) |> Enum.sum(),
          sandboxes: group |> Enum.map(& &1.sandboxes) |> Enum.sum(),
          users: group |> Enum.map(& &1.user_id) |> Enum.uniq() |> length()
        }}
@@ -247,14 +263,14 @@ defmodule Fountain.Billing.SandboxUsage do
   end
 
   @doc """
-  One tenant's *turn* seconds per provider: `%{provider => busy_seconds}`.
+  One tenant's *busy* seconds per provider: `%{provider => busy_seconds}` —
+  for each sandbox, how long it had any turn in flight (a union).
 
   The same rows `for_user/3` reads, reporting the part of each with a prompt
-  actually in flight rather than the whole active window. This is the unit a
-  plan's included hours are measured in (`Fountain.Plans.included_turn_hours/1`):
-  an idle sandbox costs Fountain money and is reported by `for_user/3`, but
-  spending nothing of a customer's allowance is the deliberate choice — the
-  allowance measures work, not forgetfulness.
+  actually in flight rather than the whole active window. This is the
+  machine's view, the one a provider bill on the `:turn` basis relates to. The
+  tenant's allowance is spent in `turn_seconds_for_user/3`, which sums turns
+  instead: on a shared sandbox the two differ.
 
   Providers with no turn time in the period are absent rather than zero, so a
   tenant whose sandboxes all sat idle gets an empty map, not `%{"sprites" => 0}`.
@@ -268,6 +284,30 @@ defmodule Fountain.Billing.SandboxUsage do
     |> attribution(period_end, user_id: user_id)
     |> Enum.reject(&(&1.busy_seconds == 0))
     |> Map.new(&{&1.provider, &1.busy_seconds})
+  end
+
+  @doc """
+  One tenant's *turn* seconds per provider: `%{provider => turn_seconds}` —
+  the sum over its turns, each clipped to the period.
+
+  This is the unit a plan's included hours are measured in
+  (`Fountain.Plans.included_turn_hours/1`): an idle sandbox costs Fountain
+  money and is reported by `for_user/3`, but spending nothing of a customer's
+  allowance is the deliberate choice — the allowance measures work, not
+  forgetfulness. And it is a sum, not a union: two conversations each running
+  an hour on one machine are two hours of work (decisions/0023, step 6).
+
+  Same shape and absence rule as `busy_for_user/3`.
+  """
+  @spec turn_seconds_for_user(binary(), DateTime.t(), DateTime.t()) :: %{
+          optional(String.t()) => non_neg_integer()
+        }
+  def turn_seconds_for_user(user_id, %DateTime{} = period_start, %DateTime{} = period_end)
+      when is_binary(user_id) do
+    period_start
+    |> attribution(period_end, user_id: user_id)
+    |> Enum.reject(&(&1.turn_seconds == 0))
+    |> Map.new(&{&1.provider, &1.turn_seconds})
   end
 
   @doc """
@@ -401,22 +441,24 @@ defmodule Fountain.Billing.SandboxUsage do
           # A turn with no end is still running, or ended without the row being
           # written; either way it cannot outlive the sandbox.
           close = effective_end(sandbox, ceiling)
+          intervals = Enum.map(own, &{&1.started_at, &1.ended_at || close})
+          clipped = fn {from, to} -> span_seconds(from, to, period_start, ceiling) end
 
-          seconds =
-            own
-            |> Enum.map(&{&1.started_at, &1.ended_at || close})
-            |> merge_intervals()
-            |> Enum.map(fn {from, to} -> span_seconds(from, to, period_start, ceiling) end)
-            |> Enum.sum()
+          # Both readings of the same intervals: the union (how long the
+          # machine had any turn in flight — `busy_seconds`) and the sum (how
+          # much turn time the tenant spent — `turn_seconds`).
+          union = intervals |> merge_intervals() |> Enum.map(clipped) |> Enum.sum()
+          sum = intervals |> Enum.map(clipped) |> Enum.sum()
 
-          Map.put(acc, sandbox.id, seconds)
+          Map.put(acc, sandbox.id, {union, sum})
       end
     end)
   end
 
-  # Union, not sum: two conversations prompting on one sandbox at the same
-  # moment is one busy sandbox. Summing them would let busy exceed active and
-  # report negative idle.
+  # Union, not sum, for the busy figure: two conversations prompting on one
+  # sandbox at the same moment is one busy sandbox. Summing them would let busy
+  # exceed active and report negative idle. (The sum is kept separately as
+  # `turn_seconds`, where exceeding active is the point.)
   defp merge_intervals(intervals) do
     intervals
     |> Enum.sort_by(fn {from, _} -> from end, DateTime)

--- a/ee/test/fountain/billing_sandbox_usage_test.exs
+++ b/ee/test/fountain/billing_sandbox_usage_test.exs
@@ -349,6 +349,39 @@ defmodule Fountain.Billing.SandboxUsageTest do
       assert [row] = attribution()
       assert row.busy_seconds == 2400
       assert row.idle_seconds == 1200
+      # The tenant's view is the sum: two half-hour turns are an hour of work,
+      # on a machine that was busy for forty minutes (ADR 0023 step 6).
+      assert row.turn_seconds == 3600
+    end
+
+    test "turn seconds sum per turn and may exceed the machine's active time" do
+      # Several conversations on one sandbox at once (ADR 0023): each hour of
+      # each turn spends an hour of the allowance, however many share the disk.
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      turn(sandbox, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+      turn(sandbox, user, ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+      turn(sandbox, user, ~U[2026-05-10 12:30:00Z], ~U[2026-05-10 13:00:00Z])
+
+      assert [row] = attribution()
+      assert row.active_seconds == 3600
+      assert row.busy_seconds == 3600
+      assert row.idle_seconds == 0
+      assert row.turn_seconds == 9000
+
+      assert SandboxUsage.by_provider([row])["sprites"].turn_seconds == 9000
+
+      assert SandboxUsage.turn_seconds_for_user(user.id, @period_start, @period_end) ==
+               %{"sprites" => 9000}
+
+      assert SandboxUsage.busy_for_user(user.id, @period_start, @period_end) ==
+               %{"sprites" => 3600}
+
+      # The allowance is spent in the sum.
+      assert Billing.turn_hours_used(user, period: {@period_start, @period_end}) == 2.5
     end
 
     test "a turn still running is busy up to the ceiling" do
@@ -451,6 +484,7 @@ defmodule Fountain.Billing.SandboxUsageTest do
                active_seconds: 1800,
                busy_seconds: 0,
                idle_seconds: 1800,
+               turn_seconds: 0,
                sandboxes: 2,
                users: 2
              }
@@ -459,6 +493,7 @@ defmodule Fountain.Billing.SandboxUsageTest do
                active_seconds: 300,
                busy_seconds: 0,
                idle_seconds: 300,
+               turn_seconds: 0,
                sandboxes: 1,
                users: 1
              }


### PR DESCRIPTION
ADR 0023 **gate 4** (step 6, decided 2026-08-23), recorded as an **ADR 0026 addendum**. Independent of #1064; touches billing only.

## The two readings

With several conversations on one sandbox at once, "busy time" means two different things:

| | what it measures | how | capped at `active`? | used for |
|---|---|---|---|---|
| `busy_seconds` (unchanged) | how long the **machine** had any turn in flight | union of the sandbox's turn intervals | yes | idle/busy split, provider cost on the `:turn` basis |
| `turn_seconds` (new) | how much **work** the tenant did | sum of the turns, each clipped to the period | no — may exceed active | the plan's turn-hour allowance |

Two conversations each running an hour on one machine are two turn hours, on a machine that was busy for one.

## What changed

- `SandboxUsage.attribution/3` rows carry `turn_seconds` beside `busy_seconds`; `by_provider/1` rolls it up; `turn_seconds_for_user/3` is the per-tenant reader beside `busy_for_user/3`, whose doc now says which view it is.
- `Billing.turn_hours_used/2`, `usage_summary/3` (`:turn_hours`), `usage_summaries/2` and `Finance`'s per-tenant rows (`turn_hours`, `allowance_used`) read the **sum**. `Finance.cost/3` on the `:turn` basis keeps the union — the provider charges for the machine.
- `plans-and-prices.md`, `CLAUDE.md` and the 0026 addendum say which is which.

On a sandbox with one conversation the two numbers are equal, so **nothing moves for today's accounts**; the new test is the overlapping case (three turns on one hour-long sandbox: busy 3600, turn 9000, `turn_hours_used` 2.5).

## Gate

- ee billing suites (`billing_sandbox_usage`, `billing_finance`, `billing`, `billing_trial_allowance`, `usage_metering`): **177 tests, 0 failures**; format clean.
- `vale lint`, `docs-style.py`, `okf validate decisions` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
