### PR TITLE
fix(conversations): a server restarted mid-provision rebuilds the sandbox instead of failing in clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ upgrade, is in
 
 ### Fixed
 
+- **A conversation interrupted mid-provision now rebuilds its sandbox instead of failing in `clone`.** A deploy or a Horde rebalance that killed a server during provisioning restarted it against the same half-built sprite, where `git clone` refused the existing checkout and the whole conversation failed. The restart now discards the remnant and provisions clean; the `provision started` event says so.
+
 - **The finance panel reported teammate-contact revenue nobody was charged.**
   It priced every non-comped contact at `Plans.contact_monthly_cents/0`, which
   returns $5 whether or not anything is configured to charge it. The actual

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -689,8 +689,23 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp do_fresh_provision_inner(state, conv, sandbox, agent, env, secrets) do
+    # The row only ever becomes `starting` right here, so finding it already
+    # `starting` means an earlier attempt was interrupted mid-provision — a
+    # deploy or a Horde rebalance killed the server while it was blocked in
+    # this function. The sprite it was building is most likely still there.
+    interrupted? = sandbox.status == "starting"
+
     {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
-    publish_stage(state.conversation_id, "provision", "started")
+
+    publish_stage(
+      state.conversation_id,
+      "provision",
+      "started",
+      if(interrupted?,
+        do: %{retry: "an earlier attempt was interrupted; rebuilding the sandbox"},
+        else: %{}
+      )
+    )
 
     # A `limited` environment on a backend with no `:network_policy` capability
     # can only fail. It failed closed before, but several steps in, after a
@@ -705,7 +720,8 @@ defmodule Fountain.Conversations.ConversationServer do
                provider,
                env,
                state.conversation_id
-             ) do
+             ),
+           :ok <- discard_interrupted_attempt(provider, sandbox, interrupted?) do
         create_sandbox_handle(provider, sandbox)
       end
 
@@ -2375,6 +2391,38 @@ defmodule Fountain.Conversations.ConversationServer do
 
   # The row's provider decides where the sandbox is created; adopt-on-
   # already-exists is the adapter's job.
+  # A sandbox left behind by an interrupted attempt cannot be finished in
+  # place: `Sandbox.create` adopts an existing sprite by name, so a restarted
+  # server would re-run every step on a half-built machine — and the steps
+  # are not idempotent (`git clone` refuses a checkout that already exists,
+  # a setup script that starts services fails on the second start). Seen
+  # live when a deploy landed during an environment's `setup` stage: the
+  # restart re-provisioned onto the same sprite and died in `clone`. Tear the
+  # remnant down first; a sprite that is already gone is not an error.
+  defp discard_interrupted_attempt(_provider, _sandbox, false), do: :ok
+
+  defp discard_interrupted_attempt(provider, sandbox, true) do
+    Logger.warning(
+      "sandbox #{sandbox.id}: sprite #{sandbox.sprite_name} was left mid-provision by an " <>
+        "interrupted attempt; destroying it before provisioning again"
+    )
+
+    handle = Fountain.Sandbox.build_handle(provider, sandbox.sprite_name)
+
+    case Fountain.Sandbox.destroy(handle) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.info(
+          "sandbox #{sandbox.id}: discarding sprite #{sandbox.sprite_name} returned " <>
+            "#{inspect(reason)}; provisioning anyway"
+        )
+
+        :ok
+    end
+  end
+
   defp create_sandbox_handle(provider, sandbox) do
     Fountain.Retry.with_backoff(
       fn -> Fountain.Sandbox.create(provider, sandbox.sprite_name) end,

--- a/apps/fountain/test/fountain/conversations/conversation_server_reprovision_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_reprovision_test.exs
@@ -1,0 +1,78 @@
+defmodule Fountain.Conversations.ConversationServerReprovisionTest do
+  # A server killed mid-provision (a deploy, a Horde rebalance) is restarted
+  # into handle_continue(:provision) with the sandbox row still `starting`.
+  # `Sandbox.create` adopts the existing sprite by name, so without care the
+  # restart re-runs every step on a half-built machine — and `git clone`
+  # refuses a checkout that already exists. Seen in production the first
+  # time a deploy landed during an environment's `setup` stage.
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Conversations
+
+  test "a row already `starting` gets its half-built sprite destroyed before a fresh create" do
+    stub_happy_sprite()
+    test_pid = self()
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :destroy, fn handle ->
+      send(test_pid, {:sprite_destroyed, handle.name})
+      :ok
+    end)
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :create, fn name, _opts ->
+      send(test_pid, {:sprite_created, name})
+      {:ok, Fountain.Sandbox.Sprites.build_handle(name)}
+    end)
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+    sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+    {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
+
+    {pid, _ref, :alive} = start_server(conv)
+
+    name = sandbox.sprite_name
+    assert_receive {:sprite_destroyed, ^name}, 5_000
+    assert_receive {:sprite_created, ^name}, 5_000
+    assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).status == "ready"
+
+    GenServer.call(pid, :terminate_conv, 30_000)
+  end
+
+  test "a `pending` row provisions without destroying anything" do
+    stub_happy_sprite()
+    test_pid = self()
+
+    Mimic.stub(Fountain.Sandbox.Sprites, :destroy, fn _handle ->
+      send(test_pid, :sprite_destroyed)
+      :ok
+    end)
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+    assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).status == "pending"
+
+    {pid, _ref, :alive} = start_server(conv)
+    assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).status == "ready"
+    refute_received :sprite_destroyed
+
+    GenServer.call(pid, :terminate_conv, 30_000)
+  end
+
+  test "a destroy that fails does not block the rebuild" do
+    stub_happy_sprite()
+    Mimic.stub(Fountain.Sandbox.Sprites, :destroy, fn _handle -> {:error, :not_found} end)
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, runtime: "gemini")
+    conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+    sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+    {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
+
+    {pid, _ref, :alive} = start_server(conv)
+    assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).status == "ready"
+
+    GenServer.call(pid, :terminate_conv, 30_000)
+  end
+end


### PR DESCRIPTION
## Summary

Conversation `e77ffa1d` (fountain-maintainer on fountain-contributor) failed with `{:clone, "https://github.com/BinaryBourbon/fountain", 128}` — `fatal: destination path '/workspace/fountain' already exists`. Timeline: provision → packages → clone → `setup started` 02:19:59; pods for #1062 rolled at 02:20:42/52; a second `provision started` at 02:21:24 on the **same sprite**, whose clone then refused the existing checkout.

The mechanism: a deploy (or Horde rebalance) kills a server blocked inside `handle_continue(:provision)`; the transient restart re-enters `:provision` with the sandbox row still `starting`; `Sandbox.create` adopts the existing sprite by name (sprites adapter, 409 → adopt); every step re-runs on a half-built machine, and the steps are not idempotent (`git clone`, a setup script that starts Postgres).

The rehydrator deliberately leaves mid-provision rows alone, and the #394 guard only covers the watchdog's ordering — neither covers this restart.

## Fix

In `do_fresh_provision_inner`, a row that is already `starting` on entry means an earlier attempt was interrupted (the row only becomes `starting` there). Destroy the remnant sprite first (a `destroy` error is logged and ignored — the sprite may already be gone), then create clean. The `provision started` stage event carries `retry: "an earlier attempt was interrupted; rebuilding the sandbox"` so a transcript explains the repeated stages.

## Test plan

- [x] New `conversation_server_reprovision_test.exs` (3 tests): `starting` row → destroy then create, ends `ready`; `pending` row → no destroy; a failing destroy does not block the rebuild
- [x] **Verified by reverting**: without the server change the first test fails on the destroy it never sees
- [x] Existing `conversation_server_provision_deadline_test.exs` still green (7/7 across both files)
- [x] `mix format --check-formatted`, `credo --strict` on the changed files

Not in scope: draining in-flight provisioning on SIGTERM so a deploy does not interrupt it in the first place — that is the larger change (#408 territory); this makes the interruption recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)