### PR TITLE
feat(conversations): a wake onto a fresh sandbox takes the machine's co-tenants along

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ upgrade, is in
   one conversation the two numbers are equal, so nothing changes for
   today's accounts. ADR 0026 addendum; ADR 0023 step 6.
 
+- **A sandbox that is gone is gone for every conversation on it.** When a
+  prompt wakes a conversation and finds its sandbox has vanished, the fresh
+  machine it provisions now takes every live conversation that shared the old
+  one along (runtime sessions cleared, a `sandbox`/`replaced` stage event on
+  each transcript), instead of leaving them pointing at a terminated row and
+  provisioning a machine each on their next prompt. ADR 0023 gate 5.
+
 - **A sandbox several conversations hold is treated as one machine.**
   Three rules that used to be one conversation's to break (ADR 0023, steps
   4 and 5): a turn on an opencode or gemini sandbox is refused with

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2597,10 +2597,15 @@ defmodule Fountain.Conversations do
       # handed the prompt instead of being raced by a second provision.
       case start_conversation_server(conv, new_sandbox.id, runtime_module, initial_prompt) do
         {:ok, _} ->
-          _ = mark_old_sandbox_terminated(conv.sandbox_id)
+          old_sandbox_id = conv.sandbox_id
+          _ = mark_old_sandbox_terminated(old_sandbox_id)
 
           {:ok, conv} =
             update_conversation(conv, %{sandbox_id: new_sandbox.id, status: "pending"})
+
+          # The machine was gone for everyone on it, not just the conversation
+          # that noticed (ADR 0023 gate 5).
+          move_cotenants(old_sandbox_id, new_sandbox.id, conv.id)
 
           {:ok, _unsafe_get_conversation!(conv.id)}
 
@@ -2638,6 +2643,61 @@ defmodule Fountain.Conversations do
   end
 
   defp assert_resumable(_), do: :ok
+
+  # A wake that found the sprite gone re-provisioned a machine for the
+  # conversation that woke. Every other live conversation on the old row was
+  # on the same dead disk, so it follows onto the new one (ADR 0023 gate 5) —
+  # the alternative leaves each co-tenant pointing at a `terminated` row and
+  # provisioning yet another machine on its own next prompt, and the shared
+  # disk they were sharing ends up as N disks.
+  #
+  # `old_sandbox_id` is the row the waking conversation *used* to name; by the
+  # time this runs the waking conversation itself already names the new one,
+  # so it is not among the co-tenants.
+  #
+  # A co-tenant whose server is somehow alive holds a handle to the dead
+  # sprite; it is told the machine is gone, cuts any turn, and stops, so its
+  # next prompt takes the wake path onto the new row. `runtime_session_id` is
+  # cleared for each: a fresh disk has no session to resume (#778).
+  defp move_cotenants(nil, _new_sandbox_id, _conv_id), do: :ok
+
+  defp move_cotenants(old_sandbox_id, new_sandbox_id, conv_id)
+       when is_binary(old_sandbox_id) and is_binary(new_sandbox_id) do
+    case _unsafe_list_cotenant_ids(old_sandbox_id, conv_id) do
+      [] ->
+        :ok
+
+      ids ->
+        message =
+          "The sandbox this conversation was on is gone; it moved to a fresh one together " <>
+            "with the conversations that shared it. The transcript is kept, but the agent " <>
+            "starts a new session and will not remember the earlier turns."
+
+        Enum.each(ids, fn id ->
+          case ConversationServer.whereis(id) do
+            nil -> :ok
+            pid -> GenServer.cast(pid, {:machine_gone, "replaced", "sprite_gone", message})
+          end
+        end)
+
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+        Repo.update_all(from(c in Conversation, where: c.id in ^ids),
+          set: [sandbox_id: new_sandbox_id, runtime_session_id: nil, updated_at: now]
+        )
+
+        Enum.each(ids, fn id ->
+          publish_stage(id, "sandbox", "done", %{
+            event: "replaced",
+            reason: "sprite_gone",
+            sandbox_id: new_sandbox_id,
+            message: message
+          })
+        end)
+
+        :ok
+    end
+  end
 
   defp mark_old_sandbox_terminated(nil), do: :ok
 

--- a/apps/fountain/test/fountain/conversations_wake_test.exs
+++ b/apps/fountain/test/fountain/conversations_wake_test.exs
@@ -214,6 +214,58 @@ defmodule Fountain.ConversationsWakeTest do
       assert Repo.reload(sandbox).status == "terminated"
     end
 
+    test "a gone sprite moves every live conversation on the machine to the new one (ADR 0023)" do
+      # Several conversations share one sandbox. When one of them wakes and
+      # finds the sprite gone, the disk was gone for all of them: they follow
+      # onto the fresh machine with their runtime sessions cleared (#778), a
+      # terminated one stays behind as history, and each moved transcript says
+      # what happened.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, status: "ready", sprite_name: "shared-gone")
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      neighbour =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: sandbox,
+          status: "idle",
+          runtime_session_id: "sess_neighbour"
+        )
+
+      retired =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: sandbox,
+          status: "terminated"
+        )
+
+      stub(Fountain.Sandbox.Sprites, :get, fn _handle -> {:error, :not_found} end)
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
+
+      assert {:ok, woken} = Conversations.wake_conversation(conv.id)
+      new_id = woken.sandbox_id
+      assert new_id != sandbox.id
+
+      moved = Repo.reload(neighbour)
+      assert moved.sandbox_id == new_id
+      assert is_nil(moved.runtime_session_id)
+      assert moved.status == "idle"
+
+      assert Repo.reload(retired).sandbox_id == sandbox.id
+      assert Repo.reload(sandbox).status == "terminated"
+
+      assert Enum.any?(Conversations._unsafe_list_log_events(neighbour.id), fn e ->
+               e.kind == "stage" and e.stage == "sandbox" and
+                 Jason.decode!(e.data)["event"] == "replaced"
+             end)
+    end
+
     test "returns {:ok, conv} creating fresh sandbox when sprite is gone" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)


### PR DESCRIPTION
ADR 0023 **gate 5**. Independent of #1064 and #1065; one function and one test.

## Why

When a prompt wakes a conversation and finds its sandbox gone, `create_fresh_sandbox_and_start/4` provisions a new machine — and repointed only the conversation that noticed. Every other live conversation on the old row was on the same dead disk: it stayed pointed at a `terminated` sandbox and would have provisioned a machine of its own on its next prompt, so the disk they were sharing became N disks.

## What

`move_cotenants/3`, called from the success arm after the waking conversation is repointed:

- every other conversation on the old row that is not `terminated`/`failed` moves to the new sandbox in one `update_all`, with `runtime_session_id` cleared — a fresh disk has no session to resume (#778);
- each moved transcript gets a `sandbox`/`done` stage event with `event: "replaced"`, `reason: "sprite_gone"` and the new `sandbox_id`, worded like the ceiling's honesty message (transcript kept, memory not);
- a co-tenant whose server is somehow still alive is told `{:machine_gone, "replaced", …}` (the cast #1061 added), so it cuts any turn and stops instead of holding a handle to a dead sprite; its next prompt wakes onto the new row.

A terminated co-tenant stays behind as history. The `already_started` and error arms are untouched — nothing moved there.

## Gate

- `mix precommit` at the root: **4,015 tests, 0 failures**; format clean.
- New test in `conversations_wake_test.exs`: a shared sandbox with an idle neighbour (with a session id) and a terminated one — the neighbour follows with its session cleared and a `replaced` event, the terminated one stays, the old row is terminated. It failed against the first draft, which read the *new* id after the repoint; the fix captures the old id first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
