### PR TITLE
feat(agents): a persistent sandbox per agent — the agent's computer (sandbox_mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,15 +30,6 @@ upgrade, is in
   launch while the home is still provisioning gets `503 provisioning`.
   Sandboxes carry `mode`. ADR 0023 gate 6.
 
-### Fixed
-
-- **Deleting an agent that had a versioned conversation failed.** The
-  delete cascades to the agent's versions, and Postgres re-checked the
-  conversation's `agent_version_id` mid-cascade, before its own SET NULL
-  ran, so every agent with a conversation started since config versioning
-  (#1049) refused to delete with a foreign-key error. The conversations are
-  unpinned from their versions first now; the version was provenance only.
-
 - **A second conversation on a sandbox you already have.** `sandbox_id` on
   `POST /api/conversations` attaches the new conversation to an existing
   machine instead of provisioning one: it must be yours, `ready` or
@@ -146,6 +137,13 @@ upgrade, is in
   separating the two. ADR 0026 carries an amendment with the reasoning.
 
 ### Fixed
+
+- **Deleting an agent that had a versioned conversation failed.** The
+  delete cascades to the agent's versions, and Postgres re-checked the
+  conversation's `agent_version_id` mid-cascade, before its own SET NULL
+  ran, so every agent with a conversation started since config versioning
+  (#1049) refused to delete with a foreign-key error. The conversations are
+  unpinned from their versions first now; the version was provenance only.
 
 - **A conversation interrupted mid-provision now rebuilds its sandbox instead of failing in `clone`.** A deploy or a Horde rebalance that killed a server during provisioning restarted it against the same half-built sprite, where `git clone` refused the existing checkout and the whole conversation failed. The restart now discards the remnant and provisions clean; the `provision started` event says so.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ upgrade, is in
 
 ### Added
 
+- **A persistent sandbox per agent — the agent's computer.** An agent's
+  `sandbox_mode` is `ephemeral` (a sandbox per conversation, the default and
+  today's behaviour) or `persistent`: one machine per agent identity (agent,
+  environment, vault) that every conversation of that identity lands on and
+  shares, provisioned on the first launch and attached to on every later
+  one. A home survives a conversation ending, is parked rather than
+  destroyed at the ceiling, and is destroyed when its agent is deleted. A
+  launch may name the other mode (`sandbox_mode` on `POST /api/conversations`,
+  `fountain run --sandbox-mode`, the SDK's `run({ sandboxMode })`); a second
+  launch while the home is still provisioning gets `503 provisioning`.
+  Sandboxes carry `mode`. ADR 0023 gate 6.
+
+### Fixed
+
+- **Deleting an agent that had a versioned conversation failed.** The
+  delete cascades to the agent's versions, and Postgres re-checked the
+  conversation's `agent_version_id` mid-cascade, before its own SET NULL
+  ran, so every agent with a conversation started since config versioning
+  (#1049) refused to delete with a foreign-key error. The conversations are
+  unpinned from their versions first now; the version was provenance only.
+
 - **A second conversation on a sandbox you already have.** `sandbox_id` on
   `POST /api/conversations` attaches the new conversation to an existing
   machine instead of provisioning one: it must be yours, `ready` or

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -190,8 +190,35 @@ defmodule Fountain.Agents do
   end
 
   @doc "Delete an agent. See `create_agent/2` for `opts`."
-  def delete_agent(%Agent{} = agent, opts \\ []),
-    do: agent |> Repo.delete() |> audited("agent.deleted", opts)
+  def delete_agent(%Agent{} = agent, opts \\ []) do
+    # A home is the agent's computer; without the agent its identity is gone
+    # (ADR 0023 step 5). Torn down before the row goes, while `agent_id` still
+    # names it — deletion would nilify the pointer and orphan the sprite.
+    # Ownership: `agent` came from the caller's scoped fetch.
+    _ = Fountain.Conversations._unsafe_destroy_homes_for_agent(agent.id)
+
+    # Unpin the agent's conversations from its versions before the row goes.
+    # Deleting the agent cascades to `agent_versions`, and Postgres re-checks
+    # `conversations.agent_version_id` while it is still setting
+    # `conversations.agent_id` to NULL in the same statement — before its own
+    # SET NULL for the version has run — so the delete failed with a
+    # foreign-key violation for every agent that had a versioned
+    # conversation (found building ADR 0023 gate 6; versioning is #1049).
+    # The version is provenance only, so clearing it here loses nothing the
+    # cascade would not have cleared anyway.
+    Repo.transaction(fn ->
+      Repo.update_all(
+        from(c in Fountain.Conversations.Conversation, where: c.agent_id == ^agent.id),
+        set: [agent_version_id: nil]
+      )
+
+      case Repo.delete(agent) do
+        {:ok, deleted} -> deleted
+        {:error, changeset} -> Repo.rollback(changeset)
+      end
+    end)
+    |> audited("agent.deleted", opts)
+  end
 
   @doc """
   Upload or replace the avatar for an agent.
@@ -269,6 +296,7 @@ defmodule Fountain.Agents do
     :model,
     :runtime,
     :sandbox_provider,
+    :sandbox_mode,
     :skills,
     :mcp_servers,
     :metadata,

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -23,6 +23,11 @@ defmodule Fountain.Agents.Agent do
     # Optional sandbox-backend override; nil inherits the instance default
     # (SANDBOX_PROVIDER) at conversation start.
     field :sandbox_provider, :string
+    # Where a conversation of this agent runs by default (ADR 0023):
+    # `ephemeral`, a sandbox per conversation, or `persistent`, one sandbox
+    # per agent identity that every conversation lands on — the agent's
+    # computer. A launch may name the other; this is the default, not a rule.
+    field :sandbox_mode, :string, default: "ephemeral"
     # Each entry is one of:
     #   %{"name" => name, "content" => skill_md}     # inline SKILL.md
     #   %{"source" => "owner/repo", "name" => opt}   # github via skills.sh CLI
@@ -53,6 +58,11 @@ defmodule Fountain.Agents.Agent do
 
   def runtimes, do: @runtimes
 
+  @sandbox_modes ~w(ephemeral persistent)
+
+  @doc "The sandbox modes a launch may choose (ADR 0023)."
+  def sandbox_modes, do: @sandbox_modes
+
   def changeset(agent, attrs) do
     agent
     |> cast(attrs, [
@@ -62,6 +72,7 @@ defmodule Fountain.Agents.Agent do
       :model,
       :runtime,
       :sandbox_provider,
+      :sandbox_mode,
       :skills,
       :mcp_servers,
       :metadata,
@@ -73,6 +84,7 @@ defmodule Fountain.Agents.Agent do
     ])
     |> validate_required([:name, :model, :runtime])
     |> validate_inclusion(:runtime, @runtimes)
+    |> validate_inclusion(:sandbox_mode, @sandbox_modes)
     |> validate_format(:model, ~r{^[a-z0-9_-]+/[a-z0-9._-]+$},
       message: "must be in canonical provider/model_id form"
     )

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1699,10 +1699,16 @@ defmodule Fountain.Conversations do
          {:ok, runtime_module} <- Fountain.Runtimes.for_runtime(agent.runtime),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
+         {:ok, mode} <- resolve_sandbox_mode(attrs["sandbox_mode"], agent),
          {:ok, perm_policy} <- resolve_permission_policy(attrs["permission_policy"], agent),
          {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Accounts.check_not_suspended(user_id),
          :ok <- Fountain.Billing.check_active(user_id),
+         # A persistent launch lands on the identity's home when there is one
+         # (ADR 0023 gate 6): `{:home, sandbox}` leaves the `with` and attaches
+         # below. Only when there is none does a machine get provisioned, and
+         # it is stamped as the home.
+         :new <- home_or_new(mode, user_id, agent, env_id || agent.environment_id, vault_id),
          {:ok, provider} <- resolve_sandbox_provider(agent),
          {:ok, sprite_name} <- mint_sprite_name(provider, user_id, attrs["sprite_name"]),
          # Quota check + row insert under one per-user advisory lock: checked
@@ -1716,6 +1722,7 @@ defmodule Fountain.Conversations do
                # later must name the same three.
                agent_id: agent.id,
                vault_id: vault_id,
+               mode: mode,
                sprite_name: sprite_name,
                status: "pending",
                provider: Atom.to_string(provider),
@@ -1810,9 +1817,146 @@ defmodule Fountain.Conversations do
           {:ok, result}
       end
     else
-      nil -> {:error, :not_found}
-      {:error, _} = err -> err
+      nil ->
+        {:error, :not_found}
+
+      # The identity already has a home: this launch is a conversation on it.
+      {:home, %Sandbox{} = home} ->
+        attach_conversation(home.id, attrs, opts)
+
+      # Two persistent launches of one identity raced to create its home and
+      # this one lost at the unique index. The winner's row is the home now;
+      # land on it rather than fail a request that asked for nothing unusual.
+      {:error, %Ecto.Changeset{errors: errors}} = err ->
+        if Keyword.has_key?(errors, :home) do
+          with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id),
+               {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
+               {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
+               %Sandbox{} = home <-
+                 _unsafe_find_home(user_id, agent.id, env_id || agent.environment_id, vault_id) do
+            attach_conversation(home.id, attrs, opts)
+          else
+            _ -> err
+          end
+        else
+          err
+        end
+
+      {:error, _} = err ->
+        err
     end
+  end
+
+  # The launch's sandbox mode: the agent's default unless the launch names
+  # one (ADR 0023). Not an allowlisted override like `environment_id` — the
+  # mode is not a security boundary; the tenant scope on the sandbox is.
+  defp resolve_sandbox_mode(mode, %Agents.Agent{sandbox_mode: default}) when mode in [nil, ""],
+    do: {:ok, default || "ephemeral"}
+
+  defp resolve_sandbox_mode(mode, _agent) when is_binary(mode) do
+    if mode in Sandbox.modes(), do: {:ok, mode}, else: {:error, :invalid_sandbox_mode}
+  end
+
+  defp resolve_sandbox_mode(_mode, _agent), do: {:error, :invalid_sandbox_mode}
+
+  # `:new` when a machine has to be provisioned; `{:home, sandbox}` when the
+  # identity already has one to land on. A home still provisioning from its
+  # first launch cannot take a second conversation yet — its prompt would be
+  # handed to the wrong server — so it reads as `:provisioning`, the same
+  # retry-shortly answer a mid-provision conversation gives.
+  defp home_or_new("ephemeral", _user_id, _agent, _env_id, _vault_id), do: :new
+
+  defp home_or_new("persistent", user_id, %Agents.Agent{id: agent_id}, env_id, vault_id) do
+    case _unsafe_find_home(user_id, agent_id, env_id, vault_id) do
+      nil -> :new
+      %Sandbox{status: s} when s in ["pending", "starting"] -> {:error, :provisioning}
+      %Sandbox{} = home -> {:home, home}
+    end
+  end
+
+  @doc """
+  The live home of an agent identity — the one persistent sandbox for
+  `(user, agent, environment, vault)` that is not terminated or failed — or
+  nil. `nil` environment and vault are part of the identity, not wildcards.
+  `_unsafe_`: callers have resolved the agent tenant-scoped already.
+  """
+  def _unsafe_find_home(user_id, agent_id, env_id, vault_id)
+      when is_binary(user_id) and is_binary(agent_id) do
+    from(s in Sandbox,
+      where:
+        s.user_id == ^user_id and s.agent_id == ^agent_id and s.mode == "persistent" and
+          s.status not in ["terminated", "failed"],
+      order_by: [desc: s.inserted_at],
+      limit: 1
+    )
+    |> where_sandbox_environment(env_id)
+    |> where_sandbox_vault(vault_id)
+    |> Repo.one()
+  end
+
+  defp where_sandbox_vault(query, nil), do: from(s in query, where: is_nil(s.vault_id))
+  defp where_sandbox_vault(query, id), do: from(s in query, where: s.vault_id == ^id)
+
+  defp where_sandbox_environment(query, nil),
+    do: from(s in query, where: is_nil(s.environment_id))
+
+  defp where_sandbox_environment(query, id), do: from(s in query, where: s.environment_id == ^id)
+
+  @doc """
+  Whether terminating `conv_id` leaves its sandbox standing: a home is never
+  torn down by one conversation ending (ADR 0023 step 5), and neither is a
+  machine another live conversation still holds. Both `ConversationServer`
+  terminate paths ask this. `_unsafe_`: the caller owns `conv_id`.
+  """
+  def _unsafe_sandbox_kept_on_terminate?(sandbox_id, conv_id)
+      when is_binary(sandbox_id) and is_binary(conv_id) do
+    case _unsafe_get_sandbox(sandbox_id) do
+      %Sandbox{mode: "persistent"} -> true
+      _ -> _unsafe_sandbox_held_by_other?(sandbox_id, conv_id)
+    end
+  end
+
+  @doc """
+  Tear down every home of `agent_id` — what deleting the agent does, since
+  the identity the homes were built for is gone (ADR 0023 step 5). Each live
+  conversation on a home is terminated (a home survives that on its own), then
+  the sprite is destroyed and the row terminated. Best-effort per machine; a
+  provider error is logged and the row still retires, so the reaper's sweep
+  sees a terminal row rather than a live one nobody can find. Returns the
+  number of homes torn down. `_unsafe_`: the caller owns the agent.
+  """
+  def _unsafe_destroy_homes_for_agent(agent_id) when is_binary(agent_id) do
+    from(s in Sandbox,
+      where:
+        s.agent_id == ^agent_id and s.mode == "persistent" and
+          s.status not in ["terminated", "failed"]
+    )
+    |> Repo.all()
+    |> Enum.map(&_unsafe_destroy_home/1)
+    |> length()
+  end
+
+  @doc false
+  def _unsafe_destroy_home(%Sandbox{} = sandbox) do
+    sandbox = Repo.preload(sandbox, :conversations)
+
+    sandbox.conversations
+    |> Enum.reject(&(&1.status in ["terminated", "failed"]))
+    |> Enum.each(&ConversationServer.terminate_conversation(&1.id, actor: "system:home_reset"))
+
+    handle = Fountain.Sandbox.build_handle(sandbox_provider_atom(sandbox), sandbox.sprite_name)
+
+    case Fountain.Sandbox.destroy(handle) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("home #{sandbox.sprite_name} destroy failed: #{inspect(reason)}")
+    end
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    {:ok, _} = update_sandbox(sandbox, %{status: "terminated", terminated_at: now})
+    :ok
   end
 
   # A conversation on a machine the caller already has (ADR 0023 gate 3).
@@ -2550,6 +2694,15 @@ defmodule Fountain.Conversations do
     # Waking a dormant conversation provisions a fresh sprite, so it is subject
     # to the same gate as creating one. Without this, prompting an existing
     # conversation was an unmetered way past billing entirely.
+    # The replacement keeps the mode of the machine it replaces: a home whose
+    # sprite is gone is re-provisioned as the home, and every conversation on
+    # it follows (move_cotenants/3). The old row is retired *first* for a
+    # home — the partial unique index allows one live home per identity, and
+    # the probe has already said this sprite is gone (ADR 0023 gate 6).
+    old = if conv.sandbox_id, do: _unsafe_get_sandbox(conv.sandbox_id)
+    mode = (old && old.mode) || "ephemeral"
+    if mode == "persistent", do: _ = mark_old_sandbox_terminated(conv.sandbox_id)
+
     with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
          :ok <- Fountain.Billing.check_active(conv.user_id),
          # A fresh sandbox is a fresh placement decision — re-resolve from
@@ -2567,6 +2720,7 @@ defmodule Fountain.Conversations do
                  environment_id: conv.environment_id || agent.environment_id,
                  agent_id: conv.agent_id,
                  vault_id: conv.vault_id,
+                 mode: mode,
                  sprite_name: sprite_name,
                  status: "pending",
                  provider: Atom.to_string(provider),

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -239,11 +239,14 @@ defmodule Fountain.Conversations.ConversationServer do
               {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
 
               # A sandbox handed on to a successor conversation
-              # (`release_conversation/2`) is that conversation's computer now;
-              # terminating the retired thread must not take it down.
-              if is_binary(conv.sandbox_id) and
-                   not Conversations._unsafe_sandbox_held_by_other?(conv.sandbox_id, conv.id) do
-                sb = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+              # (`release_conversation/2`) is that conversation's computer now,
+              # and a home is the agent's (ADR 0023); terminating this thread
+              # must not take either down.
+              sandbox_id = conv.sandbox_id
+
+              if is_binary(sandbox_id) and
+                   not Conversations._unsafe_sandbox_kept_on_terminate?(sandbox_id, conv.id) do
+                sb = Conversations._unsafe_get_sandbox!(sandbox_id)
 
                 if sb.status not in ["terminated", "failed"] do
                   Conversations.update_sandbox(sb, %{status: "terminated", terminated_at: now})
@@ -1479,19 +1482,22 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   def handle_call(:terminate_conv, _from, state) do
-    if Conversations._unsafe_sandbox_held_by_other?(state.sandbox_id, state.conversation_id) do
-      # The machine is shared (ADR 0023): end this conversation and leave the
-      # sprite to the others — the same guard the no-server path applies in
-      # terminate_conversation/2. A turn of ours still running is cut first,
-      # since nothing would be left to drive it; `handle: nil` so no stop path
-      # touches the sprite.
+    kept? =
+      Conversations._unsafe_sandbox_kept_on_terminate?(state.sandbox_id, state.conversation_id)
+
+    if kept? do
+      # The machine is shared, or it is the agent's home (ADR 0023): end this
+      # conversation and leave the sprite — the same guard the no-server path
+      # applies in terminate_conversation/2. A turn of ours still running is
+      # cut first, since nothing would be left to drive it; `handle: nil` so
+      # no stop path touches the sprite.
       state = if state.current_turn, do: interrupt_turn(state), else: state
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
       {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
 
       publish_stage(state.conversation_id, "terminate", "done", %{
         sandbox: "kept",
-        reason: "held_by_another_conversation"
+        reason: if(home?(state), do: "persistent_home", else: "held_by_another_conversation")
       })
 
       {:stop, :normal, :ok, %{state | handle: nil}}
@@ -2159,9 +2165,29 @@ defmodule Fountain.Conversations.ConversationServer do
   # for the conversation that never stops being busy; the conversation stays
   # `idle` and resumable — setting it `terminated` here would make a cost
   # control into data loss. See Fountain.Conversations.Lifecycle.
+  #
+  # A home is parked instead, where the provider can park: its disk is the
+  # agent's memory across every conversation, and destroying it at a busy
+  # ceiling would defeat the mode (ADR 0023 step 5). The ceiling itself is
+  # slated to go; until then this is the interim it names. A home on a
+  # provider that cannot park, or whose park call fails, is destroyed as an
+  # ephemeral one would be — an unparked machine keeps billing.
   defp reclaim_sandbox(state, :max_lifetime) do
-    destroy_sandbox(state, :max_lifetime)
+    with true <- home?(state),
+         :suspend <- Lifecycle.idle_action(provider(state)),
+         :ok <- suspend_sandbox(state) do
+      park_sandbox(state, :max_lifetime)
+    else
+      _ -> destroy_sandbox(state, :max_lifetime)
+    end
   end
+
+  # Whether this server's machine is a persistent home (ADR 0023).
+  defp home?(%{sandbox_id: sandbox_id}) when is_binary(sandbox_id) do
+    match?(%{mode: "persistent"}, Conversations._unsafe_get_sandbox(sandbox_id))
+  end
+
+  defp home?(_state), do: false
 
   defp reclaim_idle_machine(state) do
     with :suspend <- Lifecycle.idle_action(provider(state)),
@@ -2188,9 +2214,9 @@ defmodule Fountain.Conversations.ConversationServer do
   defp suspend_sandbox(%{handle: nil}), do: :ok
   defp suspend_sandbox(state), do: Fountain.Sandbox.suspend(state.handle)
 
-  defp park_sandbox(state) do
+  defp park_sandbox(state, reason \\ :idle) do
     Logger.info(
-      "suspending sandbox for conv #{state.conversation_id}: idle " <>
+      "suspending sandbox for conv #{state.conversation_id}: #{reason} " <>
         "(sprite #{inspect(state.handle && state.handle.name)})"
     )
 
@@ -2210,15 +2236,15 @@ defmodule Fountain.Conversations.ConversationServer do
     # clients already key on the "sandbox" stage); `event` is the discriminator.
     publish_stage(state.conversation_id, "sandbox", "done", %{
       event: "suspended",
-      reason: "idle",
-      message: Lifecycle.explain(:idle, :suspend)
+      reason: to_string(reason),
+      message: Lifecycle.explain(reason, :suspend)
     })
 
     :telemetry.execute([:fountain, :sandbox, :suspended], %{count: 1}, %{
       provider: provider(state)
     })
 
-    stop_cotenants(state, "suspended", "idle", Lifecycle.explain(:idle, :suspend))
+    stop_cotenants(state, "suspended", to_string(reason), Lifecycle.explain(reason, :suspend))
 
     {:stop, :normal, %{state | handle: nil}}
   end

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -145,10 +145,18 @@ defmodule Fountain.Conversations.Lifecycle do
   The idle copy, by what actually happened. Same honesty rule as the two
   arms of `explain/1`: promise memory only where the disk survives.
   """
-  @spec explain(:idle, :suspend | :destroy) :: String.t()
+  @spec explain(:idle | :max_lifetime, :suspend | :destroy) :: String.t()
   def explain(:idle, :suspend) do
     "Sandbox suspended after #{minutes(idle_timeout_seconds())} minutes idle. " <>
       "Send another prompt to continue — the agent picks up right where it left off."
+  end
+
+  # A home at the ceiling is parked, not destroyed (ADR 0023): the disk stays,
+  # the turn that was in flight does not.
+  def explain(:max_lifetime, :suspend) do
+    "Sandbox suspended after reaching the #{hours(max_lifetime_seconds())} hour maximum " <>
+      "lifetime; a turn in flight was cut. Send another prompt to continue — the agent " <>
+      "picks up right where it left off."
   end
 
   def explain(:idle, :destroy) do

--- a/apps/fountain/lib/fountain/conversations/sandbox.ex
+++ b/apps/fountain/lib/fountain/conversations/sandbox.ex
@@ -15,6 +15,13 @@ defmodule Fountain.Conversations.Sandbox do
   # next prompt via the reattach path. See decisions/0017.
   @statuses ~w(pending starting ready suspended terminated failed)
 
+  # `ephemeral`: the conversation's machine, created with it and reclaimed
+  # with it. `persistent`: the agent identity's machine — a home — that every
+  # conversation of that identity lands on, kept when a conversation ends,
+  # parked rather than destroyed at the ceiling, and single per identity by
+  # the partial unique index (ADR 0023).
+  @modes ~w(ephemeral persistent)
+
   schema "sandboxes" do
     # Provider-scoped sandbox identity: the name Fountain mints
     # (`fountain-<tenant-prefix>-<hex>`) and uses as the primary external ref.
@@ -28,6 +35,7 @@ defmodule Fountain.Conversations.Sandbox do
     field :provider, :string, default: "sprites"
     # Adapter-opaque state (e.g. a server-assigned id). Never tenant-visible.
     field :provider_meta, :map, default: %{}
+    field :mode, :string, default: "ephemeral"
     field :terminated_at, :utc_datetime
     field :last_resumed_at, :utc_datetime
     belongs_to :environment, Environment
@@ -46,6 +54,9 @@ defmodule Fountain.Conversations.Sandbox do
 
   def statuses, do: @statuses
 
+  @doc "The sandbox modes (ADR 0023)."
+  def modes, do: @modes
+
   def changeset(sandbox, attrs) do
     sandbox
     |> cast(attrs, [
@@ -53,6 +64,7 @@ defmodule Fountain.Conversations.Sandbox do
       :status,
       :provider,
       :provider_meta,
+      :mode,
       :terminated_at,
       :last_resumed_at,
       :environment_id,
@@ -60,8 +72,15 @@ defmodule Fountain.Conversations.Sandbox do
       :vault_id,
       :user_id
     ])
-    |> validate_required([:sprite_name, :status, :provider, :user_id])
+    |> validate_required([:sprite_name, :status, :provider, :mode, :user_id])
     |> validate_inclusion(:status, @statuses)
+    |> validate_inclusion(:mode, @modes)
     |> validate_inclusion(:provider, Fountain.Sandbox.known_providers())
+    # One live home per identity. Surfaced under `:home` so a launch that
+    # lost the race to create it can tell and attach to the winner instead.
+    |> unique_constraint(:home,
+      name: :sandboxes_home_identity_index,
+      message: "a home for this agent, environment and vault already exists"
+    )
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/agent_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_json.ex
@@ -21,6 +21,7 @@ defmodule FountainWeb.AgentJSON do
       # held-back runtime is converted.
       acp: Fountain.Runtimes.ACP.enabled?(a.runtime),
       sandbox_provider: a.sandbox_provider,
+      sandbox_mode: a.sandbox_mode,
       environment_id: a.environment_id,
       skills: a.skills,
       mcp_servers: a.mcp_servers,

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -85,6 +85,7 @@ defmodule FountainWeb.ConversationJSON do
       agent_id: s.agent_id,
       environment_id: s.environment_id,
       vault_id: s.vault_id,
+      mode: s.mode,
       # The sandbox's own HTTP endpoint, for providers that give it one. Read
       # from the row rather than the provider so listing conversations stays a
       # single query; null means the provider has no such concept (or the

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -236,6 +236,16 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  def call(conn, {:error, :invalid_sandbox_mode}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "invalid_sandbox_mode",
+      message:
+        "sandbox_mode must be one of " <> Enum.join(Fountain.Agents.Agent.sandbox_modes(), ", ")
+    })
+  end
+
   def call(conn, {:error, :sandbox_runtime_mismatch}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -62,6 +62,7 @@ defmodule FountainWeb.AgentsLive.Form do
       "model" => a.model || "anthropic/claude-sonnet-4-6",
       "runtime" => a.runtime || "claude",
       "sandbox_provider" => a.sandbox_provider || "",
+      "sandbox_mode" => a.sandbox_mode || "ephemeral",
       "environment_id" => a.environment_id || "",
       "permission_default" => Permissions.verdict_for(a.permission_policy, nil),
       "permission_kinds" => permission_kind_form(a.permission_policy)
@@ -680,6 +681,29 @@ defmodule FountainWeb.AgentsLive.Form do
             </option>
           </select>
           <.error_msg field="sandbox_provider" errors={@errors} />
+        </div>
+
+        <div class="space-y-1">
+          <label class="block text-sm font-medium text-zinc-700">Sandbox</label>
+          <select
+            name="agent[sandbox_mode]"
+            class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+          >
+            <option value="ephemeral" selected={@form["sandbox_mode"] != "persistent"}>
+              A fresh sandbox per conversation
+            </option>
+            <option value="persistent" selected={@form["sandbox_mode"] == "persistent"}>
+              One persistent sandbox — the agent's computer
+            </option>
+          </select>
+          <p class="text-xs text-zinc-500">
+            Persistent: every conversation of this agent (with the same environment and
+            vault) lands on one machine and shares its disk, at the same time. Notes,
+            clones and installed tools accrue; so does anything a bad turn leaves
+            behind. It survives a conversation ending and is parked, not destroyed, at
+            the ceiling. A launch can still ask for the other mode.
+          </p>
+          <.error_msg field="sandbox_mode" errors={@errors} />
         </div>
 
         <div class="space-y-1">

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -36,6 +36,13 @@ defmodule FountainWeb.Schemas do
         },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         vault_id: %Schema{type: :string, format: :uuid, nullable: true},
+        mode: %Schema{
+          type: :string,
+          enum: ~w(ephemeral persistent),
+          description:
+            "ephemeral: one conversation's machine, reclaimed with it. persistent: the " <>
+              "agent identity's home, shared by its conversations and kept when one ends."
+        },
         url: %Schema{
           type: :string,
           nullable: true,
@@ -363,6 +370,18 @@ defmodule FountainWeb.Schemas do
           type: :string,
           description: "Override the auto-generated sprite name."
         },
+        sandbox_mode: %Schema{
+          type: :string,
+          enum: ~w(ephemeral persistent),
+          nullable: true,
+          description:
+            "Where this conversation runs (ADR 0023); null takes the agent's sandbox_mode. " <>
+              "persistent lands on the agent identity's home — provisioning it if this is " <>
+              "the first launch of that (agent, environment, vault), attaching to it " <>
+              "otherwise, or 503 provisioning while the first launch is still building it. " <>
+              "ephemeral provisions a sandbox for this conversation alone. Ignored when " <>
+              "sandbox_id names a machine."
+        },
         sandbox_id: %Schema{
           type: :string,
           format: :uuid,
@@ -543,6 +562,17 @@ defmodule FountainWeb.Schemas do
           description:
             "Sandbox backend override; null inherits the instance default " <>
               "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
+        },
+        sandbox_mode: %Schema{
+          type: :string,
+          enum: ~w(ephemeral persistent),
+          description:
+            "Where a conversation of this agent runs by default (ADR 0023). ephemeral: a " <>
+              "sandbox per conversation, reclaimed with it. persistent: one sandbox per " <>
+              "agent identity (agent, environment, vault) — the agent's computer — that " <>
+              "every conversation of that identity lands on and shares; it survives a " <>
+              "conversation ending and is parked, not destroyed, at the ceiling. A launch " <>
+              "may name the other with sandbox_mode on POST /api/conversations."
         },
         environment_id: %Schema{type: :string, format: :uuid, nullable: true},
         permission_policy: %Schema{
@@ -800,6 +830,17 @@ defmodule FountainWeb.Schemas do
             "Sandbox backend override; null inherits the instance default " <>
               "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
         },
+        sandbox_mode: %Schema{
+          type: :string,
+          enum: ~w(ephemeral persistent),
+          description:
+            "Where a conversation of this agent runs by default (ADR 0023). ephemeral: a " <>
+              "sandbox per conversation, reclaimed with it. persistent: one sandbox per " <>
+              "agent identity (agent, environment, vault) — the agent's computer — that " <>
+              "every conversation of that identity lands on and shares; it survives a " <>
+              "conversation ending and is parked, not destroyed, at the ceiling. A launch " <>
+              "may name the other with sandbox_mode on POST /api/conversations."
+        },
         permission_policy: %Schema{
           type: :object,
           nullable: true,
@@ -906,6 +947,17 @@ defmodule FountainWeb.Schemas do
           description:
             "Sandbox backend override; null inherits the instance default " <>
               "(SANDBOX_PROVIDER). Only providers configured on this instance are accepted"
+        },
+        sandbox_mode: %Schema{
+          type: :string,
+          enum: ~w(ephemeral persistent),
+          description:
+            "Where a conversation of this agent runs by default (ADR 0023). ephemeral: a " <>
+              "sandbox per conversation, reclaimed with it. persistent: one sandbox per " <>
+              "agent identity (agent, environment, vault) — the agent's computer — that " <>
+              "every conversation of that identity lands on and shares; it survives a " <>
+              "conversation ending and is parked, not destroyed, at the ceiling. A launch " <>
+              "may name the other with sandbox_mode on POST /api/conversations."
         },
         permission_policy: %Schema{
           type: :object,

--- a/apps/fountain/priv/repo/migrations/20260824020000_add_sandbox_mode.exs
+++ b/apps/fountain/priv/repo/migrations/20260824020000_add_sandbox_mode.exs
@@ -1,0 +1,30 @@
+defmodule Fountain.Repo.Migrations.AddSandboxMode do
+  use Ecto.Migration
+
+  # ADR 0023 gate 6. A launch chooses a sandbox mode, defaulted from the
+  # agent: `ephemeral` (a sandbox per conversation, today's model, the
+  # default) or `persistent` (one sandbox per agent identity — the agent's
+  # computer — that every conversation of that identity lands on). Both
+  # columns default to `ephemeral`, so nothing changes for a row that
+  # predates them.
+  #
+  # The partial unique index is what makes a home findable and single: one
+  # live persistent sandbox per (user, agent, environment, vault). NULLS NOT
+  # DISTINCT (Postgres 15+) so an agent with no vault and its own environment
+  # still gets exactly one home rather than one per launch.
+  def change do
+    alter table(:agents) do
+      add :sandbox_mode, :string, null: false, default: "ephemeral"
+    end
+
+    alter table(:sandboxes) do
+      add :mode, :string, null: false, default: "ephemeral"
+    end
+
+    create unique_index(:sandboxes, [:user_id, :agent_id, :environment_id, :vault_id],
+             name: :sandboxes_home_identity_index,
+             where: "mode = 'persistent' AND status NOT IN ('terminated', 'failed')",
+             nulls_distinct: false
+           )
+  end
+end

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -252,6 +252,24 @@ defmodule Fountain.AgentsTest do
       {:ok, _} = Agents.delete_agent(agent)
       assert Agents.list_agent_versions(agent.id, user.id) == []
     end
+
+    test "an agent with a versioned conversation can still be deleted" do
+      # Deleting the agent cascades to its versions, and Postgres re-checked
+      # the conversation's version FK mid-cascade — before its own SET NULL —
+      # so every agent with a conversation stamped by #1049 refused to go.
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      {:ok, agent} = Agents.update_agent(agent, %{"description" => "v2"})
+      version_id = Agents._unsafe_current_version_id(agent.id)
+      conv = insert_conversation(user_id: user.id, agent: agent, agent_version_id: version_id)
+      assert conv.agent_version_id == version_id
+
+      assert {:ok, _} = Agents.delete_agent(agent)
+
+      reloaded = Fountain.Conversations._unsafe_get_conversation!(conv.id)
+      assert is_nil(reloaded.agent_id)
+      assert is_nil(reloaded.agent_version_id)
+    end
   end
 
   describe "_unsafe_get_agent/1 and _unsafe_get_agent!/1" do

--- a/apps/fountain/test/fountain/conversations/conversation_server_shared_sandbox_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_shared_sandbox_test.exs
@@ -166,6 +166,31 @@ defmodule Fountain.Conversations.ConversationServerSharedSandboxTest do
       end)
     end
 
+    test "a home at the ceiling is parked, not destroyed (ADR 0023)" do
+      %{a: a, sandbox: sandbox} = shared_machine("claude")
+      {:ok, _} = Conversations.update_sandbox(sandbox, %{mode: "persistent"})
+      stub_happy_sprite()
+      reject(&Fountain.Sandbox.Sprites.destroy/1)
+      Mimic.stub(Fountain.Sandbox.Sprites, :suspend, fn _h -> :ok end)
+
+      with_bounds([sandbox_idle_timeout_minutes: 0, sandbox_max_lifetime_hours: 24], fn ->
+        {pid, ref} = start(a)
+
+        :sys.replace_state(pid, fn state ->
+          %{state | sandbox_started_at: DateTime.add(DateTime.utc_now(), -25 * 3600, :second)}
+        end)
+
+        send(pid, :lifecycle_check)
+        assert :normal = assert_stopped(ref)
+      end)
+
+      assert Repo.reload(sandbox).status == "suspended"
+
+      assert Enum.any?(sandbox_stages(a.id), fn d ->
+               d["event"] == "suspended" and d["reason"] == "max_lifetime"
+             end)
+    end
+
     test "a co-tenant told the machine is gone records it and stops" do
       %{b: b} = shared_machine("claude")
       stub_happy_sprite()

--- a/apps/fountain/test/fountain/conversations/sandbox_mode_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_mode_test.exs
@@ -1,0 +1,164 @@
+defmodule Fountain.Conversations.SandboxModeTest do
+  # ADR 0023 gate 6: a persistent launch lands on the agent identity's one
+  # home, provisioning it on the first launch and attaching on every later
+  # one; a home outlives a conversation and dies with its agent.
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Agents
+  alias Fountain.Agents.Agent
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Sandbox
+
+  setup do
+    user = insert_active_user()
+    # Several homes get provisioned in one test; the cap is not the subject.
+    {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 10)
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+    agent = agent |> Ecto.Changeset.change(sandbox_mode: "persistent") |> Repo.update!()
+    stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+    {:ok, user: user, env: env, agent: agent}
+  end
+
+  defp launch(ctx, extra \\ %{}) do
+    Conversations.start_conversation(
+      Map.merge(%{"agent_id" => ctx.agent.id, "user_id" => ctx.user.id}, extra)
+    )
+  end
+
+  test "the agent's mode is validated" do
+    user = insert_active_user()
+
+    cs =
+      Agent.changeset(%Agent{}, %{
+        name: "a",
+        model: "anthropic/x",
+        runtime: "claude",
+        user_id: user.id,
+        sandbox_mode: "sometimes"
+      })
+
+    assert %{sandbox_mode: ["is invalid"]} = errors_on(cs)
+    assert Agent.sandbox_modes() == ["ephemeral", "persistent"]
+    assert Sandbox.modes() == ["ephemeral", "persistent"]
+  end
+
+  test "the first persistent launch provisions the home, stamped as one", ctx do
+    assert {:ok, conv} = launch(ctx)
+    home = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+    assert home.mode == "persistent"
+    assert home.agent_id == ctx.agent.id
+    assert home.environment_id == ctx.env.id
+    assert conv.status == "pending"
+  end
+
+  test "a second persistent launch lands on the same home once it is ready", ctx do
+    {:ok, first} = launch(ctx)
+
+    {:ok, _} =
+      Conversations.update_sandbox(Conversations._unsafe_get_sandbox!(first.sandbox_id), %{
+        status: "ready"
+      })
+
+    assert {:ok, second} = launch(ctx)
+    assert second.sandbox_id == first.sandbox_id
+    assert second.status == "idle"
+    assert Conversations._unsafe_list_cotenant_ids(first.sandbox_id, first.id) == [second.id]
+  end
+
+  test "while the home is still provisioning a second launch is told to retry", ctx do
+    {:ok, _first} = launch(ctx)
+    assert {:error, :provisioning} = launch(ctx)
+  end
+
+  test "a different environment or vault is a different home", ctx do
+    {:ok, first} = launch(ctx)
+
+    {:ok, _} =
+      Conversations.update_sandbox(Conversations._unsafe_get_sandbox!(first.sandbox_id), %{
+        status: "ready"
+      })
+
+    other_env = insert_env(user_id: ctx.user.id)
+    assert {:ok, second} = launch(ctx, %{"environment_id" => other_env.id})
+    refute second.sandbox_id == first.sandbox_id
+    assert Conversations._unsafe_get_sandbox!(second.sandbox_id).mode == "persistent"
+
+    vault = insert_vault(user_id: ctx.user.id)
+    assert {:ok, third} = launch(ctx, %{"vault_id" => vault.id})
+    refute third.sandbox_id in [first.sandbox_id, second.sandbox_id]
+  end
+
+  test "a launch may ask for the other mode, and an unknown one is refused", ctx do
+    assert {:ok, conv} = launch(ctx, %{"sandbox_mode" => "ephemeral"})
+    assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).mode == "ephemeral"
+    # An ephemeral launch is never a home, so the next persistent one builds one.
+    assert {:ok, other} = launch(ctx)
+    refute other.sandbox_id == conv.sandbox_id
+
+    assert {:error, :invalid_sandbox_mode} = launch(ctx, %{"sandbox_mode" => "sometimes"})
+  end
+
+  test "the home is single per identity even when two launches race", ctx do
+    # Simulate the loser of the race: a home already exists but this launch
+    # did not see it and tries to insert its own. The unique index refuses,
+    # and the launch lands on the existing home instead.
+    {:ok, first} = launch(ctx)
+    home = Conversations._unsafe_get_sandbox!(first.sandbox_id)
+    {:ok, _} = Conversations.update_sandbox(home, %{status: "ready"})
+
+    assert {:error, changeset} =
+             Conversations.create_sandbox(%{
+               user_id: ctx.user.id,
+               agent_id: ctx.agent.id,
+               environment_id: ctx.env.id,
+               vault_id: nil,
+               mode: "persistent",
+               sprite_name: "dup",
+               status: "pending",
+               provider: "sprites"
+             })
+
+    assert %{home: [_]} = errors_on(changeset)
+  end
+
+  test "terminating a conversation keeps the home", ctx do
+    {:ok, conv} = launch(ctx)
+    assert Conversations._unsafe_sandbox_kept_on_terminate?(conv.sandbox_id, conv.id)
+
+    ephemeral = insert_sandbox(user_id: ctx.user.id, status: "ready", mode: "ephemeral")
+    alone = insert_conversation(user_id: ctx.user.id, agent: ctx.agent, sandbox: ephemeral)
+    refute Conversations._unsafe_sandbox_kept_on_terminate?(ephemeral.id, alone.id)
+  end
+
+  test "a wake onto a fresh sandbox keeps the home a home", ctx do
+    {:ok, conv} = launch(ctx)
+    old = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+    {:ok, _} = Conversations.update_sandbox(old, %{status: "ready"})
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+
+    stub(Fountain.Sandbox.Sprites, :get, fn _handle -> {:error, :not_found} end)
+
+    assert {:ok, woken} = Conversations.wake_conversation(conv.id)
+    refute woken.sandbox_id == old.id
+    assert Conversations._unsafe_get_sandbox!(woken.sandbox_id).mode == "persistent"
+    assert Repo.reload(old).status == "terminated"
+    # And the new one is the home now.
+    assert %{id: id} = Conversations._unsafe_find_home(ctx.user.id, ctx.agent.id, ctx.env.id, nil)
+    assert id == woken.sandbox_id
+  end
+
+  test "deleting the agent destroys its homes", ctx do
+    {:ok, conv} = launch(ctx)
+    home = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+    {:ok, _} = Conversations.update_sandbox(home, %{status: "ready"})
+    test = self()
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> send(test, :destroyed) && :ok end)
+
+    assert {:ok, _} = Agents.delete_agent(ctx.agent)
+    assert_received :destroyed
+    assert Repo.reload(home).status == "terminated"
+    assert Conversations._unsafe_get_conversation!(conv.id).status == "terminated"
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/conversation_attach_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_attach_controller_test.exs
@@ -79,6 +79,41 @@ defmodule FountainWeb.ConversationAttachControllerTest do
              |> json_response(422)
   end
 
+  test "sandbox_mode=persistent lands every launch of an identity on one home", ctx do
+    stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+    first =
+      ctx
+      |> create(%{"sandbox_mode" => "persistent"})
+      |> json_response(201)
+      |> Map.fetch!("data")
+
+    assert first["sandbox"]["mode"] == "persistent"
+
+    # Still provisioning: a second launch is told to retry, not given a
+    # second machine.
+    assert %{"error" => "provisioning"} =
+             ctx |> create(%{"sandbox_mode" => "persistent"}) |> json_response(503)
+
+    {:ok, _} =
+      Fountain.Conversations.update_sandbox(
+        Fountain.Conversations._unsafe_get_sandbox!(first["sandbox_id"]),
+        %{status: "ready"}
+      )
+
+    second =
+      ctx
+      |> create(%{"sandbox_mode" => "persistent"})
+      |> json_response(201)
+      |> Map.fetch!("data")
+
+    assert second["sandbox_id"] == first["sandbox_id"]
+    assert second["status"] == "idle"
+
+    # Refused at the door — the spec's enum, before the context sees it.
+    assert ctx |> create(%{"sandbox_mode" => "sometimes"}) |> json_response(422)
+  end
+
   test "a one-at-a-time runtime at capacity is a 409 when a prompt comes with it", ctx do
     agent = ctx.agent |> Ecto.Changeset.change(runtime: "opencode") |> Fountain.Repo.update!()
     {:ok, _} = Fountain.Conversations.update_conversation(ctx.first, %{runtime: "opencode"})

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -98,6 +98,14 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.ManifestResource, "kind"} => {Manifest, :kinds},
     {FountainWeb.Schemas.OnboardingResponse, "data.state"} => {Accounts, :onboarding_states},
     {FountainWeb.Schemas.Sandbox, "status"} => {Sandbox, :statuses},
+    # The sandbox mode (ADR 0023 gate 6): on the agent as a default, on a
+    # launch as the choice, on the sandbox row as what it is.
+    {FountainWeb.Schemas.Sandbox, "mode"} => {Sandbox, :modes},
+    {FountainWeb.Schemas.SandboxDetail, "mode"} => {Sandbox, :modes},
+    {FountainWeb.Schemas.ConversationCreateRequest, "sandbox_mode"} => {Sandbox, :modes},
+    {FountainWeb.Schemas.Agent, "sandbox_mode"} => {Agent, :sandbox_modes},
+    {FountainWeb.Schemas.AgentRequest, "sandbox_mode"} => {Agent, :sandbox_modes},
+    {FountainWeb.Schemas.AgentUpdate, "sandbox_mode"} => {Agent, :sandbox_modes},
     # The sandbox listing (ADR 0023 gate 3): a sandbox with its conversations.
     {FountainWeb.Schemas.SandboxDetail, "status"} => {Sandbox, :statuses},
     {FountainWeb.Schemas.SandboxDetail, "provider"} => {Fountain.Sandbox, :known_providers},

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -85,6 +85,7 @@ func init() {
 	runCmd.Flags().String("vault", "", "vault name or id")
 	runCmd.Flags().String("environment", "", "environment name or id to provision from, instead of the agent's own")
 	runCmd.Flags().String("sandbox", "", "sandbox id to attach to, instead of provisioning a new one")
+	runCmd.Flags().String("sandbox-mode", "", "ephemeral or persistent, instead of the agent's default")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -282,6 +283,9 @@ func runAgent(cmd *cobra.Command, target string) error {
 	// Sandboxes have ids only, no names: nothing to resolve.
 	if sandbox, _ := cmd.Flags().GetString("sandbox"); sandbox != "" {
 		body["sandbox_id"] = sandbox
+	}
+	if mode, _ := cmd.Flags().GetString("sandbox-mode"); mode != "" {
+		body["sandbox_mode"] = mode
 	}
 
 	c := activeClient()

--- a/docs/api.md
+++ b/docs/api.md
@@ -236,6 +236,13 @@ checks the media type again at serve time.
 An agent object carries `conversation_count`. An environment carries
 `secret_count` and `agent_count`. A vault carries `secret_count`.
 
+An agent carries `sandbox_mode`, which is `ephemeral` or `persistent`. With
+`ephemeral`, each conversation gets a sandbox of its own. With `persistent`,
+the agent has one machine, and each conversation with the same environment
+and vault lands on it. That machine survives a conversation that ends, and
+Fountain parks it at the ceiling instead of a destroy. A launch can name the
+other mode with `sandbox_mode` on `POST /api/conversations`.
+
 They are on the list read and on the single-resource read. So "does this
 environment have a user, and is it safe to delete" is one request.
 
@@ -336,7 +343,7 @@ it again and again.
 
 ```
 GET    /api/conversations                  # list (?roots_only=true; ?agent_id= ?channel_id= ?status=idle,terminated)
-POST   /api/conversations                  # start (agent_id; optional vault_id, environment_id, sandbox_id, prompt, images)
+POST   /api/conversations                  # start (agent_id; optional vault_id, environment_id, sandbox_id, sandbox_mode, prompt, images)
 GET    /api/conversations/:id
 DELETE /api/conversations/:id
 POST   /api/conversations/:id/read         # clear unread state
@@ -362,6 +369,12 @@ Otherwise you get `404 sandbox_not_found`, `409 sandbox_not_attachable` or
 disk at the same time. On an opencode or gemini sandbox, only one turn runs
 at a time. A second prompt gets `409 sandbox_at_capacity` while the first
 one runs.
+
+`sandbox_mode` is `ephemeral` or `persistent`, and it replaces the agent's
+default for this conversation. A persistent conversation lands on the agent's
+own machine. Fountain makes that machine on the first persistent launch of an
+agent, environment and vault. A second launch while the first still builds
+it gets `503 provisioning`, so send again shortly.
 
 Whatever does not resolve is a `404`, so nobody can probe for an id.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -149,6 +149,10 @@ The `--sandbox` flag attaches the conversation to a sandbox you already have,
 by id. Two conversations then share one disk. A conversation's `sandbox_id`
 names its sandbox.
 
+The `--sandbox-mode` flag is `ephemeral` or `persistent`. It replaces the
+agent's default for this conversation. A persistent conversation lands on the
+agent's own machine, and Fountain makes that machine on the first launch.
+
 ### Long-running turns
 
 The server closes an idle SSE connection after 60 seconds. So a turn that

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -301,10 +301,11 @@ fountain run <agent-name-or-id> [flags]
 Options:
 
 ```
-      --environment string   environment name or id to provision from, instead of the agent's own
-  -p, --prompt string        prompt text (required)
-      --sandbox string       sandbox id to attach to, instead of provisioning a new one
-      --vault string         vault name or id
+      --environment string    environment name or id to provision from, instead of the agent's own
+  -p, --prompt string         prompt text (required)
+      --sandbox string        sandbox id to attach to, instead of provisioning a new one
+      --sandbox-mode string   ephemeral or persistent, instead of the agent's default
+      --vault string          vault name or id
 ```
 
 ## `fountain runner`

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -8,30 +8,50 @@ configure one, read [Self-host Fountain](../self-hosting.md).
 
 ## What a sandbox is
 
-A sandbox is the isolated machine that one [conversation](conversation.md)
-runs in.
+A sandbox is the isolated machine that a [conversation](conversation.md)
+runs in. Several conversations can run on one sandbox at the same time, each
+with its own transcript.
 
-It is not a primitive. You never create, name or address one. Fountain
-provisions it when a conversation starts. Fountain reclaims it when the
-conversation goes quiet, or when it runs too long.
+You never create one on its own. Fountain provisions a sandbox when a
+conversation starts. Fountain reclaims it when every conversation on it goes
+quiet, or when it runs too long. You can name one, with `sandbox_id`, to put
+a second conversation on it.
 
 That is deliberate. A sandbox you could create on its own would be a resource
 you could leak. The machine that nobody remembered to stop is what makes agent
 infrastructure expensive.
 
-## Why the lifecycle belongs to the conversation
+## Two modes
 
-Tie the machine to the run, and three problems solve themselves.
+An agent chooses a default, and a launch can name the other.
 
-Reclamation gets an owner. An idle conversation means an idle machine, and no
-separate record can go wrong.
+With `ephemeral`, the default, each conversation gets a sandbox of its own.
+When the conversation ends, the sandbox ends. This is the mode for a
+one-shot task, for a fan-out, and for input you do not trust.
+
+With `persistent`, the agent has one machine of its own. Each conversation
+with the same environment and vault lands on it. Notes, clones and installed
+tools accrue across conversations. So does anything a bad turn leaves
+behind, because the disk is shared. The machine survives a conversation that
+ends. Fountain parks it at the ceiling instead of a destroy. When you delete
+the agent, Fountain destroys the machine.
+
+## Why the lifecycle belongs to the conversations on it
+
+Tie the machine to the runs on it, and three problems solve themselves.
+
+Reclamation gets an owner. When every conversation on a machine is idle, the
+machine is idle, and no separate record can go wrong.
 
 Cost gets a shape that a user recognises. "This conversation cost something"
-reads clearly, and "you have 14 sandboxes" does not.
+reads clearly, and "you have 14 sandboxes" does not. Two conversations that
+each run for an hour on one machine spend two turn hours, on a machine that
+was busy for one.
 
 Memory gets somewhere to live. The runtime keeps its session on the sandbox's
 disk. To suspend and wake the machine is therefore the same act as to pause
-and resume the conversation. Read [About conversations](conversation.md).
+and resume the conversations on it. Read
+[About conversations](conversation.md).
 
 ## One seam, four backends
 

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -31,9 +31,9 @@ one-shot task, for a fan-out, and for input you do not trust.
 
 With `persistent`, the agent has one machine of its own. Each conversation
 with the same environment and vault lands on it. Notes, clones and installed
-tools accrue across conversations. So does anything a bad turn leaves
-behind, because the disk is shared. The machine survives a conversation that
-ends. Fountain parks it at the ceiling instead of a destroy. When you delete
+tools accrue across conversations. What a bad turn leaves behind also
+accrues, because all of them use the one disk. The machine survives a
+conversation that ends. Fountain parks it at the ceiling instead of a destroy. When you delete
 the agent, Fountain destroys the machine.
 
 ## Why the lifecycle belongs to the conversations on it

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -182,6 +182,7 @@ Here are the fields that need a word.
 | `system` | The agent's system prompt. |
 | `skills` | Either `{ source, ref? }`, which installs from GitHub, or `{ name, content }`, which Fountain writes into the sandbox word for word. Each entry takes exactly one shape. |
 | `sandbox_provider` | `sprites`, `e2b`, `daytona` or `runner`. A `null` takes the instance default. |
+| `sandbox_mode` | `ephemeral` (default) or `persistent`. Persistent gives the agent one machine of its own, and each conversation lands on it. |
 | `allowed_vault_ids` | Which vaults a conversation can attach. A `null` permits each one, `[]` permits none, and a list is an allowlist. A vault value overrides the environment, so this is what scopes who can override a config that somebody reviewed. |
 | `allowed_environment_ids` | The same shape. It covers a launch of the agent under a different environment. |
 

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,17 @@ server releases.
 
 ---
 
+## [0.1.7] — 2026-08-24
+
+### Added
+
+- `run({ sandboxMode })` — `"ephemeral"` or `"persistent"`, replacing the
+  agent's default for that conversation. A persistent conversation lands on
+  the agent's own machine, which Fountain makes on the first such launch;
+  while that first launch is still building it, a second one gets
+  `provisioning` (retryable). Agents carry `sandbox_mode` and sandboxes carry
+  `mode`, both generated from the server's spec (ADR 0023).
+
 ## [0.1.6] — 2026-08-24
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -53,6 +53,12 @@ export interface RunConfig extends RunOptions {
    * environment and vault; several conversations then share one disk.
    */
   sandbox?: string;
+  /**
+   * `"ephemeral"` (a sandbox for this conversation alone) or `"persistent"`
+   * (the agent's own machine, shared by every conversation of that agent,
+   * environment and vault). Defaults to the agent's `sandbox_mode`.
+   */
+  sandboxMode?: "ephemeral" | "persistent";
 }
 
 /**
@@ -133,6 +139,7 @@ export class Fountain {
           if (config.fresh) body.fresh = true;
           if (config.spriteName) body.sprite_name = config.spriteName;
           if (config.sandbox) body.sandbox_id = config.sandbox;
+          if (config.sandboxMode) body.sandbox_mode = config.sandboxMode;
 
           const conversation = await this.api.data<ConversationRecord>(
             "POST",

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2061,6 +2061,11 @@ export interface components {
              * @description Attach the conversation to a sandbox you already have instead of provisioning one (ADR 0023). The sandbox must be yours (404 sandbox_not_found), ready or suspended (409 sandbox_not_attachable), and built for the same agent, environment and vault as this launch (422 sandbox_identity_mismatch; 422 sandbox_runtime_mismatch if the agent's runtime changed since). The conversation opens idle on that machine; a prompt here wakes it. Several conversations then run on one disk at once, except on opencode and gemini, where a second turn is refused with 409 sandbox_at_capacity while one runs.
              */
             sandbox_id?: string | null;
+            /**
+             * @description Where this conversation runs (ADR 0023); null takes the agent's sandbox_mode. persistent lands on the agent identity's home — provisioning it if this is the first launch of that (agent, environment, vault), attaching to it otherwise, or 503 provisioning while the first launch is still building it. ephemeral provisions a sandbox for this conversation alone. Ignored when sandbox_id names a machine.
+             * @enum {string|null}
+             */
+            sandbox_mode?: "ephemeral" | "persistent" | null;
             /** @description Override the auto-generated sprite name. */
             sprite_name?: string;
             /** @description Optional display title. The team page names a teammate with it. */
@@ -2302,6 +2307,11 @@ export interface components {
             /** Format: date-time */
             last_resumed_at?: string | null;
             /**
+             * @description ephemeral: one conversation's machine, reclaimed with it. persistent: the agent identity's home, shared by its conversations and kept when one ends.
+             * @enum {string}
+             */
+            mode?: "ephemeral" | "persistent";
+            /**
              * @description The sandbox backend this row lives on.
              * @enum {string}
              */
@@ -2388,6 +2398,11 @@ export interface components {
             environment_id?: string | null;
             /** Format: uuid */
             id: string;
+            /**
+             * @description ephemeral: one conversation's machine, reclaimed with it. persistent: the agent identity's home, shared by its conversations and kept when one ends.
+             * @enum {string}
+             */
+            mode?: "ephemeral" | "persistent";
             /**
              * @description The sandbox backend this row lives on.
              * @enum {string}
@@ -2772,6 +2787,11 @@ export interface components {
             } | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode";
+            /**
+             * @description Where a conversation of this agent runs by default (ADR 0023). ephemeral: a sandbox per conversation, reclaimed with it. persistent: one sandbox per agent identity (agent, environment, vault) — the agent's computer — that every conversation of that identity lands on and shares; it survives a conversation ending and is parked, not destroyed, at the ceiling. A launch may name the other with sandbox_mode on POST /api/conversations.
+             * @enum {string}
+             */
+            sandbox_mode?: "ephemeral" | "persistent";
             /**
              * @description Sandbox backend override; null inherits the instance default (SANDBOX_PROVIDER). Only providers configured on this instance are accepted
              * @enum {string|null}
@@ -3215,6 +3235,11 @@ export interface components {
             /** @enum {string} */
             runtime?: "claude" | "codex" | "gemini" | "opencode";
             /**
+             * @description Where a conversation of this agent runs by default (ADR 0023). ephemeral: a sandbox per conversation, reclaimed with it. persistent: one sandbox per agent identity (agent, environment, vault) — the agent's computer — that every conversation of that identity lands on and shares; it survives a conversation ending and is parked, not destroyed, at the ceiling. A launch may name the other with sandbox_mode on POST /api/conversations.
+             * @enum {string}
+             */
+            sandbox_mode?: "ephemeral" | "persistent";
+            /**
              * @description Sandbox backend override; null inherits the instance default (SANDBOX_PROVIDER). Only providers configured on this instance are accepted
              * @enum {string|null}
              */
@@ -3460,6 +3485,11 @@ export interface components {
             } | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode";
+            /**
+             * @description Where a conversation of this agent runs by default (ADR 0023). ephemeral: a sandbox per conversation, reclaimed with it. persistent: one sandbox per agent identity (agent, environment, vault) — the agent's computer — that every conversation of that identity lands on and shares; it survives a conversation ending and is parked, not destroyed, at the ceiling. A launch may name the other with sandbox_mode on POST /api/conversations.
+             * @enum {string}
+             */
+            sandbox_mode?: "ephemeral" | "persistent";
             /**
              * @description Sandbox backend override; null inherits the instance default (SANDBOX_PROVIDER). Only providers configured on this instance are accepted
              * @enum {string|null}

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.6";
+export const USER_AGENT = "fountain-sdk-js/0.1.7";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
ADR 0023 **gate 6**: the mode itself. An agent's `sandbox_mode` is `ephemeral` (a sandbox per conversation — the default, today's behaviour) or `persistent`: one machine per agent identity `(agent, environment, vault)` that every conversation of that identity lands on and shares, provisioned on the first launch and attached to on every later one. A launch may name the other mode. Builds on #1064 (attach) and #1061 (the shared-machine rules).

## Schema

- `agents.sandbox_mode`, `sandboxes.mode` — both `NOT NULL DEFAULT 'ephemeral'`, so nothing changes for existing rows.
- A partial unique index `sandboxes_home_identity_index` on `(user_id, agent_id, environment_id, vault_id) WHERE mode = 'persistent' AND status NOT IN ('terminated','failed')`, **NULLS NOT DISTINCT** (Postgres 15+; CI and prod are 16), so an agent with no vault still has exactly one home.

## The launch

`start_conversation/2` resolves the mode (launch attr, else the agent's; `422 invalid_sandbox_mode`) and, for `persistent`:

| home state | what happens |
|---|---|
| none | provision a sandbox stamped `mode: persistent` (the ordinary fresh path) |
| `ready` / `suspended` | attach through the gate-3 path — idle conversation, prompt via the wake path |
| `pending` / `starting` | `503 provisioning` — a second conversation's prompt must not be handed to the first launch's server |
| lost the creation race | the unique index refuses (surfaced as `:home` on the changeset) and the launch lands on the winner |

## The lifecycle split (ADR step 5)

- **terminate** keeps a home (`_unsafe_sandbox_kept_on_terminate?/2`, both terminate paths — it wraps the co-tenant guard #1061 added).
- **ceiling** parks a home instead of destroying it, where the provider can park (`Lifecycle.explain(:max_lifetime, :suspend)`); the ceiling itself is slated to go, this is the interim the ADR names.
- **wake onto a fresh sandbox** keeps the mode, and retires the old home *first* so the new one satisfies the index; #1067 then moves the co-tenants.
- **deleting the agent** destroys its homes (`_unsafe_destroy_homes_for_agent/1`): live conversations terminated, sprite destroyed, row terminated.

## Every door

`sandbox_mode` on `POST /api/conversations`; `fountain run --sandbox-mode` (+ regenerated reference); the SDK's `run({ sandboxMode })` — **SDK 0.1.7**; the agent form (a select with the trade-off spelled out); `Agent`/`AgentRequest`/`AgentUpdate`/`Sandbox`/`ConversationCreateRequest` schemas + enum-guardrail rows; agent versions snapshot the field; docs (`api.md`, `sdk.md`, `cli.md`, and `concepts/sandboxes.md` rewritten for shared machines); CHANGELOG. Team and Buzz launches take the agent's default through the ordinary path.

## A bug found on the way (fixed here, separately noted in the changelog)

**Deleting an agent that had a versioned conversation failed.** Reproduced in raw SQL: the delete cascades to `agent_versions`, and Postgres re-checks `conversations.agent_version_id` while it is still setting `conversations.agent_id` to NULL in the same statement — before its own SET NULL for the version has run — so every agent with a conversation started since #1049 refused to delete with `conversations_agent_version_id_fkey`. `Agents.delete_agent/2` now unpins the agent's conversations from their versions in a transaction, then deletes. Test added in `agents_test.exs`. Worth checking whether prod has seen a 500 on `DELETE /api/agents/:id` since 2026-08-23.

## Gate

- `mix precommit` at the root: **4,048 tests, 0 failures**; format clean (root; long lines wrapped for 1.19.2).
- `go test/vet`, gofmt, generated CLI reference; SDK typecheck + tests + release guard (0.1.7); `vale lint`, `docs-style.py`.
- New: `sandbox_mode_test.exs` (10 — first launch provisions, second attaches, provisioning → retry, env/vault → different homes, per-launch override + invalid, the race at the index, terminate keeps, wake keeps the mode, agent delete destroys), a controller test through the door, a server test for the ceiling parking a home, the agent-delete regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
