### PR TITLE
feat(sandbox): a running sandbox is no longer destroyed at 24 hours (#936)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,10 +68,11 @@ SPRITES_TOKEN=
 # DAYTONA_API_URL=https://app.daytona.io/api
 # DAYTONA_SNAPSHOT=fountain
 
-# Sandbox lifetime bounds: reclaim after this long idle, and an absolute age
-# ceiling. 0 disables a bound; the conversation always stays resumable.
+# Sandbox lifetime bounds: park after this long idle, and an optional ceiling
+# on one continuous run (off by default, #936). 0 disables a bound; the
+# conversation always stays resumable.
 # SANDBOX_IDLE_TIMEOUT_MINUTES=60
-# SANDBOX_MAX_LIFETIME_HOURS=24
+# SANDBOX_MAX_LIFETIME_HOURS=0
 
 # Durable log volume per conversation (#331): once this much sandbox output
 # is persisted, a truncation marker is written and further output dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ upgrade, is in
 
 ### Changed
 
+- **A running sandbox is no longer destroyed at 24 hours.** The continuous-run
+  ceiling (`SANDBOX_MAX_LIFETIME_HOURS`, ADR 0017) now defaults to `0`, off,
+  for every sandbox mode: a tenant who wants a machine running all day is not
+  something to stop, and for a persistent home the disk is the product. The
+  idle timeout (`SANDBOX_IDLE_TIMEOUT_MINUTES`, still 60) is the only
+  automatic stop, and it parks rather than destroys; the plan's
+  concurrent-sandbox cap bounds how many machines stay up. An operator who
+  wants the old backstop sets the variable, and then an ephemeral sandbox is
+  destroyed at the ceiling and a home is parked, exactly as before. #936.
+
 - **Turn hours add up per turn.** With several conversations on one sandbox
   at once, a tenant's turn hours are the sum of their turns (two
   conversations each running an hour on one machine spend two), while the

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -15,9 +15,13 @@ defmodule Fountain.Conversations.Lifecycle do
 
   * **Max lifetime** — a ceiling on a *continuous run*, measured from the
     sandbox's creation or its last wake from `suspended`
-    (`last_resumed_at || inserted_at`). Crossing it **destroys** the sprite.
-    It catches the case the idle bound cannot: a conversation that keeps
-    itself busy forever, burning compute unattended.
+    (`last_resumed_at || inserted_at`). Crossing it **destroys** an ephemeral
+    sprite and **parks** a persistent home (ADR 0023). **Off by default since
+    #936**: a tenant who wants a machine running 24/7 is not something to
+    stop, so nothing automatic stops a sandbox that keeps itself busy — the
+    idle timeout parks it once it stops, and the concurrent-sandbox cap
+    bounds how many can be up. An operator who wants the old backstop sets
+    `SANDBOX_MAX_LIFETIME_HOURS`.
 
   ## Why the split
 
@@ -43,7 +47,7 @@ defmodule Fountain.Conversations.Lifecycle do
   """
 
   @default_idle_minutes 60
-  @default_max_lifetime_hours 24
+  @default_max_lifetime_hours 0
 
   @doc "Idle timeout in seconds, or `nil` when disabled."
   @spec idle_timeout_seconds() :: pos_integer() | nil

--- a/apps/fountain/test/fountain/compose_passthrough_config_test.exs
+++ b/apps/fountain/test/fountain/compose_passthrough_config_test.exs
@@ -140,7 +140,7 @@ defmodule Fountain.ComposePassthroughConfigTest do
         |> read_prod()
 
       assert cfg[:fountain][:sandbox_idle_timeout_minutes] == 60
-      assert cfg[:fountain][:sandbox_max_lifetime_hours] == 24
+      assert cfg[:fountain][:sandbox_max_lifetime_hours] == 0
     end
 
     test "a real value is parsed", %{base: base} do

--- a/apps/fountain/test/fountain/conversations/lifecycle_test.exs
+++ b/apps/fountain/test/fountain/conversations/lifecycle_test.exs
@@ -26,13 +26,13 @@ defmodule Fountain.Conversations.LifecycleTest do
   defp ago(seconds), do: DateTime.add(DateTime.utc_now(), -seconds, :second)
 
   describe "configuration" do
-    test "defaults are an hour idle and a day absolute" do
+    test "defaults are an hour idle and no ceiling (#936)" do
       with_config([sandbox_idle_timeout_minutes: nil, sandbox_max_lifetime_hours: nil], fn ->
         Application.delete_env(:fountain, :sandbox_idle_timeout_minutes)
         Application.delete_env(:fountain, :sandbox_max_lifetime_hours)
 
         assert Lifecycle.idle_timeout_seconds() == 3600
-        assert Lifecycle.max_lifetime_seconds() == 86_400
+        assert Lifecycle.max_lifetime_seconds() == nil
       end)
     end
 
@@ -91,6 +91,16 @@ defmodule Fountain.Conversations.LifecycleTest do
     test "max lifetime is reported in preference to idle" do
       with_config([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
         assert {:expired, :max_lifetime} = Lifecycle.check(ago(90_000), ago(90_000), false)
+      end)
+    end
+
+    test "the default config never reaches the ceiling, however long the run (#936)" do
+      with_config([sandbox_idle_timeout_minutes: nil, sandbox_max_lifetime_hours: nil], fn ->
+        Application.delete_env(:fountain, :sandbox_idle_timeout_minutes)
+        Application.delete_env(:fountain, :sandbox_max_lifetime_hours)
+        # Ten days busy: still fine. Ten days idle: the idle bound, never the ceiling.
+        assert :ok = Lifecycle.check(ago(864_000), DateTime.utc_now(), true)
+        assert {:expired, :idle} = Lifecycle.check(ago(864_000), ago(864_000), false)
       end)
     end
 

--- a/apps/fountain/test/fountain/sandbox_bounds_config_test.exs
+++ b/apps/fountain/test/fountain/sandbox_bounds_config_test.exs
@@ -42,11 +42,11 @@ defmodule Fountain.SandboxBoundsConfigTest do
     Config.Reader.read!(@runtime_exs, env: :prod)[:fountain]
   end
 
-  test "defaults are an hour idle and a day absolute", %{base: base} do
+  test "defaults are an hour idle and no ceiling (#936)", %{base: base} do
     config = read_prod(base)
 
     assert config[:sandbox_idle_timeout_minutes] == 60
-    assert config[:sandbox_max_lifetime_hours] == 24
+    assert config[:sandbox_max_lifetime_hours] == 0
   end
 
   test "values are read from the environment", %{base: base} do

--- a/config/config.exs
+++ b/config/config.exs
@@ -61,13 +61,15 @@ config :fountain,
 
 # Sandbox lifetime bounds. Crossing the idle bound SUSPENDS the sandbox — the
 # sprite stays (scaled to zero) and the next prompt resumes the agent with its
-# memory intact, so this bound is free to be aggressive. Crossing the
-# max-lifetime ceiling DESTROYS the sprite, and the agent's session with it
-# (#649) — it exists to bound runaway busy compute. Set either to 0 to
-# disable. See Fountain.Conversations.Lifecycle and decisions/0017.
+# memory intact, so this bound is free to be aggressive. The max-lifetime
+# ceiling is OFF by default (#936): a tenant who wants a machine running
+# 24/7 is not something to stop. Set it to bound a continuous run; crossing
+# it parks a persistent home and destroys an ephemeral sprite, and the
+# agent's session with it (#649). 0 disables either bound. See
+# Fountain.Conversations.Lifecycle and decisions/0017.
 config :fountain,
   sandbox_idle_timeout_minutes: 60,
-  sandbox_max_lifetime_hours: 24
+  sandbox_max_lifetime_hours: 0
 
 config :fountain,
   ecto_repos: [Fountain.Repo],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -483,7 +483,7 @@ end
 
 config :fountain,
   sandbox_idle_timeout_minutes: parse_bound.("SANDBOX_IDLE_TIMEOUT_MINUTES", "60"),
-  sandbox_max_lifetime_hours: parse_bound.("SANDBOX_MAX_LIFETIME_HOURS", "24")
+  sandbox_max_lifetime_hours: parse_bound.("SANDBOX_MAX_LIFETIME_HOURS", "0")
 
 # Webhooks (#700). On by default; a deployment with no outbound HTTP egress
 # can switch dispatch off entirely. WEBHOOK_ALLOW_HTTP relaxes the https-only

--- a/decisions/0017-suspend-idle-sandboxes.md
+++ b/decisions/0017-suspend-idle-sandboxes.md
@@ -16,6 +16,15 @@ verified: { by: human:jhgaylor, at: 2026-08-13T19:28:44-04:00 }
 **Status:** Accepted (built in the PR that added this document)
 **Date:** 2026-08-13
 
+**Amended 2026-08-24 (#936):** the max-lifetime ceiling this ADR keeps as the
+one destroying bound is now **off by default** (`SANDBOX_MAX_LIFETIME_HOURS`
+defaults to `0`). Decided 2026-08-23 with ADR 0023: a tenant who wants a
+machine running 24/7 is not something to stop, and a persistent home's disk
+is the product. The idle timeout is the only automatic stop; the
+concurrent-sandbox cap (0026) bounds how many machines a tenant can keep up.
+An operator who wants the backstop sets the variable, and then the text below
+applies as written (ephemeral: destroy; persistent home: park, per 0023).
+
 ## Context
 
 Since #233, both lifetime bounds destroyed the sprite: the ConversationServer

--- a/decisions/0023-persistent-agent-sandbox.md
+++ b/decisions/0023-persistent-agent-sandbox.md
@@ -78,9 +78,10 @@ Shipped as seven gates, one PR each, in dependency order:
   move into one owner.
 - At capacity a turn is refused (`sandbox_at_capacity`); the `queued` stage
   of the original step 4 was dropped with the lease and is not built.
-- The continuous-run ceiling (0017) still exists. A home at the ceiling is
-  parked, not destroyed (`Lifecycle`), which is the interim behaviour the
-  table names; removing the ceiling for every mode is its own change.
+- The continuous-run ceiling (0017) is **off by default** since #936's
+  fix (the PR after #1069). An operator who sets `SANDBOX_MAX_LIFETIME_HOURS`
+  gets the table's interim behaviour: a home at the ceiling is parked, not
+  destroyed (`Lifecycle`); an ephemeral sprite is destroyed.
 - Of the step 8 doors, `POST /api/conversations`, `fountain run`, the SDK
   and the agent form take the override. The ACP editor door
   (`session/new` `_meta`), Buzz provision and the `fountain` skill's fan-out
@@ -428,10 +429,10 @@ to show something a conversation-centric view cannot.
 
 - **Concurrency.** Parallel turns on one machine, per runtime capacity
   (step 4). Serialized-per-home was not what the target user wanted.
-- **Ceiling.** The 24 h continuous-run ceiling is going away for every mode,
-  in its own change — a tenant who wants a machine up 24/7 is not stopped.
-  Not this ADR's work. Interim: a home at the ceiling is suspended, never
-  destroyed (step 5).
+- **Ceiling.** The 24 h continuous-run ceiling went away for every mode in
+  its own change (#936) — a tenant who wants a machine up 24/7 is not
+  stopped. The knob stays for operators; when set, a home at the ceiling is
+  suspended, never destroyed (step 5).
 - **Identity key.** `(user_id, agent_id, environment_id, vault_id)` stays.
   The disk is materialized from the environment and vault at provision —
   env vars, packages, cloned repos, setup scripts — so a machine built from

--- a/docs/api.md
+++ b/docs/api.md
@@ -240,7 +240,7 @@ An agent carries `sandbox_mode`, which is `ephemeral` or `persistent`. With
 `ephemeral`, each conversation gets a sandbox of its own. With `persistent`,
 the agent has one machine, and each conversation with the same environment
 and vault lands on it. That machine survives a conversation that ends, and
-Fountain parks it at the ceiling instead of a destroy. A launch can name the
+nothing stops it while it runs. A launch can name the
 other mode with `sandbox_mode` on `POST /api/conversations`.
 
 They are on the list read and on the single-resource read. So "does this

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,10 +167,11 @@ a state of `started`, `done`, `failed` or `interrupted`.
     stays and scales itself to zero, and the sandbox parks in `suspended`. The
     next prompt wakes it with everything intact.
 
-    To cross the **max lifetime** *destroys* the sprite, and marks the sandbox
-    `terminated`. The conversation goes back to `idle`, and it is resumable at
-    the #649 price. The hourly reaper applies the same split to whatever a
-    crashed server left behind.
+    The **max lifetime** is off by default. When an operator sets it, to
+    cross it *destroys* an ephemeral sprite and marks the sandbox
+    `terminated`, or *parks* a persistent home. The conversation goes back to
+    `idle`, and it is resumable at the #649 price. The hourly reaper applies
+    the same split to whatever a crashed server left behind.
 7. **`terminate`.** An explicit `POST .../terminate` destroys the sprite and
    marks the conversation `terminated`. That is one of the two terminal
    states, next to `failed`.

--- a/docs/build/pieces.md
+++ b/docs/build/pieces.md
@@ -113,13 +113,14 @@ states around its lifecycle.
 A suspend is free and invisible. The disk survives, which keeps the runtime's
 session alive. So message five never explains messages one to four again.
 
-The ceiling costs you that. A sandbox that the max-lifetime bound destroys
-loses its disk. The stored transcript is intact and the conversation still
-resumes, and the agent's own memory of it has gone.
+A destroy costs you that. A sandbox that a terminate, or a configured
+max-lifetime bound, destroys loses its disk. The stored transcript is intact
+and the conversation still resumes, and the agent's own memory of it has gone.
 
 You can configure both bounds, with `SANDBOX_IDLE_TIMEOUT_MINUTES` and
-`SANDBOX_MAX_LIFETIME_HOURS`. `freshConversation()` is the deliberate version
-of the same thing. It gives you a new session on the *same* disk.
+`SANDBOX_MAX_LIFETIME_HOURS`. The ceiling is off by default.
+`freshConversation()` is the deliberate version of the same thing. It gives
+you a new session on the *same* disk.
 
 ## Who reads what
 

--- a/docs/concepts/conversation.md
+++ b/docs/concepts/conversation.md
@@ -64,18 +64,20 @@ sandbox. It scales to zero, and a parked sandbox costs nothing. The next
 prompt wakes it, and the agent's memory is intact. The runtime keeps its
 session on the sandbox's disk, and a suspended sandbox keeps its disk.
 
-**A ceiling destroys.** By default, 24 hours of continuous run time destroys
-the sandbox. The disk goes with it. The stored transcript survives and the
-conversation stays resumable. The next turn starts a fresh runtime session, so
-the agent answers without the earlier turns. Expect to state your context
-again after a ceiling reclaim.
+**Nothing stops a busy sandbox.** A conversation that keeps its sandbox busy
+keeps it up. There is no ceiling on a continuous run by default. A
+self-hoster can set one with `SANDBOX_MAX_LIFETIME_HOURS`. When set, to cross
+it destroys an ephemeral sandbox, and the disk goes with it. The stored
+transcript survives and the conversation stays resumable. The next turn
+starts a fresh runtime session, so the agent answers without the earlier
+turns. Fountain parks a persistent home instead.
 
-The difference matters. Suspend keeps the agent's memory. The ceiling does
+The difference matters. Suspend keeps the agent's memory. A destroy does
 not.
 
-A self-hoster can widen both bounds, or stop them. The settings are
-`SANDBOX_IDLE_TIMEOUT_MINUTES` and `SANDBOX_MAX_LIFETIME_HOURS`, and a `0`
-stops one. Read the [configuration reference](../configuration.md).
+A self-hoster can widen or stop the idle bound with
+`SANDBOX_IDLE_TIMEOUT_MINUTES`, and a `0` stops it. Read the
+[configuration reference](../configuration.md).
 
 Not every sandbox provider can suspend. A provider that does not advertise the
 capability destroys on idle. It does not fake a park, because a resume with a

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -33,8 +33,8 @@ With `persistent`, the agent has one machine of its own. Each conversation
 with the same environment and vault lands on it. Notes, clones and installed
 tools accrue across conversations. What a bad turn leaves behind also
 accrues, because all of them use the one disk. The machine survives a
-conversation that ends. Fountain parks it at the ceiling instead of a destroy. When you delete
-the agent, Fountain destroys the machine.
+conversation that ends. Nothing stops it while it runs. When you delete the
+agent, Fountain destroys the machine.
 
 ## Why the lifecycle belongs to the conversations on it
 

--- a/docs/concepts/teammates.md
+++ b/docs/concepts/teammates.md
@@ -88,10 +88,9 @@ conversation to a channel.
 **Not a shared inbox.** One Agent has one team conversation. Two people who
 message the same teammate talk to the same thread and the same machine.
 
-**Not persistent memory.** The teammate's memory is the sandbox's disk. The
-max-lifetime ceiling destroys that sandbox and takes the memory with it, and
-the thread survives without it. Read
-[About conversations](conversation.md).
+**Not persistent memory.** The teammate's memory is the sandbox's disk. A
+terminate destroys that sandbox and takes the memory with it, and the thread
+survives without it. Read [About conversations](conversation.md).
 
 ## Where to go next
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ message.
 | `DAYTONA_API_URL` | `https://app.daytona.io/api` | — | Repoints the Daytona API, for a Daytona you host yourself. |
 | `DAYTONA_SNAPSHOT` | The org default. | — | The snapshot, which is an image, that Fountain creates a new Daytona sandbox from. The organization must hold it. The default image has no agent CLI, so build one from `images/daytona/` for real use. |
 | `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long, and Fountain reclaims the sandbox. The conversation stays [resumable](guides/operate/sandbox-lifetime.md). A `0` turns the bound off, and boot refuses whatever is not a non-negative integer. |
-| `SANDBOX_MAX_LIFETIME_HOURS` | `24` | — | The absolute ceiling on a sandbox's age, whatever the activity. The same `0` rule and the same boot refusal apply. |
+| `SANDBOX_MAX_LIFETIME_HOURS` | `0` (off) | — | A ceiling on one continuous run, whatever the activity. Off by default: nothing stops a sandbox that stays busy. Set it to park a persistent home, or destroy an ephemeral sandbox, after this many hours. The same boot refusal applies. |
 | `LOG_OUTPUT_BUDGET_MB` | `50` | — | The durable log volume for one conversation. Once a conversation has persisted this much sandbox output, Fountain writes one truncation marker and discards the rest. Retention bounds age, and this bounds rate. The same `0` rule and the same boot refusal apply. |
 
 ## Webhooks

--- a/docs/guides/operate/sandbox-lifetime.md
+++ b/docs/guides/operate/sandbox-lifetime.md
@@ -11,10 +11,14 @@ do.
 | Setting | Default | |
 |---|---|---|
 | `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | No turn activity for this long **suspends** the sandbox. The sprite stays, scaled to zero. The next prompt wakes it, and the agent's memory is intact. |
-| `SANDBOX_MAX_LIFETIME_HOURS` | `24` | A ceiling on one continuous run, from creation or from the last wake. To cross it **destroys** the sprite. It is the backstop for a conversation that never stops. |
+| `SANDBOX_MAX_LIFETIME_HOURS` | `0` (off) | A ceiling on one continuous run, from creation or from the last wake. To cross it **destroys** an ephemeral sandbox, and **parks** a persistent one. Off by default, because a machine that runs all day is not a fault. |
 
-Set either one to `0` to stop it. A value that is not a non-negative integer
-refuses to boot, and it does not quietly turn the bound off.
+A `0` stops either bound. A value that is not a non-negative integer refuses
+to boot, and it does not quietly turn the bound off.
+
+With the ceiling off, the idle timeout is the one automatic stop. A sandbox
+that stays busy stays up, and the concurrent-sandbox cap bounds how many can
+be up at once.
 
 ## Which one you can be aggressive with
 
@@ -22,10 +26,12 @@ Neither bound ends the conversation. It stays resumable either way.
 
 You can be aggressive with the idle bound, because a suspend loses nothing.
 
-You cannot be aggressive with the max-lifetime ceiling. The runtime session
-lives on the disk that the ceiling destroys. After a ceiling reclaim, the next
-prompt provisions a fresh sandbox, and the agent starts with no memory of the
-earlier turns. Expect a user to state their context again after one.
+You cannot be aggressive with the max-lifetime ceiling, if you turn it on.
+The runtime session lives on the disk that the ceiling destroys. After a
+ceiling reclaim, the next prompt provisions a fresh sandbox, and the agent
+starts with no memory of the earlier turns. Expect a user to state their
+context again after one. Fountain parks a persistent home instead, and the
+home keeps its disk.
 
 Fountain never ages a suspended sandbox out. Its sprite stays at the provider
 until you terminate the conversation, or until somebody deletes the account.

--- a/docs/integrations/sprites-contract.md
+++ b/docs/integrations/sprites-contract.md
@@ -26,7 +26,7 @@ execution, and an endpoint that streams NDJSON for checkpoints.
 |---|---|---|
 | Create a sprite | `POST /v1/sprites`, JSON `{"name": …}`, allowed 120s. | Each conversation start. |
 | Get a sprite | `GET /v1/sprites/{name}`, where 404 means not found. | A wake, and sandbox reuse. |
-| Destroy a sprite | `DELETE /v1/sprites/{name}`, where **404 counts as success**. | Terminate, the max-lifetime ceiling, the reaper, and account deletion. An idle suspend deliberately calls nothing, because the sprite scales to zero on its own. |
+| Destroy a sprite | `DELETE /v1/sprites/{name}`, where **404 counts as success**. | Terminate, a configured max-lifetime ceiling, the reaper, and account deletion. An idle suspend deliberately calls nothing, because the sprite scales to zero on its own. |
 | List sprites | `GET /v1/sprites`, paginated, as below. | The reaper's hourly reconciliation. |
 | Write a file | `PUT /v1/sprites/{name}/fs/write?path=…&workingDir=…&mode=…&mkdirParents=…`, with a raw body. | The env file, inline skills, and the runtime config files. |
 | Execute, and block | A WebSocket at `/v1/sprites/{name}/exec`. Run to exit, then collect the output. | Package installs, git clones, setup scripts, and the runtime preparation. |

--- a/docs/reference/conversation-states.md
+++ b/docs/reference/conversation-states.md
@@ -42,11 +42,11 @@ supports.
 |---|---|---|---|
 | Suspend | Idle for `SANDBOX_IDLE_TIMEOUT_MINUTES`, 60 by default. | None. It stays `idle`. | Kept. The disk survives. |
 | Wake | The next prompt. | `idle` to `running`. | Kept. |
-| Destroy on ceiling | It ran for `SANDBOX_MAX_LIFETIME_HOURS`, 24 by default. | None. It stays resumable. | Lost. The next turn starts a fresh runtime session. |
+| Destroy on ceiling | It ran for `SANDBOX_MAX_LIFETIME_HOURS`. Off by default, so this never happens unless you set it. | None. It stays resumable. | Lost for an ephemeral sandbox. Fountain parks a persistent home, which keeps it. |
 | Destroy on idle | It went idle on a provider with no `:suspend` capability. | None. | Lost. |
 
-You set both bounds for each instance. A `0` turns either one off. Read the
-[configuration reference](../configuration.md).
+You set both bounds for each instance. A `0` turns either one off, and the
+ceiling starts off. Read the [configuration reference](../configuration.md).
 
 ## Warnings
 
@@ -60,9 +60,9 @@ Do not terminate a conversation you want back. Termination destroys the
 sandbox, and the memory the agent works from goes with it. The transcript
 stays.
 
-A sandbox that the ceiling reclaims leaves the conversation resumable, and
-leaves the agent without its earlier context. State what matters again on the
-next turn.
+A sandbox that a configured ceiling reclaims leaves the conversation
+resumable, and leaves the agent without its earlier context. State what
+matters again on the next turn.
 
 ## Where to go next
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -64,7 +64,7 @@ on. The docs say **sandbox**.
 | **Inference credentials** | A user's own model provider keys, which they enter in the app. An operator never sets them. Read [Services Fountain uses](../integrations/index.md). |
 | **Log event** | One entry in a conversation's stream. It arrives over SSE, and `?blocks=true` parses it for you. |
 | **MCP server** | A Model Context Protocol server that an Agent gives its runtime. You declare it in `mcp_servers`. |
-| **Reaper** | The background sweep that suspends an idle sandbox, and destroys one that passed the ceiling. |
+| **Reaper** | The background sweep that suspends an idle sandbox, and destroys one that passed a configured ceiling. |
 | **Runner** | A machine you own that runs `fountain runner` and acts as a sandbox provider. Read [Self-hosted runners](../integrations/runners.md). |
 | **Runtime** | The coding-agent CLI that a sandbox runs. One of `claude`, `codex`, `gemini`, `opencode`. |
 | **Sandbox** | The isolated machine that one Conversation runs in. Fountain provisions it at launch and reclaims it on the lifetime rules. |

--- a/docs/troubleshooting/conversation-stuck-or-failed.md
+++ b/docs/troubleshooting/conversation-stuck-or-failed.md
@@ -60,8 +60,8 @@ further prompt.
 error. The sandbox parks and scales to zero. The next prompt wakes it, and the
 agent's memory is intact.
 
-`idle` with a *destroyed* sandbox is what the max-lifetime ceiling leaves
-behind, or what an explicit reap leaves. The next prompt provisions a fresh
+`idle` with a *destroyed* sandbox is what an explicit reap leaves, or what a
+configured max-lifetime ceiling leaves behind. The next prompt provisions a fresh
 sandbox. Fountain leaves the stored transcript alone, but the agent starts a
 fresh session. Read [About conversations](../concepts/conversation.md), and
 the full table in [Conversation states](../reference/conversation-states.md).


### PR DESCRIPTION
## Summary
- `SANDBOX_MAX_LIFETIME_HOURS` defaults to `0` (off) in `config/config.exs`, `config/runtime.exs` and `Lifecycle`'s fallback, for every sandbox mode. Decided 2026-08-23 with ADR 0023: a tenant who wants a machine running 24/7 is not something to stop; a persistent home's disk is the product.
- The knob stays. An operator who sets it gets exactly the old behaviour: an ephemeral sandbox is destroyed at the ceiling, a persistent home is parked (#1068). No reaper or server code changed; the `{:expired, :max_lifetime}` path is intact and every test of it already set the value explicitly.
- **What bounds a perpetually-busy sandbox now:** nothing automatic while it stays busy. Once it stops, the idle timeout (60 min) parks it. The plan's concurrent-sandbox cap bounds how many a tenant can keep up. The reaper's abandoned pass still parks/expires rows whose server died (it reads both bounds; with the ceiling nil it uses idle alone).
- Docs: `configuration.md`, `guides/operate/sandbox-lifetime.md`, `concepts/conversation.md`, `concepts/sandboxes.md`, `concepts/teammates.md`, `reference/conversation-states.md`, `architecture.md`, `build/pieces.md`, `integrations/sprites-contract.md`, `reference/glossary.md`, `troubleshooting/conversation-stuck-or-failed.md`, `api.md`, `.env.example`. ADR 0017 gets a dated amendment note; ADR 0023's outcome bullet on the ceiling points here. `okf validate decisions` passes.
- Tests: defaults assertions updated in `lifecycle_test`, `sandbox_bounds_config_test`, `compose_passthrough_config_test`; new `lifecycle_test` case that the default config never returns `{:expired, :max_lifetime}` however long the run.

## Test plan
- [x] `mix compile --warnings-as-errors`, `mix credo --strict`, `mix format`
- [x] lifecycle, bounds-config, compose-passthrough, conversation_server_lifetime, shared_sandbox, sandbox_reaper, config_reference, audit_guardrail, docs tests: 163 tests, 0 failures
- [x] `python3 scripts/docs-style.py` clean; `vale lint docs` 0 errors 0 warnings
- [ ] CI

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)