### PR TITLE
feat(sandboxes): reset a persistent sandbox — the home is destroyed, the conversations stay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ upgrade, is in
 
 ### Added
 
+- **Reset a persistent sandbox.** `DELETE /api/sandboxes/:id` destroys an
+  agent's home so the next launch on the same agent, environment and vault
+  builds a clean machine — the conversations on it are kept, idle, and each
+  one's next prompt lands on the fresh home together with the others. Only a
+  live `persistent` sandbox resets (`422 sandbox_not_resettable`), and not
+  while a conversation on it is mid-turn (`409 sandbox_mid_turn`). Also
+  `fountain sandbox list|show|reset` and the SDK's `resetSandbox(id)`.
+  Audited as `sandbox.reset`. Until now the only reset was to delete the
+  agent (#1071, ADR 0023 step 5).
+
 - **A persistent sandbox per agent — the agent's computer.** An agent's
   `sandbox_mode` is `ephemeral` (a sandbox per conversation, the default and
   today's behaviour) or `persistent`: one machine per agent identity (agent,

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1944,6 +1944,16 @@ defmodule Fountain.Conversations do
     |> Enum.reject(&(&1.status in ["terminated", "failed"]))
     |> Enum.each(&ConversationServer.terminate_conversation(&1.id, actor: "system:home_reset"))
 
+    _unsafe_retire_home(sandbox)
+  end
+
+  # Destroy the sprite behind a home and retire its row. Best-effort on the
+  # provider side: a destroy error is logged and the row still goes
+  # `terminated`, so the reaper's sweep sees a terminal row rather than a
+  # live one nobody can find. What happens to the conversations on the home
+  # is the caller's decision — agent delete terminates them, a reset keeps
+  # them.
+  defp _unsafe_retire_home(%Sandbox{} = sandbox) do
     handle = Fountain.Sandbox.build_handle(sandbox_provider_atom(sandbox), sandbox.sprite_name)
 
     case Fountain.Sandbox.destroy(handle) do
@@ -1957,6 +1967,109 @@ defmodule Fountain.Conversations do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
     {:ok, _} = update_sandbox(sandbox, %{status: "terminated", terminated_at: now})
     :ok
+  end
+
+  @doc """
+  Reset a home: destroy the agent's machine so the next launch on its
+  identity builds a clean one (ADR 0023 step 5, #1071). The conversations on
+  it stay — idle and resumable — because the disk was the problem, not the
+  transcripts; each is told the machine is gone, so its next prompt takes the
+  wake path, which provisions a fresh home and moves the others onto it.
+
+  `sandbox` came from the caller's scoped `get_sandbox/2`. Only a live
+  `persistent` sandbox resets: an ephemeral one is a conversation's own and
+  ends with it (`{:sandbox_not_resettable, "ephemeral"}`), a terminated or
+  failed one is already gone (`{:sandbox_not_resettable, status}`). Refused
+  with `:sandbox_mid_turn` while any conversation on it runs a turn — the
+  check and the row flip share the per-sandbox advisory lock that turn
+  creation takes, so a turn cannot slip in between them.
+
+  See `create_agent/2` for `opts` (`:actor`, `:request_ip`).
+  """
+  def reset_sandbox(%Sandbox{} = sandbox, opts \\ []) do
+    cond do
+      sandbox.mode != "persistent" ->
+        {:error, {:sandbox_not_resettable, "ephemeral"}}
+
+      sandbox.status in ["terminated", "failed"] ->
+        {:error, {:sandbox_not_resettable, sandbox.status}}
+
+      true ->
+        do_reset_sandbox(sandbox, opts)
+    end
+  end
+
+  defp do_reset_sandbox(%Sandbox{id: sandbox_id} = sandbox, opts) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    result =
+      Repo.transaction(fn ->
+        Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
+          @sandbox_lock_namespace,
+          :erlang.phash2(sandbox_id)
+        ])
+
+        if _unsafe_running_turns_elsewhere(sandbox_id, nil) > 0 do
+          Repo.rollback(:sandbox_mid_turn)
+        else
+          ids =
+            Repo.all(
+              from c in Conversation,
+                where: c.sandbox_id == ^sandbox_id and c.status not in ["terminated", "failed"],
+                select: c.id
+            )
+
+          # A fresh disk has no session to resume (#778).
+          Repo.update_all(from(c in Conversation, where: c.id in ^ids),
+            set: [runtime_session_id: nil, updated_at: now]
+          )
+
+          ids
+        end
+      end)
+
+    with {:ok, ids} <- result do
+      message =
+        "The sandbox was reset by its owner. The transcript is kept; the next prompt " <>
+          "builds a fresh machine, and the agent starts a new session there."
+
+      # A conversation with a live server is told through it — the server
+      # cuts nothing (no turn is running), records the event on its own
+      # transcript and stops. One without a server gets the event recorded
+      # here, so every transcript on the home says the same thing.
+      Enum.each(ids, fn id ->
+        case ConversationServer.whereis(id) do
+          nil ->
+            publish_stage(id, "sandbox", "done", %{
+              event: "reset",
+              reason: "home_reset",
+              by: "owner",
+              message: message
+            })
+
+          pid ->
+            GenServer.cast(pid, {:machine_gone, "reset", "home_reset", message})
+        end
+      end)
+
+      _unsafe_retire_home(sandbox)
+
+      Audit.record(%{
+        user_id: sandbox.user_id,
+        action: "sandbox.reset",
+        resource_type: "sandbox",
+        resource_id: sandbox.id,
+        actor: Keyword.get(opts, :actor, "self"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{
+          "agent_id" => sandbox.agent_id,
+          "provider" => sandbox.provider,
+          "conversations" => length(ids)
+        }
+      })
+
+      {:ok, _unsafe_get_sandbox!(sandbox.id)}
+    end
   end
 
   # A conversation on a machine the caller already has (ADR 0023 gate 3).

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -236,6 +236,31 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # Reset (#1071): an ephemeral sandbox is a conversation's own and ends
+  # with it; a terminated or failed one is already gone.
+  def call(conn, {:error, {:sandbox_not_resettable, why}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "sandbox_not_resettable",
+      message: sandbox_not_resettable_message(why),
+      reason: why
+    })
+  end
+
+  # A reset while a turn runs would cut it from under the conversation; the
+  # caller waits for the turn to end, or interrupts it, then sends again.
+  def call(conn, {:error, :sandbox_mid_turn}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "sandbox_mid_turn",
+      message:
+        "a conversation on this sandbox is running a turn; wait for it to finish or " <>
+          "interrupt it, then send again"
+    })
+  end
+
   def call(conn, {:error, :invalid_sandbox_mode}) do
     conn
     |> put_status(:unprocessable_entity)
@@ -328,4 +353,10 @@ defmodule FountainWeb.FallbackController do
     |> put_status(:unprocessable_entity)
     |> json(%{error: to_string(reason)})
   end
+
+  defp sandbox_not_resettable_message("ephemeral"),
+    do: "only a persistent sandbox resets; an ephemeral one ends with its conversation"
+
+  defp sandbox_not_resettable_message(status),
+    do: "the sandbox is #{status}; there is nothing left to reset"
 end

--- a/apps/fountain/lib/fountain_web/controllers/sandbox_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/sandbox_controller.ex
@@ -2,15 +2,17 @@ defmodule FountainWeb.SandboxController do
   @moduledoc """
   The caller's sandboxes — the machines their conversations run on.
 
-  Read-only. A sandbox is created by `POST /api/conversations` and reused by
-  passing its id back as `sandbox_id` (ADR 0023 gate 3); this is where a
-  client learns which machines it has, and which conversations are on each.
+  A sandbox is created by `POST /api/conversations` and reused by passing its
+  id back as `sandbox_id` (ADR 0023 gate 3); this is where a client learns
+  which machines it has, and which conversations are on each. The one write
+  is `DELETE /api/sandboxes/:id`, which resets a persistent home (#1071).
   """
   use FountainWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Conversations
   alias Fountain.Conversations.Sandbox
+  alias FountainWeb.Audited
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
@@ -62,6 +64,34 @@ defmodule FountainWeb.SandboxController do
     case Conversations.get_sandbox_with_conversations(id, user.id) do
       nil -> {:error, :not_found}
       sandbox -> render(conn, :show, sandbox: sandbox)
+    end
+  end
+
+  operation(:delete,
+    summary: "Reset a sandbox",
+    description:
+      "Destroy a persistent sandbox — the agent's home — so the next launch on the same " <>
+        "agent, environment and vault builds a clean machine. The conversations on it are " <>
+        "kept, idle; each one's next prompt lands on the fresh home. Only a `persistent` " <>
+        "sandbox that is not `terminated` or `failed` resets (`422 sandbox_not_resettable`), " <>
+        "and not while any conversation on it is mid-turn (`409 sandbox_mid_turn`).",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Reset",
+      not_found: {"Not found", "application/json", Schemas.Error},
+      conflict: {"A conversation on it is mid-turn", "application/json", Schemas.Error},
+      unprocessable_entity: {"Not a live persistent sandbox", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    # Ownership: the scoped get_sandbox establishes it; reset_sandbox trusts
+    # the row it is handed.
+    with %Sandbox{} = sandbox <- Conversations.get_sandbox(id, user.id) || {:error, :not_found},
+         {:ok, _} <- Conversations.reset_sandbox(sandbox, Audited.attribution(conn)) do
+      send_resp(conn, :no_content, "")
     end
   end
 

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -462,6 +462,7 @@ defmodule FountainWeb.Router do
     # `sandbox_id` on the next one.
     get "/sandboxes", SandboxController, :index
     get "/sandboxes/:id", SandboxController, :show
+    delete "/sandboxes/:id", SandboxController, :delete
 
     resources "/conversations", ConversationController, only: [:index, :show, :create, :delete] do
       post "/prompts", ConversationController, :prompt, as: :prompt

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -56,6 +56,7 @@ defmodule Fountain.AuditGuardrailTest do
     {"inference credential write", &__MODULE__.do_cred_write/1, "inference_credential.write"},
     {"inference credential clear", &__MODULE__.do_cred_clear/1, "inference_credential.delete"},
     {"conversation delete", &__MODULE__.do_conv_delete/1, "conversation.deleted"},
+    {"sandbox reset", &__MODULE__.do_sandbox_reset/1, "sandbox.reset"},
     {"role change", &__MODULE__.do_role_change/1, "account.role_changed"},
     {"sandbox limit change", &__MODULE__.do_limit_change/1, "account.sandbox_limit_changed"},
     {"suspend", &__MODULE__.do_suspend/1, "account.suspended"},
@@ -310,6 +311,22 @@ defmodule Fountain.AuditGuardrailTest do
     sandbox = insert_sandbox(user_id: user.id, status: "ready")
     conv = insert_conversation(user_id: user.id, agent: agent, sandbox_id: sandbox.id)
     {:ok, _} = Conversations.delete_conversation(conv)
+  end
+
+  def do_sandbox_reset(user) do
+    agent = insert_agent(user_id: user.id)
+
+    home =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        mode: "persistent",
+        agent_id: agent.id,
+        provider: "sprites"
+      )
+
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+    {:ok, _} = Conversations.reset_sandbox(home)
   end
 
   def do_team_add(user) do

--- a/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
@@ -1,0 +1,157 @@
+defmodule Fountain.Conversations.SandboxResetTest do
+  # #1071: resetting a home destroys the machine and keeps the conversations;
+  # each one's next prompt builds a fresh home (ADR 0023 step 5).
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.ConversationServer
+
+  setup do
+    user = insert_active_user()
+    {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 10)
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+    home =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        mode: "persistent",
+        agent_id: agent.id,
+        environment_id: env.id,
+        provider: "sprites"
+      )
+
+    a =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        sandbox: home,
+        status: "idle",
+        runtime_session_id: "sess-a"
+      )
+
+    b = insert_conversation(user_id: user.id, agent: agent, sandbox: home, status: "idle")
+    stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+    {:ok, user: user, env: env, agent: agent, home: home, a: a, b: b}
+  end
+
+  test "destroys the sprite, retires the row, keeps the conversations", ctx do
+    test = self()
+    stub(Fountain.Sandbox.Sprites, :destroy, fn h -> send(test, {:destroyed, h.name}) && :ok end)
+
+    assert {:ok, sandbox} = Conversations.reset_sandbox(ctx.home, actor: "api")
+    assert sandbox.status == "terminated"
+    assert_received {:destroyed, name}
+    assert name == ctx.home.sprite_name
+
+    for conv <- [ctx.a, ctx.b] do
+      reloaded = Conversations._unsafe_get_conversation!(conv.id)
+      assert reloaded.status == "idle"
+      assert reloaded.sandbox_id == ctx.home.id
+      assert is_nil(reloaded.runtime_session_id)
+    end
+  end
+
+  test "every conversation's transcript says the machine was reset", ctx do
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+    assert {:ok, _} = Conversations.reset_sandbox(ctx.home)
+
+    for conv <- [ctx.a, ctx.b] do
+      assert [event] =
+               Conversations._unsafe_list_log_events(conv.id)
+               |> Enum.filter(&(&1.kind == "stage" and &1.stage == "sandbox"))
+
+      assert %{"event" => "reset", "reason" => "home_reset"} = Jason.decode!(event.data)
+    end
+  end
+
+  test "a live server on the home is told the machine is gone, and nothing else", ctx do
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+    test = self()
+
+    # Stand in for conversation A's ConversationServer: registered under its
+    # id, forwards whatever is cast to it.
+    fake =
+      spawn(fn ->
+        {:ok, _} = Horde.Registry.register(Fountain.ConversationRegistry, ctx.a.id, nil)
+        send(test, :registered)
+
+        receive do
+          {:"$gen_cast", msg} -> send(test, {:cast, msg})
+        end
+      end)
+
+    assert_receive :registered
+    assert {:ok, ^fake} = ConversationServer.await_registered(ctx.a.id)
+
+    assert {:ok, _} = Conversations.reset_sandbox(ctx.home)
+    assert_receive {:cast, {:machine_gone, "reset", "home_reset", message}}, 1_000
+    assert message =~ "reset by its owner"
+
+    # The server records the event on A's transcript itself; the reset does
+    # not write a second one. B, with no server, gets it recorded here.
+    assert Conversations._unsafe_list_log_events(ctx.a.id)
+           |> Enum.filter(&(&1.stage == "sandbox")) == []
+
+    assert [_] =
+             Conversations._unsafe_list_log_events(ctx.b.id)
+             |> Enum.filter(&(&1.stage == "sandbox"))
+  end
+
+  test "refused while a conversation on it is mid-turn", ctx do
+    insert_turn(ctx.a, status: "running")
+    assert {:error, :sandbox_mid_turn} = Conversations.reset_sandbox(ctx.home)
+    assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "ready"
+  end
+
+  test "refused for an ephemeral sandbox and for one already gone", ctx do
+    ephemeral = insert_sandbox(user_id: ctx.user.id, status: "ready", mode: "ephemeral")
+
+    assert {:error, {:sandbox_not_resettable, "ephemeral"}} =
+             Conversations.reset_sandbox(ephemeral)
+
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+    {:ok, gone} = Conversations.reset_sandbox(ctx.home)
+
+    assert {:error, {:sandbox_not_resettable, "terminated"}} =
+             Conversations.reset_sandbox(gone)
+  end
+
+  test "the row retires even when the provider refuses the destroy", ctx do
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> {:error, :boom} end)
+    assert {:ok, sandbox} = Conversations.reset_sandbox(ctx.home)
+    assert sandbox.status == "terminated"
+  end
+
+  test "the next prompt builds a fresh home on the same identity", ctx do
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+    {:ok, _} = Conversations.reset_sandbox(ctx.home)
+
+    assert {:ok, woken} = Conversations.wake_conversation(ctx.a.id)
+    refute woken.sandbox_id == ctx.home.id
+    fresh = Conversations._unsafe_get_sandbox!(woken.sandbox_id)
+    assert fresh.mode == "persistent"
+    assert fresh.agent_id == ctx.agent.id
+
+    assert %{id: id} = Conversations._unsafe_find_home(ctx.user.id, ctx.agent.id, ctx.env.id, nil)
+    assert id == woken.sandbox_id
+    # The co-tenant followed onto the fresh home (#1067).
+    assert Conversations._unsafe_get_conversation!(ctx.b.id).sandbox_id == woken.sandbox_id
+  end
+
+  test "records sandbox.reset with the actor", ctx do
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+    {:ok, _} = Conversations.reset_sandbox(ctx.home, actor: "api", request_ip: "10.0.0.1")
+
+    assert [event] =
+             Fountain.Audit.list_for_user(ctx.user.id)
+             |> Enum.filter(&(&1.action == "sandbox.reset"))
+
+    assert event.resource_id == ctx.home.id
+    assert event.actor == "api"
+    assert event.metadata["conversations"] == 2
+    assert event.metadata["agent_id"] == ctx.agent.id
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/sandbox_reset_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sandbox_reset_controller_test.exs
@@ -1,0 +1,78 @@
+defmodule FountainWeb.SandboxResetControllerTest do
+  # DELETE /api/sandboxes/:id (#1071), at the door.
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+
+  setup do
+    user = insert_active_user()
+    {_key_record, raw_key} = insert_api_key(user)
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+    home =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        mode: "persistent",
+        agent_id: agent.id,
+        environment_id: env.id,
+        provider: "sprites"
+      )
+
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: home, status: "idle")
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+    {:ok, user: user, raw_key: raw_key, agent: agent, home: home, conv: conv}
+  end
+
+  defp reset(ctx, id) do
+    ctx.conn |> authed_with_key(ctx.raw_key) |> delete("/api/sandboxes/#{id}")
+  end
+
+  test "204: the home is terminated and the conversation kept", ctx do
+    assert ctx |> reset(ctx.home.id) |> response(204)
+    assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "terminated"
+    assert Conversations._unsafe_get_conversation!(ctx.conv.id).status == "idle"
+  end
+
+  test "404 for another tenant's sandbox, and for a made-up id", ctx do
+    other = insert_active_user()
+    theirs = insert_sandbox(user_id: other.id, status: "ready", mode: "persistent")
+
+    assert %{"error" => "not_found"} = ctx |> reset(theirs.id) |> json_response(404)
+    assert Conversations._unsafe_get_sandbox!(theirs.id).status == "ready"
+    assert ctx |> reset(Ecto.UUID.generate()) |> json_response(404)
+    assert ctx |> reset("nope") |> json_response(404)
+  end
+
+  test "422 sandbox_not_resettable for an ephemeral sandbox", ctx do
+    ephemeral = insert_sandbox(user_id: ctx.user.id, status: "ready", mode: "ephemeral")
+
+    assert %{"error" => "sandbox_not_resettable", "reason" => "ephemeral"} =
+             ctx |> reset(ephemeral.id) |> json_response(422)
+  end
+
+  test "422 sandbox_not_resettable for a home already gone", ctx do
+    assert ctx |> reset(ctx.home.id) |> response(204)
+
+    assert %{"error" => "sandbox_not_resettable", "reason" => "terminated"} =
+             ctx |> reset(ctx.home.id) |> json_response(422)
+  end
+
+  test "409 sandbox_mid_turn while a conversation on it runs a turn", ctx do
+    insert_turn(ctx.conv, status: "running")
+    assert %{"error" => "sandbox_mid_turn"} = ctx |> reset(ctx.home.id) |> json_response(409)
+    assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "ready"
+  end
+
+  test "the reset is audited as api", ctx do
+    assert ctx |> reset(ctx.home.id) |> response(204)
+
+    assert [event] =
+             Fountain.Audit.list_for_user(ctx.user.id)
+             |> Enum.filter(&(&1.action == "sandbox.reset"))
+
+    assert event.actor == "api"
+  end
+end

--- a/cli/internal/cmd/sandbox.go
+++ b/cli/internal/cmd/sandbox.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/api"
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// The caller's sandboxes — the machines conversations run on (ADR 0023).
+// `reset` is the one write: it destroys a persistent home so the next
+// launch on the same agent, environment and vault builds a clean one
+// (#1071). The conversations on it are kept.
+func init() {
+	sandboxCmd := &cobra.Command{Use: "sandbox", Short: "Manage sandboxes"}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List sandboxes",
+		RunE:  func(cmd *cobra.Command, args []string) error { return sandboxList(cmd) },
+	}
+	listCmd.Flags().Bool("json", false, "output JSON")
+	listCmd.Flags().String("status", "", "comma-separated statuses to include (default: all)")
+
+	sandboxCmd.AddCommand(
+		listCmd,
+		&cobra.Command{
+			Use:   "show <id>",
+			Short: "Show a sandbox and the conversations on it",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return sandboxShow(args[0]) },
+		},
+		&cobra.Command{
+			Use:   "reset <id>",
+			Short: "Destroy a persistent sandbox; the next launch builds a clean one",
+			Args:  cobra.ExactArgs(1),
+			RunE:  func(cmd *cobra.Command, args []string) error { return sandboxReset(args[0]) },
+		},
+	)
+	rootCmd.AddCommand(sandboxCmd)
+}
+
+func sandboxList(cmd *cobra.Command) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	status, _ := cmd.Flags().GetString("status")
+	c := activeClient()
+	path := "/sandboxes"
+	if status != "" {
+		path += "?status=" + status
+	}
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := c.Get(path, &resp); err != nil {
+		Fatal(err.Error())
+	}
+	if jsonOut {
+		return output.PrintJSON(resp.Data)
+	}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, v := range resp.Data {
+		convs, _ := v["conversations"].([]any)
+		rows = append(rows, []string{
+			output.ToString(v["status"]),
+			output.ToString(v["mode"]),
+			output.ShortID(output.ToString(v["id"])),
+			output.ShortID(output.ToString(v["agent_id"])),
+			output.ToString(v["provider"]),
+			fmt.Sprintf("%d", len(convs)),
+			output.ToString(v["inserted_at"]),
+		})
+	}
+	output.Table([]string{"status", "mode", "id", "agent_id", "provider", "convs", "started"}, rows)
+	return nil
+}
+
+func sandboxShow(id string) error {
+	c := activeClient()
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := c.Get("/sandboxes/"+id, &resp); err != nil {
+		if api.StatusCode(err) == 404 {
+			Fatal("not found")
+		}
+		Fatal(err.Error())
+	}
+	s := resp.Data
+	fmt.Printf("sandbox %s\n", output.ToString(s["id"]))
+	fmt.Printf("  status:       %s\n", output.ToString(s["status"]))
+	fmt.Printf("  mode:         %s\n", output.ToString(s["mode"]))
+	fmt.Printf("  provider:     %s\n", output.ToString(s["provider"]))
+	fmt.Printf("  agent:        %s\n", output.ToString(s["agent_id"]))
+	fmt.Printf("  environment:  %s\n", output.ToString(s["environment_id"]))
+	fmt.Printf("  vault:        %s\n", output.ToString(s["vault_id"]))
+	fmt.Printf("  started:      %s\n", output.ToString(s["inserted_at"]))
+	convs, _ := s["conversations"].([]any)
+	fmt.Printf("  conversations: %d\n", len(convs))
+	for _, raw := range convs {
+		conv, _ := raw.(map[string]any)
+		midTurn := ""
+		if b, ok := conv["mid_turn"].(bool); ok && b {
+			midTurn = "  (mid-turn)"
+		}
+		fmt.Printf("    %s  %s%s\n", output.ToString(conv["status"]), output.ToString(conv["id"]), midTurn)
+	}
+	return nil
+}
+
+func sandboxReset(id string) error {
+	c := activeClient()
+	if err := c.Delete("/sandboxes/"+id, nil); err != nil {
+		if api.StatusCode(err) == 404 {
+			Fatal("not found")
+		}
+		Fatal(err.Error())
+	}
+	fmt.Printf("reset %s\n", id)
+	return nil
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -499,13 +499,21 @@ several conversations.
 ```
 GET    /api/sandboxes          # list (?status=ready,suspended)
 GET    /api/sandboxes/:id
+DELETE /api/sandboxes/:id      # reset a persistent sandbox
 ```
 
-Each sandbox carries `status`, `provider` and `url`. It also carries the
-`agent_id`, `environment_id` and `vault_id` that Fountain built it for, and
-`conversations`. Each entry there carries `mid_turn`, which is true while
+Each sandbox carries `status`, `mode`, `provider` and `url`. It also carries
+the `agent_id`, `environment_id` and `vault_id` that Fountain built it for,
+and `conversations`. Each entry there carries `mid_turn`, which is true while
 that conversation runs a turn. To put a second conversation on a sandbox,
 pass its id as `sandbox_id` to `POST /api/conversations`.
+
+`DELETE` resets a `persistent` sandbox. Fountain destroys the machine and
+keeps the conversations on it. The next prompt on one of them builds a clean
+machine for the same agent, environment and vault. The response is `204`.
+An ephemeral sandbox, or one that is already `terminated` or `failed`, gets
+`422 sandbox_not_resettable`. While a conversation on the sandbox runs a
+turn, the request gets `409 sandbox_mid_turn`.
 
 ## Search
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,6 +129,22 @@ fountain conv delete <id>
 
 You can repeat `-i` and `--image`. Each one takes a local file path.
 
+## Sandboxes
+
+A sandbox is the computer a conversation runs on. One persistent sandbox can
+hold the conversations of one agent (ADR 0023).
+
+```bash
+fountain sandbox list [--json] [--status ready,suspended]
+fountain sandbox show <id>
+fountain sandbox reset <id>
+```
+
+`reset` destroys a persistent sandbox. The conversations on it stay. The next
+prompt on one of them builds a clean machine for the same agent, environment
+and vault. Fountain refuses the command while a conversation on the sandbox
+runs a turn, and for an ephemeral sandbox.
+
 ## Run an agent
 
 ```bash

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -339,6 +339,37 @@ Options:
       --root string        sandbox root (default: ~/.fountain/runners/<name>/sandboxes)
 ```
 
+## `fountain sandbox list`
+
+List sandboxes
+
+```
+fountain sandbox list [flags]
+```
+
+Options:
+
+```
+      --json            output JSON
+      --status string   comma-separated statuses to include (default: all)
+```
+
+## `fountain sandbox reset`
+
+Destroy a persistent sandbox; the next launch builds a clean one
+
+```
+fountain sandbox reset <id>
+```
+
+## `fountain sandbox show`
+
+Show a sandbox and the conversations on it
+
+```
+fountain sandbox show <id>
+```
+
 ## `fountain vault create`
 
 Create a vault

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -34,7 +34,9 @@ with the same environment and vault lands on it. Notes, clones and installed
 tools accrue across conversations. What a bad turn leaves behind also
 accrues, because all of them use the one disk. The machine survives a
 conversation that ends. Nothing stops it while it runs. When you delete the
-agent, Fountain destroys the machine.
+agent, Fountain destroys the machine. A reset (`DELETE /api/sandboxes/:id`)
+also destroys the machine, and keeps the conversations. The next prompt builds
+a clean one.
 
 ## Why the lifecycle belongs to the conversations on it
 

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,16 @@ server releases.
 
 ---
 
+## [0.1.8] — 2026-08-24
+
+### Added
+
+- `resetSandbox(id)` — `DELETE /api/sandboxes/:id`: destroy a persistent
+  sandbox (the agent's home) so the next launch on the same agent,
+  environment and vault builds a clean machine; the conversations on it are
+  kept. `sandbox_not_resettable` for an ephemeral or already-gone sandbox,
+  `sandbox_mid_turn` while a conversation on it runs a turn (#1071).
+
 ## [0.1.7] — 2026-08-24
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -214,6 +214,17 @@ export class Fountain {
     return this.api.data<SandboxRecord>("GET", `/api/sandboxes/${id}`);
   }
 
+  /**
+   * Reset a persistent sandbox: destroy the agent's home so the next launch
+   * on the same agent, environment and vault builds a clean machine. The
+   * conversations on it are kept. Refused (`sandbox_not_resettable`) for an
+   * ephemeral or already-gone sandbox, and (`sandbox_mid_turn`) while a
+   * conversation on it runs a turn.
+   */
+  async resetSandbox(id: string): Promise<void> {
+    await this.api.request("DELETE", `/api/sandboxes/${id}`);
+  }
+
   /** Full-text search across the caller's conversations. */
   async search(query: string, opts: { limit?: number } = {}): Promise<SearchHit[]> {
     return this.api.list<SearchHit>("/api/search", { query: { q: query, limit: opts.limit } });

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -219,7 +219,11 @@ export interface paths {
         get: operations["FountainWeb.SandboxController.show"];
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Reset a sandbox
+         * @description Destroy a persistent sandbox — the agent's home — so the next launch on the same agent, environment and vault builds a clean machine. The conversations on it are kept, idle; each one's next prompt lands on the fresh home. Only a `persistent` sandbox that is not `terminated` or `failed` resets (`422 sandbox_not_resettable`), and not while any conversation on it is mid-turn (`409 sandbox_mid_turn`).
+         */
+        delete: operations["FountainWeb.SandboxController.delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -4343,6 +4347,53 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SandboxController.delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Reset */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description A conversation on it is mid-turn */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not a live persistent sandbox */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.7";
+export const USER_AGENT = "fountain-sdk-js/0.1.8";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
## Summary
- `DELETE /api/sandboxes/:id` resets a persistent home: the sprite is destroyed and the row terminated; the conversations on it are **kept**, idle, with `runtime_session_id` cleared. A conversation with a live server is cast `{:machine_gone, "reset", "home_reset", …}` (it records the event and stops); one without a server gets the same `sandbox` stage written to its transcript. The next prompt on any of them takes the wake path → fresh home on the same identity, co-tenants moved along (#1067). Verified by test.
- Semantics: `204` on success; `404` foreign/unknown id; `422 sandbox_not_resettable` (`reason: "ephemeral" | "terminated" | "failed"`); `409 sandbox_mid_turn` while any conversation on it has a running turn. The mid-turn check and the row flip run under the per-sandbox advisory lock that turn creation takes (`_unsafe_create_turn_on_sandbox`), so a turn cannot start between check and reset. The provider destroy is best-effort (row retires regardless), same as agent delete — which now shares `_unsafe_retire_home/1`.
- Audited as `sandbox.reset` in the context (actor from `Audited.attribution(conn)`), metadata: `agent_id`, `provider`, conversation count. Added to the audit guardrail's `@must_audit`.
- CLI: new `fountain sandbox list|show|reset` group; `docs/cli.md` section; `docs/cli/commands.md` regenerated.
- SDK 0.1.8: `resetSandbox(id)`, generated types regenerated, USER_AGENT bumped, SDK CHANGELOG entry.
- Docs: `docs/api.md` sandboxes section, `docs/concepts/sandboxes.md` lifecycle sentence. CHANGELOG `[Unreleased] → Added`.

## Not built (from the issue's open question)
A home is orphaned when the agent's environment or vault changes — the identity key moves, the old row stays `ready` under the old key until the idle timeout parks it, and counts against the cap meanwhile. Nothing in this PR touches that; `Agents.update_agent` does not look at homes. Reset works on such an orphan (it is still a `persistent` row the caller owns), so the manual fix exists now; automatic handling is a separate change.

## Test plan
- [x] `sandbox_reset_test.exs` (8) — destroy/retire/keep, transcripts, live-server cast vs. no-server stage, mid-turn refusal under lock, ephemeral/gone refusal, provider-error still retires, next wake builds a fresh home and moves the co-tenant, audit row
- [x] `sandbox_reset_controller_test.exs` (6) — 204/404/422/409, audit actor `api`
- [x] `audit_guardrail_test`, `api_spec_test`, `schema_enum_guardrail_test`, `docs_test`, `sandbox_mode_test`, `agents_test` — 174 tests, 0 failures
- [x] `mix compile --warnings-as-errors`, `mix credo --strict`, `mix format`
- [x] `go vet ./... && go test ./...` (cli), `docs/cli/commands.md` regenerated
- [x] SDK: `npm run generate` (types match spec), typecheck, 72 tests pass, build
- [x] `python3 scripts/docs-style.py`, `vale lint docs` → 0 warnings

Closes #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)